### PR TITLE
Lazily enumerate DSI response pages

### DIFF
--- a/lib/dfe_sign_in_api.rb
+++ b/lib/dfe_sign_in_api.rb
@@ -61,18 +61,16 @@ module DFESignIn
     response["users"].blank? || response["users"].first.blank?
   end
 
-  def get_response_pages
-    response_pages = []
-    (1..number_of_pages).each do |page|
+  def response_pages
+    (1..number_of_pages).lazy.map do |page|
       response = api_response(page: page)
       if users_nil_or_empty?(response)
-        Rollbar.log(:error,
-                    "DfE Sign In API responded with nil users")
+        Rollbar.log(:error, "DfE Sign In API responded with nil users")
         raise error_message_for(response)
       end
-      response_pages.push(response["users"])
+
+      response["users"]
     end
-    response_pages
   end
 
   def la_code(user)

--- a/lib/export_dsi_approvers_to_big_query.rb
+++ b/lib/export_dsi_approvers_to_big_query.rb
@@ -5,7 +5,7 @@ class ExportDsiApproversToBigQuery < BaseDsiBigQueryExporter
 
   def run!
     delete_table(TABLE_NAME)
-    get_response_pages.each { |page| insert_table_data(page) }
+    response_pages.each { |page| insert_table_data(page) }
   rescue StandardError => e
     Rails.logger.warn("DSI API /approvers failed to respond with error: #{e.message}")
     raise "#{e.message}, while writing data from DSI /approvers endpoint. Flag this to Steven + Comms team"

--- a/lib/export_dsi_users_to_big_query.rb
+++ b/lib/export_dsi_users_to_big_query.rb
@@ -5,7 +5,7 @@ class ExportDsiUsersToBigQuery < BaseDsiBigQueryExporter
 
   def run!
     delete_table(TABLE_NAME)
-    get_response_pages.each { |page| insert_table_data(page) }
+    response_pages.each { |page| insert_table_data(page) }
   rescue StandardError => e
     Rails.logger.warn("DSI API /users failed to respond with error: #{e.message}")
     raise "#{e.message}, while writing data from DSI /users endpoint. Flag this to Steven + Comms team"

--- a/lib/update_dsi_users_in_db.rb
+++ b/lib/update_dsi_users_in_db.rb
@@ -4,7 +4,7 @@ class UpdateDsiUsersInDb
   include DFESignIn
 
   def run!
-    get_response_pages.each { |page| convert_to_users(page) }
+    response_pages.each { |page| convert_to_users(page) }
   end
 
   private


### PR DESCRIPTION
`DFESignIn` was fetching all response pages from DSI into one enormous
array, which was causing the workers running DSI fetching jobs to run
out of memory.

This turns `DFESignIn#get_response_pages` into a lazy enumerator that
just takes life one page at a time.