### PR TITLE
[teva-2374] Incrase memory on web app memory

### DIFF
--- a/terraform/workspace-variables/production.tfvars
+++ b/terraform/workspace-variables/production.tfvars
@@ -34,6 +34,7 @@ paas_web_app_instances                 = 4
 paas_worker_app_deployment_strategy    = "blue-green-v2"
 paas_worker_app_instances              = 2
 paas_worker_app_memory                 = 1536
+paas_web_app_memory                    = 1536
 
 # StatusCake
 


### PR DESCRIPTION
Observed crashes on web app instance memory reaching over 90%, which caused the application to crash.
As result, there is the need to increase the web app instance memory to mimic that of the worker app

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2073

## Changes in this PR:

override default value in variable.tf with `paas_web_app_memory = 1536` in production.tfvars


