### PR TITLE
[TEVA-2328] Update User Feedback Forms

### DIFF
--- a/app/controllers/general_feedbacks_controller.rb
+++ b/app/controllers/general_feedbacks_controller.rb
@@ -22,10 +22,10 @@ class GeneralFeedbacksController < ApplicationController
 
   def general_feedback_form_params
     params.require(:general_feedback_form)
-          .permit(:comment, :email, :user_participation_response, :visit_purpose, :visit_purpose_comment)
+          .permit(:comment, :email, :report_a_problem, :user_participation_response, :visit_purpose, :visit_purpose_comment)
   end
 
   def feedback_attributes
-    general_feedback_form_params.merge(feedback_type: "general", jobseeker_id: current_jobseeker&.id, publisher_id: current_publisher&.id)
+    general_feedback_form_params.except("report_a_problem").merge(feedback_type: "general", jobseeker_id: current_jobseeker&.id, publisher_id: current_publisher&.id)
   end
 end

--- a/app/controllers/jobseekers/account_feedbacks_controller.rb
+++ b/app/controllers/jobseekers/account_feedbacks_controller.rb
@@ -17,10 +17,10 @@ class Jobseekers::AccountFeedbacksController < Jobseekers::BaseController
   private
 
   def account_feedback_form_params
-    params.require(:jobseekers_account_feedback_form).permit(:rating, :comment, :origin)
+    params.require(:jobseekers_account_feedback_form).permit(:comment, :email, :origin, :rating, :report_a_problem, :user_participation_response)
   end
 
   def feedback_attributes
-    account_feedback_form_params.merge(jobseeker_id: current_jobseeker.id, feedback_type: "jobseeker_account")
+    account_feedback_form_params.except("report_a_problem").merge(jobseeker_id: current_jobseeker.id, feedback_type: "jobseeker_account")
   end
 end

--- a/app/controllers/jobseekers/job_alert_feedbacks_controller.rb
+++ b/app/controllers/jobseekers/job_alert_feedbacks_controller.rb
@@ -44,7 +44,7 @@ class Jobseekers::JobAlertFeedbacksController < ApplicationController
   end
 
   def further_feedback_form_params
-    params.require(:jobseekers_job_alert_further_feedback_form).permit(:comment)
+    params.require(:jobseekers_job_alert_further_feedback_form).permit(:comment, :email, :user_participation_response)
   end
 
   def token

--- a/app/controllers/jobseekers/job_applications/feedbacks_controller.rb
+++ b/app/controllers/jobseekers/job_applications/feedbacks_controller.rb
@@ -15,7 +15,7 @@ class Jobseekers::JobApplications::FeedbacksController < Jobseekers::BaseControl
   private
 
   def feedback_form_params
-    params.require(:jobseekers_job_application_feedback_form).permit(:rating, :comment)
+    params.require(:jobseekers_job_application_feedback_form).permit(:email, :rating, :comment, :user_participation_response)
   end
 
   def feedback_attributes

--- a/app/controllers/jobseekers/unsubscribe_feedbacks_controller.rb
+++ b/app/controllers/jobseekers/unsubscribe_feedbacks_controller.rb
@@ -36,6 +36,6 @@ class Jobseekers::UnsubscribeFeedbacksController < ApplicationController
 
   def unsubscribe_feedback_form_params
     params.require(:jobseekers_unsubscribe_feedback_form)
-          .permit(:comment, :other_unsubscribe_reason_comment, :unsubscribe_reason)
+          .permit(:comment, :email, :other_unsubscribe_reason_comment, :unsubscribe_reason, :user_participation_response)
   end
 end

--- a/app/controllers/publishers/vacancies/feedbacks_controller.rb
+++ b/app/controllers/publishers/vacancies/feedbacks_controller.rb
@@ -14,10 +14,10 @@ class Publishers::Vacancies::FeedbacksController < Publishers::Vacancies::BaseCo
   private
 
   def feedback_form_params
-    params.require(:publishers_job_listing_feedback_form).permit(:comment, :rating)
+    params.require(:publishers_job_listing_feedback_form).permit(:comment, :email, :rating, :report_a_problem, :user_participation_response)
   end
 
   def feedback_attributes
-    feedback_form_params.merge(feedback_type: "vacancy_publisher", publisher_id: current_publisher&.id, vacancy_id: @vacancy.id)
+    feedback_form_params.except("report_a_problem").merge(feedback_type: "vacancy_publisher", publisher_id: current_publisher&.id, vacancy_id: @vacancy.id)
   end
 end

--- a/app/form_models/general_feedback_form.rb
+++ b/app/form_models/general_feedback_form.rb
@@ -1,8 +1,9 @@
 class GeneralFeedbackForm
   include ActiveModel::Model
 
-  attr_accessor :comment, :email, :user_participation_response, :visit_purpose, :visit_purpose_comment
+  attr_accessor :comment, :email, :report_a_problem, :user_participation_response, :visit_purpose, :visit_purpose_comment
 
+  validates :report_a_problem, inclusion: { in: %w[yes no] }
   validates :comment, presence: true, length: { maximum: 1200 }
   validates :email, presence: true, if: -> { user_participation_response == "interested" }
   validates :email, format: { with: Devise.email_regexp }, if: -> { email.present? }

--- a/app/form_models/jobseekers/account_feedback_form.rb
+++ b/app/form_models/jobseekers/account_feedback_form.rb
@@ -1,8 +1,12 @@
 class Jobseekers::AccountFeedbackForm
   include ActiveModel::Model
 
-  attr_accessor :origin, :comment, :rating
+  attr_accessor :comment, :email, :origin, :rating, :report_a_problem, :user_participation_response
 
+  validates :report_a_problem, inclusion: { in: %w[yes no] }
   validates :comment, length: { maximum: 1200 }, if: -> { comment.present? }
