### PR TITLE
[TEVA-1643] Conduct generic search when user searches nationwide

### DIFF
--- a/app/services/search/location_builder.rb
+++ b/app/services/search/location_builder.rb
@@ -2,6 +2,7 @@ require "geocoding"
 
 class Search::LocationBuilder
   DEFAULT_RADIUS = 10
+  NATIONWIDE_LOCATIONS = ["england", "uk", "united kingdom", "britain", "great britain"].freeze
 
   include DistanceHelper
 
@@ -19,7 +20,9 @@ class Search::LocationBuilder
                            location_category
                          end
 
-    if location_category_search?
+    if NATIONWIDE_LOCATIONS.include?(@location&.downcase)
+      initialize_nationwide_search
+    elsif location_category_search?
       initialize_location_polygon
     elsif @location.present?
       @location_filter = build_location_filter(@location, @radius)
@@ -62,5 +65,9 @@ private
       point_coordinates: Geocoding.new(location).coordinates,
       radius: convert_miles_to_metres(radius),
     }
+  end
+
+  def initialize_nationwide_search
+    @location = nil
   end
 end

--- a/spec/services/search/location_builder_spec.rb
+++ b/spec/services/search/location_builder_spec.rb
@@ -100,5 +100,16 @@ RSpec.describe Search::LocationBuilder do
         end
       end
     end
+
+    context "when a nationwide location is specified" do
+      let(:location) { Search::LocationBuilder::NATIONWIDE_LOCATIONS.sample }
+
+      it "does not set location filters" do
+        expect(subject.location).to be nil
+        expect(subject.location_category).to be nil
+        expect(subject.location_polygon).to be nil
+        expect(subject.location_filter).to eq({})
+      end
+    end
   end
 end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1643

## Changes in this PR:

- Added a check for terms users use/may use for nationwide searches. If the user does use one of these searches, a generic search is conducted, returning all vacancies.

## Questions:

- Not sure about the name of the method
- The coverage is at 90.2%. I checked the report but not too sure why the lines highlighted as not covered have been included. 
- I can see there's also a code smell: 'Merge this "unless" statement with the nested one.' I included the unless so that @location.downcase will not throw an error when @location is nil. I'm not too sure what to do here...

https://user-images.githubusercontent.com/30624173/103671982-8e2bca80-4f73-11eb-9322-ac1368081f47.mov

