### PR TITLE
Improve password manager experience

### DIFF
--- a/app/views/jobseekers/registrations/_edit_password.html.slim
+++ b/app/views/jobseekers/registrations/_edit_password.html.slim
@@ -1,4 +1,4 @@
 p.govuk-body = t(".description", email: resource.email)
-= f.govuk_password_field :current_password, label: { text: t(".current_password"), size: "s" }, width: "two-thirds"
-= f.govuk_password_field :password, label: { text: t(".new_password"), size: "s" }, width: "two-thirds"
+= f.govuk_password_field :current_password, label: { text: t(".current_password"), size: "s" }, width: "two-thirds", autocomplete: "current-password"
+= f.govuk_password_field :password, label: { text: t(".new_password"), size: "s" }, width: "two-thirds", autocomplete: "new-password"
 = f.govuk_submit t("buttons.update_password"), classes: "govuk-!-margin-bottom-0"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -148,6 +148,9 @@ Rails.application.routes.draw do
   # Legacy publisher sign in path (users may still have this bookmarked)
   get "/identifications/new", to: redirect("/publishers/sign_in")
 
+  # Well known URLs
+  get ".well-known/change-password", to: redirect(status: 302) { Rails.application.routes.url_helpers.edit_jobseeker_registration_path(password_update: true) }
+
   post "/errors/csp_violation", to: "errors#csp_violation"
   get "/invalid-recaptcha", to: "errors#invalid_recaptcha", as: "invalid_recaptcha"
   match "/401", as: :unauthorised, to: "errors#unauthorised", via: :all


### PR DESCRIPTION
c.f. https://web.dev/change-password-url/

- Add "well-known" URL for changing passwords
- Add autocomplete attributes to help password managers understand what
  fields are for