### PR TITLE
Remove old Redis instance

### DIFF
--- a/terraform/app/modules/paas/main.tf
+++ b/terraform/app/modules/paas/main.tf
@@ -5,12 +5,6 @@ resource cloudfoundry_service_instance postgres_instance {
   json_params  = "{\"enable_extensions\": [\"pgcrypto\", \"fuzzystrmatch\", \"plpgsql\"]}"
 }
 
-resource cloudfoundry_service_instance redis_instance {
-  name         = local.redis_old_service_name
-  space        = data.cloudfoundry_space.space.id
-  service_plan = data.cloudfoundry_service.redis.service_plans[var.redis_old_service_plan]
-}
-
 resource cloudfoundry_service_instance redis_cache_instance {
   name         = local.redis_cache_service_name
   space        = data.cloudfoundry_space.space.id

--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -38,8 +38,6 @@ variable redis_cache_service_plan {
 }
 variable redis_queue_service_plan {
 }
-variable redis_old_service_plan {
-}
 variable service_name {
 }
 variable space_name {
@@ -99,7 +97,6 @@ locals {
     cloudfoundry_service_instance.postgres_instance.id,
     cloudfoundry_service_instance.redis_cache_instance.id,
     cloudfoundry_service_instance.redis_queue_instance.id,
-    cloudfoundry_service_instance.redis_instance.id
   ]
   app_user_provided_service_bindings = var.papertrail_service_binding_enable ? [cloudfoundry_user_provided_service.papertrail.id] : []
   app_service_bindings = concat(
@@ -108,7 +105,6 @@ locals {
   )
   papertrail_service_name  = "${var.service_name}-papertrail-${var.environment}"
   postgres_service_name    = "${var.service_name}-postgres-${var.environment}"
-  redis_old_service_name   = "${var.service_name}-redis-old-${var.environment}"
   redis_cache_service_name = "${var.service_name}-redis-cache-${var.environment}"
   redis_queue_service_name = "${var.service_name}-redis-queue-${var.environment}"
   web_app_name             = "${var.service_name}-${var.environment}"

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -81,7 +81,6 @@ module paas {
   parameter_store_environment       = var.parameter_store_environment
   service_name                      = local.service_name
   postgres_service_plan             = var.paas_postgres_service_plan
-  redis_old_service_plan            = var.paas_redis_old_service_plan
   redis_cache_service_plan          = var.paas_redis_cache_service_plan
   redis_queue_service_plan          = var.paas_redis_queue_service_plan
   space_name                        = var.paas_space_name

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -67,10 +67,6 @@ variable paas_postgres_service_plan {
   default = "tiny-unencrypted-11"
 }
 
-variable paas_redis_old_service_plan {
-  default = "micro-5_x"
-}
-
 variable paas_redis_cache_service_plan {
   default = "micro-5_x"
 }

--- a/terraform/workspace-variables/dev.tfvars
+++ b/terraform/workspace-variables/dev.tfvars
@@ -26,7 +26,6 @@ paas_api_url                           = "https://api.london.cloud.service.gov.u
 paas_space_name                        = "teaching-vacancies-dev"
 paas_papertrail_service_binding_enable = false
 paas_postgres_service_plan             = "tiny-unencrypted-11"
-paas_redis_old_service_plan            = "micro-5_x"
 paas_redis_cache_service_plan          = "micro-5_x"
 paas_redis_queue_service_plan          = "micro-5_x"
 paas_app_start_timeout                 = "180"

--- a/terraform/workspace-variables/production.tfvars
+++ b/terraform/workspace-variables/production.tfvars
@@ -26,7 +26,6 @@ paas_api_url                           = "https://api.london.cloud.service.gov.u
 paas_space_name                        = "teaching-vacancies-production"
 paas_papertrail_service_binding_enable = true
 paas_postgres_service_plan             = "medium-ha-11"
-paas_redis_old_service_plan            = "small-ha-4_x"
 paas_redis_cache_service_plan          = "tiny-5_x"
 paas_redis_queue_service_plan          = "micro-ha-5_x"
 paas_app_start_timeout                 = "180"

--- a/terraform/workspace-variables/review.tfvars
+++ b/terraform/workspace-variables/review.tfvars
@@ -25,7 +25,6 @@ channel_list = {
 paas_api_url                           = "https://api.london.cloud.service.gov.uk"
 paas_space_name                        = "teaching-vacancies-review"
 paas_postgres_service_plan             = "tiny-unencrypted-11"
-paas_redis_old_service_plan            = "micro-5_x"
 paas_redis_cache_service_plan          = "micro-5_x"
 paas_redis_queue_service_plan          = "micro-5_x"
 paas_papertrail_service_binding_enable = false

--- a/terraform/workspace-variables/staging.tfvars
+++ b/terraform/workspace-variables/staging.tfvars
@@ -26,7 +26,6 @@ paas_api_url                           = "https://api.london.cloud.service.gov.u
 paas_space_name                        = "teaching-vacancies-staging"
 paas_papertrail_service_binding_enable = true
 paas_postgres_service_plan             = "small-11"
-paas_redis_old_service_plan            = "micro-5_x"
 paas_redis_cache_service_plan          = "micro-5_x"
 paas_redis_queue_service_plan          = "micro-5_x"
 paas_app_start_timeout                 = "180"


### PR DESCRIPTION
Now that the app is successfully using the new Redis instance, we can
get rid of the old one.