### PR TITLE
Do not refer to ActionMailer::Base in initializers

### DIFF
--- a/config/initializers/default_url_options.rb
+++ b/config/initializers/default_url_options.rb
@@ -7,6 +7,7 @@ default_domains = {
 DOMAIN = ENV.fetch("DOMAIN") { default_domains[Rails.env.to_sym] }
 domain = URI(DOMAIN)
 protocol = Rails.application.config.force_ssl ? "https" : "http"
+url_options = { protocol: protocol, host: domain.to_s }
 
-ActionMailer::Base.default_url_options = { protocol: protocol, host: domain.to_s }
-Rails.application.routes.default_url_options = ActionMailer::Base.default_url_options
+Rails.configuration.action_mailer.default_url_options = url_options
+Rails.application.routes.default_url_options = url_options


### PR DESCRIPTION
This causes issues with autoloading (invoking behaviour that has been
deprecated in Zeitwerk when certain stars align, in our case if we add
ActionText, c.f. https://github.com/rails/rails/issues/36546)

Instead of adding configuration to `ActionMailer::Base`, set it on
`Rails.configuration.action_mailer` instead.