### PR TITLE
Prohibit changing enable_job_applications once listed

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -60,6 +60,7 @@ class Vacancy < ApplicationRecord
   paginates_per 10
 
   validates :slug, presence: true
+  validate :enable_job_applications_cannot_be_changed_once_listed
 
   before_save :on_expired_vacancy_feedback_submitted_update_stats_updated_at
 
@@ -125,5 +126,11 @@ class Vacancy < ApplicationRecord
     return unless listed_elsewhere_changed? && hired_status_changed?
 
     self.stats_updated_at = Time.current
+  end
+
+  def enable_job_applications_cannot_be_changed_once_listed
+    return unless persisted? && listed? && enable_job_applications_changed?
+
+    errors.add(:enable_job_applications, :cannot_be_changed_once_listed)
   end
 end

--- a/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
+++ b/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
@@ -16,12 +16,19 @@
         = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f
 
         - if JobseekerApplicationsFeature.enabled?
-          = f.govuk_radio_buttons_fieldset :enable_job_applications do
-            = f.govuk_radio_button :enable_job_applications, true, link_errors: true do
-              = f.govuk_text_area :personal_statement_guidance, label: { size: "s" }
+          - if @vacancy.listed?
+            = f.hidden_field :enable_job_applications
+            - if @vacancy.enable_job_applications?
+                = f.govuk_text_area :personal_statement_guidance, label: { size: "s" }
+            - else
+                = f.govuk_url_field :application_link, label: { size: "s" }, form_group: { classes: "optional-field" }
+          - else
+            = f.govuk_radio_buttons_fieldset :enable_job_applications do
+              = f.govuk_radio_button :enable_job_applications, true, link_errors: true do
+                = f.govuk_text_area :personal_statement_guidance, label: { size: "s" }
 
-            = f.govuk_radio_button :enable_job_applications, "false" do
-              = f.govuk_url_field :application_link, label: { size: "s" }, form_group: { classes: "optional-field" }
+              = f.govuk_radio_button :enable_job_applications, "false" do
+                = f.govuk_url_field :application_link, label: { size: "s" }, form_group: { classes: "optional-field" }
 
         = f.govuk_email_field :contact_email, label: { size: "s" }, required: true, width: "two-thirds"
 

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -112,6 +112,7 @@ en:
     application_link:
       url: Enter a link in the correct format, like http://www.school.ac.uk
     enable_job_applications:
+      cannot_be_changed_once_listed: You cannot change how you would like candidates to apply now that your listing is published
       inclusion: Select how you would like candidates to apply
     contact_email:
       blank: Enter a contact email

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -350,4 +350,35 @@ RSpec.describe Vacancy do
       end
     end
   end
+
+  describe "validations" do
+    describe "changing enable_job_applications" do
+      subject { build_stubbed(:vacancy, status, enable_job_applications: true) }
+
+      before do
+        subject.enable_job_applications = false
+      end
+
+      context "when already listed" do
+        let(:status) { :published }
+
+        it "fails validation" do
+          expect(subject).not_to be_valid
+          expect(subject.errors).to include(:enable_job_applications)
+        end
+      end
+
+      context "when draft" do
+        let(:status) { :draft }
+
+        it { is_expected.to be_valid }
+      end
+
+      context "when scheduled" do
+        let(:status) { :draft }
+
+        it { is_expected.to be_valid }
+      end
+    end
+  end
 end


### PR DESCRIPTION
To save ourselves several headaches, we've decided that for MAP we will
not allow publishers to change whether or not a vacancy can be applied
for through TV after it has gone live.

- Change "Applying for the job" step to not show the radio button with
  collapsible subfields when the vacancy is listed, and instead just
  show the subfields relevant to the original selection
- Add validation to ensure `enable_job_applications` cannot be changed
  when vacancy state is listed (e.g. by a user manipulating the hidden
  field)

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2368