### PR TITLE
Fix NQT suitable bugs (option 2)

### DIFF
--- a/app/controllers/concerns/publishers/wizardable.rb
+++ b/app/controllers/concerns/publishers/wizardable.rb
@@ -83,9 +83,14 @@ module Publishers::Wizardable
   def job_details_params(params)
     job_location = vacancy.job_location.presence || "at_one_school"
     readable_job_location = vacancy.readable_job_location.presence || readable_job_location(job_location, school_name: current_organisation.name)
-    if params[:publishers_job_listing_job_details_form][:suitable_for_nqt] == "yes"
-      params[:publishers_job_listing_job_details_form][:job_roles] |= [:nqt_suitable]
-    end
+    params[:publishers_job_listing_job_details_form][:job_roles] |= case params[:publishers_job_listing_job_details_form][:suitable_for_nqt]
+                                                                    when "yes"
+                                                                      [:nqt_suitable]
+                                                                    when "no"
+                                                                      [:nqt_not_suitable]
+                                                                    else
+                                                                      []
+                                                                    end
     attributes_to_merge = {
       completed_steps: completed_steps,
       job_location: job_location,

--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -38,7 +38,7 @@ class SitemapController < ApplicationController
   end
 
   def add_job_roles(map)
-    Vacancy.job_roles.each_key do |job_role|
+    Vacancy.job_roles.except(:nqt_not_suitable).each_key do |job_role|
       map.add job_role_path(job_role), period: "hourly"
     end
   end

--- a/app/form_models/jobseekers/search_form.rb
+++ b/app/form_models/jobseekers/search_form.rb
@@ -43,7 +43,7 @@ class Jobseekers::SearchForm
   end
 
   def set_facet_options
-    @job_role_options = Vacancy.job_roles.except(:nqt_suitable).keys.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_details_form.job_roles_options.#{option}")] }
+    @job_role_options = Vacancy.job_roles.except(:nqt_suitable, :nqt_not_suitable).keys.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_details_form.job_roles_options.#{option}")] }
     @phase_options = [%w[primary Primary], %w[middle Middle], %w[secondary Secondary], %w[16-19 16-19]]
     @nqt_suitable_options = Vacancy.job_roles.slice(:nqt_suitable).keys.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_details_form.job_roles_options.#{option}")] }
     @working_pattern_options = Vacancy.working_patterns.keys.map do |option|

--- a/app/form_models/jobseekers/subscription_form.rb
+++ b/app/form_models/jobseekers/subscription_form.rb
@@ -53,7 +53,7 @@ class Jobseekers::SubscriptionForm
   private
 
   def set_facet_options
-    @job_role_options = Vacancy.job_roles.except(:nqt_suitable).keys.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_details_form.job_roles_options.#{option}")] }
+    @job_role_options = Vacancy.job_roles.except(:nqt_suitable, :nqt_not_suitable).keys.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_details_form.job_roles_options.#{option}")] }
     @phase_options = [%w[primary Primary], %w[middle Middle], %w[secondary Secondary], %w[16-19 16-19]]
     @nqt_suitable_options = Vacancy.job_roles.slice(:nqt_suitable).keys.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_details_form.job_roles_options.#{option}")] }
     @working_pattern_options = Vacancy.working_patterns.keys.map do |option|

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -6,7 +6,7 @@ class Vacancy < ApplicationRecord
 
   friendly_id :slug_candidates, use: %w[slugged history]
 
-  array_enum job_roles: { teacher: 0, leadership: 1, sen_specialist: 2, nqt_suitable: 3 }
+  array_enum job_roles: { teacher: 0, leadership: 1, sen_specialist: 2, nqt_suitable: 3, nqt_not_suitable: 4 }
   array_enum working_patterns: { full_time: 0, part_time: 100, job_share: 101 }
   # Legacy vacancies can have these working_pattern options too: { compressed_hours: 102, staggered_hours: 103 }
   enum contract_type: { permanent: 0, fixed_term: 1 }
@@ -123,8 +123,16 @@ class Vacancy < ApplicationRecord
     job_applications.after_submission.count >= EQUAL_OPPORTUNITIES_PUBLICATION_THRESHOLD
   end
 
+  def searchable_job_roles
+    job_roles.excluding("nqt_not_suitable")
+  end
+
   def suitable_for_nqt
-    job_roles.include?("nqt_suitable") ? "yes" : "no"
+    if job_roles.include?("nqt_suitable")
+      "yes"
+    elsif job_roles.include?("nqt_not_suitable")
+      "no"
+    end
   end
 
   private

--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -67,7 +67,7 @@ class VacancyPresenter < BasePresenter
   end
 
   def show_job_roles(exclude_nqt_suitable: false)
-    roles = exclude_nqt_suitable ? model.job_roles.excluding("nqt_suitable") : model.job_roles
+    roles = exclude_nqt_suitable ? model.searchable_job_roles.excluding("nqt_suitable") : model.searchable_job_roles
     roles.map { |role| I18n.t("helpers.label.publishers_job_listing_job_details_form.job_roles_options.#{role}") }.join(", ")
   end
 

--- a/app/services/search/criteria_deviser.rb
+++ b/app/services/search/criteria_deviser.rb
@@ -16,7 +16,7 @@ class Search::CriteriaDeviser
       radius: (@vacancy.parent_organisation.postcode.present? ? "10" : nil),
       working_patterns: @vacancy.working_patterns,
       phases: @vacancy.education_phases,
-      job_roles: @vacancy.job_roles,
+      job_roles: @vacancy.searchable_job_roles,
       subjects: get_subjects_from_vacancy,
       keyword: keyword,
     }.delete_if { |_k, v| v.blank? }
