### PR TITLE
remove semantically incorrect aside tag

### DIFF
--- a/app/views/vacancies/_filters.html.slim
+++ b/app/views/vacancies/_filters.html.slim
@@ -44,8 +44,7 @@ ruby:
     = f.hidden_field :jobs_sort, value: @jobs_search_form.jobs_sort
     = f.govuk_submit t("buttons.search"), classes: "govuk-button govuk-!-margin-bottom-0 govuk-!-width-full"
 
-  aside
-    = render(FiltersComponent.new(form: f,
-      filters: { total_count: @jobs_search_form.total_filters, title: "Filter results" },
-      items: items,
-      options: { remove_buttons: true, mobile_variant: true, close_all: true }))
+  = render(FiltersComponent.new(form: f,
+    filters: { total_count: @jobs_search_form.total_filters, title: "Filter results" },
+    items: items,
+    options: { remove_buttons: true, mobile_variant: true, close_all: true }))


### PR DESCRIPTION
no ticket - slipped through when i resolved rebase conflict incorrectly. part of the a11y work

the reason this is a problem is that the tags header, main, footer, aside (maybe one or two more) should be direct children of the body element. this is their intended use as per the HTML specification. To use the aside tag correctly it would mean bringing it into application.html template. this would require significant refactoring and i deem that out of scope for the value it would bring/effort involved in the immediate future