### PR TITLE
[TEVA-2550] Remove Validation from Ask For Support Form and Add Callback to Job Application

### DIFF
--- a/app/form_models/jobseekers/job_application/ask_for_support_form.rb
+++ b/app/form_models/jobseekers/job_application/ask_for_support_form.rb
@@ -5,5 +5,4 @@ class Jobseekers::JobApplication::AskForSupportForm
 
   validates :support_needed, inclusion: { in: %w[yes no] }
   validates :support_needed_details, presence: true, if: -> { support_needed == "yes" }
-  validates :support_needed_details, absence: true, if: -> { support_needed == "no" }
 end

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -1,6 +1,7 @@
 class JobApplication < ApplicationRecord
   before_save :update_status_timestamp, if: :will_save_change_to_status?
   before_save :anonymise_report, if: :will_save_change_to_status?
+  before_save :reset_support_needed_details
 
   extend ArrayEnum
 
@@ -83,5 +84,9 @@ class JobApplication < ApplicationRecord
 
   def reset_equal_opportunities_attributes
     Jobseekers::JobApplication::EqualOpportunitiesForm::ATTRIBUTES.each { |attr| self[attr] = "" }
+  end
+
+  def reset_support_needed_details
+    self[:support_needed_details] = "" if support_needed == "no"
   end
 end

--- a/spec/form_models/jobseekers/job_application/ask_for_support_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/ask_for_support_form_spec.rb
@@ -8,10 +8,4 @@ RSpec.describe Jobseekers::JobApplication::AskForSupportForm, type: :model do
 
     it { is_expected.to validate_presence_of(:support_needed_details) }
   end
-
-  context "when support_needed is no" do
-    before { allow(subject).to receive(:support_needed).and_return("no") }
-
-    it { is_expected.to validate_absence_of(:support_needed_details) }
-  end
 end

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -24,6 +24,17 @@ RSpec.describe JobApplication do
     end
   end
 
+  context "when setting support needed to 'no'" do
+    subject { create(:job_application) }
+
+    before { subject.update(support_needed: "no", support_needed_details: "details in need of resetting") }
+
+    it "resets support needed details" do
+      expect(subject.support_needed).to eq "no"
+      expect(subject.support_needed_details).to be_blank
+    end
+  end
+
   context "when submitted" do
     subject do
       build(:job_application, vacancy: vacancy, disability: "no", gender: "man", gender_description: "",


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2550

## Comments

- Tried to do the resetting in the form model but couldn't figure out a way to make it work so put it in the job application model. Any suggestions welcome!

