### PR TITLE
Remove application_id from feedbacks

### DIFF
--- a/db/migrate/20210624104321_remove_application_id_from_feedbacks.rb
+++ b/db/migrate/20210624104321_remove_application_id_from_feedbacks.rb
@@ -1,0 +1,5 @@
+class RemoveApplicationIdFromFeedbacks < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :feedbacks, :application_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_17_132404) do
+ActiveRecord::Schema.define(version: 2021_06_24_104321) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -157,7 +157,6 @@ ActiveRecord::Schema.define(version: 2021_06_17_132404) do
     t.uuid "publisher_id"
     t.uuid "subscription_id"
     t.uuid "vacancy_id"
-    t.uuid "application_id"
     t.boolean "exported_to_bigquery", default: false, null: false
     t.integer "close_account_reason"
     t.text "close_account_reason_comment"

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -46,23 +46,3 @@ namespace :ons do
     %i[regions counties cities].each { |api_location_type| ImportPolygons.new(api_location_type: api_location_type).call }
   end
 end
-
-namespace :feedbacks do
-  desc "Copy application_id to job_application_id"
-  task copy_application_id_to_job_application_id: :environment do
-    feedbacks_to_fix_count = Feedback.where.not(application_id: nil).where(job_application_id: nil).count
-    fixed_feedbacks_count = 0
-
-    puts "Checking #{feedbacks_to_fix_count} feedbacks with application_id set and job_application_id nil..."
-
-    Feedback.find_each do |feedback|
-      next unless feedback.application_id.present? && feedback.job_application_id.blank?
-
-      feedback.update_column(:job_application_id, feedback.application_id)
-      fixed_feedbacks_count += 1
-    end
-
-    puts "Fixed #{fixed_feedbacks_count} feedbacks."
-    puts "⛅ Have a nice day!"
-  end
-end


### PR DESCRIPTION
Console output of the script removed in this PR:

```
Checking 99 feedbacks with application_id set and job_application_id nil...
Fixed 99 feedbacks.
⛅ Have a nice day!
```