### PR TITLE
[TEVA-2069] Automate generation of offline site

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,11 +40,14 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
 
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: eu-west-2
+
     - name: Validate secrets
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AWS_REGION: eu-west-2
       run: |
         gem install aws-sdk-ssm --no-document
         bin/run-in-env -t /teaching-vacancies/staging -o quiet \
@@ -184,6 +187,14 @@ jobs:
         terraform init -upgrade=true -reconfigure -input=false
         terraform apply -input=false -auto-approve
       working-directory: terraform/monitoring
+
+    - name: Download and extract Gov.UK frontend archive
+      shell: bash
+      run: bin/regenerate-offline
+
+    - name: Sync offline S3 bucket
+      shell: bash
+      run: aws s3 sync ./offline s3://tvs-offline/offline
 
     - name: Send job status message to twd_tv_dev channel
       if: always() && github.ref == 'refs/heads/master'

--- a/bin/regenerate-offline
+++ b/bin/regenerate-offline
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -eu
+
+RELEASE=3.11.0
+GOVUK_FRONTEND_PREFIX=https://github.com/alphagov/govuk-frontend/releases/download/v${RELEASE}/
+GOVUK_FRONTEND_ARCHIVE_NAME=release-v${RELEASE}.zip
+GOVUK_FRONTEND_URL="${GOVUK_FRONTEND_PREFIX}${GOVUK_FRONTEND_ARCHIVE_NAME}"
+
+wget ${GOVUK_FRONTEND_URL}
+if [[ ! -f "${GOVUK_FRONTEND_ARCHIVE_NAME}" ]]; then
+  echo "${GOVUK_FRONTEND_ARCHIVE_NAME} does not exist."
+  exit 1
+else
+  unzip ${GOVUK_FRONTEND_ARCHIVE_NAME} -d ./offline
+fi
+mv ./offline/govuk-frontend-${RELEASE}.min.css ./offline/govuk-frontend.min.css
+rm ./offline/govuk-frontend-ie8-${RELEASE}.min.css
+rm ./offline/govuk-frontend-${RELEASE}.min.js
+cp ./public/favicon.ico ./offline/favicon.ico

--- a/documentation/offline-site.md
+++ b/documentation/offline-site.md
@@ -1,0 +1,34 @@
+# Offline site
+
+## When is it served?
+
+The "site offline" page is served if Cloudfront detects that the PaaS-hosted site is returning HTTP status codes:
+- [502 Bad Gateway](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502)
+- [503 Service Unavailable](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/503)
+
+## How is it generated?
+
+The [regenerate-offline](../bin/regenerate-offline) script:
+
+- downloads and unzips a particular version of the [Gov.UK frontend](https://github.com/alphagov/govuk-frontend/releases/) into the [offline](../offline) folder
+- renames the version-specific minified CSS file to `offline/govuk-frontend.min.css`
+- copies the `favicon.ico`
+
+The GitHub Action [deploy](../.github/workflows/deploy.yml) workflow includes these steps:
+- run the regenerate-offline script
+- use the AWS CLI to synchronise with the offline site S3 bucket
+
+## How to update
+
+### Edit the offline page
+
+The offline page is a single HTML file in [offline/index.html](../offline/index.html)
+
+### Update the version of the Gov.UK frontend
+
+- Check for a new release of the [Gov.UK frontend](https://github.com/alphagov/govuk-frontend/releases/)
+- Set the release in the [regenerate-offline](../bin/regenerate-offline) script
+```
+RELEASE=3.11.0
+```
+- When the change is merged, the new version will be synchronised

--- a/offline/index.html
+++ b/offline/index.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en" class="govuk-template app-html-class">
+<head>
+  <meta charset="utf-8">
+  <title>Sorry, there is a problem with the service – Teaching Vacancies</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="theme-color" content="blue">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/assets/images/favicon.ico" type="image/x-icon">
+  <link rel="mask-icon" href="/assets/images/govuk-mask-icon.svg" color="blue">
+  <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/govuk-apple-touch-icon-180x180.png">
+  <link rel="apple-touch-icon" sizes="167x167" href="/assets/images/govuk-apple-touch-icon-167x167.png">
+  <link rel="apple-touch-icon" sizes="152x152" href="/assets/images/govuk-apple-touch-icon-152x152.png">
+  <link rel="apple-touch-icon" href="/assets/images/govuk-apple-touch-icon.png">
+  <link href="/govuk-frontend.min.css" rel="stylesheet">
+</head>
+<body class="govuk-template__body app-body-class">
+  <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
+  <header class="govuk-header " role="banner" data-module="govuk-header">
+    <div class="govuk-header__container govuk-width-container" style="border-bottom: 10px solid #f47738; ">
+      <div class="govuk-header__logo">
+        <a href="#" class="govuk-header__link govuk-header__link--homepage">
+          <span class="govuk-header__logotype">
+            <svg aria-hidden="true" focusable="false" class="govuk-header__logotype-crown"
+              xmlns="http://www.w3.org/2000/svg" viewBox="0 0 132 97" height="30" width="36">
+              <path fill="currentColor" fill-rule="evenodd"
+                d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z">
+              </path>
+              <image src="/assets/images/govuk-logotype-crown.png" xlink:href="data:," display="none"
+                class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
+            </svg>
+            <span class="govuk-header__logotype-text">
+              GOV.UK
+            </span>
+          </span>
+        </a>
+      </div>
+      <div class="govuk-header__content">
+        <a href="#" class="govuk-header__link govuk-header__link--service-name">
+          Teaching Vacancies
+        </a>
+      </div>
+    </div>
+  </header>
+  <div class="govuk-width-container app-width-container">
+    <div class="govuk-phase-banner">
+      <p class="govuk-phase-banner__content">
+        <strong class="govuk-tag govuk-phase-banner__content__tag">
+          Beta
+        </strong>
+        <span class="govuk-phase-banner__text">
+          This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.
+        </span>
+      </p>
+    </div>
+    <main class="govuk-main-wrapper app-main-class" id="main-content" role="main">
+      <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
+      <p class="govuk-body">Please try again later.</p>
+      <p class="govuk-body">
+        Email <a class="govuk-link"
+          href="mailto:teaching.vacancies@education.gov.uk">teaching.vacancies@education.gov.uk</a> if you would like
+        more information or support.
+      </p>
+    </main>
+  </div>
+  <footer class="govuk-footer " role="contentinfo">
+    <div class="govuk-width-container ">
+      <div class="govuk-footer__meta">
+        <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+          <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo"
+            xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
+            <path fill="currentColor"
+              d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
+          </svg>
+          <span class="govuk-footer__licence-description">
+            All content is available under the
+            <a class="govuk-footer__link"
+              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open
+              Government Licence v3.0</a>, except where otherwise stated
+          </span>
+        </div>
+        <div class="govuk-footer__meta-item">
+          <a class="govuk-footer__link govuk-footer__copyright-logo"
+            href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">©
+            Crown copyright</a>
+        </div>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2069

## Changes in this PR:

- Change to use the Gov.UK Frontend
- Automate the generation of the offline site with a GitHub Actions workflow
- Split out the regeneration into a shell script
- Used the root of the bucket, as the bundled CSS from the Gov.UK design frontend assumes `/assets` in the root of the web directory.

New offline page can be seen at https://tvs-offline.s3.eu-west-2.amazonaws.com/index.html

Further ticket will bring this under Terraform control.