### PR TITLE
[TEVA-2991] Include 'how to apply' in the review step

### DIFF
--- a/app/components/publishers/vacancy_form_page_heading_component.rb
+++ b/app/components/publishers/vacancy_form_page_heading_component.rb
@@ -22,6 +22,6 @@ class Publishers::VacancyFormPageHeadingComponent < ViewComponent::Base
   end
 
   def organisation_from_job_location
-    vacancy.job_location == "at_multiple_schools" ? "multiple schools" : vacancy.parent_organisation_name
+    vacancy.at_multiple_schools? ? "multiple schools" : vacancy.parent_organisation_name
   end
 end

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -62,22 +62,20 @@ module VacanciesHelper
 
   def vacancy_job_location(vacancy)
     organisation = vacancy.parent_organisation
-    return "#{t('publishers.organisations.readable_job_location.at_multiple_schools')}, #{organisation.name}" if
-      vacancy.job_location == "at_multiple_schools"
+    return "#{t('publishers.organisations.readable_job_location.at_multiple_schools')}, #{organisation.name}" if vacancy.at_multiple_schools?
 
     address_join([organisation.name, organisation.town, organisation.county])
   end
 
   def vacancy_full_job_location(vacancy)
     organisation = vacancy.parent_organisation
-    return "#{t('publishers.organisations.readable_job_location.at_multiple_schools')}, #{organisation.name}" if
-      vacancy.job_location == "at_multiple_schools"
+    return "#{t('publishers.organisations.readable_job_location.at_multiple_schools')}, #{organisation.name}" if vacancy.at_multiple_schools?
 
     address_join([organisation.name, organisation.town, organisation.county, organisation.postcode])
   end
 
   def vacancy_job_location_heading(vacancy)
-    return t("school_groups.job_location_heading.#{vacancy.job_location}") unless vacancy.job_location == "at_multiple_schools"
+    return t("school_groups.job_location_heading.#{vacancy.job_location}") unless vacancy.at_multiple_schools?
 
     t("school_groups.job_location_heading.at_multiple_schools", organisation_type: organisation_type_basic(vacancy.parent_organisation))
   end

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_applying_for_the_job.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_applying_for_the_job.html.slim
@@ -7,22 +7,28 @@
 
   - review.body do
     = govuk_summary_list do |component|
-      - component.slot(:row,
-        key: t("jobs.enable_job_applications"),
-        value: @vacancy.enable_job_applications? ? "Yes" : "No",
-        html_attributes: { id: "enable_job_applications" })
+      - unless current_organisation.group_type == "local_authority"
+        - component.slot(:row,
+          key: t("jobs.enable_job_applications"),
+          value: @vacancy.enable_job_applications? ? "Yes" : "No",
+          html_attributes: { id: "enable_job_applications" })
 
       - if @vacancy.enable_job_applications?
         - component.slot(:row,
           key: t("jobs.personal_statement_guidance"),
           value: @vacancy.personal_statement_guidance.presence || t("jobs.not_defined"),
           html_attributes: { id: "personal_statement_guidance" })
-
-      - elsif @vacancy.enable_job_applications == false # as opposed to nil
+      - else
         - component.slot(:row,
           key: t("jobs.application_link"),
           value: @vacancy.application_link.present? ? open_in_new_tab_link_to(@vacancy.application_link, @vacancy.application_link, "aria-label": t("jobs.aria_labels.apply_link")) : t("jobs.not_defined"),
           html_attributes: { id: "application_link" })
