### PR TITLE
Bigquery string functions

### DIFF
--- a/bigquery/scheduled_queries/append-yesterdays-daily-users-from-cloudfront-logs.sql
+++ b/bigquery/scheduled_queries/append-yesterdays-daily-users-from-cloudfront-logs.sql
@@ -27,7 +27,8 @@ SELECT
     utm_medium,
     referrer,
     landing_page_stem) AS medium,
-  utm_campaign LIKE "%alert%" AS from_job_alert
+  IFNULL(utm_campaign LIKE "%alert%",
+    FALSE) AS from_job_alert
 FROM (
   SELECT
     all_logs.date,

--- a/bigquery/scheduled_queries/append-yesterdays-daily-users-from-cloudfront-logs.sql
+++ b/bigquery/scheduled_queries/append-yesterdays-daily-users-from-cloudfront-logs.sql
@@ -23,37 +23,10 @@ WITH
     )
 SELECT
   *,
-  CASE
-    WHEN utm_campaign LIKE "%alert%" THEN "Job alert"
-    WHEN LOWER(utm_medium) LIKE "%email%" THEN "Email"
-    WHEN referrer LIKE "%facebook%" OR referrer LIKE "%twitter%" OR referrer LIKE "%t.co%" OR referrer LIKE "%linkedin%" OR referrer LIKE "%youtube%" THEN "Social"
-    WHEN (referrer IS NOT NULL
-    AND referrer NOT LIKE "%teaching-jobs.service.gov.uk%"
-    AND referrer NOT LIKE "%teaching-vacancies.service.gov.uk%"
-    AND referrer NOT LIKE "%google%"
-    AND referrer NOT LIKE "%bing%"
-    AND referrer NOT LIKE "%yahoo%"
-    AND referrer NOT LIKE "%aol%"
-    AND referrer NOT LIKE "%ask.co%")
-  OR utm_medium="referral" THEN "Referral"
-    WHEN utm_medium = "cpc" THEN "PPC"
-    WHEN referrer LIKE "%google%"
-  OR referrer LIKE "%bing%"
-  OR referrer LIKE "%yahoo%"
-  OR referrer LIKE "%aol"
-  OR referrer LIKE "%ask.co%"
-  OR utm_medium="organic" THEN (CASE
-      WHEN landing_page_stem = "/" THEN "Organic - to home page"
-      WHEN landing_page_stem LIKE "/jobs/%" THEN "Organic - to listing (e.g. Google Jobs)"
-      WHEN landing_page_stem LIKE "/teaching-jobs%" THEN "Organic - to landing page"
-    ELSE
-    "Organic - other"
-  END
-    )
-  ELSE
-  "Direct"
-END
-  AS medium,
+  `teacher-vacancy-service.production_dataset.categorise_traffic_by_medium`(utm_campaign,
+    utm_medium,
+    referrer,
+    landing_page_stem) AS medium,
   utm_campaign LIKE "%alert%" AS from_job_alert
 FROM (
   SELECT
@@ -67,9 +40,12 @@ FROM (
     search_parameters,
     vacancies_viewed_slugs,
     vacancies_with_gmi_clicks_ids,
-    REGEXP_EXTRACT(first_page.query,"utm_source=([^&]+)") AS utm_source,
-    REGEXP_EXTRACT(first_page.query,"utm_campaign=([^&]+)") AS utm_campaign,
-    REGEXP_EXTRACT(first_page.query,"utm_medium=([^&]+)") AS utm_medium,
+    `teacher-vacancy-service.production_dataset.extract_parameter_from_url_query`(first_page.query,
+      "utm_source") AS utm_source,
+    `teacher-vacancy-service.production_dataset.extract_parameter_from_url_query`(first_page.query,
+      "utm_campaign") AS utm_campaign,
+    `teacher-vacancy-service.production_dataset.extract_parameter_from_url_query`(first_page.query,
+      "utm_medium") AS utm_medium,
     job_alert_destination_links,
     job_alert_destinations,
     vacancies_viewed_slugs IS NOT NULL AS viewed_a_vacancy,
@@ -99,7 +75,9 @@ FROM (
       IF
         (cs_uri_stem = "/jobs"
           AND cs_uri_query != "-",
-          REGEXP_REPLACE(REGEXP_REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(cs_uri_query,"jobs_search_form",""),"%255D",""),"%255B",""),"+"," "),"%252C",","),"location=([^&]+)","location=redacted"),"(&page=[0-9+])",""),
+          `teacher-vacancy-service.production_dataset.redact_parameter`( `teacher-vacancy-service.production_dataset.decode_url_escape_characters`( `teacher-vacancy-service.production_dataset.remove_parameter`(cs_uri_query,
+                "page")),
+            "location"),
           NULL) IGNORE NULLS) AS search_parameters,
       ARRAY_AGG(DISTINCT
       IF
@@ -109,12 +87,14 @@ FROM (
       ARRAY_AGG(DISTINCT REGEXP_EXTRACT(cs_uri_stem,"^/jobs/(.+)/interests/new") IGNORE NULLS) AS vacancies_with_gmi_clicks_ids,
       ARRAY_AGG(DISTINCT
       IF
-        (cs_uri_query LIKE "%utm_campaign=%alert%",
+        (`teacher-vacancy-service.production_dataset.extract_parameter_from_url_query`(cs_uri_query,
+            "utm_campaign") LIKE "%alert%",
           cs_uri_stem,
           NULL) IGNORE NULLS) AS job_alert_destination_links,
       ARRAY_AGG(DISTINCT
       IF
-        (cs_uri_query LIKE "%utm_campaign=%alert%",
+        (`teacher-vacancy-service.production_dataset.extract_parameter_from_url_query`(cs_uri_query,
+            "utm_campaign") LIKE "%alert%",
           CASE
             WHEN cs_uri_stem LIKE "/jobs/%" THEN "vacancy"
             WHEN cs_uri_stem LIKE "/subscriptions/%/edit%" THEN "edit"
@@ -124,19 +104,7 @@ FROM (
         END
           ,
           NULL) IGNORE NULLS) AS job_alert_destinations,
-      CASE
-        WHEN LOWER(c_user_agent) LIKE "%bot%" OR LOWER(c_user_agent) LIKE "%http%" OR LOWER(c_user_agent) LIKE "%python%" OR LOWER(c_user_agent) LIKE "%scan%" OR LOWER(c_user_agent) LIKE "%check%" OR LOWER(c_user_agent) LIKE "%spider%" OR LOWER(c_user_agent) LIKE "%curl%" OR LOWER(c_user_agent) LIKE "%trend%" OR LOWER(c_user_agent) LIKE "%fetch%" THEN "bot"
-        WHEN LOWER(c_user_agent) LIKE "%mobile%"
-      OR LOWER(c_user_agent) LIKE "%android%"
-      OR LOWER(c_user_agent) LIKE "%whatsapp%"
-      OR LOWER(c_user_agent) LIKE "%iphone%"
-      OR LOWER(c_user_agent) LIKE "%ios%"
-      OR LOWER(c_user_agent) LIKE "%samsung%" THEN "mobile"
-        WHEN LOWER(c_user_agent) LIKE "%win%" OR LOWER(c_user_agent) LIKE "%mac%" OR LOWER(c_user_agent) LIKE "%x11%" THEN "desktop"
-      ELSE
-      "unknown"
-    END
-      AS device_category
+      `teacher-vacancy-service.production_dataset.convert_client_user_agent_to_device_category`(c_user_agent) AS device_category
     FROM
       cloudfront_logs
     GROUP BY

--- a/bigquery/scheduled_queries/append-yesterdays-job-alert-subscriptions-from-cloudfront-logs.sql
+++ b/bigquery/scheduled_queries/append-yesterdays-job-alert-subscriptions-from-cloudfront-logs.sql
@@ -1,80 +1,52 @@
 SELECT
-  *,
-  ARRAY_TO_STRING([
-  IF
-    (keyword IS NULL,
-      NULL,
-      "keyword"),
-  IF
-    (location IS NULL,
-      NULL,
-      "location"),
-  IF
-    (job_roles IS NULL,
-      NULL,
-      "job_roles"),
-  IF
-    (phases IS NULL,
-      NULL,
-      "phases"),
-  IF
-    (working_patterns IS NULL,
-      NULL,
-      "working_patterns") ]," and ") AS criteria_used
+  date,
+  time,
+  device_category,
+IF
+  (REGEXP_CONTAINS(cs_referer,"[?&]origin=/jobs/([^&?]+)"),
+    "vacancy",
+    "search") AS route_to_job_alert,
+  REGEXP_EXTRACT(cs_referer,"[?&]origin=/jobs/([^&?]+)") AS listing_page_clicked_job_alert_link_on,
+  `teacher-vacancy-service.production_dataset.make_search_parameters_human_readable`(cs_referer) AS criteria_used,
+  #extract the value of each of these parameters from the query in the logs
+  TRIM(LOWER(`teacher-vacancy-service.production_dataset.extract_parameter_from_url_query`(cs_referer,
+        "keyword"))) AS keyword,
+IF
+  (REGEXP_CONTAINS(`teacher-vacancy-service.production_dataset.extract_parameter_from_url_query`(cs_referer,
+        "location"),"[0-9]"),
+    "postcode",
+    `teacher-vacancy-service.production_dataset.extract_parameter_from_url_query`(cs_referer,
+      "location")) AS location,
+  `teacher-vacancy-service.production_dataset.extract_parameter_from_url_query`(cs_referer,
+    "radius") AS radius,
+  `teacher-vacancy-service.production_dataset.extract_parameter_from_url_query`(cs_referer,
+    "job_roles") AS job_roles,
+  `teacher-vacancy-service.production_dataset.extract_parameter_from_url_query`(cs_referer,
+    "phases") AS phases,
+  `teacher-vacancy-service.production_dataset.extract_parameter_from_url_query`(cs_referer,
+    "working_patterns") AS working_patterns,
 FROM (
   SELECT
     date,
     time,
-    device_category,
-  IF
-    (REGEXP_CONTAINS(cs_referer,"[?&]origin=/jobs/([^&?]+)"),
-      "vacancy",
-      "search") AS route_to_job_alert,
-    REGEXP_EXTRACT(cs_referer,"[?&]origin=/jobs/([^&?]+)") AS listing_page_clicked_job_alert_link_on,
-    #extract the value of each of these parameters from the query in the logs
-    TRIM(LOWER(REGEXP_EXTRACT(cs_referer,r'[?&]search_criteria\[keyword\]=([^&]+)'))) AS keyword,
-  IF
-    (REGEXP_CONTAINS(REGEXP_EXTRACT(cs_referer,r'[?&]search_criteria\[location\]=([^&]+)'),"[0-9]"),
-      "postcode",
-      REGEXP_EXTRACT(cs_referer,r'[?&]search_criteria\[location\]=([^&]+)')) AS location,
-    REGEXP_EXTRACT(cs_referer,r'[?&]search_criteria\[radius\]=([^&]+)') AS radius,
-    REGEXP_EXTRACT(cs_referer,r'[?&]search_criteria\[job_roles\]\[\]=([^&]+)') AS job_roles,
-    REGEXP_EXTRACT(cs_referer,r'[?&]search_criteria\[phases\]\[\]=([^&]+)') AS phases,
-    REGEXP_EXTRACT(cs_referer,r'[?&]search_criteria\[working_patterns\]=([^&]+)') AS working_patterns,
-  FROM (
-    SELECT
-      date,
-      time,
-      c_ip,
-      REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(cs_referer,"%255B","["),"%255D","]"),"%252F","/"),"%253F","?"),"%253D","="),"%2526","&"),"+"," "),"%253a",":"),"%252c",",") AS cs_referer,
-      CASE
-        WHEN LOWER(c_user_agent) LIKE "%bot%" OR LOWER(c_user_agent) LIKE "%http%" OR LOWER(c_user_agent) LIKE "%python%" OR LOWER(c_user_agent) LIKE "%scan%" OR LOWER(c_user_agent) LIKE "%check%" OR LOWER(c_user_agent) LIKE "%spider%" OR LOWER(c_user_agent) LIKE "%curl%" OR LOWER(c_user_agent) LIKE "%trend%" OR LOWER(c_user_agent) LIKE "%fetch%" THEN "bot"
-        WHEN LOWER(c_user_agent) LIKE "%mobile%"
-      OR LOWER(c_user_agent) LIKE "%android%"
-      OR LOWER(c_user_agent) LIKE "%whatsapp%"
-      OR LOWER(c_user_agent) LIKE "%iphone%"
-      OR LOWER(c_user_agent) LIKE "%ios%"
-      OR LOWER(c_user_agent) LIKE "%samsung%" THEN "mobile"
-        WHEN LOWER(c_user_agent) LIKE "%win%" OR LOWER(c_user_agent) LIKE "%mac%" OR LOWER(c_user_agent) LIKE "%x11%" THEN "desktop"
-      ELSE
-      "unknown"
-    END
-      AS device_category,
-    FROM
-      `teacher-vacancy-service.production_dataset.cloudfront_logs`
-    WHERE
-      cs_method="POST"
-      AND cs_uri_stem="/subscriptions"
-      AND sc_status="200"
-      AND sc_content_type LIKE "%text/html%" ))
-WHERE
-  device_category != "bot" AND
-  #only append job alert subscriptions from yesterday
-  date = DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)
-  AND (
-  SELECT
-    MAX(date)
+    c_ip,
+    `teacher-vacancy-service.production_dataset.decode_url_escape_characters`(cs_referer) AS cs_referer,
+    `teacher-vacancy-service.production_dataset.convert_client_user_agent_to_device_category`(c_user_agent) AS device_category,
   FROM
-    `teacher-vacancy-service.production_dataset.CALCULATED_job_alerts_created_from_cloudfront_logs`)<DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY) #in case something breaks - don't append anything if it looks like we already appended yesterday's job alert subscriptions
+    `teacher-vacancy-service.production_dataset.cloudfront_logs`
+  WHERE
+    cs_method="POST"
+    AND cs_uri_stem="/subscriptions"
+    AND sc_status="200"
+    AND sc_content_type LIKE "%text/html%" AND   #only append job alert subscriptions from yesterday
+    date = DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)
+    AND (
+    SELECT
+      MAX(date)
+    FROM
+      `teacher-vacancy-service.production_dataset.CALCULATED_job_alerts_created_from_cloudfront_logs`)<DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY) #in case something breaks - don't append anything if it looks like we already appended yesterday's job alert subscriptions
+    )
+WHERE
+  device_category != "bot"
 ORDER BY
   date ASC

