### PR TITLE
Minor fixes to jobseeker pages

### DIFF
--- a/app/views/jobseekers/passwords/check_your_email_password.html.haml
+++ b/app/views/jobseekers/passwords/check_your_email_password.html.haml
@@ -2,7 +2,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    %h1.govuk-heading-l= t(".title")
+    %h1.govuk-heading-xl= t(".title")
 
     %p.govuk-body= t(".description")
 

--- a/app/views/jobseekers/passwords/edit.html.haml
+++ b/app/views/jobseekers/passwords/edit.html.haml
@@ -2,7 +2,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    %h1.govuk-heading-l= t(".title")
+    %h1.govuk-heading-xl= t(".title")
 
     = form_for resource, as: resource_name, url: password_path(resource_name), html: { method: :put } do |f|
       = f.hidden_field :reset_password_token

--- a/app/views/jobseekers/passwords/expired_token.html.haml
+++ b/app/views/jobseekers/passwords/expired_token.html.haml
@@ -2,7 +2,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    %h1.govuk-heading-l= t(".title")
+    %h1.govuk-heading-xl= t(".title")
 
     %p.govuk-body= t(".description", email: resource.email)
 

--- a/app/views/jobseekers/passwords/new.html.haml
+++ b/app/views/jobseekers/passwords/new.html.haml
@@ -2,7 +2,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    %h1.govuk-heading-l= t(".title")
+    %h1.govuk-heading-xl= t(".title")
 
     %p.govuk-body= t(".description")
 

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -21,8 +21,8 @@ en:
         title: Your request is no longer valid
     registrations:
       check_your_email:
-        description: We have sent you an email with simple instructions on how to quickly finish creating your account
-        having_trouble_html: Still having trouble? %{mail_to} to our support team
+        description: We have sent you an email with simple instructions on how to quickly finish creating your account.
+        having_trouble_html: Still having trouble? %{mail_to} to our support team.
         report_it: Report it
         title: Check your email
       edit:
@@ -37,7 +37,7 @@ en:
           link: how to create an account
         description: >-
           If you have an account you can save teaching jobs you are interested in, apply for jobs and
-          create job alerts
+          create job alerts.
         existing_account:
           content_html: You can %{link_to} here.
           link: sign in
@@ -45,19 +45,19 @@ en:
         title: Create an account
     passwords:
       check_your_email_password:
-        description: We have sent you an email with instructions on how to reset your password
-        having_trouble_html: Still having trouble? %{mail_to} to our support team
+        description: We have sent you an email with instructions on how to reset your password.
+        having_trouble_html: Still having trouble? %{mail_to} to our support team.
         report_it: Report it
         title: Check your email
       edit:
         new_password: New password
         title: Reset your password
       expired_token:
-        description: The link has expired. You need to request that a new link is sent to your email address (%{email})
+        description: The link has expired. You need to request that a new link is sent to your email address (%{email}).
         new_password: New password
         title: Your request is no longer valid
       new:
-        description: Enter your email address and we will send you a link so that you can reset your password
+        description: Enter your email address and we will send you a link so that you can reset your password.
         title: Reset your password
     saved_jobs:
       destroy:


### PR DESCRIPTION
- Copy was missing periods
- Heading sizes were `l` instead of `xl` on resetting password pages. We use the smaller size for the jobseeker dashboard headings, but the larger size on other jobseeker pages.
