### PR TITLE
Move from using `eql` to `eq` matchers

### DIFF
--- a/spec/components/publishers/vacancies_component_spec.rb
+++ b/spec/components/publishers/vacancies_component_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Publishers::VacanciesComponent, type: :component do
       it "renders the filters sidebar" do
         expect(
           inline_component.css('.new_managed_organisations_form input[type="submit"]').attribute("value").value,
-        ).to eql(I18n.t("buttons.apply_filters"))
+        ).to eq(I18n.t("buttons.apply_filters"))
       end
 
       it "renders the trust head office as a filter option" do
@@ -140,7 +140,7 @@ RSpec.describe Publishers::VacanciesComponent, type: :component do
       it "renders the filters sidebar" do
         expect(
           inline_component.css('.new_managed_organisations_form input[type="submit"]').attribute("value").value,
-        ).to eql(I18n.t("buttons.apply_filters"))
+        ).to eq(I18n.t("buttons.apply_filters"))
       end
 
       it "does not render the trust head office as a filter option" do

--- a/spec/components/shared/banner_link_component_spec.rb
+++ b/spec/components/shared/banner_link_component_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Shared::BannerLinkComponent, type: :component do
     let(:link_method) { :get }
 
     it "renders the banner link" do
-      expect(rendered_component).to eql(
+      expect(rendered_component).to eq(
         '<a class="banner-link icon icon--left icon--test" id="test-id" data-method="get" href="#test">'\
         '<div class="banner-link__text">Click this link!</div></a>',
       )
@@ -31,7 +31,7 @@ RSpec.describe Shared::BannerLinkComponent, type: :component do
     let(:link_method) { :post }
 
     it "renders the banner link" do
-      expect(rendered_component).to eql(
+      expect(rendered_component).to eq(
         '<a class="banner-link icon icon--left icon--test" id="test-id" rel="nofollow" data-method="post" href="#test">'\
         '<div class="banner-link__text">Click this link!</div></a>',
       )

--- a/spec/components/shared/pill_link_component_spec.rb
+++ b/spec/components/shared/pill_link_component_spec.rb
@@ -9,6 +9,6 @@ RSpec.describe Shared::PillLinkComponent, type: :component do
   end
 
   it "renders the pill link" do
-    expect(rendered_component).to eql('<a class="pill-link" href="#some-element">Go to this section</a>')
+    expect(rendered_component).to eq('<a class="pill-link" href="#some-element">Go to this section</a>')
   end
 end

--- a/spec/controllers/api/location_suggestion_controller_spec.rb
+++ b/spec/controllers/api/location_suggestion_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Api::LocationSuggestionController, type: :controller do
         get :show, params: { api_version: 1 }
 
         expect(response).to have_http_status(:bad_request)
-        expect(json[:error]).to eql("Missing location input")
+        expect(json[:error]).to eq("Missing location input")
       end
     end
 
@@ -39,7 +39,7 @@ RSpec.describe Api::LocationSuggestionController, type: :controller do
         get :show, params: { api_version: 1, location: location }
 
         expect(response).to have_http_status(:bad_request)
-        expect(json[:error]).to eql("Insufficient location input")
+        expect(json[:error]).to eq("Insufficient location input")
       end
     end
 
@@ -55,9 +55,9 @@ RSpec.describe Api::LocationSuggestionController, type: :controller do
         get :show, params: { api_version: 1, location: location }
 
         expect(response).to have_http_status(:ok)
-        expect(json[:query]).to eql(location)
-        expect(json[:suggestions]).to eql(suggestions)
-        expect(json[:matched_terms]).to eql(matched_terms)
+        expect(json[:query]).to eq(location)
+        expect(json[:suggestions]).to eq(suggestions)
+        expect(json[:matched_terms]).to eq(matched_terms)
       end
     end
 
@@ -70,7 +70,7 @@ RSpec.describe Api::LocationSuggestionController, type: :controller do
         get :show, params: { api_version: 1, location: location }
 
         expect(response).to have_http_status(:bad_request)
-        expect(json[:error]).to eql("HTTP error")
+        expect(json[:error]).to eq("HTTP error")
       end
     end
 
@@ -84,7 +84,7 @@ RSpec.describe Api::LocationSuggestionController, type: :controller do
         get :show, params: { api_version: 1, location: location }
 
         expect(response).to have_http_status(:bad_request)
-        expect(json[:error]).to eql("Google error")
+        expect(json[:error]).to eq("Google error")
       end
     end
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -49,9 +49,9 @@ RSpec.describe ApplicationController, type: :controller do
     end
 
     it "removes empty checkboxes as expected" do
-      expect(controller.params[:test_form][:nothing_to_remove_field]).to eql(%w[first_box second_box])
-      expect(controller.params[:test_form][:array_field]).to eql(%w[first_box])
-      expect(controller.params[:test_form][:string_field]).to eql("")
+      expect(controller.params[:test_form][:nothing_to_remove_field]).to eq(%w[first_box second_box])
+      expect(controller.params[:test_form][:array_field]).to eq(%w[first_box])
+      expect(controller.params[:test_form][:string_field]).to eq("")
     end
   end
 

--- a/spec/controllers/cookies_preferences_controller_spec.rb
+++ b/spec/controllers/cookies_preferences_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CookiesPreferencesController, type: :controller do
   describe "#create" do
     it "sets cookie value" do
       post :create, params: { cookies_consent: "yes" }
-      expect(response.cookies["consented-to-cookies"]).to eql("yes")
+      expect(response.cookies["consented-to-cookies"]).to eq("yes")
     end
   end
 end

--- a/spec/controllers/nqt_job_alerts_controller_spec.rb
+++ b/spec/controllers/nqt_job_alerts_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe NqtJobAlertsController, type: :controller do
 
     it "returns 200" do
       subject
-      expect(response.code).to eql("200")
+      expect(response.code).to eq("200")
     end
   end
 
@@ -27,7 +27,7 @@ RSpec.describe NqtJobAlertsController, type: :controller do
 
     it "returns 200" do
       subject
-      expect(response.code).to eql("200")
+      expect(response.code).to eq("200")
     end
 
     it "queues a job to audit the subscription" do

--- a/spec/controllers/publishers/vacancies/application_controller_spec.rb
+++ b/spec/controllers/publishers/vacancies/application_controller_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Publishers::Vacancies::ApplicationController, type: :controller d
 
       it "converts date params to a Date object" do
         subject.convert_multiparameter_attributes_to_dates(:test_form, [:starts_on])
-        expect(controller.params[:test_form][:starts_on]).to eql(Date.parse("2020-01-01"))
+        expect(controller.params[:test_form][:starts_on]).to eq(Date.parse("2020-01-01"))
       end
     end
 
@@ -79,13 +79,13 @@ RSpec.describe Publishers::Vacancies::ApplicationController, type: :controller d
       let(:dates) { { 'starts_on(3i)': "100", 'starts_on(2i)': "", 'starts_on(1i)': "2020" } }
 
       it "the form object has an invalid date error" do
-        expect(subject.convert_multiparameter_attributes_to_dates(:test_form, [:starts_on])[:starts_on]).to eql(
+        expect(subject.convert_multiparameter_attributes_to_dates(:test_form, [:starts_on])[:starts_on]).to eq(
           I18n.t("activerecord.errors.models.vacancy.attributes.starts_on.invalid"),
         )
       end
 
       it "does not convert date params to a Date object" do
-        expect(controller.params[:test_form][:starts_on]).to eql(nil)
+        expect(controller.params[:test_form][:starts_on]).to eq(nil)
       end
     end
 
@@ -94,7 +94,7 @@ RSpec.describe Publishers::Vacancies::ApplicationController, type: :controller d
 
       it "does not convert date params to a Date object" do
         subject.convert_multiparameter_attributes_to_dates(:test_form, [:starts_on])
-        expect(controller.params[:test_form][:starts_on]).to eql(nil)
+        expect(controller.params[:test_form][:starts_on]).to eq(nil)
       end
     end
   end

--- a/spec/controllers/schools_vacancies_controller.rb
+++ b/spec/controllers/schools_vacancies_controller.rb
@@ -9,7 +9,7 @@ RSpec.describe Schools::VacanciesController, type: :controller do
       end
 
       it "should redirect to the first step of the new vacancy process" do
-        expect(response.status).to eql(302)
+        expect(response.status).to eq(302)
       end
     end
 
@@ -19,7 +19,7 @@ RSpec.describe Schools::VacanciesController, type: :controller do
       end
 
       it "should be not found" do
-        expect(response.status).to eql(404)
+        expect(response.status).to eq(404)
       end
     end
   end

--- a/spec/controllers/vacancies_controller_spec.rb
+++ b/spec/controllers/vacancies_controller_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe VacanciesController, type: :controller do
 
         it "sets the search replica on Search::SearchBuilder" do
           subject
-          expect(controller.instance_variable_get(:@vacancies_search).search_replica).to eql("#{Indexable::INDEX_NAME}_#{sort}")
+          expect(controller.instance_variable_get(:@vacancies_search).search_replica).to eq("#{Indexable::INDEX_NAME}_#{sort}")
         end
       end
 
@@ -82,7 +82,7 @@ RSpec.describe VacanciesController, type: :controller do
 
         it "sets the search replica on Search::SearchBuilder" do
           subject
-          expect(controller.instance_variable_get(:@vacancies_search).search_replica).to eql("#{Indexable::INDEX_NAME}_#{sort}")
+          expect(controller.instance_variable_get(:@vacancies_search).search_replica).to eq("#{Indexable::INDEX_NAME}_#{sort}")
         end
       end
 
@@ -91,7 +91,7 @@ RSpec.describe VacanciesController, type: :controller do
 
         it "sets the search replica on Search::SearchBuilder" do
           subject
-          expect(controller.instance_variable_get(:@vacancies_search).search_replica).to eql("#{Indexable::INDEX_NAME}_#{sort}")
+          expect(controller.instance_variable_get(:@vacancies_search).search_replica).to eq("#{Indexable::INDEX_NAME}_#{sort}")
         end
       end
 
@@ -106,7 +106,7 @@ RSpec.describe VacanciesController, type: :controller do
 
         it "sets the search replica on Search::SearchBuilder to the default sort strategy: newest listing" do
           subject
-          expect(controller.instance_variable_get(:@vacancies_search).search_replica).to eql("#{Indexable::INDEX_NAME}_publish_on_desc")
+          expect(controller.instance_variable_get(:@vacancies_search).search_replica).to eq("#{Indexable::INDEX_NAME}_publish_on_desc")
         end
       end
     end

--- a/spec/form_models/applying_for_the_job_form_spec.rb
+++ b/spec/form_models/applying_for_the_job_form_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ApplyingForTheJobForm, type: :model do
 
         it "raises correct error message" do
           subject.valid?
-          expect(subject.errors.messages[:application_link].first).to eql(
+          expect(subject.errors.messages[:application_link].first).to eq(
             I18n.t("applying_for_the_job_errors.application_link.url"),
           )
         end
@@ -31,7 +31,7 @@ RSpec.describe ApplyingForTheJobForm, type: :model do
 
         it "raises correct error message" do
           subject.valid?
-          expect(subject.errors.messages[:contact_email].first).to eql(
+          expect(subject.errors.messages[:contact_email].first).to eq(
             I18n.t("applying_for_the_job_errors.contact_email.blank"),
           )
         end
@@ -46,7 +46,7 @@ RSpec.describe ApplyingForTheJobForm, type: :model do
 
         it "raises correct error message" do
           subject.valid?
-          expect(subject.errors.messages[:contact_email].first).to eql(
+          expect(subject.errors.messages[:contact_email].first).to eq(
             I18n.t("applying_for_the_job_errors.contact_email.invalid"),
           )
         end
@@ -63,7 +63,7 @@ RSpec.describe ApplyingForTheJobForm, type: :model do
 
         it "raises correct error message" do
           subject.valid?
-          expect(subject.errors.messages[:contact_number].first).to eql(
+          expect(subject.errors.messages[:contact_number].first).to eq(
             I18n.t("applying_for_the_job_errors.contact_number.invalid"),
           )
         end
@@ -81,11 +81,11 @@ RSpec.describe ApplyingForTheJobForm, type: :model do
                                                       school_visits: "How you can visit the school")
 
       expect(application_details.valid?).to be true
-      expect(application_details.vacancy.application_link).to eql("http://an.application.link")
-      expect(application_details.vacancy.contact_email).to eql("some@email.com")
-      expect(application_details.vacancy.contact_number).to eql("01234 123456")
-      expect(application_details.vacancy.how_to_apply).to eql("How you can apply for the job")
-      expect(application_details.vacancy.school_visits).to eql("How you can visit the school")
+      expect(application_details.vacancy.application_link).to eq("http://an.application.link")
+      expect(application_details.vacancy.contact_email).to eq("some@email.com")
+      expect(application_details.vacancy.contact_number).to eq("01234 123456")
+      expect(application_details.vacancy.how_to_apply).to eq("How you can apply for the job")
+      expect(application_details.vacancy.school_visits).to eq("How you can visit the school")
     end
   end
 end

--- a/spec/form_models/cookies_preferences_form_spec.rb
+++ b/spec/form_models/cookies_preferences_form_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CookiesPreferencesForm, type: :model do
 
   describe "#initialize" do
     it "assigns attributes" do
-      expect(subject.cookies_consent).to eql(cookies_consent)
+      expect(subject.cookies_consent).to eq(cookies_consent)
     end
   end
 
@@ -23,7 +23,7 @@ RSpec.describe CookiesPreferencesForm, type: :model do
       it "raises correct error message" do
         subject.valid?
 
-        expect(subject.errors.messages[:cookies_consent].first).to eql(
+        expect(subject.errors.messages[:cookies_consent].first).to eq(
           I18n.t("cookies_preferences_errors.cookies_consent.inclusion"),
         )
       end
@@ -39,7 +39,7 @@ RSpec.describe CookiesPreferencesForm, type: :model do
       it "raises correct error message" do
         subject.valid?
 
-        expect(subject.errors.messages[:cookies_consent].first).to eql(
+        expect(subject.errors.messages[:cookies_consent].first).to eq(
           I18n.t("cookies_preferences_errors.cookies_consent.inclusion"),
         )
       end

--- a/spec/form_models/job_location_form_spec.rb
+++ b/spec/form_models/job_location_form_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe JobLocationForm, type: :model do
 
     it "a JobLocationForm can be converted to a vacancy" do
       expect(job_location_form.valid?).to be true
-      expect(job_location_form.vacancy.job_location).to eql("central_office")
+      expect(job_location_form.vacancy.job_location).to eq("central_office")
     end
   end
 end

--- a/spec/form_models/managed_organisations_form_spec.rb
+++ b/spec/form_models/managed_organisations_form_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe ManagedOrganisationsForm, type: :model do
 
   describe "#initialize" do
     it "assigns attributes" do
-      expect(subject.managed_organisations).to eql(managed_organisations)
-      expect(subject.managed_school_ids).to eql(managed_school_ids)
+      expect(subject.managed_organisations).to eq(managed_organisations)
+      expect(subject.managed_school_ids).to eq(managed_school_ids)
     end
   end
 

--- a/spec/form_models/nqt_job_alerts_form_spec.rb
+++ b/spec/form_models/nqt_job_alerts_form_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe NqtJobAlertsForm, type: :model do
       end
 
       it "adds location_category to the search criteria" do
-        expect(subject.job_alert_params[:search_criteria]).to eql(expected_hash.to_json)
+        expect(subject.job_alert_params[:search_criteria]).to eq(expected_hash.to_json)
       end
     end
 
@@ -32,7 +32,7 @@ RSpec.describe NqtJobAlertsForm, type: :model do
       end
 
       it "does not add location_category to the search criteria" do
-        expect(subject.job_alert_params[:search_criteria]).to eql(expected_hash.to_json)
+        expect(subject.job_alert_params[:search_criteria]).to eq(expected_hash.to_json)
       end
     end
   end

--- a/spec/form_models/organisation_form_spec.rb
+++ b/spec/form_models/organisation_form_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe OrganisationForm, type: :model do
 
   describe "#initialize" do
     it "assigns attributes" do
-      expect(subject.description).to eql(description)
-      expect(subject.website).to eql(website)
+      expect(subject.description).to eq(description)
+      expect(subject.website).to eq(website)
     end
   end
 
@@ -19,7 +19,7 @@ RSpec.describe OrganisationForm, type: :model do
 
       it "is invalid" do
         expect(subject.valid?).to be false
-        expect(subject.errors.messages[:website].first).to eql(I18n.t("organisation_errors.website.url"))
+        expect(subject.errors.messages[:website].first).to eq(I18n.t("organisation_errors.website.url"))
       end
     end
 

--- a/spec/form_models/schools_form_spec.rb
+++ b/spec/form_models/schools_form_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe SchoolsForm, type: :model do
 
         it "requires a school to be selected" do
           expect(subject.valid?).to be false
-          expect(subject.errors.messages[:organisation_ids]).to eql([I18n.t("schools_errors.organisation_ids.blank")])
+          expect(subject.errors.messages[:organisation_ids]).to eq([I18n.t("schools_errors.organisation_ids.blank")])
         end
       end
 
@@ -23,7 +23,7 @@ RSpec.describe SchoolsForm, type: :model do
 
         it "is valid" do
           expect(subject.valid?).to be true
-          expect(subject.organisation_ids).to eql(organisation.id)
+          expect(subject.organisation_ids).to eq(organisation.id)
         end
       end
     end
@@ -37,7 +37,7 @@ RSpec.describe SchoolsForm, type: :model do
 
         it "requires at least 2 schools to be selected" do
           expect(subject.valid?).to be false
-          expect(subject.errors.messages[:organisation_ids]).to eql([I18n.t("schools_errors.organisation_ids.blank")])
+          expect(subject.errors.messages[:organisation_ids]).to eq([I18n.t("schools_errors.organisation_ids.blank")])
         end
       end
 
@@ -47,7 +47,7 @@ RSpec.describe SchoolsForm, type: :model do
 
         it "requires at least 2 schools to be selected" do
           expect(subject.valid?).to be false
-          expect(subject.errors.messages[:organisation_ids]).to eql([I18n.t("schools_errors.organisation_ids.invalid")])
+          expect(subject.errors.messages[:organisation_ids]).to eq([I18n.t("schools_errors.organisation_ids.invalid")])
         end
       end
 
@@ -58,7 +58,7 @@ RSpec.describe SchoolsForm, type: :model do
 
         it "is valid" do
           expect(subject.valid?).to be true
-          expect(subject.organisation_ids).to eql(organisation_ids)
+          expect(subject.organisation_ids).to eq(organisation_ids)
         end
       end
     end

--- a/spec/form_models/subscription_form_spec.rb
+++ b/spec/form_models/subscription_form_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SubscriptionForm, type: :model do
       let(:keyword) { nil }
 
       it "is deleted from the hash" do
-        expect(subject.search_criteria_hash).to eql({ job_roles: job_roles })
+        expect(subject.search_criteria_hash).to eq({ job_roles: job_roles })
       end
     end
 
@@ -20,7 +20,7 @@ RSpec.describe SubscriptionForm, type: :model do
       let(:job_roles) { [] }
 
       it "is deleted from the hash" do
-        expect(subject.search_criteria_hash).to eql({ keyword: keyword })
+        expect(subject.search_criteria_hash).to eq({ keyword: keyword })
       end
     end
   end

--- a/spec/helpers/sort_helper_spec.rb
+++ b/spec/helpers/sort_helper_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe SortHelper, type: :helper do
     before { allow(helper).to receive(:request).and_return(request) }
 
     it "returns a link to the given path with the appended sort parameters" do
-      expect(result).to eql(
+      expect(result).to eq(
         '<a class="govuk-link sortable-link sortby--asc" aria-label="Sort jobs by test_heading in ascending order" '\
         'href="/test/test_path?sort_column=test_column&amp;sort_order=asc">test_heading</a>',
       )
@@ -22,7 +22,7 @@ RSpec.describe SortHelper, type: :helper do
       let(:column) { "expires_on" }
 
       it "returns a link to the given path with the appended sort parameters, an active class and reversed sort order" do
-        expect(result).to eql(
+        expect(result).to eq(
           '<a class="govuk-link sortable-link sortby--desc active" aria-label="Sort jobs by test_heading in descending order" '\
           'href="/test/test_path?sort_column=expires_on&amp;sort_order=desc">test_heading</a>',
         )

--- a/spec/helpers/vacancies_helper_spec.rb
+++ b/spec/helpers/vacancies_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe VacanciesHelper, type: :helper do
 
     it "includes supporting_documents for legacy listings" do
       allow(vacancy).to receive(:supporting_documents).and_return(nil)
-      expect(helper.new_attributes(vacancy)[:supporting_documents]).to eql(I18n.t("jobs.supporting_documents"))
+      expect(helper.new_attributes(vacancy)[:supporting_documents]).to eq(I18n.t("jobs.supporting_documents"))
     end
   end
 
@@ -17,14 +17,14 @@ RSpec.describe VacanciesHelper, type: :helper do
       allow(vacancy).to receive(:published?).and_return(false)
       allow(vacancy).to receive(:state).and_return("copy")
 
-      expect(review_heading(vacancy)).to eql(I18n.t("jobs.copy_review_heading"))
+      expect(review_heading(vacancy)).to eq(I18n.t("jobs.copy_review_heading"))
     end
 
     it "returns review heading" do
       allow(vacancy).to receive(:published?).and_return(false)
       allow(vacancy).to receive(:state).and_return("not_copy_review")
 
-      expect(review_heading(vacancy)).to eql(I18n.t("jobs.review_heading"))
+      expect(review_heading(vacancy)).to eq(I18n.t("jobs.review_heading"))
     end
   end
 
@@ -37,29 +37,29 @@ RSpec.describe VacanciesHelper, type: :helper do
     end
 
     it "returns copy if copy true" do
-      expect(hidden_state_field_value(vacancy, true)).to eql("copy")
+      expect(hidden_state_field_value(vacancy, true)).to eq("copy")
     end
 
     it "returns edit_published if published vacancy" do
       allow(vacancy).to receive(:published?).and_return(true)
-      expect(hidden_state_field_value(vacancy)).to eql("edit_published")
+      expect(hidden_state_field_value(vacancy)).to eq("edit_published")
     end
 
     it "returns current state if vacancy state is copy/review/edit" do
       allow(vacancy).to receive(:published?).and_return(false)
 
       allow(vacancy).to receive(:state).and_return("copy")
-      expect(hidden_state_field_value(vacancy)).to eql("copy")
+      expect(hidden_state_field_value(vacancy)).to eq("copy")
 
       allow(vacancy).to receive(:state).and_return("review")
-      expect(hidden_state_field_value(vacancy)).to eql("review")
+      expect(hidden_state_field_value(vacancy)).to eq("review")
 
       allow(vacancy).to receive(:state).and_return("edit")
-      expect(hidden_state_field_value(vacancy)).to eql("edit")
+      expect(hidden_state_field_value(vacancy)).to eq("edit")
     end
 
     it "returns create" do
-      expect(hidden_state_field_value(vacancy)).to eql("create")
+      expect(hidden_state_field_value(vacancy)).to eq("create")
     end
   end
 
@@ -73,24 +73,24 @@ RSpec.describe VacanciesHelper, type: :helper do
     end
 
     it "returns draft jobs link for draft jobs" do
-      expect(back_to_manage_jobs_link(vacancy)).to eql(jobs_with_type_organisation_path("draft"))
+      expect(back_to_manage_jobs_link(vacancy)).to eq(jobs_with_type_organisation_path("draft"))
     end
 
     it "returns pending jobs link for scheduled jobs" do
       allow(vacancy).to receive(:published?).and_return(true)
       allow(vacancy).to receive_message_chain(:expires_at, :future?).and_return(true)
-      expect(back_to_manage_jobs_link(vacancy)).to eql(jobs_with_type_organisation_path("pending"))
+      expect(back_to_manage_jobs_link(vacancy)).to eq(jobs_with_type_organisation_path("pending"))
     end
 
     it "returns published jobs link for published jobs" do
       allow(vacancy).to receive(:listed?).and_return(true)
-      expect(back_to_manage_jobs_link(vacancy)).to eql(jobs_with_type_organisation_path("published"))
+      expect(back_to_manage_jobs_link(vacancy)).to eq(jobs_with_type_organisation_path("published"))
     end
 
     it "returns expired jobs link for expired jobs" do
       allow(vacancy).to receive(:published?).and_return(true)
       allow(vacancy).to receive_message_chain(:expires_at, :past?).and_return(true)
-      expect(back_to_manage_jobs_link(vacancy)).to eql(jobs_with_type_organisation_path("expired"))
+      expect(back_to_manage_jobs_link(vacancy)).to eq(jobs_with_type_organisation_path("expired"))
     end
   end
 end

--- a/spec/lib/modules/aws_ip_ranges_spec.rb
+++ b/spec/lib/modules/aws_ip_ranges_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe AWSIpRanges do
         216.137.32.0/19
       ]
 
-      expect(AWSIpRanges.cloudfront_ips).to eql(expected_result)
+      expect(AWSIpRanges.cloudfront_ips).to eq(expected_result)
     end
 
     it "configures a short timeout" do
@@ -59,7 +59,7 @@ RSpec.describe AWSIpRanges do
     context "when there was any connectivity issue" do
       it "returns an empty array" do
         allow_any_instance_of(Net::HTTP).to receive(:start).and_raise(Timeout::Error.new("error"))
-        expect(AWSIpRanges.cloudfront_ips).to eql([])
+        expect(AWSIpRanges.cloudfront_ips).to eq([])
       end
 
       it "logs a warning" do
@@ -84,7 +84,7 @@ RSpec.describe AWSIpRanges do
         context "when #{error} is raised" do
           it "returns an empty array" do
             allow_any_instance_of(Net::HTTP).to receive(:start).and_raise(error.new("error"))
-            expect(AWSIpRanges.cloudfront_ips).to eql([])
+            expect(AWSIpRanges.cloudfront_ips).to eq([])
           end
         end
       end
@@ -97,7 +97,7 @@ RSpec.describe AWSIpRanges do
       end
 
       it "returns an empty array" do
-        expect(AWSIpRanges.cloudfront_ips).to eql([])
+        expect(AWSIpRanges.cloudfront_ips).to eq([])
       end
 
       it "logs a warning" do

--- a/spec/lib/organisation_import/import_school_data_spec.rb
+++ b/spec/lib/organisation_import/import_school_data_spec.rb
@@ -62,15 +62,15 @@ RSpec.describe ImportSchoolData do
     end
 
     it "creates Schools" do
-      expect { subject.run! }.to change(School, :count).to eql(9)
+      expect { subject.run! }.to change(School, :count).to eq(9)
     end
 
     it "creates SchoolGroups" do
-      expect { subject.run! }.to change(SchoolGroup, :count).to eql(2)
+      expect { subject.run! }.to change(SchoolGroup, :count).to eq(2)
     end
 
     it "creates SchoolGroupMemberships" do
-      expect { subject.run! }.to change(SchoolGroupMembership, :count).to eql(8)
+      expect { subject.run! }.to change(SchoolGroupMembership, :count).to eq(8)
     end
 
     it "links the correct schools and local authorities" do
@@ -91,15 +91,15 @@ RSpec.describe ImportSchoolData do
       expect(example_school.gias_data).not_to be_blank
       expect(example_school.address3).to be_nil
       expect(example_school.county).to be_nil
-      expect(example_school.detailed_school_type).to eql("Voluntary aided school")
-      expect(example_school.establishment_status).to eql("Open")
-      expect(example_school.locality).to eql("Duke's Place")
-      expect(example_school.local_authority_within).to eql("City of London")
-      expect(example_school.name).to eql("Sir John Cass's Foundation Primary School")
-      expect(example_school.phase).to eql("primary")
-      expect(example_school.region).to eql("London")
-      expect(example_school.school_type).to eql("LA maintained schools")
-      expect(example_school.url).to eql("http://www.sirjohncassprimary.org")
+      expect(example_school.detailed_school_type).to eq("Voluntary aided school")
+      expect(example_school.establishment_status).to eq("Open")
+      expect(example_school.locality).to eq("Duke's Place")
+      expect(example_school.local_authority_within).to eq("City of London")
+      expect(example_school.name).to eq("Sir John Cass's Foundation Primary School")
+      expect(example_school.phase).to eq("primary")
+      expect(example_school.region).to eq("London")
+      expect(example_school.school_type).to eq("LA maintained schools")
+      expect(example_school.url).to eq("http://www.sirjohncassprimary.org")
     end
 
     context "when the CSV contains smart-quotes using Windows 1252 encoding" do
@@ -116,7 +116,7 @@ RSpec.describe ImportSchoolData do
 
       it "should correct convert the file to UTF-8" do
         subject.run!
-        expect(example_school.name).to eql("St John’s School")
+        expect(example_school.name).to eq("St John’s School")
       end
     end
 
@@ -131,7 +131,7 @@ RSpec.describe ImportSchoolData do
                     "Town,Postcode\n" \
                     "100000,St John\x92s School,999,999,ZZZ,test.com,?,?,?")
         subject.run!
-        expect(example_school.url).to eql("http://test.com")
+        expect(example_school.url).to eq("http://test.com")
       end
 
       it "does not return a value if the website is not set" do

--- a/spec/lib/organisation_import/import_trust_data_spec.rb
+++ b/spec/lib/organisation_import/import_trust_data_spec.rb
@@ -61,8 +61,8 @@ RSpec.describe ImportTrustData do
     context "when coordinates are found" do
       it "sets the coordinates" do
         subject.send(:set_geolocation, trust, "postcode")
-        expect(trust.geolocation.x).to eql(Geocoder::DEFAULT_STUB_COORDINATES[0])
-        expect(trust.geolocation.y).to eql(Geocoder::DEFAULT_STUB_COORDINATES[1])
+        expect(trust.geolocation.x).to eq(Geocoder::DEFAULT_STUB_COORDINATES[0])
+        expect(trust.geolocation.y).to eq(Geocoder::DEFAULT_STUB_COORDINATES[1])
       end
     end
   end
@@ -93,11 +93,11 @@ RSpec.describe ImportTrustData do
     end
 
     it "creates SchoolGroups" do
-      expect { subject.run! }.to change(SchoolGroup, :count).to eql(3)
+      expect { subject.run! }.to change(SchoolGroup, :count).to eq(3)
     end
 
     it "creates SchoolGroupMemberships" do
-      expect { subject.run! }.to change(SchoolGroupMembership, :count).to eql(3)
+      expect { subject.run! }.to change(SchoolGroupMembership, :count).to eq(3)
     end
 
     it "links the correct schools and trusts" do
@@ -111,13 +111,13 @@ RSpec.describe ImportTrustData do
       subject.run!
       expect(trust_1).not_to be_blank
       expect(trust_1.gias_data).not_to be_blank
-      expect(trust_1.name).to eql("Abbey Academies Trust")
-      expect(trust_1.group_type).to eql("Multi-academy trust")
-      expect(trust_1.address).to eql("Abbey Road")
-      expect(trust_1.county).to eql("Not recorded")
-      expect(trust_1.postcode).to eql("PE10 9EP")
-      expect(trust_1.geolocation.x.round(13)).to eql(Geocoder::DEFAULT_STUB_COORDINATES[0].round(13))
-      expect(trust_1.geolocation.y.round(13)).to eql(Geocoder::DEFAULT_STUB_COORDINATES[1].round(13))
+      expect(trust_1.name).to eq("Abbey Academies Trust")
+      expect(trust_1.group_type).to eq("Multi-academy trust")
+      expect(trust_1.address).to eq("Abbey Road")
+      expect(trust_1.county).to eq("Not recorded")
+      expect(trust_1.postcode).to eq("PE10 9EP")
+      expect(trust_1.geolocation.x.round(13)).to eq(Geocoder::DEFAULT_STUB_COORDINATES[0].round(13))
+      expect(trust_1.geolocation.y.round(13)).to eq(Geocoder::DEFAULT_STUB_COORDINATES[1].round(13))
     end
   end
 end

--- a/spec/models/school_group_spec.rb
+++ b/spec/models/school_group_spec.rb
@@ -5,5 +5,5 @@ RSpec.describe SchoolGroup, type: :model do
   it { should have_many(:schools) }
 
   it { expect(subject.attributes).to include("gias_data") }
-  it { expect(described_class.columns_hash["gias_data"].type).to eql(:json) }
+  it { expect(described_class.columns_hash["gias_data"].type).to eq(:json) }
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe School, type: :model do
   it { expect(subject.attributes).to include("gias_data") }
-  it { expect(described_class.columns_hash["gias_data"].type).to eql(:json) }
+  it { expect(described_class.columns_hash["gias_data"].type).to eq(:json) }
 
   it { should have_many(:school_group_memberships) }
   it { should have_many(:school_groups) }
@@ -53,15 +53,15 @@ RSpec.describe School, type: :model do
           school.easting = 533_498
           school.northing = 181_201
 
-          expect(school.geolocation.x).to eql(51.51396894535262)
-          expect(school.geolocation.y).to eql(-0.07751626505544208)
+          expect(school.geolocation.x).to eq(51.51396894535262)
+          expect(school.geolocation.y).to eq(-0.07751626505544208)
         end
       end
 
       context "when setting just a GB easting" do
         it "should not set a geolocation" do
           school.easting = 533_498
-          expect(school.geolocation).to eql(nil)
+          expect(school.geolocation).to eq(nil)
         end
       end
 
@@ -69,7 +69,7 @@ RSpec.describe School, type: :model do
         it "should not set a geolocation" do
           school.northing = 308_885
 
-          expect(school.geolocation).to eql(nil)
+          expect(school.geolocation).to eq(nil)
         end
       end
     end
@@ -82,8 +82,8 @@ RSpec.describe School, type: :model do
           school.easting = 533_498
           school.northing = 181_201
 
-          expect(school.geolocation.x).to eql(51.51396894535262)
-          expect(school.geolocation.y).to eql(-0.07751626505544208)
+          expect(school.geolocation.x).to eq(51.51396894535262)
+          expect(school.geolocation.y).to eq(-0.07751626505544208)
         end
       end
 
@@ -92,7 +92,7 @@ RSpec.describe School, type: :model do
           school.easting = 533_498
           school.northing = nil
 
-          expect(school.geolocation).to eql(nil)
+          expect(school.geolocation).to eq(nil)
         end
       end
 
@@ -101,7 +101,7 @@ RSpec.describe School, type: :model do
           school.northing = 308_885
           school.easting = nil
 
-          expect(school.geolocation).to eql(nil)
+          expect(school.geolocation).to eq(nil)
         end
       end
     end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -14,19 +14,19 @@ RSpec.describe Subscription, type: :model do
 
     describe "#daily" do
       it "retrieves all subscriptions with frequency set to :daily" do
-        expect(Subscription.daily.count).to eql(4)
+        expect(Subscription.daily.count).to eq(4)
       end
     end
 
     describe "#weekly" do
       it "retrieves all subscriptions with frequency set to :daily" do
-        expect(Subscription.weekly.count).to eql(5)
+        expect(Subscription.weekly.count).to eq(5)
       end
     end
 
     describe "active" do
       it "retrieves all subscriptions with active set to true" do
-        expect(Subscription.active.count).to eql(8)
+        expect(Subscription.active.count).to eq(8)
       end
     end
   end
@@ -114,7 +114,7 @@ RSpec.describe Subscription, type: :model do
     after { travel_back }
 
     it "calls out to algolia search" do
-      expect(subscription.vacancies_for_range(date_yesterday, date_today)).to eql(vacancies)
+      expect(subscription.vacancies_for_range(date_yesterday, date_today)).to eq(vacancies)
     end
   end
 

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -289,20 +289,20 @@ RSpec.describe Vacancy, type: :model do
   describe "#application_link" do
     it "returns the url" do
       vacancy = create(:vacancy, application_link: "https://example.com")
-      expect(vacancy.application_link).to eql("https://example.com")
+      expect(vacancy.application_link).to eq("https://example.com")
     end
 
     context "when a protocol was not provided" do
       it "returns an absolute url with `http` as the protocol" do
         vacancy = create(:vacancy, application_link: "example.com")
-        expect(vacancy.application_link).to eql("http://example.com")
+        expect(vacancy.application_link).to eq("http://example.com")
       end
     end
 
     context "when only the `www` sub domain was provided" do
       it "returns an absolute url with `http` as the protocol" do
         vacancy = create(:vacancy, application_link: "www.example.com")
-        expect(vacancy.application_link).to eql("http://www.example.com")
+        expect(vacancy.application_link).to eq("http://www.example.com")
       end
     end
   end

--- a/spec/presenters/subscription_presenter_spec.rb
+++ b/spec/presenters/subscription_presenter_spec.rb
@@ -134,19 +134,19 @@ RSpec.describe SubscriptionPresenter do
 
   describe "#search_criteria_field" do
     it "does not return the radius field" do
-      expect(presenter.send(:search_criteria_field, "radius", "some radius")).to eql(nil)
+      expect(presenter.send(:search_criteria_field, "radius", "some radius")).to eq(nil)
     end
 
     it "does not return the location_category field" do
-      expect(presenter.send(:search_criteria_field, "location_category", "some location category")).to eql(nil)
+      expect(presenter.send(:search_criteria_field, "location_category", "some location category")).to eq(nil)
     end
 
     it "does not return the jobs_sort field" do
-      expect(presenter.send(:search_criteria_field, "jobs_sort", "search_replica")).to eql(nil)
+      expect(presenter.send(:search_criteria_field, "jobs_sort", "search_replica")).to eq(nil)
     end
 
     it "returns a field:value hash" do
-      expect(presenter.send(:search_criteria_field, "random_field", "value")).to eql({ 'random_field': "value" })
+      expect(presenter.send(:search_criteria_field, "random_field", "value")).to eq({ 'random_field': "value" })
     end
   end
 end

--- a/spec/requests/redirect_to_canonical_domain_spec.rb
+++ b/spec/requests/redirect_to_canonical_domain_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe "Redirect to canonical domain", type: :request do
     it "redirects to the canonical domain" do
       get "/", headers: headers
 
-      expect(response.location).to eql("http://#{DOMAIN}/")
-      expect(response.status).to eql(301)
+      expect(response.location).to eq("http://#{DOMAIN}/")
+      expect(response.status).to eq(301)
     end
   end
 
@@ -25,7 +25,7 @@ RSpec.describe "Redirect to canonical domain", type: :request do
     it "does not redirect" do
       get "/", headers: headers
 
-      expect(response.status).to eql(200)
+      expect(response.status).to eq(200)
     end
   end
 end

--- a/spec/services/location_suggestion_spec.rb
+++ b/spec/services/location_suggestion_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe LocationSuggestion do
 
     context "the request is successful" do
       it "returns the correct response" do
-        expect(subject.send(:get_suggestions_from_google)).to eql(JSON.parse(request_body))
+        expect(subject.send(:get_suggestions_from_google)).to eq(JSON.parse(request_body))
       end
     end
   end
@@ -75,7 +75,7 @@ RSpec.describe LocationSuggestion do
     end
 
     it "returns the parsed data" do
-      expect(subject.suggest_locations).to eql([suggestions, matched_terms])
+      expect(subject.suggest_locations).to eq([suggestions, matched_terms])
     end
   end
 end

--- a/spec/services/search/alert_builder_spec.rb
+++ b/spec/services/search/alert_builder_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Search::AlertBuilder do
     context "#initialize" do
       context "#keyword" do
         it "adds subject and job_title to the keyword" do
-          expect(subject.keyword).to eql(search_query)
+          expect(subject.keyword).to eq(search_query)
         end
       end
 
@@ -102,7 +102,7 @@ RSpec.describe Search::AlertBuilder do
       end
 
       it "carries out alert search with correct criteria" do
-        expect(subject.vacancies).to eql(vacancies)
+        expect(subject.vacancies).to eq(vacancies)
       end
     end
   end
@@ -130,7 +130,7 @@ RSpec.describe Search::AlertBuilder do
       end
 
       it "carries out alert search with correct criteria" do
-        expect(subject.vacancies).to eql(vacancies)
+        expect(subject.vacancies).to eq(vacancies)
       end
     end
   end

--- a/spec/services/search/algolia_search_request_spec.rb
+++ b/spec/services/search/algolia_search_request_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe Search::AlgoliaSearchRequest do
     let(:total_results) { 57 }
 
     it "returns the correct array" do
-      expect(subject.send(:build_stats, page, pages, results_per_page, total_results)).to eql([1, 10, 57])
+      expect(subject.send(:build_stats, page, pages, results_per_page, total_results)).to eq([1, 10, 57])
     end
 
     context "when there are no results" do
       let(:total_results) { 0 }
 
       it "returns the correct array" do
-        expect(subject.send(:build_stats, page, pages, results_per_page, total_results)).to eql([0, 0, 0])
+        expect(subject.send(:build_stats, page, pages, results_per_page, total_results)).to eq([0, 0, 0])
       end
     end
 
@@ -26,7 +26,7 @@ RSpec.describe Search::AlgoliaSearchRequest do
       let(:page) { 5 }
 
       it "returns the correct array" do
-        expect(subject.send(:build_stats, page, pages, results_per_page, total_results)).to eql([51, 57, 57])
+        expect(subject.send(:build_stats, page, pages, results_per_page, total_results)).to eq([51, 57, 57])
       end
     end
   end
@@ -56,7 +56,7 @@ RSpec.describe Search::AlgoliaSearchRequest do
     before { mock_algolia_search(vacancies, 1, "maths", arguments_to_algolia) }
 
     it "carries out search with the correct parameters" do
-      expect(subject.vacancies).to eql(vacancies)
+      expect(subject.vacancies).to eq(vacancies)
     end
   end
 end

--- a/spec/services/search/buffer_suggestions_builder_spec.rb
+++ b/spec/services/search/buffer_suggestions_builder_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Search::BufferSuggestionsBuilder do
       end
 
       it "suggests the buffer with the smallest radius" do
-        expect(subject.buffer_suggestions).to eql([["5", 1]])
+        expect(subject.buffer_suggestions).to eq([["5", 1]])
       end
     end
 
@@ -89,7 +89,7 @@ RSpec.describe Search::BufferSuggestionsBuilder do
       end
 
       it "suggests the wider buffer radii as well" do
-        expect(subject.buffer_suggestions).to eql([["5", 1], ["10", 2], ["15", 3], ["20", 4], ["25", 5]])
+        expect(subject.buffer_suggestions).to eq([["5", 1], ["10", 2], ["15", 3], ["20", 4], ["25", 5]])
       end
     end
 
@@ -118,7 +118,7 @@ RSpec.describe Search::BufferSuggestionsBuilder do
       end
 
       it "only returns buffer radii that include vacancies" do
-        expect(subject.buffer_suggestions).to eql([["25", 5]])
+        expect(subject.buffer_suggestions).to eq([["25", 5]])
       end
     end
   end

--- a/spec/services/search/filters_builder_spec.rb
+++ b/spec/services/search/filters_builder_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Search::FiltersBuilder do
       let(:to_date) { nil }
 
       it "builds the correct date filter" do
-        expect(subject.send(:build_date_filters)).to eql("publication_date_timestamp >= #{from_date.to_time.to_i}")
+        expect(subject.send(:build_date_filters)).to eq("publication_date_timestamp >= #{from_date.to_time.to_i}")
       end
     end
 
@@ -45,13 +45,13 @@ RSpec.describe Search::FiltersBuilder do
       let(:from_date) { nil }
 
       it "builds the correct date filter" do
-        expect(subject.send(:build_date_filters)).to eql("publication_date_timestamp <= #{to_date.to_time.to_i}")
+        expect(subject.send(:build_date_filters)).to eq("publication_date_timestamp <= #{to_date.to_time.to_i}")
       end
     end
 
     context "when both dates are supplied" do
       it "builds the correct date filter" do
-        expect(subject.send(:build_date_filters)).to eql(
+        expect(subject.send(:build_date_filters)).to eq(
           "publication_date_timestamp >= #{from_date.to_time.to_i} AND " \
           "publication_date_timestamp <= #{to_date.to_time.to_i}",
         )
@@ -97,7 +97,7 @@ RSpec.describe Search::FiltersBuilder do
       after { travel_back }
 
       it "builds the correct query" do
-        expect(subject.filter_query).to eql(
+        expect(subject.filter_query).to eq(
           "(publication_date_timestamp <= #{published_today_filter} AND"\
           " expires_at_timestamp > #{expired_now_filter}) AND "\
           "(publication_date_timestamp >= #{from_date.to_time.to_i} AND" \

--- a/spec/services/search/location_builder_spec.rb
+++ b/spec/services/search/location_builder_spec.rb
@@ -2,10 +2,10 @@ require "rails_helper"
 
 RSpec.shared_examples "a search using polygons" do |options|
   it "sets the correct attributes" do
-    expect(subject.location_category).to eql(options&.dig(:location)&.presence || location_polygon.name)
-    expect(subject.location_polygon).to eql(location_polygon)
-    expect(subject.location_filter).to eql({})
-    expect(subject.buffer_radius).to eql(buffer_radius)
+    expect(subject.location_category).to eq(options&.dig(:location)&.presence || location_polygon.name)
+    expect(subject.location_polygon).to eq(location_polygon)
+    expect(subject.location_filter).to eq({})
+    expect(subject.buffer_radius).to eq(buffer_radius)
   end
 end
 
@@ -46,7 +46,7 @@ RSpec.describe Search::LocationBuilder do
         it "missing polygon is true" do
           expect(subject.location_category).to eq "North West"
           expect(subject.location_polygon).to be nil
-          expect(subject.location_filter).to eql({})
+          expect(subject.location_filter).to eq({})
           expect(subject.missing_polygon).to be true
         end
       end
@@ -78,7 +78,7 @@ RSpec.describe Search::LocationBuilder do
         it "sets location filter around the location with the default radius" do
           expect(subject.location_category).to be nil
           expect(subject.location_polygon).to be nil
-          expect(subject.location_filter).to eql({
+          expect(subject.location_filter).to eq({
             point_coordinates: Geocoder::DEFAULT_STUB_COORDINATES,
             radius: expected_radius,
           })
@@ -93,7 +93,7 @@ RSpec.describe Search::LocationBuilder do
         it "carries out geographical search around a coordinate location with the specified radius" do
           expect(subject.location_category).to be nil
           expect(subject.location_polygon).to be nil
-          expect(subject.location_filter).to eql({
+          expect(subject.location_filter).to eq({
             point_coordinates: Geocoder::DEFAULT_STUB_COORDINATES,
             radius: expected_radius,
           })

--- a/spec/services/search/radius_suggestions_builder_spec.rb
+++ b/spec/services/search/radius_suggestions_builder_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Search::RadiusSuggestionsBuilder do
       end
 
       it "sets the correct radius suggestions" do
-        expect(subject.radius_suggestions).to eql([[5, 1], [15, 3], [20, 4], [25, 7]])
+        expect(subject.radius_suggestions).to eq([[5, 1], [15, 3], [20, 4], [25, 7]])
       end
     end
 
@@ -69,7 +69,7 @@ RSpec.describe Search::RadiusSuggestionsBuilder do
       end
 
       it "sets the correct radius suggestions" do
-        expect(subject.radius_suggestions).to eql([[100, 5], [200, 9]])
+        expect(subject.radius_suggestions).to eq([[100, 5], [200, 9]])
       end
     end
   end

--- a/spec/services/search/replica_builder_spec.rb
+++ b/spec/services/search/replica_builder_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Search::ReplicaBuilder do
 
       context "and a keyword is NOT specified" do
         it "uses the default search replica" do
-          expect(subject.search_replica).to eql("#{Indexable::INDEX_NAME}_publish_on_desc")
+          expect(subject.search_replica).to eq("#{Indexable::INDEX_NAME}_publish_on_desc")
         end
       end
     end
@@ -27,7 +27,7 @@ RSpec.describe Search::ReplicaBuilder do
       let(:job_sort) { "worst_listing" }
 
       it "uses the default search replica" do
-        expect(subject.search_replica).to eql("#{Indexable::INDEX_NAME}_publish_on_desc")
+        expect(subject.search_replica).to eq("#{Indexable::INDEX_NAME}_publish_on_desc")
       end
     end
 
@@ -35,14 +35,14 @@ RSpec.describe Search::ReplicaBuilder do
       let(:job_sort) { "expires_at_desc" }
 
       it "uses the specified search replica" do
-        expect(subject.search_replica).to eql("#{Indexable::INDEX_NAME}_expires_at_desc")
+        expect(subject.search_replica).to eq("#{Indexable::INDEX_NAME}_expires_at_desc")
       end
 
       context "and a keyword is specified" do
         let(:keyword) { "maths teacher" }
 
         it "uses the specified search replica" do
-          expect(subject.search_replica).to eql("#{Indexable::INDEX_NAME}_expires_at_desc")
+          expect(subject.search_replica).to eq("#{Indexable::INDEX_NAME}_expires_at_desc")
         end
       end
     end

--- a/spec/services/search/search_builder_spec.rb
+++ b/spec/services/search/search_builder_spec.rb
@@ -32,11 +32,11 @@ RSpec.describe Search::SearchBuilder do
       before { allow_any_instance_of(Search::LocationBuilder).to receive(:missing_polygon).and_return(true) }
 
       it "appends location to the keyword" do
-        expect(subject.keyword).to eql("maths teacher london")
+        expect(subject.keyword).to eq("maths teacher london")
       end
 
       it "appends location to keyword in the active hash" do
-        expect(subject.only_active_to_hash[:keyword]).to eql("maths teacher london")
+        expect(subject.only_active_to_hash[:keyword]).to eq("maths teacher london")
       end
     end
 
@@ -44,7 +44,7 @@ RSpec.describe Search::SearchBuilder do
       before { allow_any_instance_of(Search::LocationBuilder).to receive(:location_category_search?).and_return(true) }
 
       it "sets location_category in the active params hash" do
-        expect(subject.only_active_to_hash[:location_category]).to eql("london")
+        expect(subject.only_active_to_hash[:location_category]).to eq("london")
       end
     end
   end

--- a/spec/services/updates_parser_spec.rb
+++ b/spec/services/updates_parser_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe UpdatesParser do
   describe "#call" do
     it "only adds valid update files to the hash" do
       expect(UpdatesParser.new(update_paths).call[date])
-        .to eql([{ path: "valid_update_title_2020_04_10", name: "Valid update title" }])
+        .to eq([{ path: "valid_update_title_2020_04_10", name: "Valid update title" }])
     end
   end
 end

--- a/spec/system/hiring_staff_can_copy_a_vacancy_spec.rb
+++ b/spec/system/hiring_staff_can_copy_a_vacancy_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Copying a vacancy" do
 
       click_on(I18n.t("buttons.cancel_copy"), class: "govuk-back-link")
 
-      expect(page.current_path).to eql(organisation_path)
+      expect(page.current_path).to eq(organisation_path)
       expect(page).not_to have_content("A new job title")
     end
 
@@ -58,7 +58,7 @@ RSpec.describe "Copying a vacancy" do
 
       click_on(I18n.t("buttons.cancel_copy"), class: "govuk-link")
 
-      expect(page.current_path).to eql(organisation_path)
+      expect(page.current_path).to eq(organisation_path)
       expect(page).not_to have_content("A new job title")
     end
   end

--- a/spec/system/hiring_staff_can_edit_a_draft_vacancy_as_a_school_group_spec.rb
+++ b/spec/system/hiring_staff_can_edit_a_draft_vacancy_as_a_school_group_spec.rb
@@ -20,50 +20,50 @@ RSpec.describe "Editing a draft vacancy" do
 
       expect(page).to have_content(I18n.t("school_groups.job_location_heading.central_office"))
       expect(page).to have_content(full_address(school_group))
-      expect(Vacancy.find(vacancy.id).readable_job_location).to eql(
+      expect(Vacancy.find(vacancy.id).readable_job_location).to eq(
         I18n.t("publishers.organisations.readable_job_location.central_office"),
       )
 
       change_job_location(vacancy, "at_one_school")
 
-      expect(page.current_path).to eql(organisation_job_build_path(vacancy.id, :schools))
+      expect(page.current_path).to eq(organisation_job_build_path(vacancy.id, :schools))
       fill_in_school_form_field(school_1)
       click_on I18n.t("buttons.update_job")
 
-      expect(page.current_path).to eql(organisation_job_review_path(vacancy.id))
+      expect(page.current_path).to eq(organisation_job_review_path(vacancy.id))
       expect(page).to have_content(I18n.t("school_groups.job_location_heading.at_one_school"))
       expect(page).to have_content(full_address(school_1))
-      expect(Vacancy.find(vacancy.id).readable_job_location).to eql(school_1.name)
+      expect(Vacancy.find(vacancy.id).readable_job_location).to eq(school_1.name)
 
       change_job_location(vacancy, "at_one_school")
 
-      expect(page.current_path).to eql(organisation_job_build_path(vacancy.id, :schools))
+      expect(page.current_path).to eq(organisation_job_build_path(vacancy.id, :schools))
       fill_in_school_form_field(school_2)
       click_on I18n.t("buttons.update_job")
 
-      expect(page.current_path).to eql(organisation_job_review_path(vacancy.id))
+      expect(page.current_path).to eq(organisation_job_review_path(vacancy.id))
       expect(page).to have_content(I18n.t("school_groups.job_location_heading.at_one_school"))
       expect(page).to have_content(full_address(school_2))
-      expect(Vacancy.find(vacancy.id).readable_job_location).to eql(school_2.name)
+      expect(Vacancy.find(vacancy.id).readable_job_location).to eq(school_2.name)
 
       change_job_location(vacancy, "at_multiple_schools")
 
-      expect(page.current_path).to eql(organisation_job_build_path(vacancy.id, :schools))
+      expect(page.current_path).to eq(organisation_job_build_path(vacancy.id, :schools))
       check school_1.name, name: "schools_form[organisation_ids][]", visible: false
       check school_2.name, name: "schools_form[organisation_ids][]", visible: false
       click_on I18n.t("buttons.update_job")
 
-      expect(page.current_path).to eql(organisation_job_review_path(vacancy.id))
+      expect(page.current_path).to eq(organisation_job_review_path(vacancy.id))
       expect(page).to have_content(I18n.t("school_groups.job_location_heading.at_multiple_schools",
                                           organisation_type: "trust"))
-      expect(Vacancy.find(vacancy.id).readable_job_location).to eql("More than one school (2)")
+      expect(Vacancy.find(vacancy.id).readable_job_location).to eq("More than one school (2)")
 
       change_job_location(vacancy, "central_office")
 
-      expect(page.current_path).to eql(organisation_job_review_path(vacancy.id))
+      expect(page.current_path).to eq(organisation_job_review_path(vacancy.id))
       expect(page).to have_content(I18n.t("school_groups.job_location_heading.central_office"))
       expect(page).to have_content(full_address(school_group))
-      expect(Vacancy.find(vacancy.id).readable_job_location).to eql(
+      expect(Vacancy.find(vacancy.id).readable_job_location).to eq(
         I18n.t("publishers.organisations.readable_job_location.central_office"),
       )
     end

--- a/spec/system/hiring_staff_can_edit_a_draft_vacancy_as_a_school_spec.rb
+++ b/spec/system/hiring_staff_can_edit_a_draft_vacancy_as_a_school_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe "Hiring staff can edit a draft vacancy" do
     scenario "vacancy state is edit" do
       visit organisation_job_review_path(vacancy.id, edit_draft: true)
 
-      expect(Vacancy.last.state).to eql("edit")
+      expect(Vacancy.last.state).to eq("edit")
       within("h2.govuk-heading-l") do
         expect(page).to have_content(I18n.t("jobs.review_heading"))
       end
@@ -249,7 +249,7 @@ RSpec.describe "Hiring staff can edit a draft vacancy" do
         expect(page).to have_content(I18n.t("buttons.cancel_and_return"))
 
         click_on I18n.t("buttons.cancel_and_return")
-        expect(page.current_path).to eql(organisation_job_review_path(vacancy.id))
+        expect(page.current_path).to eq(organisation_job_review_path(vacancy.id))
       end
     end
   end

--- a/spec/system/hiring_staff_can_edit_a_published_vacancy_as_a_school_group_spec.rb
+++ b/spec/system/hiring_staff_can_edit_a_published_vacancy_as_a_school_group_spec.rb
@@ -20,50 +20,50 @@ RSpec.describe "Editing a published vacancy" do
 
       expect(page).to have_content(I18n.t("school_groups.job_location_heading.central_office"))
       expect(page).to have_content(full_address(school_group))
-      expect(Vacancy.find(vacancy.id).readable_job_location).to eql(
+      expect(Vacancy.find(vacancy.id).readable_job_location).to eq(
         I18n.t("publishers.organisations.readable_job_location.central_office"),
       )
 
       change_job_location(vacancy, "at_one_school")
 
-      expect(page.current_path).to eql(organisation_job_build_path(vacancy.id, :schools))
+      expect(page.current_path).to eq(organisation_job_build_path(vacancy.id, :schools))
       fill_in_school_form_field(school_1)
       click_on I18n.t("buttons.update_job")
 
-      expect(page.current_path).to eql(edit_organisation_job_path(vacancy.id))
+      expect(page.current_path).to eq(edit_organisation_job_path(vacancy.id))
       expect(page).to have_content(I18n.t("school_groups.job_location_heading.at_one_school"))
       expect(page).to have_content(full_address(school_1))
-      expect(Vacancy.find(vacancy.id).readable_job_location).to eql(school_1.name)
+      expect(Vacancy.find(vacancy.id).readable_job_location).to eq(school_1.name)
 
       change_job_location(vacancy, "at_one_school")
 
-      expect(page.current_path).to eql(organisation_job_build_path(vacancy.id, :schools))
+      expect(page.current_path).to eq(organisation_job_build_path(vacancy.id, :schools))
       fill_in_school_form_field(school_2)
       click_on I18n.t("buttons.update_job")
 
-      expect(page.current_path).to eql(edit_organisation_job_path(vacancy.id))
+      expect(page.current_path).to eq(edit_organisation_job_path(vacancy.id))
       expect(page).to have_content(I18n.t("school_groups.job_location_heading.at_one_school"))
       expect(page).to have_content(full_address(school_2))
-      expect(Vacancy.find(vacancy.id).readable_job_location).to eql(school_2.name)
+      expect(Vacancy.find(vacancy.id).readable_job_location).to eq(school_2.name)
 
       change_job_location(vacancy, "at_multiple_schools")
 
-      expect(page.current_path).to eql(organisation_job_build_path(vacancy.id, :schools))
+      expect(page.current_path).to eq(organisation_job_build_path(vacancy.id, :schools))
       check school_1.name, name: "schools_form[organisation_ids][]", visible: false
       check school_2.name, name: "schools_form[organisation_ids][]", visible: false
       click_on I18n.t("buttons.update_job")
 
-      expect(page.current_path).to eql(edit_organisation_job_path(vacancy.id))
+      expect(page.current_path).to eq(edit_organisation_job_path(vacancy.id))
       expect(page).to have_content(I18n.t("school_groups.job_location_heading.at_multiple_schools",
                                           organisation_type: "trust"))
-      expect(Vacancy.find(vacancy.id).readable_job_location).to eql("More than one school (2)")
+      expect(Vacancy.find(vacancy.id).readable_job_location).to eq("More than one school (2)")
 
       change_job_location(vacancy, "central_office")
 
-      expect(page.current_path).to eql(edit_organisation_job_path(vacancy.id))
+      expect(page.current_path).to eq(edit_organisation_job_path(vacancy.id))
       expect(page).to have_content(I18n.t("school_groups.job_location_heading.central_office"))
       expect(page).to have_content(full_address(school_group))
-      expect(Vacancy.find(vacancy.id).readable_job_location).to eql(
+      expect(Vacancy.find(vacancy.id).readable_job_location).to eq(
         I18n.t("publishers.organisations.readable_job_location.central_office"),
       )
     end
@@ -74,7 +74,7 @@ RSpec.describe "Editing a published vacancy" do
 
         expect(page).to have_content(I18n.t("school_groups.job_location_heading.central_office"))
         expect(page).to have_content(full_address(school_group))
-        expect(Vacancy.find(vacancy.id).readable_job_location).to eql(
+        expect(Vacancy.find(vacancy.id).readable_job_location).to eq(
           I18n.t("publishers.organisations.readable_job_location.central_office"),
         )
 
@@ -82,22 +82,22 @@ RSpec.describe "Editing a published vacancy" do
 
         click_on I18n.t("buttons.cancel_and_return")
 
-        expect(page.current_path).to eql(edit_organisation_job_path(vacancy.id))
+        expect(page.current_path).to eq(edit_organisation_job_path(vacancy.id))
         expect(page).to have_content(I18n.t("school_groups.job_location_heading.central_office"))
         expect(page).to have_content(full_address(school_group))
-        expect(Vacancy.find(vacancy.id).readable_job_location).to eql(
+        expect(Vacancy.find(vacancy.id).readable_job_location).to eq(
           I18n.t("publishers.organisations.readable_job_location.central_office"),
         )
 
         change_job_location(vacancy, "at_one_school")
-        expect(page.current_path).to eql(organisation_job_build_path(vacancy.id, :schools))
+        expect(page.current_path).to eq(organisation_job_build_path(vacancy.id, :schools))
         fill_in_school_form_field(school_2)
         click_on I18n.t("buttons.update_job")
 
-        expect(page.current_path).to eql(edit_organisation_job_path(vacancy.id))
+        expect(page.current_path).to eq(edit_organisation_job_path(vacancy.id))
         expect(page).to have_content(I18n.t("school_groups.job_location_heading.at_one_school"))
         expect(page).to have_content(full_address(school_2))
-        expect(Vacancy.find(vacancy.id).readable_job_location).to eql(school_2.name)
+        expect(Vacancy.find(vacancy.id).readable_job_location).to eq(school_2.name)
       end
     end
   end

--- a/spec/system/hiring_staff_can_edit_a_published_vacancy_as_a_school_spec.rb
+++ b/spec/system/hiring_staff_can_edit_a_published_vacancy_as_a_school_spec.rb
@@ -60,10 +60,10 @@ RSpec.describe "Hiring staff can edit a vacancy" do
 
     scenario "vacancy state is edit_published" do
       visit edit_organisation_job_path(vacancy.id)
-      expect(Vacancy.last.state).to eql("edit_published")
+      expect(Vacancy.last.state).to eq("edit_published")
 
       click_header_link(I18n.t("jobs.job_details"))
-      expect(Vacancy.last.state).to eql("edit_published")
+      expect(Vacancy.last.state).to eq("edit_published")
     end
 
     scenario "create a job sidebar is not present" do
@@ -80,7 +80,7 @@ RSpec.describe "Hiring staff can edit a vacancy" do
         expect(page).to have_content(I18n.t("buttons.cancel_and_return"))
 
         click_on I18n.t("buttons.cancel_and_return")
-        expect(page.current_path).to eql(edit_organisation_job_path(vacancy.id))
+        expect(page.current_path).to eq(edit_organisation_job_path(vacancy.id))
       end
     end
 

--- a/spec/system/hiring_staff_can_edit_school_details_spec.rb
+++ b/spec/system/hiring_staff_can_edit_school_details_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Editing a School’s details" do
     expect(page).to have_content(school.url)
 
     click_on "Change school description"
-    expect(find_field("organisation_form[website]").value).to eql(school.url)
+    expect(find_field("organisation_form[website]").value).to eq(school.url)
     fill_in "organisation_form[description]", with: "Our school prides itself on excellence."
     fill_in "organisation_form[website]", with: "https://www.this-is-a-test-url.tvs"
     click_on I18n.t("buttons.save_changes")
@@ -24,6 +24,6 @@ RSpec.describe "Editing a School’s details" do
     expect(page).to have_content("Our school prides itself on excellence.")
     expect(page).to have_content("https://www.this-is-a-test-url.tvs")
     expect(page).to have_content("Details updated for #{school.name}")
-    expect(page.current_path).to eql(organisation_path)
+    expect(page.current_path).to eq(organisation_path)
   end
 end

--- a/spec/system/hiring_staff_can_manage_schools_in_school_group_spec.rb
+++ b/spec/system/hiring_staff_can_manage_schools_in_school_group_spec.rb
@@ -23,7 +23,7 @@ RSpec.shared_examples "a successful edit" do
     expect(page).to have_content("New description of the trust")
     expect(page).to have_content("Details updated for #{school_group.name}")
     expect(page).to have_content("https://www.this-is-a-test-url.tvs")
-    expect(page.current_path).to eql(organisation_schools_path)
+    expect(page.current_path).to eq(organisation_schools_path)
 
     visit edit_organisation_school_path(school_1)
 
@@ -34,7 +34,7 @@ RSpec.shared_examples "a successful edit" do
     expect(page).to have_content("New description of the school")
     expect(page).to have_content("https://www.this-is-a-test-url.tvs")
     expect(page).to have_content("Details updated for #{school_1.name}")
-    expect(page.current_path).to eql(organisation_schools_path)
+    expect(page.current_path).to eq(organisation_schools_path)
   end
 end
 

--- a/spec/system/hiring_staff_can_publish_a_vacancy_as_a_school_spec.rb
+++ b/spec/system/hiring_staff_can_publish_a_vacancy_as_a_school_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe "Creating a vacancy" do
         fill_in_job_details_form_fields(vacancy)
         click_on I18n.t("buttons.continue")
 
-        expect(Vacancy.last.state).to eql("create")
+        expect(Vacancy.last.state).to eq("create")
       end
     end
 
@@ -612,7 +612,7 @@ RSpec.describe "Creating a vacancy" do
           fill_in_job_summary_form_fields(vacancy)
           click_on I18n.t("buttons.continue")
 
-          expect(Vacancy.last.state).to eql("review")
+          expect(Vacancy.last.state).to eq("review")
           expect(page).to have_content(I18n.t("jobs.current_step", step: 7, total: 7))
           within("h2.govuk-heading-l") do
             expect(page).to have_content(I18n.t("jobs.review_heading"))
@@ -641,7 +641,7 @@ RSpec.describe "Creating a vacancy" do
           fill_in_job_summary_form_fields(vacancy)
           click_on I18n.t("buttons.continue")
 
-          expect(Vacancy.last.state).to eql("review")
+          expect(Vacancy.last.state).to eq("review")
           expect(page).to have_content(I18n.t("jobs.current_step", step: 7, total: 7))
           within("h2.govuk-heading-l") do
             expect(page).to have_content(I18n.t("jobs.review_heading"))
@@ -652,17 +652,17 @@ RSpec.describe "Creating a vacancy" do
           within("h2.govuk-heading-l") do
             expect(page).to have_content(I18n.t("jobs.applying_for_the_job"))
           end
-          expect(Vacancy.last.state).to eql("review")
+          expect(Vacancy.last.state).to eq("review")
 
           click_on I18n.t("buttons.update_job")
-          expect(Vacancy.last.state).to eql("review")
+          expect(Vacancy.last.state).to eq("review")
 
           click_header_link(I18n.t("jobs.job_details"))
           expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 7))
           within("h2.govuk-heading-l") do
             expect(page).to have_content(I18n.t("jobs.job_details"))
           end
-          expect(Vacancy.last.state).to eql("review")
+          expect(Vacancy.last.state).to eq("review")
         end
       end
 
@@ -958,9 +958,9 @@ RSpec.describe "Creating a vacancy" do
           expect(page).to have_content(I18n.t("jobs.important_dates"))
         end
 
-        expect(find_field("important_dates_form[expires_on(3i)]").value).to eql(yesterday_date.day.to_s)
-        expect(find_field("important_dates_form[expires_on(2i)]").value).to eql(yesterday_date.month.to_s)
-        expect(find_field("important_dates_form[expires_on(1i)]").value).to eql(yesterday_date.year.to_s)
+        expect(find_field("important_dates_form[expires_on(3i)]").value).to eq(yesterday_date.day.to_s)
+        expect(find_field("important_dates_form[expires_on(2i)]").value).to eq(yesterday_date.month.to_s)
+        expect(find_field("important_dates_form[expires_on(1i)]").value).to eq(yesterday_date.year.to_s)
 
         click_on I18n.t("buttons.continue")
 

--- a/spec/system/hiring_staff_can_save_and_return_later_spec.rb
+++ b/spec/system/hiring_staff_can_save_and_return_later_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Hiring staff can save and return later" do
         visit organisation_path
         click_on I18n.t("buttons.create_job")
 
-        expect(page.current_path).to eql(organisation_job_build_path(Vacancy.last.id, :job_details))
+        expect(page.current_path).to eq(organisation_job_build_path(Vacancy.last.id, :job_details))
         expect(page).to have_content(I18n.t("jobs.create_a_job_title_no_org"))
         expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 7))
         within("h2.govuk-heading-l") do
@@ -26,13 +26,13 @@ RSpec.describe "Hiring staff can save and return later" do
         click_on I18n.t("buttons.save_and_return_later")
         created_vacancy = Vacancy.find_by(job_title: @vacancy.job_title)
 
-        expect(page.current_path).to eql(jobs_with_type_organisation_path("draft"))
+        expect(page.current_path).to eq(jobs_with_type_organisation_path("draft"))
         expect(page.body).to include(I18n.t("messages.jobs.draft_saved_html", job_title: @vacancy.job_title))
 
         click_on "Edit"
 
-        expect(page.current_path).to eql(organisation_job_build_path(created_vacancy.id, :job_details))
-        expect(find_field("job_details_form[job_title]").value).to eql(@vacancy.job_title)
+        expect(page.current_path).to eq(organisation_job_build_path(created_vacancy.id, :job_details))
+        expect(find_field("job_details_form[job_title]").value).to eq(@vacancy.job_title)
       end
     end
 
@@ -45,18 +45,18 @@ RSpec.describe "Hiring staff can save and return later" do
         click_on I18n.t("buttons.continue")
         created_vacancy = Vacancy.find_by(job_title: @vacancy.job_title)
 
-        expect(page.current_path).to eql(organisation_job_build_path(created_vacancy.id, :pay_package))
+        expect(page.current_path).to eq(organisation_job_build_path(created_vacancy.id, :pay_package))
 
         fill_in "pay_package_form[benefits]", with: @vacancy.benefits
         click_on I18n.t("buttons.save_and_return_later")
 
-        expect(page.current_path).to eql(jobs_with_type_organisation_path("draft"))
+        expect(page.current_path).to eq(jobs_with_type_organisation_path("draft"))
         expect(page.body).to include(I18n.t("messages.jobs.draft_saved_html", job_title: @vacancy.job_title))
 
         click_on "Edit"
 
-        expect(page.current_path).to eql(organisation_job_build_path(created_vacancy.id, :pay_package))
-        expect(find_field("pay_package_form[benefits]").value).to eql(@vacancy.benefits)
+        expect(page.current_path).to eq(organisation_job_build_path(created_vacancy.id, :pay_package))
+        expect(find_field("pay_package_form[benefits]").value).to eq(@vacancy.benefits)
       end
     end
 
@@ -72,22 +72,22 @@ RSpec.describe "Hiring staff can save and return later" do
         fill_in_pay_package_form_fields(@vacancy)
         click_on I18n.t("buttons.continue")
 
-        expect(page.current_path).to eql(organisation_job_build_path(created_vacancy.id, :important_dates))
+        expect(page.current_path).to eq(organisation_job_build_path(created_vacancy.id, :important_dates))
 
         fill_in "important_dates_form[publish_on(3i)]", with: "12"
         fill_in "important_dates_form[publish_on(2i)]", with: "01"
         fill_in "important_dates_form[publish_on(1i)]", with: "2010"
         click_on I18n.t("buttons.save_and_return_later")
 
-        expect(page.current_path).to eql(jobs_with_type_organisation_path("draft"))
+        expect(page.current_path).to eq(jobs_with_type_organisation_path("draft"))
         expect(page.body).to include(I18n.t("messages.jobs.draft_saved_html", job_title: @vacancy.job_title))
 
         click_on "Edit"
 
-        expect(page.current_path).to eql(organisation_job_build_path(created_vacancy.id, :important_dates))
-        expect(find_field("important_dates_form[publish_on(3i)]").value).to eql("12")
-        expect(find_field("important_dates_form[publish_on(2i)]").value).to eql("1")
-        expect(find_field("important_dates_form[publish_on(1i)]").value).to eql("2010")
+        expect(page.current_path).to eq(organisation_job_build_path(created_vacancy.id, :important_dates))
+        expect(find_field("important_dates_form[publish_on(3i)]").value).to eq("12")
+        expect(find_field("important_dates_form[publish_on(2i)]").value).to eq("1")
+        expect(find_field("important_dates_form[publish_on(1i)]").value).to eq("2010")
       end
 
       scenario "redirected to important_dates if not valid" do
@@ -101,7 +101,7 @@ RSpec.describe "Hiring staff can save and return later" do
         fill_in_pay_package_form_fields(@vacancy)
         click_on I18n.t("buttons.continue")
 
-        expect(page.current_path).to eql(organisation_job_build_path(created_vacancy.id, :important_dates))
+        expect(page.current_path).to eq(organisation_job_build_path(created_vacancy.id, :important_dates))
 
         fill_in_important_dates_fields(@vacancy)
         fill_in "important_dates_form[publish_on(3i)]", with: "12"
@@ -109,15 +109,15 @@ RSpec.describe "Hiring staff can save and return later" do
         fill_in "important_dates_form[publish_on(1i)]", with: "2010"
         click_on I18n.t("buttons.save_and_return_later")
 
-        expect(page.current_path).to eql(jobs_with_type_organisation_path("draft"))
+        expect(page.current_path).to eq(jobs_with_type_organisation_path("draft"))
         expect(page.body).to include(I18n.t("messages.jobs.draft_saved_html", job_title: @vacancy.job_title))
 
         click_on "Edit"
 
-        expect(page.current_path).to eql(organisation_job_build_path(created_vacancy.id, :important_dates))
-        expect(find_field("important_dates_form[publish_on(3i)]").value).to eql("12")
-        expect(find_field("important_dates_form[publish_on(2i)]").value).to eql("1")
-        expect(find_field("important_dates_form[publish_on(1i)]").value).to eql("2010")
+        expect(page.current_path).to eq(organisation_job_build_path(created_vacancy.id, :important_dates))
+        expect(find_field("important_dates_form[publish_on(3i)]").value).to eq("12")
+        expect(find_field("important_dates_form[publish_on(2i)]").value).to eq("1")
+        expect(find_field("important_dates_form[publish_on(1i)]").value).to eq("2010")
       end
     end
 
@@ -136,18 +136,18 @@ RSpec.describe "Hiring staff can save and return later" do
         fill_in_important_dates_fields(@vacancy)
         click_on I18n.t("buttons.continue")
 
-        expect(page.current_path).to eql(organisation_job_build_path(created_vacancy.id, :supporting_documents))
+        expect(page.current_path).to eq(organisation_job_build_path(created_vacancy.id, :supporting_documents))
 
         click_on I18n.t("buttons.save_and_return_later")
 
-        expect(page.current_path).to eql(jobs_with_type_organisation_path("draft"))
+        expect(page.current_path).to eq(jobs_with_type_organisation_path("draft"))
         expect(page.body).to include(I18n.t("messages.jobs.draft_saved_html", job_title: @vacancy.job_title))
 
         click_on "Edit"
 
-        expect(page.current_path).to eql(organisation_job_build_path(created_vacancy.id, :supporting_documents))
-        expect(find_field("supporting-documents-form-supporting-documents-yes-field").checked?).to eql(false)
-        expect(find_field("supporting-documents-form-supporting-documents-no-field").checked?).to eql(false)
+        expect(page.current_path).to eq(organisation_job_build_path(created_vacancy.id, :supporting_documents))
+        expect(find_field("supporting-documents-form-supporting-documents-yes-field").checked?).to eq(false)
+        expect(find_field("supporting-documents-form-supporting-documents-no-field").checked?).to eq(false)
       end
     end
 
@@ -169,18 +169,18 @@ RSpec.describe "Hiring staff can save and return later" do
         select_no_for_supporting_documents
         click_on I18n.t("buttons.continue")
 
-        expect(page.current_path).to eql(organisation_job_build_path(created_vacancy.id, :applying_for_the_job))
+        expect(page.current_path).to eq(organisation_job_build_path(created_vacancy.id, :applying_for_the_job))
 
         fill_in "applying_for_the_job_form[application_link]", with: "some link"
         click_on I18n.t("buttons.save_and_return_later")
 
-        expect(page.current_path).to eql(jobs_with_type_organisation_path("draft"))
+        expect(page.current_path).to eq(jobs_with_type_organisation_path("draft"))
         expect(page.body).to include(I18n.t("messages.jobs.draft_saved_html", job_title: @vacancy.job_title))
 
         click_on "Edit"
 
-        expect(page.current_path).to eql(organisation_job_build_path(created_vacancy.id, :applying_for_the_job))
-        expect(find_field("applying_for_the_job_form[application_link]").value).to eql("some link")
+        expect(page.current_path).to eq(organisation_job_build_path(created_vacancy.id, :applying_for_the_job))
+        expect(find_field("applying_for_the_job_form[application_link]").value).to eq("some link")
       end
     end
 
@@ -205,20 +205,20 @@ RSpec.describe "Hiring staff can save and return later" do
         fill_in_applying_for_the_job_form_fields(@vacancy)
         click_on I18n.t("buttons.continue")
 
-        expect(page.current_path).to eql(organisation_job_build_path(created_vacancy.id, :job_summary))
+        expect(page.current_path).to eq(organisation_job_build_path(created_vacancy.id, :job_summary))
 
         fill_in "job_summary_form[job_summary]", with: ""
         fill_in "job_summary_form[about_school]", with: @vacancy.about_school
         click_on I18n.t("buttons.save_and_return_later")
 
-        expect(page.current_path).to eql(jobs_with_type_organisation_path("draft"))
+        expect(page.current_path).to eq(jobs_with_type_organisation_path("draft"))
         expect(page.body).to include(I18n.t("messages.jobs.draft_saved_html", job_title: @vacancy.job_title))
 
         click_on "Edit"
 
-        expect(page.current_path).to eql(organisation_job_build_path(created_vacancy.id, :job_summary))
-        expect(find_field("job_summary_form[job_summary]").value).to eql("")
-        expect(find_field("job_summary_form[about_school]").value).to eql(@vacancy.about_school)
+        expect(page.current_path).to eq(organisation_job_build_path(created_vacancy.id, :job_summary))
+        expect(find_field("job_summary_form[job_summary]").value).to eq("")
+        expect(find_field("job_summary_form[about_school]").value).to eq(@vacancy.about_school)
       end
     end
   end

--- a/spec/system/hiring_staff_can_set_managed_organisations_user_preferences_spec.rb
+++ b/spec/system/hiring_staff_can_set_managed_organisations_user_preferences_spec.rb
@@ -36,13 +36,13 @@ RSpec.describe "Hiring staff can set managed organisations user preferences" do
 
     scenario "it shows the trust head office option" do
       visit organisation_managed_organisations_path
-      expect(page.current_path).to eql(organisation_managed_organisations_path)
+      expect(page.current_path).to eq(organisation_managed_organisations_path)
       expect(page).to have_content(I18n.t("publishers.organisations.managed_organisations.show.options.school_group"))
     end
 
     scenario "it does not show closed school option" do
       visit organisation_managed_organisations_path
-      expect(page.current_path).to eql(organisation_managed_organisations_path)
+      expect(page.current_path).to eq(organisation_managed_organisations_path)
       expect(page).not_to have_content(school_3.name)
     end
 
@@ -59,8 +59,8 @@ RSpec.describe "Hiring staff can set managed organisations user preferences" do
 
       click_on I18n.t("buttons.continue")
 
-      expect(page.current_path).to eql(organisation_path)
-      expect(publisher_preference.managed_school_ids).to eql([school_group.id, school_1.id])
+      expect(page.current_path).to eq(organisation_path)
+      expect(publisher_preference.managed_school_ids).to eq([school_group.id, school_1.id])
     end
 
     scenario "it allows school group users to select to manage all jobs" do
@@ -76,9 +76,9 @@ RSpec.describe "Hiring staff can set managed organisations user preferences" do
 
       click_on I18n.t("buttons.continue")
 
-      expect(page.current_path).to eql(organisation_path)
-      expect(publisher_preference.managed_organisations).to eql("all")
-      expect(publisher_preference.managed_school_ids).to eql([])
+      expect(page.current_path).to eq(organisation_path)
+      expect(publisher_preference.managed_organisations).to eq("all")
+      expect(publisher_preference.managed_school_ids).to eq([])
     end
   end
 
@@ -87,7 +87,7 @@ RSpec.describe "Hiring staff can set managed organisations user preferences" do
 
     scenario "it does not show the trust head office option" do
       visit organisation_managed_organisations_path
-      expect(page.current_path).to eql(organisation_managed_organisations_path)
+      expect(page.current_path).to eq(organisation_managed_organisations_path)
       expect(page).not_to have_content(
         I18n.t("publishers.organisations.managed_organisations.show.options.school_group"),
       )

--- a/spec/system/hiring_staff_can_sign_in_with_dfe_spec.rb
+++ b/spec/system/hiring_staff_can_sign_in_with_dfe_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe "Hiring staff signing-in with DfE Sign In" do
     scenario "it redirects the sign in page to the school page" do
       visit new_identifications_path
       expect(page).to have_content("Jobs at #{organisation.name}")
-      expect(current_path).to eql(organisation_path)
+      expect(current_path).to eq(organisation_path)
     end
 
     context "the user can switch between organisations" do
@@ -148,7 +148,7 @@ RSpec.describe "Hiring staff signing-in with DfE Sign In" do
       let(:school_group) { create(:trust, uid: "14323") }
 
       it "associates the user with the trust instead of the school" do
-        expect(current_path).to eql(organisation_managed_organisations_path)
+        expect(current_path).to eq(organisation_managed_organisations_path)
       end
 
       it "shows the trust name" do
@@ -160,7 +160,7 @@ RSpec.describe "Hiring staff signing-in with DfE Sign In" do
       let(:school_group) { create(:local_authority, local_authority_code: "323") }
 
       it "associates the user with the local_authority instead of the school" do
-        expect(current_path).to eql(organisation_managed_organisations_path)
+        expect(current_path).to eq(organisation_managed_organisations_path)
       end
 
       it "shows the local_authority name" do
@@ -190,7 +190,7 @@ RSpec.describe "Hiring staff signing-in with DfE Sign In" do
       scenario "it redirects the sign in page to the SchoolGroup page" do
         visit new_identifications_path
         expect(page).to have_content("Jobs at #{organisation.name}")
-        expect(current_path).to eql(organisation_path)
+        expect(current_path).to eq(organisation_path)
       end
     end
 
@@ -198,7 +198,7 @@ RSpec.describe "Hiring staff signing-in with DfE Sign In" do
       let(:publisher_preference) { nil }
 
       scenario "it redirects the sign in page to the managed organisations user preference page" do
-        expect(current_path).to eql(organisation_managed_organisations_path)
+        expect(current_path).to eq(organisation_managed_organisations_path)
       end
     end
 
@@ -234,7 +234,7 @@ RSpec.describe "Hiring staff signing-in with DfE Sign In" do
         scenario "it redirects the sign in page to the SchoolGroup page" do
           visit new_identifications_path
           expect(page).to have_content("Jobs in #{organisation.name}")
-          expect(current_path).to eql(organisation_path)
+          expect(current_path).to eq(organisation_path)
         end
       end
 
@@ -242,7 +242,7 @@ RSpec.describe "Hiring staff signing-in with DfE Sign In" do
         let(:publisher_preference) { nil }
 
         scenario "it redirects the sign in page to the managed organisations user preference page" do
-          expect(current_path).to eql(organisation_managed_organisations_path)
+          expect(current_path).to eq(organisation_managed_organisations_path)
         end
       end
 

--- a/spec/system/jobseekers_can_change_email_spec.rb
+++ b/spec/system/jobseekers_can_change_email_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Jobseekers can change email" do
       expect(delivered_emails.first.to.first).to eq(jobseeker.email)
       expect(delivered_emails.second.subject).to eq(I18n.t("jobseeker_mailer.confirmation_instructions.reconfirmation.subject"))
       expect(delivered_emails.second.to.first).to eq("new@email.com")
-      expect(current_path).to eql(jobseekers_check_your_email_path)
+      expect(current_path).to eq(jobseekers_check_your_email_path)
     end
   end
 

--- a/spec/system/jobseekers_can_manage_their_subscription_spec.rb
+++ b/spec/system/jobseekers_can_manage_their_subscription_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "A jobseeker can manage a subscription" do
         subscription.reload
         expect(subscription.email).to eq("jimi@hendrix.com")
         expect(subscription.frequency).to eq("weekly")
-        expect(JSON.parse(subscription.search_criteria).symbolize_keys[:keyword]).to eql("English")
+        expect(JSON.parse(subscription.search_criteria).symbolize_keys[:keyword]).to eq("English")
       end
     end
 
@@ -59,8 +59,8 @@ RSpec.describe "A jobseeker can manage a subscription" do
         subscription.reload
         expect(subscription.email).to eq("bob@dylan.com")
         expect(subscription.frequency).to eq("daily")
-        expect(JSON.parse(subscription.search_criteria).symbolize_keys[:keyword]).to eql("Math")
-        expect(JSON.parse(subscription.search_criteria).symbolize_keys[:location]).to eql("London")
+        expect(JSON.parse(subscription.search_criteria).symbolize_keys[:keyword]).to eq("Math")
+        expect(JSON.parse(subscription.search_criteria).symbolize_keys[:location]).to eq("London")
       end
     end
   end

--- a/spec/system/jobseekers_can_save_a_job_spec.rb
+++ b/spec/system/jobseekers_can_save_a_job_spec.rb
@@ -86,14 +86,14 @@ RSpec.describe "Jobseekers can save a job" do
   end
 
   def and_the_job_is_saved
-    expect(current_path).to eql(job_path(vacancy))
+    expect(current_path).to eq(job_path(vacancy))
     expect(page).to have_content("You have saved this job. View all your saved jobs on your account")
     expect(page).to have_content(I18n.t("jobseekers.saved_jobs.saved"))
     expect(created_jobseeker.saved_jobs.pluck(:vacancy_id)).to include(vacancy.id)
   end
 
   def and_the_job_is_unsaved
-    expect(current_path).to eql(job_path(vacancy))
+    expect(current_path).to eq(job_path(vacancy))
     expect(page).to have_content(I18n.t("jobseekers.saved_jobs.save"))
     expect(created_jobseeker.saved_jobs.pluck(:vacancy_id)).not_to include(vacancy.id)
   end

--- a/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Jobseekers can sign up to an account" do
       click_on I18n.t("buttons.continue")
       expect(page).to have_content("There is a problem")
       expect { sign_up_jobseeker }.to change { delivered_emails.count }.by(1)
-      expect(current_path).to eql(jobseekers_check_your_email_path)
+      expect(current_path).to eq(jobseekers_check_your_email_path)
     end
   end
 
@@ -27,7 +27,7 @@ RSpec.describe "Jobseekers can sign up to an account" do
     context "when the confirmation token is valid" do
       it "confirms email and redirects to saved jobs page" do
         confirm_email_address
-        expect(current_path).to eql(jobseekers_saved_jobs_path)
+        expect(current_path).to eq(jobseekers_saved_jobs_path)
         expect(page).to have_content(I18n.t("devise.confirmations.confirmed"))
       end
     end
@@ -39,14 +39,14 @@ RSpec.describe "Jobseekers can sign up to an account" do
 
       it "does not confirm email and redirects to resend confirmation page" do
         confirm_email_address
-        expect(current_path).to eql(jobseeker_confirmation_path)
+        expect(current_path).to eq(jobseeker_confirmation_path)
         expect(page).to have_content(I18n.t("jobseekers.confirmations.new.title"))
       end
 
       context "when the confirmation email is resent" do
         it "resends confirmation email and redirects to check your email page" do
           expect { resend_confirmation_email }.to change { delivered_emails.count }.by(1)
-          expect(current_path).to eql(jobseekers_check_your_email_path)
+          expect(current_path).to eq(jobseekers_check_your_email_path)
         end
       end
     end

--- a/spec/system/jobseekers_can_unsubscribe_from_subscriptions_spec.rb
+++ b/spec/system/jobseekers_can_unsubscribe_from_subscriptions_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "A jobseeker can unsubscribe from subscriptions" do
     end
 
     it "updates the subscription status" do
-      expect(subscription.reload.active).to eql(false)
+      expect(subscription.reload.active).to eq(false)
     end
 
     it "audits the unsubscription" do
@@ -55,7 +55,7 @@ RSpec.describe "A jobseeker can unsubscribe from subscriptions" do
       end
 
       it "updates the subscription status" do
-        expect(subscription.reload.active).to eql(false)
+        expect(subscription.reload.active).to eq(false)
       end
 
       it "audits the unsubscription" do

--- a/spec/system/jobseekers_can_view_a_vacancy_spec.rb
+++ b/spec/system/jobseekers_can_view_a_vacancy_spec.rb
@@ -84,9 +84,9 @@ RSpec.describe "Viewing a single published vacancy" do
       scenario "can click on the first link to create a job alert" do
         click_on I18n.t("jobs.alert.similar.terse")
         expect(page).to have_content(I18n.t("subscriptions.new.title"))
-        expect(page.find_field("subscription-form-keyword-field").value).to eql("Physics")
-        expect(page.find_field("subscription-form-location-field").value).to eql(school.postcode)
-        expect(page.find_field("subscription-form-radius-field").value).to eql("10")
+        expect(page.find_field("subscription-form-keyword-field").value).to eq("Physics")
+        expect(page.find_field("subscription-form-location-field").value).to eq(school.postcode)
+        expect(page.find_field("subscription-form-radius-field").value).to eq("10")
         click_on I18n.t("buttons.back")
         expect(page).to have_current_path(job_path(vacancy))
       end
@@ -94,9 +94,9 @@ RSpec.describe "Viewing a single published vacancy" do
       scenario "can click on the second link to create a job alert" do
         click_on I18n.t("jobs.alert.similar.verbose.link_text")
         expect(page).to have_content(I18n.t("subscriptions.new.title"))
-        expect(page.find_field("subscription-form-keyword-field").value).to eql("Physics")
-        expect(page.find_field("subscription-form-location-field").value).to eql(school.postcode)
-        expect(page.find_field("subscription-form-radius-field").value).to eql("10")
+        expect(page.find_field("subscription-form-keyword-field").value).to eq("Physics")
+        expect(page.find_field("subscription-form-location-field").value).to eq(school.postcode)
+        expect(page.find_field("subscription-form-radius-field").value).to eq("10")
         click_on I18n.t("buttons.back")
         expect(page).to have_current_path(job_path(vacancy))
       end


### PR DESCRIPTION
Change our equality matchers across the board to check value equality
rather than object identity.