### PR TITLE
Refactor review component to extend GovukComponent::Base

### DIFF
--- a/app/components/shared/review_component.rb
+++ b/app/components/shared/review_component.rb
@@ -1,9 +1,18 @@
-class Shared::ReviewComponent < ViewComponent::Base
-  attr_accessor :edit_link, :title, :id
+class Shared::ReviewComponent < GovukComponent::Base
+  attr_accessor :id, :title, :edit_link, :summary
 
-  def initialize(edit_link:, title:, id:)
-    @edit_link = edit_link
-    @title = title
+  def initialize(id:, title:, edit_link: nil, summary: nil, classes: [], html_attributes: {})
+    super(classes: classes, html_attributes: html_attributes)
+
     @id = id
+    @title = title
+    @edit_link = edit_link
+    @summary = summary
+  end
+
+  private
+
+  def default_classes
+    %w[review-component]
   end
 end

--- a/app/components/shared/review_component/review_component.html.slim
+++ b/app/components/shared/review_component/review_component.html.slim
@@ -1,5 +1,8 @@
-.review-component
-  .review-component__heading
-    h2.govuk-heading-m.review-component__section id="#{id}_heading"
-      = title
-      = govuk_link_to(t("buttons.change"), edit_link, class: "review-component__section-button", "aria-label": t("jobs.aria_labels.change_#{id}"))
+= tag.div(class: classes, **html_attributes) do
+  = tag.h2(class: "govuk-heading-m review-component__heading review-component__section", id: "#{id}_heading") do
+    = title
+    - if edit_link.present?
+      = govuk_link_to(t("buttons.change"), edit_link, class: "review-component__section-button", "aria-label": "Change #{id.humanize}")
+
+  .review-component__body
+    = summary || content

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_applying_for_the_job.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_applying_for_the_job.html.slim
@@ -1,43 +1,40 @@
 = render "publishers/vacancies/new_attributes_tag", attributes: %i[contact_email contact_number school_visits how_to_apply application_link], section: "applying_for_the_job"
 = render "publishers/vacancies/error_tag", attributes: %i[contact_email contact_number school_visits how_to_apply application_link], section: "applying_for_the_job"
 
-= render Shared::ReviewComponent.new(id: "applying_for_the_job", title: t("jobs.applying_for_the_job"), edit_link: organisation_job_build_path(@vacancy.id, :applying_for_the_job))
+= render Shared::ReviewComponent.new(id: "applying_for_the_job", title: t("jobs.applying_for_the_job"), edit_link: organisation_job_build_path(@vacancy.id, :applying_for_the_job)) do
+  = govuk_summary_list do |component|
+    - if JobseekerApplicationsFeature.enabled?
+      - component.slot(:row,
+        key: t("jobs.apply_through_teaching_vacancies"),
+        value: @vacancy.apply_through_teaching_vacancies&.capitalize)
 
-.review-component
-  .review-component__body
-    = render GovukComponent::SummaryList.new do |component|
-      - if JobseekerApplicationsFeature.enabled?
+      - if @vacancy.apply_through_teaching_vacancies == "yes"
         - component.slot(:row,
-          key: t("jobs.apply_through_teaching_vacancies"),
-          value: @vacancy.apply_through_teaching_vacancies&.capitalize)
+          key: t("jobs.personal_statement_guidance"),
+          value: @vacancy.personal_statement_guidance)
 
