### PR TITLE
Basic AB testing prototype

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,6 +15,7 @@ class ApplicationController < ActionController::Base
   helper_method :cookies_preference_set?, :referred_from_jobs_path?, :utm_parameters
 
   include Publishers::AuthenticationConcerns
+  include AbTestable
 
   def check
     render json: { status: "OK" }, status: :ok

--- a/app/controllers/concerns/ab_testable.rb
+++ b/app/controllers/concerns/ab_testable.rb
@@ -1,0 +1,21 @@
+module AbTestable
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :ab_variant_for, :current_ab_variants
+  end
+
+private
+
+  def ab_variant_for(test)
+    params.dig(:ab_test_override, test)&.to_sym || ab_tests.variant_for(test)
+  end
+
+  def current_ab_variants
+    ab_tests.current_variants
+  end
+
+  def ab_tests
+    @ab_tests ||= AbTests.new(session)
+  end
+end

--- a/app/services/ab_tests.rb
+++ b/app/services/ab_tests.rb
@@ -1,0 +1,36 @@
+# Selects and persists AB test variants in the Rails session
+class AbTests
+  SESSION_KEY = :ab_tests
+
+  # Creates a new instance for a given Rails session, with an option to override the default
+  # configuration
+  def initialize(session, test_configuration: Rails.configuration.ab_tests)
+    @session = session
+    @test_configuration = test_configuration
+
+    session[SESSION_KEY] ||= {}
+  end
+
+  # Returns the selected variant for a given test
+  def variant_for(test)
+    raise ArgumentError, "AB test '#{test}' is not configured" unless available_ab_tests.include?(test)
+    return session[SESSION_KEY][test] if session[SESSION_KEY][test]
+
+    candidates = test_configuration[test].flat_map { |variant_name, weight| [variant_name] * weight }
+
+    session[SESSION_KEY][test] = candidates.sample
+  end
+
+  # Returns a hash of all tests mapped to their selected variants
+  def current_variants
+    available_ab_tests.to_h { |test| [test, variant_for(test)] }
+  end
+
+private
+
+  attr_reader :session, :test_configuration
+
+  def available_ab_tests
+    test_configuration.keys
+  end
+end

--- a/app/services/request_event.rb
+++ b/app/services/request_event.rb
@@ -27,6 +27,7 @@ private
       request_method: request.method,
       request_path: request.path,
       request_query: request.query_string,
+      request_ab_tests: ab_tests,
       response_content_type: response.content_type,
       response_status: response.status,
       user_anonymised_request_identifier: anonymise([user_agent, request.remote_ip].join),
@@ -38,6 +39,10 @@ private
 
   def user_agent
     request.headers["User-Agent"]
+  end
+
+  def ab_tests
+    AbTests.new(session).current_variants.map { |test, variant| { test: test, variant: variant } }
   end
 
   ##

--- a/app/views/pages/ab-tests.html.slim
+++ b/app/views/pages/ab-tests.html.slim
@@ -1,0 +1,12 @@
+- content_for :page_title_prefix, t("static_pages.ab_tests.page_title")
+
+h1.govuk-heading-l = t("static_pages.ab_tests.page_title")
+
+p.govuk-body = t("static_pages.ab_tests.introduction")
+
+dl.govuk-summary-list
+  - current_ab_variants.each do |test, variant|
+    .govuk-summary-list__row
+      dt.govuk-summary-list__key = test
+      dd.govuk-summary-list__value
+        span.govuk-tag.govuk-tag--blue = variant

--- a/config/ab_tests.yml
+++ b/config/ab_tests.yml
@@ -1,0 +1,30 @@
+# Describes currently running AB tests
+#
+# A test has a name as its key, and consists of a mapping of variants to weights, e.g.:
+#
+#    2021_01_another_testing_test:
+#      foo: 1
+#      bar: 2
+#
+# In this example, variant `bar` is twice as likely to be selected for any given user
+# as variant `foo`.
+#
+# Things to bear in mind:
+#   - Tests must have unique names, including any past tests
+#   - Weights must be integers, avoid having too big weights as this may become inefficient
+#   - Variants are persisted against a Rails session, so once an AB test has been deployed,
+#     you must not remove/rename any existing variants. If you want a variant to receive no
+#     new participants, set its weight to 0 instead.
+#   - You need to restart your Rails server when changing this file in development
+shared:
+  # A fake test to test (ha!) the AB testing functionality
+  2021_01_testing_test:
+    red: 1
+    blue: 1
+    yellow: 1
+    green: 3
+  # Another fake test with no real consequences
+  2021_01_another_testing_test:
+    foo: 1
+    bar: 1
+    baz: 1

--- a/config/application.rb
+++ b/config/application.rb
@@ -52,5 +52,7 @@ module TeacherVacancyService
     config.action_mailer.notify_settings = {
       api_key: ENV["NOTIFY_KEY"],
     }
+
+    config.ab_tests = config_for(:ab_tests)
   end
 end

