### PR TITLE
[TEVA-2009] Terraform AWS provider name and version

### DIFF
--- a/terraform/app/modules/cloudfront/versions.tf
+++ b/terraform/app/modules/cloudfront/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.1"
   required_providers {
     aws = {
-      source  = "-/aws"
+      source  = "hashicorp/aws"
       version = ">= 3.28.0"
     }
   }

--- a/terraform/app/modules/cloudfront/versions.tf
+++ b/terraform/app/modules/cloudfront/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "-/aws"
-      version = ">= 3.8.0"
+      version = ">= 3.28.0"
     }
   }
 }

--- a/terraform/app/modules/cloudwatch/versions.tf
+++ b/terraform/app/modules/cloudwatch/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.1"
   required_providers {
     aws = {
-      source  = "-/aws"
+      source  = "hashicorp/aws"
       version = ">= 3.28.0"
     }
     template = {

--- a/terraform/app/modules/cloudwatch/versions.tf
+++ b/terraform/app/modules/cloudwatch/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "-/aws"
-      version = ">= 3.8.0"
+      version = ">= 3.28.0"
     }
     template = {
       source  = "hashicorp/template"

--- a/terraform/app/modules/paas/versions.tf
+++ b/terraform/app/modules/paas/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.1"
   required_providers {
     aws = {
-      source  = "-/aws"
+      source  = "hashicorp/aws"
       version = ">= 3.28.0"
     }
     cloudfoundry = {

--- a/terraform/app/modules/paas/versions.tf
+++ b/terraform/app/modules/paas/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "-/aws"
-      version = ">= 3.8.0"
+      version = ">= 3.28.0"
     }
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"

--- a/terraform/app/versions.tf
+++ b/terraform/app/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = "~> 0.13.1"
   required_providers {
     aws = {
-      source  = "-/aws"
+      source  = "hashicorp/aws"
       version = "~> 3.28.0"
     }
     cloudfoundry = {

--- a/terraform/app/versions.tf
+++ b/terraform/app/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "-/aws"
-      version = "~> 3.8.0"
+      version = "~> 3.28.0"
     }
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"

--- a/terraform/common/modules/domains/versions.tf
+++ b/terraform/common/modules/domains/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "-/aws"
-      version = ">= 3.18.0"
+      version = ">= 3.28.0"
     }
   }
 }

--- a/terraform/common/modules/domains/versions.tf
+++ b/terraform/common/modules/domains/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.1"
   required_providers {
     aws = {
-      source  = "-/aws"
+      source  = "hashicorp/aws"
       version = ">= 3.28.0"
     }
   }

--- a/terraform/common/versions.tf
+++ b/terraform/common/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "-/aws"
-      version = "~> 3.18.0"
+      version = "~> 3.28.0"
     }
   }
 }

--- a/terraform/common/versions.tf
+++ b/terraform/common/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = "~> 0.13.1"
   required_providers {
     aws = {
-      source  = "-/aws"
+      source  = "hashicorp/aws"
       version = "~> 3.28.0"
     }
   }

--- a/terraform/monitoring/versions.tf
+++ b/terraform/monitoring/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.15.0"
+      version = "~> 3.28.0"
     }
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2009

## Changes in this PR:

- Upgrade version of Terraform AWS provider to `3.28.0` throughout
- Rename provider with full namespace (from `-/aws` to `hashicorp/aws` as per [Terraform guide on upgrading to 0.13](https://www.terraform.io/upgrade-guides/0-13.html)

## Next steps 

New code, current state:

```
terraform state show 'module.cloudfront["tvsdev"].data.aws_acm_certificate.cloudfront_cert'
```
Gives error
```
Error: Could not load plugin
Failed to instantiate provider "registry.terraform.io/-/aws" to obtain schema:
unknown provider "registry.terraform.io/-/aws"
```

- Against each state file, apply the provider name change with
```
terraform state replace-provider 'registry.terraform.io/-/aws' 'registry.terraform.io/hashicorp/aws'
```
