### PR TITLE
(Fix) Add chmod +x /docker-entrypoint.sh to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ COPY . $INSTALL_PATH
 RUN bundle exec rake DATABASE_URL=postgresql:does_not_exist --quiet assets:precompile
 
 COPY ./docker-entrypoint.sh /
+RUN chmod +x /docker-entrypoint.sh
 EXPOSE 3000
 
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
* CodePipeline pulls the repo, then pushes it to S3. CodeBuild then
pulls it from S3,  which causes all files to change mode to 0644 (Not
executable). /docker-entrypoint.sh needs to be executable.