### PR TITLE
Teva 1602 rename tvs parameter store

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,10 +52,10 @@ jobs:
         AWS_REGION: eu-west-2
       run: |
         gem install aws-sdk-ssm --no-document
-        bin/run-in-env -t /tvs/staging -o quiet \
-          && echo Data in /tvs/staging looks valid
-        bin/run-in-env -t /tvs/production -o quiet \
-          && echo Data in /tvs/production looks valid
+        bin/run-in-env -t /teaching-vacancies/staging -o quiet \
+          && echo Data in /teaching-vacancies/staging looks valid
+        bin/run-in-env -t /teaching-vacancies/production -o quiet \
+          && echo Data in /teaching-vacancies/production looks valid
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1

--- a/.github/workflows/deploy_app.yml
+++ b/.github/workflows/deploy_app.yml
@@ -56,8 +56,8 @@ jobs:
         AWS_REGION: eu-west-2
       run: |
         gem install aws-sdk-ssm --no-document
-        bin/run-in-env -t /tvs/${{ env.PARAMETER_STORE_ENVIRONMENT }} -o quiet \
-          && echo Data in /tvs/${{ env.PARAMETER_STORE_ENVIRONMENT }} looks valid
+        bin/run-in-env -t /teaching-vacancies/${{ env.PARAMETER_STORE_ENVIRONMENT }} -o quiet \
+          && echo Data in /teaching-vacancies/${{ env.PARAMETER_STORE_ENVIRONMENT }} looks valid
 
     - name: Deploy to environment
       env:

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -57,8 +57,8 @@ jobs:
         AWS_REGION: eu-west-2
       run: |
         gem install aws-sdk-ssm --no-document
-        bin/run-in-env -t "/tvs/${BRANCH}" -o quiet \
-          && echo Data in "/tvs/${BRANCH}" looks valid
+        bin/run-in-env -t "/teaching-vacancies/${BRANCH}" -o quiet \
+          && echo Data in "/teaching-vacancies/${BRANCH}" looks valid
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -38,8 +38,8 @@ jobs:
         AWS_REGION: eu-west-2
       run: |
         gem install aws-sdk-ssm --no-document
-        bin/run-in-env -t /tvs/dev -o quiet \
-          && echo Data in /tvs/dev looks valid
+        bin/run-in-env -t /teaching-vacancies/dev -o quiet \
+          && echo Data in /teaching-vacancies/dev looks valid
 
     - name: Terraform pin version
       uses: hashicorp/setup-terraform@v1.2.1

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -43,8 +43,8 @@ jobs:
         AWS_REGION: eu-west-2
       run: |
         gem install aws-sdk-ssm --no-document
-        bin/run-in-env -t /tvs/dev -o quiet \
-          && echo Data in /tvs/dev looks valid
+        bin/run-in-env -t /teaching-vacancies/dev -o quiet \
+          && echo Data in /teaching-vacancies/dev looks valid
 
     - name: Terraform pin version
       uses: hashicorp/setup-terraform@v1.2.1

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ LOCAL_TAG			:=dev-$(LOCAL_BRANCH)-$(LOCAL_SHA)
 .PHONY: print-env
 print-env: ## make -s local print-env > .env
 		$(if $(env), , $(error Usage: make <env> print-env))
-		@bin/run-in-env -t /tvs/dev/app -y terraform/workspace-variables/$(env)_app_env.yml \
+		@bin/run-in-env -t /teaching-vacancies/dev/app -y terraform/workspace-variables/$(env)_app_env.yml \
 			$(local_override) -o env_stdout $(local_filter)
 
 ##@ Set environment and corresponding configuration

--- a/documentation/api-keys.md
+++ b/documentation/api-keys.md
@@ -7,7 +7,7 @@ In order to manage API keys:
 1. Go to the API Keys tab on the sidebar
 1. Filter by API Key
 1. Create new API key
