### PR TITLE
[TEVA 1992] component style name spacing - part 2

### DIFF
--- a/app/components/jobseekers/vacancy_details_component/vacancy_details_component.html.slim
+++ b/app/components/jobseekers/vacancy_details_component/vacancy_details_component.html.slim
@@ -47,6 +47,6 @@ section#job-details class="govuk-!-margin-bottom-5"
   - if @vacancy.documents.any?
     section#supporting-documents
       h3.govuk-heading-l.section-heading = t("jobs.supporting_documents")
-      ul.supporting-documents-component
+      ul.document-link-component
         - @vacancy.documents.in_groups_of(1, false).each do |row|
           = render Shared::DocumentLinkComponent.with_collection(row)

--- a/app/components/jobseekers/vacancy_details_component/vacancy_details_component.html.slim
+++ b/app/components/jobseekers/vacancy_details_component/vacancy_details_component.html.slim
@@ -47,6 +47,6 @@ section#job-details class="govuk-!-margin-bottom-5"
   - if @vacancy.documents.any?
     section#supporting-documents
       h3.govuk-heading-l.section-heading = t("jobs.supporting_documents")
-      ul.supporting-docs
+      ul.supporting-documents-component
         - @vacancy.documents.in_groups_of(1, false).each do |row|
           = render Shared::DocumentLinkComponent.with_collection(row)

--- a/app/components/shared/banner_link_component.rb
+++ b/app/components/shared/banner_link_component.rb
@@ -13,6 +13,6 @@ class Shared::BannerLinkComponent < ViewComponent::Base
   def call
     button_to link_text, link_path,
               method: link_method, params: params,
-              class: "banner-link icon icon--left icon--#{icon_class}", id: link_id, form_class: "banner-link-form"
+              class: "banner-link-component__button icon icon--left icon--#{icon_class}", id: link_id, form_class: "banner-link-component"
   end
 end

--- a/app/components/shared/banner_link_component/banner_link_component.scss
+++ b/app/components/shared/banner_link_component/banner_link_component.scss
@@ -20,16 +20,16 @@
     padding-left: govuk-spacing(6);
     text-align: left;
     text-decoration: none;
-  }
 
-  &:hover {
-    color: $govuk-link-hover-colour;
-  }
+    &:hover {
+      color: $govuk-link-hover-colour;
+    }
 
-  &:focus {
-    background-color: $govuk-focus-colour;
-    box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-focus-text-colour;
-    color: $govuk-focus-text-colour;
-    outline: 3px solid transparent;
+    &:focus {
+      background-color: $govuk-focus-colour;
+      box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-focus-text-colour;
+      color: $govuk-focus-text-colour;
+      outline: 3px solid transparent;
+    }
   }
 }