+  validates :email, presence: true, if: -> { user_participation_response == "interested" }
+  validates :email, format: { with: Devise.email_regexp }, if: -> { email.present? }
   validates :rating, inclusion: { in: Feedback.ratings.keys }
+  validates :user_participation_response, inclusion: { in: Feedback.user_participation_responses.keys }
 end

--- a/app/form_models/jobseekers/job_alert_further_feedback_form.rb
+++ b/app/form_models/jobseekers/job_alert_further_feedback_form.rb
@@ -1,7 +1,10 @@
 class Jobseekers::JobAlertFurtherFeedbackForm
   include ActiveModel::Model
 
-  attr_accessor :comment
+  attr_accessor :comment, :email, :user_participation_response
 
   validates :comment, presence: true, length: { maximum: 1200 }
+  validates :email, presence: true, if: -> { user_participation_response == "interested" }
+  validates :email, format: { with: Devise.email_regexp }, if: -> { email.present? }
+  validates :user_participation_response, inclusion: { in: Feedback.user_participation_responses.keys }
 end

--- a/app/form_models/jobseekers/job_application/feedback_form.rb
+++ b/app/form_models/jobseekers/job_application/feedback_form.rb
@@ -1,8 +1,11 @@
 class Jobseekers::JobApplication::FeedbackForm
   include ActiveModel::Model
 
-  attr_accessor :comment, :rating
+  attr_accessor :comment, :email, :rating, :user_participation_response
 
   validates :comment, length: { maximum: 1200 }, if: -> { comment.present? }
+  validates :email, presence: true, if: -> { user_participation_response == "interested" }
+  validates :email, format: { with: Devise.email_regexp }, if: -> { email.present? }
   validates :rating, inclusion: { in: Feedback.ratings.keys }
+  validates :user_participation_response, inclusion: { in: Feedback.user_participation_responses.keys }
 end

--- a/app/form_models/jobseekers/unsubscribe_feedback_form.rb
+++ b/app/form_models/jobseekers/unsubscribe_feedback_form.rb
@@ -1,9 +1,12 @@
 class Jobseekers::UnsubscribeFeedbackForm
   include ActiveModel::Model
 
-  attr_accessor :comment, :other_unsubscribe_reason_comment, :unsubscribe_reason
+  attr_accessor :comment, :email, :other_unsubscribe_reason_comment, :unsubscribe_reason, :user_participation_response
 
   validates :comment, length: { maximum: 1200 }
+  validates :email, presence: true, if: -> { user_participation_response == "interested" }
+  validates :email, format: { with: Devise.email_regexp }, if: -> { email.present? }
   validates :other_unsubscribe_reason_comment, presence: true, if: -> { unsubscribe_reason == "other_reason" }
   validates :unsubscribe_reason, inclusion: { in: Feedback.unsubscribe_reasons.keys }
+  validates :user_participation_response, inclusion: { in: Feedback.user_participation_responses.keys }
 end

--- a/app/form_models/publishers/job_listing/feedback_form.rb
+++ b/app/form_models/publishers/job_listing/feedback_form.rb
@@ -1,7 +1,11 @@
 class Publishers::JobListing::FeedbackForm
   include ActiveModel::Model
 
-  attr_accessor :comment, :rating
+  attr_accessor :comment, :email, :rating, :report_a_problem, :user_participation_response
 
+  validates :report_a_problem, inclusion: { in: %w[yes no] }
   validates :rating, inclusion: { in: Feedback.ratings.keys }
+  validates :email, presence: true, if: -> { user_participation_response == "interested" }
+  validates :email, format: { with: Devise.email_regexp }, if: -> { email.present? }
+  validates :user_participation_response, inclusion: { in: Feedback.user_participation_responses.keys }
 end

--- a/app/helpers/feedback_helper.rb
+++ b/app/helpers/feedback_helper.rb
@@ -1,0 +1,5 @@
+module FeedbackHelper
+  def current_user_email(current_jobseeker, current_publisher)
+    current_jobseeker&.email.presence || current_publisher&.email.presence
+  end
+end

--- a/app/views/feedback/_form.html.slim
+++ b/app/views/feedback/_form.html.slim
@@ -6,6 +6,5 @@
 
 = f.govuk_radio_buttons_fieldset(:user_participation_response, legend: { size: "m" }) do
   = f.govuk_radio_button :user_participation_response, :interested, link_errors: true do
-    = f.govuk_email_field :email, required: true
-
+    = f.govuk_email_field :email, value: current_user_email(current_jobseeker, current_publisher), required: true
   = f.govuk_radio_button :user_participation_response, :uninterested

--- a/app/views/general_feedbacks/new.html.slim
+++ b/app/views/general_feedbacks/new.html.slim
@@ -8,7 +8,10 @@
 
         h1.govuk-heading-xl = t(".heading")
 
-        p.govuk-body = t(".report_a_problem_html", mail_to: govuk_mail_to(t("help.email"), t("help.email")))
+        = f.govuk_radio_buttons_fieldset(:report_a_problem, legend: { size: "m" }) do
+          = f.govuk_radio_button :report_a_problem, :yes, link_errors: true do
+            p.govuk-body = t("help.report_a_problem_html", mail_to: govuk_mail_to(t("help.email"), t("help.email")))
+          = f.govuk_radio_button :report_a_problem, :no, link_errors: true
 
         = f.govuk_radio_buttons_fieldset(:visit_purpose, legend: { size: "m" }) do
           - Feedback.visit_purposes.keys.each_with_index do |visit_purpose, idx|

--- a/app/views/jobseekers/account_feedbacks/new.html.slim
+++ b/app/views/jobseekers/account_feedbacks/new.html.slim
@@ -10,8 +10,18 @@
 
         h1.govuk-heading-xl = t(".title")
 
