### PR TITLE
[TEVA-2122] Terraform offline site S3 bucket and Cloudfront update

### DIFF
--- a/terraform/app/modules/cloudfront/main.tf
+++ b/terraform/app/modules/cloudfront/main.tf
@@ -12,7 +12,7 @@ resource "aws_cloudfront_distribution" "default" {
   }
 
   origin {
-    domain_name = var.offline_bucket_domain_name
+    domain_name = "${data.aws_caller_identity.current.account_id}-offline-site.s3.amazonaws.com"
     origin_id   = "${var.service_name}-${var.environment}-offline"
   }
 
@@ -30,14 +30,14 @@ resource "aws_cloudfront_distribution" "default" {
     error_code            = "503"
     error_caching_min_ttl = "60"
     response_code         = "503"
-    response_page_path    = "${var.offline_bucket_origin_path}/index.html"
+    response_page_path    = "/index.html"
   }
 
   custom_error_response {
     error_code            = "502"
     error_caching_min_ttl = "60"
     response_code         = "502"
-    response_page_path    = "${var.offline_bucket_origin_path}/index.html"
+    response_page_path    = "/index.html"
   }
 
   enabled = true
@@ -68,7 +68,7 @@ resource "aws_cloudfront_distribution" "default" {
     cached_methods   = ["GET", "HEAD"]
     target_origin_id = "${var.service_name}-${var.environment}-offline"
 
-    path_pattern = "${var.offline_bucket_origin_path}/*"
+    path_pattern = "/*"
 
     forwarded_values {
       query_string = false

--- a/terraform/app/modules/cloudfront/variables.tf
+++ b/terraform/app/modules/cloudfront/variables.tf
@@ -7,13 +7,6 @@ variable "service_name" {
 variable "cloudfront_origin_domain_name" {
 }
 
-variable "offline_bucket_domain_name" {
-}
-
-variable "offline_bucket_origin_path" {
-}
-
-
 variable "default_header_list" {
   default = [
     "Authorization",

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -43,8 +43,6 @@ module "cloudfront" {
   environment                   = var.environment
   service_name                  = local.service_name
   cloudfront_origin_domain_name = each.value.cloudfront_origin_domain_name
-  offline_bucket_domain_name    = each.value.offline_bucket_domain_name
-  offline_bucket_origin_path    = each.value.offline_bucket_origin_path
   route53_zones                 = var.route53_zones
   is_production                 = local.is_production
   route53_a_records             = local.route53_a_records

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -9,8 +9,6 @@ variable "environment" {}
 variable "distribution_list" {
   description = "Define Cloudfront distributions with the attributes below"
   type = map(object({
-    offline_bucket_domain_name    = string
-    offline_bucket_origin_path    = string
     cloudfront_origin_domain_name = string
   }))
   default = {}

--- a/terraform/common/s3.tf
+++ b/terraform/common/s3.tf
@@ -21,3 +21,7 @@ resource "aws_s3_bucket_public_access_block" "db_backups" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+resource "aws_s3_bucket" "offline_site" {
+  bucket = "${data.aws_caller_identity.current.account_id}-offline-site"
+}

--- a/terraform/workspace-variables/production.tfvars
+++ b/terraform/workspace-variables/production.tfvars
@@ -7,8 +7,6 @@ parameter_store_environment = "production"
 # CloudFront
 distribution_list = {
   "tvsprod" = {
-    offline_bucket_domain_name    = "tvs-offline.s3.amazonaws.com"
-    offline_bucket_origin_path    = "/school-jobs-offline"
     cloudfront_origin_domain_name = "teaching-vacancies-production.london.cloudapps.digital"
   }
 }

--- a/terraform/workspace-variables/staging.tfvars
+++ b/terraform/workspace-variables/staging.tfvars
@@ -7,8 +7,6 @@ parameter_store_environment = "staging"
 # CloudFront
 distribution_list = {
   "tvsstaging" = {
-    offline_bucket_domain_name    = "tvs-offline.s3.amazonaws.com"
-    offline_bucket_origin_path    = "/school-jobs-offline"
     cloudfront_origin_domain_name = "teaching-vacancies-staging.london.cloudapps.digital"
   }
 }

--- a/terraform/workspace-variables/workspace.tfvars.example
+++ b/terraform/workspace-variables/workspace.tfvars.example
@@ -6,9 +6,6 @@ parameter_store_environment = "staging"
 # CloudFront
 distribution_list = {
   "tvsstaging" = {
-    cloudfront_aliases            = ["tvs.staging.dxw.net", "*.tvs.staging.dxw.net"]
-    offline_bucket_domain_name    = "tvs-offline.s3.amazonaws.com"
-    offline_bucket_origin_path    = "/school-jobs-offline"
     cloudfront_origin_domain_name = "teaching-vacancies-staging.london.cloudapps.digital"
     domain                        = "staging.teaching-vacancies.service.gov.uk"
   }


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2122

## Changes in this PR:

- In `terraform/common`, create S3 bucket using unique organisation ID
- In `terraform/app`, use S3 bucket via datasource, and update Cloudfront distributions