### PR TITLE
[TEVA-2751] Add column encryption with Lockbox: step C

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ For local development, you can use a [dotenv-rails environment override](https:/
 ```
 DFE_SIGN_IN_REDIRECT_URL=https://localhost:3000/publishers/auth/dfe/callback
 DOMAIN=localhost:3000
+LOCKBOX_MASTER_KEY=0000000000000000000000000000000000000000000000000000000000000000
 ```
 
 ### Set up the database

--- a/app/jobs/send_feedback_to_big_query_job.rb
+++ b/app/jobs/send_feedback_to_big_query_job.rb
@@ -20,8 +20,8 @@ class SendFeedbackToBigQueryJob < ApplicationJob
             type: record.feedback_type,
             occurred_at: record.created_at,
             data: record.attributes_except_ciphertext.map do |key, value|
-              { key: key.to_s, value: formatted_value(value) }
-            end,
+                    { key: key.to_s, value: formatted_value(value) }
+                  end,
           }
         end,
       )

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -67,7 +67,9 @@ class JobApplication < ApplicationRecord
   scope :after_submission, -> { where(status: %w[submitted reviewed shortlisted unsuccessful withdrawn]) }
 
   def name
-    "#{first_name} #{last_name}"
+    # Insert string for staging environment so that on the job show page there is some text to make a
+    # link to the application. (Staging will have purged this from the database dump in sanitise.sql.)
+    Rails.configuration.app_role.staging? ? "Anonymous Anon" : "#{first_name} #{last_name}"
   end
 
   def email

--- a/db/migrate/20210722094927_drop_unencrypted_columns.rb
+++ b/db/migrate/20210722094927_drop_unencrypted_columns.rb
@@ -1,0 +1,32 @@
+class DropUnencryptedColumns < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :employments, :organisation
+    remove_column :employments, :job_title
+    remove_column :employments, :main_duties
+    remove_column :job_applications, :first_name
+    remove_column :job_applications, :last_name
+    remove_column :job_applications, :previous_names
+    remove_column :job_applications, :street_address
+    remove_column :job_applications, :city
+    remove_column :job_applications, :postcode
+    remove_column :job_applications, :phone_number
+    remove_column :job_applications, :teacher_reference_number
+    remove_column :job_applications, :national_insurance_number
+    remove_column :job_applications, :personal_statement
+    remove_column :job_applications, :support_needed_details
+    remove_column :job_applications, :close_relationships_details
+    remove_column :job_applications, :further_instructions
+    remove_column :job_applications, :rejection_reasons
+    remove_column :job_applications, :gaps_in_employment_details
+    remove_column :jobseekers, :last_sign_in_ip
+    remove_column :jobseekers, :current_sign_in_ip
+    remove_column :publishers, :family_name
+    remove_column :publishers, :given_name
+    remove_column :qualifications, :finished_studying_details
+    remove_column :references, :name
+    remove_column :references, :job_title
+    remove_column :references, :organisation
+    remove_column :references, :email
+    remove_column :references, :phone_number
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -75,12 +75,9 @@ ActiveRecord::Schema.define(version: 2021_08_06_161056) do
   end
 
   create_table "employments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "organisation", default: ""
-    t.string "job_title", default: ""
     t.string "salary", default: "", null: false
     t.string "subjects", default: "", null: false
     t.string "current_role", default: "", null: false
-    t.text "main_duties", default: ""
     t.date "started_on"
     t.date "ended_on"
     t.uuid "job_application_id", null: false
@@ -189,29 +186,14 @@ ActiveRecord::Schema.define(version: 2021_08_06_161056) do
     t.datetime "shortlisted_at"
     t.datetime "unsuccessful_at"
     t.datetime "withdrawn_at"
-    t.string "first_name", default: ""
-    t.string "last_name", default: ""
-    t.string "previous_names", default: ""
-    t.string "street_address", default: ""
-    t.string "city", default: ""
-    t.string "postcode", default: ""
-    t.string "phone_number", default: ""
-    t.string "teacher_reference_number", default: ""
-    t.string "national_insurance_number", default: ""
     t.string "qualified_teacher_status", default: "", null: false
     t.string "qualified_teacher_status_year", default: "", null: false
     t.text "qualified_teacher_status_details", default: "", null: false
     t.string "statutory_induction_complete", default: "", null: false
-    t.text "personal_statement", default: ""
     t.string "support_needed", default: "", null: false
-    t.text "support_needed_details", default: ""
     t.string "close_relationships", default: "", null: false
-    t.text "close_relationships_details", default: ""
     t.string "right_to_work_in_uk", default: "", null: false
-    t.text "further_instructions", default: ""
-    t.text "rejection_reasons", default: ""
     t.string "gaps_in_employment", default: "", null: false
-    t.string "gaps_in_employment_details", default: ""
     t.string "disability", default: "", null: false
     t.string "gender", default: "", null: false
     t.string "gender_description", default: "", null: false
@@ -252,8 +234,6 @@ ActiveRecord::Schema.define(version: 2021_08_06_161056) do
     t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string "current_sign_in_ip"
-    t.string "last_sign_in_ip"
     t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
@@ -369,8 +349,6 @@ ActiveRecord::Schema.define(version: 2021_08_06_161056) do
     t.datetime "accepted_terms_at"
     t.string "email"
     t.datetime "last_activity_at"
-    t.string "family_name"
-    t.string "given_name"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
     t.text "family_name_ciphertext"
@@ -392,7 +370,6 @@ ActiveRecord::Schema.define(version: 2021_08_06_161056) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "category"
     t.boolean "finished_studying"
-    t.text "finished_studying_details", default: ""
     t.string "grade", default: "", null: false
     t.string "institution", default: "", null: false
     t.string "name", default: "", null: false
