### PR TITLE
[TEVA-2141] fix padding on all page layouts

### DIFF
--- a/app/components/shared/dashboard_component/dashboard_component.html.slim
+++ b/app/components/shared/dashboard_component/dashboard_component.html.slim
@@ -1,4 +1,4 @@
-.dashboard-component__header
+.dashboard-component
   .govuk-width-container
     h2.govuk-heading-m class="govuk-!-margin-bottom-2"
       = heading
@@ -6,7 +6,7 @@
   .govuk-width-container
     - if link.present?
       .filters-information.moj-action-bar
-        = govuk_button_to link[:text], link[:url], class: "govuk-!-margin-bottom-0 govuk-!-margin-top-0 dashboard__link"
+        = govuk_button_to link[:text], link[:url], class: "govuk-!-margin-bottom-0 govuk-!-margin-top-0 dashboard-component__link"
     .moj-primary-navigation
       .moj-primary-navigation__container
         .moj-primary-navigation__nav aria-label="Account navigation"

--- a/app/components/shared/dashboard_component/dashboard_component.scss
+++ b/app/components/shared/dashboard_component/dashboard_component.scss
@@ -1,23 +1,28 @@
 @import 'base_component';
-@import '../../../frontend/src/styles/application/dashboard';
+@import '../../../frontend/src/styles/application/full-width-mast';
 
 .dashboard-component {
-  &__header {
-    @include dashboard;
-    background-color: govuk-colour('light-grey');
+  @include full-width-mast;
+  background-color: govuk-colour('light-grey');
+  padding: govuk-spacing(3) 0 0;
 
-    padding: govuk-spacing(3) 0 0;
+  h2 {
+    word-wrap: break-word;
+  }
 
-    h2 {
-      word-wrap: break-word;
+  &__link {
+    float: right;
+
+    .govuk-button {
+      margin-bottom: 0;
     }
+  }
 
-    .filters-information {
-      display: block;
+  .filters-information {
+    display: block;
 
-      .filters-applied-text {
-        line-height: 2em;
-      }
+    .filters-applied-text {
+      line-height: 2em;
     }
   }
 }

--- a/app/components/shared/notification_component/notification_component.html.slim
+++ b/app/components/shared/notification_component/notification_component.html.slim
@@ -1,7 +1,7 @@
 .govuk-notification *@html_attributes class=notification_classes
+  - if @dismiss
+    = govuk_link_to(t("buttons.dismiss"), "#", class: "govuk-link--no-visited-state dismiss-link js-dismissible__link")
   .govuk-notification__content
-    - if @dismiss
-      = govuk_link_to(t("buttons.dismiss"), "#", class: "govuk-link--no-visited-state dismiss-link js-dismissible__link")
     - if render_title_and_body?
       - if content[:title].present?
         .govuk-notification__title = content[:title]

--- a/app/components/shared/notification_component/notification_component.js
+++ b/app/components/shared/notification_component/notification_component.js
@@ -10,6 +10,10 @@ document.addEventListener('click', (e) => {
     dismissibleEl.style.opacity = '0';
 
     dismissibleEl.addEventListener('transitionend', () => {
+      if (dismissibleEl.closest('.govuk-main-wrapper__notification')) {
+        dismissibleEl.closest('.govuk-main-wrapper__notification').remove();
+      }
+
       dismissibleEl.remove();
     });
   }

--- a/app/components/shared/notification_component/notification_component.scss
+++ b/app/components/shared/notification_component/notification_component.scss
@@ -1,16 +1,19 @@
 @import 'base_component';
-
-.dismiss-link {
-  display: block;
-  float: right;
-}
+@import '../../../frontend/src/styles/application/full-width-mast';
 
 .govuk-main-wrapper__notification {
-  background-color: govuk-colour('white');
+  @include full-width-mast;
+  background-color: inherit;
+  padding-bottom: govuk-spacing(2);
   padding-top: govuk-spacing(2);
 
   .govuk-notification {
     margin-bottom: 0;
+
+    .dismiss-link {
+      display: block;
+      float: right;
+    }
   }
 }
 
@@ -41,7 +44,7 @@
   }
 
   &.js-dismissible .govuk-notification__content {
-    padding-right: govuk-spacing(9);
+    padding-right: 120px;
   }
 }
 

--- a/app/frontend/src/styles/application.scss
+++ b/app/frontend/src/styles/application.scss
@@ -18,7 +18,7 @@ $govuk-image-url-function: frontend-image-url;
 
 @import 'application/accordion';
 @import 'application/banners';
-@import 'application/dashboard';
+@import 'application/full-width-mast';
 @import 'application/form';
 @import 'application/icons';
 @import 'application/modal';
@@ -65,21 +65,18 @@ body {
   }
 
   .govuk-main-wrapper {
-    @include dashboard;
-  }
+    background-color: govuk-colour('light-grey');
+    margin-bottom: govuk-spacing(6);
+    padding-bottom: 0;
+    padding-top: 0;
 
-  &.vacancies_index,
-  &.vacancies_show,
-  &.home_index {
-    .govuk-main-wrapper {
-      > .govuk-width-container {
-        margin-bottom: govuk-spacing(6);
-        margin-top: 0;
+    .content-wrapper {
+      background-color: govuk-colour('white');
+    }
 
-        > .govuk-grid-row {
-          margin-top: govuk-spacing(4);
-        }
-      }
+    h1,
+    .govuk-heading-xl {
+      margin-top: govuk-spacing(4);
     }
   }
 
@@ -111,8 +108,4 @@ p {
 strong,
 b {
   font-weight: bold;
-}
-
-.govuk-back-link {
-  margin-top: 0;
 }

--- a/app/frontend/src/styles/application/full-width-mast.scss
+++ b/app/frontend/src/styles/application/full-width-mast.scss
@@ -1,4 +1,4 @@
-@mixin dashboard {
+@mixin full-width-mast {
   left: 50%;
   margin-left: -50vw;
   padding-bottom: 0;

--- a/app/frontend/src/styles/application/jobseekers/jobseeker.scss
+++ b/app/frontend/src/styles/application/jobseekers/jobseeker.scss
@@ -1,41 +1,22 @@
 .jobseeker {
-  &.jobseekers_sessions_new {
+  &[class*='subscriptions_'],
+  &[class*='vacancies_'] {
     .govuk-main-wrapper {
-      > .govuk-width-container {
-        margin-top: govuk-spacing(4);
-      }
+      background-color: govuk-colour('white');
     }
   }
 
-  &.publishers_sessions_new,
-  &.jobseekers_saved_jobs_index,
-  &.jobseekers_subscriptions_index,
-  &.jobseekers_accounts_show,
-  &[class*='jobseekers_job_applications_'] {
+  &.jobseekers_subscriptions_index {
     .govuk-main-wrapper {
-      > .govuk-width-container {
-        margin-top: 0;
-
-        > .govuk-grid-row {
-          margin-top: govuk-spacing(4);
-        }
-      }
-    }
-
-    .govuk-main-wrapper__notification {
       background-color: govuk-colour('light-grey');
     }
+  }
 
-    .moj-filter-layout__content {
-      overflow-x: hidden;
-    }
-
-    .create-alert__button {
-      text-align: right;
-
-      .govuk-button {
-        margin-bottom: 0;
-      }
-    }
+  .create-alert__button {
+    text-align: right;
+  }
+  
+  .moj-filter-layout__content {
+    overflow-x: hidden;
   }
 }

--- a/app/frontend/src/styles/application/publishers/publisher.scss
+++ b/app/frontend/src/styles/application/publishers/publisher.scss
@@ -21,7 +21,6 @@ $desktop-container-width: 1200px;
     .govuk-main-wrapper {
       > .govuk-width-container {
         margin-top: 0;
-
       }
     }
 

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -60,12 +60,12 @@ html.govuk-template.app-html-class lang="en"
             | This is a new service - #{govuk_link_to "your feedback", new_feedback_path} will help us to improve it.
 
       main.govuk-main-wrapper#main-content role="main"
-        - unless flash.empty?
+        - flash.each do |style, message|
           .govuk-main-wrapper__notification
             .govuk-width-container
-              = render "shared/components/notification"
+              = render(Shared::NotificationComponent.new(content: message, style: style))
 
-        .govuk-width-container
+        .content-wrapper
           = yield
 
       = content_for :after_main

--- a/app/views/publishers/vacancies/documents/destroy.html.slim
+++ b/app/views/publishers/vacancies/documents/destroy.html.slim
@@ -1,1 +1,2 @@
-= render "shared/components/notification"
+- flash.each do |style, message|
+  = render(Shared::NotificationComponent.new(content: message, style: style))

--- a/app/views/shared/components/_notification.html.slim
+++ b/app/views/shared/components/_notification.html.slim
@@ -1,2 +1,0 @@
-- flash.each do |style, message|
-  = render(Shared::NotificationComponent.new(content: message, style: style))

--- a/spec/page_objects/jobseekers/account.rb
+++ b/spec/page_objects/jobseekers/account.rb
@@ -3,7 +3,7 @@ module PageObjects
     class Account < SitePrism::Page
       set_url "/jobseekers/account"
 
-      section :dashboard_header, ".dashboard-component__header" do
+      section :dashboard_header, ".dashboard-component" do
         element :email, "h2.govuk-heading-m"
         section :nav, ".moj-primary-navigation__list" do
           elements :links, ".moj-primary-navigation__link"


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-2141

this fixes 2 things

- the padding on all pages this is now not done with a controller overide but just using default containers and the only padding is applied to all page titles. basically a load of weird margin overides for controllers have been removed and this feels like right thing to do as it was too brittle
- The notification component causes complications with background colours and so this has been refactored including use of a renamed `dashboard` -> `full-width-mast` mixin that is used only for this full width with a background
- removes pointless `shared/components/notification` partial
- markup slightly altered in notifications so the dismiss link is positioned correctly (its actually teva-2145 in same PR)
