### PR TITLE
Strip whitespaces when looking up LocationPolygons

### DIFF
--- a/app/models/location_polygon.rb
+++ b/app/models/location_polygon.rb
@@ -5,6 +5,7 @@ class LocationPolygon < ApplicationRecord
   scope :regions, -> { where(location_type: "regions") }
 
   def self.with_name(location)
+    location.strip!
     find_by(name: (MAPPED_LOCATIONS[location.downcase].presence || location).downcase)
   end
 end

--- a/spec/models/location_polygon_spec.rb
+++ b/spec/models/location_polygon_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe LocationPolygon, type: :model do
+  before do
+    stub_const("MAPPED_LOCATIONS", mapped_locations)
+    LocationPolygon.create(name: "london")
+  end
+
+  let(:mapped_locations) { { "the big smoke" => "London" } }
+
+  describe ".with_name?" do
+    it "translates the user-input name into the name of our LocationPolygon and retrieves that record" do
+      expect(described_class.with_name("the big smoke").name).to eq("london")
+    end
+
+    context "when the search query has a preceding or trailing whitespace" do
+      it "strips the whitespace before retrieving the requested record" do
+        expect(described_class.with_name(" the big smoke ").name).to eq("london")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently, 'london' searches a polygon and 'london ' searches a point.


Compare "90 jobs found near 'London '" and "134 jobs found in 'London'". The former fails to use a polygon because of the trailing whitespace.

This has also been messing up searches in Birmingham (127 counts of searching with a whitespace), Manchester, Liverpool, Sheffield, etc.

In our sample, there were 168 searches for "london " and 6376 for "london"

