### PR TITLE
Bigquery improve vacancy tagging accuracy

### DIFF
--- a/bigquery/scheduled_queries/calculate-daily-vacancy-tag-time-metrics.sql
+++ b/bigquery/scheduled_queries/calculate-daily-vacancy-tag-time-metrics.sql
@@ -174,13 +174,15 @@ WITH
   CROSS JOIN
     `teacher-vacancy-service.production_dataset.scraped_vacancies` AS scraped_vacancies
   LEFT JOIN
-    `teacher-vacancy-service.production_dataset.CALCULATED_schools_joined_with_metrics` AS school
+    `teacher-vacancy-service.production_dataset.school` AS school
   ON
     scraped_vacancies.school_id=school.id
   WHERE
     scraped
     AND NOT expired_before_scrape
-    AND (school_id IS NOT NULL
+    AND (detailed_school_type_in_scope
+      OR school.id IS NULL)
+    AND (school.id IS NOT NULL
       OR school_group_id IS NOT NULL)
   GROUP BY
     date,

--- a/bigquery/views/school.sql
+++ b/bigquery/views/school.sql
@@ -112,12 +112,20 @@ SELECT
   school.data_typeofresourcedprovision_name AS type_of_resourced_provision,
   school.data_ukprn AS ukprn,
   school.data_uprn AS uprn,
-  school.data_urbanrural_name AS urban_rural
+  school.data_urbanrural_name AS urban_rural,
+IF
+  (schoolgroup.type="Multi-academy trust",
+    schoolgroup.size,
+    NULL) AS trust_size
 FROM
   `teacher-vacancy-service.production_dataset.feb20_organisation` AS school
 LEFT JOIN
   `teacher-vacancy-service.production_dataset.feb20_schoolgroupmembership` AS schoolgroupmembership
 ON
   schoolgroupmembership.school_id = school.id
+LEFT JOIN
+  `teacher-vacancy-service.production_dataset.schoolgroup` AS schoolgroup
+ON
+  schoolgroup.id = schoolgroupmembership.school_group_id
 WHERE
   school.type="School" #excludes organisations which aren't schools, like School Groups i.e. MATs

--- a/bigquery/views/schoolgroup.sql
+++ b/bigquery/views/schoolgroup.sql
@@ -1,5 +1,5 @@
 SELECT
-  id,
+  organisation.id,
   name,
   CAST(created_at AS DATE) AS date_created,
   CAST(updated_at AS DATE) AS date_updated,
@@ -28,8 +28,37 @@ SELECT
   data_head_of_group_last_name AS head_last_name,
   REPLACE(data_head_of_group_title,"Not recorded",NULL) AS head_title,
   data_incorporated_on_open_date AS date_opened,
-  data_ukprn AS ukprn
+  data_ukprn AS ukprn,
+  COUNT(DISTINCT schoolgroupmembership.school_id) AS size
 FROM
   `teacher-vacancy-service.production_dataset.feb20_organisation` AS organisation
+LEFT JOIN
+  `teacher-vacancy-service.production_dataset.feb20_schoolgroupmembership` AS schoolgroupmembership
+ON
+  organisation.id=schoolgroupmembership.school_group_id
 WHERE
   type="SchoolGroup" #excludes Schools
+GROUP BY
+  organisation.id,
+  name,
+  date_created,
+  date_updated,
+  date_closed,
+  companies_house_number,
+  county,
+  group_id,
+  locality,
+  group_name,
+  postcode,
+  status,
+  status_code,
+  street,
+  town,
+  full_address,
+  type,
+  uid,
+  head_first_name,
+  head_last_name,
+  head_title,
+  date_opened,
+  ukprn


### PR DESCRIPTION
- Add school group size to schoolgroup view of organisation table.
- Add trust_size to school view of vacancy table
- Switch back to using school view (instead of precalculated table) to calculate tags for crawled vacancies. This reduces query performance but increases accuracy for past values of metrics.