### PR TITLE
[TEVA-2443] Add dependent: :destroy to has_many :organisations

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -44,7 +44,7 @@ class Vacancy < ApplicationRecord
   has_noticed_notifications
 
   has_many :organisation_vacancies, dependent: :destroy
-  has_many :organisations, through: :organisation_vacancies
+  has_many :organisations, through: :organisation_vacancies, dependent: :destroy
   accepts_nested_attributes_for :organisation_vacancies
 
   delegate :name, to: :parent_organisation, prefix: true, allow_nil: true


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-2443

## Changes in this PR:
When we update organisations using nested attributes, we lose the destroy callback that send events to BigQuery. This does it manually and callbacks are not lost