### PR TITLE
Anonymise vacancy ids in request events

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -97,10 +97,15 @@ class ApplicationController < ActionController::Base
   end
 
   def trigger_click_event
-    request_event.trigger(click_event_param.to_sym)
+    request_event.trigger(click_event_param.to_sym, click_event_data_params.to_h)
   end
 
   def click_event_param
     params[:click_event]
+  end
+
+  def click_event_data_params
+    # Any params that might be present must be explicitly permitted in order to convert to hash
+    params[:click_event_data].permit(:vacancy_id)
   end
 end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,7 +1,10 @@
 class DocumentsController < ApplicationController
   def show
     document = Document.find(params[:id])
-    request_event.trigger(:vacancy_document_downloaded, vacancy_id: document.vacancy.id, document_id: document.id, filename: document.name)
+    request_event.trigger(:vacancy_document_downloaded,
+                          vacancy_id: StringAnonymiser.new(document.vacancy.id),
+                          document_id: StringAnonymiser.new(document.id),
+                          filename: document.name)
     redirect_to(document.download_url)
   end
 end

--- a/app/controllers/interests_controller.rb
+++ b/app/controllers/interests_controller.rb
@@ -1,7 +1,7 @@
 class InterestsController < ApplicationController
   def new
     PersistVacancyGetMoreInfoClickJob.perform_later(vacancy.id) unless publisher_signed_in?
-    request_event.trigger(:vacancy_get_more_info_clicked, vacancy_id: vacancy.id)
+    request_event.trigger(:vacancy_get_more_info_clicked, vacancy_id: StringAnonymiser.new(vacancy.id))
 
     redirect_to(vacancy.application_link)
   end

--- a/app/controllers/jobseekers/job_applications_controller.rb
+++ b/app/controllers/jobseekers/job_applications_controller.rb
@@ -8,7 +8,7 @@ class Jobseekers::JobApplicationsController < Jobseekers::BaseController
   helper_method :job_application, :qualification_form_param_key, :review_form, :vacancy, :withdraw_form
 
   def new
-    request_event.trigger(:vacancy_apply_clicked, vacancy_id: vacancy.id)
+    request_event.trigger(:vacancy_apply_clicked, vacancy_id: StringAnonymiser.new(vacancy.id))
     redirect_to new_quick_apply_jobseekers_job_job_application_path(vacancy.id) if
       current_jobseeker.job_applications.not_draft.any?
   end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -84,7 +84,7 @@ class SubscriptionsController < ApplicationController
     vacancy = Vacancy.find_by_slug(origin_param.split("/").last)
     return unless vacancy
 
-    request_event.trigger(:vacancy_create_job_alert_clicked, vacancy_id: vacancy.id)
+    request_event.trigger(:vacancy_create_job_alert_clicked, vacancy_id: StringAnonymiser.new(vacancy.id))
   end
 
   def trigger_subscription_event(type, subscription)

--- a/app/views/shared/vacancy/_jobseeker_view.html.slim
+++ b/app/views/shared/vacancy/_jobseeker_view.html.slim
@@ -44,7 +44,7 @@
             href: @saved_job.present? ? jobseekers_saved_job_path(@vacancy.id, @saved_job) : new_jobseekers_saved_job_path(@vacancy.id),
             icon: @saved_job.present? ? "saved" : "save",
             method: @saved_job.present? ? :delete : :get,
-            params: { click_event: "vacancy_save_to_account_clicked" }
+            params: { click_event: "vacancy_save_to_account_clicked", click_event_data: { vacancy_id: StringAnonymiser.new(@vacancy.id) } }
 
 .govuk-grid-row
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -18,9 +18,13 @@ RSpec.describe ApplicationController do
   end
 
   describe "click_event events" do
+    let(:params) do
+      { click_event: "this_event", click_event_data: { vacancy_id: "more_data" } }
+    end
+
     it "triggers a `click_event` event on a request" do
-      expect { get :test_action, params: { click_event: "this_event" } }
-        .to have_triggered_event(:this_event).with_request_data
+      expect { get :test_action, params: params }
+        .to have_triggered_event(:this_event).with_request_data.and_data(vacancy_id: "more_data")
     end
   end
 

--- a/spec/requests/documents_spec.rb
+++ b/spec/requests/documents_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Documents" do
     it "triggers a `vacancy_document_downloaded` event" do
       expect { get document_path(document) }
         .to have_triggered_event(:vacancy_document_downloaded)
-        .and_data(vacancy_id: vacancy.id, document_id: document.id, filename: document.name)
+        .and_data(vacancy_id: anonymised_form_of(vacancy.id), document_id: anonymised_form_of(document.id), filename: document.name)
     end
   end
 end

--- a/spec/requests/interests_spec.rb
+++ b/spec/requests/interests_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Interests" do
     it "triggers a `vacancy_get_more_info_clicked` event" do
       expect { get new_job_interest_path(vacancy.id) }
         .to have_triggered_event(:vacancy_get_more_info_clicked)
-        .and_data(vacancy_id: vacancy.id)
+        .and_data(vacancy_id: anonymised_form_of(vacancy.id))
     end
   end
 end

--- a/spec/requests/jobseekers/job_applications_spec.rb
+++ b/spec/requests/jobseekers/job_applications_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Job applications" do
     context "when the job is live" do
       it "triggers a `vacancy_apply_clicked` event" do
         expect { get new_jobseekers_job_job_application_path(vacancy.id) }
-          .to have_triggered_event(:vacancy_apply_clicked).with_data(vacancy_id: vacancy.id)
+          .to have_triggered_event(:vacancy_apply_clicked).with_data(vacancy_id: anonymised_form_of(vacancy.id))
       end
 
       context "when a job application for the job already exists" do

--- a/spec/requests/subscriptions_spec.rb
+++ b/spec/requests/subscriptions_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Subscriptions" do
       it "triggers a `vacancy_create_job_alert_clicked` event" do
         expect { get new_subscription_path(origin: origin) }
           .to have_triggered_event(:vacancy_create_job_alert_clicked)
-          .and_data(vacancy_id: vacancy.id)
+          .and_data(vacancy_id: anonymised_form_of(vacancy.id))
       end
     end
 


### PR DESCRIPTION
In order to match up the events with records, we need to use the anonymised version.

Also:

Allow click_events to have further event data (from a click_event_data param)
to include in the event. The use case here is to match up a 'save vacancy' click
event with the vacancy in question. We have to explicitly permit such parameters
in order to convert the click_event_data param into a hash for consumption by
Event.
