### PR TITLE
Update Algolia settings backup

### DIFF
--- a/config/algolia_settings.json
+++ b/config/algolia_settings.json
@@ -24,6 +24,7 @@
     ],
     "numericAttributesToIndex": null,
     "attributesToRetrieve": null,
+    "advancedSyntax": true,
     "unretrievableAttributes": null,
     "optionalWords": null,
     "attributesForFaceting": [
@@ -127,9 +128,25 @@
   "rules": [],
   "synonyms": [
     {
-      "type": "synonym",
+      "type": "onewaysynonym",
+      "input": "ks2",
       "synonyms": [
-        "primary",
+        "primary"
+      ],
+      "objectID": "syn-1626273585224-26"
+    },
+    {
+      "type": "onewaysynonym",
+      "input": "ks1",
+      "synonyms": [
+        "primary"
+      ],
+      "objectID": "syn-1626273515462-21"
+    },
+    {
+      "type": "onewaysynonym",
+      "input": "primary",
+      "synonyms": [
         "ks1",
         "ks2"
       ],


### PR DESCRIPTION
The settings have changed. We are backing it up because we lost the settings once before in the past.

- Correct synonym direction
- Allow advanced syntax (let users write '-computer' to exclude results containing
'computer')
