### PR TITLE
Make Devise IP tracking columns strings

### DIFF
--- a/db/migrate/20201120133910_change_devise_ip_columns_to_string.rb
+++ b/db/migrate/20201120133910_change_devise_ip_columns_to_string.rb
@@ -1,0 +1,8 @@
+class ChangeDeviseIpColumnsToString < ActiveRecord::Migration[6.0]
+  def change
+    change_table :jobseekers do |t|
+      t.change :current_sign_in_ip, :string
+      t.change :last_sign_in_ip, :string
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_18_144227) do
+ActiveRecord::Schema.define(version: 2020_11_20_133910) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -117,8 +117,8 @@ ActiveRecord::Schema.define(version: 2020_11_18_144227) do
     t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.inet "current_sign_in_ip"
-    t.inet "last_sign_in_ip"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
     t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"


### PR DESCRIPTION
These have been generated as `inet` column types because the migration
ran using Postgres, which is normally fine as we run Postgres in
production too, but the BigQuery import library isn't able to deal with
these types. We don't really need any of the functionality Postgres
offers us to deal with IPs, so it's fine for these to be strings
instead.