+        = f.govuk_radio_buttons_fieldset(:report_a_problem, legend: { size: "s" }) do
+          = f.govuk_radio_button :report_a_problem, :yes, link_errors: true do
+            p.govuk-body = t("help.report_a_problem_html", mail_to: govuk_mail_to(t("help.email"), t("help.email")))
+          = f.govuk_radio_button :report_a_problem, :no, link_errors: true
+
         = f.govuk_collection_radio_buttons :rating, Feedback.ratings.keys, :to_s
 
         = f.govuk_text_area :comment, label: { size: "s" }, rows: 10, max_chars: 1200, form_group: { classes: "optional-field" }
+
+        = f.govuk_radio_buttons_fieldset(:user_participation_response, legend: { size: "s" }) do
+          = f.govuk_radio_button :user_participation_response, :interested, link_errors: true do
+            = f.govuk_email_field :email, value: current_jobseeker.email, required: true
+          = f.govuk_radio_button :user_participation_response, :uninterested
 
         = f.govuk_submit t("buttons.submit")

--- a/app/views/jobseekers/job_alert_feedbacks/edit.html.slim
+++ b/app/views/jobseekers/job_alert_feedbacks/edit.html.slim
@@ -14,6 +14,11 @@
 
         = f.govuk_text_area :comment, label: { size: "s" }, max_chars: 1200, rows: 11
 
+        = f.govuk_radio_buttons_fieldset(:user_participation_response, legend: { size: "s" }) do
+          = f.govuk_radio_button :user_participation_response, :interested, link_errors: true do
+            = f.govuk_email_field :email, value: current_jobseeker&.email, required: true
+          = f.govuk_radio_button :user_participation_response, :uninterested
+
         = recaptcha
 
         = f.govuk_submit t("buttons.submit"), classes: "govuk-!-padding-left-8 govuk-!-padding-right-8"

--- a/app/views/jobseekers/job_applications/submit.html.slim
+++ b/app/views/jobseekers/job_applications/submit.html.slim
@@ -28,4 +28,9 @@
 
         = f.govuk_text_area :comment, label: { size: "s" }, rows: 10, max_chars: 1200, form_group: { classes: "optional-field" }
 
+        = f.govuk_radio_buttons_fieldset(:user_participation_response, legend: { size: "s" }) do
+          = f.govuk_radio_button :user_participation_response, :interested, link_errors: true do
+            = f.govuk_email_field :email, value: current_jobseeker.email, required: true
+          = f.govuk_radio_button :user_participation_response, :uninterested
+
         = f.govuk_submit t("buttons.submit_feedback")

--- a/app/views/jobseekers/unsubscribe_feedbacks/new.html.slim
+++ b/app/views/jobseekers/unsubscribe_feedbacks/new.html.slim
@@ -21,4 +21,9 @@
 
         = f.govuk_text_area :comment, label: { size: "s" }, max_chars: 1200
 
+        = f.govuk_radio_buttons_fieldset(:user_participation_response, legend: { size: "s" }) do
+          = f.govuk_radio_button :user_participation_response, :interested, link_errors: true do
+            = f.govuk_email_field :email, value: current_jobseeker&.email, required: true
+          = f.govuk_radio_button :user_participation_response, :uninterested
+
         = f.govuk_submit t("buttons.submit_feedback")

--- a/app/views/publishers/vacancies/summary.html.slim
+++ b/app/views/publishers/vacancies/summary.html.slim
@@ -28,6 +28,19 @@
 
       = form_for @feedback_form, url: organisation_job_feedback_path(@vacancy.id) do |f|
         = f.govuk_error_summary
+
+        = f.govuk_radio_buttons_fieldset(:report_a_problem, legend: { size: "s" }) do
+          = f.govuk_radio_button :report_a_problem, :yes, link_errors: true do
+            p.govuk-body = t("help.report_a_problem_html", mail_to: govuk_mail_to(t("help.email"), t("help.email")))
+          = f.govuk_radio_button :report_a_problem, :no, link_errors: true
+
         = f.govuk_collection_radio_buttons :rating, Feedback.ratings.keys, :to_s
+
         = f.govuk_text_area :comment, label: { size: "s" }, rows: 10, form_group: { classes: "optional-field" }
+
+        = f.govuk_radio_buttons_fieldset(:user_participation_response, legend: { size: "s" }) do
+          = f.govuk_radio_button :user_participation_response, :interested, link_errors: true do
+            = f.govuk_email_field :email, value: current_publisher.email, required: true
+          = f.govuk_radio_button :user_participation_response, :uninterested
+
         = f.govuk_submit t("buttons.submit_feedback")

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -36,17 +36,29 @@ en:
     frequency:
       blank: Select when you want to receive job alert emails
   unsubscribe_feedback_errors: &unsubscribe_feedback_errors
-    unsubscribe_reason:
-      inclusion: Tell us why you want to unsubscribe
+    email:
+      blank: Enter your email address
+      invalid: Enter an email address in the correct format, like name@example.com
     other_unsubscribe_reason_comment:
       blank: Tell us why you want to unsubscribe
+    unsubscribe_reason:
+      inclusion: Tell us why you want to unsubscribe
+    user_participation_response:
+      inclusion: Please indicate if you'd like to participate in user research
 
   # Feedback forms
   account_feedback_errors: &account_feedback_errors
-    rating:
-      inclusion: Select how satisfied or dissatisfied you are
     comment:
       too_long: Feedback must not be more than 1,200 characters
+    email:
+      blank: Enter your email address
+      invalid: Enter an email address in the correct format, like name@example.com
+    rating:
+      inclusion: Select how satisfied or dissatisfied you are
+    report_a_problem:
+      inclusion: Select yes if you want to report a problem or request support
+    user_participation_response:
+      inclusion: Please indicate if you'd like to participate in user research
   general_feedback_errors: &general_feedback_errors
     user_participation_response:
       inclusion: Please indicate if you'd like to participate in user research
@@ -56,6 +68,8 @@ en:
     comment:
       blank: Enter your feedback
       too_long: Feedback must not be more than 1,200 characters
