### PR TITLE
[TEVA-1757] Update to Part 1: Update feedback copy task

### DIFF
--- a/app/services/event.rb
+++ b/app/services/event.rb
@@ -17,8 +17,8 @@ class Event
   def trigger(event_type, data = {})
     data = base_data.merge(
       type: event_type,
-      occurred_at: Time.now.utc.iso8601(6),
-      data: data.map { |key, value| { key: key.to_s, value: value&.to_s } },
+      occurred_at: occurred_at(data),
+      data: data.map { |key, value| { key: key.to_s, value: formatted_value(value) } },
     )
     SendEventToDataWarehouseJob.perform_later(TABLE_NAME, data)
   rescue StandardError => e
@@ -31,5 +31,31 @@ class Event
   # Data to be included with any event (to be overridden as appropriate in subclasses)
   def base_data
     {}
+  end
+
+  ##
+  # For json objects or hashes passed to Event#trigger as values in the `data` param, such as
+  # Subscription#search_criteria or Feedback#search_criteria, we should format these as json for BigQuery,
+  # rather than strings, for easier data manipulation by Performance Analysis.
+  # Arrays, such as job alert Feedbacks with a vacancy_ids attribute, should remain as arrays.
+  # @param [Object] value Any value in the data passed to the event.
+  def formatted_value(value)
+    return value if value.is_a?(Array)
+
+    value.respond_to?(:keys) ? value.to_json : value&.to_s
+  end
+
+  ##
+  # When converting existing records into events, set `occurred_at` to the time the record was created, if the
+  # record's `created_at` value is passed to Event#trigger in the `data` param.
+  # @param [Hash{Symbol => Object}] data Any data included with the event, which, in the case of converting
+  # existing records into events, will include attributes from the existing record being converted.
+  def occurred_at(data)
+    time = if data[:created_at].present?
+             data[:created_at]
+           else
+             Time.now.utc
+           end
+    time.iso8601(6)
   end
 end

--- a/spec/services/event_spec.rb
+++ b/spec/services/event_spec.rb
@@ -7,11 +7,15 @@ RSpec.describe Event do
         "events",
         type: :reticulated_splines,
         occurred_at: "1999-12-31T23:59:59.000000Z",
-        data: [{ key: "foo", value: "Bar" }],
+        data: [
+          { key: "foo", value: "Bar" },
+          { key: "baz", value: [1, 2] },
+          { key: "params", value: { foo: "bar" }.to_json },
+        ],
       )
 
       travel_to(Time.utc(1999, 12, 31, 23, 59, 59)) do
-        subject.trigger(:reticulated_splines, foo: "Bar")
+        subject.trigger(:reticulated_splines, foo: "Bar", baz: [1, 2], params: { foo: "bar" })
       end
     end
 


### PR DESCRIPTION
## Jira ticket URL

Part of https://dfedigital.atlassian.net/browse/TEVA-1757

## Changes in this PR:

- Updates the work in https://github.com/DFE-Digital/teaching-vacancies/pull/2738
- Send Events to BigQuery at the same time as moving feedback data
- This updates the task which sends feedback from old feedback tables to the
new feedback table, so that we are creating Events (sent to BigQuery) at
the same time. These events will be used alongside newer RequestEvents,
representing controller events that create Feedbacks, to store/manage/
monitor/analyse/collate all feedback of a certain 'feedback_type'.
- The task has not yet been run. It will be run when all code has been
updated to use the new Feedback table rather than the old feedback table.
- I'm using find_or_create_by in case GovUK PaaS explodes and we need to
run the task a second time.
- I have also updated the Event model so that any data containing a
'created_at' attribute is reflected in the 'occurred_at' column of the
Event (rather than Time.now); and so that fewer data value types are
converted to string (which can be an annoyance for someone wanting to
manipulate the data after it's received).

- When the task is run, I'll remove the code for the task, as well as the occurred_at method in Event.