### PR TITLE
Teva 2477 delete qa branch and tidy up

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -175,7 +175,7 @@ jobs:
         SLACK_CHANNEL: twd_tv_dev
         SLACK_USERNAME: CI Deployment
         SLACK_TITLE: Deployment ${{ job.status }}
-        SLACK_MESSAGE: 'Deployment of Docker tag ${{ github.sha }} to {{matrix.environment}} - ${{ job.status }}'
+        SLACK_MESSAGE: 'Deployment of Docker tag ${{ github.sha }} to ${{matrix.environment}} - ${{ job.status }}'
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
   post_deployment:

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - dev
-      - qa
       - pentest
     paths-ignore:
     - 'bigquery/**'


### PR DESCRIPTION
## Jira ticket URL

- Just add the ticket number to the end:

https://dfedigital.atlassian.net/browse/TEVA-2477

## Changes in this PR:

Since we now deploy to QA as part of Ci\CD, there is the need to remove QA branch for `deploy branch` workflow. Also, a squeezed in a fix to amend a slack deployment error notification, which isn't rendering properly.