### PR TITLE
Truncate about_school field when indexing

### DIFF
--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -34,7 +34,7 @@ module Indexable
       end
 
       attribute :about_school do
-        strip_tags(about_school)
+        strip_tags(about_school)&.truncate(256)
       end
 
       attribute :school_visits do


### PR DESCRIPTION
Algolia can't cope with the size of the about school field that a school added to their vacancy.

I'm leaving it in, rather than deleting it completely, in case we decide in the future that we do want about_school to be a searchable attribute.

Bug ticket: https://dfedigital.atlassian.net/browse/TEVA-2891

Conversation: https://ukgovernmentdfe.slack.com/archives/CP987RP6J/p1626942008174300

Bug: https://rollbar.com/dfe/teacher-vacancies/items/5164/?utm_campaign=exp_repeat_item_message&utm_medium=slack&utm_source=rollbar-notification