### PR TITLE
[TEVA-1503] Jobseeker sign in: Part 1, Version 3

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -105,7 +105,9 @@ private
   end
 
   def replace_devise_notice_flash_with_success!
-    flash[:success] = flash.discard(:notice) if flash[:notice].present?
+    return unless flash[:notice].present?
+
+    flash[:success] = flash.discard(:notice)
   end
 
   def remove_devise_notice_flash!

--- a/app/controllers/jobseekers/sessions_controller.rb
+++ b/app/controllers/jobseekers/sessions_controller.rb
@@ -3,11 +3,10 @@ class Jobseekers::SessionsController < Devise::SessionsController
   before_action :sign_out_publisher!, only: %i[create]
 
   def new
-    if [I18n.t("devise.failure.invalid"), I18n.t("devise.failure.not_found_in_database")].include? flash[:alert]
-      self.resource = resource_class.new(sign_in_params)
-      resource.errors.add(:email, flash[:alert])
+    @sign_in_form = JobseekerSignInForm.new(flash[:alert], sign_in_params)
+    if params[:action] == "create" && @sign_in_form.invalid?
       flash.clear
-      render :new and return
+      render :new
     else
       super
     end

--- a/app/controllers/jobseekers/sessions_controller.rb
+++ b/app/controllers/jobseekers/sessions_controller.rb
@@ -1,14 +1,26 @@
 class Jobseekers::SessionsController < Devise::SessionsController
   after_action :replace_devise_notice_flash_with_success!, only: %i[create destroy]
   before_action :sign_out_publisher!, only: %i[create]
+  before_action :render_form_with_errors, only: %i[new]
 
-  def new
-    @sign_in_form = JobseekerSignInForm.new(flash[:alert], sign_in_params)
-    if params[:action] == "create" && @sign_in_form.invalid?
-      flash.clear
-      render :new
-    else
-      super
+  AUTHENTICATION_FAILURE_MESSAGES = %w[
+    invalid not_found_in_database locked last_attempt
+  ].map { |error| I18n.t("devise.failure.#{error}") }.freeze
+
+private
+
+  def render_form_with_errors
+    self.resource = JobseekerSignInForm.new(sign_in_params)
+    if params[:action] == "create" && resource.invalid?
+      clear_flash_and_render(:new)
+    elsif AUTHENTICATION_FAILURE_MESSAGES.include?(flash[:alert])
+      resource.errors.add(:email, flash[:alert])
+      clear_flash_and_render(:new)
     end
+  end
+
+  def clear_flash_and_render(view)
+    flash.clear
+    render view
   end
 end

--- a/app/controllers/jobseekers/sessions_controller.rb
+++ b/app/controllers/jobseekers/sessions_controller.rb
@@ -1,4 +1,15 @@
 class Jobseekers::SessionsController < Devise::SessionsController
   after_action :replace_devise_notice_flash_with_success!, only: %i[create destroy]
   before_action :sign_out_publisher!, only: %i[create]
+
+  def new
+    if [I18n.t("devise.failure.invalid"), I18n.t("devise.failure.not_found_in_database")].include? flash[:alert]
+      self.resource = resource_class.new(sign_in_params)
+      resource.errors.add(:email, flash[:alert])
+      flash.clear
+      render :new and return
+    else
+      super
+    end
+  end
 end

--- a/app/form_models/jobseeker_sign_in_form.rb
+++ b/app/form_models/jobseeker_sign_in_form.rb
@@ -1,12 +1,9 @@
 class JobseekerSignInForm
   include ActiveModel::Model
 
-  AUTHENTICATION_FAILURE_MESSAGES = [
-    I18n.t("devise.failure.invalid"),
-    I18n.t("devise.failure.not_found_in_database"),
-    I18n.t("devise.failure.locked"),
-    I18n.t("devise.failure.last_attempt"),
-  ].freeze
+  AUTHENTICATION_FAILURE_MESSAGES = %w[
+    invalid not_found_in_database locked last_attempt
+  ].map { |error| I18n.t("devise.failure.#{error}") }.freeze
 
   attr_reader :email, :password, :alert
 

