### PR TITLE
[TEVA-1757] The last step in refactoring existing feedback forms: unsubscribe feedback

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -84,7 +84,7 @@ class ApplicationController < ActionController::Base
 
   def trigger_feedback_provided_event
     anonymise_these_params = %w[jobseeker_id publisher_id]
-    feedback_data = feedback_params.to_h.each_with_object({}) do |(key, value), params|
+    feedback_data = feedback_attributes.to_h.each_with_object({}) do |(key, value), params|
       if anonymise_these_params.include?(key)
         params["anonymised_#{key}"] = StringAnonymiser.new(value)
       else

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -82,19 +82,6 @@ class ApplicationController < ActionController::Base
     @request_event ||= RequestEvent.new(request, response, session, current_jobseeker, current_publisher_oid)
   end
 
-  def trigger_feedback_provided_event
-    anonymise_these_params = %w[jobseeker_id publisher_id]
-    feedback_data = feedback_attributes.to_h.each_with_object({}) do |(key, value), params|
-      if anonymise_these_params.include?(key)
-        params["anonymised_#{key}"] = StringAnonymiser.new(value)
-      else
-        params[key] = value
-      end
-    end
-    feedback_data[:recaptcha_score] = recaptcha_reply["score"] unless recaptcha_reply&.dig("score").blank?
-    request_event.trigger(:feedback_provided, feedback_data)
-  end
-
   def trigger_page_visited_event
     request_event.trigger(:page_visited)
   end

--- a/app/controllers/concerns/feedback_event_concerns.rb
+++ b/app/controllers/concerns/feedback_event_concerns.rb
@@ -1,0 +1,16 @@
+module FeedbackEventConcerns
+  extend ActiveSupport::Concern
+
+  def trigger_feedback_provided_event
+    anonymise_these_params = %w[jobseeker_id publisher_id]
+    feedback_data = feedback_attributes.to_h.each_with_object({}) do |(key, value), params|
+      if anonymise_these_params.include?(key)
+        params["anonymised_#{key}"] = StringAnonymiser.new(value)
+      else
+        params[key] = value
+      end
+    end
+    feedback_data[:recaptcha_score] = recaptcha_reply["score"] unless recaptcha_reply&.dig("score").blank?
+    request_event.trigger(:feedback_provided, feedback_data)
+  end
+end

--- a/app/controllers/general_feedbacks_controller.rb
+++ b/app/controllers/general_feedbacks_controller.rb
@@ -4,8 +4,8 @@ class GeneralFeedbacksController < ApplicationController
   end
 
   def create
-    @general_feedback_form = GeneralFeedbackForm.new(feedback_params)
-    @feedback = Feedback.new(feedback_params)
+    @general_feedback_form = GeneralFeedbackForm.new(general_feedback_form_params)
+    @feedback = Feedback.new(feedback_attributes)
 
     if @general_feedback_form.invalid?
       render :new
@@ -21,9 +21,12 @@ class GeneralFeedbacksController < ApplicationController
 
   private
 
-  def feedback_params
+  def general_feedback_form_params
     params.require(:general_feedback_form)
           .permit(:comment, :email, :user_participation_response, :visit_purpose, :visit_purpose_comment)
-          .merge(feedback_type: "general")
+  end
+
+  def feedback_attributes
+    general_feedback_form_params.merge(feedback_type: "general")
   end
 end

--- a/app/controllers/general_feedbacks_controller.rb
+++ b/app/controllers/general_feedbacks_controller.rb
@@ -1,4 +1,6 @@
 class GeneralFeedbacksController < ApplicationController
+  include FeedbackEventConcerns
+
   def new
     @general_feedback_form = GeneralFeedbackForm.new
   end

--- a/app/controllers/jobseekers/account_feedbacks_controller.rb
+++ b/app/controllers/jobseekers/account_feedbacks_controller.rb
@@ -4,10 +4,10 @@ class Jobseekers::AccountFeedbacksController < Jobseekers::ApplicationController
   end
 
   def create
-    @account_feedback_form = Jobseekers::AccountFeedbackForm.new(feedback_params)
+    @account_feedback_form = Jobseekers::AccountFeedbackForm.new(account_feedback_form_params)
 
     if @account_feedback_form.valid?
