### PR TITLE
[TEVA-2458] Job application status update

### DIFF
--- a/.slim-lint.yml
+++ b/.slim-lint.yml
@@ -2,5 +2,7 @@ exclude:
   - 'vendor/bundle/**/*.slim'
 
 linters:
+  ConsecutiveControlStatements:
+    enabled: false
   LineLength:
     enabled: false

--- a/app/controllers/jobseekers/job_applications_controller.rb
+++ b/app/controllers/jobseekers/job_applications_controller.rb
@@ -59,13 +59,13 @@ class Jobseekers::JobApplicationsController < Jobseekers::BaseController
   end
 
   def confirm_withdraw
-    raise ActionController::RoutingError, "Cannot withdraw non-submitted or non-shortlisted application" unless
-      job_application.status.in?(%w[shortlisted submitted])
+    raise ActionController::RoutingError, "Cannot withdraw non-reviewed/shortlisted/submitted application" unless
+      job_application.status.in?(%w[reviewed shortlisted submitted])
   end
 
   def withdraw
-    raise ActionController::RoutingError, "Cannot withdraw non-submitted or non-shortlisted application" unless
-      job_application.status.in?(%w[shortlisted submitted])
+    raise ActionController::RoutingError, "Cannot withdraw non-reviewed/shortlisted/submitted application" unless
+      job_application.status.in?(%w[reviewed shortlisted submitted])
 
     if withdraw_form.valid?
       job_application.withdrawn!
@@ -85,7 +85,7 @@ class Jobseekers::JobApplicationsController < Jobseekers::BaseController
     job_application = current_jobseeker.job_applications.find_by(vacancy_id: vacancy.id)
     return unless job_application
 
-    if job_application.submitted?
+    if job_application.submitted? || job_application.reviewed?
       redirect_to jobseekers_job_applications_path,
                   warning: t("messages.jobseekers.job_applications.already_exists.submitted",
                              job_title: vacancy.job_title)

--- a/app/controllers/publishers/vacancies/job_applications_controller.rb
+++ b/app/controllers/publishers/vacancies/job_applications_controller.rb
@@ -14,6 +14,8 @@ class Publishers::Vacancies::JobApplicationsController < Publishers::Vacancies::
   def show
     raise ActionController::RoutingError, "Cannot view a draft or withdrawn application" if
       job_application.draft? || job_application.withdrawn?
+
+    job_application.reviewed! if job_application.submitted?
   end
 
   def update_status
@@ -22,8 +24,7 @@ class Publishers::Vacancies::JobApplicationsController < Publishers::Vacancies::
 
     job_application.update(form_params.merge(status: status))
     Jobseekers::JobApplicationMailer.send("application_#{status}".to_sym, job_application).deliver_now
-    # TODO: Update redirect when job applications index page exists (and update request/system specs)
-    redirect_to organisation_jobs_path,
+    redirect_to organisation_job_job_applications_path(vacancy.id),
                 success: t(".#{status}", name: "#{job_application.first_name} #{job_application.last_name}")
   end
 

--- a/app/frontend/src/components/printPage/printPage.scss
+++ b/app/frontend/src/components/printPage/printPage.scss
@@ -4,8 +4,4 @@
   .govuk-footer {
     display: none;
   }
-
-  .print-page-content {
-    display: block;
-  }
 }

--- a/app/frontend/src/styles/base/_utilities.scss
+++ b/app/frontend/src/styles/base/_utilities.scss
@@ -186,7 +186,3 @@
     display: inline-block;
   }
 }
-
-.print-page-content {
-  display: none;
-}

--- a/app/helpers/job_application_helper.rb
+++ b/app/helpers/job_application_helper.rb
@@ -1,15 +1,33 @@
 module JobApplicationHelper
   PUBLISHER_STATUS_MAPPINGS = {
-    shortlisted: "shortlisted", submitted: "review", unsuccessful: "rejected", withdrawn: "withdrawn"
+    submitted: "unread",
+    reviewed: "reviewed",
+    shortlisted: "shortlisted",
+    unsuccessful: "rejected",
+    withdrawn: "withdrawn",
+  }.freeze
+
+  JOBSEEKER_STATUS_MAPPINGS = {
+    draft: "draft",
+    submitted: "submitted",
+    reviewed: "submitted",
+    shortlisted: "shortlisted",
+    unsuccessful: "unsuccessful",
+    withdrawn: "withdrawn",
   }.freeze
 
   JOB_APPLICATION_STATUS_TAG_COLOURS = {
-    draft: "pink", submitted: "blue", shortlisted: "green", unsuccessful: "red", withdrawn: "orange"
+    draft: "pink",
+    submitted: "blue",
+    reviewed: "purple",
+    shortlisted: "green",
+    unsuccessful: "red",
+    withdrawn: "orange",
   }.freeze
 
   def job_application_status_tag(status)
