### PR TITLE
Strip whitespaces from form input

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,6 @@ class ApplicationController < ActionController::Base
 
   before_action :redirect_to_canonical_domain, :set_headers
   before_action :store_jobseeker_redirect_to!, if: -> { redirect_to_param.present? }
-  before_action { strip_nested_param_whitespaces(request.params) }
 
   after_action :trigger_page_visited_event, unless: :request_is_healthcheck?
 
@@ -77,20 +76,6 @@ class ApplicationController < ActionController::Base
 
   def invalid_recaptcha_score?
     recaptcha_reply["score"] < SUSPICIOUS_RECAPTCHA_THRESHOLD
-  end
-
-  def strip_nested_param_whitespaces(object)
-    # Recursively find strings and strip them of trailing whitespaces
-    case object
-    when String
-      return object.strip
-    when Hash
-      object.each do |key, value|
-        object[key] = strip_nested_param_whitespaces(value)
-      end
-    end
-
-    object
   end
 
   def request_event

--- a/app/form_models/vacancy_algolia_search_form.rb
+++ b/app/form_models/vacancy_algolia_search_form.rb
@@ -9,6 +9,7 @@ class VacancyAlgoliaSearchForm
               :total_filters
 
   def initialize(params = {})
+    strip_trailing_whitespaces_from_params(params)
     @keyword = params[:keyword] || params[:subject]
 
     @location = params[:location] || params[:location_category]
@@ -43,6 +44,10 @@ class VacancyAlgoliaSearchForm
   end
 
   private
+
+  def strip_trailing_whitespaces_from_params(params)
+    params.each_value { |value| value.strip! if value.respond_to?(:strip!) }
+  end
 
   def set_facet_options
     @job_role_options = Vacancy.job_roles.keys.map { |option| [option, I18n.t("helpers.label.job_details_form.job_roles_options.#{option}")] }

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -55,31 +55,6 @@ RSpec.describe ApplicationController, type: :controller do
     end
   end
 
-  describe "#strip_nested_param_whitespaces" do
-    let(:nested_field) { { array_field: %w[1 2], string_field: "   Buckle my shoe   " } }
-    let(:test_form) { { array_field: %w[3 4], string_field: "   Knock on the door   ", nested_field: nested_field } }
-    let(:params) { { test_form: test_form } }
-
-    before do
-      get :test_action, params: params
-    end
-
-    it "strips any string fields of trailing whitespaces" do
-      expect(controller.params[:test_form][:string_field]).to eq "Knock on the door"
-    end
-
-    it "strips any nested string fields of trailing whitespaces" do
-      expect(controller.params[:test_form][:nested_field][:string_field]).to eq "Buckle my shoe"
-    end
-
-    it "leaves the other fields and params unchanged" do
-      expect(controller.params[:action]).to eq "test_action"
-      expect(controller.params[:controller]).to eq "anonymous"
-      expect(controller.params[:test_form][:nested_field][:array_field]).to eq %w[1 2]
-      expect(controller.params[:test_form][:array_field]).to eq %w[3 4]
-    end
-  end
-
   describe "AB testing helpers" do
     let(:ab_tests) { double(AbTests, current_variants: {}) }
 

--- a/spec/form_models/vacancy_algolia_search_form_spec.rb
+++ b/spec/form_models/vacancy_algolia_search_form_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe VacancyAlgoliaSearchForm, type: :model do
+  let(:subject) { described_class.new(params) }
+
+  describe "#strip_trailing_whitespaces_from_params" do
+    context "when user input contains trailing whitespace" do
+      let(:keyword) { " teacher " }
+      let(:location) { "the big smoke " }
+      let(:location_category) { " whitespace county" }
+      let(:params) do
+        { keyword: keyword, location: location, location_category: location_category }
+      end
+
+      it "strips the whitespace before saving the attribute" do
+        expect(subject.keyword).to eq "teacher"
+        expect(subject.location).to eq "the big smoke"
+        expect(subject.location_category).to eq "whitespace county"
+      end
+    end
+  end
+end


### PR DESCRIPTION
The previous solution was not having the desired effect - it did not have any effect.

This solution is hopefully simple enough to work.

The issue is probably caused by phones inserting a whitespace after a word is selected.

Previous discussion: https://ukgovernmentdfe.slack.com/archives/G0127R0KXQF/p1606902817045700
