### PR TITLE
Refactor govuk-main-wrapper usage to ensure all pages have correct padding

### DIFF
--- a/app/components/publishers/vacancies_component/vacancies_component.html.slim
+++ b/app/components/publishers/vacancies_component/vacancies_component.html.slim
@@ -1,28 +1,29 @@
 = render(Shared::DashboardComponent.new(heading: t("jobs.manage.heading_html", organisation: @organisation.name, email: @email), navigation_items: vacancy_links, link: { url: organisation_jobs_path, text: t("buttons.create_job") }))
 
-.vacancies-component
-  .govuk-grid-row.vacancies-component__header class="govuk-!-margin-top-7"
-    .govuk-grid-column-full
-      h1.govuk-heading-l class="govuk-!-margin-bottom-4" = t(".#{@selected_type}.with_count_html", count: @vacancies.count)
+.govuk-main-wrapper
+  .vacancies-component
+    .govuk-grid-row.vacancies-component__header class="govuk-!-margin-top-7"
+      .govuk-grid-column-full
+        h1.govuk-heading-l class="govuk-!-margin-bottom-4" = t(".#{@selected_type}.with_count_html", count: @vacancies.count)
 
-  .govuk-grid-row
-    .moj-filter-sidebar class="govuk-!-margin-bottom-5"
-      - if @organisation.is_a?(SchoolGroup)
-        .govuk-grid-column-one-third
-          = form_for @filters_form, url: organisation_managed_organisations_path(anchor: "search-results"), html: { data: { "auto-submit": true, "hide-submit": true } }, method: :patch do |f|
-            = render(Shared::FiltersComponent.new(filters: { total_count: @filters[:managed_school_ids]&.count, title: t("jobs.filters.job_filters") }, form: f, items: [{ title: "Locations", key: "locations", search: true, scroll: true, attribute: :managed_school_ids, selected: @filters[:managed_school_ids], options: @organisation_options, value_method: :id, text_method: :label, selected_method: :name, small: true }], options: { remove_buttons: true, mobile_variant: true }))
+    .govuk-grid-row
+      .moj-filter-sidebar class="govuk-!-margin-bottom-5"
+        - if @organisation.is_a?(SchoolGroup)
+          .govuk-grid-column-one-third
+            = form_for @filters_form, url: organisation_managed_organisations_path(anchor: "search-results"), html: { data: { "auto-submit": true, "hide-submit": true } }, method: :patch do |f|
+              = render(Shared::FiltersComponent.new(filters: { total_count: @filters[:managed_school_ids]&.count, title: t("jobs.filters.job_filters") }, form: f, items: [{ title: "Locations", key: "locations", search: true, scroll: true, attribute: :managed_school_ids, selected: @filters[:managed_school_ids], options: @organisation_options, value_method: :id, text_method: :label, selected_method: :name, small: true }], options: { remove_buttons: true, mobile_variant: true }))
 
-            = f.hidden_field :jobs_type, value: @selected_type
+              = f.hidden_field :jobs_type, value: @selected_type
 
-    .moj-filter-layout__content class=grid_column_class
-      - if @vacancies.any?
-        = form_for @sort_form, as: "", url: jobs_with_type_organisation_path(@selected_type), method: :get, data: { 'auto-submit': true, "hide-submit": true } do |f|
-          = f.govuk_collection_select :sort_column,
-            vacancy_sort_options,
-            :column,
-            :display_name,
-            label: { text: t("jobs.sort_by.label"), size: "s", class: "govuk-label inline govuk-!-margin-right-2" }
+      .moj-filter-layout__content class=grid_column_class
+        - if @vacancies.any?
+          = form_for @sort_form, as: "", url: jobs_with_type_organisation_path(@selected_type), method: :get, data: { 'auto-submit': true, "hide-submit": true } do |f|
+            = f.govuk_collection_select :sort_column,
+              vacancy_sort_options,
+              :column,
+              :display_name,
+              label: { text: t("jobs.sort_by.label"), size: "s", class: "govuk-label inline govuk-!-margin-right-2" }
 
-          = f.govuk_submit t("jobs.sort_by.submit")
-      section
-        = render "publishers/organisations/vacancies_#{@selected_type}", selected_type: @selected_type, organisation: @organisation, vacancies: @vacancies, sort: @sort, filters_form: @filters_form, no_jobs_text: no_jobs_text
+            = f.govuk_submit t("jobs.sort_by.submit")
+        section
+          = render "publishers/organisations/vacancies_#{@selected_type}", selected_type: @selected_type, organisation: @organisation, vacancies: @vacancies, sort: @sort, filters_form: @filters_form, no_jobs_text: no_jobs_text

