### PR TITLE
Jobseekers can edit draft job applications

### DIFF
--- a/app/controllers/concerns/jobseekers/wizardable.rb
+++ b/app/controllers/concerns/jobseekers/wizardable.rb
@@ -1,26 +1,4 @@
 module Jobseekers::Wizardable
-  FORMS = {
-    personal_details: Jobseekers::JobApplication::PersonalDetailsForm,
-    professional_status: Jobseekers::JobApplication::ProfessionalStatusForm,
-    employment_history: Jobseekers::JobApplication::EmploymentHistoryForm,
-    personal_statement: Jobseekers::JobApplication::PersonalStatementForm,
-    references: Jobseekers::JobApplication::ReferencesForm,
-    equal_opportunities: Jobseekers::JobApplication::EqualOpportunitiesForm,
-    ask_for_support: Jobseekers::JobApplication::AskForSupportForm,
-    declarations: Jobseekers::JobApplication::DeclarationsForm,
-  }.freeze
-
-  FORM_PARAMS = {
-    personal_details: :personal_details_params,
-    professional_status: :professional_status_params,
-    employment_history: :employment_history_params,
-    personal_statement: :personal_statement_params,
-    references: :references_params,
-    equal_opportunities: :equal_opportunities_params,
-    ask_for_support: :ask_for_support_params,
-    declarations: :declarations_params,
-  }.freeze
-
   def steps_config
     {
       personal_details: { number: 1, title: t(".personal_details.heading") },
@@ -34,46 +12,36 @@ module Jobseekers::Wizardable
     }.freeze
   end
 
-  def personal_details_params(params)
-    params.require(:jobseekers_job_application_personal_details_form)
-          .permit(:city, :email_address, :first_name, :last_name, :national_insurance_number,
-                  :phone_number, :previous_names, :postcode, :street_address, :teacher_reference_number)
+  def personal_details_fields
+    %i[city first_name last_name national_insurance_number phone_number previous_names postcode street_address teacher_reference_number]
   end
 
-  def professional_status_params(params)
-    params.require(:jobseekers_job_application_professional_status_form)
-          .permit(:qualified_teacher_status, :qualified_teacher_status_year,
-                  :qualified_teacher_status_details, :statutory_induction_complete)
+  def professional_status_fields
+    %i[qualified_teacher_status qualified_teacher_status_year qualified_teacher_status_details statutory_induction_complete]
   end
 
-  def employment_history_params(params)
-    params.require(:jobseekers_job_application_employment_history_form)
-          .permit(:gaps_in_employment, :gaps_in_employment_details)
+  def employment_history_fields
+    %i[gaps_in_employment gaps_in_employment_details]
   end
 
-  def personal_statement_params(params)
-    params.require(:jobseekers_job_application_personal_statement_form)
-          .permit(:personal_statement)
+  def personal_statement_fields
+    %i[personal_statement]
   end
 
-  def references_params(_params)
-    {}
+  def references_fields
+    []
   end
 
-  def equal_opportunities_params(params)
-    params.require(:jobseekers_job_application_equal_opportunities_form)
-          .permit(:disability, :gender, :gender_description, :orientation, :orientation_description,
-                  :ethnicity, :ethnicity_description, :religion, :religion_description)
+  def equal_opportunities_fields
+    %i[disability gender gender_description orientation orientation_description ethnicity ethnicity_description religion religion_description]
   end
 
-  def ask_for_support_params(params)
-    params.require(:jobseekers_job_application_ask_for_support_form)
-          .permit(:support_needed, :support_needed_details)
+  def ask_for_support_fields
+    %i[support_needed support_needed_details]
   end
 
-  def declarations_params(params)
-    params.require(:jobseekers_job_application_declarations_form)
-          .permit(:banned_or_disqualified, :close_relationships, :close_relationships_details, :right_to_work_in_uk)
+  def declarations_fields
+    %i[banned_or_disqualified close_relationships close_relationships_details right_to_work_in_uk]
   end
 
   def employment_history_info

--- a/app/controllers/jobseekers/job_applications/build_controller.rb
+++ b/app/controllers/jobseekers/job_applications/build_controller.rb
@@ -2,24 +2,27 @@ class Jobseekers::JobApplications::BuildController < Jobseekers::BaseController
   include Wicked::Wizard
   include Jobseekers::Wizardable
 
-  steps :personal_details, :professional_status, :employment_history, :personal_statement, :references, :equal_opportunities, :ask_for_support, :declarations
+  steps :personal_details, :professional_status, :employment_history, :personal_statement, :references,
+        :equal_opportunities, :ask_for_support, :declarations
 
-  helper_method :back_link_path, :employment_history_info, :job_application, :process_steps, :reference_info, :vacancy
+  helper_method :back_path, :employment_history_info, :form, :job_application, :process_steps, :reference_info, :vacancy
 
   def show
-    @form = FORMS[step].new unless step == "wicked_finish"
     render_wizard
   end
 
   def update
