### PR TITLE
[TEVA-1819] Job alert account creation ab test

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
 
   after_action :trigger_page_visited_event, unless: :request_is_healthcheck?
 
-  helper_method :cookies_preference_set?, :referred_from_jobs_path?, :utm_parameters, :current_variant?
+  helper_method :cookies_preference_set?, :referred_from_jobs_path?, :utm_parameters
 
   include Publishers::AuthenticationConcerns
   include AbTestable

--- a/app/controllers/concerns/ab_testable.rb
+++ b/app/controllers/concerns/ab_testable.rb
@@ -2,7 +2,7 @@ module AbTestable
   extend ActiveSupport::Concern
 
   included do
-    helper_method :ab_variant_for, :current_ab_variants
+    helper_method :ab_variant_for, :current_ab_variants, :current_variant?
   end
 
   def current_variant?(name_of_test, variant_name)

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -24,7 +24,7 @@ class SubscriptionsController < ApplicationController
       if jobseeker_signed_in?
         redirect_to jobseekers_subscriptions_path, success: t(".success")
       else
-        @jobseeker_account_exists = Jobseeker.exists?(email: subscription.email)
+        @jobseeker = Jobseeker.find_by(email: subscription.email)
         render :confirm
       end
     end
@@ -48,7 +48,7 @@ class SubscriptionsController < ApplicationController
       if jobseeker_signed_in?
         redirect_to jobseekers_subscriptions_path, success: t(".success")
       else
-        @jobseeker_account_exists = Jobseeker.exists?(email: subscription.email)
+        @jobseeker = Jobseeker.find_by(email: subscription.email)
         render :confirm
       end
     else

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -16,7 +16,7 @@ class SubscriptionsController < ApplicationController
     elsif recaptcha_is_invalid?(subscription)
       redirect_to invalid_recaptcha_path(form_name: subscription.class.name.underscore.humanize)
     else
-      subscription.recaptcha_score = recaptcha_reply["score"]
+      subscription.recaptcha_score = recaptcha_reply&.dig("score")
       subscription.save
       SubscriptionMailer.confirmation(subscription.id).deliver_later
       trigger_subscription_event(:job_alert_subscription_created, subscription)

--- a/app/views/jobseekers/registrations/new.html.slim
+++ b/app/views/jobseekers/registrations/new.html.slim
@@ -12,7 +12,7 @@
       = f.govuk_email_field :email, label: { size: "s" }, width: "two-thirds"
       = f.govuk_password_field :password, label: { size: "s" }, width: "two-thirds"
 
-      = f.govuk_submit t("buttons.continue"), classes: "govuk-!-margin-bottom-0"
+      = f.govuk_submit t("buttons.create_account"), classes: "govuk-!-margin-bottom-0"
 
     hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
     h2.govuk-heading-m = t(".existing_account.heading")

--- a/app/views/subscriptions/_jobseeker_account_prompt.html.slim
+++ b/app/views/subscriptions/_jobseeker_account_prompt.html.slim
@@ -1,10 +1,10 @@
 - if @jobseeker_account_exists
   div data-account-prompt="sign-in"
-    h1.govuk-heading-xl class="govuk-!-margin-bottom-5" = t(".heading.sign_in")
+    h1.govuk-heading-l class="govuk-!-margin-bottom-5" = t(".heading.sign_in")
     p.govuk-body = t(".body.sign_in")
     = govuk_link_to t(".link.sign_in"), new_jobseeker_session_path(redirect_to: jobseekers_subscriptions_path), button: true
 - else
   div data-account-prompt="sign-up"
-    h1.govuk-heading-xl class="govuk-!-margin-bottom-5" = t(".heading.sign_up")
+    h1.govuk-heading-l class="govuk-!-margin-bottom-5" = t(".heading.sign_up")
     p.govuk-body = t(".body.sign_up")
     = govuk_link_to t(".link.sign_up"), new_jobseeker_registration_path(redirect_to: jobseekers_subscriptions_path), button: true