--- a/config/locales/static_pages.yml
+++ b/config/locales/static_pages.yml
@@ -1,5 +1,11 @@
 en:
   static_pages:
+    ab_tests:
+      page_title: A/B Testing
+      introduction: >-
+        From time to time, we run "A/B testing" experiments to improve our service. This page displays
+        which variants you are seeing for each experiment. Some of these experiments may no longer be
+        running.
     accessibility:
       date_reviewed: This statement was prepared on 12 September 2019. It was last updated on 12 September 2019.
       enforcement_procedure:

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -79,4 +79,33 @@ RSpec.describe ApplicationController, type: :controller do
       expect(controller.params[:test_form][:array_field]).to eq %w[3 4]
     end
   end
+
+  describe "AB testing helpers" do
+    let(:ab_tests) { double(AbTests, current_variants: {}) }
+
+    before do
+      allow(AbTests).to receive(:new).and_return(ab_tests)
+      get :test_action, params: params
+    end
+
+    describe "#ab_variant_for" do
+      context "when no override is given" do
+        let(:params) { {} }
+
+        it "returns the variant as determined by AbTests" do
+          expect(ab_tests).to receive(:variant_for).with(:foo).and_return(:bar)
+          expect(controller.view_context.ab_variant_for(:foo)).to eq(:bar)
+        end
+      end
+
+      context "when an override is given" do
+        let(:params) { { ab_test_override: { foo: :baz } } }
+
+        it "returns the variant as determined by AbTests" do
+          expect(ab_tests).not_to receive(:variant_for).with(:foo)
+          expect(controller.view_context.ab_variant_for(:foo)).to eq(:baz)
+        end
+      end
+    end
+  end
 end

--- a/spec/services/ab_tests_spec.rb
+++ b/spec/services/ab_tests_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe AbTests do
+  subject { described_class.new(session, test_configuration: test_configuration) }
+
+  let(:session) { {} }
+  let(:test_configuration) do
+    {
+      test_one: {
+        blue: 3,
+        red: 2,
+        yellow: 1,
+      },
+      test_two: {
+        yes: 1,
+        no: 1,
+      },
+    }
+  end
+
+  around do |example|
+    # Ensure we always get the same "random" choice by seeding Ruby's random number generator,
+    # returning it to the RSpec seed after (so as to not affect other specs)
+    srand(42)
+    example.run
+    srand(RSpec.configuration.seed)
+  end
+
+  describe "#current_variants" do
+    context "when no tests are set in the session yet" do
+      let(:session) { {} }
+      let(:expected_variants) { { test_one: :red, test_two: :yes } }
+
+      it "creates the session cache and populates it with variants" do
+        expect(subject.current_variants).to eq(expected_variants)
+        expect(session[:ab_tests]).to eq(expected_variants)
+      end
+    end
+
+    context "when some tests are set in the session already" do
+      let(:session) { { ab_tests: { test_two: :no } } }
+      let(:expected_variants) { { test_one: :red, test_two: :no } }
+
+      it "populates missing variants in the session cache" do
+        expect(subject.current_variants).to eq(expected_variants)
+        expect(session[:ab_tests]).to eq(expected_variants)
+      end
+    end
+  end
+
+  describe "#variant_for" do
+    it "returns the variant for the requested test" do
+      expect(subject.variant_for(:test_one)).to eq(:red)
+    end
+
+    it "errors when requesting a non-existent variant" do
+      expect { subject.variant_for(:test_three) }.to raise_error(ArgumentError, /not configured/)
+    end
+  end
+end

--- a/spec/services/request_event_spec.rb
+++ b/spec/services/request_event_spec.rb
@@ -33,6 +33,12 @@ RSpec.describe RequestEvent do
   let(:current_publisher_oid) { 1234 }
   let(:jobseeker) { instance_double(Jobseeker, id: 4321) }
 
+  let(:ab_tests) { double(AbTests, current_variants: { foo: :bar }) }
+
+  before do
+    allow(AbTests).to receive(:new).with(session).and_return(ab_tests)
+  end
+
   describe "#trigger" do
     let(:expected_data) do
       {
@@ -45,6 +51,7 @@ RSpec.describe RequestEvent do
         request_method: "DELETE",
         request_path: "/foo/bar",
         request_query: "foo=bar&baz=bat",
+        request_ab_tests: [{ test: :foo, variant: :bar }],
         response_content_type: "image/gif",
         response_status: 418,
         user_anonymised_request_identifier: "xeben-tocep-fadin-tezyg-rapic-begyn-hiraz-pedus-revuk-fisif-lypeh-tohim-lefyb-zolon-nilyk-sigud-coxux",


### PR DESCRIPTION
- Add `AbTests` service to select and persist variants
- Add `AbTestable` concern with exposed helpers for accessing `AbTests`
- Update `RequestEvent` to include AB variants
- Add fake testing AB tests for now to validate functionality
- Add overview page displaying current AB testing variants

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-1443

## Before merging
- [ ] Requires `request_ab_tests` record field to be created on production BQ dataset