### PR TITLE
Convert bullet point symbols in job listing details to li tags

### DIFF
--- a/spec/presenters/vacancy_presenter_spec.rb
+++ b/spec/presenters/vacancy_presenter_spec.rb
@@ -30,6 +30,35 @@ RSpec.describe VacancyPresenter do
 
       expect(presenter.job_advert).to eq("<p> call();Sanitized content</p>")
     end
+
+    it "transforms badly formatted inline `•` symbols into validly formatted <li> tags" do
+      vacancy = build(:vacancy, job_advert:
+        "Required skills: \n\n• Skill • Competency \n" \
+        "This is a paragraph that's not part of the bullet pointy bit. \n" \
+        "And this is going to have some more bullet points... \n" \
+        "• Interpersonal skills • Wonderfulness • Skill three \n" \
+        "There you go. No more bullet points.")
+      presenter = VacancyPresenter.new(vacancy)
+
+      expect(presenter.job_advert).to eq(
+        "<p>Required skills: </p>\n\n" \
+        "<p>" \
+          "<ul>\n<br />" \
+            "<li> Skill </li>\n<br />" \
+            "<li> Competency </li>\n<br />" \
+          "</ul>\n" \
+          "<br />This is a paragraph that's not part of the bullet pointy bit. \n" \
+          "<br />And this is going to have some more bullet points... \n<br />" \
+          "<ul>\n" \
+            "<br /><li> Interpersonal skills </li>\n" \
+            "<br /><li> Wonderfulness </li>\n" \
+            "<br /><li> Skill three </li>\n" \
+            "<br />" \
+          "</ul>\n" \
+        "<br />There you go. No more bullet points." \
+        "</p>",
+      )
+    end
   end
 
   describe "#about_school" do


### PR DESCRIPTION
No ticket.

This is to solve the problem where (particularly) job adverts contain '•' but do not contain corresponding newlines, resulting in inline bullets.

## Before (from https://teaching-vacancies.service.gov.uk/jobs/estates-and-facilities-manager)

<img width="809" alt="Screenshot 2021-08-03 at 14 12 14" src="https://user-images.githubusercontent.com/60350599/128021348-5731b9fd-373e-4801-9e2a-81e806b71880.png">

## After

<img width="742" alt="Screenshot 2021-08-03 at 14 11 12" src="https://user-images.githubusercontent.com/60350599/128021178-f90b3c18-e561-4252-9903-d3fa678f0a8c.png">
<img width="742" alt="Screenshot 2021-08-03 at 14 11 17" src="https://user-images.githubusercontent.com/60350599/128021183-22328474-26c8-40eb-9409-265c191cae66.png">

## Join the conversation

https://ukgovernmentdfe.slack.com/archives/CG9A8H1HP/p1627990485014100