-        - if @vacancy.apply_through_teaching_vacancies == "yes"
-          - component.slot(:row,
-            key: t("jobs.personal_statement_guidance"),
-            value: @vacancy.personal_statement)
-
-        - if @vacancy.apply_through_teaching_vacancies == "no"
-          - component.slot(:row,
-            key: t("jobs.application_link"),
-            value: @vacancy.application_link.present? ? govuk_link_to(@vacancy.application_link, @vacancy.application_link, "aria-label": t("jobs.aria_labels.apply_link"), target: "_blank", rel: "noopener noreferrer") : t("jobs.not_defined"))
-
-      - component.slot(:row,
-        key: t("jobs.job_title"),
-        value: govuk_mail_to("Job contact email", @vacancy.contact_email, "aria-label": t("jobs.aria_labels.contact_email_link", email: @vacancy.contact_email)))
-
-      - component.slot(:row,
-        key: t("jobs.contact_number"),
-        value: @vacancy.contact_number.present? ? govuk_link_to(@vacancy.contact_number, "tel:#{@vacancy.contact_number}") : t("jobs.not_defined"))
-
-      - component.slot(:row,
-        key: t("jobs.#{school_or_trust_visits(@vacancy.parent_organisation)}"),
-        value: @vacancy.school_visits.presence || t("jobs.not_defined"))
-
-      - unless JobseekerApplicationsFeature.enabled?
-        - component.slot(:row,
-          key: t("jobs.how_to_apply"),
-          value: @vacancy.how_to_apply.presence || t("jobs.not_defined"))
-
+      - if @vacancy.apply_through_teaching_vacancies == "no"
         - component.slot(:row,
           key: t("jobs.application_link"),
           value: @vacancy.application_link.present? ? govuk_link_to(@vacancy.application_link, @vacancy.application_link, "aria-label": t("jobs.aria_labels.apply_link"), target: "_blank", rel: "noopener noreferrer") : t("jobs.not_defined"))
+
+    - component.slot(:row,
+      key: t("jobs.job_title"),
+      value: govuk_mail_to("Job contact email", @vacancy.contact_email, "aria-label": t("jobs.aria_labels.contact_email_link", email: @vacancy.contact_email)))
+
+    - component.slot(:row,
+      key: t("jobs.contact_number"),
+      value: @vacancy.contact_number.present? ? govuk_link_to(@vacancy.contact_number, "tel:#{@vacancy.contact_number}") : t("jobs.not_defined"))
+
+    - component.slot(:row,
+      key: t("jobs.#{school_or_trust_visits(@vacancy.parent_organisation)}"),
+      value: @vacancy.school_visits.presence || t("jobs.not_defined"))
+
+    - unless JobseekerApplicationsFeature.enabled?
+      - component.slot(:row,
+        key: t("jobs.how_to_apply"),
+        value: @vacancy.how_to_apply.presence || t("jobs.not_defined"))
+
+      - component.slot(:row,
+        key: t("jobs.application_link"),
+        value: @vacancy.application_link.present? ? govuk_link_to(@vacancy.application_link, @vacancy.application_link, "aria-label": t("jobs.aria_labels.apply_link"), target: "_blank", rel: "noopener noreferrer") : t("jobs.not_defined"))

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_important_dates.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_important_dates.html.slim
@@ -1,19 +1,16 @@
 = render "publishers/vacancies/new_attributes_tag", attributes: %i[publish_on expires_on starts_on], section: "important_dates"
 = render "publishers/vacancies/error_tag", attributes: %i[publish_on expires_on starts_on], section: "important_dates"
 
-= render Shared::ReviewComponent.new(id: "important_dates", title: t("jobs.important_dates"), edit_link: organisation_job_build_path(@vacancy.id, :important_dates))
+= render Shared::ReviewComponent.new(id: "important_dates", title: t("jobs.important_dates"), edit_link: organisation_job_build_path(@vacancy.id, :important_dates)) do
+  = govuk_summary_list do |component|
+    - component.slot(:row,
+      key: t("jobs.publication_date"),
+      value: format_date(@vacancy.publish_on))
 
-.review-component
-  .review-component__body
-    = render GovukComponent::SummaryList.new do |component|
-      - component.slot(:row,
-        key: t("jobs.publication_date"),
-        value: format_date(@vacancy.publish_on))
+    - component.slot(:row,
+      key: t("jobs.application_deadline"),
+      value: "#{format_date(@vacancy.expires_on)} #{t('jobs.time_at') unless @vacancy.expires_at.nil?} #{format_time(@vacancy.expires_at)}")
 
