### PR TITLE
Include search criteria info in unsubscribe/job alert feedback

### DIFF
--- a/app/controllers/concerns/feedback_event_concerns.rb
+++ b/app/controllers/concerns/feedback_event_concerns.rb
@@ -1,11 +1,11 @@
 module FeedbackEventConcerns
   extend ActiveSupport::Concern
 
-  ANONYMISE_THESE_PARAMS = %w[jobseeker_id publisher_id email].freeze
+  ANONYMISE_THESE_PARAMS = %w[email jobseeker_id publisher_id subscription_id].freeze
 
   def trigger_feedback_provided_event
     feedback_data = feedback_attributes.to_h.each_with_object({}) do |(key, value), params|
-      if ANONYMISE_THESE_PARAMS.include?(key)
+      if ANONYMISE_THESE_PARAMS.include?(key.to_s)
         params["anonymised_#{key}"] = StringAnonymiser.new(value)
       else
         params[key] = value

--- a/app/controllers/concerns/feedback_event_concerns.rb
+++ b/app/controllers/concerns/feedback_event_concerns.rb
@@ -1,14 +1,19 @@
 module FeedbackEventConcerns
   extend ActiveSupport::Concern
 
-  ANONYMISE_THESE_PARAMS = %w[email jobseeker_id publisher_id subscription_id].freeze
+  ANONYMISED_ATTRIBUTES = {
+    email: "email_identifier",
+    jobseeker_id: "jobseeker_identifier",
+    publisher_id: "publisher_identifier",
+    subscription_id: "subscription_identifier",
+  }.freeze
 
   def trigger_feedback_provided_event
-    feedback_data = feedback_attributes.to_h.each_with_object({}) do |(key, value), params|
-      if ANONYMISE_THESE_PARAMS.include?(key.to_s)
-        params["anonymised_#{key}"] = StringAnonymiser.new(value)
+    feedback_data = feedback_attributes.to_h.each_with_object({}) do |(key, value), attributes|
+      if ANONYMISED_ATTRIBUTES.include?(key.to_sym)
+        attributes[ANONYMISED_ATTRIBUTES[key.to_sym]] = StringAnonymiser.new(value)
       else
-        params[key] = value
+        attributes[key] = value
       end
     end
     feedback_data[:recaptcha_score] = recaptcha_reply["score"] unless recaptcha_reply&.dig("score").blank?

--- a/app/controllers/jobseekers/job_alert_feedbacks_controller.rb
+++ b/app/controllers/jobseekers/job_alert_feedbacks_controller.rb
@@ -40,13 +40,16 @@ class Jobseekers::JobAlertFeedbacksController < ApplicationController
     # `trigger_feedback_provided_event`, which we use to create Events, relies on feedback_attributes.
     # This method allows events to be created for either type of action. Here felt like the best place for this logic,
     # since job alert feedback is the only feedback type that has >1 action.
-    attributes = case action_name
-                 when "new"
-                   job_alert_email_link_params
-                 when "update"
-                   further_feedback_form_params
-                 end
-    attributes.merge(feedback_type: "job_alert", subscription_id: @subscription.id)
+    case action_name
+    when "new"
+      feedback_attributes_base.merge(job_alert_email_link_params)
+    when "update"
+      feedback_attributes_base.merge(further_feedback_form_params)
+    end
+  end
+
+  def feedback_attributes_base
+    { feedback_type: "job_alert", search_criteria: @subscription.search_criteria, subscription_id: @subscription.id }
   end
 
   def job_alert_email_link_params

--- a/app/controllers/jobseekers/unsubscribe_feedbacks_controller.rb
+++ b/app/controllers/jobseekers/unsubscribe_feedbacks_controller.rb
@@ -29,7 +29,11 @@ class Jobseekers::UnsubscribeFeedbacksController < ApplicationController
   end
 
   def feedback_attributes
-    unsubscribe_feedback_form_params.merge(feedback_type: "unsubscribe", subscription_id: subscription_id)
+    unsubscribe_feedback_form_params.merge(
+      feedback_type: "unsubscribe",
+      subscription_id: subscription_id,
+      search_criteria: @subscription.search_criteria,
+    )
   end
 
   def unsubscribe_feedback_form_params

