### PR TITLE
Add email identifier to jobseeker_account_created event

### DIFF
--- a/app/controllers/jobseekers/registrations_controller.rb
+++ b/app/controllers/jobseekers/registrations_controller.rb
@@ -49,7 +49,11 @@ class Jobseekers::RegistrationsController < Devise::RegistrationsController
   end
 
   def after_inactive_sign_up_path_for(resource)
-    request_event.trigger(:jobseeker_account_created, user_anonymised_jobseeker_id: StringAnonymiser.new(resource.id))
+    request_event.trigger(
+      :jobseeker_account_created,
+      user_anonymised_jobseeker_id: StringAnonymiser.new(resource.id),
+      email_identifier: StringAnonymiser.new(resource.email),
+    )
     jobseekers_check_your_email_path
   end
 

--- a/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "Jobseekers can sign up to an account" do
       expect(page).to have_content("There is a problem")
       expect { sign_up_jobseeker }.to have_triggered_event(:jobseeker_account_created).with_data(
         user_anonymised_jobseeker_id: anything,
+        email_identifier: anything,
       ).and change { delivered_emails.count }.by(1)
       expect(current_path).to eq(jobseekers_check_your_email_path)
     end


### PR DESCRIPTION
This will help @stevenleggdfe link subscription events to jobseeker accounts