-1. Update ALGOLIA_WRITE_API_KEY in [AWS Systems Manager Parameter Store](https://eu-west-2.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-2&tab=Table) `/tvs/<env>/app/secrets` files
+1. Update ALGOLIA_WRITE_API_KEY in [AWS Systems Manager Parameter Store](https://eu-west-2.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-2&tab=Table) `/teaching-vacancies/<env>/app/secrets` files
 1. Rolling restart the application
 1. Delete the old API key
 
@@ -29,7 +29,7 @@ The secret_key_base is used as the input secret to the application's key generat
 In order to generate a new secret key:
 1. Run the `rails secret` task from the repo, it will generate a new secret key
 1. You need to generate a different key per environment
-1. Update `SECRET_KEY_BASE` in in [AWS Systems Manager Parameter Store](https://eu-west-2.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-2&tab=Table) `/tvs/<env>/app/secrets` files
+1. Update `SECRET_KEY_BASE` in in [AWS Systems Manager Parameter Store](https://eu-west-2.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-2&tab=Table) `/teaching-vacancies/<env>/app/secrets` files
 
 ### ROLLBAR_ACCESS_TOKEN
 Used to report server-side errors to Rollbar.
@@ -38,14 +38,14 @@ Used to report server-side errors to Rollbar.
 1. Select `Yes, disable this token` and click `Save`
 1. Click `Create a new access token`
 1. Select `post_server_item` and click `Save`
-1. Update `ROLLBAR_ACCESS_TOKEN` in [AWS Systems Manager Parameter Store](https://eu-west-2.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-2&tab=Table) `/tvs/<env>/app/secrets` files
+1. Update `ROLLBAR_ACCESS_TOKEN` in [AWS Systems Manager Parameter Store](https://eu-west-2.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-2&tab=Table) `/teaching-vacancies/<env>/app/secrets` files
 
 ### ROLLBAR_CLIENT_ERRORS_ACCESS_TOKEN
 Used to report client-side errors to Rollbar.
 1. Access https://rollbar.com/
 1. Navigate to: Setting > Project access tokens > Create a new access token
 1. Select `post_client_item` and click Save
-1. Update `ROLLBAR_ACCESSROLLBAR_CLIENT_ERRORS_ACCESS_TOKEN_TOKEN` in [AWS Systems Manager Parameter Store](https://eu-west-2.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-2&tab=Table) `/tvs/<env>/app/secrets` files
+1. Update `ROLLBAR_ACCESSROLLBAR_CLIENT_ERRORS_ACCESS_TOKEN_TOKEN` in [AWS Systems Manager Parameter Store](https://eu-west-2.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-2&tab=Table) `/teaching-vacancies/<env>/app/secrets` files
 
 ### DFE_SIGN_IN_PASSWORD and DFE_SIGN_IN_SECRET
 * DFE_SIGN_IN_PASSWORD is used to encrypt JWT tokens to authorise a user with DFE sign-in.
@@ -56,7 +56,7 @@ In order to update the password you need to have access to the DSI Manage consol
 __Once you are inside:__
 1. Follow the `Service configuration` link
 1. Regenerate the `Client secret` (`DFE_SIGN_IN_SECRET` env variable) and `API secret` (`DFE_SIGN_IN_PASSWORD` env variable)
-1. Update `DFE_SIGN_IN_SECRET` and `DFE_SIGN_IN_PASSWORD` in [AWS Systems Manager Parameter Store](https://eu-west-2.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-2&tab=Table) `/tvs/<env>/app/secrets` files
+1. Update `DFE_SIGN_IN_SECRET` and `DFE_SIGN_IN_PASSWORD` in [AWS Systems Manager Parameter Store](https://eu-west-2.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-2&tab=Table) `/teaching-vacancies/<env>/app/secrets` files
 
 ### Google API Keys
 There are several different API keys in use in different environments. There are keys for Google Maps, as well as service accounts for Google Analytics, BigQuery and Google Drive.
@@ -82,7 +82,7 @@ __NOTE: Keys with `JSON` in the name are `JSON` objects, not simple strings. The
 1. Select the API and access level for the key
 1. Create one key per API and enviroment and use the minimum necessary permission(s) for that key
 1. Click 'Save'
-1. Copy your new key from the table and update it in [AWS Systems Manager Parameter Store](https://eu-west-2.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-2&tab=Table) `/tvs/<env>/app/secrets` files
+1. Copy your new key from the table and update it in [AWS Systems Manager Parameter Store](https://eu-west-2.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-2&tab=Table) `/teaching-vacancies/<env>/app/secrets` files
 1. Do a rolling restart on the updated environment for the application
 1. Check that everything works as expected
 1. Delete the old API key from the Credentials table in the Google Cloud console
@@ -103,7 +103,7 @@ __NOTE: Keys with `JSON` in the name are `JSON` objects, not simple strings. The
     jq -c . teacher-vacancy-service-<some UID>.json | pbcopy
     ```
 1. Copy the full body of the new key as a json string (not necessary if you used `...| pbcopy` in the `jq` example, above)
-1. Paste the full string of the new key in [AWS Systems Manager Parameter Store](https://eu-west-2.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-2&tab=Table) `/tvs/<env>/app/BIG_QUERY_API_JSON_KEY` or `/tvs/<env>/app/GOOGLE_API_JSON_KEY` files
+1. Paste the full string of the new key in [AWS Systems Manager Parameter Store](https://eu-west-2.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-2&tab=Table) `/teaching-vacancies/<env>/app/BIG_QUERY_API_JSON_KEY` or `/teaching-vacancies/<env>/app/GOOGLE_API_JSON_KEY` files
 1. Do a rolling restart on the updated environment for the application
 1. Check that everything works as expected
 1. Delete the old key from the 'Keys' section in the Service Account window
@@ -128,7 +128,7 @@ To create a new key:
 1. Connect to https://developer.ordnancesurvey.co.uk/
 1. Navigate to My Keys > Add a new key
 1. Enter key name, select `OS Names API` and click `Save Key`
-1. Update `ORDNANCE_SURVEY_API_KEY` in in [AWS Systems Manager Parameter Store](https://eu-west-2.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-2&tab=Table) `/tvs/<env>/app/secrets` files
+1. Update `ORDNANCE_SURVEY_API_KEY` in in [AWS Systems Manager Parameter Store](https://eu-west-2.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-2&tab=Table) `/teaching-vacancies/<env>/app/secrets` files
 
 ### SKYLIGHT_AUTHENTICATION
 Used by the app to report performance data to [Skylight](https://www.skylight.io/).
@@ -141,4 +141,4 @@ Used to integrate with the GovUK Notify API.
 1. Click `Revoke` on the old key
 1. Click Create an API key
 1. Add a specific name, select the type of key and click `Continue`
-1. Update `NOTIFY_KEY` in in [AWS Systems Manager Parameter Store](https://eu-west-2.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-2&tab=Table) `/tvs/<env>/app/secrets` files
+1. Update `NOTIFY_KEY` in in [AWS Systems Manager Parameter Store](https://eu-west-2.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-2&tab=Table) `/teaching-vacancies/<env>/app/secrets` files

--- a/terraform/app/data.tf
+++ b/terraform/app/data.tf
@@ -1,3 +1,3 @@
 data aws_ssm_parameter infra_secrets {
-  name = "/tvs/${var.parameter_store_environment}/infra/secrets"
+  name = "/${local.service_name}/${var.parameter_store_environment}/infra/secrets"
 }

--- a/terraform/app/modules/cloudfront/main.tf
+++ b/terraform/app/modules/cloudfront/main.tf
@@ -1,7 +1,7 @@
 resource aws_cloudfront_distribution default {
   origin {
     domain_name = var.cloudfront_origin_domain_name
-    origin_id   = "${var.project_name}-${var.environment}-default-origin"
+    origin_id   = "${var.service_name}-${var.environment}-default-origin"
 
     custom_origin_config {
       origin_protocol_policy = "https-only"
@@ -13,7 +13,7 @@ resource aws_cloudfront_distribution default {
 
   origin {
     domain_name = var.offline_bucket_domain_name
-    origin_id   = "${var.project_name}-${var.environment}-offline"
+    origin_id   = "${var.service_name}-${var.environment}-offline"
   }
 
   custom_error_response {
@@ -46,7 +46,7 @@ resource aws_cloudfront_distribution default {
   default_cache_behavior {
     allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods   = ["GET", "HEAD"]
-    target_origin_id = "${var.project_name}-${var.environment}-default-origin"
+    target_origin_id = "${var.service_name}-${var.environment}-default-origin"
 
     forwarded_values {
       query_string = true
@@ -66,7 +66,7 @@ resource aws_cloudfront_distribution default {
   ordered_cache_behavior {
     allowed_methods  = ["GET", "HEAD"]
     cached_methods   = ["GET", "HEAD"]
-    target_origin_id = "${var.project_name}-${var.environment}-offline"
+    target_origin_id = "${var.service_name}-${var.environment}-offline"
 
     path_pattern = "${var.offline_bucket_origin_path}/*"
 
@@ -88,7 +88,7 @@ resource aws_cloudfront_distribution default {
   ordered_cache_behavior {
     allowed_methods  = ["GET", "HEAD"]
     cached_methods   = ["GET", "HEAD"]
-    target_origin_id = "${var.project_name}-${var.environment}-default-origin"
+    target_origin_id = "${var.service_name}-${var.environment}-default-origin"
 
     path_pattern = "/assets/*"
 
@@ -111,7 +111,7 @@ resource aws_cloudfront_distribution default {
   ordered_cache_behavior {
     allowed_methods  = ["GET", "HEAD"]
     cached_methods   = ["GET", "HEAD"]
-    target_origin_id = "${var.project_name}-${var.environment}-default-origin"
+    target_origin_id = "${var.service_name}-${var.environment}-default-origin"
 
     path_pattern = "/api/*"
 
@@ -154,7 +154,7 @@ resource aws_cloudfront_distribution default {
   }
 
   tags = {
-    Name        = "${var.project_name}-${var.environment}"
+    Name        = "${var.service_name}-${var.environment}"
     Environment = var.environment
   }
 }

--- a/terraform/app/modules/cloudfront/variables.tf
+++ b/terraform/app/modules/cloudfront/variables.tf
@@ -1,7 +1,7 @@
 variable environment {
 }
 
-variable project_name {
+variable service_name {
 }
 
 variable cloudfront_enable_standard_logs {
@@ -45,7 +45,7 @@ locals {
   route53_zones                = toset(var.route53_zones)
   route53_zones_with_a_records = var.is_production ? local.route53_zones : toset([])
   route53_zones_with_cnames    = local.route53_zones
-  cloudfront_cert_cn           = "${var.project_name}.service.gov.uk"
+  cloudfront_cert_cn           = "${var.service_name}.service.gov.uk"
   domain                       = var.is_production ? local.cloudfront_cert_cn : "${var.environment}.${local.cloudfront_cert_cn}"
   cloudfront_aliases_cnames    = [for zone in var.route53_zones : "${var.route53_cname_record}.${zone}"]
   cloudfront_aliases           = concat(var.route53_a_records, local.cloudfront_aliases_cnames)

--- a/terraform/app/modules/cloudwatch/main.tf
+++ b/terraform/app/modules/cloudwatch/main.tf
@@ -2,7 +2,7 @@ data aws_caller_identity current {
 }
 
 resource aws_sns_topic cloudwatch_alerts {
-  name = "${var.project_name}-${var.environment}-cloudwatch-alerts"
+  name = "${var.service_name}-${var.environment}-cloudwatch-alerts"
 }
 
 resource aws_sns_topic_policy sns_cloudwatch_alerts {
@@ -15,28 +15,28 @@ data template_file sns_cloudwatch_alerts_policy {
   template = file("${path.module}/../../policies/sns-policy.json")
 
   vars = {
-    policy_id      = "${var.project_name}-${var.environment}-cloudwatch-alerts-policy"
+    policy_id      = "${var.service_name}-${var.environment}-cloudwatch-alerts-policy"
     sns_arn        = aws_sns_topic.cloudwatch_alerts.arn
     aws_account_id = data.aws_caller_identity.current.account_id
   }
 }
 
 resource aws_kms_key cloudwatch_lambda {
-  description             = "${var.project_name} ${var.environment} cloudwatch lambda kms key"
+  description             = "${var.service_name} ${var.environment} cloudwatch lambda kms key"
   deletion_window_in_days = 10
 }
 
 resource aws_kms_alias lambda {
-  name          = "alias/${var.project_name}-${var.environment}-cloudwatch-lambda"
+  name          = "alias/${var.service_name}-${var.environment}-cloudwatch-lambda"
   target_key_id = aws_kms_key.cloudwatch_lambda.key_id
 }
 
 resource aws_cloudwatch_log_group cloudwatch_lambda_log_group {
-  name = "/aws/lambda/${var.project_name}-${var.environment}-cloudwatch_to_slack_opsgenie"
+  name = "/aws/lambda/${var.service_name}-${var.environment}-cloudwatch_to_slack_opsgenie"
 }
 
 resource aws_iam_role slack_lambda_role {
-  name = "${var.project_name}-${var.environment}-slack-lambda-role"
+  name = "${var.service_name}-${var.environment}-slack-lambda-role"
   assume_role_policy = file(
     "${path.module}/../../policies/cloudwatch-slack-lambda-role.json",
   )
@@ -54,14 +54,14 @@ data template_file slack_lambda_policy {
 }
 
 resource aws_iam_role_policy slack_lambda_policy {
-  name   = "${var.project_name}-${var.environment}-slack-lambda-policy"
+  name   = "${var.service_name}-${var.environment}-slack-lambda-policy"
   role   = aws_iam_role.slack_lambda_role.id
   policy = data.template_file.slack_lambda_policy.rendered
 }
 
 resource aws_lambda_function cloudwatch_to_slack {
   filename      = "${path.module}/../../lambda/lambda_cloudwatch_to_slack_opsgenie_payload.zip"
-  function_name = "${var.project_name}-${var.environment}-cloudwatch_to_slack_opsgenie"
+  function_name = "${var.service_name}-${var.environment}-cloudwatch_to_slack_opsgenie"
   role          = aws_iam_role.slack_lambda_role.arn
   handler       = "lambda_function.lambda_handler"
   source_code_hash = filebase64sha256(
@@ -93,4 +93,3 @@ resource aws_lambda_permission with_sns {
   principal     = "sns.amazonaws.com"
   source_arn    = aws_sns_topic.cloudwatch_alerts.arn
 }
-

--- a/terraform/app/modules/cloudwatch/variables.tf
+++ b/terraform/app/modules/cloudwatch/variables.tf
@@ -1,7 +1,7 @@
 variable environment {
 }
 
-variable project_name {
+variable service_name {
 }
 
 variable slack_hook_url {
@@ -12,4 +12,3 @@ variable slack_channel {
 
 variable ops_genie_api_key {
 }
-

--- a/terraform/app/modules/paas/data.tf
+++ b/terraform/app/modules/paas/data.tf
@@ -1,13 +1,13 @@
 data aws_ssm_parameter app_env_api_key_big_query {
-  name = "/tvs/${var.parameter_store_environment}/app/BIG_QUERY_API_JSON_KEY"
+  name = "/${var.service_name}/${var.parameter_store_environment}/app/BIG_QUERY_API_JSON_KEY"
 }
 
 data aws_ssm_parameter app_env_api_key_google {
-  name = "/tvs/${var.parameter_store_environment}/app/GOOGLE_API_JSON_KEY"
+  name = "/${var.service_name}/${var.parameter_store_environment}/app/GOOGLE_API_JSON_KEY"
 }
 
 data aws_ssm_parameter app_env_secrets {
-  name = "/tvs/${var.parameter_store_environment}/app/secrets"
+  name = "/${var.service_name}/${var.parameter_store_environment}/app/secrets"
 }
 
 data cloudfoundry_org org {

--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -34,12 +34,11 @@ variable parameter_store_environment {
 variable postgres_service_plan {
 }
 
-variable project_name {
-}
-
 variable redis_service_plan {
 }
 
+variable service_name {
+}
 variable space_name {
 }
 
@@ -102,10 +101,10 @@ locals {
     local.app_cloudfoundry_service_instances,
     local.app_user_provided_service_bindings
   )
-  papertrail_service_name  = "${var.project_name}-papertrail-${var.environment}"
-  postgres_service_name    = "${var.project_name}-postgres-${var.environment}"
-  redis_service_name       = "${var.project_name}-redis-${var.environment}"
-  web_app_name             = "${var.project_name}-${var.environment}"
+  papertrail_service_name  = "${var.service_name}-papertrail-${var.environment}"
+  postgres_service_name    = "${var.service_name}-postgres-${var.environment}"
+  redis_service_name       = "${var.service_name}-redis-${var.environment}"
+  web_app_name             = "${var.service_name}-${var.environment}"
   worker_app_start_command = "bundle exec sidekiq -C config/sidekiq.yml"
-  worker_app_name          = "${var.project_name}-worker-${var.environment}"
+  worker_app_name          = "${var.service_name}-worker-${var.environment}"
 }

--- a/terraform/app/modules/statuscake/variables.tf
+++ b/terraform/app/modules/statuscake/variables.tf
@@ -1,7 +1,7 @@
 variable environment {
 }
 
-variable project_name {
+variable service_name {
 }
 
 variable statuscake_alerts {

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -41,7 +41,7 @@ module cloudfront {
   source                          = "./modules/cloudfront"
   for_each                        = var.distribution_list
   environment                     = var.environment
-  project_name                    = var.project_name
+  service_name                    = local.service_name
   cloudfront_origin_domain_name   = each.value.cloudfront_origin_domain_name
   offline_bucket_domain_name      = each.value.offline_bucket_domain_name
   offline_bucket_origin_path      = each.value.offline_bucket_origin_path
@@ -60,7 +60,7 @@ module cloudwatch {
   source            = "./modules/cloudwatch"
   for_each          = var.channel_list
   environment       = var.environment
-  project_name      = var.project_name
+  service_name      = local.service_name
   slack_hook_url    = local.infra_secrets.cloudwatch_slack_hook_url
   slack_channel     = each.value.cloudwatch_slack_channel
   ops_genie_api_key = local.infra_secrets.cloudwatch_ops_genie_api_key
@@ -79,7 +79,7 @@ module paas {
   papertrail_url                    = local.infra_secrets.papertrail_url
   papertrail_service_binding_enable = var.paas_papertrail_service_binding_enable
   parameter_store_environment       = var.parameter_store_environment
-  project_name                      = var.project_name
+  service_name                      = local.service_name
   postgres_service_plan             = var.paas_postgres_service_plan
   redis_service_plan                = var.paas_redis_service_plan
   space_name                        = var.paas_space_name
@@ -99,6 +99,6 @@ module statuscake {
   source = "./modules/statuscake"
 
   environment       = var.environment
-  project_name      = var.project_name
+  service_name      = local.service_name
   statuscake_alerts = var.statuscake_alerts
 }

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -1,7 +1,3 @@
-variable project_name {
-  description = "This name will be used to identify all AWS resources. The workspace name will be suffixed. Alphanumeric characters only due to RDS."
-}
-
 variable region {
   default = "eu-west-2"
 }
@@ -140,6 +136,7 @@ locals {
   is_production        = var.environment == "production"
   route53_a_records    = local.is_production ? var.route53_zones : []
   route53_cname_record = local.is_production ? "www" : var.environment
+  service_name         = "teaching-vacancies"
   hostname_domain_map = {
     for zone in var.route53_zones :
     "${local.route53_cname_record}.${zone}" => {

--- a/terraform/common/iam.tf
+++ b/terraform/common/iam.tf
@@ -5,7 +5,7 @@
 
 resource aws_iam_user deploy {
   name = "deploy"
-  path = "/tvs/"
+  path = "/${local.service_name}/"
 }
 
 resource aws_iam_access_key deploy {
@@ -14,7 +14,7 @@ resource aws_iam_access_key deploy {
 
 resource aws_iam_user bigquery {
   name = "bigquery"
-  path = "/tvs/"
+  path = "/${local.service_name}/"
 }
 
 resource aws_iam_access_key bigquery {

--- a/terraform/common/variables.tf
+++ b/terraform/common/variables.tf
@@ -7,4 +7,5 @@ locals {
   aws_canonical_user_id_awslogsdelivery = "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0"
   primary_zone_name                     = "teaching-vacancies.service.gov.uk"
   secondary_zone_name                   = "teaching-jobs.service.gov.uk"
+  service_name                          = "teaching-vacancies"
 }

--- a/terraform/monitoring/data.tf
+++ b/terraform/monitoring/data.tf
@@ -4,5 +4,5 @@ data cloudfoundry_space monitoring {
 }
 
 data aws_ssm_parameter monitoring_secrets {
-  name = "/tvs/production/infra/monitoring"
+  name = "/${local.service_name}/production/infra/monitoring"
 }

--- a/terraform/monitoring/variables.tf
+++ b/terraform/monitoring/variables.tf
@@ -3,11 +3,12 @@ variable paas_user { default = null }
 variable paas_password { default = null }
 
 locals {
-  monitoring_instance_name = "teaching-vacancies"
+  service_name             = "teaching-vacancies"
+  monitoring_instance_name = local.service_name
   paas_api_url             = "https://api.london.cloud.service.gov.uk"
   monitoring_org_name      = "dfe-teacher-services"
-  space_name               = "teaching-vacancies-monitoring"
-  monitoring_space_name    = "teaching-vacancies-monitoring"
+  space_name               = "${local.service_name}-monitoring"
+  monitoring_space_name    = "${local.service_name}-monitoring"
   aws_region               = "eu-west-2"
   secrets                  = yamldecode(data.aws_ssm_parameter.monitoring_secrets.value)
 }

--- a/terraform/workspace-variables/dev.tfvars
+++ b/terraform/workspace-variables/dev.tfvars
@@ -1,6 +1,5 @@
 # Platform
 region                      = "eu-west-2"
-project_name                = "teaching-vacancies"
 environment                 = "dev"
 app_environment             = "dev"
 parameter_store_environment = "dev"

--- a/terraform/workspace-variables/production.tfvars
+++ b/terraform/workspace-variables/production.tfvars
@@ -1,6 +1,5 @@
 # Platform
 region                      = "eu-west-2"
-project_name                = "teaching-vacancies"
 environment                 = "production"
 app_environment             = "production"
 parameter_store_environment = "production"

--- a/terraform/workspace-variables/review.tfvars
+++ b/terraform/workspace-variables/review.tfvars
@@ -1,6 +1,5 @@
 # Platform
 region                      = "eu-west-2"
-project_name                = "teaching-vacancies"
 parameter_store_environment = "dev"
 app_environment             = "review"
 #environment                 = "review"  # For review, pass in TF_VAR_environment=review-pr-[PR number]

--- a/terraform/workspace-variables/staging.tfvars
+++ b/terraform/workspace-variables/staging.tfvars
@@ -1,6 +1,5 @@
 # Platform
 region                      = "eu-west-2"
-project_name                = "teaching-vacancies"
 environment                 = "staging"
 app_environment             = "staging"
 parameter_store_environment = "staging"

--- a/terraform/workspace-variables/workspace.tfvars.example
+++ b/terraform/workspace-variables/workspace.tfvars.example
@@ -1,6 +1,6 @@
 # Platform
 region                      = "eu-west-2"
-project_name                = "teaching-vacancies"
+service_name                = "teaching-vacancies"
 parameter_store_environment = "staging"
 
 # CloudFront


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1602

## Changes in this PR:

- Rename `tvs` with `teaching-vacancies`
- Rename `project_name` with `service_name`
- Add `teaching-vacancies` as a local in the root Terraform, and remove from per-environment configuration
- Update Makefile target for creation of local `.env` file
- Update documentation on API keys

## Next steps:

Implementation
- [x] Create new parameters, prefixed with `teaching-vacancies`
- [x] Run terraform plan actions against `dev`, `staging`, `production`, `monitoring`
- [ ] Merge PR

Post-merge:
- [ ] Wait for successful runs using new parameter names (terraform's data resource will complain if removed while tracking the state)
- [ ] Remove parameters with old name