### PR TITLE
Allow programmatic alerts to use at channel for Slack

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,7 +113,7 @@ jobs:
         SLACK_CHANNEL: twd_tv_dev
         SLACK_USERNAME: CI Deployment
         SLACK_TITLE: Deployment failure
-        SLACK_MESSAGE: 'Deployment of Docker tag ${{ env.TAG }} to staging - ${{ job.status }}'
+        SLACK_MESSAGE: 'Deployment of Docker tag ${{ env.TAG }} to staging - unsuccessful <!channel>'
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
     - name: Exit whole workflow if staging deployment was not successful
@@ -144,7 +144,7 @@ jobs:
         SLACK_CHANNEL: twd_tv_dev
         SLACK_USERNAME: CI Deployment
         SLACK_TITLE: Deployment failure
-        SLACK_MESSAGE: 'Smoke test of Docker tag ${{ env.TAG }} on staging - ${{ job.status }}'
+        SLACK_MESSAGE: 'Smoke test of Docker tag ${{ env.TAG }} on staging - unsuccessful <!channel>'
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
     - name: Exit whole workflow if staging smoke test was not successful
@@ -176,7 +176,7 @@ jobs:
         SLACK_CHANNEL: twd_tv_dev
         SLACK_USERNAME: CI Deployment
         SLACK_TITLE: Deployment failure
-        SLACK_MESSAGE: 'Deployment of Docker tag ${{ env.TAG }} to production - ${{ job.status }}'
+        SLACK_MESSAGE: 'Deployment of Docker tag ${{ env.TAG }} to production - unsuccessful <!channel>'
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
     - name: Exit whole workflow if production deployment was not successful

--- a/.github/workflows/restore_db.yml
+++ b/.github/workflows/restore_db.yml
@@ -41,24 +41,12 @@ jobs:
         CF_DESTINATION_ENVIRONMENT: ${{ github.event.inputs.environment }}
         FILENAME: sanitised-backup.sql
 
-    - name: Send success message to twd_tv_dev channel
-      if: success()
+    - name: Send job status message to twd_tv_dev channel
+      if: always() && github.ref == 'refs/heads/master'
       uses: rtCamp/action-slack-notify@v2.1.2
       env:
         SLACK_CHANNEL: twd_tv_dev
         SLACK_USERNAME: CI Deployment
-        SLACK_ICON_EMOJI: ':rocket:'
-        SLACK_TITLE: DB syncing success
-        SLACK_MESSAGE: 'Successful db restore production->${{ github.event.inputs.environment }}'
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-
-    - name: Send failure message to twd_tv_dev channel
-      if: failure()
-      uses: rtCamp/action-slack-notify@v2.1.2
-      env:
-        SLACK_CHANNEL: twd_tv_dev
-        SLACK_USERNAME: CI Deployment
-        SLACK_ICON_EMOJI: ':cry:'
-        SLACK_TITLE: DB syncing failure
-        SLACK_MESSAGE: 'Failed db restore production->${{ github.event.inputs.environment }}'
+        SLACK_TITLE: Deployment ${{ job.status }}
+        SLACK_MESSAGE: 'Restore sanitised production DB to ${{ github.event.inputs.environment }} - ${{ job.status }}'
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/smoke-test-manual.yml
+++ b/.github/workflows/smoke-test-manual.yml
@@ -36,14 +36,3 @@ jobs:
 
       - name: Run smoke test
         run: bundle exec rspec spec/smoke_tests/jobseekers_can_view_homepage_${{ github.event.inputs.environment }}_spec.rb --tag smoke_test
-
-      - name: Slack notification
-        if: failure()
-        uses: rtCamp/action-slack-notify@v2.1.2
-        env:
-          SLACK_CHANNEL: twd_tv_dev
-          SLACK_USERNAME: Smoke Test
-          SLACK_ICON_EMOJI: ':cry:'
-          SLACK_TITLE: Smoke test failed
-          SLACK_MESSAGE: 'Smoke Test ${{ github.event.inputs.sha }} on ${{ github.event.inputs.environment }} has failed !channel'
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -38,5 +38,5 @@ jobs:
           SLACK_USERNAME: Smoke Test
           SLACK_ICON_EMOJI: ':cry:'
           SLACK_TITLE: Smoke test failed
-          SLACK_MESSAGE: 'Production website smoke test has failed !channel'
+          SLACK_MESSAGE: 'Production website smoke test has failed <!channel>'
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1981

## Changes in this PR:

- Slack [documentation](https://slack.com/intl/en-gb/help/articles/202009646-Notify-a-channel-or-workspace) shows syntax for programmatic notifications is `!channel` enclosed in angle brackets (describing in words, otherwise GitHub to Slack will try and alert the channel)
- Add channel alerts to highest-priority notifications (failed smoke tests on staging or production, failed deployment to staging or production)
- Remove double-alert from `smoke test manual` when called with workflow dispatch
- Remove step duplication by using job-status for the result of a workflow job
