### PR TITLE
Make smoke test print page contents on failure

### DIFF
--- a/spec/smoke_tests/jobseekers_can_view_homepage_spec.rb
+++ b/spec/smoke_tests/jobseekers_can_view_homepage_spec.rb
@@ -4,12 +4,16 @@ require "i18n_helper"
 DEFAULT_DOMAIN = "teaching-vacancies.service.gov.uk".freeze
 
 RSpec.describe "Page availability", js: true, smoke_test: true do
+  after do |example|
+    # Print page on failure to help triage failures
+    puts page.html if example.exception
+  end
+
   context "Jobseeker visits vacancy page" do
     let(:smoke_test_domain) { (ENV.include? "SMOKE_TEST_DOMAIN") && !ENV["SMOKE_TEST_DOMAIN"].empty? ? ENV["SMOKE_TEST_DOMAIN"] : DEFAULT_DOMAIN }
+    let(:page) { Capybara::Session.new(:selenium_chrome_headless) }
 
     it "ensures users can search and view a job vacancy page" do
-      page = Capybara::Session.new(:selenium_chrome_headless)
-
       page.visit "https://#{smoke_test_domain}/404" # you need to be on the domain to set the cookie
 
       page.driver.browser.manage.add_cookie(name: "smoke_test", value: "1", domain: smoke_test_domain)


### PR DESCRIPTION
This is to help us figure out what failed, and whether or not it is
something we need to be worried about.