### PR TITLE
TEVA-1604 GH Actions use deploy app workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Set environment variables
       id: set_env_vars
       run: |
-        TAG=${GITHUB_SHA}
+        TAG=${{ github.sha }}
         echo "TAG=${TAG}" >> $GITHUB_ENV
 
     - name: Set up Ruby
@@ -95,7 +95,7 @@ jobs:
       with:
         workflow: Deploy App to Environment # Workflow name
         token: ${{ secrets.PERSONAL_TOKEN }}
-        inputs: '{"environment": "staging", "tag": "${TAG}"}'
+        inputs: '{"environment": "staging", "tag": "${{ env.TAG }}"}'
 
     - name: Wait for Deploy App Workflow for staging
       id: wait_for_deploy_app_staging
@@ -131,7 +131,7 @@ jobs:
       with:
         workflow: Deploy App to Environment # Workflow name
         token: ${{ secrets.PERSONAL_TOKEN }}
-        inputs: '{"environment": "production", "tag": "${TAG}"}'
+        inputs: '{"environment": "production", "tag": "${{ env.TAG }}"}'
 
     - name: Wait for Deploy App Workflow
       id: wait_for_deploy_app_production
@@ -151,29 +151,29 @@ jobs:
         TF_VAR_paas_user: ${{ secrets.CF_USERNAME }}
         TF_VAR_paas_password: ${{ secrets.CF_PASSWORD }}
       run: |
-        export TF_VAR_paas_app_docker_image=${DOCKERHUB_REPOSITORY}:${TAG}
+        export TF_VAR_paas_app_docker_image=${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TAG }}
         cd terraform/monitoring
         terraform init -upgrade=true -reconfigure -input=false
         terraform apply -input=false -auto-approve
 
     - name: Send success message to twd_tv_dev channel
-      if: ${{ success() }}
+      if: ${{ steps.wait_for_deploy_app_production.outputs.conclusion == 'success' }} && github.ref == 'refs/heads/master'
       uses: rtCamp/action-slack-notify@v2.1.1
       env:
         SLACK_CHANNEL: twd_tv_dev
         SLACK_USERNAME: CI Deployment
         SLACK_ICON_EMOJI: ':tada:'
         SLACK_TITLE: Deployment success
-        SLACK_MESSAGE: 'Deployment of Docker tag ${{ steps.set_env_vars.outputs.TAG }} to production - successful :rocket:'
+        SLACK_MESSAGE: 'Deployment of Docker tag ${{ env.TAG }} to production - successful :rocket:'
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
     - name: Send failure message to twd_tv_dev channel
-      if: ${{ failure() }}
+      if: ${{ steps.wait_for_deploy_app_production.outputs.conclusion == 'failure' }} && github.ref == 'refs/heads/master'
       uses: rtCamp/action-slack-notify@v2.1.1
       env:
         SLACK_CHANNEL: twd_tv_dev
         SLACK_USERNAME: CI Deployment
         SLACK_ICON_EMOJI: ':cry:'
         SLACK_TITLE: Deployment failure
-        SLACK_MESSAGE: 'Deployment of Docker tag ${{ steps.set_env_vars.outputs.TAG }} to production - failure'
+        SLACK_MESSAGE: 'Deployment of Docker tag ${{ env.TAG }} to production - failure'
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,8 +40,7 @@ jobs:
     - name: Set environment variables
       id: set_env_vars
       run: |
-        TAG=${{ github.sha }}
-        echo "TAG=${TAG}" >> $GITHUB_ENV
+        echo "TAG=${{ github.sha }}" >> $GITHUB_ENV
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
@@ -156,24 +155,12 @@ jobs:
         terraform init -upgrade=true -reconfigure -input=false
         terraform apply -input=false -auto-approve
 
