### PR TITLE
 [TEVA-2751] Add column encryption with Lockbox: step 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ For local development, you can use a [dotenv-rails environment override](https:/
 ```
 DFE_SIGN_IN_REDIRECT_URL=https://localhost:3000/publishers/auth/dfe/callback
 DOMAIN=localhost:3000
+LOCKBOX_MASTER_KEY=0000000000000000000000000000000000000000000000000000000000000000
 ```
 
 ### Set up the database

--- a/app/jobs/send_feedback_to_big_query_job.rb
+++ b/app/jobs/send_feedback_to_big_query_job.rb
@@ -20,8 +20,8 @@ class SendFeedbackToBigQueryJob < ApplicationJob
             type: record.feedback_type,
             occurred_at: record.created_at,
             data: record.attributes_except_ciphertext.map do |key, value|
-              { key: key.to_s, value: formatted_value(value) }
-            end,
+                    { key: key.to_s, value: formatted_value(value) }
+                  end,
           }
         end,
       )

--- a/app/models/employment.rb
+++ b/app/models/employment.rb
@@ -1,4 +1,4 @@
 class Employment < ApplicationRecord
   belongs_to :job_application
-  encrypts :organisation, :job_title, :main_duties, migrating: true
+  encrypts :organisation, :job_title, :main_duties
 end

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -35,7 +35,7 @@ class JobApplication < ApplicationRecord
   encrypts :first_name, :last_name, :previous_names, :street_address, :city, :postcode, :phone_number,
            :teacher_reference_number, :national_insurance_number, :personal_statement, :support_needed_details,
            :close_relationships_details, :further_instructions, :rejection_reasons,
-           :gaps_in_employment_details, migrating: true
+           :gaps_in_employment_details
 
   belongs_to :jobseeker
   belongs_to :vacancy

--- a/app/models/jobseeker.rb
+++ b/app/models/jobseeker.rb
@@ -1,5 +1,5 @@
 class Jobseeker < ApplicationRecord
-  encrypts :last_sign_in_ip, :current_sign_in_ip, migrating: true
+  encrypts :last_sign_in_ip, :current_sign_in_ip
 
   devise :database_authenticatable, :registerable, :recoverable, :validatable,
          :confirmable, :lockable, :trackable, :timeoutable

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -9,7 +9,7 @@ class Publisher < ApplicationRecord
 
   accepts_nested_attributes_for :organisation_publishers
 
-  encrypts :family_name, :given_name, migrating: true
+  encrypts :family_name, :given_name
 
   devise :omniauthable, :timeoutable, omniauth_providers: %i[dfe]
   self.timeout_in = 60.minutes # Overrides default Devise configuration

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -4,7 +4,7 @@ class Qualification < ApplicationRecord
   belongs_to :job_application
   has_many :qualification_results, dependent: :delete_all, autosave: true
   accepts_nested_attributes_for :qualification_results
-  encrypts :finished_studying_details, migrating: true
+  encrypts :finished_studying_details
 
   SECONDARY_QUALIFICATIONS = %w[gcse as_level a_level other_secondary].freeze
 

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -1,5 +1,5 @@
 class Reference < ApplicationRecord
   belongs_to :job_application
 
-  encrypts :name, :job_title, :organisation, :email, :phone_number, migrating: true
+  encrypts :name, :job_title, :organisation, :email, :phone_number
 end

--- a/config/initializers/lockbox.rb
+++ b/config/initializers/lockbox.rb
@@ -1,0 +1,7 @@
+module Lockbox
+  class Encryptor
+    def decrypt(ciphertext, **options)
+      return "Lorem ipsum"
+    end
+  end
+end

--- a/config/initializers/lockbox.rb
+++ b/config/initializers/lockbox.rb
@@ -1,6 +1,16 @@
 module Lockbox
   class Encryptor
