### PR TITLE
reduce size of application printout

### DIFF
--- a/app/frontend/src/styles/application/publishers/print-application.scss
+++ b/app/frontend/src/styles/application/publishers/print-application.scss
@@ -1,5 +1,49 @@
 @media print {
   .publishers_vacancies_job_applications_show {
+
+    .review-component__body {
+      .govuk-summary-list__row > * {
+        font-size: 0.8em;
+      }
+
+      .govuk-body {
+        font-size: 1em;
+      }
+
+      margin-bottom: govuk-spacing(4);
+    }
+
+    .review-component__heading {
+      margin-bottom: 0;
+    }
+
+    .review-component {
+      border-bottom: 1px solid $govuk-border-colour;
+      margin-bottom: govuk-spacing(4);
+    }
+
+    .govuk-accordion__section-header, .govuk-accordion__section, .govuk-summary-list__actions, .review-component__body--border {
+      border: none !important;
+    }
+
+    .govuk-heading-xl {
+      margin-bottom: 0 !important;
+    }
+
+    .review-component__heading__title {
+      flex-basis: 75%;
+    }
+
+    .govuk-summary-list__key, .govuk-summary-list__value, .govuk-summary-list__actions, .govuk-summary-list__value .govuk-body {
+      display: table-row;
+      margin-bottom: govuk-spacing(2);
+      width: 100%;
+    }
+
+    .govuk-summary-list__row, .govuk-summary-list__value .govuk-body {
+      border-bottom: none !important;
+    }
+
     .govuk-accordion__icon,
     .timeline-component {
       display: none !important;


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-2609

reducing font-size actually makes neglibible difference to the size of the printout and it is margins and padding that needed tweeking as much. so this ticket has become a bit more geared to the size generally rather than just font. the total size has come down by about 25% because of this PR

its a very longwinded process tweeking print stylesheet like this with no dev tools at your disposal!

before page 1
![Screenshot 2021-05-20 at 15 51 51](https://user-images.githubusercontent.com/1792451/119000789-54d48400-b983-11eb-965b-6185b1339c3d.png)

after page 1
![Screenshot 2021-05-20 at 15 51 13](https://user-images.githubusercontent.com/1792451/119000845-5dc55580-b983-11eb-9804-1b652b06ba21.png)

