### PR TITLE
Backup sync/restore workflow bugfix and improvements

### DIFF
--- a/.github/workflows/sync_staging_db.yml
+++ b/.github/workflows/sync_staging_db.yml
@@ -39,6 +39,18 @@ jobs:
       shell: bash
       run: bin/dump-db
 
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: eu-west-2
+
+    - name: Upload backup to S3
+      run: bin/upload-db-backup
+      env:
+        FILENAME: backup.sql
+
     - name: Sanitise the Database backup
       run: |
         echo "::group::Restore backup to intermediate database"
@@ -64,18 +76,6 @@ jobs:
       env:
         CF_DESTINATION_ENVIRONMENT: staging
         FILENAME: sanitised-backup.sql
-
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: eu-west-2
-
-    - name: Upload backup to S3
-      run: bin/upload-db-backup
-      env:
-        FILENAME: backup.sql
 
     - name: Upload sanitised backup to S3
       run: bin/upload-db-backup

--- a/bin/restore-db
+++ b/bin/restore-db
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -eu
+CF_ORG_NAME='dfe'
 CF_SERVICE_NAME='teaching-vacancies'
 if [[ "${CF_DESTINATION_ENVIRONMENT}" = "production" ]] ; then
   echo "CF_DESTINATION_ENVIRONMENT should not equal production"
@@ -7,7 +8,7 @@ if [[ "${CF_DESTINATION_ENVIRONMENT}" = "production" ]] ; then
 fi
 CONDUIT_APP_NAME="${CF_SERVICE_NAME}-conduit-${CF_DESTINATION_ENVIRONMENT}"
 
-cf target -o "${CF_ORG}" -s "${CF_SERVICE_NAME}-${CF_DESTINATION_ENVIRONMENT}"
+cf target -o "${CF_ORG_NAME}" -s "${CF_SERVICE_NAME}-${CF_DESTINATION_ENVIRONMENT}"
 cf conduit "${CF_SERVICE_NAME}-postgres-${CF_DESTINATION_ENVIRONMENT}" --app-name "${CONDUIT_APP_NAME}" -- psql < backup.sql
 # The conduit app may have to be deleted explicitly
 cf delete -f "${CONDUIT_APP_NAME}" || true


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1414

## Changes in this PR:

- Refactored `restore-db` script failed with `CF_ORG: unbound variable` (https://github.com/DFE-Digital/teaching-vacancies/runs/1819460312?check_suite_focus=true)
- Adding Org name as a constant, and changed constant name to `CF_ORG_NAME` for consistency with shared GitHub Action https://github.com/DFE-Digital/github-actions/tree/master/setup-cf-cli
- Resequenced steps in the workflow to ensure that the production backup is uploaded before the sanitisation steps are performed, to ensure the best chance of having the backup in S3.