### PR TITLE
Add type predicates to organisation

### DIFF
--- a/app/components/publishers/school_overview_component.rb
+++ b/app/components/publishers/school_overview_component.rb
@@ -6,6 +6,6 @@ class Publishers::SchoolOverviewComponent < ViewComponent::Base
   end
 
   def render?
-    @organisation.is_a?(School)
+    @organisation.school?
   end
 end

--- a/app/components/publishers/vacancies_component.rb
+++ b/app/components/publishers/vacancies_component.rb
@@ -10,7 +10,7 @@ class Publishers::VacanciesComponent < ViewComponent::Base
     @vacancy_types = %w[published expired pending draft awaiting_feedback]
     @selected_type = @vacancy_types.include?(selected_type) ? selected_type : "published"
 
-    set_organisation_options if @organisation.is_a?(SchoolGroup)
+    set_organisation_options if @organisation.school_group?
     set_vacancies
   end
 
@@ -31,7 +31,7 @@ class Publishers::VacanciesComponent < ViewComponent::Base
   end
 
   def grid_column_class
-    organisation.is_a?(SchoolGroup) ? "govuk-grid-column-two-thirds" : "govuk-grid-column-full"
+    organisation.school_group? ? "govuk-grid-column-two-thirds" : "govuk-grid-column-full"
   end
 
   def vacancy_type_tab_link(vacancy_type, selected)

--- a/app/components/publishers/vacancies_component/vacancies_component.html.slim
+++ b/app/components/publishers/vacancies_component/vacancies_component.html.slim
@@ -8,7 +8,7 @@
 
     .govuk-grid-row
       .moj-filter-sidebar class="govuk-!-margin-bottom-5"
-        - if @organisation.is_a?(SchoolGroup)
+        - if @organisation.school_group?
           .govuk-grid-column-one-third
             = form_for @publisher_preference, html: { data: { "auto-submit": true, "hide-submit": true } } do |f|
               = render(FiltersComponent.new(filters: { total_count: @publisher_preference.organisations.count,
@@ -27,7 +27,7 @@
                                                                          small: true }],
                                                                options: { remove_buttons: true,
                                                                           mobile_variant: true,
-                                                                          publisher_preference: (@publisher_preference if @organisation.local_authority_code?) }))
+                                                                          publisher_preference: (@publisher_preference if @organisation.local_authority?) }))
 
               = f.hidden_field :jobs_type, value: @selected_type
 
@@ -52,7 +52,7 @@
               = render Shared::CardComponent.new(html_attributes: { id: dom_id(vacancy) }) do |card|
                 - card.header do
                   = tag.div(govuk_link_to(vacancy.job_title, organisation_job_path(vacancy.id)))
-                  - if organisation.is_a?(SchoolGroup)
+                  - if organisation.school_group?
                     = tag.div(vacancy.readable_job_location)
 
                 - card.body do

--- a/app/components/shared/navbar_component/navbar_component.html.slim
+++ b/app/components/shared/navbar_component/navbar_component.html.slim
@@ -3,7 +3,7 @@ nav.navbar-component role="navigation"
     - if publisher_signed_in?
       li class=active_link_class(organisation_path)
         = link_to t("nav.school_page_link"), organisation_path, class: "govuk-header__link"
-      - if current_organisation.is_a?(SchoolGroup)
+      - if current_organisation.school_group?
         li class=active_link_class(organisation_schools_path)
           = link_to t("nav.school_group_index_link", organisation_type: organisation_type_basic(current_organisation)), organisation_schools_path, class: "govuk-header__link"
       li class=active_link_class(root_path)

--- a/app/controllers/publishers/omniauth_callbacks_controller.rb
+++ b/app/controllers/publishers/omniauth_callbacks_controller.rb
@@ -69,7 +69,7 @@ class Publishers::OmniauthCallbacksController < Devise::OmniauthCallbacksControl
   end
 
   def use_school_group_if_available(publisher, organisation)
