### PR TITLE
[TEVA-3024] improve accessibilty markup for footer links

### DIFF
--- a/app/views/home/_vacancy_facets.html.slim
+++ b/app/views/home/_vacancy_facets.html.slim
@@ -5,9 +5,8 @@
       - @vacancy_facets.cities.each do |city, count|
         li
           = govuk_link_to location_path(city) do
-              span.govuk-visually-hidden
-                = "#{t('.link_prefix_visually_hidden')} "
-              = "#{city} (#{count})"
+            = "#{city} "
+            = t(".link_text_html", count: count)
 
   .govuk-grid-column-one-half data={ "facet-type": "counties" }
     h3.govuk-heading-s = t(".counties")
@@ -15,9 +14,8 @@
       - @vacancy_facets.counties.each do |county, count|
         li
           = govuk_link_to location_path(county) do
-            span.govuk-visually-hidden
-              = "#{t('.link_prefix_visually_hidden')} "
-            = "#{county} (#{count})"
+            = "#{county} "
+            = t(".link_text_html", count: count)
 
 .govuk-grid-row
   .govuk-grid-column-one-half data={ "facet-type": "subjects" }
@@ -26,9 +24,8 @@
       - @vacancy_facets.subjects.each do |subject, count|
         li
           = govuk_link_to subject_path(subject) do
-            span.govuk-visually-hidden
-              = "#{t('.link_prefix_visually_hidden')} "
-            = "#{subject} (#{count})"
+            = "#{subject} "
+            = t(".link_text_html", count: count)
 
   .govuk-grid-column-one-half data={ "facet-type": "job_roles" }
     h3.govuk-heading-s = t(".job_roles")
@@ -36,6 +33,5 @@
       - @vacancy_facets.job_roles.each do |job_role, count|
         li
           = govuk_link_to job_role_path(job_role) do
-            span.govuk-visually-hidden
-              = "#{t('.link_prefix_visually_hidden')} "
-            = "#{t("helpers.label.publishers_job_listing_job_details_form.job_roles_options.#{job_role}")} (#{count})"
+            = "#{t("helpers.label.publishers_job_listing_job_details_form.job_roles_options.#{job_role}")} "
+            = t(".link_text_html", count: count)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -242,7 +242,7 @@ en:
       cities: Cities and towns with teaching jobs
       counties: Counties with teaching jobs
       job_roles: Current teaching jobs by role
-      link_prefix_visually_hidden: View all vacancies for
+      link_text_html: <span class="govuk-visually-hidden"> view </span><span class="bracket-content">%{count}</span><span class="govuk-visually-hidden"> vacancies listed</span>
       subjects: Current teaching jobs by subject
 
   pages:

--- a/spec/system/jobseekers_can_view_and_visit_homepage_facets_spec.rb
+++ b/spec/system/jobseekers_can_view_and_visit_homepage_facets_spec.rb
@@ -19,11 +19,11 @@ RSpec.describe "Jobseekers can view and visit homepage facets", vcr: { cassette_
 
   describe "job roles" do
     it "has the expected facet" do
-      expect(page).to have_css("div[data-facet-type='job_roles']", text: "Teacher (1)")
+      expect(page).to have_css("div[data-facet-type='job_roles']", text: "Teacher view 1 vacancies listed")
     end
 
     it "goes to the correct landing page and checks the job roles filter" do
-      within "div[data-facet-type='job_roles']", text: "Teacher (1)" do
+      within "div[data-facet-type='job_roles']", text: "Teacher view 1 vacancies listed" do
         click_on "Teacher"
       end
 
@@ -34,11 +34,11 @@ RSpec.describe "Jobseekers can view and visit homepage facets", vcr: { cassette_
 
   describe "subjects" do
     it "has the expected facet" do
-      expect(page).to have_css("div[data-facet-type='subjects']", text: "Bengali (5)")
+      expect(page).to have_css("div[data-facet-type='subjects']", text: "Bengali view 5 vacancies listed")
     end
 
     it "goes to the correct landing page and checks the job roles filter" do
-      within "div[data-facet-type='subjects']", text: "Bengali (5)" do
+      within "div[data-facet-type='subjects']", text: "Bengali view 5 vacancies listed" do
         click_on "Bengali"
       end
 
@@ -49,11 +49,11 @@ RSpec.describe "Jobseekers can view and visit homepage facets", vcr: { cassette_
 
   describe "cities" do
     it "has the expected facet" do
-      expect(page).to have_css("div[data-facet-type='cities']", text: "London (10)")
+      expect(page).to have_css("div[data-facet-type='cities']", text: "London view 10 vacancies listed")
     end
 
     it "goes to the correct landing page and checks the job roles filter" do
-      within "div[data-facet-type='cities']", text: "London (10)" do
+      within "div[data-facet-type='cities']", text: "London view 10 vacancies listed" do
         click_on "London"
       end
 
@@ -64,11 +64,11 @@ RSpec.describe "Jobseekers can view and visit homepage facets", vcr: { cassette_
 
   describe "counties" do
     it "has the expected facet" do
-      expect(page).to have_css("div[data-facet-type='counties']", text: "Devon (15)")
+      expect(page).to have_css("div[data-facet-type='counties']", text: "Devon view 15 vacancies listed")
     end
 
     it "goes to the correct landing page and fills the location field" do
-      within "div[data-facet-type='counties']", text: "Devon (15)" do
+      within "div[data-facet-type='counties']", text: "Devon view 15 vacancies listed" do
         click_on "Devon"
       end
 


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-3024

- makes the screen reader readout a bit more sensible
- puts the brackets into pseudo content as i feel would get very repetitive for screenreader with the amount of link t0 tab through

![Screenshot 2021-08-17 at 10 01 06](https://user-images.githubusercontent.com/1792451/129696568-e9b95c22-d914-47dc-94f4-70eb08603890.png)

