### PR TITLE
[TEVA-2119] Show postcode on search result summaries.

### DIFF
--- a/app/components/jobseekers/vacancy_summary_component/vacancy_summary_component.html.slim
+++ b/app/components/jobseekers/vacancy_summary_component/vacancy_summary_component.html.slim
@@ -2,7 +2,7 @@ li.vacancy role="listitem" tab-index="0"
   h2.govuk-heading-m class="govuk-!-margin-bottom-0"
     = govuk_link_to(@vacancy.job_title, job_path(@vacancy), class: "view-vacancy-link")
   p.govuk-body
-    = location(@vacancy.parent_organisation, job_location: @vacancy.job_location)
+    = vacancy_full_job_location(@vacancy)
   dl
     dt = t("jobs.salary")
     dd.double

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -27,10 +27,7 @@ module OrganisationHelper
     address_join([organisation.address, organisation.town, organisation.county, organisation.postcode])
   end
 
-  def location(organisation, job_location: nil)
-    return "#{I18n.t('publishers.organisations.readable_job_location.at_multiple_schools')}, #{organisation.name}" if
-      job_location.presence == "at_multiple_schools"
-
+  def location(organisation)
     address_join([organisation.name, organisation.town, organisation.county])
   end
 

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -86,6 +86,14 @@ module VacanciesHelper
     address_join([organisation.name, organisation.town, organisation.county])
   end
 
+  def vacancy_full_job_location(vacancy)
+    organisation = vacancy.parent_organisation
+    return "#{t('publishers.organisations.readable_job_location.at_multiple_schools')}, #{organisation.name}" if
+      vacancy.job_location == "at_multiple_schools"
+
+    address_join([organisation.address, organisation.town, organisation.county, organisation.postcode])
+  end
+
   def vacancy_job_location_heading(vacancy)
     return t("school_groups.job_location_heading.#{vacancy.job_location}") unless vacancy.job_location == "at_multiple_schools"
 

--- a/app/mailers/jobseekers/alert_mailer.rb
+++ b/app/mailers/jobseekers/alert_mailer.rb
@@ -1,6 +1,7 @@
 class Jobseekers::AlertMailer < Jobseekers::BaseMailer
   self.delivery_job = AlertMailerJob
   helper DatesHelper
+  helper VacanciesHelper
 
   helper_method :subscription, :jobseeker
 

--- a/app/views/jobseekers/alert_mailer/alert.text.erb
+++ b/app/views/jobseekers/alert_mailer/alert.text.erb
@@ -4,7 +4,7 @@
 
 <%- @vacancies.each do |vacancy| %>
   <%= show_link(vacancy) %>
-  <%= location(vacancy.parent_organisation, job_location: vacancy.job_location) %>
+  <%= vacancy_full_job_location(vacancy) %>
 
   <%= t(".salary", salary: vacancy.salary) %>
   <%- if vacancy.working_patterns? %>

--- a/app/views/jobseekers/job_applications/index.html.slim
+++ b/app/views/jobseekers/job_applications/index.html.slim
@@ -14,7 +14,7 @@
             = render Shared::CardComponent.new do |card|
               - card.header do
                 = tag.div(govuk_link_to(draft_application.vacancy.job_title, job_path(draft_application.vacancy), class: "govuk-link--no-visited-state"))
-                = tag.div(location(draft_application.vacancy.parent_organisation, job_location: draft_application.vacancy.job_location))
+                = tag.div(vacancy_job_location(draft_application.vacancy))
 
               - card.body do
                 = draft_application.vacancy.expires_at.future? ? job_application_status_tag(draft_application.status) : govuk_tag(text: "deadline passed", colour: "grey", classes: "govuk-!-margin-bottom-2")
@@ -30,7 +30,7 @@
             = render Shared::CardComponent.new do |card|
               - card.header do
                 = tag.div(govuk_link_to(submitted_application.vacancy.job_title, job_path(submitted_application.vacancy), class: "govuk-link--no-visited-state"))
-                = tag.div(location(submitted_application.vacancy.parent_organisation, job_location: submitted_application.vacancy.job_location))
+                = tag.div(vacancy_job_location(submitted_application.vacancy))
 
               - card.body do
                 = job_application_status_tag(submitted_application.status)

