### PR TITLE
[TEVA-2166] - Terraform replace workspaces with well-named folders

### DIFF
--- a/.github/workflows/deploy_app.yml
+++ b/.github/workflows/deploy_app.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Set environment variables for review
       if: startsWith(github.event.inputs.environment, 'review')
       run: |
-        BACKEND_CONFIG=-backend-config="workspace_key_prefix=review:"
+        BACKEND_CONFIG=-backend-config="key=review/${{ github.event.inputs.environment }}.tfstate"
         PARAMETER_STORE_ENVIRONMENT=dev
         TF_VAR_environment=${{ github.event.inputs.environment }}
         VAR_FILE=review
@@ -62,6 +62,7 @@ jobs:
     - name: Set environment variables for non-review environments
       if: startsWith(github.event.inputs.environment, 'review') != true
       run: |
+        BACKEND_CONFIG=-backend-config="key=${{ github.event.inputs.environment }}/app.tfstate"
         PARAMETER_STORE_ENVIRONMENT=${{ github.event.inputs.environment }}
         VAR_FILE=${{ github.event.inputs.environment }}
         echo "PARAMETER_STORE_ENVIRONMENT=${PARAMETER_STORE_ENVIRONMENT}" >> $GITHUB_ENV
@@ -92,6 +93,5 @@ jobs:
       run: |
         export TF_VAR_paas_app_docker_image=${{ env.DOCKERHUB_REPOSITORY }}:${{ github.event.inputs.tag }}
         terraform init -reconfigure -input=false ${{ env.BACKEND_CONFIG }}
-        terraform workspace select ${{ github.event.inputs.environment }} || terraform workspace new ${{ github.event.inputs.environment }}
         terraform apply -var-file ../workspace-variables/${{ env.VAR_FILE }}.tfvars -auto-approve -input=false
       working-directory: terraform/app

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -67,10 +67,8 @@ jobs:
         TF_VAR_paas_password: ${{ secrets.CF_PASSWORD }}
       run: |
         export TF_VAR_environment=review-pr-${{ github.event.number }}
-        terraform init -reconfigure -input=false -backend-config="workspace_key_prefix=review:"
-        terraform workspace select review-pr-${{ github.event.number }} || terraform workspace new review-pr-${{ github.event.number }}
+        terraform init -reconfigure -input=false -backend-config="key=review/review-pr-${{ github.event.number }}.tfstate"
         terraform destroy -var-file ../workspace-variables/review.tfvars -auto-approve
-        terraform workspace select default && terraform workspace delete review-pr-${{ github.event.number }}
       working-directory: terraform/app
 
     - name: Send failure message to twd_tv_dev channel

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -40,8 +40,7 @@ jobs:
           TF_VAR_paas_user: ${{ secrets.CF_USERNAME }}
           TF_VAR_paas_password: ${{ secrets.CF_PASSWORD }}
         run: |
-          terraform init -reconfigure -input=false
-          terraform workspace select ${{ github.event.inputs.environment }}
+          terraform init -reconfigure -input=false -backend-config="key=${{ github.event.inputs.environment }}/app.tfstate"
           echo ::set-output name=tag::$(terraform output docker_tag)
         working-directory: terraform/app
 

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,8 @@ production: ## production # Requires `CONFIRM_PRODUCTION=true`
 .PHONY: qa
 qa: ## qa
 		$(eval env=qa)
-		$(eval var_file=qa)
+		$(eval var_file=$(env))
+		$(eval backend_config=-backend-config="key=$(env)/app.tfstate")
 
 ##@ Docker - build, tag, and push an image from local code. Requires Docker CLI
 

--- a/terraform/app/output.tf
+++ b/terraform/app/output.tf
@@ -7,8 +7,3 @@ output "docker_tag" {
   value       = module.paas.docker_tag
   description = "Docker tag"
 }
