### PR TITLE
Include ONS 'regions' that are cities in faceting

### DIFF
--- a/config/initializers/location_data.rb
+++ b/config/initializers/location_data.rb
@@ -44,8 +44,9 @@ COUNTIES = (composite_locations.keys + ons_counties).reject do |county|
   MAPPED_LOCATIONS.include?(county.downcase)
 end
 
+ons_region_cities = ons_regions.select { |line| line.second == "cities" }.map(&:first)
 ons_unitary_authority_cities = ons_counties_and_unitary_authorities.select { |line| line.second == "cities" }.map(&:first)
-CITIES = (ons_cities.map(&:first) + ons_unitary_authority_cities).reject do |city|
+CITIES = (ons_cities.map(&:first) + ons_region_cities + ons_unitary_authority_cities).reject do |city|
   # Reject duplicates caused by mapping locations, e.g. use Telford & Wrekin instead of Telford as location facets, rather than both.
   MAPPED_LOCATIONS.include?(city.downcase)
 end


### PR DESCRIPTION
Treats ONS 'regions' the same as ONS 'counties and unitary
authorities': we include some of these as cities if they
are considered to be cities by regular humans.

This commit therefore hopefully causes London to appear in
the landing page links on the home page: it makes sure
London is included in CITIES.

Before:

CITIES.include?('London')
=> false

After:

CITIES.include?('London')
=> true
