### PR TITLE
[TEVA-2070] convert searchable collection to govuk standard

### DIFF
--- a/app/components/flash_component.rb
+++ b/app/components/flash_component.rb
@@ -1,25 +1,25 @@
 class FlashComponent < GovukComponent::Base
-  attr_reader :variant, :message
+  attr_reader :variant_name, :message
 
   VARIANTS = %w[notice success warning alert].freeze
 
-  def initialize(variant:, message:, classes: [], html_attributes: {})
+  def initialize(variant_name:, message:, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes.merge(default_html_attributes))
 
-    @variant = variant
+    @variant_name = variant_name
     @message = message
   end
 
   def render?
-    variant.in?(VARIANTS)
+    variant_name.in?(VARIANTS)
   end
 
   def variant_class
-    "flash-component--#{variant}"
+    "flash-component--#{variant_name}"
   end
 
   def icon_class
-    "icon icon--left icon--#{variant}"
+    "icon icon--left icon--#{variant_name}"
   end
 
   private

--- a/app/components/searchable_collection_component.rb
+++ b/app/components/searchable_collection_component.rb
@@ -1,7 +1,11 @@
-class SearchableCollectionComponent < ViewComponent::Base
+class SearchableCollectionComponent < GovukComponent::Base
   attr_accessor :form, :attribute_name, :collection, :value_method, :text_method, :hint_method, :threshold, :small, :scrollable
 
-  def initialize(form:, attribute_name:, collection:, value_method:, text_method:, hint_method:, threshold: 10, scrollable: false)
+  # rubocop:disable Metrics/ParameterLists
+  def initialize(form:, attribute_name:, collection:, value_method:, text_method:, hint_method:, threshold: 10, scrollable: false, classes: [], html_attributes: {})
+    # rubocop:enable Metrics/ParameterLists
+    super(classes: classes, html_attributes: html_attributes)
+
     @form = form
     @threshold = threshold
     @attribute_name = attribute_name
@@ -24,5 +28,11 @@ class SearchableCollectionComponent < ViewComponent::Base
 
   def border_class
     return "searchable-collection-component--border" if searchable
+  end
+
+  private
+
+  def default_classes
+    %w[searchable-collection-component]
   end
 end

--- a/app/components/searchable_collection_component/searchable_collection_component.html+checkbox.slim
+++ b/app/components/searchable_collection_component/searchable_collection_component.html+checkbox.slim
@@ -1,15 +1,16 @@
-.searchable-collection-component class="#{border_class} #{scrollable_class}"
-  - if searchable
-    .searchable-collection-component__search
-      input.govuk-input.searchable-collection-component__search-input.icon.icon--left.icon--search placeholder="Search"
-      button.searchable-collection-component__search-button type="submit" aria-label="search options"
+= tag.div(class: classes, **html_attributes) do
+  div class="#{border_class} #{scrollable_class}"
+    - if searchable
+      .searchable-collection-component__search
+        input.govuk-input.searchable-collection-component__search-input.icon.icon--left.icon--search placeholder="Search"
+        button.searchable-collection-component__search-button type="submit" aria-label="search options"
 
-  = form.govuk_collection_check_boxes attribute_name,
-    collection,
-    value_method,
-    text_method,
-    hint_method,
-    small: small,
-    classes: "checkbox-label__bold",
-    legend: nil,
-    hint: nil
+    = form.govuk_collection_check_boxes attribute_name,
+      collection,
+      value_method,
+      text_method,
+      hint_method,
+      small: small,
+      classes: "checkbox-label__bold",
+      legend: nil,
+      hint: nil

--- a/app/components/searchable_collection_component/searchable_collection_component.html+radiobutton.slim
+++ b/app/components/searchable_collection_component/searchable_collection_component.html+radiobutton.slim
@@ -1,15 +1,16 @@
-.searchable-collection-component class="#{border_class} #{scrollable_class}"
-  - if searchable
-    .searchable-collection-component__search
-      input.govuk-input.searchable-collection-component__search-input.icon.icon--left.icon--search placeholder="Search"
-      button.searchable-collection-component__search-button type="submit" aria-label="search options"
+= tag.div(class: classes, **html_attributes) do
+  div class="#{border_class} #{scrollable_class}"
+    - if searchable
+      .searchable-collection-component__search
+        input.govuk-input.searchable-collection-component__search-input.icon.icon--left.icon--search placeholder="Search"
+        button.searchable-collection-component__search-button type="submit" aria-label="search options"
 
