### PR TITLE
Add mailer previews

### DIFF
--- a/app/mailers/previewing_emails.md
+++ b/app/mailers/previewing_emails.md
@@ -1,0 +1,19 @@
+# Previewing emails
+
+![screenshot of a mailer preview](https://user-images.githubusercontent.com/60350599/109692100-054e9b00-7b80-11eb-8568-34d6817d7ad8.png)
+
+During development, you can quickly check the format/text of an email, and easily permute the data which the email presents, by using Rails' [mailer previews](https://edgeguides.rubyonrails.org/action_mailer_basics.html#previewing-emails).
+
+The preview files have been written to rely either on your existing records, or records from the seed data (`seeds.rb`), so that you do not clutter your development database with new factory-created records every time you view the preview.
+
+### View the previews
+
+Visit http://localhost:3000/rails/mailers.
+
+### Edit the preview files
+
+Go to `spec/mailers/previews`.
+
+
+
+

--- a/spec/mailers/previews/alert_preview.rb
+++ b/spec/mailers/previews/alert_preview.rb
@@ -1,0 +1,11 @@
+# Preview all emails at http://localhost:3000/rails/mailers
+class AlertPreview < ActionMailer::Preview
+  def alert
+    unless Subscription.any? && Vacancy.count > 1
+      raise "I don't want to mess up your development database with factory-created records, so this preview won't
+            run unless there is >=1 subscription and >=2 vacancies in the database."
+    end
+
+    AlertMailer.alert(Subscription.first.id, Vacancy.all.take(2).pluck(:id))
+  end
+end

--- a/spec/mailers/previews/alert_preview.rb
+++ b/spec/mailers/previews/alert_preview.rb
@@ -1,4 +1,4 @@
-# Preview all emails at http://localhost:3000/rails/mailers
+# Documentation: app/mailers/previewing_emails.md
 class AlertPreview < ActionMailer::Preview
   def alert
     unless Subscription.any? && Vacancy.count > 1

--- a/spec/mailers/previews/authentication_fallback_preview.rb
+++ b/spec/mailers/previews/authentication_fallback_preview.rb
@@ -1,4 +1,4 @@
-# Preview all emails at http://localhost:3000/rails/mailers
+# Documentation: app/mailers/previewing_emails.md
 class AuthenticationFallbackPreview < ActionMailer::Preview
   def sign_in_fallback
     unless Publisher.any?

--- a/spec/mailers/previews/authentication_fallback_preview.rb
+++ b/spec/mailers/previews/authentication_fallback_preview.rb
@@ -1,0 +1,11 @@
+# Preview all emails at http://localhost:3000/rails/mailers
+class AuthenticationFallbackPreview < ActionMailer::Preview
+  def sign_in_fallback
+    unless Publisher.any?
+      raise "I don't want to mess up your development database with factory-created records, so this preview won't
+            run unless there is >=1 publisher in the database."
+    end
+
+    AuthenticationFallbackMailer.sign_in_fallback(login_key_id: "example", publisher: Publisher.first)
+  end
+end

--- a/spec/mailers/previews/feedback_prompt_preview.rb
+++ b/spec/mailers/previews/feedback_prompt_preview.rb
@@ -1,4 +1,4 @@
-# Preview all emails at http://localhost:3000/rails/mailers
+# Documentation: app/mailers/previewing_emails.md
 class FeedbackPromptPreview < ActionMailer::Preview
   def prompt_for_feedback
     unless Publisher.any? && Vacancy.count > 1

--- a/spec/mailers/previews/feedback_prompt_preview.rb
+++ b/spec/mailers/previews/feedback_prompt_preview.rb
@@ -1,0 +1,11 @@
+# Preview all emails at http://localhost:3000/rails/mailers
+class FeedbackPromptPreview < ActionMailer::Preview
+  def prompt_for_feedback
+    unless Publisher.any? && Vacancy.count > 1
+      raise "I don't want to mess up your development database with factory-created records, so this preview won't
+            run unless there is >=1 publisher and >=2 vacancies in the database."
+    end
+
+    FeedbackPromptMailer.prompt_for_feedback(Publisher.first, [Vacancy.first, Vacancy.second])
+  end
+end

--- a/spec/mailers/previews/jobseeker_preview.rb
+++ b/spec/mailers/previews/jobseeker_preview.rb
@@ -1,0 +1,40 @@
+# Preview all emails at http://localhost:3000/rails/mailers
+class JobseekerPreview < ActionMailer::Preview
+  def application_submitted_at_central_office
+    application_submitted("7bfadb84-cf30-4121-88bd-a9f958440cc9")
+  end
+
+  def application_submitted_at_multiple_schools
+    application_submitted("9910d184-5686-4ffc-9322-69aa150c19d3")
+  end
+
+  def application_submitted_at_one_school
+    vacancy = School.first.vacancies.where(job_location: "at_one_school").sample
+    application_submitted(vacancy.id)
+  end
+
+  def confirmation_instructions
+    JobseekerMailer.confirmation_instructions(Jobseeker.first, "fake_token")
+  end
+
+  def email_changed
+    JobseekerMailer.email_changed(Jobseeker.first)
+  end
+
+  def reset_password_instructions
+    JobseekerMailer.reset_password_instructions(Jobseeker.first, "fake_token")
+  end
+
+  def unlock_instructions
+    JobseekerMailer.reset_password_instructions(Jobseeker.first, "fake_token")
+  end
+
+  private
+
+  def application_submitted(vacancy_id)
+    seeded_vacancy = Vacancy.find(vacancy_id)
+    job_application = JobApplication.find_by(jobseeker_id: Jobseeker.first.id, vacancy_id: seeded_vacancy.id) ||
+                      FactoryBot.create(:job_application, jobseeker: Jobseeker.first, vacancy: seeded_vacancy)
+    JobseekerMailer.application_submitted(job_application)
+  end
+end

--- a/spec/mailers/previews/jobseeker_preview.rb
+++ b/spec/mailers/previews/jobseeker_preview.rb
@@ -1,4 +1,4 @@
-# Preview all emails at http://localhost:3000/rails/mailers
+# Documentation: app/mailers/previewing_emails.md
 class JobseekerPreview < ActionMailer::Preview
   def application_submitted_at_central_office
     application_submitted("7bfadb84-cf30-4121-88bd-a9f958440cc9")

--- a/spec/mailers/previews/subscription_preview.rb
+++ b/spec/mailers/previews/subscription_preview.rb
@@ -1,0 +1,18 @@
+# Preview all emails at http://localhost:3000/rails/mailers
+class SubscriptionPreview < ActionMailer::Preview
+  def confirmation
+    unless Subscription.any?
+      raise "I don't want to mess up your development database with factory-created subscriptions, so this preview won't
+            run unless there is a subscription in the database."
+    end
+    SubscriptionMailer.confirmation(Subscription.first.id)
+  end
+
+  def update
+    unless Subscription.any?
+      raise "I don't want to mess up your development database with factory-created subscriptions, so this preview won't
+            run unless there is a subscription in the database."
+    end
+    SubscriptionMailer.update(Subscription.first.id)
+  end
+end

--- a/spec/mailers/previews/subscription_preview.rb
+++ b/spec/mailers/previews/subscription_preview.rb
@@ -1,4 +1,4 @@
-# Preview all emails at http://localhost:3000/rails/mailers
+# Documentation: app/mailers/previewing_emails.md
 class SubscriptionPreview < ActionMailer::Preview
   def confirmation
     unless Subscription.any?


### PR DESCRIPTION
These can be viewed in the browser during development in order to avoid triggering the email, for quickly checking the format/text of an email.

<img width="1099" alt="Screenshot 2021-03-02 at 17 52 10" src="https://user-images.githubusercontent.com/60350599/109692100-054e9b00-7b80-11eb-8568-34d6817d7ad8.png">

<img width="503" alt="Screenshot 2021-03-02 at 17 51 40" src="https://user-images.githubusercontent.com/60350599/109692125-0bdd1280-7b80-11eb-8e9a-cb33166f631e.png">
