### PR TITLE
Rename concept of "user" to "publisher"

### DIFF
--- a/app/controllers/hiring_staff/base_controller.rb
+++ b/app/controllers/hiring_staff/base_controller.rb
@@ -20,32 +20,32 @@ class HiringStaff::BaseController < ApplicationController
   end
 
   def check_terms_and_conditions
-    redirect_to terms_and_conditions_path unless current_user&.accepted_terms_and_conditions?
+    redirect_to terms_and_conditions_path unless current_publisher&.accepted_terms_and_conditions?
   end
 
-  def current_user
+  def current_publisher
     return if current_session_id.blank?
 
-    @current_user ||= User.find_or_create_by(oid: current_session_id)
+    @current_publisher ||= Publisher.find_or_create_by(oid: current_session_id)
   end
 
-  def current_user_preferences
+  def current_publisher_preferences
     return unless current_organisation.is_a?(SchoolGroup)
 
-    UserPreference.find_by(user_id: current_user.id, school_group_id: current_organisation.id)
+    PublisherPreference.find_by(publisher_id: current_publisher.id, school_group_id: current_organisation.id)
   end
 
   def check_user_last_activity_at
-    return redirect_to logout_endpoint if current_user&.last_activity_at.blank?
+    return redirect_to logout_endpoint if current_publisher&.last_activity_at.blank?
 
-    if Time.current > (current_user.last_activity_at + TIMEOUT_PERIOD)
+    if Time.current > (current_publisher.last_activity_at + TIMEOUT_PERIOD)
       session[:signing_out_for_inactivity] = true
       redirect_to logout_endpoint
     end
   end
 
   def update_user_last_activity_at
-    current_user&.update(last_activity_at: Time.current)
+    current_publisher&.update(last_activity_at: Time.current)
   end
 
   def logout_endpoint
@@ -56,7 +56,7 @@ class HiringStaff::BaseController < ApplicationController
     url.to_s
   end
 
-  def redirect_signed_in_users
+  def redirect_signed_in_publishers
     redirect_to organisation_path if current_organisation.present?
   end
 

--- a/app/controllers/hiring_staff/identifications_controller.rb
+++ b/app/controllers/hiring_staff/identifications_controller.rb
@@ -4,7 +4,7 @@ class HiringStaff::IdentificationsController < HiringStaff::BaseController
   skip_before_action :check_terms_and_conditions, only: %i[new create]
   skip_before_action :verify_authenticity_token, only: %i[create]
 
-  before_action :redirect_signed_in_users, only: %i[new create]
+  before_action :redirect_signed_in_publishers, only: %i[new create]
   before_action :redirect_for_fallback_authentication, only: %i[new create]
 
   def new; end

--- a/app/controllers/hiring_staff/organisations/managed_organisations_controller.rb
+++ b/app/controllers/hiring_staff/organisations/managed_organisations_controller.rb
@@ -30,7 +30,7 @@ private
   end
 
   def vacancy_filter
-    @vacancy_filter ||= HiringStaff::VacancyFilter.new(current_user, current_school_group)
+    @vacancy_filter ||= HiringStaff::VacancyFilter.new(current_publisher, current_school_group)
   end
 
   def set_organisation_options

--- a/app/controllers/hiring_staff/organisations_controller.rb
+++ b/app/controllers/hiring_staff/organisations_controller.rb
@@ -5,7 +5,7 @@ class HiringStaff::OrganisationsController < HiringStaff::BaseController
     @multiple_organisations = session_has_multiple_organisations?
     @organisation = current_organisation
     @sort = VacancySort.new.update(column: sort_column, order: sort_order)
-    @filters = HiringStaff::VacancyFilter.new(current_user, current_school_group).to_h
+    @filters = HiringStaff::VacancyFilter.new(current_publisher, current_school_group).to_h
     @managed_organisations_form = ManagedOrganisationsForm.new(@filters)
     @selected_type = params[:type]
     @awaiting_feedback_count = @organisation.vacancies.awaiting_feedback.count
@@ -19,7 +19,7 @@ class HiringStaff::OrganisationsController < HiringStaff::BaseController
 private
 
   def redirect_to_user_preferences
-    if current_organisation.is_a?(SchoolGroup) && current_user_preferences.nil?
+    if current_organisation.is_a?(SchoolGroup) && current_publisher_preferences.nil?
       redirect_to organisation_managed_organisations_path
     end
   end

--- a/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
+++ b/app/controllers/hiring_staff/sign_in/dfe/sessions_controller.rb
@@ -141,7 +141,7 @@ private
   end
 
   def use_school_group_if_available
-    user = User.find_by(email: identifier)
+    user = Publisher.find_by(email: identifier)
     user_trusts = user&.dsi_data&.fetch("trust_uids", [])
     user_local_authorities = user&.dsi_data&.fetch("la_codes", [])
     return unless user_trusts&.any? || user_local_authorities&.any?

--- a/app/controllers/hiring_staff/terms_and_conditions_controller.rb
+++ b/app/controllers/hiring_staff/terms_and_conditions_controller.rb
@@ -8,7 +8,7 @@ class HiringStaff::TermsAndConditionsController < HiringStaff::BaseController
   def update
     @terms_and_conditions_form = TermsAndConditionsForm.new(terms_params)
     if @terms_and_conditions_form.valid?
-      current_user.update(accepted_terms_at: Time.current)
+      current_publisher.update(accepted_terms_at: Time.current)
       audit_toc_acceptance
       redirect_to organisation_path
     else
@@ -23,6 +23,6 @@ private
   end
 
   def audit_toc_acceptance
-    Auditor::Audit.new(current_user, "user.terms_and_conditions.accept", current_session_id).log
+    Auditor::Audit.new(current_publisher, "user.terms_and_conditions.accept", current_session_id).log
   end
 end

--- a/app/controllers/hiring_staff/vacancies/publish_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/publish_controller.rb
@@ -4,7 +4,7 @@ class HiringStaff::Vacancies::PublishController < HiringStaff::Vacancies::Applic
   def create
     if @vacancy.published?
       redirect_to organisation_job_path(@vacancy.id), notice: I18n.t("messages.jobs.already_published")
-    elsif all_steps_valid? && PublishVacancy.new(@vacancy, current_user, current_organisation).call
+    elsif all_steps_valid? && PublishVacancy.new(@vacancy, current_publisher, current_organisation).call
       audit_publish_vacancy
       redirect_to organisation_job_summary_path(@vacancy.id)
     else

--- a/app/controllers/hiring_staff/vacancies/vacancy_publish_feedback_controller.rb
+++ b/app/controllers/hiring_staff/vacancies/vacancy_publish_feedback_controller.rb
@@ -12,7 +12,7 @@ class HiringStaff::Vacancies::VacancyPublishFeedbackController < HiringStaff::Va
 
   def create
     @feedback = VacancyPublishFeedback.create(
-      vacancy_publish_feedback_params.merge(vacancy: @vacancy, user: current_user),
+      vacancy_publish_feedback_params.merge(vacancy: @vacancy, publisher: current_publisher),
     )
 
     return render "new" unless @feedback.save

--- a/app/form_models/managed_organisations_form.rb
+++ b/app/form_models/managed_organisations_form.rb
@@ -16,6 +16,6 @@ private
   def at_least_one_option_selected
     return if managed_organisations.present? || managed_school_ids.any?
 
-    errors.add(:managed_organisations, I18n.t("hiring_staff_user_preference_errors.managed_organisations.blank"))
+    errors.add(:managed_organisations, I18n.t("hiring_staff_publisher_preference_errors.managed_organisations.blank"))
   end
 end

--- a/app/jobs/send_expired_vacancy_feedback_email_job.rb
+++ b/app/jobs/send_expired_vacancy_feedback_email_job.rb
@@ -2,10 +2,10 @@ class SendExpiredVacancyFeedbackEmailJob < ApplicationJob
   queue_as :email_feedback_prompt
 
   def perform
