### PR TITLE
[TEVA-2036] Redirect to dashboard if job application already exists

### DIFF
--- a/app/controllers/jobseekers/job_applications/feedbacks_controller.rb
+++ b/app/controllers/jobseekers/job_applications/feedbacks_controller.rb
@@ -1,4 +1,4 @@
-class Jobseekers::JobApplications::FeedbacksController < Jobseekers::JobApplicationsController
+class Jobseekers::JobApplications::FeedbacksController < Jobseekers::BaseController
   include FeedbackEventConcerns
 
   def create
@@ -25,5 +25,9 @@ class Jobseekers::JobApplications::FeedbacksController < Jobseekers::JobApplicat
       feedback_type: "application",
       jobseeker_id: current_jobseeker.id,
     )
+  end
+
+  def job_application
+    @job_application ||= current_jobseeker.job_applications.find(params[:job_application_id])
   end
 end

--- a/app/controllers/jobseekers/job_applications_controller.rb
+++ b/app/controllers/jobseekers/job_applications_controller.rb
@@ -1,6 +1,8 @@
 class Jobseekers::JobApplicationsController < Jobseekers::BaseController
   helper_method :job_application, :review_form, :vacancy
 
+  before_action :redirect_if_job_application_exists, only: %i[new create]
+
   def new
     request_event.trigger(:vacancy_apply_clicked, vacancy_id: vacancy.id)
   end
@@ -26,6 +28,21 @@ class Jobseekers::JobApplicationsController < Jobseekers::BaseController
 
   def job_application
     @job_application ||= current_jobseeker.job_applications.find(params[:job_application_id] || params[:id])
+  end
+
+  def redirect_if_job_application_exists
+    job_application = current_jobseeker.job_applications.find_by(vacancy_id: vacancy.id)
+    return unless job_application
+
+    if job_application.submitted?
+      redirect_to jobseekers_job_applications_path,
+                  danger: t("messages.jobseekers.job_applications.already_exists.submitted",
+                            job_title: vacancy.job_title)
+    elsif job_application.draft?
+      redirect_to jobseekers_job_applications_path,
+                  danger: t("messages.jobseekers.job_applications.already_exists.draft_html",
+                            job_title: vacancy.job_title, link: jobseekers_job_application_review_path(job_application))
+    end
   end
 
   def review_form

--- a/config/locales/notifications.yml
+++ b/config/locales/notifications.yml
@@ -27,6 +27,11 @@ en:
         message: Improve your job listing using the new sections and features below
     jobseekers:
       job_applications:
+        already_exists:
+          draft_html: >-
+            You have already started an application for %{job_title}.
+            <a href="%{link}" class="govuk-link">Continue application</a>
+          submitted: You have applied for %{job_title}
         employment_history:
           deleted: Your employment history was deleted
         references:

--- a/spec/page_objects/jobseekers/job_applications/new.rb
+++ b/spec/page_objects/jobseekers/job_applications/new.rb
@@ -1,0 +1,12 @@
+module PageObjects
+  module Jobseekers
+    module JobApplications
+      class New < SitePrism::Page
+        set_url "jobseekers{/job_id}/job_application/new"
+
+        element :caption, ".govuk-caption-l"
+        element :start_application, ".govuk-button--start"
+      end
+    end
+  end
+end

--- a/spec/requests/jobseekers/job_applications_spec.rb
+++ b/spec/requests/jobseekers/job_applications_spec.rb
@@ -15,5 +15,23 @@ RSpec.describe "Job applications", type: :request do
         .to have_triggered_event(:vacancy_apply_clicked)
         .and_data(vacancy_id: vacancy.id)
     end
+
+    context "when an job application for the job already exists" do
+      let!(:job_application) { create(:job_application, jobseeker: jobseeker, vacancy: vacancy) }
+
+      it "redirects to `jobseekers_job_applications_path`" do
+        expect(get(new_jobseekers_job_job_application_path(vacancy.id))).to redirect_to(jobseekers_job_applications_path)
+      end
+    end
+  end
+
+  describe "POST #create" do
+    context "when an job application for the job already exists" do
+      let!(:job_application) { create(:job_application, jobseeker: jobseeker, vacancy: vacancy) }
+
+      it "redirects to `jobseekers_job_applications_path`" do
+        expect(post(jobseekers_job_job_application_path(vacancy.id))).to redirect_to(jobseekers_job_applications_path)
+      end
+    end
   end
 end

