### PR TITLE
Wrap filter values in strings to account for multiple words

### DIFF
--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -71,7 +71,7 @@ module Indexable
         VacancyPresenter.new(self).working_patterns
       end
 
-      attributesForFaceting %i[job_roles working_patterns education_phases]
+      attributesForFaceting %i[job_roles working_patterns education_phases subjects]
 
       add_replica "#{INDEX_NAME}_publish_on_desc", inherit: true do
         ranking ["desc(publication_date_timestamp)"]

--- a/app/services/search/filters_builder.rb
+++ b/app/services/search/filters_builder.rb
@@ -51,7 +51,7 @@ class Search::FiltersBuilder
   end
 
   def build_filter_string(attribute, value)
-    "#{attribute}:#{value}"
+    "#{attribute}:'#{value}'"
   end
 
   def published_today_filter

--- a/spec/services/search/alert_builder_spec.rb
+++ b/spec/services/search/alert_builder_spec.rb
@@ -68,19 +68,19 @@ RSpec.describe Search::AlertBuilder do
 
         it "adds working patterns filter" do
           expect(subject.search_filters).to include(
-            "(working_patterns:full_time OR working_patterns:part_time)",
+            "(working_patterns:'full_time' OR working_patterns:'part_time')",
           )
         end
 
         it "adds NQT filter" do
           expect(subject.search_filters).to include(
-            "(job_roles:nqt_suitable)",
+            "(job_roles:'nqt_suitable')",
           )
         end
 
         it "adds school phase filter" do
           expect(subject.search_filters).to include(
-            "(education_phases:secondary OR education_phases:primary)",
+            "(education_phases:'secondary' OR education_phases:'primary')",
           )
         end
       end
@@ -92,9 +92,9 @@ RSpec.describe Search::AlertBuilder do
         "(publication_date_timestamp <= #{date_today.to_i} AND expires_at_timestamp > #{expired_now.to_time.to_i})"\
         " AND (publication_date_timestamp >= #{date_today.to_i} AND publication_date_timestamp <="\
         " #{date_today.to_i}) AND "\
-        "(education_phases:secondary OR education_phases:primary) AND "\
-        "(working_patterns:full_time OR working_patterns:part_time) AND "\
-        "(job_roles:nqt_suitable)"
+        "(education_phases:'secondary' OR education_phases:'primary') AND "\
+        "(working_patterns:'full_time' OR working_patterns:'part_time') AND "\
+        "(job_roles:'nqt_suitable')"
       end
 
       before do

--- a/spec/services/search/filters_builder_spec.rb
+++ b/spec/services/search/filters_builder_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Search::FiltersBuilder do
       let(:working_patterns) { ["full_time", nil] }
 
       it "only filters the valid working pattern" do
-        expect(subject.filter_query).to include("(working_patterns:full_time)")
+        expect(subject.filter_query).to include("(working_patterns:'full_time')")
       end
     end
 
@@ -82,7 +82,7 @@ RSpec.describe Search::FiltersBuilder do
       let(:newly_qualified_teacher) { "true" }
 
       it "filters NQT jobs" do
-        expect(subject.filter_query).to match(/job_roles:nqt_suitable/)
+        expect(subject.filter_query).to match(/job_roles:'nqt_suitable'/)
       end
     end
 
@@ -104,10 +104,10 @@ RSpec.describe Search::FiltersBuilder do
           " expires_at_timestamp > #{expired_now_filter}) AND "\
           "(publication_date_timestamp >= #{from_date.to_time.to_i} AND" \
           " publication_date_timestamp <= #{to_date.to_time.to_i}) AND " \
-          "(job_roles:teacher OR job_roles:sen_specialist) AND " \
-          "(education_phases:secondary OR education_phases:primary) AND " \
-          "(working_patterns:full_time OR working_patterns:part_time) AND " \
-          "(subjects:Science OR subjects:Biology)",
+          "(job_roles:'teacher' OR job_roles:'sen_specialist') AND " \
+          "(education_phases:'secondary' OR education_phases:'primary') AND " \
+          "(working_patterns:'full_time' OR working_patterns:'part_time') AND " \
+          "(subjects:'Science' OR subjects:'Biology')",
         )
       end
     end


### PR DESCRIPTION
For subjects that have multiple words, algolia didn't like the whitespace (and rightly so!)

Now we put all facet values inside single quotes like `job_role:'teacher'` so that this is no longer a problem

**Fixes**
- https://rollbar.com/dfe/teacher-vacancies/items/3165/
- https://rollbar.com/dfe/teacher-vacancies/items/2789/