-    @form = FORMS[step].new(form_params)
-    completed_steps = job_application.completed_steps.presence || []
-    if params[:commit] == t("buttons.save_as_draft")
+    if params[:commit] == t("buttons.save_and_come_back")
       job_application.update(form_params)
       redirect_to jobseekers_job_applications_path, success: t("messages.jobseekers.job_applications.saved")
-    elsif @form.valid?
-      job_application.assign_attributes(form_params.merge(completed_steps: completed_steps.push(step)))
-      render_wizard job_application
+    elsif form.valid?
+      if referrer_is_finish_wizard_path?
+        job_application.update(update_params)
+        redirect_to finish_wizard_path, success: t("messages.jobseekers.job_applications.saved")
+      else
+        job_application.assign_attributes(update_params)
+        render_wizard job_application
+      end
     else
       render_wizard
     end
@@ -27,17 +30,35 @@ class Jobseekers::JobApplications::BuildController < Jobseekers::BaseController
 
   private
 
-  def back_link_path
-    @back_link_path ||= case step
-                        when :personal_details
-                          new_jobseekers_job_job_application_path(vacancy.id)
-                        else
-                          previous_wizard_path
-                        end
+  def back_path
+    @back_path ||= if referrer_is_finish_wizard_path?
+                     finish_wizard_path
+                   elsif step == :personal_details
+                     new_jobseekers_job_job_application_path(vacancy.id)
+                   else
+                     previous_wizard_path
+                   end
+  end
+
+  def form
+    @form ||= "Jobseekers::JobApplication::#{step.to_s.camelize}Form".constantize.new(form_attributes)
+  end
+
+  def form_attributes
+    case action_name
+    when "show"
+      job_application.slice(*send("#{step}_fields"))
+    when "update"
+      form_params
+    end
   end
 
   def form_params
-    send(FORM_PARAMS[step], params)
+    (params["jobseekers_job_application_#{step}_form".to_sym] || params).permit(*send("#{step}_fields"))
+  end
+
+  def update_params
+    form_params.merge(completed_steps: job_application.completed_steps.append(step).uniq)
   end
 
   def finish_wizard_path
@@ -45,11 +66,15 @@ class Jobseekers::JobApplications::BuildController < Jobseekers::BaseController
   end
 
   def job_application
-    @job_application ||= current_jobseeker.job_applications.find(params[:job_application_id])
+    @job_application ||= current_jobseeker.job_applications.draft.find(params[:job_application_id])
   end
 
   def process_steps
     @process_steps ||= ProcessSteps.new(steps: steps_config, adjust: 0, step: step)
+  end
+
+  def referrer_is_finish_wizard_path?
+    URI(request.referrer || "").path == finish_wizard_path || URI(params[:origin] || "").path == finish_wizard_path
   end
 
   def vacancy

--- a/app/controllers/jobseekers/job_applications_controller.rb
+++ b/app/controllers/jobseekers/job_applications_controller.rb
@@ -16,7 +16,7 @@ class Jobseekers::JobApplicationsController < Jobseekers::BaseController
     raise ActionController::RoutingError, "Cannot submit application for non-listed job" unless vacancy.listed?
     raise ActionController::RoutingError, "Cannot submit non-draft application" unless job_application.draft?
 
-    if params[:commit] == t("buttons.save_as_draft")
+    if params[:commit] == t("buttons.save_and_come_back")
       redirect_to jobseekers_job_applications_path, success: t("messages.jobseekers.job_applications.saved")
     elsif review_form.valid?
       job_application.submitted!

--- a/app/form_models/jobseekers/job_application/ask_for_support_form.rb
+++ b/app/form_models/jobseekers/job_application/ask_for_support_form.rb
@@ -5,9 +5,5 @@ class Jobseekers::JobApplication::AskForSupportForm
 
   validates :support_needed, inclusion: { in: %w[yes no] }
   validates :support_needed_details, presence: true, if: -> { support_needed == "yes" }
-
-  def initialize(params = {})
-    @support_needed = params[:support_needed]
-    @support_needed_details = support_needed == "yes" ? params[:support_needed_details] : nil
-  end
+  validates :support_needed_details, absence: true, if: -> { support_needed == "no" }
 end

--- a/app/views/jobseekers/job_applications/build/ask_for_support.html.slim
+++ b/app/views/jobseekers/job_applications/build/ask_for_support.html.slim
@@ -1,7 +1,7 @@
 - content_for :page_title_prefix, t(".title")
 
 = render BannerComponent.new do
-  = govuk_back_link text: t("buttons.back"), href: back_link_path, classes: "govuk-!-margin-top-3"
+  = govuk_back_link text: t("buttons.back"), href: back_path, classes: "govuk-!-margin-top-3"
   .govuk-caption-l class="govuk-!-margin-top-5" = t("jobseekers.job_applications.caption", job_title: vacancy.job_title, organisation: vacancy.parent_organisation_name)
   h2.govuk-heading-xl class="govuk-!-margin-bottom-5" = t("jobseekers.job_applications.heading")
 
