### PR TITLE
[TEVA-1357] Remove job alerts with invalid emails

### DIFF
--- a/app/jobs/remove_invalid_subscriptions_job.rb
+++ b/app/jobs/remove_invalid_subscriptions_job.rb
@@ -1,0 +1,11 @@
+require "remove_invalid_subscriptions"
+
+class RemoveInvalidSubscriptionsJob < ApplicationJob
+  queue_as :remove_invalid_subscriptions
+
+  def perform
+    return if DisableExpensiveJobs.enabled?
+
+    RemoveInvalidSubscriptions.new.run!
+  end
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -8,8 +8,8 @@ class Subscription < ApplicationRecord
 
   enum frequency: FREQUENCY_OPTIONS
 
-  has_many :alert_runs
-  has_many :job_alert_feedbacks
+  has_many :alert_runs, dependent: :destroy
+  has_many :job_alert_feedbacks, dependent: :destroy
 
   scope :active, (-> { where(active: true) })
 

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -43,6 +43,11 @@ refresh_cached_vacancy_statistics:
   class: 'RefreshCachedVacancyStatisticsJob'
   queue: refresh_cached_vacancy_statistics
 
+remove_invalid_subscriptions:
+  cron: '0 05 * * *'
+  class: 'RemoveInvalidSubscriptionsJob'
+  queue: remove_invalid_subscriptions
+
 remove_stale_vacancies:
   cron: '0 00 * * *'
   class: 'RemoveStaleVacanciesJob'

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -23,6 +23,7 @@
   - [import_trust_data, 1]
   - [refresh_cached_vacancy_statistics, 1]
   - [refresh_vacancy_facets, 1]
+  - [remove_invalid_subscriptions, 1]
   - [remove_stale_vacancies, 1]
   - [remove_vacancies_that_expired_yesterday, 1]
   - [reset_sessions, 1]
@@ -57,6 +58,8 @@ export_users:
 refresh_cached_vacancy_statistics:
   :concurrency: 1
 refresh_vacancy_facets:
+  :concurrency: 1
+remove_invalid_subscriptions:
   :concurrency: 1
 remove_stale_vacancies:
   :concurrency: 1

--- a/lib/remove_invalid_subscriptions.rb
+++ b/lib/remove_invalid_subscriptions.rb
@@ -1,0 +1,25 @@
+require "notifications/client"
+
+class RemoveInvalidSubscriptions
+  # The GOV.UK Notify API retrieves a maximum of 250 messages that are 7 days old or newer
+
+  def run!
+    permanent_failures.each do |failed_message|
+      Subscription.where(email: failed_message.email_address).destroy_all
+    end
+  end
+
+private
+
+  def api_response
+    Notifications::Client.new(NOTIFY_KEY).get_notifications(args)
+  end
+
+  def args
+    { template_type: "email", status: "failed" }
+  end
+
+  def permanent_failures
+    api_response.collection.select { |response| response.status == "permanent-failure" }
+  end
+end

--- a/spec/jobs/remove_invalid_subscriptions_job_spec.rb
+++ b/spec/jobs/remove_invalid_subscriptions_job_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe RemoveInvalidSubscriptionsJob, type: :job do
+  include ActiveJob::TestHelper
+
+  subject(:job) { described_class.perform_later }
+
+  before { allow(DisableExpensiveJobs).to receive(:enabled?).and_return(disable_expensive_jobs_enabled?) }
+
+  context "when DisableExpensiveJobs is not enabled" do
+    let(:disable_expensive_jobs_enabled?) { false }
+
+    it "queues the job" do
+      expect { job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
+    end
+
+    it "is in the remove_invalid_subscriptions queue" do
+      expect(job.queue_name).to eq("remove_invalid_subscriptions")
+    end
+
+    it "executes perform" do
+      expect(RemoveInvalidSubscriptions).to receive_message_chain(:new, :run!)
+      perform_enqueued_jobs { job }
+    end
+  end
+
+  context "when DisabledExpensiveJobs is enabled" do
+    let(:disable_expensive_jobs_enabled?) { true }
+
+    it "does not perform the job" do
+      expect(RemoveInvalidSubscriptions).not_to receive(:new)
+
+      perform_enqueued_jobs { job }
+    end
+  end
+end

--- a/spec/jobs/remove_stale_vacancies_job_spec.rb
+++ b/spec/jobs/remove_stale_vacancies_job_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe RemoveStaleVacanciesJob, type: :job do
     expect { job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
   end
 
-  it "is in the clear_emergency_login_keys queue" do
+  it "is in the remove_stale_vacancies queue" do
     expect(job.queue_name).to eq("remove_stale_vacancies")
   end
 
   it "deletes all vacancies without a job title" do
     2.times { create(:vacancy) }
     2.times { create(:vacancy, job_title: nil) }
-    expect { perform_enqueued_jobs { job } }.to change { Vacancy.all.size }.from(4).to(2)
+    expect { perform_enqueued_jobs { job } }.to change { Vacancy.count }.from(4).to(2)
   end
 end

--- a/spec/lib/remove_invalid_subscriptions_spec.rb
+++ b/spec/lib/remove_invalid_subscriptions_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe RemoveInvalidSubscriptions do
+  let(:subject) { described_class.new }
+
+  describe "#run!" do
+    let(:notify_api_response) do
+      [OpenStruct.new({ status: "permanent-failure", email_address: "first@failed.com" }),
+       OpenStruct.new({ status: "permanent-failure", email_address: "second@failed.com" }),
+       OpenStruct.new({ status: "not-permanent-failure", email_address: "test@tempfailed.com" })]
+    end
+
+    let!(:failed_subscription_1) { create(:subscription, email: "first@failed.com") }
+    let!(:failed_subscription_2) { create(:subscription, email: "second@failed.com") }
+    let!(:temp_failed_subscription) { create(:subscription, email: "test@tempfailed.com") }
+
+    let(:notify_client_mock) { instance_double(Notifications::Client) }
+    let(:notify_notifications_mock) { double("notifications") }
+
+    before do
+      allow(Notifications::Client).to receive(:new).with(NOTIFY_KEY).and_return(notify_client_mock)
+      allow(notify_client_mock)
+        .to receive(:get_notifications).with({ template_type: "email", status: "failed" })
+        .and_return(notify_notifications_mock)
+      allow(notify_notifications_mock).to receive(:collection).and_return(notify_api_response)
+    end
+
+    it "destroys subscriptions with permanently failed email addresses" do
+      expect { subject.run! }.to change { Subscription.count }.from(3).to(1)
+    end
+  end
+end


### PR DESCRIPTION
This PR uses the [notify api](https://docs.notifications.service.gov.uk/ruby.html#get-the-status-of-multiple-messages) to get the status of all (max 250) the failed messages in the past 7 days. Job alert subscriptions with these email addresses are then destroyed.

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-1357

## Changes in this PR
- Add lib class to retrieve failed messages and destroy subscriptions
- Add scheduled job that runs nightly