### PR TITLE
[TEVA-2622] Set default paas_environment input as production

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -9,6 +9,8 @@ on:
         description: GitHub SHA
         required: true
       paas_environment:
+        required: true
+        default: "production"
         description: Environment to test
 
 jobs:

--- a/spec/smoke_tests/jobseekers_can_view_homepage_spec.rb
+++ b/spec/smoke_tests/jobseekers_can_view_homepage_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Page availability", js: true, smoke_test: true do
 
   context "Jobseeker visits vacancy page" do
     let(:smoke_test_domain) do
-      paas_environment = !ENV.include?("PAAS_ENVIRONMENT") || ENV["PAAS_ENVIRONMENT"].empty? ? "production" : ENV["PAAS_ENVIRONMENT"]
+      paas_environment = ENV["PAAS_ENVIRONMENT"]
       begin
         YAML.load_file("#{__dir__}/../../terraform/workspace-variables/#{paas_environment}_app_env.yml")["DOMAIN"]
       rescue Errno::ENOENT


### PR DESCRIPTION
Under certain conditions, especially when the scheduled smoke test fails....
the slack notifcation fires but without specifying the affected environment.
This needs to corrected. Upon investigtion, it turns this condition is only
applicable to production.... this condition needs to work in concert with:-

/teaching-vacancies/spec/smoke_tests/jobseekers_can_view_homepage_spec.rb

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2622

## Changes in this PR:
changed the smoke-test workflow by specifying a default input value value (production).