### PR TITLE
Use a boolean field for "Apply through TV"

### DIFF
--- a/app/components/publishers/vacancies_component.rb
+++ b/app/components/publishers/vacancies_component.rb
@@ -43,7 +43,7 @@ class Publishers::VacanciesComponent < ViewComponent::Base
   end
 
   def view_applicants(vacancy, card)
-    return unless vacancy.apply_through_teaching_vacancies == "yes"
+    return unless vacancy.enable_job_applications?
     return unless include_job_applications?
 
     if vacancy.job_applications.any?

--- a/app/controllers/concerns/publishers/wizardable.rb
+++ b/app/controllers/concerns/publishers/wizardable.rb
@@ -102,7 +102,7 @@ module Publishers::Wizardable
 
   def applying_for_the_job_params(params)
     params.require(:publishers_job_listing_applying_for_the_job_form)
-          .permit(:state, :application_link, :apply_through_teaching_vacancies, :contact_email, :contact_number, :personal_statement_guidance, :school_visits, :how_to_apply)
+          .permit(:state, :application_link, :enable_job_applications, :contact_email, :contact_number, :personal_statement_guidance, :school_visits, :how_to_apply)
           .merge(completed_step: steps_config[step][:number])
   end
 

--- a/app/form_models/publishers/job_listing/applying_for_the_job_form.rb
+++ b/app/form_models/publishers/job_listing/applying_for_the_job_form.rb
@@ -1,7 +1,7 @@
 class Publishers::JobListing::ApplyingForTheJobForm < Publishers::JobListing::VacancyForm
   validates :application_link, url: true, if: :application_link?
 
-  validates :apply_through_teaching_vacancies, inclusion: { in: %w[yes no] }, if: -> { JobseekerApplicationsFeature.enabled? }
+  validates :enable_job_applications, inclusion: { in: [true, false] }, if: -> { JobseekerApplicationsFeature.enabled? }
 
   validates :contact_email, presence: true
   validates :contact_email, format: { with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i }, if: :contact_email?

--- a/app/views/jobseekers/saved_jobs/index.html.slim
+++ b/app/views/jobseekers/saved_jobs/index.html.slim
@@ -36,7 +36,7 @@
                 = tag.div(card.labelled_item(t(".application_deadline"), OrganisationVacancyPresenter.new(saved_job.vacancy).application_deadline))
 
               - card.actions do
-                = tag.div(govuk_link_to(t(".apply"), new_jobseekers_job_job_application_path(saved_job.vacancy.id))) if JobseekerApplicationsFeature.enabled? && saved_job.vacancy.apply_through_teaching_vacancies == "yes" && Vacancy.live.exists?(saved_job.vacancy.id)
+                = tag.div(govuk_link_to(t(".apply"), new_jobseekers_job_job_application_path(saved_job.vacancy.id))) if JobseekerApplicationsFeature.enabled? && saved_job.vacancy.enable_job_applications? && Vacancy.live.exists?(saved_job.vacancy.id)
                 = tag.div(button_to(t(".delete"), jobseekers_saved_job_path(saved_job.vacancy.id, saved_job, redirect_to_dashboard: true), method: :delete, class: "govuk-delete-link"))
         - else
           = render EmptySectionComponent.new title: t(".zero_saved_jobs_title") do

--- a/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
+++ b/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
@@ -16,11 +16,11 @@
         = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f
 
         - if JobseekerApplicationsFeature.enabled?
-          = f.govuk_radio_buttons_fieldset :apply_through_teaching_vacancies do
-            = f.govuk_radio_button :apply_through_teaching_vacancies, :yes, link_errors: true do
+          = f.govuk_radio_buttons_fieldset :enable_job_applications do
+            = f.govuk_radio_button :enable_job_applications, true, link_errors: true do
               = f.govuk_text_area :personal_statement_guidance, label: { size: "s" }
 
-            = f.govuk_radio_button :apply_through_teaching_vacancies, :no do
+            = f.govuk_radio_button :enable_job_applications, "false" do
               = f.govuk_url_field :application_link, label: { size: "s" }, form_group: { classes: "optional-field" }
 
         = f.govuk_email_field :contact_email, label: { size: "s" }, required: true, width: "two-thirds"

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_applying_for_the_job.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_applying_for_the_job.html.slim
@@ -10,15 +10,15 @@
     = govuk_summary_list do |component|
       - if JobseekerApplicationsFeature.enabled?
         - component.slot(:row,
-          key: t("jobs.apply_through_teaching_vacancies"),
-          value: @vacancy.apply_through_teaching_vacancies&.capitalize)
+          key: t("jobs.enable_job_applications"),
+          value: @vacancy.enable_job_applications? ? "Yes" : "No")
 
