### PR TITLE
Cache similar jobs for 12 hours

### DIFF
--- a/app/services/search/similar_jobs.rb
+++ b/app/services/search/similar_jobs.rb
@@ -1,11 +1,31 @@
 class Search::SimilarJobs
-  attr_reader :similar_jobs
+  attr_reader :vacancy
 
   NUMBER_OF_SIMILAR_JOBS = 4
+  CACHE_DURATION = 12.hours
 
   def initialize(vacancy)
+    @vacancy = vacancy
+  end
+
+  def criteria
     # For now, similar jobs are retrieved based on the same set of rules that define similar job alerts
-    criteria = Search::CriteriaDeviser.new(vacancy).criteria
-    @similar_jobs = Search::VacancySearch.new(criteria).vacancies.reject { |job| job.id == vacancy.id }.take(NUMBER_OF_SIMILAR_JOBS)
+    @criteria ||= Search::CriteriaDeviser.new(vacancy).criteria
+  end
+
+  def similar_jobs
+    @similar_jobs ||= Vacancy.live.where(id: similar_job_ids).first(NUMBER_OF_SIMILAR_JOBS)
+  end
+
+  private
+
+  def similar_job_ids
+    Rails.cache.fetch([:similar_job_ids, vacancy.id], expires_in: CACHE_DURATION) do
+      Search::VacancySearch
+        .new(criteria, per_page: NUMBER_OF_SIMILAR_JOBS * 3) # Fetch more than we need in case some expire while being cached
+        .vacancies
+        .reject { |job| job.id == vacancy.id }
+        .map(&:id)
+    end
   end
 end

--- a/spec/services/search/similar_jobs_spec.rb
+++ b/spec/services/search/similar_jobs_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe Search::SimilarJobs do
 
   it "calls Search::CriteriaDeviser" do
     expect(Search::CriteriaDeviser).to receive(:new).with(vacancy).and_call_original
-    subject
+    subject.similar_jobs
   end
 
   it "calls Search::VacancySearch" do
     expect(Search::VacancySearch).to receive(:new).and_call_original
-    subject
+    subject.similar_jobs
   end
 end


### PR DESCRIPTION
Store vacancy IDs for similar jobs in the Rails cache for 12 hours so
we don't keep hitting Algolia.