### PR TITLE
Reduce jobseeker session timeout to 8 hours

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -186,7 +186,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  config.timeout_in = 2.weeks
+  config.timeout_in = 8.hours
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.

--- a/spec/system/jobseekers_session_timeout_spec.rb
+++ b/spec/system/jobseekers_session_timeout_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Jobseekers session timeout" do
   let!(:jobseeker) { create(:jobseeker, email: "jobseeker@example.com") }
-  let(:timeout_period) { 2.weeks }
+  let(:timeout_period) { 8.hours }
 
   before { login_as(jobseeker, scope: :jobseeker) }
 


### PR DESCRIPTION
Now that we will start handling more personal data, improve security by
decreasing the amount of time jobseekers stay logged in to their account
without activity.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2529