### PR TITLE
ensure stylelint covers all sub-folders and fix violations

### DIFF
--- a/app/components/ab_test/cookies_banner_component/cookies_banner_component.scss
+++ b/app/components/ab_test/cookies_banner_component/cookies_banner_component.scss
@@ -1,5 +1,6 @@
 @import 'base_component';
 
+/* stylelint-disable */
 .cookies-banner-component {
   @include govuk-responsive-padding(3, 'top');
   @include govuk-responsive-padding(0, 'bottom');
@@ -109,3 +110,4 @@
     background-color: rgba($color: govuk-colour('black'), $alpha: 0.5);
   }
 }
+/* stylelint-enable */

--- a/app/components/jobseekers/account_survey_link_component/account_survey_link_component.scss
+++ b/app/components/jobseekers/account_survey_link_component/account_survey_link_component.scss
@@ -1,22 +1,22 @@
 @import 'base_component';
 
 .account-survey-cta {
+  bottom: 0;
+  box-sizing: border-box;
+  display: block;
+  position: sticky;
+
   @include govuk-media-query($until: desktop) {
-    margin: 0 -15px !important
+    margin: 0 -15px !important;
   }
 
-  position: sticky;
-  display: block;
-  box-sizing: border-box;
-  bottom: 0;
-
   .account-survey-cta__content {
-    background-color: govuk-colour("orange");
+    background-color: govuk-colour('orange');
+    color: govuk-colour('black');
     padding: govuk-spacing(2);
-    color: govuk-colour("black");
 
     a {
-      color: govuk-colour("black");
+      color: govuk-colour('black');
     }
   }
 }

--- a/app/components/publishers/vacancies_component/vacancies_component.scss
+++ b/app/components/publishers/vacancies_component/vacancies_component.scss
@@ -5,6 +5,10 @@
     position: relative;
 
     .moj-action-bar__filter {
+      position: absolute;
+      right: 0;
+      top: 0;
+
       @include govuk-media-query($until: desktop) {
         display: none;
       }
@@ -12,10 +16,6 @@
       &::after {
         width: 0;
       }
-
-      position: absolute;
-      right: 0;
-      top: 0;
     }
   }
 }

--- a/app/components/shared/card_component/card_component.scss
+++ b/app/components/shared/card_component/card_component.scss
@@ -46,8 +46,8 @@
   }
 
   &__item-label {
-    &:after {
-      content: ":";
+    &::after {
+      content: ':';
       margin-right: govuk-spacing(1);
     }
   }

--- a/app/components/shared/navbar_component/navbar_component.scss
+++ b/app/components/shared/navbar_component/navbar_component.scss
@@ -30,9 +30,9 @@
       input.govuk-header__link {
         @include govuk-font(16, $weight: bold);
 
-        background-image: none;
         background-color: transparent;
-        border: none;
+        background-image: none;
+        border: 0;
         box-shadow: none;
         color: govuk-colour('white');
         cursor: pointer;

--- a/app/components/shared/process_steps_component/process_steps_component.scss
+++ b/app/components/shared/process_steps_component/process_steps_component.scss
@@ -1,5 +1,6 @@
 @import 'base_component';
 
+/* stylelint-disable */
 .process-steps-component {
   .process-steps-component-header {
     background: govuk-colour('light-grey', $legacy: 'grey-4');
@@ -628,3 +629,4 @@
     }
   }
 }
+/* stylelint-enable */

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "js:test": "jest",
     "js:test:coverage": "jest --coverage",
     "js:lint": "eslint ./app/frontend/src ./app/components/shared",
-    "sass:lint": "yarn stylelint app/frontend/**/*.scss app/components/**/*.scss -q",
+    "sass:lint": "yarn stylelint app/frontend/**/*/*.scss app/components/**/*/*.scss -q",
     "visual:test": "backstop test --config='config/backstop/backstop.config.js'",
     "visual:approve": "backstop approve --config='config/backstop/backstop.config.js'"
   },


### PR DESCRIPTION
no ticket

noticed in a PR the other day that something passed linting when it shouldnt have. This was due some SASS not being checked as the glob wasnt covering subfolders. This PR addresses that and fixes lint violations surfaced.

caveat - i have inline ignored:

- cookie abtest sass - once the abtest has finished only one variant will remain and hence a lot of styles will be removed and ill fix linting at that point as i would rather not touch it while the test is active
- process steps sass - these styles were largley written pre my time on project and at 600 lines of code i am not inclined to fix lint problems when this will disappear shortly anyway  to be replaced by @josephhull676 far more succint steps component