### PR TITLE
Dates refactor - Part 1

### DIFF
--- a/app/controllers/publishers/vacancies/extend_deadline_controller.rb
+++ b/app/controllers/publishers/vacancies/extend_deadline_controller.rb
@@ -28,7 +28,7 @@ class Publishers::Vacancies::ExtendDeadlineController < Publishers::Vacancies::B
 
   def form_params
     params.require(:publishers_job_listing_extend_deadline_form)
-          .permit(:expires_on, :expiry_time, :starts_on, :starts_asap)
+          .permit(:expires_at, :expiry_time, :starts_on, :starts_asap)
           .merge(previous_deadline: vacancy.expires_at)
   end
 

--- a/app/form_models/date_attribute_assignment.rb
+++ b/app/form_models/date_attribute_assignment.rb
@@ -1,0 +1,15 @@
+module DateAttributeAssignment
+  private
+
+  def date_from_multiparameter_hash(date_params)
+    Date.new(date_params[1], date_params[2], date_params[3])
+  rescue ArgumentError, TypeError, NoMethodError
+    date_params
+  end
+
+  def datetime_from_date_and_time(date, time)
+    return date unless date.is_a?(Date)
+
+    Time.zone.parse("#{date} #{time}")
+  end
+end

--- a/app/form_models/jobseekers/job_application/details/employment_form.rb
+++ b/app/form_models/jobseekers/job_application/details/employment_form.rb
@@ -1,46 +1,21 @@
 class Jobseekers::JobApplication::Details::EmploymentForm
   include ActiveModel::Model
   include ActiveRecord::AttributeAssignment
+  include DateAttributeAssignment
 
-  attr_accessor :organisation, :job_title, :salary, :subjects, :main_duties, :started_on, :current_role, :ended_on
+  attr_accessor :organisation, :job_title, :salary, :subjects, :main_duties, :current_role
+  attr_reader :started_on, :ended_on
 
   validates :organisation, :job_title, :main_duties, presence: true
-  validates :started_on, presence: true, date: true
-  validate :started_on_is_in_the_past
+  validates :started_on, date: { before: :today }
   validates :current_role, inclusion: { in: %w[yes no] }
-  validates :ended_on, presence: true, date: true, if: -> { current_role == "no" }
-  validate :ended_on_is_in_the_past, if: -> { current_role == "no" }
-  validate :ended_on_is_after_started_on, if: -> { current_role == "no" }
+  validates :ended_on, date: { before: :today, after: :started_on }, if: -> { current_role == "no" }
 
-  def started_on_is_in_the_past
-    return if started_on.nil?
-
-    errors.add(:started_on, :not_in_the_past) unless started_on_date < Date.current
-  rescue Date::Error, TypeError
-    nil
+  def started_on=(value)
+    @started_on = date_from_multiparameter_hash(value)
   end
 
-  def ended_on_is_in_the_past
-    return if ended_on.nil?
-
-    errors.add(:ended_on, :not_in_the_past) unless ended_on_date < Date.current
-  rescue Date::Error, TypeError
-    nil
-  end
-
-  def ended_on_is_after_started_on
-    return if ended_on.nil? || started_on.nil?
-
-    errors.add(:ended_on, :before_started_on) unless ended_on_date > started_on_date
-  rescue Date::Error, TypeError
-    nil
-  end
-
-  def started_on_date
-    @started_on_date ||= Date.new(started_on[1], started_on[2], started_on[3])
-  end
-
-  def ended_on_date
-    @ended_on_date ||= Date.new(ended_on[1], ended_on[2], ended_on[3])
+  def ended_on=(value)
+    @ended_on = date_from_multiparameter_hash(value)
   end
 end

--- a/app/form_models/publishers/job_listing/extend_deadline_form.rb
+++ b/app/form_models/publishers/job_listing/extend_deadline_form.rb
@@ -1,65 +1,38 @@
 class Publishers::JobListing::ExtendDeadlineForm
   include ActiveModel::Model
   include ActiveRecord::AttributeAssignment
+  include DateAttributeAssignment
 
   EXPIRY_TIME_OPTIONS = %w[9:00 12:00 17:00 23:59].freeze
 
