### PR TITLE
[TEVA-2151] test canonial rel links on duplicate pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,6 +20,8 @@ class ApplicationController < ActionController::Base
   include DeviseFlashConcerns
   include AbTestable
 
+  helper_method :canonical_href
+
   def check
     render json: { status: "OK" }, status: :ok
   end
@@ -33,6 +35,10 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  def canonical_href
+    nil
+  end
 
   def cookies_preference_set?
     cookies["consented-to-cookies"].present?

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -1,6 +1,10 @@
 class VacanciesController < ApplicationController
   helper_method :job_application
 
+  attr_accessor :canonical_href
+
+  SEO_CANONICAL_TEST_VACANCIES = %w[c9f9a45f-1f42-4686-9515-311bc169af29 ef21f5d2-4226-4cf8-b8d2-3155e149b0b2].freeze
+
   def index
     set_map_display
     params[:location] = params[:location_facet] if params[:location_facet]
@@ -22,6 +26,8 @@ class VacanciesController < ApplicationController
       return render "/errors/trashed_vacancy_found", status: :not_found
     end
 
+    canonical
+
     return redirect_to(job_path(vacancy), status: :moved_permanently) if old_vacancy_path?(vacancy)
 
     @saved_job = current_jobseeker&.saved_jobs&.find_by(vacancy_id: vacancy.id)
@@ -33,6 +39,16 @@ class VacanciesController < ApplicationController
   end
 
   private
+
+  UUID_REGEX = /\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b/
+
+  def canonical
+    return unless SEO_CANONICAL_TEST_VACANCIES.include?(vacancy.id)
+
+    return unless UUID_REGEX.match(id) || !job_path(vacancy).end_with?(vacancy.slug)
+
+    @canonical_href = job_url(id)
+  end
 
   def algolia_search_params
     strip_empty_checkboxes(%i[job_roles phases working_patterns])

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -8,6 +8,10 @@ html.govuk-template.app-html-class lang="en"
     title #{content_for :page_title_prefix} — #{t("app.title")}
     meta content="width=device-width, initial-scale=1" name="viewport"
     meta content="blue" name="theme-color"
+
+    - if canonical_href
+      link rel="canonical" href="#{canonical_href}"
+
     link href=asset_pack_path("media/images/favicon.ico") rel="shortcut icon" type="image/x-icon"
     link color="blue" href=asset_pack_path("media/images/govuk-mask-icon.svg") rel="mask-icon"
     link href=asset_pack_path("media/images/govuk-apple-touch-icon-180x180.png") rel="apple-touch-icon" sizes="180x180"

--- a/spec/system/jobseekers_can_view_a_vacancy_spec.rb
+++ b/spec/system/jobseekers_can_view_a_vacancy_spec.rb
@@ -4,12 +4,15 @@ RSpec.describe "Viewing a single published vacancy" do
   let(:school) { create(:school) }
 
   scenario "Published vacancies are viewable" do
+    allow_any_instance_of(ApplicationController).to receive(:canonical_href).and_return(false)
     vacancy = create(:vacancy, :published)
     vacancy.organisation_vacancies.create(organisation: school)
 
     published_vacancy = VacancyPresenter.new(vacancy)
 
     visit job_path(published_vacancy)
+
+    expect(page).to_not have_css("link[rel='canonical']")
 
     verify_vacancy_show_page_details(published_vacancy)
   end
@@ -77,6 +80,7 @@ RSpec.describe "Viewing a single published vacancy" do
       let(:vacancy) { create(:vacancy, subjects: %w[Physics]) }
 
       before do
+        allow_any_instance_of(ApplicationController).to receive(:canonical_href).and_return(false)
         vacancy.organisation_vacancies.create(organisation: school)
         visit job_path(vacancy)
       end
@@ -132,6 +136,7 @@ RSpec.describe "Viewing a single published vacancy" do
 
   context "meta tags" do
     include ActionView::Helpers::SanitizeHelper
+
     scenario "the vacancy's meta data are rendered correctly" do
       vacancy = create(:vacancy, :published)
       vacancy.organisation_vacancies.create(organisation: school)


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-2151

## Changes in this PR:

- mark duplicate content job pages as <link rel="canonical" />
- testing this on two vacancies that SEM rush as flagged with errors because of this error. then can think about making this change for all vacancy listing pages