### PR TITLE
[TEVA-2011] Statuscake Terraform provider version bump

### DIFF
--- a/terraform/app/modules/statuscake/versions.tf
+++ b/terraform/app/modules/statuscake/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_version = ">= 0.13.1"
   required_providers {
     statuscake = {
-      source  = "terraform-providers/statuscake"
-      version = ">= 1.0.0"
+      source  = "StatusCakeDev/statuscake"
+      version = ">= 1.0.1"
     }
   }
 }

--- a/terraform/app/versions.tf
+++ b/terraform/app/versions.tf
@@ -10,8 +10,8 @@ terraform {
       version = "~> 0.13.0"
     }
     statuscake = {
-      source  = "terraform-providers/statuscake"
-      version = "~> 1.0.0"
+      source  = "StatusCakeDev/statuscake"
+      version = "~> 1.0.1"
     }
     template = {
       source  = "hashicorp/template"


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2011

## Changes in this PR:

The Statuscake provider has moved. This PR
- changes the name of the provider in use
- bumps the version to `1.0.1`

## Next steps:

On `master`
```
cd terraform/app
terraform init
terraform workspace select production
terraform state show 'module.statuscake.statuscake_test.alert["PaaS500String"]'
```

But with new code, before replacing provider:
```
Error: Could not load plugin
Failed to instantiate provider
"registry.terraform.io/terraform-providers/statuscake" to obtain schema:
unknown provider "registry.terraform.io/terraform-providers/statuscake"
```

As per https://www.terraform.io/upgrade-guides/0-13.html, rename the provider name in the production state file with 
```
terraform state replace-provider 'registry.terraform.io/terraform-providers/statuscake' 'registry.terraform.io/StatusCakeDev/statuscake'
```
