### PR TITLE
Improve copy on sign in page when authentication fallback is switched on

### DIFF
--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -138,7 +138,9 @@ en:
         heading: Sign in to Teaching Vacancies
         subject: Sign in to Teaching Vacancies
       heading: Temporary login
-      please_use_email: DfE Sign In is experiencing problems. Please sign in using your email address.
+      please_use_email: >-
+        There are some technical problems with our sign in page. We’re working on fixing it,
+        but in the meantime you can still access your account.
     vacancies_component:
       awaiting_feedback:
         tab_heading: Jobs awaiting feedback


### PR DESCRIPTION
This change is for part of this ticket: https://dfedigital.atlassian.net/browse/TEVA-2306?atlOrigin=eyJpIjoiYTY1YzQ3NGFmZDliNGU0MGFiYzA3YTU2MzM4YjcwZDIiLCJwIjoiaiJ9

I've updated the red 'Warning' box, but haven't updated the rest of the copy as David advised a developer should do this.