### PR TITLE
Job application review page form

### DIFF
--- a/app/controllers/jobseekers/job_applications/build_controller.rb
+++ b/app/controllers/jobseekers/job_applications/build_controller.rb
@@ -14,13 +14,17 @@ class Jobseekers::JobApplications::BuildController < Jobseekers::BaseController
   def update
     @form = FORMS[step].new(form_params)
     application_data = job_application.application_data.presence || {}
+    completed_steps = job_application.completed_steps.presence || []
 
     if params[:commit] == t("buttons.save_as_draft")
       job_application.assign_attributes(application_data: application_data.merge(form_params))
       job_application.save
       redirect_to jobseekers_saved_jobs_path, success: t("messages.jobseekers.job_applications.saved")
     elsif @form.valid?
-      job_application.assign_attributes(application_data: application_data.merge(form_params))
+      job_application.assign_attributes(
+        application_data: application_data.merge(form_params),
+        completed_steps: completed_steps.push(step),
+      )
       render_wizard job_application
     else
       render_wizard

--- a/app/form_models/jobseekers/job_application/review_form.rb
+++ b/app/form_models/jobseekers/job_application/review_form.rb
@@ -1,0 +1,15 @@
+class Jobseekers::JobApplication::ReviewForm
+  include ActiveModel::Model
+
+  attr_accessor :confirm_data_accurate, :confirm_data_usage, :completed_steps
+
+  validates :confirm_data_accurate, acceptance: true
+  validates :confirm_data_usage, acceptance: true
+  validate :all_steps_completed
+
+  def all_steps_completed
+    return if JobApplication.completed_steps.keys.all? { |step| completed_steps.include?(step) }
+
+    errors.add(:base, "Please complete all incomplete steps")
+  end
+end

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -1,4 +1,16 @@
 class JobApplication < ApplicationRecord
+  extend ArrayEnum
+
+  array_enum completed_steps: {
+    personal_details: 0,
+    professional_status: 2,
+    employment_history: 3,
+    personal_statement: 4,
+    references: 5,
+    ask_for_support: 7,
+    declarations: 8,
+  }
+
   enum status: { draft: 0, submitted: 1 }
 
   belongs_to :jobseeker

--- a/app/views/jobseekers/job_applications/build/ask_for_support.html.slim
+++ b/app/views/jobseekers/job_applications/build/ask_for_support.html.slim
@@ -22,8 +22,8 @@
           = f.govuk_text_area :support_details, rows: 10
         = f.govuk_radio_button :support_needed, :no
 
-      = f.govuk_submit t("buttons.continue") do
-        = f.govuk_submit t("buttons.save_as_draft"), secondary: true
+      = f.govuk_submit t("buttons.continue")
+      = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"
 
   .govuk-grid-column-one-third
     = render(Shared::ProcessStepsComponent.new(process: job_application.vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))

--- a/app/views/jobseekers/job_applications/build/declarations.html.slim
+++ b/app/views/jobseekers/job_applications/build/declarations.html.slim
@@ -19,8 +19,8 @@
 
       = f.govuk_collection_radio_buttons :right_to_work_in_uk, %w[yes no], :to_s, :capitalize, inline: true
 
-      = f.govuk_submit t("buttons.continue") do
-        = f.govuk_submit t("buttons.save_as_draft"), secondary: true
+      = f.govuk_submit t("buttons.continue")
+      = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"
 
   .govuk-grid-column-one-third
     = render(Shared::ProcessStepsComponent.new(process: job_application.vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))

--- a/app/views/jobseekers/job_applications/build/employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/build/employment_history.html.slim
@@ -21,7 +21,5 @@
       = f.govuk_text_area :gaps_in_employment, label: { size: "s" }, rows: 5, form_group: { classes: "optional-field" }
 
       - if job_application.employment_history.any?
-        = f.govuk_submit t("buttons.continue") do
-          = f.govuk_submit t("buttons.save_as_draft"), secondary: true
-      - else
-        = f.govuk_submit t("buttons.save_as_draft"), secondary: true
+        = f.govuk_submit t("buttons.continue")
+      = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"

--- a/app/views/jobseekers/job_applications/build/personal_details.html.slim
+++ b/app/views/jobseekers/job_applications/build/personal_details.html.slim
@@ -20,8 +20,8 @@
       = f.govuk_number_field :phone_number, label: { size: "s" }, width: "one-half", aria: { required: true }
       = f.govuk_text_field :teacher_reference_number, label: { size: "s" }, width: "one-half", aria: { required: true }
       = f.govuk_text_field :national_insurance_number, label: { size: "s" }, width: "one-half", aria: { required: true }
-      = f.govuk_submit t("buttons.continue") do
-        = f.govuk_submit t("buttons.save_as_draft"), secondary: true
+      = f.govuk_submit t("buttons.continue")
+      = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"
 
   .govuk-grid-column-one-third
     = render(Shared::ProcessStepsComponent.new(process: job_application.vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))

