### PR TITLE
set Common -module output as sensitive

### DIFF
--- a/terraform/common/output.tf
+++ b/terraform/common/output.tf
@@ -3,5 +3,6 @@ output "deploy_aws_access_key_id" {
 }
 
 output "deploy_aws_secret_access_key" {
-  value = aws_iam_access_key.deploy.secret
+  value     = aws_iam_access_key.deploy.secret
+  sensitive = true
 }


### PR DESCRIPTION
## Jira ticket URL

- Just add the ticket number to the end:

https://dfedigital.atlassian.net/browse/TEVA-

## Changes in this PR:

since upgrading to terraform 0.15.5, it now complains about `output "deploy_aws_secret_access_key"` being marked as sensitive