### PR TITLE
Limit host Faker URLs to example.com

### DIFF
--- a/spec/factories/school_groups.rb
+++ b/spec/factories/school_groups.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
     postcode { Faker::Address.postcode }
     town { Faker::Address.city.delete("'") }
     uid { Faker::Number.number(digits: 5).to_s }
-    website { Faker::Internet.url }
+    website { Faker::Internet.url(host: "example.com") }
   end
 
   factory :local_authority, parent: :school_group do

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -35,7 +35,7 @@ FactoryBot.define do
     postcode { Faker::Address.postcode }
     town { Faker::Address.city.delete("'") }
     urn { Faker::Number.number(digits: 6) }
-    url { Faker::Internet.url }
+    url { Faker::Internet.url(host: "example.com") }
 
     trait :closed do
       establishment_status { "Closed" }

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
 
     job_location { "at_one_school" }
     about_school { Faker::Lorem.paragraph(sentence_count: 4) }
-    application_link { Faker::Internet.url }
+    application_link { Faker::Internet.url(host: "example.com") }
     apply_through_teaching_vacancies { "yes" }
     benefits { Faker::Lorem.paragraph(sentence_count: 4) }
     contact_email { Faker::Internet.email }


### PR DESCRIPTION
These sometimes generate URLs with existing spammy websites which isn't
a good look (especially as we use them to generate fake data for review
apps). This way we end up with URLs that are guaranteed to not exist.