### PR TITLE
refactor of filters front end code (removing moj dependency)

### DIFF
--- a/app/components/filters_component/filters_component.html.slim
+++ b/app/components/filters_component/filters_component.html.slim
@@ -1,44 +1,45 @@
 = tag.div(class: classes, **html_attributes) do
 
-  .filters-component__heading.moj-filter
+  .filters-component__heading
     = tag.div(class: options[:close_all] ? "filters-component__heading-container" : "") do
       .filters-component__section-heading class=mobile_modifier("filters-component__heading")
-        .moj-filter__heading-title
-          h2.govuk-heading-s class=mobile_modifier("filters-component__heading-title") id=(options[:mobile_variant] ? "mobile-filters-component-button" : "")
-            = filters[:title]
+        .filters-component__heading-title
+          a.govuk-button.govuk-button--secondary id=(options[:mobile_variant] ? "filters-component-show-mobile" : "")
+            = "Show filters"
+            span.govuk-body.filters-component__heading-applied = applied_text
+          h3.govuk-heading-s = filters[:title]
           - if options[:publisher_preference]
-            = govuk_link_to t(".add_or_remove_schools"), edit_publisher_preference_path(options[:publisher_preference]), class: "govuk-link--no-visited-state"
-          span.govuk-body.filters-component__heading-applied = applied_text
-          button.govuk-link.govuk-link--no-visited-state.filters-component--show-mobile-open id="return-to-results"
+            = govuk_link_to t(".add_or_remove_schools"), edit_publisher_preference_path(options[:publisher_preference]), class: "filters-button govuk-link--no-visited-state"
+
+          button.filters-button.filters-component--show-mobile-open id="filters-component-filters-component-return-to-results"
             = t("shared.filter_group.return_to_results")
         - if options[:close_all]
           span.js-action
-            button.govuk-link.govuk-link--no-visited-state.filters-component__heading-close-all id="close-all-groups" class="close-all"
+            button.filters-button.filters-component__heading-close-all id="filters-component-close-all"
               = t("shared.filter_group.close_all_filter_groups")
 
   .filters-component__remove
     - if display_remove_buttons
-      .moj-filter__content
-        .moj-filter__selected
-          .filters-component__section-heading class="govuk-!-margin-bottom-2"
-            .govuk-body class="govuk-!-margin-bottom-0"
-              = t("shared.filter_group.current_selected_filters")
-            button.govuk-link.govuk-link--no-visited-state id="clear-filters-component-button"
-              = t("shared.filter_group.clear_all_filters")
+      .filters-component-filter__selected
+        .filters-component__section-heading class="govuk-!-margin-bottom-2"
+          .govuk-body class="govuk-!-margin-bottom-0"
+            = t("shared.filter_group.current_selected_filters")
+          button.filters-button.govuk-link--no-visited-state id="filters-component-clear-all"
+            = t("shared.filter_group.clear_all_filters")
 
-          - items.each do |group|
-            - if group[:selected]&.any?
-              .govuk-heading-s class="govuk-!-margin-bottom-0 govuk-!-font-weight-bold"
-                = group[:title]
+        - items.each do |group|
+          - if group[:selected]&.any?
+            .govuk-heading-s class="govuk-!-margin-bottom-0 govuk-!-font-weight-bold"
+              = group[:title]
 
-            ul.moj-filter-tags
-              - group[:options].each do |tag|
-                - if group[:selected]&.include?(tag.send(group[:value_method]))
-                  li
-                    button.moj-filter__tag.icon.icon--left.icon--cross data-group=group[:key] data-key=tag.send(group[:value_method])
-                      span.govuk-visually-hidden
-                        = t("shared.filter_group.remove_filter_hidden")
-                      = tag.send(group[:selected_method])
+          ul.filters-component__remove-tags
+            - group[:options].each do |tag|
+              - if group[:selected]&.include?(tag.send(group[:value_method]))
+                li
+                  button.filters-component__remove-tags__tag.icon.icon--left.icon--cross data-group=group[:key] data-key=tag.send(group[:value_method])
+                    span.govuk-visually-hidden
+                      = t("shared.filter_group.remove_filter_hidden")
+                    = tag.send(group[:selected_method])
 
   .filters-component__submit
     = form.govuk_submit t("buttons.apply_filters"), classes: "govuk-!-margin-top-4 govuk-!-margin-bottom-2 filters-component__submit-button"
@@ -47,7 +48,7 @@
     - items.each_with_index do |group, index|
       - component.slot(:section,
         title: group[:title]) do
-          .govuk-accordion__section-content.filters-component__group id="accordion-default-content-#{index}" aria-labelledby="accordion-default-heading-#{index}" data-group=group[:key]
+          .govuk-accordion__section-content.filters-component__groups__group id="accordion-default-content-#{index}" aria-labelledby="accordion-default-heading-#{index}" data-group=group[:key]
             = form.govuk_collection_check_boxes group[:attribute],
               group[:options],
               group[:value_method],