-      Feedback.create(feedback_params.except(:origin))
+      Feedback.create(feedback_attributes.except(:origin))
       trigger_feedback_provided_event
       redirect_to @account_feedback_form.origin, success: t(".success")
     else
@@ -17,8 +17,11 @@ class Jobseekers::AccountFeedbacksController < Jobseekers::ApplicationController
 
   private
 
-  def feedback_params
+  def account_feedback_form_params
     params.require(:jobseekers_account_feedback_form).permit(:rating, :comment, :origin)
-          .merge(jobseeker_id: current_jobseeker.id, feedback_type: "jobseeker_account")
+  end
+
+  def feedback_attributes
+    account_feedback_form_params.merge(jobseeker_id: current_jobseeker.id, feedback_type: "jobseeker_account")
   end
 end

--- a/app/controllers/jobseekers/account_feedbacks_controller.rb
+++ b/app/controllers/jobseekers/account_feedbacks_controller.rb
@@ -1,4 +1,6 @@
 class Jobseekers::AccountFeedbacksController < Jobseekers::ApplicationController
+  include FeedbackEventConcerns
+
   def new
     @account_feedback_form = Jobseekers::AccountFeedbackForm.new(origin: params[:origin])
   end

--- a/app/controllers/jobseekers/job_alert_feedbacks_controller.rb
+++ b/app/controllers/jobseekers/job_alert_feedbacks_controller.rb
@@ -1,4 +1,6 @@
 class Jobseekers::JobAlertFeedbacksController < ApplicationController
+  include FeedbackEventConcerns
+
   def new
     # The `new` action creates the Feedback record because it is called from a link in the alert email.
     # Such links can only perform GET requests. HTTP forbids redirecting from GET to POST.

--- a/app/controllers/jobseekers/job_alert_feedbacks_controller.rb
+++ b/app/controllers/jobseekers/job_alert_feedbacks_controller.rb
@@ -1,12 +1,9 @@
 class Jobseekers::JobAlertFeedbacksController < ApplicationController
   def new
-    # This action creates the JobAlertFeedback record.
-    # This is because it is called from a link in the alert email. Such links can only perform
-    # GET requests. HTTP forbids redirecting from GET to POST.
-
+    # The `new` action creates the Feedback record because it is called from a link in the alert email.
+    # Such links can only perform GET requests. HTTP forbids redirecting from GET to POST.
     @subscription = Subscription.find_and_verify_by_token(token)
-    @feedback = Feedback.create(feedback_params)
-
+    @feedback = Feedback.create(feedback_attributes)
     trigger_feedback_provided_event
     redirect_to edit_subscription_job_alert_feedback_path(id: @feedback.id), success: t(".success")
   end
@@ -14,20 +11,20 @@ class Jobseekers::JobAlertFeedbacksController < ApplicationController
   def edit
     @feedback = Feedback.find(feedback_id)
     @subscription = Subscription.find_and_verify_by_token(token)
-    @feedback_form = Jobseekers::JobAlertFeedbackForm.new
+    @feedback_form = Jobseekers::JobAlertFurtherFeedbackForm.new
   end
 
   def update
     @feedback = Feedback.find(feedback_id)
     @subscription = Subscription.find_and_verify_by_token(token)
-    @feedback_form = Jobseekers::JobAlertFeedbackForm.new(form_params)
+    @feedback_form = Jobseekers::JobAlertFurtherFeedbackForm.new(further_feedback_form_params)
 
     if @feedback_form.invalid?
       render :edit
     elsif recaptcha_is_invalid?(@feedback)
       redirect_to invalid_recaptcha_path(form_name: @feedback_form.class.name.gsub("::", "").underscore.humanize)
     else
-      @feedback.update(form_params)
+      @feedback.update(further_feedback_form_params)
       @feedback.recaptcha_score = recaptcha_reply["score"]
       @feedback.save
       trigger_feedback_provided_event
@@ -37,25 +34,30 @@ class Jobseekers::JobAlertFeedbacksController < ApplicationController
 
   private
 
