### PR TITLE
[TEVA-2871] equal_opportunities_report_published events missing data

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -23,7 +23,7 @@ shared:
     - reason_for_break
     - created_at
     - updated_at
-  equal_opportunities:
+  equal_opportunities_reports:
     - id
     - vacancy_id
     - total_submissions
@@ -60,6 +60,13 @@ shared:
     - religion_other_descriptions
     - created_at
     - updated_at
+    - age_under_twenty_five
+    - age_twenty_five_to_twenty_nine
+    - age_prefer_not_to_say
+    - age_thirty_to_thirty_nine
+    - age_forty_to_forty_nine
+    - age_fifty_to_fifty_nine
+    - age_sixty_and_over
   feedbacks:
     - id
     - created_at

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -10,7 +10,7 @@ shared:
   documents:
     - id
     - vacancy_id
-  equal_opportunities:
+  equal_opportunities_reports:
     - id
     - vacancy_id
   employments:

--- a/spec/factories/equal_opportunities_report.rb
+++ b/spec/factories/equal_opportunities_report.rb
@@ -1,0 +1,45 @@
+FactoryBot.define do
+  factory :equal_opportunities_report do
+    vacancy
+
+    total_submissions { 1 }
+    disability_no { 1 }
+    disability_prefer_not_to_say { 0 }
+    disability_yes { 0 }
+    gender_man { 0 }
+    gender_other { 1 }
+    gender_prefer_not_to_say { 0 }
+    gender_woman { 0 }
+    gender_other_descriptions { [Faker::Lorem.paragraph(sentence_count: 1)] }
+    orientation_bisexual { 0 }
+    orientation_gay_or_lesbian { 0 }
+    orientation_heterosexual { 0 }
+    orientation_other { 1 }
+    orientation_prefer_not_to_say { 0 }
+    orientation_other_descriptions { [Faker::Lorem.paragraph(sentence_count: 1)] }
+    ethnicity_asian { 0 }
+    ethnicity_black { 0 }
+    ethnicity_mixed { 0 }
+    ethnicity_other { 1 }
+    ethnicity_prefer_not_to_say { 0 }
+    ethnicity_white { 0 }
+    ethnicity_other_descriptions { [Faker::Lorem.paragraph(sentence_count: 1)] }
+    religion_buddhist { 0 }
+    religion_christian { 0 }
+    religion_hindu { 0 }
+    religion_jewish { 0 }
+    religion_muslim { 0 }
+    religion_none { 0 }
+    religion_other { 1 }
+    religion_prefer_not_to_say { 0 }
+    religion_sikh { 0 }
+    religion_other_descriptions { [Faker::Lorem.paragraph(sentence_count: 1)] }
+    age_under_twenty_five { 1 }
+    age_twenty_five_to_twenty_nine { 0 }
+    age_prefer_not_to_say { 0 }
+    age_thirty_to_thirty_nine { 0 }
+    age_forty_to_forty_nine { 0 }
+    age_fifty_to_fifty_nine { 0 }
+    age_sixty_and_over { 0 }
+  end
+end

--- a/spec/models/equal_opportunities_report_spec.rb
+++ b/spec/models/equal_opportunities_report_spec.rb
@@ -1,11 +1,14 @@
 require "rails_helper"
 
 RSpec.describe EqualOpportunitiesReport do
+  subject { FactoryBot.create(:equal_opportunities_report) }
   it { is_expected.to belong_to(:vacancy) }
 
   describe "#trigger_event" do
-    it "triggers an event of the correct type" do
-      expect { described_class.new.trigger_event }.to have_triggered_event(:equal_opportunities_report_published).with_data({ table_name: "equal_opportunities_reports" })
+    let(:equal_opportunities_report_data_example) { { "table_name" => "equal_opportunities_reports", "total_submissions" => 1 } }
+
+    it "triggers an event with the correct data" do
+      expect { subject.trigger_event }.to have_triggered_event(:equal_opportunities_report_published).with_data(equal_opportunities_report_data_example)
     end
   end
 end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2871

## Changes in this PR:

- Updated equal opportunities related keys in analytics.yml and analytics_pii.yml so that the value for `self.class.table_name.to_sym` in application_record.rb, allowing the event_data to be passed in correctly when the `equal_opportunities_report_published` event is triggered. 

- Added missing attributes in analytics.yml

- Changed test so that it checks for the attributes as well as the table name as this test did not catch this bug

## Screenshots

<img width="1076" alt="Screenshot 2021-08-19 at 12 25 14" src="https://user-images.githubusercontent.com/30624173/130060816-12e481d8-7051-43e7-bfee-dbe508f4c936.png">


