### PR TITLE
Make seeding DB conditional on presence of vacancies

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,4 @@
-raise if Rails.env.production?
+raise "Aborting seeds - running in production with existing vacancies" if Rails.env.production? && Vacancy.any?
 
 require "faker"
 require "factory_bot_rails"


### PR DESCRIPTION
We used to run review apps using a separate Rails environment of
"staging", which is no more. They now (sensibly) refuse to load the
seeds, so we need to relax the requirement of "never seed in production"
to "never seed in production when any vacancies exist".