### PR TITLE
[TEVA-2269] Remove secondary button cancel

### DIFF
--- a/app/controllers/jobseekers/job_applications/employments_controller.rb
+++ b/app/controllers/jobseekers/job_applications/employments_controller.rb
@@ -2,9 +2,7 @@ class Jobseekers::JobApplications::EmploymentsController < Jobseekers::BaseContr
   helper_method :back_path, :employment, :form, :job_application
 
   def create
-    if params[:commit] == t("buttons.cancel")
-      redirect_to back_path
-    elsif form.valid?
+    if form.valid?
       job_application.employments.create(employment_params)
       redirect_to back_path
     else
@@ -13,9 +11,7 @@ class Jobseekers::JobApplications::EmploymentsController < Jobseekers::BaseContr
   end
 
   def update
-    if params[:commit] == t("buttons.cancel")
-      redirect_to back_path
-    elsif form.valid?
+    if form.valid?
       employment.update(employment_params)
       redirect_to back_path
     else

--- a/app/controllers/jobseekers/job_applications/qualifications_controller.rb
+++ b/app/controllers/jobseekers/job_applications/qualifications_controller.rb
@@ -3,9 +3,7 @@ class Jobseekers::JobApplications::QualificationsController < Jobseekers::BaseCo
                 :submit_text
 
   def submit_category
-    if params[:commit] == t("buttons.cancel")
-      redirect_to back_path
-    elsif form.valid?
+    if form.valid?
       redirect_to new_jobseekers_job_application_qualification_path(qualification_params)
     else
       render :select_category
@@ -13,9 +11,7 @@ class Jobseekers::JobApplications::QualificationsController < Jobseekers::BaseCo
   end
 
   def create
-    if params[:commit] == t("buttons.cancel")
-      redirect_to back_path
-    elsif form.valid?
+    if form.valid?
       job_application.qualifications.create(qualification_params)
       redirect_to back_path
     else
@@ -24,9 +20,7 @@ class Jobseekers::JobApplications::QualificationsController < Jobseekers::BaseCo
   end
 
   def update
-    if params[:commit] == t("buttons.cancel")
-      redirect_to back_path
-    elsif form.valid?
+    if form.valid?
       qualification.update(qualification_params)
       redirect_to back_path
     else

--- a/app/controllers/jobseekers/job_applications/references_controller.rb
+++ b/app/controllers/jobseekers/job_applications/references_controller.rb
@@ -2,9 +2,7 @@ class Jobseekers::JobApplications::ReferencesController < Jobseekers::BaseContro
   helper_method :back_path, :form, :job_application, :reference
 
   def create
-    if params[:commit] == t("buttons.cancel")
-      redirect_to back_path
-    elsif form.valid?
+    if form.valid?
       job_application.references.create(reference_params)
       redirect_to back_path
     else
@@ -13,9 +11,7 @@ class Jobseekers::JobApplications::ReferencesController < Jobseekers::BaseContro
   end
 
   def update
-    if params[:commit] == t("buttons.cancel")
-      redirect_to back_path
-    elsif form.valid?
+    if form.valid?
       reference.update(reference_params)
       redirect_to back_path
     else

--- a/app/controllers/jobseekers/job_applications_controller.rb
+++ b/app/controllers/jobseekers/job_applications_controller.rb
@@ -67,11 +67,7 @@ class Jobseekers::JobApplicationsController < Jobseekers::BaseController
     raise ActionController::RoutingError, "Cannot withdraw non-submitted or non-shortlisted application" unless
       job_application.status.in?(%w[shortlisted submitted])
 
-    if params[:commit] == t("buttons.cancel")
-      return redirect_to jobseekers_job_applications_path if URI(params[:origin]).path == jobseekers_job_applications_path
-
-      redirect_to jobseekers_job_application_path(job_application)
-    elsif withdraw_form.valid?
+    if withdraw_form.valid?
       job_application.withdrawn!
       redirect_to jobseekers_job_applications_path, success: t(".success", job_title: vacancy.job_title)
     else

--- a/app/controllers/publishers/vacancies/end_listing_controller.rb
+++ b/app/controllers/publishers/vacancies/end_listing_controller.rb
@@ -2,8 +2,6 @@ class Publishers::Vacancies::EndListingController < Publishers::Vacancies::BaseC
   helper_method :form, :vacancy
 
   def update
