### PR TITLE
alter paths of previews to be more intuitive

### DIFF
--- a/app/components/previews/notification_component_preview.rb
+++ b/app/components/previews/notification_component_preview.rb
@@ -1,4 +1,4 @@
-class Previews::NotificationComponentPreview < ViewComponent::Preview
+class NotificationComponentPreview < ViewComponent::Preview
   layout "design_system"
 
   def self.component_name
@@ -10,7 +10,7 @@ class Previews::NotificationComponentPreview < ViewComponent::Preview
   end
 
   def self.form
-    Previews::NotificationComponentPreview::OptionsForm
+    NotificationComponentPreview::OptionsForm
   end
 
   def self.interactive_options

--- a/app/components/previews/notification_component_preview/options_form.rb
+++ b/app/components/previews/notification_component_preview/options_form.rb
@@ -1,11 +1,11 @@
-class Previews::NotificationComponentPreview::OptionsForm
+class NotificationComponentPreview::OptionsForm
   include ActiveModel::Model
 
   attr_reader :background, :dismiss, :icon
 
   def initialize(params = {})
-    preview_criteria = if params[:previews_notification_component_preview_options_form].present?
-                         JSON.parse(params[:previews_notification_component_preview_options_form].to_json).symbolize_keys
+    preview_criteria = if params[:notification_component_preview_options_form].present?
+                         JSON.parse(params[:notification_component_preview_options_form].to_json).symbolize_keys
                        else
                          {}
                        end

--- a/app/controllers/previews_controller.rb
+++ b/app/controllers/previews_controller.rb
@@ -1,4 +1,4 @@
-class PreviewController < ApplicationController
+class PreviewsController < ApplicationController
   layout "design_system"
 
   before_action :find_preview, only: :previews

--- a/config/application.rb
+++ b/config/application.rb
@@ -83,9 +83,9 @@ module TeacherVacancyService
 
     config.geocoder_lookup = :default
 
-    config.view_component.preview_paths << "#{Rails.root}/app/components"
+    config.view_component.preview_paths << "#{Rails.root}/app/components/previews"
     config.view_component.preview_route = "/components"
-    config.view_component.preview_controller = "PreviewController"
+    config.view_component.preview_controller = "PreviewsController"
     config.view_component.show_previews = true
   end
 end


### PR DESCRIPTION
no ticket

makes path bit cleaner e.g `components/notification_component/preview`