### PR TITLE
Rename all the search things

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -7,7 +7,7 @@ class VacanciesController < ApplicationController
       @landing_page_translation = "#{params[:pretty]}.#{@landing_page.parameterize.underscore}"
     end
     @jobs_search_form = Jobseekers::SearchForm.new(algolia_search_params)
-    @vacancies_search = Search::SearchBuilder.new(@jobs_search_form.to_hash)
+    @vacancies_search = Search::VacancySearch.new(@jobs_search_form.to_hash)
     @jobs_search_form.jobs_sort = @vacancies_search.sort_by
     @vacancies = VacanciesPresenter.new(@vacancies_search.vacancies)
   end

--- a/app/jobs/alert_email/base.rb
+++ b/app/jobs/alert_email/base.rb
@@ -13,6 +13,6 @@ class AlertEmail::Base < ApplicationJob
   end
 
   def vacancies_for_subscription(subscription)
-    subscription.vacancies_for_range(from_date, Date.current).limit(Search::AlertBuilder::MAXIMUM_SUBSCRIPTION_RESULTS)
+    subscription.vacancies_for_range(from_date, Date.current).limit(Search::AlertVacancySearch::MAXIMUM_SUBSCRIPTION_RESULTS)
   end
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -35,7 +35,7 @@ class Subscription < ApplicationRecord
   end
 
   def vacancies_for_range(date_from, date_to)
-    Search::AlertBuilder.new(search_criteria.symbolize_keys.merge(from_date: date_from, to_date: date_to)).vacancies
+    Search::AlertVacancySearch.new(search_criteria.symbolize_keys.merge(from_date: date_from, to_date: date_to)).vacancies
   end
 
   def alert_run_today

--- a/app/services/search/alert_vacancy_search.rb
+++ b/app/services/search/alert_vacancy_search.rb
@@ -1,4 +1,4 @@
-class Search::AlertBuilder < Search::SearchBuilder
+class Search::AlertVacancySearch < Search::VacancySearch
   MAXIMUM_SUBSCRIPTION_RESULTS = 500
 
   def initialize(params)

--- a/app/services/search/buffer_suggestions_builder.rb
+++ b/app/services/search/buffer_suggestions_builder.rb
@@ -20,7 +20,7 @@ class Search::BufferSuggestionsBuilder
       locations.each do |location|
         location.buffers[distance.to_s].each { |buffer| buffered_polygons.push(buffer) }
       end
-      [distance.to_s, Search::AlgoliaSearchRequest.new(search_params.merge(polygons: buffered_polygons)).total_count]
+      [distance.to_s, Search::Strategies::Algolia.new(search_params.merge(polygons: buffered_polygons)).total_count]
     end
 
     buffer_vacancy_count&.uniq(&:last)&.reject { |array| array.last.zero? }

--- a/app/services/search/radius_suggestions_builder.rb
+++ b/app/services/search/radius_suggestions_builder.rb
@@ -20,7 +20,7 @@ class Search::RadiusSuggestionsBuilder
       unless wider_radius.nil?
         [
           wider_radius,
-          Search::AlgoliaSearchRequest.new(search_params.merge(radius: convert_miles_to_metres(wider_radius))).total_count,
+          Search::Strategies::Algolia.new(search_params.merge(radius: convert_miles_to_metres(wider_radius))).total_count,
         ]
       end
     }&.reject(&:nil?)

--- a/app/services/search/similar_jobs.rb
+++ b/app/services/search/similar_jobs.rb
@@ -6,6 +6,6 @@ class Search::SimilarJobs
   def initialize(vacancy)
     # For now, similar jobs are retrieved based on the same set of rules that define similar job alerts
     criteria = Search::CriteriaDeviser.new(vacancy).criteria
-    @similar_jobs = Search::SearchBuilder.new(criteria).vacancies.reject { |job| job.id == vacancy.id }.take(NUMBER_OF_SIMILAR_JOBS)
+    @similar_jobs = Search::VacancySearch.new(criteria).vacancies.reject { |job| job.id == vacancy.id }.take(NUMBER_OF_SIMILAR_JOBS)
   end
 end

--- a/app/services/search/strategies/algolia.rb
+++ b/app/services/search/strategies/algolia.rb
@@ -1,4 +1,4 @@
-class Search::AlgoliaSearchRequest
+class Search::Strategies::Algolia
   def initialize(search_params)
     @keyword = search_params[:keyword]
     @coordinates = search_params[:coordinates]

