### PR TITLE
Add expanded versions of acronyms

### DIFF
--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -542,7 +542,7 @@ en:
         job_roles_options:
           teacher: Teacher
           leadership: Leadership
-          sen_specialist: SEN specialist
+          sen_specialist: Special educational needs (SEN) specialist
           nqt_suitable: Suitable for NQTs
           nqt_suitable_hidden_prefix: Only show results
         job_title: Job title

--- a/config/locales/landing_pages.yml
+++ b/config/locales/landing_pages.yml
@@ -9,7 +9,7 @@ en:
           Find NQT jobs at schools in England. Teaching Vacancies is a free job-listing service from the Department
           for Education.
         sen_specialist: >-
-          Find SEN specialist and SENCO jobs in England. Teaching Vacancies is a free job-listing service from the
+          Find special educational needs (SEN) specialist and SENCO jobs in England. Teaching Vacancies is a free job-listing service from the
           Department for Education.
         teacher: >-
           Find teaching jobs at schools and trusts in England. Teaching Vacancies is a free job-listing service from


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2917

## Comments

- The only use of the acronym QTS, as far as I could see, were on the professional status step of the job application form. The first instance of this acronym includes the 'expanded version', so no need to change them. There are some error messages that can be displayed on that page with the acronym in though, would the first of these be considered the first instance of the acronym?