### PR TITLE
[TEVA-2566] Stream job application data to BigQuery (part 1)

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -1,3 +1,4 @@
+# This file lists all the attributes to be exported, including those to be anonymised.
 shared:
   documents:
     - id
@@ -9,6 +10,19 @@ shared:
     - created_at
     - updated_at
     - vacancy_id
+  employments:
+    - id
+    - organisation
+    - job_title
+    - salary
+    - subjects
+    - current_role
+    - main_duties
+    - started_on
+    - ended_on
+    - job_application_id
+    - created_at
+    - updated_at
   feedbacks:
     - id
     - created_at
@@ -35,14 +49,38 @@ shared:
     - created_at
     - updated_at
     - submitted_at
+    - jobseeker_id
+    - vacancy_id
+    - completed_steps
     - draft_at
     - shortlisted_at
     - unsuccessful_at
     - withdrawn_at
-    - jobseeker_id
-    - vacancy_id
-    - completed_steps
+    - first_name
+    - last_name
+    - previous_names
+    - street_address
+    - city
+    - postcode
+    - phone_number
+    - teacher_reference_number
+    - national_insurance_number
+    - qualified_teacher_status
+    - qualified_teacher_status_year
+    - statutory_induction_complete
+    - personal_statement
+    - support_needed
+    - support_needed_details
+    - close_relationships
+    - close_relationships_details
+    - right_to_work_in_uk
+    - further_instructions
+    - rejection_reasons
+    - gaps_in_employment
+    - gaps_in_employment_details
     - in_progress_steps
+    - reviewed_at
+    - country
   jobseekers:
     - id
     - email
@@ -64,6 +102,14 @@ shared:
     - id
     - publisher_preference_id
     - school_id
+    - created_at
+    - updated_at
+  notifications:
+    - id
+    - recipient_type
+    - recipient_id
+    - type
+    - read_at
     - created_at
     - updated_at
   organisations:
@@ -130,6 +176,37 @@ shared:
     - id
     - publisher_id
     - organisation_id
+    - created_at
+    - updated_at
+  qualifications:
+    - id
+    - created_at
+    - updated_at
+    - category
+    - finished_studying
+    - finished_studying_details
+    - grade
+    - institution
+    - name
+    - subject
+    - year
+    - job_application_id
+  qualification_results:
+    - id
+    - qualification_id
+    - subject
+    - grade
+    - created_at
+    - updated_at
+  references:
+    - id
+    - name
+    - job_title
+    - organisation
+    - relationship
+    - email
+    - phone_number
+    - job_application_id
     - created_at
     - updated_at
   saved_jobs:

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -1,7 +1,15 @@
+# This file lists the attributes which should be anonymised when exported.
+# If an attribute is not listed in analytics.yml, it will not exported, even if it is listed here.
 shared:
   documents:
     - id
     - vacancy_id
+  employments:
+    - id
+    - organisation
+    - job_title
+    - main_duties
+    - job_application_id
   feedbacks:
     - id
     - email
@@ -15,6 +23,21 @@ shared:
     - id
     - jobseeker_id
     - vacancy_id
+    - first_name
+    - last_name
+    - previous_names
+    - street_address
+    - city
+    - postcode
+    - phone_number
+    - teacher_reference_number
+    - national_insurance_number
+    - personal_statement
+    - support_needed_details
+    - close_relationships_details
+    - further_instructions
+    - rejection_reasons
+    - gaps_in_employment_details
   jobseekers:
     - id
     - email
@@ -23,6 +46,9 @@ shared:
     - id
     - publisher_preference_id
     - school_id
+  notifications:
+    - id
+    - recipient_id
   organisations:
     - id
   organisation_publisher_preferences:
@@ -47,6 +73,21 @@ shared:
     - id
     - publisher_id
     - organisation_id
+  qualifications:
+    - id
+    - finished_studying_details
+    - job_application_id
+  qualification_results:
+    - id
+    - qualification_id
+  references:
+    - id
+    - name
+    - job_title
+    - organisation
+    - email
+    - phone_number
+    - job_application_id
   saved_jobs:
     - id
     - jobseeker_id


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2566

## Changes in this PR:

Discussed these fields with Performance Analysis.

The 'params' field on the notifications table does not contain the message of the notification - it contains entire records (e.g. vacancy, job_application), so I am excluding it from the streamed data.

I still need to:

- Watch the data being received at the other end, and check that it looks correct

- In a separate PR, add code to export equal_opportunities_reports data. As this data is sensitive, and could be deduced from matching up timestamps of the updated equal_opportunities_reports and job_applications, we will need to handle it separately and differently, rather than sending equal_opportunities_reports to BigQuery whenever the report is updated (which is the same thing as 'whenever a job application is submitted'). So it will look something like triggering an event when a job closes; that event will only export the record if the job has more than [threshold] applications.
