### PR TITLE
[TEVA-2033] Apply CTA Application Status

### DIFF
--- a/app/frontend/images/svg/icon-green-tick.svg
+++ b/app/frontend/images/svg/icon-green-tick.svg
@@ -1,0 +1,4 @@
+<svg width="25" height="26" viewBox="0 0 25 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <ellipse cx="12.5" cy="12.6363" rx="12.5" ry="12.6363" fill="#00823B"/>
+  <path d="M16.9991 7.61133L11.0692 13.4575L8.30185 10.7293L6.3252 12.678L11.0692 17.3549L18.9758 9.56005L16.9991 7.61133Z" fill="white"/>
+</svg>

--- a/app/frontend/src/styles/application/icons.scss
+++ b/app/frontend/src/styles/application/icons.scss
@@ -60,3 +60,7 @@
 .icon--cross {
   background-image: url('../../images/svg/icon-cross.svg');
 }
+
+.icon--green-tick {
+  background-image: url('../../images/svg/icon-green-tick.svg');
+}

--- a/app/views/shared/vacancy/_jobseeker_view.html.slim
+++ b/app/views/shared/vacancy/_jobseeker_view.html.slim
@@ -16,13 +16,29 @@
         h2.govuk-caption-l.job-caption class="govuk-!-margin-bottom-5 govuk-!-margin-top-0"
           = vacancy_job_location(@vacancy)
     .govuk-grid-row
-      - if JobseekerApplicationsFeature.enabled?
-        .govuk-grid-column-one-third
-          = render(Shared::BannerLinkComponent.new(icon_class: "apply",
-                                                   link_id: "apply-job-application",
-                                                   link_method: :get,
-                                                   link_path: new_jobseekers_job_job_application_path(@vacancy.id),
-                                                   link_text: t("jobseekers.job_applications.apply")))
+      - if JobseekerApplicationsFeature.enabled? && @vacancy.apply_through_teaching_vacancies&.downcase == "yes"
+        - case current_jobseeker&.job_applications&.find_by(vacancy_id: @vacancy.id)&.status
+        - when "submitted"
+            .govuk-grid-column-one-third
+              = render(Shared::BannerLinkComponent.new(icon_class: "green-tick",
+                                                       link_id: "apply-job-application",
+                                                       link_method: :get,
+                                                       link_path: jobseekers_job_application_path(current_jobseeker.job_applications.find_by(vacancy_id: @vacancy.id)),
+                                                       link_text: t("jobseekers.job_applications.banner_links.submitted")))
+        - when "draft"
+          .govuk-grid-column-one-third
+              = render(Shared::BannerLinkComponent.new(icon_class: "green-tick",
+                                                      link_id: "apply-job-application",
+                                                      link_method: :get,
+                                                      link_path: jobseekers_job_application_path(current_jobseeker.job_applications.find_by(vacancy_id: @vacancy.id)),
+                                                      link_text: t("jobseekers.job_applications.banner_links.draft")))
+        - else
+          .govuk-grid-column-one-third
+              = render(Shared::BannerLinkComponent.new(icon_class: "apply",
+                                                       link_id: "apply-job-application",
+                                                       link_method: :get,
+                                                       link_path: new_jobseekers_job_job_application_path(@vacancy.id),
+                                                       link_text: t("jobseekers.job_applications.banner_links.apply")))
 
       .govuk-grid-column-one-third
         / The "origin" param is used both for the back button on the subsequent page and for performance analysis.
@@ -32,13 +48,15 @@
                                                  link_path: new_subscription_path,
                                                  link_text: t("jobs.alert.similar.terse"),
                                                  params: { search_criteria: @devised_job_alert_search_criteria, origin: request.original_fullpath }))
-      .govuk-grid-column-one-third
-        = render(Shared::BannerLinkComponent.new(icon_class: @saved_job.present? ? "saved" : "save",
-                                                 link_id: "#{@saved_job.present? ? 'saved' : 'save'}-job-listing",
-                                                 link_method: @saved_job.present? ? :delete : :get,
-                                                 link_path: @saved_job.present? ? jobseekers_saved_job_path(@vacancy.id, @saved_job) : new_jobseekers_saved_job_path(@vacancy.id),
-                                                 params: { click_event: "vacancy_save_to_account_clicked" },
-                                                 link_text: t("jobseekers.saved_jobs.#{@saved_job.present? ? 'saved' : 'save'}")))
+
+      - if current_jobseeker&.job_applications&.find_by(vacancy_id: @vacancy.id).nil?
+        .govuk-grid-column-one-third
+          = render(Shared::BannerLinkComponent.new(icon_class: @saved_job.present? ? "saved" : "save",
+                                                  link_id: "#{@saved_job.present? ? 'saved' : 'save'}-job-listing",
+                                                  link_method: @saved_job.present? ? :delete : :get,
+                                                  link_path: @saved_job.present? ? jobseekers_saved_job_path(@vacancy.id, @saved_job) : new_jobseekers_saved_job_path(@vacancy.id),
+                                                  params: { click_event: "vacancy_save_to_account_clicked" },
+                                                  link_text: t("jobseekers.saved_jobs.#{@saved_job.present? ? 'saved' : 'save'}")))
 
 .govuk-grid-row
 

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -41,7 +41,10 @@ en:
       apply: Apply for this job
       applying_for_the_role_heading: Applying for the role
       applying_for_the_role_paragraph: Please complete the online application.
