### PR TITLE
[TEVA-2880] Seed QA with accurate dummy data

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,66 +3,71 @@ raise "Aborting seeds - running in production with existing vacancies" if Rails.
 require "faker"
 require "factory_bot_rails"
 
-school_one = FactoryBot.create(:school,
-                               name: "Bexleyheath Academy",
-                               urn: "137138",
-                               phase: :secondary,
-                               url: "http://www.bexleyheathacademy.org/",
-                               minimum_age: 11,
-                               maximum_age: 18,
-                               address: "Woolwich Road",
-                               town: "Bexleyheath",
-                               county: "Kent",
-                               postcode: "DA6 7DA",
-                               region: "London",
-                               easting: "549194",
-                               northing: "175388",
-                               geolocation: "(51.4578146490981,0.146065490118642)",
-                               readable_phases: %w[secondary],
-                               detailed_school_type: "Academy sponsor led",
-                               school_type: "Academy",
-                               gias_data: { "ReligiousCharacter (name)": "None" })
+single_school_one = FactoryBot.create(:school,
+                                      name: "Bexleyheath Academy",
+                                      urn: "137138",
+                                      phase: :secondary,
+                                      url: "http://www.bexleyheathacademy.org/",
+                                      minimum_age: 11,
+                                      maximum_age: 18,
+                                      address: "Woolwich Road",
+                                      town: "Bexleyheath",
+                                      county: "Kent",
+                                      postcode: "DA6 7DA",
+                                      region: "London",
+                                      easting: "549194",
+                                      northing: "175388",
+                                      geolocation: "(51.4578146490981,0.146065490118642)",
+                                      readable_phases: %w[secondary],
+                                      detailed_school_type: "Academy sponsor led",
+                                      school_type: "Academy",
+                                      gias_data: { "ReligiousCharacter (name)": "None" })
 
-school_two = FactoryBot.create(:school,
-                               name: "Upton Cross ACE Academy",
-                               urn: "144523",
-                               phase: :primary,
-                               url: "http://www.uptoncross.kernowlearning.co.uk",
-                               minimum_age: 4,
-                               maximum_age: 11,
-                               address: "Upton Cross",
-                               town: "Liskeard",
-                               county: "Cornwall",
-                               postcode: "PL14 5AX",
-                               region: "London",
-                               easting: "228041",
-                               northing: "72116",
-                               geolocation: "(50.52350433336815,-4.427269703777728)",
-                               readable_phases: %w[primary],
-                               detailed_school_type: "Academy converter",
-                               school_type: "Academy",
-                               gias_data: { "ReligiousCharacter (name)": "None" })
+local_authority_one = FactoryBot.create(:local_authority,
+                                        name: "Southampton",
+                                        local_authority_code: "852",
+                                        group_type: "local_authority")
+
+la_school_one = FactoryBot.create(:school,
+                                  name: "Upton Cross ACE Academy",
+                                  urn: "144523",
+                                  phase: :primary,
+                                  url: "http://www.uptoncross.kernowlearning.co.uk",
+                                  minimum_age: 4,
+                                  maximum_age: 11,
+                                  address: "Upton Cross",
+                                  town: "Liskeard",
+                                  county: "Cornwall",
+                                  postcode: "PL14 5AX",
+                                  region: "South West",
+                                  easting: "228041",
+                                  northing: "72116",
+                                  geolocation: "(50.52350433336815,-4.427269703777728)",
+                                  readable_phases: %w[primary],
+                                  detailed_school_type: "Academy converter",
+                                  school_type: "Academy",
+                                  gias_data: { "ReligiousCharacter (name)": "None" })
 
 # A second school at the local authority to enable seeding a vacancy at multiple schools.
