### PR TITLE
Update robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,3 +2,6 @@ SITEMAP: https://teaching-vacancies.service.gov.uk/sitemap.xml
 User-agent: *
 Allow: /
 Disallow: /check
+Disallow: /subscriptions/
+Disallow: /documents/
+Disallow: /attachments/


### PR DESCRIPTION
- Disallow `/subscriptions/` as this is just a whole bunch of job
  alert sign up pages that have no SEO value
- Disallow `/documents/` as this is a legacy path that for some
  reason gets crawled a lot causing spikes in 404s
- Disallow `/attachments/` as these are public but don't really
  add value to search engines

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2791
