### PR TITLE
[TEVA-1373] Prevent suspicious recaptcha form submissions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  SUSPICIOUS_RECAPTCHA_THRESHOLD = 0.5
+
   before_action :redirect_to_domain
 
   add_flash_types :success, :danger
@@ -79,5 +81,9 @@ private
 
   def set_headers
     response.set_header("X-Robots-Tag", "noindex, nofollow")
+  end
+
+  def invalid_recaptcha_score?
+    recaptcha_reply["score"] < SUSPICIOUS_RECAPTCHA_THRESHOLD
   end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -36,4 +36,13 @@ class ErrorsController < ApplicationController
     Rollbar.error("CSP Violation", details: request.raw_post)
     head :no_content
   end
+
+  def invalid_recaptcha
+    @form = params[:form_name]
+    Rollbar.error("Invalid recaptcha", details: @form)
+
+    respond_to do |format|
+      format.html { render status: :unauthorized }
+    end
+  end
 end

--- a/app/controllers/general_feedback_controller.rb
+++ b/app/controllers/general_feedback_controller.rb
@@ -5,25 +5,24 @@ class GeneralFeedbackController < ApplicationController
 
   def create
     @feedback = GeneralFeedback.new(general_feedback_params)
-    return render "new" unless @feedback.valid?
 
     recaptcha_is_valid = verify_recaptcha(model: @feedback, action: "feedback")
-
-    # v3_recaptcha does not interact with the user in any way. All it does is give them a score based on a number of
-    # heurisitics. For now, all we will do is attach the score to the submitted feedback. Once we have a representative
-    # data sample, we can decide how we will act on it.
-    #
-    # https://developers.google.com/recaptcha/docs/v3
     @feedback.recaptcha_score = recaptcha_reply["score"] if recaptcha_is_valid && recaptcha_reply
-    @feedback.save
 
-    redirect_to root_path, success: I18n.t("messages.feedback.submitted")
+    if recaptcha_is_valid && recaptcha_reply && invalid_recaptcha_score?
+      redirect_to invalid_recaptcha_path(form_name: @feedback.class.name.underscore.humanize)
+    elsif @feedback.valid?
+      @feedback.save
+      redirect_to root_path, success: I18n.t("messages.feedback.submitted")
+    else
+      render :new
+    end
   end
 
 private
 
   def general_feedback_params
     params.require(:general_feedback)
-      .permit(:visit_purpose, :visit_purpose_comment, :comment, :user_participation_response, :email)
+          .permit(:visit_purpose, :visit_purpose_comment, :comment, :user_participation_response, :email)
   end
 end

--- a/app/controllers/job_alert_feedbacks_controller.rb
+++ b/app/controllers/job_alert_feedbacks_controller.rb
@@ -26,7 +26,9 @@ class JobAlertFeedbacksController < ApplicationController
     @feedback.recaptcha_score = recaptcha_reply["score"] if recaptcha_is_valid && recaptcha_reply
     @feedback.save
 
-    if @feedback_form.valid?
+    if recaptcha_is_valid && recaptcha_reply && invalid_recaptcha_score?
+      redirect_to invalid_recaptcha_path(form_name: @feedback.class.name.underscore.humanize)
+    elsif @feedback_form.valid?
       @feedback.update(form_params)
       Auditor::Audit.new(@feedback, "job_alert_feedback.update", current_session_id).log
       redirect_to root_path, success: I18n.t("job_alert_feedbacks.submitted.comment")

--- a/app/controllers/nqt_job_alerts_controller.rb
+++ b/app/controllers/nqt_job_alerts_controller.rb
@@ -13,7 +13,9 @@ class NqtJobAlertsController < ApplicationController
     recaptcha_is_valid = verify_recaptcha(model: subscription, action: "subscription")
     subscription.recaptcha_score = recaptcha_reply["score"] if recaptcha_is_valid && recaptcha_reply
 
-    if @nqt_job_alerts_form.valid?
+    if recaptcha_is_valid && recaptcha_reply && invalid_recaptcha_score?
+      redirect_to invalid_recaptcha_path(form_name: @nqt_job_alerts_form.class.name.underscore.humanize)
+    elsif @nqt_job_alerts_form.valid?
       subscription.save
       AuditSubscriptionCreationJob.perform_later(@subscription.to_row)
       SubscriptionMailer.confirmation(subscription.id).deliver_later