-    def decrypt(ciphertext, **options)
+    # Wrap original `decrypt` method with error handling so that we can display 'Lorem ipsum'
+    # for encrypted data in the staging environment while using a production data dump.
+
+    # Using this StackOverflow way in order to avoid duplicating the method implementation
+    # https://stackoverflow.com/a/4471202
+
+    old_decrypt = instance_method(:decrypt)
+
+    define_method(:decrypt) do |ciphertext, **options|
+      old_decrypt.bind_call(self, ciphertext, **options)
+    rescue DecryptionError
       return "Lorem ipsum"
     end
   end

--- a/db/migrate/20210722094927_drop_unencrypted_columns.rb
+++ b/db/migrate/20210722094927_drop_unencrypted_columns.rb
@@ -1,0 +1,32 @@
+class DropUnencryptedColumns < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :employments, :organisation
+    remove_column :employments, :job_title
+    remove_column :employments, :main_duties
+    remove_column :job_applications, :first_name
+    remove_column :job_applications, :last_name
+    remove_column :job_applications, :previous_names
+    remove_column :job_applications, :street_address
+    remove_column :job_applications, :city
+    remove_column :job_applications, :postcode
+    remove_column :job_applications, :phone_number
+    remove_column :job_applications, :teacher_reference_number
+    remove_column :job_applications, :national_insurance_number
+    remove_column :job_applications, :personal_statement
+    remove_column :job_applications, :support_needed_details
+    remove_column :job_applications, :close_relationships_details
+    remove_column :job_applications, :further_instructions
+    remove_column :job_applications, :rejection_reasons
+    remove_column :job_applications, :gaps_in_employment_details
+    remove_column :jobseekers, :last_sign_in_ip
+    remove_column :jobseekers, :current_sign_in_ip
+    remove_column :publishers, :family_name
+    remove_column :publishers, :given_name
+    remove_column :qualifications, :finished_studying_details
+    remove_column :references, :name
+    remove_column :references, :job_title
+    remove_column :references, :organisation
+    remove_column :references, :email
+    remove_column :references, :phone_number
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_21_135549) do
+ActiveRecord::Schema.define(version: 2021_07_22_094927) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -73,12 +73,9 @@ ActiveRecord::Schema.define(version: 2021_07_21_135549) do
   end
 
   create_table "employments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "organisation", default: "", null: false
-    t.string "job_title", default: "", null: false
     t.string "salary", default: "", null: false
     t.string "subjects", default: "", null: false
     t.string "current_role", default: "", null: false
-    t.text "main_duties", default: "", null: false
     t.date "started_on"
     t.date "ended_on"
     t.uuid "job_application_id", null: false
@@ -185,29 +182,14 @@ ActiveRecord::Schema.define(version: 2021_07_21_135549) do
     t.datetime "shortlisted_at"
     t.datetime "unsuccessful_at"
     t.datetime "withdrawn_at"
-    t.string "first_name", default: "", null: false
-    t.string "last_name", default: "", null: false
-    t.string "previous_names", default: "", null: false
-    t.string "street_address", default: "", null: false
-    t.string "city", default: "", null: false
-    t.string "postcode", default: "", null: false
-    t.string "phone_number", default: "", null: false
-    t.string "teacher_reference_number", default: "", null: false
-    t.string "national_insurance_number", default: "", null: false
     t.string "qualified_teacher_status", default: "", null: false
     t.string "qualified_teacher_status_year", default: "", null: false
     t.text "qualified_teacher_status_details", default: "", null: false
     t.string "statutory_induction_complete", default: "", null: false
-    t.text "personal_statement", default: "", null: false
     t.string "support_needed", default: "", null: false
-    t.text "support_needed_details", default: "", null: false
     t.string "close_relationships", default: "", null: false
-    t.text "close_relationships_details", default: "", null: false
     t.string "right_to_work_in_uk", default: "", null: false
-    t.text "further_instructions", default: "", null: false
-    t.text "rejection_reasons", default: "", null: false
     t.string "gaps_in_employment", default: "", null: false
-    t.string "gaps_in_employment_details", default: "", null: false
     t.string "disability", default: "", null: false
     t.string "gender", default: "", null: false
     t.string "gender_description", default: "", null: false
@@ -248,8 +230,6 @@ ActiveRecord::Schema.define(version: 2021_07_21_135549) do
     t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string "current_sign_in_ip"
