### PR TITLE
Jobseekers can only apply to vacancies where enable_job_applications is true

### DIFF
--- a/app/components/jobseekers/vacancy_details_component/vacancy_details_component.html.slim
+++ b/app/components/jobseekers/vacancy_details_component/vacancy_details_component.html.slim
@@ -32,17 +32,18 @@ section#job-details class="govuk-!-margin-bottom-5"
     h4.govuk-heading-s = t("jobs.benefits")
     p = @vacancy.benefits
 
-  - if @vacancy.how_to_apply.present?
-    h4.govuk-heading-s = t("jobs.applying_for_the_job")
-    p = @vacancy.how_to_apply
-
-  - if @vacancy.application_link.present?
-    = govuk_link_to t("jobs.apply"), new_job_interest_path(@vacancy.id), target: "_blank", class: "vacancy-apply-link govuk-!-margin-bottom-5", button: true, "aria-label": t("jobs.aria_labels.apply_link")
-
-  - elsif JobseekerApplicationsFeature.enabled?
+  - if JobseekerApplicationsFeature.enabled? && @vacancy.enable_job_applications?
     h4.govuk-heading-s = t("jobseekers.job_applications.applying_for_the_role_heading")
     p = t("jobseekers.job_applications.applying_for_the_role_paragraph")
-    = govuk_button_to t("jobseekers.job_applications.apply"), new_jobseekers_job_job_application_path(@vacancy.id), method: :get
+    = govuk_link_to t("jobseekers.job_applications.apply"), new_jobseekers_job_job_application_path(@vacancy.id), button: true
+
+  - else
+    - if @vacancy.how_to_apply.present?
+      h4.govuk-heading-s = t("jobs.applying_for_the_job")
+      p = @vacancy.how_to_apply
+
+    - if @vacancy.application_link.present?
+      = govuk_link_to t("jobs.apply"), new_job_interest_path(@vacancy.id), target: "_blank", class: "vacancy-apply-link govuk-!-margin-bottom-5", button: true, "aria-label": t("jobs.aria_labels.apply_link")
 
   - if @vacancy.documents.any?
     section#supporting-documents

--- a/app/controllers/jobseekers/job_applications_controller.rb
+++ b/app/controllers/jobseekers/job_applications_controller.rb
@@ -1,5 +1,6 @@
 class Jobseekers::JobApplicationsController < Jobseekers::BaseController
-  before_action :redirect_if_job_application_exists, only: %i[new create new_quick_apply quick_apply]
+  before_action :raise_unless_vacancy_enable_job_applications,
+                :redirect_if_job_application_exists, only: %i[new create new_quick_apply quick_apply]
 
   helper_method :job_application, :review_form, :vacancy, :withdraw_form
 
@@ -98,6 +99,10 @@ class Jobseekers::JobApplicationsController < Jobseekers::BaseController
                   warning: t("messages.jobseekers.job_applications.already_exists.draft_html",
                              job_title: vacancy.job_title, link: jobseekers_job_application_review_path(job_application))
     end
+  end
+
+  def raise_unless_vacancy_enable_job_applications
+    raise ActionController::RoutingError, "Cannot apply for this vacancy" unless vacancy.enable_job_applications?
   end
 
   def review_form

--- a/spec/components/jobseekers/vacancy_details_component_spec.rb
+++ b/spec/components/jobseekers/vacancy_details_component_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Jobseekers::VacancyDetailsComponent, type: :component do
   let(:vacancy_presenter) { VacancyPresenter.new(vacancy) }
 
   before do
+    allow(JobseekerApplicationsFeature).to receive(:enabled?).and_return(true)
     vacancy.organisation_vacancies.create(organisation: organisation)
     render_inline(described_class.new(vacancy: vacancy_presenter))
   end
@@ -52,7 +53,9 @@ RSpec.describe Jobseekers::VacancyDetailsComponent, type: :component do
     end
   end
 