@@ -17,7 +17,9 @@
         li = example
     p.govuk-body = t(".closing")
 
-    = form_for @form, url: wizard_path, method: :patch do |f|
+    = form_for form, url: wizard_path, method: :patch do |f|
+      = hidden_field_tag :origin, request.referrer
+
       = f.govuk_error_summary
 
       = f.govuk_radio_buttons_fieldset :support_needed do
@@ -25,8 +27,8 @@
           = f.govuk_text_area :support_needed_details, rows: 10
         = f.govuk_radio_button :support_needed, :no
 
-      = f.govuk_submit t("buttons.continue")
-      = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"
+      = f.govuk_submit t("buttons.save_and_continue") do
+        = f.govuk_submit t("buttons.save_and_come_back"), secondary: true
 
   .govuk-grid-column-one-third
     = render(Shared::ProcessStepsComponent.new(process: vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))

--- a/app/views/jobseekers/job_applications/build/declarations.html.slim
+++ b/app/views/jobseekers/job_applications/build/declarations.html.slim
@@ -1,7 +1,7 @@
 - content_for :page_title_prefix, t(".title")
 
 = render BannerComponent.new do
-  = govuk_back_link text: t("buttons.back"), href: back_link_path, classes: "govuk-!-margin-top-3"
+  = govuk_back_link text: t("buttons.back"), href: back_path, classes: "govuk-!-margin-top-3"
   .govuk-caption-l class="govuk-!-margin-top-5" = t("jobseekers.job_applications.caption", job_title: vacancy.job_title, organisation: vacancy.parent_organisation_name)
   h2.govuk-heading-xl class="govuk-!-margin-bottom-5" = t("jobseekers.job_applications.heading")
 
@@ -10,7 +10,9 @@
     .govuk-caption-m = t("jobseekers.job_applications.current_step", current: process_steps.current_step_number, total: 10)
     h1.govuk-heading-l = t(".heading")
 
-    = form_for @form, url: wizard_path, method: :patch do |f|
+    = form_for form, url: wizard_path, method: :patch do |f|
+      = hidden_field_tag :origin, request.referrer
+
       = f.govuk_error_summary
 
       = f.govuk_collection_radio_buttons :banned_or_disqualified, %w[yes no], :to_s, :capitalize, inline: true
@@ -22,8 +24,8 @@
 
       = f.govuk_collection_radio_buttons :right_to_work_in_uk, %w[yes no], :to_s, :capitalize, inline: true
 
-      = f.govuk_submit t("buttons.continue")
-      = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"
+      = f.govuk_submit t("buttons.save_and_continue") do
+        = f.govuk_submit t("buttons.save_and_come_back"), secondary: true
 
   .govuk-grid-column-one-third
     = render(Shared::ProcessStepsComponent.new(process: vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))

--- a/app/views/jobseekers/job_applications/build/employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/build/employment_history.html.slim
@@ -1,7 +1,7 @@
 - content_for :page_title_prefix, t(".title")
 
 = render BannerComponent.new do
-  = govuk_back_link text: t("buttons.back"), href: back_link_path, classes: "govuk-!-margin-top-3"
+  = govuk_back_link text: t("buttons.back"), href: back_path, classes: "govuk-!-margin-top-3"
   .govuk-caption-l class="govuk-!-margin-top-5" = t("jobseekers.job_applications.caption", job_title: vacancy.job_title, organisation: vacancy.parent_organisation_name)
   h2.govuk-heading-xl class="govuk-!-margin-bottom-5" = t("jobseekers.job_applications.heading")
 
@@ -20,7 +20,9 @@
       = render EmptySectionComponent.new title: t(".no_employment_history") do
         = govuk_link_to t("buttons.add_role"), new_jobseekers_job_application_build_detail_path(job_application, :employment_history), button: true, class: "govuk-button--secondary govuk-!-margin-bottom-0"
 
-    = form_for @form, url: wizard_path, method: :patch do |f|
+    = form_for form, url: wizard_path, method: :patch do |f|
+      = hidden_field_tag :origin, request.referrer
+
       = f.govuk_error_summary
 
       = f.govuk_radio_buttons_fieldset :gaps_in_employment do
@@ -28,8 +30,8 @@
           = f.govuk_text_area :gaps_in_employment_details, form_group: { classes: "optional-field" }
         = f.govuk_radio_button :gaps_in_employment, :no
 
-      = f.govuk_submit t("buttons.continue")
-      = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"
+      = f.govuk_submit t("buttons.save_and_continue") do
+        = f.govuk_submit t("buttons.save_and_come_back"), secondary: true
 
   .govuk-grid-column-one-third
     = render(Shared::ProcessStepsComponent.new(process: vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))

--- a/app/views/jobseekers/job_applications/build/equal_opportunities.html.slim
+++ b/app/views/jobseekers/job_applications/build/equal_opportunities.html.slim
@@ -1,7 +1,7 @@
 - content_for :page_title_prefix, t(".title")
 
 = render BannerComponent.new do