--- a/app/views/jobseekers/saved_jobs/index.html.slim
+++ b/app/views/jobseekers/saved_jobs/index.html.slim
@@ -27,7 +27,7 @@
             = render Shared::CardComponent.new do |card|
               - card.header do
                 = tag.div(govuk_link_to(saved_job.vacancy.job_title, job_path(saved_job.vacancy), class: "govuk-link--no-visited-state"))
-                = tag.div(location(saved_job.vacancy.parent_organisation, job_location: saved_job.vacancy.job_location))
+                = tag.div(vacancy_job_location(saved_job.vacancy))
 
               - card.body do
                 = tag.div(card.labelled_item(t(".added"), saved_job.created_at.strftime("%d %B %Y")))

--- a/app/views/shared/vacancy/_jobseeker_view.html.slim
+++ b/app/views/shared/vacancy/_jobseeker_view.html.slim
@@ -8,7 +8,7 @@
     h1.govuk-heading-xl class="govuk-!-margin-bottom-2"
       = @vacancy.job_title
     h2.govuk-caption-l.job-caption class="govuk-!-margin-bottom-5 govuk-!-margin-top-0"
-      = vacancy_job_location(@vacancy)
+      = vacancy_full_job_location(@vacancy)
 
     .govuk-grid-row
       - if JobseekerApplicationsFeature.enabled? && @vacancy.enable_job_applications? && @vacancy.expires_at.future?

--- a/spec/components/jobseekers/vacancy_summary_component_spec.rb
+++ b/spec/components/jobseekers/vacancy_summary_component_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Jobseekers::VacancySummaryComponent, type: :component do
       end
 
       it "renders the address" do
-        expect(rendered_component).to include(location(vacancy.parent_organisation))
+        expect(rendered_component).to include(vacancy_full_job_location(vacancy))
       end
 
       it "renders the school type label" do
@@ -78,7 +78,7 @@ RSpec.describe Jobseekers::VacancySummaryComponent, type: :component do
     end
 
     it "renders the job location" do
-      expect(rendered_component).to include(location(vacancy.parent_organisation, job_location: "at_multiple_schools"))
+      expect(rendered_component).to include("#{I18n.t('publishers.organisations.readable_job_location.at_multiple_schools')}, #{organisation.name}")
     end
 
     it "renders the unique school types" do
@@ -97,7 +97,7 @@ RSpec.describe Jobseekers::VacancySummaryComponent, type: :component do
     end
 
     it "renders the address" do
-      assert_includes rendered_component, location(vacancy.parent_organisation)
+      assert_includes rendered_component, vacancy_full_job_location(vacancy)
     end
 
     it "renders the trust type label" do

--- a/spec/mailers/jobseekers/alert_mailer_spec.rb
+++ b/spec/mailers/jobseekers/alert_mailer_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Jobseekers::AlertMailer do
                   .and include(vacancies.first.job_title)
                   .and include(vacancies.first.job_title)
                   .and include(job_url(vacancies.first, **campaign_params))
-                  .and include(location(vacancies.first.organisation))
+                  .and include(vacancy_full_job_location(vacancies.first))
                   .and include(I18n.t("jobseekers.alert_mailer.alert.salary", salary: vacancies.first.salary))
                   .and include(I18n.t("jobseekers.alert_mailer.alert.working_pattern", working_pattern: vacancies.first.working_patterns))
                   .and include(I18n.t("jobseekers.alert_mailer.alert.closing_date", closing_date: format_date(vacancies.first.expires_on)))
@@ -118,7 +118,7 @@ RSpec.describe Jobseekers::AlertMailer do
                   .and include(vacancies.first.job_title)
                   .and include(vacancies.first.job_title)
                   .and include(job_url(vacancies.first, **campaign_params))
-                  .and include(location(vacancies.first.organisation))
+                  .and include(vacancy_full_job_location(vacancies.first))
                   .and include(I18n.t("jobseekers.alert_mailer.alert.salary", salary: vacancies.first.salary))
                   .and include(I18n.t("jobseekers.alert_mailer.alert.working_pattern",
                                       working_pattern: vacancies.first.working_patterns))


### PR DESCRIPTION
## Jira ticket
https://dfedigital.atlassian.net/browse/TEVA-2119

## Changes in this PR
- Add vacancy_full_job_location method that includes postcode
- Use vacancy location helpers for vacancies, and organisation helper for organisations
- Use full location for job alerts and job listing pages too

## Product sign off
- [x] Looks good!