### PR TITLE
Prohibit LAs from creating applyable vacancies

### DIFF
--- a/app/controllers/concerns/publishers/wizardable.rb
+++ b/app/controllers/concerns/publishers/wizardable.rb
@@ -103,7 +103,7 @@ module Publishers::Wizardable
   def applying_for_the_job_params(params)
     params.require(:publishers_job_listing_applying_for_the_job_form)
           .permit(:state, :application_link, :enable_job_applications, :contact_email, :contact_number, :personal_statement_guidance, :school_visits, :how_to_apply)
-          .merge(completed_step: steps_config[step][:number])
+          .merge(completed_step: steps_config[step][:number], current_organisation: current_organisation)
   end
 
   def job_summary_params(params)

--- a/app/form_models/publishers/job_listing/applying_for_the_job_form.rb
+++ b/app/form_models/publishers/job_listing/applying_for_the_job_form.rb
@@ -1,4 +1,6 @@
 class Publishers::JobListing::ApplyingForTheJobForm < Publishers::JobListing::VacancyForm
+  before_validation :override_enable_job_applications_for_local_authority!
+
   validates :application_link, url: true, if: :application_link?
 
   validates :enable_job_applications, inclusion: { in: [true, false] }, if: -> { JobseekerApplicationsFeature.enabled? }
@@ -7,4 +9,17 @@ class Publishers::JobListing::ApplyingForTheJobForm < Publishers::JobListing::Va
   validates :contact_email, format: { with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i }, if: :contact_email?
 
   validates :contact_number, format: { with: /\A\+?(?:\d\s?){10,12}\z/ }, if: :contact_number?
+
+  private
+
+  # If a publisher is signed in as an LA, we do not allow them to set the job applications feature.
+  # This forces the field to be set so the validations pass when submitting the form (despite the
+  # field not being there).
+  # TODO: Remove me (and conditional in view) when we start allowing applications feature for LAs
+  def override_enable_job_applications_for_local_authority!
+    return if params[:current_organisation].nil?
+    return unless params[:current_organisation].local_authority? && enable_job_applications.nil?
+
+    self.enable_job_applications = false
+  end
 end

--- a/app/form_models/publishers/job_listing/vacancy_form.rb
+++ b/app/form_models/publishers/job_listing/vacancy_form.rb
@@ -1,5 +1,6 @@
 class Publishers::JobListing::VacancyForm
   include ActiveModel::Model
+  include ActiveModel::Validations::Callbacks
 
   attr_accessor :params, :vacancy
 
@@ -9,11 +10,11 @@ class Publishers::JobListing::VacancyForm
 
   def initialize(params = {})
     @params = params
-    @vacancy = Vacancy.new(params.except(:documents_attributes, :expires_at_hh, :expires_at_mm, :expires_at_meridiem))
+    @vacancy = Vacancy.new(params.except(:documents_attributes, :expires_at_hh, :expires_at_mm, :expires_at_meridiem, :current_organisation))
   end
 
   def params_to_save
-    params
+    params.except(:current_organisation)
   end
 
   # This method is only necessary for forms with specific error messages for date inputs.

--- a/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
+++ b/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
@@ -16,7 +16,7 @@
         = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f
 
         - if JobseekerApplicationsFeature.enabled?
-          - if @vacancy.listed?
+          - if @vacancy.listed? || current_organisation.local_authority?
             = f.hidden_field :enable_job_applications
             - if @vacancy.enable_job_applications?
                 = f.govuk_text_area :personal_statement_guidance, label: { size: "s" }

--- a/spec/form_models/publishers/job_listing/applying_for_the_job_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/applying_for_the_job_form_spec.rb
@@ -17,5 +17,31 @@ RSpec.describe Publishers::JobListing::ApplyingForTheJobForm, type: :model do
     before { allow(JobseekerApplicationsFeature).to receive(:enabled?).and_return(true) }
 
     it { is_expected.to validate_inclusion_of(:enable_job_applications).in_array([true, false]) }
+
+    describe "enable job applications override" do
+      subject { described_class.new(current_organisation: organisation) }
+
+      context "when the current organisation given is a local authority" do
+        let(:organisation) { build_stubbed(:local_authority) }
+
+        it "overrides enable_job_applications to false" do
+          subject.valid?
+
+          expect(subject.enable_job_applications).to eq(false)
+          expect(subject.errors).not_to include(:enable_job_applications)
+        end
+      end
+
+      context "when the current organisation given is not a local authority" do
+        let(:organisation) { build_stubbed(:trust) }
+
+        it "does not override enable_job_applications" do
+          subject.valid?
+
+          expect(subject.enable_job_applications).to be_nil
+          expect(subject.errors).to include(:enable_job_applications)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This removes the ability from publishers signed in as a local authority
to create vacancies that can be applied for through the service.

- Pass current organisation through to the vacancy forms
- Make the "applying for the job" view show only the fields for the
  existing value (as we would for a live vacancy), which is the online
  application link (or exceptionally, if a school itself created the
  vacancy and set it to be applyable, the personal statement, which the
  LA should still be allowed to edit in that case)
- Add a callback to `ApplyingForTheJobForm` that sets the
  `enable_job_applications` to `false` if the current organisation is
  an LA (so that a valid value is set despite the field not being there
  in the form)

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2367