-    govuk_tag text: status,
-              colour: JOB_APPLICATION_STATUS_TAG_COLOURS[status.to_sym],
+    govuk_tag text: JOBSEEKER_STATUS_MAPPINGS[status.to_sym],
+              colour: JOB_APPLICATION_STATUS_TAG_COLOURS[JOBSEEKER_STATUS_MAPPINGS[status.to_sym].to_sym],
               classes: "govuk-!-margin-bottom-2"
   end
 

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -29,7 +29,7 @@ class JobApplication < ApplicationRecord
   }
 
   # If you want to add a status, be sure to add a `status_at` column to the `job_applications` table
-  enum status: { draft: 0, submitted: 1, shortlisted: 2, unsuccessful: 3, withdrawn: 4 }, _default: 0
+  enum status: { draft: 0, submitted: 1, reviewed: 2, shortlisted: 3, unsuccessful: 4, withdrawn: 5 }, _default: 0
 
   belongs_to :jobseeker
   belongs_to :vacancy

--- a/app/views/jobseekers/job_applications/show.html.slim
+++ b/app/views/jobseekers/job_applications/show.html.slim
@@ -14,7 +14,7 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    - if job_application.status.in?(%w[shortlisted submitted])
+    - if job_application.status.in?(%w[shortlisted submitted reviewed])
       = govuk_link_to t("buttons.withdraw_application"), jobseekers_job_application_confirm_withdraw_path(job_application), button: true, class: "govuk-button--warning"
 
     - if job_application.shortlisted?
@@ -22,13 +22,17 @@
         - banner.add_heading text: t(".shortlist_alert.title")
         span class="govuk-!-margin-top-3" = t(".shortlist_alert.body", organisation: vacancy.parent_organisation_name)
 
-    // TODO: Complete in later ticket
     .grey-border-box
       h3.govuk-heading-m = t(".school_details.heading")
       = govuk_summary_list classes: "govuk-!-margin-bottom-0" do |component|
         - component.slot(:row, key: t(".school_details.name"), value: vacancy.parent_organisation_name)
+        - component.slot(:row, key: t(".school_details.type"), value: vacancy.parent_organisation.school_type)
         - component.slot(:row, key: t(".school_details.number"), value: vacancy.contact_number)
-        - component.slot(:row, key: t(".school_details.email"), value: vacancy.contact_email)
+        - component.slot(:row, key: t(".school_details.email"), value: govuk_mail_to(vacancy.contact_email, vacancy.contact_email))
+        - if vacancy.parent_organisation.website.present? || vacancy.parent_organisation.url.present?
+          - component.slot(:row, key: t(".school_details.website"),
+                           value: govuk_link_to(vacancy.parent_organisation.website.presence || vacancy.parent_organisation.url, vacancy.parent_organisation.website.presence || vacancy.parent_organisation.url))
+        - component.slot(:row, key: t(".school_details.address"), value: full_address(vacancy.parent_organisation))
 
     - if job_application.unsuccessful? && job_application.rejection_reasons.present?
       .grey-border-box

--- a/app/views/publishers/vacancies/job_applications/index.html.slim
+++ b/app/views/publishers/vacancies/job_applications/index.html.slim
@@ -27,7 +27,7 @@
     .govuk-grid-column-one-quarter
       .application-count.govuk-tag class="govuk-tag--#{status_tag_colour(:submitted)}"
         .govuk-heading-l = job_applications.submitted.count
-        h3.govuk-caption-s = t(".review")
+        h3.govuk-caption-s = t(".submitted")
 
     .govuk-grid-column-one-quarter
       .application-count.govuk-tag class="govuk-tag--#{status_tag_colour(:shortlisted)}"
