### PR TITLE
Limit API to only return live vacancies

### DIFF
--- a/app/controllers/api/vacancies_controller.rb
+++ b/app/controllers/api/vacancies_controller.rb
@@ -1,12 +1,11 @@
 class Api::VacanciesController < Api::ApplicationController
   before_action :verify_json_request, only: %i[show index]
 
-  MAX_API_RESULTS_PER_PAGE = 50
+  MAX_API_RESULTS_PER_PAGE = 100
 
   def index
     records = Vacancy.includes(organisation_vacancies: :organisation)
-                     .listed
-                     .published
+                     .live
                      .page(page_number)
                      .per(MAX_API_RESULTS_PER_PAGE)
                      .order(publish_on: :desc)

--- a/spec/requests/api/vacancies_spec.rb
+++ b/spec/requests/api/vacancies_spec.rb
@@ -49,20 +49,17 @@ RSpec.describe "Api::Vacancies", type: :request do
       expect(json[:links].keys).to include(:self, :first, :last, :prev, :next)
     end
 
-    it "retrieves all available vacancies" do
+    it "retrieves all live vacancies" do
       published_vacancy = create(:vacancy)
       published_vacancy.organisation_vacancies.create(organisation: school)
       expired_vacancy = create(:vacancy, :expired)
       expired_vacancy.organisation_vacancies.create(organisation: school)
-      vacancies = [published_vacancy, expired_vacancy]
 
       get api_jobs_path(api_version: 1), params: { format: :json }
 
       expect(response.status).to eq(Rack::Utils.status_code(:ok))
-      expect(json[:data].count).to eq(2)
-      vacancies.each do |v|
-        expect(json[:data]).to include(vacancy_json_ld(VacancyPresenter.new(v)))
-      end
+      expect(json[:data].count).to eq(1)
+      expect(json[:data]).to include(vacancy_json_ld(VacancyPresenter.new(published_vacancy)))
     end
 
     context "when there are more vacancies than the per-page limit" do


### PR DESCRIPTION
Our API has a fair share of issues, and we need to take a step back and
rethink it in the future.

Until then, we need to limit vacancies being returned to just be live
vacancies as existing users are crawling hundreds of pages of expired
vacancies which is causing issues, and potential new users don't want
to deal with this overload.