### PR TITLE
[TEVA-1638] Remove leading text from Pull Request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,3 @@
-Pull Request template
-
-- Fill in or remove sections as necessary
-- Delete this section before submitting your PR
-
 ## Jira ticket URL
 
 - Just add the ticket number to the end:


### PR DESCRIPTION
The first 3 lines of the Pull Request Template are always deleted.
Tiny improvement - remove from the template

This is a markdown template, so as such, has no automation possibilities. Even if we look at https://docs.github.com/en/github/managing-your-work-on-github/about-automation-for-issues-and-pull-requests-with-query-parameters we see that the “template” option just chooses which template, but doesn’t provide any content into that template

Jira and GitHub are linked in one direction - Jira can know about GitHub, but GitHub doesn’t know about JIRA

The Pull Request number isn’t known at the point of raising the PR. As not every PR generates a review app, we should rely on the Sticky comment added by the review workflow.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1638

## Changes in this PR:

- Remove the first 3 lines of the pull request template to avoid having to delete each time.