### PR TITLE
[TEVA-2007] Set explicit 60s healthcheck timeout for CF apps

### DIFF
--- a/terraform/app/modules/paas/main.tf
+++ b/terraform/app/modules/paas/main.tf
@@ -31,6 +31,7 @@ resource "cloudfoundry_app" "web_app" {
   docker_image               = var.app_docker_image
   health_check_type          = "http"
   health_check_http_endpoint = "/check"
+  health_check_timeout       = 60
   instances                  = var.web_app_instances
   memory                     = var.web_app_memory
   routes {
@@ -85,16 +86,17 @@ resource "cloudfoundry_route" "web_app_route_cloudfront_subdomain" {
 }
 
 resource "cloudfoundry_app" "worker_app" {
-  name              = local.worker_app_name
-  command           = local.worker_app_start_command
-  docker_image      = var.app_docker_image
-  health_check_type = "process"
-  instances         = var.worker_app_instances
-  memory            = var.worker_app_memory
-  space             = data.cloudfoundry_space.space.id
-  stopped           = var.app_stopped
-  strategy          = var.worker_app_deployment_strategy
-  timeout           = var.app_start_timeout
+  name                 = local.worker_app_name
+  command              = local.worker_app_start_command
+  docker_image         = var.app_docker_image
+  health_check_type    = "process"
+  health_check_timeout = 10
+  instances            = var.worker_app_instances
+  memory               = var.worker_app_memory
+  space                = data.cloudfoundry_space.space.id
+  stopped              = var.app_stopped
+  strategy             = var.worker_app_deployment_strategy
+  timeout              = var.app_start_timeout
   dynamic "service_binding" {
     for_each = local.app_service_bindings
     content {


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2077

## Changes in this PR:

- Set web and worker app healthcheck to `10s`