-      - component.slot(:row,
-        key: t("jobs.application_deadline"),
-        value: "#{format_date(@vacancy.expires_on)} #{t('jobs.time_at') unless @vacancy.expires_at.nil?} #{format_time(@vacancy.expires_at)}")
-
-      - component.slot(:row,
-        key: t("jobs.starts_on"),
-        value: @vacancy.starts_asap? ? t("jobs.starts_asap") : format_date(@vacancy.starts_on))
+    - component.slot(:row,
+      key: t("jobs.starts_on"),
+      value: @vacancy.starts_asap? ? t("jobs.starts_asap") : format_date(@vacancy.starts_on))

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_details.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_details.html.slim
@@ -1,31 +1,28 @@
 = render "publishers/vacancies/new_attributes_tag", attributes: %i[job_title job_roles suitable_for_nqt subjects working_patterns], section: "job_details"
 = render "publishers/vacancies/error_tag", attributes: %i[job_title job_roles suitable_for_nqt subjects working_patterns], section: "job_details"
 
-= render Shared::ReviewComponent.new(id: "job_details", title: t("jobs.job_details"), edit_link: organisation_job_build_path(@vacancy.id, :job_details))
+= render Shared::ReviewComponent.new(id: "job_details", title: t("jobs.job_details"), edit_link: organisation_job_build_path(@vacancy.id, :job_details)) do
+  = govuk_summary_list do |component|
+    - component.slot(:row,
+      key: t("jobs.job_title"),
+      value: @vacancy.job_title)
 
-.review-component
-  .review-component__body
-    = render GovukComponent::SummaryList.new do |component|
-      - component.slot(:row,
-        key: t("jobs.job_title"),
-        value: @vacancy.job_title)
+    - component.slot(:row,
+      key: t("jobs.job_roles"),
+      value: @vacancy.show_job_roles.presence || t("jobs.not_defined"))
 
-      - component.slot(:row,
-        key: t("jobs.job_roles"),
-        value: @vacancy.show_job_roles.presence || t("jobs.not_defined"))
+    - component.slot(:row,
+      key: t("jobs.suitable_for_nqt"),
+      value: @vacancy.suitable_for_nqt&.capitalize)
 
-      - component.slot(:row,
-        key: t("jobs.suitable_for_nqt"),
-        value: @vacancy.suitable_for_nqt&.capitalize)
+    - component.slot(:row,
+      key: t("jobs.subjects"),
+      value: @vacancy.show_subjects.presence || t("jobs.not_defined"))
 
-      - component.slot(:row,
-        key: t("jobs.subjects"),
-        value: @vacancy.show_subjects.presence || t("jobs.not_defined"))
+    - component.slot(:row,
+      key: t("jobs.working_patterns"),
+      value: @vacancy.working_patterns)
 
-      - component.slot(:row,
-        key: t("jobs.working_patterns"),
-        value: @vacancy.working_patterns)
-
-      - component.slot(:row,
-        key: t("jobs.contract_type"),
-        value: @vacancy.contract_type_with_duration)
+    - component.slot(:row,
+      key: t("jobs.contract_type"),
+      value: @vacancy.contract_type_with_duration)

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_location.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_location.html.slim
@@ -1,16 +1,13 @@
 = render "publishers/vacancies/new_attributes_tag", attributes: %i[job_location organisation_id organisation_ids], section: "job_location"
 = render "publishers/vacancies/error_tag", attributes: %i[job_location organisation_id organisation_ids], section: "job_location"
 
