### PR TITLE
Allow deletion of non-empty S3 buckets in review apps

### DIFF
--- a/terraform/app/modules/paas/main.tf
+++ b/terraform/app/modules/paas/main.tf
@@ -26,7 +26,8 @@ resource "cloudfoundry_user_provided_service" "papertrail" {
 }
 
 resource "aws_s3_bucket" "documents_s3_bucket" {
-  bucket = local.documents_s3_bucket_name
+  bucket        = local.documents_s3_bucket_name
+  force_destroy = var.documents_s3_bucket_force_destroy
 }
 
 resource "aws_s3_bucket_public_access_block" "documents_s3_bucket_block" {

--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -39,6 +39,10 @@ variable "redis_cache_service_plan" {
 variable "redis_queue_service_plan" {
 }
 
+variable "documents_s3_bucket_force_destroy" {
+  default = false
+}
+
 variable "service_name" {
 }
 variable "service_abbreviation" {

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -30,6 +30,11 @@ variable "channel_list" {
   default = {}
 }
 
+# Documents S3 bucket
+variable "documents_s3_bucket_force_destroy" {
+  default = false
+}
+
 # Gov.UK PaaS
 
 variable "paas_app_docker_image" {

--- a/terraform/workspace-variables/dev.tfvars
+++ b/terraform/workspace-variables/dev.tfvars
@@ -20,6 +20,9 @@ channel_list = {
   #   }
 }
 
+# Documents S3 bucket
+documents_s3_bucket_force_destroy = false
+
 # Gov.UK PaaS
 paas_space_name                        = "teaching-vacancies-dev"
 paas_papertrail_service_binding_enable = false

--- a/terraform/workspace-variables/pentest.tfvars
+++ b/terraform/workspace-variables/pentest.tfvars
@@ -20,6 +20,10 @@ channel_list = {
   #   }
 }
 
+
+# Documents S3 bucket
+documents_s3_bucket_force_destroy = false
+
 # Gov.UK PaaS
 paas_space_name                        = "teaching-vacancies-dev"
 paas_papertrail_service_binding_enable = false

--- a/terraform/workspace-variables/production.tfvars
+++ b/terraform/workspace-variables/production.tfvars
@@ -20,6 +20,9 @@ channel_list = {
   }
 }
 
+# Documents S3 bucket
+documents_s3_bucket_force_destroy = false
+
 # Gov.UK PaaS
 paas_space_name                        = "teaching-vacancies-production"
 paas_papertrail_service_binding_enable = true

--- a/terraform/workspace-variables/qa.tfvars
+++ b/terraform/workspace-variables/qa.tfvars
@@ -20,6 +20,9 @@ channel_list = {
   #   }
 }
 
+# Documents S3 bucket
+documents_s3_bucket_force_destroy = false
+
 # Gov.UK PaaS
 paas_space_name                        = "teaching-vacancies-dev"
 paas_papertrail_service_binding_enable = false

--- a/terraform/workspace-variables/review.tfvars
+++ b/terraform/workspace-variables/review.tfvars
@@ -20,6 +20,9 @@ channel_list = {
   #   }
 }
 
+# Documents S3 bucket
+documents_s3_bucket_force_destroy = true
+
 # Gov.UK PaaS
 paas_space_name                        = "teaching-vacancies-review"
 paas_postgres_service_plan             = "tiny-unencrypted-11"

--- a/terraform/workspace-variables/staging.tfvars
+++ b/terraform/workspace-variables/staging.tfvars
@@ -20,6 +20,9 @@ channel_list = {
   }
 }
 
+# Documents S3 bucket
+documents_s3_bucket_force_destroy = false
+
 # Gov.UK PaaS
 paas_space_name                        = "teaching-vacancies-staging"
 paas_papertrail_service_binding_enable = true

--- a/terraform/workspace-variables/workspace.tfvars.example
+++ b/terraform/workspace-variables/workspace.tfvars.example
@@ -21,6 +21,9 @@ channel_list = {
   }
 }
 
+# Documents S3 bucket
+documents_s3_bucket_force_destroy = false
+
 # Gov.UK PaaS
 paas_api_url                        = "https://api.london.cloud.service.gov.uk"
 paas_space_name                     = ""


### PR DESCRIPTION
When destroying review apps, allow destruction of S3 buckets even if
they're not empty (e.g. if someone has uploaded files for testing
purposes).