### PR TITLE
[TEVA-2123] ProcessStepsComponent uses Job Application on the Application Form

### DIFF
--- a/app/components/shared/process_steps_component.rb
+++ b/app/components/shared/process_steps_component.rb
@@ -6,11 +6,25 @@ class Shared::ProcessStepsComponent < ViewComponent::Base
   end
 
   def render?
-    @process.blank? || %w[create review].include?(@process.state)
+    @process.blank? || %w[create draft review].include?(process_state)
   end
 
   def current_step_number
     @service.current_step_number
+  end
+
+  def completed_step_number
+    if @process.is_a?(JobApplication)
+      @process.completed_steps.map { |step| @service.steps[step.to_sym][:number] }.max
+    else
+      @process.completed_step
+    end
+  end
+
+  def process_state
+    return @process.status if @process.is_a?(JobApplication)
+
+    @process.state
   end
 
   def steps_to_display

--- a/app/components/shared/process_steps_component/process_steps_component.html.slim
+++ b/app/components/shared/process_steps_component/process_steps_component.html.slim
@@ -6,7 +6,7 @@
   .process-steps-component.process-steps-component--active
     ol.process-steps-component__steps
       - steps_to_display.values.uniq.each do |step|
-        li.process-steps-component__step.js-step class="#{active_step_class(step[:number], current_step_number)} #{visited_step_class(step[:number], @process.completed_step.presence || 0)}" aria-current="step" dat-show=""
+        li.process-steps-component__step.js-step class="#{active_step_class(step[:number], current_step_number)} #{visited_step_class(step[:number], completed_step_number.presence || 0)}" aria-current="step" dat-show=""
           .process-steps-component__header.js-toggle-panel data-position="1"
             h3.process-steps-component__title
               span.process-steps-component__circle.process-steps-component__circle--number

--- a/app/services/process_steps.rb
+++ b/app/services/process_steps.rb
@@ -1,4 +1,6 @@
 class ProcessSteps
+  attr_reader :steps
+
   def initialize(steps:, step:, adjust:)
     @steps = steps
     @step = step

--- a/app/views/jobseekers/job_applications/build/ask_for_support.html.slim
+++ b/app/views/jobseekers/job_applications/build/ask_for_support.html.slim
@@ -26,4 +26,4 @@
       = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"
 
   .govuk-grid-column-one-third
-    = render(Shared::ProcessStepsComponent.new(process: vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))
+    = render(Shared::ProcessStepsComponent.new(process: job_application, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))

--- a/app/views/jobseekers/job_applications/build/declarations.html.slim
+++ b/app/views/jobseekers/job_applications/build/declarations.html.slim
@@ -23,4 +23,4 @@
       = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"
 
   .govuk-grid-column-one-third
-    = render(Shared::ProcessStepsComponent.new(process: vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))
+    = render(Shared::ProcessStepsComponent.new(process: job_application, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))

--- a/app/views/jobseekers/job_applications/build/employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/build/employment_history.html.slim
@@ -28,4 +28,4 @@
       = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"
 
   .govuk-grid-column-one-third
-    = render(Shared::ProcessStepsComponent.new(process: vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))
+    = render(Shared::ProcessStepsComponent.new(process: job_application, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))

--- a/app/views/jobseekers/job_applications/build/equal_opportunities.html.slim
+++ b/app/views/jobseekers/job_applications/build/equal_opportunities.html.slim
@@ -64,4 +64,4 @@
       = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"
 
   .govuk-grid-column-one-third
-    = render(Shared::ProcessStepsComponent.new(process: vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))
+    = render(Shared::ProcessStepsComponent.new(process: job_application, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))

--- a/app/views/jobseekers/job_applications/build/personal_details.html.slim
+++ b/app/views/jobseekers/job_applications/build/personal_details.html.slim
@@ -24,4 +24,4 @@
       = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"
 
   .govuk-grid-column-one-third
