### PR TITLE
Correct timestamps

### DIFF
--- a/app/helpers/dates_helper.rb
+++ b/app/helpers/dates_helper.rb
@@ -14,7 +14,17 @@ module DatesHelper
   def format_time(time)
     return "" if time.nil?
 
-    time.strftime("%-l:%M %P")
+    time.strftime("%-l:%M%P")
+  end
+
+  def day(date)
+    if date.today?
+      "Today"
+    elsif date.yesterday?
+      "Yesterday"
+    else
+      date.strftime("%-d %B")
+    end
   end
 
   def date_format_error_message(format, date_formats)

--- a/app/notifications/publishers/job_application_received_notification.rb
+++ b/app/notifications/publishers/job_application_received_notification.rb
@@ -1,6 +1,7 @@
 class Publishers::JobApplicationReceivedNotification < Noticed::Base
   include ActionView::Helpers::UrlHelper
   include GovukLinkHelper
+  include DatesHelper
 
   deliver_by :database
   delegate :created_at, to: :record
@@ -12,10 +13,7 @@ class Publishers::JobApplicationReceivedNotification < Noticed::Base
   end
 
   def timestamp
-    return created_at.strftime("Today at %H:%I") if created_at.today?
-    return created_at.strftime("Yesterday at %H:%I") if created_at.yesterday?
-
-    created_at.strftime("%B %d at %H:%I")
+    created_at.strftime("#{day(created_at)} at #{format_time(created_at)}")
   end
 
   private

--- a/app/notifications/publishers/job_application_received_notification.rb
+++ b/app/notifications/publishers/job_application_received_notification.rb
@@ -13,7 +13,7 @@ class Publishers::JobApplicationReceivedNotification < Noticed::Base
   end
 
   def timestamp
-    created_at.strftime("#{day(created_at)} at #{format_time(created_at)}")
+    "#{day(created_at)} at #{format_time(created_at)}"
   end
 
   private

--- a/spec/notifications/publishers/job_application_received_notification_spec.rb
+++ b/spec/notifications/publishers/job_application_received_notification_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Publishers::JobApplicationReceivedNotification do
 
     context "when the notification was delivered before yesterday" do
       before do
-        travel_to 2.days.ago do
+        travel_to DateTime.new(2000, 0o1, 0o1, 14, 30) do
           described_class
             .with(vacancy: job_application.vacancy, job_application: job_application)
             .deliver(vacancy.publisher)
@@ -43,7 +43,7 @@ RSpec.describe Publishers::JobApplicationReceivedNotification do
       end
 
       it "returns the correct timestamp" do
-        expect(subject).to match(/#{2.days.ago.strftime("%B %d")} at/)
+        expect(subject).to eq("1 January at 2:30pm")
       end
     end
   end


### PR DESCRIPTION
There was a bug where the notifications were displaying hour:hour instead of hour:minute for the time.

GDS style guide recommends 2:30pm over 2:30 pm so I have fixed this generally
