### PR TITLE
[TEVA-1908] Part 1 - Stream jobseeker email events

### DIFF
--- a/app/mailers/jobseeker_mailer.rb
+++ b/app/mailers/jobseeker_mailer.rb
@@ -3,32 +3,61 @@ class JobseekerMailer < Devise::Mailer
   include Devise::Controllers::UrlHelpers
   default template_path: "jobseeker_mailer"
 
+  after_action :trigger_email_event
+
   def confirmation_instructions(record, token, _opts = {})
+    @template = NOTIFY_JOBSEEKER_CONFIRMATION_TEMPLATE
     @jobseeker = record
-    @token = token
-    @confirmation_type = @jobseeker.pending_reconfirmation? ? ".reconfirmation" : ""
     @to = @jobseeker.pending_reconfirmation? ? @jobseeker.unconfirmed_email : @jobseeker.email
 
-    view_mail(NOTIFY_JOBSEEKER_CONFIRMATION_TEMPLATE, to: @to, subject: t("#{@confirmation_type}.subject"))
+    @token = token
+    @confirmation_type = @jobseeker.pending_reconfirmation? ? ".reconfirmation" : ""
+
+    view_mail(@template, to: @to, subject: t("#{@confirmation_type}.subject"))
   end
 
   def email_changed(record, _opts = {})
+    @template = NOTIFY_JOBSEEKER_EMAIL_CHANGED_TEMPLATE
     @jobseeker = record
+    @to = @jobseeker.email
 
-    view_mail(NOTIFY_JOBSEEKER_EMAIL_CHANGED_TEMPLATE, to: @jobseeker.email, subject: t(".subject"))
+    view_mail(@template, to: @to, subject: t(".subject"))
   end
 
   def reset_password_instructions(record, token, _opts = {})
+    @template = NOTIFY_JOBSEEKER_RESET_PASSWORD_TEMPLATE
     @jobseeker = record
+    @to = @jobseeker.email
+
     @token = token
 
-    view_mail(NOTIFY_JOBSEEKER_RESET_PASSWORD_TEMPLATE, to: @jobseeker.email, subject: t(".subject"))
+    view_mail(@template, to: @to, subject: t(".subject"))
   end
 
   def unlock_instructions(record, token, _opts = {})
+    @template = NOTIFY_JOBSEEKER_LOCKED_ACCOUNT_TEMPLATE
     @jobseeker = record
+    @to = @jobseeker.email
+
     @token = token
 
-    view_mail(NOTIFY_JOBSEEKER_LOCKED_ACCOUNT_TEMPLATE, to: @jobseeker.email, subject: t(".subject"))
+    view_mail(@template, to: @to, subject: t(".subject"))
+  end
+
+  private
+
+  def email_event
+    @email_event ||= EmailEvent.new(@template, @to, jobseeker: @jobseeker)
+  end
+
+  def trigger_email_event
+    data = case action_name
+           when "confirmation_instructions"
+             { previous_email_identifier: StringAnonymiser.new(@jobseeker.email) }
+           else
+             {}
+           end
+
+    email_event.trigger("jobseeker_#{action_name}".to_sym, data)
   end
 end

--- a/app/services/email_event.rb
+++ b/app/services/email_event.rb
@@ -1,0 +1,25 @@
+##
+# Represents events occuring as a part of emails being sent to users
+#
+# This event should only be triggered in mailers.
+class EmailEvent < Event
+  def initialize(notify_template, email, jobseeker: nil, publisher: nil)
+    @notify_template = notify_template
+    @email = email
+    @jobseeker = jobseeker
+    @publisher = publisher
+  end
+
+  private
+
+  attr_reader :notify_template, :email, :jobseeker, :publisher
+
+  def base_data
+    @base_data ||= super.merge(
+      notify_template: notify_template,
+      email_identifier: anonymise(email),
+      user_anonymised_jobseeker_id: anonymise(jobseeker&.id),
+      user_anonymised_publisher_id: anonymise(publisher&.oid),
+    )
+  end
+end

--- a/app/services/event.rb
+++ b/app/services/event.rb
@@ -60,4 +60,10 @@ class Event
            end
     time.iso8601(6)
   end
+
+  ##
+  # Personally identifiable information (PII) should be anonymised before the data is sent to BigQuery
+  def anonymise(identifier)
+    StringAnonymiser.new(identifier).to_s if identifier.present?
+  end
 end

