### PR TITLE
[TEVA-2273] Monitor all redis instances via prometheus

### DIFF
--- a/terraform/monitoring/data.tf
+++ b/terraform/monitoring/data.tf
@@ -1,17 +1,3 @@
-data "cloudfoundry_space" "monitoring" {
-  name     = local.monitoring_space_name
-  org_name = local.monitoring_org_name
-}
-
-data "cloudfoundry_space" "service" {
-  name     = local.service_space_name
-  org_name = local.monitoring_org_name
-}
-data "cloudfoundry_service_instance" "redis_queue" {
-  name_or_id = local.redis_queue_name
-  space      = data.cloudfoundry_space.service.id
-}
-
 data "aws_ssm_parameter" "monitoring_secrets" {
   name = "/${local.service_name}/production/infra/monitoring"
 }

--- a/terraform/monitoring/resources.tf
+++ b/terraform/monitoring/resources.tf
@@ -11,5 +11,10 @@ module "prometheus_all" {
   alert_rules                = file("${path.module}/config/alert.rules.yml")
   alertmanager_slack_url     = local.alertmanager_slack_url
   alertmanager_slack_channel = local.alertmanager_slack_channel
-  redis_service_instance_id  = data.cloudfoundry_service_instance.redis_queue.id
+  redis_services = [
+    "${local.service_name}-production/${local.service_name}-redis-queue-production",
+    "${local.service_name}-production/${local.service_name}-redis-cache-production",
+    "${local.service_name}-staging/${local.service_name}-redis-queue-staging",
+    "${local.service_name}-staging/${local.service_name}-redis-cache-staging"
+  ]
 }

--- a/terraform/monitoring/variables.tf
+++ b/terraform/monitoring/variables.tf
@@ -7,10 +7,7 @@ locals {
   monitoring_instance_name   = local.service_name
   paas_api_url               = "https://api.london.cloud.service.gov.uk"
   monitoring_org_name        = "dfe"
-  space_name                 = "${local.service_name}-monitoring"
   monitoring_space_name      = "${local.service_name}-monitoring"
-  service_space_name         = "${local.service_name}-production"
-  redis_queue_name           = "${local.service_name}-redis-queue-production"
   aws_region                 = "eu-west-2"
   secrets                    = yamldecode(data.aws_ssm_parameter.monitoring_secrets.value)
   alertmanager_slack_url     = local.secrets["alertmanager_slack_url"]


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2273

## Changes in this PR:
We can now monitor queue and cache redis in staging and production
