### PR TITLE
(Chore) Add TLS protocols to CloudFront

### DIFF
--- a/terraform/modules/cloudfront/cloudfront.tf
+++ b/terraform/modules/cloudfront/cloudfront.tf
@@ -4,9 +4,9 @@ resource "aws_cloudfront_distribution" "default" {
     domain_name = "${var.cloudfront_origin_domain_name}"
     origin_id   = "${var.project_name}-${var.environment}-default-origin"
     custom_origin_config {
-      origin_protocol_policy = "http-only"
+      origin_protocol_policy = "https-only"
       http_port  = "80"
-      https_port = "80"
+      https_port = "443"
       origin_ssl_protocols = ["TLSv1","TLSv1.1","TLSv1.2"]
     }
   }


### PR DESCRIPTION
* CloudFront was unable to communicate with the ALB that had the TLSv1.2
policy applied. We may be able to narrow this down to just ["TLSv1.2"]
in furture