@@ -27,7 +27,7 @@ class Search::CriteriaDeviser
     return @vacancy.subjects.first if @vacancy.subjects&.one?
     return @subjects_from_job_title.first if @subjects_from_job_title.one?
 
-    get_keywords_from_job_title.presence unless @vacancy.job_roles.present?
+    get_keywords_from_job_title.presence unless @vacancy.searchable_job_roles.present?
   end
 
   def get_subjects_from_vacancy

--- a/app/services/vacancy_facets.rb
+++ b/app/services/vacancy_facets.rb
@@ -33,7 +33,7 @@ class VacancyFacets
   end
 
   def job_role_facet
-    Vacancy.job_roles.keys.each_with_object({}) { |job_role, facets| facets[job_role] = algolia_facet_count(job_roles: [job_role]) }
+    Vacancy.job_roles.except(:nqt_not_suitable).keys.each_with_object({}) { |job_role, facets| facets[job_role] = algolia_facet_count(job_roles: [job_role]) }
   end
 
   def subject_facet

--- a/app/views/publishers/vacancies/build/job_details.html.slim
+++ b/app/views/publishers/vacancies/build/job_details.html.slim
@@ -29,7 +29,7 @@
           = f.govuk_radio_button :contract_type, :fixed_term do
             = f.govuk_text_field :contract_type_duration, label: { size: "s" }
 
-        = f.govuk_collection_check_boxes :job_roles, Vacancy.job_roles.except("nqt_suitable").keys, :to_s, :to_s, form_group: { classes: "optional-field" }
+        = f.govuk_collection_check_boxes :job_roles, Vacancy.job_roles.except(:nqt_suitable, :nqt_not_suitable).keys, :to_s, :to_s, form_group: { classes: "optional-field" }
 
         = f.govuk_collection_radio_buttons :suitable_for_nqt, %w[yes no], :to_s, :capitalize
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -179,7 +179,7 @@ Rails.application.routes.draw do
 
   match "teaching-jobs-for-:job_role",
         to: "vacancies#index", as: :job_role, via: :get,
-        constraints: ->(request) { Vacancy.job_roles.key?(request.params[:job_role]) },
+        constraints: ->(request) { Vacancy.job_roles.except(:nqt_not_suitable).key?(request.params[:job_role]) },
         defaults: { pretty: :job_role }
 
   match "teaching-jobs-for-:subject",

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -55,3 +55,16 @@ namespace :ons do
     %i[regions counties cities].each { |api_location_type| ImportPolygons.new(api_location_type: api_location_type).call }
   end
 end
+
+namespace :vacancy do
+  desc "Update job roles on published vacancies"
+  task update_job_roles: :environment do
+    # Not yet tested on a production-like database
+    Vacancy.published.find_each(batch_size: 100) do |vacancy|
+      nqt_suitable_role = vacancy.job_roles.include?("nqt_suitable") ? "nqt_suitable" : "nqt_not_suitable"
+      roles = vacancy.job_roles | [nqt_suitable_role]
+      roles_to_i = roles.map { |r| Vacancy.job_roles[r] }
+      vacancy.update_column(:job_roles, roles_to_i)
+    end
+  end
+end

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
     expires_at { 6.months.from_now.change(hour: 9, minute: 0, second: 0) }
     hired_status { nil }
     job_advert { Faker::Lorem.paragraph(sentence_count: 4) }
