### PR TITLE
Make rack_attack return HTTP 204

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -7,6 +7,12 @@ class Rack::Attack
   end
 end
 
+# Override response to return 204 No Content (instead of 429) so our monitoring doesn't count it
+# as a failed request
+Rack::Attack.throttled_response = lambda do |_request|
+  [204, {}, ["\n"]]
+end
+
 # Throttle general requests by IP
 Rack::Attack.throttle("requests by remote ip", limit: 10, period: 4, &:remote_ip)
 


### PR DESCRIPTION
We rely on measuring HTTP 4xx errors in our monitoring, and when we get
scraped or suffer from otherwise misbehaving clients, we get a deluge of
alerts.

This makes rack_attack return `204 No Content` instead.