-= render Shared::ReviewComponent.new(id: "job_location", title: t("jobs.job_location"), edit_link: organisation_job_build_path(@vacancy.id, :job_location))
+= render Shared::ReviewComponent.new(id: "job_location", title: t("jobs.job_location"), edit_link: organisation_job_build_path(@vacancy.id, :job_location)) do
+  dl.govuk-summary-list
+    .govuk-summary-list__row
+      dt.govuk-summary-list__key
+        h4.govuk-heading-s = vacancy_job_location_heading(@vacancy)
 
-.review-component
-  .review-component__body
-    dl.govuk-summary-list
-      .govuk-summary-list__row
-        dt.govuk-summary-list__key
-          h4.govuk-heading-s = vacancy_job_location_heading(@vacancy)
-
-        - @vacancy.organisations.each do |organisation|
-          dd.govuk-summary-list__value
-            div class="govuk-!-font-weight-bold" = organisation.name
-            = full_address(organisation)
+      - @vacancy.organisations.each do |organisation|
+        dd.govuk-summary-list__value
+          div class="govuk-!-font-weight-bold" = organisation.name
+          = full_address(organisation)

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_summary.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_summary.html.slim
@@ -1,15 +1,12 @@
 = render "publishers/vacancies/new_attributes_tag", attributes: %i[job_summary about_school], section: "job_summary"
 = render "publishers/vacancies/error_tag", attributes: %i[job_summary about_school], section: "job_summary"
 
-= render Shared::ReviewComponent.new(id: "job_summary", title: t("jobs.job_summary"), edit_link: organisation_job_build_path(@vacancy.id, :job_summary))
+= render Shared::ReviewComponent.new(id: "job_summary", title: t("jobs.job_summary"), edit_link: organisation_job_build_path(@vacancy.id, :job_summary)) do
+  = govuk_summary_list do |component|
+    - component.slot(:row,
+      key: t("jobs.job_summary"),
+      value: @vacancy.job_summary)
 
-.review-component
-  .review-component__body
-    = render GovukComponent::SummaryList.new classes: "review-component__body" do |component|
-      - component.slot(:row,
-        key: t("jobs.job_summary"),
-        value: @vacancy.job_summary)
-
-      - component.slot(:row,
-        key: t("jobs.about_school", school: vacancy_about_school_label_organisation(@vacancy)),
-        value: @vacancy.about_school)
+    - component.slot(:row,
+      key: t("jobs.about_school", school: vacancy_about_school_label_organisation(@vacancy)),
+      value: @vacancy.about_school)

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_pay_package.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_pay_package.html.slim
@@ -1,15 +1,12 @@
 = render "publishers/vacancies/new_attributes_tag", attributes: %i[salary benefits], section: "pay_package"
 = render "publishers/vacancies/error_tag", attributes: %i[salary benefits], section: "pay_package"
 
-= render Shared::ReviewComponent.new(id: "pay_package", title: t("jobs.pay_package"), edit_link: organisation_job_build_path(@vacancy.id, :pay_package))
+= render Shared::ReviewComponent.new(id: "pay_package", title: t("jobs.pay_package"), edit_link: organisation_job_build_path(@vacancy.id, :pay_package)) do
+  = govuk_summary_list do |component|
+    - component.slot(:row,
+      key: t("jobs.salary"),
+      value: @vacancy.salary)
 
-.review-component
-  .review-component__body
-    = render GovukComponent::SummaryList.new classes: "review-component__body" do |component|
-      - component.slot(:row,
-        key: t("jobs.salary"),
-        value: @vacancy.salary)
-
-      - component.slot(:row,
-        key: t("jobs.benefits"),
-        value: @vacancy.benefits.presence || t("jobs.not_defined"))
+    - component.slot(:row,
+      key: t("jobs.benefits"),
+      value: @vacancy.benefits.presence || t("jobs.not_defined"))

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_supporting_documents.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_supporting_documents.html.slim
@@ -1,18 +1,15 @@
 = render "publishers/vacancies/new_attributes_tag", attributes: %i[supporting_documents], section: "supporting_documents"
 
