### PR TITLE
Add url to error logs for CSV file download

### DIFF
--- a/lib/organisation_import/import_organisation_data.rb
+++ b/lib/organisation_import/import_organisation_data.rb
@@ -58,9 +58,9 @@ class ImportOrganisationData
     when 200
       File.write(location, request.body, mode: "wb")
     when 404
-      raise HTTParty::ResponseError, "CSV file not found."
+      raise HTTParty::ResponseError, "CSV file not found at #{url}."
     else
-      raise HTTParty::ResponseError, "Unexpected problem downloading CSV file."
+      raise HTTParty::ResponseError, "Unexpected problem downloading CSV file from #{url}."
     end
   end
 

--- a/spec/lib/organisation_import/import_school_data_spec.rb
+++ b/spec/lib/organisation_import/import_school_data_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ImportSchoolData do
 
       it "raises an HTTP error" do
         expect { subject.send(:save_csv_file, csv_url, temp_file_location) }
-          .to raise_error(HTTParty::ResponseError).with_message("CSV file not found.")
+          .to raise_error(HTTParty::ResponseError).with_message("CSV file not found at #{csv_url}.")
       end
     end
 
@@ -26,7 +26,7 @@ RSpec.describe ImportSchoolData do
 
       it "raises an HTTP error" do
         expect { subject.send(:save_csv_file, csv_url, temp_file_location) }
-          .to raise_error(HTTParty::ResponseError).with_message("Unexpected problem downloading CSV file.")
+          .to raise_error(HTTParty::ResponseError).with_message("Unexpected problem downloading CSV file from #{csv_url}.")
       end
     end
 

--- a/spec/lib/organisation_import/import_trust_data_spec.rb
+++ b/spec/lib/organisation_import/import_trust_data_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ImportTrustData do
 
       it "raises an HTTP error" do
         expect { subject.send(:save_csv_file, csv_url, temp_file_location) }
-          .to raise_error(HTTParty::ResponseError).with_message("CSV file not found.")
+          .to raise_error(HTTParty::ResponseError).with_message("CSV file not found at #{csv_url}.")
       end
     end
 
@@ -26,7 +26,7 @@ RSpec.describe ImportTrustData do
 
       it "raises an HTTP error" do
         expect { subject.send(:save_csv_file, csv_url, temp_file_location) }
-          .to raise_error(HTTParty::ResponseError).with_message("Unexpected problem downloading CSV file.")
+          .to raise_error(HTTParty::ResponseError).with_message("Unexpected problem downloading CSV file from #{csv_url}.")
       end
     end
 


### PR DESCRIPTION
A lazy way to begin the debugging process for:

https://ukgovernmentdfe.slack.com/archives/CP987RP6J/p1623540413000600

https://rollbar.com/dfe/teacher-vacancies/items/3867/?utm_campaign=exp_repeat_item_message&utm_medium=slack&utm_source=rollbar-notification
