### PR TITLE
[TEVA-1708] Extend run-in-env and Makefile for AWS MFA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,11 @@ LOCAL_TAG			:=dev-$(LOCAL_BRANCH)-$(LOCAL_SHA)
 ##@ Query parameter store to display environment variables. Requires AWS credentials
 
 .PHONY: print-env
-print-env: ## make -s local print-env > .env
-		$(if $(env), , $(error Usage: make <env> print-env))
+print-env: ## make -s local print-env mfa_code=123456 > .env
+		$(if $(env), , $(error Usage: make <env> print-env mfa_code=<mfa_code>))
+		$(if $(mfa_code), , $(error Usage: make <env> print-env mfa_code=<mfa_code>))
 		@bin/run-in-env -t /teaching-vacancies/dev/app -y terraform/workspace-variables/$(env)_app_env.yml \
-			$(local_override) -o env_stdout $(local_filter)
+			$(local_override) -m $(mfa_code) -o env_stdout $(local_filter)
 
 ##@ Set environment and corresponding configuration
 

--- a/bin/run-in-env
+++ b/bin/run-in-env
@@ -7,13 +7,14 @@ require 'aws-sdk-ssm'
 require 'erb'
 
 OUTPUT_LIST = ['stdout', 'env_stdout', 'env_file', 'subshell', 'tf_subshell', 'quiet']
+DEFAULT_AWS_REGION = 'eu-west-2'
 
 @log = Logger.new(STDOUT)
 @log.level = Logger::INFO
 
 def usage
   puts <<~EOF
-  Usage: run_in_env.sh [-p <parameter>]... [-t <parameter-path>]... [-o <output>] [-f <output_file>] [-v] [-- <command>]
+  Usage: run_in_env.sh [-p <parameter>]... [-t <parameter-path>]... [-o <output>] [-f <output_file>] [-m <MFA code>] [-v] [-- <command>]
   Arguments:
     -p (--parameter): parameter name in AWS SSM Parameter store. Can be repeated
     -t (--parameter-path): parameter path in AWS SSM Parameter store hierarchy. Can be repeated
@@ -26,6 +27,7 @@ def usage
       tf_subshell: Run command in a subshell with terraform env. variables. Must provide command
       quiet: No output (Validates input)
     -f (--output_file): path to output file
+    -m (--mfa_token_code): virtual MFA TOTP code
     -v (--verbose): verbose output
   EOF
   exit(1)
@@ -41,10 +43,37 @@ def run_command_with_env(config_map, command)
   exec command
 end
 
-def pull_ssm_parameters(parameters)
+def create_ssm_client(mfa_token_code=nil)
+  if mfa_token_code
+    sts_client = Aws::STS::Client.new
+    caller_id = sts_client.get_caller_identity()
+    serial_number = caller_id.arn.sub("user", "mfa")
+    user_name = caller_id.arn.split("/").last
+    role = "ReadOnly"
+    credentials = Aws::AssumeRoleCredentials.new(
+      client: sts_client,
+      role_arn: "arn:aws:iam::" + caller_id.account + ":role/" + role,
+      role_session_name: user_name + role,
+      serial_number: serial_number,
+      token_code: mfa_token_code
+    )
+    ssm_client = Aws::SSM::Client.new(
+      credentials: credentials,
+      region: DEFAULT_AWS_REGION
+    )
+  else
+    ssm_client = Aws::SSM::Client.new(
+      region: DEFAULT_AWS_REGION
+    )    
+  end
+
+  ssm_client
+end
+
+def pull_ssm_parameters(parameters, mfa_token_code=nil)
   @log.debug 'Fetching parameters ' + parameters.to_s
   config_map = {}
