### PR TITLE
Remove paas_api_url from tfvar files

### DIFF
--- a/terraform/workspace-variables/dev.tfvars
+++ b/terraform/workspace-variables/dev.tfvars
@@ -21,7 +21,6 @@ channel_list = {
 }
 
 # Gov.UK PaaS
-paas_api_url                           = "https://api.london.cloud.service.gov.uk"
 paas_space_name                        = "teaching-vacancies-dev"
 paas_papertrail_service_binding_enable = false
 paas_postgres_service_plan             = "tiny-unencrypted-11"

--- a/terraform/workspace-variables/pentest.tfvars
+++ b/terraform/workspace-variables/pentest.tfvars
@@ -21,7 +21,6 @@ channel_list = {
 }
 
 # Gov.UK PaaS
-paas_api_url                           = "https://api.london.cloud.service.gov.uk"
 paas_space_name                        = "teaching-vacancies-dev"
 paas_papertrail_service_binding_enable = false
 paas_postgres_service_plan             = "tiny-unencrypted-11"

--- a/terraform/workspace-variables/production.tfvars
+++ b/terraform/workspace-variables/production.tfvars
@@ -21,7 +21,6 @@ channel_list = {
 }
 
 # Gov.UK PaaS
-paas_api_url                           = "https://api.london.cloud.service.gov.uk"
 paas_space_name                        = "teaching-vacancies-production"
 paas_papertrail_service_binding_enable = true
 paas_postgres_service_plan             = "medium-ha-11"

--- a/terraform/workspace-variables/qa.tfvars
+++ b/terraform/workspace-variables/qa.tfvars
@@ -21,7 +21,6 @@ channel_list = {
 }
 
 # Gov.UK PaaS
-paas_api_url                           = "https://api.london.cloud.service.gov.uk"
 paas_space_name                        = "teaching-vacancies-dev"
 paas_papertrail_service_binding_enable = false
 paas_postgres_service_plan             = "tiny-unencrypted-11"

--- a/terraform/workspace-variables/review.tfvars
+++ b/terraform/workspace-variables/review.tfvars
@@ -21,7 +21,6 @@ channel_list = {
 }
 
 # Gov.UK PaaS
-paas_api_url                           = "https://api.london.cloud.service.gov.uk"
 paas_space_name                        = "teaching-vacancies-review"
 paas_postgres_service_plan             = "tiny-unencrypted-11"
 paas_redis_cache_service_plan          = "micro-5_x"

--- a/terraform/workspace-variables/staging.tfvars
+++ b/terraform/workspace-variables/staging.tfvars
@@ -21,7 +21,6 @@ channel_list = {
 }
 
 # Gov.UK PaaS
-paas_api_url                           = "https://api.london.cloud.service.gov.uk"
 paas_space_name                        = "teaching-vacancies-staging"
 paas_papertrail_service_binding_enable = true
 paas_postgres_service_plan             = "small-11"


### PR DESCRIPTION
This is no longer needed because no such variable set as a variable in the root module; and the
ability to use undeclared variable has been deprected by terraform

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-

## Changes in this PR:

- Is there anything specific you want feedback on?

Remove paas_api_url from tfvar files
This is no longer needed because no such variable set as a variable; and the
ability to use undeclared variable has been deprected by terraform 