-  = form.govuk_collection_radio_buttons attribute_name,
-    collection,
-    value_method,
-    text_method,
-    hint_method,
-    small: small,
-    classes: "radiobutton-label__bold",
-    legend: nil,
-    hint: nil
+    = form.govuk_collection_radio_buttons attribute_name,
+      collection,
+      value_method,
+      text_method,
+      hint_method,
+      small: small,
+      classes: "radiobutton-label__bold",
+      legend: nil,
+      hint: nil

--- a/app/components/searchable_collection_component/searchable_collection_component.scss
+++ b/app/components/searchable_collection_component/searchable_collection_component.scss
@@ -5,14 +5,14 @@
     margin-bottom: 0;
   }
 
-  &.searchable-collection-component--scrollable {
+  &--scrollable {
     .govuk-form-group {
       max-height: 400px;
       overflow: auto;
     }
   }
 
-  &.searchable-collection-component--border {
+  &--border {
     background-color: #fff;
     border: 2px solid $govuk-border-colour;
     padding: 0;
@@ -23,7 +23,7 @@
     }
   }
 
-  .searchable-collection-component__search {
+  &__search {
     background: #fff;
     margin: govuk-spacing(2);
     position: relative;

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -53,7 +53,7 @@ html.govuk-template.app-html-class lang="en"
 
     main.govuk-width-container#main-content role="main"
       - flash.each do |variant, message|
-        = render FlashComponent.new(variant: convert_devise_flash_variant(variant, message), message: message)
+        = render FlashComponent.new(variant_name: convert_devise_flash_variant(variant, message), message: message)
 
       = yield
 

--- a/app/views/shared/vacancy/_jobseeker_view.html.slim
+++ b/app/views/shared/vacancy/_jobseeker_view.html.slim
@@ -1,4 +1,4 @@
-= render FlashComponent.new variant: "notice", message: t("jobs.listing_expired") if @vacancy.expired?
+= render FlashComponent.new variant_name: "notice", message: t("jobs.listing_expired") if @vacancy.expired?
 
 = render BannerComponent.new do
     = govuk_breadcrumbs breadcrumbs: { "#{t("breadcrumbs.home")}": root_path,

--- a/spec/components/flash_component_spec.rb
+++ b/spec/components/flash_component_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe FlashComponent, type: :component do
-  let(:variant) { "notice" }
-  let(:kwargs) { { variant: variant, message: "Some message" } }
+  let(:variant_name) { "notice" }
+  let(:kwargs) { { variant_name: variant_name, message: "Some message" } }
 
   subject! { render_inline(described_class.new(**kwargs)) }
 
@@ -17,7 +17,7 @@ RSpec.describe FlashComponent, type: :component do
   end
 
   context "when variant is invalid" do
-    let(:variant) { "invalid-variant" }
+    let(:variant_name) { "invalid-variant" }
 
     it "does not render the flash" do
       expect(page).not_to have_css("div", class: "flash-component")

--- a/spec/components/searchable_collection_component_spec.rb
+++ b/spec/components/searchable_collection_component_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe SearchableCollectionComponent, type: :component do
     allow(form).to receive(:govuk_collection_check_boxes)
   end
 
+  let(:variant_mapping) { { radiobutton: :govuk_collection_radio_buttons, checkbox: :govuk_collection_check_boxes } }
+
   let(:base) do
     {
       form: form,
@@ -21,34 +23,45 @@ RSpec.describe SearchableCollectionComponent, type: :component do
     }
   end
 
-  context "when using radio button variant" do
+  let(:kwargs) { { collection: collection, form: form, attribute_name: :attributes, text_method: :first, hint_method: :first, value_method: :first } }
+
+  %i[radiobutton checkbox].each do |variant_name|
+    context "when initialised with #{variant_name} variant" do
+      it_behaves_like "a component that accepts custom classes", variant_name
+      it_behaves_like "a component that accepts custom HTML attributes", variant_name
+
+      subject! { render_inline(described_class.new(**kwargs).with_variant(variant_name)) }
+
+      it "the correct formbuilder collection is used" do
+        expect(form).to have_received(variant_mapping[variant_name])
+      end
+    end
+  end
+
+  context "when using an item threshold of higher than collection size" do
     let(:options) { { threshold: 10 } }
     let(:radio_collection) do
-      described_class.new(base.merge(options)).with_variant(:radiobutton)
+      described_class.new(base.merge(options)).with_variant(:checkbox)
     end
 
     let!(:inline_component) { render_inline(radio_collection) }
 
-    it "a formbuilder radio button collection is used" do
-      expect(form).to have_received(:govuk_collection_radio_buttons)
-    end
-
-    it "is not searchable when collection is smaller than threshold" do
+    it "is not searchable" do
       expect(radio_collection.searchable).to be_falsey
       expect(inline_component.css(".searchable-collection-component__search")).to be_blank
       expect(inline_component.css(".searchable-collection-component--border")).to be_blank
     end
 
-    it "does not have small buttons when collection is smaller than threshold" do
+    it "has large collection items" do
       expect(radio_collection.small).to be_falsey
     end
 
-    it "container is not scrollable when collection is smaller than threshold" do
+    it "is not scrollable" do
       expect(radio_collection.scrollable).to be_falsey
     end
   end
 
-  context "when using check box variant" do
+  context "when using an item threshold of lower or equal than collection size" do
     let(:options) { { threshold: 5 } }
 
     let(:checkbox_collection) do
@@ -57,21 +70,17 @@ RSpec.describe SearchableCollectionComponent, type: :component do
 
     let!(:inline_component) { render_inline(checkbox_collection) }
 
-    it "a formbuilder checkbox collection is used" do
-      expect(form).to have_received(:govuk_collection_check_boxes)
-    end
-
-    it "is searchable when collection is equal to threshold" do
+    it "is searchable" do
       expect(checkbox_collection.searchable).to be_truthy
       expect(inline_component.css(".searchable-collection-component__search").count).to eq(1)
       expect(inline_component.css(".searchable-collection-component--border").count).to eq(1)
     end
 
-    it "has buttons when collection is equal to threshold" do
+    it "has small collection items" do
       expect(checkbox_collection.small).to be_truthy
     end
 
-    it "container is scrollable when collection is equal to threshold" do
+    it "is scrollable" do
       expect(checkbox_collection.scrollable).to be_truthy
     end
   end

--- a/spec/components/shared_examples/a_component_that_accepts_custom_classes.rb
+++ b/spec/components/shared_examples/a_component_that_accepts_custom_classes.rb
@@ -1,5 +1,5 @@
-RSpec.shared_examples "a component that accepts custom classes" do
-  subject! { render_inline(described_class.send(:new, **kwargs.merge(classes: custom_classes))) }
+RSpec.shared_examples "a component that accepts custom classes" do |variant_name|
+  subject! { render_inline(described_class.send(:new, **kwargs.merge(classes: custom_classes)).with_variant(variant_name)) }
 
   context "when classes are supplied as a string" do
     let(:custom_classes) { "purple-stripes" }

--- a/spec/components/shared_examples/a_component_that_accepts_custom_html_attributes.rb
+++ b/spec/components/shared_examples/a_component_that_accepts_custom_html_attributes.rb
@@ -1,5 +1,5 @@
-RSpec.shared_examples "a component that accepts custom HTML attributes" do
-  subject! { render_inline(described_class.send(:new, html_attributes: custom_attributes, **kwargs)) }
+RSpec.shared_examples "a component that accepts custom HTML attributes" do |variant_name|
+  subject! { render_inline(described_class.send(:new, html_attributes: custom_attributes, **kwargs).with_variant(variant_name)) }
 
   let(:custom_attributes) { { lang: "en-GB", style: "background-color: blue;" } }
 


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-2070

## Changes in this PR:

- Convert to the Govuk component standard
- refactor test to allow for different variants when testing shared examples. Also i feel the test reads better as a test now as tests the variant and the options separately as they weren't clear before
