### PR TITLE
♻️ Refactor GIAS import data transformations

### DIFF
--- a/spec/lib/organisation_import/import_school_data_spec.rb
+++ b/spec/lib/organisation_import/import_school_data_spec.rb
@@ -3,37 +3,6 @@ require "rails_helper"
 RSpec.describe ImportSchoolData do
   let(:subject) { described_class.new }
 
-  describe "#create_organisation" do
-    let(:row) { { "URN" => "test_urn" } }
-    let(:school) { create(:school) }
-
-    before do
-      allow(School).to receive(:find_or_initialize_by).with(hash_including(urn: row["URN"])).and_return(school)
-      allow(subject).to receive(:set_gias_data_as_json).with(school, row)
-      subject.send(:create_organisation, row)
-    end
-
-    it "calls set_complex_properties" do
-      expect(subject).to receive(:set_complex_properties).with(school, row)
-      subject.send(:create_organisation, row)
-    end
-
-    it "calls set_simple_properties" do
-      expect(subject).to receive(:set_simple_properties).with(school, row)
-      subject.send(:create_organisation, row)
-    end
-
-    it "calls set_gias_data_as_json" do
-      expect(subject).to receive(:set_gias_data_as_json).with(school, row)
-      subject.send(:create_organisation, row)
-    end
-
-    it "calls set_readable_phases" do
-      expect(subject).to receive(:set_readable_phases).with(school)
-      subject.send(:create_organisation, row)
-    end
-  end
-
   describe "#save_csv_file" do
     let(:csv_url) { "https://csv_endpoint.csv/magic_endpoint/test.csv" }
     let(:temp_file_location) { "/some_temporary_location/test.csv" }
@@ -175,7 +144,7 @@ RSpec.describe ImportSchoolData do
                     "Town,Postcode\n" \
                     "100000,St John\x92s School,999,999,ZZZ,,?,?,?")
         subject.run!
-        expect(example_school.url).to eql("")
+        expect(example_school.url).to be_nil
       end
     end
   end

--- a/spec/lib/organisation_import/import_trust_data_spec.rb
+++ b/spec/lib/organisation_import/import_trust_data_spec.rb
@@ -3,65 +3,6 @@ require "rails_helper"
 RSpec.describe ImportTrustData do
   let(:subject) { described_class.new }
 
-  describe "#create_organisation" do
-    let(:trust) { create(:trust) }
-    let(:row) do
-      { "Group UID" => "test_uid",
-        "Group Postcode" => "WA1 234",
-        "Group Type (code)" => "06",
-        "Group Name" => "test trust",
-        "Group Locality" => "3 Trust Street",
-        "Group Town" => "Trust Town",
-        "Group County" => "Trustshire" }
-    end
-
-    before do
-      allow(SchoolGroup).to receive(:find_or_initialize_by).with(hash_including(uid: row["Group UID"])).and_return(trust)
-      allow(subject).to receive(:set_gias_data_as_json).with(trust, row)
-      subject.send(:create_organisation, row)
-    end
-
-    it "calls set_complex_properties" do
-      expect(subject).to receive(:set_complex_properties).with(trust, row)
-      subject.send(:create_organisation, row)
-    end
-
-    it "calls set_simple_properties" do
-      expect(subject).to receive(:set_simple_properties).with(trust, row)
-      subject.send(:create_organisation, row)
-    end
-
-    it "calls set_gias_data_as_json" do
-      expect(subject).to receive(:set_gias_data_as_json).with(trust, row)
-      subject.send(:create_organisation, row)
-    end
-
-    it "calls set_geolocation" do
-      expect(subject).to receive(:set_geolocation).with(trust, row["Group Postcode"])
-      subject.send(:create_organisation, row)
-    end
-
-    it "updates the postcode" do
-      expect(trust.postcode).to eq("WA1 234")
-    end
-
-    it "updates the name (with title case)" do
-      expect(trust.name).to eq("Test Trust")
-    end
-
-    it "updates the address" do
-      expect(trust.address).to eq("3 Trust Street")
-    end
-
-    it "updates the town" do
-      expect(trust.town).to eq("Trust Town")
-    end
-
-    it "updates the county" do
-      expect(trust.county).to eq("Trustshire")
-    end
-  end
-
   describe "#save_csv_file" do
     let(:csv_url) { "https://csv_endpoint.csv/magic_endpoint/test.csv" }
     let(:temp_file_location) { "/some_temporary_location/test.csv" }


### PR DESCRIPTION
- Refactored "simple" and "complex" property setting to use a single
  mapping of GIAS keys to our attributes, and a separate set of
  transformations to be applied (using any object that can act as a
  `Proc` and be called with a value to be transformed)
- Call `#presence` on all values by default (instead of specifically
  just for a few fields)
- Removed specs testing internal implementation details of import
  classes

Co-authored-by: David Mears <david.mears@digital.education.gov.uk>