### PR TITLE
[TEVA-2566] Send equal opportunities report publication events to BigQuery

### DIFF
--- a/app/components/publishers/vacancies_component.rb
+++ b/app/components/publishers/vacancies_component.rb
@@ -46,10 +46,10 @@ class Publishers::VacanciesComponent < ViewComponent::Base
     return unless vacancy.enable_job_applications?
     return unless include_job_applications?
 
-    after_submission_job_applications = vacancy.job_applications.after_submission
+    applications = vacancy.job_applications.where(status: %w[submitted reviewed shortlisted unsuccessful])
 
-    if after_submission_job_applications.any?
-      link = govuk_link_to(I18n.t("jobs.manage.view_applicants", count: after_submission_job_applications.count),
+    if applications.any?
+      link = govuk_link_to(I18n.t("jobs.manage.view_applicants", count: applications.count),
                            organisation_job_job_applications_path(vacancy.id),
                            class: "govuk-link--no-visited-state")
       tag.div(card.labelled_item(I18n.t("jobs.manage.applications"), link))

--- a/app/jobs/stream_equal_opportunities_report_publication_job.rb
+++ b/app/jobs/stream_equal_opportunities_report_publication_job.rb
@@ -1,0 +1,9 @@
+class StreamEqualOpportunitiesReportPublicationJob < ApplicationJob
+  queue_as :low
+
+  def perform
+    Vacancy.expired_yesterday.listed.select(&:publish_equal_opportunities_report?).each do |vacancy|
+      vacancy.equal_opportunities_report&.trigger_event
+    end
+  end
+end

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -121,8 +121,7 @@ module Indexable
     end
 
     def remove_vacancies_that_expired_yesterday!
-      expired_records = where("expires_at BETWEEN ? AND ?", Time.zone.yesterday.midnight, Date.current.midnight)
-      index.delete_objects(expired_records.map(&:id)) if expired_records&.any?
+      index.delete_objects(expired_yesterday.map(&:id)) if expired_yesterday&.any?
     end
   end
 

--- a/app/models/equal_opportunities_report.rb
+++ b/app/models/equal_opportunities_report.rb
@@ -1,3 +1,7 @@
 class EqualOpportunitiesReport < ApplicationRecord
   belongs_to :vacancy
+
+  def trigger_event
+    Event.new.trigger(:equal_opportunities_report_published, event_data)
+  end
 end

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -40,7 +40,7 @@ class JobApplication < ApplicationRecord
   has_many :references, dependent: :destroy
 
   scope :submitted_yesterday, -> { submitted.where("DATE(submitted_at) = ?", Date.yesterday) }
-  scope :after_submission, -> { where(status: %w[submitted reviewed shortlisted unsuccessful]) }
+  scope :after_submission, -> { where(status: %w[submitted reviewed shortlisted unsuccessful withdrawn]) }
 
   def name
     "#{first_name} #{last_name}"

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -51,14 +51,15 @@ class Vacancy < ApplicationRecord
 
   scope :active, (-> { where(status: %i[published draft]) })
   scope :applicable, (-> { where("expires_at >= ?", Time.current) })
-  scope :expires_within_data_access_period, (-> { where("expires_at >= ?", Time.current - DATA_ACCESS_PERIOD_FOR_PUBLISHERS) })
-  scope :expired, (-> { published.where("expires_at < ?", Time.current) })
   scope :awaiting_feedback, (-> { expired.where(listed_elsewhere: nil, hired_status: nil) })
-  scope :listed, (-> { published.where("publish_on <= ?", Date.current) })
-  scope :pending, (-> { published.where("publish_on > ?", Date.current) })
-  scope :live, (-> { listed.applicable })
-  scope :published_on_count, (->(date) { published.where(publish_on: date.all_day).count })
+  scope :expired, (-> { published.where("expires_at < ?", Time.current) })
+  scope :expired_yesterday, (-> { where("expires_at BETWEEN ? AND ?", Time.zone.yesterday.midnight, Date.current.midnight) })
+  scope :expires_within_data_access_period, (-> { where("expires_at >= ?", Time.current - DATA_ACCESS_PERIOD_FOR_PUBLISHERS) })
   scope :in_organisation_ids, (->(ids) { joins(:organisation_vacancies).where(organisation_vacancies: { organisation_id: ids }).distinct })
+  scope :listed, (-> { published.where("publish_on <= ?", Date.current) })
+  scope :live, (-> { listed.applicable })
+  scope :pending, (-> { published.where("publish_on > ?", Date.current) })
+  scope :published_on_count, (->(date) { published.where(publish_on: date.all_day).count })
 
   paginates_per 10
 
@@ -66,6 +67,8 @@ class Vacancy < ApplicationRecord
   validate :enable_job_applications_cannot_be_changed_once_listed
 
   before_save :on_expired_vacancy_feedback_submitted_update_stats_updated_at
+
+  EQUAL_OPPORTUNITIES_PUBLICATION_THRESHOLD = 5
 
   def organisation
     organisation_vacancies.first&.organisation
@@ -109,6 +112,10 @@ class Vacancy < ApplicationRecord
 
   def education_phases
     organisations.map(&:readable_phases).flatten.uniq
+  end
+
+  def publish_equal_opportunities_report?
+    job_applications.after_submission.count >= EQUAL_OPPORTUNITIES_PUBLICATION_THRESHOLD
   end
 
   private

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -23,6 +23,43 @@ shared:
     - job_application_id
     - created_at
     - updated_at
+  equal_opportunities:
+    - id
+    - vacancy_id
+    - total_submissions
+    - disability_no
+    - disability_prefer_not_to_say
+    - disability_yes
+    - gender_man
+    - gender_other
+    - gender_prefer_not_to_say
+    - gender_woman
+    - gender_other_descriptions
+    - orientation_bisexual
+    - orientation_gay_or_lesbian
+    - orientation_heterosexual
+    - orientation_other
+    - orientation_prefer_not_to_say
+    - orientation_other_descriptions
+    - ethnicity_asian
+    - ethnicity_black
+    - ethnicity_mixed
+    - ethnicity_other
+    - ethnicity_prefer_not_to_say
+    - ethnicity_white
+    - ethnicity_other_descriptions
+    - religion_buddhist
+    - religion_christian
+    - religion_hindu
+    - religion_jewish
+    - religion_muslim
+    - religion_none
+    - religion_other
+    - religion_prefer_not_to_say
+    - religion_sikh
+    - religion_other_descriptions
+    - created_at
+    - updated_at
   feedbacks:
     - id
     - created_at

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -4,6 +4,9 @@ shared:
   documents:
     - id
     - vacancy_id
+  equal_opportunities:
+    - id
+    - vacancy_id
   employments:
     - id
     - organisation

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -63,6 +63,11 @@ send_feedback:
   class: 'SendFeedbackToBigQueryJob'
   queue: low
 
+stream_equal_opportunities_report_publication_job:
+  cron: '30 01 * * *'
+  class: 'StreamEqualOpportunitiesReportPublicationJob'
+  queue: low
+
 update_algolia_index:
   cron: '*/5 * * * *'
   class: 'UpdateAlgoliaIndex'

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -103,6 +103,21 @@ FactoryBot.define do
       expires_at { Faker::Time.backward(days: 6) }
     end
 
+    trait :expired_yesterday do
+      expires_on { Time.zone.yesterday.end_of_day }
+      expires_at { Time.zone.yesterday.midday }
+    end
+
+    trait :expired_years_ago do
+      expires_at { 2.years.ago }
+      expires_on { 2.years.ago }
+    end
+
+    trait :expires_tomorrow do
+      expires_on { Time.zone.tomorrow.end_of_day }
+      expires_at { Time.zone.tomorrow.midday }
+    end
+
     trait :future_publish do
       publish_on { Date.current + 2.days }
       expires_on { Date.current + 2.months }
@@ -119,15 +134,6 @@ FactoryBot.define do
     trait :job_schema do
       working_patterns { %w[full_time part_time] }
       benefits { Faker::Lorem.sentence }
-    end
-
-    trait :expire_tomorrow do
-      expires_on { Time.zone.tomorrow.end_of_day }
-    end
-
-    trait :expired_years_ago do
-      expires_at { 2.years.ago }
-      expires_on { 2.years.ago }
     end
 
     trait :without_working_patterns do

--- a/spec/jobs/stream_equal_opportunities_report_publication_job_spec.rb
+++ b/spec/jobs/stream_equal_opportunities_report_publication_job_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe StreamEqualOpportunitiesReportPublicationJob do
+  subject(:job) { described_class.perform_later }
+  let(:vacancy) do
+    instance_double(Vacancy,
+                    publish_equal_opportunities_report?: publish_report?,
+                    equal_opportunities_report: report)
+  end
+  let(:publish_report?) { true }
+  let(:report) { instance_double(EqualOpportunitiesReport) }
+
+  before do
+    allow(Vacancy).to receive_message_chain(:expired_yesterday, :listed).and_return([vacancy])
+  end
+
+  context "when the vacancy has had no applications" do
+    let(:report) { nil }
+
+    it "doesn't throw an error" do
+      expect { perform_enqueued_jobs { job } }.not_to raise_exception
+    end
+  end
+
+  it "triggers an equal opportunities report event for vacancies that expired yesterday" do
+    expect(report).to receive(:trigger_event)
+
+    perform_enqueued_jobs { job }
+  end
+
+  context "when the vacancy does not have enough applicants to publish the equal opportunities report" do
+    let(:publish_report?) { false }
+
+    it "does not trigger an event for that report" do
+      expect(report).not_to receive(:trigger_event)
+
+      perform_enqueued_jobs { job }
+    end
+  end
+end

--- a/spec/models/equal_opportunities_report_spec.rb
+++ b/spec/models/equal_opportunities_report_spec.rb
@@ -2,4 +2,10 @@ require "rails_helper"
 
 RSpec.describe EqualOpportunitiesReport do
   it { is_expected.to belong_to(:vacancy) }
+
+  describe "#trigger_event" do
+    it "triggers an event of the correct type" do
+      expect { described_class.new.trigger_event }.to have_triggered_event(:equal_opportunities_report_published).with_data({ table_name: "equal_opportunities_reports" })
+    end
+  end
 end

--- a/spec/system/jobseekers_can_view_all_the_jobs_spec.rb
+++ b/spec/system/jobseekers_can_view_all_the_jobs_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "Jobseekers can view all the jobs" do
 
   describe "sorting" do
     let!(:newest_job) { create(:vacancy, :past_publish, publish_on: Date.current, expires_at: 1.year.from_now, organisation_vacancies_attributes: [{ organisation: school }]) }
-    let!(:expires_tomorrow_job) { create(:vacancy, :past_publish, :expire_tomorrow, organisation_vacancies_attributes: [{ organisation: school }]) }
+    let!(:expires_tomorrow_job) { create(:vacancy, :past_publish, :expires_tomorrow, organisation_vacancies_attributes: [{ organisation: school }]) }
 
     context "when visiting the home page and performing an empty search" do
       before do


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2566

## Changes in this PR:

As this data is sensitive, and could be deduced from matching up timestamps of the updated equal_opportunities_reports and job_applications, we will need to handle it separately and differently than we do normal entity create/update/destroy events, rather than sending equal opportunities reports to BigQuery whenever the report is updated (which is the same thing as 'whenever a job application is submitted').

A new job runs every night after midnight. This works by triggering an event for every job listing that expired yesterday, but only if the listing has more than [threshold] applications, to preserve anonymity in the streamed events db.

## Next steps:

- [x] Write tests

- [ ] Check the data coming out of the other end of the pipeline
