### PR TITLE
Refactor qualification errors

### DIFF
--- a/app/controllers/jobseekers/job_applications/qualifications_controller.rb
+++ b/app/controllers/jobseekers/job_applications/qualifications_controller.rb
@@ -48,7 +48,9 @@ class Jobseekers::JobApplications::QualificationsController < Jobseekers::BaseCo
     when "select_category"
       {}
     when "edit"
-      qualification.slice(:category, :finished_studying, :finished_studying_details, :grade, :institution, :name, :subject, :year, :qualification_results)
+      qualification
+        .slice(:category, :finished_studying, :finished_studying_details, :grade, :institution, :name, :subject, :year, :qualification_results)
+        .reject { |_, v| v.blank? }
     when "create", "update", "submit_category"
       qualification_params
     end

--- a/app/form_models/jobseekers/job_application/details/qualifications/degree_form.rb
+++ b/app/form_models/jobseekers/job_application/details/qualifications/degree_form.rb
@@ -1,4 +1,6 @@
 class Jobseekers::JobApplication::Details::Qualifications::DegreeForm < Jobseekers::JobApplication::Details::Qualifications::QualificationForm
+  attr_accessor :subject, :grade
+
   validates :finished_studying, :institution, :subject, presence: true
 
   validates :grade, presence: true, if: -> { finished_studying == "true" }

--- a/app/form_models/jobseekers/job_application/details/qualifications/other_form.rb
+++ b/app/form_models/jobseekers/job_application/details/qualifications/other_form.rb
@@ -1,3 +1,5 @@
 class Jobseekers::JobApplication::Details::Qualifications::OtherForm < Jobseekers::JobApplication::Details::Qualifications::QualificationForm
+  attr_accessor :subject, :grade
+
   validates :finished_studying, :institution, :name, presence: true
 end

--- a/app/form_models/jobseekers/job_application/details/qualifications/qualification_form.rb
+++ b/app/form_models/jobseekers/job_application/details/qualifications/qualification_form.rb
@@ -1,8 +1,7 @@
 class Jobseekers::JobApplication::Details::Qualifications::QualificationForm
   include ActiveModel::Model
 
-  attr_accessor :category, :finished_studying, :finished_studying_details, :grade, :name,
-                :institution, :subject, :year, :qualification_results
+  attr_accessor :category, :finished_studying, :finished_studying_details, :name, :institution, :year
 
   validates :category, presence: true
   validates :finished_studying_details, presence: true, if: -> { finished_studying == "false" }

--- a/app/form_models/jobseekers/job_application/details/qualifications/secondary/common_form.rb
+++ b/app/form_models/jobseekers/job_application/details/qualifications/secondary/common_form.rb
@@ -2,6 +2,8 @@ module Jobseekers::JobApplication::Details::Qualifications::Secondary
   class CommonForm < ::Jobseekers::JobApplication::Details::Qualifications::QualificationForm
     MAXIMUM_NUMBER_OF_RESULTS = 6
 
+    attr_accessor :qualification_results
+
     validate :at_least_one_qualification_result
     validate :all_qualification_results_valid
     validates :institution, :year, presence: true
@@ -41,8 +43,8 @@ module Jobseekers::JobApplication::Details::Qualifications::Secondary
       qualification_results.each_with_index do |result, idx|
         next if result.empty? || result.valid?
 
-        field = result.errors.attribute_names.first
-        errors.add(:"qualification_results_attributes_#{idx}_#{field}", :incomplete_qualification_result, result_idx: idx + 1)
+        attr = result.errors.attribute_names.first
+        errors.add(:"qualification_results_attributes_#{idx}_#{attr}", :incomplete_qualification_result, attribute: attr, result_idx: idx + 1)
       end
     end
 

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -148,7 +148,7 @@ en:
     messages:
       taken: has already been taken
       blank: can't be blank
-      incomplete_qualification_result: Enter both a subject and a grade for subject %{result_idx}
+      incomplete_qualification_result: Enter a %{attribute} for Subject %{result_idx}
   activemodel:
     errors:
       models:

--- a/spec/factories/qualifications.rb
+++ b/spec/factories/qualifications.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
       next unless qualification.secondary?
 
       create_list(:qualification_result, evaluator.results_count, qualification: qualification)
+      qualification.reload
     end
 
     transient do
@@ -11,14 +12,14 @@ FactoryBot.define do
       results_count { 5 }
     end
 