-  def feedback_params
-    # `trigger_feedback_provided_event`, which we use to create Events, relies on feedback_params. Hence this slightly
-    # unconventional, abstracted feedback_params method, which allows events to be created for either type of action.
-    # Here felt like the best place for this logic, since job alert feedback is the only feedback type that has >1 action.
-    case action_name
-    when "new"
-      # The duplication here is because of the old-style params provided in links in emails that have already been sent.
-      # TODO: drop the left-most version of each duplication after e.g. 30 days, and the transformation.
-      params.require(:job_alert_feedback)
-            .permit(:relevant_to_user, :search_criteria, search_criteria: {}, vacancy_ids: [], job_alert_vacancy_ids: [])
-            .merge(feedback_type: "job_alert", subscription_id: @subscription.id)
-            .transform_keys { |key| key == "vacancy_ids" ? "job_alert_vacancy_ids" : key }
-    when "update"
-      form_params.merge(feedback_type: "job_alert", subscription_id: @subscription.id)
-    end
+  def feedback_attributes
+    # `trigger_feedback_provided_event`, which we use to create Events, relies on feedback_attributes.
+    # This method allows events to be created for either type of action. Here felt like the best place for this logic,
+    # since job alert feedback is the only feedback type that has >1 action.
+    attributes = case action_name
+                 when "new"
+                   job_alert_email_link_params
+                 when "update"
+                   further_feedback_form_params
+                 end
+    attributes.merge(feedback_type: "job_alert", subscription_id: @subscription.id)
   end
 
-  def form_params
-    params.require(:jobseekers_job_alert_feedback_form).permit(:comment)
+  def job_alert_email_link_params
+    # The duplication here is because of the old-style params provided in links in emails that
+    # have already been sent.
+    # TODO: drop the left-most version of each duplication after e.g. 30 days, and the transformation.
+    params.require(:job_alert_feedback)
+          .permit(:relevant_to_user, :search_criteria, search_criteria: {}, vacancy_ids: [], job_alert_vacancy_ids: [])
+          .transform_keys { |key| key == "vacancy_ids" ? "job_alert_vacancy_ids" : key }
+  end
+
+  def further_feedback_form_params
+    params.require(:jobseekers_job_alert_further_feedback_form).permit(:comment)
   end
 
   def token

--- a/app/controllers/jobseekers/unsubscribe_feedbacks_controller.rb
+++ b/app/controllers/jobseekers/unsubscribe_feedbacks_controller.rb
@@ -1,15 +1,15 @@
 class Jobseekers::UnsubscribeFeedbacksController < ApplicationController
   def new
-    subscription = Subscription.find(subscription_id)
-    @subscription = SubscriptionPresenter.new(subscription)
+    @subscription = Subscription.find(subscription_id)
     @unsubscribe_feedback_form = Jobseekers::UnsubscribeFeedbackForm.new
   end
 
   def create
     @subscription = Subscription.find(subscription_id)
-    @unsubscribe_feedback_form = Jobseekers::UnsubscribeFeedbackForm.new(unsubscribe_feedback_params)
+    @unsubscribe_feedback_form = Jobseekers::UnsubscribeFeedbackForm.new(unsubscribe_feedback_form_params)
 
-    if @unsubscribe_feedback_form.valid? && @subscription.unsubscribe_feedbacks.create(unsubscribe_feedback_params)
+    if @unsubscribe_feedback_form.valid? && Feedback.create(feedback_params)
+      trigger_feedback_provided_event
       if current_jobseeker
         redirect_to jobseekers_subscriptions_path, success: t(".success")
       else
@@ -26,7 +26,12 @@ class Jobseekers::UnsubscribeFeedbacksController < ApplicationController
     params.require(:subscription_id)
   end
 
-  def unsubscribe_feedback_params
-    params.require(:jobseekers_unsubscribe_feedback_form).permit(:reason, :other_reason, :additional_info)
+  def feedback_params
+    unsubscribe_feedback_form_params.merge(feedback_type: "unsubscribe", subscription_id: subscription_id)
+  end
+
+  def unsubscribe_feedback_form_params
+    params.require(:jobseekers_unsubscribe_feedback_form)
+          .permit(:comment, :other_unsubscribe_reason_comment, :unsubscribe_reason)
   end
 end

--- a/app/controllers/jobseekers/unsubscribe_feedbacks_controller.rb
+++ b/app/controllers/jobseekers/unsubscribe_feedbacks_controller.rb
@@ -1,4 +1,6 @@
 class Jobseekers::UnsubscribeFeedbacksController < ApplicationController