-= render Shared::ReviewComponent.new(id: "supporting_documents", title: t("jobs.supporting_documents"), edit_link: organisation_job_build_path(@vacancy.id, :documents))
-
-.review-component
-  .review-component__body
-    dl.govuk-summary-list
-      - if @vacancy.documents.none?
+= render Shared::ReviewComponent.new(id: "supporting_documents", title: t("jobs.supporting_documents"), edit_link: organisation_job_build_path(@vacancy.id, :documents)) do
+  dl.govuk-summary-list
+    - if @vacancy.documents.none?
+      .govuk-summary-list__row
+        dt.govuk-summary-list__key#supporting_documents class="govuk-!-font-weight-regular"
+          = t("jobs.no_supporting_documents")
+    - else
+      - @vacancy.documents.each_with_index do |document, index|
+        - index_from_one = index + 1
         .govuk-summary-list__row
-          dt.govuk-summary-list__key#supporting_documents class="govuk-!-font-weight-regular"
-            = t("jobs.no_supporting_documents")
-      - else
-        - @vacancy.documents.each_with_index do |document, index|
-          - index_from_one = index + 1
-          .govuk-summary-list__row
-            dt.govuk-summary-list__key#supporting_documents class=(index.zero? && "first-question")
-              h4.govuk-heading-s = "Document #{index_from_one}"
-            dd.govuk-summary-list__value class=(index.zero? && "first-question") = document.name
+          dt.govuk-summary-list__key#supporting_documents class=(index.zero? && "first-question")
+            h4.govuk-heading-s = "Document #{index_from_one}"
+          dd.govuk-summary-list__value class=(index.zero? && "first-question") = document.name

--- a/spec/components/shared/review_component_spec.rb
+++ b/spec/components/shared/review_component_spec.rb
@@ -1,17 +1,60 @@
 require "rails_helper"
 
 RSpec.describe Shared::ReviewComponent, type: :component do
-  let(:title) { "Review section title" }
-  let(:edit_link) { "http://edit.com" }
+  let(:id) { "test_review" }
+  let(:title) { "Test title" }
+  let(:edit_link) { "/edit_test_review" }
+  let(:summary) { "Test summary" }
+  let(:kwargs) { { id: id, title: title, edit_link: edit_link, summary: summary } }
 
-  describe "renders correctly" do
-    let!(:inline_component) { render_inline(described_class.new(title: title, edit_link: edit_link, id: "job_location")) }
+  subject! { render_inline(described_class.new(**kwargs)) }
 
-    it "renders the heading" do
-      expect(rendered_component).to include(title)
-      expect(inline_component.css("a.review-component__section-button").to_html).to include(edit_link)
-      expect(inline_component.css("#job_location_heading").count).to eq(1)
-      expect(inline_component.css("[aria-label='Change job location']").count).to eq(1)
+  context "when an edit_link is supplied" do
+    it "contains a div element with the correct id, title, edit link, summary and aria-label" do
+      expect(page).to have_css("div", class: %w[review-component]) do |review|
+        expect(review).to have_css("h2", class: %w[govuk-heading-m review-component__heading review-component__section], id: "test_review_heading", text: title) do |heading|
+          expect(heading).to have_css("a[aria-label='Change Test review'][href='/edit_test_review']", class: %w[govuk-link review-component__section-button], text: I18n.t("buttons.change"))
+        end
+        expect(review).to have_css(".review-component__body", text: summary)
+      end
     end
   end