-  context "when how_to_apply is present" do
+  context "when vacancy does not enable job applications" do
+    let(:vacancy) { create(:vacancy, :no_tv_applications) }
+
     it "renders the how_to_apply label" do
       expect(rendered_component).to include(I18n.t("jobs.applying_for_the_job"))
     end
@@ -60,27 +63,21 @@ RSpec.describe Jobseekers::VacancyDetailsComponent, type: :component do
     it "renders the how_to_apply" do
       expect(rendered_component).to include(vacancy_presenter.how_to_apply)
     end
-  end
 
-  context "when how_to_apply is not present" do
-    let(:vacancy) { create(:vacancy, how_to_apply: "") }
-
-    it "does not render the how_to_apply label" do
-      expect(rendered_component).not_to include(I18n.t("jobs.applying_for_the_job"))
-    end
-  end
-
-  context "when an application link is present" do
     it "renders the application link" do
       expect(rendered_component).to include(Rails.application.routes.url_helpers.new_job_interest_path(vacancy.id))
     end
   end
 
-  context "when an application link is not present" do
-    let(:vacancy) { create(:vacancy, application_link: "") }
+  context "when vacancy enables job applications" do
+    it "renders the how_to_apply label and description" do
+      expect(rendered_component).to include(I18n.t("jobseekers.job_applications.applying_for_the_role_heading"))
+      expect(rendered_component).to include(I18n.t("jobseekers.job_applications.applying_for_the_role_paragraph"))
+    end
 
-    it "does not render the application link" do
-      expect(rendered_component).not_to include(I18n.t("jobs.apply"))
+    it "renders the application link" do
+      expect(rendered_component)
+        .to include(Rails.application.routes.url_helpers.new_jobseekers_job_job_application_path(vacancy.id))
     end
   end
 end

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -6,7 +6,6 @@ FactoryBot.define do
 
     job_location { "at_one_school" }
     about_school { Faker::Lorem.paragraph(sentence_count: 4) }
-    application_link { Faker::Internet.url(host: "example.com") }
     enable_job_applications { true }
     benefits { Faker::Lorem.paragraph(sentence_count: 4) }
     contact_email { Faker::Internet.email }
@@ -18,7 +17,6 @@ FactoryBot.define do
     expires_on { Faker::Time.forward(days: 14) }
     expires_at { expires_on&.change(sec: 0) }
     hired_status { nil }
-    how_to_apply { Faker::Lorem.paragraph(sentence_count: 4) }
     job_summary { Faker::Lorem.paragraph(sentence_count: 4) }
     job_roles { [:teacher] }
     job_title { Faker::Lorem.sentence[1...30].strip }
@@ -34,6 +32,12 @@ FactoryBot.define do
     subjects { SUBJECT_OPTIONS.sample(2).map(&:first).sort! }
     suitable_for_nqt { "no" }
     working_patterns { %w[full_time] }
+
+    trait :no_tv_applications do
+      application_link { Faker::Internet.url(host: "example.com") }
+      enable_job_applications { false }
+      how_to_apply { Faker::Lorem.paragraph(sentence_count: 4) }
+    end
 
     trait :central_office do
       job_location { "central_office" }

--- a/spec/requests/jobseekers/job_applications_spec.rb
+++ b/spec/requests/jobseekers/job_applications_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Job applications" do
   end
 
   describe "GET #new" do
-    context "when the job is not listed" do
+    context "when the job is not live" do
       let(:vacancy) { create(:vacancy, :expired, organisation_vacancies_attributes: [{ organisation: build(:school) }]) }
 
       it "does not trigger a `vacancy_apply_clicked` event and returns not found" do
@@ -20,7 +20,7 @@ RSpec.describe "Job applications" do
       end
     end
 
-    context "when the job is listed" do
+    context "when the job is live" do
       it "triggers a `vacancy_apply_clicked` event" do
         expect { get new_jobseekers_job_job_application_path(vacancy.id) }
           .to have_triggered_event(:vacancy_apply_clicked).with_data(vacancy_id: vacancy.id)
