### PR TITLE
refactor similar jobs to use gds containers

### DIFF
--- a/app/components/jobseekers/similar_job_component.rb
+++ b/app/components/jobseekers/similar_job_component.rb
@@ -1,7 +1,9 @@
 class Jobseekers::SimilarJobComponent < ViewComponent::Base
   include OrganisationHelper
 
-  attr_accessor :vacancy
+  attr_reader :vacancy
+
+  with_collection_parameter :vacancy
 
   def initialize(vacancy:)
     @vacancy = vacancy

--- a/app/components/jobseekers/similar_job_component/similar_job_component.html.slim
+++ b/app/components/jobseekers/similar_job_component/similar_job_component.html.slim
@@ -1,6 +1,6 @@
-.similar-job
+.similar-job.govuk-grid-column-one-half
   = govuk_link_to(vacancy.job_title, job_path(vacancy), class: "view-similar-job-gtm")
   p.govuk-body-s class="govuk-!-margin-bottom-0 govuk-!-font-weight-bold"
-    = @vacancy.parent_organisation.name
+    = vacancy.parent_organisation.name
   p.govuk-body-s class="govuk-!-margin-bottom-0 govuk-!-margin-top-0"
-    = full_address(@vacancy.parent_organisation)
+    = full_address(vacancy.parent_organisation)

--- a/app/components/jobseekers/similar_job_component/similar_job_component.scss
+++ b/app/components/jobseekers/similar_job_component/similar_job_component.scss
@@ -1,12 +1,8 @@
 .similar-job {
   border-left: 5px solid govuk-colour('orange');
-  flex-basis: auto;
-  flex-grow: 1;
   margin-bottom: govuk-spacing(4);
-  max-width: 50%;
   padding-bottom: govuk-spacing(2);
   padding-left: govuk-spacing(2);
   padding-right: govuk-spacing(4);
   padding-top: govuk-spacing(2);
-  width: 38%;
 }

--- a/app/views/shared/vacancy/_jobseeker_view.html.slim
+++ b/app/views/shared/vacancy/_jobseeker_view.html.slim
@@ -72,9 +72,9 @@
     - if @similar_jobs.present?
       section.similar-jobs class="govuk-!-margin-bottom-5"
         h3.govuk-heading-m = t("jobs.similar_jobs")
-        .govuk-grid-row
-          - @similar_jobs.each do |similar_job|
-            = render(Jobseekers::SimilarJobComponent.new(vacancy: similar_job))
+        - @similar_jobs.in_groups_of(2, false).each do |row|
+          .govuk-grid-row
+            = render Jobseekers::SimilarJobComponent.with_collection(row)
 
     section
       p.icon.icon--left.icon--alert-blue


### PR DESCRIPTION
no ticket

Wasn't happy with the previous fix for the misalignment of similar jobs. turns out a combination of @cpjmcquillan @csutter suggestions and my original is much more sensible and neater.

flex-box isn't designed to solve this type of layout in a horizontal sense - as horizontally it isn't flexing - so use standard GDS columns for this and use flex-box for the vertical layout which does need to flex. nice.