### PR TITLE
[TEVA-2058] Print a job application

### DIFF
--- a/app/components/filters_component/filters_component.html.slim
+++ b/app/components/filters_component/filters_component.html.slim
@@ -12,7 +12,7 @@
           button.govuk-link.govuk-link--no-visited-state.filters-component--show-mobile-open id="return-to-results"
             = t("shared.filter_group.return_to_results")
         - if options[:close_all]
-          button.govuk-link.govuk-link--no-visited-state.filters-component__heading-close-all id="close-all-groups" class="close-all"
+          button.govuk-link.govuk-link--no-visited-state.filters-component__heading-close-all.js-action id="close-all-groups" class="close-all"
             = t("shared.filter_group.close_all_filter_groups")
 
   .filters-component__remove

--- a/app/frontend/src/application/publishers/init.js
+++ b/app/frontend/src/application/publishers/init.js
@@ -1,3 +1,8 @@
 import './uploadDocuments/uploadDocuments';
 import './deleteDocument';
 import '../../components/form/form';
+import { initTriggerElements } from '../../components/printPage/printPage';
+
+document.addEventListener('DOMContentLoaded', () => {
+  initTriggerElements('.print-application');
+});

--- a/app/frontend/src/components/printPage/printPage.js
+++ b/app/frontend/src/components/printPage/printPage.js
@@ -1,0 +1,17 @@
+import './printPage.scss';
+
+export const initTriggerElements = (selector) => Array.from(document.querySelectorAll(selector)).forEach((el) => {
+  printPage.addTriggerEvent(el);
+});
+
+export const addTriggerEvent = (el) => el.addEventListener('click', () => printPage.printHandler());
+
+export const printHandler = () => window.print();
+
+const printPage = {
+  initTriggerElements,
+  addTriggerEvent,
+  printHandler,
+};
+
+export default printPage;

--- a/app/frontend/src/components/printPage/printPage.scss
+++ b/app/frontend/src/components/printPage/printPage.scss
@@ -1,0 +1,11 @@
+@media print {
+  .govuk-header,
+  .govuk-breadcrumbs,
+  .govuk-footer {
+    display: none;
+  }
+
+  .print-page-content {
+    display: block;
+  }
+}

--- a/app/frontend/src/components/printPage/printPage.test.js
+++ b/app/frontend/src/components/printPage/printPage.test.js
@@ -1,0 +1,27 @@
+import printPage, { initTriggerElements, addTriggerEvent } from './printPage';
+
+describe('printPage', () => {
+  document.body.innerHTML = '<button id="print-me">print</button>';
+
+  const button = document.getElementById('print-me');
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('calls addTriggerEvent', () => {
+    printPage.addTriggerEvent = jest.fn();
+    const triggerMock = jest.spyOn(printPage, 'addTriggerEvent');
+    initTriggerElements('#print-me');
+    expect(triggerMock).toHaveBeenCalled();
+  });
+
+  test('calls printHandler when trigger element clicked', () => {
+    printPage.printHandler = jest.fn();
+
+    const handlerMock = jest.spyOn(printPage, 'printHandler');
+    addTriggerEvent(button);
+    button.dispatchEvent(new Event('click'));
+    expect(handlerMock).toHaveBeenCalled();
+  });
+});

--- a/app/frontend/src/styles/application.scss
+++ b/app/frontend/src/styles/application.scss
@@ -43,6 +43,7 @@ $govuk-image-url-function: frontend-image-url;
 @import 'application/publishers/information-summary';
 @import 'application/publishers/interruption-card';
 @import 'application/publishers/og-preview';
+@import 'application/publishers/print-application';
 @import 'application/publishers/publisher';
 @import 'application/publishers/schools-in-your-trust';
 @import 'application/publishers/scrollable-panel';

--- a/app/frontend/src/styles/application/jobseekers/sortable-links.scss
+++ b/app/frontend/src/styles/application/jobseekers/sortable-links.scss
@@ -36,7 +36,7 @@
 }
 
 .sort-results {
-  #vacancies-stats-top {
+  .vacancies-stats-top {
     flex-grow: 1;
     text-align: right;
 
@@ -44,5 +44,10 @@
       float: right;
       margin-top: 0.5rem;
     }
+  }
+
+  .govuk-form-group {
+    align-items: center;
+    display: flex;
   }
 }

