### PR TITLE
Add vacancy helper, and use jobseeker_root_path helper

### DIFF
--- a/app/components/shared/navbar_component/navbar_component.html.slim
+++ b/app/components/shared/navbar_component/navbar_component.html.slim
@@ -14,8 +14,8 @@ nav
       li.navbar-component__navigation-item--left class=active_link_class(root_path)
         = link_to t("nav.find_job"), root_path, class: "govuk-header__link"
       - if jobseeker_signed_in?
-        li.navbar-component__navigation-item--left class=active_link_class(jobseekers_saved_jobs_path)
-          = link_to t("footer.your_account"), jobseekers_saved_jobs_path, class: "govuk-header__link"
+        li.navbar-component__navigation-item--left class=active_link_class(jobseeker_root_path)
+          = link_to t("footer.your_account"), jobseeker_root_path, class: "govuk-header__link"
         li.navbar-component__navigation-spacer aria-hidden="true" tab-index="-1"
         li.navbar-component__navigation-item--right class=active_link_class(destroy_jobseeker_session_path)
           = button_to t("nav.sign_out"), destroy_jobseeker_session_path, method: :delete, class: "govuk-header__link"

--- a/app/controllers/jobseekers/confirmations_controller.rb
+++ b/app/controllers/jobseekers/confirmations_controller.rb
@@ -7,7 +7,7 @@ class Jobseekers::ConfirmationsController < Devise::ConfirmationsController
   def after_confirmation_path_for(resource_name, resource)
     sign_in(resource)
     request_event.trigger(:jobseeker_email_confirmed)
-    stored_location_for(resource_name) || jobseekers_saved_jobs_path
+    stored_location_for(resource_name) || jobseeker_root_path
   end
 
   def after_resending_confirmation_instructions_path_for(_resource)

--- a/app/controllers/jobseekers/job_applications/build_controller.rb
+++ b/app/controllers/jobseekers/job_applications/build_controller.rb
@@ -19,7 +19,7 @@ class Jobseekers::JobApplications::BuildController < Jobseekers::BaseController
     if params[:commit] == t("buttons.save_as_draft")
       job_application.assign_attributes(application_data: application_data.merge(form_params))
       job_application.save
