### PR TITLE
[TEVA-2447] - Remove red text on 0 applicants in the jobs dashboard

### DIFF
--- a/app/components/publishers/vacancies_component.rb
+++ b/app/components/publishers/vacancies_component.rb
@@ -52,7 +52,7 @@ class Publishers::VacanciesComponent < ViewComponent::Base
                            class: "govuk-link--no-visited-state")
       tag.div(card.labelled_item(I18n.t("jobs.manage.applications"), link))
     elsif vacancy.job_applications.none?
-      text = tag.span(I18n.t("jobs.manage.view_applicants", count: 0), class: "text-red")
+      text = tag.span(I18n.t("jobs.manage.view_applicants", count: 0))
       tag.div(card.labelled_item(I18n.t("jobs.manage.applications"), text))
     end
   end


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-2447

## Changes in this PR
- Remove red text class on `0 applicants` text

## Product sign off 
- [x] Looks good!

## Screenshot
![image](https://user-images.githubusercontent.com/25187547/115538900-41ef6680-a294-11eb-96db-972b3068ebe0.png)
