### PR TITLE
upgrade to postgres 12

### DIFF
--- a/terraform/workspace-variables/production.tfvars
+++ b/terraform/workspace-variables/production.tfvars
@@ -26,7 +26,7 @@ documents_s3_bucket_force_destroy = false
 # Gov.UK PaaS
 paas_space_name                        = "teaching-vacancies-production"
 paas_papertrail_service_binding_enable = true
-paas_postgres_service_plan             = "medium-ha-11"
+paas_postgres_service_plan             = "medium-ha-12"
 paas_redis_cache_service_plan          = "small-ha-5_x"
 paas_redis_queue_service_plan          = "micro-ha-5_x"
 paas_app_start_timeout                 = "180"


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2922

Changes in this PR:-

As part of moving away from Algolia, there is the need to upgrade the existing tier of postgres database in production in order to leavrage some of the capabilities that would make searching more powerful similar to Algolia's. Postgress Plugins have already been installed.