-    return unless organisation.is_a?(School)
+    return unless organisation.school?
 
     publisher_organisation = publisher.organisations.school_groups.find { |school_group| school_group.schools.include?(organisation) }
     session.update(publisher_organisation_id: publisher_organisation.id) if publisher_organisation

--- a/app/controllers/publishers/organisations/schools_controller.rb
+++ b/app/controllers/publishers/organisations/schools_controller.rb
@@ -22,8 +22,8 @@ class Publishers::Organisations::SchoolsController < Publishers::BaseController
   private
 
   def set_organisation
-    @organisation = if current_organisation.is_a?(School) ||
-                       (current_organisation.is_a?(SchoolGroup) && current_organisation.id == params[:id])
+    @organisation = if current_organisation.school? ||
+                       (current_organisation.school_group? && current_organisation.id == params[:id])
                       current_organisation
                     else
                       current_organisation.schools.find(params[:id])
@@ -31,7 +31,7 @@ class Publishers::Organisations::SchoolsController < Publishers::BaseController
   end
 
   def set_redirect_path
-    @redirect_path = current_organisation.is_a?(School) ? organisation_path : organisation_schools_path
+    @redirect_path = current_organisation.school? ? organisation_path : organisation_schools_path
   end
 
   def organisation_params

--- a/app/controllers/publishers/organisations_controller.rb
+++ b/app/controllers/publishers/organisations_controller.rb
@@ -16,7 +16,7 @@ class Publishers::OrganisationsController < Publishers::BaseController
   private
 
   def show_publisher_preferences
-    return unless current_organisation.local_authority_code?
+    return unless current_organisation.local_authority?
     return if PublisherPreference.find_by(publisher: current_publisher, organisation: current_organisation)
 
     redirect_to new_publisher_preference_path

--- a/app/controllers/publishers/vacancies/base_controller.rb
+++ b/app/controllers/publishers/vacancies/base_controller.rb
@@ -4,7 +4,7 @@ class Publishers::Vacancies::BaseController < Publishers::BaseController
   helper_method :process_steps, :step_current, :steps_adjust
 
   def steps_adjust
-    current_organisation.is_a?(SchoolGroup) ? 0 : 1
+    current_organisation.school_group? ? 0 : 1
   end
 
   def step_current

--- a/app/controllers/publishers/vacancies/build_controller.rb
+++ b/app/controllers/publishers/vacancies/build_controller.rb
@@ -19,10 +19,10 @@ class Publishers::Vacancies::BuildController < Publishers::Vacancies::BaseContro
   def show
     case step
     when :job_location
-      skip_step if current_organisation.is_a?(School)
+      skip_step if current_organisation.school?
     when :schools
       job_location = session[:job_location].presence || @vacancy.job_location
-      skip_step if current_organisation.is_a?(School) || job_location == "central_office"
+      skip_step if current_organisation.school? || job_location == "central_office"
     when :job_details
       @job_details_back_path = @vacancy.central_office? ? wizard_path(:job_location) : wizard_path(:schools)
     when :documents
@@ -77,16 +77,16 @@ class Publishers::Vacancies::BuildController < Publishers::Vacancies::BaseContro
   end
 
   def set_multiple_schools
-    return unless step == :schools && current_organisation.is_a?(SchoolGroup)
+    return unless step == :schools && current_organisation.school_group?
 
     job_location = session[:job_location].presence || @vacancy.job_location
     @multiple_schools = job_location == "at_multiple_schools"
   end
 
   def set_school_options
-    return unless step == :schools && current_organisation.is_a?(SchoolGroup)
+    return unless step == :schools && current_organisation.school_group?
 
-    schools = current_organisation.local_authority_code? ? current_publisher_preference.schools : current_organisation.schools
+    schools = current_organisation.local_authority? ? current_publisher_preference.schools : current_organisation.schools
     @school_options = schools.not_closed.order(:name).map do |school|
       OpenStruct.new({ id: school.id, name: school.name, address: full_address(school) })
     end

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -19,7 +19,7 @@ module OrganisationHelper
       applying_for_the_job: 6,
       job_summary: 7,
     }
