### PR TITLE
(Feature) AWS request signing for ElasticSearch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'rails', '~> 5.1.4'
 gem 'puma', '~> 3.7'
 gem 'pg', '~> 0.18'
 gem 'elasticsearch-model'
+gem 'faraday_middleware-aws-signers-v4'
 gem 'friendly_id'
 gem 'figaro'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,12 @@ GEM
     ansi (1.5.0)
     arel (8.0.0)
     ast (2.3.0)
+    aws-sdk-core (2.11.8)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.11.8)
+      aws-sdk-core (= 2.11.8)
+    aws-sigv4 (1.0.2)
     bindex (0.5.0)
     breasal (0.0.1)
     builder (3.2.3)
@@ -107,6 +113,9 @@ GEM
       i18n (~> 0.5)
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
+    faraday_middleware-aws-signers-v4 (0.1.9)
+      aws-sdk-resources (>= 2, < 3)
+      faraday (~> 0.9)
     ffi (1.9.18)
     figaro (1.1.1)
       thor (~> 0.14)
@@ -146,6 +155,7 @@ GEM
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    jmespath (1.3.1)
     kaminari (1.0.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.0.1)
@@ -338,6 +348,7 @@ DEPENDENCIES
   elasticsearch-model
   factory_girl_rails
   faker
+  faraday_middleware-aws-signers-v4
   figaro
   friendly_id
   gov_uk_date_fields (~> 2.0, >= 2.0.3)

--- a/config/initializers/elastic_search.rb
+++ b/config/initializers/elastic_search.rb
@@ -1,1 +1,17 @@
-Elasticsearch::Model.client = Elasticsearch::Client.new(host: ENV['ELASTICSEARCH_URL'])
+require 'faraday_middleware/aws_signers_v4'
+
+if ENV['ELASTICSEARCH_AWS_SIGNING']
+
+  Elasticsearch::Model.client = Elasticsearch::Client.new(host: ENV['ELASTICSEARCH_URL']) do |f|
+    f.request :aws_signers_v4,
+      credentials: Aws::Credentials.new(ENV['AWS_ELASTICSEARCH_KEY'], ENV['AWS_ELASTICSEARCH_SECRET']),
+      service_name: 'es',
+      region: ENV['AWS_ELASTICSEARCH_REGION']
+
+    f.response :logger
+    f.adapter  Faraday.default_adapter
+  end
+
+else
+  Elasticsearch::Model.client = Elasticsearch::Client.new(host: ENV['ELASTICSEARCH_URL'])
+end


### PR DESCRIPTION
* When locking down an ElasticSearch domain in AWS to a single user, request signing is
required.