### PR TITLE
[TEVA-2417] Job alert email uids

### DIFF
--- a/app/helpers/notify_view_helper.rb
+++ b/app/helpers/notify_view_helper.rb
@@ -8,42 +8,40 @@ module NotifyViewHelper
   end
 
   def edit_link(subscription)
-    url = edit_subscription_url(subscription.token, params: utm_params(subscription))
+    url = edit_subscription_url(subscription.token, **utm_params)
     notify_link(url, t(".edit_link_text"))
   end
 
-  def home_page_link(subscription)
-    url = root_url(params: utm_params(subscription))
+  def home_page_link
+    url = root_url(**utm_params)
     notify_link(url, t("app.title"))
   end
 
   def job_alert_feedback_url(relevant, subscription, vacancies)
-    new_subscription_job_alert_feedback_url(
-      subscription.token,
-      params: { job_alert_feedback: { relevant_to_user: relevant,
-                                      job_alert_vacancy_ids: vacancies.pluck(:id),
-                                      search_criteria: subscription.search_criteria } },
-    )
+    params = { job_alert_feedback: { relevant_to_user: relevant,
+                                     job_alert_vacancy_ids: vacancies.pluck(:id),
+                                     search_criteria: subscription.search_criteria } }.merge(utm_params)
+    new_subscription_job_alert_feedback_url(subscription.token, **params)
   end
 
-  def show_link(vacancy, subscription)
-    url = vacancy.share_url(**utm_params(subscription))
-    text = vacancy.job_title
-    notify_link(url, text)
+  def show_link(vacancy)
+    url = vacancy.share_url(**utm_params)
+    notify_link(url, vacancy.job_title)
   end
 
-  def sign_up_link(subscription)
-    notify_link(new_jobseeker_registration_url(params: utm_params(subscription)), t(".create_account.link"))
+  def sign_up_link
+    url = new_jobseeker_registration_url(**utm_params)
+    notify_link(url, t(".create_account.link"))
   end
 
   def unsubscribe_link(subscription)
-    url = unsubscribe_subscription_url(subscription.token, params: utm_params(subscription))
+    url = unsubscribe_subscription_url(subscription.token, **utm_params)
     notify_link(url, t(".unsubscribe_link_text"))
   end
 
   private
 
-  def utm_params(subscription)
-    { utm_source: subscription.alert_run_today&.id, utm_medium: "email", utm_campaign: "#{subscription.frequency}_alert" }
+  def utm_params
+    { utm_source: uid, utm_medium: "email", utm_campaign: utm_campaign }
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -2,15 +2,31 @@ class ApplicationMailer < Mail::Notify::Mailer
   helper NotifyViewHelper
   helper OrganisationHelper
 
+  helper_method :uid, :utm_campaign
+
   after_action :trigger_email_event
 
   private
+
+  attr_reader :template, :to
+
+  def trigger_email_event
+    email_event.trigger(email_event_type, email_event_data)
+  end
 
   def email_event_data
     {}
   end
 
-  def trigger_email_event
-    email_event.trigger("#{email_event_prefix}_#{action_name}".to_sym, email_event_data)
+  def email_event_type
+    "#{email_event_prefix}_#{action_name}".to_sym
+  end
+
+  def uid
+    @uid ||= SecureRandom.uuid
+  end
+
+  def utm_campaign
+    email_event_type
   end
 end

--- a/app/mailers/jobseekers/alert_mailer.rb
+++ b/app/mailers/jobseekers/alert_mailer.rb
@@ -17,6 +17,8 @@ class Jobseekers::AlertMailer < Jobseekers::BaseMailer
 
   private
 
+  attr_reader :subscription_id
+
   def email_event_data
     { subscription_identifier: StringAnonymiser.new(subscription.id), subscription_frequency: subscription.frequency }
   end
@@ -30,6 +32,10 @@ class Jobseekers::AlertMailer < Jobseekers::BaseMailer
   end
 
   def subscription
-    @subscription ||= SubscriptionPresenter.new(Subscription.find(@subscription_id))
+    @subscription ||= SubscriptionPresenter.new(Subscription.find(subscription_id))
+  end
+
+  def utm_campaign
+    "#{subscription.frequency}_alert"
   end
 end

--- a/app/mailers/jobseekers/base_mailer.rb
+++ b/app/mailers/jobseekers/base_mailer.rb
@@ -2,7 +2,7 @@ class Jobseekers::BaseMailer < ApplicationMailer
   private
 
   def email_event