--- a/app/components/shared/notification_component/notification_component.scss
+++ b/app/components/shared/notification_component/notification_component.scss
@@ -4,8 +4,8 @@
 .govuk-main-wrapper__notification {
   @include full-width-mast;
   background-color: inherit;
-  padding-bottom: govuk-spacing(2);
-  padding-top: govuk-spacing(2);
+  margin-bottom: govuk-spacing(2);
+  margin-top: govuk-spacing(2);
 
   .govuk-notification {
     margin-bottom: 0;

--- a/app/frontend/src/styles/application.scss
+++ b/app/frontend/src/styles/application.scss
@@ -63,48 +63,6 @@ body {
   .govuk-header__container {
     border-bottom: 10px solid govuk-colour('orange');
   }
-
-  .govuk-main-wrapper {
-    background-color: govuk-colour('light-grey');
-    margin-bottom: govuk-spacing(6);
-    padding-bottom: 0;
-    padding-top: 0;
-
-    .content-wrapper {
-      background-color: govuk-colour('white');
-    }
-
-    h1,
-    .govuk-heading-xl {
-      margin-top: govuk-spacing(4);
-    }
-  }
-
-  &.home_index {
-    .govuk-main-wrapper__notification {
-      background-color: $govuk-brand-colour;
-
-      .govuk-notification__background {
-        background-color: govuk-colour('white');
-      }
-    }
-  }
-
-  &[class*='_sessions_new'] {
-    .govuk-main-wrapper {
-      background-color: govuk-colour('white');
-
-      .content-wrapper {
-        padding-top: govuk-spacing(4);
-      }
-    }
-  }
-
-  &.vacancies_show {
-    .govuk-main-wrapper__notification {
-      background-color: govuk-colour('light-grey');
-    }
-  }
 }
 
 input[type='search'] {

--- a/app/frontend/src/styles/application/jobseekers/jobseeker.scss
+++ b/app/frontend/src/styles/application/jobseekers/jobseeker.scss
@@ -1,21 +1,8 @@
 .jobseeker {
-  &[class*='subscriptions_'],
-  &[class*='vacancies_'] {
-    .govuk-main-wrapper {
-      background-color: govuk-colour('white');
-    }
-  }
-
-  &.jobseekers_subscriptions_index {
-    .govuk-main-wrapper {
-      background-color: govuk-colour('light-grey');
-    }
-  }
-
   .create-alert__button {
     text-align: right;
   }
-  
+
   .moj-filter-layout__content {
     overflow-x: hidden;
   }

--- a/app/frontend/src/styles/application/publishers/publisher.scss
+++ b/app/frontend/src/styles/application/publishers/publisher.scss
@@ -6,26 +6,4 @@ $desktop-container-width: 1200px;
       width: $desktop-container-width;
     }
   }
-
-  &.publishers_vacancies_index,
-  &.publishers_vacancies_show,
-  &.publishers_vacancies_preview {
-    .govuk-main-wrapper {
-      > .govuk-width-container {
-        margin-top: govuk-spacing(4);
-      }
-    }
-  }
-
-  &.publishers_organisations_show {
-    .govuk-main-wrapper {
-      > .govuk-width-container {
-        margin-top: 0;
-      }
-    }
-
-    .govuk-main-wrapper__notification {
-      background-color: govuk-colour('light-grey');
-    }
-  }
 }

--- a/app/frontend/src/styles/application/publishers/share-url.scss
+++ b/app/frontend/src/styles/application/publishers/share-url.scss
@@ -3,7 +3,6 @@
   border: $thick-border solid;
   border-color: $warning-color;
   margin-bottom: $govuk-gutter;
-  margin-top: $govuk-gutter-half;
   padding: $govuk-gutter-half;
 
   h2 {

--- a/app/views/cookies_preferences/new.html.slim
+++ b/app/views/cookies_preferences/new.html.slim
@@ -1,53 +1,54 @@
 - content_for :page_title_prefix, t(".title")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    h1.govuk-heading-xl = t(".heading")
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      h1.govuk-heading-xl = t(".heading")
 
-    h2.govuk-heading-l = t(".subheading")
-    p.govuk-body = t(".body.explanation")
+      h2.govuk-heading-l = t(".subheading")
+      p.govuk-body = t(".body.explanation")
 
-    p.govuk-body = t(".body.details.intro")
-    ul.govuk-list.govuk-list--bullet
-      - t(".body.details.list").each do |list_text|
-        li = list_text
+      p.govuk-body = t(".body.details.intro")
+      ul.govuk-list.govuk-list--bullet
+        - t(".body.details.list").each do |list_text|
+          li = list_text
 
-    p.govuk-body = t(".body.anonymity")
+      p.govuk-body = t(".body.anonymity")
 
-    = render "cookies_consent_form"
+      = render "cookies_consent_form"
 
-    h2.govuk-heading-l = t(".body.usage.heading")
+      h2.govuk-heading-l = t(".body.usage.heading")
 
-    h3.govuk-heading-m = t(".body.usage.essential.heading")
-    p.govuk-body = t(".body.usage.essential.intro")
+      h3.govuk-heading-m = t(".body.usage.essential.heading")
+      p.govuk-body = t(".body.usage.essential.intro")
 
-    table.govuk-table
-      thead.govuk-table__head
-        th.govuk-table__header = t(".body.usage.essential.table.header.name")
-        th.govuk-table__header = t(".body.usage.essential.table.header.purpose")
-        th.govuk-table__header = t(".body.usage.essential.table.header.expires")
-      tr.govuk-table__row
-        td.govuk-table__cell = t(".body.usage.essential.table.teaching_vacancies.name")
-        td.govuk-table__cell = t(".body.usage.essential.table.teaching_vacancies.purpose")
-        td.govuk-table__cell = t(".body.usage.essential.table.teaching_vacancies.expires")
-      tr.govuk-table__row
-        td.govuk-table__cell = t(".body.usage.essential.table.consent.name")
-        td.govuk-table__cell = t(".body.usage.essential.table.consent.purpose")
-        td.govuk-table__cell = t(".body.usage.essential.table.consent.expires")
-
-    h3.govuk-heading-m = t(".body.usage.google_analytics.heading")
-    p.govuk-body = t(".body.usage.google_analytics.intro")
-
-    table.govuk-table
-      thead.govuk-table__head
-        th.govuk-table__header = t(".body.usage.google_analytics.table.header.name")
-        th.govuk-table__header = t(".body.usage.google_analytics.table.header.purpose")
-        th.govuk-table__header = t(".body.usage.google_analytics.table.header.expires")
-      - %w[first second third fourth].each do |row|
+      table.govuk-table
+        thead.govuk-table__head
+          th.govuk-table__header = t(".body.usage.essential.table.header.name")
+          th.govuk-table__header = t(".body.usage.essential.table.header.purpose")
+          th.govuk-table__header = t(".body.usage.essential.table.header.expires")
         tr.govuk-table__row
-          td.govuk-table__cell = t(".body.usage.google_analytics.table.#{row}.name")
-          td.govuk-table__cell = t(".body.usage.google_analytics.table.#{row}.purpose")
-          td.govuk-table__cell = t(".body.usage.google_analytics.table.#{row}.expires")
+          td.govuk-table__cell = t(".body.usage.essential.table.teaching_vacancies.name")
+          td.govuk-table__cell = t(".body.usage.essential.table.teaching_vacancies.purpose")
+          td.govuk-table__cell = t(".body.usage.essential.table.teaching_vacancies.expires")
+        tr.govuk-table__row
+          td.govuk-table__cell = t(".body.usage.essential.table.consent.name")
+          td.govuk-table__cell = t(".body.usage.essential.table.consent.purpose")
+          td.govuk-table__cell = t(".body.usage.essential.table.consent.expires")
 
-    h2.govuk-heading-l = t(".body.service.heading")
-    p.govuk-body = t(".body.service.intro_html", feedback_link: govuk_link_to(t(".body.service.feedback"), new_feedback_path))
+      h3.govuk-heading-m = t(".body.usage.google_analytics.heading")
+      p.govuk-body = t(".body.usage.google_analytics.intro")
+
+      table.govuk-table
+        thead.govuk-table__head
+          th.govuk-table__header = t(".body.usage.google_analytics.table.header.name")
+          th.govuk-table__header = t(".body.usage.google_analytics.table.header.purpose")
+          th.govuk-table__header = t(".body.usage.google_analytics.table.header.expires")
+        - %w[first second third fourth].each do |row|
+          tr.govuk-table__row
+            td.govuk-table__cell = t(".body.usage.google_analytics.table.#{row}.name")
+            td.govuk-table__cell = t(".body.usage.google_analytics.table.#{row}.purpose")
+            td.govuk-table__cell = t(".body.usage.google_analytics.table.#{row}.expires")
+
+      h2.govuk-heading-l = t(".body.service.heading")
+      p.govuk-body = t(".body.service.intro_html", feedback_link: govuk_link_to(t(".body.service.feedback"), new_feedback_path))

--- a/app/views/errors/internal_server_error.html.slim
+++ b/app/views/errors/internal_server_error.html.slim
@@ -1,5 +1,6 @@
 - content_for :page_title_prefix, t("error_pages.server_error")
 
-h1.govuk-heading-xl = t("error_pages.server_error")
-p We’re working to fix this, so please try again shortly.
-p If you continue to have problems accessing Teaching Vacancies you can email #{govuk_mail_to t("help.email"), t("help.email")}
+.govuk-main-wrapper
+  h1.govuk-heading-xl = t("error_pages.server_error")
+  p.govuk-body We’re working to fix this, so please try again shortly.
+  p.govuk-body If you continue to have problems accessing Teaching Vacancies you can email #{govuk_mail_to t("help.email"), t("help.email")}

--- a/app/views/errors/invalid_recaptcha.html.slim
+++ b/app/views/errors/invalid_recaptcha.html.slim
@@ -1,6 +1,7 @@
 - content_for :page_title_prefix, t("error_pages.invalid_recaptcha.title")
 
-h1.govuk-heading-xl = t("error_pages.invalid_recaptcha.title")
+.govuk-main-wrapper
+  h1.govuk-heading-xl = t("error_pages.invalid_recaptcha.title")
 
-p.govuk-body
-  = t("error_pages.invalid_recaptcha.text_html", mail_to: govuk_mail_to(t("help.email"), t("help.email"), class: "link-wrap", subject: t("error_pages.invalid_recaptcha.email_subject", form: @form)))
+  p.govuk-body
+    = t("error_pages.invalid_recaptcha.text_html", mail_to: govuk_mail_to(t("help.email"), t("help.email"), class: "link-wrap", subject: t("error_pages.invalid_recaptcha.email_subject", form: @form)))

--- a/app/views/errors/not_found.html.slim
+++ b/app/views/errors/not_found.html.slim
@@ -1,5 +1,6 @@
 - content_for :page_title_prefix, t("error_pages.not_found")
 
-h1.govuk-heading-xl = t("error_pages.not_found")
-p If you entered a web address please check it was correct.
-p You can #{govuk_link_to("return to the homepage", "/")} to try and find the information you need.
+.govuk-main-wrapper
+  h1.govuk-heading-xl = t("error_pages.not_found")
+  p.govuk-body If you entered a web address please check it was correct.
+  p.govuk-body You can #{govuk_link_to("return to the homepage", "/")} to try and find the information you need.

--- a/app/views/errors/trashed_vacancy_found.html.slim
+++ b/app/views/errors/trashed_vacancy_found.html.slim
@@ -1,4 +1,5 @@
 - content_for :page_title_prefix, t("error_pages.trashed_vacancy_found")
 
-h1.govuk-heading-xl = t("error_pages.trashed_vacancy_found")
-p The job you are looking for is no longer listed on Teaching Vacancies. Try #{govuk_link_to("searching again", "/")}.
+.govuk-main-wrapper
+  h1.govuk-heading-xl = t("error_pages.trashed_vacancy_found")
+  p.govuk-body The job you are looking for is no longer listed on Teaching Vacancies. Try #{govuk_link_to("searching again", "/")}.

--- a/app/views/errors/unauthorised.html.slim
+++ b/app/views/errors/unauthorised.html.slim
@@ -1,9 +1,10 @@
 - content_for :page_title_prefix, t("error_pages.unauthorised.title")
 
-h1.govuk-heading-xl = t("error_pages.unauthorised.title")
-p = t("error_pages.unauthorised.text_html")
-ul.govuk-list.govuk-list--bullet
-  - t("error_pages.unauthorised.options_html").each do |option|
-    li = option
-p = t("error_pages.unauthorised.footer")
-p You can email #{govuk_mail_to t("help.email"), t("help.email")} if the problem persists.
+.govuk-main-wrapper
+  h1.govuk-heading-xl = t("error_pages.unauthorised.title")
+  p.govuk-body = t("error_pages.unauthorised.text_html")
+  ul.govuk-list.govuk-list--bullet
+    - t("error_pages.unauthorised.options_html").each do |option|
+      li = option
+  p.govuk-body = t("error_pages.unauthorised.footer")
+  p.govuk-body You can email #{govuk_mail_to t("help.email"), t("help.email")} if the problem persists.

--- a/app/views/errors/unprocessable_entity.html.slim
+++ b/app/views/errors/unprocessable_entity.html.slim
@@ -1,3 +1,4 @@
 - content_for :page_title_prefix, t("error_pages.unprocessable_entity")
 
-h1.govuk-heading-xl = t("error_pages.unprocessable_entity")
+.govuk-main-wrapper
+  h1.govuk-heading-xl = t("error_pages.unprocessable_entity")

--- a/app/views/general_feedbacks/new.html.slim
+++ b/app/views/general_feedbacks/new.html.slim
@@ -1,26 +1,27 @@
 - content_for :page_title_prefix, t(".title")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    = form_for @general_feedback_form, url: feedback_path do |f|
-      = f.govuk_error_summary
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = form_for @general_feedback_form, url: feedback_path do |f|
+        = f.govuk_error_summary
 
-      h2.govuk-heading-xl
-        = t(".heading")
+        h2.govuk-heading-xl
+          = t(".heading")
 
-      = f.govuk_radio_buttons_fieldset(:visit_purpose, legend: { size: "m" }) do
-        - Feedback.visit_purposes.keys.each_with_index do |visit_purpose, idx|
-          - if visit_purpose == "other_purpose"
-            = f.govuk_radio_button :visit_purpose, visit_purpose, link_errors: idx.zero? do
-              = f.govuk_text_area :visit_purpose_comment,
-                label: { hidden: true },
-                rows: 5,
-                max_chars: 1200
-          - else
-            = f.govuk_radio_button :visit_purpose, visit_purpose, link_errors: idx.zero?
+        = f.govuk_radio_buttons_fieldset(:visit_purpose, legend: { size: "m" }) do
+          - Feedback.visit_purposes.keys.each_with_index do |visit_purpose, idx|
+            - if visit_purpose == "other_purpose"
+              = f.govuk_radio_button :visit_purpose, visit_purpose, link_errors: idx.zero? do
+                = f.govuk_text_area :visit_purpose_comment,
+                  label: { hidden: true },
+                  rows: 5,
+                  max_chars: 1200
+            - else
+              = f.govuk_radio_button :visit_purpose, visit_purpose, link_errors: idx.zero?
 
-      = render "/feedback/form", f: f
+        = render "/feedback/form", f: f
 
-      = recaptcha
+        = recaptcha
 
-      = f.govuk_submit t("buttons.submit_feedback")
+        = f.govuk_submit t("buttons.submit_feedback")

--- a/app/views/home/_signed_in_jobseeker.html.slim
+++ b/app/views/home/_signed_in_jobseeker.html.slim
@@ -1,6 +1,6 @@
 h2.govuk-heading-m = t(".title")
 
-p = t(".description")
+p.govuk-body = t(".description")
 
 - if current_variant?(:"2021_02_jobseeker_account_cta_test", :colour)
   = govuk_link_to t("buttons.view_account"), jobseeker_root_path, class: "govuk-!-margin-bottom-0", button: true

--- a/app/views/home/_signed_out_jobseeker.html.slim
+++ b/app/views/home/_signed_out_jobseeker.html.slim
@@ -1,6 +1,6 @@
 h2.govuk-heading-m = t(".title")
 
-p = t(".description_html", link: govuk_link_to(t("buttons.sign_in"), new_jobseeker_session_path, class: "govuk-link--no-visited-state"))
+p.govuk-body = t(".description_html", link: govuk_link_to(t("buttons.sign_in"), new_jobseeker_session_path, class: "govuk-link--no-visited-state"))
 
 - if current_variant?(:"2021_02_jobseeker_account_cta_test", :colour)
   = govuk_link_to t("buttons.create_account"), new_jobseeker_registration_path, class: "govuk-!-margin-bottom-0", button: true

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -22,10 +22,11 @@
           .signin
             = render "signed_in_jobseeker"
 
-.govuk-grid-row
-  .govuk-grid-column-full
-    = render "vacancy_facets"
+.govuk-main-wrapper class="govuk-!-padding-top-0"
+  .govuk-grid-row
+    .govuk-grid-column-full
+      = render "vacancy_facets"
 
-.govuk-grid-row class="govuk-!-margin-top-2"
-  .govuk-grid-column-full
-    = govuk_link_to(t(".browse_all"), jobs_path, class: "govuk-!-font-size-19")
+  .govuk-grid-row class="govuk-!-margin-top-2"
+    .govuk-grid-column-full
+      = govuk_link_to(t(".browse_all"), jobs_path, class: "govuk-!-font-size-19")

--- a/app/views/jobseekers/account_feedbacks/new.html.slim
+++ b/app/views/jobseekers/account_feedbacks/new.html.slim
@@ -1,18 +1,19 @@
 - content_for :page_title_prefix, t(".title")
 
-= govuk_back_link text: t("buttons.back"), href: @account_feedback_form.origin
+.govuk-main-wrapper
+  = govuk_back_link text: t("buttons.back"), href: @account_feedback_form.origin
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    = form_for @account_feedback_form, url: jobseekers_account_feedback_path do |f|
-      = f.hidden_field :origin
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = form_for @account_feedback_form, url: jobseekers_account_feedback_path do |f|
+        = f.hidden_field :origin
 
-      = f.govuk_error_summary
+        = f.govuk_error_summary
 
-      h1.govuk-heading-xl = t(".title")
+        h1.govuk-heading-xl = t(".title")
 
-      = f.govuk_collection_radio_buttons :rating, Feedback.ratings.keys, :to_s
+        = f.govuk_collection_radio_buttons :rating, Feedback.ratings.keys, :to_s
 
-      = f.govuk_text_area :comment, label: { size: "s" }, rows: 10, max_chars: 1200, form_group: { classes: "optional-field" }
+        = f.govuk_text_area :comment, label: { size: "s" }, rows: 10, max_chars: 1200, form_group: { classes: "optional-field" }
 
-      = f.govuk_submit t("buttons.submit")
+        = f.govuk_submit t("buttons.submit")

--- a/app/views/jobseekers/accounts/show.html.slim
+++ b/app/views/jobseekers/accounts/show.html.slim
@@ -2,32 +2,34 @@
 
 = render "jobseekers/dashboard/account_header"
 
+.govuk-main-wrapper class="govuk-!-padding-bottom-0"
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      h1.govuk-heading-l = t(".page_title")
+
+      dl.govuk-summary-list
+        .govuk-summary-list__row
+          dt.govuk-summary-list__key = t(".summary_list.email")
+          dd.govuk-summary-list__value = current_jobseeker.email
+          dd.govuk-summary-list__actions
+            = govuk_link_to edit_jobseeker_registration_path do
+              = t(".summary_list.change")
+              span.govuk-visually-hidden
+                = t(".summary_list.email")
+        .govuk-summary-list__row
+          dt.govuk-summary-list__key = t(".summary_list.password")
+          dd.govuk-summary-list__value = t(".summary_list.password_placeholder")
+          dd.govuk-summary-list__actions
+            = govuk_link_to edit_jobseeker_registration_path(password_update: true) do
+              = t(".summary_list.change")
+              span.govuk-visually-hidden
+                = t(".summary_list.password")
+
+    .govuk-grid-column-one-third
+      .account-sidebar
+        h2.account-sidebar__heading = t(".assistance.heading")
+        p.govuk-body-s = t(".assistance.content_html", link: govuk_mail_to(t("help.email"), t(".assistance.link_text")))
+
 .govuk-grid-row
-  .govuk-grid-column-two-thirds
-    h1.govuk-heading-l = t(".page_title")
-
-    dl.govuk-summary-list
-      .govuk-summary-list__row
-        dt.govuk-summary-list__key = t(".summary_list.email")
-        dd.govuk-summary-list__value = current_jobseeker.email
-        dd.govuk-summary-list__actions
-          = govuk_link_to edit_jobseeker_registration_path do
-            = t(".summary_list.change")
-            span.govuk-visually-hidden
-              = t(".summary_list.email")
-      .govuk-summary-list__row
-        dt.govuk-summary-list__key = t(".summary_list.password")
-        dd.govuk-summary-list__value = t(".summary_list.password_placeholder")
-        dd.govuk-summary-list__actions
-          = govuk_link_to edit_jobseeker_registration_path(password_update: true) do
-            = t(".summary_list.change")
-            span.govuk-visually-hidden
-              = t(".summary_list.password")
-
-  .govuk-grid-column-one-third
-    .account-sidebar
-      h2.account-sidebar__heading = t(".assistance.heading")
-      p.govuk-body-s = t(".assistance.content_html", link: govuk_mail_to(t("help.email"), t(".assistance.link_text")))
-
   .govuk-grid-column-full
     = render(Jobseekers::AccountSurveyLinkComponent.new(origin: url_for))

--- a/app/views/jobseekers/confirmations/new.html.slim
+++ b/app/views/jobseekers/confirmations/new.html.slim
@@ -1,12 +1,13 @@
 - content_for :page_title_prefix, t(".title")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    h1.govuk-heading-xl = t(".title")
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      h1.govuk-heading-xl = t(".title")
 
-    p.govuk-body = t(".description", email: resource.email)
+      p.govuk-body = t(".description", email: resource.email)
 
-    = form_for resource, url: jobseeker_confirmation_path, method: :post do |f|
-      = f.hidden_field :email
+      = form_for resource, url: jobseeker_confirmation_path, method: :post do |f|
+        = f.hidden_field :email
 
-      = f.govuk_submit t("buttons.resend_email"), classes: "govuk-!-margin-bottom-0"
+        = f.govuk_submit t("buttons.resend_email"), classes: "govuk-!-margin-bottom-0"

--- a/app/views/jobseekers/job_alert_feedbacks/edit.html.slim
+++ b/app/views/jobseekers/job_alert_feedbacks/edit.html.slim
@@ -1,22 +1,23 @@
 - content_for :page_title_prefix, t(".title")
 
-.govuk-grid-row
-  .govuk-grid-column-full
-    - unless @feedback.relevant_to_user
-      = render Shared::NotificationComponent.new style: "notice",
-        content: t(".change_alert_text", link: govuk_link_to(t(".change_alert_link"), edit_subscription_path(@subscription.token))),
-        background: true,
-        alert: "info",
-        dismiss: false
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-full
+      - unless @feedback.relevant_to_user
+        = render Shared::NotificationComponent.new style: "notice",
+          content: t(".change_alert_text", link: govuk_link_to(t(".change_alert_link"), edit_subscription_path(@subscription.token))),
+          background: true,
+          alert: "info",
+          dismiss: false
 
-  .govuk-grid-column-two-thirds
-    h1.govuk-heading-xl = t(".heading")
+    .govuk-grid-column-two-thirds
+      h1.govuk-heading-xl = t(".heading")
 
-    = form_for @feedback_form, url: subscription_job_alert_feedback_path, method: :patch do |f|
-      = f.govuk_error_summary
+      = form_for @feedback_form, url: subscription_job_alert_feedback_path, method: :patch do |f|
+        = f.govuk_error_summary
 
-      = f.govuk_text_area :comment, label: { size: "s" }, max_chars: 1200, rows: 11
+        = f.govuk_text_area :comment, label: { size: "s" }, max_chars: 1200, rows: 11
 
-      = recaptcha
+        = recaptcha
 
-      = f.govuk_submit t("buttons.submit"), classes: "govuk-!-padding-left-8 govuk-!-padding-right-8"
+        = f.govuk_submit t("buttons.submit"), classes: "govuk-!-padding-left-8 govuk-!-padding-right-8"

--- a/app/views/jobseekers/job_applications/confirm_destroy.html.slim
+++ b/app/views/jobseekers/job_applications/confirm_destroy.html.slim
@@ -1,11 +1,12 @@
 - content_for :page_title_prefix, t(".title")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    .govuk-caption-l class="govuk-!-margin-top-5" = t("jobseekers.job_applications.heading_component.caption", job_title: vacancy.job_title, organisation_name: vacancy.parent_organisation_name)
-    h1.govuk-heading-l = t(".heading")
-    p.govuk-heading-s = t(".confirmation_heading")
-    p.govuk-body = t(".confirmation_details")
-    = govuk_button_to t(".confirm"), jobseekers_job_application_path(job_application), method: :delete, class: "govuk-button--warning govuk-!-margin-bottom-3"
-    p.govuk-body
-      = govuk_link_to t(".cancel"), jobseekers_job_applications_path, class: "govuk-link--no-visited-state"
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      .govuk-caption-l = t("jobseekers.job_applications.heading_component.caption", job_title: vacancy.job_title, organisation_name: vacancy.parent_organisation_name)
+      h1.govuk-heading-l = t(".heading")
+      p.govuk-heading-s = t(".confirmation_heading")
+      p.govuk-body = t(".confirmation_details")
+      = govuk_button_to t(".confirm"), jobseekers_job_application_path(job_application), method: :delete, class: "govuk-button--warning govuk-!-margin-bottom-3"
+      p.govuk-body
+        = govuk_link_to t(".cancel"), jobseekers_job_applications_path, class: "govuk-link--no-visited-state"

--- a/app/views/jobseekers/job_applications/details/_form.html.slim
+++ b/app/views/jobseekers/job_applications/details/_form.html.slim
@@ -1,20 +1,20 @@
 - content_for :page_title_prefix, t(".#{build_step}.title")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    = govuk_back_link text: t("buttons.back"), href: back_link_path, classes: "govuk-!-margin-bottom-9"
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = govuk_back_link text: t("buttons.back"), href: back_link_path
+      .govuk-caption-l = t(".#{build_step}.caption")
+      h1.govuk-heading-xl = t(".#{build_step}.heading")
 
-    .govuk-caption-l = t(".#{build_step}.caption")
-    h1.govuk-heading-xl = t(".#{build_step}.heading")
+      - if I18n.exists?("jobseekers.job_applications.details.form.#{build_step}.description")
+        p.govuk-body = t(".#{build_step}.description")
 
-    - if I18n.exists?("jobseekers.job_applications.details.form.#{build_step}.description")
-      p.govuk-body = t(".#{build_step}.description")
+      = form_for form, url: url, method: method do |f|
+        = f.govuk_error_summary
 
-    = form_for form, url: url, method: method do |f|
-      = f.govuk_error_summary
+        = render "#{build_step}_fields", f: f
 
-      = render "#{build_step}_fields", f: f
+        = f.govuk_submit t(".#{build_step}.save")
 
-      = f.govuk_submit t(".#{build_step}.save")
-
-    = govuk_link_to t("buttons.cancel"), back_link_path
+      = govuk_link_to t("buttons.cancel"), back_link_path

--- a/app/views/jobseekers/job_applications/expired.html.slim
+++ b/app/views/jobseekers/job_applications/expired.html.slim
@@ -1,16 +1,17 @@
 - content_for :page_title_prefix, t(".title")
 
-.govuk-grid-row
-  .govuk-grid-column-full
-    p.govuk-caption-l class="govuk-!-margin-bottom-2"
-      = t("jobseekers.job_applications.heading_component.caption", job_title: vacancy.job_title, organisation_name: vacancy.parent_organisation_name)
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-full
+      p.govuk-caption-l class="govuk-!-margin-bottom-2"
+        = t("jobseekers.job_applications.heading_component.caption", job_title: vacancy.job_title, organisation_name: vacancy.parent_organisation_name)
 
-    h1.govuk-heading-xl = t(".heading")
+      h1.govuk-heading-xl = t(".heading")
 
-    p.govuk-body
-      = t(".deadline", deadline: OrganisationVacancyPresenter.new(vacancy).application_deadline)
+      p.govuk-body
+        = t(".deadline", deadline: OrganisationVacancyPresenter.new(vacancy).application_deadline)
 
-    p.govuk-body
-      = t(".prompt")
+      p.govuk-body
+        = t(".prompt")
 
-    = govuk_link_to t("buttons.view_account"), jobseeker_root_path, class: "govuk-button--primary", button: true
+      = govuk_link_to t("buttons.view_account"), jobseeker_root_path, class: "govuk-button--primary", button: true

--- a/app/views/jobseekers/job_applications/index.html.slim
+++ b/app/views/jobseekers/job_applications/index.html.slim
@@ -2,14 +2,13 @@
 
 = render "jobseekers/dashboard/account_header"
 
-.govuk-grid-row
-  .govuk-grid-column-full
-    h1.govuk-heading-l = t(".page_title")
+.govuk-main-wrapper class="govuk-!-padding-bottom-0"
+  .govuk-grid-row
+    .govuk-grid-column-full
+      h1.govuk-heading-l = t(".page_title")
 
-.govuk-grid-row class="govuk-!-margin-top-0"
-  .govuk-grid-column-full
-    .moj-filter-layout__content
-      section
+  .govuk-grid-row class="govuk-!-margin-top-0"
+    .govuk-grid-column-full
         - if current_jobseeker.job_applications.any?
           - current_jobseeker.job_applications.includes(:vacancy).order(updated_at: :desc).draft.each do |draft_application|
             = render Shared::CardComponent.new do |card|
@@ -43,5 +42,6 @@
         - else
           = render Shared::NotificationComponent.new(content: { title: t(".no_job_applications"), body: t(".no_job_applications_body_html", link_to: govuk_link_to(t(".find_and_apply"), jobs_path)) }, style: "empty", dismiss: false, background: true, alert: false)
 
+.govuk-grid-row
   .govuk-grid-column-full
     = render(Jobseekers::AccountSurveyLinkComponent.new(origin: url_for))

--- a/app/views/jobseekers/job_applications/submit.html.slim
+++ b/app/views/jobseekers/job_applications/submit.html.slim
@@ -1,34 +1,35 @@
 - content_for :page_title_prefix, t(".title")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    = govuk_panel title: t(".panel.title"), body: t(".panel.body", email: current_jobseeker.email)
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = govuk_panel title: t(".panel.title"), body: t(".panel.body", email: current_jobseeker.email)
 
-  .govuk-grid-column-two-thirds
-    h2.govuk-heading-l = t(".next_step.heading")
+    .govuk-grid-column-two-thirds
+      h2.govuk-heading-l = t(".next_step.heading")
 
-    = render Shared::NotificationComponent.new style: "notice",
-      content: { title: t(".notice.title"), body: t(".notice.body") },
-      background: true,
-      alert: "info",
-      dismiss: false,
-      html_attributes: {}
+      = render Shared::NotificationComponent.new style: "notice",
+        content: { title: t(".notice.title"), body: t(".notice.body") },
+        background: true,
+        alert: "info",
+        dismiss: false,
+        html_attributes: {}
 
-    p = t(".next_step.school_communication", organisation: vacancy.parent_organisation.name, deadline: format_date(vacancy.expires_on))
-    p = t(".next_step.shortlisted", organisation: vacancy.parent_organisation.name)
+      p = t(".next_step.school_communication", organisation: vacancy.parent_organisation.name, deadline: format_date(vacancy.expires_on))
+      p = t(".next_step.shortlisted", organisation: vacancy.parent_organisation.name)
 
-    = govuk_link_to t(".next_step.view_applications"), jobseekers_job_applications_path, class: "govuk-button--secondary govuk-!-margin-bottom-3", button: true
+      = govuk_link_to t(".next_step.view_applications"), jobseekers_job_applications_path, class: "govuk-button--secondary govuk-!-margin-bottom-3", button: true
 
-    hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
+      hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
 
-    = form_for @application_feedback_form, url: jobseekers_job_application_feedback_path(anchor: "new_jobseekers_job_application_feedback_form") do |f|
-      = f.govuk_error_summary
+      = form_for @application_feedback_form, url: jobseekers_job_application_feedback_path(anchor: "new_jobseekers_job_application_feedback_form") do |f|
+        = f.govuk_error_summary
 
-      h2.govuk-heading-m = t(".feedback.heading")
-      p = t(".feedback.description")
+        h2.govuk-heading-m = t(".feedback.heading")
+        p = t(".feedback.description")
 
-      = f.govuk_collection_radio_buttons :rating, Feedback.ratings.keys, :to_s
+        = f.govuk_collection_radio_buttons :rating, Feedback.ratings.keys, :to_s
 
-      = f.govuk_text_area :comment, label: { size: "s" }, rows: 10, max_chars: 1200, form_group: { classes: "optional-field" }
+        = f.govuk_text_area :comment, label: { size: "s" }, rows: 10, max_chars: 1200, form_group: { classes: "optional-field" }
 
-      = f.govuk_submit t("buttons.submit_feedback")
+        = f.govuk_submit t("buttons.submit_feedback")

--- a/app/views/jobseekers/passwords/check_your_email_password.html.slim
+++ b/app/views/jobseekers/passwords/check_your_email_password.html.slim
@@ -1,9 +1,10 @@
 - content_for :page_title_prefix, t(".title")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    h1.govuk-heading-xl = t(".title")
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      h1.govuk-heading-xl = t(".title")
 
-    p.govuk-body = t(".description")
+      p.govuk-body = t(".description")
 
-    p.govuk-body-s = t(".having_trouble_html", mail_to: govuk_mail_to(t("help.email"), t(".report_it")))
+      p.govuk-body-s = t(".having_trouble_html", mail_to: govuk_mail_to(t("help.email"), t(".report_it")))

--- a/app/views/jobseekers/passwords/edit.html.slim
+++ b/app/views/jobseekers/passwords/edit.html.slim
@@ -1,14 +1,15 @@
 - content_for :page_title_prefix, t(".title")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    h1.govuk-heading-xl = t(".title")
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      h1.govuk-heading-xl = t(".title")
 
-    = form_for resource, url: jobseeker_password_path, method: :patch do |f|
-      = f.hidden_field :reset_password_token
+      = form_for resource, url: jobseeker_password_path, method: :patch do |f|
+        = f.hidden_field :reset_password_token
 
-      = f.govuk_error_summary
+        = f.govuk_error_summary
 
-      = f.govuk_password_field :password, label: { text: t(".new_password"), size: "s" }, width: "two-thirds"
+        = f.govuk_password_field :password, label: { text: t(".new_password"), size: "s" }, width: "two-thirds"
 
-      = f.govuk_submit t("buttons.update_password"), classes: "govuk-!-margin-bottom-0"
+        = f.govuk_submit t("buttons.update_password"), classes: "govuk-!-margin-bottom-0"

--- a/app/views/jobseekers/passwords/expired_token.html.slim
+++ b/app/views/jobseekers/passwords/expired_token.html.slim
@@ -1,12 +1,13 @@
 - content_for :page_title_prefix, t(".title")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    h1.govuk-heading-xl = t(".title")
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      h1.govuk-heading-xl = t(".title")
 
-    p.govuk-body = t(".description", email: resource.email)
+      p.govuk-body = t(".description", email: resource.email)
 
-    = form_for resource, url: jobseeker_password_path, method: :post do |f|
-      = f.hidden_field :email
+      = form_for resource, url: jobseeker_password_path, method: :post do |f|
+        = f.hidden_field :email
 
-      = f.govuk_submit t("buttons.resend_email"), classes: "govuk-!-margin-bottom-0"
+        = f.govuk_submit t("buttons.resend_email"), classes: "govuk-!-margin-bottom-0"

--- a/app/views/jobseekers/passwords/new.html.slim
+++ b/app/views/jobseekers/passwords/new.html.slim
@@ -1,14 +1,15 @@
 - content_for :page_title_prefix, t(".title")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    h1.govuk-heading-xl = t(".title")
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      h1.govuk-heading-xl = t(".title")
 
-    p.govuk-body = t(".description")
+      p.govuk-body = t(".description")
 
-    = form_for resource, url: jobseeker_password_path do |f|
-      = f.govuk_error_summary
+      = form_for resource, url: jobseeker_password_path do |f|
+        = f.govuk_error_summary
 
-      = f.govuk_email_field :email, label: { size: "s" }, width: "two-thirds"
+        = f.govuk_email_field :email, label: { size: "s" }, width: "two-thirds"
 
-      = f.govuk_submit t("buttons.continue"), classes: "govuk-!-margin-bottom-0"
+        = f.govuk_submit t("buttons.continue"), classes: "govuk-!-margin-bottom-0"

--- a/app/views/jobseekers/registrations/check_your_email.html.slim
+++ b/app/views/jobseekers/registrations/check_your_email.html.slim
@@ -1,9 +1,10 @@
 - content_for :page_title_prefix, t(".title")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    h1.govuk-heading-xl = t(".title")
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      h1.govuk-heading-xl = t(".title")
 
-    p.govuk-body = t(".description")
+      p.govuk-body = t(".description")
 
-    p.govuk-body-s = t(".having_trouble_html", mail_to: govuk_mail_to(t("help.email"), t(".report_it")))
+      p.govuk-body-s = t(".having_trouble_html", mail_to: govuk_mail_to(t("help.email"), t(".report_it")))

--- a/app/views/jobseekers/registrations/edit.html.slim
+++ b/app/views/jobseekers/registrations/edit.html.slim
@@ -1,17 +1,18 @@
 - content_for :page_title_prefix, password_update? ? t(".edit_password_title") : t(".edit_email_title")
 
-= govuk_back_link text: t("buttons.back"), href: jobseekers_account_path
+.govuk-main-wrapper
+  = govuk_back_link text: t("buttons.back"), href: jobseekers_account_path
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    h1.govuk-heading-xl = password_update? ? t(".edit_password_title") : t(".edit_email_title")
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      h1.govuk-heading-xl = password_update? ? t(".edit_password_title") : t(".edit_email_title")
 
-    = form_for resource, url: jobseeker_registration_path, method: :patch do |f|
-      = f.govuk_error_summary
+      = form_for resource, url: jobseeker_registration_path, method: :patch do |f|
+        = f.govuk_error_summary
 
-      - if password_update?
-        = render "edit_password", f: f
-      - else
-        = render "edit_email", f: f
+        - if password_update?
+          = render "edit_password", f: f
+        - else
+          = render "edit_email", f: f
 
-    hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
+      hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible

--- a/app/views/jobseekers/registrations/new.html.slim
+++ b/app/views/jobseekers/registrations/new.html.slim
@@ -1,24 +1,25 @@
 - content_for :page_title_prefix, t(".title")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    h1.govuk-heading-xl = t(".title")
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      h1.govuk-heading-xl = t(".title")
 
-    = form_for resource, url: jobseeker_registration_path do |f|
-      = f.govuk_error_summary
+      = form_for resource, url: jobseeker_registration_path do |f|
+        = f.govuk_error_summary
 
-      p.govuk-body = t(".description")
+        p.govuk-body = t(".description")
 
-      = f.govuk_email_field :email, label: { size: "s" }, width: "two-thirds"
-      = f.govuk_password_field :password, label: { size: "s" }, width: "two-thirds"
+        = f.govuk_email_field :email, label: { size: "s" }, width: "two-thirds"
+        = f.govuk_password_field :password, label: { size: "s" }, width: "two-thirds"
 
-      = f.govuk_submit t("buttons.create_account"), classes: "govuk-!-margin-bottom-0"
+        = f.govuk_submit t("buttons.create_account"), classes: "govuk-!-margin-bottom-0"
 
-    hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
-    h2.govuk-heading-m = t(".existing_account.heading")
-    p.govuk-body = t(".existing_account.content_html", link_to: govuk_link_to(t(".existing_account.link"), new_jobseeker_session_path))
+      hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
+      h2.govuk-heading-m = t(".existing_account.heading")
+      p.govuk-body = t(".existing_account.content_html", link_to: govuk_link_to(t(".existing_account.link"), new_jobseeker_session_path))
 
-  .govuk-grid-column-one-third
-    .account-sidebar
-      h2.account-sidebar__heading = t(".assistance.heading")
-      p.govuk-body-s = t(".assistance.content_html", link_to: govuk_link_to(t(".assistance.link"), new_publisher_session_path))
+    .govuk-grid-column-one-third
+      .account-sidebar
+        h2.account-sidebar__heading = t(".assistance.heading")
+        p.govuk-body-s = t(".assistance.content_html", link_to: govuk_link_to(t(".assistance.link"), new_publisher_session_path))

--- a/app/views/jobseekers/saved_jobs/index.html.slim
+++ b/app/views/jobseekers/saved_jobs/index.html.slim
@@ -2,27 +2,26 @@
 
 = render "jobseekers/dashboard/account_header"
 
-.govuk-grid-row
-  .govuk-grid-column-full
-    h1.govuk-heading-l = t(".page_title")
-
-- if saved_jobs.any?
-  .govuk-grid-row class="govuk-!-margin-top-0"
+.govuk-main-wrapper class="govuk-!-padding-bottom-0"
+  .govuk-grid-row
     .govuk-grid-column-full
-      = form_for sort_form, as: "", url: jobseekers_saved_jobs_path, method: :get, data: { 'auto-submit': true, "hide-submit": true } do |f|
-        = f.govuk_collection_select :sort_column,
-          sort,
-          :column,
-          :display_name,
-          label: { text: t("jobs.sort_by.label"), size: "s", class: "govuk-label inline govuk-!-margin-right-2" },
-          form_group: { classes: "govuk-!-margin-bottom-2" }
+      h1.govuk-heading-l = t(".page_title")
 
-        = f.govuk_submit t("jobs.sort_by.submit")
+  - if saved_jobs.any?
+    .govuk-grid-row class="govuk-!-margin-top-0"
+      .govuk-grid-column-full
+        = form_for sort_form, as: "", url: jobseekers_saved_jobs_path, method: :get, data: { 'auto-submit': true, "hide-submit": true } do |f|
+          = f.govuk_collection_select :sort_column,
+            sort,
+            :column,
+            :display_name,
+            label: { text: t("jobs.sort_by.label"), size: "s", class: "govuk-label inline govuk-!-margin-right-2" },
+            form_group: { classes: "govuk-!-margin-bottom-2" }
 
-.govuk-grid-row
-  .govuk-grid-column-full
-    .moj-filter-layout__content
-      section
+          = f.govuk_submit t("jobs.sort_by.submit")
+
+  .govuk-grid-row
+    .govuk-grid-column-full
         - if saved_jobs.any?
           - saved_jobs.each do |saved_job|
             = render Shared::CardComponent.new do |card|
@@ -42,5 +41,6 @@
         - else
           = render(Shared::NotificationComponent.new(content: { title: t(".zero_saved_jobs_title"), body: t(".zero_saved_jobs_body_html", link_to: govuk_link_to(t(".link_find"), root_path)) }, style: "empty", dismiss: false, background: true, alert: false))
 
+.govuk-grid-row
   .govuk-grid-column-full
     = render(Jobseekers::AccountSurveyLinkComponent.new(origin: url_for))

--- a/app/views/jobseekers/sessions/locked.html.slim
+++ b/app/views/jobseekers/sessions/locked.html.slim
@@ -1,11 +1,12 @@
 - content_for :page_title_prefix, t(".title")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    h1.govuk-heading-xl = t(".heading")
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      h1.govuk-heading-xl = t(".heading")
 
-    p.govuk-body = t(".description")
+      p.govuk-body = t(".description")
 
-    p.govuk-body-s = t(".instructions")
+      p.govuk-body-s = t(".instructions")
 
-    p.govuk-body-s = t(".having_trouble_html", mail_to: govuk_mail_to(t("help.email"), t(".report_it")))
+      p.govuk-body-s = t(".having_trouble_html", mail_to: govuk_mail_to(t("help.email"), t(".report_it")))

--- a/app/views/jobseekers/sessions/new.html.slim
+++ b/app/views/jobseekers/sessions/new.html.slim
@@ -1,26 +1,27 @@
 - content_for :page_title_prefix, t(".title")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    h1.govuk-heading-l = t(".title")
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      h1.govuk-heading-l = t(".title")
 
-    = form_for resource, url: new_jobseeker_session_path do |f|
-      = f.govuk_error_summary
+      = form_for resource, url: new_jobseeker_session_path do |f|
+        = f.govuk_error_summary
 
-      p.govuk-body = t(".description")
+        p.govuk-body = t(".description")
 
-      = f.govuk_email_field :email, label: { text: t("helpers.label.jobseekers_sign_in_form.email"), size: "s" }, width: "two-thirds"
-      = f.govuk_password_field :password, label: { text: t("helpers.label.jobseekers_sign_in_form.password"), size: "s" }, hint: nil, width: "two-thirds"
+        = f.govuk_email_field :email, label: { text: t("helpers.label.jobseekers_sign_in_form.email"), size: "s" }, width: "two-thirds"
+        = f.govuk_password_field :password, label: { text: t("helpers.label.jobseekers_sign_in_form.password"), size: "s" }, hint: nil, width: "two-thirds"
 
-      p.govuk-body = govuk_link_to(t(".forgotten"), new_jobseeker_password_path)
+        p.govuk-body = govuk_link_to(t(".forgotten"), new_jobseeker_password_path)
 
-      = f.govuk_submit t("buttons.sign_in"), classes: "govuk-!-margin-bottom-0"
+        = f.govuk_submit t("buttons.sign_in"), classes: "govuk-!-margin-bottom-0"
 
-    hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
-    h2.govuk-heading-m = t(".no_account.heading")
-    p.govuk-body = t(".no_account.content_html", link_to: govuk_link_to(t(".no_account.link"), new_jobseeker_registration_path))
+      hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
+      h2.govuk-heading-m = t(".no_account.heading")
+      p.govuk-body = t(".no_account.content_html", link_to: govuk_link_to(t(".no_account.link"), new_jobseeker_registration_path))
 
-  .govuk-grid-column-one-third
-    .account-sidebar
-      h2.account-sidebar__heading = t(".assistance.heading")
-      p.govuk-body-s = t(".assistance.content_html", link_to: govuk_link_to(t(".assistance.link"), new_publisher_session_path))
+    .govuk-grid-column-one-third
+      .account-sidebar
+        h2.account-sidebar__heading = t(".assistance.heading")
+        p.govuk-body-s = t(".assistance.content_html", link_to: govuk_link_to(t(".assistance.link"), new_publisher_session_path))

--- a/app/views/jobseekers/subscriptions/index.html.slim
+++ b/app/views/jobseekers/subscriptions/index.html.slim
@@ -2,30 +2,29 @@
 
 = render "jobseekers/dashboard/account_header"
 
-.govuk-grid-row
-  .govuk-grid-column-full
-    h1.govuk-heading-l = t(".page_title")
+.govuk-main-wrapper class="govuk-!-padding-bottom-0"
+  .govuk-grid-row
+    .govuk-grid-column-full
+      h1.govuk-heading-l = t(".page_title")
 
-- if subscriptions.any?
-  .govuk-grid-row class="govuk-!-margin-top-0"
-    .govuk-grid-column-two-thirds
-      = form_for sort_form, as: "", url: jobseekers_subscriptions_path, method: :get, data: { 'auto-submit': true, "hide-submit": true } do |f|
-        = f.govuk_collection_select :sort_column,
-          sort,
-          :column,
-          :display_name,
-          label: { text: t("jobs.sort_by.label"), size: "s", class: "govuk-label inline govuk-!-margin-right-2" },
-          form_group: { classes: "govuk-!-margin-bottom-2" }
+  - if subscriptions.any?
+    .govuk-grid-row class="govuk-!-margin-top-0"
+      .govuk-grid-column-two-thirds
+        = form_for sort_form, as: "", url: jobseekers_subscriptions_path, method: :get, data: { 'auto-submit': true, "hide-submit": true } do |f|
+          = f.govuk_collection_select :sort_column,
+            sort,
+            :column,
+            :display_name,
+            label: { text: t("jobs.sort_by.label"), size: "s", class: "govuk-label inline govuk-!-margin-right-2" },
+            form_group: { classes: "govuk-!-margin-bottom-2" }
 
-        = f.govuk_submit t("jobs.sort_by.submit")
+          = f.govuk_submit t("jobs.sort_by.submit")
 
-    .govuk-grid-column-one-third.create-alert__button
-      = govuk_link_to(t(".button_create"), new_subscription_path(email: current_jobseeker.email, origin: jobseekers_subscriptions_path), button: true)
+      .govuk-grid-column-one-third.create-alert__button
+        = govuk_link_to(t(".button_create"), new_subscription_path(email: current_jobseeker.email, origin: jobseekers_subscriptions_path), button: true)
 
-.govuk-grid-row
-  .govuk-grid-column-full
-    .moj-filter-layout__content
-      section
+  .govuk-grid-row
+    .govuk-grid-column-full
         - if subscriptions.any?
           - subscriptions.each do |subscription|
             = render Shared::CardComponent.new do |card|
@@ -42,5 +41,6 @@
         - else
           = render(Shared::NotificationComponent.new(content: { title: t(".zero_subscriptions_title"), body: t(".zero_subscriptions_body_html", link_to: govuk_link_to(t(".link_create"), new_subscription_path(email: current_jobseeker.email, origin: jobseekers_subscriptions_path))) }, style: "empty", dismiss: false, background: true, alert: false))
 
+.govuk-grid-row
   .govuk-grid-column-full
     = render(Jobseekers::AccountSurveyLinkComponent.new(origin: url_for))

--- a/app/views/jobseekers/unlocks/new.html.slim
+++ b/app/views/jobseekers/unlocks/new.html.slim
@@ -1,13 +1,14 @@
 - content_for :page_title_prefix, t(".title")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    h1.govuk-heading-xl = t(".heading")
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      h1.govuk-heading-xl = t(".heading")
 
-    = form_for resource, url: jobseeker_unlock_path do |f|
+      = form_for resource, url: jobseeker_unlock_path do |f|
 
-      p.govuk-body = t(".description")
+        p.govuk-body = t(".description")
 
-      = f.govuk_email_field :email, label: { size: "s" }, width: "two-thirds"
+        = f.govuk_email_field :email, label: { size: "s" }, width: "two-thirds"
 
-      = f.govuk_submit t(".form_submit"), classes: "govuk-!-margin-bottom-0"
+        = f.govuk_submit t(".form_submit"), classes: "govuk-!-margin-bottom-0"

--- a/app/views/jobseekers/unsubscribe_feedbacks/confirmation.slim
+++ b/app/views/jobseekers/unsubscribe_feedbacks/confirmation.slim
@@ -1,9 +1,10 @@
 - content_for :page_title_prefix, t(".title")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    = govuk_panel title: t(".header"), body: ""
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = govuk_panel title: t(".header"), body: ""
 
-    h2.govuk-heading-m = t(".heading")
+      h2.govuk-heading-m = t(".heading")
 
-    p = t(".new_search_html", link: govuk_link_to(t(".new_search_link"), jobs_path, class: "govuk-link--no-visited-state"))
+      p = t(".new_search_html", link: govuk_link_to(t(".new_search_link"), jobs_path, class: "govuk-link--no-visited-state"))

--- a/app/views/jobseekers/unsubscribe_feedbacks/new.html.slim
+++ b/app/views/jobseekers/unsubscribe_feedbacks/new.html.slim
@@ -1,23 +1,24 @@
 - content_for :page_title_prefix, t(".title")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    = govuk_panel title: t(".header"), body: t(".confirmation")
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = govuk_panel title: t(".header"), body: t(".confirmation")
 
-    = form_for @unsubscribe_feedback_form, url: subscription_unsubscribe_feedbacks_path(@subscription) do |f|
-      = f.govuk_error_summary
+      = form_for @unsubscribe_feedback_form, url: subscription_unsubscribe_feedbacks_path(@subscription) do |f|
+        = f.govuk_error_summary
 
-      h2.govuk-heading-l
-        = t(".heading")
+        h2.govuk-heading-l
+          = t(".heading")
 
-      = f.govuk_radio_buttons_fieldset(:reason) do
-        - Feedback.unsubscribe_reasons.each_key do |reason|
-          - if reason == "other_reason"
-            = f.govuk_radio_button :unsubscribe_reason, reason do
-              = f.govuk_text_field :other_unsubscribe_reason_comment, label: { size: "s" }
-          - else
-            = f.govuk_radio_button :unsubscribe_reason, reason
+        = f.govuk_radio_buttons_fieldset(:reason) do
+          - Feedback.unsubscribe_reasons.each_key do |reason|
+            - if reason == "other_reason"
+              = f.govuk_radio_button :unsubscribe_reason, reason do
+                = f.govuk_text_field :other_unsubscribe_reason_comment, label: { size: "s" }
+            - else
+              = f.govuk_radio_button :unsubscribe_reason, reason
 
-      = f.govuk_text_area :comment, label: { size: "s" }, max_chars: 1200
+        = f.govuk_text_area :comment, label: { size: "s" }, max_chars: 1200
 
-      = f.govuk_submit t("buttons.submit_feedback")
+        = f.govuk_submit t("buttons.submit_feedback")

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -61,14 +61,13 @@ html.govuk-template.app-html-class lang="en"
           span.govuk-phase-banner__text
             | This is a new service - #{govuk_link_to "your feedback", new_feedback_path} will help us to improve it.
 
-      main.govuk-main-wrapper#main-content role="main"
+      main#main-content role="main"
         - flash.each do |style, message|
           .govuk-main-wrapper__notification
             .govuk-width-container
               = render(Shared::NotificationComponent.new(content: message, style: style))
 
-        .content-wrapper
-          = yield
+        = yield
 
       = content_for :after_main
 

--- a/app/views/nqt_job_alerts/confirm.html.slim
+++ b/app/views/nqt_job_alerts/confirm.html.slim
@@ -1,24 +1,25 @@
 - content_for :page_title_prefix, t("nqt_job_alerts.page_title")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    .nqt-job-alert-success-gtm
-      = govuk_panel title: t("nqt_job_alerts.confirm.splash.heading"), body: t("nqt_job_alerts.confirm.splash.message", email: @nqt_job_alerts_form.email)
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      .nqt-job-alert-success-gtm
+        = govuk_panel title: t("nqt_job_alerts.confirm.splash.heading"), body: t("nqt_job_alerts.confirm.splash.message", email: @nqt_job_alerts_form.email)
 
-    h2.govuk-heading-l = t("nqt_job_alerts.confirm.heading")
-    p.govuk-body = t("nqt_job_alerts.confirm.intro")
+      h2.govuk-heading-l = t("nqt_job_alerts.confirm.heading")
+      p.govuk-body = t("nqt_job_alerts.confirm.intro")
 
-    .grouped-text-block
-      ul.govuk-list
-        li
-          span class="govuk-!-font-weight-bold"
-            = t("nqt_job_alerts.confirm.keywords")
-          = @nqt_job_alerts_form.keywords
-        li
-          span class="govuk-!-font-weight-bold"
-            = t("nqt_job_alerts.confirm.location")
-          = @nqt_job_alerts_form.location_reference
+      .grouped-text-block
+        ul.govuk-list
+          li
+            span class="govuk-!-font-weight-bold"
+              = t("nqt_job_alerts.confirm.keywords")
+            = @nqt_job_alerts_form.keywords
+          li
+            span class="govuk-!-font-weight-bold"
+              = t("nqt_job_alerts.confirm.location")
+            = @nqt_job_alerts_form.location_reference
 
-    p.govuk-body = t("nqt_job_alerts.confirm.unsubscribe")
+      p.govuk-body = t("nqt_job_alerts.confirm.unsubscribe")
 
-    p = govuk_link_to(t("buttons.go_to_teaching_vacancies"), jobs_path(keyword: "nqt #{@nqt_job_alerts_form.keywords}", location: @nqt_job_alerts_form.location), class: "govuk-link--no-visited-state")
+      p = govuk_link_to(t("buttons.go_to_teaching_vacancies"), jobs_path(keyword: "nqt #{@nqt_job_alerts_form.keywords}", location: @nqt_job_alerts_form.location), class: "govuk-link--no-visited-state")

--- a/app/views/nqt_job_alerts/new.html.slim
+++ b/app/views/nqt_job_alerts/new.html.slim
@@ -1,36 +1,37 @@
 - content_for :page_title_prefix, t("nqt_job_alerts.page_title")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    h1.govuk-heading-xl class="govuk-!-margin-bottom-6"
-      = t("nqt_job_alerts.heading")
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      h1.govuk-heading-xl class="govuk-!-margin-bottom-6"
+        = t("nqt_job_alerts.heading")
 
-    p.govuk-body-l = t("nqt_job_alerts.intro.teaching_vacancies")
-    p.govuk-body = t("nqt_job_alerts.intro.content")
+      p.govuk-body-l = t("nqt_job_alerts.intro.teaching_vacancies")
+      p.govuk-body = t("nqt_job_alerts.intro.content")
 
-    = form_for @nqt_job_alerts_form, url: new_nqt_job_alert_path do |f|
-      = f.govuk_error_summary
+      = form_for @nqt_job_alerts_form, url: new_nqt_job_alert_path do |f|
+        = f.govuk_error_summary
 
-      = f.govuk_text_field :keywords,
-        label: { size: "s" },
-        placeholder: t("helpers.placeholder.jobseekers_nqt_job_alerts_form.keywords"),
-        width: "two-thirds",
-        required: true
+        = f.govuk_text_field :keywords,
+          label: { size: "s" },
+          placeholder: t("helpers.placeholder.jobseekers_nqt_job_alerts_form.keywords"),
+          width: "two-thirds",
+          required: true
 
-      = f.govuk_text_field :location,
-        label: { size: "s" },
-        placeholder: t("helpers.placeholder.jobseekers_nqt_job_alerts_form.location"),
-        width: "two-thirds",
-        required: true
+        = f.govuk_text_field :location,
+          label: { size: "s" },
+          placeholder: t("helpers.placeholder.jobseekers_nqt_job_alerts_form.location"),
+          width: "two-thirds",
+          required: true
 
-      = f.govuk_email_field :email, label: { size: "s" }, width: "two-thirds", required: true
+        = f.govuk_email_field :email, label: { size: "s" }, width: "two-thirds", required: true
 
-      = recaptcha
+        = recaptcha
 
-      = render(Shared::NotificationComponent.new(content: t("nqt_job_alerts.intro.unsubscribe"), style: "notice", background: true, alert: "info", dismiss: false, html_attributes: {}))
+        = render(Shared::NotificationComponent.new(content: t("nqt_job_alerts.intro.unsubscribe"), style: "notice", background: true, alert: "info", dismiss: false, html_attributes: {}))
 
-      = f.govuk_submit t("buttons.subscribe"), classes: "nqt-job-alert-subscribe-gtm govuk-!-padding-left-8 govuk-!-padding-right-8"
+        = f.govuk_submit t("buttons.subscribe"), classes: "nqt-job-alert-subscribe-gtm govuk-!-padding-left-8 govuk-!-padding-right-8"
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds.govuk-body class="govuk-!-margin-top-4"
-    = t("terms_and_conditions.read_html")
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds.govuk-body class="govuk-!-margin-top-4"
+      = t("terms_and_conditions.read_html")

--- a/app/views/pages/ab-tests.html.slim
+++ b/app/views/pages/ab-tests.html.slim
@@ -1,23 +1,24 @@
 - content_for :page_title_prefix do
   | A/B Testing
 
-h1.govuk-heading-l A/B Testing
+.govuk-main-wrapper
+  h1.govuk-heading-l A/B Testing
 
-p.govuk-body We sometimes run A/B and multivariate tests to improve our service.
+  p.govuk-body We sometimes run A/B and multivariate tests to improve our service.
 
-p.govuk-body
-  | In an A/B test we create two versions of a webpage and show some website visitors one and some the other.
-  |  This lets us see which version works better for our users.
+  p.govuk-body
+    | In an A/B test we create two versions of a webpage and show some website visitors one and some the other.
+    |  This lets us see which version works better for our users.
 
-p.govuk-body Multivariate tests work in the same way, but use three or more versions of the webpage rather than just two.
+  p.govuk-body Multivariate tests work in the same way, but use three or more versions of the webpage rather than just two.
 
-p.govuk-body Below are the versions of webpages that you will see when you browse the Teaching Vacancies website.
+  p.govuk-body Below are the versions of webpages that you will see when you browse the Teaching Vacancies website.
 
-p.govuk-body For more information on our A/B and multivariate tests email #{govuk_mail_to(t("help.email"), t("help.email"))}.
+  p.govuk-body For more information on our A/B and multivariate tests email #{govuk_mail_to(t("help.email"), t("help.email"))}.
 
-dl.govuk-summary-list
-  - current_ab_variants.each do |test, variant|
-    .govuk-summary-list__row
-      dt.govuk-summary-list__key = test
-      dd.govuk-summary-list__value
-        span.govuk-tag.govuk-tag--blue = variant
+  dl.govuk-summary-list
+    - current_ab_variants.each do |test, variant|
+      .govuk-summary-list__row
+        dt.govuk-summary-list__key = test
+        dd.govuk-summary-list__value
+          span.govuk-tag.govuk-tag--blue = variant

--- a/app/views/pages/accessibility.html.slim
+++ b/app/views/pages/accessibility.html.slim
@@ -1,97 +1,98 @@
 - content_for :page_title_prefix do
   | Accessibility
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    h1.govuk-heading-xl Accessibility
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      h1.govuk-heading-xl Accessibility
 
-    h2.govuk-heading-l Accessibility statement for Teaching Vacancies
+      h2.govuk-heading-l Accessibility statement for Teaching Vacancies
 
-    p.govuk-body
-      | Teaching Vacancies is run by the Department for Education. We want as many people as possible to be able to use
-      |  the service. For example, that means users should be able to:
-      ul.govuk-list.govuk-list--bullet
-        li change colours, contrast levels and fonts
+      p.govuk-body
+        | Teaching Vacancies is run by the Department for Education. We want as many people as possible to be able to use
+        |  the service. For example, that means users should be able to:
+        ul.govuk-list.govuk-list--bullet
+          li change colours, contrast levels and fonts
 
-        li zoom in up to 300% without the text spilling off the screen
+          li zoom in up to 300% without the text spilling off the screen
 
-        li navigate most of the service using just a keyboard
+          li navigate most of the service using just a keyboard
 
-        li navigate most of the service using speech recognition software
+          li navigate most of the service using speech recognition software
 
-        li
-          | listen to most of the content on Teaching Vacancies using a screen reader
-          |  (including the most recent versions of JAWS, NVDA and VoiceOver)
+          li
+            | listen to most of the content on Teaching Vacancies using a screen reader
+            |  (including the most recent versions of JAWS, NVDA and VoiceOver)
 
-    p.govuk-body We’ve also made the text on the service as simple as possible to understand.
+      p.govuk-body We’ve also made the text on the service as simple as possible to understand.
 
-    h3.govuk-heading-m How accessible Teaching Vacancies is
+      h3.govuk-heading-m How accessible Teaching Vacancies is
 
-    p.govuk-body
-      | Teaching Vacancies is fully compliant with the #{govuk_link_to("Web Content Accessibility Guidelines version (WCAG) 2.1", "https://www.w3.org/TR/WCAG21/")}.
-      |  We are constantly improving the service and run accessibility audits during each new phase of development.
-      |  We last did an accessibility audit in May 2019.
+      p.govuk-body
+        | Teaching Vacancies is fully compliant with the #{govuk_link_to("Web Content Accessibility Guidelines version (WCAG) 2.1", "https://www.w3.org/TR/WCAG21/")}.
+        |  We are constantly improving the service and run accessibility audits during each new phase of development.
+        |  We last did an accessibility audit in May 2019.
 
-    h3.govuk-heading-m Reporting accessibility problems with Teaching Vacancies
+      h3.govuk-heading-m Reporting accessibility problems with Teaching Vacancies
 
-    p.govuk-body
-      | We’re always looking to improve the accessibility of this service. If you find any problems that are not
-      |  listed on this page or think we’re not meeting accessibility requirements, please
-      |  email #{govuk_mail_to(t("help.email"), t("help.email"))} with 'Accessibility issues' in the subject line of the email.
+      p.govuk-body
+        | We’re always looking to improve the accessibility of this service. If you find any problems that are not
+        |  listed on this page or think we’re not meeting accessibility requirements, please
+        |  email #{govuk_mail_to(t("help.email"), t("help.email"))} with 'Accessibility issues' in the subject line of the email.
 
-    h3.govuk-heading-m Enforcement procedure
+      h3.govuk-heading-m Enforcement procedure
 
-    p.govuk-body
-      | The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies
-      |  (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’).
-      |  If you’re not happy with how we respond to your complaint,
-      |  #{govuk_link_to("contact the Equality Advisory and Support Service (EASS)", "https://www.equalityadvisoryservice.com")}.
+      p.govuk-body
+        | The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies
+        |  (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’).
+        |  If you’re not happy with how we respond to your complaint,
+        |  #{govuk_link_to("contact the Equality Advisory and Support Service (EASS)", "https://www.equalityadvisoryservice.com")}.
 
-    h2.govuk-heading-l Technical information about Teaching Vacancies' accessibility
+      h2.govuk-heading-l Technical information about Teaching Vacancies' accessibility
 
-    p.govuk-body
-      | The Department for Education is committed to making its digital services accessible, in accordance
-      |  with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+      p.govuk-body
+        | The Department for Education is committed to making its digital services accessible, in accordance
+        |  with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
 
-    p.govuk-body
-      | This website is at present compliant with the #{govuk_link_to("WCAG 2.1", "https://www.w3.org/TR/WCAG21/")} AA standard.
+      p.govuk-body
+        | This website is at present compliant with the #{govuk_link_to("WCAG 2.1", "https://www.w3.org/TR/WCAG21/")} AA standard.
 
-    h3.govuk-heading-m Non-accessible content
+      h3.govuk-heading-m Non-accessible content
 
-    p.govuk-body
-      | A number of issues related to the accessibility of Teaching Vacancies were raised in an accessibility audit
-      |  conducted in May 2019. All of the issues that fall within the scope of accessibility regulations have been corrected.
+      p.govuk-body
+        | A number of issues related to the accessibility of Teaching Vacancies were raised in an accessibility audit
+        |  conducted in May 2019. All of the issues that fall within the scope of accessibility regulations have been corrected.
 
-    p.govuk-body
-      | The following accessibility issue has been identified but does not
-      |  fall within the scope of the WCAG 2.1 guidelines for the reason stated.
+      p.govuk-body
+        | The following accessibility issue has been identified but does not
+        |  fall within the scope of the WCAG 2.1 guidelines for the reason stated.
 
-    p.govuk-body
-      b Issue:
-      |  The colour used to indicate when an element such as a radio button has received focus does not meet the
-      |  expected ratio. However, this is a Government Digital Service (GDS) Design System issue, so is not within
-      |  our scope to correct. Note that a subtle movement effect also helps convey the focus state of a button,
-      |  for example, so colour contrast is not the only tactic we use for improving distinguishability.
+      p.govuk-body
+        b Issue:
+        |  The colour used to indicate when an element such as a radio button has received focus does not meet the
+        |  expected ratio. However, this is a Government Digital Service (GDS) Design System issue, so is not within
+        |  our scope to correct. Note that a subtle movement effect also helps convey the focus state of a button,
+        |  for example, so colour contrast is not the only tactic we use for improving distinguishability.
 
-    p.govuk-body
-      b Criterion failed:
-      |  1.4.11 Distinguishable: Non-text contrast
+      p.govuk-body
+        b Criterion failed:
+        |  1.4.11 Distinguishable: Non-text contrast
 
-    h3.govuk-heading-m How we tested this website
+      h3.govuk-heading-m How we tested this website
 
-    p.govuk-body This website was last tested on 28 May 2019. The test was carried out by the Digital Accessibility Centre (DAC).
+      p.govuk-body This website was last tested on 28 May 2019. The test was carried out by the Digital Accessibility Centre (DAC).
 
-    p.govuk-body
-      | DAC tested various combinations of the following for both desktop and mobile/tablet users:
-      ul.govuk-list.govuk-list--bullet
-        li assistive technologies (for example, screen magnifiers, screen readers and speech recognition tools)
-        li different browsers (IE11, Firefox, Safari, Chrome)
-        li accessibility user groups (for example, people with visual impairments, dyslexia, mobility impairments and learning disabilities)
+      p.govuk-body
+        | DAC tested various combinations of the following for both desktop and mobile/tablet users:
+        ul.govuk-list.govuk-list--bullet
+          li assistive technologies (for example, screen magnifiers, screen readers and speech recognition tools)
+          li different browsers (IE11, Firefox, Safari, Chrome)
+          li accessibility user groups (for example, people with visual impairments, dyslexia, mobility impairments and learning disabilities)
 
-    p.govuk-body
-      | DAC tested:
-      ul.govuk-list.govuk-list--bullet
-        li the hiring staff journey for listing a job on the service, available at #{govuk_link_to(new_publisher_session_url, new_publisher_session_url)}
-        li the jobseeker journey for searching for a teaching job and signing up for a job alert, available at #{govuk_link_to(root_url, root_url)}
+      p.govuk-body
+        | DAC tested:
+        ul.govuk-list.govuk-list--bullet
+          li the hiring staff journey for listing a job on the service, available at #{govuk_link_to(new_publisher_session_url, new_publisher_session_url)}
+          li the jobseeker journey for searching for a teaching job and signing up for a job alert, available at #{govuk_link_to(root_url, root_url)}
 
-    p.govuk-body This statement was prepared on 12 September 2019. It was last updated on Thursday 12th  February 2021.
+      p.govuk-body This statement was prepared on 12 September 2019. It was last updated on Thursday 12th  February 2021.

--- a/app/views/pages/privacy-policy.html.slim
+++ b/app/views/pages/privacy-policy.html.slim
@@ -1,155 +1,156 @@
 - content_for :page_title_prefix do
   | Privacy Policy
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    h1.govuk-heading-xl Privacy Notice: Teaching Vacancies
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      h1.govuk-heading-xl Privacy Notice: Teaching Vacancies
 
-    h2.govuk-heading-m Who we are
-    p.govuk-body
-      | The Teaching Vacancies service is run by DfE Digital, which is a part of the Department for Education (DfE).
-    p.govuk-body
-      | Any information we collect when you use our services will be used and looked after by the Department for
-      |  Education.
-    p.govuk-body
-      | This means that the DfE is the data controller, as well as data processor, of your information
-      |  (as defined by data protection law).
+      h2.govuk-heading-m Who we are
+      p.govuk-body
+        | The Teaching Vacancies service is run by DfE Digital, which is a part of the Department for Education (DfE).
+      p.govuk-body
+        | Any information we collect when you use our services will be used and looked after by the Department for
+        |  Education.
+      p.govuk-body
+        | This means that the DfE is the data controller, as well as data processor, of your information
+        |  (as defined by data protection law).
 
-    h2.govuk-heading-m When we collect personal information
-    p.govuk-body We receive your personal data when you submit it:
-    ul.govuk-list.govuk-list--bullet
-      li when contacting us for support using the service, to leave feedback or for any other matter
-      li as a jobseeker in order to create a Teaching Vacancies account
-      li as a member of hiring staff in order to create a Teaching Vacancies account
-      li as a contact person for a job that has been listed on Teaching Vacancies
-      li as a jobseeker signing up for emailed job alerts
-      li when you opt in to Google Analytics cookies
-    p.govuk-body = govuk_link_to("Find out more about our cookie policy", cookies_preferences_path)
+      h2.govuk-heading-m When we collect personal information
+      p.govuk-body We receive your personal data when you submit it:
+      ul.govuk-list.govuk-list--bullet
+        li when contacting us for support using the service, to leave feedback or for any other matter
+        li as a jobseeker in order to create a Teaching Vacancies account
+        li as a member of hiring staff in order to create a Teaching Vacancies account
+        li as a contact person for a job that has been listed on Teaching Vacancies
+        li as a jobseeker signing up for emailed job alerts
+        li when you opt in to Google Analytics cookies
+      p.govuk-body = govuk_link_to("Find out more about our cookie policy", cookies_preferences_path)
 
-    h2.govuk-heading-m What personal information we collect
-    p.govuk-body
-      | The personal data that we collect depends on whether you are using the service with a jobseeker account,
-      |  a hiring staff account, or without an account.
+      h2.govuk-heading-m What personal information we collect
+      p.govuk-body
+        | The personal data that we collect depends on whether you are using the service with a jobseeker account,
+        |  a hiring staff account, or without an account.
 
-    h3.govuk-heading-s What data we collect if you use Teaching Vacancies without an account
-    p.govuk-body
-      | If you use the Teaching Vacancies service without creating an account we may collect the following information
-      |  about you:
-    ul.govuk-list.govuk-list--bullet
-      li your Internet Protocol (IP) address
-      li the version of the web browser you use
-    p.govuk-body
-      | If you use the Teaching Vacancies service without creating an account, and also contact our support desk, we may
-      | collect the following information about you:
-    ul.govuk-list.govuk-list--bullet
-      li your name
-      li your email address
-      li your phone number
+      h3.govuk-heading-s What data we collect if you use Teaching Vacancies without an account
+      p.govuk-body
+        | If you use the Teaching Vacancies service without creating an account we may collect the following information
+        |  about you:
+      ul.govuk-list.govuk-list--bullet
+        li your Internet Protocol (IP) address
+        li the version of the web browser you use
+      p.govuk-body
+        | If you use the Teaching Vacancies service without creating an account, and also contact our support desk, we may
+        | collect the following information about you:
+      ul.govuk-list.govuk-list--bullet
+        li your name
+        li your email address
+        li your phone number
 
-    h3.govuk-heading-s What data we collect if you have a jobseeker account
-    p.govuk-body
-      | If you create a jobseeker account with Teaching Vacancies and use our service we may collect the following
-      |  information about you:
-    ul.govuk-list.govuk-list--bullet
-      li your Internet Protocol (IP) address
-      li the version of the web browser you use
-      li your email address
+      h3.govuk-heading-s What data we collect if you have a jobseeker account
+      p.govuk-body
+        | If you create a jobseeker account with Teaching Vacancies and use our service we may collect the following
+        |  information about you:
+      ul.govuk-list.govuk-list--bullet
+        li your Internet Protocol (IP) address
+        li the version of the web browser you use
+        li your email address
 
-    h3.govuk-heading-s What data we collect if you have a hiring staff account
-    p.govuk-body
-      | If you use the Teaching Vacancies service with a hiring staff account we may collect the following information
-      |  about you:
-    ul.govuk-list.govuk-list--bullet
-      li your Internet Protocol (IP) address
-      li the version of the web browser you use
-      li the email address you use for the purpose of creating a Teaching Vacancies account and listing jobs
-      li
-        | personal information such as the name and email of a contact person at your school, if you choose to share
-        | this in a job listing you post on Teaching Vacancies
+      h3.govuk-heading-s What data we collect if you have a hiring staff account
+      p.govuk-body
+        | If you use the Teaching Vacancies service with a hiring staff account we may collect the following information
+        |  about you:
+      ul.govuk-list.govuk-list--bullet
+        li your Internet Protocol (IP) address
+        li the version of the web browser you use
+        li the email address you use for the purpose of creating a Teaching Vacancies account and listing jobs
+        li
+          | personal information such as the name and email of a contact person at your school, if you choose to share
+          | this in a job listing you post on Teaching Vacancies
 
-    h2.govuk-heading-m How we use your information
-    p.govuk-body
-      | If you visit our service your IP address and details about your web browser will be collected to help us
-      |  understand how you use Teaching Vacancies. We do this to make sure the site is meeting the needs of its users
-      |  and to make improvements. We might analyse your data to help inform government policy around teacher recruitment
-      |  and retention.
-    p.govuk-body
-      | We may use and store things like your IP address and web browser version to actively identify security and
-      |  privacy threats to the service. We also use this information to make sure the service is working correctly and
-      |  to help us fix technical  problems with the website. This data is stored on a separate system that is not used
-      |  for analytics purposes.
-    p.govuk-body
-      | If you contact us by email, DfE will use your name and contact information for the purpose of responding to you
-      |  and providing support. We will not share this information with any other parties.
-    p.govuk-body
-      | If you sign up for a job alert your email address will be used exclusively for the purpose of sending you an
-      |  email when a job meeting your chosen search criteria is published on Teaching Vacancies.
-    p.govuk-body
-      | If you sign up for a jobseeker account your email address will be used exclusively for the purpose of sending
-      |  you emails related to account actions such as updating your password.
-    p.govuk-body
-      | To list jobs on the service, hiring staff at schools need a Teaching Vacancies account. To set up an account,
-      |  they need to tell us their name and email address. Names and email addresses shared with us for this purpose are
-      |  not shared by us with other parties.
-    p.govuk-body
-      | Information published in job listings may be used by third party job listing sites that use our job listing data
-      |  through an application programming interface (API), as described in our
-      |  #{govuk_link_to("Terms and Conditions", page_path("terms-and-conditions"))}. We are not responsible for how a
-      |  third party handles any personal information you choose to include in a job listing.
-    p.govuk-body
-      | If you indicate in the feedback form that we can contact you for user research then we may use your email for
-      |  that purpose. It will not be shared with third parties.
+      h2.govuk-heading-m How we use your information
+      p.govuk-body
+        | If you visit our service your IP address and details about your web browser will be collected to help us
+        |  understand how you use Teaching Vacancies. We do this to make sure the site is meeting the needs of its users
+        |  and to make improvements. We might analyse your data to help inform government policy around teacher recruitment
+        |  and retention.
+      p.govuk-body
+        | We may use and store things like your IP address and web browser version to actively identify security and
+        |  privacy threats to the service. We also use this information to make sure the service is working correctly and
+        |  to help us fix technical  problems with the website. This data is stored on a separate system that is not used
+        |  for analytics purposes.
+      p.govuk-body
+        | If you contact us by email, DfE will use your name and contact information for the purpose of responding to you
+        |  and providing support. We will not share this information with any other parties.
+      p.govuk-body
+        | If you sign up for a job alert your email address will be used exclusively for the purpose of sending you an
+        |  email when a job meeting your chosen search criteria is published on Teaching Vacancies.
+      p.govuk-body
+        | If you sign up for a jobseeker account your email address will be used exclusively for the purpose of sending
+        |  you emails related to account actions such as updating your password.
+      p.govuk-body
+        | To list jobs on the service, hiring staff at schools need a Teaching Vacancies account. To set up an account,
+        |  they need to tell us their name and email address. Names and email addresses shared with us for this purpose are
+        |  not shared by us with other parties.
+      p.govuk-body
+        | Information published in job listings may be used by third party job listing sites that use our job listing data
+        |  through an application programming interface (API), as described in our
+        |  #{govuk_link_to("Terms and Conditions", page_path("terms-and-conditions"))}. We are not responsible for how a
+        |  third party handles any personal information you choose to include in a job listing.
+      p.govuk-body
+        | If you indicate in the feedback form that we can contact you for user research then we may use your email for
+        |  that purpose. It will not be shared with third parties.
 
-    h2.govuk-heading-m Why our use of your personal data is lawful
-    p.govuk-body
-      | In order for our use of your personal data to be lawful, we need to meet one (or more) conditions in the data
-      |  protection legislation.
-    p.govuk-body
-      | Teaching Vacancies can use your personal data because you have a ‘legitimate need’ (as defined by data
-      |  protection law) to list, search for, and view jobs, as well as subscribe to job notifications. This is in
-      |  addition to DfE’s ‘legitimate need’ to process information to provide such services, and gather data to improve
-      |  that service including website performance and security.
+      h2.govuk-heading-m Why our use of your personal data is lawful
+      p.govuk-body
+        | In order for our use of your personal data to be lawful, we need to meet one (or more) conditions in the data
+        |  protection legislation.
+      p.govuk-body
+        | Teaching Vacancies can use your personal data because you have a ‘legitimate need’ (as defined by data
+        |  protection law) to list, search for, and view jobs, as well as subscribe to job notifications. This is in
+        |  addition to DfE’s ‘legitimate need’ to process information to provide such services, and gather data to improve
+        |  that service including website performance and security.
 
-    h2.govuk-heading-m How long we will keep your personal data
-    p.govuk-body
-      | The DfE will not keep your personal data longer than we need it for the purpose(s) of research, security and/or
-      |  delivery of the service. Your data will be deleted when DfE no longer needs it for these purposes, or when 7
-      |  years have passed, whichever comes first. We will never keep your data longer than 7 years.
-    p.govuk-body
-      | If you share personal information in a job listing we will keep this information while the job listing is live
-      |  and for one year after it has expired.
+      h2.govuk-heading-m How long we will keep your personal data
+      p.govuk-body
+        | The DfE will not keep your personal data longer than we need it for the purpose(s) of research, security and/or
+        |  delivery of the service. Your data will be deleted when DfE no longer needs it for these purposes, or when 7
+        |  years have passed, whichever comes first. We will never keep your data longer than 7 years.
+      p.govuk-body
+        | If you share personal information in a job listing we will keep this information while the job listing is live
+        |  and for one year after it has expired.
 
-    h2.govuk-heading-m Your data protection rights
-    p.govuk-body You have the right:
-    ul.govuk-list.govuk-list--bullet
-      li to ask us what information we hold about you
-      li to have your personal data corrected, if it is inaccurate or incomplete
-      li to ask us to delete your personal data. We will then delete your data unless we are required by law to keep it
-      li
-        | to restrict our processing of your personal data (for example, permitting its storage but no further
-        |  processing)
-      li
-        | to object to direct marketing (including profiling) and processing for the purposes of scientific/historical
-        |  research and statistics
-      li
-        | not to be subject to decisions based purely on automated processing where it has a legal or similarly
-        |  significant effect on you
-    p.govuk-body
-      | If you need to contact us about any of the above, or have any other questions about how your personal
-      |  information is used, please #{govuk_link_to("contact the DfE", "https://www.gov.uk/contact-dfe")}.
-    p.govuk-body
-      | The Information Commissioner's Office makes further information about your data protection rights available in
-      |  their #{govuk_link_to("Guide to the General Data Protection Regulation (GDPR)", "https://ico.org.uk/for-organisations/guide-to-the-general-data-protection-regulation-gdpr")}.
+      h2.govuk-heading-m Your data protection rights
+      p.govuk-body You have the right:
+      ul.govuk-list.govuk-list--bullet
+        li to ask us what information we hold about you
+        li to have your personal data corrected, if it is inaccurate or incomplete
+        li to ask us to delete your personal data. We will then delete your data unless we are required by law to keep it
+        li
+          | to restrict our processing of your personal data (for example, permitting its storage but no further
+          |  processing)
+        li
+          | to object to direct marketing (including profiling) and processing for the purposes of scientific/historical
+          |  research and statistics
+        li
+          | not to be subject to decisions based purely on automated processing where it has a legal or similarly
+          |  significant effect on you
+      p.govuk-body
+        | If you need to contact us about any of the above, or have any other questions about how your personal
+        |  information is used, please #{govuk_link_to("contact the DfE", "https://www.gov.uk/contact-dfe")}.
+      p.govuk-body
+        | The Information Commissioner's Office makes further information about your data protection rights available in
+        |  their #{govuk_link_to("Guide to the General Data Protection Regulation (GDPR)", "https://ico.org.uk/for-organisations/guide-to-the-general-data-protection-regulation-gdpr")}.
 
-    h2.govuk-heading-m Right to lodge a complaint
-    p.govuk-body
-      | If you are unhappy with our use of your personal data, please let us know by emailing
-      |  #{govuk_mail_to(t("help.email"), t("help.email"))}.
-    p.govuk-body
-      | You have the right to raise any concerns with the
-      |  #{govuk_link_to("Information Commissioner’s Office (ICO)", "https://ico.org.uk/concerns/")}.
+      h2.govuk-heading-m Right to lodge a complaint
+      p.govuk-body
+        | If you are unhappy with our use of your personal data, please let us know by emailing
+        |  #{govuk_mail_to(t("help.email"), t("help.email"))}.
+      p.govuk-body
+        | You have the right to raise any concerns with the
+        |  #{govuk_link_to("Information Commissioner’s Office (ICO)", "https://ico.org.uk/concerns/")}.
 
-    h2.govuk-heading-m Last updated
-    p.govuk-body
-      | We may need to update this privacy notice so we recommend that you revisit this information from time to time.
-    p.govuk-body This version was last updated on 04 February 2021.
+      h2.govuk-heading-m Last updated
+      p.govuk-body
+        | We may need to update this privacy notice so we recommend that you revisit this information from time to time.
+      p.govuk-body This version was last updated on 04 February 2021.

--- a/app/views/pages/terms-and-conditions.html.slim
+++ b/app/views/pages/terms-and-conditions.html.slim
@@ -1,220 +1,221 @@
 - content_for :page_title_prefix do
   | Terms and Conditions
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    markdown:
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      markdown:
 
-      # Terms and conditions
-      {: .govuk-heading-xl}
+        # Terms and conditions
+        {: .govuk-heading-xl}
 
-      ## All users
-      {: .govuk-heading-l}
+        ## All users
+        {: .govuk-heading-l}
 
-      ### Using the Service
-      {: .govuk-heading-m}
+        ### Using the Service
+        {: .govuk-heading-m}
 
-      By accessing and using the Teaching Vacancies website (the 'Service') you, as the user, are confirming that you accept
-      these terms and conditions ('General Terms'). This takes effect from the date you first use the Service. If you do not
-      agree to these General Terms, you must not use this website.
+        By accessing and using the Teaching Vacancies website (the 'Service') you, as the user, are confirming that you accept
+        these terms and conditions ('General Terms'). This takes effect from the date you first use the Service. If you do not
+        agree to these General Terms, you must not use this website.
 
-      If we change these General Terms we will post the revised document here with an updated effective date. If we make
-      significant changes to these terms, we may notify you by other means such as sending an email or posting a notice on
-      our home page.
+        If we change these General Terms we will post the revised document here with an updated effective date. If we make
+        significant changes to these terms, we may notify you by other means such as sending an email or posting a notice on
+        our home page.
 
-      By using Teaching Vacancies you agree to abide by the following terms and conditions.
+        By using Teaching Vacancies you agree to abide by the following terms and conditions.
 
-      ### **Information about us**
-      {: .govuk-heading-m}
+        ### **Information about us**
+        {: .govuk-heading-m}
 
-      This Service is operated by [the Department for
-      Education](https://www.gov.uk/government/organisations/department-for-education) ('we', 'our',
-      or 'us'). We are a central government department and have our registered office at Sanctuary Buildings, 20 Great
-      Smith Street, SW1P 3BT.
+        This Service is operated by [the Department for
+        Education](https://www.gov.uk/government/organisations/department-for-education) ('we', 'our',
+        or 'us'). We are a central government department and have our registered office at Sanctuary Buildings, 20 Great
+        Smith Street, SW1P 3BT.
 
-      You can contact us using the following email address: [teaching.vacancies@education.gov.uk](mailto:teaching.vacancies@education.gov.uk)
+        You can contact us using the following email address: [teaching.vacancies@education.gov.uk](mailto:teaching.vacancies@education.gov.uk)
 
-      ### **Hyperlinking to the Teaching Vacancies website**
-      {: .govuk-heading-m}
+        ### **Hyperlinking to the Teaching Vacancies website**
+        {: .govuk-heading-m}
 
-      We do not object to you linking directly to pages on this site and you do not need to ask permission to do so.
-      However, we do not permit our pages to be loaded into frames on your site.
+        We do not object to you linking directly to pages on this site and you do not need to ask permission to do so.
+        However, we do not permit our pages to be loaded into frames on your site.
 
-      The Teaching Vacancies pages must be displayed in the user's entire browser window.
+        The Teaching Vacancies pages must be displayed in the user's entire browser window.
 
-      You may not charge your website's users to click on a link to any page on the Service.
+        You may not charge your website's users to click on a link to any page on the Service.
 
-      ### **Third-party content and hyperlinking from the Service**
-      {: .govuk-heading-m}
+        ### **Third-party content and hyperlinking from the Service**
+        {: .govuk-heading-m}
 
-      We are not liable or responsible for the third-party content on the Service. Third-party content includes
-      material posted by other users of the Service, job listings, uploaded documents and their contents, and
-      display advertising.
+        We are not liable or responsible for the third-party content on the Service. Third-party content includes
+        material posted by other users of the Service, job listings, uploaded documents and their contents, and
+        display advertising.
 
-      Where the Service contains links to other sites and resources, we are not liable or responsible for the content or
-      reliability of those websites and resources. We do not necessarily endorse the views expressed within them.
+        Where the Service contains links to other sites and resources, we are not liable or responsible for the content or
+        reliability of those websites and resources. We do not necessarily endorse the views expressed within them.
 
-      We aim to replace broken links to other sites but cannot guarantee that these links will always work as we have no
-      control over the availability of other sites.
+        We aim to replace broken links to other sites but cannot guarantee that these links will always work as we have no
+        control over the availability of other sites.
 
-      ### **Virus protection**
-      {: .govuk-heading-m}
+        ### **Virus protection**
+        {: .govuk-heading-m}
 
-      We make every effort to check and test material at all stages of production. It is always wise for you to run an
-      antivirus program on all material downloaded from the Internet as we do not guarantee our service will be secure or
-      free from bugs or viruses. We cannot accept any responsibility for any loss, disruption or damage to your data or
-      your computer system which may occur whilst using material from this website.
+        We make every effort to check and test material at all stages of production. It is always wise for you to run an
+        antivirus program on all material downloaded from the Internet as we do not guarantee our service will be secure or
+        free from bugs or viruses. We cannot accept any responsibility for any loss, disruption or damage to your data or
+        your computer system which may occur whilst using material from this website.
 
-      You must not misuse our service by knowingly introducing viruses, trojans, worms, logic bombs or other material that
-      is malicious or technologically harmful.
+        You must not misuse our service by knowingly introducing viruses, trojans, worms, logic bombs or other material that
+        is malicious or technologically harmful.
 
-      You must not attempt to gain unauthorised access to our service, the server on which our service is stored or any
-      server, computer or database connected to our service.
+        You must not attempt to gain unauthorised access to our service, the server on which our service is stored or any
+        server, computer or database connected to our service.
 
-      You must not attack our site via a denial-of-service attack or a distributed denial-of service attack.
+        You must not attack our site via a denial-of-service attack or a distributed denial-of service attack.
 
-      Each of these acts is a criminal offence. We will report any such offence to the relevant law enforcement
-      authorities and co-operate with them to determine your identity. In the event of such a breach your right to use the
-      Service will cease immediately.
+        Each of these acts is a criminal offence. We will report any such offence to the relevant law enforcement
+        authorities and co-operate with them to determine your identity. In the event of such a breach your right to use the
+        Service will cease immediately.
 
-      ### **Disclaimer and Liability**
-      {: .govuk-heading-m}
+        ### **Disclaimer and Liability**
+        {: .govuk-heading-m}
 
-      The content of this Service includes both content created by us (included but not limited to content that helps you
-      use the Service) and third-party content (included but not limited to job listings). We do not:
+        The content of this Service includes both content created by us (included but not limited to content that helps you
+        use the Service) and third-party content (included but not limited to job listings). We do not:
 
-      * endorse third-party content
-      * vouch for its accuracy
-      * guarantee that the views, instructions and/or assertions expressed in it are our own
-      {: .govuk-list.govuk-list--bullet }
+        * endorse third-party content
+        * vouch for its accuracy
+        * guarantee that the views, instructions and/or assertions expressed in it are our own
+        {: .govuk-list.govuk-list--bullet }
 
-      The content we create for the Service is not advice. You should verify any information on the Service yourself and
-      use your own judgement before doing or not doing anything on the basis of the content.
+        The content we create for the Service is not advice. You should verify any information on the Service yourself and
+        use your own judgement before doing or not doing anything on the basis of the content.
 
-      Unless expressly stated in writing by us, the Service and material relating to government information, products and
-      services (or to third-party information, products and services), is provided 'as is', without any representation
-      or endorsement made and without warranty of any kind, whether express or implied, including but not limited to the
-      implied warranties of satisfactory quality, fitness for a particular purpose, non-infringement, compatibility,
-      security and accuracy.
+        Unless expressly stated in writing by us, the Service and material relating to government information, products and
+        services (or to third-party information, products and services), is provided 'as is', without any representation
+        or endorsement made and without warranty of any kind, whether express or implied, including but not limited to the
+        implied warranties of satisfactory quality, fitness for a particular purpose, non-infringement, compatibility,
+        security and accuracy.
 
-      We do not warrant that the functions contained in the material contained in this site will be uninterrupted or error
-      free, that defects will be corrected, or that this site or the server that makes it available are free of viruses or
-      represent the full functionality, accuracy, reliability of the materials.
+        We do not warrant that the functions contained in the material contained in this site will be uninterrupted or error
+        free, that defects will be corrected, or that this site or the server that makes it available are free of viruses or
+        represent the full functionality, accuracy, reliability of the materials.
 
-      In no event will we be liable for:
+        In no event will we be liable for:
 
-      * any action you may take as a result of relying on any information/materials provided on the Service or for any
-      loss or damage suffered by you as a result of you taking such action including, without limitation, indirect or
-      consequential loss or damage, or any loss or damages whatsoever arising from or in connection with the use of
-      the Service
-      * any dealings you have with third parties (other users or advertisers, for example) that take place using or
-      facilitated by the Service
-      {: .govuk-list.govuk-list--bullet }
+        * any action you may take as a result of relying on any information/materials provided on the Service or for any
+        loss or damage suffered by you as a result of you taking such action including, without limitation, indirect or
+        consequential loss or damage, or any loss or damages whatsoever arising from or in connection with the use of
+        the Service
+        * any dealings you have with third parties (other users or advertisers, for example) that take place using or
+        facilitated by the Service
+        {: .govuk-list.govuk-list--bullet }
 
-      ### **Validity of these General Terms**
-      {: .govuk-heading-m}
+        ### **Validity of these General Terms**
+        {: .govuk-heading-m}
 
-      If any of these terms and conditions are held to be invalid, unenforceable or illegal for any reason, the remaining
-      terms and conditions will still apply.
+        If any of these terms and conditions are held to be invalid, unenforceable or illegal for any reason, the remaining
+        terms and conditions will still apply.
 
-      ### **Applicable law and jurisdiction**
-      {: .govuk-heading-m}
+        ### **Applicable law and jurisdiction**
+        {: .govuk-heading-m}
 
-      These General Terms are governed by the laws of England and Wales. Any dispute arising under these General Terms
-      will be subject to the exclusive jurisdiction of the courts of England and Wales.
+        These General Terms are governed by the laws of England and Wales. Any dispute arising under these General Terms
+        will be subject to the exclusive jurisdiction of the courts of England and Wales.
 
-      ## **Terms and conditions for schools, trusts and local authorities (LAs)**
-      {: .govuk-heading-l}
+        ## **Terms and conditions for schools, trusts and local authorities (LAs)**
+        {: .govuk-heading-l}
 
-      ### **Approving user accounts**
-      {: .govuk-heading-m}
+        ### **Approving user accounts**
+        {: .govuk-heading-m}
 
-      Users must be approved before they are given a Teaching Vacancies account for the purposes of publishing or
-      managing job listings for a school or trust. Each school, trust or LA must have a nominated 'approver' who is
-      responsible for approving Teaching Vacancies accounts for users at that school, trust or LA.
+        Users must be approved before they are given a Teaching Vacancies account for the purposes of publishing or
+        managing job listings for a school or trust. Each school, trust or LA must have a nominated 'approver' who is
+        responsible for approving Teaching Vacancies accounts for users at that school, trust or LA.
 
-      An approver must only allow someone working for their school, trust or LA to publish or manage job listings for
-      their school or trust.
+        An approver must only allow someone working for their school, trust or LA to publish or manage job listings for
+        their school or trust.
 
-      Approvers must not create accounts for or allow third parties to publish or manage job listings on behalf of their
-      school, trust or LA. If the Teaching Vacancies team detects or is alerted to any account held by or used by third
-      parties then that account will be deleted immediately.
+        Approvers must not create accounts for or allow third parties to publish or manage job listings on behalf of their
+        school, trust or LA. If the Teaching Vacancies team detects or is alerted to any account held by or used by third
+        parties then that account will be deleted immediately.
 
-      ### **Using the Service**
-      {: .govuk-heading-m}
+        ### **Using the Service**
+        {: .govuk-heading-m}
 
-      By accessing and using the Service you, as the user, are confirming that you accept these General Terms. This
-      takes effect from the date you first use the Service. If you do not agree to these General Terms, you must not use
-      this website.
+        By accessing and using the Service you, as the user, are confirming that you accept these General Terms. This
+        takes effect from the date you first use the Service. If you do not agree to these General Terms, you must not use
+        this website.
 
-      By using Teaching Vacancies you agree to abide by the following terms and conditions.
+        By using Teaching Vacancies you agree to abide by the following terms and conditions.
 
-      ### **Unacceptable use**
-      {: .govuk-heading-m}
+        ### **Unacceptable use**
+        {: .govuk-heading-m}
 
-      You must not publish, edit or delete a job listing if you do not have authority from the school, trust or local authority to do so.
+        You must not publish, edit or delete a job listing if you do not have authority from the school, trust or local authority to do so.
 
-      Local authorities, multi-academy trusts and other organisations must not charge any fee or commission for listing a job on Teaching Vacancies.
+        Local authorities, multi-academy trusts and other organisations must not charge any fee or commission for listing a job on Teaching Vacancies.
 
-      You must not publish:
+        You must not publish:
 
-      * listings for teaching vacancies that aren't relevant to the service, such as but not limited to non-teaching
-      roles, supply teaching roles and unpaid positions
-      * listings for unconfirmed or non-existent vacancies
-      * listings for any school or trust that is not state funded, that is not in England or that does not teach primary
-      or secondary pupils
-      * offensive or inappropriate language, including but not limited to profanities or language pejorative of any
-      group, such as racist, sexist or homophobic comments
-      * discriminatory content: you must not state or imply in a job advert that you will discriminate against anyone
-      (subject to certain exceptions under the Equality Act 2010, particularly those applying to schools with a
-      religious character); for further information see GOV.UK's [guidance on discrimination in job
-      adverts](https://www.gov.uk/employer-preventing-discrimination/recruitment)
-      * material that infringes any intellectual property rights, such as copyright and trademarks (this means generally
-      that you must own the rights in everything you submit or must obtain permission from the rights owner to submit
-      the material)
-      * material that is technically harmful (including, without limitation, computer viruses, logic bombs, Trojan
-      horses, worms, harmful components, corrupted data or other malicious software or harmful data)
-      * material that encourages or teaches conduct that is a criminal offence, gives rise to civil liability, or is
-      otherwise unlawful
-      {: .govuk-list.govuk-list--bullet }
+        * listings for teaching vacancies that aren't relevant to the service, such as but not limited to non-teaching
+        roles, supply teaching roles and unpaid positions
+        * listings for unconfirmed or non-existent vacancies
+        * listings for any school or trust that is not state funded, that is not in England or that does not teach primary
+        or secondary pupils
+        * offensive or inappropriate language, including but not limited to profanities or language pejorative of any
+        group, such as racist, sexist or homophobic comments
+        * discriminatory content: you must not state or imply in a job advert that you will discriminate against anyone
+        (subject to certain exceptions under the Equality Act 2010, particularly those applying to schools with a
+        religious character); for further information see GOV.UK's [guidance on discrimination in job
+        adverts](https://www.gov.uk/employer-preventing-discrimination/recruitment)
+        * material that infringes any intellectual property rights, such as copyright and trademarks (this means generally
+        that you must own the rights in everything you submit or must obtain permission from the rights owner to submit
+        the material)
+        * material that is technically harmful (including, without limitation, computer viruses, logic bombs, Trojan
+        horses, worms, harmful components, corrupted data or other malicious software or harmful data)
+        * material that encourages or teaches conduct that is a criminal offence, gives rise to civil liability, or is
+        otherwise unlawful
+        {: .govuk-list.govuk-list--bullet }
 
-      ### **Access to the Service**
-      {: .govuk-heading-m}
+        ### **Access to the Service**
+        {: .govuk-heading-m}
 
-      We will not be liable if for any reason the Service is unavailable at any time or for any period. From time to
-      time, we may restrict access to all or some parts of the Service to users who have registered with us.
+        We will not be liable if for any reason the Service is unavailable at any time or for any period. From time to
+        time, we may restrict access to all or some parts of the Service to users who have registered with us.
 
-      If you choose, or are provided with, a user identification code, password or any other piece of information as
-      part of our security procedures, you must treat such information as confidential, and you must not disclose it to
-      any third party.
+        If you choose, or are provided with, a user identification code, password or any other piece of information as
+        part of our security procedures, you must treat such information as confidential, and you must not disclose it to
+        any third party.
 
-      We reserve the right to restrict or deny you access to all or some parts of the Service if, in our opinion, you
-      have failed to comply with these terms and conditions.
+        We reserve the right to restrict or deny you access to all or some parts of the Service if, in our opinion, you
+        have failed to comply with these terms and conditions.
 
-      The Department for Education retains the right to withdraw without notice listings that breach these terms and to
-      withdraw the access of users who breach them.
+        The Department for Education retains the right to withdraw without notice listings that breach these terms and to
+        withdraw the access of users who breach them.
 
-      ### **Listing data**
-      {: .govuk-heading-m}
+        ### **Listing data**
+        {: .govuk-heading-m}
 
-      Application Programming Interface (API) use: listings are published under the [Open Government
-      Licence](http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/open-government-licence/)
-      (OGL), which permits a wide range of information in the public sector to be reused free of charge. This means the
-      listing data on Teaching Vacancies will be available to third parties to publish on external sites after the pilot
-      phase, aside from where [exceptions to the
-      OGL](http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/open-government-licence/exceptions-to-ogl/)
-      prohibit it.
+        Application Programming Interface (API) use: listings are published under the [Open Government
+        Licence](http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/open-government-licence/)
+        (OGL), which permits a wide range of information in the public sector to be reused free of charge. This means the
+        listing data on Teaching Vacancies will be available to third parties to publish on external sites after the pilot
+        phase, aside from where [exceptions to the
+        OGL](http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/open-government-licence/exceptions-to-ogl/)
+        prohibit it.
 
-      Data ownership: schools have sole responsibility for maintaining the accuracy and appropriateness of the data
-      contained in their listings.
+        Data ownership: schools have sole responsibility for maintaining the accuracy and appropriateness of the data
+        contained in their listings.
 
-      ### **Terms and conditions for API users**
-      {: .govuk-heading-m}
+        ### **Terms and conditions for API users**
+        {: .govuk-heading-m}
 
-      You are free to reuse job listing data under the terms of the [Open Government
-      Licence](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/) for public sector
-      information with the following exception:
+        You are free to reuse job listing data under the terms of the [Open Government
+        Licence](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/) for public sector
+        information with the following exception:
 
-      * you may not charge a school any fee or commission for contacting, interviewing or hiring a respondent to your
-      advertisement or listing if it is based on Teaching Vacancies data that you have reused.
-      {: .govuk-list.govuk-list--bullet }
+        * you may not charge a school any fee or commission for contacting, interviewing or hiring a respondent to your
+        advertisement or listing if it is based on Teaching Vacancies data that you have reused.
+        {: .govuk-list.govuk-list--bullet }

--- a/app/views/publishers/omniauth_callbacks/not_authorised.html.slim
+++ b/app/views/publishers/omniauth_callbacks/not_authorised.html.slim
@@ -1,27 +1,28 @@
 - content_for :page_title_prefix do
   | The email you're signed in with isn't authorised to list jobs for this school
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    h1.govuk-heading-xl The email you're signed in with isn't authorised to list jobs for this school
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      h1.govuk-heading-xl The email you're signed in with isn't authorised to list jobs for this school
 
-    p.govuk-body
-      | You've tried to sign in with #{@identifier}, which is not authorised to list jobs for this school.
-      |  If you have an authorised account associated with another email, you must sign #{@identifier} out of DfE Sign-in,
-      |  then sign into Teaching Vacancies with your authorised email. You can do this at
-      |  #{govuk_link_to("DfE Sign-in", "https://profile.signin.education.gov.uk/")}
+      p.govuk-body
+        | You've tried to sign in with #{@identifier}, which is not authorised to list jobs for this school.
+        |  If you have an authorised account associated with another email, you must sign #{@identifier} out of DfE Sign-in,
+        |  then sign into Teaching Vacancies with your authorised email. You can do this at
+        |  #{govuk_link_to("DfE Sign-in", "https://profile.signin.education.gov.uk/")}
 
-    h2.govuk-heading-m If you are signing in with an authorised email
+      h2.govuk-heading-m If you are signing in with an authorised email
 
-    p.govuk-body
-      | If you know the email you’ve signed in with is authorised then there could be a technical issue. Please try using
-      |  a different web browser to sign in or, if this fails, email #{govuk_mail_to(t("help.email"), t("help.email"))}
-      |  with 'help' in the subject line.
+      p.govuk-body
+        | If you know the email you’ve signed in with is authorised then there could be a technical issue. Please try using
+        |  a different web browser to sign in or, if this fails, email #{govuk_mail_to(t("help.email"), t("help.email"))}
+        |  with 'help' in the subject line.
 
-    h2.govuk-heading-m If you need an account
+      h2.govuk-heading-m If you need an account
 
-    p.govuk-body
-      | If you don’t have an authorised Teaching Vacancies account, you can get one if you work at a state-funded
-      |  school or trust providing primary or secondary education in England and have your headteacher or CEO’s approval.
-      |  Just ask them to send your full name and email address to #{govuk_mail_to(t("help.email"), t("help.email"))}.
-      |  Or email us your details directly, copying in your headteacher or CEO.
+      p.govuk-body
+        | If you don’t have an authorised Teaching Vacancies account, you can get one if you work at a state-funded
+        |  school or trust providing primary or secondary education in England and have your headteacher or CEO’s approval.
+        |  Just ask them to send your full name and email address to #{govuk_mail_to(t("help.email"), t("help.email"))}.
+        |  Or email us your details directly, copying in your headteacher or CEO.

--- a/app/views/publishers/organisations/managed_organisations/show.html.slim
+++ b/app/views/publishers/organisations/managed_organisations/show.html.slim
@@ -1,35 +1,36 @@
 - content_for :page_title_prefix, t(".page_title")
 
-.govuk-grid-row
-  .govuk-grid-column-full
-    .interruption-card
-      h1.interruption-card__title = t(".panel.title", organisation: current_organisation.name)
-      .interruption-card__body = t(".panel.body", organisation_type: organisation_type_basic(current_organisation))
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-full
+      .interruption-card
+        h1.interruption-card__title = t(".panel.title", organisation: current_organisation.name)
+        .interruption-card__body = t(".panel.body", organisation_type: organisation_type_basic(current_organisation))
 
-  .govuk-grid-column-two-thirds
-    = form_for @managed_organisations_form, url: organisation_managed_organisations_path, method: :patch do |f|
-      = f.govuk_error_summary
+    .govuk-grid-column-two-thirds
+      = form_for @managed_organisations_form, url: organisation_managed_organisations_path, method: :patch do |f|
+        = f.govuk_error_summary
 
-      = f.govuk_check_boxes_fieldset :managed_organisations,
-        legend: { text: t(".labels.select_organisations") },
-        hint: { text: t(".hints.select_organisations") },
-        classes: "checkbox-label__bold govuk-!-margin-top-5" do
+        = f.govuk_check_boxes_fieldset :managed_organisations,
+          legend: { text: t(".labels.select_organisations") },
+          hint: { text: t(".hints.select_organisations") },
+          classes: "checkbox-label__bold govuk-!-margin-top-5" do
 
-        = f.govuk_check_box :managed_organisations,
-          "all",
-          label: { text: managed_organisations_all_label(current_organisation) },
-          link_errors: true
+          = f.govuk_check_box :managed_organisations,
+            "all",
+            label: { text: managed_organisations_all_label(current_organisation) },
+            link_errors: true
 
-        .govuk-body class="govuk-!-margin-left-2 govuk-!-margin-bottom-2"
-          | Or
+          .govuk-body class="govuk-!-margin-left-2 govuk-!-margin-bottom-2"
+            | Or
 
-        = render Shared::SearchableCollectionComponent.new(form: f,
-          threshold: 10,
-          attribute_name: :managed_school_ids,
-          collection: @organisation_options,
-          value_method: :id,
-          text_method: :name,
-          hint_method: :address).with_variant(:checkbox)
+          = render Shared::SearchableCollectionComponent.new(form: f,
+            threshold: 10,
+            attribute_name: :managed_school_ids,
+            collection: @organisation_options,
+            value_method: :id,
+            text_method: :name,
+            hint_method: :address).with_variant(:checkbox)
 
-      = f.govuk_submit
-      = f.govuk_submit t("buttons.skip_this_step"), secondary: true, classes: "button-link"
+        = f.govuk_submit
+        = f.govuk_submit t("buttons.skip_this_step"), secondary: true, classes: "button-link"

--- a/app/views/publishers/organisations/schools/edit.html.slim
+++ b/app/views/publishers/organisations/schools/edit.html.slim
@@ -1,25 +1,26 @@
 - content_for :page_title_prefix, @organisation.name.titlecase
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
 
-    h2.govuk-heading-m
-      = @organisation.name
+      h2.govuk-heading-m
+        = @organisation.name
 
-    = govuk_back_link text: t("buttons.back"), href: @redirect_path
+      = govuk_back_link text: t("buttons.back"), href: @redirect_path
 
-    = form_for @organisation_form, url: organisation_school_path(@organisation), method: :patch do |f|
-      = f.govuk_error_summary
+      = form_for @organisation_form, url: organisation_school_path(@organisation), method: :patch do |f|
+        = f.govuk_error_summary
 
-      h2.govuk-heading-l = t(".title", organisation_type: organisation_type_basic(@organisation))
+        h2.govuk-heading-l = t(".title", organisation_type: organisation_type_basic(@organisation))
 
-      = f.govuk_url_field :website,
-        label: { text: t("helpers.label.publishers_organisation_form.website", organisation_type: organisation_type_basic(@organisation)&.capitalize), size: "s" },
-        value: @organisation_form.website.presence || @organisation.url
+        = f.govuk_url_field :website,
+          label: { text: t("helpers.label.publishers_organisation_form.website", organisation_type: organisation_type_basic(@organisation)&.capitalize), size: "s" },
+          value: @organisation_form.website.presence || @organisation.url
 
-      = f.govuk_text_area :description,
-        label: { text: t("helpers.label.publishers_organisation_form.description", organisation_type: organisation_type_basic(@organisation)), size: "s" },
-        hint: { text: t("helpers.hint.publishers_organisation_form.description", organisation_type: organisation_type_basic(@organisation)) },
-        rows: 10
+        = f.govuk_text_area :description,
+          label: { text: t("helpers.label.publishers_organisation_form.description", organisation_type: organisation_type_basic(@organisation)), size: "s" },
+          hint: { text: t("helpers.hint.publishers_organisation_form.description", organisation_type: organisation_type_basic(@organisation)) },
+          rows: 10
 
-      = f.govuk_submit t("buttons.save_changes")
+        = f.govuk_submit t("buttons.save_changes")

--- a/app/views/publishers/organisations/schools/index.html.slim
+++ b/app/views/publishers/organisations/schools/index.html.slim
@@ -1,24 +1,25 @@
 - content_for :page_title_prefix, current_organisation.name
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
 
-    h1.govuk-heading-xl class="govuk-!-margin-bottom-0"
-      = t(".title", organisation_type: organisation_type_basic(current_organisation))
-    p
-      = t(".description", organisation_type: organisation_type_basic(current_organisation))
-
-    = render "school_group"
-
-    h2.govuk-heading-l class="govuk-!-margin-bottom-0"
-      = t(".schools", count: current_organisation.schools.not_closed.count)
-
-    .schools
-      = render "schools"
-
-  .govuk-grid-column-one-third
-    .missing-information
-      h3.govuk-heading-m
-        = t(".missing_information_title")
+      h1.govuk-heading-xl class="govuk-!-margin-bottom-0"
+        = t(".title", organisation_type: organisation_type_basic(current_organisation))
       p
-        = t(".missing_information_description_html", organisation_type: organisation_type_basic(current_organisation), mail_to: govuk_mail_to(t("help.email"), t(".contact_support")))
+        = t(".description", organisation_type: organisation_type_basic(current_organisation))
+
+      = render "school_group"
+
+      h2.govuk-heading-l class="govuk-!-margin-bottom-0"
+        = t(".schools", count: current_organisation.schools.not_closed.count)
+
+      .schools
+        = render "schools"
+
+    .govuk-grid-column-one-third
+      .missing-information
+        h3.govuk-heading-m
+          = t(".missing_information_title")
+        p
+          = t(".missing_information_description_html", organisation_type: organisation_type_basic(current_organisation), mail_to: govuk_mail_to(t("help.email"), t(".contact_support")))

--- a/app/views/publishers/sessions/new.html.slim
+++ b/app/views/publishers/sessions/new.html.slim
@@ -1,20 +1,21 @@
 - content_for :page_title_prefix, t(".sign_in.title")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    h1.govuk-heading-l = t(".sign_in.title")
-    p = t(".sign_in.description")
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      h1.govuk-heading-l = t(".sign_in.title")
+      p = t(".sign_in.description")
 
-    - if AuthenticationFallback.enabled?
-      = govuk_link_to t("buttons.sign_in"), new_auth_email_path, class: "govuk-button govuk-!-margin-bottom-0"
-    - else
-      = govuk_button_to t("buttons.sign_in"), publisher_dfe_omniauth_authorize_path, class: "govuk-!-margin-bottom-0", form_class: "publisher-sign-in"
+      - if AuthenticationFallback.enabled?
+        = govuk_link_to t("buttons.sign_in"), new_auth_email_path, class: "govuk-button govuk-!-margin-bottom-0"
+      - else
+        = govuk_button_to t("buttons.sign_in"), publisher_dfe_omniauth_authorize_path, class: "govuk-!-margin-bottom-0", form_class: "publisher-sign-in"
 
-    hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
-    h2.govuk-heading-m = t(".request_account_title")
-    p = t(".request_account_html", mail_to: govuk_mail_to(t("help.email"), t("help.email")))
+      hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
+      h2.govuk-heading-m = t(".request_account_title")
+      p = t(".request_account_html", mail_to: govuk_mail_to(t("help.email"), t("help.email")))
 
-  .govuk-grid-column-one-third
-    .account-sidebar
-      h2.account-sidebar__heading = t(".assistance.heading")
-      p.govuk-body-s = t(".assistance.content_html", link: govuk_link_to(t(".assistance.link_text"), new_jobseeker_session_path))
+    .govuk-grid-column-one-third
+      .account-sidebar
+        h2.account-sidebar__heading = t(".assistance.heading")
+        p.govuk-body-s = t(".assistance.content_html", link: govuk_link_to(t(".assistance.link_text"), new_jobseeker_session_path))

--- a/app/views/publishers/sign_in/email/sessions/check_your_email.html.slim
+++ b/app/views/publishers/sign_in/email/sessions/check_your_email.html.slim
@@ -1,10 +1,11 @@
 - content_for :page_title_prefix, t("publishers.temp_login.check_your_email.page_title")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
 
-    h1.govuk-heading-l = t("publishers.temp_login.check_your_email.heading")
+      h1.govuk-heading-l = t("publishers.temp_login.check_your_email.heading")
 
-    p = t("publishers.temp_login.check_your_email.sent")
+      p.govuk-body = t("publishers.temp_login.check_your_email.sent")
 
-    p = t("publishers.temp_login.check_your_email.check_spam_html", try_again: govuk_link_to("try again", new_publisher_session_path))
+      p.govuk-body = t("publishers.temp_login.check_your_email.check_spam_html", try_again: govuk_link_to("try again", new_publisher_session_path))

--- a/app/views/publishers/sign_in/email/sessions/choose_organisation.html.slim
+++ b/app/views/publishers/sign_in/email/sessions/choose_organisation.html.slim
@@ -1,17 +1,18 @@
 - content_for :page_title_prefix, t("publishers.temp_login.choose_organisation.page_title")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    - if @reason_for_failing_sign_in
-      = render(Shared::NotificationComponent.new(content: { title: t("publishers.temp_login.choose_organisation.denial.title"), body: t("publishers.temp_login.choose_organisation.denial.#{@reason_for_failing_sign_in}_html", try_again: govuk_link_to("try again", new_publisher_session_path)) }, style: "notice", background: true, dismiss: false))
-    - else
-      h1.govuk-heading-l = t("publishers.temp_login.choose_organisation.heading")
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      - if @reason_for_failing_sign_in
+        = render(Shared::NotificationComponent.new(content: { title: t("publishers.temp_login.choose_organisation.denial.title"), body: t("publishers.temp_login.choose_organisation.denial.#{@reason_for_failing_sign_in}_html", try_again: govuk_link_to("try again", new_publisher_session_path)) }, style: "notice", background: true, dismiss: false))
+      - else
+        h1.govuk-heading-l = t("publishers.temp_login.choose_organisation.heading")
 
-      p = t("publishers.temp_login.choose_organisation.please_select")
+        p = t("publishers.temp_login.choose_organisation.please_select")
 
-      - @publisher.organisations.each do |organisation|
-        p
-          - if organisation.is_a?(School)
-            = govuk_link_to(location(organisation), auth_email_create_session_path(organisation_id: organisation.id))
-          - else
-            = govuk_link_to(organisation.name, auth_email_create_session_path(organisation_id: organisation.id))
+        - @publisher.organisations.each do |organisation|
+          p
+            - if organisation.is_a?(School)
+              = govuk_link_to(location(organisation), auth_email_create_session_path(organisation_id: organisation.id))
+            - else
+              = govuk_link_to(organisation.name, auth_email_create_session_path(organisation_id: organisation.id))

--- a/app/views/publishers/sign_in/email/sessions/new.html.slim
+++ b/app/views/publishers/sign_in/email/sessions/new.html.slim
@@ -1,27 +1,28 @@
 - content_for :page_title_prefix, t("publishers.sessions.new.sign_in.title")
 
-.govuk-grid-row
-  .govuk-grid-column-full
-    = render(Shared::NotificationComponent.new(content: { title: t("publishers.temp_login.heading"), body: t("publishers.temp_login.please_use_email") }, style: "danger"))
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-full
+      = render(Shared::NotificationComponent.new(content: { title: t("publishers.temp_login.heading"), body: t("publishers.temp_login.please_use_email") }, style: "danger"))
 
-  .govuk-grid-column-two-thirds
-    h1.govuk-heading-l = t("publishers.sessions.new.sign_in.title")
+    .govuk-grid-column-two-thirds
+      h1.govuk-heading-l = t("publishers.sessions.new.sign_in.title")
 
-    p = t("publishers.sessions.new.sign_in.description")
+      p = t("publishers.sessions.new.sign_in.description")
 
-    = form_for Publisher.new, url: auth_email_check_your_email_path do |f|
-      = f.govuk_email_field :email
+      = form_for Publisher.new, url: auth_email_check_your_email_path do |f|
+        = f.govuk_email_field :email
 
-      = f.govuk_submit t("buttons.continue"), classes: "fallback-authentication-submit-email-gtm govuk-!-margin-bottom-0"
+        = f.govuk_submit t("buttons.continue"), classes: "fallback-authentication-submit-email-gtm govuk-!-margin-bottom-0"
 
-    hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
+      hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
 
-    h2.govuk-heading-m = t("publishers.sessions.new.request_account_title")
+      h2.govuk-heading-m = t("publishers.sessions.new.request_account_title")
 
-    p = t("publishers.sessions.new.request_account_html", mail_to: govuk_mail_to(t("help.email"), t("help.email")))
+      p = t("publishers.sessions.new.request_account_html", mail_to: govuk_mail_to(t("help.email"), t("help.email")))
 
-  .govuk-grid-column-one-third
-    .account-sidebar
-      h2.account-sidebar__heading = t("publishers.sessions.new.assistance.heading")
+    .govuk-grid-column-one-third
+      .account-sidebar
+        h2.account-sidebar__heading = t("publishers.sessions.new.assistance.heading")
 
-      p.govuk-body-s = t("publishers.sessions.new.assistance.content_html", link: govuk_link_to(t("publishers.sessions.new.assistance.link_text"), new_jobseeker_session_path))
+        p.govuk-body-s = t("publishers.sessions.new.assistance.content_html", link: govuk_link_to(t("publishers.sessions.new.assistance.link_text"), new_jobseeker_session_path))

--- a/app/views/publishers/terms_and_conditions/show.html.slim
+++ b/app/views/publishers/terms_and_conditions/show.html.slim
@@ -1,24 +1,25 @@
 - content_for :page_title_prefix, t("terms_and_conditions.page_title")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    = form_for @terms_and_conditions_form, url: terms_and_conditions_path, method: :patch do |f|
-      = f.govuk_error_summary
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = form_for @terms_and_conditions_form, url: terms_and_conditions_path, method: :patch do |f|
+        = f.govuk_error_summary
 
-      h1.govuk-heading-xl = t("terms_and_conditions.page_title")
-      p = t("terms_and_conditions.intro_html", link: govuk_link_to(t("terms_and_conditions.intro_link_text"), page_path("terms-and-conditions")))
-      p = t("terms_and_conditions.schools_section_html", link: govuk_link_to(t("terms_and_conditions.schools_section_link_text"), page_path("terms-and-conditions", anchor: "terms-and-conditions-for-schools-trusts-and-local-authorities-las")))
-      ul.govuk-list.govuk-list--bullet
-        - t("terms_and_conditions.summary_list").each do |item|
-          li = item
+        h1.govuk-heading-xl = t("terms_and_conditions.page_title")
+        p = t("terms_and_conditions.intro_html", link: govuk_link_to(t("terms_and_conditions.intro_link_text"), page_path("terms-and-conditions")))
+        p = t("terms_and_conditions.schools_section_html", link: govuk_link_to(t("terms_and_conditions.schools_section_link_text"), page_path("terms-and-conditions", anchor: "terms-and-conditions-for-schools-trusts-and-local-authorities-las")))
+        ul.govuk-list.govuk-list--bullet
+          - t("terms_and_conditions.summary_list").each do |item|
+            li = item
 
-      = f.govuk_check_boxes_fieldset :terms,
-        legend: { text: t("terms_and_conditions.please_accept"), size: "m" } do
+        = f.govuk_check_boxes_fieldset :terms,
+          legend: { text: t("terms_and_conditions.please_accept"), size: "m" } do
 
-        = f.govuk_check_box :terms,
-          true,
-          multiple: false,
-          link_errors: true,
-          label: { text: t("terms_and_conditions.label") }
+          = f.govuk_check_box :terms,
+            true,
+            multiple: false,
+            link_errors: true,
+            label: { text: t("terms_and_conditions.label") }
 
-      = f.govuk_submit t("buttons.accept_and_continue")
+        = f.govuk_submit t("buttons.accept_and_continue")

--- a/app/views/publishers/vacancies/_show.html.slim
+++ b/app/views/publishers/vacancies/_show.html.slim
@@ -1,26 +1,27 @@
 - content_for :page_title_prefix, "#{@vacancy.job_title} - #{@vacancy.parent_organisation.name}"
 
-.vacancy
-  .share-url-info
-    .govuk-grid-row
-      .govuk-grid-column-one-half
-        .share-url.display-none class="govuk-!-margin-bottom-6"
-          h2.govuk-heading-m class="govuk-!-margin-top-0" | Share this job
-          = govuk_link_to(t("jobs.view_public_link"), @vacancy.share_url, "aria-label": t("jobs.view_public_link"))
-          | , or
-          = govuk_link_to(t("jobs.copy_public_url"), "#", class: "copy-to-clipboard", "data-clipboard-text": @vacancy.share_url, "aria-label": t("jobs.copy_public_url"))
-        .share-url-no-js class="govuk-!-margin-bottom-6"
-          h2.govuk-heading-s class="govuk-!-margin-top-0" | Share this job
-          = govuk_link_to("#{t('jobs.view_public_link')} (#{@vacancy.share_url})", job_path(@vacancy))
-        = render partial: "/shared/vacancy/share_buttons"
-      .govuk-grid-column-one-half
-        .og-preview
-          .og_image = image_pack_tag "og_image.jpg"
-          .og_text
-            .og_url = t("app.title")
-            .og_title #{@vacancy.job_title} - #{@vacancy.parent_organisation.name}
-            .og_description = truncate(strip_tags(@vacancy.job_summary), length: 76, separator: " ")
-        .og-caption
-          | Your job listing will appear on Facebook in a format similar to the above.
+.govuk-main-wrapper
+  .vacancy
+    .share-url-info
+      .govuk-grid-row
+        .govuk-grid-column-one-half
+          .share-url.display-none class="govuk-!-margin-bottom-6"
+            h2.govuk-heading-m class="govuk-!-margin-top-0" | Share this job
+            = govuk_link_to(t("jobs.view_public_link"), @vacancy.share_url, "aria-label": t("jobs.view_public_link"))
+            | , or
+            = govuk_link_to(t("jobs.copy_public_url"), "#", class: "copy-to-clipboard", "data-clipboard-text": @vacancy.share_url, "aria-label": t("jobs.copy_public_url"))
+          .share-url-no-js class="govuk-!-margin-bottom-6"
+            h2.govuk-heading-s class="govuk-!-margin-top-0" | Share this job
+            = govuk_link_to("#{t('jobs.view_public_link')} (#{@vacancy.share_url})", job_path(@vacancy))
+          = render partial: "/shared/vacancy/share_buttons"
+        .govuk-grid-column-one-half
+          .og-preview
+            .og_image = image_pack_tag "og_image.jpg"
+            .og_text
+              .og_url = t("app.title")
+              .og_title #{@vacancy.job_title} - #{@vacancy.parent_organisation.name}
+              .og_description = truncate(strip_tags(@vacancy.job_summary), length: 76, separator: " ")
+          .og-caption
+            | Your job listing will appear on Facebook in a format similar to the above.
 
-  = render "/shared/vacancy/jobseeker_view"
+    = render "/shared/vacancy/jobseeker_view"

--- a/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
+++ b/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
@@ -1,43 +1,44 @@
 - content_for :page_title_prefix, page_title_prefix(@vacancy, @form, t("jobs.applying_for_the_job"))
 
-.govuk-grid-row
-  .govuk-grid-column-full
-    = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy, process_steps.current_step_number, process_steps.total_steps)
-    = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: previous_wizard_path)
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-full
+      = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy, process_steps.current_step_number, process_steps.total_steps)
+      = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: previous_wizard_path)
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    = form_for @form, url: wizard_path, method: :patch do |f|
-      = f.govuk_error_summary
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = form_for @form, url: wizard_path, method: :patch do |f|
+        = f.govuk_error_summary
 