@@ -43,11 +43,20 @@ RSpec.describe "Job applications" do
             .to redirect_to(new_quick_apply_jobseekers_job_job_application_path(new_vacancy.id))
         end
       end
+
+      context "when the vacancy does not enable job applications" do
+        let(:vacancy) { create(:vacancy, enable_job_applications: false, organisation_vacancies_attributes: [{ organisation: build(:school) }]) }
+
+        it "raises an error" do
+          expect { get new_jobseekers_job_job_application_path(vacancy.id) }
+            .to raise_error(ActionController::RoutingError, /Cannot apply for this vacancy/)
+        end
+      end
     end
   end
 
   describe "POST #create" do
-    context "when the job is not listed" do
+    context "when the job is not live" do
       let(:vacancy) { create(:vacancy, :expired, organisation_vacancies_attributes: [{ organisation: build(:school) }]) }
 
       it "does not create a job application and returns not found" do
@@ -62,6 +71,15 @@ RSpec.describe "Job applications" do
 
       it "redirects to `jobseekers_job_applications_path`" do
         expect(post(jobseekers_job_job_application_path(vacancy.id))).to redirect_to(jobseekers_job_applications_path)
+      end
+    end
+
+    context "when the vacancy does not enable job applications" do
+      let(:vacancy) { create(:vacancy, enable_job_applications: false, organisation_vacancies_attributes: [{ organisation: build(:school) }]) }
+
+      it "raises an error" do
+        expect { post(jobseekers_job_job_application_path(vacancy.id)) }
+          .to raise_error(ActionController::RoutingError, /Cannot apply for this vacancy/)
       end
     end
 
@@ -90,6 +108,15 @@ RSpec.describe "Job applications" do
       it "raises an error" do
         expect { get new_quick_apply_jobseekers_job_job_application_path(vacancy.id) }
           .to raise_error(ActionController::RoutingError, /non-draft/)
+      end
+    end
+
+    context "when the vacancy does not enable job applications" do
+      let(:vacancy) { create(:vacancy, enable_job_applications: false, organisation_vacancies_attributes: [{ organisation: build(:school) }]) }
+
+      it "raises an error" do
+        expect { get new_jobseekers_job_job_application_path(vacancy.id) }
+          .to raise_error(ActionController::RoutingError, /Cannot apply for this vacancy/)
       end
     end
 
@@ -131,6 +158,15 @@ RSpec.describe "Job applications" do
       it "raises an error" do
         expect { post quick_apply_jobseekers_job_job_application_path(vacancy.id) }
           .to raise_error(ActionController::RoutingError, /non-draft/)
+      end
+    end
+
+    context "when the vacancy does not enable job applications" do
+      let(:vacancy) { create(:vacancy, enable_job_applications: false, organisation_vacancies_attributes: [{ organisation: build(:school) }]) }
+
+      it "raises an error" do
+        expect { post quick_apply_jobseekers_job_job_application_path(vacancy.id) }
+          .to raise_error(ActionController::RoutingError, /Cannot apply for this vacancy/)
       end
     end
 

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -132,8 +132,11 @@ module VacancyHelpers
     expect(page).to have_content(vacancy.contact_email)
     expect(page).to have_content(vacancy.contact_number)
     expect(page.html).to include(vacancy.school_visits)
-    expect(page.html).to include(vacancy.how_to_apply)
-    expect(page).to have_content(vacancy.application_link)
+
+    unless vacancy.enable_job_applications?
+      expect(page.html).to include(vacancy.how_to_apply)
+      expect(page).to have_content(vacancy.application_link)
+    end
 
     expect(page.html).to include(vacancy.job_summary)
     expect(page.html).to include(vacancy.about_school)
@@ -157,7 +160,7 @@ module VacancyHelpers
     end
 
     expect(page.html).to include(vacancy.school_visits)
