### PR TITLE
TF AWS provider version bump

### DIFF
--- a/terraform/app/modules/cloudfront/versions.tf
+++ b/terraform/app/modules/cloudfront/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "-/aws"
-      version = "~> 3.8.0"
+      version = "~> 3.28.0"
     }
   }
 }

--- a/terraform/app/modules/cloudwatch/versions.tf
+++ b/terraform/app/modules/cloudwatch/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "-/aws"
-      version = "~> 3.8.0"
+      version = "~> 3.28.0"
     }
     template = {
       source  = "hashicorp/template"

--- a/terraform/app/modules/paas/versions.tf
+++ b/terraform/app/modules/paas/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "-/aws"
-      version = "~> 3.8.0"
+      version = "~> 3.28.0"
     }
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"

--- a/terraform/app/versions.tf
+++ b/terraform/app/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "-/aws"
-      version = "~> 3.8.0"
+      version = ">= 3.28.0"
     }
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"

--- a/terraform/common/modules/domains/versions.tf
+++ b/terraform/common/modules/domains/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "-/aws"
-      version = "~> 3.18.0"
+      version = "~> 3.28.0"
     }
   }
 }

--- a/terraform/common/versions.tf
+++ b/terraform/common/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "-/aws"
-      version = "~> 3.18.0"
+      version = ">= 3.28.0"
     }
   }
 }

--- a/terraform/monitoring/versions.tf
+++ b/terraform/monitoring/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.15.0"
+      version = "~> 3.28.0"
     }
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2009

## Changes in this PR:

- Version bump of Terraform AWS Provider to 3.28.0
- Changed version comparison operator from `~>` (increments only the revision number) to `>=`
