### PR TITLE
Add a fake DSI sign out endpoint for testing

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -64,6 +64,10 @@ Rails.application.configure do
   end
 
   config.active_storage.service = :test
+
+  require "fake_dsi_sign_out_endpoint"
+  ENV["DFE_SIGN_IN_ISSUER"] = "http://fake.dsi.example.com"
+  config.middleware.insert_before 0, FakeDsiSignOutEndpoint
 end
 
 # Avoid OmniAuth output in tests:

--- a/lib/fake_dsi_sign_out_endpoint.rb
+++ b/lib/fake_dsi_sign_out_endpoint.rb
@@ -1,0 +1,20 @@
+# A fake DSI sign out endpoint to be mounted in test environments
+# Intercepts requests for the DFE_SIGN_IN_ISSUER (overridden in `environments/test.rb`)
+# and redirects if the location is the log out endpoint
+class FakeDsiSignOutEndpoint
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    return @app.call(env) unless env["HTTP_HOST"] == "fake.dsi.example.com"
+
+    if env["PATH_INFO"] == "/session/end"
+      location = Rack::Utils.parse_nested_query(env["QUERY_STRING"])["post_logout_redirect_uri"]
+
+      [301, { "Location" => location, "Content-Type" => "text/html", "Content-Length" => "0" }, []]
+    else
+      [404, {}, ["Not found."]]
+    end
+  end
+end


### PR DESCRIPTION
This adds a `FakeDsiSignOutEndpoint` Rack middleware that intercepts
requests to a fake URL that it overrides `DFE_SIGN_IN_ISSUER` with.

This simulates the proper flow a user would go through for the
purpose of system tests checking that hiring staff can sign out
properly, and fixes an issue where tests will fail locally if a
value is set for `DFE_SIGN_IN_ISSUER`.