### PR TITLE
[TEVA-1603] Rename tvs in terraform state paths

### DIFF
--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -31,7 +31,7 @@ terraform {
 
   backend "s3" {
     bucket  = "terraform-state-002"
-    key     = "tvs/terraform.tfstate" # When using workspaces this changes to ':env/{terraform.workspace}/tvs/terraform.tfstate'
+    key     = "teaching-vacancies/terraform.tfstate" # When using workspaces this changes to ':env/{terraform.workspace}/teaching-vacancies/terraform.tfstate'
     region  = "eu-west-2"
     encrypt = "true"
   }

--- a/terraform/common/terraform.tf
+++ b/terraform/common/terraform.tf
@@ -6,7 +6,7 @@ terraform {
 
   backend "s3" {
     bucket  = "terraform-state-002"
-    key     = "tvs/terraform-common.tfstate"
+    key     = "teaching-vacancies/terraform-common.tfstate"
     region  = "eu-west-2"
     encrypt = "true"
   }

--- a/terraform/monitoring/terraform.tf
+++ b/terraform/monitoring/terraform.tf
@@ -6,7 +6,7 @@ terraform {
 
   backend "s3" {
     bucket  = "terraform-state-002"
-    key     = "tvs/terraform-monitoring.tfstate" # When using workspaces this changes to ':env/{terraform.workspace}/tvs/terraform.tfstate'
+    key     = "teaching-vacancies/terraform-monitoring.tfstate" # When using workspaces this changes to ':env/{terraform.workspace}/tvs/terraform.tfstate'
     region  = "eu-west-2"
     encrypt = "true"
   }


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1603

## Changes in this PR:

- Small rename of intermediate folder, from `tvs` to `teaching-vacancies`, so that
```
/terraform-state-002/tvs/
```
becomes
```
/terraform-state-002/teaching-vacancies/
```

## Next steps:

- [ ] Block merges
- [ ] Rename path through console / command line
- [ ] Merge