### PR TITLE
[TEVA-1978] Fix smoke test for production

### DIFF
--- a/spec/smoke_tests/jobseekers_can_view_homepage_spec.rb
+++ b/spec/smoke_tests/jobseekers_can_view_homepage_spec.rb
@@ -1,9 +1,15 @@
 require "capybara/rspec"
 require "i18n_helper"
 
+PRODUCTION_DOMAIN = "teaching-vacancies.service.gov.uk".freeze
+
 RSpec.describe "Page availability", js: true, smoke_test: true do
   context "Jobseeker visits vacancy page" do
-    let(:smoke_test_domain) { ENV.fetch("SMOKE_TEST_DOMAIN", "teaching-vacancies.service.gov.uk") }
+    let(:smoke_test_domain) do
+      smoke_test_domain = ENV.fetch("SMOKE_TEST_DOMAIN", "")
+      smoke_test_domain = PRODUCTION_DOMAIN if smoke_test_domain.empty?
+      smoke_test_domain
+    end
 
     it "ensures users can search and view a job vacancy page" do
       page = Capybara::Session.new(:selenium_chrome_headless)


### PR DESCRIPTION

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1978

## Changes in this PR:

When it runs in the scheduled workflow, the SMOKE_TEST_DOMAIN is an
empty string. We now use the production domain for this case.
