### PR TITLE
Raise in test on missing translations and fix them

### DIFF
--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_applying_for_the_job.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_applying_for_the_job.html.slim
@@ -35,6 +35,6 @@ dl.app-check-your-answers.app-check-your-answers--short
       h4.govuk-heading-s = t("jobs.application_link")
     dd.app-check-your-answers__answer
       - if @vacancy.application_link.present?
-        = govuk_link_to(@vacancy.application_link, @vacancy.application_link, "aria-label": t("jobs.aria_labels.application_link_url"), "target": "_blank", rel: "noopener noreferrer")
+        = govuk_link_to(@vacancy.application_link, @vacancy.application_link, "aria-label": t("jobs.aria_labels.apply_link"), "target": "_blank", rel: "noopener noreferrer")
       - else
         = t("jobs.not_defined")

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,11 +41,9 @@ Rails.application.configure do
     from: "mail@example.com",
   }
 
-  # Raise an error when encountering deprecated behaviour
+  # Raise an error when encountering deprecated behaviour or missing translations
   config.active_support.deprecation = :raise
-
-  # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.i18n.raise_on_missing_translations = true
 
   config.middleware.use RackSessionAccess::Middleware
 end

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -174,6 +174,9 @@ en:
     benefits: Employee benefits
     pay_package: Pay package
 
+    school_visits: School visits
+    trust_visits: Trust visits
+
     important_dates: Important dates and deadlines
     application_deadline: Application deadline
     days_to_apply:
@@ -185,6 +188,7 @@ en:
     starts_asap: As soon as possible
     start_on: Date job starts
     starts_on: Expected start date
+    publish_on: Publish on
     expires_on: Closing date
     time_at: ' at '
 


### PR DESCRIPTION
We have a handful of missing translations in the app. This enables
`config.i18n.raise_on_missing_translations` in the test environment so
that tests will fail if they encounter any missing translations, and
fixes the missing translations I've come across.