--- a/app/form_models/jobseeker_sign_in_form.rb
+++ b/app/form_models/jobseeker_sign_in_form.rb
@@ -1,0 +1,30 @@
+class JobseekerSignInForm
+  include ActiveModel::Model
+
+  AUTHENTICATION_FAILURE_MESSAGES = [
+    I18n.t("devise.failure.invalid"),
+    I18n.t("devise.failure.not_found_in_database"),
+    I18n.t("devise.failure.locked"),
+    I18n.t("devise.failure.last_attempt"),
+  ].freeze
+
+  attr_reader :email, :password, :alert
+
+  validates           :email, presence: true
+  validates_format_of :email, with: Devise.email_regexp
+  validates           :password, presence: true
+
+  validate            :authentication
+
+  def initialize(alert, params = {})
+    @email = params[:email]
+    @password = params[:password]
+    @alert = alert
+  end
+
+  def authentication
+    return unless AUTHENTICATION_FAILURE_MESSAGES.include?(alert) && errors.none?
+
+    errors.add(:email, alert)
+  end
+end

--- a/app/form_models/jobseeker_sign_in_form.rb
+++ b/app/form_models/jobseeker_sign_in_form.rb
@@ -1,27 +1,14 @@
 class JobseekerSignInForm
   include ActiveModel::Model
 
-  AUTHENTICATION_FAILURE_MESSAGES = %w[
-    invalid not_found_in_database locked last_attempt
-  ].map { |error| I18n.t("devise.failure.#{error}") }.freeze
-
-  attr_reader :email, :password, :alert
+  attr_reader :email, :password
 
   validates           :email, presence: true
   validates_format_of :email, with: Devise.email_regexp
   validates           :password, presence: true
 
-  validate            :authentication
-
-  def initialize(alert, params = {})
+  def initialize(params = {})
     @email = params[:email]
     @password = params[:password]
-    @alert = alert
-  end
-
-  def authentication
-    return unless AUTHENTICATION_FAILURE_MESSAGES.include?(alert) && errors.none?
-
-    errors.add(:email, alert)
   end
 end

--- a/app/views/jobseekers/passwords/edit.html.haml
+++ b/app/views/jobseekers/passwords/edit.html.haml
@@ -9,6 +9,6 @@
 
       = f.govuk_error_summary
 
-      = f.govuk_password_field :password, label: { text: t(".new_password"), size: "s" }, width: "two-thirds"
+      = f.govuk_password_field :password, label: { text: t(".new_password"), size: "s" }, hint: { text: t("helpers.hint.jobseeker_sign_up.password") }, width: "two-thirds"
 
       = f.govuk_submit t("buttons.update_password"), classes: "govuk-!-margin-bottom-0"

--- a/app/views/jobseekers/registrations/edit.html.haml
+++ b/app/views/jobseekers/registrations/edit.html.haml
@@ -8,6 +8,8 @@
 
     = form_for resource, url: jobseeker_registration_path, method: :put do |f|
       = f.govuk_error_summary
+    
+      %p.govuk-body= t(".description", email: resource.email)
 
       = f.govuk_password_field :current_password, label: { text: t(".current_password"), size: "s" }, width: "two-thirds"
       = f.govuk_password_field :password, label: { text: t(".new_password"), size: "s" }, width: "two-thirds"

--- a/app/views/jobseekers/registrations/edit.html.haml
+++ b/app/views/jobseekers/registrations/edit.html.haml
@@ -12,7 +12,7 @@
       %p.govuk-body= t(".description", email: resource.email)
 
       = f.govuk_password_field :current_password, label: { text: t(".current_password"), size: "s" }, width: "two-thirds"
