### PR TITLE
Make back/cancel link on vacancy wizard a component

### DIFF
--- a/app/components/publishers/vacancy_wizard_back_link_component.rb
+++ b/app/components/publishers/vacancy_wizard_back_link_component.rb
@@ -1,0 +1,47 @@
+class Publishers::VacancyWizardBackLinkComponent < ViewComponent::Base
+  def initialize(vacancy, previous_step_path: nil, current_step_is_first_step: false)
+    @vacancy = vacancy
+    @previous_step_path = previous_step_path
+    @current_step_is_first_step = current_step_is_first_step
+  end
+
+  def render?
+    !vacancy_is_in_create_state? || !current_step_is_first_step?
+  end
+
+  def call
+    govuk_back_link(text: text, href: href)
+  end
+
+private
+
+  def text
+    if vacancy_is_in_create_state?
+      t("buttons.back")
+    else
+      t("buttons.cancel_and_return")
+    end
+  end
+
+  def href
+    if vacancy_is_in_create_state?
+      @previous_step_path
+    elsif vacancy_is_published?
+      edit_organisation_job_path(@vacancy.id)
+    else
+      organisation_job_review_path(@vacancy.id)
+    end
+  end
+
+  def vacancy_is_in_create_state?
+    @vacancy.state == "create"
+  end
+
+  def vacancy_is_published?
+    @vacancy.published?
+  end
+
+  def current_step_is_first_step?
+    @current_step_is_first_step.present?
+  end
+end

--- a/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
+++ b/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
@@ -3,11 +3,7 @@
 .govuk-grid-row
   .govuk-grid-column-full
     = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy)
-
-- if @vacancy.state == "create"
-  = govuk_back_link text: t("buttons.back"), href: @applying_for_the_job_back_path
-- else
-  = render "publishers/vacancies/vacancy_form_partials/cancel_and_return_link"
+    = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: @applying_for_the_job_back_path)
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/publishers/vacancies/build/important_dates.html.slim
+++ b/app/views/publishers/vacancies/build/important_dates.html.slim
@@ -3,11 +3,7 @@
 .govuk-grid-row
   .govuk-grid-column-full
     = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy)
-
-- if @vacancy.state == "create"
-  = govuk_back_link text: t("buttons.back"), href: previous_wizard_path
-- else
-  = render "publishers/vacancies/vacancy_form_partials/cancel_and_return_link"
+    = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: previous_wizard_path)
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/publishers/vacancies/build/job_details.html.slim
+++ b/app/views/publishers/vacancies/build/job_details.html.slim
@@ -3,11 +3,7 @@
 .govuk-grid-row
   .govuk-grid-column-full
     = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy)
-
-- if current_organisation.is_a?(School) || @vacancy.state != "create"
-  = render "publishers/vacancies/vacancy_form_partials/cancel_and_return_link"
-- else
-  = govuk_back_link text: t("buttons.back"), href: @job_details_back_path
+    = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: @job_details_back_path, current_step_is_first_step: current_organisation.is_a?(School))
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/publishers/vacancies/build/job_location.html.slim
+++ b/app/views/publishers/vacancies/build/job_location.html.slim
@@ -3,9 +3,7 @@
 .govuk-grid-row
   .govuk-grid-column-full
     = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy)
-
-- if @vacancy.state != "create"
-  = render "publishers/vacancies/vacancy_form_partials/cancel_and_return_link"
+    = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, current_step_is_first_step: true)
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/publishers/vacancies/build/job_summary.html.slim
+++ b/app/views/publishers/vacancies/build/job_summary.html.slim
@@ -3,11 +3,7 @@
 .govuk-grid-row
   .govuk-grid-column-full
     = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy)
-
-- if @vacancy.state == "create"
-  = govuk_back_link text: t("buttons.back"), href: previous_wizard_path
-- else
-  = render "publishers/vacancies/vacancy_form_partials/cancel_and_return_link"
+    = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: previous_wizard_path)
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/publishers/vacancies/build/pay_package.html.slim
+++ b/app/views/publishers/vacancies/build/pay_package.html.slim
@@ -3,11 +3,7 @@
 .govuk-grid-row
   .govuk-grid-column-full
     = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy)
-
-- if @vacancy.state == "create"
-  = govuk_back_link text: t("buttons.back"), href: previous_wizard_path
-- else
-  = render "publishers/vacancies/vacancy_form_partials/cancel_and_return_link"
+    = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: previous_wizard_path)
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/publishers/vacancies/build/schools.html.slim
+++ b/app/views/publishers/vacancies/build/schools.html.slim
@@ -3,11 +3,7 @@
 .govuk-grid-row
   .govuk-grid-column-full
     = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy)
