### PR TITLE
[TEVA-2556] Refactor the conversion of Devise flash variants

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,6 +17,7 @@ class ApplicationController < ActionController::Base
   helper_method :cookies_preference_set?, :referred_from_jobs_path?, :utm_parameters, :current_variant?
 
   include Publishers::AuthenticationConcerns
+  include DeviseFlashConcerns
   include AbTestable
 
   def check

--- a/app/controllers/concerns/devise_flash_concerns.rb
+++ b/app/controllers/concerns/devise_flash_concerns.rb
@@ -1,0 +1,26 @@
+module DeviseFlashConcerns
+  extend ActiveSupport::Concern
+
+  DEVISE_FLASH_VARIANT_MAPPING = {
+    alert: "notice",
+    notice: "success",
+  }.freeze
+
+  included do
+    helper_method :convert_devise_flash_variant
+  end
+
+  def convert_devise_flash_variant(variant, message)
+    message.in?(devise_messages) ? DEVISE_FLASH_VARIANT_MAPPING[variant.to_sym] : variant
+  end
+
+  private
+
+  def devise_messages
+    get_nested_values(I18n.t("devise"))
+  end
+
+  def get_nested_values(hash)
+    hash.respond_to?(:values) ? hash.values.map { |value| get_nested_values(value) }.flatten : hash
+  end
+end

--- a/app/controllers/jobseekers/confirmations_controller.rb
+++ b/app/controllers/jobseekers/confirmations_controller.rb
@@ -1,6 +1,5 @@
 class Jobseekers::ConfirmationsController < Devise::ConfirmationsController
   after_action :remove_devise_flash!, only: %i[create]
-  after_action :replace_devise_notice_flash_with_success!, only: %i[show]
 
   protected
 

--- a/app/controllers/jobseekers/devise_controller.rb
+++ b/app/controllers/jobseekers/devise_controller.rb
@@ -7,12 +7,8 @@ class Jobseekers::DeviseController < ApplicationController
 
   private
 
-  def replace_devise_notice_flash_with_success!
-    flash[:success] = flash.discard(:notice) if flash[:notice].present?
-  end
-
   def remove_devise_flash!
+    flash.discard(:alert) if flash[:alert].present?
     flash.discard(:notice) if flash[:notice].present?
-    flash.discard(:success) if flash[:success].present?
   end
 end

--- a/app/controllers/jobseekers/registrations_controller.rb
+++ b/app/controllers/jobseekers/registrations_controller.rb
@@ -4,7 +4,6 @@ class Jobseekers::RegistrationsController < Devise::RegistrationsController
   before_action :check_password_difference, only: %i[update]
   before_action :check_new_password_presence, only: %i[update]
   before_action :check_email_difference, only: %i[update]
-  after_action :replace_devise_notice_flash_with_success!, only: %i[destroy update]
   after_action :set_correct_update_message, only: %i[update]
   after_action :remove_devise_flash!, only: %i[create update]
 

--- a/app/controllers/jobseekers/sessions_controller.rb
+++ b/app/controllers/jobseekers/sessions_controller.rb
@@ -2,8 +2,6 @@ class Jobseekers::SessionsController < Devise::SessionsController
   before_action :sign_out_publisher!, only: %i[create]
   before_action :render_resource_with_errors, only: %i[new]
   before_action :check_if_access_locked, only: %i[new]
-  before_action :replace_devise_alert_flash_with_notice!, only: %i[new]
-  after_action :replace_devise_notice_flash_with_success!, only: %i[create destroy]
   after_action only: %i[create] do
     trigger_jobseeker_sign_in_event(:success)
   end
@@ -45,10 +43,5 @@ class Jobseekers::SessionsController < Devise::SessionsController
       success: success_or_failure == :success,
       errors: errors,
     )
-  end
-
-  def replace_devise_alert_flash_with_notice!
-    flash[:notice] = flash[:alert] if flash[:alert].present?
-    flash.delete(:alert)
   end
 end

