### PR TITLE
Add experiment for switching out search strategy

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -9,7 +9,12 @@ class VacanciesController < ApplicationController
       @landing_page_translation = "#{params[:pretty]}.#{@landing_page.parameterize.underscore}"
     end
     @jobs_search_form = Jobseekers::SearchForm.new(algolia_search_params)
-    @vacancies_search = Search::VacancySearch.new(@jobs_search_form.to_hash, sort_by: @jobs_search_form.jobs_sort, page: params[:page])
+    @vacancies_search = Search::VacancySearch.new(
+      @jobs_search_form.to_hash,
+      sort_by: @jobs_search_form.jobs_sort,
+      page: params[:page],
+      pg_search: ActiveModel::Type::Boolean.new.cast(params[:pg_search]),
+    )
     @vacancies = VacanciesPresenter.new(@vacancies_search.vacancies)
   end
 

--- a/app/services/search/strategies/experiment.rb
+++ b/app/services/search/strategies/experiment.rb
@@ -1,0 +1,46 @@
+class Search::Strategies::Experiment
+  def initialize(control, experiment, search_criteria:, use_experiment: false)
+    @control = control
+    @experiment = experiment
+
+    @search_criteria = search_criteria
+    @use_experiment = use_experiment
+
+    compare_and_send_results
+  end
+
+  def vacancies
+    @vacancies ||= result_strategy.vacancies
+  end
+
+  def total_count
+    @total_count ||= result_strategy.total_count
+  end
+
+  private
+
+  attr_reader :control, :experiment, :search_criteria, :use_experiment
+
+  def result_strategy
+    use_experiment ? experiment : control
+  end
+
+  def compare_and_send_results
+    control_ids = control.vacancies.map(&:id)
+    experiment_ids = experiment.vacancies.map(&:id)
+
+    Event.new.trigger(
+      :search_experiment_performed,
+      control_strategy: control.class.to_s,
+      experiment_strategy: experiment.class.to_s,
+      search_criteria: search_criteria.to_json,
+      control_result_count: control.total_count,
+      experiment_result_count: experiment.total_count,
+      matches: (control_ids & experiment_ids).count,
+      mismatches_from_control: (control_ids - experiment_ids).count,
+      mismatches_from_experiment: (experiment_ids - control_ids).count,
+    )
+  rescue StandardError => e
+    Rollbar.error(e)
+  end
+end

--- a/app/services/search/strategies/pg_search.rb
+++ b/app/services/search/strategies/pg_search.rb
@@ -1,0 +1,19 @@
+class Search::Strategies::PgSearch
+  attr_reader :page, :per_page
+
+  def initialize(keyword, page:, per_page:)
+    @keyword = keyword
+    @page = page
+    @per_page = per_page
+  end
+
+  def vacancies
+    # TODO: Implement me
+    Kaminari.paginate_array([], total_count: total_count).page(page).per(per_page)
+  end
+
+  def total_count
+    # TODO: Implement me
+    0
+  end
+end

--- a/app/services/search/vacancy_search.rb
+++ b/app/services/search/vacancy_search.rb
@@ -6,9 +6,9 @@ class Search::VacancySearch
   def_delegators :search_strategy, :vacancies, :total_count
   def_delegators :location_search, :point_coordinates
 
-  attr_reader :search_criteria, :keyword, :sort_by, :page, :per_page, :fuzzy
+  attr_reader :search_criteria, :keyword, :sort_by, :page, :per_page, :fuzzy, :pg_search
 
-  def initialize(search_criteria, sort_by: nil, page: nil, per_page: nil, fuzzy: true)
+  def initialize(search_criteria, sort_by: nil, page: nil, per_page: nil, fuzzy: true, pg_search: false)
     @search_criteria = search_criteria
     @keyword = search_criteria[:keyword]
 
@@ -16,6 +16,7 @@ class Search::VacancySearch
     @per_page = (per_page || DEFAULT_HITS_PER_PAGE).to_i
     @page = (page || DEFAULT_PAGE).to_i
     @fuzzy = fuzzy
+    @pg_search = pg_search
   end
 
   def active_criteria
@@ -61,7 +62,12 @@ class Search::VacancySearch
 
   def search_strategy
     @search_strategy ||= if active_criteria?
