### PR TITLE
Prevent error when click event has no data params

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -106,6 +106,6 @@ class ApplicationController < ActionController::Base
 
   def click_event_data_params
     # Any params that might be present must be explicitly permitted in order to convert to hash
-    params[:click_event_data].permit(:vacancy_id)
+    params[:click_event_data]&.permit(:vacancy_id)
   end
 end


### PR DESCRIPTION
This has been preventing users clicking things due to:
NoMethodError: undefined method 'permit' for nil:NilClass
