### PR TITLE
Refactor job creation steps translations

### DIFF
--- a/app/components/jobseekers/vacancy_details_component/vacancy_details_component.html.slim
+++ b/app/components/jobseekers/vacancy_details_component/vacancy_details_component.html.slim
@@ -1,6 +1,6 @@
 section#job-details class="govuk-!-margin-bottom-5"
   h3.govuk-heading-l.section-heading
-    = t("jobs.job_details")
+    = t("publishers.vacancies.steps.job_details")
 
   = render GovukComponent::SummaryList.new do |component|
     - if @vacancy.job_roles.any?
@@ -16,7 +16,7 @@ section#job-details class="govuk-!-margin-bottom-5"
     - else
       = component.slot(:row, key: I18n.t("jobs.salary"), value: @vacancy.salary)
 
-  h4.govuk-heading-m = t("jobs.job_summary")
+  h4.govuk-heading-m = t("publishers.vacancies.steps.job_summary")
   p = @vacancy.job_advert
 
   - if @vacancy.benefits.present?
@@ -31,7 +31,7 @@ section#job-details class="govuk-!-margin-bottom-5"
 
     - else
       - if @vacancy.how_to_apply.present?
-        h4.govuk-heading-m = t("jobs.applying_for_the_job")
+        h4.govuk-heading-m = t("publishers.vacancies.steps.applying_for_the_job")
         p = @vacancy.how_to_apply
 
       - if @vacancy.application_link.present?
@@ -41,7 +41,7 @@ section#job-details class="govuk-!-margin-bottom-5"
 
   - if @vacancy.supporting_documents.any?
     section#supporting-documents
-      h3.govuk-heading-l.section-heading = t("jobs.supporting_documents")
+      h3.govuk-heading-l.section-heading = t("publishers.vacancies.steps.documents")
       p.govuk-body = t("jobs.supporting_documents_accessibility")
       .grey-border-box--thin
         = render SupportingDocumentComponent.with_collection(@vacancy.supporting_documents)

--- a/app/controllers/concerns/publishers/wizardable.rb
+++ b/app/controllers/concerns/publishers/wizardable.rb
@@ -6,15 +6,15 @@ module Publishers::Wizardable
 
   def steps_config
     {
-      job_location: { number: 1, title: I18n.t("jobs.job_location") },
-      schools: { number: 1, title: I18n.t("jobs.job_location") },
-      job_details: { number: 2, title: I18n.t("jobs.job_details") },
-      pay_package: { number: 3, title: I18n.t("jobs.pay_package") },
-      important_dates: { number: 4, title: I18n.t("jobs.important_dates") },
-      documents: { number: 5, title: I18n.t("jobs.supporting_documents") },
-      applying_for_the_job: { number: 6, title: I18n.t("jobs.applying_for_the_job") },
-      job_summary: { number: 7, title: I18n.t("jobs.job_summary") },
-      review: { number: 8, title: I18n.t("jobs.review_heading") },
+      job_location: { number: 1, title: I18n.t("publishers.vacancies.steps.job_location") },
+      schools: { number: 1, title: I18n.t("publishers.vacancies.steps.job_location") },
+      job_details: { number: 2, title: I18n.t("publishers.vacancies.steps.job_details") },
+      pay_package: { number: 3, title: I18n.t("publishers.vacancies.steps.pay_package") },
+      important_dates: { number: 4, title: I18n.t("publishers.vacancies.steps.important_dates") },
+      documents: { number: 5, title: I18n.t("publishers.vacancies.steps.documents") },
+      applying_for_the_job: { number: 6, title: I18n.t("publishers.vacancies.steps.applying_for_the_job") },
+      job_summary: { number: 7, title: I18n.t("publishers.vacancies.steps.job_summary") },
+      review: { number: 8, title: I18n.t("publishers.vacancies.steps.review_heading") },
     }.freeze
   end
 

--- a/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
+++ b/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, page_title_prefix(vacancy, form, t("jobs.applying_for_the_job"))
+- content_for :page_title_prefix, page_title_prefix(vacancy, form, t("publishers.vacancies.steps.applying_for_the_job"))
 
 .govuk-main-wrapper
   .govuk-grid-row
@@ -11,7 +11,7 @@
       = form_for form, url: wizard_path, method: :patch do |f|
         = f.govuk_error_summary
 
-        h2.govuk-heading-l = t("jobs.applying_for_the_job")
+        h2.govuk-heading-l = t("publishers.vacancies.steps.applying_for_the_job")
 
         - if vacancy.listed? || current_organisation.local_authority?
           = f.hidden_field :enable_job_applications

--- a/app/views/publishers/vacancies/build/important_dates.html.slim
+++ b/app/views/publishers/vacancies/build/important_dates.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, page_title_prefix(vacancy, form, t("jobs.important_dates"))
+- content_for :page_title_prefix, page_title_prefix(vacancy, form, t("publishers.vacancies.steps.important_dates"))
 
 .govuk-main-wrapper
   .govuk-grid-row
@@ -11,7 +11,7 @@
       = form_for form, url: wizard_path, method: :patch do |f|
         = f.govuk_error_summary
 
-        h2.govuk-heading-l = t("jobs.important_dates")
+        h2.govuk-heading-l = t("publishers.vacancies.steps.important_dates")
 
         - if form.disable_editing_publish_on?
           #publish_on

--- a/app/views/publishers/vacancies/build/job_details.html.slim
+++ b/app/views/publishers/vacancies/build/job_details.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, page_title_prefix(vacancy, form, t("jobs.job_details"))
+- content_for :page_title_prefix, page_title_prefix(vacancy, form, t("publishers.vacancies.steps.job_details"))
 
 .govuk-main-wrapper
   .govuk-grid-row
@@ -12,7 +12,7 @@
       = form_for form, url: wizard_path, method: :patch do |f|
         = f.govuk_error_summary
 