-    = render(Shared::ProcessStepsComponent.new(process: vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))
+    = render(Shared::ProcessStepsComponent.new(process: job_application, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))

--- a/app/views/jobseekers/job_applications/build/personal_statement.html.slim
+++ b/app/views/jobseekers/job_applications/build/personal_statement.html.slim
@@ -25,4 +25,4 @@
       = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"
 
   .govuk-grid-column-one-third
-    = render(Shared::ProcessStepsComponent.new(process: vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))
+    = render(Shared::ProcessStepsComponent.new(process: job_application, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))

--- a/app/views/jobseekers/job_applications/build/professional_status.html.slim
+++ b/app/views/jobseekers/job_applications/build/professional_status.html.slim
@@ -23,4 +23,4 @@
       = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"
 
   .govuk-grid-column-one-third
-    = render(Shared::ProcessStepsComponent.new(process: vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))
+    = render(Shared::ProcessStepsComponent.new(process: job_application, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))

--- a/app/views/jobseekers/job_applications/build/references.html.slim
+++ b/app/views/jobseekers/job_applications/build/references.html.slim
@@ -24,4 +24,4 @@
       = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"
 
   .govuk-grid-column-one-third
-    = render(Shared::ProcessStepsComponent.new(process: vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))
+    = render(Shared::ProcessStepsComponent.new(process: job_application, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))

--- a/spec/components/shared/process_steps_component_spec.rb
+++ b/spec/components/shared/process_steps_component_spec.rb
@@ -1,100 +1,155 @@
 require "rails_helper"
 
 RSpec.describe Shared::ProcessStepsComponent, type: :component do
-  let(:vacancy) { create(:vacancy, completed_step: completed_step) }
-  let(:completed_step) { 0 }
-  let(:current_step_number) { 1 }
-  let(:current_organisation) { build(:school_group) }
   let(:process_title) { "Process title" }
-  let(:steps) do
-    {
-      job_location: { number: 1, title: I18n.t("jobs.job_location") },
-      schools: { number: 1, title: I18n.t("jobs.job_location") },
-      job_details: { number: 2, title: I18n.t("jobs.job_details") },
-      pay_package: { number: 3, title: I18n.t("jobs.pay_package") },
-      important_dates: { number: 4, title: I18n.t("jobs.important_dates") },
-      supporting_documents: { number: 5, title: I18n.t("jobs.supporting_documents") },
-      documents: { number: 5, title: I18n.t("jobs.supporting_documents") },
-      applying_for_the_job: { number: 6, title: I18n.t("jobs.applying_for_the_job") },
-      job_summary: { number: 7, title: I18n.t("jobs.job_summary") },
-      review: { number: 8, title: I18n.t("jobs.review_heading") },
-    }.freeze
-  end
 
-  let(:steps_adjust) { current_organisation.is_a?(SchoolGroup) ? 0 : 1 }
+  context "when the component is built for a vacancy" do
+    let(:completed_step) { 0 }
+    let(:current_step_number) { 1 }
+    let(:vacancy) { create(:vacancy, completed_step: completed_step) }
+    let(:current_organisation) { build(:school_group) }
+    let(:steps) do
+      {
+        job_location: { number: 1, title: I18n.t("jobs.job_location") },
+        schools: { number: 1, title: I18n.t("jobs.job_location") },
+        job_details: { number: 2, title: I18n.t("jobs.job_details") },
+        pay_package: { number: 3, title: I18n.t("jobs.pay_package") },
+        important_dates: { number: 4, title: I18n.t("jobs.important_dates") },
+        supporting_documents: { number: 5, title: I18n.t("jobs.supporting_documents") },
+        documents: { number: 5, title: I18n.t("jobs.supporting_documents") },
+        applying_for_the_job: { number: 6, title: I18n.t("jobs.applying_for_the_job") },
+        job_summary: { number: 7, title: I18n.t("jobs.job_summary") },
+        review: { number: 8, title: I18n.t("jobs.review_heading") },
+      }.freeze
+    end
 
