### PR TITLE
Add fields to BigQuery tables to link LA DSI users to organisations

### DIFF
--- a/lib/dfe_sign_in_api.rb
+++ b/lib/dfe_sign_in_api.rb
@@ -72,4 +72,19 @@ private
     end
     response_pages
   end
+
+  def la_code(user)
+    # The organisation in the user from the DSI response contains an establishment number, which
+    # matches the LA code if the organisation is an LA.
+    # Category '002' denotes an LA.
+    # To be consistent with trusts and schools, we only send the LA code to BigQuery if the organisation
+    # is of the right type (i.e. it's an LA).
+
+    # There is a different schema for the approvers and users API responses:
+    if user.dig("organisation", "Category") == "002"
+      user.dig("organisation", "EstablishmentNumber")
+    elsif user.dig("organisation", "category", "id") == "002"
+      user.dig("organisation", "establishmentNumber")
+    end
+  end
 end

--- a/lib/export_dsi_approvers_to_big_query.rb
+++ b/lib/export_dsi_approvers_to_big_query.rb
@@ -19,7 +19,8 @@ private
         email: user["email"],
         family_name: user["familyName"],
         given_name: user["givenName"],
-        organisation_uid: user.dig("organisation", "uid"),
+        la_code: la_code(user),
+        trust_uid: user.dig("organisation", "uid"),
         role_id: user["roleId"],
         role_name: user["roleName"],
         school_urn: user.dig("organisation", "urn"),
@@ -33,10 +34,11 @@ private
       schema.string "email", mode: :required
       schema.string "family_name", mode: :required
       schema.string "given_name", mode: :required
-      schema.integer "organisation_uid", mode: :nullable
+      schema.integer "la_code", mode: :nullable
       schema.string "role_id", mode: :required
       schema.string "role_name", mode: :required
       schema.integer "school_urn", mode: :nullable
+      schema.integer "trust_uid", mode: :nullable
       schema.string "user_id", mode: :required
     end
   end

--- a/lib/export_dsi_approvers_to_big_query.rb
+++ b/lib/export_dsi_approvers_to_big_query.rb
@@ -16,28 +16,28 @@ private
   def present_for_big_query(batch)
     batch.map do |user|
       {
-        user_id: user["userId"],
-        role_id: user["roleId"],
-        role_name: user["roleName"],
         email: user["email"],
         family_name: user["familyName"],
         given_name: user["givenName"],
-        school_urn: user.dig("organisation", "urn"),
         organisation_uid: user.dig("organisation", "uid"),
+        role_id: user["roleId"],
+        role_name: user["roleName"],
+        school_urn: user.dig("organisation", "urn"),
+        user_id: user["userId"],
       }
     end
   end
 
   def insert_table_data(batch)
     dataset.insert TABLE_NAME, present_for_big_query(batch), autocreate: true do |schema|
-      schema.string "user_id", mode: :required
-      schema.string "role_id", mode: :required
-      schema.string "role_name", mode: :required
       schema.string "email", mode: :required
       schema.string "family_name", mode: :required
       schema.string "given_name", mode: :required
-      schema.integer "school_urn", mode: :nullable
       schema.integer "organisation_uid", mode: :nullable
+      schema.string "role_id", mode: :required
+      schema.string "role_name", mode: :required
+      schema.integer "school_urn", mode: :nullable
+      schema.string "user_id", mode: :required
     end
   end
 

--- a/lib/export_dsi_users_to_big_query.rb
+++ b/lib/export_dsi_users_to_big_query.rb
@@ -20,7 +20,8 @@ private
         email: user["email"],
         family_name: user["familyName"],
         given_name: user["givenName"],
-        organisation_uid: user.dig("organisation", "UID"),
+        la_code: la_code(user),
+        trust_uid: user.dig("organisation", "UID"),
         role: user["roleName"],
         school_urn: user.dig("organisation", "URN"),
         update_datetime: user["updatedAt"],
@@ -35,9 +36,10 @@ private
       schema.string "email", mode: :nullable
       schema.string "family_name", mode: :nullable
       schema.string "given_name", mode: :nullable
-      schema.integer "organisation_uid", mode: :nullable
+      schema.integer "la_code", mode: :nullable
       schema.string "role", mode: :nullable
       schema.integer "school_urn", mode: :nullable
+      schema.integer "trust_uid", mode: :nullable
       schema.timestamp "update_datetime", mode: :nullable
       schema.string "user_id", mode: :nullable
     end