-      redirect_to jobseekers_saved_jobs_path, success: t("messages.jobseekers.job_applications.saved")
+      redirect_to jobseeker_root_path, success: t("messages.jobseekers.job_applications.saved")
     elsif @form.valid?
       job_application.assign_attributes(
         application_data: application_data.merge(form_params),

--- a/app/controllers/jobseekers/job_applications/build_controller.rb
+++ b/app/controllers/jobseekers/job_applications/build_controller.rb
@@ -4,7 +4,7 @@ class Jobseekers::JobApplications::BuildController < Jobseekers::BaseController
 
   steps :personal_details, :professional_status, :employment_history, :personal_statement, :references, :equal_opportunities, :ask_for_support, :declarations
 
-  helper_method :back_link_path, :employment_history_info, :job_application, :process_steps, :reference_info
+  helper_method :back_link_path, :employment_history_info, :job_application, :process_steps, :reference_info, :vacancy
 
   def show
     @form = FORMS[step].new unless step == "wicked_finish"
@@ -36,7 +36,7 @@ class Jobseekers::JobApplications::BuildController < Jobseekers::BaseController
   def back_link_path
     @back_link_path ||= case step
                         when :personal_details
-                          new_jobseekers_job_job_application_path(job_application.vacancy.id)
+                          new_jobseekers_job_job_application_path(vacancy.id)
                         else
                           previous_wizard_path
                         end
@@ -56,5 +56,9 @@ class Jobseekers::JobApplications::BuildController < Jobseekers::BaseController
 
   def process_steps
     @process_steps ||= ProcessSteps.new(steps: steps_config, adjust: 0, step: step)
+  end
+
+  def vacancy
+    @vacancy ||= job_application.vacancy
   end
 end

--- a/app/views/home/_signed_in_jobseeker.html.slim
+++ b/app/views/home/_signed_in_jobseeker.html.slim
@@ -3,6 +3,6 @@ h2.govuk-heading-m = t(".title")
 p = t(".description")
 
 - if current_variant?(:"2012_02_jobseeker_account_cta_test", :colour)
-  = govuk_link_to t("buttons.view_account"), jobseekers_saved_jobs_path, class: "govuk-!-margin-bottom-0", button: true
+  = govuk_link_to t("buttons.view_account"), jobseeker_root_path, class: "govuk-!-margin-bottom-0", button: true
 - else
-  = govuk_link_to t("buttons.view_account"), jobseekers_saved_jobs_path, class: "govuk-button--secondary govuk-!-margin-bottom-0", button: true
+  = govuk_link_to t("buttons.view_account"), jobseeker_root_path, class: "govuk-button--secondary govuk-!-margin-bottom-0", button: true

--- a/app/views/jobseekers/job_applications/build/ask_for_support.html.slim
+++ b/app/views/jobseekers/job_applications/build/ask_for_support.html.slim
@@ -1,6 +1,6 @@
 - content_for :page_title_prefix, t(".title")
 
-= render(Jobseekers::JobApplications::HeadingComponent.new(vacancy: job_application.vacancy, back_path: back_link_path))
+= render(Jobseekers::JobApplications::HeadingComponent.new(vacancy: vacancy, back_path: back_link_path))
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
@@ -26,4 +26,4 @@
       = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"
 
   .govuk-grid-column-one-third
-    = render(Shared::ProcessStepsComponent.new(process: job_application.vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))
+    = render(Shared::ProcessStepsComponent.new(process: vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))

--- a/app/views/jobseekers/job_applications/build/declarations.html.slim
+++ b/app/views/jobseekers/job_applications/build/declarations.html.slim
@@ -1,6 +1,6 @@
 - content_for :page_title_prefix, t(".title")
 
-= render(Jobseekers::JobApplications::HeadingComponent.new(vacancy: job_application.vacancy, back_path: back_link_path))
+= render(Jobseekers::JobApplications::HeadingComponent.new(vacancy: vacancy, back_path: back_link_path))
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
@@ -12,7 +12,7 @@
 
       = f.govuk_collection_radio_buttons :banned_or_disqualified, %w[yes no], :to_s, :capitalize, inline: true
 
-      = f.govuk_radio_buttons_fieldset :close_relationships, legend: { text: t("helpers.legend.jobseekers_job_application_declarations_form.close_relationships", organisation: job_application.vacancy.organisation.name) } do
+      = f.govuk_radio_buttons_fieldset :close_relationships, legend: { text: t("helpers.legend.jobseekers_job_application_declarations_form.close_relationships", organisation: vacancy.organisation.name) } do
         = f.govuk_radio_button :close_relationships, :yes, link_errors: true do
           = f.govuk_text_field :close_relationships_details
         = f.govuk_radio_button :close_relationships, :no
@@ -23,4 +23,4 @@
       = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"
 
   .govuk-grid-column-one-third
-    = render(Shared::ProcessStepsComponent.new(process: job_application.vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))
+    = render(Shared::ProcessStepsComponent.new(process: vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))

--- a/app/views/jobseekers/job_applications/build/employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/build/employment_history.html.slim
@@ -1,6 +1,6 @@
 - content_for :page_title_prefix, t(".title")
 
-= render(Jobseekers::JobApplications::HeadingComponent.new(vacancy: job_application.vacancy, back_path: back_link_path))
+= render(Jobseekers::JobApplications::HeadingComponent.new(vacancy: vacancy, back_path: back_link_path))
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
@@ -28,4 +28,4 @@
       = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"
 
   .govuk-grid-column-one-third
-    = render(Shared::ProcessStepsComponent.new(process: job_application.vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))
+    = render(Shared::ProcessStepsComponent.new(process: vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))

--- a/app/views/jobseekers/job_applications/build/equal_opportunities.html.slim
+++ b/app/views/jobseekers/job_applications/build/equal_opportunities.html.slim
@@ -1,6 +1,6 @@
 - content_for :page_title_prefix, t(".title")
 
-= render(Jobseekers::JobApplications::HeadingComponent.new(vacancy: job_application.vacancy, back_path: back_link_path))
+= render(Jobseekers::JobApplications::HeadingComponent.new(vacancy: vacancy, back_path: back_link_path))
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
@@ -64,4 +64,4 @@
       = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"
 
   .govuk-grid-column-one-third
-    = render(Shared::ProcessStepsComponent.new(process: job_application.vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))
+    = render(Shared::ProcessStepsComponent.new(process: vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))

--- a/app/views/jobseekers/job_applications/build/personal_details.html.slim
+++ b/app/views/jobseekers/job_applications/build/personal_details.html.slim
@@ -1,6 +1,6 @@
 - content_for :page_title_prefix, t(".title")
 
-= render(Jobseekers::JobApplications::HeadingComponent.new(vacancy: job_application.vacancy, back_path: back_link_path))
+= render(Jobseekers::JobApplications::HeadingComponent.new(vacancy: vacancy, back_path: back_link_path))
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
@@ -24,4 +24,4 @@
       = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"
 
   .govuk-grid-column-one-third
-    = render(Shared::ProcessStepsComponent.new(process: job_application.vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))
+    = render(Shared::ProcessStepsComponent.new(process: vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))

--- a/app/views/jobseekers/job_applications/build/personal_statement.html.slim
+++ b/app/views/jobseekers/job_applications/build/personal_statement.html.slim
@@ -1,6 +1,6 @@
 - content_for :page_title_prefix, t(".title")
 
-= render(Jobseekers::JobApplications::HeadingComponent.new(vacancy: job_application.vacancy, back_path: back_link_path))
+= render(Jobseekers::JobApplications::HeadingComponent.new(vacancy: vacancy, back_path: back_link_path))
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
@@ -27,4 +27,4 @@
       = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"
 
   .govuk-grid-column-one-third
-    = render(Shared::ProcessStepsComponent.new(process: job_application.vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))
+    = render(Shared::ProcessStepsComponent.new(process: vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))

--- a/app/views/jobseekers/job_applications/build/professional_status.html.slim
+++ b/app/views/jobseekers/job_applications/build/professional_status.html.slim
@@ -1,6 +1,6 @@
 - content_for :page_title_prefix, t(".title")
 
-= render(Jobseekers::JobApplications::HeadingComponent.new(vacancy: job_application.vacancy, back_path: back_link_path))
+= render(Jobseekers::JobApplications::HeadingComponent.new(vacancy: vacancy, back_path: back_link_path))
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
@@ -23,4 +23,4 @@
       = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"
 
   .govuk-grid-column-one-third
-    = render(Shared::ProcessStepsComponent.new(process: job_application.vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))
+    = render(Shared::ProcessStepsComponent.new(process: vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))

--- a/app/views/jobseekers/job_applications/build/references.html.slim
+++ b/app/views/jobseekers/job_applications/build/references.html.slim
@@ -1,6 +1,6 @@
 - content_for :page_title_prefix, t(".title")
 
-= render(Jobseekers::JobApplications::HeadingComponent.new(vacancy: job_application.vacancy, back_path: back_link_path))
+= render(Jobseekers::JobApplications::HeadingComponent.new(vacancy: vacancy, back_path: back_link_path))
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
@@ -24,4 +24,4 @@
       = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"
 
   .govuk-grid-column-one-third
-    = render(Shared::ProcessStepsComponent.new(process: job_application.vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))
+    = render(Shared::ProcessStepsComponent.new(process: vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))

--- a/app/views/jobseekers/job_applications/review.html.slim
+++ b/app/views/jobseekers/job_applications/review.html.slim
@@ -1,6 +1,6 @@
 - content_for :page_title_prefix, t(".title")
 
-= render(Jobseekers::JobApplications::HeadingComponent.new(vacancy: job_application.vacancy, back_path: jobseekers_job_application_build_path(job_application, :declarations)))
+= render(Jobseekers::JobApplications::HeadingComponent.new(vacancy: vacancy, back_path: jobseekers_job_application_build_path(job_application, :declarations)))
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/jobseekers/job_applications/review/_declarations.html.slim
+++ b/app/views/jobseekers/job_applications/review/_declarations.html.slim
@@ -6,7 +6,7 @@
       html_attributes: { id: "declarations_banned_or_disqualified" })
 
     - component.slot(:row,
-      key: t("helpers.legend.jobseekers_job_application_declarations_form.close_relationships", organisation: job_application.vacancy.organisation.name),
+      key: t("helpers.legend.jobseekers_job_application_declarations_form.close_relationships", organisation: vacancy.organisation.name),
       value: safe_join([tag.div(job_application.application_data["close_relationships"]&.capitalize, class: "govuk-body"),
                         tag.div(job_application.application_data["close_relationships_details"], class: "govuk-body")]),
       html_attributes: { id: "declarations_close_relationships" })

