### PR TITLE
[TEVA-2014] no longer have (required) on forms

### DIFF
--- a/app/views/publishers/organisations/managed_organisations/show.html.slim
+++ b/app/views/publishers/organisations/managed_organisations/show.html.slim
@@ -11,7 +11,7 @@
       = f.govuk_error_summary
 
       = f.govuk_check_boxes_fieldset :managed_organisations,
-        legend: { text: t(".labels.select_organisations_html") },
+        legend: { text: t(".labels.select_organisations") },
         hint: { text: t(".hints.select_organisations") },
         classes: "checkbox-label__bold govuk-!-margin-top-5" do
 

--- a/app/views/publishers/vacancies/_expires_at_field.html.slim
+++ b/app/views/publishers/vacancies/_expires_at_field.html.slim
@@ -1,7 +1,7 @@
 .govuk-form-group class=(f.object.errors[:expires_at].present? ? "govuk-form-group--error" : "")
   fieldset.govuk-fieldset aria-describedby="##{f.object_name}-expiry-time-hint" id=(f.object.errors[:expires_at].present? ? "##{f.object_name}-expity-time-field-error" : "##{f.object_name}-expity-time-field")
     legend.govuk-fieldset__legend.govuk-fieldset__legend--s
-      h1.govuk-fieldset__heading = t("helpers.legend.publishers_job_listing_important_dates_form.expires_at_html")
+      h1.govuk-fieldset__heading = t("helpers.legend.publishers_job_listing_important_dates_form.expires_at")
     span.govuk-hint id="#{f.object_name}-expiry-time-hint"
       = t("helpers.hint.publishers_job_listing_important_dates_form.expires_at")
     - f.object.errors[:expires_at]&.each do |error|

--- a/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
+++ b/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
@@ -27,7 +27,7 @@
       = f.govuk_phone_field :contact_number, label: { size: "s" }, width: "one-third"
 
       = f.govuk_text_area :school_visits,
-        label: { text: t("helpers.label.publishers_job_listing_applying_for_the_job_form.#{school_or_trust_visits(@vacancy.parent_organisation)}"), size: "s" },
+        label: { text: t("helpers.label.publishers_job_listing_applying_for_the_job_form.#{school_or_trust_visits(@vacancy.parent_organisation)}_html"), size: "s" },
         hint: { text: vacancy_school_visits_hint(@vacancy) },
         rows: 10
 

--- a/app/views/publishers/vacancies/build/important_dates.html.slim
+++ b/app/views/publishers/vacancies/build/important_dates.html.slim
@@ -17,7 +17,7 @@
       - if @form.disable_editing_publish_on?
         #publish_on
           legend.govuk-fieldset__legend.govuk-fieldset__legend--s
-            h1.govuk-fieldset__heading = t("helpers.legend.publishers_job_listing_important_dates_form.publish_on_html")
+            h1.govuk-fieldset__heading = t("helpers.legend.publishers_job_listing_important_dates_form.publish_on")
           p = format_date @vacancy.publish_on
         br
         .display-none

--- a/app/views/publishers/vacancies/build/job_details.html.slim
+++ b/app/views/publishers/vacancies/build/job_details.html.slim
@@ -27,7 +27,7 @@
 
       = f.govuk_collection_radio_buttons :suitable_for_nqt, %w[yes no], :to_s, :capitalize
 
-      = f.govuk_fieldset legend: { text: t("helpers.legend.publishers_job_listing_job_details_form.subjects") } do
+      = f.govuk_fieldset legend: { text: t("helpers.legend.publishers_job_listing_job_details_form.subjects_html") } do
 
         label for="publishers-job-listing-job-details-form-subject-search"
           span.govuk-visually-hidden | Subject filter

--- a/app/views/publishers/vacancies/build/job_summary.html.slim
+++ b/app/views/publishers/vacancies/build/job_summary.html.slim
@@ -17,7 +17,7 @@
       = f.govuk_text_area :job_summary, label: { size: "s" }, rows: 10, required: true
 
       = f.govuk_text_area :about_school,
