### PR TITLE
Rename "supporting documents" step to "documents"

### DIFF
--- a/app/controllers/concerns/publishers/wizardable.rb
+++ b/app/controllers/concerns/publishers/wizardable.rb
@@ -34,6 +34,10 @@ module Publishers::Wizardable
     %i[actual_salary salary benefits]
   end
 
+  def documents_fields
+    []
+  end
+
   def important_dates_fields
     %i[starts_asap starts_on publish_on expires_at]
   end

--- a/app/controllers/publishers/vacancies_controller.rb
+++ b/app/controllers/publishers/vacancies_controller.rb
@@ -4,7 +4,7 @@ class Publishers::VacanciesController < Publishers::Vacancies::BaseController
   before_action :redirect_if_published, only: %i[preview review]
   before_action :devise_job_alert_search_criteria, only: %i[show preview]
 
-  helper_method :applying_for_the_job_fields, :important_dates_fields, :job_details_fields, :job_location_fields, :job_summary_fields, :pay_package_fields, :schools_fields
+  helper_method :applying_for_the_job_fields, :documents_fields, :important_dates_fields, :job_details_fields, :job_location_fields, :job_summary_fields, :pay_package_fields, :schools_fields
 
   def show
     @vacancy = VacancyPresenter.new(vacancy)

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -15,7 +15,7 @@ module OrganisationHelper
       job_details: 2,
       pay_package: 3,
       important_dates: 4,
-      supporting_documents: 5,
+      documents: 5,
       applying_for_the_job: 6,
       job_summary: 7,
     }

--- a/app/views/publishers/vacancies/edit.html.slim
+++ b/app/views/publishers/vacancies/edit.html.slim
@@ -16,7 +16,7 @@
         li = render "publishers/vacancies/edit_vacancy_sections/edit_job_details"
         li = render "publishers/vacancies/edit_vacancy_sections/edit_pay_package"
         li = render "publishers/vacancies/edit_vacancy_sections/edit_important_dates"
-        li = render "publishers/vacancies/edit_vacancy_sections/edit_supporting_documents"
+        li = render "publishers/vacancies/edit_vacancy_sections/edit_documents"
         li = render "publishers/vacancies/edit_vacancy_sections/edit_applying_for_the_job"
         li = render "publishers/vacancies/edit_vacancy_sections/edit_job_summary"
 

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_documents.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_documents.html.slim
@@ -1,4 +1,6 @@
-= render ReviewComponent.new id: "supporting_documents" do |review|
+= render "publishers/vacancies/error_tag", attributes: documents_fields
+
+= render ReviewComponent.new id: "documents" do |review|
   - review.heading title: t("publishers.vacancies.steps.documents"),
                    text: t("buttons.change"),
                    href: organisation_job_build_path(@vacancy.id, :documents)

--- a/app/views/publishers/vacancies/review.html.slim
+++ b/app/views/publishers/vacancies/review.html.slim
@@ -23,7 +23,7 @@
         li = render "publishers/vacancies/edit_vacancy_sections/edit_job_details"
         li = render "publishers/vacancies/edit_vacancy_sections/edit_pay_package"
         li = render "publishers/vacancies/edit_vacancy_sections/edit_important_dates"
-        li = render "publishers/vacancies/edit_vacancy_sections/edit_supporting_documents"
+        li = render "publishers/vacancies/edit_vacancy_sections/edit_documents"
         li = render "publishers/vacancies/edit_vacancy_sections/edit_applying_for_the_job"
         li = render "publishers/vacancies/edit_vacancy_sections/edit_job_summary"
 

--- a/app/views/publishers/vacancies/show.html.slim
+++ b/app/views/publishers/vacancies/show.html.slim
@@ -23,7 +23,7 @@
       li = render "publishers/vacancies/edit_vacancy_sections/edit_job_details"
       li = render "publishers/vacancies/edit_vacancy_sections/edit_pay_package"
       li = render "publishers/vacancies/edit_vacancy_sections/edit_important_dates"
-      li = render "publishers/vacancies/edit_vacancy_sections/edit_supporting_documents"
+      li = render "publishers/vacancies/edit_vacancy_sections/edit_documents"
       li = render "publishers/vacancies/edit_vacancy_sections/edit_applying_for_the_job"
       li = render "publishers/vacancies/edit_vacancy_sections/edit_job_summary"
 

--- a/spec/system/publishers_can_save_and_return_later_spec.rb
+++ b/spec/system/publishers_can_save_and_return_later_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe "Publishers can save and return later" do
         expect(page.body).to include(I18n.t("messages.jobs.draft_saved_html", job_title: @vacancy.job_title))
 
         click_on @vacancy.job_title
-        within(".review-component#supporting_documents") do
+        within(".review-component#documents") do
           click_on I18n.t("buttons.change")
         end
 


### PR DESCRIPTION
- Add missing `error_tag` to documents edit section

(Another little change extracted from David's refactor)