### PR TITLE
Have StringAnonymiser not alter blank inputs

### DIFF
--- a/app/services/string_anonymiser.rb
+++ b/app/services/string_anonymiser.rb
@@ -11,8 +11,9 @@ class StringAnonymiser
   end
 
   def to_s
-    Digest::SHA256.bubblebabble(@raw_string)
+    raw_string.blank? ? "" : Digest::SHA256.bubblebabble(raw_string)
   end
+
   alias to_str to_s
 
   def ==(other)

--- a/spec/services/string_anonymiser_spec.rb
+++ b/spec/services/string_anonymiser_spec.rb
@@ -1,11 +1,20 @@
 require "rails_helper"
 
 RSpec.describe StringAnonymiser do
-  subject { described_class.new("Hello world!") }
+  let(:input) { "Hello world!" }
+  subject { described_class.new(input) }
 
   describe "#to_s" do
     it "returns an anonymised form of the input string" do
       expect(subject.to_s).to eq("xubah-fylag-ramor-laluz-tigyd-nigyb-hybek-ryvym-nysog-vodif-zyrus-bulos-zezer-ruzuz-fyket-nenac-pyxyx")
+    end
+
+    context "when input is empty" do
+      let(:input) { nil }
+
+      it "returns blank string if the input is empty" do
+        expect(subject.to_s).to eq("")
+      end
     end
   end
 


### PR DESCRIPTION
This is to make Events in BigQuery more readable - so that a reader can instantly see that an id is not present (nil), rather than remembering that xumor-boceg-dakuz-sulic-gukoz-rutas etc etc denotes a column that's empty.

An alternative would be to put the logic into the method trigger_feedback_provided_event. Which place is better? I prefer in the StringAnonymiser, but is there a reason not to put it there?
