### PR TITLE
Convert search_criteria from JSON string to Hash

### DIFF
--- a/app/form_models/jobseekers/nqt_job_alerts_form.rb
+++ b/app/form_models/jobseekers/nqt_job_alerts_form.rb
@@ -21,7 +21,7 @@ class Jobseekers::NqtJobAlertsForm
     {
       email: email,
       frequency: :daily,
-      search_criteria: nqt_job_alert_hash.to_json,
+      search_criteria: nqt_job_alert_hash,
     }
   end
 

--- a/app/form_models/jobseekers/subscription_form.rb
+++ b/app/form_models/jobseekers/subscription_form.rb
@@ -37,7 +37,7 @@ class Jobseekers::SubscriptionForm
     {
       email: email,
       frequency: frequency,
-      search_criteria: search_criteria_hash.to_json,
+      search_criteria: search_criteria_hash,
     }
   end
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -26,6 +26,8 @@ class Subscription < ApplicationRecord
   end
 
   def search_criteria_to_h
+    return search_criteria if search_criteria.is_a?(Hash)
+
     parsed_criteria = JSON.parse(search_criteria) if search_criteria.present?
     parsed_criteria.is_a?(Hash) ? parsed_criteria : {}
   rescue JSON::ParserError

--- a/lib/tasks/convert_search_criteria.rake
+++ b/lib/tasks/convert_search_criteria.rake
@@ -1,0 +1,6 @@
+namespace :subscriptions do
+  desc "Convert search criteria from JSON string to Hash"
+  task convert_search_criteria: :environment do
+    Subscription.find_each { |s| s.update_column :search_criteria, JSON.parse(s.search_criteria) if s.search_criteria.is_a?(String) }
+  end
+end

--- a/spec/controllers/nqt_job_alerts_controller_spec.rb
+++ b/spec/controllers/nqt_job_alerts_controller_spec.rb
@@ -9,9 +9,7 @@ RSpec.describe NqtJobAlertsController, type: :controller do
 
   describe "#create" do
     let(:params) { { jobseekers_nqt_job_alerts_form: form_inputs } }
-    let(:search_criteria) do
-      { keyword: "nqt #{keywords}", location: location, radius: 10 }.to_json
-    end
+    let(:search_criteria) { { keyword: "nqt #{keywords}", location: location, radius: 10 } }
     let(:subscription) { Subscription.last }
     let(:subject) { post :create, params: params }
 
@@ -23,7 +21,7 @@ RSpec.describe NqtJobAlertsController, type: :controller do
     it "creates a subscription" do
       expect { subject }.to change { Subscription.count }.by(1)
       expect(subscription.email).to eq(email)
-      expect(subscription.search_criteria).to eq(search_criteria)
+      expect(subscription.search_criteria.symbolize_keys).to eq(search_criteria)
     end
 
     it "triggers a `job_alert_subscription_created` event" do

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe SubscriptionsController, type: :controller do
     it "creates a subscription" do
       expect { subject }.to change { Subscription.count }.by(1)
       expect(subscription.email).to eq("foo@email.com")
-      expect(subscription.search_criteria).to eq({ keyword: "english" }.to_json)
+      expect(subscription.search_criteria.symbolize_keys).to eq({ keyword: "english" })
     end
 
     it "triggers a `job_alert_subscription_created` event" do
@@ -81,7 +81,7 @@ RSpec.describe SubscriptionsController, type: :controller do
     it "updates the subscription" do
       expect { subject }.not_to(change { Subscription.count })
       expect(subscription.reload.email).to eq("jimi@hendrix.com")
-      expect(subscription.reload.search_criteria).to eq({ keyword: "english" }.to_json)
+      expect(subscription.reload.search_criteria.symbolize_keys).to eq({ keyword: "english" })
     end
 
     it "triggers a `job_alert_subscription_updated` event" do

--- a/spec/form_models/jobseekers/nqt_job_alerts_form_spec.rb
+++ b/spec/form_models/jobseekers/nqt_job_alerts_form_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Jobseekers::NqtJobAlertsForm, type: :model do
       before { allow(LocationPolygon).to receive(:include?).with(location).and_return(true) }
 
       it "adds location_category to the search criteria" do
-        expect(subject.job_alert_params[:search_criteria]).to eq(expected_hash.to_json)
+        expect(subject.job_alert_params[:search_criteria]).to eq(expected_hash)
       end
     end
 
@@ -48,7 +48,7 @@ RSpec.describe Jobseekers::NqtJobAlertsForm, type: :model do
       before { allow(LocationPolygon).to receive(:include?).with(location).and_return(false) }
 
       it "does not add location_category to the search criteria" do
-        expect(subject.job_alert_params[:search_criteria]).to eq(expected_hash.to_json)
+        expect(subject.job_alert_params[:search_criteria]).to eq(expected_hash)
       end
     end
   end

--- a/spec/system/jobseekers_can_manage_their_job_alerts_from_the_email_spec.rb
+++ b/spec/system/jobseekers_can_manage_their_job_alerts_from_the_email_spec.rb
@@ -103,8 +103,8 @@ RSpec.describe "Jobseekers can manage their job alerts from the email" do
         subscription.reload
         expect(subscription.email).to eq(jobseeker.email)
         expect(subscription.frequency).to eq("weekly")
-        expect(JSON.parse(subscription.search_criteria).symbolize_keys[:keyword]).to eq("English")
-        expect(JSON.parse(subscription.search_criteria).symbolize_keys[:location]).to eq("Radley")
+        expect(subscription.search_criteria["keyword"]).to eq("English")
+        expect(subscription.search_criteria["location"]).to eq("Radley")
       end
     end
 


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-1850

## Changes in this PR:
This is the first step in refactoring the logic around search_criteria. As soon as this code is deployed I will manually run the following command on production:

```bash
rails subscriptions:convert_search_criteria
```

I have tested it on a production DB dump and it works. I prefer to manually run it instead of creating a migration that will stay in our code for some time.