-    expired_vacancies.group_by(&:publisher_user).each do |user, users_vacancies|
-      unless user.email.nil?
-        FeedbackPromptMailer.prompt_for_feedback(user.email, users_vacancies).deliver_later
-        Rails.logger.info("Sidekiq: Sending feedback prompt emails for #{users_vacancies.count} vacancies")
+    expired_vacancies.group_by(&:publisher).each do |publisher, publisher_vacancies|
+      unless publisher.email.nil?
+        FeedbackPromptMailer.prompt_for_feedback(publisher.email, publisher_vacancies).deliver_later
+        Rails.logger.info("Sidekiq: Sending feedback prompt emails for #{publisher_vacancies.count} vacancies")
       end
     end
   end
@@ -14,6 +14,6 @@ private
 
   def expired_vacancies
     Vacancy.where(expires_on: Time.current - 2.weeks, hired_status: nil)
-           .where.not(publisher_user: nil)
+           .where.not(publisher: nil)
   end
 end

--- a/app/models/emergency_login_key.rb
+++ b/app/models/emergency_login_key.rb
@@ -1,5 +1,5 @@
 class EmergencyLoginKey < ApplicationRecord
-  belongs_to :user
+  belongs_to :publisher
   validates :not_valid_after, presence: true
 
   def expired?

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -1,4 +1,4 @@
-class User < ApplicationRecord
+class Publisher < ApplicationRecord
   include Auditor::Model
 
   has_many :emergency_login_keys

--- a/app/models/publisher_preference.rb
+++ b/app/models/publisher_preference.rb
@@ -1,0 +1,4 @@
+class PublisherPreference < ApplicationRecord
+  belongs_to :publisher
+  belongs_to :school_group, optional: true
+end

--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -1,4 +1,0 @@
-class UserPreference < ApplicationRecord
-  belongs_to :user
-  belongs_to :school_group, optional: true
-end

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -39,7 +39,7 @@ class Vacancy < ApplicationRecord
     hired_dont_know: 6,
   }
 
-  belongs_to :publisher_user, class_name: "User", optional: true
+  belongs_to :publisher, optional: true
   belongs_to :publisher_organisation, class_name: "Organisation", optional: true
 
   has_one :publish_feedback, class_name: "VacancyPublishFeedback"

--- a/app/models/vacancy_publish_feedback.rb
+++ b/app/models/vacancy_publish_feedback.rb
@@ -4,7 +4,7 @@ class VacancyPublishFeedback < ApplicationRecord
   enum user_participation_response: { interested: 0, not_interested: 1 }
 
   belongs_to :vacancy
-  belongs_to :user
+  belongs_to :publisher
 
   scope :published_on, (->(date) { where(created_at: date.all_day) })
 end

--- a/app/services/get_information_from_login_key.rb
+++ b/app/services/get_information_from_login_key.rb
@@ -8,7 +8,7 @@ class GetInformationFromLoginKey
 
   def details_to_update_in_session
     { multiple_organisations: multiple_organisations?,
-      oid: @user&.oid }
+      oid: @publisher&.oid }
   end
 
   def multiple_organisations?
@@ -27,7 +27,7 @@ private
   end
 
   def process_key
-    @user = get_user
+    @publisher = get_publisher
     @schools = get_schools
     @trusts = get_trusts
     @local_authorities = get_local_authorities
@@ -35,13 +35,13 @@ private
     @reason_for_failing_sign_in = "no_orgs" if @schools.empty? && @trusts.empty? && @local_authorities.empty?
   end
 
-  def get_user
-    @key.user_id ? User.find(@key.user_id) : nil
+  def get_publisher
+    @key.publisher_id && Publisher.find(@key.publisher_id)
   end
 
   def get_schools
     scratch = []
-    @user&.dsi_data&.dig("school_urns")&.each do |urn|
+    @publisher&.dsi_data&.dig("school_urns")&.each do |urn|
       school_query = School.where(urn: urn)
       scratch.push school_query.first unless school_query.empty?
     end
@@ -50,7 +50,7 @@ private
 
   def get_trusts
     scratch = []
-    @user&.dsi_data&.dig("trust_uids")&.each do |uid|
+    @publisher&.dsi_data&.dig("trust_uids")&.each do |uid|
       school_group_query = SchoolGroup.where(uid: uid)
       scratch.push(school_group_query.first) unless school_group_query.empty?
     end
@@ -61,7 +61,7 @@ private
     return [] unless LocalAuthorityAccessFeature.enabled?
 
     scratch = []
-    @user&.dsi_data&.dig("la_codes")&.each do |la_code|
+    @publisher&.dsi_data&.dig("la_codes")&.each do |la_code|
       school_group_query = SchoolGroup.where(local_authority_code: la_code, group_type: "local_authority")
       scratch.push(school_group_query.first) unless school_group_query.empty?
     end

--- a/app/services/hiring_staff/vacancy_filter.rb
+++ b/app/services/hiring_staff/vacancy_filter.rb
@@ -1,10 +1,10 @@
 class HiringStaff::VacancyFilter
   attr_reader :managed_school_ids, :managed_organisations
 
-  def initialize(user, school_group)
-    @user_preference = UserPreference.find_or_initialize_by(user: user, school_group: school_group)
-    @managed_school_ids = @user_preference.managed_school_ids
-    @managed_organisations = @user_preference.managed_organisations
+  def initialize(publisher, school_group)
+    @publisher_preference = PublisherPreference.find_or_initialize_by(publisher: publisher, school_group: school_group)
+    @managed_school_ids = @publisher_preference.managed_school_ids
+    @managed_organisations = @publisher_preference.managed_organisations
   end
 
   def update(params)
@@ -16,7 +16,7 @@ class HiringStaff::VacancyFilter
       @managed_school_ids = []
     end
 
-    @user_preference.update(managed_organisations: managed_organisations, managed_school_ids: managed_school_ids)
+    @publisher_preference.update(managed_organisations: managed_organisations, managed_school_ids: managed_school_ids)
   end
 
   def to_h

--- a/app/services/publish_vacancy.rb
+++ b/app/services/publish_vacancy.rb
@@ -1,15 +1,15 @@
 class PublishVacancy
-  attr_accessor :current_organisation, :current_user, :vacancy
+  attr_accessor :current_organisation, :current_publisher, :vacancy
 
-  def initialize(vacancy, current_user, current_organisation)
+  def initialize(vacancy, current_publisher, current_organisation)
     @current_organisation = current_organisation
-    @current_user = current_user
+    @current_publisher = current_publisher
     @vacancy = vacancy
   end
 
   def call
     vacancy.publisher_organisation = current_organisation
-    vacancy.publisher_user = current_user
+    vacancy.publisher = current_publisher
     vacancy.status = :published
     vacancy.state = "edit_published"
     vacancy.save

--- a/app/views/hiring_staff/sign_in/email/sessions/new.html.haml
+++ b/app/views/hiring_staff/sign_in/email/sessions/new.html.haml
@@ -5,7 +5,7 @@
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-l= t('sign_in.title')
     %p= t('pages.home.signin.description')
-    = form_for User.new, url: auth_email_check_your_email_path do |f|
+    = form_for Publisher.new, url: auth_email_check_your_email_path do |f|
       = f.govuk_email_field :email
       = f.govuk_submit 'Continue', classes: 'govuk-button fallback-authentication-submit-email-gtm'
     %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -2,7 +2,7 @@ en:
   cookies_preferences_errors: &cookies_preferences_errors
     cookies_consent:
       inclusion: Please select an option
-  hiring_staff_user_preference_errors:
+  hiring_staff_publisher_preference_errors:
     managed_organisations:
       blank: Select which schools' job listings you would like to view
   job_alert_feedback: &job_alert_feedback_errors

