### PR TITLE
Rename session keys to be unambiguous

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,10 +29,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def current_session_id
-    session.to_h["session_id"]
-  end
-
   def strip_empty_checkboxes(fields, form_key = nil)
     params_to_strip = params[form_key].present? ? params[form_key] : params
     fields.each do |field|

--- a/app/controllers/concerns/publishers/authentication_concerns.rb
+++ b/app/controllers/concerns/publishers/authentication_concerns.rb
@@ -10,7 +10,11 @@ module Publishers::AuthenticationConcerns
   end
 
   def publisher_signed_in?
-    session.key?(:session_id)
+    session.key?(:publisher_oid)
+  end
+
+  def current_publisher_oid
+    session.to_h["publisher_oid"]
   end
 
   def current_organisation
@@ -18,18 +22,18 @@ module Publishers::AuthenticationConcerns
   end
 
   def current_school
-    @current_school ||= School.find_by!(urn: session[:urn]) if session[:urn].present?
+    @current_school ||= School.find_by!(urn: session[:organisation_urn]) if session[:organisation_urn].present?
   end
 
   def current_school_group
-    if session[:uid].present?
-      @current_school_group ||= SchoolGroup.find_by!(uid: session[:uid])
-    elsif LocalAuthorityAccessFeature.enabled? && session[:la_code].present?
-      @current_school_group ||= SchoolGroup.find_by!(local_authority_code: session[:la_code])
+    if session[:organisation_uid].present?
+      @current_school_group ||= SchoolGroup.find_by!(uid: session[:organisation_uid])
+    elsif LocalAuthorityAccessFeature.enabled? && session[:organisation_la_code].present?
+      @current_school_group ||= SchoolGroup.find_by!(local_authority_code: session[:organisation_la_code])
     end
   end
 
   def current_publisher_is_part_of_school_group?
-    session[:uid].present? || session[:la_code].present?
+    session[:organisation_uid].present? || session[:organisation_la_code].present?
   end
 end

--- a/app/controllers/concerns/sign_in_audit_concerns.rb
+++ b/app/controllers/concerns/sign_in_audit_concerns.rb
@@ -3,14 +3,14 @@ module SignInAuditConcerns
   extend ActiveSupport::Concern
 
   def audit_successful_authentication
-    Auditor::Audit.new(nil, "dfe-sign-in.authentication.success", current_session_id).log_without_association
+    Auditor::Audit.new(nil, "dfe-sign-in.authentication.success", current_publisher_oid).log_without_association
   end
 
   def audit_successful_authorisation
-    Auditor::Audit.new(current_organisation, "dfe-sign-in.authorisation.success", current_session_id).log
+    Auditor::Audit.new(current_organisation, "dfe-sign-in.authorisation.success", current_publisher_oid).log
   end
 
   def audit_failed_authorisation
-    Auditor::Audit.new(nil, "dfe-sign-in.authorisation.failure", current_session_id).log_without_association
+    Auditor::Audit.new(nil, "dfe-sign-in.authorisation.failure", current_publisher_oid).log_without_association
   end
 end

--- a/app/controllers/interests_controller.rb
+++ b/app/controllers/interests_controller.rb
@@ -8,7 +8,7 @@ private
 
   def audit_click
     VacancyGetMoreInfoClick.new(vacancy).track
-    Auditor::Audit.new(vacancy, "vacancy.get_more_information", current_session_id).log
+    Auditor::Audit.new(vacancy, "vacancy.get_more_information", current_publisher_oid).log
     AuditExpressInterestEventJob.perform_later(
       datestamp: Time.current.iso8601.to_s,
       vacancy_id: vacancy.id,

--- a/app/controllers/job_alert_feedbacks_controller.rb
+++ b/app/controllers/job_alert_feedbacks_controller.rb
@@ -9,7 +9,7 @@ class JobAlertFeedbacksController < ApplicationController
       job_alert_feedback_params.merge(subscription: subscription),
     )
     if @feedback.save
-      Auditor::Audit.new(@feedback, "job_alert_feedback.create", current_session_id).log
+      Auditor::Audit.new(@feedback, "job_alert_feedback.create", current_publisher_oid).log
       redirect_to edit_subscription_job_alert_feedback_path(id: @feedback.id), success: I18n.t("job_alert_feedbacks.submitted.relevance")
     end
   end
@@ -30,7 +30,7 @@ class JobAlertFeedbacksController < ApplicationController
       redirect_to invalid_recaptcha_path(form_name: @feedback.class.name.underscore.humanize)
     elsif @feedback_form.valid?
       @feedback.update(form_params)
