### PR TITLE
Force signout of opposite user type on sign in

### DIFF
--- a/app/controllers/concerns/publishers/authentication_concerns.rb
+++ b/app/controllers/concerns/publishers/authentication_concerns.rb
@@ -13,6 +13,17 @@ module Publishers::AuthenticationConcerns
     session.key?(:publisher_oid)
   end
 
+  def sign_out_publisher!
+    %i[
+      organisation_la_code
+      organisation_uid
+      organisation_urn
+      publisher_id_token
+      publisher_multiple_organisations
+      publisher_oid
+    ].each { |key| session.delete(key) }
+  end
+
   def current_publisher_oid
     session.to_h["publisher_oid"]
   end

--- a/app/controllers/jobseekers/sessions_controller.rb
+++ b/app/controllers/jobseekers/sessions_controller.rb
@@ -1,3 +1,4 @@
 class Jobseekers::SessionsController < Devise::SessionsController
   after_action :replace_devise_notice_flash_with_success!, only: %i[create destroy]
+  before_action :sign_out_publisher!, only: %i[create]
 end

--- a/app/controllers/publishers/identifications_controller.rb
+++ b/app/controllers/publishers/identifications_controller.rb
@@ -1,5 +1,5 @@
 class Publishers::IdentificationsController < Publishers::BaseController
-  skip_before_action :check_user_last_activity_at
+  skip_before_action :authenticate_publisher!
   skip_before_action :check_session, only: %i[new create]
   skip_before_action :check_terms_and_conditions, only: %i[new create]
   skip_before_action :verify_authenticity_token, only: %i[create]

--- a/app/controllers/publishers/sessions_controller.rb
+++ b/app/controllers/publishers/sessions_controller.rb
@@ -1,8 +1,8 @@
 class Publishers::SessionsController < Publishers::BaseController
   protect_from_forgery with: :null_session, only: %i[destroy]
 
-  skip_before_action :check_user_last_activity_at, only: %i[destroy]
-  skip_before_action :update_user_last_activity_at, only: %i[destroy]
+  skip_before_action :authenticate_publisher!, only: %i[destroy]
+  skip_before_action :update_publisher_last_activity_at, only: %i[destroy]
   skip_before_action :check_session, only: %i[destroy]
   skip_before_action :check_terms_and_conditions, only: %i[destroy]
 

--- a/app/controllers/publishers/sign_in/base_sessions_controller.rb
+++ b/app/controllers/publishers/sign_in/base_sessions_controller.rb
@@ -1,5 +1,6 @@
 class Publishers::SignIn::BaseSessionsController < Publishers::BaseController
-  skip_before_action :check_user_last_activity_at
+  skip_before_action :authenticate_publisher!
+  before_action :sign_out_jobseeker!, only: %i[create]
 
   def end_session_and_redirect
     flash_message = if session[:publisher_signing_out_for_inactivity]
@@ -12,6 +13,10 @@ class Publishers::SignIn::BaseSessionsController < Publishers::BaseController
   end
 
 private
+
+  def sign_out_jobseeker!
+    sign_out(:jobseeker)
+  end
 
   def updated_session_details
     if session[:organisation_urn].present?

--- a/app/controllers/publishers/sign_in/dfe/sessions_controller.rb
+++ b/app/controllers/publishers/sign_in/dfe/sessions_controller.rb
@@ -120,7 +120,7 @@ private
   def check_authorisation(authorisation_permissions)
     if authorisation_permissions.authorised? && organisation_id_present? && allowed_user?
       update_session(authorisation_permissions)
-      update_user_last_activity_at
+      update_publisher_last_activity_at
       redirect_to organisation_path
     else
       not_authorised

--- a/spec/support/auth_helpers.rb
+++ b/spec/support/auth_helpers.rb
@@ -1,10 +1,4 @@
 module AuthHelpers
-  def stub_global_auth(return_value: true)
-    allow_any_instance_of(ApplicationController)
-      .to receive(:authenticate?)
-      .and_return(return_value)
-  end
-
   def stub_publishers_auth(urn: nil, uid: nil, la_code: "123", oid: "oid", email: nil)
     if urn.present?
       page.set_rack_session(organisation_urn: urn, organisation_uid: "", organisation_la_code: "")
@@ -98,8 +92,8 @@ module AuthHelpers
     ).to_return(body: authorisation_response, status: 200)
   end
 
-  def sign_in_user
-    within(".govuk-header__navigation") { click_on(I18n.t("nav.sign_in")) }
+  def sign_in_publisher
+    visit new_identifications_path
     within("form") { click_on(I18n.t("buttons.sign_in")) }
   end
 