-  = govuk_back_link text: t("buttons.back"), href: back_link_path, classes: "govuk-!-margin-top-3"
+  = govuk_back_link text: t("buttons.back"), href: back_path, classes: "govuk-!-margin-top-3"
   .govuk-caption-l class="govuk-!-margin-top-5" = t("jobseekers.job_applications.caption", job_title: vacancy.job_title, organisation: vacancy.parent_organisation_name)
   h2.govuk-heading-xl class="govuk-!-margin-bottom-5" = t("jobseekers.job_applications.heading")
 
@@ -14,7 +14,9 @@
     p.govuk-body = t(".anonymity")
     p.govuk-body = t(".optional")
 
-    = form_for @form, url: wizard_path, method: :patch do |f|
+    = form_for form, url: wizard_path, method: :patch do |f|
+      = hidden_field_tag :origin, request.referrer
+
       = f.govuk_error_summary
 
       = f.govuk_radio_buttons_fieldset :disability do
@@ -63,8 +65,8 @@
         = f.govuk_radio_divider
         = f.govuk_radio_button :religion, :prefer_not_to_say
 
-      = f.govuk_submit t("buttons.continue")
-      = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"
+      = f.govuk_submit t("buttons.save_and_continue") do
+        = f.govuk_submit t("buttons.save_and_come_back"), secondary: true
 
   .govuk-grid-column-one-third
     = render(Shared::ProcessStepsComponent.new(process: vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))

--- a/app/views/jobseekers/job_applications/build/personal_details.html.slim
+++ b/app/views/jobseekers/job_applications/build/personal_details.html.slim
@@ -1,7 +1,7 @@
 - content_for :page_title_prefix, t(".title")
 
 = render BannerComponent.new do
-  = govuk_back_link text: t("buttons.back"), href: back_link_path, classes: "govuk-!-margin-top-3"
+  = govuk_back_link text: t("buttons.back"), href: back_path, classes: "govuk-!-margin-top-3"
   .govuk-caption-l class="govuk-!-margin-top-5" = t("jobseekers.job_applications.caption", job_title: vacancy.job_title, organisation: vacancy.parent_organisation_name)
   h2.govuk-heading-xl class="govuk-!-margin-bottom-5" = t("jobseekers.job_applications.heading")
 
@@ -11,8 +11,11 @@
     h1.govuk-heading-l = t(".heading")
     p.govuk-body = t(".description")
 
-    = form_for @form, url: wizard_path, method: :patch do |f|
+    = form_for form, url: wizard_path, method: :patch do |f|
+      = hidden_field_tag :origin, request.referrer
+
       = f.govuk_error_summary
+
       = f.govuk_text_field :first_name, label: { size: "s" }, width: "one-half", aria: { required: true }
       = f.govuk_text_field :last_name, label: { size: "s" }, width: "one-half", aria: { required: true }
       = f.govuk_text_field :previous_names, label: { size: "s" }, width: "one-half", form_group: { classes: "optional-field" }
@@ -23,8 +26,9 @@
       = f.govuk_number_field :phone_number, label: { size: "s" }, width: "one-half", aria: { required: true }
       = f.govuk_text_field :teacher_reference_number, label: { size: "s" }, width: "one-half", aria: { required: true }
       = f.govuk_text_field :national_insurance_number, label: { size: "s" }, width: "one-half", form_group: { classes: "optional-field" }
-      = f.govuk_submit t("buttons.continue")
-      = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"
+
+      = f.govuk_submit t("buttons.save_and_continue") do
+        = f.govuk_submit t("buttons.save_and_come_back"), secondary: true
 
   .govuk-grid-column-one-third
     = render(Shared::ProcessStepsComponent.new(process: vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))

--- a/app/views/jobseekers/job_applications/build/personal_statement.html.slim
+++ b/app/views/jobseekers/job_applications/build/personal_statement.html.slim
@@ -1,7 +1,7 @@
 - content_for :page_title_prefix, t(".title")
 
 = render BannerComponent.new do
-  = govuk_back_link text: t("buttons.back"), href: back_link_path, classes: "govuk-!-margin-top-3"
+  = govuk_back_link text: t("buttons.back"), href: back_path, classes: "govuk-!-margin-top-3"
   .govuk-caption-l class="govuk-!-margin-top-5" = t("jobseekers.job_applications.caption", job_title: vacancy.job_title, organisation: vacancy.parent_organisation_name)
   h2.govuk-heading-xl class="govuk-!-margin-bottom-5" = t("jobseekers.job_applications.heading")
 
@@ -21,11 +21,15 @@
       h3.govuk-heading-s = t(".additional_instructions")
       = govuk_inset_text text: job_application.vacancy.personal_statement_guidance
 
-    = form_for @form, url: wizard_path, method: :patch do |f|
+    = form_for form, url: wizard_path, method: :patch do |f|
+      = hidden_field_tag :origin, request.referrer
+
       = f.govuk_error_summary