-  attr_accessor :expires_on, :expiry_time, :starts_on, :starts_asap, :previous_deadline
+  attr_accessor :expiry_time, :starts_asap, :previous_deadline
+  attr_reader :expires_at, :starts_on
 
-  validates :expires_on, presence: true, date: true
-  validates :starts_on, date: true, if: proc { starts_on.present? && starts_asap == "0" }
+  validates :expires_at, date: { on_or_after: :now, after: :previous_deadline }
   validates :expiry_time, inclusion: { in: EXPIRY_TIME_OPTIONS }
-
-  validate :expires_at_extended
-  validate :expires_at_in_future
-  validate :starts_on_in_future, if: proc { starts_on.present? && starts_asap == "0" }
-  validate :starts_on_after_expires_at, if: proc { starts_on.present? && starts_asap == "0" }
+  validates :starts_on, date: { on_or_after: :today, after: :expires_at }, allow_blank: true,
+                        if: proc { starts_asap == "0" }
   validate :starts_on_and_starts_asap_not_present
 
   def attributes_to_save
     {
-      expires_on: expires_on,
+      expires_on: expires_at.to_date,
       expires_at: expires_at,
       starts_on: (starts_on unless starts_asap == "true"),
       starts_asap: starts_asap,
     }
   end
 
+  def expires_at=(value)
+    expires_on = date_from_multiparameter_hash(value)
+    @expires_at = datetime_from_date_and_time(expires_on, expiry_time)
+  end
+
+  def starts_on=(value)
+    @starts_on = date_from_multiparameter_hash(value)
+  end
+
   private
-
-  def expires_at
-    Time.zone.parse("#{expires_on[1]}-#{expires_on[2]}-#{expires_on[3]} #{expiry_time}")
-  end
-
-  def expires_at_extended
-    return if expiry_time.nil? || expires_on.nil? || expires_at < Time.current
-
-    errors.add(:expires_on, :not_extended) if expires_at <= previous_deadline
-  rescue ArgumentError, TypeError
-    nil
-  end
-
-  def expires_at_in_future
-    return if expiry_time.nil? || expires_on.nil?
-
-    errors.add(:expires_on, :in_past) if expires_at < Time.current
-  rescue ArgumentError, TypeError
-    nil
-  end
-
-  def starts_on_in_future
-    errors.add(:starts_on, :in_past) if Date.new(starts_on[1], starts_on[2], starts_on[3]) < Date.current
-  rescue ArgumentError, TypeError
-    nil
-  end
-
-  def starts_on_after_expires_at
-    return if expires_on.nil? || Date.new(starts_on[1], starts_on[2], starts_on[3]) < Date.current
-
-    errors.add(:starts_on, :before_deadline) if Date.new(starts_on[1], starts_on[2], starts_on[3]) < expires_at
-  rescue ArgumentError, TypeError
-    nil
-  end
 
   def starts_on_and_starts_asap_not_present
     errors.add(:starts_on, :date_and_asap) if starts_on.present? && starts_asap == "true"

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -1,9 +1,38 @@
 class DateValidator < ActiveModel::EachValidator
-  def validate_each(record, attribute, value)
-    return if value.nil?
+  RESTRICTION_TYPES = {
+    after: :>,
+    before: :<,
+    on_or_after: :>=,
+    on_or_before: :<=,
+  }.freeze
 
-    Date.new(value[1], value[2], value[3])
-  rescue Date::Error, TypeError
-    record.errors.add(attribute, :invalid)
+  DEFAULT_CHECK_VALUES = {
+    today: Date.current,
+    now: Time.current,
+  }.freeze
+
+  def validate_each(record, attribute, value)
+    return record.errors.add(attribute, :blank) if value.blank?
+    return record.errors.add(attribute, :invalid) if value.is_a?(Hash)
+
+    restrictions = RESTRICTION_TYPES.keys & options.keys
+
+    restrictions.each do |restriction|
+      operator = RESTRICTION_TYPES[restriction]
+      restriction_option = options[restriction]
+
+      raise ArgumentError, "give me something to work with!!" unless
+        DEFAULT_CHECK_VALUES.key?(restriction_option) || record.respond_to?(restriction_option)
+
+      if DEFAULT_CHECK_VALUES.key?(restriction_option)
+        value_to_compare = DEFAULT_CHECK_VALUES[restriction_option]
+      elsif record.respond_to?(restriction_option)
+        value_to_compare = record.send(restriction_option)
+      end
+
+      next if value_to_compare.blank? || value_to_compare.is_a?(Hash)
+
+      record.errors.add(attribute, restriction) unless value.send(operator, value_to_compare)
+    end
   end
 end

