### PR TITLE
Use bang-suffixed load method for sidekiq-cron

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -19,7 +19,7 @@ schedule_file = "config/schedule.yml"
 
 if File.exist?(schedule_file) && Sidekiq.server?
   Rails.application.config.after_initialize do
-    Sidekiq::Cron::Job.load_from_hash YAML.load_file(schedule_file)
+    Sidekiq::Cron::Job.load_from_hash! YAML.load_file(schedule_file)
   end
 end
 


### PR DESCRIPTION
`Sidekiq::Cron::Job.load_from_hash` will not actually remove jobs that
no longer exist, and leave behind zombie jobs for those that have been
renamed - we need to use `.load_from_hash!`

> Bang-suffixed methods will remove jobs that are not present in the
> given hash/array, update jobs that have the same names, and create
> new ones when the names are previously unknown.