### PR TITLE
Make notification components less hostile to screen-readers

### DIFF
--- a/app/components/shared/notification_component.rb
+++ b/app/components/shared/notification_component.rb
@@ -4,14 +4,14 @@ class Shared::NotificationComponent < ViewComponent::Base
                  dismiss: true,
                  background: false,
                  alert: "warning",
-                 html_attributes: { role: "alert", tabindex: "-1" })
+                 html_attributes: nil)
     @content = content
     @style = style
     @links = links
     @dismiss = style == "danger" ? false : dismiss
     @background = background
     @alert = %w[danger success].include?(style) ? false : alert
-    @html_attributes = html_attributes
+    @html_attributes = html_attributes || default_html_attributes
   end
 
   def notification_classes
@@ -24,5 +24,13 @@ class Shared::NotificationComponent < ViewComponent::Base
 
   def render_title_and_body?
     @content.is_a?(Hash) && @content[:body].present?
+  end
+
+  def default_html_attributes
+    if @style == "empty"
+      {}
+    else
+      { role: "alert", tabindex: "-1" }
+    end
   end
 end

--- a/app/views/nqt_job_alerts/new.html.slim
+++ b/app/views/nqt_job_alerts/new.html.slim
@@ -27,7 +27,7 @@
 
       = recaptcha
 
-      = render(Shared::NotificationComponent.new(content: t("nqt_job_alerts.intro.unsubscribe"), style: "notice", background: true, alert: "info", dismiss: false))
+      = render(Shared::NotificationComponent.new(content: t("nqt_job_alerts.intro.unsubscribe"), style: "notice", background: true, alert: "info", dismiss: false, html_attributes: {}))
 
       = f.govuk_submit t("buttons.subscribe"), classes: "nqt-job-alert-subscribe-gtm govuk-!-padding-left-8 govuk-!-padding-right-8"
 

--- a/app/views/shared/vacancy/_jobseeker_view.html.slim
+++ b/app/views/shared/vacancy/_jobseeker_view.html.slim
@@ -46,7 +46,7 @@
   .govuk-grid-column-two-thirds
 
     - if @vacancy.organisations.many?
-      = render(Shared::NotificationComponent.new(content: t("messages.jobs.multi_school_job_notification_html", organisation_type: organisation_type_basic(@vacancy.parent_organisation)), style: "notice", background: true, dismiss: false, alert: true))
+      = render(Shared::NotificationComponent.new(content: t("messages.jobs.multi_school_job_notification_html", organisation_type: organisation_type_basic(@vacancy.parent_organisation)), style: "notice", background: true, dismiss: false, alert: true, html_attributes: {}))
 
     .content-pills class="govuk-!-margin-bottom-6"
       h3.govuk-heading-s class="govuk-!-margin-bottom-3" = t("jobs.contents")

--- a/app/views/subscriptions/new.html.slim
+++ b/app/views/subscriptions/new.html.slim
@@ -13,7 +13,7 @@
 
       .location-search = render "fields", f: f
 
-      = render(Shared::NotificationComponent.new(content: { body: t("subscriptions.info") }, style: "notice", background: true, dismiss: false, alert: "info"))
+      = render(Shared::NotificationComponent.new(content: { body: t("subscriptions.info") }, style: "notice", background: true, dismiss: false, alert: "info", html_attributes: {}))
 
       = recaptcha
 

--- a/spec/components/shared/notification_component_spec.rb
+++ b/spec/components/shared/notification_component_spec.rb
@@ -160,6 +160,15 @@ RSpec.describe Shared::NotificationComponent, type: :component do
         expect(subject).to include('role="alert"')
         expect(subject).to include('tabindex="-1"')
       end
+
+      context "when the style is empty" do
+        let(:style) { "empty" }
+
+        it "has no html_attributes" do
+          expect(subject).not_to include('role="alert"')
+          expect(subject).not_to include('tabindex="-1"')
+        end
+      end
     end
 
     context "when html attributes are specified" do
@@ -175,10 +184,20 @@ RSpec.describe Shared::NotificationComponent, type: :component do
                       ))
       end
 
-      it "does not have the default role and tab-index" do
+      it "has the specified html_attributes and does not have the default role and tab-index" do
         expect(subject).not_to include('role="alert"')
         expect(subject).not_to include('tabindex="-1"')
         expect(subject).to include('role="fake-role"')
+      end
+
+      context "when the style is empty" do
+        let(:style) { "empty" }
+
+        it "has the specified html_attributes and does not have the default role and tab-index" do
+          expect(subject).not_to include('role="alert"')
+          expect(subject).not_to include('tabindex="-1"')
+          expect(subject).to include('role="fake-role"')
+        end
       end
     end
   end


### PR DESCRIPTION
The issue which the html_attributes attribute tries to solve is when we
reuse the notification component as something other than a notification,
e.g. for an 'empty' box (such as 'You have no saved jobs'), or for an
info box (such as 'You can unsubscribe in such and such a way'), we don't
want to give it the html role of 'alert' or the tabindex of '-1' which
cause screen-readers to get to the non-notification before anything else
and mess with the tab-order.

This can be refactored in the very near future but I wanted to get this
piece of accessibility in first so that it can be retained when the
refactoring happens - but maybe doing things in the other order
(refactor then accessibilize) is better?