-      = f.govuk_password_field :password, label: { text: t(".new_password"), size: "s" }, width: "two-thirds"
+      = f.govuk_password_field :password, label: { text: t(".new_password"), size: "s" }, hint: { text: t("helpers.hint.jobseeker_sign_up.password") }, width: "two-thirds"
 
       = f.govuk_submit t("buttons.update_password"), classes: "govuk-!-margin-bottom-0"
 

--- a/app/views/jobseekers/registrations/new.html.haml
+++ b/app/views/jobseekers/registrations/new.html.haml
@@ -10,7 +10,7 @@
       %p.govuk-body= t(".description")
 
       = f.govuk_email_field :email, label: { size: "s" }, width: "two-thirds"
-      = f.govuk_password_field :password, label: { size: "s" }, width: "two-thirds"
+      = f.govuk_password_field :password, label: { size: "s" }, hint: { text: t("helpers.hint.jobseeker_sign_up.password") }, width: "two-thirds"
 
       = f.govuk_submit t("buttons.continue"), classes: "govuk-!-margin-bottom-0"
 

--- a/app/views/jobseekers/registrations/new.html.haml
+++ b/app/views/jobseekers/registrations/new.html.haml
@@ -4,10 +4,10 @@
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl= t(".title")
 
-    %p.govuk-body= t(".description")
-
     = form_for resource, url: jobseeker_registration_path do |f|
       = f.govuk_error_summary
+
+      %p.govuk-body= t(".description")
 
       = f.govuk_email_field :email, label: { size: "s" }, width: "two-thirds"
       = f.govuk_password_field :password, label: { size: "s" }, width: "two-thirds"

--- a/app/views/jobseekers/sessions/new.html.haml
+++ b/app/views/jobseekers/sessions/new.html.haml
@@ -4,13 +4,15 @@
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl= t(".title")
 
-    = form_for(resource, url: jobseeker_session_path) do |f|
+    = form_for(resource, url: new_session_path(resource_name)) do |f|
       = f.govuk_error_summary
 
       %p.govuk-body= t(".description")
 
       = f.govuk_email_field :email, label: { size: "s" }, width: "two-thirds"
       = f.govuk_password_field :password, label: { size: "s" }, width: "two-thirds"
+
+      %p.govuk-body= govuk_link_to(t(".forgotten"), new_password_path(resource_name))
 
       = f.govuk_submit t("buttons.sign_in"), classes: "govuk-!-margin-bottom-0"
 

--- a/app/views/jobseekers/sessions/new.html.haml
+++ b/app/views/jobseekers/sessions/new.html.haml
@@ -6,19 +6,20 @@
 
     %p.govuk-body= t(".description")
 
-    = form_for resource, url: jobseeker_registration_path do |f|
+    = form_for(resource, url: jobseeker_session_path) do |f|
       = f.govuk_error_summary
 
       = f.govuk_email_field :email, label: { size: "s" }, width: "two-thirds"
       = f.govuk_password_field :password, label: { size: "s" }, width: "two-thirds"
 
-      = f.govuk_submit t("buttons.continue"), classes: "govuk-!-margin-bottom-0"
+      = f.govuk_submit t("buttons.sign_in"), classes: "govuk-!-margin-bottom-0"
 
     %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
-    %h2.govuk-heading-m= t(".existing_account.heading")
-    %p.govuk-body= t(".existing_account.content_html", link_to: govuk_link_to(t(".existing_account.link"), new_jobseeker_session_path))
+    %h2.govuk-heading-m= t(".no_account.heading")
+    %p.govuk-body= t(".no_account.content_html", link_to: govuk_link_to(t(".no_account.link"), new_jobseeker_registration_path))
 
   .govuk-grid-column-one-third
     .account-sidebar
       %h2.account-sidebar__heading= t(".assistance.heading")
       %p.govuk-body-s= t(".assistance.content_html", link_to: govuk_link_to(t(".assistance.link"), new_identifications_path))
+

--- a/app/views/jobseekers/sessions/new.html.haml
+++ b/app/views/jobseekers/sessions/new.html.haml
@@ -4,10 +4,10 @@
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl= t(".title")
 