--- a/app/views/errors/invalid_recaptcha.html.haml
+++ b/app/views/errors/invalid_recaptcha.html.haml
@@ -1,0 +1,7 @@
+- content_for :page_title_prefix, t("error_pages.invalid_recaptcha.title")
+
+%h1.govuk-heading-xl= t("error_pages.invalid_recaptcha.title")
+%p.govuk-body
+  = t("error_pages.invalid_recaptcha.text_html", mail_to: mail_to("teaching.vacancies@education.gov.uk", "teaching.vacancies@education.gov.uk",
+                                                                  class: "govuk-link link-wrap", subject: t("error_pages.invalid_recaptcha.email_subject", form: @form)))
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,6 +104,12 @@ en:
       default: "%e %B %Y %H:%M"
 
   error_pages:
+    invalid_recaptcha:
+      email_subject: Invalid recaptcha - %{form}
+      text_html: >-
+        Your request was identified as suspiciously robotic. If you are in fact human, please email %{mail_to} to
+        confirm this.
+      title: Sorry, you seem to be a robot
     not_found: Page not found.
     server_error: Sorry, there’s a technical issue at our end
     trashed_vacancy_found: Page not found.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,6 +97,7 @@ Rails.application.routes.draw do
   end
 
   post "/errors/csp_violation", to: "errors#csp_violation"
+  get "/invalid-recaptcha", to: "errors#invalid_recaptcha", as: "invalid_recaptcha"
   match "/401", to: "errors#unauthorised", via: :all
   match "/404", to: "errors#not_found", via: :all
   match "/422", to: "errors#unprocessable_entity", via: :all

--- a/documentation/bot-mitigation.md
+++ b/documentation/bot-mitigation.md
@@ -1,0 +1,24 @@
+# Bot mitigation
+
+## What
+Currently there are several forms on the service that can be accessed and submitted by anybody. These are open to spam and exploitation by bots.
+
+Google's recaptcha v3 was implemented on these forms in order to start obtaining recaptcha 'scores' which would help identify suspicious requests.
+
+## Why
+This version of the recaptcha does not obstruct the user (or bot) in any way and as a result we still receive some spam. Notably this results in bots creating job alert subscriptions.
+
+We want to prevent this from happening, so intend to use the recaptcha scores to stop forms being submitted when the actor is identified as being 'suspicious'
+
+## How
+Google don't reveal much information on how recaptcha scores work, or what indeed is 'suspicious', however they do [suggest](https://developers.google.com/recaptcha/docs/v3#interpreting_the_score) that a threshold of 0.5 might be a good place to start.
+
+For context, a threshold of 0.5 would have impacted just 1.7% of total form submissions.
+
+When form submissions have a recaptcha score below this threshold, we will:
+- invalidate the submission
+- redirect the bot to an /invalid-request page
+- provide an email link with the subject 'Invalid request - %{form name}'
+- log the event to Rollbar
+
+This strategy should be monitored and revisited and iterated on to ensure we filter out bots as much as possible while impacting real users as infrequently as possible.

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -30,4 +30,17 @@ RSpec.describe ErrorsController, type: :controller do
       expect(response).to have_http_status(:no_content)
     end
   end
+
+  describe "GET #invalid_recaptcha" do
+    it "sends the error to Rollbar" do
+      expect(Rollbar).to receive(:error).with("Invalid recaptcha", details: "this form")
+
+      get :invalid_recaptcha, params: { form_name: "this form" }
+    end
+
+    it "returns unauthorised" do
+      get :invalid_recaptcha
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
 end

--- a/spec/controllers/general_feedback_controller_spec.rb
+++ b/spec/controllers/general_feedback_controller_spec.rb
@@ -2,18 +2,20 @@ require "rails_helper"
 
 RSpec.describe GeneralFeedbackController, type: :controller do
   describe "#create" do
