### PR TITLE
[TEVA-2164] Update offline site generation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -204,7 +204,7 @@ jobs:
 
     - name: Sync offline S3 bucket
       shell: bash
-      run: aws s3 sync ./offline s3://530003481352-offline-site/teaching-vacancies-offline
+      run: bin/sync-offline
 
     - name: Send job status message to twd_tv_dev channel
       if: always() && github.ref == 'refs/heads/master'

--- a/bin/regenerate-offline
+++ b/bin/regenerate-offline
@@ -6,14 +6,29 @@ GOVUK_FRONTEND_PREFIX=https://github.com/alphagov/govuk-frontend/releases/downlo
 GOVUK_FRONTEND_ARCHIVE_NAME=release-v${RELEASE}.zip
 GOVUK_FRONTEND_URL="${GOVUK_FRONTEND_PREFIX}${GOVUK_FRONTEND_ARCHIVE_NAME}"
 
-wget ${GOVUK_FRONTEND_URL}
+# If archive file does not exist locally, attempt to download it
+if [[ ! -f ${GOVUK_FRONTEND_ARCHIVE_NAME} ]]; then
+  # we use wget to support the redirect to the underlying files being served from github-releases.githubusercontent.com
+  wget -O ${GOVUK_FRONTEND_ARCHIVE_NAME} ${GOVUK_FRONTEND_URL}
+fi
+# If archive file still does not exist locally, then exit this script
 if [[ ! -f "${GOVUK_FRONTEND_ARCHIVE_NAME}" ]]; then
   echo "${GOVUK_FRONTEND_ARCHIVE_NAME} does not exist."
   exit 1
 else
   unzip ${GOVUK_FRONTEND_ARCHIVE_NAME} -d ./offline
 fi
+
+# Rename version-specific CSS to well-known name
 mv ./offline/govuk-frontend-${RELEASE}.min.css ./offline/govuk-frontend.min.css
+# The supplied CSS expects the assets folder to be in the root of the file structure
+# We want to be able to serve from a subfolder
+# Use sed stream editor to replace links starting `url(/assets` with `url(./assets`
+sed -i 's/url(\/assets/url(.\/assets/g' ./offline/govuk-frontend.min.css
+# Remove specific support for IE8
 rm ./offline/govuk-frontend-ie8-${RELEASE}.min.css
+# There is no JavaScript in this simple HTML file
 rm ./offline/govuk-frontend-${RELEASE}.min.js
+# Although there is a favicon.ico supplied in /assets/images/favicon.ico
+# Copy the favicon from the /public folder for consistency
 cp ./public/favicon.ico ./offline/favicon.ico

--- a/bin/sync-offline
+++ b/bin/sync-offline
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -eu
+
+BUCKET=530003481352-offline-site
+LOCAL_FOLDER=offline
+REMOTE_FOLDER=teaching-vacancies-offline
+# Rather than fail with an aws-cli error `The user-provided path LOCAL_FOLDER does not exist.`,
+# Test for existence of local folder before attempting an S3 sync
+if [[ ! -d "${LOCAL_FOLDER}" ]]; then
+  echo "${LOCAL_FOLDER} does not exist."
+  exit 1
+else
+  aws s3 sync "${LOCAL_FOLDER}" "s3://${BUCKET}/${REMOTE_FOLDER}"
+fi

