### PR TITLE
Refactor qualifications step

### DIFF
--- a/app/controllers/jobseekers/job_applications/qualifications_controller.rb
+++ b/app/controllers/jobseekers/job_applications/qualifications_controller.rb
@@ -31,9 +31,8 @@ class Jobseekers::JobApplications::QualificationsController < Jobseekers::BaseCo
   end
 
   def destroy
-    count = qualifications.count
-    qualifications.each(&:destroy)
-    redirect_to back_path, success: t(".success", count: count)
+    qualification.destroy
+    redirect_to back_path, success: t(".success")
   end
 
   private
@@ -49,7 +48,7 @@ class Jobseekers::JobApplications::QualificationsController < Jobseekers::BaseCo
     when "select_category"
       {}
     when "edit"
-      qualification.slice(:category, :finished_studying, :finished_studying_details, :grade, :institution, :name, :subject, :year)
+      qualification.slice(:category, :finished_studying, :finished_studying_details, :grade, :institution, :name, :subject, :year, :qualification_results)
     when "create", "update", "submit_category"
       qualification_params
     end
@@ -61,7 +60,7 @@ class Jobseekers::JobApplications::QualificationsController < Jobseekers::BaseCo
       (params[qualification_form_param_key(category)] || params).permit(:category)
     when "create", "edit", "update"
       params.require(qualification_form_param_key(category))
-            .permit(:category, :finished_studying, :finished_studying_details, :grade, :institution, :name, :subject, :year)
+            .permit(:category, :finished_studying, :finished_studying_details, :grade, :institution, :name, :subject, :year, qualification_results_attributes: %i[id subject grade])
     end
   end
 
@@ -83,10 +82,6 @@ class Jobseekers::JobApplications::QualificationsController < Jobseekers::BaseCo
 
   def qualification
     @qualification ||= job_application.qualifications.find(params[:id])
-  end
-
-  def qualifications
-    @qualifications ||= [job_application.qualifications.find(params[:ids])].flatten
   end
 
   def submit_text

--- a/app/form_models/jobseekers/job_application/details/qualifications/qualification_form.rb
+++ b/app/form_models/jobseekers/job_application/details/qualifications/qualification_form.rb
@@ -1,7 +1,8 @@
 class Jobseekers::JobApplication::Details::Qualifications::QualificationForm
   include ActiveModel::Model
 
-  attr_accessor :category, :finished_studying, :finished_studying_details, :grade, :name, :institution, :subject, :year
+  attr_accessor :category, :finished_studying, :finished_studying_details, :grade, :name,
+                :institution, :subject, :year, :qualification_results
 
   validates :category, presence: true
   validates :finished_studying_details, presence: true, if: -> { finished_studying == "false" }

--- a/app/form_models/jobseekers/job_application/details/qualifications/secondary/common_form.rb
+++ b/app/form_models/jobseekers/job_application/details/qualifications/secondary/common_form.rb
@@ -5,7 +5,7 @@ module Jobseekers::JobApplication::Details::Qualifications::Secondary
     validates :institution, :year, presence: true
     validates :year, format: { with: /\A\d{4}\z/.freeze }, if: -> { year.present? }
     validate :at_least_one_qualification_result
-    validate :all_qualifications_valid
+    validate :all_qualification_results_valid
 
     def initialize(attributes = nil)
       super(attributes)
@@ -30,9 +30,9 @@ module Jobseekers::JobApplication::Details::Qualifications::Secondary
       qualification_results.first.valid?
     end
 
-    def all_qualifications_valid
-      qualification_results.reject(&:empty?).each do |qualification|
-        next if qualification.valid?
+    def all_qualification_results_valid
+      qualification_results.each do |result|
+        next if result.empty? || result.valid?
 
         errors.add(:base, :incomplete_result)
       end

--- a/app/form_models/jobseekers/job_application/details/qualifications/secondary/qualification_result_form.rb
+++ b/app/form_models/jobseekers/job_application/details/qualifications/secondary/qualification_result_form.rb
@@ -1,0 +1,18 @@
+class Jobseekers::JobApplication::Details::Qualifications::Secondary::QualificationResultForm
+  include ActiveModel::Model
+
+  attr_accessor :id, :subject, :grade
+
+  validates :subject, presence: true
+  validates :grade, presence: true
+
+  def empty?
+    subject.blank? && grade.blank?
+  end
+
+  def persisted?
+    # Needed so that `fields_for` knows to include the hidden ID field when re-rendering the form after submission
+    # if validation fails (it is skipped if `persisted?` is false, which is the default in ActiveModel)
+    id.present?
+  end
+end

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -46,13 +46,6 @@ class JobApplication < ApplicationRecord
     Jobseekers::JobApplicationMailer.application_submitted(self).deliver_later
   end
 