+  include FeedbackEventConcerns
+
   def new
     @subscription = Subscription.find(subscription_id)
     @unsubscribe_feedback_form = Jobseekers::UnsubscribeFeedbackForm.new

--- a/app/controllers/jobseekers/unsubscribe_feedbacks_controller.rb
+++ b/app/controllers/jobseekers/unsubscribe_feedbacks_controller.rb
@@ -8,7 +8,7 @@ class Jobseekers::UnsubscribeFeedbacksController < ApplicationController
     @subscription = Subscription.find(subscription_id)
     @unsubscribe_feedback_form = Jobseekers::UnsubscribeFeedbackForm.new(unsubscribe_feedback_form_params)
 
-    if @unsubscribe_feedback_form.valid? && Feedback.create(feedback_params)
+    if @unsubscribe_feedback_form.valid? && Feedback.create(feedback_attributes)
       trigger_feedback_provided_event
       if current_jobseeker
         redirect_to jobseekers_subscriptions_path, success: t(".success")
@@ -26,7 +26,7 @@ class Jobseekers::UnsubscribeFeedbacksController < ApplicationController
     params.require(:subscription_id)
   end
 
-  def feedback_params
+  def feedback_attributes
     unsubscribe_feedback_form_params.merge(feedback_type: "unsubscribe", subscription_id: subscription_id)
   end
 

--- a/app/controllers/publishers/vacancies/vacancy_publisher_feedbacks_controller.rb
+++ b/app/controllers/publishers/vacancies/vacancy_publisher_feedbacks_controller.rb
@@ -1,6 +1,8 @@
 class Publishers::Vacancies::VacancyPublisherFeedbacksController < Publishers::Vacancies::ApplicationController
   before_action :set_vacancy, only: %i[new create]
 
+  include FeedbackEventConcerns
+
   def new
     return redirect_to organisation_path, notice: t(".already_submitted") if already_submitted?
 

--- a/app/controllers/publishers/vacancies/vacancy_publisher_feedbacks_controller.rb
+++ b/app/controllers/publishers/vacancies/vacancy_publisher_feedbacks_controller.rb
@@ -8,11 +8,11 @@ class Publishers::Vacancies::VacancyPublisherFeedbacksController < Publishers::V
   end
 
   def create
-    @vacancy_publisher_feedback_form = Publishers::Vacancies::VacancyPublisherFeedbackForm.new(feedback_params)
+    @vacancy_publisher_feedback_form =
+      Publishers::Vacancies::VacancyPublisherFeedbackForm.new(vacancy_publisher_feedback_form_params)
 
     if @vacancy_publisher_feedback_form.valid?
-      @feedback = Feedback.create(feedback_params)
-      Auditor::Audit.new(@vacancy, "vacancy.publish_feedback.create", current_publisher_oid).log
+      @feedback = Feedback.create(feedback_attributes)
       trigger_feedback_provided_event
       redirect_to organisation_path, success: t("messages.jobs.feedback.submitted_html", job_title: @vacancy.job_title)
     else
@@ -22,10 +22,14 @@ class Publishers::Vacancies::VacancyPublisherFeedbacksController < Publishers::V
 
   private
 
-  def feedback_params
+  def vacancy_publisher_feedback_form_params
     params.require(:publishers_vacancies_vacancy_publisher_feedback_form)
           .permit(:comment, :user_participation_response, :email)
-          .merge(feedback_type: "vacancy_publisher", vacancy_id: @vacancy.id, publisher_id: current_publisher.id)
+  end
+
+  def feedback_attributes
+    vacancy_publisher_feedback_form_params
+      .merge(feedback_type: "vacancy_publisher", vacancy_id: @vacancy.id, publisher_id: current_publisher.id)
   end
 
   def set_vacancy

--- a/app/form_models/general_feedback_form.rb
+++ b/app/form_models/general_feedback_form.rb
@@ -1,8 +1,7 @@
 class GeneralFeedbackForm
   include ActiveModel::Model
 