-      h2.govuk-heading-l = t("jobs.applying_for_the_job")
+        h2.govuk-heading-l = t("jobs.applying_for_the_job")
 
-      = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f
+        = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f
 
-      - if JobseekerApplicationsFeature.enabled?
-        = f.govuk_radio_buttons_fieldset :apply_through_teaching_vacancies do
-          = f.govuk_radio_button :apply_through_teaching_vacancies, :yes, link_errors: true do
-            = f.govuk_text_area :personal_statement_guidance, label: { size: "s" }
+        - if JobseekerApplicationsFeature.enabled?
+          = f.govuk_radio_buttons_fieldset :apply_through_teaching_vacancies do
+            = f.govuk_radio_button :apply_through_teaching_vacancies, :yes, link_errors: true do
+              = f.govuk_text_area :personal_statement_guidance, label: { size: "s" }
 
-          = f.govuk_radio_button :apply_through_teaching_vacancies, :no do
-            = f.govuk_url_field :application_link, label: { size: "s" }, form_group: { classes: "optional-field" }
+            = f.govuk_radio_button :apply_through_teaching_vacancies, :no do
+              = f.govuk_url_field :application_link, label: { size: "s" }, form_group: { classes: "optional-field" }
 
-      = f.govuk_email_field :contact_email, label: { size: "s" }, required: true, width: "two-thirds"
+        = f.govuk_email_field :contact_email, label: { size: "s" }, required: true, width: "two-thirds"
 