+
       = f.govuk_text_area :personal_statement, label: { size: "s" }, rows: 15, required: true, aria: { required: true }
-      = f.govuk_submit t("buttons.continue")
-      = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"
+
+      = f.govuk_submit t("buttons.save_and_continue") do
+        = f.govuk_submit t("buttons.save_and_come_back"), secondary: true
 
   .govuk-grid-column-one-third
     = render(Shared::ProcessStepsComponent.new(process: vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))

--- a/app/views/jobseekers/job_applications/build/professional_status.html.slim
+++ b/app/views/jobseekers/job_applications/build/professional_status.html.slim
@@ -1,7 +1,7 @@
 - content_for :page_title_prefix, t(".title")
 
 = render BannerComponent.new do
-  = govuk_back_link text: t("buttons.back"), href: back_link_path, classes: "govuk-!-margin-top-3"
+  = govuk_back_link text: t("buttons.back"), href: back_path, classes: "govuk-!-margin-top-3"
   .govuk-caption-l class="govuk-!-margin-top-5" = t("jobseekers.job_applications.caption", job_title: vacancy.job_title, organisation: vacancy.parent_organisation_name)
   h2.govuk-heading-xl class="govuk-!-margin-bottom-5" = t("jobseekers.job_applications.heading")
 
@@ -10,7 +10,9 @@
     .govuk-caption-m = t("jobseekers.job_applications.current_step", current: process_steps.current_step_number, total: 10)
     h1.govuk-heading-l = t(".heading")
 
-    = form_for @form, url: wizard_path, method: :patch do |f|
+    = form_for form, url: wizard_path, method: :patch do |f|
+      = hidden_field_tag :origin, request.referrer
+
       = f.govuk_error_summary
 
       = f.govuk_radio_buttons_fieldset :qualified_teacher_status do
@@ -22,8 +24,8 @@
 
       = f.govuk_collection_radio_buttons :statutory_induction_complete, %w[yes no], :to_s, :capitalize, inline: true
 
-      = f.govuk_submit t("buttons.continue")
-      = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"
+      = f.govuk_submit t("buttons.save_and_continue") do
+        = f.govuk_submit t("buttons.save_and_come_back"), secondary: true
 
   .govuk-grid-column-one-third
     = render(Shared::ProcessStepsComponent.new(process: vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))

--- a/app/views/jobseekers/job_applications/build/references.html.slim
+++ b/app/views/jobseekers/job_applications/build/references.html.slim
@@ -1,7 +1,7 @@
 - content_for :page_title_prefix, t(".title")
 
 = render BannerComponent.new do
-  = govuk_back_link text: t("buttons.back"), href: back_link_path, classes: "govuk-!-margin-top-3"
+  = govuk_back_link text: t("buttons.back"), href: back_path, classes: "govuk-!-margin-top-3"
   .govuk-caption-l class="govuk-!-margin-top-5" = t("jobseekers.job_applications.caption", job_title: vacancy.job_title, organisation: vacancy.parent_organisation_name)
   h2.govuk-heading-xl class="govuk-!-margin-bottom-5" = t("jobseekers.job_applications.heading")
 
@@ -20,12 +20,16 @@
       = render EmptySectionComponent.new title: t(".no_references") do
         = govuk_link_to t("buttons.add_reference"), new_jobseekers_job_application_build_detail_path(job_application, :references), button: true, class: "govuk-button--secondary govuk-!-margin-bottom-0"
 
-    = form_for @form, url: wizard_path, method: :patch do |f|
+    = form_for form, url: wizard_path, method: :patch do |f|
+      = hidden_field_tag :origin, request.referrer
+
       = f.govuk_error_summary
 
       - if job_application.references.many?
-        = f.govuk_submit t("buttons.continue")
-      = f.govuk_submit t("buttons.save_as_draft"), secondary: true, classes: "button-link"
+        = f.govuk_submit t("buttons.save_and_continue") do
+          = f.govuk_submit t("buttons.save_and_come_back"), secondary: true
+      - else
+        = f.govuk_submit t("buttons.save_and_come_back"), secondary: true
 
   .govuk-grid-column-one-third
     = render(Shared::ProcessStepsComponent.new(process: vacancy, service: process_steps, title: t("jobseekers.job_applications.build.process_title")))

--- a/app/views/jobseekers/job_applications/confirm_withdraw.html.slim
+++ b/app/views/jobseekers/job_applications/confirm_withdraw.html.slim
@@ -7,9 +7,9 @@
       h1.govuk-heading-xl = t(".heading")
 
       = form_for withdraw_form, url: jobseekers_job_application_withdraw_path(job_application), method: :post do |f|
-        = f.govuk_error_summary
+        = hidden_field_tag :origin, request.referrer
 
-        = hidden_field_tag :origin, value: request.referrer
+        = f.govuk_error_summary
 
         = f.govuk_radio_buttons_fieldset :withdraw_reason do
           = f.govuk_radio_button :withdraw_reason, :another_role, link_errors: true

