### PR TITLE
Fix feedbacks with empty job_application_id

### DIFF
--- a/app/controllers/jobseekers/job_applications/feedbacks_controller.rb
+++ b/app/controllers/jobseekers/job_applications/feedbacks_controller.rb
@@ -20,7 +20,7 @@ class Jobseekers::JobApplications::FeedbacksController < Jobseekers::BaseControl
 
   def feedback_attributes
     feedback_form_params.merge(
-      application_id: job_application.id,
+      job_application_id: job_application.id,
       feedback_type: "application",
       jobseeker_id: current_jobseeker.id,
     )

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -79,7 +79,6 @@ shared:
     - publisher_id
     - subscription_id
     - vacancy_id
-    - application_id
     - close_account_reason
     - close_account_reason_comment
   job_applications:

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -21,7 +21,6 @@ shared:
     - publisher_id
     - subscription_id
     - vacancy_id
-    - application_id
   job_applications:
     - id
     - jobseeker_id

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -46,3 +46,23 @@ namespace :ons do
     %i[regions counties cities].each { |api_location_type| ImportPolygons.new(api_location_type: api_location_type).call }
   end
 end
+
+namespace :feedbacks do
+  desc "Copy application_id to job_application_id"
+  task copy_application_id_to_job_application_id: :environment do
+    feedbacks_to_fix_count = Feedback.where.not(application_id: nil).where(job_application_id: nil).count
+    fixed_feedbacks_count = 0
+
+    puts "Checking #{feedbacks_to_fix_count} feedbacks with application_id set and job_application_id nil..."
+
+    Feedback.find_each do |feedback|
+      next unless feedback.application_id.present? && feedback.job_application_id.blank?
+
+      feedback.update_column(:job_application_id, feedback.application_id)
+      fixed_feedbacks_count += 1
+    end
+
+    puts "Fixed #{fixed_feedbacks_count} feedbacks."
+    puts "⛅ Have a nice day!"
+  end
+end


### PR DESCRIPTION
## Changes in this PR:
`application_id` field on feedbacks is redundant as we have `job_application_id`