### PR TITLE
Yet more refactoring of search

### DIFF
--- a/app/components/jobseekers/search_results/job_alerts_link_component.rb
+++ b/app/components/jobseekers/search_results/job_alerts_link_component.rb
@@ -6,6 +6,6 @@ class Jobseekers::SearchResults::JobAlertsLinkComponent < ViewComponent::Base
   end
 
   def render?
-    @vacancies_search.any_criteria_given? && !ReadOnlyFeature.enabled? && @count.positive?
+    @vacancies_search.active_criteria? && !ReadOnlyFeature.enabled? && @count.positive?
   end
 end

--- a/app/components/jobseekers/search_results/job_alerts_link_component/job_alerts_link_component.html.slim
+++ b/app/components/jobseekers/search_results/job_alerts_link_component/job_alerts_link_component.html.slim
@@ -2,4 +2,4 @@
   .job-alert-cta__fade
   .job-alert-cta__content class="govuk-heading-s govuk-!-font-weight-regular govuk-!-margin-0" id="job-alert-cta"
     .icon.icon--left.icon--alert-white
-      = t("subscriptions.link.help_text_html", link: link_to(t("subscriptions.link.text"), new_subscription_path(search_criteria: @vacancies_search.only_active_to_hash, origin: @origin), id: "job-alert-link-sticky-gtm"))
+      = t("subscriptions.link.help_text_html", link: link_to(t("subscriptions.link.text"), new_subscription_path(search_criteria: @vacancies_search.active_criteria, origin: @origin), id: "job-alert-link-sticky-gtm"))

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -55,7 +55,7 @@ class VacanciesController < ApplicationController
   end
 
   def valid_search?
-    @vacancies_search.any_criteria_given? && !smoke_test?
+    @vacancies_search.active_criteria? && !smoke_test?
   end
 
   def smoke_test?

--- a/app/services/search/location_builder.rb
+++ b/app/services/search/location_builder.rb
@@ -27,6 +27,10 @@ class Search::LocationBuilder
     location && LocationPolygon.include?(location)
   end
 
+  def point_coordinates
+    location_filter[:point_coordinates]
+  end
+
   private
 
   def initialize_polygon_boundaries

--- a/app/views/vacancies/index.html.slim
+++ b/app/views/vacancies/index.html.slim
@@ -19,7 +19,7 @@
   .govuk-grid-column-two-thirds
     = render(Jobseekers::SearchResults::SearchVisualizerComponent.new(vacancies_search: @vacancies_search, render: @display_map))
     section.sort-results.sortable-links role="search" aria-label="Sort vacancies"
-      = render partial: "sorting_options", locals: { search_criteria: @vacancies_search.only_active_to_hash, sort: @vacancies_search.sort_by }
+      = render partial: "sorting_options", locals: { search_criteria: @vacancies_search.active_criteria, sort: @vacancies_search.sort_by }
       - unless @vacancies_search.out_of_bounds?
         .govuk-body#vacancies-stats-top aria-label="Number of results"
           - if @vacancies_search.total_count <= @vacancies_search.hits_per_page
@@ -32,7 +32,7 @@
           - @vacancies.each do |vacancy|
             = render(Jobseekers::VacancySummaryComponent.new(vacancy: vacancy))
 
-      - elsif @vacancies_search.any_criteria_given?
+      - elsif @vacancies_search.active_criteria?
         .divider-bottom
           .govuk-heading-m = t("jobs.no_jobs.heading")
           p.govuk-body
@@ -57,7 +57,7 @@
                                                         search_link: govuk_link_to(t(".wider_search_suggestions.radius_distance", radius: wider_radius.first), jobs_path(@vacancies_search.params.merge(radius: wider_radius.first)), class: "wider-radius-gtm"),
                                                         count: t(".wider_search_suggestions.results", count: wider_radius.last))
         span.govuk-heading-m
-          = t("subscriptions.link.no_search_results.text_html", link_to: govuk_link_to(t("subscriptions.link.no_search_results.link"), new_subscription_path(search_criteria: @vacancies_search.only_active_to_hash, origin: request.original_fullpath), id: "job-alert-link-no-search-results-gtm"))
+          = t("subscriptions.link.no_search_results.text_html", link_to: govuk_link_to(t("subscriptions.link.no_search_results.link"), new_subscription_path(search_criteria: @vacancies_search.active_criteria, origin: request.original_fullpath), id: "job-alert-link-no-search-results-gtm"))
         p class="govuk-!-margin-1"
           = t("subscriptions.benefits.title")
           ul.govuk-list.govuk-list--bullet

--- a/spec/components/jobseekers/search_results/job_alerts_link_component_spec.rb
+++ b/spec/components/jobseekers/search_results/job_alerts_link_component_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Jobseekers::SearchResults::JobAlertsLinkComponent, type: :compone
   let(:active_hash) { { keyword: "maths" } }
 
   before do
-    allow(vacancies_search).to receive(:only_active_to_hash).and_return(active_hash)
-    allow(vacancies_search).to receive(:any_criteria_given?).and_return(search_params_present?)
+    allow(vacancies_search).to receive(:active_criteria).and_return(active_hash)
+    allow(vacancies_search).to receive(:active_criteria?).and_return(search_params_present?)
     allow(ReadOnlyFeature).to receive(:enabled?).and_return(read_only_enabled?)
   end
 

--- a/spec/services/search/search_builder_spec.rb
+++ b/spec/services/search/search_builder_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Search::SearchBuilder do
       before { allow_any_instance_of(Search::LocationBuilder).to receive(:search_with_polygons?).and_return(true) }
 
       it "sets location in the active params hash to the polygon's name" do
-        expect(subject.only_active_to_hash[:location]).to eq("london")
+        expect(subject.active_criteria[:location]).to eq("london")
       end
     end
   end


### PR DESCRIPTION
- Delegate `point_coordinates` to `LocationBuilder` from `SearchBuilder`
- Rename `SearchBuilder#only_active_to_hash` to `#active_criteria` and
  `#any_criteria_given?` to `active_criteria?`
- Remove `except(:radius)` from check in `active_criteria?` as it will
  only be in there if location is in there too
- Refactor `AlgoliaSearchRequest` to use lazy instance method
  memoization