### PR TITLE
[TEVA 2076] Add initial automated a11y testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,8 @@ group :development do
 end
 
 group :development, :test do
+  gem "axe-core-capybara"
+  gem "axe-core-rspec"
   gem "brakeman"
   gem "bullet"
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,23 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.2.2)
       aws-eventstream (~> 1, >= 1.0.2)
+    axe-core-api (4.1.0)
+      capybara
+      dumb_delegator
+      selenium-webdriver
+      virtus
+      watir
+    axe-core-capybara (4.1.0)
+      axe-core-api
+      dumb_delegator
+    axe-core-rspec (4.1.0)
+      axe-core-api
+      dumb_delegator
+      virtus
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     bcrypt (3.1.16)
     bindata (2.4.8)
     bindex (0.8.1)
@@ -112,6 +129,8 @@ GEM
       xpath (~> 3.2)
     childprocess (3.0.0)
     coderay (1.1.3)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     colorize (0.8.1)
     concurrent-ruby (1.1.8)
     connection_pool (2.2.3)
@@ -120,6 +139,8 @@ GEM
     crass (1.0.6)
     declarative (0.0.20)
     declarative-option (0.1.0)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     devise (4.7.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -132,6 +153,8 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
+    dumb_delegator (1.0.0)
+    equalizer (0.0.11)
     erubi (1.10.0)
     et-orbi (1.2.4)
       tzinfo
@@ -226,6 +249,7 @@ GEM
     httpclient (2.8.3)
     i18n (1.8.9)
       concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
     ipaddr (1.2.2)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
@@ -517,6 +541,7 @@ GEM
       httpclient (>= 2.4)
     temple (0.8.2)
     thor (1.1.0)
+    thread_safe (0.3.6)
     tilt (2.0.10)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -532,8 +557,15 @@ GEM
     vcr (6.0.0)
     view_component (2.24.0)
       activesupport (>= 5.0.0, < 7.0)
+    virtus (1.0.5)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
+      equalizer (~> 0.0, >= 0.0.9)
     warden (1.2.9)
       rack (>= 2.0.9)
+    watir (6.14.0)
+      selenium-webdriver (~> 3.4, >= 3.4.1)
     web-console (4.1.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -572,6 +604,8 @@ DEPENDENCIES
   algoliasearch-rails
   array_enum
   aws-sdk-ssm
+  axe-core-capybara
+  axe-core-rspec
   brakeman
   breasal
   browser

--- a/app/components/jobseekers/organisation_overviews/school_component/school_component.html.slim
+++ b/app/components/jobseekers/organisation_overviews/school_component/school_component.html.slim
@@ -33,8 +33,8 @@ section#school-overview class="govuk-!-margin-bottom-5"
 
   section#school-location
     h3.govuk-heading-l.section-heading = t("schools.school_location.one")
-    p = full_address(organisation)
+    = govuk_link_to full_address(organisation), "https://www.google.com/maps/search/#{full_address(organisation)}+UK", "aria-label": t("schools.map_link_aria_label")
 
     - if organisation.geolocation
       div id="map" role="presentation" aria-label=t("schools.map_aria_label") data-school=organisation_map_data
-      script defer=true src="https://maps.googleapis.com/maps/api/js?key=#{GOOGLE_MAPS_API_KEY}&callback=initMap"
+      script defer=true title=t("schools.map_aria_label") src="https://maps.googleapis.com/maps/api/js?key=#{GOOGLE_MAPS_API_KEY}&callback=initMap"

--- a/app/components/jobseekers/organisation_overviews/school_component/school_component.html.slim
+++ b/app/components/jobseekers/organisation_overviews/school_component/school_component.html.slim
@@ -36,5 +36,5 @@ section#school-overview class="govuk-!-margin-bottom-5"
     p = full_address(organisation)
 
     - if organisation.geolocation
-      div id="map" role="presentation" aria-hidden="true" aria-label=t("schools.map_aria_label") data-school=organisation_map_data
+      div id="map" role="presentation" aria-label=t("schools.map_aria_label") data-school=organisation_map_data
       script defer=true src="https://maps.googleapis.com/maps/api/js?key=#{GOOGLE_MAPS_API_KEY}&callback=initMap"

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -33,7 +33,7 @@ html.govuk-template.app-html-class class=("modal" if current_variant?(:"2021_02_
         .govuk-header__logo
           a.govuk-header__link.govuk-header__link--homepage href="https://www.gov.uk"
             span.govuk-header__logotype
-              img.govuk-header__logotype-crown src=asset_pack_path("media/images/svg/govuk-logo-crown.svg") height="26" width="32"
+              img.govuk-header__logotype-crown src=asset_pack_path("media/images/svg/govuk-logo-crown.svg") height="26" width="32" aria-hidden="true"
               span.govuk-header__logotype-text
                 | GOV.UK
         .govuk-header__content

--- a/app/views/shared/vacancy/_share_buttons.html.slim
+++ b/app/views/shared/vacancy/_share_buttons.html.slim
@@ -1,11 +1,11 @@
 ul.govuk-list
   li.share-links__list-item
     a target="_blank" class="govuk-link share-links__link vacancy-share-link" href="https://www.facebook.com/sharer/sharer.php?u=#{CGI.escape(@vacancy.share_url)}" data-target="facebook"
-      img src=asset_pack_path("media/images/svg/logo-facebook.svg") height="40" width="40" class="share-links__link-icon"
+      img src=asset_pack_path("media/images/svg/logo-facebook.svg") height="40" width="40" class="share-links__link-icon" aria-hidden="true"
       span.visually-hidden = t("jobs.share_on")
       | Facebook
   li.share-links__list-item
     a target="_blank" class="govuk-link share-links__link vacancy-share-link" href="https://twitter.com/share?url=#{CGI.escape(@vacancy.share_url)}&text=#{CGI.escape(@vacancy.job_title_and_parent_organisation_name)}" data-target="twitter"
-      img src=asset_pack_path("media/images/svg/logo-twitter.svg") height="40" width="40" class="share-links__link-icon"
+      img src=asset_pack_path("media/images/svg/logo-twitter.svg") height="40" width="40" class="share-links__link-icon" aria-hidden="true"
       span.visually-hidden = t("jobs.share_on")
       | Twitter

--- a/app/views/vacancies/_filters.html.slim
+++ b/app/views/vacancies/_filters.html.slim
@@ -32,7 +32,7 @@ ruby:
     },
   ]
 
-= form_for @jobs_search_form, as: "", url: jobs_path, method: :get, html: { data: { "auto-submit": true }, class: "filters-form", role: "search", aria: { label: "Search criteria" } } do |f|
+= form_for @jobs_search_form, as: "", url: jobs_path, method: :get, html: { id: "filter-form", data: { "auto-submit": true }, class: "filters-form", role: "search", aria: { label: "Search criteria" } } do |f|
   aside.filter-vacancies class="govuk-!-margin-bottom-3"
     h2.govuk-heading-m = t("jobs.filters.title")
 

--- a/app/views/vacancies/_sorting_options.html.slim
+++ b/app/views/vacancies/_sorting_options.html.slim
@@ -1,4 +1,4 @@
-= form_for @jobs_search_form, as: "", url: jobs_path, method: :get, id: "jobs_sort_form", html: { class: "sort-inline", data: { 'auto-submit': true, "hide-submit": true } } do |f|
+= form_for @jobs_search_form, as: "", url: jobs_path, method: :get, id: "jobs_sort_form", html: { id: "sorting-options-form", class: "sort-inline", data: { 'auto-submit': true, "hide-submit": true } } do |f|
   = f.hidden_field :keyword, value: @jobs_search_form.keyword
   = f.hidden_field :location, value: @jobs_search_form.location
   = f.hidden_field :radius, value: @jobs_search_form.radius

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -240,6 +240,7 @@ en:
     description: Description
     info: About %{organisation}
     map_aria_label: Interactive map showing school location
+    map_link_aria_label: Open in Google Maps
     no_information: No information available
     no_jobs:
       bullets:

--- a/spec/accessibility/jobseeker_experience_accessibility_spec.rb
+++ b/spec/accessibility/jobseeker_experience_accessibility_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe "Jobseeker experience accessibility", type: :system, accessibility: true do
+  let(:school) { create(:school) }
+  let!(:job1) { create(:vacancy, :past_publish, job_title: "Teacher of Potions", organisation_vacancies_attributes: [{ organisation: school }]) }
+
+  scenario "jobseeker visits homepage, performs a search, and views a job page" do
+    visit root_path
+    expect(page).to meet_accessibility_standards
+
+    click_on "Search"
+    expect(page).to meet_accessibility_standards
+
+    click_on "Teacher of Potions"
+    expect(page).to meet_accessibility_standards
+  end
+end

--- a/spec/components/jobseekers/organisation_overviews/school_component_spec.rb
+++ b/spec/components/jobseekers/organisation_overviews/school_component_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Jobseekers::OrganisationOverviews::SchoolComponent, type: :compon
   let(:vacancy) { create(:vacancy, :at_one_school) }
   let(:vacancy_presenter) { VacancyPresenter.new(vacancy) }
 
-  before do
+  let!(:inline_component) do
     vacancy.organisation_vacancies.create(organisation: organisation)
     render_inline(described_class.new(vacancy: vacancy_presenter))
   end
@@ -106,7 +106,7 @@ RSpec.describe Jobseekers::OrganisationOverviews::SchoolComponent, type: :compon
     end
 
     it "shows the map element for Google Maps API to populate" do
-      expect(rendered_component).to include("map")
+      expect(inline_component.css("#map").count).to eq(1)
     end
   end
 
@@ -118,7 +118,7 @@ RSpec.describe Jobseekers::OrganisationOverviews::SchoolComponent, type: :compon
     end
 
     it "does not show the map" do
-      expect(rendered_component).not_to include("map")
+      expect(inline_component.css("#map").count).to eq(0)
     end
   end
 

--- a/spec/components/jobseekers/organisation_overviews/schools_component_spec.rb
+++ b/spec/components/jobseekers/organisation_overviews/schools_component_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Jobseekers::OrganisationOverviews::SchoolsComponent, type: :compo
   end
   let(:vacancy_presenter) { VacancyPresenter.new(vacancy) }
 
-  before do
+  let!(:inline_component) do
     organisation.school_group_memberships.create(school: school1)
     organisation.school_group_memberships.create(school: school2)
     organisation.school_group_memberships.create(school: school3)
@@ -119,7 +119,7 @@ RSpec.describe Jobseekers::OrganisationOverviews::SchoolsComponent, type: :compo
     end
 
     it "shows the map element for Google Maps API to populate" do
-      expect(rendered_component).to include("map")
+      expect(inline_component.css("#map").count).to eq(1)
     end
   end
 
@@ -131,7 +131,7 @@ RSpec.describe Jobseekers::OrganisationOverviews::SchoolsComponent, type: :compo
     end
 
     it "does not show the map" do
-      expect(rendered_component).not_to include("map")
+      expect(inline_component.css("#map").count).to eq(0)
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@ require File.expand_path("../config/environment", __dir__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
+require "axe-rspec"
 require "factory_bot_rails"
 require "geocoder"
 require "rack_session_access/capybara"
@@ -56,6 +57,10 @@ RSpec.configure do |config|
     driven_by :selenium, using: :headless_chrome
   end
 
+  config.before(:each, type: :system, accessibility: true) do
+    driven_by :selenium, using: :headless_chrome
+  end
+
   config.before do
     allow(JobseekerApplicationsFeature).to receive(:enabled?).and_return(false)
     allow(Redis).to receive(:new).and_return(MockRedis.new)
@@ -66,6 +71,7 @@ RSpec.configure do |config|
     allow(Rails.application.config).to receive(:geocoder_lookup).and_return(:default)
   end
 
+  config.include AccessibilityHelpers, type: :system
   config.include ActionView::Helpers::NumberHelper
   config.include ActionView::Helpers::TextHelper
   config.include ActiveSupport::Testing::Assertions # required for ActiveJob::TestHelper#perform_enqueued_jobs

--- a/spec/support/accessibility_helpers.rb
+++ b/spec/support/accessibility_helpers.rb
@@ -1,0 +1,5 @@
+module AccessibilityHelpers
+  def meet_accessibility_standards
+    be_axe_clean.according_to(:wcag2a, :wcag2aa, :wcag21a, :wcag21aa)
+  end
+end


### PR DESCRIPTION
This uses the `axe` tool in a separate set of accessibility system specs
to identify violations of WCAG standards in what will eventually be a
representative sample of user journeys.

Fixes the following accessibility violations:
- Add `aria-hidden` to several purely decorative images (social media
  icons, GOV.UK crown in logotype)
- Filter and sort form on search results page should have distinct
  HTML IDs (they were clashing due to `as: ""` on the form)