### PR TITLE
Remove protocol from URL generation

### DIFF
--- a/app/controllers/hiring_staff/vacancies/application_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/application_controller.rb
@@ -63,7 +63,7 @@ class HiringStaff::Vacancies::ApplicationController < HiringStaff::BaseControlle
   def remove_google_index(job)
     return unless Rails.env.production?
 
-    url = job_url(job, protocol: "https")
+    url = job_url(job)
     RemoveGoogleIndexQueueJob.perform_later(url)
   end
 
@@ -85,7 +85,7 @@ class HiringStaff::Vacancies::ApplicationController < HiringStaff::BaseControlle
   def update_google_index(job)
     return unless Rails.env.production?
 
-    url = job_url(job, protocol: "https")
+    url = job_url(job)
     UpdateGoogleIndexQueueJob.perform_later(url)
   end
 end

--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -15,27 +15,24 @@ private
 
   def add_vacancies(map)
     Vacancy.listed.applicable.find_each do |vacancy|
-      map.add job_path(vacancy, protocol: "https"), updated: vacancy.updated_at,
-                                                    expires: vacancy.expires_on,
-                                                    period: "hourly", priority: 0.7
+      map.add job_path(vacancy), updated: vacancy.updated_at, expires: vacancy.expires_on, period: "hourly", priority: 0.7
     end
   end
 
   def add_new_identifications(map)
-    map.add new_identifications_path(protocol: "https"), period: "weekly",
-                                                         priority: 0.8
+    map.add new_identifications_path, period: "weekly", priority: 0.8
   end
 
   def add_location_categories(map)
     ALL_LOCATION_CATEGORIES.each do |location_category|
-      map.add jobs_path(location: location_category, protocol: "https"), period: "hourly"
+      map.add jobs_path(location: location_category), period: "hourly"
     end
   end
 
   def add_pages(map)
-    map.add page_path("privacy-policy", protocol: "https"), period: "weekly"
-    map.add page_path("terms-and-conditions", protocol: "https"), period: "weekly"
-    map.add page_path("cookies", protocol: "https"), period: "weekly"
-    map.add page_path("accessibility", protocol: "https"), period: "weekly"
+    map.add page_path("privacy-policy"), period: "weekly"
+    map.add page_path("terms-and-conditions"), period: "weekly"
+    map.add page_path("cookies"), period: "weekly"
+    map.add page_path("accessibility"), period: "weekly"
   end
 end

--- a/app/helpers/notify_view_helper.rb
+++ b/app/helpers/notify_view_helper.rb
@@ -4,23 +4,18 @@ module NotifyViewHelper
   end
 
   def edit_link(subscription)
-    url = edit_subscription_url(
-      subscription.token,
-      protocol: "https",
-      params: utm_params(subscription),
-    )
+    url = edit_subscription_url(subscription.token, params: utm_params(subscription))
     notify_link(url, t(".edit_link_text"))
   end
 
   def home_page_link(subscription)