--- a/app/views/publishers/vacancies/extend_deadline/show.html.slim
+++ b/app/views/publishers/vacancies/extend_deadline/show.html.slim
@@ -13,7 +13,7 @@
       = form_for form, url: organisation_job_extend_deadline_path(vacancy.id), method: :patch do |f|
         = f.govuk_error_summary
 
-        = f.govuk_date_field :expires_on
+        = f.govuk_date_field :expires_at
 
         = f.govuk_collection_radio_buttons :expiry_time,
           form.class::EXPIRY_TIME_OPTIONS,
@@ -24,7 +24,7 @@
           = f.govuk_date_field :starts_on
 
           .clear-form__checkbox
-            = f.govuk_check_box :starts_asap, true, 0, multiple: false, link_errors: false
+            = f.govuk_check_box :starts_asap, "true", 0, multiple: false, link_errors: false
 
         = f.govuk_submit t("buttons.extend_deadline"), classes: "govuk-!-margin-bottom-5"
 

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -215,18 +215,18 @@ en:
               inclusion: Select how the successful candidate applied for the role
         publishers/job_listing/extend_deadline_form:
           attributes:
-            expires_on:
-              blank: Enter the closing date
-              in_past: The closing date must be in the future
+            expires_at:
+              after: To extend the closing date enter a date that is after the current deadline
+              blank: Enter a closing date
               invalid: Enter a date in the correct format
-              not_extended: To extend the closing date enter a date that is after the current deadline
+              on_or_after: The closing date must be in the future
             expiry_time:
               inclusion: Select the time the application is due
             starts_on:
-              before_deadline: The date the job starts must be after the date applications are due
+              after: The date the job starts must be after the date applications are due
               date_and_asap: Select either a start date or 'As soon as possible'
-              in_past: The date the job starts must be in the future
               invalid: Enter a date in the correct format
+              on_or_after: The date the job starts must be in the future
         publishers/organisation_form:
           attributes:
             <<: *organisation_errors
@@ -343,10 +343,10 @@ en:
             current_role:
               inclusion: Select yes if this is your current role
             ended_on:
-              before_started_on: End date must be after the start date
+              after: End date must be after the start date
+              before: The date the role ended must be in the past
               blank: Enter the date you left this school or organisation
-              invalid: Enter a valid end date
-              not_in_the_past: The date the role ended must be in the past
+              invalid: Enter a date in the correct format
             job_title:
               blank: Enter your job title
             main_duties:
@@ -354,9 +354,9 @@ en:
             organisation:
               blank: Enter a school or other organisation
             started_on:
+              before: The date the role started must be in the past
               blank: Enter the date you started at this school or organisation
-              invalid: Enter a valid start date
-              not_in_the_past: The date the role started must be in the past
+              invalid: Enter a date in the correct format
         jobseekers/job_application/details/qualifications/category_form:
           attributes:
             <<: *qualification_errors

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -178,7 +178,7 @@ en:
           href="https://www.gov.uk/guidance/publishing-accessible-documents#writing-accessible-documents">
           how to make documents accessible.</a></p>
       publishers_job_listing_extend_deadline_form:
-        expires_on: For example, 01 05 2021
+        expires_at: For example, 01 05 2021
         starts_on: For example, 01 09 2021
       publishers_job_listing_important_dates_form:
         expires_on: For example, 01 05 2021
@@ -538,7 +538,7 @@ en:
       publishers_job_listing_end_listing_form:
         end_listing_reason: Why would you like to end this job listing early?
       publishers_job_listing_extend_deadline_form:
