### PR TITLE
Add 'git secrets'

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ make -s local print-env > .env
 
 To run the command above you need [AWS credentials](#aws-credentials).
 
+[Git secrets](/documentation/secrets-detection.md) offers an easy way to defend against accidentally publishing these secrets.
+
 ### Install dependencies
 
 Install Ruby dependency libraries:

--- a/documentation/secrets-detection.md
+++ b/documentation/secrets-detection.md
@@ -1,0 +1,20 @@
+# Secrets detection
+
+[Git secrets](https://github.com/awslabs/git-secrets) (not to be confused with [git-secret](https://git-secret.io/), nor with GitHub Secrets) acts as an extra line of defence to prevent you committing secrets. Once installed, it hooks into the git commit command.
+
+From your `teaching-vacancies` repo, run:
+
+```bash
+brew install git-secrets
+git secrets --install
+git secrets --add '.+_PASSWORD\s*=\s*.+'
+git secrets --add '.+_ID\s*=\s*.+'
+git secrets --add '.+_KEY\s*=\s*.+'
+git secrets --add '.+_SECRET\s*=\s*.+'
+git secrets --add '.+_TOKEN\s*=\s*.+'
+git secrets --add '.+_SALT\s*=\s*.+'
+git secrets --add '.+_AUTHENTICATION\s*=\s*.+'
+git secrets --add '.+_BASE\s*=\s*.+'
+```
+
+You should see these patterns added to the `.git/config` file.


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1593

## Changes in this PR:

- The idea is to add another line of defence for these secrets, as we have twice lost time this year to accidental publication of secrets.
- Added [git secrets](https://github.com/awslabs/git-secrets). The patterns were based on the contents of `.env` and nothing else.
- Try setting this up locally and let me know if you have any issues.
- If a pattern is matched when committing, git secrets offers the option to ignore the warning (temporarily or permanently).

