### PR TITLE
[TEVA-1896] Review app environment specificity

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -50,7 +50,9 @@ jobs:
       id: set_env_vars
       run: |
         $(echo "BRANCH=${{ github.head_ref }}" | sed -e 's/\//_/g' >> $GITHUB_ENV)
-        TAG=review-pr-${{ github.event.number }}-${{ github.sha }}-$(date '+%Y%m%d%H%M%S')
+        ENVIRONMENT=review-pr-${{ github.event.number }}
+        TAG=${ENVIRONMENT}-${{ github.sha }}-$(date '+%Y%m%d%H%M%S')
+        echo "ENVIRONMENT=${ENVIRONMENT}" >> $GITHUB_ENV
         echo "TAG=${TAG}" >> $GITHUB_ENV
 
     - name: Set up Docker Buildx
@@ -93,14 +95,14 @@ jobs:
         token: ${{ secrets.PERSONAL_TOKEN }}
         ref: ${{ github.event.pull_request.head.ref || github.ref }}
         workflow: Deploy App to Environment # Workflow name
-        inputs: '{"environment": "review-pr-${{ github.event.number }}", "tag": "${{ env.TAG }}"}'
+        inputs: '{"environment": "${{ env.ENVIRONMENT }}", "tag": "${{ env.TAG }}"}'
 
     - name: Wait for Deploy App Workflow for review
       id: wait_for_deploy_app
       uses: fountainhead/action-wait-for-check@v1.0.0
       with:
         token: ${{ secrets.PERSONAL_TOKEN }}
-        checkName: Deploy ${{ env.TAG }} to review # Job name within workflow
+        checkName: Deploy ${{ env.TAG }} to ${{ env.ENVIRONMENT }} # Job name within workflow
         ref: ${{ github.event.pull_request.head.sha || github.ref }}
         timeoutSeconds: 720
         intervalSeconds: 15


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1896

## Changes in this PR:

- For review apps, the environment is more specific than just `review`
- For the permanent branches, the environment is `dev`, `staging`, `production`
- For review, it's e.g. `review-pr-2721-af23d14f7ac6d5c5035916d1579dc54c0cf5f2e4-20210127162424`
- This longer environment needs to be used in the wait action
- Note the sticky comment applied in this PR