-        h2.govuk-heading-l = t("jobs.job_details")
+        h2.govuk-heading-l = t("publishers.vacancies.steps.job_details")
 
         .govuk-character-count data-module="govuk-character-count" data-maxlength=100
           = f.govuk_text_field :job_title,

--- a/app/views/publishers/vacancies/build/job_location.html.slim
+++ b/app/views/publishers/vacancies/build/job_location.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, page_title_prefix(vacancy, form, t("jobs.job_location"))
+- content_for :page_title_prefix, page_title_prefix(vacancy, form, t("publishers.vacancies.steps.job_location"))
 
 .govuk-main-wrapper
   .govuk-grid-row
@@ -10,7 +10,7 @@
       = form_for form, url: wizard_path, method: :patch do |f|
         = f.govuk_error_summary
 
-        h2.govuk-heading-l = t("jobs.job_location")
+        h2.govuk-heading-l = t("publishers.vacancies.steps.job_location")
 
         = f.govuk_collection_radio_buttons :job_location, t("helpers.options.publishers_job_listing_job_location_form.job_location.#{current_organisation.group_type}"), :first, :last
 

--- a/app/views/publishers/vacancies/build/job_summary.html.slim
+++ b/app/views/publishers/vacancies/build/job_summary.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, page_title_prefix(vacancy, form, t("jobs.job_summary"))
+- content_for :page_title_prefix, page_title_prefix(vacancy, form, t("publishers.vacancies.steps.job_summary"))
 
 .govuk-main-wrapper
   .govuk-grid-row
@@ -11,7 +11,7 @@
       = form_for form, url: wizard_path, method: :patch do |f|
         = f.govuk_error_summary
 
-        h2.govuk-heading-l = t("jobs.job_summary")
+        h2.govuk-heading-l = t("publishers.vacancies.steps.job_summary")
 
         = f.govuk_text_area :job_advert, label: { size: "s", id: "job-advert-label" }, rows: 10, required: true
 

--- a/app/views/publishers/vacancies/build/pay_package.html.slim
+++ b/app/views/publishers/vacancies/build/pay_package.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, page_title_prefix(vacancy, form, t("jobs.pay_package"))
+- content_for :page_title_prefix, page_title_prefix(vacancy, form, t("publishers.vacancies.steps.pay_package"))
 
 .govuk-main-wrapper
   .govuk-grid-row
@@ -11,7 +11,7 @@
       = form_for form, url: wizard_path, method: :patch do |f|
         = f.govuk_error_summary
 
-        h2.govuk-heading-l = t("jobs.pay_package")
+        h2.govuk-heading-l = t("publishers.vacancies.steps.pay_package")
 
         = f.govuk_text_field :salary, label: { size: "s" }, required: true
         - unless vacancy.working_patterns == ["full_time"]

--- a/app/views/publishers/vacancies/build/schools.html.slim
+++ b/app/views/publishers/vacancies/build/schools.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, page_title_prefix(vacancy, form, t("jobs.job_location"))
+- content_for :page_title_prefix, page_title_prefix(vacancy, form, t("publishers.vacancies.steps.job_location"))
 
 .govuk-main-wrapper
   .govuk-grid-row
@@ -11,7 +11,7 @@
       = form_for form, url: wizard_path, method: :patch do |f|
         = f.govuk_error_summary
 
-        h2.govuk-heading-l = t("jobs.job_location")
+        h2.govuk-heading-l = t("publishers.vacancies.steps.job_location")
 
         = f.govuk_fieldset legend: { text: t("helpers.legend.publishers_job_listing_schools_form.organisation_id#{'s' if @multiple_schools}") } do
           - if current_organisation.local_authority?

--- a/app/views/publishers/vacancies/documents/show.html.slim
+++ b/app/views/publishers/vacancies/documents/show.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, page_title_prefix(vacancy, form, t("jobs.supporting_documents"))
+- content_for :page_title_prefix, page_title_prefix(vacancy, form, t("publishers.vacancies.steps.documents"))
 
 .govuk-main-wrapper
   .govuk-grid-row
@@ -13,7 +13,7 @@
         = f.govuk_error_summary
 
         h2.govuk-heading-l
-          = t("jobs.supporting_documents")
+          = t("publishers.vacancies.steps.documents")
 
         #js-xhr-flashes
 

--- a/app/views/publishers/vacancies/edit.html.slim
+++ b/app/views/publishers/vacancies/edit.html.slim
@@ -7,7 +7,7 @@
 
   .vacancy.govuk-grid-row
     .govuk-grid-column-two-thirds
-      h2.govuk-heading-l = t("jobs.review_heading")
+      h2.govuk-heading-l = t("publishers.vacancies.steps.review_heading")
       = render "shared/error_messages", errors: @vacancy.errors
 
       ol.app-task-list

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_applying_for_the_job.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_applying_for_the_job.html.slim
@@ -1,7 +1,7 @@
 = render "publishers/vacancies/error_tag", attributes: applying_for_the_job_fields
 
 = render ReviewComponent.new id: "applying_for_the_job" do |review|
-  - review.heading title: t("jobs.applying_for_the_job"),
+  - review.heading title: t("publishers.vacancies.steps.applying_for_the_job"),
                    text: t("buttons.change"),
                    href: organisation_job_build_path(@vacancy.id, :applying_for_the_job)
 

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_important_dates.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_important_dates.html.slim
@@ -2,7 +2,7 @@
 
 #expiry_time
 = render ReviewComponent.new id: "important_dates" do |review|
-  - review.heading title: t("jobs.important_dates"),
+  - review.heading title: t("publishers.vacancies.steps.important_dates"),
                    text: t("buttons.change"),
                    href: organisation_job_build_path(@vacancy.id, :important_dates)
 

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_details.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_details.html.slim
@@ -1,7 +1,7 @@
 = render "publishers/vacancies/error_tag", attributes: job_details_fields
 
 = render ReviewComponent.new id: "job_details" do |review|
