### PR TITLE
TEVA-2122 use terraformed s3 offline bucket

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -201,7 +201,7 @@ jobs:
 
     - name: Sync offline S3 bucket
       shell: bash
-      run: aws s3 sync ./offline s3://tvs-offline/offline
+      run: aws s3 sync ./offline s3://530003481352-offline-site/teaching-vacancies-offline
 
     - name: Send job status message to twd_tv_dev channel
       if: always() && github.ref == 'refs/heads/master'

--- a/terraform/workspace-variables/dev.tfvars
+++ b/terraform/workspace-variables/dev.tfvars
@@ -7,8 +7,8 @@ parameter_store_environment = "dev"
 # CloudFront
 distribution_list = {
   "tvsdev" = {
-    offline_bucket_domain_name    = "tvs-offline.s3.amazonaws.com"
-    offline_bucket_origin_path    = "/school-jobs-offline"
+    offline_bucket_domain_name    = "530003481352-offline-site.s3.amazonaws.com"
+    offline_bucket_origin_path    = "/teaching-vacancies-offline"
     cloudfront_origin_domain_name = "teaching-vacancies-dev.london.cloudapps.digital"
   }
 }


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2122

## Changes in this PR:

Part 2 of TEVA-2122
- during deploy workflow, synchronise with new bucket
- update Cloudfront distribution to populate offline origin from new S3 bucket

## Post-deployment

- Delete current `tvs-offline` bucket
- Delete https://github.com/DFE-Digital/school-jobs-offline