--- a/bigquery/user_defined_functions/string-functions.sql
+++ b/bigquery/user_defined_functions/string-functions.sql
@@ -1,0 +1,109 @@
+# Contains useful string processing functions that can be reused across multiple scheduled queries and views in BigQuery.
+# This script must be run in BigQuery for these functions to become available, and re-run to overwrite the available functions with any new version.
+  
+# Take a client user agent from a Cloudfront server log and use it to categorise that traffic into a device category
+CREATE OR REPLACE FUNCTION
+  `teacher-vacancy-service.production_dataset.convert_client_user_agent_to_device_category`(client_user_agent STRING)
+  RETURNS STRING AS (
+    CASE
+      WHEN LOWER(client_user_agent) LIKE "%bot%" OR LOWER(client_user_agent) LIKE "%http%" OR LOWER(client_user_agent) LIKE "%python%" OR LOWER(client_user_agent) LIKE "%scan%" OR LOWER(client_user_agent) LIKE "%check%" OR LOWER(client_user_agent) LIKE "%spider%" OR LOWER(client_user_agent) LIKE "%curl%" OR LOWER(client_user_agent) LIKE "%trend%" OR LOWER(client_user_agent) LIKE "%fetch%" THEN "bot"
+      WHEN LOWER(client_user_agent) LIKE "%mobile%"
+    OR LOWER(client_user_agent) LIKE "%android%"
+    OR LOWER(client_user_agent) LIKE "%whatsapp%"
+    OR LOWER(client_user_agent) LIKE "%iphone%"
+    OR LOWER(client_user_agent) LIKE "%ios%"
+    OR LOWER(client_user_agent) LIKE "%samsung%" THEN "mobile"
+      WHEN LOWER(client_user_agent) LIKE "%win%" OR LOWER(client_user_agent) LIKE "%mac%" OR LOWER(client_user_agent) LIKE "%x11%" THEN "desktop"
+    ELSE
+    "unknown"
+  END
+    );
+
+#take various fields from a Cloudfront server log and use them to categorise that traffic into a medium
+CREATE OR REPLACE FUNCTION
+  `teacher-vacancy-service.production_dataset.categorise_traffic_by_medium`(utm_campaign STRING,
+    utm_medium STRING,
+    referrer STRING,
+    landing_page_stem STRING)
+  RETURNS STRING AS (
+    CASE
+      WHEN utm_campaign LIKE "%alert%" THEN "Job alert"
+      WHEN LOWER(utm_medium) LIKE "%email%" THEN "Email"
+      WHEN referrer LIKE "%facebook%" OR referrer LIKE "%twitter%" OR referrer LIKE "%t.co%" OR referrer LIKE "%linkedin%" OR referrer LIKE "%youtube%" THEN "Social"
+      WHEN (referrer IS NOT NULL
+      AND referrer NOT LIKE "%teaching-jobs.service.gov.uk%"
+      AND referrer NOT LIKE "%teaching-vacancies.service.gov.uk%"
+      AND referrer NOT LIKE "%google%"
+      AND referrer NOT LIKE "%bing%"
+      AND referrer NOT LIKE "%yahoo%"
+      AND referrer NOT LIKE "%aol%"
+      AND referrer NOT LIKE "%ask.co%")
+    OR utm_medium="referral" THEN "Referral"
+      WHEN utm_medium = "cpc" THEN "PPC"
+      WHEN referrer LIKE "%google%"
+    OR referrer LIKE "%bing%"
+    OR referrer LIKE "%yahoo%"
+    OR referrer LIKE "%aol"
+    OR referrer LIKE "%ask.co%"
+    OR utm_medium="organic" THEN (CASE
+        WHEN landing_page_stem = "/" THEN "Organic - to home page"
+        WHEN landing_page_stem LIKE "/jobs/%" THEN "Organic - to listing (e.g. Google Jobs)"
+        WHEN landing_page_stem LIKE "/teaching-jobs%" THEN "Organic - to landing page"
+      ELSE
+      "Organic - other"
+    END
+      )
+    ELSE
+    "Direct"
+  END
+    );
+    
+# Converts escaped characters in a URL (like '%20') into their actual characters (like ' '), and converts '+' into ' '.
+# Also removes "jobs_search_form","search_criteria" and square brackets from before search parameters to make specific parameter extraction more readable.
+CREATE OR REPLACE FUNCTION
+  `teacher-vacancy-service.production_dataset.decode_url_escape_characters`(url STRING) AS (REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(url,"%255D",""),"%255B",""),"%252F","/"),"%253F","?"),"%253D","="),"%2526","&"),"+"," "),"%252C",","),"%253A",":"),"jobs_search_form",""),"search_criteria",""));
+
+# Extracts the value of a specified parameter from within a URL query (the query is the part after the ?)
+CREATE OR REPLACE FUNCTION
+  `teacher-vacancy-service.production_dataset.extract_parameter_from_url_query`(url_query STRING,
+    parameter_to_extract STRING)
+  RETURNS STRING AS (REGEXP_EXTRACT(url_query,parameter_to_extract || "=([^&]+)") );
+
+# Remove a specified parameter entirely from a URL query string
+CREATE OR REPLACE FUNCTION
+  `teacher-vacancy-service.production_dataset.remove_parameter`(url_query STRING,
+    parameter_to_remove STRING) AS (REGEXP_REPLACE(url_query,"([&?]*" || parameter_to_remove || "=[0-9a-zA-Z_%-]+)",""));
+
+# Redact a specified parameter from a URL query string
+CREATE OR REPLACE FUNCTION
+  `teacher-vacancy-service.production_dataset.redact_parameter`(url_query STRING,
+    parameter_to_redact STRING) AS (REGEXP_REPLACE(url_query,"(" || parameter_to_redact || "=[0-9a-zA-Z_%-]+)",parameter_to_redact || "=redacted"));
+
+# Extract important search criteria from a URL query, and concatenate them together separated by 'and' in loose order of importance
+CREATE OR REPLACE FUNCTION
+  `teacher-vacancy-service.production_dataset.make_search_parameters_human_readable`(url_query STRING) AS ( ARRAY_TO_STRING([
+    IF
+      (`teacher-vacancy-service.production_dataset.extract_parameter_from_url_query`(url_query,
+          "keyword") IS NULL,
+        NULL,
+        "keyword"),
+    IF
+      (`teacher-vacancy-service.production_dataset.extract_parameter_from_url_query`(url_query,
+          "location") IS NULL,
+        NULL,
+        "location"),
+    IF
+      (`teacher-vacancy-service.production_dataset.extract_parameter_from_url_query`(url_query,
+          "job_roles") IS NULL,
+        NULL,
+        "job_roles"),
+    IF
+      (`teacher-vacancy-service.production_dataset.extract_parameter_from_url_query`(url_query,
+          "phases") IS NULL,
+        NULL,
+        "phases"),
+    IF
+      (`teacher-vacancy-service.production_dataset.extract_parameter_from_url_query`(url_query,
+          "working_patterns") IS NULL,
+        NULL,
+        "working_patterns") ]," and "))

