### PR TITLE
remove uneeded padding to top of cookie banner

### DIFF
--- a/app/components/cookies_banner_component/cookies_banner_component.scss
+++ b/app/components/cookies_banner_component/cookies_banner_component.scss
@@ -1,7 +1,6 @@
 @import 'base_component';
 
 .cookies-banner-component {
-  @include govuk-responsive-padding(3, 'top');
   @include govuk-responsive-padding(0, 'bottom');
   background-color: govuk-colour('light-grey');
   bottom: 0;
@@ -28,9 +27,5 @@
   .govuk-heading-s,
   .govuk-body {
     color: govuk-colour('black');
-  }
-
-  .govuk-width-container {
-    padding-top: 15px;
   }
 }


### PR DESCRIPTION
no ticket, i took the liberty to remove this padding at the top of the banner as it doesnt look good and crept in because of the internals of how the component is built

### Before

![Screenshot 2021-06-07 at 14 50 02](https://user-images.githubusercontent.com/1792451/121028861-0f47f180-c7a0-11eb-8149-694a58d4fd84.png)

### After

![Screenshot 2021-06-07 at 14 49 28](https://user-images.githubusercontent.com/1792451/121028901-17a02c80-c7a0-11eb-836f-a72258932d2e.png)
![Screenshot 2021-06-07 at 14 49 15](https://user-images.githubusercontent.com/1792451/121028909-1838c300-c7a0-11eb-9829-01f0e7cc95e6.png)


