### PR TITLE
Remove superfluous boolean inclusion spec

### DIFF
--- a/spec/form_models/publishers/job_listing/applying_for_the_job_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/applying_for_the_job_form_spec.rb
@@ -13,8 +13,6 @@ RSpec.describe Publishers::JobListing::ApplyingForTheJobForm, type: :model do
   it { is_expected.to allow_value("").for(:application_link) }
   it { is_expected.not_to allow_value("invalid-01234").for(:contact_number) }
 
-  it { is_expected.to validate_inclusion_of(:enable_job_applications).in_array([true, false]) }
-
   context "when enable_job_applications is false" do
     subject { described_class.new(enable_job_applications: "false") }
 


### PR DESCRIPTION
This was causing a shoulda-matchers warning message - this spec will
always pass as boolean columns auto-cast.

```
************************************************************************
Warning from shoulda-matchers:

You are using `validate_inclusion_of` to assert that a boolean column
allows boolean values and disallows non-boolean ones. Be aware that it
is not possible to fully test this, as boolean columns will
automatically convert non-boolean values to boolean ones. Hence, you
should consider removing this test.
************************************************************************
```