### PR TITLE
[TEVA-2430] fix button layout and refactor dashboard css

### DIFF
--- a/app/components/publishers/vacancies_component.rb
+++ b/app/components/publishers/vacancies_component.rb
@@ -35,7 +35,7 @@ class Publishers::VacanciesComponent < ViewComponent::Base
   end
 
   def vacancy_type_tab_link(vacancy_type, selected)
-    link_to t(".#{vacancy_type}.tab_heading"), jobs_with_type_organisation_path(vacancy_type), class: "moj-primary-navigation__link", "aria-current": ("page" if selected)
+    link_to t(".#{vacancy_type}.tab_heading"), jobs_with_type_organisation_path(vacancy_type), class: "dashboard-component-navigation__link", "aria-current": ("page" if selected)
   end
 
   def no_jobs_text

--- a/app/components/shared/dashboard_component/dashboard_component.html.slim
+++ b/app/components/shared/dashboard_component/dashboard_component.html.slim
@@ -1,16 +1,16 @@
 .dashboard-component
   .govuk-width-container
-    h2.govuk-heading-m class="govuk-!-margin-bottom-2"
-      = heading
+    .dashboard-component__header
+      h2.govuk-heading-m class="govuk-!-margin-bottom-2"
+        = heading
 
   .govuk-width-container
-    - if link.present?
-      .filters-information.moj-action-bar
-        = govuk_button_to link[:text], link[:url], class: "govuk-!-margin-bottom-0 govuk-!-margin-top-0 dashboard-component__link"
-    .moj-primary-navigation
-      .moj-primary-navigation__container
-        .moj-primary-navigation__nav aria-label="Account navigation"
-          ul.moj-primary-navigation__list
+    .dashboard-component-navigation
+      .dashboard-component-navigation__container
+        .dashboard-component-navigation__nav aria-label="Account navigation"
+          ul.dashboard-component-navigation__list
             - @navigation_items.each do |item|
-              li.moj-primary-navigation__item
+              li.dashboard-component-navigation__item
                 = item
+    - if link.present?
+      = govuk_button_to link[:text], link[:url], class: "govuk-!-margin-bottom-0 govuk-!-margin-top-0", form_class: "dashboard-component__button"