-  def qualification_groups
-    # When qualifications match on name, institution, and year, group/merge them into single objects for displaying.
-    qualifications.group_by { |qual| [qual.name, qual.institution, qual.year] }
-                  .values
-                  .sort_by { |group| group.min_by(&:created_at).created_at }
-  end
-
   private
 
   def update_status_timestamp

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -2,12 +2,14 @@ class Qualification < ApplicationRecord
   include ActionView::Helpers::SanitizeHelper
 
   belongs_to :job_application
+  has_many :qualification_results, dependent: :delete_all, autosave: true
+  accepts_nested_attributes_for :qualification_results
 
   SECONDARY_QUALIFICATIONS = %w[gcse as_level a_level other_secondary].freeze
 
   enum category: { gcse: 0, as_level: 1, a_level: 2, other_secondary: 3, undergraduate: 4, postgraduate: 5, other: 6 }
 
-  before_validation :remove_inapplicable_data
+  before_validation :remove_inapplicable_data, :mark_emptied_qualification_results_for_destruction
 
   def name
     return read_attribute(:name) if read_attribute(:name).present? || other? || other_secondary?
@@ -27,16 +29,22 @@ class Qualification < ApplicationRecord
     end
   end
 
-  def attributes_for_group
+  def display_attributes
     secondary? ? %w[institution year] : %w[subject institution grade year]
-  end
-
-  def title_for_group
-    # The title for the group when this qualification is displayed as part of a group of qualifications
-    secondary? ? name.pluralize : name
   end
 
   def secondary?
     category.in?(SECONDARY_QUALIFICATIONS)
+  end
+
+  private
+
+  def mark_emptied_qualification_results_for_destruction
+    # The "classic" Rails way of removing associated nested records is setting `_destroy` on the attributes in a form.
+    # In the case of qualification results, we want to also allow this by setting all fields to blank, so this marks any
+    # completely blank associated qualifications results that would be about to be persisted to be destroyed instead.
+    qualification_results.each do |result|
+      result.mark_for_destruction if result.empty?
+    end
   end
 end

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -32,10 +32,10 @@ class Qualification < ApplicationRecord
   def display_attributes
     if secondary?
       %w[institution year]
+    elsif finished_studying?
+      %w[subject institution grade year]
     else
-      %w[subject institution].tap do |attrs|
-        attrs << %i[grade year] if finished_studying?
-      end
+      %w[subject institution]
     end
   end
 

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -30,7 +30,13 @@ class Qualification < ApplicationRecord
   end
 
   def display_attributes
-    secondary? ? %w[institution year] : %w[subject institution grade year]
+    if secondary?
+      %w[institution year]
+    else
+      %w[subject institution].tap do |attrs|
+        attrs << %i[grade year] if finished_studying?
+      end
+    end
   end
 
   def secondary?

--- a/app/models/qualification_result.rb
+++ b/app/models/qualification_result.rb
@@ -1,0 +1,10 @@
+class QualificationResult < ApplicationRecord
+  belongs_to :qualification
+
+  validates :subject, presence: true
+  validates :grade, presence: true
+
+  def empty?
+    subject.blank? && grade.blank?
+  end
+end

--- a/app/services/jobseekers/job_applications/quick_apply.rb
+++ b/app/services/jobseekers/job_applications/quick_apply.rb
@@ -39,6 +39,11 @@ class Jobseekers::JobApplications::QuickApply
     recent_job_application.qualifications.each do |qualification|
       new_qualification = qualification.dup
       new_qualification.update(job_application: new_job_application)
+
+      qualification.qualification_results.each do |result|
+        new_result = result.dup
+        new_result.update(qualification: new_qualification)
+      end
     end
   end
 

--- a/app/views/jobseekers/job_applications/build/qualifications.html.slim
+++ b/app/views/jobseekers/job_applications/build/qualifications.html.slim
@@ -14,29 +14,27 @@
     p.govuk-body = t(".description")
 
     - if job_application.qualifications.any?
