### PR TITLE
Teva 1708 bugfix policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,35 @@ When onboarded, you will be provided with an AWS user. You can use it to access 
 
 ### Assuming a role in the console
 
-- First check that your user account does not have permissions - go to the [Parameter Store](https://eu-west-2.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-2&tab=Table)
-- Assume the [ReadOnly](https://signin.aws.amazon.com/switchrole?account=530003481352&roleName=ReadOnly&displayName=TV%20ReadOnly) role
-- You should now be able to see secrets in the [Parameter Store](https://eu-west-2.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-2&tab=Table)
-- Edit a secret. When you click the button `Save changes`, you should see an error like
-`User: arn:aws:sts::530003481352:assumed-role/ReadOnly/YOURUSERNAME is not authorized to perform: ssm:PutParameter on resource: arn:aws:ssm:eu-west-2:530003481352:parameter/teaching-vacancies/dev/infra/secrets`
-- If you need to edit a secret, assume the [SecretEditor](https://signin.aws.amazon.com/switchrole?account=530003481352&roleName=SecretEditor&displayName=TV%20SecretEditor) role. 
+- When you log in to AWS you will have permissions to
+  - Change your password
+  - Set up an MFA device
+  - Generate Access Keys
+To carry out more privileged operations, you will need to [switch to a role](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-console.html)
+- Choose your user name on the navigation bar in the upper right. It typically looks like this: <YOUR-AWS-USERNAME>@teaching-vacancies.
+- Choose `Switch Roles`. 
+- For Account, enter `530003481352`
+- For Role, enter `ReadOnly`
+- For Display Name, this will be greyed out as `ReadOnly @ 530003481352`
+- Pick a colour for the role display and click `Switch Role`
+- Choose `Switch Roles` again
+- For Account, enter `530003481352`
+- For Role, enter `SecretEditor`
+- For Display Name, this will be greyed out as `SecretEditor @ 530003481352`
+- These two roles should now be listed in your Role History
+### Roles
+
+- `Administrator` can:
+  - administer the AWS account, and all resources, including user and group management
+- `BillingManager` can:
+  - access invoices and other billing information
+  - read all resources
+- `ReadOnly` can:
+  - read all resources
+- `SecretEditor` can:
+  - read and update existing secrets within Parameter Store
+
+### Install AWS CLI
 
 Install and configure the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html).
 
@@ -95,13 +118,13 @@ You'll be prompted to enter:
 - Default region name (choose `eu-west-2`)
 - Default output format (choose `json`)
 
-To check that everything has been done correctly, check the contents of the generated files
+Following this procedure will create two files
 
 ```bash
 cat ~/.aws/credentials
 ```
 
-It should contain a default entry, with your access key and secret key:
+This should contain a default entry, with your access key and secret key:
 
 ```
 [default]
@@ -109,9 +132,11 @@ aws_access_key_id=<AWS_ACCESS_KEY_ID>
 aws_secret_access_key=<AWS_SECRET_ACCESS_KEY>
 ```
 
-Edit `~/.aws/config`
+```bash
+cat ~/.aws/config
+```
 
-It should begin with the region and output defaults:
+This should contain defaults for the region and output format:
 
 ```
 [default]
@@ -119,24 +144,32 @@ region = eu-west-2
 output = json
 ```
 
-Add two profiles to this, replacing `<YOURUSERNAME>`
+Append two profiles to `~/.aws/config`, replacing `<YOUR-AWS-USERNAME>` appropriately:
 
 ```
-[profile readonly]
-role_arn = arn:aws:iam::530003481352:role/readonly
+[profile ReadOnly]
+region = eu-west-2
+role_arn = arn:aws:iam::530003481352:role/ReadOnly
 source_profile = default
-mfa_serial = arn:aws:iam::530003481352:mfa/<YOURUSERNAME>
+mfa_serial = arn:aws:iam::530003481352:mfa/<YOUR-AWS-USERNAME>
 
-[profile secreteditor]
-role_arn = arn:aws:iam::530003481352:role/secreteditor
+[profile SecretEditor]
+region = eu-west-2
+role_arn = arn:aws:iam::530003481352:role/SecretEditor
 source_profile = default
-mfa_serial = arn:aws:iam::530003481352:mfa/<YOURUSERNAME>
+mfa_serial = arn:aws:iam::530003481352:mfa/<YOUR-AWS-USERNAME>
 ```
 
 When using the AWS CLI, you may pass in the profile like so
 
 ```bash
-aws --profile readonly s3 ls
+aws --profile ReadOnly s3 ls
+```
+
+or
+
+```bash
+AWS_PROFILE=SecretEditor aws ssm get-parameters --names "/teaching-vacancies/dev/app/secrets" --with-decryption
 ```
 
 ### Environment Variables

--- a/README.md
+++ b/README.md
@@ -59,20 +59,23 @@ brew cask install chromedriver
 ### AWS credentials, MFA, and role profiles
 
 When onboarded, you will be provided with an AWS user. You can use it to access the AWS console at:
-https://teaching-vacancies.signin.aws.amazon.com/console.
+[https://teaching-vacancies.signin.aws.amazon.com/console](https://teaching-vacancies.signin.aws.amazon.com/console).
 
-Once you are logged in, go to [My Security Credentials](https://console.aws.amazon.com/iam/home?region=eu-west-2#/security_credentials)
-Choose `Assign MFA device` and set up an authenticator app as a Virtual MFA device.
-If using an Authenticator App, scan the QR code, and when prompted to enter codes, enter the first code, wait 30 seconds until a new code has been generated on your authenticator app, and enter the new code in the second box.
+- Log in to the console and go to [My Security Credentials](https://console.aws.amazon.com/iam/home?region=eu-west-2#/security_credentials).
+- Choose `Assign MFA device` and set up an authenticator app as a Virtual MFA device.
+- If using an Authenticator App, scan the QR code, and when prompted to enter codes, enter the first code, wait 30 seconds until a new code has been generated on your authenticator app, and enter the new code in the second box.
+- Log out, and back in. You should be prompted for an MFA code.
+- Go to [My Security Credentials](https://console.aws.amazon.com/iam/home?region=eu-west-2#/security_credentials).
+- Choose `Create access key`. Note the credentials securely, as you will need these to configure the AWS CLI.
 
-Log out, and back in. You should be prompted for an MFA code.
+### Assuming a role in the console
 
-Again, go to [My Security Credentials](https://console.aws.amazon.com/iam/home?region=eu-west-2#/security_credentials).
-Choose `Create access key`. Note the credentials securely, as you will need these to configure the AWS CLI.
-
-Check you can assume the [ReadOnly](https://signin.aws.amazon.com/switchrole?account=530003481352&roleName=ReadOnly&displayName=TV%20ReadOnly) role
-
-Check if you can see the [Parameter Store](https://eu-west-2.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-2&tab=Table)
+- First check that your user account does not have permissions - go to the [Parameter Store](https://eu-west-2.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-2&tab=Table)
+- Assume the [ReadOnly](https://signin.aws.amazon.com/switchrole?account=530003481352&roleName=ReadOnly&displayName=TV%20ReadOnly) role
+- You should now be able to see secrets in the [Parameter Store](https://eu-west-2.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-2&tab=Table)
+- Edit a secret. When you click the button `Save changes`, you should see an error like
+`User: arn:aws:sts::530003481352:assumed-role/ReadOnly/YOURUSERNAME is not authorized to perform: ssm:PutParameter on resource: arn:aws:ssm:eu-west-2:530003481352:parameter/teaching-vacancies/dev/infra/secrets`
+- If you need to edit a secret, assume the [SecretEditor](https://signin.aws.amazon.com/switchrole?account=530003481352&roleName=SecretEditor&displayName=TV%20SecretEditor) role. 
 
 Install and configure the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html).
 
@@ -92,13 +95,13 @@ You'll be prompted to enter:
 - Default region name (choose `eu-west-2`)
 - Default output format (choose `json`)
 
-To check that everything has been done correctly, checking the contents of the generated files
+To check that everything has been done correctly, check the contents of the generated files
 
 ```bash
 cat ~/.aws/credentials
 ```
 
-should contain a default entry, with your access key and secret key:
+It should contain a default entry, with your access key and secret key:
 
 ```
 [default]
@@ -116,7 +119,7 @@ region = eu-west-2
 output = json
 ```
 
-Extend this by adding to two profiles, replacing `<YOURUSERNAME>`
+Add two profiles to this, replacing `<YOURUSERNAME>`
 
 ```
 [profile readonly]

--- a/bin/run-in-env
+++ b/bin/run-in-env
@@ -45,7 +45,9 @@ end
 
 def create_ssm_client(mfa_token_code=nil)
   if mfa_token_code
-    sts_client = Aws::STS::Client.new
+    sts_client = Aws::STS::Client.new(
+      region: DEFAULT_AWS_REGION
+    )
     caller_id = sts_client.get_caller_identity()
     serial_number = caller_id.arn.sub("user", "mfa")
     user_name = caller_id.arn.split("/").last

--- a/terraform/common/groups.tf
+++ b/terraform/common/groups.tf
@@ -244,11 +244,12 @@ resource aws_iam_policy allow_assume_role_secreteditor {
 data aws_iam_policy_document parameter_store {
   statement {
     actions = [
-      "ssm:PutParameter",
       "ssm:GetParameterHistory",
       "ssm:GetParametersByPath",
       "ssm:GetParameters",
-      "ssm:GetParameter"
+      "ssm:GetParameter",
+      "ssm:ListTagsForResource",
+      "ssm:PutParameter"
     ]
     resources = [
       "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/${local.service_name}/*"


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1708

## Changes in this PR:

- Extended IAM policy to grant `ssm:ListTagsForResource` permission on Parameter Store
- `run-in-env` script - added AWS region to STS call, in addition to SSM call
- README
  - added switch roles information
  - added region to sample profiles to be included in `~/.aws/config`
  - added details of roles and permissions
  - added example of querying SSM Parameter Store with AWS CLI
