### PR TITLE
(Fix) Add missing comma in web_task_definition.json

### DIFF
--- a/web_task_definition.json
+++ b/web_task_definition.json
@@ -42,7 +42,7 @@
       {
         "name": "ROLLBAR_ACCESS_TOKEN",
         "value": "${rollbar_access_token}"
-      }
+      },
       {
         "name": "SECRET_KEY_BASE",
         "value": "${secret_key_base}"


### PR DESCRIPTION
* Note that invalid JSON in task definitions do not cause terraform to
stop, it just doesn't create the resource. The error you'll subsequently
see is only if another resource tries referencing the task definition.
* The warning for invalid JSON can only be seen by setting TF_LOG to
DEBUG