### PR TITLE
Update job application step page titles when forms have errors

### DIFF
--- a/app/helpers/job_application_helper.rb
+++ b/app/helpers/job_application_helper.rb
@@ -107,4 +107,12 @@ module JobApplicationHelper
                     organisation_job_job_application_path(vacancy.id, job_application)
     end
   end
+
+  def job_application_page_title_prefix(form, title)
+    if form.errors.any?
+      "Error: #{title}"
+    else
+      title
+    end
+  end
 end

--- a/app/views/jobseekers/job_applications/build/ask_for_support.html.slim
+++ b/app/views/jobseekers/job_applications/build/ask_for_support.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, t(".title")
+- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
 
 = render BannerComponent.new do
   = govuk_back_link text: t("buttons.back_to_previous_step"), href: back_path, classes: "govuk-!-margin-top-3"

--- a/app/views/jobseekers/job_applications/build/declarations.html.slim
+++ b/app/views/jobseekers/job_applications/build/declarations.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, t(".title")
+- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
 
 = render BannerComponent.new do
   = govuk_back_link text: t("buttons.back_to_previous_step"), href: back_path, classes: "govuk-!-margin-top-3"

--- a/app/views/jobseekers/job_applications/build/employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/build/employment_history.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, t(".title")
+- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
 
 = render BannerComponent.new do
   = govuk_back_link text: t("buttons.back_to_previous_step"), href: back_path, classes: "govuk-!-margin-top-3"

--- a/app/views/jobseekers/job_applications/build/equal_opportunities.html.slim
+++ b/app/views/jobseekers/job_applications/build/equal_opportunities.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, t(".title")
+- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
 
 = render BannerComponent.new do
   = govuk_back_link text: t("buttons.back_to_previous_step"), href: back_path, classes: "govuk-!-margin-top-3"

--- a/app/views/jobseekers/job_applications/build/personal_details.html.slim
+++ b/app/views/jobseekers/job_applications/build/personal_details.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, t(".title")
+- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
 
 = render BannerComponent.new do
   = govuk_back_link text: t("buttons.back_to_previous_step"), href: back_path, classes: "govuk-!-margin-top-3"

--- a/app/views/jobseekers/job_applications/build/personal_statement.html.slim
+++ b/app/views/jobseekers/job_applications/build/personal_statement.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, t(".title")
+- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
 
 = render BannerComponent.new do
   = govuk_back_link text: t("buttons.back_to_previous_step"), href: back_path, classes: "govuk-!-margin-top-3"

--- a/app/views/jobseekers/job_applications/build/professional_status.html.slim
+++ b/app/views/jobseekers/job_applications/build/professional_status.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, t(".title")
+- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
 
 = render BannerComponent.new do
   = govuk_back_link text: t("buttons.back_to_previous_step"), href: back_path, classes: "govuk-!-margin-top-3"

--- a/app/views/jobseekers/job_applications/build/qualifications.html.slim
+++ b/app/views/jobseekers/job_applications/build/qualifications.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, t(".title")
+- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
 
 = render BannerComponent.new do
   = govuk_back_link text: t("buttons.back_to_previous_step"), href: back_path, classes: "govuk-!-margin-top-3"

--- a/app/views/jobseekers/job_applications/build/references.html.slim
+++ b/app/views/jobseekers/job_applications/build/references.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, t(".title")
+- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
 
 = render BannerComponent.new do
   = govuk_back_link text: t("buttons.back_to_previous_step"), href: back_path, classes: "govuk-!-margin-top-3"

--- a/app/views/jobseekers/job_applications/confirm_withdraw.html.slim
+++ b/app/views/jobseekers/job_applications/confirm_withdraw.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, t(".title")
+- content_for :page_title_prefix, job_application_page_title_prefix(withdraw_form, t(".title"))
 
 .govuk-main-wrapper
   .govuk-grid-row

--- a/app/views/jobseekers/job_applications/employments/edit.html.slim
+++ b/app/views/jobseekers/job_applications/employments/edit.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, t(".title")
+- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
 
 .govuk-main-wrapper
   .govuk-grid-row

--- a/app/views/jobseekers/job_applications/employments/new.html.slim
+++ b/app/views/jobseekers/job_applications/employments/new.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, t(".title")
+- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
 
 .govuk-main-wrapper
   .govuk-grid-row

--- a/app/views/jobseekers/job_applications/qualifications/edit.html.slim
+++ b/app/views/jobseekers/job_applications/qualifications/edit.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, t(".title")
+- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
 
 .govuk-main-wrapper
   .govuk-grid-row

--- a/app/views/jobseekers/job_applications/qualifications/new.html.slim
+++ b/app/views/jobseekers/job_applications/qualifications/new.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, t(".title")
+- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
 
 .govuk-main-wrapper
   .govuk-grid-row

--- a/app/views/jobseekers/job_applications/qualifications/select_category.html.slim
+++ b/app/views/jobseekers/job_applications/qualifications/select_category.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, t(".title")
+- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
 
 .govuk-main-wrapper
   .govuk-grid-row

--- a/app/views/jobseekers/job_applications/references/edit.html.slim
+++ b/app/views/jobseekers/job_applications/references/edit.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, t(".title")
+- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
 
 .govuk-main-wrapper
   .govuk-grid-row

--- a/app/views/jobseekers/job_applications/references/new.html.slim
+++ b/app/views/jobseekers/job_applications/references/new.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, t(".title")
+- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
 
 .govuk-main-wrapper
   .govuk-grid-row

--- a/app/views/jobseekers/job_applications/review.html.slim
+++ b/app/views/jobseekers/job_applications/review.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, t(".title")
+- content_for :page_title_prefix, job_application_page_title_prefix(review_form, t(".title"))
 
 = render BannerComponent.new do
   - if current_jobseeker.job_applications.not_draft.none?

--- a/app/views/jobseekers/job_applications/submit.html.slim
+++ b/app/views/jobseekers/job_applications/submit.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, t(".title")
+- content_for :page_title_prefix, job_application_page_title_prefix(@application_feedback_form, t(".title"))
 
 .govuk-main-wrapper
   .govuk-grid-row

--- a/spec/helpers/job_application_helper_spec.rb
+++ b/spec/helpers/job_application_helper_spec.rb
@@ -178,4 +178,26 @@ RSpec.describe JobApplicationHelper do
       end
     end
   end
+
+  describe "#job_application_page_title_prefix" do
+    subject { helper.job_application_page_title_prefix(form, title) }
+
+    let(:title) { "A page title" }
+
+    context "when the form has errors" do
+      let(:form) { double("some_form", errors: ["an error"]) }
+
+      it "prepends `Error:` to the title" do
+        expect(subject).to eq("Error: A page title")
+      end
+    end
+
+    context "when the form does not have errors" do
+      let(:form) { double("some_form", errors: []) }
+
+      it "returns the title" do
+        expect(subject).to eq("A page title")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Jira ticket 
https://dfedigital.atlassian.net/browse/TEVA-2398

## Changes in this PR
- Add a helper method to prepend `Error:` to page titles when the form has any errors

## Product sign off
- [x] Looks good!