-    @email_event ||= EmailEvent.new(@template, @to, jobseeker: @jobseeker)
+    @email_event ||= EmailEvent.new(template, to, uid, jobseeker: @jobseeker)
   end
 
   def email_event_prefix

--- a/app/mailers/publishers/base_mailer.rb
+++ b/app/mailers/publishers/base_mailer.rb
@@ -2,7 +2,7 @@ class Publishers::BaseMailer < ApplicationMailer
   private
 
   def email_event
-    @email_event ||= EmailEvent.new(@template, @to, publisher: @publisher)
+    @email_event ||= EmailEvent.new(template, to, uid, publisher: @publisher)
   end
 
   def email_event_prefix

--- a/app/services/email_event.rb
+++ b/app/services/email_event.rb
@@ -3,19 +3,21 @@
 #
 # This event should only be triggered in mailers.
 class EmailEvent < Event
-  def initialize(notify_template, email, jobseeker: nil, publisher: nil)
+  def initialize(notify_template, email, uid, jobseeker: nil, publisher: nil)
     @notify_template = notify_template
     @email = email
+    @uid = uid
     @jobseeker = jobseeker
     @publisher = publisher
   end
 
   private
 
-  attr_reader :notify_template, :email, :jobseeker, :publisher
+  attr_reader :notify_template, :email, :uid, :jobseeker, :publisher
 
   def data
     @data ||= super.push(
+      { key: "uid", value: uid },
       { key: "notify_template", value: notify_template },
       { key: "email_identifier", value: anonymise(email) },
       { key: "user_anonymised_jobseeker_id", value: anonymise(jobseeker&.id) },

--- a/app/views/jobseekers/alert_mailer/alert.text.erb
+++ b/app/views/jobseekers/alert_mailer/alert.text.erb
@@ -3,7 +3,7 @@
 ---
 
 <%- @vacancies.each do |vacancy| %>
-  <%= show_link(vacancy, subscription) %>
+  <%= show_link(vacancy) %>
   <%= location(vacancy.parent_organisation, job_location: vacancy.job_location) %>
 
   <%= t(".salary", salary: vacancy.salary) %>
@@ -38,12 +38,12 @@
 
 <%- unless jobseeker.present? %>
   # <%= t(".create_account.heading") %>
-  <%= t(".create_account.intro", link_to: sign_up_link(subscription)) %>
+  <%= t(".create_account.intro", link_to: sign_up_link) %>
 
   ---
 
 <% end %>
 
-<%= t("shared.footer", home_page_link: home_page_link(subscription)) %>
+<%= t("shared.footer", home_page_link: home_page_link) %>
 
 <%= t(".unsubscribe", unsubscribe_link: unsubscribe_link(subscription)) %>

--- a/app/views/jobseekers/subscription_mailer/confirmation.text.erb
+++ b/app/views/jobseekers/subscription_mailer/confirmation.text.erb
@@ -11,7 +11,7 @@
 
 <%- unless jobseeker.present? %>
   # <%= t(".create_account.heading") %>
-  <%= t(".create_account.intro", link_to: sign_up_link(subscription)) %>
+  <%= t(".create_account.intro", link_to: sign_up_link) %>
 
   ---
 

--- a/app/views/jobseekers/subscription_mailer/update.text.erb
+++ b/app/views/jobseekers/subscription_mailer/update.text.erb
@@ -11,7 +11,7 @@
 
 <%- unless jobseeker.present? %>
   # <%= t(".create_account.heading") %>
-  <%= t(".create_account.intro", link_to: sign_up_link(subscription)) %>
+  <%= t(".create_account.intro", link_to: sign_up_link) %>
 
   ---
 

--- a/spec/mailers/jobseekers/alert_mailer_spec.rb
+++ b/spec/mailers/jobseekers/alert_mailer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Jobseekers::AlertMailer do
   let(:mail) { described_class.alert(subscription.id, vacancies.pluck(:id)) }
   # The array of vacancies is set to length 1 because the order varies, making it hard to test url parameters.
   let(:vacancies) { VacanciesPresenter.new(create_list(:vacancy, 1, :published)).decorated_collection }
-  let(:campaign_params) { { utm_source: subscription.alert_run_today.id, utm_medium: "email", utm_campaign: "#{frequency}_alert" } }
+  let(:campaign_params) { { utm_source: "a_unique_identifier", utm_medium: "email", utm_campaign: "#{frequency}_alert" } }
   let(:relevant_job_alert_feedback_url) do
     new_subscription_job_alert_feedback_url(
       subscription.token,
@@ -48,10 +48,13 @@ RSpec.describe Jobseekers::AlertMailer do
       user_anonymised_publisher_id: nil,
       subscription_identifier: anonymised_form_of(subscription.id),
       subscription_frequency: frequency,
+      uid: "a_unique_identifier",
     }
   end
 
   before do
+    # Stub the uid so that we can test links more easily
+    allow_any_instance_of(ApplicationMailer).to receive(:uid).and_return("a_unique_identifier")
     vacancies.each { |vacancy| vacancy.organisation_vacancies.create(organisation: school) }
     subscription.create_alert_run
   end

--- a/spec/mailers/jobseekers/subscription_mailer_spec.rb
+++ b/spec/mailers/jobseekers/subscription_mailer_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Jobseekers::SubscriptionMailer do
     subscription
   end
 
-  let(:campaign_params) { { utm_source: nil, utm_medium: "email", utm_campaign: "daily_alert" } }
   let(:body) { mail.body }
 
   let(:expected_data) do
@@ -25,12 +24,17 @@ RSpec.describe Jobseekers::SubscriptionMailer do
       user_anonymised_jobseeker_id: user_anonymised_jobseeker_id,
       user_anonymised_publisher_id: nil,
       subscription_identifier: anonymised_form_of(subscription.id),
+      uid: "a_unique_identifier",
     }
   end
