### PR TITLE
[TEVA-2542] add variants for round 3 of cookie banner ab test

### DIFF
--- a/app/components/ab_test/cookies_banner_component/cookies_banner_component.html+bottom_sticky_default.slim
+++ b/app/components/ab_test/cookies_banner_component/cookies_banner_component.html+bottom_sticky_default.slim
@@ -1,0 +1,8 @@
+.cookies-banner-component.cookies-banner-component__bottom.cookies-banner-component__sticky aria-label=t("cookies_preferences.banner.aria.label") role="region"
+  .cookies-banner-component__background
+    .govuk-width-container
+      h3.govuk-heading-s class="govuk-!-margin-bottom-2" = t("cookies_preferences.banner.heading")
+      p.govuk-body = t("cookies_preferences.banner.body")
+      .govuk-button-group
+        = govuk_button_to t("buttons.accept_all_cookies"), create_path, form_class: "govuk-button--primary"
+        = govuk_link_to t("buttons.set_preferences"), preferences_path, class: "govuk-button--secondary", button: true

--- a/app/components/ab_test/cookies_banner_component/cookies_banner_component.html+bottom_sticky_gds.slim
+++ b/app/components/ab_test/cookies_banner_component/cookies_banner_component.html+bottom_sticky_gds.slim
@@ -1,4 +1,4 @@
-.govuk-cookie-banner.cookies-banner-component__gds role="region" aria-label = t("cookies_preferences.banner.aria.label")
+.govuk-cookie-banner.cookies-banner-component.cookies-banner-component__bottom.cookies-banner-component__sticky role="region" aria-label = t("cookies_preferences.banner.aria.label")
   .govuk-cookie-banner__message.govuk-width-container
     .govuk-grid-row
       .govuk-grid-column-two-thirds

--- a/app/components/ab_test/cookies_banner_component/cookies_banner_component.html+default.slim
+++ b/app/components/ab_test/cookies_banner_component/cookies_banner_component.html+default.slim
@@ -1,7 +1,0 @@
-.cookies-banner-component aria-label=t("cookies_preferences.banner.aria.label") role="region"
-  .govuk-width-container
-    h3.govuk-heading-s class="govuk-!-margin-bottom-2" = t("cookies_preferences.banner.heading")
-    p.govuk-body = t("cookies_preferences.banner.body")
-    .govuk-button-group
-      = govuk_button_to t("buttons.accept_all_cookies"), create_path, form_class: "govuk-button--primary"
-      = govuk_link_to t("buttons.set_preferences"), preferences_path, class: "govuk-button--secondary", button: true

--- a/app/components/ab_test/cookies_banner_component/cookies_banner_component.html+modal.slim
+++ b/app/components/ab_test/cookies_banner_component/cookies_banner_component.html+modal.slim
@@ -1,7 +1,0 @@
-.cookies-banner-component.cookies-banner-component__modal aria-label=t("cookies_preferences.banner.aria.label") role="region"
-  .govuk-width-container
-    h3.govuk-heading-s class="govuk-!-margin-bottom-2" = t("cookies_preferences.banner.heading")
-    p.govuk-body = t("cookies_preferences.banner.body")
-    .govuk-button-group
-      = govuk_button_to t("buttons.accept_all_cookies"), create_path, form_class: "govuk-button--primary"
-      = govuk_link_to t("buttons.set_preferences"), preferences_path, class: "govuk-button--secondary", button: true

--- a/app/components/ab_test/cookies_banner_component/cookies_banner_component.html+top_grey_sticky_default.slim
+++ b/app/components/ab_test/cookies_banner_component/cookies_banner_component.html+top_grey_sticky_default.slim
@@ -1,5 +1,4 @@
-.cookies-banner-component.cookies-banner-component__bottom.cookies-banner-component__bottom--black aria-label=t("cookies_preferences.banner.aria.label") role="region"
-  .cookies-banner-component__fade
+.cookies-banner-component.cookies-banner-component__top.cookies-banner-component__sticky aria-label=t("cookies_preferences.banner.aria.label") role="region"
   .cookies-banner-component__background
     .govuk-width-container
       h3.govuk-heading-s class="govuk-!-margin-bottom-2" = t("cookies_preferences.banner.heading")