-    let(:feedback) do
-      instance_double(GeneralFeedback).as_null_object
+    let(:feedback) { instance_double(GeneralFeedback).as_null_object }
+    let(:feedback_valid?) { true }
+    let(:recaptcha_valid?) { true }
+    let(:recaptcha_score) { 0.9 }
+
+    before do
+      allow(GeneralFeedback).to receive(:new).and_return(feedback)
+      allow(feedback).to receive(:valid?).and_return(feedback_valid?)
+      allow(feedback).to receive(:class).and_return(GeneralFeedback)
+      allow(controller).to receive(:recaptcha_reply).and_return({ "score" => recaptcha_score })
+      allow(controller).to receive(:verify_recaptcha).and_return(recaptcha_valid?)
     end
 
-    context "verify_recaptcha is true and @feeback.valid? is true" do
-      before do
-        allow(GeneralFeedback).to receive(:new).and_return(feedback)
-        allow(feedback).to receive(:valid?).and_return(true)
-        allow(controller).to receive(:recaptcha_reply).and_return({ "score" => 0.9 })
-        allow(controller).to receive(:verify_recaptcha).and_return(true)
-      end
-
+    context "when verify_recaptcha is valid" do
       it "verifies the recaptcha" do
         expect(controller).to receive(:verify_recaptcha)
         post :create, params: { general_feedback: attributes_for(:general_feedback) }
@@ -34,44 +36,81 @@ RSpec.describe GeneralFeedbackController, type: :controller do
         post :create, params: { general_feedback: attributes_for(:general_feedback) }
       end
 
-      it "redirects to root" do
-        post :create, params: { general_feedback: attributes_for(:general_feedback) }
-        expect(response).to redirect_to(root_url)
+      context "and the recaptcha score is not valid" do
+        let(:recaptcha_score) { 0.1 }
+
+        it "redirects to invalid_recaptcha_path" do
+          post :create, params: { general_feedback: attributes_for(:general_feedback) }
+          expect(response).to redirect_to(invalid_recaptcha_path(form_name: "General feedback"))
+        end
+
+        it "does not save the GeneralFeedback record" do
+          expect(feedback).not_to receive(:save)
+          post :create, params: { general_feedback: attributes_for(:general_feedback) }
+        end
+      end
+
+      context "and the recaptcha score is valid" do
+        context "and feedback is valid" do
+          it "saves the GeneralFeedback record" do
+            expect(feedback).to receive(:save)
+            post :create, params: { general_feedback: attributes_for(:general_feedback) }
+          end
+
+          it "redirects to root" do
+            post :create, params: { general_feedback: attributes_for(:general_feedback) }
+            expect(response).to redirect_to(root_url)
+          end
+        end
+
+        context "and feedback is not valid" do
+          let(:feedback_valid?) { false }
+
+          it "does not save the GeneralFeedback record" do
+            expect(feedback).not_to receive(:save)
+            post :create, params: { general_feedback: attributes_for(:general_feedback) }
+          end
+
+          it "renders :new" do
+            post :create, params: { general_feedback: attributes_for(:general_feedback) }
+            expect(response).to render_template(:new)
+          end
+        end
       end
     end
 
-    context "verify_recaptcha is false and @feeback.valid? is true" do
-      before do
-        allow(GeneralFeedback).to receive(:new).and_return(feedback)
-        allow(feedback).to receive(:valid?).and_return(true)
-        allow(controller).to receive(:verify_recaptcha).and_return(false)
-      end
+    context "when verify_recaptcha is not valid" do
+      let(:recaptcha_valid?) { false }
 
       it "does not set the recaptcha score on the GeneralFeedback record" do
         expect(feedback).not_to receive(:recaptcha_score=)
         post :create, params: { general_feedback: attributes_for(:general_feedback) }
       end
 
-      it "saves the GeneralFeedback record" do
-        expect(feedback).to receive(:save)
-        post :create, params: { general_feedback: attributes_for(:general_feedback) }
+      context "and feedback is valid" do
+        it "saves the GeneralFeedback record" do
+          expect(feedback).to receive(:save)
+          post :create, params: { general_feedback: attributes_for(:general_feedback) }
+        end
+
+        it "redirects to root" do
+          post :create, params: { general_feedback: attributes_for(:general_feedback) }
+          expect(response).to redirect_to(root_url)
+        end
       end
 