-    return redirect_to jobs_with_type_organisation_path(:published) if params[:commit] == t("buttons.cancel")
-
     if form.valid?
       vacancy.update(form_params.merge(expires_on: Time.current, expires_at: Time.current))
       update_google_index(vacancy)

--- a/app/controllers/publishers/vacancies/extend_deadline_controller.rb
+++ b/app/controllers/publishers/vacancies/extend_deadline_controller.rb
@@ -2,8 +2,6 @@ class Publishers::Vacancies::ExtendDeadlineController < Publishers::Vacancies::B
   helper_method :form, :vacancy
 
   def update
-    return redirect_to organisation_job_job_applications_path(vacancy.id) if params[:commit] == t("buttons.cancel")
-
     if form.valid?
       vacancy.update(form.attributes_to_save)
       update_google_index(vacancy)

--- a/app/views/jobseekers/job_applications/confirm_withdraw.html.slim
+++ b/app/views/jobseekers/job_applications/confirm_withdraw.html.slim
@@ -19,5 +19,4 @@
         = govuk_notification_banner title: t("banners.warning"), classes: "govuk-notification-banner--warning" do
           = t(".description")
 
-        = f.govuk_submit t("buttons.withdraw_application") do
-          = f.govuk_submit t("buttons.cancel"), secondary: true
+        = f.govuk_submit t("buttons.withdraw_application")

--- a/app/views/jobseekers/job_applications/employments/edit.html.slim
+++ b/app/views/jobseekers/job_applications/employments/edit.html.slim
@@ -11,5 +11,4 @@
 
         = render "fields", f: f
 
-        = f.govuk_submit t("buttons.save_employment") do
-          = f.govuk_submit t("buttons.cancel"), secondary: true
+        = f.govuk_submit t("buttons.save_employment")

--- a/app/views/jobseekers/job_applications/employments/new.html.slim
+++ b/app/views/jobseekers/job_applications/employments/new.html.slim
@@ -11,5 +11,4 @@
 
         = render "fields", f: f
 
-        = f.govuk_submit t("buttons.save_employment") do
-          = f.govuk_submit t("buttons.cancel"), secondary: true
+        = f.govuk_submit t("buttons.save_employment")

--- a/app/views/jobseekers/job_applications/qualifications/edit.html.slim
+++ b/app/views/jobseekers/job_applications/qualifications/edit.html.slim
@@ -11,5 +11,4 @@
 
         = render "fields", f: f
 
-        = f.govuk_submit submit_text do
-          = f.govuk_submit t("buttons.cancel"), secondary: true
+        = f.govuk_submit submit_text

--- a/app/views/jobseekers/job_applications/qualifications/new.html.slim
+++ b/app/views/jobseekers/job_applications/qualifications/new.html.slim
@@ -11,5 +11,4 @@
 
         = render "fields", f: f
 
-        = f.govuk_submit submit_text do
-          = f.govuk_submit t("buttons.cancel"), secondary: true
+        = f.govuk_submit submit_text

--- a/app/views/jobseekers/job_applications/qualifications/select_category.html.slim
+++ b/app/views/jobseekers/job_applications/qualifications/select_category.html.slim
@@ -11,5 +11,4 @@
 
         = f.govuk_collection_radio_buttons :category, Qualification.categories.keys, :to_s
 
-        = f.govuk_submit t("buttons.continue") do
-          = f.govuk_submit t("buttons.cancel"), secondary: true
+        = f.govuk_submit t("buttons.continue")

--- a/app/views/jobseekers/job_applications/references/edit.html.slim
+++ b/app/views/jobseekers/job_applications/references/edit.html.slim
@@ -13,5 +13,4 @@
 
         = render "fields", f: f
 
-        = f.govuk_submit t("buttons.save_reference") do
-          = f.govuk_submit t("buttons.cancel"), secondary: true
+        = f.govuk_submit t("buttons.save_reference")

--- a/app/views/jobseekers/job_applications/references/new.html.slim
+++ b/app/views/jobseekers/job_applications/references/new.html.slim
@@ -13,5 +13,4 @@
 
         = render "fields", f: f
 
-        = f.govuk_submit t("buttons.save_reference") do
-          = f.govuk_submit t("buttons.cancel"), secondary: true
+        = f.govuk_submit t("buttons.save_reference")

--- a/app/views/publishers/vacancies/end_listing/show.html.slim
+++ b/app/views/publishers/vacancies/end_listing/show.html.slim
@@ -14,5 +14,4 @@
             = f.govuk_collection_select :candidate_hired_from, candidate_hired_from_options, :last, :first, label: { size: "s" }
           = f.govuk_radio_button :end_listing_reason, :end_early
 
