### PR TITLE
Add one word to translation

### DIFF
--- a/config/locales/notifications.yml
+++ b/config/locales/notifications.yml
@@ -31,7 +31,7 @@ en:
           draft_html: >-
             You have already started an application for %{job_title}.
             <a href="%{link}" class="govuk-link">Continue application</a>
-          submitted: You have applied for %{job_title}
+          submitted: You have already applied for %{job_title}.
         employment_history:
           deleted: Your employment history was deleted
         references:


### PR DESCRIPTION
There were two conflicting versions of this text on the Figma. I personally prefer the version that includes 'already'. The below is a screenshot of my preferred version.

<img width="364" alt="Screenshot 2021-03-04 at 10 14 59" src="https://user-images.githubusercontent.com/60350599/109981726-17a01480-7cf9-11eb-8f56-c221c5854fae.png">
