### PR TITLE
Comment out unusable migration

### DIFF
--- a/db/migrate/20180404131534_add_leadership_data.rb
+++ b/db/migrate/20180404131534_add_leadership_data.rb
@@ -1,9 +1,11 @@
 class AddLeadershipData < ActiveRecord::Migration[5.1]
   def change
-    ['Executive Head', 'Headteacher',
-     'Middle Leader', 'Multi-Academy Trust',
-     'Senior Leader'].each do |leadership|
-       Leadership.find_or_create_by(title: leadership)
-     end
+    # Commented out this method as it relies on code that no longer exists. We removed the class Leadership.
+    
+#     ['Executive Head', 'Headteacher',
+#      'Middle Leader', 'Multi-Academy Trust',
+#      'Senior Leader'].each do |leadership|
+#        Leadership.find_or_create_by(title: leadership)
+#      end
   end
 end


### PR DESCRIPTION
Commented out this method as it relies on code that no longer exists. We removed the class Leadership.