### PR TITLE
[TEVA-2970] filter out nqt_suitable from job roles

### DIFF
--- a/app/views/subscriptions/_fields.html.slim
+++ b/app/views/subscriptions/_fields.html.slim
@@ -9,7 +9,7 @@ ruby:
       title: t("jobs.filters.job_roles"),
       key: "job_roles",
       attribute: :job_roles,
-      selected: @form.job_roles,
+      selected: @form.job_roles.reject { |role| role == "nqt_suitable" },
       options: @form.job_role_options,
       value_method: :first,
       text_method: :last,

--- a/app/views/vacancies/_search.html.slim
+++ b/app/views/vacancies/_search.html.slim
@@ -4,7 +4,7 @@ ruby:
       title: t("jobs.filters.job_roles"),
       key: "job_roles",
       attribute: :job_roles,
-      selected: @form.job_roles,
+      selected: @form.job_roles.reject { |role| role == "nqt_suitable" },
       options: @form.job_role_options,
       value_method: :first,
       text_method: :last,


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-2970

filter out nqt_suitable from job roles so doesnt appear in filter remove buttons

![Screenshot 2021-08-19 at 11 15 02](https://user-images.githubusercontent.com/1792451/130051912-af14dae6-cee8-4235-8031-11b3be5c328c.png)

