### PR TITLE
Add 'one' to translation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -492,6 +492,7 @@ en:
       no_polygons: This search didn't use any polygons.
       title:
         zero: Find a job in teaching - Search results
+        one: Find a job in teaching - Search results
         other: Find a job in teaching - Search results page %{count}
       wider_search_suggestions:
         heading:


### PR DESCRIPTION
To fix this bug:

```
ActionView::Template::Error: translation data {:zero=>"Find a job in teaching - Search results", :other=>"Find a job in teaching - Search results page %{count}"} can not be used with :count => 1. key 'one' is missing.
```