-  - review.heading title: t("jobs.job_details"),
+  - review.heading title: t("publishers.vacancies.steps.job_details"),
                    text: t("buttons.change"),
                    href: organisation_job_build_path(@vacancy.id, :job_details)
 

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_location.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_location.html.slim
@@ -1,7 +1,7 @@
 = render "publishers/vacancies/error_tag", attributes: (job_location_fields + schools_fields)
 
 = render ReviewComponent.new id: "job_location" do |review|
-  - review.heading title: t("jobs.job_location"),
+  - review.heading title: t("publishers.vacancies.steps.job_location"),
                    text: t("buttons.change"),
                    href: organisation_job_build_path(@vacancy.id, :job_location)
 

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_summary.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_summary.html.slim
@@ -1,7 +1,7 @@
 = render "publishers/vacancies/error_tag", attributes: job_summary_fields
 
 = render ReviewComponent.new id: "job_summary" do |review|
-  - review.heading title: t("jobs.job_summary"),
+  - review.heading title: t("publishers.vacancies.steps.job_summary"),
                    text: t("buttons.change"),
                    href: organisation_job_build_path(@vacancy.id, :job_summary)
 

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_pay_package.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_pay_package.html.slim
@@ -1,7 +1,7 @@
 = render "publishers/vacancies/error_tag", attributes: pay_package_fields
 
 = render ReviewComponent.new id: "pay_package" do |review|
-  - review.heading title: t("jobs.pay_package"),
+  - review.heading title: t("publishers.vacancies.steps.pay_package"),
                    text: t("buttons.change"),
                    href: organisation_job_build_path(@vacancy.id, :pay_package)
 

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_supporting_documents.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_supporting_documents.html.slim
@@ -1,5 +1,5 @@
 = render ReviewComponent.new id: "supporting_documents" do |review|
-  - review.heading title: t("jobs.supporting_documents"),
+  - review.heading title: t("publishers.vacancies.steps.documents"),
                    text: t("buttons.change"),
                    href: organisation_job_build_path(@vacancy.id, :documents)
 

--- a/app/views/publishers/vacancies/review.html.slim
+++ b/app/views/publishers/vacancies/review.html.slim
@@ -7,7 +7,7 @@
 
   .vacancy.govuk-grid-row
     .govuk-grid-column-two-thirds
-      h2.govuk-heading-l = t("jobs.review_heading")
+      h2.govuk-heading-l = t("publishers.vacancies.steps.review_heading")
       = render "shared/error_messages", errors: @vacancy.errors
 
       p.govuk-body-l

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -172,14 +172,11 @@ en:
     manage_listing: Manage listing
     new_job_listing_details: New job listing details
     review_page_title: Review the job listing — Create a job listing for %{organisation}
-    review_heading: Review the job listing
     edit_job_title: Edit %{job_title}
     current_step: Step %{step} of %{total}
 
-    job_location: Job location
     location: Location
 
-    job_details: Job details
     job_title: Job title
     job_roles: Job role
     suitable_for_nqt: Is this job suitable for NQTs?
@@ -196,12 +193,10 @@ en:
     annual_salary: Annual or full-time equivalent (FTE) salary
     salary: Salary
     benefits: Additional allowances
-    pay_package: Pay package
 
     school_visits_html: School visits
     trust_visits_html: Trust visits
 
-    important_dates: Important dates and deadlines
     application_deadline: Application deadline
     days_to_apply:
       remaining: '%{days_remaining} days remaining to apply'
@@ -215,7 +210,6 @@ en:
     expires_at: Closing date
     time_at: at
 
-    supporting_documents: Supporting documents
     supporting_documents_accessibility: If you need these documents in an accessible format, please contact the school.
     no_files_message: No files selected
     no_supporting_documents: No documents uploaded
@@ -240,7 +234,6 @@ en:
         remove: Remove
         removing: Removing...
 
-    applying_for_the_job: Applying for the job
     apply: More on how to apply
     application_link: Link to online application
     contact_email: Contact email
@@ -252,7 +245,6 @@ en:
     school_visits_heading: Arranging a visit to %{school}
     how_to_apply: Application instructions
 
-    job_summary: Job summary
     job_advert: Job advert
     about_school: About %{school}
 

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -265,6 +265,16 @@ en:
       show:
         view_live_listing_link: View this listing
         view_live_listing_title: View the live listing
+      steps:
+        job_location: Job location
+        schools: Job location
+        job_details: Job details
+        pay_package: Pay package
+        important_dates: Important dates and deadlines
+        documents: Supporting documents
+        applying_for_the_job: Applying for the job
+        job_summary: Job summary
+        review_heading: Review the job listing
       summary:
         date_expires: >-
           The listing will appear on the service until %{application_deadline}, after which it will no longer be

--- a/spec/components/jobseekers/vacancy_details_component_spec.rb
+++ b/spec/components/jobseekers/vacancy_details_component_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Jobseekers::VacancyDetailsComponent, type: :component do
     let(:vacancy) { create(:vacancy, :no_tv_applications) }
 
     it "renders the how_to_apply label" do
-      expect(rendered_component).to include(I18n.t("jobs.applying_for_the_job"))
+      expect(rendered_component).to include(I18n.t("publishers.vacancies.steps.applying_for_the_job"))
     end
 
     it "renders the how_to_apply" do
@@ -122,7 +122,7 @@ RSpec.describe Jobseekers::VacancyDetailsComponent, type: :component do
     let(:vacancy) { create(:vacancy, :expired) }
 
     it "does not render the application headings" do
-      expect(rendered_component).not_to include(I18n.t("jobs.applying_for_the_job"))
+      expect(rendered_component).not_to include(I18n.t("publishers.vacancies.steps.applying_for_the_job"))
       expect(rendered_component).not_to include(I18n.t("jobseekers.job_applications.applying_for_the_role_heading"))
     end
 

