### PR TITLE
Add missing permission for Deployments role

### DIFF
--- a/terraform/common/iam.tf
+++ b/terraform/common/iam.tf
@@ -119,7 +119,8 @@ data "aws_iam_policy_document" "deployments_role_policy" {
       "iam:GetPolicyVersion",
       "iam:ListPolicyVersions",
       "iam:CreatePolicy",
-      "iam:DeletePolicy"
+      "iam:DeletePolicy",
+      "iam:CreatePolicyVersion"
     ]
     resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/attachment_buckets_policies/*"]
   }


### PR DESCRIPTION
The `Deployments` role needs to be able to create a new policy version
when updating the S3 attachment bucket policy (in case it has changed).