### PR TITLE
[TEVA-2501] Pluralise messages in applications dashboard

### DIFF
--- a/app/views/publishers/vacancies/job_applications/index.html.slim
+++ b/app/views/publishers/vacancies/job_applications/index.html.slim
@@ -27,17 +27,17 @@
     .govuk-grid-column-one-quarter
       .application-count.govuk-tag class="govuk-tag--#{status_tag_colour(:submitted)}"
         .govuk-heading-l = job_applications.submitted.count
-        h3.govuk-caption-s = t(".submitted")
+        h3.govuk-caption-s = t(".submitted", count: job_applications.submitted.count)
 
     .govuk-grid-column-one-quarter
       .application-count.govuk-tag class="govuk-tag--#{status_tag_colour(:shortlisted)}"
         .govuk-heading-l = job_applications.shortlisted.count
-        h3.govuk-caption-s = t(".shortlisted")
+        h3.govuk-caption-s = t(".shortlisted", count: job_applications.shortlisted.count)
 
     .govuk-grid-column-one-quarter
       .application-count.govuk-tag class="govuk-tag--#{status_tag_colour(:unsuccessful)}"
         .govuk-heading-l = job_applications.unsuccessful.count
-        h3.govuk-caption-s = t(".rejected")
+        h3.govuk-caption-s = t(".rejected", count: job_applications.unsuccessful.count)
 
 .govuk-grid-row
   .govuk-grid-column-one-third

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -192,12 +192,18 @@ en:
           heading: Applicants for
           no_applicants: Nobody has applied for this job yet
           received: Received on
-          rejected: Rejected applications
-          shortlisted: Shortlisted applications
+          rejected:
+            one: Rejected application
+            other: Rejected applications
+          shortlisted:
+            one: Shortlisted application
+            other: Shortlisted applications
           sort_by:
             date_received: date received (most recent)
             applicant_last_name: applicant last name (A to Z)
-          submitted: Unread applications
+          submitted:
+            one: Unread application
+            other: Unread applications
         reject:
           alert: The candidate will be sent an email telling them that their application has not been successful.
           heading: Reject applicant

--- a/spec/system/publishers_can_manage_job_applications_for_a_vacancy_spec.rb
+++ b/spec/system/publishers_can_manage_job_applications_for_a_vacancy_spec.rb
@@ -42,17 +42,17 @@ RSpec.describe "Publishers can manage job applications for a vacancy" do
       it "shows total of each status for all applications" do
         within(".application-count.govuk-tag--green") do
           expect(page).to have_content("1")
-          expect(page).to have_content(I18n.t("publishers.vacancies.job_applications.index.shortlisted"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.job_applications.index.shortlisted", count: 1))
         end
 
         within(".application-count.govuk-tag--blue") do
           expect(page).to have_content("1")
-          expect(page).to have_content(I18n.t("publishers.vacancies.job_applications.index.submitted"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.job_applications.index.submitted", count: 1))
         end
 
         within(".application-count.govuk-tag--red") do
           expect(page).to have_content("1")
-          expect(page).to have_content(I18n.t("publishers.vacancies.job_applications.index.rejected"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.job_applications.index.rejected", count: 1))
         end
       end
 
@@ -222,17 +222,17 @@ RSpec.describe "Publishers can manage job applications for a vacancy" do
       it "shows total of each status for all applications" do
         within(".application-count.govuk-tag--green") do
           expect(page).to have_content("0")
-          expect(page).to have_content(I18n.t("publishers.vacancies.job_applications.index.shortlisted"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.job_applications.index.shortlisted", count: 0))
         end
 
         within(".application-count.govuk-tag--blue") do
           expect(page).to have_content("0")
-          expect(page).to have_content(I18n.t("publishers.vacancies.job_applications.index.submitted"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.job_applications.index.submitted", count: 0))
         end
 
         within(".application-count.govuk-tag--red") do
           expect(page).to have_content("0")
-          expect(page).to have_content(I18n.t("publishers.vacancies.job_applications.index.rejected"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.job_applications.index.rejected", count: 0))
         end
       end
 


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-2501

## Changes in this PR
- Singularise or pluralise the number of applications in dashboard

## Product sign off
- [ ] Looks good!

## Screenshots of UI changes:
![Screenshot 2021-04-26 at 14 38 45](https://user-images.githubusercontent.com/7215/116092345-a26c1280-a69d-11eb-908c-e67330b74a3d.png)
