### PR TITLE
Simplify DSI sign in error handling

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,7 +94,7 @@ Rails.application.routes.draw do
 
   get "/auth/dfe/callback", to: "publishers/sign_in/dfe/sessions#create"
   get "/auth/dfe/signout", to: "publishers/sign_in/dfe/sessions#destroy"
-  get "/auth/failure", to: "publishers/sign_in/dfe/sessions#new"
+  get "/auth/failure", to: redirect("/dfe/sessions/new", status: 303)
 
   resource :terms_and_conditions, only: %i[show update], controller: "publishers/terms_and_conditions"
 

--- a/spec/requests/dfe_sign_in_spec.rb
+++ b/spec/requests/dfe_sign_in_spec.rb
@@ -1,26 +1,13 @@
 require "rails_helper"
 
 RSpec.describe "DfE Sign-in", type: :request do
-  context "when DfE Sign-in respond with an OIDC payload for authentication purposes" do
-    context "when that payload is unauthorised" do
-      it "redirects the user to the DfE sign-in new session page" do
-        params = {
-          'code': "a-long-secret",
-          'session_state': "123.456",
-        }
+  context "when a request comes in without proper OIDC params" do
+    it "routes the request back to DSI" do
+      get auth_dfe_callback_path
 
-        get auth_dfe_callback_path, params: params
-
-        expect(response.status).to eq(302)
-        expect(response.body).to eq("Redirecting to /dfe/sessions/new...")
-      end
-    end
-  end
-
-  context "when a user is linked back to our service with a redirect" do
-    it "routes the request back to the new sign-in page" do
-      request = get auth_dfe_callback_path
-      expect(request).to redirect_to(new_dfe_path)
+      expect(response).to redirect_to("/auth/failure?message=csrf_detected&strategy=dfe")
+      follow_redirect!
+      expect(response).to redirect_to("/dfe/sessions/new")
     end
   end
 end


### PR DESCRIPTION
Apparently DSI will sometimes redirect to our callback URL outside of
the OIDC authentication flow, which will cause OmniAuth to think a CSRF
attempt has been made, and leave the user stranded on an error page.

This was previously handled by tweaked copy-and-pasted code from the
`omniauth_openid_connect` library in order to identify when a request
comes in without the requisite flow parameters. This doesn't make much
sense however, as `omniauth` will handle errors by default anyway by
redirecting to `/auth/failure`, which we already route to an appropriate
place.

- Remove custom OmniAuth strategy and use default OIDC strategy
- Redirect `/auth/failure` route to DSI instead of routing directly