### PR TITLE
Use vanilla Rubocop instead of `rubocop-govuk`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,13 +1,122 @@
 require:
   - rubocop-performance
 
-inherit_gem:
-  rubocop-govuk:
-    - config/default.yml
-
-inherit_mode:
-  merge:
-    - Exclude
-
 AllCops:
   NewCops: enable
+  Exclude:
+    - "bin/**"
+    - "config.ru"
+    - "tmp/**/*"
+    - "db/schema.rb"
+    - "db/migrate/20*"
+    - "vendor/**/*"
+    - "node_modules/**/*"
+
+  DisplayCopNames:
+    Enabled: true
+
+  ExtraDetails:
+    Enabled: true
+
+  DisplayStyleGuide:
+    Enabled: true
+
+##
+# Team Style conventions
+
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent
+
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent
+
+Layout/LineLength:
+  Enabled: false
+
+Layout/MultilineMethodCallIndentation:
+  Enabled: false
+
+Style/BlockDelimiters:
+  EnforcedStyle: braces_for_chaining
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: never
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma
+
+##
+# Temporary rules
+# TODO: These have a lot of warnings, or relate to unfinished stylistic discussions within the team
+
+Layout/AccessModifierIndentation:
+  EnforcedStyle: outdent
+
+Lint/MissingSuper:
+  Enabled: false
+
+Naming/AccessorMethodName:
+  Enabled: false
+
+##
+# Tech Debt
+# TODO: `rubocop-govuk` previously had all these metrics disabled as they are "just heuristics".
+# They're not brilliant metrics, but they *can* point to some degree of accidental complexity.
+# We should consider slowly moving closer to the default settings.
+
+Metrics/AbcSize:
+  Max: 40
+  Exclude:
+    - "config/**/*"
+    - "lib/**/*"
+    - "spec/**/*"
+
+Metrics/BlockLength:
+  Max: 75
+  Exclude:
+    - "config/**/*"
+    - "spec/**/*"
+
+Metrics/ClassLength:
+  Max: 200
+
+Metrics/CyclomaticComplexity:
+  Max: 20
+  Exclude:
+    - "spec/**/*"
+
+Metrics/MethodLength:
+  Max: 25
+  Exclude:
+    - "config/**/*"
+    - "lib/**/*"
+    - "spec/**/*"
+
+Metrics/ModuleLength:
+  Max: 200
+
+Metrics/ParameterLists:
+  Max: 8
+
+Metrics/PerceivedComplexity:
+  Max: 20
+  Exclude:
+    - "spec/**/*"

--- a/Gemfile
+++ b/Gemfile
@@ -73,8 +73,9 @@ group :development, :test do
   gem "rails-controller-testing"
   gem "rspec-rails"
   gem "rspec-sonarqube-formatter", require: false
-  gem "rubocop-govuk"
   gem "rubocop-performance"
+  gem "rubocop-rails"
+  gem "rubocop-rspec"
   gem "slim_lint", require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,7 +291,7 @@ GEM
     orm_adapter (0.5.0)
     os (1.1.1)
     parallel (1.20.1)
-    parser (2.7.2.0)
+    parser (3.0.0.0)
       ast (~> 2.4.1)
     pg (1.2.3)
     pry (0.13.1)
@@ -405,23 +405,17 @@ GEM
       htmlentities (~> 4.3.3)
       rspec (~> 3.0)
     rspec-support (3.10.0)
-    rubocop (0.87.1)
+    rubocop (1.8.0)
       parallel (~> 1.10)
-      parser (>= 2.7.1.1)
+      parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.7)
+      regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 0.1.0, < 1.0)
+      rubocop-ast (>= 1.2.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.8.0)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.4.0)
       parser (>= 2.7.1.5)
-    rubocop-govuk (3.17.2)
-      rubocop (= 0.87.1)
-      rubocop-ast (= 0.8.0)
-      rubocop-rails (= 2.8.1)
-      rubocop-rake (= 0.5.1)
-      rubocop-rspec (= 1.42.0)
     rubocop-performance (1.8.1)
       rubocop (>= 0.87.0)
       rubocop-ast (>= 0.4.0)
@@ -429,11 +423,10 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 0.87.0)
-    rubocop-rake (0.5.1)
-      rubocop
-    rubocop-rspec (1.42.0)
-      rubocop (>= 0.87.0)
-    ruby-progressbar (1.10.1)
+    rubocop-rspec (2.1.0)
+      rubocop (~> 1.0)
+      rubocop-ast (>= 1.1.0)
+    ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.2)
     rubyzip (2.3.0)
     sanitize (5.2.1)
@@ -499,7 +492,7 @@ GEM
     tzinfo (1.2.8)
       thread_safe (~> 0.1)
     uber (0.1.0)
-    unicode-display_width (1.7.0)
+    unicode-display_width (2.0.0)
     uniform_notifier (1.13.0)
     validate_email (0.1.6)
       activemodel (>= 3.0)
@@ -598,8 +591,9 @@ DEPENDENCIES
   rollbar
   rspec-rails
   rspec-sonarqube-formatter
-  rubocop-govuk
   rubocop-performance
+  rubocop-rails
+  rubocop-rspec
   sanitize
   selenium-webdriver
   shoulda-matchers

--- a/app/components/publishers/vacancies_component.rb
+++ b/app/components/publishers/vacancies_component.rb
@@ -64,11 +64,12 @@ private
       count = Vacancy.in_organisation_ids(school.id).send(selected_scope).count
       OpenStruct.new({ id: school.id, name: school.name, label: "#{school.name} (#{count})" })
     end
+
+    return if @organisation.group_type == "local_authority"
+
     count = Vacancy.in_organisation_ids(@organisation.id).send(selected_scope).count
-    unless @organisation.group_type == "local_authority"
-      @organisation_options.unshift(
-        OpenStruct.new({ id: @organisation.id, name: "Trust head office", label: "Trust head office (#{count})" }),
-      )
-    end
+    @organisation_options.unshift(
+      OpenStruct.new({ id: @organisation.id, name: "Trust head office", label: "Trust head office (#{count})" }),
+    )
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -57,9 +57,9 @@ private
   end
 
   def redirect_to_canonical_domain
-    if request_host_is_invalid?
-      redirect_to status: 301, host: DOMAIN
-    end
+    return unless request_host_is_invalid?
+
+    redirect_to status: 301, host: DOMAIN
   end
 
   def request_host_is_invalid?
@@ -80,9 +80,10 @@ private
 
   def strip_nested_param_whitespaces(object)
     # Recursively find strings and strip them of trailing whitespaces
-    if object.is_a?(String)
+    case object
+    when String
       return object.strip
-    elsif object.is_a?(Hash)
+    when Hash
       object.each do |key, value|
         object[key] = strip_nested_param_whitespaces(value)
       end

--- a/app/controllers/concerns/parameter_sanitiser.rb
+++ b/app/controllers/concerns/parameter_sanitiser.rb
@@ -6,9 +6,10 @@ module ParameterSanitiser
   end
 
   def self.sanitize_params_value(value)
-    if value.is_a?(ActionController::Parameters)
+    case value
+    when ActionController::Parameters
       sanitize_nested_params(value)
-    elsif value.is_a?(Array)
+    when Array
       value.map { |v| Sanitize.fragment(v) }
     else
       Sanitize.fragment(value)

--- a/app/controllers/job_alert_feedbacks_controller.rb
+++ b/app/controllers/job_alert_feedbacks_controller.rb
@@ -8,10 +8,11 @@ class JobAlertFeedbacksController < ApplicationController
     @feedback = JobAlertFeedback.new(
       job_alert_feedback_params.merge(subscription: subscription),
     )
-    if @feedback.save
-      Auditor::Audit.new(@feedback, "job_alert_feedback.create", current_publisher_oid).log
-      redirect_to edit_subscription_job_alert_feedback_path(id: @feedback.id), success: t(".success")
-    end
+
+    return unless @feedback.save
+
+    Auditor::Audit.new(@feedback, "job_alert_feedback.create", current_publisher_oid).log
+    redirect_to edit_subscription_job_alert_feedback_path(id: @feedback.id), success: t(".success")
   end
 
   def edit

--- a/app/controllers/publishers/base_controller.rb
+++ b/app/controllers/publishers/base_controller.rb
@@ -38,10 +38,10 @@ class Publishers::BaseController < ApplicationController
     return redirect_to(new_identifications_path) unless current_publisher
     return redirect_to(logout_endpoint) if current_publisher.last_activity_at.blank?
 
-    if Time.current > (current_publisher.last_activity_at + TIMEOUT_PERIOD)
-      session[:publisher_signing_out_for_inactivity] = true
-      redirect_to logout_endpoint
-    end
+    return unless Time.current > (current_publisher.last_activity_at + TIMEOUT_PERIOD)
+
+    session[:publisher_signing_out_for_inactivity] = true
+    redirect_to logout_endpoint
   end
 
   def update_publisher_last_activity_at

--- a/app/controllers/publishers/organisations/managed_organisations_controller.rb
+++ b/app/controllers/publishers/organisations/managed_organisations_controller.rb
@@ -37,12 +37,13 @@ private
     @organisation_options = current_organisation.schools.not_closed.order(:name).map do |school|
       OpenStruct.new({ id: school.id, name: school.name, address: full_address(school) })
     end
-    unless current_organisation.group_type == "local_authority"
-      @organisation_options.unshift(
-        OpenStruct.new({ id: current_organisation.id,
-                         name: t("publishers.organisations.managed_organisations.show.options.school_group"),
-                         address: full_address(current_organisation) }),
-      )
-    end
+
+    return if current_organisation.group_type == "local_authority"
+
+    @organisation_options.unshift(
+      OpenStruct.new({ id: current_organisation.id,
+                       name: t("publishers.organisations.managed_organisations.show.options.school_group"),
+                       address: full_address(current_organisation) }),
+    )
   end
 end

--- a/app/controllers/publishers/organisations_controller.rb
+++ b/app/controllers/publishers/organisations_controller.rb
@@ -20,9 +20,9 @@ class Publishers::OrganisationsController < Publishers::BaseController
 private
 
   def redirect_to_user_preferences
-    if current_organisation.is_a?(SchoolGroup) && current_publisher_preferences.nil?
-      redirect_to organisation_managed_organisations_path
-    end
+    return unless current_organisation.is_a?(SchoolGroup) && current_publisher_preferences.nil?
+
+    redirect_to organisation_managed_organisations_path
   end
 
   def session_has_multiple_organisations?

--- a/app/controllers/publishers/vacancies/application_controller.rb
+++ b/app/controllers/publishers/vacancies/application_controller.rb
@@ -38,11 +38,12 @@ class Publishers::Vacancies::ApplicationController < Publishers::BaseController
   end
 
   def readable_job_location(job_location, school_name: nil, schools_count: nil)
-    if job_location == "at_one_school"
+    case job_location
+    when "at_one_school"
       school_name
-    elsif job_location == "at_multiple_schools"
+    when "at_multiple_schools"
       t("publishers.organisations.readable_job_location.at_multiple_schools_with_count", count: schools_count)
-    elsif job_location == "central_office"
+    when "central_office"
       t("publishers.organisations.readable_job_location.central_office")
     end
   end

--- a/app/controllers/publishers/vacancies/build_controller.rb
+++ b/app/controllers/publishers/vacancies/build_controller.rb
@@ -29,11 +29,9 @@ class Publishers::Vacancies::BuildController < Publishers::Vacancies::Applicatio
         skip_step
       end
     when :documents
-      if @vacancy.supporting_documents == "no"
-        skip_step
-      else
-        return redirect_to organisation_job_documents_path(@vacancy.id)
-      end
+      return redirect_to(organisation_job_documents_path(@vacancy.id)) unless @vacancy.supporting_documents == "no"
+
+      skip_step
     when :applying_for_the_job
       @applying_for_the_job_back_path = @vacancy.supporting_documents == "no" ? wizard_path(:supporting_documents) : wizard_path(:documents)
     end
@@ -112,9 +110,9 @@ private
   end
 
   def strip_checkbox_params
-    if VACANCY_STRIP_CHECKBOXES.key?(step)
-      strip_empty_checkboxes(VACANCY_STRIP_CHECKBOXES[step], "#{step}_form".to_sym)
-    end
+    return unless VACANCY_STRIP_CHECKBOXES.key?(step)
+
+    strip_empty_checkboxes(VACANCY_STRIP_CHECKBOXES[step], "#{step}_form".to_sym)
   end
 
   def update_incomplete_listing