-school_three = FactoryBot.create(:school,
-                                 name: "Townhill Junior School",
-                                 urn: "116134",
-                                 phase: :primary,
-                                 url: "http://www.townhilljuniorschool.co.uk",
-                                 minimum_age: 7,
-                                 maximum_age: 11,
-                                 address: "Benhams Road",
-                                 town: "Southampton",
-                                 county: "Hampshire",
-                                 postcode: "SO18 2NX",
-                                 region: "London",
-                                 easting: "445283",
-                                 northing: "114779",
-                                 geolocation: "(50.9306936449461,-1.3569968052135)",
-                                 readable_phases: %w[primary],
-                                 detailed_school_type: "Foundation school",
-                                 school_type: "Local authority maintained schools",
-                                 gias_data: { "ReligiousCharacter (name)": "Does not apply" })
+la_school_two = FactoryBot.create(:school,
+                                  name: "Heathfield Infant School",
+                                  urn: "116097",
+                                  phase: :primary,
+                                  url: "http://www.townhilljuniorschool.co.uk",
+                                  minimum_age: 4,
+                                  maximum_age: 7,
+                                  address: "Valentine Avenue",
+                                  town: "Southampton",
+                                  county: "Hampshire",
+                                  postcode: "SO19 0EQ",
+                                  region: "London",
+                                  easting: "446387",
+                                  northing: "110975",
+                                  geolocation: "(50.89640138403752,-1.3417708429893471)",
+                                  readable_phases: %w[primary],
+                                  detailed_school_type: "Community school",
+                                  school_type: "Local authority maintained schools",
+                                  gias_data: { "ReligiousCharacter (name)": "None" })
 
 trust_one = FactoryBot.create(:trust,
                               name: "Weydon Multi Academy Trust",
@@ -74,18 +79,159 @@ trust_one = FactoryBot.create(:trust,
                               postcode: "GU9 8UG",
                               geolocation: "(51.2023732521965,-0.814476304733643)")
 
-local_authority_one = FactoryBot.create(:local_authority,
-                                        name: "Southampton",
-                                        local_authority_code: "852",
-                                        group_type: "local_authority")
+trust_school_one = FactoryBot.create(:school,
+                                     name: "Weydon School",
+                                     urn: "136531",
+                                     phase: :secondary,
+                                     url: "http://www.weydonschool.surrey.sch.uk/",
+                                     minimum_age: 11,
+                                     maximum_age: 16,
+                                     address: "Weydon Lane",
+                                     town: "Farnham",
+                                     county: "Surrey",
+                                     postcode: "GU9 8UG",
+                                     region: "South East",
+                                     easting: "482923",
+                                     northing: "145462",
+                                     geolocation: "(51.20236411721489,0.8144622254228397)",
+                                     readable_phases: %w[secondary],
+                                     detailed_school_type: "Academy converter",
+                                     school_type: "Academies",
+                                     gias_data: { "ReligiousCharacter (name)": "None" })
 
-SchoolGroupMembership.create(school_group: trust_one, school: school_one)
-SchoolGroupMembership.create(school_group: local_authority_one, school: school_two)
-SchoolGroupMembership.create(school_group: local_authority_one, school: school_three)
+trust_school_two = FactoryBot.create(:school,
+                                     name: "The Park School",
+                                     urn: "137524",
+                                     phase: :not_applicable,
+                                     url: "http://www.thepark.surrey.sch.uk",
+                                     minimum_age: 11,
+                                     maximum_age: 16,
+                                     address: "Onslow Crescent",
+                                     town: "Woking",
+                                     county: "Surrey",
+                                     postcode: "GU22 7AT",
+                                     region: "South East",
+                                     easting: "501159",
+                                     northing: "158701",
+                                     geolocation: "(51.31843413306593,0.5497856835186931)",
+                                     readable_phases: [],
+                                     detailed_school_type: "Academy special sponsor led",
+                                     school_type: "Academies",
+                                     gias_data: { "ReligiousCharacter (name)": "None" })
 
+trust_school_three = FactoryBot.create(:school,
+                                       name: "The Ridgeway School",
+                                       urn: "141843",
+                                       phase: :not_applicable,
+                                       url: nil,
+                                       minimum_age: 2,
+                                       maximum_age: 19,
+                                       address: "14 Frensham Road",
+                                       town: "Farnham",
+                                       county: "Surrey",
+                                       postcode: "GU9 8HB",
+                                       region: "South East",
+                                       easting: "484376",
+                                       northing: "145427",
+                                       geolocation: "(51.201836959020504,0.7936780598044166)",
+                                       readable_phases: [],
+                                       detailed_school_type: "Academy special converter",
+                                       school_type: "Academies",
+                                       gias_data: { "ReligiousCharacter (name)": "None" })
+
+trust_school_four = FactoryBot.create(:school,
+                                      name: "Farnham Heath End",
+                                      urn: "144520",
+                                      phase: :secondary,
+                                      url: "https://www.fhes.org.uk/",
+                                      minimum_age: 11,
+                                      maximum_age: 16,
+                                      address: "Hale Reeds",
+                                      town: "Farnham",
+                                      county: "Surrey",
+                                      postcode: "GU9 9BN",
+                                      region: "South East",
+                                      easting: "485153",
+                                      northing: "148719",
+                                      geolocation: "(51.231316451350786,0.7817786894584878)",
+                                      readable_phases: %w[secondary],
+                                      detailed_school_type: "Academy converter",
+                                      school_type: "Academies",
+                                      gias_data: { "ReligiousCharacter (name)": "None" })
+
+trust_school_five = FactoryBot.create(:school,
+                                      name: "Rodborough",
+                                      urn: "137019",
+                                      phase: :secondary,
+                                      url: "http://www.rodborough.surrey.sch.uk",
+                                      minimum_age: 11,
+                                      maximum_age: 16,
+                                      address: "Rake Lane",
+                                      town: "Godalming",
+                                      county: "Surrey",
+                                      postcode: "GU8 5BZ",
+                                      region: "South East",
+                                      easting: "494578",
+                                      northing: "141251",
+                                      geolocation: "(51.16270091037534,0.6487940940127327)",
+                                      readable_phases: %w[secondary],
+                                      detailed_school_type: "Academy converter",
+                                      school_type: "Academies",
+                                      gias_data: { "ReligiousCharacter (name)": "None" })
+
+trust_school_six = FactoryBot.create(:school,
+                                     name: "The Abbey School",
+                                     urn: "146255",
+                                     phase: :not_applicable,
+                                     url: "http://www.abbey.surrey.sch.uk",
+                                     minimum_age: 11,
+                                     maximum_age: 16,
+                                     address: "Menin Way",
+                                     town: "Farnham",
+                                     county: "Surrey",
+                                     postcode: "GU9 8DY",
+                                     region: "South East",
+                                     easting: "484990",
+                                     northing: "146252",
+                                     geolocation: "(51.20916271142808,0.7846967240986934)",
+                                     readable_phases: [],
+                                     detailed_school_type: "Academy special converter",
+                                     school_type: "Academies",
+                                     gias_data: { "ReligiousCharacter (name)": "None" })
+
+trust_school_seven = FactoryBot.create(:school,
+                                       name: "Woolmer Hill School",
+                                       urn: "137314",
+                                       phase: :secondary,
+                                       url: "http://www.woolmerhill.surrey.sch.uk",
+                                       minimum_age: 11,
+                                       maximum_age: 16,
+                                       address: "Woolmer Hill",
+                                       town: "Haslemere",
+                                       county: "Surrey",
+                                       postcode: "GU27 1QB",
+                                       region: "South East",
+                                       easting: "487735",
+                                       northing: "133362",
+                                       geolocation: "(51.09286892095426,0.7485485972532422)",
+                                       readable_phases: %w[secondary],
+                                       detailed_school_type: "Academy converter",
+                                       school_type: "Academies",
+                                       gias_data: { "ReligiousCharacter (name)": "None" })
+
+SchoolGroupMembership.create(school_group: local_authority_one, school: la_school_one)
+SchoolGroupMembership.create(school_group: local_authority_one, school: la_school_two)
+SchoolGroupMembership.create(school_group: trust_one, school: trust_school_one)
+SchoolGroupMembership.create(school_group: trust_one, school: trust_school_two)
+SchoolGroupMembership.create(school_group: trust_one, school: trust_school_three)
+SchoolGroupMembership.create(school_group: trust_one, school: trust_school_four)
+SchoolGroupMembership.create(school_group: trust_one, school: trust_school_five)
+SchoolGroupMembership.create(school_group: trust_one, school: trust_school_six)
+SchoolGroupMembership.create(school_group: trust_one, school: trust_school_seven)
+
+# TODO: Is being associated with the school group enough? Check if publisher users need to be associated with the individual schools.
 organisation_publishers_attributes = [
-  { organisation: school_one },
-  { organisation: school_two },
+  { organisation: single_school_one },
   { organisation: trust_one },
   { organisation: local_authority_one },
 ]
@@ -119,12 +265,6 @@ Publisher.create(oid: "5A21B414-EFE4-4B32-82BC-FC9751F841A5",
                  organisation_publishers_attributes: organisation_publishers_attributes,
                  family_name: "Sutter",
                  given_name: "Christian")
-
-Publisher.create(oid: "A111A1AA-A111-1111-1AA1-AAAA1A111A1A",
-                 email: "craig.forrester@digital.education.gov.uk",
-                 organisation_publishers_attributes: organisation_publishers_attributes,
-                 family_name: "Forrester",
-                 given_name: "Craig")
 
 Publisher.create(oid: "421542E6-ED96-4656-B61F-A06D8D487C07",
                  email: "colin.saliceti@digital.education.gov.uk",
@@ -174,126 +314,262 @@ Publisher.create(oid: "7AEC8E8D-6036-4E6E-92A4-800E381A12E0",
                  family_name: "Mackworth-Young",
                  given_name: "Rose")
 
-physics_job = FactoryBot.create(:vacancy,
-                                id: "20cc99ff-4fdb-4637-851a-68cf5f8fea9f",
-                                job_title: "Physics Teacher",
-                                subjects: %w[Physics],
-                                working_patterns: %w[full_time],
-                                salary: "£35,000",
-                                publisher: Publisher.find_by(email: "david.mears@digital.education.gov.uk"),
-                                publisher_organisation: school_one,
-                                organisation_vacancies_attributes: [{ organisation: school_one }])
+publishers = Publisher.all
 
-FactoryBot.create(:vacancy,
-                  id: "67991ea9-431d-4d9d-9c99-a78b80108fe1",
-                  job_title: "Maths Teacher",
-                  subjects: %w[Maths],
-                  working_patterns: %w[part_time],
-                  salary: "£35,000",
-                  publisher: Publisher.find_by(email: "christian.sutter@digital.education.gov.uk"),
-                  publisher_organisation: school_one,
-                  organisation_vacancies_attributes: [{ organisation: school_two }])
+# Vacancies
 
-FactoryBot.create(:vacancy,
-                  id: "ba7dfaf8-2b9f-4fbe-9243-c16a299598aa",
-                  job_title: "English Teacher",
-                  subjects: %w[English],
-                  working_patterns: %w[full_time],
-                  salary: "£35,000",
-                  publisher: Publisher.find_by(email: "mili.malde@digital.education.gov.uk"),
-                  publisher_organisation: school_one,
-                  organisation_vacancies_attributes: [{ organisation: school_one }])
+## Bexleyheath
 
-# vacancy at a trust central office
+### Published
+
+7.times do
+  FactoryBot.create(:vacancy, :published,
+                    publisher_organisation: single_school_one,
+                    publisher: publishers.sample,
+                    organisation_vacancies_attributes: [{ organisation: single_school_one }])
+end
+
+2.times do
+  FactoryBot.create(:vacancy, :published, :no_tv_applications,
+                    publisher_organisation: single_school_one,
+                    publisher: publishers.sample,
+                    organisation_vacancies_attributes: [{ organisation: single_school_one }])
+end
+
+### Scheduled
+
+4.times do
+  FactoryBot.create(:vacancy, :future_publish,
+                    publisher_organisation: single_school_one,
+                    publisher: publishers.sample,
+                    organisation_vacancies_attributes: [{ organisation: single_school_one }])
+end
+
+### Draft
+
+4.times do
+  FactoryBot.create(:vacancy, :draft,
+                    publisher_organisation: single_school_one,
+                    publisher: publishers.sample,
+                    organisation_vacancies_attributes: [{ organisation: single_school_one }])
+end
+
+### Expired
+
+4.times do
+  expired_vacancy = FactoryBot.build(:vacancy, :expired,
+                                     publisher_organisation: single_school_one,
+                                     publisher: publishers.sample,
+                                     organisation_vacancies_attributes: [{ organisation: single_school_one }])
+
+  expired_vacancy.save(validate: false)
+end
+
+## Weydon Multi Academy Trust
+
+weydon_schools = trust_one.schools
+
+#### At one school
+
+#### Published
+
+8.times do
+  school = weydon_schools.sample
+
+  FactoryBot.create(:vacancy, :published,
+                    publisher_organisation: school,
+                    publisher: publishers.sample,
+                    organisation_vacancies_attributes: [{ organisation: school }])
+end
+
+4.times do
+  school = weydon_schools.sample
+
+  FactoryBot.create(:vacancy, :published, :no_tv_applications,
+                    publisher_organisation: school,
+                    publisher: publishers.sample,
+                    organisation_vacancies_attributes: [{ organisation: school }])
+end
+
+#### Scheduled
+
+4.times do
+  school = weydon_schools.sample
+
+  FactoryBot.create(:vacancy, :future_publish,
+                    publish_on: Date.current + 6.months,
+                    expires_at: 2.years.from_now.change(hour: 9, minute: 0),
+                    publisher_organisation: school,
+                    publisher: publishers.sample,
+                    organisation_vacancies_attributes: [{ organisation: school }])
+end
+
+### Draft
+
+4.times do
+  school = weydon_schools.sample
+
+  FactoryBot.create(:vacancy, :draft,
+                    publisher_organisation: school,
+                    publisher: publishers.sample,
+                    organisation_vacancies_attributes: [{ organisation: school }])
+end
+
+### Expired
+
+4.times do
+  school = weydon_schools.sample
+
+  expired_vacancy = FactoryBot.build(:vacancy, :expired,
+                                     publisher_organisation: school,
+                                     publisher: publishers.sample,
+                                     organisation_vacancies_attributes: [{ organisation: school }])
+
+  expired_vacancy.save(validate: false)
+end
+
+#### At multiple schools
+
+FactoryBot.create(:vacancy, :published, :at_multiple_schools,
+                  publisher_organisation: trust_one,
+                  publisher: publishers.sample,
+                  organisation_vacancies_attributes: [
+                    { organisation: trust_school_one },
+                    { organisation: trust_school_two },
+                    { organisation: trust_school_three },
+                    { organisation: trust_school_four },
+                    { organisation: trust_school_five },
+                    { organisation: trust_school_six },
+                    { organisation: trust_school_seven },
+                  ])
+
+#### At the central office
+
+# Pass in vacancy id used in application_submitted_at_central_office in /spec/mailers/previews/jobseekers/job_application_preview.rb
 FactoryBot.create(:vacancy, :central_office,
                   id: "7bfadb84-cf30-4121-88bd-a9f958440cc9",
-                  job_title: "Trust Executive Officer",
-                  subjects: %w[],
-                  working_patterns: %w[full_time],
-                  salary: "£35,000",
-                  expires_at: Faker::Time.forward(days: 7).change(hour: 9, minute: 0),
-                  publisher: Publisher.find_by(email: "alex.bowen@digital.education.gov.uk"),
                   publisher_organisation: trust_one,
+                  publisher: publishers.sample,
                   organisation_vacancies_attributes: [{ organisation: trust_one }])
 
-# vacancy at multiple schools in a local authority
-FactoryBot.create(:vacancy, :at_multiple_schools,
+## Southampton
+
+la_schools = local_authority_one.schools
+
+### At one school
+
+#### Published
+
+4.times do
+  school = la_schools.sample
+
+  FactoryBot.create(:vacancy, :published,
+                    publisher_organisation: school,
+                    publisher: publishers.sample,
+                    organisation_vacancies_attributes: [{ organisation: school }])
+end
+
+#### Scheduled
+
+4.times do
+  school = la_schools.sample
+
+  FactoryBot.create(:vacancy, :future_publish,
+                    publisher_organisation: school,
+                    publisher: publishers.sample,
+                    organisation_vacancies_attributes: [{ organisation: school }])
+end
+
+#### Draft
+
+4.times do
+  school = la_schools.sample
+
+  FactoryBot.create(:vacancy, :draft,
+                    publisher_organisation: school,
+                    publisher: publishers.sample,
+                    organisation_vacancies_attributes: [{ organisation: school }])
+end
+
+#### Expired
+
+4.times do
+  school = la_schools.sample
+
+  expired_vacancy = FactoryBot.build(:vacancy, :expired,
+                                     publisher_organisation: school,
+                                     publisher: publishers.sample,
+                                     organisation_vacancies_attributes: [{ organisation: school }])
+
+  expired_vacancy.save(validate: false)
+end
+
+### At multiple schools
+
+# Pass in vacancy id used in application_submitted_at_multiple_schools in /spec/mailers/previews/jobseekers/job_application_preview.rb
+FactoryBot.create(:vacancy, :published, :at_multiple_schools,
                   id: "9910d184-5686-4ffc-9322-69aa150c19d3",
-                  job_title: "PE Teacher",
-                  subjects: ["Physical Education"],
-                  working_patterns: %w[full_time],
-                  salary: "£30,000",
-                  publisher: Publisher.find_by(email: "cesidio.dilanda@digital.education.gov.uk"),
-                  publisher_organisation: school_two,
-                  organisation_vacancies_attributes: [{ organisation: school_two }, { organisation: school_three }])
-
-FactoryBot.create(:vacancy,
-                  id: "3bf67da6-039c-4ee1-bf59-8475672a0d2b",
-                  job_title: "Chemistry Teacher",
-                  subjects: %w[Chemistry],
-                  working_patterns: %w[full_time part_time job_share],
-                  salary: "£55,000",
-                  publisher: Publisher.find_by(email: "david.mears@digital.education.gov.uk"),
-                  publisher_organisation: school_two,
-                  organisation_vacancies_attributes: [{ organisation: school_two }])
-
-FactoryBot.create(:vacancy,
-                  id: "e750baf6-cc9a-4b93-84cf-ee4e5f8a7ee4",
-                  job_title: "Geography Teacher",
-                  subjects: %w[Geography],
-                  working_patterns: %w[part_time job_share],
-                  salary: "£25,000",
-                  publisher: Publisher.find_by(email: "joseph.hull@digital.education.gov.uk"),
-                  publisher_organisation: school_one,
-                  organisation_vacancies_attributes: [{ organisation: school_one }])
-
-# pending vacancy
-FactoryBot.create(:vacancy,
-                  job_title: "Teacher of Drama",
-                  subjects: %w[Drama],
-                  salary: "£28,000",
-                  publish_on: 1.month.from_now.to_date,
-                  expires_at: 2.month.from_now.change(hour: 9, minute: 0),
-                  starts_on: 3.month.from_now.to_date,
-                  publisher: Publisher.find_by(email: "joseph.hull@digital.education.gov.uk"),
-                  publisher_organisation: school_one,
-                  organisation_vacancies_attributes: [{ organisation: school_one }])
-
-# expired vacancy
-expired_one = FactoryBot.build(:vacancy,
-                               job_title: "Subject lead in Art",
-                               subjects: %w[Art],
-                               working_patterns: %w[full_time part_time job_share],
-                               salary: "£32,000",
-                               publish_on: 5.days.ago.to_date,
-                               expires_at: 2.days.ago.to_date.change(hour: 9, minute: 0),
-                               publisher: Publisher.find_by(email: "joseph.hull@digital.education.gov.uk"),
-                               publisher_organisation: school_one,
-                               organisation_vacancies_attributes: [{ organisation: school_one }])
-expired_one.send :set_slug
-expired_one.save(validate: false)
-
-expired_two = FactoryBot.build(:vacancy,
-                               job_title: "Subject lead in Drama",
-                               subjects: %w[Drama],
-                               working_patterns: %w[full_time part_time job_share],
-                               salary: "£46,000",
-                               publish_on: 5.days.ago.to_date,
-                               expires_at: 2.days.ago.to_date.change(hour: 9, minute: 0),
-                               publisher: Publisher.find_by(email: "joseph.hull@digital.education.gov.uk"),
-                               publisher_organisation: school_one,
-                               organisation_vacancies_attributes: [{ organisation: school_one }])
-expired_two.send :set_slug
-expired_two.save(validate: false)
+                  publisher_organisation: local_authority_one,
+                  publisher: publishers.sample,
+                  organisation_vacancies_attributes: [
+                    { organisation: la_school_one },
+                    { organisation: la_school_two },
+                  ])
 
 Vacancy.index.clear_index
 Vacancy.reindex!
 
-jobseeker = Jobseeker.create(email: "jobseeker@example.com",
-                             password: "password",
-                             confirmed_at: Time.zone.now)
+# Jobseekers
 
+## Create the jobseeker account that users are accustomed to logging in with
+Jobseeker.create(email: "jobseeker@example.com", password: "password", confirmed_at: Time.zone.now)
+
+# Create extra jobseekers so each vacancy has multiple applications
+
+5.times do |i|
+  Jobseeker.create(email: "jobseeker#{i}@example.com",
+                   password: "password",
+                   confirmed_at: Time.zone.now)
+end
+
+# Job Applications
+
+# Drop one vacancy so this can be used later when a specific ID needs to be given to a submitted job application (for mailer previews)
+Vacancy.listed.drop(1).each do |vacancy|
+  submitted_statuses = %w[submitted reviewed shortlisted unsuccessful withdrawn]
+  Jobseeker.where.not(email: "jobseeker@example.com").each do |jobseeker|
+    application_status = submitted_statuses.sample
+    FactoryBot.create(:job_application, "status_#{application_status}".to_sym,
+                      jobseeker: jobseeker,
+                      vacancy: vacancy)
+
+    submitted_statuses.delete(application_status)
+  end
+end
+
+vacancy = Vacancy.listed.where.missing(:job_applications).first
+
+jobseeker = Jobseeker.where.missing(:job_applications).first
+
+# Pass in job application id used in application_shortlisted and application_unsuccessful in /spec/mailers/previews/jobseekers/job_application_preview.rb
 FactoryBot.create(:job_application, :status_submitted,
                   id: "6683c564-15e6-41af-ab44-7adf125f4c84",
                   jobseeker: jobseeker,
-                  vacancy: physics_job)
+                  vacancy: vacancy)
+
+# Create applications in other states so vacancy has an application in each state
+FactoryBot.create(:job_application, :status_reviewed,
+                  jobseeker: jobseeker,
+                  vacancy: vacancy)
+
+FactoryBot.create(:job_application, :status_shortlisted,
+                  jobseeker: jobseeker,
+                  vacancy: vacancy)
+
+FactoryBot.create(:job_application, :status_unsuccessful,
+                  jobseeker: jobseeker,
+                  vacancy: vacancy)
+
+FactoryBot.create(:job_application, :status_withdrawn,
+                  jobseeker: jobseeker,
+                  vacancy: vacancy)

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -1,33 +1,45 @@
+JOB_TITLES = ["Tutor of Science (opportunity exists for the right candidate for Head of Physics and/or KS4 Lead)",
+              "PROGRESS LEADER (HEAD OF DEPARTMENT) FOR RS, PSHE, RSE AND CITIZENSHIP EDUCATION WITH TLR 2 £6698",
+              "Tutor of Music (Part-time, permanent) to include Music Performance Enhancement project for 1 year",
+              "Tutor of Maths MPS (A recruitment and retention point will be offered to the successful candidate)",
+              "Tutor of PE (male)", "Games Design Tutor", "Team Leader of Maths", "KEY STAGE 2 Tutor",
+              "Lead in Health and Social Care", "Director of Learning - Science"].freeze
+
+SALARIES = ["Main pay range 1 to Upper pay range 3, £23,719 to £39,406 per year (full-time equivalent)",
+            "£6,084 to £6,084 per year (full-time equivalent)", "Main pay range 2 to Upper pay range 3, £30,113 to £44,541",
+            "Main pay range 1 to Upper pay range 3, £30,480 to £49,571", "MPR / UPR",
+            "MPS/UPS", "£25,543 to £41,635 per year (full-time equivalent)"].freeze
+
 FactoryBot.define do
   factory :vacancy do
     publisher
 
     job_location { "at_one_school" }
-    about_school { "Great school with amazing people" }
+    about_school { Faker::Lorem.paragraph(sentence_count: rand(5..10)) }
     actual_salary { rand(20_000..100_000) }
     enable_job_applications { true }
-    benefits { Faker::Lorem.paragraph(sentence_count: 4) }
+    benefits { Faker::Lorem.paragraph(sentence_count: rand(1..3)) }
     completed_steps do
       %w[job_location schools job_details pay_package important_dates documents applying_for_the_job job_summary]
     end
     contact_email { Faker::Internet.email }
     contact_number { "01234 123456" }
-    contract_type { :fixed_term }
+    contract_type { Vacancy.contract_types.keys.sample }
     contract_type_duration { "6 months" }
     expires_at { 6.months.from_now.change(hour: 9, minute: 0, second: 0) }
     hired_status { nil }
-    job_advert { Faker::Lorem.paragraph(sentence_count: 4) }
-    job_roles { [:teacher] }
-    job_title { Faker::Lorem.sentence[1...30].strip }
+    job_advert { Faker::Lorem.paragraph(sentence_count: rand(50..300)) }
+    job_roles { Vacancy.job_roles.keys.first(3).sample(rand(1..3)) }
+    job_title { JOB_TITLES.sample }
     listed_elsewhere { nil }
-    personal_statement_guidance { Faker::Lorem.paragraph(sentence_count: 4) }
+    personal_statement_guidance { Faker::Lorem.paragraph(sentence_count: rand(5..10)) }
     publish_on { Date.current }
-    salary { Faker::Lorem.sentence[1...30].strip }
-    school_visits { Faker::Lorem.paragraph(sentence_count: 4) }
+    salary { SALARIES.sample }
+    school_visits { Faker::Lorem.paragraph(sentence_count: rand(5..10)) }
     starts_on { 1.year.from_now.to_date }
     status { :published }
     subjects { SUBJECT_OPTIONS.sample(2).map(&:first).sort! }
-    working_patterns { %w[full_time] }
+    working_patterns { Vacancy.working_patterns.keys.sample(rand(1..3)) }
 
     trait :no_tv_applications do
       application_link { Faker::Internet.url(host: "example.com") }
@@ -48,7 +60,7 @@ FactoryBot.define do
 
     trait :at_multiple_schools do
       job_location { "at_multiple_schools" }
-      readable_job_location { "More than one school (3)" }
+      readable_job_location { "More than one school (2)" }
     end
 
     trait :fail_minimum_validation do
@@ -106,8 +118,9 @@ FactoryBot.define do
 
     trait :future_publish do
       status { :published }
-      publish_on { Date.current + 2.days }
-      expires_at { 2.months.from_now.change(hour: 9, minute: 0) }
+      publish_on { Date.current + 6.months }
+      expires_at { 2.years.from_now.change(hour: 9, minute: 0) }
+      starts_on { 2.years.from_now + 2.months }
     end
 
     trait :past_publish do

--- a/spec/mailers/publishers/feedback_prompt_mailer_spec.rb
+++ b/spec/mailers/publishers/feedback_prompt_mailer_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe Publishers::FeedbackPromptMailer do
         expect(mail.to).to eq([email])
 
         expect(body).to match(/Dear vacancy publisher/)
-                    .and match(/\* #{vacancies.first.job_title}/)
-                    .and match(/\* #{vacancies.second.job_title}/)
+                    .and include(vacancies.first.job_title)
+                    .and include(vacancies.second.job_title)
       end
 
       it "triggers a `publisher_prompt_for_feedback` email event" do

--- a/spec/system/application_sitemap_spec.rb
+++ b/spec/system/application_sitemap_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 RSpec.describe "Application sitemap" do
   context "sitemap.xml" do
     scenario "generates a sitemap of the application" do
-      published_jobs = create_list(:vacancy, 4, :published)
+      published_jobs = (1..4).map { |i| create(:vacancy, :published, job_title: "Title#{i}") }
       build_list(:vacancy, 2, :expired).each { |j| j.save(validate: false) }
 
       visit sitemap_path(format: :xml)

--- a/spec/system/jobseekers_can_manage_their_job_applications_spec.rb
+++ b/spec/system/jobseekers_can_manage_their_job_applications_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe "Jobseekers can manage their job applications" do
   let(:jobseeker) { create(:jobseeker) }
   let(:organisation) { create(:school) }
 
-  let(:vacancy1) { create(:vacancy, organisation_vacancies_attributes: [{ organisation: organisation }]) }
-  let(:vacancy2) { create(:vacancy, :expired, organisation_vacancies_attributes: [{ organisation: organisation }]) }
-  let(:vacancy3) { create(:vacancy, organisation_vacancies_attributes: [{ organisation: organisation }]) }
-  let(:vacancy4) { create(:vacancy, organisation_vacancies_attributes: [{ organisation: organisation }]) }
+  let(:vacancy1) { create(:vacancy, job_title: "Team Leader of Maths", organisation_vacancies_attributes: [{ organisation: organisation }]) }
+  let(:vacancy2) { create(:vacancy, :expired, job_title: "Teacher of History", organisation_vacancies_attributes: [{ organisation: organisation }]) }
+  let(:vacancy3) { create(:vacancy, job_title: "Teacher of Design & Technology", organisation_vacancies_attributes: [{ organisation: organisation }]) }
+  let(:vacancy4) { create(:vacancy, job_title: "Teacher of RE & PSHE", organisation_vacancies_attributes: [{ organisation: organisation }]) }
 
   context "when logged in" do
     before { login_as(jobseeker, scope: :jobseeker) }

--- a/spec/system/publishers_can_add_stats_to_a_vacancy_spec.rb
+++ b/spec/system/publishers_can_add_stats_to_a_vacancy_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe "Submitting effectiveness statistics on expired vacancies" do
   end
 
   context "when there are vacancies awaiting feedback" do
-    let!(:vacancy) { create(:vacancy, :expired, organisation_vacancies_attributes: [{ organisation: school }]) }
-    let!(:another_vacancy) { create(:vacancy, :expired, organisation_vacancies_attributes: [{ organisation: school }]) }
-    let!(:third_vacancy) { create(:vacancy, :expired, organisation_vacancies_attributes: [{ organisation: school }]) }
+    let!(:vacancy) { create(:vacancy, :expired, job_title: "Maths teacher", organisation_vacancies_attributes: [{ organisation: school }]) }
+    let!(:another_vacancy) { create(:vacancy, :expired, job_title: "English teacher", organisation_vacancies_attributes: [{ organisation: school }]) }
+    let!(:third_vacancy) { create(:vacancy, :expired, job_title: "Science teacher", organisation_vacancies_attributes: [{ organisation: school }]) }
 
     scenario "displays the vacancies awaiting feedback" do
       visit jobs_with_type_organisation_path(type: :awaiting_feedback)

--- a/spec/system/publishers_can_filter_vacancies_in_their_dashboard_spec.rb
+++ b/spec/system/publishers_can_filter_vacancies_in_their_dashboard_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe "Publishers can filter vacancies in their dashboard" do
   let(:local_authority2) { create(:local_authority) }
   let(:school1) { create(:school, name: "Happy Rainbows School") }
   let(:school2) { create(:school, name: "Dreary Grey School") }
-  let!(:school_group_vacancy) { create(:vacancy, :published, :central_office) }
-  let!(:school1_vacancy) { create(:vacancy, :published, :at_one_school) }
-  let!(:school1_draft_vacancy) { create(:vacancy, :draft, :at_one_school) }
-  let!(:school2_draft_vacancy) { create(:vacancy, :draft, :at_one_school) }
+  let!(:school_group_vacancy) { create(:vacancy, :published, :central_office, job_title: "Maths Teacher") }
+  let!(:school1_vacancy) { create(:vacancy, :published, :at_one_school, job_title: "English Teacher") }
+  let!(:school1_draft_vacancy) { create(:vacancy, :draft, :at_one_school, job_title: "Science Teacher") }
+  let!(:school2_draft_vacancy) { create(:vacancy, :draft, :at_one_school, job_title: "History Teacher") }
   let!(:publisher_preference_local_authority) { PublisherPreference.create(publisher: publisher, organisation: local_authority2) }
   let!(:publisher_preference_trust) { PublisherPreference.create(publisher: publisher, organisation: trust) }
 


### PR DESCRIPTION

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2880

## Changes in this PR:

The seed has been updated to include multiple vacancies in each
state with attributes of varying length. Multiple job applications in each state
have also been added.

- Multiple vacancies in each state (published, draft, expired and scheduled) have been created
- Vacancies have been created at one school, multiple schools (for both a trust and a LA) and at the central office (for the trust)
- Multiple jobseekers have been created (have kept the original jobseeker account so people know the credentials) have been created. This has allowed for multiple job applications to be created, in each state, for each of these jobseekers, meaning that each vacancy should have multiple applications.

## Screenshots of UI changes:

### Vacancies: 

![Screenshot 2021-08-05 at 17 21 53](https://user-images.githubusercontent.com/30624173/128385557-1ea79afe-ad74-4381-8a86-e9e174a7dffa.png)

### Job applications on the publisher dashboard:

![Screenshot 2021-08-05 at 17 52 20](https://user-images.githubusercontent.com/30624173/128389872-fc4566fe-8f1c-4b8a-9380-1ae71fe6706f.png)


### Job applications on the jobseeker dashboard:

![Screenshot 2021-08-05 at 17 21 40](https://user-images.githubusercontent.com/30624173/128385520-7fff4355-473a-4c8e-a0e9-48a3ea542bbe.png)
