### PR TITLE
[TEVA-1757] Consolidate 5 existing feedback tables into one

### DIFF
--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,0 +1,10 @@
+class Feedback < ApplicationRecord
+  enum feedback_type: { jobseeker_account: 0, general: 1, job_alert: 2, unsubscribe: 3, vacancy_publisher: 4 }
+  enum user_participation_response: { interested: 0, uninterested: 1 }
+  enum rating: { highly_satisfied: 0, somewhat_satisfied: 1, neither: 2, somewhat_dissatisfied: 3, highly_dissatisfied: 4 }
+  enum unsubscribe_reason: { not_relevant: 0, job_found: 1, circumstances_change: 2, other_reason: 3 }
+  enum visit_purpose: { find_teaching_job: 1, list_teaching_job: 2, other_purpose: 0 }
+
+  validates :comment, length: { maximum: 1200 }, if: :comment?
+  validate :feedback_type, :presence
+end

--- a/app/models/general_feedback.rb
+++ b/app/models/general_feedback.rb
@@ -7,6 +7,4 @@ class GeneralFeedback < ApplicationRecord
   validates :visit_purpose, presence: true
 
   validates :visit_purpose_comment, length: { maximum: 1200 }, if: :visit_purpose_comment?
-
-  scope :published_on, (->(date) { where(created_at: date.all_day) })
 end

--- a/app/models/vacancy_publish_feedback.rb
+++ b/app/models/vacancy_publish_feedback.rb
@@ -5,6 +5,4 @@ class VacancyPublishFeedback < ApplicationRecord
 
   belongs_to :vacancy
   belongs_to :publisher
-
-  scope :published_on, (->(date) { where(created_at: date.all_day) })
 end

--- a/app/views/feedback_prompt_mailer/prompt_for_feedback.text.erb
+++ b/app/views/feedback_prompt_mailer/prompt_for_feedback.text.erb
@@ -2,7 +2,7 @@
 
 Dear vacancy publisher,
 
-We’re constantly working to improve #{t('app.title')}. You can help us do so by answering a couple quick questions about the following expired job listings for your school:
+We’re constantly working to improve #{t('app.title')}. You can help us do so by answering a couple of quick questions about the following expired job listings for your school:
 
 <%- @vacancies.each do |vacancy| %>
   <%="* #{vacancy.job_title}" %>

--- a/db/migrate/20210128111522_create_feedback_table_for_consolidating_all_feedback_tables.rb
+++ b/db/migrate/20210128111522_create_feedback_table_for_consolidating_all_feedback_tables.rb
@@ -1,0 +1,25 @@
+class CreateFeedbackTableForConsolidatingAllFeedbackTables < ActiveRecord::Migration[6.1]
+  def change
+    create_table :feedbacks, id: :uuid do |t|
+      t.timestamps
+      t.integer :feedback_type
+      t.integer :rating
+      t.text :comment
+      t.float :recaptcha_score
+      t.boolean :relevant_to_user
+      t.jsonb :search_criteria
+      t.uuid :job_alert_vacancy_ids, array: true
+      t.integer :unsubscribe_reason
+      t.text :other_unsubscribe_reason_comment
+      t.string :email
+      t.integer :user_participation_response
+      t.integer :visit_purpose
+      t.text :visit_purpose_comment
+      t.uuid :job_application_id
+      t.uuid :jobseeker_id
+      t.uuid :publisher_id
+      t.uuid :subscription_id
+      t.uuid :vacancy_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_27_144122) do
+ActiveRecord::Schema.define(version: 2021_01_28_111522) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -80,6 +80,29 @@ ActiveRecord::Schema.define(version: 2021_01_27_144122) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["publisher_id"], name: "index_emergency_login_keys_on_publisher_id"
+  end
+
+  create_table "feedbacks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.integer "feedback_type"
+    t.integer "rating"
+    t.text "comment"
+    t.float "recaptcha_score"
+    t.boolean "relevant_to_user"
+    t.jsonb "search_criteria"
+    t.uuid "job_alert_vacancy_ids", array: true
+    t.integer "unsubscribe_reason"
+    t.text "other_unsubscribe_reason_comment"
+    t.string "email"
+    t.integer "user_participation_response"
+    t.integer "visit_purpose"
+    t.text "visit_purpose_comment"
+    t.uuid "job_application_id"
+    t.uuid "jobseeker_id"
+    t.uuid "publisher_id"
+    t.uuid "subscription_id"
+    t.uuid "vacancy_id"
   end
 
   create_table "friendly_id_slugs", force: :cascade do |t|