--- a/db/migrate/20201124105900_rename_user_to_publisher.rb
+++ b/db/migrate/20201124105900_rename_user_to_publisher.rb
@@ -1,0 +1,11 @@
+class RenameUserToPublisher < ActiveRecord::Migration[6.0]
+  def change
+    rename_table :users, :publishers
+    rename_table :user_preferences, :publisher_preferences
+
+    rename_column :emergency_login_keys, :user_id, :publisher_id
+    rename_column :publisher_preferences, :user_id, :publisher_id
+    rename_column :vacancies, :publisher_user_id, :publisher_id
+    rename_column :vacancy_publish_feedbacks, :user_id, :publisher_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -67,10 +67,10 @@ ActiveRecord::Schema.define(version: 2020_11_24_120747) do
 
   create_table "emergency_login_keys", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "not_valid_after", null: false
-    t.uuid "user_id"
+    t.uuid "publisher_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_emergency_login_keys_on_user_id"
+    t.index ["publisher_id"], name: "index_emergency_login_keys_on_publisher_id"
   end
 
   create_table "friendly_id_slugs", force: :cascade do |t|
@@ -182,6 +182,26 @@ ActiveRecord::Schema.define(version: 2020_11_24_120747) do
     t.index ["urn"], name: "index_organisations_on_urn"
   end
 
+  create_table "publisher_preferences", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "managed_organisations"
+    t.uuid "publisher_id"
+    t.uuid "school_group_id"
+    t.string "managed_school_ids", array: true
+    t.index ["publisher_id"], name: "index_publisher_preferences_on_publisher_id"
+    t.index ["school_group_id"], name: "index_publisher_preferences_on_school_group_id"
+  end
+
+  create_table "publishers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "oid"
+    t.datetime "accepted_terms_at"
+    t.string "email"
+    t.jsonb "dsi_data"
+    t.datetime "last_activity_at"
+    t.string "family_name"
+    t.string "given_name"
+    t.index ["oid"], name: "index_publishers_on_oid", unique: true
+  end
+
   create_table "school_group_memberships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "school_id"
     t.uuid "school_group_id"
@@ -226,26 +246,6 @@ ActiveRecord::Schema.define(version: 2020_11_24_120747) do
     t.index ["subscription_id"], name: "index_unsubscribe_feedbacks_on_subscription_id"
   end
 
-  create_table "user_preferences", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "managed_organisations"
-    t.uuid "user_id"
-    t.uuid "school_group_id"
-    t.string "managed_school_ids", array: true
-    t.index ["school_group_id"], name: "index_user_preferences_on_school_group_id"
-    t.index ["user_id"], name: "index_user_preferences_on_user_id"
-  end
-
-  create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "oid"
-    t.datetime "accepted_terms_at"
-    t.string "email"
-    t.jsonb "dsi_data"
-    t.datetime "last_activity_at"
-    t.string "family_name"
-    t.string "given_name"
-    t.index ["oid"], name: "index_users_on_oid", unique: true
-  end
-
   create_table "vacancies", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "job_title"
     t.string "slug", null: false
@@ -274,7 +274,7 @@ ActiveRecord::Schema.define(version: 2020_11_24_120747) do
     t.integer "listed_elsewhere"
     t.integer "hired_status"
     t.datetime "stats_updated_at"
-    t.uuid "publisher_user_id"
+    t.uuid "publisher_id"
     t.datetime "expires_at"
     t.string "supporting_documents"
     t.string "salary"
@@ -295,8 +295,8 @@ ActiveRecord::Schema.define(version: 2020_11_24_120747) do
     t.index ["expires_at"], name: "index_vacancies_on_expires_at"
     t.index ["expires_on"], name: "index_vacancies_on_expires_on"
     t.index ["initially_indexed"], name: "index_vacancies_on_initially_indexed"
+    t.index ["publisher_id"], name: "index_vacancies_on_publisher_id"
     t.index ["publisher_organisation_id"], name: "index_vacancies_on_publisher_organisation_id"
-    t.index ["publisher_user_id"], name: "index_vacancies_on_publisher_user_id"
   end
 
   create_table "vacancy_publish_feedbacks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -305,18 +305,18 @@ ActiveRecord::Schema.define(version: 2020_11_24_120747) do
     t.text "comment"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "user_id"
+    t.uuid "publisher_id"
     t.string "email"
     t.integer "user_participation_response"
-    t.index ["user_id"], name: "index_vacancy_publish_feedbacks_on_user_id"
+    t.index ["publisher_id"], name: "index_vacancy_publish_feedbacks_on_publisher_id"
     t.index ["vacancy_id"], name: "index_vacancy_publish_feedbacks_on_vacancy_id", unique: true
   end
 
   add_foreign_key "documents", "vacancies"
-  add_foreign_key "emergency_login_keys", "users"
+  add_foreign_key "emergency_login_keys", "publishers"
   add_foreign_key "job_alert_feedbacks", "subscriptions"
+  add_foreign_key "publisher_preferences", "publishers"
   add_foreign_key "unsubscribe_feedbacks", "subscriptions"
-  add_foreign_key "user_preferences", "users"
   add_foreign_key "vacancies", "organisations", column: "publisher_organisation_id"
-  add_foreign_key "vacancies", "users", column: "publisher_user_id"
+  add_foreign_key "vacancies", "publishers"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -139,83 +139,83 @@ expired_two.save(validate: false)
 Vacancy.index.clear_index
 Vacancy.reindex!
 
-User.create(oid: "899808DB-9038-4779-A20A-9E47B9DB99F9",
-            email: "alex.bowen@digital.education.gov.uk",
-            dsi_data: { "school_urns" => %w[137138 144523], "trust_uids" => %w[16644], "la_codes" => %w[852] },
-            family_name: "Bowen",
-            given_name: "Alex")
+Publisher.create(oid: "899808DB-9038-4779-A20A-9E47B9DB99F9",
+                 email: "alex.bowen@digital.education.gov.uk",
+                 dsi_data: { "school_urns" => %w[137138 144523], "trust_uids" => %w[16644], "la_codes" => %w[852] },
+                 family_name: "Bowen",
+                 given_name: "Alex")
 
-User.create(oid: "B553A9A4-869B-44FA-8146-D35657EAD590",
-            email: "ben.mitchell@digital.education.gov.uk",
-            dsi_data: { "school_urns" => %w[137138 144523], "trust_uids" => %w[16644], "la_codes" => %w[852] },
-            family_name: "Mitchell",
-            given_name: "Ben")
+Publisher.create(oid: "B553A9A4-869B-44FA-8146-D35657EAD590",
+                 email: "ben.mitchell@digital.education.gov.uk",
+                 dsi_data: { "school_urns" => %w[137138 144523], "trust_uids" => %w[16644], "la_codes" => %w[852] },
+                 family_name: "Mitchell",
+                 given_name: "Ben")
 
-User.create(oid: "ED61B414-EFE4-4B32-82BC-FC9751F8443B",
-            email: "cesidio.dilanda@digital.education.gov.uk",
-            dsi_data: { "school_urns" => %w[137138 144523], "trust_uids" => %w[16644], "la_codes" => %w[852] },
-            family_name: "Di Landa",
-            given_name: "Cesidio")
+Publisher.create(oid: "ED61B414-EFE4-4B32-82BC-FC9751F8443B",
+                 email: "cesidio.dilanda@digital.education.gov.uk",
+                 dsi_data: { "school_urns" => %w[137138 144523], "trust_uids" => %w[16644], "la_codes" => %w[852] },
+                 family_name: "Di Landa",
+                 given_name: "Cesidio")
 
