### PR TITLE
Teva 1968 gh actions honour step conclusion

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,7 +107,7 @@ jobs:
         intervalSeconds: 15
 
     - name: Trigger Smoke Test
-      if: ${{ steps.wait_for_deploy_app_staging.outputs.conclusion == 'success' }}
+      if: steps.wait_for_deploy_app_staging.outputs.conclusion == 'success'
       uses: benc-uk/workflow-dispatch@v1.1
       with:
         workflow: Smoke Test Manual # Workflow name
@@ -125,7 +125,7 @@ jobs:
         intervalSeconds: 15
 
     - name: Trigger Deploy App Workflow for production
-      if: ${{ steps.wait_for_smoke_test.outputs.conclusion == 'success' }} && github.ref == 'refs/heads/master'
+      if: steps.wait_for_smoke_test.outputs.conclusion == 'success' && github.ref == 'refs/heads/master'
       uses: benc-uk/workflow-dispatch@v1.1
       with:
         workflow: Deploy App to Environment # Workflow name
@@ -143,7 +143,7 @@ jobs:
         intervalSeconds: 15
 
     - name: Deploy monitoring
-      if: ${{ steps.wait_for_deploy_app_production.outputs.conclusion == 'success' }} && github.ref == 'refs/heads/master'
+      if: steps.wait_for_deploy_app_production.outputs.conclusion == 'success' && github.ref == 'refs/heads/master'
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -156,7 +156,7 @@ jobs:
       working-directory: terraform/monitoring
 
     - name: Send job status message to twd_tv_dev channel
-      if: ${{ always() && github.ref == 'refs/heads/master' }}
+      if: always() && github.ref == 'refs/heads/master'
       uses: rtCamp/action-slack-notify@v2.1.2
       env:
         SLACK_CHANNEL: twd_tv_dev

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,11 +103,24 @@ jobs:
         token: ${{ secrets.PERSONAL_TOKEN }}
         checkName: Deploy ${{ env.TAG }} to staging # Job name within workflow
         ref: ${{ github.ref }}
-        timeoutSeconds: 300
+        timeoutSeconds: 720
         intervalSeconds: 15
 
+    - name: Notify twd_tv_dev channel on staging deployment failure
+      if: steps.wait_for_deploy_app_staging.outputs.conclusion != 'success' && 'refs/heads/master'
+      uses: rtCamp/action-slack-notify@v2.1.2
+      env:
+        SLACK_CHANNEL: twd_tv_dev
+        SLACK_USERNAME: CI Deployment
+        SLACK_TITLE: Deployment failure
+        SLACK_MESSAGE: 'Deployment of Docker tag ${{ env.TAG }} to staging - ${{ job.status }}'
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+    - name: Exit whole workflow if staging deployment was not successful
+      if: steps.wait_for_deploy_app_staging.outputs.conclusion != 'success' && 'refs/heads/master'
+      run: exit 1
+
     - name: Trigger Smoke Test
-      if: steps.wait_for_deploy_app_staging.outputs.conclusion == 'success'
       uses: benc-uk/workflow-dispatch@v1.1
       with:
         workflow: Smoke Test Manual # Workflow name
@@ -124,6 +137,20 @@ jobs:
         timeoutSeconds: 300
         intervalSeconds: 15
 
+    - name: Notify twd_tv_dev channel on staging smoke test failure
+      if: steps.wait_for_smoke_test.outputs.conclusion != 'success' && 'refs/heads/master'
+      uses: rtCamp/action-slack-notify@v2.1.2
+      env:
+        SLACK_CHANNEL: twd_tv_dev
+        SLACK_USERNAME: CI Deployment
+        SLACK_TITLE: Deployment failure
+        SLACK_MESSAGE: 'Smoke test of Docker tag ${{ env.TAG }} on staging - ${{ job.status }}'
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+    - name: Exit whole workflow if staging smoke test was not successful
+      if: steps.wait_for_smoke_test.outputs.conclusion != 'success' && github.ref == 'refs/heads/master'
+      run: exit 1
+
     - name: Trigger Deploy App Workflow for production
       if: steps.wait_for_smoke_test.outputs.conclusion == 'success' && github.ref == 'refs/heads/master'
       uses: benc-uk/workflow-dispatch@v1.1
