### PR TITLE
[TEVA-2309] CloudFront - pin newer viewer TLS policy

### DIFF
--- a/terraform/app/modules/cloudfront/main.tf
+++ b/terraform/app/modules/cloudfront/main.tf
@@ -140,8 +140,9 @@ resource "aws_cloudfront_distribution" "default" {
   }
 
   viewer_certificate {
-    acm_certificate_arn = data.aws_acm_certificate.cloudfront_cert.arn
-    ssl_support_method  = "sni-only"
+    acm_certificate_arn      = data.aws_acm_certificate.cloudfront_cert.arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = local.cloudfront_viewer_certificate_minimum_protocol_version
   }
 
   tags = {

--- a/terraform/app/modules/cloudfront/variables.tf
+++ b/terraform/app/modules/cloudfront/variables.tf
@@ -39,11 +39,12 @@ variable "route53_cname_record" {}
 variable "route53_a_records" {}
 
 locals {
-  route53_zones                = toset(var.route53_zones)
-  route53_zones_with_a_records = var.is_production ? local.route53_zones : toset([])
-  route53_zones_with_cnames    = local.route53_zones
-  cloudfront_cert_cn           = "${var.service_name}.service.gov.uk"
-  domain                       = var.is_production ? local.cloudfront_cert_cn : "${var.environment}.${local.cloudfront_cert_cn}"
-  cloudfront_aliases_cnames    = [for zone in var.route53_zones : "${var.route53_cname_record}.${zone}"]
-  cloudfront_aliases           = concat(var.route53_a_records, local.cloudfront_aliases_cnames)
+  route53_zones                                          = toset(var.route53_zones)
+  route53_zones_with_a_records                           = var.is_production ? local.route53_zones : toset([])
+  route53_zones_with_cnames                              = local.route53_zones
+  cloudfront_cert_cn                                     = "${var.service_name}.service.gov.uk"
+  domain                                                 = var.is_production ? local.cloudfront_cert_cn : "${var.environment}.${local.cloudfront_cert_cn}"
+  cloudfront_aliases_cnames                              = [for zone in var.route53_zones : "${var.route53_cname_record}.${zone}"]
+  cloudfront_aliases                                     = concat(var.route53_a_records, local.cloudfront_aliases_cnames)
+  cloudfront_viewer_certificate_minimum_protocol_version = "TLSv1.2_2018"
 }


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2309

## Changes in this PR:

From the March 2021 pen test, we are still supporting older ciphers
- Support configuration of CloudFront viewer TLS policy through Terraform local var
- Pin to `TLSv1.2_2018`

## Testing

Planning against `dev` via Makefile
```
  # module.cloudfront["tvsdev"].aws_cloudfront_distribution.default will be updated in-place
  ~ resource "aws_cloudfront_distribution" "default" {
        id                             = "E1GFAMOTLJHUWT"
        tags                           = {
            "Environment" = "dev"
            "Name"        = "teaching-vacancies-dev"
        }
        # (16 unchanged attributes hidden)

      ~ viewer_certificate {
          ~ minimum_protocol_version       = "TLSv1" -> "TLSv1.2_2018"
            # (3 unchanged attributes hidden)
        }
        # (11 unchanged blocks hidden)
    }
```