### PR TITLE
Get rid of "stats" in `SearchBuilder`

### DIFF
--- a/app/services/search/algolia_search_request.rb
+++ b/app/services/search/algolia_search_request.rb
@@ -1,5 +1,5 @@
 class Search::AlgoliaSearchRequest
-  attr_reader :vacancies, :stats, :total_count
+  attr_reader :vacancies, :total_count
 
   def initialize(search_params)
     @keyword = search_params[:keyword]
@@ -16,23 +16,9 @@ class Search::AlgoliaSearchRequest
     return if @vacancies.nil?
 
     @total_count = vacancies.raw_answer["nbHits"]
-    @stats = build_stats(
-      vacancies.raw_answer["page"],
-      vacancies.raw_answer["nbPages"],
-      vacancies.raw_answer["hitsPerPage"],
-      vacancies.raw_answer["nbHits"],
-    )
   end
 
   private
-
-  def build_stats(page, pages, results_per_page, total_results)
-    return [0, 0, 0] unless total_results.positive?
-
-    first_number = page * results_per_page + 1
-    last_number = page + 1 == pages ? total_results : (page + 1) * results_per_page
-    [first_number, last_number, total_results]
-  end
 
   def search
     Vacancy.includes(organisation_vacancies: :organisation).search(@keyword, search_arguments)

--- a/app/services/search/buffer_suggestions_builder.rb
+++ b/app/services/search/buffer_suggestions_builder.rb
@@ -20,7 +20,7 @@ class Search::BufferSuggestionsBuilder
       locations.each do |location|
         location.buffers[distance.to_s].each { |buffer| buffered_polygons.push(buffer) }
       end
-      [distance.to_s, Search::AlgoliaSearchRequest.new(search_params.merge(polygons: buffered_polygons)).stats.last]
+      [distance.to_s, Search::AlgoliaSearchRequest.new(search_params.merge(polygons: buffered_polygons)).total_count]
     end
 
     buffer_vacancy_count&.uniq(&:last)&.reject { |array| array.last.zero? }

--- a/app/services/search/radius_suggestions_builder.rb
+++ b/app/services/search/radius_suggestions_builder.rb
@@ -20,7 +20,7 @@ class Search::RadiusSuggestionsBuilder
       unless wider_radius.nil?
         [
           wider_radius,
-          Search::AlgoliaSearchRequest.new(search_params.merge(radius: convert_miles_to_metres(wider_radius))).stats.last,
+          Search::AlgoliaSearchRequest.new(search_params.merge(radius: convert_miles_to_metres(wider_radius))).total_count,
         ]
       end
     }&.reject(&:nil?)

--- a/app/services/search/search_builder.rb
+++ b/app/services/search/search_builder.rb
@@ -2,7 +2,7 @@ class Search::SearchBuilder
   DEFAULT_HITS_PER_PAGE = 10
   DEFAULT_PAGE = 1
 
-  attr_reader :params_hash, :keyword, :page, :hits_per_page, :stats, :total_count, :vacancies
+  attr_reader :params_hash, :keyword, :page, :hits_per_page, :total_count, :vacancies
 
   def initialize(form_hash)
     @params_hash = form_hash
@@ -53,6 +53,18 @@ class Search::SearchBuilder
                                   end
   end
 
+  def out_of_bounds?
+    page_from > total_count
+  end
+
+  def page_from
+    (page - 1) * hits_per_page + 1
+  end
+
+  def page_to
+    [(page * hits_per_page), total_count].min
+  end
+
   private
 
   def replica_builder
@@ -66,7 +78,6 @@ class Search::SearchBuilder
                Search::VacancyPaginator.new(page, hits_per_page, params_hash[:jobs_sort])
              end
     @vacancies = search.vacancies || []
-    @stats = search.stats || []
     @total_count = search.total_count
   end
 

--- a/app/services/search/vacancy_paginator.rb
+++ b/app/services/search/vacancy_paginator.rb
@@ -6,7 +6,7 @@ class Search::VacancyPaginator
     expires_at_asc: "expires_at ASC",
   }.freeze
 
-  attr_reader :stats, :total_count, :vacancies
+  attr_reader :total_count, :vacancies
 
   def initialize(page, hits_per_page, jobs_sort)
     @page = page
@@ -14,7 +14,6 @@ class Search::VacancyPaginator
     @jobs_sort = jobs_sort
     @order = build_order
     @vacancies = Vacancy.live.order(@order).page(@page).per(@hits_per_page)
