### PR TITLE
[TEVA-2921] Move COMMIT_SHA to bottom of Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,6 @@ RUN rm -rf node_modules log tmp yarn.lock && \
 FROM ruby:3.0.2-alpine AS production
 
 ARG PROD_PACKAGES
-ARG COMMIT_SHA
-ENV COMMIT_SHA=$COMMIT_SHA
-
 WORKDIR /app
 
 RUN apk update && apk add --no-cache $PROD_PACKAGES
@@ -51,6 +48,9 @@ COPY --from=builder /app /app
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 RUN echo export PATH=/usr/local/bundle/:/usr/local/bin/:$PATH > /root/.ashrc
 ENV ENV="/root/.ashrc"
+
+ARG COMMIT_SHA
+ENV COMMIT_SHA=$COMMIT_SHA
 
 EXPOSE 3000
 CMD bundle exec rails db:migrate && bundle exec rails s

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PROD_PACKAGES="libxml2 libxslt libpq tzdata nodejs shared-mime-info"
+ARG PROD_PACKAGES="libxml2 libxslt libpq tzdata shared-mime-info"
 
 FROM ruby:3.0.2-alpine AS builder
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,10 @@ ARG PROD_PACKAGES="libxml2 libxslt libpq tzdata nodejs shared-mime-info"
 
 FROM ruby:3.0.2-alpine AS builder
 
-ARG DEV_PACKAGES="gcc libc-dev make yarn postgresql-dev build-base libxml2-dev libxslt-dev"
-ARG PROD_PACKAGES
-
 WORKDIR /app
 
+ARG PROD_PACKAGES
+ENV DEV_PACKAGES="gcc libc-dev make yarn postgresql-dev build-base libxml2-dev libxslt-dev"
 RUN apk add --no-cache $PROD_PACKAGES $DEV_PACKAGES
 RUN echo "Europe/London" > /etc/timezone && \
         cp /usr/share/zoneinfo/Europe/London /etc/localtime
@@ -36,9 +35,9 @@ RUN rm -rf node_modules log tmp yarn.lock && \
 # this stage reduces the image size.
 FROM ruby:3.0.2-alpine AS production
 
-ARG PROD_PACKAGES
 WORKDIR /app
 
+ARG PROD_PACKAGES
 RUN apk update && apk add --no-cache $PROD_PACKAGES
 RUN echo "Europe/London" > /etc/timezone && \
         cp /usr/share/zoneinfo/Europe/London /etc/localtime


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2921

## Changes in this PR:

- Move the COMMIT_SHA ARG to the bottom of the Dockerfile to improve caching
- Remove nodejs from the list of prod packages

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