-      it "redirects to root" do
-        post :create, params: { general_feedback: attributes_for(:general_feedback) }
-        expect(response).to redirect_to(root_url)
-      end
-    end
+      context "and feedback is not valid" do
+        let(:feedback_valid?) { false }
 
-    context "verify_recaptcha is anything and @feeback.valid? is false" do
-      before do
-        allow(GeneralFeedback).to receive(:new).and_return(feedback)
-        allow(feedback).to receive(:valid?).and_return(false)
-      end
+        it "does not save the GeneralFeedback record" do
+          expect(feedback).not_to receive(:save)
+          post :create, params: { general_feedback: attributes_for(:general_feedback) }
+        end
 
-      it "renders :new" do
-        post :create, params: { general_feedback: attributes_for(:general_feedback) }
-        expect(response).to render_template(:new)
+        it "renders :new" do
+          post :create, params: { general_feedback: attributes_for(:general_feedback) }
+          expect(response).to render_template(:new)
+        end
       end
     end
   end

--- a/spec/system/general_feedback_spec.rb
+++ b/spec/system/general_feedback_spec.rb
@@ -1,66 +1,42 @@
 require "rails_helper"
 
 RSpec.describe "Giving general feedback for the service" do
-  before(:each) do
-    visit new_feedback_path
-  end
+  context "when all required fields are complete" do
+    scenario "can submit feedback" do
+      visit new_feedback_path
+      expect(page).to have_content(I18n.t("feedback.heading"))
 
-  it "displays the general feedback page" do
-    expect(page).to have_content(I18n.t("feedback.heading"))
-  end
-
-  context "when submitting feedback on the service" do
-    let(:choose_yes_to_participation) { choose("general-feedback-user-participation-response-interested-field") }
-    let(:choose_no_to_participation) { choose("general-feedback-user-participation-response-not-interested-field") }
-
-    scenario "must have a visit purpose" do
-      fill_in "general_feedback[comment]", with: "Keep going!"
-      choose_no_to_participation
-
-      click_on I18n.t("buttons.submit_feedback")
-
-      expect(page).to have_content("Enter the reason for your visit")
-    end
-
-    scenario "must have a participation response" do
-      choose "Find a job in teaching"
+      choose("general-feedback-visit-purpose-find-teaching-job-field")
       fill_in "general_feedback[comment]", with: "Keep going!"
 
-      click_on I18n.t("buttons.submit_feedback")
-
-      expect(page).to have_content("Please indicate if you'd like to participate in user research")
-    end
-
-    scenario "successfully submitting feedback for the service" do
-      choose "Find a job in teaching"
-      fill_in "general_feedback[comment]", with: "Keep going!"
-      choose_no_to_participation
-
-      click_on I18n.t("buttons.submit_feedback")
-
-      expect(page).to have_content("Your feedback has been successfully submitted")
-    end
-
-    scenario "must have an email when participation response is Yes" do
-      choose "Find a job in teaching"
-      fill_in "general_feedback[comment]", with: "Keep going!"
-      choose_yes_to_participation
-
-      click_on I18n.t("buttons.submit_feedback")
-
-      expect(page).to have_content("Enter your email address")
-    end
-
-    scenario "successfully submitting feedback and interest in user research" do
-      choose "Find a job in teaching"
-      fill_in "general_feedback[comment]", with: "Keep going!"
-
-      choose_yes_to_participation
+      choose("general-feedback-user-participation-response-interested-field")
       fill_in "email", with: "test@test.com"
 
       click_on I18n.t("buttons.submit_feedback")
 
-      expect(page).to have_content("Your feedback has been successfully submitted")
+      expect(page).to have_content(I18n.t("messages.feedback.submitted"))
+    end
+  end
+
+  context "when all required fields are not complete" do
+    scenario "can not submit feedback" do
+      visit new_feedback_path
+      expect(page).to have_content(I18n.t("feedback.heading"))
+      click_on I18n.t("buttons.submit_feedback")
+      expect(page).to have_content("There is a problem")
+    end
+  end
+
+  context "when recaptcha score is invalid" do
+    before do
+      allow_any_instance_of(ApplicationController).to receive(:verify_recaptcha).and_return(true)
+      allow_any_instance_of(ApplicationController).to receive(:recaptcha_reply).and_return({ "score" => 0.1 })
+    end
+
+    scenario "redirects to invalid_recaptcha path" do
+      visit new_feedback_path
+      click_on I18n.t("buttons.submit_feedback")
+      expect(page).to have_current_path(invalid_recaptcha_path(form_name: "General feedback"))
     end
   end
 end

