### PR TITLE
JS improvements to existing qualifications [1747]

### DIFF
--- a/app/frontend/src/application/jobseekers/manageQualifications.test.js
+++ b/app/frontend/src/application/jobseekers/manageQualifications.test.js
@@ -1,36 +1,37 @@
 import manageQualifications, {
-  addDeletionEventListener,
   addEventListenerForAddSubject,
   rowMarkup,
   addSubject,
-  insertDeleteButton,
+  renumberRow,
+  renumberRows,
   onDelete,
   DELETE_BUTTON_CLASSNAME,
   FIELDSET_CLASSNAME,
+  GOVUK_INPUT_CLASSNAME,
   ROW_CLASS,
-  SUBJECT_LINK_ID, renumberRemainingRows,
+  SUBJECT_LINK_ID,
 } from './manageQualifications';
 
 describe('manageQualifications', () => {
   const originalMarkup = `<div class="${FIELDSET_CLASSNAME}">
       <div class="${ROW_CLASS}">
         <label for="subject1">Subject 1</label>
-        <input class="govuk-input" id="s1" value="Maths">
+        <input class="${GOVUK_INPUT_CLASSNAME}" id="s1" value="Maths" />
       </div>
       <div class="${ROW_CLASS}">
         <label for="subject2">Subject 2</label>
-        <input class="govuk-input" id="s2" value="Music">
-        <a id="delete_2" class="${DELETE_BUTTON_CLASSNAME}" href="#">delete subject</a>
+        <input class="${GOVUK_INPUT_CLASSNAME}" id="s2" value="Music" />
+        <a class="${DELETE_BUTTON_CLASSNAME}" href="#">delete subject</a>
       </div>
       <div class="${ROW_CLASS}">
         <label for="subject3">Subject 3</label>
-        <input class="govuk-input" id="s3" value="Geography">
-        <a id="delete_3" class="${DELETE_BUTTON_CLASSNAME}" href="#">delete subject</a>
+        <input class="${GOVUK_INPUT_CLASSNAME}" class="govuk-input--error" id="s3" value="Geography" />
+        <a class="${DELETE_BUTTON_CLASSNAME}" href="#">delete subject</a>
       </div>
       <div class="${ROW_CLASS}">
         <label for="subject4">Subject 4</label>
-        <input class="govuk-input" id="s4" value="Economics 101">
-        <a id="delete_4" class="${DELETE_BUTTON_CLASSNAME}" href="#">delete subject</a>
+        <input class="${GOVUK_INPUT_CLASSNAME}" id="s4" value="Economics 101" />
+        <a class="${DELETE_BUTTON_CLASSNAME}" href="#">delete subject</a>
       </div>
     </div>
     <a id="${SUBJECT_LINK_ID}" href="#">Add subject</a>`;
@@ -52,7 +53,6 @@ describe('manageQualifications', () => {
   });
 
   describe('addSubject', () => {
-    manageQualifications.insertDeleteButton = jest.fn();
     manageQualifications.renumberRow = jest.fn();
 
     const initialNumberOfRows = document.getElementsByClassName(ROW_CLASS).length;
@@ -67,12 +67,7 @@ describe('manageQualifications', () => {
 
     test('renumbers row, discarding values and errors', () => {
       const renumberRowSpy = jest.spyOn(manageQualifications, 'renumberRow');
-      expect(renumberRowSpy).toHaveBeenCalledWith(rowMarkup(), document.getElementsByClassName(ROW_CLASS).length, false);
-    });
-
-    test('adds a delete button', () => {
-      const insertDeleteButtonSpy = jest.spyOn(manageQualifications, 'insertDeleteButton');
-      expect(insertDeleteButtonSpy).toHaveBeenCalledWith(rowMarkup(), document.getElementsByClassName(ROW_CLASS).length);
+      expect(renumberRowSpy).toHaveBeenCalledWith(rowMarkup(), document.getElementsByClassName(ROW_CLASS).length, true);
     });
 
     test('puts the new subject input in focus', () => {
@@ -80,65 +75,63 @@ describe('manageQualifications', () => {
     });
   });
 
-  describe('insertDeleteButton', () => {
-    manageQualifications.addDeletionEventListener = jest.fn();
-    const addDeletionEventListenerSpy = jest.spyOn(manageQualifications, 'addDeletionEventListener');
-    const newRow = document.getElementsByClassName(ROW_CLASS)[0].cloneNode(true);
-    insertDeleteButton(newRow, 10);
-    const deleteButton = newRow.lastElementChild;
-
-    test('adds button markup', () => {
-      expect(deleteButton.text).toBe('delete subject');
-      expect(deleteButton.id).toBe('delete_10');
-      expect(deleteButton.classList).toContain(DELETE_BUTTON_CLASSNAME);
-    });
-
-    test('adds deletion event listener', () => {
-      expect(addDeletionEventListenerSpy).toHaveBeenCalledWith(deleteButton);
-    });
-  });
-
-  describe('addDeletionEventListener', () => {
-    manageQualifications.onDelete = jest.fn();
-    const onDeleteSpy = jest.spyOn(manageQualifications, 'onDelete');
-    const newRow = document.getElementsByClassName(ROW_CLASS)[0].cloneNode(true);
-    const deleteButton = newRow.lastElementChild;
-    addDeletionEventListener(deleteButton);
-    deleteButton.dispatchEvent(new Event('click'));
-
-    test('when the link is clicked, it deletes row and renumbers remaining rows', () => {
-      expect(onDeleteSpy).toHaveBeenCalledWith(deleteButton);
-    });
-  });
-
   describe('onDelete', () => {
-    manageQualifications.renumberRemainingRows = jest.fn();
+    manageQualifications.renumberRows = jest.fn();
+    const renumberRowsSpy = jest.spyOn(manageQualifications, 'renumberRows');
+
     const initialNumberOfRows = document.getElementsByClassName(ROW_CLASS).length;
     const rowNumberToDelete = '2';
 
     beforeEach(() => {
-      onDelete(document.getElementById(`delete_${rowNumberToDelete}`));
+      onDelete(document.getElementsByClassName(ROW_CLASS)[rowNumberToDelete].children[2]);
     });
 
     test('deletes row', () => {
       expect(document.getElementsByClassName(ROW_CLASS).length).toBe(initialNumberOfRows - 1);
     });
 
-    test('renumbers the rows after the deleted row', () => {
-      const renumberRemainingRowsSpy = jest.spyOn(manageQualifications, 'renumberRemainingRows');
-      expect(renumberRemainingRowsSpy).toHaveBeenCalledWith(rowNumberToDelete);
+    test('renumbers the rows', () => {
+      expect(renumberRowsSpy).toHaveBeenCalledTimes(2);
     });
   });
 
-  describe('renumberRemainingRows', () => {
+  describe('renumber rows', () => {
     manageQualifications.renumberRow = jest.fn();
     const renumberRowSpy = jest.spyOn(manageQualifications, 'renumberRow');
 
-    test('renumbers the rows after the deleted row, keeping the values and errors', () => {
-      const rows = document.getElementsByClassName(ROW_CLASS);
-      renumberRemainingRows(2);
-      expect(renumberRowSpy).toHaveBeenCalledWith(rows[2], 3, true);
-      expect(renumberRowSpy).toHaveBeenCalledWith(rows[3], 4, true);
+    beforeEach(() => {
+      renumberRows();
+    });
+
+    test('renumbers all rows', () => {
+      expect(renumberRowSpy).toHaveBeenCalledWith(document.getElementsByClassName(ROW_CLASS)[3], 5, true);
+    });
+  });
+
+  describe('renumber row', () => {
+    manageQualifications.renumberCell = jest.fn();
+    const renumberCellSpy = jest.spyOn(manageQualifications, 'renumberCell');
+
+    const row = document.getElementsByClassName(FIELDSET_CLASSNAME)[0];
+
+    beforeEach(() => {
+      renumberRow(row, 3, false);
+    });
+
+    test('renumbers all cells', () => {
+      expect(renumberCellSpy).toHaveBeenCalledTimes(11);
+    });
+  });
+
+  describe('renumbers cells', () => {
+    const row = document.getElementsByClassName(FIELDSET_CLASSNAME)[0];
+
+    test('renumbers all cell attributes and labels', () => {
+      renumberRow(row, 3, false);
+      expect(document.getElementsByClassName(ROW_CLASS)[3].children[0].innerHTML).toBe('Subject 4');
+      expect(document.getElementsByClassName(ROW_CLASS)[3].children[0].getAttribute('for')).toBe('subject4');
+      expect(document.getElementsByClassName(ROW_CLASS)[3].children[1].value).toBe('Economics 101');
     });
   });
 });
+

--- a/app/frontend/src/styles/application/jobseekers/subjects-and-grades.scss
+++ b/app/frontend/src/styles/application/jobseekers/subjects-and-grades.scss
@@ -26,6 +26,10 @@
       .govuk-label {
         margin-bottom: govuk-spacing(3);
       }
+
+      .delete-button {
+        display: none;
+      }
     }
 
     &:not(:first-of-type) {

--- a/app/views/jobseekers/job_applications/qualifications/fields/_secondary_school.html.slim
+++ b/app/views/jobseekers/job_applications/qualifications/fields/_secondary_school.html.slim
@@ -9,8 +9,7 @@
         label: { text: t("helpers.label.jobseekers_job_application_details_qualifications_shared_labels.grade1") },
         aria: { required: index.zero? },
         form_group: { classes: "govuk-!-width-one-quarter" }
-      - unless index.zero?
-        = govuk_link_to t("buttons.delete_subject"), "#", id: "delete_#{index + 1}", class: "js-action delete-button govuk-!-margin-bottom-6 govuk-!-padding-bottom-2"
+      = govuk_link_to t("buttons.delete_subject"), "#", id: "delete_#{index + 1}", class: "js-action delete-button govuk-!-margin-bottom-6 govuk-!-padding-bottom-2"
 
 p class="govuk-!-margin-bottom-6 govuk-!-margin-top-0 js-action"
   = govuk_link_to t("buttons.add_another_subject"), "#", id: "add_subject"


### PR DESCRIPTION
- remove delete button adding code and just use bubbled event on fieldset container. makes delete button purely part of slim template.
- change attributes on row elements rather than flatpacked innerHTML of whole row, removing unnecessary logic.
- didnt really see much advantage to not having a little simpler renumber all rows when rows are deleted flow in code