### PR TITLE
Only render links for non withdrawn job applications

### DIFF
--- a/app/helpers/job_application_helper.rb
+++ b/app/helpers/job_application_helper.rb
@@ -98,4 +98,13 @@ module JobApplicationHelper
       t("buttons.save_and_continue")
     end
   end
+
+  def job_application_view_applicant(vacancy, job_application)
+    if job_application.withdrawn?
+      tag.span "#{job_application.first_name} #{job_application.last_name}", class: "govuk-!-font-size-19"
+    else
+      govuk_link_to "#{job_application.first_name} #{job_application.last_name}",
+                    organisation_job_job_application_path(vacancy.id, job_application)
+    end
+  end
 end

--- a/app/views/publishers/vacancies/job_applications/index.html.slim
+++ b/app/views/publishers/vacancies/job_applications/index.html.slim
@@ -65,7 +65,7 @@
       - job_applications.each do |application|
         = render Shared::CardComponent.new(classes: "application-#{application.status}") do |card|
           - card.header do
-            = tag.div(govuk_link_to("#{application.first_name} #{application.last_name}", organisation_job_job_application_path(vacancy.id, application.id)))
+            = tag.div(job_application_view_applicant(vacancy, application))
 
           - card.body do
             = tag.div(publisher_job_application_status_tag(application.status))

--- a/spec/helpers/job_application_helper_spec.rb
+++ b/spec/helpers/job_application_helper_spec.rb
@@ -152,4 +152,30 @@ RSpec.describe JobApplicationHelper do
       end
     end
   end
+
+  describe "#job_application_view_applicant" do
+    subject { helper.job_application_view_applicant(vacancy, job_application) }
+
+    let(:vacancy) { create(:vacancy, :published) }
+
+    context "when job application is withdrawn" do
+      let(:job_application) { create(:job_application, :status_withdrawn) }
+
+      it "renders the applicant name" do
+        expect(subject).to include("#{job_application.first_name} #{job_application.last_name}")
+      end
+
+      it "does not render a link" do
+        expect(subject).to have_no_link("#{job_application.first_name} #{job_application.last_name}")
+      end
+    end
+
+    context "when job application is not withdrawn" do
+      let(:job_application) { create(:job_application, :status_submitted) }
+
+      it "renders the applicant name as a link" do
+        expect(subject).to have_link("#{job_application.first_name} #{job_application.last_name}")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Jira ticket 
https://dfedigital.atlassian.net/browse/TEVA-2523

## Changes in this PR
- Add job application view applicant helper method
- Don't render link for withdrawn applications in the publisher dashboard

## Screenshots
![image](https://user-images.githubusercontent.com/25187547/116978531-bc1fe200-acbb-11eb-9f43-bf127b4ddb6e.png)

## Product sign off
- [x] Looks good!
