### PR TITLE
Migrate Vacancy.completed_step to an array (migration step 1)

### DIFF
--- a/app/controllers/concerns/publishers/wizardable.rb
+++ b/app/controllers/concerns/publishers/wizardable.rb
@@ -11,7 +11,6 @@ module Publishers::Wizardable
       job_details: { number: 2, title: I18n.t("jobs.job_details") },
       pay_package: { number: 3, title: I18n.t("jobs.pay_package") },
       important_dates: { number: 4, title: I18n.t("jobs.important_dates") },
-      supporting_documents: { number: 5, title: I18n.t("jobs.supporting_documents") },
       documents: { number: 5, title: I18n.t("jobs.supporting_documents") },
       applying_for_the_job: { number: 6, title: I18n.t("jobs.applying_for_the_job") },
       job_summary: { number: 7, title: I18n.t("jobs.job_summary") },
@@ -53,7 +52,8 @@ module Publishers::Wizardable
       job_location, school_name: current_organisation.name, schools_count: vacancy.organisation_ids.count
     )
     attributes_to_merge = {
-      completed_step: steps_config[step][:number],
+      completed_step: job_location == "central_office" ? nil : completed_step,
+      completed_steps: completed_steps,
       readable_job_location: job_location == "central_office" ? readable_job_location : nil,
       organisation_ids: job_location == "central_office" ? current_organisation.id : nil,
     }
@@ -71,9 +71,15 @@ module Publishers::Wizardable
                       params[:publishers_job_listing_schools_form][:organisation_ids].count
                     end
     readable_job_location = readable_job_location(job_location, school_name: school_name, schools_count: schools_count)
+    attributes_to_merge = {
+      completed_steps: completed_steps,
+      completed_step: completed_step,
+      job_location: job_location,
+      readable_job_location: readable_job_location,
+    }
     params.require(:publishers_job_listing_schools_form)
           .permit(:organisation_ids, organisation_ids: [])
-          .merge(completed_step: steps_config[step][:number], job_location: job_location, readable_job_location: readable_job_location)
+          .merge(attributes_to_merge.compact)
   end
 
   def job_details_params(params)
