### PR TITLE
Even more search refactoring

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -7,7 +7,7 @@ class VacanciesController < ApplicationController
       @landing_page_translation = "#{params[:pretty]}.#{@landing_page.parameterize.underscore}"
     end
     @jobs_search_form = Jobseekers::SearchForm.new(algolia_search_params)
-    @vacancies_search = Search::VacancySearch.new(@jobs_search_form.to_hash)
+    @vacancies_search = Search::VacancySearch.new(@jobs_search_form.to_hash, page: params[:page])
     @jobs_search_form.jobs_sort = @vacancies_search.sort_by
     @vacancies = VacanciesPresenter.new(@vacancies_search.vacancies)
   end
@@ -38,7 +38,7 @@ class VacanciesController < ApplicationController
     %w[job_role job_roles phases working_patterns].each do |facet|
       params[facet] = params[facet].split if params[facet].is_a?(String)
     end
-    params.permit(:keyword, :location, :radius, :subject, :buffer_radius, :jobs_sort, :page,
+    params.permit(:keyword, :location, :radius, :subject, :buffer_radius, :jobs_sort,
                   job_role: [], job_roles: [], phases: [], working_patterns: [])
   end
 

--- a/app/form_models/jobseekers/search_form.rb
+++ b/app/form_models/jobseekers/search_form.rb
@@ -4,7 +4,6 @@ class Jobseekers::SearchForm
   attr_reader :keyword,
               :location, :radius,
               :job_roles, :phases, :working_patterns,
-              :page,
               :job_role_options, :phase_options, :working_pattern_options,
               :total_filters
 
@@ -24,7 +23,6 @@ class Jobseekers::SearchForm
     @working_patterns = params[:working_patterns]
 
     @jobs_sort = params[:jobs_sort]
-    @page = params[:page]
 
     set_facet_options
     set_total_filters
@@ -40,7 +38,6 @@ class Jobseekers::SearchForm
       phases: @phases,
       working_patterns: @working_patterns,
       jobs_sort: @jobs_sort,
-      page: @page,
     }.delete_if { |k, v| v.blank? || (k.eql?(:radius) && @location.blank?) }
   end
 

--- a/app/services/search/alert_vacancy_search.rb
+++ b/app/services/search/alert_vacancy_search.rb
@@ -1,20 +1,17 @@
 class Search::AlertVacancySearch < Search::VacancySearch
   MAXIMUM_SUBSCRIPTION_RESULTS = 500
 
-  def initialize(params)
-    super(params)
-    @keyword ||= build_subscription_keyword
+  def keyword
+    # Generate a suitable keyword if one has not been set as part of the alert
+    # TODO: This should probably be the responsibility of the subscription, not the search
+    @keyword ||= [search_criteria[:subject], search_criteria[:job_title]].reject(&:blank?).join(" ")
   end
 
   private
 
-  def build_subscription_keyword
-    [params[:subject], params[:job_title]].reject(&:blank?).join(" ")
-  end
-
-  def search_params
+  def algolia_params
     super.except(:page).merge(
-      hits_per_page: MAXIMUM_SUBSCRIPTION_RESULTS,
+      per_page: MAXIMUM_SUBSCRIPTION_RESULTS,
       typo_tolerance: false,
     )
   end

--- a/app/services/search/strategies/algolia.rb
+++ b/app/services/search/strategies/algolia.rb
@@ -6,7 +6,7 @@ class Search::Strategies::Algolia
     @polygons = search_params[:polygons]
     @filters = search_params[:filters]
     @replica = search_params[:replica]
-    @hits_per_page = search_params[:hits_per_page]
+    @per_page = search_params[:per_page]
     @page = search_params[:page]
     @typo_tolerance = search_params[:typo_tolerance]
   end
@@ -33,7 +33,7 @@ class Search::Strategies::Algolia
       insidePolygon: @polygons,
       filters: @filters,
       replica: @replica,