--- a/bigquery/user_defined_functions/string-functions.sql
+++ b/bigquery/user_defined_functions/string-functions.sql
@@ -6,20 +6,30 @@ CREATE OR REPLACE FUNCTION
   `teacher-vacancy-service.production_dataset.convert_client_user_agent_to_device_category`(client_user_agent STRING)
   RETURNS STRING AS (
     CASE
-      WHEN LOWER(client_user_agent) LIKE "%bot%" OR LOWER(client_user_agent) LIKE "%http%" OR LOWER(client_user_agent) LIKE "%python%" OR LOWER(client_user_agent) LIKE "%scan%" OR LOWER(client_user_agent) LIKE "%check%" OR LOWER(client_user_agent) LIKE "%spider%" OR LOWER(client_user_agent) LIKE "%curl%" OR LOWER(client_user_agent) LIKE "%trend%" OR LOWER(client_user_agent) LIKE "%fetch%" THEN "bot"
+      WHEN LOWER(client_user_agent) LIKE "%bot%"
+        OR LOWER(client_user_agent) LIKE "%http%"
+        OR LOWER(client_user_agent) LIKE "%python%"
+        OR LOWER(client_user_agent) LIKE "%scan%"
+        OR LOWER(client_user_agent) LIKE "%check%"
+        OR LOWER(client_user_agent) LIKE "%spider%"
+        OR LOWER(client_user_agent) LIKE "%curl%"
+        OR LOWER(client_user_agent) LIKE "%trend%"
+        OR LOWER(client_user_agent) LIKE "%fetch%" THEN "bot"
       WHEN LOWER(client_user_agent) LIKE "%mobile%"
-    OR LOWER(client_user_agent) LIKE "%android%"
-    OR LOWER(client_user_agent) LIKE "%whatsapp%"
-    OR LOWER(client_user_agent) LIKE "%iphone%"
-    OR LOWER(client_user_agent) LIKE "%ios%"
-    OR LOWER(client_user_agent) LIKE "%samsung%" THEN "mobile"
-      WHEN LOWER(client_user_agent) LIKE "%win%" OR LOWER(client_user_agent) LIKE "%mac%" OR LOWER(client_user_agent) LIKE "%x11%" THEN "desktop"
+        OR LOWER(client_user_agent) LIKE "%android%"
+        OR LOWER(client_user_agent) LIKE "%whatsapp%"
+        OR LOWER(client_user_agent) LIKE "%iphone%"
+        OR LOWER(client_user_agent) LIKE "%ios%"
+        OR LOWER(client_user_agent) LIKE "%samsung%" THEN "mobile"
+      WHEN LOWER(client_user_agent) LIKE "%win%"
+        OR LOWER(client_user_agent) LIKE "%mac%"
+        OR LOWER(client_user_agent) LIKE "%x11%" THEN "desktop"
     ELSE
     "unknown"
   END
     );
 
-#take various fields from a Cloudfront server log and use them to categorise that traffic into a medium
+# Take various fields from a Cloudfront server log and use them to categorise that traffic into a medium
 CREATE OR REPLACE FUNCTION
   `teacher-vacancy-service.production_dataset.categorise_traffic_by_medium`(utm_campaign STRING,
     utm_medium STRING,


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1424

## Changes in this PR:

- Refactor queries that process data from Cloudfront by moving string processing functions into 'user defined functions'. This significantly reduces duplication, making these functions easier to maintain. For example - we'll be able to refine how we determine device categories and mediums in one place instead of four.
- Reduce number of subqueries in some of these cases to simplify things.
- Fix minor bug in the 'from job alert' field - it used to be NULL if utm_medium was NULL. Now it's FALSE if utm_medium is NULL.