### PR TITLE
(fix): School import task can write file to disk on staging

### DIFF
--- a/app/jobs/update_schools_data_from_source_job.rb
+++ b/app/jobs/update_schools_data_from_source_job.rb
@@ -57,7 +57,7 @@ class UpdateSchoolsDataFromSourceJob < ApplicationJob
   end
 
   def csv_file_location
-    "./tmp/import/#{datestring}-schools-data.csv"
+    "./tmp/#{datestring}-schools-data.csv"
   end
 
   def save_csv_file(location: csv_file_location)


### PR DESCRIPTION
* I could either add tmp/import to git or just remove the import directory as there isn’t a tangible need for it, just organisation.