--- a/app/frontend/src/styles/application/publishers/print-application.scss
+++ b/app/frontend/src/styles/application/publishers/print-application.scss
@@ -1,0 +1,20 @@
+@media print {
+  .publishers_vacancies_job_applications_show {
+    .job-application-actions,
+    .account-sidebar,
+    .timeline-component,
+    .anchor-link-list {
+      display: none;
+    }
+
+    .review-component__heading {
+      .govuk-link {
+        display:none;
+      }
+    }
+
+    .govuk-accordion__section > div {
+      display: block;
+    }
+  }
+}

--- a/app/frontend/src/styles/base/_utilities.scss
+++ b/app/frontend/src/styles/base/_utilities.scss
@@ -176,3 +176,17 @@
     padding: govuk-spacing(3);
   }
 }
+
+.js-action {
+  display: none;
+}
+
+.js-enabled {
+  .js-action {
+    display: inline-block;
+  }
+}
+
+.print-page-content {
+  display: none;
+}

--- a/app/views/publishers/vacancies/job_applications/show.html.slim
+++ b/app/views/publishers/vacancies/job_applications/show.html.slim
@@ -8,6 +8,9 @@
   .govuk-caption-l class="govuk-!-margin-top-5"
     = t("jobseekers.job_applications.caption", job_title: vacancy.job_title, organisation: vacancy.parent_organisation_name)
 
+  .print-page-content
+    .h2.govuk-heading-l = "#{job_application.first_name} #{job_application.last_name}"
+
   div
     span.govuk-body class="govuk-!-margin-right-5" = t(".status_heading")
     = publisher_job_application_status_tag(job_application.status)
@@ -19,19 +22,20 @@
         = govuk_link_to t("buttons.shortlist"), organisation_job_job_application_shortlist_path(vacancy.id, job_application.id), button: true, class: "govuk-!-margin-right-3"
       - if job_application.submitted? || job_application.shortlisted?
         = govuk_link_to t("buttons.reject"), organisation_job_job_application_reject_path(vacancy.id, job_application.id), button: true, class: "govuk-button--warning govuk-!-margin-right-3"
-      = govuk_link_to t("buttons.download_application"), "#", button: true, class: "govuk-button--secondary"
+      = govuk_link_to t("buttons.print_download_application"), "#", button: true, class: "govuk-button--secondary js-action print-application"
 
-    h2.govuk-heading-m = t(".application_sections.heading")
+    .anchor-link-list
+      h2.govuk-heading-m = t(".application_sections.heading")
 
-    ul.govuk-list
-      li.app-page-navigation__item--em-dash = govuk_link_to t(".personal_details.heading"), "#personal_details_summary", class: "govuk-link govuk-body-s"
-      li.app-page-navigation__item--em-dash = govuk_link_to t(".professional_status.heading"), "#professional_status_summary", class: "govuk-link govuk-body-s"
-      li.app-page-navigation__item--em-dash = govuk_link_to t(".qualifications.heading"), "#qualifications_summary", class: "govuk-link govuk-body-s"
-      li.app-page-navigation__item--em-dash = govuk_link_to t(".current_role_and_employment_history.heading"), "#employment_history_summary", class: "govuk-link govuk-body-s"
-      li.app-page-navigation__item--em-dash = govuk_link_to t(".personal_statement.heading"), "#personal_statement_summary", class: "govuk-link govuk-body-s"
-      li.app-page-navigation__item--em-dash = govuk_link_to t(".references.heading"), "#references_summary", class: "govuk-link govuk-body-s"
-      li.app-page-navigation__item--em-dash = govuk_link_to t(".ask_for_support.heading"), "#ask_for_support_summary", class: "govuk-link govuk-body-s"
-      li.app-page-navigation__item--em-dash = govuk_link_to t(".declarations.heading"), "#declarations_summary", class: "govuk-link govuk-body-s"
+      ul.govuk-list
+        li.app-page-navigation__item--em-dash = govuk_link_to t(".personal_details.heading"), "#personal_details_summary", class: "govuk-link govuk-body-s"
+        li.app-page-navigation__item--em-dash = govuk_link_to t(".professional_status.heading"), "#professional_status_summary", class: "govuk-link govuk-body-s"
+        li.app-page-navigation__item--em-dash = govuk_link_to t(".qualifications.heading"), "#qualifications_summary", class: "govuk-link govuk-body-s"
+        li.app-page-navigation__item--em-dash = govuk_link_to t(".current_role_and_employment_history.heading"), "#employment_history_summary", class: "govuk-link govuk-body-s"
+        li.app-page-navigation__item--em-dash = govuk_link_to t(".personal_statement.heading"), "#personal_statement_summary", class: "govuk-link govuk-body-s"
+        li.app-page-navigation__item--em-dash = govuk_link_to t(".references.heading"), "#references_summary", class: "govuk-link govuk-body-s"
+        li.app-page-navigation__item--em-dash = govuk_link_to t(".ask_for_support.heading"), "#ask_for_support_summary", class: "govuk-link govuk-body-s"
+        li.app-page-navigation__item--em-dash = govuk_link_to t(".declarations.heading"), "#declarations_summary", class: "govuk-link govuk-body-s"
 
     - unless job_application.status.in?(%w[shortlisted unsuccessful withdrawn])
       ul.app-task-list--no-bullet

