### PR TITLE
fix location finder bug due to new autocomplete

### DIFF
--- a/app/frontend/src/components/locationFinder/locationFinder.js
+++ b/app/frontend/src/components/locationFinder/locationFinder.js
@@ -8,7 +8,7 @@ import logger from '../../lib/logging';
 import './locationFinder.scss';
 
 const containerEl = document.getElementsByClassName('accessible-autocomplete__container')[0];
-const inputEl = document.getElementsByClassName('js-location-finder__input')[0];
+let inputEl;
 
 export const ERROR_MESSAGE = 'Unable to find your location';
 export const LOGGING_MESSAGE = '[component: locationFinder]: Unable to find user location';
@@ -33,7 +33,7 @@ const getTargetElementId = () => {
     return document.getElementById('current-location').getAttribute('data-loader');
   }
 
-  return 'form-location-field';
+  return 'location-field';
 };
 
 export const showLocationLink = (container) => {
@@ -45,15 +45,15 @@ export const showErrorMessage = (link) => {
     const errorMessage = document.createElement('div');
     errorMessage.setAttribute('role', 'alert');
     errorMessage.id = 'js-location-finder__error';
-    errorMessage.classList.add('govuk-!-margin-top-2');
+    errorMessage.classList.add('js-location-finder__error');
     errorMessage.innerHTML = ERROR_MESSAGE;
     link.after(errorMessage);
   }
 };
 
 export const removeErrorMessage = () => {
-  if (document.querySelector('.js-location-finder__link .govuk-error-message')) {
-    document.querySelector('.js-location-finder__link .govuk-error-message').remove();
+  if (document.querySelector('.js-location-finder__error')) {
+    document.querySelector('.js-location-finder__error').remove();
   }
 };
 
@@ -71,7 +71,7 @@ export const onFailure = () => {
 
 export const postcodeFromPosition = (position, apiPromise) => apiPromise(position.coords.latitude, position.coords.longitude).then((response) => {
   if (response && response.result) {
-    onSuccess(response.result[0].postcode, document.getElementsByClassName('js-location-finder__input')[0]);
+    onSuccess(response.result[0].postcode, document.getElementsByClassName('autocomplete__input')[0]);
   } else {
     onFailure();
   }
@@ -82,6 +82,12 @@ export const postcodeFromPosition = (position, apiPromise) => apiPromise(positio
 export const init = () => {
   if (document.getElementById('current-location')) {
     document.getElementById('current-location').addEventListener('click', (event) => {
+      [inputEl] = document.getElementsByClassName('autocomplete__input');
+
+      inputEl.addEventListener('focus', () => {
+        removeErrorMessage();
+      });
+
       event.stopPropagation();
 
       startLoading(containerEl, inputEl);
@@ -92,10 +98,6 @@ export const init = () => {
         stopLoading(containerEl, inputEl);
         showErrorMessage(document.getElementById('current-location'));
       });
-    });
-
-    inputEl.addEventListener('focus', () => {
-      removeErrorMessage();
     });
   }
 };

--- a/app/frontend/src/components/locationFinder/locationFinder.scss
+++ b/app/frontend/src/components/locationFinder/locationFinder.scss
@@ -1,3 +1,5 @@
+@import '~govuk-frontend/govuk/base';
+
 .js-location-finder {
 
   position: relative;
@@ -14,6 +16,10 @@
   .govuk-c-loader__label {
     line-height: 26px;
     vertical-align: top;
+  }
+
+  &__error {
+    margin-top: govuk-spacing(2);
   }
 }
 

--- a/app/frontend/src/components/locationFinder/locationFinder.test.js
+++ b/app/frontend/src/components/locationFinder/locationFinder.test.js
@@ -27,10 +27,10 @@ describe('current location', () => {
     removeLoaderMock = jest.spyOn(loader, 'remove');
 
     document.body.innerHTML = `<div class="js-location-finder" id="test-container">
-<input type="text" id="form-location-field" class="js-location-finder__input" />
+<input type="text" id="location-field" class="autocomplete__input" />
 </div>`;
 
-    input = document.getElementById('form-location-field');
+    input = document.getElementById('location-field');
     container = document.getElementById('test-container');
   });
 


### PR DESCRIPTION
no ticket

fixes bug that location finder uses incorrect selectors with new autocomplete and autocomplete element initialisation is asynchronous (why that focus event needs to move inside event listener)

tbh this whole script needs a rewrite but after conversation with @jesseyuen we may not be keeping it anyway. if we do can be rewritten once that decision is made