### PR TITLE
Only show create account section in alert email when the feature is enabled

### DIFF
--- a/app/views/alert_mailer/alert.text.haml
+++ b/app/views/alert_mailer/alert.text.haml
@@ -33,7 +33,7 @@
 \
 \---
 \
-- unless @jobseeker_subscription
+- if JobseekerAccountsFeature.enabled? && !@jobseeker_subscription
   \# #{t('.create_account.heading')}
   = t('.create_account.intro', link_to: sign_up_link(@subscription))
   \

--- a/spec/mailers/alert_mailer_spec.rb
+++ b/spec/mailers/alert_mailer_spec.rb
@@ -103,17 +103,45 @@ RSpec.describe AlertMailer, type: :mailer do
     end
   end
 
-  context "when the subscription email matches a jobseeker account" do
-    let!(:jobseeker) { create(:jobseeker, email: email) }
-
-    it "does not display create account section" do
-      expect(body).not_to include(I18n.t("alert_mailer.alert.create_account.heading"))
+  describe "create account section" do
+    before do
+      allow(JobseekerAccountsFeature).to receive(:enabled?).and_return(jobseeker_accounts_enabled?)
     end
-  end
 
-  context "when the subscription email does not match a jobseeker account" do
-    it "displays create account section" do
-      expect(body).to include(I18n.t("alert_mailer.alert.create_account.heading"))
+    context "when JobseekerAccountsFeature is enabled" do
+      let(:jobseeker_accounts_enabled?) { true }
+
+      context "when the subscription email matches a jobseeker account" do
+        let!(:jobseeker) { create(:jobseeker, email: email) }
+
+        it "does not display create account section" do
+          expect(body).not_to include(I18n.t("alert_mailer.alert.create_account.heading"))
+        end
+      end
+
+      context "when the subscription email does not match a jobseeker account" do
+        it "displays create account section" do
+          expect(body).to include(I18n.t("alert_mailer.alert.create_account.heading"))
+        end
+      end
+    end
+
+    context "when JobseekerAccountsFeature is disabled" do
+      let(:jobseeker_accounts_enabled?) { false }
+
+      context "when the subscription email matches a jobseeker account" do
+        let!(:jobseeker) { create(:jobseeker, email: email) }
+
+        it "does not display create account section" do
+          expect(body).not_to include(I18n.t("alert_mailer.alert.create_account.heading"))
+        end
+      end
+
+      context "when the subscription email does not match a jobseeker account" do
+        it "does not display create account section" do
+          expect(body).not_to include(I18n.t("alert_mailer.alert.create_account.heading"))
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fixing a bad thing