-    expect(page.html).to include(vacancy.how_to_apply)
+    expect(page.html).to include(vacancy.how_to_apply) unless vacancy.enable_job_applications?
 
     expect(page.html).to include(vacancy.job_summary)
     expect(page.html).to include(vacancy.about_school)
@@ -172,7 +175,11 @@ module VacancyHelpers
       expect(page.html).to include(vacancy.experience)
     end
 
-    expect(page).to have_link(I18n.t("jobs.apply"), href: new_job_interest_path(vacancy.id))
+    if vacancy.enable_job_applications?
+      expect(page).to have_link(I18n.t("jobseekers.job_applications.apply"), href: new_jobseekers_job_job_application_path(vacancy.id))
+    else
+      expect(page).to have_link(I18n.t("jobs.apply"), href: new_job_interest_path(vacancy.id))
+    end
   end
 
   def expect_schema_property_to_match_value(key, value)

--- a/spec/system/hiring_staff_can_edit_a_published_vacancy_as_a_school_spec.rb
+++ b/spec/system/hiring_staff_can_edit_a_published_vacancy_as_a_school_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe "Hiring staff can edit a vacancy" do
   context "when editing a published vacancy" do
     let(:vacancy) do
       VacancyPresenter.new(
-        create(:vacancy, :complete, job_location: "at_one_school",
-                                    job_roles: %i[teacher sen_specialist], working_patterns: %w[full_time part_time],
-                                    publish_on: Date.current, expires_on: Time.zone.tomorrow),
+        create(:vacancy, :complete, :no_tv_applications, job_location: "at_one_school",
+                                                         job_roles: %i[teacher sen_specialist], working_patterns: %w[full_time part_time],
+                                                         publish_on: Date.current, expires_on: Time.zone.tomorrow),
       )
     end
 
@@ -247,7 +247,7 @@ RSpec.describe "Hiring staff can edit a vacancy" do
       context "when the job post has already been published" do
         context "when the publication date is in the past" do
           scenario "renders the publication date as text and does not allow editing" do
-            vacancy = build(:vacancy, :published, slug: "test-slug", publish_on: 1.day.ago)
+            vacancy = build(:vacancy, :published, :no_tv_applications, slug: "test-slug", publish_on: 1.day.ago)
             vacancy.save(validate: false)
             vacancy.organisation_vacancies.create(organisation: school)
             vacancy = VacancyPresenter.new(vacancy)
@@ -268,7 +268,7 @@ RSpec.describe "Hiring staff can edit a vacancy" do
 
         context "when the publication date is in the future" do
           scenario "renders the publication date as text and allows editing" do
-            vacancy = create(:vacancy, :published, publish_on: Time.current + 3.days)
+            vacancy = create(:vacancy, :published, :no_tv_applications, publish_on: Time.current + 3.days)
             vacancy.organisation_vacancies.create(organisation: school)
             vacancy = VacancyPresenter.new(vacancy)
             visit edit_organisation_job_path(vacancy.id)

--- a/spec/system/hiring_staff_can_publish_a_vacancy_as_a_school_spec.rb
+++ b/spec/system/hiring_staff_can_publish_a_vacancy_as_a_school_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Creating a vacancy" do
   context "creating a new vacancy" do
     let(:suitable_for_nqt) { "no" }
     let(:vacancy) do
