### PR TITLE
(Feature) AWS ES lockdown to single user

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -70,6 +70,10 @@ module "ecs" {
   rds_password                          = "${var.rds_password}"
   rds_address                           = "${module.rds.rds_address}"
   es_address                            = "${module.es.es_address}"
+  origin_url                            = "${var.origin_url}"
+  aws_elasticsearch_region              = "${var.region}"
+  aws_elasticsearch_key                 = "${module.es.es_user_access_key_id}"
+  aws_elasticsearch_secret              = "${module.es.es_user_access_key_secret}"
 }
 
 module "logs" {

--- a/terraform/modules/ecs/ecs.tf
+++ b/terraform/modules/ecs/ecs.tf
@@ -57,6 +57,10 @@ data "template_file" "web_task" {
     database_password   = "${var.rds_password}"
     database_url        = "${var.rds_address}"
     elastic_search_url  = "${var.es_address}"
+    origin_url          = "${var.origin_url}"
+    aws_elasticsearch_region = "${var.aws_elasticsearch_region}"
+    aws_elasticsearch_key    = "${var.aws_elasticsearch_key}"
+    aws_elasticsearch_secret = "${var.aws_elasticsearch_secret}"
   }
 }
 

--- a/terraform/modules/ecs/input.tf
+++ b/terraform/modules/ecs/input.tf
@@ -20,3 +20,7 @@ variable "rds_username"                {}
 variable "rds_password"                {}
 variable "rds_address"                 {}
 variable "es_address"                  {}
+variable "origin_url"                  {}
+variable "aws_elasticsearch_region"    {}
+variable "aws_elasticsearch_key"       {}
+variable "aws_elasticsearch_secret"    {}

--- a/terraform/modules/es/es.tf
+++ b/terraform/modules/es/es.tf
@@ -42,6 +42,14 @@ resource "aws_elasticsearch_domain_policy" "default" {
   access_policies = "${data.aws_iam_policy_document.es.json}"
 }
 
+resource "aws_iam_user" "es_user" {
+  name = "${var.project_name}-${var.environment}-es"
+}
+
+resource "aws_iam_access_key" "es_user_access_key" {
+  user = "${aws_iam_user.es_user.name}"
+}
+
 data "aws_iam_policy_document" "es" {
   statement {
     actions = [
@@ -54,7 +62,7 @@ data "aws_iam_policy_document" "es" {
 
     principals {
      type = "AWS"
-     identifiers = ["*"]
+     identifiers = ["${aws_iam_user.es_user.arn}"]
     }
   }
 }

--- a/terraform/modules/es/output.tf
+++ b/terraform/modules/es/output.tf
@@ -1,3 +1,11 @@
 output "es_address" {
   value = "${aws_elasticsearch_domain.default.endpoint}"
 }
+
+output "es_user_access_key_id" {
+  value = "${element(concat( aws_iam_access_key.es_user_access_key.*.id, list("")), 0)}"
+}
+
+output "es_user_access_key_secret" {
+  value = "${element(concat( aws_iam_access_key.es_user_access_key.*.secret, list("")), 0)}"
+}

--- a/web_task_definition.json
+++ b/web_task_definition.json
@@ -54,6 +54,22 @@
       {
         "name": "ELASTICSEARCH_URL",
         "value": "https://${elastic_search_url}:443"
+      },
+      {
+        "name": "ORIGIN_URL",
+        "value": "${origin_url}"
+      },
+      {
+        "name": "AWS_ELASTICSEARCH_REGION",
+        "value": "${aws_elasticsearch_region}"
+      },
+      {
+        "name": "AWS_ELASTICSEARCH_KEY",
+        "value": "${aws_elasticsearch_key}"
+      },
+      {
+        "name": "AWS_ELASTICSEARCH_SECRET",
+        "value": "${aws_elasticsearch_secret}"
       }
     ]
   }


### PR DESCRIPTION
* ElasticSearch now requires request signing. The user's key/secret are
exported to the relevant environment variables