### PR TITLE
Fix incorrectly exported Algolia configuration

### DIFF
--- a/config/algolia_settings.json
+++ b/config/algolia_settings.json
@@ -96,7 +96,14 @@
     ],
     "exactOnSingleWordQuery": "attribute",
     "ranking": [
-      "desc(publication_date_timestamp)"
+      "typo",
+      "geo",
+      "words",
+      "filters",
+      "proximity",
+      "attribute",
+      "exact",
+      "custom"
     ],
     "customRanking": [
       "desc(job_title)",


### PR DESCRIPTION
I've accidentally exported a replica's configuration rather than that of
the base index.