-        - if @vacancy.apply_through_teaching_vacancies == "yes"
+        - if @vacancy.enable_job_applications?
           - component.slot(:row,
             key: t("jobs.personal_statement_guidance"),
             value: @vacancy.personal_statement_guidance)
 
-        - if @vacancy.apply_through_teaching_vacancies == "no"
+        - elsif @vacancy.enable_job_applications == false # as opposed to nil
           - component.slot(:row,
             key: t("jobs.application_link"),
             value: @vacancy.application_link.present? ? govuk_link_to(@vacancy.application_link, @vacancy.application_link, "aria-label": t("jobs.aria_labels.apply_link"), target: "_blank", rel: "noopener noreferrer") : t("jobs.not_defined"))

--- a/app/views/shared/vacancy/_jobseeker_view.html.slim
+++ b/app/views/shared/vacancy/_jobseeker_view.html.slim
@@ -14,7 +14,7 @@
       = vacancy_job_location(@vacancy)
 
     .govuk-grid-row
-      - if JobseekerApplicationsFeature.enabled? && @vacancy.apply_through_teaching_vacancies == "yes" && @vacancy.expires_at.future?
+      - if JobseekerApplicationsFeature.enabled? && @vacancy.enable_job_applications? && @vacancy.expires_at.future?
         .govuk-grid-column-one-third
           - if defined?(job_application) && ["withdrawn", nil].exclude?(job_application&.status)
             - if job_application.draft?

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -198,7 +198,7 @@ shared:
     - starts_asap
     - contract_type
     - contract_type_duration
-    - apply_through_teaching_vacancies
+    - enable_job_applications
     - personal_statement_guidance
     - end_listing_reason
     - candidate_hired_from

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -111,7 +111,7 @@ en:
   applying_for_the_job_errors: &applying_for_the_job_errors
     application_link:
       url: Enter a link in the correct format, like http://www.school.ac.uk
-    apply_through_teaching_vacancies:
+    enable_job_applications:
       inclusion: Select how you would like candidates to apply
     contact_email:
       blank: Enter a contact email

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -355,9 +355,9 @@ en:
 
       publishers_job_listing_applying_for_the_job_form:
         application_link: Link to online application
-        apply_through_teaching_vacancies_options:
-          "no": "Use another service or organisation"
-          "yes": "Apply through Teaching Vacancies"
+        enable_job_applications_options:
+          "false": "Use another service or organisation"
+          "true": "Apply through Teaching Vacancies"
         contact_email: Contact email
         contact_number: Contact phone number
         how_to_apply: How to apply
@@ -458,7 +458,7 @@ en:
         reason: Why do you want to unsubscribe from this alert?
 
       publishers_job_listing_applying_for_the_job_form:
-        apply_through_teaching_vacancies: How would you like candidates to apply?
+        enable_job_applications: How would you like candidates to apply?
       publishers_job_listing_copy_vacancy_form:
         expires_on: Date application is due
         publish_on: Date job will be listed

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -232,11 +232,11 @@ en:
     applying_for_the_job: Applying for the job
     apply: More on how to apply
     application_link: Link to online application
-    apply_through_teaching_vacancies: Apply through Teaching Vacancies
     contact_email: Contact email
     contact_email_subject: '%{job} job enquiry'
     contact_email_body: Regarding the job at %{url}
     contact_number: Contact phone number
+    enable_job_applications: Apply through Teaching Vacancies
     personal_statement_guidance: Personal statement instructions
     school_visits_heading: Arranging a visit to %{school}
     how_to_apply: Application instructions

