### PR TITLE
(fix): Rebuilding the Docker dev env will reset the test server too

### DIFF
--- a/bin/drebuild
+++ b/bin/drebuild
@@ -1,10 +1,15 @@
 #!/bin/sh
 
-docker-compose down -v
-docker-compose build
-docker-compose up -d elasticsearch
-sleep 10 # ElasticSearch is slow to get ready
-docker-compose run web rake db:drop db:setup
-docker-compose down
+# Test server
+echo "Rebuiling the test server…"
+docker-compose --file=docker-compose.test.yml down --rmi=all -v --remove-orphans
+docker-compose --file=docker-compose.test.yml build
+bin/dtest-server
+echo "Rebuilt and started the testing server for TVS."
 
-echo "Rebuild completed. You can now start up TVS"
+# Web server
+echo "Rebuiling the web server…"
+docker-compose down -v --rmi=all --remove-orphans
+docker-compose build
+echo "Rebuilt and starting the web server for TVS."
+bin/dstart


### PR DESCRIPTION
* I have had problems when working on Dockerfiles because of adding new gems. The test-server will always fail as it uses an old image that doesn’t have the gem the application is referring to. This change will nuke everything and start again with a fresh and up-to-date state.
* It starts both sets of server which is also something I’m finding myself doing repeatedly. I never rebuild without also wanting to get my stack running and ready for dev.
* Sleep doesn't seem to be required when tested
* Because of the new docker-entrypoint.sh added recently https://github.com/dxw/teacher-vacancy-service/pull/35 we no longer need to bootstrap the container by hand. It will auto detect and sort the database out.