### PR TITLE
Spike new similar jobs location logic

### DIFF
--- a/app/controllers/publishers/vacancies_controller.rb
+++ b/app/controllers/publishers/vacancies_controller.rb
@@ -2,7 +2,7 @@ class Publishers::VacanciesController < Publishers::Vacancies::BaseController
   include Publishers::Wizardable
 
   before_action :redirect_if_published, only: %i[preview review]
-  before_action :devise_job_alert_search_criteria, only: %i[show preview]
+  before_action :invent_job_alert_search_criteria, only: %i[show preview]
 
   helper_method :applying_for_the_job_fields, :important_dates_fields, :job_details_fields, :job_location_fields, :job_summary_fields, :pay_package_fields, :schools_fields
 
@@ -60,8 +60,8 @@ class Publishers::VacanciesController < Publishers::Vacancies::BaseController
 
   private
 
-  def devise_job_alert_search_criteria
-    @devised_job_alert_search_criteria = Search::CriteriaDeviser.new(vacancy).criteria
+  def invent_job_alert_search_criteria
+    @invented_job_alert_search_criteria = Search::CriteriaInventor.new(vacancy).criteria
   end
 
   def redirect_if_published

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -31,7 +31,7 @@ class VacanciesController < ApplicationController
 
     @saved_job = current_jobseeker&.saved_jobs&.find_by(vacancy_id: vacancy.id)
     @vacancy = VacancyPresenter.new(vacancy)
-    @devised_job_alert_search_criteria = Search::CriteriaDeviser.new(vacancy).criteria
+    @invented_job_alert_search_criteria = Search::CriteriaInventor.new(vacancy).criteria
     @similar_jobs = Search::SimilarJobs.new(vacancy).similar_jobs
   end
 

--- a/app/models/organisation_vacancy.rb
+++ b/app/models/organisation_vacancy.rb
@@ -1,4 +1,8 @@
 class OrganisationVacancy < ApplicationRecord
   belongs_to :organisation
   belongs_to :vacancy
+
+  after_save do
+    vacancy.set_mean_geolocation!
+  end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -59,5 +59,6 @@ class School < Organisation
     end
 
     self.geolocation = geolocation
+    vacancies.each(&:set_mean_geolocation!)
   end
 end

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -115,6 +115,15 @@ class Vacancy < ApplicationRecord
     job_applications.after_submission.count >= EQUAL_OPPORTUNITIES_PUBLICATION_THRESHOLD
   end
 
+  def set_mean_geolocation!
+    # When SimilarJobs searches for jobs similar to a multi-school job, we need to derive a location to search around.
+    # We do not have LAs' postcodes; anyway, LAs can manage schools outside themselves.
+    # Take the mean of the geolocations of the school(s) the vacancy is at.
+    # Centroids are for polygons (ordered points defining a shape), so the mean is more appropriate than a centroid.
+    coords = organisations.map(&:geolocation).compact.map { |loc| [loc.x, loc.y] }.reject { |coord| coord == [0, 0] }
+    self.mean_geolocation = [(coords.sum(&:first) / coords.length), (coords.sum(&:second) / coords.length)] unless coords.count.zero?
+  end
+
   private
 
   def slug_candidates

--- a/app/services/search/location_builder.rb
+++ b/app/services/search/location_builder.rb
@@ -18,7 +18,7 @@ class Search::LocationBuilder
     elsif search_with_polygons?
       initialize_polygon_boundaries
     elsif @location.present?
-      @location_filter = build_location_filter(@location, @radius)
+      @location_filter = build_location_filter
     end
   end
 
@@ -50,10 +50,18 @@ class Search::LocationBuilder
     end
   end
 
-  def build_location_filter(location, radius)
+  def build_location_filter
     {
-      point_coordinates: Geocoding.new(location).coordinates,
+      point_coordinates: build_coordinates,
       radius: convert_miles_to_metres(radius),
     }
