### PR TITLE
add padding so notification text doesnt bunch up againt dismiss cta

### DIFF
--- a/app/components/shared/notification_component/notification_component.scss
+++ b/app/components/shared/notification_component/notification_component.scss
@@ -48,6 +48,7 @@
 
 .govuk-notification__body {
   @include govuk-font($size: 19);
+  padding-right: govuk-spacing(9);
 
   p {
     @include govuk-responsive-margin(4, 'bottom');


### PR DESCRIPTION
production defect

after fix

![Screenshot 2021-02-08 at 19 33 20](https://user-images.githubusercontent.com/1792451/107271730-8a90d500-6a44-11eb-98b0-04aca510bf04.png)