-        expires_on: Closing date
+        expires_at: Closing date
         expiry_time: Time application is due
         starts_on: Date job starts
       publishers_job_listing_feedback_form:

--- a/spec/form_models/jobseekers/job_application/details/employment_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/details/employment_form_spec.rb
@@ -7,40 +7,55 @@ RSpec.describe Jobseekers::JobApplication::Details::EmploymentForm, type: :model
   it { is_expected.to validate_presence_of(:organisation) }
   it { is_expected.to validate_presence_of(:job_title) }
   it { is_expected.to validate_presence_of(:main_duties) }
-  it { is_expected.to validate_presence_of(:started_on) }
   it { is_expected.to validate_inclusion_of(:current_role).in_array(%w[yes no]) }
 
-  context "when started_on is an invalid date" do
-    let(:params) { { "started_on(1i)" => "2021", "started_on(2i)" => "01", "started_on(3i)" => "100" } }
+  describe "#started_on" do
+    context "when started_on is blank" do
+      let(:params) { {} }
 
-    it "is invalid" do
-      expect(subject).not_to be_valid
-      expect(subject.errors.of_kind?(:started_on, :invalid)).to be true
+      it "is invalid" do
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:started_on, :blank)).to be true
+      end
+    end
+
+    context "when started_on is an invalid date" do
+      let(:params) { { "started_on(1i)" => "2021", "started_on(2i)" => "01", "started_on(3i)" => "100" } }
+
+      it "is invalid" do
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:started_on, :invalid)).to be true
+      end
+    end
+
+    context "when started_on is an incomplete date" do
+      let(:params) { { "started_on(3i)" => "1" } }
+
+      it "is invalid" do
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:started_on, :invalid)).to be true
+      end
+    end
+
+    context "when started_on is after today" do
+      let(:params) { { "started_on(1i)" => "2121", "started_on(2i)" => "01", "started_on(3i)" => "01" } }
+
+      it "is invalid" do
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:started_on, :before)).to be true
+      end
     end
   end
 
-  context "when started_on is an incomplete date" do
-    let(:params) { { "started_on(3i)" => "1" } }
+  describe "#ended_on" do
+    context "when ended_on is blank" do
+      let(:params) { { current_role: "no" } }
 
-    it "is invalid" do
-      expect(subject).not_to be_valid
-      expect(subject.errors.of_kind?(:started_on, :invalid)).to be true
+      it "is invalid" do
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:ended_on, :blank)).to be true
+      end
     end
-  end
-
-  context "when started_on is not in the past" do
-    let(:params) { { "started_on(1i)" => "2121", "started_on(2i)" => "01", "started_on(3i)" => "01" } }
-
-    it "is invalid" do
-      expect(subject).not_to be_valid
-      expect(subject.errors.of_kind?(:started_on, :not_in_the_past)).to be true
-    end
-  end
-
-  context "when current_role is no" do
-    let(:params) { { current_role: "no" } }
-
-    it { is_expected.to validate_presence_of(:ended_on) }
 
     context "when ended_on is invalid" do
       let(:params) { { current_role: "no", "ended_on(1i)" => "2021", "ended_on(2i)" => "01", "ended_on(3i)" => "100" } }
@@ -64,7 +79,7 @@ RSpec.describe Jobseekers::JobApplication::Details::EmploymentForm, type: :model
       end
     end
 
