### PR TITLE
Use new CI\CD account to trigger workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,14 +109,14 @@ jobs:
       uses: benc-uk/workflow-dispatch@v1.1
       with:
         workflow: Deploy App to Environment # Workflow name
-        token: ${{ secrets.PERSONAL_TOKEN }}
+        token: ${{ secrets.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
         inputs: '{"environment": "staging", "tag": "${{ env.TAG }}"}'
 
     - name: Wait for Deploy App Workflow for staging
       id: wait_for_deploy_app_staging
       uses: fountainhead/action-wait-for-check@v1.0.0
       with:
-        token: ${{ secrets.PERSONAL_TOKEN }}
+        token: ${{ secrets.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
         checkName: Deploy ${{ env.TAG }} to staging # Job name within workflow
         ref: ${{ github.sha }}
         timeoutSeconds: 720
@@ -140,14 +140,14 @@ jobs:
       uses: benc-uk/workflow-dispatch@v1.1
       with:
         workflow: Smoke Test
-        token: ${{ secrets.PERSONAL_TOKEN }}
+        token: ${{ secrets.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
         inputs: '{"smoke_test_domain": "staging.teaching-vacancies.service.gov.uk", "sha": "${{ github.sha }}"}'
 
     - name: Wait for smoke test
       id: wait_for_smoke_test
       uses: fountainhead/action-wait-for-check@v1.0.0
       with:
-        token: ${{ secrets.PERSONAL_TOKEN }}
+        token: ${{ secrets.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
         checkName: Smoke Test staging.teaching-vacancies.service.gov.uk ${{ github.sha }}
         ref: ${{ github.sha }}
         timeoutSeconds: 300
@@ -162,14 +162,14 @@ jobs:
       uses: benc-uk/workflow-dispatch@v1.1
       with:
         workflow: Deploy App to Environment # Workflow name
-        token: ${{ secrets.PERSONAL_TOKEN }}
+        token: ${{ secrets.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
         inputs: '{"environment": "production", "tag": "${{ env.TAG }}"}'
 
     - name: Wait for Deploy App Workflow for production
       id: wait_for_deploy_app_production
       uses: fountainhead/action-wait-for-check@v1.0.0
       with:
-        token: ${{ secrets.PERSONAL_TOKEN }}
+        token: ${{ secrets.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
         checkName: Deploy ${{ env.TAG }} to production # Job name within workflow
         ref: ${{ github.sha }}
         timeoutSeconds: 720

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -110,14 +110,14 @@ jobs:
       uses: benc-uk/workflow-dispatch@v1.1
       with:
         workflow: Deploy App to Environment # Workflow name
-        token: ${{ secrets.PERSONAL_TOKEN }}
+        token: ${{ secrets.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
         inputs: '{"environment": "${{ env.BRANCH }}", "tag": "${{ env.TAG }}"}'
 
     - name: Wait for Deploy App Workflow
       id: wait_for_deploy_app
       uses: fountainhead/action-wait-for-check@v1.0.0
       with:
-        token: ${{ secrets.PERSONAL_TOKEN }}
+        token: ${{ secrets.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
         checkName: Deploy ${{ env.TAG }} to ${{ env.BRANCH }} # Job name within workflow
         ref: ${{ github.sha  }}
         timeoutSeconds: 720
@@ -127,14 +127,14 @@ jobs:
       uses: benc-uk/workflow-dispatch@v1.1
       with:
         workflow: Smoke Test
-        token: ${{ secrets.PERSONAL_TOKEN }}
+        token: ${{ secrets.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
         inputs: '{"smoke_test_domain": "${{ env.BRANCH }}.teaching-vacancies.service.gov.uk", "sha": "${{ github.sha }}"}'
 
     - name: Wait for smoke test
       id: wait_for_smoke_test
       uses: fountainhead/action-wait-for-check@v1.0.0
       with:
-        token: ${{ secrets.PERSONAL_TOKEN }}
+        token: ${{ secrets.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
         checkName: Smoke Test ${{ env.BRANCH }}.teaching-vacancies.service.gov.uk ${{ github.sha }}
         ref: ${{ github.sha }}
         timeoutSeconds: 300

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -39,7 +39,7 @@ jobs:
       id: wait_for_deploy_app
       uses: fountainhead/action-wait-for-check@v1.0.0
       with:
-       token: ${{ secrets.PERSONAL_TOKEN }}
+       token: ${{ secrets.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
        checkName: Create review app ${{ github.event.pull_request.head.sha}}
        ref: ${{ github.event.pull_request.head.sha }}
        timeoutSeconds: 1800

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -48,14 +48,14 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1.1
         with:
           workflow: Deploy App to Environment # Workflow name
-          token: ${{ secrets.PERSONAL_TOKEN }}
+          token: ${{ secrets.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
           inputs: '{"environment": "${{ github.event.inputs.environment }}", "tag": "${{ steps.get_docker_tag.outputs.tag }}"}'
 
       - name: Wait for Deploy App Workflow
         id: wait_for_deploy_app
         uses: fountainhead/action-wait-for-check@v1.0.0
         with:
-          token: ${{ secrets.PERSONAL_TOKEN }}
+          token: ${{ secrets.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
           checkName: Deploy app to environment # Job name within workflow
           ref: ${{ github.sha }}
           timeoutSeconds: 300

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -114,7 +114,7 @@ jobs:
     - name: Trigger Deploy App Workflow for review
       uses: benc-uk/workflow-dispatch@v1.1
       with:
-        token: ${{ secrets.PERSONAL_TOKEN }}
+        token: ${{ secrets.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
         ref: ${{ steps.tag_version.outputs.new_tag }}
         workflow: Deploy App to Environment # Workflow name
         inputs: '{"environment": "${{ env.ENVIRONMENT }}", "tag": "${{ env.TAG }}"}'
@@ -123,7 +123,7 @@ jobs:
       id: wait_for_deploy_app
       uses: fountainhead/action-wait-for-check@v1.0.0
       with:
-        token: ${{ secrets.PERSONAL_TOKEN }}
+        token: ${{ secrets.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
         checkName: Deploy ${{ env.TAG }} to ${{ env.ENVIRONMENT }} # Job name within workflow
         ref: ${{ steps.tag_version.outputs.new_tag }}
         timeoutSeconds: 1200
@@ -136,7 +136,7 @@ jobs:
     - name: Post Sticky Pull Request Comment
       uses: marocchino/sticky-pull-request-comment@v2
       with:
-        GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
         message: |
           Review app deployed to <https://teaching-vacancies-review-pr-${{ github.event.number }}.london.cloudapps.digital>
 
@@ -144,7 +144,7 @@ jobs:
       uses: benc-uk/workflow-dispatch@v1.1
       with:
         workflow: Smoke Test
-        token: ${{ secrets.PERSONAL_TOKEN }}
+        token: ${{ secrets.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
         inputs: '{"smoke_test_domain": "teaching-vacancies-review-pr-${{ github.event.number }}.london.cloudapps.digital", "sha": "${{ github.event.pull_request.head.sha }}"}'
         ref: ${{ steps.tag_version.outputs.new_tag }}
 
@@ -152,7 +152,7 @@ jobs:
       id: wait_for_smoke_test
       uses: fountainhead/action-wait-for-check@v1.0.0
       with:
-        token: ${{ secrets.PERSONAL_TOKEN }}
+        token: ${{ secrets.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
         checkName: Smoke Test teaching-vacancies-review-pr-${{ github.event.number }}.london.cloudapps.digital ${{ github.event.pull_request.head.sha }}
         ref: ${{ steps.tag_version.outputs.new_tag }}
         timeoutSeconds: 300


### PR DESCRIPTION
## Jira ticket URL

- Just add the ticket number to the end:

https://dfedigital.atlassian.net/browse/TEVA-2005

This PR can only merged after "TEVA-2078-migrate-to-github-container-registry" has merged to master

## Changes in this PR:

changed `${{ secrets.PERSONAL_TOKEN }}` to `${{ secrets.GH_CONTAINER_REGISTRY_TOKEN }}` - this allows us to use a dedicated github service_account to run the CI\CD workflow and trigger workflow_dispatch. The service_account's token is stored as github_secrets

