### PR TITLE
Turn off cookie banner test

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,5 +1,5 @@
 doctype html
-html.govuk-template.app-html-class class=("modal" if current_variant?(:"2021_02_cookie_consent_test", :modal) && !cookies_preference_set?) lang="en"
+html.govuk-template.app-html-class lang="en"
   head
     = render partial: "shared/google_tag_manager_head" if cookies["consented-to-cookies"] == "yes"
     = render partial: "shared/open_graph"
@@ -19,15 +19,15 @@ html.govuk-template.app-html-class class=("modal" if current_variant?(:"2021_02_
     = stylesheet_pack_tag "application", media: "all"
     meta content=asset_pack_path("media/images/govuk-opengraph-image.png") property="og:image"
     = csrf_meta_tags
+
   body class=body_class data-vacancy_state=(@vacancy.present? ? @vacancy.state : "create")
-    - if current_variant?(:"2021_02_cookie_consent_test", :modal) && !cookies_preference_set?
-      .modal-container
     = render partial: "shared/google_tag_manager_body" if cookies["consented-to-cookies"] == "yes"
     = javascript_tag(nonce: true) do
       | document.body.className = ((document.body.className) ? document.body.className + " js-enabled" : "js-enabled");
     = render "shared/skip_links"
-    - unless cookies_preference_set? || %i[top none].include?(ab_variant_for(:"2021_02_cookie_consent_test"))
-      = render(AbTest::CookiesBannerComponent.new(create_path: create_cookies_preferences_path(cookies_consent: "yes", **utm_parameters), preferences_path: cookies_preferences_path(**utm_parameters)).with_variant(ab_variant_for(:"2021_02_cookie_consent_test")))
+
+    = render AbTest::CookiesBannerComponent.new(create_path: create_cookies_preferences_path(cookies_consent: "yes", **utm_parameters), preferences_path: cookies_preferences_path(**utm_parameters)).with_variant(:default) unless cookies_preference_set?
+
     header.govuk-header.navbar-component data-module="govuk-header" role="banner"
       .govuk-header__container.govuk-width-container
         .govuk-header__logo
@@ -52,8 +52,6 @@ html.govuk-template.app-html-class class=("modal" if current_variant?(:"2021_02_
             | This is a new service - #{govuk_link_to "your feedback", new_feedback_path} will help us to improve it.
 
       main.govuk-main-wrapper#main-content role="main"
-        = render(AbTest::CookiesBannerComponent.new(create_path: create_cookies_preferences_path(cookies_consent: "yes", **utm_parameters), preferences_path: cookies_preferences_path(**utm_parameters)).with_variant(:top)) if current_variant?(:"2021_02_cookie_consent_test", :top) && !cookies_preference_set?
-
         - unless flash.empty?
           .govuk-main-wrapper__notification
             .govuk-width-container

--- a/config/ab_tests.yml
+++ b/config/ab_tests.yml
@@ -28,21 +28,6 @@ shared:
     foo: 1
     bar: 1
     baz: 1
-  2021_02_cookie_consent_test:
-    none: 1
-    default: 1
-    top: 1
-    bottom: 1
-    modal: 1
-    gds: 1
   2021_02_job_alert_account_creation_test:
     link: 1
     form: 1
-test:
-  2021_02_cookie_consent_test:
-    none: 0
-    default: 1
-    top: 0
-    bottom: 0
-    modal: 0
-    gds: 0


### PR DESCRIPTION
Pretty much what it says on the tin

- Variant templates remain because subsequent testing will resume shortly on a to be confirmed subset of variants