### PR TITLE
Use sha instead of ref in refresh workflow

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           token: ${{ secrets.PERSONAL_TOKEN }}
           checkName: Deploy app to environment # Job name within workflow
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
           timeoutSeconds: 300
           intervalSeconds: 15
 


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2093

## Changes in this PR:

Use `sha` instead of `ref` in refresh workflow - **(fountainhead/action-wait-for-check@v1.0.0)**

