### PR TITLE
Remove Variables Used to Set A:B Test Variants

### DIFF
--- a/spec/system/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
+++ b/spec/system/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe "Jobseekers can create a job alert from a search", recaptcha: tru
   let(:location) { nil }
   let(:search_with_polygons?) { false }
   let(:jobseeker_signed_in?) { false }
-  let(:jobseeker_account_prompt_variant) { nil }
   let(:jobseeker) { build_stubbed(:jobseeker) }
 
   describe "recaptcha" do
@@ -36,7 +35,6 @@ RSpec.describe "Jobseekers can create a job alert from a search", recaptcha: tru
       let!(:jobseeker) { create(:jobseeker) }
 
       context "when jobseeker is signed in" do
-        let(:jobseeker_account_prompt_variant) { :link }
         let(:jobseeker_signed_in?) { true }
 
         it "redirects to job alerts dashboard" do

--- a/spec/system/jobseekers_can_manage_their_job_alerts_from_the_email_spec.rb
+++ b/spec/system/jobseekers_can_manage_their_job_alerts_from_the_email_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe "Jobseekers can manage their job alerts from the email" do
   let(:jobseeker_signed_in?) { false }
   let(:jobseeker) { build_stubbed(:jobseeker) }
-  let(:jobseeker_account_prompt_variant) { nil }
 
   let(:search_criteria) { { keyword: "Maths", location: "London" } }
   let(:frequency) { :daily }


### PR DESCRIPTION
## Changes in this PR:

These variables were added in commit 2b6b0cbb1a. They were used to set an ab test variant. The code to set the variant in the specs was removed in f211480d21, but these variables weren't removed.