### PR TITLE
Refactor email events to use data struct instead of base data

### DIFF
--- a/app/services/email_event.rb
+++ b/app/services/email_event.rb
@@ -14,12 +14,12 @@ class EmailEvent < Event
 
   attr_reader :notify_template, :email, :jobseeker, :publisher
 
-  def base_data
-    @base_data ||= super.merge(
-      notify_template: notify_template,
-      email_identifier: anonymise(email),
-      user_anonymised_jobseeker_id: anonymise(jobseeker&.id),
-      user_anonymised_publisher_id: anonymise(publisher&.oid),
+  def data
+    @data ||= super.push(
+      { key: "notify_template", value: notify_template },
+      { key: "email_identifier", value: anonymise(email) },
+      { key: "user_anonymised_jobseeker_id", value: anonymise(jobseeker&.id) },
+      { key: "user_anonymised_publisher_id", value: anonymise(publisher&.oid) },
     )
   end
 end

--- a/spec/mailers/alert_mailer_spec.rb
+++ b/spec/mailers/alert_mailer_spec.rb
@@ -40,6 +40,17 @@ RSpec.describe AlertMailer, type: :mailer do
     )
   end
 
+  let(:expected_data) do
+    {
+      notify_template: notify_template,
+      email_identifier: anonymised_form_of(email),
+      user_anonymised_jobseeker_id: user_anonymised_jobseeker_id,
+      user_anonymised_publisher_id: nil,
+      subscription_identifier: anonymised_form_of(subscription.id),
+      subscription_frequency: frequency,
+    }
+  end
+
   before do
     vacancies.each { |vacancy| vacancy.organisation_vacancies.create(organisation: school) }
     subscription.create_alert_run
@@ -47,6 +58,7 @@ RSpec.describe AlertMailer, type: :mailer do
 
   context "when frequency is daily" do
     let(:notify_template) { NOTIFY_SUBSCRIPTION_DAILY_TEMPLATE }
+    let(:frequency) { "daily" }
 
     it "sends a job alert email" do
       expect(mail.subject).to eq(I18n.t("alert_mailer.alert.subject"))
@@ -76,45 +88,25 @@ RSpec.describe AlertMailer, type: :mailer do
 
     context "when the subscription email matches a jobseeker account" do
       let(:jobseeker) { create(:jobseeker, email: email) }
-      let(:expected_base_data) do
-        {
-          notify_template: notify_template,
-          email_identifier: anonymised_form_of(email),
-          user_anonymised_jobseeker_id: anonymised_form_of(jobseeker.id),
-          user_anonymised_publisher_id: nil,
-        }
-      end
+      let(:user_anonymised_jobseeker_id) { anonymised_form_of(jobseeker.id) }
 
       it "triggers a `jobseeker_subscription_alert` email event with the anonymised jobseeker id" do
-        expect { mail.deliver_now }
-          .to have_triggered_event(:jobseeker_subscription_alert)
-          .with_base_data(expected_base_data)
-          .and_data({ subscription_identifier: anonymised_form_of(subscription.id), subscription_frequency: "daily" })
+        expect { mail.deliver_now }.to have_triggered_event(:jobseeker_subscription_alert).with_data(expected_data)
       end
     end
 
     context "when the subscription email does not match a jobseeker account" do
-      let(:expected_base_data) do
-        {
-          notify_template: notify_template,
-          email_identifier: anonymised_form_of(email),
-          user_anonymised_jobseeker_id: nil,
-          user_anonymised_publisher_id: nil,
-        }
-      end
+      let(:user_anonymised_jobseeker_id) { nil }
 
       it "triggers a `jobseeker_subscription_alert` email event without the anonymised jobseeker id" do
-        expect { mail.deliver_now }
-          .to have_triggered_event(:jobseeker_subscription_alert)
-          .with_base_data(expected_base_data)
-          .and_data({ subscription_identifier: anonymised_form_of(subscription.id), subscription_frequency: "daily" })
+        expect { mail.deliver_now }.to have_triggered_event(:jobseeker_subscription_alert).with_data(expected_data)
       end
     end
   end
 
   context "when frequency is weekly" do
     let(:notify_template) { NOTIFY_SUBSCRIPTION_WEEKLY_TEMPLATE }
-    let(:frequency) { :weekly }
+    let(:frequency) { "weekly" }
 
     it "sends a job alert email" do
       expect(mail.subject).to eq(I18n.t("alert_mailer.alert.subject"))
