### PR TITLE
Only show Rollbar error id if present

### DIFF
--- a/app/views/errors/internal_server_error.html.slim
+++ b/app/views/errors/internal_server_error.html.slim
@@ -4,6 +4,7 @@
   h1.govuk-heading-xl = t("error_pages.server_error")
   p.govuk-body We’re working to fix this, so please try again shortly.
   p.govuk-body If you continue to have problems accessing Teaching Vacancies you can email #{govuk_mail_to t("help.email"), t("help.email")}
-  p.govuk-body
-    | Please include this error number in your email, as it will help us identify the problem:
-  = govuk_inset_text(text: @rollbar_error_id)
+  - if @rollbar_error_id.present?
+    p.govuk-body
+      | Please include this error number in your email, as it will help us identify the problem:
+    = govuk_inset_text(text: @rollbar_error_id)


### PR DESCRIPTION
Previously, if the id was not assigned, this page would either show (I am not sure which) (1) an invisible id, confusing the user or (2) throw some sort of error to do with using an unassigned variable, which would obscure our debugging process by polluting the stack trace.