-    - name: Send success message to twd_tv_dev channel
-      if: ${{ steps.wait_for_deploy_app_production.outputs.conclusion == 'success' }} && github.ref == 'refs/heads/master'
+    - name: Send job status message to twd_tv_dev channel
+      if: ${{ always() && github.ref == 'refs/heads/master' }}
       uses: rtCamp/action-slack-notify@v2.1.1
       env:
         SLACK_CHANNEL: twd_tv_dev
         SLACK_USERNAME: CI Deployment
-        SLACK_ICON_EMOJI: ':tada:'
-        SLACK_TITLE: Deployment success
-        SLACK_MESSAGE: 'Deployment of Docker tag ${{ env.TAG }} to production - successful :rocket:'
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-
-    - name: Send failure message to twd_tv_dev channel
-      if: ${{ steps.wait_for_deploy_app_production.outputs.conclusion == 'failure' }} && github.ref == 'refs/heads/master'
-      uses: rtCamp/action-slack-notify@v2.1.1
-      env:
-        SLACK_CHANNEL: twd_tv_dev
-        SLACK_USERNAME: CI Deployment
-        SLACK_ICON_EMOJI: ':cry:'
-        SLACK_TITLE: Deployment failure
-        SLACK_MESSAGE: 'Deployment of Docker tag ${{ env.TAG }} to production - failure'
+        SLACK_TITLE: Deployment ${{ job.status }}
+        SLACK_MESSAGE: 'Deployment of Docker tag ${{ env.TAG }} to production - ${{ job.status }}'
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,20 +90,25 @@ jobs:
           ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TAG }}
         target: production
 
-    - name: Deploy to staging
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        TF_VAR_paas_user: ${{ secrets.CF_USERNAME }}
-        TF_VAR_paas_password: ${{ secrets.CF_PASSWORD }}
-      run: |
-        export TF_VAR_paas_app_docker_image=${DOCKERHUB_REPOSITORY}:${TAG}
-        cd terraform/app
-        terraform init -reconfigure -input=false
-        terraform workspace select staging || terraform workspace new staging
-        terraform apply -var-file ../workspace-variables/staging.tfvars -auto-approve -input=false
+    - name: Trigger Deploy App Workflow for staging
+      uses: benc-uk/workflow-dispatch@v1.1
+      with:
+        workflow: Deploy App to Environment # Workflow name
+        token: ${{ secrets.PERSONAL_TOKEN }}
+        inputs: '{"environment": "staging", "tag": "${TAG}"}'
+
+    - name: Wait for Deploy App Workflow for staging
+      id: wait_for_deploy_app_staging
+      uses: fountainhead/action-wait-for-check@v1.0.0
+      with:
+        token: ${{ secrets.PERSONAL_TOKEN }}
+        checkName: Deploy app to environment # Job name within workflow
+        ref: ${{ github.ref }}
+        timeoutSeconds: 300
+        intervalSeconds: 15
 
     - name: Trigger Smoke Test
+      if: ${{ steps.wait_for_deploy_app_staging.outputs.conclusion == 'success' }}
       uses: benc-uk/workflow-dispatch@v1.1
       with:
         workflow: Smoke Test Manual # Workflow name
@@ -120,21 +125,26 @@ jobs:
         timeoutSeconds: 300
         intervalSeconds: 15
 
-    - name: Deploy to production
+    - name: Trigger Deploy App Workflow
       if: ${{ steps.wait_for_smoke_test.outputs.conclusion == 'success' }} && github.ref == 'refs/heads/master'
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        TF_VAR_paas_user: ${{ secrets.CF_USERNAME }}
-        TF_VAR_paas_password: ${{ secrets.CF_PASSWORD }}
-      run: |
-        export TF_VAR_paas_app_docker_image=${DOCKERHUB_REPOSITORY}:${TAG}
-        cd terraform/app
-        terraform init -reconfigure -input=false
-        terraform workspace select production || terraform workspace new production
-        terraform apply -var-file ../workspace-variables/production.tfvars -auto-approve -input=false
+      uses: benc-uk/workflow-dispatch@v1.1
+      with:
+        workflow: Deploy App to Environment # Workflow name
+        token: ${{ secrets.PERSONAL_TOKEN }}
+        inputs: '{"environment": "production", "tag": "${TAG}"}'
+
+    - name: Wait for Deploy App Workflow
+      id: wait_for_deploy_app_production
+      uses: fountainhead/action-wait-for-check@v1.0.0
+      with:
+        token: ${{ secrets.PERSONAL_TOKEN }}
+        checkName: Deploy app to environment # Job name within workflow
+        ref: ${{ github.ref }}
+        timeoutSeconds: 300
+        intervalSeconds: 15
 
     - name: Deploy monitoring