-    category { Qualification.categories.keys.sample.to_s }
+    category { Qualification.categories.keys.sample }
     finished_studying { undergraduate? || postgraduate? ? Faker::Boolean.boolean : nil }
-    finished_studying_details { finished_studying.nil? || finished_studying? ? "" : "Stopped due to illness" }
-    grade { finished_studying.nil? || finished_studying? ? %w[A B C D E F].sample : "" }
-    institution { undergraduate? || postgraduate? || other? ? Faker::Educator.university : Faker::Educator.secondary_school }
+    finished_studying_details { finished_studying == false ? "Stopped due to illness" : "" }
+    grade { !finished_studying? || secondary? ? "" : %w[A B C D E F].sample }
+    institution { secondary? ? Faker::Educator.secondary_school : Faker::Educator.university }
     name { other_secondary? || other? ? Faker::Educator.degree : "" }
-    subject { Faker::Educator.subject }
-    year { finished_studying.nil? || finished_studying? ? rand(1970..2020) : nil }
+    subject { secondary? ? "" : Faker::Educator.subject }
+    year { finished_studying == false ? nil : rand(1970..2020) }
 
     job_application
   end

--- a/spec/form_models/jobseekers/job_application/details/qualifications/secondary/common_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/details/qualifications/secondary/common_form_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 RSpec.describe Jobseekers::JobApplication::Details::Qualifications::Secondary::CommonForm, type: :model do
   subject { described_class.new(params) }
   let(:params) { {} }
@@ -8,7 +10,59 @@ RSpec.describe Jobseekers::JobApplication::Details::Qualifications::Secondary::C
 
   it_behaves_like "validates year format"
 
-  describe "#subject_and_grade_correspond?" do
-    # TODO: Add test when functionality is finished
+  describe "qualification result validations" do
+    context "when no qualification results are given" do
+      let(:params) do
+        {
+          qualification_results_attributes: {
+            "0" => { "subject" => "", "grade" => "" },
+            "1" => { "subject" => "", "grade" => "" },
+            "2" => { "subject" => "", "grade" => "" },
+          },
+        }
+      end
+
+      it "is not valid" do
+        expect(subject).not_to be_valid
+        expect(subject.errors.messages_for(:qualification_results_attributes_0_subject)).to include(I18n.t("qualification_errors.qualification_results_attributes_0_subject.at_least_one_result_required"))
+      end
+    end
+
+    context "when some nested qualification results fail validation" do
+      let(:params) do
+        {
+          qualification_results_attributes: {
+            "0" => { "subject" => "Clarinet", "grade" => "A+" },
+            "1" => { "subject" => "Potions", "grade" => "" },
+            "2" => { "subject" => "", "grade" => "A-" },
+          },
+        }
+      end
+
+      it "is not valid and hoists the nested forms' errors" do
+        expect(subject).not_to be_valid
+        expect(subject.errors.messages_for(:qualification_results_attributes_1_grade)).to include(I18n.t("errors.messages.incomplete_qualification_result", attribute: "grade", result_idx: 2))
+        expect(subject.errors.messages_for(:qualification_results_attributes_2_subject)).to include(I18n.t("errors.messages.incomplete_qualification_result", attribute: "subject", result_idx: 3))
+      end
+    end
+
+    context "when all required params are given" do
+      let(:params) do
+        {
+          category: :gcse,
+          year: 1999,
+          institution: "Hogwarts",
+          qualification_results_attributes: {
+            "0" => { "subject" => "Clarinet", "grade" => "A+" },
+            "1" => { "subject" => "Potions", "grade" => "X-" },
+            "2" => { "subject" => "", "grade" => "" },
+          },
+        }
+      end
+
+      it "is valid" do
+        expect(subject).to be_valid
+      end
+    end
   end
 end

--- a/spec/form_models/jobseekers/job_application/details/qualifications/secondary/qualification_result_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/details/qualifications/secondary/qualification_result_form_spec.rb
@@ -1,0 +1,6 @@
+require "rails_helper"
+
+RSpec.describe Jobseekers::JobApplication::Details::Qualifications::Secondary::QualificationResultForm, type: :model do
+  it { is_expected.to validate_presence_of(:subject) }
+  it { is_expected.to validate_presence_of(:grade) }
+end


### PR DESCRIPTION
- More coherent error messages for the specific field that is invalid
  in nested forms
- Move attribute accessors down into appropriate form subclasses
- Add specs for error hoisting