### PR TITLE
(chore): Tell the test-server to go up or down

### DIFF
--- a/bin/dtest-server
+++ b/bin/dtest-server
@@ -1,7 +1,27 @@
 #!/bin/bash
 set -e
 
-docker-compose --project-name 'teachervacancyservice_static' down
-docker-compose --project-name 'teachervacancyservice_static' --file docker-compose.test.yml up -d db-test
-docker-compose --project-name 'teachervacancyservice_static' --file docker-compose.test.yml up -d elasticsearch-test
-docker-compose --project-name 'teachervacancyservice_static' --file docker-compose.test.yml up -d spring
+start_test_server()
+{
+  docker-compose --project-name 'teachervacancyservice_static' --file docker-compose.test.yml up -d db-test
+  docker-compose --project-name 'teachervacancyservice_static' --file docker-compose.test.yml up -d elasticsearch-test
+  docker-compose --project-name 'teachervacancyservice_static' --file docker-compose.test.yml up -d spring
+}
+
+
+if [[ $# -eq 0 ]]
+then
+  docker-compose --project-name 'teachervacancyservice_static' --file docker-compose.test.yml down
+  start_test_server
+fi
+
+if [[ $1 == "up" ]]
+then
+  docker-compose --project-name 'teachervacancyservice_static' --file docker-compose.test.yml down
+  start_test_server
+fi
+
+if [[ $1 == "down" ]]
+then
+  docker-compose --project-name 'teachervacancyservice_static' --file docker-compose.test.yml down
+fi


### PR DESCRIPTION
* When using this locally I found that if my terminal froze or there was another issue that it would leave containers around. The only way to remove these is to manually remove the containers or to add in the shell `catch` to tidy up.
* This change removes this error: WARNING: Found orphan containers (teachervacancyservicestatic_spring_1, teachervacancyservicestatic_elasticsearch-test_1, teachervacancyservicestatic_db-test_1) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up.