### PR TITLE
Upgrade README.md on chromedriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,6 @@ which chromedriver
 xattr -d com.apple.quarantine /path/to/chromedriver
 ```
 
-If this has no effect, you may need to try another path, for example: `/usr/local/bin/chromedriver`
-
 ### AWS credentials, MFA, and role profiles
 
 When onboarded, you will be provided with an AWS user. You can use it to access the AWS console at:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ brew install --cask chromedriver
 
 To update
 ```bash
-brew update --cask chromedriver
+brew upgrade --cask chromedriver
 ```
 
 On macOS you might need to "un-quarantine" chromedriver too

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ which chromedriver
 xattr -d com.apple.quarantine /path/to/chromedriver
 ```
 
+If this has no effect, you may need to try another path, for example: `/usr/local/bin/chromedriver`
+
 ### AWS credentials, MFA, and role profiles
 
 When onboarded, you will be provided with an AWS user. You can use it to access the AWS console at:


### PR DESCRIPTION
This is because I had the following issue:

> brew update --cask chromedriver

> Error: This command updates brew itself, and does not take formula names.
> Use brew upgrade --cask chromedriver instead.
