### PR TITLE
[TEVA-1935] Don't require email for job alerts when signed in

### DIFF
--- a/app/views/subscriptions/_fields.html.slim
+++ b/app/views/subscriptions/_fields.html.slim
@@ -43,6 +43,9 @@ div class="govuk-!-margin-bottom-7"
     items: items,
     options: { remove_buttons: false, mobile_variant: false, close_all: false }))
 
-= f.govuk_email_field :email, label: { size: "s" }, required: true
+- if jobseeker_signed_in?
+  = f.hidden_field :email, value: current_jobseeker.email
+- else
+  = f.govuk_email_field :email, label: { size: "s" }, required: true
 
 = f.govuk_collection_radio_buttons :frequency, Subscription.frequencies.keys, :to_s

--- a/spec/system/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
+++ b/spec/system/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe "Jobseekers can create a job alert from a search" do
   end
 
   def fill_in_subscription_fields
-    fill_in "jobseekers_subscription_form[email]", with: jobseeker.email
+    fill_in "jobseekers_subscription_form[email]", with: jobseeker.email unless jobseeker_signed_in?
     choose I18n.t("helpers.label.jobseekers_subscription_form.frequency_options.daily")
   end
 end

--- a/spec/system/jobseekers_can_create_a_job_alert_from_the_dashboard_spec.rb
+++ b/spec/system/jobseekers_can_create_a_job_alert_from_the_dashboard_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe "Jobseekers can create a job alert from the dashboard" do
 
     it "creates a job alert and redirects to the subscriptions index page" do
       click_on I18n.t("jobseekers.subscriptions.index.link_create")
-      and_email_is_prefilled
       an_invalid_form_is_rejected
       expect { create_a_job_alert }.to change { Subscription.count }.by(1)
       and_the_job_alert_is_on_the_index_page
@@ -38,7 +37,6 @@ RSpec.describe "Jobseekers can create a job alert from the dashboard" do
 
     it "creates a job alert and redirects to the subscriptions index page" do
       click_on I18n.t("jobseekers.subscriptions.index.button_create")
-      and_email_is_prefilled
       an_invalid_form_is_rejected
       expect { create_a_job_alert }.to change { Subscription.count }.by(1)
       and_the_job_alert_is_on_the_index_page
@@ -48,10 +46,6 @@ RSpec.describe "Jobseekers can create a job alert from the dashboard" do
   def an_invalid_form_is_rejected
     click_on I18n.t("buttons.subscribe")
     expect(page).to have_content("There is a problem")
-  end
-
-  def and_email_is_prefilled
-    expect(page).to have_field("jobseekers_subscription_form[email]", with: jobseeker.email)
   end
 
   def and_the_job_alert_is_on_the_index_page


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-1935

## Changes in this PR
- Add email as hidden field when jobseeker is signed in