-  before do
-    allow_any_instance_of(Publishers::AuthenticationConcerns).to receive(:current_organisation).and_return(current_organisation)
-  end
+    let(:steps_adjust) { current_organisation.is_a?(SchoolGroup) ? 0 : 1 }
 
-  let!(:inline_component) { render_inline(described_class.new(process: vacancy, service: ProcessSteps.new({ steps: steps, adjust: steps_adjust, step: :job_location }), title: process_title)) }
+    before do
+      allow_any_instance_of(Publishers::AuthenticationConcerns).to receive(:current_organisation).and_return(current_organisation)
+    end
 
-  it "renders the sidebar" do
-    expect(rendered_component).to include(process_title)
-  end
-
-  it "renders the job details step" do
-    expect(rendered_component).to include(I18n.t("jobs.job_details"))
-  end
-
-  it "renders the pay package step" do
-    expect(rendered_component).to include(I18n.t("jobs.pay_package"))
-  end
-
-  it "renders the important dates step" do
-    expect(rendered_component).to include(I18n.t("jobs.important_dates"))
-  end
-
-  it "renders the supporting documents step" do
-    expect(rendered_component).to include(I18n.t("jobs.supporting_documents"))
-  end
-
-  it "renders the application details step" do
-    expect(rendered_component).to include(I18n.t("jobs.applying_for_the_job"))
-  end
-
-  it "renders the job summary step" do
-    expect(rendered_component).to include(I18n.t("jobs.job_summary"))
-  end
-
-  it "renders the review step" do
-    expect(rendered_component).to include(I18n.t("jobs.review_heading"))
-  end
-
-  context "when a School user creates a job" do
-    let(:current_organisation) { build(:school) }
     let!(:inline_component) { render_inline(described_class.new(process: vacancy, service: ProcessSteps.new({ steps: steps, adjust: steps_adjust, step: :job_location }), title: process_title)) }
 
-    it "does not render the job location step" do
-      expect(rendered_component).not_to include(I18n.t("jobs.job_location"))
+    it "renders the sidebar" do
+      expect(rendered_component).to include(process_title)
+    end
+
+    it "renders the job details step" do
+      expect(rendered_component).to include(I18n.t("jobs.job_details"))
+    end
+
+    it "renders the pay package step" do
+      expect(rendered_component).to include(I18n.t("jobs.pay_package"))
+    end
+
+    it "renders the important dates step" do
+      expect(rendered_component).to include(I18n.t("jobs.important_dates"))
+    end
+
+    it "renders the supporting documents step" do
+      expect(rendered_component).to include(I18n.t("jobs.supporting_documents"))
+    end
+
+    it "renders the application details step" do
+      expect(rendered_component).to include(I18n.t("jobs.applying_for_the_job"))
+    end
+
+    it "renders the job summary step" do
+      expect(rendered_component).to include(I18n.t("jobs.job_summary"))
+    end
+
+    it "renders the review step" do
+      expect(rendered_component).to include(I18n.t("jobs.review_heading"))
+    end
+
+    context "when a School user creates a job" do
+      let(:current_organisation) { build(:school) }
+      let!(:inline_component) { render_inline(described_class.new(process: vacancy, service: ProcessSteps.new({ steps: steps, adjust: steps_adjust, step: :job_location }), title: process_title)) }
+
+      it "does not render the job location step" do
+        expect(rendered_component).not_to include(I18n.t("jobs.job_location"))
+      end
+    end
+
+    context "when a SchoolGroup user creates a job" do
+      it "renders the job location step" do
+        expect(rendered_component).to include(I18n.t("jobs.job_location"))
+      end
+    end
+
+    context "when a step is active" do
+      let(:component_active_step) do
+        inline_component.css(".process-steps-component__step--active .process-steps-component__circle-background").to_html
+      end
+
+      it "renders active class on current_step" do
+        expect(component_active_step).to include(current_step_number.to_s)
+      end
+    end
+
+    context "when a step is completed" do
+      let(:completed_step) { 1 }
+      let(:current_step) { 2 }
+      let(:component_completed_step) do
+        inline_component.css(".process-steps-component__step--visited .process-steps-component__circle-background").to_html
+      end
+
+      it "renders visited class on completed steps" do
+        expect(component_completed_step).to include(component_completed_step.to_s)
+      end
     end
   end
 
