### PR TITLE
[TEVA-2704] Use ISO8601 format for timestamps sent to BigQuery

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -17,6 +17,7 @@ class ApplicationRecord < ActiveRecord::Base
     attributes.each_with_object({}) do |(key, value), anonymised|
       next unless export?(key)
 
+      value = value.to_s(:iso8601) if value.respond_to?(:strftime)
       anonymised[key] = anonymise?(key) ? anonymise_value(value) : value
     end
   end

--- a/spec/models/application_record_spec.rb
+++ b/spec/models/application_record_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe ApplicationRecord do
                                "oid" => StringAnonymiser.new(model.oid).to_s,
                                "email" => StringAnonymiser.new(model.email).to_s,
                                "given_name" => StringAnonymiser.new(model.given_name).to_s,
-                               "family_name" => StringAnonymiser.new(model.family_name).to_s)
+                               "family_name" => StringAnonymiser.new(model.family_name).to_s,
+                               "accepted_terms_at" => model.accepted_terms_at.to_s(:iso8601))
       end
 
       it "anonymises data" do


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-2704

## Screenshots of UI changes:
![Screenshot 2021-06-28 at 13 52 42](https://user-images.githubusercontent.com/7215/123639479-249cc280-d818-11eb-91d3-c5bdad2bab56.png)