--- a/lib/export_dsi_users_to_big_query.rb
+++ b/lib/export_dsi_users_to_big_query.rb
@@ -16,30 +16,30 @@ private
   def present_for_big_query(batch)
     batch.map do |user|
       {
-        user_id: user["userId"],
-        role: user["roleName"],
         approval_datetime: user["approvedAt"],
-        update_datetime: user["updatedAt"],
-        given_name: user["givenName"],
-        family_name: user["familyName"],
         email: user["email"],
-        school_urn: user.dig("organisation", "URN"),
+        family_name: user["familyName"],
+        given_name: user["givenName"],
         organisation_uid: user.dig("organisation", "UID"),
+        role: user["roleName"],
+        school_urn: user.dig("organisation", "URN"),
+        update_datetime: user["updatedAt"],
+        user_id: user["userId"],
       }
     end
   end
 
   def insert_table_data(batch)
     dataset.insert TABLE_NAME, present_for_big_query(batch), autocreate: true do |schema|
-      schema.string "user_id", mode: :nullable
-      schema.string "role", mode: :nullable
       schema.timestamp "approval_datetime", mode: :nullable
-      schema.timestamp "update_datetime", mode: :nullable
-      schema.string "given_name", mode: :nullable
-      schema.string "family_name", mode: :nullable
       schema.string "email", mode: :nullable
-      schema.integer "school_urn", mode: :nullable
+      schema.string "family_name", mode: :nullable
+      schema.string "given_name", mode: :nullable
       schema.integer "organisation_uid", mode: :nullable
+      schema.string "role", mode: :nullable
+      schema.integer "school_urn", mode: :nullable
+      schema.timestamp "update_datetime", mode: :nullable
+      schema.string "user_id", mode: :nullable
     end
   end
 

--- a/lib/organisation_import/import_organisation_data.rb
+++ b/lib/organisation_import/import_organisation_data.rb
@@ -4,13 +4,6 @@ require "httparty"
 require "open-uri"
 
 class ImportOrganisationData
-# NB: To me it doesn't seem too unreasonable to have the transformation logic here, but in the interest of not
-#     deleting comments I didn't write, see the TODO below.
-# TODO: Refactor the transformation logic into the model.
-# These are the attributes that require additional transformation before being added to the model. The first value of
-# the array is the row key name, the second is the method used for the transformation.  URL is the exception, as it
-# requires an external function call-this is handled in the method.
-
 private
 
   def create_organisation(row)

--- a/lib/organisation_import/import_school_data.rb
+++ b/lib/organisation_import/import_school_data.rb
@@ -23,6 +23,9 @@ class ImportSchoolData < ImportOrganisationData
 
 private
 