@@ -144,38 +136,18 @@ RSpec.describe AlertMailer, type: :mailer do
 
     context "when the subscription email matches a jobseeker account" do
       let(:jobseeker) { create(:jobseeker, email: email) }
-      let(:expected_base_data) do
-        {
-          notify_template: notify_template,
-          email_identifier: anonymised_form_of(email),
-          user_anonymised_jobseeker_id: anonymised_form_of(jobseeker.id),
-          user_anonymised_publisher_id: nil,
-        }
-      end
+      let(:user_anonymised_jobseeker_id) { anonymised_form_of(jobseeker.id) }
 
       it "triggers a `jobseeker_subscription_alert` email event with the anonymised jobseeker id" do
-        expect { mail.deliver_now }
-          .to have_triggered_event(:jobseeker_subscription_alert)
-          .with_base_data(expected_base_data)
-          .and_data({ subscription_identifier: anonymised_form_of(subscription.id), subscription_frequency: "weekly" })
+        expect { mail.deliver_now }.to have_triggered_event(:jobseeker_subscription_alert).with_data(expected_data)
       end
     end
 
     context "when the subscription email does not match a jobseeker account" do
-      let(:expected_base_data) do
-        {
-          notify_template: notify_template,
-          email_identifier: anonymised_form_of(email),
-          user_anonymised_jobseeker_id: nil,
-          user_anonymised_publisher_id: nil,
-        }
-      end
+      let(:user_anonymised_jobseeker_id) { nil }
 
       it "triggers a `jobseeker_subscription_alert` email event without the anonymised jobseeker id" do
-        expect { mail.deliver_now }
-          .to have_triggered_event(:jobseeker_subscription_alert)
-          .with_base_data(expected_base_data)
-          .and_data({ subscription_identifier: anonymised_form_of(subscription.id), subscription_frequency: "weekly" })
+        expect { mail.deliver_now }.to have_triggered_event(:jobseeker_subscription_alert).with_data(expected_data)
       end
     end
   end

--- a/spec/mailers/authentication_fallback_mailer_spec.rb
+++ b/spec/mailers/authentication_fallback_mailer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe AuthenticationFallbackMailer, type: :mailer do
     let(:login_key) { publisher.emergency_login_keys.create(not_valid_after: Time.current + 10.minutes) }
     let(:mail) { described_class.sign_in_fallback(login_key: login_key, publisher: publisher) }
     let(:notify_template) { "2f37ec1d-58ef-4cd9-9d0a-4272723dda3d" }