--- a/app/views/subscriptions/_jobseeker_account_prompt.html.slim
+++ b/app/views/subscriptions/_jobseeker_account_prompt.html.slim
@@ -1,10 +1,38 @@
-- if @jobseeker_account_exists
+- if @jobseeker.present?
   div data-account-prompt="sign-in"
     h1.govuk-heading-l class="govuk-!-margin-bottom-5" = t(".heading.sign_in")
     p.govuk-body = t(".body.sign_in")
-    = govuk_link_to t(".link.sign_in"), new_jobseeker_session_path(redirect_to: jobseekers_subscriptions_path), button: true
+
+    - if current_variant?(:"2021_02_job_alert_account_creation_test", :link)
+      = govuk_link_to t(".link.sign_in"), new_jobseeker_session_path(redirect_to: jobseekers_subscriptions_path), button: true
+    - elsif current_variant?(:"2021_02_job_alert_account_creation_test", :form)
+      = form_for @jobseeker, url: jobseeker_session_path, method: :post do |f|
+        = f.govuk_email_field :email,
+          label: { text: t("helpers.label.jobseekers_sign_in_form.email"), size: "s" },
+          width: "two-thirds",
+          value: @jobseeker.email
+
+        = f.govuk_password_field :password, label: { text: t("helpers.label.jobseekers_sign_in_form.password"), size: "s" }, hint: nil, width: "two-thirds"
+
+        = hidden_field_tag :redirect_to, jobseekers_subscriptions_path
+        = f.govuk_submit t("buttons.sign_in")
+
 - else
   div data-account-prompt="sign-up"
     h1.govuk-heading-l class="govuk-!-margin-bottom-5" = t(".heading.sign_up")
     p.govuk-body = t(".body.sign_up")
-    = govuk_link_to t(".link.sign_up"), new_jobseeker_registration_path(redirect_to: jobseekers_subscriptions_path), button: true
+
+    - if current_variant?(:"2021_02_job_alert_account_creation_test", :link)
+      = govuk_link_to t(".link.sign_up"), new_jobseeker_registration_path(redirect_to: jobseekers_subscriptions_path), button: true
+    - elsif current_variant?(:"2021_02_job_alert_account_creation_test", :form)
+      = form_for Jobseeker.new, as: :jobseeker, url: jobseeker_registration_path, method: :post do |f|
+        = f.govuk_email_field :email,
+          label: { text: t("helpers.label.jobseekers_sign_in_form.email"), size: "s" },
+          width: "two-thirds",
+          value: @subscription.email,
+          readonly: true
+
+        = f.govuk_password_field :password, label: { size: "s" }, width: "two-thirds"
+
+        = hidden_field_tag :redirect_to, jobseekers_subscriptions_path
+        = f.govuk_submit t("buttons.create_account"), classes: "govuk-!-margin-bottom-0"

--- a/app/views/subscriptions/confirm.html.slim
+++ b/app/views/subscriptions/confirm.html.slim
@@ -11,5 +11,5 @@
     .divider-bottom class="govuk-!-padding-bottom-5"
       p.govuk-body = t(".unsubscribe")
       = govuk_link_to t(".back_to_search_results"), jobs_path(@subscription.search_criteria), class: "govuk-!-font-size-19"
-    p.govuk-body
-      = render "jobseeker_account_prompt"
+
+    = render "jobseeker_account_prompt"

--- a/app/views/subscriptions/confirm.html.slim
+++ b/app/views/subscriptions/confirm.html.slim
@@ -8,6 +8,8 @@
     p.govuk-body = t(".next_step_details")
     = render Jobseekers::SubscriptionDetailsComponent.new(@subscription)
 
