### PR TITLE
Enable deployments to create attachment buckets

### DIFF
--- a/terraform/common/groups.tf
+++ b/terraform/common/groups.tf
@@ -319,7 +319,9 @@ resource "aws_iam_role_policy_attachment" "deployments_role_policies" {
     aws_iam_policy.acm.arn,
     aws_iam_policy.cloudfront.arn,
     aws_iam_policy.db_backups_in_s3_fullaccess.arn,
-    aws_iam_policy.offline_site_full_access.arn
+    aws_iam_policy.iam_manage_attachment_buckets_credentials.arn,
+    aws_iam_policy.offline_site_full_access.arn,
+    aws_iam_policy.s3_manage_attachment_buckets.arn
   ])
 
   role       = aws_iam_role.deployments.name

--- a/terraform/common/iam.tf
+++ b/terraform/common/iam.tf
@@ -122,6 +122,48 @@ resource "aws_iam_policy" "cloudfront" {
   policy = data.aws_iam_policy_document.cloudfront.json
 }
 
+# IAM user/key/policy management for file attachment buckets
+
+data "aws_iam_policy_document" "iam_manage_attachment_buckets_credentials" {
+  statement {
+    actions = [
+      "iam:CreateUser",
+      "iam:DeleteUser",
+      "iam:CreateAccessKey",
+      "iam:DeleteAccessKey",
+      "iam:AttachUserPolicy",
+      "iam:DetachUserPolicy"
+    ]
+    resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/attachment_buckets_users/*"]
+  }
+  statement {
+    actions = [
+      "iam:CreatePolicy",
+      "iam:DeletePolicy"
+    ]
+    resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/attachment_buckets_policies/*"]
+  }
+}
+
+resource "aws_iam_policy" "iam_manage_attachment_buckets_credentials" {
+  name   = "iam_manage_attachment_buckets_credentials"
+  policy = data.aws_iam_policy_document.iam_manage_attachment_buckets_credentials.json
+}
+
+# S3 file attachment buckets
+
+data "aws_iam_policy_document" "s3_manage_attachment_buckets" {
+  statement {
+    actions   = ["s3:CreateBucket", "s3:DeleteBucket"]
+    resources = ["arn:aws:s3:::${data.aws_caller_identity.current.account_id}-${local.service_name}-attachments-*"]
+  }
+}
+
+resource "aws_iam_policy" "s3_manage_attachment_buckets" {
+  name   = "s3_manage_attachment_buckets"
+  policy = data.aws_iam_policy_document.s3_manage_attachment_buckets.json
+}
+
 # DB backups in S3
 
 data "aws_iam_policy_document" "db_backups_in_s3_fullaccess" {


### PR DESCRIPTION
We want to create S3 buckets as part of our Terraform deployments to
store various kinds of "attachments" (file uploads to the app), so the
deployment role needs to be able to create and delete S3 buckets and IAM
users (and keys/policies/attachments) to own them.

- Create `iam_manage_attachment_buckets_credentials` IAM policy to allow
  deployments role to manage credentials for users/access keys/policies
  for attachment buckets
- Create `s3_manage_attachment_buckets` IAM policy to allow deployments
  role to create and delete S3 buckets (scoped to permissible attachment
  bucket names)
- Attach policies to deployments role