--- a/app/views/jobseekers/job_applications/review.html.slim
+++ b/app/views/jobseekers/job_applications/review.html.slim
@@ -38,4 +38,4 @@
 
       - if vacancy.listed?
         = f.govuk_submit t("buttons.submit_application") do
-          = f.govuk_submit t("buttons.save_as_draft"), secondary: true
+          = f.govuk_submit t("buttons.save_and_come_back"), secondary: true

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -206,9 +206,11 @@ en:
         jobseekers/job_application/ask_for_support_form:
           attributes:
             support_needed:
-              inclusion: Select an option
+              inclusion: Select yes if you would like interview support
             support_needed_details:
               blank: Give details about what support you might need
+              # TODO: Update content once confirmed
+              present: If you don't need support, extra information must be blank
         jobseekers/job_application/declarations_form:
           attributes:
             banned_or_disqualified:

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -29,8 +29,8 @@ en:
     reject: Confirm rejection
     resend_email: Resend request
     save_and_continue: Save and continue
+    save_and_come_back: Save and come back later
     save_and_return_later: Save and return later
-    save_as_draft: Save as draft
     save_changes: Save changes
     search: Search
     select_file: Select a file

--- a/db/migrate/20210326134138_add_default_completed_steps_to_job_applications.rb
+++ b/db/migrate/20210326134138_add_default_completed_steps_to_job_applications.rb
@@ -1,0 +1,6 @@
+class AddDefaultCompletedStepsToJobApplications < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :job_applications, :completed_steps, []
+    change_column_null :job_applications, :completed_steps, false, []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_26_085916) do
+ActiveRecord::Schema.define(version: 2021_03_26_134138) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -100,7 +100,7 @@ ActiveRecord::Schema.define(version: 2021_03_26_085916) do
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "jobseeker_id"
     t.uuid "vacancy_id"
-    t.integer "completed_steps", array: true
+    t.integer "completed_steps", default: [], null: false, array: true
     t.datetime "submitted_at"
     t.datetime "draft_at"
     t.datetime "shortlisted_at"

--- a/spec/factories/job_applications.rb
+++ b/spec/factories/job_applications.rb
@@ -101,6 +101,17 @@ FactoryBot.define do
     # Personal statement
     personal_statement { "" }
 
+    # Equal opportunities
+    disability { "" }
+    gender { "" }
+    gender_description { "" }
+    orientation { "" }
+    orientation_description { "" }
+    ethnicity { "" }
+    ethnicity_description { "" }
+    religion { "" }
+    religion_description { "" }
+
     # Ask for support
     support_needed { "" }
     support_needed_details { "" }

--- a/spec/form_models/jobseekers/job_application/ask_for_support_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/ask_for_support_form_spec.rb
@@ -10,12 +10,8 @@ RSpec.describe Jobseekers::JobApplication::AskForSupportForm, type: :model do
   end
 
   context "when support_needed is no" do
-    context "when params contains support_needed_details" do
-      subject { described_class.new({ support_needed: "no", support_needed_details: "Some misplaced details" }) }
+    before { allow(subject).to receive(:support_needed).and_return("no") }
 
-      it "sets support_needed_details to nil" do
-        expect(subject.support_needed_details).to be_blank
-      end
-    end
+    it { is_expected.to validate_absence_of(:support_needed_details) }
   end
 end

