### PR TITLE
[TEVA-2267] Improve local setup documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,8 @@ dotenv*
 !dotenv*.gpg
 **/**/cf-vars*.yml
 terraform/workspace-variables/my_app_env.yml
+.env.local
+# See https://github.com/bkeepers/dotenv#frequently-answered-questions for dotenv-rails env files and whether they should be in .gitignore
 
 # Certificates
 *.pem

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ print-env: install-fetch-config ## make -s local print-env > .env
 local: ## local # Same values as the deployed dev environment, adapted for local developmemt
 		$(eval env=dev)
 		$(eval local_override=-d file:terraform/workspace-variables/local_app_env.yml -d file:terraform/workspace-variables/my_app_env.yml)
-		$(eval local_filter=| sed -e '/RAILS_ENV=/d' -e '/ROLLBAR_ENV=/d')
+		$(eval local_filter=| sed -e '/APP_ROLE=/d' -e '/RAILS_ENV=/d' -e '/ROLLBAR_ENV=/d')
 		@bin/algolia-prefix > terraform/workspace-variables/my_app_env.yml
 
 .PHONY: dev

--- a/README.md
+++ b/README.md
@@ -87,12 +87,15 @@ Non-secrets (eg: public URLs or feature flags) are stored in the repository in `
 Run the following command to fetch all the required environment variables for development and output to a shell environment file:
 
 ```
-aws-vault exec SecretEditor -- make -s local print-env > .env
+aws-vault exec ReadOnly -- make -s local print-env > .env
 ```
 
 To run the command above you need [AWS credentials](#aws-credentials-mfa-and-role-profiles).
 
 [Git secrets](/documentation/secrets-detection.md) offers an easy way to defend against accidentally publishing these secrets.
+
+For local development, you can use a [dotenv-rails environment override](https://github.com/bkeepers/dotenv#frequently-answered-questions):
+- create the file `.env.local`, with contents `DOMAIN=localhost:3000`
 
 ### Install dependencies
 
@@ -114,7 +117,13 @@ yarn
 bundle exec rails db:create db:schema:load
 ```
 
-If you have problems connecting with the database, edit `DATABASE_URL` variable in `.env`
+[/config/database.yml](./config/database.yml) sets the default for `DATABASE_URL` to `postgres://postgres@localhost:5432`, which should work without any additional configuration on a Mac
+
+If you set up your local Postgres with a custom user and password, such as in Ubuntu 20.04, set this in `.env.local`:
+```
+DATABASE_URL=postgres://mylocaluser:mylocalpassword@localhost:5432
+```
+
 
 ### Seeding the database
 

--- a/documentation/aws-roles-and-cli-tools.md
+++ b/documentation/aws-roles-and-cli-tools.md
@@ -197,7 +197,7 @@ https://signin.aws.amazon.com/federation?Action=login&Issuer=aws-vault&Destinati
 
 Refresh the `.env` file
 ```bash
-aws-vault exec SecretEditor -- make -s local print-env > .env
+aws-vault exec ReadOnly -- make -s local print-env > .env
 ```
 
 List the S3 buckets

--- a/documentation/aws-roles-and-cli-tools.md
+++ b/documentation/aws-roles-and-cli-tools.md
@@ -205,6 +205,14 @@ List the S3 buckets
 aws-vault exec ReadOnly -- aws s3 ls
 ```
 
+## Rotate AWS credentials for AWS Vault
+
+[Rotate your AWS access keys](https://github.com/99designs/aws-vault/blob/master/USAGE.md#rotating-credentials) at least every 90 days with this command:
+
+```bash
+aws-vault rotate teaching-vacancies
+```
+
 ## Use the AWS CLI without AWS Vault
 
 In this example you will use your personal Access Key and Secret key in the `[teaching-vacancies]` profile


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2267

## Changes in this PR:

- link to `dotenv-rails` local overrides documentation
- link to where `DATABASE_URL` rails default is set
- use lower-privileged AWS role to refresh `.env` file
- unset `APP_ROLE` for local development
- Add AWS credentials rotation documentation for use with `aws-vault`