--- a/db/migrate/20210409094259_change_vacancy_apply_through_field.rb
+++ b/db/migrate/20210409094259_change_vacancy_apply_through_field.rb
@@ -1,0 +1,15 @@
+class ChangeVacancyApplyThroughField < ActiveRecord::Migration[6.1]
+  def up
+    add_column :vacancies, :enable_job_applications, :boolean, null: true
+    Vacancy.where("apply_through_teaching_vacancies = 'yes'").update_all("enable_job_applications = TRUE")
+    Vacancy.where("apply_through_teaching_vacancies = 'no'").update_all("enable_job_applications = FALSE")
+    remove_column :vacancies, :apply_through_teaching_vacancies
+  end
+
+  def down
+    add_column :vacancies, :apply_through_teaching_vacancies, :string
+    Vacancy.where("enable_job_applications = TRUE").update_all("apply_through_teaching_vacancies = 'yes'")
+    Vacancy.where("enable_job_applications = FALSE").update_all("apply_through_teaching_vacancies = 'no'")
+    remove_column :vacancies, :enable_job_applications
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_06_145837) do
+ActiveRecord::Schema.define(version: 2021_04_09_094259) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -357,10 +357,10 @@ ActiveRecord::Schema.define(version: 2021_04_06_145837) do
     t.boolean "starts_asap", default: false
     t.integer "contract_type"
     t.string "contract_type_duration"
-    t.string "apply_through_teaching_vacancies"
     t.text "personal_statement_guidance"
     t.integer "end_listing_reason"
     t.integer "candidate_hired_from"
+    t.boolean "enable_job_applications"
     t.index ["expires_at"], name: "index_vacancies_on_expires_at"
     t.index ["expires_on"], name: "index_vacancies_on_expires_on"
     t.index ["initially_indexed"], name: "index_vacancies_on_initially_indexed"

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     job_location { "at_one_school" }
     about_school { Faker::Lorem.paragraph(sentence_count: 4) }
     application_link { Faker::Internet.url(host: "example.com") }
-    apply_through_teaching_vacancies { "yes" }
+    enable_job_applications { true }
     benefits { Faker::Lorem.paragraph(sentence_count: 4) }
     contact_email { Faker::Internet.email }
     contact_number { "01234 123456" }

--- a/spec/form_models/publishers/job_listing/applying_for_the_job_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/applying_for_the_job_form_spec.rb
@@ -16,6 +16,6 @@ RSpec.describe Publishers::JobListing::ApplyingForTheJobForm, type: :model do
   context "when JobseekerApplicationsFeature is enabled" do
     before { allow(JobseekerApplicationsFeature).to receive(:enabled?).and_return(true) }
 
-    it { is_expected.to validate_inclusion_of(:apply_through_teaching_vacancies).in_array(%w[yes no]) }
+    it { is_expected.to validate_inclusion_of(:enable_job_applications).in_array([true, false]) }
   end
 end

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -75,7 +75,7 @@ module VacancyHelpers
 
   def fill_in_applying_for_the_job_form_fields(vacancy)
     if JobseekerApplicationsFeature.enabled?
-      choose I18n.t("helpers.label.publishers_job_listing_applying_for_the_job_form.apply_through_teaching_vacancies_options.#{vacancy.apply_through_teaching_vacancies}")
+      choose I18n.t("helpers.label.publishers_job_listing_applying_for_the_job_form.enable_job_applications_options.#{vacancy.enable_job_applications}")
       fill_in "publishers_job_listing_applying_for_the_job_form[personal_statement_guidance]", with: vacancy.personal_statement_guidance
     end
     fill_in "publishers_job_listing_applying_for_the_job_form[contact_email]", with: vacancy.contact_email

--- a/spec/system/jobseekers_can_manage_their_saved_jobs_spec.rb
+++ b/spec/system/jobseekers_can_manage_their_saved_jobs_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe "Jobseekers can manage their saved jobs" do
   let(:jobseeker) { create(:jobseeker) }
   let(:organisation) { create(:school) }
 
-  let(:vacancy1) { create(:vacancy, apply_through_teaching_vacancies: "no", organisation_vacancies_attributes: [{ organisation: organisation }]) }
-  let(:vacancy2) { create(:vacancy, apply_through_teaching_vacancies: "yes", organisation_vacancies_attributes: [{ organisation: organisation }]) }
+  let(:vacancy1) { create(:vacancy, enable_job_applications: false, organisation_vacancies_attributes: [{ organisation: organisation }]) }
+  let(:vacancy2) { create(:vacancy, enable_job_applications: true, organisation_vacancies_attributes: [{ organisation: organisation }]) }
   let(:expired_vacancy) { create(:vacancy, :expired, organisation_vacancies_attributes: [{ organisation: organisation }]) }
 
   let(:saved_jobs_page) { PageObjects::Jobseekers::SavedJobs::Index.new }


### PR DESCRIPTION
This makes more sense as a boolean field (for SQL values of "boolean",
i.e. true/false/NULL).

- Add `enable_job_applications` boolean field (to be more agnostic of
  our service name) and migrate existing data
- Remove old `apply_through_teaching_vacancies` field and change all
  usages