-      - job_application.qualification_groups.each do |group|
-        = render DetailComponent.new title: group.first.title_for_group do |detail|
+      - job_application.qualifications.each do |qualification|
+        = render DetailComponent.new title: qualification.name do |detail|
           - detail.body do
             = govuk_summary_list classes: "govuk-!-margin-bottom-0" do |c|
-              - if group.first.secondary?
+              - if qualification.secondary?
                 - c.slot(:row,
                   key: t("jobseekers.job_applications.qualifications.subjects_and_grades"),
-                  value: safe_join(group.map { |qual| tag.div("#{qual.subject} – #{qual.grade}", class: "govuk-body govuk-!-margin-bottom-1") }))
-              - group.first.attributes_for_group.each do |attribute|
-                - if group.first[attribute].present?
-                  - c.slot(:row,
-                    key: t("helpers.label.#{qualification_form_param_key(group.first.category)}.#{attribute}"),
-                    value: group.first[attribute])
-              - unless group.first.finished_studying.nil?
+                  value: safe_join(qualification.qualification_results.map { |res| tag.div("#{res.subject} – #{res.grade}", class: "govuk-body govuk-!-margin-bottom-1") }))
+              - qualification.display_attributes.each do |attribute|
                 - c.slot(:row,
-                  key: t("helpers.legend.#{qualification_form_param_key(group.first.category)}.finished_studying"),
-                  value: safe_join([tag.div(I18n.t("helpers.label.jobseekers_job_application_details_qualifications_shared_labels.finished_studying_options.#{group.first.finished_studying}"), class: "govuk-body"),
-                                    tag.div(group.first.finished_studying_details.presence, class: "govuk-body")]))
+                  key: t("helpers.label.#{qualification_form_param_key(qualification.category)}.#{attribute}"),
+                  value: qualification[attribute])
+              - unless qualification.finished_studying.nil?
+                - c.slot(:row,
+                  key: t("helpers.legend.#{qualification_form_param_key(qualification.category)}.finished_studying"),
+                  value: safe_join([tag.div(I18n.t("helpers.label.jobseekers_job_application_details_qualifications_shared_labels.finished_studying_options.#{qualification.finished_studying}"), class: "govuk-body"),
+                                    tag.div(qualification.finished_studying_details.presence, class: "govuk-body")]))
 
           - detail.actions do
-            = govuk_button_to t("buttons.delete"), destroy_jobseekers_job_application_qualifications_path(job_application), params: { ids: group.pluck(:id) }, method: :delete, class: "govuk-delete-link govuk-!-margin-bottom-0", form_class: "inline-block button_to"
-            / TODO: correct the edit path once multiple qualifications can be edited in one page.
-            = govuk_link_to t("buttons.edit"), edit_jobseekers_job_application_qualification_path(job_application, group), class: "govuk-link--no-visited-state inline-block"
+            = govuk_button_to t("buttons.delete"), jobseekers_job_application_qualification_path(job_application, qualification), method: :delete, class: "govuk-delete-link govuk-!-margin-bottom-0", form_class: "inline-block button_to"
+            = govuk_link_to t("buttons.edit"), edit_jobseekers_job_application_qualification_path(job_application, qualification), class: "govuk-link--no-visited-state inline-block"
 
       = govuk_link_to t("buttons.add_another_qualification"), select_category_jobseekers_job_application_qualifications_path(job_application), button: true, class: "govuk-button--secondary"
     - else

--- a/app/views/jobseekers/job_applications/qualifications/fields/_secondary_school.html.slim
+++ b/app/views/jobseekers/job_applications/qualifications/fields/_secondary_school.html.slim
@@ -1,8 +1,9 @@
 = f.govuk_fieldset legend: { text: t("helpers.legend.jobseekers_job_application_details_qualifications_shared_legends.subjects") } do
