### PR TITLE
[TEVA-1503] Part 1: Sign in page with a single error message

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -107,6 +107,8 @@ private
   end
 
   def replace_devise_notice_flash_with_success!
+    return unless flash[:notice].present?
+
     flash[:success] = flash.discard(:notice)
   end
 

--- a/app/controllers/jobseekers/sessions_controller.rb
+++ b/app/controllers/jobseekers/sessions_controller.rb
@@ -1,4 +1,15 @@
 class Jobseekers::SessionsController < Devise::SessionsController
   after_action :replace_devise_notice_flash_with_success!, only: %i[create destroy]
   before_action :sign_out_publisher!, only: %i[create]
+
+  def new
+    if [I18n.t("devise.failure.invalid"), I18n.t("devise.failure.not_found_in_database")].include? flash[:alert]
+      self.resource = resource_class.new(sign_in_params)
+      resource.errors.add(:email, flash[:alert])
+      flash.clear
+      render :new and return
+    else
+      super
+    end
+  end
 end

--- a/app/views/jobseekers/confirmations/new.html.haml
+++ b/app/views/jobseekers/confirmations/new.html.haml
@@ -2,7 +2,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    %h1.govuk-heading-l= t(".title")
+    %h1.govuk-heading-xl= t(".title")
 
     %p.govuk-body= t(".description", email: resource.email)
 

--- a/app/views/jobseekers/registrations/check_your_email.html.haml
+++ b/app/views/jobseekers/registrations/check_your_email.html.haml
@@ -2,7 +2,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    %h1.govuk-heading-l= t(".title")
+    %h1.govuk-heading-xl= t(".title")
 
     %p.govuk-body= t(".description")
 

--- a/app/views/jobseekers/registrations/edit.html.haml
+++ b/app/views/jobseekers/registrations/edit.html.haml
@@ -2,7 +2,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    %h1.govuk-heading-l= t(".title")
+    %h1.govuk-heading-xl= t(".title")
 
     %p.govuk-body= t(".description")
 

--- a/app/views/jobseekers/registrations/edit.html.haml
+++ b/app/views/jobseekers/registrations/edit.html.haml
@@ -4,10 +4,10 @@
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl= t(".title")
 
-    %p.govuk-body= t(".description")
-
     -# = form_for @jobseeker, url: jobseeker_registration_path, method: :put do |f|
     -#   = f.govuk_error_summary
+
+    %p.govuk-body= t(".description")
 
     -#   = f.govuk_email_field :email, label: { size: "s" }, width: "two-thirds"
     -#   = f.govuk_password_field :password, label: { size: "s" }, width: "two-thirds"

--- a/app/views/jobseekers/registrations/new.html.haml
+++ b/app/views/jobseekers/registrations/new.html.haml
@@ -2,7 +2,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    %h1.govuk-heading-l= t(".title")
+    %h1.govuk-heading-xl= t(".title")
 
     %p.govuk-body= t(".description")
 

--- a/app/views/jobseekers/registrations/new.html.haml
+++ b/app/views/jobseekers/registrations/new.html.haml
@@ -4,10 +4,10 @@
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl= t(".title")
 
-    %p.govuk-body= t(".description")
-
     = form_for resource, url: jobseeker_registration_path do |f|
       = f.govuk_error_summary
+
+      %p.govuk-body= t(".description")
 
       = f.govuk_email_field :email, label: { size: "s" }, width: "two-thirds"
       = f.govuk_password_field :password, label: { size: "s" }, width: "two-thirds"

--- a/app/views/jobseekers/sessions/new.html.haml
+++ b/app/views/jobseekers/sessions/new.html.haml
@@ -6,19 +6,20 @@
 
     %p.govuk-body= t(".description")
 
-    = form_for resource, url: jobseeker_registration_path do |f|
+    = form_for(resource, url: jobseeker_session_path) do |f|
       = f.govuk_error_summary
 
       = f.govuk_email_field :email, label: { size: "s" }, width: "two-thirds"
       = f.govuk_password_field :password, label: { size: "s" }, width: "two-thirds"
 
-      = f.govuk_submit t("buttons.continue"), classes: "govuk-!-margin-bottom-0"
+      = f.govuk_submit t("buttons.sign_in"), classes: "govuk-!-margin-bottom-0"
 
     %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
