### PR TITLE
[TEVA-2129] Add A:B Test for Job Alert Account Creation CTA

### DIFF
--- a/app/frontend/src/styles/application/signin.scss
+++ b/app/frontend/src/styles/application/signin.scss
@@ -10,3 +10,53 @@
     color: govuk-colour('white');
   }
 }
+
+.job-alert-signin {
+  @include govuk-responsive-padding(5);
+  margin-bottom: govuk-spacing(5);
+
+  &__submit {
+    width: 100%;
+  }
+
+  &__prompt {
+    text-align: center;
+  }
+
+  .wrap-email {
+    word-break: break-all;
+  }
+
+  input[type="submit"] {
+    white-space: normal;
+    word-break: break-word;
+  }
+
+  &--blue {
+    background-color: govuk-colour('blue');
+
+    .govuk-link:not(:focus) {
+      color: govuk-colour('white');
+    }
+
+    * {
+      color: govuk-colour('white');
+    }
+
+    input[type="password"] {
+      color: govuk-colour('black');
+    }
+  }
+
+  &--grey {
+    background-color: govuk-colour('light-grey');
+
+    .govuk-link:not(:focus) {
+      color: govuk-colour('black');
+    }
+
+    input[type="submit"] {
+      color: govuk-colour('white');
+    }
+  }
+}

--- a/app/views/subscriptions/_jobseeker_account_prompt.html.slim
+++ b/app/views/subscriptions/_jobseeker_account_prompt.html.slim
@@ -4,10 +4,11 @@
     p.govuk-body = t(".body.sign_in")
 
     = form_for @jobseeker, url: jobseeker_session_path, method: :post do |f|
-      = f.govuk_email_field :email,
-        label: { text: t("helpers.label.jobseekers_sign_in_form.email"), size: "s" },
-        width: "two-thirds",
-        value: @jobseeker.email
+      .govuk-heading-s class="govuk-!-margin-bottom-2"
+        = t(".form.email_address")
+      .govuk-body = @subscription.email
+
+      = f.hidden_field :email, value: @subscription.email
 
       = f.govuk_password_field :password, label: { text: t("helpers.label.jobseekers_sign_in_form.password"), size: "s" }, hint: nil, width: "two-thirds"
 
@@ -20,11 +21,11 @@
     p.govuk-body = t(".body.sign_up")
 
     = form_for Jobseeker.new, as: :jobseeker, url: jobseeker_registration_path, method: :post do |f|
-      = f.govuk_email_field :email,
-        label: { text: t("helpers.label.jobseekers_sign_in_form.email"), size: "s" },
-        width: "two-thirds",
-        value: @subscription.email,
-        readonly: true
+      .govuk-heading-s class="govuk-!-margin-bottom-2"
+        = t(".form.email_address")
+      .govuk-body = @subscription.email
+
+      = f.hidden_field :email, value: @subscription.email
 
       = f.govuk_password_field :password, label: { size: "s" }, width: "two-thirds"
 

--- a/app/views/subscriptions/confirm.html.slim
+++ b/app/views/subscriptions/confirm.html.slim
@@ -13,4 +13,28 @@
         p.govuk-body = t(".unsubscribe")
         = govuk_link_to t(".back_to_search_results"), jobs_path(@subscription.search_criteria), class: "govuk-!-font-size-19"
 