-      hitsPerPage: @hits_per_page,
+      hitsPerPage: @per_page,
       page: @page,
       typoTolerance: @typo_tolerance,
     }.compact

--- a/app/services/search/strategies/database.rb
+++ b/app/services/search/strategies/database.rb
@@ -8,12 +8,12 @@ class Search::Strategies::Database
 
   attr_reader :total_count, :vacancies
 
-  def initialize(page, hits_per_page, jobs_sort)
+  def initialize(page, per_page, jobs_sort)
     @page = page
-    @hits_per_page = hits_per_page
+    @per_page = per_page
     @jobs_sort = jobs_sort
     @order = build_order
-    @vacancies = Vacancy.live.order(@order).page(@page).per(@hits_per_page)
+    @vacancies = Vacancy.live.order(@order).page(@page).per(@per_page)
     @total_count = vacancies.total_count
   end
 

--- a/app/views/vacancies/index.html.slim
+++ b/app/views/vacancies/index.html.slim
@@ -22,7 +22,7 @@
       = render partial: "sorting_options", locals: { search_criteria: @vacancies_search.active_criteria, sort: @vacancies_search.sort_by }
       - unless @vacancies_search.out_of_bounds?
         .govuk-body#vacancies-stats-top aria-label="Number of results"
-          - if @vacancies_search.total_count <= @vacancies_search.hits_per_page
+          - if @vacancies_search.total_count <= @vacancies_search.per_page
             = t("jobs.number_of_results_one_page_html", count: @vacancies_search.total_count)
           - else
             = t("jobs.number_of_results_html", first: @vacancies_search.page_from, last: @vacancies_search.page_to, count: @vacancies_search.total_count)
@@ -50,11 +50,11 @@
               - @vacancies_search.wider_search_suggestions.each do |wider_radius|
                 - if @vacancies_search.location_search.polygon_boundaries.present?
                   li = t(".wider_search_suggestions.suggestion_html",
-                                                        search_link: govuk_link_to(t(".wider_search_suggestions.radius_distance", radius: wider_radius.first), jobs_path(@vacancies_search.params.merge(buffer_radius: wider_radius.first)), class: "wider-radius-gtm"),
+                                                        search_link: govuk_link_to(t(".wider_search_suggestions.radius_distance", radius: wider_radius.first), jobs_path(@vacancies_search.search_criteria.merge(buffer_radius: wider_radius.first)), class: "wider-radius-gtm"),
                                                         count: t(".wider_search_suggestions.results", count: wider_radius.last))
                 - else
                   li = t(".wider_search_suggestions.suggestion_html",
-                                                        search_link: govuk_link_to(t(".wider_search_suggestions.radius_distance", radius: wider_radius.first), jobs_path(@vacancies_search.params.merge(radius: wider_radius.first)), class: "wider-radius-gtm"),
+                                                        search_link: govuk_link_to(t(".wider_search_suggestions.radius_distance", radius: wider_radius.first), jobs_path(@vacancies_search.search_criteria.merge(radius: wider_radius.first)), class: "wider-radius-gtm"),
                                                         count: t(".wider_search_suggestions.results", count: wider_radius.last))
         span.govuk-heading-m
           = t("subscriptions.link.no_search_results.text_html", link_to: govuk_link_to(t("subscriptions.link.no_search_results.link"), new_subscription_path(search_criteria: @vacancies_search.active_criteria, origin: request.original_fullpath), id: "job-alert-link-no-search-results-gtm"))

--- a/spec/services/search/buffer_suggestions_builder_spec.rb
+++ b/spec/services/search/buffer_suggestions_builder_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Search::BufferSuggestionsBuilder do
   describe "#get_buffers_suggestions" do
     let(:search_params) do
       {
-        hits_per_page: 10,
+        per_page: 10,
       }
     end
     let(:buffer_coordinates_five_miles) { [[5.004562496029994090, 56.50833566307333], [5.005710530794815389, 56.5051084208278]] }