+      if: ${{ steps.wait_for_deploy_app_production.outputs.conclusion == 'success' }} && github.ref == 'refs/heads/master'
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -154,7 +164,7 @@ jobs:
         SLACK_USERNAME: CI Deployment
         SLACK_ICON_EMOJI: ':tada:'
         SLACK_TITLE: Deployment success
-        SLACK_MESSAGE: 'Deployment to production on GOV.UK PaaS successful :rocket:'
+        SLACK_MESSAGE: 'Deployment of Docker tag ${{ steps.set_env_vars.outputs.TAG }} to production - successful :rocket:'
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
     - name: Send failure message to twd_tv_dev channel
@@ -165,5 +175,5 @@ jobs:
         SLACK_USERNAME: CI Deployment
         SLACK_ICON_EMOJI: ':cry:'
         SLACK_TITLE: Deployment failure
-        SLACK_MESSAGE: 'Deployment to production failed'
+        SLACK_MESSAGE: 'Deployment of Docker tag ${{ steps.set_env_vars.outputs.TAG }} to production - failure'
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy_app.yml
+++ b/.github/workflows/deploy_app.yml
@@ -26,6 +26,26 @@ jobs:
       with:
         terraform_version: 0.13.4
 
+    - name: Set environment variables for review
+      if: ${{ startsWith(github.event.inputs.environment, 'review') }}
+      run: |
+        BACKEND_CONFIG=-backend-config="workspace_key_prefix=review:"
+        PARAMETER_STORE_ENVIRONMENT=dev
+        TF_VAR_environment=${{ github.event.inputs.environment }}
+        VAR_FILE=review
+        echo "BACKEND_CONFIG=${BACKEND_CONFIG}" >> $GITHUB_ENV
+        echo "PARAMETER_STORE_ENVIRONMENT=${PARAMETER_STORE_ENVIRONMENT}" >> $GITHUB_ENV
+        echo "TF_VAR_environment=${TF_VAR_environment}" >> $GITHUB_ENV
+        echo "VAR_FILE=${VAR_FILE}" >> $GITHUB_ENV
+
+    - name: Set environment variables for non-review environments
+      if: ${{ !startsWith(github.event.inputs.environment, 'review') }}
+      run: |
+        PARAMETER_STORE_ENVIRONMENT=${{ github.event.inputs.environment }}
+        VAR_FILE=${{ github.event.inputs.environment }}
+        echo "PARAMETER_STORE_ENVIRONMENT=${PARAMETER_STORE_ENVIRONMENT}" >> $GITHUB_ENV
+        echo "VAR_FILE=${VAR_FILE}" >> $GITHUB_ENV
+
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
 
@@ -36,8 +56,8 @@ jobs:
         AWS_REGION: eu-west-2
       run: |
         gem install aws-sdk-ssm --no-document
-        bin/run-in-env -t /tvs/${{ github.event.inputs.environment }} -o quiet \
-          && echo Data in /tvs/${{ github.event.inputs.environment }} looks valid
+        bin/run-in-env -t /tvs/${{ env.PARAMETER_STORE_ENVIRONMENT }} -o quiet \
+          && echo Data in /tvs/${{ env.PARAMETER_STORE_ENVIRONMENT }} looks valid
 
     - name: Deploy to environment
       env:
@@ -46,8 +66,8 @@ jobs:
         TF_VAR_paas_user: ${{ secrets.CF_USERNAME }}
         TF_VAR_paas_password: ${{ secrets.CF_PASSWORD }}
       run: |
-        export TF_VAR_paas_app_docker_image=${DOCKERHUB_REPOSITORY}:${{ github.event.inputs.tag }}
+        export TF_VAR_paas_app_docker_image=${{ env.DOCKERHUB_REPOSITORY }}:${{ github.event.inputs.tag }}
         cd terraform/app
-        terraform init -reconfigure -input=false
+        terraform init -reconfigure -input=false ${{ env.BACKEND_CONFIG }}
         terraform workspace select ${{ github.event.inputs.environment }} || terraform workspace new ${{ github.event.inputs.environment }}
-        terraform apply -var-file ../workspace-variables/${{ github.event.inputs.environment }}.tfvars -auto-approve -input=false
+        terraform apply -var-file ../workspace-variables/${{ env.VAR_FILE }}.tfvars -auto-approve -input=false

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -111,24 +111,12 @@ jobs:
         timeoutSeconds: 300
         intervalSeconds: 15
 
-    - name: Send success message to twd_tv_dev channel
-      if: ${{ success() }}
+    - name: Send job status message to twd_tv_dev channel
+      if: ${{ always() && github.ref == 'refs/heads/master' }}
       uses: rtCamp/action-slack-notify@v2.1.1
       env:
         SLACK_CHANNEL: twd_tv_dev
         SLACK_USERNAME: CI Deployment
-        SLACK_ICON_EMOJI: ':tada:'
-        SLACK_TITLE: Deployment success
-        SLACK_MESSAGE: 'Deployment of Docker tag ${{ env.TAG }} to ${{ env.BRANCH }} - successful :rocket:'
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-
-    - name: Send failure message to twd_tv_dev channel
-      if: ${{ failure() }}
-      uses: rtCamp/action-slack-notify@v2.1.1
-      env:
-        SLACK_CHANNEL: twd_tv_dev
-        SLACK_USERNAME: CI Deployment
-        SLACK_ICON_EMOJI: ':cry:'
-        SLACK_TITLE: Deployment failure
-        SLACK_MESSAGE: 'Deployment of Docker tag ${{ env.TAG }} to ${{ env.BRANCH }} - failure'
+        SLACK_TITLE: Deployment ${{ job.status }}
+        SLACK_MESSAGE: 'Deployment of Docker tag ${{ env.TAG }} to ${{ env.BRANCH }} - ${{ job.status }}'
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -30,9 +30,6 @@ jobs:
     name: build docker image and deploy
     needs: turnstyle
     runs-on: ubuntu-20.04
-    outputs:
-      BRANCH: ${{ steps.set_env_vars.outputs.BRANCH }}
-      TAG: ${{ steps.set_env_vars.outputs.TAG }}
     steps:
     - uses: actions/checkout@v2
       name: Checkout Code
@@ -45,12 +42,10 @@ jobs:
     - name: Set environment variables
       id: set_env_vars
       run: |
-        BRANCH=$(echo ${GITHUB_REF} | cut -d/ -f3)
-        TAG=${BRANCH}-${GITHUB_SHA}-$(date '+%Y%m%d%H%M%S')
+        BRANCH=${{ github.head_ref }}
+        TAG=${BRANCH}-${{ github.sha }}-$(date '+%Y%m%d%H%M%S')
         echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
         echo "TAG=${TAG}" >> $GITHUB_ENV
-        echo ::set-output name=BRANCH::${BRANCH}
-        echo ::set-output name=TAG::${TAG}
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
@@ -104,7 +99,7 @@ jobs:
       with:
         workflow: Deploy App to Environment # Workflow name
         token: ${{ secrets.PERSONAL_TOKEN }}
