### PR TITLE
TEVA-2092 Exit review workflow on smoke test failure

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -136,6 +136,10 @@ jobs:
         timeoutSeconds: 300
         intervalSeconds: 15
 
+    - name: Exit whole workflow if review smoke test was not successful
+      if: steps.wait_for_smoke_test.outputs.conclusion != 'success'
+      run: exit 1
+
     - name: Send job status message to twd_tv_dev channel
       uses: rtCamp/action-slack-notify@v2.1.2
       env:


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2092

## Changes in this PR:

- Add step to mark the whole workflow as failed if the smoke test fails, which will prevent merging until corrected.