-    p.govuk-body.divider-bottom class="govuk-!-padding-bottom-5" = t(".unsubscribe")
+    .divider-bottom class="govuk-!-padding-bottom-5"
+      p.govuk-body = t(".unsubscribe")
+      = govuk_link_to t(".back_to_search_results"), jobs_path(@subscription.search_criteria), class: "govuk-!-font-size-19"
     p.govuk-body
       = render "jobseeker_account_prompt"

--- a/config/ab_tests.yml
+++ b/config/ab_tests.yml
@@ -35,6 +35,9 @@ shared:
     bottom: 1
     modal: 1
     gds: 1
+  2021_02_job_alert_account_creation_test:
+    link: 1
+    form: 1
 test:
   2021_02_cookie_consent_test:
     none: 0

--- a/spec/support/jobseeker_helpers.rb
+++ b/spec/support/jobseeker_helpers.rb
@@ -14,7 +14,7 @@ module JobseekerHelpers
   def sign_up_jobseeker(email: jobseeker.email, password: jobseeker.password)
     fill_in "Email address", with: email
     fill_in "Password", with: password
-    click_on I18n.t("buttons.continue")
+    click_on I18n.t("buttons.create_account")
   end
 
   def sign_in_jobseeker(email: jobseeker.email, password: jobseeker.password)

--- a/spec/support/jobseeker_helpers.rb
+++ b/spec/support/jobseeker_helpers.rb
@@ -12,15 +12,17 @@ module JobseekerHelpers
   end
 
   def sign_up_jobseeker(email: jobseeker.email, password: jobseeker.password)
-    fill_in "Email address", with: email
-    fill_in "Password", with: password
-    click_on I18n.t("buttons.create_account")
+    within(".new_jobseeker") do
+      fill_in "Email address", with: email
+      fill_in "Password", with: password
+      click_on I18n.t("buttons.create_account")
+    end
   end
 
   def sign_in_jobseeker(email: jobseeker.email, password: jobseeker.password)
-    fill_in "Email address", with: email
-    fill_in "Password", with: password
     within(".new_jobseeker") do
+      fill_in "Email address", with: email
+      fill_in "Password", with: password
       click_on I18n.t("buttons.sign_in")
     end
   end

--- a/spec/system/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
+++ b/spec/system/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe "Jobseekers can create a job alert from a search", recaptcha: tru
   let(:location) { nil }
   let(:search_with_polygons?) { false }
   let(:jobseeker_signed_in?) { false }
+  let(:jobseeker_account_prompt_variant) { nil }
   let(:jobseeker) { build_stubbed(:jobseeker) }
 
   describe "recaptcha" do
@@ -23,6 +24,7 @@ RSpec.describe "Jobseekers can create a job alert from a search", recaptcha: tru
 
   describe "job alert confirmation page" do
     before do
+      page.set_rack_session(ab_tests: { "2021_02_job_alert_account_creation_test": jobseeker_account_prompt_variant })
       login_as(jobseeker, scope: :jobseeker) if jobseeker_signed_in?
       visit jobs_path
       and_perform_a_search
@@ -35,6 +37,7 @@ RSpec.describe "Jobseekers can create a job alert from a search", recaptcha: tru
       let!(:jobseeker) { create(:jobseeker) }
 
       context "when jobseeker is signed in" do
+        let(:jobseeker_account_prompt_variant) { :link }
         let(:jobseeker_signed_in?) { true }
 
         it "redirects to job alerts dashboard" do
@@ -43,28 +46,84 @@ RSpec.describe "Jobseekers can create a job alert from a search", recaptcha: tru
       end
 
       context "when jobseeker is signed out" do
