### PR TITLE
[TEVA-2715] Add email field to personal details step (job application)

### DIFF
--- a/app/controllers/concerns/jobseekers/wizardable.rb
+++ b/app/controllers/concerns/jobseekers/wizardable.rb
@@ -1,6 +1,6 @@
 module Jobseekers::Wizardable
   def personal_details_fields
-    %i[city country first_name last_name national_insurance_number phone_number previous_names postcode street_address teacher_reference_number]
+    %i[city country email_address first_name last_name national_insurance_number phone_number previous_names postcode street_address teacher_reference_number]
   end
 
   def professional_status_fields

--- a/app/form_models/jobseekers/job_application/personal_details_form.rb
+++ b/app/form_models/jobseekers/job_application/personal_details_form.rb
@@ -1,13 +1,14 @@
 class Jobseekers::JobApplication::PersonalDetailsForm
   include ActiveModel::Model
 
-  attr_accessor :city, :country, :first_name, :last_name, :national_insurance_number,
+  attr_accessor :city, :country, :email_address, :first_name, :last_name, :national_insurance_number,
                 :phone_number, :previous_names, :postcode, :street_address, :teacher_reference_number
 
-  validates :city, :country, :first_name, :last_name,
+  validates :city, :country, :email_address, :first_name, :last_name,
             :phone_number, :postcode, :street_address, presence: true
 
   validates :national_insurance_number, format: { with: /\A\s*[a-zA-Z]{2}(?:\s*\d\s*){6}[a-zA-Z]?\s*\z/.freeze }, allow_blank: true
   validates :phone_number, format: { with: /\A\+?(?:\d\s?){10,12}\z/.freeze }
-  validates :teacher_reference_number, format: { with: /\A\d{7}\z/.freeze }, allow_blank: true
+  validates_format_of :teacher_reference_number, with: /\A\d{7}\z/.freeze, allow_blank: true
+  validates_format_of :email_address, with: Devise.email_regexp
 end

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -48,6 +48,12 @@ class JobApplication < ApplicationRecord
     "#{first_name} #{last_name}"
   end
 
+  def email
+    # This method and its test can be removed once there are no job applications remaining which were begun before we asked
+    # jobseekers for their emails as part of the application, or after https://dfedigital.atlassian.net/browse/TEVA-2720 is done.
+    email_address.presence || jobseeker.email
+  end
+
   def submit!
     submitted!
     Publishers::JobApplicationReceivedNotification.with(vacancy: vacancy, job_application: self).deliver(vacancy.publisher)

--- a/app/views/jobseekers/job_applications/build/personal_details.html.slim
+++ b/app/views/jobseekers/job_applications/build/personal_details.html.slim
@@ -26,7 +26,8 @@
         = f.govuk_text_field :postcode, width: "one-third"
         = f.govuk_text_field :country, width: "one-third"
       = f.govuk_phone_field :phone_number, label: { size: "s" }, width: "one-half", aria: { required: true }
-      = f.govuk_text_field :teacher_reference_number, label: { size: "s" }, width: "one-half", aria: { required: true }, form_group: { classes: "optional-field" }
+      = f.govuk_email_field :email_address, value: (form.email_address.presence || job_application.email), label: { size: "s" }, width: "one-half", aria: { required: true }
+      = f.govuk_text_field :teacher_reference_number, label: { size: "s" }, width: "one-half", form_group: { classes: "optional-field" }
       = f.govuk_text_field :national_insurance_number, label: { size: "s" }, width: "one-half", form_group: { classes: "optional-field" }
 
       = f.govuk_submit job_application_build_submit_button_text do

--- a/app/views/jobseekers/job_applications/review/_personal_details.html.slim
+++ b/app/views/jobseekers/job_applications/review/_personal_details.html.slim
@@ -25,6 +25,9 @@
                       key: t("helpers.label.jobseekers_job_application_personal_details_form.phone_number"),
                       value: job_application.phone_number
       - summary.slot :row,
