### PR TITLE
Add Job Application Email Address to Analytics ymls

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -118,6 +118,7 @@ shared:
     - in_progress_steps
     - reviewed_at
     - country
+    - email_address
   jobseekers:
     - id
     - email

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -41,6 +41,7 @@ shared:
     - further_instructions
     - rejection_reasons
     - gaps_in_employment_details
+    - email_address
   jobseekers:
     - id
     - email


### PR DESCRIPTION
## Changes in this PR:

- Added the email address associated with job applications to both yml files so they're sent to big query