--- a/lib/tasks/copy_feedback_tables_into_one_consolidated_table.rake
+++ b/lib/tasks/copy_feedback_tables_into_one_consolidated_table.rake
@@ -10,8 +10,8 @@ namespace :consolidate_feedback_tables do
       feedback_data = feedback.attributes.map.each { |key, value|
         next if value.blank? || %w[id updated_at].include?(key) # updated_at will be the time this task is run
 
-        if FeedbackEventConcerns::ANONYMISE_THESE_PARAMS.include?(key)
-          ["anonymised_#{key}", StringAnonymiser.new(value)]
+        if FeedbackEventConcerns::ANONYMISED_ATTRIBUTES.include?(key.to_sym)
+          [attributes[ANONYMISED_ATTRIBUTES[key.to_sym]], StringAnonymiser.new(value)]
         else
           [key, value]
         end

--- a/spec/controllers/nqt_job_alerts_controller_spec.rb
+++ b/spec/controllers/nqt_job_alerts_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe NqtJobAlertsController, type: :controller, recaptcha: true do
         email_identifier: anonymised_form_of("test@gmail.com"),
         frequency: "daily",
         subscription_identifier: anything,
-        recaptcha_score: anything,
+        recaptcha_score: 0.9,
         search_criteria: /^{.*}$/,
       )
     end

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe SubscriptionsController, type: :controller, recaptcha: true do
         email_identifier: anonymised_form_of("foo@email.com"),
         frequency: "daily",
         subscription_identifier: anything,
-        recaptcha_score: anything,
+        recaptcha_score: 0.9,
         search_criteria: /^{.*}$/,
         origin: "/some/where",
       )

--- a/spec/support/matchers/json_including.rb
+++ b/spec/support/matchers/json_including.rb
@@ -1,0 +1,8 @@
+RSpec::Matchers.define :json_including do |expected_as_hash|
+  match do |actual|
+    parsed_actual = JSON.parse(actual)
+    expected_as_hash.each do |key, value|
+      return false unless parsed_actual[key] == value
+    end
+  end
+end

