### PR TITLE
Add jobseeker email address to application form

### DIFF
--- a/app/views/shared/job_application/_show.html.slim
+++ b/app/views/shared/job_application/_show.html.slim
@@ -23,6 +23,7 @@
                                        tag.div(job_application.city, class: "govuk-body"),
                                        tag.div(job_application.postcode, class: "govuk-body")])
       - summary.slot :row, key: t(".personal_details.phone_number"), value: job_application.phone_number
+      - summary.slot :row, key: t(".personal_details.email"), value: job_application.jobseeker.email
       - if job_application.teacher_reference_number.present?
         - summary.slot :row, key: t(".personal_details.teacher_reference_number"), value: job_application.teacher_reference_number
       - if job_application.national_insurance_number.present?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -321,6 +321,7 @@ en:
           subjects: Subjects and key stages taught
         heading: Application sections
         personal_details:
+          email: Email address
           heading: Personal details
           first_name: First name
           last_name: Last name


### PR DESCRIPTION
There was an oversight where we forgot to provide hiring staff with the email contact for their candidates.

Slack conv:
https://ukgovernmentdfe.slack.com/archives/CG9A8H1HP/p1623246756048900

Support desk conv:
https://teachingjobs.zendesk.com/agent/tickets/20144

<img width="848" alt="Screenshot 2021-06-09 at 15 19 17" src="https://user-images.githubusercontent.com/60350599/121372274-10128c00-c936-11eb-9931-fe30c45263f5.png">