--- a/spec/services/search/radius_suggestions_builder_spec.rb
+++ b/spec/services/search/radius_suggestions_builder_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Search::RadiusSuggestionsBuilder do
         keyword: "maths",
         coordinates: Geocoder::DEFAULT_STUB_COORDINATES,
         radius: convert_miles_to_metres(1),
-        hits_per_page: 10,
+        per_page: 10,
         page: 1,
       }
     end

--- a/spec/services/search/strategies/algolia_spec.rb
+++ b/spec/services/search/strategies/algolia_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Search::Strategies::Algolia do
       keyword: "maths",
       coordinates: Geocoder::DEFAULT_STUB_COORDINATES,
       radius: convert_miles_to_metres(10),
-      hits_per_page: 10,
+      per_page: 10,
       page: 1,
     }
   end

--- a/spec/services/search/strategies/database_spec.rb
+++ b/spec/services/search/strategies/database_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
 RSpec.describe Search::Strategies::Database do
-  subject { described_class.new(page, hits_per_page, jobs_sort) }
+  subject { described_class.new(page, per_page, jobs_sort) }
 
   let(:page) { 1 }
-  let(:hits_per_page) { 2 }
+  let(:per_page) { 2 }
   let(:jobs_sort) { "" }
 
   describe "#build_order" do

--- a/spec/services/search/vacancy_search_spec.rb
+++ b/spec/services/search/vacancy_search_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Search::VacancySearch do
-  let(:subject) { described_class.new(form_hash) }
+  let(:subject) { described_class.new(form_hash, page: page, per_page: per_page) }
 
   let(:form_hash) do
     {
@@ -9,8 +9,6 @@ RSpec.describe Search::VacancySearch do
       location: location,
       radius: radius,
       jobs_sort: jobs_sort,
-      per_page: hits_per_page,
-      page: page,
     }.compact
   end
 
@@ -18,13 +16,13 @@ RSpec.describe Search::VacancySearch do
   let(:location) { "" }
   let(:radius) { "" }
   let(:jobs_sort) { "" }
-  let(:hits_per_page) { nil }
+  let(:per_page) { nil }
   let(:page) { 1 }
   let(:filter_query) { Search::FiltersBuilder.new(form_hash).filter_query }
   let!(:location_polygon) { create(:location_polygon, name: "london") }
 
   describe "pagination helpers" do
-    let(:hits_per_page) { 10 }
+    let(:per_page) { 10 }
     let(:page) { 3 }
 
     before do
@@ -87,7 +85,7 @@ RSpec.describe Search::VacancySearch do
             keyword: keyword,
             polygons: location_polygon.polygons["polygons"],
             filters: filter_query,
-            hits_per_page: 10,
+            per_page: 10,
             page: page,
           }
         end
@@ -109,7 +107,7 @@ RSpec.describe Search::VacancySearch do
             coordinates: Geocoder::DEFAULT_STUB_COORDINATES,
             radius: convert_miles_to_metres(radius),
             filters: filter_query,
-            hits_per_page: 10,
+            per_page: 10,
             page: page,
           }
         end
@@ -166,7 +164,7 @@ RSpec.describe Search::VacancySearch do
             keyword: keyword,
             polygons: location_polygon.polygons["polygons"],
             filters: filter_query,
-            hits_per_page: 10,
+            per_page: 10,
             page: page,
           }
         end
@@ -187,7 +185,7 @@ RSpec.describe Search::VacancySearch do
           coordinates: Geocoder::DEFAULT_STUB_COORDINATES,
           radius: convert_miles_to_metres(radius),
           filters: filter_query,
-          hits_per_page: 10,
+          per_page: 10,
           page: page,
         }
       end


### PR DESCRIPTION
- Override keyword method in AlertVacancySearch instead of custom
  initializer
- Rename `params` to `search_criteria`
- Promote `page` and `per_page` to keyword params (they're not really
  search criteria) and remove page from the search form
- Rename `hits_per_page` to `per_page` everywhere for consistency