--- a/app/controllers/publishers/vacancies_controller.rb
+++ b/app/controllers/publishers/vacancies_controller.rb
@@ -62,10 +62,10 @@ private
   end
 
   def redirect_if_published
-    if @vacancy.published?
-      redirect_to organisation_job_path(@vacancy.id),
-                  notice: t("messages.jobs.already_published")
-    end
+    return unless @vacancy.published?
+
+    redirect_to organisation_job_path(@vacancy.id),
+                notice: t("messages.jobs.already_published")
   end
 
   def redirect_to_incomplete_step

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -40,7 +40,7 @@ private
   def algolia_search_params
     strip_empty_checkboxes(%i[job_roles phases working_patterns])
     %w[job_role job_roles phases working_patterns].each do |facet|
-      params[facet] = params[facet].split(" ") if params[facet].is_a?(String)
+      params[facet] = params[facet].split if params[facet].is_a?(String)
     end
     params.permit(:keyword, :location, :radius, :location_category, :subject, :buffer_radius, :jobs_sort, :page,
                   job_role: [], job_roles: [], phases: [], working_patterns: [])

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,7 +8,7 @@ module ApplicationHelper
 
   def body_class
     auth_class = publisher_signed_in? ? "publisher" : "jobseeker"
-    action_class = controller_path.tr("/", "_") + "_" + action_name
+    action_class = "#{controller_path.tr('/', '_')}_#{action_name}"
     "govuk-template__body #{auth_class} #{action_class}"
   end
 

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -9,7 +9,7 @@ module VacanciesHelper
   end
 
   def uncapitalize_words(location_name)
-    array = location_name.split(" ")
+    array = location_name.split
     array.map! { |word| WORD_EXCEPTIONS.include?(word.downcase) ? word.downcase : word }
     array.join(" ")
   end
@@ -40,7 +40,7 @@ module VacanciesHelper
     t("jobs.review_heading")
   end
 
-  def hidden_state_field_value(vacancy, copy = false)
+  def hidden_state_field_value(vacancy, copy: false)
     return "copy" if copy
     return "edit_published" if vacancy.published?
     return vacancy.state if %w[copy review edit].include?(vacancy.state)
@@ -62,7 +62,7 @@ module VacanciesHelper
   end
 
   def expiry_date_and_time(vacancy)
-    format_date(vacancy.expires_on) + " at " + vacancy.expires_at.strftime("%-l:%M %P")
+    "#{format_date(vacancy.expires_on)} at #{vacancy.expires_at.strftime('%-l:%M %P')}"
   end
 
   def vacancy_or_organisation_description(vacancy)

--- a/app/models/concerns/vacancy_copy_validations.rb
+++ b/app/models/concerns/vacancy_copy_validations.rb
@@ -13,10 +13,8 @@ module VacancyCopyValidations
   end
 
   def job_title_has_no_tags?
-    unless job_title == sanitize(job_title, tags: [])
-      errors.add(
-        :job_title, I18n.t("job_details_errors.job_title.invalid_characters")
-      )
-    end
+    return if job_title == sanitize(job_title, tags: [])
+
+    errors.add(:job_title, I18n.t("job_details_errors.job_title.invalid_characters"))
   end
 end

--- a/app/models/concerns/vacancy_job_details_validations.rb
+++ b/app/models/concerns/vacancy_job_details_validations.rb
@@ -13,10 +13,8 @@ module VacancyJobDetailsValidations
   end
 
   def job_title_has_no_tags?
-    unless job_title == sanitize(job_title, tags: [])
-      errors.add(
-        :job_title, I18n.t("job_details_errors.job_title.invalid_characters")
-      )
-    end
+    return if job_title == sanitize(job_title, tags: [])
+
+    errors.add(:job_title, I18n.t("job_details_errors.job_title.invalid_characters"))
   end
 end

--- a/app/models/concerns/vacancy_job_summary_validations.rb
+++ b/app/models/concerns/vacancy_job_summary_validations.rb
@@ -10,11 +10,12 @@ module VacancyJobSummaryValidations
     return if about_school.present?
 
     # Since vacancy is set by VacancyForm.initialize, it can be undefined here.
-    if job_location == "central_office"
+    case job_location
+    when "central_office"
       organisation = "trust"
-    elsif job_location == "at_one_school"
+    when "at_one_school"
       organisation = "school"
-    elsif job_location == "at_multiple_schools"
+    when "at_multiple_schools"
       organisation = "schools"
     end
     errors.add(:about_school,

--- a/app/models/concerns/vacancy_pay_package_validations.rb
+++ b/app/models/concerns/vacancy_pay_package_validations.rb
@@ -9,10 +9,10 @@ module VacancyPayPackageValidations
   end
 
   def salary_has_no_tags?
-    unless salary == sanitize(salary, tags: [])
-      errors.add(
-        :salary, I18n.t("activemodel.errors.models.pay_package_form.attributes.salary.invalid_characters")
-      )
-    end
+    return if salary == sanitize(salary, tags: [])
+
+    errors.add(
+      :salary, I18n.t("activemodel.errors.models.pay_package_form.attributes.salary.invalid_characters")
+    )
   end
 end

--- a/app/presenters/organisation_vacancy_presenter.rb
+++ b/app/presenters/organisation_vacancy_presenter.rb
@@ -15,14 +15,15 @@ class OrganisationVacancyPresenter < BasePresenter
   end
 
   def days_to_apply
-    if model.expires_on == Date.current
-      return I18n.t("jobs.days_to_apply.today")
-    elsif model.expires_on == Time.zone.tomorrow
-      return I18n.t("jobs.days_to_apply.tomorrow")
+    case model.expires_on
+    when Date.current
+      I18n.t("jobs.days_to_apply.today")
+    when Time.zone.tomorrow
+      I18n.t("jobs.days_to_apply.tomorrow")
+    else
+      days_remaining = (model.expires_on - Date.current).to_i
+      I18n.t("jobs.days_to_apply.remaining", days_remaining: days_remaining)
     end
-
-    days_remaining = (model.expires_on - Date.current).to_i
-    I18n.t("jobs.days_to_apply.remaining", days_remaining: days_remaining)
   end
 
   def expires_on

--- a/app/services/location_suggestion.rb
+++ b/app/services/location_suggestion.rb
@@ -3,7 +3,9 @@ class LocationSuggestion
   NUMBER_OF_SUGGESTIONS = 5
 
   class InsufficientLocationInput < StandardError; end
+
   class MissingLocationInput < StandardError; end
+
   class GooglePlacesAutocompleteError < StandardError; end
 
   attr_accessor :location_input

--- a/app/services/search/criteria_deviser.rb
+++ b/app/services/search/criteria_deviser.rb
@@ -30,8 +30,8 @@ private
 
   def get_subjects_from_job_title
     subject_options = SUBJECT_OPTIONS.map(&:first)
-    single_word_subjects = subject_options.select { |subject| subject.split(" ").one? }
-    multi_word_subjects = subject_options.select { |subject| subject.split(" ").many? }
+    single_word_subjects = subject_options.select { |subject| subject.split.one? }
+    multi_word_subjects = subject_options.select { |subject| subject.split.many? }
     keyword = get_strings_from_job_title(single_word_subjects, multi_word_subjects)
     # Hard code synonym 'Maths' for 'Mathematics' - SUBJECT_OPTIONS only contains 'Mathematics'
     keyword << "Mathematics" if normalize(@vacancy.job_title).include?(normalize("Maths"))
@@ -45,7 +45,7 @@ private
   def get_strings_from_job_title(words, phrases)
     words_and_phrases = []
     words.each do |word|
-      if normalize(@vacancy.job_title).split(" ").include?(normalize(word))
+      if normalize(@vacancy.job_title).split.include?(normalize(word))
         words_and_phrases << word
       end
     end

--- a/app/services/search/location_builder.rb
+++ b/app/services/search/location_builder.rb
@@ -42,19 +42,20 @@ private
                                    [@location_polygon.boundary]
                                  end
     end
-    if location_polygon.nil? && (DOWNCASE_REGIONS + DOWNCASE_COUNTIES).include?(@location_category.downcase)
-      # If a location category that we expect to have a polygon actually does not,
-      # append the location category to the text search as a fallback.
-      # This applies only to regions and counties: large areas for which there is
-      # very little value in using a point coordinate, and for which there is a
-      # low chance of ambiguity (unlike Clapham borough vs Clapham village in Bedfordshire)
-      Rollbar.log(
-        :error,
-        "A location category search was performed as a text search as no LocationPolygon could
-        be found with the name '#{@location_category}'.",
-      )
-      @missing_polygon = true
-    end
+
+    return unless location_polygon.nil? && (DOWNCASE_REGIONS + DOWNCASE_COUNTIES).include?(@location_category.downcase)
+
+    # If a location category that we expect to have a polygon actually does not,
+    # append the location category to the text search as a fallback.
+    # This applies only to regions and counties: large areas for which there is
+    # very little value in using a point coordinate, and for which there is a
+    # low chance of ambiguity (unlike Clapham borough vs Clapham village in Bedfordshire)
+    Rollbar.log(
+      :error,
+      "A location category search was performed as a text search as no LocationPolygon could
+      be found with the name '#{@location_category}'.",
+    )
+    @missing_polygon = true
   end
 
   def build_location_filter(location, radius)

--- a/app/views/publishers/vacancies/_expires_at_field.html.slim
+++ b/app/views/publishers/vacancies/_expires_at_field.html.slim
@@ -10,9 +10,9 @@
     .govuk-date-input
       .govuk-date-input__item.add-colon-positioned-next-to-element
         = f.govuk_number_field :expires_at_hh, width: 2,
-          class: "govuk-input govuk-date-input__input govuk-input--width-2 " + (f.object.errors[:expires_at].present? ? "govuk-input--error" : "")
+          class: "govuk-input govuk-date-input__input govuk-input--width-2 #{f.object.errors[:expires_at].present? ? 'govuk-input--error' : ''}"
       .govuk-date-input__item
         = f.govuk_number_field :expires_at_mm, width: 2,
-          class: "govuk-input govuk-date-input__input govuk-input--width-2 " + (f.object.errors[:expires_at].present? ? "govuk-input--error" : "")
+          class: "govuk-input govuk-date-input__input govuk-input--width-2 #{f.object.errors[:expires_at].present? ? 'govuk-input--error' : ''}"
       .govuk-date-input__item
         = f.govuk_collection_select :expires_at_meridiem, %w[am pm], :itself, :itself

--- a/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
+++ b/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
@@ -4,10 +4,10 @@
   .govuk-grid-column-full
     = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy)
 
-- if @vacancy.state != "create"
-  = render "publishers/vacancies/vacancy_form_partials/cancel_and_return_link"
-- else
+- if @vacancy.state == "create"
   = govuk_back_link text: t("buttons.back"), href: @applying_for_the_job_back_path
+- else
+  = render "publishers/vacancies/vacancy_form_partials/cancel_and_return_link"
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/publishers/vacancies/build/important_dates.html.slim
+++ b/app/views/publishers/vacancies/build/important_dates.html.slim
@@ -4,10 +4,10 @@
   .govuk-grid-column-full
     = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy)
 
-- if @vacancy.state != "create"
-  = render "publishers/vacancies/vacancy_form_partials/cancel_and_return_link"
-- else
+- if @vacancy.state == "create"
   = govuk_back_link text: t("buttons.back"), href: previous_wizard_path
+- else
+  = render "publishers/vacancies/vacancy_form_partials/cancel_and_return_link"
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/publishers/vacancies/build/job_summary.html.slim
+++ b/app/views/publishers/vacancies/build/job_summary.html.slim
@@ -4,10 +4,10 @@
   .govuk-grid-column-full
     = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy)
 
-- if @vacancy.state != "create"
-  = render "publishers/vacancies/vacancy_form_partials/cancel_and_return_link"
-- else
+- if @vacancy.state == "create"
   = govuk_back_link text: t("buttons.back"), href: previous_wizard_path
+- else
+  = render "publishers/vacancies/vacancy_form_partials/cancel_and_return_link"
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/publishers/vacancies/build/pay_package.html.slim
+++ b/app/views/publishers/vacancies/build/pay_package.html.slim
@@ -4,10 +4,10 @@
   .govuk-grid-column-full
     = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy)
 
