### PR TITLE
[TEVA-1757] Part 2 of many: refactor account feedback to use new Feedback model

### DIFF
--- a/app/components/jobseekers/account_survey_link_component.rb
+++ b/app/components/jobseekers/account_survey_link_component.rb
@@ -1,12 +1,12 @@
 class Jobseekers::AccountSurveyLinkComponent < ViewComponent::Base
-  def initialize(back_link:)
-    @back_link = back_link
+  def initialize(origin:)
+    @origin = origin
   end
 
   def link_to_survey
     link_to(
       I18n.t("jobseekers.accounts.footer.survey_link"),
-      new_jobseekers_account_feedback_path(back_link: @back_link),
+      new_jobseekers_account_feedback_path(origin: @origin),
       id: "account-survey-link-sticky-gtm",
     )
   end

--- a/app/form_models/jobseekers/account_feedback_form.rb
+++ b/app/form_models/jobseekers/account_feedback_form.rb
@@ -1,0 +1,8 @@
+class Jobseekers::AccountFeedbackForm
+  include ActiveModel::Model
+
+  attr_accessor :origin, :comment, :feedback_type, :jobseeker_id, :rating
+
+  validates :comment, length: { maximum: 1200 }, if: -> { comment.present? }
+  validates :rating, inclusion: { in: Feedback.ratings.keys }
+end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -5,6 +5,5 @@ class Feedback < ApplicationRecord
   enum unsubscribe_reason: { not_relevant: 0, job_found: 1, circumstances_change: 2, other_reason: 3 }
   enum visit_purpose: { find_teaching_job: 1, list_teaching_job: 2, other_purpose: 0 }
 
-  validates :comment, length: { maximum: 1200 }, if: :comment?
   validate :feedback_type, :presence
 end

--- a/app/views/jobseekers/account_feedbacks/new.html.slim
+++ b/app/views/jobseekers/account_feedbacks/new.html.slim
@@ -1,18 +1,18 @@
 - content_for :page_title_prefix, t(".title")
 
-= govuk_back_link text: t("buttons.back"), href: @account_feedback.back_link
+= govuk_back_link text: t("buttons.back"), href: @account_feedback_form.origin
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = form_for @account_feedback, url: jobseekers_account_feedback_path do |f|
-      = f.hidden_field :back_link
+    = form_for @account_feedback_form, url: jobseekers_account_feedback_path do |f|
+      = f.hidden_field :origin
 
       = f.govuk_error_summary
 
       h1.govuk-heading-xl = t(".title")
 
-      = f.govuk_collection_radio_buttons :rating, AccountFeedback.ratings.keys, :to_s
+      = f.govuk_collection_radio_buttons :rating, Feedback.ratings.keys, :to_s
 
-      = f.govuk_text_area :suggestions, label: { size: "s" }, rows: 10, max_chars: 1200
+      = f.govuk_text_area :comment, label: { size: "s" }, rows: 10, max_chars: 1200
 
       = f.govuk_submit t("buttons.submit")

--- a/app/views/jobseekers/accounts/show.html.slim
+++ b/app/views/jobseekers/accounts/show.html.slim
@@ -30,4 +30,4 @@
       p.govuk-body-s = t(".assistance.content_html", link: govuk_mail_to(t("help.email"), t(".assistance.link_text")))
 
   .govuk-grid-column-full
-    = render(Jobseekers::AccountSurveyLinkComponent.new(back_link: url_for))
+    = render(Jobseekers::AccountSurveyLinkComponent.new(origin: url_for))

--- a/app/views/jobseekers/saved_jobs/index.html.slim
+++ b/app/views/jobseekers/saved_jobs/index.html.slim
@@ -41,4 +41,4 @@
           = render(Shared::NotificationComponent.new(content: { title: t(".zero_saved_jobs_title"), body: t(".zero_saved_jobs_body_html", link_to: govuk_link_to(t(".link_find"), root_path)) }, style: "empty", dismiss: false, background: true, alert: false))
 
   .govuk-grid-column-full
-    = render(Jobseekers::AccountSurveyLinkComponent.new(back_link: url_for))
+    = render(Jobseekers::AccountSurveyLinkComponent.new(origin: url_for))

--- a/app/views/jobseekers/subscriptions/index.html.slim
+++ b/app/views/jobseekers/subscriptions/index.html.slim
@@ -45,4 +45,4 @@
           = render(Shared::NotificationComponent.new(content: { title: t(".zero_subscriptions_title"), body: t(".zero_subscriptions_body_html", link_to: govuk_link_to(t(".link_create"), new_subscription_path(email: current_jobseeker.email, origin: jobseekers_subscriptions_path))) }, style: "empty", dismiss: false, background: true, alert: false))
 
   .govuk-grid-column-full
