### PR TITLE
Always say 'local authority' after an LA's name

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -24,4 +24,8 @@ class Organisation < ApplicationRecord
 
     Rails.configuration.allowed_local_authorities.include?(local_authority_code)
   end
+
+  def name
+    @name ||= read_attribute(:name).concat(group_type == "local_authority" ? " local authority" : "")
+  end
 end

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -93,7 +93,7 @@ en:
           You can add or remove schools from your account at any point.
         page_title: Set up your Teaching Vacancies account
       form:
-        schools_in: Schools in %{organisation} local authority
+        schools_in: Schools in %{organisation}
         missing_schools_error: Select one or more schools to continue
       edit:
         description_1: >-

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -5,4 +5,22 @@ RSpec.describe Organisation, type: :model do
   it { is_expected.to have_many(:organisation_publishers) }
   it { is_expected.to have_many(:vacancies) }
   it { is_expected.to have_many(:organisation_vacancies) }
+
+  describe "#name" do
+    context "when the organisation is a local authority" do
+      let(:trust) { create(:trust, name: "My Amazing Trust") }
+
+      it "does not append 'local authority' when reading the name" do
+        expect(trust.name).to eq("My Amazing Trust")
+      end
+    end
+
+    context "when the organisation is not a local authority" do
+      let(:local_authority) { create(:local_authority, name: "Camden") }
+
+      it "does not append 'local authority' when reading the name" do
+        expect(local_authority.name).to eq("Camden local authority")
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is the lesser evil for now, until we do the refactoring that properly separates LAs from Trusts and removes the logic that
checks for the group_type.