### PR TITLE
Fix Job Application Data Expiry Mailer Spec

### DIFF
--- a/spec/mailers/publishers/job_application_data_expiry_mailer_spec.rb
+++ b/spec/mailers/publishers/job_application_data_expiry_mailer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Publishers::JobApplicationDataExpiryMailer do
   describe "#job_application_data_expiry" do
     it "sends a `job_application_data_expiry` email" do
       expect(mail.subject).to eq(I18n.t("publishers.job_application_data_expiry_mailer.job_application_data_expiry.subject", job_title: vacancy.job_title,
-                                                                                                                             expiration_date: vacancy_data_expiration_date))
+                                                                                                                             expiration_date: format_date(vacancy_data_expiration_date)))
       expect(mail.to).to eq(["test@example.com"])
       expect(mail.body.encoded).to include(vacancy.job_title)
                                .and include(I18n.t("publishers.job_application_data_expiry_mailer.job_application_data_expiry.title", job_title: vacancy.job_title,


### PR DESCRIPTION
## Changes in this PR:

- Value for expiration_date was not formatted correctly in the expectation, causing the test to fail.