### PR TITLE
Add an HTTP permissions policy

### DIFF
--- a/config/initializers/permissions_policy.rb
+++ b/config/initializers/permissions_policy.rb
@@ -1,11 +1,11 @@
 # Define an application-wide HTTP permissions policy. For further
 # information see https://developers.google.com/web/updates/2018/06/feature-policy
 #
-# Rails.application.config.permissions_policy do |f|
-#   f.camera      :none
-#   f.gyroscope   :none
-#   f.microphone  :none
-#   f.usb         :none
-#   f.fullscreen  :self
-#   f.payment     :self, "https://secure.example.com"
-# end
+Rails.application.config.permissions_policy do |f|
+  f.camera      :none
+  f.gyroscope   :none
+  f.microphone  :none
+  f.usb         :none
+  f.fullscreen  :none
+  f.payment     :none
+end


### PR DESCRIPTION
Enable the default Rails permissions policy and make it more restrictive
(we are not using any of these APIs anytime soon).