-      Auditor::Audit.new(@feedback, "job_alert_feedback.update", current_session_id).log
+      Auditor::Audit.new(@feedback, "job_alert_feedback.update", current_publisher_oid).log
       redirect_to root_path, success: I18n.t("job_alert_feedbacks.submitted.comment")
     else
       render :edit

--- a/app/controllers/publishers/base_controller.rb
+++ b/app/controllers/publishers/base_controller.rb
@@ -15,7 +15,7 @@ class Publishers::BaseController < ApplicationController
 
   def check_session
     redirect_to new_identifications_path unless
-      session[:urn].present? || session[:uid].present? || session[:la_code].present?
+      session[:organisation_urn].present? || session[:organisation_uid].present? || session[:organisation_la_code].present?
   end
 
   def check_terms_and_conditions
@@ -23,9 +23,9 @@ class Publishers::BaseController < ApplicationController
   end
 
   def current_publisher
-    return if current_session_id.blank?
+    return if current_publisher_oid.blank?
 
-    @current_publisher ||= Publisher.find_or_create_by(oid: current_session_id)
+    @current_publisher ||= Publisher.find_or_create_by(oid: current_publisher_oid)
   end
 
   def current_publisher_preferences
@@ -38,7 +38,7 @@ class Publishers::BaseController < ApplicationController
     return redirect_to logout_endpoint if current_publisher&.last_activity_at.blank?
 
     if Time.current > (current_publisher.last_activity_at + TIMEOUT_PERIOD)
-      session[:signing_out_for_inactivity] = true
+      session[:publisher_signing_out_for_inactivity] = true
       redirect_to logout_endpoint
     end
   end
@@ -51,7 +51,7 @@ class Publishers::BaseController < ApplicationController
     return auth_email_sign_out_path if AuthenticationFallback.enabled?
 
     url = URI.parse("#{ENV['DFE_SIGN_IN_ISSUER']}/session/end")
-    url.query = { post_logout_redirect_uri: auth_dfe_signout_url, id_token_hint: session[:id_token] }.to_query
+    url.query = { post_logout_redirect_uri: auth_dfe_signout_url, id_token_hint: session[:publisher_id_token] }.to_query
     url.to_s
   end
 

--- a/app/controllers/publishers/organisations_controller.rb
+++ b/app/controllers/publishers/organisations_controller.rb
@@ -25,7 +25,7 @@ private
   end
 
   def session_has_multiple_organisations?
-    session[:multiple_organisations] == true
+    session[:publisher_multiple_organisations] == true
   end
 
   def sort_column

--- a/app/controllers/publishers/sign_in/base_sessions_controller.rb
+++ b/app/controllers/publishers/sign_in/base_sessions_controller.rb
@@ -2,10 +2,10 @@ class Publishers::SignIn::BaseSessionsController < Publishers::BaseController
   skip_before_action :check_user_last_activity_at
 
   def end_session_and_redirect
-    flash_message = if session[:signing_out_for_inactivity]
-                      { notice: I18n.t("messages.access.signed_out_for_inactivity", duration: timeout_period_as_string) }
+    flash_message = if session[:publisher_signing_out_for_inactivity]
+                      { notice: I18n.t("messages.access.publisher_signed_out_for_inactivity", duration: timeout_period_as_string) }
                     else
-                      { success: I18n.t("messages.access.signed_out") }
+                      { success: I18n.t("messages.access.publisher_signed_out") }
                     end
     session.destroy
     redirect_to new_identifications_path, flash_message
@@ -14,12 +14,12 @@ class Publishers::SignIn::BaseSessionsController < Publishers::BaseController
 private
 
   def updated_session_details
-    if session[:urn].present?
-      "Updated session with URN #{session[:urn]}"
-    elsif session[:uid].present?
-      "Updated session with UID #{session[:uid]}"
-    elsif session[:la_code].present?
-      "Updated session with LA_CODE #{session[:la_code]}"
+    if session[:organisation_urn].present?
+      "Updated session with URN #{session[:organisation_urn]}"
+    elsif session[:organisation_uid].present?
+      "Updated session with UID #{session[:organisation_uid]}"
+    elsif session[:organisation_la_code].present?
+      "Updated session with LA_CODE #{session[:organisation_la_code]}"
     end
   end
 end

