### PR TITLE
Update cutoff date in Gdrive deletion task

### DIFF
--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -50,7 +50,7 @@ end
 namespace :google_drive do
   desc "Delete old documents"
   task :delete_old_documents, [:commit] => [:environment] do |_task, args|
-    delete_before = Date.new(2020, 0o4, 15)
+    delete_before = Date.new(2020, 0o5, 15)
 
     documents = Document.includes(:vacancy).where("documents.created_at <?", delete_before)
 


### PR DESCRIPTION
We need to prune even more old documents until we have a long-term
solution in place. This updates the deletion task to delete an extra
month's worth of documents.