### PR TITLE
[TEVA-2413] Sort vacancies by expires_at rather than expires_on

### DIFF
--- a/app/services/publishers/vacancy_sort.rb
+++ b/app/services/publishers/vacancy_sort.rb
@@ -20,13 +20,13 @@ class Publishers::VacancySort < RecordSort
     case @vacancy_type
     when "published"
       [
-        SortOption.new("expires_on", "asc", I18n.t("jobs.sort_by.expires_on.ascending")),
+        SortOption.new("expires_at", "asc", I18n.t("jobs.sort_by.expires_on.ascending")),
         SortOption.new("job_title", "asc", I18n.t("jobs.sort_by.job_title.ascending")),
       ]
     when "pending"
       [
         SortOption.new("publish_on", "desc", I18n.t("jobs.sort_by.published_date.descending")),
-        SortOption.new("expires_on", "asc", I18n.t("jobs.sort_by.expires_on.ascending")),
+        SortOption.new("expires_at", "asc", I18n.t("jobs.sort_by.expires_on.ascending")),
         SortOption.new("job_title", "asc", I18n.t("jobs.sort_by.job_title.ascending")),
       ]
     when "draft"
@@ -37,7 +37,7 @@ class Publishers::VacancySort < RecordSort
       ]
     when "expired", "awaiting_feedback"
       [
-        SortOption.new("expires_on", "desc", I18n.t("jobs.sort_by.expires_on.descending")),
+        SortOption.new("expires_at", "desc", I18n.t("jobs.sort_by.expires_on.descending")),
         SortOption.new("job_title", "asc", I18n.t("jobs.sort_by.job_title.ascending")),
       ]
     end

--- a/spec/services/publishers/vacancy_sort_spec.rb
+++ b/spec/services/publishers/vacancy_sort_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Publishers::VacancySort do
 
   describe "#initialize" do
     it "sets the column and order of the first sort option by default" do
-      expect(subject.column).to eq "expires_on"
+      expect(subject.column).to eq "expires_at"
       expect(subject.order).to eq "asc"
     end
   end
@@ -18,7 +18,7 @@ RSpec.describe Publishers::VacancySort do
       let(:vacancy_type) { "any_old_type" }
 
       it "defaults to published sort options" do
-        expect(subject.map(&:column)).to eq %w[expires_on job_title]
+        expect(subject.map(&:column)).to eq %w[expires_at job_title]
       end
     end
 
@@ -26,7 +26,7 @@ RSpec.describe Publishers::VacancySort do
       let(:organisation) { build_stubbed(:school_group) }
 
       it "appends readable_job_location to sort options" do
-        expect(subject.map(&:column)).to eq %w[expires_on job_title readable_job_location]
+        expect(subject.map(&:column)).to eq %w[expires_at job_title readable_job_location]
       end
     end
   end
@@ -49,7 +49,7 @@ RSpec.describe Publishers::VacancySort do
       let(:column) { "something_nasty" }
 
       it "does not update the sort column" do
-        expect(subject.update(column: column).column).to eq "expires_on"
+        expect(subject.update(column: column).column).to eq "expires_at"
       end
 
       it "does not update the sort order" do
@@ -61,7 +61,7 @@ RSpec.describe Publishers::VacancySort do
       let(:column) { nil }
 
       it "does not update the sort column" do
-        expect(subject.update(column: column).column).to eq "expires_on"
+        expect(subject.update(column: column).column).to eq "expires_at"
       end
 
       it "does not update the sort order" do


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-2413

## Changes in this PR
- Sort vacancies by `expires_at` rather than `expires_on`

_P.S. I can't wait to purge `expires_on` from existence_