### PR TITLE
Fix margin in warning banner on confirm withdraw page

### DIFF
--- a/app/views/jobseekers/job_applications/confirm_withdraw.html.slim
+++ b/app/views/jobseekers/job_applications/confirm_withdraw.html.slim
@@ -17,7 +17,7 @@
           = f.govuk_radio_button :withdraw_reason, :other
 
         = govuk_notification_banner title: t("banners.warning"), classes: "govuk-notification-banner--warning" do
-          p.govuk-body = t(".description")
+          = t(".description")
 
         = f.govuk_submit t("buttons.withdraw_application") do
           = f.govuk_submit t("buttons.cancel"), secondary: true


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-2424

## Changes in this PR
- Remove `p.govuk-body` inside notification banner to remove the margin

## Product sign off
- [x] Looks good!