-- if @vacancy.state != "create"
-  = render "publishers/vacancies/vacancy_form_partials/cancel_and_return_link"
-- else
+- if @vacancy.state == "create"
   = govuk_back_link text: t("buttons.back"), href: previous_wizard_path
+- else
+  = render "publishers/vacancies/vacancy_form_partials/cancel_and_return_link"
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/publishers/vacancies/build/schools.html.slim
+++ b/app/views/publishers/vacancies/build/schools.html.slim
@@ -4,10 +4,10 @@
   .govuk-grid-column-full
     = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy)
 
-- if @vacancy.state != "create"
-  = render "publishers/vacancies/vacancy_form_partials/cancel_and_return_link"
-- else
+- if @vacancy.state == "create"
   = govuk_back_link text: t("buttons.back"), href: previous_wizard_path
+- else
+  = render "publishers/vacancies/vacancy_form_partials/cancel_and_return_link"
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/publishers/vacancies/build/supporting_documents.html.slim
+++ b/app/views/publishers/vacancies/build/supporting_documents.html.slim
@@ -4,10 +4,10 @@
   .govuk-grid-column-full
     = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy)
 
-- if @vacancy.state != "create"
-  = render "publishers/vacancies/vacancy_form_partials/cancel_and_return_link"
-- else
+- if @vacancy.state == "create"
   = govuk_back_link text: t("buttons.back"), href: previous_wizard_path
+- else
+  = render "publishers/vacancies/vacancy_form_partials/cancel_and_return_link"
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/publishers/vacancies/documents/show.html.slim
+++ b/app/views/publishers/vacancies/documents/show.html.slim
@@ -4,10 +4,10 @@
   .govuk-grid-column-full
     = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy)
 
-- if @vacancy.state != "create"
-  = render "publishers/vacancies/vacancy_form_partials/cancel_and_return_link"
-- else
+- if @vacancy.state == "create"
   = govuk_back_link text: t("buttons.back"), href: organisation_job_build_path(@vacancy.id, :supporting_documents)
+- else
+  = render "publishers/vacancies/vacancy_form_partials/cancel_and_return_link"
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/publishers/vacancies/vacancy_form_partials/_hidden_state_input.html.slim
+++ b/app/views/publishers/vacancies/vacancy_form_partials/_hidden_state_input.html.slim
@@ -1,2 +1,2 @@
 - copy = false if local_assigns[:copy].nil?
-= f.hidden_field :state, value: hidden_state_field_value(@vacancy, copy)
+= f.hidden_field :state, value: hidden_state_field_value(@vacancy, copy: copy)

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,13 +1,33 @@
 {
   "ignored_warnings": [
     {
+      "warning_type": "Unscoped Find",
+      "warning_code": 82,
+      "fingerprint": "0154c62f733be2e251649d6eb9d004013037c8c82b10c73704efe4012f2620ba",
+      "check_name": "UnscopedFind",
+      "message": "Unscoped call to `EmergencyLoginKey#find`",
+      "file": "app/controllers/publishers/sign_in/email/sessions_controller.rb",
+      "line": 81,
+      "link": "https://brakemanscanner.org/docs/warning_types/unscoped_find/",
+      "code": "EmergencyLoginKey.find(params[:login_key])",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Publishers::SignIn::Email::SessionsController",
+        "method": "get_key"
+      },
+      "user_input": "params[:login_key]",
+      "confidence": "Weak",
+      "note": "Intended behaviour - we do not have a user available at this point"
+    },
+    {
       "warning_type": "Authentication",
       "warning_code": 101,
       "fingerprint": "1d94226b7d2099d5fbdfc82158f8100f98d20a42e468bc779bf98c2ac77b7c05",
       "check_name": "Secrets",
       "message": "Hardcoded value for `NOTIFY_JOBSEEKER_RESET_PASSWORD_TEMPLATE` in source code",
       "file": "config/initializers/notifications.rb",
-      "line": 3,
+      "line": 5,
       "link": "https://brakemanscanner.org/docs/warning_types/authentication/",
       "code": null,
       "render_path": null,
@@ -39,7 +59,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/controllers/jobseekers/saved_jobs_controller.rb",
-      "line": 20,
+      "line": 22,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "current_jobseeker.saved_jobs.includes(:vacancy).order(\"#{SavedJobSort.new.update(:column => sort_column, :order => sort_order).column} #{SavedJobSort.new.update(:column => sort_column, :order => sort_order).order}\")",
       "render_path": null,
@@ -51,28 +71,8 @@
       "user_input": "SavedJobSort.new.update(:column => sort_column, :order => sort_order).column",
       "confidence": "Weak",
       "note": "Sorts columns and orders only come from an allowed list of values, so SQL injection risk can be ignored"
-    },
-    {
-      "warning_type": "Unscoped Find",
-      "warning_code": 82,
-      "fingerprint": "c5959d2ec2d9d19a49b2aafe023b3f6647ef30c14c8333449c9344098282bdb5",
-      "check_name": "UnscopedFind",
-      "message": "Unscoped call to `EmergencyLoginKey#find`",
-      "file": "app/controllers/publishers/sign_in/email/sessions_controller.rb",
-      "line": 80,
-      "link": "https://brakemanscanner.org/docs/warning_types/unscoped_find/",
-      "code": "EmergencyLoginKey.find(params.dig(:login_key))",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Publishers::SignIn::Email::SessionsController",
-        "method": "get_key"
-      },
-      "user_input": "params.dig(:login_key)",
-      "confidence": "Weak",
-      "note": "Intended behaviour: No user is available at this point, so cannot scope."
     }
   ],
-  "updated": "2020-12-10 10:21:42 +0000",
-  "brakeman_version": "4.10.0"
+  "updated": "2021-01-07 17:32:28 +0000",
+  "brakeman_version": "4.10.1"
 }

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,7 +43,7 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  logger           = ActiveSupport::Logger.new(STDOUT)
+  logger           = ActiveSupport::Logger.new($stdout)
   logger.formatter = config.log_formatter
   config.logger    = ActiveSupport::TaggedLogging.new(logger)
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -70,14 +70,14 @@ Rails.application.configure do
   # Logging
   config.log_level = :info
   config.log_tags = [:request_id] # Prepend all log lines with the following tags.
-  config.logger = ActiveSupport::Logger.new(STDOUT)
+  config.logger = ActiveSupport::Logger.new($stdout)
   config.active_record.logger = nil # Don't log SQL in production
 
   # Use Lograge for cleaner logging
   config.lograge.enabled = true
   config.lograge.formatter = ColourLogFormatter.new
   config.lograge.ignore_actions = ["ApplicationController#check"]
-  config.lograge.logger = ActiveSupport::Logger.new(STDOUT)
+  config.lograge.logger = ActiveSupport::Logger.new($stdout)
 
   # Include params in logs: https://github.com/roidrage/lograge#what-it-doesnt-do
   config.lograge.custom_options = lambda do |event|

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -77,13 +77,13 @@ Rails.application.configure do
   # Logging
   config.log_level = :info
   config.log_tags = [:request_id] # Prepend all log lines with the following tags.
-  config.logger = ActiveSupport::Logger.new(STDOUT)
+  config.logger = ActiveSupport::Logger.new($stdout)
 
   # Use Lograge for cleaner logging
   config.lograge.enabled = true
   config.lograge.formatter = ColourLogFormatter.new
   config.lograge.ignore_actions = ["ApplicationController#check"]
-  config.lograge.logger = ActiveSupport::Logger.new(STDOUT)
+  config.lograge.logger = ActiveSupport::Logger.new($stdout)
 
   # Include params in logs: https://github.com/roidrage/lograge#what-it-doesnt-do
   config.lograge.custom_options = lambda do |event|

--- a/config/initializers/google_api.rb
+++ b/config/initializers/google_api.rb
@@ -5,7 +5,8 @@ GOOGLE_ANALYTICS_PROFILE_ID = ENV.fetch("GOOGLE_ANALYTICS_PROFILE_ID", "")
 GOOGLE_PLACES_AUTOCOMPLETE_KEY = ENV.fetch("GOOGLE_PLACES_AUTOCOMPLETE_KEY", "")
 
 if GOOGLE_API_JSON_KEY.empty? || JSON.parse(GOOGLE_API_JSON_KEY).empty?
