### PR TITLE
wrong label was used in edit vacancy section

### DIFF
--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_applying_for_the_job.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_applying_for_the_job.html.slim
@@ -19,7 +19,7 @@
           value: @vacancy.application_link.present? ? govuk_link_to(@vacancy.application_link, @vacancy.application_link, "aria-label": t("jobs.aria_labels.apply_link"), target: "_blank", rel: "noopener noreferrer") : t("jobs.not_defined"))
 
     - component.slot(:row,
-      key: t("jobs.job_title"),
+      key: t("jobs.contact_email"),
       value: govuk_mail_to("Job contact email", @vacancy.contact_email, "aria-label": t("jobs.aria_labels.contact_email_link", email: @vacancy.contact_email)))
 
     - component.slot(:row,


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-2115

label for the row had job title as label instead of correct contact email