-        = f.govuk_submit t("buttons.end_listing") do
-          = f.govuk_submit t("buttons.cancel"), secondary: true
+        = f.govuk_submit t("buttons.end_listing")

--- a/app/views/publishers/vacancies/extend_deadline/show.html.slim
+++ b/app/views/publishers/vacancies/extend_deadline/show.html.slim
@@ -26,5 +26,4 @@
           .clear-form__checkbox
             = f.govuk_check_box :starts_asap, true, 0, multiple: false, link_errors: false
 
-        = f.govuk_submit t("buttons.extend_deadline") do
-          = f.govuk_submit t("buttons.cancel"), secondary: true
+        = f.govuk_submit t("buttons.extend_deadline")

--- a/app/views/publishers/vacancies/job_applications/reject.html.slim
+++ b/app/views/publishers/vacancies/job_applications/reject.html.slim
@@ -16,5 +16,3 @@
       = form_for form, url: organisation_job_job_application_update_status_path(vacancy.id, job_application.id) do |f|
         = f.govuk_text_area :rejection_reasons, label: { size: "s" }, rows: 10, form_group: { classes: "optional-field" }
         = f.govuk_submit t("buttons.confirm_rejection")
-
-      = govuk_link_to t("buttons.cancel"), organisation_job_job_application_path(vacancy.id, job_application.id)

--- a/app/views/publishers/vacancies/job_applications/shortlist.html.slim
+++ b/app/views/publishers/vacancies/job_applications/shortlist.html.slim
@@ -16,5 +16,3 @@
       = form_for form, url: organisation_job_job_application_update_status_path(vacancy.id, job_application.id) do |f|
         = f.govuk_text_area :further_instructions, label: { size: "s" }, rows: 10, form_group: { classes: "optional-field" }
         = f.govuk_submit t("buttons.shortlist")
-
-      = govuk_link_to t("buttons.cancel"), organisation_job_job_application_path(vacancy.id, job_application.id)

--- a/app/views/subscriptions/edit.html.slim
+++ b/app/views/subscriptions/edit.html.slim
@@ -18,7 +18,3 @@
         = f.hidden_field :token, value: @subscription.token
 
         = f.govuk_submit t("buttons.update_alert"), classes: "govuk-!-padding-left-8 govuk-!-padding-right-8"
-
-  .govuk-grid-row
-    .govuk-grid-column-two-thirds
-      = govuk_link_to(t("buttons.cancel"), root_path, class: "govuk-!-font-size-19")

--- a/app/views/subscriptions/new.html.slim
+++ b/app/views/subscriptions/new.html.slim
@@ -20,7 +20,3 @@
         = recaptcha
 
         = f.govuk_submit t("buttons.subscribe"), classes: "govuk-!-padding-left-8 govuk-!-padding-right-8"
-
-  .govuk-grid-row
-    .govuk-grid-column-two-thirds
-      = govuk_link_to(t("buttons.cancel"), @origin.presence || jobs_path(@subscription_form.search_criteria_hash), class: "govuk-!-font-size-19")

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -11,7 +11,6 @@ en:
     apply_filters: Apply filters
     back: Back
     back_to_manage_jobs: Back to manage jobs
-    cancel: Cancel
     cancel_copy: Cancel copy
     cancel_and_return: Cancel and return
     change: Change

--- a/spec/requests/jobseekers/job_applications/employments_spec.rb
+++ b/spec/requests/jobseekers/job_applications/employments_spec.rb
@@ -69,17 +69,6 @@ RSpec.describe "Job applications employments" do
           expect(response).to have_http_status(:not_found)
         end
       end
-
-      context "when the commit param is `Cancel`" do
-        let(:button) { I18n.t("buttons.cancel") }
-
-        it "does not create the employment and redirects to the employment history build step" do
-          expect { post jobseekers_job_application_employments_path(job_application), params: params }
-            .to(not_change { Employment.count })
-
-          expect(response).to redirect_to(jobseekers_job_application_build_path(job_application, :employment_history))
-        end
-      end
     end
 
     context "when the form is invalid" do
@@ -106,17 +95,6 @@ RSpec.describe "Job applications employments" do
           .to change { employment.reload.organisation }.from("Cool school").to("Awesome academy")
 
         expect(response).to redirect_to(jobseekers_job_application_build_path(job_application, :employment_history))
