### PR TITLE
remove unused npm rollbar dependency

### DIFF
--- a/app/frontend/src/application/publishers/textareaFormat.js
+++ b/app/frontend/src/application/publishers/textareaFormat.js
@@ -1,9 +1,21 @@
+import logger from '../../lib/logging';
+
 document.addEventListener('trix-initialize', (e) => {
   const inputAttribute = Array.from(e.target.attributes).filter((attr) => attr.name === 'input')[0];
-  document.getElementById(inputAttribute.value).style.display = 'none';
+
+  try {
+    document.getElementById(inputAttribute.value).style.display = 'none';
+  } catch (error) {
+    logger.warn(`[component: textarea formatting init] ${error.message} input: ${inputAttribute.name}`);
+  }
 });
 
 document.addEventListener('trix-change', (e) => {
   const inputAttribute = Array.from(e.target.attributes).filter((attr) => attr.name === 'input')[0];
-  document.getElementById(inputAttribute.value).value = e.target.editor.element.innerHTML;
+
+  try {
+    document.getElementById(inputAttribute.value).value = e.target.editor.element.innerHTML;
+  } catch (error) {
+    logger.warn(`[component: textarea formatting change] ${error.message} input: ${inputAttribute.name}`);
+  }
 });

--- a/app/frontend/src/components/locationFinder/locationFinder.js
+++ b/app/frontend/src/components/locationFinder/locationFinder.js
@@ -5,14 +5,14 @@ import '../../lib/polyfill/remove.polyfill';
 import loader from '../loader/loader';
 import { getPostcodeFromCoordinates } from '../../lib/api';
 import { enableRadiusSelect, disableRadiusSelect } from '../../application/jobseekers/radius';
-import Rollbar from '../../lib/logging';
+import logger from '../../lib/logging';
 import './locationFinder.scss';
 
 const containerEl = document.getElementsByClassName('js-location-finder')[0];
 const inputEl = document.getElementsByClassName('js-location-finder__input')[0];
 
 export const ERROR_MESSAGE = 'Unable to find your location';
-export const LOGGING_MESSAGE = '[Module: locationFinder]: Unable to find user location';
+export const LOGGING_MESSAGE = '[component: locationFinder]: Unable to find user location';
 
 export const DEFAULT_PLACEHOLDER = 'City, town or postcode';
 export const LOADING_PLACEHOLDER = 'Finding Location...';
@@ -70,7 +70,7 @@ export const onFailure = () => {
   locationFinder.showErrorMessage(document.getElementById('current-location'));
   disableRadiusSelect();
   locationFinder.stopLoading(containerEl, inputEl);
-  Rollbar.log(LOGGING_MESSAGE);
+  logger.log(LOGGING_MESSAGE);
 };
 
 export const postcodeFromPosition = (position, apiPromise) => apiPromise(position.coords.latitude, position.coords.longitude).then((response) => {

--- a/app/frontend/src/components/locationFinder/locationFinder.test.js
+++ b/app/frontend/src/components/locationFinder/locationFinder.test.js
@@ -105,7 +105,8 @@ describe('current location', () => {
         .then(() => {
           expect(onSuccessMock).toHaveBeenCalled();
           expect(onFailureMock).not.toHaveBeenCalled();
-        });
+        })
+        .catch(() => true);
     });
 
     test('calls onFailure handler when API returns falsy value', () => {
@@ -118,7 +119,8 @@ describe('current location', () => {
         .then(() => {
           expect(onFailureMock).toHaveBeenCalled();
           expect(onSuccessMock).not.toHaveBeenCalled();
-        });
+        })
+        .catch(() => true);
     });
   });
 });

--- a/app/frontend/src/lib/api.js
+++ b/app/frontend/src/lib/api.js
@@ -1,18 +1,18 @@
 import axios from 'axios';