--- a/app/services/search/strategies/database.rb
+++ b/app/services/search/strategies/database.rb
@@ -1,4 +1,4 @@
-class Search::VacancyPaginator
+class Search::Strategies::Database
   DEFAULT_ORDER = "publish_on DESC".freeze
   ORDER_OPTIONS = {
     publish_on_desc: "publish_on DESC",

--- a/app/services/search/vacancy_search.rb
+++ b/app/services/search/vacancy_search.rb
@@ -1,4 +1,4 @@
-class Search::SearchBuilder
+class Search::VacancySearch
   DEFAULT_HITS_PER_PAGE = 10
   DEFAULT_PAGE = 1
 
@@ -71,9 +71,9 @@ class Search::SearchBuilder
 
   def search_strategy
     @search_strategy ||= if active_criteria?
-                           Search::AlgoliaSearchRequest.new(search_params)
+                           Search::Strategies::Algolia.new(search_params)
                          else
-                           Search::VacancyPaginator.new(page, hits_per_page, params[:jobs_sort])
+                           Search::Strategies::Database.new(page, hits_per_page, params[:jobs_sort])
                          end
   end
 

--- a/app/services/vacancy_facets.rb
+++ b/app/services/vacancy_facets.rb
@@ -52,6 +52,6 @@ class VacancyFacets
     # Disable this very expensive operation unless caching is enabled (e.g. in dev, system tests)
     return 0 unless Rails.application.config.action_controller.perform_caching
 
-    Search::SearchBuilder.new(query).total_count || 0
+    Search::VacancySearch.new(query).total_count || 0
   end
 end

--- a/spec/components/jobseekers/search_results/heading_component_spec.rb
+++ b/spec/components/jobseekers/search_results/heading_component_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Jobseekers::SearchResults::HeadingComponent, type: :component do
   subject { described_class.new(vacancies_search: vacancies_search) }
 
-  let(:vacancies_search) { instance_double(Search::SearchBuilder) }
+  let(:vacancies_search) { instance_double(Search::VacancySearch) }
   let(:keyword) { "maths" }
   let(:location) { "London" }
   let(:polygon_boundaries) { [[51.0, 51.0]] }

--- a/spec/components/jobseekers/search_results/job_alerts_link_component_spec.rb
+++ b/spec/components/jobseekers/search_results/job_alerts_link_component_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Jobseekers::SearchResults::JobAlertsLinkComponent, type: :component do
   subject { described_class.new(vacancies_search: vacancies_search, count: 1, origin: "/foo/bar") }
 
-  let(:vacancies_search) { instance_double(Search::SearchBuilder) }
+  let(:vacancies_search) { instance_double(Search::VacancySearch) }
   let(:active_hash) { { keyword: "maths" } }
 
   before do

--- a/spec/components/jobseekers/search_results/search_visualizer_component_spec.rb
+++ b/spec/components/jobseekers/search_results/search_visualizer_component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Jobseekers::SearchResults::SearchVisualizerComponent, type: :comp
     render_inline(subject)
   end
 
-  let(:vacancies_search) { instance_double(Search::SearchBuilder) }
+  let(:vacancies_search) { instance_double(Search::VacancySearch) }
   let(:polygon_boundaries) { [[1, 2, 1, 2], [3, 4, 3, 4]] }
   let(:point_coordinates) { [1, 2] }
 

--- a/spec/controllers/vacancies_controller_spec.rb
+++ b/spec/controllers/vacancies_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe VacanciesController, type: :controller do
       context "when parameters include the sort by newest listing option" do
         let(:sort) { "publish_on_desc" }
 
-        it "sets the search replica on Search::SearchBuilder" do
+        it "sets the search replica on Search::VacancySearch" do
           subject
           expect(controller.instance_variable_get(:@vacancies_search).search_replica).to eq("#{Indexable::INDEX_NAME}_#{sort}")
         end
@@ -32,7 +32,7 @@ RSpec.describe VacanciesController, type: :controller do
       context "when parameters include the sort by most time to apply option" do
         let(:sort) { "expires_at_desc" }
 
-        it "sets the search replica on Search::SearchBuilder" do
+        it "sets the search replica on Search::VacancySearch" do
           subject
           expect(controller.instance_variable_get(:@vacancies_search).search_replica).to eq("#{Indexable::INDEX_NAME}_#{sort}")
         end
@@ -41,7 +41,7 @@ RSpec.describe VacanciesController, type: :controller do
       context "when parameters include the sort by least time to apply option" do
         let(:sort) { "expires_at_asc" }
 
-        it "sets the search replica on Search::SearchBuilder" do
+        it "sets the search replica on Search::VacancySearch" do
           subject
           expect(controller.instance_variable_get(:@vacancies_search).search_replica).to eq("#{Indexable::INDEX_NAME}_#{sort}")
         end
@@ -56,7 +56,7 @@ RSpec.describe VacanciesController, type: :controller do
           }
         end
 
-        it "sets the search replica on Search::SearchBuilder to the default sort strategy: newest listing" do
+        it "sets the search replica on Search::VacancySearch to the default sort strategy: newest listing" do
           subject
           expect(controller.instance_variable_get(:@vacancies_search).search_replica).to eq("#{Indexable::INDEX_NAME}_publish_on_desc")
         end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Subscription, type: :model do
     let(:algolia_search_args) do
       {
         filters: search_filter,
-        hitsPerPage: Search::AlertBuilder::MAXIMUM_SUBSCRIPTION_RESULTS,
+        hitsPerPage: Search::AlertVacancySearch::MAXIMUM_SUBSCRIPTION_RESULTS,
         typoTolerance: false,
       }
     end

