### PR TITLE
[TEVA-2885] Adapt behavior of navbar component

### DIFF
--- a/app/components/navbar_component.rb
+++ b/app/components/navbar_component.rb
@@ -1,6 +1,4 @@
 class NavbarComponent < GovukComponent::Base
-  delegate :active_link_class, to: :helpers
-
   def initialize(classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
   end
@@ -16,6 +14,14 @@ class NavbarComponent < GovukComponent::Base
   }
 
   private
+
+  def active_link_class(link_path)
+    if current_page?(link_path) || link_path == organisation_path && request.original_fullpath.include?("organisation/jobs")
+      return "govuk-header__navigation-item govuk-header__navigation-item--active"
+    end
+
+    "govuk-header__navigation-item"
+  end
 
   def default_classes
     %w[navbar-component]

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -1,10 +1,4 @@
 module LinkHelper
-  def active_link_class(link_path)
-    return "govuk-header__navigation-item govuk-header__navigation-item--active" if current_page?(link_path)
-
-    "govuk-header__navigation-item"
-  end
-
   def open_in_new_tab_link_to(text, href, **kwargs)
     govuk_link_to("#{text} (opens in new tab)", href, target: "_blank", rel: "noreferrer noopener", **kwargs)
   end


### PR DESCRIPTION
We wanted the 'Manage jobs' link to be styled as if active when using
the jobs dashboard; as this dashboard uses multiple urls, we need to
check if the current url includes a certain string that's common to the
urls.

<img width="360" alt="Screenshot 2021-07-22 at 17 27 40" src="https://user-images.githubusercontent.com/60350599/126674558-134a3846-d99a-4743-9020-c566fc77c902.png">


## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2885
