### PR TITLE
Re-enable arbitrary LA access on staging

### DIFF
--- a/terraform/workspace-variables/staging_app_env.yml
+++ b/terraform/workspace-variables/staging_app_env.yml
@@ -6,7 +6,7 @@ DFE_SIGN_IN_REDIRECT_URL: https://staging.teaching-vacancies.service.gov.uk/auth
 DFE_SIGN_IN_URL: https://pp-api.signin.education.gov.uk
 DISABLE_EXPENSIVE_JOBS: true
 DOMAIN: staging.teaching-vacancies.service.gov.uk
-ENFORCE_LOCAL_AUTHORITY_ALLOWLIST: true
+ENFORCE_LOCAL_AUTHORITY_ALLOWLIST: false
 FEATURE_JOBSEEKER_APPLICATIONS: false
 GOOGLE_ANALYTICS_PROFILE_ID: ga:171744074
 MALLOC_ARENA_MAX: 2


### PR DESCRIPTION
In the long term, we want to use staging purely within our CI pipeline.
However, various parts of the product team rely on having access to
staging for UR and demo purposes at the moment, and until we have found
an alternative solution we need to stop enforcing the LA allowlist on
staging.