### PR TITLE
Improve application caching behaviour

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,6 +48,9 @@ Rails.application.configure do
 
   config.cache_store = :redis_cache_store, { url: config.redis_cache_url, pool_size: ENV.fetch("RAILS_MAX_THREADS", 5) }
 
+  # This will affect assets in /public, /packs e.g. Webpack assets to be cached in Cloudfront
+  config.public_file_server.headers = { "Cache-Control" => "public, max-age=#{1.year.seconds}" }
+
   # Use a real queuing backend for Active Job
   # (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque
@@ -95,9 +98,6 @@ Rails.application.configure do
     ActionDispatch::RemoteIp::TRUSTED_PROXIES,
     AWSIpRanges.cloudfront_ips.map { |proxy| IPAddr.new(proxy) },
   ].flatten
-
-  # Ensure browsers don't cache
-  config.action_dispatch.default_headers["Cache-Control"] = "no-cache, no-store"
 
   config.active_storage.service = :amazon
 end

--- a/config/initializers/assets_cache_headers.rb
+++ b/config/initializers/assets_cache_headers.rb
@@ -1,6 +1,0 @@
-# This will affect assets in /public, /packs e.g. webpacker assets.
-# We set cache headers to instruct Cloudfront to cache assets for one year
-
-Rails.application.config.public_file_server.headers = {
-  "Cache-Control" => "public, max-age=31536000",
-}

--- a/terraform/app/modules/cloudfront/variables.tf
+++ b/terraform/app/modules/cloudfront/variables.tf
@@ -30,7 +30,7 @@ locals {
   cloudfront_aliases_cnames                              = [for zone in var.route53_zones : "${var.route53_cname_record}.${zone}"]
   cloudfront_aliases                                     = concat(var.route53_a_records, local.cloudfront_aliases_cnames)
   cloudfront_viewer_certificate_minimum_protocol_version = "TLSv1.2_2018"
-  cloudfront_cached_paths                                = ["/packs/*", "/attachment/*"]
+  cloudfront_cached_paths                                = ["/packs/*", "/attachments/*"]
   cloudfront_custom_response = {
     404 = { ttl = "10" },
     500 = { ttl = "60", response_code = "500", page_path = "${var.offline_bucket_origin_path}/index.html" },


### PR DESCRIPTION
- Stop sending overly restrictive `Cache-Control` header
- Fix attachments path pattern in Cloudfront TF config
- Move file server cache configuration from initializer into
  production environment config