### PR TITLE
Use Rails configuration to store Redis URL

### DIFF
--- a/app/services/vacancy_facets.rb
+++ b/app/services/vacancy_facets.rb
@@ -1,7 +1,7 @@
 class VacancyFacets
   FIELDS = %i[job_roles subjects cities counties].freeze
 
-  def initialize(store: Redis.new(url: REDIS_URL))
+  def initialize(store: Redis.new(url: Rails.configuration.redis_store_url))
     @store = store
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -52,6 +52,15 @@ module TeacherVacancyService
       api_key: ENV["NOTIFY_KEY"],
     }
 
+    # Set up backing services through Cloudfoundry VCAP_SERVICES if running in production
+    if ENV["VCAP_SERVICES"].present?
+      vcap_services = JSON.parse(ENV["VCAP_SERVICES"])
+
+      config.redis_store_url = vcap_services["redis"][0]["credentials"]["uri"]
+    else
+      config.redis_store_url = ENV.fetch("REDIS_URL", "redis://localhost:6379")
+    end
+
     config.ab_tests = config_for(:ab_tests)
   end
 end

--- a/config/initializers/00_set_services.rb
+++ b/config/initializers/00_set_services.rb
@@ -1,7 +1,0 @@
-REDIS_URL =
-  if ENV["VCAP_SERVICES"]
-    VCAP_SERVICES = JSON.parse(ENV["VCAP_SERVICES"])
-    VCAP_SERVICES["redis"][0]["credentials"]["uri"]
-  else
-    "redis://localhost:6379"
-  end

--- a/config/initializers/01_redis_objects.rb
+++ b/config/initializers/01_redis_objects.rb
@@ -5,6 +5,6 @@ Redis::Objects.redis =
     MockRedis.new
   else
     ConnectionPool.new(size: 5, timeout: 5) do
-      Redis.new(url: "#{REDIS_URL}/1")
+      Redis.new(url: "#{Rails.configuration.redis_store_url}/1")
     end
   end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,7 +1,5 @@
 return if Rails.env.test?
 
-redis_url = "#{REDIS_URL}/0"
-
 options = {
   concurrency: Integer(ENV.fetch("RAILS_MAX_THREADS", 5)),
 }
@@ -9,12 +7,12 @@ options = {
 # Redis concurrency must be plus 5 https://github.com/mperham/sidekiq/wiki/Using-Redis#complete-control
 Sidekiq.configure_server do |config|
   config.options.merge!(options)
-  config.redis = { url: redis_url, network_timeout: 5, size: config.options[:concurrency] + 5 }
+  config.redis = { url: Rails.configuration.redis_store_url, network_timeout: 5, size: config.options[:concurrency] + 5 }
 end
 
 Sidekiq.configure_client do |config|
   config.options.merge!(options)
-  config.redis = { url: redis_url, network_timeout: 5, size: config.options[:concurrency] + 5 }
+  config.redis = { url: Rails.configuration.redis_store_url, network_timeout: 5, size: config.options[:concurrency] + 5 }
 end
 
 schedule_file = "config/schedule.yml"


### PR DESCRIPTION
This shouldn't be a global constant, but use idiomatic Rails
configuration instead. In production, read it from `VCAP_SERVICES`,
otherwise rely on `REDIS_URL` or a sensible fallback.

Use `redis_store_url` for this, and then we may add a `redis_cache_url`
in the future.