### PR TITLE
[TEVA-1762] Add Sidekiq dashboard with basic auth

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -24,3 +24,6 @@ if File.exist?(schedule_file) && Sidekiq.server?
     Sidekiq::Cron::Job.load_from_hash YAML.load_file(schedule_file)
   end
 end
+
+require "sidekiq/web"
+Sidekiq::Web.disable(:sessions)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,12 @@
+require "sidekiq/web"
+
 Rails.application.routes.draw do
+  Sidekiq::Web.use Rack::Auth::Basic do |username, password|
+    ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_USERNAME"])) &
+      ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_PASSWORD"]))
+  end
+  mount Sidekiq::Web, at: "/sidekiq"
+
   constraints(-> { JobseekerAccountsFeature.enabled? }) do
     devise_for :jobseekers, controllers: {
       confirmations: "jobseekers/confirmations",


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1762

## Changes in this PR:

- Expose sidekiq dashboard, but protect behind basic auth, with credentials pulled from AWS Parameter Store
