### PR TITLE
Make Elastic Search configurable in any environment

### DIFF
--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -1,5 +1,11 @@
 # Example file
 
+# Basic auth
 HTTP_USER: user
 HTTP_PASS: password
+
+# External dependencies
+ELASTIC_SEARCH_ENDPOINT: 'localhost:9200'
+
+# Integrations
 GOOGLE_MAPS_API_KEY: '123'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,5 +92,3 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 end
-
-Elasticsearch::Model.client = Elasticsearch::Client.new host: ENV['SEARCHBOX_URL']

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -92,5 +92,3 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 end
-
-Elasticsearch::Model.client = Elasticsearch::Client.new host: ENV['SEARCHBOX_URL']

--- a/config/initializers/elastic_search.rb
+++ b/config/initializers/elastic_search.rb
@@ -1,0 +1,1 @@
+Elasticsearch::Model.client = Elasticsearch::Client.new(host: Figaro.env.elastic_search_endpoint!)


### PR DESCRIPTION
* Removing mystery SEARCHBOX_URL ENV variable in favour of explicitly defining all the envrionment variables in one place for all environments and for them to ‘just work’ for development and test. Making this application more 12 factor which will enable us to host this service.
* elasticsearch/model automatically looks at localhost:9200 so this used to work based on the omission of the connection in different environment files. https://github.com/elastic/elasticsearch-rails/tree/master/elasticsearch-model#the-elasticsearch-client