### PR TITLE
Map searches in 'Kensington, London' to K&C borough

### DIFF
--- a/lib/tasks/data/mapped_locations.yml
+++ b/lib/tasks/data/mapped_locations.yml
@@ -39,6 +39,7 @@
 - ['islington, london', 'islington']
 - ['isle of wight, newport', 'isle of wight']
 - ['kensington', 'kensington and chelsea']
+- ['kensington, london', 'kensington and chelsea']
 - ['kensington and chelsea, london', 'kensington and chelsea']
 - ['kingston', 'kingston upon thames']
 - ['kingston upon hull, hull', 'kingston upon hull']


### PR DESCRIPTION
The 'Kensington, London' search query is suggested by autocomplete. We should map it to the name of the LocationPolygon record.