--- a/spec/system/jobseekers_can_give_application_feedback_spec.rb
+++ b/spec/system/jobseekers_can_give_application_feedback_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Jobseekers can give job application feedback after submitting th
     choose I18n.t("helpers.label.jobseekers_job_application_feedback_form.rating_options.somewhat_satisfied")
     fill_in "jobseekers_job_application_feedback_form[comment]", with: comment
 
-    expect { click_button I18n.t("buttons.submit") }.to have_triggered_event(:feedback_provided)
+    expect { click_on I18n.t("buttons.submit_feedback") }.to have_triggered_event(:feedback_provided)
       .with_base_data(
         user_anonymised_jobseeker_id: StringAnonymiser.new(jobseeker.id).to_s,
       ).and_data(comment: comment,

--- a/spec/system/jobseekers_can_start_a_job_application_spec.rb
+++ b/spec/system/jobseekers_can_start_a_job_application_spec.rb
@@ -2,72 +2,127 @@ require "rails_helper"
 
 RSpec.describe "Jobseekers can start a job application" do
   let(:jobseeker) { build_stubbed(:jobseeker) }
-  let(:vacancy) { create(:vacancy) }
+  let(:vacancy) { create(:vacancy, organisation_vacancies_attributes: [{ organisation: school }]) }
   let(:school) { create(:school) }
   let(:created_job_application) { JobApplication.first }
+  let(:new_job_application_page) { PageObjects::Jobseekers::JobApplications::New.new }
 
   before do
     allow(JobseekerApplicationsFeature).to receive(:enabled?).and_return(jobseeker_applications_enabled?)
-    vacancy.organisation_vacancies.create(organisation: school)
+    visit job_path(vacancy)
   end
 
   context "when JobseekerApplicationsFeature is enabled" do
     let(:jobseeker_applications_enabled?) { true }
 
-    context "when the jobseeker has an account" do
-      let!(:jobseeker) { create(:jobseeker) }
+    context "when the jobseeker has not applied to the job before" do
+      context "when the jobseeker has an account" do
+        let!(:jobseeker) { create(:jobseeker) }
 
-      context "when the jobseeker is signed in" do
+        context "when the jobseeker is signed in" do
+          before { login_as(jobseeker, scope: :jobseeker) }
+
+          context "when clicking apply on the job page" do
+            before { click_on I18n.t("jobseekers.job_applications.apply") }
+
+            it "starts a job application" do
+              expect(current_path).to eq(new_jobseekers_job_job_application_path(vacancy.id))
+              expect(new_job_application_page.caption).to have_content(vacancy.job_title)
+
+              expect { new_job_application_page.start_application.click }.to change { JobApplication.count }.by(1)
+
+              expect(current_path).to eq(jobseekers_job_application_build_path(created_job_application, :personal_details))
+            end
+          end
+        end
+
+        context "when the jobseeker is not signed in" do
+          context "when clicking apply on the job page" do
+            before { click_on I18n.t("jobseekers.job_applications.apply") }
+
+            it "starts a job application after signing in" do
+              expect(current_path).not_to eq(new_jobseekers_job_job_application_path(vacancy.id))
+
+              sign_in_jobseeker
+
+              expect(current_path).to eq(new_jobseekers_job_job_application_path(vacancy.id))
+              expect(new_job_application_page.caption).to have_content(vacancy.job_title)
+
+              expect { new_job_application_page.start_application.click }.to change { JobApplication.count }.by(1)
+
+              expect(current_path).to eq(jobseekers_job_application_build_path(created_job_application, :personal_details))
+            end
+          end
+        end
+      end
+
+      context "when the jobseeker does not have an account" do
+        context "when clicking apply on the job page" do
+          before { click_on I18n.t("jobseekers.job_applications.apply") }
+
+          it "starts a job application after signing up" do
+            expect(current_path).not_to eq(new_jobseekers_job_job_application_path(vacancy.id))
+
+            click_on I18n.t("jobseekers.sessions.new.no_account.link")
+            sign_up_jobseeker
+            visit first_link_from_last_mail
+
+            expect(current_path).to eq(new_jobseekers_job_job_application_path(vacancy.id))
+            expect(new_job_application_page.caption).to have_content(vacancy.job_title)
+
+            expect { new_job_application_page.start_application.click }.to change { JobApplication.count }.by(1)
+
+            expect(current_path).to eq(jobseekers_job_application_build_path(created_job_application, :personal_details))
+          end
+        end
+      end
+    end
+
+    context "when the jobseeker has a draft application for the job" do
+      context "when clicking apply on the job page" do
+        let!(:jobseeker) { create(:jobseeker) }
+        let!(:job_application) { create(:job_application, :complete, jobseeker: jobseeker, vacancy: vacancy) }
+
         before do
           login_as(jobseeker, scope: :jobseeker)
+          click_on I18n.t("jobseekers.job_applications.apply")
         end
 
-        it "starts a job application" do
-          apply_on_vacancy
-          and_it_starts_a_job_application
-        end
-      end
-
-      context "when the jobseeker is not signed in" do
-        it "starts a job application after signing in" do
-          apply_on_vacancy
-          sign_in_jobseeker
-          and_it_starts_a_job_application
+        it "redirects to job applications dashboard with correct message" do
+          expect(current_path).to eq(jobseekers_job_applications_path)
+          expect(page)
+            .to have_content(strip_tags(I18n.t("messages.jobseekers.job_applications.already_exists.draft_html",
+                                               job_title: vacancy.job_title,
+                                               link: jobseekers_job_application_review_path(job_application))))
         end
       end
     end
 
-    context "when the jobseeker does not have an account" do
-      it "starts a job application after signing up" do
-        apply_on_vacancy
-        click_on I18n.t("jobseekers.sessions.new.no_account.link")
-        sign_up_jobseeker
-        visit first_link_from_last_mail
-        and_it_starts_a_job_application
+    context "when the jobseeker has a submitted application for the job" do
+      context "when clicking apply on the job page" do
+        let!(:jobseeker) { create(:jobseeker) }
+        let!(:job_application) { create(:job_application, :status_submitted, jobseeker: jobseeker, vacancy: vacancy) }
+
+        before do
+          login_as(jobseeker, scope: :jobseeker)
+          click_on I18n.t("jobseekers.job_applications.apply")
+        end
+
+        it "redirects to job applications dashboard with correct message" do
+          expect(current_path).to eq(jobseekers_job_applications_path)
+          expect(page).to have_content(I18n.t("messages.jobseekers.job_applications.already_exists.submitted",
+                                              job_title: vacancy.job_title))
+        end
       end
     end
+  end
 
-    context "when JobseekerApplicationsFeature is disabled" do
-      let(:jobseeker_applications_enabled?) { false }
+  context "when JobseekerApplicationsFeature is disabled" do
+    let(:jobseeker_applications_enabled?) { false }
 
-      it "returns not found" do
-        visit new_jobseekers_job_job_application_path(vacancy.id)
-        expect(page.status_code).to eq(404)
-      end
+    it "returns not found" do
+      visit new_jobseekers_job_job_application_path(vacancy.id)
+      expect(page.status_code).to eq(404)
     end
-  end
-
-  def apply_on_vacancy
-    visit job_path(vacancy)
-    click_on I18n.t("jobseekers.job_applications.apply")
-  end
-
-  def start_application
-    click_on I18n.t("buttons.start_application")
-  end
-
-  def and_it_starts_a_job_application
-    expect { start_application }.to change { JobApplication.count }.by(1)
-    expect(current_path).to eq(jobseekers_job_application_build_path(created_job_application, :personal_details))
   end
 end


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-2036

## Changes in this PR
- If a draft or submitted application already exists for a jobseeker and a vacancy, redirect to the applications dashboard!