### PR TITLE
Style: Indent access modifiers with rest of class

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -67,9 +67,6 @@ Style/TrailingCommaInHashLiteral:
 # Temporary rules
 # TODO: These have a lot of warnings, or relate to unfinished stylistic discussions within the team
 
-Layout/AccessModifierIndentation:
-  EnforcedStyle: outdent
-
 Lint/MissingSuper:
   Enabled: false
 

--- a/app/components/publishers/vacancies_component.rb
+++ b/app/components/publishers/vacancies_component.rb
@@ -48,7 +48,7 @@ class Publishers::VacanciesComponent < ViewComponent::Base
     link_to t("jobs.#{vacancy_type}_jobs"), jobs_with_type_organisation_path(vacancy_type), class: "moj-primary-navigation__link", "aria-current": ("page" if selected)
   end
 
-private
+  private
 
   def set_vacancies
     @vacancies =

--- a/app/components/publishers/vacancy_form_page_heading_component.rb
+++ b/app/components/publishers/vacancy_form_page_heading_component.rb
@@ -15,7 +15,7 @@ class Publishers::VacancyFormPageHeadingComponent < ViewComponent::Base
     %w[copy edit edit_published].exclude?(vacancy.state)
   end
 
-private
+  private
 
   attr_reader :vacancy
 

--- a/app/components/publishers/vacancy_wizard_back_link_component.rb
+++ b/app/components/publishers/vacancy_wizard_back_link_component.rb
@@ -13,7 +13,7 @@ class Publishers::VacancyWizardBackLinkComponent < ViewComponent::Base
     govuk_back_link(text: text, href: href)
   end
 
-private
+  private
 
   def text
     if vacancy_is_in_create_state?

--- a/app/controllers/api/coordinates_controller.rb
+++ b/app/controllers/api/coordinates_controller.rb
@@ -12,7 +12,7 @@ class Api::CoordinatesController < Api::ApplicationController
     }
   end
 
-private
+  private
 
   def location
     params[:location]

--- a/app/controllers/api/location_suggestion_controller.rb
+++ b/app/controllers/api/location_suggestion_controller.rb
@@ -16,7 +16,7 @@ class Api::LocationSuggestionController < Api::ApplicationController
     }
   end
 
-private
+  private
 
   def location
     params[:location]

--- a/app/controllers/api/vacancies_controller.rb
+++ b/app/controllers/api/vacancies_controller.rb
@@ -22,7 +22,7 @@ class Api::VacanciesController < Api::ApplicationController
     @vacancy = VacancyPresenter.new(vacancy)
   end
 
-private
+  private
 
   def id
     params[:id]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,7 +29,7 @@ class ApplicationController < ActionController::Base
     end
   end
 
-private
+  private
 
   def cookies_preference_set?
     cookies["consented-to-cookies"].present?

--- a/app/controllers/concerns/ab_testable.rb
+++ b/app/controllers/concerns/ab_testable.rb
@@ -5,7 +5,7 @@ module AbTestable
     helper_method :ab_variant_for, :current_ab_variants
   end
 
-private
+  private
 
   def ab_variant_for(test)
     params.dig(:ab_test_override, test)&.to_sym || ab_tests.variant_for(test)

--- a/app/controllers/cookies_preferences_controller.rb
+++ b/app/controllers/cookies_preferences_controller.rb
@@ -16,7 +16,7 @@ class CookiesPreferencesController < ApplicationController
     end
   end
 
-private
+  private
 
   def cookies_preferences_params
     (params[:cookies_preferences_form] || params).permit(:cookies_consent)

--- a/app/controllers/general_feedback_controller.rb
+++ b/app/controllers/general_feedback_controller.rb
@@ -19,7 +19,7 @@ class GeneralFeedbackController < ApplicationController
     end
   end
 
-private
+  private
 
   def general_feedback_params
     params.require(:general_feedback)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -8,7 +8,7 @@ class HomeController < ApplicationController
     @counties_facets = @vacancy_facets.get(:counties)
   end
 
-private
+  private
 
   def set_headers
     response.set_header("X-Robots-Tag", "index, nofollow")

--- a/app/controllers/interests_controller.rb
+++ b/app/controllers/interests_controller.rb
@@ -4,7 +4,7 @@ class InterestsController < ApplicationController
     redirect_to(vacancy.application_link)
   end
 
-private
+  private
 
   def audit_click
     VacancyGetMoreInfoClick.new(vacancy).track

--- a/app/controllers/job_alert_feedbacks_controller.rb
+++ b/app/controllers/job_alert_feedbacks_controller.rb
@@ -37,7 +37,7 @@ class JobAlertFeedbacksController < ApplicationController
     end
   end
 