-      end
-
-      context "when the commit param is `Cancel`" do
-        let(:button) { I18n.t("buttons.cancel") }
-
-        it "does not update the employment and redirects to the employment history build step" do
-          expect { patch jobseekers_job_application_employment_path(job_application, employment), params: params }
-            .to(not_change { employment.reload.organisation })
-
-          expect(response).to redirect_to(jobseekers_job_application_build_path(job_application, :employment_history))
-        end
       end
 
       context "when the job application status is not draft" do

--- a/spec/requests/jobseekers/job_applications/qualifications_spec.rb
+++ b/spec/requests/jobseekers/job_applications/qualifications_spec.rb
@@ -43,16 +43,6 @@ RSpec.describe "Job applications qualifications" do
 
         expect(response).to redirect_to(new_jobseekers_job_application_qualification_path(job_application, category: "other"))
       end
-
-      context "when the commit param is `Cancel`" do
-        let(:button) { I18n.t("buttons.cancel") }
-
-        it "redirects to the qualification build step" do
-          post submit_category_jobseekers_job_application_qualifications_path(job_application), params: params
-
-          expect(response).to redirect_to(jobseekers_job_application_build_path(job_application, :qualifications))
-        end
-      end
     end
 
     context "when the form is invalid" do
@@ -128,17 +118,6 @@ RSpec.describe "Job applications qualifications" do
 
         expect(response).to redirect_to(jobseekers_job_application_build_path(job_application, :qualifications))
       end
-
-      context "when the commit param is `Cancel`" do
-        let(:button) { I18n.t("buttons.cancel") }
-
-        it "does not create the qualification and redirects to the qualification build step" do
-          expect { post jobseekers_job_application_qualifications_path(job_application), params: params }
-            .to(not_change { Qualification.count })
-
-          expect(response).to redirect_to(jobseekers_job_application_build_path(job_application, :qualifications))
-        end
-      end
     end
 
     context "when the form is invalid" do
@@ -205,17 +184,6 @@ RSpec.describe "Job applications qualifications" do
           patch jobseekers_job_application_qualification_path(job_application, qualification), params: params
 
           expect(response).to have_http_status(:not_found)
-        end
-      end
-
-      context "when the commit param is `Cancel`" do
-        let(:button) { I18n.t("buttons.cancel") }
-
-        it "does not update the qualification and redirects to the qualification build step" do
-          expect { patch jobseekers_job_application_qualification_path(job_application, qualification), params: params }
-            .to(not_change { qualification.reload.subject })
-
-          expect(response).to redirect_to(jobseekers_job_application_build_path(job_application, :qualifications))
         end
       end
     end

--- a/spec/requests/jobseekers/job_applications/references_spec.rb
+++ b/spec/requests/jobseekers/job_applications/references_spec.rb
@@ -69,17 +69,6 @@ RSpec.describe "Job applications references" do
           expect(response).to have_http_status(:not_found)
         end
       end
-
-      context "when the commit param is `Cancel`" do
-        let(:button) { I18n.t("buttons.cancel") }
-
-        it "does not create the reference and redirects to the references build step" do
-          expect { post jobseekers_job_application_references_path(job_application), params: params }
-            .to(not_change { Reference.count })
-
-          expect(response).to redirect_to(jobseekers_job_application_build_path(job_application, :references))
-        end
-      end
     end
 
     context "when the form is invalid" do
@@ -115,17 +104,6 @@ RSpec.describe "Job applications references" do
           patch jobseekers_job_application_reference_path(job_application, reference), params: params
 
           expect(response).to have_http_status(:not_found)
-        end
-      end
-
-      context "when the commit param is `Cancel`" do
-        let(:button) { I18n.t("buttons.cancel") }
-
-        it "does not update the reference and redirects to the references build step" do
-          expect { patch jobseekers_job_application_reference_path(job_application, reference), params: params }
-            .to(not_change { reference.reload.name })
-
-          expect(response).to redirect_to(jobseekers_job_application_build_path(job_application, :references))
         end
       end
     end

--- a/spec/requests/jobseekers/job_applications_spec.rb
+++ b/spec/requests/jobseekers/job_applications_spec.rb
@@ -354,50 +354,23 @@ RSpec.describe "Job applications" do
 
     context "when the application is submitted" do
       let!(:job_application) { create(:job_application, :status_submitted, jobseeker: jobseeker, vacancy: vacancy) }
+      let(:button) { I18n.t("buttons.withdraw_application") }
 
