### PR TITLE
[TEVA-2962-] Change references to NQT to early career teacher

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,8 +5,7 @@ en:
 
   app:
     description: >-
-      On Teaching Vacancies, NQTs, experienced teachers and leaders can search for a job at a school or Trust in England
-      and set up job alerts.
+      On Teaching Vacancies, early career teachers, experienced teachers and leaders can search for a job at a school or Trust in England and set up job alerts.
     govuk: GOV.UK
     menu: Menu
     title: Teaching Vacancies

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -542,7 +542,7 @@ en:
           teacher: Teacher
           leadership: Leadership
           sen_specialist: Special educational needs (SEN) specialist
-          nqt_suitable: Suitable for NQTs
+          nqt_suitable: Suitable for early career teachers
           nqt_suitable_hidden_prefix: Only show results
         job_title: Job title
         suitable_for_nqt: Is this job suitable for NQTs?

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -13,7 +13,7 @@ en:
     filters:
       job_filters: Job Filters
       job_roles: Job role
-      nqt_suitable: Suitable for NQTs
+      nqt_suitable: Suitable for early career teachers
       phases: Education phase
       working_patterns: Working pattern
 
@@ -47,9 +47,10 @@ en:
 
     search:
       keyword: Keywords
-      keyword_nqt_hint: Tell us what teaching job you’re looking for and what kind of school you’d like to teach in.
+      keyword_nqt_hint: >-
+        Tell us what teaching job you’re looking for and what kind of school you’d like to teach in.
         You can use any keywords that describe your ideal role.
-        This alert is especially for NQT suitable jobs, so you don’t need to add NQT as a keyword.
+        This alert is especially for jobs suitable for early career teachers, so you don’t need to add early career teacher or ECT as a keyword.
       location: Location
       location_hint: For example, city, county or postcode
       number_of_miles:


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2962

## Changes in this PR:

- Initially, as part of this ticket, I only needed to change content in the Google Search results (first row in the table found in the ticket) and the job listing (fourth row). However, changing the content displayed on the job listing also changed the checkbox label's content on the subscription form and on the search results page. Because of this, I also had to change title of the filter.

- I also had to change keyword_nqt_hint (rendered when a user reaches the subscription form via `/sign-up-for-NQT-job-alerts`) as this hint contained references to NQT suitable jobs etc.

## Screenshots 

### Job listing 

<img width="1202" alt="Screenshot 2021-08-17 at 16 51 58" src="https://user-images.githubusercontent.com/30624173/129760414-3da07ee2-998e-4d79-87b1-3bf32cc3067d.png">

### Search results

<img width="976" alt="Screenshot 2021-08-17 at 16 57 37" src="https://user-images.githubusercontent.com/30624173/129760473-1ec2a9cd-ff77-4685-b36e-5086a1db2c69.png">

### Subscription form

<img width="1056" alt="Screenshot 2021-08-17 at 16 58 31" src="https://user-images.githubusercontent.com/30624173/129760606-98d374af-8a54-41ca-a7a4-e21a8dbc2a56.png">

### /sign-up-for-NQT-job-alerts

<img width="1165" alt="Screenshot 2021-08-17 at 16 58 48" src="https://user-images.githubusercontent.com/30624173/129760696-27d0532d-b655-425c-bd3f-4546131de7df.png">


## Comments 

- It seems we will also have to change `/sign-up-for-NQT-job-alerts`. This is a link currently provided to NQTs (ECTs) by policy and comms. We will need to communicate these changes to them and they'll need to pass on the new link before we make the change. Alex is creating a ticket for this.