### PR TITLE
Add check for submitted applications

### DIFF
--- a/app/views/jobseekers/saved_jobs/index.html.slim
+++ b/app/views/jobseekers/saved_jobs/index.html.slim
@@ -36,7 +36,10 @@
                 = tag.div(card.labelled_item(t(".application_deadline"), OrganisationVacancyPresenter.new(saved_job.vacancy).application_deadline))
 
               - card.actions do
-                = tag.div(govuk_link_to(t(".apply"), new_jobseekers_job_job_application_path(saved_job.vacancy.id))) if JobseekerApplicationsFeature.enabled? && saved_job.vacancy.enable_job_applications? && Vacancy.live.exists?(saved_job.vacancy.id)
+                - if JobseekerApplicationsFeature.enabled? && saved_job.vacancy.enable_job_applications? && Vacancy.live.exists?(saved_job.vacancy.id) && current_jobseeker.job_applications.after_submission.find_by(vacancy_id: saved_job.vacancy.id).present?
+                  = tag.div(govuk_link_to(t(".view"), jobseekers_job_application_path(JobApplication.find_by(vacancy_id: saved_job.vacancy.id))))
+                - elsif JobseekerApplicationsFeature.enabled? && saved_job.vacancy.enable_job_applications? && Vacancy.live.exists?(saved_job.vacancy.id)
+                  = tag.div(govuk_link_to(t(".apply"), new_jobseekers_job_job_application_path(saved_job.vacancy.id)))
                 = tag.div(button_to(t(".delete"), jobseekers_saved_job_path(saved_job.vacancy.id, saved_job, redirect_to_dashboard: true), method: :delete, class: "govuk-delete-link"))
         - else
           = render EmptySectionComponent.new title: t(".zero_saved_jobs_title") do

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -413,6 +413,7 @@ en:
         page_title: Saved jobs
         deadline_passed: Deadline passed
         delete: Delete
+        view: View application
         zero_saved_jobs_body_html: '%{link_to} and start saving jobs you may want to review and apply for later.'
         zero_saved_jobs_title: You have no saved teaching jobs
       save: Save this job for later


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2603

## Changes in this PR:

- If a jobseeker has applied for a saved job (the job application's status is in the 'after submission' scope), a link to view the application is rendered
- If an application hasn't been submitted and other conditions are met, a link to apply is rendered

## Questions

- What if an application is in draft? Should we render a 'continue application' link?