### PR TITLE
[TEVA-1757] Part n+1: Update Job Alert Feedback controller/form to rely on new Feedback table

### DIFF
--- a/app/controllers/job_alert_feedbacks_controller.rb
+++ b/app/controllers/job_alert_feedbacks_controller.rb
@@ -3,41 +3,55 @@ class JobAlertFeedbacksController < ApplicationController
     # This action creates the JobAlertFeedback record.
     # This is because it is called from a link in the alert email. Such links can only perform
     # GET requests. HTTP forbids redirecting from GET to POST.
-    subscription = Subscription.find_and_verify_by_token(token)
-    @feedback = subscription.job_alert_feedbacks.create(job_alert_feedback_params)
 
-    Auditor::Audit.new(@feedback, "job_alert_feedback.create", current_publisher_oid).log
+    @subscription = Subscription.find_and_verify_by_token(token)
+    @feedback = Feedback.create(feedback_params)
+
+    trigger_feedback_provided_event
     redirect_to edit_subscription_job_alert_feedback_path(id: @feedback.id), success: t(".success")
   end
 
   def edit
-    @feedback = JobAlertFeedback.find(feedback_id)
+    @feedback = Feedback.find(feedback_id)
     @subscription = Subscription.find_and_verify_by_token(token)
     @feedback_form = Jobseekers::JobAlertFeedbackForm.new
   end
 
   def update
-    @feedback = JobAlertFeedback.find(feedback_id)
+    @feedback = Feedback.find(feedback_id)
     @subscription = Subscription.find_and_verify_by_token(token)
     @feedback_form = Jobseekers::JobAlertFeedbackForm.new(form_params)
 
     if @feedback_form.invalid?
       render :edit
     elsif recaptcha_is_invalid?(@feedback)
-      redirect_to invalid_recaptcha_path(form_name: @feedback.class.name.underscore.humanize)
+      redirect_to invalid_recaptcha_path(form_name: @feedback_form.class.name.gsub("::", "").underscore.humanize)
     else
       @feedback.update(form_params)
       @feedback.recaptcha_score = recaptcha_reply["score"]
       @feedback.save
-      Auditor::Audit.new(@feedback, "job_alert_feedback.update", current_publisher_oid).log
+      trigger_feedback_provided_event
       redirect_to root_path, success: t(".success")
     end
   end
 
   private
 
-  def job_alert_feedback_params
-    params.require(:job_alert_feedback).permit(:comment, :relevant_to_user, :search_criteria, search_criteria: {}, vacancy_ids: [])
+  def feedback_params
+    # `trigger_feedback_provided_event`, which we use to create Events, relies on feedback_params. Hence this slightly
+    # unconventional, abstracted feedback_params method, which allows events to be created for either type of action.
+    # Here felt like the best place for this logic, since job alert feedback is the only feedback type that has >1 action.
+    case action_name
+    when "new"
+      # The duplication here is because of the old-style params provided in links in emails that have already been sent.
+      # TODO: drop the left-most version of each duplication after e.g. 30 days, and the transformation.
+      params.require(:job_alert_feedback)
+            .permit(:relevant_to_user, :search_criteria, search_criteria: {}, vacancy_ids: [], job_alert_vacancy_ids: [])
+            .merge(feedback_type: "job_alert", subscription_id: @subscription.id)
+            .transform_keys { |key| key == "vacancy_ids" ? "job_alert_vacancy_ids" : key }
+    when "update"
+      form_params.merge(feedback_type: "job_alert", subscription_id: @subscription.id)
+    end
   end
 
   def form_params

--- a/app/helpers/notify_view_helper.rb
+++ b/app/helpers/notify_view_helper.rb
@@ -17,7 +17,7 @@ module NotifyViewHelper
     new_subscription_job_alert_feedback_url(
       subscription.token,
       params: { job_alert_feedback: { relevant_to_user: relevant,
-                                      vacancy_ids: vacancies.pluck(:id),
+                                      job_alert_vacancy_ids: vacancies.pluck(:id),
                                       search_criteria: subscription.search_criteria } },
     )
   end

--- a/app/services/event.rb
+++ b/app/services/event.rb
@@ -37,10 +37,12 @@ class Event
   # For json objects or hashes passed to Event#trigger as values in the `data` param, such as
   # Subscription#search_criteria or Feedback#search_criteria, we should format these as json for BigQuery,
   # rather than strings, for easier data manipulation by Performance Analysis.