-      current_step: Step %{current} of %{total}
+      banner_links:
+        apply: Apply for this job
+        draft: Started - continue application
+        submitted: Submitted - view application
       build:
         ask_for_support:
           adjustments: "This could be:"
@@ -111,6 +114,7 @@ en:
           heading: References
           no_references: No referees specified
           title: References — Application
+      current_step: Step %{current} of %{total}
       details:
         employment_history: Role
         form:

--- a/spec/system/jobseekers_can_start_a_job_application_spec.rb
+++ b/spec/system/jobseekers_can_start_a_job_application_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Jobseekers can start a job application" do
           before { login_as(jobseeker, scope: :jobseeker) }
 
           context "when clicking apply on the job page" do
-            before { click_on I18n.t("jobseekers.job_applications.apply") }
+            before { click_on I18n.t("jobseekers.job_applications.banner_links.apply") }
 
             it "starts a job application" do
               expect(current_path).to eq(new_jobseekers_job_job_application_path(vacancy.id))
@@ -38,7 +38,7 @@ RSpec.describe "Jobseekers can start a job application" do
 
         context "when the jobseeker is not signed in" do
           context "when clicking apply on the job page" do
-            before { click_on I18n.t("jobseekers.job_applications.apply") }
+            before { click_on I18n.t("jobseekers.job_applications.banner_links.apply") }
 
             it "starts a job application after signing in" do
               expect(current_path).not_to eq(new_jobseekers_job_job_application_path(vacancy.id))
@@ -58,7 +58,7 @@ RSpec.describe "Jobseekers can start a job application" do
 
       context "when the jobseeker does not have an account" do
         context "when clicking apply on the job page" do
-          before { click_on I18n.t("jobseekers.job_applications.apply") }
+          before { click_on I18n.t("jobseekers.job_applications.banner_links.apply") }
 
           it "starts a job application after signing up" do
             expect(current_path).not_to eq(new_jobseekers_job_job_application_path(vacancy.id))
@@ -85,7 +85,7 @@ RSpec.describe "Jobseekers can start a job application" do
 
         before do
           login_as(jobseeker, scope: :jobseeker)
-          click_on I18n.t("jobseekers.job_applications.apply")
+          click_on I18n.t("jobseekers.job_applications.banner_links.apply")
         end
 
         it "redirects to job applications dashboard with correct message" do
@@ -105,7 +105,7 @@ RSpec.describe "Jobseekers can start a job application" do
 
         before do
           login_as(jobseeker, scope: :jobseeker)
-          click_on I18n.t("jobseekers.job_applications.apply")
+          click_on I18n.t("jobseekers.job_applications.banner_links.apply")
         end
 
         it "redirects to job applications dashboard with correct message" do


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2033

## Changes in this PR:

- Different values passed in to the button link component depending on the status of a jobseekers' application
- 'Apply for job' link now only rendered if the school have indicated that they would like jobseekers to be able to apply through teaching vacancies
- 'Save job' button link now only rendered if the jobseeker has not applied for the job

## Screenshots of UI changes:

###  Jobseeker not signed in

<img width="1228" alt="Screenshot 2021-03-10 at 16 13 31" src="https://user-images.githubusercontent.com/30624173/110660548-9266a500-81bb-11eb-96ef-c4684102b20e.png">

### Jobseeker Signed in

#### No Application

<img width="1227" alt="Screenshot 2021-03-10 at 16 14 29" src="https://user-images.githubusercontent.com/30624173/110660684-b4f8be00-81bb-11eb-9207-97ce16479cfb.png">

#### Application in draft

<img width="1254" alt="Screenshot 2021-03-10 at 16 18 58" src="https://user-images.githubusercontent.com/30624173/110661299-54b64c00-81bc-11eb-98a3-942ef9f687b5.png">

#### Application submitted

<img width="1250" alt="Screenshot 2021-03-10 at 16 23 54" src="https://user-images.githubusercontent.com/30624173/110662009-03f32300-81bd-11eb-8388-e10d445e0c44.png">