@@ -403,12 +380,7 @@ ActiveRecord::Schema.define(version: 2021_08_06_161056) do
   end
 
   create_table "references", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "name", default: ""
-    t.string "job_title", default: ""
-    t.string "organisation", default: ""
     t.string "relationship", default: "", null: false
-    t.string "email", default: ""
-    t.string "phone_number", default: ""
     t.uuid "job_application_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/scripts/sanitise.sql
+++ b/db/scripts/sanitise.sql
@@ -2,21 +2,10 @@ TRUNCATE TABLE alert_runs;
 TRUNCATE TABLE emergency_login_keys;
 TRUNCATE TABLE sessions;
 
--- Columns encrypted with lockbox should be set to values that can be decrypted by the target environment.
--- These values are encrypted with the staging lockbox master key.
--- Change them if you are using this script for a different environment, as the key will be different.
--- There are multiple values in order to pass the different validations on each attribute.
-SET lorem_string_ciphertext = 'London'
-SET lorem_phone_number_ciphertext
-SET lorem_email_ciphertext
-SET lorem_teacher_reference_number_ciphertext
-SET lorem_national_insurance_number_ciphertext
-SET empty_string_ciphertext
-
 UPDATE employments
-       SET organisation='Example Organisation',
-           job_title='Example Job Title',
-           main_duties='Lorem ipsum dolor sit amet';
+       SET organisation_ciphertext='',
+           job_title_ciphertext='',
+           main_duties_ciphertext='';
 
 UPDATE equal_opportunities_reports
        SET disability_no=0,
@@ -53,26 +42,26 @@ UPDATE equal_opportunities_reports
 
 UPDATE feedbacks
        SET comment=NULL,
-           email=concat('anonymised-feedback-',id,'@example.org'),  -- encrypt. doesn't need id
+           email=concat('anonymised-feedback-',id,'@example.org'),
            other_unsubscribe_reason_comment=NULL,
            visit_purpose_comment=NULL;
 
 UPDATE job_applications
-       SET first_name='Anonymous', -- encrypt
-           last_name='Anon', -- encrypt
-           previous_names='', -- encrypt
-           street_address='1 Example Street', -- encrypt
-           city='Anonymised City', -- encrypt
-           postcode='P05T C0DE', -- encrypt
-           phone_number='01234567890',  -- encrypt
-           teacher_reference_number='1234567',  -- encrypt
-           national_insurance_number='QQ 12 34 56 C', -- encrypt
-           personal_statement='Lorem ipsum dolor sit amet', -- encrypt
-           support_needed_details='', -- encrypt
-           close_relationships_details='', -- encrypt
-           further_instructions='', -- encrypt
-           rejection_reasons='', -- encrypt
-           gaps_in_employment_details='', -- encrypt
+       SET first_name_ciphertext='',
+           last_name_ciphertext='',
+           previous_names_ciphertext='',
+           street_address_ciphertext='',
+           city_ciphertext='',
+           postcode_ciphertext='',
+           phone_number_ciphertext='',
+           teacher_reference_number_ciphertext='',
+           national_insurance_number_ciphertext='',
+           personal_statement_ciphertext='',
+           support_needed_details_ciphertext='',
+           close_relationships_details_ciphertext='',
+           further_instructions_ciphertext='',
+           rejection_reasons_ciphertext='',
+           gaps_in_employment_details_ciphertext='',
            disability='prefer_not_to_say',
            gender='prefer_not_to_say',
            gender_description='',
@@ -84,30 +73,29 @@ UPDATE job_applications
            religion_description='';
 
 UPDATE jobseekers
-       SET email=concat('anonymised-jobseeker-',id,'@example.org'), -- encrypt, and account for email LIKE '%education'
+       SET email=concat('anonymised-jobseeker-',id,'@example.org'),
            encrypted_password='ABCDEFGH12345',
            reset_password_token=concat('anonymised-reset-password-token-',id),
-           current_sign_in_ip='8.8.8.8',
-           last_sign_in_ip='8.8.4.4',
+           current_sign_in_ip_ciphertext='',
+           last_sign_in_ip_ciphertext='',
            confirmation_token=concat('anonymised-confirmation-token-',id),
-           unconfirmed_email='', -- encrypt
+           unconfirmed_email='',
            unlock_token=concat('anonymised-unlock-token-',id)
        WHERE email NOT LIKE '%education.gov.uk';
 
 UPDATE publishers
-       SET email=concat('anonymised-publisher-',id,'@example.org'), -- encrypt. no need for unique
-           family_name='anon', -- encrypt
-           given_name='anon'; -- encrypt
-           oid=;  -- encrypt (and add to sanitise.sql) (must match the original record)
+       SET email=concat('anonymised-publisher-',id,'@example.org'),
+           family_name_ciphertext='',
+           given_name_ciphertext='';
 
 UPDATE qualifications
-       SET finished_studying_details='';
+       SET finished_studying_details_ciphertext='';
 
 UPDATE "references"
-       SET name='Anonymous Anon',
-           job_title='Example Job Title',
-           email='anon@example.org',
-           phone_number='01234567890';
+       SET name_ciphertext='',
+           job_title_ciphertext='',
+           email_ciphertext='',
+           phone_number_ciphertext='';
 
 UPDATE subscriptions
        SET email=concat('anonymised-subscription-',id,'@example.org');


### PR DESCRIPTION
- Drop unencrypted columns. These attributes are still available in Object.attributes (e.g. `jobseeker.attributes`)

- Add lockbox 'master key' for development to .env.local
 
- Update sanitise.sql
Given that different environments use different column
encryption keys for Lockbox, we can't hard-code values other
than null or empty string for ciphertext columns when
writing a script that could be used in any environment.