### PR TITLE
Improve "save as draft" for job applications

### DIFF
--- a/app/controllers/jobseekers/job_applications/build_controller.rb
+++ b/app/controllers/jobseekers/job_applications/build_controller.rb
@@ -19,7 +19,7 @@ class Jobseekers::JobApplications::BuildController < Jobseekers::BaseController
     if params[:commit] == t("buttons.save_as_draft")
       job_application.assign_attributes(application_data: application_data.merge(form_params))
       job_application.save
-      redirect_to jobseeker_root_path, success: t("messages.jobseekers.job_applications.saved")
+      redirect_to jobseekers_job_applications_path, success: t("messages.jobseekers.job_applications.saved")
     elsif @form.valid?
       job_application.assign_attributes(
         application_data: application_data.merge(form_params),

--- a/app/controllers/jobseekers/job_applications_controller.rb
+++ b/app/controllers/jobseekers/job_applications_controller.rb
@@ -17,7 +17,7 @@ class Jobseekers::JobApplicationsController < Jobseekers::BaseController
     return redirect_to expired_jobseekers_job_job_application_path(vacancy.id) unless vacancy.listed?
 
     if params[:commit] == t("buttons.save_as_draft")
-      redirect_to jobseeker_root_path, notice: "Application saved as draft"
+      redirect_to jobseekers_job_applications_path, success: t("messages.jobseekers.job_applications.saved")
     elsif review_form.valid?
       job_application.update(status: :submitted, submitted_at: Time.zone.now)
       JobseekerMailer.application_submitted(job_application).deliver_later

--- a/spec/system/jobseekers_can_save_a_job_application_spec.rb
+++ b/spec/system/jobseekers_can_save_a_job_application_spec.rb
@@ -2,7 +2,9 @@ require "rails_helper"
 
 RSpec.describe "Jobseekers can save a job application" do
   let(:jobseeker) { create(:jobseeker) }
-  let(:job_application) { create(:job_application, jobseeker: jobseeker) }
+  let(:organisation) { create(:school) }
+  let(:vacancy) { create(:vacancy, organisation_vacancies_attributes: [{ organisation: organisation }]) }
+  let(:job_application) { create(:job_application, vacancy: vacancy, jobseeker: jobseeker) }
 
   before do
     allow(JobseekerApplicationsFeature).to receive(:enabled?).and_return(true)
@@ -33,7 +35,7 @@ RSpec.describe "Jobseekers can save a job application" do
         "national_insurance_number" => "AB 12 12 12 A",
       },
     )
-    expect(current_path).to eq(jobseeker_root_path)
+    expect(current_path).to eq(jobseekers_job_applications_path)
     expect(page).to have_content(I18n.t("messages.jobseekers.job_applications.saved"))
   end
 end

--- a/spec/system/jobseekers_can_submit_a_job_application_spec.rb
+++ b/spec/system/jobseekers_can_submit_a_job_application_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe "Jobseekers can submit a job application" do
       click_on I18n.t("buttons.save_as_draft")
 
       expect(JobApplication.first.status).to eq("draft")
-      expect(page).to have_content("Application saved as draft")
-      expect(current_path).to eq(jobseeker_root_path)
+      expect(page).to have_content(I18n.t("messages.jobseekers.job_applications.saved"))
+      expect(current_path).to eq(jobseekers_job_applications_path)
     end
   end
 


### PR DESCRIPTION
- Redirect to the "My applications" page instead of "saved jobs"
- Consistently use draft saved translation
- Consistently use success flash message