-  return Rails.logger.info("***No GOOGLE_API_JSON_KEY set")
+  Rails.logger.info("***No GOOGLE_API_JSON_KEY set")
+  return
 end
 
 scope = ["https://www.googleapis.com/auth/indexing",

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 Kaminari.configure do |config|
   config.default_per_page = 10
   config.max_per_page = nil

--- a/lib/dfe_sign_in_api.rb
+++ b/lib/dfe_sign_in_api.rb
@@ -1,6 +1,8 @@
 module DFESignIn
   class ExternalServerError < StandardError; end
+
   class ForbiddenRequestError < StandardError; end
+
   class UnknownResponseError < StandardError; end
 
   class API

--- a/lib/export_tables_to_big_query.rb
+++ b/lib/export_tables_to_big_query.rb
@@ -114,7 +114,7 @@ private
 
     json_record.map do |key, value|
       data = value.presence
-      data = Date.parse(data).to_s(:db) if data.is_a?(String) && data.match?(/^\d{2}[-\/]\d{2}[-\/]\d{4}/)
+      data = Date.parse(data).to_s(:db) if data.is_a?(String) && data.match?(%r{^\d{2}[-/]\d{2}[-/]\d{4}})
       data = data.to_i if data.is_a?(String) && data.match?(/^\d+$/)
       @bigquery_data[data_key_name(key)] = data
     end

--- a/lib/organisation_import/import_organisation_data.rb
+++ b/lib/organisation_import/import_organisation_data.rb
@@ -14,9 +14,10 @@ private
 
   def save_csv_file(url, location)
     request = HTTParty.get(url)
-    if request.code == 200
+    case request.code
+    when 200
       File.write(location, request.body, mode: "wb")
-    elsif request.code == 404
+    when 404
       raise HTTParty::ResponseError, "CSV file not found."
     else
       raise HTTParty::ResponseError, "Unexpected problem downloading CSV file."

--- a/lib/organisation_import/import_trust_data.rb
+++ b/lib/organisation_import/import_trust_data.rb
@@ -70,10 +70,10 @@ private
 
   def set_geolocation(trust, postcode)
     # We don't need to make an API request if the postcode hasn't changed
-    if postcode.present? && (trust.geolocation.blank? || trust.postcode != postcode)
-      trust.postcode = postcode
-      coordinates = Geocoding.new(trust.postcode).coordinates
-      trust.geolocation = coordinates unless coordinates == [0, 0]
-    end
+    return unless postcode.present? && (trust.geolocation.blank? || trust.postcode != postcode)
+
+    trust.postcode = postcode
+    coordinates = Geocoding.new(trust.postcode).coordinates
+    trust.geolocation = coordinates unless coordinates == [0, 0]
   end
 end

--- a/lib/performance_platform_sender.rb
+++ b/lib/performance_platform_sender.rb
@@ -3,7 +3,7 @@ require "performance_platform"
 module PerformancePlatformSender
   class Base
     def self.by_type(type)
-      const_get("PerformancePlatformSender::" + type.to_s.capitalize).new
+      const_get("PerformancePlatformSender::#{type.to_s.capitalize}").new
     end
 
     def call(date:)

--- a/lib/tasks/cloudfoundry.rake
+++ b/lib/tasks/cloudfoundry.rake
@@ -2,10 +2,10 @@ namespace :cf do
   desc "Only run on the first application instance"
   task :on_first_instance do
     instance_index = begin
-                       JSON.parse(ENV["VCAP_APPLICATION"])["instance_index"]
-                     rescue StandardError
-                       nil
-                     end
+      JSON.parse(ENV["VCAP_APPLICATION"])["instance_index"]
+    rescue StandardError
+      nil
+    end
     exit(0) unless instance_index.zero?
   end
 end

--- a/lib/tasks/logging.rake
+++ b/lib/tasks/logging.rake
@@ -1,6 +1,6 @@
 desc "switch rails logger to stdout"
 task verbose: [:environment] do
-  Rails.logger = Logger.new(STDOUT)
+  Rails.logger = Logger.new($stdout)
 end
 
 desc "switch rails logger log level to debug"

--- a/lib/tasks/slim_lint.rake
+++ b/lib/tasks/slim_lint.rake
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 if Rails.env.development? || Rails.env.test?
   require "slim_lint/rake_task"
   SlimLint::RakeTask.new

--- a/spec/components/jobseekers/organisation_overviews/schools_component_spec.rb
+++ b/spec/components/jobseekers/organisation_overviews/schools_component_spec.rb
@@ -3,21 +3,21 @@ require "rails_helper"
 RSpec.describe Jobseekers::OrganisationOverviews::SchoolsComponent, type: :component do
   let(:organisation) { create(:trust) }
   let(:geolocation_trait) { nil }
-  let(:school_1) { create(:school, geolocation_trait, name: "Oxford Uni", website: "https://this-is-a-test-url.tvs") }
-  let(:school_2) { create(:school, geolocation_trait, name: "Cambridge Uni") }
-  let(:school_3) { create(:school, geolocation_trait, name: "London LSE") }
+  let(:school1) { create(:school, geolocation_trait, name: "Oxford Uni", website: "https://this-is-a-test-url.tvs") }
+  let(:school2) { create(:school, geolocation_trait, name: "Cambridge Uni") }
+  let(:school3) { create(:school, geolocation_trait, name: "London LSE") }
 
   let(:vacancy) do
     create(:vacancy, :at_multiple_schools, organisation_vacancies_attributes: [
-      { organisation: school_1 }, { organisation: school_2 }, { organisation: school_3 }
+      { organisation: school1 }, { organisation: school2 }, { organisation: school3 }
     ])
   end
   let(:vacancy_presenter) { VacancyPresenter.new(vacancy) }
 
   before do
-    organisation.school_group_memberships.create(school: school_1)
-    organisation.school_group_memberships.create(school: school_2)
-    organisation.school_group_memberships.create(school: school_3)
+    organisation.school_group_memberships.create(school: school1)
+    organisation.school_group_memberships.create(school: school2)
+    organisation.school_group_memberships.create(school: school3)
     render_inline(described_class.new(vacancy: vacancy_presenter))
   end
 
@@ -41,7 +41,7 @@ RSpec.describe Jobseekers::OrganisationOverviews::SchoolsComponent, type: :compo
     context "when vacancy job_location is at_multiple_schools" do
       let(:vacancy) do
         create(:vacancy, :at_multiple_schools, organisation_vacancies_attributes: [
-          { organisation: school_1 }, { organisation: school_2 }, { organisation: school_3 }
+          { organisation: school1 }, { organisation: school2 }, { organisation: school3 }
         ])
       end
 
@@ -68,47 +68,47 @@ RSpec.describe Jobseekers::OrganisationOverviews::SchoolsComponent, type: :compo
   end
 
   it "renders all the school name in accordions" do
-    [school_1, school_2, school_3].each { |school| expect(rendered_component).to include(school.name) }
+    [school1, school2, school3].each { |school| expect(rendered_component).to include(school.name) }
   end
 
   it "renders all the school types" do
-    [school_1, school_2, school_3].each do |school|
+    [school1, school2, school3].each do |school|
       expect(rendered_component).to include(organisation_type(organisation: school, with_age_range: false))
     end
   end
 
   it "renders all the school education phases" do
-    [school_1, school_2, school_3].each { |school| expect(rendered_component).to include(school_phase(school)) }
+    [school1, school2, school3].each { |school| expect(rendered_component).to include(school_phase(school)) }
   end
 
   it "renders all the school sizes" do
-    [school_1, school_2, school_3].each { |school| expect(rendered_component).to include(school_size(school)) }
+    [school1, school2, school3].each { |school| expect(rendered_component).to include(school_size(school)) }
   end
 
   it "renders all the school age ranges" do
-    [school_1, school_2, school_3].each { |school| expect(rendered_component).to include(age_range(school)) }
+    [school1, school2, school3].each { |school| expect(rendered_component).to include(age_range(school)) }
   end
 
   it "renders all the school ofsted_reports" do
-    [school_1, school_2, school_3].each { |school| expect(rendered_component).to include(ofsted_report(school)) }
+    [school1, school2, school3].each { |school| expect(rendered_component).to include(ofsted_report(school)) }
   end
 
   it "renders all the school addresses" do
-    [school_1, school_2, school_3].each { |school| expect(rendered_component).to include(full_address(school)) }
+    [school1, school2, school3].each { |school| expect(rendered_component).to include(full_address(school)) }
   end
 
   context "when GIAS-provided website has been overwritten" do
     it "renders a link to the school website" do
-      expect(rendered_component).to include(school_1.website)
+      expect(rendered_component).to include(school1.website)
     end
 
     it "does not render the GIAS-provided website" do
-      expect(rendered_component).not_to include(school_1.url)
+      expect(rendered_component).not_to include(school1.url)
     end
   end
 
   it "renders all the GIAS-provided links to the school website section" do
-    [school_2, school_3].each { |school| expect(rendered_component).to include(school.url) }
+    [school2, school3].each { |school| expect(rendered_component).to include(school.url) }
   end
 
   it "renders the school visits" do
@@ -143,22 +143,22 @@ RSpec.describe Jobseekers::OrganisationOverviews::SchoolsComponent, type: :compo
     end
 
     let(:school_1_data) do
-      organisation_map_data.find { |s| s["name"] == school_1.name }
+      organisation_map_data.find { |s| s["name"] == school1.name }
     end
 
     let(:school_2_data) do
-      organisation_map_data.find { |s| s["name"] == school_2.name }
+      organisation_map_data.find { |s| s["name"] == school2.name }
     end
 
     context "when the user has provided a website" do
       it "links to the user-provided website" do
-        expect(school_1_data["name_link"]).to eq "<a href=\"#{school_1.website}\">#{school_1.name}</a>"
+        expect(school_1_data["name_link"]).to eq "<a href=\"#{school1.website}\">#{school1.name}</a>"
       end
     end
 
     context "when the user has NOT provided a website" do
       it "links to the GIAS-provided url" do
-        expect(school_2_data["name_link"]).to eq "<a href=\"#{school_2.url}\">#{school_2.name}</a>"
+        expect(school_2_data["name_link"]).to eq "<a href=\"#{school2.url}\">#{school2.name}</a>"
       end
     end
   end

--- a/spec/components/jobseekers/vacancy_summary_component_spec.rb
+++ b/spec/components/jobseekers/vacancy_summary_component_spec.rb
@@ -71,19 +71,19 @@ RSpec.describe Jobseekers::VacancySummaryComponent, type: :component do
 
   context "when vacancy job_location is at_multiple_schools" do
     let(:organisation) { create(:trust) }
-    let(:school_1) { create(:school, :catholic, school_type: "Academy") }
-    let(:school_2) { create(:school, :catholic, school_type: "Academy") }
-    let(:school_3) { create(:school, :catholic, school_type: "Academy", minimum_age: 16) }
+    let(:school1) { create(:school, :catholic, school_type: "Academy") }
+    let(:school2) { create(:school, :catholic, school_type: "Academy") }
+    let(:school3) { create(:school, :catholic, school_type: "Academy", minimum_age: 16) }
     let(:vacancy) do
       create(:vacancy, :at_multiple_schools, organisation_vacancies_attributes: [
-        { organisation: school_1 }, { organisation: school_2 }, { organisation: school_3 }
+        { organisation: school1 }, { organisation: school2 }, { organisation: school3 }
       ])
     end
 
     before do
-      SchoolGroupMembership.find_or_create_by(school_id: school_1.id, school_group_id: organisation.id)
-      SchoolGroupMembership.find_or_create_by(school_id: school_2.id, school_group_id: organisation.id)
-      SchoolGroupMembership.find_or_create_by(school_id: school_3.id, school_group_id: organisation.id)
+      SchoolGroupMembership.find_or_create_by(school_id: school1.id, school_group_id: organisation.id)
+      SchoolGroupMembership.find_or_create_by(school_id: school2.id, school_group_id: organisation.id)
+      SchoolGroupMembership.find_or_create_by(school_id: school3.id, school_group_id: organisation.id)
       render_inline(described_class.new(vacancy: vacancy_presenter))
     end
 

--- a/spec/factories/school_groups.rb
+++ b/spec/factories/school_groups.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
       }
     end
     group_type { "Multi-academy trust" }
-    name { Faker::Company.name.delete("'") + " Trust" }
+    name { "#{Faker::Company.name.delete("'")} Trust" }
     postcode { Faker::Address.postcode }
     town { Faker::Address.city.delete("'") }
     uid { Faker::Number.number(digits: 5).to_s }
@@ -27,7 +27,7 @@ FactoryBot.define do
   end
 
   factory :local_authority, parent: :school_group do
-    name { Faker::Address.state_abbr + " LA" }
+    name { "#{Faker::Address.state_abbr} LA" }
     group_type { "local_authority" }
     local_authority_code { Faker::Number.number(digits: 3).to_s }
   end

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
-  OFSTED_RATINGS = ["Outstanding", "Good", "Requires Improvement", "Inadequate"].freeze
-  RELIGIOUS_CHARACTERS = ["Church of England", "Roman Catholic", "None", "Does not apply"].freeze
+  ofsted_ratings = ["Outstanding", "Good", "Requires Improvement", "Inadequate"].freeze
+  religious_characters = ["Church of England", "Roman Catholic", "None", "Does not apply"].freeze
 
   factory :school do
     address { Faker::Address.street_name.delete("'") }
@@ -16,12 +16,12 @@ FactoryBot.define do
         "HeadPreferredJobTitle": Faker::Name.prefix.delete("."),
         "DateOfLastInspectionVisit": Faker::Date.between(from: 999.days.ago, to: 5.days.ago),
         "NumberOfPupils": Faker::Number.number(digits: 3),
-        "OfstedRating (name)": OFSTED_RATINGS.sample,
+        "OfstedRating (name)": ofsted_ratings.sample,
         "OpenDate": Faker::Date.between(from: 10_000.days.ago, to: 1000.days.ago),
-        "ReligiousCharacter (name)": RELIGIOUS_CHARACTERS.sample,
+        "ReligiousCharacter (name)": religious_characters.sample,
         "SchoolCapacity": Faker::Number.number(digits: 4),
         "TelephoneNum": Faker::Number.number(digits: 11).to_s,
-        "Trusts (name)": Faker::Company.name.delete("'") + " Trust",
+        "Trusts (name)": "#{Faker::Company.name.delete("'")} Trust",
       }
     end
     minimum_age { 11 }
@@ -73,12 +73,12 @@ FactoryBot.define do
           "HeadPreferredJobTitle": Faker::Name.prefix.delete("."),
           "DateOfLastInspectionVisit": Faker::Date.between(from: 999.days.ago, to: 5.days.ago),
           "NumberOfPupils": Faker::Number.number(digits: 3),
-          "OfstedRating (name)": OFSTED_RATINGS.sample,
+          "OfstedRating (name)": ofsted_ratings.sample,
           "OpenDate": Faker::Date.between(from: 10_000.days.ago, to: 1000.days.ago),
           "ReligiousCharacter (name)": "Roman Catholic",
           "SchoolCapacity": Faker::Number.number(digits: 4),
           "TelephoneNum": Faker::Number.number(digits: 11).to_s,
-          "Trusts (name)": Faker::Company.name.delete("'") + " Trust",
+          "Trusts (name)": "#{Faker::Company.name.delete("'")} Trust",
         }
       end
     end

--- a/spec/form_models/job_alert_feedback_form_spec.rb
+++ b/spec/form_models/job_alert_feedback_form_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe JobAlertFeedbackForm, type: :model do
       end
 
       context "when comment is too long" do
-        let(:comment) { (1..1000).to_a.join("") }
+        let(:comment) { (1..1000).to_a.join }
 
         it "returns the correct error" do
           expect(subject).not_to be_valid

--- a/spec/form_models/schools_form_spec.rb
+++ b/spec/form_models/schools_form_spec.rb
@@ -52,9 +52,9 @@ RSpec.describe SchoolsForm, type: :model do
       end
 
       context "when 2 or more organisations are selected" do
-        let!(:organisation_1) { create(:school) }
-        let!(:organisation_2) { create(:school) }
-        let(:organisation_ids) { [organisation_1.id, organisation_2.id] }
+        let!(:organisation1) { create(:school) }
+        let!(:organisation2) { create(:school) }
+        let(:organisation_ids) { [organisation1.id, organisation2.id] }
 
         it "is valid" do
           expect(subject.valid?).to be true

