### PR TITLE
[TEVA-2687] Keep track of date when jobseeker closes account

### DIFF
--- a/app/controllers/jobseekers/sessions_controller.rb
+++ b/app/controllers/jobseekers/sessions_controller.rb
@@ -47,7 +47,7 @@ class Jobseekers::SessionsController < Devise::SessionsController
   end
 
   def reactivate_account_if_closed
-    return unless current_jobseeker.closed_account
+    return unless current_jobseeker.account_closed_on?
 
     Jobseekers::ReactivateAccount.new(current_jobseeker).call
   end

--- a/app/services/jobseekers/close_account.rb
+++ b/app/services/jobseekers/close_account.rb
@@ -17,7 +17,7 @@ class Jobseekers::CloseAccount
   private
 
   def mark_jobseeker_account_closed
-    jobseeker.update(closed_account: true)
+    jobseeker.update(account_closed_on: Date.current)
   end
 
   def create_feedback

--- a/app/services/jobseekers/reactivate_account.rb
+++ b/app/services/jobseekers/reactivate_account.rb
@@ -13,7 +13,7 @@ class Jobseekers::ReactivateAccount
   private
 
   def mark_jobseeker_account_not_closed
-    jobseeker.update(closed_account: false)
+    jobseeker.update(account_closed_on: nil)
   end
 
   def mark_subscriptions_active

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -136,7 +136,7 @@ shared:
     - locked_at
     - created_at
     - updated_at
-    - closed_account
+    - account_closed_on
   local_authority_publisher_schools:
     - id
     - publisher_preference_id

--- a/db/migrate/20210719151911_add_account_closed_on_to_jobseekers.rb
+++ b/db/migrate/20210719151911_add_account_closed_on_to_jobseekers.rb
@@ -1,0 +1,6 @@
+class AddAccountClosedOnToJobseekers < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :jobseekers, :closed_account
+    add_column :jobseekers, :account_closed_on, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_15_075650) do
+ActiveRecord::Schema.define(version: 2021_07_19_151911) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -243,7 +243,7 @@ ActiveRecord::Schema.define(version: 2021_07_15_075650) do
     t.datetime "locked_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.boolean "closed_account", default: false, null: false
+    t.date "account_closed_on"
     t.index ["confirmation_token"], name: "index_jobseekers_on_confirmation_token", unique: true
     t.index ["email"], name: "index_jobseekers_on_email", unique: true
     t.index ["reset_password_token"], name: "index_jobseekers_on_reset_password_token", unique: true

--- a/spec/services/jobseekers/close_account_spec.rb
+++ b/spec/services/jobseekers/close_account_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Jobseekers::CloseAccount do
   describe "#call" do
     before { subject.call }
 
-    it "marks jobseeker account as closed" do
-      expect(jobseeker.closed_account).to be true
+    it "sets jobseeker account_closed_on to current date" do
+      expect(jobseeker.account_closed_on).to eq Date.current
     end
 
     context "when close_account_feedback_form_params are present" do

--- a/spec/services/jobseekers/reactivate_account_spec.rb
+++ b/spec/services/jobseekers/reactivate_account_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Jobseekers::ReactivateAccount do
   subject { described_class.new(jobseeker) }
 
-  let(:jobseeker) { create(:jobseeker, closed_account: true) }
+  let(:jobseeker) { create(:jobseeker, account_closed_on: Date.yesterday) }
   let!(:subscription) { create(:subscription, email: jobseeker.email, active: false) }
   let!(:subscription_previously_unsubscribed) { create(:subscription, email: jobseeker.email, active: false, unsubscribed_at: 1.day.ago) }
   let!(:job_application) { create(:job_application, :withdrawn, jobseeker: jobseeker, withdrawn_by_closing_account: true) }
@@ -11,8 +11,8 @@ RSpec.describe Jobseekers::ReactivateAccount do
   describe "#call" do
     before { subject.call }
 
-    it "marks jobseeker account as not closed" do
-      expect(jobseeker.closed_account).to be false
+    it "sets jobseeker account_closed_on to nil" do
+      expect(jobseeker.account_closed_on).to be nil
     end
 
     it "marks subscriptions as active" do


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-2687

## Changes in this PR:
This is the first step for ticket 2687. We keep track of when a jobseeker account has been closed. No accounts in production have been closed yet, so the migration is very simple