### PR TITLE
[TEVA-1747] Qualifications: Part 2

### DIFF
--- a/app/components/jobseekers/organisation_overviews/schools_component/schools_component.html.slim
+++ b/app/components/jobseekers/organisation_overviews/schools_component/schools_component.html.slim
@@ -52,7 +52,7 @@ section#school-overview class="govuk-!-margin-bottom-5"
 
   - if vacancy.organisations.any?(&:geolocation)
     section#school-location
-      h3.govuk-heading-l.section-heading = t("schools.school_location.many")
+      h3.govuk-heading-l.section-heading = t("schools.school_location.other")
 
       div id="map" role="presentation" aria-hidden="true" aria-label=t("schools.map_aria_label") data-schools=organisation_map_data
       script defer=true src="https://maps.googleapis.com/maps/api/js?key=#{GOOGLE_MAPS_API_KEY}&callback=initMap"

--- a/app/controllers/concerns/qualification_form_concerns.rb
+++ b/app/controllers/concerns/qualification_form_concerns.rb
@@ -1,0 +1,25 @@
+module QualificationFormConcerns
+  extend ActiveSupport::Concern
+
+  def qualification_form_param_key(category)
+    form_class(category).to_s.underscore.tr("/", "_").to_sym
+  end
+
+  def form_class(category)
+    name = if %w[select_category submit_category].include?(action_name)
+             "CategoryForm"
+           else
+             case category
+             when "gcse", "a_level", "as_level"
+               "Secondary::CommonForm"
+             when "other_secondary"
+               "Secondary::OtherForm"
+             when "undergraduate", "postgraduate"
+               "DegreeForm"
+             when "other"
+               "OtherForm"
+             end
+           end
+    "Jobseekers::JobApplication::Details::Qualifications::#{name}".constantize
+  end
+end

--- a/app/controllers/jobseekers/job_applications/build_controller.rb
+++ b/app/controllers/jobseekers/job_applications/build_controller.rb
@@ -1,11 +1,12 @@
 class Jobseekers::JobApplications::BuildController < Jobseekers::BaseController
   include Wicked::Wizard
   include Jobseekers::Wizardable
+  include QualificationFormConcerns
 
   steps :personal_details, :professional_status, :qualifications, :employment_history, :personal_statement, :references,
         :equal_opportunities, :ask_for_support, :declarations
 
-  helper_method :back_path, :form, :job_application, :vacancy
+  helper_method :back_path, :form, :job_application, :qualification_form_param_key, :vacancy
 
   def show
     render_wizard

--- a/app/controllers/jobseekers/job_applications/qualifications_controller.rb
+++ b/app/controllers/jobseekers/job_applications/qualifications_controller.rb
@@ -1,4 +1,6 @@
 class Jobseekers::JobApplications::QualificationsController < Jobseekers::BaseController
+  include QualificationFormConcerns
+
   helper_method :back_path, :category, :form, :job_application, :qualification,
                 :submit_text
 
@@ -29,14 +31,15 @@ class Jobseekers::JobApplications::QualificationsController < Jobseekers::BaseCo
   end
 
   def destroy
-    qualification.destroy
-    redirect_to back_path, success: t(".success")
+    count = qualifications.count
+    qualifications.each(&:destroy)
+    redirect_to back_path, success: t(".success", count: count)
   end
 
   private
 
   def form
-    @form ||= form_class.new(form_attributes)
+    @form ||= form_class(category).new(form_attributes)
   end
 
   def form_attributes
@@ -53,32 +56,13 @@ class Jobseekers::JobApplications::QualificationsController < Jobseekers::BaseCo
   end
 
   def qualification_params
-    form_param_key = form_class.to_s.underscore.tr("/", "_").to_sym
     case action_name
     when "new", "select_category", "submit_category"
-      (params[form_param_key] || params).permit(:category)
+      (params[qualification_form_param_key(category)] || params).permit(:category)
     when "create", "edit", "update"
-      params.require(form_param_key)
+      params.require(qualification_form_param_key(category))
             .permit(:category, :finished_studying, :finished_studying_details, :grade, :institution, :name, :subject, :year)
     end
-  end
-
-  def form_class
-    name = if %w[select_category submit_category].include?(action_name)
-             "CategoryForm"
-           else
-             case category
-             when "gcse", "a_level", "as_level"
-               "Secondary::CommonForm"
-             when "other_secondary"
-               "Secondary::OtherForm"
-             when "undergraduate", "postgraduate"
-               "DegreeForm"
-             when "other"
-               "OtherForm"
-             end
-           end
-    "Jobseekers::JobApplication::Details::Qualifications::#{name}".constantize
   end
 
   def category
@@ -101,7 +85,11 @@ class Jobseekers::JobApplications::QualificationsController < Jobseekers::BaseCo
     @qualification ||= job_application.qualifications.find(params[:id])
   end
 
+  def qualifications
+    @qualifications ||= [job_application.qualifications.find(params[:ids])].flatten
+  end
+
   def submit_text
-    category.in?(%w[undergraduate postgraduate other]) ? t("buttons.save_qualification.one") : t("buttons.save_qualification.many")
+    category.in?(%w[undergraduate postgraduate other]) ? t("buttons.save_qualification.one") : t("buttons.save_qualification.other")
   end
 end

--- a/app/controllers/jobseekers/job_applications_controller.rb
+++ b/app/controllers/jobseekers/job_applications_controller.rb
@@ -1,8 +1,10 @@
 class Jobseekers::JobApplicationsController < Jobseekers::BaseController
+  include QualificationFormConcerns
+
   before_action :raise_unless_vacancy_enable_job_applications,
                 :redirect_if_job_application_exists, only: %i[new create new_quick_apply quick_apply]
 
-  helper_method :job_application, :review_form, :vacancy, :withdraw_form
+  helper_method :job_application, :qualification_form_param_key, :review_form, :vacancy, :withdraw_form
 
   def new
     request_event.trigger(:vacancy_apply_clicked, vacancy_id: vacancy.id)

--- a/app/controllers/publishers/vacancies/job_applications_controller.rb
+++ b/app/controllers/publishers/vacancies/job_applications_controller.rb
@@ -1,5 +1,7 @@
 class Publishers::Vacancies::JobApplicationsController < Publishers::Vacancies::BaseController
-  helper_method :form, :job_application, :job_applications, :sort, :sort_form, :vacancy
+  include QualificationFormConcerns
+
+  helper_method :form, :job_application, :job_applications, :qualification_form_param_key, :sort, :sort_form, :vacancy
 
   def reject
     raise ActionController::RoutingError, "Cannot reject a draft or withdrawn application" if

