### PR TITLE
Tweak jobseeker account sign out functionality

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -59,6 +59,10 @@ protected
     jobseekers_saved_jobs_path
   end
 
+  def after_sign_out_path_for(_resource)
+    new_jobseeker_session_path
+  end
+
 private
 
   def append_info_to_payload(payload)

--- a/app/controllers/jobseekers/sessions_controller.rb
+++ b/app/controllers/jobseekers/sessions_controller.rb
@@ -1,8 +1,10 @@
 class Jobseekers::SessionsController < Devise::SessionsController
-  def create
-    super do
-      # Devise adds a :notice flash on login, we want it to be a :success flash
-      flash[:success] = flash.discard(:notice)
-    end
+  after_action :replace_devise_notice_flash_with_success!, only: %i[create destroy]
+
+private
+
+  def replace_devise_notice_flash_with_success!
+    # We want to display Devise notices for sessions (but not alerts) as success messages instead
+    flash[:success] = flash.discard(:notice)
   end
 end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -11,7 +11,7 @@ en:
       locked: Your account is locked.
       last_attempt: You have one more attempt before your account is locked.
       not_found_in_database: Invalid %{authentication_keys} or password.
-      timeout: Your session expired. Please sign in again to continue.
+      timeout: You have been signed out because you have been inactive for 60 minutes.
       unauthenticated: You need to sign in or sign up before continuing.
       unconfirmed: You have to confirm your email address before continuing.
     mailer:
@@ -42,7 +42,7 @@ en:
       updated_but_not_signed_in: Your account has been updated successfully, but since your password was changed, you need to sign in again
     sessions:
       signed_in: Welcome to your Teaching Vacancies account.
-      signed_out: Signed out successfully.
+      signed_out: You have been successfully signed out.
       already_signed_out: Signed out successfully.
     unlocks:
       send_instructions: You will receive an email with instructions for how to unlock your account in a few minutes.

--- a/spec/system/jobseekers_can_sign_out_from_their_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_out_from_their_account_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe "Jobseekers can sign out from their account" do
+  let!(:jobseeker) { create(:jobseeker, email: "jobseeker@example.com") }
+
+  before do
+    allow(JobseekerAccountsFeature).to receive(:enabled?).and_return(true)
+    login_as(jobseeker, scope: :jobseeker)
+  end
+
+  scenario "signing out takes them to sign in page with banner" do
+    # TODO: Implement me properly when we have a real "sign out" link in the header
+    visit jobseekers_account_path
+    click_button "Temporary log out button until we create a proper logout link in the header"
+
+    expect(current_path).to eq(new_jobseeker_session_path)
+    expect(page).to have_content(I18n.t("devise.sessions.signed_out"))
+  end
+end

--- a/spec/system/jobseekers_session_timeout_spec.rb
+++ b/spec/system/jobseekers_session_timeout_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe "Jobseekers session timeout" do
+  let!(:jobseeker) { create(:jobseeker, email: "jobseeker@example.com") }
+  let(:timeout_period) { 60.minutes }
+
+  before do
+    allow(JobseekerAccountsFeature).to receive(:enabled?).and_return(true)
+    login_as(jobseeker, scope: :jobseeker)
+  end
+
+  it "expires after the desired timeout period" do
+    visit jobseekers_saved_jobs_path
+    expect(page).to have_content(jobseeker.email)
+
+    travel(timeout_period + 10.seconds) do
+      visit jobseekers_saved_jobs_path
+
+      expect(current_path).to eq(new_jobseeker_session_path)
+      expect(page).to have_content(I18n.t("devise.failure.timeout"))
+    end
+  end
+
+  it "doesn't expire before the desired timeout period" do
+    visit jobseekers_saved_jobs_path
+    expect(page).to have_content(jobseeker.email)
+
+    travel(timeout_period - 10.seconds) do
+      visit jobseekers_saved_jobs_path
+
+      expect(current_path).to eq(jobseekers_saved_jobs_path)
+      expect(page).to have_content(jobseeker.email)
+    end
+  end
+end


### PR DESCRIPTION
- Redirect users to login page after signing out (instead of homepage)
- Change content to be in line with the design
- Add initial system tests for signing out and session timeouts
  (to be amended when we have a proper "sign out" link in the header)
- DRY up Devise flash key replacement to replace `notice` flashes with
  `success` flashes both on sign in and sign out

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1519