### PR TITLE
[TEVA-2049] Add job for entity_imported events

### DIFF
--- a/app/jobs/send_entity_imported_events_to_data_warehouse_job.rb
+++ b/app/jobs/send_entity_imported_events_to_data_warehouse_job.rb
@@ -1,0 +1,47 @@
+class SendEntityImportedEventsToDataWarehouseJob < ApplicationJob
+  TABLE_NAME = "events".freeze
+
+  queue_as :low
+
+  self.logger = nil
+
+  def perform
+    bq = Google::Cloud::Bigquery.new
+    dataset = bq.dataset(ENV.fetch("BIG_QUERY_DATASET"), skip_lookup: true)
+    bq_table = dataset.table(TABLE_NAME, skip_lookup: true)
+
+    ApplicationRecord.connection.tables.each do |db_table|
+      next unless Rails.configuration.analytics.key?(db_table.to_sym)
+
+      Rails.logger.info("sending #{db_table.camelize.singularize.constantize.count} #{db_table} entity_imported events to bigquery")
+      db_table.camelize.singularize.constantize.find_in_batches(batch_size: 100) do |batch|
+        bq_table.insert(
+          batch.map do |record|
+            {
+              type: :entity_imported,
+              occurred_at: occurred_at(record),
+              data: record.send(:event_data).map { |key, value| { key: key.to_s, value: formatted_value(value) } },
+            }
+          end,
+        )
+      end
+    end
+  end
+
+  private
+
+  def formatted_value(value)
+    return value if value.is_a?(Float) || value.is_a?(Integer)
+
+    value.respond_to?(:keys) ? value.to_json : value&.to_s
+  end
+
+  def occurred_at(data)
+    time = if data[:created_at].present?
+             data[:created_at]
+           else
+             Time.now.utc
+           end
+    time.iso8601(6)
+  end
+end

--- a/spec/jobs/send_entity_imported_events_to_data_warehouse_job_spec.rb
+++ b/spec/jobs/send_entity_imported_events_to_data_warehouse_job_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe SendEntityImportedEventsToDataWarehouseJob, type: :job do
+  let!(:jobseeker) { create(:jobseeker) }
+  let!(:publisher) { create(:publisher) }
+  let(:big_query) { double("Bigquery") }
+  let(:dataset) { double("Dataset") }
+  let(:table) { double("Table") }
+
+  before do
+    allow(ENV).to receive(:fetch).with("BIG_QUERY_DATASET").and_return("test_dataset")
+    allow(Google::Cloud::Bigquery).to receive(:new).and_return(big_query)
+    allow(ApplicationRecord).to receive(:descendants).and_return([Jobseeker, Publisher])
+  end
+
+  describe "#perform" do
+    it "sends data to big query" do
+      expect(big_query).to receive(:dataset).with("test_dataset", skip_lookup: true).and_return(dataset)
+      expect(dataset).to receive(:table).with("events", skip_lookup: true).and_return(table)
+      expect(table).to receive(:insert)
+        .with([hash_including(type: :entity_imported, data: array_including({ key: "table_name", value: "jobseekers" }))])
+      expect(table).to receive(:insert)
+        .with([hash_including(type: :entity_imported, data: array_including({ key: "table_name", value: "publishers" }))])
+
+      subject.perform
+    end
+  end
+end

--- a/spec/sidekiq/sidekiq_spec.rb
+++ b/spec/sidekiq/sidekiq_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "Sidekiq configuration" do
       PersistVacancyGetMoreInfoClickJob
       PersistVacancyPageViewJob
       RemoveGoogleIndexQueueJob
+      SendEntityImportedEventsToDataWarehouseJob
       SendEventToDataWarehouseJob
       UpdateGoogleIndexQueueJob
     ]


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-2049

## Changes in this PR
- Add task to trigger `entity_imported` events for all records

## Next steps
- [x] Run task on dev/staging with production data
- [x] Figure out what to do with the job/volume of records/redis
- [ ] **After merge** run task on production