### PR TITLE
[TEVA-2720] Validate job applications before submitting them

### DIFF
--- a/app/components/review_component/review_component.scss
+++ b/app/components/review_component/review_component.scss
@@ -98,5 +98,4 @@
 
 .action-required-tag {
   @extend .notification-tag;
-  background-color: govuk-colour('red');
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::Base
 
   after_action :trigger_page_visited_event, unless: :request_is_healthcheck?
 
-  helper_method :cookies_preference_set?, :referred_from_jobs_path?, :utm_parameters, :current_variant?
+  helper_method :cookies_preference_set?, :referred_from_jobs_path?, :user_type, :utm_parameters, :current_variant?
 
   include Publishers::AuthenticationConcerns
   include DeviseFlashConcerns
@@ -29,6 +29,14 @@ class ApplicationController < ActionController::Base
       format.html { render "errors/not_found", status: :not_found }
       format.json { render json: { error: "Resource not found" }, status: :not_found }
       format.all { render status: :not_found, body: nil }
+    end
+  end
+
+  def user_type
+    if current_jobseeker.present?
+      :jobseeker
+    elsif current_publisher.present?
+      :publisher
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,9 +35,9 @@ class ApplicationController < ActionController::Base
   private
 
   def user_type
-    if current_jobseeker.present?
+    if jobseeker_signed_in?
       :jobseeker
-    elsif current_publisher.present?
+    elsif publisher_signed_in?
       :publisher
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,6 +32,8 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  private
+
   def user_type
     if current_jobseeker.present?
       :jobseeker
@@ -39,8 +41,6 @@ class ApplicationController < ActionController::Base
       :publisher
     end
   end
-
-  private
 
   def cookies_preference_set?
     cookies["consented-to-cookies"].present?

--- a/app/controllers/jobseekers/job_applications_controller.rb
+++ b/app/controllers/jobseekers/job_applications_controller.rb
@@ -84,13 +84,12 @@ class Jobseekers::JobApplicationsController < Jobseekers::BaseController
   def completed_steps_valid?
     # Check that all completed steps are valid, in case we have changed the validations since the step was completed.
     # NB: Only validates top-level step forms. Does not validate individual qualifications, employments, or references.
-    job_application.completed_steps.all? do |step|
-      step_valid?("jobseekers/job_application/#{step}_form".camelize.constantize)
-    end
+    job_application.completed_steps.all? { |step| step_valid?(step) }
   end
 
-  def step_valid?(step_form)
-    form = step_form.new(job_application.slice(*send("#{step_form.to_s.underscore.split('/').last.split('_form').first}_fields")))
+  def step_valid?(step)
+    step_form = "jobseekers/job_application/#{step}_form".camelize.constantize
+    form = step_form.new(job_application.slice(*send("#{step}_fields")))
 
     form.valid?.tap do
       job_application.errors.merge!(form.errors)

--- a/app/controllers/publishers/vacancies/base_controller.rb
+++ b/app/controllers/publishers/vacancies/base_controller.rb
@@ -27,17 +27,15 @@ class Publishers::Vacancies::BaseController < Publishers::BaseController
 
   def all_steps_valid?
     steps_config.except(:job_location, :schools, :supporting_documents, :documents, :review).keys.all? do |step|
-      step_valid?("publishers/job_listing/#{step}_form".camelize.constantize)
+      step_valid?(step)
     end
   end
 
-  def step_valid?(step_form)
+  def step_valid?(step)
+    step_form = "publishers/job_listing/#{step}_form".camelize.constantize
+
     # We need to merge in the current organisation otherwise the form will always be invalid for local authority users
-    form = step_form.new(
-      vacancy.slice(*send("#{step_form.to_s.underscore.split('/').last.split('_form').first}_fields"))
-             .merge(current_organisation: current_organisation),
-      vacancy,
-    )
+    form = step_form.new(vacancy.slice(*send("#{step}_fields")).merge(current_organisation: current_organisation), vacancy)
 
     form.valid?.tap do
       vacancy.errors.merge!(form.errors)

--- a/app/controllers/publishers/vacancies/base_controller.rb
+++ b/app/controllers/publishers/vacancies/base_controller.rb
@@ -81,10 +81,6 @@ class Publishers::Vacancies::BaseController < Publishers::BaseController
     session[:current_step] = nil
   end
 
-  def review_path_with_errors(vacancy)
-    organisation_job_review_path(job_id: vacancy.id, anchor: "errors", source: "publish")
-  end
-
   def update_google_index(job)
     return if DisableExpensiveJobs.enabled?
 

--- a/app/controllers/publishers/vacancies/base_controller.rb
+++ b/app/controllers/publishers/vacancies/base_controller.rb
@@ -26,11 +26,9 @@ class Publishers::Vacancies::BaseController < Publishers::BaseController
   end
 
   def all_steps_valid?
-    step_valid?(Publishers::JobListing::JobDetailsForm) &&
-      step_valid?(Publishers::JobListing::PayPackageForm) &&
-      step_valid?(Publishers::JobListing::ImportantDatesForm) &&
-      step_valid?(Publishers::JobListing::ApplyingForTheJobForm) &&
-      step_valid?(Publishers::JobListing::JobSummaryForm)
+    steps_config.except(:job_location, :schools, :supporting_documents, :documents, :review).keys.all? do |step|
+      step_valid?("publishers/job_listing/#{step}_form".camelize.constantize)
+    end
   end
 
   def step_valid?(step_form)

--- a/app/controllers/publishers/vacancies/publish_controller.rb
+++ b/app/controllers/publishers/vacancies/publish_controller.rb
@@ -7,7 +7,8 @@ class Publishers::Vacancies::PublishController < Publishers::Vacancies::BaseCont
       reset_session_vacancy!
       redirect_to organisation_job_summary_path(vacancy.id)
     else
-      redirect_to review_path_with_errors(vacancy), warning: t("errors.jobs.unable_to_publish")
+      redirect_to organisation_job_review_path(job_id: vacancy.id, anchor: "errors", source: "publish"),
+                  warning: t("errors.jobs.unable_to_publish")
     end
   end
 end

--- a/app/controllers/publishers/vacancies_controller.rb
+++ b/app/controllers/publishers/vacancies_controller.rb
@@ -4,6 +4,8 @@ class Publishers::VacanciesController < Publishers::Vacancies::BaseController
   before_action :redirect_if_published, only: %i[preview review]
   before_action :devise_job_alert_search_criteria, only: %i[show preview]
 
+  helper_method :applying_for_the_job_fields, :important_dates_fields, :job_details_fields, :job_location_fields, :job_summary_fields, :pay_package_fields, :schools_fields
+
   def show
     return redirect_to organisation_job_review_path(vacancy.id), notice: t(".notice") unless vacancy.published?
 

--- a/app/controllers/publishers/vacancies_controller.rb
+++ b/app/controllers/publishers/vacancies_controller.rb
@@ -71,12 +71,12 @@ class Publishers::VacanciesController < Publishers::Vacancies::BaseController
   end
 
   def redirect_to_incomplete_step
-    return redirect_to organisation_job_build_path(vacancy.id, :job_details) unless step_valid?(Publishers::JobListing::JobDetailsForm)
-    return redirect_to organisation_job_build_path(vacancy.id, :pay_package) unless step_valid?(Publishers::JobListing::PayPackageForm)
-    return redirect_to organisation_job_build_path(vacancy.id, :important_dates) unless step_valid?(Publishers::JobListing::ImportantDatesForm)
+    return redirect_to organisation_job_build_path(vacancy.id, :job_details) unless step_valid?(:job_details)
+    return redirect_to organisation_job_build_path(vacancy.id, :pay_package) unless step_valid?(:pay_package)
+    return redirect_to organisation_job_build_path(vacancy.id, :important_dates) unless step_valid?(:important_dates)
     return redirect_to organisation_job_build_path(vacancy.id, :documents) unless vacancy.completed_step >= steps_config[:documents][:number]
-    return redirect_to organisation_job_build_path(vacancy.id, :applying_for_the_job) unless step_valid?(Publishers::JobListing::ApplyingForTheJobForm)
-    return redirect_to organisation_job_build_path(vacancy.id, :job_summary) unless step_valid?(Publishers::JobListing::JobSummaryForm)
+    return redirect_to organisation_job_build_path(vacancy.id, :applying_for_the_job) unless step_valid?(:applying_for_the_job)
+    return redirect_to organisation_job_build_path(vacancy.id, :job_summary) unless step_valid?(:job_summary)
   end
 
   def set_completed_step
@@ -85,7 +85,7 @@ class Publishers::VacanciesController < Publishers::Vacancies::BaseController
 
   def validate_all_steps
     steps_config.except(:job_location, :schools, :supporting_documents, :documents, :review).each_key do |step|
-      step_valid?("publishers/job_listing/#{step}_form".camelize.constantize)
+      step_valid?(step)
     end
   end
 end

--- a/app/controllers/publishers/vacancies_controller.rb
+++ b/app/controllers/publishers/vacancies_controller.rb
@@ -30,7 +30,6 @@ class Publishers::VacanciesController < Publishers::Vacancies::BaseController
     if all_steps_valid?
       session[:current_step] = :review
       set_completed_step
-      validate_all_steps
     else
       session[:current_step] = :edit_incomplete
       redirect_to_incomplete_step
@@ -83,10 +82,8 @@ class Publishers::VacanciesController < Publishers::Vacancies::BaseController
   end
 
   def validate_all_steps
-    step_valid?(Publishers::JobListing::JobDetailsForm)
-    step_valid?(Publishers::JobListing::PayPackageForm)
-    step_valid?(Publishers::JobListing::ImportantDatesForm)
-    step_valid?(Publishers::JobListing::ApplyingForTheJobForm)
-    step_valid?(Publishers::JobListing::JobSummaryForm)
+    steps_config.except(:job_location, :schools, :supporting_documents, :documents, :review).each_key do |step|
+      step_valid?("publishers/job_listing/#{step}_form".camelize.constantize)
+    end
   end
 end

--- a/app/form_models/jobseekers/job_application/review_form.rb
+++ b/app/form_models/jobseekers/job_application/review_form.rb
@@ -3,11 +3,12 @@ class Jobseekers::JobApplication::ReviewForm
 
   attr_accessor :confirm_data_accurate, :confirm_data_usage, :completed_steps
 
-  validates :confirm_data_accurate, acceptance: true
-  validates :confirm_data_usage, acceptance: true
-  validate :all_steps_completed
+  validates_acceptance_of :confirm_data_accurate, :confirm_data_usage,
+                          acceptance: true,
+                          if: :all_steps_completed?
+  validate :all_steps_completed?
 
-  def all_steps_completed
+  def all_steps_completed?
     JobApplication.completed_steps.each_key do |step|
       next if step.in?(completed_steps)
 

--- a/app/helpers/job_application_helper.rb
+++ b/app/helpers/job_application_helper.rb
@@ -1,4 +1,6 @@
 module JobApplicationHelper
+  include Jobseekers::Wizardable
+
   PUBLISHER_STATUS_MAPPINGS = {
     submitted: "unread",
     reviewed: "reviewed",
@@ -28,32 +30,33 @@ module JobApplicationHelper
   def job_application_qualified_teacher_status_info(job_application)
     case job_application.qualified_teacher_status
     when "yes"
-      tag.div("Yes, awarded in #{job_application.qualified_teacher_status_year}", class: "govuk-body")
+      safe_join([tag.span("Yes, awarded in ", class: "govuk-body", id: "qualified_teacher_status"),
+                 tag.span(job_application.qualified_teacher_status_year, class: "govuk-body", id: "qualified_teacher_status_year")])
     when "no"
-      safe_join([tag.div("No", class: "govuk-body"),
-                 tag.p(job_application.qualified_teacher_status_details, class: "govuk-body")])
+      safe_join([tag.div("No", class: "govuk-body", id: "qualified_teacher_status"),
+                 tag.p(job_application.qualified_teacher_status_details, class: "govuk-body", id: "qualified_teacher_status_details")])
     when "on_track"
-      tag.div("I'm on track to receive my QTS", class: "govuk-body")
+      tag.div("I'm on track to receive my QTS", class: "govuk-body", id: "qualified_teacher_status")
     end
   end
 
   def job_application_support_needed_info(job_application)
     case job_application.support_needed
     when "yes"
-      safe_join([tag.div("Yes", class: "govuk-body"),
-                 tag.p(job_application.support_needed_details, class: "govuk-body")])
+      safe_join([tag.div("Yes", class: "govuk-body", id: "support_needed"),
+                 tag.p(job_application.support_needed_details, class: "govuk-body", id: "support_needed_details")])
     when "no"
-      tag.div("No", class: "govuk-body")
+      tag.div("No", class: "govuk-body", id: "support_needed")
     end
   end
 
   def job_application_close_relationships_info(job_application)
     case job_application.close_relationships
     when "yes"
-      safe_join([tag.div("Yes", class: "govuk-body"),
-                 tag.p(job_application.close_relationships_details, class: "govuk-body")])
+      safe_join([tag.div("Yes", class: "govuk-body", id: "close_relationships"),
+                 tag.p(job_application.close_relationships_details, class: "govuk-body", id: "close_relationships_details")])
     when "no"
-      tag.div("No", class: "govuk-body")
+      tag.div("No", class: "govuk-body", id: "close_relationships")
     end
   end
 
@@ -80,10 +83,12 @@ module JobApplicationHelper
   end
 
   def job_application_review_section_tag(job_application, step)
-    tag_attributes = if step.to_s.in?(job_application.completed_steps)
-                       { text: "complete" }
+    tag_attributes = if send("#{step}_fields".to_sym).any? { |field| field.in?(job_application.errors.messages.keys) }
+                       { text: t("messages.jobs.action_required.label"), colour: "orange" }
                      elsif step.to_s.in?(job_application.in_progress_steps)
                        { text: "in progress", colour: "yellow" }
+                     elsif step.to_s.in?(job_application.completed_steps)
+                       { text: "complete" }
                      else
                        { text: "not started", colour: "red" }
                      end

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -49,8 +49,8 @@ class JobApplication < ApplicationRecord
   end
 
   def email
-    # This method and its test can be removed once there are no job applications remaining which were begun before we asked
-    # jobseekers for their emails as part of the application, or after https://dfedigital.atlassian.net/browse/TEVA-2720 is done.
+    # This method and its test can be removed once there are no job applications remaining which were submitted before
+    # we asked jobseekers for their emails as part of the application.
     email_address.presence || jobseeker.email
   end
 

--- a/app/views/jobseekers/job_applications/review.html.slim
+++ b/app/views/jobseekers/job_applications/review.html.slim
@@ -14,6 +14,9 @@
       = govuk_notification_banner title: t("banners.important") do
         p.govuk-body = t(".deadline_passed")
 
+    - unless review_form.errors.any?
+      = render "shared/error_messages", errors: @job_application.errors
+
     = form_for review_form, url: jobseekers_job_application_submit_path(job_application), method: :post do |f|
       = f.govuk_error_summary
 

--- a/app/views/jobseekers/job_applications/review/_declarations.html.slim
+++ b/app/views/jobseekers/job_applications/review/_declarations.html.slim
@@ -11,4 +11,5 @@
                      value: job_application_close_relationships_info(job_application)
       - summary.slot :row,
                      key: t("helpers.legend.jobseekers_job_application_declarations_form.right_to_work_in_uk"),
-                     value: job_application.right_to_work_in_uk.humanize
+                     value: job_application.right_to_work_in_uk.humanize,
+                     html_attributes: { id: "right_to_work_in_uk" }

--- a/app/views/jobseekers/job_applications/review/_employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/review/_employment_history.html.slim
@@ -1,7 +1,8 @@
 = render ReviewComponent.new id: "jobseekers-job-application-review-form-employment-history-field-error" do |review|
   - review.heading title: t("jobseekers.job_applications.build.employment_history.heading"),
                     text: job_application_review_edit_section_text(job_application, :employment_history),
-                    href: jobseekers_job_application_build_path(job_application, :employment_history) do
+                    href: jobseekers_job_application_build_path(job_application, :employment_history),
+                    html_attributes: { id: "gaps_in_employment" } do
       = job_application_review_section_tag(job_application, :employment_history)
 
   - review.body do

--- a/app/views/jobseekers/job_applications/review/_equal_opportunities.html.slim
+++ b/app/views/jobseekers/job_applications/review/_equal_opportunities.html.slim
@@ -8,23 +8,25 @@
     = govuk_summary_list do |summary|
       - summary.slot :row,
                      key: t("helpers.legend.jobseekers_job_application_equal_opportunities_form.disability"),
-                     value: job_application.disability.humanize
+                     value: job_application.disability.humanize,
+                     html_attributes: { id: "disability" }
       - summary.slot :row,
                      key: t("helpers.legend.jobseekers_job_application_equal_opportunities_form.age"),
-                     value: job_application.age.humanize
+                     value: job_application.age.humanize,
+                     html_attributes: { id: "age" }
       - summary.slot :row,
                      key: t("helpers.legend.jobseekers_job_application_equal_opportunities_form.gender"),
-                     value: safe_join([tag.div(job_application.gender.humanize, class: "govuk-body"),
-                                       tag.div(job_application.gender_description, class: "govuk-body")])
+                     value: safe_join([tag.div(job_application.gender.humanize, class: "govuk-body", id: "gender"),
+                                       tag.div(job_application.gender_description, class: "govuk-body", id: "gender_description")])
       - summary.slot :row,
                      key: t("helpers.legend.jobseekers_job_application_equal_opportunities_form.orientation"),
-                     value: safe_join([tag.div(job_application.orientation.humanize, class: "govuk-body"),
-                                       tag.div(job_application.orientation_description, class: "govuk-body")])
+                     value: safe_join([tag.div(job_application.orientation.humanize, class: "govuk-body", id: "orientation"),
+                                       tag.div(job_application.orientation_description, class: "govuk-body", id: "orientation_description")])
       - summary.slot :row,
                      key: t("helpers.legend.jobseekers_job_application_equal_opportunities_form.ethnicity"),
-                     value: safe_join([tag.div(job_application.ethnicity.humanize, class: "govuk-body"),
-                                       tag.div(job_application.ethnicity_description, class: "govuk-body")])
+                     value: safe_join([tag.div(job_application.ethnicity.humanize, class: "govuk-body", id: "ethnicity"),
+                                       tag.div(job_application.ethnicity_description, class: "govuk-body", id: "ethnicity_description")])
       - summary.slot :row,
                      key: t("helpers.legend.jobseekers_job_application_equal_opportunities_form.religion"),
-                     value: safe_join([tag.div(job_application.religion.humanize, class: "govuk-body"),
-                                       tag.div(job_application.religion_description, class: "govuk-body")])
+                     value: safe_join([tag.div(job_application.religion.humanize, class: "govuk-body", id: "religion"),
+                                       tag.div(job_application.religion_description, class: "govuk-body", id: "religion_description")])

--- a/app/views/jobseekers/job_applications/review/_personal_details.html.slim
+++ b/app/views/jobseekers/job_applications/review/_personal_details.html.slim
@@ -8,28 +8,35 @@
     = govuk_summary_list do |summary|
       - summary.slot :row,
                       key: t("helpers.label.jobseekers_job_application_personal_details_form.first_name"),
-                      value: job_application.first_name
+                      value: job_application.first_name,
+                      html_attributes: { id: "first_name" }
       - summary.slot :row,
                       key: t("helpers.label.jobseekers_job_application_personal_details_form.last_name"),
-                      value: job_application.last_name
+                      value: job_application.last_name,
+                      html_attributes: { id: "last_name" }
       - summary.slot :row,
                       key: t("helpers.label.jobseekers_job_application_personal_details_form.previous_names"),
-                      value: job_application.previous_names.presence || t("jobseekers.job_applications.not_defined")
+                      value: job_application.previous_names.presence || t("jobseekers.job_applications.not_defined"),
+                      html_attributes: { id: "previous_names" }
       - summary.slot :row,
                       key: t("helpers.legend.jobseekers_job_application_personal_details_form.your_address"),
-                      value: safe_join([tag.div(job_application.street_address, class: "govuk-body"),
-                                        tag.div(job_application.city, class: "govuk-body"),
-                                        tag.div(job_application.postcode, class: "govuk-body"),
-                                        tag.div(job_application.country, class: "govuk-body")])
+                      value: safe_join([tag.div(job_application.street_address, class: "govuk-body", id: "street_address"),
+                                        tag.div(job_application.city, class: "govuk-body", id: "city"),
+                                        tag.div(job_application.postcode, class: "govuk-body", id: "postcode"),
+                                        tag.div(job_application.country, class: "govuk-body", id: "country")])
       - summary.slot :row,
                       key: t("helpers.label.jobseekers_job_application_personal_details_form.phone_number"),
-                      value: job_application.phone_number
+                      value: job_application.phone_number,
+                      html_attributes: { id: "phone_number" }
       - summary.slot :row,
                       key: t("helpers.label.jobseekers_job_application_personal_details_form.email_address"),
-                      value: job_application.email
+                      value: job_application.email,
+                      html_attributes: { id: "email_address" }
       - summary.slot :row,
                       key: t("helpers.label.jobseekers_job_application_personal_details_form.teacher_reference_number"),
-                      value: job_application.teacher_reference_number.presence || t("jobseekers.job_applications.not_defined")
+                      value: job_application.teacher_reference_number.presence || t("jobseekers.job_applications.not_defined"),
+                      html_attributes: { id: "teacher_reference_number" }
       - summary.slot :row,
                       key: t("helpers.label.jobseekers_job_application_personal_details_form.national_insurance_number"),
-                      value: job_application.national_insurance_number.presence || t("jobseekers.job_applications.not_defined")
+                      value: job_application.national_insurance_number.presence || t("jobseekers.job_applications.not_defined"),
+                      html_attributes: { id: "national_insurance_number" }

--- a/app/views/jobseekers/job_applications/review/_personal_statement.html.slim
+++ b/app/views/jobseekers/job_applications/review/_personal_statement.html.slim
@@ -1,7 +1,8 @@
 = render ReviewComponent.new id: "jobseekers-job-application-review-form-personal-statement-field-error" do |review|
   - review.heading title: t("jobseekers.job_applications.build.personal_statement.heading"),
                    text: job_application_review_edit_section_text(job_application, :personal_statement),
-                   href: jobseekers_job_application_build_path(job_application, :personal_statement) do
+                   href: jobseekers_job_application_build_path(job_application, :personal_statement),
+                   html_attributes: { id: "personal_statement" } do
       = job_application_review_section_tag(job_application, :personal_statement)
 
   - review.body do

--- a/app/views/jobseekers/job_applications/review/_professional_status.html.slim
+++ b/app/views/jobseekers/job_applications/review/_professional_status.html.slim
@@ -11,4 +11,5 @@
                       value: job_application_qualified_teacher_status_info(job_application)
       - summary.slot :row,
                       key: t("helpers.legend.jobseekers_job_application_professional_status_form.statutory_induction_complete"),
-                      value: job_application.statutory_induction_complete.humanize
+                      value: job_application.statutory_induction_complete.humanize,
+                      html_attributes: { id: "statutory_induction_complete" }

--- a/app/views/publishers/vacancies/_error_tag.html.slim
+++ b/app/views/publishers/vacancies/_error_tag.html.slim
@@ -1,5 +1,5 @@
 - attributes.each do |attribute|
   - if @vacancy.errors.messages.key?(attribute)
-    strong.govuk-tag.action-required-tag class="action-required--#{section}"
+    strong.govuk-tag.action-required-tag
       = t("messages.jobs.action_required.label")
     - break

--- a/app/views/publishers/vacancies/_error_tag.html.slim
+++ b/app/views/publishers/vacancies/_error_tag.html.slim
@@ -1,5 +1,0 @@
-- attributes.each do |attribute|
-  - if @vacancy.errors.messages.key?(attribute)
-    strong.govuk-tag.action-required-tag
-      = t("messages.jobs.action_required.label")
-    - break

--- a/app/views/publishers/vacancies/_error_tag.html.slim
+++ b/app/views/publishers/vacancies/_error_tag.html.slim
@@ -1,0 +1,4 @@
+- attributes.each do |attribute|
+  - if @vacancy.errors.messages.key?(attribute)
+    strong.govuk-tag.govuk-tag--red.action-required-tag = t("messages.jobs.action_required.label")
+    - break

--- a/app/views/publishers/vacancies/edit.html.slim
+++ b/app/views/publishers/vacancies/edit.html.slim
@@ -8,7 +8,7 @@
   .vacancy.govuk-grid-row
     .govuk-grid-column-two-thirds
       h2.govuk-heading-l = t("jobs.review_heading")
-      = render "publishers/vacancies/error_messages", errors: @vacancy.errors
+      = render "shared/error_messages", errors: @vacancy.errors
 
       ol.app-task-list
         - if current_organisation.school_group?

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_applying_for_the_job.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_applying_for_the_job.html.slim
@@ -1,4 +1,4 @@
-= render "publishers/vacancies/error_tag", attributes: %i[contact_email contact_number school_visits how_to_apply application_link], section: "applying_for_the_job"
+= render "publishers/vacancies/error_tag", attributes: %i[contact_email contact_number school_visits how_to_apply application_link]
 
 = render ReviewComponent.new id: "applying_for_the_job" do |review|
   - review.heading title: t("jobs.applying_for_the_job"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_applying_for_the_job.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_applying_for_the_job.html.slim
@@ -1,4 +1,4 @@
-= render "shared/error_tag", applying_for_the_job_fields, model: @vacancy
+= render "publishers/vacancies/error_tag", attributes: applying_for_the_job_fields
 
 = render ReviewComponent.new id: "applying_for_the_job" do |review|
   - review.heading title: t("jobs.applying_for_the_job"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_applying_for_the_job.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_applying_for_the_job.html.slim
@@ -9,26 +9,32 @@
     = govuk_summary_list do |component|
       - component.slot(:row,
         key: t("jobs.enable_job_applications"),
-        value: @vacancy.enable_job_applications? ? "Yes" : "No")
+        value: @vacancy.enable_job_applications? ? "Yes" : "No",
+        html_attributes: { id: "enable_job_applications" })
 
       - if @vacancy.enable_job_applications?
         - component.slot(:row,
           key: t("jobs.personal_statement_guidance"),
-          value: @vacancy.personal_statement_guidance.presence || t("jobs.not_defined"))
+          value: @vacancy.personal_statement_guidance.presence || t("jobs.not_defined"),
+          html_attributes: { id: "personal_statement_guidance" })
 
       - elsif @vacancy.enable_job_applications == false # as opposed to nil
         - component.slot(:row,
           key: t("jobs.application_link"),
-          value: @vacancy.application_link.present? ? open_in_new_tab_link_to(@vacancy.application_link, @vacancy.application_link, "aria-label": t("jobs.aria_labels.apply_link")) : t("jobs.not_defined"))
+          value: @vacancy.application_link.present? ? open_in_new_tab_link_to(@vacancy.application_link, @vacancy.application_link, "aria-label": t("jobs.aria_labels.apply_link")) : t("jobs.not_defined"),
+          html_attributes: { id: "application_link" })
 
       - component.slot(:row,
         key: t("jobs.contact_email"),
-        value: govuk_mail_to("Job contact email", @vacancy.contact_email, "aria-label": t("jobs.aria_labels.contact_email_link", email: @vacancy.contact_email)))
+        value: govuk_mail_to("Job contact email", @vacancy.contact_email, "aria-label": t("jobs.aria_labels.contact_email_link", email: @vacancy.contact_email)),
+        html_attributes: { id: "contact_email" })
 
       - component.slot(:row,
         key: t("jobs.contact_number"),
-        value: @vacancy.contact_number.present? ? govuk_link_to(@vacancy.contact_number, "tel:#{@vacancy.contact_number}") : t("jobs.not_defined"))
+        value: @vacancy.contact_number.present? ? govuk_link_to(@vacancy.contact_number, "tel:#{@vacancy.contact_number}") : t("jobs.not_defined"),
+        html_attributes: { id: "contact_number" })
 
       - component.slot(:row,
         key: t("jobs.#{school_or_trust_visits(@vacancy.parent_organisation)}"),
-        value: @vacancy.school_visits.presence || t("jobs.not_defined"))
+        value: @vacancy.school_visits.presence || t("jobs.not_defined"),
+        html_attributes: { id: "school_visits" })

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_applying_for_the_job.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_applying_for_the_job.html.slim
@@ -1,4 +1,4 @@
-= render "shared/error_tag", attributes: %i[contact_email contact_number school_visits how_to_apply application_link], model: @vacancy
+= render "shared/error_tag", applying_for_the_job_fields, model: @vacancy
 
 = render ReviewComponent.new id: "applying_for_the_job" do |review|
   - review.heading title: t("jobs.applying_for_the_job"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_applying_for_the_job.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_applying_for_the_job.html.slim
@@ -1,4 +1,4 @@
-= render "publishers/vacancies/error_tag", attributes: %i[contact_email contact_number school_visits how_to_apply application_link]
+= render "shared/error_tag", attributes: %i[contact_email contact_number school_visits how_to_apply application_link], model: @vacancy
 
 = render ReviewComponent.new id: "applying_for_the_job" do |review|
   - review.heading title: t("jobs.applying_for_the_job"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_important_dates.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_important_dates.html.slim
@@ -1,4 +1,4 @@
-= render "shared/error_tag", attributes: important_dates_fields, model: @vacancy
+= render "publishers/vacancies/error_tag", attributes: important_dates_fields
 
 #expiry_time
 = render ReviewComponent.new id: "important_dates" do |review|

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_important_dates.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_important_dates.html.slim
@@ -1,4 +1,4 @@
-= render "publishers/vacancies/error_tag", attributes: %i[publish_on expires_at starts_on], section: "important_dates"
+= render "publishers/vacancies/error_tag", attributes: %i[publish_on expires_at starts_on]
 
 #expiry_time
 = render ReviewComponent.new id: "important_dates" do |review|

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_important_dates.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_important_dates.html.slim
@@ -1,4 +1,4 @@
-= render "shared/error_tag", attributes: %i[publish_on expires_at starts_on], model: @vacancy
+= render "shared/error_tag", attributes: important_dates_fields, model: @vacancy
 
 #expiry_time
 = render ReviewComponent.new id: "important_dates" do |review|

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_important_dates.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_important_dates.html.slim
@@ -1,4 +1,4 @@
-= render "publishers/vacancies/error_tag", attributes: %i[publish_on expires_at starts_on]
+= render "shared/error_tag", attributes: %i[publish_on expires_at starts_on], model: @vacancy
 
 #expiry_time
 = render ReviewComponent.new id: "important_dates" do |review|

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_important_dates.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_important_dates.html.slim
@@ -10,12 +10,15 @@
     = govuk_summary_list do |component|
       - component.slot(:row,
         key: t("jobs.publication_date"),
-        value: format_date(@vacancy.publish_on))
+        value: format_date(@vacancy.publish_on),
+        html_attributes: { id: "publish_on" })
 
       - component.slot(:row,
         key: t("jobs.application_deadline"),
-        value: format_time_to_datetime_at(@vacancy.expires_at))
+        value: format_time_to_datetime_at(@vacancy.expires_at),
+        html_attributes: { id: "expires_at" })
 
       - component.slot(:row,
         key: t("jobs.starts_on"),
-        value: @vacancy.starts_asap? ? t("jobs.starts_asap") : format_date(@vacancy.starts_on))
+        value: @vacancy.starts_asap? ? t("jobs.starts_asap") : format_date(@vacancy.starts_on),
+        html_attributes: { id: "starts_on" })

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_details.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_details.html.slim
@@ -1,4 +1,4 @@
-= render "shared/error_tag", attributes: job_details_fields, model: @vacancy
+= render "publishers/vacancies/error_tag", attributes: job_details_fields
 
 = render ReviewComponent.new id: "job_details" do |review|
   - review.heading title: t("jobs.job_details"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_details.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_details.html.slim
@@ -1,4 +1,4 @@
-= render "publishers/vacancies/error_tag", attributes: %i[job_title job_roles suitable_for_nqt subjects working_patterns]
+= render "shared/error_tag", attributes: %i[job_title job_roles suitable_for_nqt subjects working_patterns], model: @vacancy
 
 = render ReviewComponent.new id: "job_details" do |review|
   - review.heading title: t("jobs.job_details"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_details.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_details.html.slim
@@ -1,4 +1,4 @@
-= render "publishers/vacancies/error_tag", attributes: %i[job_title job_roles suitable_for_nqt subjects working_patterns], section: "job_details"
+= render "publishers/vacancies/error_tag", attributes: %i[job_title job_roles suitable_for_nqt subjects working_patterns]
 
 = render ReviewComponent.new id: "job_details" do |review|
   - review.heading title: t("jobs.job_details"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_details.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_details.html.slim
@@ -1,4 +1,4 @@
-= render "shared/error_tag", attributes: %i[job_title job_roles suitable_for_nqt subjects working_patterns], model: @vacancy
+= render "shared/error_tag", attributes: job_details_fields, model: @vacancy
 
 = render ReviewComponent.new id: "job_details" do |review|
   - review.heading title: t("jobs.job_details"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_details.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_details.html.slim
@@ -9,24 +9,30 @@
     = govuk_summary_list do |component|
       - component.slot(:row,
         key: t("jobs.job_title"),
-        value: @vacancy.job_title)
+        value: @vacancy.job_title,
+        html_attributes: { id: "job_title" })
 
       - component.slot(:row,
         key: t("jobs.job_roles"),
-        value: @vacancy.show_job_roles.presence || t("jobs.not_defined"))
+        value: @vacancy.show_job_roles.presence || t("jobs.not_defined"),
+        html_attributes: { id: "job_roles" })
 
       - component.slot(:row,
         key: t("jobs.suitable_for_nqt"),
-        value: @vacancy.suitable_for_nqt&.capitalize)
+        value: @vacancy.suitable_for_nqt&.capitalize,
+        html_attributes: { id: "suitable_for_nqt" })
 
       - component.slot(:row,
         key: t("jobs.subjects"),
-        value: @vacancy.show_subjects.presence || t("jobs.not_defined"))
+        value: @vacancy.show_subjects.presence || t("jobs.not_defined"),
+        html_attributes: { id: "subjects" })
 
       - component.slot(:row,
         key: t("jobs.working_patterns"),
-        value: @vacancy.working_patterns)
+        value: @vacancy.working_patterns,
+        html_attributes: { id: "working_patterns" })
 
       - component.slot(:row,
         key: t("jobs.contract_type"),
-        value: @vacancy.contract_type_with_duration)
+        value: @vacancy.contract_type_with_duration,
+        html_attributes: { id: "contract_type" })

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_location.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_location.html.slim
@@ -1,4 +1,4 @@
-= render "publishers/vacancies/error_tag", attributes: %i[job_location organisation_id organisation_ids]
+= render "shared/error_tag", attributes: %i[job_location organisation_id organisation_ids], model: @vacancy
 
 = render ReviewComponent.new id: "job_location" do |review|
   - review.heading title: t("jobs.job_location"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_location.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_location.html.slim
@@ -1,4 +1,4 @@
-= render "shared/error_tag", attributes: %i[job_location organisation_id organisation_ids], model: @vacancy
+= render "shared/error_tag", attributes: (job_location_fields + schools_fields), model: @vacancy
 
 = render ReviewComponent.new id: "job_location" do |review|
   - review.heading title: t("jobs.job_location"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_location.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_location.html.slim
@@ -1,4 +1,4 @@
-= render "publishers/vacancies/error_tag", attributes: %i[job_location organisation_id organisation_ids], section: "job_location"
+= render "publishers/vacancies/error_tag", attributes: %i[job_location organisation_id organisation_ids]
 
 = render ReviewComponent.new id: "job_location" do |review|
   - review.heading title: t("jobs.job_location"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_location.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_location.html.slim
@@ -1,4 +1,4 @@
-= render "shared/error_tag", attributes: (job_location_fields + schools_fields), model: @vacancy
+= render "publishers/vacancies/error_tag", attributes: (job_location_fields + schools_fields)
 
 = render ReviewComponent.new id: "job_location" do |review|
   - review.heading title: t("jobs.job_location"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_summary.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_summary.html.slim
@@ -9,8 +9,10 @@
     = govuk_summary_list do |component|
       - component.slot(:row,
         key: t("jobs.job_advert"),
-        value: @vacancy.job_advert)
+        value: @vacancy.job_advert,
+        html_attributes: { id: "job_advert" })
 
       - component.slot(:row,
         key: t("jobs.about_school", school: vacancy_about_school_label_organisation(@vacancy)),
-        value: @vacancy.about_school)
+        value: @vacancy.about_school,
+        html_attributes: { id: "about_school" })

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_summary.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_summary.html.slim
@@ -1,4 +1,4 @@
-= render "publishers/vacancies/error_tag", attributes: %i[job_summary about_school], section: "job_summary"
+= render "publishers/vacancies/error_tag", attributes: %i[job_summary about_school]
 
 = render ReviewComponent.new id: "job_summary" do |review|
   - review.heading title: t("jobs.job_summary"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_summary.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_summary.html.slim
@@ -1,4 +1,4 @@
-= render "shared/error_tag", attributes: job_summary_fields, model: @vacancy
+= render "publishers/vacancies/error_tag", attributes: job_summary_fields
 
 = render ReviewComponent.new id: "job_summary" do |review|
   - review.heading title: t("jobs.job_summary"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_summary.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_summary.html.slim
@@ -1,4 +1,4 @@
-= render "publishers/vacancies/error_tag", attributes: %i[job_summary about_school]
+= render "shared/error_tag", attributes: %i[job_summary about_school], model: @vacancy
 
 = render ReviewComponent.new id: "job_summary" do |review|
   - review.heading title: t("jobs.job_summary"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_summary.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_summary.html.slim
@@ -1,4 +1,4 @@
-= render "shared/error_tag", attributes: %i[job_summary about_school], model: @vacancy
+= render "shared/error_tag", attributes: job_summary_fields, model: @vacancy
 
 = render ReviewComponent.new id: "job_summary" do |review|
   - review.heading title: t("jobs.job_summary"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_pay_package.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_pay_package.html.slim
@@ -1,4 +1,4 @@
-= render "shared/error_tag", attributes: %i[salary benefits], model: @vacancy
+= render "shared/error_tag", attributes: pay_package_fields, model: @vacancy
 
 = render ReviewComponent.new id: "pay_package" do |review|
   - review.heading title: t("jobs.pay_package"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_pay_package.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_pay_package.html.slim
@@ -9,8 +9,10 @@
     = govuk_summary_list do |component|
       - component.slot(:row,
         key: t("jobs.salary"),
-        value: @vacancy.salary)
+        value: @vacancy.salary,
+        html_attributes: { id: "salary" })
 
       - component.slot(:row,
         key: t("jobs.benefits"),
-        value: @vacancy.benefits.presence || t("jobs.not_defined"))
+        value: @vacancy.benefits.presence || t("jobs.not_defined"),
+        html_attributes: { id: "benefits" })

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_pay_package.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_pay_package.html.slim
@@ -1,4 +1,4 @@
-= render "shared/error_tag", attributes: pay_package_fields, model: @vacancy
+= render "publishers/vacancies/error_tag", attributes: pay_package_fields
 
 = render ReviewComponent.new id: "pay_package" do |review|
   - review.heading title: t("jobs.pay_package"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_pay_package.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_pay_package.html.slim
@@ -1,4 +1,4 @@
-= render "publishers/vacancies/error_tag", attributes: %i[salary benefits], section: "pay_package"
+= render "publishers/vacancies/error_tag", attributes: %i[salary benefits]
 
 = render ReviewComponent.new id: "pay_package" do |review|
   - review.heading title: t("jobs.pay_package"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_pay_package.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_pay_package.html.slim
@@ -1,4 +1,4 @@
-= render "publishers/vacancies/error_tag", attributes: %i[salary benefits]
+= render "shared/error_tag", attributes: %i[salary benefits], model: @vacancy
 
 = render ReviewComponent.new id: "pay_package" do |review|
   - review.heading title: t("jobs.pay_package"),

--- a/app/views/publishers/vacancies/review.html.slim
+++ b/app/views/publishers/vacancies/review.html.slim
@@ -8,7 +8,7 @@
   .vacancy.govuk-grid-row
     .govuk-grid-column-two-thirds
       h2.govuk-heading-l = t("jobs.review_heading")
-      = render "publishers/vacancies/error_messages", errors: @vacancy.errors
+      = render "shared/error_messages", errors: @vacancy.errors
 
       p.govuk-body-l
         - if @vacancy.publish_on.today?

--- a/app/views/shared/_error_messages.html.slim
+++ b/app/views/shared/_error_messages.html.slim
@@ -1,7 +1,8 @@
 - if errors.any?
   = govuk_notification_banner title: t("banners.warning"), classes: "govuk-notification-banner--warning" do |banner|
     - banner.add_heading text: t("messages.jobs.action_required.heading")
-    span class="govuk-!-margin-top-3" = t("messages.jobs.action_required.message")
+    t("messages.action_required.message.job_applications")
+    span class="govuk-!-margin-top-3" = t("messages.jobs.action_required.message.#{user_type.to_s}")
     div class="govuk-!-margin-top-3"
       - errors.each do |error|
         div class="govuk-!-margin-bottom-1"

--- a/app/views/shared/_error_messages.html.slim
+++ b/app/views/shared/_error_messages.html.slim
@@ -1,8 +1,7 @@
 - if errors.any?
   = govuk_notification_banner title: t("banners.warning"), classes: "govuk-notification-banner--warning" do |banner|
     - banner.add_heading text: t("messages.jobs.action_required.heading")
-    t("messages.action_required.message.job_applications")
-    span class="govuk-!-margin-top-3" = t("messages.jobs.action_required.message.#{user_type.to_s}")
+    span class="govuk-!-margin-top-3" = t("messages.jobs.action_required.message")[user_type]
     div class="govuk-!-margin-top-3"
       - errors.each do |error|
         div class="govuk-!-margin-bottom-1"

--- a/app/views/shared/_error_tag.html.slim
+++ b/app/views/shared/_error_tag.html.slim
@@ -1,0 +1,4 @@
+- attributes.each do |attribute|
+  - if model.errors.messages.key?(attribute)
+    strong.govuk-tag.action-required-tag = t("messages.jobs.action_required.label")
+    - break

--- a/app/views/shared/_error_tag.html.slim
+++ b/app/views/shared/_error_tag.html.slim
@@ -1,4 +1,0 @@
-- attributes.each do |attribute|
-  - if model.errors.messages.key?(attribute)
-    strong.govuk-tag.action-required-tag = t("messages.jobs.action_required.label")
-    - break

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -370,6 +370,8 @@ en:
               incomplete: Complete your personal statement
             professional_status:
               incomplete: Complete the questions about your professional status
+            qualifications:
+              incomplete: Complete your qualifications
             references:
               incomplete: Complete your references
         jobseekers/job_application/withdraw_form:

--- a/config/locales/notifications.yml
+++ b/config/locales/notifications.yml
@@ -7,7 +7,9 @@ en:
       action_required:
         heading: Action required
         label: action required
-        message: You must complete the required actions below in order to publish this listing.
+        message:
+          jobseekers: You must complete the required actions below in order to submit this application.
+          publishers: You must complete the required actions below in order to publish this listing.
       already_published: This job has already been published
       draft_saved_html: <span class="govuk-!-font-weight-bold">Draft saved</span> for %{job_title}
       feedback:

--- a/config/locales/notifications.yml
+++ b/config/locales/notifications.yml
@@ -7,7 +7,7 @@ en:
       action_required:
         heading: Action required
         label: action required
-        message: You must complete the required actions below in order to publish this listing
+        message: You must complete the required actions below in order to publish this listing.
       already_published: This job has already been published
       draft_saved_html: <span class="govuk-!-font-weight-bold">Draft saved</span> for %{job_title}
       feedback:

--- a/config/locales/notifications.yml
+++ b/config/locales/notifications.yml
@@ -8,8 +8,8 @@ en:
         heading: Action required
         label: action required
         message:
-          jobseekers: You must complete the required actions below in order to submit this application.
-          publishers: You must complete the required actions below in order to publish this listing.
+          jobseeker: You must complete the required actions below in order to submit this application.
+          publisher: You must complete the required actions below in order to publish this listing.
       already_published: This job has already been published
       draft_saved_html: <span class="govuk-!-font-weight-bold">Draft saved</span> for %{job_title}
       feedback:

--- a/spec/helpers/job_application_helper_spec.rb
+++ b/spec/helpers/job_application_helper_spec.rb
@@ -8,8 +8,10 @@ RSpec.describe JobApplicationHelper do
       let(:job_application) { build_stubbed(:job_application, qualified_teacher_status: "yes") }
 
       it "returns the correct info" do
-        expect(subject)
-          .to eq(tag.div("Yes, awarded in #{job_application.qualified_teacher_status_year}", class: "govuk-body"))
+        expect(subject).to eq(safe_join([
+          tag.span("Yes, awarded in ", class: "govuk-body", id: "qualified_teacher_status"),
+          tag.span(job_application.qualified_teacher_status_year, class: "govuk-body", id: "qualified_teacher_status_year"),
+        ]))
       end
     end
 
@@ -17,8 +19,10 @@ RSpec.describe JobApplicationHelper do
       let(:job_application) { build_stubbed(:job_application, qualified_teacher_status: "no") }
 
       it "returns the correct info" do
-        expect(subject).to eq(safe_join([tag.div("No", class: "govuk-body"),
-                                         tag.p(job_application.qualified_teacher_status_details, class: "govuk-body")]))
+        expect(subject).to eq(safe_join([
+          tag.div("No", class: "govuk-body", id: "qualified_teacher_status"),
+          tag.p(job_application.qualified_teacher_status_details, class: "govuk-body", id: "qualified_teacher_status_details"),
+        ]))
       end
     end
 
@@ -26,7 +30,7 @@ RSpec.describe JobApplicationHelper do
       let(:job_application) { build_stubbed(:job_application, qualified_teacher_status: "on_track") }
 
       it "returns the correct info" do
-        expect(subject).to eq(tag.div("I'm on track to receive my QTS", class: "govuk-body"))
+        expect(subject).to eq(tag.div("I'm on track to receive my QTS", class: "govuk-body", id: "qualified_teacher_status"))
       end
     end
 
@@ -46,8 +50,8 @@ RSpec.describe JobApplicationHelper do
       let(:job_application) { build_stubbed(:job_application, support_needed: "yes") }
 
       it "returns the correct info" do
-        expect(subject).to eq(safe_join([tag.div("Yes", class: "govuk-body"),
-                                         tag.p(job_application.support_needed_details, class: "govuk-body")]))
+        expect(subject).to eq(safe_join([tag.div("Yes", class: "govuk-body", id: "support_needed"),
+                                         tag.p(job_application.support_needed_details, class: "govuk-body", id: "support_needed_details")]))
       end
     end
 
@@ -55,7 +59,7 @@ RSpec.describe JobApplicationHelper do
       let(:job_application) { build_stubbed(:job_application, support_needed: "no") }
 
       it "returns the correct info" do
-        expect(subject).to eq(tag.div("No", class: "govuk-body"))
+        expect(subject).to eq(tag.div("No", class: "govuk-body", id: "support_needed"))
       end
     end
 
@@ -75,8 +79,10 @@ RSpec.describe JobApplicationHelper do
       let(:job_application) { build_stubbed(:job_application, close_relationships: "yes") }
 
       it "returns the correct info" do
-        expect(subject).to eq(safe_join([tag.div("Yes", class: "govuk-body"),
-                                         tag.p(job_application.close_relationships_details, class: "govuk-body")]))
+        expect(subject).to eq(safe_join([
+          tag.div("Yes", class: "govuk-body", id: "close_relationships"),
+          tag.p(job_application.close_relationships_details, class: "govuk-body", id: "close_relationships_details"),
+        ]))
       end
     end
 
@@ -84,7 +90,7 @@ RSpec.describe JobApplicationHelper do
       let(:job_application) { build_stubbed(:job_application, close_relationships: "no") }
 
       it "returns the correct info" do
-        expect(subject).to eq(tag.div("No", class: "govuk-body"))
+        expect(subject).to eq(tag.div("No", class: "govuk-body", id: "close_relationships"))
       end
     end
 
@@ -128,10 +134,20 @@ RSpec.describe JobApplicationHelper do
                     in_progress_steps: %w[ask_for_support])
     end
 
+    context "when there is an error on an attribute in the step" do
+      let(:step) { :personal_details }
+
+      before { allow(job_application).to receive_message_chain(:errors, :messages).and_return({ city: "Invalid city" }) }
+
+      it "returns 'action required' tag" do
+        expect(subject).to eq(helper.govuk_tag(text: t("messages.jobs.action_required.label"), colour: "orange"))
+      end
+    end
+
     context "when the step is completed" do
       let(:step) { :personal_details }
 
-      it "returns complete tag" do
+      it "returns 'complete' tag" do
         expect(subject).to eq(helper.govuk_tag(text: "complete"))
       end
     end
@@ -139,7 +155,7 @@ RSpec.describe JobApplicationHelper do
     context "when the step is in progress" do
       let(:step) { :ask_for_support }
 
-      it "returns in progress tag" do
+      it "returns in 'progress' tag" do
         expect(subject).to eq(helper.govuk_tag(text: "in progress", colour: "yellow"))
       end
     end
@@ -147,7 +163,7 @@ RSpec.describe JobApplicationHelper do
     context "when the step is not started" do
       let(:step) { :personal_statement }
 
-      it "returns not started tag" do
+      it "returns 'not started' tag" do
         expect(subject).to eq(helper.govuk_tag(text: "not started", colour: "red"))
       end
     end

--- a/spec/system/jobseekers_can_submit_a_job_application_spec.rb
+++ b/spec/system/jobseekers_can_submit_a_job_application_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Jobseekers can submit a job application" do
   context "when the application is incomplete" do
     let(:job_application) { create(:job_application, :status_draft, jobseeker: jobseeker, vacancy: vacancy) }
 
-    it "does not allow jobseekers to submit application and go to confirmation page" do
+    it "does not allow jobseekers to submit application" do
       check I18n.t("helpers.label.jobseekers_job_application_review_form.confirm_data_accurate_options.1")
       check I18n.t("helpers.label.jobseekers_job_application_review_form.confirm_data_usage_options.1")
 
@@ -44,6 +44,31 @@ RSpec.describe "Jobseekers can submit a job application" do
 
       expect(JobApplication.first.status).to eq("draft")
       expect(page).to have_content("There is a problem")
+    end
+
+    it "allows jobseekers to save application and go to dashboard" do
+      click_on I18n.t("buttons.save_and_come_back")
+
+      expect(JobApplication.first.status).to eq("draft")
+      expect(page).to have_content(I18n.t("messages.jobseekers.job_applications.saved"))
+      expect(current_path).to eq(jobseekers_job_applications_path)
+    end
+  end
+
+  context "when the application is complete but invalid" do
+    let(:job_application) { create(:job_application, jobseeker: jobseeker, vacancy: vacancy, statutory_induction_complete: "invalid answer") }
+
+    it "does not allow jobseekers to submit application, and informs jobseeker of invalid value" do
+      check I18n.t("helpers.label.jobseekers_job_application_review_form.confirm_data_accurate_options.1")
+      check I18n.t("helpers.label.jobseekers_job_application_review_form.confirm_data_usage_options.1")
+
+      click_on I18n.t("buttons.submit_application")
+
+      expect(JobApplication.first.status).to eq("draft")
+      expect(page).not_to have_content("There is a problem")
+      expect(page).to have_content(I18n.t("messages.jobs.action_required.message.jobseeker"))
+      expect(page).to have_link(I18n.t("activemodel.errors.models.jobseekers/job_application/professional_status_form.attributes.statutory_induction_complete.inclusion"),
+                                href: "#statutory_induction_complete")
     end
 
     it "allows jobseekers to save application and go to dashboard" do

--- a/spec/system/publishers_can_edit_a_published_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers_can_edit_a_published_vacancy_as_a_school_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Publishers can edit a vacancy" do
         visit edit_organisation_job_path(vacancy.id)
 
         expect(page).to have_content(I18n.t("messages.jobs.action_required.heading"))
-        expect(page).to have_content(I18n.t("messages.jobs.action_required.message"))
+        expect(page).to have_content(I18n.t("messages.jobs.action_required.message.publisher"))
         expect(page).to have_content(I18n.t("job_summary_errors.about_school.blank", organisation: "school"))
         expect(page).to have_content(I18n.t("job_details_errors.suitable_for_nqt.inclusion"))
       end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2720

## Changes in this PR:

- **Refactor/fix up the code that serves the equivalent purpose for vacancy publishers**

Then:

- **Add 'action required' error message to job applications when invalid**

If we change the validations on job application forms after a job application is
started but before it is submitted, a job application can be submitted with invalid
values (e.g. missing a field). We should alert the user to this so that we can avoid
having submitted applications in unexpected states (this has caused a bug recently
owing to us adding a field 'age' to the equal opportunities form - this resulted in
an error being thrown which prevented applications which completed that form before
the change from being able to be submitted).

This solution is modelled on the 'action required' solution which serves a parallel
purpose for the vacancy build process on the hiring staff side. It is not a perfect
solution as it does not validate references, employment histories, qualifications, or
qualification results.

`id` attributes are added to values in the review step so that the 'action required' error
summary can link to the relevant part of the page.

We will not display the review form errors and action required errors at the same time
to avoid confusion/visual overload. The review form errors will take precedence.

## Screenshots of UI changes:

### After

<img width="824" alt="Screenshot 2021-07-08 at 17 11 45" src="https://user-images.githubusercontent.com/60350599/124956183-a4dcd800-e00f-11eb-9000-ddf74cc0b3af.png">

