### PR TITLE
Get vacancy view count from BigQuery

### DIFF
--- a/app/jobs/send_entity_imported_events_to_data_warehouse_job.rb
+++ b/app/jobs/send_entity_imported_events_to_data_warehouse_job.rb
@@ -7,7 +7,7 @@ class SendEntityImportedEventsToDataWarehouseJob < ApplicationJob
 
   def perform
     bq = Google::Cloud::Bigquery.new
-    dataset = bq.dataset(ENV.fetch("BIG_QUERY_DATASET"), skip_lookup: true)
+    dataset = bq.dataset(Rails.configuration.big_query_dataset, skip_lookup: true)
     bq_table = dataset.table(TABLE_NAME, skip_lookup: true)
 
     ApplicationRecord.connection.tables.each do |db_table|

--- a/app/jobs/send_event_to_data_warehouse_job.rb
+++ b/app/jobs/send_event_to_data_warehouse_job.rb
@@ -6,7 +6,7 @@ class SendEventToDataWarehouseJob < ApplicationJob
 
   def perform(table_name, data)
     bq = Google::Cloud::Bigquery.new
-    dataset = bq.dataset(ENV.fetch("BIG_QUERY_DATASET"), skip_lookup: true)
+    dataset = bq.dataset(Rails.configuration.big_query_dataset, skip_lookup: true)
     table = dataset.table(table_name, skip_lookup: true)
 
     table.insert(data)

--- a/app/jobs/send_feedback_to_big_query_job.rb
+++ b/app/jobs/send_feedback_to_big_query_job.rb
@@ -8,7 +8,7 @@ class SendFeedbackToBigQueryJob < ApplicationJob
 
   def perform
     bq = Google::Cloud::Bigquery.new
-    dataset = bq.dataset(ENV.fetch("BIG_QUERY_DATASET"), skip_lookup: true)
+    dataset = bq.dataset(Rails.configuration.big_query_dataset, skip_lookup: true)
     bq_table = dataset.table(TABLE_NAME, skip_lookup: true)
 
     Rails.logger.info("sending #{Feedback.where(exported_to_bigquery: false).count} new feedback events to bigquery")

--- a/app/services/publishers/vacancy_stats.rb
+++ b/app/services/publishers/vacancy_stats.rb
@@ -1,0 +1,39 @@
+class Publishers::VacancyStats
+  CACHE_DURATION = 6.hours
+  TABLE_NAME = "vacancies_published".freeze
+
+  def initialize(vacancy)
+    @vacancy = vacancy
+  end
+
+  def number_of_unique_views
+    query_single_field(:number_of_unique_vacancy_views)
+  end
+
+  private
+
+  attr_reader :vacancy
+
+  def query_single_field(field)
+    Rails.cache.fetch([field, vacancy.id], expires_in: CACHE_DURATION, skip_nil: true) do
+      # publish_on added to make query more efficient as the BigQuery table is partitioned by it
+      sql = <<~SQL
+        SELECT #{field}
+        FROM `#{Rails.configuration.big_query_dataset}.#{TABLE_NAME}`
+        WHERE id="#{StringAnonymiser.new(vacancy.id)}"
+        AND publish_on = "#{vacancy.publish_on.iso8601}"
+      SQL
+
+      big_query.query(sql).first&.fetch(field)
+    end
+  rescue StandardError => e
+    # Stats are a nice-to-have, return `nil` instead of failing hard if we can't get them
+    Rollbar.error(e)
+
+    nil
+  end
+
+  def big_query
+    @big_query ||= Google::Cloud::Bigquery.new
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -91,6 +91,8 @@ module TeacherVacancyService
     config.analytics = config_for(:analytics)
     config.analytics_pii = config_for(:analytics_pii)
 
+    config.big_query_dataset = ENV["BIG_QUERY_DATASET"]
+
     config.enforce_local_authority_allowlist = ActiveModel::Type::Boolean.new.cast(ENV["ENFORCE_LOCAL_AUTHORITY_ALLOWLIST"])
 
     config.algolia_index_prefix = ENV.fetch("ALGOLIA_INDEX_PREFIX", nil)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -52,6 +52,8 @@ Rails.application.configure do
   # Algolia index prefix must be nil in order for VCR system specs to run
   config.algolia_index_prefix = nil
 
+  config.big_query_dataset = "test_dataset"
+
   # Use test geocoder lookup, unless otherwise specified
   config.geocoder_lookup = :test
 

