### PR TITLE
TEVA-2122 terraform S3offline bucket

### DIFF
--- a/terraform/common/s3.tf
+++ b/terraform/common/s3.tf
@@ -31,3 +31,7 @@ resource "aws_s3_bucket_public_access_block" "db_backups" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+resource "aws_s3_bucket" "offline_site" {
+  bucket = "${data.aws_caller_identity.current.account_id}-offline-site"
+}

--- a/terraform/common/s3.tf
+++ b/terraform/common/s3.tf
@@ -35,3 +35,32 @@ resource "aws_s3_bucket_public_access_block" "db_backups" {
 resource "aws_s3_bucket" "offline_site" {
   bucket = "${data.aws_caller_identity.current.account_id}-offline-site"
 }
+
+data "aws_iam_policy_document" "offline_site_full_access" {
+  statement {
+    actions = [
+      "s3:GetBucketAcl",
+      "s3:GetBucketLocation",
+      "s3:GetObject",
+      "s3:GetObjectAcl",
+      "s3:ListBucket",
+      "s3:PutBucketAcl",
+      "s3:PutObject"
+    ]
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.offline_site.bucket}/",
+      "arn:aws:s3:::${aws_s3_bucket.offline_site.bucket}/*",
+      "arn:aws:s3:::${aws_s3_bucket.offline_site.bucket}/teaching-vacancies-offline/*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "offline_site_full_access" {
+  name   = "offline_site_full_access"
+  policy = data.aws_iam_policy_document.offline_site_full_access.json
+}
+
+resource "aws_iam_user_policy_attachment" "offline_site_full_access" {
+  user       = aws_iam_user.deploy.name
+  policy_arn = aws_iam_policy.offline_site_full_access.arn
+}


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2122

## Changes in this PR:

- Granular PR to Terraform creation of a new S3 bucket for the offline site, and grant permissions to the `deploy` user