-    %p.govuk-body= t(".description")
-
     = form_for(resource, url: jobseeker_session_path) do |f|
       = f.govuk_error_summary
+
+      %p.govuk-body= t(".description")
 
       = f.govuk_email_field :email, label: { size: "s" }, width: "two-thirds"
       = f.govuk_password_field :password, label: { size: "s" }, width: "two-thirds"

--- a/app/views/jobseekers/sessions/new.html.haml
+++ b/app/views/jobseekers/sessions/new.html.haml
@@ -4,7 +4,7 @@
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl= t(".title")
 
-    = form_for(@sign_in_form, as: resource_name, url: new_session_path(resource_name)) do |f|
+    = form_for(resource, as: resource_name, url: new_session_path(resource_name)) do |f|
       = f.govuk_error_summary
 
       %p.govuk-body= t(".description")

--- a/app/views/jobseekers/sessions/new.html.haml
+++ b/app/views/jobseekers/sessions/new.html.haml
@@ -4,13 +4,13 @@
   .govuk-grid-column-two-thirds
     %h1.govuk-heading-xl= t(".title")
 
-    = form_for(resource, url: new_session_path(resource_name)) do |f|
+    = form_for(@sign_in_form, as: resource_name, url: new_session_path(resource_name)) do |f|
       = f.govuk_error_summary
 
       %p.govuk-body= t(".description")
 
-      = f.govuk_email_field :email, label: { size: "s" }, width: "two-thirds"
-      = f.govuk_password_field :password, label: { size: "s" }, width: "two-thirds"
+      = f.govuk_email_field :email, label: { text: t('helpers.label.jobseeker_sign_in_form.email'), size: "s" }, width: "two-thirds"
+      = f.govuk_password_field :password, label: { text: t('helpers.label.jobseeker_sign_in_form.password'), size: "s" }, width: "two-thirds"
 
       %p.govuk-body= govuk_link_to(t(".forgotten"), new_password_path(resource_name))
 

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -24,16 +24,6 @@ en:
     other_reason:
       blank: Tell us why you want to unsubscribe
 
-  # Jobseekers
-  sign_up_errors: &sign_up_errors
-    email:
-      blank: Enter your email address
-      invalid: Enter an email address in the correct format, like name@example.com
-      taken: This email seems to already have an account with Teaching Vacancies
-    password:
-      blank: Enter a password
-      too_short: Enter a password that is at least 8 characters long
-
   # Hiring staff journey
   job_location_errors: &job_location_errors
     job_location:
@@ -169,8 +159,10 @@ en:
       models:
         jobseeker:
           attributes:
-            <<: *sign_up_errors
             email:
+              blank: Enter your email address
+              invalid: Enter an email address in the correct format, like name@example.com
+              taken: This email seems to already have an account with Teaching Vacancies
               not_found: Email address is not valid or the account was not created
             current_password:
               blank: Enter your current password
@@ -178,6 +170,7 @@ en:
             password:
               blank: Enter a password that is at least 8 characters long
               same_as_old: Your new password can't be the same as your old password
+              blank: Enter a password
               too_short: Enter a password that is at least 8 characters long
         vacancy:
           attributes:

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -9,6 +9,12 @@ en:
     comment:
       blank: You have not submitted any further feedback.
       too_long: Feedback must not be more than 1,200 characters
+  jobseeker_sign_in_errors: &jobseeker_sign_in_errors
+    email:
+      blank: Enter your email address
+      invalid: Enter an email address in the correct format, like name@example.com
+    password:
+      blank: Enter a password
   organisation_errors: &organisation_errors
     website:
       url: Enter a link in the correct format, like http://www.school.ac.uk
@@ -102,6 +108,9 @@ en:
         job_alert_feedback_form:
           attributes:
             <<: *job_alert_feedback_errors
+        jobseeker_sign_in_form:
+          attributes:
+            <<: *jobseeker_sign_in_errors
         nqt_job_alerts_form:
           attributes:
             keywords:

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -14,7 +14,7 @@ en:
       blank: Enter your email address
       invalid: Enter an email address in the correct format, like name@example.com
     password:
