### PR TITLE
[TEVA-1517] (part of) add empty variant to notification component

### DIFF
--- a/app/components/shared/notification_component/notification_component.scss
+++ b/app/components/shared/notification_component/notification_component.scss
@@ -61,6 +61,11 @@
   margin-top: govuk-spacing(1);
 }
 
+
+.govuk-notification--empty {
+  border: 5px dashed $govuk-border-colour;
+}
+
 .govuk-notification--notice {
   border-color: govuk-colour('blue');
 }
@@ -89,6 +94,10 @@
   .govuk-notification__list a {
     color: govuk-colour('red');
   }
+}
+
+.govuk-notification--empty.govuk-notification__background {
+  background-color: rgba($color: govuk-colour('light-grey'), $alpha: 0.5);
 }
 
 .govuk-notification--notice.govuk-notification__background {

--- a/app/views/jobseekers/subscriptions/index.html.haml
+++ b/app/views/jobseekers/subscriptions/index.html.haml
@@ -4,5 +4,7 @@
 
 .govuk-width-container
   .govuk-grid-row
-    .govuk-grid-column-two-thirds
+    .govuk-grid-column-full-width
       %h1.govuk-heading-l= t(".page_title")
+
+      = render(Shared::NotificationComponent.new(content: { title: t('.zero_subscriptions_title'), body: t('.zero_subscriptions_body_html') }, style: 'empty', links: nil, dismiss: false, background: true, alert: false))

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -44,3 +44,5 @@ en:
     subscriptions:
       index:
         page_title: Job alerts
+        zero_subscriptions_title: You have no job alert setup
+        zero_subscriptions_body_html: '<a class="govuk-link" href="/">Find a teaching job</a> and a create a job alert to be made aware of future listings.'


### PR DESCRIPTION
creates an `empty` variant of the notification component that can be used in instances like this

design

![Screenshot 2020-12-02 at 14 28 54](https://user-images.githubusercontent.com/1792451/100886396-af4c5780-34ab-11eb-8fa6-241093929008.png)

implementation

![Screenshot 2020-12-02 at 15 08 06](https://user-images.githubusercontent.com/1792451/100890513-3ef40500-34b0-11eb-9b68-65c7810a7a2c.png)