--- a/app/controllers/publishers/sign_in/dfe/sessions_controller.rb
+++ b/app/controllers/publishers/sign_in/dfe/sessions_controller.rb
@@ -44,12 +44,12 @@ private
 
   def update_session(authorisation_permissions)
     session.update(
-      session_id: user_id,
-      urn: school_urn,
-      uid: trust_uid,
-      la_code: local_authority_code,
-      multiple_organisations: authorisation_permissions.many_organisations?,
-      id_token: id_token,
+      publisher_oid: user_id,
+      organisation_urn: school_urn,
+      organisation_uid: trust_uid,
+      organisation_la_code: local_authority_code,
+      publisher_multiple_organisations: authorisation_permissions.many_organisations?,
+      publisher_id_token: id_token,
     )
     use_school_group_if_available
     Rails.logger.info(updated_session_details)
@@ -150,7 +150,7 @@ private
     school_group = school&.school_groups&.first
     return unless school_group
 
-    session.update(urn: "", uid: school_group.uid) if user_trusts.include?(school_group.uid)
-    session.update(urn: "", la_code: school_group.local_authority_code) if user_local_authorities.include?(school_group.local_authority_code)
+    session.update(organisation_urn: "", organisation_uid: school_group.uid) if user_trusts.include?(school_group.uid)
+    session.update(organisation_urn: "", organisation_la_code: school_group.local_authority_code) if user_local_authorities.include?(school_group.local_authority_code)
   end
 end

--- a/app/controllers/publishers/sign_in/email/sessions_controller.rb
+++ b/app/controllers/publishers/sign_in/email/sessions_controller.rb
@@ -13,13 +13,13 @@ class Publishers::SignIn::Email::SessionsController < Publishers::SignIn::BaseSe
   def new; end
 
   def create
-    session.update(urn: get_urn, uid: get_uid, la_code: get_la_code)
+    session.update(organisation_urn: get_urn, organisation_uid: get_uid, organisation_la_code: get_la_code)
     Rails.logger.info(updated_session_details)
     redirect_to organisation_path
   end
 
   def destroy
-    Rails.logger.info("Hiring staff clicked sign out via fallback authentication: #{session[:oid]}")
+    Rails.logger.info("Hiring staff clicked sign out via fallback authentication: #{session[:publisher_oid]}")
     end_session_and_redirect
   end
 
@@ -56,8 +56,8 @@ private
     return unless options[:oid]
 
     session.update(
-      session_id: options[:oid],
-      multiple_organisations: options[:multiple_organisations],
+      publisher_oid: options[:oid],
+      publisher_multiple_organisations: options[:multiple_organisations],
     )
     Rails.logger.warn("Hiring staff signed in via fallback authentication: #{options[:oid]}")
   end
@@ -104,7 +104,7 @@ private
 
   def publisher_authorised?
     publisher = begin
-                  Publisher.find_by(oid: session.to_h["session_id"])
+                  Publisher.find_by(oid: session.to_h["publisher_oid"])
                 rescue StandardError
                   nil
                 end

--- a/app/controllers/publishers/terms_and_conditions_controller.rb
+++ b/app/controllers/publishers/terms_and_conditions_controller.rb
@@ -23,6 +23,6 @@ private
   end
 
   def audit_toc_acceptance
-    Auditor::Audit.new(current_publisher, "user.terms_and_conditions.accept", current_session_id).log
+    Auditor::Audit.new(current_publisher, "user.terms_and_conditions.accept", current_publisher_oid).log
   end
 end

--- a/app/controllers/publishers/vacancies/copy_controller.rb
+++ b/app/controllers/publishers/vacancies/copy_controller.rb
@@ -14,7 +14,7 @@ class Publishers::Vacancies::CopyController < Publishers::Vacancies::Application
       new_vacancy.refresh_slug
       new_vacancy.save
       update_google_index(new_vacancy) if new_vacancy.listed?
-      Auditor::Audit.new(new_vacancy, "vacancy.copy", current_session_id).log
+      Auditor::Audit.new(new_vacancy, "vacancy.copy", current_publisher_oid).log
       redirect_to organisation_job_review_path(new_vacancy.id)
     else
       replace_errors_in_form(@date_errors, @copy_form)

--- a/app/controllers/publishers/vacancies/publish_controller.rb
+++ b/app/controllers/publishers/vacancies/publish_controller.rb
@@ -18,7 +18,7 @@ class Publishers::Vacancies::PublishController < Publishers::Vacancies::Applicat
 private
 
   def audit_publish_vacancy
-    Auditor::Audit.new(@vacancy, "vacancy.publish", current_session_id).log
+    Auditor::Audit.new(@vacancy, "vacancy.publish", current_publisher_oid).log
     AuditPublishedVacancyJob.perform_later(@vacancy.id)
     update_google_index(@vacancy) if @vacancy.listed?
   end