-    %h2.govuk-heading-m= t(".existing_account.heading")
-    %p.govuk-body= t(".existing_account.content_html", link_to: govuk_link_to(t(".existing_account.link"), new_jobseeker_session_path))
+    %h2.govuk-heading-m= t(".no_account.heading")
+    %p.govuk-body= t(".no_account.content_html", link_to: govuk_link_to(t(".no_account.link"), new_jobseeker_registration_path))
 
   .govuk-grid-column-one-third
     .account-sidebar
       %h2.account-sidebar__heading= t(".assistance.heading")
       %p.govuk-body-s= t(".assistance.content_html", link_to: govuk_link_to(t(".assistance.link"), new_identifications_path))
+

--- a/app/views/jobseekers/sessions/new.html.haml
+++ b/app/views/jobseekers/sessions/new.html.haml
@@ -4,10 +4,10 @@
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl= t(".title")
 
-    %p.govuk-body= t(".description")
-
     = form_for(resource, url: jobseeker_session_path) do |f|
       = f.govuk_error_summary
+
+      %p.govuk-body= t(".description")
 
       = f.govuk_email_field :email, label: { size: "s" }, width: "two-thirds"
       = f.govuk_password_field :password, label: { size: "s" }, width: "two-thirds"

--- a/app/views/jobseekers/sessions/new.html.haml
+++ b/app/views/jobseekers/sessions/new.html.haml
@@ -2,7 +2,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    %h1.govuk-heading-l= t(".title")
+    %h1.govuk-heading-xl= t(".title")
 
     %p.govuk-body= t(".description")
 

--- a/app/views/jobseekers/sessions/new.html.haml
+++ b/app/views/jobseekers/sessions/new.html.haml
@@ -4,7 +4,7 @@
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl= t(".title")
 
-    = form_for(resource, url: jobseeker_session_path) do |f|
+    = form_for(resource, url: new_session_path(resource_name)) do |f|
       = f.govuk_error_summary
 
       %p.govuk-body= t(".description")
@@ -12,7 +12,7 @@
       = f.govuk_email_field :email, label: { size: "s" }, width: "two-thirds"
       = f.govuk_password_field :password, label: { size: "s" }, width: "two-thirds"
 
-      %p.govuk-body= govuk_link_to(t(".forgotten"), root_path)
+      %p.govuk-body= govuk_link_to(t(".forgotten"), new_password_path(resource_name))
 
       = f.govuk_submit t("buttons.sign_in"), classes: "govuk-!-margin-bottom-0"
 

--- a/app/views/jobseekers/sessions/new.html.haml
+++ b/app/views/jobseekers/sessions/new.html.haml
@@ -12,6 +12,8 @@
       = f.govuk_email_field :email, label: { size: "s" }, width: "two-thirds"
       = f.govuk_password_field :password, label: { size: "s" }, width: "two-thirds"
 
+      %p.govuk-body= govuk_link_to(t(".forgotten"), root_path)
+
       = f.govuk_submit t("buttons.sign_in"), classes: "govuk-!-margin-bottom-0"
 
     %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -7,10 +7,10 @@ en:
     failure:
       already_authenticated: You are already signed in.
       inactive: Your account is not activated yet.
-      invalid: Invalid %{authentication_keys} or password.
+      invalid: Incorrect email or password
       locked: Your account is locked.
       last_attempt: You have one more attempt before your account is locked.
-      not_found_in_database: Invalid %{authentication_keys} or password.
+      not_found_in_database: Incorrect email or password
       timeout: You have been signed out because you have been inactive for 60 minutes.
       unauthenticated: You need to sign in or sign up before continuing.
       unconfirmed: You have to confirm your email address before continuing.

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -127,8 +127,7 @@ en:
         description: Description of %{organisation_type}
         website: '%{organisation_type} website'
       jobseeker:
-        email_html: Email address (<span class='text-red'>Required</span>)
-        password_html: Password (<span class='text-red'>Required</span>)
+        email: Email address
       job_summary_form:
         about_organisation_html: About %{organisation} (<span class='text-red'>Required</span>)
         job_summary_html: Job summary (<span class='text-red'>Required</span>)

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -72,6 +72,7 @@ en:
           heading: School or Trust accounts
           link: how to create an account
         description: Use your Teaching Vacancies account details to sign in.
+        forgotten: Forgotten your password?
         no_account:
           content_html: If you %{link_to} you can save and apply for jobs you are interested in.
           heading: Don't have an account yet?

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -36,7 +36,7 @@ en:
         existing_account:
           content_html: You can %{link_to} here.
           link: sign in
-          title: Already have an account?
+          heading: Already have an account?
         title: Create an account
     passwords:
       check_your_email_password:
@@ -65,6 +65,18 @@ en:
           job: Job listing
         deadline_passed: Deadline passed
         delete: Delete
