### PR TITLE
Split Redis configuration for app

### DIFF
--- a/app/services/vacancy_facets.rb
+++ b/app/services/vacancy_facets.rb
@@ -1,7 +1,7 @@
 class VacancyFacets
   FIELDS = %i[job_roles subjects cities counties].freeze
 
-  def initialize(store: Redis.new(url: Rails.configuration.redis_store_url))
+  def initialize(store: Redis.new(url: Rails.configuration.redis_queue_url))
     @store = store
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -57,9 +57,13 @@ module TeacherVacancyService
     if ENV["VCAP_SERVICES"].present?
       vcap_services = VcapServices.new(ENV["VCAP_SERVICES"])
 
-      config.redis_store_url = vcap_services.named_service_url(:redis, "queue")
+      config.redis_queue_url = vcap_services.named_service_url(:redis, "queue")
+      config.redis_cache_url = vcap_services.named_service_url(:redis, "cache")
     else
-      config.redis_store_url = ENV.fetch("REDIS_URL", "redis://localhost:6379")
+      redis_url = ENV.fetch("REDIS_URL", "redis://localhost:6379")
+
+      config.redis_queue_url = "#{redis_url}/0"
+      config.redis_cache_url = "#{redis_url}/1"
     end
 
     config.ab_tests = config_for(:ab_tests)

--- a/config/initializers/01_redis_objects.rb
+++ b/config/initializers/01_redis_objects.rb
@@ -5,6 +5,6 @@ Redis::Objects.redis =
     MockRedis.new
   else
     ConnectionPool.new(size: 5, timeout: 5) do
-      Redis.new(url: "#{Rails.configuration.redis_store_url}/1")
+      Redis.new(url: Rails.configuration.redis_cache_url)
     end
   end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -7,12 +7,12 @@ options = {
 # Redis concurrency must be plus 5 https://github.com/mperham/sidekiq/wiki/Using-Redis#complete-control
 Sidekiq.configure_server do |config|
   config.options.merge!(options)
-  config.redis = { url: Rails.configuration.redis_store_url, network_timeout: 5, size: config.options[:concurrency] + 5 }
+  config.redis = { url: Rails.configuration.redis_queue_url, network_timeout: 5, size: config.options[:concurrency] + 5 }
 end
 
 Sidekiq.configure_client do |config|
   config.options.merge!(options)
-  config.redis = { url: Rails.configuration.redis_store_url, network_timeout: 5, size: config.options[:concurrency] + 5 }
+  config.redis = { url: Rails.configuration.redis_queue_url, network_timeout: 5, size: config.options[:concurrency] + 5 }
 end
 
 schedule_file = "config/schedule.yml"


### PR DESCRIPTION
- Rename `redis_store_url` config to `redis_queue_url`
- Make `RedisObjects` configuration use cache Redis instead of queue
- Make `VacancyFacets` continue to use queue Redis instance until we
  refactor it properly (it only stores a small amount of data, and
  relies on it being present so would cause issues with a switchover)