### PR TITLE
[TEVA-1625] fixes lingering page layout issues

### DIFF
--- a/app/components/shared/navbar_component/navbar_component.scss
+++ b/app/components/shared/navbar_component/navbar_component.scss
@@ -1,6 +1,6 @@
 .govuk-header {
   .govuk-header__navigation {
-    @include govuk-media-query($from: tablet) {
+    @include govuk-media-query($from: desktop) {
       display: flex;
 
       .govuk-header__navigation-spacer {

--- a/app/frontend/src/styles/application.scss
+++ b/app/frontend/src/styles/application.scss
@@ -65,7 +65,10 @@ $govuk-image-url-function: frontend-image-url;
 body {
   .govuk-width-container {
     @include govuk-media-query($from: desktop) {
+      margin-left: auto;
+      margin-right: auto;
       max-width: $desktop-container-width;
+      width: 90%;
     }
   }
 
@@ -78,7 +81,7 @@ body {
 
     > .govuk-width-container {
       margin-bottom: govuk-spacing(7);
-      margin-top: govuk-spacing(7);
+      margin-top: govuk-spacing(4);
     }
   }
 
@@ -88,6 +91,10 @@ body {
     .govuk-main-wrapper {
       > .govuk-width-container {
         margin-top: 0;
+
+        > .govuk-grid-row {
+          margin-top: govuk-spacing(7);
+        }
       }
     }
   }
@@ -120,4 +127,8 @@ p {
 strong,
 b {
   font-weight: bold;
+}
+
+.govuk-back-link {
+  margin-top: 0;
 }

--- a/app/frontend/src/styles/application/publishers/publisher.scss
+++ b/app/frontend/src/styles/application/publishers/publisher.scss
@@ -1,15 +1,6 @@
 $desktop-container-width: 1200px;
 
 .publisher {
-  .govuk-width-container {
-    @include govuk-media-query($from: desktop) {
-      margin-left: auto;
-      margin-right: auto;
-      max-width: $desktop-container-width;
-      width: 90%;
-    }
-  }
-
   .desktop-container-width {
     @include govuk-media-query($from: tablet) {
       width: $desktop-container-width;

--- a/app/views/publishers/organisations/schools/edit.html.haml
+++ b/app/views/publishers/organisations/schools/edit.html.haml
@@ -3,7 +3,7 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
 
-    %h2.govuk-heading-m{ class: "govuk-!-margin-bottom-0" }
+    %h2.govuk-heading-m
       = @organisation.name
 
     = link_to t('buttons.back'), @redirect_path, class: 'govuk-back-link'

--- a/app/views/shared/vacancy/_jobseeker_view.html.haml
+++ b/app/views/shared/vacancy/_jobseeker_view.html.haml
@@ -11,7 +11,7 @@
                                                       { link_path: '#', link_text: @vacancy.job_title }]))
     .govuk-grid-row
       .govuk-grid-column-full
-        %h1.govuk-heading-xl{ class: 'govuk-!-margin-bottom-2 govuk-!-margin-top-5' }
+        %h1.govuk-heading-xl{ class: 'govuk-!-margin-bottom-2' }
           = @vacancy.job_title
         %h2.govuk-caption-l.job-caption{ class: 'govuk-!-margin-bottom-5 govuk-!-margin-top-0' }
           = vacancy_job_location(@vacancy)

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -2,7 +2,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = link_to t('buttons.back'), @origin.present? ? @origin : jobs_path(@subscription_form.search_criteria_hash), class: 'govuk-back-link govuk-!-margin-top-0'
+    = link_to t('buttons.back'), @origin.present? ? @origin : jobs_path(@subscription_form.search_criteria_hash), class: 'govuk-back-link'
     = form_for @subscription_form, url: subscriptions_path do |f|
       = f.govuk_error_summary
 


### PR DESCRIPTION
no Jira ticket

unfortunatley still some layout problems as a result of recent page reworking to accomodate dashboard page layouts. you will see in jobseeker mode when you resize the screen its not quite right at certain widths

- max-width of the main `govuk-width-container` was changed as it was conditional to user signed in status. this was the right thing to do but the max width needs to be less than the main app container or the margin disappears on smaller desktop views. so now the `govuk-width-container` max-width is calculated as main app container width minus 10% up to `$desktop-container-width`
- the main header navigation was not switching at correct breakpoint and this meant the navigation was not appearing correctly in menu dropdown for tablet screen size
- there were conflicting overrides of some inline GDS styles that was leading to inconsistency of vertical spacing on certain pages - these have been removed