### PR TITLE
[TEVA-2422] Check employment dates are in the past

### DIFF
--- a/app/form_models/jobseekers/job_application/details/employment_form.rb
+++ b/app/form_models/jobseekers/job_application/details/employment_form.rb
@@ -6,16 +6,41 @@ class Jobseekers::JobApplication::Details::EmploymentForm
 
   validates :organisation, :job_title, :main_duties, presence: true
   validates :started_on, presence: true, date: true
+  validate :started_on_is_in_the_past
   validates :current_role, inclusion: { in: %w[yes no] }
   validates :ended_on, presence: true, date: true, if: -> { current_role == "no" }
+  validate :ended_on_is_in_the_past, if: -> { current_role == "no" }
   validate :ended_on_is_after_started_on, if: -> { current_role == "no" }
+
+  def started_on_is_in_the_past
+    return if started_on.nil?
+
+    errors.add(:started_on, :not_in_the_past) unless started_on_date < Date.current
+  rescue Date::Error, TypeError
+    nil
+  end
+
+  def ended_on_is_in_the_past
+    return if ended_on.nil?
+
+    errors.add(:ended_on, :not_in_the_past) unless ended_on_date < Date.current
+  rescue Date::Error, TypeError
+    nil
+  end
 
   def ended_on_is_after_started_on
     return if ended_on.nil? || started_on.nil?
 
-    errors.add(:ended_on, :before_started_on) unless
-      Date.new(ended_on[1], ended_on[2], ended_on[3]) > Date.new(started_on[1], started_on[2], started_on[3])
+    errors.add(:ended_on, :before_started_on) unless ended_on_date > started_on_date
   rescue Date::Error, TypeError
     nil
+  end
+
+  def started_on_date
+    @started_on_date ||= Date.new(started_on[1], started_on[2], started_on[3])
+  end
+
+  def ended_on_date
+    @ended_on_date ||= Date.new(ended_on[1], ended_on[2], ended_on[3])
   end
 end

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -343,6 +343,7 @@ en:
               before_started_on: End date must be after the start date
               blank: Enter the date you left this school or organisation
               invalid: Enter a valid end date
+              not_in_the_past: The date the role ended must be in the past
             job_title:
               blank: Enter your job title
             main_duties:
@@ -352,6 +353,7 @@ en:
             started_on:
               blank: Enter the date you started at this school or organisation
               invalid: Enter a valid start date
+              not_in_the_past: The date the role started must be in the past
         jobseekers/job_application/details/qualifications/category_form:
           attributes:
             <<: *qualification_errors

--- a/spec/form_models/jobseekers/job_application/details/employment_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/details/employment_form_spec.rb
@@ -28,6 +28,15 @@ RSpec.describe Jobseekers::JobApplication::Details::EmploymentForm, type: :model
     end
   end
 
+  context "when started_on is not in the past" do
+    let(:params) { { "started_on(1i)" => "2121", "started_on(2i)" => "01", "started_on(3i)" => "01" } }
+
+    it "is invalid" do
+      expect(subject).not_to be_valid
+      expect(subject.errors.of_kind?(:started_on, :not_in_the_past)).to be true
+    end
+  end
+
   context "when current_role is no" do
     let(:params) { { current_role: "no" } }
 
@@ -52,6 +61,19 @@ RSpec.describe Jobseekers::JobApplication::Details::EmploymentForm, type: :model
       it "is invalid" do
         expect(subject).not_to be_valid
         expect(subject.errors.of_kind?(:ended_on, :invalid)).to be true
+      end
+    end
+
+    context "when ended_on is not in the past" do
+      let(:params) do
+        { current_role: "no",
+          "started_on(1i)" => "2021", "started_on(2i)" => "01", "started_on(3i)" => "01",
+          "ended_on(1i)" => "2120", "ended_on(2i)" => "01", "ended_on(3i)" => "01" }
+      end
+
+      it "is invalid" do
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:ended_on, :not_in_the_past)).to be true
       end
     end
 


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-2422

## Changes in this PR:
We check that employment dates are in the past

## Screenshots of UI changes:
![Screenshot 2021-04-27 at 17 13 06](https://user-images.githubusercontent.com/7215/116276122-1aa90580-a77c-11eb-9b38-ca288ab3ff45.png)
![Screenshot 2021-04-27 at 17 13 34](https://user-images.githubusercontent.com/7215/116276127-1bda3280-a77c-11eb-8509-dd92e7594145.png)
