### PR TITLE
Display the right number of vacancies awaiting feedback.

### DIFF
--- a/app/controllers/publishers/omniauth_callbacks_controller.rb
+++ b/app/controllers/publishers/omniauth_callbacks_controller.rb
@@ -47,7 +47,7 @@ class Publishers::OmniauthCallbacksController < Devise::OmniauthCallbacksControl
   end
 
   def organisation_from_request
-    # https://github.com/david-mears-dfe/login.dfe.public-api/blob/patch-1/README.md#organisation-categories
+    # https://github.com/DFE-Digital/login.dfe.public-api#how-do-ids-map-to-categories-and-types
     case auth_hash.dig("extra", "raw_info", "organisation", "category", "id")
     when "001"
       School.find_by!(urn: auth_hash.dig("extra", "raw_info", "organisation", "urn"))

--- a/app/controllers/publishers/organisations_controller.rb
+++ b/app/controllers/publishers/organisations_controller.rb
@@ -8,8 +8,8 @@ class Publishers::OrganisationsController < Publishers::BaseController
     @publisher_preference = PublisherPreference.find_or_create_by(publisher: current_publisher, organisation: current_organisation)
     @sort = Publishers::VacancySort.new(current_organisation, @selected_type).update(column: params[:sort_column])
     @sort_form = SortForm.new(@sort.column)
-    @awaiting_feedback_count = current_organisation.vacancies.awaiting_feedback.count
-    flash.now[:notice] = t(".awaiting", count: @awaiting_feedback_count) if @awaiting_feedback_count.positive?
+    awaiting_feedback_count = current_organisation.all_vacancies.awaiting_feedback.count
+    flash.now[:notice] = t(".awaiting", count: awaiting_feedback_count) if awaiting_feedback_count.positive?
     render_draft_saved_message if params[:from_review]
   end
 

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Organisation do
     context "when the organisation is not a local authority" do
       let(:local_authority) { create(:local_authority, name: "Camden") }
 
-      it "does not append 'local authority' when reading the name" do
+      it "appends 'local authority' when reading the name" do
         expect(local_authority.name).to eq("Camden local authority")
       end
     end
@@ -31,7 +31,7 @@ RSpec.describe Organisation do
 
     before { allow(Rails.configuration).to receive(:local_authorities_extra_schools).and_return(local_authorities_extra_schools) }
 
-    context "when there are schools outside local authority" do
+    context "when there are schools outside the local authority" do
       let(:local_authorities_extra_schools) { { 111 => [123_456, 999_999], 999 => [654_321, 111_111] } }
 
       it "returns the schools with matching URNs" do


### PR DESCRIPTION
For school groups, 'organisation.vacancies' will only retrieve vacancies with a location of 'central_office', rather than all vacancies at the organisation.

Previously, the number of jobs displayed in the 'awaiting feedback' tab and in the flash notice about giving feedback were different.

This uses a controller spec because that is the easiest (and probably best) way to test an instance variable assignment.

copied from Slack:
> I've used a controller spec to test that the instance variable is assigned to what it should be assigned to. I prefer that to request specs because I don't think request specs can access instance variable assignments (except by testing the response body, which is effectively equivalent to a system spec at that point). Alternatively, if your hatred for controller specs is sufficiently high, I can write a vacancies_awaiting_feedback_count method on Organisation, and test that.