### PR TITLE
Terraform: IAM tweaks for attachment buckets

### DIFF
--- a/terraform/common/iam.tf
+++ b/terraform/common/iam.tf
@@ -98,10 +98,15 @@ data "aws_iam_policy_document" "deployments_role_policy" {
   statement {
     sid = "ManageAttachmentBucketUsers"
     actions = [
+      "iam:GetUser",
       "iam:CreateUser",
+      "iam:UpdateUser",
       "iam:DeleteUser",
+      "iam:ListGroupsForUser",
+      "iam:ListAccessKeys",
       "iam:CreateAccessKey",
       "iam:DeleteAccessKey",
+      "iam:ListAttachedUserPolicies",
       "iam:AttachUserPolicy",
       "iam:DetachUserPolicy"
     ]
@@ -110,6 +115,9 @@ data "aws_iam_policy_document" "deployments_role_policy" {
   statement {
     sid = "ManageAttachmentBucketPolicies"
     actions = [
+      "iam:GetPolicy",
+      "iam:GetPolicyVersion",
+      "iam:ListPolicyVersions",
       "iam:CreatePolicy",
       "iam:DeletePolicy"
     ]
@@ -119,8 +127,8 @@ data "aws_iam_policy_document" "deployments_role_policy" {
   # S3 file attachment buckets
   statement {
     sid       = "ManageAttachmentBucketS3"
-    actions   = ["s3:CreateBucket", "s3:DeleteBucket"]
-    resources = ["arn:aws:s3:::${data.aws_caller_identity.current.account_id}-${local.service_name}-attachments-*"]
+    actions   = ["s3:*"]
+    resources = ["arn:aws:s3:::${data.aws_caller_identity.current.account_id}-${local.service_abbreviation}-attachments-*"]
   }
 
   # DB backups in S3


### PR DESCRIPTION
- Add additional required actions for managing attachment bucket users
  and policies (`apply` was failing for the S3 bucket PR because the
  deployments role didn't have enough permissions)
- Give unrestricted access to S3 (limited to attachment bucket
  resources) to deployments role
- Add service abbreviation to S3 attachment bucket name in policy

- [ ] Apply TF common updates