### PR TITLE
Add maintenance mode to service

### DIFF
--- a/app/views/errors/maintenance.html.slim
+++ b/app/views/errors/maintenance.html.slim
@@ -1,0 +1,5 @@
+- content_for :page_title_prefix, "Sorry, the service is unavailable"
+
+.govuk-main-wrapper
+  h1.govuk-heading-l Sorry, the service is unavailable
+  p.govuk-body We are busy making changes to the service. You will be able to use the service again soon.

--- a/config/application.rb
+++ b/config/application.rb
@@ -99,6 +99,8 @@ module TeacherVacancyService
 
     config.geocoder_lookup = :default
 
+    config.maintenance_mode = ActiveModel::Type::Boolean.new.cast(ENV["MAINTENANCE_MODE"])
+
     config.view_component.preview_paths << "#{Rails.root}/app/components/previews"
     config.view_component.preview_route = "/components"
     config.view_component.preview_controller = "PreviewsController"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,14 @@ Rails.application.routes.draw do
   end
   mount Sidekiq::Web, at: "/sidekiq"
 
+  get "check" => "application#check"
+
+  if Rails.application.config.maintenance_mode
+    # If in maintenance mode, route *all* requests to maintenance page
+    match "*path", to: "errors#maintenance", via: :all
+    root to: "errors#maintenance", as: "maintenance_root", via: :all
+  end
+
   devise_for :jobseekers, controllers: {
     confirmations: "jobseekers/confirmations",
     passwords: "jobseekers/passwords",
@@ -92,7 +100,6 @@ Rails.application.routes.draw do
 
   root "home#index"
 
-  get "check" => "application#check"
   get "sitemap" => "sitemap#show", format: "xml"
 
   get "/pages/*id" => "pages#show", as: :page, format: false
@@ -171,6 +178,7 @@ Rails.application.routes.draw do
   match "/404", as: :not_found, to: "errors#not_found", via: :all
   match "/422", as: :unprocessable_entity, to: "errors#unprocessable_entity", via: :all
   match "/500", as: :internal_server_error, to: "errors#internal_server_error", via: :all
+  match "/maintenance", as: :maintenance, to: "errors#maintenance", via: :all
 
   # If parameters are used that are the same as those in the search form, pagination with kaminari will break
   match "teaching-jobs-in-:location_facet",

--- a/documentation/maintenance-mode.md
+++ b/documentation/maintenance-mode.md
@@ -1,0 +1,10 @@
+# Maintenance mode
+
+The application has a simple routing-level maintenance mode triggered by the `MAINTENANCE_MODE`
+environment variable. This needs the app to be restarted to enable maintenance mode, e.g. via
+a deploy or a `cf restage`. This is handy in case of a critical bug being discovered where we need
+to take the service offline, or in case of maintenance where we want to avoid users interacting
+with the service while
+
+When enabled, all requests of all types will be routed to the maintenance page (found under
+`app/views/errors/maintenance.html.erb`).


### PR DESCRIPTION
Adds a simple routing-based maintenance mode triggered by an env
variable to take the service offline (e.g. for maintenance or in
case of other issues).