### PR TITLE
Create deployments role

### DIFF
--- a/documentation/aws-roles-and-cli-tools.md
+++ b/documentation/aws-roles-and-cli-tools.md
@@ -36,6 +36,8 @@ To carry out more privileged operations, you will need to [switch to a role](htt
 - `BillingManager` can:
   - access invoices and other billing information
   - read all resources
+- `Deployments` can:
+  - deploy apps and resources
 - `ReadOnly` can:
   - read all resources
 - `SecretEditor` can:

--- a/terraform/common/modules/domains/data.tf
+++ b/terraform/common/modules/domains/data.tf
@@ -6,3 +6,7 @@ data "aws_route53_zone" "zone" {
 data "aws_iam_user" "deploy" {
   user_name = "deploy"
 }
+
+data "aws_iam_role" "deployments" {
+  name = "deployments"
+}

--- a/terraform/common/modules/domains/iam.tf
+++ b/terraform/common/modules/domains/iam.tf
@@ -27,6 +27,11 @@ resource "aws_iam_user_policy_attachment" "route53_all" {
   policy_arn = aws_iam_policy.route53_all.arn
 }
 
+resource "aws_iam_role_policy_attachment" "route53_all" {
+  role       = data.aws_iam_role.deployments.name
+  policy_arn = aws_iam_policy.route53_all.arn
+}
+
 # Route53 specific hosted zones
 
 data "aws_iam_policy_document" "route53_hosted_zones" {
@@ -57,5 +62,10 @@ resource "aws_iam_policy" "route53_hosted_zones" {
 
 resource "aws_iam_user_policy_attachment" "route53_hosted_zones" {
   user       = data.aws_iam_user.deploy.user_name
+  policy_arn = aws_iam_policy.route53_hosted_zones.arn
+}
+
+resource "aws_iam_role_policy_attachment" "route53_hosted_zones" {
+  role       = data.aws_iam_role.deployments.name
   policy_arn = aws_iam_policy.route53_hosted_zones.arn
 }


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2161

## Changes in this PR:

- create deployers group
- allow members of deployers group to assume deployments role, without needing MFA
- attach existing policies associated with the deploy user to the deployments role
- support role and policy attachment in `common/modules/domains` 

## Testing

Add `deploy` user to Deployers group
With the keys for `deploy` user, assume the role
```
aws sts assume-role --role-arn arn:aws:iam::530003481352:role/Deployments --role-session-name deploy
```

## Future PR

- Use assumed role in CI/CD
- Remove direct policy attachments to the `deploy` user