-      blank: Enter a password
+      blank: Enter your password
   organisation_errors: &organisation_errors
     website:
       url: Enter a link in the correct format, like http://www.school.ac.uk

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -7,10 +7,10 @@ en:
     failure:
       already_authenticated: You are already signed in.
       inactive: Your account is not activated yet.
-      invalid: Incorrect email or password
+      invalid: We did not recognise your sign-in details
       locked: Your account is locked.
       last_attempt: You have one more attempt before your account is locked.
-      not_found_in_database: Incorrect email or password
+      not_found_in_database: We did not recognise your sign-in details
       timeout: You have been signed out because you have been inactive for 60 minutes.
       unauthenticated: You need to sign in or sign up before continuing.
       unconfirmed: You have to confirm your email address before continuing.

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -7,10 +7,10 @@ en:
     failure:
       already_authenticated: You are already signed in.
       inactive: Your account is not activated yet.
-      invalid: Invalid %{authentication_keys} or password.
+      invalid: Incorrect email or password
       locked: Your account is locked.
       last_attempt: You have one more attempt before your account is locked.
-      not_found_in_database: Invalid %{authentication_keys} or password.
+      not_found_in_database: Incorrect email or password
       timeout: You have been signed out because you have been inactive for 60 minutes.
       unauthenticated: You need to sign in or sign up before continuing.
       unconfirmed: You have to confirm your email address before continuing.

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -129,8 +129,7 @@ en:
         description: Description of %{organisation_type}
         website: '%{organisation_type} website'
       jobseeker:
-        email_html: Email address (<span class='text-red'>Required</span>)
-        password_html: Password (<span class='text-red'>Required</span>)
+        email: Email address
       job_summary_form:
         about_organisation_html: About %{organisation} (<span class='text-red'>Required</span>)
         job_summary_html: Job summary (<span class='text-red'>Required</span>)

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -129,7 +129,11 @@ en:
         description: Description of %{organisation_type}
         website: '%{organisation_type} website'
       jobseeker:
+        email_html: Email address (<span class='text-red'>Required</span>)
+        password_html: Password (<span class='text-red'>Required</span>)
+      jobseeker_sign_in_form:
         email: Email address
+        password: Password
       job_summary_form:
         about_organisation_html: About %{organisation} (<span class='text-red'>Required</span>)
         job_summary_html: Job summary (<span class='text-red'>Required</span>)

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -58,8 +58,8 @@ en:
         expires_at: For example, 9:30 am or 11:59 pm (midnight)
         publish_on: For example, 01 01 2021
         starts_on: For example, 01 09 2021
-      jobseeker:
-        password_html: Your password has to be at least 8 characters long
+      jobseeker_sign_up:
+        password: Your password has to be at least 8 characters long
       job_summary_form:
         about_organisation: >-
           This will appear next to the job details under '%{organisation_type} overview'. Feel free to adapt this text

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -81,6 +81,7 @@ en:
           heading: School or Trust accounts
           link: how to create an account
         description: Use your Teaching Vacancies account details to sign in.
+        forgotten: Forgotten your password?
         no_account:
           content_html: If you %{link_to} you can save and apply for jobs you are interested in.
           heading: Don't have an account yet?

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -40,7 +40,7 @@ en:
         existing_account:
           content_html: You can %{link_to} here.
           link: sign in
-          title: Already have an account?
+          heading: Already have an account?
         title: Create an account
     passwords:
       check_your_email_password:
@@ -73,7 +73,18 @@ en:
       saved: Job saved
       success_html: >-
         You have saved this job. <a href="%{link}" class="govuk-link">View all your saved jobs</a> on your account.
