### PR TITLE
[TEVA-859] Remove local alertmanager template

### DIFF
--- a/terraform/monitoring/resources.tf
+++ b/terraform/monitoring/resources.tf
@@ -1,17 +1,14 @@
 module prometheus_all {
   source = "git::https://github.com/DFE-Digital/cf-monitoring.git//prometheus_all"
 
-  monitoring_instance_name = local.monitoring_instance_name
-  monitoring_org_name      = local.monitoring_org_name
-  monitoring_space_name    = local.monitoring_space_name
-  paas_exporter_username   = local.secrets["paas_exporter_username"]
-  paas_exporter_password   = local.secrets["paas_exporter_password"]
-  grafana_admin_password   = local.secrets["grafana_admin_password"]
-  grafana_json_dashboards  = [file("${path.module}/config/paas_dashboard.json")]
-  alert_rules              = file("${path.module}/config/alert.rules.yml")
-  # Send alertmanager_slack_channel and alertmanager_slack_url to prometheus_all to use default notifications
+  monitoring_instance_name   = local.monitoring_instance_name
+  monitoring_org_name        = local.monitoring_org_name
+  monitoring_space_name      = local.monitoring_space_name
+  paas_exporter_username     = local.secrets["paas_exporter_username"]
+  paas_exporter_password     = local.secrets["paas_exporter_password"]
+  grafana_admin_password     = local.secrets["grafana_admin_password"]
+  grafana_json_dashboards    = [file("${path.module}/config/paas_dashboard.json")]
+  alert_rules                = file("${path.module}/config/alert.rules.yml")
   alertmanager_slack_url     = local.alertmanager_slack_url
   alertmanager_slack_channel = local.alertmanager_slack_channel
-  # Send alertmanager_config to prometheus_all to use notifications defined in config/alertmanager.yml.tmpl
-  #alertmanager_config = local.alertmanager_config
 }

--- a/terraform/monitoring/variables.tf
+++ b/terraform/monitoring/variables.tf
@@ -13,8 +13,4 @@ locals {
   secrets                    = yamldecode(data.aws_ssm_parameter.monitoring_secrets.value)
   alertmanager_slack_url     = local.secrets["alertmanager_slack_url"]
   alertmanager_slack_channel = "twd_tv_dev"
-  alertmanager_config = templatefile("${path.module}/config/alertmanager.yml.tmpl", {
-    slack_url     = local.alertmanager_slack_url
-    slack_channel = local.alertmanager_slack_channel
-  })
 }


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-859

## Changes in this PR:

- We have decided to use the alertmanager template as declared in the alertmanager module of cf-monitoring.
- Already removed the local template
- Remove the local variables and resources which rely on the already-removed template