--- a/app/components/ab_test/cookies_banner_component/cookies_banner_component.html+top_grey_sticky_gds.slim
+++ b/app/components/ab_test/cookies_banner_component/cookies_banner_component.html+top_grey_sticky_gds.slim
@@ -1,0 +1,16 @@
+.govuk-cookie-banner.cookies-banner-component.cookies-banner-component__top.cookies-banner-component__sticky role="region" aria-label = t("cookies_preferences.banner.aria.label")
+  .govuk-cookie-banner__message.govuk-width-container
+    .govuk-grid-row
+      .govuk-grid-column-two-thirds
+        h2.govuk-cookie-banner__heading.govuk-heading-m Cookies on Teaching Vacancies
+
+        .govuk-cookie-banner__content
+          p We use some essential cookies to make this service work.
+          p We’d also like to use analytics cookies so we can understand how you use the service and make improvements.
+
+    .govuk-button-group
+      = govuk_button_to "Accept analytics cookies", create_path, form_class: "govuk-button--primary"
+
+      = govuk_button_to "Reject analytics cookies", reject_path, form_class: "govuk-button--primary"
+
+      = govuk_link_to "View cookies", preferences_path

--- a/app/components/ab_test/cookies_banner_component/cookies_banner_component.html+top_static_default.slim
+++ b/app/components/ab_test/cookies_banner_component/cookies_banner_component.html+top_static_default.slim
@@ -1,5 +1,4 @@
-.cookies-banner-component.cookies-banner-component__bottom.cookies-banner-component__bottom--blue aria-label=t("cookies_preferences.banner.aria.label") role="region"
-  .cookies-banner-component__fade
+.cookies-banner-component.cookies-banner-component__top aria-label=t("cookies_preferences.banner.aria.label") role="region"
   .cookies-banner-component__background
     .govuk-width-container
       h3.govuk-heading-s class="govuk-!-margin-bottom-2" = t("cookies_preferences.banner.heading")

--- a/app/components/ab_test/cookies_banner_component/cookies_banner_component.html+top_static_gds.slim
+++ b/app/components/ab_test/cookies_banner_component/cookies_banner_component.html+top_static_gds.slim
@@ -1,0 +1,16 @@
+.govuk-cookie-banner.cookies-banner-component.cookies-banner-component__top role="region" aria-label = t("cookies_preferences.banner.aria.label")
+  .govuk-cookie-banner__message.govuk-width-container
+    .govuk-grid-row
+      .govuk-grid-column-two-thirds
+        h2.govuk-cookie-banner__heading.govuk-heading-m Cookies on Teaching Vacancies
+
+        .govuk-cookie-banner__content
+          p We use some essential cookies to make this service work.
+          p We’d also like to use analytics cookies so we can understand how you use the service and make improvements.
+
+    .govuk-button-group
+      = govuk_button_to "Accept analytics cookies", create_path, form_class: "govuk-button--primary"
+
+      = govuk_button_to "Reject analytics cookies", reject_path, form_class: "govuk-button--primary"
+
+      = govuk_link_to "View cookies", preferences_path

--- a/app/components/ab_test/cookies_banner_component/cookies_banner_component.scss
+++ b/app/components/ab_test/cookies_banner_component/cookies_banner_component.scss
@@ -1,16 +1,26 @@
 @import 'base_component';
 
