### PR TITLE
[TEVA-1470] Add timestamps to JobAlertFeedbacks table

### DIFF
--- a/db/migrate/20201118111330_add_timestamps_to_job_alert_feedbacks.rb
+++ b/db/migrate/20201118111330_add_timestamps_to_job_alert_feedbacks.rb
@@ -1,0 +1,7 @@
+class AddTimestampsToJobAlertFeedbacks < ActiveRecord::Migration[6.0]
+  def change
+    add_timestamps :job_alert_feedbacks, default: Time.new(2020, 10, 16)
+    change_column_default :job_alert_feedbacks, :created_at, from: Time.new(2020, 10, 16), to: nil
+    change_column_default :job_alert_feedbacks, :updated_at, from: Time.new(2020, 10, 16), to: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_18_083645) do
+ActiveRecord::Schema.define(version: 2020_11_18_111330) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -104,6 +104,8 @@ ActiveRecord::Schema.define(version: 2020_11_18_083645) do
     t.uuid "vacancy_ids", array: true
     t.uuid "subscription_id", null: false
     t.float "recaptcha_score"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["subscription_id"], name: "index_job_alert_feedbacks_on_subscription_id"
   end
 


### PR DESCRIPTION
Because records already exist in this table, we need to give them a default created_at and updated_at.

In this migration, after applying that default to all existing records, we then reinstate the default 'null: false' restriction which raises an error if you try to create a feedback without one of these timestamps.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1470