### PR TITLE
[TEVA-2752] Close down the wider search suggestions AB test

### DIFF
--- a/app/views/vacancies/index.html.slim
+++ b/app/views/vacancies/index.html.slim
@@ -43,7 +43,7 @@
               ul.govuk-list.govuk-list--bullet
                 - t("jobs.no_jobs.suggestions").each do |list_item|
                   li = list_item
-          - if current_variant?(:"2021_05_wider_search_suggestions", :with) && @vacancies_search.wider_search_suggestions.present?
+          - if @vacancies_search.wider_search_suggestions.present?
             .divider-bottom
               - if @vacancies_search.keyword.present?
                 .govuk-heading-m = t(".wider_search_suggestions.heading.keyword_html", keyword: @vacancies_search.keyword)

--- a/config/ab_tests.yml
+++ b/config/ab_tests.yml
@@ -28,9 +28,6 @@ shared:
     foo: 1
     bar: 1
     baz: 1
-  2021_05_wider_search_suggestions:
-    with: 1
-    without: 1
   2021_05_job_alert_account_creation_prompt_test:
     bottom: 1
     right_blue: 1


### PR DESCRIPTION
The test showed that with the links displayed, there's an overall 1.4% increase in the number of users who view a vacancy, and no significant impact on the job alert creation rate. So, it seems that this feature is helping jobseekers find vacancies, and isn't doing this at the cost of distracting people from creating job alerts.

Reverses https://github.com/DFE-Digital/teaching-vacancies/pull/3420

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2752
