### PR TITLE
[TEVA-1980] Add string match Statuscake test

### DIFF
--- a/terraform/app/modules/statuscake/main.tf
+++ b/terraform/app/modules/statuscake/main.tf
@@ -2,11 +2,11 @@ resource statuscake_test alert {
   for_each      = var.statuscake_alerts
   website_name  = each.value.website_name
   website_url   = each.value.website_url
-  test_type     = each.value.test_type
-  check_rate    = each.value.check_rate
+  test_type     = "HTTP"
+  check_rate    = 30
   contact_group = each.value.contact_group
-  trigger_rate  = each.value.trigger_rate
-  find_string   = each.value.find_string
-  do_not_find   = each.value.do_not_find
+  trigger_rate  = 0
+  find_string   = lookup(each.value, "find_string", null)
+  do_not_find   = lookup(each.value, "do_not_find", false)
   confirmations = 1
 }

--- a/terraform/app/modules/statuscake/main.tf
+++ b/terraform/app/modules/statuscake/main.tf
@@ -8,5 +8,7 @@ resource statuscake_test alert {
   trigger_rate  = each.value.trigger_rate
   custom_header = each.value.custom_header
   status_codes  = each.value.status_codes
+  find_string   = each.value.find_string
+  do_not_find   = each.value.do_not_find
   confirmations = 1
 }

--- a/terraform/app/modules/statuscake/main.tf
+++ b/terraform/app/modules/statuscake/main.tf
@@ -6,8 +6,6 @@ resource statuscake_test alert {
   check_rate    = each.value.check_rate
   contact_group = each.value.contact_group
   trigger_rate  = each.value.trigger_rate
-  custom_header = each.value.custom_header
-  status_codes  = each.value.status_codes
   find_string   = each.value.find_string
   do_not_find   = each.value.do_not_find
   confirmations = 1

--- a/terraform/app/modules/statuscake/variables.tf
+++ b/terraform/app/modules/statuscake/variables.tf
@@ -13,8 +13,6 @@ variable statuscake_alerts {
     check_rate    = string
     contact_group = list(string)
     trigger_rate  = string
-    custom_header = string
-    status_codes  = string
     find_string   = string
     do_not_find   = bool
   }))