-      = f.govuk_phone_field :contact_number, label: { size: "s" }, width: "one-third", form_group: { classes: "optional-field" }
+        = f.govuk_phone_field :contact_number, label: { size: "s" }, width: "one-third", form_group: { classes: "optional-field" }
 
-      = f.govuk_text_area :school_visits,
-        label: { text: t("helpers.label.publishers_job_listing_applying_for_the_job_form.#{school_or_trust_visits(@vacancy.parent_organisation)}"), size: "s" },
-        hint: { text: vacancy_school_visits_hint(@vacancy) },
-        rows: 10,
-        form_group: { classes: "optional-field" }
+        = f.govuk_text_area :school_visits,
+          label: { text: t("helpers.label.publishers_job_listing_applying_for_the_job_form.#{school_or_trust_visits(@vacancy.parent_organisation)}"), size: "s" },
+          hint: { text: vacancy_school_visits_hint(@vacancy) },
+          rows: 10,
+          form_group: { classes: "optional-field" }
 
-      - unless JobseekerApplicationsFeature.enabled?
-        = f.govuk_text_area :how_to_apply, label: { size: "s" }, rows: 10, form_group: { classes: "optional-field" }
+        - unless JobseekerApplicationsFeature.enabled?
+          = f.govuk_text_area :how_to_apply, label: { size: "s" }, rows: 10, form_group: { classes: "optional-field" }
 
