### PR TITLE
Fix for the remove_location_category_from_subscription_search_criteria task

### DIFF
--- a/lib/tasks/remove_location_cateogory_from_subscription_search_criteria.rake
+++ b/lib/tasks/remove_location_cateogory_from_subscription_search_criteria.rake
@@ -2,8 +2,13 @@ namespace :subscription do
   desc "remove location_category from search_criteria"
   task remove_location_category_from_search_criteria: :environment do
     Subscription.find_each do |subscription|
-      subscription.search_criteria["location"] = subscription.search_criteria.delete("location_category")
-      subscription.save
+      if subscription.search_criteria["location_category"].present? && subscription.search_criteria["location"].blank?
+        subscription.search_criteria["location"] = subscription.search_criteria.delete("location_category")
+        subscription.save
+      elsif subscription.search_criteria["location_category"].present?
+        subscription.search_criteria.delete("location_category")
+        subscription.save
+      end
     end
   end
 end


### PR DESCRIPTION
**This task needs to be tested.** 

Previous to these changes, the task did not check that location_category was present and location was blank before setting location to the value of location_category and deleting location_category. 

Because of this, all of the subscriptions that did not have a location_category in the search_criteria set location to nil - the return value of subscription.search_criteria.delete[location_category] is nil if location_category is not present.

Now the task has a clause that checks that location_category is present and location is blank before setting location_category to location and deleting location_category.

If location is not blank and the location_category is present, the location_category is deleted.
