### PR TITLE
Restrict flash types shown in application layout

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   SUSPICIOUS_RECAPTCHA_THRESHOLD = 0.5
+  FLASH_TYPES = %i[success warning notice alert].freeze
 
   add_flash_types :success, :warning
 

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -63,6 +63,7 @@ html.govuk-template.app-html-class lang="en"
 
       main#main-content role="main"
         - flash.each do |style, message|
+          - next unless ApplicationController::FLASH_TYPES.include?(style.to_sym)
           .govuk-main-wrapper__notification
             .govuk-width-container
               = render(Shared::NotificationComponent.new(body: message, variant: style))


### PR DESCRIPTION
Devise adds a `timedout` flash key to the flash when a user's session
times out (in addition to a friendly message). We don't want to show
this (or in fact any other random thing in the flash), so restrict the
keys shown.

Unfortunately the Rails flash hash isn't a proper hash (so we can't do
a simple `Hash#slice`) and is keyed with strings, so this isn't the
prettiest way of doing it but it does the job.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2218