+    report_a_problem:
+      inclusion: Select yes if you want to report a problem or request support
     visit_purpose:
       inclusion: Enter the reason for your visit
     visit_purpose_comment:
@@ -65,14 +79,37 @@ en:
     comment:
       blank: You have not submitted any further feedback
       too_long: Feedback must not be more than 1,200 characters
+    email:
+      blank: Enter your email address
+      invalid: Enter an email address in the correct format, like name@example.com
+    user_participation_response:
+      inclusion: Please indicate if you'd like to participate in user research
+  jobseekers_job_alert_further_feedback_form: &job_alert_further_feedback_form_errors
+    email:
+      blank: Enter your email address
+      invalid: Enter an email address in the correct format, like name@example.com
+    user_participation_response:
+      inclusion: Please indicate if you'd like to participate in user research
   jobseekers_job_application_feedback_form: &jobseekers_job_application_feedback_form_errors
+    email:
+      blank: Enter your email address
+      invalid: Enter an email address in the correct format, like name@example.com
     rating:
       inclusion: Choose how satisfied you are with the application process
     comment:
       too_long: Feedback must not be more than 1,200 characters
+    user_participation_response:
+      inclusion: Please indicate if you'd like to participate in user research
   publisher_job_listing_feedback_form: &publisher_job_listing_feedback_form_errors
+    email:
+      blank: Enter your email address
+      invalid: Enter an email address in the correct format, like name@example.com
     rating:
       inclusion: Choose how satisfied you are with the job listing process
+    report_a_problem:
+      inclusion: Select yes if you want to report a problem or request support
+    user_participation_response:
+      inclusion: Please indicate if you'd like to participate in user research
 
   # Hiring staff journey
   job_location_errors: &job_location_errors
@@ -166,6 +203,9 @@ en:
         jobseekers/job_alert_feedback_form:
           attributes:
             <<: *job_alert_feedback_errors
+        jobseekers/job_alert_further_feedback_form:
+          attributes:
+            <<: *job_alert_further_feedback_form_errors
         jobseekers/job_application/feedback_form:
           attributes:
             <<: *jobseekers_job_application_feedback_form_errors

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -157,12 +157,13 @@ en:
       success: Your feedback has been successfully submitted
     new:
       heading: Give feedback
-      report_a_problem_html: To report a problem, or for support using Teaching Vacancies, please email %{mail_to}
       page_description: Tell us how we can improve Teaching Vacancies and volunteer as a user research participant.
       title: Feedback
 
   help:
     email: teaching.vacancies@education.gov.uk
+    report_a_problem_html: To report a problem, or for support using Teaching Vacancies, please email %{mail_to}
+
 
   organisation:
     location_link_text:

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -80,9 +80,13 @@ en:
         visit_purpose_comment: >-
           Please tell us what you came here to do. Do not include any information that could identify you personally
           (such as your name or the name of your school).
-
       jobseeker:
         password: Your password has to be at least 8 characters long
+
+      jobseekers_account_feedback_form:
+        email: >-
+          We'll only use this to tell you about opportunities to take part in user research that helps us improve
+          Department for Education services.
 
       jobseekers_job_application_declarations_form:
         right_to_work_in_uk_html: >-
@@ -113,6 +117,10 @@ en:
         religion: >-
           Tell us about your religion or faith. You can select ‘Other’ if your beliefs are not represented by one of the
           given options.
+      jobseekers_job_application_feedback_form:
+        email: >-
+          We'll only use this to tell you about opportunities to take part in user research that helps us improve
+          Department for Education services.
       jobseekers_job_application_personal_details_form:
         national_insurance_number: >-
           If you have a National Insurance number you should enter it here. It's on your National Insurance card,
@@ -122,6 +130,9 @@ en:
         teacher_reference_number: Enter the 7 numbers of your TRN, excluding any letters and symbols.
       jobseekers_job_alert_further_feedback_form:
         comment: This is optional, but the information will help us to make improvements.
+        email: >-
+          We'll only use this to tell you about opportunities to take part in user research that helps us improve
+          Department for Education services.
       jobseekers_nqt_job_alerts_form:
         email: Enter your email address. We will only use it to send you job alerts.
         keywords: >-
@@ -134,6 +145,9 @@ en:
         email: Enter your email address. We'll only use it to send you job alerts.
       jobseekers_unsubscribe_feedback_form:
         comment: Any more information you can share will help us to improve the service
+        email: >-
+          We'll only use this to tell you about opportunities to take part in user research that helps us improve
+          Department for Education services.
 
       publishers_organisation_form:
         description: Jobseekers will see this description of the %{organisation_type} in the job listing
@@ -179,6 +193,10 @@ en:
       publishers_job_listing_extend_deadline_form:
         expires_at: For example, 01 05 2021
         starts_on: For example, 01 09 2021
+      publishers_job_listing_feedback_form:
+        email: >-
+          We'll only use this to tell you about opportunities to take part in user research that helps us improve
+          Department for Education services.
       publishers_job_listing_important_dates_form:
         expires_at: For example, 01 05 2021
         publish_on: For example, 01 01 2021
@@ -218,7 +236,9 @@ en:
       general_feedback_form:
         comment: How could we improve this service?
         email: What is your email address?
-        visit_purpose: Visit purpose
+        report_a_problem_options:
+          "no": "No"
+          "yes": "Yes"
         visit_purpose_options:
           find_teaching_job: Find a job in teaching
           list_teaching_job: List a teaching job on the service
@@ -232,15 +252,26 @@ en:
         password: Password
 
       jobseekers_account_feedback_form:
+        comment: Do you have any suggestions on how we should improve the service?
+        email: What is your email address?
         rating_options:
+          highly_dissatisfied: Highly dissatisfied
           highly_satisfied: Highly satisfied
