### PR TITLE
[TEVA-1898] Remove Cloudfront standard logging

### DIFF
--- a/terraform/app/modules/cloudfront/main.tf
+++ b/terraform/app/modules/cloudfront/main.tf
@@ -144,15 +144,6 @@ resource aws_cloudfront_distribution default {
     ssl_support_method  = "sni-only"
   }
 
-  dynamic "logging_config" {
-    for_each = var.cloudfront_enable_standard_logs ? [1] : []
-    content {
-      include_cookies = false
-      bucket          = data.aws_s3_bucket.cloudfront_logs.bucket_domain_name
-      prefix          = var.environment
-    }
-  }
-
   tags = {
     Name        = "${var.service_name}-${var.environment}"
     Environment = var.environment

--- a/terraform/app/modules/cloudfront/variables.tf
+++ b/terraform/app/modules/cloudfront/variables.tf
@@ -4,9 +4,6 @@ variable environment {
 variable service_name {
 }
 
-variable cloudfront_enable_standard_logs {
-}
-
 variable cloudfront_origin_domain_name {
 }
 

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -38,18 +38,17 @@ terraform {
 }
 
 module cloudfront {
-  source                          = "./modules/cloudfront"
-  for_each                        = var.distribution_list
-  environment                     = var.environment
-  service_name                    = local.service_name
-  cloudfront_origin_domain_name   = each.value.cloudfront_origin_domain_name
-  offline_bucket_domain_name      = each.value.offline_bucket_domain_name
-  offline_bucket_origin_path      = each.value.offline_bucket_origin_path
-  cloudfront_enable_standard_logs = each.value.cloudfront_enable_standard_logs
-  route53_zones                   = var.route53_zones
-  is_production                   = local.is_production
-  route53_a_records               = local.route53_a_records
-  route53_cname_record            = local.route53_cname_record
+  source                        = "./modules/cloudfront"
+  for_each                      = var.distribution_list
+  environment                   = var.environment
+  service_name                  = local.service_name
+  cloudfront_origin_domain_name = each.value.cloudfront_origin_domain_name
+  offline_bucket_domain_name    = each.value.offline_bucket_domain_name
+  offline_bucket_origin_path    = each.value.offline_bucket_origin_path
+  route53_zones                 = var.route53_zones
+  is_production                 = local.is_production
+  route53_a_records             = local.route53_a_records
+  route53_cname_record          = local.route53_cname_record
   providers = {
     aws.default       = aws.default
     aws.aws_us_east_1 = aws.aws_us_east_1

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -9,10 +9,9 @@ variable environment {}
 variable distribution_list {
   description = "Define Cloudfront distributions with the attributes below"
   type = map(object({
-    offline_bucket_domain_name      = string
-    offline_bucket_origin_path      = string
-    cloudfront_origin_domain_name   = string
-    cloudfront_enable_standard_logs = bool
+    offline_bucket_domain_name    = string
+    offline_bucket_origin_path    = string
+    cloudfront_origin_domain_name = string
   }))
   default = {}
 }

--- a/terraform/common/iam.tf
+++ b/terraform/common/iam.tf
@@ -12,15 +12,6 @@ resource aws_iam_access_key deploy {
   user = aws_iam_user.deploy.name
 }
 
-resource aws_iam_user bigquery {
-  name = "bigquery"
-  path = "/${local.service_name}/"
-}
-
-resource aws_iam_access_key bigquery {
-  user = aws_iam_user.bigquery.name
-}
-
 # Terraform state
 
 data aws_iam_policy_document edit_terraform_state {
@@ -172,59 +163,4 @@ resource aws_iam_policy db_backups_in_s3 {
 resource aws_iam_user_policy_attachment db_backups_in_s3 {
   user       = aws_iam_user.deploy.name
   policy_arn = aws_iam_policy.db_backups_in_s3.arn
-}
-
-# Cloudfront logs to S3
-
-data aws_iam_policy_document cloudfront_logs_to_s3 {
-  statement {
-    actions = [
-      "s3:GetBucketAcl",
-      "s3:ListBucket",
-      "s3:PutBucketAcl",
-      "s3:PutObject"
-    ]
-    resources = [
-      "arn:aws:s3:::${aws_s3_bucket.cloudfront_logs.bucket}",
-      "arn:aws:s3:::${aws_s3_bucket.cloudfront_logs.bucket}/*"
-    ]
-  }
-}
-
-resource aws_iam_policy cloudfront_logs_to_s3 {
-  name   = "cloudfront_logs_to_s3"
-  policy = data.aws_iam_policy_document.cloudfront_logs_to_s3.json
-}
-
-resource aws_iam_user_policy_attachment cloudfront_logs_to_s3 {
-  user       = aws_iam_user.deploy.name
-  policy_arn = aws_iam_policy.cloudfront_logs_to_s3.arn
-}
-
-# Allow BigQuery to collect Cloudfront logs from S3 bucket
-
-data aws_iam_policy_document cloudfront_logs_bigquery_access {
-  statement {
-    actions = [
-      "s3:GetBucketAcl",
-      "s3:GetBucketLocation",
-      "s3:ListBucket",
-      "s3:GetObject",
-      "s3:GetObjectAcl"
-    ]
-    resources = [
-      "arn:aws:s3:::${aws_s3_bucket.cloudfront_logs.bucket}",
-      "arn:aws:s3:::${aws_s3_bucket.cloudfront_logs.bucket}/*"
-    ]
-  }
-}
-
-resource aws_iam_policy cloudfront_logs_bigquery_access {
-  name   = "cloudfront_logs_bigquery_access"
-  policy = data.aws_iam_policy_document.cloudfront_logs_bigquery_access.json
-}
-
-resource aws_iam_user_policy_attachment cloudfront_logs_bigquery_access {
-  user       = aws_iam_user.bigquery.name
-  policy_arn = aws_iam_policy.cloudfront_logs_bigquery_access.arn
 }

--- a/terraform/common/output.tf
+++ b/terraform/common/output.tf
@@ -1,11 +1,3 @@
-output bigquery_aws_access_key_id {
-  value = aws_iam_access_key.bigquery.id
-}
-
-output bigquery_aws_secret_access_key {
-  value = aws_iam_access_key.bigquery.secret
-}
-
 output deploy_aws_access_key_id {
   value = aws_iam_access_key.deploy.id
 }

--- a/terraform/common/s3.tf
+++ b/terraform/common/s3.tf
@@ -1,5 +1,4 @@
 data aws_caller_identity current {}
-data aws_canonical_user_id current {}
 
 resource aws_s3_bucket db_backups {
   bucket = "${data.aws_caller_identity.current.account_id}-tv-db-backups"
@@ -12,45 +11,4 @@ resource aws_s3_bucket db_backups {
       days = 7
     }
   }
-}
-
-resource aws_s3_bucket cloudfront_logs {
-  bucket = "${data.aws_caller_identity.current.account_id}-tv-cloudfront-logs"
-
-  # Specifically setting the ACL grant from awslogsdelivery
-  # By explicitly setting any grant, we must declare ALL grants (i.e. also the bucket owner)
-  grant {
-    id          = local.aws_canonical_user_id_awslogsdelivery
-    type        = "CanonicalUser"
-    permissions = ["FULL_CONTROL"]
-  }
-
-  grant {
-    id          = data.aws_canonical_user_id.current.id
-    type        = "CanonicalUser"
-    permissions = ["FULL_CONTROL"]
-  }
-
-  lifecycle_rule {
-    id      = "staging"
-    enabled = true
-
-    prefix = "staging/"
-
-    expiration {
-      days = 3
-    }
-  }
-
-  lifecycle_rule {
-    id      = "production"
-    enabled = true
-
-    prefix = "production/"
-
-    expiration {
-      days = 35
-    }
-  }
-
 }

--- a/terraform/workspace-variables/dev.tfvars
+++ b/terraform/workspace-variables/dev.tfvars
@@ -7,10 +7,9 @@ parameter_store_environment = "dev"
 # CloudFront
 distribution_list = {
   "tvsdev" = {
-    offline_bucket_domain_name      = "tvs-offline.s3.amazonaws.com"
-    offline_bucket_origin_path      = "/school-jobs-offline"
-    cloudfront_origin_domain_name   = "teaching-vacancies-dev.london.cloudapps.digital"
-    cloudfront_enable_standard_logs = false
+    offline_bucket_domain_name    = "tvs-offline.s3.amazonaws.com"
+    offline_bucket_origin_path    = "/school-jobs-offline"
+    cloudfront_origin_domain_name = "teaching-vacancies-dev.london.cloudapps.digital"
   }
 }
 

--- a/terraform/workspace-variables/production.tfvars
+++ b/terraform/workspace-variables/production.tfvars
@@ -7,10 +7,9 @@ parameter_store_environment = "production"
 # CloudFront
 distribution_list = {
   "tvsprod" = {
-    offline_bucket_domain_name      = "tvs-offline.s3.amazonaws.com"
-    offline_bucket_origin_path      = "/school-jobs-offline"
-    cloudfront_origin_domain_name   = "teaching-vacancies-production.london.cloudapps.digital"
-    cloudfront_enable_standard_logs = true
+    offline_bucket_domain_name    = "tvs-offline.s3.amazonaws.com"
+    offline_bucket_origin_path    = "/school-jobs-offline"
+    cloudfront_origin_domain_name = "teaching-vacancies-production.london.cloudapps.digital"
   }
 }
 

--- a/terraform/workspace-variables/review.tfvars
+++ b/terraform/workspace-variables/review.tfvars
@@ -10,7 +10,6 @@ distribution_list = {
   #   offline_bucket_domain_name    = "tvs-offline.s3.amazonaws.com"
   #   offline_bucket_origin_path    = "/school-jobs-offline"
   #   cloudfront_origin_domain_name = "teaching-vacancies-review-pr-2012.london.cloudapps.digital"
-  #   cloudfront_enable_standard_logs = false
   # }
 }
 

--- a/terraform/workspace-variables/staging.tfvars
+++ b/terraform/workspace-variables/staging.tfvars
@@ -7,10 +7,9 @@ parameter_store_environment = "staging"
 # CloudFront
 distribution_list = {
   "tvsstaging" = {
-    offline_bucket_domain_name      = "tvs-offline.s3.amazonaws.com"
-    offline_bucket_origin_path      = "/school-jobs-offline"
-    cloudfront_origin_domain_name   = "teaching-vacancies-staging.london.cloudapps.digital"
-    cloudfront_enable_standard_logs = true
+    offline_bucket_domain_name    = "tvs-offline.s3.amazonaws.com"
+    offline_bucket_origin_path    = "/school-jobs-offline"
+    cloudfront_origin_domain_name = "teaching-vacancies-staging.london.cloudapps.digital"
   }
 }
 

--- a/terraform/workspace-variables/workspace.tfvars.example
+++ b/terraform/workspace-variables/workspace.tfvars.example
@@ -11,7 +11,6 @@ distribution_list = {
     offline_bucket_origin_path    = "/school-jobs-offline"
     cloudfront_origin_domain_name = "teaching-vacancies-staging.london.cloudapps.digital"
     domain                        = "staging.teaching-vacancies.service.gov.uk"
-    cloudfront_enable_standard_logs = false
   }
 }
 


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-1898

## Changes in this PR:

- Removes the Cloudfront to S3 logging which was introduced in TEVA-1365
- Removes the `bigquery` user, the S3 bucket, and the logging setup within the Cloudfront distributions

## Next steps:

Sequence:
- [ ] Deploy the app changes through the pipeline, to disable cloudfront logging for the `staging` and `production` distributions
- [ ] Empty the S3 cloudfront logs bucket through the web UI
- [ ] Remove the S3 bucket and other resources via `make terraform-common-apply`