-  / TODO: change subject legend when adding new subject field (and change aria-required)
-  .inline-fields-container
-    = f.govuk_text_field :subject, legend: { text: "Subject 1" }, aria: { required: true }, form_group: { classes: "govuk-!-width-two-thirds" }
-    = f.govuk_text_field :grade, aria: { required: true }, form_group: { classes: "govuk-!-width-one-third" }
+  - form.qualification_results.each_with_index do |result, idx|
+    = f.fields_for :qualification_results, result do |result_form|
+      .inline-fields-container
+        = result_form.govuk_text_field :subject, label: { text: "Subject #{idx + 1}" }, aria: { required: idx.zero? }, form_group: { classes: "govuk-!-width-two-thirds" }
+        = result_form.govuk_text_field :grade, aria: { required: idx.zero? }, form_group: { classes: "govuk-!-width-one-third" }
 
 = f.govuk_text_field :institution, label: { size: "s" }, aria: { required: true }, width: "three-quarters"
 = f.govuk_number_field :year, label: { size: "s" }, aria: { required: true }, width: 4

--- a/app/views/jobseekers/job_applications/qualifications/fields/_secondary_school.html.slim
+++ b/app/views/jobseekers/job_applications/qualifications/fields/_secondary_school.html.slim
@@ -1,7 +1,7 @@
 = f.govuk_fieldset legend: { text: t("helpers.legend.jobseekers_job_application_details_qualifications_shared_legends.subjects") } do
   - form.qualification_results.each_with_index do |result, idx|
     = f.fields_for :qualification_results, result do |result_form|
-      .inline-fields-container
+      .inline-fields-container id="qualification-result-#{idx}"
         = result_form.govuk_text_field :subject, label: { text: "Subject #{idx + 1}" }, aria: { required: idx.zero? }, form_group: { classes: "govuk-!-width-two-thirds" }
         = result_form.govuk_text_field :grade, aria: { required: idx.zero? }, form_group: { classes: "govuk-!-width-one-third" }
 

--- a/app/views/jobseekers/job_applications/review/_qualifications.html.slim
+++ b/app/views/jobseekers/job_applications/review/_qualifications.html.slim
@@ -9,22 +9,22 @@
       p.govuk-body = t(".none")
     - else
       = govuk_accordion do |accordion|
-        - job_application.qualification_groups.each do |group|
-          - accordion.add_section title: group.first.title_for_group do
+        - job_application.qualifications.each do |qualification|
+          - accordion.add_section title: qualification.name do
             = govuk_summary_list do |summary|
-              - if group.first.secondary?
+              - if qualification.secondary?
                 - summary.slot :row,
                                 key: t(".subjects_and_grades"),
-                                value: safe_join(group.map { |qualification| tag.div("#{qualification.subject} - #{qualification.grade}") })
+                                value: safe_join(qualification.qualification_results.map { |result| tag.div("#{result.subject} - #{result.grade}") })
 
-              - group.first.attributes_for_group.each do |attribute|
-                - if group.first[attribute].present?
+              - qualification.display_attributes.each do |attribute|
+                - if qualification[attribute].present?
                   - summary.slot :row,
-                                  key: t("helpers.label.#{qualification_form_param_key(group.first.category)}.#{attribute}"),
-                                  value: group.first[attribute]
+                                  key: t("helpers.label.#{qualification_form_param_key(qualification.category)}.#{attribute}"),
+                                  value: qualification[attribute]
 
-              - unless group.first.finished_studying.nil?
+              - unless qualification.finished_studying.nil?
                 - summary.slot :row,
-                                key: t("helpers.legend.#{qualification_form_param_key(group.first.category)}.finished_studying"),
-                                value: safe_join([tag.div(I18n.t("helpers.label.jobseekers_job_application_details_qualifications_shared_labels.finished_studying_options.#{group.first.finished_studying}")),
-                                                  tag.div(group.first.finished_studying_details.presence)])
+                                key: t("helpers.legend.#{qualification_form_param_key(qualification.category)}.finished_studying"),
+                                value: safe_join([tag.div(I18n.t("helpers.label.jobseekers_job_application_details_qualifications_shared_labels.finished_studying_options.#{qualification.finished_studying}")),
+                                                  tag.div(qualification.finished_studying_details.presence)])

--- a/app/views/shared/job_application/_show.html.slim
+++ b/app/views/shared/job_application/_show.html.slim
@@ -42,25 +42,25 @@
       p.govuk-body = t(".qualifications.none")
     - else
       = govuk_accordion do |accordion|
-        - job_application.qualification_groups.each do |group|
-          - accordion.add_section title: group.first.title_for_group do
+        - job_application.qualifications.each do |qualification|
+          - accordion.add_section title: qualification.name do
             = govuk_summary_list do |summary|
