### PR TITLE
update vacancy card content for publisher dashboard views

### DIFF
--- a/app/views/publishers/organisations/_vacancy_expired.html.slim
+++ b/app/views/publishers/organisations/_vacancy_expired.html.slim
@@ -5,9 +5,8 @@
     dl.card__details
       - if organisation.is_a?(SchoolGroup)
         dd.govuk-body = vacancy.readable_job_location
-      dd.govuk-body = t("jobs.publication_date_html", date: vacancy.publish_on)
-      dd.govuk-body = t("jobs.closing_date_html", date: vacancy.expires_on)
-      dd.govuk-body = t("jobs.page_views_html", views: vacancy.page_views)
+      dd.govuk-body = t("jobs.date_listed_html", date: vacancy.publish_on)
+      dd.govuk-body = t("jobs.expired_on_html", date: vacancy.expires_on)
 
   dl.card__actions
     dd

--- a/app/views/publishers/organisations/_vacancy_published.html.slim
+++ b/app/views/publishers/organisations/_vacancy_published.html.slim
@@ -5,7 +5,6 @@
     dl.card__details
       - if organisation.is_a?(SchoolGroup)
         dd.govuk-body#vacancy_location = vacancy.readable_job_location
-      dd.govuk-body = t("jobs.published_on_html", date: vacancy.publish_on)
       dd.govuk-body = t("jobs.closing_date_html", date: vacancy.expires_on)
       dd.govuk-body = t("jobs.page_views_html", views: vacancy.page_views)
 

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -167,6 +167,7 @@ en:
     application_deadline: Application deadline
     closing_date_html: '<span class="govuk-!-font-weight-bold">Closing date:</span> %{date}'
     created_at_html: '<span class="govuk-!-font-weight-bold">Date drafted:</span> %{date}'
+    date_listed_html: '<span class="govuk-!-font-weight-bold">Date listed:</span> %{date}'
     days_to_apply:
       remaining: '%{days_remaining} days remaining to apply'
       today: Deadline is today
@@ -178,7 +179,7 @@ en:
     start_on: Date job starts
     starts_on: Expected start date
     page_views_html: '<span class="govuk-!-font-weight-bold">Page views:</span> %{views}'
-    published_on_html: '<span class="govuk-!-font-weight-bold">Date listed:</span> %{date}'
+    expired_on_html: '<span class="govuk-!-font-weight-bold">Expired on:</span> %{date}'
     expires_on: Closing date
     time_at: ' at '
     updated_at_html: '<span class="govuk-!-font-weight-bold">Date last updated:</span> %{date}'

--- a/spec/system/hiring_staff_can_see_their_vacancies_spec.rb
+++ b/spec/system/hiring_staff_can_see_their_vacancies_spec.rb
@@ -67,7 +67,6 @@ RSpec.describe "Hiring staff can see their vacancies" do
       end
 
       within(".moj-filter-layout__content") do
-        expect(page).to have_content(published_vacancy.publish_on)
         expect(page).to have_content(published_vacancy.job_title)
         expect(page).to have_css(".card", count: 1)
       end

--- a/spec/system/hiring_staff_can_see_vacancy_statistics_spec.rb
+++ b/spec/system/hiring_staff_can_see_vacancy_statistics_spec.rb
@@ -40,38 +40,4 @@ RSpec.describe "Hiring staff can see vacancy statistics" do
       end
     end
   end
-
-  context "when vacancy is expired" do
-    let!(:vacancy) do
-      expired_vacancy = build(:vacancy,
-                              :expired,
-                              total_pageviews: total_pageviews,
-                              total_get_more_info_clicks: total_get_more_info_clicks)
-      expired_vacancy.save(validate: false)
-      expired_vacancy
-    end
-
-    before do
-      vacancy.organisation_vacancies.create(organisation: school)
-      visit jobs_with_type_organisation_path(:expired)
-    end
-
-    context "page views are nil" do
-      scenario "page views show zero" do
-        within(".card#vacancy_#{vacancy.id}") do
-          expect(page.find(".card__details")).to have_content("0")
-        end
-      end
-    end
-
-    context "page views are present" do
-      let(:total_pageviews) { 100 }
-
-      scenario "page views show the page view count" do
-        within(".card#vacancy_#{vacancy.id}") do
-          expect(page.find(".card__details")).to have_content(total_pageviews)
-        end
-      end
-    end
-  end
 end


### PR DESCRIPTION
no ticket

this fixes the content of the vacancy cards on dashboard views to be align with figma https://www.figma.com/file/wyEeHQ1U9aCXOJdzh8lF8a/Sprint-72?node-id=97%3A2842

screen shots of updates made:

![Screenshot 2021-01-12 at 07 49 19](https://user-images.githubusercontent.com/1792451/104284900-b69f5180-54aa-11eb-8900-a1a2d7be21e0.png)

![Screenshot 2021-01-12 at 07 47 06](https://user-images.githubusercontent.com/1792451/104284905-b737e800-54aa-11eb-8828-39573306b4d1.png)