-          somewhat_satisfied: Somewhat satisfied
           neither: Neither satisfied nor dissatisfied
           somewhat_dissatisfied: Somewhat dissatisfied
-          highly_dissatisfied: Highly dissatisfied
-        comment: Do you have any suggestions on how we should improve the service?
+          somewhat_satisfied: Somewhat satisfied
+        report_a_problem_options:
+          "no": "No"
+          "yes": "Yes"
+        user_participation_response_options:
+          interested: 'Yes'
+          uninterested: 'No'
       jobseekers_job_alert_further_feedback_form:
         comment: Would you like to add any further comments about the relevancy of the job alerts you have received?
+        email: What is your email address?
+        user_participation_response_options:
+          interested: 'Yes'
+          uninterested: 'No'
 
       jobseekers_job_application_ask_for_support_form:
         support_needed_details: Tell us any information you think is relevant
@@ -351,13 +382,17 @@ en:
           prefer_not_to_say: Prefer not to say
           sikh: Sikh
       jobseekers_job_application_feedback_form:
+        email: What is your email address?
+        comment: Do you have any suggestions on how we should improve the service?
         rating_options:
+          highly_dissatisfied: Highly dissatisfied
           highly_satisfied: Highly satisfied
-          somewhat_satisfied: Somewhat satisfied
           neither: Neither satisfied nor dissatisfied
           somewhat_dissatisfied: Somewhat dissatisfied
-          highly_dissatisfied: Highly dissatisfied
-        comment: Do you have any suggestions on how we should improve the service?
+          somewhat_satisfied: Somewhat satisfied
+        user_participation_response_options:
+              interested: 'Yes'
+              uninterested: 'No'
       jobseekers_job_application_personal_details_form:
         city: Town or city
         country: Country
@@ -400,13 +435,17 @@ en:
           daily: Daily, at around 3 pm
           weekly: Weekly (Friday evening at around 6 pm)
       jobseekers_unsubscribe_feedback_form:
+        email: What is your email address?
         comment: Is there anything else you'd like to tell us?
         other_unsubscribe_reason_comment: Briefly, tell us more about that reason
         unsubscribe_reason_options:
-          not_relevant: The alerts I am receiving are not relevant to me
-          job_found: I have found a teaching job
           circumstances_change: My circumstances have changed
+          job_found: I have found a teaching job
+          not_relevant: The alerts I am receiving are not relevant to me
           other_reason: Another reason
+        user_participation_response_options:
+          interested: 'Yes'
+          uninterested: 'No'
 
       publisher:
         email: Email address
@@ -451,13 +490,21 @@ en:
         starts_asap_options:
           "true": As soon as possible
       publishers_job_listing_feedback_form:
+        email: What is your email address?
+        comment: Do you have any suggestions on how we should improve the service?
         rating_options:
+          highly_dissatisfied: Highly dissatisfied
           highly_satisfied: Highly satisfied
-          somewhat_satisfied: Somewhat satisfied
           neither: Neither satisfied nor dissatisfied
           somewhat_dissatisfied: Somewhat dissatisfied
-          highly_dissatisfied: Highly dissatisfied
-        comment: Do you have any suggestions on how we should improve the service?
+          somewhat_satisfied: Somewhat satisfied
+        report_a_problem_options:
+          "no": "No"
+          "yes": "Yes"
+        user_participation_response_options:
+          interested: 'Yes'
+          uninterested: 'No'
+
       publishers_job_listing_important_dates_form:
         publish_on_day_options:
           another_day: On another day
@@ -494,11 +541,17 @@ en:
 
     legend:
       general_feedback_form:
+        report_a_problem: Do you need to report a problem, or request support with using Teaching Vacancies?
         visit_purpose: What did you come to Teaching Vacancies to do?
+        user_participation_response: Would you like to participate in our research?
+
+      jobseekers_job_alert_further_feedback_form:
         user_participation_response: Would you like to participate in our research?
 
       jobseekers_account_feedback_form:
         rating: How satisfied are you with your experience of using Teaching Vacancies?
+        report_a_problem: Do you need to report a problem, or request support with using Teaching Vacancies?
+        user_participation_response: Would you like to participate in our research?
 
       jobseekers_job_application_ask_for_support_form:
         support_needed: Do you want to ask for support so that you can attend an interview?
@@ -529,6 +582,7 @@ en:
         <<: *jobseekers_job_application_details_qualifications_shared_legends
       jobseekers_job_application_feedback_form:
         rating: How satisfied are you with your experience of using Teaching Vacancies?
+        user_participation_response: Would you like to participate in our research?
       jobseekers_job_application_personal_details_form:
         your_address: Your address
       jobseekers_job_application_professional_status_form:
@@ -541,6 +595,7 @@ en:
         frequency: When do you want to receive alerts?
       jobseekers_unsubscribe_feedback_form:
         reason: Why do you want to unsubscribe from this alert?
+        user_participation_response: Would you like to participate in our research?
 
       publishers_job_listing_applying_for_the_job_form:
         enable_job_applications: How would you like candidates to apply?
@@ -558,6 +613,8 @@ en:
         starts_on: Date job starts
       publishers_job_listing_feedback_form:
         rating: How satisfied are you with the job listing process on Teaching Vacancies?
+        report_a_problem: Do you need to report a problem, or request support with using Teaching Vacancies?
+        user_participation_response: Would you like to participate in our research?
       publishers_job_listing_important_dates_form:
         expires_at: Closing date
         expiry_time: Time application is due

--- a/spec/form_models/general_feedback_form_spec.rb
+++ b/spec/form_models/general_feedback_form_spec.rb
@@ -3,13 +3,14 @@ require "rails_helper"
 RSpec.describe GeneralFeedbackForm, type: :model do
   subject { described_class.new(params) }
   let(:email) { "helpful@user.com" }