@@ -83,7 +89,8 @@ module Publishers::Wizardable
       params[:publishers_job_listing_job_details_form][:job_roles] |= [:nqt_suitable]
     end
     attributes_to_merge = {
-      completed_step: steps_config[step][:number],
+      completed_steps: completed_steps,
+      completed_step: completed_step,
       job_location: job_location,
       readable_job_location: readable_job_location,
       organisation_ids: vacancy.organisation_ids.blank? ? current_organisation.id : nil,
@@ -96,23 +103,36 @@ module Publishers::Wizardable
 
   def pay_package_params(params)
     params.require(:publishers_job_listing_pay_package_form)
-          .permit(:salary, :benefits).merge(completed_step: steps_config[step][:number])
+          .permit(:salary, :benefits)
+          .merge({ completed_steps: completed_steps, completed_step: completed_step })
   end
 
   def important_dates_params(params)
     params.require(:publishers_job_listing_important_dates_form)
           .permit(:starts_asap, :starts_on, :publish_on, :publish_on_day, :expires_at, :expiry_time)
-          .merge(completed_step: steps_config[step][:number])
+          .merge({ completed_steps: completed_steps, completed_step: completed_step })
   end
 
   def applying_for_the_job_params(params)
     params.require(:publishers_job_listing_applying_for_the_job_form)
           .permit(:application_link, :enable_job_applications, :contact_email, :contact_number, :personal_statement_guidance, :school_visits, :how_to_apply)
-          .merge(completed_step: steps_config[step][:number], current_organisation: current_organisation)
+          .merge({ completed_steps: completed_steps, completed_step: completed_step, current_organisation: current_organisation })
   end
 
   def job_summary_params(params)
     params.require(:publishers_job_listing_job_summary_form)
-          .permit(:job_advert, :about_school).merge(completed_step: steps_config[step][:number])
+          .permit(:job_advert, :about_school).merge({ completed_steps: completed_steps, completed_step: completed_step })
+  end
+
+  private
+
+  def completed_steps
+    defined_step = defined?(step) ? step : :review
+    completed_step = params[:commit] == t("buttons.save_and_return_later") ? nil : defined_step.to_s
+    (vacancy.completed_steps | [completed_step]).compact
+  end
+
+  def completed_step
+    params[:commit] == t("buttons.save_and_return_later") ? nil : steps_config[step][:number]
   end
 end

--- a/app/controllers/publishers/vacancies/copy_controller.rb
+++ b/app/controllers/publishers/vacancies/copy_controller.rb
@@ -26,6 +26,7 @@ class Publishers::Vacancies::CopyController < Publishers::Vacancies::BaseControl
   def copy_form_params
     params.require(:publishers_job_listing_copy_vacancy_form)
           .permit(:job_title, :publish_on, :publish_on_day, :expires_at, :expiry_time, :starts_on, :starts_asap)
+          .merge(completed_steps: [])
   end
 
   def set_up_copy_form

--- a/app/controllers/publishers/vacancies/documents_controller.rb
+++ b/app/controllers/publishers/vacancies/documents_controller.rb
@@ -57,10 +57,10 @@ class Publishers::Vacancies::DocumentsController < Publishers::Vacancies::BaseCo
     if params[:commit] == t("buttons.save_and_return_later")
       redirect_saved_draft_with_message
     elsif params[:commit] == t("buttons.update_job")
-      vacancy.update(completed_step: steps_config[step][:number])
+      vacancy.update(completed_step: steps_config[step][:number], completed_steps: completed_steps)
       redirect_updated_job_with_message
     elsif params[:commit] == t("buttons.continue")
-      vacancy.update(completed_step: steps_config[step][:number])
+      vacancy.update(completed_step: steps_config[step][:number], completed_steps: completed_steps)
       redirect_to organisation_job_build_path(vacancy.id, :applying_for_the_job)
     end
   end

--- a/app/controllers/publishers/vacancies_controller.rb
+++ b/app/controllers/publishers/vacancies_controller.rb
@@ -29,7 +29,7 @@ class Publishers::VacanciesController < Publishers::Vacancies::BaseController
 
     if all_steps_valid?
       session[:current_step] = :review
-      set_completed_step
+      vacancy.update(completed_step: current_step_number, completed_steps: completed_steps)
     else
       session[:current_step] = :edit_incomplete
       redirect_to_incomplete_step
@@ -75,10 +75,6 @@ class Publishers::VacanciesController < Publishers::Vacancies::BaseController
     return redirect_to organisation_job_build_path(vacancy.id, :documents) unless vacancy.completed_step >= steps_config[:documents][:number]
     return redirect_to organisation_job_build_path(vacancy.id, :applying_for_the_job) unless step_valid?(:applying_for_the_job)
     return redirect_to organisation_job_build_path(vacancy.id, :job_summary) unless step_valid?(:job_summary)
-  end
-
-  def set_completed_step
-    vacancy.update(completed_step: current_step_number)
   end
 
   def validate_all_steps

--- a/app/form_models/publishers/job_listing/important_dates_form.rb
+++ b/app/form_models/publishers/job_listing/important_dates_form.rb
@@ -31,6 +31,7 @@ class Publishers::JobListing::ImportantDatesForm < Publishers::JobListing::Vacan
       starts_on: (starts_on unless starts_asap == "true"),
       starts_asap: starts_asap,
       completed_step: completed_step,
+      completed_steps: completed_steps,
     }.delete_if { |k, v| k == :completed_step && v.blank? }
   end
 