-  ssm_client = Aws::SSM::Client.new(region: 'eu-west-2')
+  ssm_client = create_ssm_client(mfa_token_code)
 
   parameters.each { |parameter_path|
     response = ssm_client.get_parameter({
@@ -63,10 +92,10 @@ def pull_ssm_parameters(parameters)
   config_map
 end
 
-def pull_ssm_parameter_paths(parameter_paths)
+def pull_ssm_parameter_paths(parameter_paths, mfa_token_code=nil)
   @log.debug 'Fetching parameters in paths ' + parameter_paths.to_s
   config_map = {}
-  ssm_client = Aws::SSM::Client.new(region: 'eu-west-2')
+  ssm_client = create_ssm_client(mfa_token_code)
 
   parameter_paths.each { |parameter_path|
     response = ssm_client.get_parameters_by_path({
@@ -149,6 +178,7 @@ opts = GetoptLong.new(
   [ '--yaml-file', '-y', GetoptLong::REQUIRED_ARGUMENT ],
   [ '--output', '-o', GetoptLong::REQUIRED_ARGUMENT ],
   [ '--output_file', '-f', GetoptLong::REQUIRED_ARGUMENT ],
+  [ '--mfa_token_code', '-m', GetoptLong::REQUIRED_ARGUMENT ],
   [ '--verbose', '-v', GetoptLong::NO_ARGUMENT ]
 )
 
@@ -158,6 +188,7 @@ yaml_files = []
 output = nil
 output_file = nil
 command = nil
+mfa_token_code = nil
 
 opts.each do |opt, arg|
   case opt
@@ -173,6 +204,8 @@ opts.each do |opt, arg|
     output = arg
   when '--output_file'
     output_file = arg
+  when '--mfa_token_code'
+    mfa_token_code = arg
   when '--verbose'
     @log.level = Logger::DEBUG
   end
@@ -200,11 +233,11 @@ end
 config_map = {}
 
 unless parameters.empty?
-  config_map.update pull_ssm_parameters parameters
+  config_map.update pull_ssm_parameters(parameters, mfa_token_code)
 end
 
 unless parameter_paths.empty?
-  config_map.update pull_ssm_parameter_paths parameter_paths
+  config_map.update pull_ssm_parameter_paths(parameter_paths, mfa_token_code)
 end
 
 unless yaml_files.empty?

--- a/terraform/common/groups.tf
+++ b/terraform/common/groups.tf
@@ -13,6 +13,123 @@ resource aws_iam_group developers {
   path = "/${local.service_name}/"
 }
 
+data aws_iam_policy_document manage_own_security {
+
+  statement {
+    sid = "AllowUsersToCreateEnableResyncTheirOwnVirtualMFADevice"
+
+    actions = [
+      "iam:CreateVirtualMFADevice",
+      "iam:EnableMFADevice",
+      "iam:ResyncMFADevice",
+    ]
+
+    resources = [
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:mfa/&{aws:username}",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/&{aws:username}",
+    ]
+  }
+
+  statement {
+    sid = "AllowUsersToDeactivateTheirOwnVirtualMFADevice"
+
+    actions = [
+      "iam:DeactivateMFADevice",
+    ]
+
+    resources = [
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:mfa/&{aws:username}",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/&{aws:username}",
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:MultiFactorAuthPresent"
+      values   = ["true"]
+    }
+  }
+
+  statement {
+    sid = "AllowUsersToDeleteTheirOwnVirtualMFADevice"
+
+    actions = [
+      "iam:DeleteVirtualMFADevice",
+    ]
+
+    resources = [
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:mfa/&{aws:username}",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/&{aws:username}",
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:MultiFactorAuthPresent"
+      values   = ["true"]
+    }
+  }
+
+  statement {
+    sid = "AllowUsersToListMFADevicesandUsersForConsole"
+
+    actions = [
+      "iam:ListMFADevices",
+      "iam:ListVirtualMFADevices",
+      "iam:ListUsers",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    actions = ["iam:ChangePassword"]
+
+    resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/&{aws:username}"]
+  }
+
+  statement {
+    actions   = ["iam:GetAccountPasswordPolicy"]
+    resources = ["*"]
+  }
+
+  statement {
+    actions = ["iam:GetLoginProfile"]
+
+    resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/&{aws:username}"]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:MultiFactorAuthPresent"
+      values   = ["true"]
+    }
+  }
+
+  statement {
+    actions = [
+      "iam:DeleteAccessKey",
+      "iam:GetAccessKeyLastUsed",
+      "iam:UpdateAccessKey",
+      "iam:GetUser",
+      "iam:CreateAccessKey",
+      "iam:ListAccessKeys",
+    ]
+
+    resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/&{aws:username}"]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:MultiFactorAuthPresent"
+      values   = ["true"]
+    }
+  }
+}
+
+resource aws_iam_policy manage_own_security {
+  name        = "manage_own_security"
+  description = "Allow managing own MFA, keys, passwords"
+  policy      = data.aws_iam_policy_document.manage_own_security.json
+}
 data aws_iam_policy_document assume_role_if_mfa_present {
 
   statement {
@@ -127,7 +244,6 @@ resource aws_iam_policy allow_assume_role_secreteditor {
 data aws_iam_policy_document parameter_store {
   statement {
     actions = [
-      "ssm:DescribeParameters",
       "ssm:PutParameter",
       "ssm:GetParameterHistory",
       "ssm:GetParametersByPath",
@@ -137,6 +253,13 @@ data aws_iam_policy_document parameter_store {
     resources = [
       "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/${local.service_name}/*"
     ]
+  }
+
+  statement {
+    actions = [
+      "ssm:DescribeParameters"
+    ]
+    resources = ["*"]
   }
 }
 
@@ -151,7 +274,22 @@ resource aws_iam_role_policy_attachment secreteditor_role_policies {
   policy_arn = aws_iam_policy.parameter_store.arn
 }
 
-# Allow groups to assume roles
+# Allow group members to manage own MFA, access keys, passwords
+
+resource aws_iam_group_policy_attachment permit_administrators_group_manage_own_security {
+  group      = aws_iam_group.administrators.name
+  policy_arn = aws_iam_policy.manage_own_security.arn
+}
+
+resource aws_iam_group_policy_attachment permit_billingmanagers_group_manage_own_security {
+  group      = aws_iam_group.billingmanagers.name
+  policy_arn = aws_iam_policy.manage_own_security.arn
+}
+resource aws_iam_group_policy_attachment permit_developers_group_manage_own_security {
+  group      = aws_iam_group.developers.name
+  policy_arn = aws_iam_policy.manage_own_security.arn
+}
+# Allow group members to assume roles
 
 resource aws_iam_group_policy_attachment permit_administrators_group_assume_role_administrator {
   group      = aws_iam_group.administrators.name


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1708

## Changes in this PR:

- Extend IAM policy to allow users to manage their own MFA, keys, passwords
- `run-in-env` script
  - extend to support MFA tokens
  - refactor to have a common method of authenticating, used whether retrieving a single parameter, or a tree of nested parameters
- Extend `Makefile` to support MFA tokens (passing on to run-in-env script)
- Update README documentation to cover installation and setup of AWS CLI and profiles

## Next steps:

- [ ] Terraform apply common
- [ ] Meet with developers to explain new process
