### PR TITLE
Fix for bug related to Location Polygons

### DIFF
--- a/lib/tasks/data/counties.yml
+++ b/lib/tasks/data/counties.yml
@@ -27,7 +27,7 @@
 - Isle of Wight
 - Isles of Scilly
 - Kent
-- Kingston-upon-Hull, City of
+- Kingston upon Hull, City of
 - Kirklees
 - Knowsley
 - Leicestershire


### PR DESCRIPTION
## Changes in this PR:

- I noticed a problem when working on another ticket. When running VacancyFacets.new.refersh locally, I encountered an error related to finding a Location Polygon with the name 'Kingston-upon-Hull, City of'.

- I can also see similar problems have been logged when location category searches have been conducted: https://rollbar.com/dfe/teacher-vacancies/items/1852/

- This problem is due to the presence of hyphens in 'Kingston-upon-Hull, City of' in counties.yml. This name does not match the name retrieved in the API response when the polygons are imported, so the location polygon is not created. 

- The name is instead ''kingston upon hull, city of'
```

   8: def call
     9:   response = HTTParty.get(LOCATION_POLYGON_SETTINGS[location_type][:api])
    10:
    11:   response.fetch("features", []).each do |region_response|
    12:     region_name = region_response.dig("attributes", LOCATION_POLYGON_SETTINGS[location_type][:name_key]).downcase
    13:
    14:     binding.pry
    15:
 => 16:     next unless location_categories_include?(region_name)
    17:
    18:     geometry_rings = region_response.dig("geometry", "rings")
    19:
    20:     # The first ring is the outer boundary and tends to contain far more points than subsequent rings.
    21:     # All subsequent rings within this outer ring are bodies of water (essentially exclusion rings) and
    22:     # can therefore be dismissed.
    23:     # Boundary should be visualised to check how it should be used.
    24:     # If algolia searches by polygon are slow, these boundaries could be downsampled significantly.
    25:     points = []
    26:     geometry_rings[0].each do |point|
    27:       # API returns coords in an unconventional lng,lat order
    28:       # Coordinates rounded as they are stored as double precision floats which have a precision of
    29:       # 15 decimal digits. All UK coordinates only have a maxium of 2 digits before decimal point.
    30:       points.push(*point.reverse.map { |coord| coord.round(13) })
    31:     end
    32:
    33:     LocationPolygon.find_or_create_by(name: region_name, location_type: location_type.to_s)
    34:                    .update(boundary: points)
    35:   end
    36: end

[1] pry(#<ImportPolygons>)> region_name
=> "kingston upon hull, city of"
```