### PR TITLE
Refactor Active Storage migration into a job

### DIFF
--- a/app/jobs/migrate_document_to_active_storage_job.rb
+++ b/app/jobs/migrate_document_to_active_storage_job.rb
@@ -1,0 +1,68 @@
+class MigrateDocumentToActiveStorageJob < ApplicationJob
+  class MigrationIntegrityError < RuntimeError; end
+
+  queue_as :low
+  discard_on MigrationIntegrityError
+
+  def perform(document_id)
+    document = Document.includes(:vacancy).find(document_id)
+
+    if existing_attachment?(document)
+      Rails.logger.info("Skipped migrating document #{document_id} as it already exists in AS")
+      return
+    end
+
+    Rails.logger.info("Migrating document #{document.id} (GDrive ID: #{document.google_drive_id})")
+
+    Tempfile.create(binmode: true) do |local_file|
+      # Download file from Google Drive into the tempfile
+      drive_service.get_file(
+        document.google_drive_id,
+        download_dest: local_file.path,
+      )
+
+      EventContext.suppress_events do
+        # Attach file to the vacancy's supporting documents using ActiveStorage
+        document.vacancy.supporting_documents.attach(
+          io: local_file,
+          filename: document.name,
+          content_type: document.content_type,
+        )
+      end
+    end
+
+    # Verify the attachment was successful by trying to find it again
+    fail_integrity_check!(document) unless existing_attachment?(document)
+  end
+
+  private
+
+  def existing_attachment?(document)
+    document.vacancy.supporting_documents.reload.any? do |supporting_doc|
+      supporting_doc.filename == document.name &&
+        supporting_doc.byte_size == document.size &&
+        supporting_doc.content_type == document.content_type
+    end
+  end
+
+  def fail_integrity_check!(document)
+    doc_details = document.vacancy.supporting_documents.map do |sd|
+      "#{sd.filename} (size: #{sd.byte_size}, type: #{sd.content_type}"
+    end
+
+    Rollbar.error(
+      "Failed to verify integrity of migrated document #{document_id}",
+      vacancy: document.vacancy_id,
+      google_drive_id: doc.google_drive_id,
+      document_name: document.name,
+      document_size: document.size,
+      document_content_type: document.content_type,
+      supporting_documents_details: doc_details,
+    )
+    raise MigrationIntegrityError
+  end
+
+  def drive_service
+    @drive_service = Google::Apis::DriveV3::DriveService.new
+  end
+end

--- a/app/models/event_context.rb
+++ b/app/models/event_context.rb
@@ -1,8 +1,19 @@
 class EventContext < ActiveSupport::CurrentAttributes
   attribute :request_event
+  attribute :events_suppressed
+
+  # Stop sending events in the current context for the duration of a block
+  # (useful for situations where records are updated programatically, e.g. in background jobs,
+  # and we don't want to send events)
+  def suppress_events
+    self.events_suppressed = true
+    yield
+    self.events_suppressed = false
+  end
 
   def trigger_event(event_type, data = {})
     return unless Rails.configuration.analytics.key?(data[:table_name].to_sym)
+    return if events_suppressed
 
     event.trigger(event_type, data)
   end

--- a/spec/sidekiq/sidekiq_spec.rb
+++ b/spec/sidekiq/sidekiq_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "Sidekiq configuration" do
   let(:unscheduled_jobs) do
     %w[
       AlertEmail::Base
+      MigrateDocumentToActiveStorageJob
       PerformancePlatformTransactionsQueueJob
       PersistVacancyGetMoreInfoClickJob
       PersistVacancyPageViewJob


### PR DESCRIPTION
Our nice-and-simple approach didn't work, so this makes it a bit more
"enterprise".

- Move migration of documents into a job, and change the original Rake
  task to simply kick off one job per document
- Add integrity checks in the job to make sure we've actually
  successfully migrated the document
- Add a new Rake task `verify_migration` to verify documents and
  supporting documents match after migration
- Add `EventContext#suppress_events!` to make sure we don't fire events
  when all we're doing is programatically updating something