### PR TITLE
Tidy up translations

### DIFF
--- a/app/components/jobseekers/account_survey_link_component.rb
+++ b/app/components/jobseekers/account_survey_link_component.rb
@@ -5,7 +5,7 @@ class Jobseekers::AccountSurveyLinkComponent < ViewComponent::Base
 
   def link_to_survey
     link_to(
-      I18n.t("jobseekers.accounts.footer.survey_link"),
+      t(".survey_link"),
       new_jobseekers_account_feedback_path(origin: @origin),
       id: "account-survey-link-sticky-gtm",
     )

--- a/app/components/jobseekers/account_survey_link_component/account_survey_link_component.html.slim
+++ b/app/components/jobseekers/account_survey_link_component/account_survey_link_component.html.slim
@@ -1,3 +1,3 @@
 .account-survey-cta
   .account-survey-cta__content class="govuk-heading-s govuk-!-font-weight-regular govuk-!-margin-0" id="account-survey-cta"
-    = t("jobseekers.accounts.footer.survey_text_html", link: link_to_survey)
+    = t(".survey_text_html", link: link_to_survey)

--- a/app/components/jobseekers/job_applications/heading_component/heading_component.html.slim
+++ b/app/components/jobseekers/job_applications/heading_component/heading_component.html.slim
@@ -3,5 +3,5 @@
     .govuk-grid-row
       .govuk-grid-column-full
         = govuk_back_link text: t("buttons.back"), href: back_path, classes: "govuk-!-margin-top-3"
-        .govuk-caption-l class="govuk-!-margin-top-5" = t("jobseekers.job_applications.heading_component.caption", job_title: vacancy.job_title, organisation_name: vacancy.parent_organisation_name)
-        h2.govuk-heading-xl class="govuk-!-margin-bottom-5" = t("jobseekers.job_applications.heading_component.heading")
+        .govuk-caption-l class="govuk-!-margin-top-5" = t(".caption", job_title: vacancy.job_title, organisation_name: vacancy.parent_organisation_name)
+        h2.govuk-heading-xl class="govuk-!-margin-bottom-5" = t(".heading")

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -1,9 +1,6 @@
 en:
   jobseekers:
     accounts:
-      footer:
-        survey_link: take our quick survey
-        survey_text_html: Spare some time to %{link} on your account experience with Teaching Vacancies.
       header:
         accessible_signed_in_as: You are signed in as
       show:
@@ -23,6 +20,9 @@ en:
         success: Thank you for your feedback
       new:
         title: Account survey
+    account_survey_link_component:
+      survey_link: take our quick survey
+      survey_text_html: Spare some time to %{link} on your account experience with Teaching Vacancies.
     confirmations:
       new:
         description: The link has expired. You need to request that a new link is sent to your email address (%{email}).

--- a/spec/system/jobseekers_can_give_account_feedback_spec.rb
+++ b/spec/system/jobseekers_can_give_account_feedback_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Jobseekers can give account feedback" do
     end
 
     it "submits account feedback and triggers a RequestEvent" do
-      click_on I18n.t("jobseekers.accounts.footer.survey_link")
+      click_on I18n.t("jobseekers.account_survey_link_component.survey_link")
 
       choose I18n.t("helpers.label.jobseekers_account_feedback_form.rating_options.somewhat_satisfied")
       fill_in "jobseekers_account_feedback_form[comment]", with: comment


### PR DESCRIPTION
Having discovered (with Connor's guess) how to scope translations for a component template, I started the tidy-up process.

Look, it hasn't broken everything:

<img width="780" alt="Screenshot 2021-03-11 at 13 58 22" src="https://user-images.githubusercontent.com/60350599/110798245-df0cb780-8271-11eb-9e74-2e3f2d2d3887.png">
<img width="469" alt="Screenshot 2021-03-11 at 13 58 04" src="https://user-images.githubusercontent.com/60350599/110798250-e03de480-8271-11eb-89ca-bd770d71a723.png">
