### PR TITLE
Update build step call to action and redirect behaviour for job applications

### DIFF
--- a/app/helpers/job_application_helper.rb
+++ b/app/helpers/job_application_helper.rb
@@ -65,4 +65,12 @@ module JobApplicationHelper
 
     govuk_tag(**tag_attributes)
   end
+
+  def job_application_build_submit_button_text
+    if redirect_to_review?
+      t("buttons.save")
+    else
+      t("buttons.save_and_continue")
+    end
+  end
 end

--- a/app/views/jobseekers/job_applications/build/ask_for_support.html.slim
+++ b/app/views/jobseekers/job_applications/build/ask_for_support.html.slim
@@ -28,7 +28,7 @@
           = f.govuk_text_area :support_needed_details, rows: 10
         = f.govuk_radio_button :support_needed, :no
 
-      = f.govuk_submit current_jobseeker.job_applications.not_draft.none? ? t("buttons.save_and_continue") : t("buttons.save_changes") do
+      = f.govuk_submit job_application_build_submit_button_text do
         = f.govuk_submit t("buttons.save_and_come_back"), secondary: true
 
   - if current_jobseeker.job_applications.not_draft.none?

--- a/app/views/jobseekers/job_applications/build/declarations.html.slim
+++ b/app/views/jobseekers/job_applications/build/declarations.html.slim
@@ -23,7 +23,7 @@
 
       = f.govuk_collection_radio_buttons :right_to_work_in_uk, %w[yes no], :to_s, :capitalize, inline: true
 
-      = f.govuk_submit current_jobseeker.job_applications.not_draft.none? ? t("buttons.save_and_continue") : t("buttons.save_changes") do
+      = f.govuk_submit job_application_build_submit_button_text do
         = f.govuk_submit t("buttons.save_and_come_back"), secondary: true
 
   - if current_jobseeker.job_applications.not_draft.none?

--- a/app/views/jobseekers/job_applications/build/employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/build/employment_history.html.slim
@@ -51,7 +51,7 @@
           = f.govuk_text_area :gaps_in_employment_details, form_group: { classes: "optional-field" }
         = f.govuk_radio_button :gaps_in_employment, :no
 
-      = f.govuk_submit current_jobseeker.job_applications.not_draft.none? ? t("buttons.save_and_continue") : t("buttons.save_changes") do
+      = f.govuk_submit job_application_build_submit_button_text do
         = f.govuk_submit t("buttons.save_and_come_back"), secondary: true
 
   - if current_jobseeker.job_applications.not_draft.none?

--- a/app/views/jobseekers/job_applications/build/equal_opportunities.html.slim
+++ b/app/views/jobseekers/job_applications/build/equal_opportunities.html.slim
@@ -66,7 +66,7 @@
         = f.govuk_radio_divider
         = f.govuk_radio_button :religion, :prefer_not_to_say
 
-      = f.govuk_submit current_jobseeker.job_applications.not_draft.none? ? t("buttons.save_and_continue") : t("buttons.save_changes") do
+      = f.govuk_submit job_application_build_submit_button_text do
         = f.govuk_submit t("buttons.save_and_come_back"), secondary: true
 
   - if current_jobseeker.job_applications.not_draft.none?

--- a/app/views/jobseekers/job_applications/build/personal_details.html.slim
+++ b/app/views/jobseekers/job_applications/build/personal_details.html.slim
@@ -28,7 +28,7 @@
       = f.govuk_text_field :teacher_reference_number, label: { size: "s" }, width: "one-half", aria: { required: true }, form_group: { classes: "optional-field" }
       = f.govuk_text_field :national_insurance_number, label: { size: "s" }, width: "one-half", form_group: { classes: "optional-field" }
 
-      = f.govuk_submit current_jobseeker.job_applications.not_draft.none? ? t("buttons.save_and_continue") : t("buttons.save_changes") do
+      = f.govuk_submit job_application_build_submit_button_text do
         = f.govuk_submit t("buttons.save_and_come_back"), secondary: true
 
   - if current_jobseeker.job_applications.not_draft.none?

--- a/app/views/jobseekers/job_applications/build/personal_statement.html.slim
+++ b/app/views/jobseekers/job_applications/build/personal_statement.html.slim
@@ -29,7 +29,7 @@
 
       = f.govuk_text_area :personal_statement, label: { size: "s" }, rows: 15, required: true, aria: { required: true }
 
-      = f.govuk_submit current_jobseeker.job_applications.not_draft.none? ? t("buttons.save_and_continue") : t("buttons.save_changes") do
+      = f.govuk_submit job_application_build_submit_button_text do
         = f.govuk_submit t("buttons.save_and_come_back"), secondary: true
 
   - if current_jobseeker.job_applications.not_draft.none?

--- a/app/views/jobseekers/job_applications/build/professional_status.html.slim
+++ b/app/views/jobseekers/job_applications/build/professional_status.html.slim
@@ -25,7 +25,7 @@
 
       = f.govuk_collection_radio_buttons :statutory_induction_complete, %w[yes no], :to_s, :capitalize, inline: true
 
-      = f.govuk_submit current_jobseeker.job_applications.not_draft.none? ? t("buttons.save_and_continue") : t("buttons.save_changes") do
+      = f.govuk_submit job_application_build_submit_button_text do
         = f.govuk_submit t("buttons.save_and_come_back"), secondary: true
 
   - if current_jobseeker.job_applications.not_draft.none?

--- a/app/views/jobseekers/job_applications/build/qualifications.html.slim
+++ b/app/views/jobseekers/job_applications/build/qualifications.html.slim
@@ -48,7 +48,7 @@
 
       = f.govuk_error_summary
 
-      = f.govuk_submit t("buttons.save_and_continue") do
+      = f.govuk_submit job_application_build_submit_button_text do
         = f.govuk_submit t("buttons.save_and_come_back"), secondary: true
 
   - if current_jobseeker.job_applications.not_draft.none?

--- a/app/views/jobseekers/job_applications/build/references.html.slim
+++ b/app/views/jobseekers/job_applications/build/references.html.slim
@@ -37,7 +37,7 @@
       = f.govuk_error_summary
 
       - if job_application.references.many?
-        = f.govuk_submit t("buttons.save_and_continue") do
+        = f.govuk_submit job_application_build_submit_button_text do
           = f.govuk_submit t("buttons.save_and_come_back"), secondary: true
       - else
         = f.govuk_submit t("buttons.save_and_come_back"), secondary: true

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -33,6 +33,7 @@ en:
     print_download_application: Print or download
     reject: Reject
     resend_email: Resend request
+    save: Save
     save_and_continue: Save and continue
     save_and_come_back: Save and come back later
     save_and_return_later: Save and return later

--- a/spec/system/jobseekers_can_edit_a_draft_job_application_spec.rb
+++ b/spec/system/jobseekers_can_edit_a_draft_job_application_spec.rb
@@ -21,8 +21,7 @@ RSpec.describe "Jobseekers can edit a draft job application" do
 
     fill_in "First name", with: "Dave"
 
-    expect { click_on I18n.t("buttons.save_and_continue") }
-      .to change { job_application.reload.first_name }.from("Steve").to("Dave")
+    expect { click_on I18n.t("buttons.save") }.to change { job_application.reload.first_name }.from("Steve").to("Dave")
 
     expect(current_path).to eq(jobseekers_job_application_review_path(job_application))
     expect(page).to have_content(I18n.t("messages.jobseekers.job_applications.saved"))


### PR DESCRIPTION
## Changes in this PR
- Always redirect to review page when updating subsequent job application
- Update build step primary call to action based on the same criteria

## Product sign off
- [x] Looks good!