### PR TITLE
(fix): Rollbar knows what Terraform environment it is in

### DIFF
--- a/import_schools_task_definition.json
+++ b/import_schools_task_definition.json
@@ -19,6 +19,10 @@
         "value": "${rails_env}"
       },
       {
+        "name": "ROLLBAR_ENV",
+        "value": "${environment}"
+      },
+      {
         "name": "GOOGLE_MAPS_API_KEY",
         "value": "${google_maps_api_key}"
       },

--- a/vacancies_scrape_task_definition.json
+++ b/vacancies_scrape_task_definition.json
@@ -19,6 +19,10 @@
         "value": "${rails_env}"
       },
       {
+        "name": "ROLLBAR_ENV",
+        "value": "${environment}"
+      },
+      {
         "name": "GOOGLE_MAPS_API_KEY",
         "value": "${google_maps_api_key}"
       },

--- a/web_task_definition.json
+++ b/web_task_definition.json
@@ -28,6 +28,10 @@
         "value": "${default_school_urn}"
       },
       {
+        "name": "ROLLBAR_ENV",
+        "value": "${environment}"
+      },
+      {
         "name": "HTTP_USER",
         "value": "${http_user}"
       },


### PR DESCRIPTION
* Before this change we had staging, testing and edge environments, all running in the Rails staging environment. Rollbar was reporting all errors from these 3 environments as `staging` which is not very useful as they can all be running different copies of the code and we need to know which stack/envrionment caused the error.
* This ENV was already being read from the Rollbar initialiser: https://github.com/dxw/teacher-vacancy-service/blob/develop/config/initializers/rollbar.rb#L66