-  # Arrays, such as job alert Feedbacks with a vacancy_ids attribute, should remain as arrays.
+  # Floats, Integers and Arrays, such as job alert Feedbacks with a job_alert_vacancy_ids attribute,
+  # should remain as they are.
   # @param [Object] value Any value in the data passed to the event.
   def formatted_value(value)
-    return value if value.is_a?(Array)
+    return value if value.is_a?(Float) || value.is_a?(Integer)
+    return value.map { |item| formatted_value(item) } if value.is_a?(Array)
 
     value.respond_to?(:keys) ? value.to_json : value&.to_s
   end

--- a/spec/mailers/alert_mailer_spec.rb
+++ b/spec/mailers/alert_mailer_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe AlertMailer, type: :mailer do
     new_subscription_job_alert_feedback_url(
       subscription.token,
       params: { job_alert_feedback: { relevant_to_user: true,
-                                      vacancy_ids: vacancies.pluck(:id),
+                                      job_alert_vacancy_ids: vacancies.pluck(:id),
                                       search_criteria: subscription.search_criteria } },
     )
   end
@@ -35,7 +35,7 @@ RSpec.describe AlertMailer, type: :mailer do
     new_subscription_job_alert_feedback_url(
       subscription.token,
       params: { job_alert_feedback: { relevant_to_user: false,
-                                      vacancy_ids: vacancies.pluck(:id),
+                                      job_alert_vacancy_ids: vacancies.pluck(:id),
                                       search_criteria: subscription.search_criteria } },
     )
   end

--- a/spec/services/event_spec.rb
+++ b/spec/services/event_spec.rb
@@ -9,13 +9,18 @@ RSpec.describe Event do
         occurred_at: "1999-12-31T23:59:59.000000Z",
         data: [
           { key: "foo", value: "Bar" },
-          { key: "baz", value: [1, 2] },
+          { key: "pi", value: 3.14 },
+          { key: "baz", value: [1, "string", 0.5] },
           { key: "params", value: { foo: "bar" }.to_json },
         ],
       )
 
       travel_to(Time.utc(1999, 12, 31, 23, 59, 59)) do
-        subject.trigger(:reticulated_splines, foo: "Bar", baz: [1, 2], params: { foo: "bar" })
+        subject.trigger(:reticulated_splines,
+                        foo: "Bar",
+                        pi: 3.14,
+                        baz: [1, "string", 0.5],
+                        params: { foo: "bar" })
       end
     end
 

--- a/spec/system/general_feedback_spec.rb
+++ b/spec/system/general_feedback_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Giving general feedback for the service", recaptcha: true do
         .with_data(comment: comment,
                    email: email,
                    feedback_type: "general",
-                   recaptcha_score: "0.9",
+                   recaptcha_score: 0.9,
                    user_participation_response: "interested",
                    visit_purpose: "other_purpose",
                    visit_purpose_comment: visit_purpose_comment)

--- a/spec/system/jobseekers_can_give_job_alert_feedback_spec.rb
+++ b/spec/system/jobseekers_can_give_job_alert_feedback_spec.rb
@@ -1,70 +1,90 @@
 require "rails_helper"
 
+RSpec.shared_examples "a correctly created Feedback" do
+  it "creates a Feedback with the correct attributes" do
+    expect(feedback.relevant_to_user).to eq relevant_to_user
+    expect(feedback.search_criteria).to eq subscription.search_criteria
+    expect(feedback.job_alert_vacancy_ids).to contain_exactly(vacancies.first.id, vacancies.second.id)
+    expect(feedback.subscription_id).to eq subscription.id
+  end
+end
+
 RSpec.describe "A jobseeker can give feedback on a job alert", recaptcha: true do
   let(:search_criteria) { { keyword: "Math", location: "London" } }
   let(:subscription) { create(:subscription, email: "bob@dylan.com", frequency: :daily, search_criteria: search_criteria) }
   let(:relevant_to_user) { true }
   let(:vacancies) { create_list(:vacancy, 2, :published) }
+  let(:job_alert_vacancy_ids) { vacancies.pluck(:id) }
   let(:verify_recaptcha) { true }
 
   before do
     allow_any_instance_of(ApplicationController).to receive(:verify_recaptcha).and_return(verify_recaptcha)
