### PR TITLE
Fix NQT suitable bugs (option 1)

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -124,7 +124,16 @@ class Vacancy < ApplicationRecord
   end
 
   def suitable_for_nqt
-    job_roles.include?("nqt_suitable") ? "yes" : "no"
+    # For both (1) editing/reviewing a vacancy and (2) validating all steps when publishing a vacancy,
+    # we have to reconstruct the user's response to this question, because we don't store their
+    # boolean answer in its own separate column, but rather in the job_roles array column.
+    # But when we are showing the step for the first time, we should not pre-fill the NQT question with
+    # 'no', so we should return 'nil' here.
+    if job_roles.include?("nqt_suitable")
+      "yes"
+    elsif completed_steps.include?("job_details")
+      "no"
+    end
   end
 
   private

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_details.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_details.html.slim
@@ -19,7 +19,7 @@
 
       - component.slot(:row,
         key: t("jobs.suitable_for_nqt"),
-        value: @vacancy.suitable_for_nqt&.capitalize,
+        value: @vacancy.suitable_for_nqt&.capitalize || t("jobs.not_defined"),
         html_attributes: { id: "suitable_for_nqt" })
 
       - component.slot(:row,


### PR DESCRIPTION
The NQT suitable 'no' option was selected by default on creating a job listing after we dropped the boolean column for NQT suitable.

This solution (option 1 of 2) fixes it by reconstructing the user's answer to the question, in an imperfect but mostly acceptable way. It will fail to be correct if the user responds to the question and then selects 'Save and continue' as this will result in the step not being counted as 'complete'.
