### PR TITLE
[TEVA-1599] Add provider version pinning to terraform/monitoring

### DIFF
--- a/terraform/monitoring/versions.tf
+++ b/terraform/monitoring/versions.tf
@@ -1,6 +1,14 @@
 terraform {
   required_version = ">= 0.13"
   required_providers {
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.0.0"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.15.0"
+    }
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"
       version = ">= 0.12.6"


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1599

## Changes in this PR:

- Pin terraform provider versions of `hashicorp/archive` and `hashicorp/aws` to match the latest versions already used, and present in the state file.