--- a/spec/requests/jobseekers/job_applications/build_spec.rb
+++ b/spec/requests/jobseekers/job_applications/build_spec.rb
@@ -1,0 +1,93 @@
+require "rails_helper"
+
+RSpec.describe "Job applications build" do
+  let(:vacancy) { create(:vacancy, organisation_vacancies_attributes: [{ organisation: build(:school) }]) }
+  let(:jobseeker) { create(:jobseeker) }
+  let(:job_application) { create(:job_application, :status_draft, jobseeker: jobseeker, vacancy: vacancy) }
+
+  before do
+    allow(JobseekerApplicationsFeature).to receive(:enabled?).and_return(true)
+    sign_in(jobseeker, scope: :jobseeker)
+  end
+
+  describe "GET #show" do
+    context "when the job application status is not draft" do
+      let(:job_application) { create(:job_application, :status_submitted, jobseeker: jobseeker, vacancy: vacancy) }
+
+      it "returns not_found" do
+        get jobseekers_job_application_build_path(job_application, :personal_details)
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    it "renders the show page" do
+      expect(get(jobseekers_job_application_build_path(job_application, :personal_details)))
+        .to render_template(:personal_details)
+    end
+  end
+
+  describe "PATCH #update" do
+    let(:params) { { commit: button, origin: origin, jobseekers_job_application_personal_details_form: { first_name: "Cool name" } } }
+    let(:button) { I18n.t("buttons.save_and_continue") }
+    let(:origin) { "" }
+
+    context "when the job application status is not draft" do
+      let(:job_application) { create(:job_application, :status_submitted, jobseeker: jobseeker, vacancy: vacancy) }
+
+      it "returns not_found" do
+        patch jobseekers_job_application_build_path(job_application, :personal_details)
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when the commit param is `Save and come back later`" do
+      let(:button) { I18n.t("buttons.save_and_come_back") }
+
+      it "updates the job application without form validation and redirects to the dashboard" do
+        expect { patch jobseekers_job_application_build_path(job_application, :personal_details), params: params }
+          .to change { job_application.reload.first_name }.from("").to("Cool name")
+          .and(not_change { job_application.reload.completed_steps })
+
+        expect(response).to redirect_to(jobseekers_job_applications_path)
+      end
+    end
+
+    context "when the form is valid" do
+      before { allow_any_instance_of(Jobseekers::JobApplication::PersonalDetailsForm).to receive(:valid?).and_return(true) }
+
+      context "when origin param is `jobseekers_job_application_review_url`" do
+        let(:origin) { jobseekers_job_application_review_url(job_application) }
+
+        it "updates the job application and redirects to the review page" do
+          expect { patch jobseekers_job_application_build_path(job_application, :personal_details), params: params }
+            .to change { job_application.reload.first_name }.from("").to("Cool name")
+            .and change { job_application.reload.completed_steps }.from([]).to(["personal_details"])
+
+          expect(response).to redirect_to(jobseekers_job_application_review_path(job_application))
+        end
+      end
+
+      context "when origin param is not `jobseekers_job_application_review_url`" do
+        it "updates the job application and redirects to the next step" do
+          expect { patch jobseekers_job_application_build_path(job_application, :personal_details), params: params }
+            .to change { job_application.reload.first_name }.from("").to("Cool name")
+            .and change { job_application.reload.completed_steps }.from([]).to(["personal_details"])
+
+          expect(response).to redirect_to(jobseekers_job_application_build_path(job_application, :professional_status))
+        end
+      end
+    end
+
+    context "when the form is invalid" do
+      it "does not update the job application and renders show page" do
+        expect { patch jobseekers_job_application_build_path(job_application, :personal_details), params: params }
+          .to not_change { job_application.reload.first_name }
+          .and(not_change { job_application.reload.completed_steps })
+
+        expect(response).to render_template(:personal_details)
+      end
+    end
+  end
+end

--- a/spec/requests/jobseekers/job_applications_spec.rb
+++ b/spec/requests/jobseekers/job_applications_spec.rb
@@ -93,8 +93,8 @@ RSpec.describe "Job applications" do
       end
     end
 
-    context "when the commit param is `Save as draft`" do
-      let(:button) { I18n.t("buttons.save_as_draft") }
+    context "when the commit param is `Save and come back later`" do
+      let(:button) { I18n.t("buttons.save_and_come_back") }
 
       it "does not submit the job application and redirects to applications dashboard" do
         assert_emails 0 do

--- a/spec/system/jobseekers_can_add_employment_history_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers_can_add_employment_history_to_their_job_application_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Jobseekers can add employment history to their job application" 
         visit jobseekers_job_application_build_path(job_application, :employment_history)
         choose "Yes", name: "jobseekers_job_application_employment_history_form[gaps_in_employment]"
         fill_in "jobseekers_job_application_employment_history_form[gaps_in_employment_details]", with: "Some details about gaps in employment"
-        click_on I18n.t("buttons.save_as_draft")
+        click_on I18n.t("buttons.save_and_come_back")
         expect(job_application.reload.gaps_in_employment).to eq("yes")
         expect(job_application.reload.gaps_in_employment_details).to eq("Some details about gaps in employment")
       end

--- a/spec/system/jobseekers_can_complete_a_job_application_spec.rb
+++ b/spec/system/jobseekers_can_complete_a_job_application_spec.rb
@@ -16,12 +16,12 @@ RSpec.describe "Jobseekers can complete a job application" do
     expect(page).to have_content(I18n.t("jobseekers.job_applications.build.personal_details.heading"))
     validates_step_complete
     fill_in_personal_details
-    click_on I18n.t("buttons.continue")
+    click_on I18n.t("buttons.save_and_continue")
 
     expect(page).to have_content(I18n.t("jobseekers.job_applications.build.professional_status.heading"))
     validates_step_complete
     fill_in_professional_status
-    click_on I18n.t("buttons.continue")
+    click_on I18n.t("buttons.save_and_continue")
 
     expect(page).to have_content(I18n.t("jobseekers.job_applications.build.employment_history.heading"))
     validates_step_complete
@@ -32,15 +32,15 @@ RSpec.describe "Jobseekers can complete a job application" do
     click_on I18n.t("jobseekers.job_applications.details.form.employment_history.save")
     validates_step_complete
     choose "No", name: "jobseekers_job_application_employment_history_form[gaps_in_employment]"
