### PR TITLE
add margin space to header logo

### DIFF
--- a/app/frontend/src/styles/application.scss
+++ b/app/frontend/src/styles/application.scss
@@ -68,6 +68,10 @@ body {
       border-bottom: govuk-spacing(2) solid govuk-colour('orange');
     }
 
+    .govuk-header__logotype-text {
+      margin-left: govuk-spacing(1);
+    }
+
     .govuk-phase-banner {
       background-color: govuk-colour('white');
       border: 0;


### PR DESCRIPTION
no ticket - i noticed the header logo/text are a little too close for comfort

teacher vacancies as exists now
![Screenshot 2021-04-11 at 12 20 01](https://user-images.githubusercontent.com/1792451/114302463-0cdb5b00-9ac1-11eb-8199-1042e922ec12.png)

other gov page
![Screenshot 2021-04-11 at 12 23 43](https://user-images.githubusercontent.com/1792451/114302494-385e4580-9ac1-11eb-8cda-fc61e747cc68.png)

updated teacher vacancies
![Screenshot 2021-04-11 at 12 23 30](https://user-images.githubusercontent.com/1792451/114302477-2086c180-9ac1-11eb-8d11-46573bd5f808.png)




