### PR TITLE
Create S3 bucket for supporting documents

### DIFF
--- a/terraform/app/modules/paas/data.tf
+++ b/terraform/app/modules/paas/data.tf
@@ -1,3 +1,5 @@
+data "aws_caller_identity" "current" {}
+
 data "aws_ssm_parameter" "app_env_api_key_big_query" {
   name = "/${var.service_name}/${var.parameter_store_environment}/app/BIG_QUERY_API_JSON_KEY"
 }

--- a/terraform/app/modules/paas/main.tf
+++ b/terraform/app/modules/paas/main.tf
@@ -25,6 +25,52 @@ resource "cloudfoundry_user_provided_service" "papertrail" {
   syslog_drain_url = var.papertrail_url
 }
 
+resource "aws_s3_bucket" "documents_s3_bucket" {
+  bucket = local.documents_s3_bucket_name
+}
+
+resource "aws_s3_bucket_public_access_block" "documents_s3_bucket_block" {
+  bucket = aws_s3_bucket.documents_s3_bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_iam_policy" "documents_s3_bucket_policy" {
+  name   = "${local.documents_s3_bucket_name}-policy"
+  path   = "/attachment_buckets_policies/"
+  policy = data.aws_iam_policy_document.documents_s3_bucket_policy_document.json
+}
+
+data "aws_iam_policy_document" "documents_s3_bucket_policy_document" {
+  statement {
+    actions   = ["s3:ListAllMyBuckets"]
+    resources = ["arn:aws:s3:::*"]
+    effect    = "Allow"
+  }
+  statement {
+    actions   = ["s3:*"]
+    resources = [aws_s3_bucket.documents_s3_bucket.arn]
+    effect    = "Allow"
+  }
+}
+
+resource "aws_iam_user" "documents_s3_bucket_user" {
+  name = "${local.documents_s3_bucket_name}-user"
+  path = "/attachment_buckets_users/"
+}
+
+resource "aws_iam_access_key" "documents_s3_bucket_access_key" {
+  user = aws_iam_user.documents_s3_bucket_user.name
+}
+
+resource "aws_iam_user_policy_attachment" "attachment" {
+  user       = aws_iam_user.documents_s3_bucket_user.name
+  policy_arn = aws_iam_policy.documents_s3_bucket_policy.arn
+}
+
 resource "cloudfoundry_app" "web_app" {
   name                       = local.web_app_name
   command                    = var.web_app_start_command

--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -38,7 +38,10 @@ variable "redis_cache_service_plan" {
 }
 variable "redis_queue_service_plan" {
 }
+
 variable "service_name" {
+}
+variable "service_abbreviation" {
 }
 variable "space_name" {
 }
@@ -86,10 +89,16 @@ locals {
     yamldecode(data.aws_ssm_parameter.app_env_api_key_google.value)
   )
   app_env_secrets = yamldecode(data.aws_ssm_parameter.app_env_secrets.value)
+  app_env_documents_bucket_credentials = {
+    DOCUMENTS_S3_BUCKET         = local.documents_s3_bucket_name
+    DOCUMENTS_ACCESS_KEY_ID     = aws_iam_access_key.documents_s3_bucket_access_key.id
+    DOCUMENTS_ACCESS_KEY_SECRET = aws_iam_access_key.documents_s3_bucket_access_key.secret
+  }
   app_env_domain  = { "DOMAIN" = "teaching-vacancies-${var.environment}.london.cloudapps.digital" }
   app_environment = merge(
     local.app_env_api_keys,
     local.app_env_secrets,
+    local.app_env_documents_bucket_credentials,
     local.app_env_domain,
     var.app_env_values #Because of merge order, if present, the value of DOMAIN in .tfvars will overwrite app_env_domain
   )
@@ -107,6 +116,8 @@ locals {
   postgres_service_name    = "${var.service_name}-postgres-${var.environment}"
   redis_cache_service_name = "${var.service_name}-redis-cache-${var.environment}"
   redis_queue_service_name = "${var.service_name}-redis-queue-${var.environment}"
+  # S3 bucket name uses abbreviation so we don't run into 63 character bucket name limit
+  documents_s3_bucket_name = "${data.aws_caller_identity.current.account_id}-${var.service_abbreviation}-attachments-documents-${var.environment}"
   web_app_name             = "${var.service_name}-${var.environment}"
   worker_app_start_command = "bundle exec sidekiq -C config/sidekiq.yml"
   worker_app_name          = "${var.service_name}-worker-${var.environment}"

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -77,6 +77,7 @@ module "paas" {
   papertrail_service_binding_enable = var.paas_papertrail_service_binding_enable
   parameter_store_environment       = var.parameter_store_environment
   service_name                      = local.service_name
+  service_abbreviation              = local.service_abbreviation
   postgres_service_plan             = var.paas_postgres_service_plan
   redis_cache_service_plan          = var.paas_redis_cache_service_plan
   redis_queue_service_plan          = var.paas_redis_queue_service_plan

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -130,6 +130,7 @@ locals {
   route53_a_records    = local.is_production ? var.route53_zones : []
   route53_cname_record = local.is_production ? "www" : var.environment
   service_name         = "teaching-vacancies"
+  service_abbreviation = "tv"
   hostname_domain_map = {
     for zone in var.route53_zones :
     "${local.route53_cname_record}.${zone}" => {

--- a/terraform/common/variables.tf
+++ b/terraform/common/variables.tf
@@ -6,5 +6,5 @@ locals {
   primary_zone_name                     = "teaching-vacancies.service.gov.uk"
   secondary_zone_name                   = "teaching-jobs.service.gov.uk"
   service_name                          = "teaching-vacancies"
-  service_abbreviation                  = "TV"
+  service_abbreviation                  = "tv"
 }


### PR DESCRIPTION
This creates an S3 bucket (and IAM user and credentials) for storing
supporting documents for vacancies, and attaches the credentials to
the PaaS app.

- Create an S3 bucket per environment to store supporting documents
- Create an IAM user and access key for the app to access the bucket
- Merge bucket name and credentials into app environment
- Change service abbreviation to lowercase (not used anywhere else,
  and S3 doesn't support uppercase characters in bucket names)

## Jira ticket URL

- Just add the ticket number to the end:

https://dfedigital.atlassian.net/browse/TEVA-

## Changes in this PR:

- Is there anything specific you want feedback on?

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
