### PR TITLE
[TEVA-2098] Wider Search Suggestions A:B Test

### DIFF
--- a/app/views/vacancies/index.html.slim
+++ b/app/views/vacancies/index.html.slim
@@ -41,7 +41,7 @@
               ul.govuk-list.govuk-list--bullet
                 - t("jobs.no_jobs.suggestions").each do |list_item|
                   li = list_item
-          - if @vacancies_search.wider_search_suggestions.present?
+          - if current_variant?(:"2021_05_wider_search_suggestions", :with) && @vacancies_search.wider_search_suggestions.present?
             .divider-bottom
               - if @vacancies_search.keyword.present?
                 .govuk-heading-m = t(".wider_search_suggestions.heading.keyword_html", keyword: @vacancies_search.keyword)

--- a/config/ab_tests.yml
+++ b/config/ab_tests.yml
@@ -38,6 +38,9 @@ shared:
   2021_04_application_preview_test:
     link: 1
     no_link: 1
+  2021_05_wider_search_suggestions:
+    with: 1
+    without: 1
 test:
   2021_04_cookie_consent_test:
     none: 0


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2098

## Screenshots

### With Wider Suggestions

<img width="1048" alt="Screenshot 2021-05-07 at 18 28 49" src="https://user-images.githubusercontent.com/30624173/117486832-13df7700-af62-11eb-8116-08e30ff8478a.png">

### Without Wider Suggestions

<img width="1005" alt="Screenshot 2021-05-07 at 18 30 20" src="https://user-images.githubusercontent.com/30624173/117486959-49846000-af62-11eb-967d-cb387be51e33.png">

## Viewing Variants in the Review App

- It can be a bit tricky finding a location polygon with no vacancies that also has location polygons near it with vacancies. Worth checking the locations in the yaml files in lib > tasks > data for small towns near big towns. Weston-Super-Mare worked for me locally.

### To apply the variants, add these to the end of the url once you've made a search

- with: `&ab_test_override[2021_05_wider_search_suggestions]=with`
- without: `&ab_test_override[2021_05_wider_search_suggestions]=without`