-        inputs: '{"environment": "${ env.BRANCH }", "tag": "${ env.TAG }"}'
+        inputs: '{"environment": "${{ env.BRANCH }}", "tag": "${{ env.TAG }}"}'
 
     - name: Wait for Deploy App Workflow
       id: wait_for_deploy_app
@@ -124,7 +119,7 @@ jobs:
         SLACK_USERNAME: CI Deployment
         SLACK_ICON_EMOJI: ':tada:'
         SLACK_TITLE: Deployment success
-        SLACK_MESSAGE: 'Deployment of Docker tag ${{ steps.set_env_vars.outputs.TAG }} to ${{ steps.set_env_vars.outputs.BRANCH }} - successful :rocket:'
+        SLACK_MESSAGE: 'Deployment of Docker tag ${{ env.TAG }} to ${{ env.BRANCH }} - successful :rocket:'
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
     - name: Send failure message to twd_tv_dev channel
@@ -135,5 +130,5 @@ jobs:
         SLACK_USERNAME: CI Deployment
         SLACK_ICON_EMOJI: ':cry:'
         SLACK_TITLE: Deployment failure
-        SLACK_MESSAGE: 'Deployment of Docker tag ${{ steps.set_env_vars.outputs.TAG }} to ${{ steps.set_env_vars.outputs.BRANCH }} - failure'
+        SLACK_MESSAGE: 'Deployment of Docker tag ${{ env.TAG }} to ${{ env.BRANCH }} - failure'
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -99,18 +99,22 @@ jobs:
           ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.BRANCH }}
         target: production
 
-    - name: Deploy
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        TF_VAR_paas_user: ${{ secrets.CF_USERNAME }}
-        TF_VAR_paas_password: ${{ secrets.CF_PASSWORD }}
-      run: |
-        export TF_VAR_paas_app_docker_image=${DOCKERHUB_REPOSITORY}:${TAG}
-        cd terraform/app
-        terraform init -reconfigure -input=false
-        terraform workspace select ${BRANCH} || terraform workspace new ${BRANCH}
-        terraform apply -var-file ../workspace-variables/${BRANCH}.tfvars -auto-approve -input=false
+    - name: Trigger Deploy App Workflow for branch
+      uses: benc-uk/workflow-dispatch@v1.1
+      with:
+        workflow: Deploy App to Environment # Workflow name
+        token: ${{ secrets.PERSONAL_TOKEN }}
+        inputs: '{"environment": "${ env.BRANCH }", "tag": "${ env.TAG }"}'
+
+    - name: Wait for Deploy App Workflow
+      id: wait_for_deploy_app
+      uses: fountainhead/action-wait-for-check@v1.0.0
+      with:
+        token: ${{ secrets.PERSONAL_TOKEN }}
+        checkName: Deploy app to environment # Job name within workflow
+        ref: ${{ github.ref }}
+        timeoutSeconds: 300
+        intervalSeconds: 15
 
     - name: Send success message to twd_tv_dev channel
       if: ${{ success() }}
@@ -120,7 +124,7 @@ jobs:
         SLACK_USERNAME: CI Deployment
         SLACK_ICON_EMOJI: ':tada:'
         SLACK_TITLE: Deployment success
-        SLACK_MESSAGE: 'Deployment of ${{ steps.set_env_vars.outputs.TAG }} to ${{ steps.set_env_vars.outputs.BRANCH }} on GOV.UK PaaS successful :rocket:'
+        SLACK_MESSAGE: 'Deployment of Docker tag ${{ steps.set_env_vars.outputs.TAG }} to ${{ steps.set_env_vars.outputs.BRANCH }} - successful :rocket:'
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
     - name: Send failure message to twd_tv_dev channel
@@ -131,5 +135,5 @@ jobs:
         SLACK_USERNAME: CI Deployment
         SLACK_ICON_EMOJI: ':cry:'
         SLACK_TITLE: Deployment failure