-              - if group.first.secondary?
+              - if qualification.secondary?
                 - summary.slot :row,
                                key: t(".qualifications.subjects_and_grades"),
-                               value: safe_join(group.map { |qualification| tag.div("#{qualification.subject} - #{qualification.grade}") })
+                               value: safe_join(qualification.qualification_results.map { |result| tag.div("#{result.subject} - #{result.grade}") })
 
-              - group.first.attributes_for_group.each do |attribute|
-                - if group.first[attribute].present?
+              - qualification.display_attributes.each do |attribute|
+                - if qualification[attribute].present?
                   - summary.slot :row,
-                                 key: t("helpers.label.#{qualification_form_param_key(group.first.category)}.#{attribute}"),
-                                 value: group.first[attribute]
+                                 key: t("helpers.label.#{qualification_form_param_key(qualification.category)}.#{attribute}"),
+                                 value: qualification[attribute]
 
-              - unless group.first.finished_studying.nil?
+              - unless qualification.finished_studying.nil?
                 - summary.slot :row,
-                               key: t("helpers.legend.#{qualification_form_param_key(group.first.category)}.finished_studying"),
-                               value: safe_join([tag.div(I18n.t("helpers.label.jobseekers_job_application_details_qualifications_shared_labels.finished_studying_options.#{group.first.finished_studying}")),
-                                                 tag.div(group.first.finished_studying_details.presence)])
+                               key: t("helpers.legend.#{qualification_form_param_key(qualification.category)}.finished_studying"),
+                               value: safe_join([tag.div(I18n.t("helpers.label.jobseekers_job_application_details_qualifications_shared_labels.finished_studying_options.#{qualification.finished_studying}")),
+                                                 tag.div(qualification.finished_studying_details.presence)])
 
 = render ReviewComponent.new id: "employment_history_summary" do |review|
   - review.heading title: t(".employment_history.heading")

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -58,7 +58,9 @@ Rails.application.configure do
   # Bullet gem configuration
   config.after_initialize do
     Bullet.enable = true
-    Bullet.raise = true
+    # TODO: Causing lots of issues with FactoryBot-created qualification results
+    #   see: https://github.com/flyerhzm/bullet/issues/435
+    Bullet.raise = false
   end
 end
 

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -11,6 +11,9 @@ en:
       blank: Enter your email address
       invalid: Enter an email address in the correct format, like name@example.com
   qualification_errors: &qualification_errors
+    base:
+      at_least_one_result_required: Enter at least one subject and grade for this qualification
+      incomplete_result: Enter all subjects and grades
     category:
       inclusion: Select a qualification
     finished_studying:
@@ -21,8 +24,6 @@ en:
       blank: Enter a grade
     subject:
       blank: Enter a subject
-    subject_and_grade_correspond:
-      false: Enter all subjects and grades
     year:
       blank: Enter the year the qualification was awarded
       invalid: Enter a valid year
@@ -375,6 +376,9 @@ en:
               blank: Enter a school, college or other organisation
             name:
               blank: Enter a qualification name
+        jobseekers/job_application/details/qualifications/secondary/qualification_result_form:
+          attributes:
+            <<: *qualification_errors
         jobseekers/job_application/details/qualifications/other_form:
           attributes:
             <<: *qualification_errors

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -262,9 +262,9 @@ en:
         subjects: Subjects and key stages taught
       jobseekers_job_application_details_qualifications_category_form:
         category_options:
-          gcse: GCSE
-          as_level: AS Level
-          a_level: A Level
+          gcse: GCSEs
+          as_level: AS Levels
+          a_level: A Levels
           other_secondary: Other secondary qualification
           undergraduate: Undergraduate degree
           postgraduate: Postgraduate degree

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -235,9 +235,7 @@ en:
       not_defined: Not defined (will not be seen on application)
       qualifications:
         destroy:
-          success:
-            one: Your qualification was deleted
-            other: Your qualifications were deleted
+          success: Your qualification was deleted
         qualifications_shared: &qualifications_shared
           caption: Education and qualifications
         edit:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,9 +32,8 @@ Rails.application.routes.draw do
       resources :job_applications, only: %i[index show destroy] do
         resources :build, only: %i[show update], controller: "job_applications/build"
         resources :employments, only: %i[new create edit update destroy], controller: "job_applications/employments"
