### PR TITLE
Send page view events to BigQuery

### DIFF
--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -1,4 +1,6 @@
 class Api::ApplicationController < ApplicationController
+  skip_after_action :trigger_page_visited_event
+
   def set_headers
     response.set_header("X-Robots-Tag", "noarchive")
     response.charset = "utf-8"

--- a/app/jobs/send_event_to_data_warehouse_job.rb
+++ b/app/jobs/send_event_to_data_warehouse_job.rb
@@ -1,0 +1,11 @@
+class SendEventToDataWarehouseJob < ApplicationJob
+  queue_as :send_event_to_data_warehouse
+
+  def perform(table_name, data)
+    bq = Google::Cloud::Bigquery.new
+    dataset = bq.dataset(ENV.fetch("BIG_QUERY_DATASET"), skip_lookup: true)
+    table = dataset.table(table_name, skip_lookup: true)
+
+    table.insert(data)
+  end
+end

--- a/app/services/event.rb
+++ b/app/services/event.rb
@@ -1,0 +1,35 @@
+##
+# Represents events occurring within the application that we are interested in tracking.
+#
+# At a minimum, an event has a type and a timestamp at which it occurred. It may also have optional
+# metadata that describes what occurred in more detail. Events are asynchronously sent to our data
+# warehouse using a background job. An instance of `Event` can trigger an arbitrary number of
+# events (to allow for potentially expensive computation on initialization of subclasses).
+class Event
+  TABLE_NAME = "events".freeze
+
+  ##
+  # Asynchronously sends an event and its metadata to the data warehouse
+  #
+  # @param [Symbol, String] event_type The type of event (e.g. `:page_visited`) to trigger
+  # @param [Hash{Symbol => Object}] data An optional hash of data to include with the event
+  #   (Important: if present, values will be coerced into Strings)
+  def trigger(event_type, data = {})
+    data = base_data.merge(
+      type: event_type,
+      occurred_at: Time.now.utc.iso8601(6),
+      data: data.map { |key, value| { key: key.to_s, value: value&.to_s } },
+    )
+    SendEventToDataWarehouseJob.perform_later(TABLE_NAME, data)
+  rescue StandardError => e
+    Rollbar.error(e)
+  end
+
+private
+
+  ##
+  # Data to be included with any event (to be overridden as appropriate in subclasses)
+  def base_data
+    {}
+  end
+end

--- a/app/services/request_event.rb
+++ b/app/services/request_event.rb
@@ -1,0 +1,52 @@
+require "digest/bubblebabble"
+
+##
+# Represents events occurring as part of the Rails request lifecycle
+#
+# This includes additional information in the event that allows us to put the event into the
+# context of a user request. This event can only meaningfully be triggered in controllers.
+class RequestEvent < Event
+  def initialize(request, response, session, current_jobseeker, current_publisher_oid)
+    @request = request
+    @response = response
+    @session = session
+    @current_jobseeker = current_jobseeker
+    @current_publisher_oid = current_publisher_oid
+  end
+
+private
+
+  attr_reader :request, :response, :session, :current_jobseeker, :current_publisher_oid
+
+  def base_data
+    @base_data ||= super.merge(
+      request_uuid: request.uuid,
+      request_ip: request.remote_ip,
+      request_user_agent: user_agent,
+      request_referer: request.referer,
+      request_method: request.method,
+      request_path: request.path,
+      request_query: request.query_string,
+      response_content_type: response.content_type,
+      response_status: response.status,
+      user_anonymised_request_identifier: anonymise([user_agent, request.remote_ip].join),
+      user_anonymised_session_id: anonymise(session.id),
+      user_anonymised_jobseeker_id: anonymise(current_jobseeker&.id),
+      user_anonymised_publisher_id: anonymise(current_publisher_oid),
+    )
+  end
+
+  def user_agent
+    request.headers["User-Agent"]
+  end
+
+  ##
+  # Hashes potentially identifiable information. Uses "bubblebabble" algorithm to make the
+  # resulting SHA hash more human-readable.
+  #
+  # @param [#to_s] identifier An item of identifiable information to anonymise
+  # @return [String, nil] a human-readable anonymised identifier or nil if the identifier is blank
+  def anonymise(identifier)
+    Digest::SHA256.bubblebabble(identifier.to_s) if identifier.present?
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -28,6 +28,7 @@
   - [remove_vacancies_that_expired_yesterday, 1]
   - [reset_sessions, 1]
   - [seed_vacancies_from_api, 1]
+  - [send_event_to_data_warehouse, 1]
   - [submit_performance_platform, 1]
   - [update_algolia_index, 1]
   - [update_dsi_users_in_db, 1]

