### PR TITLE
Fix flaky reset password spec

### DIFF
--- a/spec/support/mailer_helpers.rb
+++ b/spec/support/mailer_helpers.rb
@@ -8,6 +8,6 @@ module MailerHelpers
   end
 
   def devise_token_from_last_mail(token_name)
-    last_email.body.to_s[/#{token_name}_token=(\w*)/, 1]
+    last_email.body.to_s[/#{token_name}_token=([^)]*)/, 1]
   end
 end


### PR DESCRIPTION
The way we parsed the token in the reset password email sent was not considering the fact that there could be non characters signs