### PR TITLE
Jobseekers cannot view draft applications

### DIFF
--- a/app/controllers/jobseekers/job_applications_controller.rb
+++ b/app/controllers/jobseekers/job_applications_controller.rb
@@ -27,6 +27,10 @@ class Jobseekers::JobApplicationsController < Jobseekers::BaseController
     end
   end
 
+  def show
+    raise ActionController::RoutingError, "Cannot view draft application" if job_application.draft?
+  end
+
   def confirm_destroy
     raise ActionController::RoutingError, "Cannot delete non-draft application" unless job_application.draft?
   end

--- a/spec/requests/jobseekers/job_applications_spec.rb
+++ b/spec/requests/jobseekers/job_applications_spec.rb
@@ -131,6 +131,24 @@ RSpec.describe "Job applications", type: :request do
     end
   end
 
+  describe "GET #show" do
+    context "when the application is not a draft" do
+      let!(:job_application) { create(:job_application, :status_submitted, jobseeker: jobseeker, vacancy: vacancy) }
+
+      it "shows the application page" do
+        expect(get(jobseekers_job_application_path(job_application.id))).to render_template(:show)
+      end
+    end
+
+    context "when the application is a draft" do
+      let!(:job_application) { create(:job_application, jobseeker: jobseeker, vacancy: vacancy) }
+
+      it "raises an error" do
+        expect { get(jobseekers_job_application_path(job_application.id)) }.to raise_error(ActionController::RoutingError, /draft/)
+      end
+    end
+  end
+
   describe "GET #confirm_destroy" do
     context "when the application is a draft" do
       let!(:job_application) { create(:job_application, jobseeker: jobseeker, vacancy: vacancy) }


### PR DESCRIPTION
Previously they could (misplaced link or via the path), but they shouldn't (it doesn't make sense/UX).

So now (even by path), they can't (raises error).