### PR TITLE
Use correct h4 size classes

### DIFF
--- a/app/components/jobseekers/vacancy_details_component/vacancy_details_component.html.slim
+++ b/app/components/jobseekers/vacancy_details_component/vacancy_details_component.html.slim
@@ -21,13 +21,13 @@ section#job-details class="govuk-!-margin-bottom-5"
 
   - if @vacancy.expires_at.future?
     - if @vacancy.enable_job_applications?
-      h4.govuk-heading-s = t("jobseekers.job_applications.applying_for_the_role_heading")
+      h4.govuk-heading-m = t("jobseekers.job_applications.applying_for_the_role_heading")
       p = t("jobseekers.job_applications.applying_for_the_role_paragraph")
       = govuk_link_to t("jobseekers.job_applications.apply"), new_jobseekers_job_job_application_path(@vacancy.id), button: true
 
     - else
       - if @vacancy.how_to_apply.present?
-        h4.govuk-heading-s = t("jobs.applying_for_the_job")
+        h4.govuk-heading-m = t("jobs.applying_for_the_job")
         p = @vacancy.how_to_apply
 
       - if @vacancy.application_link.present?


### PR DESCRIPTION
These sizes are correct because they match other h4s and thus distinguish themselves from bolded text in the job ad

https://ukgovernmentdfe.slack.com/archives/CG9A8H1HP/p1628676943045500
