### PR TITLE
[TEVA-2362] Always show 'Continue' as the submit CTA for the job location step

### DIFF
--- a/app/controllers/publishers/vacancies/build_controller.rb
+++ b/app/controllers/publishers/vacancies/build_controller.rb
@@ -37,10 +37,9 @@ class Publishers::Vacancies::BuildController < Publishers::Vacancies::BaseContro
       save_listing_and_return_later
     elsif @form.complete_and_valid?
       update_vacancy
-      if params[:commit] == t("buttons.update_job")
+      if params[:commit] == t("buttons.update_job") ||
+         (params[:commit] == t("buttons.continue") && session[:current_step] == :review)
         update_listing
-      elsif params[:commit] == t("buttons.continue") && session[:current_step] == :review
-        update_incomplete_listing
       else
         render_wizard @vacancy
       end
@@ -112,11 +111,6 @@ class Publishers::Vacancies::BuildController < Publishers::Vacancies::BaseContro
     return unless STRIP_CHECKBOXES.key?(step)
 
     strip_empty_checkboxes(STRIP_CHECKBOXES[step], "publishers_job_listing_#{step}_form".to_sym)
-  end
-
-  def update_incomplete_listing
-    @vacancy.save
-    redirect_updated_job_with_message
   end
 
   def update_listing

--- a/app/controllers/publishers/vacancies_controller.rb
+++ b/app/controllers/publishers/vacancies_controller.rb
@@ -23,6 +23,7 @@ class Publishers::VacanciesController < Publishers::Vacancies::BaseController
 
     @vacancy.update(state: "edit_published")
     validate_all_steps
+    session[:current_step] = :review
     @vacancy = VacancyPresenter.new(@vacancy)
   end
 

--- a/app/views/publishers/vacancies/build/job_location.html.slim
+++ b/app/views/publishers/vacancies/build/job_location.html.slim
@@ -17,7 +17,7 @@
 
         = f.govuk_collection_radio_buttons :job_location, t("helpers.options.publishers_job_listing_job_location_form.job_location.#{current_organisation.group_type}"), :first, :last
 
-        = render "publishers/vacancies/vacancy_form_partials/continue_or_update_submit", f: f
+        = f.govuk_submit t("buttons.continue")
 
     .govuk-grid-column-one-third
       = render(Shared::ProcessStepsComponent.new(process: @vacancy, service: process_steps, title: t("publishers.vacancies.build.process_title")))

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -7,7 +7,7 @@ module VacancyHelpers
     vacancy.job_location = location
     click_header_link(I18n.t("jobs.job_location"))
     fill_in_job_location_form_field(vacancy, group_type)
-    click_on I18n.t("buttons.update_job")
+    click_on I18n.t("buttons.continue")
   end
 
   def fill_in_school_form_field(school)


### PR DESCRIPTION
## Jira ticket
https://dfedigital.atlassian.net/browse/TEVA-2362

## Changes in this PR
- Only ever show `Continue` as the CTA for the job location step, even when updating it. This was a product decision.

## Product sign off
- [x] Looks good!