### PR TITLE
Refactor publisher vacancies sorting options

### DIFF
--- a/app/components/publishers/vacancies_component.rb
+++ b/app/components/publishers/vacancies_component.rb
@@ -27,7 +27,7 @@ class Publishers::VacanciesComponent < ViewComponent::Base
   end
 
   def vacancy_sort_options
-    Organisation::JOB_SORTING_OPTIONS[@selected_type]
+    Publishers::VacancySortingOptions.new(@organisation, @selected_type)
   end
 
   def heading

--- a/app/components/publishers/vacancies_component/vacancies_component.html.slim
+++ b/app/components/publishers/vacancies_component/vacancies_component.html.slim
@@ -12,8 +12,8 @@
             = form_for @sort_form, as: "", url: jobs_with_type_organisation_path(@selected_type), id: "jobs_sort_form", html: { data: { 'auto-submit': true }, class: "sort-inline" }, method: :get do |f|
               = f.govuk_collection_select :sort_column,
                 vacancy_sort_options,
-                :last,
-                :first,
+                :column,
+                :display_name,
                 label: { text: t("jobs.sort_by.label"), size: "s", class: "govuk-label inline govuk-!-margin-right-2" }
 
               = f.govuk_submit t("jobs.sort_by.submit")

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -10,21 +10,6 @@ class Organisation < ApplicationRecord
 
   alias_attribute :data, :gias_data
 
-  JOB_SORTING_OPTIONS_BASE = [
-    [I18n.t("jobs.sort_by.expires_on.ascending"), "expires_on"],
-    [I18n.t("jobs.sort_by.job_title.ascending"), "job_title"],
-    [I18n.t("jobs.sort_by.location.ascending"), "readable_job_location"],
-  ].freeze
-
-  JOB_SORTING_OPTIONS_EXTENDED = (JOB_SORTING_OPTIONS_BASE + [I18n.t("jobs.sort_by.published_date.ascending"), "publish_on"]).freeze
-
-  JOB_SORTING_OPTIONS = {
-    published: JOB_SORTING_OPTIONS_BASE,
-    pending: JOB_SORTING_OPTIONS_EXTENDED,
-    draft: JOB_SORTING_OPTIONS_EXTENDED,
-    expired: JOB_SORTING_OPTIONS_BASE,
-  }.freeze
-
   def all_vacancies
     ids = is_a?(School) ? [id] : [id] + schools.pluck(:id)
     Vacancy.in_organisation_ids(ids)

--- a/app/services/publishers/vacancy_sorting_options.rb
+++ b/app/services/publishers/vacancy_sorting_options.rb
@@ -1,0 +1,36 @@
+class Publishers::VacancySortingOptions
+  SortOption = Struct.new(:column, :display_name)
+
+  include Enumerable
+
+  def initialize(organisation, vacancy_type)
+    @organisation = organisation
+    @vacancy_type = vacancy_type
+  end
+
+  delegate :each, to: :options
+
+  def options
+    base_options.tap do |options|
+      options << readable_job_location_option if @organisation.is_a?(SchoolGroup)
+      options << publish_on_option if %i[pending draft].include?(@vacancy_type)
+    end
+  end
+
+private
+
+  def readable_job_location_option
+    SortOption.new("readable_job_location", I18n.t("jobs.sort_by.location.ascending"))
+  end
+
+  def publish_on_option
+    SortOption.new("publish_on", I18n.t("jobs.sort_by.published_date.ascending"))
+  end
+
+  def base_options
+    [
+      SortOption.new("expires_on", I18n.t("jobs.sort_by.expires_on.ascending")),
+      SortOption.new("job_title", I18n.t("jobs.sort_by.job_title.ascending")),
+    ]
+  end
+end

--- a/spec/services/publishers/vacancy_sorting_options_spec.rb
+++ b/spec/services/publishers/vacancy_sorting_options_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe Publishers::VacancySortingOptions do
+  subject { described_class.new(organisation, vacancy_type) }
+
+  context "for a School" do
+    let(:organisation) { build_stubbed(:school) }
+
+    context "by default" do
+      let(:vacancy_type) { :any_old_type }
+
+      it "returns the base set of options" do
+        expect(subject.map(&:column)).to eq(%w[expires_on job_title])
+      end
+    end
+
+    %i[pending draft].each do |status|
+      context "for a `#{status}` status" do
+        let(:vacancy_type) { status }
+
+        it "returns the extended set of options" do
+          expect(subject.map(&:column)).to eq(%w[expires_on job_title publish_on])
+        end
+      end
+    end
+  end
+
+  context "for a SchoolGroup" do
+    let(:organisation) { build_stubbed(:school_group) }
+
+    context "by default" do
+      let(:vacancy_type) { :any_old_type }
+
+      it "returns the base set of options" do
+        expect(subject.map(&:column)).to eq(%w[expires_on job_title readable_job_location])
+      end
+    end
+
+    %i[pending draft].each do |status|
+      context "for a `#{status}` status" do
+        let(:vacancy_type) { status }
+
+        it "returns the extended set of options" do
+          expect(subject.map(&:column)).to eq(%w[expires_on job_title readable_job_location publish_on])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We previously assigned translations to a constant on app boot time,
which does not reliably work (as the I18n translations may not have been
loaded yet). Instead, this is extracted to a `VacancySortingOptions`
object which loads translations at runtime (and acts as an `Enumerable`
so can be directly used by the `collection_select` view helper).