### PR TITLE
Add logging to organisation import task

### DIFF
--- a/lib/organisation_import/import_organisation_data.rb
+++ b/lib/organisation_import/import_organisation_data.rb
@@ -17,7 +17,7 @@ class ImportOrganisationData
     if memberships_to_delete.count > 10
       school_group_name_and_count_of_memberships = memberships_to_delete.map { |membership| membership.school_group.name }
                                                                         .group_by { |x| x }
-                                                                        .transform_values { |v| v.length }
+                                                                        .transform_values(&:length)
       Rollbar.log(:info, "The number of memberships to delete, by SchoolGroup: #{school_group_name_and_count_of_memberships}")
 
       raise SuspiciouslyHighNumberOfRecordsToDelete, memberships_to_delete.count

--- a/lib/organisation_import/import_organisation_data.rb
+++ b/lib/organisation_import/import_organisation_data.rb
@@ -15,13 +15,12 @@ class ImportOrganisationData
   def self.delete_marked_school_group_memberships!
     memberships_to_delete = SchoolGroupMembership.where(do_not_delete: false)
     if memberships_to_delete.count > 10
-      raise SuspiciouslyHighNumberOfRecordsToDelete, memberships_to_delete.count 
-    
-      school_group_name_and_count_of_memberships = memberships_to_delete.map { |membership| membership.school_group.name}
+      school_group_name_and_count_of_memberships = memberships_to_delete.map { |membership| membership.school_group.name }
                                                                         .group_by { |x| x }
-                                                                        .map{ |key, value| [key, value.length]}
-                                                                        .to_h
+                                                                        .transform_values { |v| v.length }
       Rollbar.log(:info, "The number of memberships to delete, by SchoolGroup: #{school_group_name_and_count_of_memberships}")
+
+      raise SuspiciouslyHighNumberOfRecordsToDelete, memberships_to_delete.count
     else
       memberships_to_delete.delete_all
     end


### PR DESCRIPTION
This is confirm that the recent errors (text below) are from Northamptonshire, as hypothesised.

"There was a suspiciously high number of SchoolGroupMemberships to delete: 686. Skipped deletion."
https://rollbar.com/dfe/teacher-vacancies/items/3860/

Slack discussion: https://ukgovernmentdfe.slack.com/archives/G0127R0KXQF/p1617786204001600

I tested the chained methods by running them on `SchoolGroupMembership.all`, which output:

```ruby
{"Weydon Multi Academy Trust"=>1,
 "Southampton local authority"=>2,
 "City of London local authority"=>6,
 "Camden local authority"=>92,
 "Greenwich local authority"=>116,
 "Lewisham local authority"=>100,
 "Hackney local authority"=>101,
 "Tower Hamlets local authority"=>109
 # etc.
```