--- a/spec/system/general_feedback_spec.rb
+++ b/spec/system/general_feedback_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Giving general feedback for the service", recaptcha: true do
 
       expect { click_button I18n.t("buttons.submit_feedback") }.to have_triggered_event(:feedback_provided)
         .with_data(comment: comment,
-                   anonymised_email: anything,
+                   email_identifier: anything,
                    feedback_type: "general",
                    recaptcha_score: 0.9,
                    user_participation_response: "interested",

--- a/spec/system/hiring_staff_can_give_vacancy_publisher_feedback_spec.rb
+++ b/spec/system/hiring_staff_can_give_vacancy_publisher_feedback_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "Hiring staff can give vacancy publisher feedback" do
 
       expect { click_on I18n.t("buttons.submit_feedback") }.to have_triggered_event(:feedback_provided)
         .with_data(comment: comment,
-                   anonymised_email: anything,
+                   email_identifier: anything,
                    feedback_type: "vacancy_publisher",
                    user_participation_response: "interested",
                    vacancy_id: published_job.id)

--- a/spec/system/jobseekers_can_give_job_alert_feedback_spec.rb
+++ b/spec/system/jobseekers_can_give_job_alert_feedback_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "A jobseeker can give feedback on a job alert", recaptcha: true d
           .to have_triggered_event(:feedback_provided)
           .with_data(feedback_type: "job_alert",
                      subscription_id: subscription.id,
-                     search_criteria: search_criteria.to_json,
+                     search_criteria: json_including(subscription.search_criteria),
                      job_alert_vacancy_ids: job_alert_vacancy_ids,
                      relevant_to_user: relevant_to_user.to_s)
       end
@@ -82,7 +82,7 @@ RSpec.describe "A jobseeker can give feedback on a job alert", recaptcha: true d
           .to have_triggered_event(:feedback_provided)
                 .with_data(feedback_type: "job_alert",
                            subscription_id: subscription.id,
-                           search_criteria: search_criteria.to_json,
+                           search_criteria: json_including(subscription.search_criteria),
                            job_alert_vacancy_ids: job_alert_vacancy_ids,
                            relevant_to_user: relevant_to_user.to_s)
       end
@@ -108,6 +108,7 @@ RSpec.describe "A jobseeker can give feedback on a job alert", recaptcha: true d
           .to have_triggered_event(:feedback_provided)
                 .with_data(recaptcha_score: 0.9,
                            comment: comment,
+                           search_criteria: json_including(subscription.search_criteria),
                            subscription_id: subscription.id,
                            feedback_type: "job_alert")
       end

--- a/spec/system/jobseekers_can_give_job_alert_feedback_spec.rb
+++ b/spec/system/jobseekers_can_give_job_alert_feedback_spec.rb
@@ -50,11 +50,11 @@ RSpec.describe "A jobseeker can give feedback on a job alert", recaptcha: true d
       it "triggers a RequestEvent of type 'feedback_provided'" do
         expect { follow_the_link_in_the_job_alert_email }
           .to have_triggered_event(:feedback_provided)
-          .with_data(feedback_type: "job_alert",
-                     subscription_id: subscription.id,
-                     search_criteria: json_including(subscription.search_criteria),
+          .with_data(anonymised_subscription_id: anything,
+                     feedback_type: "job_alert",
                      job_alert_vacancy_ids: job_alert_vacancy_ids,
-                     relevant_to_user: relevant_to_user.to_s)
+                     relevant_to_user: relevant_to_user.to_s,
+                     search_criteria: json_including(subscription.search_criteria))
       end
     end
 
@@ -80,11 +80,11 @@ RSpec.describe "A jobseeker can give feedback on a job alert", recaptcha: true d
       it "triggers a RequestEvent of type 'feedback_provided'" do
         expect { follow_the_link_in_the_job_alert_email }
           .to have_triggered_event(:feedback_provided)
-                .with_data(feedback_type: "job_alert",
-                           subscription_id: subscription.id,
-                           search_criteria: json_including(subscription.search_criteria),
+                .with_data(anonymised_subscription_id: anything,
+                           feedback_type: "job_alert",
                            job_alert_vacancy_ids: job_alert_vacancy_ids,
-                           relevant_to_user: relevant_to_user.to_s)
+                           relevant_to_user: relevant_to_user.to_s,
+                           search_criteria: json_including(subscription.search_criteria))
       end
     end
 
@@ -106,11 +106,11 @@ RSpec.describe "A jobseeker can give feedback on a job alert", recaptcha: true d
       it "triggers a RequestEvent of type 'feedback_provided'" do
         expect { click_button I18n.t("buttons.submit") }
           .to have_triggered_event(:feedback_provided)
-                .with_data(recaptcha_score: 0.9,
+                .with_data(anonymised_subscription_id: anything,
                            comment: comment,
-                           search_criteria: json_including(subscription.search_criteria),
-                           subscription_id: subscription.id,
-                           feedback_type: "job_alert")
+                           feedback_type: "job_alert",
+                           recaptcha_score: 0.9,
+                           search_criteria: json_including(subscription.search_criteria))
       end
 
       context "when recaptcha is invalid" do

--- a/spec/system/jobseekers_can_give_job_alert_feedback_spec.rb
+++ b/spec/system/jobseekers_can_give_job_alert_feedback_spec.rb
@@ -50,11 +50,13 @@ RSpec.describe "A jobseeker can give feedback on a job alert", recaptcha: true d
       it "triggers a RequestEvent of type 'feedback_provided'" do
         expect { follow_the_link_in_the_job_alert_email }
           .to have_triggered_event(:feedback_provided)
-          .with_data(anonymised_subscription_id: anything,
-                     feedback_type: "job_alert",
-                     job_alert_vacancy_ids: job_alert_vacancy_ids,
-                     relevant_to_user: relevant_to_user.to_s,
-                     search_criteria: json_including(subscription.search_criteria))
+          .with_data(
+            feedback_type: "job_alert",
+            job_alert_vacancy_ids: job_alert_vacancy_ids,
+            relevant_to_user: relevant_to_user.to_s,
+            search_criteria: json_including(subscription.search_criteria),
+            subscription_identifier: anything,
+          )
       end
     end
 
@@ -80,11 +82,13 @@ RSpec.describe "A jobseeker can give feedback on a job alert", recaptcha: true d
       it "triggers a RequestEvent of type 'feedback_provided'" do
         expect { follow_the_link_in_the_job_alert_email }
           .to have_triggered_event(:feedback_provided)
-                .with_data(anonymised_subscription_id: anything,
-                           feedback_type: "job_alert",
-                           job_alert_vacancy_ids: job_alert_vacancy_ids,
-                           relevant_to_user: relevant_to_user.to_s,
-                           search_criteria: json_including(subscription.search_criteria))
+                .with_data(
+                  feedback_type: "job_alert",
+                  job_alert_vacancy_ids: job_alert_vacancy_ids,
+                  relevant_to_user: relevant_to_user.to_s,
+                  search_criteria: json_including(subscription.search_criteria),
+                  subscription_identifier: anything,
+                )
       end
     end
 
@@ -106,11 +110,13 @@ RSpec.describe "A jobseeker can give feedback on a job alert", recaptcha: true d
       it "triggers a RequestEvent of type 'feedback_provided'" do
         expect { click_button I18n.t("buttons.submit") }
           .to have_triggered_event(:feedback_provided)
-                .with_data(anonymised_subscription_id: anything,
-                           comment: comment,
-                           feedback_type: "job_alert",
-                           recaptcha_score: 0.9,
-                           search_criteria: json_including(subscription.search_criteria))
+                .with_data(
+                  comment: comment,
+                  feedback_type: "job_alert",
+                  recaptcha_score: 0.9,
+                  search_criteria: json_including(subscription.search_criteria),
+                  subscription_identifier: anything,
+                )
       end
 
       context "when recaptcha is invalid" do

--- a/spec/system/jobseekers_can_unsubscribe_from_subscriptions_spec.rb
+++ b/spec/system/jobseekers_can_unsubscribe_from_subscriptions_spec.rb
@@ -34,10 +34,11 @@ RSpec.describe "A jobseeker can unsubscribe from subscriptions" do
 
       expect { click_on I18n.t("buttons.submit_feedback") }
         .to have_triggered_event(:feedback_provided)
-        .with_data(unsubscribe_reason: "other_reason",
+        .with_data(comment: "Eggs",
+                   feedback_type: "unsubscribe",
                    other_unsubscribe_reason_comment: "Spam",
-                   comment: "Eggs",
-                   feedback_type: "unsubscribe")
+                   search_criteria: json_including(subscription.search_criteria),
+                   unsubscribe_reason: "other_reason")
 
       click_on I18n.t("jobseekers.unsubscribe_feedbacks.confirmation.new_search_link")
 

--- a/spec/system/jobseekers_can_unsubscribe_from_subscriptions_spec.rb
+++ b/spec/system/jobseekers_can_unsubscribe_from_subscriptions_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "A jobseeker can unsubscribe from subscriptions" do
                    feedback_type: "unsubscribe",
                    other_unsubscribe_reason_comment: "Spam",
                    search_criteria: json_including(subscription.search_criteria),
-                   anonymised_subscription_id: anything,
+                   subscription_identifier: anything,
                    unsubscribe_reason: "other_reason")
 
       click_on I18n.t("jobseekers.unsubscribe_feedbacks.confirmation.new_search_link")

--- a/spec/system/jobseekers_can_unsubscribe_from_subscriptions_spec.rb
+++ b/spec/system/jobseekers_can_unsubscribe_from_subscriptions_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe "A jobseeker can unsubscribe from subscriptions" do
                    feedback_type: "unsubscribe",
                    other_unsubscribe_reason_comment: "Spam",
                    search_criteria: json_including(subscription.search_criteria),
+                   anonymised_subscription_id: anything,
                    unsubscribe_reason: "other_reason")
 
       click_on I18n.t("jobseekers.unsubscribe_feedbacks.confirmation.new_search_link")


### PR DESCRIPTION
This info is handy to include, partly because the search criteria may be edited
after the feedback is submitted, and partly for convenience.

Added matcher to check two json strings match which are not necessarily in the same order,
since hashes can vary their orders. Named by analogy with existing hash_including method.