-        SLACK_MESSAGE: 'GitHub actions pipeline failed to deploy a review app for PR ${{ github.event.number }}'
+        SLACK_MESSAGE: 'Deployment of Docker tag ${{ steps.set_env_vars.outputs.TAG }} to ${{ steps.set_env_vars.outputs.BRANCH }} - failure'
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   DOCKERHUB_REPOSITORY: dfedigital/teaching-vacancies
-  PR_NAME: ${{ format('pr-{0}', github.event.number) }}
 
 jobs:
   turnstyle:
@@ -50,7 +49,7 @@ jobs:
     - name: Set environment variables
       id: set_env_vars
       run: |
-        TAG=review-${PR_NAME}-${GITHUB_SHA}-$(date '+%Y%m%d%H%M%S')
+        TAG=review-pr-${{ github.event.number }}-${{ github.sha }}-$(date '+%Y%m%d%H%M%S')
         echo "TAG=${TAG}" >> $GITHUB_ENV
 
     - name: Terraform destroy (on PR closed)
@@ -60,14 +59,14 @@ jobs:
         TF_VAR_paas_user: ${{ secrets.CF_USERNAME }}
         TF_VAR_paas_password: ${{ secrets.CF_PASSWORD }}
       run: |
-        export TF_VAR_paas_app_docker_image=${DOCKERHUB_REPOSITORY}:${TAG}
-        export TF_VAR_environment=review-${PR_NAME}
+        export TF_VAR_paas_app_docker_image=${{ env.DOCKERHUB_REPOSITORY }}:${ env.TAG }}
+        export TF_VAR_environment=review-pr-${{ github.event.number }}
         cd terraform/app
         terraform init -reconfigure -input=false -backend-config="workspace_key_prefix=review:"
-        terraform workspace select review-${PR_NAME} || terraform workspace new review-${PR_NAME}
+        terraform workspace select review-pr-${{ github.event.number }} || terraform workspace new review-pr-${{ github.event.number }}
         terraform plan -var-file ../workspace-variables/review.tfvars -destroy -out=tfdestroy
         terraform apply -auto-approve "tfdestroy"
-        terraform workspace select default && terraform workspace delete review-${PR_NAME}
+        terraform workspace select default && terraform workspace delete review-pr-${{ github.event.number }}
 
     - name: Send failure message to twd_tv_dev channel
       if: ${{ failure() }}

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -53,14 +53,13 @@ jobs:
           ref: ${{ github.ref }}
           timeoutSeconds: 300
           intervalSeconds: 15
-
-      - name: Send success message to twd_tv_dev channel
-        if: ${{ steps.wait_for_deploy_app.outputs.conclusion == 'success' }} && github.ref == 'refs/heads/master'          
+    
+      - name: Send job status message to twd_tv_dev channel
+        if: ${{ always() && github.ref == 'refs/heads/master' }}
         uses: rtCamp/action-slack-notify@v2.1.1
         env:
           SLACK_CHANNEL: twd_tv_dev
           SLACK_USERNAME: CI Deployment
-          SLACK_ICON_EMOJI: ':tada:'
-          SLACK_TITLE: ${{ github.event.inputs.environment }} env vars refresh successful
-          SLACK_MESSAGE: 'Refresh of Docker tag ${{ steps.get_docker_tag.outputs.tag }} to ${{ github.event.inputs.environment }} - successful :rocket:'
+          SLACK_TITLE: ${{ github.event.inputs.environment }} env vars refresh ${{ job.status }}
+          SLACK_MESSAGE: 'Deployment of Docker tag ${{ steps.get_docker_tag.outputs.tag }} to ${{ github.event.inputs.environment }} - ${{ job.status }}'
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -62,5 +62,5 @@ jobs:
           SLACK_USERNAME: CI Deployment
           SLACK_ICON_EMOJI: ':tada:'
           SLACK_TITLE: ${{ github.event.inputs.environment }} env vars refresh successful
