### PR TITLE
(fix): Vacancies can be reliably created in test

### DIFF
--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :subject do
     name { Faker::Educator.course }
+    initialize_with { Subject.find_or_create_by(name: name) }
   end
 end


### PR DESCRIPTION
* Subjects are an association on Vacancy. Whenever FactoryGirl is asked to creation it tries to create a subject (amoungst other things) this eventually/sometimes breaks with the following error:

Faker::UniqueGenerator::RetryLimitExceeded:
       Faker::UniqueGenerator::RetryLimitExceeded
     # /usr/local/bundle/gems/faker-1.7.3/lib/helpers/unique_generator.rb:19:in `method_missing'

* I’ve changed approach to try and deal with this so it’s idempotent