-    @stats = build_stats
     @total_count = vacancies.total_count
   end
 
@@ -22,13 +21,5 @@ class Search::VacancyPaginator
 
   def build_order
     @jobs_sort.present? && ORDER_OPTIONS.key?(@jobs_sort.to_sym) ? ORDER_OPTIONS[@jobs_sort.to_sym] : DEFAULT_ORDER
-  end
-
-  def build_stats
-    return [0, 0, 0] if vacancies.total_count.zero? || vacancies.out_of_range?
-
-    first_number = (vacancies.current_page - 1) * @hits_per_page + 1
-    last_number = (vacancies.current_page - 1) * @hits_per_page + vacancies.count
-    [first_number, last_number, vacancies.total_count]
   end
 end

--- a/app/services/vacancy_facets.rb
+++ b/app/services/vacancy_facets.rb
@@ -52,6 +52,6 @@ class VacancyFacets
     # Disable this very expensive operation unless caching is enabled (e.g. in dev, system tests)
     return 0 unless Rails.application.config.action_controller.perform_caching
 
-    Search::SearchBuilder.new(query).stats.last || 0
+    Search::SearchBuilder.new(query).total_count || 0
   end
 end

--- a/app/views/vacancies/index.html.slim
+++ b/app/views/vacancies/index.html.slim
@@ -20,11 +20,12 @@
     = render(Jobseekers::SearchResults::SearchVisualizerComponent.new(vacancies_search: @vacancies_search, render: @display_map))
     section.sort-results.sortable-links role="search" aria-label="Sort vacancies"
       = render partial: "sorting_options", locals: { search_criteria: @vacancies_search.only_active_to_hash, sort: @vacancies_search.sort_by }
-      .govuk-body#vacancies-stats-top aria-label="Number of results"
-        - if @vacancies_search.stats[2] <= @vacancies_search.hits_per_page
-          = t("jobs.number_of_results_one_page_html", count: @vacancies_search.stats[2])
-        - else
-          = t("jobs.number_of_results_html", first: @vacancies_search.stats[0], last: @vacancies_search.stats[1], count: @vacancies_search.stats[2])
+      - unless @vacancies_search.out_of_bounds?
+        .govuk-body#vacancies-stats-top aria-label="Number of results"
+          - if @vacancies_search.total_count <= @vacancies_search.hits_per_page
+            = t("jobs.number_of_results_one_page_html", count: @vacancies_search.total_count)
+          - else
+            = t("jobs.number_of_results_html", first: @vacancies_search.page_from, last: @vacancies_search.page_to, count: @vacancies_search.total_count)
     #search-results aria-label="Search results"
       - if @vacancies.any?
         ul.vacancies role="list"

--- a/spec/services/search/algolia_search_request_spec.rb
+++ b/spec/services/search/algolia_search_request_spec.rb
@@ -3,58 +3,36 @@ require "rails_helper"
 RSpec.describe Search::AlgoliaSearchRequest do
   let(:subject) { described_class.new(search_params) }
 
-  describe "#build_stats" do
-    let(:search_params) { {} }
-    let(:page) { 0 }
-    let(:pages) { 6 }
-    let(:results_per_page) { 10 }
-    let(:total_results) { 57 }
+  let(:vacancies) { double("vacancies") }
 
-    it "returns the correct array" do
-      expect(subject.send(:build_stats, page, pages, results_per_page, total_results)).to eq([1, 10, 57])
-    end
+  let(:search_params) do
+    {
+      keyword: "maths",
+      coordinates: Geocoder::DEFAULT_STUB_COORDINATES,
+      radius: convert_miles_to_metres(10),
+      hits_per_page: 10,
+      page: 1,
+    }
+  end
 
-    context "when there are no results" do
-      let(:total_results) { 0 }
+  let(:arguments_to_algolia) do
+    {
+      aroundLatLng: Geocoder::DEFAULT_STUB_COORDINATES,
+      aroundRadius: convert_miles_to_metres(10),
+      hitsPerPage: 10,
+      page: 1,
+    }
+  end
 
-      it "returns the correct array" do
-        expect(subject.send(:build_stats, page, pages, results_per_page, total_results)).to eq([0, 0, 0])
-      end
-    end
+  before { mock_algolia_search(vacancies, 42, "maths", arguments_to_algolia) }
 
