### PR TITLE
[TEVA-1850] Fix bug with job alerts sent before refactoring

### DIFF
--- a/app/controllers/job_alert_feedbacks_controller.rb
+++ b/app/controllers/job_alert_feedbacks_controller.rb
@@ -40,7 +40,7 @@ class JobAlertFeedbacksController < ApplicationController
   private
 
   def job_alert_feedback_params
-    params.require(:job_alert_feedback).permit(:comment, :relevant_to_user, search_criteria: {}, vacancy_ids: [])
+    params.require(:job_alert_feedback).permit(:comment, :relevant_to_user, :search_criteria, search_criteria: {}, vacancy_ids: [])
   end
 
   def form_params


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-1850

## Changes in this PR:
We changed the way we store search_criteria of subscriptions and email job alerts sent before this refactoring did not allow users to provide relevance feedback. We now support both JSON strings and Hashes when following the link to provide feedback sent from emails.
