### PR TITLE
Strip whitespaces when searching

### DIFF
--- a/app/form_models/vacancy_algolia_search_form.rb
+++ b/app/form_models/vacancy_algolia_search_form.rb
@@ -9,10 +9,10 @@ class VacancyAlgoliaSearchForm
               :total_filters
 
   def initialize(params = {})
-    @keyword = params[:keyword]
+    @keyword = params[:keyword].strip!
 
-    @location = params[:location] || params[:location_category]
-    @location_category = params[:location_category]
+    @location = params[:location].strip! || params[:location_category].strip!
+    @location_category = params[:location_category].strip!
     @radius = params[:radius] || 10
 
     @job_roles = params[:job_roles]

--- a/spec/form_models/vacancy_algolia_search_form_spec.rb
+++ b/spec/form_models/vacancy_algolia_search_form_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe VacancyAlgoliaSearchForm, type: :model do
+  let(:subject) { described_class.new(params) }
+
+  context "when user input contains trailing whitespace" do
+    let(:keyword) { " teacher " }
+    let(:location) { "the big smoke " }
+    let(:location_category) { " whitespace county" }
+    let(:params) do
+      { keyword: keyword, location: location, location_category: location_category }
+    end
+
+    it "strips the whitespace before saving the attribute" do
+      expect(subject.keyword).to eq "teacher"
+      expect(subject.location).to eq "the big smoke"
+      expect(subject.location_category).to eq "whitespace county"
+    end
+  end
+end


### PR DESCRIPTION
Currently, 'london' searches a polygon and 'london ' searches a point.

Compare "90 jobs found near 'London '" and "134 jobs found in 'London'". The former fails to use a polygon because of the trailing whitespace.

This has also been messing up searches in Birmingham (127 counts of searching with a whitespace), Manchester, Liverpool, Sheffield, etc.

In our sample, there were 168 searches for "london " and 6376 for "london"