-private
+  private
 
   def job_alert_feedback_params
     params.require(:job_alert_feedback).permit(:comment, :relevant_to_user, :search_criteria, vacancy_ids: [])

--- a/app/controllers/jobseekers/account_feedbacks_controller.rb
+++ b/app/controllers/jobseekers/account_feedbacks_controller.rb
@@ -13,7 +13,7 @@ class Jobseekers::AccountFeedbacksController < Jobseekers::ApplicationController
     end
   end
 
-private
+  private
 
   def account_feedback_params
     params.require(:account_feedback).permit(:rating, :suggestions, :back_link)

--- a/app/controllers/jobseekers/application_controller.rb
+++ b/app/controllers/jobseekers/application_controller.rb
@@ -2,7 +2,7 @@ class Jobseekers::ApplicationController < ApplicationController
   before_action :store_jobseeker_location!, if: :storable_location?
   before_action :authenticate_jobseeker!
 
-private
+  private
 
   def storable_location?
     request.get? && is_navigational_format? && !devise_controller? && !request.xhr?

--- a/app/controllers/jobseekers/confirmations_controller.rb
+++ b/app/controllers/jobseekers/confirmations_controller.rb
@@ -2,7 +2,7 @@ class Jobseekers::ConfirmationsController < Devise::ConfirmationsController
   after_action :remove_devise_flash!, only: %i[create]
   after_action :replace_devise_notice_flash_with_success!, only: %i[show]
 
-protected
+  protected
 
   def after_confirmation_path_for(resource_name, resource)
     sign_in(resource)

--- a/app/controllers/jobseekers/devise_controller.rb
+++ b/app/controllers/jobseekers/devise_controller.rb
@@ -1,11 +1,11 @@
 class Jobseekers::DeviseController < ApplicationController
-protected
+  protected
 
   def after_sign_out_path_for(_resource)
     new_jobseeker_session_path
   end
 
-private
+  private
 
   def replace_devise_notice_flash_with_success!
     flash[:success] = flash.discard(:notice) if flash[:notice].present?

--- a/app/controllers/jobseekers/passwords_controller.rb
+++ b/app/controllers/jobseekers/passwords_controller.rb
@@ -2,7 +2,7 @@ class Jobseekers::PasswordsController < Devise::PasswordsController
   before_action :ensure_reset_password_period_valid, only: %i[edit update]
   after_action :remove_devise_flash!, only: %i[create]
 
-protected
+  protected
 
   def ensure_reset_password_period_valid
     token = params[:reset_password_token] || params[resource_name][:reset_password_token]

--- a/app/controllers/jobseekers/registrations_controller.rb
+++ b/app/controllers/jobseekers/registrations_controller.rb
@@ -6,7 +6,7 @@ class Jobseekers::RegistrationsController < Devise::RegistrationsController
   after_action :replace_devise_notice_flash_with_success!, only: %i[destroy update]
   after_action :remove_devise_flash!, only: %i[create update]
 
-protected
+  protected
 
   def check_password_difference
     return unless @update_password

--- a/app/controllers/jobseekers/saved_jobs_controller.rb
+++ b/app/controllers/jobseekers/saved_jobs_controller.rb
@@ -21,7 +21,7 @@ class Jobseekers::SavedJobsController < Jobseekers::ApplicationController
     @saved_jobs = current_jobseeker.saved_jobs.includes(:vacancy).order("#{@sort.column} #{@sort.order}")
   end
 
-private
+  private
 
   def saved_job_params
     ParameterSanitiser.call(params).permit(:id, :redirect_to_dashboard)

--- a/app/controllers/jobseekers/sessions_controller.rb
+++ b/app/controllers/jobseekers/sessions_controller.rb
@@ -8,7 +8,7 @@ class Jobseekers::SessionsController < Devise::SessionsController
     invalid not_found_in_database last_attempt
   ].map { |error| I18n.t("devise.failure.#{error}") }.freeze
 
-private
+  private
 
   def render_form_with_errors
     self.resource = JobseekerSignInForm.new(sign_in_params)

--- a/app/controllers/nqt_job_alerts_controller.rb
+++ b/app/controllers/nqt_job_alerts_controller.rb
@@ -25,7 +25,7 @@ class NqtJobAlertsController < ApplicationController
     end
   end
 
-private
+  private
 
   def nqt_job_alerts_params
     ParameterSanitiser.call(params[:nqt_job_alerts_form] || params).permit(:keywords, :location, :email)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -5,7 +5,7 @@ class PagesController < ApplicationController
     not_found
   end
 
-private
+  private
 
   def set_headers
     response.set_header("X-Robots-Tag", "index, nofollow")

