### PR TITLE
Strip whitespaces from all form params, and from all existing job alert search criteria

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,8 +9,8 @@ class ApplicationController < ActionController::Base
 
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
 
-  before_action :set_headers
-  before_action :set_root_headers
+  before_action :set_headers, :set_root_headers
+  before_action { strip_nested_param_whitespaces(request.params) }
 
   helper_method :cookies_preference_set?, :referred_from_jobs_path?, :utm_parameters
 
@@ -91,6 +91,19 @@ private
 
   def invalid_recaptcha_score?
     recaptcha_reply["score"] < SUSPICIOUS_RECAPTCHA_THRESHOLD
+  end
+
+  def strip_nested_param_whitespaces(object)
+    # Recursively find strings and strip them of trailing whitespaces
+    if object.is_a?(String)
+      return object.strip
+    elsif object.is_a?(Hash)
+      object.each do |key, value|
+        object[key] = strip_nested_param_whitespaces(value)
+      end
+    end
+
+    object
   end
 
   def replace_devise_notice_flash_with_success!

--- a/db/migrate/20201126201055_remove_trailing_whitespaces_from_subscription_search_criteria.rb
+++ b/db/migrate/20201126201055_remove_trailing_whitespaces_from_subscription_search_criteria.rb
@@ -1,0 +1,15 @@
+class RemoveTrailingWhitespacesFromSubscriptionSearchCriteria < ActiveRecord::Migration[6.0]
+  def change
+    Subscription.find_each(batch_size: 100) do |subscription|
+      new_criteria = {}
+      JSON.parse(subscription.search_criteria).each do |field, value|
+        new_criteria[field] = if value.is_a?(String)
+                                value.strip
+                              else
+                                value
+                              end
+      end
+      subscription.update!(search_criteria: new_criteria.to_json)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_24_120747) do
+ActiveRecord::Schema.define(version: 2020_11_26_201055) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -102,4 +102,29 @@ RSpec.describe ApplicationController, type: :controller do
       end
     end
   end
+
+  describe "#strip_nested_param_whitespaces" do
+    let(:nested_field) { { array_field: %w[1 2], string_field: "   Buckle my shoe   " } }
+    let(:test_form) { { array_field: %w[3 4], string_field: "   Knock on the door   ", nested_field: nested_field } }
+    let(:params) { { test_form: test_form } }
+
+    before do
+      get :check, params: params
+    end
+
+    it "strips any string fields of trailing whitespaces" do
+      expect(controller.request.params[:test_form][:string_field]).to eq "Knock on the door"
+    end
+
+    it "strips any nested string fields of trailing whitespaces" do
+      expect(controller.request.params[:test_form][:nested_field][:string_field]).to eq "Buckle my shoe"
+    end
+
+    it "leaves the other fields and params unchanged" do
+      expect(controller.request.params[:action]).to eq "check"
+      expect(controller.request.params[:controller]).to eq "application"
+      expect(controller.request.params[:test_form][:nested_field][:array_field]).to eq %w[1 2]
+      expect(controller.request.params[:test_form][:array_field]).to eq %w[3 4]
+    end
+  end
 end


### PR DESCRIPTION
The reason for doing this was that, currently, 'london' is handled differently by search than 'london     ' (the latter searches around a point, the former in a polygon).

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1653
