### PR TITLE
[Teva-2735] Add /attachment* behaviour pattern to cloudfront 

### DIFF
--- a/terraform/app/modules/cloudfront/main.tf
+++ b/terraform/app/modules/cloudfront/main.tf
@@ -16,28 +16,14 @@ resource "aws_cloudfront_distribution" "default" {
     origin_id   = "${var.service_name}-${var.environment}-offline"
   }
 
-  custom_error_response {
-    error_code            = "404"
-    error_caching_min_ttl = "10"
-  }
-
-  custom_error_response {
-    error_code            = "500"
-    error_caching_min_ttl = "60"
-  }
-
-  custom_error_response {
-    error_code            = "503"
-    error_caching_min_ttl = "60"
-    response_code         = "503"
-    response_page_path    = "${var.offline_bucket_origin_path}/index.html"
-  }
-
-  custom_error_response {
-    error_code            = "502"
-    error_caching_min_ttl = "60"
-    response_code         = "502"
-    response_page_path    = "${var.offline_bucket_origin_path}/index.html"
+  dynamic "custom_error_response" {
+    for_each = local.cloudfront_custom_response
+    content {
+      error_code            = custom_error_response.key
+      error_caching_min_ttl = custom_error_response.value.ttl
+      response_code         = try(custom_error_response.value.response_code, null)
+      response_page_path    = try(custom_error_response.value.page_path, null)
+    }
   }
 
   enabled = true
@@ -85,19 +71,18 @@ resource "aws_cloudfront_distribution" "default" {
     viewer_protocol_policy = "redirect-to-https"
   }
 
-  ordered_cache_behavior {
-    allowed_methods = [
-      "GET",
-      "HEAD",
-    ]
-    cached_methods = [
-      "GET",
-      "HEAD",
-    ]
-    path_pattern           = "/packs/*"
-    target_origin_id       = "${var.service_name}-${var.environment}-default-origin"
-    viewer_protocol_policy = "redirect-to-https"
-    cache_policy_id        = data.aws_cloudfront_cache_policy.managed-caching-optimized.id
+
+  dynamic "ordered_cache_behavior" {
+    for_each = local.cloudfront_cached_paths
+
+    content {
+      allowed_methods        = ["GET", "HEAD"]
+      cached_methods         = ["GET", "HEAD"]
+      path_pattern           = ordered_cache_behavior.value
+      target_origin_id       = "${var.service_name}-${var.environment}-default-origin"
+      viewer_protocol_policy = "redirect-to-https"
+      cache_policy_id        = data.aws_cloudfront_cache_policy.managed-caching-optimized.id
+    }
   }
 
   price_class = "PriceClass_100"

--- a/terraform/app/modules/cloudfront/variables.tf
+++ b/terraform/app/modules/cloudfront/variables.tf
@@ -47,4 +47,12 @@ locals {
   cloudfront_aliases_cnames                              = [for zone in var.route53_zones : "${var.route53_cname_record}.${zone}"]
   cloudfront_aliases                                     = concat(var.route53_a_records, local.cloudfront_aliases_cnames)
   cloudfront_viewer_certificate_minimum_protocol_version = "TLSv1.2_2018"
+  cloudfront_cached_paths                                = ["/packs/*", "/attachment*"]
+  cloudfront_custom_response = {
+    404 = { ttl = "10" },
+    500 = { ttl = "60", response_code = "500", page_path = "${var.offline_bucket_origin_path}/index.html" },
+    502 = { ttl = "60", response_code = "502", page_path = "${var.offline_bucket_origin_path}/index.html" },
+    503 = { ttl = "60", response_code = "503", page_path = "${var.offline_bucket_origin_path}/index.html" },
+    504 = { ttl = "60", response_code = "504", page_path = "${var.offline_bucket_origin_path}/index.html" }
+  }
 }


### PR DESCRIPTION
## Jira ticket URL

- Just add the ticket number to the end:

https://dfedigital.atlassian.net/browse/TEVA-2735

## Changes in this PR:

Add /attachment* behaviour pattern to cloudfront

Also revamped the custom_error_response using dynamic block as
it is a repeatable nested block. This makes the code easier to manage