-    context "when ended_on is not in the past" do
+    context "when ended_on is after today" do
       let(:params) do
         { current_role: "no",
           "started_on(1i)" => "2021", "started_on(2i)" => "01", "started_on(3i)" => "01",
@@ -73,7 +88,7 @@ RSpec.describe Jobseekers::JobApplication::Details::EmploymentForm, type: :model
 
       it "is invalid" do
         expect(subject).not_to be_valid
-        expect(subject.errors.of_kind?(:ended_on, :not_in_the_past)).to be true
+        expect(subject.errors.of_kind?(:ended_on, :before)).to be true
       end
     end
 
@@ -86,7 +101,7 @@ RSpec.describe Jobseekers::JobApplication::Details::EmploymentForm, type: :model
 
       it "is invalid" do
         expect(subject).not_to be_valid
-        expect(subject.errors.of_kind?(:ended_on, :before_started_on)).to be true
+        expect(subject.errors.of_kind?(:ended_on, :after)).to be true
       end
     end
   end

--- a/spec/form_models/publishers/job_listing/extend_deadline_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/extend_deadline_form_spec.rb
@@ -3,16 +3,16 @@ require "rails_helper"
 RSpec.describe Publishers::JobListing::ExtendDeadlineForm, type: :model do
   subject { described_class.new(params) }
 
-  let(:expires_on) { 1.year.from_now }
+  let(:expires_at) { 1.year.from_now }
   let(:previous_deadline) { 6.months.from_now }
   let(:starts_on) { 2.years.from_now }
   let(:starts_asap) { "0" }
 
   let(:params) do
     {
-      "expires_on(1i)" => expires_on.year.to_s,
-      "expires_on(2i)" => expires_on.month.to_s,
-      "expires_on(3i)" => expires_on.day.to_s,
+      "expires_at(1i)" => expires_at.year.to_s,
+      "expires_at(2i)" => expires_at.month.to_s,
+      "expires_at(3i)" => expires_at.day.to_s,
       expiry_time: "9:00",
       previous_deadline: previous_deadline,
       "starts_on(1i)" => starts_on.year.to_s,
@@ -30,51 +30,60 @@ RSpec.describe Publishers::JobListing::ExtendDeadlineForm, type: :model do
 
   it { is_expected.to validate_inclusion_of(:expiry_time).in_array(%w[9:00 12:00 17:00 23:59]) }
 
-  describe "expires_on" do
-    it { is_expected.to validate_presence_of(:expires_on) }
-
-    context "when date is incomplete" do
-      before { params.delete("expires_on(2i)") }
+  describe "expires_at" do
+    context "when date is blank" do
+      before do
+        params["expires_at(1i)"] = ""
+        params["expires_at(2i)"] = ""
+        params["expires_at(3i)"] = ""
+      end
 
       it "is invalid" do
         expect(subject).not_to be_valid
-        expect(subject.errors.of_kind?(:expires_on, :invalid)).to be true
+        expect(subject.errors.of_kind?(:expires_at, :blank)).to be true
+      end
+    end
+
+    context "when date is incomplete" do
+      before { params["expires_at(2i)"] = "" }
+
+      it "is invalid" do
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:expires_at, :invalid)).to be true
       end
     end
 
     context "when date is invalid" do
-      before { params["expires_on(2i)"] = "100" }
+      before { params["expires_at(2i)"] = "100" }
 
       it "is invalid" do
         expect(subject).not_to be_valid
-        expect(subject.errors.of_kind?(:expires_on, :invalid)).to be true
+        expect(subject.errors.of_kind?(:expires_at, :invalid)).to be true
       end
     end
-  end
 
-  describe "expires_at" do
     context "when date is not extended" do
-      let(:expires_on) { 1.month.from_now }
+      let(:expires_at) { 1.month.from_now }
 
       it "is invalid" do
         expect(subject).not_to be_valid
-        expect(subject.errors.of_kind?(:expires_on, :not_extended)).to be true
+        expect(subject.errors.of_kind?(:expires_at, :after)).to be true
       end
     end
 
     context "when date is not in the future" do
-      let(:expires_on) { 1.month.ago }
+      let(:expires_at) { 1.month.ago }
 
       it "is invalid" do
         expect(subject).not_to be_valid
-        expect(subject.errors.of_kind?(:expires_on, :in_past)).to be true
+        expect(subject.errors.of_kind?(:expires_at, :on_or_after)).to be true
       end
     end
   end
 
   describe "starts_on" do
     context "when date is incomplete" do
-      before { params.delete("starts_on(2i)") }
+      before { params["starts_on(2i)"] = "" }
 
       it "is invalid" do
         expect(subject).not_to be_valid
@@ -96,7 +105,7 @@ RSpec.describe Publishers::JobListing::ExtendDeadlineForm, type: :model do
 
       it "is invalid" do
         expect(subject).not_to be_valid
-        expect(subject.errors.of_kind?(:starts_on, :in_past)).to be true
+        expect(subject.errors.of_kind?(:starts_on, :on_or_after)).to be true
       end
     end
 
