### PR TITLE
[TEVA-1559] Create 'sign in' and 'your account' links under "For job seekers" section on service start-page

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -66,10 +66,15 @@
               %div.govuk-grid-column-one-third
                 %h2.govuk-heading-m
                   = t('footer.for_job_seekers')
-                %ul.govuk-footer__inline-list
-                  %li.govuk-footer__inline-list-item
+                %ul.govuk-footer__inline-list.hide-bullet-points
+                  %li.govuk-footer-list-item
                     =link_to t('footer.search_teaching_vacancies'), root_url, class: 'govuk-footer__link'
-
+                  - if JobseekerAccountsFeature.enabled? && !authenticated?
+                    %li.govuk-footer-list-item
+                      - if jobseeker_signed_in?
+                        =link_to t('footer.your_account'), jobseekers_account_path, class: 'govuk-footer__link'
+                      - else
+                        =link_to t('footer.sign_in'), new_jobseeker_session_path, class: 'govuk-footer__link'
               %div.govuk-grid-column-one-third
                 %h2.govuk-heading-m
                   = t('footer.for_schools')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -144,7 +144,9 @@ en:
     request_support: Report problems via email
     search_teaching_vacancies: Find a teaching job
     service_support: Service support
+    sign_in: Sign in
     updates: Updates
+    your_account: Your account
 
   general_feedback:
     new:

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,6 +65,7 @@ RSpec.configure do |config|
   config.include AuthHelpers
   config.include CapybaraHelper, type: :system
   config.include DatesHelper
+  config.include Devise::Test::ControllerHelpers, type: :controller
   config.include FactoryBot::Syntax::Methods
   config.include OrganisationHelper
   config.include SearchHelper

--- a/spec/support/auth_helpers.rb
+++ b/spec/support/auth_helpers.rb
@@ -100,7 +100,7 @@ module AuthHelpers
 
   def sign_in_user
     within(".govuk-header__navigation.mobile-header-top-border") { click_on(I18n.t("nav.sign_in")) }
-    click_on(I18n.t("sign_in.link"))
+    within("form") { click_on(I18n.t("sign_in.link")) }
   end
 
   def sign_out_via_dsi


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1559

## Changes in this PR:

- Added links to the 'for job seekers' section on the service start page