### PR TITLE
TEVA-1763 Make GH Actions deploys less brittle

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -112,14 +112,14 @@ jobs:
       with:
         workflow: Smoke Test Manual # Workflow name
         token: ${{ secrets.PERSONAL_TOKEN }}
-        inputs: '{"environment": "staging"}'
+        inputs: '{"environment": "staging"}, "sha": "${{ github.sha }}"}'
 
     - name: Wait for smoke test
       id: wait_for_smoke_test
       uses: fountainhead/action-wait-for-check@v1.0.0
       with:
         token: ${{ secrets.PERSONAL_TOKEN }}
-        checkName: Smoke Test Manual Job # Job name within workflow
+        checkName: Smoke Test ${{ github.sha }} on staging # Job name within workflow
         ref: ${{ github.ref }}
         timeoutSeconds: 300
         intervalSeconds: 15

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,7 +101,7 @@ jobs:
       uses: fountainhead/action-wait-for-check@v1.0.0
       with:
         token: ${{ secrets.PERSONAL_TOKEN }}
-        checkName: Deploy app to environment # Job name within workflow
+        checkName: Deploy ${{ env.TAG }} to staging # Job name within workflow
         ref: ${{ github.ref }}
         timeoutSeconds: 300
         intervalSeconds: 15
@@ -137,7 +137,7 @@ jobs:
       uses: fountainhead/action-wait-for-check@v1.0.0
       with:
         token: ${{ secrets.PERSONAL_TOKEN }}
-        checkName: Deploy app to environment # Job name within workflow
+        checkName: Deploy ${{ env.TAG }} to production # Job name within workflow
         ref: ${{ github.ref }}
         timeoutSeconds: 300
         intervalSeconds: 15

--- a/.github/workflows/deploy_app.yml
+++ b/.github/workflows/deploy_app.yml
@@ -14,6 +14,17 @@ env:
  DOCKERHUB_REPOSITORY: dfedigital/teaching-vacancies
 
 jobs:
+  turnstyle:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 20
+    steps:
+    - uses: softprops/turnstyle@v1
+      name: Check workflow concurrency
+      with:
+        poll-interval-seconds: 20
+        same-branch-only: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   deploy-app:
     name: Deploy ${{ github.event.inputs.tag }} to ${{ github.event.inputs.environment }}
     runs-on: ubuntu-20.04

--- a/.github/workflows/deploy_app.yml
+++ b/.github/workflows/deploy_app.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   deploy-app:
-    name: Deploy app to environment
+    name: Deploy ${{ github.event.inputs.tag }} to ${{ github.event.inputs.environment }}
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -124,5 +124,5 @@ jobs:
         SLACK_CHANNEL: twd_tv_dev
         SLACK_USERNAME: CI Deployment
         SLACK_TITLE: Deployment ${{ job.status }}
-        SLACK_MESSAGE: 'Review app for https://github.com/DFE-Digital/teaching-vacancies/pull/2516/ deployed to https://teaching-vacancies-review-pr-${{ github.event.number }}.london.cloudapps.digital - ${{ job.status }}'
+        SLACK_MESSAGE: 'Review app for https://github.com/DFE-Digital/teaching-vacancies/pull/${{ github.event.number }}/ deployed to https://teaching-vacancies-review-pr-${{ github.event.number }}.london.cloudapps.digital - ${{ job.status }}'
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/smoke-test-manual.yml
+++ b/.github/workflows/smoke-test-manual.yml
@@ -7,10 +7,13 @@ on:
         description: 'Environment'
         required: true
         default: 'staging'
+      sha:
+        description: 'GitHub SHA'
+        required: true
 
 jobs:
   smoke-test-manual-job:
-    name: Smoke Test Manual Job
+    name: Smoke Test ${{ github.event.inputs.sha }} on ${{ github.event.inputs.environment }}
 
     runs-on: ubuntu-20.04
 
@@ -42,5 +45,5 @@ jobs:
           SLACK_USERNAME: Smoke Test
           SLACK_ICON_EMOJI: ':cry:'
           SLACK_TITLE: Smoke test failed
-          SLACK_MESSAGE: '${{ github.event.inputs.environment }} website smoke test has failed !channel'
+          SLACK_MESSAGE: 'Smoke Test ${{ github.event.inputs.sha }} on ${{ github.event.inputs.environment }} has failed !channel'
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1763

## Changes in this PR:

- Used Docker tag (which is GitHub SHA) to create unique GH Action job names to ensure the correct environment and SHA/tag are used for:
-- wait for check workflow action
-- smoke test for staging
- Added waiting with turnstyle action on the `deploy_app.yml` workflow to handle multiple merges in quick succession
- Fixed accidentally hard-coded PR number in Slack Message on review app creation
