### PR TITLE
Add job_application.email_address column to log filter

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -3,6 +3,7 @@
 # Configure sensitive parameters which will be filtered from the log file.
 Rails.application.config.filter_parameters += %i[
   email
+  email_address
   password
 
   national_insurance_number


### PR DESCRIPTION
job_application.email is a method, while the column itself is job_application.email_address
