### PR TITLE
[TEVA-2379] Add Job application Summary to Publisher Job Application Show View

### DIFF
--- a/app/components/review_component/review_component.scss
+++ b/app/components/review_component/review_component.scss
@@ -1,5 +1,17 @@
 @import 'base_component';
 
+ol {
+  .review-component {
+    .review-component__body {
+      .govuk-summary-list {
+        @include govuk-media-query($until: tablet) {
+          margin-left: -15px;
+        }
+      }
+    }
+  }
+}
+
 .review-component {
   .review-component__heading {
     a {
@@ -26,10 +38,6 @@
 
       margin-bottom: 0;
       margin-top: 0;
-
-      @include govuk-media-query($until: tablet) {
-        margin-left: -15px;
-      }
 
       @include govuk-media-query($from: tablet) {
         border-top: 1px solid $govuk-border-colour;
@@ -63,6 +71,26 @@
 
   @include govuk-media-query($until: desktop) {
     margin-left: govuk-spacing(4);
+  }
+
+  &--no-bullet {
+    list-style-type: none;
+    padding-left: 0;
+  }
+}
+
+.app-page-navigation__item {
+  margin-left: govuk-spacing(5);
+
+  a {
+    display: inline-block;
+  }
+
+  &::before {
+    content: '\2014';
+    height: 100%;
+    margin-left: -25px;
+    padding-right: govuk-spacing(1);
   }
 }
 

--- a/app/views/publishers/vacancies/job_applications/show.html.slim
+++ b/app/views/publishers/vacancies/job_applications/show.html.slim
@@ -25,6 +25,44 @@
         = govuk_link_to t("buttons.reject"), organisation_job_job_application_reject_path(vacancy.id, job_application.id), button: true, class: "govuk-button--warning govuk-!-margin-right-3"
       = govuk_link_to t("buttons.download_application"), "#", button: true, class: "govuk-button--secondary"
 
+    h2.govuk-heading-m = "Application sections"
+
+    ul.govuk-list
+      li.app-page-navigation__item = govuk_link_to t(".personal_details.heading"), "#personal_details_summary", class: "govuk-link govuk-body-s govuk-!-margin-bottom-0"
+      li.app-page-navigation__item = govuk_link_to t(".professional_status.heading"), "#professional_status_summary", class: "govuk-link govuk-body-s govuk-!-margin-bottom-0"
+      li.app-page-navigation__item = govuk_link_to t(".qualifications.heading"), "#qualifications_summary", class: "govuk-link govuk-body-s govuk-!-margin-bottom-0"
+      li.app-page-navigation__item = govuk_link_to t(".current_role_and_employment_history.heading"), "#employment_history_summary", class: "govuk-link govuk-body-s govuk-!-margin-bottom-0"
+      li.app-page-navigation__item = govuk_link_to t(".personal_statement.heading"), "#personal_statement_summary", class: "govuk-link govuk-body-s govuk-!-margin-bottom-0"
+      li.app-page-navigation__item = govuk_link_to t(".references.heading"), "#references_summary", class: "govuk-link govuk-body-s govuk-!-margin-bottom-0"
+      li.app-page-navigation__item = govuk_link_to t(".ask_for_support.heading"), "#ask_for_support_summary", class: "govuk-link govuk-body-s govuk-!-margin-bottom-0"
+      li.app-page-navigation__item = govuk_link_to t(".declarations.heading"), "#declarations_summary", class: "govuk-link govuk-body-s govuk-!-margin-bottom-0"
+
+    - unless job_application.status.in?(%w[shortlisted unsuccessful withdrawn])
+      ul.app-task-list--no-bullet
+        li#personal_details_summary
+          = render "jobseekers/job_applications/review/personal_details", allow_edit: false
+        li#professional_status_summary
+          = render "jobseekers/job_applications/review/professional_status", allow_edit: false
+        li#qualifications_summary
+          = render "jobseekers/job_applications/review/qualifications", allow_edit: true
+        li#employment_history_summary
+          = render "jobseekers/job_applications/review/employment_history", allow_edit: false
+        - if job_application.gaps_in_employment == "yes"
+          li = render NotificationComponent.new variant: "notice",
+              title: "Gaps in employment",
+              body: job_application.gaps_in_employment_details,
+              background: true,
+              icon: true,
+              dismiss: false
+        li#personal_statement_summary
+          = render "jobseekers/job_applications/review/personal_statement", allow_edit: false
+        li#references_summary
+          = render "jobseekers/job_applications/review/references", allow_edit: false
+        li#ask_for_support_summary
+          = render "jobseekers/job_applications/review/ask_for_support", allow_edit: false
+        li#declarations_summary
+          = render "jobseekers/job_applications/review/declarations", allow_edit: false
+
   .govuk-grid-column-one-third
     .account-sidebar
       h2.account-sidebar__heading = t(".timeline")

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -186,7 +186,25 @@ en:
           page_title: Shortlist applicant
         shortlisted: Shortlisted applicants
         show:
+          ask_for_support:
+            heading: Ask for support if you have a disability or other needs
+          current_role_and_employment_history:
+            heading: Current role and employment history
+          declarations:
+            heading: Declarations
+          education_and_qualifications:
+            heading: Education and qualifications
           page_title: Application
+          personal_details:
+            heading: Personal Details
+          personal_statement:
+            heading: Personal statement
+          professional_status:
+            heading: Professional status
+          qualifications:
+            heading: Education and qualifications
+          references:
+            heading: References
           status_heading: Applicant status
           timeline: Timeline
         sort_by:


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2379

## Screenshots of UI changes:

<img width="1288" alt="Screenshot 2021-04-13 at 18 00 51" src="https://user-images.githubusercontent.com/30624173/114592338-b6b61580-9c82-11eb-8396-c5c25f567195.png">

<img width="1353" alt="Screenshot 2021-04-13 at 18 01 02" src="https://user-images.githubusercontent.com/30624173/114592347-ba499c80-9c82-11eb-8833-3e33fcfdc411.png">

<img width="1080" alt="Screenshot 2021-04-13 at 18 02 06" src="https://user-images.githubusercontent.com/30624173/114592358-bd448d00-9c82-11eb-9343-19ea4423bcfb.png">

<img width="1037" alt="Screenshot 2021-04-13 at 18 02 13" src="https://user-images.githubusercontent.com/30624173/114592366-bfa6e700-9c82-11eb-906f-cf9864e9e022.png">


## Comments

- I added a rule to the review component stylesheet to correct the problem below. This was caused when an element with the class of "gov-summary-list" is a child of a unordered list.

## Styling before change

### Unordered List

- As you can see the summary list is not positioned correctly.

<img width="499" alt="Screenshot 2021-04-13 at 18 07 37" src="https://user-images.githubusercontent.com/30624173/114592709-21ffe780-9c83-11eb-91af-893d30a69afd.png">

### Ordered List

<img width="392" alt="Screenshot 2021-04-14 at 10 00 14" src="https://user-images.githubusercontent.com/30624173/114683791-3934e880-9d08-11eb-935f-fa37f9d62cc7.png">

## Styling after change

### Unordered List

<img width="357" alt="Screenshot 2021-04-14 at 10 01 23" src="https://user-images.githubusercontent.com/30624173/114683965-608bb580-9d08-11eb-8b30-b7629fa84b5d.png">

### Ordered List

<img width="354" alt="Screenshot 2021-04-14 at 10 01 56" src="https://user-images.githubusercontent.com/30624173/114684044-74cfb280-9d08-11eb-8390-2d9c9aec5356.png">