-        = f.govuk_url_field :application_link, label: { size: "s" }, form_group: { classes: "optional-field" }
+          = f.govuk_url_field :application_link, label: { size: "s" }, form_group: { classes: "optional-field" }
 
-      = render "publishers/vacancies/vacancy_form_partials/submit", f: f
+        = render "publishers/vacancies/vacancy_form_partials/submit", f: f
 
-  .govuk-grid-column-one-third
-    = render(Shared::ProcessStepsComponent.new(process: @vacancy, service: process_steps, title: t("publishers.vacancies.build.process_title")))
+    .govuk-grid-column-one-third
+      = render(Shared::ProcessStepsComponent.new(process: @vacancy, service: process_steps, title: t("publishers.vacancies.build.process_title")))

--- a/app/views/publishers/vacancies/build/important_dates.html.slim
+++ b/app/views/publishers/vacancies/build/important_dates.html.slim
@@ -1,46 +1,47 @@
 - content_for :page_title_prefix, page_title_prefix(@vacancy, @form, t("jobs.important_dates"))
 
-.govuk-grid-row
-  .govuk-grid-column-full
-    = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy, process_steps.current_step_number, process_steps.total_steps)
-    = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: previous_wizard_path)
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-full
+      = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy, process_steps.current_step_number, process_steps.total_steps)
+      = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: previous_wizard_path)
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    = form_for @form, url: wizard_path, method: :patch do |f|
-      = f.govuk_error_summary
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = form_for @form, url: wizard_path, method: :patch do |f|
+        = f.govuk_error_summary
 
