### PR TITLE
[TEVA-1597] Add as soon as possible to important dates form

### DIFF
--- a/app/controllers/concerns/publishers/wizardable.rb
+++ b/app/controllers/concerns/publishers/wizardable.rb
@@ -93,7 +93,7 @@ module Publishers::Wizardable
 
   def important_dates_params(params)
     params.require(:important_dates_form)
-          .permit(:state, :starts_on, :publish_on, :expires_on,
+          .permit(:state, :starts_asap, :starts_on, :publish_on, :expires_on,
                   :expires_at, :expires_at_hh, :expires_at_mm, :expires_at_meridiem).merge(completed_step: STEPS[step])
   end
 

--- a/app/frontend/src/application/publishers/init.js
+++ b/app/frontend/src/application/publishers/init.js
@@ -2,3 +2,4 @@ import './feedbackForm';
 import './uploadDocuments/uploadDocuments';
 import './deleteDocument';
 import '../../components/checkboxFilter/checkboxFilter';
+import '../../components/form/form';

--- a/app/frontend/src/components/form/form.js
+++ b/app/frontend/src/components/form/form.js
@@ -1,0 +1,37 @@
+document.addEventListener('DOMContentLoaded', () => {
+  Array.from(document.getElementsByClassName('clear-form')).forEach((el) => {
+    el.querySelector('input[type="checkbox"]').addEventListener('click', (event) => {
+      checkboxClickHandler(el, event.target.checked);
+    });
+  });
+});
+
+export const disableInputs = (inputs) => {
+  inputs.forEach((input) => {
+    input.disabled = true;
+    input.value = '';
+  });
+};
+
+export const enableInputs = (inputs) => {
+  inputs.forEach((input) => {
+    input.disabled = false;
+  });
+};
+
+export const checkboxClickHandler = (element, checked) => {
+  const fields = Array.from(element.querySelectorAll('input[type="text"]'));
+  if (checked) {
+    form.disableInputs(fields);
+  } else {
+    form.enableInputs(fields);
+  }
+};
+
+const form = {
+  disableInputs,
+  enableInputs,
+  checkboxClickHandler,
+};
+
+export default form;

--- a/app/frontend/src/components/form/form.test.js
+++ b/app/frontend/src/components/form/form.test.js
@@ -1,0 +1,61 @@
+import form from './form';
+
+describe('form', () => {
+  document.body.innerHTML = '<div class="clear-form"> <input id="test-text-input" type="text"/> <input id="test-checkbox" type="checkbox"/> </div>';
+  const textField = document.querySelector('#test-text-input');
+  textField.value = '01';
+  const fields = Array.from(document.querySelectorAll('input[type="text"]'));
+
+  describe('toggling inputs', () => {
+    beforeEach(() => {
+      form.disableInputs(fields);
+    });
+
+    describe('disableInputs', () => {
+      test('removes the value from the input element', () => {
+        expect(document.querySelector('#test-text-input').value).toBe('');
+      });
+
+      test('disables the input element', () => {
+        expect(document.querySelector('#test-text-input').disabled).toBe(true);
+      });
+    });
+
+    describe('enableInputs', () => {
+      beforeEach(() => {
+        form.enableInputs(fields);
+        textField.value = '01';
+      });
+
+      test('allows for a value to be added to the input element', () => {
+        expect(document.querySelector('#test-text-input').value).toBe('01');
+      });
+
+      test('enables the input element', () => {
+        expect(document.querySelector('#test-text-input').disabled).toBe(false);
+      });
+    });
+  });
+
+  describe('checkboxClickHandler', () => {
+    const formElement = document.querySelector('.clear-form');
+
+    describe('when checkbox is checked', () => {
+      test('calls disableInputs', () => {
+        form.disableInputs = jest.fn();
+        const disableInputsMock = jest.spyOn(form, 'disableInputs');
+        form.checkboxClickHandler(formElement, true);
+        expect(disableInputsMock).toHaveBeenCalled();
+      });
+    });
+
+    describe('when checkbox is not checked', () => {
+      test('calls enablesInputs', () => {
+        form.enableInputs = jest.fn();
+        const enableInputsMock = jest.spyOn(form, 'enableInputs');
+        form.checkboxClickHandler(formElement, false);
+        expect(enableInputsMock).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/app/frontend/src/styles/application/form.scss
+++ b/app/frontend/src/styles/application/form.scss
@@ -19,3 +19,30 @@
   color: $govuk-link-hover-colour;
   text-decoration: underline;
 }
+
+.clear-form {
+  display: flex;
+  @media only screen and (max-width: 882px) {
+    flex-wrap: wrap;
+
+    .govuk-form-group {
+      flex-basis: 100%;
+    }
+  }
+
+  .govuk-checkboxes__item {
+    margin-bottom: govuk-spacing(6);
+    margin-left: govuk-spacing(4);
+  }
+
+  .clear-form__checkbox {
+    align-items: baseline;
+    align-self: flex-end;
+    display: flex;
+
+    &::before {
+      @include govuk-font($size: 19);
+      content: 'Or';
+    }
+  }
+}

--- a/app/models/concerns/vacancy_important_date_validations.rb
+++ b/app/models/concerns/vacancy_important_date_validations.rb
@@ -12,6 +12,7 @@ module VacancyImportantDateValidations
     validate :starts_on_must_not_be_before_today, if: :starts_on?
     validate :starts_on_must_not_be_before_publish_on, if: :starts_on?
     validate :starts_on_must_not_be_before_expires_on, if: :starts_on?
+    validate :starts_on_and_starts_asap_must_not_both_be_present
   end
 
   def publish_on_must_not_be_before_today
@@ -42,5 +43,10 @@ module VacancyImportantDateValidations
   def starts_on_must_not_be_before_expires_on
     errors.add(:starts_on, I18n.t("activerecord.errors.models.vacancy.attributes.starts_on.before_expires_on")) if
       starts_on && expires_on && starts_on < expires_on
+  end
+
+  def starts_on_and_starts_asap_must_not_be_both_given
+    errors.add(:starts_on, I18n.t("activerecord.errors.models.vacancy.attributes.starts_on.multiple_start_dates")) if
+      starts_on && starts_asap
   end
 end

--- a/app/models/concerns/vacancy_important_date_validations.rb
+++ b/app/models/concerns/vacancy_important_date_validations.rb
@@ -45,7 +45,7 @@ module VacancyImportantDateValidations
       starts_on && expires_on && starts_on < expires_on
   end
 
-  def starts_on_and_starts_asap_must_not_be_both_given
+  def starts_on_and_starts_asap_must_not_both_be_present
     errors.add(:starts_on, I18n.t("activerecord.errors.models.vacancy.attributes.starts_on.multiple_start_dates")) if
       starts_on && starts_asap
   end

--- a/app/views/publishers/vacancies/build/important_dates.html.slim
+++ b/app/views/publishers/vacancies/build/important_dates.html.slim
@@ -33,7 +33,16 @@
 
       = render "publishers/vacancies/expires_at_field", f: f
 
-      = f.govuk_date_field :starts_on
+      .clear-form
+        = f.govuk_date_field :starts_on
+
+        .clear-form__checkbox
+          = f.govuk_check_box :starts_asap,
+            true,
+            0,
+            multiple: false,
+            link_errors: false,
+            label: { text: t("helpers.legend.important_dates_form.starts_asap") }
 
       = render "publishers/vacancies/vacancy_form_partials/submit", f: f
 

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_important_dates.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_important_dates.html.slim
@@ -23,5 +23,8 @@ dl.app-check-your-answers.app-check-your-answers--short
 
   .app-check-your-answers__contents
     dt.app-check-your-answers__question#starts_on
-      h4.govuk-heading-s = t("jobs.start_on")
-    dd.app-check-your-answers__answer = format_date @vacancy.starts_on
+      h4.govuk-heading-s = t("jobs.starts_on")
+    - if @vacancy.starts_asap?
+      dd.app-check-your-answers__answer = t("jobs.starts_asap")
+    - else
+      dd.app-check-your-answers__answer = format_date @vacancy.starts_on

--- a/app/views/vacancies/_key_dates_sidebar.html.slim
+++ b/app/views/vacancies/_key_dates_sidebar.html.slim
@@ -7,9 +7,15 @@
       - if @vacancy.starts_on.present?
         li.key-dates-timeline__item
           h3.key-dates-timeline__title.govuk-heading-s
-            = t("jobs.starts_on")
+            = t("jobs.expected_start")
           p.key-dates-timeline__by
             = format_date(@vacancy.starts_on)
+      - elsif @vacancy.starts_asap?
+        li.key-dates-timeline__item
+          h3.key-dates-timeline__title.govuk-heading-s
+            = t("jobs.expected_start")
+          p.key-dates-timeline__by
+            = t("jobs.starts_asap")
       li.key-dates-timeline__item
         h3.key-dates-timeline__title.govuk-heading-s
           = t("jobs.application_deadline")

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -75,6 +75,7 @@ en:
       before_publish_on: Date job starts must be after date job will be listed
       before_expires_on: Date job starts must be after date application is due
       invalid: Use the correct format for date the job starts
+      multiple_start_dates: Select one option only
   supporting_documents_errors: &supporting_documents_errors
     supporting_documents:
       inclusion: "Please indicate if you'd like to attach supporting documents"

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -189,6 +189,7 @@ en:
         expires_on_html: Date application is due (<span class='text-red'>Required</span>)
         expires_at_html: Time application is due (<span class='text-red'>Required</span>)
         publish_on_html: Date job will be listed (<span class='text-red'>Required</span>)
+        starts_asap: As soon as possible
         starts_on: Date job starts
       job_location_form:
         job_location_html: Where will the job be based? (<span class='text-red'>Required</span>)

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -157,9 +157,10 @@ en:
       remaining: '%{days_remaining} days remaining to apply'
       today: Deadline is today
       tomorrow: Deadline is tomorrow
+    expected_start: Expected start date
     publication_date: Date job will be listed
-    start_on: Date job starts
-    starts_on: Expected start date
+    starts_asap: As soon as possible
+    starts_on: Date job starts
     publish_on: Date listed
     expires_on: Closing date
     time_at: ' at '

--- a/db/migrate/20201216164511_add_start_asap_to_vacancies.rb
+++ b/db/migrate/20201216164511_add_start_asap_to_vacancies.rb
@@ -1,0 +1,5 @@
+class AddStartAsapToVacancies < ActiveRecord::Migration[6.0]
+  def change
+    add_column :vacancies, :starts_asap, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_14_171643) do
+ActiveRecord::Schema.define(version: 2020_12_16_164511) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -309,6 +309,7 @@ ActiveRecord::Schema.define(version: 2020_12_14_171643) do
     t.integer "job_roles", array: true
     t.string "contact_number"
     t.uuid "publisher_organisation_id"
+    t.boolean "starts_asap", default: false
     t.index ["expires_at"], name: "index_vacancies_on_expires_at"
     t.index ["expires_on"], name: "index_vacancies_on_expires_on"
     t.index ["initially_indexed"], name: "index_vacancies_on_initially_indexed"

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -71,6 +71,11 @@ FactoryBot.define do
       publish_on { Faker::Time.between(from: Date.current, to: Date.current + 1.day) }
     end
 
+    trait :starts_asap do
+      starts_on { nil }
+      starts_asap { true }
+    end
+
     trait :draft do
       status { :draft }
     end

--- a/spec/form_models/important_dates_form_spec.rb
+++ b/spec/form_models/important_dates_form_spec.rb
@@ -82,6 +82,16 @@ RSpec.describe ImportantDatesForm, type: :model do
         expect(important_dates.errors.messages[:starts_on])
           .to include(I18n.t("activerecord.errors.models.vacancy.attributes.starts_on.before_expires_on"))
       end
+
+      it "must not be present if starts_asap is present" do
+        important_dates = ImportantDatesForm.new(starts_on: Date.current,
+                                                 expires_on: Time.zone.tomorrow,
+                                                 starts_asap: true)
+        expect(important_dates.valid?).to be false
+
+        expect(important_dates.errors.messages[:starts_on])
+          .to include(I18n.t("activerecord.errors.models.vacancy.attributes.starts_on.multiple_start_dates"))
+      end
     end
 
     describe "#expires_at" do

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -122,7 +122,11 @@ module VacancyHelpers
 
     expect(page).to have_content(vacancy.publish_on.to_s.strip)
     expect(page).to have_content(vacancy.expires_on.to_s.strip)
-    expect(page).to have_content(vacancy.starts_on.to_s.strip) if vacancy.starts_on?
+    if vacancy.starts_on?
+      expect(page).to have_content(vacancy.starts_on.to_s.strip)
+    elsif vacancy.starts_asap?
+      expect(page).to have_content(I18n.t("jobs.starts_asap"))
+    end
 
     expect(page).to have_content(I18n.t("jobs.supporting_documents"))
 
@@ -147,7 +151,11 @@ module VacancyHelpers
 
     expect(page).to have_content(vacancy.publish_on.to_s.strip)
     expect(page).to have_content(vacancy.expires_on.to_s.strip)
-    expect(page).to have_content(vacancy.starts_on.to_s.strip) if vacancy.starts_on?
+    if vacancy.starts_on?
+      expect(page).to have_content(vacancy.starts_on.to_s.strip)
+    elsif vacancy.starts_asap?
+      expect(page).to have_content(I18n.t("jobs.starts_asap"))
+    end
 
     expect(page.html).to include(vacancy.school_visits)
     expect(page.html).to include(vacancy.how_to_apply)

--- a/spec/system/hiring_staff_can_publish_a_vacancy_as_a_school_spec.rb
+++ b/spec/system/hiring_staff_can_publish_a_vacancy_as_a_school_spec.rb
@@ -675,16 +675,32 @@ RSpec.describe "Creating a vacancy" do
         expect(page).to have_current_path(organisation_job_path(vacancy.id))
       end
 
-      scenario "lists all the vacancy details correctly" do
-        vacancy = create(:vacancy, :complete, :draft)
-        vacancy.organisation_vacancies.create(organisation: school)
+      context "when a start date has been given" do
+        scenario "lists all the vacancy details correctly" do
+          vacancy = create(:vacancy, :complete, :draft)
+          vacancy.organisation_vacancies.create(organisation: school)
 
-        vacancy = VacancyPresenter.new(vacancy)
-        visit organisation_job_review_path(vacancy.id)
+          vacancy = VacancyPresenter.new(vacancy)
+          visit organisation_job_review_path(vacancy.id)
 
-        expect(page).to have_content(I18n.t("jobs.review_heading"))
+          expect(page).to have_content(I18n.t("jobs.review_heading"))
 
-        verify_all_vacancy_details(vacancy)
+          verify_all_vacancy_details(vacancy)
+        end
+      end
+
+      context "when the start date is as soon as possible" do
+        scenario "lists all the vacancy details correctly" do
+          vacancy = create(:vacancy, :complete, :draft, :starts_asap)
+          vacancy.organisation_vacancies.create(organisation: school)
+
+          vacancy = VacancyPresenter.new(vacancy)
+          visit organisation_job_review_path(vacancy.id)
+
+          expect(page).to have_content(I18n.t("jobs.review_heading"))
+
+          verify_all_vacancy_details(vacancy)
+        end
       end
 
       context "when the listing is full-time" do
@@ -882,18 +898,36 @@ RSpec.describe "Creating a vacancy" do
         expect(vacancy.reload.publisher_id).to eq(current_publisher.id)
       end
 
-      scenario "view the published listing as a jobseeker" do
-        vacancy = create(:vacancy, :draft)
-        vacancy.organisation_vacancies.create(organisation: school)
+      context "when a start date has been given" do
+        scenario "view the published listing as a jobseeker" do
+          vacancy = create(:vacancy, :draft)
+          vacancy.organisation_vacancies.create(organisation: school)
 
-        visit organisation_job_review_path(vacancy.id)
+          visit organisation_job_review_path(vacancy.id)
 
-        click_on I18n.t("buttons.submit_job_listing")
-        save_page
+          click_on I18n.t("buttons.submit_job_listing")
+          save_page
 
-        click_on I18n.t("jobs.confirmation_page.view_posted_job")
+          click_on I18n.t("jobs.confirmation_page.view_posted_job")
 
-        verify_vacancy_show_page_details(VacancyPresenter.new(vacancy))
+          verify_vacancy_show_page_details(VacancyPresenter.new(vacancy))
+        end
+      end
+
+      context "when the start date is as soon as possible" do
+        scenario "view the published listing as a jobseeker" do
+          vacancy = create(:vacancy, :draft, :starts_asap)
+          vacancy.organisation_vacancies.create(organisation: school)
+
+          visit organisation_job_review_path(vacancy.id)
+
+          click_on I18n.t("buttons.submit_job_listing")
+          save_page
+
+          click_on I18n.t("jobs.confirmation_page.view_posted_job")
+
+          verify_vacancy_show_page_details(VacancyPresenter.new(vacancy))
+        end
       end
 
       context "when the listing is full-time" do


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1597

## Changes in this PR:

- Added boolean starts_asap column to vacancies table
- Added checkbox to important dates form
- Added check for start_asap in _key_dates_sidebar.html.haml and _edit_important_dates.html.haml . If starts_asap is present, it displays 'As soon as possible' under the start date.
- Added javascript to disable and remove content from govuk-date-input fields when checkbox checked

<img width="595" alt="Screenshot 2020-12-22 at 16 41 54" src="https://user-images.githubusercontent.com/30624173/102911900-9c0e2580-4474-11eb-8f25-eda6e8594d83.png">

<img width="1005" alt="Screenshot 2020-12-22 at 16 42 24" src="https://user-images.githubusercontent.com/30624173/102911937-acbe9b80-4474-11eb-8fda-96d6f15c67d3.png">

<img width="1356" alt="Screenshot 2020-12-22 at 16 43 09" src="https://user-images.githubusercontent.com/30624173/102911994-c829a680-4474-11eb-8fab-682a55fdfa65.png">

## Questions:

- No instructions where given on where the checkbox should be on smaller viewports. The figma - https://www.figma.com/file/wyEeHQ1U9aCXOJdzh8lF8a/Sprint-72?node-id=0%3A1 . What does everyone think about how it looks? I assume I should ask Chris...

- I couldn't get govuk-media-queries to behave how I wanted it to, so I went with a standard media query. Does this need to change? If so and anyone knows their way around this stuff help would be appreciated!

- At it stands, this is how it looks on smaller viewports

### Tablet

<img width="454" alt="Screenshot 2020-12-22 at 16 50 00" src="https://user-images.githubusercontent.com/30624173/102912788-be547300-4475-11eb-9b2d-7cd3b83d98be.png">

### Mobile 

<img width="580" alt="Screenshot 2020-12-22 at 16 50 26" src="https://user-images.githubusercontent.com/30624173/102912818-cca28f00-4475-11eb-9041-137e16bd8e78.png">