--- a/spec/services/search/alert_vacancy_search_spec.rb
+++ b/spec/services/search/alert_vacancy_search_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Search::AlertBuilder do
+RSpec.describe Search::AlertVacancySearch do
   let(:subject) { described_class.new(subscription_hash) }
 
   let!(:expired_now) { Time.current }

--- a/spec/services/search/similar_jobs_spec.rb
+++ b/spec/services/search/similar_jobs_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Search::SimilarJobs do
     subject
   end
 
-  it "calls Search::SearchBuilder" do
-    expect(Search::SearchBuilder).to receive(:new).and_call_original
+  it "calls Search::VacancySearch" do
+    expect(Search::VacancySearch).to receive(:new).and_call_original
     subject
   end
 end

--- a/spec/services/search/strategies/algolia_spec.rb
+++ b/spec/services/search/strategies/algolia_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Search::AlgoliaSearchRequest do
+RSpec.describe Search::Strategies::Algolia do
   let(:subject) { described_class.new(search_params) }
 
   let(:vacancies) { double("vacancies") }

--- a/spec/services/search/strategies/database_spec.rb
+++ b/spec/services/search/strategies/database_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Search::VacancyPaginator do
+RSpec.describe Search::Strategies::Database do
   subject { described_class.new(page, hits_per_page, jobs_sort) }
 
   let(:page) { 1 }

--- a/spec/services/search/vacancy_search_spec.rb
+++ b/spec/services/search/vacancy_search_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Search::SearchBuilder do
+RSpec.describe Search::VacancySearch do
   let(:subject) { described_class.new(form_hash) }
 
   let(:form_hash) do
@@ -95,7 +95,7 @@ RSpec.describe Search::SearchBuilder do
         before { allow(Search::BufferSuggestionsBuilder).to receive_message_chain(:new, :buffer_suggestions) }
 
         it "calls algolia search with the correct parameters" do
-          expect(Search::AlgoliaSearchRequest).to receive(:new).with(search_params).and_call_original
+          expect(Search::Strategies::Algolia).to receive(:new).with(search_params).and_call_original
           subject.vacancies
         end
       end
@@ -117,7 +117,7 @@ RSpec.describe Search::SearchBuilder do
         before { allow(Search::RadiusSuggestionsBuilder).to receive_message_chain(:new, :radius_suggestions) }
 
         it "calls algolia search with the correct parameters" do
-          expect(Search::AlgoliaSearchRequest).to receive(:new).with(search_params).and_call_original
+          expect(Search::Strategies::Algolia).to receive(:new).with(search_params).and_call_original
           subject.vacancies
         end
       end
@@ -126,8 +126,8 @@ RSpec.describe Search::SearchBuilder do
     context "when there is not any search criteria" do
       let(:keyword) { "" }
 
-      it "calls `Search::VacancyPaginator` with the correct parameters" do
-        expect(Search::VacancyPaginator).to receive(:new).with(1, 10, "").and_call_original
+      it "calls `Search::Strategies::Database` with the correct parameters" do
+        expect(Search::Strategies::Database).to receive(:new).with(1, 10, "").and_call_original
         subject.vacancies
       end
     end

--- a/spec/services/vacancy_facets_spec.rb
+++ b/spec/services/vacancy_facets_spec.rb
@@ -3,11 +3,11 @@ require "rails_helper"
 RSpec.describe VacancyFacets do
   subject { described_class.new }
 
-  let(:search_builder) { instance_double(Search::SearchBuilder, total_count: 42) }
+  let(:search_builder) { instance_double(Search::VacancySearch, total_count: 42) }
 
   before do
     allow(Rails.application.config.action_controller).to receive(:perform_caching).and_return(true)
-    allow(Search::SearchBuilder).to receive(:new).and_return(search_builder)
+    allow(Search::VacancySearch).to receive(:new).and_return(search_builder)
   end
 
   describe "#job_roles" do

--- a/spec/system/jobseekers_can_view_all_the_jobs_spec.rb
+++ b/spec/system/jobseekers_can_view_all_the_jobs_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Jobseekers can view all the jobs" do
 
   describe "pagination" do
     before do
-      stub_const("Search::SearchBuilder::DEFAULT_HITS_PER_PAGE", 2)
+      stub_const("Search::VacancySearch::DEFAULT_HITS_PER_PAGE", 2)
     end
 
     context "when visiting the home page and performing an empty search" do


### PR DESCRIPTION
In preparation for making them a bit less coupled.

- Rename `SearchBuilder` and `AlertBuilder` to `VacancySearch` and
  `AlertVacancySearch` as these don't really just build a search, they
  actually perform a search
- Rename `Search::AlgoliaSearchRequest` to `Search::Strategies::Algolia`
  and `Search::VacancyPaginator` to `Search::Strategies::Database` to
  clarify that they serve the same purpose (but do it differently)