### PR TITLE
[TEVA-2070] refactor navbar component to govuk standard

### DIFF
--- a/app/components/navbar_component.rb
+++ b/app/components/navbar_component.rb
@@ -1,8 +1,23 @@
-class NavbarComponent < ViewComponent::Base
+class NavbarComponent < GovukComponent::Base
   delegate :active_link_class, to: :helpers
-  delegate :current_organisation, to: :helpers
-  delegate :current_publisher, to: :helpers
-  delegate :organisation_type_basic, to: :helpers
-  delegate :jobseeker_signed_in?, to: :helpers
-  delegate :publisher_signed_in?, to: :helpers
+
+  def initialize(classes: [], html_attributes: {})
+    super(classes: classes, html_attributes: html_attributes)
+  end
+
+  renders_many :items, lambda { |link_text:, aria: {}, method: :get, align: nil, path: nil|
+    if link_text == :spacer
+      tag.li class: "navbar-component__items-spacer", "aria-hidden": "true", "tab-index": "-1"
+    else
+      tag.li class: "navbar-component__navigation-item--#{align} govuk-header__navigation-item #{active_link_class(path)}" do
+        link_to link_text, path, class: "govuk-header__link", method: method, aria: aria
+      end
+    end
+  }
+
+  private
+
+  def default_classes
+    %w[navbar-component]
+  end
 end

--- a/app/components/navbar_component/navbar_component.html.slim
+++ b/app/components/navbar_component/navbar_component.html.slim
@@ -1,34 +1,4 @@
-nav.navbar-component role="navigation"
-  ul.govuk-header__navigation.navbar-component__navigation id="navigation" aria-label="Top Level Navigation"
-    - if publisher_signed_in?
-      li class=active_link_class(organisation_path)
-        = link_to t("nav.school_page_link"), organisation_path, class: "govuk-header__link"
-      - if current_organisation.school_group?
-        li class=active_link_class(organisation_schools_path)
-          = link_to t("nav.school_group_index_link", organisation_type: organisation_type_basic(current_organisation)), organisation_schools_path, class: "govuk-header__link"
-      li class=active_link_class(root_path)
-        = link_to t("nav.jobseekers_index_link"), root_path, class: "govuk-header__link"
-      li class=active_link_class(publishers_notifications_path)
-        = link_to t("nav.notifications_index_link"), publishers_notifications_path, class: "govuk-header__link", aria: { label: "#{current_publisher.notifications.unread.count} unread notifications" }
-        - if current_publisher.notifications.unread.any?
-          span.notification-badge = current_publisher.notifications.unread.count
-      li class=active_link_class(destroy_publisher_session_path)
-        = button_to t("nav.sign_out"), destroy_publisher_session_path, method: :delete, class: "govuk-header__link"
-    - else
-      li.navbar-component__navigation-item--left class=active_link_class(root_path)
-        = link_to t("nav.find_job"), root_path, class: "govuk-header__link"
-      - if jobseeker_signed_in?
-        li.navbar-component__navigation-item--left class=active_link_class(jobseeker_root_path)
-          = link_to t("footer.your_account"), jobseeker_root_path, class: "govuk-header__link"
-        li.navbar-component__navigation-spacer aria-hidden="true" tab-index="-1"
-        li.navbar-component__navigation-item--right class=active_link_class(destroy_jobseeker_session_path)
-          = button_to t("nav.sign_out"), destroy_jobseeker_session_path, method: :delete, class: "govuk-header__link"
-      - else
-        li.navbar-component__navigation-spacer aria-hidden="true" tab-index="-1"
-        li.navbar-component__navigation-item--right class=active_link_class(new_jobseeker_session_path)
-          = link_to t("buttons.sign_in"), new_jobseeker_session_path, class: "govuk-header__link"
-        li.navbar-component__navigation-item--right class=active_link_class(new_publisher_session_path)
-          - if AuthenticationFallback.enabled?
-            = link_to t("nav.for_schools"), new_login_key_path, class: "govuk-header__link"
-          - else
-            = link_to t("nav.for_schools"), new_publisher_session_path, class: "govuk-header__link"
+= tag.nav(class: classes, **html_attributes) do
+  ul.govuk-header__navigation.navbar-component__items id="navigation" aria-label="Top Level Navigation"
+    - items.each do |item|
+      = item

--- a/app/components/navbar_component/navbar_component.scss
+++ b/app/components/navbar_component/navbar_component.scss
@@ -1,52 +1,51 @@
 @import 'base_component';
 