--- a/spec/system/job_seekers_can_give_job_alert_feedback_spec.rb
+++ b/spec/system/job_seekers_can_give_job_alert_feedback_spec.rb
@@ -80,6 +80,18 @@ RSpec.describe "A job seeker can give feedback on a job alert" do
         expect(activity.key).to eq("job_alert_feedback.update")
       end
     end
+
+    context "when recaptcha score is invalid" do
+      before do
+        allow_any_instance_of(ApplicationController).to receive(:verify_recaptcha).and_return(true)
+        allow_any_instance_of(ApplicationController).to receive(:recaptcha_reply).and_return({ "score" => 0.1 })
+      end
+
+      scenario "redirects to invalid_recaptcha path" do
+        click_on "Submit"
+        expect(page).to have_current_path(invalid_recaptcha_path(form_name: "Job alert feedback"))
+      end
+    end
   end
 
   context "with the incorrect token" do

--- a/spec/system/job_seekers_can_subscribe_to_a_job_alert_spec.rb
+++ b/spec/system/job_seekers_can_subscribe_to_a_job_alert_spec.rb
@@ -1,6 +1,19 @@
 require "rails_helper"
 
 RSpec.describe "A job seeker can subscribe to a job alert" do
+  context "when recaptcha score is invalid" do
+    before do
+      allow_any_instance_of(ApplicationController).to receive(:verify_recaptcha).and_return(true)
+      allow_any_instance_of(ApplicationController).to receive(:recaptcha_reply).and_return({ "score" => 0.1 })
+    end
+
+    scenario "redirects to invalid_recaptcha path" do
+      visit new_subscription_path(search_criteria: { some_parameters: "none" })
+      click_on "Subscribe"
+      expect(page).to have_current_path(invalid_recaptcha_path(form_name: "Subscription"))
+    end
+  end
+
   context "A job seeker" do
     scenario "can access the new subscription page when search criteria have been specified" do
       expect { visit(new_subscription_path) }.to raise_error(ActionController::ParameterMissing)

--- a/spec/system/job_seekers_can_subscribe_to_an_nqt_job_alert_spec.rb
+++ b/spec/system/job_seekers_can_subscribe_to_an_nqt_job_alert_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "A job seeker can subscribe to an NQT job alert" do
+RSpec.describe "NQT job alerts" do
   describe "A job seeker" do
     scenario "can successfully subscribe to a job alert" do
       visit nqt_job_alerts_path
@@ -20,6 +20,19 @@ RSpec.describe "A job seeker can subscribe to an NQT job alert" do
       click_on I18n.t("buttons.go_to_teaching_vacancies")
 
       expect(page).to have_current_path(jobs_path(keyword: "nqt Maths", location: "London"))
+    end
+  end
+
+  context "when recaptcha score is invalid" do
+    before do
+      allow_any_instance_of(ApplicationController).to receive(:verify_recaptcha).and_return(true)
+      allow_any_instance_of(ApplicationController).to receive(:recaptcha_reply).and_return({ "score" => 0.1 })
+    end
+
+    scenario "redirects to invalid_recaptcha path" do
+      visit nqt_job_alerts_path
+      click_on I18n.t("buttons.subscribe")
+      expect(page).to have_current_path(invalid_recaptcha_path(form_name: "Nqt job alerts form"))
     end
   end
 end


### PR DESCRIPTION
Filter out form submissions when the recaptcha score is below a given threshold

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-1373

## Changes in this PR
- Redirect invalid recaptcha scores to an error page
- Log to Rollbar
- Applied to job alert feedback, job alert, nqt job alert and general feedback pages

## Next steps
- Monitor rollbar logs
- Monitor emails
- Tweak threshold score if necessary