### PR TITLE
(feature) renders required fieds in vacancy list

### DIFF
--- a/app/assets/stylesheets/components/vacancies.scss
+++ b/app/assets/stylesheets/components/vacancies.scss
@@ -18,15 +18,22 @@
     }
     dt, dd {
       display: inline-block;
+      padding-bottom: 3px;
     }
     dt {
-      width: 20%;
+      width: 25%;
       color: $secondary-text-colour;
+      @include media(desktop) {
+        width: 20%;
+      }
     }
     dd {
-      width: 25%;
+      width: 50%;
       &.double {
         width: 70%;
+      }
+      @include media(desktop) {
+        width: 25%;
       }
     }
   }

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -2,7 +2,7 @@ module DateHelper
   class FormatDateError < RuntimeError; end
 
   def format_date(date, format = :default)
-    return if date.nil?
+    return 'No date given' if date.nil?
     date_formats = Date::DATE_FORMATS.keys.join(' ')
     unless Date::DATE_FORMATS.include?(format)
       raise FormatDateError, date_format_error_message(format, date_formats)

--- a/app/views/vacancies/_vacancy.html.haml
+++ b/app/views/vacancies/_vacancy.html.haml
@@ -1,0 +1,16 @@
+%li.vacancy
+  %h2= link_to vacancy.job_title, vacancy_path(vacancy)
+  %p= vacancy.location
+  %dl
+    %dt Salary
+    %dd.double
+      = vacancy.salary_range
+      per annum
+    %dt Posted on
+    %dd= format_date(vacancy.publish_on)
+    %dt Closing date
+    %dd= format_date(vacancy.expires_on)
+    %dt Contract
+    %dd= vacancy.working_pattern&.titleize
+    %dt Start date
+    %dd= format_date(vacancy.starts_on)

--- a/app/views/vacancies/index.html.haml
+++ b/app/views/vacancies/index.html.haml
@@ -14,22 +14,7 @@
 
       %ul.vacancies
         - @vacancies.each do |vacancy|
-          %li.vacancy
-            %h2= link_to vacancy.job_title, vacancy_path(vacancy)
-            %p= vacancy.location
-            %dl
-              %dt Salary
-              %dd.double
-                = vacancy.salary_range
-                per annum
-              %dt Closing date
-              %dd= format_date(vacancy.expires_on)
-              %dt Posted on
-              %dd= format_date(vacancy.publish_on)
-              %dt Contract
-              %dd= vacancy.working_pattern&.titleize
-              %dt Job ref
-              %dd= vacancy.reference
+          = render partial: 'vacancy', locals: { vacancy: vacancy }
 
     - else
       %div.empty

--- a/spec/helpers/date_helper_spec.rb
+++ b/spec/helpers/date_helper_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe DateHelper, type: :helper do
     end
 
     it 'returns if nil date is given' do
-      expect(helper.format_date(nil)).to be_nil
+      expect(helper.format_date(nil)).to eq 'No date given'
     end
 
     it 'raises an error if an invalid format is given' do


### PR DESCRIPTION
https://trello.com/c/41fEdxEE/109-view-search-results-as-a-list

~~- adds a conditional that checks for presence of `starts_on` for a vacancy, and renders the text "Not given" where no `starts_on` exists.~~

- moves the vacancy rendering to a partial
- adds a conditional to DateHelper that returns 'No date given' when nil
- updates the spec accordingly
- adds some padding to the vacancy details

![screen shot 2018-03-06 at 17 25 15](https://user-images.githubusercontent.com/822507/37048393-b2027f1a-2165-11e8-9ff1-6e52f9279f44.png)
