### PR TITLE
Polygons step 5 of 5: Remove old-format LocationPolygons left over

### DIFF
--- a/db/migrate/20210125184458_delete_duplicate_location_polygons.rb
+++ b/db/migrate/20210125184458_delete_duplicate_location_polygons.rb
@@ -1,0 +1,5 @@
+class DeleteDuplicateLocationPolygons < ActiveRecord::Migration[6.1]
+  def change
+    LocationPolygon.where(polygons: nil).delete_all
+  end
+end

--- a/db/migrate/20210125184859_drop_boundary_column_from_location_polygons.rb
+++ b/db/migrate/20210125184859_drop_boundary_column_from_location_polygons.rb
@@ -1,0 +1,5 @@
+class DropBoundaryColumnFromLocationPolygons < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :location_polygons, :boundary
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_25_105308) do
+ActiveRecord::Schema.define(version: 2021_01_25_184859) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -155,7 +155,6 @@ ActiveRecord::Schema.define(version: 2021_01_25_105308) do
   create_table "location_polygons", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
     t.string "location_type"
-    t.float "boundary", array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "buffers"

--- a/spec/factories/location_polygon.rb
+++ b/spec/factories/location_polygon.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :location_polygon do
     name { "London" }
     location_type { "cities" }
-    boundary { [51.466517484391, -0.4919530143329] }
     buffers do
       {
         "5" => [[51.46822890300007, -0.564208123999947]],


### PR DESCRIPTION
The last step in [the plan](https://github.com/DFE-Digital/teaching-vacancies/pull/2593#issuecomment-764615951).

Remove old-format LocationPolygons left over due to e.g. changing location type from city to county.

Old-format LocationPolygons store(d) their data in the 'boundary' column; new-format
LocationPolygons store their data in the 'polygons' column
(and most of them will have data in the boundary column
left over from before, unless they changed location
type, as mentioned.)