### PR TITLE
Update synonyms in Algolia configuration

### DIFF
--- a/config/algolia_settings.json
+++ b/config/algolia_settings.json
@@ -96,14 +96,7 @@
     ],
     "exactOnSingleWordQuery": "attribute",
     "ranking": [
-      "typo",
-      "geo",
-      "words",
-      "filters",
-      "proximity",
-      "attribute",
-      "exact",
-      "custom"
+      "desc(publication_date_timestamp)"
     ],
     "customRanking": [
       "desc(job_title)",
@@ -136,7 +129,6 @@
       "type": "synonym",
       "synonyms": [
         "headteacher",
-        "head",
         "principal",
         "head teacher"
       ],


### PR DESCRIPTION
- Remove "head" as a synonym for headteacher (TEVA-1473)

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1627