--- a/app/helpers/job_application_helper.rb
+++ b/app/helpers/job_application_helper.rb
@@ -7,6 +7,13 @@ module JobApplicationHelper
     draft: "pink", submitted: "blue", shortlisted: "green", unsuccessful: "red", withdrawn: "orange"
   }.freeze
 
+  def job_application_qualified_teacher_status_info(job_application)
+    return unless job_application.qualified_teacher_status.present?
+
+    safe_join([tag.div(I18n.t("helpers.label.jobseekers_job_application_professional_status_form.qualified_teacher_status_options.#{job_application.qualified_teacher_status}"), class: "govuk-body"),
+               tag.p(job_application.qualified_teacher_status == "yes" ? job_application.qualified_teacher_status_year : job_application.qualified_teacher_status_details, class: "govuk-body")])
+  end
+
   def job_application_status_tag(status)
     govuk_tag text: status,
               colour: JOB_APPLICATION_STATUS_TAG_COLOURS[status.to_sym],

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -46,6 +46,13 @@ class JobApplication < ApplicationRecord
     Jobseekers::JobApplicationMailer.application_submitted(self).deliver_later
   end
 
+  def qualification_groups
+    # When qualifications match on name, institution, and year, group/merge them into single objects for displaying.
+    qualifications.group_by { |qual| [qual.name, qual.institution, qual.year] }
+                  .values
+                  .sort_by { |group| group.min_by(&:created_at).created_at }
+  end
+
   private
 
   def update_status_timestamp

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -1,9 +1,13 @@
 class Qualification < ApplicationRecord
+  include ActionView::Helpers::SanitizeHelper
+
   belongs_to :job_application
+
+  SECONDARY_QUALIFICATIONS = %w[gcse as_level a_level other_secondary].freeze
 
   enum category: { gcse: 0, as_level: 1, a_level: 2, other_secondary: 3, undergraduate: 4, postgraduate: 5, other: 6 }
 
-  before_validation :remove_irrelevant_data
+  before_validation :remove_inapplicable_data
 
   def name
     return read_attribute(:name) if read_attribute(:name).present? || other? || other_secondary?
@@ -11,7 +15,8 @@ class Qualification < ApplicationRecord
     I18n.t("helpers.label.jobseekers_job_application_details_qualifications_category_form.category_options.#{category}")
   end
 
-  def remove_irrelevant_data
+  def remove_inapplicable_data
+    # When `finished_studying` changes, remove answers questions that no longer apply, so that they aren't displayed
     return if finished_studying.nil?
 
     if finished_studying?
@@ -20,5 +25,18 @@ class Qualification < ApplicationRecord
       self.grade = ""
       self.year = nil
     end
+  end
+
+  def attributes_for_group
+    secondary? ? %w[institution year] : %w[subject institution grade year]
+  end
+
+  def title_for_group
+    # The title for the group when this qualification is displayed as part of a group of qualifications
+    secondary? ? name.pluralize : name
+  end
+
+  def secondary?
+    category.in?(SECONDARY_QUALIFICATIONS)
   end
 end

--- a/app/services/jobseekers/job_applications/quick_apply.rb
+++ b/app/services/jobseekers/job_applications/quick_apply.rb
@@ -36,7 +36,10 @@ class Jobseekers::JobApplications::QuickApply
   end
 
   def copy_qualifications
-    # TODO: Complete once qualification step complete
+    recent_job_application.qualifications.each do |qualification|
+      new_qualification = qualification.dup
+      new_qualification.update(job_application: new_job_application)
+    end
   end
 
   def copy_employments

--- a/app/views/jobseekers/job_applications/build/employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/build/employment_history.html.slim
@@ -33,8 +33,8 @@
               - c.slot(:row, key: t("jobseekers.job_applications.employments.main_duties"), value: employment.main_duties)
 
           - detail.actions do
-            = govuk_button_to t("buttons.delete"), jobseekers_job_application_employment_path(employment.job_application, employment), method: :delete, class: "govuk-delete-link govuk-!-margin-bottom-0", form_class: "inline-block button_to"
-            = govuk_link_to t("buttons.edit"), edit_jobseekers_job_application_employment_path(employment.job_application, employment), class: "govuk-link--no-visited-state inline-block"
+            = govuk_button_to t("buttons.delete"), jobseekers_job_application_employment_path(job_application, employment), method: :delete, class: "govuk-delete-link govuk-!-margin-bottom-0", form_class: "inline-block button_to"
+            = govuk_link_to t("buttons.edit"), edit_jobseekers_job_application_employment_path(job_application, employment), class: "govuk-link--no-visited-state inline-block"
 
       = govuk_link_to t("buttons.add_another_employment"), new_jobseekers_job_application_employment_path(job_application), button: true, class: "govuk-button--secondary"
     - else

--- a/app/views/jobseekers/job_applications/build/qualifications.html.slim
+++ b/app/views/jobseekers/job_applications/build/qualifications.html.slim
@@ -14,14 +14,40 @@
     p.govuk-body = t(".description")
 
     - if job_application.qualifications.any?
-      / = render Jobseekers::JobApplications::DetailComponent.with_collection(job_application.references.includes(:job_application), title_attribute: "name", info_to_display: qualifications_info)
+      - job_application.qualification_groups.each do |group|
+        = render DetailComponent.new title: group.first.title_for_group do |detail|
+          - detail.body do
+            = govuk_summary_list classes: "govuk-!-margin-bottom-0" do |c|
+              - if group.first.secondary?
+                - c.slot(:row,
+                  key: t("jobseekers.job_applications.qualifications.subjects_and_grades"),
+                  value: safe_join(group.map { |qual| tag.div("#{qual.subject} – #{qual.grade}", class: "govuk-body govuk-!-margin-bottom-1") }))
+              - group.first.attributes_for_group.each do |attribute|
+                - if group.first[attribute].present?
+                  - c.slot(:row,
+                    key: t("helpers.label.#{qualification_form_param_key(group.first.category)}.#{attribute}"),
+                    value: group.first[attribute])
+              - unless group.first.finished_studying.nil?
+                - c.slot(:row,
+                  key: t("helpers.legend.#{qualification_form_param_key(group.first.category)}.finished_studying"),
+                  value: safe_join([tag.div(I18n.t("helpers.label.jobseekers_job_application_details_qualifications_shared_labels.finished_studying_options.#{group.first.finished_studying}"), class: "govuk-body"),
+                                    tag.div(group.first.finished_studying_details.presence, class: "govuk-body")]))
+
+          - detail.actions do
+            = govuk_button_to t("buttons.delete"), destroy_jobseekers_job_application_qualifications_path(job_application), params: { ids: group.pluck(:id) }, method: :delete, class: "govuk-delete-link govuk-!-margin-bottom-0", form_class: "inline-block button_to"
+            / TODO: correct the edit path once multiple qualifications can be edited in one page.
+            = govuk_link_to t("buttons.edit"), edit_jobseekers_job_application_qualification_path(job_application, group), class: "govuk-link--no-visited-state inline-block"
+
       = govuk_link_to t("buttons.add_another_qualification"), select_category_jobseekers_job_application_qualifications_path(job_application), button: true, class: "govuk-button--secondary"
     - else
       = render EmptySectionComponent.new title: t(".no_qualifications") do
         = govuk_link_to t("buttons.add_qualification"), select_category_jobseekers_job_application_qualifications_path(job_application), button: true, class: "govuk-button--secondary govuk-!-margin-bottom-0"
 
     = form_for form, url: wizard_path, method: :patch do |f|