-      h2.govuk-heading-l = t("jobs.important_dates")
+        h2.govuk-heading-l = t("jobs.important_dates")
 
-      = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f
+        = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f
 
-      - if @form.disable_editing_publish_on?
-        #publish_on
-          legend.govuk-fieldset__legend.govuk-fieldset__legend--s
-            h1.govuk-fieldset__heading = t("helpers.legend.publishers_job_listing_important_dates_form.publish_on")
-          p = format_date @vacancy.publish_on
-        br
-        .display-none
+        - if @form.disable_editing_publish_on?
+          #publish_on
+            legend.govuk-fieldset__legend.govuk-fieldset__legend--s
+              h1.govuk-fieldset__heading = t("helpers.legend.publishers_job_listing_important_dates_form.publish_on")
+            p = format_date @vacancy.publish_on
+          br
+          .display-none
+            = f.govuk_date_field :publish_on
+        - else
           = f.govuk_date_field :publish_on
-      - else
-        = f.govuk_date_field :publish_on
 
-      = f.govuk_date_field :expires_on
+        = f.govuk_date_field :expires_on
 
-      = render "publishers/vacancies/expires_at_field", f: f
+        = render "publishers/vacancies/expires_at_field", f: f
 
-      .clear-form.optional-field
-        = f.govuk_date_field :starts_on
+        .clear-form.optional-field
+          = f.govuk_date_field :starts_on
 
-        .clear-form__checkbox
-          = f.govuk_check_box :starts_asap,
-            true,
-            0,
-            multiple: false,
-            link_errors: false,
-            label: { text: t("helpers.legend.publishers_job_listing_important_dates_form.starts_asap") }
+          .clear-form__checkbox
+            = f.govuk_check_box :starts_asap,
+              true,
+              0,
+              multiple: false,
+              link_errors: false,
+              label: { text: t("helpers.legend.publishers_job_listing_important_dates_form.starts_asap") }
 
-      = render "publishers/vacancies/vacancy_form_partials/submit", f: f
+        = render "publishers/vacancies/vacancy_form_partials/submit", f: f
 
-  .govuk-grid-column-one-third
-    = render(Shared::ProcessStepsComponent.new(process: @vacancy, service: process_steps, title: t("publishers.vacancies.build.process_title")))
+    .govuk-grid-column-one-third
+      = render(Shared::ProcessStepsComponent.new(process: @vacancy, service: process_steps, title: t("publishers.vacancies.build.process_title")))

--- a/app/views/publishers/vacancies/build/job_details.html.slim
+++ b/app/views/publishers/vacancies/build/job_details.html.slim
@@ -1,59 +1,60 @@
 - content_for :page_title_prefix, page_title_prefix(@vacancy, @form, t("jobs.job_details"))
 
-.govuk-grid-row
-  .govuk-grid-column-full
-    = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy, process_steps.current_step_number, process_steps.total_steps)
-    = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: @job_details_back_path, current_step_is_first_step: current_organisation.is_a?(School))
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-full
+      = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy, process_steps.current_step_number, process_steps.total_steps)
+      = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: @job_details_back_path, current_step_is_first_step: current_organisation.is_a?(School))
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    = form_for @form, url: wizard_path, method: :patch do |f|
-      = f.govuk_error_summary
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = form_for @form, url: wizard_path, method: :patch do |f|
+        = f.govuk_error_summary
 
-      h2.govuk-heading-l = t("jobs.job_details")
+        h2.govuk-heading-l = t("jobs.job_details")
 
-      = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f
+        = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f
 
-      .govuk-character-count data-module="govuk-character-count" data-maxlength=100
-        = f.govuk_text_field :job_title,
-          id: "publishers_job_listing_job_details_form_job_title",
-          label: { size: "s" },
-          class: "govuk-input string required govuk-js-character-count",
-          required: true
-        span#publishers_job_listing_job_details_form_job_title-info.govuk-hint.govuk-character-count__message aria-live="polite"
-          | You can enter up to 100 characters
+        .govuk-character-count data-module="govuk-character-count" data-maxlength=100
+          = f.govuk_text_field :job_title,
+            id: "publishers_job_listing_job_details_form_job_title",
+            label: { size: "s" },
+            class: "govuk-input string required govuk-js-character-count",
+            required: true
+          span#publishers_job_listing_job_details_form_job_title-info.govuk-hint.govuk-character-count__message aria-live="polite"
+            | You can enter up to 100 characters
 
-      = f.govuk_collection_check_boxes :job_roles, Vacancy.job_roles.except("nqt_suitable").keys, :to_s, :to_s, form_group: { classes: "optional-field" }
+        = f.govuk_collection_check_boxes :job_roles, Vacancy.job_roles.except("nqt_suitable").keys, :to_s, :to_s, form_group: { classes: "optional-field" }
 
-      = f.govuk_collection_radio_buttons :suitable_for_nqt, %w[yes no], :to_s, :capitalize
+        = f.govuk_collection_radio_buttons :suitable_for_nqt, %w[yes no], :to_s, :capitalize
 
-      .optional-field
-        = f.govuk_fieldset legend: { text: t("helpers.legend.publishers_job_listing_job_details_form.subjects") } do
+        .optional-field
+          = f.govuk_fieldset legend: { text: t("helpers.legend.publishers_job_listing_job_details_form.subjects") } do
 
-          label for="publishers-job-listing-job-details-form-subject-search"
-            span.govuk-visually-hidden | Subject filter
-          span.govuk-hint#publishers-job-listing-job-details-form-subjects-hint
-            = t("helpers.hint.publishers_job_listing_job_details_form.subjects")
+            label for="publishers-job-listing-job-details-form-subject-search"
+              span.govuk-visually-hidden | Subject filter
+            span.govuk-hint#publishers-job-listing-job-details-form-subjects-hint
+              = t("helpers.hint.publishers_job_listing_job_details_form.subjects")
 
-          div class="govuk-!-margin-bottom-6"
-            = render Shared::SearchableCollectionComponent.new(form: f,
-              threshold: 10,
-              scrollable: true,
-              attribute_name: :subjects,
-              collection: SUBJECT_OPTIONS,
-              value_method: :first,
-              text_method: :first,
-              hint_method: :last).with_variant(:checkbox)
+            div class="govuk-!-margin-bottom-6"
+              = render Shared::SearchableCollectionComponent.new(form: f,
+                threshold: 10,
+                scrollable: true,
+                attribute_name: :subjects,
+                collection: SUBJECT_OPTIONS,
+                value_method: :first,
+                text_method: :first,
+                hint_method: :last).with_variant(:checkbox)
 
-      = f.govuk_collection_check_boxes :working_patterns, Vacancy.working_patterns.keys, :to_s, :to_s
+        = f.govuk_collection_check_boxes :working_patterns, Vacancy.working_patterns.keys, :to_s, :to_s
 
-      = f.govuk_radio_buttons_fieldset :contract_type do
-        = f.govuk_radio_button :contract_type, :permanent, link_errors: true
+        = f.govuk_radio_buttons_fieldset :contract_type do
+          = f.govuk_radio_button :contract_type, :permanent, link_errors: true
 
-        = f.govuk_radio_button :contract_type, :fixed_term do
-          = f.govuk_text_field :contract_type_duration, label: { size: "s" }
+          = f.govuk_radio_button :contract_type, :fixed_term do
+            = f.govuk_text_field :contract_type_duration, label: { size: "s" }
 