--- a/app/views/jobseekers/job_applications/build/personal_statement.html.slim
+++ b/app/views/jobseekers/job_applications/build/personal_statement.html.slim
@@ -11,8 +11,8 @@
     = form_for @form, url: wizard_path, method: :patch do |f|
       = f.govuk_error_summary
       = f.govuk_text_area :personal_statement, label: { size: "s" }, rows: 15, required: true, aria: { required: true }
-      = f.govuk_submit t("buttons.continue") do
-        = f.govuk_submit t("buttons.save_as_draft"), secondary: true
+      = f.govuk_submit t("buttons.continue")
+      = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"
 
   .govuk-grid-column-one-third
     = render(Shared::ProcessStepsComponent.new(process: job_application.vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))

--- a/app/views/jobseekers/job_applications/build/professional_status.html.slim
+++ b/app/views/jobseekers/job_applications/build/professional_status.html.slim
@@ -18,8 +18,8 @@
 
       = f.govuk_collection_radio_buttons :statutory_induction_complete, %w[yes no], :to_s, :capitalize, inline: true
 
-      = f.govuk_submit t("buttons.continue") do
-        = f.govuk_submit t("buttons.save_as_draft"), secondary: true
+      = f.govuk_submit t("buttons.continue")
+      = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"
 
   .govuk-grid-column-one-third
     = render(Shared::ProcessStepsComponent.new(process: job_application.vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))

--- a/app/views/jobseekers/job_applications/build/references.html.slim
+++ b/app/views/jobseekers/job_applications/build/references.html.slim
@@ -20,7 +20,5 @@
       = f.govuk_error_summary
 
       - if job_application.references.count > 1
-        = f.govuk_submit t("buttons.continue") do
-          = f.govuk_submit t("buttons.save_as_draft"), secondary: true
-      - else
-        = f.govuk_submit t("buttons.save_as_draft"), secondary: true
+        = f.govuk_submit t("buttons.continue")
+      = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"

--- a/app/views/jobseekers/job_applications/review.html.slim
+++ b/app/views/jobseekers/job_applications/review.html.slim
@@ -4,10 +4,22 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    .govuk-caption-m Step 10 of 10
-    h1.govuk-heading-l = t(".title")
+    = form_for review_form, url: jobseekers_job_application_submit_path(job_application), method: :post do |f|
+      = f.govuk_error_summary
 
-    p.govuk-body = "First name: #{job_application.application_data['first_name']}"
-    p.govuk-body = "Status: #{job_application.status}"
+      .govuk-caption-m Step 10 of 10
+      h1.govuk-heading-l = t(".title")
 
-    = govuk_button_to t("buttons.submit_application"), jobseekers_job_application_submit_path(job_application)
+      p.govuk-body = "First name: #{job_application.application_data['first_name']}"
+      p.govuk-body = "Status: #{job_application.status}"
+
+      h3.govuk-heading-l Confirmation
+
+      = f.govuk_check_boxes_fieldset :confirm_data_accurate, multiple: false, legend: nil do
+        = f.govuk_check_box :confirm_data_accurate, 1, 0, multiple: false, link_errors: true, label: { text: "Confirm data accurate" }
+
+      = f.govuk_check_boxes_fieldset :confirm_data_usage, multiple: false, legend: nil do
+        = f.govuk_check_box :confirm_data_usage, 1, 0, multiple: false, link_errors: true, label: { text: "Confirm data usage" }
+
+      = f.govuk_submit t("buttons.submit_application")
+      = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"

--- a/db/migrate/20210224131022_add_completed_steps_to_job_applications.rb
+++ b/db/migrate/20210224131022_add_completed_steps_to_job_applications.rb
@@ -1,0 +1,5 @@
+class AddCompletedStepsToJobApplications < ActiveRecord::Migration[6.1]
+  def change
+    add_column :job_applications, :completed_steps, :integer, array: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -125,6 +125,7 @@ ActiveRecord::Schema.define(version: 2021_02_24_161051) do
     t.uuid "jobseeker_id"
     t.uuid "vacancy_id"
     t.jsonb "application_data"
+    t.integer "completed_steps", array: true
   end
 
   create_table "jobseekers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/job_applications.rb
+++ b/spec/factories/job_applications.rb
@@ -1,6 +1,8 @@
 FactoryBot.define do
   factory :job_application do
     status { :draft }
+    completed_steps { [] }
+    application_data { {} }
     jobseeker
     vacancy
   end
@@ -9,5 +11,6 @@ FactoryBot.define do
     application_data do
       { first_name: "John" }
     end
+    completed_steps { JobApplication.completed_steps.keys }
   end
 end