-        it "renders a sign in prompt that redirects to job alerts dashboard" do
-          within "div[data-account-prompt='sign-in']" do
-            expect(page).to have_content(I18n.t("subscriptions.jobseeker_account_prompt.heading.sign_in"))
-            click_on I18n.t("subscriptions.jobseeker_account_prompt.link.sign_in")
+        context "when current_variant?(:'2021_02_job_alert_account_creation_test', :link) is true" do
+          let(:jobseeker_account_prompt_variant) { :link }
+
+          it "renders a sign in prompt link that redirects to job alerts dashboard" do
+            within "div[data-account-prompt='sign-in']" do
+              expect(page).to have_content(I18n.t("subscriptions.jobseeker_account_prompt.heading.sign_in"))
+              click_on I18n.t("subscriptions.jobseeker_account_prompt.link.sign_in")
+            end
+            expect(current_path).to eq(new_jobseeker_session_path)
+            sign_in_jobseeker
+            expect(current_path).to eq(jobseekers_subscriptions_path)
           end
-          expect(current_path).to eq(new_jobseeker_session_path)
-          sign_in_jobseeker
-          expect(current_path).to eq(jobseekers_subscriptions_path)
+        end
+
+        context "when current_variant?(:'2021_02_job_alert_account_creation_test', :form) is true" do
+          let(:jobseeker_account_prompt_variant) { :form }
+
+          it "renders a sign in prompt form that redirects to job alerts dashboard" do
+            within "div[data-account-prompt='sign-in']" do
+              expect(page).to have_content(I18n.t("subscriptions.jobseeker_account_prompt.heading.sign_in"))
+              fill_in "Password", with: jobseeker.password
+              within(".edit_jobseeker") do
+                click_on I18n.t("buttons.sign_in")
+              end
+            end
+            expect(current_path).to eq(jobseekers_subscriptions_path)
+          end
+
+          it "renders a sign in prompt form that redirects to sign in page on error then redirects to job alerts dashboard" do
+            within "div[data-account-prompt='sign-in']" do
+              expect(page).to have_content(I18n.t("subscriptions.jobseeker_account_prompt.heading.sign_in"))
+              click_on I18n.t("buttons.sign_in")
+            end
+            sign_in_jobseeker
+            expect(current_path).to eq(jobseekers_subscriptions_path)
+          end
         end
       end
     end
 
     context "when jobseeker does not have an account" do
-      it "renders a create account prompt that redirects to job alerts dashboard" do
-        within "div[data-account-prompt='sign-up']" do
-          expect(page).to have_content(I18n.t("subscriptions.jobseeker_account_prompt.heading.sign_up"))
-          click_on I18n.t("subscriptions.jobseeker_account_prompt.link.sign_up")
+      context "when current_variant?(:'2021_02_job_alert_account_creation_test', :link) is true" do
+        let(:jobseeker_account_prompt_variant) { :link }
+
+        it "renders a create account prompt link that redirects to job alerts dashboard" do
+          within "div[data-account-prompt='sign-up']" do
+            expect(page).to have_content(I18n.t("subscriptions.jobseeker_account_prompt.heading.sign_up"))
+            click_on I18n.t("subscriptions.jobseeker_account_prompt.link.sign_up")
+          end
+          expect(current_path).to eq(new_jobseeker_registration_path)
+          sign_up_jobseeker
+          visit first_link_from_last_mail
+          expect(current_path).to eq(jobseekers_subscriptions_path)
         end
-        expect(current_path).to eq(new_jobseeker_registration_path)
-        sign_up_jobseeker
-        visit first_link_from_last_mail
-        expect(current_path).to eq(jobseekers_subscriptions_path)
+      end
+
+      context "when current_variant?(:'2021_02_job_alert_account_creation_test', :form) is true" do
+        let(:jobseeker_account_prompt_variant) { :form }
+
+        it "renders a create an account prompt form that redirects to job alerts dashboard" do
+          within "div[data-account-prompt='sign-up']" do
+            expect(page).to have_content(I18n.t("subscriptions.jobseeker_account_prompt.heading.sign_up"))
+            fill_in "Password", with: jobseeker.password
+            click_on I18n.t("buttons.create_account")
+          end
+          visit first_link_from_last_mail
+          expect(current_path).to eq(jobseekers_subscriptions_path)
+        end
+
+        it "renders a create an account prompt form that redirects to sign up page on error then redirects to job alerts dashboard" do
+          within "div[data-account-prompt='sign-up']" do
+            expect(page).to have_content(I18n.t("subscriptions.jobseeker_account_prompt.heading.sign_up"))
+            click_on I18n.t("buttons.create_account")
+          end
+          sign_up_jobseeker
+          visit first_link_from_last_mail
+          expect(current_path).to eq(jobseekers_subscriptions_path)
+        end
       end
     end
   end