-.govuk-template__body {
-  .navbar-component {
-    .notification-badge {
-      background-color: govuk-colour('white');
-      border-radius: 75%;
-      color: govuk-colour('black');
-      font-weight: bold;
-      margin-left: govuk-spacing(2);
-      padding: 0 govuk-spacing(1);
-    }
+nav.navbar-component {
+  .notification-badge {
+    background-color: govuk-colour('white');
+    border-radius: 75%;
+    color: govuk-colour('black');
+    font-weight: bold;
+    margin-left: govuk-spacing(2);
+    padding: 0 govuk-spacing(1);
+  }
 
-    .navbar-component__navigation {
-      @include govuk-media-query($from: desktop) {
-        display: flex;
+  .navbar-component__items {
+    @include govuk-media-query($from: desktop) {
+      display: flex;
 
-        &-spacer {
-          flex-grow: 1;
-        }
-
-        &-item--left {
-          align-self: flex-start;
-        }
-
-        &-item--right {
-          align-self: flex-end;
-        }
+      &-spacer {
+        flex-grow: 1;
       }
 
-      @include govuk-media-query($until: tablet) {
-        &-spacer {
-          visibility: hidden;
-        }
+      &-item--left {
+        align-self: flex-start;
+      }
+
+      &-item--right {
+        align-self: flex-end;
       }
     }
 
-    .govuk-header__navigation-item {
-      input.govuk-header__link {
-        @include govuk-font(16, $weight: bold);
-
-        background-color: transparent;
-        background-image: none;
-        border: 0;
-        box-shadow: none;
-        color: govuk-colour('white');
-        cursor: pointer;
-        padding: 0;
+    @include govuk-media-query($until: tablet) {
+      &-spacer {
+        visibility: hidden;
       }
     }
   }
+
+  .govuk-header__navigation-item {
+    input.govuk-header__link {
+      @include govuk-font(16, $weight: bold);
+
+      background-color: transparent;
+      background-image: none;
+      border: 0;
+      box-shadow: none;
+      color: govuk-colour('white');
+      cursor: pointer;
+      padding: 0;
+    }
+  }
 }
+

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -41,7 +41,29 @@ html.govuk-template.app-html-class lang="en"
             = t("app.title")
           button.govuk-header__menu-button.govuk-js-header-toggle data-module="govuk-button" type="button" role="button" aria-controls="navigation" aria-label="Show or hide Top Level Navigation"
             | Menu
-          = render(NavbarComponent.new)
+          = render NavbarComponent.new(html_attributes: { role: "navigation" }) do |navigation|
+            - if publisher_signed_in?
+              - navigation.item link_text: t("nav.school_page_link"), align: :left, path: organisation_path
+              - if current_organisation.school_group?
+                - navigation.item link_text: t("nav.school_group_index_link", organisation_type: organisation_type_basic(current_organisation)), align: :left, path: organisation_schools_path
+              - navigation.item link_text: t("nav.jobseekers_index_link"), align: :left, path: root_path
+              - navigation.item link_text: t("nav.notifications_index_link"), aria: { label: "#{current_publisher.notifications.unread.count} unread notifications" }, align: :left, path: publishers_notifications_path
+              - if current_publisher.notifications.unread.any?
+                span.notification-badge = current_publisher.notifications.unread.count
+              - navigation.item link_text: :spacer
+              - navigation.item link_text: t("nav.sign_out"), align: :right, path: destroy_publisher_session_path, method: :delete
+
+            - if jobseeker_signed_in?
+              - navigation.item link_text: t("nav.find_job"), align: :left, path: root_path
+              - navigation.item link_text: t("footer.your_account"), align: :left, path: jobseeker_root_path
+              - navigation.item link_text: :spacer
+              - navigation.item link_text: t("nav.sign_out"), method: :delete, align: :right, path: destroy_jobseeker_session_path
+
+            - if !jobseeker_signed_in? && !publisher_signed_in?
+              - navigation.item link_text: t("nav.find_job"), align: :left, path: root_path
+              - navigation.item link_text: :spacer
+              - navigation.item link_text: t("buttons.sign_in"), align: :right, path: new_jobseeker_session_path
+              - navigation.item link_text: t("nav.for_schools"), align: :right, path: AuthenticationFallback.enabled? ? new_login_key_path : new_publisher_session_path
 
       .govuk-phase-banner aria-label="banner"
         .govuk-width-container

--- a/spec/components/navbar_component_spec.rb
+++ b/spec/components/navbar_component_spec.rb
@@ -1,32 +1,34 @@
 require "rails_helper"
 
 RSpec.describe NavbarComponent, type: :component do
-  subject { described_class.new }
+  let(:kwargs) { {} }
 
-  before do
-    allow(controller).to receive(:jobseeker_signed_in?).and_return(true)
-    allow(controller).to receive(:publisher_signed_in?).and_return(false)
-    render_inline(subject)
-  end
+  subject! { render_inline(described_class.new(**kwargs)) }
 
-  context "when jobseeker is signed in" do
-    it "renders the correct links" do
-      expect(rendered_component).to include(I18n.t("nav.find_job"))
-      expect(rendered_component).to include(I18n.t("footer.your_account"))
-      expect(rendered_component).to include(I18n.t("nav.sign_out"))
-    end
-  end
+  it_behaves_like "a component that accepts custom classes"
+  it_behaves_like "a component that accepts custom HTML attributes"
 
-  context "when jobseeker is not signed in" do
-    before do
-      allow(controller).to receive(:jobseeker_signed_in?).and_return(false)
-      render_inline(subject)
+  context "when navigation items are defined" do
+    subject! do
+      render_inline(described_class.new(**kwargs)) do |navigation|
+        navigation.item(link_text: "A nav item", align: :left, path: "/1")
+        navigation.item(link_text: :spacer)
+        navigation.item(link_text: "Another nav item", align: :right, path: "/2")
+      end
     end
 
-    it "renders the correct links" do
-      expect(rendered_component).to include(I18n.t("nav.find_job"))
-      expect(rendered_component).to include(I18n.t("buttons.sign_in"))
-      expect(rendered_component).to include(I18n.t("nav.for_schools"))
+    it "renders the navigation items" do
+      expect(page).to have_css("nav", class: "navbar-component") do |items|
+        expect(items).to have_css("ul", class: "navbar-component__items") do |item|
+          expect(item).to have_css("li", class: "navbar-component__navigation-item--left", text: "A nav item") do |link|
+            expect(link).to have_css("a[href='/1']")
+          end
+          expect(item).to have_css("li", class: "navbar-component__items-spacer")
+          expect(item).to have_css("li", class: "navbar-component__navigation-item--right", text: "Another nav item") do |link|
+            expect(link).to have_css("a[href='/2']")
+          end
+        end
+      end
     end
   end
 end

--- a/spec/system/main_navigation_spec.rb
+++ b/spec/system/main_navigation_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe "Main navigation for users to sign in and out" do
+  let(:jobseeker) { create(:jobseeker) }
+  let(:organisation) { create(:school) }
+  let!(:publisher) { create(:publisher, organisation_publishers_attributes: [{ organisation: organisation }]) }
+
+  context "when user is not signed in" do
+    before { visit root_path }
+
+    it "renders the correct links" do
+      within ".navbar-component" do
+        expect(page).to have_content(I18n.t("nav.find_job"))
+        expect(page).to have_content(I18n.t("buttons.sign_in"))
+        expect(page).to have_content(I18n.t("nav.for_schools"))
+      end
+    end
+  end
+
+  context "when jobseeker is signed in" do
+    before do
+      login_as(jobseeker, scope: :jobseeker)
+      visit root_path
+    end
+
+    it "renders the correct links" do
+      within ".navbar-component" do
+        expect(page).to have_content(I18n.t("nav.find_job"))
+        expect(page).to have_content(I18n.t("footer.your_account"))
+        expect(page).to have_content(I18n.t("nav.sign_out"))
+      end
+    end
+  end
+
+  context "when publisher is signed in" do
+    before do
+      login_publisher(publisher: publisher, organisation: organisation)
+      visit root_path
+    end
+
+    it "renders the correct links" do
+      within ".navbar-component" do
+        expect(page).to have_content(I18n.t("nav.school_page_link"))
+        expect(page).to have_content(I18n.t("nav.jobseekers_index_link"))
+        expect(page).to have_content(I18n.t("nav.notifications_index_link"))
+        expect(page).to have_content(I18n.t("nav.sign_out"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-2070

LAST COMPONENT!

## Changes in this PR:

- refactored component to extend govuk and add shared example tests
- fixed inconsistency between publisher/jobseeker signed in state and where the sign out link is placed (see below screen shots, ~im going to confirm this with jesse tomorrow~ he's good with this)
- tests added for publisher signed in state

before

![Screenshot 2021-06-16 at 20 24 35](https://user-images.githubusercontent.com/1792451/122280509-2d6cca80-cee1-11eb-9b13-c8941c155279.png)
![Screenshot 2021-06-16 at 20 24 15](https://user-images.githubusercontent.com/1792451/122280511-2e056100-cee1-11eb-8b3d-c057a11a79fa.png)

after

![Screenshot 2021-06-16 at 20 25 41](https://user-images.githubusercontent.com/1792451/122280539-38275f80-cee1-11eb-9cce-1e249bd4fada.png)
![Screenshot 2021-06-16 at 20 25 07](https://user-images.githubusercontent.com/1792451/122280541-38bff600-cee1-11eb-95d2-7beced9c6059.png)