-          SLACK_MESSAGE: '${{ github.event.inputs.environment }} env vars refresh successful - Docker tag ${{ steps.get_docker_tag.outputs.tag }} :rocket:'
+          SLACK_MESSAGE: 'Refresh of Docker tag ${{ steps.get_docker_tag.outputs.tag }} to ${{ github.event.inputs.environment }} - successful :rocket:'
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -55,7 +55,7 @@ jobs:
       id: set_env_vars
       run: |
         BRANCH=${{ github.head_ref }}
-        TAG=review-pr-${{ github.event.number }}-${GITHUB_SHA}-$(date '+%Y%m%d%H%M%S')
+        TAG=review-pr-${{ github.event.number }}-${{ github.sha }}-$(date '+%Y%m%d%H%M%S')
         $(echo "BRANCH=${BRANCH}" | sed -e 's/\//_/g' >> $GITHUB_ENV)
         echo "TAG=${TAG}" >> $GITHUB_ENV
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -54,9 +54,8 @@ jobs:
     - name: Set environment variables
       id: set_env_vars
       run: |
-        BRANCH=${{ github.head_ref }}
+        $(echo "BRANCH=${{ github.head_ref }}" | sed -e 's/\//_/g' >> $GITHUB_ENV)
         TAG=review-pr-${{ github.event.number }}-${{ github.sha }}-$(date '+%Y%m%d%H%M%S')
-        $(echo "BRANCH=${BRANCH}" | sed -e 's/\//_/g' >> $GITHUB_ENV)
         echo "TAG=${TAG}" >> $GITHUB_ENV
 
     - name: Set up Docker Buildx
@@ -120,24 +119,11 @@ jobs:
              --data '{"body": "Review app deployed to https://teaching-vacancies-review-pr-${{ github.event.number }}.london.cloudapps.digital"}' \
              https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.number }}/comments
 
-    - name: Send success message to twd_tv_dev channel
-      if: ${{ steps.wait_for_deploy_app.outputs.conclusion == 'success' }}
+    - name: Send job status message to twd_tv_dev channel
       uses: rtCamp/action-slack-notify@v2.1.1
       env:
         SLACK_CHANNEL: twd_tv_dev
         SLACK_USERNAME: CI Deployment
-        SLACK_ICON_EMOJI: ':tada:'
-        SLACK_TITLE: Deployment success
-        SLACK_MESSAGE: 'Review app for PR ${{ github.event.number }} deployed to https://teaching-vacancies-review-pr-${{ github.event.number }}.london.cloudapps.digital :rocket:'
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-
-    - name: Send failure message to twd_tv_dev channel
-      if: ${{ failure() }}
-      uses: rtCamp/action-slack-notify@v2.1.1
-      env:
-        SLACK_CHANNEL: twd_tv_dev
-        SLACK_USERNAME: CI Deployment
-        SLACK_ICON_EMOJI: ':cry:'
-        SLACK_TITLE: Deployment failure
-        SLACK_MESSAGE: 'Review app deployment failed for PR ${{ github.event.number }}'
+        SLACK_TITLE: Deployment ${{ job.status }}
+        SLACK_MESSAGE: 'Review app for PR ${{ github.event.number }} deployed to https://teaching-vacancies-review-pr-${{ github.event.number }}.london.cloudapps.digital - ${{ job.status }}'
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -12,7 +12,6 @@ on:
 
 env:
   DOCKERHUB_REPOSITORY: dfedigital/teaching-vacancies
-  PR_NAME: ${{ format('pr-{0}', github.event.number) }}
 
 jobs:
   turnstyle:
@@ -56,10 +55,9 @@ jobs:
       id: set_env_vars
       run: |
         BRANCH=${{ github.head_ref }}
-        TAG=review-${PR_NAME}-${GITHUB_SHA}-$(date '+%Y%m%d%H%M%S')
+        TAG=review-pr-${{ github.event.number }}-${GITHUB_SHA}-$(date '+%Y%m%d%H%M%S')
         $(echo "BRANCH=${BRANCH}" | sed -e 's/\//_/g' >> $GITHUB_ENV)
         echo "TAG=${TAG}" >> $GITHUB_ENV