--- a/spec/system/jobseekers_can_manage_their_job_alerts_from_the_email_spec.rb
+++ b/spec/system/jobseekers_can_manage_their_job_alerts_from_the_email_spec.rb
@@ -3,12 +3,14 @@ require "rails_helper"
 RSpec.describe "Jobseekers can manage their job alerts from the email" do
   let(:jobseeker_signed_in?) { false }
   let(:jobseeker) { build_stubbed(:jobseeker) }
+  let(:jobseeker_account_prompt_variant) { nil }
 
   let(:search_criteria) { { keyword: "Maths", location: "London" } }
   let(:frequency) { :daily }
   let(:subscription) { create(:subscription, email: jobseeker.email, frequency: frequency, search_criteria: search_criteria) }
 
   before do
+    page.set_rack_session(ab_tests: { "2021_02_job_alert_account_creation_test": jobseeker_account_prompt_variant })
     login_as(jobseeker, scope: :jobseeker) if jobseeker_signed_in?
     visit edit_subscription_path(token)
   end
@@ -37,28 +39,84 @@ RSpec.describe "Jobseekers can manage their job alerts from the email" do
         end
 
         context "when jobseeker is signed out" do
-          it "renders a sign in prompt that redirects to job alerts dashboard" do
-            within "div[data-account-prompt='sign-in']" do
-              expect(page).to have_content(I18n.t("subscriptions.jobseeker_account_prompt.heading.sign_in"))
-              click_on I18n.t("subscriptions.jobseeker_account_prompt.link.sign_in")
+          context "when current_variant?(:'2021_02_job_alert_account_creation_test', :link) is true" do
+            let(:jobseeker_account_prompt_variant) { :link }
+
+            it "renders a sign in prompt link that redirects to job alerts dashboard" do
+              within "div[data-account-prompt='sign-in']" do
+                expect(page).to have_content(I18n.t("subscriptions.jobseeker_account_prompt.heading.sign_in"))
+                click_on I18n.t("subscriptions.jobseeker_account_prompt.link.sign_in")
+              end
+              expect(current_path).to eq(new_jobseeker_session_path)
+              sign_in_jobseeker
+              expect(current_path).to eq(jobseekers_subscriptions_path)
             end
-            expect(current_path).to eq(new_jobseeker_session_path)
-            sign_in_jobseeker
-            expect(current_path).to eq(jobseekers_subscriptions_path)
+          end
+
+          context "when current_variant?(:'2021_02_job_alert_account_creation_test', :form) is true" do
+            let(:jobseeker_account_prompt_variant) { :form }
+
+            it "renders a sign in prompt form that redirects to job alerts dashboard" do
+              within "div[data-account-prompt='sign-in']" do
+                expect(page).to have_content(I18n.t("subscriptions.jobseeker_account_prompt.heading.sign_in"))
+                fill_in "Password", with: jobseeker.password
+                within(".edit_jobseeker") do
+                  click_on I18n.t("buttons.sign_in")
+                end
+              end
+              expect(current_path).to eq(jobseekers_subscriptions_path)
+            end
+
+            it "renders a sign in prompt form that redirects to sign in page on error then redirects to job alerts dashboard" do
+              within "div[data-account-prompt='sign-in']" do
+                expect(page).to have_content(I18n.t("subscriptions.jobseeker_account_prompt.heading.sign_in"))
+                click_on I18n.t("buttons.sign_in")
+              end
+              sign_in_jobseeker
+              expect(current_path).to eq(jobseekers_subscriptions_path)
+            end
           end
         end
       end
 
       context "when jobseeker does not have an account" do
