### PR TITLE
[TEVA-2820] Remove prompt to create account from job alert email

### DIFF
--- a/app/mailers/jobseekers/alert_mailer.rb
+++ b/app/mailers/jobseekers/alert_mailer.rb
@@ -1,4 +1,6 @@
 class Jobseekers::AlertMailer < Jobseekers::BaseMailer
+  after_action :jobseeker
+
   self.delivery_job = AlertMailerJob
   helper DatesHelper
   helper VacanciesHelper

--- a/app/views/jobseekers/alert_mailer/alert.text.erb
+++ b/app/views/jobseekers/alert_mailer/alert.text.erb
@@ -36,14 +36,6 @@
 
 ---
 
-<%- unless jobseeker.present? %>
-  # <%= t(".create_account.heading") %>
-  <%= t(".create_account.intro", link_to: sign_up_link) %>
-
-  ---
-
-<% end %>
-
 <%= t("shared.footer", home_page_link: home_page_link) %>
 
 <%= t(".unsubscribe", unsubscribe_link: unsubscribe_link(subscription)) %>

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -73,10 +73,6 @@ en:
         alert_frequency: >-
           You have set to receive this job alert %{frequency} when any jobs matching your criteria are listed.
         closing_date: "Closing date: %{closing_date}"
-        create_account:
-          heading: Create a Teaching Vacancies account
-          intro: "%{link_to} to see all your job alerts in one place, and save the jobs you are interested in"
-          link: Create an account
         edit_alert: You can %{edit_link} here.
         edit_link_text: manage your alert
         feedback:

--- a/spec/mailers/jobseekers/alert_mailer_spec.rb
+++ b/spec/mailers/jobseekers/alert_mailer_spec.rb
@@ -156,20 +156,4 @@ RSpec.describe Jobseekers::AlertMailer do
       end
     end
   end
-
-  describe "create account section" do
-    context "when the subscription email matches a jobseeker account" do
-      let!(:jobseeker) { create(:jobseeker, email: email) }
-
-      it "does not display create account section" do
-        expect(body).not_to include(I18n.t("jobseekers.alert_mailer.alert.create_account.heading"))
-      end
-    end
-
-    context "when the subscription email does not match a jobseeker account" do
-      it "displays create account section" do
-        expect(body).to include(I18n.t("jobseekers.alert_mailer.alert.create_account.heading"))
-      end
-    end
-  end
 end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2820

## Changes in this PR:

- As jobseeker is no longer called in alert.text.erb, @jobseeker is not set and therefore not available when the email event is created. This caused some tests to fail and meant that the jobseeker id was not sent in the email event data. I apparently fixed this with a callback I added to the alert mailer. I don't know if this was the correct way to go about making the tests pass though...