--- a/app/controllers/jobseekers/unlocks_controller.rb
+++ b/app/controllers/jobseekers/unlocks_controller.rb
@@ -1,3 +1,1 @@
-class Jobseekers::UnlocksController < Devise::UnlocksController
-  after_action :replace_devise_notice_flash_with_success!, only: %i[show]
-end
+class Jobseekers::UnlocksController < Devise::UnlocksController; end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -53,7 +53,7 @@ html.govuk-template.app-html-class lang="en"
 
     main.govuk-width-container#main-content role="main"
       - flash.each do |variant, message|
-        = render FlashComponent.new variant: variant, message: message
+        = render FlashComponent.new(variant: convert_devise_flash_variant(variant, message), message: message)
 
       = yield
 

--- a/spec/support/jobseeker_helpers.rb
+++ b/spec/support/jobseeker_helpers.rb
@@ -4,13 +4,6 @@ module JobseekerHelpers
     click_on I18n.t("buttons.resend_email")
   end
 
-  def resend_unlock_instructions_email
-    fill_in "Email address", with: jobseeker.email
-    within(".new_jobseeker") do
-      click_on I18n.t("jobseekers.unlocks.new.form_submit")
-    end
-  end
-
   def sign_up_jobseeker(email: jobseeker.email, password: jobseeker.password)
     within(".new_jobseeker") do
       fill_in "Email address", with: email

--- a/spec/system/jobseekers_can_unlock_their_account_spec.rb
+++ b/spec/system/jobseekers_can_unlock_their_account_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Jobseekers can unlock their account" do
     end
 
     context "when the unlock token is invalid" do
-      before { visit unlock_url(jobseeker, unlock_token: "invalid token") }
+      before { visit jobseeker_unlock_url(unlock_token: "invalid token") }
 
       scenario "they are locked out of their account" do
         expect(jobseeker.reload).to be_access_locked
@@ -35,7 +35,13 @@ RSpec.describe "Jobseekers can unlock their account" do
       end
 
       scenario "they can request to be emailed the link again and use it to unlock their account" do
-        expect { resend_unlock_instructions_email }.to change { delivered_emails.count }.by(1)
+        fill_in "Email address", with: jobseeker.email
+
+        expect {
+          within(".new_jobseeker") { click_on I18n.t("jobseekers.unlocks.new.form_submit") }
+        }.to change {
+          delivered_emails.count
+        }.by(1)
 
         visit first_link_from_last_mail
 


### PR DESCRIPTION
# Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2556

# Changes in this PR:

Previously, we used methods such as 'replace_devise_notice_flash_with_success' and 'replace_devise_alert_flash_with_notice' on particular actions in order to convert flash messages originating from Devise into the variant we wanted (alert, notice, success variants).

This was unexpected, from the point of view of Devise's internals, and resulted in [odd behaviour](https://dfedigital.atlassian.net/browse/TEVA-2556) such as flash messages persisting for one extra page load. Devise expected certain messages to be stored in certain flash variants.

Therefore, instead of manipulating the variant of the flash itself, I have added some logic that alters the 'variant' parameter passed to FlashComponent, mapping all Devise alert flashes to pass 'notice' as the variant to FlashComponent, and
mapping 'notice' to 'success'. This preserves the same variants as we were already using. Any messages that are not from Devise are not altered.

# Screenshots of UI changes:

## The odd behaviour no longer happens:

https://user-images.githubusercontent.com/60350599/121948218-dcc56800-cd4e-11eb-9251-4b85987ecf83.mov

## The variants of other Devise messages remain correct:

<img width="561" alt="Screenshot 2021-06-14 at 19 56 08" src="https://user-images.githubusercontent.com/60350599/121948328-067e8f00-cd4f-11eb-8621-123ef880b937.png">

## The variants of non-Devise messages remain correct:

<img width="561" alt="Screenshot 2021-06-14 at 20 08 59" src="https://user-images.githubusercontent.com/60350599/121948368-126a5100-cd4f-11eb-9570-0211d1273341.png">

<img width="561" alt="Screenshot 2021-06-14 at 20 08 21" src="https://user-images.githubusercontent.com/60350599/121948366-126a5100-cd4f-11eb-9906-d16fd477d802.png">

