### PR TITLE
Remove gem we don't need or use

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem "google-apis-indexing_v3"
 gem "google-cloud-bigquery"
 gem "google_drive", require: false
 gem "govuk-components"
-gem "gov_uk_date_fields"
 gem "govuk_design_system_formbuilder"
 gem "high_voltage"
 gem "httparty"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,8 +230,6 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (~> 0.14)
-    gov_uk_date_fields (4.1.0)
-      rails (>= 5.0.7.2)
     govuk-components (1.1.3)
       rails (>= 6.0)
       view_component (>= 2.22.1, < 2.27.0)
@@ -616,7 +614,6 @@ DEPENDENCIES
   google-apis-indexing_v3
   google-cloud-bigquery
   google_drive
-  gov_uk_date_fields
   govuk-components
   govuk_design_system_formbuilder
   high_voltage

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -47,9 +47,6 @@ class Vacancy < ApplicationRecord
 
   delegate :name, to: :parent_organisation, prefix: true, allow_nil: true
 
-  acts_as_gov_uk_date :starts_on, :publish_on,
-                      :expires_on, error_clash_behaviour: :omit_gov_uk_date_field_error
-
   scope :active, (-> { where(status: %i[published draft]) })
   scope :applicable, (-> { where("expires_at >= ?", Time.current) })
   scope :expired, (-> { published.where("expires_at < ?", Time.current) })


### PR DESCRIPTION
Mimemagic related clean up. 

We don't actually use/need this gem, and it's a bit of legacy code we didn't notice before it bit us in the ...

There might be some next steps around cleaning up dates anyway but that lives to fight another day.