--- a/documentation/events.md
+++ b/documentation/events.md
@@ -1,0 +1,50 @@
+# Events
+
+## Context
+
+We want to keep improving our service so that users have the best possible experience. To achieve
+this, we need to have a broad idea of how users behave and what impact new features and changes
+have on their actions. We also have a need to audit certain events for security and compliance
+purposes.
+
+We allow users to explicitly opt in to non-essential cookies and client-side analytics, and very
+few do so, which limits the amount and significance of data we can gather through frontend
+analytics tools. These tools also do not allow us to track events that occur outside of the
+application frontend, and present with privacy and cross-site tracking concerns.
+
+To solve this problem, we have implemented an event-based backend data platform. Events are
+triggered within our application and shipped to our data warehouse (currently Google BigQuery).
+
+## Events
+
+At its most basic, an event has a type and a timestamp at which it occurred. Many events will also
+include some sort of metadata, which can be specified in a key/value format:
+
+```ruby
+Event.new.trigger(:reticulated_splines, foo: "bar")
+```
+
+Events can be triggered at any point in the application, but if triggered as part of the Rails
+request lifecycle (i.e. in a controller), we can include a richer set of metadata based on request,
+response, current user, and session information. The `ApplicationController` includes a
+`#request_event` method that can be used to easily trigger events in controllers:
+
+```ruby
+class FooController < ApplicationController
+  def show
+    request_event.trigger(:something_happened, foo: params["bar"])
+  end
+end
+```
+
+We trigger a `page_visited` event for every successful HTTP request (except PaaS healthchecks and
+API calls), so every page view will result in at least one event, but may result in more if custom
+events are triggered.
+
+## Privacy
+
+We create anonymised (hashed) versions of identifiable information, including a combination of a
+user's IP address and user agent, internal user identifiers, and session ID, to be able to
+aggregate events based on pertaining to one user (but not who that user is specifically). We also
+collect raw user agent and IP address information for events that result from a user request,
+which we will handle according to our privacy policy. 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,6 +1,15 @@
 require "rails_helper"
 
 RSpec.describe ApplicationController, type: :controller do
+  describe "page_visited events" do
+    it "triggers a `page_visited` event on a request" do
+      expect { get :check }.to have_enqueued_job(SendEventToDataWarehouseJob).with(
+        "events",
+        hash_including(type: :page_visited, request_path: "/check"),
+      )
+    end
+  end
+
   describe "#redirect_to_domain" do
     before do
       allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production"))

--- a/spec/controllers/nqt_job_alerts_controller_spec.rb
+++ b/spec/controllers/nqt_job_alerts_controller_spec.rb
@@ -7,10 +7,6 @@ RSpec.describe NqtJobAlertsController, type: :controller do
 
   let(:form_inputs) { { keywords: keywords, location: location, email: email } }
 
-  before do
-    ActiveJob::Base.queue_adapter = :test
-  end
-
   describe "#new" do
     let(:params) { form_inputs }
     let(:subject) { get :new, params: params }

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -1,10 +1,6 @@
 require "rails_helper"
 
 RSpec.describe SubscriptionsController, type: :controller do
-  before do
-    ActiveJob::Base.queue_adapter = :test
-  end
-
   describe "#new" do
     subject { get :new, params: { search_criteria: { keyword: "english" } }.symbolize_keys }
 

--- a/spec/jobs/send_event_to_data_warehouse_job_spec.rb
+++ b/spec/jobs/send_event_to_data_warehouse_job_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe SendEventToDataWarehouseJob, type: :job do
+  let(:big_query) { double("Bigquery") }
+  let(:dataset) { double("Dataset") }
+  let(:table) { double("Table") }
+
+  before do
+    allow(ENV).to receive(:fetch).with("BIG_QUERY_DATASET").and_return("test_dataset")
+    allow(Google::Cloud::Bigquery).to receive(:new).and_return(big_query)
+  end
+
+  describe "#perform" do
+    it "inserts the data into the BigQuery table" do
+      expect(big_query).to receive(:dataset).with("test_dataset", skip_lookup: true).and_return(dataset)
+      expect(dataset).to receive(:table).with("a_fancy_table", skip_lookup: true).and_return(table)
+      expect(table).to receive(:insert).with(foo: "bar")
+
+      subject.perform("a_fancy_table", { foo: "bar" })
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -57,6 +57,7 @@ RSpec.configure do |config|
     allow(JobseekerAccountsFeature).to receive(:enabled?).and_return(false)
     Algolia::WebMock.mock!
     allow(Redis).to receive(:new).and_return(MockRedis.new)
+    ActiveJob::Base.queue_adapter = :test
   end
 
   config.include ActionView::Helpers::NumberHelper

--- a/spec/services/event_spec.rb
+++ b/spec/services/event_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe Event do
+  describe "#trigger" do
+    it "enqueues a SendEventToDataWarehouseJob with the expected payload" do
+      expect(SendEventToDataWarehouseJob).to receive(:perform_later).with(
+        "events",
+        type: :reticulated_splines,
+        occurred_at: "1999-12-31T23:59:59.000000Z",
+        data: [{ key: "foo", value: "Bar" }],
+      )
+
+      travel_to(Time.utc(1999, 12, 31, 23, 59, 59)) do
+        subject.trigger(:reticulated_splines, foo: "Bar")
+      end
+    end
+
+    context "when an error occurs when the event is triggered" do
+      let(:error) { StandardError.new("Splines are insufficiently reticulated") }
+
+      it "ignores the error but reports it to Rollbar" do
+        allow(SendEventToDataWarehouseJob).to receive(:perform_later).and_raise(error)
+        expect(Rollbar).to receive(:error).with(error)
+
+        subject.trigger(:reticulated_splines)
+      end
+    end
+  end
+end