-    click_on I18n.t("buttons.continue")
+    click_on I18n.t("buttons.save_and_continue")
 
     expect(page).to have_content(I18n.t("jobseekers.job_applications.build.personal_statement.heading"))
     validates_step_complete
     fill_in_personal_statement
-    click_on I18n.t("buttons.continue")
+    click_on I18n.t("buttons.save_and_continue")
 
     expect(page).to have_content(I18n.t("jobseekers.job_applications.build.references.heading"))
-    expect(page).not_to have_content(I18n.t("buttons.continue"))
+    expect(page).not_to have_content(I18n.t("buttons.save_and_continue"))
     click_on I18n.t("buttons.add_reference")
     click_on I18n.t("jobseekers.job_applications.details.form.references.save")
     expect(page).to have_content("There is a problem")
@@ -49,28 +49,28 @@ RSpec.describe "Jobseekers can complete a job application" do
     click_on I18n.t("buttons.add_another_reference")
     fill_in_reference
     click_on I18n.t("jobseekers.job_applications.details.form.references.save")
-    click_on I18n.t("buttons.continue")
+    click_on I18n.t("buttons.save_and_continue")
 
     expect(page).to have_content(I18n.t("jobseekers.job_applications.build.equal_opportunities.heading"))
     validates_step_complete
     fill_in_equal_opportunities
-    click_on I18n.t("buttons.continue")
+    click_on I18n.t("buttons.save_and_continue")
 
     expect(page).to have_content(I18n.t("jobseekers.job_applications.build.ask_for_support.heading"))
     validates_step_complete
     fill_in_ask_for_support
-    click_on I18n.t("buttons.continue")
+    click_on I18n.t("buttons.save_and_continue")
 
     expect(page).to have_content(I18n.t("jobseekers.job_applications.build.declarations.heading"))
     validates_step_complete
     fill_in_declarations
-    click_on I18n.t("buttons.continue")
+    click_on I18n.t("buttons.save_and_continue")
 
     expect(current_path).to eq(jobseekers_job_application_review_path(job_application))
   end
 
   def validates_step_complete
-    click_on I18n.t("buttons.continue")
+    click_on I18n.t("buttons.save_and_continue")
     expect(page).to have_content("There is a problem")
   end
 end

--- a/spec/system/jobseekers_can_edit_a_draft_job_application_spec.rb
+++ b/spec/system/jobseekers_can_edit_a_draft_job_application_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe "Jobseekers can edit a draft job application" do
+  let(:jobseeker) { create(:jobseeker) }
+  let(:vacancy) { create(:vacancy, organisation_vacancies_attributes: [{ organisation: build(:school) }]) }
+  let(:job_application) { create(:job_application, first_name: "Steve", jobseeker: jobseeker, vacancy: vacancy) }
+
+  before do
+    allow(JobseekerApplicationsFeature).to receive(:enabled?).and_return(true)
+    login_as(jobseeker, scope: :jobseeker)
+  end
+
+  it "allows jobseekers to edit job application from review page" do
+    visit jobseekers_job_application_review_path(job_application)
+
+    within "#personal_details_heading" do
+      click_on "Change"
+    end
+
+    expect(current_path).to eq(jobseekers_job_application_build_path(job_application, :personal_details))
+
+    fill_in "First name", with: "Dave"
+
+    expect { click_on I18n.t("buttons.save_and_continue") }
+      .to change { job_application.reload.first_name }.from("Steve").to("Dave")
+
+    expect(current_path).to eq(jobseekers_job_application_review_path(job_application))
+    expect(page).to have_content(I18n.t("messages.jobseekers.job_applications.saved"))
+  end
+end

--- a/spec/system/jobseekers_can_save_a_job_application_spec.rb
+++ b/spec/system/jobseekers_can_save_a_job_application_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Jobseekers can save a job application" do
 
     fill_in "First name", with: "Steve"
 
-    expect { click_on I18n.t("buttons.save_as_draft") }
+    expect { click_on I18n.t("buttons.save_and_come_back") }
       .to change { job_application.reload.first_name }.from("").to("Steve")
 
     expect(current_path).to eq(jobseekers_job_applications_path)

--- a/spec/system/jobseekers_can_submit_a_job_application_spec.rb
+++ b/spec/system/jobseekers_can_submit_a_job_application_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Jobseekers can submit a job application" do
     end
 
     it "allows jobseekers to save application and go to dashboard" do
-      click_on I18n.t("buttons.save_as_draft")
+      click_on I18n.t("buttons.save_and_come_back")
 
       expect(JobApplication.first.status).to eq("draft")
       expect(page).to have_content(I18n.t("messages.jobseekers.job_applications.saved"))


### PR DESCRIPTION
## Changes in this PR
- Add default completed steps `[]` to job applications table
- Just validate absence of `support_needed_details` rather than form/controller magic to conditionally remove `support_needed_details`
- Allow jobseekers to edit draft job application 🦄 
- Change `Continue` button to `Save and continue` in job application journey
- Change `Save as draft` link to `Save and come back later` button in job application journey