### PR TITLE
[TEVA-2914] use govuk link compoenent for correct focus styles

### DIFF
--- a/app/components/dashboard_component/dashboard_component.scss
+++ b/app/components/dashboard_component/dashboard_component.scss
@@ -91,13 +91,11 @@
     &__link {
       @include govuk-font(19);
 
-      color: $govuk-link-colour;
       display: block;
       font-weight: bold;
       padding-bottom: govuk-spacing(3);
       padding-top: govuk-spacing(3);
       position: relative;
-      text-decoration: none;
 
       @include govuk-media-query ($until: desktop) {
         padding: govuk-spacing(2);
@@ -142,5 +140,13 @@
     .filters-applied-text {
       line-height: 2em;
     }
+  }
+}
+
+.dashboard-component .govuk-link {
+  text-decoration: none;
+
+  &:visited {
+    color: $govuk-link-colour;
   }
 }

--- a/app/components/jobseekers/account_survey_link_component.rb
+++ b/app/components/jobseekers/account_survey_link_component.rb
@@ -4,7 +4,7 @@ class Jobseekers::AccountSurveyLinkComponent < ViewComponent::Base
   end
 
   def link_to_survey
-    link_to(
+    govuk_link_to(
       t(".survey_link"),
       new_jobseekers_account_feedback_path(origin: @origin),
       id: "account-survey-link-sticky-gtm",

--- a/app/components/jobseekers/search_results/job_alerts_link_component/job_alerts_link_component.html.slim
+++ b/app/components/jobseekers/search_results/job_alerts_link_component/job_alerts_link_component.html.slim
@@ -2,4 +2,4 @@
   .job-alert-cta__fade
   .job-alert-cta__content class="govuk-heading-s govuk-!-font-weight-regular govuk-!-margin-0" id="job-alert-cta"
     .icon.icon--left.icon--alert-white
-      = t("subscriptions.link.help_text_html", link: link_to(t("subscriptions.link.text"), new_subscription_path(search_criteria: @vacancies_search.active_criteria, origin: @origin, coordinates_present: @vacancies_search.point_coordinates.present?), id: "job-alert-link-sticky-gtm"))
+      = t("subscriptions.link.help_text_html", link: govuk_link_to(t("subscriptions.link.text"), new_subscription_path(search_criteria: @vacancies_search.active_criteria, origin: @origin, coordinates_present: @vacancies_search.point_coordinates.present?), id: "job-alert-link-sticky-gtm"))

--- a/app/components/jobseekers/search_results/job_alerts_link_component/job_alerts_link_component.scss
+++ b/app/components/jobseekers/search_results/job_alerts_link_component/job_alerts_link_component.scss
@@ -24,6 +24,10 @@
 
     a {
       color: govuk-colour('white');
+
+      &:focus {
+        color: $govuk-focus-text-colour;
+      }
     }
 
     .alert-icon {

--- a/app/helpers/jobseekers/accounts_helper.rb
+++ b/app/helpers/jobseekers/accounts_helper.rb
@@ -1,5 +1,5 @@
 module Jobseekers::AccountsHelper
   def account_navigation_link(link_text, link_path)
-    link_to link_text, link_path, class: "dashboard-component-navigation__link", aria: { current: ("page" if current_page?(link_path)) }
+    govuk_link_to link_text, link_path, class: "dashboard-component-navigation__link", aria: { current: ("page" if current_page?(link_path)) }
   end
 end


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-2914

add focus styles for keyboard navigation by using govuk_link component instead of link component

## Screenshots of UI changes:

![Screenshot 2021-07-29 at 16 12 00](https://user-images.githubusercontent.com/1792451/127517853-96278015-33e2-480e-aaa7-192db95a84d8.png)
![Screenshot 2021-07-29 at 16 11 46](https://user-images.githubusercontent.com/1792451/127517858-804d781c-7cdc-436f-951a-017898711dba.png)
![Screenshot 2021-07-29 at 18 15 12](https://user-images.githubusercontent.com/1792451/127535895-190f31ab-bbc2-44df-93ce-b9be3e948a4f.png)



