### PR TITLE
[teva-2087] Block destroy.yml workflow until deploy_app.yml completes

### DIFF
--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -39,7 +39,7 @@ jobs:
       id: set_env_vars
       run: |
         BRANCH=$(echo ${GITHUB_REF#refs/heads/})
-        TAG=${BRANCH}-${{ github.sha }}-$(date '+%Y%m%d%H%M%S')
+        TAG=${BRANCH}-${{ github.sha }}
         echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
         echo "TAG=${TAG}" >> $GITHUB_ENV
 

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -4,7 +4,7 @@ on:
 
   pull_request:
     branches: [ master ]
-    types: [closed]
+    types: [synchronize]
 
 env:
   DOCKERHUB_REPOSITORY: dfedigital/teaching-vacancies
@@ -91,7 +91,7 @@ jobs:
       run: |
         export TF_VAR_environment=${{env.ENVIRONMENT}}
         terraform init -reconfigure -input=false -backend-config="key=review/review-pr-${{ github.event.number }}.tfstate"
-        terraform destroy -var-file ../workspace-variables/review.tfvars -auto-approve
+
       working-directory: terraform/app
 
     - name: Send failure message to twd_tv_dev channel

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -1,6 +1,7 @@
 name: Destroy
 
 on:
+
   pull_request:
     branches: [ master ]
     types: [closed]
@@ -21,11 +22,32 @@ jobs:
         same-branch-only: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   deploy:
     name: Destroy review app
     needs: turnstyle
     runs-on: ubuntu-20.04
+
     steps:
+
+    - name: set environment variable
+      run: |
+        ENVIRONMENT=review-pr-${{ github.event.number }}
+        TAG=${ENVIRONMENT}-${{ github.sha }}
+        echo "ENVIRONMENT=${ENVIRONMENT}" >> $GITHUB_ENV
+        echo "TAG=${TAG}" >> $GITHUB_ENV
+
+    - name: Wait for Deploy App Workflow for review
+      id: wait_for_deploy_app
+      uses: fountainhead/action-wait-for-check@v1.0.0
+      with:
+       token: ${{ secrets.PERSONAL_TOKEN }}
+       #checkName: Deploy ${{ env.TAG }} to ${{ env.ENVIRONMENT }} # Job name within workflow
+       checkName: Create review app ${{ github.sha}}
+       ref: ${{ github.event.pull_request.head.sha }}
+       timeoutSeconds: 720
+       intervalSeconds: 15
+
     - uses: actions/checkout@v2
       name: Checkout Code
 
@@ -67,7 +89,7 @@ jobs:
         TF_VAR_paas_user: ${{ secrets.CF_USERNAME }}
         TF_VAR_paas_password: ${{ secrets.CF_PASSWORD }}
       run: |
-        export TF_VAR_environment=review-pr-${{ github.event.number }}
+        export TF_VAR_environment=${{env.ENVIRONMENT}}
         terraform init -reconfigure -input=false -backend-config="key=review/review-pr-${{ github.event.number }}.tfstate"
         terraform destroy -var-file ../workspace-variables/review.tfvars -auto-approve
       working-directory: terraform/app

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -4,7 +4,7 @@ on:
 
   pull_request:
     branches: [ master ]
-    types: [synchronize]
+    types: [closed]
 
 env:
   DOCKERHUB_REPOSITORY: dfedigital/teaching-vacancies
@@ -43,7 +43,7 @@ jobs:
       with:
        token: ${{ secrets.PERSONAL_TOKEN }}
        #checkName: Deploy ${{ env.TAG }} to ${{ env.ENVIRONMENT }} # Job name within workflow
-       checkName: Create review app ${{ github.sha}}
+       checkName: Create review app ${{ github.event.pull_request.head.sha}}
        ref: ${{ github.event.pull_request.head.sha }}
        timeoutSeconds: 720
        intervalSeconds: 15

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -27,7 +27,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   deploy:
-    name: Create review app
+    name: Create review app ${{ github.sha}}
     needs: turnstyle
     runs-on: ubuntu-20.04
     steps:
@@ -67,7 +67,7 @@ jobs:
       run: |
         $(echo "BRANCH=${{ github.head_ref }}" | sed -e 's/\//_/g' >> $GITHUB_ENV)
         ENVIRONMENT=review-pr-${{ github.event.number }}
-        TAG=${ENVIRONMENT}-${{ github.sha }}-$(date '+%Y%m%d%H%M%S')
+        TAG=${ENVIRONMENT}-${{ github.sha }}
         echo "ENVIRONMENT=${ENVIRONMENT}" >> $GITHUB_ENV
         echo "TAG=${TAG}" >> $GITHUB_ENV
 


### PR DESCRIPTION
When a PR is closed soon after it has been created, it leads to a race condition between destroy.yml and deploy_app.yml.
destroy.yml is likely to complete first, but runs against non-existent infrastructure because it is still being spun up.
By the time deploy_app.yml spins up the infrastructure, there is no automated way of destroying the infrastructure subsequently.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2087

## Changes in this PR:

When a PR is closed soon after it has been created, it leads to a race condition between destroy.yml and deploy_app.yml.  
destroy.yml is likely to complete first, but runs against non-existent infrastructure because it is still being spun up.  
By the time deploy_app.yml spins up the infrastructure, there is no automated way of destroying the infrastructure subsequently.
