### PR TITLE
Allow jobseekers to delete a draft application

### DIFF
--- a/app/controllers/jobseekers/job_applications_controller.rb
+++ b/app/controllers/jobseekers/job_applications_controller.rb
@@ -24,6 +24,18 @@ class Jobseekers::JobApplicationsController < Jobseekers::BaseController
     end
   end
 
+  def confirm_destroy
+    raise ActionController::RoutingError, "Cannot delete non-draft application" unless job_application.draft?
+  end
+
+  def destroy
+    raise ActionController::RoutingError, "Cannot delete non-draft application" unless job_application.draft?
+
+    job_application.destroy
+    redirect_to jobseekers_job_applications_path,
+                success: t("messages.jobseekers.job_applications.draft_deleted", job_title: vacancy.job_title)
+  end
+
   private
 
   def job_application

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -17,7 +17,7 @@ class JobApplication < ApplicationRecord
   belongs_to :jobseeker
   belongs_to :vacancy
 
-  has_many :job_application_details
+  has_many :job_application_details, dependent: :destroy
   has_many :employment_history, -> { where(details_type: "employment_history") }, class_name: "JobApplicationDetail"
   has_many :references, -> { where(details_type: "references") }, class_name: "JobApplicationDetail"
 end

--- a/app/views/jobseekers/job_applications/confirm_destroy.html.slim
+++ b/app/views/jobseekers/job_applications/confirm_destroy.html.slim
@@ -1,0 +1,11 @@
+- content_for :page_title_prefix, t(".title")
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    .govuk-caption-l class="govuk-!-margin-top-5" = t("jobseekers.job_applications.heading_component.caption", job_title: vacancy.job_title, organisation_name: vacancy.parent_organisation_name)
+    h1.govuk-heading-l = t(".heading")
+    p.govuk-heading-s = t(".confirmation_heading")
+    p.govuk-body = t(".confirmation_details")
+    = govuk_button_to t(".confirm"), jobseekers_job_application_path(job_application), method: :delete, class: "govuk-button--warning govuk-!-margin-bottom-3"
+    p.govuk-body
+      = govuk_link_to t(".cancel"), jobseekers_job_applications_path, class: "govuk-link--no-visited-state"

--- a/app/views/jobseekers/job_applications/index.html.slim
+++ b/app/views/jobseekers/job_applications/index.html.slim
@@ -24,7 +24,7 @@
 
               - card.actions do
                 = tag.div(govuk_link_to(t(".continue_application"), jobseekers_job_application_review_path(draft_application)))
-                = tag.div(govuk_link_to(t("buttons.delete"), "#"))
+                = tag.div(govuk_link_to(t("buttons.delete"), jobseekers_job_application_confirm_destroy_path(draft_application)))
 
           - current_jobseeker.job_applications.includes(:vacancy).order(submitted_at: :desc).submitted.each do |submitted_application|
             = render Shared::CardComponent.new do |card|

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -212,6 +212,15 @@ en:
           body: We have sent an email confirmation to %{email}
           title: Your application has been submitted
         title: Application submitted – Application
+      confirm_destroy:
+        title: Delete draft
+        heading: Delete draft
+        confirmation_heading: Are you sure you want to delete your draft application?
+        confirmation_details: |
+          Your draft application will be permanently deleted. After this if you want to apply
+          for this job you will need to start a new application.
+        confirm: Delete draft
+        cancel: Keep draft
     passwords:
       check_your_email_password:
         description: We have sent you an email with instructions on how to reset your password.

--- a/config/locales/notifications.yml
+++ b/config/locales/notifications.yml
@@ -37,6 +37,7 @@ en:
         references:
           deleted: Your reference was deleted
         saved: Your job application was saved
+        draft_deleted: Your draft application for %{job_title} has been deleted
     subscriptions:
       created: Email subscription created successfully.
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,11 +27,12 @@ Rails.application.routes.draw do
     end
 
     constraints(-> { JobseekerApplicationsFeature.enabled? }) do
-      resources :job_applications, only: %i[index show] do
+      resources :job_applications, only: %i[index show destroy] do
         resources :build, only: %i[show update], controller: "job_applications/build" do
           resources :details, only: %i[new create edit update destroy], controller: "job_applications/details"
         end
         get :review
+        get :confirm_destroy
         post :submit
         resource :feedback, only: %i[create], controller: "job_applications/feedbacks"
       end

--- a/spec/requests/jobseekers/job_applications_spec.rb
+++ b/spec/requests/jobseekers/job_applications_spec.rb
@@ -34,4 +34,45 @@ RSpec.describe "Job applications", type: :request do
       end
     end
   end
+
+  describe "GET #confirm_destroy" do
+    context "when the application is a draft" do
+      let!(:job_application) { create(:job_application, jobseeker: jobseeker, vacancy: vacancy) }
+
+      it "shows a confirmation page" do
+        expect(get(jobseekers_job_application_confirm_destroy_path(job_application.id))).to render_template(:confirm_destroy)
+      end
+    end
+
+    context "when the application is not a draft" do
+      let!(:job_application) { create(:job_application, status: :submitted, jobseeker: jobseeker, vacancy: vacancy) }
+
+      it "raises an error" do
+        expect { get(jobseekers_job_application_confirm_destroy_path(job_application.id)) }.to raise_error(ActionController::RoutingError, /non-draft/)
+      end
+    end
+  end
+
+  describe "DELETE #destroy" do
+    context "when the application is a draft" do
+      let!(:job_application) { create(:job_application, jobseeker: jobseeker, vacancy: vacancy) }
+
+      it "deletes the application" do
+        expect { delete(jobseekers_job_application_path(job_application.id)) }.to change { JobApplication.count }.by(-1)
+      end
+
+      it "redirects back to the index of applications" do
+        expect(delete(jobseekers_job_application_path(job_application.id))).to redirect_to(jobseekers_job_applications_path)
+      end
+    end
+
+    context "when the application is not a draft" do
+      let!(:job_application) { create(:job_application, status: :submitted, jobseeker: jobseeker, vacancy: vacancy) }
+
+      it "raises an error and does not delete the application" do
+        expect { delete(jobseekers_job_application_path(job_application.id)) }.to raise_error(ActionController::RoutingError, /non-draft/)
+        expect(JobApplication.count).to eq(1)
+      end
+    end
+  end
 end

--- a/spec/system/jobseekers_can_delete_a_draft_job_application_spec.rb
+++ b/spec/system/jobseekers_can_delete_a_draft_job_application_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe "Jobseekers can delete a draft job application" do
+  let(:jobseeker) { create(:jobseeker) }
+  let(:organisation) { create(:school) }
+  let(:vacancy) { create(:vacancy, organisation_vacancies_attributes: [{ organisation: organisation }]) }
+  let!(:job_application) { create(:job_application, jobseeker: jobseeker, vacancy: vacancy) }
+
+  before do
+    allow(JobseekerApplicationsFeature).to receive(:enabled?).and_return(true)
+    login_as(jobseeker, scope: :jobseeker)
+  end
+
+  it "allows deleting the draft permanently" do
+    visit jobseekers_job_applications_path
+
+    click_on I18n.t("buttons.delete")
+    click_on I18n.t("jobseekers.job_applications.confirm_destroy.confirm")
+
+    expect(page).to have_content(I18n.t("messages.jobseekers.job_applications.draft_deleted", job_title: vacancy.job_title))
+    expect(JobApplication.count).to be_zero
+  end
+end


### PR DESCRIPTION
- Add confirmation page and destroy action for job applications
- Raise routing errors (=> 404) if these are accessed for non-draft
  applications

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2030