@@ -105,7 +114,7 @@ RSpec.describe Publishers::JobListing::ExtendDeadlineForm, type: :model do
 
       it "is invalid" do
         expect(subject).not_to be_valid
-        expect(subject.errors.of_kind?(:starts_on, :before_deadline)).to be true
+        expect(subject.errors.of_kind?(:starts_on, :after)).to be true
       end
     end
 

--- a/spec/requests/publishers/vacancies/extend_deadline_spec.rb
+++ b/spec/requests/publishers/vacancies/extend_deadline_spec.rb
@@ -38,14 +38,13 @@ RSpec.describe "Extend deadline" do
   end
 
   describe "PATCH #update" do
-    let(:expires_on) { 6.months.from_now }
-    let(:expires_at) { Time.zone.parse("#{expires_on.year}-#{expires_on.month}-#{expires_on.day} 9:00") }
+    let(:expires_at) { 6.months.from_now }
 
     let(:form_params) do
       {
-        "expires_on(1i)" => expires_on.year.to_s,
-        "expires_on(2i)" => expires_on.month.to_s,
-        "expires_on(3i)" => expires_on.day.to_s,
+        "expires_at(1i)" => expires_at.year.to_s,
+        "expires_at(2i)" => expires_at.month.to_s,
+        "expires_at(3i)" => expires_at.day.to_s,
         expiry_time: "9:00",
         starts_asap: "0",
       }
@@ -88,7 +87,7 @@ RSpec.describe "Extend deadline" do
     it "extends the deadline, updates google index and redirects to active jobs dashboard" do
       freeze_time do
         expect { patch organisation_job_extend_deadline_path(vacancy.id), params: params }
-            .to change { vacancy.reload.expires_at }.from(1.month.from_now).to(expires_at)
+            .to change { vacancy.reload.expires_at }.from(1.month.from_now).to(expires_at.change({ hour: 9, minute: 0 }))
             .and have_enqueued_job(UpdateGoogleIndexQueueJob)
 
         expect(response).to redirect_to(jobs_with_type_organisation_path(:published))

--- a/spec/system/publishers_can_extend_a_deadline_spec.rb
+++ b/spec/system/publishers_can_extend_a_deadline_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Publishers can extend a deadline" do
   let(:organisation) { create(:school) }
   let!(:vacancy) { create(:vacancy, :published, organisation_vacancies_attributes: [{ organisation: organisation }]) }
   let(:publisher) { create(:publisher) }
-  let(:expires_on) { vacancy.expires_at + 1.month }
+  let(:expires_at) { vacancy.expires_at + 1.month }
 
   before do
     login_publisher(publisher: publisher, organisation: organisation)
@@ -18,9 +18,9 @@ RSpec.describe "Publishers can extend a deadline" do
 
     expect(page).to have_content("There is a problem")
 
-    fill_in "publishers_job_listing_extend_deadline_form[expires_on(1i)]", with: expires_on.year
-    fill_in "publishers_job_listing_extend_deadline_form[expires_on(2i)]", with: expires_on.month
-    fill_in "publishers_job_listing_extend_deadline_form[expires_on(3i)]", with: expires_on.day
+    fill_in "publishers_job_listing_extend_deadline_form[expires_at(1i)]", with: expires_at.year
+    fill_in "publishers_job_listing_extend_deadline_form[expires_at(2i)]", with: expires_at.month
+    fill_in "publishers_job_listing_extend_deadline_form[expires_at(3i)]", with: expires_at.day
     choose "Start of the working day (9 am)", name: "publishers_job_listing_extend_deadline_form[expiry_time]"
 
     click_on I18n.t("buttons.extend_deadline")


### PR DESCRIPTION
Rethink how we validate dates that use multiparameter attribute assignment.

## Context
- Dates are submitted as multiparameter attributes. 
- We use form models (multiparameter attribute assignment is part of ActiveRecord still, despite several efforts to migrate the API to ActiveModel). 
- This means we can't reliably use date validation gems like `validates_timeliness`

## Changes in this PR
- Update date validator to use more options
- Refactor extend deadline and job application employment forms