### PR TITLE
[TEVA-2265] Add assume role to CI/CD

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,9 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: eu-west-2
+        role-to-assume: Deployments
+        role-duration-seconds: 3600
+        role-skip-session-tagging: true
 
     - name: Set environment variables
       id: set_env_vars

--- a/.github/workflows/deploy_app.yml
+++ b/.github/workflows/deploy_app.yml
@@ -38,6 +38,9 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: eu-west-2
+        role-to-assume: Deployments
+        role-duration-seconds: 3600
+        role-skip-session-tagging: true
 
     - name: Pin Terraform version
       uses: hashicorp/setup-terraform@v1

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -51,6 +51,9 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: eu-west-2
+        role-to-assume: Deployments
+        role-duration-seconds: 3600
+        role-skip-session-tagging: true
 
     - name: Download fetch_config.rb
       shell: bash

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -34,6 +34,9 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: eu-west-2
+        role-to-assume: Deployments
+        role-duration-seconds: 3600
+        role-skip-session-tagging: true
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/dump_db.yml
+++ b/.github/workflows/dump_db.yml
@@ -18,6 +18,9 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: eu-west-2
+        role-to-assume: Deployments
+        role-duration-seconds: 3600
+        role-skip-session-tagging: true
 
     - name: Setup cf cli
       uses: DFE-Digital/github-actions/setup-cf-cli@master

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -24,6 +24,9 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
+          role-to-assume: Deployments
+          role-duration-seconds: 3600
+          role-skip-session-tagging: true
 
       - name: Pin Terraform version
         uses: hashicorp/setup-terraform@v1

--- a/.github/workflows/restore_db.yml
+++ b/.github/workflows/restore_db.yml
@@ -25,6 +25,9 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: eu-west-2
+        role-to-assume: Deployments
+        role-duration-seconds: 3600
+        role-skip-session-tagging: true
 
     - name: Set PaaS space name
       shell: bash

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -39,6 +39,9 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: eu-west-2
+        role-to-assume: Deployments
+        role-duration-seconds: 3600
+        role-skip-session-tagging: true
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/sync_staging_db.yml
+++ b/.github/workflows/sync_staging_db.yml
@@ -30,6 +30,9 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: eu-west-2
+        role-to-assume: Deployments
+        role-duration-seconds: 3600
+        role-skip-session-tagging: true
 
     - name: Setup cf cli
       uses: DFE-Digital/github-actions/setup-cf-cli@master


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2265

## Changes in this PR:

- Extending use of `configure-aws-credentials` action.
- Setting role duration to 3600 seconds (1 hour) to be consistent with how we assume other roles
- Skip role session tagging
- As role is in same AWS account, can just use the role name in plain text

## Testing

- See successful creation by modifying `review.yml` workflow: https://github.com/DFE-Digital/teaching-vacancies/runs/2173076761?check_suite_focus=true