-
-- if @vacancy.state == "create"
-  = govuk_back_link text: t("buttons.back"), href: previous_wizard_path
-- else
-  = render "publishers/vacancies/vacancy_form_partials/cancel_and_return_link"
+    = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: previous_wizard_path)
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/publishers/vacancies/build/supporting_documents.html.slim
+++ b/app/views/publishers/vacancies/build/supporting_documents.html.slim
@@ -3,11 +3,7 @@
 .govuk-grid-row
   .govuk-grid-column-full
     = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy)
-
-- if @vacancy.state == "create"
-  = govuk_back_link text: t("buttons.back"), href: previous_wizard_path
-- else
-  = render "publishers/vacancies/vacancy_form_partials/cancel_and_return_link"
+    = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: previous_wizard_path)
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/publishers/vacancies/documents/show.html.slim
+++ b/app/views/publishers/vacancies/documents/show.html.slim
@@ -3,11 +3,7 @@
 .govuk-grid-row
   .govuk-grid-column-full
     = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy)
-
-- if @vacancy.state == "create"
-  = govuk_back_link text: t("buttons.back"), href: organisation_job_build_path(@vacancy.id, :supporting_documents)
-- else
-  = render "publishers/vacancies/vacancy_form_partials/cancel_and_return_link"
+    = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: organisation_job_build_path(@vacancy.id, :supporting_documents))
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/publishers/vacancies/vacancy_form_partials/_cancel_and_return_link.html.slim
+++ b/app/views/publishers/vacancies/vacancy_form_partials/_cancel_and_return_link.html.slim
@@ -1,4 +1,0 @@
-- if @vacancy.published?
-  = govuk_back_link text: t("buttons.cancel_and_return"), href: edit_organisation_job_path(@vacancy.id)
-- else
-  = govuk_back_link text: t("buttons.cancel_and_return"), href: organisation_job_review_path(@vacancy.id)

--- a/spec/components/publishers/vacancy_wizard_back_link_component_spec.rb
+++ b/spec/components/publishers/vacancy_wizard_back_link_component_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe Publishers::VacancyWizardBackLinkComponent, type: :component do
+  subject { described_class.new(vacancy, previous_step_path: previous_step_path, current_step_is_first_step: current_step_is_first_step) }
+
+  let(:previous_step_path) { "/some/where" }
+
+  before do
+    render_inline(subject)
+  end
+
+  context "when the vacancy is first being created" do
+    let(:vacancy) { build_stubbed(:vacancy, state: "create") }
+
+    context "when the current step is the first step" do
+      let(:current_step_is_first_step) { true }
+
+      it "does not render" do
+        expect(rendered_component).to be_blank
+      end
+    end
+
+    context "when the current step is not the first step" do
+      let(:current_step_is_first_step) { false }
+
+      it "renders a 'back' link to the previous path given" do
+        expect(rendered_component).to include(I18n.t("buttons.back"))
+        expect(rendered_component).to include('href="/some/where"')
+      end
+    end
+  end
+
+  context "when the vacancy has already been fully created" do
+    let(:vacancy) { create(:vacancy, id: 3, state: "review", status: status) }
+    let(:current_step_is_first_step) { false }
+
+    context "when the vacancy is already published" do
+      let(:status) { :published }
+
+      it "renders a 'cancel and return' link to the edit action" do
+        expect(rendered_component).to include(I18n.t("buttons.cancel_and_return"))
+        expect(rendered_component).to include(Rails.application.routes.url_helpers.edit_organisation_job_path(vacancy.id))
+      end
+    end
+
+    context "when the vacancy is not yet published" do
+      let(:status) { :draft }
+
+      it "renders a 'cancel and return' link to the review action" do
+        expect(rendered_component).to include(I18n.t("buttons.cancel_and_return"))
+        expect(rendered_component).to include(Rails.application.routes.url_helpers.organisation_job_review_path(vacancy.id))
+      end
+    end
+  end
+end


### PR DESCRIPTION
This always shows a GOV.UK back link, and had a lot of logic spread
across a number of views and partials.

- Create `Publishers::VacancyWizardBackLinkComponent` and replace
  view logic throughout wizard with it
- Fix bug where a back link was wrongly shown on the first page of a
  wizard during the initial creation process (which would take you right
  back to the page you were on)
- Fix back link being outside of a `govuk-grid-row`