### PR TITLE
[TEVA-2682] Allow `&` character to be in title and salary field

### DIFF
--- a/app/form_models/publishers/job_listing/copy_vacancy_form.rb
+++ b/app/form_models/publishers/job_listing/copy_vacancy_form.rb
@@ -10,7 +10,8 @@ class Publishers::JobListing::CopyVacancyForm < Publishers::JobListing::Importan
   private
 
   def job_title_has_no_tags?
-    return if job_title == sanitize(job_title, tags: [])
+    job_title_without_escaped_characters = job_title.delete("&")
+    return if job_title_without_escaped_characters == sanitize(job_title_without_escaped_characters, tags: [])
 
     errors.add(:job_title, I18n.t("job_details_errors.job_title.invalid_characters"))
   end

--- a/app/form_models/publishers/job_listing/job_details_form.rb
+++ b/app/form_models/publishers/job_listing/job_details_form.rb
@@ -15,7 +15,8 @@ class Publishers::JobListing::JobDetailsForm < Publishers::JobListing::VacancyFo
   validates :contract_type_duration, presence: true, if: -> { contract_type == "fixed_term" }
 
   def job_title_has_no_tags?
-    return if job_title == sanitize(job_title, tags: [])
+    job_title_without_escaped_characters = job_title.delete("&")
+    return if job_title_without_escaped_characters == sanitize(job_title_without_escaped_characters, tags: [])
 
     errors.add(:job_title, I18n.t("job_details_errors.job_title.invalid_characters"))
   end

--- a/app/form_models/publishers/job_listing/pay_package_form.rb
+++ b/app/form_models/publishers/job_listing/pay_package_form.rb
@@ -8,7 +8,8 @@ class Publishers::JobListing::PayPackageForm < Publishers::JobListing::VacancyFo
   validate :salary_has_no_tags?, if: proc { salary.present? }
 
   def salary_has_no_tags?
-    return if salary == sanitize(salary, tags: [])
+    salary_without_escaped_characters = salary.delete("&")
+    return if salary_without_escaped_characters == sanitize(salary_without_escaped_characters, tags: [])
 
     errors.add(:salary, I18n.t("pay_package_errors.salary.invalid_characters"))
   end


### PR DESCRIPTION
## Jira ticket
https://dfedigital.atlassian.net/browse/TEVA-2682

## Screenshots of UI changes:
![image](https://user-images.githubusercontent.com/7215/119520640-5f6f8e80-bd72-11eb-83de-f32f0747b08f.png)
![image](https://user-images.githubusercontent.com/7215/119526454-4fa67900-bd77-11eb-957e-3898e9d94d34.png)