-    context "when on the last page of results" do
-      let(:page) { 5 }
-
-      it "returns the correct array" do
-        expect(subject.send(:build_stats, page, pages, results_per_page, total_results)).to eq([51, 57, 57])
-      end
+  describe "#total_count" do
+    it "returns the total count from Algolia" do
+      expect(subject.total_count).to eq(42)
     end
   end
 
   describe "#search" do
-    let(:vacancies) { double("vacancies") }
-
-    let(:search_params) do
-      {
-        keyword: "maths",
-        coordinates: Geocoder::DEFAULT_STUB_COORDINATES,
-        radius: convert_miles_to_metres(10),
-        hits_per_page: 10,
-        page: 1,
-      }
-    end
-
-    let(:arguments_to_algolia) do
-      {
-        aroundLatLng: Geocoder::DEFAULT_STUB_COORDINATES,
-        aroundRadius: convert_miles_to_metres(10),
-        hitsPerPage: 10,
-        page: 1,
-      }
-    end
-
-    before { mock_algolia_search(vacancies, 1, "maths", arguments_to_algolia) }
-
     it "carries out search with the correct parameters" do
       expect(subject.vacancies).to eq(vacancies)
     end

--- a/spec/services/search/search_builder_spec.rb
+++ b/spec/services/search/search_builder_spec.rb
@@ -23,6 +23,35 @@ RSpec.describe Search::SearchBuilder do
   let(:filter_query) { Search::FiltersBuilder.new(form_hash).filter_query }
   let!(:location_polygon) { create(:location_polygon, name: "london") }
 
+  describe "pagination helpers" do
+    let(:hits_per_page) { 10 }
+    let(:page) { 3 }
+
+    before do
+      mock_algolia_search(double(raw_answer: nil), 50, keyword, anything)
+    end
+
+    it "returns the expected bounds" do
+      expect(subject).not_to be_out_of_bounds
+
+      expect(subject.page_from).to eq(21)
+      expect(subject.page_to).to eq(30)
+    end
+
+    context "when out of bounds" do
+      before do
+        mock_algolia_search(double(raw_answer: nil), 20, keyword, anything)
+      end
+
+      it "returns the expected bounds" do
+        expect(subject).to be_out_of_bounds
+
+        expect(subject.page_from).to eq(21)
+        expect(subject.page_to).to eq(20)
+      end
+    end
+  end
+
   describe "building location search" do
     let(:location) { location_polygon.name }
 

--- a/spec/services/search/vacancy_paginator_spec.rb
+++ b/spec/services/search/vacancy_paginator_spec.rb
@@ -31,10 +31,10 @@ RSpec.describe Search::VacancyPaginator do
     end
   end
 
-  describe "#build_stats" do
+  describe "#total_count" do
     context "when there are no vacancies" do
-      it "builds the correct results stats" do
-        expect(subject.stats).to eq([0, 0, 0])
+      it "returns 0" do
+        expect(subject.total_count).to be_zero
       end
     end
 
@@ -42,26 +42,8 @@ RSpec.describe Search::VacancyPaginator do
       let!(:vacancies) { create_list(:vacancy, 5, :complete) }
       let!(:draft_vacancies) { create_list(:vacancy, 2, :draft) }
 
-      context "when the page is the first page" do
-        it "builds the correct results stats" do
-          expect(subject.stats).to eq([1, 2, 5])
-        end
-      end
-
-      context "when the page is the last page" do
-        let(:page) { 3 }
-
-        it "build the correct results stats" do
-          expect(subject.stats).to eq([5, 5, 5])
-        end
-      end
-
-      context "when the page is out of range" do
-        let(:page) { 4 }
-
-        it "build the correct results stats" do
-          expect(subject.stats).to eq([0, 0, 0])
-        end
+      it "returns the correct count" do
+        expect(subject.total_count).to eq(5)
       end
     end
   end

--- a/spec/services/vacancy_facets_spec.rb
+++ b/spec/services/vacancy_facets_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe VacancyFacets do
   subject { described_class.new }
 
-  let(:search_builder) { instance_double(Search::SearchBuilder, stats: [42]) }
+  let(:search_builder) { instance_double(Search::SearchBuilder, total_count: 42) }
 
   before do
     allow(Rails.application.config.action_controller).to receive(:perform_caching).and_return(true)


### PR DESCRIPTION
Instead of passing around and accessing an array of values, introduce
`SearchBuilder#page_from` and `#page_to` to return the number of the
first and last result shown on this page respectively.

These can be calculated trivially from the total count of results, the
current page, and the number of items shown per page, so don't need to
be calculated separately based on whether we search Algolia or the DB.