-      = render "publishers/vacancies/vacancy_form_partials/submit", f: f
+        = render "publishers/vacancies/vacancy_form_partials/submit", f: f
 
-  .govuk-grid-column-one-third
-    = render(Shared::ProcessStepsComponent.new(process: @vacancy, service: process_steps, title: t("publishers.vacancies.build.process_title")))
+    .govuk-grid-column-one-third
+      = render(Shared::ProcessStepsComponent.new(process: @vacancy, service: process_steps, title: t("publishers.vacancies.build.process_title")))

--- a/app/views/publishers/vacancies/build/job_location.html.slim
+++ b/app/views/publishers/vacancies/build/job_location.html.slim
@@ -1,22 +1,23 @@
 - content_for :page_title_prefix, page_title_prefix(@vacancy, @form, t("jobs.job_details"))
 
-.govuk-grid-row
-  .govuk-grid-column-full
-    = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy, process_steps.current_step_number, process_steps.total_steps)
-    = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, current_step_is_first_step: true)
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-full
+      = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy, process_steps.current_step_number, process_steps.total_steps)
+      = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, current_step_is_first_step: true)
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    = form_for @form, url: wizard_path, method: :patch do |f|
-      = f.govuk_error_summary
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = form_for @form, url: wizard_path, method: :patch do |f|
+        = f.govuk_error_summary
 
-      h2.govuk-heading-l = t("jobs.job_location")
+        h2.govuk-heading-l = t("jobs.job_location")
 
-      = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f
+        = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f
 
-      = f.govuk_collection_radio_buttons :job_location, job_location_options(current_organisation), :last, :first
+        = f.govuk_collection_radio_buttons :job_location, job_location_options(current_organisation), :last, :first
 
-      = render "publishers/vacancies/vacancy_form_partials/continue_or_update_submit", f: f
+        = render "publishers/vacancies/vacancy_form_partials/continue_or_update_submit", f: f
 
-  .govuk-grid-column-one-third
-    = render(Shared::ProcessStepsComponent.new(process: @vacancy, service: process_steps, title: t("publishers.vacancies.build.process_title")))
+    .govuk-grid-column-one-third
+      = render(Shared::ProcessStepsComponent.new(process: @vacancy, service: process_steps, title: t("publishers.vacancies.build.process_title")))

--- a/app/views/publishers/vacancies/build/job_summary.html.slim
+++ b/app/views/publishers/vacancies/build/job_summary.html.slim
@@ -1,29 +1,30 @@
 - content_for :page_title_prefix, page_title_prefix(@vacancy, @form, t("jobs.job_summary"))
 
-.govuk-grid-row
-  .govuk-grid-column-full
-    = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy, process_steps.current_step_number, process_steps.total_steps)
-    = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: previous_wizard_path)
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-full
+      = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy, process_steps.current_step_number, process_steps.total_steps)
+      = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: previous_wizard_path)
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    = form_for @form, url: wizard_path, method: :patch do |f|
-      = f.govuk_error_summary
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = form_for @form, url: wizard_path, method: :patch do |f|
+        = f.govuk_error_summary
 
-      h2.govuk-heading-l = t("jobs.job_summary")
+        h2.govuk-heading-l = t("jobs.job_summary")
 
-      = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f
+        = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f
 
-      = f.govuk_text_area :job_summary, label: { size: "s" }, rows: 10, required: true
+        = f.govuk_text_area :job_summary, label: { size: "s" }, rows: 10, required: true
 
-      = f.govuk_text_area :about_school,
-        label: { text: t("helpers.label.publishers_job_listing_job_summary_form.about_organisation", organisation: vacancy_about_school_label_organisation(@vacancy)), size: "s" },
-        hint: { text: vacancy_about_school_hint_text(@vacancy) },
-        value: vacancy_about_school_value(@vacancy),
-        rows: 10,
-        required: true
+        = f.govuk_text_area :about_school,
+          label: { text: t("helpers.label.publishers_job_listing_job_summary_form.about_organisation", organisation: vacancy_about_school_label_organisation(@vacancy)), size: "s" },
+          hint: { text: vacancy_about_school_hint_text(@vacancy) },
+          value: vacancy_about_school_value(@vacancy),
+          rows: 10,
+          required: true
 
-      = render "publishers/vacancies/vacancy_form_partials/submit", f: f
+        = render "publishers/vacancies/vacancy_form_partials/submit", f: f
 
-  .govuk-grid-column-one-third
-    = render(Shared::ProcessStepsComponent.new(process: @vacancy, service: process_steps, title: t("publishers.vacancies.build.process_title")))
+    .govuk-grid-column-one-third
+      = render(Shared::ProcessStepsComponent.new(process: @vacancy, service: process_steps, title: t("publishers.vacancies.build.process_title")))

--- a/app/views/publishers/vacancies/build/pay_package.html.slim
+++ b/app/views/publishers/vacancies/build/pay_package.html.slim
@@ -1,24 +1,25 @@
 - content_for :page_title_prefix, page_title_prefix(@vacancy, @form, t("jobs.pay_package"))
 
-.govuk-grid-row
-  .govuk-grid-column-full
-    = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy, process_steps.current_step_number, process_steps.total_steps)
-    = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: previous_wizard_path)
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-full
+      = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy, process_steps.current_step_number, process_steps.total_steps)
+      = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: previous_wizard_path)
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    = form_for @form, url: wizard_path, method: :patch do |f|
-      = f.govuk_error_summary
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = form_for @form, url: wizard_path, method: :patch do |f|
+        = f.govuk_error_summary
 
-      h2.govuk-heading-l = t("jobs.pay_package")
+        h2.govuk-heading-l = t("jobs.pay_package")
 
-      = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f
+        = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f
 
-      = f.govuk_text_field :salary, label: { size: "s" }, required: true
+        = f.govuk_text_field :salary, label: { size: "s" }, required: true
 
-      = f.govuk_text_area :benefits, label: { size: "s" }, form_group: { classes: "optional-field" }
+        = f.govuk_text_area :benefits, label: { size: "s" }, form_group: { classes: "optional-field" }
 
-      = render "publishers/vacancies/vacancy_form_partials/submit", f: f
+        = render "publishers/vacancies/vacancy_form_partials/submit", f: f
 
-  .govuk-grid-column-one-third
-    = render(Shared::ProcessStepsComponent.new(process: @vacancy, service: process_steps, title: t("publishers.vacancies.build.process_title")))
+    .govuk-grid-column-one-third
+      = render(Shared::ProcessStepsComponent.new(process: @vacancy, service: process_steps, title: t("publishers.vacancies.build.process_title")))

--- a/app/views/publishers/vacancies/build/schools.html.slim
+++ b/app/views/publishers/vacancies/build/schools.html.slim
@@ -1,30 +1,31 @@
 - content_for :page_title_prefix, page_title_prefix(@vacancy, @form, t("jobs.job_location"))
 
-.govuk-grid-row
-  .govuk-grid-column-full
-    = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy, process_steps.current_step_number, process_steps.total_steps)
-    = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: previous_wizard_path)
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-full
+      = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy, process_steps.current_step_number, process_steps.total_steps)
+      = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: previous_wizard_path)
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    = form_for @form, url: wizard_path, method: :patch do |f|
-      = f.govuk_error_summary
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = form_for @form, url: wizard_path, method: :patch do |f|
+        = f.govuk_error_summary
 
-      h2.govuk-heading-l = t("jobs.job_location")
+        h2.govuk-heading-l = t("jobs.job_location")
 
-      = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f
+        = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f
 
-      = f.govuk_fieldset legend: { text: t("helpers.legend.publishers_job_listing_schools_form.organisation_ids") } do
-        = render Shared::SearchableCollectionComponent.new(form: f,
-          threshold: 10,
-          attribute_name: :organisation_ids,
-          collection: @school_options,
-          value_method: :id,
-          text_method: :name,
-          hint_method: :address).with_variant(@multiple_schools ? :checkbox : :radiobutton)
+        = f.govuk_fieldset legend: { text: t("helpers.legend.publishers_job_listing_schools_form.organisation_ids") } do
+          = render Shared::SearchableCollectionComponent.new(form: f,
+            threshold: 10,
+            attribute_name: :organisation_ids,
+            collection: @school_options,
+            value_method: :id,
+            text_method: :name,
+            hint_method: :address).with_variant(@multiple_schools ? :checkbox : :radiobutton)
 
-      div class="govuk-!-margin-top-6"
-        = render "publishers/vacancies/vacancy_form_partials/continue_or_update_submit", f: f
+        div class="govuk-!-margin-top-6"
+          = render "publishers/vacancies/vacancy_form_partials/continue_or_update_submit", f: f
 
-  .govuk-grid-column-one-third
-    = render(Shared::ProcessStepsComponent.new(process: @vacancy, service: process_steps, title: t("publishers.vacancies.build.process_title")))
+    .govuk-grid-column-one-third
+      = render(Shared::ProcessStepsComponent.new(process: @vacancy, service: process_steps, title: t("publishers.vacancies.build.process_title")))

--- a/app/views/publishers/vacancies/copy/new.html.slim
+++ b/app/views/publishers/vacancies/copy/new.html.slim
@@ -1,38 +1,39 @@
 - content_for :page_title_prefix, "#{@copy_form.errors.present? ? 'Error: ' : ''}Copy a job for #{current_organisation.name}"
 
-.govuk-grid-row class="govuk-!-margin-top-7 govuk-!-margin-bottom-5"
-  .govuk-grid-column-full
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-full
 
-    h1.govuk-heading-m = t("jobs.copy_job_title", job_title: @copy_form.vacancy.job_title)
+      h1.govuk-heading-m = t("jobs.copy_job_title", job_title: @copy_form.vacancy.job_title)
 
-    = govuk_back_link text: t("buttons.cancel_copy"), href: organisation_path
+      = govuk_back_link text: t("buttons.cancel_copy"), href: organisation_path
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    = form_for @copy_form, url: organisation_job_copy_path, data: { vacancy_state: "copy" } do |f|
-      = f.govuk_error_summary
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = form_for @copy_form, url: organisation_job_copy_path, data: { vacancy_state: "copy" } do |f|
+        = f.govuk_error_summary
 
-      h2.govuk-heading-l = t("jobs.new_job_listing_details")
+        h2.govuk-heading-l = t("jobs.new_job_listing_details")
 
-      = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f, copy: true
+        = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f, copy: true
 
-      .govuk-character-count data-module="govuk-character-count" data-maxlength=100
-        = f.govuk_text_field :job_title,
-          id: "publishers_job_listing_copy_form_job_title",
-          label: { size: "s" },
-          class: "govuk-input string required govuk-js-character-count",
-          required: true
-        span#publishers_job_listing_copy_form_job_title-info.govuk-hint.govuk-character-count__message aria-live="polite"
-          | You can enter up to 100 characters
+        .govuk-character-count data-module="govuk-character-count" data-maxlength=100
+          = f.govuk_text_field :job_title,
+            id: "publishers_job_listing_copy_form_job_title",
+            label: { size: "s" },
+            class: "govuk-input string required govuk-js-character-count",
+            required: true
+          span#publishers_job_listing_copy_form_job_title-info.govuk-hint.govuk-character-count__message aria-live="polite"
+            | You can enter up to 100 characters
 
-      = f.govuk_date_field :publish_on
+        = f.govuk_date_field :publish_on
 
-      = f.govuk_date_field :expires_on
+        = f.govuk_date_field :expires_on
 
-      = render "publishers/vacancies/expires_at_field", f: f
+        = render "publishers/vacancies/expires_at_field", f: f
 
-      = f.govuk_date_field :starts_on
+        = f.govuk_date_field :starts_on
 
-      = f.govuk_submit classes: "govuk-!-margin-bottom-5"
+        = f.govuk_submit classes: "govuk-!-margin-bottom-5"
 
-    = govuk_link_to(t("buttons.cancel_copy"), organisation_path, class: "govuk-link--no-visited-state govuk-!-font-size-19")
+      = govuk_link_to(t("buttons.cancel_copy"), organisation_path, class: "govuk-link--no-visited-state govuk-!-font-size-19")

--- a/app/views/publishers/vacancies/documents/show.html.slim
+++ b/app/views/publishers/vacancies/documents/show.html.slim
@@ -1,41 +1,42 @@
 - content_for :page_title_prefix, page_title_prefix(@vacancy, @documents_form, t("jobs.supporting_documents"))
 
-.govuk-grid-row
-  .govuk-grid-column-full
-    = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy, process_steps.current_step_number, process_steps.total_steps)
-    = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: organisation_job_build_path(@vacancy.id, :important_dates))
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-full
+      = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy, process_steps.current_step_number, process_steps.total_steps)
+      = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: organisation_job_build_path(@vacancy.id, :important_dates))
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    = form_for @documents_form, url: organisation_job_documents_path(@vacancy.id) do |f|
-      = f.govuk_error_summary
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = form_for @documents_form, url: organisation_job_documents_path(@vacancy.id) do |f|
+        = f.govuk_error_summary
 
-      h2.govuk-heading-l
-        = t("jobs.supporting_documents")
+        h2.govuk-heading-l
+          = t("jobs.supporting_documents")
 
-      = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f
+        = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f
 
-      #js-xhr-flashes
+        #js-xhr-flashes
 
-      = f.govuk_file_field :documents,
-        label: { size: "s" },
-        accept: ".doc, .docx, .xls, .xlsx, .ppt, .pptx, .pdf, image/jpeg, image/png, video/mp4",
-        multiple: true,
-        enctype: "multipart/form-data"
+        = f.govuk_file_field :documents,
+          label: { size: "s" },
+          accept: ".doc, .docx, .xls, .xlsx, .ppt, .pptx, .pdf, image/jpeg, image/png, video/mp4",
+          multiple: true,
+          enctype: "multipart/form-data"
 
-      button.govuk-button.govuk-button--secondary.display-none#select-files-button class="govuk-!-margin-bottom-3"
-        = t("buttons.select_file")
+        button.govuk-button.govuk-button--secondary.display-none#select-files-button class="govuk-!-margin-bottom-3"
+          = t("buttons.select_file")
 
-      = f.govuk_submit t("buttons.upload_files"), secondary: true, classes: "upload-files-button"
+        = f.govuk_submit t("buttons.upload_files"), secondary: true, classes: "upload-files-button"
 
-      .js-documents class=("js-documents--empty" if @documents.none?)
-        = render "publishers/vacancies/documents/documents"
-        p.js-documents__no-files = t("jobs.no_files_message")
+        .js-documents class=("js-documents--empty" if @documents.none?)
+          = render "publishers/vacancies/documents/documents"
+          p.js-documents__no-files = t("jobs.no_files_message")
 
-      = render "publishers/vacancies/vacancy_form_partials/submit", f: f
+        = render "publishers/vacancies/vacancy_form_partials/submit", f: f
 
-  .govuk-grid-column-one-third
-    = render(Shared::ProcessStepsComponent.new(process: @vacancy, service: process_steps, title: t("publishers.vacancies.build.process_title")))
+    .govuk-grid-column-one-third
+      = render(Shared::ProcessStepsComponent.new(process: @vacancy, service: process_steps, title: t("publishers.vacancies.build.process_title")))
 
-- content_for :after_main do
-  = render "shared/file_remove_confirmation_dialogue"
+  - content_for :after_main do
+    = render "shared/file_remove_confirmation_dialogue"

--- a/app/views/publishers/vacancies/edit.html.slim
+++ b/app/views/publishers/vacancies/edit.html.slim
@@ -1,22 +1,23 @@
 - content_for :page_title_prefix, review_page_title_prefix(@vacancy)
 
-.govuk-grid-row
-  .govuk-grid-column-full
-    = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy, process_steps.current_step_number, process_steps.total_steps)
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-full
+      = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy, process_steps.current_step_number, process_steps.total_steps)
 
-.vacancy.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    = render "publishers/vacancies/edit_heading"
-    = render "publishers/vacancies/error_messages", errors: @vacancy.errors
+  .vacancy.govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = render "publishers/vacancies/edit_heading"
+      = render "publishers/vacancies/error_messages", errors: @vacancy.errors
 
-    ol.app-task-list
-      - if current_organisation.is_a?(SchoolGroup)
-        li = render "publishers/vacancies/edit_vacancy_sections/edit_job_location"
-      li = render "publishers/vacancies/edit_vacancy_sections/edit_job_details"
-      li = render "publishers/vacancies/edit_vacancy_sections/edit_pay_package"
-      li = render "publishers/vacancies/edit_vacancy_sections/edit_important_dates"
-      li = render "publishers/vacancies/edit_vacancy_sections/edit_supporting_documents"
-      li = render "publishers/vacancies/edit_vacancy_sections/edit_applying_for_the_job"
-      li = render "publishers/vacancies/edit_vacancy_sections/edit_job_summary"
+      ol.app-task-list
+        - if current_organisation.is_a?(SchoolGroup)
+          li = render "publishers/vacancies/edit_vacancy_sections/edit_job_location"
+        li = render "publishers/vacancies/edit_vacancy_sections/edit_job_details"
+        li = render "publishers/vacancies/edit_vacancy_sections/edit_pay_package"
+        li = render "publishers/vacancies/edit_vacancy_sections/edit_important_dates"
+        li = render "publishers/vacancies/edit_vacancy_sections/edit_supporting_documents"
+        li = render "publishers/vacancies/edit_vacancy_sections/edit_applying_for_the_job"
+        li = render "publishers/vacancies/edit_vacancy_sections/edit_job_summary"
 
-    = render "publishers/vacancies/back_to_manage_jobs"
+      = render "publishers/vacancies/back_to_manage_jobs"

--- a/app/views/publishers/vacancies/job_applications/reject.html.slim
+++ b/app/views/publishers/vacancies/job_applications/reject.html.slim
@@ -1,19 +1,20 @@
 - content_for :page_title_prefix, t(".page_title")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    h2.govuk-heading-m class="govuk-!-margin-bottom-0"
-      = "#{job_application.application_data['first_name']} #{job_application.application_data['last_name']}"
-    .govuk-caption-l
-      = t("jobseekers.job_applications.heading_component.caption",
-          job_title: vacancy.job_title, organisation_name: vacancy.parent_organisation_name)
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      h2.govuk-heading-m class="govuk-!-margin-bottom-0"
+        = "#{job_application.application_data['first_name']} #{job_application.application_data['last_name']}"
+      .govuk-caption-l
+        = t("jobseekers.job_applications.heading_component.caption",
+            job_title: vacancy.job_title, organisation_name: vacancy.parent_organisation_name)
 
-    h1.govuk-heading-xl class="govuk-!-margin-top-5 govuk-!-margin-bottom-5" = t(".heading")
+      h1.govuk-heading-xl class="govuk-!-margin-top-5 govuk-!-margin-bottom-5" = t(".heading")
 
-    = render Shared::NotificationComponent.new style: "danger", content: t(".alert"), alert: "info", dismiss: false
+      = render Shared::NotificationComponent.new style: "danger", content: t(".alert"), alert: "info", dismiss: false
 
-    = form_for form, url: organisation_job_job_application_update_status_path(vacancy.id, job_application.id) do |f|
-      = f.govuk_text_area :rejection_reasons, label: { size: "s" }, rows: 10, form_group: { classes: "optional-field" }
-      = f.govuk_submit t("buttons.reject")
+      = form_for form, url: organisation_job_job_application_update_status_path(vacancy.id, job_application.id) do |f|
+        = f.govuk_text_area :rejection_reasons, label: { size: "s" }, rows: 10, form_group: { classes: "optional-field" }
+        = f.govuk_submit t("buttons.reject")
 
-    = govuk_link_to t("buttons.cancel"), organisation_job_job_application_path(vacancy.id, job_application.id)
+      = govuk_link_to t("buttons.cancel"), organisation_job_job_application_path(vacancy.id, job_application.id)

--- a/app/views/publishers/vacancies/job_applications/shortlist.html.slim
+++ b/app/views/publishers/vacancies/job_applications/shortlist.html.slim
@@ -1,19 +1,20 @@
 - content_for :page_title_prefix, t(".page_title")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    h2.govuk-heading-m class="govuk-!-margin-bottom-0"
-      = "#{job_application.application_data['first_name']} #{job_application.application_data['last_name']}"
-    .govuk-caption-l
-      = t("jobseekers.job_applications.heading_component.caption",
-          job_title: vacancy.job_title, organisation_name: vacancy.parent_organisation_name)
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      h2.govuk-heading-m class="govuk-!-margin-bottom-0"
+        = "#{job_application.application_data['first_name']} #{job_application.application_data['last_name']}"
+      .govuk-caption-l
+        = t("jobseekers.job_applications.heading_component.caption",
+            job_title: vacancy.job_title, organisation_name: vacancy.parent_organisation_name)
 
-    h1.govuk-heading-xl class="govuk-!-margin-top-5 govuk-!-margin-bottom-5" = t(".heading")
+      h1.govuk-heading-xl class="govuk-!-margin-top-5 govuk-!-margin-bottom-5" = t(".heading")
 
-    = render Shared::NotificationComponent.new style: "danger", content: t(".alert"), alert: "info", dismiss: false
+      = render Shared::NotificationComponent.new style: "danger", content: t(".alert"), alert: "info", dismiss: false
 
-    = form_for form, url: organisation_job_job_application_update_status_path(vacancy.id, job_application.id) do |f|
-      = f.govuk_text_area :further_instructions, label: { size: "s" }, rows: 10, form_group: { classes: "optional-field" }
-      = f.govuk_submit t("buttons.shortlist")
+      = form_for form, url: organisation_job_job_application_update_status_path(vacancy.id, job_application.id) do |f|
+        = f.govuk_text_area :further_instructions, label: { size: "s" }, rows: 10, form_group: { classes: "optional-field" }
+        = f.govuk_submit t("buttons.shortlist")
 
-    = govuk_link_to t("buttons.cancel"), organisation_job_job_application_path(vacancy.id, job_application.id)
+      = govuk_link_to t("buttons.cancel"), organisation_job_job_application_path(vacancy.id, job_application.id)

--- a/app/views/publishers/vacancies/preview.html.slim
+++ b/app/views/publishers/vacancies/preview.html.slim
@@ -1,5 +1,6 @@
 - content_for :page_title_prefix, t("jobs.preview_listing.page_title", organisation: current_organisation.name)
 
-.vacancy
-  = render "/publishers/vacancies/preview_banner"
-  = render "/shared/vacancy/jobseeker_view"
+.govuk-main-wrapper
+  .vacancy
+    = render "/publishers/vacancies/preview_banner"
+    = render "/shared/vacancy/jobseeker_view"

--- a/app/views/publishers/vacancies/review.html.slim
+++ b/app/views/publishers/vacancies/review.html.slim
@@ -1,41 +1,42 @@
 - content_for :page_title_prefix, review_page_title_prefix(@vacancy)
 
-.govuk-grid-row
-  .govuk-grid-column-full
-    = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy, process_steps.current_step_number, process_steps.total_steps)
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-full
+      = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy, process_steps.current_step_number, process_steps.total_steps)
 
-.vacancy.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    = render "publishers/vacancies/edit_heading"
-    = render "publishers/vacancies/error_messages", errors: @vacancy.errors
+  .vacancy.govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = render "publishers/vacancies/edit_heading"
+      = render "publishers/vacancies/error_messages", errors: @vacancy.errors
 
-    p.govuk-body-l
-      - if @vacancy.publish_on.today?
-        = t("jobs.review")
-      - else
-        = t("jobs.review_future")
+      p.govuk-body-l
+        - if @vacancy.publish_on.today?
+          = t("jobs.review")
+        - else
+          = t("jobs.review_future")
 
-    ol.app-task-list
-      - if current_organisation.is_a?(SchoolGroup)
-        li = render "publishers/vacancies/edit_vacancy_sections/edit_job_location"
+      ol.app-task-list
+        - if current_organisation.is_a?(SchoolGroup)
+          li = render "publishers/vacancies/edit_vacancy_sections/edit_job_location"
 
