### PR TITLE
Make auth not clear rest of session

### DIFF
--- a/app/controllers/publishers/sign_in/base_sessions_controller.rb
+++ b/app/controllers/publishers/sign_in/base_sessions_controller.rb
@@ -1,4 +1,13 @@
 class Publishers::SignIn::BaseSessionsController < Publishers::BaseController
+  PUBLISHER_SESSION_KEYS = %i[
+    publisher_id_token
+    publisher_oid
+    publisher_multiple_organisations
+    organisation_urn
+    organisation_uid
+    organisation_la_code
+  ].freeze
+
   skip_before_action :authenticate_publisher!
   before_action :sign_out_jobseeker!, only: %i[create]
 
@@ -8,11 +17,15 @@ class Publishers::SignIn::BaseSessionsController < Publishers::BaseController
                     else
                       { success: t("messages.access.publisher_signed_out") }
                     end
-    session.destroy
+    clear_publisher_session!
     redirect_to new_identifications_path, flash_message
   end
 
 private
+
+  def clear_publisher_session!
+    PUBLISHER_SESSION_KEYS.each { |key| session.delete(key) }
+  end
 
   def sign_out_jobseeker!
     sign_out(:jobseeker)

--- a/app/controllers/publishers/sign_in/email/sessions_controller.rb
+++ b/app/controllers/publishers/sign_in/email/sessions_controller.rb
@@ -30,7 +30,7 @@ class Publishers::SignIn::Email::SessionsController < Publishers::SignIn::BaseSe
 
   def change_organisation
     key = generate_login_key(publisher: current_publisher)
-    session.destroy
+    clear_publisher_session!
     redirect_to auth_email_choose_organisation_path(login_key: key.id)
   end
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -253,7 +253,10 @@ Devise.setup do |config|
 
   # Set this configuration to false if you want /users/sign_out to sign out
   # only the current scope. By default, Devise signs out all scopes.
-  # config.sign_out_all_scopes = true
+  # IMPORTANT: This is needed for us to persist non-user-related data in the session
+  #   when logging out (such as A/B tests which are stored in `session[:ab_tests]`).
+  #   If this were set to true, Warden will nuke the *entire* session on logout.
+  config.sign_out_all_scopes = false
 
   # ==> Navigation configuration
   # Lists the formats that should be treated as navigational. Formats like

--- a/spec/controllers/jobseekers/sessions_controller_spec.rb
+++ b/spec/controllers/jobseekers/sessions_controller_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe Jobseekers::SessionsController, type: :controller do
+  context "unrelated session contents" do
+    let(:unrelated_session_contents) { { keep_me: { foo: "bar" } }.stringify_keys }
+
+    let(:credentials) { { email: "test@example.com", password: "password" } }
+    let!(:jobseeker) { Jobseeker.create(credentials) }
+
+    before do
+      # Required to test Devise controller independently of routing
+      @request.env["devise.mapping"] = Devise.mappings[:jobseeker]
+
+      jobseeker.confirm
+
+      session.merge!(unrelated_session_contents)
+    end
+
+    describe "#create" do
+      it "does not clear unrelated session contents" do
+        post :create, params: { jobseeker: credentials }
+
+        expect(session).to include(*unrelated_session_contents.keys)
+      end
+    end
+
+    describe "#destroy" do
+      before do
+        sign_in jobseeker
+      end
+
+      it "does not clear unrelated session contents" do
+        delete :destroy
+
+        expect(session).to include(*unrelated_session_contents.keys)
+      end
+    end
+  end
+end

--- a/spec/controllers/publishers/sign_in/dfe/sessions_controller_spec.rb
+++ b/spec/controllers/publishers/sign_in/dfe/sessions_controller_spec.rb
@@ -2,10 +2,39 @@ require "rails_helper"
 
 RSpec.describe Publishers::SignIn::Dfe::SessionsController, type: :controller do
   describe "#new" do
-    before { allow(AuthenticationFallback).to receive(:enabled?).and_return(false) }
+    before do
+      allow(AuthenticationFallback).to receive(:enabled?).and_return(false)
+    end
+
     it "redirects to Dfe" do
       get :new
       expect(response).to redirect_to("/auth/dfe") # From here we trust Omniauth
+    end
+  end
+
+  describe "#destroy" do
+    let(:publisher_session_contents) do
+      {
+        publisher_oid: "foo",
+        organisation_urn: "foo",
+        organisation_uid: "foo",
+        organisation_la_code: "foo",
+        publisher_multiple_organisations: "foo",
+        publisher_id_token: "foo",
+      }.stringify_keys
+    end
+    let(:unrelated_session_contents) { { keep_me: { foo: "bar" } }.stringify_keys }
+
+    before do
+      session.merge!(publisher_session_contents)
+      session.merge!(unrelated_session_contents)
+    end
+
+    it "logs the publisher out but keeps the rest of the session intact" do
+      get :destroy
+
+      expect(session).not_to include(*publisher_session_contents.keys)
+      expect(session).to include(*unrelated_session_contents.keys)
     end
   end
 end


### PR DESCRIPTION
We will occasionally want to persist parts of the session that are
unrelated to authentication when a user signs in/out, such as A/B tests.

- Change publisher auth to only clear the parts of the session it owns
- Disable Devise's `sign_out_all_scopes` to prevent Warden from nuking
  the session on signing out
- Add tests and comments to make sure it doesn't get accidentally turned
  off

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1443