### PR TITLE
Set enable_job_applications to false on all published vacancies where nil

### DIFF
--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,3 +1,13 @@
+namespace :bugfix do
+  desc "Set all published vacancies' enable_job_applications attribute to false"
+  task set_enable_job_applications_false: :environment do
+    Vacancy.published.where(enable_job_applications: nil).in_batches.each_record do |vacancy|
+      vacancy.enable_job_applications = false
+      vacancy.save
+    end
+  end
+end
+
 namespace :algolia do
   desc "Load an index with live records for the first time"
   task reindex: :environment do


### PR DESCRIPTION
This was causing validation errors when updating already published vacancies with a nil enable_job_applications value.

https://ukgovernmentdfe.slack.com/archives/C016H89QSCA/p1620822285026500

These errors should not be possible for published records. For published vacancies we disallow changing the value of the field.

<img width="807" alt="Screenshot 2021-05-12 at 13 57 32" src="https://user-images.githubusercontent.com/60350599/117979947-5bcc1880-b32b-11eb-9f77-ede4e63e0d59.png">

<img width="807" alt="Screenshot 2021-05-12 at 13 24 07" src="https://user-images.githubusercontent.com/60350599/117980026-6f777f00-b32b-11eb-8689-c394567d1b62.png">