-        label: { text: t("helpers.label.publishers_job_listing_job_summary_form.about_organisation_html", organisation: vacancy_about_school_label_organisation(@vacancy)), size: "s" },
+        label: { text: t("helpers.label.publishers_job_listing_job_summary_form.about_organisation", organisation: vacancy_about_school_label_organisation(@vacancy)), size: "s" },
         hint: { text: vacancy_about_school_hint_text(@vacancy) },
         value: vacancy_about_school_value(@vacancy),
         rows: 10,

--- a/app/views/publishers/vacancies/build/schools.html.slim
+++ b/app/views/publishers/vacancies/build/schools.html.slim
@@ -14,7 +14,7 @@
 
       = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f
 
-      = f.govuk_fieldset legend: { text: t("helpers.legend.publishers_job_listing_schools_form.organisation_ids_html") } do
+      = f.govuk_fieldset legend: { text: t("helpers.legend.publishers_job_listing_schools_form.organisation_ids") } do
         = render Shared::SearchableCollectionComponent.new(form: f,
           threshold: 10,
           attribute_name: :organisation_ids,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -156,6 +156,17 @@ en:
       heading_html: "%{email} <span class='govuk-!-font-weight-regular'>- %{organisation}</span>"
     view_more_or_change: View more or change
 
+  job_alert_feedbacks:
+    edit:
+      change_alert_link: Change your job alert criteria
+      change_alert_text: If your job alerts are not relevant, you can change your alert criteria by updating keywords, location, role, education phase or working pattern. %{link}
+      heading: Further feedback
+      title: Job alert feedback
+    new:
+      success: Thank you for your feedback on your job alert
+    update:
+      success: Your further feedback on job alerts has been sent to the team
+      
   nav:
     find_job: Find a teaching job
     for_schools: For schools

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -181,8 +181,8 @@ en:
         comment: Do you have any suggestions on how we could improve the service?
 
       jobseeker:
-        email_html: Email address (<span class='text-red'>Required</span>)
-        password_html: Password (<span class='text-red'>Required</span>)
+        email: Email address
+        password: Password
 
       jobseekers_job_alert_feedback_form:
         comment: Would you like to add any further comments about the relevancy of the job alerts you have received?
@@ -273,21 +273,21 @@ en:
         website: '%{organisation_type} website'
 
       publishers_job_listing_applying_for_the_job_form:
-        application_link: Link to online application
+        application_link_html: Link to online application <span class='govuk-!-font-weight-regular'>(optional)</span>
         apply_through_teaching_vacancies_options:
           "no": "Use another service or organisation"
           "yes": "Apply through Teaching Vacancies"
-        contact_email_html: Contact email (<span class='text-red'>Required</span>)
-        contact_number: Contact phone number
-        how_to_apply: How to apply
+        contact_email: Contact email
+        contact_number_html: Contact phone number <span class='govuk-!-font-weight-regular'>(optional)</span>
+        how_to_apply_html: How to apply <span class='govuk-!-font-weight-regular'>(optional)</span>
         personal_statement_guidance: Help candidates to write their personal statement
-        school_visits: School visits
-        trust_visits: Trust visits
+        school_visits_html: School visits <span class='govuk-!-font-weight-regular'>(optional)</span>
+        trust_visits_html: Trust visits <span class='govuk-!-font-weight-regular'>(optional)</span>
       publishers_job_listing_copy_vacancy_form:
         expires_at_hh: Hour
         expires_at_meridiem: am or pm
         expires_at_mm: Minute
-        job_title_html: Job title (<span class='text-red'>Required</span>)
+        job_title: Job title
       publishers_job_listing_documents_form:
         documents: Upload files
       publishers_job_listing_important_dates_form:
@@ -304,18 +304,18 @@ en:
           leadership: Leadership
           sen_specialist: SEN specialist
           nqt_suitable: Suitable for NQTs
-        job_title_html: Job title (<span class='text-red'>Required</span>)
+        job_title: Job title
         suitable_for_nqt_html: Is this job suitable for NQTs? (<span class='text-red'>Required</span>)
         working_patterns_options:
           full_time: Full-time
           part_time: Part-time
           job_share: Job share
       publishers_job_listing_job_summary_form:
-        about_organisation_html: About %{organisation} (<span class='text-red'>Required</span>)
-        job_summary_html: Job summary (<span class='text-red'>Required</span>)
+        about_organisation: About %{organisation}
+        job_summary: Job summary
       publishers_job_listing_pay_package_form:
-        benefits: Employee benefits
-        salary_html: Salary (<span class='text-red'>Required</span>)
+        benefits_html: Employee benefits <span class='govuk-!-font-weight-regular'>(optional)</span>
+        salary: Salary
 
       publishers_vacancies_vacancy_publisher_feedback_form:
         comment_html: How could we improve this service? (<span class='text-red'>Required</span>)
@@ -366,28 +366,28 @@ en:
         address_html: Your address (<span class='text-red'>Required</span>)
 
       publishers_job_listing_applying_for_the_job_form:
-        apply_through_teaching_vacancies_html: How would you like candidates to apply? (<span class='text-red'>Required</span>)
+        apply_through_teaching_vacancies: How would you like candidates to apply?
       publishers_job_listing_copy_vacancy_form:
-        expires_on_html: Date application is due (<span class='text-red'>Required</span>)
-        publish_on_html: Date job will be listed (<span class='text-red'>Required</span>)
+        expires_on: Date application is due
+        publish_on: Date job will be listed
         starts_on: Date job starts
       publishers_job_listing_important_dates_form:
-        expires_on_html: Date application is due (<span class='text-red'>Required</span>)
-        expires_at_html: Time application is due (<span class='text-red'>Required</span>)
-        publish_on_html: Date job will be listed (<span class='text-red'>Required</span>)
+        expires_on: Date application is due
+        expires_at: Time application is due
+        publish_on: Date job will be listed
         starts_asap: As soon as possible
-        starts_on: Date job starts
+        starts_on_html: Date job starts <span class='govuk-!-font-weight-regular'>(optional)</span>
       publishers_job_listing_job_details_form:
-        contract_type_html: Contract type (<span class='text-red'>Required</span>)
-        job_roles: Job role
-        suitable_for_nqt_html: Is this job suitable for NQTs? (<span class='text-red'>Required</span>)
-        subjects: Subject(s)
-        working_patterns_html: Working patterns (<span class='text-red'>Required</span>)
+        contract_type: Contract type
+        job_roles_html: Job role <span class='govuk-!-font-weight-regular'>(optional)</span>
+        suitable_for_nqt: Is this job suitable for NQTs?
+        subjects_html: Subject(s) <span class='govuk-!-font-weight-regular'>(optional)</span>
+        working_patterns: Working patterns
       publishers_job_listing_job_location_form:
-        job_location_html: Where will the job be based? (<span class='text-red'>Required</span>)
+        job_location: Where will the job be based?
       publishers_job_listing_schools_form:
-        organisation_ids_html: In which schools will the job be based? (<span class='text-red'>Required</span>)
-        organisation_id_html: In which school will the job be based? (<span class='text-red'>Required</span>)
+        organisation_ids: In which schools will the job be based?
+        organisation_id: In which school will the job be based?
 
       publishers_vacancies_vacancy_publisher_feedback_form:
         user_participation_response_html: >-

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -30,8 +30,8 @@ en:
             select_organisations: You can change this later from your dashboard using the filters
           labels:
             select_organisations: Select which schools' job listings you would like to see
-            select_organisations_html: >-
-              Select which schools' job listings you would like to view (<span class='text-red'>Required</span>)
+            select_organisations: >-
+              Select which schools' job listings you would like to view
           options:
             all: All schools and trust head office
             all_schools: All schools

--- a/spec/system/hiring_staff_can_edit_a_published_vacancy_as_a_school_spec.rb
+++ b/spec/system/hiring_staff_can_edit_a_published_vacancy_as_a_school_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe "Hiring staff can edit a vacancy" do
         edit_date("expires_on", nil)
 
         within_row_for(element: "legend",
-                       text: strip_tags(I18n.t("helpers.legend.publishers_job_listing_important_dates_form.expires_on_html"))) do
+                       text: strip_tags(I18n.t("helpers.legend.publishers_job_listing_important_dates_form.expires_on"))) do
           expect(page).to have_content(I18n.t("important_dates_errors.expires_on.blank"))
         end
       end
