### PR TITLE
[TEVA-1996] Trigger sign in events for jobseekers

### DIFF
--- a/app/controllers/jobseekers/sessions_controller.rb
+++ b/app/controllers/jobseekers/sessions_controller.rb
@@ -3,6 +3,9 @@ class Jobseekers::SessionsController < Devise::SessionsController
   before_action :render_resource_with_errors, only: %i[new]
   before_action :check_if_access_locked, only: %i[new]
   after_action :replace_devise_notice_flash_with_success!, only: %i[create destroy]
+  after_action only: %i[create] do
+    trigger_sign_in_event(:success)
+  end
 
   AUTHENTICATION_FAILURE_MESSAGES = %w[
     invalid not_found_in_database last_attempt
@@ -15,10 +18,12 @@ class Jobseekers::SessionsController < Devise::SessionsController
     form = Jobseekers::SignInForm.new(sign_in_params)
     if params[:action] == "create" && form.invalid?
       form.errors.each { |error| resource.errors.add(error.attribute, error.type) }
+      trigger_sign_in_event(:failure, resource.errors)
       clear_flash_and_render(:new)
     elsif AUTHENTICATION_FAILURE_MESSAGES.include?(flash[:alert])
       resource.errors.add(:email, flash[:alert])
       resource.errors.add(:password, "")
+      trigger_sign_in_event(:failure, resource.errors)
       clear_flash_and_render(:new)
     end
   end
@@ -30,5 +35,14 @@ class Jobseekers::SessionsController < Devise::SessionsController
   def clear_flash_and_render(view)
     flash.clear
     render view
+  end
+
+  def trigger_sign_in_event(success_or_failure, errors = nil)
+    request_event.trigger(
+      :jobseeker_sign_in_attempt,
+      email_identifier: StringAnonymiser.new(params[:jobseeker][:email]),
+      success: success_or_failure == :success,
+      errors: errors,
+    )
   end
 end

--- a/app/controllers/publishers/sign_in/base_sessions_controller.rb
+++ b/app/controllers/publishers/sign_in/base_sessions_controller.rb
@@ -40,4 +40,13 @@ class Publishers::SignIn::BaseSessionsController < Publishers::BaseController
       "Updated session with LA_CODE #{session[:organisation_la_code]}"
     end
   end
+
+  def trigger_sign_in_event(success_or_failure, sign_in_type, publisher_oid = nil)
+    request_event.trigger(
+      :publisher_sign_in_attempt,
+      user_anonymised_publisher_id: StringAnonymiser.new(publisher_oid),
+      success: success_or_failure == :success,
+      sign_in_type: sign_in_type,
+    )
+  end
 end

--- a/app/controllers/publishers/sign_in/dfe/sessions_controller.rb
+++ b/app/controllers/publishers/sign_in/dfe/sessions_controller.rb
@@ -120,8 +120,10 @@ class Publishers::SignIn::Dfe::SessionsController < Publishers::SignIn::BaseSess
     if authorisation_permissions.authorised? && organisation_id_present? && allowed_user?
       update_session(authorisation_permissions)
       update_publisher_last_activity_at
+      trigger_sign_in_event(:success, :dsi)
       redirect_to organisation_path
     else
+      trigger_sign_in_event(:failure, :dsi, user_id)
       not_authorised
     end
   end

--- a/app/controllers/publishers/sign_in/email/sessions_controller.rb
+++ b/app/controllers/publishers/sign_in/email/sessions_controller.rb
@@ -15,6 +15,7 @@ class Publishers::SignIn::Email::SessionsController < Publishers::SignIn::BaseSe
   def create
     session.update(organisation_urn: params[:urn], organisation_uid: params[:uid], organisation_la_code: params[:la_code])
     Rails.logger.info(updated_session_details)
+    trigger_sign_in_event(:success, :email)
     redirect_to organisation_path
   end
 
@@ -88,7 +89,10 @@ class Publishers::SignIn::Email::SessionsController < Publishers::SignIn::BaseSe
   end
 
   def redirect_unauthorised_publishers
-    redirect_to new_auth_email_path, notice: t(".not_authorised") unless publisher_authorised?
+    return if publisher_authorised?
+
+    trigger_sign_in_event(:failure, :email)
+    redirect_to new_auth_email_path, notice: t(".not_authorised")
   end
 
   def publisher_authorised?

--- a/spec/system/hiring_staff_can_sign_in_by_email_spec.rb
+++ b/spec/system/hiring_staff_can_sign_in_by_email_spec.rb
@@ -81,7 +81,10 @@ RSpec.describe "Hiring staff signing in with fallback email authentication" do
           expect(page).to have_content(other_school.name)
           expect(page).to have_content(trust.name)
           expect(page).to have_content(local_authority.name)
-          click_on school.name
+          expect { click_on school.name }
+            .to have_triggered_event(:publisher_sign_in_attempt)
+            .with_base_data(user_anonymised_publisher_id: anonymised_form_of(publisher.oid))
+            .and_data(success: "true", sign_in_type: "email")
 
           expect(page).to have_content(school.name)
           expect { login_key.reload }.to raise_error ActiveRecord::RecordNotFound
@@ -129,7 +132,10 @@ RSpec.describe "Hiring staff signing in with fallback email authentication" do
             expect(page).to have_content(I18n.t("publishers.temp_login.check_your_email.sent"))
 
             # Expect that the link in the email goes to the landing page
-            visit auth_email_choose_organisation_path(login_key: login_key.id)
+            expect { visit auth_email_choose_organisation_path(login_key: login_key.id) }
+              .to have_triggered_event(:publisher_sign_in_attempt)
+              .with_base_data(user_anonymised_publisher_id: anonymised_form_of(publisher.oid))
+              .and_data(success: "true", sign_in_type: "email")
 
             expect(page).not_to have_content("Choose your organisation")
             expect(page).to have_content(school.name)
@@ -156,7 +162,10 @@ RSpec.describe "Hiring staff signing in with fallback email authentication" do
             expect(page).to have_content(I18n.t("publishers.temp_login.check_your_email.sent"))
 
             # Expect that the link in the email goes to the landing page
-            visit auth_email_choose_organisation_path(login_key: login_key.id)
+            expect { visit auth_email_choose_organisation_path(login_key: login_key.id) }
+              .to have_triggered_event(:publisher_sign_in_attempt)
+              .with_base_data(user_anonymised_publisher_id: anonymised_form_of(publisher.oid))
+              .and_data(success: "true", sign_in_type: "email")
 
             expect(page).not_to have_content("Choose your organisation")
             expect(page).to have_content(trust.name)
@@ -189,7 +198,10 @@ RSpec.describe "Hiring staff signing in with fallback email authentication" do
             expect(page).to have_content(I18n.t("publishers.temp_login.check_your_email.sent"))
 
             # Expect that the link in the email goes to the landing page
-            visit auth_email_choose_organisation_path(login_key: login_key.id)
+            expect { visit auth_email_choose_organisation_path(login_key: login_key.id) }
+              .to have_triggered_event(:publisher_sign_in_attempt)
+              .with_base_data(user_anonymised_publisher_id: anonymised_form_of(publisher.oid))
+              .and_data(success: "true", sign_in_type: "email")
 
             expect(page).not_to have_content("Choose your organisation")
             expect(page).to have_content(local_authority.name)
@@ -202,7 +214,11 @@ RSpec.describe "Hiring staff signing in with fallback email authentication" do
 
           it "cannot sign in" do
             freeze_time do
-              visit auth_email_choose_organisation_path(login_key: login_key.id)
+              expect { visit auth_email_choose_organisation_path(login_key: login_key.id) }
+                .to have_triggered_event(:publisher_sign_in_attempt)
+                .with_base_data(user_anonymised_publisher_id: anonymised_form_of(publisher.oid))
+                .and_data(success: "false", sign_in_type: "email")
+
               expect(page).to have_content "You are not authorised to log in"
             end
           end

--- a/spec/system/jobseekers_can_sign_in_to_their_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_in_to_their_account_spec.rb
@@ -2,35 +2,60 @@ require "rails_helper"
 
 RSpec.describe "Jobseekers can sign in to their account" do
   let(:jobseeker) { create(:jobseeker) }
+  let(:expected_data) do
+    {
+      email_identifier: anonymised_form_of(email),
+      success: successful_attempt?,
+      errors: sign_in_errors,
+    }
+  end
 
   before do
     visit root_path
     within("nav") do
       click_on I18n.t("buttons.sign_in")
     end
-    sign_in_jobseeker(email: email, password: password)
   end
 
   context "when entering correct details" do
     let(:email) { jobseeker.email }
     let(:password) { jobseeker.password }
+    let(:successful_attempt?) { "true" }
+    let(:sign_in_errors) { nil }
 
     it "signs in the jobseeker" do
+      sign_in_jobseeker(email: email, password: password)
       expect(current_path).to eq(jobseekers_saved_jobs_path)
       expect(page).to have_content(I18n.t("devise.sessions.signed_in"))
+    end
+
+    it "triggers a successful `jobseeker_sign_in_attempt` event" do
+      expect { sign_in_jobseeker(email: email, password: password) }
+        .to have_triggered_event(:jobseeker_sign_in_attempt)
+        .with_data(expected_data)
     end
   end
 
   context "when entering incorrect details" do
+    let(:successful_attempt?) { "false" }
+    let(:sign_in_errors) { anything }
+
     context "when details are missing" do
       let(:email) { "" }
       let(:password) { "" }
 
       it "does not sign in the jobseeker and displays an error message" do
+        sign_in_jobseeker(email: email, password: password)
         expect(current_path).to eq(jobseeker_session_path)
         expect(page).not_to have_selector(".govuk-notification")
         expect(page).to have_content(I18n.t("activerecord.errors.models.jobseeker.attributes.email.blank"))
         expect(page).to have_content(I18n.t("activerecord.errors.models.jobseeker.attributes.password.blank"))
+      end
+
+      it "triggers an unsuccessful `jobseeker_sign_in_attempt` event" do
+        expect { sign_in_jobseeker(email: email, password: password) }
+          .to have_triggered_event(:jobseeker_sign_in_attempt)
+          .with_data(expected_data)
       end
     end
 
@@ -39,9 +64,16 @@ RSpec.describe "Jobseekers can sign in to their account" do
       let(:password) { jobseeker.password }
 
       it "does not sign in the jobseeker and displays a general error message" do
+        sign_in_jobseeker(email: email, password: password)
         expect(current_path).to eq(jobseeker_session_path)
         expect(page).not_to have_selector(".govuk-notification")
         expect(page).to have_content(I18n.t("devise.failure.invalid"))
+      end
+
+      it "triggers an unsuccessful `jobseeker_sign_in_attempt` event" do
+        expect { sign_in_jobseeker(email: email, password: password) }
+          .to have_triggered_event(:jobseeker_sign_in_attempt)
+          .with_data(expected_data)
       end
     end
 
@@ -50,9 +82,16 @@ RSpec.describe "Jobseekers can sign in to their account" do
       let(:password) { "incorrect_password" }
 
       it "does not sign in the jobseeker and displays a general error message" do
+        sign_in_jobseeker(email: email, password: password)
         expect(current_path).to eq(jobseeker_session_path)
         expect(page).not_to have_selector(".govuk-notification")
         expect(page).to have_content(I18n.t("devise.failure.invalid"))
+      end
+
+      it "triggers an unsuccessful `jobseeker_sign_in_attempt` event" do
+        expect { sign_in_jobseeker(email: email, password: password) }
+          .to have_triggered_event(:jobseeker_sign_in_attempt)
+          .with_data(expected_data)
       end
     end
   end
@@ -62,6 +101,7 @@ RSpec.describe "Jobseekers can sign in to their account" do
     let(:password) { "incorrect_password" }
 
     it "does not sign in the jobseeker, displays error messages, then signs in the jobseeker" do
+      sign_in_jobseeker(email: email, password: password)
       sign_in_jobseeker(email: email, password: jobseeker.password)
       expect(current_path).to eq(jobseekers_saved_jobs_path)
       expect(page).to have_content(I18n.t("devise.sessions.signed_in"))


### PR DESCRIPTION
- For performance/business analysis purposes, we need to stream sign in attempt events to BigQuery for jobseekers and publishers. 
- Jobseekers are identified by anonymised email identifier and publishers by anonymised publisher oid. 
- Errors are streamed for jobseeker failures, but errors are not streamed for publishers (failures generally occur in DSI - although with a small refactor we could distinguish between unauthorised for teaching vacancies and not allowed LA user failures)

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-1996

## Changes in this PR
- Trigger sign in events for jobseekers
- Trigger sign in events for publishers