### PR TITLE
Fix smoke test channel alerts

### DIFF
--- a/.github/workflows/smoke-test-manual.yml
+++ b/.github/workflows/smoke-test-manual.yml
@@ -42,5 +42,5 @@ jobs:
           SLACK_USERNAME: Smoke Test
           SLACK_ICON_EMOJI: ':cry:'
           SLACK_TITLE: Smoke test failed
-          SLACK_MESSAGE: '${{ github.event.inputs.environment }} website smoke test has failed @channel'
+          SLACK_MESSAGE: '${{ github.event.inputs.environment }} website smoke test has failed !channel'
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -38,5 +38,5 @@ jobs:
           SLACK_USERNAME: Smoke Test
           SLACK_ICON_EMOJI: ':cry:'
           SLACK_TITLE: Smoke test failed
-          SLACK_MESSAGE: 'Production website smoke test has failed @channel'
+          SLACK_MESSAGE: 'Production website smoke test has failed !channel'
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
https://stackoverflow.com/questions/56397227/slack-here-mention-in-channel-via-incoming-webhook

Currently, when we have a failing smoke test, we are not alerted by `@channel`. According to the Slack Overflow link above, this should fix that.

Have also updated the Rollbar high error occurrence rate messages.