### PR TITLE
use constansts for common selectors in form JS/tests

### DIFF
--- a/app/frontend/src/components/form/form.js
+++ b/app/frontend/src/components/form/form.js
@@ -1,19 +1,24 @@
+export const CHECKBOX_CLASS = 'govuk-checkboxes__input';
+export const SELECT_CLASS = 'govuk-select';
+export const CLEARFORM_CLASS = 'clear-form';
+export const AUTOSUBMIT_ATTR_KEY = 'auto-submit';
+
 document.addEventListener('DOMContentLoaded', () => {
   initClearForm();
   initAutoSubmit();
 });
 
 export const initClearForm = () => {
-  Array.from(document.getElementsByClassName('clear-form')).forEach((el) => {
-    el.querySelector('input[type="checkbox"]').addEventListener('click', (event) => {
+  Array.from(document.getElementsByClassName(CLEARFORM_CLASS)).forEach((el) => {
+    el.querySelector(`.${CHECKBOX_CLASS}`).addEventListener('click', (event) => {
       form.checkboxClickHandler(el, event.target.checked);
     });
   });
 };
 
 export const initAutoSubmit = () => {
-  Array.from(document.querySelectorAll('[data-auto-submit="true"]')).forEach((formEl) => {
-    Array.from(formEl.querySelectorAll('.govuk-select, .govuk-checkboxes__input')).forEach((el) => {
+  Array.from(document.querySelectorAll(`[data-${AUTOSUBMIT_ATTR_KEY}="true"]`)).forEach((formEl) => {
+    Array.from(formEl.querySelectorAll(`.${SELECT_CLASS}, .${CHECKBOX_CLASS}`)).forEach((el) => {
       el.addEventListener('change', (e) => {
         if (e.target.dataset.changeSubmit !== 'false') {
           form.formSubmit(e.target.closest('form'));
@@ -57,6 +62,10 @@ const form = {
   enableInputs,
   checkboxClickHandler,
   formSubmit,
+  CHECKBOX_CLASS,
+  SELECT_CLASS,
+  CLEARFORM_CLASS,
+  AUTOSUBMIT_ATTR_KEY,
 };
 
 export default form;

--- a/app/frontend/src/components/form/form.test.js
+++ b/app/frontend/src/components/form/form.test.js
@@ -1,14 +1,20 @@
 /**
  * @jest-environment jsdom
  */
-import form, { initAutoSubmit, initClearForm } from './form';
+import form, {
+  initAutoSubmit,
+  initClearForm,
+  CHECKBOX_CLASS,
+  CLEARFORM_CLASS,
+  AUTOSUBMIT_ATTR_KEY,
+} from './form';
 
 describe('form', () => {
   describe('form auto submit behaviour', () => {
     beforeEach(() => {
-      document.body.innerHTML = `<form data-auto-submit="true">
-      <input type="checkbox" class="govuk-checkboxes__input" data-change-submit="false" id="no-submit" />
-      <input type="checkbox" class="govuk-checkboxes__input" id="should-submit" />
+      document.body.innerHTML = `<form data-${AUTOSUBMIT_ATTR_KEY}="true">
+      <input type="checkbox" class="${CHECKBOX_CLASS}" data-change-submit="false" id="no-submit" />
+      <input type="checkbox" class="${CHECKBOX_CLASS}" id="should-submit" />
       </form>`;
     });
 
@@ -39,7 +45,7 @@ describe('form', () => {
     let textField;
 
     beforeEach(() => {
-      document.body.innerHTML = '<div> <input id="test-text-input" type="text" value="10" /> </div>';
+      document.body.innerHTML = `<div class="${CLEARFORM_CLASS}"> <input id="test-text-input" type="text" value="10" /> </div>`;
       textField = document.getElementById('test-text-input');
     });
 
@@ -73,11 +79,8 @@ describe('form', () => {
   });
 
   describe('clear form', () => {
-    let clearContainer;
-
     beforeEach(() => {
-      document.body.innerHTML = '<div class="clear-form"> <input id="test-text-input" type="text"/> <input id="test-checkbox" type="checkbox"/> </div>';
-      clearContainer = document.querySelector('.clear-form');
+      document.body.innerHTML = `<div class="${CLEARFORM_CLASS}"> <input id="test-text-input" type="text" /> <input id="test-checkbox" type="checkbox" class="${CHECKBOX_CLASS}" /> </div>`;
       initClearForm();
     });
 
@@ -85,7 +88,7 @@ describe('form', () => {
       test('calls disableInputs', () => {
         form.disableInputs = jest.fn();
         const disableInputsMock = jest.spyOn(form, 'disableInputs');
-        form.checkboxClickHandler(clearContainer, true);
+        form.checkboxClickHandler(document.querySelector(`.${CLEARFORM_CLASS}`), true);
         expect(disableInputsMock).toHaveBeenCalledWith(Array.from(document.querySelectorAll('input[type="text"]')));
       });
     });
@@ -94,7 +97,7 @@ describe('form', () => {
       test('calls enablesInputs', () => {
         form.enableInputs = jest.fn();
         const enableInputsMock = jest.spyOn(form, 'enableInputs');
-        form.checkboxClickHandler(clearContainer, false);
+        form.checkboxClickHandler(document.querySelector(`.${CLEARFORM_CLASS}`), false);
         expect(enableInputsMock).toHaveBeenCalledWith(Array.from(document.querySelectorAll('input[type="text"]')));
       });
     });


### PR DESCRIPTION
no ticket

meant to add this to last PR. just keeps the test more in sync with reality if the script being tested and the test share constants where sensible