### PR TITLE
Skeleton jobseeker account dashboard

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -51,6 +51,12 @@ class ApplicationController < ActionController::Base
     params.permit(:utm_source, :utm_medium, :utm_campaign, :utm_term, :utm_content)
   end
 
+protected
+
+  def after_sign_in_path_for(_resource)
+    jobseekers_saved_jobs_path
+  end
+
 private
 
   def append_info_to_payload(payload)

--- a/app/controllers/jobseekers/accounts_controller.rb
+++ b/app/controllers/jobseekers/accounts_controller.rb
@@ -1,0 +1,3 @@
+class Jobseekers::AccountsController < Jobseekers::ApplicationController
+  def show; end
+end

--- a/app/controllers/jobseekers/application_controller.rb
+++ b/app/controllers/jobseekers/application_controller.rb
@@ -1,0 +1,3 @@
+class Jobseekers::ApplicationController < ApplicationController
+  before_action :authenticate_jobseeker!
+end

--- a/app/controllers/jobseekers/saved_jobs_controller.rb
+++ b/app/controllers/jobseekers/saved_jobs_controller.rb
@@ -1,0 +1,3 @@
+class Jobseekers::SavedJobsController < Jobseekers::ApplicationController
+  def index; end
+end

--- a/app/controllers/jobseekers/sessions_controller.rb
+++ b/app/controllers/jobseekers/sessions_controller.rb
@@ -1,0 +1,8 @@
+class Jobseekers::SessionsController < Devise::SessionsController
+  def create
+    super do
+      # Devise adds a :notice flash on login, we want it to be a :success flash
+      flash[:success] = flash.discard(:notice)
+    end
+  end
+end

--- a/app/controllers/jobseekers/subscriptions_controller.rb
+++ b/app/controllers/jobseekers/subscriptions_controller.rb
@@ -1,0 +1,3 @@
+class Jobseekers::SubscriptionsController < Jobseekers::ApplicationController
+  def index; end
+end

--- a/app/frontend/src/styles/application.scss
+++ b/app/frontend/src/styles/application.scss
@@ -40,6 +40,7 @@ $govuk-image-url-function: frontend-image-url;
 @import 'application/tabs';
 @import 'application/timeline';
 
+@import 'application/jobSeekers/account';
 @import 'application/jobSeekers/cookies-banner';
 @import 'application/jobSeekers/feedback-form';
 @import 'application/jobSeekers/location-search';
@@ -73,6 +74,9 @@ body {
     border-bottom: 10px solid govuk-colour('orange');
   }
 
+  &.jobseekers_saved_jobs_index,
+  &.jobseekers_subscriptions_index,
+  &.jobseekers_accounts_show,
   &.vacancies_index,
   &.vacancies_show,
   &.vacancies_preview,

--- a/app/frontend/src/styles/application/hiringStaff/hiring-staff.scss
+++ b/app/frontend/src/styles/application/hiringStaff/hiring-staff.scss
@@ -16,9 +16,9 @@ body.hiring-staff {
     }
   }
 
