### PR TITLE
Start reporting CSP violations again

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -44,10 +44,7 @@ Rails.application.config.content_security_policy do |policy|
                      "https://fonts.googleapis.com" # through Google Maps
 
   # Specify URI for violation reports
-  # TODO: Temporarily commented out until bug in `rollbar` gem is fixed which is causing two violations per pageview
-  #       and making us go over our Rollbar quota
-  #       https://github.com/rollbar/rollbar-gem/pull/1010
-  # policy.report_uri "/errors/csp_violation"
+  policy.report_uri "/errors/csp_violation"
 end
 
 # Enable automatic nonce generation for <script> tags


### PR DESCRIPTION
We had turned this off because the Rollbar gem generated a CSP violation
on every pageview due to it skipping the CSP nonce if `unsafe_inline`
was set (which we do for backwards compatibility), but this has been
fixed in 3.1.2 and there seem to be no spurious CSP violations left.

We'll continue running in report-only mode for the time being, but in
theory we should no longer receive any reports now! 🎉 