### PR TITLE
Update hosting.md docs

### DIFF
--- a/documentation/hosting.md
+++ b/documentation/hosting.md
@@ -169,8 +169,9 @@ cd /app
 ## Run task
 
 ```bash
-cf run-task <app_name> -c "rails task:name"
+cf run-task <app_name> "rails task:name"
 ```
+
 ## CI/CD with GitHub Actions
 
 Tests run every time is pushed on a branch.


### PR DESCRIPTION
CloudFoundry CLI v6 does not have a flag `-c` / `--command`; this is for v7 only (accessible by using `cf7`).