### PR TITLE
Add Rollbar error ID to 500 page

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -26,6 +26,8 @@ class ErrorsController < ApplicationController
   end
 
   def internal_server_error
+    @rollbar_error_id = Rollbar.last_report[:uuid] if Rollbar.last_report.present?
+
     respond_to do |format|
       format.html { render status: :internal_server_error }
       format.json { render json: { error: "Internal server error" }, status: :internal_server_error }

--- a/app/views/errors/internal_server_error.html.slim
+++ b/app/views/errors/internal_server_error.html.slim
@@ -4,3 +4,6 @@
   h1.govuk-heading-xl = t("error_pages.server_error")
   p.govuk-body We’re working to fix this, so please try again shortly.
   p.govuk-body If you continue to have problems accessing Teaching Vacancies you can email #{govuk_mail_to t("help.email"), t("help.email")}
+  p.govuk-body
+    | Please include this error number in your email, as it will help us identify the problem:
+  = govuk_inset_text(text: @rollbar_error_id)

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -4,7 +4,6 @@ Rollbar.configure do |config|
 
   config.access_token = ENV.fetch("ROLLBAR_ACCESS_TOKEN", "")
 
-  # Here we'll disable in 'test':
   config.enabled = false if Rails.env.test? || Rails.env.development?
 
   config.js_enabled = true

--- a/documentation/rollbar.md
+++ b/documentation/rollbar.md
@@ -1,0 +1,14 @@
+# Rollbar
+
+We use [Rollbar](https://www.rollbar.com) to track errors occurring in the application.
+
+## Internal Server Error pages
+
+Our 500 page will include the Rollbar UUID of the error that was just raised. This is
+helpful when users experience an error and contact support with a screenshot or a copy
+of the message. To view an error on Rollbar given a UUID, sign in to Rollbar and visit
+the following URL:
+
+```
+https://rollbar.com/occurrence/uuid/?uuid=[UUID goes here]
+```


### PR DESCRIPTION
This will help us better debug support issues, where users often send
screenshots of the 500 page, by including Rollbar's UUID for the
error that just occurred on the page.

![image](https://user-images.githubusercontent.com/72141/122912159-f0289280-d34f-11eb-9a84-fe09617aec3c.png)