### PR TITLE
[TEVA-1604] deploy_branch workflow - fix branch name

### DIFF
--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Set environment variables
       id: set_env_vars
       run: |
-        BRANCH=${{ github.head_ref }}
+        BRANCH=$(echo ${GITHUB_REF#refs/heads/})
         TAG=${BRANCH}-${{ github.sha }}-$(date '+%Y%m%d%H%M%S')
         echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
         echo "TAG=${TAG}" >> $GITHUB_ENV


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1604

## Changes in this PR:

Derive branch names from GITHUB_REF, using additional pattern `#refs/heads/` which will still work even on longer branch names (such as `feature/foo` rather than simply `staging` or `dev`)
