### PR TITLE
[TEVA-2312] - Set StatusCake node_locations to UK and Ireland

### DIFF
--- a/terraform/app/modules/statuscake/main.tf
+++ b/terraform/app/modules/statuscake/main.tf
@@ -1,12 +1,13 @@
 resource "statuscake_test" "alert" {
-  for_each      = var.statuscake_alerts
-  website_name  = each.value.website_name
-  website_url   = each.value.website_url
-  test_type     = "HTTP"
-  check_rate    = 30
-  contact_group = each.value.contact_group
-  trigger_rate  = 0
-  find_string   = lookup(each.value, "find_string", null)
-  do_not_find   = lookup(each.value, "do_not_find", false)
-  confirmations = 1
+  for_each       = var.statuscake_alerts
+  website_name   = each.value.website_name
+  website_url    = each.value.website_url
+  test_type      = "HTTP"
+  check_rate     = 30
+  contact_group  = each.value.contact_group
+  trigger_rate   = 0
+  find_string    = lookup(each.value, "find_string", null)
+  do_not_find    = lookup(each.value, "do_not_find", false)
+  confirmations  = 1
+  node_locations = ["EC1", "MAN1", "DUB2"]
 }


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2312

## Changes in this PR:

- Choose StatusCake `servercode` identifier from https://app.statuscake.com/Workfloor/Locations.php
- Use locations in StatusCake tests to avoid false positives originating from Texas
