### PR TITLE
Remove state column from vacancies

### DIFF
--- a/app/components/publishers/vacancy_form_page_heading_component.rb
+++ b/app/components/publishers/vacancy_form_page_heading_component.rb
@@ -11,20 +11,14 @@ class Publishers::VacancyFormPageHeadingComponent < ViewComponent::Base
     page_title
   end
 
-  def show_current_step?
-    %w[copy edit edit_published].exclude?(vacancy.state)
-  end
-
   private
 
-  attr_reader :vacancy
+  attr_reader :vacancy, :copy
 
   def page_title
-    return I18n.t("jobs.copy_job_title", job_title: vacancy.job_title) if vacancy.state == "copy"
-    return I18n.t("jobs.create_a_job_title", organisation: organisation_from_job_location) if
-      %w[create review].include?(vacancy.state)
+    return I18n.t("jobs.edit_job_title", job_title: vacancy.job_title) if vacancy.published?
 
-    I18n.t("jobs.edit_job_title", job_title: vacancy.job_title)
+    I18n.t("jobs.create_a_job_title", organisation: organisation_from_job_location)
   end
 
   def organisation_from_job_location

--- a/app/components/publishers/vacancy_form_page_heading_component/vacancy_form_page_heading_component.html.slim
+++ b/app/components/publishers/vacancy_form_page_heading_component/vacancy_form_page_heading_component.html.slim
@@ -1,5 +1,5 @@
 h1.govuk-heading-m
   = heading
-  - if show_current_step?
+  - unless vacancy.published?
     span.govuk-caption-m
       = t("jobs.current_step", step: @current, total: @total)

--- a/app/components/publishers/vacancy_wizard_back_link_component.rb
+++ b/app/components/publishers/vacancy_wizard_back_link_component.rb
@@ -1,12 +1,13 @@
 class Publishers::VacancyWizardBackLinkComponent < ViewComponent::Base
-  def initialize(vacancy, previous_step_path: nil, current_step_is_first_step: false)
+  def initialize(vacancy, previous_step_path: nil, current_step_is_first_step: false, review: false)
     @vacancy = vacancy
     @previous_step_path = previous_step_path
     @current_step_is_first_step = current_step_is_first_step
+    @review = review
   end
 
   def render?
-    !vacancy_is_in_create_state? || !current_step_is_first_step?
+    @review || !current_step_is_first_step?
   end
 
   def call
@@ -16,29 +17,21 @@ class Publishers::VacancyWizardBackLinkComponent < ViewComponent::Base
   private
 
   def text
-    if vacancy_is_in_create_state?
-      t("buttons.back_to_previous_step")
-    else
+    if @vacancy.published? || @review
       t("buttons.cancel_and_return")
+    else
+      t("buttons.back_to_previous_step")
     end
   end
 
   def href
-    if vacancy_is_in_create_state?
-      @previous_step_path
-    elsif vacancy_is_published?
+    if @vacancy.published?
       edit_organisation_job_path(@vacancy.id)
-    else
+    elsif @review
       organisation_job_review_path(@vacancy.id)
+    else
+      @previous_step_path
     end
-  end
-
-  def vacancy_is_in_create_state?
-    @vacancy.state == "create"
-  end
-
-  def vacancy_is_published?
-    @vacancy.published?
   end
 
   def current_step_is_first_step?

--- a/app/components/shared/process_steps_component.rb
+++ b/app/components/shared/process_steps_component.rb
@@ -6,7 +6,7 @@ class Shared::ProcessStepsComponent < ViewComponent::Base
   end
 
   def render?
-    @process.blank? || %w[create review].include?(@process.state)
+    @process.blank? || !@process.published?
   end
 
   def current_step_number

--- a/app/controllers/concerns/publishers/wizardable.rb
+++ b/app/controllers/concerns/publishers/wizardable.rb
@@ -53,7 +53,7 @@ module Publishers::Wizardable
     }
     session[:job_location] = job_location
     params.require(:publishers_job_listing_job_location_form)
-          .permit(:state, :job_location).merge(attributes_to_merge.compact)
+          .permit(:job_location).merge(attributes_to_merge.compact)
   end
 
   def schools_params(params)
@@ -67,7 +67,7 @@ module Publishers::Wizardable
                     end
     readable_job_location = readable_job_location(job_location, school_name: school_name, schools_count: schools_count)
     params.require(:publishers_job_listing_schools_form)
-          .permit(:state, :organisation_ids, organisation_ids: [])
+          .permit(:organisation_ids, organisation_ids: [])
           .merge(completed_step: steps_config[step][:number], job_location: job_location, readable_job_location: readable_job_location)
   end
 
@@ -85,29 +85,29 @@ module Publishers::Wizardable
       status: @vacancy.status.blank? ? "draft" : nil,
     }
     params.require(:publishers_job_listing_job_details_form)
