### PR TITLE
More refactoring of publisher authentication

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::Base
 
   helper_method :cookies_preference_set?, :referred_from_jobs_path?, :utm_parameters
 
-  include AuthenticationConcerns
+  include Publishers::AuthenticationConcerns
   include Ip
 
   def check

--- a/app/controllers/concerns/publishers/authentication_concerns.rb
+++ b/app/controllers/concerns/publishers/authentication_concerns.rb
@@ -1,15 +1,15 @@
-module AuthenticationConcerns
+module Publishers::AuthenticationConcerns
   extend ActiveSupport::Concern
 
   included do
-    helper_method :authenticated?
+    helper_method :publisher_signed_in?
     helper_method :current_organisation
     helper_method :current_school
     helper_method :current_school_group
-    helper_method :school_group_user?
+    helper_method :current_publisher_is_part_of_school_group?
   end
 
-  def authenticated?
+  def publisher_signed_in?
     session.key?(:session_id)
   end
 
@@ -29,7 +29,7 @@ module AuthenticationConcerns
     end
   end
 
-  def school_group_user?
+  def current_publisher_is_part_of_school_group?
     session[:uid].present? || session[:la_code].present?
   end
 end

--- a/app/controllers/interests_controller.rb
+++ b/app/controllers/interests_controller.rb
@@ -1,6 +1,6 @@
 class InterestsController < ApplicationController
   def new
-    audit_click unless authenticated?
+    audit_click unless publisher_signed_in?
     redirect_to(vacancy.application_link)
   end
 

--- a/app/controllers/publishers/base_controller.rb
+++ b/app/controllers/publishers/base_controller.rb
@@ -7,7 +7,6 @@ class Publishers::BaseController < ApplicationController
                 :check_session,
                 :check_terms_and_conditions
 
-  include AuthenticationConcerns
   include ActionView::Helpers::DateHelper
 
   def redirect_to_root_if_read_only

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -24,7 +24,7 @@ class VacanciesController < ApplicationController
     @devised_job_alert_search_criteria = Search::CriteriaDeviser.new(vacancy).criteria
     @similar_jobs = Search::SimilarJobs.new(vacancy).similar_jobs
 
-    VacancyPageView.new(vacancy).track unless authenticated? || smoke_test?
+    VacancyPageView.new(vacancy).track unless publisher_signed_in? || smoke_test?
 
     expires_in 5.minutes, public: true
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,7 +7,7 @@ module ApplicationHelper
   end
 
   def body_class
-    auth_class = authenticated? ? "hiring-staff" : ""
+    auth_class = publisher_signed_in? ? "hiring-staff" : ""
     action_class = controller_path.tr("/", "_") + "_" + action_name
     "govuk-template__body app-body-class #{auth_class} #{action_class}"
   end

--- a/app/helpers/publishers/job_creation_helper.rb
+++ b/app/helpers/publishers/job_creation_helper.rb
@@ -20,7 +20,7 @@ module Publishers::JobCreationHelper
                    else
                      params[:controller].split("/").last.to_sym == :documents ? :documents : :review
                    end
-    if school_group_user?
+    if current_publisher_is_part_of_school_group?
       STEPS[current_step][:number]
     else
       STEPS[current_step][:number] - NUMBER_OF_ADDITIONAL_STEPS_FOR_SCHOOL_GROUP_USERS
@@ -29,7 +29,7 @@ module Publishers::JobCreationHelper
 
   def steps_to_display
     steps = STEPS.dup
-    unless school_group_user?
+    unless current_publisher_is_part_of_school_group?
       steps = remove_school_group_user_only_steps(steps)
       steps = renumber_steps_for_single_school_users(steps)
     end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -67,7 +67,7 @@
                 %ul.govuk-footer__inline-list.hide-bullet-points
                   %li.govuk-footer-list-item
                     =link_to t('footer.search_teaching_vacancies'), root_url, class: 'govuk-footer__link'
-                  - if JobseekerAccountsFeature.enabled? && !authenticated?
+                  - if JobseekerAccountsFeature.enabled? && !publisher_signed_in?
                     %li.govuk-footer-list-item
                       - if jobseeker_signed_in?
                         =link_to t('footer.your_account'), jobseekers_account_path, class: 'govuk-footer__link'

--- a/app/views/pages/home/_signin.html.haml
+++ b/app/views/pages/home/_signin.html.haml
@@ -1,6 +1,6 @@
 %h2.govuk-heading-m= t('.title')
 
-- if authenticated?
+- if publisher_signed_in?
   %div.manage-vacancies
     %p= "#{t('pages.home.signed_in.description')} #{current_organisation.name}"
     = link_to t('pages.home.signed_in.manage_link'), organisation_path, class: 'govuk-button govuk-button--secondary manage-vacancies'