@@ -71,9 +71,9 @@
             = tag.div(publisher_job_application_status_tag(application.status))
             = tag.div(card.labelled_item(t(".received"), application.submitted_at))
 
-          - if application.shortlisted? || application.submitted?
+          - if application.status.in?(%w[reviewed shortlisted submitted])
             - card.actions do
-              - if application.submitted?
+              - if application.reviewed? || application.submitted?
                 = tag.div(govuk_link_to(t("buttons.shortlist"), organisation_job_job_application_shortlist_path(vacancy.id, application.id)))
               = tag.div(govuk_link_to(t("buttons.reject"), organisation_job_job_application_reject_path(vacancy.id, application.id)))
     - else

--- a/app/views/publishers/vacancies/job_applications/show.html.slim
+++ b/app/views/publishers/vacancies/job_applications/show.html.slim
@@ -2,14 +2,14 @@
 
 = render BannerComponent.new
   = govuk_breadcrumbs breadcrumbs: { "#{t("publishers.vacancies_component.published.tab_heading")}": jobs_with_type_organisation_path(:published),
-                                      "#{vacancy.job_title}": organisation_job_path(vacancy.id),
-                                      "#{job_application.first_name} #{job_application.last_name}": "" }
+                                     "#{vacancy.job_title}": organisation_job_job_applications_path(vacancy.id),
+                                     "#{job_application.first_name} #{job_application.last_name}": "" }
 
   .govuk-caption-l class="govuk-!-margin-top-5"
     = t("jobseekers.job_applications.caption", job_title: vacancy.job_title, organisation: vacancy.parent_organisation_name)
 
-  .print-page-content
-    .h2.govuk-heading-l = "#{job_application.first_name} #{job_application.last_name}"
+  h1.govuk-heading-xl class="govuk-!-margin-bottom-5 govuk-!-margin-top-0"
+    = "#{job_application.first_name} #{job_application.last_name}"
 
   div
     span.govuk-body class="govuk-!-margin-right-5" = t(".status_heading")
@@ -18,9 +18,9 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     .job-application-actions
-      - if job_application.submitted?
+      - if job_application.status.in?(%w[submitted reviewed])
         = govuk_link_to t("buttons.shortlist"), organisation_job_job_application_shortlist_path(vacancy.id, job_application.id), button: true, class: "govuk-!-margin-right-3"
-      - if job_application.submitted? || job_application.shortlisted?
+      - if job_application.status.in?(%w[submitted reviewed shortlisted])
         = govuk_link_to t("buttons.reject"), organisation_job_job_application_reject_path(vacancy.id, job_application.id), button: true, class: "govuk-button--warning govuk-!-margin-right-3"
       = govuk_link_to t("buttons.print_download_application"), "#", button: true, class: "govuk-button--secondary js-action print-application"
 
@@ -71,5 +71,8 @@
       - elsif job_application.shortlisted?
         - timeline.item(key: t("jobseekers.job_applications.status_timestamps.shortlisted"),
                         value: format_date(job_application.shortlisted_at.to_date) + I18n.t("jobs.time_at") + format_time(job_application.shortlisted_at))
+      - if job_application.reviewed_at?
+        - timeline.item(key: t("jobseekers.job_applications.status_timestamps.reviewed"),
+                        value: format_date(job_application.reviewed_at.to_date) + I18n.t("jobs.time_at") + format_time(job_application.reviewed_at))
       - timeline.item(key: t("jobseekers.job_applications.status_timestamps.submitted"),
                       value: format_date(job_application.submitted_at.to_date) + I18n.t("jobs.time_at") + format_time(job_application.submitted_at))

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -300,10 +300,13 @@ en:
         feedback: Feedback on your application
         page_title: View application
         school_details:
+          address: School address
           email: Contact email
           heading: School details
           name: School name
           number: Telephone number
+          type: School type
+          website: School website
         shortlist_alert:
           title: What happens next with shortlisting?
           body: "%{organisation} will be in touch soon with more information about next steps."
@@ -311,6 +314,7 @@ en:
         timeline: Timeline
       status_timestamps:
         rejected: Rejected
+        reviewed: Reviewed
         shortlisted: Shortlisted
         submitted: Application submitted
         unsuccessful: Unsuccessful

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -195,12 +195,12 @@ en:
           heading: Applicants for
           no_applicants: Nobody has applied for this job yet
           received: Received on
