### PR TITLE
[TEVA-2347] Application Preview A:B Test

### DIFF
--- a/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
+++ b/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
@@ -24,8 +24,11 @@
                 = f.govuk_url_field :application_link, label: { size: "s" }, form_group: { classes: "optional-field" }
           - else
             = govuk_notification_banner title: t("banners.important") do |banner|
-              - banner.add_heading text: t(".notification.heading")
-              = t(".notification.description.content_html", link: govuk_link_to(t(".notification.description.link"), page_path("job-application-preview"), target: "_blank"))
+              - banner.add_heading text: t(".banner.heading")
+              - if current_variant?(:"2021_04_application_preview_test", :link)
+                = t(".banner.description.content_with_link_html", link: govuk_link_to(t(".banner.description.link"), page_path("job-application-preview"), target: "_blank"))
+              - else
+                = t(".banner.description.content_with_no_link")
             = f.govuk_radio_buttons_fieldset :enable_job_applications do
               = f.govuk_radio_button :enable_job_applications, true, link_errors: true do
                 = f.govuk_text_area :personal_statement_guidance, label: { size: "s" }, form_group: { classes: "optional-field" }

--- a/config/ab_tests.yml
+++ b/config/ab_tests.yml
@@ -35,6 +35,9 @@ shared:
     bottom_blue: 1
     modal: 1
     gds: 1
+  2021_04_application_preview_test:
+    link: 1
+    no_link: 1
 test:
   2021_04_cookie_consent_test:
     none: 0

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -155,11 +155,12 @@ en:
     vacancies:
       build:
         applying_for_the_job:
-          notification:
+          banner:
             heading: Teaching Vacancies application form
             description:
-              content_html: You can choose for candidates to apply for the job through Teaching Vacancies. %{link} (opens in new tab).
-              link: Preview the application form
+              content_with_link_html: You can choose for candidates to apply for the job through Teaching Vacancies. %{link}
+              content_with_no_link: You can choose for candidates to apply for the job through Teaching Vacancies.
+              link: Preview the application form (opens in new tab).
         process_title: Create a job listing steps
       destroy:
         success_html: >-


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2347

## Screenshots of UI changes:

### No Link

<img width="649" alt="Screenshot 2021-04-27 at 15 25 31" src="https://user-images.githubusercontent.com/30624173/116259033-5dafac80-a76d-11eb-90d7-02b7c0a0e535.png">

### Link

<img width="1135" alt="Screenshot 2021-04-29 at 12 24 22" src="https://user-images.githubusercontent.com/30624173/116543656-0aad3500-a8e6-11eb-974b-d80a6d9549c9.png">

## Comments

- There are styling issues with the no link variant due to problems with the component we use for it. I have contacted the person who built the component and they're looking into fixing it. Agreed with Christian that this is ok for now. 

## To Apply the Variants, Add...

### No Link 

- `?ab_test_override[2021_04_application_preview_test]=no_link`

### Link 

- `?ab_test_override[2021_04_application_preview_test]=link`