### PR TITLE
TEVA-2208 - Add CF_SPACE_NAME to sync staging workflow

### DIFF
--- a/.github/workflows/sync_staging_db.yml
+++ b/.github/workflows/sync_staging_db.yml
@@ -75,6 +75,7 @@ jobs:
       run: bin/restore-db
       env:
         CF_DESTINATION_ENVIRONMENT: staging
+        CF_SPACE_NAME: staging
         BACKUP_TYPE: sanitised
 
     - name: Upload sanitised backup to S3


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2208

## Changes in this PR:

- Having introduced `CF_SPACE_NAME` to the on-demand restore_db workflow to handle the use case of where the app and the space are different, we need to specifically set `CF_SPACE_NAME: staging` in the scheduled overnight backup and sync
