### PR TITLE
[TEVA-2567] filters close all UI defect

### DIFF
--- a/app/components/filters_component/filters_component.html.slim
+++ b/app/components/filters_component/filters_component.html.slim
@@ -12,8 +12,9 @@
           button.govuk-link.govuk-link--no-visited-state.filters-component--show-mobile-open id="return-to-results"
             = t("shared.filter_group.return_to_results")
         - if options[:close_all]
-          button.govuk-link.govuk-link--no-visited-state.filters-component__heading-close-all.js-action id="close-all-groups" class="close-all"
-            = t("shared.filter_group.close_all_filter_groups")
+          span.js-action
+            button.govuk-link.govuk-link--no-visited-state.filters-component__heading-close-all id="close-all-groups" class="close-all"
+              = t("shared.filter_group.close_all_filter_groups")
 
   .filters-component__remove
     - if display_remove_buttons


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-2567

the close all button needs to be in a container of js-action else it inherits the incorrect display property

before fix
![Screenshot 2021-05-20 at 17 16 19](https://user-images.githubusercontent.com/1792451/119013691-23fa4c00-b98f-11eb-829c-304ad8c42731.png)


after fix
![Screenshot 2021-05-20 at 17 14 29](https://user-images.githubusercontent.com/1792451/119013430-df6eb080-b98e-11eb-9e6c-15441d1228bd.png)
![Screenshot 2021-05-20 at 17 14 23](https://user-images.githubusercontent.com/1792451/119013436-e09fdd80-b98e-11eb-9ae1-6ea49b6034af.png)
![Screenshot 2021-05-20 at 17 14 13](https://user-images.githubusercontent.com/1792451/119013437-e1387400-b98e-11eb-8e97-14e71a645007.png)