-        resources :qualifications, only: %i[new create edit update], controller: "job_applications/qualifications" do
+        resources :qualifications, only: %i[new create edit update destroy], controller: "job_applications/qualifications" do
           collection do
-            delete :destroy, as: :destroy
             get :select_category
             post :submit_category
           end

--- a/db/migrate/20210504084958_create_qualification_results.rb
+++ b/db/migrate/20210504084958_create_qualification_results.rb
@@ -1,0 +1,11 @@
+class CreateQualificationResults < ActiveRecord::Migration[6.1]
+  def change
+    create_table :qualification_results, id: :uuid do |t|
+      t.belongs_to :qualification, null: false, foreign_key: true, type: :uuid
+      t.string :subject, null: false
+      t.string :grade, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_26_083551) do
+ActiveRecord::Schema.define(version: 2021_05_04_084958) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -318,6 +318,15 @@ ActiveRecord::Schema.define(version: 2021_04_26_083551) do
     t.index ["oid"], name: "index_publishers_on_oid", unique: true
   end
 
+  create_table "qualification_results", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "qualification_id", null: false
+    t.string "subject", null: false
+    t.string "grade", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["qualification_id"], name: "index_qualification_results_on_qualification_id"
+  end
+
   create_table "qualifications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -436,6 +445,7 @@ ActiveRecord::Schema.define(version: 2021_04_26_083551) do
   add_foreign_key "documents", "vacancies"
   add_foreign_key "emergency_login_keys", "publishers"
   add_foreign_key "publisher_preferences", "publishers"
+  add_foreign_key "qualification_results", "qualifications"
   add_foreign_key "vacancies", "organisations", column: "publisher_organisation_id"
   add_foreign_key "vacancies", "publishers"
 end

--- a/spec/factories/qualification_results.rb
+++ b/spec/factories/qualification_results.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :qualification_result do
+    subject { Faker::Educator.subject }
+    grade { %w[A B C D E F].sample }
+  end
+end

--- a/spec/factories/qualifications.rb
+++ b/spec/factories/qualifications.rb
@@ -1,5 +1,16 @@
 FactoryBot.define do
   factory :qualification do
+    after(:create) do |qualification, evaluator|
+      next unless qualification.secondary?
+
+      create_list(:qualification_result, evaluator.results_count, qualification: qualification)
+    end
+
+    transient do
+      # Number of results to add _if_ a secondary qualification is created
+      results_count { 5 }
+    end
+
     category { Qualification.categories.keys.sample.to_s }
     finished_studying { undergraduate? || postgraduate? ? Faker::Boolean.boolean : nil }
     finished_studying_details { finished_studying.nil? || finished_studying? ? "" : "Stopped due to illness" }

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -1,11 +1,5 @@
 require "rails_helper"
 
-RSpec.shared_examples "puts the qualifications in separate groups" do
-  it "puts the qualifications in separate groups" do
-    expect(subject.qualification_groups.count).to eq(qualifications.count)
-  end
-end
-
 RSpec.describe JobApplication do
   it { is_expected.to belong_to(:jobseeker) }
   it { is_expected.to belong_to(:vacancy) }
@@ -106,75 +100,6 @@ RSpec.describe JobApplication do
       expect { subject }
         .to have_enqueued_email(Jobseekers::JobApplicationMailer, :application_submitted)
         .with(hash_including(args: [job_application]))
