### PR TITLE
(fix): Error pages did not have the correct support email

### DIFF
--- a/app/views/errors/internal_server_error.html.haml
+++ b/app/views/errors/internal_server_error.html.haml
@@ -1,2 +1,2 @@
 %h1.heading-xlarge Something went wrong at our end.
-%p You can email #{mail_to t('error_pages.help_email')} if the problem persists.
+%p You can email #{mail_to t('help.email')} if the problem persists.

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -42,7 +42,7 @@
 - content_for :footer_top do
   %p
     Problems using this service? Email
-    =mail_to 'isobel.croot@digital.education.gov.uk'
+    = mail_to I18n.t('help.email')
     for support.
 
 = render file: 'layouts/govuk_template'

--- a/app/views/shared/_beta_banner.html.haml
+++ b/app/views/shared/_beta_banner.html.haml
@@ -2,5 +2,5 @@
   .small This service is still in development, so for now only lists jobs in select schools in Cambridgeshire and the North East. When it launches, the full service will list jobs in schools throughout England.
   .small
     Interested in listing jobs at your school? Email
-    =mail_to 'isobel.croot@digital.education.gov.uk'
+    = mail_to I18n.t('help.email')
     for more information.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -149,5 +149,5 @@ en:
     url:
       invalid: is not a valid URL
 
-  error_pages:
-    help_email: email@example.com
+  help:
+    email: isobel.croot@digital.education.gov.uk


### PR DESCRIPTION
* Instead of tying this in name to ‘error_pages’ this can be a generic way a user can get ‘help’, whether that be by email or phone