### PR TITLE
Upgrade postgres from tier small-11 to small-12

### DIFF
--- a/terraform/app/modules/paas/main.tf
+++ b/terraform/app/modules/paas/main.tf
@@ -2,7 +2,7 @@ resource "cloudfoundry_service_instance" "postgres_instance" {
   name         = local.postgres_service_name
   space        = data.cloudfoundry_space.space.id
   service_plan = data.cloudfoundry_service.postgres.service_plans[var.postgres_service_plan]
-  json_params  = "{\"enable_extensions\": [\"pgcrypto\", \"fuzzystrmatch\", \"plpgsql\"]}"
+  json_params  = "{\"enable_extensions\": [\"pgcrypto\", \"fuzzystrmatch\", \"plpgsql\", \"pg_trgm\", \"postgis\"]}"
 }
 
 resource "cloudfoundry_service_instance" "redis_cache_instance" {

--- a/terraform/workspace-variables/staging.tfvars
+++ b/terraform/workspace-variables/staging.tfvars
@@ -26,7 +26,7 @@ documents_s3_bucket_force_destroy = false
 # Gov.UK PaaS
 paas_space_name                        = "teaching-vacancies-staging"
 paas_papertrail_service_binding_enable = true
-paas_postgres_service_plan             = "small-11"
+paas_postgres_service_plan             = "small-12"
 paas_redis_cache_service_plan          = "micro-5_x"
 paas_redis_queue_service_plan          = "micro-5_x"
 paas_app_start_timeout                 = "180"


### PR DESCRIPTION
The upgrade is necessary to levearage features not currently available
in Postgres 11

## Jira ticket URL

- Just add the ticket number to the end:

https://dfedigital.atlassian.net/browse/TEVA-2799

## Changes in this PR:

The upgrade is necessary to levearage features not currently available
in Postgres 11