-          .permit(:state, :job_title, :suitable_for_nqt, :contract_type, :contract_type_duration, job_roles: [], working_patterns: [], subjects: [])
+          .permit(:job_title, :suitable_for_nqt, :contract_type, :contract_type_duration, job_roles: [], working_patterns: [], subjects: [])
           .merge(attributes_to_merge.compact)
   end
 
   def pay_package_params(params)
     params.require(:publishers_job_listing_pay_package_form)
-          .permit(:state, :salary, :benefits).merge(completed_step: steps_config[step][:number])
+          .permit(:salary, :benefits).merge(completed_step: steps_config[step][:number])
   end
 
   def important_dates_params(params)
     params.require(:publishers_job_listing_important_dates_form)
-          .permit(:state, :starts_asap, :starts_on, :publish_on, :expires_on,
+          .permit(:starts_asap, :starts_on, :publish_on, :expires_on,
                   :expires_at, :expires_at_hh, :expires_at_mm, :expires_at_meridiem).merge(completed_step: steps_config[step][:number])
   end
 
   def applying_for_the_job_params(params)
     params.require(:publishers_job_listing_applying_for_the_job_form)
-          .permit(:state, :application_link, :enable_job_applications, :contact_email, :contact_number, :personal_statement_guidance, :school_visits, :how_to_apply)
+          .permit(:application_link, :enable_job_applications, :contact_email, :contact_number, :personal_statement_guidance, :school_visits, :how_to_apply)
           .merge(completed_step: steps_config[step][:number], current_organisation: current_organisation)
   end
 
   def job_summary_params(params)
     params.require(:publishers_job_listing_job_summary_form)
-          .permit(:state, :job_advert, :about_school).merge(completed_step: steps_config[step][:number])
+          .permit(:job_advert, :about_school).merge(completed_step: steps_config[step][:number])
   end
 end

--- a/app/controllers/publishers/vacancies/base_controller.rb
+++ b/app/controllers/publishers/vacancies/base_controller.rb
@@ -26,9 +26,8 @@ class Publishers::Vacancies::BaseController < Publishers::BaseController
   def step_valid?(step_form)
     form = step_form.new(@vacancy.attributes.merge(current_organisation: current_organisation))
 
-    form.complete_and_valid?.tap do |valid|
+    form.complete_and_valid?.tap do
       @vacancy.errors.merge!(form.errors)
-      session[:current_step] = nil unless valid
     end
   end
 

--- a/app/controllers/publishers/vacancies/build_controller.rb
+++ b/app/controllers/publishers/vacancies/build_controller.rb
@@ -38,7 +38,7 @@ class Publishers::Vacancies::BuildController < Publishers::Vacancies::BaseContro
     elsif @form.complete_and_valid?
       update_vacancy
       if params[:commit] == t("buttons.update_job") ||
-         (params[:commit] == t("buttons.continue") && session[:current_step] == :review)
+         (params[:commit] == t("buttons.continue") && session[:current_step].in?(%i[edit_incomplete review]))
         update_listing
       else
         render_wizard @vacancy

--- a/app/controllers/publishers/vacancies/copy_controller.rb
+++ b/app/controllers/publishers/vacancies/copy_controller.rb
@@ -25,7 +25,7 @@ class Publishers::Vacancies::CopyController < Publishers::Vacancies::BaseControl
 
   def copy_form_params
     params.require(:publishers_job_listing_copy_vacancy_form)
-          .permit(:state, :job_title, :publish_on, :expires_on, :starts_on,
+          .permit(:job_title, :publish_on, :expires_on, :starts_on,
                   :expires_at_hh, :expires_at_mm, :expires_at_meridiem)
   end
 

--- a/app/form_models/publishers/job_listing/vacancy_form.rb
+++ b/app/form_models/publishers/job_listing/vacancy_form.rb
@@ -6,8 +6,6 @@ class Publishers::JobListing::VacancyForm
 
   delegate(*Vacancy.attribute_names.map { |attr| [attr, "#{attr}=", "#{attr}?"] }.flatten, to: :vacancy)
 
-  validates :state, inclusion: { in: %w[copy create edit edit_published review] }
-
   def initialize(params = {})
     @params = params
     @vacancy = Vacancy.new(params.except(:documents_attributes, :expires_at_hh, :expires_at_mm, :expires_at_meridiem, :current_organisation))

--- a/app/frontend/src/application/init.js
+++ b/app/frontend/src/application/init.js
@@ -4,19 +4,6 @@ import './publishers/init';
 import '../components/form/form';
 
 document.addEventListener('DOMContentLoaded', () => {
-  window.dataLayer = window.dataLayer || [];
-  dataLayer.push({ event: 'optimize.activate' });
-
-  dataLayer.push({
-    dePIIedURL: window.location.pathname,
-    event: 'parametersRemoved',
-  });
-
-  // will check with steven legg about this as if needs it need to add tests around it
-  const element = document.querySelector('.new_publishers_job_listing_copy_vacancy_form') || document.body || {};
-  const dataset = element.dataset || {};
-  dataLayer.push({ vacancy_state: dataset.vacancyState });
-
   // lint disabled as would require changes to library script
   new ClipboardJS('.copy-to-clipboard'); // eslint-disable-line
 

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -15,30 +15,16 @@ module VacanciesHelper
   end
 
   def page_title_prefix(vacancy, form_object, page_heading)
-    if %w[create review].include?(vacancy.state)
-      "#{form_object.errors.present? ? 'Error: ' : ''}#{page_heading} — #{t('jobs.create_a_job_title', organisation: current_organisation.name)}"
-    else
+    if vacancy.published?
       "#{form_object.errors.present? ? 'Error: ' : ''}Edit the #{page_heading}"
+    else
+      "#{form_object.errors.present? ? 'Error: ' : ''}#{page_heading} — #{t('jobs.create_a_job_title', organisation: current_organisation.name)}"
     end
   end
 
   def review_page_title_prefix(vacancy, organisation = current_organisation)
     page_title = t("jobs.review_page_title", organisation: organisation.name)
     "#{vacancy.errors.present? ? 'Error: ' : ''}#{page_title}"
-  end
-
-  def review_heading(vacancy)
-    return t("jobs.copy_review_heading") if vacancy.state == "copy"
-
-    t("jobs.review_heading")
-  end
-
-  def hidden_state_field_value(vacancy, copy: false)
-    return "copy" if copy
-    return "edit_published" if vacancy.published?
-    return vacancy.state if %w[copy review edit].include?(vacancy.state)
-
-    "create"
   end
 
   def back_to_manage_jobs_link(vacancy)

--- a/app/services/publish_vacancy.rb
+++ b/app/services/publish_vacancy.rb
@@ -11,7 +11,6 @@ class PublishVacancy
     vacancy.publisher_organisation = current_organisation
     vacancy.publisher = current_publisher
     vacancy.status = :published
-    vacancy.state = "edit_published"
     vacancy.save
   end
 end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -20,7 +20,7 @@ html.govuk-template.app-html-class lang="en"
     meta content=asset_pack_path("media/images/govuk-opengraph-image.png") property="og:image"
     = csrf_meta_tags
 
-  body class=body_class data-vacancy_state=(@vacancy.present? ? @vacancy.state : "create")
+  body class=body_class
     = render partial: "shared/google_tag_manager_body" if cookies["consented-to-cookies"] == "yes"
     = javascript_tag(nonce: true) do
       | document.body.className = ((document.body.className) ? document.body.className + " js-enabled" : "js-enabled");

--- a/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
+++ b/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
@@ -4,7 +4,7 @@
   .govuk-grid-row
     .govuk-grid-column-full
       = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy, process_steps.current_step_number, process_steps.total_steps)
-      = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: previous_wizard_path)
+      = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: previous_wizard_path, review: session[:current_step] == :review)
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
@@ -12,8 +12,6 @@
         = f.govuk_error_summary
 
         h2.govuk-heading-l = t("jobs.applying_for_the_job")
-
-        = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f
 
         - if JobseekerApplicationsFeature.enabled?
           - if @vacancy.listed? || current_organisation.local_authority?

--- a/app/views/publishers/vacancies/build/important_dates.html.slim
+++ b/app/views/publishers/vacancies/build/important_dates.html.slim
@@ -4,7 +4,7 @@
   .govuk-grid-row
     .govuk-grid-column-full
       = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy, process_steps.current_step_number, process_steps.total_steps)
