### PR TITLE
[teva 2093] Change ref to sha in github action workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,7 +118,7 @@ jobs:
       with:
         token: ${{ secrets.PERSONAL_TOKEN }}
         checkName: Deploy ${{ env.TAG }} to staging # Job name within workflow
-        ref: ${{ github.ref }}
+        ref: ${{ github.sha }}
         timeoutSeconds: 720
         intervalSeconds: 15
 
@@ -149,7 +149,7 @@ jobs:
       with:
         token: ${{ secrets.PERSONAL_TOKEN }}
         checkName: Smoke Test staging.teaching-vacancies.service.gov.uk ${{ github.sha }}
-        ref: ${{ github.ref }}
+        ref: ${{ github.sha }}
         timeoutSeconds: 300
         intervalSeconds: 15
 
@@ -171,7 +171,7 @@ jobs:
       with:
         token: ${{ secrets.PERSONAL_TOKEN }}
         checkName: Deploy ${{ env.TAG }} to production # Job name within workflow
-        ref: ${{ github.ref }}
+        ref: ${{ github.sha }}
         timeoutSeconds: 720
         intervalSeconds: 15
 

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -1,4 +1,4 @@
-name: Deploy
+name: Deploy branch
 
 on:
   push:
@@ -118,7 +118,7 @@ jobs:
       with:
         token: ${{ secrets.PERSONAL_TOKEN }}
         checkName: Deploy ${{ env.TAG }} to ${{ env.BRANCH }} # Job name within workflow
-        ref: ${{ github.ref }}
+        ref: ${{ github.sha  }}
         timeoutSeconds: 720
         intervalSeconds: 15
 
@@ -135,7 +135,7 @@ jobs:
       with:
         token: ${{ secrets.PERSONAL_TOKEN }}
         checkName: Smoke Test ${{ env.BRANCH }}.teaching-vacancies.service.gov.uk ${{ github.sha }}
-        ref: ${{ github.ref }}
+        ref: ${{ github.sha }}
         timeoutSeconds: 300
         intervalSeconds: 15
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -109,7 +109,7 @@ jobs:
       uses: benc-uk/workflow-dispatch@v1.1
       with:
         token: ${{ secrets.PERSONAL_TOKEN }}
-        ref: ${{ github.event.pull_request.head.ref || github.ref }}
+        ref: ${{ github.event.pull_request.head.ref }}
         workflow: Deploy App to Environment # Workflow name
         inputs: '{"environment": "${{ env.ENVIRONMENT }}", "tag": "${{ env.TAG }}"}'
 
@@ -119,7 +119,7 @@ jobs:
       with:
         token: ${{ secrets.PERSONAL_TOKEN }}
         checkName: Deploy ${{ env.TAG }} to ${{ env.ENVIRONMENT }} # Job name within workflow
-        ref: ${{ github.event.pull_request.head.sha || github.ref }}
+        ref: ${{ github.event.pull_request.head.sha }}
         timeoutSeconds: 720
         intervalSeconds: 15
 
@@ -148,7 +148,7 @@ jobs:
       with:
         token: ${{ secrets.PERSONAL_TOKEN }}
         checkName: Smoke Test teaching-vacancies-review-pr-${{ github.event.number }}.london.cloudapps.digital ${{ github.sha }}
-        ref: ${{ github.event.pull_request.head.sha || github.sha }}
+        ref: ${{ github.event.pull_request.head.sha }}
         timeoutSeconds: 300
         intervalSeconds: 15
 


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2093

## Changes in this PR:

- Changed the use of `ref: github.ref` to `ref: github.sha` - This is required in order for the `fountainhead/action-wait-for-check@v1.0.0` to track the deployment `job` in the `deploy_app workflow`.

- Also, introduced uniqueness in the naming of workflow deploy_branch.yml and deploy.yml. This allows the turnstyle actions to function properly.

