### PR TITLE
(fix): Google analytics no longer errors

### DIFF
--- a/app/views/shared/_gtag.html.haml
+++ b/app/views/shared/_gtag.html.haml
@@ -4,5 +4,4 @@
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-
-  gtag('config', ENV['GOOGLE_ANALYTICS']);
+  gtag('config', "#{ENV['GOOGLE_ANALYTICS']}");


### PR DESCRIPTION
* This fixes the following error:

```
physics-teacher:39 Uncaught ReferenceError: ENV is not defined
    at physics-teacher:39
```