-      = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: previous_wizard_path)
+      = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: previous_wizard_path, review: session[:current_step] == :review)
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
@@ -12,8 +12,6 @@
         = f.govuk_error_summary
 
         h2.govuk-heading-l = t("jobs.important_dates")
-
-        = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f
 
         - if @form.disable_editing_publish_on?
           #publish_on

--- a/app/views/publishers/vacancies/build/job_details.html.slim
+++ b/app/views/publishers/vacancies/build/job_details.html.slim
@@ -4,7 +4,7 @@
   .govuk-grid-row
     .govuk-grid-column-full
       = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy, process_steps.current_step_number, process_steps.total_steps)
-      = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: @job_details_back_path, current_step_is_first_step: current_organisation.school?)
+      = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: current_organisation.school? ? nil : @job_details_back_path, current_step_is_first_step: current_organisation.school?, review: session[:current_step] == :review)
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
@@ -12,8 +12,6 @@
         = f.govuk_error_summary
 
         h2.govuk-heading-l = t("jobs.job_details")
-
-        = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f
 
         .govuk-character-count data-module="govuk-character-count" data-maxlength=100
           = f.govuk_text_field :job_title,

--- a/app/views/publishers/vacancies/build/job_location.html.slim
+++ b/app/views/publishers/vacancies/build/job_location.html.slim
@@ -4,7 +4,7 @@
   .govuk-grid-row
     .govuk-grid-column-full
       = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy, process_steps.current_step_number, process_steps.total_steps)
-      = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, current_step_is_first_step: true)
+      = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, current_step_is_first_step: true, review: session[:current_step] == :review)
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
@@ -12,8 +12,6 @@
         = f.govuk_error_summary
 
         h2.govuk-heading-l = t("jobs.job_location")