-    job_roles { [:teacher] }
+    job_roles { %i[teacher nqt_not_suitable] }
     job_title { Faker::Lorem.sentence[1...30].strip }
     listed_elsewhere { nil }
     personal_statement_guidance { Faker::Lorem.paragraph(sentence_count: 4) }

--- a/spec/services/search/criteria_deviser_spec.rb
+++ b/spec/services/search/criteria_deviser_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Search::CriteriaDeviser do
   let(:working_patterns) { %w[full_time part_time] }
   let(:subjects) { %w[English Maths] }
   let(:job_title) { "A wonderful job" }
-  let(:job_roles) { %w[teacher sen_specialist leadership] }
+  let(:job_roles) { %w[teacher sen_specialist leadership nqt_not_suitable] }
   let(:vacancy) do
     create(:vacancy, :at_one_school, organisation_vacancies_attributes: [{ organisation: school }],
                                      working_patterns: working_patterns,
@@ -55,8 +55,8 @@ RSpec.describe Search::CriteriaDeviser do
       expect(subject.criteria[:phases]).to eq(readable_phases)
     end
 
-    it "sets the job roles to the same as the vacancy" do
-      expect(subject.criteria[:job_roles]).to eq(job_roles)
+    it "sets the job roles to the same as the vacancy, excluding unsearchable job roles" do
+      expect(subject.criteria[:job_roles]).to eq(job_roles.excluding("nqt_not_suitable"))
     end
 
     describe "#keyword" do
@@ -94,8 +94,8 @@ RSpec.describe Search::CriteriaDeviser do
             it_behaves_like "no keyword in the criteria"
           end
 
-          context "when the job listing does not have at lease one job role" do
-            let(:job_roles) { [] }
+          context "when the job listing does not have at least one searchable job role" do
+            let(:job_roles) { ["nqt_not_suitable"] }
 
             context "when the job title contains pre-defined key words separated by spaces" do
               let(:job_title) { "Teacher of non-SEN-se, Principal-ity, getting a-Head, and of being a Teaching Assistant" }

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -24,7 +24,7 @@ module VacancyHelpers
             visible: false
     end
 
-    vacancy.job_roles.excluding("nqt_suitable")&.each do |job_role|
+    vacancy.job_roles.excluding("nqt_suitable", "nqt_not_suitable")&.each do |job_role|
       check I18n.t("helpers.label.publishers_job_listing_job_details_form.job_roles_options.#{job_role}"),
             name: "publishers_job_listing_job_details_form[job_roles][]",
             visible: false

--- a/spec/system/application_sitemap_spec.rb
+++ b/spec/system/application_sitemap_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Application sitemap" do
         expect(nodes.search("loc:contains('#{url}')").map(&:text)).to include(url)
       end
 
-      Vacancy.job_roles.each_key do |job_role|
+      Vacancy.job_roles.except(:nqt_not_suitable).each_key do |job_role|
         url = job_role_url(job_role, protocol: "https")
         expect(nodes.search("loc:contains('#{url}')").map(&:text)).to include(url)
       end

--- a/spec/system/publishers_can_edit_a_published_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers_can_edit_a_published_vacancy_as_a_school_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Publishers can edit a vacancy" do
     let(:vacancy) do
       VacancyPresenter.new(
         create(:vacancy, job_location: "at_one_school",
-                         job_roles: %i[teacher sen_specialist], working_patterns: %w[full_time part_time],
+                         job_roles: %i[teacher sen_specialist nqt_not_suitable], working_patterns: %w[full_time part_time],
                          publish_on: Date.current, expires_at: 1.day.from_now.change(hour: 9, minute: 0)),
       )
     end

--- a/spec/system/publishers_can_publish_a_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers_can_publish_a_vacancy_as_a_school_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Creating a vacancy" do
   end
 
   context "creating a new vacancy" do
-    let(:job_roles) { %i[teacher sen_specialist] }
+    let(:job_roles) { %i[teacher sen_specialist nqt_not_suitable] }
     let(:vacancy) do
       VacancyPresenter.new(build(:vacancy,
                                  job_roles: job_roles,


### PR DESCRIPTION
The NQT suitable 'no' option was selected by default on creating a job listing
after we dropped the boolean column for NQT suitable.

This solution (option 2 of 2) fixes it by introducing a 'nqt_not_suitable' job role which records the user's yes/no answer the the NQT suitable question. This lets us distinguish between yeses, nos, and 'not yet answered's. It also requires a migration task for already-published vacancies, or they will see an 'action required' info box if they edit the vacancy.