### PR TITLE
Legacy bookmarked URLs containing phases param are throwing errors

### DIFF
--- a/app/services/algolia/vacancy_filters_builder.rb
+++ b/app/services/algolia/vacancy_filters_builder.rb
@@ -10,7 +10,8 @@ class Algolia::VacancyFiltersBuilder
     @to_date = filters_hash[:to_date]
 
     @job_roles = filters_hash[:job_roles]
-    @phases = filters_hash[:phases]
+    # Legacy filters included phases, so legacy URLs may contain empty arrays here
+    @phases = filters_hash[:phases]&.reject(&:blank?)
     @working_patterns = filters_hash[:working_patterns]
 
     @suitable_for_nqt = filters_hash[:newly_qualified_teacher]

--- a/app/views/shared/_filter_group.html.haml
+++ b/app/views/shared/_filter_group.html.haml
@@ -33,13 +33,13 @@
               = t('shared.filter_group.clear_all_filters')
 
           - filters[:items].each do |group|
-            - if group[:selected]&.count > 0
+            - if group[:selected]&.any?
               .govuk-heading-s{ class: 'govuk-!-margin-bottom-0 govuk-!-font-weight-bold' }
                 = group[:title]
 
             %ul.moj-filter-tags
               - group[:options].each do |tag|
-                - if group[:selected].include? tag.send(group[:value_method])
+                - if group[:selected]&.include?(tag.send(group[:value_method]))
                   %li
                     %button.moj-filter__tag{ data: { group: group[:key], key: tag.send(group[:value_method]) } }
                       %i.fa.fa-close


### PR DESCRIPTION
https://rollbar.com/dfe/teacher-vacancies/items/1987/
https://rollbar.com/dfe/teacher-vacancies/items/1988/

Phases used to be a valid parameter, and some users have bookmarked URLs containing this. 
We should defend against this - this is a suggested approach