--- a/spec/helpers/vacancies_helper_spec.rb
+++ b/spec/helpers/vacancies_helper_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe VacanciesHelper, type: :helper do
     end
 
     it "returns copy if copy true" do
-      expect(hidden_state_field_value(vacancy, true)).to eq("copy")
+      expect(hidden_state_field_value(vacancy, copy: true)).to eq("copy")
     end
 
     it "returns edit_published if published vacancy" do

--- a/spec/i18n_helper.rb
+++ b/spec/i18n_helper.rb
@@ -1,2 +1,2 @@
 require "i18n"
-I18n.load_path << Dir[File.expand_path("config/locales") + "/*.yml"]
+I18n.load_path << Dir["#{File.expand_path('config/locales')}/*.yml"]

--- a/spec/lib/organisation_import/import_school_data_spec.rb
+++ b/spec/lib/organisation_import/import_school_data_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe ImportSchoolData do
     let(:temp_file_path) { Rails.root.join("spec/fixtures/temp_schools_data.csv") }
     let(:test_file_path) { Rails.root.join("spec/fixtures/example_schools_data.csv") }
 
-    let(:local_authority_1) { SchoolGroup.find_by(local_authority_code: "201") }
-    let(:local_authority_2) { SchoolGroup.find_by(local_authority_code: "202") }
+    let(:local_authority1) { SchoolGroup.find_by(local_authority_code: "201") }
+    let(:local_authority2) { SchoolGroup.find_by(local_authority_code: "202") }
 
     before do
       stub_request(
@@ -75,14 +75,14 @@ RSpec.describe ImportSchoolData do
 
     it "links the correct schools and local authorities" do
       subject.run!
-      expect(local_authority_1.schools).to include(School.find_by(urn: "100000"))
-      expect(local_authority_1.schools).to include(School.find_by(urn: "100002"))
-      expect(local_authority_1.schools).to include(School.find_by(urn: "100003"))
-      expect(local_authority_2.schools).to include(School.find_by(urn: "100004"))
-      expect(local_authority_2.schools).to include(School.find_by(urn: "100005"))
-      expect(local_authority_2.schools).to include(School.find_by(urn: "100006"))
-      expect(local_authority_2.schools).to include(School.find_by(urn: "100007"))
-      expect(local_authority_2.schools).to include(School.find_by(urn: "100008"))
+      expect(local_authority1.schools).to include(School.find_by(urn: "100000"))
+      expect(local_authority1.schools).to include(School.find_by(urn: "100002"))
+      expect(local_authority1.schools).to include(School.find_by(urn: "100003"))
+      expect(local_authority2.schools).to include(School.find_by(urn: "100004"))
+      expect(local_authority2.schools).to include(School.find_by(urn: "100005"))
+      expect(local_authority2.schools).to include(School.find_by(urn: "100006"))
+      expect(local_authority2.schools).to include(School.find_by(urn: "100007"))
+      expect(local_authority2.schools).to include(School.find_by(urn: "100008"))
     end
 
     it "stores the expected attributes" do

--- a/spec/lib/organisation_import/import_trust_data_spec.rb
+++ b/spec/lib/organisation_import/import_trust_data_spec.rb
@@ -74,12 +74,12 @@ RSpec.describe ImportTrustData do
     let(:links_csv) { File.read(links_file_path) }
     let(:links_file_path) { Rails.root.join("spec/fixtures/example_links_data.csv") }
 
-    let!(:school_1) { create(:academy, urn: "100000") }
-    let!(:school_2) { create(:academy, urn: "100001") }
-    let!(:school_3) { create(:academy, urn: "100002") }
+    let!(:school1) { create(:academy, urn: "100000") }
+    let!(:school2) { create(:academy, urn: "100001") }
+    let!(:school3) { create(:academy, urn: "100002") }
 
-    let(:trust_1) { SchoolGroup.find_by(uid: "2044") }
-    let(:trust_2) { SchoolGroup.find_by(uid: "2070") }
+    let(:trust1) { SchoolGroup.find_by(uid: "2044") }
+    let(:trust2) { SchoolGroup.find_by(uid: "2070") }
 
     before do
       stub_request(
@@ -102,22 +102,22 @@ RSpec.describe ImportTrustData do
 
     it "links the correct schools and trusts" do
       subject.run!
-      expect(trust_1.schools).to include(school_1)
-      expect(trust_1.schools).to include(school_2)
-      expect(trust_2.schools).to include(school_3)
+      expect(trust1.schools).to include(school1)
+      expect(trust1.schools).to include(school2)
+      expect(trust2.schools).to include(school3)
     end
 
     it "stores the expected attributes" do
       subject.run!
-      expect(trust_1).not_to be_blank
-      expect(trust_1.gias_data).not_to be_blank
-      expect(trust_1.name).to eq("Abbey Academies Trust")
-      expect(trust_1.group_type).to eq("Multi-academy trust")
-      expect(trust_1.address).to eq("Abbey Road")
-      expect(trust_1.county).to eq("Not recorded")
-      expect(trust_1.postcode).to eq("PE10 9EP")
-      expect(trust_1.geolocation.x.round(13)).to eq(Geocoder::DEFAULT_STUB_COORDINATES[0].round(13))
-      expect(trust_1.geolocation.y.round(13)).to eq(Geocoder::DEFAULT_STUB_COORDINATES[1].round(13))
+      expect(trust1).not_to be_blank
+      expect(trust1.gias_data).not_to be_blank
+      expect(trust1.name).to eq("Abbey Academies Trust")
+      expect(trust1.group_type).to eq("Multi-academy trust")
+      expect(trust1.address).to eq("Abbey Road")
+      expect(trust1.county).to eq("Not recorded")
+      expect(trust1.postcode).to eq("PE10 9EP")
+      expect(trust1.geolocation.x.round(13)).to eq(Geocoder::DEFAULT_STUB_COORDINATES[0].round(13))
+      expect(trust1.geolocation.y.round(13)).to eq(Geocoder::DEFAULT_STUB_COORDINATES[1].round(13))
     end
   end
 end

--- a/spec/lib/remove_invalid_subscriptions_spec.rb
+++ b/spec/lib/remove_invalid_subscriptions_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe RemoveInvalidSubscriptions do
        OpenStruct.new({ status: "not-permanent-failure", email_address: "test@tempfailed.com" })]
     end
 
-    let!(:failed_subscription_1) { create(:subscription, email: "first@failed.com") }
-    let!(:failed_subscription_2) { create(:subscription, email: "second@failed.com") }
+    let!(:failed_subscription1) { create(:subscription, email: "first@failed.com") }
+    let!(:failed_subscription2) { create(:subscription, email: "second@failed.com") }
     let!(:temp_failed_subscription) { create(:subscription, email: "test@tempfailed.com") }
 
     let(:notify_client_mock) { instance_double(Notifications::Client) }

--- a/spec/presenters/organisation_vacancy_presenter_spec.rb
+++ b/spec/presenters/organisation_vacancy_presenter_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe OrganisationVacancyPresenter do
 
     context "when expiry time present" do
       let(:deadline_time) { Time.current + 5.days }
-      let(:expected_deadline) { format_date(deadline_date) + " at " + format_time(deadline_time) }
+      let(:expected_deadline) { "#{format_date(deadline_date)} at #{format_time(deadline_time)}" }
 
       it "displays the application deadline date" do
         expect(presenter.application_deadline).to eq(expected_deadline)

--- a/spec/presenters/vacancies_presenter_spec.rb
+++ b/spec/presenters/vacancies_presenter_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe VacanciesPresenter do
 
       allow(vacancies_presenter).to receive(:decorated_collection).and_return(decorated_vacancies)
       expect(decorated_vacancies).to receive(:each)
-      vacancies_presenter.each {}
+
+      vacancies_presenter.each
     end
   end
 

--- a/spec/services/search/buffer_suggestions_builder_spec.rb
+++ b/spec/services/search/buffer_suggestions_builder_spec.rb
@@ -24,11 +24,11 @@ RSpec.describe Search::BufferSuggestionsBuilder do
         "25" => buffer_coordinates_twenty_five_miles,
       }
     end
-    let(:vacancies_1) { double("vacancies") }
-    let(:vacancies_2) { double("vacancies") }
-    let(:vacancies_3) { double("vacancies") }
-    let(:vacancies_4) { double("vacancies") }
-    let(:vacancies_5) { double("vacancies") }
+    let(:vacancies1) { double("vacancies") }
+    let(:vacancies2) { double("vacancies") }
+    let(:vacancies3) { double("vacancies") }
+    let(:vacancies4) { double("vacancies") }
+    let(:vacancies5) { double("vacancies") }
     let(:arguments_for_algolia) { { hitsPerPage: 10 } }
 
     before do
@@ -38,23 +38,23 @@ RSpec.describe Search::BufferSuggestionsBuilder do
     context "when there is only one vacancy in any of the buffer polygons" do
       before do
         mock_algolia_search(
-          vacancies_1, 1, nil,
+          vacancies1, 1, nil,
           arguments_for_algolia.merge(insidePolygon: [buffer_coordinates_five_miles])
         )
         mock_algolia_search(
-          vacancies_2, 1, nil,
+          vacancies2, 1, nil,
           arguments_for_algolia.merge(insidePolygon: [buffer_coordinates_ten_miles])
         )
         mock_algolia_search(
-          vacancies_3, 1, nil,
+          vacancies3, 1, nil,
           arguments_for_algolia.merge(insidePolygon: [buffer_coordinates_fifteen_miles])
         )
         mock_algolia_search(
-          vacancies_4, 1, nil,
+          vacancies4, 1, nil,
           arguments_for_algolia.merge(insidePolygon: [buffer_coordinates_twenty_miles])
         )
         mock_algolia_search(
-          vacancies_5, 1, nil,
+          vacancies5, 1, nil,
           arguments_for_algolia.merge(insidePolygon: [buffer_coordinates_twenty_five_miles])
         )
       end
@@ -67,23 +67,23 @@ RSpec.describe Search::BufferSuggestionsBuilder do
     context "when there are vacancies in the wider buffer polygons not found in the smaller polygons" do
       before do
         mock_algolia_search(
-          vacancies_1, 1, nil,
+          vacancies1, 1, nil,
           arguments_for_algolia.merge(insidePolygon: [buffer_coordinates_five_miles])
         )
         mock_algolia_search(
-          vacancies_2, 2, nil,
+          vacancies2, 2, nil,
           arguments_for_algolia.merge(insidePolygon: [buffer_coordinates_ten_miles])
         )
         mock_algolia_search(
-          vacancies_3, 3, nil,
+          vacancies3, 3, nil,
           arguments_for_algolia.merge(insidePolygon: [buffer_coordinates_fifteen_miles])
         )
         mock_algolia_search(
-          vacancies_4, 4, nil,
+          vacancies4, 4, nil,
           arguments_for_algolia.merge(insidePolygon: [buffer_coordinates_twenty_miles])
         )
         mock_algolia_search(
-          vacancies_5, 5, nil,
+          vacancies5, 5, nil,
           arguments_for_algolia.merge(insidePolygon: [buffer_coordinates_twenty_five_miles])
         )
       end
@@ -96,23 +96,23 @@ RSpec.describe Search::BufferSuggestionsBuilder do
     context "when there are zero vacancies in a buffer polygon" do
       before do
         mock_algolia_search(
-          vacancies_1, 0, nil,
+          vacancies1, 0, nil,
           arguments_for_algolia.merge(insidePolygon: [buffer_coordinates_five_miles])
         )
         mock_algolia_search(
-          vacancies_2, 0, nil,
+          vacancies2, 0, nil,
           arguments_for_algolia.merge(insidePolygon: [buffer_coordinates_ten_miles])
         )
         mock_algolia_search(
-          vacancies_3, 0, nil,
+          vacancies3, 0, nil,
           arguments_for_algolia.merge(insidePolygon: [buffer_coordinates_fifteen_miles])
         )
         mock_algolia_search(
-          vacancies_4, 0, nil,
+          vacancies4, 0, nil,
           arguments_for_algolia.merge(insidePolygon: [buffer_coordinates_twenty_miles])
         )
         mock_algolia_search(
-          vacancies_5, 5, nil,
+          vacancies5, 5, nil,
           arguments_for_algolia.merge(insidePolygon: [buffer_coordinates_twenty_five_miles])
         )
       end