-    section_number = organisation.is_a?(SchoolGroup) ? sections[section] : sections[section] - 1
+    section_number = organisation.school_group? ? sections[section] : sections[section] - 1
     "#{section_number}."
   end
 
@@ -39,7 +39,7 @@ module OrganisationHelper
   end
 
   def organisation_type(organisation)
-    return organisation.group_type if organisation.is_a?(SchoolGroup)
+    return organisation.group_type if organisation.school_group?
 
     school_type_details = [organisation.school_type.singularize, organisation.religious_character]
     school_type_details.reject(&:blank?).reject { |str| str == I18n.t("schools.not_given") }.join(", ")
@@ -54,9 +54,9 @@ module OrganisationHelper
   end
 
   def organisation_type_basic(organisation)
-    if organisation.is_a?(School)
+    if organisation.school?
       "school"
-    elsif organisation.group_type == "local_authority"
+    elsif organisation.local_authority?
       "local authority"
     else
       "trust"
@@ -64,10 +64,10 @@ module OrganisationHelper
   end
 
   def school_or_trust_visits(organisation)
-    if organisation.group_type == "local_authority" || organisation.is_a?(School)
-      "school_visits"
-    else
+    if organisation.trust?
       "trust_visits"
+    else
+      "school_visits"
     end
   end
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -26,4 +26,20 @@ class Organisation < ApplicationRecord
     school_urns = Rails.configuration.local_authorities_extra_schools&.dig(local_authority_code.to_i)
     School.where(urn: school_urns)
   end
+
+  def school?
+    is_a?(School)
+  end
+
+  def school_group?
+    is_a?(SchoolGroup)
+  end
+
+  def trust?
+    uid.present?
+  end
+
+  def local_authority?
+    local_authority_code.present?
+  end
 end

--- a/app/services/publishers/vacancy_sort.rb
+++ b/app/services/publishers/vacancy_sort.rb
@@ -10,7 +10,7 @@ class Publishers::VacancySort < RecordSort
 
   def options
     base_options.tap do |options|
-      options << readable_job_location_option if @organisation.is_a?(SchoolGroup)
+      options << readable_job_location_option if @organisation.school_group?
     end
   end
 

--- a/app/views/publishers/organisations/_vacancies_awaiting_feedback.html.slim
+++ b/app/views/publishers/organisations/_vacancies_awaiting_feedback.html.slim
@@ -10,7 +10,7 @@ div class="govuk-!-margin-bottom-4"
         .card-component__content
           dt.card-component__header
             div = govuk_link_to(vacancy.job_title, organisation_job_path(vacancy.id))
-            - if organisation.is_a?(SchoolGroup)
+            - if organisation.school_group?
               div = vacancy.readable_job_location
           dd.card-component__body
             div

--- a/app/views/publishers/sign_in/email/sessions/choose_organisation.html.slim
+++ b/app/views/publishers/sign_in/email/sessions/choose_organisation.html.slim
@@ -12,7 +12,7 @@
 
         - @publisher.organisations.each do |organisation|
           p
-            - if organisation.is_a?(School)
+            - if organisation.school?
               = govuk_link_to(location(organisation), auth_email_create_session_path(organisation_id: organisation.id))
             - else
               = govuk_link_to(organisation.name, auth_email_create_session_path(organisation_id: organisation.id))

--- a/app/views/publishers/vacancies/build/job_details.html.slim
+++ b/app/views/publishers/vacancies/build/job_details.html.slim
@@ -4,7 +4,7 @@
   .govuk-grid-row
     .govuk-grid-column-full
       = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy, process_steps.current_step_number, process_steps.total_steps)
-      = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: @job_details_back_path, current_step_is_first_step: current_organisation.is_a?(School))
+      = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: @job_details_back_path, current_step_is_first_step: current_organisation.school?)
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/publishers/vacancies/build/schools.html.slim
+++ b/app/views/publishers/vacancies/build/schools.html.slim
@@ -16,7 +16,7 @@
         = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f
 
         = f.govuk_fieldset legend: { text: t("helpers.legend.publishers_job_listing_schools_form.organisation_id#{'s' if @multiple_schools}") } do