-
-        = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f
 
         = f.govuk_collection_radio_buttons :job_location, t("helpers.options.publishers_job_listing_job_location_form.job_location.#{current_organisation.group_type}"), :first, :last
 

--- a/app/views/publishers/vacancies/build/job_summary.html.slim
+++ b/app/views/publishers/vacancies/build/job_summary.html.slim
@@ -4,7 +4,7 @@
   .govuk-grid-row
     .govuk-grid-column-full
       = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy, process_steps.current_step_number, process_steps.total_steps)
-      = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: previous_wizard_path)
+      = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: previous_wizard_path, review: session[:current_step] == :review)
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
@@ -12,8 +12,6 @@
         = f.govuk_error_summary
 
         h2.govuk-heading-l = t("jobs.job_summary")
-
-        = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f
 
         = f.govuk_text_area :job_advert, label: { size: "s" }, rows: 10, required: true
 

--- a/app/views/publishers/vacancies/build/pay_package.html.slim
+++ b/app/views/publishers/vacancies/build/pay_package.html.slim
@@ -4,7 +4,7 @@
   .govuk-grid-row
     .govuk-grid-column-full
       = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy, process_steps.current_step_number, process_steps.total_steps)
-      = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: previous_wizard_path)
+      = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: previous_wizard_path, review: session[:current_step] == :review)
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
@@ -12,8 +12,6 @@
         = f.govuk_error_summary
 
         h2.govuk-heading-l = t("jobs.pay_package")
-
-        = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f
 
         = f.govuk_text_field :salary, label: { size: "s" }, required: true
 

--- a/app/views/publishers/vacancies/build/schools.html.slim
+++ b/app/views/publishers/vacancies/build/schools.html.slim
@@ -4,7 +4,7 @@
   .govuk-grid-row
     .govuk-grid-column-full
       = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy, process_steps.current_step_number, process_steps.total_steps)
-      = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: previous_wizard_path)
+      = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: previous_wizard_path, review: session[:current_step] == :review)
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
@@ -12,8 +12,6 @@
         = f.govuk_error_summary
 
         h2.govuk-heading-l = t("jobs.job_location")
-
-        = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f
 
         = f.govuk_fieldset legend: { text: t("helpers.legend.publishers_job_listing_schools_form.organisation_id#{'s' if @multiple_schools}") } do
           - if current_organisation.local_authority?

--- a/app/views/publishers/vacancies/copy/new.html.slim
+++ b/app/views/publishers/vacancies/copy/new.html.slim
@@ -7,12 +7,10 @@
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      = form_for @copy_form, url: organisation_job_copy_path, data: { vacancy_state: "copy" } do |f|
+      = form_for @copy_form, url: organisation_job_copy_path do |f|
         = f.govuk_error_summary
 
         h2.govuk-heading-l = t("jobs.new_job_listing_details")
-
-        = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f, copy: true
 
         .govuk-character-count data-module="govuk-character-count" data-maxlength=100
           = f.govuk_text_field :job_title,

--- a/app/views/publishers/vacancies/documents/show.html.slim
+++ b/app/views/publishers/vacancies/documents/show.html.slim
@@ -4,7 +4,7 @@
   .govuk-grid-row
     .govuk-grid-column-full
       = render Publishers::VacancyFormPageHeadingComponent.new(@vacancy, process_steps.current_step_number, process_steps.total_steps)
-      = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: organisation_job_build_path(@vacancy.id, :important_dates))
+      = render Publishers::VacancyWizardBackLinkComponent.new(@vacancy, previous_step_path: organisation_job_build_path(@vacancy.id, :important_dates), review: session[:current_step] == :review)
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
@@ -13,8 +13,6 @@
 
         h2.govuk-heading-l
           = t("jobs.supporting_documents")
-
-        = render "publishers/vacancies/vacancy_form_partials/hidden_state_input", f: f
 
         #js-xhr-flashes
 

--- a/app/views/publishers/vacancies/edit.html.slim
+++ b/app/views/publishers/vacancies/edit.html.slim
@@ -7,7 +7,7 @@
 
   .vacancy.govuk-grid-row
     .govuk-grid-column-two-thirds
-      h2.govuk-heading-l = review_heading(@vacancy)
+      h2.govuk-heading-l = t("jobs.review_heading")
       = render "publishers/vacancies/error_messages", errors: @vacancy.errors
 
       ol.app-task-list

--- a/app/views/publishers/vacancies/review.html.slim
+++ b/app/views/publishers/vacancies/review.html.slim
@@ -7,7 +7,7 @@
 
   .vacancy.govuk-grid-row
     .govuk-grid-column-two-thirds
-      h2.govuk-heading-l = review_heading(@vacancy)
+      h2.govuk-heading-l = t("jobs.review_heading")
       = render "publishers/vacancies/error_messages", errors: @vacancy.errors
 
       p.govuk-body-l