-
+    sessions:
+      new:
+        assistance:
+          content_html: Find out %{link_to} so that you can list teaching jobs at your school or Trust.
+          heading: School or Trust accounts
+          link: how to create an account
+        description: Use your Teaching Vacancies account details to sign in.
+        no_account:
+          content_html: If you %{link_to} you can save and apply for jobs you are interested in.
+          heading: Don't have an account yet?
+          link: create an account
+        title: Teacher sign in
     subscriptions:
       index:
         frequency:

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -26,6 +26,7 @@ en:
         report_it: Report it
         title: Check your email
       edit:
+        description: Password reset for %{email}
         current_password: Old password
         new_password: New password
         title: Change password

--- a/spec/form_models/jobseeker_sign_in_form_spec.rb
+++ b/spec/form_models/jobseeker_sign_in_form_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe JobseekerSignInForm, type: :model do
   let(:email) { jobseeker.email }
   let(:password) { jobseeker.password }
   let(:params) { { email: email, password: password } }
-  let(:subject) { JobseekerSignInForm.new(alert, params) }
-  let(:alert) { "Click here to win a prize!" }
+  let(:subject) { JobseekerSignInForm.new(params) }
 
   describe "#email" do
     context "when email is blank" do
@@ -41,38 +40,6 @@ RSpec.describe JobseekerSignInForm, type: :model do
         expect(subject.errors.messages[:password]).to include(
           I18n.t("activemodel.errors.models.jobseeker_sign_in_form.attributes.password.blank"),
         )
-      end
-    end
-  end
-
-  describe "#authenticate" do
-    context "when there are no other errors" do
-      context "when Devise adds a flash alert about failed authentication" do
-        let(:alert) { I18n.t("devise.failure.not_found_in_database") }
-
-        it "converts the message into the govuk error summary component and highlights the first field" do
-          expect(subject).not_to be_valid
-          expect(subject.errors.messages[:email]).to include(alert)
-        end
-      end
-
-      context "when there is a different kind of flash message" do
-        it "does not add an authentication error" do
-          expect(subject).to be_valid
-          expect(subject.errors.messages).to be_blank
-        end
-      end
-    end
-
-    context "when there are other errors" do
-      let(:password) { nil }
-
-      it "does not add an authentication error" do
-        expect(subject).not_to be_valid
-        expect(subject.errors.messages[:password]).to include(
-          I18n.t("activemodel.errors.models.jobseeker_sign_in_form.attributes.password.blank"),
-        )
-        expect(subject.errors.messages[:email]).to be_blank
       end
     end
   end

--- a/spec/form_models/jobseeker_sign_in_form_spec.rb
+++ b/spec/form_models/jobseeker_sign_in_form_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+RSpec.describe JobseekerSignInForm, type: :model do
+  let(:jobseeker) { create(:jobseeker) }
+  let(:email) { jobseeker.email }
+  let(:password) { jobseeker.password }
+  let(:params) { { email: email, password: password } }
+  let(:subject) { JobseekerSignInForm.new(alert, params) }
+  let(:alert) { "Click here to win a prize!" }
+
+  describe "#email" do
+    context "when email is blank" do
+      let(:email) { nil }
+
+      it "raises correct error message" do
+        expect(subject).not_to be_valid
+        expect(subject.errors.messages[:email]).to include(
+          I18n.t("activemodel.errors.models.jobseeker_sign_in_form.attributes.email.blank"),
+        )
+      end
+    end
+
+    context "when contact_email is in an invalid format" do
+      let(:email) { "💅" }
+
+      it "raises correct error message" do
+        expect(subject).not_to be_valid
+        expect(subject.errors.messages[:email]).to include(
+          I18n.t("activemodel.errors.models.jobseeker_sign_in_form.attributes.email.invalid"),
+        )
+      end
+    end
+  end
+
+  describe "#password" do
+    context "when password is blank" do
+      let(:password) { nil }
+
+      it "raises correct error message" do
+        expect(subject).not_to be_valid
+        expect(subject.errors.messages[:password]).to include(
+          I18n.t("activemodel.errors.models.jobseeker_sign_in_form.attributes.password.blank"),
+        )
+      end
+    end
+  end
+
+  describe "#authenticate" do
+    context "when there are no other errors" do
+      context "when Devise adds a flash alert about failed authentication" do
+        let(:alert) { I18n.t("devise.failure.not_found_in_database") }
+
+        it "converts the message into the govuk error summary component and highlights the first field" do
+          expect(subject).not_to be_valid
+          expect(subject.errors.messages[:email]).to include(alert)
+        end
+      end
+
+      context "when there is a different kind of flash message" do
+        it "does not add an authentication error" do
+          expect(subject).to be_valid
+          expect(subject.errors.messages).to be_blank
+        end
+      end
+    end
+
+    context "when there are other errors" do
+      let(:password) { nil }
+
+      it "does not add an authentication error" do
+        expect(subject).not_to be_valid
+        expect(subject.errors.messages[:password]).to include(
+          I18n.t("activemodel.errors.models.jobseeker_sign_in_form.attributes.password.blank"),
+        )
+        expect(subject.errors.messages[:email]).to be_blank
+      end
+    end
+  end
+end