--- a/spec/system/jobseekers_can_change_email_spec.rb
+++ b/spec/system/jobseekers_can_change_email_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Jobseekers can change email" do
       visit first_link_from_last_mail
 
       expect(created_jobseeker.reload.email).to eq("new@email.com")
-      expect(current_path).to eq(jobseekers_saved_jobs_path)
+      expect(current_path).to eq(jobseeker_root_path)
       expect(page).to have_content(I18n.t("devise.confirmations.confirmed"))
     end
   end

--- a/spec/system/jobseekers_can_give_account_feedback_spec.rb
+++ b/spec/system/jobseekers_can_give_account_feedback_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Jobseekers can give account feedback" do
 
     before do
       login_as(jobseeker, scope: :jobseeker)
-      visit jobseekers_saved_jobs_path
+      visit jobseeker_root_path
     end
 
     it "submits account feedback and triggers a RequestEvent" do
@@ -22,7 +22,7 @@ RSpec.describe "Jobseekers can give account feedback" do
           user_anonymised_jobseeker_id: StringAnonymiser.new(jobseeker.id).to_s,
         ).and_data(comment: comment, rating: "somewhat_satisfied", feedback_type: "jobseeker_account")
 
-      expect(current_path).to eq(jobseekers_saved_jobs_path)
+      expect(current_path).to eq(jobseeker_root_path)
       expect(page).to have_content(I18n.t("jobseekers.account_feedbacks.create.success"))
     end
   end

