### PR TITLE
Bigquery vacancy tag significance

### DIFF
--- a/bigquery/scheduled_queries/calculate-daily-vacancy-tag-time-metrics.sql
+++ b/bigquery/scheduled_queries/calculate-daily-vacancy-tag-time-metrics.sql
@@ -227,7 +227,7 @@ IF
     SAFE_DIVIDE(live_vacancies_with_this_tag_last_year,
       total_live_vacancies_last_year)) AS change_in_proportion_of_live_vacancies_with_this_tag_since_last_year,
 IF
-  (date>='2021-08-01',
+  (date>='2021-08-01', #don't calculate this until we have at least a year's worth of data to go on
     SAFE_SUBTRACT(SAFE_DIVIDE(live_benchmark_vacancies_with_this_tag,
         benchmark_total_live_vacancies),
       SAFE_DIVIDE(live_benchmark_vacancies_with_this_tag_last_year,
@@ -262,6 +262,7 @@ FROM (
     benchmark_vacancy_metrics.vacancies_published_with_this_tag AS benchmark_vacancies_published_with_this_tag_on_this_date,
     vacancy_metrics.vacancies_published AS total_vacancies_published_on_this_date,
     benchmark_vacancy_metrics.vacancies_published AS benchmark_total_vacancies_published_on_this_date,
+    # calculate numbers of live vacancies on each date for each tag - these are the differences between the cumulative sums of the numbers of vacancies published and expired on each date up to the date we're calculating for (or a year before this date if we're calculating the figure for last year)
     SUM(vacancy_metrics.vacancies_published) OVER (dates_before_today) - SUM(vacancy_metrics.vacancies_expired) OVER (dates_before_today) AS total_live_vacancies,
     SUM(vacancy_metrics.vacancies_published_with_this_tag) OVER (dates_before_today) - SUM(vacancy_metrics.vacancies_expired_with_this_tag) OVER (dates_before_today) AS live_vacancies_with_this_tag,
     SUM(benchmark_vacancy_metrics.vacancies_published) OVER (dates_before_today) - SUM(benchmark_vacancy_metrics.vacancies_expired) OVER (dates_before_today) AS benchmark_total_live_vacancies,

--- a/bigquery/user_defined_functions/statistical-functions.sql
+++ b/bigquery/user_defined_functions/statistical-functions.sql
@@ -1,0 +1,43 @@
+  # Contains useful statistical functions that can be reused across multiple scheduled queries and views in BigQuery.
+  # This script must be run in BigQuery for these functions to become available, and re-run to overwrite the available functions with any new version.
+  #
+  # Test whether there is a probability greater than a specified confidence_level that two probabilities of a Boolean-valued outcome calculated from two independent samples are different
+  # e.g. test whether there is a >95% probability that the probabilities of a vacancy having a particular tag on a particular date and the same date in the previous year are different
+  # x1,x2 are the numbers of true outcomes (e.g. heads, vacancies with tag) in each sample of size n1,n2
+CREATE OR REPLACE FUNCTION
+  `teacher-vacancy-service.production_dataset.two_proportion_z_test`(confidence_level STRING, x1 INT64, n1 INT64, x2 INT64, n2 INT64)
+  RETURNS BOOL AS (
+  # check whether we can approximate these binomial distributions as normal distributions - return NULL if we can't
+  CASE
+  WHEN x1 <= 5 THEN NULL
+  WHEN (n1 - x1) <= 5 THEN NULL
+  WHEN x2 <= 5 THEN NULL
+  WHEN (n2 - x2) <= 5 THEN NULL
+  ELSE
+  # calculate the value of the test statistic
+  ABS(
+  SAFE_DIVIDE
+    (
+      (
+        SAFE_SUBTRACT(SAFE_DIVIDE(x1,n1), SAFE_DIVIDE(x2,n2))
+      ),
+      SAFE.SQRT(
+        SAFE_MULTIPLY(
+          SAFE_MULTIPLY(
+            SAFE_ADD(SAFE_DIVIDE(1,n1), SAFE_DIVIDE(1,n2)),
+            SAFE_DIVIDE(SAFE_ADD(x1,x2), SAFE_ADD(n1,n2))
+            ),
+          SAFE_SUBTRACT(1,SAFE_DIVIDE(SAFE_ADD(x1,x2), SAFE_ADD(n1,n2)))
+          )
+        )
+    )
+    )
+    >
+    # compare this to the z-value for this confidence level, using precalculated values for these confidence levels
+    CASE
+    WHEN confidence_level="90%" THEN 1.645
+    WHEN confidence_level="95%" THEN 1.96
+    WHEN confidence_level="99%" THEN 2.576
+    END
+    END
+    )


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-654
https://dfedigital.atlassian.net/browse/TEVA-1052

## Changes in this PR:

- Add significant_change_in_proportion_of_live_vacancies_with_this_tag_since_last_year (Boolean) and change_in_proportion_of_live_vacancies_with_this_tag_since_last_year (%) fields to daily vacancy tag time metrics calculated table.
- Add corresponding fields for benchmark calculations.
- Refactor windows into separate WINDOW statement to improve performance, improve legibility and reduce duplication.
- Add new statistical functions UDF create/update script - just contains a two-proportion z-test function for now.