+      = hidden_field_tag :origin, request.referrer
+
       = f.govuk_error_summary
+
       = f.govuk_submit t("buttons.save_and_continue") do
         = f.govuk_submit t("buttons.save_and_come_back"), secondary: true
 

--- a/app/views/jobseekers/job_applications/build/references.html.slim
+++ b/app/views/jobseekers/job_applications/build/references.html.slim
@@ -23,8 +23,8 @@
                 - c.slot(:row, key: t("jobseekers.job_applications.references.#{attribute}"), value: reference[attribute])
 
           - detail.actions do
-            = govuk_button_to t("buttons.delete"), jobseekers_job_application_reference_path(reference.job_application, reference), method: :delete, class: "govuk-delete-link govuk-!-margin-bottom-0", form_class: "inline-block button_to"
-            = govuk_link_to t("buttons.edit"), edit_jobseekers_job_application_reference_path(reference.job_application, reference), class: "govuk-link--no-visited-state inline-block"
+            = govuk_button_to t("buttons.delete"), jobseekers_job_application_reference_path(job_application, reference), method: :delete, class: "govuk-delete-link govuk-!-margin-bottom-0", form_class: "inline-block button_to"
+            = govuk_link_to t("buttons.edit"), edit_jobseekers_job_application_reference_path(job_application, reference), class: "govuk-link--no-visited-state inline-block"
 
       = govuk_link_to t("buttons.add_another_reference"), new_jobseekers_job_application_reference_path(job_application), button: true
     - else

--- a/app/views/jobseekers/job_applications/qualifications/fields/_secondary_school.html.slim
+++ b/app/views/jobseekers/job_applications/qualifications/fields/_secondary_school.html.slim
@@ -1,7 +1,7 @@
 = f.govuk_fieldset legend: { text: t("helpers.legend.jobseekers_job_application_details_qualifications_shared_legends.subjects") } do
-  / TODO: change subject legend when adding new subject field (and change aria required)
+  / TODO: change subject legend when adding new subject field (and change aria-required)
   .inline-fields-container
-    = f.govuk_text_field :subject, legend: { text: "Subject name" }, aria: { required: true }, form_group: { classes: "govuk-!-width-two-thirds" }
+    = f.govuk_text_field :subject, legend: { text: "Subject 1" }, aria: { required: true }, form_group: { classes: "govuk-!-width-two-thirds" }
     = f.govuk_text_field :grade, aria: { required: true }, form_group: { classes: "govuk-!-width-one-third" }
 
 = f.govuk_text_field :institution, label: { size: "s" }, aria: { required: true }, width: "three-quarters"

--- a/app/views/jobseekers/job_applications/review.html.slim
+++ b/app/views/jobseekers/job_applications/review.html.slim
@@ -56,7 +56,7 @@
   - if current_jobseeker.job_applications.not_draft.none?
     .govuk-grid-column-one-third
       = render StepsComponent.new title: "Application Steps", classes: "govuk-!-margin-top-6" do |component|
-        - steps = %w[personal_details professional_status employment_history personal_statement references equal_opportunities ask_for_support declarations]
+        - steps = %w[personal_details professional_status qualifications employment_history personal_statement references equal_opportunities ask_for_support declarations]
         - steps.each do |step|
           - component.step(label: t("jobseekers.job_applications.build.#{step}.step_title"), current: false, completed: step.in?(job_application.completed_steps))
         - component.step(label: t("jobseekers.job_applications.review.heading"), current: action_name == "review", completed: false)

