### PR TITLE
[TEVA-1849] Makefile help consistency of options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ terraform-app-apply: terraform-app-init check-docker-tag ## make passcode=MyPass
 		cd terraform/app && terraform apply -input=false -var-file ../workspace-variables/$(var_file).tfvars -auto-approve
 
 .PHONY: terraform-app-destroy-review
-terraform-app-destroy-review: terraform-app-init ## make CONFIRM_DESTROY=true passcode=MyPasscode pr_id=2086 review terraform-app-destroy-review
+terraform-app-destroy-review: terraform-app-init ## make passcode=MyPasscode CONFIRM_DESTROY=true pr_id=2086 review terraform-app-destroy-review
 		$(if $(CONFIRM_DESTROY), , $(error Can only run with CONFIRM_DESTROY))
 		cd terraform/app && terraform destroy -var-file ../workspace-variables/review.tfvars -auto-approve
 		cd terraform/app && terraform workspace select default && terraform workspace delete $(env)
@@ -127,11 +127,11 @@ terraform-monitoring-init:
 		cd terraform/monitoring && terraform init -upgrade=true -reconfigure -input=false
 
 .PHONY: terraform-monitoring-plan
-terraform-monitoring-plan: terraform-monitoring-init ## make terraform-monitoring-plan passcode=MyPasscode
+terraform-monitoring-plan: terraform-monitoring-init ## make passcode=MyPasscode terraform-monitoring-plan
 		cd terraform/monitoring && terraform plan -input=false
 
 .PHONY: terraform-monitoring-apply
-terraform-monitoring-apply: terraform-monitoring-init ## make terraform-monitoring-apply passcode=MyPasscode
+terraform-monitoring-apply: terraform-monitoring-init ## make passcode=MyPasscode terraform-monitoring-apply
 		cd terraform/monitoring && terraform apply -input=false -auto-approve
 
 ##@ Help

--- a/documentation/hosting.md
+++ b/documentation/hosting.md
@@ -141,7 +141,7 @@ cf run-task <app_name> -c "rails task:name"
 This builds and deploys a Docker image from local code, then updates the `dev` environment to use that image
 
 ```bash
-passcode=<passcode> make <environment> deploy-local-image
+make passcode=<passcode> <environment> deploy-local-image
 ```
 performs these steps:
 
@@ -160,7 +160,7 @@ You need:
 This allows you to update the `dev` environment to use a previously-built Docker image
 
 ```bash
-passcode=<passcode> tag=47fd1475376bbfa16a773693133569b794408995 make <environment> terraform-app-apply
+make passcode=<passcode> tag=47fd1475376bbfa16a773693133569b794408995 <environment> terraform-app-apply
 ```
 performs these steps:
 

--- a/documentation/terraform.md
+++ b/documentation/terraform.md
@@ -14,12 +14,12 @@ make passcode=MyPasscode tag=47fd1475376bbfa16a773693133569b794408995 staging te
 
 Production
 ```
-make CONFIRM_PRODUCTION=true passcode=MyPasscode tag=47fd1475376bbfa16a773693133569b794408995 production terraform-app-plan
+make passcode=MyPasscode CONFIRM_PRODUCTION=true tag=47fd1475376bbfa16a773693133569b794408995 production terraform-app-plan
 ```
 
 Review app
 ```
-make pr=2086 passcode=MyPasscode tag=review-pr-2086-e4c2c4afd991161f88808c907b4c66a30e5f3ef4-20201002203641 review terraform-app-plan
+make passcode=MyPasscode pr=2086 tag=review-pr-2086-e4c2c4afd991161f88808c907b4c66a30e5f3ef4-20201002203641 review terraform-app-plan
 ```
 
 ## `terraform plan` with Terraform CLI commands
@@ -60,7 +60,7 @@ terraform show -json dev.plan > dev.json
 Using `jq`, we can query for the specific module and find the before and after changes
 ```
 cat dev.json | jq '.resource_changes[] | select(.address=="module.paas.cloudfoundry_app.web_app") | .change.before.environment' > dev_web_app_before.json
-cat dev.json | jq '.resource_changes[] | select(.address=="module.paas.cloudfoundry_app.web_app") | .change.after.environment' > dev_web_app_after.json 
+cat dev.json | jq '.resource_changes[] | select(.address=="module.paas.cloudfoundry_app.web_app") | .change.after.environment' > dev_web_app_after.json
 ```
 
 Then a simple diff will show the planned changes.
@@ -75,5 +75,5 @@ In usual conditions, the [`destroy.yml`](.github/workflows/destroy.yml) workflow
 
 We can use the Makefile to destroy a review app, by passing a `CONFIRM_DESTROY=true` plus changing the action to `review-destroy`:
 ```
-make pr=2086 CONFIRM_DESTROY=true passcode=MyPasscode review review-destroy
+make passcode=MyPasscode pr=2086 CONFIRM_DESTROY=true review review-destroy
 ```


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1849

## Changes in this PR:

Cosmetic ordering of Makefile help and references to it.

Where present, put `passcode=MyPasscode` as the first option in:
- Makefile built-in help
- hosting documentation
- terraform documentation