--- a/app/services/request_event.rb
+++ b/app/services/request_event.rb
@@ -1,5 +1,3 @@
-require "digest/bubblebabble"
-
 ##
 # Represents events occurring as part of the Rails request lifecycle
 #
@@ -43,9 +41,5 @@ class RequestEvent < Event
 
   def ab_tests
     AbTests.new(session).current_variants.map { |test, variant| { test: test, variant: variant } }
-  end
-
-  def anonymise(identifier)
-    StringAnonymiser.new(identifier).to_s if identifier.present?
   end
 end

--- a/app/views/jobseeker_mailer/confirmation_instructions.text.erb
+++ b/app/views/jobseeker_mailer/confirmation_instructions.text.erb
@@ -4,7 +4,7 @@
 
 # <%= t(".what_to_do") %>
 
-<%= notify_link(confirmation_url(@jobseeker, confirmation_token: @token), t("#{@confirmation_type}.link")) %>
+<%= notify_link(jobseeker_confirmation_url(confirmation_token: @token), t("#{@confirmation_type}.link")) %>
 
 ---
 

--- a/app/views/jobseeker_mailer/reset_password_instructions.text.erb
+++ b/app/views/jobseeker_mailer/reset_password_instructions.text.erb
@@ -2,7 +2,7 @@
 
 <%= t(".intro") %>
 
-<%= notify_link(edit_password_url(@jobseeker, reset_password_token: @token), t(".link")) %>
+<%= notify_link(edit_jobseeker_password_url(reset_password_token: @token), t(".link")) %>
 
 ---
 

--- a/app/views/jobseeker_mailer/unlock_instructions.text.erb
+++ b/app/views/jobseeker_mailer/unlock_instructions.text.erb
@@ -4,4 +4,4 @@
 
 # <%= t(".instructions") %>
 
-<%= notify_link(unlock_url(@jobseeker, unlock_token: @token), t(".link")) %>
+<%= notify_link(jobseeker_unlock_url(unlock_token: @token), t(".link")) %>