+                      key: t("helpers.label.jobseekers_job_application_personal_details_form.email_address"),
+                      value: job_application.email
+      - summary.slot :row,
                       key: t("helpers.label.jobseekers_job_application_personal_details_form.teacher_reference_number"),
                       value: job_application.teacher_reference_number.presence || t("jobseekers.job_applications.not_defined")
       - summary.slot :row,

--- a/app/views/shared/job_application/_show.html.slim
+++ b/app/views/shared/job_application/_show.html.slim
@@ -23,7 +23,9 @@
                                        tag.div(job_application.city, class: "govuk-body"),
                                        tag.div(job_application.postcode, class: "govuk-body")])
       - summary.slot :row, key: t(".personal_details.phone_number"), value: job_application.phone_number
-      - summary.slot :row, key: t(".personal_details.email"), value: job_application.jobseeker.email
+      - summary.slot :row,
+                     key: t(".personal_details.email"),
+                     value: govuk_mail_to(job_application.email, job_application.email)
       - if job_application.teacher_reference_number.present?
         - summary.slot :row, key: t(".personal_details.teacher_reference_number"), value: job_application.teacher_reference_number
       - if job_application.national_insurance_number.present?

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -319,6 +319,9 @@ en:
               blank: Enter your town or city
             country:
               blank: Enter your country
+            email_address:
+              blank: Enter your email address
+              invalid: Enter an email address in the correct format, like name@example.com
             first_name:
               blank: Enter your first name
             last_name:

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -396,6 +396,7 @@ en:
       jobseekers_job_application_personal_details_form:
         city: Town or city
         country: Country
+        email_address: Email address
         first_name: First name
         last_name: Last name
         national_insurance_number: National Insurance number

--- a/db/migrate/20210615144822_add_email_address_to_job_applications.rb
+++ b/db/migrate/20210615144822_add_email_address_to_job_applications.rb
@@ -1,0 +1,5 @@
+class AddEmailAddressToJobApplications < ActiveRecord::Migration[6.1]
+  def change
+    add_column :job_applications, :email_address, :string, default: "", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_25_064924) do
+ActiveRecord::Schema.define(version: 2021_06_15_144822) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -222,6 +222,7 @@ ActiveRecord::Schema.define(version: 2021_05_25_064924) do
     t.datetime "reviewed_at"
     t.string "country", default: "", null: false
     t.string "age", default: "", null: false
+    t.string "email_address", default: "", null: false
   end
 
   create_table "jobseekers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/job_applications.rb
+++ b/spec/factories/job_applications.rb
@@ -22,6 +22,7 @@ FactoryBot.define do
     city { Faker::Address.city }
     postcode { Faker::Address.postcode }
     country { Faker::Address.country }
+    email_address { Faker::Internet.email }
     phone_number { "01234 567890" }
     teacher_reference_number { "1234567" }
     national_insurance_number { "QQ 12 34 56 C" }
@@ -95,6 +96,7 @@ FactoryBot.define do
     city { "" }
     postcode { "" }
     country { "" }
+    email_address { "" }
     phone_number { "" }
     teacher_reference_number { "" }
     national_insurance_number { "" }

--- a/spec/form_models/jobseekers/job_application/personal_details_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/personal_details_form_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe Jobseekers::JobApplication::PersonalDetailsForm, type: :model do
   it { is_expected.to allow_value("AB 12 12 12 A").for(:national_insurance_number) }
   it { is_expected.not_to allow_value("AB 12 12 12 A 12").for(:national_insurance_number) }
 
+  it { is_expected.to validate_presence_of(:email_address) }
+  it { is_expected.to allow_value("david@example.com").for(:email_address) }
+  it { is_expected.not_to allow_value("david at example.com").for(:email_address) }
+
   it { is_expected.to validate_presence_of(:phone_number) }
   it { is_expected.to allow_value("01234 123456").for(:phone_number) }
   it { is_expected.not_to allow_value("01234 12345678").for(:phone_number) }

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -29,6 +29,28 @@ RSpec.describe JobApplication do
     end
   end
 
