### PR TITLE
[TEVA-2094] Rename /teacher-vacancy to /app in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:2.7.2-alpine AS builder
 
 ARG DEV_PACKAGES="gcc libc-dev make yarn postgresql-dev build-base libxml2-dev libxslt-dev"
 
-WORKDIR /teacher-vacancy
+WORKDIR /app
 
 RUN apk add --no-cache libxml2 libxslt libpq tzdata nodejs $DEV_PACKAGES
 RUN echo "Europe/London" > /etc/timezone && \
@@ -30,14 +30,14 @@ RUN rm -rf node_modules log tmp yarn.lock && \
 
 # this stage reduces the image size.
 FROM ruby:2.7.2-alpine AS production
-WORKDIR /teacher-vacancy
+WORKDIR /app
 
 RUN apk update && apk add --no-cache libxml2 libxslt libpq tzdata nodejs
 RUN echo "Europe/London" > /etc/timezone && \
         cp /usr/share/zoneinfo/Europe/London /etc/localtime
 RUN gem install bundler:2.1.4 --no-document
 
-COPY --from=builder /teacher-vacancy /teacher-vacancy
+COPY --from=builder /app /app
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 
 EXPOSE 3000

--- a/documentation/docker.md
+++ b/documentation/docker.md
@@ -23,7 +23,7 @@ For both stages, we:
 - use the tag corresponding to the specific version of Ruby, but not of Alpine e.g. `ruby:2.7.2-alpine`, rather than `ruby:2.7.2-alpine3.13`
 - use the [apk tool](https://wiki.alpinelinux.org/wiki/Alpine_Linux_package_management) to update and install packages
 - set the timezone to `Europe/London` for consistency in logs
-- set the working directory to `/teacher-vacancy`
+- set the working directory to `/app`
 
 Steps from the `builder` stage worth highlighting:
 
@@ -51,7 +51,7 @@ Steps from the `production` stage worth highlighting:
 
 ```
 FROM ruby:2.7.2-alpine AS production
-COPY --from=builder /teacher-vacancy /teacher-vacancy
+COPY --from=builder /app /app
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 
 EXPOSE 3000
@@ -60,7 +60,7 @@ CMD bundle exec rails db:migrate && bundle exec rails s
 
 - Name the stage `production` so that it can be built individually
 - Copy from the `builder` stage:
-    - `/teacher-vacancy`
+    - `/app`
     - `/usr/local/bundle/`
 - Listen on port 3000
 - Run two Ruby bundle commands:
@@ -172,7 +172,7 @@ This passes the options:
 - `--rm` - tells the Docker engine to remove the container (but not the image) when it exits
 - `/bin/sh` - starts a shell (as the image is based off Alpine Linux, you'll get an error if you try to start `/bin/bash`)
 
-At this point you'll be in the `/teacher-vacancy` directory
+At this point you'll be in the `/app` directory
 
 ## Advanced features
 

--- a/documentation/hosting.md
+++ b/documentation/hosting.md
@@ -162,7 +162,7 @@ cf ssh <app_name>
 
 ```bash
 cf ssh <app_name>
-cd /teacher-vacancy
+cd /app
 /usr/local/bin/bundle exec rails console
 ```
 


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2094

## Changes in this PR:

- For consistency with other Rails apps, use `app` rather than `teacher-vacancy`

Tested with 
```
cf ssh teaching-vacancies-worker-review-pr-2945
~ # cd /app
/app # /usr/local/bin/bundle exec rails console
[SKYLIGHT] [5.0.0-beta5] Skylight agent enabled
Loading production environment (Rails 6.1.3)
irb(main):001:0
```

## Next steps:

- [ ] Ensure developers are aware of changes if they use CF CLI to connect into the running application
