### PR TITLE
Remove state from analytics.yml

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -295,7 +295,6 @@ shared:
     - completed_step
     - legacy_job_roles
     - about_school
-    - state
     - subjects
     - school_visits
     - how_to_apply


### PR DESCRIPTION
## Changes in this PR:

- The state field has been removed from the data model. This PR removes it from streamed vacancy entity events so that analytics.yml isn't misleading.