### PR TITLE
Cut test run time in half

### DIFF
--- a/spec/jobs/import_organisation_data_job_spec.rb
+++ b/spec/jobs/import_organisation_data_job_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe ImportOrganisationDataJob do
-  subject(:job) { described_class.perform_later }
-
   before { allow(DisableExpensiveJobs).to receive(:enabled?).and_return(disable_expensive_jobs_enabled?) }
 
   context "when DisableExpensiveJobs is not enabled" do
@@ -17,7 +15,7 @@ RSpec.describe ImportOrganisationDataJob do
       expect(import_school_data).to receive(:run!)
       expect(import_trust_data).to receive(:run!)
 
-      perform_enqueued_jobs { job }
+      described_class.perform_now
     end
 
     context "when there are some old memberships in the database that are not in the latest imported data" do
@@ -56,7 +54,7 @@ RSpec.describe ImportOrganisationDataJob do
           :get,
           "https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public/edubasealldata#{todays_date}.csv",
         ).to_return(body: schools_csv)
-        perform_enqueued_jobs { job }
+        described_class.perform_now
       end
 
       after do
@@ -81,7 +79,7 @@ RSpec.describe ImportOrganisationDataJob do
     it "does not perform the job" do
       expect(ImportSchoolData).not_to receive(:new)
 
-      perform_enqueued_jobs { job }
+      described_class.perform_now
     end
   end
 end

--- a/spec/jobs/persist_vacancy_get_more_info_click_job_spec.rb
+++ b/spec/jobs/persist_vacancy_get_more_info_click_job_spec.rb
@@ -1,12 +1,10 @@
 require "rails_helper"
 
 RSpec.describe PersistVacancyGetMoreInfoClickJob do
-  subject(:job) { described_class.perform_later(vacancy.id) }
-
   let(:vacancy) { create(:vacancy, total_get_more_info_clicks: 66) }
 
   it "increments the counter" do
-    perform_enqueued_jobs { job }
+    described_class.perform_now(vacancy.id)
 
     expect(vacancy.reload.total_get_more_info_clicks).to eq(67)
   end

--- a/spec/jobs/persist_vacancy_page_view_job_spec.rb
+++ b/spec/jobs/persist_vacancy_page_view_job_spec.rb
@@ -1,12 +1,10 @@
 require "rails_helper"
 
 RSpec.describe PersistVacancyPageViewJob do
-  subject(:job) { described_class.perform_later(vacancy.id) }
-
   let(:vacancy) { create(:vacancy, total_pageviews: 99) }
 
   it "increments the counter" do
-    perform_enqueued_jobs { job }
+    described_class.perform_now(vacancy.id)
 
     expect(vacancy.reload.total_pageviews).to eq(100)
   end

--- a/spec/jobs/remove_stale_vacancies_job_spec.rb
+++ b/spec/jobs/remove_stale_vacancies_job_spec.rb
@@ -1,11 +1,9 @@
 require "rails_helper"
 
 RSpec.describe RemoveStaleVacanciesJob do
-  subject(:job) { described_class.perform_later }
-
   it "deletes all vacancies without a job title" do
     2.times { create(:vacancy) }
     2.times { create(:vacancy, job_title: nil) }
-    expect { perform_enqueued_jobs { job } }.to change { Vacancy.count }.from(4).to(2)
+    expect { described_class.perform_now }.to change { Vacancy.count }.from(4).to(2)
   end
 end


### PR DESCRIPTION
Somehow using `perform_enqueued_jobs` leads to our job specs taking
minutes (instead of seconds) to run locally `¯\_(ツ)_/¯

I haven't had time to investigate root cause (probably something weird
with the ActiveJob test adapter) but running them using `perform_now`
fulfils the same testing needs and doesn't have this problem.