### PR TITLE
Uncache the build image

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -93,9 +93,9 @@ jobs:
             BUILDKIT_INLINE_CACHE=1
           # Cache from builder target tagged with branch name, may be empty first time branch is pushed
           # Cache from builder target tagged with master branch name, always present, maybe less recent
-          cache-from: |
-            ${{ env.DOCKER_REPOSITORY }}:builder-${{ env.GIT_BRANCH }}
-            ${{ env.DOCKER_REPOSITORY }}:builder-master
+          #cache-from: |
+          #  ${{ env.DOCKER_REPOSITORY }}:builder-${{ env.GIT_BRANCH }}
+          #  ${{ env.DOCKER_REPOSITORY }}:builder-master
           push: true
           # Tag with branch name for reuse
           tags: ${{ env.DOCKER_REPOSITORY }}:builder-${{ env.GIT_BRANCH }}
@@ -110,10 +110,10 @@ jobs:
           # Cache from builder target built above, always present
           # Cache from production target tagged with branch name, may be empty first time branch is pushed
           # Cache from production target tagged with master branch name, always present, maybe less recent
-          cache-from: |
-            ${{ env.DOCKER_REPOSITORY }}:builder-${{ env.GIT_BRANCH }}
-            ${{ env.DOCKER_REPOSITORY }}:${{ env.GIT_BRANCH }}
-            ${{ env.DOCKER_REPOSITORY }}:master
+          #cache-from: |
+          #  ${{ env.DOCKER_REPOSITORY }}:builder-${{ env.GIT_BRANCH }}
+          #  ${{ env.DOCKER_REPOSITORY }}:${{ env.GIT_BRANCH }}
+          #  ${{ env.DOCKER_REPOSITORY }}:master
           push: false
           load: true
           # Tag with branch name for reuse


### PR DESCRIPTION
From time to time, it might be neccesary to update all packages in the docker image.
In this particular case, we like to solve CVE-2021-3677. As the apk command had been
cached, the libpq package had not been upgraded and it is vulnerable.

## Jira ticket URL

- Just add the ticket number to the end:

https://dfedigital.atlassian.net/browse/TEVA-

## Changes in this PR:

Update all packages in the docker image