+  describe "#email" do
+    let(:jobseeker) { build_stubbed(:jobseeker, email: "backup-email@example.com") }
+    subject { build_stubbed(:job_application, email_address: email_address, jobseeker: jobseeker) }
+    let(:email_address) { "something@example.com" }
+
+    context "when the application has an email address" do
+      let(:email_address) { "something@example.com" }
+
+      it "uses the application email address" do
+        expect(subject.email).to eq("something@example.com")
+      end
+    end
+
+    context "when the application does not have an email address" do
+      let(:email_address) { "" }
+
+      it "uses the jobseeker email address" do
+        expect(subject.email).to eq("backup-email@example.com")
+      end
+    end
+  end
+
   context "when saving change to status" do
     subject { create(:job_application) }
 

--- a/spec/support/jobseeker_helpers.rb
+++ b/spec/support/jobseeker_helpers.rb
@@ -89,6 +89,7 @@ module JobseekerHelpers
     fill_in "Postcode", with: "F1 4KE"
     fill_in "Country", with: "United Kingdom"
     fill_in "Phone number", with: "01234 123456"
+    fill_in "Email address", with: "jobseeker@example.com"
     fill_in "Teacher reference number", with: "1234567"
     fill_in "National Insurance number", with: "AB 12 12 12 A"
   end

--- a/spec/system/jobseekers_can_complete_a_job_application_spec.rb
+++ b/spec/system/jobseekers_can_complete_a_job_application_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "Jobseekers can complete a job application" do
   it "allows jobseekers to complete an application and go to review page" do
     visit jobseekers_job_application_build_path(job_application, :personal_details)
     expect(page).to have_content(I18n.t("jobseekers.job_applications.build.personal_details.heading"))
+    expect(page).to have_field("Email address", with: jobseeker.email)
     validates_step_complete
     fill_in_personal_details
     click_on I18n.t("buttons.save_and_continue")


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2715

## Changes in this PR:

Add email address field to job application form

This field is pre-populated by the email address belonging to the jobseeker account.

Adds email address field to JobApplication model, and a temporary method 'email' to JobApplication, which falls back to jobseeker.email when email_address is not available. This is necessary because some users have already got draft applications without email addresses.

Until now we gave hiring staff the email address for a job application by using the one the jobseeker signed up to Teaching Vacancies with.

There are two reasons we will now instead ask the jobseeker for their email address as part of the application form:

1) Some jobseekers may prefer to provide a different email address to schools, than the one they signed up to TV with. I know if it was me I'd sign up to TV with my 'spam collector' email account but I'd want schools to get in touch in my gmail 'important emails' account.

2) We are not transparent with jobseekers about the fact we are passing on the email address they signed up to TV with, which might be a problem if the email they signed up to TV with is not a 'professional' address, e.g. they might have signed up to us with coolboy1999@hotmail.com or some such embarrassing and birth-year-revealing address. They currently have no idea we are passing on this address to hiring staff. We don't tell them on the review step of the application because review steps should only show data that the user input themselves in the relevant form, so that they can edit their responses.

## Next steps

- [ ] Test on dev environment that an application created before the migration can still be submitted.

## Screenshots of UI changes:

Prepopulated:

![Screenshot 2021-06-15 at 17 34 12](https://user-images.githubusercontent.com/60350599/122090666-ed81e680-cdff-11eb-9e76-3e69cc0a4c83.png)

![Screenshot 2021-06-15 at 17 11 43](https://user-images.githubusercontent.com/60350599/122088743-f376c800-cdfd-11eb-82f6-104f2a8bd626.png)

![Screenshot 2021-06-15 at 17 13 34](https://user-images.githubusercontent.com/60350599/122088744-f40f5e80-cdfd-11eb-8b9d-4cdcace1f1d8.png)

![Screenshot 2021-06-15 at 17 14 32](https://user-images.githubusercontent.com/60350599/122088745-f40f5e80-cdfd-11eb-9651-9be2a798a48e.png)

![Screenshot 2021-06-15 at 17 19 26](https://user-images.githubusercontent.com/60350599/122088750-f4a7f500-cdfd-11eb-98ea-2ab100cc4c7b.png)
