### PR TITLE
Permit DB restore where app and space names differ

### DIFF
--- a/.github/workflows/restore_db.yml
+++ b/.github/workflows/restore_db.yml
@@ -1,4 +1,4 @@
-name: Restore dev/staging db from production backup
+name: Restore sanitised backup to non-prod environment
 
 on:
   workflow_dispatch:
@@ -12,7 +12,7 @@ on:
         required: true
 jobs:
   sync:
-    name: Sync ${{ github.event.inputs.environment }} database from production backup
+    name: Restore sanitised backup to ${{ github.event.inputs.environment }}
     runs-on: ubuntu-20.04
 
     steps:
@@ -26,12 +26,17 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: eu-west-2
 
+    - name: Set PaaS space name
+      shell: bash
+      run: |
+        PAAS_SPACE_NAME=$(grep paas_space_name terraform/workspace-variables/${{ github.event.inputs.environment }}.tfvars | awk -F'= ' '{print $2}' | cut -d '"' -f 2)
+
     - name: Setup cf cli
       uses: DFE-Digital/github-actions/setup-cf-cli@master
       with:
         CF_USERNAME: ${{ secrets.CF_USERNAME }}
         CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-        CF_SPACE_NAME: teaching-vacancies-${{ github.event.inputs.environment }}
+        CF_SPACE_NAME: ${PAAS_SPACE_NAME}
         INSTALL_CONDUIT: true
 
     - name: Install postgres client
@@ -49,6 +54,7 @@ jobs:
       run: bin/restore-db
       env:
         CF_DESTINATION_ENVIRONMENT: ${{ github.event.inputs.environment }}
+        CF_SPACE_NAME: ${PAAS_SPACE_NAME}
         BACKUP_TYPE: sanitised
 
     - name: Send job status message to twd_tv_dev channel

--- a/bin/restore-db
+++ b/bin/restore-db
@@ -10,6 +10,10 @@ if [[ "${CF_DESTINATION_ENVIRONMENT}" = "production" ]] ; then
   echo "CF_DESTINATION_ENVIRONMENT should not equal production"
   exit 1
 fi
+if [[ -z "${CF_SPACE_NAME}" ]]; then
+  echo "CF_SPACE_NAME environment variable not set"
+  exit 1
+fi
 if [[ -z "${BACKUP_TYPE}" ]]; then
   echo "BACKUP_TYPE environment variable not set"
   exit 1
@@ -20,9 +24,9 @@ if [[ ! -f "${FILENAME}" ]]; then
   echo "${FILENAME} does not exist."
   exit 1
 else
-  CONDUIT_APP_NAME="${CF_SERVICE_NAME}-conduit-${CF_DESTINATION_ENVIRONMENT}"
+  CONDUIT_APP_NAME="${CF_SPACE_NAME}-conduit-${CF_DESTINATION_ENVIRONMENT}"
 
-  cf target -o "${CF_ORG_NAME}" -s "${CF_SERVICE_NAME}-${CF_DESTINATION_ENVIRONMENT}"
+  cf target -o "${CF_ORG_NAME}" -s "${CF_SPACE_NAME}"
   cf conduit "${CF_SERVICE_NAME}-postgres-${CF_DESTINATION_ENVIRONMENT}" --app-name "${CONDUIT_APP_NAME}" -- psql < "${FILENAME}"
   # The conduit app may have to be deleted explicitly
   cf delete -f "${CONDUIT_APP_NAME}" || true


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2208

## Changes in this PR:

- Renamed the action to reflect the growing number of environments which can use the sanitised backup
- Handled the use case of a PaaS space containing more than one environment (`dev` space currently contains `dev` and `qa)
- Derive the PaaS space name by querying the `.tfvars` file corresponding to the environment
