### PR TITLE
Do not send arrays to BigQuery

### DIFF
--- a/app/services/event.rb
+++ b/app/services/event.rb
@@ -34,15 +34,13 @@ class Event
   end
 
   ##
-  # For json objects or hashes passed to Event#trigger as values in the `data` param, such as
-  # Subscription#search_criteria or Feedback#search_criteria, we should format these as json for BigQuery,
-  # rather than strings, for easier data manipulation by Performance Analysis.
-  # Floats, Integers and Arrays, such as job alert Feedbacks with a job_alert_vacancy_ids attribute,
-  # should remain as they are.
+  # For json objects or hashes passed to Event#trigger as values in the `data` param, such as Feedback#search_criteria,
+  # we should format these as json for BigQuery, rather than strings, for easier manipulation by Performance Analysis.
+  # Floats and Integers should remain as they are. Do not pass Arrays to BigQuery without converting them to string:
+  # otherwise, it will give the error "Array specified for non repeated field" when the array has length of 1.
   # @param [Object] value Any value in the data passed to the event.
   def formatted_value(value)
     return value if value.is_a?(Float) || value.is_a?(Integer)
-    return value.map { |item| formatted_value(item) } if value.is_a?(Array)
 
     value.respond_to?(:keys) ? value.to_json : value&.to_s
   end

--- a/lib/tasks/copy_feedback_tables_into_one_consolidated_table.rake
+++ b/lib/tasks/copy_feedback_tables_into_one_consolidated_table.rake
@@ -55,6 +55,13 @@ namespace :consolidate_feedback_tables do
       trigger_event(feedback)
     end
 
+    # Convert a low-double-digits number of existing Feedback records to events because
+    # many of them will have failed to export due to the BigQuery array error dealt with in this commit.
+    # Choose not to worry about very low numbers of duplicates in analytics.
+    Feedback.where(feedback_type: "job_alert").find_each(batch_size: 100) do |job_alert_feedback|
+      trigger_event(job_alert_feedback)
+    end
+
     JobAlertFeedback.find_each(batch_size: 100) do |job_alert_feedback|
       feedback = Feedback.find_or_create_by(
         feedback_type: "job_alert",

--- a/spec/services/event_spec.rb
+++ b/spec/services/event_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Event do
         data: [
           { key: "foo", value: "Bar" },
           { key: "pi", value: 3.14 },
-          { key: "baz", value: [1, "string", 0.5] },
+          { key: "baz", value: [1, "string", 0.5].to_s },
           { key: "params", value: { foo: "bar" }.to_json },
         ],
       )

--- a/spec/system/jobseekers_can_give_job_alert_feedback_spec.rb
+++ b/spec/system/jobseekers_can_give_job_alert_feedback_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "A jobseeker can give feedback on a job alert", recaptcha: true d
           .to have_triggered_event(:feedback_provided)
           .with_data(
             feedback_type: "job_alert",
-            job_alert_vacancy_ids: job_alert_vacancy_ids,
+            job_alert_vacancy_ids: job_alert_vacancy_ids.to_s,
             relevant_to_user: relevant_to_user.to_s,
             search_criteria: json_including(subscription.search_criteria),
             subscription_identifier: anything,
@@ -84,7 +84,7 @@ RSpec.describe "A jobseeker can give feedback on a job alert", recaptcha: true d
           .to have_triggered_event(:feedback_provided)
                 .with_data(
                   feedback_type: "job_alert",
-                  job_alert_vacancy_ids: job_alert_vacancy_ids,
+                  job_alert_vacancy_ids: job_alert_vacancy_ids.to_s,
                   relevant_to_user: relevant_to_user.to_s,
                   search_criteria: json_including(subscription.search_criteria),
                   subscription_identifier: anything,


### PR DESCRIPTION
Do not pass Arrays to BigQuery: otherwise, it will give the error 'Array specified for non repeated field' when the array has length of 1.

Having tested the task on a local production-like data dump, connected to staging BigQuery dataset, I will run the task on production after this is deployed.