### PR TITLE
[SPIKE] Use CurrentAttributes and AR callbacks for events

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,7 @@ class ApplicationController < ActionController::Base
 
   before_action :redirect_to_canonical_domain, :set_headers
   before_action :store_jobseeker_redirect_to!, if: -> { redirect_to_param.present? }
+  before_action { EventContext.request_event = request_event }
 
   after_action :trigger_page_visited_event, unless: :request_is_healthcheck?
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,7 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  after_create { EventContext.trigger_event(:entity_created, entity: self.class.name) }
+  after_update { EventContext.trigger_event(:entity_updated, entity: self.class.name) }
+  after_destroy { EventContext.trigger_event(:entity_destroyed, entity: self.class.name) }
 end

--- a/app/models/event_context.rb
+++ b/app/models/event_context.rb
@@ -1,0 +1,13 @@
+class EventContext < ActiveSupport::CurrentAttributes
+  attribute :request_event
+
+  def trigger_event(...)
+    event.trigger(...)
+  end
+
+  private
+
+  def event
+    request_event || Event.new
+  end
+end


### PR DESCRIPTION
# DO NOT MERGE – just for discussion

A tiny spike to test feasibility of using `CurrentAttributes` to handle
entity CRUD events in the model layer more cleanly.