-import Rollbar from './logging';
+import logger from './logging';
 
 export const getPostcodeFromCoordinates = (latitude, longitude) => axios.get('https://api.postcodes.io/postcodes', {
   params: { latitude, longitude },
 }).then((response) => response.data)
   .catch((error) => {
-    Rollbar.log(`${error} Postcodes API`);
+    logger.log(`${error} Postcodes API`);
   });
 
 export const getLocationSuggestions = (query) => axios.get(`/api/v1/location_suggestion/${query}?format=json`)
   .then((response) => response.data)
   .then((data) => data.suggestions)
   .catch((error) => {
-    Rollbar.log(`${error} Search query: ${query}`);
+    logger.log(`${error} Search query: ${query}`);
   });
 
 const api = {

--- a/app/frontend/src/lib/logging.js
+++ b/app/frontend/src/lib/logging.js
@@ -1,11 +1,23 @@
-import Rollbar from 'rollbar';
+const environment = process.env.NODE_ENV;
+const noop = () => true;
+const silentMock = {
+  log: noop,
+  warn: noop,
+  error: noop,
+  info: noop,
+};
 
-const rollbar = new Rollbar({
-  accessToken: '14fb3641a126437ab1d29cf52357c192',
-  captureUncaught: true,
-  captureUnhandledRejections: true,
-});
+/* eslint-disable no-console */
+const consoleMock = {
+  log: console.log,
+  warn: console.warn,
+  error: console.error,
+  info: console.info,
+};
+/* eslint-enable no-console */
 
-rollbar.configure({ reportLevel: 'warning' });
+const mockLogger = environment === 'test' ? silentMock : consoleMock;
 
-export default rollbar;
+const Logger = window.Rollbar || mockLogger;
+
+export default Logger;

--- a/app/frontend/src/lib/utils.js
+++ b/app/frontend/src/lib/utils.js
@@ -1,4 +1,4 @@
-import Rollbar from './logging';
+import logger from './logging';
 
 export const stringMatchesPostcode = (postcode) => {
   const noSpacePostcode = postcode.replace(/\s/g, '');
@@ -44,7 +44,7 @@ export const storageAvailable = (type, logMessage = false) => {
     return true;
   } catch (e) {
     if (logMessage) {
-      Rollbar.log(logMessage);
+      logger.info(logMessage);
     }
 
     return e instanceof DOMException && (

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "jquery": "^3.5.0",
     "jsdom": "^16.6.0",
     "rails-ujs": "^5.2.6",
-    "rollbar": "^2.22.0",
     "trix": "^1.3.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1889,11 +1889,6 @@ async@^2.6.2:
   dependencies:
     lodash "^4.17.14"
 
-async@~1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/async/-/async-1.2.1.tgz#a4816a17cd5ff516dfa2c7698a453369b9790de0"
-  integrity sha1-pIFqF81f9RbfosdpikUzabl5DeA=
-
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -2835,11 +2830,6 @@ console-browserify@^1.1.0:
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.2.0.tgz#67063cef57ceb6cf4993a2ab3a55840ae8c49336"
   integrity sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==
 
-console-polyfill@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/console-polyfill/-/console-polyfill-0.3.0.tgz#84900902a18c47a5eba932be75fa44d23e8af861"
-  integrity sha512-w+JSDZS7XML43Xnwo2x5O5vxB0ID7T5BdqDtyqT6uiCAX2kZAgcWxNaGqT97tZfSHzfOcvrfsDAodKcJ3UvnXQ==
-
 constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
@@ -3267,13 +3257,6 @@ debug@^3.1.1, debug@^3.2.6, debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
-decache@^3.0.5:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/decache/-/decache-3.1.0.tgz#4f5036fbd6581fcc97237ac3954a244b9536c2da"
-  integrity sha1-T1A2+9ZYH8yXI3rDlUokS5U2wto=
-  dependencies:
-    find "^0.2.4"
-
 decamelize-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"
@@ -3643,13 +3626,6 @@ error-ex@^1.3.1:
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
-
-error-stack-parser@^2.0.4:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-2.0.6.tgz#5a99a707bd7a4c58a797902d48d82803ede6aad8"
-  integrity sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==
-  dependencies:
-    stackframe "^1.1.1"
 
 es-abstract@^1.17.2, es-abstract@^1.18.0-next.1, es-abstract@^1.18.0-next.2:
   version "1.18.0"
@@ -4227,13 +4203,6 @@ find-up@^4.0.0, find-up@^4.1.0:
   dependencies:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
-
-find@^0.2.4:
-  version "0.2.9"
-  resolved "https://registry.yarnpkg.com/find/-/find-0.2.9.tgz#4b73f1ff9e56ad91b76e716407fe5ffe6554bb8c"
-  integrity sha1-S3Px/55WrZG3bnFkB/5f/mVUu4w=
-  dependencies:
-    traverse-chain "~0.1.0"
 
 findup-sync@^3.0.0:
   version "3.0.0"
@@ -5362,11 +5331,6 @@ is-wsl@^2.2.0:
   dependencies:
     is-docker "^2.0.0"
 
-is_js@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/is_js/-/is_js-0.9.0.tgz#0ab94540502ba7afa24c856aa985561669e9c52d"
-  integrity sha1-CrlFQFArp6+iTIVqqYVWFmnpxS0=
-
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -5894,11 +5858,6 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
-json-stringify-safe@~5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
-  integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
-
 json3@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.3.tgz#7fc10e375fc5ae42c4705a5cc0aa6f62be305b81"
@@ -6177,11 +6136,6 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
-
-lru-cache@~2.2.1:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.2.4.tgz#6c658619becf14031d0d0b594b16042ce4dc063d"
-  integrity sha1-bGWGGb7PFAMdDQtZSxYELOTcBj0=
 
 make-dir@^2.0.0:
   version "2.1.0"
@@ -8453,13 +8407,6 @@ repeat-string@^1.0.0, repeat-string@^1.6.1:
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
 
-request-ip@~2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/request-ip/-/request-ip-2.0.2.tgz#deeae6d4af21768497db8cd05fa37143f8f1257e"
-  integrity sha1-3urm1K8hdoSX24zQX6NxQ/jxJX4=
-  dependencies:
-    is_js "^0.9.0"
-
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -8583,22 +8530,6 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
-
-rollbar@^2.22.0:
-  version "2.22.0"
-  resolved "https://registry.yarnpkg.com/rollbar/-/rollbar-2.22.0.tgz#0115f29c762b7ea14bc3b7846f4b376d99eff9e6"
-  integrity sha512-fMTKtzSnoE2ODnMAqzH/Soocb/o7Qy7U5tdRjzljKoz1vMRKkMYbW7E0s0Qraoo3xaTzd5UxDNP3c8jmrlWgug==
-  dependencies:
-    async "~1.2.1"
-    console-polyfill "0.3.0"
-    error-stack-parser "^2.0.4"
-    json-stringify-safe "~5.0.0"
-    lru-cache "~2.2.1"
-    request-ip "~2.0.1"
-    source-map "^0.5.7"
-    uuid "3.0.x"
-  optionalDependencies:
-    decache "^3.0.5"
 
 rsvp@^4.8.4:
   version "4.8.5"
@@ -8993,7 +8924,7 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.1.tgz#0af66605a745a5a2f91cf1bbf8a7afbc283dec56"
   integrity sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==
 
-source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7:
+source-map@^0.5.0, source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
@@ -9104,11 +9035,6 @@ stack-utils@^2.0.2:
   integrity sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==
   dependencies:
     escape-string-regexp "^2.0.0"
-
-stackframe@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.2.0.tgz#52429492d63c62eb989804c11552e3d22e779303"
-  integrity sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==
 
 static-extend@^0.1.1:
   version "0.1.2"
@@ -9705,11 +9631,6 @@ tr46@^2.0.2:
   dependencies:
     punycode "^2.1.1"
 
-traverse-chain@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/traverse-chain/-/traverse-chain-0.1.0.tgz#61dbc2d53b69ff6091a12a168fd7d433107e40f1"
-  integrity sha1-YdvC1Ttp/2CRoSoWj9fUMxB+QPE=
-
 tree-kill@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
@@ -10026,11 +9947,6 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
-
-uuid@3.0.x:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
-  integrity sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=
 
 uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"


### PR DESCRIPTION
loosely related to

https://dfedigital.atlassian.net/browse/TEVA-2153

does fix client side rollbar logging with fallbacks for Rollbar not available and test scenarios

doesnt address whats actually being logged, but id like to see what starts being logged before making decisions about that. whats being logged might well give some clues for some JS related production 'defects' that have existed in rollbar dashboard for some time

i also added log to textarea formatting as i just noticed something in rollbar that needs investigating

everything from Js logging is logged under production/development etc in Rollbar dashboard same as serverside logs

### After

![Screenshot 2021-06-18 at 10 57 53](https://user-images.githubusercontent.com/1792451/122548452-4aacb080-d029-11eb-8265-f6272695a77d.png)

