### PR TITLE
[TEVA-1639] Remove trigger on staging branch

### DIFF
--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - dev
-      - staging
     paths-ignore:
     - 'bigquery/**'
     - 'documentation/**'


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1639

## Changes in this PR:

- Removed GitHub actions workflow trigger on pushes to the `staging` branch, as the `deploy` workflow also deploys to the staging environment as preparation for deploying to production.
