### PR TITLE
[TEVA-2840] Check publisher_signed_in? when redirecting users

### DIFF
--- a/app/controllers/publishers/login_keys_controller.rb
+++ b/app/controllers/publishers/login_keys_controller.rb
@@ -27,7 +27,7 @@ class Publishers::LoginKeysController < ApplicationController
   private
 
   def redirect_signed_in_publishers
-    redirect_to organisation_path if current_organisation.present?
+    redirect_to organisation_path if publisher_signed_in? && current_organisation.present?
   end
 
   def redirect_for_dsi_authentication


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-2840

## Changes in this PR:
When a publisher is authenticated we redirect to the organisation path
when authentication fallback is on. We were checking only the presence
of the organisation in the session, but that caused the redirection for
when the organisation is still present in the session, but the user is 
not authenticated. We need to check them both