@@ -139,11 +166,24 @@ jobs:
         token: ${{ secrets.PERSONAL_TOKEN }}
         checkName: Deploy ${{ env.TAG }} to production # Job name within workflow
         ref: ${{ github.ref }}
-        timeoutSeconds: 300
+        timeoutSeconds: 720
         intervalSeconds: 15
 
+    - name: Notify twd_tv_dev channel on production deployment failure
+      if: steps.wait_for_deploy_app_production.outputs.conclusion != 'success' && 'refs/heads/master'
+      uses: rtCamp/action-slack-notify@v2.1.2
+      env:
+        SLACK_CHANNEL: twd_tv_dev
+        SLACK_USERNAME: CI Deployment
+        SLACK_TITLE: Deployment failure
+        SLACK_MESSAGE: 'Deployment of Docker tag ${{ env.TAG }} to production - ${{ job.status }}'
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+    - name: Exit whole workflow if production deployment was not successful
+      if: steps.wait_for_deploy_app_production.outputs.conclusion != 'success' && 'refs/heads/master'
+      run: exit 1
+
     - name: Deploy monitoring
-      if: steps.wait_for_deploy_app_production.outputs.conclusion == 'success' && github.ref == 'refs/heads/master'
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -162,5 +202,5 @@ jobs:
         SLACK_CHANNEL: twd_tv_dev
         SLACK_USERNAME: CI Deployment
         SLACK_TITLE: Deployment ${{ job.status }}
-        SLACK_MESSAGE: 'Deployment of Docker tag ${{ env.TAG }} to production - ${{ job.status }}'
+        SLACK_MESSAGE: 'Deployment of Docker tag ${{ env.TAG }} to staging and production - ${{ job.status }}'
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy_app.yml
+++ b/.github/workflows/deploy_app.yml
@@ -38,7 +38,7 @@ jobs:
         terraform_version: 0.13.5
 
     - name: Set environment variables for review
-      if: ${{ startsWith(github.event.inputs.environment, 'review') }}
+      if: startsWith(github.event.inputs.environment, 'review')
       run: |
         BACKEND_CONFIG=-backend-config="workspace_key_prefix=review:"
         PARAMETER_STORE_ENVIRONMENT=dev
@@ -50,7 +50,7 @@ jobs:
         echo "VAR_FILE=${VAR_FILE}" >> $GITHUB_ENV
 
     - name: Set environment variables for non-review environments
-      if: ${{ !startsWith(github.event.inputs.environment, 'review') }}
+      if: startsWith(github.event.inputs.environment, 'review') != true
       run: |
         PARAMETER_STORE_ENVIRONMENT=${{ github.event.inputs.environment }}
         VAR_FILE=${{ github.event.inputs.environment }}

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -106,7 +106,7 @@ jobs:
         intervalSeconds: 15
 
     - name: Send job status message to twd_tv_dev channel
-      if: ${{ always() && github.ref == 'refs/heads/master' }}
+      if: always() && github.ref == 'refs/heads/master'
       uses: rtCamp/action-slack-notify@v2.1.2
       env:
         SLACK_CHANNEL: twd_tv_dev

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -102,7 +102,7 @@ jobs:
         token: ${{ secrets.PERSONAL_TOKEN }}
         checkName: Deploy app to environment # Job name within workflow
         ref: ${{ github.ref }}
-        timeoutSeconds: 300
+        timeoutSeconds: 720
         intervalSeconds: 15
 
     - name: Send job status message to twd_tv_dev channel

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -61,7 +61,7 @@ jobs:
       working-directory: terraform/app
 
     - name: Send failure message to twd_tv_dev channel
