### PR TITLE
TEVA-1604 review destroy improvements

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -46,12 +46,6 @@ jobs:
       with:
         terraform_version: 0.13.4
 
-    - name: Set environment variables
-      id: set_env_vars
-      run: |
-        TAG=review-pr-${{ github.event.number }}-${{ github.sha }}-$(date '+%Y%m%d%H%M%S')
-        echo "TAG=${TAG}" >> $GITHUB_ENV
-
     - name: Terraform destroy (on PR closed)
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -59,13 +53,11 @@ jobs:
         TF_VAR_paas_user: ${{ secrets.CF_USERNAME }}
         TF_VAR_paas_password: ${{ secrets.CF_PASSWORD }}
       run: |
-        export TF_VAR_paas_app_docker_image=${{ env.DOCKERHUB_REPOSITORY }}:${ env.TAG }}
         export TF_VAR_environment=review-pr-${{ github.event.number }}
         cd terraform/app
         terraform init -reconfigure -input=false -backend-config="workspace_key_prefix=review:"
         terraform workspace select review-pr-${{ github.event.number }} || terraform workspace new review-pr-${{ github.event.number }}
-        terraform plan -var-file ../workspace-variables/review.tfvars -destroy -out=tfdestroy
-        terraform apply -auto-approve "tfdestroy"
+        terraform destroy -var-file ../workspace-variables/review.tfvars -auto-approve
         terraform workspace select default && terraform workspace delete review-pr-${{ github.event.number }}
 
     - name: Send failure message to twd_tv_dev channel

--- a/Makefile
+++ b/Makefile
@@ -97,10 +97,10 @@ terraform-app-plan: terraform-app-init check-docker-tag ## make passcode=MyPassc
 terraform-app-apply: terraform-app-init check-docker-tag ## make passcode=MyPasscode tag=47fd1475376bbfa16a773693133569b794408995 <env> terraform-app-apply
 		cd terraform/app && terraform apply -input=false -var-file ../workspace-variables/$(var_file).tfvars -auto-approve
 
-.PHONY: review-destroy
-review-destroy: terraform-app-init ## make CONFIRM_DESTROY=true passcode=MyPasscode pr=2086 review review-destroy
+.PHONY: terraform-app-destroy-review
+terraform-app-destroy-review: terraform-app-init ## make CONFIRM_DESTROY=true passcode=MyPasscode pr_id=2086 review terraform-app-destroy-review
 		$(if $(CONFIRM_DESTROY), , $(error Can only run with CONFIRM_DESTROY))
-		cd terraform/app && terraform destroy -var-file ../workspace-variables/review.tfvars
+		cd terraform/app && terraform destroy -var-file ../workspace-variables/review.tfvars -auto-approve
 		cd terraform/app && terraform workspace select default && terraform workspace delete $(env)
 
 ##@ terraform/common code. Requires privileged IAM account to run

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -43,7 +43,9 @@ variable paas_password {
   default = ""
 }
 
-variable paas_app_docker_image {}
+variable paas_app_docker_image {
+  default = "dfedigital/teaching-vacancies:placeholder"
+}
 
 variable paas_app_start_timeout {
   default = 300


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1604

## Changes in this PR:

- Makefile add -auto-approve to destroy action. Confirmation is provided via the CONFIRM_DESTROY variable.
- Makefile update target help to reflect name change to pr_id.
- Makefile rename destroy target for consistency.
- Destroy workflow - use terraform destroy directly, as it is in the Makefile, rather than destroy plan followed by apply plan.
- paas_app_docker_image is a required variable. Provide a default in app/variables.tf, which is then over-ridden by TF_VAR environment variables in Makefile targets and GH Actions workflows.