### PR TITLE
add a11y attributes for custom trix textbox

### DIFF
--- a/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
+++ b/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
@@ -34,11 +34,11 @@
         = f.govuk_phone_field :contact_number, label: { size: "s" }, width: "one-third", form_group: { classes: "optional-field" }
 
         = f.govuk_text_area :school_visits,
-          label: { text: t("helpers.label.publishers_job_listing_applying_for_the_job_form.#{school_or_trust_visits(vacancy.parent_organisation)}"), size: "s" },
+          label: { id: "school-visits-label", text: t("helpers.label.publishers_job_listing_applying_for_the_job_form.#{school_or_trust_visits(vacancy.parent_organisation)}"), size: "s" },
           hint: { text: vacancy_school_visits_hint(vacancy) },
           rows: 10,
           form_group: { classes: "optional-field" }
-        trix-editor input="publishers-job-listing-applying-for-the-job-form-school-visits-field" class="govuk-textarea formatable-textarea js-action govuk-!-margin-bottom-6 govuk-!-margin-top-2"
+        trix-editor input="publishers-job-listing-applying-for-the-job-form-school-visits-field" aria-labelledby="school-visits-label" role="textbox" contenteditable="true" aria-multiline="true" class="govuk-textarea formatable-textarea js-action govuk-!-margin-bottom-6 govuk-!-margin-top-2"
 
         - unless JobseekerApplicationsFeature.enabled?
           = f.govuk_text_area :how_to_apply, label: { size: "s" }, rows: 10, form_group: { classes: "optional-field" }

--- a/app/views/publishers/vacancies/build/job_summary.html.slim
+++ b/app/views/publishers/vacancies/build/job_summary.html.slim
@@ -13,16 +13,16 @@
 
         h2.govuk-heading-l = t("jobs.job_summary")
 
-        = f.govuk_text_area :job_advert, label: { size: "s" }, rows: 10, required: true
-        trix-editor input="publishers-job-listing-job-summary-form-job-advert-field" class="govuk-textarea formatable-textarea js-action govuk-!-margin-bottom-6 govuk-!-margin-top-2"
+        = f.govuk_text_area :job_advert, label: { size: "s", id: "job-advert-label" }, rows: 10, required: true
+        trix-editor input="publishers-job-listing-job-summary-form-job-advert-field" aria-labelledby="job-advert-label" role="textbox" contenteditable="true" aria-multiline="true" class="govuk-textarea formatable-textarea js-action govuk-!-margin-bottom-6 govuk-!-margin-top-2"
 
         = f.govuk_text_area :about_school,
-          label: { text: t("helpers.label.publishers_job_listing_job_summary_form.about_organisation", organisation: vacancy_about_school_label_organisation(vacancy)), size: "s" },
+          label: { id: "about-school-label", text: t("helpers.label.publishers_job_listing_job_summary_form.about_organisation", organisation: vacancy_about_school_label_organisation(vacancy)), size: "s" },
           hint: { text: vacancy_about_school_hint_text(vacancy) },
           value: vacancy_about_school_value(vacancy),
           rows: 10,
           required: true
-        trix-editor input="publishers-job-listing-job-summary-form-about-school-field" class="govuk-textarea formatable-textarea js-action govuk-!-margin-bottom-6 govuk-!-margin-top-2"
+        trix-editor input="publishers-job-listing-job-summary-form-about-school-field" aria-labelledby="about-school-label" role="textbox" contenteditable="true" aria-multiline="true" class="govuk-textarea formatable-textarea js-action govuk-!-margin-bottom-6 govuk-!-margin-top-2"
 
         = render "publishers/vacancies/vacancy_form_partials/submit", f: f
 

--- a/app/views/publishers/vacancies/build/pay_package.html.slim
+++ b/app/views/publishers/vacancies/build/pay_package.html.slim
@@ -15,8 +15,8 @@
 
         = f.govuk_text_field :salary, label: { size: "s" }, required: true
 
-        = f.govuk_text_area :benefits, label: { size: "s" }, form_group: { classes: "optional-field trix-remove" }
-        trix-editor input="publishers-job-listing-pay-package-form-benefits-field" class="govuk-textarea formatable-textarea js-action govuk-!-margin-bottom-6 govuk-!-margin-top-2"
+        = f.govuk_text_area :benefits, label: { size: "s", id: "benefits-label" }, form_group: { classes: "optional-field trix-remove" }
+        trix-editor input="publishers-job-listing-pay-package-form-benefits-field" aria-labelledby="benefits-label" role="textbox" contenteditable="true" aria-multiline="true" class="govuk-textarea formatable-textarea js-action govuk-!-margin-bottom-6 govuk-!-margin-top-2"
 
         = render "publishers/vacancies/vacancy_form_partials/submit", f: f
 


### PR DESCRIPTION
no ticket

oversight on trix text editor task. this adds correct a11y attributes for the custom textarea it provides

![Screenshot 2021-06-02 at 15 21 04](https://user-images.githubusercontent.com/1792451/120497340-383e4000-c3b6-11eb-8127-ef121d2fa2f0.png)