### PR TITLE
[TEVA-2461] Changes to Applicant Counting

### DIFF
--- a/app/components/publishers/vacancies_component.rb
+++ b/app/components/publishers/vacancies_component.rb
@@ -46,13 +46,17 @@ class Publishers::VacanciesComponent < ViewComponent::Base
     return unless vacancy.enable_job_applications?
     return unless include_job_applications?
 
-    if vacancy.job_applications.any?
-      link = govuk_link_to(I18n.t("jobs.manage.view_applicants", count: vacancy.job_applications.count),
+    after_submission_job_applications = vacancy.job_applications.after_submission
+
+    if after_submission_job_applications.any?
+      link = govuk_link_to(I18n.t("jobs.manage.view_applicants", count: after_submission_job_applications.count),
                            organisation_job_job_applications_path(vacancy.id),
                            class: "govuk-link--no-visited-state")
       tag.div(card.labelled_item(I18n.t("jobs.manage.applications"), link))
-    elsif vacancy.job_applications.none?
-      text = tag.span(I18n.t("jobs.manage.view_applicants", count: 0))
+    elsif vacancy.job_applications.withdrawn.any? || vacancy.job_applications.none?
+      text = govuk_link_to(I18n.t("jobs.manage.view_applicants", count: 0),
+                           organisation_job_job_applications_path(vacancy.id),
+                           class: "govuk-link--no-visited-state")
       tag.div(card.labelled_item(I18n.t("jobs.manage.applications"), text))
     end
   end
@@ -79,7 +83,7 @@ class Publishers::VacanciesComponent < ViewComponent::Base
   end
 
   def include_job_applications?
-    organisation.group_type != "local_authority" && @selected_type.in?(%w[published pending expired])
+    organisation.group_type != "local_authority" && @selected_type.in?(%w[published expired])
   end
 
   def selected_scope

--- a/app/components/publishers/vacancies_component/vacancies_component.html.slim
+++ b/app/components/publishers/vacancies_component/vacancies_component.html.slim
@@ -61,7 +61,6 @@
                     = view_applicants(vacancy, card)
                     = tag.div(card.labelled_item(t("jobs.manage.closing_date"), vacancy.application_deadline))
                   - when "pending"
-                    = view_applicants(vacancy, card)
                     = tag.div(card.labelled_item(t("jobs.publication_date"), vacancy.publish_on))
                     = tag.div(card.labelled_item(t("jobs.manage.closing_date"), vacancy.application_deadline))
                   - when "expired"

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -39,6 +39,7 @@ class JobApplication < ApplicationRecord
   has_many :references, dependent: :destroy
 
   scope :submitted_yesterday, -> { submitted.where("DATE(submitted_at) = ?", Date.yesterday) }
+  scope :after_submission, -> { where(status: %w[submitted reviewed shortlisted unsuccessful]) }
 
   def submit!
     submitted!

--- a/spec/components/publishers/vacancies_component_spec.rb
+++ b/spec/components/publishers/vacancies_component_spec.rb
@@ -26,173 +26,199 @@ RSpec.describe Publishers::VacanciesComponent, type: :component do
   end
 
   context "when organisation has active vacancies" do
-    context "when organisation is a school" do
+    context "when job applications have been received" do
+      context "when organisation is a school" do
+        let(:organisation) { create(:school, name: "A school with jobs") }
+        let(:vacancy) { create(:vacancy, :published) }
+        let!(:job_application) { create(:job_application, :status_submitted, vacancy: vacancy) }
+
+        before { vacancy.organisation_vacancies.create(organisation: organisation) }
+
+        let!(:inline_component) { render_inline(subject) }
+
+        it "renders the vacancies component" do
+          expect(inline_component.css(".moj-filter-layout__content").to_html).not_to be_blank
+        end
+
+        it "renders the number of jobs in the heading" do
+          expect(inline_component.css("h1.govuk-heading-l").text).to include("Active jobs (1)")
+        end
+
+        it "renders the vacancy job title in the table" do
+          expect(inline_component.css(".card-component").to_html).to include(vacancy.job_title)
+        end
+
+        it "renders the link to view applicants" do
+          expect(rendered_component).to include(I18n.t("jobs.manage.view_applicants", count: 1))
+          expect(rendered_component).to include(Rails.application.routes.url_helpers.organisation_job_job_applications_path(vacancy.id))
+        end
+
+        context "when withdrawn applications have also been received" do
+          let(:withdrawn_job_application) { create(:job_application, :status_withdrawn, vacancy: vacancy) }
+
+          it "does not affect the count" do
+            expect(rendered_component).to include(I18n.t("jobs.manage.view_applicants", count: 1))
+            expect(rendered_component).to include(Rails.application.routes.url_helpers.organisation_job_job_applications_path(vacancy.id))
+          end
+        end
+
+        it "does not render the vacancy readable job location in the table" do
+          expect(inline_component.css(".card-component #vacancy_location").to_html).to be_blank
+        end
+
+        it "does not render the filters sidebar" do
+          expect(inline_component.css('.edit_publisher_preference input[type="submit"]')).to be_blank
+        end
+
+        context "when there are no jobs within the selected vacancy type" do
+          let(:selected_type) { "draft" }
+
+          it "uses the correct 'no jobs' text ('no filters')" do
+            expect(rendered_component).to include(I18n.t("jobs.manage.draft.no_jobs.no_filters"))
+          end
+        end
+      end
+
+      context "when organisation is a trust" do
+        let(:organisation) { create(:trust) }
+        let(:open_school) { create(:school, name: "Open school") }
+        let(:closed_school) { create(:school, :closed, name: "Closed school") }
+        let!(:vacancy) do
+          create(:vacancy, :published, :central_office,
+                 organisation_vacancies_attributes: [{ organisation: organisation }])
+        end
+        let!(:job_application) { create(:job_application, :status_submitted, vacancy: vacancy) }
+
+        before do
+          organisation.school_group_memberships.create(school: open_school)
+          organisation.school_group_memberships.create(school: closed_school)
+        end
+
+        let!(:inline_component) { render_inline(subject) }
+
+        it "renders the vacancies component" do
+          expect(inline_component.css(".moj-filter-layout__content").to_html).not_to be_blank
+        end
+
+        it "renders the number of jobs in the heading" do
+          expect(inline_component.css("h1.govuk-heading-l").text).to include("Active jobs (1)")
+        end
+
+        it "renders the vacancy job title in the table" do
+          expect(inline_component.css(".card-component").to_html).to include(vacancy.job_title)
+        end
+
+        it "renders the vacancy readable job location in the table" do
+          expect(
+            inline_component.css(".card-component__header").to_html,
+          ).to include(vacancy.readable_job_location)
+        end
+
+        it "renders the link to view applicants" do
+          expect(rendered_component).to include(I18n.t("jobs.manage.view_applicants", count: 1))
+          expect(rendered_component).to include(Rails.application.routes.url_helpers.organisation_job_job_applications_path(vacancy.id))
+        end
+
+        it "renders the filters sidebar" do
+          expect(
+            inline_component.css('.edit_publisher_preference input[type="submit"]').attribute("value").value,
+          ).to eq(I18n.t("buttons.apply_filters"))
+        end
+
+        it "renders the trust head office as a filter option" do
+          expect(inline_component.css(".edit_publisher_preference").to_html).to include("Trust head office")
+        end
+
+        it "renders the open school as a filter option" do
+          expect(inline_component.css(".edit_publisher_preference").to_html).to include("Open school")
+        end
+
+        it "does not render the closed school as a filter option" do
+          expect(inline_component.css(".edit_publisher_preference").to_html).not_to include("Closed school")
+        end
+      end
+
+      context "when the organisation is a local authority" do
+        let(:organisation) { create(:local_authority) }
+        let(:open_school) { create(:school, name: "Open school") }
+        let(:closed_school) { create(:school, :closed, name: "Closed school") }
+        let(:publisher_preference) { create(:publisher_preference, publisher: publisher, organisation: organisation) }
+        let!(:vacancy) do
+          create(:vacancy, :published, :at_one_school,
+                 organisation_vacancies_attributes: [{ organisation: open_school }])
+        end
+        let!(:job_application) { create(:job_application, :status_submitted, vacancy: vacancy) }
+
+        before do
+          organisation.school_group_memberships.create(school: open_school)
+          organisation.school_group_memberships.create(school: closed_school)
+          publisher_preference.local_authority_publisher_schools.create(school_id: open_school.id)
+        end
+
+        let!(:inline_component) { render_inline(subject) }
+
+        it "renders the vacancies component" do
+          expect(inline_component.css(".moj-filter-layout__content").to_html).not_to be_blank
+        end
+
+        it "renders the number of jobs in the heading" do
+          expect(inline_component.css("h1.govuk-heading-l").text).to include("Active jobs (1)")
+        end
+
+        it "renders the vacancy job title in the table" do
+          expect(inline_component.css(".card-component").to_html).to include(vacancy.job_title)
+        end
+
+        it "does not render the link to view applicants" do
+          expect(rendered_component).not_to include(I18n.t("jobs.manage.view_applicants", count: 1))
+        end
+
+        it "renders the vacancy readable job location in the table" do
+          expect(
+            inline_component.css(".card-component__header").to_html,
+          ).to include(vacancy.readable_job_location)
+        end
+
+        it "renders the filters sidebar" do
+          expect(
+            inline_component.css('.edit_publisher_preference input[type="submit"]').attribute("value").value,
+          ).to eq(I18n.t("buttons.apply_filters"))
+        end
+
+        it "does not render the trust head office as a filter option" do
+          expect(inline_component.css(".edit_publisher_preference").to_html).not_to include("Trust head office")
+        end
+
+        it "renders the open school as a filter option" do
+          expect(inline_component.css(".edit_publisher_preference").to_html).to include("Open school")
+        end
+
+        it "does not render the closed school as a filter option" do
+          expect(inline_component.css(".edit_publisher_preference").to_html).not_to include("Closed school")
+        end
+
+        context "when there are no jobs within the selected vacancy type" do
+          let(:selected_type) { "draft" }
+
+          it "uses the correct 'no jobs' text ('no filters')" do
+            expect(rendered_component).to include(I18n.t("jobs.manage.draft.no_jobs.no_filters"))
+          end
+        end
+      end
+    end
+
+    context "when job applications have not been received" do
       let(:organisation) { create(:school, name: "A school with jobs") }
       let(:vacancy) { create(:vacancy, :published) }
-      let!(:job_application) { create(:job_application, :status_submitted, vacancy: vacancy) }
-
-      before { vacancy.organisation_vacancies.create(organisation: organisation) }
-
-      let!(:inline_component) { render_inline(subject) }
-
-      it "renders the vacancies component" do
-        expect(inline_component.css(".moj-filter-layout__content").to_html).not_to be_blank
-      end
-
-      it "renders the number of jobs in the heading" do
-        expect(inline_component.css("h1.govuk-heading-l").text).to include("Active jobs (1)")
-      end
-
-      it "renders the vacancy job title in the table" do
-        expect(inline_component.css(".card-component").to_html).to include(vacancy.job_title)
-      end
-
-      it "renders the link to view applicants" do
-        expect(rendered_component).to include(I18n.t("jobs.manage.view_applicants", count: 1))
-        expect(rendered_component).to include(Rails.application.routes.url_helpers.organisation_job_job_applications_path(vacancy.id))
-      end
-
-      it "does not render the vacancy readable job location in the table" do
-        expect(inline_component.css(".card-component #vacancy_location").to_html).to be_blank
-      end
-
-      it "does not render the filters sidebar" do
-        expect(inline_component.css('.edit_publisher_preference input[type="submit"]')).to be_blank
-      end
-
-      context "when there are no jobs within the selected vacancy type" do
-        let(:selected_type) { "draft" }
-
-        it "uses the correct 'no jobs' text ('no filters')" do
-          expect(rendered_component).to include(I18n.t("jobs.manage.draft.no_jobs.no_filters"))
-        end
-      end
-    end
-
-    context "when organisation is a trust" do
-      let(:organisation) { create(:trust) }
-      let(:open_school) { create(:school, name: "Open school") }
-      let(:closed_school) { create(:school, :closed, name: "Closed school") }
-      let!(:vacancy) do
-        create(:vacancy, :published, :central_office,
-               organisation_vacancies_attributes: [{ organisation: organisation }])
-      end
-      let!(:job_application) { create(:job_application, :status_submitted, vacancy: vacancy) }
 
       before do
-        organisation.school_group_memberships.create(school: open_school)
-        organisation.school_group_memberships.create(school: closed_school)
+        vacancy.organisation_vacancies.create(organisation: organisation)
+        render_inline(subject)
       end
 
-      let!(:inline_component) { render_inline(subject) }
-
-      it "renders the vacancies component" do
-        expect(inline_component.css(".moj-filter-layout__content").to_html).not_to be_blank
-      end
-
-      it "renders the number of jobs in the heading" do
-        expect(inline_component.css("h1.govuk-heading-l").text).to include("Active jobs (1)")
-      end
-
-      it "renders the vacancy job title in the table" do
-        expect(inline_component.css(".card-component").to_html).to include(vacancy.job_title)
-      end
-
-      it "renders the vacancy readable job location in the table" do
-        expect(
-          inline_component.css(".card-component__header").to_html,
-        ).to include(vacancy.readable_job_location)
-      end
-
-      it "renders the link to view applicants" do
-        expect(rendered_component).to include(I18n.t("jobs.manage.view_applicants", count: 1))
+      it "still renders the link to view applicants" do
+        expect(rendered_component).to include(I18n.t("jobs.manage.view_applicants", count: 0))
         expect(rendered_component).to include(Rails.application.routes.url_helpers.organisation_job_job_applications_path(vacancy.id))
-      end
-
-      it "renders the filters sidebar" do
-        expect(
-          inline_component.css('.edit_publisher_preference input[type="submit"]').attribute("value").value,
-        ).to eq(I18n.t("buttons.apply_filters"))
-      end
-
-      it "renders the trust head office as a filter option" do
-        expect(inline_component.css(".edit_publisher_preference").to_html).to include("Trust head office")
-      end
-
-      it "renders the open school as a filter option" do
-        expect(inline_component.css(".edit_publisher_preference").to_html).to include("Open school")
-      end
-
-      it "does not render the closed school as a filter option" do
-        expect(inline_component.css(".edit_publisher_preference").to_html).not_to include("Closed school")
-      end
-    end
-
-    context "when the organisation is a local authority" do
-      let(:organisation) { create(:local_authority) }
-      let(:open_school) { create(:school, name: "Open school") }
-      let(:closed_school) { create(:school, :closed, name: "Closed school") }
-      let(:publisher_preference) { create(:publisher_preference, publisher: publisher, organisation: organisation) }
-      let!(:vacancy) do
-        create(:vacancy, :published, :at_one_school,
-               organisation_vacancies_attributes: [{ organisation: open_school }])
-      end
-      let!(:job_application) { create(:job_application, :status_submitted, vacancy: vacancy) }
-
-      before do
-        organisation.school_group_memberships.create(school: open_school)
-        organisation.school_group_memberships.create(school: closed_school)
-        publisher_preference.local_authority_publisher_schools.create(school_id: open_school.id)
-      end
-
-      let!(:inline_component) { render_inline(subject) }
-
-      it "renders the vacancies component" do
-        expect(inline_component.css(".moj-filter-layout__content").to_html).not_to be_blank
-      end
-
-      it "renders the number of jobs in the heading" do
-        expect(inline_component.css("h1.govuk-heading-l").text).to include("Active jobs (1)")
-      end
-
-      it "renders the vacancy job title in the table" do
-        expect(inline_component.css(".card-component").to_html).to include(vacancy.job_title)
-      end
-
-      it "does not render the link to view applicants" do
-        expect(rendered_component).not_to include(I18n.t("jobs.manage.view_applicants", count: 1))
-      end
-
-      it "renders the vacancy readable job location in the table" do
-        expect(
-          inline_component.css(".card-component__header").to_html,
-        ).to include(vacancy.readable_job_location)
-      end
-
-      it "renders the filters sidebar" do
-        expect(
-          inline_component.css('.edit_publisher_preference input[type="submit"]').attribute("value").value,
-        ).to eq(I18n.t("buttons.apply_filters"))
-      end
-
-      it "does not render the trust head office as a filter option" do
-        expect(inline_component.css(".edit_publisher_preference").to_html).not_to include("Trust head office")
-      end
-
-      it "renders the open school as a filter option" do
-        expect(inline_component.css(".edit_publisher_preference").to_html).to include("Open school")
-      end
-
-      it "does not render the closed school as a filter option" do
-        expect(inline_component.css(".edit_publisher_preference").to_html).not_to include("Closed school")
-      end
-
-      context "when there are no jobs within the selected vacancy type" do
-        let(:selected_type) { "draft" }
-
-        it "uses the correct 'no jobs' text ('no filters')" do
-          expect(rendered_component).to include(I18n.t("jobs.manage.draft.no_jobs.no_filters"))
-        end
       end
     end
   end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2461

## Changes in this PR:

- Removed text related to applications for scheduled jobs
- The number of applications shown now only counts submitted applications
- Added link to publisher job applications index page for jobs that have not received any applications or have only received withdrawn applications

## Comments:

- Have not done 1 and 1a (in the acceptance criteria) as this had already been done.

## Screenshots of UI changes:

### No Applicants / Only Withdrawn Applicants

<img width="1058" alt="Screenshot 2021-04-27 at 17 06 17" src="https://user-images.githubusercontent.com/30624173/116279394-6315f280-a77f-11eb-9050-ee7cf79b004a.png">

### Scheduled Jobs

<img width="1096" alt="Screenshot 2021-04-27 at 16 13 48" src="https://user-images.githubusercontent.com/30624173/116279360-585b5d80-a77f-11eb-9cc7-b88713ae9c49.png">