+
+  # Stub the uid so that we can test links more easily
+  before { allow_any_instance_of(ApplicationMailer).to receive(:uid).and_return("a_unique_identifier") }
 
   describe "#confirmation" do
     let(:mail) { described_class.confirmation(subscription.id) }
     let(:notify_template) { NOTIFY_SUBSCRIPTION_CONFIRMATION_TEMPLATE }
+    let(:campaign_params) { { utm_source: "a_unique_identifier", utm_medium: "email", utm_campaign: "jobseeker_subscription_confirmation" } }
 
     it "sends a confirmation email" do
       expect(mail.subject).to eq(I18n.t("jobseekers.subscription_mailer.confirmation.subject"))
@@ -81,6 +85,7 @@ RSpec.describe Jobseekers::SubscriptionMailer do
   describe "#update" do
     let(:mail) { described_class.update(subscription.id) }
     let(:notify_template) { NOTIFY_SUBSCRIPTION_UPDATE_TEMPLATE }
+    let(:campaign_params) { { utm_source: "a_unique_identifier", utm_medium: "email", utm_campaign: "jobseeker_subscription_update" } }
 
     it "sends a confirmation email" do
       expect(mail.subject).to eq(I18n.t("jobseekers.subscription_mailer.update.subject"))

--- a/spec/services/email_event_spec.rb
+++ b/spec/services/email_event_spec.rb
@@ -1,12 +1,13 @@
 require "rails_helper"
 
 RSpec.describe EmailEvent do
-  subject { described_class.new(notify_template, email, jobseeker: jobseeker, publisher: publisher) }
+  subject { described_class.new(notify_template, email, uid, jobseeker: jobseeker, publisher: publisher) }
 
   let(:notify_template) { "test_template" }
   let(:email) { "test@email.com" }
   let(:jobseeker) { instance_double(Jobseeker, id: 1234, email: "test@email.com") }
   let(:publisher) { instance_double(Publisher, oid: 4321) }
+  let(:uid) { SecureRandom.uuid }
 
   describe "#trigger" do
     let(:expected_data) do
@@ -14,6 +15,7 @@ RSpec.describe EmailEvent do
         type: :best_ever_email_event,
         occurred_at: "1999-12-31T23:59:59.000000Z",
         data: [
+          { key: "uid", value: uid },
           { key: "notify_template", value: notify_template },
           { key: "email_identifier", value: anonymised_form_of("test@email.com") },
           { key: "user_anonymised_jobseeker_id", value: anonymised_form_of("1234") },


### PR DESCRIPTION
## Jira ticket
https://dfedigital.atlassian.net/browse/TEVA-2417

## Changes in this PR
- Send a uid with all email events
- Set utm source to the uid in the job alert email links

## Food for thought
Is the uid unique enough?

## Product sign off
- [x] Looks good!