-/* stylelint-disable */
 .cookies-banner-component {
   @include govuk-responsive-padding(3, 'top');
   @include govuk-responsive-padding(0, 'bottom');
-  background-color: rgba($color: govuk-colour('light-blue'), $alpha: 0.2);
+  background-color: rgba($color: govuk-colour('light-grey'), $alpha: 0.2);
+  padding-top: 0;
+  width: 100%;
   z-index: 1000;
+
+  &.govuk-cookie-banner {
+    padding-top: 0;
+  }
 
   .govuk-button-group {
     align-items: inherit;
     margin-bottom: 0;
   }
+
+  .cookies-banner-component__background {
+    background-color: govuk-colour('light-grey');
+  }
+
 
   &__gds {
     @include govuk-media-query($until: tablet) {
@@ -25,35 +35,8 @@
   }
 
   &__bottom {
-    &--black {
-      .cookies-banner-component__fade {
-        height: 6px;
-        background: linear-gradient(
-          to top,
-          govuk-colour("black"),
-          rgba(govuk-colour("black"), 0)
-        )
-      }
-
-      .cookies-banner-component__background {
-        background-color: govuk-colour("black");
-      }
-    }
-
-    &--blue {
-      .cookies-banner-component__fade {
-        height: 6px;
-        background: linear-gradient(
-          to top,
-          govuk-colour("dark-blue"),
-          rgba(govuk-colour("dark-blue"), 0)
-        )
-      }
-
-      .cookies-banner-component__background {
-        background-color: govuk-colour("dark-blue");
-      }
-    }
+    bottom: 0;
+    padding-top: 0;
 
     @include govuk-media-query($until: tablet) {
       .govuk-button--primary {
@@ -61,13 +44,9 @@
       }
     }
 
-    position: fixed;
-    bottom: 0;
-    padding-top: 0;
-    width: 100%;
     .govuk-heading-s,
     .govuk-body {
-      color: govuk-colour("white");
+      color: govuk-colour('black');
     }
 
     .govuk-width-container {
@@ -75,39 +54,27 @@
     }
   }
 
-  &__modal {
-    @include govuk-media-query($until: tablet) {
-      margin-left: -40vw;
-      margin-top: -8vw;
-      width: 80vw;
-      height: auto;
+  &__top {
+    padding-top: 0;
+    top: 0;
 
-      form {
-        display: flex;
+    @include govuk-media-query($until: tablet) {
+      .govuk-button--primary {
+        width: 100%;
       }
     }
 
-    background-color: govuk-colour("white");
-    width: 40vw;
-    height: auto;
-    position: absolute;
-    left: 50%;
-    top: 40%;
-    margin-left: -20vw;
-    margin-top: -8vw;
-  }
-}
+    .govuk-heading-s,
+    .govuk-body {
+      color: govuk-colour('black');
+    }
 
-.modal {
-  overflow: hidden;
-  .modal-container {
-    z-index: 999;
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    top: 0;
-    content: '';
-    background-color: rgba($color: govuk-colour('black'), $alpha: 0.5);
+    .govuk-width-container {
+      padding-top: 15px;
+    }
+  }
+
+  &__sticky {
+    position: sticky;
   }
 }
-/* stylelint-enable */

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,5 +1,5 @@
 doctype html
-html.govuk-template.app-html-class lang="en" class=("modal" if current_variant?(:"2021_04_cookie_consent_test", :modal) && !cookies_preference_set?)
+html.govuk-template.app-html-class lang="en"
   head
     = render partial: "shared/google_tag_manager_head" if cookies["consented-to-cookies"] == "yes"
     = render partial: "shared/open_graph"
@@ -21,14 +21,12 @@ html.govuk-template.app-html-class lang="en" class=("modal" if current_variant?(
     = csrf_meta_tags
 
   body class=body_class data-vacancy_state=(@vacancy.present? ? @vacancy.state : "create")
-    - if current_variant?(:"2021_04_cookie_consent_test", :modal) && !cookies_preference_set?
-      .modal-container
     = render partial: "shared/google_tag_manager_body" if cookies["consented-to-cookies"] == "yes"
     = javascript_tag(nonce: true) do
       | document.body.className = ((document.body.className) ? document.body.className + " js-enabled" : "js-enabled");
     = render "shared/skip_links"
-    - unless cookies_preference_set? || %i[top none].include?(ab_variant_for(:"2021_04_cookie_consent_test"))
-      = render(AbTest::CookiesBannerComponent.new(create_path: create_cookies_preferences_path(cookies_consent: "yes", **utm_parameters), reject_path: create_cookies_preferences_path(cookies_consent: "no", **utm_parameters), preferences_path: cookies_preferences_path(**utm_parameters)).with_variant(ab_variant_for(:"2021_04_cookie_consent_test")))
+    - unless cookies_preference_set? || %i[bottom_sticky_default bottom_sticky_gds].include?(ab_variant_for(:"2021_05_cookie_consent_test"))
+      = render(AbTest::CookiesBannerComponent.new(create_path: create_cookies_preferences_path(cookies_consent: "yes", **utm_parameters), reject_path: create_cookies_preferences_path(cookies_consent: "no", **utm_parameters), preferences_path: cookies_preferences_path(**utm_parameters)).with_variant(ab_variant_for(:"2021_05_cookie_consent_test")))
 
     = render Shared::EnvironmentBannerComponent.new
 
@@ -114,4 +112,8 @@ html.govuk-template.app-html-class lang="en" class=("modal" if current_variant?(
           .govuk-footer__meta-item
             a.govuk-footer__link.govuk-footer__copyright-logo href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
               | © Crown copyright
+
+    - unless cookies_preference_set? || %i[top_sticky_default top_sticky_gds top_static_default top_static_gds].include?(ab_variant_for(:"2021_05_cookie_consent_test"))
+      = render(AbTest::CookiesBannerComponent.new(create_path: create_cookies_preferences_path(cookies_consent: "yes", **utm_parameters), reject_path: create_cookies_preferences_path(cookies_consent: "no", **utm_parameters), preferences_path: cookies_preferences_path(**utm_parameters)).with_variant(ab_variant_for(:"2021_05_cookie_consent_test")))
+
     = javascript_pack_tag "application"

--- a/config/ab_tests.yml
+++ b/config/ab_tests.yml
@@ -28,13 +28,13 @@ shared:
     foo: 1
     bar: 1
     baz: 1
-  2021_04_cookie_consent_test:
-    none: 1
-    default: 1
-    bottom_black: 1
-    bottom_blue: 1
-    modal: 1
-    gds: 1
+  2021_05_cookie_consent_test:
+    bottom_sticky_default: 1
+    bottom_sticky_gds: 1
+    top_static_default: 1
+    top_static_gds: 1
+    top_sticky_default: 1
+    top_sticky_gds: 1
   2021_04_application_preview_test:
     link: 1
     no_link: 1
@@ -42,10 +42,10 @@ shared:
     with: 1
     without: 1
 test:
-  2021_04_cookie_consent_test:
-    none: 0
-    default: 1
-    bottom_black: 0
-    bottom_blue: 0
-    modal: 0
-    gds: 0
+  2021_05_cookie_consent_test:
+    bottom_sticky_default: 0
+    bottom_sticky_gds: 0
+    top_static_default: 1
+    top_static_gds: 0
+    top_sticky_default: 0
+    top_sticky_gds: 0


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-2542

mili/steven will be signing off using review env

variant urls:

- https://teaching-vacancies-review-pr-3448.london.cloudapps.digital/?ab_test_override[2021_05_cookie_consent_test]=bottom_sticky_default
- https://teaching-vacancies-review-pr-3448.london.cloudapps.digital/?ab_test_override[2021_05_cookie_consent_test]=bottom_sticky_gds
- https://teaching-vacancies-review-pr-3448.london.cloudapps.digital/?ab_test_override[2021_05_cookie_consent_test]=top_sticky_default
- https://teaching-vacancies-review-pr-3448.london.cloudapps.digital/?ab_test_override[2021_05_cookie_consent_test]=top_sticky_gds
- https://teaching-vacancies-review-pr-3448.london.cloudapps.digital/?ab_test_override[2021_05_cookie_consent_test]=top_static_default
- https://teaching-vacancies-review-pr-3448.london.cloudapps.digital/?ab_test_override[2021_05_cookie_consent_test]=top_static_gds