--- a/spec/form_models/jobseekers/job_application/review_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/review_form_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe Jobseekers::JobApplication::ReviewForm, type: :model do
+  let(:completed_steps) { [] }
+
+  subject do
+    described_class.new({ confirm_data_accurate: "1", confirm_data_usage: "1", completed_steps: completed_steps })
+  end
+
+  it { is_expected.to validate_acceptance_of(:confirm_data_accurate) }
+  it { is_expected.to validate_acceptance_of(:confirm_data_usage) }
+
+  context "when all steps are complete" do
+    let(:completed_steps) { JobApplication.completed_steps.keys }
+
+    it "is valid" do
+      expect(subject).to be_valid
+    end
+  end
+
+  context "when there are incomplete steps" do
+    let(:completed_steps) { %w[personal_details employment_history] }
+
+    it "is invalid" do
+      expect(subject).not_to be_valid
+    end
+  end
+end

--- a/spec/system/jobseekers_can_give_application_feedback_spec.rb
+++ b/spec/system/jobseekers_can_give_application_feedback_spec.rb
@@ -15,6 +15,9 @@ RSpec.describe "Jobseekers can give job application feedback after submitting th
   it "allows jobseekers to give job application feedback after submitting the application" do
     visit jobseekers_job_application_review_path(job_application)
 
+    check "Confirm data accurate"
+    check "Confirm data usage"
+
     click_on I18n.t("buttons.submit_application")
     choose I18n.t("helpers.label.jobseekers_job_application_feedback_form.rating_options.somewhat_satisfied")
     fill_in "jobseekers_job_application_feedback_form[comment]", with: comment

--- a/spec/system/jobseekers_can_save_a_job_application_spec.rb
+++ b/spec/system/jobseekers_can_save_a_job_application_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Jobseekers can save a job application" do
   end
 
   def and_it_saves_the_job_application
-    expect { save_as_draft }.to change { JobApplication.first.application_data }.from(nil).to(
+    expect { save_as_draft }.to change { JobApplication.first.application_data }.from({}).to(
       {
         "postcode" => "F1 4KE",
         "last_name" => "Frusciante",

--- a/spec/system/jobseekers_can_submit_a_job_application_spec.rb
+++ b/spec/system/jobseekers_can_submit_a_job_application_spec.rb
@@ -4,17 +4,53 @@ RSpec.describe "Jobseekers can submit a job application" do
   let(:jobseeker) { create(:jobseeker) }
   let(:organisation) { create(:school) }
   let(:vacancy) { create(:vacancy, organisation_vacancies_attributes: [{ organisation: organisation }]) }
-  let(:job_application) { create(:job_application, :complete, jobseeker: jobseeker, vacancy: vacancy) }
 
   before do
     allow(JobseekerApplicationsFeature).to receive(:enabled?).and_return(true)
     login_as(jobseeker, scope: :jobseeker)
   end
 
-  it "allows jobseekers to submit application and go to confirmation page" do
-    visit jobseekers_job_application_review_path(job_application)
-    expect { click_on I18n.t("buttons.submit_application") }
-      .to change { JobApplication.first.status }.from("draft").to("submitted")
-    expect(page).to have_content(I18n.t("jobseekers.job_applications.submit.panel.title"))
+  context "when the application is complete" do
+    let(:job_application) { create(:job_application, :complete, jobseeker: jobseeker, vacancy: vacancy) }
+
+    it "allows jobseekers to submit application and go to confirmation page" do
+      visit jobseekers_job_application_review_path(job_application)
+
+      click_on I18n.t("buttons.submit_application")
+      expect(page).to have_content("There is a problem")
+
+      check "Confirm data accurate"
+      check "Confirm data usage"
+
+      expect { click_on I18n.t("buttons.submit_application") }
+        .to change { JobApplication.first.status }.from("draft").to("submitted")
+      expect(page).to have_content(I18n.t("jobseekers.job_applications.submit.panel.title"))
+    end
+  end
+
+  context "when the application is incomplete" do
+    let(:job_application) { create(:job_application, jobseeker: jobseeker, vacancy: vacancy) }
+
+    it "does not allow jobseekers to submit application and go to confirmation page" do
+      visit jobseekers_job_application_review_path(job_application)
+
+      check "Confirm data accurate"
+      check "Confirm data usage"
+
+      click_on I18n.t("buttons.submit_application")
+
+      expect(JobApplication.first.status).to eq("draft")
+      expect(page).to have_content("There is a problem")
+    end
+
+    it "allows jobseekers to save application and go to dashboard" do
+      visit jobseekers_job_application_review_path(job_application)
+
+      click_on I18n.t("buttons.save_as_draft")
+
+      expect(JobApplication.first.status).to eq("draft")
+      expect(page).to have_content("Application saved as draft")
+      expect(current_path).to eq(jobseeker_root_path)
+    end
   end
 end


### PR DESCRIPTION
Some things I wanted to get in for now. Some parts are placeholders until the tickets get picked up shortly.

The main thing is the idea that a job application has completed steps. It is very possible that we will want to know this information, and we definitely want to ensure all steps are complete before submitting applications. It will have the added benefit of cleaning up some of the "which steps are complete?" sidebar logic. The final details of how we present incomplete steps to the user needs to be ironed out. 

I think this approach is an improvement on the `Create a job listing` journey where we check that all forms are valid (it's a bit nasty imo)