--- a/app/components/filters_component/filters_component.js
+++ b/app/components/filters_component/filters_component.js
@@ -5,35 +5,43 @@ import 'classlist-polyfill';
 export const ACCORDION_SECTION_CLASS_SELECTOR = 'govuk-accordion__section';
 export const ACCORDION_SECTION_EXPANDED_CLASS_SELECTOR = 'govuk-accordion__section--expanded';
 export const CHECKBOX_CLASS_SELECTOR = 'govuk-checkboxes__input';
-export const CHECKBOX_GROUP_CLASS_SELECTOR = 'filters-component__group';
+export const CHECKBOX_GROUP_CLASS_SELECTOR = 'filters-component__groups__group';
+export const REMOVE_FILTER_CLASS_SELECTOR = 'filters-component__remove-tags__tag';
 export const CLOSE_ALL_TEXT = 'Close all';
 export const OPEN_ALL_TEXT = 'Open all';
 
 window.addEventListener(
   'DOMContentLoaded',
-  () => init('govuk-accordion__section', 'moj-filter__tag', 'clear-filters-component-button', 'close-all-groups', 'mobile-filters-component-button', 'govuk-accordion__section-header'),
+  () => init(
+    ACCORDION_SECTION_CLASS_SELECTOR,
+    REMOVE_FILTER_CLASS_SELECTOR,
+    'filters-component-clear-all',
+    'filters-component-close-all',
+    'filters-component-show-mobile',
+    'govuk-accordion__section-header',
+  ),
 );
 