+    sessions:
+      new:
+        assistance:
+          content_html: Find out %{link_to} so that you can list teaching jobs at your school or Trust.
+          heading: School or Trust accounts
+          link: how to create an account
+        description: Use your Teaching Vacancies account details to sign in.
+        no_account:
+          content_html: If you %{link_to} you can save and apply for jobs you are interested in.
+          heading: Don't have an account yet?
+          link: create an account
+        title: Teacher sign in
     subscriptions:
       index:
         heading:

--- a/spec/support/jobseeker_helpers.rb
+++ b/spec/support/jobseeker_helpers.rb
@@ -9,14 +9,16 @@ module JobseekerHelpers
   end
 
   def sign_up_jobseeker
-    fill_in "Email", with: jobseeker.email
+    fill_in "Email address", with: jobseeker.email
     fill_in "Password", with: jobseeker.password
     click_on I18n.t("buttons.continue")
   end
 
-  def sign_in_jobseeker
-    fill_in "Email", with: jobseeker.email
-    fill_in "Password", with: jobseeker.password
-    click_on "Log in"
+  def sign_in_jobseeker(email: jobseeker.email, password: jobseeker.password)
+    fill_in "Email address", with: email
+    fill_in "Password", with: password
+    within(".new_jobseeker") do
+      click_on I18n.t("buttons.sign_in")
+    end
   end
 end

--- a/spec/system/jobseekers_can_save_a_job_spec.rb
+++ b/spec/system/jobseekers_can_save_a_job_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "Jobseekers can save a job" do
     it "saves the job after signing up" do
       save_job
       expect(page).to have_content(I18n.t("messages.jobseekers.saved_jobs.unauthenticated"))
-      click_on "Sign up"
+      click_on "create an account"
       sign_up_jobseeker
       confirm_email_address
       and_the_job_is_saved

--- a/spec/system/jobseekers_can_sign_in_to_their_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_in_to_their_account_spec.rb
@@ -5,17 +5,36 @@ RSpec.describe "Jobseekers can sign in to their account" do
 
   before do
     allow(JobseekerAccountsFeature).to receive(:enabled?).and_return(true)
-  end
-
-  scenario "signing in takes them to saved jobs page with banner" do
     visit root_path
     within("nav") do
-      click_link I18n.t("buttons.sign_in")
+      click_on I18n.t("buttons.sign_in")
     end
+  end
 
-    sign_in_jobseeker
+  context "with correct credentials" do
+    scenario "takes them to the saved jobs page with a banner" do
+      sign_in_jobseeker
 
-    expect(current_path).to eq(jobseekers_saved_jobs_path)
-    expect(page).to have_content(I18n.t("devise.sessions.signed_in"))
+      expect(current_path).to eq(jobseekers_saved_jobs_path)
+      expect(page).to have_content(I18n.t("devise.sessions.signed_in"))
+    end
+  end
+
+  context "with a email that does not exist" do
+    scenario "displays a generic error message" do
+      sign_in_jobseeker(email: "i-forgot-my@email-address.com", password: jobseeker.password)
+
+      expect(current_path).to eq(jobseeker_session_path)
+      expect(page).to have_content(I18n.t("devise.failure.invalid"))
+    end
+  end
+
+  context "with incorrect password" do
+    scenario "displays a generic error message" do
+      sign_in_jobseeker(email: jobseeker.email, password: "wrong and bad")
+
+      expect(current_path).to eq(jobseeker_session_path)
+      expect(page).to have_content(I18n.t("devise.failure.invalid"))
+    end
   end
 end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1503

## Questions

Can you think of a neater way to customize Devise's error notification into a GovUK error summary?

## Changes in this PR:

- In order to reduce code complexity by avoiding extending/customizing Devise too heavily, we agreed with UX only to have a single, generic error message for all jobseeker sign in errors.
- The text of the error message 'Invalid email or password' has yet to be written by Content Design
- Fix the font size for page headings on various jobseeker pages
- Put the form error summaries between the title and the description on various jobseeker pages by request of UX

## Screenshots of UI changes:

<img width="1552" alt="Screenshot 2020-12-08 at 11 59 33" src="https://user-images.githubusercontent.com/60350599/101481321-e22f9900-394c-11eb-8e28-c9a68380dabc.png">

<img width="1552" alt="Screenshot 2020-12-08 at 12 02 53" src="https://user-images.githubusercontent.com/60350599/101481591-510cf200-394d-11eb-9774-87c25497b78c.png">