--- a/app/controllers/publishers/vacancies/vacancy_publish_feedback_controller.rb
+++ b/app/controllers/publishers/vacancies/vacancy_publish_feedback_controller.rb
@@ -17,7 +17,7 @@ class Publishers::Vacancies::VacancyPublishFeedbackController < Publishers::Vaca
 
     return render "new" unless @feedback.save
 
-    Auditor::Audit.new(@vacancy, "vacancy.publish_feedback.create", current_session_id).log
+    Auditor::Audit.new(@vacancy, "vacancy.publish_feedback.create", current_publisher_oid).log
 
     redirect_to organisation_path,
                 success: I18n.t("messages.jobs.feedback.submitted_html", job_title: @vacancy.job_title)

--- a/app/controllers/publishers/vacancies_controller.rb
+++ b/app/controllers/publishers/vacancies_controller.rb
@@ -45,7 +45,7 @@ class Publishers::VacanciesController < Publishers::Vacancies::ApplicationContro
     @vacancy.delete_documents
     @vacancy.trashed!
     remove_google_index(@vacancy)
-    Auditor::Audit.new(@vacancy, "vacancy.delete", current_session_id).log
+    Auditor::Audit.new(@vacancy, "vacancy.delete", current_publisher_oid).log
     redirect_to organisation_path, success: I18n.t("messages.jobs.delete_html", job_title: @vacancy.job_title)
   end
 

--- a/config/locales/notifications.yml
+++ b/config/locales/notifications.yml
@@ -1,8 +1,8 @@
 en:
   messages:
     access:
-      signed_out: You have signed out
-      signed_out_for_inactivity: You have been signed out because you have been inactive for %{duration}
+      publisher_signed_out: You have signed out
+      publisher_signed_out_for_inactivity: You have been signed out because you have been inactive for %{duration}
     feedback:
       submitted: Your feedback has been successfully submitted
     jobs:

--- a/spec/support/auth_helpers.rb
+++ b/spec/support/auth_helpers.rb
@@ -5,16 +5,16 @@ module AuthHelpers
       .and_return(return_value)
   end
 
-  def stub_publishers_auth(urn: nil, uid: nil, la_code: "123", session_id: "session_id", email: nil)
+  def stub_publishers_auth(urn: nil, uid: nil, la_code: "123", oid: "oid", email: nil)
     if urn.present?
-      page.set_rack_session(urn: urn, uid: "", la_code: "")
+      page.set_rack_session(organisation_urn: urn, organisation_uid: "", organisation_la_code: "")
     elsif uid.present?
-      page.set_rack_session(urn: "", uid: uid, la_code: "")
+      page.set_rack_session(organisation_urn: "", organisation_uid: uid, organisation_la_code: "")
     else
-      page.set_rack_session(urn: "", uid: "", la_code: la_code)
+      page.set_rack_session(organisation_urn: "", organisation_uid: "", organisation_la_code: la_code)
     end