--- a/app/components/shared/banner_link_component/banner_link_component.scss
+++ b/app/components/shared/banner_link_component/banner_link_component.scss
@@ -1,9 +1,10 @@
-.banner-link-form {
+.banner-link-component {
   display: flex;
 
-  .banner-link {
+  .banner-link-component__button {
     @include govuk-font(19);
 
+    background-color: govuk-colour("light-grey");
     background-position: top 0 left 0;
     background-repeat: no-repeat;
     background-size: 20px 25px;
@@ -21,11 +22,11 @@
     text-decoration: none;
   }
 
-  .banner-link:hover {
+  &:hover {
     color: $govuk-link-hover-colour;
   }
 
-  .banner-link:focus {
+  &:focus {
     background-color: $govuk-focus-colour;
     box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-focus-text-colour;
     color: $govuk-focus-text-colour;

--- a/app/components/shared/banner_link_component/banner_link_component.scss
+++ b/app/components/shared/banner_link_component/banner_link_component.scss
@@ -1,7 +1,7 @@
 .banner-link-component {
   display: flex;
 
-  .banner-link-component__button {
+  &__button {
     @include govuk-font(19);
 
     background-color: govuk-colour("light-grey");

--- a/app/components/shared/dashboard_component/dashboard_component.html.slim
+++ b/app/components/shared/dashboard_component/dashboard_component.html.slim
@@ -1,4 +1,4 @@
-.dashboard__header
+.dashboard-component__header
   .govuk-width-container
     h1.govuk-heading-m class="govuk-!-margin-bottom-2"
       = heading

--- a/app/components/shared/dashboard_component/dashboard_component.scss
+++ b/app/components/shared/dashboard_component/dashboard_component.scss
@@ -1,4 +1,4 @@
-.dashboard {
+.dashboard-component {
   &__header {
     @include dashboard;
     background-color: govuk-colour('light-grey');

--- a/app/components/shared/document_link_component/document_link_component.html.slim
+++ b/app/components/shared/document_link_component/document_link_component.html.slim
@@ -1,3 +1,3 @@
 li.icon.icon--left.icon--document
-  = govuk_link_to(document.name, document.download_url, class: "document-link", target: "_blank")
+  = govuk_link_to(document.name, document.download_url, class: "supporting-documents-component__link", target: "_blank")
   = " #{number_with_precision(document.size / 1024.0 / 1024.0, precision: 2)} MB"

--- a/app/components/shared/document_link_component/document_link_component.html.slim
+++ b/app/components/shared/document_link_component/document_link_component.html.slim
@@ -1,3 +1,3 @@
 li.icon.icon--left.icon--document
-  = govuk_link_to(document.name, document.download_url, class: "supporting-documents-component__link", target: "_blank")
+  = govuk_link_to(document.name, document.download_url, class: "document-link-component__link", target: "_blank")
   = " #{number_with_precision(document.size / 1024.0 / 1024.0, precision: 2)} MB"

--- a/app/components/shared/document_link_component/document_link_component.scss
+++ b/app/components/shared/document_link_component/document_link_component.scss
@@ -1,4 +1,4 @@
-ul.supporting-docs {
+.supporting-documents-component {
   border: 1px solid $govuk-border-colour;
   list-style-type: none;
   margin-block-end: 1em;
@@ -11,7 +11,7 @@ ul.supporting-docs {
       margin-bottom: 0;
     }
 
-    .document-link {
+    &__link {
       text-decoration: none;
       word-wrap: break-word;
 

--- a/app/components/shared/document_link_component/document_link_component.scss
+++ b/app/components/shared/document_link_component/document_link_component.scss
@@ -1,4 +1,4 @@
-.supporting-documents-component {
+.document-link-component {
   border: 1px solid $govuk-border-colour;
   list-style-type: none;
   margin-block-end: 1em;

--- a/app/components/shared/navbar_component/navbar_component.html.slim
+++ b/app/components/shared/navbar_component/navbar_component.html.slim
@@ -1,5 +1,5 @@
 nav
-  ul.govuk-header__navigation id="navigation" aria-label="Top Level Navigation"
+  ul.govuk-header__navigation.navbar-component__navigation id="navigation" aria-label="Top Level Navigation"
     - if publisher_signed_in? && !ReadOnlyFeature.enabled?
       li class=active_link_class(organisation_path)
         = link_to t("nav.school_page_link"), organisation_path, class: "govuk-header__link"
@@ -11,21 +11,21 @@ nav
       li class=active_link_class(sessions_path)
         = button_to t("nav.sign_out"), sessions_path, method: :delete, class: "govuk-header__link"
     - else
-      li.govuk-header__navigation-item--left class=active_link_class(root_path)
+      li.navbar-component__navigation-item--left class=active_link_class(root_path)
         = link_to t("nav.find_job"), root_path, class: "govuk-header__link"
       - unless ReadOnlyFeature.enabled?
         - if JobseekerAccountsFeature.enabled?
           - if jobseeker_signed_in?
-            li.govuk-header__navigation-item--left class=active_link_class(jobseekers_saved_jobs_path)
+            li.navbar-component__navigation-item--left class=active_link_class(jobseekers_saved_jobs_path)
               = link_to t("footer.your_account"), jobseekers_saved_jobs_path, class: "govuk-header__link"
-            li.govuk-header__navigation-spacer aria-hidden="true" tab-index="-1"
-            li.govuk-header__navigation-item--right class=active_link_class(destroy_jobseeker_session_path)
+            li.navbar-component__navigation-spacer aria-hidden="true" tab-index="-1"
+            li.navbar-component__navigation-item--right class=active_link_class(destroy_jobseeker_session_path)
               = button_to t("nav.sign_out"), destroy_jobseeker_session_path, method: :delete, class: "govuk-header__link"
           - else
-            li.govuk-header__navigation-spacer aria-hidden="true" tab-index="-1"
-            li.govuk-header__navigation-item--right class=active_link_class(new_jobseeker_session_path)
+            li.navbar-component__navigation-spacer aria-hidden="true" tab-index="-1"
+            li.navbar-component__navigation-item--right class=active_link_class(new_jobseeker_session_path)
               = link_to t("buttons.sign_in"), new_jobseeker_session_path, class: "govuk-header__link"
-            li.govuk-header__navigation-item--right class=active_link_class(new_identifications_path)
+            li.navbar-component__navigation-item--right class=active_link_class(new_identifications_path)
               = link_to t("nav.for_schools"), new_identifications_path, class: "govuk-header__link"
         - else
           li class=active_link_class(new_identifications_path)

--- a/app/components/shared/navbar_component/navbar_component.scss
+++ b/app/components/shared/navbar_component/navbar_component.scss
@@ -1,39 +1,39 @@
-.govuk-header {
-  .govuk-header__navigation {
+.navbar-component {
+  .navbar-component__navigation {
     @include govuk-media-query($from: desktop) {
       display: flex;
 
-      .govuk-header__navigation-spacer {
+      &-spacer {
         flex-grow: 1;
       }
 
-      .govuk-header__navigation-item--left {
+      &-item--left {
         align-self: flex-start;
       }
 
-      .govuk-header__navigation-item--right {
+      &-item--right {
         align-self: flex-end;
       }
     }
 
     @include govuk-media-query($until: tablet) {
-      .govuk-header__navigation-spacer {
+      &-spacer {
         visibility: hidden;
       }
     }
+  }
 
-    .govuk-header__navigation-item {
-      input.govuk-header__link {
-        @include govuk-font(16, $weight: bold);
+  .govuk-header__navigation-item {
+    input.govuk-header__link {
+      @include govuk-font(16, $weight: bold);
 
-        background-image: none;
-        background-color: transparent;
-        border: none;
-        box-shadow: none;
-        color: govuk-colour('white');
-        cursor: pointer;
-        padding: 0;
-      }
+      background-image: none;
+      background-color: transparent;
+      border: none;
+      box-shadow: none;
+      color: govuk-colour('white');
+      cursor: pointer;
+      padding: 0;
     }
   }
 }

--- a/app/frontend/src/styles/application/dashboard.scss
+++ b/app/frontend/src/styles/application/dashboard.scss
@@ -7,7 +7,7 @@
   width: 100vw;
 
   @include govuk-media-query ($from: desktop) {
-    .dashboard__header .govuk-width-container {
+    .dashboard-component__header .govuk-width-container {
       position: relative;
 
       .moj-action-bar {

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -25,7 +25,7 @@ html.govuk-template.app-html-class lang="en"
       | document.body.className = ((document.body.className) ? document.body.className + " js-enabled" : "js-enabled");
     = render "shared/skip_links"
     = render "layouts/cookies_banner" unless controller_name == "cookies_preferences" || cookies_preference_set?
-    header.govuk-header data-module="govuk-header" role="banner"
+    header.govuk-header.navbar-component data-module="govuk-header" role="banner"
       .govuk-header__container.govuk-width-container
         .govuk-header__logo
           a.govuk-header__link.govuk-header__link--homepage href="https://www.gov.uk"

--- a/spec/components/shared/banner_link_component_spec.rb
+++ b/spec/components/shared/banner_link_component_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe Shared::BannerLinkComponent, type: :component do
 
     it "renders the banner link" do
       expect(rendered_component).to eq(
-        '<form class="banner-link-form" method="get" action="#test">'\
-        '<input class="banner-link icon icon--left icon--test" id="test-id" type="submit" value="Click this link!" />'\
+        '<form class="banner-link-component" method="get" action="#test">'\
+        '<input class="banner-link-component__button icon icon--left icon--test" id="test-id" type="submit" value="Click this link!" />'\
         "</form>",
       )
     end
@@ -34,8 +34,8 @@ RSpec.describe Shared::BannerLinkComponent, type: :component do
 
       it "renders the banner link" do
         expect(rendered_component).to eq(
-          '<form class="banner-link-form" method="get" action="#test">'\
-          '<input class="banner-link icon icon--left icon--test" id="test-id" type="submit" value="Click this link!" />'\
+          '<form class="banner-link-component" method="get" action="#test">'\
+          '<input class="banner-link-component__button icon icon--left icon--test" id="test-id" type="submit" value="Click this link!" />'\
           '<input type="hidden" name="some_param" value="test" />'\
           "</form>",
         )
@@ -48,8 +48,8 @@ RSpec.describe Shared::BannerLinkComponent, type: :component do
 
     it "renders the banner link" do
       expect(rendered_component).to eq(
-        '<form class="banner-link-form" method="post" action="#test">'\
-        '<input class="banner-link icon icon--left icon--test" id="test-id" type="submit" value="Click this link!" />'\
+        '<form class="banner-link-component" method="post" action="#test">'\
+        '<input class="banner-link-component__button icon icon--left icon--test" id="test-id" type="submit" value="Click this link!" />'\
         "</form>",
       )
     end


### PR DESCRIPTION
to mitigate a massive PR, this is the second part of this task for shared components mentioned in commits - will squash before merge

https://dfedigital.atlassian.net/browse/TEVA-1992

## Changes in this PR:

- Readme has been updated detailing whats happening here
- basically all shared component (as priority) have a parent class clearly stating what is is and that is is a component. all internal styles are contained within that
- this helps knowing what a class this there for and also mitigates styles bleeding out to things they dont relate to