-
-
-output "workspace" {
-  value = terraform.workspace
-}

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -28,8 +28,8 @@ https://www.terraform.io/docs/state/purpose.html
 terraform {
 
   backend "s3" {
-    bucket  = "terraform-state-002"
-    key     = "tvs/terraform.tfstate" # When using workspaces this changes to ':env/{terraform.workspace}/tvs/terraform.tfstate'
+    bucket = "530003481352-terraform-state"
+    # When run interactively, should prompt for key. To specify environments, we pass to terraform init -backend-config="key=dev/app.tfstate"
     region  = "eu-west-2"
     encrypt = "true"
   }

--- a/terraform/common/data.tf
+++ b/terraform/common/data.tf
@@ -1,0 +1,5 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_s3_bucket" "terraform_state" {
+  bucket = "${data.aws_caller_identity.current.account_id}-terraform-state"
+}

--- a/terraform/common/s3.tf
+++ b/terraform/common/s3.tf
@@ -1,5 +1,3 @@
-data "aws_caller_identity" "current" {}
-
 resource "aws_s3_bucket" "db_backups" {
   bucket = "${data.aws_caller_identity.current.account_id}-tv-db-backups"
 

--- a/terraform/common/terraform.tf
+++ b/terraform/common/terraform.tf
@@ -5,8 +5,8 @@ provider "aws" {
 terraform {
 
   backend "s3" {
-    bucket  = "terraform-state-002"
-    key     = "tvs/terraform-common.tfstate"
+    bucket  = "530003481352-terraform-state"
+    key     = "production/common.tfstate" # Grouping under production, as to deploy these resources requires production/Administrator permissions
     region  = "eu-west-2"
     encrypt = "true"
   }

--- a/terraform/common/variables.tf
+++ b/terraform/common/variables.tf
@@ -1,7 +1,5 @@
 variable "region" { default = "eu-west-2" }
 
-variable "s3_bucket_name" { default = "terraform-state-002" }
-
 locals {
   # awslogsdelivery ID from https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html#AccessLogsBucketAndFileOwnership
   aws_canonical_user_id_awslogsdelivery = "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0"

--- a/terraform/monitoring/terraform.tf
+++ b/terraform/monitoring/terraform.tf
@@ -5,8 +5,8 @@ https://www.terraform.io/docs/state/purpose.html
 terraform {
 
   backend "s3" {
-    bucket  = "terraform-state-002"
-    key     = "tvs/terraform-monitoring.tfstate" # When using workspaces this changes to ':env/{terraform.workspace}/tvs/terraform.tfstate'
+    bucket  = "530003481352-terraform-state"
+    key     = "production/monitoring.tfstate" # Currently we only deploy a single production instance, monitoring all environments. We may want to deploy test monitoring instances in the future
     region  = "eu-west-2"
     encrypt = "true"
   }


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2166

## Changes in this PR:

- Removes the usage of the `terraform workspace` command
- Uses a new S3 bucket which contains the AWS organisation ID to minimise namespace collisions
- Deny `ReadOnly` role from being able to read the production terraform state
- Makefile - force the removal of the `.terraform.lock.hcl` file if present (allows running against different environments in quick succession)
- Group state files following the same convention for the AWS Parameter Store and allow for future refactoring of monitoring (to allow `staging\monitoring.tfstate`

```
production\app.tfstate
staging\app.tfstate
qa\app.tfstate
dev\app.tfstate
review\review-pr-3001.tfstate
production\monitoring.tfstate
production\common.tfstate
```

## Testing

See https://github.com/DFE-Digital/teaching-vacancies/runs/2183083228?check_suite_focus=true for the creation of the review app itself, with state file in the new location
```
/home/runner/work/_temp/d1914894-52e2-49f2-992c-5bd166617d94/terraform-bin init -reconfigure -input=false -backend-config=key=review/review-pr-3071.tfstate
```
and 
```
s3://530003481352-terraform-state/review/review-pr-3071.tfstate
```