### PR TITLE
(fix) fixes grid layout for vacancy form views

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -49,6 +49,7 @@
 @import 'components/filter_vacancies';
 @import 'components/vacancies';
 @import 'components/vacancy';
+@import 'components/vacancy-form';
 @import 'components/banners';
 @import 'components/school';
 @import 'components/sortable_links';

--- a/app/assets/stylesheets/components/vacancy-form.scss
+++ b/app/assets/stylesheets/components/vacancy-form.scss
@@ -1,0 +1,10 @@
+.vacancy-form {
+  
+  .form-control {
+    width: 100%;
+    &.text {
+      max-width: 100%;
+    }
+  }
+
+}

--- a/app/assets/stylesheets/global/_helpers.scss
+++ b/app/assets/stylesheets/global/_helpers.scss
@@ -6,3 +6,7 @@
 p.form-hint {
   margin-bottom: 0;
 }
+
+.form-group {
+  margin-bottom: 30px;
+}

--- a/app/views/vacancies/application_details.html.haml
+++ b/app/views/vacancies/application_details.html.haml
@@ -4,21 +4,23 @@
   %span.heading-secondary
     Step 3 of 3
 = render 'error_messages', errors: @vacancy.errors
-= simple_form_for @vacancy do |f|
+= simple_form_for @vacancy, html: { class: 'vacancy-form' } do |f|
   = hidden_field_tag :from, :application_details
   = hidden_field_tag :next, :review
   %h2.heading-medium
     Application details
 
-  = f.input :contact_email,
-            as: :email,
-            label: 'Vacancy contact email',
-            required: true
+  .grid-row
+    .column-one-half
+      = f.input :contact_email,
+                as: :email,
+                label: 'Vacancy contact email',
+                required: true
 
-  %div.form-group
-    = f.gov_uk_date_field :expires_on, legend_text: 'Vacancy deadline date', legend_class: 'form-label-bold', form_hint_text: 'For example, 31 11 2017'
+      %div.form-group
+        = f.gov_uk_date_field :expires_on, legend_text: 'Vacancy deadline date', legend_class: 'form-label-bold', form_hint_text: 'For example, 31 11 2017'
 
-  %div.form-group
-    = f.gov_uk_date_field :publish_on, legend_text: 'Vacancy publication date', legend_class: 'form-label-bold', form_hint_text: 'For example, 31 10 2017'
+      %div.form-group
+        = f.gov_uk_date_field :publish_on, legend_text: 'Vacancy publication date', legend_class: 'form-label-bold', form_hint_text: 'For example, 31 10 2017'
 
-  = f.button :submit, 'Save and continue'
+      = f.button :submit, 'Save and continue'

--- a/app/views/vacancies/candidate_specification.html.haml
+++ b/app/views/vacancies/candidate_specification.html.haml
@@ -4,32 +4,34 @@
   %span.heading-secondary
     Step 2 of 3
 = render 'error_messages', errors: @vacancy.errors
-= simple_form_for @vacancy do |f|
+= simple_form_for @vacancy, html: { class: 'vacancy-form' } do |f|
   = hidden_field_tag :from, :candidate_specification
   = hidden_field_tag :next, (params[:next] || :application_details)
   %h2.heading-medium
     Candidate specification
 
-  = f.input :essential_requirements,
-            as: :text,
-            hint: 'Qualifications, experience, and/or professional registrations',
-            input_html: {rows: 10},
-            required: true
-  = f.input :education,
-            as: :text,
-            hint: 'Educational background needed for the position',
-            input_html: {rows: 5},
-            required: false
-  = f.input :qualifications,
-            as: :text,
-            hint: 'Specific qualifications required for this role',
-            input_html: {rows: 5},
-            required: false
-  = f.input :experience,
-            as: :text,
-            hint: 'Expected teaching or other experience',
-            input_html: {rows: 5},
-            required: false
+  .grid-row
+    .column-one-half
+      = f.input :essential_requirements,
+                as: :text,
+                hint: 'Qualifications, experience, and/or professional registrations',
+                input_html: {rows: 10},
+                required: true
+      = f.input :education,
+                as: :text,
+                hint: 'Educational background needed for the position',
+                input_html: {rows: 5},
+                required: false
+      = f.input :qualifications,
+                as: :text,
+                hint: 'Specific qualifications required for this role',
+                input_html: {rows: 5},
+                required: false
+      = f.input :experience,
+                as: :text,
+                hint: 'Expected teaching or other experience',
+                input_html: {rows: 5},
+                required: false
 
-  = f.input :school_id, as: :hidden
-  = f.button :submit, 'Save and continue'
+      = f.input :school_id, as: :hidden
+      = f.button :submit, 'Save and continue'

--- a/app/views/vacancies/job_specification.html.haml
+++ b/app/views/vacancies/job_specification.html.haml
@@ -4,77 +4,76 @@
   %span.heading-secondary
     Step 1 of 3
 = render 'error_messages', errors: @vacancy.errors
-= simple_form_for @vacancy do |f|
+= simple_form_for @vacancy, html: { class: 'vacancy-form' } do |f|
   = hidden_field_tag :from, :job_specification
   = hidden_field_tag :next, (params[:next] || :candidate_specification)
   %h2.heading-medium
     Job specification
 
