### PR TITLE
Clamp Algolia expiry filter to start of hour

### DIFF
--- a/app/services/search/filters_builder.rb
+++ b/app/services/search/filters_builder.rb
@@ -59,7 +59,7 @@ class Search::FiltersBuilder
   end
 
   def expired_now_filter
-    Time.current.to_time.to_i
+    Time.current.to_time.beginning_of_hour.to_i
   end
 
   def normalize_array_params(params)


### PR DESCRIPTION
This is the least effort way of making Algolia queries a bit easier to
cache. Because we need to filter on `expires_at_timestamp` at query
time, we can't cache any given query because the next one will have a
different timestamp.