### PR TITLE
Jobseeker dashboard markup and styles

### DIFF
--- a/app/components/shared/notification_component/notification_component.scss
+++ b/app/components/shared/notification_component/notification_component.scss
@@ -3,13 +3,13 @@
   float: right;
 }
 
-span.notification {
-  @include govuk-font($size: 19);
-  background-color: $govuk-link-colour;
-  border-radius: 50%;
-  color: govuk-colour('white');
-  margin-left: govuk-spacing(1);
-  padding: 0 govuk-spacing(1);
+.govuk-main-wrapper__notification {
+  background-color: govuk-colour('light-grey');
+  padding-top: 10px;
+
+  .govuk-notification {
+    margin-bottom: 0;
+  }
 }
 
 .js-dismissable {
@@ -23,6 +23,7 @@ span.notification {
 
   border: $govuk-border-width solid govuk-colour('black');
   margin-bottom: govuk-spacing(6);
+  background-color: govuk-colour('white');
   background-position: 13px 23px;
 
   &:focus {

--- a/app/frontend/src/styles/application.scss
+++ b/app/frontend/src/styles/application.scss
@@ -27,6 +27,7 @@ $govuk-image-url-function: frontend-image-url;
 
 @import 'application/banners';
 @import 'application/checkboxGroup';
+@import 'application/dashboard';
 @import 'application/form';
 @import 'application/icons';
 @import 'application/modal';
@@ -41,25 +42,25 @@ $govuk-image-url-function: frontend-image-url;
 @import 'application/jobseekers/account';
 @import 'application/jobseekers/cookies-banner';
 @import 'application/jobseekers/feedback-form';
-@import 'application/jobseekers/location-search';
-@import 'application/jobseekers/search-panel';
-@import 'application/jobseekers/vacancies';
-@import 'application/jobseekers/vacancy';
+@import 'application/jobseekers/filter-vacancies';
 @import 'application/jobseekers/jobs-banner';
 @import 'application/jobseekers/key-dates-sidebar';
+@import 'application/jobseekers/location-search';
+@import 'application/jobseekers/search-panel';
 @import 'application/jobseekers/sortable-links';
-@import 'application/jobseekers/filter-vacancies';
+@import 'application/jobseekers/vacancies';
+@import 'application/jobseekers/vacancy';
 
 @import 'application/publishers/awaiting-feedback-vacancies';
-@import 'application/publishers/hiring-staff';
+@import 'application/publishers/check-your-answers';
 @import 'application/publishers/information-summary';
-@import 'application/publishers/schools-in-your-trust';
 @import 'application/publishers/interruption-card';
 @import 'application/publishers/og-preview';
+@import 'application/publishers/publisher';
+@import 'application/publishers/schools-in-your-trust';
 @import 'application/publishers/scrollable-panel';
 @import 'application/publishers/share-url';
 @import 'application/publishers/statistics';
-@import 'application/publishers/check-your-answers';
 
 body {
   .govuk-width-container {

--- a/app/frontend/src/styles/application.scss
+++ b/app/frontend/src/styles/application.scss
@@ -72,9 +72,6 @@ body {
     border-bottom: 10px solid govuk-colour('orange');
   }
 
-  &.jobseekers_saved_jobs_index,
-  &.jobseekers_subscriptions_index,
-  &.jobseekers_accounts_show,
   &.vacancies_index,
   &.vacancies_show,
   &.vacancies_preview,

--- a/app/frontend/src/styles/application/dashboard.scss
+++ b/app/frontend/src/styles/application/dashboard.scss
@@ -1,0 +1,45 @@
+@mixin dashboard {
+  left: 50%;
+  margin-left: -50vw;
+  padding-bottom: 0;
+  padding-top: 0;
+  position: relative;
+  width: 100vw;
+
+  > .govuk-width-container {
+    background-color: govuk-colour('white');
+    padding-top: govuk-spacing(7);
+  }
+
+  .moj-primary-navigation {
+    background: none;
+
+    .moj-primary-navigation__container {
+      margin: 0;
+  
+      @include govuk-media-query ($until: desktop) {
+        .moj-primary-navigation__item {
+          display: block;
+          line-height: 1;
+          margin-bottom: 0;
+
+          .moj-primary-navigation__link {
+            padding: govuk-spacing(2);
+          }
+      
+          .moj-primary-navigation__link[aria-current] {
+            border-left: govuk-spacing(1) solid $govuk-link-colour;
+      
+            &::before {
+              background-color: transparent;
+            }
+          }
+        }
+      }
+
+      .moj-primary-navigation__link[aria-current] {
+        color: govuk-colour('black');
+      }
+    }
+  }
+}

--- a/app/frontend/src/styles/application/form.scss
+++ b/app/frontend/src/styles/application/form.scss
@@ -3,3 +3,19 @@
     border: 4px solid $govuk-error-colour;
   }
 }
+
+.button-link {
+  background-color: transparent;
+  border: 0;
+  box-shadow: none;
+  color: $govuk-link-colour;
+  display: block;
+  padding: 0;
+  text-decoration: underline;
+}
+
+.button-link:hover {
+  background-color: transparent;
+  color: $govuk-link-hover-colour;
+  text-decoration: underline;
+}

--- a/app/frontend/src/styles/application/jobseekers/account.scss
+++ b/app/frontend/src/styles/application/jobseekers/account.scss
@@ -1,6 +1,10 @@
 .account-header {
   background-color: govuk-colour('light-grey');
-  padding-top: govuk-spacing(2);
+  padding: govuk-spacing(2) 0;
+
+  @include govuk-media-query ($from: desktop) {
+    padding: govuk-spacing(4) 0 0;
+  }
 }
 
 .account-header__user-identifier {
@@ -26,16 +30,6 @@
 .jobseekers_subscriptions_index,
 .jobseekers_accounts_show {
   .govuk-main-wrapper {
-    left: 50%;
-    margin-left: -50vw;
-    padding-bottom: 0;
-    padding-top: govuk-spacing(2);
-    position: relative;
-    width: 100vw;
-
-    > .govuk-width-container {
-      background-color: govuk-colour('white');
-      padding-top: govuk-spacing(3);
-    }
+    @include dashboard;
   }
 }

--- a/app/frontend/src/styles/application/jobseekers/account.scss
+++ b/app/frontend/src/styles/application/jobseekers/account.scss
@@ -6,10 +6,6 @@
   padding-top: govuk-spacing(1);
   position: relative;
   width: 100vw;
-
-  .moj-primary-navigation__container {
-    margin: 0;
-  }
 }
 
 .account-header__user-identifier {

--- a/app/frontend/src/styles/application/jobseekers/account.scss
+++ b/app/frontend/src/styles/application/jobseekers/account.scss
@@ -1,16 +1,11 @@
 .account-header {
   background-color: govuk-colour('light-grey');
-  left: 50%;
-  margin-bottom: govuk-spacing(6);
-  margin-left: -50vw;
-  padding-top: govuk-spacing(1);
-  position: relative;
-  width: 100vw;
+  padding-top: govuk-spacing(2);
 }
 
 .account-header__user-identifier {
   @include govuk-font(24);
-  margin: govuk-spacing(3) 0;
+  margin-bottom: govuk-spacing(3);
 }
 
 .account-sidebar {
@@ -25,4 +20,22 @@
 .account-sidebar__heading {
   @extend %govuk-heading-m;
   margin: govuk-spacing(3) 0;
+}
+
+.jobseekers_saved_jobs_index,
+.jobseekers_subscriptions_index,
+.jobseekers_accounts_show {
+  .govuk-main-wrapper {
+    left: 50%;
+    margin-left: -50vw;
+    padding-bottom: 0;
+    padding-top: govuk-spacing(2);
+    position: relative;
+    width: 100vw;
+
+    > .govuk-width-container {
+      background-color: govuk-colour('white');
+      padding-top: govuk-spacing(3);
+    }
+  }
 }

--- a/app/frontend/src/styles/application/publishers/publisher.scss
+++ b/app/frontend/src/styles/application/publishers/publisher.scss
@@ -1,6 +1,6 @@
 $desktop-container-width: 1200px;
 
-body.hiring-staff {
+.publisher {
   .govuk-width-container {
     @include govuk-media-query($from: desktop) {
       margin-left: auto;
@@ -24,7 +24,6 @@ body.hiring-staff {
       margin-right: auto;
     }
   }
-
 }
 
 .dashboard-header {
@@ -35,20 +34,4 @@ body.hiring-staff {
       line-height: 2em;
     }
   }
-}
-
-.button-link {
-  background-color: transparent;
-  border: 0;
-  box-shadow: none;
-  color: $govuk-link-colour;
-  display: block;
-  padding: 0;
-  text-decoration: underline;
-}
-
-.button-link:hover {
-  background-color: transparent;
-  color: $govuk-link-hover-colour;
-  text-decoration: underline;
 }

--- a/app/frontend/src/styles/application/publishers/scrollable-panel.scss
+++ b/app/frontend/src/styles/application/publishers/scrollable-panel.scss
@@ -45,7 +45,7 @@
 
 // If filter sidebar is hidden, apply shadow mixin to dashboard table only for certain device-widths.
 .govuk-grid-column-full.moj-filter-layout__content {
-  // The 0.9 comes from the class body.hiring-staff .govuk-width-container 'width: 90%'.
+  // The 0.9 comes from the class .publishers .govuk-width-container 'width: 90%'.
   $breakpoint-when-filters-hidden: $desktop-container-width / 0.9;
 
   @include govuk-media-query($until: $breakpoint-when-filters-hidden) {

--- a/app/frontend/src/styles/application/tabs.scss
+++ b/app/frontend/src/styles/application/tabs.scss
@@ -18,30 +18,3 @@ a.govuk-tabs__tab.tab-links-override:focus,
 a.js-enabled .govuk-tabs__tab.tab-links-override:focus {
   color: $govuk-link-active-colour;
 }
-
-.moj-primary-navigation {
-  background: none;
-
-  @include govuk-media-query ($until: desktop) {
-    .moj-primary-navigation__item {
-      display: block;
-      line-height: 1;
-    }
-
-    .moj-primary-navigation__link {
-      padding: govuk-spacing(2);
-    }
-
-    .moj-primary-navigation__link[aria-current] {
-      border-left: govuk-spacing(1) solid $govuk-link-colour;
-
-      &::before {
-        background-color: transparent;
-      }
-    }
-  }
-
-  .moj-primary-navigation__container {
-    margin: 0;
-  }
-}

--- a/app/frontend/src/styles/application/tabs.scss
+++ b/app/frontend/src/styles/application/tabs.scss
@@ -33,7 +33,7 @@ a.js-enabled .govuk-tabs__tab.tab-links-override:focus {
     }
 
     .moj-primary-navigation__link[aria-current] {
-      border-left: 5px solid $govuk-link-colour;
+      border-left: govuk-spacing(1) solid $govuk-link-colour;
 
       &::before {
         background-color: transparent;

--- a/app/frontend/src/styles/application/tabs.scss
+++ b/app/frontend/src/styles/application/tabs.scss
@@ -18,3 +18,30 @@ a.govuk-tabs__tab.tab-links-override:focus,
 a.js-enabled .govuk-tabs__tab.tab-links-override:focus {
   color: $govuk-link-active-colour;
 }
+
+.moj-primary-navigation {
+  background: none;
+
+  @include govuk-media-query ($until: desktop) {
+    .moj-primary-navigation__item {
+      display: block;
+      line-height: 1;
+    }
+
+    .moj-primary-navigation__link {
+      padding: govuk-spacing(2);
+    }
+
+    .moj-primary-navigation__link[aria-current] {
+      border-left: 5px solid $govuk-link-colour;
+
+      &::before {
+        background-color: transparent;
+      }
+    }
+  }
+
+  .moj-primary-navigation__container {
+    margin: 0;
+  }
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,9 +7,9 @@ module ApplicationHelper
   end
 
   def body_class
-    auth_class = publisher_signed_in? ? "hiring-staff" : ""
+    auth_class = publisher_signed_in? ? "publisher" : ""
     action_class = controller_path.tr("/", "_") + "_" + action_name
-    "govuk-template__body app-body-class #{auth_class} #{action_class}"
+    "govuk-template__body #{auth_class} #{action_class}"
   end
 
   def meta_description

--- a/app/views/jobseekers/accounts/show.html.haml
+++ b/app/views/jobseekers/accounts/show.html.haml
@@ -23,7 +23,6 @@
             = t(".summary_list.change")
             %span.govuk-visually-hidden
               = t(".summary_list.password")
-    = button_to "Temporary log out button until we create a proper logout link in the header", destroy_jobseeker_session_path, method: :delete
 
   .govuk-grid-column-one-third
     .account-sidebar

--- a/app/views/jobseekers/accounts/show.html.haml
+++ b/app/views/jobseekers/accounts/show.html.haml
@@ -2,29 +2,32 @@
 
 = render partial: 'account_header'
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    %h1.govuk-heading-l= t(".page_title")
 
-    %dl.govuk-summary-list
-      .govuk-summary-list__row
-        %dt.govuk-summary-list__key= t(".summary_list.email")
-        %dd.govuk-summary-list__value= current_jobseeker.email
-        %dd.govuk-summary-list__actions
-          = link_to edit_jobseeker_registration_path, class: "govuk-link" do
-            = t(".summary_list.change")
-            %span.govuk-visually-hidden
-              = t(".summary_list.email")
-      .govuk-summary-list__row
-        %dt.govuk-summary-list__key= t(".summary_list.password")
-        %dd.govuk-summary-list__value= t(".summary_list.password_placeholder")
-        %dd.govuk-summary-list__actions
-          = link_to edit_jobseeker_registration_path, class: "govuk-link" do
-            = t(".summary_list.change")
-            %span.govuk-visually-hidden
-              = t(".summary_list.password")
 
-  .govuk-grid-column-one-third
-    .account-sidebar
-      %h2.account-sidebar__heading= t(".assistance.heading")
-      %p.govuk-body-s= t(".assistance.content_html", link: link_to(t(".assistance.link_text"), "#", class: "govuk-link"))
+.govuk-width-container
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-l= t(".page_title")
+
+      %dl.govuk-summary-list
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key= t(".summary_list.email")
+          %dd.govuk-summary-list__value= current_jobseeker.email
+          %dd.govuk-summary-list__actions
+            = link_to edit_jobseeker_registration_path, class: "govuk-link" do
+              = t(".summary_list.change")
+              %span.govuk-visually-hidden
+                = t(".summary_list.email")
+        .govuk-summary-list__row
+          %dt.govuk-summary-list__key= t(".summary_list.password")
+          %dd.govuk-summary-list__value= t(".summary_list.password_placeholder")
+          %dd.govuk-summary-list__actions
+            = link_to edit_jobseeker_registration_path, class: "govuk-link" do
+              = t(".summary_list.change")
+              %span.govuk-visually-hidden
+                = t(".summary_list.password")
+
+    .govuk-grid-column-one-third
+      .account-sidebar
+        %h2.account-sidebar__heading= t(".assistance.heading")
+        %p.govuk-body-s= t(".assistance.content_html", link: link_to(t(".assistance.link_text"), "#", class: "govuk-link"))

--- a/app/views/jobseekers/saved_jobs/index.html.haml
+++ b/app/views/jobseekers/saved_jobs/index.html.haml
@@ -2,6 +2,7 @@
 
 = render partial: 'account_header'
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    %h1.govuk-heading-l= t(".page_title")
+.govuk-width-container
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-l= t(".page_title")

--- a/app/views/jobseekers/subscriptions/index.html.haml
+++ b/app/views/jobseekers/subscriptions/index.html.haml
@@ -2,6 +2,7 @@
 
 = render partial: 'account_header'
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    %h1.govuk-heading-l= t(".page_title")
+.govuk-width-container
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-l= t(".page_title")

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -48,9 +48,12 @@
           %span.govuk-phase-banner__text
             This is a new service - #{link_to 'your feedback', new_feedback_path, class: 'govuk-link'} will help us to improve it.
 
-      %main#main-content.govuk-main-wrapper.app-main-class{ role: "main" }
+      %main#main-content.govuk-main-wrapper{ role: "main" }
 
-        = render 'shared/components/notification'
+        - if !flash.empty?
+          .govuk-main-wrapper__notification
+            .govuk-width-container
+              = render 'shared/components/notification'
 
         = yield
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
 
     it "does not return the authenticated class" do
-      expect(helper.body_class).to_not match(/hiring-staff/)
+      expect(helper.body_class).to_not match(/publisher/)
     end
 
     context "when logged in" do
@@ -31,7 +31,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
 
       it "returns the authenticated class" do
-        expect(helper.body_class).to match(/hiring-staff/)
+        expect(helper.body_class).to match(/publisher/)
       end
     end
   end


### PR DESCRIPTION
no jira

- make the jobseeker navigation responsive as per UX designs
- refactor mark up and styling for the header part of jobseeker account pages to make it full width
- found and changed a refernce to hiring staff to publisher that was being used to construct css selectors
- partially abstracted the styles/notion of a dashboard header - more could be done here

chris has given it UX seal of approval 

![Screenshot 2020-12-02 at 01 42 52](https://user-images.githubusercontent.com/1792451/100817287-c81f2380-343f-11eb-917f-d05aa4e9bb6c.png)

![Screenshot 2020-12-02 at 01 42 37](https://user-images.githubusercontent.com/1792451/100817291-c9505080-343f-11eb-8dc1-637532c7105e.png)

![Screenshot 2020-12-02 at 01 41 45](https://user-images.githubusercontent.com/1792451/100817296-ca817d80-343f-11eb-994b-af2aba413444.png)

![Screenshot 2020-12-02 at 01 42 00](https://user-images.githubusercontent.com/1792451/100817293-c9e8e700-343f-11eb-8459-1582bd02d607.png)





