### PR TITLE
Defer Sidekiq cron loading until `after_initialize`

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -20,5 +20,7 @@ end
 schedule_file = "config/schedule.yml"
 
 if File.exist?(schedule_file) && Sidekiq.server?
-  Sidekiq::Cron::Job.load_from_hash YAML.load_file(schedule_file)
+  Rails.application.config.after_initialize do
+    Sidekiq::Cron::Job.load_from_hash YAML.load_file(schedule_file)
+  end
 end


### PR DESCRIPTION
Setting up Sidekiq::Cron involves autoloading the job classes in
`config/schedule.yml`, and doing so during app initialization is
deprecated under Zeitwerk

This moves Sidekiq::Cron setup into a Rails `after_initialize` hook.