### PR TITLE
[TEVA-2751] Add column encryption with Lockbox: step B

### DIFF
--- a/app/models/employment.rb
+++ b/app/models/employment.rb
@@ -1,5 +1,9 @@
 class Employment < ApplicationRecord
   belongs_to :job_application
-  encrypts :organisation, :job_title, :main_duties, migrating: true
+  encrypts :organisation, :job_title, :main_duties
+
+  # remove this line after dropping unencrypted columns
+  self.ignored_columns = %w[organisation job_title main_duties]
+
   enum employment_type: { job: 0, break: 1 }
 end

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -35,7 +35,24 @@ class JobApplication < ApplicationRecord
   encrypts :first_name, :last_name, :previous_names, :street_address, :city, :postcode, :phone_number,
            :teacher_reference_number, :national_insurance_number, :personal_statement, :support_needed_details,
            :close_relationships_details, :further_instructions, :rejection_reasons,
-           :gaps_in_employment_details, migrating: true
+           :gaps_in_employment_details
+
+  # remove this line after dropping unencrypted columns
+  self.ignored_columns = %w[first_name
+                            last_name
+                            previous_names
+                            street_address
+                            city
+                            postcode
+                            phone_number
+                            teacher_reference_number
+                            national_insurance_number
+                            personal_statement
+                            support_needed_details
+                            close_relationships_details
+                            further_instructions
+                            rejection_reasons
+                            gaps_in_employment_details]
 
   belongs_to :jobseeker
   belongs_to :vacancy

--- a/app/models/jobseeker.rb
+++ b/app/models/jobseeker.rb
@@ -1,5 +1,8 @@
 class Jobseeker < ApplicationRecord
-  encrypts :last_sign_in_ip, :current_sign_in_ip, migrating: true
+  encrypts :last_sign_in_ip, :current_sign_in_ip
+
+  # remove this line after dropping unencrypted columns
+  self.ignored_columns = %w[last_sign_in_ip current_sign_in_ip]
 
   devise :database_authenticatable, :registerable, :recoverable, :validatable,
          :confirmable, :lockable, :trackable, :timeoutable

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -9,7 +9,10 @@ class Publisher < ApplicationRecord
 
   accepts_nested_attributes_for :organisation_publishers
 
-  encrypts :family_name, :given_name, migrating: true
+  encrypts :family_name, :given_name
+
+  # remove this line after dropping unencrypted columns
+  self.ignored_columns = %w[family_name given_name]
 
   devise :omniauthable, :timeoutable, omniauth_providers: %i[dfe]
   self.timeout_in = 60.minutes # Overrides default Devise configuration

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -4,7 +4,10 @@ class Qualification < ApplicationRecord
   belongs_to :job_application
   has_many :qualification_results, dependent: :delete_all, autosave: true
   accepts_nested_attributes_for :qualification_results
-  encrypts :finished_studying_details, migrating: true
+  encrypts :finished_studying_details
+
+  # remove this line after dropping unencrypted columns
+  self.ignored_columns = ["finished_studying_details"]
 
   SECONDARY_QUALIFICATIONS = %w[gcse as_level a_level other_secondary].freeze
 

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -1,5 +1,8 @@
 class Reference < ApplicationRecord
   belongs_to :job_application
 
-  encrypts :name, :job_title, :organisation, :email, :phone_number, migrating: true
+  encrypts :name, :job_title, :organisation, :email, :phone_number
+
+  # remove this line after dropping unencrypted columns
+  self.ignored_columns = %w[name job_title organisation email phone_number]
 end


### PR DESCRIPTION
This is a step in the Lockbox migration that should happen after the ciphertext columns have been added *and after the data has been backfilled* (by running a task added in https://github.com/DFE-Digital/teaching-vacancies/pull/3803).

## Don't merge me until you've run the abovementioned task
