### PR TITLE
[TEVA-1650]   TEVA-1650  'Ilford' should search in London area, not village in Devon

### DIFF
--- a/app/models/location_category.rb
+++ b/app/models/location_category.rb
@@ -1,5 +1,5 @@
 class LocationCategory
   def self.include?(location)
-    ALL_LOCATION_CATEGORIES.include?((MAPPED_LOCATIONS[location.downcase].presence || location).downcase)
+    ALL_LOCATION_CATEGORIES.include?((MAPPED_POLYGON_LOCATIONS[location.downcase].presence || location).downcase)
   end
 end

--- a/app/models/location_polygon.rb
+++ b/app/models/location_polygon.rb
@@ -5,6 +5,6 @@ class LocationPolygon < ApplicationRecord
   scope :regions, -> { where(location_type: "regions") }
 
   def self.with_name(location)
-    find_by(name: (MAPPED_LOCATIONS[location.downcase].presence || location).downcase)
+    find_by(name: (MAPPED_POLYGON_LOCATIONS[location.downcase].presence || location).downcase)
   end
 end

--- a/app/services/search/location_builder.rb
+++ b/app/services/search/location_builder.rb
@@ -10,7 +10,7 @@ class Search::LocationBuilder
               :location_polygon, :search_polygon_boundary, :missing_polygon, :radius, :buffer_radius
 
   def initialize(location, radius, location_category, buffer_radius)
-    @location = location || location_category
+    @location = MAPPED_POINT_LOCATIONS[location] || location || location_category
     @radius = (radius || DEFAULT_RADIUS).to_i
     @buffer_radius = buffer_radius
     @location_filter = {}

--- a/config/initializers/location_data.rb
+++ b/config/initializers/location_data.rb
@@ -31,4 +31,6 @@ LOCATION_POLYGON_SETTINGS = {
   },
 }.freeze
 
-MAPPED_LOCATIONS = YAML.load_file(base_path.join("mapped_locations.yml")).to_h
+MAPPED_POLYGON_LOCATIONS = YAML.load_file(base_path.join("mapped_polygon_locations.yml")).to_h
+
+MAPPED_POINT_LOCATIONS = YAML.load_file(base_path.join("mapped_point_locations.yml")).to_h

--- a/lib/tasks/data/mapped_point_locations.yml
+++ b/lib/tasks/data/mapped_point_locations.yml
@@ -1,0 +1,3 @@
+---
+- ['ilford', 'ilford, london']
+

--- a/lib/tasks/data/mapped_polygon_locations.yml
+++ b/lib/tasks/data/mapped_polygon_locations.yml
@@ -35,7 +35,6 @@
 - ['haringey, london', 'haringey']
 - ['herefordshire', 'herefordshire, county of']
 - ['hull', 'kingston upon hull']
-- ['ilford', 'ilford, london']
 - ['islington, london', 'islington']
 - ['isle of wight, newport', 'isle of wight']
 - ['kensington', 'kensington and chelsea']

--- a/lib/tasks/data/mapped_polygon_locations.yml
+++ b/lib/tasks/data/mapped_polygon_locations.yml
@@ -35,6 +35,7 @@
 - ['haringey, london', 'haringey']
 - ['herefordshire', 'herefordshire, county of']
 - ['hull', 'kingston upon hull']
+- ['ilford', 'ilford, london']
 - ['islington, london', 'islington']
 - ['isle of wight, newport', 'isle of wight']
 - ['kensington', 'kensington and chelsea']

--- a/spec/services/search/location_builder_spec.rb
+++ b/spec/services/search/location_builder_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Search::LocationBuilder do
       end
     end
 
-    context "when a mapped location is specified" do
+    context "when a mapped polygon location is specified" do
       let(:location) { "Map this location" }
 
       before do
@@ -67,6 +67,26 @@ RSpec.describe Search::LocationBuilder do
       end
 
       it_behaves_like "a search using polygons", location: "Map this location"
+    end
+
+    context "when a mapped point location is specified" do
+      let(:location) { "ilford" }
+      let(:radius) { 10 }
+      let(:expected_radius) { 16_093 }
+
+      before do
+        stub_const("MAPPED_POINT_LOCATIONS", { "ilford" => "ilford, london" })
+      end
+
+      it "sets location to the new mapped location name" do
+        expect(subject.location_category).to be nil
+        expect(subject.location_polygon).to be nil
+        expect(subject.location).to eq("ilford, london")
+        expect(subject.location_filter).to eq({
+          point_coordinates: Geocoder::DEFAULT_STUB_COORDINATES,
+          radius: expected_radius,
+        })
+      end
     end
 
     context "when a non-polygonable location is specified" do

--- a/spec/services/search/location_builder_spec.rb
+++ b/spec/services/search/location_builder_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Search::LocationBuilder do
       let(:location) { "Map this location" }
 
       before do
-        allow(MAPPED_LOCATIONS).to receive(:[]).with(location.downcase).and_return(location_polygon.name)
+        allow(MAPPED_POLYGON_LOCATIONS).to receive(:[]).with(location.downcase).and_return(location_polygon.name)
       end
 
       it_behaves_like "a search using polygons", location: "Map this location"


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1650

## Changes in this PR:

- Created a new mapped_point_locations.yml file and changed existing mapped_locations.yml file to mapped_polygon_locations.yml. 
- Created new MAPPED_POLYGON_LOCATION and MAPPED_POINT_LOCATIONS constants
- Updated references

`[6] pry(main)> MAPPED_POINT_LOCATIONS['ilford']
=> "ilford, london"
[7] pry(main)> Geocoding.new("ilford, london").coordinates
=> [51.557609801634506, 0.073491794712767]`

<img width="732" alt="Screenshot 2021-01-11 at 16 19 28" src="https://user-images.githubusercontent.com/30624173/104208828-dc841200-5428-11eb-8265-2835c7058d72.png">


## Questions:

- How does everyone feel about this? Splitting point location mapping out into another file seemed to make sense to me, but I wonder what everyone else thinks? 
- Not sure of `map_location_with_incorrect_coordinates` as a method name
