### PR TITLE
[TEVA-2488] Fix flaky spec

### DIFF
--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     end
 
     job_location { "at_one_school" }
-    about_school { Faker::Lorem.paragraph(sentence_count: 4) }
+    about_school { "Great school with amazing people" }
     enable_job_applications { true }
     benefits { Faker::Lorem.paragraph(sentence_count: 4) }
     contact_email { Faker::Internet.email }


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-2488

Not sure why but when using a randomly generated string, we had a slightly different version of it persisted, with words like `et` omitted.