### PR TITLE
fix filters a11y issue

### DIFF
--- a/app/components/filters_component/filters_component.html.slim
+++ b/app/components/filters_component/filters_component.html.slim
@@ -46,13 +46,12 @@
 
   = render GovukComponent::Accordion.new(id: "accordion-default", classes: "filters-component__groups") do |component|
     - items.each_with_index do |group, index|
-      - component.slot(:section,
-        title: group[:title]) do
-          .govuk-accordion__section-content.filters-component__groups__group id="accordion-default-content-#{index}" aria-labelledby="accordion-default-heading-#{index}" data-group=group[:key]
-            = form.govuk_collection_check_boxes group[:attribute],
-              group[:options],
-              group[:value_method],
-              group[:text_method],
-              small: true,
-              legend: nil,
-              hint: nil
+      - component.slot(:section, title: group[:title]) do
+        .filters-component__groups__group id="accordion-default-content-#{index + 1}" data-group=group[:key]
+          = form.govuk_collection_check_boxes group[:attribute],
+            group[:options],
+            group[:value_method],
+            group[:text_method],
+            small: true,
+            legend: nil,
+            hint: nil


### PR DESCRIPTION
no ticket

that pesky @csutter again alerted me to something this morning to do with our ruby a11y specs and took quite a bit of prodding around for this one line change

basically in the filters component we were trying to do something that the govuk-component accordion does already. also an id was out of sync with surrounding content because the thing that was trying to associate with it is not a zero starting iteration. both of these combined throwing up some confusing a11y errors

at first thought maybe i had messed something up in filters refactor the other day but i think has existed for a while

has made a significant positive impact on any page using filters

before
![Screenshot 2021-06-11 at 14 12 32](https://user-images.githubusercontent.com/1792451/121693119-ba1e1f80-cac0-11eb-8bd5-d8255abaa1f4.png)

after
![Screenshot 2021-06-11 at 14 11 25](https://user-images.githubusercontent.com/1792451/121693091-b4283e80-cac0-11eb-92cc-93c36dc6e7e7.png)

(the heading warning there ill look into seperatly, not quite as straightforward as just changing the tagname)