@@ -215,7 +215,7 @@ RSpec.describe "Hiring staff can edit a vacancy" do
         click_on I18n.t("buttons.update_job")
 
         within_row_for(element: "legend",
-                       text: strip_tags(I18n.t("helpers.legend.publishers_job_listing_important_dates_form.expires_at_html"))) do
+                       text: strip_tags(I18n.t("helpers.legend.publishers_job_listing_important_dates_form.expires_at"))) do
           expect(page).to have_content(I18n.t("important_dates_errors.expires_at.wrong_format"))
         end
       end

--- a/spec/system/hiring_staff_can_publish_a_vacancy_as_a_school_spec.rb
+++ b/spec/system/hiring_staff_can_publish_a_vacancy_as_a_school_spec.rb
@@ -164,17 +164,17 @@ RSpec.describe "Creating a vacancy" do
         end
 
         within_row_for(element: "legend",
-                       text: strip_tags(I18n.t("helpers.legend.publishers_job_listing_important_dates_form.publish_on_html"))) do
+                       text: strip_tags(I18n.t("helpers.legend.publishers_job_listing_important_dates_form.publish_on"))) do
           expect(page).to have_content(I18n.t("important_dates_errors.publish_on.blank"))
         end
 
         within_row_for(element: "legend",
-                       text: strip_tags(I18n.t("helpers.legend.publishers_job_listing_important_dates_form.expires_on_html"))) do
+                       text: strip_tags(I18n.t("helpers.legend.publishers_job_listing_important_dates_form.expires_on"))) do
           expect(page).to have_content(I18n.t("important_dates_errors.expires_on.blank"))
         end
 
         within_row_for(element: "legend",
-                       text: strip_tags(I18n.t("helpers.legend.publishers_job_listing_important_dates_form.expires_at_html"))) do
+                       text: strip_tags(I18n.t("helpers.legend.publishers_job_listing_important_dates_form.expires_at"))) do
           expect(page).to have_content(I18n.t("activerecord.errors.models.vacancy.attributes.expires_at.blank"))
         end
       end
