### PR TITLE
Update algoliasearch-rails gem to 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "railties", RAILS_VERSION
 
 gem "activerecord-session_store"
 gem "addressable"
-gem "algoliasearch-rails", "~> 1.25.0"
+gem "algoliasearch-rails", "~> 2.0"
 gem "array_enum"
 gem "aws-sdk-s3", require: false
 gem "breasal"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,11 +69,12 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     aes_key_wrap (1.1.0)
-    algoliasearch (1.27.5)
-      httpclient (~> 2.8, >= 2.8.3)
-      json (>= 1.5.1)
-    algoliasearch-rails (1.25.0)
-      algoliasearch (>= 1.26.0, < 2.0.0)
+    algolia (2.1.1)
+      faraday (>= 0.15, < 2.0)
+      multi_json (~> 1.0)
+      net-http-persistent
+    algoliasearch-rails (2.1.0)
+      algolia (< 3.0.0)
       json (>= 1.5.1)
     array_enum (1.3.0)
       activemodel
@@ -339,6 +340,8 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
+    net-http-persistent (4.0.1)
+      connection_pool (~> 2.2)
     nio4r (2.5.7)
     nokogiri (1.11.7)
       mini_portile2 (~> 2.5.0)
@@ -630,7 +633,7 @@ DEPENDENCIES
   activestorage (~> 6.1.4)
   activesupport (~> 6.1.4)
   addressable
-  algoliasearch-rails (~> 1.25.0)
+  algoliasearch-rails (~> 2.0)
   array_enum
   aws-sdk-s3
   aws-sdk-ssm


### PR DESCRIPTION
The old version has a dependecy on httpclient gem v2.8.3.
This update removes that dependecy

## Jira ticket URL

- Just add the ticket number to the end:

https://dfedigital.atlassian.net/browse/TEVA-2847

## Changes in this PR:

Update algoliasearch-rails gem to 2.0
