### PR TITLE
Update job-application-preview.html.slim

### DIFF
--- a/app/views/pages/job-application-preview.html.slim
+++ b/app/views/pages/job-application-preview.html.slim
@@ -204,5 +204,10 @@
         |  provide details if so.
 
       .govuk-body class="govuk-!-margin-top-4" They are also asked whether they have the right to work in the UK.
+      
+      .govuk-body class="govuk-!-margin-top-4"
+        | Candidates are not asked on their application form whether they are banned from working with children. 
+        | After shortlisting candidates, you should ask them whether they have a criminal record, or if there is
+        | any other information that would make them unsuitable to work with children.
 
       = govuk_link_to "Back to top", "#heading", class: "govuk-link govuk-body"

--- a/app/views/pages/job-application-preview.html.slim
+++ b/app/views/pages/job-application-preview.html.slim
@@ -204,9 +204,9 @@
         |  provide details if so.
 
       .govuk-body class="govuk-!-margin-top-4" They are also asked whether they have the right to work in the UK.
-      
+
       .govuk-body class="govuk-!-margin-top-4"
-        | Candidates are not asked on their application form whether they are banned from working with children. 
+        | Candidates are not asked on their application form whether they are banned from working with children.
         | After shortlisting candidates, you should ask them whether they have a criminal record, or if there is
         | any other information that would make them unsuitable to work with children.
 


### PR DESCRIPTION
Third paragraph added to the 'Declarations' section.

Paragraph should read:

Candidates are not asked on their application form whether they are banned from working with children. After shortlisting candidates, you should ask them whether they have a criminal record, or if there is any other information that would make them unsuitable to work with children.