--- a/app/controllers/publishers/organisations/managed_organisations_controller.rb
+++ b/app/controllers/publishers/organisations/managed_organisations_controller.rb
@@ -22,7 +22,7 @@ class Publishers::Organisations::ManagedOrganisationsController < Publishers::Ba
     end
   end
 
-private
+  private
 
   def managed_organisations_params
     strip_empty_checkboxes(%i[managed_organisations managed_school_ids], :managed_organisations_form)

--- a/app/controllers/publishers/organisations/schools_controller.rb
+++ b/app/controllers/publishers/organisations/schools_controller.rb
@@ -21,7 +21,7 @@ class Publishers::Organisations::SchoolsController < Publishers::BaseController
     end
   end
 
-private
+  private
 
   def set_organisation
     @organisation = Organisation.find(params[:id])

--- a/app/controllers/publishers/organisations_controller.rb
+++ b/app/controllers/publishers/organisations_controller.rb
@@ -18,7 +18,7 @@ class Publishers::OrganisationsController < Publishers::BaseController
     render_draft_saved_message if params[:from_review]
   end
 
-private
+  private
 
   def redirect_to_user_preferences
     return unless current_organisation.is_a?(SchoolGroup) && current_publisher_preferences.nil?

--- a/app/controllers/publishers/sign_in/base_sessions_controller.rb
+++ b/app/controllers/publishers/sign_in/base_sessions_controller.rb
@@ -21,7 +21,7 @@ class Publishers::SignIn::BaseSessionsController < Publishers::BaseController
     redirect_to new_identifications_path, flash_message
   end
 
-private
+  private
 
   def clear_publisher_session!
     PUBLISHER_SESSION_KEYS.each { |key| session.delete(key) }

--- a/app/controllers/publishers/sign_in/dfe/sessions_controller.rb
+++ b/app/controllers/publishers/sign_in/dfe/sessions_controller.rb
@@ -27,7 +27,7 @@ class Publishers::SignIn::Dfe::SessionsController < Publishers::SignIn::BaseSess
     end_session_and_redirect
   end
 
-private
+  private
 
   def not_authorised
     Rails.logger.warn(not_authorised_details)

--- a/app/controllers/publishers/sign_in/email/sessions_controller.rb
+++ b/app/controllers/publishers/sign_in/email/sessions_controller.rb
@@ -51,7 +51,7 @@ class Publishers::SignIn::Email::SessionsController < Publishers::SignIn::BaseSe
     )
   end
 
-private
+  private
 
   def update_session_except_org_id(options)
     return unless options[:oid]

--- a/app/controllers/publishers/terms_and_conditions_controller.rb
+++ b/app/controllers/publishers/terms_and_conditions_controller.rb
@@ -16,7 +16,7 @@ class Publishers::TermsAndConditionsController < Publishers::BaseController
     end
   end
 
-private
+  private
 
   def terms_params
     (params[:terms_and_conditions_form] || params).permit(:terms)

--- a/app/controllers/publishers/vacancies/build_controller.rb
+++ b/app/controllers/publishers/vacancies/build_controller.rb
@@ -57,7 +57,7 @@ class Publishers::Vacancies::BuildController < Publishers::Vacancies::Applicatio
     end
   end
 
-private
+  private
 
   def convert_date_params
     return unless step == :important_dates

--- a/app/controllers/publishers/vacancies/copy_controller.rb
+++ b/app/controllers/publishers/vacancies/copy_controller.rb
@@ -22,7 +22,7 @@ class Publishers::Vacancies::CopyController < Publishers::Vacancies::Application
     end
   end
 