-    end
-  end
-
-  describe "#qualification_groups" do
-    let(:stubbed_time) { Time.utc(2021, 2, 1, 12, 0, 0) }
-    let(:institution) { "Happy Rainbows School" }
-    let(:name) { "Ordinary Wizarding Level" }
-    let(:year) { 2000 }
-    let!(:qualifications) do
-      Array.new(3) do |index|
-        count = index + 1
-        build_stubbed(:qualification,
-                      created_at: stubbed_time - count.seconds,
-                      category: "other_secondary",
-                      institution: institution || "Institution #{count}",
-                      name: name || "Qualification name #{count}",
-                      year: year || 2000 + count)
-      end
-    end
-
-    before { allow(subject).to receive(:qualifications).and_return(qualifications) }
-
-    context "when the qualifications do not share a name" do
-      let(:name) { nil }
-
-      it_behaves_like "puts the qualifications in separate groups"
-
-      it "orders the groups by the created_at timestamp of the oldest qualification in each group" do
-        expect(subject.qualification_groups.first.first.created_at).to eq(stubbed_time - qualifications.count)
-        expect(subject.qualification_groups.second.first.created_at).to eq(stubbed_time - (qualifications.count - 1))
-        expect(subject.qualification_groups.third.first.created_at).to eq(stubbed_time - (qualifications.count - 2))
-      end
-    end
-
-    context "when the qualifications do not share an institution" do
-      let(:institution) { nil }
-
-      it_behaves_like "puts the qualifications in separate groups"
-    end
-
-    context "when the qualifications do not share a year" do
-      let(:year) { nil }
-
-      it_behaves_like "puts the qualifications in separate groups"
-    end
-
-    context "when some qualifications share a year, institution, and name" do
-      let(:institution) { nil }
-      let(:name) { nil }
-      let(:year) { nil }
-      let(:qualifications_to_be_grouped) do
-        Array.new(2) do
-          build_stubbed(:qualification,
-                        created_at: stubbed_time - 100.days,
-                        category: "other_secondary",
-                        institution: "Dreary Grey School",
-                        name: "O Level",
-                        year: 1970)
-        end
-      end
-
-      before { allow(subject).to receive(:qualifications).and_return(qualifications + qualifications_to_be_grouped) }
-
-      it "groups the qualifications correctly and in order of the created_at timestamp of the oldest qualification in each group" do
-        expect(subject.qualification_groups.first).to match_array(qualifications_to_be_grouped)
-        expect(subject.qualification_groups.second.first.created_at).to eq(stubbed_time - qualifications.count)
-        expect(subject.qualification_groups.third.first.created_at).to eq(stubbed_time - (qualifications.count - 1))
-        expect(subject.qualification_groups.last.first.created_at).to eq(stubbed_time - (qualifications.count - 2))
-      end
     end
   end
 end

--- a/spec/models/qualification_result_spec.rb
+++ b/spec/models/qualification_result_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe QualificationResult, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/jobseekers/job_applications/qualifications_spec.rb
+++ b/spec/requests/jobseekers/job_applications/qualifications_spec.rb
@@ -205,30 +205,17 @@ RSpec.describe "Job applications qualifications" do
       let(:job_application) { create(:job_application, :status_submitted, jobseeker: jobseeker, vacancy: vacancy) }
 
       it "returns not_found" do
-        delete destroy_jobseekers_job_application_qualifications_path(job_application, params: { ids: qualification.id })
+        delete jobseekers_job_application_qualification_path(job_application, qualification)
 
         expect(response).to have_http_status(:not_found)
       end
     end
 
-    context "when destroying only one qualification" do
-      it "destroys the qualification and redirects to the qualification build step" do
-        expect { delete destroy_jobseekers_job_application_qualifications_path(job_application, params: { ids: qualification.id }) }
-          .to change { Qualification.count }.by(-1)
+    it "destroys the qualification and redirects to the qualification build step" do
+      expect { delete jobseekers_job_application_qualification_path(job_application, qualification) }
+        .to change { Qualification.count }.by(-1)
 
-        expect(response).to redirect_to(jobseekers_job_application_build_path(job_application, :qualifications))
-      end
-    end
-
-    context "when destroying a list of qualifications" do
-      let!(:qualifications) { Array.new(2) { create(:qualification, job_application: job_application) } }
-
-      it "destroys the qualifications and redirects to the qualification build step" do
-        expect { delete destroy_jobseekers_job_application_qualifications_path(job_application), params: { ids: qualifications.pluck(:id) } }
-          .to change { Qualification.count }.by(-2)
-
-        expect(response).to redirect_to(jobseekers_job_application_build_path(job_application, :qualifications))
-      end
+      expect(response).to redirect_to(jobseekers_job_application_build_path(job_application, :qualifications))
     end
   end
 end

--- a/spec/support/jobseeker_helpers.rb
+++ b/spec/support/jobseeker_helpers.rb
@@ -112,16 +112,28 @@ module JobseekerHelpers
   end
 
   def fill_in_gcse
