### PR TITLE
Fix Flaky Spec

### DIFF
--- a/spec/helpers/job_application_helper_spec.rb
+++ b/spec/helpers/job_application_helper_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe JobApplicationHelper do
       let(:job_application) { create(:job_application, :status_withdrawn) }
 
       it "renders the applicant name" do
-        expect(subject).to include(job_application.name)
+        expect(subject).to include(CGI.escapeHTML(job_application.name))
       end
 
       it "does not render a link" do


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2913

## Changes in this PR:

- The test failed when Faker created a name with an apostrophe in it. As subject (the span element returned by the method) encoded the apostrophe, when this was compared with job_application.name, it failed. To fix this, I also encoded job_application.name.

## Comments

- I was unable to reproduce a failure in rspec ./spec/services/jobseekers/job_applications/quick_apply_spec.rb:43 so could not see what was making it flaky. Have mentioned this in tv_engineering and we've agreed to keep an eye on it and note the seed if it fails in the future.