-private
+  private
 
   def copy_form_params
     params.require(:copy_vacancy_form).permit(:state, :job_title, :publish_on, :expires_on, :starts_on,

--- a/app/controllers/publishers/vacancies/documents_controller.rb
+++ b/app/controllers/publishers/vacancies/documents_controller.rb
@@ -43,7 +43,7 @@ class Publishers::Vacancies::DocumentsController < Publishers::Vacancies::Applic
     end
   end
 
-private
+  private
 
   def set_documents_form
     @documents_form = DocumentsForm.new

--- a/app/controllers/publishers/vacancies/publish_controller.rb
+++ b/app/controllers/publishers/vacancies/publish_controller.rb
@@ -15,7 +15,7 @@ class Publishers::Vacancies::PublishController < Publishers::Vacancies::Applicat
     end
   end
 
-private
+  private
 
   def audit_publish_vacancy
     Auditor::Audit.new(@vacancy, "vacancy.publish", current_publisher_oid).log

--- a/app/controllers/publishers/vacancies/statistics_controller.rb
+++ b/app/controllers/publishers/vacancies/statistics_controller.rb
@@ -16,7 +16,7 @@ class Publishers::Vacancies::StatisticsController < Publishers::Vacancies::Appli
     end
   end
 
-private
+  private
 
   def update_vacancy(vacancy)
     vacancy.listed_elsewhere = statistics_params[:listed_elsewhere]

--- a/app/controllers/publishers/vacancies/vacancy_publish_feedback_controller.rb
+++ b/app/controllers/publishers/vacancies/vacancy_publish_feedback_controller.rb
@@ -19,7 +19,7 @@ class Publishers::Vacancies::VacancyPublishFeedbackController < Publishers::Vaca
     redirect_to organisation_path, success: t("messages.jobs.feedback.submitted_html", job_title: @vacancy.job_title)
   end
 
-private
+  private
 
   def vacancy_publish_feedback_params
     params.require(:vacancy_publish_feedback).permit(:comment, :user_participation_response, :email)

--- a/app/controllers/publishers/vacancies_controller.rb
+++ b/app/controllers/publishers/vacancies_controller.rb
@@ -55,7 +55,7 @@ class Publishers::VacanciesController < Publishers::Vacancies::ApplicationContro
     @vacancy = VacancyPresenter.new(@vacancy)
   end
 
-private
+  private
 
   def devise_job_alert_search_criteria
     @devised_job_alert_search_criteria = Search::CriteriaDeviser.new(@vacancy).criteria

--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -13,7 +13,7 @@ class SitemapController < ApplicationController
     render xml: map.render
   end
 
-private
+  private
 
   def add_vacancies(map)
     Vacancy.listed.applicable.find_each do |vacancy|

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -81,7 +81,7 @@ class SubscriptionsController < ApplicationController
     end
   end
 
-private
+  private
 
   def email
     ParameterSanitiser.call(params).permit(:email)

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -35,7 +35,7 @@ class VacanciesController < ApplicationController
     @params ||= ParameterSanitiser.call(super)
   end
 
-private
+  private
 
   def algolia_search_params
     strip_empty_checkboxes(%i[job_roles phases working_patterns])

--- a/app/form_models/managed_organisations_form.rb
+++ b/app/form_models/managed_organisations_form.rb
@@ -11,7 +11,7 @@ class ManagedOrganisationsForm
     @managed_school_ids = params[:managed_school_ids]
   end
 
-private
+  private
 
   def at_least_one_option_selected
     return if managed_organisations.present? || managed_school_ids.any?

--- a/app/form_models/nqt_job_alerts_form.rb
+++ b/app/form_models/nqt_job_alerts_form.rb
@@ -33,7 +33,7 @@ class NqtJobAlertsForm
     end
   end
 
-private
+  private
 
   def nqt_job_alert_hash
     {

--- a/app/form_models/schools_form.rb
+++ b/app/form_models/schools_form.rb
@@ -13,7 +13,7 @@ class SchoolsForm < VacancyForm
     super
   end
 
-private
+  private
 
   def more_than_one_school_present_multiple_schools
     errors.add(:organisation_ids, I18n.t("schools_errors.organisation_ids.invalid")) if

--- a/app/form_models/subscription_form.rb
+++ b/app/form_models/subscription_form.rb
@@ -52,7 +52,7 @@ class SubscriptionForm
     }.compact.delete_if { |_k, v| v.blank? || v.empty? }
   end
 
-private
+  private
 
   def set_facet_options
     @job_role_options = Vacancy.job_roles.keys.map { |option| [option, I18n.t("helpers.label.job_details_form.job_roles_options.#{option}")] }

--- a/app/form_models/vacancy_algolia_search_form.rb
+++ b/app/form_models/vacancy_algolia_search_form.rb
@@ -42,7 +42,7 @@ class VacancyAlgoliaSearchForm
     }.delete_if { |k, v| v.blank? || (k.eql?(:radius) && @location.blank?) }
   end
 
-private
+  private
 
   def set_facet_options
     @job_role_options = Vacancy.job_roles.keys.map { |option| [option, I18n.t("helpers.label.job_details_form.job_roles_options.#{option}")] }

--- a/app/helpers/dates_helper.rb
+++ b/app/helpers/dates_helper.rb
@@ -42,7 +42,7 @@ module DatesHelper
     "#{date_time}:#{date_time.strftime('%S')}"
   end
 
-private
+  private
 
   def in_range?(value, min, max)
     number?(value) && value.to_i >= min && value.to_i <= max

--- a/app/helpers/notify_view_helper.rb
+++ b/app/helpers/notify_view_helper.rb
@@ -37,7 +37,7 @@ module NotifyViewHelper
     notify_link(url, t(".unsubscribe_link_text"))
   end
 