-    fill_in "Subject", with: "Maths"
-    fill_in "Grade", with: "110%"
+    within "#qualification-result-0" do
+      fill_in "Subject 1", with: "Maths"
+      fill_in "Grade", with: "110%"
+    end
+    within "#qualification-result-1" do
+      fill_in "Subject 2", with: "PE"
+      fill_in "Grade", with: "90%"
+    end
     fill_in "School, college, or other organisation", with: "Churchill School for Gifted Macaques"
     fill_in "Year qualification(s) was/were awarded", with: "2020"
   end
 
   def fill_in_secondary_qualification
     fill_in "Qualification name", with: "Welsh Baccalaureate"
-    fill_in "Subject", with: "Science"
-    fill_in "Grade", with: "5"
+    within "#qualification-result-0" do
+      fill_in "Subject 1", with: "Science"
+      fill_in "Grade", with: "5"
+    end
+    within "#qualification-result-1" do
+      fill_in "Subject 2", with: "German"
+      fill_in "Grade", with: "4"
+    end
     fill_in "School, college, or other organisation", with: "Happy Rainbows School for High Achievers"
     fill_in "Year qualification(s) was/were awarded", with: "2020"
   end

--- a/spec/system/jobseekers_can_add_qualifications_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers_can_add_qualifications_to_their_job_application_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe "Jobseekers can add qualifications to their job application" do
       expect(page).to have_content("GCSEs")
       expect(page).to have_content("Churchill School for Gifted Macaques")
       expect(page).to have_content("Maths – 110%")
+      expect(page).to have_content("PE – 90%")
       expect(page).to have_content("2020")
     end
 
@@ -67,9 +68,10 @@ RSpec.describe "Jobseekers can add qualifications to their job application" do
       # TODO: fill_in_another_secondary_qualification
       click_on I18n.t("buttons.save_qualification.other")
       expect(current_path).to eq(jobseekers_job_application_build_path(job_application, :qualifications))
-      expect(page).to have_content("Welsh Baccalaureates")
+      expect(page).to have_content("Welsh Baccalaureate")
       expect(page).to have_content("Happy Rainbows School for High Achievers")
       expect(page).to have_content("Science – 5")
+      expect(page).to have_content("German – 4")
       expect(page).to have_content("2020")
     end
   end
@@ -93,37 +95,6 @@ RSpec.describe "Jobseekers can add qualifications to their job application" do
       expect(current_path).to eq(jobseekers_job_application_build_path(job_application, :qualifications))
       expect(page).not_to have_content("John")
       expect(page).to have_content("Nicholas")
-    end
-  end
-
-  context "when there is a group of more than one qualifications" do
-    let!(:qualifications) do
-      create_list(:qualification, 2,
-                  category: "other_secondary",
-                  institution: "John Mason School",
-                  name: "O Level",
-                  job_application: job_application,
-                  year: 1970)
-    end
-
-    it "allows jobseekers to delete the qualifications as a group" do
-      visit jobseekers_job_application_build_path(job_application, :qualifications)
-
-      click_on I18n.t("buttons.delete")
-
-      expect(current_path).to eq(jobseekers_job_application_build_path(job_application, :qualifications))
-      expect(page).to have_content(I18n.t("jobseekers.job_applications.qualifications.destroy.success.other"))
-      expect(page).not_to have_content("John Mason School")
-    end
-
-    # TODO: complete these pending tests when functionality implemented
-
-    xit "allows jobseekers to edit qualifications from a group" do
-      # noop
-    end
-
-    xit "allows jobseekers to delete a row from a group" do
-      # noop
     end
   end
 end


### PR DESCRIPTION
> PRing for initial feedback, to get a review app, and to go through in our session this afternoon – still needs some tests and perhaps a bit of refactoring.

Our treatment of secondary qualifications as individual qualifications
that are only summarised at display level has proven a bit of a struggle
when it came to allowing users to add/edit them. This introduces a
sub-level of "qualification results" (of which a qualification can have
many), and finishes implementation of the qualifications step for
secondary qualifications (pending some extra tests and refactoring).

- Create `QualificationResult` as an associated model of `Qualification`
  to represent subjects/grades for secondary qualifications
- Add `CommonForm#qualification_results_attributes=` to allow
  use of `fields_for` in the views
- Make use of `accepts_nested_attributes_for` to allow `Qualification`
  to handle persisting nested `QualificationResult`s once the form
  object validations have passed
- Add handling of qualification results in "Quick Apply"
- Remove handling of "grouped" qualifications everywhere (now that each
  qualification is a top-level entity)