### PR TITLE
(fix): Resart elasticsearch container (in dev) on failure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       - cluster.name=docker=docker-cluster
     volumes:
       - elasticsearch:/usr/share/elasticsearch/data
+    restart: on-failure
 
 volumes:
   pg_data: {}


### PR DESCRIPTION
* Mine crashed during some tinkering with ES query params and I didn’t notice until I went looking for it.