-  attr_accessor :comment, :email, :feedback_type, :user_participation_response,
-                :visit_purpose, :visit_purpose_comment
+  attr_accessor :comment, :email, :user_participation_response, :visit_purpose, :visit_purpose_comment
 
   validates :comment, presence: true, length: { maximum: 1200 }
   validates :email, presence: true, if: -> { user_participation_response == "interested" }

--- a/app/form_models/jobseekers/account_feedback_form.rb
+++ b/app/form_models/jobseekers/account_feedback_form.rb
@@ -1,7 +1,7 @@
 class Jobseekers::AccountFeedbackForm
   include ActiveModel::Model
 
-  attr_accessor :origin, :comment, :feedback_type, :jobseeker_id, :rating
+  attr_accessor :origin, :comment, :jobseeker_id, :rating
 
   validates :comment, length: { maximum: 1200 }, if: -> { comment.present? }
   validates :rating, inclusion: { in: Feedback.ratings.keys }

--- a/app/form_models/jobseekers/job_alert_feedback_form.rb
+++ b/app/form_models/jobseekers/job_alert_feedback_form.rb
@@ -3,6 +3,5 @@ class Jobseekers::JobAlertFeedbackForm
 
   attr_accessor :comment
 
-  validates :comment, presence: true
-  validates :comment, length: { maximum: 1200 }
+  validates :comment, presence: true, length: { maximum: 1200 }
 end

--- a/app/form_models/jobseekers/job_alert_further_feedback_form.rb
+++ b/app/form_models/jobseekers/job_alert_further_feedback_form.rb
@@ -1,4 +1,4 @@
-class Jobseekers::JobAlertFeedbackForm
+class Jobseekers::JobAlertFurtherFeedbackForm
   include ActiveModel::Model
 
   attr_accessor :comment

--- a/app/form_models/jobseekers/unsubscribe_feedback_form.rb
+++ b/app/form_models/jobseekers/unsubscribe_feedback_form.rb
@@ -1,9 +1,9 @@
 class Jobseekers::UnsubscribeFeedbackForm
   include ActiveModel::Model
 
-  attr_accessor :reason, :other_reason, :additional_info
+  attr_accessor :comment, :other_unsubscribe_reason_comment, :unsubscribe_reason
 
-  validates :reason, inclusion: { in: UnsubscribeFeedback.reasons.keys }
-  validates :other_reason, presence: true, if: -> { reason == "other_reason" }
-  validates :additional_info, length: { maximum: 1200 }
+  validates :comment, length: { maximum: 1200 }
+  validates :other_unsubscribe_reason_comment, presence: true, if: -> { unsubscribe_reason == "other_reason" }
+  validates :unsubscribe_reason, inclusion: { in: Feedback.unsubscribe_reasons.keys }
 end

--- a/app/form_models/publishers/vacancies/vacancy_publisher_feedback_form.rb
+++ b/app/form_models/publishers/vacancies/vacancy_publisher_feedback_form.rb
@@ -1,13 +1,10 @@
 class Publishers::Vacancies::VacancyPublisherFeedbackForm
   include ActiveModel::Model
 
-  attr_accessor :comment, :email, :feedback_type, :user_participation_response,
-                :publisher_id, :vacancy_id
+  attr_accessor :comment, :email, :user_participation_response
 
   validates :comment, presence: true, length: { maximum: 1200 }
   validates :email, presence: true, if: -> { user_participation_response == "interested" }
   validates :email, format: { with: Devise.email_regexp }, if: -> { email.present? }
   validates :user_participation_response, inclusion: { in: Feedback.user_participation_responses.keys }
-  validates :publisher_id, presence: true
-  validates :vacancy_id, presence: true
 end

--- a/app/views/jobseekers/unsubscribe_feedbacks/new.html.slim
+++ b/app/views/jobseekers/unsubscribe_feedbacks/new.html.slim
@@ -11,13 +11,13 @@
         = t(".heading")
 
       = f.govuk_radio_buttons_fieldset(:reason) do
-        - UnsubscribeFeedback.reasons.each_key do |reason|
+        - Feedback.unsubscribe_reasons.each_key do |reason|
           - if reason == "other_reason"
-            = f.govuk_radio_button :reason, reason do
-              = f.govuk_text_field :other_reason, label: { size: "s" }
+            = f.govuk_radio_button :unsubscribe_reason, reason do
+              = f.govuk_text_field :other_unsubscribe_reason_comment, label: { size: "s" }
           - else
