### PR TITLE
Remove candidate specification fields from vacancies

### DIFF
--- a/app/components/jobseekers/vacancy_details_component/vacancy_details_component.html.slim
+++ b/app/components/jobseekers/vacancy_details_component/vacancy_details_component.html.slim
@@ -15,19 +15,6 @@ section#job-details class="govuk-!-margin-bottom-5"
   h4.govuk-heading-s = t("jobs.job_summary")
   p = @vacancy.job_advert
 
-  - if @vacancy.documents.none? && @vacancy.any_candidate_specification?
-    - if @vacancy.education?
-      h4.govuk-heading-s = t("jobs.education")
-      p = @vacancy.education
-
-    - if @vacancy.qualifications?
-      h4.govuk-heading-s = t("jobs.qualifications")
-      p = @vacancy.qualifications
-
-    - if @vacancy.experience?
-      h4.govuk-heading-s = t("jobs.experience")
-      p = @vacancy.experience
-
   - if @vacancy.benefits.present?
     h4.govuk-heading-s = t("jobs.benefits")
     p = @vacancy.benefits

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -102,10 +102,6 @@ class Vacancy < ApplicationRecord
     super().merge("working_patterns" => working_patterns, "job_roles" => job_roles)
   end
 
-  def any_candidate_specification?
-    experience.present? || qualifications.present? || education.present?
-  end
-
   def delete_documents
     documents.each { |document| DocumentDelete.new(document).delete }
   end

--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -35,18 +35,6 @@ class VacancyPresenter < BasePresenter
     simple_format(model.how_to_apply) if model.how_to_apply.present?
   end
 
-  def education
-    simple_format(model.education) if model.education.present?
-  end
-
-  def qualifications
-    simple_format(model.qualifications) if model.qualifications.present?
-  end
-
-  def experience
-    simple_format(model.experience) if model.experience.present?
-  end
-
   def benefits
     simple_format(model.benefits) if model.benefits.present?
   end

--- a/app/services/copy_vacancy.rb
+++ b/app/services/copy_vacancy.rb
@@ -3,7 +3,6 @@ class CopyVacancy
     @vacancy = vacancy
     setup_new_vacancy
     setup_organisation_vacancies
-    reset_candidate_specification if @vacancy.any_candidate_specification?
   end
 
   def call
@@ -29,12 +28,6 @@ class CopyVacancy
         google_drive_id: document_copy.copied.id,
       })
     end
-  end
-
-  def reset_candidate_specification
-    @new_vacancy.experience = nil
-    @new_vacancy.education = nil
-    @new_vacancy.qualifications = nil
   end
 
   def setup_new_vacancy

--- a/app/views/api/vacancies/_show.json.jbuilder
+++ b/app/views/api/vacancies/_show.json.jbuilder
@@ -8,10 +8,6 @@ json.datePosted vacancy.publish_on.to_time.iso8601
 json.description vacancy.job_advert
 json.occupationalCategory vacancy.job_roles&.join(", ")
 
-json.educationRequirements vacancy.education
-json.qualifications vacancy.qualifications
-json.experienceRequirements vacancy.experience
-
 json.employmentType vacancy.working_patterns_for_job_schema
 
 json.industry "Education"

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -239,9 +239,6 @@ shared:
     - benefits
     - starts_on
     - ends_on
-    - education
-    - qualifications
-    - experience
     - contact_email
     - status
     - expires_on

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -199,10 +199,6 @@ en:
     expires_on: Closing date
     time_at: ' at '
 
-    education: Essential educational requirements
-    qualifications: Essential qualifications
-    experience: Essential skills and experience
-
     supporting_documents: Supporting documents
     supporting_documents_accessibility: If you need these documents in an accessible format, please contact the school.
     no_files_message: No files selected

--- a/db/migrate/20210514103237_remove_candidate_spec_fields_from_vacancies.rb
+++ b/db/migrate/20210514103237_remove_candidate_spec_fields_from_vacancies.rb
@@ -1,0 +1,7 @@
+class RemoveCandidateSpecFieldsFromVacancies < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :vacancies, :education
+    remove_column :vacancies, :qualifications
+    remove_column :vacancies, :experience
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_11_163320) do
+ActiveRecord::Schema.define(version: 2021_05_14_103237) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -395,9 +395,6 @@ ActiveRecord::Schema.define(version: 2021_05_11_163320) do
     t.text "benefits"
     t.date "starts_on"
     t.date "ends_on"
-    t.text "education"
-    t.text "qualifications"
-    t.text "experience"
     t.string "contact_email"
     t.integer "status"
     t.date "expires_on"

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -14,8 +14,6 @@ FactoryBot.define do
     contact_number { "01234 123456" }
     contract_type { :fixed_term }
     contract_type_duration { "6 months" }
-    education { Faker::Lorem.paragraph(sentence_count: 4) }
-    experience { Faker::Lorem.paragraph(sentence_count: 4) }
     expires_on { Faker::Time.forward(days: 14) }
     expires_at { expires_on&.change(sec: 0) }
     hired_status { nil }
@@ -25,7 +23,6 @@ FactoryBot.define do
     listed_elsewhere { nil }
     personal_statement_guidance { Faker::Lorem.paragraph(sentence_count: 4) }
     publish_on { Date.current }
-    qualifications { Faker::Lorem.paragraph(sentence_count: 4) }
     salary { Faker::Lorem.sentence[1...30].strip }
     school_visits { Faker::Lorem.paragraph(sentence_count: 4) }
     state { "create" }
