### PR TITLE
Don't titlecase acronyms in SchoolGroup names

### DIFF
--- a/spec/fixtures/example_groups_data.csv
+++ b/spec/fixtures/example_groups_data.csv
@@ -1,5 +1,5 @@
 Group UID,Group ID,Group Name,Companies House Number,Group Type (code),Group Type,Closed Date,Open date,Incorporated on (open date),Group Status (code),Group Status,Group Street,Group Locality,Group Address 3,Group Town,Group County,Group Postcode,Head of Group Title,Head of Group First Name,Head of Group Last Name,UKPRN
-2044,TR00261,ABBEY ACADEMIES TRUST,7318714,"06",Multi-academy trust,,,19/07/2010,OPEN,Open,Bourne Abbey C Of E Primary Academy,Abbey Road,,Bourne,Not recorded,PE10 9EP,Not-applicable,,,10058308
+2044,TR00261,ST. ACQUINAS' ABBEY ACADEMIES CO OPERATIVE LTD (UK),7318714,"06",Multi-academy trust,,,19/07/2010,OPEN,Open,Bourne Abbey C Of E Primary Academy,Abbey Road,,Bourne,Not recorded,PE10 9EP,Not-applicable,,,10058308
 2046,TR00002,ABBEY MULTI ACADEMY TRUST,7705552,6,Multi-academy trust,,,14/07/2011,OPEN,Open,Abbey Grange Church Of England Academy,Butcher Hill,,Leeds,Not recorded,LS16 5EA,Not-applicable,,,10059141
 2059,TR00013,THE ACADEMY OF LINCOLN TRUST,7557670,1,Federation,,,09/03/2011,OPEN,Open,Lincoln Castle Academy,Riseholme Road,,Lincoln,Not recorded,LN1 3SP,Not recorded,,,10058605
 2070,TR01229,ACORN EDUCATION TRUST,7654902,6,Multi-academy trust,,,01/06/2011,OPEN,Open,Kingdown School,Woodcock Road,,Warminster,Not recorded,BA12 9DR,Not recorded,,,10058819

--- a/spec/fixtures/example_links_data.csv
+++ b/spec/fixtures/example_links_data.csv
@@ -1,4 +1,4 @@
 URN,Group UID,Group ID,Group Name,Companies House Number,Group Type (code),Group Type,Closed Date,Open date,Incorporated on (open date),Group Status (code),Group Status,Joined date,EstablishmentName,TypeOfEstablishment (code),TypeOfEstablishment (name),PhaseOfEducation (code),PhaseOfEducation (name),LA (code),LA (name)
-100000,2044,TR00261,ABBEY ACADEMIES TRUST,7318714,"06",Multi-academy trust,,,19/07/2010,OPEN,Open,01/12/2010,Bourne Abbey Church of England Primary Academy,34,Academy converter,2,Primary,925,Lincolnshire
-100001,2044,TR00261,ABBEY ACADEMIES TRUST,7318714,6,Multi-academy trust,,,19/07/2010,OPEN,Open,01/12/2010,Bourne Abbey Church of England Primary Academy,34,Academy converter,2,Primary,925,Lincolnshire
+100000,2044,TR00261,ST. ACQUINAS' ABBEY ACADEMIES CO OPERATIVE LTD (UK),7318714,"06",Multi-academy trust,,,19/07/2010,OPEN,Open,01/12/2010,Bourne Abbey Church of England Primary Academy,34,Academy converter,2,Primary,925,Lincolnshire
+100001,2044,TR00261,ST. ACQUINAS' ABBEY ACADEMIES CO OPERATIVE LTD (UK),7318714,6,Multi-academy trust,,,19/07/2010,OPEN,Open,01/12/2010,Bourne Abbey Church of England Primary Academy,34,Academy converter,2,Primary,925,Lincolnshire
 100002,2070,TR01229,ACORN EDUCATION TRUST,7654902,6,Multi-academy trust,,,01/06/2011,OPEN,Open,01/08/2011,Kingdown School,34,Academy converter,4,Secondary,865,Wiltshire

--- a/spec/lib/organisation_import/import_trust_data_spec.rb
+++ b/spec/lib/organisation_import/import_trust_data_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe ImportTrustData do
       subject.run!
       expect(trust_1).not_to be_blank
       expect(trust_1.gias_data).not_to be_blank
-      expect(trust_1.name).to eql("Abbey Academies Trust")
+      expect(trust_1.name).to eql("St. Acquinas' Abbey Academies Co-operative Ltd (UK)")
       expect(trust_1.group_type).to eql("Multi-academy trust")
       expect(trust_1.address).to eql("Abbey Road")
       expect(trust_1.county).to eql("Not recorded")


### PR DESCRIPTION
### ⚠️ **You'll want to review by looking at the [first commit](https://github.com/DFE-Digital/teaching-vacancies/pull/2458/commits/757a86d2d7c2fbcbe34dac6ab6f1b527f84c9915). The second is just putting the methods in a different order.**

Hypothesis: Trusts will be more willing to use TV if we get their names right.

(I started doing this as something mindless yet productive to do in a ceremony-filled day that wouldn't require too much of my brain to be distracted.)

We receive names for Trusts from Get Information About Schools in a state where all the letters are uppercase.

Exclude acronyms from titlecase transformation, so that for example 'GLF SCHOOLS' is stored as 'GLF Schools', not 'Glf Schools'.

Checking that there are no vowels will not catch all acronyms. I hard-coded acronyms that the vowel-filter didn't catch.

## Screenshots of UI changes:

### Before

<img width="973" alt="Screenshot 2020-12-01 at 16 21 17" src="https://user-images.githubusercontent.com/60350599/100767095-456f7780-33f1-11eb-9e80-8cc10e02c8b2.png">

### After

```ruby
pry(main)> Organisation.find_by(uid: 3190).name
=> "GLF Schools"
```
