### PR TITLE
[TEVA-2709] Increase fountainhead/action-wait-for-check timeout to 840

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -178,7 +178,7 @@ jobs:
         token: ${{ secrets.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
         checkName: Deploy ${{ env.DOCKER_IMAGE_TAG }} to ${{ env.ENVIRONMENT }} # Job name within triggered workflow
         ref: ${{ env.BUILD_GIT_TAG }}
-        timeoutSeconds: 720
+        timeoutSeconds: 1200
         intervalSeconds: 15
 
     - name: Notify twd_tv_dev channel on ${{ env.ENVIRONMENT }} deployment failure

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -172,7 +172,7 @@ jobs:
         inputs: '{"environment": "${{ env.ENVIRONMENT }}", "tag": "${{ env.DOCKER_IMAGE_TAG }}"}'
 
     - name: Wait for Deploy App Workflow for ${{ env.ENVIRONMENT }}
-      id: wait_for_deploy_app_staging
+      id: wait_for_deploy_app
       uses: fountainhead/action-wait-for-check@v1.0.0
       with:
         token: ${{ secrets.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
@@ -182,7 +182,7 @@ jobs:
         intervalSeconds: 15
 
     - name: Notify twd_tv_dev channel on ${{ env.ENVIRONMENT }} deployment failure
-      if: steps.wait_for_deploy_app_staging.outputs.conclusion != 'success'
+      if: steps.wait_for_deploy_app.outputs.conclusion != 'success'
       uses: rtCamp/action-slack-notify@v2.1.3
       env:
         SLACK_CHANNEL: twd_tv_dev
@@ -192,7 +192,7 @@ jobs:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
     - name: Exit whole workflow if ${{ env.ENVIRONMENT }} deployment was not successful
-      if: steps.wait_for_deploy_app_staging.outputs.conclusion != 'success'
+      if: steps.wait_for_deploy_app.outputs.conclusion != 'success'
       run: exit 1
 
     - name: Trigger Smoke Test


### PR DESCRIPTION
Following recent changes, we observed that most often than not,
the fountainhead/action-wait-for-check actions timeout while waiting
for the corresponding Deploy App to Environment to complete. Hence the
need for the increase in timeout.

## Jira ticket URL

- Just add the ticket number to the end:

https://dfedigital.atlassian.net/browse/TEVA-2709

## Changes in this PR:

.github/workflows/build_and_deploy.yml