@@ -350,7 +350,7 @@ RSpec.describe "Creating a vacancy" do
           expect(page).to have_content("There is a problem")
         end
 
-        within_row_for(text: strip_tags(I18n.t("helpers.label.publishers_job_listing_applying_for_the_job_form.contact_email_html"))) do
+        within_row_for(text: strip_tags(I18n.t("helpers.label.publishers_job_listing_applying_for_the_job_form.contact_email"))) do
           expect(page).to have_content(I18n.t("applying_for_the_job_errors.contact_email.blank"))
         end
       end
@@ -922,7 +922,7 @@ RSpec.describe "Creating a vacancy" do
         end
 
         within_row_for(element: "legend",
-                       text: strip_tags(I18n.t("helpers.legend.publishers_job_listing_important_dates_form.expires_on_html"))) do
+                       text: strip_tags(I18n.t("helpers.legend.publishers_job_listing_important_dates_form.expires_on"))) do
           expect(page).to have_content(I18n.t("important_dates_errors.expires_on.before_today"))
         end
 

--- a/spec/system/jobseekers_can_view_a_vacancy_spec.rb
+++ b/spec/system/jobseekers_can_view_a_vacancy_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "Viewing a single published vacancy" do
 
     visit job_path(vacancy)
     expect(page).to have_content(vacancy.job_title)
-    expect(page).to_not have_content(I18n.t("jobs.job_roles"))
+    expect(page).to_not have_content(I18n.t("jobs.job_roles_html"))
   end
 
   context "A user viewing a vacancy" do
@@ -124,7 +124,7 @@ RSpec.describe "Viewing a single published vacancy" do
       expect(page).to_not have_content(I18n.t("jobs.education"))
       expect(page).to_not have_content(I18n.t("jobs.qualifications"))
       expect(page).to_not have_content(I18n.t("jobs.experience"))
-      expect(page).to_not have_content(I18n.t("jobs.benefits"))
+      expect(page).to_not have_content(I18n.t("jobs.benefits_html"))
     end
 
     context "without supporting documents attached but candidate spec" do


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-2014

basically inverts the forms no longer state (required) but indicate (optional) instead. this brings teacher vacancies into line with other DFE services

this only caters for live forms, a separate PR will address the jobseeker application form

![Screenshot 2021-02-10 at 10 47 30](https://user-images.githubusercontent.com/1792451/107513315-f63b8500-6b9f-11eb-8fa2-4345874f96f4.png)

