### PR TITLE
[TEVA-1675] Create a job alert from dashboard

### DIFF
--- a/app/views/jobseekers/subscriptions/index.html.haml
+++ b/app/views/jobseekers/subscriptions/index.html.haml
@@ -1,15 +1,18 @@
 - content_for :page_title_prefix, t(".page_title")
 
-= render partial: 'account_header'
+= render "account_header"
 
 .govuk-grid-row
   .govuk-grid-column-full
     %h1.govuk-heading-l= t(".page_title")
 
     - if @subscriptions.any?
+      .govuk-grid-row
+        .govuk-grid-column-full
+          = govuk_link_to(t(".button_create"), new_subscription_path(email: current_jobseeker.email, origin: jobseekers_subscriptions_path), button: true)
       %table.govuk-table
         %thead.govuk-table__head
-          %th.govuk-table__header{ class: 'govuk-!-width-two-thirds' }= t(".heading.criteria")
+          %th.govuk-table__header{ class: "govuk-!-width-two-thirds" }= t(".heading.criteria")
           %th.govuk-table__header= t(".heading.frequency")
           %th.govuk-table__header.govuk-table__header--numeric= t(".heading.actions")
         - @subscriptions.each do |subscription|
@@ -18,16 +21,16 @@
               %ul.govuk-list
                 - subscription.filtered_search_criteria.each_pair do |filter, value|
                   %li
-                    %span{ class: 'govuk-!-font-weight-bold' } #{filter.humanize}:
+                    %span{ class: "govuk-!-font-weight-bold" } #{filter.humanize}:
                     = value
 
             %td.govuk-table__cell= t(".frequency.#{subscription.frequency}")
             %td.govuk-table__cell.govuk-table__header--numeric
               %ul.govuk-list
-                %li= govuk_link_to(t('.link_manage'), edit_subscription_path(subscription.token))
-                %li= govuk_link_to(t('.link_unsubscribe'), unsubscribe_subscription_path(subscription.token))
+                %li= govuk_link_to(t(".link_manage"), edit_subscription_path(subscription.token))
+                %li= govuk_link_to(t(".link_unsubscribe"), unsubscribe_subscription_path(subscription.token))
     - else
-      = render(Shared::NotificationComponent.new(content: { title: t('.zero_subscriptions_title'), body: t('.zero_subscriptions_body_html') }, style: 'empty', links: nil, dismiss: false, background: true, alert: false))
+      = render(Shared::NotificationComponent.new(content: { title: t(".zero_subscriptions_title"), body: t(".zero_subscriptions_body_html", link_to: govuk_link_to(t(".link_create"), new_subscription_path(email: current_jobseeker.email, origin: jobseekers_subscriptions_path))) }, style: "empty", links: nil, dismiss: false, background: true, alert: false))
 
   .govuk-grid-column-full
     = render(Jobseekers::AccountSurveyLinkComponent.new(back_link: url_for))

--- a/app/views/jobseekers/subscriptions/index.html.haml
+++ b/app/views/jobseekers/subscriptions/index.html.haml
@@ -30,7 +30,7 @@
                 %li= govuk_link_to(t(".link_manage"), edit_subscription_path(subscription.token))
                 %li= govuk_link_to(t(".link_unsubscribe"), unsubscribe_subscription_path(subscription.token))
     - else