-          rejected: Rejected applicants
-          review: Applicants to review
-          shortlisted: Shortlisted applicants
+          rejected: Rejected applications
+          shortlisted: Shortlisted applications
           sort_by:
             date_received: date received (most recent)
             applicant_last_name: applicant last name (A to Z)
+          submitted: Unread applications
         reject:
           alert: The candidate will be sent an email telling them that their application has not been successful.
           heading: Reject applicant

--- a/db/migrate/20210421125544_add_reviewed_at_timestamp_to_job_application.rb
+++ b/db/migrate/20210421125544_add_reviewed_at_timestamp_to_job_application.rb
@@ -1,0 +1,5 @@
+class AddReviewedAtTimestampToJobApplication < ActiveRecord::Migration[6.1]
+  def change
+    add_column :job_applications, :reviewed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_20_133311) do
+ActiveRecord::Schema.define(version: 2021_04_21_125544) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -183,6 +183,7 @@ ActiveRecord::Schema.define(version: 2021_04_20_133311) do
     t.string "religion", default: "", null: false
     t.string "religion_description", default: "", null: false
     t.integer "in_progress_steps", default: [], null: false, array: true
+    t.datetime "reviewed_at"
   end
 
   create_table "jobseekers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -207,7 +207,7 @@ FactoryBot.create(:vacancy,
                   organisation_vacancies_attributes: [{ organisation: school_two }])
 
 FactoryBot.create(:vacancy,
-                  id: "67991ea9-431d-4d9d-9c99-a78b80108fe1",
+                  id: "ba7dfaf8-2b9f-4fbe-9243-c16a299598aa",
                   job_title: "English Teacher",
                   subjects: %w[English],
                   working_patterns: %w[full_time],

--- a/spec/factories/job_applications.rb
+++ b/spec/factories/job_applications.rb
@@ -2,8 +2,9 @@ FactoryBot.define do
   factory :job_application do
     transient do
       draft_at { 2.weeks.ago }
+      reviewed_at { 3.days.ago }
       shortlisted_at { 2.days.ago }
-      submitted_at { 3.days.ago }
+      submitted_at { 4.days.ago }
       unsuccessful_at { 1.day.ago }
       withdrawn_at { 1.week.ago }
       create_details { true }
@@ -68,6 +69,7 @@ FactoryBot.define do
 
       job_application.update_columns(
         draft_at: options.draft_at,
+        reviewed_at: options.reviewed_at,
         shortlisted_at: options.shortlisted_at,
         submitted_at: options.submitted_at,
         unsuccessful_at: options.unsuccessful_at,
@@ -127,6 +129,10 @@ FactoryBot.define do
     right_to_work_in_uk { "" }
 
     completed_steps { [] }
+  end
+
+  trait :status_reviewed do
+    status { :reviewed }
   end
 
   trait :status_shortlisted do

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe JobApplication do
 
     it "updates status timestamp" do
       freeze_time do
-        expect { subject.submitted! }.to change { subject.submitted_at }.from(3.days.ago).to(Time.current)
+        expect { subject.submitted! }.to change { subject.submitted_at }.from(4.days.ago).to(Time.current)
       end
     end
   end

--- a/spec/requests/jobseekers/job_applications_spec.rb
+++ b/spec/requests/jobseekers/job_applications_spec.rb
@@ -337,12 +337,12 @@ RSpec.describe "Job applications" do
       end
     end
 
-    context "when the application is not submitted or shortlisted" do
+    context "when the application is not reviewed, submitted or shortlisted" do
       let!(:job_application) { create(:job_application, jobseeker: jobseeker, vacancy: vacancy) }
 
       it "raises an error" do
         expect { get(jobseekers_job_application_confirm_withdraw_path(job_application.id)) }
-          .to raise_error(ActionController::RoutingError, /non-submitted or non-shortlisted/)
+          .to raise_error(ActionController::RoutingError, %r{non-reviewed/shortlisted/submitted})
       end
     end
   end
@@ -375,12 +375,12 @@ RSpec.describe "Job applications" do
       end
     end
 
-    context "when the application is not submitted or shortlisted" do
+    context "when the application is not reviewed, submitted or shortlisted" do
       let!(:job_application) { create(:job_application, jobseeker: jobseeker, vacancy: vacancy) }
 
       it "raises an error" do
         expect { post(jobseekers_job_application_withdraw_path(job_application.id)) }
-          .to raise_error(ActionController::RoutingError, /non-submitted or non-shortlisted/)
+          .to raise_error(ActionController::RoutingError, %r{non-reviewed/shortlisted/submitted})
       end
     end
   end

--- a/spec/requests/publishers/vacancies/job_applications_spec.rb
+++ b/spec/requests/publishers/vacancies/job_applications_spec.rb
@@ -73,6 +73,22 @@ RSpec.describe "Job applications" do
       end
     end
 
+    context "when the job application status is submitted" do
+      it "updates the job application status to reviewed" do
+        expect { get(organisation_job_job_application_path(vacancy.id, job_application.id)) }
+          .to change { job_application.reload.status }.from("submitted").to("reviewed")
+      end
+    end
+
+    context "when the job application status is not submitted" do
+      let(:job_application) { create(:job_application, :status_shortlisted, vacancy: vacancy) }
+
+      it "does not update the job application status" do
+        expect { get(organisation_job_job_application_path(vacancy.id, job_application.id)) }
+          .to(not_change { job_application.reload.status })
+      end
+    end
+
     context "when the job application status is draft" do
       let(:job_application) { create(:job_application, :status_draft, vacancy: vacancy) }
 
@@ -138,9 +154,8 @@ RSpec.describe "Job applications" do
         end
 
         it "redirects to job applications page" do
-          # TODO: Update expectation when redirect is updated
           expect(post(organisation_job_job_application_update_status_path(vacancy.id, job_application.id), params: params))
-            .to redirect_to(organisation_jobs_path)
+            .to redirect_to(organisation_job_job_applications_path(vacancy.id))
         end
       end
 
@@ -159,9 +174,8 @@ RSpec.describe "Job applications" do
         end
 
         it "redirects to job applications page" do
-          # TODO: Update expectation when redirect is updated
           expect(post(organisation_job_job_application_update_status_path(vacancy.id, job_application.id), params: params))
-            .to redirect_to(organisation_jobs_path)
+            .to redirect_to(organisation_job_job_applications_path(vacancy.id))
         end
       end
     end

--- a/spec/system/jobseekers_can_view_a_job_application_spec.rb
+++ b/spec/system/jobseekers_can_view_a_job_application_spec.rb
@@ -19,6 +19,15 @@ RSpec.describe "Jobseekers can view a job application" do
 
     expect(show_page.banner.status.text).to eq(job_application.status)
 
+    expect(page).to have_css("div", class: "grey-border-box", text: I18n.t("jobseekers.job_applications.show.school_details.heading")) do |school_details|
+      expect(school_details).to have_content(job_application.vacancy.parent_organisation.name)
+      expect(school_details).to have_content(job_application.vacancy.parent_organisation.school_type)
+      expect(school_details).to have_content(job_application.vacancy.contact_number)
+      expect(school_details).to have_content(job_application.vacancy.contact_email)
+      expect(school_details).to have_content(job_application.vacancy.parent_organisation.website)
+      expect(school_details).to have_content(full_address(job_application.vacancy.parent_organisation))
+    end
+
     expect(show_page.timeline.items(text: I18n.t("jobseekers.job_applications.status_timestamps.submitted")).first.text)
       .to include(format_date(job_application.submitted_at.to_date) + I18n.t("jobs.time_at") + format_time(job_application.submitted_at))
 

--- a/spec/system/publishers_can_manage_job_applications_for_a_vacancy_spec.rb
+++ b/spec/system/publishers_can_manage_job_applications_for_a_vacancy_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "Publishers can manage job applications for a vacancy" do
     let(:vacancy_trait) { :expired }
 
     let!(:job_application_submitted) { create(:job_application, :status_submitted, vacancy: vacancy) }
+    let!(:job_application_reviewed) { create(:job_application, :status_reviewed, vacancy: vacancy) }
     let!(:job_application_shortlisted) { create(:job_application, :status_shortlisted, vacancy: vacancy) }
     let!(:job_application_unsuccessful) { create(:job_application, :status_unsuccessful, vacancy: vacancy) }
     let!(:job_application_draft) { create(:job_application, :status_draft, vacancy: vacancy) }
@@ -46,7 +47,7 @@ RSpec.describe "Publishers can manage job applications for a vacancy" do
 
         within(".application-count.govuk-tag--blue") do
           expect(page).to have_content("1")
-          expect(page).to have_content(I18n.t("publishers.vacancies.job_applications.index.review"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.job_applications.index.submitted"))
         end
 
         within(".application-count.govuk-tag--red") do
@@ -56,7 +57,7 @@ RSpec.describe "Publishers can manage job applications for a vacancy" do
       end
 
       it "shows a card for each application that has been submitted and no draft applications" do
-        expect(page).to have_css(".card-component", count: 3)
+        expect(page).to have_css(".card-component", count: 4)
       end
 
       it "shows correct vacancy actions available to the publisher" do
@@ -79,7 +80,7 @@ RSpec.describe "Publishers can manage job applications for a vacancy" do
 
       it "shows blue submitted tag" do
         within(".application-#{status} .card-component__body") do
-          expect(page).to have_css(".govuk-tag--blue", text: "review")
+          expect(page).to have_css(".govuk-tag--blue", text: "unread")
         end
       end
 
@@ -102,8 +103,43 @@ RSpec.describe "Publishers can manage job applications for a vacancy" do
       end
     end
 
+    describe "reviewed application" do
+      let(:status) { "reviewed" }
+
+      it "shows applicant name that links to application" do
+        within(".application-#{status} .card-component__header") do
+          expect(page).to have_link("#{job_application_reviewed.first_name} #{job_application_reviewed.last_name}", href: organisation_job_job_application_path(vacancy.id, job_application_reviewed.id))
+        end
+      end
+
+      it "shows blue submitted tag" do
+        within(".application-#{status} .card-component__body") do
+          expect(page).to have_css(".govuk-tag--purple", text: "reviewed")
+        end
+      end
+
+      it "shows date application was received" do
+        within(".application-#{status} .card-component__body") do
+          expect(page).to have_content(job_application_reviewed.submitted_at)
+        end
+      end
+
+      it "has action to reject application" do
+        within(".application-#{status} .card-component__actions") do
+          expect(page).to have_link(I18n.t("buttons.reject"), href: organisation_job_job_application_reject_path(vacancy.id, job_application_reviewed.id))
+        end
+      end
+
+      it "has action to shortlist application" do
+        within(".application-#{status} .card-component__actions") do
+          expect(page).to have_link(I18n.t("buttons.shortlist"), href: organisation_job_job_application_shortlist_path(vacancy.id, job_application_reviewed.id))
+        end
+      end
+    end
+
     describe "shortlisted application" do
       let(:status) { "shortlisted" }
+
       it "shows applicant name that links to application" do
         within(".application-#{status} .card-component__header") do
           expect(page).to have_link("#{job_application_shortlisted.first_name} #{job_application_shortlisted.last_name}", href: organisation_job_job_application_path(vacancy.id, job_application_shortlisted.id))
@@ -191,7 +227,7 @@ RSpec.describe "Publishers can manage job applications for a vacancy" do
 
         within(".application-count.govuk-tag--blue") do
           expect(page).to have_content("0")
-          expect(page).to have_content(I18n.t("publishers.vacancies.job_applications.index.review"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.job_applications.index.submitted"))
         end
 
         within(".application-count.govuk-tag--red") do

--- a/spec/system/publishers_can_reject_a_job_application_spec.rb
+++ b/spec/system/publishers_can_reject_a_job_application_spec.rb
@@ -20,8 +20,7 @@ RSpec.describe "Publishers can reject a job application" do
     fill_in "publishers_job_application_update_status_form[rejection_reasons]", with: "Some rejection reasons"
     click_on I18n.t("buttons.confirm_rejection")
 
-    # TODO: Update expectation when redirect is updated
-    expect(current_path).to eq(organisation_jobs_path)
+    expect(current_path).to eq(organisation_job_job_applications_path(vacancy.id))
     expect(page).to have_content(I18n.t("publishers.vacancies.job_applications.update_status.unsuccessful",
                                         name: "#{job_application.first_name} #{job_application.last_name}"))
     expect(job_application.reload.status).to eq("unsuccessful")

--- a/spec/system/publishers_can_shortlist_a_job_application_spec.rb
+++ b/spec/system/publishers_can_shortlist_a_job_application_spec.rb
@@ -20,8 +20,7 @@ RSpec.describe "Publishers can shortlist a job application" do
     fill_in "publishers_job_application_update_status_form[further_instructions]", with: "Some further instructions"
     click_on I18n.t("buttons.shortlist")
 
-    # TODO: Update expectation when redirect is updated
-    expect(current_path).to eq(organisation_jobs_path)
+    expect(current_path).to eq(organisation_job_job_applications_path(vacancy.id))
     expect(page).to have_content(I18n.t("publishers.vacancies.job_applications.update_status.shortlisted",
                                         name: "#{job_application.first_name} #{job_application.last_name}"))
     expect(job_application.reload.status).to eq("shortlisted")

--- a/spec/system/publishers_can_view_a_job_application_spec.rb
+++ b/spec/system/publishers_can_view_a_job_application_spec.rb
@@ -11,23 +11,27 @@ RSpec.describe "Publishers can view a job application" do
   before do
     allow(JobseekerApplicationsFeature).to receive(:enabled?).and_return(true)
     login_publisher(publisher: publisher, organisation: organisation)
-    show_page.load(job_id: vacancy.id, id: job_application.id)
   end
 
   context "when the job application status is unsuccessful" do
     let(:job_application) { create(:job_application, :status_unsuccessful, vacancy: vacancy) }
 
     it "shows the correct calls to action and timeline" do
+      show_page.load(job_id: vacancy.id, id: job_application.id)
+
       expect(show_page.actions).not_to have_css("a", class: "govuk-button", text: I18n.t("buttons.shortlist"))
       expect(show_page.actions).not_to have_css("a", class: "govuk-button--warning", text: I18n.t("buttons.reject"))
       expect(show_page.actions).to have_css("a", class: "govuk-button--secondary", text: I18n.t("buttons.print_download_application"))
 
       expect(show_page.timeline).to have_items(text: I18n.t("jobseekers.job_applications.status_timestamps.rejected"))
       expect(show_page.timeline).not_to have_items(text: I18n.t("jobseekers.job_applications.status_timestamps.shortlisted"))
+      expect(show_page.timeline).to have_items(text: I18n.t("jobseekers.job_applications.status_timestamps.reviewed"))
       expect(show_page.timeline).to have_items(text: I18n.t("jobseekers.job_applications.status_timestamps.submitted"))
 
       expect(show_page.timeline.items(text: I18n.t("jobseekers.job_applications.status_timestamps.rejected")).first.text)
         .to include(format_date(job_application.unsuccessful_at.to_date) + I18n.t("jobs.time_at") + format_time(job_application.unsuccessful_at))
+      expect(show_page.timeline.items(text: I18n.t("jobseekers.job_applications.status_timestamps.reviewed")).first.text)
+        .to include(format_date(job_application.reviewed_at.to_date) + I18n.t("jobs.time_at") + format_time(job_application.reviewed_at))
       expect(show_page.timeline.items(text: I18n.t("jobseekers.job_applications.status_timestamps.submitted")).first.text)
         .to include(format_date(job_application.submitted_at.to_date) + I18n.t("jobs.time_at") + format_time(job_application.submitted_at))
     end
@@ -37,16 +41,21 @@ RSpec.describe "Publishers can view a job application" do
     let(:job_application) { create(:job_application, :status_shortlisted, vacancy: vacancy) }
 
     it "shows the correct calls to action and timeline" do
+      show_page.load(job_id: vacancy.id, id: job_application.id)
+
       expect(show_page.actions).not_to have_css("a", class: "govuk-button", text: I18n.t("buttons.shortlist"))
       expect(show_page.actions).to have_css("a", class: "govuk-button--warning", text: I18n.t("buttons.reject"))
       expect(show_page.actions).to have_css("a", class: "govuk-button--secondary", text: I18n.t("buttons.print_download_application"))
 
       expect(show_page.timeline).not_to have_items(text: I18n.t("jobseekers.job_applications.status_timestamps.rejected"))
       expect(show_page.timeline).to have_items(text: I18n.t("jobseekers.job_applications.status_timestamps.shortlisted"))
+      expect(show_page.timeline).to have_items(text: I18n.t("jobseekers.job_applications.status_timestamps.reviewed"))
       expect(show_page.timeline).to have_items(text: I18n.t("jobseekers.job_applications.status_timestamps.submitted"))
 
       expect(show_page.timeline.items(text: I18n.t("jobseekers.job_applications.status_timestamps.shortlisted")).first.text)
         .to include(format_date(job_application.shortlisted_at.to_date) + I18n.t("jobs.time_at") + format_time(job_application.shortlisted_at))
+      expect(show_page.timeline.items(text: I18n.t("jobseekers.job_applications.status_timestamps.reviewed")).first.text)
+        .to include(format_date(job_application.reviewed_at.to_date) + I18n.t("jobs.time_at") + format_time(job_application.reviewed_at))
       expect(show_page.timeline.items(text: I18n.t("jobseekers.job_applications.status_timestamps.submitted")).first.text)
         .to include(format_date(job_application.submitted_at.to_date) + I18n.t("jobs.time_at") + format_time(job_application.submitted_at))
     end
@@ -54,16 +63,23 @@ RSpec.describe "Publishers can view a job application" do
 
   context "when the job application status is submitted" do
     it "shows the correct calls to action and timeline" do
-      expect(show_page.actions).to have_css("a", class: "govuk-button", text: I18n.t("buttons.shortlist"))
-      expect(show_page.actions).to have_css("a", class: "govuk-button--warning", text: I18n.t("buttons.reject"))
-      expect(show_page.actions).to have_css("a", class: "govuk-button--secondary", text: I18n.t("buttons.print_download_application"))
+      freeze_time do
+        show_page.load(job_id: vacancy.id, id: job_application.id)
 
-      expect(show_page.timeline).not_to have_items(text: I18n.t("jobseekers.job_applications.status_timestamps.rejected"))
-      expect(show_page.timeline).not_to have_items(text: I18n.t("jobseekers.job_applications.status_timestamps.shortlisted"))
-      expect(show_page.timeline).to have_items(text: I18n.t("jobseekers.job_applications.status_timestamps.submitted"))
+        expect(show_page.actions).to have_css("a", class: "govuk-button", text: I18n.t("buttons.shortlist"))
+        expect(show_page.actions).to have_css("a", class: "govuk-button--warning", text: I18n.t("buttons.reject"))
+        expect(show_page.actions).to have_css("a", class: "govuk-button--secondary", text: I18n.t("buttons.print_download_application"))
 
-      expect(show_page.timeline.items(text: I18n.t("jobseekers.job_applications.status_timestamps.submitted")).first.text)
-        .to include(format_date(job_application.submitted_at.to_date) + I18n.t("jobs.time_at") + format_time(job_application.submitted_at))
+        expect(show_page.timeline).not_to have_items(text: I18n.t("jobseekers.job_applications.status_timestamps.rejected"))
+        expect(show_page.timeline).not_to have_items(text: I18n.t("jobseekers.job_applications.status_timestamps.shortlisted"))
+        expect(show_page.timeline).to have_items(text: I18n.t("jobseekers.job_applications.status_timestamps.reviewed"))
+        expect(show_page.timeline).to have_items(text: I18n.t("jobseekers.job_applications.status_timestamps.submitted"))
+
+        expect(show_page.timeline.items(text: I18n.t("jobseekers.job_applications.status_timestamps.reviewed")).first.text)
+          .to include(format_date(Time.current.to_date) + I18n.t("jobs.time_at") + format_time(Time.current))
+        expect(show_page.timeline.items(text: I18n.t("jobseekers.job_applications.status_timestamps.submitted")).first.text)
+          .to include(format_date(job_application.submitted_at.to_date) + I18n.t("jobs.time_at") + format_time(job_application.submitted_at))
+      end
     end
   end
 end


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-2458

## Changes in this PR
- Update publisher job application page as per design
- Update publisher job application dashboard as per design
- Update jobseeker job application page as per design
- Add `reviewed` status to job applications that is triggered when a publisher views a submitted job application

## Product sign off
- [x] Looks good!

_NB: Developers - this will funk up your local database if you already have applications, so I recommend resetting/destroying job applications locally_