--- a/spec/smoke_tests/jobseekers_can_view_homepage_spec.rb
+++ b/spec/smoke_tests/jobseekers_can_view_homepage_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Page availability", js: true, smoke_test: true do
 
       if page.has_css?(".view-vacancy-link")
         page.first(".view-vacancy-link").click
-        expect(page).to have_content(I18n.t("jobs.job_summary"))
+        expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_summary"))
         expect(page.current_url).to include("https://#{smoke_test_domain}/jobs/")
       end
     end

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -5,7 +5,7 @@ module VacancyHelpers
 
   def change_job_location(vacancy, location, group_type)
     vacancy.job_location = location
-    click_header_link(I18n.t("jobs.job_location"))
+    click_header_link(I18n.t("publishers.vacancies.steps.job_location"))
     fill_in_job_location_form_field(vacancy, group_type)
     click_on I18n.t("buttons.continue")
   end
@@ -142,7 +142,7 @@ module VacancyHelpers
       expect(page).to have_content(I18n.t("jobs.starts_asap"))
     end
 
-    expect(page).to have_content(I18n.t("jobs.supporting_documents"))
+    expect(page).to have_content(I18n.t("publishers.vacancies.steps.documents"))
 
     expect(page).to have_content(vacancy.contact_email)
     expect(page).to have_content(vacancy.contact_number)
@@ -183,7 +183,7 @@ module VacancyHelpers
     expect(page.html).to include(vacancy.job_advert)
     expect(page.html).to include(vacancy.about_school)
 
-    expect(page).to have_content(I18n.t("jobs.supporting_documents")) if vacancy.supporting_documents.any?
+    expect(page).to have_content(I18n.t("publishers.vacancies.steps.documents")) if vacancy.supporting_documents.any?
 
     if vacancy.enable_job_applications?
       expect(page).to have_link(I18n.t("jobseekers.job_applications.apply"), href: new_jobseekers_job_job_application_path(vacancy.id))

--- a/spec/system/jobseekers_can_view_a_vacancy_spec.rb
+++ b/spec/system/jobseekers_can_view_a_vacancy_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Viewing a single published vacancy" do
       let(:vacancy) { create(:vacancy, :published, :with_supporting_documents) }
 
       scenario "can see the supporting documents section" do
-        expect(page).to have_content(I18n.t("jobs.supporting_documents"))
+        expect(page).to have_content(I18n.t("publishers.vacancies.steps.documents"))
         expect(page).to have_content(vacancy.supporting_documents.first.filename)
       end
     end

--- a/spec/system/publishers_can_copy_a_vacancy_spec.rb
+++ b/spec/system/publishers_can_copy_a_vacancy_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "Copying a vacancy" do
     click_on I18n.t("buttons.continue")
 
     within("h2.govuk-heading-l") do
-      expect(page).to have_content(I18n.t("jobs.review_heading"))
+      expect(page).to have_content(I18n.t("publishers.vacancies.steps.review_heading"))
     end
     click_on I18n.t("buttons.submit_job_listing")
 
@@ -107,7 +107,7 @@ RSpec.describe "Copying a vacancy" do
       click_on I18n.t("buttons.continue")
 
       within("h2.govuk-heading-l") do
-        expect(page).to have_content(I18n.t("jobs.review_heading"))
+        expect(page).to have_content(I18n.t("publishers.vacancies.steps.review_heading"))
       end
       expect(page).to have_content("Some description about the school")
 
@@ -134,7 +134,7 @@ RSpec.describe "Copying a vacancy" do
       click_on I18n.t("buttons.continue")
 
       within("h2.govuk-heading-l") do
-        expect(page).to have_content(I18n.t("jobs.review_heading"))
+        expect(page).to have_content(I18n.t("publishers.vacancies.steps.review_heading"))
       end
     end
   end
@@ -163,7 +163,7 @@ RSpec.describe "Copying a vacancy" do
       click_on I18n.t("buttons.continue")
 
       within("h2.govuk-heading-l") do
-        expect(page).to have_content(I18n.t("jobs.review_heading"))
+        expect(page).to have_content(I18n.t("publishers.vacancies.steps.review_heading"))
       end
     end
   end