+
+  context "when an edit_link is not supplied" do
+    let(:edit_link) { nil }
+
+    it "contains a div element with the correct id, title, summary and aria-label" do
+      expect(page).to have_css("div", class: %w[review-component]) do |review|
+        expect(review).to have_css("h2", class: %w[govuk-heading-m review-component__heading review-component__section], id: "test_review_heading", text: title)
+        expect(review).to have_css(".review-component__body", text: summary)
+      end
+    end
+  end
+
+  context "when a summary is supplied" do
+    it "contains a div element with the correct id, title, edit link, summary and aria-label" do
+      expect(page).to have_css("div", class: %w[review-component]) do |review|
+        expect(review).to have_css("h2", class: %w[govuk-heading-m review-component__heading review-component__section], id: "test_review_heading", text: title) do |heading|
+          expect(heading).to have_css("a[aria-label='Change Test review'][href='/edit_test_review']", class: %w[govuk-link review-component__section-button], text: I18n.t("buttons.change"))
+        end
+        expect(review).to have_css(".review-component__body", text: summary)
+      end
+    end
+  end
+
+  context "when a block is supplied" do
+    subject! { render_inline(described_class.new(**kwargs.except(:summary))) { summary } }
+
+    it "contains a div element with the correct id, title, edit link, summary and aria-label" do
+      expect(page).to have_css("div", class: %w[review-component]) do |review|
+        expect(review).to have_css("h2", class: %w[govuk-heading-m review-component__heading review-component__section], id: "test_review_heading", text: title) do |heading|
+          expect(heading).to have_css("a[aria-label='Change Test review'][href='/edit_test_review']", class: %w[govuk-link review-component__section-button], text: I18n.t("buttons.change"))
+        end
+        expect(review).to have_css(".review-component__body", text: summary)
+      end
+    end
+  end
+
+  it_behaves_like "a component that accepts custom classes"
+  it_behaves_like "a component that accepts custom HTML attributes"
 end

--- a/spec/components/shared_examples/a_component_that_accepts_custom_classes.rb
+++ b/spec/components/shared_examples/a_component_that_accepts_custom_classes.rb
@@ -1,0 +1,19 @@
+RSpec.shared_examples "a component that accepts custom classes" do
+  subject! { render_inline(described_class.send(:new, **kwargs.merge(classes: custom_classes))) }
+
+  context "when classes are supplied as a string" do
+    let(:custom_classes) { "purple-stripes" }
+
+    context "the custom classes should be set" do
+      it { expect(page).to have_css(".#{custom_classes}") }
+    end
+  end
+
+  context "when classes are supplied as an array" do
+    let(:custom_classes) { %w[purple-stripes yellow-background] }
+
+    context "the custom classes should be set" do
+      it { expect(page).to have_css(".#{custom_classes.join('.')}") }
+    end
+  end
+end

--- a/spec/components/shared_examples/a_component_that_accepts_custom_html_attributes.rb
+++ b/spec/components/shared_examples/a_component_that_accepts_custom_html_attributes.rb
@@ -1,0 +1,11 @@
+RSpec.shared_examples "a component that accepts custom HTML attributes" do
+  subject! { render_inline(described_class.send(:new, html_attributes: custom_attributes, **kwargs)) }
+
+  let(:custom_attributes) { { lang: "en-GB", style: "background-color: blue;" } }
+
+  specify "the custom HTML attributes should be set correctly" do
+    custom_attributes.each do |key, value|
+      expect(page).to have_css(%(*[#{key}="#{value}"]))
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -24,6 +24,7 @@ Geocoder::DEFAULT_STUB_COORDINATES = [51.67014192630465, -1.2809649516211556].fr
 Capybara.server = :puma, { Silent: true, Threads: "0:1" }
 
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
+Dir[Rails.root.join("spec/components/shared_examples/*.rb")].sort.each { |f| require f }
 Dir[Rails.root.join("spec/page_objects/**/*.rb")].sort.each { |f| require f }
 Dir[Rails.root.join("lib/**/*.rb")].sort.each { |f| require f }
 


### PR DESCRIPTION
Pretty much what it says on the tin

- Make use of view_component `content`
- Allow custom classes and HTML attributes and add shared examples

Let me know what you think, gradually components will start to adopt this pattern (and the pattern itself will continue to be refined). For now we are taking lots of inspiration from `govuk-components` in order to make components consistent to use