### PR TITLE
[TEVA-2315] Remove publishers' access to application data after 1 year

### DIFF
--- a/app/controllers/publishers/notifications_controller.rb
+++ b/app/controllers/publishers/notifications_controller.rb
@@ -9,6 +9,7 @@ class Publishers::NotificationsController < Publishers::BaseController
 
   def notifications
     @notifications ||= current_publisher.notifications
+                                        .created_within_data_access_period
                                         .order(created_at: :desc)
                                         .page(params[:page])
                                         .per(DEFAULT_NOTIFICATIONS_PER_PAGE)

--- a/app/controllers/publishers/vacancies/job_applications_controller.rb
+++ b/app/controllers/publishers/vacancies/job_applications_controller.rb
@@ -65,6 +65,9 @@ class Publishers::Vacancies::JobApplicationsController < Publishers::Vacancies::
   end
 
   def vacancy
-    @vacancy ||= current_organisation.all_vacancies.listed.find(params[:job_id])
+    @vacancy ||= current_organisation.all_vacancies
+                                     .listed
+                                     .expires_within_data_access_period
+                                     .find(params[:job_id])
   end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -5,6 +5,8 @@ class ApplicationRecord < ActiveRecord::Base
   after_update { EventContext.trigger_event(:entity_updated, event_data) unless saved_change_to_attribute?(:last_activity_at) }
   after_destroy { EventContext.trigger_event(:entity_destroyed, event_data) }
 
+  DATA_ACCESS_PERIOD_FOR_PUBLISHERS = 1.year.freeze
+
   private
 
   def event_data

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -3,4 +3,6 @@ class Notification < ApplicationRecord
   belongs_to :recipient, polymorphic: true
 
   paginates_per 30
+
+  scope :created_within_data_access_period, (-> { where("created_at >= ?", Time.current - DATA_ACCESS_PERIOD_FOR_PUBLISHERS) })
 end

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -51,6 +51,7 @@ class Vacancy < ApplicationRecord
 
   scope :active, (-> { where(status: %i[published draft]) })
   scope :applicable, (-> { where("expires_at >= ?", Time.current) })
+  scope :expires_within_data_access_period, (-> { where("expires_at >= ?", Time.current - DATA_ACCESS_PERIOD_FOR_PUBLISHERS) })
   scope :expired, (-> { published.where("expires_at < ?", Time.current) })
   scope :awaiting_feedback, (-> { expired.where(listed_elsewhere: nil, hired_status: nil) })
   scope :listed, (-> { published.where("publish_on <= ?", Date.current) })

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -135,6 +135,11 @@ FactoryBot.define do
       expires_on { Time.zone.tomorrow.end_of_day }
     end
 
+    trait :expired_years_ago do
+      expires_at { 2.years.ago }
+      expires_on { 2.years.ago }
+    end
+
     trait :without_working_patterns do
       to_create { |instance| instance.save(validate: false) }
       sequence(:slug) { |n| "slug-#{n}" }

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe Vacancy do
   end
 
   context "scopes" do
-    let(:expired_earlier_today) { build(:vacancy, expires_on: Date.current, expires_at: 5.hour.ago) }
+    let(:expired_earlier_today) { create(:vacancy, expires_on: Date.current, expires_at: 5.hour.ago) }
     let(:expires_later_today) { create(:vacancy, status: :published, expires_on: Date.current, expires_at: 1.hour.from_now) }
 
     describe "#applicable" do
@@ -220,6 +220,15 @@ RSpec.describe Vacancy do
         trashed_expired.trashed!
 
         expect(Vacancy.expired.count).to eq(1)
+      end
+    end
+
+    describe "#expires_within_data_access_period" do
+      let(:expired_years_ago) { build(:vacancy, expires_on: 2.years.ago, expires_at: 2.years.ago) }
+
+      it "retrieves vacancies that expired not more than one year ago" do
+        expect(Vacancy.expires_within_data_access_period).to_not include(expired_years_ago)
+        expect(Vacancy.expires_within_data_access_period).to include(expired_earlier_today)
       end
     end
 

--- a/spec/requests/publishers/vacancies/job_applications_spec.rb
+++ b/spec/requests/publishers/vacancies/job_applications_spec.rb
@@ -12,6 +12,20 @@ RSpec.describe "Job applications" do
     sign_in(publisher, scope: :publisher)
   end
 
+  describe "GET #index" do
+    context "when the vacancy expired outside the data access period" do
+      let(:vacancy) do
+        create(:vacancy, :expired_years_ago, organisation_vacancies_attributes: [{ organisation: organisation }])
+      end
+
+      it "returns not found" do
+        get(organisation_job_job_applications_path(vacancy.id))
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
   describe "GET #reject" do
     context "when the job application status is not draft or withdrawn" do
       it "renders the reject page" do
@@ -70,6 +84,18 @@ RSpec.describe "Job applications" do
     context "when the job application status is not draft or withdrawn" do
       it "renders the show page" do
         expect(get(organisation_job_job_application_path(vacancy.id, job_application.id))).to render_template(:show)