--- a/spec/system/publishers_can_edit_a_draft_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers_can_edit_a_draft_vacancy_as_a_school_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Publishers can edit a draft vacancy" do
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 7))
         within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("jobs.pay_package"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.pay_package"))
         end
       end
 
@@ -41,7 +41,7 @@ RSpec.describe "Publishers can edit a draft vacancy" do
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 3, total: 7))
         within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("jobs.important_dates"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.important_dates"))
         end
       end
 
@@ -63,7 +63,7 @@ RSpec.describe "Publishers can edit a draft vacancy" do
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 4, total: 7))
         within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("jobs.supporting_documents"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.documents"))
         end
       end
 
@@ -87,7 +87,7 @@ RSpec.describe "Publishers can edit a draft vacancy" do
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 5, total: 7))
         within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("jobs.applying_for_the_job"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.applying_for_the_job"))
         end
       end
 
@@ -117,7 +117,7 @@ RSpec.describe "Publishers can edit a draft vacancy" do
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 6, total: 7))
         within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("jobs.job_summary"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_summary"))
         end
       end
     end
@@ -154,7 +154,7 @@ RSpec.describe "Publishers can edit a draft vacancy" do
         published_vacancy = create(:vacancy, :published)
         published_vacancy.organisation_vacancies.create(organisation: school)
         visit edit_organisation_job_path(published_vacancy.id)
-        click_header_link(I18n.t("jobs.applying_for_the_job"))
+        click_header_link(I18n.t("publishers.vacancies.steps.applying_for_the_job"))
 
         fill_in "publishers_job_listing_applying_for_the_job_form[personal_statement_guidance]", with: "Some different guidance"
         click_on I18n.t("buttons.update_job")
@@ -173,7 +173,7 @@ RSpec.describe "Publishers can edit a draft vacancy" do
       scenario "can cancel and return from job details page" do
         visit organisation_job_review_path(vacancy.id)
 
-        click_header_link(I18n.t("jobs.job_details"))
+        click_header_link(I18n.t("publishers.vacancies.steps.job_details"))
         expect(page).to have_content(I18n.t("buttons.cancel_and_return"))
 
         click_on I18n.t("buttons.cancel_and_return")

--- a/spec/system/publishers_can_edit_a_published_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers_can_edit_a_published_vacancy_as_a_school_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Publishers can edit a vacancy" do
     scenario "redirects to the review vacancy page" do
       visit edit_organisation_job_path(vacancy.id)
 
-      expect(page).to have_content(I18n.t("jobs.review_heading"))
+      expect(page).to have_content(I18n.t("publishers.vacancies.steps.review_heading"))
     end
   end
 
@@ -68,7 +68,7 @@ RSpec.describe "Publishers can edit a vacancy" do
       scenario "can cancel and return from job details page" do
         visit edit_organisation_job_path(vacancy.id)
 
-        click_header_link(I18n.t("jobs.job_details"))
+        click_header_link(I18n.t("publishers.vacancies.steps.job_details"))
         expect(page).to have_content(I18n.t("buttons.cancel_and_return"))
 
         click_on I18n.t("buttons.cancel_and_return")
@@ -83,7 +83,7 @@ RSpec.describe "Publishers can edit a vacancy" do
         within("h1.govuk-heading-m") do
           expect(page).to have_content(I18n.t("jobs.edit_job_title", job_title: vacancy.job_title))
         end
-        click_header_link(I18n.t("jobs.job_details"))
+        click_header_link(I18n.t("publishers.vacancies.steps.job_details"))
 
         fill_in "publishers_job_listing_job_details_form[job_title]", with: ""
         click_on I18n.t("buttons.update_job")
@@ -93,7 +93,7 @@ RSpec.describe "Publishers can edit a vacancy" do
 
       scenario "can be successfully edited" do
         visit edit_organisation_job_path(vacancy.id)
-        click_header_link(I18n.t("jobs.job_details"))
+        click_header_link(I18n.t("publishers.vacancies.steps.job_details"))
 
         fill_in "publishers_job_listing_job_details_form[job_title]", with: "Assistant Head Teacher"
         click_on I18n.t("buttons.update_job")
@@ -106,7 +106,7 @@ RSpec.describe "Publishers can edit a vacancy" do
         vacancy = create(:vacancy, :published, slug: "the-vacancy-slug")
         vacancy.organisation_vacancies.create(organisation: school)
         visit edit_organisation_job_path(vacancy.id)
-        click_header_link(I18n.t("jobs.job_details"))
+        click_header_link(I18n.t("publishers.vacancies.steps.job_details"))
 
         fill_in "publishers_job_listing_job_details_form[job_title]", with: "Assistant Head Teacher"
         click_on I18n.t("buttons.update_job")
@@ -123,7 +123,7 @@ RSpec.describe "Publishers can edit a vacancy" do
           .to receive(:update_google_index).with(vacancy)
 
         visit edit_organisation_job_path(vacancy.id)
-        click_header_link(I18n.t("jobs.job_details"))
+        click_header_link(I18n.t("publishers.vacancies.steps.job_details"))
 
         fill_in "publishers_job_listing_job_details_form[job_title]", with: "Assistant Head Teacher"
         click_on I18n.t("buttons.update_job")
@@ -138,7 +138,7 @@ RSpec.describe "Publishers can edit a vacancy" do
           expect(page).to have_content(I18n.t("jobs.edit_job_title", job_title: vacancy.job_title))
         end
 
-        click_header_link(I18n.t("jobs.pay_package"))
+        click_header_link(I18n.t("publishers.vacancies.steps.pay_package"))
 
         fill_in "publishers_job_listing_pay_package_form[salary]", with: ""
         click_on I18n.t("buttons.update_job")
@@ -150,7 +150,7 @@ RSpec.describe "Publishers can edit a vacancy" do
 
       scenario "can be successfully edited" do
         visit edit_organisation_job_path(vacancy.id)
-        click_header_link(I18n.t("jobs.pay_package"))
+        click_header_link(I18n.t("publishers.vacancies.steps.pay_package"))
 
         fill_in "publishers_job_listing_pay_package_form[salary]", with: "Pay scale 1 to Pay scale 2"
         click_on I18n.t("buttons.update_job")
@@ -164,7 +164,7 @@ RSpec.describe "Publishers can edit a vacancy" do
           .to receive(:update_google_index).with(vacancy)
 
         visit edit_organisation_job_path(vacancy.id)
-        click_header_link(I18n.t("jobs.pay_package"))
+        click_header_link(I18n.t("publishers.vacancies.steps.pay_package"))
 
         fill_in "publishers_job_listing_pay_package_form[salary]", with: "Pay scale 1 to Pay scale 2"
         click_on I18n.t("buttons.update_job")
@@ -185,7 +185,7 @@ RSpec.describe "Publishers can edit a vacancy" do
         within("h1.govuk-heading-m") do
           expect(page).to have_content(I18n.t("jobs.edit_job_title", job_title: vacancy.job_title))
         end
-        click_header_link(I18n.t("jobs.important_dates"))
+        click_header_link(I18n.t("publishers.vacancies.steps.important_dates"))
 
         edit_date("expires_at", nil)
 
@@ -197,7 +197,7 @@ RSpec.describe "Publishers can edit a vacancy" do
 
       scenario "can be successfully edited" do
         visit edit_organisation_job_path(vacancy.id)
-        click_header_link(I18n.t("jobs.important_dates"))
+        click_header_link(I18n.t("publishers.vacancies.steps.important_dates"))
 
         expiry_date = Date.current + 1.week
         edit_date("expires_at", expiry_date)
@@ -213,7 +213,7 @@ RSpec.describe "Publishers can edit a vacancy" do
           .to receive(:update_google_index).with(vacancy)
 
         visit edit_organisation_job_path(vacancy.id)
-        click_header_link(I18n.t("jobs.important_dates"))
+        click_header_link(I18n.t("publishers.vacancies.steps.important_dates"))
 
         expiry_date = Date.current + 1.week
         edit_date("expires_at", expiry_date)
@@ -228,7 +228,7 @@ RSpec.describe "Publishers can edit a vacancy" do
             vacancy = VacancyPresenter.new(vacancy)
             visit edit_organisation_job_path(vacancy.id)
 
-            click_header_link(I18n.t("jobs.important_dates"))
+            click_header_link(I18n.t("publishers.vacancies.steps.important_dates"))
             expect(page).to have_content(format_date(vacancy.publish_on))
 
             fill_in "publishers_job_listing_important_dates_form[expires_at(3i)]", with: vacancy.expires_at.day
@@ -245,7 +245,7 @@ RSpec.describe "Publishers can edit a vacancy" do
             vacancy.organisation_vacancies.create(organisation: school)
             vacancy = VacancyPresenter.new(vacancy)
             visit edit_organisation_job_path(vacancy.id)
-            click_header_link(I18n.t("jobs.important_dates"))
+            click_header_link(I18n.t("publishers.vacancies.steps.important_dates"))
 
             expect(page).to have_css("#publishers_job_listing_important_dates_form_publish_on_3i")
 
@@ -267,7 +267,7 @@ RSpec.describe "Publishers can edit a vacancy" do
       scenario "can edit documents" do
         visit edit_organisation_job_path(vacancy.id)
 
-        click_header_link(I18n.t("jobs.supporting_documents"))
+        click_header_link(I18n.t("publishers.vacancies.steps.documents"))
 
         expect(page).to have_content(I18n.t("helpers.label.publishers_job_listing_documents_form.documents"))
 
@@ -291,7 +291,7 @@ RSpec.describe "Publishers can edit a vacancy" do
         within("h1.govuk-heading-m") do
           expect(page).to have_content(I18n.t("jobs.edit_job_title", job_title: vacancy.job_title))
         end
-        click_header_link(I18n.t("jobs.applying_for_the_job"))
+        click_header_link(I18n.t("publishers.vacancies.steps.applying_for_the_job"))
 
         fill_in "publishers_job_listing_applying_for_the_job_form[contact_email]", with: "some email"
         click_on I18n.t("buttons.update_job")
@@ -302,7 +302,7 @@ RSpec.describe "Publishers can edit a vacancy" do
       scenario "can be successfully edited" do
         visit edit_organisation_job_path(vacancy.id)
 
-        click_header_link(I18n.t("jobs.applying_for_the_job"))
+        click_header_link(I18n.t("publishers.vacancies.steps.applying_for_the_job"))
         vacancy.contact_email = "new-test@email.com"
 
         fill_in "publishers_job_listing_applying_for_the_job_form[contact_email]", with: vacancy.contact_email
@@ -318,7 +318,7 @@ RSpec.describe "Publishers can edit a vacancy" do
           .to receive(:update_google_index).with(vacancy)
 
         visit edit_organisation_job_path(vacancy.id)
-        click_header_link(I18n.t("jobs.applying_for_the_job"))
+        click_header_link(I18n.t("publishers.vacancies.steps.applying_for_the_job"))
         vacancy.contact_email = "new-test@email.com"
 
         fill_in "publishers_job_listing_applying_for_the_job_form[contact_email]", with: vacancy.contact_email
@@ -333,7 +333,7 @@ RSpec.describe "Publishers can edit a vacancy" do
         within("h1.govuk-heading-m") do
           expect(page).to have_content(I18n.t("jobs.edit_job_title", job_title: vacancy.job_title))
         end
-        click_header_link(I18n.t("jobs.job_summary"))
+        click_header_link(I18n.t("publishers.vacancies.steps.job_summary"))
 
         fill_in "publishers_job_listing_job_summary_form[job_advert]", with: ""
         click_on I18n.t("buttons.update_job")
@@ -345,7 +345,7 @@ RSpec.describe "Publishers can edit a vacancy" do
 
       scenario "can be successfully edited" do
         visit edit_organisation_job_path(vacancy.id)
-        click_header_link(I18n.t("jobs.job_summary"))
+        click_header_link(I18n.t("publishers.vacancies.steps.job_summary"))
 
         fill_in "publishers_job_listing_job_summary_form[job_advert]", with: "A summary about the job."
         click_on I18n.t("buttons.update_job")
@@ -359,7 +359,7 @@ RSpec.describe "Publishers can edit a vacancy" do
           .to receive(:update_google_index).with(vacancy)
 
         visit edit_organisation_job_path(vacancy.id)
-        click_header_link(I18n.t("jobs.job_summary"))
+        click_header_link(I18n.t("publishers.vacancies.steps.job_summary"))
 
         fill_in "publishers_job_listing_job_summary_form[job_advert]", with: "A summary about the job."
         click_on I18n.t("buttons.update_job")

--- a/spec/system/publishers_can_publish_a_vacancy_as_a_local_authority_spec.rb
+++ b/spec/system/publishers_can_publish_a_vacancy_as_a_local_authority_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Creating a vacancy" do
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 8))
         within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("jobs.job_location"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_location"))
         end
 
         fill_in_job_location_form_field(vacancy, "local_authority")
@@ -48,14 +48,14 @@ RSpec.describe "Creating a vacancy" do
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 8))
         within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("jobs.job_location"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_location"))
         end
 
         click_on I18n.t("buttons.continue")
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 8))
         within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("jobs.job_location"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_location"))
         end
         within("div.govuk-error-summary") do
           expect(page).to have_content(I18n.t("schools_errors.organisation_ids.blank"))
@@ -66,7 +66,7 @@ RSpec.describe "Creating a vacancy" do
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 8))
         within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("jobs.job_details"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_details"))
         end
       end
     end
@@ -82,7 +82,7 @@ RSpec.describe "Creating a vacancy" do
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 8))
         within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("jobs.job_location"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_location"))
         end
 
         fill_in_job_location_form_field(vacancy, "local_authority")
@@ -90,7 +90,7 @@ RSpec.describe "Creating a vacancy" do
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 8))
         within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("jobs.job_location"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_location"))
         end
 
         check school1.name, name: "publishers_job_listing_schools_form[organisation_ids][]", visible: false
@@ -98,7 +98,7 @@ RSpec.describe "Creating a vacancy" do
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 8))
         within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("jobs.job_location"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_location"))
         end
         within("div.govuk-error-summary") do
           expect(page).to have_content(I18n.t("schools_errors.organisation_ids.invalid"))
@@ -110,7 +110,7 @@ RSpec.describe "Creating a vacancy" do
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 8))
         within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("jobs.job_details"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_details"))
         end
       end
     end

--- a/spec/system/publishers_can_publish_a_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers_can_publish_a_vacancy_as_a_school_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "Creating a vacancy" do
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 7))
         within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("jobs.pay_package"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.pay_package"))
         end
       end
 
@@ -128,7 +128,7 @@ RSpec.describe "Creating a vacancy" do
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 3, total: 7))
         within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("jobs.important_dates"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.important_dates"))
         end
       end
     end
@@ -181,7 +181,7 @@ RSpec.describe "Creating a vacancy" do
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 4, total: 7))
         within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("jobs.supporting_documents"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.documents"))
         end
       end
     end
@@ -317,7 +317,7 @@ RSpec.describe "Creating a vacancy" do
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 6, total: 7))
         within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("jobs.job_summary"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_summary"))
         end
       end
     end
@@ -379,7 +379,7 @@ RSpec.describe "Creating a vacancy" do
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 7, total: 7))
         within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("jobs.review_heading"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.review_heading"))
         end
         verify_all_vacancy_details(created_vacancy)
       end
@@ -399,7 +399,7 @@ RSpec.describe "Creating a vacancy" do
 
           expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 7))
           within("h2.govuk-heading-l") do