-          - if current_organisation.local_authority_code?
+          - if current_organisation.local_authority?
             span.govuk-hint = t("helpers.hint.publishers_job_listing_schools_form.edit_schools")
             span.govuk-hint = govuk_link_to t("helpers.hint.publishers_job_listing_schools_form.add_school"),
                                             edit_publisher_preference_path(current_publisher_preference), class: "govuk-link--no-visited-state"

--- a/app/views/publishers/vacancies/edit.html.slim
+++ b/app/views/publishers/vacancies/edit.html.slim
@@ -11,7 +11,7 @@
       = render "publishers/vacancies/error_messages", errors: @vacancy.errors
 
       ol.app-task-list
-        - if current_organisation.is_a?(SchoolGroup)
+        - if current_organisation.school_group?
           li = render "publishers/vacancies/edit_vacancy_sections/edit_job_location"
         li = render "publishers/vacancies/edit_vacancy_sections/edit_job_details"
         li = render "publishers/vacancies/edit_vacancy_sections/edit_pay_package"

--- a/app/views/publishers/vacancies/job_applications.html.slim
+++ b/app/views/publishers/vacancies/job_applications.html.slim
@@ -7,7 +7,7 @@
     = govuk_breadcrumbs breadcrumbs: { "#{t("publishers.vacancies_component.published.tab_heading")}": organisation_path, "#{@vacancy.job_title}": organisation_job_job_applications_path(@vacancy.id) }
   .govuk-grid-row
     .govuk-grid-column-full.application-header
-      - if current_organisation.is_a?(SchoolGroup)
+      - if current_organisation.school_group?
         h2.govuk-caption-l = current_organisation.name
         h1.govuk-heading-l
           span.govuk-heading-l class="govuk-!-font-weight-regular" = t(".heading")

--- a/app/views/publishers/vacancies/review.html.slim
+++ b/app/views/publishers/vacancies/review.html.slim
@@ -17,7 +17,7 @@
           = t("jobs.review_future")
 
       ol.app-task-list
-        - if current_organisation.is_a?(SchoolGroup)
+        - if current_organisation.school_group?
           li = render "publishers/vacancies/edit_vacancy_sections/edit_job_location"
 
         li = render "publishers/vacancies/edit_vacancy_sections/edit_job_details"

--- a/spec/components/shared/process_steps_component_spec.rb
+++ b/spec/components/shared/process_steps_component_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Shared::ProcessStepsComponent, type: :component do
     }.freeze
   end
 
-  let(:steps_adjust) { current_organisation.is_a?(SchoolGroup) ? 0 : 1 }
+  let(:steps_adjust) { current_organisation.school_group? ? 0 : 1 }
 
   before do
     allow_any_instance_of(Publishers::AuthenticationConcerns).to receive(:current_organisation).and_return(current_organisation)

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -103,4 +103,33 @@ RSpec.describe Organisation do
       end
     end
   end
+
+  describe "type predicates" do
+    context "for a school" do
+      subject { build_stubbed(:school) }
+
+      it { is_expected.to be_school }
+      it { is_expected.not_to be_school_group }
+      it { is_expected.not_to be_trust }
+      it { is_expected.not_to be_local_authority }
+    end
+
+    context "for a trust" do
+      subject { build_stubbed(:trust) }
+
+      it { is_expected.not_to be_school }
+      it { is_expected.to be_school_group }
+      it { is_expected.to be_trust }
+      it { is_expected.not_to be_local_authority }
+    end
+
+    context "for a local authority" do
+      subject { build_stubbed(:local_authority) }
+
+      it { is_expected.not_to be_school }
+      it { is_expected.to be_school_group }
+      it { is_expected.not_to be_trust }
+      it { is_expected.to be_local_authority }
+    end
+  end
 end


### PR DESCRIPTION
- Add `#school?`, `#school_group?`, `#trust?` and `#local_authority?`
  predicate methods to `Organisation` so we have an easy way to
  establish what sort of organisation we're dealing with.
- Replace existing tests for organisation class/IDs across the app with
  new predicate methods