### PR TITLE
TEVA-1892 - Support renamed Gov.UK PaaS org

### DIFF
--- a/bin/sync-db
+++ b/bin/sync-db
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -eu
+CF_ORG='dfe'
 
-cf7 api $CF_API_ENDPOINT
+cf7 api ${CF_API_ENDPOINT}
 cf7 auth
 
 cf7 target -o $CF_ORG -s $CF_SPACE_ORIGIN

--- a/documentation/hosting.md
+++ b/documentation/hosting.md
@@ -22,7 +22,7 @@ On merging a Pull Request, the same code is deployed first to Staging, and after
 
 An [organisation](https://docs.cloud.service.gov.uk/orgs_spaces_users.html#organisations)
 > represents a group of users, applications and environments. Each org shares the same resource, quota and custom domain.
-Teaching Vacancies is in the [dfe-teacher-services organisation](https://docs.cloud.service.gov.uk/orgs_spaces_users.html#organisations)
+Teaching Vacancies is in the [dfe organisation](https://docs.cloud.service.gov.uk/orgs_spaces_users.html#organisations)
 
 An org is divided into one or more [spaces](https://docs.cloud.service.gov.uk/orgs_spaces_users.html#spaces). A space is a shared location for developing, deploying and running apps and backing services.
 
@@ -50,7 +50,7 @@ Senior developers, Tech Leads, and DevOps have the `SpaceManager` role in all re
 
 - [Enable Google SSO for Gov.UK PaaS](https://docs.cloud.service.gov.uk/get_started.html#use-single-sign-on)
 - Log in to GOV.UK PaaS (with `cf login --sso`). You will need a [Passcode](https://login.london.cloud.service.gov.uk/passcode)
-- Once you've selected a space, you should see your user ID (between `API version` and `org: dfe-teacher-services`)
+- Once you've selected a space, you should see your user ID (between `API version` and `org: dfe`)
 - Add your user ID and name to [this SSO Confluence page](https://dfedigital.atlassian.net/wiki/spaces/BaT/pages/1935048705/Single+sign-on+SSO) so that it's easier to identify you.
 - A colleague with the `Space manager` role can [set or unset the Space developer role](#setunset-spacedeveloper-role) as required.
 
@@ -64,7 +64,7 @@ brew install cloudfoundry/tap/cf-cli@7
 
 ```bash
 CF_API_ENDPOINT=https://api.london.cloud.service.gov.uk
-CF_ORG=dfe-teacher-services
+CF_ORG=dfe
 ```
 
 Set `CF_SPACE` to environment(space) you want to deal with, e.g. `teaching-vacancies-dev`

--- a/documentation/onboarding.md
+++ b/documentation/onboarding.md
@@ -26,7 +26,7 @@ The new developer will be added to [teaching-vacancies-developers](https://githu
 
 ## GOV.UK PaaS
 
-`#digital-tools-support` will add the new developer to the [dfe-teacher-services organisation](https://admin.london.cloud.service.gov.uk/organisations/386a9502-d9b6-4aba-b3c3-ebe4fa3f963e) inside the following spaces:
+`#digital-tools-support` will add the new developer to the [dfe organisation](https://admin.london.cloud.service.gov.uk/organisations/386a9502-d9b6-4aba-b3c3-ebe4fa3f963e) inside the following spaces:
 
 * teaching-vacancies-dev
 * teaching-vacancies-staging

--- a/terraform/app/modules/paas/data.tf
+++ b/terraform/app/modules/paas/data.tf
@@ -11,7 +11,7 @@ data aws_ssm_parameter app_env_secrets {
 }
 
 data cloudfoundry_org org {
-  name = "dfe-teacher-services"
+  name = "dfe"
 }
 
 data cloudfoundry_space space {

--- a/terraform/monitoring/variables.tf
+++ b/terraform/monitoring/variables.tf
@@ -6,7 +6,7 @@ locals {
   service_name               = "teaching-vacancies"
   monitoring_instance_name   = local.service_name
   paas_api_url               = "https://api.london.cloud.service.gov.uk"
-  monitoring_org_name        = "dfe-teacher-services"
+  monitoring_org_name        = "dfe"
   space_name                 = "${local.service_name}-monitoring"
   monitoring_space_name      = "${local.service_name}-monitoring"
   aws_region                 = "eu-west-2"


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1892

## Changes in this PR:

- Gov.UK PaaS organisation will be renamed from `dfe-teacher-services` to `dfe`
- Changed in documentation and Terraform (app and monitoring)
- Hard-coded `CF_ORG` value in `sync-db` script to avoid dependence on a secret which is not a secret

## Next steps:

- [ ] Remove GitHub secret `CF_ORG` value after merge