--- a/spec/services/request_event_spec.rb
+++ b/spec/services/request_event_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe RequestEvent do
+  subject do
+    described_class.new(
+      request,
+      response,
+      session,
+      jobseeker,
+      current_publisher_oid,
+    )
+  end
+
+  let(:request) do
+    instance_double(
+      ActionDispatch::Request,
+      headers: { "User-Agent" => "Mozilla/4.0 (compatible; MSIE 5.5; Windows 95)" },
+      uuid: "00000000-0000-0000-0000-000000000000",
+      remote_ip: "255.255.255.255",
+      referer: "ukonline.gov.uk",
+      method: "DELETE",
+      path: "/foo/bar",
+      query_string: "foo=bar&baz=bat",
+    )
+  end
+  let(:response) do
+    instance_double(ActionDispatch::Response, content_type: "image/gif", status: 418)
+  end
+  let(:session) do
+    instance_double(ActionDispatch::Request::Session, id: "1337")
+  end
+
+  let(:current_publisher_oid) { 1234 }
+  let(:jobseeker) { instance_double(Jobseeker, id: 4321) }
+
+  describe "#trigger" do
+    let(:expected_data) do
+      {
+        type: :reticulated_splines,
+        occurred_at: "1999-12-31T23:59:59.000000Z",
+        request_uuid: "00000000-0000-0000-0000-000000000000",
+        request_ip: "255.255.255.255",
+        request_user_agent: "Mozilla/4.0 (compatible; MSIE 5.5; Windows 95)",
+        request_referer: "ukonline.gov.uk",
+        request_method: "DELETE",
+        request_path: "/foo/bar",
+        request_query: "foo=bar&baz=bat",
+        response_content_type: "image/gif",
+        response_status: 418,
+        user_anonymised_request_identifier: "xeben-tocep-fadin-tezyg-rapic-begyn-hiraz-pedus-revuk-fisif-lypeh-tohim-lefyb-zolon-nilyk-sigud-coxux",
+        user_anonymised_session_id: "xiler-ciziv-gytol-bivib-mycam-byvyp-linek-musoh-hutud-cosyc-bubul-kolat-kenyt-dumiz-gikin-zylip-poxex",
+        user_anonymised_jobseeker_id: "xuzid-hugyr-gapol-dezon-lizab-hakog-lyvoh-ryson-soded-roher-nipal-zodes-kypiz-fygob-tynit-bifys-fyxex",
+        user_anonymised_publisher_id: "xebop-senag-dehuz-fomah-satuc-vimep-humih-hesik-lyhyf-kimus-mesym-matyg-helyc-fevol-mihis-mocoz-gaxox",
+        data: [{ key: "foo", value: "Bar" }],
+      }
+    end
+
+    it "enqueues a SendEventToDataWarehouseJob with the expected payload" do
+      expect(SendEventToDataWarehouseJob).to receive(:perform_later).with("events", expected_data)
+
+      travel_to(Time.zone.local(1999, 12, 31, 23, 59, 59)) do
+        subject.trigger(:reticulated_splines, foo: "Bar")
+      end
+    end
+  end
+end

--- a/spec/sidekiq/sidekiq_spec.rb
+++ b/spec/sidekiq/sidekiq_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe "Sidekiq configuration" do
       audit_subscription_creation
       google_indexing
       seed_vacancies_from_api
+      send_event_to_data_warehouse
       vacancy_statistics
     ]
   end


### PR DESCRIPTION
This is an initial version of sending events to BigQuery from within
our application (using the Streaming Insert API). It sends one event to
BigQuery for every (non-error) page view. In the future, we will want to
send other types of events as well, such as specific user actions or
errors, as well as including additional data, such as selected variants
for currently running AB tests.

- Create `Event` class to encapsulate an arbitrary event within the app
  (to be used in non-request lifecycle situations, e.g. within a
  background job)
- Create `RequestEvent` class to represent an `Event` that happens as
  part of the Rails request lifecycle (i.e. is triggered from a
  controller) and includes information about the context of the request
- Create `SendEventToDataWarehouseJob` to send event data to BigQuery
  asynchronously
- Trigger a basic `page_view` event for every successful request (using
  `RequestEvent` with no additional metadata)

To try it out, do something on the review app then visit the BigQuery console and run:
```sql
SELECT *
FROM `teacher-vacancy-service.staging_dataset.events`
ORDER BY occurred_at DESC
LIMIT 1000;
```

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1443