### PR TITLE
Make copying vacancy copy supporting documents

### DIFF
--- a/app/services/copy_vacancy.rb
+++ b/app/services/copy_vacancy.rb
@@ -15,6 +15,10 @@ class CopyVacancy
   private
 
   def copy_documents
+    @vacancy.supporting_documents.each do |supporting_doc|
+      @new_vacancy.supporting_documents.attach(supporting_doc.blob)
+    end
+
     @vacancy.documents.each do |document|
       document_copy = DocumentCopy.new(document.google_drive_id)
       document_copy.copy

--- a/spec/services/copy_vacancy_spec.rb
+++ b/spec/services/copy_vacancy_spec.rb
@@ -36,17 +36,27 @@ RSpec.describe CopyVacancy do
     end
 
     describe "#documents" do
-      it "copies documents when copying a vacancy" do
-        document = create(:document,
-                          name: "Test.png",
-                          size: 1000,
-                          content_type: "image/png",
-                          download_url: "test/test.png",
-                          google_drive_id: "testid")
-        vacancy = create(:vacancy, documents: [document])
+      let(:document) do
+        create(
+          :document,
+          name: "Test.png",
+          size: 1000,
+          content_type: "image/png",
+          download_url: "test/test.png",
+          google_drive_id: "testid",
+        )
+      end
+      let(:vacancy) { create(:vacancy, documents: [document]) }
+      let(:result) { described_class.new(vacancy).call }
 
-        result = described_class.new(vacancy).call
+      it "attaches supporting document when copying a vacancy" do
+        vacancy.supporting_documents.attach(fixture_file_upload("blank_job_spec.pdf"))
 
+        expect(result.supporting_documents.count).to eq(1)
+        expect(result.supporting_documents.first.blob).to eq(vacancy.supporting_documents.first.blob)
+      end
+
+      it "copies legacy documents when copying a vacancy" do
         expect(result.documents.first.name).to eq(vacancy.documents.first.name)
       end
     end


### PR DESCRIPTION
The last missing link to get ready for the great migration - when
copying a vacancy, copy both "legacy" and new supporting documents