### PR TITLE
Teva 1414 bugfix improvements

### DIFF
--- a/.github/workflows/restore_db.yml
+++ b/.github/workflows/restore_db.yml
@@ -6,7 +6,7 @@ on:
       environment:
         description: 'Environment'
         required: true
-        default: 'staging'
+        default: 'dev'
 
 jobs:
   sync:
@@ -17,8 +17,13 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
-    - name: Install CF client
-      uses: DFE-Digital/github-actions/install-cf-cli@master
+    - name: Setup cf cli
+      uses: DFE-Digital/github-actions/setup-cf-cli@master
+      with:
+        CF_USERNAME: ${{ secrets.CF_USERNAME }}
+        CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
+        CF_SPACE_NAME: teaching-vacancies-${{ github.event.inputs.environment }}
+        INSTALL_CONDUIT: true
 
     - name: Install postgres client
       uses: DFE-Digital/github-actions/install-postgres-client@master

--- a/db/scripts/sanitise.sql
+++ b/db/scripts/sanitise.sql
@@ -1,3 +1,4 @@
+TRUNCATE TABLE alert_runs;
 TRUNCATE TABLE audit_data;
 TRUNCATE TABLE emergency_login_keys;
 TRUNCATE TABLE sessions;


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1414

## Changes in this PR:

- Default target to `dev` (`staging` gets refreshed nightly with the same backup, so `dev` is more likely to be refreshed on demand).
- Use `setup-cf-cli` action, as already in use on sync_staging_db.yml workflow
- TRUNCATE `alert_runs` table during sanitisation
