### PR TITLE
Drop redundant NQT suitable column

### DIFF
--- a/app/form_models/publishers/job_listing/job_details_form.rb
+++ b/app/form_models/publishers/job_listing/job_details_form.rb
@@ -20,4 +20,8 @@ class Publishers::JobListing::JobDetailsForm < Publishers::JobListing::VacancyFo
 
     errors.add(:job_title, I18n.t("job_details_errors.job_title.invalid_characters"))
   end
+
+  def params_to_save
+    super.except(:suitable_for_nqt)
+  end
 end

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -123,6 +123,10 @@ class Vacancy < ApplicationRecord
     job_applications.after_submission.count >= EQUAL_OPPORTUNITIES_PUBLICATION_THRESHOLD
   end
 
+  def suitable_for_nqt
+    job_roles.include?("nqt_suitable") ? "yes" : "no"
+  end
+
   private
 
   def slug_candidates

--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -66,8 +66,9 @@ class VacancyPresenter < BasePresenter
     model_working_patterns.compact.map(&:upcase).join(", ")
   end
 
-  def show_job_roles
-    model.job_roles.map { |job_role| I18n.t("helpers.label.publishers_job_listing_job_details_form.job_roles_options.#{job_role}") }.join(", ")
+  def show_job_roles(exclude_nqt_suitable: false)
+    roles = exclude_nqt_suitable ? model.job_roles.excluding("nqt_suitable") : model.job_roles
+    roles.map { |role| I18n.t("helpers.label.publishers_job_listing_job_details_form.job_roles_options.#{role}") }.join(", ")
   end
 
   def show_subjects

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_details.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_details.html.slim
@@ -14,7 +14,7 @@
 
       - component.slot(:row,
         key: t("jobs.job_roles"),
-        value: @vacancy.show_job_roles.presence || t("jobs.not_defined"),
+        value: @vacancy.show_job_roles(exclude_nqt_suitable: true).presence || t("jobs.not_defined"),
         html_attributes: { id: "job_roles" })
 
       - component.slot(:row,

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -301,7 +301,6 @@ shared:
     - initially_indexed
     - job_location
     - readable_job_location
-    - suitable_for_nqt
     - job_roles
     - contact_number
     - publisher_organisation_id

--- a/db/migrate/20210812121255_drop_suitable_for_nqt_column_from_vacancies.rb
+++ b/db/migrate/20210812121255_drop_suitable_for_nqt_column_from_vacancies.rb
@@ -1,0 +1,5 @@
+class DropSuitableForNqtColumnFromVacancies < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :vacancies, :suitable_for_nqt, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_06_161056) do
+ActiveRecord::Schema.define(version: 2021_08_12_121255) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -83,11 +83,11 @@ ActiveRecord::Schema.define(version: 2021_08_06_161056) do
     t.uuid "job_application_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "employment_type", default: 0
+    t.text "reason_for_break", default: ""
     t.text "organisation_ciphertext"
     t.text "job_title_ciphertext"
     t.text "main_duties_ciphertext"
-    t.integer "employment_type", default: 0
-    t.text "reason_for_break", default: ""
   end
 
   create_table "equal_opportunities_reports", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -454,7 +454,6 @@ ActiveRecord::Schema.define(version: 2021_08_06_161056) do
     t.boolean "initially_indexed", default: false
     t.integer "job_location"
     t.string "readable_job_location"
-    t.string "suitable_for_nqt"
     t.integer "job_roles", array: true
     t.string "contact_number"
     t.uuid "publisher_organisation_id"

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -26,7 +26,6 @@ FactoryBot.define do
     starts_on { 1.year.from_now.to_date }
     status { :published }
     subjects { SUBJECT_OPTIONS.sample(2).map(&:first).sort! }
-    suitable_for_nqt { "no" }
     working_patterns { %w[full_time] }
 
     trait :no_tv_applications do
@@ -127,16 +126,6 @@ FactoryBot.define do
     trait :with_feedback do
       listed_elsewhere { :listed_paid }
       hired_status { :hired_tvs }
-    end
-
-    trait :suitable_for_nqt do
-      suitable_for_nqt { "yes" }
-      job_roles { %w[nqt_suitable] }
-    end
-
-    trait :not_suitable_for_nqt do
-      suitable_for_nqt { "no" }
-      job_roles { %w[] }
     end
 
     trait :with_supporting_documents do

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -24,7 +24,7 @@ module VacancyHelpers
             visible: false
     end
 
-    vacancy.job_roles&.each do |job_role|
+    vacancy.job_roles.excluding("nqt_suitable")&.each do |job_role|
       check I18n.t("helpers.label.publishers_job_listing_job_details_form.job_roles_options.#{job_role}"),
             name: "publishers_job_listing_job_details_form[job_roles][]",
             visible: false

--- a/spec/system/publishers_can_edit_a_published_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers_can_edit_a_published_vacancy_as_a_school_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Publishers can edit a vacancy" do
     context "when the vacancy is now invalid" do
       before do
         vacancy.about_school = nil
-        vacancy.suitable_for_nqt = nil
+        vacancy.contract_type = nil
         vacancy.save(validate: false)
       end
 
@@ -40,7 +40,7 @@ RSpec.describe "Publishers can edit a vacancy" do
         expect(page).to have_content(I18n.t("messages.jobs.action_required.heading"))
         expect(page).to have_content(I18n.t("messages.jobs.action_required.message.publisher"))
         expect(page).to have_content(I18n.t("job_summary_errors.about_school.blank", organisation: "school"))
-        expect(page).to have_content(I18n.t("job_details_errors.suitable_for_nqt.inclusion"))
+        expect(page).to have_content(I18n.t("job_details_errors.contract_type.inclusion"))
       end
     end
 

--- a/spec/system/publishers_can_publish_a_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers_can_publish_a_vacancy_as_a_school_spec.rb
@@ -19,11 +19,10 @@ RSpec.describe "Creating a vacancy" do
   end
 
   context "creating a new vacancy" do
-    let(:suitable_for_nqt) { "no" }
+    let(:job_roles) { %i[teacher sen_specialist] }
     let(:vacancy) do
       VacancyPresenter.new(build(:vacancy,
-                                 job_roles: %i[teacher sen_specialist],
-                                 suitable_for_nqt: suitable_for_nqt,
+                                 job_roles: job_roles,
                                  working_patterns: %w[full_time part_time],
                                  publish_on: Date.current))
     end
@@ -84,7 +83,7 @@ RSpec.describe "Creating a vacancy" do
       end
 
       context "when job is selected as suitable for NQTs" do
-        let(:suitable_for_nqt) { "yes" }
+        let(:job_roles) { %i[nqt_suitable teacher sen_specialist] }
 
         scenario "Suitable for NQTs is appended to the job roles" do
           visit organisation_path


### PR DESCRIPTION
This column has been repeatedly [dropped](https://github.com/DFE-Digital/teaching-vacancies/pull/1603) and [readded](https://github.com/DFE-Digital/teaching-vacancies/pull/1858) depending on the flavour of the day of what filters we offer jobseekers on the search page (i.e. whether we consider NQT suitability part of job roles or something separate) and whether we ask the NQT question separately from the job roles question when vacancies are created.

We are going to add another job role soon which will, like NQT suitable, be a separate jobseeker-facing filter on the search page.

It's best if this type of data lives in the job_roles array column, rather than being duplicated into a boolean column as well. Our search ignores the boolean column and uses the job_roles array. The array data model is the most flexible; it need not map perfectly to however the search filters or questions happen to work this month, because that will inevitably vary in the future.