--- a/lib/export_tables_to_big_query.rb
+++ b/lib/export_tables_to_big_query.rb
@@ -47,6 +47,7 @@ class ExportTablesToBigQuery
   EXCLUDE_TABLES = %w[
     activities
     ar_internal_metadata
+    feedbacks
     friendly_id_slugs
     location_polygons
     schema_migrations

--- a/lib/tasks/copy_feedback_tables_into_one_consolidated_table.rake
+++ b/lib/tasks/copy_feedback_tables_into_one_consolidated_table.rake
@@ -1,0 +1,75 @@
+namespace :consolidate_feedback_tables do
+  desc "Copy data from feedback tables into one table"
+  task consolidate_feedback_tables: :environment do
+    AccountFeedback.all.in_batches(of: 100).each_record do |account_feedback|
+      Feedback.create(
+        feedback_type: "jobseeker_account",
+        created_at: account_feedback.created_at,
+        rating: account_feedback.rating,
+        jobseeker_id: account_feedback.jobseeker_id,
+        comment: account_feedback.suggestions,
+      )
+    end
+
+    GeneralFeedback.all.in_batches(of: 100).each_record do |general_feedback|
+      user_participation_response = if general_feedback.not_interested?
+                                      "uninterested"
+                                    else
+                                      general_feedback.user_participation_response
+                                    end
+
+      Feedback.create(
+        feedback_type: "general",
+        created_at: general_feedback.created_at,
+        comment: general_feedback.comment,
+        visit_purpose: general_feedback.visit_purpose,
+        visit_purpose_comment: general_feedback.visit_purpose_comment,
+        email: general_feedback.email,
+        user_participation_response: user_participation_response,
+        recaptcha_score: general_feedback.recaptcha_score,
+      )
+    end
+
+    JobAlertFeedback.all.in_batches(of: 100).each_record do |job_alert_feedback|
+      Feedback.create(
+        feedback_type: "job_alert",
+        created_at: job_alert_feedback.created_at,
+        relevant_to_user: job_alert_feedback.relevant_to_user,
+        comment: job_alert_feedback.comment,
+        search_criteria: job_alert_feedback.search_criteria,
+        job_alert_vacancy_ids: job_alert_feedback.vacancy_ids,
+        subscription_id: job_alert_feedback.subscription_id,
+        recaptcha_score: job_alert_feedback.recaptcha_score,
+      )
+    end
+
+    UnsubscribeFeedback.all.in_batches(of: 100).each_record do |unsubscribe_feedback|
+      Feedback.create(
+        feedback_type: "unsubscribe",
+        created_at: unsubscribe_feedback.created_at,
+        unsubscribe_reason: unsubscribe_feedback.reason,
+        other_unsubscribe_reason_comment: unsubscribe_feedback.other_reason,
+        comment: unsubscribe_feedback.additional_info,
+        subscription_id: unsubscribe_feedback.subscription_id,
+      )
+    end
+
+    VacancyPublishFeedback.all.in_batches(of: 100).each_record do |vacancy_publish_feedback|
+      user_participation_response = if vacancy_publish_feedback.not_interested?
+                                      "uninterested"
+                                    else
+                                      vacancy_publish_feedback.user_participation_response
+                                    end
+
+      Feedback.create(
+        feedback_type: "vacancy_publisher",
+        created_at: vacancy_publish_feedback.created_at,
+        vacancy_id: vacancy_publish_feedback.vacancy_id,
+        publisher_id: vacancy_publish_feedback.publisher_id,
+        comment: vacancy_publish_feedback.comment,
+        email: vacancy_publish_feedback.email,
+        user_participation_response: user_participation_response,
+      )
+    end
+  end
+end

--- a/spec/models/general_feedback_spec.rb
+++ b/spec/models/general_feedback_spec.rb
@@ -40,18 +40,4 @@ RSpec.describe GeneralFeedback, type: :model do
       it { is_expected.not_to validate_presence_of(:email) }
     end
   end
-
-  describe "#published_on(date)" do
-    it "retrieves feedback submitted on the given date" do
-      feedback_today = create_list(:general_feedback, 3)
-      feedback_yesterday = create_list(:general_feedback, 2, created_at: 1.day.ago)
-      feedback_the_other_day = create_list(:general_feedback, 4, created_at: 2.days.ago)
-      feedback_some_other_day = create_list(:general_feedback, 6, created_at: 1.month.ago)
-
-      expect(GeneralFeedback.published_on(Date.current).all).to match_array(feedback_today)
-      expect(GeneralFeedback.published_on(1.day.ago)).to match_array(feedback_yesterday)
-      expect(GeneralFeedback.published_on(2.days.ago)).to match_array(feedback_the_other_day)
-      expect(GeneralFeedback.published_on(1.month.ago)).to match_array(feedback_some_other_day)
-    end
-  end
 end

--- a/spec/models/vacancy_publish_feedback_spec.rb
+++ b/spec/models/vacancy_publish_feedback_spec.rb
@@ -40,18 +40,4 @@ RSpec.describe VacancyPublishFeedback, type: :model do
       it { is_expected.not_to validate_presence_of(:email) }
     end
   end
-
-  describe "#published_on(date)" do
-    it "retrieves feedback submitted on the given date" do
-      feedback_today = create_list(:vacancy_publish_feedback, 3)
-      feedback_yesterday = create_list(:vacancy_publish_feedback, 2, created_at: 1.day.ago)
-      feedback_the_other_day = create_list(:vacancy_publish_feedback, 4, created_at: 2.days.ago)
-      feedback_some_other_day = create_list(:vacancy_publish_feedback, 6, created_at: 1.month.ago)
-
-      expect(VacancyPublishFeedback.published_on(Date.current).all).to match_array(feedback_today)
-      expect(VacancyPublishFeedback.published_on(1.day.ago)).to match_array(feedback_yesterday)
-      expect(VacancyPublishFeedback.published_on(2.days.ago)).to match_array(feedback_the_other_day)
-      expect(VacancyPublishFeedback.published_on(1.month.ago)).to match_array(feedback_some_other_day)
-    end
-  end
 end


### PR DESCRIPTION
Part 1 of several on this ticket.

This new consolidated table is not yet used by the code, so the
task will have to be run after that code is updated.

I tested the task on production data locally and checked
feedbacks of all types.

- Migration for new feedback table
- Task for one-off transfer of data from old tables
- Do not export feedbacks table because we will send data as
events
- There is a sixth feedback type coming up, for application
submission
- Drop unused data in ratings columns on GeneralFeedback
and VacancyPublishFeedback - we stopped adding to these
in 2019
- Rename not_interested scopes to uninterested to avoid
warning messages about scope conflict whenever you run
the console
- Rename some other columns to be specific
- Consolidate various 1200-char columns into a single column
called 'comment'
- Remove unused scope

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1757