-            = f.govuk_radio_button :reason, reason
+            = f.govuk_radio_button :unsubscribe_reason, reason
 
-      = f.govuk_text_area :additional_info, label: { size: "s" }, max_chars: 1200
+      = f.govuk_text_area :comment, label: { size: "s" }, max_chars: 1200
 
       = f.govuk_submit t("buttons.submit_feedback")

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -23,9 +23,9 @@ en:
     frequency:
       blank: Select when you want to receive job alert emails
   unsubscribe_feedback_errors: &unsubscribe_feedback_errors
-    reason:
+    unsubscribe_reason:
       inclusion: Tell us why you want to unsubscribe
-    other_reason:
+    other_unsubscribe_reason_comment:
       blank: Tell us why you want to unsubscribe
 
   # Feedback forms

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -89,7 +89,7 @@ en:
       jobseekers_subscription_form:
         email: Enter your email address. We'll only use it to send you job alerts.
       jobseekers_unsubscribe_feedback_form:
-        additional_info: Any more information you can share will help us to improve the service
+        comment: Any more information you can share will help us to improve the service
 
       publishers_organisation_form:
         description: Jobseekers will see this description of the %{organisation_type} in the job listing
@@ -199,9 +199,9 @@ en:
           daily: Daily, at around 3 pm
           weekly: Weekly (Friday evening at around 6 pm)
       jobseekers_unsubscribe_feedback_form:
-        additional_info: Is there anything else you'd like to tell us?
-        other_reason_html: Briefly, tell us more about that reason
-        reason_options:
+        comment: Is there anything else you'd like to tell us?
+        other_unsubscribe_reason_comment: Briefly, tell us more about that reason
+        unsubscribe_reason_options:
           not_relevant: The alerts I am receiving are not relevant to me
           job_found: I have found a teaching job
           circumstances_change: My circumstances have changed

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -76,7 +76,7 @@ en:
         main_duties: A very brief summary
         started_on: For example, 31 08 2010
 
-      jobseekers_job_alert_feedback_form:
+      jobseekers_job_alert_further_feedback_form:
         comment: This is optional, but the information will help us to make improvements.
       jobseekers_nqt_job_alerts_form:
         email: Enter your email address. We will only use it to send you job alerts.
@@ -184,7 +184,7 @@ en:
         email: Email address
         password: Password
 
-      jobseekers_job_alert_feedback_form:
+      jobseekers_job_alert_further_feedback_form:
         comment: Would you like to add any further comments about the relevancy of the job alerts you have received?
       jobseekers_nqt_job_alerts_form:
         email_html: Email address (<span class='text-red'>Required</span>)

--- a/spec/form_models/jobseekers/job_alert_further_feedback_form_spec.rb
+++ b/spec/form_models/jobseekers/job_alert_further_feedback_form_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Jobseekers::JobAlertFeedbackForm, type: :model do
+RSpec.describe Jobseekers::JobAlertFurtherFeedbackForm, type: :model do
   it { is_expected.to validate_presence_of(:comment) }
   it { is_expected.to validate_length_of(:comment).is_at_most(1200) }
 end

--- a/spec/form_models/jobseekers/unsubscribe_feedback_form_spec.rb
+++ b/spec/form_models/jobseekers/unsubscribe_feedback_form_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Jobseekers::UnsubscribeFeedbackForm, type: :model do
   it { is_expected.to validate_inclusion_of(:unsubscribe_reason).in_array(Feedback.unsubscribe_reasons.keys) }
-  it { is_expected.to validate_length_of(:additional_info).is_at_most(1200) }
+  it { is_expected.to validate_length_of(:comment).is_at_most(1200) }
 
   context "when reason is job_found" do
     before { allow(subject).to receive(:unsubscribe_reason).and_return("job_found") }

--- a/spec/form_models/jobseekers/unsubscribe_feedback_form_spec.rb
+++ b/spec/form_models/jobseekers/unsubscribe_feedback_form_spec.rb
@@ -1,18 +1,18 @@
 require "rails_helper"
 
 RSpec.describe Jobseekers::UnsubscribeFeedbackForm, type: :model do
