### PR TITLE
Make migration verify task more lenient

### DIFF
--- a/lib/tasks/storage.rake
+++ b/lib/tasks/storage.rake
@@ -22,8 +22,8 @@ namespace :google_drive do
       puts "Checking #{total_count} vacancies with existing documents..."
 
       vacancies_with_documents.with_attached_supporting_documents.find_each do |vacancy|
-        docs = vacancy.documents.map { |d| [d.name, d.size, d.content_type] }.sort
-        supporting_docs = vacancy.supporting_documents.map { |sd| [sd.filename.to_s, sd.byte_size, sd.content_type] }.sort
+        docs = vacancy.documents.map { |d| [d.name, d.size] }.sort
+        supporting_docs = vacancy.supporting_documents.map { |sd| [sd.filename.to_s, sd.byte_size] }.sort
 
         if docs == supporting_docs
           puts "✅ Vacancy #{vacancy.id} has matching documents and supporting documents"


### PR DESCRIPTION
Currently this checks for equality of content type, which raises false
positives due to ActiveStorage and our existing documents having subtly
different MIME types.