-export const init = (groupContainerSelector, removeButtonSelector, clearButtonSelector, closeButtonSelector, mobileFiltersButtonSelector, accordionButtonsSelector) => {
+export const init = (groupContainerSelector, removeButtonSelector, clearButtonId, closeButtonId, mobileFiltersButtonSelector, accordionButtonsSelector) => {
   if (!isFormAutoSubmitEnabled(groupContainerSelector)) { return; }
 
-  Array.from(document.getElementsByClassName(accordionButtonsSelector)).forEach((accordionButton) => filterGroup.addUpdateOpenOrCloseEvent(accordionButton, closeButtonSelector));
+  Array.from(document.getElementsByClassName(accordionButtonsSelector)).forEach((accordionButton) => filterGroup.addUpdateOpenOrCloseEvent(accordionButton, closeButtonId));
 
   Array.from(document.getElementsByClassName(removeButtonSelector)).forEach((removeButton) => filterGroup.addRemoveFilterEvent(removeButton, () => getSubmitButton(removeButton).click()));
 
-  const clearButton = document.getElementById(clearButtonSelector);
+  const clearButton = document.getElementById(clearButtonId);
   if (clearButton) {
     filterGroup.addRemoveAllFiltersEvent(clearButton, () => getSubmitButton(clearButton).click());
   }
 
   addFilterChangeEvent(document.getElementsByClassName(groupContainerSelector));
-  if (document.getElementById(closeButtonSelector)) {
+  if (document.getElementById(closeButtonId)) {
     displayOpenOrCloseText(
-      document.getElementById(closeButtonSelector),
+      document.getElementById(closeButtonId),
       document.getElementsByClassName(ACCORDION_SECTION_EXPANDED_CLASS_SELECTOR).length,
       document.getElementsByClassName(ACCORDION_SECTION_CLASS_SELECTOR).length,
     );
-    document.getElementById(closeButtonSelector).addEventListener('click', openOrCloseAllSectionsHandler);
+    document.getElementById(closeButtonId).addEventListener('click', openOrCloseAllSectionsHandler);
   }
 
   if (document.getElementById(mobileFiltersButtonSelector)) {
@@ -46,8 +54,8 @@ export const init = (groupContainerSelector, removeButtonSelector, clearButtonSe
     });
   }
 
-  if (document.getElementById('return-to-results')) {
-    document.getElementById('return-to-results').addEventListener('click', (e) => {
+  if (document.getElementById('filters-component-return-to-results')) {
+    document.getElementById('filters-component-return-to-results').addEventListener('click', (e) => {
       e.preventDefault();
       return Array.from(document.getElementsByClassName('filters-component')).map((element) => element.classList.toggle('filters-component--show-mobile'));
     });

--- a/app/components/filters_component/filters_component.scss
+++ b/app/components/filters_component/filters_component.scss
@@ -32,6 +32,7 @@
 
         .filters-component--show-mobile-open {
           display: block;
+          top: 6px;
         }
 
         .filters-component__groups {
@@ -46,17 +47,25 @@
           .filters-component__heading-applied {
             display: none;
           }
+
+          .govuk-heading-s {
+            display: block;
+          }
+
+          .govuk-button {
+            display: none;
+          }
         }
       }
     }
   }
 
-  .govuk-link {
+  .filters-button {
     background: none;
     border: 0;
     color: $govuk-link-colour;
     cursor: pointer;
-    font-size: 1rem;
+    font-size: 0.9rem;
     padding: 0;
     position: absolute;
     right: 0;
@@ -64,10 +73,30 @@
     top: 0;
   }
 
-  .filters-component__heading {
+  &__heading {
     box-shadow: none;
 
-    .govuk-link {
+    @include govuk-media-query($from: mobile) {
+      .govuk-heading-s {
+        display: none;
+      }
+
+      .govuk-button {
+        display: block;
+      }
+    }
+
+    @include govuk-media-query($from: tablet) {
+      .govuk-heading-s {
+        display: block;
+      }
+
+      .govuk-button {
+        display: none;
+      }
+    }
+
+    .filters-button {
       top: govuk-spacing(1);
     }
 
@@ -79,17 +108,7 @@
       }
     }
 
-    &--mobile {
-      @include govuk-media-query($until: tablet) {
-        background-image: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 22 22"><path fill-rule="evenodd" clip-rule="evenodd" d="M13.4444 20.1667V11.9167L20.4538 4.8889C20.558 4.78472 20.6403 4.66079 20.6959 4.52436C20.7516 4.38794 20.7794 4.24178 20.7777 4.09446V3.05557C20.7777 2.89349 20.7133 2.73805 20.5987 2.62345C20.4841 2.50884 20.3287 2.44446 20.1666 2.44446H1.83328C1.6712 2.44446 1.51576 2.50884 1.40116 2.62345C1.28655 2.73805 1.22217 2.89349 1.22217 3.05557V4.07612C1.22228 4.22046 1.25096 4.36335 1.30655 4.49655C1.36214 4.62975 1.44354 4.75064 1.54606 4.85224L8.5555 11.9656V18.1989L13.4444 20.1667Z" ></path></svg>');
-        background-position: top 5px left;
-        background-repeat: no-repeat;
-        background-size: 22px 22px;
-        padding-left: govuk-spacing(5);
-      }
-    }
-
-    .moj-filter__heading-title {
+    &-title {
 
       display: flex;
       @include govuk-media-query($until: tablet) {
@@ -100,11 +119,6 @@
         line-height: 1.8em;
         margin-bottom: 0;
       }
-
-      .filters-component__heading-title {
-        margin-bottom: govuk-spacing(1);
-        margin-top: govuk-spacing(2);
-      }
     }
 
     &-applied {
@@ -112,7 +126,7 @@
 
       @include govuk-media-query($until: tablet) {
         color: govuk-colour('black');
-        display: block;
+        display: inline;
         font-weight: normal;
         margin: govuk-spacing(1);
         text-decoration: none;
@@ -120,6 +134,8 @@
     }
 
     &-close-all {
+      top: govuk-spacing(1);
+
       @include govuk-media-query($until: tablet) {
         display: none;
       }
@@ -138,58 +154,72 @@
     }
   }
 
-  .filters-component__remove {
-
+  &__remove {
     box-shadow: none;
+
     @include govuk-media-query($until: tablet) {
       display: none;
     }
 
-    .moj-filter__selected {
+    .filters-component-filter__selected {
+      background-color: govuk-colour('light-grey');
       box-shadow: none;
       padding: govuk-spacing(2);
       position: relative;
     }
 
-    .moj-filter__content {
-      .govuk-heading-s {
-        font-size: 1rem;
+    .govuk-heading-s {
+      font-size: 1rem;
+    }
+
+    .govuk-body {
+      font-size: 1rem;
+      font-weight: normal;
+    }
+
+    &-tags {
+      list-style-type: none;
+      margin-bottom: govuk-spacing(2);
+      margin-top: govuk-spacing(1);
+      padding-left: 0;
+
+      li {
+        display: inline-block;
+        margin-right: 10px;
       }
 
-      .govuk-body {
+      &__tag {
+        background-color: govuk-colour('white');
+        border-radius: govuk-spacing(1);
+        border-width: 1px;
+        cursor: pointer;
         font-size: 1rem;
-        font-weight: normal;
-      }
+        -webkit-font-smoothing: antialiased;
+        font-weight: 400;
+        line-height: 1.25;
+        margin-top: 5px;
+        padding: 5px;
 
-      .moj-filter-tags {
-        margin-bottom: govuk-spacing(2);
-        margin-top: govuk-spacing(1);
+        &::after {
+          height: 0;
+          width: 0;
+        }
 
-        .moj-filter__tag {
-          border-radius: govuk-spacing(1);
-          cursor: pointer;
+        &.icon--left {
+          background-position: govuk-spacing(1);
+          padding-left: 28px;
+        }
 
-          &::after {
-            height: 0;
-            width: 0;
-          }
-
-          &.icon--left {
-            background-position: govuk-spacing(1);
-            padding-left: 28px;
-          }
-
-          .fa-times {
-            color: $govuk-link-colour;
-            font-size: 80%;
-            margin: 0 govuk-spacing(1);
-          }
+        .fa-times {
+          color: $govuk-link-colour;
+          font-size: 80%;
+          margin: 0 govuk-spacing(1);
         }
       }
     }
   }
 
-  .filters-component__submit {
+  &__submit {
     @include govuk-media-query($until: tablet) {
       background-color: govuk-colour('white');
       bottom: 0;
@@ -200,19 +230,19 @@
       width: 100%;
       z-index: 2000;
 
-      &-button {
+      .govuk-button {
         margin: 0 govuk-spacing(3);
       }
     }
   }
 
-  .filters-component__groups {
+  &__groups {
     .govuk-accordion__section-button {
       font-size: 1.2rem;
       padding: 0 0 govuk-spacing(1) 0;
     }
 
-    .filters-component__group {
+    &__group {
       border: 2px solid $govuk-border-colour;
       margin-bottom: govuk-spacing(3);
 
@@ -222,17 +252,6 @@
       }
     }
   }
-}
-
-// misc (for dashboard)
-.moj-filter-sidebar {
-  &.moj-filter-sidebar__hidden {
-    display: none;
-  }
-}
-
-.moj-action-bar {
-  margin-bottom: govuk-spacing(3);
 }
 
 .js-enabled .filters-component__submit {

--- a/app/components/filters_component/filters_component.test.js
+++ b/app/components/filters_component/filters_component.test.js
@@ -22,6 +22,7 @@ import filterGroup, {
   OPEN_ALL_TEXT,
   ACCORDION_SECTION_CLASS_SELECTOR,
   ACCORDION_SECTION_EXPANDED_CLASS_SELECTOR,
+  REMOVE_FILTER_CLASS_SELECTOR,
   addUpdateOpenOrCloseEvent,
 } from './filters_component';
 
@@ -46,17 +47,17 @@ describe('filterGroup', () => {
       const addUpdateOpenOrCloseEventMock = jest.spyOn(filterGroup, 'addUpdateOpenOrCloseEvent');
 
       document.body.innerHTML = `<form data-auto-submit="true"><div>
-<h2 id="mobile-filters-component-button"></h2>
-<button class="moj-filter__tag">remove</button>
-<button class="moj-filter__tag">remove</button>
-<button id="clear-filters-component-button">remove</button>
-<button id="close-all-groups">remove</button>
+<h2 id="filters-component-show-mobile"></h2>
+<button class="${REMOVE_FILTER_CLASS_SELECTOR}">remove</button>
+<button class="${REMOVE_FILTER_CLASS_SELECTOR}">remove</button>
+<button id="filters-component-clear-all">remove</button>
+<button id="filters-component-close-all">remove</button>
 </div>
-<div class="govuk-accordion__section"><div class="govuk-accordion__section-header"><h3 class="heading"><button class="govuk-accordion__section-button"></button></h3></div></div>
-<div class="govuk-accordion__section"><div class="govuk-accordion__section-header"><h3 class="heading"><button class="govuk-accordion__section-button"></button></h3></div></div>
+<div class="${ACCORDION_SECTION_CLASS_SELECTOR}"><div class="govuk-accordion__section-header"><h3 class="heading"><button class="govuk-accordion__section-button"></button></h3></div></div>
+<div class="${ACCORDION_SECTION_CLASS_SELECTOR}"><div class="govuk-accordion__section-header"><h3 class="heading"><button class="govuk-accordion__section-button"></button></h3></div></div>
 </form>`;
 
-      init('govuk-accordion__section', 'moj-filter__tag', 'clear-filters-component-button', 'close-all-groups', 'mobile-filters-component-button', 'govuk-accordion__section-header');
+      init(ACCORDION_SECTION_CLASS_SELECTOR, REMOVE_FILTER_CLASS_SELECTOR, 'filters-component-clear-all', 'filters-component-close-all', 'filters-component-show-mobile', 'govuk-accordion__section-header');
 
       expect(addRemoveFilterEventMock).toHaveBeenCalledTimes(2);
       expect(addRemoveAllFiltersEventMock).toHaveBeenCalledTimes(1);
@@ -215,7 +216,7 @@ describe('filterGroup', () => {
   describe('filterChangeHandler', () => {
     test('submits the form only if a filter checkbox is clicked', () => {
       document.body.innerHTML = `<form data-auto-submit="true">
-  <div class="govuk-accordion__section">
+  <div class="${ACCORDION_SECTION_CLASS_SELECTOR}">
   <input type="text" id="should-submit" class="${CHECKBOX_CLASS_SELECTOR}" />
   <span id="should-not-submit">abc</span>
   </div>
@@ -250,9 +251,9 @@ describe('filterGroup', () => {
 
   describe('openOrCloseAllSectionsHandler', () => {
     test('removes the class selector from all filter groups that makes them visible', () => {
-      document.body.innerHTML = `<div class="govuk-accordion__section govuk-accordion__section--expanded"></div>
-      <div class="govuk-accordion__section govuk-accordion__section--expanded"></div>
-      <div class="govuk-accordion__section"></div>`;
+      document.body.innerHTML = `<div class="govuk-accordion__section ${ACCORDION_SECTION_EXPANDED_CLASS_SELECTOR}"></div>
+      <div class="govuk-accordion__section ${ACCORDION_SECTION_EXPANDED_CLASS_SELECTOR}"></div>
+      <div class="${ACCORDION_SECTION_CLASS_SELECTOR}"></div>`;
 
       const event = { preventDefault: jest.fn(), target: { innerText: CLOSE_ALL_TEXT } };
       const dontFollowLinkMock = jest.spyOn(event, 'preventDefault');
@@ -260,13 +261,13 @@ describe('filterGroup', () => {
       openOrCloseAllSectionsHandler(event);
 
       expect(dontFollowLinkMock).toHaveBeenCalled();
-      expect(document.getElementsByClassName('govuk-accordion__section--expanded').length).toEqual(0);
+      expect(document.getElementsByClassName(ACCORDION_SECTION_EXPANDED_CLASS_SELECTOR).length).toEqual(0);
     });
 
     test('adds the class selector from all filter groups that makes them visible', () => {
-      document.body.innerHTML = `<div class="govuk-accordion__section govuk-accordion__section--expanded"></div>
-      <div class="govuk-accordion__section govuk-accordion__section--expanded"></div>
-      <div class="govuk-accordion__section"></div>`;
+      document.body.innerHTML = `<div class="govuk-accordion__section ${ACCORDION_SECTION_EXPANDED_CLASS_SELECTOR}"></div>
+      <div class="govuk-accordion__section ${ACCORDION_SECTION_EXPANDED_CLASS_SELECTOR}"></div>
+      <div class="${ACCORDION_SECTION_CLASS_SELECTOR}"></div>`;
 
       const event = { preventDefault: jest.fn(), target: { innerText: OPEN_ALL_TEXT } };
       const dontFollowLinkMock = jest.spyOn(event, 'preventDefault');
@@ -274,7 +275,7 @@ describe('filterGroup', () => {
       openOrCloseAllSectionsHandler(event);
 
       expect(dontFollowLinkMock).toHaveBeenCalled();
-      expect(document.getElementsByClassName('govuk-accordion__section--expanded').length).toEqual(3);
+      expect(document.getElementsByClassName(ACCORDION_SECTION_EXPANDED_CLASS_SELECTOR).length).toEqual(3);
     });
   });
 
@@ -300,25 +301,25 @@ describe('filterGroup', () => {
 
   describe('openOrCloseAllSections', () => {
     test('closes all elements when called', () => {
-      document.body.innerHTML = `<div class="govuk-accordion__section govuk-accordion__section--expanded"></div>
-      <div class="govuk-accordion__section govuk-accordion__section--expanded"></div>
-      <div class="govuk-accordion__section"></div>`;
+      document.body.innerHTML = `<div class="govuk-accordion__section ${ACCORDION_SECTION_EXPANDED_CLASS_SELECTOR}"></div>
+      <div class="govuk-accordion__section ${ACCORDION_SECTION_EXPANDED_CLASS_SELECTOR}"></div>
+      <div class="${ACCORDION_SECTION_CLASS_SELECTOR}"></div>`;
       const targetElement = { innerText: CLOSE_ALL_TEXT };
 
       openOrCloseAllSections(targetElement);
       expect(targetElement.innerText).toEqual(OPEN_ALL_TEXT);
-      expect(document.getElementsByClassName('govuk-accordion__section--expanded').length).toEqual(0);
+      expect(document.getElementsByClassName(ACCORDION_SECTION_EXPANDED_CLASS_SELECTOR).length).toEqual(0);
     });
 
     test('opens all elements when called', () => {
-      document.body.innerHTML = `<div class="govuk-accordion__section govuk-accordion__section--expanded"></div>
-      <div class="govuk-accordion__section govuk-accordion__section--expanded"></div>
-      <div class="govuk-accordion__section"></div>`;
+      document.body.innerHTML = `<div class="govuk-accordion__section ${ACCORDION_SECTION_EXPANDED_CLASS_SELECTOR}"></div>
+      <div class="govuk-accordion__section ${ACCORDION_SECTION_EXPANDED_CLASS_SELECTOR}"></div>
+      <div class="${ACCORDION_SECTION_CLASS_SELECTOR}"></div>`;
       const targetElement = { innerText: OPEN_ALL_TEXT };
 
       openOrCloseAllSections(targetElement);
       expect(targetElement.innerText).toEqual(CLOSE_ALL_TEXT);
-      expect(document.getElementsByClassName('govuk-accordion__section--expanded').length).toEqual(3);
+      expect(document.getElementsByClassName(ACCORDION_SECTION_EXPANDED_CLASS_SELECTOR).length).toEqual(3);
     });
   });
 
@@ -326,13 +327,13 @@ describe('filterGroup', () => {
     const accordionTemplate = (allOpen) => {
       const expandedClass = allOpen ? ACCORDION_SECTION_EXPANDED_CLASS_SELECTOR : '';
       return `
-      <div><button id="close-all-groups"></button></div>
+      <div><button id="filters-component-close-all"></button></div>
       <div class="${ACCORDION_SECTION_CLASS_SELECTOR} ${expandedClass}"><div></div></div>
       <div class="${ACCORDION_SECTION_CLASS_SELECTOR} ${expandedClass}"><div id="click-this-header"></div></div>
       `;
     };
 
-    const openOrCloseAllSelector = 'close-all-groups';
+    const openOrCloseAllSelector = 'filters-component-close-all';
 
     test('displays close all when all elements are open', () => {
       document.body.innerHTML = accordionTemplate(true);

--- a/app/components/publishers/vacancies_component/vacancies_component.html.slim
+++ b/app/components/publishers/vacancies_component/vacancies_component.html.slim
@@ -7,31 +7,30 @@
         h1.govuk-heading-l class="govuk-!-margin-bottom-4" = t(".#{@selected_type}.with_count_html", count: @vacancies.count)
 
     .govuk-grid-row
-      .moj-filter-sidebar class="govuk-!-margin-bottom-5"
-        - if @organisation.school_group?
-          .govuk-grid-column-one-third
-            = form_for @publisher_preference, html: { data: { "auto-submit": true, "hide-submit": true } } do |f|
-              = render(FiltersComponent.new(filters: { total_count: @publisher_preference.organisations.count,
-                                                               title: t("jobs.filters.job_filters") },
-                                                               form: f,
-                                                               items: [{ title: "Locations",
-                                                                         key: "locations",
-                                                                         search: true,
-                                                                         scroll: true,
-                                                                         attribute: :organisation_ids,
-                                                                         selected: @publisher_preference.organisations.map(&:id),
-                                                                         options: @organisation_options,
-                                                                         value_method: :id,
-                                                                         text_method: :label,
-                                                                         selected_method: :name,
-                                                                         small: true }],
-                                                               options: { remove_buttons: true,
-                                                                          mobile_variant: true,
-                                                                          publisher_preference: (@publisher_preference if @organisation.local_authority?) }))
+      - if @organisation.school_group?
+        .govuk-grid-column-one-third class="govuk-!-margin-bottom-5"
+          = form_for @publisher_preference, html: { data: { "auto-submit": true, "hide-submit": true } } do |f|
+            = render(FiltersComponent.new(filters: { total_count: @publisher_preference.organisations.count,
+                                                              title: t("jobs.filters.job_filters") },
+                                                              form: f,
+                                                              items: [{ title: "Locations",
+                                                                        key: "locations",
+                                                                        search: true,
+                                                                        scroll: true,
+                                                                        attribute: :organisation_ids,
+                                                                        selected: @publisher_preference.organisations.map(&:id),
+                                                                        options: @organisation_options,
+                                                                        value_method: :id,
+                                                                        text_method: :label,
+                                                                        selected_method: :name,
+                                                                        small: true }],
+                                                              options: { remove_buttons: true,
+                                                                        mobile_variant: true,
+                                                                        publisher_preference: (@publisher_preference if @organisation.local_authority?) }))
 
-              = f.hidden_field :jobs_type, value: @selected_type
+            = f.hidden_field :jobs_type, value: @selected_type
 
-      .moj-filter-layout__content class=grid_column_class
+      .vacancies-component__content class=grid_column_class
         - if @vacancies.any?
           = form_for @sort_form, as: "", url: jobs_with_type_organisation_path(@selected_type), method: :get, data: { "auto-submit": true, "hide-submit": true } do |f|
             = f.govuk_collection_select :sort_column,

--- a/app/frontend/src/styles/application.scss
+++ b/app/frontend/src/styles/application.scss
@@ -10,7 +10,6 @@ $govuk-font-url-function: frontend-font-url;
 $govuk-image-url-function: frontend-image-url;
 
 @import '~govuk-frontend/govuk/all';
-@import '~@ministryofjustice/frontend/moj/all';
 @import '~trix/dist/trix';
 
 @import 'base/mixins';

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "not dead"
   ],
   "dependencies": {
-    "@ministryofjustice/frontend": "^0.2.4",
     "@rails/webpacker": "5.3.0",
     "axios": "^0.21.1",
     "classlist-polyfill": "^1.2.0",

--- a/spec/components/filters_component_spec.rb
+++ b/spec/components/filters_component_spec.rb
@@ -29,12 +29,12 @@ RSpec.describe FiltersComponent, type: :component do
 
   context "when there are selected filters" do
     it "renders filter remove UI" do
-      expect(subject.css(".moj-filter__content").to_html).not_to be_blank
+      expect(subject.css(".filters-component__remove").to_html).not_to be_blank
     end
 
     it "renders filter remove buttons for the selected filters" do
-      expect(subject.css(".moj-filter__content .govuk-heading-s").to_html).to include("Group 1")
-      expect(subject.css(".moj-filter__content .govuk-heading-s").to_html).to include("Group 2")
+      expect(subject.css(".filters-component__remove .govuk-heading-s").to_html).to include("Group 1")
+      expect(subject.css(".filters-component__remove .govuk-heading-s").to_html).to include("Group 2")
     end
 
     it "renders count of number of filters applied" do
@@ -52,8 +52,8 @@ RSpec.describe FiltersComponent, type: :component do
     end
 
     it "filters remove UI is not visible" do
-      expect(subject.css(".moj-filter__content").to_html).to be_blank
-      expect(subject.css(".moj-filter__content .govuk-heading-s").to_html).to be_blank
+      expect(subject.css(".filters-component__remove").to_html).to be_blank
+      expect(subject.css(".filters-component__remove .govuk-heading-s").to_html).to be_blank
       expect(subject.css(".filters-component__heading-applied").to_html).to be_blank
     end
   end

--- a/spec/components/publishers/vacancies_component_spec.rb
+++ b/spec/components/publishers/vacancies_component_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Publishers::VacanciesComponent, type: :component do
         let!(:inline_component) { render_inline(subject) }
 
         it "renders the vacancies component" do
-          expect(inline_component.css(".moj-filter-layout__content").to_html).not_to be_blank
+          expect(inline_component.css(".vacancies-component__content").to_html).not_to be_blank
         end
 
         it "renders the number of jobs in the heading" do
@@ -97,7 +97,7 @@ RSpec.describe Publishers::VacanciesComponent, type: :component do
         let!(:inline_component) { render_inline(subject) }
 
         it "renders the vacancies component" do
-          expect(inline_component.css(".moj-filter-layout__content").to_html).not_to be_blank
+          expect(inline_component.css(".vacancies-component__content").to_html).not_to be_blank
         end
 
         it "renders the number of jobs in the heading" do
@@ -158,7 +158,7 @@ RSpec.describe Publishers::VacanciesComponent, type: :component do
         let!(:inline_component) { render_inline(subject) }
 
         it "renders the vacancies component" do
-          expect(inline_component.css(".moj-filter-layout__content").to_html).not_to be_blank
+          expect(inline_component.css(".vacancies-component__content").to_html).not_to be_blank
         end
 
         it "renders the number of jobs in the heading" do

--- a/spec/system/hiring_staff_can_filter_vacancies_in_their_dashboard_spec.rb
+++ b/spec/system/hiring_staff_can_filter_vacancies_in_their_dashboard_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Hiring staff can filter vacancies in their dashboard" do
       scenario "it shows all published vacancies" do
         visit jobs_with_type_organisation_path(:published)
 
-        expect(page).to_not have_css(".moj-filter__tag")
+        expect(page).to_not have_css(".filters-component__remove-tags__tag")
 
         expect(page).to have_content(school_group_vacancy.job_title)
         expect(page).to have_content(school1_vacancy.job_title)
@@ -46,7 +46,7 @@ RSpec.describe "Hiring staff can filter vacancies in their dashboard" do
           check "Happy Rainbows School (1)"
           click_on I18n.t("buttons.apply_filters")
 
-          expect(page).to have_css(".moj-filter__tag", count: 1)
+          expect(page).to have_css(".filters-component__remove-tags__tag", count: 1)
 
           expect(page).to_not have_content(school_group_vacancy.job_title)
           expect(page).to have_content(school1_vacancy.job_title)
@@ -60,7 +60,7 @@ RSpec.describe "Hiring staff can filter vacancies in their dashboard" do
       scenario "it shows all draft vacancies" do
         visit jobs_with_type_organisation_path(:draft)
 
-        expect(page).to_not have_css(".moj-filter__tag")
+        expect(page).to_not have_css(".filters-component__remove-tags__tag")
 
         expect(page).to_not have_content(school_group_vacancy.job_title)
         expect(page).to_not have_content(school1_vacancy.job_title)
@@ -79,7 +79,7 @@ RSpec.describe "Hiring staff can filter vacancies in their dashboard" do
     scenario "it shows filtered published vacancies" do
       visit organisation_path
 
-      expect(page).to have_css(".moj-filter__tag", count: 2)
+      expect(page).to have_css(".filters-component__remove-tags__tag", count: 2)
 
       expect(page).to_not have_content(school_group_vacancy.job_title)
       expect(page).to have_content(school1_vacancy.job_title)

--- a/spec/system/jobseekers_can_search_from_home_page_spec.rb
+++ b/spec/system/jobseekers_can_search_from_home_page_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Searching on the home page", vcr: { cassette_name: "algoliasearc
     expect(page.find("#keyword-field").value).to eq("math")
     expect(page.find("#location-field").value).to eq("bristol")
 
-    expect(page).to have_css(".moj-filter__tag", count: 4)
+    expect(page).to have_css(".filters-component__remove-tags__tag", count: 4)
 
     expect(page.find("#job-roles-nqt-suitable-field")).to be_checked
     expect(page.find("#phases-primary-field")).to be_checked

--- a/spec/system/publishers_can_see_the_vacancies_dashboard_spec.rb
+++ b/spec/system/publishers_can_see_the_vacancies_dashboard_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "Hiring staff can see the vacancies dashboard" do
         click_on(I18n.t("publishers.vacancies_component.published.tab_heading"))
       end
 
-      within(".moj-filter-layout__content") do
+      within(".vacancies-component__content") do
         expect(page).to have_content(published_vacancy.job_title)
         expect(page).to have_css(".card-component", count: 1)
       end
@@ -82,7 +82,7 @@ RSpec.describe "Hiring staff can see the vacancies dashboard" do
         click_on(I18n.t("publishers.vacancies_component.draft.tab_heading"))
       end
 
-      within(".moj-filter-layout__content") do
+      within(".vacancies-component__content") do
         expect(page).to have_content(I18n.t("jobs.manage.draft.time_created"))
         expect(page).to have_content(format_date(draft_vacancy.created_at.to_date))
         expect(page).to have_content(format_date(draft_vacancy.updated_at.to_date))
@@ -98,7 +98,7 @@ RSpec.describe "Hiring staff can see the vacancies dashboard" do
         click_on(I18n.t("publishers.vacancies_component.pending.tab_heading"))
       end
 
-      within(".moj-filter-layout__content") do
+      within(".vacancies-component__content") do
         expect(page).to have_content(I18n.t("jobs.publication_date"))
         expect(page).to have_content(pending_vacancy.job_title)
         expect(page).to have_content(format_date(pending_vacancy.publish_on))
@@ -114,7 +114,7 @@ RSpec.describe "Hiring staff can see the vacancies dashboard" do
         click_on(I18n.t("publishers.vacancies_component.expired.tab_heading"))
       end
 
-      within(".moj-filter-layout__content") do
+      within(".vacancies-component__content") do
         expect(page).to have_content(expired_vacancy.job_title)
         expect(page).to have_content(format_date(expired_vacancy.expires_at.to_date))
         expect(page).to have_content(format_date(expired_vacancy.publish_on))
@@ -137,7 +137,7 @@ RSpec.describe "Hiring staff can see the vacancies dashboard" do
           click_on(I18n.t("publishers.vacancies_component.draft.tab_heading"))
         end
 
-        within(".moj-filter-layout__content") do
+        within(".vacancies-component__content") do
           expect(page).to have_content(format_date(draft_vacancy.created_at.to_date))
           expect(page).to have_content(format_date(draft_vacancy.updated_at.to_date))
         end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1182,13 +1182,6 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@ministryofjustice/frontend@^0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@ministryofjustice/frontend/-/frontend-0.2.4.tgz#88b6a0d03b5ef2f577dddd0e4624deb66821e738"
-  integrity sha512-KmDTogrU0cDBs7Mwa/v2I5jHEdeV67oyHohX2MezQCC8HZnCFh5ZtqYPsdXd3fj0Smb/H9m5NHv5wdWPNkLkrA==
-  dependencies:
-    moment "^2.27.0"
-
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz#d4b3549a5db5de2683e0c1071ab4f140904bbf69"
@@ -6661,11 +6654,6 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
-
-moment@^2.27.0:
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
-  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
no ticket

@csutter bought up the MOJ frontend dependency we have. And off the back of it this PR has given me great pleasure

## Changes in this PR:

- it turns out MOJ was purely for a specific part of the filters UI and it has been on the radar to remove the dependency for sometime and this PR removes it. removes ~70k of unminified CSS that we were using for 2 or 3 style rules.
- talked to @jesseyuen about a few filters related bits and i have refactored a heading that was being used as a button on mobile. now it is a button on mobile and h3 on desktop.
- tightened up the filters JS unit tests so the tests are a bit more tied to to the script it is testing in terms of HTML selectors used otherwise false positives could creep in.

there is no before and after as they should be exactly the same. the one area changed as described above follows

(ignore the showing x results of ... part which looks nasty. again mentioned this to @jesseyuen but i will adress that in separate PR as its not really anything to do with filters)

## Screenshots of UI changes:

### Before
![Screenshot 2021-06-09 at 15 35 04](https://user-images.githubusercontent.com/1792451/121375681-d1ca9c00-c938-11eb-885f-34a9556cca25.png)

![Screenshot 2021-06-09 at 15 40 48](https://user-images.githubusercontent.com/1792451/121376079-22da9000-c939-11eb-99dd-890b5f95ee16.png)

### After
![Screenshot 2021-06-09 at 15 56 15](https://user-images.githubusercontent.com/1792451/121378681-51f20100-c93b-11eb-84c8-1bf40f655106.png)

![Screenshot 2021-06-09 at 15 40 39](https://user-images.githubusercontent.com/1792451/121376138-2d952500-c939-11eb-963d-acba82488c4e.png)
