### PR TITLE
[TEVA-2862] do not allow radius select to auto submit form

### DIFF
--- a/app/frontend/src/components/form/form.js
+++ b/app/frontend/src/components/form/form.js
@@ -32,6 +32,7 @@ export const disableInputs = (inputs) => {
 export const enableInputs = (inputs) => {
   inputs.forEach((input) => {
     input.disabled = false;
+    input.value = input.getAttribute('value');
   });
 };
 

--- a/app/frontend/src/components/form/form.js
+++ b/app/frontend/src/components/form/form.js
@@ -1,22 +1,29 @@
 document.addEventListener('DOMContentLoaded', () => {
+  initClearForm();
+  initAutoSubmit();
+});
+
+export const initClearForm = () => {
   Array.from(document.getElementsByClassName('clear-form')).forEach((el) => {
     el.querySelector('input[type="checkbox"]').addEventListener('click', (event) => {
-      checkboxClickHandler(el, event.target.checked);
+      form.checkboxClickHandler(el, event.target.checked);
     });
   });
+};
 
-  Array.from(document.querySelectorAll('[data-auto-submit="true"]')).forEach((el) => {
-    el.addEventListener('change', (e) => {
-      ['govuk-select', 'govuk-checkboxes__input'].forEach((selector) => {
-        if (e.target.classList.contains(selector) && e.target.dataset.changeSubmit !== 'false') {
-          changeHandler(e.target.closest('form'));
+export const initAutoSubmit = () => {
+  Array.from(document.querySelectorAll('[data-auto-submit="true"]')).forEach((formEl) => {
+    Array.from(formEl.querySelectorAll('.govuk-select, .govuk-checkboxes__input')).forEach((el) => {
+      el.addEventListener('change', (e) => {
+        if (e.target.dataset.changeSubmit !== 'false') {
+          form.formSubmit(e.target.closest('form'));
         }
       });
     });
   });
-});
+};
 
-export const changeHandler = (formEl) => {
+export const formSubmit = (formEl) => {
   if (formEl.dataset.autoSubmit) {
     formEl.submit();
   }
@@ -49,6 +56,7 @@ const form = {
   disableInputs,
   enableInputs,
   checkboxClickHandler,
+  formSubmit,
 };
 
 export default form;

--- a/app/frontend/src/components/form/form.js
+++ b/app/frontend/src/components/form/form.js
@@ -8,7 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
   Array.from(document.querySelectorAll('[data-auto-submit="true"]')).forEach((el) => {
     el.addEventListener('change', (e) => {
       ['govuk-select', 'govuk-checkboxes__input'].forEach((selector) => {
-        if (e.target.classList.contains(selector)) {
+        if (e.target.classList.contains(selector) && e.target.dataset.changeSubmit !== 'false') {
           changeHandler(e.target.closest('form'));
         }
       });

--- a/app/frontend/src/components/form/form.test.js
+++ b/app/frontend/src/components/form/form.test.js
@@ -1,55 +1,60 @@
 /**
  * @jest-environment jsdom
  */
-
 import form from './form';
 
 describe('form', () => {
-  document.body.innerHTML = '<div class="clear-form"> <input id="test-text-input" type="text"/> <input id="test-checkbox" type="checkbox"/> </div>';
-  const textField = document.querySelector('#test-text-input');
-  textField.value = '01';
-  const fields = Array.from(document.querySelectorAll('input[type="text"]'));
-
   describe('toggling inputs', () => {
+    let textField;
+
     beforeEach(() => {
-      form.disableInputs(fields);
+      document.body.innerHTML = '<div> <input id="test-text-input" type="text" value="10" /> <input id="test-checkbox" type="checkbox"/> </div>';
+      textField = document.getElementById('test-text-input');
     });
 
     describe('disableInputs', () => {
+      beforeEach(() => {
+        form.disableInputs(Array.from(document.querySelectorAll('input[type="text"]')));
+      });
+
       test('removes the value from the input element', () => {
-        expect(document.querySelector('#test-text-input').value).toBe('');
+        expect(textField.value).toBe('');
       });
 
       test('disables the input element', () => {
-        expect(document.querySelector('#test-text-input').disabled).toBe(true);
+        expect(textField.disabled).toBe(true);
       });
     });
 
     describe('enableInputs', () => {
       beforeEach(() => {
-        form.enableInputs(fields);
-        textField.value = '01';
+        form.enableInputs(Array.from(document.querySelectorAll('input[type="text"]')));
       });
 
-      test('allows for a value to be added to the input element', () => {
-        expect(document.querySelector('#test-text-input').value).toBe('01');
+      test('restores the original value of the input element', () => {
+        expect(textField.value).toBe('10');
       });
 
       test('enables the input element', () => {
-        expect(document.querySelector('#test-text-input').disabled).toBe(false);
+        expect(textField.disabled).toBe(false);
       });
     });
   });
 
-  describe('checkboxClickHandler', () => {
-    const formElement = document.querySelector('.clear-form');
+  describe('clear form', () => {
+    let clearContainer;
+
+    beforeEach(() => {
+      document.body.innerHTML = '<div class="clear-form"> <input id="test-text-input" type="text"/> <input id="test-checkbox" type="checkbox"/> </div>';
+      clearContainer = document.querySelector('.clear-form');
+    });
 
     describe('when checkbox is checked', () => {
       test('calls disableInputs', () => {
         form.disableInputs = jest.fn();
         const disableInputsMock = jest.spyOn(form, 'disableInputs');
-        form.checkboxClickHandler(formElement, true);
-        expect(disableInputsMock).toHaveBeenCalled();
+        form.checkboxClickHandler(clearContainer, true);
+        expect(disableInputsMock).toHaveBeenCalledWith(Array.from(document.querySelectorAll('input[type="text"]')));
       });
     });
 
@@ -57,8 +62,8 @@ describe('form', () => {
       test('calls enablesInputs', () => {
         form.enableInputs = jest.fn();
         const enableInputsMock = jest.spyOn(form, 'enableInputs');
-        form.checkboxClickHandler(formElement, false);
-        expect(enableInputsMock).toHaveBeenCalled();
+        form.checkboxClickHandler(clearContainer, false);
+        expect(enableInputsMock).toHaveBeenCalledWith(Array.from(document.querySelectorAll('input[type="text"]')));
       });
     });
   });

--- a/app/frontend/src/components/form/form.test.js
+++ b/app/frontend/src/components/form/form.test.js
@@ -1,14 +1,45 @@
 /**
  * @jest-environment jsdom
  */
-import form from './form';
+import form, { initAutoSubmit, initClearForm } from './form';
 
 describe('form', () => {
+  describe('form auto submit behaviour', () => {
+    beforeEach(() => {
+      document.body.innerHTML = `<form data-auto-submit="true">
+      <input type="checkbox" class="govuk-checkboxes__input" data-change-submit="false" id="no-submit" />
+      <input type="checkbox" class="govuk-checkboxes__input" id="should-submit" />
+      </form>`;
+    });
+
+    describe('form has auto submit data attribute', () => {
+      let formSubmitMock = null;
+
+      beforeEach(() => {
+        form.formSubmit = jest.fn();
+        formSubmitMock = jest.spyOn(form, 'formSubmit');
+        initAutoSubmit();
+      });
+
+      test('changing state of an input with data-change-submit="false" attribute does not submit form', () => {
+        const event = new Event('change');
+        document.getElementById('no-submit').dispatchEvent(event);
+        expect(formSubmitMock).not.toHaveBeenCalled();
+      });
+
+      test('changing state of an input without data-change-submit="false" attribute does submit form', () => {
+        const event = new Event('change');
+        document.getElementById('should-submit').dispatchEvent(event);
+        expect(formSubmitMock).toHaveBeenCalled();
+      });
+    });
+  });
+
   describe('toggling inputs', () => {
     let textField;
 
     beforeEach(() => {
-      document.body.innerHTML = '<div> <input id="test-text-input" type="text" value="10" /> <input id="test-checkbox" type="checkbox"/> </div>';
+      document.body.innerHTML = '<div> <input id="test-text-input" type="text" value="10" /> </div>';
       textField = document.getElementById('test-text-input');
     });
 
@@ -47,6 +78,7 @@ describe('form', () => {
     beforeEach(() => {
       document.body.innerHTML = '<div class="clear-form"> <input id="test-text-input" type="text"/> <input id="test-checkbox" type="checkbox"/> </div>';
       clearContainer = document.querySelector('.clear-form');
+      initClearForm();
     });
 
     describe('when checkbox is checked', () => {

--- a/app/views/shared/search/_radius.html.slim
+++ b/app/views/shared/search/_radius.html.slim
@@ -4,5 +4,6 @@
   :first,
   label: { text: t("jobs.search.within_radius"), size: "s" },
   class: "govuk-!-width-#{wide ? 'full' : 'one-third'}",
+  data: { "change-submit": "false" },
   form_group: { classes: "location-radius-select" },
   options: { selected: @form.radius || Search::LocationBuilder::DEFAULT_RADIUS }


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-2862

this also includes a change whereby the 'as soon as possible' functionality didnt preserve its values if it was unchecked and checked again

old sequence

![Screenshot 2021-07-21 at 13 30 12](https://user-images.githubusercontent.com/1792451/126488770-dc32cda1-71d1-4d25-a1d8-6e5326d3a9ed.png)
![Screenshot 2021-07-21 at 13 29 54](https://user-images.githubusercontent.com/1792451/126488772-1bc06a9a-00a1-4c3a-a9ac-3f78c786c506.png)
![Screenshot 2021-07-21 at 13 31 38](https://user-images.githubusercontent.com/1792451/126488768-3597e252-9e6a-4cc2-a812-d0d640a8218f.png)

new sequence

![Screenshot 2021-07-21 at 13 30 12](https://user-images.githubusercontent.com/1792451/126488770-dc32cda1-71d1-4d25-a1d8-6e5326d3a9ed.png)
![Screenshot 2021-07-21 at 13 29 54](https://user-images.githubusercontent.com/1792451/126488772-1bc06a9a-00a1-4c3a-a9ac-3f78c786c506.png)
![Screenshot 2021-07-21 at 13 29 40](https://user-images.githubusercontent.com/1792451/126488774-e837b40b-72a7-475f-8155-8fc0c78f8cf1.png)

