### PR TITLE
Cache from master by default

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -80,9 +80,13 @@ jobs:
         with:
           build-args: |
             BUILDKIT_INLINE_CACHE=1
+          # Cache from builder target tagged with branch name, may be empty first time branch is pushed
+          # Cache from builder target tagged with master branch name, always present, maybe less recent
           cache-from: |
             ${{ env.DOCKER_REPOSITORY }}:builder-${{ env.GIT_BRANCH }}
+            ${{ env.DOCKER_REPOSITORY }}:builder-master
           push: true
+          # Tag with branch name for reuse
           tags: ${{ env.DOCKER_REPOSITORY }}:builder-${{ env.GIT_BRANCH }}
           target: builder
 
@@ -92,10 +96,16 @@ jobs:
           build-args: |
             BUILDKIT_INLINE_CACHE=1
             COMMIT_SHA=${{ env.COMMIT_SHA }}
+          # Cache from builder target built above, always present
+          # Cache from production target tagged with branch name, may be empty first time branch is pushed
+          # Cache from production target tagged with master branch name, always present, maybe less recent
           cache-from: |
             ${{ env.DOCKER_REPOSITORY }}:builder-${{ env.GIT_BRANCH }}
             ${{ env.DOCKER_REPOSITORY }}:${{ env.GIT_BRANCH }}
+            ${{ env.DOCKER_REPOSITORY }}:master
           push: true
+          # Tag with branch name for reuse
+          # Tag with branch name and commit sha for unique identification
           tags: |
             ${{ env.DOCKER_REPOSITORY }}:${{ env.GIT_BRANCH }}
             ${{ env.DOCKER_REPOSITORY }}:${{ env.DOCKER_IMAGE_TAG }}


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2702

## Changes in this PR:
The docker image build uses a base image as cache and it's tagged with the branch name. The first push has no branch tag to cache brom so it builds from scratch.
We now add master as a cache-from source so there is always a cache present.

## How to review
Cached successfully on first deployment: https://github.com/DFE-Digital/teaching-vacancies/pull/3579/checks?check_run_id=2762635743