+      end
+
+      context "when the vacancy expired more than a year ago" do
+        let(:vacancy) do
+          create(:vacancy, :expired_years_ago, organisation_vacancies_attributes: [{ organisation: organisation }])
+        end
+
+        it "returns not found" do
+          get(organisation_job_job_application_path(vacancy.id, job_application.id))
+
+          expect(response).to have_http_status(:not_found)
+        end
       end
     end
 

--- a/spec/system/publishers_can_view_their_notifications_spec.rb
+++ b/spec/system/publishers_can_view_their_notifications_spec.rb
@@ -6,31 +6,47 @@ RSpec.describe "Publishers can view their notifications" do
   let(:vacancy) { create(:vacancy, :published, organisation_vacancies_attributes: [{ organisation: organisation }], publisher: publisher) }
   let(:job_application) { create(:job_application, :status_submitted, vacancy: vacancy) }
 
-  before do
-    stub_const("Publishers::NotificationsController::DEFAULT_NOTIFICATIONS_PER_PAGE", 1)
-    Publishers::JobApplicationReceivedNotification.with(vacancy: vacancy, job_application: job_application).deliver(vacancy.publisher)
-    Publishers::JobApplicationReceivedNotification.with(vacancy: vacancy, job_application: job_application).deliver(vacancy.publisher)
-    login_publisher(publisher: publisher, organisation: organisation)
-    visit root_path
+  before { login_publisher(publisher: publisher, organisation: organisation) }
+
+  context "when the notification was created outside the data access period" do
+    before do
+      travel_to 2.years.ago do
+        Publishers::JobApplicationReceivedNotification.with(vacancy: vacancy, job_application: job_application).deliver(vacancy.publisher)
+      end
+      visit publishers_notifications_path
+    end
+
+    it "does not display the notification" do
+      expect(page).not_to have_css("div", class: "notification-component")
+    end
   end
 
-  it "clicks notifications link, renders the notifications, paginates, and marks as read" do
-    click_on I18n.t("nav.notifications_index_link")
-
-    expect(page).to have_css("div", class: "notification-component", count: 1) do |notification|
-      expect(notification).to have_css("div", class: "notification-component__tag", text: "new", count: 1)
+  context "when paginating" do
+    before do
+      stub_const("Publishers::NotificationsController::DEFAULT_NOTIFICATIONS_PER_PAGE", 1)
+      Publishers::JobApplicationReceivedNotification.with(vacancy: vacancy, job_application: job_application).deliver(vacancy.publisher)
+      Publishers::JobApplicationReceivedNotification.with(vacancy: vacancy, job_application: job_application).deliver(vacancy.publisher)
+      visit root_path
     end
 
-    click_on "Next"
+    it "clicks notifications link, renders the notifications, paginates, and marks as read" do
+      click_on I18n.t("nav.notifications_index_link")
 
-    expect(page).to have_css("div", class: "notification-component", count: 1) do |notification|
-      expect(notification).to have_css("div", class: "notification-component__tag", text: "new", count: 1)
-    end
+      expect(page).to have_css("div", class: "notification-component", count: 1) do |notification|
+        expect(notification).to have_css("div", class: "notification-component__tag", text: "new", count: 1)
+      end
 
-    click_on "Previous"
+      click_on "Next"
 
-    expect(page).to have_css("div", class: "notification-component", count: 1) do |notification|
-      expect(notification).not_to have_css("div", class: "notification-component__tag", text: "new", count: 1)
+      expect(page).to have_css("div", class: "notification-component", count: 1) do |notification|
+        expect(notification).to have_css("div", class: "notification-component__tag", text: "new", count: 1)
+      end
+
+      click_on "Previous"
+
+      expect(page).to have_css("div", class: "notification-component", count: 1) do |notification|
+        expect(notification).not_to have_css("div", class: "notification-component__tag", text: "new", count: 1)
+      end
     end
   end
 end


### PR DESCRIPTION
## Slack conversation

https://ukgovernmentdfe.slack.com/archives/C020RU6LX1T/p1620908134011900

Related to https://dfedigital.atlassian.net/browse/TEVA-2315

## Changes in this PR:

This implements the minimal code required for the feature - does not include communicating anything to publishers using notifications/banners/emails.

We do this by scoping notifications to those which have been created in the past year, and job applications to those belonging to a vacancy that expired in the past year.

## Screenshots of UI changes:

In the vacancies dashboard:

<img width="1080" alt="Screenshot 2021-05-14 at 13 02 36" src="https://user-images.githubusercontent.com/60350599/118268727-ad081380-b4b5-11eb-8e97-53eb3f328c59.png">

After clicking the link to view applications:

<img width="1080" alt="Screenshot 2021-05-14 at 13 02 45" src="https://user-images.githubusercontent.com/60350599/118268725-ab3e5000-b4b5-11eb-99b9-a2c0ffc7d6f6.png">


