### PR TITLE
[TEVA-2149] remove meta title tag

### DIFF
--- a/app/views/shared/_meta.html.slim
+++ b/app/views/shared/_meta.html.slim
@@ -1,3 +1,2 @@
-meta name="title" content=(content_for :page_title_prefix).strip
 meta name="description" content=meta_description
 meta name="keywords" content=meta_keywords


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-2149

remove meta title as its deemed uneccessary duplication (title already exists) and causes a lot of noise in SEO reporting tools