--- a/spec/system/hiring_staff_can_filter_vacancies_in_their_dashboard_spec.rb
+++ b/spec/system/hiring_staff_can_filter_vacancies_in_their_dashboard_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Hiring staff can filter vacancies in their dashboard" do
     stub_sign_in_with_multiple_organisations
 
     visit root_path
-    sign_in_user
+    sign_in_publisher
 
     PublisherPreference.find_or_create_by(
       publisher_id: Publisher.last.id, school_group_id: school_group.id,

--- a/spec/system/hiring_staff_can_manage_schools_in_school_group_spec.rb
+++ b/spec/system/hiring_staff_can_manage_schools_in_school_group_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Schools in your school group" do
     stub_sign_in_with_multiple_organisations
 
     visit root_path
-    sign_in_user
+    sign_in_publisher
   end
 
   after do

--- a/spec/system/hiring_staff_can_set_managed_organisations_user_preferences_spec.rb
+++ b/spec/system/hiring_staff_can_set_managed_organisations_user_preferences_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Hiring staff can set managed organisations user preferences" do
     stub_sign_in_with_multiple_organisations
 
     visit root_path
-    sign_in_user
+    sign_in_publisher
   end
 
   after do

--- a/spec/system/hiring_staff_can_sign_in_with_dfe_spec.rb
+++ b/spec/system/hiring_staff_can_sign_in_with_dfe_spec.rb
@@ -30,7 +30,7 @@ RSpec.shared_examples "a failed sign in" do |options|
   scenario "it does not sign-in the user, and tells the user what to do" do
     visit root_path
 
-    sign_in_user
+    sign_in_publisher
 
     expect(page).to have_content(I18n.t("static_pages.not_authorised.title"))
     expect(page).to have_content(options[:email])
@@ -40,7 +40,7 @@ RSpec.shared_examples "a failed sign in" do |options|
   scenario "adds entries in the audit log" do
     visit root_path
 
-    sign_in_user
+    sign_in_publisher
 
     authentication = PublicActivity::Activity.first
     expect(authentication.key).to eq("dfe-sign-in.authentication.success")
@@ -60,7 +60,7 @@ RSpec.shared_examples "a failed sign in" do |options|
 
     visit root_path
 
-    sign_in_user
+    sign_in_publisher
   end
 end
 
@@ -90,7 +90,7 @@ RSpec.describe "Hiring staff signing-in with DfE Sign In" do
 
       visit root_path
 
-      sign_in_user
+      sign_in_publisher
     end
 
     it_behaves_like "a successful sign in"
@@ -141,7 +141,7 @@ RSpec.describe "Hiring staff signing-in with DfE Sign In" do
       stub_sign_in_with_multiple_organisations
 
       visit root_path
-      sign_in_user
+      sign_in_publisher
     end
 
     context "with trust" do
@@ -181,7 +181,7 @@ RSpec.describe "Hiring staff signing-in with DfE Sign In" do
       stub_sign_in_with_multiple_organisations
 
       visit root_path
-      sign_in_user
+      sign_in_publisher
     end
 
     context "when user preferences have been set" do
@@ -225,7 +225,7 @@ RSpec.describe "Hiring staff signing-in with DfE Sign In" do
         stub_sign_in_with_multiple_organisations
 
         visit root_path
-        sign_in_user
+        sign_in_publisher
       end
 
       context "when user preferences have been set" do
@@ -292,7 +292,7 @@ RSpec.describe "Hiring staff signing-in with DfE Sign In" do
     it "raises an error" do
       visit root_path
 
-      expect { sign_in_user }.to raise_error(Authorisation::ExternalServerError)
+      expect { sign_in_publisher }.to raise_error(Authorisation::ExternalServerError)
     end
   end
 end

--- a/spec/system/hiring_staff_can_visit_the_public_listings_spec.rb
+++ b/spec/system/hiring_staff_can_visit_the_public_listings_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "School viewing public listings" do
     scenario "A signed in school should see a link back to their own dashboard when viewing public listings" do
       visit root_path
 
-      sign_in_user
+      sign_in_publisher
 
       link_to_dashboard_is_visible_to_publishers?
     end

--- a/spec/system/users_can_only_be_signed_in_to_one_type_of_account_spec.rb
+++ b/spec/system/users_can_only_be_signed_in_to_one_type_of_account_spec.rb
@@ -1,0 +1,124 @@
+require "rails_helper"
+
+RSpec.describe "Users can only be signed in to one type of account" do
+  let!(:jobseeker) { create(:jobseeker, email: "jobseeker@example.com") }
+  let!(:publisher) { create(:publisher, dsi_data: dsi_data) }
+
+  let(:school) { create(:school, urn: "110627") }
+  let(:dsi_data) do
+    { "school_urns" => [school.urn], "trust_uids" => [], "la_codes" => [] }
+  end
+
+  before(:each) do
+    allow(JobseekerAccountsFeature).to receive(:enabled?).and_return(true)
+  end
+
+  context "when a jobseeker is signed in" do
+    before(:each) do
+      login_as(jobseeker, scope: :jobseeker)
+    end
+
+    context "when email fallback is disabled" do
+      let(:dsi_email_address) { Faker::Internet.email }
+
+      before(:each) do
+        allow(AuthenticationFallback).to receive(:enabled?) { false }
+        OmniAuth.config.test_mode = true
+        stub_accepted_terms_and_conditions
+        stub_authentication_step email: dsi_email_address
+        stub_authorisation_step
+        stub_sign_in_with_multiple_organisations
+      end
+
+      after(:each) do
+        OmniAuth.config.mock_auth[:default] = nil
+        OmniAuth.config.mock_auth[:dfe] = nil
+        OmniAuth.config.test_mode = false
+      end
+
+      it "signs out from the jobseeker account when signing in as a publisher using DSI" do
+        visit jobseekers_account_path
+        expect(page).to have_content(I18n.t("jobseekers.accounts.show.page_title"))
+
+        visit root_path
+        sign_in_publisher
+        expect(page).to have_content("Jobs at #{school.name}")
+
+        visit jobseekers_account_path
+        expect(current_path).to eq(new_jobseeker_session_path)
+      end
+    end
+
+    context "when email fallback is enabled" do
+      let!(:login_key) do
+        publisher.emergency_login_keys.create(
+          not_valid_after: Time.current + Publishers::SignIn::Email::SessionsController::EMERGENCY_LOGIN_KEY_DURATION,
+        )
+      end
+
+      before(:each) do
+        allow(AuthenticationFallback).to receive(:enabled?) { true }
+      end
+
+      it "signs out from the jobseeker account when signing in as a publisher using DSI" do
+        visit jobseekers_account_path
+        expect(page).to have_content(I18n.t("jobseekers.accounts.show.page_title"))
+
+        visit auth_email_choose_organisation_path(login_key: login_key.id)
+        expect(page).to have_content("Jobs at #{school.name}")
+
+        visit jobseekers_account_path
+        expect(current_path).to eq(new_jobseeker_session_path)
+      end
+    end
+  end
+
+  context "when a publisher is signed in" do
+    let!(:jobseeker) { create(:jobseeker, email: "jobseeker@example.com", password: "passw0rd") }
+    before(:each) do
+      stub_publishers_auth(urn: "110627")
+    end
+
+    context "when email fallback is disabled" do
+      before(:each) do
+        allow(AuthenticationFallback).to receive(:enabled?) { false }
+      end
+
+      it "signs out from the publisher account when signing in as a jobseeker" do
+        visit organisation_path
+        expect(current_path).to eq(organisation_path)
+
+        visit new_jobseeker_session_path
+        fill_in "Email", with: "jobseeker@example.com"
+        fill_in "Password", with: "passw0rd"
+        click_button "Log in"
+
+        expect(current_path).to eq(jobseekers_saved_jobs_path)
+
+        visit organisation_path
+        expect(current_path).to eq(new_identifications_path)
+      end
+    end
+
+    context "when email fallback is enabled" do
+      before(:each) do
+        allow(AuthenticationFallback).to receive(:enabled?) { true }
+      end
+
+      it "signs out from the publisher account when signing in as a jobseeker" do
+        visit organisation_path
+        expect(current_path).to eq(organisation_path)
+
+        visit new_jobseeker_session_path
+        fill_in "Email", with: "jobseeker@example.com"
+        fill_in "Password", with: "passw0rd"
+        click_button "Log in"
+
+        expect(current_path).to eq(jobseekers_saved_jobs_path)
+
+        visit organisation_path
+        expect(current_path).to eq(new_auth_email_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
When signing in as a publisher or jobseeker, we need to sign out the
respective opposite user type to avoid getting the application into a
weird state or confuse our users. This is very much an edge case (we
don't expect either kind of user to have an account of the opposite
type), but needs to be covered nonetheless.

- Rename `Publishers::BaseController#check_user_last_activity_at` to
  `authenticate_publisher!` to be more consistent with Devise-style
  controller authentication enforcement
- Rename `Publishers::BaseController#update_user_last_activity_at` to
  to `update_publisher_last_activity_at`
- Add `Publishers::AuthenticationConcerns#sign_out_publisher!` to
  clear publisher-related session data (and call on jobseeker sign in)
- Add `Publishers::SignIn::BaseSessionsController::sign_out_jobseeker!`
  (and call on publisher sign in)
- Rename `sign_in_user` test helper to `sign_in_publisher`

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1634