### PR TITLE
Report and show error for OmniAuth failures

### DIFF
--- a/app/controllers/publishers/omniauth_callbacks_controller.rb
+++ b/app/controllers/publishers/omniauth_callbacks_controller.rb
@@ -17,7 +17,11 @@ class Publishers::OmniauthCallbacksController < Devise::OmniauthCallbacksControl
   end
 
   def failure
-    redirect_to root_path
+    omniauth_error = request.respond_to?(:get_header) ? request.get_header("omniauth.error") : request.env["omniauth.error"]
+    Rollbar.error(omniauth_error, strategy: failed_strategy.name)
+    Rails.logger.error("DSI failure - strategy: #{failed_strategy.name}, reason: #{omniauth_error.inspect}")
+
+    redirect_to new_publisher_session_path, flash: { warning: t(".message") }
   end
 
   private

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -1,5 +1,8 @@
 en:
   publishers:
+    omniauth_callbacks:
+      failure:
+        message: Sorry, we could not sign you in because of a technical problem. The team have been notified and will investigate as soon as possible. Please try again later.
     sessions:
       new:
         assistance:


### PR DESCRIPTION
We currently just silently swallow OmniAuth failures and redirect the
user to the homepage - we need to surface the errors and show a
meaningful message to publishers.

- Ship OmniAuth errors to Rollbar
- Redirect to login page on failure (instead of homepage)
- Show an error message to the user on failure