-      VacancyPresenter.new(build(:vacancy, :complete,
+      VacancyPresenter.new(build(:vacancy, :complete, :no_tv_applications,
                                  job_roles: %i[teacher sen_specialist],
                                  suitable_for_nqt: suitable_for_nqt,
                                  working_patterns: %w[full_time part_time],
@@ -594,7 +594,7 @@ RSpec.describe "Creating a vacancy" do
 
       context "when a start date has been given" do
         scenario "lists all the vacancy details correctly" do
-          vacancy = create(:vacancy, :complete, :draft)
+          vacancy = create(:vacancy, :complete, :draft, :no_tv_applications)
           vacancy.organisation_vacancies.create(organisation: school)
 
           vacancy = VacancyPresenter.new(vacancy)
@@ -608,7 +608,7 @@ RSpec.describe "Creating a vacancy" do
 
       context "when the start date is as soon as possible" do
         scenario "lists all the vacancy details correctly" do
-          vacancy = create(:vacancy, :complete, :draft, :starts_asap)
+          vacancy = create(:vacancy, :complete, :draft, :starts_asap, :no_tv_applications)
           vacancy.organisation_vacancies.create(organisation: school)
 
           vacancy = VacancyPresenter.new(vacancy)
@@ -622,7 +622,7 @@ RSpec.describe "Creating a vacancy" do
 
       context "when the listing is full-time" do
         scenario "lists all the full-time vacancy details correctly" do
-          vacancy = create(:vacancy, :complete, :draft, working_patterns: %w[full_time])
+          vacancy = create(:vacancy, :complete, :draft, :no_tv_applications, working_patterns: %w[full_time])
           vacancy.organisation_vacancies.create(organisation: school)
 
           vacancy = VacancyPresenter.new(vacancy)
@@ -637,7 +637,7 @@ RSpec.describe "Creating a vacancy" do
 
       context "when the listing is part-time" do
         scenario "lists all the part-time vacancy details correctly" do
-          vacancy = create(:vacancy, :complete, :draft, working_patterns: %w[part_time])
+          vacancy = create(:vacancy, :complete, :draft, :no_tv_applications, working_patterns: %w[part_time])
           vacancy.organisation_vacancies.create(organisation: school)
 
           vacancy = VacancyPresenter.new(vacancy)
@@ -652,7 +652,7 @@ RSpec.describe "Creating a vacancy" do
 
       context "when the listing is both full- and part-time" do
         scenario "lists all the working pattern vacancy details correctly" do
-          vacancy = create(:vacancy, :complete, :draft, working_patterns: %w[full_time part_time])
+          vacancy = create(:vacancy, :complete, :draft, :no_tv_applications, working_patterns: %w[full_time part_time])
           vacancy.organisation_vacancies.create(organisation: school)
 
           vacancy = VacancyPresenter.new(vacancy)

--- a/spec/system/hiring_staff_can_view_vacancies_spec.rb
+++ b/spec/system/hiring_staff_can_view_vacancies_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "School viewing vacancies" do
   end
 
   scenario "clicking on more information does not increment the counter" do
-    vacancy = create(:vacancy, status: "published")
+    vacancy = create(:vacancy, :no_tv_applications, status: "published")
     vacancy.organisation_vacancies.create(organisation: school)
 
     visit organisation_job_path(vacancy.id)

--- a/spec/system/jobseekers_can_apply_for_a_vacancy_spec.rb
+++ b/spec/system/jobseekers_can_apply_for_a_vacancy_spec.rb
@@ -1,23 +1,18 @@
 require "rails_helper"
 
 RSpec.describe "Jobseekers can apply for a vacancy" do
-  let(:school) { create(:school) }
+  let(:vacancy) do
+    create(:vacancy, :published, :no_tv_applications,
+           application_link: "www.google.com", organisation_vacancies_attributes: [{ organisation: build(:school) }])
+  end
+
+  before { visit job_path(vacancy) }
 
   scenario "the application link is without protocol" do
-    vacancy = create(:vacancy, :published, application_link: "www.google.com")
-    vacancy.organisation_vacancies.create(organisation: school)
-
-    visit job_path(vacancy)
-
     expect(page).to have_link(I18n.t("jobs.apply", href: "http://www.google.com"))
   end
 
   scenario "it increments the get_more_info_counter in the background" do
-    vacancy = create(:vacancy, :published)
-    vacancy.organisation_vacancies.create(organisation: school)
-
-    visit job_path(vacancy)
-
     expect { click_on I18n.t("jobs.apply") }.to have_enqueued_job(PersistVacancyGetMoreInfoClickJob).with(vacancy.id)
   end
 end

--- a/spec/system/jobseekers_can_start_a_job_application_spec.rb
+++ b/spec/system/jobseekers_can_start_a_job_application_spec.rb
@@ -20,7 +20,9 @@ RSpec.describe "Jobseekers can start or continue a job application" do
           before do
             login_as(jobseeker, scope: :jobseeker)
             visit job_path(vacancy)
-            click_on I18n.t("jobseekers.job_applications.banner_links.apply")
+            within ".banner-component" do
+              click_on I18n.t("jobseekers.job_applications.banner_links.apply")
+            end
           end
 
           it "starts a job application" do
@@ -37,7 +39,9 @@ RSpec.describe "Jobseekers can start or continue a job application" do
           context "when clicking 'apply' on the job page" do
             before do
               visit job_path(vacancy)
-              click_on I18n.t("jobseekers.job_applications.banner_links.apply")
+              within ".banner-component" do
+                click_on I18n.t("jobseekers.job_applications.banner_links.apply")
+              end
             end
 
             it "starts a job application after signing in" do
@@ -60,7 +64,9 @@ RSpec.describe "Jobseekers can start or continue a job application" do
         context "when clicking 'apply' on the job page" do
           before do
             visit job_path(vacancy)
-            click_on I18n.t("jobseekers.job_applications.banner_links.apply")
+            within ".banner-component" do
+              click_on I18n.t("jobseekers.job_applications.banner_links.apply")
+            end
           end
 
           it "starts a job application after signing up" do
@@ -102,7 +108,9 @@ RSpec.describe "Jobseekers can start or continue a job application" do
         before do
           visit job_path(vacancy)
           login_as(jobseeker, scope: :jobseeker)
-          click_on I18n.t("jobseekers.job_applications.banner_links.apply")
+          within ".banner-component" do
+            click_on I18n.t("jobseekers.job_applications.banner_links.apply")
+          end
         end
 
         it "redirects to job applications dashboard with correct message" do
@@ -135,7 +143,9 @@ RSpec.describe "Jobseekers can start or continue a job application" do
         before do
           visit job_path(vacancy)
           login_as(jobseeker, scope: :jobseeker)
-          click_on I18n.t("jobseekers.job_applications.banner_links.apply")
+          within ".banner-component" do
+            click_on I18n.t("jobseekers.job_applications.banner_links.apply")
+          end
         end
 
         it "redirects to job applications dashboard with correct message" do

--- a/spec/system/jobseekers_can_view_a_vacancy_on_mobile_spec.rb
+++ b/spec/system/jobseekers_can_view_a_vacancy_on_mobile_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe "Viewing a single vacancy on mobile" do
   let(:school) { create(:school) }
 
   before(:each) do
+    allow(JobseekerApplicationsFeature).to receive(:enabled?).and_return(true)
     page.driver.header("User-Agent", USER_AGENTS["MOBILE_CHROME"])
   end
 

--- a/spec/system/jobseekers_can_view_a_vacancy_spec.rb
+++ b/spec/system/jobseekers_can_view_a_vacancy_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe "Viewing a single published vacancy" do
   let(:school) { create(:school) }
 
+  before { allow(JobseekerApplicationsFeature).to receive(:enabled?).and_return(true) }
+
   scenario "Published vacancies are viewable" do
     vacancy = create(:vacancy, :published)
     vacancy.organisation_vacancies.create(organisation: school)
@@ -103,7 +105,7 @@ RSpec.describe "Viewing a single published vacancy" do
     end
 
     scenario "can click on the application link when there is one set" do
-      vacancy = create(:vacancy, :job_schema)
+      vacancy = create(:vacancy, :job_schema, :no_tv_applications)
       vacancy.organisation_vacancies.create(organisation: school)
 
       visit job_path(vacancy)


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-2387

## Changes in this PR
- Only render `Apply for the job` button is `vacancy.enable_job_applications` is `true`
- Raise an error on the relevant controller actions unless `vacancy.enable_job_applications` is `true`