### PR TITLE
Add logging to document upload

### DIFF
--- a/app/controllers/publishers/vacancies/documents_controller.rb
+++ b/app/controllers/publishers/vacancies/documents_controller.rb
@@ -85,6 +85,7 @@ class Publishers::Vacancies::DocumentsController < Publishers::Vacancies::BaseCo
   end
 
   def upload_document(document_params)
+    Rails.logger.info("Uploading document #{document_params.original_filename}, inferred type: #{document_params.content_type}")
     add_file_type_error(document_params.original_filename) unless valid_content_type?(document_params.tempfile)
     add_file_size_error(document_params.original_filename) if document_params.size > FILE_SIZE_LIMIT
 


### PR DESCRIPTION
The recent change to more aggressive content type checking _may_ have
caused some issues, this should help with debugging in the logs.