--- a/terraform/app/modules/statuscake/variables.tf
+++ b/terraform/app/modules/statuscake/variables.tf
@@ -6,14 +6,4 @@ variable service_name {
 
 variable statuscake_alerts {
   description = "Define Statuscake alerts with the attributes below"
-  type = map(object({
-    website_name  = string
-    website_url   = string
-    test_type     = string
-    check_rate    = string
-    contact_group = list(string)
-    trigger_rate  = string
-    find_string   = string
-    do_not_find   = bool
-  }))
 }

--- a/terraform/app/modules/statuscake/variables.tf
+++ b/terraform/app/modules/statuscake/variables.tf
@@ -15,5 +15,7 @@ variable statuscake_alerts {
     trigger_rate  = string
     custom_header = string
     status_codes  = string
+    find_string   = string
+    do_not_find   = bool
   }))
 }

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -127,8 +127,6 @@ variable statuscake_alerts {
     check_rate    = string
     contact_group = list(string)
     trigger_rate  = string
-    custom_header = string
-    status_codes  = string
     find_string   = string
     do_not_find   = bool
   }))

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -129,6 +129,8 @@ variable statuscake_alerts {
     trigger_rate  = string
     custom_header = string
     status_codes  = string
+    find_string   = string
+    do_not_find   = bool
   }))
   default = {}
 }

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -120,17 +120,7 @@ variable paas_worker_app_memory {
 # Statuscake
 variable statuscake_alerts {
   description = "Define Statuscake alerts with the attributes below"
-  type = map(object({
-    website_name  = string
-    website_url   = string
-    test_type     = string
-    check_rate    = string
-    contact_group = list(string)
-    trigger_rate  = string
-    find_string   = string
-    do_not_find   = bool
-  }))
-  default = {}
+  default     = {}
 }
 
 locals {

--- a/terraform/workspace-variables/production.tfvars
+++ b/terraform/workspace-variables/production.tfvars
@@ -41,30 +41,18 @@ statuscake_alerts = {
   "tvsprod" = {
     website_name  = "teaching-vacancies-production"
     website_url   = "https://teaching-vacancies.service.gov.uk/check"
-    test_type     = "HTTP"
-    check_rate    = "30"
     contact_group = [183741]
-    trigger_rate  = "0"
-    find_string   = ""
-    do_not_find   = false
   }
   "stringmatch" = {
     website_name  = "teaching-vacancies-production"
     website_url   = "https://teaching-vacancies.service.gov.uk"
-    test_type     = "HTTP"
-    check_rate    = "30"
     contact_group = [183741]
-    trigger_rate  = "0"
     find_string   = "create an account"
-    do_not_find   = false
   }
   "PaaS500String" = {
     website_name  = "teaching-vacancies-production"
     website_url   = "https://teaching-vacancies.service.gov.uk"
-    test_type     = "HTTP"
-    check_rate    = "30"
     contact_group = [183741]
-    trigger_rate  = "0"
     find_string   = "500 Internal Server Error"
     do_not_find   = true
   }

--- a/terraform/workspace-variables/production.tfvars
+++ b/terraform/workspace-variables/production.tfvars
@@ -45,8 +45,6 @@ statuscake_alerts = {
     check_rate    = "30"
     contact_group = [183741]
     trigger_rate  = "0"
-    custom_header = "{\"Content-Type\": \"application/x-www-form-urlencoded\"}"
-    status_codes  = "204,205,206,303,400,401,403,404,405,406,408,410,413,444,429,494,495,496,499,500,501,502,503,504,505,506,507,508,509,510,511,521,522,523,524,520,598,599"
     find_string   = ""
     do_not_find   = false
   }
@@ -57,8 +55,6 @@ statuscake_alerts = {
     check_rate    = "30"
     contact_group = [183741]
     trigger_rate  = "0"
-    custom_header = "{\"Content-Type\": \"application/x-www-form-urlencoded\"}"
-    status_codes  = null
     find_string   = "create an account"
     do_not_find   = false
   }
@@ -69,8 +65,6 @@ statuscake_alerts = {
     check_rate    = "30"
     contact_group = [183741]
     trigger_rate  = "0"
-    custom_header = "{\"Content-Type\": \"application/x-www-form-urlencoded\"}"
-    status_codes  = null
     find_string   = "500 Internal Server Error"
     do_not_find   = true
   }

--- a/terraform/workspace-variables/production.tfvars
+++ b/terraform/workspace-variables/production.tfvars
@@ -47,5 +47,31 @@ statuscake_alerts = {
     trigger_rate  = "0"
     custom_header = "{\"Content-Type\": \"application/x-www-form-urlencoded\"}"
     status_codes  = "204,205,206,303,400,401,403,404,405,406,408,410,413,444,429,494,495,496,499,500,501,502,503,504,505,506,507,508,509,510,511,521,522,523,524,520,598,599"
+    find_string   = ""
+    do_not_find   = false
+  }
+  "stringmatch" = {
+    website_name  = "teaching-vacancies-production"
+    website_url   = "https://teaching-vacancies.service.gov.uk"
+    test_type     = "HTTP"
+    check_rate    = "30"
+    contact_group = [183741]
+    trigger_rate  = "0"
+    custom_header = "{\"Content-Type\": \"application/x-www-form-urlencoded\"}"
+    status_codes  = null
+    find_string   = "create an account"
+    do_not_find   = false
+  }
+  "PaaS500String" = {
+    website_name  = "teaching-vacancies-production"
+    website_url   = "https://teaching-vacancies.service.gov.uk"
+    test_type     = "HTTP"
+    check_rate    = "30"
+    contact_group = [183741]
+    trigger_rate  = "0"
+    custom_header = "{\"Content-Type\": \"application/x-www-form-urlencoded\"}"
+    status_codes  = null
+    find_string   = "500 Internal Server Error"
+    do_not_find   = true
   }
 }

--- a/terraform/workspace-variables/workspace.tfvars.example
+++ b/terraform/workspace-variables/workspace.tfvars.example
@@ -35,17 +35,15 @@ paas_worker_app_instances           = 2
 paas_worker_app_memory              = 512
 
 # Statuscake
-statuscake_alerts =  {
-    "tvsstg" = {
-	  website_name  = "teaching-vacancies-staging"
-	  website_url   = "https://teaching-vacancies-staging.london.cloudapps.digital/check"
-	  test_type     = "HTTP"
-	  check_rate    = "300"
-	  contact_group = [123456]
-	  trigger_rate  = "0"
-	  custom_header = "{\"Content-Type\": \"application/x-www-form-urlencoded\"}"
-	  status_codes  = "204,205,206,303,400,401,403,404,405,406,408,410,413,444,429,494,495,496,499,500,501,502,503,504,505,506,507,508,509,510,511,521,522,523,524,520,598,599"
+statuscake_alerts = {
+  "tvsstg" = {
+    website_name  = "teaching-vacancies-staging"
+    website_url   = "https://teaching-vacancies-staging.london.cloudapps.digital/check"
+    test_type     = "HTTP"
+    check_rate    = "300"
+    contact_group = [123456]
+    trigger_rate  = "0"
     find_string   = null
     do_not_find   = false
-    }
+  }
 }

--- a/terraform/workspace-variables/workspace.tfvars.example
+++ b/terraform/workspace-variables/workspace.tfvars.example
@@ -45,5 +45,7 @@ statuscake_alerts =  {
 	  trigger_rate  = "0"
 	  custom_header = "{\"Content-Type\": \"application/x-www-form-urlencoded\"}"
 	  status_codes  = "204,205,206,303,400,401,403,404,405,406,408,410,413,444,429,494,495,496,499,500,501,502,503,504,505,506,507,508,509,510,511,521,522,523,524,520,598,599"
+    find_string   = null
+    do_not_find   = false
     }
 }

--- a/terraform/workspace-variables/workspace.tfvars.example
+++ b/terraform/workspace-variables/workspace.tfvars.example
@@ -38,12 +38,13 @@ paas_worker_app_memory              = 512
 statuscake_alerts = {
   "tvsstg" = {
     website_name  = "teaching-vacancies-staging"
-    website_url   = "https://teaching-vacancies-staging.london.cloudapps.digital/check"
-    test_type     = "HTTP"
-    check_rate    = "300"
-    contact_group = [123456]
-    trigger_rate  = "0"
-    find_string   = null
-    do_not_find   = false
+    website_url   = "https://staging.teaching-vacancies.service.gov.uk/check"
+    contact_group = [183741]
+  }
+  "stringmatch" = {
+    website_name  = "teaching-vacancies-staging"
+    website_url   = "https://staging.teaching-vacancies.service.gov.uk"
+    contact_group = [183741]
+    find_string   = "create an account"
   }
 }


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1980

## Changes in this PR:

- As per [Statuscake documentation](https://github.com/StatusCakeDev/terraform-provider-statuscake/blob/master/website/docs/r/test.html.markdown), added string matching support to Statuscake Terraform module.
- Added two string matching tests against the homepage
  - For the absence of "create an account", which should be present
  - For the presence of "500 Internal Server Error" which was served by the PaaS platform during the P1 incident