--- a/app/views/publishers/vacancies/vacancy_form_partials/_continue_or_update_submit.html.slim
+++ b/app/views/publishers/vacancies/vacancy_form_partials/_continue_or_update_submit.html.slim
@@ -1,4 +1,4 @@
-- if @vacancy.published? || %w[copy edit edit_published review].include?(@vacancy.state)
-  = f.govuk_submit t("buttons.update_job"), classes: "update-listing-gtm disabled-on-load"
+- if @vacancy.published? || session[:current_step] == :review
+  = f.govuk_submit t("buttons.update_job"), classes: "update-listing-gtm"
 - else
   = f.govuk_submit t("buttons.continue"), classes: "govuk-!-margin-bottom-5 save-listing-gtm"

--- a/app/views/publishers/vacancies/vacancy_form_partials/_hidden_state_input.html.slim
+++ b/app/views/publishers/vacancies/vacancy_form_partials/_hidden_state_input.html.slim
@@ -1,2 +1,0 @@
-- copy = false if local_assigns[:copy].nil?
-= f.hidden_field :state, value: hidden_state_field_value(@vacancy, copy: copy)

--- a/app/views/publishers/vacancies/vacancy_form_partials/_save_and_return_submit.html.slim
+++ b/app/views/publishers/vacancies/vacancy_form_partials/_save_and_return_submit.html.slim
@@ -1,2 +1,2 @@
-- unless @vacancy.published? || %w[copy edit edit_published review].include?(@vacancy.state)
+- unless @vacancy.published?
   = f.govuk_submit t("buttons.save_and_return_later"), secondary: true, classes: "button-link save-and-return-listing-gtm"

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -158,7 +158,6 @@ en:
     new_job_listing_details: New job listing details
     review_page_title: Review the job listing — Create a job listing for %{organisation}
     review_heading: Review the job listing
-    copy_review_heading: Review the new job listing
     edit_job_title: Edit %{job_title}
     current_step: Step %{step} of %{total}
 

--- a/db/migrate/20210520225531_remove_state_from_vacancies.rb
+++ b/db/migrate/20210520225531_remove_state_from_vacancies.rb
@@ -1,0 +1,5 @@
+class RemoveStateFromVacancies < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :vacancies, :state
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_18_143454) do
+ActiveRecord::Schema.define(version: 2021_05_20_225531) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -442,7 +442,6 @@ ActiveRecord::Schema.define(version: 2021_05_18_143454) do
     t.integer "completed_step"
     t.string "legacy_job_roles", array: true
     t.text "about_school"
-    t.string "state", default: "create"
     t.string "subjects", array: true
     t.text "school_visits"
     t.text "how_to_apply"

--- a/spec/components/publishers/vacancy_form_page_heading_component_spec.rb
+++ b/spec/components/publishers/vacancy_form_page_heading_component_spec.rb
@@ -2,11 +2,8 @@ require "rails_helper"
 
 RSpec.describe Publishers::VacancyFormPageHeadingComponent, type: :component do
   let(:organisation) { create(:school, name: "Teaching Vacancies Academy") }
-  let(:state) { "create" }
-  let(:vacancy) { create(:vacancy, state: state, job_title: "Test job title") }
-  let(:session_job_location) { nil }
-  let(:session_readable_job_location) { nil }
-  let(:session_vacancy_attributes) { { "job_location" => session_job_location, "readable_job_location" => session_readable_job_location } }
+  let(:vacancy) { create(:vacancy, status, job_title: "Test job title") }
+  let(:status) { :published }
   let(:current_step) { 1 }
   let(:current_publisher_is_part_of_school_group?) { true }
   let(:steps_adjust) { current_publisher_is_part_of_school_group? ? 0 : 1 }
@@ -28,18 +25,16 @@ RSpec.describe Publishers::VacancyFormPageHeadingComponent, type: :component do
     render_inline(subject)
   end
 
-  describe "#show_current_step?" do
-    context "when vacancy state is create or review" do
-      let(:state) { "create" }
+  describe "caption" do
+    context "when vacancy is not published" do
+      let(:status) { :draft }
 
       it "shows the current step" do
         expect(rendered_component).to include(I18n.t("jobs.current_step", step: current_step, total: 2))
       end
     end
 
-    context "when vacancy state is not create or review" do
-      let(:state) { "copy" }
-
+    context "when vacancy is published" do
       it "does not show the current step" do
         expect(rendered_component).not_to include("Step")
       end
@@ -47,51 +42,17 @@ RSpec.describe Publishers::VacancyFormPageHeadingComponent, type: :component do
   end
 
   describe "#heading" do
-    let(:state) { "copy" }
-
-    context "when a published vacancy is being edited" do
-      let(:vacancy) { create(:vacancy, :published, state: "edit", job_title: "Test job title") }
-
+    context "when the vacancy is published" do
       it "returns edit job title" do
         expect(rendered_component).to include(I18n.t("jobs.edit_job_title", job_title: "Test job title"))
       end
     end
 
     context "when the vacancy is not published" do
-      before { allow(vacancy).to receive(:published?).and_return(false) }
+      let(:status) { :draft }
 
