### PR TITLE
Reduce Devise patching

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -51,10 +51,6 @@ class ApplicationController < ActionController::Base
 
 protected
 
-  def after_sign_in_path_for(resource_or_scope)
-    stored_location_for(resource_or_scope) || jobseekers_saved_jobs_path
-  end
-
   def after_sign_out_path_for(_resource)
     new_jobseeker_session_path
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
       sessions: "jobseekers/sessions",
     }
 
+    get "/jobseekers/saved_jobs", to: "jobseekers/saved_jobs#index", as: :jobseeker_root
+
     namespace :jobseekers do
       devise_scope :jobseeker do
         get :check_your_email, to: "registrations#check_your_email", as: :check_your_email


### PR DESCRIPTION
The original Devise method looks like this:

      def after_sign_in_path_for(resource_or_scope)
        stored_location_for(resource_or_scope) || signed_in_root_path(resource_or_scope)
      end

Devise lets us specify the jobseeker_root_path in routes, for it to find with its `after_sign_in_path_for` method.