-    url = root_url(protocol: "https", params: utm_params(subscription))
+    url = root_url(params: utm_params(subscription))
     notify_link(url, t("app.title"))
   end
 
   def job_alert_feedback_url(relevant, subscription, vacancies)
     new_subscription_job_alert_feedback_url(
       subscription.token,
-      protocol: "https",
       params: { job_alert_feedback: { relevant_to_user: relevant,
                                       vacancy_ids: vacancies.pluck(:id),
                                       search_criteria: subscription.search_criteria } },
@@ -34,11 +29,7 @@ module NotifyViewHelper
   end
 
   def unsubscribe_link(subscription)
-    url = unsubscribe_subscription_url(
-      subscription.token,
-      protocol: "https",
-      params: utm_params(subscription),
-    )
+    url = unsubscribe_subscription_url(subscription.token, params: utm_params(subscription))
     notify_link(url, t(".unsubscribe_link_text"))
   end
 

--- a/app/presenters/vacancies_presenter.rb
+++ b/app/presenters/vacancies_presenter.rb
@@ -43,7 +43,6 @@ private
     {
       format: :json,
       api_version: 1,
-      protocol: "https",
     }
   end
 end

--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -7,7 +7,7 @@ class VacancyPresenter < BasePresenter
   delegate :job_roles, to: :model, prefix: true
 
   def share_url(utm_source: nil, utm_medium: nil, utm_campaign: nil, utm_content: nil)
-    params = { protocol: "https" }
+    params = {}
     if utm_source.present?
       params.merge!(
         utm_source: utm_source,

--- a/app/views/api/vacancies/index.json.jbuilder
+++ b/app/views/api/vacancies/index.json.jbuilder
@@ -1,7 +1,7 @@
 json.info do
   json.title "GOV UK - #{t('app.title')}"
   json.description t("app.description")
-  json.termsOfService terms_and_conditions_url(protocol: "https", anchor: "api")
+  json.termsOfService terms_and_conditions_url(anchor: "api")
   json.contact do
     json.name "#{t('app.title')} API Support"
     json.email t("help.email")

--- a/app/views/feedback_prompt_mailer/prompt_for_feedback.text.haml
+++ b/app/views/feedback_prompt_mailer/prompt_for_feedback.text.haml
@@ -7,9 +7,9 @@ We’re constantly working to improve #{t('app.title')}. You can help us do so b
 - @vacancies.each do |vacancy|
   = "* #{vacancy.job_title}"
 \
-It should only take a minute or 2 of your time. Just #{notify_link(new_identifications_url(:protocol => 'https'), "sign into your Teaching Vacancies account")} and select the ‘Jobs awaiting feedback’ tab.
+It should only take a minute or 2 of your time. Just #{notify_link(new_identifications_url, "sign into your Teaching Vacancies account")} and select the ‘Jobs awaiting feedback’ tab.
 \
-If you are already signed in to your Teaching Vacancies account you can access the expired jobs awaiting your feedback by clicking #{notify_link(jobs_with_type_organisation_url(:type=>'awaiting_feedback' , :protocol => 'https') , "here")}.
+If you are already signed in to your Teaching Vacancies account you can access the expired jobs awaiting your feedback by clicking #{notify_link(jobs_with_type_organisation_url(type: 'awaiting_feedback') , "here")}.
 \
 Insights from schools like yours are essential to our efforts to improve Teaching Vacancies. With your help we can make it the resource schools prefer to use when looking for teachers, leading to even bigger savings on recruitment costs.
 \

--- a/config/application.rb
+++ b/config/application.rb
@@ -52,6 +52,5 @@ module TeacherVacancyService
     config.action_mailer.notify_settings = {
       api_key: ENV["NOTIFY_KEY"],
     }
-    config.action_mailer.default_url_options = { protocol: "https" }
   end
 end

--- a/spec/controllers/api/vacancies_controller_spec.rb
+++ b/spec/controllers/api/vacancies_controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Api::VacanciesController, type: :controller do
       expect(info_object[:title]).to eq("GOV UK - #{I18n.t('app.title')}")
       expect(info_object[:description]).to eq(I18n.t("app.description"))
       expect(info_object[:termsOfService])
-        .to eq(terms_and_conditions_url(protocol: "https", anchor: "api"))
+        .to eq(terms_and_conditions_url(anchor: "api"))
       expect(info_object[:contact][:email]).to eq(I18n.t("help.email"))
     end
 
@@ -89,11 +89,11 @@ RSpec.describe Api::VacanciesController, type: :controller do
 
       it "includes the correct pagination links" do
         expect(links_object).to include(
-          self: "https://localhost:3000/api/v1/jobs.json?page=2",
-          first: "https://localhost:3000/api/v1/jobs.json?page=1",
-          last: "https://localhost:3000/api/v1/jobs.json?page=4",
-          next: "https://localhost:3000/api/v1/jobs.json?page=3",
-          prev: "https://localhost:3000/api/v1/jobs.json?page=1",
+          self: "http://localhost:3000/api/v1/jobs.json?page=2",
+          first: "http://localhost:3000/api/v1/jobs.json?page=1",
+          last: "http://localhost:3000/api/v1/jobs.json?page=4",
+          next: "http://localhost:3000/api/v1/jobs.json?page=3",
+          prev: "http://localhost:3000/api/v1/jobs.json?page=1",
         )
       end
 

--- a/spec/mailers/alert_mailer_spec.rb
+++ b/spec/mailers/alert_mailer_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe AlertMailer, type: :mailer do
   let(:relevant_job_alert_feedback_url) do
     new_subscription_job_alert_feedback_url(
       subscription.token,
-      protocol: "https",
       params: { job_alert_feedback: { relevant_to_user: true,
                                       vacancy_ids: vacancies.pluck(:id),
                                       search_criteria: subscription.search_criteria } },
@@ -34,7 +33,6 @@ RSpec.describe AlertMailer, type: :mailer do
   let(:irrelevant_job_alert_feedback_url) do
     new_subscription_job_alert_feedback_url(
       subscription.token,
-      protocol: "https",
       params: { job_alert_feedback: { relevant_to_user: false,
                                       vacancy_ids: vacancies.pluck(:id),
                                       search_criteria: subscription.search_criteria } },

--- a/spec/presenters/vacancies_presenter_spec.rb
+++ b/spec/presenters/vacancies_presenter_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe VacanciesPresenter do
       let(:prev_page) { 4 }
 
       it "returns the full url of the next page" do
-        expect(vacancies_presenter.previous_api_url).to eq("https://localhost:3000/api/v1/jobs.json?page=4")
+        expect(vacancies_presenter.previous_api_url).to eq("http://localhost:3000/api/v1/jobs.json?page=4")
       end
     end
 
@@ -42,7 +42,7 @@ RSpec.describe VacanciesPresenter do
       let(:next_page) { 2 }
 
       it "returns the full url of the next page" do
-        expect(vacancies_presenter.next_api_url).to eq("https://localhost:3000/api/v1/jobs.json?page=2")
+        expect(vacancies_presenter.next_api_url).to eq("http://localhost:3000/api/v1/jobs.json?page=2")
       end
     end
 

--- a/spec/presenters/vacancy_presenter_spec.rb
+++ b/spec/presenters/vacancy_presenter_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe VacancyPresenter do
 
     context "when campaign parameters are passed" do
       it "builds the campaign URL" do
-        expected_campaign_url = URI("https://localhost:3000/jobs/pe-teacher?utm_medium=interpretative_dance&utm_source=alert_run_id")
+        expected_campaign_url = URI("http://localhost:3000/jobs/pe-teacher?utm_medium=interpretative_dance&utm_source=alert_run_id")
         expect(presenter.share_url(utm_source: "alert_run_id", utm_medium: "interpretative_dance")).to match(expected_campaign_url.to_s)
       end
     end

--- a/spec/system/job_seekers_can_give_job_alert_feedback_spec.rb
+++ b/spec/system/job_seekers_can_give_job_alert_feedback_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe "A job seeker can give feedback on a job alert" do
     # Follow the link in the job alert email
     visit new_subscription_job_alert_feedback_url(
       token,
-      protocol: "https",
       params: { job_alert_feedback: { relevant_to_user: relevant_to_user,
                                       vacancy_ids: vacancies.pluck(:id),
                                       search_criteria: subscription.search_criteria } },


### PR DESCRIPTION
We used to run development environment in HTTPS, so we had to specify the protocol to test URL generation. Now it just uses the correct protocol, HTTP for development, HTTPS for production environments