--- a/app/views/shared/_navigation.haml
+++ b/app/views/shared/_navigation.haml
@@ -1,8 +1,8 @@
 %nav
   %ul.govuk-header__navigation.mobile-header-top-border{ id: "navigation", "aria-label": "Top Level Navigation" }
-    - if authenticated? && !ReadOnlyFeature.enabled?
+    - if publisher_signed_in? && !ReadOnlyFeature.enabled?
       %li{ class: active_link_class(organisation_path) }= link_to t('nav.school_page_link'), organisation_path, class: 'govuk-header__link'
-      - if school_group_user?
+      - if current_publisher_is_part_of_school_group?
         %li{ class: active_link_class(organisation_schools_path) }= link_to t('nav.school_group_index_link', organisation_type: organisation_type_basic(current_organisation)), organisation_schools_path, class: 'govuk-header__link'
       %li{ class: active_link_class(root_path) }= link_to t('nav.jobseekers_index_link'), root_path, class: 'govuk-header__link'
       %li{ class: active_link_class(sessions_path) }= link_to t('nav.sign_out'), sessions_path, method: :delete, class: 'govuk-header__link'

--- a/spec/components/publishers/sidebar_component_spec.rb
+++ b/spec/components/publishers/sidebar_component_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe Publishers::SidebarComponent, type: :component do
   let(:vacancy) { create(:vacancy, completed_step: completed_step) }
   let(:completed_step) { 0 }
   let(:current_step) { 1 }
-  let(:school_group_user?) { true }
+  let(:current_publisher_is_part_of_school_group?) { true }
 
   before do
     allow_any_instance_of(Publishers::JobCreationHelper).to receive(:current_step_number).and_return(current_step)
-    allow_any_instance_of(AuthenticationConcerns).to receive(:school_group_user?).and_return(school_group_user?)
+    allow_any_instance_of(Publishers::AuthenticationConcerns).to receive(:current_publisher_is_part_of_school_group?).and_return(current_publisher_is_part_of_school_group?)
   end
 
   let!(:inline_component) { render_inline(described_class.new(vacancy: vacancy)) }
@@ -46,7 +46,7 @@ RSpec.describe Publishers::SidebarComponent, type: :component do
   end
 
   context "when a School user creates a job" do
-    let(:school_group_user?) { false }
+    let(:current_publisher_is_part_of_school_group?) { false }
 
     it "does not render the job location step" do
       expect(rendered_component).not_to include(I18n.t("jobs.job_location"))

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ApplicationHelper, type: :helper do
     before do
       expect(controller).to receive(:controller_path) { "foo/baz" }
       expect(controller).to receive(:action_name) { "bar" }
-      allow(controller).to receive(:authenticated?) { false }
+      allow(controller).to receive(:publisher_signed_in?) { false }
     end
 
     it "returns the controller and action name" do
@@ -27,7 +27,7 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     context "when logged in" do
       before do
-        expect(controller).to receive(:authenticated?) { true }
+        expect(controller).to receive(:publisher_signed_in?) { true }
       end
 
       it "returns the authenticated class" do

--- a/spec/support/test_controller.rb
+++ b/spec/support/test_controller.rb
@@ -1,3 +1,3 @@
 class ActionView::TestCase::TestController
-  include AuthenticationConcerns
+  include Publishers::AuthenticationConcerns
 end

--- a/spec/views/pages/home/_signin.html.haml_spec.rb
+++ b/spec/views/pages/home/_signin.html.haml_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "pages/home/_signin.html.haml" do
   context "if session is authenticated" do
     before do
-      allow(view).to receive(:authenticated?).and_return(true)
+      allow(view).to receive(:publisher_signed_in?).and_return(true)
       school = create(:school, name: "Salisbury School")
       allow(view).to receive(:current_organisation) { school }
       render
@@ -16,7 +16,7 @@ RSpec.describe "pages/home/_signin.html.haml" do
 
   context "if session is not authenticated" do
     before do
-      allow(view).to receive(:authenticated?).and_return(false)
+      allow(view).to receive(:publisher_signed_in?).and_return(false)
       render
     end
 


### PR DESCRIPTION
- Move `AuthenticationConcerns` into `Publishers` namespace
- Rename `AuthenticationConcerns#authenticated?` to
  `#publisher_signed_in?`
- Rename `AuthenticationConcerns#school_group_user?` to
  `current_publisher_is_part_of_school_group?`
- Remove superfluous include of `AuthenticationConcerns` in
  `Publishers::BaseController` (it's already included in
  `ApplicationController`)

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1634