### PR TITLE
Reduce maximum attempts before locking

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -206,7 +206,7 @@ Devise.setup do |config|
 
   # Number of authentication tries before locking an account if lock_strategy
   # is failed attempts.
-  config.maximum_attempts = 10
+  config.maximum_attempts = 5
 
   # Time interval to unlock the account if :time is enabled as unlock_strategy.
   # config.unlock_in = 1.hour


### PR DESCRIPTION
When a jobseeker attempts to log in with an invalid password, give them
5 (instead of 10) attempts before we lock their account.