### PR TITLE
Use govuk_button_to to avoid js disabled bug when creating jobs

### DIFF
--- a/app/components/publishers/no_vacancies_component.html.slim
+++ b/app/components/publishers/no_vacancies_component.html.slim
@@ -3,7 +3,7 @@
     .govuk-grid-column-full
       h2.govuk-heading-m = t("schools.no_jobs.heading")
 
-      = link_to t("buttons.create_job"), organisation_jobs_path, method: :post, class: "govuk-button govuk-!-margin-bottom-0"
+      = govuk_button_to t("buttons.create_job"), organisation_jobs_path, class: "govuk-!-margin-bottom-0"
 
       p = t("schools.no_jobs.intro")
 

--- a/app/components/publishers/vacancies_component.html.slim
+++ b/app/components/publishers/vacancies_component.html.slim
@@ -14,7 +14,7 @@
           = t("buttons.hide_filters")
         span.govuk-body class="govuk-!-margin-left-3 filters-applied-text"
           = filters_applied_text
-      = link_to t("buttons.create_job"), organisation_jobs_path, method: :post, class: "govuk-button govuk-!-margin-bottom-0 govuk-!-margin-top-0 float-right"
+      = govuk_button_to t("buttons.create_job"), organisation_jobs_path, class: "govuk-!-margin-bottom-0 govuk-!-margin-top-0", form_class: "float-right"
   .moj-scrollable-pane.moj-scrollable-pane-shadow
     .moj-scrollable-pane__wrapper
       .govuk-tabs.desktop-container-width

--- a/app/views/publishers/organisations/show.html.slim
+++ b/app/views/publishers/organisations/show.html.slim
@@ -8,7 +8,7 @@
       - else
         = t("schools.jobs.index", organisation: @organisation.name)
     - if @organisation.is_a?(School) && @organisation.all_vacancies.active.any?
-      = link_to t("buttons.create_job"), organisation_jobs_path, method: :post, class: "govuk-button govuk-!-margin-bottom-0 govuk-!-margin-top-0 inline-block float-right"
+      = govuk_button_to t("buttons.create_job"), organisation_jobs_path, class: "govuk-!-margin-bottom-0 govuk-!-margin-top-0", form_class: "float-right"
   - if @multiple_organisations && @organisation.is_a?(School)
     .govuk-grid-column-full
       - if AuthenticationFallback.enabled?

--- a/spec/system/hiring_staff_can_preview_a_vacancy_spec.rb
+++ b/spec/system/hiring_staff_can_preview_a_vacancy_spec.rb
@@ -39,7 +39,6 @@ RSpec.describe "Hiring staff can preview a vacancy" do
       click_on I18n.t("buttons.back_to_manage_jobs")
       expect(page).to have_current_path(jobs_with_type_organisation_path("draft", from_review: vacancy.id))
       expect(page).to have_content(I18n.t("schools.jobs.index", organisation: school.name))
-      expect(page).to have_content(I18n.t("buttons.create_job"))
     end
   end
 

--- a/spec/system/hiring_staff_can_publish_a_vacancy_as_a_school_spec.rb
+++ b/spec/system/hiring_staff_can_publish_a_vacancy_as_a_school_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Creating a vacancy" do
     expect(page).to have_content(/#{school.address}/)
     expect(page).to have_content(/#{school.town}/)
 
-    click_link "Create a job listing"
+    click_on I18n.t("buttons.create_job")
 
     expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 7))
   end


### PR DESCRIPTION
~~So... linking to the same path as the current path with a post action obviously causes some problems when JS is disabled. This circumnavigates that scenario by using a new action instead of a create action (not very restful I know). This brought to my attention a similar issue with deleting jobs.~~

~~This fixes the first issue at hand now in the quickest way possible, however nobody has complained about this _yet_, so I'm going to take the liberty of spending a bit more time ironing this out for deleting jobs too - and also use a create action but just with a different route.~~

Forget all that nonsense, just use a lovely button in a form

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-1811

## Changes in this PR
- Use `govuk_button_to` for create a job links