### PR TITLE
[TEVA 2436] align status tags for application sections to right

### DIFF
--- a/app/components/review_component.rb
+++ b/app/components/review_component.rb
@@ -28,13 +28,23 @@ class ReviewComponent < GovukComponent::Base
     end
 
     def call
-      tag.h2(class: classes, **html_attributes) { safe_join([title, edit_link, content].compact) }
+      tag.div(class: classes, **html_attributes) do
+        safe_join([
+          tag.div(class: "review-component__heading__title") do
+            safe_join([
+              tag.h2(class: "govuk-heading-m") { title },
+              edit_link,
+            ].compact)
+          end,
+          tag.div(class: "review-component__heading__status") { content },
+        ].compact)
+      end
     end
 
     private
 
     def default_classes
-      %w[review-component__heading govuk-heading-m]
+      %w[review-component__heading]
     end
 
     def edit_link

--- a/app/components/review_component/review_component.scss
+++ b/app/components/review_component/review_component.scss
@@ -1,20 +1,46 @@
 @import 'base_component';
 
 .review-component {
-  .review-component__heading {
-    a {
+  &__heading {
+    display: flex;
+    margin-bottom: govuk-spacing(4);
+
+    .govuk-link {
       @include govuk-font($size: 16, $weight: bold);
 
-      margin-left: govuk-spacing(4);
-      margin-right: govuk-spacing(4);
+      line-height: 1.6;
+      white-space: nowrap;
 
       @include govuk-media-query($from: desktop) {
         @include govuk-font($size: 19, $weight: bold);
       }
     }
 
-    .govuk-tag {
-      vertical-align: text-bottom;
+    &__title {
+      flex-basis: 50%;
+
+      @include govuk-media-query($from: tablet) {
+        flex-basis: 75%;
+      }
+
+      .govuk-heading-m {
+        display: block;
+
+        @include govuk-media-query($from: tablet) {
+          display: inline;
+          margin-bottom: 0;
+          margin-right: govuk-spacing(2);
+        }
+      }
+    }
+
+    &__status {
+      flex-grow: 1;
+      text-align: right;
+
+      .govuk-tag {
+        white-space: nowrap;
+      }
     }
   }
 

--- a/app/frontend/src/styles/application/jobseekers/jobseeker.scss
+++ b/app/frontend/src/styles/application/jobseekers/jobseeker.scss
@@ -6,4 +6,15 @@
   .moj-filter-layout__content {
     overflow-x: hidden;
   }
+
+  &.jobseekers_job_applications_review  {
+  .govuk-grid-column-two-thirds {
+
+    @media (max-width: 900px) {
+        box-sizing: border-box;
+        width: 100%;
+        padding: 0 govuk-spacing(3);
+      }
+    }
+  }
 }

--- a/spec/components/review_component_spec.rb
+++ b/spec/components/review_component_spec.rb
@@ -22,9 +22,8 @@ RSpec.describe ReviewComponent, type: :component do
 
       it "renders the edit link in the heading" do
         expect(page).to have_css("div", class: "review-component") do |review|
-          expect(review).to have_css("h2", class: "review-component__heading govuk-heading-m", text: title) do |heading|
-            expect(heading).to have_css("a", class: "govuk-link", text: text)
-          end
+          expect(review).to have_css("h2", class: "govuk-heading-m", text: title)
+          expect(review).to have_css("a", class: "govuk-link", text: text)
         end
       end
     end
@@ -32,7 +31,7 @@ RSpec.describe ReviewComponent, type: :component do
     context "when text and href are not provided" do
       it "does not render the edit link in the heading" do
         expect(page).to have_css("div", class: "review-component") do |review|
-          expect(review).to have_css("h2", class: "review-component__heading govuk-heading-m", text: title) do |heading|
+          expect(review).to have_css("h2", class: "govuk-heading-m", text: title) do |heading|
             expect(heading).not_to have_css("a", class: "govuk-link")
           end
         end
@@ -41,7 +40,7 @@ RSpec.describe ReviewComponent, type: :component do
 
     it "renders the heading with a title" do
       expect(page).to have_css("div", class: "review-component") do |review|
-        expect(review).to have_css("h2", class: "review-component__heading govuk-heading-m", text: title)
+        expect(review).to have_css("h2", class: "govuk-heading-m", text: title)
       end
     end
 
@@ -50,9 +49,8 @@ RSpec.describe ReviewComponent, type: :component do
 
       it "renders the heading with a title and the content provided" do
         expect(page).to have_css("div", class: "review-component") do |review|
-          expect(review).to have_css("h2", class: "review-component__heading govuk-heading-m", text: title) do |heading|
-            expect(heading).to have_css("strong", text: "A tag")
-          end
+          expect(review).to have_css("h2", class: "govuk-heading-m", text: title)
+          expect(review).to have_css("strong", text: "A tag")
         end
       end
     end
@@ -61,7 +59,7 @@ RSpec.describe ReviewComponent, type: :component do
   context "when a heading slot is not defined" do
     it "does not render the heading" do
       expect(page).to have_css("div", class: "review-component") do |review|
-        expect(review).not_to have_css("h2", class: "review-component__heading govuk-heading-m")
+        expect(review).not_to have_css("h2", class: "govuk-heading-m")
       end
     end
   end

--- a/spec/support/capybara_helper.rb
+++ b/spec/support/capybara_helper.rb
@@ -1,6 +1,6 @@
 module CapybaraHelper
   def click_header_link(text)
-    find("h2", text: text).find("a", text: "Change").click
+    find(".review-component__heading__title", text: text).find("a", text: "Change").click
   end
 
   def within_row_for(text:, element: "label", &block)


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-2436

below is where this has got to. i havent time tonight to do any more. i think need to discuss my comment r.e full width...

i dont feel like the default classes on this component are right either, need to sort that out

Desktop
![Screenshot 2021-04-26 at 11 06 32](https://user-images.githubusercontent.com/1792451/116066149-a6893780-a67f-11eb-9df9-510f5a18c2d3.png)


Mobile
![Screenshot 2021-04-22 at 20 37 06](https://user-images.githubusercontent.com/1792451/115775485-d946dd80-a3aa-11eb-9c61-2f5dc5cc9906.png)

tablet
![Screenshot 2021-04-26 at 10 58 00](https://user-images.githubusercontent.com/1792451/116065018-78efbe80-a67e-11eb-987a-6554d1e9b54e.png)