--- a/lib/base_dsi_exporter.rb
+++ b/lib/base_dsi_exporter.rb
@@ -7,7 +7,7 @@ class BaseDsiBigQueryExporter
   attr_reader :dataset
 
   def initialize(bigquery: Google::Cloud::Bigquery.new)
-    @dataset = bigquery.dataset ENV.fetch("BIG_QUERY_DATASET")
+    @dataset = bigquery.dataset(Rails.configuration.big_query_dataset)
   end
 
   private

--- a/spec/jobs/send_entity_imported_events_to_data_warehouse_job_spec.rb
+++ b/spec/jobs/send_entity_imported_events_to_data_warehouse_job_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe SendEntityImportedEventsToDataWarehouseJob do
   let(:table) { double("Table") }
 
   before do
-    allow(ENV).to receive(:fetch).with("BIG_QUERY_DATASET").and_return("test_dataset")
     allow(Google::Cloud::Bigquery).to receive(:new).and_return(big_query)
     allow(ApplicationRecord).to receive(:descendants).and_return([Jobseeker, Publisher])
   end

--- a/spec/jobs/send_event_to_data_warehouse_job_spec.rb
+++ b/spec/jobs/send_event_to_data_warehouse_job_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe SendEventToDataWarehouseJob do
   let(:table) { double("Table") }
 
   before do
-    allow(ENV).to receive(:fetch).with("BIG_QUERY_DATASET").and_return("test_dataset")
     allow(Google::Cloud::Bigquery).to receive(:new).and_return(big_query)
   end
 

--- a/spec/jobs/send_feedback_to_big_query_job_spec.rb
+++ b/spec/jobs/send_feedback_to_big_query_job_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe SendFeedbackToBigQueryJob do
   let!(:feedback2) { create(:feedback, comment: "A different comment") }
 
   before do
-    allow(ENV).to receive(:fetch).with("BIG_QUERY_DATASET").and_return("test_dataset")
     allow(Google::Cloud::Bigquery).to receive(:new).and_return(big_query)
   end
 

--- a/spec/lib/export_dsi_approver_records_to_big_query_spec.rb
+++ b/spec/lib/export_dsi_approver_records_to_big_query_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe ExportDsiApproversToBigQuery do
   before do
-    ENV["BIG_QUERY_DATASET"] = "test_dataset"
     expect(bigquery_stub).to receive(:dataset).with("test_dataset").and_return(dataset_stub)
     expect(dataset_stub).to receive(:table).and_return(table_stub)
 

--- a/spec/lib/export_dsi_user_records_to_big_query_spec.rb
+++ b/spec/lib/export_dsi_user_records_to_big_query_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe ExportDsiUsersToBigQuery do
   before do
-    ENV["BIG_QUERY_DATASET"] = "test_dataset"
     expect(bigquery_stub).to receive(:dataset).with("test_dataset").and_return(dataset_stub)
     expect(dataset_stub).to receive(:table).and_return(table_stub)
 

--- a/spec/services/publishers/vacancy_stats_spec.rb
+++ b/spec/services/publishers/vacancy_stats_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe Publishers::VacancyStats do
+  subject { described_class.new(vacancy) }
+
+  let(:vacancy) { build_stubbed(:vacancy, publish_on: Date.new(1999, 12, 31)) }
+  let(:big_query) { double("BigQuery") }
+
+  before do
+    allow(Google::Cloud::Bigquery).to receive(:new).and_return(big_query)
+    allow(StringAnonymiser).to receive(:new).with(vacancy.id).and_return("anonymous-id")
+  end
+
+  describe "#number_of_unique_views" do
+    let(:response) { [{ number_of_unique_vacancy_views: 42 }] }
+    let(:expected_sql) do
+      <<~SQL
+        SELECT number_of_unique_vacancy_views
+        FROM `test_dataset.vacancies_published`
+        WHERE id="anonymous-id"
+        AND publish_on = "1999-12-31"
+      SQL
+    end
+
+    before do
+      allow(big_query).to receive(:query).with(expected_sql).and_return(response)
+    end
+
+    it "retrieves the vacancy view count from the BigQuery API" do
+      expect(subject.number_of_unique_views).to eq(42)
+    end
+  end
+end


### PR DESCRIPTION
- Add basic initial code to get vacancy view count data from BigQuery
  (to be refactored when we have multiple things we need to retrieve)
- Change BigQuery dataset configuration to use Rails configuration
  instead of fetching from `ENV` throughout the code