-    let(:expected_base_data) do
+    let(:expected_data) do
       {
         notify_template: notify_template,
         email_identifier: anonymised_form_of(publisher.email),
@@ -27,9 +27,7 @@ RSpec.describe AuthenticationFallbackMailer, type: :mailer do
     end
 
     it "triggers a `publisher_sign_in_fallback` email event" do
-      expect { mail.deliver_now }
-        .to have_triggered_event(:publisher_sign_in_fallback)
-        .with_base_data(expected_base_data)
+      expect { mail.deliver_now }.to have_triggered_event(:publisher_sign_in_fallback).with_data(expected_data)
     end
   end
 end

--- a/spec/mailers/feedback_prompt_mailer_spec.rb
+++ b/spec/mailers/feedback_prompt_mailer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe FeedbackPromptMailer, type: :mailer do
     let(:mail) { described_class.prompt_for_feedback(publisher, vacancies) }
     let(:notify_template) { NOTIFY_PROMPT_FEEDBACK_FOR_EXPIRED_VACANCIES }
     let(:vacancies) { create_list(:vacancy, 2, :published) }
-    let(:expected_base_data) do
+    let(:expected_data) do
       {
         notify_template: notify_template,
         email_identifier: anonymised_form_of(email),
@@ -32,9 +32,7 @@ RSpec.describe FeedbackPromptMailer, type: :mailer do
       end
 
       it "triggers a `publisher_prompt_for_feedback` email event" do
-        expect { mail.deliver_now }
-          .to have_triggered_event(:publisher_prompt_for_feedback)
-          .with_base_data(expected_base_data)
+        expect { mail.deliver_now }.to have_triggered_event(:publisher_prompt_for_feedback).with_data(expected_data)
       end
     end
   end

--- a/spec/mailers/jobseeker_mailer_spec.rb
+++ b/spec/mailers/jobseeker_mailer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe JobseekerMailer, type: :mailer do
   let(:email) { "test@email.com" }
   let(:token) { "some-special-token" }
 
-  let(:expected_base_data) do
+  let(:expected_data) do
     {
       notify_template: notify_template,
       email_identifier: anonymised_form_of(email),
@@ -32,10 +32,8 @@ RSpec.describe JobseekerMailer, type: :mailer do
       end
 
       it "triggers a `jobseeker_confirmation_instructions` email event" do
-        expect { mail.deliver_now }
-          .to have_triggered_event(:jobseeker_confirmation_instructions)
-          .with_base_data(expected_base_data)
-          .and_data(previous_email_identifier: anonymised_form_of("test@email.com"))
+        expect { mail.deliver_now }.to have_triggered_event(:jobseeker_confirmation_instructions)
+          .with_data(expected_data.merge(previous_email_identifier: anonymised_form_of("test@email.com")))
       end
     end
 
@@ -50,9 +48,7 @@ RSpec.describe JobseekerMailer, type: :mailer do
       end
 
       it "triggers a `jobseeker_confirmation_instructions` email event" do
-        expect { mail.deliver_now }
-          .to have_triggered_event(:jobseeker_confirmation_instructions)
-          .with_base_data(expected_base_data)
+        expect { mail.deliver_now }.to have_triggered_event(:jobseeker_confirmation_instructions).with_data(expected_data)
       end
     end
   end
@@ -68,9 +64,7 @@ RSpec.describe JobseekerMailer, type: :mailer do
     end
 
     it "triggers a `jobseeker_email_changed` email event" do
-      expect { mail.deliver_now }
-        .to have_triggered_event(:jobseeker_email_changed)
-        .with_base_data(expected_base_data)
+      expect { mail.deliver_now }.to have_triggered_event(:jobseeker_email_changed).with_data(expected_data)
     end
   end
 
@@ -86,9 +80,7 @@ RSpec.describe JobseekerMailer, type: :mailer do
     end
 
     it "triggers a `jobseeker_reset_passwords_instructions` email event" do
-      expect { mail.deliver_now }
-        .to have_triggered_event(:jobseeker_reset_password_instructions)
-        .with_base_data(expected_base_data)
+      expect { mail.deliver_now }.to have_triggered_event(:jobseeker_reset_password_instructions).with_data(expected_data)
     end
   end
 
@@ -104,9 +96,7 @@ RSpec.describe JobseekerMailer, type: :mailer do
     end
 
     it "triggers a `jobseeker_unlock_instructions` email event" do
-      expect { mail.deliver_now }
-        .to have_triggered_event(:jobseeker_unlock_instructions)
-        .with_base_data(expected_base_data)
+      expect { mail.deliver_now }.to have_triggered_event(:jobseeker_unlock_instructions).with_data(expected_data)
     end
   end
 end

--- a/spec/mailers/subscription_mailer_spec.rb
+++ b/spec/mailers/subscription_mailer_spec.rb
@@ -18,6 +18,16 @@ RSpec.describe SubscriptionMailer, type: :mailer do
   let(:campaign_params) { { utm_source: nil, utm_medium: "email", utm_campaign: "daily_alert" } }
   let(:body) { mail.body }
 
+  let(:expected_data) do
+    {
+      notify_template: notify_template,
+      email_identifier: anonymised_form_of(email),
+      user_anonymised_jobseeker_id: user_anonymised_jobseeker_id,
+      user_anonymised_publisher_id: nil,
+      subscription_identifier: anonymised_form_of(subscription.id),
+    }
+  end
+
   describe "#confirmation" do
     let(:mail) { described_class.confirmation(subscription.id) }
     let(:notify_template) { NOTIFY_SUBSCRIPTION_CONFIRMATION_TEMPLATE }
@@ -35,38 +45,18 @@ RSpec.describe SubscriptionMailer, type: :mailer do
 
     context "when the subscription email matches a jobseeker account" do
       let(:jobseeker) { create(:jobseeker, email: email) }
-      let(:expected_base_data) do
-        {
-          notify_template: notify_template,
-          email_identifier: anonymised_form_of(email),
-          user_anonymised_jobseeker_id: anonymised_form_of(jobseeker.id),
-          user_anonymised_publisher_id: nil,
-        }
-      end
+      let(:user_anonymised_jobseeker_id) { anonymised_form_of(jobseeker.id) }
 
       it "triggers a `jobseeker_subscription_confirmation` email event with the anonymised jobseeker id" do
-        expect { mail.deliver_now }
-          .to have_triggered_event(:jobseeker_subscription_confirmation)
-          .with_base_data(expected_base_data)
-          .and_data({ subscription_identifier: anonymised_form_of(subscription.id) })
+        expect { mail.deliver_now }.to have_triggered_event(:jobseeker_subscription_confirmation).with_data(expected_data)
       end
     end
 
     context "when the subscription email does not match a jobseeker account" do
-      let(:expected_base_data) do
-        {
-          notify_template: notify_template,
-          email_identifier: anonymised_form_of(email),
-          user_anonymised_jobseeker_id: nil,
-          user_anonymised_publisher_id: nil,
-        }
-      end
+      let(:user_anonymised_jobseeker_id) { nil }
 
       it "triggers a `jobseeker_subscription_confirmation` email event without the anonymised jobseeker id" do
-        expect { mail.deliver_now }
-          .to have_triggered_event(:jobseeker_subscription_confirmation)
-          .with_base_data(expected_base_data)
-          .and_data({ subscription_identifier: anonymised_form_of(subscription.id) })
+        expect { mail.deliver_now }.to have_triggered_event(:jobseeker_subscription_confirmation).with_data(expected_data)
       end
     end
   end
@@ -88,38 +78,18 @@ RSpec.describe SubscriptionMailer, type: :mailer do
 
     context "when the subscription email matches a jobseeker account" do
       let(:jobseeker) { create(:jobseeker, email: email) }
-      let(:expected_base_data) do
-        {
-          notify_template: notify_template,
-          email_identifier: anonymised_form_of(email),
-          user_anonymised_jobseeker_id: anonymised_form_of(jobseeker.id),
-          user_anonymised_publisher_id: nil,
-        }
-      end
+      let(:user_anonymised_jobseeker_id) { anonymised_form_of(jobseeker.id) }
 
       it "triggers a `jobseeker_subscription_update` email event with the anonymised jobseeker id" do
-        expect { mail.deliver_now }
-          .to have_triggered_event(:jobseeker_subscription_update)
-          .with_base_data(expected_base_data)
-          .and_data({ subscription_identifier: anonymised_form_of(subscription.id) })
+        expect { mail.deliver_now }.to have_triggered_event(:jobseeker_subscription_update).with_data(expected_data)
       end
     end
 
     context "when the subscription email does not match a jobseeker account" do
-      let(:expected_base_data) do
-        {
-          notify_template: notify_template,
-          email_identifier: anonymised_form_of(email),
-          user_anonymised_jobseeker_id: nil,
-          user_anonymised_publisher_id: nil,
-        }
-      end
+      let(:user_anonymised_jobseeker_id) { nil }
 
       it "triggers a `jobseeker_subscription_update` email event without the anonymised jobseeker id" do
-        expect { mail.deliver_now }
-          .to have_triggered_event(:jobseeker_subscription_update)
-          .with_base_data(expected_base_data)
-          .and_data({ subscription_identifier: anonymised_form_of(subscription.id) })
+        expect { mail.deliver_now }.to have_triggered_event(:jobseeker_subscription_update).with_data(expected_data)
       end
     end
   end

--- a/spec/services/email_event_spec.rb
+++ b/spec/services/email_event_spec.rb
@@ -13,11 +13,13 @@ RSpec.describe EmailEvent do
       {
         type: :best_ever_email_event,
         occurred_at: "1999-12-31T23:59:59.000000Z",
-        notify_template: notify_template,
-        email_identifier: anonymised_form_of("test@email.com"),
-        user_anonymised_jobseeker_id: anonymised_form_of("1234"),
-        user_anonymised_publisher_id: anonymised_form_of("4321"),
-        data: [{ key: "foozy", value: "barzy" }],
+        data: [
+          { key: "notify_template", value: notify_template },
+          { key: "email_identifier", value: anonymised_form_of("test@email.com") },
+          { key: "user_anonymised_jobseeker_id", value: anonymised_form_of("1234") },
+          { key: "user_anonymised_publisher_id", value: anonymised_form_of("4321") },
+          { key: "foozy", value: "barzy" },
+        ],
       }
     end
 


### PR DESCRIPTION
When we stream events to BigQuery, we stream them to a single table `events`. This table has a defined schema (essentially the base data from request events). 

We want to continue to stream events to a single table because it makes analytics easier. This means that email events cannot have their own base data, since these columns would not be defined in the schema. 

Instead email events have some default data which is sent alongside event data (triggered by the event) in the data struct to BigQuery.

This PR adds the concept of default data for events.