### PR TITLE
Update README production data dump instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,10 +268,14 @@ Try [seeding the database](https://github.com/DFE-Digital/teaching-vacancies#see
 
 ### Getting production-like data for local development
 
-You can use conduit to create a dump of production data. See [this section](/documentation/hosting.md#backuprestore-govuk-paas-postgres-service-database) of the GovUK PaaS docs. Then you can load this into your local database:
+To get sanitised production-like data for local development, first log in to AWS with the ReadOnly role. To do so, follow the instructions here: [AWS Login](/documentation/aws-roles-and-cli-tools.md#log-in-to-the-aws-console-with-aws-vault).
+
+Once logged in, go to S3 >  530003481352-tv-db-backups > sanitised. Then click the checkbox next to the backup you want (the names of the backups will include dates) and click "Download".
+
+Then, unzip the file and load it into your local database like so:
 
 ```bash
-psql tvs_development < backup.sql
+  psql tvs_development < <path to unzipped .sql backup file>
 ```
 
 ### Integration between Jira and Github


### PR DESCRIPTION
After a conversation with Christian we realised that the instructions in the README for getting a production data dump needed updating (downloaded unsanitised db backup)

## Changes in this PR

- README now includes instructions to download a sanitised db backup