--- a/documentation/offline-site.md
+++ b/documentation/offline-site.md
@@ -12,11 +12,16 @@ The [regenerate-offline](../bin/regenerate-offline) script:
 
 - downloads and unzips a particular version of the [Gov.UK frontend](https://github.com/alphagov/govuk-frontend/releases/) into the [offline](../offline) folder
 - renames the version-specific minified CSS file to `offline/govuk-frontend.min.css`
-- copies the `favicon.ico`
+- does a search and replace to allow the site to be served from a sub-folder
+- copies the `favicon.ico` from `/public/favicon.ico`
+
+The [sync-offline](../bin/sync-offline) script:
+
+- uses the AWS CLI to synchronise with the offline site S3 bucket
 
 The GitHub Action [deploy](../.github/workflows/deploy.yml) workflow includes these steps:
-- run the regenerate-offline script
-- use the AWS CLI to synchronise with the offline site S3 bucket
+- runs the regenerate-offline script
+- runs the sync-offline script
 
 ## How to update
 
@@ -32,3 +37,7 @@ The offline page is a single HTML file in [offline/index.html](../offline/index.
 RELEASE=3.11.0
 ```
 - When the change is merged, the new version will be synchronised
+
+## How to test
+
+- Check the underlying page [in the S3 bucket](https://530003481352-offline-site.s3.eu-west-2.amazonaws.com/teaching-vacancies-offline/index.html)

--- a/offline/index.html
+++ b/offline/index.html
@@ -6,13 +6,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="blue">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/assets/images/favicon.ico" type="image/x-icon">
-  <link rel="mask-icon" href="/assets/images/govuk-mask-icon.svg" color="blue">
-  <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/govuk-apple-touch-icon-180x180.png">
-  <link rel="apple-touch-icon" sizes="167x167" href="/assets/images/govuk-apple-touch-icon-167x167.png">
-  <link rel="apple-touch-icon" sizes="152x152" href="/assets/images/govuk-apple-touch-icon-152x152.png">
-  <link rel="apple-touch-icon" href="/assets/images/govuk-apple-touch-icon.png">
-  <link href="/govuk-frontend.min.css" rel="stylesheet">
+  <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="./assets/images/favicon.ico" type="image/x-icon">
+  <link rel="mask-icon" href="./assets/images/govuk-mask-icon.svg" color="blue">
+  <link rel="apple-touch-icon" sizes="180x180" href="./assets/images/govuk-apple-touch-icon-180x180.png">
+  <link rel="apple-touch-icon" sizes="167x167" href="./assets/images/govuk-apple-touch-icon-167x167.png">
+  <link rel="apple-touch-icon" sizes="152x152" href="./assets/images/govuk-apple-touch-icon-152x152.png">
+  <link rel="apple-touch-icon" href="./assets/images/govuk-apple-touch-icon.png">
+  <link href="./govuk-frontend.min.css" rel="stylesheet">
 </head>
 <body class="govuk-template__body app-body-class">
   <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
@@ -26,7 +26,7 @@
               <path fill="currentColor" fill-rule="evenodd"
                 d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z">
               </path>
-              <image src="/assets/images/govuk-logotype-crown.png" xlink:href="data:," display="none"
+              <image src="./assets/images/govuk-logotype-crown.png" xlink:href="data:," display="none"
                 class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
             </svg>
             <span class="govuk-header__logotype-text">

--- a/terraform/common/s3.tf
+++ b/terraform/common/s3.tf
@@ -33,3 +33,32 @@ resource "aws_s3_bucket_public_access_block" "db_backups" {
 resource "aws_s3_bucket" "offline_site" {
   bucket = "${data.aws_caller_identity.current.account_id}-offline-site"
 }
+
+resource "aws_s3_bucket_public_access_block" "offline_site" {
+  bucket = aws_s3_bucket.offline_site.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_policy" "offline_site" {
+  bucket = aws_s3_bucket.offline_site.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = "OfflineSitePublicReadGetObject"
+    Statement = [
+      {
+        Sid       = "PublicReadGetObject"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = "s3:GetObject"
+        Resource = [
+          "${aws_s3_bucket.offline_site.arn}/teaching-vacancies-offline/*",
+        ]
+      },
+    ]
+  })
+}


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2164

## Changes in this PR:

- Handle files being synchronised to a folder, not the root
- Make regenerate-offline script idempotent
- Make sync-offline script to match regenerate-offline
- Make offline-site S3 bucket public
- Update documentation
