### PR TITLE
[TEVA-2007] Terraform CLI upgrade

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Terraform pin version
       uses: hashicorp/setup-terraform@v1
       with:
-        terraform_version: 0.13.5
+        terraform_version: 0.14.6
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1

--- a/.github/workflows/deploy_app.yml
+++ b/.github/workflows/deploy_app.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Pin Terraform version
       uses: hashicorp/setup-terraform@v1
       with:
-        terraform_version: 0.13.5
+        terraform_version: 0.14.6
 
     - name: Set environment variables for review
       if: startsWith(github.event.inputs.environment, 'review')

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Terraform pin version
       uses: hashicorp/setup-terraform@v1
       with:
-        terraform_version: 0.13.5
+        terraform_version: 0.14.6
 
     - name: Terraform destroy (on PR closed)
       env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Terraform pin version
         uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.13.5
+          terraform_version: 0.14.6
 
       - name: Terraform fmt check
         run: |

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Pin Terraform version
         uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.13.5
+          terraform_version: 0.14.6
           terraform_wrapper: false
 
       - name: Get current Docker tag from Terraform output

--- a/terraform/app/modules/cloudfront/versions.tf
+++ b/terraform/app/modules/cloudfront/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 0.13.0"
   required_providers {
     aws = {
       source  = "-/aws"
-      version = "~> 3.8.0"
+      version = ">= 3.8.0"
     }
   }
 }

--- a/terraform/app/modules/cloudfront/versions.tf
+++ b/terraform/app/modules/cloudfront/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      source  = "-/aws"
+      source  = "hashicorp/aws"
       version = ">= 3.8.0"
     }
   }

--- a/terraform/app/modules/cloudwatch/versions.tf
+++ b/terraform/app/modules/cloudwatch/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      source  = "-/aws"
+      source  = "hashicorp/aws"
       version = ">= 3.8.0"
     }
     template = {

--- a/terraform/app/modules/cloudwatch/versions.tf
+++ b/terraform/app/modules/cloudwatch/versions.tf
@@ -1,13 +1,13 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 0.13.0"
   required_providers {
     aws = {
       source  = "-/aws"
-      version = "~> 3.8.0"
+      version = ">= 3.8.0"
     }
     template = {
       source  = "hashicorp/template"
-      version = ">= 2.0.0"
+      version = ">= 2.2.0"
     }
   }
 }

--- a/terraform/app/modules/paas/versions.tf
+++ b/terraform/app/modules/paas/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      source  = "-/aws"
+      source  = "hashicorp/aws"
       version = ">= 3.8.0"
     }
     cloudfoundry = {

--- a/terraform/app/modules/paas/versions.tf
+++ b/terraform/app/modules/paas/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 0.13.0"
   required_providers {
     aws = {
       source  = "-/aws"
-      version = "~> 3.8.0"
+      version = ">= 3.8.0"
     }
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"

--- a/terraform/app/modules/statuscake/versions.tf
+++ b/terraform/app/modules/statuscake/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 0.13.0"
   required_providers {
     statuscake = {
       source  = "terraform-providers/statuscake"

--- a/terraform/app/versions.tf
+++ b/terraform/app/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = "~> 0.14.0"
   required_providers {
     aws = {
       source  = "-/aws"
@@ -7,7 +7,7 @@ terraform {
     }
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"
-      version = ">= 0.13.0"
+      version = "~> 0.13.0"
     }
     statuscake = {
       source  = "terraform-providers/statuscake"
@@ -15,7 +15,7 @@ terraform {
     }
     template = {
       source  = "hashicorp/template"
-      version = "~> 2.1.2"
+      version = "~> 2.2.0"
     }
   }
 }

--- a/terraform/app/versions.tf
+++ b/terraform/app/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = "~> 0.14.0"
   required_providers {
     aws = {
-      source  = "-/aws"
+      source  = "hashicorp/aws"
       version = "~> 3.8.0"
     }
     cloudfoundry = {

--- a/terraform/common/modules/domains/versions.tf
+++ b/terraform/common/modules/domains/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 0.13.0"
   required_providers {
     aws = {
       source  = "-/aws"
-      version = "~> 3.18.0"
+      version = ">= 3.18.0"
     }
   }
 }

--- a/terraform/common/modules/domains/versions.tf
+++ b/terraform/common/modules/domains/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      source  = "-/aws"
+      source  = "hashicorp/aws"
       version = ">= 3.18.0"
     }
   }

--- a/terraform/common/versions.tf
+++ b/terraform/common/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = "~> 0.14.0"
   required_providers {
     aws = {
       source  = "-/aws"

--- a/terraform/common/versions.tf
+++ b/terraform/common/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = "~> 0.14.0"
   required_providers {
     aws = {
-      source  = "-/aws"
+      source  = "hashicorp/aws"
       version = "~> 3.18.0"
     }
   }

--- a/terraform/monitoring/versions.tf
+++ b/terraform/monitoring/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = "~> 0.14.0"
   required_providers {
     archive = {
       source  = "hashicorp/archive"
@@ -11,7 +11,7 @@ terraform {
     }
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"
-      version = ">= 0.13.0"
+      version = "~> 0.13.0"
     }
   }
 }


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2007

## Changes in this PR:

- Updated GitHub Actions workflows to use Terraform `0.14.6`
- Used version constraints as per [Terraform documentation](https://www.terraform.io/docs/language/expressions/version-constraints.html#terraform-core-and-provider-versions) - `>=` inside the module and `~>` outside
- Set the module constraints to require `0.13.0` and above
- Set the root constraints to require `0.14.0` and above (within the `0.14` release family)
- Updated the provider name for AWS from `-/aws` to `hashicorp/aws`, as this was throwing an error when using `0.14.6`

## Next steps:

- [ ] Update AWS provider in existing state files with
```
terraform state replace-provider 'registry.terraform.io/-/aws' 'terraform.example.com/hashicorp/aws'
```