### PR TITLE
Ignore most common CSP violations

### DIFF
--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -23,10 +23,11 @@ RSpec.describe "Errors", type: :request do
   end
 
   describe "POST #csp_violation" do
+    let(:violation) { { "csp-report": { foo: "bar" } }.to_json }
     it "sends the error to Rollbar" do
-      expect(Rollbar).to receive(:error).with("CSP Violation", details: "foo=bar")
+      expect(Rollbar).to receive(:error).with("CSP Violation", details: violation)
 
-      post errors_csp_violation_path, params: { foo: "bar" }
+      post errors_csp_violation_path, params: violation
       expect(response).to have_http_status(:no_content)
     end
   end


### PR DESCRIPTION
Most of the CSP violations that currently come through on Rollbar fall
into one of the following categories:
- Misbehaving browser plugins
- Facebook mobile app injecting JS into in-app browser

We don't want to drown in CSP violation errors on Rollbar, so start
ignoring these (and possibly others in the future).