--- a/app/views/shared/search/_current_location.html.slim
+++ b/app/views/shared/search/_current_location.html.slim
@@ -1,3 +1,3 @@
-.js-location-finder__link.govuk-body-s
+.js-location-finder__link.govuk-body-s.js-action
   | or
   =< govuk_link_to(t("jobs.filters.use_current_location"), "#", id: "current-location", class: "govuk-link--no-visited-state", data: { loader: loaderElement })

--- a/app/views/vacancies/_sorting_options.html.slim
+++ b/app/views/vacancies/_sorting_options.html.slim
@@ -6,15 +6,16 @@
   = f.hidden_field :phases, value: @jobs_search_form.phases
   = f.hidden_field :working_patterns, value: @jobs_search_form.working_patterns
 
-  = f.govuk_collection_select :jobs_sort,
-    Search::VacancySearchSort.options,
-    :key,
-    :display_name,
-    label: { text: t("jobs.sort_by.label"), size: "s", class: "govuk-label inline govuk-!-margin-right-2", id: "jobs_sort_label" },
-    form_group: { classes: "govuk-!-margin-bottom-0" },
-    class: %w[govuk-input--width-10],
-    disabled: @vacancies.none?
+  .govuk-form-group
+    = f.govuk_collection_select :jobs_sort,
+      Search::VacancySearchSort.options,
+      :key,
+      :display_name,
+      label: { text: t("jobs.sort_by.label"), size: "s", class: "govuk-label govuk-!-margin-right-2", id: "jobs_sort_label" },
+      form_group: { classes: "govuk-!-margin-bottom-0" },
+      class: %w[govuk-input--width-10],
+      disabled: @vacancies.none?
 
-  = f.govuk_submit t("jobs.sort_by.submit"),
-    classes: "govuk-button govuk-!-margin-0 govuk-input--width-5 jobs-sort-submit",
-    disabled: @vacancies.none?
+    = f.govuk_submit t("jobs.sort_by.submit"),
+      classes: "govuk-button govuk-!-margin-0 govuk-input--width-5",
+      disabled: @vacancies.none?

--- a/app/views/vacancies/index.html.slim
+++ b/app/views/vacancies/index.html.slim
@@ -22,7 +22,7 @@
       section.sort-results.sortable-links role="search" aria-label="Sort vacancies"
         = render partial: "sorting_options", locals: { search_criteria: @vacancies_search.active_criteria, sort: @vacancies_search.sort_by }
         - unless @vacancies_search.out_of_bounds?
-          .govuk-body#vacancies-stats-top aria-label="Number of results"
+          .govuk-body.vacancies-stats-top aria-label="Number of results"
             - if @vacancies_search.total_count <= @vacancies_search.per_page
               = t("jobs.number_of_results_one_page_html", count: @vacancies_search.total_count)
             - else

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -21,7 +21,6 @@ en:
     create_account: Create an account
     delete: Delete
     dismiss: Dismiss
-    download_application: Download application
     edit: Edit
     end_listing: End job listing
     extend_deadline: Extend deadline
@@ -30,6 +29,7 @@ en:
     hide_filters: Hide filters
     make_changes: Make changes
     preview_job_listing: Preview job listing
+    print_download_application: Print or download
     reject: Confirm rejection
     resend_email: Resend request
     save_and_continue: Save and continue

