### PR TITLE
Update text shown while browser finds user location

### DIFF
--- a/app/frontend/src/components/locationFinder/locationFinder.js
+++ b/app/frontend/src/components/locationFinder/locationFinder.js
@@ -15,7 +15,7 @@ export const ERROR_MESSAGE = 'Unable to find your location';
 export const LOGGING_MESSAGE = '[Module: locationFinder]: Unable to find user location';
 
 export const DEFAULT_PLACEHOLDER = 'City, town or postcode';
-export const LOADING_PLACEHOLDER = 'Finding Location...';
+export const LOADING_PLACEHOLDER = 'Requesting location...';
 
 export const startLoading = (container, input) => {
   input.disabled = true;


### PR DESCRIPTION
This text is only displayed for long enough to read it if the browser is taking longer than expected to find the location. permissions This probably means that the user has disabled location services in some settings (system-wide, browser, etc.) If location services are disabled, the current behaviour is that the wheel keeps spinning indefinitely and the text, misleadingly, says "finding location". If the text says "finding location", the user may take that to mean that the computer is performing the task correctly; "requesting" is more likely to hint to the user that the reason it has stalled is because of permissions.

This change will be checked with Content Design.

<img width="402" alt="Screenshot 2021-03-10 at 11 20 14" src="https://user-images.githubusercontent.com/60350599/110621945-bf529200-8192-11eb-9e0f-593eaf7eaae0.png">
