### PR TITLE
Don't show '0 applicants' when applications disabled

### DIFF
--- a/app/components/publishers/vacancies_component/vacancies_component.html.slim
+++ b/app/components/publishers/vacancies_component/vacancies_component.html.slim
@@ -69,10 +69,11 @@
                     = tag.div(card.labelled_item(t("jobs.publication_date"), vacancy.publish_on))
                     = tag.div(card.labelled_item(t("jobs.manage.closing_date"), vacancy.application_deadline))
                   - when "expired"
-                    - if vacancy.enable_job_applications && !vacancy_expired_over_a_year_ago?(vacancy) && vacancy.job_applications.where.not(status: %w[draft withdrawn]).any?
-                      = view_applicants(vacancy)
-                    - else
-                      = tag.div(t("jobs.manage.view_applicants", count: 0), class: "govuk-!-font-size-19")
+                    - if vacancy.enable_job_applications
+                      - if !vacancy_expired_over_a_year_ago?(vacancy) && vacancy.job_applications.where.not(status: %w[draft withdrawn]).any?
+                        = view_applicants(vacancy)
+                      - else
+                        = tag.div(t("jobs.manage.view_applicants", count: 0), class: "govuk-!-font-size-19")
                     = tag.div(card.labelled_item(t("jobs.date_listed"), vacancy.publish_on))
                     = tag.div(card.labelled_item(t("jobs.manage.expired.expired_on"), vacancy.application_deadline))
                   - when "draft"


### PR DESCRIPTION
For expired vacancies, we were showing '0 applicants' for local authority
users, even though local authorities cannot accept applications through
Teaching Vacancies.