--- a/spec/mailers/jobseeker_mailer_spec.rb
+++ b/spec/mailers/jobseeker_mailer_spec.rb
@@ -1,0 +1,112 @@
+require "rails_helper"
+
+RSpec.describe JobseekerMailer, type: :mailer do
+  let(:jobseeker) { create(:jobseeker, email: email) }
+  let(:email) { "test@email.com" }
+  let(:token) { "some-special-token" }
+
+  let(:expected_base_data) do
+    {
+      notify_template: notify_template,
+      email_identifier: anonymised_form_of(email),
+      user_anonymised_jobseeker_id: anonymised_form_of(jobseeker.id),
+      user_anonymised_publisher_id: nil,
+    }
+  end
+
+  describe "#confirmation_instructions" do
+    let(:mail) { described_class.confirmation_instructions(jobseeker, token) }
+    let(:notify_template) { NOTIFY_JOBSEEKER_CONFIRMATION_TEMPLATE }
+
+    context "when the jobseeker is pending reconfirmation" do
+      let(:email) { "unconfirmed@email.com" }
+      let(:jobseeker) { create(:jobseeker, email: "test@email.com", unconfirmed_email: email) }
+
+      before { allow(jobseeker).to receive(:pending_reconfirmation?).and_return(true) }
+
+      it "sends confirmation_instructions email" do
+        expect(mail.subject).to eq(I18n.t("jobseeker_mailer.confirmation_instructions.reconfirmation.subject"))
+        expect(mail.to).to eq(["unconfirmed@email.com"])
+        expect(mail.body.encoded).to include(I18n.t("jobseeker_mailer.confirmation_instructions.reconfirmation.heading"))
+        expect(mail.body.encoded).to include(jobseeker_confirmation_path(confirmation_token: token))
+      end
+
+      it "triggers a `confirmation_instructions` email event" do
+        expect { mail.deliver_now }
+          .to have_triggered_event(:jobseeker_confirmation_instructions)
+          .with_base_data(expected_base_data)
+          .and_data(previous_email_identifier: anonymised_form_of("test@email.com"))
+      end
+    end
+
+    context "when the jobseeker is not pending reconfirmation" do
+      before { allow(jobseeker).to receive(:pending_reconfirmation?).and_return(false) }
+
+      it "sends a `confirmation_instructions` email" do
+        expect(mail.subject).to eq(I18n.t("jobseeker_mailer.confirmation_instructions.subject"))
+        expect(mail.to).to eq(["test@email.com"])
+        expect(mail.body.encoded).to include(I18n.t("jobseeker_mailer.confirmation_instructions.heading"))
+        expect(mail.body.encoded).to include(jobseeker_confirmation_path(confirmation_token: token))
+      end
+
+      it "triggers a `confirmation_instructions` email event" do
+        expect { mail.deliver_now }
+          .to have_triggered_event(:jobseeker_confirmation_instructions)
+          .with_base_data(expected_base_data)
+      end
+    end
+  end
+
+  describe "#email_changed" do
+    let(:mail) { described_class.email_changed(jobseeker) }
+    let(:notify_template) { NOTIFY_JOBSEEKER_EMAIL_CHANGED_TEMPLATE }
+
+    it "sends a `email_changed` email" do
+      expect(mail.subject).to eq(I18n.t("jobseeker_mailer.email_changed.subject"))
+      expect(mail.to).to eq(["test@email.com"])
+      expect(mail.body.encoded).to include(I18n.t("jobseeker_mailer.email_changed.heading"))
+    end
+
+    it "triggers a `email_changed` email event" do
+      expect { mail.deliver_now }
+        .to have_triggered_event(:jobseeker_email_changed)
+        .with_base_data(expected_base_data)
+    end
+  end
+
+  describe "#reset_password_instructions" do
+    let(:mail) { described_class.reset_password_instructions(jobseeker, token) }
+    let(:notify_template) { NOTIFY_JOBSEEKER_RESET_PASSWORD_TEMPLATE }
+
+    it "sends a `reset_password_instructions` email" do
+      expect(mail.subject).to eq(I18n.t("jobseeker_mailer.reset_password_instructions.subject"))
+      expect(mail.to).to eq(["test@email.com"])
+      expect(mail.body.encoded).to include(I18n.t("jobseeker_mailer.reset_password_instructions.heading"))
+      expect(mail.body.encoded).to include(edit_jobseeker_password_path(reset_password_token: token))
+    end
+
+    it "triggers a `reset_passwords_instructions` email event" do
+      expect { mail.deliver_now }
+        .to have_triggered_event(:jobseeker_reset_password_instructions)
+        .with_base_data(expected_base_data)
+    end
+  end
+
+  describe "#unlock_instructions" do
+    let(:mail) { described_class.unlock_instructions(jobseeker, token) }
+    let(:notify_template) { NOTIFY_JOBSEEKER_LOCKED_ACCOUNT_TEMPLATE }
+
+    it "sends a `unlock_instructions` email" do
+      expect(mail.subject).to eq(I18n.t("jobseeker_mailer.unlock_instructions.subject"))
+      expect(mail.to).to eq(["test@email.com"])
+      expect(mail.body.encoded).to include(I18n.t("jobseeker_mailer.unlock_instructions.heading"))
+      expect(mail.body.encoded).to include(jobseeker_unlock_path(unlock_token: token))
+    end
+
+    it "triggers a `unlock_instructions` email event" do
+      expect { mail.deliver_now }
+        .to have_triggered_event(:jobseeker_unlock_instructions)
+        .with_base_data(expected_base_data)
+    end
+  end
+end

--- a/spec/services/email_event_spec.rb
+++ b/spec/services/email_event_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe EmailEvent do
+  subject { described_class.new(notify_template, email, jobseeker: jobseeker, publisher: publisher) }
+
+  let(:notify_template) { "test_template" }
+  let(:email) { "test@email.com" }
+  let(:jobseeker) { instance_double(Jobseeker, id: 1234, email: "test@email.com") }
+  let(:publisher) { instance_double(Publisher, oid: 4321) }
+
+  describe "#trigger" do
+    let(:expected_data) do
+      {
+        type: :best_ever_email_event,
+        occurred_at: "1999-12-31T23:59:59.000000Z",
+        notify_template: notify_template,
+        email_identifier: anonymised_form_of("test@email.com"),
+        user_anonymised_jobseeker_id: anonymised_form_of("1234"),
+        user_anonymised_publisher_id: anonymised_form_of("4321"),
+        data: [{ key: "foozy", value: "barzy" }],
+      }
+    end
+
+    it "enqueues a SendEventToDataWarehouseJob with the expected payload" do
+      expect(SendEventToDataWarehouseJob).to receive(:perform_later).with("events", expected_data)
+
+      travel_to(Time.zone.local(1999, 12, 31, 23, 59, 59)) do
+        subject.trigger(:best_ever_email_event, foozy: "barzy")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-1908

## Changes in this PR
- Add email event
- Trigger email events after jobseeker emails are sent