-        it "renders a create account prompt that redirects to job alerts dashboard" do
-          within "div[data-account-prompt='sign-up']" do
-            expect(page).to have_content(I18n.t("subscriptions.jobseeker_account_prompt.heading.sign_up"))
-            click_on I18n.t("subscriptions.jobseeker_account_prompt.link.sign_up")
+        context "when current_variant?(:'2021_02_job_alert_account_creation_test', :link) is true" do
+          let(:jobseeker_account_prompt_variant) { :link }
+
+          it "renders a create account prompt link that redirects to job alerts dashboard" do
+            within "div[data-account-prompt='sign-up']" do
+              expect(page).to have_content(I18n.t("subscriptions.jobseeker_account_prompt.heading.sign_up"))
+              click_on I18n.t("subscriptions.jobseeker_account_prompt.link.sign_up")
+            end
+            expect(current_path).to eq(new_jobseeker_registration_path)
+            sign_up_jobseeker
+            visit first_link_from_last_mail
+            expect(current_path).to eq(jobseekers_subscriptions_path)
           end
-          expect(current_path).to eq(new_jobseeker_registration_path)
-          sign_up_jobseeker
-          visit first_link_from_last_mail
-          expect(current_path).to eq(jobseekers_subscriptions_path)
+        end
+
+        context "when current_variant?(:'2021_02_job_alert_account_creation_test', :form) is true" do
+          let(:jobseeker_account_prompt_variant) { :form }
+
+          it "renders a create an account prompt form that redirects to job alerts dashboard" do
+            within "div[data-account-prompt='sign-up']" do
+              expect(page).to have_content(I18n.t("subscriptions.jobseeker_account_prompt.heading.sign_up"))
+              fill_in "Password", with: jobseeker.password
+              click_on I18n.t("buttons.create_account")
+            end
+            visit first_link_from_last_mail
+            expect(current_path).to eq(jobseekers_subscriptions_path)
+          end
+
+          it "renders a create an account prompt form that redirects to sign up page on error then redirects to job alerts dashboard" do
+            within "div[data-account-prompt='sign-up']" do
+              expect(page).to have_content(I18n.t("subscriptions.jobseeker_account_prompt.heading.sign_up"))
+              click_on I18n.t("buttons.create_account")
+            end
+            sign_up_jobseeker
+            visit first_link_from_last_mail
+            expect(current_path).to eq(jobseekers_subscriptions_path)
+          end
         end
       end
     end

--- a/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Jobseekers can sign up to an account" do
   describe "creating an account" do
     it "validates and submits the form, triggers account created event, sends confirmation email and redirects to check your email page" do
       visit new_jobseeker_registration_path
-      click_on I18n.t("buttons.continue")
+      click_on I18n.t("buttons.create_account")
       expect(page).to have_content("There is a problem")
       expect { sign_up_jobseeker }.to have_triggered_event(:jobseeker_account_created).with_data(
         user_anonymised_jobseeker_id: anything,


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-1819

## Changes in this PR
- Some small design tweaks
- Use `Create an account` instead of `Continue` when creating an account
- Add ab test for job alert account creation prompts

## Screenshots
### Account exists, form variant 
![image](https://user-images.githubusercontent.com/25187547/108386699-cd049f80-7204-11eb-8067-e0926b8f354a.png)

### Account exists, link variant
![image](https://user-images.githubusercontent.com/25187547/108386911-01785b80-7205-11eb-8886-2e83f0a6d27d.png)

### Account doesn't exist, form variant
![image](https://user-images.githubusercontent.com/25187547/108387067-266cce80-7205-11eb-9195-493bdcca6e94.png)

### Account doesn't exist, link variant
![image](https://user-images.githubusercontent.com/25187547/108387161-3edce900-7205-11eb-9c47-9cc9e5088bcb.png)