--- a/spec/page_objects/vacancy/index.rb
+++ b/spec/page_objects/vacancy/index.rb
@@ -26,7 +26,7 @@ module PageObjects
 
       element :search_button, "input[value='Search']"
       element :sort_field, "#jobs-sort-field"
-      element :stats, "#vacancies-stats-top"
+      element :stats, ".vacancies-stats-top"
       section :filters, PageObjects::Search::Filters, ".filters-form"
       section :pagination, Pagination, "ul.pagination"
       sections :jobs, VacancyRow, "li.vacancy"

--- a/spec/smoke_tests/jobseekers_can_view_homepage_spec.rb
+++ b/spec/smoke_tests/jobseekers_can_view_homepage_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Page availability", js: true, smoke_test: true do
       page.fill_in I18n.t("jobs.filters.keyword"), with: "Maths"
       page.click_on I18n.t("buttons.search")
 
-      if page.has_css?("#vacancies-stats-top")
+      if page.has_css?(".vacancies-stats-top")
         expect(page).to have_content(I18n.t("subscriptions.link.text"))
       else
         expect(page).to have_content(I18n.t("subscriptions.link.no_search_results.link"))

--- a/spec/system/publishers_can_view_a_job_application_spec.rb
+++ b/spec/system/publishers_can_view_a_job_application_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Publishers can view a job application" do
     it "shows the correct calls to action and timeline" do
       expect(show_page.actions).not_to have_css("a", class: "govuk-button", text: I18n.t("buttons.shortlist"))
       expect(show_page.actions).not_to have_css("a", class: "govuk-button--warning", text: I18n.t("buttons.reject"))
-      expect(show_page.actions).to have_css("a", class: "govuk-button--secondary", text: I18n.t("buttons.download_application"))
+      expect(show_page.actions).to have_css("a", class: "govuk-button--secondary", text: I18n.t("buttons.print_download_application"))
 
       expect(show_page.timeline).to have_items(text: I18n.t("jobseekers.job_applications.status_timestamps.rejected"))
       expect(show_page.timeline).not_to have_items(text: I18n.t("jobseekers.job_applications.status_timestamps.shortlisted"))
@@ -39,7 +39,7 @@ RSpec.describe "Publishers can view a job application" do
     it "shows the correct calls to action and timeline" do
       expect(show_page.actions).not_to have_css("a", class: "govuk-button", text: I18n.t("buttons.shortlist"))
       expect(show_page.actions).to have_css("a", class: "govuk-button--warning", text: I18n.t("buttons.reject"))
-      expect(show_page.actions).to have_css("a", class: "govuk-button--secondary", text: I18n.t("buttons.download_application"))
+      expect(show_page.actions).to have_css("a", class: "govuk-button--secondary", text: I18n.t("buttons.print_download_application"))
 
       expect(show_page.timeline).not_to have_items(text: I18n.t("jobseekers.job_applications.status_timestamps.rejected"))
       expect(show_page.timeline).to have_items(text: I18n.t("jobseekers.job_applications.status_timestamps.shortlisted"))
@@ -56,7 +56,7 @@ RSpec.describe "Publishers can view a job application" do
     it "shows the correct calls to action and timeline" do
       expect(show_page.actions).to have_css("a", class: "govuk-button", text: I18n.t("buttons.shortlist"))
       expect(show_page.actions).to have_css("a", class: "govuk-button--warning", text: I18n.t("buttons.reject"))
-      expect(show_page.actions).to have_css("a", class: "govuk-button--secondary", text: I18n.t("buttons.download_application"))
+      expect(show_page.actions).to have_css("a", class: "govuk-button--secondary", text: I18n.t("buttons.print_download_application"))
 
       expect(show_page.timeline).not_to have_items(text: I18n.t("jobseekers.job_applications.status_timestamps.rejected"))
       expect(show_page.timeline).not_to have_items(text: I18n.t("jobseekers.job_applications.status_timestamps.shortlisted"))


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-2058

Front end code for printing application page (or potentially any page). Adds print button JS functionality and basic print stylesheet for printing application via this button or standard ctrl p way. 

![Screenshot 2021-04-19 at 21 05 16](https://user-images.githubusercontent.com/1792451/115296684-2af52b00-a153-11eb-8884-3c13eb294e87.png)

i also took the liberty while i was in JS/no JS territory of fixing a few things in other places:

- hiding elements that are for JS behaviour and make no sense being there if JS is not available for whatever reason
- some non JS positional styling was a little bit broken
