### PR TITLE
Remove legacy vacancies routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,11 +37,6 @@ Rails.application.routes.draw do
     resources :interests, only: %i[new]
   end
 
-  # Backward compatibility after changing routes to 'jobs'
-  resources :vacancies, only: [:show], controller: "vacancies" do
-    resources :interests, only: %i[new]
-  end
-
   resource :feedback, controller: "general_feedback", only: %i[new create]
 
   resources :subscriptions, only: %i[new create edit update] do

--- a/spec/controllers/interest_controller_spec.rb
+++ b/spec/controllers/interest_controller_spec.rb
@@ -12,16 +12,5 @@ RSpec.describe InterestsController, type: :controller do
 
       expect(request).to redirect_to("http://foo.com")
     end
-
-    context "when the old vacancy url is used" do
-      it "redirects to the vacancy application link" do
-        vacancy = create(:vacancy, application_link: "http://bar.com")
-        vacancy.organisation_vacancies.create(organisation: school)
-
-        get :new, params: { vacancy_id: vacancy.id }
-
-        expect(request).to redirect_to("http://bar.com")
-      end
-    end
   end
 end

--- a/spec/system/jobseekers_can_view_a_vacancy_spec.rb
+++ b/spec/system/jobseekers_can_view_a_vacancy_spec.rb
@@ -178,35 +178,6 @@ RSpec.describe "Viewing a single published vacancy" do
     end
   end
 
-  context "when the old vacancy URL is used" do
-    scenario "vacancy is viewable" do
-      vacancy = create(:vacancy, :published)
-      vacancy.organisation_vacancies.create(organisation: school)
-      published_vacancy = VacancyPresenter.new(vacancy)
-
-      visit vacancy_path(published_vacancy)
-
-      expect(page).to have_content(published_vacancy.job_title)
-    end
-
-    context "when the vacancy's url changes" do
-      scenario "the user is still able to use the old url" do
-        vacancy = create(:vacancy, :published)
-        vacancy.organisation_vacancies.create(organisation: school)
-        vacancy = VacancyPresenter.new(vacancy)
-        old_path = job_path(vacancy)
-        vacancy.job_title = "A new job title"
-        vacancy.refresh_slug
-        vacancy.save
-        new_path = job_path(vacancy)
-
-        visit old_path
-
-        expect(page.current_path).to eq(new_path)
-      end
-    end
-  end
-
   context "meta tags" do
     include ActionView::Helpers::SanitizeHelper
     scenario "the vacancy's meta data are rendered correctly" do


### PR DESCRIPTION
The `/vacancies/...` routes were changed to `/jobs` 3+ years ago and we don't need to redirect anymore.