### PR TITLE
Add jobs search system spec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,6 +87,7 @@ group :test do
   gem "selenium-webdriver"
   gem "shoulda-matchers"
   gem "simplecov", "<= 0.17.1", require: false # Newer versions of simplecov are not compatible with Sonarqube
+  gem "vcr"
   gem "webmock"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -529,6 +529,7 @@ GEM
     validate_url (1.0.13)
       activemodel (>= 3.0.0)
       public_suffix
+    vcr (6.0.0)
     view_component (2.24.0)
       activesupport (>= 5.0.0, < 7.0)
     warden (1.2.9)
@@ -638,6 +639,7 @@ DEPENDENCIES
   spring-watcher-listen
   tzinfo-data
   validate_url
+  vcr
   view_component
   web-console
   webmock

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -1,7 +1,7 @@
 module Indexable
   extend ActiveSupport::Concern
 
-  INDEX_NAME = [Rails.env.test? ? nil : ENV.fetch("ALGOLIA_INDEX_PREFIX", nil), DOMAIN, Vacancy].compact.join("-").freeze
+  INDEX_NAME = [Rails.configuration.algolia_index_prefix, DOMAIN, Vacancy].compact.join("-").freeze
 
   included do
     include AlgoliaSearch

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -1,14 +1,14 @@
 module Indexable
   extend ActiveSupport::Concern
 
-  INDEX_NAME = [ENV["ALGOLIA_INDEX_PREFIX"], DOMAIN, Vacancy].compact.join("-").freeze
+  INDEX_NAME = [Rails.env.test? ? nil : ENV.fetch("ALGOLIA_INDEX_PREFIX", nil), DOMAIN, Vacancy].compact.join("-").freeze
 
   included do
     include AlgoliaSearch
 
     scope :unindexed, (-> { live.where(initially_indexed: false) })
 
-    algoliasearch index_name: INDEX_NAME, auto_index: true, auto_remove: true, if: :listed? do
+    algoliasearch index_name: INDEX_NAME, auto_index: !Rails.env.test?, auto_remove: !Rails.env.test?, if: :listed? do
       attributes :education_phases, :job_roles, :job_title, :parent_organisation_name, :salary, :subjects, :working_patterns, :_geoloc
 
       attribute :expires_at do

--- a/app/services/search/strategies/algolia.rb
+++ b/app/services/search/strategies/algolia.rb
@@ -15,11 +15,11 @@ class Search::Strategies::Algolia
     @vacancies ||= Vacancy.includes(organisation_vacancies: :organisation).search(@keyword, search_arguments)
   rescue Algolia::AlgoliaProtocolError => e
     Rollbar.error("Algolia search error", details: e, search_arguments: search_arguments)
-    @vacancies = nil
+    @vacancies = Vacancy.none
   end
 
   def total_count
-    return 0 unless vacancies
+    return 0 if vacancies.none?
 
     vacancies.raw_answer["nbHits"]
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -67,5 +67,7 @@ module TeacherVacancyService
     end
 
     config.ab_tests = config_for(:ab_tests)
+
+    config.algolia_index_prefix = ENV.fetch("ALGOLIA_INDEX_PREFIX", nil)
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -48,6 +48,9 @@ Rails.application.configure do
   config.cache_store = :null_store
 
   config.middleware.use RackSessionAccess::Middleware
+
+  # Algolia index prefix must be nil in order for VCR system specs to run
+  config.algolia_index_prefix = nil
 end
 
 # Avoid OmniAuth output in tests:

--- a/config/initializers/algoliasearch.rb
+++ b/config/initializers/algoliasearch.rb
@@ -1,5 +1,5 @@
 AlgoliaSearch.configuration = {
-  application_id: ENV.fetch("ALGOLIA_APP_ID", "Placeholder"),
-  api_key: ENV.fetch("ALGOLIA_WRITE_API_KEY", "Placeholder"),
+  application_id: Rails.env.test? ? "Placeholder" : ENV.fetch("ALGOLIA_APP_ID", "Placeholder"),
+  api_key: Rails.env.test? ? "Placeholder" : ENV.fetch("ALGOLIA_WRITE_API_KEY", "Placeholder"),
   pagination_backend: :kaminari,
 }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -51,7 +51,7 @@ trust_one = FactoryBot.create(:trust,
                               town: "Farnham",
                               county: "Not recorded",
                               postcode: "GU9 8UG",
-                              geolocation: "(51.2023732521965,0.814476304733643)")
+                              geolocation: "(51.2023732521965,-0.814476304733643)")
 
 local_authority_one = FactoryBot.create(:local_authority,
                                         name: "Southampton",
@@ -76,6 +76,15 @@ FactoryBot.create(:vacancy,
                   working_patterns: %w[part_time],
                   salary: "£35,000",
                   organisation_vacancies_attributes: [{ organisation: school_two }])
+
+FactoryBot.create(:vacancy,
+                  id: "7bfadb84-cf30-4121-88bd-a9f958440cc9",
+                  job_title: "Maths Teacher 2",
+                  subjects: %w[Maths],
+                  working_patterns: %w[full_time],
+                  salary: "£35,000",
+                  expires_on: Faker::Time.forward(days: 7),
+                  organisation_vacancies_attributes: [{ organisation: school_one }])
 
 FactoryBot.create(:vacancy,
                   id: "9910d184-5686-4ffc-9322-69aa150c19d3",

--- a/spec/fixtures/vcr/algoliasearch.yml
+++ b/spec/fixtures/vcr/algoliasearch.yml
@@ -1,0 +1,415 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://placeholder-dsn.algolia.net/1/indexes/localhost:3000-Vacancy_publish_on_desc/settings?getVersion=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - Algolia for Ruby (1.27.5); Ruby (2.7.2); Algolia for Rails (1.25.0); Rails
+        (6.1.2.1)
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 12 Feb 2021 10:55:31 GMT
+      X-Algolia-Api-Key:
+      - Placeholder
+      X-Algolia-Application-Id:
+      - Placeholder
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 12 Feb 2021 10:55:32 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Accept-Encoding:
+      - deflate, gzip
+      Cache-Control:
+      - no-store
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Disposition:
+      - inline; filename=a.txt
+      Content-Encoding:
+      - gzip
+    body:
+      encoding: UTF-8
+      string: '{"minWordSizefor1Typo":4,"minWordSizefor2Typos":8,"hitsPerPage":20,"maxValuesPerFacet":100,"version":1,"attributesToIndex":null,"numericAttributesToIndex":null,"attributesToRetrieve":null,"unretrievableAttributes":null,"optionalWords":null,"primary":"localhost:3000-Vacancy","attributesForFaceting":["job_roles","working_patterns","education_phases","subjects"],"attributesToSnippet":null,"attributesToHighlight":null,"paginationLimitedTo":1000,"attributeForDistinct":null,"exactOnSingleWordQuery":"attribute","ranking":["desc(publication_date_timestamp)"],"customRanking":null,"separatorsToIndex":"","removeWordsIfNoResults":"none","queryType":"prefixLast","highlightPreTag":"<em>","highlightPostTag":"</em>","snippetEllipsisText":"","alternativesAsExact":["ignorePlurals","singleWordSynonym"]}'
+  recorded_at: Fri, 12 Feb 2021 10:55:32 GMT
+- request:
+    method: put
+    uri: https://placeholder.algolia.net/1/indexes/localhost:3000-Vacancy_publish_on_desc/settings
+    body:
+      encoding: UTF-8
+      string: '{"attributesForFaceting":["job_roles","working_patterns","education_phases","subjects"],"ranking":["desc(publication_date_timestamp)"]}'
+    headers:
+      User-Agent:
+      - Algolia for Ruby (1.27.5); Ruby (2.7.2); Algolia for Rails (1.25.0); Rails
+        (6.1.2.1)
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 12 Feb 2021 10:55:32 GMT
+      X-Algolia-Api-Key:
+      - Placeholder
+      X-Algolia-Application-Id:
+      - Placeholder
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 12 Feb 2021 10:55:32 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '62'
+      Connection:
+      - keep-alive
+      Accept-Encoding:
+      - deflate, gzip
+      Cache-Control:
+      - no-store
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Disposition:
+      - inline; filename=a.txt
+    body:
+      encoding: UTF-8
+      string: '{"updatedAt":"2021-02-12T10:55:32.334Z","taskID":174554616002}'
+  recorded_at: Fri, 12 Feb 2021 10:55:32 GMT
+- request:
+    method: post
+    uri: https://placeholder-dsn.algolia.net/1/indexes/localhost:3000-Vacancy_publish_on_desc/query
+    body:
+      encoding: UTF-8
+      string: '{"params":"filters=%28publication_date_timestamp+%3C%3D+1613088000+AND+expires_at_timestamp+%3E+1613127331%29\u0026hitsPerPage=10\u0026page=0\u0026query=Teacher"}'
+    headers:
+      User-Agent:
+      - Algolia for Ruby (1.27.5); Ruby (2.7.2); Algolia for Rails (1.25.0); Rails
+        (6.1.2.1)
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 12 Feb 2021 10:55:32 GMT
+      X-Algolia-Api-Key:
+      - Placeholder
+      X-Algolia-Application-Id:
+      - Placeholder
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 12 Feb 2021 10:55:32 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Alg-Pt:
+      - '1'
+      Accept-Encoding:
+      - deflate, gzip
+      Cache-Control:
+      - no-store
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Disposition:
+      - inline; filename=a.txt
+      Content-Encoding:
+      - gzip
+    body:
+      encoding: UTF-8
+      string: '{"hits":[{"education_phases":["secondary"],"job_roles":["teacher"],"job_title":"Geography
+        Teacher","parent_organisation_name":"Bexleyheath Academy","salary":"£25,000","subjects":["Geography"],"working_patterns":["part_time","job_share"],"_geoloc":[{"lat":51.4578146490981,"lng":0.146065490118642}],"expires_at":"21
+        February 2021 at 8:15 am","expires_at_timestamp":1613895300,"job_roles_for_display":"Teacher","job_summary":"Cupiditate
+        itaque deleniti. Perspiciatis nam at. Optio maiores non. Doloremque modi sapiente.","last_updated_at":1612957698,"organisations":{"names":["Bexleyheath
+        Academy"],"counties":["Kent"],"detailed_school_types":["Academy sponsor led"],"group_type":[],"local_authorities_within":[],"religious_characters":[],"regions":["London"],"school_types":["Academy"],"towns":["Bexleyheath"]},"permalink":"geography-teacher","publication_date":"10
+        February 2021","publication_date_timestamp":1612915200,"start_date":"10 February
+        2022","start_date_timestamp":1644451200,"subjects_for_display":"Geography","working_patterns_for_display":"Will
+        consider part-time, job share","objectID":"e750baf6-cc9a-4b93-84cf-ee4e5f8a7ee4","_highlightResult":{"education_phases":[{"value":"secondary","matchLevel":"none","matchedWords":[]}],"job_roles":[{"value":"<em>teacher</em>","matchLevel":"full","fullyHighlighted":true,"matchedWords":["teacher"]}],"job_title":{"value":"Geography
+        <em>Teacher</em>","matchLevel":"full","fullyHighlighted":false,"matchedWords":["teacher"]},"parent_organisation_name":{"value":"Bexleyheath
+        Academy","matchLevel":"none","matchedWords":[]},"salary":{"value":"£25,000","matchLevel":"none","matchedWords":[]},"subjects":[{"value":"Geography","matchLevel":"none","matchedWords":[]}],"working_patterns":[{"value":"part_time","matchLevel":"none","matchedWords":[]},{"value":"job_share","matchLevel":"none","matchedWords":[]}],"_geoloc":[{"lat":{"value":"51.4578146490981","matchLevel":"none","matchedWords":[]},"lng":{"value":"0.146065490118642","matchLevel":"none","matchedWords":[]}}],"expires_at":{"value":"21
+        February 2021 at 8:15 am","matchLevel":"none","matchedWords":[]},"expires_at_timestamp":{"value":"1613895300","matchLevel":"none","matchedWords":[]},"job_roles_for_display":{"value":"<em>Teacher</em>","matchLevel":"full","fullyHighlighted":true,"matchedWords":["teacher"]},"job_summary":{"value":"Cupiditate
+        itaque deleniti. Perspiciatis nam at. Optio maiores non. Doloremque modi sapiente.","matchLevel":"none","matchedWords":[]},"last_updated_at":{"value":"1612957698","matchLevel":"none","matchedWords":[]},"organisations":{"names":[{"value":"Bexleyheath
+        Academy","matchLevel":"none","matchedWords":[]}],"counties":[{"value":"Kent","matchLevel":"none","matchedWords":[]}],"detailed_school_types":[{"value":"Academy
+        sponsor led","matchLevel":"none","matchedWords":[]}],"regions":[{"value":"London","matchLevel":"none","matchedWords":[]}],"school_types":[{"value":"Academy","matchLevel":"none","matchedWords":[]}],"towns":[{"value":"Bexleyheath","matchLevel":"none","matchedWords":[]}]},"permalink":{"value":"geography-<em>teacher</em>","matchLevel":"full","fullyHighlighted":false,"matchedWords":["teacher"]},"publication_date":{"value":"10
+        February 2021","matchLevel":"none","matchedWords":[]},"publication_date_timestamp":{"value":"1612915200","matchLevel":"none","matchedWords":[]},"start_date":{"value":"10
+        February 2022","matchLevel":"none","matchedWords":[]},"start_date_timestamp":{"value":"1644451200","matchLevel":"none","matchedWords":[]},"subjects_for_display":{"value":"Geography","matchLevel":"none","matchedWords":[]},"working_patterns_for_display":{"value":"Will
+        consider part-time, job share","matchLevel":"none","matchedWords":[]}}},{"education_phases":["secondary"],"job_roles":["teacher"],"job_title":"PE
+        Teacher","parent_organisation_name":"Bexleyheath Academy","salary":"£30,000","subjects":["Physical
+        Education"],"working_patterns":["full_time"],"_geoloc":[{"lat":51.4578146490981,"lng":0.146065490118642}],"expires_at":"14
+        February 2021 at 6:53 am","expires_at_timestamp":1613285580,"job_roles_for_display":"Teacher","job_summary":"Et
+        beatae in. Iste deserunt quo. Delectus sapiente illo. Placeat nihil in.","last_updated_at":1612957698,"organisations":{"names":["Bexleyheath
+        Academy"],"counties":["Kent"],"detailed_school_types":["Academy sponsor led"],"group_type":[],"local_authorities_within":[],"religious_characters":[],"regions":["London"],"school_types":["Academy"],"towns":["Bexleyheath"]},"permalink":"pe-teacher","publication_date":"10
+        February 2021","publication_date_timestamp":1612915200,"start_date":"10 February
+        2022","start_date_timestamp":1644451200,"subjects_for_display":"Physical Education","working_patterns_for_display":"Full-time
+        only","objectID":"9910d184-5686-4ffc-9322-69aa150c19d3","_highlightResult":{"education_phases":[{"value":"secondary","matchLevel":"none","matchedWords":[]}],"job_roles":[{"value":"<em>teacher</em>","matchLevel":"full","fullyHighlighted":true,"matchedWords":["teacher"]}],"job_title":{"value":"PE
+        <em>Teacher</em>","matchLevel":"full","fullyHighlighted":false,"matchedWords":["teacher"]},"parent_organisation_name":{"value":"Bexleyheath
+        Academy","matchLevel":"none","matchedWords":[]},"salary":{"value":"£30,000","matchLevel":"none","matchedWords":[]},"subjects":[{"value":"Physical
+        Education","matchLevel":"none","matchedWords":[]}],"working_patterns":[{"value":"full_time","matchLevel":"none","matchedWords":[]}],"_geoloc":[{"lat":{"value":"51.4578146490981","matchLevel":"none","matchedWords":[]},"lng":{"value":"0.146065490118642","matchLevel":"none","matchedWords":[]}}],"expires_at":{"value":"14
+        February 2021 at 6:53 am","matchLevel":"none","matchedWords":[]},"expires_at_timestamp":{"value":"1613285580","matchLevel":"none","matchedWords":[]},"job_roles_for_display":{"value":"<em>Teacher</em>","matchLevel":"full","fullyHighlighted":true,"matchedWords":["teacher"]},"job_summary":{"value":"Et
+        beatae in. Iste deserunt quo. Delectus sapiente illo. Placeat nihil in.","matchLevel":"none","matchedWords":[]},"last_updated_at":{"value":"1612957698","matchLevel":"none","matchedWords":[]},"organisations":{"names":[{"value":"Bexleyheath
+        Academy","matchLevel":"none","matchedWords":[]}],"counties":[{"value":"Kent","matchLevel":"none","matchedWords":[]}],"detailed_school_types":[{"value":"Academy
+        sponsor led","matchLevel":"none","matchedWords":[]}],"regions":[{"value":"London","matchLevel":"none","matchedWords":[]}],"school_types":[{"value":"Academy","matchLevel":"none","matchedWords":[]}],"towns":[{"value":"Bexleyheath","matchLevel":"none","matchedWords":[]}]},"permalink":{"value":"pe-<em>teacher</em>","matchLevel":"full","fullyHighlighted":false,"matchedWords":["teacher"]},"publication_date":{"value":"10
+        February 2021","matchLevel":"none","matchedWords":[]},"publication_date_timestamp":{"value":"1612915200","matchLevel":"none","matchedWords":[]},"start_date":{"value":"10
+        February 2022","matchLevel":"none","matchedWords":[]},"start_date_timestamp":{"value":"1644451200","matchLevel":"none","matchedWords":[]},"subjects_for_display":{"value":"Physical
+        Education","matchLevel":"none","matchedWords":[]},"working_patterns_for_display":{"value":"Full-time
+        only","matchLevel":"none","matchedWords":[]}}}],"nbHits":2,"page":0,"nbPages":1,"hitsPerPage":10,"exhaustiveNbHits":false,"query":"Teacher","params":"filters=%28publication_date_timestamp+%3C%3D+1613088000+AND+expires_at_timestamp+%3E+1613127331%29&hitsPerPage=10&page=0&query=Teacher","processingTimeMS":1}'
+  recorded_at: Fri, 12 Feb 2021 10:55:32 GMT
+- request:
+    method: get
+    uri: https://placeholder-dsn.algolia.net/1/indexes/localhost:3000-Vacancy/settings?getVersion=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - Algolia for Ruby (1.27.5); Ruby (2.7.2); Algolia for Rails (1.25.0); Rails
+        (6.1.2.1)
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 12 Feb 2021 10:55:31 GMT
+      X-Algolia-Api-Key:
+      - Placeholder
+      X-Algolia-Application-Id:
+      - Placeholder
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 12 Feb 2021 10:55:32 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Accept-Encoding:
+      - deflate, gzip
+      Cache-Control:
+      - no-store
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Disposition:
+      - inline; filename=a.txt
+      Content-Encoding:
+      - gzip
+    body:
+      encoding: UTF-8
+      string: '{"minWordSizefor1Typo":4,"minWordSizefor2Typos":8,"hitsPerPage":20,"maxValuesPerFacet":100,"version":1,"attributesToIndex":null,"numericAttributesToIndex":null,"attributesToRetrieve":null,"unretrievableAttributes":null,"optionalWords":null,"primary":"localhost:3000-Vacancy","attributesForFaceting":["job_roles","working_patterns","education_phases","subjects"],"attributesToSnippet":null,"attributesToHighlight":null,"paginationLimitedTo":1000,"attributeForDistinct":null,"exactOnSingleWordQuery":"attribute","ranking":["desc(publication_date_timestamp)"],"customRanking":null,"separatorsToIndex":"","removeWordsIfNoResults":"none","queryType":"prefixLast","highlightPreTag":"<em>","highlightPostTag":"</em>","snippetEllipsisText":"","alternativesAsExact":["ignorePlurals","singleWordSynonym"]}'
+  recorded_at: Fri, 12 Feb 2021 10:55:32 GMT
+- request:
+    method: put
+    uri: https://placeholder.algolia.net/1/indexes/localhost:3000-Vacancy/settings
+    body:
+      encoding: UTF-8
+      string: '{"attributesForFaceting":["job_roles","working_patterns","education_phases","subjects"],"ranking":["desc(publication_date_timestamp)"]}'
+    headers:
+      User-Agent:
+      - Algolia for Ruby (1.27.5); Ruby (2.7.2); Algolia for Rails (1.25.0); Rails
+        (6.1.2.1)
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 12 Feb 2021 10:55:32 GMT
+      X-Algolia-Api-Key:
+      - Placeholder
+      X-Algolia-Application-Id:
+      - Placeholder
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 12 Feb 2021 10:55:32 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '62'
+      Connection:
+      - keep-alive
+      Accept-Encoding:
+      - deflate, gzip
+      Cache-Control:
+      - no-store
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Disposition:
+      - inline; filename=a.txt
+    body:
+      encoding: UTF-8
+      string: '{"updatedAt":"2021-02-12T10:55:32.334Z","taskID":174554616002}'
+  recorded_at: Fri, 12 Feb 2021 10:55:32 GMT
+- request:
+    method: post
+    uri: https://placeholder-dsn.algolia.net/1/indexes/localhost:3000-Vacancy/query
+    body:
+      encoding: UTF-8
+      string: '{"params":"filters=%28publication_date_timestamp+%3C%3D+1613088000+AND+expires_at_timestamp+%3E+1613127331%29\u0026hitsPerPage=10\u0026page=0\u0026query=Teacher"}'
+    headers:
+      User-Agent:
+      - Algolia for Ruby (1.27.5); Ruby (2.7.2); Algolia for Rails (1.25.0); Rails
+        (6.1.2.1)
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 12 Feb 2021 10:55:32 GMT
+      X-Algolia-Api-Key:
+      - Placeholder
+      X-Algolia-Application-Id:
+      - Placeholder
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 12 Feb 2021 10:55:32 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Alg-Pt:
+      - '1'
+      Accept-Encoding:
+      - deflate, gzip
+      Cache-Control:
+      - no-store
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Disposition:
+      - inline; filename=a.txt
+      Content-Encoding:
+      - gzip
+    body:
+      encoding: UTF-8
+      string: '{"hits":[{"education_phases":["secondary"],"job_roles":["teacher"],"job_title":"Geography
+        Teacher","parent_organisation_name":"Bexleyheath Academy","salary":"£25,000","subjects":["Geography"],"working_patterns":["part_time","job_share"],"_geoloc":[{"lat":51.4578146490981,"lng":0.146065490118642}],"expires_at":"21
+        February 2021 at 8:15 am","expires_at_timestamp":1613895300,"job_roles_for_display":"Teacher","job_summary":"Cupiditate
+        itaque deleniti. Perspiciatis nam at. Optio maiores non. Doloremque modi sapiente.","last_updated_at":1612957698,"organisations":{"names":["Bexleyheath
+        Academy"],"counties":["Kent"],"detailed_school_types":["Academy sponsor led"],"group_type":[],"local_authorities_within":[],"religious_characters":[],"regions":["London"],"school_types":["Academy"],"towns":["Bexleyheath"]},"permalink":"geography-teacher","publication_date":"10
+        February 2021","publication_date_timestamp":1612915200,"start_date":"10 February
+        2022","start_date_timestamp":1644451200,"subjects_for_display":"Geography","working_patterns_for_display":"Will
+        consider part-time, job share","objectID":"e750baf6-cc9a-4b93-84cf-ee4e5f8a7ee4","_highlightResult":{"education_phases":[{"value":"secondary","matchLevel":"none","matchedWords":[]}],"job_roles":[{"value":"<em>teacher</em>","matchLevel":"full","fullyHighlighted":true,"matchedWords":["teacher"]}],"job_title":{"value":"Geography
+        <em>Teacher</em>","matchLevel":"full","fullyHighlighted":false,"matchedWords":["teacher"]},"parent_organisation_name":{"value":"Bexleyheath
+        Academy","matchLevel":"none","matchedWords":[]},"salary":{"value":"£25,000","matchLevel":"none","matchedWords":[]},"subjects":[{"value":"Geography","matchLevel":"none","matchedWords":[]}],"working_patterns":[{"value":"part_time","matchLevel":"none","matchedWords":[]},{"value":"job_share","matchLevel":"none","matchedWords":[]}],"_geoloc":[{"lat":{"value":"51.4578146490981","matchLevel":"none","matchedWords":[]},"lng":{"value":"0.146065490118642","matchLevel":"none","matchedWords":[]}}],"expires_at":{"value":"21
+        February 2021 at 8:15 am","matchLevel":"none","matchedWords":[]},"expires_at_timestamp":{"value":"1613895300","matchLevel":"none","matchedWords":[]},"job_roles_for_display":{"value":"<em>Teacher</em>","matchLevel":"full","fullyHighlighted":true,"matchedWords":["teacher"]},"job_summary":{"value":"Cupiditate
+        itaque deleniti. Perspiciatis nam at. Optio maiores non. Doloremque modi sapiente.","matchLevel":"none","matchedWords":[]},"last_updated_at":{"value":"1612957698","matchLevel":"none","matchedWords":[]},"organisations":{"names":[{"value":"Bexleyheath
+        Academy","matchLevel":"none","matchedWords":[]}],"counties":[{"value":"Kent","matchLevel":"none","matchedWords":[]}],"detailed_school_types":[{"value":"Academy
+        sponsor led","matchLevel":"none","matchedWords":[]}],"regions":[{"value":"London","matchLevel":"none","matchedWords":[]}],"school_types":[{"value":"Academy","matchLevel":"none","matchedWords":[]}],"towns":[{"value":"Bexleyheath","matchLevel":"none","matchedWords":[]}]},"permalink":{"value":"geography-<em>teacher</em>","matchLevel":"full","fullyHighlighted":false,"matchedWords":["teacher"]},"publication_date":{"value":"10
+        February 2021","matchLevel":"none","matchedWords":[]},"publication_date_timestamp":{"value":"1612915200","matchLevel":"none","matchedWords":[]},"start_date":{"value":"10
+        February 2022","matchLevel":"none","matchedWords":[]},"start_date_timestamp":{"value":"1644451200","matchLevel":"none","matchedWords":[]},"subjects_for_display":{"value":"Geography","matchLevel":"none","matchedWords":[]},"working_patterns_for_display":{"value":"Will
+        consider part-time, job share","matchLevel":"none","matchedWords":[]}}},{"education_phases":["secondary"],"job_roles":["teacher"],"job_title":"PE
+        Teacher","parent_organisation_name":"Bexleyheath Academy","salary":"£30,000","subjects":["Physical
+        Education"],"working_patterns":["full_time"],"_geoloc":[{"lat":51.4578146490981,"lng":0.146065490118642}],"expires_at":"14
+        February 2021 at 6:53 am","expires_at_timestamp":1613285580,"job_roles_for_display":"Teacher","job_summary":"Et
+        beatae in. Iste deserunt quo. Delectus sapiente illo. Placeat nihil in.","last_updated_at":1612957698,"organisations":{"names":["Bexleyheath
+        Academy"],"counties":["Kent"],"detailed_school_types":["Academy sponsor led"],"group_type":[],"local_authorities_within":[],"religious_characters":[],"regions":["London"],"school_types":["Academy"],"towns":["Bexleyheath"]},"permalink":"pe-teacher","publication_date":"10
+        February 2021","publication_date_timestamp":1612915200,"start_date":"10 February
+        2022","start_date_timestamp":1644451200,"subjects_for_display":"Physical Education","working_patterns_for_display":"Full-time
+        only","objectID":"9910d184-5686-4ffc-9322-69aa150c19d3","_highlightResult":{"education_phases":[{"value":"secondary","matchLevel":"none","matchedWords":[]}],"job_roles":[{"value":"<em>teacher</em>","matchLevel":"full","fullyHighlighted":true,"matchedWords":["teacher"]}],"job_title":{"value":"PE
+        <em>Teacher</em>","matchLevel":"full","fullyHighlighted":false,"matchedWords":["teacher"]},"parent_organisation_name":{"value":"Bexleyheath
+        Academy","matchLevel":"none","matchedWords":[]},"salary":{"value":"£30,000","matchLevel":"none","matchedWords":[]},"subjects":[{"value":"Physical
+        Education","matchLevel":"none","matchedWords":[]}],"working_patterns":[{"value":"full_time","matchLevel":"none","matchedWords":[]}],"_geoloc":[{"lat":{"value":"51.4578146490981","matchLevel":"none","matchedWords":[]},"lng":{"value":"0.146065490118642","matchLevel":"none","matchedWords":[]}}],"expires_at":{"value":"14
+        February 2021 at 6:53 am","matchLevel":"none","matchedWords":[]},"expires_at_timestamp":{"value":"1613285580","matchLevel":"none","matchedWords":[]},"job_roles_for_display":{"value":"<em>Teacher</em>","matchLevel":"full","fullyHighlighted":true,"matchedWords":["teacher"]},"job_summary":{"value":"Et
+        beatae in. Iste deserunt quo. Delectus sapiente illo. Placeat nihil in.","matchLevel":"none","matchedWords":[]},"last_updated_at":{"value":"1612957698","matchLevel":"none","matchedWords":[]},"organisations":{"names":[{"value":"Bexleyheath
+        Academy","matchLevel":"none","matchedWords":[]}],"counties":[{"value":"Kent","matchLevel":"none","matchedWords":[]}],"detailed_school_types":[{"value":"Academy
+        sponsor led","matchLevel":"none","matchedWords":[]}],"regions":[{"value":"London","matchLevel":"none","matchedWords":[]}],"school_types":[{"value":"Academy","matchLevel":"none","matchedWords":[]}],"towns":[{"value":"Bexleyheath","matchLevel":"none","matchedWords":[]}]},"permalink":{"value":"pe-<em>teacher</em>","matchLevel":"full","fullyHighlighted":false,"matchedWords":["teacher"]},"publication_date":{"value":"10
+        February 2021","matchLevel":"none","matchedWords":[]},"publication_date_timestamp":{"value":"1612915200","matchLevel":"none","matchedWords":[]},"start_date":{"value":"10
+        February 2022","matchLevel":"none","matchedWords":[]},"start_date_timestamp":{"value":"1644451200","matchLevel":"none","matchedWords":[]},"subjects_for_display":{"value":"Physical
+        Education","matchLevel":"none","matchedWords":[]},"working_patterns_for_display":{"value":"Full-time
+        only","matchLevel":"none","matchedWords":[]}}}],"nbHits":2,"page":0,"nbPages":1,"hitsPerPage":10,"exhaustiveNbHits":false,"query":"Teacher","params":"filters=%28publication_date_timestamp+%3C%3D+1613088000+AND+expires_at_timestamp+%3E+1613127331%29&hitsPerPage=10&page=0&query=Teacher","processingTimeMS":1}'
+  recorded_at: Fri, 12 Feb 2021 10:55:32 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr/algoliasearch_maths.yml
+++ b/spec/fixtures/vcr/algoliasearch_maths.yml
@@ -1,0 +1,413 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://placeholder-dsn.algolia.net/1/indexes/localhost:3000-Vacancy_publish_on_desc/settings?getVersion=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - Algolia for Ruby (1.27.5); Ruby (2.7.2); Algolia for Rails (1.25.0); Rails
+        (6.1.2.1)
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 12 Feb 2021 15:19:00 GMT
+      X-Algolia-Api-Key:
+      - Placeholder
+      X-Algolia-Application-Id:
+      - Placeholder
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 12 Feb 2021 15:19:01 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Accept-Encoding:
+      - deflate, gzip
+      Cache-Control:
+      - no-store
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Disposition:
+      - inline; filename=a.txt
+      Content-Encoding:
+      - gzip
+    body:
+      encoding: UTF-8
+      string: '{"minWordSizefor1Typo":4,"minWordSizefor2Typos":8,"hitsPerPage":20,"maxValuesPerFacet":100,"version":1,"attributesToIndex":null,"numericAttributesToIndex":null,"attributesToRetrieve":null,"unretrievableAttributes":null,"optionalWords":null,"primary":"localhost:3000-Vacancy","attributesForFaceting":["job_roles","working_patterns","education_phases","subjects"],"attributesToSnippet":null,"attributesToHighlight":null,"paginationLimitedTo":1000,"attributeForDistinct":null,"exactOnSingleWordQuery":"attribute","ranking":["desc(publication_date_timestamp)"],"customRanking":null,"separatorsToIndex":"","removeWordsIfNoResults":"none","queryType":"prefixLast","highlightPreTag":"<em>","highlightPostTag":"</em>","snippetEllipsisText":"","alternativesAsExact":["ignorePlurals","singleWordSynonym"]}'
+  recorded_at: Fri, 12 Feb 2021 15:19:01 GMT
+- request:
+    method: put
+    uri: https://placeholder.algolia.net/1/indexes/localhost:3000-Vacancy_publish_on_desc/settings
+    body:
+      encoding: UTF-8
+      string: '{"attributesForFaceting":["job_roles","working_patterns","education_phases","subjects"],"ranking":["desc(publication_date_timestamp)"]}'
+    headers:
+      User-Agent:
+      - Algolia for Ruby (1.27.5); Ruby (2.7.2); Algolia for Rails (1.25.0); Rails
+        (6.1.2.1)
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 12 Feb 2021 15:19:01 GMT
+      X-Algolia-Api-Key:
+      - Placeholder
+      X-Algolia-Application-Id:
+      - Placeholder
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 12 Feb 2021 15:19:01 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '62'
+      Connection:
+      - keep-alive
+      Accept-Encoding:
+      - deflate, gzip
+      Cache-Control:
+      - no-store
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Disposition:
+      - inline; filename=a.txt
+    body:
+      encoding: UTF-8
+      string: '{"updatedAt":"2021-02-12T15:19:01.350Z","taskID":181717598001}'
+  recorded_at: Fri, 12 Feb 2021 15:19:01 GMT
+- request:
+    method: post
+    uri: https://placeholder-dsn.algolia.net/1/indexes/localhost:3000-Vacancy_publish_on_desc/query
+    body:
+      encoding: UTF-8
+      string: '{"params":"filters=%28publication_date_timestamp+%3C%3D+1613088000+AND+expires_at_timestamp+%3E+1613143140%29\u0026hitsPerPage=2\u0026page=0\u0026query=Maths+Teacher"}'
+    headers:
+      User-Agent:
+      - Algolia for Ruby (1.27.5); Ruby (2.7.2); Algolia for Rails (1.25.0); Rails
+        (6.1.2.1)
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 12 Feb 2021 15:19:01 GMT
+      X-Algolia-Api-Key:
+      - Placeholder
+      X-Algolia-Application-Id:
+      - Placeholder
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 12 Feb 2021 15:19:01 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Alg-Pt:
+      - '1'
+      Accept-Encoding:
+      - deflate, gzip
+      Cache-Control:
+      - no-store
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Disposition:
+      - inline; filename=a.txt
+      Content-Encoding:
+      - gzip
+    body:
+      encoding: UTF-8
+      string: '{"hits":[{"education_phases":["secondary"],"job_roles":["teacher"],"job_title":"Maths
+        Teacher","parent_organisation_name":"Bexleyheath Academy","salary":"£35,000","subjects":["Maths"],"working_patterns":["full_time"],"_geoloc":[{"lat":51.4578146490981,"lng":0.146065490118642}],"expires_at":"16
+        February 2021 at 8:43 pm","expires_at_timestamp":1613508180,"job_roles_for_display":"Teacher","job_summary":"Amet
+        molestias aut. Aut modi cum. Sunt neque ratione. Molestiae dolores sit.","last_updated_at":1613142819,"organisations":{"names":["Bexleyheath
+        Academy"],"counties":["Kent"],"detailed_school_types":["Academy sponsor led"],"group_type":[],"local_authorities_within":[],"religious_characters":[],"regions":["London"],"school_types":["Academy"],"towns":["Bexleyheath"]},"permalink":"maths-teacher-2","publication_date":"12
+        February 2021","publication_date_timestamp":1613088000,"start_date":"12 February
+        2022","start_date_timestamp":1644624000,"subjects_for_display":"Maths","working_patterns_for_display":"Full-time
+        only","objectID":"67991ea9-431d-4d9d-9c99-a78b80108fe1","_highlightResult":{"education_phases":[{"value":"secondary","matchLevel":"none","matchedWords":[]}],"job_roles":[{"value":"<em>teacher</em>","matchLevel":"partial","fullyHighlighted":true,"matchedWords":["teacher"]}],"job_title":{"value":"<em>Maths</em>
+        <em>Teacher</em> 2","matchLevel":"full","fullyHighlighted":false,"matchedWords":["maths","teacher"]},"parent_organisation_name":{"value":"Bexleyheath
+        Academy","matchLevel":"none","matchedWords":[]},"salary":{"value":"£35,000","matchLevel":"none","matchedWords":[]},"subjects":[{"value":"<em>Maths</em>","matchLevel":"partial","fullyHighlighted":true,"matchedWords":["maths"]}],"working_patterns":[{"value":"full_time","matchLevel":"none","matchedWords":[]}],"_geoloc":[{"lat":{"value":"51.4578146490981","matchLevel":"none","matchedWords":[]},"lng":{"value":"0.146065490118642","matchLevel":"none","matchedWords":[]}}],"expires_at":{"value":"16
+        February 2021 at 8:43 pm","matchLevel":"none","matchedWords":[]},"expires_at_timestamp":{"value":"1613508180","matchLevel":"none","matchedWords":[]},"job_roles_for_display":{"value":"<em>Teacher</em>","matchLevel":"partial","fullyHighlighted":true,"matchedWords":["teacher"]},"job_summary":{"value":"Amet
+        molestias aut. Aut modi cum. Sunt neque ratione. Molestiae dolores sit.","matchLevel":"none","matchedWords":[]},"last_updated_at":{"value":"1613142819","matchLevel":"none","matchedWords":[]},"organisations":{"names":[{"value":"Bexleyheath
+        Academy","matchLevel":"none","matchedWords":[]}],"counties":[{"value":"Kent","matchLevel":"none","matchedWords":[]}],"detailed_school_types":[{"value":"Academy
+        sponsor led","matchLevel":"none","matchedWords":[]}],"regions":[{"value":"London","matchLevel":"none","matchedWords":[]}],"school_types":[{"value":"Academy","matchLevel":"none","matchedWords":[]}],"towns":[{"value":"Bexleyheath","matchLevel":"none","matchedWords":[]}]},"permalink":{"value":"<em>maths</em>-<em>teacher</em>-2","matchLevel":"full","fullyHighlighted":false,"matchedWords":["maths","teacher"]},"publication_date":{"value":"12
+        February 2021","matchLevel":"none","matchedWords":[]},"publication_date_timestamp":{"value":"1613088000","matchLevel":"none","matchedWords":[]},"start_date":{"value":"12
+        February 2022","matchLevel":"none","matchedWords":[]},"start_date_timestamp":{"value":"1644624000","matchLevel":"none","matchedWords":[]},"subjects_for_display":{"value":"<em>Maths</em>","matchLevel":"partial","fullyHighlighted":true,"matchedWords":["maths"]},"working_patterns_for_display":{"value":"Full-time
+        only","matchLevel":"none","matchedWords":[]}}},{"education_phases":["primary"],"job_roles":["teacher"],"job_title":"Maths
+        Teacher 2","parent_organisation_name":"Upton Cross ACE Academy","salary":"£35,000","subjects":["Maths"],"working_patterns":["part_time"],"_geoloc":[{"lat":50.52350433336815,"lng":-4.427269703777728}],"expires_at":"23
+        February 2021 at 3:48 pm","expires_at_timestamp":1614095280,"job_roles_for_display":"Teacher","job_summary":"Tenetur
+        ut ut. Sint officia omnis. Facilis tenetur laborum. Molestias unde et.","last_updated_at":1613142818,"organisations":{"names":["Upton
+        Cross ACE Academy"],"counties":["Cornwall"],"detailed_school_types":["Academy
+        converter"],"group_type":[],"local_authorities_within":[],"religious_characters":[],"regions":["London"],"school_types":["Academy"],"towns":["Liskeard"]},"permalink":"maths-teacher","publication_date":"12
+        February 2021","publication_date_timestamp":1613088000,"start_date":"12 February
+        2022","start_date_timestamp":1644624000,"subjects_for_display":"Maths","working_patterns_for_display":"Part-time
+        only","objectID":"7bfadb84-cf30-4121-88bd-a9f958440cc9","_highlightResult":{"education_phases":[{"value":"primary","matchLevel":"none","matchedWords":[]}],"job_roles":[{"value":"<em>teacher</em>","matchLevel":"partial","fullyHighlighted":true,"matchedWords":["teacher"]}],"job_title":{"value":"<em>Maths</em>
+        <em>Teacher</em>","matchLevel":"full","fullyHighlighted":true,"matchedWords":["maths","teacher"]},"parent_organisation_name":{"value":"Upton
+        Cross ACE Academy","matchLevel":"none","matchedWords":[]},"salary":{"value":"£35,000","matchLevel":"none","matchedWords":[]},"subjects":[{"value":"<em>Maths</em>","matchLevel":"partial","fullyHighlighted":true,"matchedWords":["maths"]}],"working_patterns":[{"value":"part_time","matchLevel":"none","matchedWords":[]}],"_geoloc":[{"lat":{"value":"50.52350433336815","matchLevel":"none","matchedWords":[]},"lng":{"value":"-4.427269703777728","matchLevel":"none","matchedWords":[]}}],"expires_at":{"value":"23
+        February 2021 at 3:48 pm","matchLevel":"none","matchedWords":[]},"expires_at_timestamp":{"value":"1614095280","matchLevel":"none","matchedWords":[]},"job_roles_for_display":{"value":"<em>Teacher</em>","matchLevel":"partial","fullyHighlighted":true,"matchedWords":["teacher"]},"job_summary":{"value":"Tenetur
+        ut ut. Sint officia omnis. Facilis tenetur laborum. Molestias unde et.","matchLevel":"none","matchedWords":[]},"last_updated_at":{"value":"1613142818","matchLevel":"none","matchedWords":[]},"organisations":{"names":[{"value":"Upton
+        Cross ACE Academy","matchLevel":"none","matchedWords":[]}],"counties":[{"value":"Cornwall","matchLevel":"none","matchedWords":[]}],"detailed_school_types":[{"value":"Academy
+        converter","matchLevel":"none","matchedWords":[]}],"regions":[{"value":"London","matchLevel":"none","matchedWords":[]}],"school_types":[{"value":"Academy","matchLevel":"none","matchedWords":[]}],"towns":[{"value":"Liskeard","matchLevel":"none","matchedWords":[]}]},"permalink":{"value":"<em>maths</em>-<em>teacher</em>","matchLevel":"full","fullyHighlighted":true,"matchedWords":["maths","teacher"]},"publication_date":{"value":"12
+        February 2021","matchLevel":"none","matchedWords":[]},"publication_date_timestamp":{"value":"1613088000","matchLevel":"none","matchedWords":[]},"start_date":{"value":"12
+        February 2022","matchLevel":"none","matchedWords":[]},"start_date_timestamp":{"value":"1644624000","matchLevel":"none","matchedWords":[]},"subjects_for_display":{"value":"<em>Maths</em>","matchLevel":"partial","fullyHighlighted":true,"matchedWords":["maths"]},"working_patterns_for_display":{"value":"Part-time
+        only","matchLevel":"none","matchedWords":[]}}}],"nbHits":2,"page":0,"nbPages":1,"hitsPerPage":2,"exhaustiveNbHits":true,"query":"Maths
+        Teacher","params":"filters=%28publication_date_timestamp+%3C%3D+1613088000+AND+expires_at_timestamp+%3E+1613143140%29&hitsPerPage=2&page=0&query=Maths+Teacher","processingTimeMS":1}'
+  recorded_at: Fri, 12 Feb 2021 15:19:01 GMT
+- request:
+    method: get
+    uri: https://placeholder-dsn.algolia.net/1/indexes/localhost:3000-Vacancy_expires_at_asc/settings?getVersion=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - Algolia for Ruby (1.27.5); Ruby (2.7.2); Algolia for Rails (1.25.0); Rails
+        (6.1.2.1)
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 12 Feb 2021 15:19:00 GMT
+      X-Algolia-Api-Key:
+      - Placeholder
+      X-Algolia-Application-Id:
+      - Placeholder
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 12 Feb 2021 15:19:01 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Accept-Encoding:
+      - deflate, gzip
+      Cache-Control:
+      - no-store
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Disposition:
+      - inline; filename=a.txt
+      Content-Encoding:
+      - gzip
+    body:
+      encoding: UTF-8
+      string: '{"minWordSizefor1Typo":4,"minWordSizefor2Typos":8,"hitsPerPage":20,"maxValuesPerFacet":100,"version":1,"attributesToIndex":null,"numericAttributesToIndex":null,"attributesToRetrieve":null,"unretrievableAttributes":null,"optionalWords":null,"primary":"localhost:3000-Vacancy","attributesForFaceting":["job_roles","working_patterns","education_phases","subjects"],"attributesToSnippet":null,"attributesToHighlight":null,"paginationLimitedTo":1000,"attributeForDistinct":null,"exactOnSingleWordQuery":"attribute","ranking":["desc(publication_date_timestamp)"],"customRanking":null,"separatorsToIndex":"","removeWordsIfNoResults":"none","queryType":"prefixLast","highlightPreTag":"<em>","highlightPostTag":"</em>","snippetEllipsisText":"","alternativesAsExact":["ignorePlurals","singleWordSynonym"]}'
+  recorded_at: Fri, 12 Feb 2021 15:19:01 GMT
+- request:
+    method: put
+    uri: https://placeholder.algolia.net/1/indexes/localhost:3000-Vacancy_expires_at_asc/settings
+    body:
+      encoding: UTF-8
+      string: '{"attributesForFaceting":["job_roles","working_patterns","education_phases","subjects"],"ranking":["desc(publication_date_timestamp)"]}'
+    headers:
+      User-Agent:
+      - Algolia for Ruby (1.27.5); Ruby (2.7.2); Algolia for Rails (1.25.0); Rails
+        (6.1.2.1)
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 12 Feb 2021 15:19:01 GMT
+      X-Algolia-Api-Key:
+      - Placeholder
+      X-Algolia-Application-Id:
+      - Placeholder
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 12 Feb 2021 15:19:01 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '62'
+      Connection:
+      - keep-alive
+      Accept-Encoding:
+      - deflate, gzip
+      Cache-Control:
+      - no-store
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Disposition:
+      - inline; filename=a.txt
+    body:
+      encoding: UTF-8
+      string: '{"updatedAt":"2021-02-12T15:19:01.350Z","taskID":181717598001}'
+  recorded_at: Fri, 12 Feb 2021 15:19:01 GMT
+- request:
+    method: post
+    uri: https://placeholder-dsn.algolia.net/1/indexes/localhost:3000-Vacancy_expires_at_asc/query
+    body:
+      encoding: UTF-8
+      string: '{"params":"filters=%28publication_date_timestamp+%3C%3D+1613088000+AND+expires_at_timestamp+%3E+1613143140%29\u0026hitsPerPage=2\u0026page=0\u0026query=Maths+Teacher"}'
+    headers:
+      User-Agent:
+      - Algolia for Ruby (1.27.5); Ruby (2.7.2); Algolia for Rails (1.25.0); Rails
+        (6.1.2.1)
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 12 Feb 2021 15:19:01 GMT
+      X-Algolia-Api-Key:
+      - Placeholder
+      X-Algolia-Application-Id:
+      - Placeholder
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 12 Feb 2021 15:19:01 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Alg-Pt:
+      - '1'
+      Accept-Encoding:
+      - deflate, gzip
+      Cache-Control:
+      - no-store
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Disposition:
+      - inline; filename=a.txt
+      Content-Encoding:
+      - gzip
+    body:
+      encoding: UTF-8
+      string: '{"hits":[{"education_phases":["secondary"],"job_roles":["teacher"],"job_title":"Maths
+        Teacher 2","parent_organisation_name":"Bexleyheath Academy","salary":"£35,000","subjects":["Maths"],"working_patterns":["full_time"],"_geoloc":[{"lat":51.4578146490981,"lng":0.146065490118642}],"expires_at":"16
+        February 2021 at 8:43 pm","expires_at_timestamp":1613508180,"job_roles_for_display":"Teacher","job_summary":"Amet
+        molestias aut. Aut modi cum. Sunt neque ratione. Molestiae dolores sit.","last_updated_at":1613142819,"organisations":{"names":["Bexleyheath
+        Academy"],"counties":["Kent"],"detailed_school_types":["Academy sponsor led"],"group_type":[],"local_authorities_within":[],"religious_characters":[],"regions":["London"],"school_types":["Academy"],"towns":["Bexleyheath"]},"permalink":"maths-teacher-2","publication_date":"12
+        February 2021","publication_date_timestamp":1613088000,"start_date":"12 February
+        2022","start_date_timestamp":1644624000,"subjects_for_display":"Maths","working_patterns_for_display":"Full-time
+        only","objectID":"7bfadb84-cf30-4121-88bd-a9f958440cc9","_highlightResult":{"education_phases":[{"value":"secondary","matchLevel":"none","matchedWords":[]}],"job_roles":[{"value":"<em>teacher</em>","matchLevel":"partial","fullyHighlighted":true,"matchedWords":["teacher"]}],"job_title":{"value":"<em>Maths</em>
+        <em>Teacher</em> 2","matchLevel":"full","fullyHighlighted":false,"matchedWords":["maths","teacher"]},"parent_organisation_name":{"value":"Bexleyheath
+        Academy","matchLevel":"none","matchedWords":[]},"salary":{"value":"£35,000","matchLevel":"none","matchedWords":[]},"subjects":[{"value":"<em>Maths</em>","matchLevel":"partial","fullyHighlighted":true,"matchedWords":["maths"]}],"working_patterns":[{"value":"full_time","matchLevel":"none","matchedWords":[]}],"_geoloc":[{"lat":{"value":"51.4578146490981","matchLevel":"none","matchedWords":[]},"lng":{"value":"0.146065490118642","matchLevel":"none","matchedWords":[]}}],"expires_at":{"value":"16
+        February 2021 at 8:43 pm","matchLevel":"none","matchedWords":[]},"expires_at_timestamp":{"value":"1613508180","matchLevel":"none","matchedWords":[]},"job_roles_for_display":{"value":"<em>Teacher</em>","matchLevel":"partial","fullyHighlighted":true,"matchedWords":["teacher"]},"job_summary":{"value":"Amet
+        molestias aut. Aut modi cum. Sunt neque ratione. Molestiae dolores sit.","matchLevel":"none","matchedWords":[]},"last_updated_at":{"value":"1613142819","matchLevel":"none","matchedWords":[]},"organisations":{"names":[{"value":"Bexleyheath
+        Academy","matchLevel":"none","matchedWords":[]}],"counties":[{"value":"Kent","matchLevel":"none","matchedWords":[]}],"detailed_school_types":[{"value":"Academy
+        sponsor led","matchLevel":"none","matchedWords":[]}],"regions":[{"value":"London","matchLevel":"none","matchedWords":[]}],"school_types":[{"value":"Academy","matchLevel":"none","matchedWords":[]}],"towns":[{"value":"Bexleyheath","matchLevel":"none","matchedWords":[]}]},"permalink":{"value":"<em>maths</em>-<em>teacher</em>-2","matchLevel":"full","fullyHighlighted":false,"matchedWords":["maths","teacher"]},"publication_date":{"value":"12
+        February 2021","matchLevel":"none","matchedWords":[]},"publication_date_timestamp":{"value":"1613088000","matchLevel":"none","matchedWords":[]},"start_date":{"value":"12
+        February 2022","matchLevel":"none","matchedWords":[]},"start_date_timestamp":{"value":"1644624000","matchLevel":"none","matchedWords":[]},"subjects_for_display":{"value":"<em>Maths</em>","matchLevel":"partial","fullyHighlighted":true,"matchedWords":["maths"]},"working_patterns_for_display":{"value":"Full-time
+        only","matchLevel":"none","matchedWords":[]}}},{"education_phases":["primary"],"job_roles":["teacher"],"job_title":"Maths
+        Teacher","parent_organisation_name":"Upton Cross ACE Academy","salary":"£35,000","subjects":["Maths"],"working_patterns":["part_time"],"_geoloc":[{"lat":50.52350433336815,"lng":-4.427269703777728}],"expires_at":"23
+        February 2021 at 3:48 pm","expires_at_timestamp":1614095280,"job_roles_for_display":"Teacher","job_summary":"Tenetur
+        ut ut. Sint officia omnis. Facilis tenetur laborum. Molestias unde et.","last_updated_at":1613142818,"organisations":{"names":["Upton
+        Cross ACE Academy"],"counties":["Cornwall"],"detailed_school_types":["Academy
+        converter"],"group_type":[],"local_authorities_within":[],"religious_characters":[],"regions":["London"],"school_types":["Academy"],"towns":["Liskeard"]},"permalink":"maths-teacher","publication_date":"12
+        February 2021","publication_date_timestamp":1613088000,"start_date":"12 February
+        2022","start_date_timestamp":1644624000,"subjects_for_display":"Maths","working_patterns_for_display":"Part-time
+        only","objectID":"67991ea9-431d-4d9d-9c99-a78b80108fe1","_highlightResult":{"education_phases":[{"value":"primary","matchLevel":"none","matchedWords":[]}],"job_roles":[{"value":"<em>teacher</em>","matchLevel":"partial","fullyHighlighted":true,"matchedWords":["teacher"]}],"job_title":{"value":"<em>Maths</em>
+        <em>Teacher</em>","matchLevel":"full","fullyHighlighted":true,"matchedWords":["maths","teacher"]},"parent_organisation_name":{"value":"Upton
+        Cross ACE Academy","matchLevel":"none","matchedWords":[]},"salary":{"value":"£35,000","matchLevel":"none","matchedWords":[]},"subjects":[{"value":"<em>Maths</em>","matchLevel":"partial","fullyHighlighted":true,"matchedWords":["maths"]}],"working_patterns":[{"value":"part_time","matchLevel":"none","matchedWords":[]}],"_geoloc":[{"lat":{"value":"50.52350433336815","matchLevel":"none","matchedWords":[]},"lng":{"value":"-4.427269703777728","matchLevel":"none","matchedWords":[]}}],"expires_at":{"value":"23
+        February 2021 at 3:48 pm","matchLevel":"none","matchedWords":[]},"expires_at_timestamp":{"value":"1614095280","matchLevel":"none","matchedWords":[]},"job_roles_for_display":{"value":"<em>Teacher</em>","matchLevel":"partial","fullyHighlighted":true,"matchedWords":["teacher"]},"job_summary":{"value":"Tenetur
+        ut ut. Sint officia omnis. Facilis tenetur laborum. Molestias unde et.","matchLevel":"none","matchedWords":[]},"last_updated_at":{"value":"1613142818","matchLevel":"none","matchedWords":[]},"organisations":{"names":[{"value":"Upton
+        Cross ACE Academy","matchLevel":"none","matchedWords":[]}],"counties":[{"value":"Cornwall","matchLevel":"none","matchedWords":[]}],"detailed_school_types":[{"value":"Academy
+        converter","matchLevel":"none","matchedWords":[]}],"regions":[{"value":"London","matchLevel":"none","matchedWords":[]}],"school_types":[{"value":"Academy","matchLevel":"none","matchedWords":[]}],"towns":[{"value":"Liskeard","matchLevel":"none","matchedWords":[]}]},"permalink":{"value":"<em>maths</em>-<em>teacher</em>","matchLevel":"full","fullyHighlighted":true,"matchedWords":["maths","teacher"]},"publication_date":{"value":"12
+        February 2021","matchLevel":"none","matchedWords":[]},"publication_date_timestamp":{"value":"1613088000","matchLevel":"none","matchedWords":[]},"start_date":{"value":"12
+        February 2022","matchLevel":"none","matchedWords":[]},"start_date_timestamp":{"value":"1644624000","matchLevel":"none","matchedWords":[]},"subjects_for_display":{"value":"<em>Maths</em>","matchLevel":"partial","fullyHighlighted":true,"matchedWords":["maths"]},"working_patterns_for_display":{"value":"Part-time
+        only","matchLevel":"none","matchedWords":[]}}}],"nbHits":2,"page":0,"nbPages":1,"hitsPerPage":2,"exhaustiveNbHits":true,"query":"Maths
+        Teacher","params":"filters=%28publication_date_timestamp+%3C%3D+1613088000+AND+expires_at_timestamp+%3E+1613143140%29&hitsPerPage=2&page=0&query=Maths+Teacher","processingTimeMS":1}'
+  recorded_at: Fri, 12 Feb 2021 15:19:01 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr/algoliasearch_teacher_page_1.yml
+++ b/spec/fixtures/vcr/algoliasearch_teacher_page_1.yml
@@ -1,0 +1,209 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://placeholder-dsn.algolia.net/1/indexes/localhost:3000-Vacancy_publish_on_desc/settings?getVersion=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - Algolia for Ruby (1.27.5); Ruby (2.7.2); Algolia for Rails (1.25.0); Rails
+        (6.1.2.1)
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 12 Feb 2021 10:55:31 GMT
+      X-Algolia-Api-Key:
+      - Placeholder
+      X-Algolia-Application-Id:
+      - Placeholder
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 12 Feb 2021 10:55:32 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Accept-Encoding:
+      - deflate, gzip
+      Cache-Control:
+      - no-store
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Disposition:
+      - inline; filename=a.txt
+      Content-Encoding:
+      - gzip
+    body:
+      encoding: UTF-8
+      string: '{"minWordSizefor1Typo":4,"minWordSizefor2Typos":8,"hitsPerPage":20,"maxValuesPerFacet":100,"version":1,"attributesToIndex":null,"numericAttributesToIndex":null,"attributesToRetrieve":null,"unretrievableAttributes":null,"optionalWords":null,"primary":"localhost:3000-Vacancy","attributesForFaceting":["job_roles","working_patterns","education_phases","subjects"],"attributesToSnippet":null,"attributesToHighlight":null,"paginationLimitedTo":1000,"attributeForDistinct":null,"exactOnSingleWordQuery":"attribute","ranking":["desc(publication_date_timestamp)"],"customRanking":null,"separatorsToIndex":"","removeWordsIfNoResults":"none","queryType":"prefixLast","highlightPreTag":"<em>","highlightPostTag":"</em>","snippetEllipsisText":"","alternativesAsExact":["ignorePlurals","singleWordSynonym"]}'
+  recorded_at: Fri, 12 Feb 2021 10:55:32 GMT
+- request:
+    method: put
+    uri: https://placeholder.algolia.net/1/indexes/localhost:3000-Vacancy_publish_on_desc/settings
+    body:
+      encoding: UTF-8
+      string: '{"attributesForFaceting":["job_roles","working_patterns","education_phases","subjects"],"ranking":["desc(publication_date_timestamp)"]}'
+    headers:
+      User-Agent:
+      - Algolia for Ruby (1.27.5); Ruby (2.7.2); Algolia for Rails (1.25.0); Rails
+        (6.1.2.1)
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 12 Feb 2021 10:55:32 GMT
+      X-Algolia-Api-Key:
+      - Placeholder
+      X-Algolia-Application-Id:
+      - Placeholder
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 12 Feb 2021 10:55:32 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '62'
+      Connection:
+      - keep-alive
+      Accept-Encoding:
+      - deflate, gzip
+      Cache-Control:
+      - no-store
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Disposition:
+      - inline; filename=a.txt
+    body:
+      encoding: UTF-8
+      string: '{"updatedAt":"2021-02-12T10:55:32.334Z","taskID":174554616002}'
+  recorded_at: Fri, 12 Feb 2021 10:55:32 GMT
+- request:
+    method: post
+    uri: https://placeholder-dsn.algolia.net/1/indexes/localhost:3000-Vacancy_publish_on_desc/query
+    body:
+      encoding: UTF-8
+      string: '{"params":"filters=%28publication_date_timestamp+%3C%3D+1613088000+AND+expires_at_timestamp+%3E+1613127331%29\u0026hitsPerPage=2\u0026page=0\u0026query=Teacher"}'
+    headers:
+      User-Agent:
+      - Algolia for Ruby (1.27.5); Ruby (2.7.2); Algolia for Rails (1.25.0); Rails
+        (6.1.2.1)
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 12 Feb 2021 10:55:32 GMT
+      X-Algolia-Api-Key:
+      - Placeholder
+      X-Algolia-Application-Id:
+      - Placeholder
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 12 Feb 2021 10:55:32 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Alg-Pt:
+      - '1'
+      Accept-Encoding:
+      - deflate, gzip
+      Cache-Control:
+      - no-store
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Disposition:
+      - inline; filename=a.txt
+      Content-Encoding:
+      - gzip
+    body:
+      encoding: UTF-8
+      string: '{"hits":[{"education_phases":["secondary"],"job_roles":["teacher"],"job_title":"Geography
+        Teacher","parent_organisation_name":"Bexleyheath Academy","salary":"£25,000","subjects":["Geography"],"working_patterns":["part_time","job_share"],"_geoloc":[{"lat":51.4578146490981,"lng":0.146065490118642}],"expires_at":"21
+        February 2021 at 8:15 am","expires_at_timestamp":1613895300,"job_roles_for_display":"Teacher","job_summary":"Cupiditate
+        itaque deleniti. Perspiciatis nam at. Optio maiores non. Doloremque modi sapiente.","last_updated_at":1612957698,"organisations":{"names":["Bexleyheath
+        Academy"],"counties":["Kent"],"detailed_school_types":["Academy sponsor led"],"group_type":[],"local_authorities_within":[],"religious_characters":[],"regions":["London"],"school_types":["Academy"],"towns":["Bexleyheath"]},"permalink":"geography-teacher","publication_date":"10
+        February 2021","publication_date_timestamp":1612915200,"start_date":"10 February
+        2022","start_date_timestamp":1644451200,"subjects_for_display":"Geography","working_patterns_for_display":"Will
+        consider part-time, job share","objectID":"e750baf6-cc9a-4b93-84cf-ee4e5f8a7ee4","_highlightResult":{"education_phases":[{"value":"secondary","matchLevel":"none","matchedWords":[]}],"job_roles":[{"value":"<em>teacher</em>","matchLevel":"full","fullyHighlighted":true,"matchedWords":["teacher"]}],"job_title":{"value":"Geography
+        <em>Teacher</em>","matchLevel":"full","fullyHighlighted":false,"matchedWords":["teacher"]},"parent_organisation_name":{"value":"Bexleyheath
+        Academy","matchLevel":"none","matchedWords":[]},"salary":{"value":"£25,000","matchLevel":"none","matchedWords":[]},"subjects":[{"value":"Geography","matchLevel":"none","matchedWords":[]}],"working_patterns":[{"value":"part_time","matchLevel":"none","matchedWords":[]},{"value":"job_share","matchLevel":"none","matchedWords":[]}],"_geoloc":[{"lat":{"value":"51.4578146490981","matchLevel":"none","matchedWords":[]},"lng":{"value":"0.146065490118642","matchLevel":"none","matchedWords":[]}}],"expires_at":{"value":"21
+        February 2021 at 8:15 am","matchLevel":"none","matchedWords":[]},"expires_at_timestamp":{"value":"1613895300","matchLevel":"none","matchedWords":[]},"job_roles_for_display":{"value":"<em>Teacher</em>","matchLevel":"full","fullyHighlighted":true,"matchedWords":["teacher"]},"job_summary":{"value":"Cupiditate
+        itaque deleniti. Perspiciatis nam at. Optio maiores non. Doloremque modi sapiente.","matchLevel":"none","matchedWords":[]},"last_updated_at":{"value":"1612957698","matchLevel":"none","matchedWords":[]},"organisations":{"names":[{"value":"Bexleyheath
+        Academy","matchLevel":"none","matchedWords":[]}],"counties":[{"value":"Kent","matchLevel":"none","matchedWords":[]}],"detailed_school_types":[{"value":"Academy
+        sponsor led","matchLevel":"none","matchedWords":[]}],"regions":[{"value":"London","matchLevel":"none","matchedWords":[]}],"school_types":[{"value":"Academy","matchLevel":"none","matchedWords":[]}],"towns":[{"value":"Bexleyheath","matchLevel":"none","matchedWords":[]}]},"permalink":{"value":"geography-<em>teacher</em>","matchLevel":"full","fullyHighlighted":false,"matchedWords":["teacher"]},"publication_date":{"value":"10
+        February 2021","matchLevel":"none","matchedWords":[]},"publication_date_timestamp":{"value":"1612915200","matchLevel":"none","matchedWords":[]},"start_date":{"value":"10
+        February 2022","matchLevel":"none","matchedWords":[]},"start_date_timestamp":{"value":"1644451200","matchLevel":"none","matchedWords":[]},"subjects_for_display":{"value":"Geography","matchLevel":"none","matchedWords":[]},"working_patterns_for_display":{"value":"Will
+        consider part-time, job share","matchLevel":"none","matchedWords":[]}}},{"education_phases":["secondary"],"job_roles":["teacher"],"job_title":"PE
+        Teacher","parent_organisation_name":"Bexleyheath Academy","salary":"£30,000","subjects":["Physical
+        Education"],"working_patterns":["full_time"],"_geoloc":[{"lat":51.4578146490981,"lng":0.146065490118642}],"expires_at":"14
+        February 2021 at 6:53 am","expires_at_timestamp":1613285580,"job_roles_for_display":"Teacher","job_summary":"Et
+        beatae in. Iste deserunt quo. Delectus sapiente illo. Placeat nihil in.","last_updated_at":1612957698,"organisations":{"names":["Bexleyheath
+        Academy"],"counties":["Kent"],"detailed_school_types":["Academy sponsor led"],"group_type":[],"local_authorities_within":[],"religious_characters":[],"regions":["London"],"school_types":["Academy"],"towns":["Bexleyheath"]},"permalink":"pe-teacher","publication_date":"10
+        February 2021","publication_date_timestamp":1612915200,"start_date":"10 February
+        2022","start_date_timestamp":1644451200,"subjects_for_display":"Physical Education","working_patterns_for_display":"Full-time
+        only","objectID":"9910d184-5686-4ffc-9322-69aa150c19d3","_highlightResult":{"education_phases":[{"value":"secondary","matchLevel":"none","matchedWords":[]}],"job_roles":[{"value":"<em>teacher</em>","matchLevel":"full","fullyHighlighted":true,"matchedWords":["teacher"]}],"job_title":{"value":"PE
+        <em>Teacher</em>","matchLevel":"full","fullyHighlighted":false,"matchedWords":["teacher"]},"parent_organisation_name":{"value":"Bexleyheath
+        Academy","matchLevel":"none","matchedWords":[]},"salary":{"value":"£30,000","matchLevel":"none","matchedWords":[]},"subjects":[{"value":"Physical
+        Education","matchLevel":"none","matchedWords":[]}],"working_patterns":[{"value":"full_time","matchLevel":"none","matchedWords":[]}],"_geoloc":[{"lat":{"value":"51.4578146490981","matchLevel":"none","matchedWords":[]},"lng":{"value":"0.146065490118642","matchLevel":"none","matchedWords":[]}}],"expires_at":{"value":"14
+        February 2021 at 6:53 am","matchLevel":"none","matchedWords":[]},"expires_at_timestamp":{"value":"1613285580","matchLevel":"none","matchedWords":[]},"job_roles_for_display":{"value":"<em>Teacher</em>","matchLevel":"full","fullyHighlighted":true,"matchedWords":["teacher"]},"job_summary":{"value":"Et
+        beatae in. Iste deserunt quo. Delectus sapiente illo. Placeat nihil in.","matchLevel":"none","matchedWords":[]},"last_updated_at":{"value":"1612957698","matchLevel":"none","matchedWords":[]},"organisations":{"names":[{"value":"Bexleyheath
+        Academy","matchLevel":"none","matchedWords":[]}],"counties":[{"value":"Kent","matchLevel":"none","matchedWords":[]}],"detailed_school_types":[{"value":"Academy
+        sponsor led","matchLevel":"none","matchedWords":[]}],"regions":[{"value":"London","matchLevel":"none","matchedWords":[]}],"school_types":[{"value":"Academy","matchLevel":"none","matchedWords":[]}],"towns":[{"value":"Bexleyheath","matchLevel":"none","matchedWords":[]}]},"permalink":{"value":"pe-<em>teacher</em>","matchLevel":"full","fullyHighlighted":false,"matchedWords":["teacher"]},"publication_date":{"value":"10
+        February 2021","matchLevel":"none","matchedWords":[]},"publication_date_timestamp":{"value":"1612915200","matchLevel":"none","matchedWords":[]},"start_date":{"value":"10
+        February 2022","matchLevel":"none","matchedWords":[]},"start_date_timestamp":{"value":"1644451200","matchLevel":"none","matchedWords":[]},"subjects_for_display":{"value":"Physical
+        Education","matchLevel":"none","matchedWords":[]},"working_patterns_for_display":{"value":"Full-time
+        only","matchLevel":"none","matchedWords":[]}}}],"nbHits":6,"page":0,"nbPages":3,"hitsPerPage":2,"exhaustiveNbHits":true,"query":"Teacher","params":"filters=%28publication_date_timestamp+%3C%3D+1613088000+AND+expires_at_timestamp+%3E+1613127331%29&hitsPerPage=2&page=0&query=Teacher","processingTimeMS":1}'
+  recorded_at: Fri, 12 Feb 2021 10:55:32 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr/algoliasearch_teacher_page_3.yml
+++ b/spec/fixtures/vcr/algoliasearch_teacher_page_3.yml
@@ -1,0 +1,301 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://placeholder-dsn.algolia.net/1/indexes/localhost:3000-Vacancy_publish_on_desc/settings?getVersion=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - Algolia for Ruby (1.27.5); Ruby (2.7.2); Algolia for Rails (1.25.0); Rails
+        (6.1.2.1)
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 12 Feb 2021 10:55:31 GMT
+      X-Algolia-Api-Key:
+      - Placeholder
+      X-Algolia-Application-Id:
+      - Placeholder
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 12 Feb 2021 10:55:32 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Accept-Encoding:
+      - deflate, gzip
+      Cache-Control:
+      - no-store
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Disposition:
+      - inline; filename=a.txt
+      Content-Encoding:
+      - gzip
+    body:
+      encoding: UTF-8
+      string: '{"minWordSizefor1Typo":4,"minWordSizefor2Typos":8,"hitsPerPage":20,"maxValuesPerFacet":100,"version":1,"attributesToIndex":null,"numericAttributesToIndex":null,"attributesToRetrieve":null,"unretrievableAttributes":null,"optionalWords":null,"primary":"localhost:3000-Vacancy","attributesForFaceting":["job_roles","working_patterns","education_phases","subjects"],"attributesToSnippet":null,"attributesToHighlight":null,"paginationLimitedTo":1000,"attributeForDistinct":null,"exactOnSingleWordQuery":"attribute","ranking":["desc(publication_date_timestamp)"],"customRanking":null,"separatorsToIndex":"","removeWordsIfNoResults":"none","queryType":"prefixLast","highlightPreTag":"<em>","highlightPostTag":"</em>","snippetEllipsisText":"","alternativesAsExact":["ignorePlurals","singleWordSynonym"]}'
+  recorded_at: Fri, 12 Feb 2021 10:55:32 GMT
+- request:
+    method: put
+    uri: https://placeholder.algolia.net/1/indexes/localhost:3000-Vacancy_publish_on_desc/settings
+    body:
+      encoding: UTF-8
+      string: '{"attributesForFaceting":["job_roles","working_patterns","education_phases","subjects"],"ranking":["desc(publication_date_timestamp)"]}'
+    headers:
+      User-Agent:
+      - Algolia for Ruby (1.27.5); Ruby (2.7.2); Algolia for Rails (1.25.0); Rails
+        (6.1.2.1)
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 12 Feb 2021 10:55:32 GMT
+      X-Algolia-Api-Key:
+      - Placeholder
+      X-Algolia-Application-Id:
+      - Placeholder
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 12 Feb 2021 10:55:32 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '62'
+      Connection:
+      - keep-alive
+      Accept-Encoding:
+      - deflate, gzip
+      Cache-Control:
+      - no-store
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Disposition:
+      - inline; filename=a.txt
+    body:
+      encoding: UTF-8
+      string: '{"updatedAt":"2021-02-12T10:55:32.334Z","taskID":174554616002}'
+  recorded_at: Fri, 12 Feb 2021 10:55:32 GMT
+- request:
+    method: post
+    uri: https://placeholder-dsn.algolia.net/1/indexes/localhost:3000-Vacancy_publish_on_desc/query
+    body:
+      encoding: UTF-8
+      string: '{"params":"filters=%28publication_date_timestamp+%3C%3D+1613088000+AND+expires_at_timestamp+%3E+1613127333%29\u0026hitsPerPage=2\u0026page=0\u0026query=Teacher"}'
+    headers:
+      User-Agent:
+      - Algolia for Ruby (1.27.5); Ruby (2.7.2); Algolia for Rails (1.25.0); Rails
+        (6.1.2.1)
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 12 Feb 2021 10:55:33 GMT
+      X-Algolia-Api-Key:
+      - Placeholder
+      X-Algolia-Application-Id:
+      - Placeholder
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 12 Feb 2021 10:55:33 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Alg-Pt:
+      - '1'
+      Accept-Encoding:
+      - deflate, gzip
+      Cache-Control:
+      - no-store
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Disposition:
+      - inline; filename=a.txt
+      Content-Encoding:
+      - gzip
+    body:
+      encoding: UTF-8
+      string: '{"hits":[{"education_phases":["secondary"],"job_roles":["teacher"],"job_title":"Geography
+        Teacher","parent_organisation_name":"Bexleyheath Academy","salary":"£25,000","subjects":["Geography"],"working_patterns":["part_time","job_share"],"_geoloc":[{"lat":51.4578146490981,"lng":0.146065490118642}],"expires_at":"21
+        February 2021 at 8:15 am","expires_at_timestamp":1613895300,"job_roles_for_display":"Teacher","job_summary":"Cupiditate
+        itaque deleniti. Perspiciatis nam at. Optio maiores non. Doloremque modi sapiente.","last_updated_at":1612957698,"organisations":{"names":["Bexleyheath
+        Academy"],"counties":["Kent"],"detailed_school_types":["Academy sponsor led"],"group_type":[],"local_authorities_within":[],"religious_characters":[],"regions":["London"],"school_types":["Academy"],"towns":["Bexleyheath"]},"permalink":"geography-teacher","publication_date":"10
+        February 2021","publication_date_timestamp":1612915200,"start_date":"10 February
+        2022","start_date_timestamp":1644451200,"subjects_for_display":"Geography","working_patterns_for_display":"Will
+        consider part-time, job share","objectID":"e750baf6-cc9a-4b93-84cf-ee4e5f8a7ee4","_highlightResult":{"education_phases":[{"value":"secondary","matchLevel":"none","matchedWords":[]}],"job_roles":[{"value":"<em>teacher</em>","matchLevel":"full","fullyHighlighted":true,"matchedWords":["teacher"]}],"job_title":{"value":"Geography
+        <em>Teacher</em>","matchLevel":"full","fullyHighlighted":false,"matchedWords":["teacher"]},"parent_organisation_name":{"value":"Bexleyheath
+        Academy","matchLevel":"none","matchedWords":[]},"salary":{"value":"£25,000","matchLevel":"none","matchedWords":[]},"subjects":[{"value":"Geography","matchLevel":"none","matchedWords":[]}],"working_patterns":[{"value":"part_time","matchLevel":"none","matchedWords":[]},{"value":"job_share","matchLevel":"none","matchedWords":[]}],"_geoloc":[{"lat":{"value":"51.4578146490981","matchLevel":"none","matchedWords":[]},"lng":{"value":"0.146065490118642","matchLevel":"none","matchedWords":[]}}],"expires_at":{"value":"21
+        February 2021 at 8:15 am","matchLevel":"none","matchedWords":[]},"expires_at_timestamp":{"value":"1613895300","matchLevel":"none","matchedWords":[]},"job_roles_for_display":{"value":"<em>Teacher</em>","matchLevel":"full","fullyHighlighted":true,"matchedWords":["teacher"]},"job_summary":{"value":"Cupiditate
+        itaque deleniti. Perspiciatis nam at. Optio maiores non. Doloremque modi sapiente.","matchLevel":"none","matchedWords":[]},"last_updated_at":{"value":"1612957698","matchLevel":"none","matchedWords":[]},"organisations":{"names":[{"value":"Bexleyheath
+        Academy","matchLevel":"none","matchedWords":[]}],"counties":[{"value":"Kent","matchLevel":"none","matchedWords":[]}],"detailed_school_types":[{"value":"Academy
+        sponsor led","matchLevel":"none","matchedWords":[]}],"regions":[{"value":"London","matchLevel":"none","matchedWords":[]}],"school_types":[{"value":"Academy","matchLevel":"none","matchedWords":[]}],"towns":[{"value":"Bexleyheath","matchLevel":"none","matchedWords":[]}]},"permalink":{"value":"geography-<em>teacher</em>","matchLevel":"full","fullyHighlighted":false,"matchedWords":["teacher"]},"publication_date":{"value":"10
+        February 2021","matchLevel":"none","matchedWords":[]},"publication_date_timestamp":{"value":"1612915200","matchLevel":"none","matchedWords":[]},"start_date":{"value":"10
+        February 2022","matchLevel":"none","matchedWords":[]},"start_date_timestamp":{"value":"1644451200","matchLevel":"none","matchedWords":[]},"subjects_for_display":{"value":"Geography","matchLevel":"none","matchedWords":[]},"working_patterns_for_display":{"value":"Will
+        consider part-time, job share","matchLevel":"none","matchedWords":[]}}},{"education_phases":["secondary"],"job_roles":["teacher"],"job_title":"PE
+        Teacher","parent_organisation_name":"Bexleyheath Academy","salary":"£30,000","subjects":["Physical
+        Education"],"working_patterns":["full_time"],"_geoloc":[{"lat":51.4578146490981,"lng":0.146065490118642}],"expires_at":"14
+        February 2021 at 6:53 am","expires_at_timestamp":1613285580,"job_roles_for_display":"Teacher","job_summary":"Et
+        beatae in. Iste deserunt quo. Delectus sapiente illo. Placeat nihil in.","last_updated_at":1612957698,"organisations":{"names":["Bexleyheath
+        Academy"],"counties":["Kent"],"detailed_school_types":["Academy sponsor led"],"group_type":[],"local_authorities_within":[],"religious_characters":[],"regions":["London"],"school_types":["Academy"],"towns":["Bexleyheath"]},"permalink":"pe-teacher","publication_date":"10
+        February 2021","publication_date_timestamp":1612915200,"start_date":"10 February
+        2022","start_date_timestamp":1644451200,"subjects_for_display":"Physical Education","working_patterns_for_display":"Full-time
+        only","objectID":"9910d184-5686-4ffc-9322-69aa150c19d3","_highlightResult":{"education_phases":[{"value":"secondary","matchLevel":"none","matchedWords":[]}],"job_roles":[{"value":"<em>teacher</em>","matchLevel":"full","fullyHighlighted":true,"matchedWords":["teacher"]}],"job_title":{"value":"PE
+        <em>Teacher</em>","matchLevel":"full","fullyHighlighted":false,"matchedWords":["teacher"]},"parent_organisation_name":{"value":"Bexleyheath
+        Academy","matchLevel":"none","matchedWords":[]},"salary":{"value":"£30,000","matchLevel":"none","matchedWords":[]},"subjects":[{"value":"Physical
+        Education","matchLevel":"none","matchedWords":[]}],"working_patterns":[{"value":"full_time","matchLevel":"none","matchedWords":[]}],"_geoloc":[{"lat":{"value":"51.4578146490981","matchLevel":"none","matchedWords":[]},"lng":{"value":"0.146065490118642","matchLevel":"none","matchedWords":[]}}],"expires_at":{"value":"14
+        February 2021 at 6:53 am","matchLevel":"none","matchedWords":[]},"expires_at_timestamp":{"value":"1613285580","matchLevel":"none","matchedWords":[]},"job_roles_for_display":{"value":"<em>Teacher</em>","matchLevel":"full","fullyHighlighted":true,"matchedWords":["teacher"]},"job_summary":{"value":"Et
+        beatae in. Iste deserunt quo. Delectus sapiente illo. Placeat nihil in.","matchLevel":"none","matchedWords":[]},"last_updated_at":{"value":"1612957698","matchLevel":"none","matchedWords":[]},"organisations":{"names":[{"value":"Bexleyheath
+        Academy","matchLevel":"none","matchedWords":[]}],"counties":[{"value":"Kent","matchLevel":"none","matchedWords":[]}],"detailed_school_types":[{"value":"Academy
+        sponsor led","matchLevel":"none","matchedWords":[]}],"regions":[{"value":"London","matchLevel":"none","matchedWords":[]}],"school_types":[{"value":"Academy","matchLevel":"none","matchedWords":[]}],"towns":[{"value":"Bexleyheath","matchLevel":"none","matchedWords":[]}]},"permalink":{"value":"pe-<em>teacher</em>","matchLevel":"full","fullyHighlighted":false,"matchedWords":["teacher"]},"publication_date":{"value":"10
+        February 2021","matchLevel":"none","matchedWords":[]},"publication_date_timestamp":{"value":"1612915200","matchLevel":"none","matchedWords":[]},"start_date":{"value":"10
+        February 2022","matchLevel":"none","matchedWords":[]},"start_date_timestamp":{"value":"1644451200","matchLevel":"none","matchedWords":[]},"subjects_for_display":{"value":"Physical
+        Education","matchLevel":"none","matchedWords":[]},"working_patterns_for_display":{"value":"Full-time
+        only","matchLevel":"none","matchedWords":[]}}}],"nbHits":6,"page":0,"nbPages":3,"hitsPerPage":2,"exhaustiveNbHits":true,"query":"Teacher","params":"filters=%28publication_date_timestamp+%3C%3D+1613088000+AND+expires_at_timestamp+%3E+1613127333%29&hitsPerPage=2&page=0&query=Teacher","processingTimeMS":1}'
+  recorded_at: Fri, 12 Feb 2021 10:55:33 GMT
+- request:
+    method: post
+    uri: https://placeholder-dsn.algolia.net/1/indexes/localhost:3000-Vacancy_publish_on_desc/query
+    body:
+      encoding: UTF-8
+      string: '{"params":"filters=%28publication_date_timestamp+%3C%3D+1613088000+AND+expires_at_timestamp+%3E+1613127333%29\u0026hitsPerPage=2\u0026page=2\u0026query=Teacher"}'
+    headers:
+      User-Agent:
+      - Algolia for Ruby (1.27.5); Ruby (2.7.2); Algolia for Rails (1.25.0); Rails
+        (6.1.2.1)
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 12 Feb 2021 10:55:33 GMT
+      X-Algolia-Api-Key:
+      - Placeholder
+      X-Algolia-Application-Id:
+      - Placeholder
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 12 Feb 2021 10:55:33 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Alg-Pt:
+      - '1'
+      Accept-Encoding:
+      - deflate, gzip
+      Cache-Control:
+      - no-store
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Disposition:
+      - inline; filename=a.txt
+      Content-Encoding:
+      - gzip
+    body:
+      encoding: UTF-8
+      string: '{"hits":[{"education_phases":["primary"],"job_roles":["teacher"],"job_title":"Chemistry
+        Teacher","parent_organisation_name":"Upton Cross ACE Academy","salary":"£55,000","subjects":["Chemistry"],"working_patterns":["full_time","part_time","job_share"],"_geoloc":[{"lat":50.52350433336815,"lng":-4.427269703777728}],"expires_at":"20
+        February 2021 at 3:33 am","expires_at_timestamp":1613791980,"job_roles_for_display":"Teacher","job_summary":"Ea
+        natus cumque. Harum earum minus. Maxime cumque est. Qui molestiae cumque.","last_updated_at":1612957698,"organisations":{"names":["Upton
+        Cross ACE Academy"],"counties":["Cornwall"],"detailed_school_types":["Academy
+        converter"],"group_type":[],"local_authorities_within":[],"religious_characters":[],"regions":["London"],"school_types":["Academy"],"towns":["Liskeard"]},"permalink":"chemistry-teacher","publication_date":"10
+        February 2021","publication_date_timestamp":1612915200,"start_date":"10 February
+        2022","start_date_timestamp":1644451200,"subjects_for_display":"Chemistry","working_patterns_for_display":"Will
+        consider full-time, part-time, job share","objectID":"3bf67da6-039c-4ee1-bf59-8475672a0d2b","_highlightResult":{"education_phases":[{"value":"primary","matchLevel":"none","matchedWords":[]}],"job_roles":[{"value":"<em>teacher</em>","matchLevel":"full","fullyHighlighted":true,"matchedWords":["teacher"]}],"job_title":{"value":"Chemistry
+        <em>Teacher</em>","matchLevel":"full","fullyHighlighted":false,"matchedWords":["teacher"]},"parent_organisation_name":{"value":"Upton
+        Cross ACE Academy","matchLevel":"none","matchedWords":[]},"salary":{"value":"£55,000","matchLevel":"none","matchedWords":[]},"subjects":[{"value":"Chemistry","matchLevel":"none","matchedWords":[]}],"working_patterns":[{"value":"full_time","matchLevel":"none","matchedWords":[]},{"value":"part_time","matchLevel":"none","matchedWords":[]},{"value":"job_share","matchLevel":"none","matchedWords":[]}],"_geoloc":[{"lat":{"value":"50.52350433336815","matchLevel":"none","matchedWords":[]},"lng":{"value":"-4.427269703777728","matchLevel":"none","matchedWords":[]}}],"expires_at":{"value":"20
+        February 2021 at 3:33 am","matchLevel":"none","matchedWords":[]},"expires_at_timestamp":{"value":"1613791980","matchLevel":"none","matchedWords":[]},"job_roles_for_display":{"value":"<em>Teacher</em>","matchLevel":"full","fullyHighlighted":true,"matchedWords":["teacher"]},"job_summary":{"value":"Ea
+        natus cumque. Harum earum minus. Maxime cumque est. Qui molestiae cumque.","matchLevel":"none","matchedWords":[]},"last_updated_at":{"value":"1612957698","matchLevel":"none","matchedWords":[]},"organisations":{"names":[{"value":"Upton
+        Cross ACE Academy","matchLevel":"none","matchedWords":[]}],"counties":[{"value":"Cornwall","matchLevel":"none","matchedWords":[]}],"detailed_school_types":[{"value":"Academy
+        converter","matchLevel":"none","matchedWords":[]}],"regions":[{"value":"London","matchLevel":"none","matchedWords":[]}],"school_types":[{"value":"Academy","matchLevel":"none","matchedWords":[]}],"towns":[{"value":"Liskeard","matchLevel":"none","matchedWords":[]}]},"permalink":{"value":"chemistry-<em>teacher</em>","matchLevel":"full","fullyHighlighted":false,"matchedWords":["teacher"]},"publication_date":{"value":"10
+        February 2021","matchLevel":"none","matchedWords":[]},"publication_date_timestamp":{"value":"1612915200","matchLevel":"none","matchedWords":[]},"start_date":{"value":"10
+        February 2022","matchLevel":"none","matchedWords":[]},"start_date_timestamp":{"value":"1644451200","matchLevel":"none","matchedWords":[]},"subjects_for_display":{"value":"Chemistry","matchLevel":"none","matchedWords":[]},"working_patterns_for_display":{"value":"Will
+        consider full-time, part-time, job share","matchLevel":"none","matchedWords":[]}}},{"education_phases":["secondary"],"job_roles":["teacher"],"job_title":"Physics
+        Teacher","parent_organisation_name":"Bexleyheath Academy","salary":"£35,000","subjects":["Physics"],"working_patterns":["full_time"],"_geoloc":[{"lat":51.4578146490981,"lng":0.146065490118642}],"expires_at":"22
+        February 2021 at 6:55 pm","expires_at_timestamp":1614020100,"job_roles_for_display":"Teacher","job_summary":"Sunt
+        optio mollitia. Dolores placeat quos. Quae nihil doloribus. Vel autem consequuntur.","last_updated_at":1612957697,"organisations":{"names":["Bexleyheath
+        Academy"],"counties":["Kent"],"detailed_school_types":["Academy sponsor led"],"group_type":[],"local_authorities_within":[],"religious_characters":[],"regions":["London"],"school_types":["Academy"],"towns":["Bexleyheath"]},"permalink":"physics-teacher","publication_date":"10
+        February 2021","publication_date_timestamp":1612915200,"start_date":"10 February
+        2022","start_date_timestamp":1644451200,"subjects_for_display":"Physics","working_patterns_for_display":"Full-time
+        only","objectID":"20cc99ff-4fdb-4637-851a-68cf5f8fea9f","_highlightResult":{"education_phases":[{"value":"secondary","matchLevel":"none","matchedWords":[]}],"job_roles":[{"value":"<em>teacher</em>","matchLevel":"full","fullyHighlighted":true,"matchedWords":["teacher"]}],"job_title":{"value":"Physics
+        <em>Teacher</em>","matchLevel":"full","fullyHighlighted":false,"matchedWords":["teacher"]},"parent_organisation_name":{"value":"Bexleyheath
+        Academy","matchLevel":"none","matchedWords":[]},"salary":{"value":"£35,000","matchLevel":"none","matchedWords":[]},"subjects":[{"value":"Physics","matchLevel":"none","matchedWords":[]}],"working_patterns":[{"value":"full_time","matchLevel":"none","matchedWords":[]}],"_geoloc":[{"lat":{"value":"51.4578146490981","matchLevel":"none","matchedWords":[]},"lng":{"value":"0.146065490118642","matchLevel":"none","matchedWords":[]}}],"expires_at":{"value":"22
+        February 2021 at 6:55 pm","matchLevel":"none","matchedWords":[]},"expires_at_timestamp":{"value":"1614020100","matchLevel":"none","matchedWords":[]},"job_roles_for_display":{"value":"<em>Teacher</em>","matchLevel":"full","fullyHighlighted":true,"matchedWords":["teacher"]},"job_summary":{"value":"Sunt
+        optio mollitia. Dolores placeat quos. Quae nihil doloribus. Vel autem consequuntur.","matchLevel":"none","matchedWords":[]},"last_updated_at":{"value":"1612957697","matchLevel":"none","matchedWords":[]},"organisations":{"names":[{"value":"Bexleyheath
+        Academy","matchLevel":"none","matchedWords":[]}],"counties":[{"value":"Kent","matchLevel":"none","matchedWords":[]}],"detailed_school_types":[{"value":"Academy
+        sponsor led","matchLevel":"none","matchedWords":[]}],"regions":[{"value":"London","matchLevel":"none","matchedWords":[]}],"school_types":[{"value":"Academy","matchLevel":"none","matchedWords":[]}],"towns":[{"value":"Bexleyheath","matchLevel":"none","matchedWords":[]}]},"permalink":{"value":"physics-<em>teacher</em>","matchLevel":"full","fullyHighlighted":false,"matchedWords":["teacher"]},"publication_date":{"value":"10
+        February 2021","matchLevel":"none","matchedWords":[]},"publication_date_timestamp":{"value":"1612915200","matchLevel":"none","matchedWords":[]},"start_date":{"value":"10
+        February 2022","matchLevel":"none","matchedWords":[]},"start_date_timestamp":{"value":"1644451200","matchLevel":"none","matchedWords":[]},"subjects_for_display":{"value":"Physics","matchLevel":"none","matchedWords":[]},"working_patterns_for_display":{"value":"Full-time
+        only","matchLevel":"none","matchedWords":[]}}}],"nbHits":6,"page":2,"nbPages":3,"hitsPerPage":2,"exhaustiveNbHits":true,"query":"Teacher","params":"filters=%28publication_date_timestamp+%3C%3D+1613088000+AND+expires_at_timestamp+%3E+1613127333%29&hitsPerPage=2&page=2&query=Teacher","processingTimeMS":1}'
+  recorded_at: Fri, 12 Feb 2021 10:55:33 GMT
+recorded_with: VCR 6.0.0

--- a/spec/page_objects/vacancy/index.rb
+++ b/spec/page_objects/vacancy/index.rb
@@ -24,7 +24,7 @@ module PageObjects
       set_url "/jobs"
       set_url_matcher(/jobs/)
 
-      element :search_button, ".govuk-button"
+      element :search_button, "input[value='Search']"
       element :sort_field, "#jobs-sort-field"
       element :stats, "#vacancies-stats-top"
       section :filters, PageObjects::Search::Filters, ".filters-form"

--- a/spec/services/search/buffer_suggestions_builder_spec.rb
+++ b/spec/services/search/buffer_suggestions_builder_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Search::BufferSuggestionsBuilder do
         allow(LocationPolygon).to receive_message_chain(:with_name, :buffers).and_return(buffer_hash)
         search_hits.zip(all_buffer_coordinates).each do |search_hits_count, buffered_polygons|
           mock_algolia_search(
-            double("vacancies"), search_hits_count, nil,
+            double("vacancies", none?: false), search_hits_count, nil,
             arguments_for_algolia.merge(insidePolygon: buffered_polygons)
           )
         end
@@ -72,7 +72,7 @@ RSpec.describe Search::BufferSuggestionsBuilder do
           buffer_coordinates_for_all_districts = []
           districts.length.times { buffered_polygons.each { |polygon| buffer_coordinates_for_all_districts.push(polygon) } }
           mock_algolia_search(
-            double("vacancies"), search_hits_count, nil,
+            double("vacancies", none?: false), search_hits_count, nil,
             arguments_for_algolia.merge(insidePolygon: buffer_coordinates_for_all_districts)
           )
         end

--- a/spec/services/search/radius_suggestions_builder_spec.rb
+++ b/spec/services/search/radius_suggestions_builder_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Search::RadiusSuggestionsBuilder do
     before do
       search_hits.zip(wider_radii).each do |search_hits_count, radius_option|
         mock_algolia_search(
-          double("vacancies"), search_hits_count, "maths",
+          double("vacancies", none?: false), search_hits_count, "maths",
           arguments_for_algolia.merge(aroundRadius: convert_miles_to_metres(radius_option))
         )
       end

--- a/spec/services/search/strategies/algolia_spec.rb
+++ b/spec/services/search/strategies/algolia_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Search::Strategies::Algolia do
   let(:subject) { described_class.new(search_params) }
 
-  let(:vacancies) { double("vacancies") }
+  let(:vacancies) { double("vacancies", none?: false) }
 
   let(:search_params) do
     {

--- a/spec/services/search/vacancy_search_spec.rb
+++ b/spec/services/search/vacancy_search_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Search::VacancySearch do
     let(:page) { 3 }
 
     before do
-      mock_algolia_search(double(raw_answer: nil), 50, keyword, anything)
+      mock_algolia_search(double(none?: false), 50, keyword, anything)
     end
 
     it "returns the expected bounds" do
@@ -37,7 +37,7 @@ RSpec.describe Search::VacancySearch do
 
     context "when out of bounds" do
       before do
-        mock_algolia_search(double(raw_answer: nil), 20, keyword, anything)
+        mock_algolia_search(double(none?: false), 20, keyword, anything)
       end
 
       it "returns the expected bounds" do

--- a/spec/system/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
+++ b/spec/system/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Jobseekers can create a job alert from a search", recaptcha: true do
+RSpec.describe "Jobseekers can create a job alert from a search", recaptcha: true, vcr: { cassette_name: "algoliasearch" } do
   let(:location) { nil }
   let(:search_with_polygons?) { false }
   let(:jobseeker_signed_in?) { false }

--- a/spec/system/jobseekers_can_search_for_jobs_spec.rb
+++ b/spec/system/jobseekers_can_search_for_jobs_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe "Jobseekers can search for jobs" do
+  let(:jobs_page) { PageObjects::Vacancy::Index.new }
+  let(:school) { create(:school) }
+  let!(:maths_job1) { create(:vacancy, :past_publish, id: "67991ea9-431d-4d9d-9c99-a78b80108fe1", job_title: "Maths Teacher", organisation_vacancies_attributes: [{ organisation: school }]) }
+  let!(:maths_job2) { create(:vacancy, :past_publish, id: "7bfadb84-cf30-4121-88bd-a9f958440cc9", job_title: "Maths Teacher 2", organisation_vacancies_attributes: [{ organisation: school }]) }
+  let!(:job1) { create(:vacancy, :past_publish, id: "20cc99ff-4fdb-4637-851a-68cf5f8fea9f", job_title: "Physics Teacher", organisation_vacancies_attributes: [{ organisation: school }]) }
+  let!(:job2) { create(:vacancy, :past_publish, id: "9910d184-5686-4ffc-9322-69aa150c19d3", job_title: "PE Teacher", organisation_vacancies_attributes: [{ organisation: school }]) }
+  let!(:job3) { create(:vacancy, :past_publish, id: "3bf67da6-039c-4ee1-bf59-8475672a0d2b", job_title: "Chemistry Teacher", organisation_vacancies_attributes: [{ organisation: school }]) }
+  let!(:job4) { create(:vacancy, :past_publish, id: "e750baf6-cc9a-4b93-84cf-ee4e5f8a7ee4", job_title: "Geography Teacher", organisation_vacancies_attributes: [{ organisation: school }]) }
+  let!(:expired_job) { create(:vacancy, :expired, id: "0f86d38c-56d4-48d3-b8a2-474f19d4908e", job_title: "Maths Teacher", organisation_vacancies_attributes: [{ organisation: school }]) }
+
+  before do
+    stub_const("Search::VacancySearch::DEFAULT_HITS_PER_PAGE", 2)
+
+    jobs_page.load
+    jobs_page.filters.keyword.set(keyword)
+    jobs_page.search
+  end
+
+  context "when searching for teacher jobs" do
+    let(:keyword) { "Teacher" }
+
+    it "displays page 1 jobs", vcr: { cassette_name: "algoliasearch teacher page 1" } do
+      expect(jobs_page).to have_jobs(count: 2)
+      expect(jobs_page.stats).to have_content(strip_tags(I18n.t("jobs.number_of_results_html", first: 1, last: 2, count: 6)))
+    end
+
+    context "when navigating between pages" do
+      it "displays page 3 jobs", vcr: { cassette_name: "algoliasearch teacher page 3" } do
+        jobs_page.pagination.go_to("3")
+
+        expect(jobs_page).to have_jobs(count: 2)
+        expect(jobs_page.stats).to have_content(strip_tags(I18n.t("jobs.number_of_results_html", first: 5, last: 6, count: 6)))
+      end
+    end
+  end
+
+  context "when searching for maths jobs", vcr: { cassette_name: "algoliasearch maths" } do
+    let(:keyword) { "Maths Teacher" }
+
+    it "displays the Maths jobs" do
+      expect(jobs_page).to have_jobs(count: 2)
+      expect(jobs_page.stats).to have_content(strip_tags(I18n.t("jobs.number_of_results_one_page_html", count: 2)))
+      expect(jobs_page.jobs.first.job_title).to eq("Maths Teacher")
+      expect(jobs_page.jobs.last.job_title).to eq("Maths Teacher 2")
+    end
+
+    context "when sorting the jobs", js: true do
+      before do
+        jobs_page.sort_field.find("option[value='expires_at_asc']").click
+      end
+
+      it "displays the Maths jobs that expires soonest first" do
+        expect(jobs_page).to have_jobs(count: 2)
+        expect(jobs_page.stats).to have_content(strip_tags(I18n.t("jobs.number_of_results_one_page_html", count: 2)))
+        expect(jobs_page.jobs.first.job_title).to eq("Maths Teacher 2")
+        expect(jobs_page.jobs.last.job_title).to eq("Maths Teacher")
+      end
+    end
+  end
+end

--- a/spec/system/jobseekers_can_search_from_home_page_spec.rb
+++ b/spec/system/jobseekers_can_search_from_home_page_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Searching on the home page" do
+RSpec.describe "Searching on the home page", vcr: { cassette_name: "algoliasearch" } do
   let(:home_page) { PageObjects::Home.new }
   let(:jobs_page) { PageObjects::Vacancy::Index.new }
 

--- a/spec/system/jobseekers_can_subscribe_to_an_nqt_job_alert_spec.rb
+++ b/spec/system/jobseekers_can_subscribe_to_an_nqt_job_alert_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "NQT job alerts", recaptcha: true do
+RSpec.describe "NQT job alerts", recaptcha: true, vcr: { cassette_name: "algoliasearch" } do
   before do
     visit nqt_job_alerts_path
   end

--- a/spec/system/jobseekers_can_view_and_visit_homepage_facets_spec.rb
+++ b/spec/system/jobseekers_can_view_and_visit_homepage_facets_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Jobseekers can view and visit homepage facets" do
+RSpec.describe "Jobseekers can view and visit homepage facets", vcr: { cassette_name: "algoliasearch" } do
   let(:home_page) { PageObjects::Home.new }
   let(:jobs_page) { PageObjects::Vacancy::Index.new }
 


### PR DESCRIPTION
VCR records request/response to cassettes which can be replayed for testing purposes.

In order to ensure we can all use the same test files and avoid the need for app IDs or secrets in the pipeline, responses have been anonymised and use the placeholder environment variables. 

For now VCR has been implemented only for algolia search, and mainly for a single spec file. There is a generic algoliasearch cassette which can be used to stub a useful response for other specs. 

In future I imagine we may want to refine this approach, and also add cassettes to improve other system specs that call out to external API services (e.g Google Drive API).

## Changes in this PR
- Add VCR gem
- Update Algolia config for test environment 
- Add a jobs search system spec