-      if: ${{ failure() }}
+      if: failure()
       uses: rtCamp/action-slack-notify@v2.1.2
       env:
         SLACK_CHANNEL: twd_tv_dev

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -55,7 +55,7 @@ jobs:
           intervalSeconds: 15
 
       - name: Send job status message to twd_tv_dev channel
-        if: ${{ always() && github.ref == 'refs/heads/master' }}
+        if: always() && github.ref == 'refs/heads/master'
         uses: rtCamp/action-slack-notify@v2.1.2
         env:
           SLACK_CHANNEL: twd_tv_dev

--- a/.github/workflows/restore_db.yml
+++ b/.github/workflows/restore_db.yml
@@ -42,7 +42,7 @@ jobs:
         FILENAME: sanitised-backup.sql
 
     - name: Send success message to twd_tv_dev channel
-      if: ${{ success() }}
+      if: success()
       uses: rtCamp/action-slack-notify@v2.1.2
       env:
         SLACK_CHANNEL: twd_tv_dev
@@ -53,7 +53,7 @@ jobs:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
     - name: Send failure message to twd_tv_dev channel
-      if: ${{ failure() }}
+      if: failure()
       uses: rtCamp/action-slack-notify@v2.1.2
       env:
         SLACK_CHANNEL: twd_tv_dev

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -107,8 +107,11 @@ jobs:
         timeoutSeconds: 720
         intervalSeconds: 15
 
+    - name: Exit whole workflow if deployment was not successful
+      if: steps.wait_for_deploy_app.outputs.conclusion != 'success'
+      run: exit 1
+
     - name: Post Sticky Pull Request Comment
-      if: steps.wait_for_deploy_app.outputs.conclusion == 'success'
       uses: marocchino/sticky-pull-request-comment@v2
       with:
         GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -108,7 +108,7 @@ jobs:
         intervalSeconds: 15
 
     - name: Post Sticky Pull Request Comment
-      if: ${{ steps.wait_for_deploy_app.outputs.conclusion == 'success' }}
+      if: steps.wait_for_deploy_app.outputs.conclusion == 'success'
       uses: marocchino/sticky-pull-request-comment@v2
       with:
         GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}

--- a/.github/workflows/smoke-test-manual.yml
+++ b/.github/workflows/smoke-test-manual.yml
@@ -38,7 +38,7 @@ jobs:
         run: bundle exec rspec spec/smoke_tests/jobseekers_can_view_homepage_${{ github.event.inputs.environment }}_spec.rb --tag smoke_test
 
       - name: Slack notification
-        if: ${{ failure() }}
+        if: failure()
         uses: rtCamp/action-slack-notify@v2.1.2
         env:
           SLACK_CHANNEL: twd_tv_dev

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -31,7 +31,7 @@ jobs:
         run: bundle exec rspec spec/smoke_tests/jobseekers_can_view_homepage_production_spec.rb --tag smoke_test
 
       - name: Slack notification
-        if: ${{ failure() }}
+        if: failure()
         uses: rtCamp/action-slack-notify@v2.1.2
         env:
           SLACK_CHANNEL: twd_tv_dev

--- a/.github/workflows/sync_staging_db.yml
+++ b/.github/workflows/sync_staging_db.yml
@@ -83,7 +83,7 @@ jobs:
         FILENAME: sanitised-backup.sql
 
     - name: Send success message to twd_tv_dev channel
-      if: ${{ success() }}
+      if: success()
       uses: rtCamp/action-slack-notify@v2.1.2
       env:
         SLACK_CHANNEL: twd_tv_dev
@@ -94,7 +94,7 @@ jobs:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
     - name: Send failure message to twd_tv_dev channel
-      if: ${{ failure() }}
+      if: failure()
       uses: rtCamp/action-slack-notify@v2.1.2
       env:
         SLACK_CHANNEL: twd_tv_dev


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1968

## Changes in this PR:

- Remove double braces for if conditions which caused the if condition to always be true
- Add Slack messages after failure of important steps (deploy to staging, smoke test, deploy to production), and then `exit 1` to fail the whole workflow
- Increase timeout to 720 seconds to handle Redis instances creation / destruction.