### PR TITLE
fix error state for textarea that use formatting functionality

### DIFF
--- a/app/frontend/src/application/publishers/textareaFormat.js
+++ b/app/frontend/src/application/publishers/textareaFormat.js
@@ -1,21 +1,26 @@
-import logger from '../../lib/logging';
+const ERROR_CLASS_POSTFIX = '-error';
 
 document.addEventListener('trix-initialize', (e) => {
   const inputAttribute = Array.from(e.target.attributes).filter((attr) => attr.name === 'input')[0];
 
-  try {
+  if (document.getElementById(inputAttribute.value)) {
     document.getElementById(inputAttribute.value).style.display = 'none';
-  } catch (error) {
-    logger.warn(`[component: textarea formatting init] ${error.message} input: ${inputAttribute.name}`);
+  }
+
+  if (document.getElementById(`${inputAttribute.value}${ERROR_CLASS_POSTFIX}`)) {
+    document.getElementById(`${inputAttribute.value}${ERROR_CLASS_POSTFIX}`).style.display = 'none';
+    e.target.parentElement.classList.add('govuk-form-group--error');
   }
 });
 
 document.addEventListener('trix-change', (e) => {
   const inputAttribute = Array.from(e.target.attributes).filter((attr) => attr.name === 'input')[0];
 
-  try {
+  if (document.getElementById(inputAttribute.value)) {
     document.getElementById(inputAttribute.value).value = e.target.editor.element.innerHTML;
-  } catch (error) {
-    logger.warn(`[component: textarea formatting change] ${error.message} input: ${inputAttribute.name}`);
+  }
+
+  if (document.getElementById(`${inputAttribute.value}${ERROR_CLASS_POSTFIX}`)) {
+    document.getElementById(`${inputAttribute.value}${ERROR_CLASS_POSTFIX}`).value = e.target.editor.element.innerHTML;
   }
 });

--- a/app/views/publishers/vacancies/build/job_summary.html.slim
+++ b/app/views/publishers/vacancies/build/job_summary.html.slim
@@ -14,7 +14,9 @@
         h2.govuk-heading-l = t("jobs.job_summary")
 
         = f.govuk_text_area :job_advert, label: { size: "s", id: "job-advert-label" }, rows: 10, required: true
-        trix-editor input="publishers-job-listing-job-summary-form-job-advert-field" aria-labelledby="job-advert-label" role="textbox" contenteditable="true" aria-multiline="true" class="govuk-textarea formatable-textarea js-action govuk-!-margin-bottom-6 govuk-!-margin-top-2"
+
+        .govuk-form-group
+          trix-editor input="publishers-job-listing-job-summary-form-job-advert-field" aria-labelledby="job-advert-label" role="textbox" contenteditable="true" aria-multiline="true" class="govuk-textarea formatable-textarea js-action govuk-!-margin-bottom-6 govuk-!-margin-top-2"
 
         = f.govuk_text_area :about_school,
           label: { id: "about-school-label", text: t("helpers.label.publishers_job_listing_job_summary_form.about_organisation", organisation: vacancy_about_school_label_organisation(vacancy)), size: "s" },
@@ -22,7 +24,9 @@
           value: vacancy_about_school_value(vacancy),
           rows: 10,
           required: true
-        trix-editor input="publishers-job-listing-job-summary-form-about-school-field" aria-labelledby="about-school-label" role="textbox" contenteditable="true" aria-multiline="true" class="govuk-textarea formatable-textarea js-action govuk-!-margin-bottom-6 govuk-!-margin-top-2"
+
+        .govuk-form-group
+          trix-editor input="publishers-job-listing-job-summary-form-about-school-field" aria-labelledby="about-school-label" role="textbox" contenteditable="true" aria-multiline="true" class="govuk-textarea formatable-textarea js-action govuk-!-margin-bottom-6 govuk-!-margin-top-2"
 
         = render "publishers/vacancies/vacancy_form_partials/submit", f: f
 


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-2755

fixes a problem whereby when formbuilder text area have error states the trix editors have the incorrect id to associate with

there is a small style issue with the left hand red line not joining which i can think of a non-hacky approach for right now but this PR fixes the user impacting problem

see ticket for before, this is after
![Screenshot 2021-06-29 at 14 57 03](https://user-images.githubusercontent.com/1792451/123816889-9ac02880-d8ef-11eb-958c-8ebe3b39eea8.png)