-    = render(Jobseekers::AccountSurveyLinkComponent.new(back_link: url_for))
+    = render(Jobseekers::AccountSurveyLinkComponent.new(origin: url_for))

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -2,10 +2,6 @@ en:
   cookies_preferences_errors: &cookies_preferences_errors
     cookies_consent:
       inclusion: Please select an option
-  job_alert_feedback_errors: &job_alert_feedback_errors
-    comment:
-      blank: You have not submitted any further feedback.
-      too_long: Feedback must not be more than 1,200 characters
   nqt_job_alert_errors: &nqt_job_alert_errors
     keywords:
       blank: Enter keyword(s)
@@ -31,6 +27,17 @@ en:
       inclusion: Tell us why you want to unsubscribe
     other_reason:
       blank: Tell us why you want to unsubscribe
+
+  # Feedback forms
+  account_feedback_errors: &account_feedback_errors
+    rating:
+      inclusion: Select how satisfied or dissatisfied you are
+    comment:
+      too_long: Feedback must not be more than 1,200 characters
+  job_alert_feedback_errors: &job_alert_feedback_errors
+    comment:
+      blank: You have not submitted any further feedback.
+      too_long: Feedback must not be more than 1,200 characters
 
   # Hiring staff journey
   job_location_errors: &job_location_errors
@@ -109,6 +116,9 @@ en:
         cookies_preferences_form:
           attributes:
             <<: *cookies_preferences_errors
+        jobseekers/account_feedback_form:
+          attributes:
+            <<: *account_feedback_errors
         jobseekers/job_alert_feedback_form:
           attributes:
             <<: *job_alert_feedback_errors
@@ -229,10 +239,6 @@ en:
         part_time: Part-time
     errors:
       models:
-        account_feedback:
-          attributes:
-            rating:
-              inclusion: Select how satisfied or dissatisfied you are
         jobseeker:
           attributes:
             email:

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -126,14 +126,14 @@ en:
           Where relevant, state if the salary is full-time equivalent
 
     label:
-      account_feedback:
+      jobseekers_account_feedback_form:
         rating_options:
           highly_satisfied: Highly satisfied
           somewhat_satisfied: Somewhat satisfied
           neither: Neither satisfied nor dissatisfied
           somewhat_dissatisfied: Somewhat dissatisfied
           highly_dissatisfied: Highly dissatisfied
-        suggestions: Do you have any suggestions on how we could improve the service?
+        comment: Do you have any suggestions on how we could improve the service?
       general_feedback:
         visit_purpose_options:
           find_teaching_job: Find a job in teaching
@@ -261,7 +261,7 @@ en:
         town_or_city: Town or city
 
     legend:
-      account_feedback:
+      jobseekers_account_feedback_form:
         rating_html: >-
           How satisfied are you with your experience of using Teaching Vacancies?
           (<span class='text-red'>Required</span>)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -329,9 +329,9 @@ ActiveRecord::Schema.define(version: 2021_01_28_111522) do
     t.datetime "stats_updated_at"
     t.uuid "publisher_id"
     t.datetime "expires_at"
+    t.string "legacy_job_roles", array: true
     t.string "salary"
     t.integer "completed_step"
-    t.string "legacy_job_roles", array: true
     t.text "about_school"
     t.string "state", default: "create"
     t.string "subjects", array: true

--- a/spec/form_models/jobseekers/account_feedback_form_spec.rb
+++ b/spec/form_models/jobseekers/account_feedback_form_spec.rb
@@ -1,0 +1,6 @@
+require "rails_helper"
+
+RSpec.describe Jobseekers::AccountFeedbackForm, type: :model do
+  it { is_expected.to validate_inclusion_of(:rating).in_array(Feedback.ratings.keys) }
+  it { is_expected.to validate_length_of(:comment).is_at_most(1200) }
+end


### PR DESCRIPTION
Updates to other types of feedback to follow. This is a trial run to make sure Steven (performance analysis) is receiving the data.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1757

## Changes in this PR:

- Rename 'back_link' to 'origin' to match terminology in `trigger_subscription_event`
- Add and use form object instead of AccountFeedback object

## Next steps:

- [ ] Before removing account_feedback table, transfer data to DataForm/BigQuery.