### PR TITLE
[TEVA-2072] Add create an account prompt to subscription confirmation email

### DIFF
--- a/app/mailers/subscription_mailer.rb
+++ b/app/mailers/subscription_mailer.rb
@@ -1,5 +1,5 @@
 class SubscriptionMailer < ApplicationMailer
-  helper_method :subscription
+  helper_method :subscription, :jobseeker
 
   def confirmation(subscription_id)
     @subscription_id = subscription_id

--- a/app/views/subscription_mailer/confirmation.text.erb
+++ b/app/views/subscription_mailer/confirmation.text.erb
@@ -7,6 +7,14 @@
 
 <%= t(".next_steps", frequency: t(".frequency.#{subscription.frequency}")) %>
 
-<%= t(".unsubscribe") %>
 ---
-<%= unsubscribe_link(subscription) %>
+
+<%- unless jobseeker.present? %>
+  # <%= t(".create_account.heading") %>
+  <%= t(".create_account.intro", link_to: sign_up_link(subscription)) %>
+
+  ---
+
+<% end %>
+
+<%= t(".unsubscribe", unsubscribe_link: unsubscribe_link(subscription)) %>

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -5,9 +5,9 @@ en:
         You have set to receive this job alert %{frequency} when any jobs matching your criteria are listed.
       closing_date: "Closing date: %{closing_date}"
       create_account:
-        heading: Create an account
-        intro: "%{link_to} to see all your job alerts in one place, and save the jobs you're interested in"
-        link: Set up a Teaching Vacancies account
+        heading: Create a Teaching Vacancies account
+        intro: "%{link_to} to see all your job alerts in one place, and save the jobs you are interested in"
+        link: Create an account
       edit_alert: You can %{edit_link} here.
       edit_link_text: manage your alert
       feedback:
@@ -87,6 +87,10 @@ en:
 
   subscription_mailer:
     confirmation:
+      create_account:
+        heading: Create a Teaching Vacancies account
+        intro: "%{link_to} to see all your job alerts in one place, and save the jobs you are interested in"
+        link: Create an account
       frequency:
         daily: at the end of the day (at around 3 pm)
         weekly: weekly (at around 6 pm on Friday evening)
@@ -94,7 +98,7 @@ en:
         You’ll receive a job alert %{frequency} when a job matching your criteria is listed.
       subject: Teaching Vacancies job alert confirmation
       title: You have subscribed to a job alert from Teaching Vacancies
-      unsubscribe: You can unsubscribe by following the link at the bottom of these emails.
+      unsubscribe: Don’t want to receive these email alerts? %{unsubscribe_link}
       unsubscribe_link_text: Unsubscribe here
     update:
       frequency:

--- a/spec/mailers/subscription_mailer_spec.rb
+++ b/spec/mailers/subscription_mailer_spec.rb
@@ -59,6 +59,22 @@ RSpec.describe SubscriptionMailer, type: :mailer do
         expect { mail.deliver_now }.to have_triggered_event(:jobseeker_subscription_confirmation).with_data(expected_data)
       end
     end
+
+    describe "create account section" do
+      context "when the subscription email matches a jobseeker account" do
+        let!(:jobseeker) { create(:jobseeker, email: email) }
+
+        it "does not display create account section" do
+          expect(body).not_to include(I18n.t("subscription_mailer.confirmation.create_account.heading"))
+        end
+      end
+
+      context "when the subscription email does not match a jobseeker account" do
+        it "displays create account section" do
+          expect(body).to include(I18n.t("subscription_mailer.confirmation.create_account.heading"))
+        end
+      end
+    end
   end
 
   describe "#update" do


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-2072

## Changes in this PR
- Add create an account prompt section to email when jobseeker doesn't exist
- Update alert email typo
- Update subscription confirmation unsubscribe link to match alert email