### PR TITLE
[TEVA-2572] disable map mouse scroll to stop font requests

### DIFF
--- a/app/frontend/src/application/jobseekers/map.js
+++ b/app/frontend/src/application/jobseekers/map.js
@@ -49,6 +49,7 @@ window.initMap = () => {
 
     const map = new google.maps.Map(document.getElementById('map'), {
       zoom: 14,
+      scrollwheel: false,
       center: myLatLng,
       mapTypeControlOptions, // Removes terrain options section ('map' or 'satellite')
     });


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-2572

disabling mouse scroll feature stops the requests for fonts that 404. whilst doesnt find the root cause my feeling that it is more important to stop the 404 requests and noisy logging in papertrail
