### PR TITLE
Add new Redis queue instance

### DIFF
--- a/terraform/app/modules/paas/main.tf
+++ b/terraform/app/modules/paas/main.tf
@@ -18,6 +18,13 @@ resource cloudfoundry_service_instance redis_cache_instance {
   json_params  = "{\"maxmemory_policy\": \"allkeys-lru\"}"
 }
 
+resource cloudfoundry_service_instance redis_queue_instance {
+  name         = local.redis_queue_service_name
+  space        = data.cloudfoundry_space.space.id
+  service_plan = data.cloudfoundry_service.redis.service_plans[var.redis_queue_service_plan]
+  json_params  = "{\"maxmemory_policy\": \"noeviction\"}"
+}
+
 resource cloudfoundry_user_provided_service papertrail {
   name             = local.papertrail_service_name
   space            = data.cloudfoundry_space.space.id

--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -36,6 +36,8 @@ variable postgres_service_plan {
 
 variable redis_cache_service_plan {
 }
+variable redis_queue_service_plan {
+}
 variable redis_old_service_plan {
 }
 variable service_name {
@@ -96,6 +98,7 @@ locals {
   app_cloudfoundry_service_instances = [
     cloudfoundry_service_instance.postgres_instance.id,
     cloudfoundry_service_instance.redis_cache_instance.id,
+    cloudfoundry_service_instance.redis_queue_instance.id,
     cloudfoundry_service_instance.redis_instance.id
   ]
   app_user_provided_service_bindings = var.papertrail_service_binding_enable ? [cloudfoundry_user_provided_service.papertrail.id] : []
@@ -107,6 +110,7 @@ locals {
   postgres_service_name    = "${var.service_name}-postgres-${var.environment}"
   redis_old_service_name   = "${var.service_name}-redis-old-${var.environment}"
   redis_cache_service_name = "${var.service_name}-redis-cache-${var.environment}"
+  redis_queue_service_name = "${var.service_name}-redis-queue-${var.environment}"
   web_app_name             = "${var.service_name}-${var.environment}"
   worker_app_start_command = "MALLOC_ARENA_MAX=2 bundle exec sidekiq -C config/sidekiq.yml"
   worker_app_name          = "${var.service_name}-worker-${var.environment}"

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -83,6 +83,7 @@ module paas {
   postgres_service_plan             = var.paas_postgres_service_plan
   redis_old_service_plan            = var.paas_redis_old_service_plan
   redis_cache_service_plan          = var.paas_redis_cache_service_plan
+  redis_queue_service_plan          = var.paas_redis_queue_service_plan
   space_name                        = var.paas_space_name
   web_app_deployment_strategy       = var.paas_web_app_deployment_strategy
   web_app_instances                 = var.paas_web_app_instances

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -75,6 +75,10 @@ variable paas_redis_cache_service_plan {
   default = "micro-5_x"
 }
 
+variable paas_redis_queue_service_plan {
+  default = "micro-5_x"
+}
+
 variable paas_space_name {
 }
 

--- a/terraform/workspace-variables/dev.tfvars
+++ b/terraform/workspace-variables/dev.tfvars
@@ -28,6 +28,7 @@ paas_papertrail_service_binding_enable = false
 paas_postgres_service_plan             = "tiny-unencrypted-11"
 paas_redis_old_service_plan            = "micro-5_x"
 paas_redis_cache_service_plan          = "micro-5_x"
+paas_redis_queue_service_plan          = "micro-5_x"
 paas_app_start_timeout                 = "180"
 paas_app_stopped                       = false
 paas_web_app_deployment_strategy       = "blue-green-v2"

--- a/terraform/workspace-variables/production.tfvars
+++ b/terraform/workspace-variables/production.tfvars
@@ -28,6 +28,7 @@ paas_papertrail_service_binding_enable = true
 paas_postgres_service_plan             = "medium-ha-11"
 paas_redis_old_service_plan            = "small-ha-4_x"
 paas_redis_cache_service_plan          = "tiny-5_x"
+paas_redis_queue_service_plan          = "micro-ha-5_x"
 paas_app_start_timeout                 = "180"
 paas_app_stopped                       = false
 paas_web_app_deployment_strategy       = "blue-green-v2"

--- a/terraform/workspace-variables/review.tfvars
+++ b/terraform/workspace-variables/review.tfvars
@@ -27,6 +27,7 @@ paas_space_name                        = "teaching-vacancies-review"
 paas_postgres_service_plan             = "tiny-unencrypted-11"
 paas_redis_old_service_plan            = "micro-5_x"
 paas_redis_cache_service_plan          = "micro-5_x"
+paas_redis_queue_service_plan          = "micro-5_x"
 paas_papertrail_service_binding_enable = false
 paas_app_start_timeout                 = "180"
 paas_app_stopped                       = false

--- a/terraform/workspace-variables/staging.tfvars
+++ b/terraform/workspace-variables/staging.tfvars
@@ -28,6 +28,7 @@ paas_papertrail_service_binding_enable = true
 paas_postgres_service_plan             = "small-11"
 paas_redis_old_service_plan            = "micro-5_x"
 paas_redis_cache_service_plan          = "micro-5_x"
+paas_redis_queue_service_plan          = "micro-5_x"
 paas_app_start_timeout                 = "180"
 paas_app_stopped                       = false
 paas_web_app_deployment_strategy       = "blue-green-v2"


### PR DESCRIPTION
This runs in parallel to the one now called "old" so we can do a
painless switchover.