### PR TITLE
Push image even on scan failure

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -151,7 +151,7 @@ jobs:
             snyk/snyk-cli:docker test --docker ${{ env.DOCKER_REPOSITORY }}:${{ env.DOCKER_IMAGE_TAG }} --file=Dockerfile
 
       - name: Push ${{ env.DOCKER_REPOSITORY }} images
-        if: ${{ success() }}
+        if: ${{ always() }}
         run: docker image push --all-tags ${{ env.DOCKER_REPOSITORY }}
 
   deploy:


### PR DESCRIPTION
## Jira ticket URL

- Just add the ticket number to the end:

https://dfedigital.atlassian.net/browse/TEVA-

## Changes in this PR:

Push docker image even on scan failure