### PR TITLE
Refactor DSI API consumption when signing in

### DIFF
--- a/spec/support/auth_helpers.rb
+++ b/spec/support/auth_helpers.rb
@@ -18,8 +18,11 @@ module AuthHelpers
   end
 
   def stub_authentication_step(organisation_id: "939eac36-0777-48c2-9c2c-b87c948a9ee0",
-                               school_urn: "110627", trust_uid: nil, la_code: "123",
+                               school_urn: "110627", trust_uid: nil, la_code: nil,
                                email: "an-email@example.com")
+    category = "001" if school_urn.present?
+    category = "010" if trust_uid.present?
+    category = "002" if la_code.present?
     OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(
       provider: "dfe",
       uid: "161d1f6a-44f1-4a1a-940d-d1088c439da7",
@@ -32,6 +35,7 @@ module AuthHelpers
             id: organisation_id,
             urn: school_urn,
             uid: trust_uid,
+            category: { id: category },
             establishmentNumber: la_code,
           },
         },


### PR DESCRIPTION
Splitted out from https://github.com/DFE-Digital/teaching-vacancies/pull/2358 and refactored further

It's more robust against edge-cases to check for e.g. the LA category '002' in the DSI API response, than to assume that an organisation is LA if it's neither trust or school, or to assume that if the JSON contains a URN then it's a school.

I asked DSI for the mapping from id to category and submitted a PR https://github.com/DFE-Digital/login.dfe.public-api/pull/60 adding that to the API README.
