### PR TITLE
Set Sidekiq logger level to WARN

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -7,6 +7,7 @@ options = {
 # Redis concurrency must be plus 5 https://github.com/mperham/sidekiq/wiki/Using-Redis#complete-control
 Sidekiq.configure_server do |config|
   config.options.merge!(options)
+  config.logger.level = Logger::WARN
   config.redis = { url: Rails.configuration.redis_queue_url, network_timeout: 5, size: config.options[:concurrency] + 5 }
 end
 


### PR DESCRIPTION
Sidekiq logs quite extensively and the default `INFO` level is not that
helpful for us in production (it logs on start and end of every single
job, of which we have a lot). This turns down the log level to `WARN`
which should be less spammy.