-  it { is_expected.to validate_inclusion_of(:reason).in_array(UnsubscribeFeedback.reasons.keys) }
+  it { is_expected.to validate_inclusion_of(:unsubscribe_reason).in_array(Feedback.unsubscribe_reasons.keys) }
   it { is_expected.to validate_length_of(:additional_info).is_at_most(1200) }
 
   context "when reason is job_found" do
-    before { allow(subject).to receive(:reason).and_return("job_found") }
+    before { allow(subject).to receive(:unsubscribe_reason).and_return("job_found") }
 
-    it { is_expected.not_to validate_presence_of(:other_reason) }
+    it { is_expected.not_to validate_presence_of(:other_unsubscribe_reason_comment) }
   end
 
   context "when reason is other_reason" do
-    before { allow(subject).to receive(:reason).and_return("other_reason") }
+    before { allow(subject).to receive(:unsubscribe_reason).and_return("other_reason") }
 
-    it { is_expected.to validate_presence_of(:other_reason) }
+    it { is_expected.to validate_presence_of(:other_unsubscribe_reason_comment) }
   end
 end

--- a/spec/form_models/publishers/vacancies/vacancy_publisher_feedback_form_spec.rb
+++ b/spec/form_models/publishers/vacancies/vacancy_publisher_feedback_form_spec.rb
@@ -10,15 +10,11 @@ RSpec.describe Publishers::Vacancies::VacancyPublisherFeedbackForm, type: :model
       comment: "Fancy",
       email: email,
       user_participation_response: user_participation_response,
-      publisher_id: 1,
-      vacancy_id: 1,
     }
   end
 
   it { is_expected.to validate_presence_of(:comment) }
   it { is_expected.to validate_length_of(:comment).is_at_most(1200) }
-  it { is_expected.to validate_presence_of(:publisher_id) }
-  it { is_expected.to validate_presence_of(:vacancy_id) }
   it {
     is_expected.to validate_inclusion_of(:user_participation_response)
                         .in_array(Feedback.user_participation_responses.keys)

--- a/spec/system/jobseekers_can_give_job_alert_feedback_spec.rb
+++ b/spec/system/jobseekers_can_give_job_alert_feedback_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "A jobseeker can give feedback on a job alert", recaptcha: true d
 
       before do
         follow_the_link_in_the_job_alert_email
-        fill_in "jobseekers_job_alert_feedback_form[comment]", with: comment
+        fill_in "jobseekers_job_alert_further_feedback_form[comment]", with: comment
       end
 
       it "allows the user to submit further feedback" do
@@ -119,7 +119,7 @@ RSpec.describe "A jobseeker can give feedback on a job alert", recaptcha: true d
 
         context "and the form is valid" do
           scenario "redirects to invalid_recaptcha path" do
-            expect(page).to have_current_path(invalid_recaptcha_path(form_name: "Jobseekers job alert feedback form"))
+            expect(page).to have_current_path(invalid_recaptcha_path(form_name: "Jobseekers job alert further feedback form"))
           end
         end
 

--- a/spec/system/jobseekers_can_manage_their_job_alerts_from_the_dashboard_spec.rb
+++ b/spec/system/jobseekers_can_manage_their_job_alerts_from_the_dashboard_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Jobseekers can manage their job alerts from the dashboard" do
       it "allows to unsubscribe from a job alert" do
         click_on I18n.t("jobseekers.subscriptions.index.link_unsubscribe")
         click_on I18n.t("subscriptions.unsubscribe.button_text")
-        choose I18n.t("helpers.label.jobseekers_unsubscribe_feedback_form.reason_options.job_found")
+        choose I18n.t("helpers.label.jobseekers_unsubscribe_feedback_form.unsubscribe_reason_options.job_found")
         click_button I18n.t("buttons.submit_feedback")
 
         expect(page).to have_content(I18n.t("jobseekers.unsubscribe_feedbacks.create.success"))


### PR DESCRIPTION
### For this one, you'll probably find it easier to review the first and second commits separately.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1757

## Changes in this PR:

- Update UnsubscribeFeedback code to rely on new Feedback table
- Refactor all feedback controllers to separate form-params from feedback-attributes. Attributes are used for two purposes: triggering events, and creating Feedbacks. These responsibilities have been separated out from the form params, which are used for validations.
