### PR TITLE
Fix letter spacing for application count

### DIFF
--- a/app/frontend/src/styles/application/publishers/publisher.scss
+++ b/app/frontend/src/styles/application/publishers/publisher.scss
@@ -46,6 +46,7 @@ $desktop-container-width: 1200px;
 
     .govuk-caption-s {
       font-weight: normal;
+      letter-spacing: normal;
     }
   }
 }


### PR DESCRIPTION
This inherits some funny letter spacing from `govuk-tag`, which needs
to be reset to normal.

## Screenshots

### Before
<img width="260" alt="Screenshot 2021-05-05 at 11 38 07" src="https://user-images.githubusercontent.com/72141/117129290-69672880-ad96-11eb-8c34-bdf6f3587275.png">

### After
<img width="273" alt="Screenshot 2021-05-05 at 11 37 59" src="https://user-images.githubusercontent.com/72141/117129315-708e3680-ad96-11eb-932f-42f39bd4e4d1.png">