-User.create(oid: "5A21B414-EFE4-4B32-82BC-FC9751F841A5",
-            email: "christian.sutter@digital.education.gov.uk",
-            dsi_data: { "school_urns" => %w[137138 144523], "trust_uids" => %w[16644], "la_codes" => %w[852] },
-            family_name: "Sutter",
-            given_name: "Christian")
+Publisher.create(oid: "5A21B414-EFE4-4B32-82BC-FC9751F841A5",
+                 email: "christian.sutter@digital.education.gov.uk",
+                 dsi_data: { "school_urns" => %w[137138 144523], "trust_uids" => %w[16644], "la_codes" => %w[852] },
+                 family_name: "Sutter",
+                 given_name: "Christian")
 
-User.create(oid: "A120A4FB-B773-4336-9BB5-CDBD1C977A2E",
-            email: "chris.taylor@digital.education.gov.uk",
-            dsi_data: { "school_urns" => %w[137138 144523], "trust_uids" => %w[16644], "la_codes" => %w[852] },
-            family_name: "Taylor",
-            given_name: "Chris")
+Publisher.create(oid: "A120A4FB-B773-4336-9BB5-CDBD1C977A2E",
+                 email: "chris.taylor@digital.education.gov.uk",
+                 dsi_data: { "school_urns" => %w[137138 144523], "trust_uids" => %w[16644], "la_codes" => %w[852] },
+                 family_name: "Taylor",
+                 given_name: "Chris")
 
-User.create(oid: "421542E6-ED96-4656-B61F-A06D8D487C07",
-            email: "colin.saliceti@digital.education.gov.uk",
-            dsi_data: { "school_urns" => %w[137138 144523], "trust_uids" => %w[16644], "la_codes" => %w[852] },
-            family_name: "Saliceti",
-            given_name: "Colin")
+Publisher.create(oid: "421542E6-ED96-4656-B61F-A06D8D487C07",
+                 email: "colin.saliceti@digital.education.gov.uk",
+                 dsi_data: { "school_urns" => %w[137138 144523], "trust_uids" => %w[16644], "la_codes" => %w[852] },
+                 family_name: "Saliceti",
+                 given_name: "Colin")
 
-User.create(oid: "897A6EE6-83D2-43F2-9E71-22B106541C94",
-            email: "connor.mcquillan@digital.education.gov.uk",
-            dsi_data: { "school_urns" => %w[137138 144523], "trust_uids" => %w[16644], "la_codes" => %w[852] },
-            family_name: "McQuillan",
-            given_name: "Connor")
+Publisher.create(oid: "897A6EE6-83D2-43F2-9E71-22B106541C94",
+                 email: "connor.mcquillan@digital.education.gov.uk",
+                 dsi_data: { "school_urns" => %w[137138 144523], "trust_uids" => %w[16644], "la_codes" => %w[852] },
+                 family_name: "McQuillan",
+                 given_name: "Connor")
 
-User.create(oid: "B81FC38C-4122-4BCE-9F1D-8B1A328FA4D8",
-            email: "david.mears@digital.education.gov.uk",
-            dsi_data: { "school_urns" => %w[137138 144523], "trust_uids" => %w[16644], "la_codes" => %w[852] },
-            family_name: "Mears",
-            given_name: "David")
+Publisher.create(oid: "B81FC38C-4122-4BCE-9F1D-8B1A328FA4D8",
+                 email: "david.mears@digital.education.gov.uk",
+                 dsi_data: { "school_urns" => %w[137138 144523], "trust_uids" => %w[16644], "la_codes" => %w[852] },
+                 family_name: "Mears",
+                 given_name: "David")
 
-User.create(oid: "DF97F25C-3A3E-4655-B7D3-5CDBDCBBBC69",
-            email: "joseph.hull@digital.education.gov.uk",
-            dsi_data: { "school_urns" => %w[137138 144523], "trust_uids" => %w[16644], "la_codes" => %w[852] },
-            family_name: "Hull",
-            given_name: "Joseph")
+Publisher.create(oid: "DF97F25C-3A3E-4655-B7D3-5CDBDCBBBC69",
+                 email: "joseph.hull@digital.education.gov.uk",
+                 dsi_data: { "school_urns" => %w[137138 144523], "trust_uids" => %w[16644], "la_codes" => %w[852] },
+                 family_name: "Hull",
+                 given_name: "Joseph")
 
-User.create(oid: "CA300D6A-4FC1-4C1E-97E5-D6BD4FDB80D9",
-            email: "judith.thrasher@digital.education.gov.uk",
-            dsi_data: { "school_urns" => %w[137138 144523], "trust_uids" => %w[16644], "la_codes" => %w[852] },
-            family_name: "Thrasher",
-            given_name: "Judith")
+Publisher.create(oid: "CA300D6A-4FC1-4C1E-97E5-D6BD4FDB80D9",
+                 email: "judith.thrasher@digital.education.gov.uk",
+                 dsi_data: { "school_urns" => %w[137138 144523], "trust_uids" => %w[16644], "la_codes" => %w[852] },
+                 family_name: "Thrasher",
+                 given_name: "Judith")
 
-User.create(oid: "EC3312BA-E33B-4791-A815-4D1907DD578E",
-            email: "mili.malde@digital.education.gov.uk",
-            dsi_data: { "school_urns" => %w[137138 144523], "trust_uids" => %w[16644], "la_codes" => %w[852] },
-            family_name: "Malde",
-            given_name: "Mili")
+Publisher.create(oid: "EC3312BA-E33B-4791-A815-4D1907DD578E",
+                 email: "mili.malde@digital.education.gov.uk",
+                 dsi_data: { "school_urns" => %w[137138 144523], "trust_uids" => %w[16644], "la_codes" => %w[852] },
+                 family_name: "Malde",
+                 given_name: "Mili")
 
-User.create(oid: "B5ECCE49-634C-4212-AC55-07F5C7BE74C2",
-            email: "nick.romney@digital.education.gov.uk",
-            dsi_data: { "school_urns" => %w[137138 144523], "trust_uids" => %w[16644], "la_codes" => %w[852] },
-            family_name: "Romney",
-            given_name: "Nick")
+Publisher.create(oid: "B5ECCE49-634C-4212-AC55-07F5C7BE74C2",
+                 email: "nick.romney@digital.education.gov.uk",
+                 dsi_data: { "school_urns" => %w[137138 144523], "trust_uids" => %w[16644], "la_codes" => %w[852] },
+                 family_name: "Romney",
+                 given_name: "Nick")
 
