### PR TITLE
[TEVA-1896] Increase timeout on wait step

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -102,7 +102,7 @@ jobs:
         token: ${{ secrets.PERSONAL_TOKEN }}
         checkName: Deploy ${{ env.TAG }} to review # Job name within workflow
         ref: ${{ github.event.pull_request.head.sha || github.ref }}
-        timeoutSeconds: 300
+        timeoutSeconds: 720
         intervalSeconds: 15
 
     - name: Post Sticky Pull Request Comment


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1896

## Changes in this PR:

- Review environments created from scratch take around 10 minutes to be created.
- The previous timeout of 5 minutes was triggering and skipping over the condition for adding the PR comment.
- Increased to 720 seconds (12 minutes)