### PR TITLE
[TEVA-2578] Hide govuk-accordion icon when printing applications

### DIFF
--- a/app/frontend/src/styles/application/publishers/print-application.scss
+++ b/app/frontend/src/styles/application/publishers/print-application.scss
@@ -3,6 +3,7 @@
     .account-sidebar,
     .anchor-link-list,
     .application-status,
+    .govuk-accordion__icon,
     .job-application-actions,
     .timeline-component {
       display: none !important;


### PR DESCRIPTION
## Jira ticket
https://dfedigital.atlassian.net/browse/TEVA-2578

## Changes in this PR
- Explicitly hide `govuk-accordion__icon` when printing job applications

## Product sign off
- [x] Looks good!