### PR TITLE
More refactoring of `SearchBuilder`

### DIFF
--- a/app/services/search/alert_builder.rb
+++ b/app/services/search/alert_builder.rb
@@ -1,31 +1,21 @@
 class Search::AlertBuilder < Search::SearchBuilder
-  attr_reader :vacancies
-
   MAXIMUM_SUBSCRIPTION_RESULTS = 500
 
-  def initialize(subscription_hash)
-    @params_hash = subscription_hash
-    @keyword = @params_hash[:keyword] || build_subscription_keyword(@params_hash)
-
-    call_search
+  def initialize(params)
+    super(params)
+    @keyword ||= build_subscription_keyword
   end
 
   private
 
-  def build_subscription_keyword(subscription_hash)
-    [subscription_hash[:subject], subscription_hash[:job_title]].reject(&:blank?).join(" ")
+  def build_subscription_keyword
+    [params[:subject], params[:job_title]].reject(&:blank?).join(" ")
   end
 
   def search_params
-    {
-      keyword: keyword,
-      coordinates: location_search.location_filter[:point_coordinates],
-      radius: location_search.location_filter[:radius],
-      polygons: location_search.polygon_boundaries,
-      filters: search_filters,
-      replica: search_replica,
+    super.except(:page).merge(
       hits_per_page: MAXIMUM_SUBSCRIPTION_RESULTS,
       typo_tolerance: false,
-    }.compact
+    )
   end
 end

--- a/app/views/vacancies/index.html.slim
+++ b/app/views/vacancies/index.html.slim
@@ -50,11 +50,11 @@
               - @vacancies_search.wider_search_suggestions.each do |wider_radius|
                 - if @vacancies_search.location_search.polygon_boundaries.present?
                   li = t(".wider_search_suggestions.suggestion_html",
-                                                        search_link: govuk_link_to(t(".wider_search_suggestions.radius_distance", radius: wider_radius.first), jobs_path(@vacancies_search.params_hash.merge(buffer_radius: wider_radius.first)), class: "wider-radius-gtm"),
+                                                        search_link: govuk_link_to(t(".wider_search_suggestions.radius_distance", radius: wider_radius.first), jobs_path(@vacancies_search.params.merge(buffer_radius: wider_radius.first)), class: "wider-radius-gtm"),
                                                         count: t(".wider_search_suggestions.results", count: wider_radius.last))
                 - else
                   li = t(".wider_search_suggestions.suggestion_html",
-                                                        search_link: govuk_link_to(t(".wider_search_suggestions.radius_distance", radius: wider_radius.first), jobs_path(@vacancies_search.params_hash.merge(radius: wider_radius.first)), class: "wider-radius-gtm"),
+                                                        search_link: govuk_link_to(t(".wider_search_suggestions.radius_distance", radius: wider_radius.first), jobs_path(@vacancies_search.params.merge(radius: wider_radius.first)), class: "wider-radius-gtm"),
                                                         count: t(".wider_search_suggestions.results", count: wider_radius.last))
         span.govuk-heading-m
           = t("subscriptions.link.no_search_results.text_html", link_to: govuk_link_to(t("subscriptions.link.no_search_results.link"), new_subscription_path(search_criteria: @vacancies_search.only_active_to_hash, origin: request.original_fullpath), id: "job-alert-link-no-search-results-gtm"))

--- a/spec/services/search/search_builder_spec.rb
+++ b/spec/services/search/search_builder_spec.rb
@@ -67,14 +67,14 @@ RSpec.describe Search::SearchBuilder do
   describe "building filters" do
     it "calls the filters builder" do
       expect(Search::FiltersBuilder).to receive(:new).with(form_hash).and_call_original
-      subject
+      subject.search_filters
     end
   end
 
   describe "building replica" do
     it "calls the replica builder" do
       expect(Search::ReplicaBuilder).to receive(:new).with(form_hash[:jobs_sort], keyword).and_call_original
-      subject
+      subject.search_replica
     end
   end
 
@@ -96,7 +96,7 @@ RSpec.describe Search::SearchBuilder do
 
         it "calls algolia search with the correct parameters" do
           expect(Search::AlgoliaSearchRequest).to receive(:new).with(search_params).and_call_original
-          subject
+          subject.vacancies
         end
       end
 
@@ -118,7 +118,7 @@ RSpec.describe Search::SearchBuilder do
 
         it "calls algolia search with the correct parameters" do
           expect(Search::AlgoliaSearchRequest).to receive(:new).with(search_params).and_call_original
-          subject
+          subject.vacancies
         end
       end
     end
@@ -128,7 +128,7 @@ RSpec.describe Search::SearchBuilder do
 
       it "calls `Search::VacancyPaginator` with the correct parameters" do
         expect(Search::VacancyPaginator).to receive(:new).with(1, 10, "").and_call_original
-        subject
+        subject.vacancies
       end
     end
   end


### PR DESCRIPTION
- Rename `params_hash`/`form_hash` to just `params`
- Make rest of `SearchBuilder` lazy too (don't run search from
  `#initialize`)
- Tidy up `AlertBuilder` to not reinvent the wheel of its parent class