--- a/app/form_models/publishers/job_listing/job_location_form.rb
+++ b/app/form_models/publishers/job_listing/job_location_form.rb
@@ -6,6 +6,7 @@ class Publishers::JobListing::JobLocationForm < Publishers::JobListing::VacancyF
   def params_to_save
     {
       completed_step: params[:completed_step],
+      completed_steps: params[:completed_steps],
       job_location: params[:job_location] == "central_office" ? params[:job_location] : nil,
       readable_job_location: params[:readable_job_location],
       organisation_ids: params[:organisation_ids],

--- a/app/form_models/publishers/job_listing/vacancy_form.rb
+++ b/app/form_models/publishers/job_listing/vacancy_form.rb
@@ -2,7 +2,7 @@ class Publishers::JobListing::VacancyForm
   include ActiveModel::Model
   include ActiveModel::Validations::Callbacks
 
-  attr_accessor :params, :vacancy, :completed_step, :current_organisation
+  attr_accessor :params, :vacancy, :completed_step, :completed_steps, :current_organisation
 
   def initialize(params = {}, vacancy = nil)
     @params = params

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -87,18 +87,17 @@ module VacanciesHelper
     t("helpers.hint.publishers_job_listing_applying_for_the_job_form.#{organisation}_visits")
   end
 
-  def vacancy_step_completed?(vacancy, step_number)
-    return false if vacancy.completed_step.nil?
+  def vacancy_step_completed?(vacancy, step)
+    return false if vacancy.completed_step.nil? || step == :review
 
-    step_number <= vacancy.completed_step
+    steps_config[step][:number] <= steps_config.find { |_step, details|
+      details[:number] == vacancy.completed_step
+    }.second[:number]
   end
 
-  def steps_to_display(steps, steps_adjust)
-    steps_to_remove = current_organisation.is_a?(School) ? %i[supporting_documents review] : %i[supporting_documents schools review]
-
-    steps.transform_values { |step_details| step_details[:number] - steps_adjust }
-         .except!(*steps_to_remove)
-         .reject { |_, step_number| step_number.zero? }
+  def steps_to_display(steps)
+    steps_to_skip = current_organisation.is_a?(School) ? %i[job_location schools review] : %i[schools review]
+    steps.except(*steps_to_skip).keys
   end
 
   def total_steps(steps)

--- a/app/views/publishers/vacancies/build/_steps.html.slim
+++ b/app/views/publishers/vacancies/build/_steps.html.slim
@@ -1,4 +1,4 @@
 = render StepsComponent.new title: t("publishers.vacancies.review.steps"), classes: "govuk-!-margin-top-6" do |component|
-  - steps_to_display(steps_config, steps_adjust).each do |vacancy_step, step_number|
-    - component.step(label: t("publishers.vacancies.build.#{vacancy_step}.step_title"), current: (vacancy_step == step_current), completed: vacancy_step_completed?(vacancy, step_number))
+  - steps_to_display(steps_config).each do |vacancy_step|
+    - component.step(label: t("publishers.vacancies.build.#{vacancy_step}.step_title"), current: (vacancy_step == step_current), completed: vacancy_step_completed?(vacancy, vacancy_step))
   - component.step(label: t("publishers.vacancies.review.heading"), current: step_current == :review, completed: false)

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -313,3 +313,4 @@ shared:
     - personal_statement_guidance
     - end_listing_reason
     - candidate_hired_from
+    - completed_steps

--- a/db/migrate/20210804155509_add_completed_steps_to_vacancy.rb
+++ b/db/migrate/20210804155509_add_completed_steps_to_vacancy.rb
@@ -1,0 +1,5 @@
+class AddCompletedStepsToVacancy < ActiveRecord::Migration[6.1]
+  def change
+    add_column :vacancies, :completed_steps, :string, array: true, default: [], null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_21_145619) do
+ActiveRecord::Schema.define(version: 2021_08_04_155509) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -445,9 +445,9 @@ ActiveRecord::Schema.define(version: 2021_07_21_145619) do
     t.datetime "stats_updated_at"
     t.uuid "publisher_id"
     t.datetime "expires_at"
+    t.string "legacy_job_roles", array: true
     t.string "salary"
     t.integer "completed_step"
-    t.string "legacy_job_roles", array: true
     t.text "about_school"
     t.string "subjects", array: true
     t.text "school_visits"
@@ -466,6 +466,7 @@ ActiveRecord::Schema.define(version: 2021_07_21_145619) do
     t.integer "end_listing_reason"
     t.integer "candidate_hired_from"
     t.boolean "enable_job_applications"
+    t.string "completed_steps", default: [], null: false, array: true
     t.index ["expires_at"], name: "index_vacancies_on_expires_at"
     t.index ["initially_indexed"], name: "index_vacancies_on_initially_indexed"
     t.index ["publisher_id"], name: "index_vacancies_on_publisher_id"

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -46,3 +46,27 @@ namespace :ons do
     %i[regions counties cities].each { |api_location_type| ImportPolygons.new(api_location_type: api_location_type).call }
   end
 end