-      context "when the commit param is `Cancel`" do
-        let(:button) { I18n.t("buttons.cancel") }
+      context "when the withdraw form is invalid" do
+        let(:withdraw_reason) { "invalid" }
 
-        context "when the origin param is not `jobseekers_job_applications_url`" do
-          it "does not withdraw the job application and redirects to the applications dashboard" do
-            expect { post jobseekers_job_application_withdraw_path(job_application.id), params: params }
-              .to(not_change { job_application.reload.status })
+        it "does not withdraw the job application and redirects to the confirm withdraw template" do
+          expect { post jobseekers_job_application_withdraw_path(job_application.id), params: params }
+            .to(not_change { job_application.reload.status })
 
-            expect(response).to redirect_to(jobseekers_job_application_path(job_application.id))
-          end
-        end
-
-        context "when the origin param is `jobseekers_job_applications_url`" do
-          let(:origin) { jobseekers_job_applications_url }
-
-          it "does not withdraw the job application and redirects to the job application page" do
-            expect { post jobseekers_job_application_withdraw_path(job_application.id), params: params }
-              .to(not_change { job_application.reload.status })
-
-            expect(response).to redirect_to(jobseekers_job_applications_path)
-          end
+          expect(response).to render_template(:confirm_withdraw)
         end
       end
 
-      context "when the commit param is `Withdraw application`" do
-        let(:button) { I18n.t("buttons.withdraw_application") }
-
-        context "when the withdraw form is invalid" do
-          let(:withdraw_reason) { "invalid" }
-
-          it "does not withdraw the job application and redirects to the confirm withdraw template" do
-            expect { post jobseekers_job_application_withdraw_path(job_application.id), params: params }
-              .to(not_change { job_application.reload.status })
-
-            expect(response).to render_template(:confirm_withdraw)
-          end
-        end
-
-        context "when the withdraw form is valid" do
-          it "withdraws the job application and redirects to the applications dashboard" do
-            expect { post jobseekers_job_application_withdraw_path(job_application.id), params: params }
-              .to change { job_application.reload.status }.from("submitted").to("withdrawn")
-          end
+      context "when the withdraw form is valid" do
+        it "withdraws the job application and redirects to the applications dashboard" do
+          expect { post jobseekers_job_application_withdraw_path(job_application.id), params: params }
+            .to change { job_application.reload.status }.from("submitted").to("withdrawn")
         end
       end
     end

--- a/spec/requests/publishers/vacancies/end_listing_spec.rb
+++ b/spec/requests/publishers/vacancies/end_listing_spec.rb
@@ -61,19 +61,6 @@ RSpec.describe "End job listing early" do
       end
     end
 
-    context "when the commit param is `Cancel`" do
-      let(:button) { I18n.t("buttons.cancel") }
-
-      it "does not update expires_at, end_listing_reason, google index and redirects to the dashboard" do
-        expect { patch(organisation_job_end_listing_path(vacancy.id), params: params) }
-          .to not_change { vacancy.reload.expires_at }
-          .and not_change { vacancy.reload.end_listing_reason }
-          .and not_have_enqueued_job(UpdateGoogleIndexQueueJob)
-
-        expect(response).to redirect_to(jobs_with_type_organisation_path(:published))
-      end
-    end
-
     it "updates expires_at, end_listing_reason, google index and redirects to the dashboard" do
       freeze_time do
         expect { patch(organisation_job_end_listing_path(vacancy.id), params: params) }

--- a/spec/requests/publishers/vacancies/extend_deadline_spec.rb
+++ b/spec/requests/publishers/vacancies/extend_deadline_spec.rb
@@ -74,18 +74,6 @@ RSpec.describe "Extend deadline" do
       end
     end
 
-    context "when the commit param is `Cancel`" do
-      let(:button) { I18n.t("buttons.cancel") }
-
-      it "does not extend the deadline or update google index and redirects to vacancy job applications dashboard" do
-        expect { patch organisation_job_extend_deadline_path(vacancy.id), params: params }
-          .to not_change { vacancy.reload.expires_at }
-          .and not_have_enqueued_job(UpdateGoogleIndexQueueJob)
-
-        expect(response).to redirect_to(organisation_job_job_applications_path(vacancy.id))
-      end
-    end
-
     context "when the form is invalid" do
       before { allow_any_instance_of(Publishers::JobListing::ExtendDeadlineForm).to receive(:valid?).and_return(false) }
 


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-2269

## Changes in this PR:
We are removing the secondary button `Cancel` and rely on users using the browser back button to navigate back