+  # These are the attributes that require additional transformation before being added to the model. The first value of
+  # the array is the row key name, the second is the method used for the transformation. URL is the exception, as it
+  # requires an external function call - this is handled in the set_complex_properties method.
   def complex_mappings
     {
       address3: ["Address3", :presence],

--- a/lib/organisation_import/import_trust_data.rb
+++ b/lib/organisation_import/import_trust_data.rb
@@ -12,6 +12,8 @@ class ImportTrustData < ImportOrganisationData
 
 private
 
+  # These are the attributes that require additional transformation before being added to the model. The first value of
+  # the array is the row key name, the second is the method used for the transformation.
   def complex_mappings
     {
       name: ["Group Name", :titlecase],

--- a/lib/update_dsi_users_in_db.rb
+++ b/lib/update_dsi_users_in_db.rb
@@ -16,17 +16,13 @@ private
         user.email = dsi_user["email"]
         user.given_name = dsi_user["givenName"]
         user.family_name = dsi_user["familyName"]
+
         # When a user is associated with multiple organisations,
         # DfE Sign In returns 1 user object per organisation.
         # Each of these user objects has the same userId.
-        organisation = dsi_user["organisation"]
-        urn = organisation["URN"]
-        uid = organisation["UID"]
-
-        # All organisations have an EstablishmentNumber, but we only want this for identifying LAs by.
-        # If a User has a dsi_data local_authority_code, they can sign in as that LA.
-        # Assume that if and only if an organisation has no URN or UID, it is a Local Authority.
-        la_code = urn.present? || uid.present? ? nil : organisation["EstablishmentNumber"]
+        urn = dsi_user.dig("organisation", "URN")
+        uid = dsi_user.dig("organisation", "UID")
+        la_code = la_code(dsi_user)
 
         school_urns = user.dsi_data&.[]("school_urns") || []
         trust_uids = user.dsi_data&.[]("trust_uids") || []

--- a/spec/fixtures/dfe_sign_in_service_users_response_page_1.json
+++ b/spec/fixtures/dfe_sign_in_service_users_response_page_1.json
@@ -5,7 +5,7 @@
     "organisation": {
       "id": "13F20E54-79EA-4146-8E39-18197576F023",
       "name": "Department for Education",
-      "Category": "002",
+      "Category": "001",
       "Type": null,
       "URN": "111111",
       "UID": null,

--- a/spec/fixtures/dfe_sign_in_service_users_response_page_2.json
+++ b/spec/fixtures/dfe_sign_in_service_users_response_page_2.json
@@ -6,7 +6,7 @@
     "organisation": {
       "id": "13F20E54-79EA-4146-8E39-18197576F024",
       "name": "Organisation 2",
-      "Category": "002",
+      "Category": "001",
       "Type": null,
       "URN": null,
       "UID": "222222",
@@ -38,7 +38,7 @@
     "organisation": {
       "id": "23F20E54-79EA-4146-8E39-18197576F025",
       "name": "Organisation 3",
-      "Category": "002",
+      "Category": "001",
       "Type": null,
       "URN": "333333",
       "UID": null,
@@ -70,7 +70,7 @@
     "organisation": {
       "id": "13F20E54-79EA-4146-8E39-18197576F024",
       "name": "Organisation 2",
-      "Category": "002",
+      "Category": "010",
       "Type": null,
       "URN": null,
       "UID": "444444",
@@ -102,7 +102,7 @@
     "organisation": {
       "id": "23F20E54-79EA-4146-8E39-18197576F025",
       "name": "Organisation 3",
-      "Category": "002",
+      "Category": "001",
       "Type": null,
       "URN": "555555",
       "UID": null,
@@ -131,7 +131,7 @@
   {
     "approvedAt": "2020-09-16T11:15:21.555Z",
     "updatedAt": "2020-09-16T11:15:21.555Z",
-    "organisation": 
+    "organisation":
      {"id": "ABC-123",
       "name": "Local-authority-shire",
       "Category": "002",

--- a/spec/lib/export_dsi_approver_records_to_big_query_spec.rb
+++ b/spec/lib/export_dsi_approver_records_to_big_query_spec.rb
@@ -43,21 +43,27 @@ RSpec.describe ExportDsiApproversToBigQuery do
       "given_name" => Faker::Name.first_name,
       "family_name" => Faker::Name.last_name,
       "email" => Faker::Internet.email,
-      "organisation" => { "urn" => 100_000, "uid" => 999_999 },
+      "organisation" => {
+        "urn" => 100_000,
+        "uid" => 999_999,
+        "category" => { id: "002" },
+        "establishmentNumber" => "800",
+      },
     }
   end
 
   let(:expected_table_data) do
     [
       {
-        user_id: approver["userId"],
-        role_id: approver["roleId"],
-        role_name: approver["roleName"],
         email: approver["email"],
         family_name: approver["familyName"],
         given_name: approver["givenName"],
+        la_code: approver["organisation"]["establishmentNumber"],
+        role_id: approver["roleId"],
+        role_name: approver["roleName"],
         school_urn: approver["organisation"]["urn"],
-        organisation_uid: approver["organisation"]["uid"],
+        trust_uid: approver["organisation"]["uid"],
+        user_id: approver["userId"],
       },
     ]
   end

--- a/spec/lib/export_dsi_user_records_to_big_query_spec.rb
+++ b/spec/lib/export_dsi_user_records_to_big_query_spec.rb
@@ -42,22 +42,28 @@ RSpec.describe ExportDsiUsersToBigQuery do
       "given_name" => Faker::Name.first_name,
       "family_name" => Faker::Name.last_name,
       "email" => Faker::Internet.email,
-      "organisation" => { "URN" => 100_000, "UID" => 999_999 },
+      "organisation" => {
+        "URN" => 100_000,
+        "UID" => 999_999,
+        "Category" => "002",
+        "EstablishmentNumber" => "800",
+      },
     }
   end
 
   let(:expected_table_data) do
     [
       {
-        user_id: user["userId"],
-        role: user["roleName"],
         approval_datetime: user["approvedAt"],
-        update_datetime: user["updatedAt"],
-        given_name: user["givenName"],
-        family_name: user["familyName"],
         email: user["email"],
+        family_name: user["familyName"],
+        given_name: user["givenName"],
+        la_code: user["organisation"]["EstablishmentNumber"],
+        role: user["roleName"],
         school_urn: user["organisation"]["URN"],
-        organisation_uid: user["organisation"]["UID"],
+        trust_uid: user["organisation"]["UID"],
+        update_datetime: user["updatedAt"],
+        user_id: user["userId"],
       },
     ]
   end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1571

## Changes in this PR

This PR is mainly about updating the job which calls the DSI API and sends the data to BigQuery.

There was an option suggested of scrapping this job, and putting everything in our Users table (and then send that to BigQuery).

I propose keeping the DSI export to BigQuery separate from the User table for two reasons:

1. A user entity in Postgres corresponds to several user entities in BigQuery; in BQ, there is one user record per organisation the user has access to. These differences correspond to different use cases. In the app itself we benefit from consolidating all user data into a single record. In analytics, however, we benefit from keeping them apart so that we can ask questions such as "When did the approvals of users to sign in as LAs happen?" (each BQ user has an 'approved at' field).

2. The principle of not storing data that's only used for analytics/monitoring in the app database (separation of concerns)

I have tested the jobs on the staging dataset.
