### PR TITLE
Initial configuration for Rails cache

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
   if Rails.root.join("tmp/caching-dev.txt").exist?
     config.action_controller.perform_caching = true
 
-    config.cache_store = :memory_store
+    config.cache_store = :redis_cache_store, { url: config.redis_cache_url }
     config.public_file_server.headers = {
       "Cache-Control" => "public, max-age=#{2.days.seconds.to_i}",
     }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,8 +46,7 @@ Rails.application.configure do
   config.force_ssl = true
   config.ssl_options = { redirect: { exclude: ->(request) { request.path.include?("check") } } }
 
-  # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :redis_cache_store, { url: config.redis_cache_url, pool_size: ENV.fetch("RAILS_MAX_THREADS", 5) }
 
   # Use a real queuing backend for Active Job
   # (and separate queues per environment)

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -53,8 +53,7 @@ Rails.application.configure do
   config.force_ssl = true
   config.ssl_options = { redirect: { exclude: ->(request) { request.path.include?("check") } } }
 
-  # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :redis_cache_store, { url: config.redis_cache_url, pool_size: ENV.fetch("RAILS_MAX_THREADS", 5) }
 
   # Use a real queuing backend for Active Job
   # (and separate queues per environment)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,6 +45,8 @@ Rails.application.configure do
   config.active_support.deprecation = :raise
   config.i18n.raise_on_missing_translations = true
 
+  config.cache_store = :null_store
+
   config.middleware.use RackSessionAccess::Middleware
 end
 


### PR DESCRIPTION
- Use Redis for caching in production and staging, with an appropriate
  connection pool size
- Use null_store in test to ensure nothing gets cached
- Use Redis for caching in development if caching is enabled (for
  parity with production)