--- a/spec/services/vacancy_facets_spec.rb
+++ b/spec/services/vacancy_facets_spec.rb
@@ -30,12 +30,11 @@ RSpec.describe VacancyFacets do
     let(:subject_count) { SUBJECT_OPTIONS.count }
     let(:city_count) { CITIES.count }
     let(:county_count) { COUNTIES.count }
+    let(:job_roles_subjects_cities_and_counties) { job_role_count + subject_count + city_count + county_count }
 
     it "calls Search::SearchBuilder" do
-      JOB_ROLES_SUBJECTS_CITIES_AND_COUNTIES = job_role_count + subject_count + city_count + county_count
-
       search = instance_double(Search::SearchBuilder, stats: [0, 0, 5])
-      expect(Search::SearchBuilder).to receive(:new).and_return(search).exactly(JOB_ROLES_SUBJECTS_CITIES_AND_COUNTIES).times
+      expect(Search::SearchBuilder).to receive(:new).and_return(search).exactly(job_roles_subjects_cities_and_counties).times
       subject.refresh
     end
   end

--- a/spec/sidekiq/sidekiq_spec.rb
+++ b/spec/sidekiq/sidekiq_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Sidekiq configuration" do
     files_to_exclude = [".", "..", "application_job.rb", "alert_mailer_job.rb", "performance_platform_transactions_queue_job.rb"]
     job_filenames = Dir.entries("./app/jobs/").reject { |filename| files_to_exclude.include?(filename) }
     job_classes = job_filenames.map { |filename| filename.gsub(".rb", "").camelize.constantize }
-    job_classes.reject { |job_class| job_class.class == Module }.map(&:queue_name)
+    job_classes.reject { |job_class| job_class.instance_of?(Module) }.map(&:queue_name)
   end
 
   let(:sidekiq_config) { YAML.load_file("./config/sidekiq.yml") }

--- a/spec/support/capybara_helper.rb
+++ b/spec/support/capybara_helper.rb
@@ -3,7 +3,7 @@ module CapybaraHelper
     find("h2", text: text).find("a", text: "Change").click
   end
 
-  def within_row_for(element: "label", text:, &block)
+  def within_row_for(text:, element: "label", &block)
     element = page.find(element, text: text).find(:xpath, "../..")
     within(element, &block)
   end

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -224,8 +224,7 @@ private
     expect(page.find(".vacancy")).to have_content(vacancy.salary)
     expect(page.find(".vacancy")).to have_content(vacancy.working_patterns)
     expect(page.find(".vacancy")).to have_content(vacancy.expires_on)
-    unless vacancy.expires_at.nil?
-      expect(page.find(".vacancy")).to have_content(vacancy.expires_at.strftime("%-l:%M %P"))
-    end
+
+    expect(page.find(".vacancy")).to have_content(vacancy.expires_at.strftime("%-l:%M %P")) unless vacancy.expires_at.nil?
   end
 end

--- a/spec/system/hiring_staff_can_add_stats_to_a_vacancy_spec.rb
+++ b/spec/system/hiring_staff_can_add_stats_to_a_vacancy_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 require "sanitize"
 
 RSpec.describe "Submitting effectiveness feedback on expired vacancies", js: true do
-  NOTIFICATION_BADGE_SELECTOR = "[data-test='expired-vacancies-with-feedback-outstanding']".freeze
-  JOB_TITLE_LINK_SELECTOR = "#job-title.view-vacancy-link".freeze
+  let(:notification_badge_selector) { "[data-test='expired-vacancies-with-feedback-outstanding']" }
+  let(:job_title_link_selector) { "#job-title.view-vacancy-link" }
 
   let(:school) { create(:school) }
 
@@ -27,7 +27,7 @@ RSpec.describe "Submitting effectiveness feedback on expired vacancies", js: tru
     scenario "hiring staff can see notification badge" do
       visit organisation_path
 
-      expect(page).to have_selector(NOTIFICATION_BADGE_SELECTOR, text: 3)
+      expect(page).to have_selector(notification_badge_selector, text: 3)
     end
 
     scenario "hiring staff can see notice of vacancies awaiting feedback" do
@@ -41,10 +41,10 @@ RSpec.describe "Submitting effectiveness feedback on expired vacancies", js: tru
     scenario "continously displays the number of vacancies awaiting feedback" do
       visit jobs_with_type_organisation_path(type: :awaiting_feedback)
 
-      expect(page).to have_selector(JOB_TITLE_LINK_SELECTOR, count: 3)
-      expect(page).to have_selector(JOB_TITLE_LINK_SELECTOR, text: vacancy.job_title)
-      expect(page).to have_selector(JOB_TITLE_LINK_SELECTOR, text: another_vacancy.job_title)
-      expect(page).to have_selector(JOB_TITLE_LINK_SELECTOR, text: third_vacancy.job_title)
+      expect(page).to have_selector(job_title_link_selector, count: 3)
+      expect(page).to have_selector(job_title_link_selector, text: vacancy.job_title)
+      expect(page).to have_selector(job_title_link_selector, text: another_vacancy.job_title)
+      expect(page).to have_selector(job_title_link_selector, text: third_vacancy.job_title)
 
       submit_feedback_for(vacancy)
       within("div.govuk-notification--notice") do
@@ -126,14 +126,14 @@ RSpec.describe "Submitting effectiveness feedback on expired vacancies", js: tru
     scenario "when all feedback has been submitted" do
       visit jobs_with_type_organisation_path(type: :awaiting_feedback)
 
-      expect(page).to have_selector(JOB_TITLE_LINK_SELECTOR, count: 3)
+      expect(page).to have_selector(job_title_link_selector, count: 3)
 
       submit_feedback_for(vacancy)
       submit_feedback_for(another_vacancy)
       submit_feedback_for(third_vacancy)
 
       expect(page).to_not have_content(I18n.t("jobs.awaiting_feedback_intro"))
-      expect(page).to have_selector(JOB_TITLE_LINK_SELECTOR, count: 0)
+      expect(page).to have_selector(job_title_link_selector, count: 0)
     end
 
     scenario "when adding feedback to an invalid vacancy, it saves the feedback to the model" do
@@ -154,7 +154,7 @@ RSpec.describe "Submitting effectiveness feedback on expired vacancies", js: tru
     scenario "hiring staff can not see notification badge" do
       visit jobs_with_type_organisation_path(type: :awaiting_feedback)
 
-      expect(page).to_not have_selector(NOTIFICATION_BADGE_SELECTOR)
+      expect(page).to_not have_selector(notification_badge_selector)
       expect(page).to have_content(I18n.t("jobs.no_awaiting_feedback"))
     end
   end

--- a/spec/system/hiring_staff_can_edit_a_draft_vacancy_as_a_school_group_spec.rb
+++ b/spec/system/hiring_staff_can_edit_a_draft_vacancy_as_a_school_group_spec.rb
@@ -2,15 +2,15 @@ require "rails_helper"
 
 RSpec.describe "Editing a draft vacancy" do
   let(:school_group) { create(:trust) }
-  let(:school_1) { create(:school, name: "First school") }
-  let(:school_2) { create(:school, name: "Second school") }
+  let(:school1) { create(:school, name: "First school") }
+  let(:school2) { create(:school, name: "Second school") }
   let(:oid) { SecureRandom.uuid }
   let(:vacancy) { create(:vacancy, :at_central_office, :draft) }
 
   before do
     vacancy.organisation_vacancies.create(organisation: school_group)
-    SchoolGroupMembership.find_or_create_by(school_id: school_1.id, school_group_id: school_group.id)
-    SchoolGroupMembership.find_or_create_by(school_id: school_2.id, school_group_id: school_group.id)
+    SchoolGroupMembership.find_or_create_by(school_id: school1.id, school_group_id: school_group.id)
+    SchoolGroupMembership.find_or_create_by(school_id: school2.id, school_group_id: school_group.id)
     stub_publishers_auth(uid: school_group.uid, oid: oid)
   end
 
@@ -27,30 +27,30 @@ RSpec.describe "Editing a draft vacancy" do
       change_job_location(vacancy, "at_one_school")
 
       expect(page.current_path).to eq(organisation_job_build_path(vacancy.id, :schools))
-      fill_in_school_form_field(school_1)
+      fill_in_school_form_field(school1)
       click_on I18n.t("buttons.update_job")
 
       expect(page.current_path).to eq(organisation_job_review_path(vacancy.id))
       expect(page).to have_content(I18n.t("school_groups.job_location_heading.at_one_school"))
-      expect(page).to have_content(full_address(school_1))
-      expect(Vacancy.find(vacancy.id).readable_job_location).to eq(school_1.name)
+      expect(page).to have_content(full_address(school1))
+      expect(Vacancy.find(vacancy.id).readable_job_location).to eq(school1.name)
 
       change_job_location(vacancy, "at_one_school")
 
       expect(page.current_path).to eq(organisation_job_build_path(vacancy.id, :schools))
-      fill_in_school_form_field(school_2)
+      fill_in_school_form_field(school2)
       click_on I18n.t("buttons.update_job")
 
       expect(page.current_path).to eq(organisation_job_review_path(vacancy.id))
       expect(page).to have_content(I18n.t("school_groups.job_location_heading.at_one_school"))
-      expect(page).to have_content(full_address(school_2))
-      expect(Vacancy.find(vacancy.id).readable_job_location).to eq(school_2.name)
+      expect(page).to have_content(full_address(school2))
+      expect(Vacancy.find(vacancy.id).readable_job_location).to eq(school2.name)
 
       change_job_location(vacancy, "at_multiple_schools")
 
       expect(page.current_path).to eq(organisation_job_build_path(vacancy.id, :schools))
-      check school_1.name, name: "schools_form[organisation_ids][]", visible: false
-      check school_2.name, name: "schools_form[organisation_ids][]", visible: false
+      check school1.name, name: "schools_form[organisation_ids][]", visible: false
+      check school2.name, name: "schools_form[organisation_ids][]", visible: false
       click_on I18n.t("buttons.update_job")
 
       expect(page.current_path).to eq(organisation_job_review_path(vacancy.id))

--- a/spec/system/hiring_staff_can_edit_a_published_vacancy_as_a_school_group_spec.rb
+++ b/spec/system/hiring_staff_can_edit_a_published_vacancy_as_a_school_group_spec.rb
@@ -2,15 +2,15 @@ require "rails_helper"
 
 RSpec.describe "Editing a published vacancy" do
   let(:school_group) { create(:trust) }
-  let(:school_1) { create(:school, name: "First school") }
-  let(:school_2) { create(:school, name: "Second school") }
+  let(:school1) { create(:school, name: "First school") }
+  let(:school2) { create(:school, name: "Second school") }
   let(:oid) { SecureRandom.uuid }
   let(:vacancy) { create(:vacancy, :at_central_office, :published) }
 
   before do
     vacancy.organisation_vacancies.create(organisation: school_group)
-    SchoolGroupMembership.find_or_create_by(school_id: school_1.id, school_group_id: school_group.id)
-    SchoolGroupMembership.find_or_create_by(school_id: school_2.id, school_group_id: school_group.id)
+    SchoolGroupMembership.find_or_create_by(school_id: school1.id, school_group_id: school_group.id)
+    SchoolGroupMembership.find_or_create_by(school_id: school2.id, school_group_id: school_group.id)
     stub_publishers_auth(uid: school_group.uid, oid: oid)
   end
 
@@ -27,30 +27,30 @@ RSpec.describe "Editing a published vacancy" do
       change_job_location(vacancy, "at_one_school")
 
       expect(page.current_path).to eq(organisation_job_build_path(vacancy.id, :schools))
-      fill_in_school_form_field(school_1)
+      fill_in_school_form_field(school1)
       click_on I18n.t("buttons.update_job")
 
       expect(page.current_path).to eq(edit_organisation_job_path(vacancy.id))
       expect(page).to have_content(I18n.t("school_groups.job_location_heading.at_one_school"))
-      expect(page).to have_content(full_address(school_1))
-      expect(Vacancy.find(vacancy.id).readable_job_location).to eq(school_1.name)
+      expect(page).to have_content(full_address(school1))
+      expect(Vacancy.find(vacancy.id).readable_job_location).to eq(school1.name)
 
       change_job_location(vacancy, "at_one_school")
 
       expect(page.current_path).to eq(organisation_job_build_path(vacancy.id, :schools))
