### PR TITLE
Gentle initial refactor of `Search::SearchBuilder`

### DIFF
--- a/app/components/jobseekers/search_results/job_alerts_link_component.rb
+++ b/app/components/jobseekers/search_results/job_alerts_link_component.rb
@@ -6,6 +6,6 @@ class Jobseekers::SearchResults::JobAlertsLinkComponent < ViewComponent::Base
   end
 
   def render?
-    @vacancies_search.any? && !ReadOnlyFeature.enabled? && @count.positive?
+    @vacancies_search.any_criteria_given? && !ReadOnlyFeature.enabled? && @count.positive?
   end
 end

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -56,7 +56,7 @@ class VacanciesController < ApplicationController
   end
 
   def valid_search?
-    @vacancies_search.any? && !smoke_test?
+    @vacancies_search.any_criteria_given? && !smoke_test?
   end
 
   def smoke_test?

--- a/app/services/search/alert_builder.rb
+++ b/app/services/search/alert_builder.rb
@@ -7,9 +7,6 @@ class Search::AlertBuilder < Search::SearchBuilder
     @params_hash = subscription_hash
     @keyword = @params_hash[:keyword] || build_subscription_keyword(@params_hash)
 
-    build_location_search
-    build_search_filters
-    build_search_replica
     call_search
   end
 
@@ -21,12 +18,12 @@ class Search::AlertBuilder < Search::SearchBuilder
 
   def search_params
     {
-      keyword: @keyword,
-      coordinates: @location_search.location_filter[:point_coordinates],
-      radius: @location_search.location_filter[:radius],
-      polygons: @location_search.polygon_boundaries,
-      filters: @search_filters,
-      replica: @search_replica,
+      keyword: keyword,
+      coordinates: location_search.location_filter[:point_coordinates],
+      radius: location_search.location_filter[:radius],
+      polygons: location_search.polygon_boundaries,
+      filters: search_filters,
+      replica: search_replica,
       hits_per_page: MAXIMUM_SUBSCRIPTION_RESULTS,
       typo_tolerance: false,
     }.compact

--- a/app/services/search/search_builder.rb
+++ b/app/services/search/search_builder.rb
@@ -2,9 +2,7 @@ class Search::SearchBuilder
   DEFAULT_HITS_PER_PAGE = 10
   DEFAULT_PAGE = 1
 
-  attr_reader :hits_per_page, :keyword, :location_search, :page, :params_hash,
-              :point_coordinates, :search_filters, :search_replica, :sort_by, :stats, :total_count, :vacancies,
-              :wider_search_suggestions
+  attr_reader :params_hash, :keyword, :page, :hits_per_page, :stats, :total_count, :vacancies
 
   def initialize(form_hash)
     @params_hash = form_hash
@@ -12,52 +10,57 @@ class Search::SearchBuilder
     @hits_per_page = (@params_hash[:per_page] || DEFAULT_HITS_PER_PAGE).to_i
     @page = (@params_hash[:page] || DEFAULT_PAGE).to_i
 
-    build_location_search
-    build_search_filters
-    build_search_replica
     call_search
-    build_suggestions if @vacancies.empty? && any?
   end
 
   def only_active_to_hash
-    @params_hash.merge(keyword: @keyword).delete_if do |k, v|
-      v.blank? || (k.eql?(:radius) && @params_hash[:location].blank?) || k.eql?(:jobs_sort) || k.eql?(:page)
-    end
+    @params_hash
+      .except(:jobs_sort, :page)
+      .reject { |k, v| v.blank? || (k == :radius && @params_hash[:location].blank?) }
   end
 
-  def any?
-    filters = only_active_to_hash.dup
-    filters.delete_if { |k, _| k.eql?(:radius) }
-    filters.any?
+  def any_criteria_given?
+    only_active_to_hash.except(:radius).any?
+  end
+
+  def location_search
+    @location_search ||= Search::LocationBuilder.new(@params_hash[:location], @params_hash[:radius], @params_hash[:buffer_radius])
+  end
+
+  def point_coordinates
+    @point_coordinates ||= location_search.location_filter[:point_coordinates]
+  end
+
+  def search_filters
+    @search_filters ||= Search::FiltersBuilder.new(@params_hash).filter_query
+  end
+
+  def search_replica
+    @search_replica ||= replica_builder.search_replica
+  end
+
+  def sort_by
+    @sort_by ||= replica_builder.sort_by
+  end
+
+  def wider_search_suggestions
+    return unless @vacancies.empty? && any_criteria_given?
+
+    @wider_search_suggestions ||= if point_coordinates.present?
+                                    Search::RadiusSuggestionsBuilder.new(@params_hash[:radius], search_params).radius_suggestions
+                                  elsif location_search.polygon_boundaries.present?
+                                    Search::BufferSuggestionsBuilder.new(@params_hash[:location], search_params).buffer_suggestions
+                                  end
   end
 
   private
 
-  def build_location_search
-    @location_search = Search::LocationBuilder.new(@params_hash[:location], @params_hash[:radius], @params_hash[:buffer_radius])
-    @point_coordinates = @location_search.location_filter[:point_coordinates]
-  end
-
-  def build_search_filters
-    @search_filters = Search::FiltersBuilder.new(@params_hash).filter_query
-  end
-
-  def build_search_replica
-    replica = Search::ReplicaBuilder.new(@params_hash[:jobs_sort], @keyword)
-    @search_replica = replica.search_replica
-    @sort_by = replica.sort_by
-  end
-
-  def build_suggestions
-    if @point_coordinates.present?
-      @wider_search_suggestions = Search::RadiusSuggestionsBuilder.new(@params_hash[:radius], search_params).radius_suggestions
-    elsif @location_search.polygon_boundaries.present?
-      @wider_search_suggestions = Search::BufferSuggestionsBuilder.new(@params_hash[:location], search_params).buffer_suggestions
-    end
+  def replica_builder
+    @replica_builder ||= Search::ReplicaBuilder.new(@params_hash[:jobs_sort], @keyword)
   end
 
   def call_search