-      context "when the vacancy state is edit" do
-        let(:state) { "edit" }
-
-        before { allow(vacancy).to receive(:published?).and_return(false) }
-
-        it "returns edit job title" do
-          expect(rendered_component).to include(I18n.t("jobs.edit_job_title", job_title: "Test job title"))
-        end
-      end
-
-      context "when vacancy state is copy" do
-        let(:state) { "copy" }
-
-        it "returns copy job title " do
-          expect(rendered_component).to include(I18n.t("jobs.copy_job_title", job_title: "Test job title"))
-        end
-      end
-
-      context "when vacancy state is create" do
-        let(:state) { "create" }
-
-        it "returns create a job title" do
-          expect(rendered_component).to include(I18n.t("jobs.create_a_job_title", organisation: "Teaching Vacancies Academy"))
-        end
-      end
-
-      context "when vacancy state is review" do
-        let(:state) { "review" }
-
-        it "returns create a job title" do
-          expect(rendered_component).to include(I18n.t("jobs.create_a_job_title", organisation: "Teaching Vacancies Academy"))
-        end
+      it "returns create a job title" do
+        expect(rendered_component).to include(I18n.t("jobs.create_a_job_title", organisation: "Teaching Vacancies Academy"))
       end
     end
   end

--- a/spec/components/publishers/vacancy_wizard_back_link_component_spec.rb
+++ b/spec/components/publishers/vacancy_wizard_back_link_component_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Publishers::VacancyWizardBackLinkComponent, type: :component do
-  subject { described_class.new(vacancy, previous_step_path: previous_step_path, current_step_is_first_step: current_step_is_first_step) }
+  subject { described_class.new(vacancy, previous_step_path: previous_step_path, current_step_is_first_step: current_step_is_first_step, review: current_step_is_review) }
 
   let(:previous_step_path) { "/some/where" }
 
@@ -10,7 +10,8 @@ RSpec.describe Publishers::VacancyWizardBackLinkComponent, type: :component do
   end
 
   context "when the vacancy is first being created" do
-    let(:vacancy) { build_stubbed(:vacancy, state: "create") }
+    let(:vacancy) { build_stubbed(:vacancy, :draft) }
+    let(:current_step_is_review) { false }
 
     context "when the current step is the first step" do
       let(:current_step_is_first_step) { true }
@@ -31,8 +32,9 @@ RSpec.describe Publishers::VacancyWizardBackLinkComponent, type: :component do
   end
 
   context "when the vacancy has already been fully created" do
-    let(:vacancy) { create(:vacancy, id: 3, state: "review", status: status) }
+    let(:vacancy) { create(:vacancy, status: status) }
     let(:current_step_is_first_step) { false }
+    let(:current_step_is_review) { true }
 
     context "when the vacancy is already published" do
       let(:status) { :published }

--- a/spec/components/shared/process_steps_component_spec.rb
+++ b/spec/components/shared/process_steps_component_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Shared::ProcessStepsComponent, type: :component do
-  let(:vacancy) { create(:vacancy, completed_step: completed_step) }
+  let(:vacancy) { create(:vacancy, :draft, completed_step: completed_step) }
   let(:completed_step) { 0 }
   let(:current_step_number) { 1 }
   let(:current_organisation) { build(:school_group) }

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     about_school { "Great school with amazing people" }
     enable_job_applications { true }
     benefits { Faker::Lorem.paragraph(sentence_count: 4) }
+    completed_step { 7 }
     contact_email { Faker::Internet.email }
     contact_number { "01234 123456" }
     contract_type { :fixed_term }
@@ -25,7 +26,6 @@ FactoryBot.define do
     publish_on { Date.current }
     salary { Faker::Lorem.sentence[1...30].strip }
     school_visits { Faker::Lorem.paragraph(sentence_count: 4) }
-    state { "create" }
     starts_on { Date.current + 1.year }
     status { :published }
     subjects { SUBJECT_OPTIONS.sample(2).map(&:first).sort! }

--- a/spec/form_models/publishers/job_listing/important_dates_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/important_dates_form_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
   context "when all attributes are valid" do
     let(:params) do
       {
-        state: "create", expires_on: 1.week.from_now, publish_on: Date.current,
+        expires_on: 1.week.from_now, publish_on: Date.current,
         starts_on: 1.month.from_now, expires_at_hh: "9", expires_at_mm: "1", expires_at_meridiem: "am"
       }
     end

--- a/spec/helpers/vacancies_helper_spec.rb
+++ b/spec/helpers/vacancies_helper_spec.rb
@@ -1,59 +1,6 @@
 require "rails_helper"
 
 RSpec.describe VacanciesHelper do