--- a/app/views/jobseekers/job_applications/review/_professional_status.html.slim
+++ b/app/views/jobseekers/job_applications/review/_professional_status.html.slim
@@ -9,8 +9,7 @@
     = govuk_summary_list do |component|
       - component.slot(:row,
         key: t("helpers.legend.jobseekers_job_application_professional_status_form.qualified_teacher_status"),
-        value: safe_join([tag.div(t("helpers.label.jobseekers_job_application_professional_status_form.qualified_teacher_status_options.#{job_application.qualified_teacher_status}"), class: "govuk-body"),
-                          tag.p(job_application.qualified_teacher_status == "yes" ? job_application.qualified_teacher_status_year : job_application.qualified_teacher_status_details, class: "govuk-body")]),
+        value: job_application_qualified_teacher_status_info(job_application),
         html_attributes: { id: "professional_status_qualified_teacher_status" })
 
       - component.slot(:row,

--- a/app/views/jobseekers/job_applications/review/_qualifications.html.slim
+++ b/app/views/jobseekers/job_applications/review/_qualifications.html.slim
@@ -6,4 +6,27 @@
         = job_application_review_section_tag(job_application, :qualifications)
 
   - review.body do
-    p = "TODO"
+    - if job_application.qualifications.none?
+      p = t("jobseekers.job_applications.review.no_qualifications")
+    - else
+      = govuk_accordion do |accordion|
+        - job_application.qualification_groups.each_with_index do |group, index|
+          - accordion.add_section(title: group.first.title_for_group, html_attributes: { id: "qualification_group_#{index}" }) do
+            = govuk_summary_list do |component|
+              - if group.first.secondary?
+                - component.slot(:row,
+                  key: t("jobseekers.job_applications.qualifications.subjects_and_grades"),
+                  value: group.map { |qual| sanitize([qual.subject, qual.grade].join(" – ")) }.join("</br>").html_safe,
+                  html_attributes: { id: "qualification_group_subjects_and_grades" })
+              - group.first.attributes_for_group.each do |attribute|
+                - if group.first[attribute].present?
+                  - component.slot(:row,
+                    key: t("helpers.label.#{qualification_form_param_key(group.first.category)}.#{attribute}"),
+                    value: group.first[attribute],
+                    html_attributes: { id: "qualification_group_#{attribute}" })
+              - unless group.first.finished_studying.nil?
+                - component.slot(:row,
+                  key: t("helpers.legend.#{qualification_form_param_key(group.first.category)}.finished_studying"),
+                  value: safe_join([tag.div(I18n.t("helpers.label.jobseekers_job_application_details_qualifications_shared_labels.finished_studying_options.#{group.first.finished_studying}")),
+                    tag.div(group.first.finished_studying_details.presence)]),
+                  html_attributes: { id: "qualification_group_finished_studying" })

--- a/app/views/jobseekers/job_applications/show.html.slim
+++ b/app/views/jobseekers/job_applications/show.html.slim
@@ -38,6 +38,7 @@
     ol.app-task-list
       li = render "jobseekers/job_applications/review/personal_details", allow_edit: false
       li = render "jobseekers/job_applications/review/professional_status", allow_edit: false
+      li = render "jobseekers/job_applications/review/qualifications", allow_edit: false
       li = render "jobseekers/job_applications/review/employment_history", allow_edit: false
       li = render "jobseekers/job_applications/review/personal_statement", allow_edit: false
       li = render "jobseekers/job_applications/review/references", allow_edit: false

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -254,7 +254,7 @@ en:
     school_details: School details
     school_location:
       one: School location
-      many: School locations
+      other: School locations
     school_overview: School overview
     school_size: School size
     schools_overview: Schools overview

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -38,8 +38,8 @@ en:
     save_changes: Save changes
     save_employment: Save role
     save_qualification:
-      many: Save qualifications
       one: Save qualification
+      other: Save qualifications
     save_reference: Save referee
     search: Search
     select_file: Select a file
@@ -276,7 +276,9 @@ en:
         finished_studying_options:
           false: "No"
           true: "Yes"
+        grade: Grade
         institution: School, college, or other organisation
+        subject: Subject
         year: Year qualification(s) was/were awarded
       jobseekers_job_application_details_qualifications_degree_form:
         <<: *jobseekers_job_application_details_qualifications_shared_labels

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -233,7 +233,9 @@ en:
       not_defined: Not defined (will not be seen on application)
       qualifications:
         destroy:
-          success: Your qualification was deleted
+          success:
+            one: Your qualification was deleted
+            other: Your qualifications were deleted
         qualifications_shared: &qualifications_shared
           caption: Education and qualifications
         edit:
@@ -262,6 +264,7 @@ en:
           <<: *qualifications_shared
           heading: Add a qualification
           title: Add a qualification — Application
+        subjects_and_grades: Subjects and grades
       references:
         destroy:
           success: Your referee was deleted
@@ -295,6 +298,7 @@ en:
               description_html: For more information on how we use your data, please read our %{link_to}.
               link_text: Privacy Policy
         heading: Review your application
+        no_qualifications: You have not added any qualifications.
         title: Review your application — Application
       show:
         feedback: Feedback on your application

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,9 +30,12 @@ Rails.application.routes.draw do
       resources :job_applications, only: %i[index show destroy] do
         resources :build, only: %i[show update], controller: "job_applications/build"
         resources :employments, only: %i[new create edit update destroy], controller: "job_applications/employments"
-        resources :qualifications, only: %i[new create edit update destroy], controller: "job_applications/qualifications" do
-          get :select_category, on: :collection
-          post :submit_category, on: :collection
+        resources :qualifications, only: %i[new create edit update], controller: "job_applications/qualifications" do
+          collection do
+            delete :destroy, as: :destroy
+            get :select_category
+            post :submit_category
+          end
         end
         resources :references, only: %i[new create edit update destroy], controller: "job_applications/references"
         get :review

--- a/spec/factories/employments.rb
+++ b/spec/factories/employments.rb
@@ -8,5 +8,7 @@ FactoryBot.define do
     started_on { Faker::Date.in_date_period(year: 2016) }
     current_role { "no" }
     ended_on { Faker::Date.in_date_period(year: 2018) }
+
+    job_application
   end
 end

--- a/spec/factories/job_applications.rb
+++ b/spec/factories/job_applications.rb
@@ -61,9 +61,9 @@ FactoryBot.define do
 
     after :create do |job_application, options|
       if options.create_details
-        # TODO: education
         create_list :employment, 3, job_application: job_application
         create_list :reference, 2, job_application: job_application
+        create_list :qualification, 3, job_application: job_application
       end
 
       job_application.update_columns(

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -1,5 +1,11 @@
 require "rails_helper"
 
+RSpec.shared_examples "puts the qualifications in separate groups" do
+  it "puts the qualifications in separate groups" do
+    expect(subject.qualification_groups.count).to eq(qualifications.count)
+  end
+end
+
 RSpec.describe JobApplication do
   it { is_expected.to belong_to(:jobseeker) }
   it { is_expected.to belong_to(:vacancy) }
@@ -100,6 +106,75 @@ RSpec.describe JobApplication do
       expect { subject }
         .to have_enqueued_email(Jobseekers::JobApplicationMailer, :application_submitted)
         .with(hash_including(args: [job_application]))
+    end
+  end
+
+  describe "#qualification_groups" do
+    let(:stubbed_time) { Time.utc(2021, 2, 1, 12, 0, 0) }
+    let(:institution) { "Happy Rainbows School" }
+    let(:name) { "Ordinary Wizarding Level" }
+    let(:year) { 2000 }
+    let!(:qualifications) do
+      Array.new(3) do |index|
+        count = index + 1
+        build_stubbed(:qualification,
+                      created_at: stubbed_time - count.seconds,
+                      category: "other_secondary",
+                      institution: institution || "Institution #{count}",
+                      name: name || "Qualification name #{count}",
+                      year: year || 2000 + count)
+      end
+    end
+
+    before { allow(subject).to receive(:qualifications).and_return(qualifications) }
+
+    context "when the qualifications do not share a name" do
+      let(:name) { nil }
+
+      it_behaves_like "puts the qualifications in separate groups"
+
+      it "orders the groups by the created_at timestamp of the oldest qualification in each group" do
+        expect(subject.qualification_groups.first.first.created_at).to eq(stubbed_time - qualifications.count)
+        expect(subject.qualification_groups.second.first.created_at).to eq(stubbed_time - (qualifications.count - 1))
+        expect(subject.qualification_groups.third.first.created_at).to eq(stubbed_time - (qualifications.count - 2))
+      end
+    end
+
+    context "when the qualifications do not share an institution" do
+      let(:institution) { nil }
+
+      it_behaves_like "puts the qualifications in separate groups"
+    end
+
+    context "when the qualifications do not share a year" do
+      let(:year) { nil }
+
+      it_behaves_like "puts the qualifications in separate groups"
+    end
+
+    context "when some qualifications share a year, institution, and name" do
+      let(:institution) { nil }
+      let(:name) { nil }
+      let(:year) { nil }
+      let(:qualifications_to_be_grouped) do
+        Array.new(2) do
+          build_stubbed(:qualification,
+                        created_at: stubbed_time - 100.days,
+                        category: "other_secondary",
+                        institution: "Dreary Grey School",
+                        name: "O Level",
+                        year: 1970)
+        end
+      end
+
+      before { allow(subject).to receive(:qualifications).and_return(qualifications + qualifications_to_be_grouped) }
+
+      it "groups the qualifications correctly and in order of the created_at timestamp of the oldest qualification in each group" do
+        expect(subject.qualification_groups.first).to match_array(qualifications_to_be_grouped)
+        expect(subject.qualification_groups.second.first.created_at).to eq(stubbed_time - qualifications.count)
+        expect(subject.qualification_groups.third.first.created_at).to eq(stubbed_time - (qualifications.count - 1))
+        expect(subject.qualification_groups.last.first.created_at).to eq(stubbed_time - (qualifications.count - 2))
+      end
     end
   end
 end

--- a/spec/requests/jobseekers/job_applications/qualifications_spec.rb
+++ b/spec/requests/jobseekers/job_applications/qualifications_spec.rb
@@ -205,17 +205,30 @@ RSpec.describe "Job applications qualifications" do
       let(:job_application) { create(:job_application, :status_submitted, jobseeker: jobseeker, vacancy: vacancy) }
 
       it "returns not_found" do
-        delete jobseekers_job_application_qualification_path(job_application, qualification)
+        delete destroy_jobseekers_job_application_qualifications_path(job_application, params: { ids: qualification.id })
 
         expect(response).to have_http_status(:not_found)
       end
     end
 
-    it "destroys the qualification and redirects to the qualification build step" do
-      expect { delete jobseekers_job_application_qualification_path(job_application, qualification) }
-        .to change { Qualification.count }.by(-1)
+    context "when destroying only one qualification" do
+      it "destroys the qualification and redirects to the qualification build step" do
+        expect { delete destroy_jobseekers_job_application_qualifications_path(job_application, params: { ids: qualification.id }) }
+          .to change { Qualification.count }.by(-1)
 
-      expect(response).to redirect_to(jobseekers_job_application_build_path(job_application, :qualifications))
+        expect(response).to redirect_to(jobseekers_job_application_build_path(job_application, :qualifications))
+      end
+    end
+
+    context "when destroying a list of qualifications" do
+      let!(:qualifications) { Array.new(2) { create(:qualification, job_application: job_application) } }
+
+      it "destroys the qualifications and redirects to the qualification build step" do
+        expect { delete destroy_jobseekers_job_application_qualifications_path(job_application), params: { ids: qualifications.pluck(:id) } }
+          .to change { Qualification.count }.by(-2)
+
+        expect(response).to redirect_to(jobseekers_job_application_build_path(job_application, :qualifications))
+      end
     end
   end
 end

--- a/spec/services/jobseekers/job_applications/quick_apply_spec.rb
+++ b/spec/services/jobseekers/job_applications/quick_apply_spec.rb
@@ -40,8 +40,10 @@ RSpec.describe Jobseekers::JobApplications::QuickApply do
     end
 
     it "copies qualifications" do
-      # TODO: Complete once qualification step complete
-      # expect(subject.qualifications).to eq(recent_job_application.qualifications)
+      attributes_to_copy = %i[category finished_studying finished_studying_details grade institution name subject year]
+
+      expect(subject.qualifications.map { |qualification| qualification.slice(*attributes_to_copy) })
+        .to eq(recent_job_application.qualifications.map { |qualification| qualification.slice(*attributes_to_copy) })
     end
 
     it "copies employments" do

--- a/spec/support/jobseeker_helpers.rb
+++ b/spec/support/jobseeker_helpers.rb
@@ -27,6 +27,16 @@ module JobseekerHelpers
     end
   end
 
+  def validates_step_complete(button: I18n.t("buttons.save_and_continue"))
+    click_on button
+    expect(page).to have_content("There is a problem")
+  end
+
+  def select_qualification_category(category)
+    choose category
+    click_on I18n.t("buttons.continue")
+  end
+
   def fill_in_ask_for_support
     choose "Yes", name: "jobseekers_job_application_ask_for_support_form[support_needed]"
     fill_in "Tell us any information you think is relevant", with: "Some details about support"

--- a/spec/system/jobseekers_can_add_employments_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers_can_add_employments_to_their_job_application_spec.rb
@@ -10,83 +10,75 @@ RSpec.describe "Jobseekers can add employments to their job application" do
     login_as(jobseeker, scope: :jobseeker)
   end
 
-  describe "employments" do
-    context "when completing a job application" do
-      it "allows jobseekers to add a current role" do
-        visit jobseekers_job_application_build_path(job_application, :employment_history)
+  it "allows jobseekers to add a current role" do
+    visit jobseekers_job_application_build_path(job_application, :employment_history)
 
-        click_on I18n.t("buttons.add_employment")
-        click_on I18n.t("buttons.save_employment")
+    expect(page).to have_content("No employment specified")
 
-        expect(page).to have_content("There is a problem")
+    click_on I18n.t("buttons.add_employment")
+    validates_step_complete(button: I18n.t("buttons.save_employment"))
 
-        fill_in_current_role
+    fill_in_current_role
 
-        click_on I18n.t("buttons.save_employment")
+    click_on I18n.t("buttons.save_employment")
 
-        expect(current_path).to eq(jobseekers_job_application_build_path(job_application, :employment_history))
-        expect(page).to have_content("The Best Teacher")
-      end
+    expect(current_path).to eq(jobseekers_job_application_build_path(job_application, :employment_history))
+    expect(page).to have_content("The Best Teacher")
+  end
 
-      it "allows jobseekers to add employment history" do
-        visit jobseekers_job_application_build_path(job_application, :employment_history)
+  it "allows jobseekers to add employment history" do
+    visit jobseekers_job_application_build_path(job_application, :employment_history)
 
-        click_on I18n.t("buttons.add_employment")
-        click_on I18n.t("buttons.save_employment")
+    click_on I18n.t("buttons.add_employment")
+    validates_step_complete(button: I18n.t("buttons.save_employment"))
 
-        expect(page).to have_content("There is a problem")
+    fill_in_employment_history
 
-        fill_in_employment_history
+    click_on I18n.t("buttons.save_employment")
 
-        click_on I18n.t("buttons.save_employment")
+    expect(current_path).to eq(jobseekers_job_application_build_path(job_application, :employment_history))
+    expect(page).to have_content("The Best Teacher")
+    expect(page).to have_content(Date.new(2020, 0o7, 30).to_s)
+  end
 
-        expect(current_path).to eq(jobseekers_job_application_build_path(job_application, :employment_history))
-        expect(page).to have_content("The Best Teacher")
-        expect(page).to have_content(Date.new(2020, 0o7, 30).to_s)
-      end
+  it "allows jobseekers to add gaps in employment" do
+    visit jobseekers_job_application_build_path(job_application, :employment_history)
 
-      it "allows jobseekers to add gaps in employment" do
-        visit jobseekers_job_application_build_path(job_application, :employment_history)
+    choose "Yes", name: "jobseekers_job_application_employment_history_form[gaps_in_employment]"
+    fill_in "jobseekers_job_application_employment_history_form[gaps_in_employment_details]", with: "Some details about gaps in employment"
+    click_on I18n.t("buttons.save_and_come_back")
 
-        choose "Yes", name: "jobseekers_job_application_employment_history_form[gaps_in_employment]"
-        fill_in "jobseekers_job_application_employment_history_form[gaps_in_employment_details]", with: "Some details about gaps in employment"
-        click_on I18n.t("buttons.save_and_come_back")
+    expect(job_application.reload.gaps_in_employment).to eq("yes")
+    expect(job_application.reload.gaps_in_employment_details).to eq("Some details about gaps in employment")
+  end
 
-        expect(job_application.reload.gaps_in_employment).to eq("yes")
-        expect(job_application.reload.gaps_in_employment_details).to eq("Some details about gaps in employment")
-      end
+  context "when there is at least one role" do
+    let!(:employment) { create(:employment, organisation: "A school", job_application: job_application) }
 
-      context "when there is at least one role" do
-        let!(:employment) { create(:employment, organisation: "A school", job_application: job_application) }
+    it "allows jobseekers to delete employment history" do
+      visit jobseekers_job_application_build_path(job_application, :employment_history)
 
-        it "allows jobseekers to delete employment history" do
-          visit jobseekers_job_application_build_path(job_application, :employment_history)
+      click_on I18n.t("buttons.delete")
 
-          click_on I18n.t("buttons.delete")
+      expect(current_path).to eq(jobseekers_job_application_build_path(job_application, :employment_history))
+      expect(page).to have_content(I18n.t("jobseekers.job_applications.employments.destroy.success"))
+      expect(page).not_to have_content("Teacher")
+    end
 
-          expect(current_path).to eq(jobseekers_job_application_build_path(job_application, :employment_history))
-          expect(page).to have_content(I18n.t("jobseekers.job_applications.employments.destroy.success"))
-          expect(page).not_to have_content("Teacher")
-        end
+    it "allows jobseekers to edit employment history" do
+      visit jobseekers_job_application_build_path(job_application, :employment_history)
 
-        it "allows jobseekers to edit employment history" do
-          visit jobseekers_job_application_build_path(job_application, :employment_history)
+      click_on I18n.t("buttons.edit")
 
-          click_on I18n.t("buttons.edit")
+      fill_in "School or other organisation", with: ""
+      validates_step_complete(button: I18n.t("buttons.save_employment"))
 
-          fill_in "School or other organisation", with: ""
-          click_on I18n.t("buttons.save_employment")
+      fill_in "School or other organisation", with: "A different school"
+      click_on I18n.t("buttons.save_employment")
 
-          expect(page).to have_content("There is a problem")
-
-          fill_in "School or other organisation", with: "A different school"
-          click_on I18n.t("buttons.save_employment")
-
-          expect(current_path).to eq(jobseekers_job_application_build_path(job_application, :employment_history))
-          expect(page).not_to have_content("A school")
-          expect(page).to have_content("A different school")
-        end
-      end
+      expect(current_path).to eq(jobseekers_job_application_build_path(job_application, :employment_history))
+      expect(page).not_to have_content("A school")
+      expect(page).to have_content("A different school")
     end
   end
 end

--- a/spec/system/jobseekers_can_add_qualifications_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers_can_add_qualifications_to_their_job_application_spec.rb
@@ -1,0 +1,129 @@
+require "rails_helper"
+
+RSpec.describe "Jobseekers can add qualifications to their job application" do
+  let(:jobseeker) { create(:jobseeker) }
+  let(:vacancy) { create(:vacancy, organisation_vacancies_attributes: [{ organisation: build(:school) }]) }
+  let(:job_application) { create(:job_application, :status_draft, jobseeker: jobseeker, vacancy: vacancy) }
+
+  before do
+    allow(JobseekerApplicationsFeature).to receive(:enabled?).and_return(true)
+    login_as(jobseeker, scope: :jobseeker)
+  end
+
+  context "adding a qualification" do
+    before do
+      visit jobseekers_job_application_build_path(job_application, :qualifications)
+      click_on I18n.t("buttons.add_qualification")
+    end
+
+    it "allows jobseekers to add a graduate degree" do
+      validates_step_complete(button: I18n.t("buttons.continue"))
+      select_qualification_category("Undergraduate degree")
+      expect(page).to have_content(I18n.t("jobseekers.job_applications.qualifications.new.heading.undergraduate"))
+      validates_step_complete(button: I18n.t("buttons.save_qualification.one"))
+      fill_in_undergraduate_degree
+      click_on I18n.t("buttons.save_qualification.one")
+      expect(current_path).to eq(jobseekers_job_application_build_path(job_application, :qualifications))
+      expect(page).to have_content(I18n.t("buttons.add_another_qualification"))
+      expect(page).to have_content("Undergraduate degree")
+      expect(page).to have_content("University of Life")
+      expect(page).not_to have_content("Subjects and grades")
+      expect(page).not_to have_content("School, college, or other organisation")
+    end
+
+    it "allows jobseekers to add a custom qualification or course (category 'other')" do
+      select_qualification_category("Other qualification or course")
+      expect(page).to have_content(I18n.t("jobseekers.job_applications.qualifications.new.heading.other"))
+      validates_step_complete(button: I18n.t("buttons.save_qualification.one"))
+      fill_in_other_qualification
+      click_on I18n.t("buttons.save_qualification.one")
+      expect(current_path).to eq(jobseekers_job_application_build_path(job_application, :qualifications))
+      expect(page).to have_content("Superteacher Certificate")
+      expect(page).to have_content("Teachers Academy")
+      expect(page).to have_content("I expect to finish next year")
+      expect(page).not_to have_content("Grade")
+      expect(page).not_to have_content("Year")
+    end
+
+    it "allows jobseekers to add a common secondary qualification" do
+      select_qualification_category("GCSE")
+      expect(page).to have_content(I18n.t("jobseekers.job_applications.qualifications.new.heading.gcse"))
+      validates_step_complete(button: I18n.t("buttons.save_qualification.other"))
+      fill_in_gcse
+      # TODO: fill_in_another_gcse
+      click_on I18n.t("buttons.save_qualification.other")
+      expect(current_path).to eq(jobseekers_job_application_build_path(job_application, :qualifications))
+      expect(page).to have_content("GCSEs")
+      expect(page).to have_content("Churchill School for Gifted Macaques")
+      expect(page).to have_content("Maths – 110%")
+      expect(page).to have_content("2020")
+    end
+
+    it "allows jobseekers to add a custom secondary qualification" do
+      select_qualification_category("Other secondary qualification")
+      expect(page).to have_content(I18n.t("jobseekers.job_applications.qualifications.new.heading.other_secondary"))
+      validates_step_complete(button: I18n.t("buttons.save_qualification.other"))
+      fill_in_secondary_qualification
+      # TODO: fill_in_another_secondary_qualification
+      click_on I18n.t("buttons.save_qualification.other")
+      expect(current_path).to eq(jobseekers_job_application_build_path(job_application, :qualifications))
+      expect(page).to have_content("Welsh Baccalaureates")
+      expect(page).to have_content("Happy Rainbows School for High Achievers")
+      expect(page).to have_content("Science – 5")
+      expect(page).to have_content("2020")
+    end
+  end
+
+  context "when there is exactly one qualification" do
+    let!(:qualification) do
+      create(:qualification,
+             category: "other_secondary",
+             institution: "John Mason School",
+             job_application: job_application)
+    end
+
+    it "allows jobseekers to edit a single qualification" do
+      visit jobseekers_job_application_build_path(job_application, :qualifications)
+
+      click_on I18n.t("buttons.edit")
+
+      fill_in "School", with: "St Nicholas School"
+      click_on I18n.t("buttons.save_qualification.one")
+
+      expect(current_path).to eq(jobseekers_job_application_build_path(job_application, :qualifications))
+      expect(page).not_to have_content("John")
+      expect(page).to have_content("Nicholas")
+    end
+  end
+
+  context "when there is a group of more than one qualifications" do
+    let!(:qualifications) do
+      create_list(:qualification, 2,
+                  category: "other_secondary",
+                  institution: "John Mason School",
+                  name: "O Level",
+                  job_application: job_application,
+                  year: 1970)
+    end
+
+    it "allows jobseekers to delete the qualifications as a group" do
+      visit jobseekers_job_application_build_path(job_application, :qualifications)
+
+      click_on I18n.t("buttons.delete")
+
+      expect(current_path).to eq(jobseekers_job_application_build_path(job_application, :qualifications))
+      expect(page).to have_content(I18n.t("jobseekers.job_applications.qualifications.destroy.success.other"))
+      expect(page).not_to have_content("John Mason School")
+    end
+
+    # TODO: complete these pending tests when functionality implemented
+
+    xit "allows jobseekers to edit qualifications from a group" do
+      # noop
+    end
+
+    xit "allows jobseekers to delete a row from a group" do
+      # noop
+    end
+  end
+end

--- a/spec/system/jobseekers_can_add_references_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers_can_add_references_to_their_job_application_spec.rb
@@ -10,55 +10,49 @@ RSpec.describe "Jobseekers can add references to their job application" do
     login_as(jobseeker, scope: :jobseeker)
   end
 
-  describe "references" do
-    context "when completing a job application" do
-      it "allows jobseekers to add references" do
-        visit jobseekers_job_application_build_path(job_application, :references)
+  it "allows jobseekers to add references" do
+    visit jobseekers_job_application_build_path(job_application, :references)
 
-        click_on I18n.t("buttons.add_reference")
-        click_on I18n.t("buttons.save_reference")
+    expect(page).to have_content("No referees specified")
 
-        expect(page).to have_content("There is a problem")
+    click_on I18n.t("buttons.add_reference")
+    validates_step_complete(button: I18n.t("buttons.save_reference"))
 
-        fill_in_reference
+    fill_in_reference
 
-        click_on I18n.t("buttons.save_reference")
+    click_on I18n.t("buttons.save_reference")
 
-        expect(current_path).to eq(jobseekers_job_application_build_path(job_application, :references))
-        expect(page).to have_content("Jim Referee")
-      end
+    expect(current_path).to eq(jobseekers_job_application_build_path(job_application, :references))
+    expect(page).to have_content("Jim Referee")
+  end
 
-      context "when there is at least one reference" do
-        let!(:reference) { create(:reference, name: "John", job_application: job_application) }
+  context "when there is at least one reference" do
+    let!(:reference) { create(:reference, name: "John", job_application: job_application) }
 
-        it "allows jobseekers to delete references" do
-          visit jobseekers_job_application_build_path(job_application, :references)
+    it "allows jobseekers to delete references" do
+      visit jobseekers_job_application_build_path(job_application, :references)
 
-          click_on I18n.t("buttons.delete")
+      click_on I18n.t("buttons.delete")
 
-          expect(current_path).to eq(jobseekers_job_application_build_path(job_application, :references))
-          expect(page).to have_content(I18n.t("jobseekers.job_applications.references.destroy.success"))
-          expect(page).not_to have_content("John")
-        end
+      expect(current_path).to eq(jobseekers_job_application_build_path(job_application, :references))
+      expect(page).to have_content(I18n.t("jobseekers.job_applications.references.destroy.success"))
+      expect(page).not_to have_content("John")
+    end
 
-        it "allows jobseekers to edit references" do
-          visit jobseekers_job_application_build_path(job_application, :references)
+    it "allows jobseekers to edit references" do
+      visit jobseekers_job_application_build_path(job_application, :references)
 
-          click_on I18n.t("buttons.edit")
+      click_on I18n.t("buttons.edit")
 
-          fill_in "Name", with: ""
-          click_on I18n.t("buttons.save_reference")
+      fill_in "Name", with: ""
+      validates_step_complete(button: I18n.t("buttons.save_reference"))
 
-          expect(page).to have_content("There is a problem")
+      fill_in "Name", with: "Jason"
+      click_on I18n.t("buttons.save_reference")
 
-          fill_in "Name", with: "Jason"
-          click_on I18n.t("buttons.save_reference")
-
-          expect(current_path).to eq(jobseekers_job_application_build_path(job_application, :references))
-          expect(page).not_to have_content("John")
-          expect(page).to have_content("Jason")
-        end
-      end
+      expect(current_path).to eq(jobseekers_job_application_build_path(job_application, :references))
+      expect(page).not_to have_content("John")
+      expect(page).to have_content("Jason")
     end
   end
 end

--- a/spec/system/jobseekers_can_complete_a_job_application_spec.rb
+++ b/spec/system/jobseekers_can_complete_a_job_application_spec.rb
@@ -23,68 +23,20 @@ RSpec.describe "Jobseekers can complete a job application" do
     fill_in_professional_status
     click_on I18n.t("buttons.save_and_continue")
 
-    # Education and qualifications. There are four different user journeys to test.
-    #
-    # Move these to a new file jobseekers_can_add_qualifications_to_their_job_application.
-
     expect(page).to have_content(I18n.t("jobseekers.job_applications.build.qualifications.heading"))
-    expect(page).to have_content("No qualifications specified")
     click_on I18n.t("buttons.save_and_continue")
     expect(page).not_to have_content("There is a problem")
     click_on I18n.t("buttons.back")
-    # 1. Graduate degrees
     click_on I18n.t("buttons.add_qualification")
     validates_step_complete(button: I18n.t("buttons.continue"))
-    choose "Undergraduate degree"
-    click_on I18n.t("buttons.continue")
+    select_qualification_category("Undergraduate degree")
     expect(page).to have_content(I18n.t("jobseekers.job_applications.qualifications.new.heading.undergraduate"))
     validates_step_complete(button: I18n.t("buttons.save_qualification.one"))
     fill_in_undergraduate_degree
     click_on I18n.t("buttons.save_qualification.one")
-    # TODO: expect the qualification to be displayed
-    # 2. Generic 'other' qualification
-    click_on I18n.t("buttons.add_another_qualification")
-    choose "Other qualification or course"
-    click_on I18n.t("buttons.continue")
-    expect(page).to have_content(I18n.t("jobseekers.job_applications.qualifications.new.heading.other"))
-    validates_step_complete(button: I18n.t("buttons.save_qualification.one"))
-    fill_in_other_qualification
-    click_on I18n.t("buttons.save_qualification.one")
-    # TODO: expect the qualification to be displayed
-    # 3. Common secondary qualifications
-    click_on I18n.t("buttons.add_another_qualification")
-    choose "GCSE"
-    click_on I18n.t("buttons.continue")
-    expect(page).to have_content(I18n.t("jobseekers.job_applications.qualifications.new.heading.gcse"))
-    validates_step_complete(button: I18n.t("buttons.save_qualification.many"))
-    fill_in_gcse
-    # TODO: fill_in_another_gcse
-    click_on I18n.t("buttons.save_qualification.many")
-    # TODO: expect the qualification to be displayed
-    #
-    # TODO: Can delete and edit GCSE
-    # click_on I18n.t("buttons.add_another_qualification")
-    # choose "GCSE"
-    # click_on I18n.t("buttons.continue")
-    # delete_gcse
-    # edit_other_gcse
-    # click_on I18n.t("buttons.save_qualification")
-    # expect the qualifications to be deleted and edited
-    #
-    # 4. Other secondary qualification
-    click_on I18n.t("buttons.add_another_qualification")
-    choose "Other secondary qualification"
-    click_on I18n.t("buttons.continue")
-    expect(page).to have_content(I18n.t("jobseekers.job_applications.qualifications.new.heading.other_secondary"))
-    validates_step_complete(button: I18n.t("buttons.save_qualification.many"))
-    fill_in_secondary_qualification
-    # TODO: fill_in_another_secondary_qualification
-    click_on I18n.t("buttons.save_qualification.many")
-    # TODO: expect the qualification to be displayed
     click_on I18n.t("buttons.save_and_continue")
 
     expect(page).to have_content(I18n.t("jobseekers.job_applications.build.employment_history.heading"))
-    expect(page).to have_content("No employment specified")
     validates_step_complete
     click_on I18n.t("buttons.add_employment")
     click_on I18n.t("buttons.save_employment")
@@ -128,10 +80,5 @@ RSpec.describe "Jobseekers can complete a job application" do
     click_on I18n.t("buttons.save_and_continue")
 
     expect(current_path).to eq(jobseekers_job_application_review_path(job_application))
-  end
-
-  def validates_step_complete(button: I18n.t("buttons.save_and_continue"))
-    click_on button
-    expect(page).to have_content("There is a problem")
   end
 end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-1747

## Changes

Adds the DetailsComponent and ReviewComponent for qualifications.

Complicated by the fact that grouping of qualifications into a single box happens when the qualifications share a name (e.g. GCSE), school, and year.

Minor fixes included:

- Display nothing (rather than mangled yaml) when professional_status is an empty string
on the review page

- Correct erroneous usage of 'many' instead of 'other' in I18n pluralization

## Screenshots

### Qualifications step

![Screenshot 2021-04-14 at 16 09 27](https://user-images.githubusercontent.com/60350599/115276780-608e1a00-a13b-11eb-88d6-1bede1fa7209.png)
![Screenshot 2021-04-14 at 16 09 50](https://user-images.githubusercontent.com/60350599/115276769-5e2bc000-a13b-11eb-8d61-ffc713553ec6.png)
![Screenshot 2021-04-14 at 16 09 41](https://user-images.githubusercontent.com/60350599/115276777-5ff58380-a13b-11eb-8e0a-37fbd7f0d965.png)

### Review page

![Screenshot 2021-04-19 at 18 25 58](https://user-images.githubusercontent.com/60350599/115277888-b31c0600-a13c-11eb-84fc-8ac7e4fe64d6.png)

## Next

The ability to add / edit / delete multiple secondary school qualifications in one form will come in a later PR.