-
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
@@ -95,38 +93,42 @@ jobs:
           ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.BRANCH }}
         target: production
 
-    - name: Terraform deploy
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        TF_VAR_paas_user: ${{ secrets.CF_USERNAME }}
-        TF_VAR_paas_password: ${{ secrets.CF_PASSWORD }}
-      run: |
-        export TF_VAR_paas_app_docker_image=${DOCKERHUB_REPOSITORY}:${TAG}
-        export TF_VAR_environment=review-${PR_NAME}
-        cd terraform/app
-        terraform init -reconfigure -input=false -backend-config="workspace_key_prefix=review:"
-        terraform workspace select review-${PR_NAME} || terraform workspace new review-${PR_NAME}
-        terraform apply -var-file ../workspace-variables/review.tfvars -auto-approve -input=false
+    - name: Trigger Deploy App Workflow for review
+      uses: benc-uk/workflow-dispatch@v1.1
+      with:
+        token: ${{ secrets.PERSONAL_TOKEN }}
+        ref: ${{ github.event.pull_request.head.ref || github.ref }}
+        workflow: Deploy App to Environment # Workflow name
+        inputs: '{"environment": "review-pr-${{ github.event.number }}", "tag": "${{ env.TAG }}"}'
+
+    - name: Wait for Deploy App Workflow
+      id: wait_for_deploy_app
+      uses: fountainhead/action-wait-for-check@v1.0.0
+      with:
+        token: ${{ secrets.PERSONAL_TOKEN }}
+        ref: ${{ github.event.pull_request.head.sha || github.ref }}
+        checkName: Deploy app to environment # Job name within workflow
+        timeoutSeconds: 300
+        intervalSeconds: 15
 
     - name: Post PR comment
-      if: ${{ success() }}
+      if: ${{ steps.wait_for_deploy_app.outputs.conclusion == 'success' }}
       run: |
         curl --header "Accept: application/vnd.github.v3+json" \
              --header "Authorization: Bearer ${{ github.token }}" \
              --request POST \
-             --data '{"body": "Review app deployed to https://teaching-vacancies-review-${{ format('pr-{0}', github.event.number) }}.london.cloudapps.digital"}' \
+             --data '{"body": "Review app deployed to https://teaching-vacancies-review-pr-${{ github.event.number }}.london.cloudapps.digital"}' \
              https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.number }}/comments
 
     - name: Send success message to twd_tv_dev channel
-      if: ${{ success() }}
+      if: ${{ steps.wait_for_deploy_app.outputs.conclusion == 'success' }}
       uses: rtCamp/action-slack-notify@v2.1.1
       env:
         SLACK_CHANNEL: twd_tv_dev
         SLACK_USERNAME: CI Deployment
         SLACK_ICON_EMOJI: ':tada:'
         SLACK_TITLE: Deployment success
-        SLACK_MESSAGE: 'Review app for PR ${{ github.event.number }} deployed to https://teaching-vacancies-review-${{ env.PR_NAME }}.london.cloudapps.digital :rocket:'
+        SLACK_MESSAGE: 'Review app for PR ${{ github.event.number }} deployed to https://teaching-vacancies-review-pr-${{ github.event.number }}.london.cloudapps.digital :rocket:'
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
     - name: Send failure message to twd_tv_dev channel


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1604

## Changes in this PR:

- Use `deploy_app` workflow from other workflows (`deploy`, `deploy_branch`, `review`)
- Access variables with `${{ github.X }}` not `$GITHUB_X`
- Access variables with `${{ env.VAR }}` not `${VAR}`
- Get branch with `${{ github.head_ref }}` instead of `$(echo ${GITHUB_REF} | cut -d/ -f3)`
- Remove additional outputs where these were already available as environment variables