-  describe "#review_heading" do
-    let(:vacancy) { double("vacancy").as_null_object }
-
-    it "returns copy review heading if vacancy state is copy" do
-      allow(vacancy).to receive(:published?).and_return(false)
-      allow(vacancy).to receive(:state).and_return("copy")
-
-      expect(review_heading(vacancy)).to eq(I18n.t("jobs.copy_review_heading"))
-    end
-
-    it "returns review heading" do
-      allow(vacancy).to receive(:published?).and_return(false)
-      allow(vacancy).to receive(:state).and_return("not_copy_review")
-
-      expect(review_heading(vacancy)).to eq(I18n.t("jobs.review_heading"))
-    end
-  end
-
-  describe "#hidden_state_field_value" do
-    let(:vacancy) { double("vacancy").as_null_object }
-
-    before do
-      allow(vacancy).to receive(:published?).and_return(nil)
-      allow(vacancy).to receive(:state).and_return(nil)
-    end
-
-    it "returns copy if copy true" do
-      expect(hidden_state_field_value(vacancy, copy: true)).to eq("copy")
-    end
-
-    it "returns edit_published if published vacancy" do
-      allow(vacancy).to receive(:published?).and_return(true)
-      expect(hidden_state_field_value(vacancy)).to eq("edit_published")
-    end
-
-    it "returns current state if vacancy state is copy/review/edit" do
-      allow(vacancy).to receive(:published?).and_return(false)
-
-      allow(vacancy).to receive(:state).and_return("copy")
-      expect(hidden_state_field_value(vacancy)).to eq("copy")
-
-      allow(vacancy).to receive(:state).and_return("review")
-      expect(hidden_state_field_value(vacancy)).to eq("review")
-
-      allow(vacancy).to receive(:state).and_return("edit")
-      expect(hidden_state_field_value(vacancy)).to eq("edit")
-    end
-
-    it "returns create" do
-      expect(hidden_state_field_value(vacancy)).to eq("create")
-    end
-  end
-
   describe "#back_to_manage_jobs_link" do
     let(:vacancy) { double("vacancy").as_null_object }
 

--- a/spec/system/hiring_staff_can_copy_a_vacancy_spec.rb
+++ b/spec/system/hiring_staff_can_copy_a_vacancy_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "Copying a vacancy" do
     click_on I18n.t("buttons.continue")
 
     within("h2.govuk-heading-l") do
-      expect(page).to have_content(I18n.t("jobs.copy_review_heading"))
+      expect(page).to have_content(I18n.t("jobs.review_heading"))
     end
     click_on I18n.t("buttons.submit_job_listing")
 
@@ -121,25 +121,11 @@ RSpec.describe "Copying a vacancy" do
       fill_in_copy_vacancy_form_fields(new_vacancy)
       click_on I18n.t("buttons.continue")
 
-      within("h2.govuk-heading-l") do
-        expect(page).to have_content(I18n.t("jobs.copy_review_heading"))
-      end
-
-      expect(page).to have_content(I18n.t("messages.jobs.action_required.heading"))
-      expect(page).to have_content(I18n.t("messages.jobs.action_required.message"))
-      expect(page).to have_content(I18n.t("job_summary_errors.about_school.blank", organisation: "school"))
-
-      click_on I18n.t("buttons.submit_job_listing")
-      expect(page).to have_content(I18n.t("messages.jobs.action_required.heading"))
-      expect(page).to have_content(I18n.t("messages.jobs.action_required.message"))
-      expect(page).to have_content(I18n.t("job_summary_errors.about_school.blank", organisation: "school"))
-
-      click_header_link(I18n.t("jobs.job_summary"))
       fill_in "publishers_job_listing_job_summary_form[about_school]", with: "Some description about the school"
-      click_on I18n.t("buttons.update_job")
+      click_on I18n.t("buttons.continue")
 
       within("h2.govuk-heading-l") do
-        expect(page).to have_content(I18n.t("jobs.copy_review_heading"))
+        expect(page).to have_content(I18n.t("jobs.review_heading"))
       end
       expect(page).to have_content("Some description about the school")
 
@@ -168,7 +154,7 @@ RSpec.describe "Copying a vacancy" do
       click_on I18n.t("buttons.continue")
 
       within("h2.govuk-heading-l") do
-        expect(page).to have_content(I18n.t("jobs.copy_review_heading"))
+        expect(page).to have_content(I18n.t("jobs.review_heading"))
       end
     end
   end
@@ -199,7 +185,7 @@ RSpec.describe "Copying a vacancy" do
       click_on I18n.t("buttons.continue")
 
       within("h2.govuk-heading-l") do
-        expect(page).to have_content(I18n.t("jobs.copy_review_heading"))
+        expect(page).to have_content(I18n.t("jobs.review_heading"))
       end
     end
   end

--- a/spec/system/hiring_staff_can_edit_a_draft_vacancy_as_a_school_spec.rb
+++ b/spec/system/hiring_staff_can_edit_a_draft_vacancy_as_a_school_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+
 RSpec.describe "Hiring staff can edit a draft vacancy" do
   let(:publisher) { create(:publisher) }
   let(:school) { create(:school) }
@@ -171,15 +172,6 @@ RSpec.describe "Hiring staff can edit a draft vacancy" do
     let(:vacancy) { create(:vacancy, :draft) }
 
     before { vacancy.organisation_vacancies.create(organisation: school) }
