### PR TITLE
Improve handling of VCAP_SERVICES

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -21,6 +21,7 @@ Bundler.require(*Rails.groups)
 # These are needed in configuration before autoloading kicks in
 require_relative "../lib/logging/colour_log_formatter"
 require_relative "../lib/modules/aws_ip_ranges"
+require_relative "../lib/vcap_services"
 
 module TeacherVacancyService
   class Application < Rails::Application
@@ -52,11 +53,11 @@ module TeacherVacancyService
       api_key: ENV["NOTIFY_KEY"],
     }
 
-    # Set up backing services through Cloudfoundry VCAP_SERVICES if running in production
+    # Set up backing services through VCAP_SERVICES if running on Cloudfoundry (GOV.UK PaaS)
     if ENV["VCAP_SERVICES"].present?
-      vcap_services = JSON.parse(ENV["VCAP_SERVICES"])
+      vcap_services = VcapServices.new(ENV["VCAP_SERVICES"])
 
-      config.redis_store_url = vcap_services["redis"][0]["credentials"]["uri"]
+      config.redis_store_url = vcap_services.service_url(:redis)
     else
       config.redis_store_url = ENV.fetch("REDIS_URL", "redis://localhost:6379")
     end

--- a/lib/vcap_services.rb
+++ b/lib/vcap_services.rb
@@ -1,0 +1,26 @@
+# Retrieve service URLs from CloudFoundry VCAP_SERVICES
+class VcapServices
+  def initialize(vcap_services_env)
+    @services = JSON.parse(vcap_services_env)
+  end
+
+  def service_url(service_type)
+    candidates = services_of_type(service_type)
+    raise "VCAP_SERVICES has no services of type '#{service_type}'" if candidates.blank?
+
+    candidates.first.dig("credentials", "uri")
+  end
+
+  def named_service_url(service_type, name)
+    candidates = services_of_type(service_type).select { |service| service["name"].start_with?(name) }
+    raise "VCAP_SERVICES has no '#{name}' services of type '#{service_type}'" if candidates.blank?
+
+    candidates.first.dig("credentials", "uri")
+  end
+
+  private
+
+  def services_of_type(service_type)
+    @services[service_type.to_s] || []
+  end
+end

--- a/spec/fixtures/files/vcap_services.json
+++ b/spec/fixtures/files/vcap_services.json
@@ -1,0 +1,90 @@
+{
+  "elasticsearch": [
+    {
+      "binding_name": null,
+      "credentials": {
+        "hostname": "es_host",
+        "password": "es_pass",
+        "port": "es_port",
+        "uri": "es_uri",
+        "username": "es_user"
+      },
+      "instance_name": "es_instance_name",
+      "label": "elasticsearch",
+      "name": "es_name",
+      "plan": "es_plan",
+      "provider": null,
+      "syslog_drain_url": null,
+      "tags": [],
+      "volume_mounts": []
+    }
+  ],
+  "postgres": [
+    {
+      "binding_name": null,
+      "credentials": {
+        "host": "pg_host",
+        "jdbcuri": "pg_jdbc",
+        "name": "pg_name",
+        "password": "pg_pass",
+        "port": "pg_port",
+        "uri": "pg_uri",
+        "username": "pg_user"
+      },
+      "instance_name": "pg_instance_name",
+      "label": "postgres",
+      "name": "pg_name",
+      "plan": "pg_plan",
+      "provider": null,
+      "syslog_drain_url": null,
+      "tags": [
+        "postgres"
+      ],
+      "volume_mounts": []
+    }
+  ],
+  "redis": [
+    {
+      "binding_name": "redis-cache",
+      "credentials": {
+        "host": "redis_cache_host",
+        "name": "redis_cache_name",
+        "password": "redis_cache_pass",
+        "port": "redis_cache_port",
+        "tls_enabled": true,
+        "uri": "redis_cache_uri"
+      },
+      "instance_name": "redis_cache_instance_name",
+      "label": "redis",
+      "name": "redis_cache_name",
+      "plan": "redis_cache_plan",
+      "provider": null,
+      "syslog_drain_url": null,
+      "tags": [
+        "redis"
+      ],
+      "volume_mounts": []
+    },
+    {
+      "binding_name": "redis-sidekiq",
+      "credentials": {
+        "host": "redis_sidekiq_host",
+        "name": "redis_sidekiq_name",
+        "password": "redis_sidekiq_pass",
+        "port": "redis_sidekiq_port",
+        "tls_enabled": true,
+        "uri": "redis_sidekiq_uri"
+      },
+      "instance_name": "redis_sidekiq_instance_name",
+      "label": "redis",
+      "name": "redis_sidekiq_name",
+      "plan": "redis_sidekiq_plan",
+      "provider": null,
+      "syslog_drain_url": null,
+      "tags": [
+        "redis"
+      ],
+      "volume_mounts": []
+    }
+  ]
+}

--- a/spec/lib/vcap_services_spec.rb
+++ b/spec/lib/vcap_services_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+RSpec.describe VcapServices do
+  subject { described_class.new(env_var) }
+
+  let(:env_var) { file_fixture("vcap_services.json").read }
+
+  describe "#service_url" do
+    context "when there is only one service of the given type" do
+      let(:service_url) { subject.service_url(:elasticsearch) }
+
+      it "gets the url for the service of the given type" do
+        expect(service_url).to eq("es_uri")
+      end
+    end
+
+    context "when there are multiple services of the given type" do
+      let(:service_url) { subject.service_url(:redis) }
+
+      it "gets the url for the first service of the given type" do
+        expect(service_url).to eq("redis_cache_uri")
+      end
+    end
+
+    context "when there are no services of the given type" do
+      let(:service_url) { subject.service_url(:ms_sql_server) }
+
+      it "raises an error" do
+        expect { service_url }
+          .to raise_error("VCAP_SERVICES has no services of type 'ms_sql_server'")
+      end
+    end
+  end
+
+  describe "#named_service_url" do
+    context "for a service with a binding name that exists" do
+      let(:named_service_url) { subject.named_service_url(:redis, "redis_sidekiq") }
+
+      it "gets the url for the service of the given type and binding name" do
+        expect(named_service_url).to eq("redis_sidekiq_uri")
+      end
+    end
+
+    context "for a service with a binding name that does not exist" do
+      let(:named_service_url) { subject.named_service_url(:redis, "redis_foo") }
+
+      it "raises an error" do
+        expect { named_service_url }
+          .to raise_error("VCAP_SERVICES has no 'redis_foo' services of type 'redis'")
+      end
+    end
+
+    context "when there are no services of the given type" do
+      let(:named_service_url) { subject.named_service_url(:ms_sql_server, "foo") }
+
+      it "raises an error" do
+        expect { named_service_url }
+          .to raise_error("VCAP_SERVICES has no 'foo' services of type 'ms_sql_server'")
+      end
+    end
+  end
+end


### PR DESCRIPTION
In preparation for having multiple different Redis instances, this
tidies up how we load service configuration from Cloudfoundry's
`VCAP_SERVICES` env variable.

(Shamelessly stolen from a previous project I worked on!)