-  let(:user_participation_response) { "uninterested" }
+  let(:user_participation_response) { "interested" }
   let(:visit_purpose) { "find_teaching_job" }
   let(:visit_purpose_comment) { nil }
   let(:params) do
     {
       comment: "Fancy",
       email: email,
+      report_a_problem: "no",
       user_participation_response: user_participation_response,
       visit_purpose: visit_purpose,
       visit_purpose_comment: visit_purpose_comment,
@@ -18,50 +19,16 @@ RSpec.describe GeneralFeedbackForm, type: :model do
 
   it { is_expected.to validate_presence_of(:comment) }
   it { is_expected.to validate_length_of(:comment).is_at_most(1200) }
+  it { is_expected.to validate_presence_of(:email) }
+  it { is_expected.to allow_value("email@example").for(:email) }
+  it { is_expected.to_not allow_value("invalid@email@com").for(:email) }
+  it { is_expected.to validate_inclusion_of(:report_a_problem).in_array(%w[yes no]) }
   it {
     is_expected.to validate_inclusion_of(:user_participation_response)
                   .in_array(Feedback.user_participation_responses.keys)
   }
   it { is_expected.to validate_inclusion_of(:visit_purpose).in_array(Feedback.visit_purposes.keys) }
   it { is_expected.to validate_length_of(:visit_purpose_comment).is_at_most(1200) }
-
-  describe "#email" do
-    context "when the user is uninterested in participating in user research" do
-      let(:email) { nil }
-
-      it "allows email to be blank" do
-        expect(subject).to be_valid
-      end
-    end
-
-    context "when the user is interested in participating in user research" do
-      let(:user_participation_response) { "interested" }
-
-      context "and the email is provided" do
-        it "is valid" do
-          expect(subject).to be_valid
-        end
-
-        context "and the email is invalid" do
-          let(:email) { "invalid@email@com" }
-
-          it "ensures a valid email address is used" do
-            expect(subject).to be_invalid
-            expect(subject.errors[:email]).to include(I18n.t("general_feedback_errors.email.invalid"))
-          end
-        end
-      end
-
-      context "and the email is not provided" do
-        let(:email) { nil }
-
-        it "is invalid" do
-          expect(subject).to be_invalid
-          expect(subject.errors[:email]).to include(I18n.t("general_feedback_errors.email.blank"))
-        end
-      end
-    end
-  end
 
   describe "#visit_purpose_comment" do
     context "when the visit purpose is not 'other_purpose'" do

--- a/spec/form_models/jobseekers/account_feedback_form_spec.rb
+++ b/spec/form_models/jobseekers/account_feedback_form_spec.rb
@@ -1,6 +1,25 @@
 require "rails_helper"
 
 RSpec.describe Jobseekers::AccountFeedbackForm, type: :model do
+  subject { described_class.new(params) }
+  let(:params) do
+    {
+      comment: "Fancy",
+      email: "email@example.com",
+      rating: "neither",
+      report_a_problem: "no",
+      user_participation_response: "interested",
+    }
+  end
+
   it { is_expected.to validate_inclusion_of(:rating).in_array(Feedback.ratings.keys) }
   it { is_expected.to validate_length_of(:comment).is_at_most(1200) }
+  it { is_expected.to validate_presence_of(:email) }
+  it { is_expected.to allow_value("email@example").for(:email) }
+  it { is_expected.to_not allow_value("invalid@email@com").for(:email) }
+  it { is_expected.to validate_inclusion_of(:report_a_problem).in_array(%w[yes no]) }
+  it {
+    is_expected.to validate_inclusion_of(:user_participation_response)
+                    .in_array(Feedback.user_participation_responses.keys)
+  }
 end

--- a/spec/form_models/jobseekers/job_alert_further_feedback_form_spec.rb
+++ b/spec/form_models/jobseekers/job_alert_further_feedback_form_spec.rb
@@ -1,6 +1,22 @@
 require "rails_helper"
 
 RSpec.describe Jobseekers::JobAlertFurtherFeedbackForm, type: :model do
+  subject { described_class.new(params) }
+  let(:params) do
+    {
+      comment: "Found a job mate",
+      email: "email@example.com",
+      user_participation_response: "interested",
+    }
+  end
+
+  it { is_expected.to validate_presence_of(:email) }
+  it { is_expected.to allow_value("email@example").for(:email) }
+  it { is_expected.to_not allow_value("invalid@email@com").for(:email) }
   it { is_expected.to validate_presence_of(:comment) }
   it { is_expected.to validate_length_of(:comment).is_at_most(1200) }
+  it {
+    is_expected.to validate_inclusion_of(:user_participation_response)
+                  .in_array(Feedback.user_participation_responses.keys)
+  }
 end

--- a/spec/form_models/jobseekers/job_application/application_feedback_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/application_feedback_form_spec.rb
@@ -1,6 +1,22 @@
 require "rails_helper"
 
 RSpec.describe Jobseekers::JobApplication::FeedbackForm, type: :model do
+  subject { described_class.new(params) }
+  let(:params) do
+    {
+      email: "email@example.com",
+      rating: "neither",
+      user_participation_response: "interested",
+    }
+  end
+
+  it { is_expected.to validate_presence_of(:email) }
+  it { is_expected.to allow_value("email@example").for(:email) }
+  it { is_expected.to_not allow_value("invalid@email@com").for(:email) }
   it { is_expected.to validate_inclusion_of(:rating).in_array(Feedback.ratings.keys) }
   it { is_expected.to validate_length_of(:comment).is_at_most(1200) }
+  it {
+    is_expected.to validate_inclusion_of(:user_participation_response)
+                    .in_array(Feedback.user_participation_responses.keys)
+  }
 end

--- a/spec/form_models/jobseekers/unsubscribe_feedback_form_spec.rb
+++ b/spec/form_models/jobseekers/unsubscribe_feedback_form_spec.rb
@@ -1,8 +1,25 @@
 require "rails_helper"
 
 RSpec.describe Jobseekers::UnsubscribeFeedbackForm, type: :model do
+  subject { described_class.new(params) }
+  let(:params) do
+    {
+      comment: "Found a job mate",
+      email: "email@example.com",
+      unsubscribe_reason: "job_found",
+      user_participation_response: "interested",
+    }
+  end
+
+  it { is_expected.to validate_presence_of(:email) }
+  it { is_expected.to allow_value("email@example").for(:email) }
+  it { is_expected.to_not allow_value("invalid@email@com").for(:email) }
   it { is_expected.to validate_inclusion_of(:unsubscribe_reason).in_array(Feedback.unsubscribe_reasons.keys) }
   it { is_expected.to validate_length_of(:comment).is_at_most(1200) }
+  it {
+    is_expected.to validate_inclusion_of(:user_participation_response)
+                    .in_array(Feedback.user_participation_responses.keys)
+  }
 
   context "when reason is job_found" do
     before { allow(subject).to receive(:unsubscribe_reason).and_return("job_found") }

--- a/spec/form_models/publishers/job_listing/feedback_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/feedback_form_spec.rb
@@ -1,5 +1,23 @@
 require "rails_helper"
 
 RSpec.describe Publishers::JobListing::FeedbackForm, type: :model do
+  subject { described_class.new(params) }
+  let(:params) do
+    {
+      email: "email@example.com",
+      rating: "neither",
+      report_a_problem: "no",
+      user_participation_response: "interested",
+    }
+  end
+
+  it { is_expected.to validate_presence_of(:email) }
+  it { is_expected.to allow_value("email@example").for(:email) }
+  it { is_expected.to_not allow_value("invalid@email@com").for(:email) }
   it { is_expected.to validate_inclusion_of(:rating).in_array(Feedback.ratings.keys) }
+  it { is_expected.to validate_inclusion_of(:report_a_problem).in_array(%w[yes no]) }
+  it {
+    is_expected.to validate_inclusion_of(:user_participation_response)
+                    .in_array(Feedback.user_participation_responses.keys)
+  }
 end

--- a/spec/system/general_feedback_spec.rb
+++ b/spec/system/general_feedback_spec.rb
@@ -58,12 +58,13 @@ RSpec.describe "Giving general feedback for the service", recaptcha: true do
   end
 
   def fill_in_general_feedback
-    choose("general-feedback-form-visit-purpose-other-purpose-field")
-    fill_in "general_feedback_form[visit_purpose_comment]", with: visit_purpose_comment
+    choose name: "general_feedback_form[report_a_problem]", option: "yes"
+    choose I18n.t("helpers.label.general_feedback_form.visit_purpose_options.other_purpose")
 
+    fill_in "general_feedback_form[visit_purpose_comment]", with: visit_purpose_comment
     fill_in "general_feedback_form[comment]", with: comment
 
-    choose("general-feedback-form-user-participation-response-interested-field")
+    choose name: "general_feedback_form[user_participation_response]", option: "interested"
     fill_in "email", with: email
   end
 end

--- a/spec/system/jobseekers_can_give_account_feedback_spec.rb
+++ b/spec/system/jobseekers_can_give_account_feedback_spec.rb
@@ -12,10 +12,13 @@ RSpec.describe "Jobseekers can give account feedback" do
   it "submits account feedback" do
     click_on I18n.t("jobseekers.account_survey_link_component.survey_link")
 
+    choose name: "jobseekers_account_feedback_form[report_a_problem]", option: "yes"
     choose I18n.t("helpers.label.jobseekers_account_feedback_form.rating_options.somewhat_satisfied")
+    choose name: "jobseekers_account_feedback_form[user_participation_response]", option: "interested"
     fill_in "jobseekers_account_feedback_form[comment]", with: comment
+
     expect { click_button I18n.t("buttons.submit") }.to change {
-      jobseeker.feedbacks.where(comment: comment, rating: "somewhat_satisfied", feedback_type: "jobseeker_account").count
+      jobseeker.feedbacks.where(comment: comment, email: jobseeker.email, rating: "somewhat_satisfied", feedback_type: "jobseeker_account", user_participation_response: "interested").count
     }.by(1)
     expect(current_path).to eq(jobseeker_root_path)
     expect(page).to have_content(I18n.t("jobseekers.account_feedbacks.create.success"))

--- a/spec/system/jobseekers_can_give_application_feedback_spec.rb
+++ b/spec/system/jobseekers_can_give_application_feedback_spec.rb
@@ -20,10 +20,11 @@ RSpec.describe "Jobseekers can give job application feedback after submitting th
     expect(page).to have_content("There is a problem")
 
     choose I18n.t("helpers.label.jobseekers_job_application_feedback_form.rating_options.somewhat_satisfied")
+    choose I18n.t("helpers.label.jobseekers_job_application_feedback_form.user_participation_response_options.interested")
     fill_in "jobseekers_job_application_feedback_form[comment]", with: comment
 
     expect { click_on I18n.t("buttons.submit_feedback") }.to change {
-      jobseeker.feedbacks.where(comment: comment, feedback_type: "application", rating: "somewhat_satisfied").count
+      jobseeker.feedbacks.where(comment: comment, email: jobseeker.email, feedback_type: "application", rating: "somewhat_satisfied", user_participation_response: "interested").count
     }.by(1)
 
     expect(current_path).to eq(jobseekers_job_applications_path)

--- a/spec/system/jobseekers_can_give_job_alert_feedback_spec.rb
+++ b/spec/system/jobseekers_can_give_job_alert_feedback_spec.rb
@@ -61,10 +61,13 @@ RSpec.describe "A jobseeker can give feedback on a job alert", recaptcha: true d
 
     context "when submitting further feedback" do
       let(:comment) { "Excellent" }
+      let(:email) { subscription.email }
 
       before do
         follow_the_link_in_the_job_alert_email
         fill_in "jobseekers_job_alert_further_feedback_form[comment]", with: comment
+        choose name: "jobseekers_job_alert_further_feedback_form[user_participation_response]", option: "interested"
+        fill_in "email", with: email
       end
 
       it "allows the user to submit further feedback" do
@@ -72,6 +75,8 @@ RSpec.describe "A jobseeker can give feedback on a job alert", recaptcha: true d
         expect(current_path).to eq root_path
         expect(page).to have_content(I18n.t("jobseekers.job_alert_feedbacks.update.success"))
         expect(feedback.comment).to eq comment
+        expect(feedback.email).to eq email
+        expect(feedback.user_participation_response).to eq("interested")
         expect(feedback.recaptcha_score).to eq(0.9)
       end
 

--- a/spec/system/jobseekers_can_manage_their_job_alerts_from_the_dashboard_spec.rb
+++ b/spec/system/jobseekers_can_manage_their_job_alerts_from_the_dashboard_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe "Jobseekers can manage their job alerts from the dashboard" do
         it "unsubscribes from the job alert and redirects to the dashboard" do
           click_on I18n.t("subscriptions.unsubscribe.button_text")
           choose I18n.t("helpers.label.jobseekers_unsubscribe_feedback_form.unsubscribe_reason_options.job_found")
+          choose name: "jobseekers_unsubscribe_feedback_form[user_participation_response]", option: "interested"
           click_button I18n.t("buttons.submit_feedback")
 
           expect(page).to have_css("h1.govuk-heading-l", text: I18n.t("jobseekers.subscriptions.index.page_title"))

--- a/spec/system/jobseekers_can_unsubscribe_from_subscriptions_spec.rb
+++ b/spec/system/jobseekers_can_unsubscribe_from_subscriptions_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe "A jobseeker can unsubscribe from subscriptions" do
   let(:subscription) { create(:subscription) }
+  let(:email) { "email@example.com" }
 
   context "with the correct token" do
     before do
@@ -32,9 +33,12 @@ RSpec.describe "A jobseeker can unsubscribe from subscriptions" do
         choose "jobseekers-unsubscribe-feedback-form-unsubscribe-reason-other-reason-field"
         fill_in "jobseekers_unsubscribe_feedback_form[other_unsubscribe_reason_comment]", with: "Spam"
         fill_in "jobseekers_unsubscribe_feedback_form[comment]", with: "Eggs"
+        choose name: "jobseekers_unsubscribe_feedback_form[user_participation_response]", option: "interested"
+        fill_in "jobseekers_unsubscribe_feedback_form[email]", with: email
 
         expect { click_on I18n.t("buttons.submit_feedback") }.to change {
           subscription.feedbacks.where(comment: "Eggs",
+                                       email: email,
                                        feedback_type: "unsubscribe",
                                        other_unsubscribe_reason_comment: "Spam",
                                        search_criteria: subscription.search_criteria,

--- a/spec/system/publishers_can_give_job_listing_feedback_spec.rb
+++ b/spec/system/publishers_can_give_job_listing_feedback_spec.rb
@@ -26,11 +26,13 @@ RSpec.describe "Publishers can give job listing feedback" do
 
       expect(page).to have_content("There is a problem")
 
+      choose name: "publishers_job_listing_feedback_form[report_a_problem]", option: "yes"
       choose I18n.t("helpers.label.publishers_job_listing_feedback_form.rating_options.somewhat_satisfied")
+      choose name: "publishers_job_listing_feedback_form[user_participation_response]", option: "interested"
       fill_in "publishers_job_listing_feedback_form[comment]", with: comment
 
       expect { click_on I18n.t("buttons.submit_feedback") }.to change {
-        publisher.feedbacks.where(comment: comment, feedback_type: "vacancy_publisher", vacancy_id: vacancy.id).count
+        publisher.feedbacks.where(comment: comment, email: publisher.email, feedback_type: "vacancy_publisher", user_participation_response: "interested", vacancy_id: vacancy.id).count
       }.by(1)
 
       expect(current_path).to eq(jobs_with_type_organisation_path(:published))


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2328

## Changes in this PR:

- Added "Do you need to report a problem, or request support with using Teaching Vacancies?" to the three feedback forms listed below

1. General feedback form
2. Jobseeker account feedback form
3. Create a job listing feedback form

- Added "Would you like to participate in our research?" to all forms

- Email field nested under "Would you like to participate in our research?" question is pre-populated with user's email, if available.

- Added validations and related error messages. If the user does not answer  "Do you need to report a problem, or request support with using Teaching Vacancies?", they are reminded. If they do not answer "Would you like to participate in our research?", they're also reminded to. If they do not provide an email answer "Yes" to the previous question, they are asked for their email address.

## Screenshots:

### General Feedback Form:

<img width="694" alt="General Feedback" src="https://user-images.githubusercontent.com/30624173/121379829-4fdc7200-c93c-11eb-95ef-7cc5733e1c37.png">

### Jobseeker Account Feedback Form

![Account Feedback](https://user-images.githubusercontent.com/30624173/121379893-5c60ca80-c93c-11eb-9ce4-395bb781acf3.png)

### Unsubscribe Feedback Form

![Unsubscribe Feedback](https://user-images.githubusercontent.com/30624173/121379976-6e426d80-c93c-11eb-95be-5057f0b971b9.png)

### Publish Job Listing Feedback Form

![Publisher Job Listing](https://user-images.githubusercontent.com/30624173/121380045-77cbd580-c93c-11eb-83ba-b479784b0464.png)

### Job Application Feedback Form

![Job Application Feedback](https://user-images.githubusercontent.com/30624173/121380089-81553d80-c93c-11eb-9fc9-9676174934fa.png)

### Job Alert Further Feedback

![Job Alert Further Feedback](https://user-images.githubusercontent.com/30624173/121380157-8e722c80-c93c-11eb-840e-d679b1a5bb9f.png)