-User.create(oid: "7AEC8E8D-6036-4E6E-92A4-800E381A12E0",
-            email: "valentine.carter@digital.education.gov.uk",
-            dsi_data: { "school_urns" => %w[137138 144523], "trust_uids" => %w[16644], "la_codes" => %w[852] },
-            family_name: "Carter",
-            given_name: "Valentine")
+Publisher.create(oid: "7AEC8E8D-6036-4E6E-92A4-800E381A12E0",
+                 email: "valentine.carter@digital.education.gov.uk",
+                 dsi_data: { "school_urns" => %w[137138 144523], "trust_uids" => %w[16644], "la_codes" => %w[852] },
+                 family_name: "Carter",
+                 given_name: "Valentine")
 
 Jobseeker.create(email: "jobseeker@example.com",
                  password: "password",

--- a/lib/update_dsi_users_in_db.rb
+++ b/lib/update_dsi_users_in_db.rb
@@ -11,8 +11,8 @@ private
 
   def convert_to_users(dsi_users)
     dsi_users.each do |dsi_user|
-      User.transaction do
-        user = User.find_or_initialize_by(oid: dsi_user["userId"])
+      Publisher.transaction do
+        user = Publisher.find_or_initialize_by(oid: dsi_user["userId"])
         user.email = dsi_user["email"]
         user.given_name = dsi_user["givenName"]
         user.family_name = dsi_user["familyName"]

--- a/spec/factories/emergency_login_keys.rb
+++ b/spec/factories/emergency_login_keys.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :emergency_login_key do
     not_valid_after { Date.current - 5.months }
-    user
+    publisher
   end
 end

--- a/spec/factories/user_preferences.rb
+++ b/spec/factories/user_preferences.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
-  factory :user_preference do
+  factory :publisher_preference do
     association :school_group
-    association :user
+    association :publisher
     managed_organisations { "all" }
     managed_school_ids { [] }
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :user do
+  factory :publisher do
     accepted_terms_at { Date.current - 5.months }
     dsi_data do
       {

--- a/spec/factories/vacancy_publish_feedbacks.rb
+++ b/spec/factories/vacancy_publish_feedbacks.rb
@@ -3,13 +3,13 @@ FactoryBot.define do
     rating { 1 }
     comment { "Some feedback text" }
     vacancy
-    user
+    publisher
     user_participation_response { :not_interested }
     email { nil }
 
-    trait :old_with_no_user do
+    trait :old_with_no_publisher do
       to_create { |instance| instance.save(validate: false) }
-      user { nil }
+      publisher { nil }
     end
   end
 end

--- a/spec/form_models/managed_organisations_form_spec.rb
+++ b/spec/form_models/managed_organisations_form_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ManagedOrganisationsForm, type: :model do
       it "validates presence of managed_organisations or managed_school_ids" do
         expect(subject.valid?).to be(false)
         expect(subject.errors.messages[:managed_organisations]).to include(
-          I18n.t("hiring_staff_user_preference_errors.managed_organisations.blank"),
+          I18n.t("hiring_staff_publisher_preference_errors.managed_organisations.blank"),
         )
       end
     end

--- a/spec/jobs/send_expired_vacancy_feedback_email_prompts_job_spec.rb
+++ b/spec/jobs/send_expired_vacancy_feedback_email_prompts_job_spec.rb
@@ -21,11 +21,11 @@ RSpec.describe SendExpiredVacancyFeedbackEmailJob, type: :job do
   end
 
   context "for one hiring staff" do
-    let(:user) { create(:user, email: email_of_hiring_staff) }
+    let(:user) { create(:publisher, email: email_of_hiring_staff) }
     let(:email_of_hiring_staff) { "email@example.com" }
 
     context "with one expired vacancy needing feedback" do
-      let!(:expired_vacancy) { create(:vacancy, :expired, publisher_user: user, expires_on: Date.current) }
+      let!(:expired_vacancy) { create(:vacancy, :expired, publisher: user, expires_on: Date.current) }
 
       it "sends an email" do
         expect(FeedbackPromptMailer).to receive(:prompt_for_feedback).with(email_of_hiring_staff, [expired_vacancy])
@@ -45,7 +45,7 @@ RSpec.describe SendExpiredVacancyFeedbackEmailJob, type: :job do
 
     context "with one expired vacancy with feedback already completed" do
       let!(:expired_vacancies) do
-        create(:vacancy, :expired, :with_feedback, expires_on: Date.current, publisher_user: user)
+        create(:vacancy, :expired, :with_feedback, expires_on: Date.current, publisher: user)
       end
 
       it "does not send an email" do
@@ -56,8 +56,8 @@ RSpec.describe SendExpiredVacancyFeedbackEmailJob, type: :job do
 
     context "with two expired vacancies needing feedback" do
       let!(:expired_vacancies) do
-        [create(:vacancy, :expired, expires_on: Date.current, publisher_user: user),
-         create(:vacancy, :expired, expires_on: Date.current, publisher_user: user)]
+        [create(:vacancy, :expired, expires_on: Date.current, publisher: user),
+         create(:vacancy, :expired, expires_on: Date.current, publisher: user)]
       end
 
       it "sends an email with both vacancies" do
@@ -71,7 +71,7 @@ RSpec.describe SendExpiredVacancyFeedbackEmailJob, type: :job do
 
     context "running the job before hiring staff have had 2 weeks opportunity to fill in feedback" do
       let!(:expired_vacancy) do
-        create(:vacancy, :expired, expires_on: Date.current, publisher_user: user)
+        create(:vacancy, :expired, expires_on: Date.current, publisher: user)
       end
 
       it "sends no emails" do
@@ -83,16 +83,16 @@ RSpec.describe SendExpiredVacancyFeedbackEmailJob, type: :job do
   end
 
   context "for two hiring staff" do
-    let(:first_hiring_staff) { create(:user, email: "first_hiring_staff@email.com") }
-    let(:second_hiring_staff) { create(:user, email: "second_hiring_staff@email.com") }
+    let(:first_hiring_staff) { create(:publisher, email: "first_hiring_staff@email.com") }
+    let(:second_hiring_staff) { create(:publisher, email: "second_hiring_staff@email.com") }
 
     context "with one expired vacancy each" do
       let(:first_expired_vacancy) do
-        create(:vacancy, :expired, expires_on: Date.current, publisher_user: first_hiring_staff)
+        create(:vacancy, :expired, expires_on: Date.current, publisher: first_hiring_staff)
       end
 
       let(:second_expired_vacancy) do
-        create(:vacancy, :expired, expires_on: Date.current, publisher_user: second_hiring_staff)
+        create(:vacancy, :expired, expires_on: Date.current, publisher: second_hiring_staff)
       end
 
       it "sends one email for each hiring staff" do
@@ -111,7 +111,7 @@ RSpec.describe SendExpiredVacancyFeedbackEmailJob, type: :job do
 
   context "without a publisher hiring staff" do
     context "with one expired vacancy needing feedback" do
-      let!(:expired_vacancy) { create(:vacancy, :expired, expires_on: Date.current, publisher_user: nil) }
+      let!(:expired_vacancy) { create(:vacancy, :expired, expires_on: Date.current, publisher: nil) }
 
       it "does not send an email" do
         expect(FeedbackPromptMailer).to_not receive(:prompt_for_feedback)

--- a/spec/lib/update_dsi_users_in_db_spec.rb
+++ b/spec/lib/update_dsi_users_in_db_spec.rb
@@ -21,23 +21,23 @@ RSpec.describe UpdateDsiUsersInDb do
           )
       end
 
-      expect { update_dfe_sign_in_users.run! }.to change { User.all.size }.by(3)
+      expect { update_dfe_sign_in_users.run! }.to change { Publisher.all.size }.by(3)
 
-      user_with_one_school = User.find_by(email: "foo@example.com")
+      user_with_one_school = Publisher.find_by(email: "foo@example.com")
       expect(user_with_one_school.dsi_data["school_urns"]).to eq(%w[111111])
       expect(user_with_one_school.dsi_data["trust_uids"]).to eq([])
       expect(user_with_one_school.dsi_data["la_codes"]).to eq([])
       expect(user_with_one_school.given_name).to eq("Roger")
       expect(user_with_one_school.family_name).to eq("Johnson")
 
-      user_with_multiple_orgs = User.find_by(email: "bar@example.com")
+      user_with_multiple_orgs = Publisher.find_by(email: "bar@example.com")
       expect(user_with_multiple_orgs.dsi_data["school_urns"]).to eq(%w[333333 555555])
       expect(user_with_multiple_orgs.dsi_data["trust_uids"]).to eq(%w[222222 444444])
       expect(user_with_one_school.dsi_data["la_codes"]).to eq([])
       expect(user_with_multiple_orgs.given_name).to eq("Alice")
       expect(user_with_multiple_orgs.family_name).to eq("Robertson")
 
-      local_authority_user = User.find_by(email: "baz@example.com")
+      local_authority_user = Publisher.find_by(email: "baz@example.com")
       expect(local_authority_user.dsi_data["school_urns"]).to eq([])
       expect(local_authority_user.dsi_data["trust_uids"]).to eq([])
       expect(local_authority_user.dsi_data["la_codes"]).to eq(%w[813])

--- a/spec/mailers/authentication_fallback_mailer_spec.rb
+++ b/spec/mailers/authentication_fallback_mailer_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe AuthenticationFallbackMailer, type: :mailer do
   describe "the user receives the sign in email containing the magic link" do
-    let(:user) { create(:user) }
+    let(:user) { create(:publisher) }
     let(:login_key) { user.emergency_login_keys.create(not_valid_after: Time.current + 10.minutes) }
     let(:mail) { described_class.sign_in_fallback(login_key: login_key, email: user.email) }
 

--- a/spec/models/emergency_login_key_spec.rb
+++ b/spec/models/emergency_login_key_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe EmergencyLoginKey, type: :model do
-  it { should belong_to(:user) }
+  it { should belong_to(:publisher) }
 
   describe "validations" do
     context "a new key" do

--- a/spec/models/publisher_preference_spec.rb
+++ b/spec/models/publisher_preference_spec.rb
@@ -1,0 +1,6 @@
+require "rails_helper"
+
+RSpec.describe PublisherPreference, type: :model do
+  it { should belong_to(:publisher) }
+  it { should belong_to(:school_group).optional }
+end

--- a/spec/models/publisher_spec.rb
+++ b/spec/models/publisher_spec.rb
@@ -1,16 +1,16 @@
 require "rails_helper"
 
-RSpec.describe User, type: :model do
+RSpec.describe Publisher, type: :model do
   describe "#accepted_terms_and_conditions?" do
     subject { user.accepted_terms_and_conditions? }
 
     context "has accepted terms and conditions" do
-      let(:user) { create(:user, accepted_terms_at: Time.current) }
+      let(:user) { create(:publisher, accepted_terms_at: Time.current) }
 
       it { is_expected.to be true }
     end
     context "has not accepted terms and conditions" do
-      let(:user) { create(:user, accepted_terms_at: nil) }
+      let(:user) { create(:publisher, accepted_terms_at: nil) }
 
       it { is_expected.to be false }
     end

--- a/spec/models/user_preference_spec.rb
+++ b/spec/models/user_preference_spec.rb
@@ -1,6 +1,0 @@
-require "rails_helper"
-
-RSpec.describe UserPreference, type: :model do
-  it { should belong_to(:user) }
-  it { should belong_to(:school_group).optional }
-end

--- a/spec/models/vacancy_publish_feedback_spec.rb
+++ b/spec/models/vacancy_publish_feedback_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe VacancyPublishFeedback, type: :model do
   it { should belong_to(:vacancy) }
-  it { should belong_to(:user) }
+  it { should belong_to(:publisher) }
 
   describe "validations" do
     it { should validate_presence_of(:comment) }

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Vacancy, type: :model do
   it { should belong_to(:publisher_organisation).optional }
-  it { should belong_to(:publisher_user).optional }
+  it { should belong_to(:publisher).optional }
   it { should have_many(:documents) }
   it { should have_many(:organisation_vacancies) }
   it { should have_many(:organisations) }

--- a/spec/services/hiring_staff/vacancy_filter_spec.rb
+++ b/spec/services/hiring_staff/vacancy_filter_spec.rb
@@ -1,23 +1,23 @@
 require "rails_helper"
 
 RSpec.describe HiringStaff::VacancyFilter do
-  let(:user) { create :user }
+  let(:publisher) { create :publisher }
   let(:organisation) { create :trust }
   let(:managed_organisations) { "school_group" }
   let(:managed_school_ids) { %w[1234 5678] }
-  let!(:user_preference) do
-    create :user_preference, user: user, school_group: organisation,
-                             managed_organisations: managed_organisations, managed_school_ids: managed_school_ids
+  let!(:publisher_preference) do
+    create :publisher_preference, publisher: publisher, school_group: organisation,
+                                  managed_organisations: managed_organisations, managed_school_ids: managed_school_ids
   end
 
-  subject { described_class.new(user, organisation) }
+  subject { described_class.new(publisher, organisation) }
 
   describe ".initialize" do
-    it "sets the managed_organisations from user_preference" do
+    it "sets the managed_organisations from publisher_preference" do
       expect(subject.managed_organisations).to eq managed_organisations
     end
 
-    it "sets the managed_school_ids from user_preference" do
+    it "sets the managed_school_ids from publisher_preference" do
       expect(subject.managed_school_ids).to eq managed_school_ids
     end
   end
@@ -29,12 +29,12 @@ RSpec.describe HiringStaff::VacancyFilter do
       let(:new_organisations) { nil }
       let(:new_school_ids) { %w[4321 8765] }
 
-      it "updates user_preference managed_organisations" do
-        expect(user_preference.reload.managed_organisations).to eq new_organisations
+      it "updates publisher_preference managed_organisations" do
+        expect(publisher_preference.reload.managed_organisations).to eq new_organisations
       end
 
-      it "updates user_preference managed_school_ids" do
-        expect(user_preference.reload.managed_school_ids).to eq new_school_ids
+      it "updates publisher_preference managed_school_ids" do
+        expect(publisher_preference.reload.managed_school_ids).to eq new_school_ids
       end
     end
 
@@ -42,12 +42,12 @@ RSpec.describe HiringStaff::VacancyFilter do
       let(:new_organisations) { %w[all] }
       let(:new_school_ids) { %w[4321 8765] }
 
-      it "updates user_preference managed_organisations to all" do
-        expect(user_preference.reload.managed_organisations).to eq "all"
+      it "updates publisher_preference managed_organisations to all" do
+        expect(publisher_preference.reload.managed_organisations).to eq "all"
       end
 
-      it "updates user_preference managed_school_ids to empty array" do
-        expect(user_preference.reload.managed_school_ids).to eq []
+      it "updates publisher_preference managed_school_ids to empty array" do
+        expect(publisher_preference.reload.managed_school_ids).to eq []
       end
     end
   end

--- a/spec/services/publish_vacancy_spec.rb
+++ b/spec/services/publish_vacancy_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.describe PublishVacancy do
   let(:organisation) { create(:school) }
-  let(:user) { create(:user) }
-  let(:vacancy) { create(:vacancy, :draft, publisher_user: nil) }
+  let(:user) { create(:publisher) }
+  let(:vacancy) { create(:vacancy, :draft, publisher: nil) }
 
   describe "#call" do
     it "updates the vacancy's status to published" do
@@ -16,7 +16,7 @@ RSpec.describe PublishVacancy do
       PublishVacancy.new(vacancy, user, organisation).call
       vacancy.reload
 
-      expect(vacancy.publisher_user_id).to eq(user.id)
+      expect(vacancy.publisher_id).to eq(user.id)
     end
 
     it "updates the id of the organisation of the user who confirmed the publishing of a vacancy" do

--- a/spec/support/auth_helpers.rb
+++ b/spec/support/auth_helpers.rb
@@ -14,7 +14,7 @@ module AuthHelpers
       page.set_rack_session(urn: "", uid: "", la_code: la_code)
     end
     page.set_rack_session(session_id: session_id)
-    create(:user, oid: session_id, email: email, last_activity_at: Time.current)
+    create(:publisher, oid: session_id, email: email, last_activity_at: Time.current)
   end
 
   def stub_authentication_step(organisation_id: "939eac36-0777-48c2-9c2c-b87c948a9ee0",
@@ -112,6 +112,6 @@ module AuthHelpers
   end
 
   def stub_accepted_terms_and_conditions
-    create(:user, oid: "161d1f6a-44f1-4a1a-940d-d1088c439da7", accepted_terms_at: 1.day.ago)
+    create(:publisher, oid: "161d1f6a-44f1-4a1a-940d-d1088c439da7", accepted_terms_at: 1.day.ago)
   end
 end

--- a/spec/system/hiring_staff_can_filter_vacancies_in_their_dashboard_spec.rb
+++ b/spec/system/hiring_staff_can_filter_vacancies_in_their_dashboard_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe "Hiring staff can filter vacancies in their dashboard" do
     visit root_path
     sign_in_user
 
-    UserPreference.find_or_create_by(
-      user_id: User.last.id, school_group_id: school_group.id,
+    PublisherPreference.find_or_create_by(
+      publisher_id: Publisher.last.id, school_group_id: school_group.id,
       managed_organisations: managed_organisations, managed_school_ids: managed_school_ids
     )
   end

--- a/spec/system/hiring_staff_can_publish_a_vacancy_as_a_local_authority_spec.rb
+++ b/spec/system/hiring_staff_can_publish_a_vacancy_as_a_local_authority_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Creating a vacancy" do
     allow(LocalAuthorityAccessFeature).to receive(:enabled?).and_return(true)
     SchoolGroupMembership.find_or_create_by(school_id: school_1.id, school_group_id: school_group.id)
     SchoolGroupMembership.find_or_create_by(school_id: school_2.id, school_group_id: school_group.id)
-    allow(UserPreference).to receive(:find_by).and_return(instance_double(UserPreference))
+    allow(PublisherPreference).to receive(:find_by).and_return(instance_double(PublisherPreference))
     stub_hiring_staff_auth(la_code: school_group.local_authority_code, session_id: session_id)
   end
 

--- a/spec/system/hiring_staff_can_publish_a_vacancy_as_a_school_spec.rb
+++ b/spec/system/hiring_staff_can_publish_a_vacancy_as_a_school_spec.rb
@@ -860,14 +860,14 @@ RSpec.describe "Creating a vacancy" do
 
     describe "#publish" do
       scenario "adds the current user as a contact for feedback on the published vacancy" do
-        current_user = User.find_by(oid: session_id)
+        current_publisher = Publisher.find_by(oid: session_id)
         vacancy = create(:vacancy, :draft)
         vacancy.organisation_vacancies.create(organisation: school)
 
         visit organisation_job_review_path(vacancy.id)
         click_on I18n.t("buttons.submit_job_listing")
 
-        expect(vacancy.reload.publisher_user_id).to eq(current_user.id)
+        expect(vacancy.reload.publisher_id).to eq(current_publisher.id)
       end
 
       scenario "view the published listing as a jobseeker" do

--- a/spec/system/hiring_staff_can_publish_a_vacancy_as_a_trust_spec.rb
+++ b/spec/system/hiring_staff_can_publish_a_vacancy_as_a_trust_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Creating a vacancy" do
     SchoolGroupMembership.find_or_create_by(school_id: school_1.id, school_group_id: school_group.id)
     SchoolGroupMembership.find_or_create_by(school_id: school_2.id, school_group_id: school_group.id)
     SchoolGroupMembership.find_or_create_by(school_id: school_3.id, school_group_id: school_group.id)
-    allow(UserPreference).to receive(:find_by).and_return(instance_double(UserPreference))
+    allow(PublisherPreference).to receive(:find_by).and_return(instance_double(PublisherPreference))
     stub_hiring_staff_auth(uid: school_group.uid, session_id: session_id)
   end
 

--- a/spec/system/hiring_staff_can_set_managed_organisations_user_preferences_spec.rb
+++ b/spec/system/hiring_staff_can_set_managed_organisations_user_preferences_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Hiring staff can set managed organisations user preferences" do
   let(:school_1) { create(:school, name: "Happy Rainbows School") }
   let(:school_2) { create(:school, name: "Dreary Grey School") }
   let(:school_3) { create(:school, :closed, name: "Closed School") }
-  let(:user_preference) { UserPreference.last }
+  let(:publisher_preference) { PublisherPreference.last }
 
   before do
     allow(LocalAuthorityAccessFeature).to receive(:enabled?).and_return(true)
@@ -60,7 +60,7 @@ RSpec.describe "Hiring staff can set managed organisations user preferences" do
       click_on I18n.t("buttons.continue")
 
       expect(page.current_path).to eql(organisation_path)
-      expect(user_preference.managed_school_ids).to eql([school_group.id, school_1.id])
+      expect(publisher_preference.managed_school_ids).to eql([school_group.id, school_1.id])
     end
 
     scenario "it allows school group users to select to manage all jobs" do
@@ -77,8 +77,8 @@ RSpec.describe "Hiring staff can set managed organisations user preferences" do
       click_on I18n.t("buttons.continue")
 
       expect(page.current_path).to eql(organisation_path)
-      expect(user_preference.managed_organisations).to eql("all")
-      expect(user_preference.managed_school_ids).to eql([])
+      expect(publisher_preference.managed_organisations).to eql("all")
+      expect(publisher_preference.managed_school_ids).to eql([])
     end
   end
 

--- a/spec/system/hiring_staff_can_sign_in_with_dfe_spec.rb
+++ b/spec/system/hiring_staff_can_sign_in_with_dfe_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe "Hiring staff signing-in with DfE Sign In" do
 
   context "with DSI data including a school group (trust or local authority) that the school belongs to" do
     let(:dsi_data) { { "trust_uids" => %w[14323], "school_urns" => %w[246757 953341 122792], "la_codes" => %w[323] } }
-    let!(:user) { create(:user, email: dsi_email_address, dsi_data: dsi_data) }
+    let!(:user) { create(:publisher, email: dsi_email_address, dsi_data: dsi_data) }
     let(:school) { create(:school, urn: "246757") }
 
     before do
@@ -171,10 +171,10 @@ RSpec.describe "Hiring staff signing-in with DfE Sign In" do
 
   context "with valid credentials that match a Trust" do
     let(:organisation) { create(:trust) }
-    let(:user_preference) { instance_double(UserPreference) }
+    let(:publisher_preference) { instance_double(PublisherPreference) }
 
     before do
-      allow(UserPreference).to receive(:find_by).and_return(user_preference)
+      allow(PublisherPreference).to receive(:find_by).and_return(publisher_preference)
 
       stub_authentication_step(school_urn: nil, trust_uid: organisation.uid, email: dsi_email_address)
       stub_authorisation_step
@@ -195,7 +195,7 @@ RSpec.describe "Hiring staff signing-in with DfE Sign In" do
     end
 
     context "when user preferences have not been set" do
-      let(:user_preference) { nil }
+      let(:publisher_preference) { nil }
 
       scenario "it redirects the sign in page to the managed organisations user preference page" do
         expect(current_path).to eql(organisation_managed_organisations_path)
@@ -210,7 +210,7 @@ RSpec.describe "Hiring staff signing-in with DfE Sign In" do
 
   context "with valid credentials that match a Local Authority" do
     let(:organisation) { create(:local_authority, local_authority_code: "100") }
-    let(:user_preference) { instance_double(UserPreference) }
+    let(:publisher_preference) { instance_double(PublisherPreference) }
     let(:la_user_allowed?) { true }
 
     context "LocalAuthorityAccessFeature enabled" do
@@ -218,7 +218,7 @@ RSpec.describe "Hiring staff signing-in with DfE Sign In" do
         allow(LocalAuthorityAccessFeature).to receive(:enabled?).and_return(true)
         allow(ALLOWED_LOCAL_AUTHORITIES)
           .to receive(:include?).with(organisation.local_authority_code).and_return(la_user_allowed?)
-        allow(UserPreference).to receive(:find_by).and_return(user_preference)
+        allow(PublisherPreference).to receive(:find_by).and_return(publisher_preference)
 
         stub_authentication_step(school_urn: nil, la_code: organisation.local_authority_code, email: dsi_email_address)
         stub_authorisation_step
@@ -239,7 +239,7 @@ RSpec.describe "Hiring staff signing-in with DfE Sign In" do
       end
 
       context "when user preferences have not been set" do
-        let(:user_preference) { nil }
+        let(:publisher_preference) { nil }
 
         scenario "it redirects the sign in page to the managed organisations user preference page" do
           expect(current_path).to eql(organisation_managed_organisations_path)

--- a/spec/system/hiring_staff_can_submit_vacancy_publish_feedback_spec.rb
+++ b/spec/system/hiring_staff_can_submit_vacancy_publish_feedback_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "Vacancy publish feedback" do
 
       expect(feedback).to_not be_nil
       expect(feedback.comment).to eq("Perfect!")
-      expect(feedback.user).to eq(User.find_by(oid: session_id))
+      expect(feedback.publisher).to eq(Publisher.find_by(oid: session_id))
       expect(feedback.email).to eq("user@email.com")
     end
 

--- a/spec/system/hiring_staff_have_to_accept_terms_spec.rb
+++ b/spec/system/hiring_staff_have_to_accept_terms_spec.rb
@@ -3,13 +3,13 @@ require "rails_helper"
 RSpec.describe "Hiring staff accepts terms and conditions" do
   let(:school) { create(:school) }
   let(:session_id) { "a-valid-oid" }
-  let(:current_user) { User.find_by(oid: session_id) }
+  let(:current_publisher) { Publisher.find_by(oid: session_id) }
   before do
     stub_hiring_staff_auth(urn: school.urn, session_id: session_id)
   end
 
   context "the user has not accepted the terms and conditions" do
-    before { current_user.update(accepted_terms_at: nil) }
+    before { current_publisher.update(accepted_terms_at: nil) }
 
     scenario "they will see the terms and conditions" do
       visit organisation_path
@@ -20,25 +20,25 @@ RSpec.describe "Hiring staff accepts terms and conditions" do
     scenario "they can accept the terms and conditions" do
       visit terms_and_conditions_path
 
-      expect(current_user).not_to be_accepted_terms_and_conditions
+      expect(current_publisher).not_to be_accepted_terms_and_conditions
 
       check I18n.t("terms_and_conditions.label")
       click_on I18n.t("buttons.accept_and_continue")
 
-      current_user.reload
+      current_publisher.reload
       expect(page).to have_content(I18n.t("schools.jobs.index", organisation: school.name))
-      expect(current_user).to be_accepted_terms_and_conditions
+      expect(current_publisher).to be_accepted_terms_and_conditions
     end
 
     scenario "an audit entry is logged when they accept" do
       visit terms_and_conditions_path
 
-      expect(current_user).not_to be_accepted_terms_and_conditions
+      expect(current_publisher).not_to be_accepted_terms_and_conditions
 
       check I18n.t("terms_and_conditions.label")
       click_on I18n.t("buttons.accept_and_continue")
 
-      activity = current_user.activities.last
+      activity = current_publisher.activities.last
       expect(activity.key).to eq("user.terms_and_conditions.accept")
       expect(activity.session_id).to eq(session_id)
     end
@@ -46,14 +46,14 @@ RSpec.describe "Hiring staff accepts terms and conditions" do
     scenario "an error is shown if they don’t accept" do
       visit terms_and_conditions_path
 
-      expect(current_user).not_to be_accepted_terms_and_conditions
+      expect(current_publisher).not_to be_accepted_terms_and_conditions
 
       click_on I18n.t("buttons.accept_and_continue")
 
-      current_user.reload
+      current_publisher.reload
 
       expect(page).to have_content("There is a problem")
-      expect(current_user).not_to be_accepted_terms_and_conditions
+      expect(current_publisher).not_to be_accepted_terms_and_conditions
     end
 
     context "signing out" do
@@ -82,7 +82,7 @@ RSpec.describe "Hiring staff accepts terms and conditions" do
 
   context "the user has accepted the terms and conditions" do
     scenario "they will not see the terms and conditions" do
-      current_user.update(accepted_terms_at: Time.current)
+      current_publisher.update(accepted_terms_at: Time.current)
 
       visit organisation_path
 

--- a/spec/system/hiring_staff_receive_email_prompt_for_expired_vacancy_feedback_spec.rb
+++ b/spec/system/hiring_staff_receive_email_prompt_for_expired_vacancy_feedback_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe "Creating a vacancy" do
 
   context "Hiring staff has expired vacancy that is not older than 2 weeks" do
     scenario "does not receive feedback prompt e-mail" do
-      current_user = User.find_by(oid: session_id)
+      current_publisher = Publisher.find_by(oid: session_id)
       vacancy = create(
         :vacancy,
         :published,
         job_title: "Vacancy",
         publish_on: Date.current,
         expires_on: Date.current + 1.week,
-        publisher_user_id: current_user.id,
+        publisher_id: current_publisher.id,
       )
       vacancy.organisation_vacancies.create(organisation: school)
 
@@ -38,14 +38,14 @@ RSpec.describe "Creating a vacancy" do
 
   context "Hiring staff has 2 expired vacancies that are older than 2 weeks" do
     scenario "receives feedback prompt email with 2 vacancies" do
-      current_user = User.find_by(oid: session_id)
+      current_publisher = Publisher.find_by(oid: session_id)
       vacancy = create(
         :vacancy,
         :published,
         job_title: "Job one",
         publish_on: Date.current,
         expires_on: Date.current,
-        publisher_user_id: current_user.id,
+        publisher_id: current_publisher.id,
       )
       vacancy.organisation_vacancies.create(organisation: school)
 
@@ -55,7 +55,7 @@ RSpec.describe "Creating a vacancy" do
         job_title: "Job two",
         publish_on: Date.current,
         expires_on: Date.current,
-        publisher_user_id: current_user.id,
+        publisher_id: current_publisher.id,
       )
       vacancy.organisation_vacancies.create(organisation: school)
 
@@ -65,7 +65,7 @@ RSpec.describe "Creating a vacancy" do
         job_title: "Job three",
         publish_on: Date.current,
         expires_on: Date.current + 2.weeks,
-        publisher_user_id: current_user.id,
+        publisher_id: current_publisher.id,
       )
       vacancy.organisation_vacancies.create(organisation: school)
 
@@ -85,15 +85,15 @@ RSpec.describe "Creating a vacancy" do
 
   context "Two expired vacancies for two users that are older than 2 weeks" do
     scenario "both receives feedback prompt emails" do
-      current_user = User.find_by(oid: session_id)
-      another_user = create(:user, email: "another@user.com")
+      current_publisher = Publisher.find_by(oid: session_id)
+      another_user = create(:publisher, email: "another@user.com")
       vacancy = create(
         :vacancy,
         :published,
         job_title: "Job one",
         publish_on: Date.current,
         expires_on: Date.current,
-        publisher_user_id: current_user.id,
+        publisher_id: current_publisher.id,
       )
       vacancy.organisation_vacancies.create(organisation: school)
 
@@ -103,7 +103,7 @@ RSpec.describe "Creating a vacancy" do
         job_title: "Job two",
         publish_on: Date.current,
         expires_on: Date.current,
-        publisher_user_id: another_user.id,
+        publisher_id: another_user.id,
       )
       vacancy.organisation_vacancies.create(organisation: school)
 

--- a/spec/system/hiring_staff_session_timeout_spec.rb
+++ b/spec/system/hiring_staff_session_timeout_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Hiring staff session" do
   let(:school) { create(:school) }
   let(:session_id) { "session_id" }
-  let(:current_user) { User.find_by(oid: session_id) }
+  let(:current_publisher) { Publisher.find_by(oid: session_id) }
   before do
     allow(AuthenticationFallback).to receive(:enabled?).and_return(false)
     stub_hiring_staff_auth(urn: school.urn, session_id: session_id)


### PR DESCRIPTION
We now have multiple distinct types of users, so the original naming of
hiring staff members as "user" is confusing.

This renames the `User` model to `Publisher` and refactors most
occurrences of "user" in the codebase to "publisher", with the exception
of where they specifically refer to DSI users.