### PR TITLE
Update mapped_locations.yml

### DIFF
--- a/lib/tasks/data/mapped_locations.yml
+++ b/lib/tasks/data/mapped_locations.yml
@@ -83,6 +83,7 @@
 - ['newcastle under lyme', 'newcastle-under-lyme']
 - ['north east england', 'north east']
 - ['north east, england', 'north east']
+- ['north tyneside district', 'north tyneside']
 - ['north west england', 'north west']
 - ['north west, england', 'north west']
 - ['nottinghamshire, nottingham', 'nottinghamshire']


### PR DESCRIPTION
TEVA-1939 change, to map searches for North Tyneside District to the North Tyneside polygon.

## Jira ticket URL

- Just add the ticket number to the end:

https://dfedigital.atlassian.net/browse/TEVA-1939


