### PR TITLE
Make publisher dashboard no-jobs text depend on filters

### DIFF
--- a/app/components/publishers/vacancies_component/vacancies_component.html.slim
+++ b/app/components/publishers/vacancies_component/vacancies_component.html.slim
@@ -25,4 +25,4 @@
 
           = f.govuk_submit t("jobs.sort_by.submit")
       section
-        = render "publishers/organisations/vacancies_#{@selected_type}", selected_type: @selected_type, organisation: @organisation, vacancies: @vacancies, sort: @sort, filters_form: @filters_form
+        = render "publishers/organisations/vacancies_#{@selected_type}", selected_type: @selected_type, organisation: @organisation, vacancies: @vacancies, sort: @sort, filters_form: @filters_form, no_jobs_text: no_jobs_text

--- a/app/views/publishers/organisations/_vacancies_awaiting_feedback.html.slim
+++ b/app/views/publishers/organisations/_vacancies_awaiting_feedback.html.slim
@@ -6,4 +6,4 @@
     - vacancies.each do |vacancy|
       = render "publishers/organisations/vacancy_awaiting_feedback", vacancy: vacancy, organisation: organisation
 - else
-  = render(Shared::NotificationComponent.new(content: { body: t("jobs.manage.awaiting_feedback.no_jobs") }, style: "empty", links: nil, dismiss: false, background: true, alert: false))
+  = render(Shared::NotificationComponent.new(content: { body: no_jobs_text }, style: "empty", links: nil, dismiss: false, background: true, alert: false))

--- a/app/views/publishers/organisations/_vacancies_draft.html.slim
+++ b/app/views/publishers/organisations/_vacancies_draft.html.slim
@@ -15,4 +15,4 @@
         = tag.div(govuk_link_to(t("jobs.manage.copy_link_text"), vacancy.copy_path))
         = tag.div(button_to(t("jobs.manage.delete_link_text"), vacancy.delete_path, method: :delete, data: { confirm: t("jobs.manage.are_you_sure", job_title: vacancy.job_title) }, class: "govuk-delete-link"))
 - else
-  = render(Shared::NotificationComponent.new(content: { body: t("jobs.manage.draft.no_jobs") }, style: "empty", links: nil, dismiss: false, background: true, alert: false))
+  = render(Shared::NotificationComponent.new(content: { body: no_jobs_text }, style: "empty", links: nil, dismiss: false, background: true, alert: false))

--- a/app/views/publishers/organisations/_vacancies_expired.html.slim
+++ b/app/views/publishers/organisations/_vacancies_expired.html.slim
@@ -14,4 +14,4 @@
         = tag.div(govuk_link_to(t("jobs.manage.copy_link_text"), vacancy.copy_path))
         = tag.div(button_to(t("jobs.manage.delete_link_text"), vacancy.delete_path, method: :delete, data: { confirm: t("jobs.manage.are_you_sure", job_title: vacancy.job_title) }, class: "govuk-delete-link"))
 - else
-  = render(Shared::NotificationComponent.new(content: { body: t("jobs.manage.expired.no_jobs") }, style: "empty", links: nil, dismiss: false, background: true, alert: false))
+  = render(Shared::NotificationComponent.new(content: { body: no_jobs_text }, style: "empty", links: nil, dismiss: false, background: true, alert: false))

--- a/app/views/publishers/organisations/_vacancies_pending.html.slim
+++ b/app/views/publishers/organisations/_vacancies_pending.html.slim
@@ -15,4 +15,4 @@
         = tag.div(govuk_link_to(t("jobs.manage.copy_link_text"), vacancy.copy_path))
         = tag.div(button_to(t("jobs.manage.delete_link_text"), vacancy.delete_path, method: :delete, data: { confirm: t("jobs.manage.are_you_sure", job_title: vacancy.job_title) }, class: "govuk-delete-link"))
 - else
-  = render(Shared::NotificationComponent.new(content: { body: t("jobs.manage.pending.no_jobs") }, style: "empty", links: nil, dismiss: false, background: true, alert: false))
+  = render(Shared::NotificationComponent.new(content: { body: no_jobs_text }, style: "empty", links: nil, dismiss: false, background: true, alert: false))

--- a/app/views/publishers/organisations/_vacancies_published.html.slim
+++ b/app/views/publishers/organisations/_vacancies_published.html.slim
@@ -14,4 +14,4 @@
         = tag.div(govuk_link_to(t("jobs.manage.copy_link_text"), vacancy.copy_path))
         = tag.div(button_to(t("jobs.manage.delete_link_text"), vacancy.delete_path, method: :delete, data: { confirm: t("jobs.manage.are_you_sure", job_title: vacancy.job_title) }, class: "govuk-delete-link"))
 - else
