### PR TITLE
Fix for task and subscription presenter

### DIFF
--- a/app/presenters/subscription_presenter.rb
+++ b/app/presenters/subscription_presenter.rb
@@ -45,7 +45,7 @@ class SubscriptionPresenter < BasePresenter
   end
 
   def render_location_filter(location, radius)
-    return if location.empty?
+    return if location.blank?
 
     return { location: I18n.t("subscriptions.location_polygon_text", location: location) } if LocationPolygon.include?(location)
     return { location: I18n.t("subscriptions.location_radius_text", radius: radius, location: location) } if radius


### PR DESCRIPTION
##The Issue:

Due to task below, when run, if a subscription did not have a location category, the location in the search criteria was set to nil. This is because `subscription.search_criteria.delete("location_category")` returns nil if there is no location_category key. 

```
namespace :subscription do
  desc "remove location_category from search_criteria"
  task remove_location_category_from_search_criteria: :environment do
    Subscription.find_each do |subscription|
        subscription.search_criteria["location"] = subscription.search_criteria.delete("location_category")
        subscription.save
      end
    end
  end
end
```

As some subscriptions now had location set to nil, in the subscription presenter, when line 48 in the `render_location_filter ` was hit, a NoMethodError was raised(correct term?). 

##The Solution:

-  Replaced `.empty?` with `.blank?` in the subscription presenter as `nil.blank?` does not raise a NoMethodError and instead returns `true`
- Will create a new PR later with the shiny new task that doesn't break everything :)