### PR TITLE
Add location polygon usage counter

### DIFF
--- a/app/services/search/location_builder.rb
+++ b/app/services/search/location_builder.rb
@@ -38,7 +38,10 @@ private
 
   def initialize_location_polygon
     @location_polygon = LocationPolygon.with_name(@location_category)
-    @location_polygon_boundary = [@location_polygon.boundary] if @location_polygon.present?
+    if @location_polygon.present?
+      @location_polygon_boundary = [@location_polygon.boundary]
+      @location_polygon.increment!(:usage_count)
+    end
     if location_polygon.nil? && (DOWNCASE_REGIONS + DOWNCASE_COUNTIES).include?(@location_category.downcase)
       # If a location category that we expect to have a polygon actually does not,
       # append the location category to the text search as a fallback.

--- a/db/migrate/20201124133720_add_usage_count_to_location_polygons.rb
+++ b/db/migrate/20201124133720_add_usage_count_to_location_polygons.rb
@@ -1,0 +1,5 @@
+class AddUsageCountToLocationPolygons < ActiveRecord::Migration[6.0]
+  def change
+    add_column :location_polygons, :usage_count, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_24_120747) do
+ActiveRecord::Schema.define(version: 2020_11_24_133720) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -140,6 +140,7 @@ ActiveRecord::Schema.define(version: 2020_11_24_120747) do
     t.float "boundary", array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "usage_count", default: 0
   end
 
   create_table "organisation_vacancies", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/export_tables_to_big_query.rb
+++ b/lib/export_tables_to_big_query.rb
@@ -15,6 +15,8 @@ class ExportTablesToBigQuery
   # gias_data removes duplication of data.
   DROP_THESE_ATTRIBUTES = %w[
     benefits
+    boundary
+    buffers
     description
     education
     experience
@@ -49,7 +51,6 @@ class ExportTablesToBigQuery
     activities
     ar_internal_metadata
     friendly_id_slugs
-    location_polygons
     schema_migrations
     sessions
   ].freeze

--- a/spec/services/search/location_builder_spec.rb
+++ b/spec/services/search/location_builder_spec.rb
@@ -3,8 +3,9 @@ require "rails_helper"
 RSpec.shared_examples "a search using polygons" do |options|
   it "sets the correct attributes" do
     expect(subject.location_category).to eql(options&.dig(:location)&.presence || polygonable_location)
-    expect(subject.location_polygon).to eql(location_polygon)
     expect(subject.location_filter).to eql({})
+    expect(subject.location_polygon).to eql(location_polygon)
+    expect(subject.location_polygon.usage_count).to eql(1)
   end
 end
 


### PR DESCRIPTION
This is to help us to detect when there is something wrong with
our polygons. If a polygon is never or very rarely used - which
here means 'searched in' - then one possible explanation is that
it is misnamed. For example, we map 'herefordshire' to our polygon
called 'herefordshire, county of' because no human would ever
choose to input the latter when they mean 'herefordshire'.

To find issues it might be clever to compare the analytics of
which location search terms are commonly used (currently available
on our [dashboard](https://datastudio.google.com/u/1/reporting/1X_lrbWUn7Nw5LZnRWynJKtalYg6-L4Oi/page/vo6kB) page 30) and the actual recorded usage of the
corresponding location polygon.
