### PR TITLE
[TEVA-1690] Update devise timeoutable config

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -189,7 +189,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  config.timeout_in = 60.minutes
+  config.timeout_in = 2.weeks
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -11,7 +11,6 @@ en:
       locked: You have been locked out of your account because you have made too many attempts to log in.
       last_attempt: You have one more attempt before your account is locked.
       not_found_in_database: We did not recognise your sign-in details
-      timeout: You have been signed out because you have been inactive for 60 minutes.
       unauthenticated: You need to sign in or sign up before continuing.
       unconfirmed: You have to confirm your email address before continuing.
     mailer:

--- a/spec/system/jobseekers_session_timeout_spec.rb
+++ b/spec/system/jobseekers_session_timeout_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Jobseekers session timeout" do
   let!(:jobseeker) { create(:jobseeker, email: "jobseeker@example.com") }
-  let(:timeout_period) { 60.minutes }
+  let(:timeout_period) { 2.weeks }
 
   before do
     allow(JobseekerAccountsFeature).to receive(:enabled?).and_return(true)
@@ -17,7 +17,6 @@ RSpec.describe "Jobseekers session timeout" do
       visit jobseekers_saved_jobs_path
 
       expect(current_path).to eq(new_jobseeker_session_path)
-      expect(page).to have_content(I18n.t("devise.failure.timeout"))
     end
   end
 


### PR DESCRIPTION
Previously we rendered a flash message when a jobseeker was timed out. Now this time out period is set to 2 weeks, this isn't really useful at all - so it is no longer expected in the test and our session_store expires_after has been left at 2 weeks.

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-1690
