### PR TITLE
[TEVA-2632] Add A/B test for contents tabs on job listings

### DIFF
--- a/app/views/shared/vacancy/_jobseeker_view.html.slim
+++ b/app/views/shared/vacancy/_jobseeker_view.html.slim
@@ -60,19 +60,20 @@
       = govuk_notification_banner title: t("banners.important"), classes: "govuk-!-margin-bottom-5" do
         = t("messages.jobs.multi_school_job_notification_html", organisation_type: organisation_type_basic(@vacancy.parent_organisation))
 
-    .content-pills class="govuk-!-margin-bottom-6"
-      h3.govuk-heading-s class="govuk-!-margin-bottom-3" = t("jobs.contents")
-      .govuk-grid-row
-        / Up to four half columns in one row so that they automatically wrap depending on how many are present
-        .govuk-grid-column-one-half
-          = render PillLinkComponent.new text: "Job details", href: "#job-details"
-        - if @vacancy.supporting_documents.any?
+    - if current_variant?(:"2021_07_contents_tabs_on_job_listing_test", :present)
+      .content-pills class="govuk-!-margin-bottom-6"
+        h3.govuk-heading-s class="govuk-!-margin-bottom-3" = t("jobs.contents")
+        .govuk-grid-row
+          / Up to four half columns in one row so that they automatically wrap depending on how many are present
           .govuk-grid-column-one-half
-            = render PillLinkComponent.new text: "Supporting documents", href: "#supporting-documents"
-        .govuk-grid-column-one-half
-          = render PillLinkComponent.new text: t("organisation.overview_link_text.#{@vacancy.job_location}"), href: "#school-overview"
-        .govuk-grid-column-one-half
-          = render PillLinkComponent.new text: t("organisation.location_link_text.#{@vacancy.job_location}"), href: "#school-location"
+            = render PillLinkComponent.new text: "Job details", href: "#job-details"
+          - if @vacancy.supporting_documents.any?
+            .govuk-grid-column-one-half
+              = render PillLinkComponent.new text: "Supporting documents", href: "#supporting-documents"
+          .govuk-grid-column-one-half
+            = render PillLinkComponent.new text: t("organisation.overview_link_text.#{@vacancy.job_location}"), href: "#school-overview"
+          .govuk-grid-column-one-half
+            = render PillLinkComponent.new text: t("organisation.location_link_text.#{@vacancy.job_location}"), href: "#school-location"
 
     = render(Jobseekers::VacancyDetailsComponent.new(vacancy: @vacancy))
     = render(Jobseekers::OrganisationOverviews::SchoolGroupComponent.new(vacancy: @vacancy))

--- a/config/ab_tests.yml
+++ b/config/ab_tests.yml
@@ -16,6 +16,8 @@
 #     you must not remove/rename any existing variants. If you want a variant to receive no
 #     new participants, set its weight to 0 instead.
 #   - You need to restart your Rails server when changing this file in development
+#   - You can add a query parameter such as the below to force a particular variant:
+#     ?ab_test_override[2021_01_testing_test]=red
 shared:
   # A fake test to test (ha!) the AB testing functionality
   2021_01_testing_test:
@@ -35,6 +37,9 @@ shared:
   2021_06_mandatory_job_alert_fields_test:
     mandatory_location_and_one_other_field: 1
     default: 1
+  2021_07_contents_tabs_on_job_listing_test:
+    present: 1
+    absent: 1
 test:
   2021_04_cookie_consent_test:
     none: 0
@@ -47,3 +52,6 @@ test:
     bottom: 1
     right_blue: 0
     right_grey: 0
+  2021_07_contents_tabs_on_job_listing_test:
+    present: 1
+    absent: 0


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2632

## Changes in this PR:

- Is there anything else I have to remember to do here? I've not set up an AB test before.

## Screenshots of UI changes:

### :present
![Screenshot 2021-07-15 at 17 35 08](https://user-images.githubusercontent.com/60350599/125824674-ea7da290-4185-4623-a38e-6f4609c8ed89.png)

### :absent
![Screenshot 2021-07-15 at 17 35 31](https://user-images.githubusercontent.com/60350599/125824732-db6c3d74-825f-4373-850b-5f1851163e0e.png)

## Next steps:

- [ ] We measure the document download rate, saved job rate and GMI/apply click rate.
- [ ] We break this down by device category (mobile / desktop).
- [ ] We decide whether or not to retain the contents page for each device category.
- [ ] We wait long enough to get a statistically significant result to do this.