-      fill_in_school_form_field(school_2)
+      fill_in_school_form_field(school2)
       click_on I18n.t("buttons.update_job")
 
       expect(page.current_path).to eq(edit_organisation_job_path(vacancy.id))
       expect(page).to have_content(I18n.t("school_groups.job_location_heading.at_one_school"))
-      expect(page).to have_content(full_address(school_2))
-      expect(Vacancy.find(vacancy.id).readable_job_location).to eq(school_2.name)
+      expect(page).to have_content(full_address(school2))
+      expect(Vacancy.find(vacancy.id).readable_job_location).to eq(school2.name)
 
       change_job_location(vacancy, "at_multiple_schools")
 
       expect(page.current_path).to eq(organisation_job_build_path(vacancy.id, :schools))
-      check school_1.name, name: "schools_form[organisation_ids][]", visible: false
-      check school_2.name, name: "schools_form[organisation_ids][]", visible: false
+      check school1.name, name: "schools_form[organisation_ids][]", visible: false
+      check school2.name, name: "schools_form[organisation_ids][]", visible: false
       click_on I18n.t("buttons.update_job")
 
       expect(page.current_path).to eq(edit_organisation_job_path(vacancy.id))
@@ -91,13 +91,13 @@ RSpec.describe "Editing a published vacancy" do
 
         change_job_location(vacancy, "at_one_school")
         expect(page.current_path).to eq(organisation_job_build_path(vacancy.id, :schools))
-        fill_in_school_form_field(school_2)
+        fill_in_school_form_field(school2)
         click_on I18n.t("buttons.update_job")
 
         expect(page.current_path).to eq(edit_organisation_job_path(vacancy.id))
         expect(page).to have_content(I18n.t("school_groups.job_location_heading.at_one_school"))
-        expect(page).to have_content(full_address(school_2))
-        expect(Vacancy.find(vacancy.id).readable_job_location).to eq(school_2.name)
+        expect(page).to have_content(full_address(school2))
+        expect(Vacancy.find(vacancy.id).readable_job_location).to eq(school2.name)
       end
     end
   end

--- a/spec/system/hiring_staff_can_filter_vacancies_in_their_dashboard_spec.rb
+++ b/spec/system/hiring_staff_can_filter_vacancies_in_their_dashboard_spec.rb
@@ -2,21 +2,21 @@ require "rails_helper"
 
 RSpec.describe "Hiring staff can filter vacancies in their dashboard" do
   let(:school_group) { create(:trust) }
-  let(:school_1) { create(:school, name: "Happy Rainbows School") }
-  let(:school_2) { create(:school, name: "Dreary Grey School") }
+  let(:school1) { create(:school, name: "Happy Rainbows School") }
+  let(:school2) { create(:school, name: "Dreary Grey School") }
   let!(:school_group_vacancy) { create(:vacancy, :published, :at_central_office) }
-  let!(:school_1_vacancy) { create(:vacancy, :published, :at_one_school) }
-  let!(:school_1_draft_vacancy) { create(:vacancy, :draft, :at_one_school) }
-  let!(:school_2_draft_vacancy) { create(:vacancy, :draft, :at_one_school) }
+  let!(:school1_vacancy) { create(:vacancy, :published, :at_one_school) }
+  let!(:school1_draft_vacancy) { create(:vacancy, :draft, :at_one_school) }
+  let!(:school2_draft_vacancy) { create(:vacancy, :draft, :at_one_school) }
 
   before do
     school_group_vacancy.organisation_vacancies.create(organisation: school_group)
-    school_1_vacancy.organisation_vacancies.create(organisation: school_1)
-    school_1_draft_vacancy.organisation_vacancies.create(organisation: school_1)
-    school_2_draft_vacancy.organisation_vacancies.create(organisation: school_2)
+    school1_vacancy.organisation_vacancies.create(organisation: school1)
+    school1_draft_vacancy.organisation_vacancies.create(organisation: school1)
+    school2_draft_vacancy.organisation_vacancies.create(organisation: school2)
 
-    SchoolGroupMembership.find_or_create_by(school_id: school_1.id, school_group_id: school_group.id)
-    SchoolGroupMembership.find_or_create_by(school_id: school_2.id, school_group_id: school_group.id)
+    SchoolGroupMembership.find_or_create_by(school_id: school1.id, school_group_id: school_group.id)
+    SchoolGroupMembership.find_or_create_by(school_id: school2.id, school_group_id: school_group.id)
 
     stub_accepted_terms_and_conditions
     OmniAuth.config.test_mode = true
@@ -52,9 +52,9 @@ RSpec.describe "Hiring staff can filter vacancies in their dashboard" do
         expect(page).to have_content("Showing all jobs")
 
         expect(page).to have_content(school_group_vacancy.job_title)
-        expect(page).to have_content(school_1_vacancy.job_title)
-        expect(page).to_not have_content(school_1_draft_vacancy.job_title)
-        expect(page).to_not have_content(school_2_draft_vacancy.job_title)
+        expect(page).to have_content(school1_vacancy.job_title)
+        expect(page).to_not have_content(school1_draft_vacancy.job_title)
+        expect(page).to_not have_content(school2_draft_vacancy.job_title)
       end
 
       context "when applying filters" do
@@ -68,9 +68,9 @@ RSpec.describe "Hiring staff can filter vacancies in their dashboard" do
           expect(page).to have_content("1 filter applied")
 
           expect(page).to_not have_content(school_group_vacancy.job_title)
-          expect(page).to have_content(school_1_vacancy.job_title)
-          expect(page).to_not have_content(school_1_draft_vacancy.job_title)
-          expect(page).to_not have_content(school_2_draft_vacancy.job_title)
+          expect(page).to have_content(school1_vacancy.job_title)
+          expect(page).to_not have_content(school1_draft_vacancy.job_title)
+          expect(page).to_not have_content(school2_draft_vacancy.job_title)
         end
       end
     end
@@ -83,9 +83,9 @@ RSpec.describe "Hiring staff can filter vacancies in their dashboard" do
         expect(page).to have_content("Showing all jobs")
 
         expect(page).to_not have_content(school_group_vacancy.job_title)
-        expect(page).to_not have_content(school_1_vacancy.job_title)
-        expect(page).to have_content(school_1_draft_vacancy.job_title)
-        expect(page).to have_content(school_2_draft_vacancy.job_title)
+        expect(page).to_not have_content(school1_vacancy.job_title)
+        expect(page).to have_content(school1_draft_vacancy.job_title)
+        expect(page).to have_content(school2_draft_vacancy.job_title)
       end
     end
   end
@@ -101,15 +101,15 @@ RSpec.describe "Hiring staff can filter vacancies in their dashboard" do
       expect(page).to have_content("1 filter applied")
 
       expect(page).to have_content(school_group_vacancy.job_title)
-      expect(page).to_not have_content(school_1_vacancy.job_title)
-      expect(page).to_not have_content(school_1_draft_vacancy.job_title)
-      expect(page).to_not have_content(school_2_draft_vacancy.job_title)
+      expect(page).to_not have_content(school1_vacancy.job_title)
+      expect(page).to_not have_content(school1_draft_vacancy.job_title)
+      expect(page).to_not have_content(school2_draft_vacancy.job_title)
     end
   end
 
   context "when managed_school_ids is not empty" do
     let(:managed_organisations) { "" }
-    let(:managed_school_ids) { [school_1.id, school_2.id] }
+    let(:managed_school_ids) { [school1.id, school2.id] }
 
     scenario "it shows filtered published vacancies" do
       visit organisation_path
@@ -118,9 +118,9 @@ RSpec.describe "Hiring staff can filter vacancies in their dashboard" do
       expect(page).to have_content("2 filters applied")
 
       expect(page).to_not have_content(school_group_vacancy.job_title)
-      expect(page).to have_content(school_1_vacancy.job_title)
-      expect(page).to_not have_content(school_1_draft_vacancy.job_title)
-      expect(page).to_not have_content(school_2_draft_vacancy.job_title)
+      expect(page).to have_content(school1_vacancy.job_title)
+      expect(page).to_not have_content(school1_draft_vacancy.job_title)
+      expect(page).to_not have_content(school2_draft_vacancy.job_title)
     end
   end
 end

--- a/spec/system/hiring_staff_can_manage_schools_in_school_group_spec.rb
+++ b/spec/system/hiring_staff_can_manage_schools_in_school_group_spec.rb
@@ -25,7 +25,7 @@ RSpec.shared_examples "a successful edit" do
     expect(page).to have_content("https://www.this-is-a-test-url.tvs")
     expect(page.current_path).to eq(organisation_schools_path)
 
-    visit edit_organisation_school_path(school_1)
+    visit edit_organisation_school_path(school1)
 
     fill_in "organisation_form[description]", with: "New description of the school"
     fill_in "organisation_form[website]", with: "https://www.this-is-a-test-url.tvs"
@@ -33,25 +33,25 @@ RSpec.shared_examples "a successful edit" do
 
     expect(page).to have_content("New description of the school")
     expect(page).to have_content("https://www.this-is-a-test-url.tvs")
-    expect(page).to have_content("Details updated for #{school_1.name}")
+    expect(page).to have_content("Details updated for #{school1.name}")
     expect(page.current_path).to eq(organisation_schools_path)
   end
 end
 
 RSpec.describe "Schools in your school group" do
-  let(:school_1) { create(:school) }
-  let(:school_2) { create(:school) }
-  let(:school_3) { create(:school) }
-  let(:school_4) { create(:school, :closed, name: "Closed school") }
+  let(:school1) { create(:school) }
+  let(:school2) { create(:school) }
+  let(:school3) { create(:school) }
+  let(:school4) { create(:school, :closed, name: "Closed school") }
 
   before do
     allow(LocalAuthorityAccessFeature).to receive(:enabled?).and_return(true)
     allow(ALLOWED_LOCAL_AUTHORITIES).to receive(:include?).with(school_group.local_authority_code).and_return(true)
 
-    SchoolGroupMembership.find_or_create_by(school_id: school_1.id, school_group_id: school_group.id)
-    SchoolGroupMembership.find_or_create_by(school_id: school_2.id, school_group_id: school_group.id)
-    SchoolGroupMembership.find_or_create_by(school_id: school_3.id, school_group_id: school_group.id)
-    SchoolGroupMembership.find_or_create_by(school_id: school_4.id, school_group_id: school_group.id)
+    SchoolGroupMembership.find_or_create_by(school_id: school1.id, school_group_id: school_group.id)
+    SchoolGroupMembership.find_or_create_by(school_id: school2.id, school_group_id: school_group.id)
+    SchoolGroupMembership.find_or_create_by(school_id: school3.id, school_group_id: school_group.id)
+    SchoolGroupMembership.find_or_create_by(school_id: school4.id, school_group_id: school_group.id)
 
     stub_accepted_terms_and_conditions
     OmniAuth.config.test_mode = true

--- a/spec/system/hiring_staff_can_publish_a_vacancy_as_a_local_authority_spec.rb
+++ b/spec/system/hiring_staff_can_publish_a_vacancy_as_a_local_authority_spec.rb
@@ -2,15 +2,15 @@ require "rails_helper"
 
 RSpec.describe "Creating a vacancy" do
   let(:school_group) { create(:local_authority) }
-  let(:school_1) { create(:school, name: "First school") }
-  let(:school_2) { create(:school, name: "Second school") }
+  let(:school1) { create(:school, name: "First school") }
+  let(:school2) { create(:school, name: "Second school") }
   let(:oid) { SecureRandom.uuid }
   let(:vacancy) { build(:vacancy, :at_one_school, :complete) }
 
   before do
     allow(LocalAuthorityAccessFeature).to receive(:enabled?).and_return(true)
-    SchoolGroupMembership.find_or_create_by(school_id: school_1.id, school_group_id: school_group.id)
-    SchoolGroupMembership.find_or_create_by(school_id: school_2.id, school_group_id: school_group.id)
+    SchoolGroupMembership.find_or_create_by(school_id: school1.id, school_group_id: school_group.id)
+    SchoolGroupMembership.find_or_create_by(school_id: school2.id, school_group_id: school_group.id)
     allow(PublisherPreference).to receive(:find_by).and_return(instance_double(PublisherPreference))
     stub_publishers_auth(la_code: school_group.local_authority_code, oid: oid)
   end
