### PR TITLE
Don't log enqueueing of SendEventToDataWarehouseJob

### DIFF
--- a/app/jobs/send_event_to_data_warehouse_job.rb
+++ b/app/jobs/send_event_to_data_warehouse_job.rb
@@ -1,6 +1,9 @@
 class SendEventToDataWarehouseJob < ApplicationJob
   queue_as :send_event_to_data_warehouse
 
+  # Do not log that this job has been enqueued (as it produces at least one superfluous log per request)
+  self.logger = nil
+
   def perform(table_name, data)
     bq = Google::Cloud::Bigquery.new
     dataset = bq.dataset(ENV.fetch("BIG_QUERY_DATASET"), skip_lookup: true)


### PR DESCRIPTION
This job gets enqueued at least once per request with a huge amount of
data, which is firehosing our logs. We don't really care about the job
having been enqueued, so we can just set its logger to `nil` to stop it
from spamming.