-  context "when a SchoolGroup user creates a job" do
-    it "renders the job location step" do
-      expect(rendered_component).to include(I18n.t("jobs.job_location"))
-    end
-  end
-
-  context "when a step is active" do
-    let(:component_active_step) do
-      inline_component.css(".process-steps-component__step--active .process-steps-component__circle-background").to_html
-    end
-
-    it "renders active class on current_step" do
-      expect(component_active_step).to include(current_step_number.to_s)
-    end
-  end
-
-  context "when a step is completed" do
+  context "when the component is built for a job application" do
     let(:completed_step) { 1 }
-    let(:current_step) { 2 }
-    let(:component_completed_step) do
-      inline_component.css(".process-steps-component__step--visited .process-steps-component__circle-background").to_html
+    let(:current_step_number) { 3 }
+    let(:job_application) { create(:job_application) }
+    let(:steps) do
+      {
+        personal_details: { number: 1, title: I18n.t(".personal_details.heading") },
+        professional_status: { number: 3, title: I18n.t(".professional_status.heading") },
+        employment_history: { number: 4, title: I18n.t(".employment_history.heading") },
+        personal_statement: { number: 5, title: I18n.t(".personal_statement.heading") },
+        references: { number: 6, title: I18n.t(".references.heading") },
+        equal_opportunities: { number: 7, title: I18n.t(".equal_opportunities.heading") },
+        ask_for_support: { number: 8, title: I18n.t(".ask_for_support.heading") },
+        declarations: { number: 9, title: I18n.t(".declarations.heading") },
+      }.freeze
     end
 
-    it "renders visited class on completed steps" do
-      expect(component_completed_step).to include(component_completed_step.to_s)
+    let!(:inline_component) { render_inline(described_class.new(process: job_application, service: ProcessSteps.new({ steps: steps, adjust: 0, step: :personal_details }), title: process_title)) }
+
+    it "renders the job details step" do
+      expect(rendered_component).to include(I18n.t(".personal_details.heading"))
+    end
+
+    it "renders the pay package step" do
+      expect(rendered_component).to include(I18n.t(".professional_status.heading"))
+    end
+
+    it "renders the important dates step" do
+      expect(rendered_component).to include(I18n.t(".employment_history.heading"))
+    end
+
+    it "renders the supporting documents step" do
+      expect(rendered_component).to include(I18n.t(".personal_statement.heading"))
+    end
+
+    it "renders the application details step" do
+      expect(rendered_component).to include(I18n.t(".references.heading"))
+    end
+
+    it "renders the job summary step" do
+      expect(rendered_component).to include(I18n.t(".equal_opportunities.heading"))
+    end
+
+    it "renders the job summary step" do
+      expect(rendered_component).to include(I18n.t(".ask_for_support.heading"))
+    end
+
+    it "renders the review step" do
+      expect(rendered_component).to include(I18n.t(".declarations.heading"))
     end
   end
 end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2123

## Changes in this PR:

- Added methods to retrieve the completed step number and the process status for both job applications and vacancies
- Pass job application into the component when rendered in a view related to the application form

### Before

![Screenshot 2021-03-16 at 16 17 42](https://user-images.githubusercontent.com/30624173/111343365-43b18300-8673-11eb-8a1e-c7dbcdb7f9f8.png)

### After

<img width="1062" alt="Screenshot 2021-03-16 at 16 15 33" src="https://user-images.githubusercontent.com/30624173/111343393-4a3ffa80-8673-11eb-993b-2dea199ab571.png">