-    t.string "last_sign_in_ip"
     t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
@@ -365,8 +345,6 @@ ActiveRecord::Schema.define(version: 2021_07_21_135549) do
     t.datetime "accepted_terms_at"
     t.string "email"
     t.datetime "last_activity_at"
-    t.string "family_name"
-    t.string "given_name"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
     t.text "family_name_ciphertext"
@@ -388,7 +366,6 @@ ActiveRecord::Schema.define(version: 2021_07_21_135549) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "category"
     t.boolean "finished_studying"
-    t.text "finished_studying_details", default: "", null: false
     t.string "grade", default: "", null: false
     t.string "institution", default: "", null: false
     t.string "name", default: "", null: false
@@ -399,12 +376,7 @@ ActiveRecord::Schema.define(version: 2021_07_21_135549) do
   end
 
   create_table "references", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "name", default: "", null: false
-    t.string "job_title", default: "", null: false
-    t.string "organisation", default: "", null: false
     t.string "relationship", default: "", null: false
-    t.string "email", default: "", null: false
-    t.string "phone_number", default: "", null: false
     t.uuid "job_application_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/scripts/sanitise.sql
+++ b/db/scripts/sanitise.sql
@@ -2,11 +2,6 @@ TRUNCATE TABLE alert_runs;
 TRUNCATE TABLE emergency_login_keys;
 TRUNCATE TABLE sessions;
 
-UPDATE employments
-       SET organisation='Example Organisation',
-           job_title='Example Job Title',
-           main_duties='Lorem ipsum dolor sit amet';
-
 UPDATE equal_opportunities_reports
        SET disability_no=0,
            disability_prefer_not_to_say=0,
@@ -47,22 +42,7 @@ UPDATE feedbacks
            visit_purpose_comment=NULL;
 
 UPDATE job_applications
-       SET first_name='Anonymous',
-           last_name='Anon',
-           previous_names='',
-           street_address='1 Example Street',
-           city='Anonymised City',
-           postcode='P05T C0DE',
-           phone_number='01234567890',
-           teacher_reference_number='1234567',
-           national_insurance_number='QQ 12 34 56 C',
-           personal_statement='Lorem ipsum dolor sit amet',
-           support_needed_details='',
-           close_relationships_details='',
-           further_instructions='',
-           rejection_reasons='',
-           gaps_in_employment_details='',
-           disability='prefer_not_to_say',
+       SET disability='prefer_not_to_say',
            gender='prefer_not_to_say',
            gender_description='',
            orientation='prefer_not_to_say',
@@ -76,26 +56,13 @@ UPDATE jobseekers
        SET email=concat('anonymised-jobseeker-',id,'@example.org'),
            encrypted_password='ABCDEFGH12345',
            reset_password_token=concat('anonymised-reset-password-token-',id),
-           current_sign_in_ip='8.8.8.8',
-           last_sign_in_ip='8.8.4.4',
            confirmation_token=concat('anonymised-confirmation-token-',id),
            unconfirmed_email='',
            unlock_token=concat('anonymised-unlock-token-',id)
        WHERE email NOT LIKE '%education.gov.uk';
 
 UPDATE publishers
-       SET email=concat('anonymised-publisher-',id,'@example.org'),
-           family_name='anon',
-           given_name='anon';
-
-UPDATE qualifications
-       SET finished_studying_details='';
-
-UPDATE "references"
-       SET name='Anonymous Anon',
-           job_title='Example Job Title',
-           email='anon@example.org',
-           phone_number='01234567890';
+       SET email=concat('anonymised-publisher-',id,'@example.org');
 
 UPDATE subscriptions
        SET email=concat('anonymised-subscription-',id,'@example.org');


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2751

## Changes in this PR:

Builds on #3762.

 - Drop unencrypted columns. These attributes are still available in Object.attributes.
 - Wrap Lockbox's decrypt method in an error catcher so that we will show 'Lorem ipsum' wherever decryption fails (instead of an error page).
 - 'Why is he overwriting a Lockbox method?' https://ukgovernmentdfe.slack.com/archives/G0127R0KXQF/p1626964378024900