+  end
+
+  def build_coordinates
+    if location.respond_to?(:x)
+      [location.x, location.y]
+    else
+      Geocoding.new(location).coordinates
+    end
   end
 end

--- a/app/services/search/similar_jobs.rb
+++ b/app/services/search/similar_jobs.rb
@@ -10,7 +10,7 @@ class Search::SimilarJobs
 
   def criteria
     # For now, similar jobs are retrieved based on the same set of rules that define similar job alerts
-    @criteria ||= Search::CriteriaDeviser.new(vacancy).criteria
+    @criteria ||= Search::CriteriaInventor.new(vacancy).criteria
   end
 
   def similar_jobs

--- a/app/views/shared/vacancy/_jobseeker_view.html.slim
+++ b/app/views/shared/vacancy/_jobseeker_view.html.slim
@@ -39,7 +39,7 @@
         = render BannerButtonComponent.new text: t("jobs.alert.similar.terse"),
           href: new_subscription_path,
           icon: "alert-blue",
-          params: { search_criteria: @devised_job_alert_search_criteria, origin: request.original_fullpath }
+          params: { search_criteria: @invented_job_alert_search_criteria, origin: request.original_fullpath }
 
       - unless defined?(job_application) && job_application.present?
         .govuk-grid-column-one-third
@@ -88,7 +88,7 @@
 
     section
       p.icon.icon--left.icon--alert-blue
-        = govuk_link_to(t("jobs.alert.similar.verbose.link_text"), new_subscription_path(search_criteria: @devised_job_alert_search_criteria, origin: request.original_fullpath), id: "job-alert-link-from-bottom-of-job-listing-gtm")
+        = govuk_link_to(t("jobs.alert.similar.verbose.link_text"), new_subscription_path(search_criteria: @invented_job_alert_search_criteria, origin: request.original_fullpath), id: "job-alert-link-from-bottom-of-job-listing-gtm")
         =< t("jobs.alert.similar.verbose.reminder")
 
     section class="govuk-!-margin-top-3"

--- a/db/migrate/20210715121846_add_mean_geolocation_to_vacancies.rb
+++ b/db/migrate/20210715121846_add_mean_geolocation_to_vacancies.rb
@@ -1,0 +1,13 @@
+class AddMeanGeolocationToVacancies < ActiveRecord::Migration[6.1]
+  def up
+    add_column :vacancies, :mean_geolocation, :point
+
+    Vacancy.find_each do |vacancy|
+      vacancy.set_mean_geolocation! if vacancy.respond_to?(:set_mean_geolocation!)
+    end
+  end
+
+  def down
+    remove_column :vacancies, :mean_geolocation, :point
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_15_075650) do
+ActiveRecord::Schema.define(version: 2021_07_15_121846) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -464,6 +464,7 @@ ActiveRecord::Schema.define(version: 2021_07_15_075650) do
     t.integer "end_listing_reason"
     t.integer "candidate_hired_from"
     t.boolean "enable_job_applications"
+    t.point "mean_geolocation"
     t.index ["expires_at"], name: "index_vacancies_on_expires_at"
     t.index ["initially_indexed"], name: "index_vacancies_on_initially_indexed"
     t.index ["publisher_id"], name: "index_vacancies_on_publisher_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -247,7 +247,7 @@ FactoryBot.create(:vacancy,
                   publisher_organisation: school_one,
                   organisation_vacancies_attributes: [{ organisation: school_one }])
 