--- a/app/components/shared/dashboard_component/dashboard_component.scss
+++ b/app/components/shared/dashboard_component/dashboard_component.scss
@@ -3,11 +3,104 @@
 
 .dashboard-component {
   @include full-width-mast;
+
   background-color: govuk-colour('light-grey');
   padding: govuk-spacing(3) 0 0;
 
+  @include govuk-media-query ($from: desktop) {
+    .govuk-width-container {
+      position: relative;
+    }
+
+    &__button {
+      bottom: govuk-spacing(3);
+      margin-top: 0;
+      position: absolute;
+      right: 0;
+    }
+  }
+
   h2 {
     word-wrap: break-word;
+  }
+
+  &__button {
+    margin-top: govuk-spacing(4);
+  }
+
+  &-navigation {
+    background: none;
+
+    &__container {
+      font-size: 0;
+      margin: 0;
+      text-align: justify;
+    }
+
+    &__nav {
+      text-align: left;
+    }
+
+    &__list {
+      font-size: 0;
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+
+    &__item {
+      display: inline-block;
+      font-size: 1rem;
+      line-height: 1.25;
+      margin-bottom: 0;
+      margin-right: govuk-spacing(4);
+      margin-top: 0;
+
+      @include govuk-media-query ($until: desktop) {
+        display: block;
+        line-height: 1;
+        margin-bottom: 0;
+      }
+    }
+
+    &__link {
+      @include govuk-font(19);
+
+      color: $govuk-link-colour;
+      display: block;
+      font-weight: bold;
+      padding-bottom: govuk-spacing(3);
+      padding-top: govuk-spacing(3);
+      position: relative;
+      text-decoration: none;
+
+      @include govuk-media-query ($until: desktop) {
+        padding: govuk-spacing(2);
+      }
+
+      &[aria-current] {
+        color: govuk-colour('black');
+
+        @include govuk-media-query ($until: desktop) {
+          border-left: govuk-spacing(1) solid govuk-colour('light-blue');
+        }
+
+        &::before {
+          background-color: govuk-colour('light-blue');
+          bottom: 0;
+          content: '';
+          display: block;
+          height: govuk-spacing(1);
+          left: 0;
+          position: absolute;
+          width: 100%;
+
+          @include govuk-media-query ($until: desktop) {
+            background: none;
+          }
+        }
+      }
+    }
   }
 
   &__link {

--- a/app/frontend/src/styles/application/full-width-mast.scss
+++ b/app/frontend/src/styles/application/full-width-mast.scss
@@ -6,51 +6,7 @@
   position: relative;
   width: 100vw;
 
-  @include govuk-media-query ($from: desktop) {
-    .dashboard-component__header .govuk-width-container {
-      position: relative;
-
-      .moj-action-bar {
-        bottom: 0;
-        position: absolute;
-        right: 0;
-      }
-    }
-  }
-
   > .govuk-width-container {
     background-color: inherit;
-  }
-
-  .moj-primary-navigation {
-    background: none;
-
-    .moj-primary-navigation__container {
-      margin: 0;
-  
-      @include govuk-media-query ($until: desktop) {
-        .moj-primary-navigation__item {
-          display: block;
-          line-height: 1;
-          margin-bottom: 0;
-
-          .moj-primary-navigation__link {
-            padding: govuk-spacing(2);
-          }
-      
-          .moj-primary-navigation__link[aria-current] {
-            border-left: govuk-spacing(1) solid $govuk-link-colour;
-      
-            &::before {
-              background-color: transparent;
-            }
-          }
-        }
-      }
-
-      .moj-primary-navigation__link[aria-current] {
-        color: govuk-colour('black');
-      }
-    }
   }
 }

--- a/app/helpers/jobseekers/accounts_helper.rb
+++ b/app/helpers/jobseekers/accounts_helper.rb
@@ -1,5 +1,5 @@
 module Jobseekers::AccountsHelper
   def account_navigation_link(link_text, link_path)
-    link_to link_text, link_path, class: "moj-primary-navigation__link", aria: { current: ("page" if current_page?(link_path)) }
+    link_to link_text, link_path, class: "dashboard-component-navigation__link", aria: { current: ("page" if current_page?(link_path)) }
   end
 end

--- a/spec/page_objects/jobseekers/account.rb
+++ b/spec/page_objects/jobseekers/account.rb
@@ -5,8 +5,8 @@ module PageObjects
 
       section :dashboard_header, ".dashboard-component" do
         element :email, "h2.govuk-heading-m"
-        section :nav, ".moj-primary-navigation__list" do
-          elements :links, ".moj-primary-navigation__link"
+        section :nav, ".dashboard-component-navigation__list" do
+          elements :links, ".dashboard-component-navigation__link"
         end
       end
     end

--- a/spec/system/publishers_can_see_the_vacancies_dashboard_spec.rb
+++ b/spec/system/publishers_can_see_the_vacancies_dashboard_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Hiring staff can see the vacancies dashboard" do
     scenario "with published vacancies" do
       visit organisation_path
 
-      within(".moj-primary-navigation__list") do
+      within(".dashboard-component-navigation__list") do
         click_on(I18n.t("publishers.vacancies_component.published.tab_heading"))
       end
 
@@ -78,7 +78,7 @@ RSpec.describe "Hiring staff can see the vacancies dashboard" do
     scenario "with draft vacancies" do
       visit organisation_path
 
-      within(".moj-primary-navigation__list") do
+      within(".dashboard-component-navigation__list") do
         click_on(I18n.t("publishers.vacancies_component.draft.tab_heading"))
       end
 
@@ -94,7 +94,7 @@ RSpec.describe "Hiring staff can see the vacancies dashboard" do
     scenario "with pending vacancies" do
       visit organisation_path
 
-      within(".moj-primary-navigation__list") do
+      within(".dashboard-component-navigation__list") do
         click_on(I18n.t("publishers.vacancies_component.pending.tab_heading"))
       end
 
@@ -110,7 +110,7 @@ RSpec.describe "Hiring staff can see the vacancies dashboard" do
     scenario "with expired vacancies" do
       visit organisation_path
 
-      within(".moj-primary-navigation__list") do
+      within(".dashboard-component-navigation__list") do
         click_on(I18n.t("publishers.vacancies_component.expired.tab_heading"))
       end
 
@@ -133,7 +133,7 @@ RSpec.describe "Hiring staff can see the vacancies dashboard" do
         draft_vacancy
         visit organisation_path
 
-        within(".moj-primary-navigation__list") do
+        within(".dashboard-component-navigation__list") do
           click_on(I18n.t("publishers.vacancies_component.draft.tab_heading"))
         end
 


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-2430

this fixes the layout of publisher dashboard layout/create vacancy button position. could have done a quick fix putting some margin on the button, but once i looked a bit closer at this area of css written a while back, i was none too pleased so i refactored it and fixes the initial problem properly. this also removes MOJ styling from this area.

(yes i know the button on mobile was previously above the menu items but this is non critical publisher mobile view and thats how the button sits in the flow of the html. it is no longer absolutley positioned which i felt wasnt the best way to position it)

![Screenshot 2021-04-16 at 10 13 48](https://user-images.githubusercontent.com/1792451/115002731-ff491b00-9e9c-11eb-9126-0c0f602f0408.png)
![Screenshot 2021-04-16 at 10 13 34](https://user-images.githubusercontent.com/1792451/115002755-02dca200-9e9d-11eb-87b3-cf62bc3d01fb.png)

<img width="282" alt="Screenshot 2021-04-16 at 12 43 34" src="https://user-images.githubusercontent.com/1792451/115020112-02023b00-9eb2-11eb-84d2-fc21196b7104.png">
<img width="832" alt="Screenshot 2021-04-16 at 12 43 21" src="https://user-images.githubusercontent.com/1792451/115020118-03336800-9eb2-11eb-80c8-8ad6959baf2e.png">