-            expect(page).to have_content(I18n.t("jobs.pay_package"))
+            expect(page).to have_content(I18n.t("publishers.vacancies.steps.pay_package"))
           end
         end
 
@@ -423,7 +423,7 @@ RSpec.describe "Creating a vacancy" do
 
           expect(page).to have_content(I18n.t("jobs.current_step", step: 5, total: 7))
           within("h2.govuk-heading-l") do
-            expect(page).to have_content(I18n.t("jobs.applying_for_the_job"))
+            expect(page).to have_content(I18n.t("publishers.vacancies.steps.applying_for_the_job"))
           end
         end
 
@@ -450,7 +450,7 @@ RSpec.describe "Creating a vacancy" do
 
           expect(page).to have_content(I18n.t("jobs.current_step", step: 6, total: 7))
           within("h2.govuk-heading-l") do
-            expect(page).to have_content(I18n.t("jobs.job_summary"))
+            expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_summary"))
           end
         end
       end
@@ -472,7 +472,7 @@ RSpec.describe "Creating a vacancy" do
           vacancy = VacancyPresenter.new(vacancy)
           visit organisation_job_review_path(vacancy.id)
 
-          expect(page).to have_content(I18n.t("jobs.review_heading"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.review_heading"))
 
           verify_all_vacancy_details(vacancy)
         end
@@ -486,7 +486,7 @@ RSpec.describe "Creating a vacancy" do
           vacancy = VacancyPresenter.new(vacancy)
           visit organisation_job_review_path(vacancy.id)
 
-          expect(page).to have_content(I18n.t("jobs.review_heading"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.review_heading"))
 
           verify_all_vacancy_details(vacancy)
         end
@@ -501,7 +501,7 @@ RSpec.describe "Creating a vacancy" do
 
           visit organisation_job_review_path(vacancy.id)
 
-          expect(page).to have_content(I18n.t("jobs.review_heading"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.review_heading"))
 
           verify_all_vacancy_details(vacancy)
         end
@@ -516,7 +516,7 @@ RSpec.describe "Creating a vacancy" do
 
           visit organisation_job_review_path(vacancy.id)
 
-          expect(page).to have_content(I18n.t("jobs.review_heading"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.review_heading"))
 
           verify_all_vacancy_details(vacancy)
         end
@@ -531,7 +531,7 @@ RSpec.describe "Creating a vacancy" do
 
           visit organisation_job_review_path(vacancy.id)
 
-          expect(page).to have_content(I18n.t("jobs.review_heading"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.review_heading"))
 
           verify_all_vacancy_details(vacancy)
         end
@@ -542,14 +542,14 @@ RSpec.describe "Creating a vacancy" do
           vacancy = create(:vacancy, :draft)
           vacancy.organisation_vacancies.create(organisation: school)
           visit organisation_job_review_path(vacancy.id)
-          click_header_link(I18n.t("jobs.job_details"))
+          click_header_link(I18n.t("publishers.vacancies.steps.job_details"))
 
           expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 7))
 
           fill_in "publishers_job_listing_job_details_form[job_title]", with: "An edited job title"
           click_on I18n.t("buttons.update_job")
 
-          expect(page).to have_content(I18n.t("jobs.review_heading"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.review_heading"))
           expect(page).to have_content("An edited job title")
         end
 
@@ -557,7 +557,7 @@ RSpec.describe "Creating a vacancy" do
           vacancy = create(:vacancy, :draft)
           vacancy.organisation_vacancies.create(organisation: school)
           visit organisation_job_review_path(vacancy.id)
-          click_header_link(I18n.t("jobs.job_details"))
+          click_header_link(I18n.t("publishers.vacancies.steps.job_details"))
 
           fill_in "publishers_job_listing_job_details_form[job_title]", with: ""
           click_on I18n.t("buttons.update_job")
@@ -567,7 +567,7 @@ RSpec.describe "Creating a vacancy" do
           fill_in "publishers_job_listing_job_details_form[job_title]", with: "A new job title"
           click_on I18n.t("buttons.update_job")
 
-          expect(page).to have_content(I18n.t("jobs.review_heading"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.review_heading"))
           expect(page).to have_content("A new job title")
         end
       end
@@ -594,16 +594,16 @@ RSpec.describe "Creating a vacancy" do
           fill_in_job_summary_form_fields(vacancy)
           click_on I18n.t("buttons.continue")
 
-          expect(page).to have_content(I18n.t("jobs.review_heading"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.review_heading"))
 
-          click_header_link(I18n.t("jobs.supporting_documents"))
+          click_header_link(I18n.t("publishers.vacancies.steps.documents"))
 
           expect(page).to have_content(I18n.t("jobs.current_step", step: 4, total: 7))
           expect(page).to have_content(I18n.t("helpers.label.publishers_job_listing_documents_form.documents"))
 
           click_on I18n.t("buttons.update_job")
 
-          expect(page).to have_content(I18n.t("jobs.review_heading"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.review_heading"))
         end
       end
 
@@ -612,7 +612,7 @@ RSpec.describe "Creating a vacancy" do
           vacancy = create(:vacancy, :draft)
           vacancy.organisation_vacancies.create(organisation: school)
           visit organisation_job_review_path(vacancy.id)
-          click_header_link(I18n.t("jobs.applying_for_the_job"))
+          click_header_link(I18n.t("publishers.vacancies.steps.applying_for_the_job"))
 
           expect(page).to have_content(I18n.t("jobs.current_step", step: 5, total: 7))
 
@@ -624,7 +624,7 @@ RSpec.describe "Creating a vacancy" do
           fill_in "publishers_job_listing_applying_for_the_job_form[contact_email]", with: "a@valid.email"
           click_on I18n.t("buttons.update_job")
 
-          expect(page).to have_content(I18n.t("jobs.review_heading"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.review_heading"))
           expect(page).to have_content("a@valid.email")
         end
 
@@ -632,14 +632,14 @@ RSpec.describe "Creating a vacancy" do
           vacancy = create(:vacancy, :draft)
           vacancy.organisation_vacancies.create(organisation: school)
           visit organisation_job_review_path(vacancy.id)
-          click_header_link(I18n.t("jobs.applying_for_the_job"))
+          click_header_link(I18n.t("publishers.vacancies.steps.applying_for_the_job"))
 
           expect(page).to have_content(I18n.t("jobs.current_step", step: 5, total: 7))
 
           fill_in "publishers_job_listing_applying_for_the_job_form[contact_email]", with: "an@email.com"
           click_on I18n.t("buttons.update_job")
 
-          expect(page).to have_content(I18n.t("jobs.review_heading"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.review_heading"))
           expect(page).to have_content("an@email.com")
         end
       end
@@ -666,7 +666,7 @@ RSpec.describe "Creating a vacancy" do
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 3, total: 7))
         within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("jobs.important_dates"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.important_dates"))
         end
 
         expect(find_field("publishers_job_listing_important_dates_form[expires_at(3i)]").value).to eq(yesterday_date.day.to_s)

--- a/spec/system/publishers_can_publish_a_vacancy_as_a_trust_spec.rb
+++ b/spec/system/publishers_can_publish_a_vacancy_as_a_trust_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Creating a vacancy" do
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 8))
         within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("jobs.job_location"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_location"))
         end
 
         fill_in_job_location_form_field(vacancy, "Multi-academy trust")
@@ -47,7 +47,7 @@ RSpec.describe "Creating a vacancy" do
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 8))
         within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("jobs.job_details"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_details"))
         end
       end
     end
@@ -63,7 +63,7 @@ RSpec.describe "Creating a vacancy" do
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 8))
         within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("jobs.job_location"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_location"))
         end
 
         fill_in_job_location_form_field(vacancy, "Multi-academy trust")
@@ -71,14 +71,14 @@ RSpec.describe "Creating a vacancy" do
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 8))
         within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("jobs.job_location"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_location"))
         end
 
         click_on I18n.t("buttons.continue")
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 8))
         within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("jobs.job_location"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_location"))
         end
         within("div.govuk-error-summary") do
           expect(page).to have_content(I18n.t("schools_errors.organisation_ids.blank"))
@@ -89,7 +89,7 @@ RSpec.describe "Creating a vacancy" do
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 8))
         within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("jobs.job_details"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_details"))
         end
       end
     end
@@ -105,7 +105,7 @@ RSpec.describe "Creating a vacancy" do
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 8))
         within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("jobs.job_location"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_location"))
         end
 
         fill_in_job_location_form_field(vacancy, "Multi-academy trust")
@@ -113,7 +113,7 @@ RSpec.describe "Creating a vacancy" do
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 8))
         within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("jobs.job_location"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_location"))
         end
 
         check school1.name, name: "publishers_job_listing_schools_form[organisation_ids][]", visible: false
@@ -121,7 +121,7 @@ RSpec.describe "Creating a vacancy" do
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 8))
         within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("jobs.job_location"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_location"))
         end
         within("div.govuk-error-summary") do
           expect(page).to have_content(I18n.t("schools_errors.organisation_ids.invalid"))
@@ -133,7 +133,7 @@ RSpec.describe "Creating a vacancy" do
 
         expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 8))
         within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("jobs.job_details"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_details"))
         end
       end
     end

--- a/spec/system/publishers_can_save_and_return_later_spec.rb
+++ b/spec/system/publishers_can_save_and_return_later_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Publishers can save and return later" do
         expect(page).to have_content(I18n.t("jobs.create_a_job_title_no_org"))
         expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 7))
         within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("jobs.job_details"))
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_details"))
         end
 
         fill_in "publishers_job_listing_job_details_form[job_title]", with: @vacancy.job_title


### PR DESCRIPTION
This moves step title translations into a more sensible place.

_Cherry-picked from David's branch into a separate PR to make review and rebasing easier._