### PR TITLE
[TEVA-2496] Only render organisation types for jobs at multiple schools.

### DIFF
--- a/app/components/jobseekers/vacancy_summary_component/vacancy_summary_component.html.slim
+++ b/app/components/jobseekers/vacancy_summary_component/vacancy_summary_component.html.slim
@@ -9,11 +9,11 @@ li.vacancy role="listitem" tab-index="0"
       = @vacancy.salary
     dt = @vacancy.central_office? ? t("jobs.trust_type") : t("jobs.school_type")
     dd.double
-      - if @vacancy.central_office?
-        = organisation_type(@vacancy.parent_organisation)
-      - else
+      - if @vacancy.at_multiple_schools?
         - organisation_types(@vacancy.organisations).each do |organisation_type|
           .govuk-body-s class="govuk-!-margin-bottom-0" = organisation_type
+      - else
+        = organisation_type(@vacancy.parent_organisation)
     - if @vacancy.working_patterns?
       dt = t("jobs.working_patterns")
       dd.double

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -41,7 +41,12 @@ module OrganisationHelper
   def organisation_type(organisation)
     return organisation.group_type if organisation.school_group?
 
-    school_type_details = [organisation.school_type.singularize, organisation.religious_character]
+    school_type_details = [
+      organisation.school_type.singularize,
+      organisation.religious_character,
+      "ages #{organisation.minimum_age} to #{organisation.maximum_age}",
+    ]
+
     school_type_details.reject(&:blank?).reject { |str| str == I18n.t("schools.not_given") }.join(", ")
   end
 

--- a/spec/components/jobseekers/vacancy_summary_component_spec.rb
+++ b/spec/components/jobseekers/vacancy_summary_component_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Jobseekers::VacancySummaryComponent, type: :component do
       end
 
       it "renders the school type" do
-        organisation_types(vacancy.organisations).each { |school_type| expect(rendered_component).to include(school_type) }
+        expect(rendered_component).to include(organisation_type(vacancy.organisation))
       end
 
       it "renders the working pattern" do


### PR DESCRIPTION
Jobs at single schools should render the singular organisation type in the vacancy summary instead.

## Jira ticket
https://dfedigital.atlassian.net/browse/TEVA-2496

## Changes in this PR
- Render different organisation type for jobs `at_multiple_schools` and everything else

## Product sign off
- [x] Looks good!