-private
+  private
 
   def utm_params(subscription)
     { utm_source: subscription.alert_run_today&.id, utm_medium: "email", utm_campaign: "#{subscription.frequency}_alert" }

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -89,7 +89,7 @@ module OrganisationHelper
     I18n.t("schools.no_information")
   end
 
-private
+  private
 
   def number_of_pupils(school)
     I18n.t("schools.size.enrolled", pupils: pupils, number: school.gias_data["NumberOfPupils"])

--- a/app/jobs/alert_mailer_job.rb
+++ b/app/jobs/alert_mailer_job.rb
@@ -17,7 +17,7 @@ class AlertMailerJob < ActionMailer::MailDeliveryJob
     alert_run.update(status: :sent)
   end
 
-private
+  private
 
   def job_already_run?
     alert_run.sent?

--- a/app/jobs/send_expired_vacancy_feedback_email_job.rb
+++ b/app/jobs/send_expired_vacancy_feedback_email_job.rb
@@ -10,7 +10,7 @@ class SendExpiredVacancyFeedbackEmailJob < ApplicationJob
     end
   end
 
-private
+  private
 
   def expired_vacancies
     Vacancy.where(expires_on: Time.current - 2.weeks, hired_status: nil)

--- a/app/models/concerns/vacancy_expires_at_field_validations.rb
+++ b/app/models/concerns/vacancy_expires_at_field_validations.rb
@@ -7,7 +7,7 @@ module VacancyExpiresAtFieldValidations
     validate :expires_at_meridiem_must_not_be_blank, unless: proc { |v| validate_expires_at?(v) }
   end
 
-private
+  private
 
   def expires_at_must_not_be_blank
     errors.add(:expires_at, I18n.t("activerecord.errors.models.vacancy.attributes.expires_at.blank")) if

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -47,7 +47,7 @@ class School < Organisation
     gias_data["ReligiousCharacter (name)"]
   end
 
-private
+  private
 
   def set_geolocation_from_easting_and_northing
     if easting && northing

--- a/app/models/transaction_auditor.rb
+++ b/app/models/transaction_auditor.rb
@@ -21,7 +21,7 @@ class TransactionAuditor < ApplicationRecord
       log(task, date, false)
     end
 
-  private
+    private
 
     def log(task, date, success)
       TransactionAuditor.where(task: task, date: date).first_or_create.update(success: success)

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -125,7 +125,7 @@ class Vacancy < ApplicationRecord
     organisations.map(&:readable_phases).flatten.uniq
   end
 
