### PR TITLE
Replace delete link_to with delete button_to

### DIFF
--- a/app/views/publishers/organisations/_vacancy_draft.html.slim
+++ b/app/views/publishers/organisations/_vacancy_draft.html.slim
@@ -13,4 +13,4 @@
       ul.actions.govuk-list
         li = govuk_link_to(t("jobs.edit_link"), vacancy.edit_path)
         li = govuk_link_to(t("jobs.copy_link"), vacancy.copy_path, method: :get)
-        li = govuk_link_to(t("jobs.delete_link"), vacancy.delete_path, method: :delete, data: { confirm: t("jobs.are_you_sure", job_title: vacancy.job_title) })
+        li = button_to(t("jobs.delete_link"), vacancy.delete_path, method: :delete, data: { confirm: t("jobs.are_you_sure", job_title: vacancy.job_title) }, class: "govuk-delete-link")

--- a/app/views/publishers/organisations/_vacancy_expired.html.slim
+++ b/app/views/publishers/organisations/_vacancy_expired.html.slim
@@ -13,4 +13,4 @@
     dd
       ul.actions.govuk-list
         li = govuk_link_to(t("jobs.copy_link"), vacancy.copy_path, method: :get)
-        li = govuk_link_to(t("jobs.delete_link"), vacancy.delete_path, method: :delete, data: { confirm: t("jobs.are_you_sure", job_title: vacancy.job_title) })
+        li = button_to(t("jobs.delete_link"), vacancy.delete_path, method: :delete, data: { confirm: t("jobs.are_you_sure", job_title: vacancy.job_title) }, class: "govuk-delete-link")

--- a/app/views/publishers/organisations/_vacancy_pending.html.slim
+++ b/app/views/publishers/organisations/_vacancy_pending.html.slim
@@ -13,4 +13,4 @@
       ul.actions.govuk-list
         li = govuk_link_to(t("jobs.edit_link"), vacancy.edit_path)
         li = govuk_link_to(t("jobs.copy_link"), vacancy.copy_path, method: :get)
-        li = govuk_link_to(t("jobs.delete_link"), vacancy.delete_path, method: :delete, data: { confirm: t("jobs.are_you_sure", job_title: vacancy.job_title) })
+        li = button_to(t("jobs.delete_link"), vacancy.delete_path, method: :delete, data: { confirm: t("jobs.are_you_sure", job_title: vacancy.job_title) }, class: "govuk-delete-link")

--- a/app/views/publishers/organisations/_vacancy_published.html.slim
+++ b/app/views/publishers/organisations/_vacancy_published.html.slim
@@ -12,4 +12,4 @@
       ul.actions.govuk-list
         li = govuk_link_to(t("jobs.edit_link"), vacancy.edit_path)
         li = govuk_link_to(t("jobs.copy_link"), vacancy.copy_path, method: :get)
-        li = govuk_link_to(t("jobs.delete_link"), vacancy.delete_path, method: :delete, data: { confirm: t("jobs.are_you_sure", job_title: vacancy.job_title) })
+        li = button_to(t("jobs.delete_link"), vacancy.delete_path, method: :delete, data: { confirm: t("jobs.are_you_sure", job_title: vacancy.job_title) }, class: "govuk-delete-link")


### PR DESCRIPTION
A small PR that replaces the last of the `link_to, method: :delete` components with `button_to` (styled appropriately)