### PR TITLE
Fix Indentation

### DIFF
--- a/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
+++ b/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
@@ -46,6 +46,6 @@
 
         = render "publishers/vacancies/vacancy_form_partials/submit", f: f
 
-  - unless vacancy.published?
-    .govuk-grid-column-one-third
-      = render "steps"
+    - unless vacancy.published?
+      .govuk-grid-column-one-third
+        = render "steps"

--- a/app/views/publishers/vacancies/build/important_dates.html.slim
+++ b/app/views/publishers/vacancies/build/important_dates.html.slim
@@ -39,6 +39,6 @@
 
         = render "publishers/vacancies/vacancy_form_partials/submit", f: f
 
-  - unless vacancy.published?
-    .govuk-grid-column-one-third
-      = render "steps"
+    - unless vacancy.published?
+      .govuk-grid-column-one-third
+        = render "steps"

--- a/app/views/publishers/vacancies/build/job_details.html.slim
+++ b/app/views/publishers/vacancies/build/job_details.html.slim
@@ -55,6 +55,6 @@
 
         = render "publishers/vacancies/vacancy_form_partials/submit", f: f
 
-  - unless vacancy.published?
-    .govuk-grid-column-one-third
-      = render "steps"
+    - unless vacancy.published?
+      .govuk-grid-column-one-third
+        = render "steps"

--- a/app/views/publishers/vacancies/build/job_location.html.slim
+++ b/app/views/publishers/vacancies/build/job_location.html.slim
@@ -16,6 +16,6 @@
 
         = f.govuk_submit t("buttons.continue")
 
-  - unless vacancy.published?
-    .govuk-grid-column-one-third
-      = render "steps"
+    - unless vacancy.published?
+      .govuk-grid-column-one-third
+        = render "steps"

--- a/app/views/publishers/vacancies/build/job_summary.html.slim
+++ b/app/views/publishers/vacancies/build/job_summary.html.slim
@@ -26,6 +26,6 @@
 
         = render "publishers/vacancies/vacancy_form_partials/submit", f: f
 
-  - unless vacancy.published?
-    .govuk-grid-column-one-third
-      = render "steps"
+    - unless vacancy.published?
+      .govuk-grid-column-one-third
+        = render "steps"

--- a/app/views/publishers/vacancies/build/pay_package.html.slim
+++ b/app/views/publishers/vacancies/build/pay_package.html.slim
@@ -20,6 +20,6 @@
 
         = render "publishers/vacancies/vacancy_form_partials/submit", f: f
 
-  - unless vacancy.published?
-    .govuk-grid-column-one-third
-      = render "steps"
+    - unless vacancy.published?
+      .govuk-grid-column-one-third
+        = render "steps"

--- a/app/views/publishers/vacancies/build/schools.html.slim
+++ b/app/views/publishers/vacancies/build/schools.html.slim
@@ -30,6 +30,6 @@
         div class="govuk-!-margin-top-6"
           = render "publishers/vacancies/vacancy_form_partials/continue_or_update_submit", f: f
 
-  - unless vacancy.published?
-    .govuk-grid-column-one-third
-      = render "steps"
+    - unless vacancy.published?
+      .govuk-grid-column-one-third
+        = render "steps"

--- a/app/views/publishers/vacancies/documents/show.html.slim
+++ b/app/views/publishers/vacancies/documents/show.html.slim
@@ -34,9 +34,9 @@
 
         = render "publishers/vacancies/vacancy_form_partials/submit", f: f
 
-  - unless vacancy.published?
-    .govuk-grid-column-one-third
-      = render "publishers/vacancies/build/steps"
+    - unless vacancy.published?
+      .govuk-grid-column-one-third
+        = render "publishers/vacancies/build/steps"
 
   - content_for :after_main do
     = render "shared/file_remove_confirmation_dialogue"

--- a/app/views/publishers/vacancies/review.html.slim
+++ b/app/views/publishers/vacancies/review.html.slim
@@ -40,6 +40,6 @@
       br
       = govuk_link_to t("buttons.back_to_manage_jobs"), jobs_with_type_organisation_path("draft", from_review: @vacancy.id), class: "govuk-link--no-visited-state"
 
-  - unless vacancy.published?
-    .govuk-grid-column-one-third
-      = render "publishers/vacancies/build/steps"
+    - unless vacancy.published?
+      .govuk-grid-column-one-third
+        = render "publishers/vacancies/build/steps"


### PR DESCRIPTION
## Changes in this PR:

- An incorrectly indented div with the class `govuk-grid-column-one-third` was causing the steps to be displayed in the footer. These changes should put the steps component in the correct place.