### PR TITLE
Remove hiring staff access to applications after 1 year

### DIFF
--- a/app/controllers/publishers/vacancies/job_applications_controller.rb
+++ b/app/controllers/publishers/vacancies/job_applications_controller.rb
@@ -65,6 +65,10 @@ class Publishers::Vacancies::JobApplicationsController < Publishers::Vacancies::
   end
 
   def vacancy
-    @vacancy ||= current_organisation.all_vacancies.listed.find(params[:job_id])
+    @vacancy ||= if action_name == "show"
+                   current_organisation.all_vacancies.listed.expires_after_data_retention_period.find(params[:job_id])
+                 else
+                   current_organisation.all_vacancies.listed.find(params[:job_id])
+                 end
   end
 end

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -51,6 +51,7 @@ class Vacancy < ApplicationRecord
 
   scope :active, (-> { where(status: %i[published draft]) })
   scope :applicable, (-> { where("expires_at >= ?", Time.current) })
+  scope :expires_after_data_retention_period, (-> { where("expires_at >= ?", Time.current - DATA_RETENTION_PERIOD_FOR_PUBLISHERS) })
   scope :expired, (-> { published.where("expires_at < ?", Time.current) })
   scope :awaiting_feedback, (-> { expired.where(listed_elsewhere: nil, hired_status: nil) })
   scope :listed, (-> { published.where("publish_on <= ?", Date.current) })
@@ -60,6 +61,8 @@ class Vacancy < ApplicationRecord
   scope :in_organisation_ids, (->(ids) { joins(:organisation_vacancies).where(organisation_vacancies: { organisation_id: ids }).distinct })
 
   paginates_per 10
+
+  DATA_RETENTION_PERIOD_FOR_PUBLISHERS = 1.year.freeze
 
   validates :slug, presence: true
   validate :enable_job_applications_cannot_be_changed_once_listed

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe Vacancy do
   end
 
   context "scopes" do
-    let(:expired_earlier_today) { build(:vacancy, expires_on: Date.current, expires_at: 5.hour.ago) }
+    let(:expired_earlier_today) { create(:vacancy, expires_on: Date.current, expires_at: 5.hour.ago) }
     let(:expires_later_today) { create(:vacancy, status: :published, expires_on: Date.current, expires_at: 1.hour.from_now) }
 
     describe "#applicable" do
@@ -220,6 +220,15 @@ RSpec.describe Vacancy do
         trashed_expired.trashed!
 
         expect(Vacancy.expired.count).to eq(1)
+      end
+    end
+
+    describe "#expires_after_data_retention_period" do
+      let(:expired_years_ago) { build(:vacancy, expires_on: 2.years.ago, expires_at: 2.years.ago) }
+
+      it "retrieves vacancies that expired not more than one year ago" do
+        expect(Vacancy.expires_after_data_retention_period).to_not include(expired_years_ago)
+        expect(Vacancy.expires_after_data_retention_period).to include(expired_earlier_today)
       end
     end
 

--- a/spec/requests/publishers/vacancies/job_applications_spec.rb
+++ b/spec/requests/publishers/vacancies/job_applications_spec.rb
@@ -71,6 +71,21 @@ RSpec.describe "Job applications" do
       it "renders the show page" do
         expect(get(organisation_job_job_application_path(vacancy.id, job_application.id))).to render_template(:show)
       end
+
+      context "when the vacancy expired more than a year ago" do
+        let(:vacancy) do
+          create(:vacancy,
+                 expires_at: 2.years.ago,
+                 expires_on: 2.years.ago,
+                 organisation_vacancies_attributes: [{ organisation: organisation }])
+        end
+
+        it "returns not found" do
+          get(organisation_job_job_application_path(vacancy.id, job_application.id))
+
+          expect(response).to have_http_status(:not_found)
+        end
+      end
     end
 
     context "when the job application status is submitted" do


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2315

## Changes in this PR:

This implements the minimal code required for the feature, because we will not need the feature until a year from now.

If we want to at the time, we can spruce it up and, for example, tell the user why they can't view the application. Another future approach could be to remove the 'view application' link.

But for now we can save time by doing the minimal change that makes us compliant.

## Screenshots

Page that lists applications:

![Screenshot 2021-05-13 at 17 48 28](https://user-images.githubusercontent.com/60350599/118158512-c9537400-b413-11eb-9072-5ef98aba468a.png)

Click on the application and see:

![Screenshot 2021-05-13 at 17 48 50](https://user-images.githubusercontent.com/60350599/118158508-c8224700-b413-11eb-9eca-d1e8b3f8c745.png)