-      = render(Shared::NotificationComponent.new(content: { title: t(".zero_subscriptions_title"), body: t(".zero_subscriptions_body_html", link_to: govuk_link_to(t(".link_create"), new_subscription_path(email: current_jobseeker.email, origin: jobseekers_subscriptions_path))) }, style: "empty", links: nil, dismiss: false, background: true, alert: false))
+      = render(Shared::NotificationComponent.new(content: { title: t(".zero_subscriptions_title"), body: t(".zero_subscriptions_body_html", link_to: govuk_link_to(t(".link_create"), new_subscription_path(email: current_jobseeker.email, origin: jobseekers_subscriptions_path))) }, style: "empty", dismiss: false, background: true, alert: false))
 
   .govuk-grid-column-full
     = render(Jobseekers::AccountSurveyLinkComponent.new(back_link: url_for))

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -2,7 +2,8 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = govuk_back_link(text: t('buttons.back'), href: @origin.present? ? @origin : jobs_path(@subscription_form.search_criteria_hash))
+    = govuk_back_link(text: t('buttons.back'), href: @origin.presence || jobs_path(@subscription_form.search_criteria_hash))
+
     = form_for @subscription_form, url: subscriptions_path do |f|
       = f.govuk_error_summary
 
@@ -18,7 +19,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = govuk_link_to(t('buttons.cancel'), @origin.present? ? @origin : jobs_path(@subscription_form.search_criteria_hash), class: 'govuk-!-font-size-19')
+    = govuk_link_to(t('buttons.cancel'), @origin.presence || jobs_path(@subscription_form.search_criteria_hash), class: 'govuk-!-font-size-19')
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds.govuk-body{ class: 'govuk-!-margin-top-4' }

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -2,7 +2,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = link_to t('buttons.back'), @origin.present? ? @origin : jobs_path(@subscription_form.search_criteria_hash), class: 'govuk-back-link'
+    = govuk_back_link(text: t('buttons.back'), href: @origin.present? ? @origin : jobs_path(@subscription_form.search_criteria_hash))
     = form_for @subscription_form, url: subscriptions_path do |f|
       = f.govuk_error_summary
 
@@ -18,7 +18,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = govuk_link_to(t('buttons.cancel'), jobs_path(@subscription_form.search_criteria_hash), class: 'govuk-!-font-size-19')
+    = govuk_link_to(t('buttons.cancel'), @origin.present? ? @origin : jobs_path(@subscription_form.search_criteria_hash), class: 'govuk-!-font-size-19')
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds.govuk-body{ class: 'govuk-!-margin-top-4' }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -481,6 +481,8 @@ en:
         - can unsubscribe at any time
         - receive no more than 1 email a day
       title: Subscribers
+    create:
+      success: Your job alert has been created
     confirm:
       back_to_search_results: Return to your search results
       body: We sent an email confirmation to %{email}.

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -111,6 +111,7 @@ en:
         title: Too many password attempts
     subscriptions:
       index:
+        button_create: Create job alert
         frequency:
           daily: Daily, at around 3 pm
           weekly: Weekly (Friday at around 6 pm)
@@ -118,10 +119,11 @@ en:
           actions: Actions
           criteria: Alert criteria
           frequency: When receive alert
-        link_unsubscribe: Unsubscribe
+        link_create: Create a job alert
         link_manage: Manage alert
+        link_unsubscribe: Unsubscribe
         page_title: Job alerts
-        zero_subscriptions_body_html: '<a class="govuk-link" href="/">Find a teaching job</a> and a create a job alert to be made aware of future listings.'
+        zero_subscriptions_body_html: '%{link_to} to be made aware of future listings.'
         zero_subscriptions_title: You have no job alerts set up
     unlocks:
       new:

--- a/spec/system/jobseekers_can_create_a_job_alert_spec.rb
+++ b/spec/system/jobseekers_can_create_a_job_alert_spec.rb
@@ -1,0 +1,83 @@
+require "rails_helper"
+
+RSpec.describe "Jobseekers can create a job alert" do
+  let(:jobseeker) { create(:jobseeker) }
+  let(:subscription) { build(:subscription) }
+  let(:search_criteria) { JSON.parse(subscription.search_criteria) }
+
+  before do
+    allow(JobseekerAccountsFeature).to receive(:enabled?).and_return(true)
+    login_as(jobseeker, scope: :jobseeker)
+  end
+
+  context "when the jobseeker has no job alerts" do
+    before { visit jobseekers_subscriptions_path }
+
+    it "displays the no job alerts notification component" do
+      expect(page).to have_content(I18n.t("jobseekers.subscriptions.index.zero_subscriptions_title"))
+      expect(page).to have_content(I18n.t("jobseekers.subscriptions.index.link_create"))
+    end
+
+    it "creates a job alert and redirects to the subscriptions index page" do
+      click_on I18n.t("jobseekers.subscriptions.index.link_create")
+      and_email_is_prefilled
+      an_invalid_form_is_rejected
+      expect { create_a_job_alert }.to change { Subscription.count }.by(1)
+      and_the_job_alert_is_on_the_index_page
+    end
+  end
+
+  context "when the jobseeker has job alerts" do
+    let!(:created_subscription) { create(:subscription, email: jobseeker.email) }
+
+    before { visit jobseekers_subscriptions_path }
+
+    it "displays the create job alert button" do
+      expect(page).to have_content(I18n.t("jobseekers.subscriptions.index.button_create"))
+    end
+
+    it "creates a job alert and redirects to the subscriptions index page" do
+      click_on I18n.t("jobseekers.subscriptions.index.button_create")
+      and_email_is_prefilled
+      an_invalid_form_is_rejected
+      expect { create_a_job_alert }.to change { Subscription.count }.by(1)
+      and_the_job_alert_is_on_the_index_page
+    end
+  end
+
+  def an_invalid_form_is_rejected
+    click_on I18n.t("buttons.subscribe")
+    expect(page).to have_content("There is a problem")
+  end
+
+  def and_email_is_prefilled
+    expect(page).to have_field("subscription_form[email]", with: jobseeker.email)
+  end
+
+  def and_the_job_alert_is_on_the_index_page
+    expect(current_path).to eq(jobseekers_subscriptions_path)
+    expect(page).to have_content(I18n.t("subscriptions.create.success"))
+    expect(page).to have_content("Keyword: #{search_criteria['keyword']}")
+  end
+
+  def create_a_job_alert
+    fill_in_subscription_fields
+    click_on I18n.t("buttons.subscribe")
+  end
+
+  def fill_in_subscription_fields
+    fill_in "subscription_form[keyword]", with: search_criteria["keyword"]
+    fill_in "subscription_form[location]", with: search_criteria["location"]
+    select I18n.t("jobs.filters.number_of_miles", count: search_criteria["radius"])
+    choose I18n.t("helpers.label.subscription_form.frequency_options.#{subscription.frequency}")
+    search_criteria["working_patterns"].each do |working_pattern|
+      check I18n.t("helpers.label.job_details_form.working_patterns_options.#{working_pattern}")
+    end
+    search_criteria["job_roles"].each do |job_role|
+      check I18n.t("helpers.label.job_details_form.job_roles_options.#{job_role}")
+    end
+    search_criteria["phases"].each do |phase|
+      check I18n.t("jobs.education_phase_options.#{phase}")
+    end
+  end
+end

--- a/spec/system/jobseekers_can_subscribe_to_a_job_alert_spec.rb
+++ b/spec/system/jobseekers_can_subscribe_to_a_job_alert_spec.rb
@@ -15,13 +15,6 @@ RSpec.describe "A job seeker can subscribe to a job alert" do
   end
 
   context "A job seeker" do
-    scenario "can access the new subscription page when search criteria have been specified" do
-      expect { visit(new_subscription_path) }.to raise_error(ActionController::ParameterMissing)
-
-      visit new_subscription_path(search_criteria: { some_parameters: "none" })
-      expect(page).to have_content(I18n.t("subscriptions.new.title"))
-    end
-
     context "when carrying out a location category search" do
       scenario "can view the search criteria" do
         visit new_subscription_path(


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-1675

## Changes in this PR
- Update back and cancel links
- Update controller to create subscription without search criteria
- Create job alert from dashboard when a jobseeker has/has no job alerts