### PR TITLE
[TEVA-2311] CloudFront - use new offline site in staging and prod

### DIFF
--- a/terraform/workspace-variables/production.tfvars
+++ b/terraform/workspace-variables/production.tfvars
@@ -7,8 +7,8 @@ parameter_store_environment = "production"
 # CloudFront
 distribution_list = {
   "tvsprod" = {
-    offline_bucket_domain_name    = "tvs-offline.s3.amazonaws.com"
-    offline_bucket_origin_path    = "/school-jobs-offline"
+    offline_bucket_domain_name    = "530003481352-offline-site.s3.amazonaws.com"
+    offline_bucket_origin_path    = "/teaching-vacancies-offline"
     cloudfront_origin_domain_name = "teaching-vacancies-production.london.cloudapps.digital"
   }
 }

--- a/terraform/workspace-variables/staging.tfvars
+++ b/terraform/workspace-variables/staging.tfvars
@@ -7,8 +7,8 @@ parameter_store_environment = "staging"
 # CloudFront
 distribution_list = {
   "tvsstaging" = {
-    offline_bucket_domain_name    = "tvs-offline.s3.amazonaws.com"
-    offline_bucket_origin_path    = "/school-jobs-offline"
+    offline_bucket_domain_name    = "530003481352-offline-site.s3.amazonaws.com"
+    offline_bucket_origin_path    = "/teaching-vacancies-offline"
     cloudfront_origin_domain_name = "teaching-vacancies-staging.london.cloudapps.digital"
   }
 }


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2311

## Changes in this PR:

- Use new offline site on `staging` and `production`
