### PR TITLE
[TEVA-1764] GitHub Actions - Terraform improvements

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,11 +32,6 @@ jobs:
     - uses: actions/checkout@v2
       name: Checkout Code
 
-    - name: Pin Terraform version
-      uses: hashicorp/setup-terraform@v1.3.2
-      with:
-        terraform_version: 0.13.4
-
     - name: Set environment variables
       id: set_env_vars
       run: |
@@ -56,6 +51,11 @@ jobs:
           && echo Data in /teaching-vacancies/staging looks valid
         bin/run-in-env -t /teaching-vacancies/production -o quiet \
           && echo Data in /teaching-vacancies/production looks valid
+
+    - name: Terraform pin version
+      uses: hashicorp/setup-terraform@v1
+      with:
+        terraform_version: 0.13.5
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
@@ -151,9 +151,9 @@ jobs:
         TF_VAR_paas_password: ${{ secrets.CF_PASSWORD }}
       run: |
         export TF_VAR_paas_app_docker_image=${{ env.DOCKERHUB_REPOSITORY }}:${{ env.TAG }}
-        cd terraform/monitoring
         terraform init -upgrade=true -reconfigure -input=false
         terraform apply -input=false -auto-approve
+      working-directory: terraform/monitoring
 
     - name: Send job status message to twd_tv_dev channel
       if: ${{ always() && github.ref == 'refs/heads/master' }}

--- a/.github/workflows/deploy_app.yml
+++ b/.github/workflows/deploy_app.yml
@@ -33,9 +33,9 @@ jobs:
       name: Checkout Code
 
     - name: Pin Terraform version
-      uses: hashicorp/setup-terraform@v1.3.2
+      uses: hashicorp/setup-terraform@v1
       with:
-        terraform_version: 0.13.4
+        terraform_version: 0.13.5
 
     - name: Set environment variables for review
       if: ${{ startsWith(github.event.inputs.environment, 'review') }}
@@ -78,7 +78,7 @@ jobs:
         TF_VAR_paas_password: ${{ secrets.CF_PASSWORD }}
       run: |
         export TF_VAR_paas_app_docker_image=${{ env.DOCKERHUB_REPOSITORY }}:${{ github.event.inputs.tag }}
-        cd terraform/app
         terraform init -reconfigure -input=false ${{ env.BACKEND_CONFIG }}
         terraform workspace select ${{ github.event.inputs.environment }} || terraform workspace new ${{ github.event.inputs.environment }}
         terraform apply -var-file ../workspace-variables/${{ env.VAR_FILE }}.tfvars -auto-approve -input=false
+      working-directory: terraform/app

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -33,11 +33,6 @@ jobs:
     - uses: actions/checkout@v2
       name: Checkout Code
 
-    - name: Pin Terraform version
-      uses: hashicorp/setup-terraform@v1.3.2
-      with:
-        terraform_version: 0.13.4
-
     - name: Set environment variables
       id: set_env_vars
       run: |

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -42,9 +42,9 @@ jobs:
           && echo Data in /teaching-vacancies/dev looks valid
 
     - name: Terraform pin version
-      uses: hashicorp/setup-terraform@v1.3.2
+      uses: hashicorp/setup-terraform@v1
       with:
-        terraform_version: 0.13.4
+        terraform_version: 0.13.5
 
     - name: Terraform destroy (on PR closed)
       env:
@@ -54,11 +54,11 @@ jobs:
         TF_VAR_paas_password: ${{ secrets.CF_PASSWORD }}
       run: |
         export TF_VAR_environment=review-pr-${{ github.event.number }}
-        cd terraform/app
         terraform init -reconfigure -input=false -backend-config="workspace_key_prefix=review:"
         terraform workspace select review-pr-${{ github.event.number }} || terraform workspace new review-pr-${{ github.event.number }}
         terraform destroy -var-file ../workspace-variables/review.tfvars -auto-approve
         terraform workspace select default && terraform workspace delete review-pr-${{ github.event.number }}
+      working-directory: terraform/app
 
     - name: Send failure message to twd_tv_dev channel
       if: ${{ failure() }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -75,9 +75,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Terraform pin version
-        uses: hashicorp/setup-terraform@v1.3.2
+        uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.13.4
+          terraform_version: 0.13.5
 
       - name: Terraform fmt check
         run: |

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -1,4 +1,4 @@
-name: Refresh environment 
+name: Refresh environment
 
 on:
   workflow_dispatch:
@@ -19,9 +19,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Pin Terraform version
-        uses: hashicorp/setup-terraform@v1.3.2
+        uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.13.4
+          terraform_version: 0.13.5
           terraform_wrapper: false
 
       - name: Get current Docker tag from Terraform output
@@ -32,10 +32,10 @@ jobs:
           TF_VAR_paas_user: ${{ secrets.CF_USERNAME }}
           TF_VAR_paas_password: ${{ secrets.CF_PASSWORD }}
         run: |
-          cd terraform/app
           terraform init -reconfigure -input=false
           terraform workspace select ${{ github.event.inputs.environment }}
           echo ::set-output name=tag::$(terraform output docker_tag)
+        working-directory: terraform/app
 
       - name: Trigger Deploy App Workflow
         uses: benc-uk/workflow-dispatch@v1.1
@@ -53,7 +53,7 @@ jobs:
           ref: ${{ github.ref }}
           timeoutSeconds: 300
           intervalSeconds: 15
-    
+
       - name: Send job status message to twd_tv_dev channel
         if: ${{ always() && github.ref == 'refs/heads/master' }}
         uses: rtCamp/action-slack-notify@v2.1.2

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -46,11 +46,6 @@ jobs:
         bin/run-in-env -t /teaching-vacancies/dev -o quiet \
           && echo Data in /teaching-vacancies/dev looks valid
 
-    - name: Terraform pin version
-      uses: hashicorp/setup-terraform@v1.3.2
-      with:
-        terraform_version: 0.13.4
-
     - name: Set environment variables
       id: set_env_vars
       run: |

--- a/terraform/monitoring/versions.tf
+++ b/terraform/monitoring/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.1"
   required_providers {
     archive = {
       source  = "hashicorp/archive"


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1764

## Changes in this PR:

- Terraform CLI - minor version bump to `0.13.5`
- Switch to using semantic versioning `@v1` of the Terraform action rather than a specific version
- Used `working-directory` of Terraform action rather than changing directory in the run command
- Removed Terraform setup from actions which no longer need it, as they then call a deployment workflow
- Made minimum version requirement `0.13.1` for monitoring (whose state was already at `0.13.4` because of the version of the CLI which was in use)
