### PR TITLE
[TEVA-1966] Implement Jobseeker Account Creation CTA A:B Variants

### DIFF
--- a/app/frontend/src/styles/application/signin.scss
+++ b/app/frontend/src/styles/application/signin.scss
@@ -1,7 +1,6 @@
 .signin {
   @include govuk-responsive-padding(5);
-
-  background-color: rgba($color: govuk-colour('black'), $alpha: 0.5);
+  background-color: govuk-colour('dark-blue');
   margin-bottom: govuk-spacing(5);
   margin-top: govuk-spacing(3);
 
@@ -9,5 +8,68 @@
   p,
   .govuk-link:not(:focus) {
     color: govuk-colour('white');
+  }
+
+  &--colour-variant {
+    background-color: govuk-colour('light-grey');
+
+    h2,
+    p,
+    .govuk-link:not(:focus) {
+      color: govuk-colour('black');
+    }
+  }
+
+  &--sticky-variant {
+    bottom: 0;
+    display: block;
+    margin-bottom: 0;
+    margin-top: 0;
+    padding: 0;
+    position: fixed;
+    width: 100%;
+    z-index: 1000;
+
+    &__fade {
+      background: linear-gradient($govuk-border-colour, transparent);
+      height: 6px;
+    }
+
+    &__content {
+      align-items: center;
+      color: govuk-colour('white');
+      display: flex;
+      justify-content: center;
+      padding: govuk-spacing(2);
+
+      @include govuk-media-query($until: tablet) {
+        display: block;
+      }
+
+      a {
+        color: govuk-colour('white');
+      }
+
+      p {
+        color: govuk-colour('white');
+        @include govuk-media-query($until: tablet) {
+          margin-left: govuk-spacing(1);
+        }
+      }
+
+      &-button {
+        display: inline;
+        justify-content: flex-start;
+        left: 2px;
+        margin-bottom: govuk-spacing(1);
+        margin-right: govuk-spacing(4);
+        position: relative;
+        top: 2px;
+
+        @include govuk-media-query($until: tablet) {
+          margin-bottom: govuk-spacing(2);
+        }
+      }
+    }
   }
 }

--- a/app/views/home/_signed_in_jobseeker.html.slim
+++ b/app/views/home/_signed_in_jobseeker.html.slim
@@ -2,4 +2,7 @@ h2.govuk-heading-m = t(".title")
 
 p = t(".description")
 
-= govuk_link_to t("buttons.view_account"), jobseekers_saved_jobs_path, class: "govuk-button--secondary govuk-!-margin-bottom-0", button: true
+- if current_variant?(:"2012_02_jobseeker_account_cta_test", :colour)
+  = govuk_link_to t("buttons.view_account"), jobseekers_saved_jobs_path, class: "govuk-!-margin-bottom-0", button: true
+- else
+  = govuk_link_to t("buttons.view_account"), jobseekers_saved_jobs_path, class: "govuk-button--secondary govuk-!-margin-bottom-0", button: true

--- a/app/views/home/_signed_out_jobseeker.html.slim
+++ b/app/views/home/_signed_out_jobseeker.html.slim
@@ -2,4 +2,7 @@ h2.govuk-heading-m = t(".title")
 
 p = t(".description_html", link: govuk_link_to(t("buttons.sign_in"), new_jobseeker_session_path, class: "govuk-link--no-visited-state"))
 
-= govuk_link_to t("buttons.create_account"), new_jobseeker_registration_path, class: "govuk-button--secondary govuk-!-margin-bottom-0", button: true
+- if current_variant?(:"2012_02_jobseeker_account_cta_test", :colour)
+  = govuk_link_to t("buttons.create_account"), new_jobseeker_registration_path, class: "govuk-!-margin-bottom-0", button: true
+- else
+  = govuk_link_to t("buttons.create_account"), new_jobseeker_registration_path, class: "govuk-button--secondary govuk-!-margin-bottom-0", button: true

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -6,11 +6,21 @@
       .govuk-grid-column-two-thirds
         .search-panel.location-search = render "search"
       .govuk-grid-column-one-third
-        .signin
-          - if jobseeker_signed_in?
+        - if current_variant?(:"2012_02_jobseeker_account_cta_test", :colour)
+          .signin.signin--colour-variant
+            - if jobseeker_signed_in?
+              = render "signed_in_jobseeker"
+            - else
+              = render "signed_out_jobseeker"
+        - if current_variant?(:"2012_02_jobseeker_account_cta_test", :default)
+          .signin
+            - if jobseeker_signed_in?
+              = render "signed_in_jobseeker"
+            - else
+              = render "signed_out_jobseeker"
+        - if current_variant?(:"2012_02_jobseeker_account_cta_test", :sticky) && jobseeker_signed_in?
+          .signin
             = render "signed_in_jobseeker"
-          - else
-            = render "signed_out_jobseeker"
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -28,6 +28,14 @@ html.govuk-template.app-html-class lang="en"
 
     = render AbTest::CookiesBannerComponent.new(create_path: create_cookies_preferences_path(cookies_consent: "yes", **utm_parameters), preferences_path: cookies_preferences_path(**utm_parameters)).with_variant(:default) unless cookies_preference_set?
 
+    - if current_variant?(:"2012_02_jobseeker_account_cta_test", :sticky) && controller_name == "home" && !jobseeker_signed_in?
+      .signin.signin--sticky-variant
+        .signin--sticky-variant__fade
+        .signin--sticky-variant__content class="govuk-heading-s govuk-!-font-weight-regular govuk-!-margin-0"
+          = govuk_button_to t("buttons.create_account"), new_jobseeker_registration_path, class: "govuk-button--secondary signin--sticky-variant__content-button"
+          p.govuk-body class="govuk-!-margin-bottom-0"
+            = t("account_creation_cta.help_text_html", link: link_to(t("account_creation_cta.sign_in"), new_jobseeker_session_path))
+
     header.govuk-header.navbar-component data-module="govuk-header" role="banner"
       .govuk-header__container.govuk-width-container
         .govuk-header__logo

--- a/config/ab_tests.yml
+++ b/config/ab_tests.yml
@@ -31,3 +31,7 @@ shared:
   2021_02_job_alert_account_creation_test:
     link: 1
     form: 1
+  2012_02_jobseeker_account_cta_test:
+    default: 1
+    colour: 1
+    sticky: 1

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,8 @@
 en:
+  account_creation_cta:
+    help_text_html: "%{link} or create an account to save the jobs you are interested in. You don’t need an account to search for a job or set up job alerts."
+    sign_in: Sign in
+    
   app:
     description: >-
       On Teaching Vacancies, NQTs, experienced teachers and leaders can search for a job at a school or Trust in England


### PR DESCRIPTION
# **DO NOT MERGE**

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1966

## Changes in this PR:

- Added variants to ab_tests.yml
- Added checks for variants in templates - Different CTAs rendered depending on the variant

## Comments:

- Perhaps not the cleanest way to do this, I don't know, but I was wary of spending too much time on something that may be scrapped depending on the results of the A:B test.
- If anyone has any suggestions to quickly clean up what I've done, it'd be appreciated
- The designs: https://www.figma.com/file/o1rQp5E9WRhdLwmeQIAdhb/Jobseeker-Account-Creation-Call-to-Action-Variants


