### PR TITLE
[TEVA-2604] Display page when attempting to view a withdrawn application

### DIFF
--- a/app/controllers/publishers/vacancies/job_applications_controller.rb
+++ b/app/controllers/publishers/vacancies/job_applications_controller.rb
@@ -15,8 +15,9 @@ class Publishers::Vacancies::JobApplicationsController < Publishers::Vacancies::
   end
 
   def show
-    raise ActionController::RoutingError, "Cannot view a draft or withdrawn application" if
-      job_application.draft? || job_application.withdrawn?
+    redirect_to organisation_job_job_application_withdrawn_path(vacancy.id, job_application) if job_application.withdrawn?
+
+    raise ActionController::RoutingError, "Cannot view a draft application" if job_application.draft?
 
     job_application.reviewed! if job_application.submitted?
   end

--- a/app/views/publishers/vacancies/job_applications/withdrawn.html.slim
+++ b/app/views/publishers/vacancies/job_applications/withdrawn.html.slim
@@ -1,0 +1,10 @@
+- content_for :page_title_prefix, t(".page_title")
+
+.govuk-caption-l class="govuk-!-margin-top-5"
+  = t("jobseekers.job_applications.caption", job_title: vacancy.job_title, organisation: vacancy.parent_organisation_name)
+
+h1.govuk-heading-xl class="govuk-!-margin-bottom-8 govuk-!-margin-top-3" = t(".heading")
+
+p.govuk-body = t(".content")
+
+= govuk_link_to t(".view_more_applications"), organisation_job_job_applications_path(vacancy.id), class: "govuk-!-margin-bottom-0 govuk-!-margin-top-5", button: true

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -251,6 +251,11 @@ en:
         update_status:
           unsuccessful: "%{name} has been sent an email telling them their application has not been successful"
           shortlisted: "%{name} has been sent an email telling them that they have been shortlisted"
+        withdrawn:
+          content: The candidate has withdrawn their application and you cannot view it any more.
+          heading: This application has been withdrawn
+          page_title: Application withdrawn
+          view_more_applications: View more applications
       live:
         notice: You can only view active jobs
       review:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -148,6 +148,7 @@ Rails.application.routes.draw do
       resources :job_applications, only: %i[index show], controller: "publishers/vacancies/job_applications" do
         get :shortlist
         get :reject
+        get :withdrawn
         post :update_status
       end
     end

--- a/spec/requests/publishers/vacancies/job_applications_spec.rb
+++ b/spec/requests/publishers/vacancies/job_applications_spec.rb
@@ -126,9 +126,9 @@ RSpec.describe "Job applications" do
     context "when the job application status is withdrawn" do
       let(:job_application) { create(:job_application, :status_withdrawn, vacancy: vacancy) }
 
-      it "raises an error" do
-        expect { get(organisation_job_job_application_path(vacancy.id, job_application.id)) }
-          .to raise_error(ActionController::RoutingError, /Cannot view/)
+      it "redirects to the withdrawn page" do
+        expect(get(organisation_job_job_application_path(vacancy.id, job_application.id)))
+          .to redirect_to(organisation_job_job_application_withdrawn_path(vacancy.id, job_application.id))
       end
     end
   end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2604

## Screenshots of UI changes:

<img width="1287" alt="Screenshot 2021-07-20 at 15 31 09" src="https://user-images.githubusercontent.com/30624173/126342208-8f010e27-177e-47bd-b0a0-67e6df926611.png">