-# pending vacancy
+# scheduled vacancy
 FactoryBot.create(:vacancy,
                   job_title: "Teacher of Drama",
                   subjects: %w[Drama],

--- a/lib/geocoding.rb
+++ b/lib/geocoding.rb
@@ -15,13 +15,32 @@ class Geocoding
     rescue Geocoder::OverQueryLimitError
       Rails.logger.error("Google Geocoding API responded with OVER_QUERY_LIMIT")
       Geocoder.coordinates(location, lookup: :uk_ordnance_survey_names)
-    end || no_match
+    end || no_coordinates_match
+  end
+
+  def postcode_from_coordinates
+    return Geocoder::DEFAULT_LOCATION if Rails.application.config.geocoder_lookup == :test
+
+    Rails.cache.fetch([:geocoding, location], expires_in: CACHE_DURATION, skip_nil: true) do
+      result = Geocoder.search(location, lookup: :google).first # specifying `components: country:gb` would force the result to be a country
+      result.data["address_components"].select { |line| "postal_code".in?(line["types"]) }.first["short_name"]
+    rescue Geocoder::OverQueryLimitError
+      Rails.logger.error("Google Geocoding API responded with OVER_QUERY_LIMIT")
+      result = Geocoder.search(location).first
+      Rails.logger.error("Geocoding API responded with error: #{result.first.data["error"]}") if result.first.data["error"].present?
+      result.data["address"]["postcode"]
+    end || no_postcode_match
   end
 
   private
 
-  def no_match
-    Rails.logger.info("The Geocoder API returned no match (0, 0) for '#{location}'. This was not cached.")
+  def no_coordinates_match
+    Rails.logger.info("The Geocoder API returned no coordinates match (0, 0) for '#{location}'. This was not cached.")
     [0, 0]
+  end
+
+  def no_postcode_match
+    Rails.logger.info("The Geocoder API returned no postcode match for '#{location}'. This was not cached.")
+    ""
   end
 end

--- a/lib/organisation_import/import_trust_data.rb
+++ b/lib/organisation_import/import_trust_data.rb
@@ -52,6 +52,7 @@ class ImportTrustData < ImportOrganisationData
     trust.postcode = postcode
     coordinates = Geocoding.new(trust.postcode).coordinates
     trust.geolocation = coordinates unless coordinates == [0, 0]
+    trust.vacancies.each(&:set_mean_geolocation!)
   end
 
   def csv_metadata

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -19,6 +19,7 @@ Sidekiq::Testing.fake!
 
 # Stub Geocoder HTTP requests in specs
 Geocoder::DEFAULT_STUB_COORDINATES = [51.67014192630465, -1.2809649516211556].freeze
+Geocoder::DEFAULT_LOCATION = "TE5 T1NG".freeze
 
 Capybara.server = :puma, { Silent: true, Threads: "0:1" }
 

--- a/spec/services/search/criteria_inventor_spec.rb
+++ b/spec/services/search/criteria_inventor_spec.rb
@@ -6,7 +6,7 @@ RSpec.shared_examples "no keyword in the criteria" do
   end
 end
 
-RSpec.describe Search::CriteriaDeviser do
+RSpec.describe Search::CriteriaInventor do
   subject { described_class.new(vacancy) }
 
   let(:postcode) { "ab12 3cd" }

--- a/spec/services/search/similar_jobs_spec.rb
+++ b/spec/services/search/similar_jobs_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Search::SimilarJobs do
   let(:vacancy) { create(:vacancy, :at_one_school, organisation_vacancies_attributes: [{ organisation: school }]) }
 
   it "calls Search::CriteriaDeviser" do
-    expect(Search::CriteriaDeviser).to receive(:new).with(vacancy).and_call_original
+    expect(Search::CriteriaInventor).to receive(:new).with(vacancy).and_call_original
     subject.similar_jobs
   end
 


### PR DESCRIPTION
No ticket.

Currently there is an issue whereby searching for jobs that are similar to a multi-school job will use the postcode of the parent organisation. For MATs, this is suboptimal but acceptable, but for LAs, it is a bug, because we don't have postcodes for LAs (so the search goes ahead without a location).

This is a proposed solution which takes the mean location of the schools the vacancy is at, as the location to search around. This is also probably slightly better for the MAT case, too.

Conversation: https://ukgovernmentdfe.slack.com/archives/CG9A8H1HP/p1626341468288200