-    search = if any?
+    search = if any_criteria_given?
                Search::AlgoliaSearchRequest.new(search_params)
              else
                Search::VacancyPaginator.new(page, hits_per_page, params_hash[:jobs_sort])
@@ -69,14 +72,14 @@ class Search::SearchBuilder
 
   def search_params
     {
-      keyword: @keyword,
-      coordinates: @location_search.location_filter[:point_coordinates],
-      radius: @location_search.location_filter[:radius],
-      polygons: @location_search.polygon_boundaries,
-      filters: @search_filters,
-      replica: @search_replica,
-      hits_per_page: @hits_per_page,
-      page: @page,
+      keyword: keyword,
+      coordinates: location_search.location_filter[:point_coordinates],
+      radius: location_search.location_filter[:radius],
+      polygons: location_search.polygon_boundaries,
+      filters: search_filters,
+      replica: search_replica,
+      hits_per_page: hits_per_page,
+      page: page,
     }.compact
   end
 end

--- a/app/views/vacancies/index.html.slim
+++ b/app/views/vacancies/index.html.slim
@@ -31,7 +31,7 @@
           - @vacancies.each do |vacancy|
             = render(Jobseekers::VacancySummaryComponent.new(vacancy: vacancy))
 
-      - elsif @vacancies_search.any?
+      - elsif @vacancies_search.any_criteria_given?
         .divider-bottom
           .govuk-heading-m = t("jobs.no_jobs.heading")
           p.govuk-body

--- a/spec/components/jobseekers/search_results/job_alerts_link_component_spec.rb
+++ b/spec/components/jobseekers/search_results/job_alerts_link_component_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Jobseekers::SearchResults::JobAlertsLinkComponent, type: :compone
 
   before do
     allow(vacancies_search).to receive(:only_active_to_hash).and_return(active_hash)
-    allow(vacancies_search).to receive(:any?).and_return(search_params_present?)
+    allow(vacancies_search).to receive(:any_criteria_given?).and_return(search_params_present?)
     allow(ReadOnlyFeature).to receive(:enabled?).and_return(read_only_enabled?)
   end
 

--- a/spec/services/search/search_builder_spec.rb
+++ b/spec/services/search/search_builder_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Search::SearchBuilder do
   let(:filter_query) { Search::FiltersBuilder.new(form_hash).filter_query }
   let!(:location_polygon) { create(:location_polygon, name: "london") }
 
-  describe "#build_location_search" do
+  describe "building location search" do
     let(:location) { location_polygon.name }
 
     context "when a polygon search is carried out" do
@@ -35,21 +35,21 @@ RSpec.describe Search::SearchBuilder do
     end
   end
 
-  describe "#build_search_filters" do
+  describe "building filters" do
     it "calls the filters builder" do
       expect(Search::FiltersBuilder).to receive(:new).with(form_hash).and_call_original
       subject
     end
   end
 
-  describe "#build_search_replica" do
+  describe "building replica" do
     it "calls the replica builder" do
       expect(Search::ReplicaBuilder).to receive(:new).with(form_hash[:jobs_sort], keyword).and_call_original
       subject
     end
   end
 
-  describe "#call_search" do
+  describe "performing search" do
     context "when there is any search criteria" do
       context "when location matches a location polygon" do
         let(:location) { location_polygon.name }
@@ -104,7 +104,7 @@ RSpec.describe Search::SearchBuilder do
     end
   end
 
-  describe "#build_suggestions" do
+  describe "wider suggestions" do
     context "when location matches a location polygon" do
       let(:location) { location_polygon.name }
 
@@ -127,7 +127,7 @@ RSpec.describe Search::SearchBuilder do
 
         it "does not call the buffer suggestions builder" do
           expect(Search::BufferSuggestionsBuilder).not_to receive(:new)
-          subject
+          subject.wider_search_suggestions
         end
       end
 
@@ -144,7 +144,7 @@ RSpec.describe Search::SearchBuilder do
 
         it "calls the buffer suggestions builder" do
           expect(Search::BufferSuggestionsBuilder).to receive(:new).with(location_polygon.name, search_params).and_call_original
-          subject
+          subject.wider_search_suggestions
         end
       end
     end
@@ -183,14 +183,14 @@ RSpec.describe Search::SearchBuilder do
 
         it "does not call the radius suggestions builder" do
           expect(Search::RadiusSuggestionsBuilder).not_to receive(:new)
-          subject
+          subject.wider_search_suggestions
         end
       end
 
       context "when vacancies is empty" do
         it "calls the radius suggestions builder" do
           expect(Search::RadiusSuggestionsBuilder).to receive(:new).with(radius, search_params).and_call_original
-          subject
+          subject.wider_search_suggestions
         end
       end
     end


### PR DESCRIPTION
- Move logic from being always run and assigned to instance variables
  on `initialize` to be in memoised instance methods (this means e.g.
  `wider_search_suggestions` is no longer auto-populated on requests
  where it is then never used, such as homepage facets)
- Rename `#any?` to `any_criteria_given?` to make its purpose more
  obvious