### PR TITLE
Remove email field in job application Step 1

### DIFF
--- a/app/form_models/jobseekers/job_application/personal_details_form.rb
+++ b/app/form_models/jobseekers/job_application/personal_details_form.rb
@@ -1,13 +1,11 @@
 class Jobseekers::JobApplication::PersonalDetailsForm
   include ActiveModel::Model
 
-  attr_accessor :building_and_street, :email_address, :first_name, :last_name, :national_insurance_number,
+  attr_accessor :building_and_street, :first_name, :last_name, :national_insurance_number,
                 :phone_number, :previous_names, :postcode, :teacher_reference_number, :town_or_city
 
-  validates :building_and_street, :email_address, :first_name, :last_name, :national_insurance_number,
+  validates :building_and_street, :first_name, :last_name, :national_insurance_number,
             :phone_number, :postcode, :teacher_reference_number, :town_or_city, presence: true
-
-  validates :email_address, format: { with: Devise.email_regexp }
 
   validates :national_insurance_number, format: { with: /\A\s*[a-zA-Z]{2}(?:\s*\d\s*){6}[a-zA-Z]?\s*\z/.freeze }
 

--- a/app/views/jobseekers/job_applications/build/personal_details.html.slim
+++ b/app/views/jobseekers/job_applications/build/personal_details.html.slim
@@ -18,7 +18,6 @@
         = f.govuk_text_field :town_or_city, width: "two-thirds"
         = f.govuk_text_field :postcode, width: "one-third"
       = f.govuk_number_field :phone_number, label: { size: "s" }, width: "one-half", aria: { required: true }
-      = f.govuk_email_field :email_address, label: { size: "s" }, width: "one-half", aria: { required: true }
       = f.govuk_text_field :teacher_reference_number, label: { size: "s" }, width: "one-half", aria: { required: true }
       = f.govuk_text_field :national_insurance_number, label: { size: "s" }, width: "one-half", aria: { required: true }
       = f.govuk_submit t("buttons.continue") do

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -212,9 +212,6 @@ en:
           attributes:
             building_and_street:
               blank: Enter your building and street
-            email_address:
-              blank: Enter your email address
-              invalid: Enter an email address in the correct format, like name@example.com
             first_name:
               blank: Enter your first name
             last_name:

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -222,7 +222,6 @@ en:
       jobseekers_job_application_personal_details_form:
         your_address: Your address
         building_and_street: Building and street
-        email_address: Email address
         first_name: First name
         last_name: Last name
         national_insurance_number: National Insurance number

--- a/spec/form_models/jobseekers/job_application/personal_details_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/personal_details_form_spec.rb
@@ -5,10 +5,6 @@ RSpec.describe Jobseekers::JobApplication::PersonalDetailsForm, type: :model do
   it { is_expected.to validate_presence_of(:postcode) }
   it { is_expected.to validate_presence_of(:town_or_city) }
 
-  it { is_expected.to validate_presence_of(:email_address) }
-  it { is_expected.to allow_value("jacknifedjuggernaut@example.com").for(:email_address) }
-  it { is_expected.not_to allow_value("invalidemail").for(:email_address) }
-
   it { is_expected.to validate_presence_of(:first_name) }
   it { is_expected.to validate_presence_of(:last_name) }
 

--- a/spec/support/jobseeker_helpers.rb
+++ b/spec/support/jobseeker_helpers.rb
@@ -68,7 +68,6 @@ module JobseekerHelpers
     fill_in "Town or city", with: "Fakeopolis"
     fill_in "Postcode", with: "F1 4KE"
     fill_in "Phone number", with: "01234 123456"
-    fill_in "Email address", with: "funkymonk@example.com"
     fill_in "Teacher reference number", with: "AB 99/12345"
     fill_in "National Insurance number", with: "AB 12 12 12 A"
   end

--- a/spec/system/jobseekers_can_save_a_job_application_spec.rb
+++ b/spec/system/jobseekers_can_save_a_job_application_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe "Jobseekers can save a job application" do
         "first_name" => "John",
         "phone_number" => "01234 123456",
         "town_or_city" => "Fakeopolis",
-        "email_address" => "funkymonk@example.com",
         "previous_names" => "",
         "building_and_street" => "123 Fake Street",
         "teacher_reference_number" => "AB 99/12345",


### PR DESCRIPTION
We already know jobseekers' email addresses.

https://ukgovernmentdfe.slack.com/archives/C01BB5D318W/p1613582416025000
