### PR TITLE
Improve Sidekiq memory usage by tuning glibc

### DIFF
--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -105,6 +105,6 @@ locals {
   postgres_service_name    = "${var.service_name}-postgres-${var.environment}"
   redis_service_name       = "${var.service_name}-redis-${var.environment}"
   web_app_name             = "${var.service_name}-${var.environment}"
-  worker_app_start_command = "bundle exec sidekiq -C config/sidekiq.yml"
+  worker_app_start_command = "MALLOC_ARENA_MAX=2 bundle exec sidekiq -C config/sidekiq.yml"
   worker_app_name          = "${var.service_name}-worker-${var.environment}"
 }


### PR DESCRIPTION
Reduce glibc’s memory arena count for our sidekiq workers so they don't
gobble up memory like it's candy. 🍭

cf. https://devcenter.heroku.com/changelog-items/1683