+
+      - if @vacancy.how_to_apply.present?
+        - component.slot(:row,
+          key: t("jobs.how_to_apply"),
+          value: @vacancy.how_to_apply,
+          html_attributes: { id: "how_to_apply" })
 
       - component.slot(:row,
         key: t("jobs.contact_email"),

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -112,6 +112,19 @@ module VacancyHelpers
   end
 
   def verify_all_vacancy_details(vacancy)
+    vacancy.reload
+    vacancy = VacancyPresenter.new(vacancy) unless vacancy.is_a?(VacancyPresenter)
+
+    unless vacancy.parent_organisation.school?
+      if vacancy.at_multiple_schools?
+        expect(page).to have_content(t("school_groups.job_location_heading.at_multiple_schools", organisation_type: organisation_type_basic(vacancy.parent_organisation)))
+      else
+        expect(page).to have_content(I18n.t("school_groups.job_location_heading.#{vacancy.job_location}"))
+      end
+      expect(page).to have_content(vacancy.organisations.first.name)
+      expect(page).to have_content(full_address(vacancy.organisations.first))
+    end
+
     expect(page).to have_content(vacancy.job_title)
     expect(page).to have_content(vacancy.show_job_roles)
     expect(page).to have_content(vacancy.show_subjects)
@@ -169,9 +182,7 @@ module VacancyHelpers
     expect(page.html).to include(vacancy.job_advert)
     expect(page.html).to include(vacancy.about_school)
 
-    if vacancy.supporting_documents.any?
-      expect(page).to have_content(I18n.t("jobs.supporting_documents"))
-    end
+    expect(page).to have_content(I18n.t("jobs.supporting_documents")) if vacancy.supporting_documents.any?
 
     if vacancy.enable_job_applications?
       expect(page).to have_link(I18n.t("jobseekers.job_applications.apply"), href: new_jobseekers_job_job_application_path(vacancy.id))

--- a/spec/system/publishers_can_publish_a_vacancy_as_a_local_authority_spec.rb
+++ b/spec/system/publishers_can_publish_a_vacancy_as_a_local_authority_spec.rb
@@ -179,6 +179,7 @@ RSpec.describe "Creating a vacancy" do
     fill_in_job_summary_form_fields(vacancy)
     click_on I18n.t("buttons.continue")
     expect(current_path).to eq(organisation_job_review_path(created_vacancy.id))
+    verify_all_vacancy_details(created_vacancy)
 
     click_on I18n.t("buttons.submit_job_listing")
     expect(current_path).to eq(organisation_job_summary_path(created_vacancy.id))

--- a/spec/system/publishers_can_publish_a_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers_can_publish_a_vacancy_as_a_school_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe "Creating a vacancy" do
                                  working_patterns: %w[full_time part_time],
                                  publish_on: Date.current))
     end
+    let(:created_vacancy) { Vacancy.last }
 
     scenario "redirects to step 1, job details" do
       visit organisation_path
@@ -381,7 +382,7 @@ RSpec.describe "Creating a vacancy" do
         within("h2.govuk-heading-l") do
           expect(page).to have_content(I18n.t("jobs.review_heading"))
         end
-        verify_all_vacancy_details(vacancy)
+        verify_all_vacancy_details(created_vacancy)
       end
     end
 

--- a/spec/system/publishers_can_publish_a_vacancy_as_a_trust_spec.rb
+++ b/spec/system/publishers_can_publish_a_vacancy_as_a_trust_spec.rb
@@ -194,6 +194,7 @@ RSpec.describe "Creating a vacancy" do
     fill_in_job_summary_form_fields(vacancy)
     click_on I18n.t("buttons.continue")
     expect(current_path).to eq(organisation_job_review_path(created_vacancy.id))
+    verify_all_vacancy_details(created_vacancy)
 
     click_on I18n.t("buttons.submit_job_listing")
     expect(current_path).to eq(organisation_job_summary_path(created_vacancy.id))


### PR DESCRIPTION
We omitted to include this information in the review step after creating a vacancy.

Also, for local authorities, there is no option to enable job applications, so we should not display the 'Apply through Teaching Vacancies: No' section (as they have not answered this question/cannot change this).

We should show the application link for local authorities, too; so the check that 'enable_job_applications' was false is updated to check that it's nil or false (since local authority vacancies have this value as nil).

https://dfedigital.atlassian.net/browse/TEVA-2991

## Before (for local authority)

<img width="812" alt="Screenshot 2021-08-09 at 15 42 34" src="https://user-images.githubusercontent.com/60350599/128725211-9b203102-5886-4211-92ad-2883fffde141.png">

## After (for local authority)

<img width="812" alt="Screenshot 2021-08-09 at 15 47 16" src="https://user-images.githubusercontent.com/60350599/128725972-188c84af-ae7e-460e-a526-00ad4b62ca1b.png">