-      = render "jobseeker_account_prompt"
+      = render "jobseeker_account_prompt" if current_variant?(:"2021_05_job_alert_account_creation_prompt_test", :bottom)
+
+    .govuk-grid-column-one-third
+      - if current_variant?(:"2021_05_job_alert_account_creation_prompt_test", :right_blue) || current_variant?(:"2021_05_job_alert_account_creation_prompt_test", :right_grey)
+        .job-alert-signin class="job-alert-signin--#{ab_variant_for(:"2021_05_job_alert_account_creation_prompt_test").to_s.split("_").last}"
+
+          h2.govuk-heading-m = t(".account_creation_cta.title")
+          p.govuk-body = t(".account_creation_cta.description")
+
+          = form_for Jobseeker.new, as: :jobseeker, url: jobseeker_registration_path, method: :post do |f|
+
+            .govuk-heading-s class="govuk-!-margin-bottom-1"
+              = t(".account_creation_cta.email")
+            .govuk-body.wrap-email = @subscription.email
+
+            = f.hidden_field :email, value: @subscription.email
+
+            = f.govuk_password_field :password, label: { size: "s" }
+
+            = hidden_field_tag :redirect_to, jobseekers_subscriptions_path
+
+            = f.govuk_submit t("buttons.create_account"), classes: "govuk-!-margin-bottom-0 job-alert-signin__submit"
+
+            .govuk-body class="govuk-!-margin-top-5 job-alert-signin__prompt"
+              = t(".account_creation_cta.sign_in.content_html", link: govuk_link_to(t(".account_creation_cta.sign_in.link"), new_jobseeker_session_path))

--- a/config/ab_tests.yml
+++ b/config/ab_tests.yml
@@ -38,6 +38,10 @@ shared:
   2021_05_wider_search_suggestions:
     with: 1
     without: 1
+  2021_05_job_alert_account_creation_prompt_test:
+    bottom: 1
+    right_blue: 1
+    right_grey: 1
 test:
   2021_05_cookie_consent_test:
     bottom_sticky_default: 0
@@ -46,3 +50,14 @@ test:
     top_static_gds: 0
     top_sticky_default: 0
     top_sticky_gds: 0
+  2021_04_cookie_consent_test:
+    none: 0
+    default: 1
+    bottom_black: 0
+    bottom_blue: 0
+    modal: 0
+    gds: 0
+  2021_05_job_alert_account_creation_prompt_test:
+    bottom: 1
+    right_blue: 0
+    right_grey: 0

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -378,6 +378,13 @@ en:
     create:
       success: Your job alert has been created
     confirm:
+      account_creation_cta:
+        description: If you have an account you can see all your job alerts in one place, and save and apply for jobs you are interested in.
+        email: Email address
+        sign_in:
+          content_html: Already have an account? %{link}
+          link: Sign in
+        title: Create a Teaching Vacancies account
       back_to_search_results: Return to your search results
       body: We sent an email confirmation to %{email}.
       header:
@@ -403,6 +410,8 @@ en:
       body:
         sign_in: Sign in to see all your job alerts in one place and save the jobs you are interested in.
         sign_up: Create an account to see all your job alerts in one place and save the jobs you are interested in.
+      form:
+        email_address: Email address
       heading:
         sign_in: Sign in to your Teaching Vacancies account
         sign_up: Create a Teaching Vacancies account

--- a/spec/system/jobseekers_can_manage_their_job_alerts_from_the_email_spec.rb
+++ b/spec/system/jobseekers_can_manage_their_job_alerts_from_the_email_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe "Jobseekers can manage their job alerts from the email" do
   let(:jobseeker_signed_in?) { false }
   let(:jobseeker) { build_stubbed(:jobseeker) }
-  let(:jobseeker_account_prompt_variant) { nil }
 
   let(:search_criteria) { { keyword: "Maths", location: "London" } }
   let(:frequency) { :daily }


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2129

## Changes in this PR:

- Added variants to ab_tests.yml
- Added variants to confirm page
- Updated _jobseeker_account_prompt partial to reflect changes in designs

## Designs

https://www.figma.com/file/8GxfMTTqBsg1Cco7ffgViQ/create-account?node-id=0%3A1

## Variants

- `bottom`
- `right_blue`
- `right_grey`

## Video of UI changes:

### Bottom

https://user-images.githubusercontent.com/30624173/118146813-e0d83000-b406-11eb-978f-4da300cee32d.mov

### Right Blue 

https://user-images.githubusercontent.com/30624173/118146952-02391c00-b407-11eb-85c5-d6fed751eaf0.mov

### Right Grey

https://user-images.githubusercontent.com/30624173/118146981-09602a00-b407-11eb-943c-176d43c5c9ab.mov