-      li = render "publishers/vacancies/edit_vacancy_sections/edit_job_details"
-      li = render "publishers/vacancies/edit_vacancy_sections/edit_pay_package"
-      li = render "publishers/vacancies/edit_vacancy_sections/edit_important_dates"
-      li = render "publishers/vacancies/edit_vacancy_sections/edit_supporting_documents"
-      li = render "publishers/vacancies/edit_vacancy_sections/edit_applying_for_the_job"
-      li = render "publishers/vacancies/edit_vacancy_sections/edit_job_summary"
+        li = render "publishers/vacancies/edit_vacancy_sections/edit_job_details"
+        li = render "publishers/vacancies/edit_vacancy_sections/edit_pay_package"
+        li = render "publishers/vacancies/edit_vacancy_sections/edit_important_dates"
+        li = render "publishers/vacancies/edit_vacancy_sections/edit_supporting_documents"
+        li = render "publishers/vacancies/edit_vacancy_sections/edit_applying_for_the_job"
+        li = render "publishers/vacancies/edit_vacancy_sections/edit_job_summary"
 
-    h3.govuk-heading-m = t("jobs.preview_listing.heading")
-    p = t("jobs.preview_listing.message")
-    = govuk_link_to t("buttons.preview_job_listing"), organisation_job_preview_path(@vacancy.id), class: "preview-listing-gtm", id: "vacancy-review-preview", button: true
+      h3.govuk-heading-m = t("jobs.preview_listing.heading")
+      p = t("jobs.preview_listing.message")
+      = govuk_link_to t("buttons.preview_job_listing"), organisation_job_preview_path(@vacancy.id), class: "preview-listing-gtm", id: "vacancy-review-preview", button: true
 
-    h3.govuk-heading-m = t("jobs.submit_listing.heading", count: @vacancy.publish_on.today? ? 0 : 1, date: @vacancy.publish_on.to_s.strip)
-    p = t("jobs.submit_listing.message_html")
-    = govuk_button_to t("buttons.submit_job_listing"), organisation_job_publish_path(@vacancy.id), class: "govuk-button--secondary submit-listing-without-preview-gtm", id: "vacancy-review-submit"
+      h3.govuk-heading-m = t("jobs.submit_listing.heading", count: @vacancy.publish_on.today? ? 0 : 1, date: @vacancy.publish_on.to_s.strip)
+      p = t("jobs.submit_listing.message_html")
+      = govuk_button_to t("buttons.submit_job_listing"), organisation_job_publish_path(@vacancy.id), class: "govuk-button--secondary submit-listing-without-preview-gtm", id: "vacancy-review-submit"
 
-    br
-    = govuk_link_to t("buttons.back_to_manage_jobs"), jobs_with_type_organisation_path("draft", from_review: @vacancy.id), class: "govuk-link--no-visited-state"
+      br
+      = govuk_link_to t("buttons.back_to_manage_jobs"), jobs_with_type_organisation_path("draft", from_review: @vacancy.id), class: "govuk-link--no-visited-state"
 
-  .govuk-grid-column-one-third
-    = render(Shared::ProcessStepsComponent.new(process: @vacancy, service: process_steps, title: t("publishers.vacancies.build.process_title")))
+    .govuk-grid-column-one-third
+      = render(Shared::ProcessStepsComponent.new(process: @vacancy, service: process_steps, title: t("publishers.vacancies.build.process_title")))

--- a/app/views/publishers/vacancies/show.html.slim
+++ b/app/views/publishers/vacancies/show.html.slim
@@ -1,3 +1,1 @@
-.govuk-grid-row class="govuk-!-margin-top-4"
-  .govuk-grid-column-full
-    = render "publishers/vacancies/show"
+= render "publishers/vacancies/show"

--- a/app/views/publishers/vacancies/summary.html.slim
+++ b/app/views/publishers/vacancies/summary.html.slim
@@ -1,32 +1,33 @@
 - content_for :page_title_prefix, t(".page_title", organisation: current_organisation.name)
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    = govuk_panel title: t(".success"), body: ""
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = govuk_panel title: t(".success"), body: ""
 
-    h3.govuk-heading-m = t(".what_happens_next")
+      h3.govuk-heading-m = t(".what_happens_next")
 
-    - if @vacancy.publish_today?
-      p.govuk-body = t(".date_posted_now")
-    - else
-      p.govuk-body = t(".date_posted", date: @vacancy.publish_on)
+      - if @vacancy.publish_today?
+        p.govuk-body = t(".date_posted_now")
+      - else
+        p.govuk-body = t(".date_posted", date: @vacancy.publish_on)
 
-    p.govuk-body
-      = t(".date_expires", application_deadline: OrganisationVacancyPresenter.new(@vacancy).application_deadline)
+      p.govuk-body
+        = t(".date_expires", application_deadline: OrganisationVacancyPresenter.new(@vacancy).application_deadline)
 
-    = govuk_link_to t(".view_jobs"), jobs_with_type_organisation_path(:published), button: true, class: "govuk-button--secondary"
+      = govuk_link_to t(".view_jobs"), jobs_with_type_organisation_path(:published), button: true, class: "govuk-button--secondary"
 
-    .divider-bottom
-      h4.govuk-heading-s.share-this-job class="govuk-!-margin-top-0" = t("jobs.share_this_job")
-      = render "/shared/vacancy/share_buttons"
+      .divider-bottom
+        h4.govuk-heading-s.share-this-job class="govuk-!-margin-top-0" = t("jobs.share_this_job")
+        = render "/shared/vacancy/share_buttons"
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    h3.govuk-heading-m = t(".feedback.heading")
-    p.govuk-body = t(".feedback.description")
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      h3.govuk-heading-m = t(".feedback.heading")
+      p.govuk-body = t(".feedback.description")
 
-    = form_for @feedback_form, url: organisation_job_feedback_path(@vacancy.id) do |f|
-      = f.govuk_error_summary
-      = f.govuk_collection_radio_buttons :rating, Feedback.ratings.keys, :to_s
-      = f.govuk_text_area :comment, label: { size: "s" }, rows: 10, form_group: { classes: "optional-field" }
-      = f.govuk_submit t("buttons.submit_feedback")
+      = form_for @feedback_form, url: organisation_job_feedback_path(@vacancy.id) do |f|
+        = f.govuk_error_summary
+        = f.govuk_collection_radio_buttons :rating, Feedback.ratings.keys, :to_s
+        = f.govuk_text_area :comment, label: { size: "s" }, rows: 10, form_group: { classes: "optional-field" }
+        = f.govuk_submit t("buttons.submit_feedback")

--- a/app/views/subscriptions/confirm.html.slim
+++ b/app/views/subscriptions/confirm.html.slim
@@ -1,15 +1,16 @@
 - content_for :page_title_prefix, t(".title.#{action_name}")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    = govuk_panel title: t(".header.#{action_name}"), body: t(".body", email: @subscription.email)
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = govuk_panel title: t(".header.#{action_name}"), body: t(".body", email: @subscription.email)
 
-    h2.govuk-heading-m = t(".next_step")
-    p.govuk-body = t(".next_step_details")
-    = render Jobseekers::SubscriptionDetailsComponent.new(@subscription)
+      h2.govuk-heading-m = t(".next_step")
+      p.govuk-body = t(".next_step_details")
+      = render Jobseekers::SubscriptionDetailsComponent.new(@subscription)
 
-    .divider-bottom class="govuk-!-padding-bottom-5"
-      p.govuk-body = t(".unsubscribe")
-      = govuk_link_to t(".back_to_search_results"), jobs_path(@subscription.search_criteria), class: "govuk-!-font-size-19"
+      .divider-bottom class="govuk-!-padding-bottom-5"
+        p.govuk-body = t(".unsubscribe")
+        = govuk_link_to t(".back_to_search_results"), jobs_path(@subscription.search_criteria), class: "govuk-!-font-size-19"
 
-    = render "jobseeker_account_prompt"
+      = render "jobseeker_account_prompt"

--- a/app/views/subscriptions/edit.html.slim
+++ b/app/views/subscriptions/edit.html.slim
@@ -1,26 +1,27 @@
 - content_for :page_title_prefix, t(".title")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    = form_for @subscription_form, url: subscription_path(@subscription.token), method: :patch do |f|
-      = f.govuk_error_summary
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = form_for @subscription_form, url: subscription_path(@subscription.token), method: :patch do |f|
+        = f.govuk_error_summary
 
-      h1.govuk-heading-xl class="govuk-!-margin-bottom-4" = t(".title")
+        h1.govuk-heading-xl class="govuk-!-margin-bottom-4" = t(".title")
 
-      p.govuk-body-m class="govuk-!-margin-bottom-4" = t(".description")
+        p.govuk-body-m class="govuk-!-margin-bottom-4" = t(".description")
 
-      .location-search = render "fields", f: f
+        .location-search = render "fields", f: f
 
-      = render(Shared::NotificationComponent.new(content: { body: t("subscriptions.info") }, style: "notice", background: true, dismiss: false, alert: "info"))
+        = render(Shared::NotificationComponent.new(content: { body: t("subscriptions.info") }, style: "notice", background: true, dismiss: false, alert: "info"))
 
-      = f.hidden_field :token, value: @subscription.token
+        = f.hidden_field :token, value: @subscription.token
 
-      = f.govuk_submit t("buttons.update_alert"), classes: "govuk-!-padding-left-8 govuk-!-padding-right-8"
+        = f.govuk_submit t("buttons.update_alert"), classes: "govuk-!-padding-left-8 govuk-!-padding-right-8"
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    = govuk_link_to(t("buttons.cancel"), root_path, class: "govuk-!-font-size-19")
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = govuk_link_to(t("buttons.cancel"), root_path, class: "govuk-!-font-size-19")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds.govuk-body class="govuk-!-margin-top-4"
-    = t("terms_and_conditions.read_html")
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds.govuk-body class="govuk-!-margin-top-4"
+      = t("terms_and_conditions.read_html")

--- a/app/views/subscriptions/new.html.slim
+++ b/app/views/subscriptions/new.html.slim
@@ -1,28 +1,29 @@
 - content_for :page_title_prefix, t(".title")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    = govuk_back_link(text: t("buttons.back"), href: @origin.presence || jobs_path(@subscription_form.search_criteria_hash))
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = govuk_back_link(text: t("buttons.back"), href: @origin.presence || jobs_path(@subscription_form.search_criteria_hash))
 
-    = form_for @subscription_form, url: subscriptions_path do |f|
-      = f.govuk_error_summary
+      = form_for @subscription_form, url: subscriptions_path do |f|
+        = f.govuk_error_summary
 
-      h1.govuk-heading-xl class="govuk-!-margin-bottom-4" = t(".title")
+        h1.govuk-heading-xl class="govuk-!-margin-bottom-4" = t(".title")
 
-      p.govuk-body-m class="govuk-!-margin-bottom-4" = t(".description")
+        p.govuk-body-m class="govuk-!-margin-bottom-4" = t(".description")
 
-      .location-search = render "fields", f: f
+        .location-search = render "fields", f: f
 
-      = render(Shared::NotificationComponent.new(content: { body: t("subscriptions.info") }, style: "notice", background: true, dismiss: false, alert: "info", html_attributes: {}))
+        = render(Shared::NotificationComponent.new(content: { body: t("subscriptions.info") }, style: "notice", background: true, dismiss: false, alert: "info", html_attributes: {}))
 
-      = recaptcha
+        = recaptcha
 
-      = f.govuk_submit t("buttons.subscribe"), classes: "govuk-!-padding-left-8 govuk-!-padding-right-8"
+        = f.govuk_submit t("buttons.subscribe"), classes: "govuk-!-padding-left-8 govuk-!-padding-right-8"
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    = govuk_link_to(t("buttons.cancel"), @origin.presence || jobs_path(@subscription_form.search_criteria_hash), class: "govuk-!-font-size-19")
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = govuk_link_to(t("buttons.cancel"), @origin.presence || jobs_path(@subscription_form.search_criteria_hash), class: "govuk-!-font-size-19")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds.govuk-body class="govuk-!-margin-top-4"
-    = t("terms_and_conditions.read_html")
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds.govuk-body class="govuk-!-margin-top-4"
+      = t("terms_and_conditions.read_html")

--- a/app/views/subscriptions/unsubscribe.html.slim
+++ b/app/views/subscriptions/unsubscribe.html.slim
@@ -1,14 +1,15 @@
 - content_for :page_title_prefix, t(".title")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    h1.govuk-heading-l = t(".heading")
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      h1.govuk-heading-l = t(".heading")
 
-    p.govuk-body = t(".description")
+      p.govuk-body = t(".description")
 
-    = render Jobseekers::SubscriptionDetailsComponent.new(@subscription, current_subscription: true)
+      = render Jobseekers::SubscriptionDetailsComponent.new(@subscription, current_subscription: true)
 
-    p.govuk-body = t(".edit_instead_html", edit_link: govuk_link_to(t(".edit_instead_link"), edit_subscription_path(@subscription.token)))
-    = t(".edit_instead_options_html")
+      p.govuk-body = t(".edit_instead_html", edit_link: govuk_link_to(t(".edit_instead_link"), edit_subscription_path(@subscription.token)))
+      = t(".edit_instead_options_html")
 
-    = govuk_button_to t(".button_text"), subscription_path(@subscription.token), method: :delete, class: "govuk-button--warning govuk-!-margin-top-5"
+      = govuk_button_to t(".button_text"), subscription_path(@subscription.token), method: :delete, class: "govuk-button--warning govuk-!-margin-top-5"

--- a/app/views/updates/index.html.slim
+++ b/app/views/updates/index.html.slim
@@ -1,16 +1,17 @@
 - content_for :page_title_prefix, t("updates.heading")
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    h1.govuk-heading-xl = t("updates.heading")
-    h2.govuk-heading-s
-      = t("updates.updates_description_html",
-          link: govuk_link_to("provide feedback", new_feedback_path))
-    ul.updates-timeline.notes-timeline
-      - @updates.each do |date, updates_by_date|
-        li.updates-timeline__item
-          h3.updates-timeline__title.govuk-heading-s = format_date(date)
-          - updates_by_date.each do |update|
-            h4.govuk-heading-s = update[:name]
-            p.updates-timeline__by.notes-copy
-              = render "updates/update_files/#{update[:path]}"
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      h1.govuk-heading-xl = t("updates.heading")
+      h2.govuk-heading-s
+        = t("updates.updates_description_html",
+            link: govuk_link_to("provide feedback", new_feedback_path))
+      ul.updates-timeline.notes-timeline
+        - @updates.each do |date, updates_by_date|
+          li.updates-timeline__item
+            h3.updates-timeline__title.govuk-heading-s = format_date(date)
+            - updates_by_date.each do |update|
+              h4.govuk-heading-s = update[:name]
+              p.updates-timeline__by.notes-copy
+                = render "updates/update_files/#{update[:path]}"

--- a/app/views/vacancies/index.html.slim
+++ b/app/views/vacancies/index.html.slim
@@ -9,69 +9,70 @@
 - if @landing_page.present? && I18n.exists?("landing_pages.description.#{@landing_page_translation}")
   - content_for :page_description, t("landing_pages.description.#{@landing_page_translation}")
 
-= render(Shared::BreadcrumbComponent.new(collapse_on_mobile: false, crumbs: [{ link_path: root_path, link_text: t("breadcrumbs.home") }, { link_path: "#", link_text: t("breadcrumbs.jobs") }]))
+.govuk-main-wrapper class="govuk-!-padding-top-3"
+  = render(Shared::BreadcrumbComponent.new(collapse_on_mobile: false, crumbs: [{ link_path: root_path, link_text: t("breadcrumbs.home") }, { link_path: "#", link_text: t("breadcrumbs.jobs") }]))
 
-= render(Jobseekers::SearchResults::HeadingComponent.new(vacancies_search: @vacancies_search))
+  = render(Jobseekers::SearchResults::HeadingComponent.new(vacancies_search: @vacancies_search))
 
-.govuk-grid-row
-  .govuk-grid-column-one-third class="govuk-!-margin-bottom-4"
-    = render "filters"
-  .govuk-grid-column-two-thirds
-    = render(Jobseekers::SearchResults::SearchVisualizerComponent.new(vacancies_search: @vacancies_search, render: @display_map))
-    section.sort-results.sortable-links role="search" aria-label="Sort vacancies"
-      = render partial: "sorting_options", locals: { search_criteria: @vacancies_search.active_criteria, sort: @vacancies_search.sort_by }
-      - unless @vacancies_search.out_of_bounds?
-        .govuk-body#vacancies-stats-top aria-label="Number of results"
-          - if @vacancies_search.total_count <= @vacancies_search.per_page
-            = t("jobs.number_of_results_one_page_html", count: @vacancies_search.total_count)
-          - else
-            = t("jobs.number_of_results_html", first: @vacancies_search.page_from, last: @vacancies_search.page_to, count: @vacancies_search.total_count)
-    #search-results aria-label="Search results"
-      - if @vacancies.any?
-        ul.vacancies role="list"
-          - @vacancies.each do |vacancy|
-            = render(Jobseekers::VacancySummaryComponent.new(vacancy: vacancy))
-
-      - elsif @vacancies_search.active_criteria?
-        .divider-bottom
-          .govuk-heading-m = t("jobs.no_jobs.heading")
-          p.govuk-body
-            = t("jobs.no_jobs.intro")
-            ul.govuk-list.govuk-list--bullet
-              - t("jobs.no_jobs.suggestions").each do |list_item|
-                li = list_item
-        - if @vacancies_search.wider_search_suggestions.present?
-          .divider-bottom
-            - if @vacancies_search.keyword.present?
-              .govuk-heading-m = t(".wider_search_suggestions.heading.keyword_html", keyword: @vacancies_search.keyword)
+  .govuk-grid-row
+    .govuk-grid-column-one-third class="govuk-!-margin-bottom-4"
+      = render "filters"
+    .govuk-grid-column-two-thirds
+      = render(Jobseekers::SearchResults::SearchVisualizerComponent.new(vacancies_search: @vacancies_search, render: @display_map))
+      section.sort-results.sortable-links role="search" aria-label="Sort vacancies"
+        = render partial: "sorting_options", locals: { search_criteria: @vacancies_search.active_criteria, sort: @vacancies_search.sort_by }
+        - unless @vacancies_search.out_of_bounds?
+          .govuk-body#vacancies-stats-top aria-label="Number of results"
+            - if @vacancies_search.total_count <= @vacancies_search.per_page
+              = t("jobs.number_of_results_one_page_html", count: @vacancies_search.total_count)
             - else
-              .govuk-heading-m = t(".wider_search_suggestions.heading.no_keyword")
+              = t("jobs.number_of_results_html", first: @vacancies_search.page_from, last: @vacancies_search.page_to, count: @vacancies_search.total_count)
+      #search-results aria-label="Search results"
+        - if @vacancies.any?
+          ul.vacancies role="list"
+            - @vacancies.each do |vacancy|
+              = render(Jobseekers::VacancySummaryComponent.new(vacancy: vacancy))
+
+        - elsif @vacancies_search.active_criteria?
+          .divider-bottom
+            .govuk-heading-m = t("jobs.no_jobs.heading")
+            p.govuk-body
+              = t("jobs.no_jobs.intro")
+              ul.govuk-list.govuk-list--bullet
+                - t("jobs.no_jobs.suggestions").each do |list_item|
+                  li = list_item
+          - if @vacancies_search.wider_search_suggestions.present?
+            .divider-bottom
+              - if @vacancies_search.keyword.present?
+                .govuk-heading-m = t(".wider_search_suggestions.heading.keyword_html", keyword: @vacancies_search.keyword)
+              - else
+                .govuk-heading-m = t(".wider_search_suggestions.heading.no_keyword")
+              ul.govuk-list.govuk-list--bullet
+                - @vacancies_search.wider_search_suggestions.each do |wider_radius|
+                  - if @vacancies_search.location_search.polygon_boundaries.present?
+                    li = t(".wider_search_suggestions.suggestion_html",
+                                                          search_link: govuk_link_to(t(".wider_search_suggestions.radius_distance", radius: wider_radius.first), jobs_path(@vacancies_search.search_criteria.merge(buffer_radius: wider_radius.first)), class: "wider-radius-gtm"),
+                                                          count: t(".wider_search_suggestions.results", count: wider_radius.last))
+                  - else
+                    li = t(".wider_search_suggestions.suggestion_html",
+                                                          search_link: govuk_link_to(t(".wider_search_suggestions.radius_distance", radius: wider_radius.first), jobs_path(@vacancies_search.search_criteria.merge(radius: wider_radius.first)), class: "wider-radius-gtm"),
+                                                          count: t(".wider_search_suggestions.results", count: wider_radius.last))
+          span.govuk-heading-m
+            = t("subscriptions.link.no_search_results.text_html", link_to: govuk_link_to(t("subscriptions.link.no_search_results.link"), new_subscription_path(search_criteria: @vacancies_search.active_criteria, origin: request.original_fullpath), id: "job-alert-link-no-search-results-gtm"))
+          p class="govuk-!-margin-1"
+            = t("subscriptions.benefits.title")
             ul.govuk-list.govuk-list--bullet
-              - @vacancies_search.wider_search_suggestions.each do |wider_radius|
-                - if @vacancies_search.location_search.polygon_boundaries.present?
-                  li = t(".wider_search_suggestions.suggestion_html",
-                                                        search_link: govuk_link_to(t(".wider_search_suggestions.radius_distance", radius: wider_radius.first), jobs_path(@vacancies_search.search_criteria.merge(buffer_radius: wider_radius.first)), class: "wider-radius-gtm"),
-                                                        count: t(".wider_search_suggestions.results", count: wider_radius.last))
-                - else
-                  li = t(".wider_search_suggestions.suggestion_html",
-                                                        search_link: govuk_link_to(t(".wider_search_suggestions.radius_distance", radius: wider_radius.first), jobs_path(@vacancies_search.search_criteria.merge(radius: wider_radius.first)), class: "wider-radius-gtm"),
-                                                        count: t(".wider_search_suggestions.results", count: wider_radius.last))
-        span.govuk-heading-m
-          = t("subscriptions.link.no_search_results.text_html", link_to: govuk_link_to(t("subscriptions.link.no_search_results.link"), new_subscription_path(search_criteria: @vacancies_search.active_criteria, origin: request.original_fullpath), id: "job-alert-link-no-search-results-gtm"))
-        p class="govuk-!-margin-1"
-          = t("subscriptions.benefits.title")
-          ul.govuk-list.govuk-list--bullet
-            - t("subscriptions.benefits.list").each do |list_item|
-              li = list_item
+              - t("subscriptions.benefits.list").each do |list_item|
+                li = list_item
 
-      - else
-        .empty
-          - t("jobs.none_listed", count: Vacancy.listed.count).each do |sentence|
-            p = sentence
+        - else
+          .empty
+            - t("jobs.none_listed", count: Vacancy.listed.count).each do |sentence|
+              p = sentence
 
-    .pagination-and-stats
-      .pagination-results
-        = paginate @vacancies_search.vacancies
-      p.govuk-body#vacancies-stats-bottom aria-label="Number of results"
+      .pagination-and-stats
+        .pagination-results
+          = paginate @vacancies_search.vacancies
+        p.govuk-body#vacancies-stats-bottom aria-label="Number of results"
 
-    = render(Jobseekers::SearchResults::JobAlertsLinkComponent.new(vacancies_search: @vacancies_search, count: @vacancies.count, origin: request.original_fullpath))
+      = render(Jobseekers::SearchResults::JobAlertsLinkComponent.new(vacancies_search: @vacancies_search, count: @vacancies.count, origin: request.original_fullpath))


### PR DESCRIPTION
This fixes the padding issue. 

It removes notification wrapper backgrounds. I think this is the lesser of two evils and doesn't look particularly bad anyway.

If we really want to we can try and address that a later date, but given we've got lots of notification work/refactoring on the horizon, I'm not sure if it is worth it at this point in time anyway. 