+
+namespace :vacancy_completed_steps do
+  desc "Migrate completed step data from integer to array of strings"
+  task migrate: :environment do
+    steps_config = {
+      job_location: "1",
+      schools: "1",
+      job_details: "2",
+      pay_package: "3",
+      important_dates: "4",
+      documents: "5",
+      applying_for_the_job: "6",
+      job_summary: "7",
+      review: "8",
+    }.freeze
+
+    Vacancy.includes(organisation_vacancies: :organisation).find_each(batch_size: 100) do |vacancy|
+      completed_steps = vacancy.completed_steps | steps_config.select { |_step, number|
+        number.to_i == vacancy.completed_step
+      }.keys.map(&:to_s)
+      vacancy.update_column(:completed_steps, completed_steps)
+    end
+  end
+end

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -7,6 +7,9 @@ FactoryBot.define do
     enable_job_applications { true }
     benefits { Faker::Lorem.paragraph(sentence_count: 4) }
     completed_step { 7 }
+    completed_steps do
+      %w[job_location schools job_details pay_package important_dates documents applying_for_the_job job_summary]
+    end
     contact_email { Faker::Internet.email }
     contact_number { "01234 123456" }
     contract_type { :fixed_term }


### PR DESCRIPTION
We need to make this attribute more accurate before introducing upcoming
changes which add further steps to the journey. There are a few ways that
the current setup doesn't work for us. In the current setup we save the
last step completed as an integer (not an enum).

1) Some steps have two parts. Job location step and schools step are both part of step 1, at the moment. So we can’t tell which of those is completed, currently, as we set completed_step to 1 when someone submits either of those forms.

2) We are about to add two new steps to the process, putting all the numbers out of kilter. So if someone has previously completed the documents step, their completed_step will have been set to 6. But after we add the two new steps, ‘6’ will point to the pay package step instead. So storing the step number on the vacancy is not very maintainable/scalable.

(In fact, this discrepancy is already causing bugs - I edited
vacancy_step_completed? so that it would compare like with like. However the
bug can't be completely fixed using the current data model because '1' and '2'
mean different things depending on what type of organisation is currently logged
in (as single school users do not see the job location step), and the same vacancy
can be edited by someone logged in as either the school or the school group.)

3) Although we try to funnel publishers to complete the steps in a certain
order, they can in fact fill out the steps in any order they like (except that
step 1 is always first), by using 'save and return later' and editing the draft.
So by saving only the last section updated, we lose the information of what
sections they have already completed.

This is the first of a two-part migration. In this PR we add the new column
completed_steps (plural) and a task to update existing records on this attribute.
Later we will both drop the old column and update code to rely on the new column.

### Further conversation

https://ukgovernmentdfe.slack.com/archives/G0127R0KXQF/p1628091167007600

### Before running task on local db

```ruby
> pry(main)> Vacancy.pluck(:completed_step, :completed_steps, :id).sort_by(&:last).map { |list| list[0..1] }
   (0.5ms)  SELECT "vacancies"."completed_step", "vacancies"."completed_steps", "vacancies"."id" FROM "vacancies"
=> [[2, []], [3, ["job_location"]], [7, []], [6, []], [1, []], [4, []], [5, []], [2, []], [1, ["job_location"]]]
```

### After running task on local db

```ruby
pry(main)> Vacancy.pluck(:completed_step, :completed_steps, :id).sort_by(&:last).map { |list| list[0..1] }
   (0.8ms)  SELECT "vacancies"."completed_step", "vacancies"."completed_steps", "vacancies"."id" FROM "vacancies"
=> [[2, ["job_details"]],
 [3, ["job_location", "pay_package"]],
 [7, ["job_summary"]],
 [6, ["applying_for_the_job"]],
 [1, ["job_location", "schools"]],
 [4, ["important_dates"]],
 [5, ["documents"]],
 [2, ["job_details"]],
 [1, ["job_location", "schools"]]]
 ```

### Next steps

- [x] Check task on prod-like db
- [ ] Run the task