-  = render(Shared::NotificationComponent.new(content: { body: t("jobs.manage.published.no_jobs") }, style: "empty", links: nil, dismiss: false, background: true, alert: false))
+  = render(Shared::NotificationComponent.new(content: { body: no_jobs_text }, style: "empty", links: nil, dismiss: false, background: true, alert: false))

--- a/app/views/publishers/vacancies/job_applications/show.html.slim
+++ b/app/views/publishers/vacancies/job_applications/show.html.slim
@@ -4,7 +4,7 @@
   .govuk-width-container
     .govuk-grid-row
       .govuk-grid-column-full
-        = govuk_breadcrumbs breadcrumbs: { "#{t("jobs.published_jobs")}": jobs_with_type_organisation_path(:published),
+        = govuk_breadcrumbs breadcrumbs: { "#{t("publishers.vacancies_component.published.tab_heading")}": jobs_with_type_organisation_path(:published),
                                            "#{vacancy.job_title}": "",
                                            "#{job_application.application_data["first_name"]} #{job_application.application_data["last_name"]}": "" }
         .govuk-caption-l class="govuk-!-margin-top-5"

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -285,23 +285,33 @@ en:
         intro: >-
           Please tell us if you filled these expired jobs through Teaching Vacancies,
           and whether you listed them elsewhere. Your feedback will help us improve the service.
-        no_jobs: There are no jobs waiting for your feedback at the moment.
+        no_jobs:
+          no_filters: There are no jobs waiting for your feedback at the moment.
+          with_filters: There are no jobs waiting for your feedback for the schools you have selected.
       closing_date: Closing date
       copy_link_text: Copy listing
       delete_link_text: Delete
       draft:
-        no_jobs: You currently have no draft jobs.
+        no_jobs:
+          no_filters: You currently have no draft jobs.
+          with_filters: There are no draft jobs for the schools you have selected.
         time_created: Date drafted
         time_updated: Date last updated
       edit_link_text: Edit listing
       heading_html: "%{email} <span class='govuk-!-font-weight-regular'>- %{organisation}</span>"
       expired:
         expired_on: Expired on
-        no_jobs: You currently have no jobs that have passed the deadline.
+        no_jobs:
+          no_filters: You currently have no jobs that have passed the deadline.
+          with_filters: There are no jobs that have passed the deadline for the schools you have selected.
       pending:
-        no_jobs: You currently have no scheduled jobs.
+        no_jobs:
+          no_filters: You currently have no scheduled jobs.
+          with_filters: There are no scheduled jobs for the schools you have selected.
       published:
-        no_jobs: You currently have no published jobs.
+        no_jobs:
+          no_filters: You currently have no published jobs.
+          with_filters: There are no published jobs for the schools you have selected.
 
     date_listed: Date listed
     job_filled: Job filled on Teaching Vacancies?

--- a/spec/system/hiring_staff_can_add_stats_to_a_vacancy_spec.rb
+++ b/spec/system/hiring_staff_can_add_stats_to_a_vacancy_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe "Submitting effectiveness feedback on expired vacancies", js: tru
     scenario "hiring staff can not see notification badge" do
       visit jobs_with_type_organisation_path(type: :awaiting_feedback)
 
-      expect(page).to have_content(I18n.t("jobs.manage.awaiting_feedback.no_jobs"))
+      expect(page).to have_content(I18n.t("jobs.manage.awaiting_feedback.no_jobs.no_filters"))
     end
   end
 


### PR DESCRIPTION
And use private attr_readers where possible in VacanciesComponent, and refactor the spec thereof.

Previously, we displayed the text 'You currently have no [type] jobs', even when thatvwas not true, when the filters were applied such that there were no [type] jobs belonging to the filtered job locations.

This was deemed misleading.

Now, the text displayed when there are no jobs to display varies depending on whether any filters are applied.

This text has been reviewed by Content Design.

## Screenshots of UI changes:

<img width="1228" alt="Screenshot 2021-03-10 at 17 01 22" src="https://user-images.githubusercontent.com/60350599/110667551-44a16b00-81c2-11eb-86f1-a5eab00ebb53.png">

<img width="1228" alt="Screenshot 2021-03-10 at 17 00 36" src="https://user-images.githubusercontent.com/60350599/110667555-4703c500-81c2-11eb-8ef2-a253b92c881e.png">
