### PR TITLE
Log search arguments when algolia throws an error

### DIFF
--- a/app/services/search/algolia_search_request.rb
+++ b/app/services/search/algolia_search_request.rb
@@ -13,6 +13,8 @@ class Search::AlgoliaSearchRequest
     @typo_tolerance = search_params[:typo_tolerance]
 
     @vacancies = search
+    return if @vacancies.nil?
+
     @stats = build_stats(
       vacancies.raw_answer["page"],
       vacancies.raw_answer["nbPages"],
@@ -33,6 +35,9 @@ private
 
   def search
     Vacancy.includes(organisation_vacancies: :organisation).search(@keyword, search_arguments)
+  rescue Algolia::AlgoliaProtocolError => e
+    Rollbar.error("Algolia search error", details: e, search_arguments: search_arguments)
+    nil
   end
 
   def search_arguments


### PR DESCRIPTION
This should provide more insight on otherwise completely not insightful Algolia errors (e.g https://rollbar.com/dfe/teacher-vacancies/items/2781/)

It should also stop the job alert job falling over