### PR TITLE
[TEVA-2226] Split S3 backups bucket IAM policy into two statements

### DIFF
--- a/terraform/common/iam.tf
+++ b/terraform/common/iam.tf
@@ -139,23 +139,18 @@ resource "aws_iam_user_policy_attachment" "cloudfront" {
 
 data "aws_iam_policy_document" "db_backups_in_s3_fullaccess" {
   statement {
-    actions = [
-      "s3:GetBucketAcl",
-      "s3:GetBucketLocation",
-      "s3:GetObject",
-      "s3:GetObjectAcl",
-      "s3:ListBucket",
-      "s3:PutBucketAcl",
-      "s3:PutObject"
-    ]
+    actions = ["s3:GetObject", "s3:GetObjectAcl", "s3:PutObject"]
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.db_backups.bucket}/",
-      "arn:aws:s3:::${aws_s3_bucket.db_backups.bucket}/*",
       "arn:aws:s3:::${aws_s3_bucket.db_backups.bucket}/full/*",
       "arn:aws:s3:::${aws_s3_bucket.db_backups.bucket}/sanitised/*"
     ]
   }
+  statement {
+    actions   = ["s3:GetBucketAcl", "s3:GetBucketLocation", "s3:ListBucket", "s3:PutBucketAcl"]
+    resources = ["arn:aws:s3:::${aws_s3_bucket.db_backups.bucket}"]
+  }
 }
+
 
 resource "aws_iam_policy" "db_backups_in_s3_fullaccess" {
   name   = "db_backups_in_s3_fullaccess"
@@ -174,8 +169,22 @@ data "aws_iam_policy_document" "deny_sensitive_data_in_s3" {
     ]
     effect = "Deny"
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.db_backups.bucket}/backups/*"
+      "arn:aws:s3:::${aws_s3_bucket.db_backups.bucket}/full/*"
     ]
+  }
+  statement {
+    actions   = ["s3:ListBucket"]
+    effect    = "Deny"
+    resources = ["arn:aws:s3:::${aws_s3_bucket.db_backups.bucket}"]
+    condition {
+      test     = "StringEquals"
+      variable = "s3:prefix"
+
+      values = [
+        "",
+        "full"
+      ]
+    }
   }
 }
 


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2226

## Changes in this PR:

- Grant Object level permissions to the prefixes (folders)
- Grant bucket level permissions to the bucket
- Update deny statement to reflect new location of full backups

## Testing

Confirm that the `deploy` user can run this AWS statement and see files returned
```
aws s3api list-objects-v2 --bucket 530003481352-tv-db-backups --prefix sanitised
```

Confirm that assuming the `ReadOnly` role, running this AWS statement gives an "Access Denied" error:
```
aws s3api list-objects-v2 --bucket 530003481352-tv-db-backups --prefix full
```