-                           Search::Strategies::Algolia.new(algolia_params)
+                           Search::Strategies::Experiment.new(
+                             Search::Strategies::Algolia.new(algolia_params),
+                             Search::Strategies::PgSearch.new(keyword, page: page, per_page: per_page),
+                             search_criteria: search_criteria,
+                             use_experiment: pg_search,
+                           )
                          else
                            Search::Strategies::Database.new(page, per_page, sort_by)
                          end

--- a/spec/services/search/strategies/experiment_spec.rb
+++ b/spec/services/search/strategies/experiment_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+RSpec.describe Search::Strategies::Experiment do
+  subject { described_class.new(control, experiment, search_criteria: search_criteria, use_experiment: use_experiment) }
+
+  let(:control_vacancies) { (1..5).map { |i| instance_double(Vacancy, id: i) } }
+  let(:experiment_vacancies) { (3..6).map { |i| instance_double(Vacancy, id: i) } }
+
+  let(:control) { double("Control", class: "FooStrategy", vacancies: control_vacancies, total_count: 66) }
+  let(:experiment) { double("Experiment", class: "BarStrategy", vacancies: experiment_vacancies, total_count: 99) }
+
+  let(:search_criteria) { double("Criteria", to_json: "{\"foo\": \"bar\"}") }
+  let(:use_experiment) { false }
+
+  describe "#vacancies" do
+    it "delegates to the control strategy by default" do
+      expect(subject.vacancies).to eq(control.vacancies)
+    end
+
+    context "when use_experiment is given" do
+      let(:use_experiment) { true }
+
+      it "delegates to the experiment strategy" do
+        expect(subject.vacancies).to eq(experiment.vacancies)
+      end
+    end
+  end
+
+  describe "#total_count" do
+    it "delegates to the control strategy by default" do
+      expect(subject.total_count).to eq(control.total_count)
+    end
+
+    context "when use_experiment is given" do
+      let(:use_experiment) { true }
+
+      it "delegates to the experiment strategy" do
+        expect(subject.total_count).to eq(experiment.total_count)
+      end
+    end
+  end
+
+  it "sends an event with the data" do
+    expect { subject }.to have_triggered_event(:search_experiment_performed)
+      .with_data(
+        control_strategy: "FooStrategy",
+        experiment_strategy: "BarStrategy",
+        search_criteria: "{\"foo\": \"bar\"}",
+        control_result_count: 66,
+        experiment_result_count: 99,
+        matches: 3,
+        mismatches_from_control: 2,
+        mismatches_from_experiment: 1,
+      )
+  end
+
+  context "when the experiment strategy raises an error" do
+    let(:error) { RuntimeError.new("Oops lol") }
+
+    before do
+      expect(experiment).to receive(:vacancies).and_raise(error)
+    end
+
+    it "swallows errors and reports them to Rollbar" do
+      expect(Rollbar).to receive(:error).with(error)
+
+      expect { subject }.not_to raise_error
+    end
+  end
+end

--- a/spec/services/search/strategies/pg_search_spec.rb
+++ b/spec/services/search/strategies/pg_search_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe Search::Strategies::PgSearch do
+  describe "#vacancies" do
+    pending
+  end
+
+  describe "#total_count" do
+    pending
+  end
+end

--- a/spec/support/search_helper.rb
+++ b/spec/support/search_helper.rb
@@ -2,5 +2,9 @@ module SearchHelper
   def mock_algolia_search(result, count, query, arguments_to_algolia)
     allow(result).to receive(:raw_answer).and_return({ "page" => 1, "nbPages" => 1, "hitsPerPage" => 10, "nbHits" => count })
     allow(Vacancy).to receive(:search).with(query, arguments_to_algolia).and_return(result)
+
+    # Workarounds for excessive mocking in specs
+    allow(result).to receive(:map).and_return([])
+    allow(result).to receive(:none?).and_return(count.zero?)
   end
 end


### PR DESCRIPTION
The very first step towards switching out Algolia for Postgres full
text search, this adds an `Experiment` search strategy that allows
us to collect some search performance data.

- Add `Search::Strategies::Experiment` to allow us to run both a
  control and an experimental strategy on every search, and report
  back the total result counts and any differences in results
- Add `Search::Strategies::PgSearch` as a placeholder for the Postgres
  search strategy that we are about to build (always returns no search
  results for now)
- Add `pg_search` param to `VacanciesController#index` to allow us to
  use the `PgSearch` strategy on demand

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2756