### PR TITLE
Fix missing leading whitespace in job alert link text

### DIFF
--- a/app/components/jobseekers/search_results/job_alerts_link_component.html.slim
+++ b/app/components/jobseekers/search_results/job_alerts_link_component.html.slim
@@ -2,5 +2,4 @@
   .job-alert-cta__fade
   .job-alert-cta__content class="govuk-heading-s govuk-!-font-weight-regular govuk-!-margin-0" id="job-alert-cta"
     .icon.icon--left.icon--alert-white
-      = link_to t("subscriptions.link.text"), new_subscription_path(search_criteria: @vacancies_search.only_active_to_hash), id: "job-alert-link-sticky-gtm"
-      = t("subscriptions.link.help_text")
+      == t("subscriptions.link.help_text", link: link_to(t("subscriptions.link.text"), new_subscription_path(search_criteria: @vacancies_search.only_active_to_hash), id: "job-alert-link-sticky-gtm"))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -520,7 +520,7 @@ en:
     info: You can unsubscribe at any time by following the simple instructions at the bottom of the alert.
     intro: 'We’ll email you details of any new jobs that match the following criteria:'
     link:
-      help_text: whenever a job matching this search is listed
+      help_text: "%{link} whenever a job matching this search is listed"
       home_page: Visit %{home_page_link}
       no_search_results:
         link: get notified


### PR DESCRIPTION
## Screenshots of UI changes:

### Before
![Screenshot 2021-01-07 at 15 29 53](https://user-images.githubusercontent.com/7215/103910896-49339f80-50fd-11eb-96bb-7ec086a73d94.png)

### After
![Screenshot 2021-01-07 at 15 30 10](https://user-images.githubusercontent.com/7215/103910923-52247100-50fd-11eb-964e-f2d3b17ba02a.png)