-    # Follow the link in the job alert email
-    visit new_subscription_job_alert_feedback_url(
-      token,
-      params: { job_alert_feedback: { relevant_to_user: relevant_to_user,
-                                      vacancy_ids: vacancies.pluck(:id),
-                                      search_criteria: subscription.search_criteria } },
-    )
   end
 
   context "with the correct token" do
     let(:token) { subscription.token }
-    let(:feedback) { subscription.job_alert_feedbacks.last }
-    let(:activity) { feedback.activities.last }
+    let(:feedback) { Feedback.where(subscription_id: subscription.id).first }
 
     context "when the user selects Yes" do
-      it "creates a JobAlertFeedback with the correct attributes" do
-        expect(feedback.relevant_to_user).to eq true
-        expect(feedback.search_criteria).to eq subscription.search_criteria
-        expect(feedback.vacancy_ids).to include vacancies.first.id
-        expect(feedback.vacancy_ids).to include vacancies.second.id
-        expect(feedback.subscription_id).to eq subscription.id
+      context "and follows a link from an old job alert email with different parameter names/formats" do
+        # TODO: Remove this context after e.g. 30 days.
+
+        let(:search_criteria) { { keyword: "Math", location: "London" }.to_json }
+
+        before { follow_a_link_from_an_old_job_alert_email }
+
+        it_behaves_like "a correctly created Feedback"
       end
 
-      it "audits the creation of the feedback" do
-        expect(activity.key).to eq("job_alert_feedback.create")
+      context "and follows the link in the job alert email" do
+        before { follow_the_link_in_the_job_alert_email }
+
+        it_behaves_like "a correctly created Feedback"
+
+        it "renders the page title and notification" do
+          expect(page.title).to have_content(I18n.t("job_alert_feedbacks.edit.title"))
+          expect(page).to have_content(I18n.t("job_alert_feedbacks.new.success"))
+        end
       end
 
-      it "renders the page title and notification" do
-        expect(page.title).to have_content(I18n.t("job_alert_feedbacks.edit.title"))
-        expect(page).to have_content(I18n.t("job_alert_feedbacks.new.success"))
+      it "triggers a RequestEvent of type 'feedback_provided'" do
+        expect { follow_the_link_in_the_job_alert_email }
+          .to have_triggered_event(:feedback_provided)
+          .with_data(feedback_type: "job_alert",
+                     subscription_id: subscription.id,
+                     search_criteria: search_criteria.to_json,
+                     job_alert_vacancy_ids: job_alert_vacancy_ids,
+                     relevant_to_user: relevant_to_user.to_s)
       end
     end
 
     context "when the user selects No" do
       let(:relevant_to_user) { false }
 
-      it "creates a JobAlertFeedback with the correct attributes" do
-        expect(feedback.relevant_to_user).to eq false
-        expect(feedback.search_criteria).to eq subscription.search_criteria
-        expect(feedback.vacancy_ids).to include vacancies.first.id
-        expect(feedback.vacancy_ids).to include vacancies.second.id
-        expect(feedback.subscription_id).to eq subscription.id
+      context "and follows the link in the job alert email" do
+        before { follow_the_link_in_the_job_alert_email }
+
+        it "shows a link to edit the job alert" do
+          click_on I18n.t("job_alert_feedbacks.edit.change_alert_link")
+          expect(page).to have_content I18n.t("subscriptions.edit.title")
+        end
+
+        it_behaves_like "a correctly created Feedback"
+
+        it "renders the page title and notification" do
+          expect(page.title).to have_content(I18n.t("job_alert_feedbacks.edit.title"))
+          expect(page).to have_content(I18n.t("job_alert_feedbacks.new.success"))
+        end
       end
 
