### PR TITLE
Don't show caption or steps for subsequent job applications

### DIFF
--- a/app/views/jobseekers/job_applications/build/_steps.html.slim
+++ b/app/views/jobseekers/job_applications/build/_steps.html.slim
@@ -1,3 +1,4 @@
 = render StepsComponent.new title: "Application Steps", classes: "govuk-!-margin-top-6" do |component|
   - wizard_steps.each do |wizard_step|
     - component.step(label: t("jobseekers.job_applications.build.#{wizard_step}.step_title"), current: current_step?(wizard_step), completed: wizard_step.to_s.in?(job_application.completed_steps))
+  - component.step(label: t("jobseekers.job_applications.review.heading"), current: false, completed: false)

--- a/app/views/jobseekers/job_applications/build/ask_for_support.html.slim
+++ b/app/views/jobseekers/job_applications/build/ask_for_support.html.slim
@@ -7,7 +7,8 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = render "caption"
+    - if current_jobseeker.job_applications.not_draft.none?
+      = render "caption"
     h1.govuk-heading-l = t(".heading")
 
     p.govuk-body = t(".opening")
@@ -30,5 +31,6 @@
       = f.govuk_submit t("buttons.save_and_continue") do
         = f.govuk_submit t("buttons.save_and_come_back"), secondary: true
 
-  .govuk-grid-column-one-third
-    = render "steps"
+  - if current_jobseeker.job_applications.not_draft.none?
+    .govuk-grid-column-one-third
+      = render "steps"

--- a/app/views/jobseekers/job_applications/build/declarations.html.slim
+++ b/app/views/jobseekers/job_applications/build/declarations.html.slim
@@ -7,7 +7,8 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = render "caption"
+    - if current_jobseeker.job_applications.not_draft.none?
+      = render "caption"
     h1.govuk-heading-l = t(".heading")
 
     = form_for form, url: wizard_path, method: :patch do |f|
@@ -27,5 +28,6 @@
       = f.govuk_submit t("buttons.save_and_continue") do
         = f.govuk_submit t("buttons.save_and_come_back"), secondary: true
 
-  .govuk-grid-column-one-third
-    = render "steps"
+  - if current_jobseeker.job_applications.not_draft.none?
+    .govuk-grid-column-one-third
+      = render "steps"

--- a/app/views/jobseekers/job_applications/build/employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/build/employment_history.html.slim
@@ -7,7 +7,8 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = render "caption"
+    - if current_jobseeker.job_applications.not_draft.none?
+      = render "caption"
     h1.govuk-heading-l = t(".heading")
 
     p.govuk-body = t(".description1")
@@ -54,5 +55,6 @@
       = f.govuk_submit t("buttons.save_and_continue") do
         = f.govuk_submit t("buttons.save_and_come_back"), secondary: true
 
-  .govuk-grid-column-one-third
-    = render "steps"
+  - if current_jobseeker.job_applications.not_draft.none?
+    .govuk-grid-column-one-third
+      = render "steps"

--- a/app/views/jobseekers/job_applications/build/equal_opportunities.html.slim
+++ b/app/views/jobseekers/job_applications/build/equal_opportunities.html.slim
@@ -7,7 +7,8 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = render "caption"
+    - if current_jobseeker.job_applications.not_draft.none?
+      = render "caption"
     h1.govuk-heading-l = t(".heading")
 
     p.govuk-body = t(".explanation")
@@ -68,5 +69,6 @@
       = f.govuk_submit t("buttons.save_and_continue") do
         = f.govuk_submit t("buttons.save_and_come_back"), secondary: true
 
-  .govuk-grid-column-one-third
-    = render "steps"
+  - if current_jobseeker.job_applications.not_draft.none?
+    .govuk-grid-column-one-third
+      = render "steps"

--- a/app/views/jobseekers/job_applications/build/personal_details.html.slim
+++ b/app/views/jobseekers/job_applications/build/personal_details.html.slim
@@ -7,7 +7,8 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = render "caption"
+    - if current_jobseeker.job_applications.not_draft.none?
+      = render "caption"
     h1.govuk-heading-l = t(".heading")
     p.govuk-body = t(".description")
 
@@ -30,5 +31,6 @@
       = f.govuk_submit t("buttons.save_and_continue") do
         = f.govuk_submit t("buttons.save_and_come_back"), secondary: true
 
-  .govuk-grid-column-one-third
-    = render "steps"
+  - if current_jobseeker.job_applications.not_draft.none?
+    .govuk-grid-column-one-third
+      = render "steps"

--- a/app/views/jobseekers/job_applications/build/personal_statement.html.slim
+++ b/app/views/jobseekers/job_applications/build/personal_statement.html.slim
@@ -7,7 +7,8 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = render "caption"
+    - if current_jobseeker.job_applications.not_draft.none?
+      = render "caption"
     h1.govuk-heading-l = t(".heading")
     p.govuk-body = t(".description")
 
@@ -31,5 +32,6 @@
       = f.govuk_submit t("buttons.save_and_continue") do
         = f.govuk_submit t("buttons.save_and_come_back"), secondary: true
 
-  .govuk-grid-column-one-third
-    = render "steps"
+  - if current_jobseeker.job_applications.not_draft.none?
+    .govuk-grid-column-one-third
+      = render "steps"

--- a/app/views/jobseekers/job_applications/build/professional_status.html.slim
+++ b/app/views/jobseekers/job_applications/build/professional_status.html.slim
@@ -7,7 +7,8 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = render "caption"
+    - if current_jobseeker.job_applications.not_draft.none?
+      = render "caption"
     h1.govuk-heading-l = t(".heading")
 
     = form_for form, url: wizard_path, method: :patch do |f|
@@ -27,5 +28,6 @@
       = f.govuk_submit t("buttons.save_and_continue") do
         = f.govuk_submit t("buttons.save_and_come_back"), secondary: true
 
-  .govuk-grid-column-one-third
-    = render "steps"
+  - if current_jobseeker.job_applications.not_draft.none?
+    .govuk-grid-column-one-third
+      = render "steps"

--- a/app/views/jobseekers/job_applications/review.html.slim
+++ b/app/views/jobseekers/job_applications/review.html.slim
@@ -39,3 +39,11 @@
       - if vacancy.listed?
         = f.govuk_submit t("buttons.submit_application") do
           = f.govuk_submit t("buttons.save_and_come_back"), secondary: true
+
+  - if current_jobseeker.job_applications.not_draft.none?
+    .govuk-grid-column-one-third
+      = render StepsComponent.new title: "Application Steps", classes: "govuk-!-margin-top-6" do |component|
+        - steps = %w[personal_details professional_status employment_history personal_statement references equal_opportunities ask_for_support declarations]
+        - steps.each do |step|
+          - component.step(label: t("jobseekers.job_applications.build.#{step}.step_title"), current: false, completed: step.in?(job_application.completed_steps))
+        - component.step(label: t("jobseekers.job_applications.review.heading"), current: action_name == "review", completed: false)


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-2037

## Changes in this PR
- Once a jobseeker has a non-draft job application, they shouldn't see the caption and steps because the process will no longer be a linear journey
- Add review step to job application steps 
- Add steps to review page