### PR TITLE
Configure default cloudfront behaviour to use non caching policy

### DIFF
--- a/terraform/app/modules/cloudfront/data.tf
+++ b/terraform/app/modules/cloudfront/data.tf
@@ -16,3 +16,11 @@ data "aws_acm_certificate" "cloudfront_cert" {
 data "aws_cloudfront_cache_policy" "managed-caching-optimized" {
   name = "Managed-CachingOptimized"
 }
+
+data "aws_cloudfront_cache_policy" "Managed-CachingDisabled" {
+  name = "Managed-CachingDisabled"
+}
+
+data "aws_cloudfront_origin_request_policy" "Managed-AllViewer" {
+  name = "Managed-AllViewer"
+}

--- a/terraform/app/modules/cloudfront/main.tf
+++ b/terraform/app/modules/cloudfront/main.tf
@@ -29,7 +29,7 @@ resource "aws_cloudfront_distribution" "default" {
   enabled = true
   aliases = local.cloudfront_aliases
 
-    ordered_cache_behavior {
+  ordered_cache_behavior {
     allowed_methods  = ["GET", "HEAD"]
     cached_methods   = ["GET", "HEAD"]
     target_origin_id = "${var.service_name}-${var.environment}-offline"

--- a/terraform/app/modules/cloudfront/main.tf
+++ b/terraform/app/modules/cloudfront/main.tf
@@ -29,27 +29,7 @@ resource "aws_cloudfront_distribution" "default" {
   enabled = true
   aliases = local.cloudfront_aliases
 
-  default_cache_behavior {
-    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
-    cached_methods   = ["GET", "HEAD"]
-    target_origin_id = "${var.service_name}-${var.environment}-default-origin"
-
-    forwarded_values {
-      query_string = true
-      headers      = var.default_header_list
-
-      cookies {
-        forward = "all"
-      }
-    }
-
-    # The absense of `ttl` configuration here means caching is deferred to the origin
-    # https://angristan.xyz/terraform-enable-origin-cache-headers-aws-cloudfront/
-
-    viewer_protocol_policy = "redirect-to-https"
-  }
-
-  ordered_cache_behavior {
+    ordered_cache_behavior {
     allowed_methods  = ["GET", "HEAD"]
     cached_methods   = ["GET", "HEAD"]
     target_origin_id = "${var.service_name}-${var.environment}-offline"
@@ -71,7 +51,6 @@ resource "aws_cloudfront_distribution" "default" {
     viewer_protocol_policy = "redirect-to-https"
   }
 
-
   dynamic "ordered_cache_behavior" {
     for_each = local.cloudfront_cached_paths
 
@@ -83,6 +62,16 @@ resource "aws_cloudfront_distribution" "default" {
       viewer_protocol_policy = "redirect-to-https"
       cache_policy_id        = data.aws_cloudfront_cache_policy.managed-caching-optimized.id
     }
+  }
+
+  default_cache_behavior {
+    allowed_methods          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods           = ["GET", "HEAD"]
+    target_origin_id         = "${var.service_name}-${var.environment}-default-origin"
+    cache_policy_id          = data.aws_cloudfront_cache_policy.Managed-CachingDisabled.id
+    origin_request_policy_id = data.aws_cloudfront_origin_request_policy.Managed-AllViewer.id
+
+    viewer_protocol_policy = "redirect-to-https"
   }
 
   price_class = "PriceClass_100"

--- a/terraform/app/modules/cloudfront/variables.tf
+++ b/terraform/app/modules/cloudfront/variables.tf
@@ -13,23 +13,6 @@ variable "offline_bucket_domain_name" {
 variable "offline_bucket_origin_path" {
 }
 
-
-variable "default_header_list" {
-  default = [
-    "Authorization",
-    "Origin",
-    "Referer",
-    "Accept",
-    "Accept-Charset",
-    "Accept-DateTime",
-    "Accept-Encoding",
-    "Accept-Language",
-    "CloudFront-Forwarded-Proto",
-    "User-Agent",
-    "Host"
-  ]
-}
-
 variable "route53_zones" {
   type = list(any)
 }

--- a/terraform/app/modules/cloudfront/variables.tf
+++ b/terraform/app/modules/cloudfront/variables.tf
@@ -30,7 +30,7 @@ locals {
   cloudfront_aliases_cnames                              = [for zone in var.route53_zones : "${var.route53_cname_record}.${zone}"]
   cloudfront_aliases                                     = concat(var.route53_a_records, local.cloudfront_aliases_cnames)
   cloudfront_viewer_certificate_minimum_protocol_version = "TLSv1.2_2018"
-  cloudfront_cached_paths                                = ["/packs/*", "/attachment*"]
+  cloudfront_cached_paths                                = ["/packs/*", "/attachment/*"]
   cloudfront_custom_response = {
     404 = { ttl = "10" },
     500 = { ttl = "60", response_code = "500", page_path = "${var.offline_bucket_origin_path}/index.html" },


### PR DESCRIPTION
## Jira ticket URL


https://dfedigital.atlassian.net/browse/TEVA-2736

## Changes in this PR:
1 - “Configure default cloudfront behaviour to use non caching policy” it’s to simplify the code and stop using the legacy cache behavior

2 - for “Change Cloudfront cached path for attachment” it’s to make it more accurate and also more consistent with /packs/*

