### PR TITLE
[TEVA-2214] - Add redis queue exporter to monitoring

### DIFF
--- a/terraform/monitoring/data.tf
+++ b/terraform/monitoring/data.tf
@@ -3,6 +3,15 @@ data "cloudfoundry_space" "monitoring" {
   org_name = local.monitoring_org_name
 }
 
+data "cloudfoundry_space" "service" {
+  name     = local.service_space_name
+  org_name = local.monitoring_org_name
+}
+data "cloudfoundry_service_instance" "redis_queue" {
+  name_or_id = local.redis_queue_name
+  space      = data.cloudfoundry_space.service.id
+}
+
 data "aws_ssm_parameter" "monitoring_secrets" {
   name = "/${local.service_name}/production/infra/monitoring"
 }

--- a/terraform/monitoring/resources.tf
+++ b/terraform/monitoring/resources.tf
@@ -11,4 +11,5 @@ module "prometheus_all" {
   alert_rules                = file("${path.module}/config/alert.rules.yml")
   alertmanager_slack_url     = local.alertmanager_slack_url
   alertmanager_slack_channel = local.alertmanager_slack_channel
+  redis_service_instance_id  = data.cloudfoundry_service_instance.redis_queue.id
 }

--- a/terraform/monitoring/variables.tf
+++ b/terraform/monitoring/variables.tf
@@ -9,6 +9,8 @@ locals {
   monitoring_org_name        = "dfe"
   space_name                 = "${local.service_name}-monitoring"
   monitoring_space_name      = "${local.service_name}-monitoring"
+  service_space_name         = "${local.service_name}-production"
+  redis_queue_name           = "${local.service_name}-redis-queue-production"
   aws_region                 = "eu-west-2"
   secrets                    = yamldecode(data.aws_ssm_parameter.monitoring_secrets.value)
   alertmanager_slack_url     = local.secrets["alertmanager_slack_url"]


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2214

## Changes in this PR:

- Add redis exporter recently added to upstream `prometheus_all` module. Choose to monitor `redis-queue-*` resource