--- a/spec/support/jobseeker_helpers.rb
+++ b/spec/support/jobseeker_helpers.rb
@@ -9,14 +9,16 @@ module JobseekerHelpers
   end
 
   def sign_up_jobseeker
-    fill_in "Email", with: jobseeker.email
+    fill_in "Email address", with: jobseeker.email
     fill_in "Password", with: jobseeker.password
     click_on I18n.t("buttons.continue")
   end
 
-  def sign_in_jobseeker
-    fill_in "Email", with: jobseeker.email
-    fill_in "Password", with: jobseeker.password
-    click_on "Log in"
+  def sign_in_jobseeker(email: jobseeker.email, password: jobseeker.password)
+    fill_in "Email address", with: email
+    fill_in "Password", with: password
+    within(".new_jobseeker") do
+      click_on I18n.t("buttons.sign_in")
+    end
   end
 end

--- a/spec/system/jobseekers_can_save_a_job_spec.rb
+++ b/spec/system/jobseekers_can_save_a_job_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "Jobseekers can save a job" do
     it "saves the job after signing up" do
       save_job
       expect(page).to have_content(I18n.t("messages.jobseekers.saved_jobs.unauthenticated"))
-      click_on "Sign up"
+      click_on "create an account"
       sign_up_jobseeker
       confirm_email_address
       and_the_job_is_saved

--- a/spec/system/jobseekers_can_save_a_job_spec.rb
+++ b/spec/system/jobseekers_can_save_a_job_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "Jobseekers can save a job" do
     it "saves the job after signing up" do
       save_job
       expect(page).to have_content(I18n.t("messages.jobseekers.saved_jobs.unauthenticated"))
-      click_on "create an account"
+      click_on I18n.t("jobseekers.sessions.new.no_account.link")
       sign_up_jobseeker
       confirm_email_address
       and_the_job_is_saved

--- a/spec/system/jobseekers_can_sign_in_to_their_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_in_to_their_account_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe "Jobseekers can sign in to their account" do
       sign_in_jobseeker(email: "i-forgot-my@email-address.com", password: jobseeker.password)
 
       expect(current_path).to eq(jobseeker_session_path)
+      expect(page).not_to have_selector(".govuk-notification")
       expect(page).to have_content(I18n.t("devise.failure.invalid"))
     end
   end
@@ -34,6 +35,7 @@ RSpec.describe "Jobseekers can sign in to their account" do
       sign_in_jobseeker(email: jobseeker.email, password: "wrong and bad")
 
       expect(current_path).to eq(jobseeker_session_path)
+      expect(page).not_to have_selector(".govuk-notification")
       expect(page).to have_content(I18n.t("devise.failure.invalid"))
     end
   end

--- a/spec/system/jobseekers_can_sign_in_to_their_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_in_to_their_account_spec.rb
@@ -20,6 +20,16 @@ RSpec.describe "Jobseekers can sign in to their account" do
     end
   end
 
