### PR TITLE
[TEVA-2631] Fix live vacancies that have about_school wrong

### DIFF
--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -79,3 +79,34 @@ namespace :google_drive do
     puts "#{documents_deleted} Documents deleted. Have a good day!"
   end
 end
+
+namespace :vacancies do
+  desc "Fix about_school fields of live vacancies"
+  task fix_about_school: :environment do
+    organisation_ids = Organisation.not_closed.where.not(description: [nil, ""]).pluck(:id)
+
+    vacancies = Vacancy.live
+                       .distinct
+                       .joins(:organisation_vacancies)
+                       .where(organisation_vacancies: { organisation_id: organisation_ids })
+
+    fixed_vacancies = 0
+
+    vacancies.find_each do |vacancy|
+      organisation_description = vacancy.parent_organisation.description
+      next if organisation_description.blank?
+
+      uniq_organisation_description = organisation_description.split.uniq.join(" ")
+
+      next if uniq_organisation_description == organisation_description
+      next unless uniq_organisation_description == vacancy.about_school
+
+      puts "Fixing vacancy with slug: #{vacancy.slug}"
+      vacancy.update_column :about_school, organisation_description
+
+      fixed_vacancies += 1
+    end
+
+    puts "#{fixed_vacancies} Vacancies fixed. Have a good day!"
+  end
+end


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-2631

## Changes in this PR:
In this PR we create a rake task that updates about_school fields of live vacancies that have that field equals to the uniq count of words in the school description