### PR TITLE
Add missing permitted parameter

### DIFF
--- a/app/controllers/concerns/jobseekers/wizardable.rb
+++ b/app/controllers/concerns/jobseekers/wizardable.rb
@@ -42,7 +42,8 @@ module Jobseekers::Wizardable
 
   def professional_status_params(params)
     params.require(:jobseekers_job_application_professional_status_form)
-          .permit(:qualified_teacher_status, :qualified_teacher_status_year, :statutory_induction_complete)
+          .permit(:qualified_teacher_status, :qualified_teacher_status_year,
+                  :no_qualified_teacher_status_details, :statutory_induction_complete)
   end
 
   def employment_history_params(params)


### PR DESCRIPTION
`no_qualified_teacher_status_details` was missing a permitted parameter
and didn't submit.