-  = f.input :job_title,
-            hint: 'Must indicate subject to be taught (secondary school) or level of seniority',
-            required: true
-  = f.input :headline,
-            as: :text,
-            hint: 'Single sentence, summing up the job on offer, to appear at top of the listing',
-            input_html: {rows: 5},
-            required: true
-  = f.input :job_description,
-            as: :text,
-            hint: 'A description of the job, and the duties involved, and competencies and attitudes expected to be shown by the jobholder',
-            input_html: {rows: 10},
-            required: true
-  = f.input :benefits,
-            as: :text,
-            input_html: {rows: 5},
-            required: false
-  = f.association :subject,
-                  label: "Main Subject",
-                  hint: 'The main subject to be taught by teacher',
-                  collection: Subject.order(:name),
-                  required: false
-  %fieldset.form-group
-    %legend
-      %div Salary range
-      %span.form-hint Annual pay before tax (£)
+  .grid-row
+    .column-one-half
+      = f.input :job_title,
+                hint: 'Must indicate subject to be taught (secondary school) or level of seniority',
+                required: true
+      = f.input :headline,
+                hint: 'Single sentence, summing up the job on offer, to appear at top of the listing',
+                input_html: {rows: 5},
+                required: true
+      = f.input :job_description,
+                hint: 'A description of the job, and the duties involved, and competencies and attitudes expected to be shown by the jobholder',
+                input_html: {rows: 10},
+                required: true
+      = f.input :benefits,
+                input_html: {rows: 5},
+                required: false
+      = f.association :subject,
+                      label: "Main Subject",
+                      hint: 'The main subject to be taught by teacher',
+                      collection: Subject.order(:name),
+                      required: false
+      %fieldset.form-group
+        %legend
+          %div Salary range
+          %span.form-hint Annual pay before tax (£)
 
-    = f.input :minimum_salary,
-              as: :integer,
-              required: true,
-              wrapper: false,
-              label: false,
-              input_html: {class: 'form-control-1-8'}
+        = f.input :minimum_salary,
+                  as: :integer,
+                  required: true,
+                  wrapper: false,
+                  label: false,
+                  input_html: {class: 'form-control-1-8'}
 
-    to
+        to
 
-    = f.input :maximum_salary,
-              as: :integer,
-              wrapper: false,
-              required: true,
-              label: false,
-              input_html: {class: 'form-control-1-8'}
+        = f.input :maximum_salary,
+                  as: :integer,
+                  wrapper: false,
+                  required: true,
+                  label: false,
+                  input_html: {class: 'form-control-1-8'}
 
-  = f.association :pay_scale,
-                  hint: 'The pay scale on which the salary of the job falls',
-                  collection: PayScale.order(:label),
-                  label_method: :label,
-                  required: false
-  = f.input :working_pattern,
-            collection: working_pattern_options,
-            required: true
-  = f.input :weekly_hours,
-            as: :decimal,
-            hint: 'Number of hours to be worked each week',
-            required: false
-  = f.association :leadership,
-                  label: 'Leadership level',
-                  collection: Leadership.order(:title),
-                  required: false
+      = f.association :pay_scale,
+                      hint: 'The pay scale on which the salary of the job falls',
+                      collection: PayScale.order(:label),
+                      label_method: :label,
+                      required: false
+      = f.input :working_pattern,
+                collection: working_pattern_options,
+                required: true
+      = f.input :weekly_hours,
+                as: :decimal,
+                hint: 'Number of hours to be worked each week',
+                required: false
+      = f.association :leadership,
+                      label: 'Leadership level',
+                      collection: Leadership.order(:title),
+                      required: false
 
-  %div.form-group
-    = f.gov_uk_date_field :starts_on, legend_text: 'Expected start date (optional)', legend_class: 'form-label-bold', form_hint_text: 'For example, 31 9 2018'
+      %div.form-group
+        = f.gov_uk_date_field :starts_on, legend_text: 'Expected start date (optional)', legend_class: 'form-label-bold', form_hint_text: 'For example, 31 9 2018'
 
-  %div.form-group
-    = f.gov_uk_date_field :ends_on, legend_text: 'Expected end date (optional)', legend_class: 'form-label-bold', form_hint_text: 'For example, 31 2 2019'
+      %div.form-group
+        = f.gov_uk_date_field :ends_on, legend_text: 'Expected end date (optional)', legend_class: 'form-label-bold', form_hint_text: 'For example, 31 2 2019'
 
-  = f.input :school_id, as: :hidden, if: :new_record?
-  = f.button :submit, 'Save and continue'
+      = f.input :school_id, as: :hidden, if: :new_record?
+      = f.button :submit, 'Save and continue'


### PR DESCRIPTION
- adds `.vacancy-form` class to form wrapper
- adds some gov.uk grid classes to form content
- overrides `.form-control` class in `.vacancy-form` namespace to ensure correct width of `<textarea>`
- overrides gov.uk `.form-group` margins on mobile (they’re too small)

Fixes https://trello.com/c/4Vj262g2/21-vacancy-form-layout

Before: <img width="990" alt="screen_shot_2018-02-22_at_14 46 13" src="https://user-images.githubusercontent.com/822507/36855736-31d0c498-1d6c-11e8-8e73-53ac0cf427b5.png">

After: 
![screen shot 2018-03-01 at 16 07 32](https://user-images.githubusercontent.com/822507/36855746-3f01fb14-1d6c-11e8-99a1-29705d699afa.png)