@@ -58,7 +58,7 @@ RSpec.describe "Creating a vacancy" do
           expect(page).to have_content(I18n.t("schools_errors.organisation_ids.blank"))
         end
 
-        fill_in_school_form_field(school_2)
+        fill_in_school_form_field(school2)
         click_on I18n.t("buttons.continue")
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 8))
@@ -90,7 +90,7 @@ RSpec.describe "Creating a vacancy" do
           expect(page).to have_content(I18n.t("jobs.job_location"))
         end
 
-        check school_1.name, name: "schools_form[organisation_ids][]", visible: false
+        check school1.name, name: "schools_form[organisation_ids][]", visible: false
         click_on I18n.t("buttons.continue")
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 8))
@@ -101,8 +101,8 @@ RSpec.describe "Creating a vacancy" do
           expect(page).to have_content(I18n.t("schools_errors.organisation_ids.invalid"))
         end
 
-        check school_1.name, name: "schools_form[organisation_ids][]", visible: false
-        check school_2.name, name: "schools_form[organisation_ids][]", visible: false
+        check school1.name, name: "schools_form[organisation_ids][]", visible: false
+        check school2.name, name: "schools_form[organisation_ids][]", visible: false
         click_on I18n.t("buttons.continue")
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 8))

--- a/spec/system/hiring_staff_can_publish_a_vacancy_as_a_trust_spec.rb
+++ b/spec/system/hiring_staff_can_publish_a_vacancy_as_a_trust_spec.rb
@@ -2,16 +2,16 @@ require "rails_helper"
 
 RSpec.describe "Creating a vacancy" do
   let(:school_group) { create(:trust) }
-  let(:school_1) { create(:school, name: "First school") }
-  let(:school_2) { create(:school, name: "Second school") }
-  let(:school_3) { create(:school, :closed, name: "Closed school") }
+  let(:school1) { create(:school, name: "First school") }
+  let(:school2) { create(:school, name: "Second school") }
+  let(:school3) { create(:school, :closed, name: "Closed school") }
   let(:oid) { SecureRandom.uuid }
   let(:vacancy) { build(:vacancy, :at_central_office, :complete) }
 
   before do
-    SchoolGroupMembership.find_or_create_by(school_id: school_1.id, school_group_id: school_group.id)
-    SchoolGroupMembership.find_or_create_by(school_id: school_2.id, school_group_id: school_group.id)
-    SchoolGroupMembership.find_or_create_by(school_id: school_3.id, school_group_id: school_group.id)
+    SchoolGroupMembership.find_or_create_by(school_id: school1.id, school_group_id: school_group.id)
+    SchoolGroupMembership.find_or_create_by(school_id: school2.id, school_group_id: school_group.id)
+    SchoolGroupMembership.find_or_create_by(school_id: school3.id, school_group_id: school_group.id)
     allow(PublisherPreference).to receive(:find_by).and_return(instance_double(PublisherPreference))
     stub_publishers_auth(uid: school_group.uid, oid: oid)
   end
@@ -83,7 +83,7 @@ RSpec.describe "Creating a vacancy" do
           expect(page).to have_content(I18n.t("schools_errors.organisation_ids.blank"))
         end
 
-        fill_in_school_form_field(school_2)
+        fill_in_school_form_field(school2)
         click_on I18n.t("buttons.continue")
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 8))
@@ -115,7 +115,7 @@ RSpec.describe "Creating a vacancy" do
           expect(page).to have_content(I18n.t("jobs.job_location"))
         end
 
-        check school_1.name, name: "schools_form[organisation_ids][]", visible: false
+        check school1.name, name: "schools_form[organisation_ids][]", visible: false
         click_on I18n.t("buttons.continue")
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 8))
@@ -126,8 +126,8 @@ RSpec.describe "Creating a vacancy" do
           expect(page).to have_content(I18n.t("schools_errors.organisation_ids.invalid"))
         end
 
-        check school_1.name, name: "schools_form[organisation_ids][]", visible: false
-        check school_2.name, name: "schools_form[organisation_ids][]", visible: false
+        check school1.name, name: "schools_form[organisation_ids][]", visible: false
+        check school2.name, name: "schools_form[organisation_ids][]", visible: false
         click_on I18n.t("buttons.continue")
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 8))

--- a/spec/system/hiring_staff_can_set_managed_organisations_user_preferences_spec.rb
+++ b/spec/system/hiring_staff_can_set_managed_organisations_user_preferences_spec.rb
@@ -1,18 +1,18 @@
 require "rails_helper"
 
 RSpec.describe "Hiring staff can set managed organisations user preferences" do
-  let(:school_1) { create(:school, name: "Happy Rainbows School") }
-  let(:school_2) { create(:school, name: "Dreary Grey School") }
-  let(:school_3) { create(:school, :closed, name: "Closed School") }
+  let(:school1) { create(:school, name: "Happy Rainbows School") }
+  let(:school2) { create(:school, name: "Dreary Grey School") }
+  let(:school3) { create(:school, :closed, name: "Closed School") }
   let(:publisher_preference) { PublisherPreference.last }
 
   before do
     allow(LocalAuthorityAccessFeature).to receive(:enabled?).and_return(true)
     allow(ALLOWED_LOCAL_AUTHORITIES).to receive(:include?).with(school_group.local_authority_code).and_return(true)
 
-    SchoolGroupMembership.find_or_create_by(school_id: school_1.id, school_group_id: school_group.id)
-    SchoolGroupMembership.find_or_create_by(school_id: school_2.id, school_group_id: school_group.id)
-    SchoolGroupMembership.find_or_create_by(school_id: school_3.id, school_group_id: school_group.id)
+    SchoolGroupMembership.find_or_create_by(school_id: school1.id, school_group_id: school_group.id)
+    SchoolGroupMembership.find_or_create_by(school_id: school2.id, school_group_id: school_group.id)
+    SchoolGroupMembership.find_or_create_by(school_id: school3.id, school_group_id: school_group.id)
 
     stub_accepted_terms_and_conditions
     OmniAuth.config.test_mode = true
@@ -43,7 +43,7 @@ RSpec.describe "Hiring staff can set managed organisations user preferences" do
     scenario "it does not show closed school option" do
       visit organisation_managed_organisations_path
       expect(page.current_path).to eq(organisation_managed_organisations_path)
-      expect(page).not_to have_content(school_3.name)
+      expect(page).not_to have_content(school3.name)
     end
 
     scenario "it allows school group users to select which organisation's jobs they want to manage" do
@@ -55,12 +55,12 @@ RSpec.describe "Hiring staff can set managed organisations user preferences" do
 
       check I18n.t("publishers.organisations.managed_organisations.show.options.school_group"),
             name: "managed_organisations_form[managed_school_ids][]", visible: false
-      check school_1.name, name: "managed_organisations_form[managed_school_ids][]", visible: false
+      check school1.name, name: "managed_organisations_form[managed_school_ids][]", visible: false
 
       click_on I18n.t("buttons.continue")
 
       expect(page.current_path).to eq(organisation_path)
-      expect(publisher_preference.managed_school_ids).to eq([school_group.id, school_1.id])
+      expect(publisher_preference.managed_school_ids).to eq([school_group.id, school1.id])
     end
 
     scenario "it allows school group users to select to manage all jobs" do
@@ -72,7 +72,7 @@ RSpec.describe "Hiring staff can set managed organisations user preferences" do
 
       check I18n.t("publishers.organisations.managed_organisations.show.options.all"),
             name: "managed_organisations_form[managed_organisations][]", visible: false
-      check school_1.name, name: "managed_organisations_form[managed_school_ids][]", visible: false
+      check school1.name, name: "managed_organisations_form[managed_school_ids][]", visible: false
 
       click_on I18n.t("buttons.continue")
 

--- a/spec/system/jobseekers_can_manage_their_saved_jobs_spec.rb
+++ b/spec/system/jobseekers_can_manage_their_saved_jobs_spec.rb
@@ -14,17 +14,17 @@ RSpec.describe "Jobseekers can manage their saved jobs" do
 
     context "when there are saved jobs" do
       let(:school) { create(:school) }
-      let(:vacancy_1) { create(:vacancy) }
-      let(:vacancy_2) { create(:vacancy) }
+      let(:vacancy1) { create(:vacancy) }
+      let(:vacancy2) { create(:vacancy) }
       let(:expired_vacancy) { create(:vacancy, :expired) }
 
       before do
-        vacancy_1.organisation_vacancies.create(organisation: school)
-        vacancy_2.organisation_vacancies.create(organisation: school)
+        vacancy1.organisation_vacancies.create(organisation: school)
+        vacancy2.organisation_vacancies.create(organisation: school)
         expired_vacancy.organisation_vacancies.create(organisation: school)
 
-        jobseeker.saved_jobs.create(vacancy: vacancy_1)
-        jobseeker.saved_jobs.create(vacancy: vacancy_2)
+        jobseeker.saved_jobs.create(vacancy: vacancy1)
+        jobseeker.saved_jobs.create(vacancy: vacancy2)
         jobseeker.saved_jobs.create(vacancy: expired_vacancy)
 
         visit jobseekers_saved_jobs_path
@@ -33,17 +33,17 @@ RSpec.describe "Jobseekers can manage their saved jobs" do
       context "when the jobseeker views saved jobs" do
         it "shows saved jobs" do
           expect(page).to have_content(I18n.t("jobseekers.saved_jobs.index.page_title"))
-          expect(page).to have_content(vacancy_1.job_title)
-          expect(page).to have_content(vacancy_2.job_title)
+          expect(page).to have_content(vacancy1.job_title)
+          expect(page).to have_content(vacancy2.job_title)
           expect(page).to have_content(expired_vacancy.job_title)
         end
 
         it "renders deadline passed label for expired jobs" do
-          within "tr[data-slug='#{vacancy_1.slug}']" do
+          within "tr[data-slug='#{vacancy1.slug}']" do
             expect(page).not_to have_content(I18n.t("jobseekers.saved_jobs.index.deadline_passed"))
           end
 
-          within "tr[data-slug='#{vacancy_2.slug}']" do
+          within "tr[data-slug='#{vacancy2.slug}']" do
             expect(page).not_to have_content(I18n.t("jobseekers.saved_jobs.index.deadline_passed"))
           end
 
@@ -55,7 +55,7 @@ RSpec.describe "Jobseekers can manage their saved jobs" do
 
       context "when the jobseeker deletes a saved job" do
         before do
-          within "tr[data-slug='#{vacancy_1.slug}']" do
+          within "tr[data-slug='#{vacancy1.slug}']" do
             click_on "Delete"
           end
         end
@@ -63,8 +63,8 @@ RSpec.describe "Jobseekers can manage their saved jobs" do
         it "deletes the saved job and redirects to the dashboard" do
           expect(page).to have_content(I18n.t("jobseekers.saved_jobs.index.page_title"))
           expect(page).to have_content(I18n.t("jobseekers.saved_jobs.destroy.success"))
-          expect(page).not_to have_content(vacancy_1.job_title)
-          expect(page).to have_content(vacancy_2.job_title)
+          expect(page).not_to have_content(vacancy1.job_title)
+          expect(page).to have_content(vacancy2.job_title)
           expect(page).to have_content(expired_vacancy.job_title)
         end
       end


### PR DESCRIPTION
We were using `rubocop-govuk`, but it moves very slowly and is somewhat
GDS-specific, catering for idiosyncracies specific to their apps. We
should move closer to the Ruby community styleguide, with a handful of
overrides for rules where as a team we agree to deviate.

- Autocorrect all autocorrectable offences
- Manually correct the following offences:
  - Lint/ConstantDefinitionInBlock: Constants should not be defined
    inside blocks (replacing them with appropriate `let`s)
  - Lint/EmptyBlock: Empty block detected
  - Lint/TopLevelReturnWithArgument: Top-level return statements cannot
    have arguments
  - Naming/VariableNumber: Use normalcase for symbol numbers
  - Style/GuardClause: Use a guard clause instead of wrapping code inside
    a conditional expression.
  - Style/HashLikeCase: case-when represents a simple 1:1 mapping and can
    be replaced with a hash lookup
  - Style/OptionalBooleanParameter: Use keyword arguments when defining
    method with boolean argument
- Other refactorings:
  - Rename `Publishers::SignIn::Dfe::SessionsController#user_category` to
    `#publisher_category` for consistency

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1812