-    page.set_rack_session(session_id: session_id)
-    create(:publisher, oid: session_id, email: email, last_activity_at: Time.current)
+    page.set_rack_session(publisher_oid: oid)
+    create(:publisher, oid: oid, email: email, last_activity_at: Time.current)
   end
 
   def stub_authentication_step(organisation_id: "939eac36-0777-48c2-9c2c-b87c948a9ee0",

--- a/spec/system/hiring_staff_can_delete_vacancies_spec.rb
+++ b/spec/system/hiring_staff_can_delete_vacancies_spec.rb
@@ -2,11 +2,11 @@ require "rails_helper"
 RSpec.describe "School deleting vacancies" do
   let(:school) { create(:school) }
   let(:vacancy) { create(:vacancy) }
-  let(:session_id) { SecureRandom.uuid }
+  let(:oid) { SecureRandom.uuid }
 
   before do
     vacancy.organisation_vacancies.create(organisation: school)
-    stub_publishers_auth(urn: school.urn, session_id: session_id)
+    stub_publishers_auth(urn: school.urn, oid: oid)
     stub_document_deletion_of_vacancy
   end
 
@@ -41,7 +41,7 @@ RSpec.describe "School deleting vacancies" do
     delete_vacancy(school, vacancy.id)
 
     activity = vacancy.activities.last
-    expect(activity.session_id).to eq(session_id)
+    expect(activity.session_id).to eq(oid)
     expect(activity.key).to eq("vacancy.delete")
   end
 

--- a/spec/system/hiring_staff_can_edit_a_draft_vacancy_as_a_school_group_spec.rb
+++ b/spec/system/hiring_staff_can_edit_a_draft_vacancy_as_a_school_group_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe "Editing a draft vacancy" do
   let(:school_group) { create(:trust) }
   let(:school_1) { create(:school, name: "First school") }
   let(:school_2) { create(:school, name: "Second school") }
-  let(:session_id) { SecureRandom.uuid }
+  let(:oid) { SecureRandom.uuid }
   let(:vacancy) { create(:vacancy, :at_central_office, :draft) }
 
   before do
     vacancy.organisation_vacancies.create(organisation: school_group)
     SchoolGroupMembership.find_or_create_by(school_id: school_1.id, school_group_id: school_group.id)
     SchoolGroupMembership.find_or_create_by(school_id: school_2.id, school_group_id: school_group.id)
-    stub_publishers_auth(uid: school_group.uid, session_id: session_id)
+    stub_publishers_auth(uid: school_group.uid, oid: oid)
   end
 
   describe "#job_location" do

--- a/spec/system/hiring_staff_can_edit_a_published_vacancy_as_a_school_group_spec.rb
+++ b/spec/system/hiring_staff_can_edit_a_published_vacancy_as_a_school_group_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe "Editing a published vacancy" do
   let(:school_group) { create(:trust) }
   let(:school_1) { create(:school, name: "First school") }
   let(:school_2) { create(:school, name: "Second school") }
-  let(:session_id) { SecureRandom.uuid }
+  let(:oid) { SecureRandom.uuid }
   let(:vacancy) { create(:vacancy, :at_central_office, :published) }
 
   before do
     vacancy.organisation_vacancies.create(organisation: school_group)
     SchoolGroupMembership.find_or_create_by(school_id: school_1.id, school_group_id: school_group.id)
     SchoolGroupMembership.find_or_create_by(school_id: school_2.id, school_group_id: school_group.id)
-    stub_publishers_auth(uid: school_group.uid, session_id: session_id)
+    stub_publishers_auth(uid: school_group.uid, oid: oid)
   end
 
   describe "#job_location" do

--- a/spec/system/hiring_staff_can_edit_a_published_vacancy_as_a_school_spec.rb
+++ b/spec/system/hiring_staff_can_edit_a_published_vacancy_as_a_school_spec.rb
@@ -1,11 +1,11 @@
 require "rails_helper"
 RSpec.describe "Hiring staff can edit a vacancy" do
   let(:school) { create(:school) }
-  let(:session_id) { SecureRandom.uuid }
+  let(:oid) { SecureRandom.uuid }
 
   before(:each) do
     vacancy.organisation_vacancies.create(organisation: school)
-    stub_publishers_auth(urn: school.urn, session_id: session_id)
+    stub_publishers_auth(urn: school.urn, oid: oid)
   end
 
   context "when attempting to edit a draft vacancy" do

--- a/spec/system/hiring_staff_can_edit_school_details_spec.rb
+++ b/spec/system/hiring_staff_can_edit_school_details_spec.rb
@@ -2,10 +2,10 @@ require "rails_helper"
 
 RSpec.describe "Editing a School’s details" do
   let(:school) { create(:school) }
-  let(:session_id) { SecureRandom.uuid }
+  let(:oid) { SecureRandom.uuid }
 
   before do
-    stub_publishers_auth(urn: school.urn, session_id: session_id)
+    stub_publishers_auth(urn: school.urn, oid: oid)
   end
 
   scenario "it allows school users to edit the school details" do

--- a/spec/system/hiring_staff_can_preview_a_vacancy_spec.rb
+++ b/spec/system/hiring_staff_can_preview_a_vacancy_spec.rb
@@ -2,12 +2,12 @@ require "rails_helper"
 
 RSpec.describe "Hiring staff can preview a vacancy" do
   let(:school) { create(:school) }
-  let(:session_id) { SecureRandom.uuid }
+  let(:oid) { SecureRandom.uuid }
   let(:vacancy) { create(:vacancy, :draft) }
 
   before(:each) do
     vacancy.organisation_vacancies.create(organisation: school)
-    stub_publishers_auth(urn: school.urn, session_id: session_id)
+    stub_publishers_auth(urn: school.urn, oid: oid)
   end
 
   context "when reviewing a draft vacancy" do

--- a/spec/system/hiring_staff_can_publish_a_vacancy_as_a_local_authority_spec.rb
+++ b/spec/system/hiring_staff_can_publish_a_vacancy_as_a_local_authority_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Creating a vacancy" do
   let(:school_group) { create(:local_authority) }
   let(:school_1) { create(:school, name: "First school") }
   let(:school_2) { create(:school, name: "Second school") }
-  let(:session_id) { SecureRandom.uuid }
+  let(:oid) { SecureRandom.uuid }
   let(:vacancy) { build(:vacancy, :at_one_school, :complete) }
 
   before do
@@ -12,7 +12,7 @@ RSpec.describe "Creating a vacancy" do
     SchoolGroupMembership.find_or_create_by(school_id: school_1.id, school_group_id: school_group.id)
     SchoolGroupMembership.find_or_create_by(school_id: school_2.id, school_group_id: school_group.id)
     allow(PublisherPreference).to receive(:find_by).and_return(instance_double(PublisherPreference))
-    stub_publishers_auth(la_code: school_group.local_authority_code, session_id: session_id)
+    stub_publishers_auth(la_code: school_group.local_authority_code, oid: oid)
   end
 
   scenario "resets session current_step" do

--- a/spec/system/hiring_staff_can_publish_a_vacancy_as_a_school_spec.rb
+++ b/spec/system/hiring_staff_can_publish_a_vacancy_as_a_school_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "Creating a vacancy" do
   let(:school) { create(:school) }
-  let(:session_id) { SecureRandom.uuid }
+  let(:oid) { SecureRandom.uuid }
 
-  before(:each) { stub_publishers_auth(urn: school.urn, session_id: session_id) }
+  before(:each) { stub_publishers_auth(urn: school.urn, oid: oid) }
 
   scenario "Visiting the school page" do
     school = create(:school, name: "Salisbury School")
@@ -872,7 +872,7 @@ RSpec.describe "Creating a vacancy" do
 
     describe "#publish" do
       scenario "adds the current user as a contact for feedback on the published vacancy" do
-        current_publisher = Publisher.find_by(oid: session_id)
+        current_publisher = Publisher.find_by(oid: oid)
         vacancy = create(:vacancy, :draft)
         vacancy.organisation_vacancies.create(organisation: school)
 
@@ -1020,7 +1020,7 @@ RSpec.describe "Creating a vacancy" do
         click_on "Confirm and submit job"
 
         activity = vacancy.activities.last
-        expect(activity.session_id).to eq(session_id)
+        expect(activity.session_id).to eq(oid)
         expect(activity.key).to eq("vacancy.publish")
       end
 

--- a/spec/system/hiring_staff_can_publish_a_vacancy_as_a_trust_spec.rb
+++ b/spec/system/hiring_staff_can_publish_a_vacancy_as_a_trust_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Creating a vacancy" do
   let(:school_1) { create(:school, name: "First school") }
   let(:school_2) { create(:school, name: "Second school") }
   let(:school_3) { create(:school, :closed, name: "Closed school") }
-  let(:session_id) { SecureRandom.uuid }
+  let(:oid) { SecureRandom.uuid }
   let(:vacancy) { build(:vacancy, :at_central_office, :complete) }
 
   before do
@@ -13,7 +13,7 @@ RSpec.describe "Creating a vacancy" do
     SchoolGroupMembership.find_or_create_by(school_id: school_2.id, school_group_id: school_group.id)
     SchoolGroupMembership.find_or_create_by(school_id: school_3.id, school_group_id: school_group.id)
     allow(PublisherPreference).to receive(:find_by).and_return(instance_double(PublisherPreference))
-    stub_publishers_auth(uid: school_group.uid, session_id: session_id)
+    stub_publishers_auth(uid: school_group.uid, oid: oid)
   end
 
   scenario "resets session current_step" do

--- a/spec/system/hiring_staff_can_save_and_return_later_spec.rb
+++ b/spec/system/hiring_staff_can_save_and_return_later_spec.rb
@@ -2,10 +2,10 @@ require "rails_helper"
 
 RSpec.describe "Hiring staff can save and return later" do
   let(:school) { create(:school) }
-  let(:session_id) { SecureRandom.uuid }
+  let(:oid) { SecureRandom.uuid }
 
   before do
-    stub_publishers_auth(urn: school.urn, session_id: session_id)
+    stub_publishers_auth(urn: school.urn, oid: oid)
     @vacancy = VacancyPresenter.new(build(:vacancy, :draft))
   end
 

--- a/spec/system/hiring_staff_can_sign_in_by_email_spec.rb
+++ b/spec/system/hiring_staff_can_sign_in_by_email_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe "Hiring staff signing in with fallback email authentication" do
             click_on(I18n.t("nav.sign_out"))
 
             within(".govuk-header__navigation") { expect(page).to have_content(I18n.t("nav.sign_in")) }
-            expect(page).to have_content(I18n.t("messages.access.signed_out"))
+            expect(page).to have_content(I18n.t("messages.access.publisher_signed_out"))
 
             # Login link no longer works
             visit auth_email_choose_organisation_path(login_key: login_key.id)

--- a/spec/system/hiring_staff_can_sign_out_with_dfe_spec.rb
+++ b/spec/system/hiring_staff_can_sign_out_with_dfe_spec.rb
@@ -14,6 +14,6 @@ RSpec.describe "Hiring staff can sign out with DfE Sign In" do
     sign_out_via_dsi
 
     within(".govuk-header__navigation") { expect(page).to have_content(I18n.t("nav.sign_in")) }
-    expect(page).to have_content(I18n.t("messages.access.signed_out"))
+    expect(page).to have_content(I18n.t("messages.access.publisher_signed_out"))
   end
 end

--- a/spec/system/hiring_staff_can_submit_vacancy_publish_feedback_spec.rb
+++ b/spec/system/hiring_staff_can_submit_vacancy_publish_feedback_spec.rb
@@ -1,13 +1,13 @@
 require "rails_helper"
 RSpec.describe "Vacancy publish feedback" do
   let(:school) { create(:school) }
-  let(:session_id) { SecureRandom.uuid }
+  let(:oid) { SecureRandom.uuid }
   let(:choose_yes_to_participation) { choose("vacancy-publish-feedback-user-participation-response-interested-field") }
   let(:choose_no_to_participation) do
     choose("vacancy-publish-feedback-user-participation-response-not-interested-field")
   end
 
-  before { stub_publishers_auth(urn: school.urn, session_id: session_id) }
+  before { stub_publishers_auth(urn: school.urn, oid: oid) }
 
   context "The feedback page can not be accessed for a draft job post" do
     let(:draft_job) { create(:vacancy, :complete, :draft) }
@@ -83,7 +83,7 @@ RSpec.describe "Vacancy publish feedback" do
 
       expect(feedback).to_not be_nil
       expect(feedback.comment).to eq("Perfect!")
-      expect(feedback.publisher).to eq(Publisher.find_by(oid: session_id))
+      expect(feedback.publisher).to eq(Publisher.find_by(oid: oid))
       expect(feedback.email).to eq("user@email.com")
     end
 
@@ -100,7 +100,7 @@ RSpec.describe "Vacancy publish feedback" do
 
       activity = published_job.activities.last
       expect(activity.key).to eq("vacancy.publish_feedback.create")
-      expect(activity.session_id).to eq(session_id)
+      expect(activity.session_id).to eq(oid)
     end
   end
 end

--- a/spec/system/hiring_staff_cannot_manage_vacancies_on_maintenance_spec.rb
+++ b/spec/system/hiring_staff_cannot_manage_vacancies_on_maintenance_spec.rb
@@ -2,13 +2,13 @@ require "rails_helper"
 
 RSpec.describe "Hiring staff cannot manage vacancies on maintenance" do
   let(:school) { create(:school) }
-  let(:session_id) { SecureRandom.uuid }
+  let(:oid) { SecureRandom.uuid }
 
   context "when the read-only feature flag is set to true" do
     before do
       allow(ReadOnlyFeature).to receive(:enabled?).and_return(true)
 
-      stub_publishers_auth(urn: school.urn, session_id: session_id)
+      stub_publishers_auth(urn: school.urn, oid: oid)
 
       visit organisation_path
     end
@@ -26,7 +26,7 @@ RSpec.describe "Hiring staff cannot manage vacancies on maintenance" do
     before do
       allow(ReadOnlyFeature).to receive(:enabled?).and_return(false)
 
-      stub_publishers_auth(urn: school.urn, session_id: session_id)
+      stub_publishers_auth(urn: school.urn, oid: oid)
 
       visit organisation_path
     end

--- a/spec/system/hiring_staff_have_to_accept_terms_spec.rb
+++ b/spec/system/hiring_staff_have_to_accept_terms_spec.rb
@@ -2,10 +2,10 @@ require "rails_helper"
 
 RSpec.describe "Hiring staff accepts terms and conditions" do
   let(:school) { create(:school) }
-  let(:session_id) { "a-valid-oid" }
-  let(:current_publisher) { Publisher.find_by(oid: session_id) }
+  let(:oid) { "a-valid-oid" }
+  let(:current_publisher) { Publisher.find_by(oid: oid) }
   before do
-    stub_publishers_auth(urn: school.urn, session_id: session_id)
+    stub_publishers_auth(urn: school.urn, oid: oid)
   end
 
   context "the user has not accepted the terms and conditions" do
@@ -40,7 +40,7 @@ RSpec.describe "Hiring staff accepts terms and conditions" do
 
       activity = current_publisher.activities.last
       expect(activity.key).to eq("user.terms_and_conditions.accept")
-      expect(activity.session_id).to eq(session_id)
+      expect(activity.session_id).to eq(oid)
     end
 
     scenario "an error is shown if they don’t accept" do
@@ -63,7 +63,7 @@ RSpec.describe "Hiring staff accepts terms and conditions" do
         visit terms_and_conditions_path
         click_on(I18n.t("nav.sign_out"))
 
-        expect(page).to have_content(I18n.t("messages.access.signed_out"))
+        expect(page).to have_content(I18n.t("messages.access.publisher_signed_out"))
       end
 
       scenario "without authentication fallback" do
@@ -75,7 +75,7 @@ RSpec.describe "Hiring staff accepts terms and conditions" do
 
         sign_out_via_dsi
 
-        expect(page).to have_content(I18n.t("messages.access.signed_out"))
+        expect(page).to have_content(I18n.t("messages.access.publisher_signed_out"))
       end
     end
   end

--- a/spec/system/hiring_staff_receive_email_prompt_for_expired_vacancy_feedback_spec.rb
+++ b/spec/system/hiring_staff_receive_email_prompt_for_expired_vacancy_feedback_spec.rb
@@ -2,11 +2,11 @@ require "rails_helper"
 RSpec.describe "Creating a vacancy" do
   include ActiveJob::TestHelper
   let(:school) { create(:school) }
-  let(:session_id) { SecureRandom.uuid }
+  let(:oid) { SecureRandom.uuid }
 
   before(:each) do
     ActionMailer::Base.deliveries.clear
-    stub_publishers_auth(urn: school.urn, session_id: session_id, email: "test@mail.com")
+    stub_publishers_auth(urn: school.urn, oid: oid, email: "test@mail.com")
   end
 
   after(:each) do
@@ -15,7 +15,7 @@ RSpec.describe "Creating a vacancy" do
 
   context "Hiring staff has expired vacancy that is not older than 2 weeks" do
     scenario "does not receive feedback prompt e-mail" do
-      current_publisher = Publisher.find_by(oid: session_id)
+      current_publisher = Publisher.find_by(oid: oid)
       vacancy = create(
         :vacancy,
         :published,
@@ -38,7 +38,7 @@ RSpec.describe "Creating a vacancy" do
 
   context "Hiring staff has 2 expired vacancies that are older than 2 weeks" do
     scenario "receives feedback prompt email with 2 vacancies" do
-      current_publisher = Publisher.find_by(oid: session_id)
+      current_publisher = Publisher.find_by(oid: oid)
       vacancy = create(
         :vacancy,
         :published,
@@ -85,7 +85,7 @@ RSpec.describe "Creating a vacancy" do
 
   context "Two expired vacancies for two users that are older than 2 weeks" do
     scenario "both receives feedback prompt emails" do
-      current_publisher = Publisher.find_by(oid: session_id)
+      current_publisher = Publisher.find_by(oid: oid)
       another_user = create(:publisher, email: "another@user.com")
       vacancy = create(
         :vacancy,

--- a/spec/system/hiring_staff_session_timeout_spec.rb
+++ b/spec/system/hiring_staff_session_timeout_spec.rb
@@ -2,11 +2,11 @@ require "rails_helper"
 
 RSpec.describe "Hiring staff session" do
   let(:school) { create(:school) }
-  let(:session_id) { "session_id" }
-  let(:current_publisher) { Publisher.find_by(oid: session_id) }
+  let(:oid) { "oid" }
+  let(:current_publisher) { Publisher.find_by(oid: oid) }
   before do
     allow(AuthenticationFallback).to receive(:enabled?).and_return(false)
-    stub_publishers_auth(urn: school.urn, session_id: session_id)
+    stub_publishers_auth(urn: school.urn, oid: oid)
   end
 
   after do


### PR DESCRIPTION
- Rename `session_id` to `publisher_oid`
- Prefix `urn`, `uid`, `la_code`, `multiple_organisations`, `id_token`,
  and `signing_out_for_inactivity` with `publisher_` for consistency
- Tweak i18n keys for signing out notifications to match

The existing naming is a bit confusing, and the `session_id` key
conflicts with Devise (which we are now using for jobseeker accounts).

Caution: Deploying this will have the side effect of logging out all
currently logged in users (as the code checks for presence of the new
`publisher_oid` value in the session as part of the activity check in
`Publishers::BaseController#check_user_last_activity_at`)

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1634