### PR TITLE
[TEVA-2981] Fix bug caused by nil expires_at

### DIFF
--- a/app/views/publishers/vacancies/job_applications/_banner.html.slim
+++ b/app/views/publishers/vacancies/job_applications/_banner.html.slim
@@ -16,31 +16,31 @@
 
   - if vacancy.enable_job_applications?
     .govuk-grid-row.job-applications-summary
-      .govuk-grid-column-one-quarter
-        .vacancy-deadline class=("vacancy-deadline--passed" if vacancy.expires_at.past?)
-          h4.govuk-body.govuk-caption-s class="govuk-!-font-weight-bold govuk-!-margin-bottom-0"
-            - if vacancy.expires_at.past?
-              = t(".deadline.after")
-            - elsif vacancy.pending?
-              = t(".deadline.scheduled")
-            - else
-              = t(".deadline.before")
-          span.govuk-body = format_time_to_datetime_at(vacancy.expires_at)
+      - if vacancy.expires_at.present?
+        .govuk-grid-column-one-quarter
+          .vacancy-deadline class=("vacancy-deadline--passed" if vacancy.expires_at.past?)
+            h4.govuk-body.govuk-caption-s class="govuk-!-font-weight-bold govuk-!-margin-bottom-0"
+              - if vacancy.expires_at.past?
+                = t(".deadline.after")
+              - else
+                = t(".deadline.before")
+            span.govuk-body = format_time_to_datetime_at(vacancy.expires_at)
 
-      .govuk-grid-column-one-quarter
-        .application-count.govuk-tag class="govuk-tag--#{status_tag_colour(:submitted)}"
-          .govuk-heading-l = job_applications.submitted.count
-          h3.govuk-caption-s = t(".submitted", count: job_applications.submitted.count)
+      - unless vacancy.draft?
+        .govuk-grid-column-one-quarter
+          .application-count.govuk-tag class="govuk-tag--#{status_tag_colour(:submitted)}"
+            .govuk-heading-l = job_applications.submitted.count
+            h3.govuk-caption-s = t(".submitted", count: job_applications.submitted.count)
 
-      .govuk-grid-column-one-quarter
-        .application-count.govuk-tag class="govuk-tag--#{status_tag_colour(:shortlisted)}"
-          .govuk-heading-l = job_applications.shortlisted.count
-          h3.govuk-caption-s = t(".shortlisted", count: job_applications.shortlisted.count)
+        .govuk-grid-column-one-quarter
+          .application-count.govuk-tag class="govuk-tag--#{status_tag_colour(:shortlisted)}"
+            .govuk-heading-l = job_applications.shortlisted.count
+            h3.govuk-caption-s = t(".shortlisted", count: job_applications.shortlisted.count)
 
-      .govuk-grid-column-one-quarter
-        .application-count.govuk-tag class="govuk-tag--#{status_tag_colour(:unsuccessful)}"
-          .govuk-heading-l = job_applications.unsuccessful.count
-          h3.govuk-caption-s = t(".rejected", count: job_applications.unsuccessful.count)
+        .govuk-grid-column-one-quarter
+          .application-count.govuk-tag class="govuk-tag--#{status_tag_colour(:unsuccessful)}"
+            .govuk-heading-l = job_applications.unsuccessful.count
+            h3.govuk-caption-s = t(".rejected", count: job_applications.unsuccessful.count)
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -209,7 +209,6 @@ en:
           deadline:
             after: Deadline passed
             before: Application deadline
-            scheduled: Date to be listed
           rejected:
             one: Rejected application
             other: Rejected applications

--- a/spec/system/publishers_can_save_and_return_later_spec.rb
+++ b/spec/system/publishers_can_save_and_return_later_spec.rb
@@ -239,4 +239,37 @@ RSpec.describe "Publishers can save and return later" do
       end
     end
   end
+
+  describe "can temporarily omit a step by saving at an earlier step and returning on a later step" do
+    scenario "can edit the job details step and then the applying for this job step" do
+      visit organisation_path
+      click_on I18n.t("buttons.create_job")
+
+      fill_in "publishers_job_listing_job_details_form[job_title]", with: @vacancy.job_title
+      click_on I18n.t("buttons.save_and_return_later")
+      created_vacancy = Vacancy.find_by(job_title: @vacancy.job_title)
+
+      expect(page.current_path).to eq(jobs_with_type_organisation_path("draft"))
+
+      click_on @vacancy.job_title
+      within("#applying_for_the_job") do
+        click_on I18n.t("buttons.change")
+      end
+
+      expect(page.current_path).to eq(organisation_job_build_path(created_vacancy.id, :applying_for_the_job))
+      fill_in "publishers_job_listing_applying_for_the_job_form[application_link]", with: "some link"
+      click_on I18n.t("buttons.save_and_return_later")
+
+      expect(page.current_path).to eq(jobs_with_type_organisation_path("draft"))
+      expect(page.body).to include(I18n.t("messages.jobs.draft_saved_html", job_title: @vacancy.job_title))
+
+      click_on @vacancy.job_title
+      within("#applying_for_the_job") do
+        click_on I18n.t("buttons.change")
+      end
+
+      expect(page.current_path).to eq(organisation_job_build_path(created_vacancy.id, :applying_for_the_job))
+      expect(find_field("publishers_job_listing_applying_for_the_job_form[application_link]").value).to eq("some link")
+    end
+  end
 end


### PR DESCRIPTION
This bug occurred when a hiring staff/publisher filled out 'applying for the job' and
enabled applications through TV, without first having set an expires_at time.

- Added regression test
- Stopped showing number of applications of each type when vacancy is in draft state
- Corrected a translation - we had been labelling expires_at with 'Date to be listed',
which is not what expires_at means.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2981

## Screenshots of UI changes:

### Before

<img width="1006" alt="Screenshot 2021-08-05 at 15 39 26" src="https://user-images.githubusercontent.com/60350599/128369050-7f638199-92c7-4548-a5c4-c1ffaa24cae1.png">


### After (for a draft job and then for a published job)

<img width="1006" alt="Screenshot 2021-08-05 at 15 39 42" src="https://user-images.githubusercontent.com/60350599/128369088-7e025bbf-0f7e-4b31-9d56-e96fe51cb501.png">
<img width="1219" alt="Screenshot 2021-08-05 at 15 40 13" src="https://user-images.githubusercontent.com/60350599/128369171-d081c23d-5796-42cf-a339-057c6478b198.png">
