### PR TITLE
[TEVA-2310] CloudFront - communicate with origins using TLS 1.2 only

### DIFF
--- a/terraform/app/modules/cloudfront/main.tf
+++ b/terraform/app/modules/cloudfront/main.tf
@@ -7,7 +7,7 @@ resource "aws_cloudfront_distribution" "default" {
       origin_protocol_policy = "https-only"
       http_port              = "80"
       https_port             = "443"
-      origin_ssl_protocols   = ["TLSv1", "TLSv1.1", "TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2"]
     }
   }
 


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2310

## Changes in this PR:

- Gov.UK PaaS origins only listen for TLS1.2, so we can pin CloudFront `origin_ssl_protocols` to that version.

## Source

[SSL Labs report](https://www.ssllabs.com/ssltest/analyze.html?d=teaching%2dvacancies%2dreview%2dpr%2d3178.london.cloudapps.digital&s=18.135.54.224&hideResults=on) gives this report on Protocols supported by PaaS:
```
TLS 1.3	No
TLS 1.2	Yes
TLS 1.1	No
TLS 1.0	No
SSL 3	No
SSL 2	No
```

## Testing

`terraform-app-plan` against QA shows 

```
      - origin {
          - domain_name = "teaching-vacancies-qa.london.cloudapps.digital" -> null
          - origin_id   = "teaching-vacancies-qa-default-origin" -> null

          - custom_origin_config {
              - http_port                = 80 -> null
              - https_port               = 443 -> null
              - origin_keepalive_timeout = 5 -> null
              - origin_protocol_policy   = "https-only" -> null
              - origin_read_timeout      = 30 -> null
              - origin_ssl_protocols     = [
                  - "TLSv1",
                  - "TLSv1.1",
                  - "TLSv1.2",
                ] -> null
            }
        }
      + origin {
          + domain_name = "teaching-vacancies-qa.london.cloudapps.digital"
          + origin_id   = "teaching-vacancies-qa-default-origin"

          + custom_origin_config {
              + http_port                = 80
              + https_port               = 443
              + origin_keepalive_timeout = 5
              + origin_protocol_policy   = "https-only"
              + origin_read_timeout      = 30
              + origin_ssl_protocols     = [
                  + "TLSv1.2",
                ]
            }
        }
```