-
-    scenario "vacancy state is edit" do
-      visit organisation_job_review_path(vacancy.id, edit_draft: true)
-
-      expect(Vacancy.last.state).to eq("edit")
-      within("h2.govuk-heading-l") do
-        expect(page).to have_content(I18n.t("jobs.review_heading"))
-      end
-    end
 
     describe "#cancel_and_return_later" do
       scenario "can cancel and return from job details page" do

--- a/spec/system/hiring_staff_can_edit_a_published_vacancy_as_a_school_spec.rb
+++ b/spec/system/hiring_staff_can_edit_a_published_vacancy_as_a_school_spec.rb
@@ -58,14 +58,6 @@ RSpec.describe "Hiring staff can edit a vacancy" do
       end
     end
 
-    scenario "vacancy state is edit_published" do
-      visit edit_organisation_job_path(vacancy.id)
-      expect(Vacancy.last.state).to eq("edit_published")
-
-      click_header_link(I18n.t("jobs.job_details"))
-      expect(Vacancy.last.state).to eq("edit_published")
-    end
-
     scenario "create a job sidebar is not present" do
       visit edit_organisation_job_path(vacancy.id)
 

--- a/spec/system/hiring_staff_can_publish_a_vacancy_as_a_school_spec.rb
+++ b/spec/system/hiring_staff_can_publish_a_vacancy_as_a_school_spec.rb
@@ -95,16 +95,6 @@ RSpec.describe "Creating a vacancy" do
           expect(Vacancy.last.job_roles).to include("nqt_suitable")
         end
       end
-
-      scenario "vacancy state is create" do
-        visit organisation_path
-        click_on I18n.t("buttons.create_job")
-
-        fill_in_job_details_form_fields(vacancy)
-        click_on I18n.t("buttons.continue")
-
-        expect(Vacancy.last.state).to eq("create")
-      end
     end
 
     describe "#pay_package" do
@@ -507,79 +497,6 @@ RSpec.describe "Creating a vacancy" do
           within("h2.govuk-heading-l") do
             expect(page).to have_content(I18n.t("jobs.job_summary"))
           end
-        end
-
-        scenario "vacancy state is review when all steps completed" do
-          visit organisation_path
-          click_on I18n.t("buttons.create_job")
-
-          fill_in_job_details_form_fields(vacancy)
-          click_on I18n.t("buttons.continue")
-
-          fill_in_pay_package_form_fields(vacancy)
-          click_on I18n.t("buttons.continue")
-
-          fill_in_important_dates_fields(vacancy)
-          click_on I18n.t("buttons.continue")
-
-          click_on I18n.t("buttons.continue")
-
-          fill_in_applying_for_the_job_form_fields(vacancy)
-          click_on I18n.t("buttons.continue")
-
-          fill_in_job_summary_form_fields(vacancy)
-          click_on I18n.t("buttons.continue")
-
-          expect(Vacancy.last.state).to eq("review")
-          expect(page).to have_content(I18n.t("jobs.current_step", step: 7, total: 7))
-          within("h2.govuk-heading-l") do
-            expect(page).to have_content(I18n.t("jobs.review_heading"))
-          end
-        end
-
-        scenario "vacancy state is review" do
-          visit organisation_path
-          click_on I18n.t("buttons.create_job")
-
-          fill_in_job_details_form_fields(vacancy)
-          click_on I18n.t("buttons.continue")
-
-          fill_in_pay_package_form_fields(vacancy)
-          click_on I18n.t("buttons.continue")
-
-          fill_in_important_dates_fields(vacancy)
-          click_on I18n.t("buttons.continue")
-
-          click_on I18n.t("buttons.continue")
-
-          fill_in_applying_for_the_job_form_fields(vacancy)
-          click_on I18n.t("buttons.continue")
-
-          fill_in_job_summary_form_fields(vacancy)
-          click_on I18n.t("buttons.continue")
-
-          expect(Vacancy.last.state).to eq("review")
-          expect(page).to have_content(I18n.t("jobs.current_step", step: 7, total: 7))
-          within("h2.govuk-heading-l") do
-            expect(page).to have_content(I18n.t("jobs.review_heading"))
-          end
-
-          click_header_link(I18n.t("jobs.applying_for_the_job"))
-          expect(page).to have_content(I18n.t("jobs.current_step", step: 5, total: 7))
-          within("h2.govuk-heading-l") do
-            expect(page).to have_content(I18n.t("jobs.applying_for_the_job"))
-          end
-          expect(Vacancy.last.state).to eq("review")
-
-          click_on I18n.t("buttons.update_job")
-          expect(Vacancy.last.state).to eq("review")
-
-          click_header_link(I18n.t("jobs.job_details"))
-          expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 7))
-          within("h2.govuk-heading-l") do
-            expect(page).to have_content(I18n.t("jobs.job_details"))
-          end
-          expect(Vacancy.last.state).to eq("review")
         end
       end
 


### PR DESCRIPTION
This field initially arose from a performance analysis need, and ended up being used for things it shouldn't have.
This need no longer exists, so we should remove the field.
This PR does that, but prioritises maintaining functionality over code quality.

This is part of a wider refactor around the create a job journey.

## Changes in this PR
- Remove vacancy state