-      it "shows a link to edit the job alert" do
-        click_on I18n.t("job_alert_feedbacks.edit.change_alert_link")
-        expect(page).to have_content I18n.t("subscriptions.edit.title")
-      end
-
-      it "audits the creation of the feedback" do
-        expect(activity.key).to eq("job_alert_feedback.create")
-      end
-
-      it "renders the page title and notification" do
-        expect(page.title).to have_content(I18n.t("job_alert_feedbacks.edit.title"))
-        expect(page).to have_content(I18n.t("job_alert_feedbacks.new.success"))
+      it "triggers a RequestEvent of type 'feedback_provided'" do
+        expect { follow_the_link_in_the_job_alert_email }
+          .to have_triggered_event(:feedback_provided)
+                .with_data(feedback_type: "job_alert",
+                           subscription_id: subscription.id,
+                           search_criteria: search_criteria.to_json,
+                           job_alert_vacancy_ids: job_alert_vacancy_ids,
+                           relevant_to_user: relevant_to_user.to_s)
       end
     end
 
@@ -72,26 +92,34 @@ RSpec.describe "A jobseeker can give feedback on a job alert", recaptcha: true d
       let(:comment) { "Excellent" }
 
       before do
+        follow_the_link_in_the_job_alert_email
         fill_in "jobseekers_job_alert_feedback_form[comment]", with: comment
-        click_on "Submit"
       end
 
       it "allows the user to submit further feedback" do
+        click_button I18n.t("buttons.submit")
         expect(current_path).to eq root_path
         expect(page).to have_content(I18n.t("job_alert_feedbacks.update.success"))
         expect(feedback.comment).to eq comment
       end
 
-      it "audits the update" do
-        expect(activity.key).to eq("job_alert_feedback.update")
+      it "triggers a RequestEvent of type 'feedback_provided'" do
+        expect { click_button I18n.t("buttons.submit") }
+          .to have_triggered_event(:feedback_provided)
+                .with_data(recaptcha_score: 0.9,
+                           comment: comment,
+                           subscription_id: subscription.id,
+                           feedback_type: "job_alert")
       end
 
       context "when recaptcha is invalid" do
         let(:verify_recaptcha) { false }
 
+        before { click_button I18n.t("buttons.submit") }
+
         context "and the form is valid" do
           scenario "redirects to invalid_recaptcha path" do
-            expect(page).to have_current_path(invalid_recaptcha_path(form_name: "Job alert feedback"))
+            expect(page).to have_current_path(invalid_recaptcha_path(form_name: "Jobseekers job alert feedback form"))
           end
         end
 
@@ -107,6 +135,8 @@ RSpec.describe "A jobseeker can give feedback on a job alert", recaptcha: true d
   end
 
   context "with the incorrect token" do
+    before { follow_the_link_in_the_job_alert_email }
+
     let(:token) { subscription.id }
 
     it "returns not found" do
@@ -115,6 +145,8 @@ RSpec.describe "A jobseeker can give feedback on a job alert", recaptcha: true d
   end
 
   context "with an old token" do
+    before { follow_the_link_in_the_job_alert_email }
+
     let(:token) { subscription.token }
 
     scenario "still returns 200" do
@@ -122,5 +154,25 @@ RSpec.describe "A jobseeker can give feedback on a job alert", recaptcha: true d
         expect(page.status_code).to eq(200)
       end
     end
+  end
+
+  def follow_the_link_in_the_job_alert_email
+    visit new_subscription_job_alert_feedback_url(
+      token,
+      params: { job_alert_feedback: { relevant_to_user: relevant_to_user,
+                                      job_alert_vacancy_ids: job_alert_vacancy_ids,
+                                      search_criteria: search_criteria } },
+    )
+  end
+
+  def follow_a_link_from_an_old_job_alert_email
+    # TODO: Remove this method after e.g. 30 days.
+
+    visit new_subscription_job_alert_feedback_url(
+      token,
+      params: { job_alert_feedback: { relevant_to_user: relevant_to_user,
+                                      vacancy_ids: job_alert_vacancy_ids,
+                                      search_criteria: search_criteria } },
+    )
   end
 end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1757

## Changes in this PR:

Update Job Alert Feedback controller/form to rely on new Feedback table

- And use trigger_feedback_provided_event to create Events. This method uses
feedback_params, resulting in a slightly unconventional feedback_params
method on JobAlertFeedbacksController, since this is the only type of
feedback that has more than one action (they can be updated as well as
created).

- Update Event#format_value to keep floats and integers rather than
transform them to strings. The idea here is to save deconverting them
after they are sent to BigQuery.

- This PR includes a single test for links in job alert emails already sent,
in order to avoid a bug such as that fixed in
https://github.com/DFE-Digital/teaching-vacancies/pull/2737.