+  context "with a missing field that triggers form validation errors" do
+    scenario "displays a helpful error message" do
+      sign_in_jobseeker(email: nil, password: jobseeker.password)
+
+      expect(current_path).to eq(jobseeker_session_path)
+      expect(page).not_to have_selector(".govuk-notification")
+      expect(page).to have_content(I18n.t("jobseeker_sign_in_errors.email.blank"))
+    end
+  end
+
   context "with a email that does not exist" do
     scenario "displays a generic error message" do
       sign_in_jobseeker(email: "i-forgot-my@email-address.com", password: jobseeker.password)

--- a/spec/system/jobseekers_can_sign_in_to_their_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_in_to_their_account_spec.rb
@@ -5,17 +5,36 @@ RSpec.describe "Jobseekers can sign in to their account" do
 
   before do
     allow(JobseekerAccountsFeature).to receive(:enabled?).and_return(true)
-  end
-
-  scenario "signing in takes them to saved jobs page with banner" do
     visit root_path
     within("nav") do
-      click_link I18n.t("buttons.sign_in")
+      click_on I18n.t("buttons.sign_in")
     end
+  end
 
-    sign_in_jobseeker
+  context "with correct credentials" do
+    scenario "takes them to the saved jobs page with a banner" do
+      sign_in_jobseeker
 
-    expect(current_path).to eq(jobseekers_saved_jobs_path)
-    expect(page).to have_content(I18n.t("devise.sessions.signed_in"))
+      expect(current_path).to eq(jobseekers_saved_jobs_path)
+      expect(page).to have_content(I18n.t("devise.sessions.signed_in"))
+    end
+  end
+
+  context "with a email that does not exist" do
+    scenario "displays a generic error message" do
+      sign_in_jobseeker(email: "i-forgot-my@email-address.com", password: jobseeker.password)
+
+      expect(current_path).to eq(jobseeker_session_path)
+      expect(page).to have_content(I18n.t("devise.failure.invalid"))
+    end
+  end
+
+  context "with incorrect password" do
+    scenario "displays a generic error message" do
+      sign_in_jobseeker(email: jobseeker.email, password: "wrong and bad")
+
+      expect(current_path).to eq(jobseeker_session_path)
+      expect(page).to have_content(I18n.t("devise.failure.invalid"))
+    end
   end
 end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1503

## Changes in this PR:

This reimplements https://github.com/DFE-Digital/teaching-vacancies/pull/2489.

- Add sign in page with form validation errors for email format, email and password presence

    Content has deemed it to be important for us to do some extension of Devise in order to make this very frequently used form more user-friendly. I don't believe extending Devise in order to include a form model introduces too much code complexity relative to the need for this page to be as user-friendly as we can afford. We'll be allowed more leeway to keep code simple on other less important forms. Significantly different code, so a different PR.

Also:

- Put back the errors on the sign up page that got broken
- Fix the font size for page headings on various jobseeker pages
- Put the form error summaries between the title and the description on various jobseeker pages by request of UX
- Add a missing description to the change password page

## Questions

I'm not 100% happy with my solution to the problem of how to use govuk error summary components in place of the Devise flash alerts. Currently, I am solving it by, after being returned to the new sessions page after an attempted form submission, checking for any Devise flash alerts and then adding their text as an error on the form model.

An alternative idea would be to discard any flash messages, and then use a custom validation on the form to directly check whether `jobseeker.valid_password?(password)`, and then add the error on the form model.

What would be best?

## Screenshots of UI changes:

<img width="1552" alt="Screenshot 2020-12-09 at 20 06 41" src="https://user-images.githubusercontent.com/60350599/101688222-9de2ec80-3a63-11eb-89a9-1d1a8c8bac7a.png">

<img width="1552" alt="Screenshot 2020-12-09 at 20 07 26" src="https://user-images.githubusercontent.com/60350599/101688261-ae936280-3a63-11eb-9cdf-a48c08286d22.png">

## Next steps:

- [ ] Locking users out after 10 failed attempts and unlocking the account