### PR TITLE
change location finder error text to white (on blue bg)

### DIFF
--- a/app/frontend/src/components/locationFinder/locationFinder.js
+++ b/app/frontend/src/components/locationFinder/locationFinder.js
@@ -41,11 +41,10 @@ export const showLocationLink = (container) => {
 };
 
 export const showErrorMessage = (link) => {
-  if (!document.querySelector('.js-location-finder__link .govuk-error-message')) {
+  if (!document.getElementById('js-location-finder__error')) {
     const errorMessage = document.createElement('div');
     errorMessage.setAttribute('role', 'alert');
     errorMessage.id = 'js-location-finder__error';
-    errorMessage.classList.add('govuk-error-message');
     errorMessage.classList.add('govuk-!-margin-top-2');
     errorMessage.innerHTML = ERROR_MESSAGE;
     link.after(errorMessage);
@@ -61,6 +60,7 @@ export const removeErrorMessage = () => {
 export const onSuccess = (postcode, element) => {
   element.value = postcode;
   locationFinder.stopLoading(containerEl, inputEl);
+  logger.log('location finder usage: success');
 };
 
 export const onFailure = () => {


### PR DESCRIPTION
no ticket but verified should do this with @jesseyuen 

also taking opportunity to log usage success events to provide some kind of stat of how much this feature is used

before (not great for colour blindness)

![Screenshot 2021-08-05 at 15 17 55](https://user-images.githubusercontent.com/1792451/128365808-a29b45bf-ffc0-403b-97f9-97e6449757b7.png)

After

![Screenshot 2021-08-05 at 14 15 16](https://user-images.githubusercontent.com/1792451/128365610-987d0123-cc0b-416c-b859-9e5928b94ffb.png)
