### PR TITLE
Miscellaneous ActiveStorage preparation

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -66,6 +66,9 @@ module TeacherVacancyService
       api_key: ENV["NOTIFY_KEY"],
     }
 
+    config.active_storage.routes_prefix = "/attachments"
+    config.active_storage.resolve_model_to_route = :rails_storage_proxy
+
     # Set up backing services through VCAP_SERVICES if running on Cloudfoundry (GOV.UK PaaS)
     if ENV["VCAP_SERVICES"].present?
       vcap_services = VcapServices.new(ENV["VCAP_SERVICES"])
@@ -98,5 +101,11 @@ module TeacherVacancyService
     config.view_component.preview_route = "/components"
     config.view_component.preview_controller = "PreviewsController"
     config.view_component.show_previews = true
+
+    config.after_initialize do |app|
+      # Catch-all 404 route
+      # Defined here instead of routes.rb to ensure it doesn't override gem/engine routes
+      app.routes.append { match "*path", to: "errors#not_found", via: :all }
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -191,6 +191,4 @@ Rails.application.routes.draw do
         to: "vacancies#index", as: :subject, via: :get,
         constraints: ->(request) { SUBJECT_OPTIONS.map(&:first).include?(request.params[:subject]) },
         defaults: { pretty: :subject }
-
-  match "*path", to: "errors#not_found", via: :all
 end


### PR DESCRIPTION
- Append catch-all 404 route in `after_initialize` block instead of
  having it at the end of routes.rb (so it doesn't override routes
  added by engines such as ActiveStorage)
- Proxy ActiveStorage downloads through the application (so we can
  cache them more easily later)
- Change routes prefix to `/attachments` (because it looks nicer)