### PR TITLE
Specify the key_name over the key_name_prefix

### DIFF
--- a/terraform/modules/core/core.tf
+++ b/terraform/modules/core/core.tf
@@ -552,8 +552,8 @@ Launch configuration
 ======*/
 
 resource "aws_key_pair" "ecs" {
-  key_name_prefix = "${var.ecs_cluster_name}"
-  public_key      = "${var.ecs_ssh_public_key}"
+  key_name   = "${var.ecs_cluster_name}"
+  public_key = "${var.ecs_ssh_public_key}"
 }
 
 resource "aws_launch_configuration" "ecs-launch-configuration" {


### PR DESCRIPTION
## Changes in this PR:

Setting a prefix means that key name changes when the public key
changes. This causes the autoscaling group to be recreated, which causes
downtime. IF we make the key name static, this doesn't happen.

## Next steps:

- [x] Terraform deployment required?
