### PR TITLE
Update qualification year validation and error.

### DIFF
--- a/app/form_models/jobseekers/job_application/details/qualifications/qualification_form.rb
+++ b/app/form_models/jobseekers/job_application/details/qualifications/qualification_form.rb
@@ -5,6 +5,6 @@ class Jobseekers::JobApplication::Details::Qualifications::QualificationForm
 
   validates :category, presence: true
   validates :finished_studying_details, presence: true, if: -> { finished_studying == "false" }
-  validates :year, presence: true, if: -> { finished_studying == "true" }
-  validates :year, format: { with: /\A\d{4}\z/.freeze }, if: -> { year.present? }
+  validates :year, numericality: { less_than_or_equal_to: proc { Time.current.year } },
+                   if: -> { finished_studying == "true" }
 end

--- a/app/form_models/jobseekers/job_application/details/qualifications/secondary/common_form.rb
+++ b/app/form_models/jobseekers/job_application/details/qualifications/secondary/common_form.rb
@@ -6,8 +6,8 @@ module Jobseekers::JobApplication::Details::Qualifications::Secondary
 
     validate :at_least_one_qualification_result
     validate :all_qualification_results_valid
-    validates :institution, :year, presence: true
-    validates :year, format: { with: /\A\d{4}\z/.freeze }, if: -> { year.present? }
+    validates :institution, presence: true
+    validates :year, numericality: { less_than_or_equal_to: proc { Time.current.year } }
 
     def initialize(attributes = nil)
       super(attributes)

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -24,8 +24,8 @@ en:
     subject:
       blank: Enter a subject
     year:
-      blank: Enter the year the qualification was awarded
-      invalid: Enter a valid year
+      less_than_or_equal_to: The year the qualification was awarded must be the current year or in the past
+      not_a_number: Enter the year the qualification was awarded
   organisation_errors: &organisation_errors
     website:
       url: Enter a link in the correct format, like http://www.school.ac.uk
@@ -308,7 +308,7 @@ en:
             qualified_teacher_status:
               inclusion: Select yes if you have qualified teacher status
             qualified_teacher_status_year:
-              less_than_or_equal_to: Enter a valid year
+              less_than_or_equal_to: The year your QTS was awarded must be the current year or in the past
               not_a_number: Enter the year your QTS was awarded
             statutory_induction_complete:
               inclusion: Select yes if you have completed your statutory induction year

--- a/spec/form_models/jobseekers/job_application/details/qualifications/degree_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/details/qualifications/degree_form_spec.rb
@@ -19,8 +19,6 @@ RSpec.describe Jobseekers::JobApplication::Details::Qualifications::DegreeForm, 
     let(:params) { { "finished_studying" => "true" } }
 
     it { is_expected.to validate_presence_of(:grade) }
-    it { is_expected.to validate_presence_of(:year) }
-
-    it_behaves_like "validates year format"
+    it { is_expected.to validate_numericality_of(:year).is_less_than_or_equal_to(Time.current.year) }
   end
 end

--- a/spec/form_models/jobseekers/job_application/details/qualifications/other_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/details/qualifications/other_form_spec.rb
@@ -18,8 +18,6 @@ RSpec.describe Jobseekers::JobApplication::Details::Qualifications::OtherForm, t
   context "when finished studying is true" do
     let(:params) { { "finished_studying" => "true" } }
 
-    it { is_expected.to validate_presence_of(:year) }
-
-    it_behaves_like "validates year format"
+    it { is_expected.to validate_numericality_of(:year).is_less_than_or_equal_to(Time.current.year) }
   end
 end

--- a/spec/form_models/jobseekers/job_application/details/qualifications/secondary/common_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/details/qualifications/secondary/common_form_spec.rb
@@ -6,9 +6,7 @@ RSpec.describe Jobseekers::JobApplication::Details::Qualifications::Secondary::C
 
   it { is_expected.to validate_presence_of(:category) }
   it { is_expected.to validate_presence_of(:institution) }
-  it { is_expected.to validate_presence_of(:year) }
-
-  it_behaves_like "validates year format"
+  it { is_expected.to validate_numericality_of(:year).is_less_than_or_equal_to(Time.current.year) }
 
   describe "qualification result validations" do
     context "when no qualification results are given" do

--- a/spec/form_models/jobseekers/job_application/details/qualifications/secondary/other_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/details/qualifications/secondary/other_form_spec.rb
@@ -4,9 +4,7 @@ RSpec.describe Jobseekers::JobApplication::Details::Qualifications::Secondary::O
   it { is_expected.to validate_presence_of(:category) }
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_presence_of(:institution) }
-  it { is_expected.to validate_presence_of(:year) }
-
-  it_behaves_like "validates year format"
+  it { is_expected.to validate_numericality_of(:year).is_less_than_or_equal_to(Time.current.year) }
 
   describe "#subject_and_grade_correspond?" do
     # TODO: Add test when functionality is finished

--- a/spec/support/shared_examples/form_models.rb
+++ b/spec/support/shared_examples/form_models.rb
@@ -1,6 +1,0 @@
-RSpec.shared_examples "validates year format" do
-  it { is_expected.to allow_value("2010").for(:year) }
-  it { is_expected.not_to allow_value("123").for(:year) }
-  it { is_expected.not_to allow_value("12345").for(:year) }
-  it { is_expected.not_to allow_value("12cd").for(:year) }
-end


### PR DESCRIPTION
## Jira ticket
https://dfedigital.atlassian.net/browse/TEVA-2602

## Changes in this PR
- Update qualification year error messages
- Update QTS year error message
- Use numericality and less_than_or_equal_to for year validation
  rather than a custom validation
  
 ## Product sign off
 - [x] Looks good!