@@ -58,20 +55,14 @@ FactoryBot.define do
     end
 
     trait :fail_minimum_validation do
-      education { Faker::Lorem.paragraph[0..8] }
-      experience { Faker::Lorem.paragraph[0..7] }
       job_advert { Faker::Lorem.paragraph[0..5] }
       job_title { Faker::Job.title[0..2] }
-      qualifications { Faker::Lorem.paragraph[0...8] }
     end
 
     trait :fail_maximum_validation do
-      education { Faker::Lorem.characters(number: 1005) }
-      experience { Faker::Lorem.characters(number: 1010) }
       job_advert { Faker::Lorem.characters(number: 50_001) }
       job_title { Faker::Lorem.characters(number: 150) }
       salary { Faker::Lorem.characters(number: 257) }
-      qualifications { Faker::Lorem.characters(number: 1002) }
     end
 
     trait :complete do
@@ -127,7 +118,6 @@ FactoryBot.define do
 
     trait :job_schema do
       working_patterns { %w[full_time part_time] }
-      education { Faker::Lorem.paragraph }
       benefits { Faker::Lorem.sentence }
     end
 

--- a/spec/services/copy_vacancy_spec.rb
+++ b/spec/services/copy_vacancy_spec.rb
@@ -49,16 +49,6 @@ RSpec.describe CopyVacancy do
 
         expect(result.documents.first.name).to eq(vacancy.documents.first.name)
       end
-
-      it "does not copy candidate specification fields" do
-        vacancy = create(:vacancy)
-
-        result = described_class.new(vacancy).call
-
-        expect(result.experience).to eq(nil)
-        expect(result.education).to eq(nil)
-        expect(result.qualifications).to eq(nil)
-      end
     end
 
     context "not all fields are copied" do

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -172,12 +172,6 @@ module VacancyHelpers
       expect(page).to have_content(I18n.t("jobs.supporting_documents"))
     end
 
-    if vacancy.documents.none? && vacancy.any_candidate_specification?
-      expect(page.html).to include(vacancy.education)
-      expect(page.html).to include(vacancy.qualifications)
-      expect(page.html).to include(vacancy.experience)
-    end
-
     if vacancy.enable_job_applications?
       expect(page).to have_link(I18n.t("jobseekers.job_applications.apply"), href: new_jobseekers_job_job_application_path(vacancy.id))
     else
@@ -199,9 +193,6 @@ module VacancyHelpers
       datePosted: vacancy.publish_on.to_time.iso8601,
       description: vacancy.job_advert,
       occupationalCategory: vacancy.job_roles&.join(", "),
-      educationRequirements: vacancy.education,
-      qualifications: vacancy.qualifications,
-      experienceRequirements: vacancy.experience,
       employmentType: vacancy.working_patterns_for_job_schema,
       industry: "Education",
       jobLocation: {

--- a/spec/system/jobseekers_can_view_a_vacancy_spec.rb
+++ b/spec/system/jobseekers_can_view_a_vacancy_spec.rb
@@ -111,60 +111,16 @@ RSpec.describe "Viewing a single published vacancy" do
       expect(page.current_url).to eq vacancy.application_link
     end
 
-    scenario "does not see headers of empty fields" do
-      vacancy = build(:vacancy, education: nil, qualifications: nil,
-                                experience: nil, benefits: nil, slug: "vacancy")
-      vacancy.save(validate: false)
-      vacancy.organisation_vacancies.create(organisation: school)
-
-      visit job_path(vacancy)
-
-      expect(page).to_not have_content(I18n.t("jobs.education"))
-      expect(page).to_not have_content(I18n.t("jobs.qualifications"))
-      expect(page).to_not have_content(I18n.t("jobs.experience"))
-      expect(page).to_not have_content(I18n.t("jobs.benefits_html"))
-    end
-
-    context "without supporting documents attached but candidate spec" do
+    context "with supporting documents attached" do
       before do
         vacancy = create(:vacancy, :published)
         vacancy.organisation_vacancies.create(organisation: school)
-        vacancy.documents = []
-        vacancy.save
-        visit job_path(vacancy)
-      end
-
-      scenario "cannot see the supporting documents section" do
-        expect(page).to_not have_content(I18n.t("jobs.supporting_documents"))
-      end
-
-      scenario "can see the candidate specification sections" do
-        expect(page).to have_content(I18n.t("jobs.education"))
-        expect(page).to have_content(I18n.t("jobs.qualifications"))
-        expect(page).to have_content(I18n.t("jobs.experience"))
-      end
-    end
-
-    context "with supporting documents attached and candidate spec" do
-      before do
-        vacancy = create(:vacancy, :published)
-        vacancy.organisation_vacancies.create(organisation: school)
-        vacancy.education = nil
-        vacancy.qualifications = nil
-        vacancy.experience = nil
-        vacancy.save
         visit job_path(vacancy)
       end
 
       scenario "can see the supporting documents section" do
         expect(page).to have_content(I18n.t("jobs.supporting_documents"))
         expect(page).to have_content("Test.png")
-      end
-
-      scenario "cannot see the candidate specification sections" do
-        expect(page).to_not have_content(I18n.t("jobs.education"))
-        expect(page).to_not have_content(I18n.t("jobs.qualifications"))
-        expect(page).to_not have_content(I18n.t("jobs.experience"))
       end
     end
 


### PR DESCRIPTION
These fields haven't been used in over a year now, so the columns should be dropped.