-private
+  private
 
   def slug_candidates
     [

--- a/app/presenters/base_presenter.rb
+++ b/app/presenters/base_presenter.rb
@@ -1,6 +1,6 @@
 require "delegate"
 class BasePresenter < SimpleDelegator
-private
+  private
 
   def model
     __getobj__

--- a/app/presenters/organisation_vacancy_presenter.rb
+++ b/app/presenters/organisation_vacancy_presenter.rb
@@ -51,7 +51,7 @@ class OrganisationVacancyPresenter < BasePresenter
     url_helpers.organisation_job_path(id: model.id)
   end
 
-private
+  private
 
   def url_helpers
     Rails.application.routes.url_helpers

--- a/app/presenters/subscription_presenter.rb
+++ b/app/presenters/subscription_presenter.rb
@@ -21,7 +21,7 @@ class SubscriptionPresenter < BasePresenter
     full_search_criteria.transform_values! { |value| value.is_a?(Array) ? value.join(", ") : value }
   end
 
-private
+  private
 
   def sorted_search_criteria
     search_criteria_to_h.sort_by { |(key, _)|

--- a/app/presenters/vacancies_presenter.rb
+++ b/app/presenters/vacancies_presenter.rb
@@ -37,7 +37,7 @@ class VacanciesPresenter < BasePresenter
     api_jobs_url(json_api_params.merge(page: model.next_page)) if model.next_page
   end
 
-private
+  private
 
   def json_api_params
     {

--- a/app/services/ab_tests.rb
+++ b/app/services/ab_tests.rb
@@ -26,7 +26,7 @@ class AbTests
     available_ab_tests.to_h { |test| [test, variant_for(test)] }
   end
 
-private
+  private
 
   attr_reader :session, :test_configuration
 

--- a/app/services/auditor.rb
+++ b/app/services/auditor.rb
@@ -18,7 +18,7 @@ module Auditor
       create_without_model
     end
 
-  private
+    private
 
     def create(changes)
       PublicActivity::Activity.create trackable: model, key: key, session_id: session_id, parameters: changes

--- a/app/services/authorisation.rb
+++ b/app/services/authorisation.rb
@@ -46,7 +46,7 @@ class Authorisation
     nil
   end
 
-private
+  private
 
   def generate_jwt_token
     payload = {

--- a/app/services/copy_vacancy.rb
+++ b/app/services/copy_vacancy.rb
@@ -13,7 +13,7 @@ class CopyVacancy
     @new_vacancy
   end
 
-private
+  private
 
   def copy_documents
     @vacancy.documents.each do |document|

--- a/app/services/counter.rb
+++ b/app/services/counter.rb
@@ -17,7 +17,7 @@ class Counter
     reset_counter if model.save
   end
 
-private
+  private
 
   def increment_persisted_counter
     model.send(self.class.persisted_column).to_i + redis_counter.to_i

--- a/app/services/document_delete.rb
+++ b/app/services/document_delete.rb
@@ -17,7 +17,7 @@ class DocumentDelete
     document.destroy
   end
 
-private
+  private
 
   attr_accessor :document, :drive_service
 

--- a/app/services/event.rb
+++ b/app/services/event.rb
@@ -25,7 +25,7 @@ class Event
     Rollbar.error(e)
   end
 
-private
+  private
 
   ##
   # Data to be included with any event (to be overridden as appropriate in subclasses)

--- a/app/services/get_information_from_login_key.rb
+++ b/app/services/get_information_from_login_key.rb
@@ -16,7 +16,7 @@ class GetInformationFromLoginKey
     @schools&.count.to_i + @trusts&.count.to_i + @local_authorities&.count.to_i > 1
   end
 
-private
+  private
 
   def deny_sign_in
     @reason_for_failing_sign_in = if @key&.expired?

--- a/app/services/import_polygons.rb
+++ b/app/services/import_polygons.rb
@@ -38,7 +38,7 @@ class ImportPolygons
     end
   end
 
-private
+  private
 
   def location_categories_include?(region_name)
     location_type == :regions && DOWNCASE_REGIONS.include?(region_name) ||

--- a/app/services/location_suggestion.rb
+++ b/app/services/location_suggestion.rb
@@ -26,7 +26,7 @@ class LocationSuggestion
     [suggestions, matched_terms]
   end
 
-private
+  private
 
   def request_url
     "https://maps.googleapis.com/maps/api/place/autocomplete/json?#{build_google_query.to_query}"

--- a/app/services/publishers/vacancy_sort.rb
+++ b/app/services/publishers/vacancy_sort.rb
@@ -14,7 +14,7 @@ class Publishers::VacancySort < RecordSort
     end
   end
 
-private
+  private
 
   def base_options
     case @vacancy_type

--- a/app/services/request_event.rb
+++ b/app/services/request_event.rb
@@ -14,7 +14,7 @@ class RequestEvent < Event
     @current_publisher_oid = current_publisher_oid
   end
 
-private
+  private
 
   attr_reader :request, :response, :session, :current_jobseeker, :current_publisher_oid
 

--- a/app/services/search/alert_builder.rb
+++ b/app/services/search/alert_builder.rb
@@ -13,7 +13,7 @@ class Search::AlertBuilder < Search::SearchBuilder
     call_algolia_search
   end
 
-private
+  private
 
   def build_subscription_keyword(subscription_hash)
     [subscription_hash[:subject], subscription_hash[:job_title]].reject(&:blank?).join(" ")

--- a/app/services/search/algolia_search_request.rb
+++ b/app/services/search/algolia_search_request.rb
@@ -23,7 +23,7 @@ class Search::AlgoliaSearchRequest
     )
   end
 
-private
+  private
 
   def build_stats(page, pages, results_per_page, total_results)
     return [0, 0, 0] unless total_results.positive?

--- a/app/services/search/criteria_deviser.rb
+++ b/app/services/search/criteria_deviser.rb
@@ -7,7 +7,7 @@ class Search::CriteriaDeviser
     @criteria = devise_search_criteria
   end
 
-private
+  private
 
   def devise_search_criteria
     {

--- a/app/services/search/filters_builder.rb
+++ b/app/services/search/filters_builder.rb
@@ -28,7 +28,7 @@ class Search::FiltersBuilder
     filter_array.reject(&:blank?).join(" AND ")
   end
 
-private
+  private
 
   def build_filters
     @dates_filter = build_date_filters

--- a/app/services/search/location_builder.rb
+++ b/app/services/search/location_builder.rb
@@ -34,7 +34,7 @@ class Search::LocationBuilder
       (@location && LocationCategory.include?(@location))
   end
 
-private
+  private
 
   def initialize_location_polygon
     @location_polygon = LocationPolygon.with_name(@location_category)

--- a/app/services/search/replica_builder.rb
+++ b/app/services/search/replica_builder.rb
@@ -11,7 +11,7 @@ class Search::ReplicaBuilder
     @search_replica = [Indexable::INDEX_NAME, sort_by].reject(&:blank?).join("_") if sort_by.present?
   end
 
-private
+  private
 
   def valid_sort?(sort)
     Vacancy::JOB_SORTING_OPTIONS.map(&:last).include?(sort)

--- a/app/services/search/search_builder.rb
+++ b/app/services/search/search_builder.rb
@@ -30,7 +30,7 @@ class Search::SearchBuilder
     filters.any?
   end
 
-private
+  private
 
   def build_location_search
     @location_search = Search::LocationBuilder.new(@params_hash[:location], @params_hash[:radius], @params_hash[:location_category], @params_hash[:buffer_radius])

--- a/app/services/updates_parser.rb
+++ b/app/services/updates_parser.rb
@@ -7,7 +7,7 @@ class UpdatesParser
     update_file_paths_to_hash(@update_paths)
   end
 
-private
+  private
 
   def update_file_paths_to_hash(update_paths)
     updates_by_date = {}

--- a/app/services/vacancy_facets.rb
+++ b/app/services/vacancy_facets.rb
@@ -18,7 +18,7 @@ class VacancyFacets
     store.set(:counties, sort_and_limit(county_facet, 20).to_json)
   end
 
-private
+  private
 
   attr_reader :store
 

--- a/app/validators/concerns/validator_concerns.rb
+++ b/app/validators/concerns/validator_concerns.rb
@@ -5,7 +5,7 @@ module ValidatorConcerns
     options.key?(:presence) && options[:presence]
   end
 
-private
+  private
 
   def error_message(record, attribute, message)
     record.errors.add(attribute, message)

--- a/app/validators/email_address_validator.rb
+++ b/app/validators/email_address_validator.rb
@@ -8,7 +8,7 @@ class EmailAddressValidator < ActiveModel::EachValidator
     error_message(record, attribute, invalid_error_message) if value[EMAIL_FORMAT].nil?
   end
 
-private
+  private
 
   def blank_email_message
     I18n.t("activerecord.errors.models.general_feedback.attributes.email.blank")

--- a/lib/base_dsi_exporter.rb
+++ b/lib/base_dsi_exporter.rb
@@ -10,7 +10,7 @@ class BaseDsiBigQueryExporter
     @dataset = bigquery.dataset ENV.fetch("BIG_QUERY_DATASET")
   end
 
-private
+  private
 
   def delete_table(table_name)
     table = dataset.table table_name

--- a/lib/dfe_sign_in_api.rb
+++ b/lib/dfe_sign_in_api.rb
@@ -17,7 +17,7 @@ module DFESignIn
       perform_request("/users/approvers", page, APPROVERS_PAGE_SIZE)
     end
 
-  private
+    private
 
     def perform_request(endpoint, page, page_size)
       token = generate_jwt_token
@@ -44,7 +44,7 @@ module DFESignIn
     end
   end
 
-private
+  private
 
   def error_message_for(response)
     response["message"] || "failed request"

--- a/lib/export_dsi_approvers_to_big_query.rb
+++ b/lib/export_dsi_approvers_to_big_query.rb
@@ -11,7 +11,7 @@ class ExportDsiApproversToBigQuery < BaseDsiBigQueryExporter
     raise "#{e.message}, while writing data from DSI /approvers endpoint. Flag this to Steven + Comms team"
   end
 
-private
+  private
 
   def present_for_big_query(batch)
     batch.map do |user|

--- a/lib/export_dsi_users_to_big_query.rb
+++ b/lib/export_dsi_users_to_big_query.rb
@@ -11,7 +11,7 @@ class ExportDsiUsersToBigQuery < BaseDsiBigQueryExporter
     raise "#{e.message}, while writing data from DSI /users endpoint. Flag this to Steven + Comms team"
   end
 
-private
+  private
 
   def present_for_big_query(batch)
     batch.map do |user|

--- a/lib/export_tables_to_big_query.rb
+++ b/lib/export_tables_to_big_query.rb
@@ -86,7 +86,7 @@ class ExportTablesToBigQuery
     Rails.logger.info({ bigquery_export: "finished" }.to_json)
   end
 
-private
+  private
 
   def bigquery_data(record, table)
     @bigquery_data = {}

--- a/lib/flag.rb
+++ b/lib/flag.rb
@@ -8,7 +8,7 @@ class Flag
     self.class.const_get(key) == "true"
   end
 
-private
+  private
 
   attr_accessor :is_feature
 

--- a/lib/geocoding.rb
+++ b/lib/geocoding.rb
@@ -9,7 +9,7 @@ class Geocoding
     Geocoder.coordinates(location) || no_match
   end
 
-private
+  private
 
   def no_match
     [0, 0]

--- a/lib/indexing.rb
+++ b/lib/indexing.rb
@@ -23,7 +23,7 @@ class Indexing
     call(:remove)
   end
 
-private
+  private
 
   def call(action)
     notification = API::UrlNotification.new(url: url, type: ACTIONS[action])

--- a/lib/jobseeker_failure_app.rb
+++ b/lib/jobseeker_failure_app.rb
@@ -12,7 +12,7 @@ class JobseekerFailureApp < Devise::FailureApp
     end
   end
 
-private
+  private
 
   def add_flash_message
     flash_info = UNAUTHENTICATED_FLASH_MESSAGES[request.original_fullpath.split("?").first.to_sym]

--- a/lib/message_encryptor.rb
+++ b/lib/message_encryptor.rb
@@ -11,7 +11,7 @@ class MessageEncryptor
     data.is_a?(Array) ? decrypt_array : crypt.decrypt_and_verify(data)
   end
 
-private
+  private
 
   attr_reader :data
 

--- a/lib/organisation_import/import_organisation_data.rb
+++ b/lib/organisation_import/import_organisation_data.rb
@@ -4,7 +4,7 @@ require "httparty"
 require "open-uri"
 
 class ImportOrganisationData
-private
+  private
 
   def create_organisation(row)
     organisation = convert_to_organisation(row)

--- a/lib/organisation_import/import_school_data.rb
+++ b/lib/organisation_import/import_school_data.rb
@@ -20,7 +20,7 @@ class ImportSchoolData < ImportOrganisationData
     File.delete(csv_file_location)
   end
 
-private
+  private
 
   def column_name_mappings
     {

--- a/lib/organisation_import/import_trust_data.rb
+++ b/lib/organisation_import/import_trust_data.rb
@@ -10,7 +10,7 @@ class ImportTrustData < ImportOrganisationData
     import_data(membership_csv_url, MEMBERSHIP_TEMP_LOCATION, :create_school_group_membership)
   end
 
-private
+  private
 
   def column_name_mappings
     {

--- a/lib/performance_platform.rb
+++ b/lib/performance_platform.rb
@@ -20,7 +20,7 @@ module PerformancePlatform
   end
 
   class TransactionsByChannel < Base
-  private
+    private
 
     def transaction_endpoint
       "/data/teaching-jobs-job-listings/transactions-by-channel"

--- a/lib/performance_platform_sender.rb
+++ b/lib/performance_platform_sender.rb
@@ -21,7 +21,7 @@ module PerformancePlatformSender
       raise
     end
 
-  private
+    private
 
     attr_reader :date
 
@@ -31,7 +31,7 @@ module PerformancePlatformSender
   end
 
   class Transactions < Base
-  private
+    private
 
     def log_source
       "performance_platform:submit_transactions"

--- a/lib/remove_invalid_subscriptions.rb
+++ b/lib/remove_invalid_subscriptions.rb
@@ -9,7 +9,7 @@ class RemoveInvalidSubscriptions
     end
   end
 
-private
+  private
 
   def api_response
     Notifications::Client.new(NOTIFY_KEY).get_notifications(args)

--- a/lib/update_dsi_users_in_db.rb
+++ b/lib/update_dsi_users_in_db.rb
@@ -7,7 +7,7 @@ class UpdateDsiUsersInDb
     get_response_pages.each { |page| convert_to_users(page) }
   end
 
-private
+  private
 
   def convert_to_users(dsi_users)
     dsi_users.each do |dsi_user|

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -224,7 +224,7 @@ module VacancyHelpers
     verify_shared_vacancy_list_page_details(vacancy)
   end
 
-private
+  private
 
   def verify_shared_vacancy_list_page_details(vacancy)
     expect(page.find(".vacancy")).to have_content(vacancy.job_title)

--- a/spec/system/hiring_staff_can_delete_vacancies_spec.rb
+++ b/spec/system/hiring_staff_can_delete_vacancies_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "School deleting vacancies" do
     delete_vacancy(school, vacancy.id)
   end
 
-private
+  private
 
   def delete_vacancy(school, vacancy_id)
     visit organisation_path(school)

--- a/spec/system/hiring_staff_can_sign_in_by_email_spec.rb
+++ b/spec/system/hiring_staff_can_sign_in_by_email_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe "Hiring staff signing in with fallback email authentication" do
     end
   end
 
-private
+  private
 
   def click_sign_in
     within(".signin") { click_on(I18n.t("buttons.sign_in")) }


### PR DESCRIPTION
After discussing within the team, we've agreed to follow the Ruby
community guidelines' position on access modifier indentation:
https://rubystyle.guide/#indent-public-private-protected