--- a/spec/system/jobseekers_can_save_a_job_application_spec.rb
+++ b/spec/system/jobseekers_can_save_a_job_application_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Jobseekers can save a job application" do
         "national_insurance_number" => "AB 12 12 12 A",
       },
     )
-    expect(current_path).to eq(jobseekers_saved_jobs_path)
+    expect(current_path).to eq(jobseeker_root_path)
     expect(page).to have_content(I18n.t("messages.jobseekers.job_applications.saved"))
   end
 end

--- a/spec/system/jobseekers_can_sign_in_to_their_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_in_to_their_account_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Jobseekers can sign in to their account" do
 
     it "signs in the jobseeker" do
       sign_in_jobseeker(email: email, password: password)
-      expect(current_path).to eq(jobseekers_saved_jobs_path)
+      expect(current_path).to eq(jobseeker_root_path)
       expect(page).to have_content(I18n.t("devise.sessions.signed_in"))
     end
 
@@ -103,7 +103,7 @@ RSpec.describe "Jobseekers can sign in to their account" do
     it "does not sign in the jobseeker, displays error messages, then signs in the jobseeker" do
       sign_in_jobseeker(email: email, password: password)
       sign_in_jobseeker(email: email, password: jobseeker.password)
-      expect(current_path).to eq(jobseekers_saved_jobs_path)
+      expect(current_path).to eq(jobseeker_root_path)
       expect(page).to have_content(I18n.t("devise.sessions.signed_in"))
     end
   end

--- a/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
@@ -24,11 +24,11 @@ RSpec.describe "Jobseekers can sign up to an account" do
     end
 
     context "when the confirmation token is valid" do
-      it "confirms email, triggers email confirmed event and redirects to saved jobs page" do
+      it "confirms email, triggers email confirmed event and redirects to jobseeker root page" do
         expect { visit first_link_from_last_mail }.to have_triggered_event(:jobseeker_email_confirmed).with_base_data(
           user_anonymised_jobseeker_id: StringAnonymiser.new(created_jobseeker.id).to_s,
         )
-        expect(current_path).to eq(jobseekers_saved_jobs_path)
+        expect(current_path).to eq(jobseeker_root_path)
         expect(page).to have_content(I18n.t("devise.confirmations.confirmed"))
       end
     end

--- a/spec/system/jobseekers_session_timeout_spec.rb
+++ b/spec/system/jobseekers_session_timeout_spec.rb
@@ -9,24 +9,24 @@ RSpec.describe "Jobseekers session timeout" do
   end
 
   it "expires after the desired timeout period" do
-    visit jobseekers_saved_jobs_path
+    visit jobseeker_root_path
     expect(page).to have_content(jobseeker.email)
 
     travel(timeout_period + 10.seconds) do
-      visit jobseekers_saved_jobs_path
+      visit jobseeker_root_path
 
       expect(current_path).to eq(new_jobseeker_session_path)
     end
   end
 
   it "doesn't expire before the desired timeout period" do
-    visit jobseekers_saved_jobs_path
+    visit jobseeker_root_path
     expect(page).to have_content(jobseeker.email)
 
     travel(timeout_period - 10.seconds) do
-      visit jobseekers_saved_jobs_path
+      visit jobseeker_root_path
 
-      expect(current_path).to eq(jobseekers_saved_jobs_path)
+      expect(current_path).to eq(jobseeker_root_path)
       expect(page).to have_content(jobseeker.email)
     end
   end

--- a/spec/system/users_can_only_be_signed_in_to_one_type_of_account_spec.rb
+++ b/spec/system/users_can_only_be_signed_in_to_one_type_of_account_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "Users can only be signed in to one type of account" do
         visit new_jobseeker_session_path
         sign_in_jobseeker
 
-        expect(current_path).to eq(jobseekers_saved_jobs_path)
+        expect(current_path).to eq(jobseeker_root_path)
 
         visit organisation_path
         expect(current_path).to eq(new_identifications_path)
@@ -99,7 +99,7 @@ RSpec.describe "Users can only be signed in to one type of account" do
         visit new_jobseeker_session_path
         sign_in_jobseeker
 
-        expect(current_path).to eq(jobseekers_saved_jobs_path)
+        expect(current_path).to eq(jobseeker_root_path)
 
         visit organisation_path
         expect(current_path).to eq(new_auth_email_path)


### PR DESCRIPTION
## Changes in this PR:

- Add helper_method 'vacancy' to the BuildController, and replace the usage of job_application.vacancy to take advantage of this method in build views and review views.

- Use jobseeker_root_path helper. This would enable us to easily switch which page is the default root for jobseekers in the future by moving `as: :jobseeker_root` within routes.rb.