-  &.vacancies_index,
-  &.vacancies_show,
-  &.vacancies_preview {
+  &.hiring_staff_vacancies_index,
+  &.hiring_staff_vacancies_show,
+  &.hiring_staff_vacancies_preview {
     .govuk-main-wrapper {
       margin-left: auto;
       margin-right: auto;

--- a/app/frontend/src/styles/application/jobSeekers/account.scss
+++ b/app/frontend/src/styles/application/jobSeekers/account.scss
@@ -1,0 +1,32 @@
+.account-header {
+  background-color: govuk-colour('light-grey');
+  left: 50%;
+  margin-bottom: govuk-spacing(6);
+  margin-left: -50vw;
+  padding-top: govuk-spacing(1);
+  position: relative;
+  width: 100vw;
+
+  .moj-primary-navigation__container {
+    margin: 0;
+  }
+}
+
+.account-header__user-identifier {
+  @include govuk-font(24);
+  margin: govuk-spacing(3) 0;
+}
+
+.account-sidebar {
+  border-top: 5px solid $govuk-link-colour;
+  margin-top: govuk-spacing(3);
+
+  @include govuk-media-query ($from: desktop) {
+    margin-top: 0;
+  }
+}
+
+.account-sidebar__heading {
+  @extend %govuk-heading-m;
+  margin: govuk-spacing(3) 0;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,7 +8,7 @@ module ApplicationHelper
 
   def body_class
     auth_class = authenticated? ? "hiring-staff" : ""
-    action_class = controller_name + "_" + action_name
+    action_class = controller_path.tr("/", "_") + "_" + action_name
     "govuk-template__body app-body-class #{auth_class} #{action_class}"
   end
 

--- a/app/views/jobseekers/accounts/show.html.haml
+++ b/app/views/jobseekers/accounts/show.html.haml
@@ -1,0 +1,31 @@
+- content_for :page_title_prefix, t(".page_title")
+
+= render partial: 'account_header'
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    %h1.govuk-heading-l= t(".page_title")
+
+    %dl.govuk-summary-list
+      .govuk-summary-list__row
+        %dt.govuk-summary-list__key= t(".summary_list.email")
+        %dd.govuk-summary-list__value= current_jobseeker.email
+        %dd.govuk-summary-list__actions
+          = link_to edit_jobseeker_registration_path, class: "govuk-link" do
+            = t(".summary_list.change")
+            %span.govuk-visually-hidden
+              = t(".summary_list.email")
+      .govuk-summary-list__row
+        %dt.govuk-summary-list__key= t(".summary_list.password")
+        %dd.govuk-summary-list__value= t(".summary_list.password_placeholder")
+        %dd.govuk-summary-list__actions
+          = link_to edit_jobseeker_registration_path, class: "govuk-link" do
+            = t(".summary_list.change")
+            %span.govuk-visually-hidden
+              = t(".summary_list.password")
+    = button_to "Temporary log out button until we create a proper logout link in the header", destroy_jobseeker_session_path, method: :delete
+
+  .govuk-grid-column-one-third
+    .account-sidebar
+      %h2.account-sidebar__heading= t(".assistance.heading")
+      %p.govuk-body= t(".assistance.content_html", link: link_to(t(".assistance.link_text"), "#", class: "govuk-link"))

--- a/app/views/jobseekers/application/_account_header.html.haml
+++ b/app/views/jobseekers/application/_account_header.html.haml
@@ -1,0 +1,17 @@
+.account-header
+  .govuk-width-container
+    .account-header__user-identifier
+      %span.govuk-visually-hidden
+        = t("jobseekers.accounts.header.accessible_signed_in_as")
+      = current_jobseeker.email
+
+    .moj-primary-navigation
+      .moj-primary-navigation__container
+        .moj-primary-navigation__nav{aria: { label: "Account navigation" }}
+          %ul.moj-primary-navigation__list
+            %li.moj-primary-navigation__item
+              = link_to t("jobseekers.saved_jobs.index.page_title"), jobseekers_saved_jobs_path, class: 'moj-primary-navigation__link', aria: { current: ("page" if current_page?(jobseekers_saved_jobs_path)) }
+            %li.moj-primary-navigation__item
+              = link_to t("jobseekers.subscriptions.index.page_title"), jobseekers_subscriptions_path, class: 'moj-primary-navigation__link', aria: { current: ("page" if current_page?(jobseekers_subscriptions_path)) }
+            %li.moj-primary-navigation__item
+              = link_to t("jobseekers.accounts.show.page_title"), jobseekers_account_path, class: 'moj-primary-navigation__link', aria: { current: ("page" if current_page?(jobseekers_account_path)) }

--- a/app/views/jobseekers/saved_jobs/index.html.haml
+++ b/app/views/jobseekers/saved_jobs/index.html.haml
@@ -1,0 +1,7 @@
+- content_for :page_title_prefix, t(".page_title")
+
+= render partial: 'account_header'
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    %h1.govuk-heading-l= t(".page_title")

--- a/app/views/jobseekers/subscriptions/index.html.haml
+++ b/app/views/jobseekers/subscriptions/index.html.haml
@@ -1,0 +1,7 @@
+- content_for :page_title_prefix, t(".page_title")
+
+= render partial: 'account_header'
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    %h1.govuk-heading-l= t(".page_title")

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -41,7 +41,7 @@ en:
       updated: Your account has been updated successfully.
       updated_but_not_signed_in: Your account has been updated successfully, but since your password was changed, you need to sign in again
     sessions:
-      signed_in: Signed in successfully.
+      signed_in: Welcome to your Teaching Vacancies account.
       signed_out: Signed out successfully.
       already_signed_out: Signed out successfully.
     unlocks:

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -1,0 +1,23 @@
+en:
+  jobseekers:
+    accounts:
+      header:
+        accessible_signed_in_as: You are signed in as
+      show:
+        page_title: Account details
+        summary_list:
+          email: Email address
+          password: Account password
+          password_placeholder: "**************"
+          change: Change
+        delete_account: Delete your account
+        assistance:
+          heading: Need assistance?
+          content_html: "%{link} to get help with problems you are having with your account."
+          link_text: Contact our support team
+    saved_jobs:
+      index:
+        page_title: Saved jobs
+    subscriptions:
+      index:
+        page_title: Job alerts

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,13 @@
 Rails.application.routes.draw do
-  devise_for :jobseekers if JobseekerAccountsFeature.enabled?
+  constraints(-> { JobseekerAccountsFeature.enabled? }) do
+    devise_for :jobseekers, controllers: { sessions: "jobseekers/sessions" }
+
+    namespace :jobseekers do
+      resources :saved_jobs, only: %i[index]
+      resources :subscriptions, only: %i[index]
+      resource :account, only: %i[show]
+    end
+  end
 
   root "pages#home"
 

--- a/spec/factories/jobseekers.rb
+++ b/spec/factories/jobseekers.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :jobseeker do
     email { Faker::Internet.email }
     password { "passw0rd" }
+    confirmed_at { 1.hour.ago }
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe ApplicationHelper, type: :helper do
 
   describe "#body_class" do
     before do
-      expect(controller).to receive(:controller_name) { "foo" }
+      expect(controller).to receive(:controller_path) { "foo/baz" }
       expect(controller).to receive(:action_name) { "bar" }
       allow(controller).to receive(:authenticated?) { false }
     end
 
     it "returns the controller and action name" do
-      expect(helper.body_class).to match(/foo_bar/)
+      expect(helper.body_class).to match(/foo_baz_bar/)
     end
 
     it "does not return the authenticated class" do

--- a/spec/support/warden.rb
+++ b/spec/support/warden.rb
@@ -1,0 +1,8 @@
+RSpec.configure do |config|
+  include Warden::Test::Helpers
+  Warden.test_mode!
+
+  config.after(:each) do
+    Warden.test_reset!
+  end
+end

--- a/spec/system/jobseekers_can_manage_their_account_details_spec.rb
+++ b/spec/system/jobseekers_can_manage_their_account_details_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe "Jobseekers can manage their account details" do
+  let(:jobseeker) { create(:jobseeker, email: "job.seeker@example.com") }
+
+  before do
+    allow(JobseekerAccountsFeature).to receive(:enabled?).and_return(true)
+  end
+
+  context "when logged in" do
+    before do
+      login_as(jobseeker, scope: :jobseeker)
+      visit jobseekers_account_path
+    end
+
+    it "shows their account details" do
+      within("dl") do
+        expect(page).to have_content(I18n.t("jobseekers.accounts.show.summary_list.email"))
+        expect(page).to have_content("job.seeker@example.com")
+      end
+    end
+  end
+
+  context "when logged out" do
+    before do
+      visit jobseekers_account_path
+    end
+
+    it "redirects to the sign in page" do
+      expect(current_path).to eq(new_jobseeker_session_path)
+    end
+  end
+end

--- a/spec/system/jobseekers_can_manage_their_account_details_spec.rb
+++ b/spec/system/jobseekers_can_manage_their_account_details_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Jobseekers can manage their account details" do
-  let(:jobseeker) { create(:jobseeker, email: "job.seeker@example.com") }
+  let(:jobseeker) { create(:jobseeker, email: "jobseeker@example.com") }
 
   before do
     allow(JobseekerAccountsFeature).to receive(:enabled?).and_return(true)
@@ -16,7 +16,7 @@ RSpec.describe "Jobseekers can manage their account details" do
     it "shows their account details" do
       within("dl") do
         expect(page).to have_content(I18n.t("jobseekers.accounts.show.summary_list.email"))
-        expect(page).to have_content("job.seeker@example.com")
+        expect(page).to have_content("jobseeker@example.com")
       end
     end
   end

--- a/spec/system/jobseekers_can_manage_their_job_alerts_spec.rb
+++ b/spec/system/jobseekers_can_manage_their_job_alerts_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe "Jobseekers can manage their job alerts" do
+  let(:jobseeker) { create(:jobseeker) }
+
+  before do
+    allow(JobseekerAccountsFeature).to receive(:enabled?).and_return(true)
+  end
+
+  context "when logged in" do
+    before do
+      login_as(jobseeker, scope: :jobseeker)
+      visit jobseekers_subscriptions_path
+    end
+
+    it "shows their job alerts" do
+      # TODO: Implement me properly when job alerts are implemented
+      expect(page).to have_content(I18n.t("jobseekers.subscriptions.index.page_title"))
+    end
+  end
+
+  context "when logged out" do
+    before do
+      visit jobseekers_subscriptions_path
+    end
+
+    it "redirects to the sign in page" do
+      expect(current_path).to eq(new_jobseeker_session_path)
+    end
+  end
+end

--- a/spec/system/jobseekers_can_manage_their_saved_jobs_spec.rb
+++ b/spec/system/jobseekers_can_manage_their_saved_jobs_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe "Jobseekers can manage their saved jobs" do
+  let(:jobseeker) { create(:jobseeker) }
+
+  before do
+    allow(JobseekerAccountsFeature).to receive(:enabled?).and_return(true)
+  end
+
+  context "when logged in" do
+    before do
+      login_as(jobseeker, scope: :jobseeker)
+      visit jobseekers_saved_jobs_path
+    end
+
+    it "shows their saved jobs" do
+      # TODO: Implement me properly when saved jobs are implemented
+      expect(page).to have_content(I18n.t("jobseekers.saved_jobs.index.page_title"))
+    end
+  end
+
+  context "when logged out" do
+    before do
+      visit jobseekers_saved_jobs_path
+    end
+
+    it "redirects to the sign in page" do
+      expect(current_path).to eq(new_jobseeker_session_path)
+    end
+  end
+end

--- a/spec/system/jobseekers_can_sign_in_to_their_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_in_to_their_account_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe "Jobseekers can sign in to their account" do
+  let!(:jobseeker) { create(:jobseeker, email: "jobseeker@example.com", password: "correct_horse_battery_staple") }
+
+  before do
+    allow(JobseekerAccountsFeature).to receive(:enabled?).and_return(true)
+  end
+
+  scenario "signing in takes them to saved jobs page with banner" do
+    # TODO: Implement me properly when signing in is implemented
+    visit new_jobseeker_session_path
+
+    fill_in "Email", with: "jobseeker@example.com"
+    fill_in "Password", with: "correct_horse_battery_staple"
+    click_button "Log in"
+
+    expect(current_path).to eq(jobseekers_saved_jobs_path)
+    expect(page).to have_content(I18n.t("devise.sessions.signed_in"))
+  end
+end


### PR DESCRIPTION
- Add placeholder "saved jobs" index page
- Add placeholder "job alerts" index page
- Add placeholder "account details" page and link to unfinished Devise
  account edit page for now
- Add prototype jobseeker account header with primary navigation
  (using MoJ frontend for now, will need to be implemented properly
  later)
- Redirect jobseekers to "saved jobs" index page on login
- Amend `body_class` helper to take controller namespaces into account
- Change `Jobseeker` factory to create confirmed accounts by default
- Add basic Warden configuration for test suite

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1504

## Screenshots of UI changes:

Magic! 🧙 

<img width="1336" alt="Screenshot 2020-11-20 at 10 48 02" src="https://user-images.githubusercontent.com/72141/99791698-e4f15800-2b1d-11eb-9aef-78ec46c34a73.png">

