### PR TITLE
[TEVA-2758] Use github label for deployments of pull requests

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -14,6 +14,12 @@ on:
   pull_request:
     branches:
     - master
+    types:
+      - labeled
+      - opened
+      - synchronize
+      - reopened
+
     paths-ignore:
     - 'bigquery/**'
     - 'documentation/**'
@@ -27,6 +33,7 @@ env:
 jobs:
 
   build:
+    if: contains(github.event.pull_request.labels.*.name, 'deploy') || github.event_name != 'pull_request'
     name: Build docker image
     outputs:
       build_git_tag: ${{steps.tag_version.outputs.new_tag}}

--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   delete-review-app:
+    if: contains(github.event.pull_request.labels.*.name, 'deploy')
     name: Delete review app after deploy
     runs-on: ubuntu-20.04
 


### PR DESCRIPTION
This allows for flexibility in the deployment of pull requests such that,
it gives the option to deploy a review app with the underlying infrastructure
on PaaS or not, which saves time and speeds up the end-to-end engineering process
and bring new features to market.

## Jira ticket URL

- Just add the ticket number to the end:

https://dfedigital.atlassian.net/browse/TEVA-

## Changes in this PR:

Introduce `if: contains(github.event.pull_request.labels.*.name, 'deploy') || github.event_name != 'pull_request'` in both build_deploy workflow and `if: contains(github.event.pull_request.labels.*.name, 'deploy')` in the delete delete workflow