### PR TITLE
[TEVA-2871] Job roles changes in job listing journey

### DIFF
--- a/app/components/jobseekers/vacancy_details_component/vacancy_details_component.html.slim
+++ b/app/components/jobseekers/vacancy_details_component/vacancy_details_component.html.slim
@@ -4,7 +4,7 @@ section#job-details class="govuk-!-margin-bottom-5"
 
   = render GovukComponent::SummaryList.new do |component|
     - if @vacancy.job_roles.any?
-      = component.slot(:row, key: I18n.t("jobs.job_roles"), value: @vacancy.show_job_roles)
+      = component.slot(:row, key: I18n.t("jobs.job_role"), value: @vacancy.show_job_roles)
     - if @vacancy.subjects.any?
       = component.slot(:row, key: I18n.t("jobs.subject", count: @vacancy.subjects.count), value: @vacancy.show_subjects)
     = component.slot(:row, key: I18n.t("jobs.working_patterns"), value: @vacancy.working_patterns)

--- a/app/controllers/concerns/publishers/wizardable.rb
+++ b/app/controllers/concerns/publishers/wizardable.rb
@@ -1,5 +1,6 @@
 module Publishers::Wizardable
   STRIP_CHECKBOXES = {
+    job_role_details: %i[additional_job_roles],
     schools: %i[organisation_ids],
     job_details: %i[subjects working_patterns],
   }.freeze
@@ -7,6 +8,7 @@ module Publishers::Wizardable
   def steps_config
     {
       job_role: { number: 1, title: I18n.t("publishers.vacancies.steps.job_role") },
+      job_role_details: { number: 1, title: I18n.t("publishers.vacancies.steps.job_role") },
       job_location: { number: 2, title: I18n.t("publishers.vacancies.steps.job_location") },
       schools: { number: 2, title: I18n.t("publishers.vacancies.steps.job_location") },
       job_details: { number: 3, title: I18n.t("publishers.vacancies.steps.job_details") },
@@ -21,6 +23,10 @@ module Publishers::Wizardable
 
   def job_role_fields
     %i[primary_job_role]
+  end
+
+  def job_role_details_fields
+    %i[additional_job_roles]
   end
 
   def job_location_fields
@@ -58,6 +64,11 @@ module Publishers::Wizardable
   def job_role_params(params)
     params.require(:publishers_job_listing_job_role_form)
           .permit(:primary_job_role).merge(completed_steps: completed_steps)
+  end
+
+  def job_role_details_params(params)
+    params.require(:publishers_job_listing_job_role_details_form)
+          .permit(:send_responsible, additional_job_roles: []).merge(completed_steps: completed_steps)
   end
 
   def job_location_params(params)

--- a/app/controllers/concerns/publishers/wizardable.rb
+++ b/app/controllers/concerns/publishers/wizardable.rb
@@ -1,21 +1,26 @@
 module Publishers::Wizardable
   STRIP_CHECKBOXES = {
     schools: %i[organisation_ids],
-    job_details: %i[job_roles subjects working_patterns],
+    job_details: %i[subjects working_patterns],
   }.freeze
 
   def steps_config
     {
-      job_location: { number: 1, title: I18n.t("publishers.vacancies.steps.job_location") },
-      schools: { number: 1, title: I18n.t("publishers.vacancies.steps.job_location") },
-      job_details: { number: 2, title: I18n.t("publishers.vacancies.steps.job_details") },
-      pay_package: { number: 3, title: I18n.t("publishers.vacancies.steps.pay_package") },
-      important_dates: { number: 4, title: I18n.t("publishers.vacancies.steps.important_dates") },
-      documents: { number: 5, title: I18n.t("publishers.vacancies.steps.documents") },
-      applying_for_the_job: { number: 6, title: I18n.t("publishers.vacancies.steps.applying_for_the_job") },
-      job_summary: { number: 7, title: I18n.t("publishers.vacancies.steps.job_summary") },
-      review: { number: 8, title: I18n.t("publishers.vacancies.steps.review_heading") },
+      job_role: { number: 1, title: I18n.t("publishers.vacancies.steps.job_role") },
+      job_location: { number: 2, title: I18n.t("publishers.vacancies.steps.job_location") },
+      schools: { number: 2, title: I18n.t("publishers.vacancies.steps.job_location") },
+      job_details: { number: 3, title: I18n.t("publishers.vacancies.steps.job_details") },
+      pay_package: { number: 4, title: I18n.t("publishers.vacancies.steps.pay_package") },
+      important_dates: { number: 5, title: I18n.t("publishers.vacancies.steps.important_dates") },
+      documents: { number: 6, title: I18n.t("publishers.vacancies.steps.documents") },
+      applying_for_the_job: { number: 7, title: I18n.t("publishers.vacancies.steps.applying_for_the_job") },
+      job_summary: { number: 8, title: I18n.t("publishers.vacancies.steps.job_summary") },
+      review: { number: 9, title: I18n.t("publishers.vacancies.steps.review_heading") },
     }.freeze
+  end
+
+  def job_role_fields
+    %i[primary_job_role]
   end
 
   def job_location_fields
@@ -27,7 +32,7 @@ module Publishers::Wizardable
   end
 
   def job_details_fields
-    %i[job_title suitable_for_nqt contract_type contract_type_duration job_roles working_patterns subjects]
+    %i[job_title contract_type contract_type_duration working_patterns subjects]
   end
 
   def pay_package_fields
@@ -48,6 +53,11 @@ module Publishers::Wizardable
 
   def job_summary_fields
     %i[job_advert about_school]
+  end
+
+  def job_role_params(params)
+    params.require(:publishers_job_listing_job_role_form)
+          .permit(:primary_job_role).merge(completed_steps: completed_steps)
   end
 
   def job_location_params(params)
@@ -87,9 +97,6 @@ module Publishers::Wizardable
   def job_details_params(params)
     job_location = vacancy.job_location.presence || "at_one_school"
     readable_job_location = vacancy.readable_job_location.presence || readable_job_location(job_location, school_name: current_organisation.name)
-    if params[:publishers_job_listing_job_details_form][:suitable_for_nqt] == "yes"
-      params[:publishers_job_listing_job_details_form][:job_roles] |= [:nqt_suitable]
-    end
     attributes_to_merge = {
       completed_steps: completed_steps,
       job_location: job_location,
@@ -98,7 +105,7 @@ module Publishers::Wizardable
       status: vacancy.status.blank? ? "draft" : nil,
     }
     params.require(:publishers_job_listing_job_details_form)
-          .permit(:job_title, :suitable_for_nqt, :contract_type, :contract_type_duration, job_roles: [], working_patterns: [], subjects: [])
+          .permit(:job_title, :contract_type, :contract_type_duration, working_patterns: [], subjects: [])
           .merge(attributes_to_merge.compact)
   end
 

--- a/app/controllers/publishers/vacancies/base_controller.rb
+++ b/app/controllers/publishers/vacancies/base_controller.rb
@@ -7,16 +7,21 @@ class Publishers::Vacancies::BaseController < Publishers::BaseController
 
   def steps_adjust
     # Only adjust *after* job role step as the extra step for school groups comes after that
-    return 0 if defined?(step) && step == :job_role
+    return 0 if defined?(step) && step.in?(%i[job_role job_role_details])
 
     current_organisation.school_group? ? 0 : 1
   end
 
   def step_current
-    if defined?(step)
-      step == :schools ? :job_location : step
+    return :review unless defined?(step)
+
+    case step
+    when :schools
+      :job_location
+    when :job_role_details
+      :job_role
     else
-      :review
+      step
     end
   end
 

--- a/app/controllers/publishers/vacancies/base_controller.rb
+++ b/app/controllers/publishers/vacancies/base_controller.rb
@@ -6,6 +6,9 @@ class Publishers::Vacancies::BaseController < Publishers::BaseController
   helper_method :current_step_number, :step_current, :steps_adjust, :steps_config, :vacancy
 
   def steps_adjust
+    # Only adjust *after* job role step as the extra step for school groups comes after that
+    return 0 if defined?(step) && step == :job_role
+
     current_organisation.school_group? ? 0 : 1
   end
 

--- a/app/controllers/publishers/vacancies/build_controller.rb
+++ b/app/controllers/publishers/vacancies/build_controller.rb
@@ -2,8 +2,8 @@ class Publishers::Vacancies::BuildController < Publishers::Vacancies::BaseContro
   include Wicked::Wizard
   include OrganisationHelper
 
-  steps :job_role, :job_location, :schools, :job_details, :pay_package, :important_dates,
-        :documents, :applying_for_the_job, :job_summary
+  steps :job_role, :job_role_details, :job_location, :schools, :job_details, :pay_package,
+        :important_dates, :documents, :applying_for_the_job, :job_summary
 
   helper_method :back_path, :form
 
@@ -15,6 +15,8 @@ class Publishers::Vacancies::BuildController < Publishers::Vacancies::BaseContro
 
   def show
     case step
+    when :job_role_details
+      skip_step if vacancy.primary_job_role == "sendco"
     when :job_location
       skip_step if current_organisation.school?
     when :schools
@@ -45,15 +47,20 @@ class Publishers::Vacancies::BuildController < Publishers::Vacancies::BaseContro
   private
 
   def back_path
-    @back_path ||= if session[:current_step] == :review
-                     finish_wizard_path
-                   elsif step == :job_details && !current_organisation.school?
-                     vacancy.central_office? ? wizard_path(:job_location) : wizard_path(:schools)
-                   elsif step == :job_details
-                     wizard_path(:job_role)
-                   else
-                     previous_wizard_path
-                   end
+    return finish_wizard_path if session[:current_step] == :review
+
+    case step
+    when :job_details
+      if current_organisation.school?
+        vacancy.primary_job_role == "sendco" ? wizard_path(:job_role) : wizard_path(:job_role_details)
+      else
+        vacancy.central_office? ? wizard_path(:job_location) : wizard_path(:schools)
+      end
+    when :job_location
+      vacancy.primary_job_role == "sendco" ? wizard_path(:job_role) : wizard_path(:job_role_details)
+    else
+      previous_wizard_path
+    end
   end
 
   def form
@@ -116,6 +123,8 @@ class Publishers::Vacancies::BuildController < Publishers::Vacancies::BaseContro
     vacancy.save
     if step == :job_location && job_location != "central_office"
       redirect_to wizard_path(:schools)
+    elsif step == :job_role && vacancy.primary_job_role != "sendco"
+      redirect_to wizard_path(:job_role_details)
     else
       redirect_updated_job_with_message
     end

--- a/app/controllers/publishers/vacancies/build_controller.rb
+++ b/app/controllers/publishers/vacancies/build_controller.rb
@@ -2,8 +2,8 @@ class Publishers::Vacancies::BuildController < Publishers::Vacancies::BaseContro
   include Wicked::Wizard
   include OrganisationHelper
 
-  steps :job_location, :schools, :job_details, :pay_package, :important_dates, :documents, :applying_for_the_job,
-        :job_summary
+  steps :job_role, :job_location, :schools, :job_details, :pay_package, :important_dates,
+        :documents, :applying_for_the_job, :job_summary
 
   helper_method :back_path, :form
 
@@ -49,6 +49,8 @@ class Publishers::Vacancies::BuildController < Publishers::Vacancies::BaseContro
                      finish_wizard_path
                    elsif step == :job_details && !current_organisation.school?
                      vacancy.central_office? ? wizard_path(:job_location) : wizard_path(:schools)
+                   elsif step == :job_details
+                     wizard_path(:job_role)
                    else
                      previous_wizard_path
                    end

--- a/app/controllers/publishers/vacancies_controller.rb
+++ b/app/controllers/publishers/vacancies_controller.rb
@@ -69,7 +69,7 @@ class Publishers::VacanciesController < Publishers::Vacancies::BaseController
   end
 
   def redirect_to_incomplete_step
-    return redirect_to organisation_job_build_path(vacancy.id, :job_role) unless step_valid?(:job_roles)
+    return redirect_to organisation_job_build_path(vacancy.id, :job_role) unless step_valid?(:job_role)
     return redirect_to organisation_job_build_path(vacancy.id, :job_details) unless step_valid?(:job_details)
     return redirect_to organisation_job_build_path(vacancy.id, :pay_package) unless step_valid?(:pay_package)
     return redirect_to organisation_job_build_path(vacancy.id, :important_dates) unless step_valid?(:important_dates)

--- a/app/controllers/publishers/vacancies_controller.rb
+++ b/app/controllers/publishers/vacancies_controller.rb
@@ -4,7 +4,7 @@ class Publishers::VacanciesController < Publishers::Vacancies::BaseController
   before_action :redirect_if_published, only: %i[preview review]
   before_action :devise_job_alert_search_criteria, only: %i[show preview]
 
-  helper_method :applying_for_the_job_fields, :documents_fields, :important_dates_fields, :job_details_fields, :job_location_fields, :job_summary_fields, :pay_package_fields, :schools_fields
+  helper_method :applying_for_the_job_fields, :documents_fields, :important_dates_fields, :job_details_fields, :job_location_fields, :job_role_fields, :job_summary_fields, :pay_package_fields, :schools_fields
 
   def show
     @vacancy = VacancyPresenter.new(vacancy)
@@ -13,7 +13,7 @@ class Publishers::VacanciesController < Publishers::Vacancies::BaseController
   def create
     reset_session_vacancy!
     vacancy = Vacancy.create(organisation_vacancies_attributes: [{ organisation: current_organisation }])
-    redirect_to organisation_job_build_path(vacancy.id, :job_location)
+    redirect_to organisation_job_build_path(vacancy.id, :job_role)
   end
 
   def edit
@@ -69,6 +69,7 @@ class Publishers::VacanciesController < Publishers::Vacancies::BaseController
   end
 
   def redirect_to_incomplete_step
+    return redirect_to organisation_job_build_path(vacancy.id, :job_role) unless step_valid?(:job_roles)
     return redirect_to organisation_job_build_path(vacancy.id, :job_details) unless step_valid?(:job_details)
     return redirect_to organisation_job_build_path(vacancy.id, :pay_package) unless step_valid?(:pay_package)
     return redirect_to organisation_job_build_path(vacancy.id, :important_dates) unless step_valid?(:important_dates)

--- a/app/form_models/jobseekers/search_form.rb
+++ b/app/form_models/jobseekers/search_form.rb
@@ -43,9 +43,9 @@ class Jobseekers::SearchForm
   end
 
   def set_facet_options
-    @job_role_options = Vacancy.job_roles.except(:nqt_suitable).keys.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_details_form.job_roles_options.#{option}")] }
+    @job_role_options = Vacancy.primary_job_role_options.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_role_form.primary_job_role_options.#{option}")] }
     @phase_options = [%w[primary Primary], %w[middle Middle], %w[secondary Secondary], %w[16-19 16-19]]
-    @nqt_suitable_options = Vacancy.job_roles.slice(:nqt_suitable).keys.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_details_form.job_roles_options.#{option}")] }
+    @nqt_suitable_options = Vacancy.job_roles.slice(:nqt_suitable).keys.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_role_details_form.additional_job_roles_options.#{option}")] }
     @working_pattern_options = Vacancy.working_patterns.keys.map do |option|
       [option, I18n.t("helpers.label.publishers_job_listing_job_details_form.working_patterns_options.#{option}")]
     end

--- a/app/form_models/jobseekers/subscription_form.rb
+++ b/app/form_models/jobseekers/subscription_form.rb
@@ -53,9 +53,9 @@ class Jobseekers::SubscriptionForm
   private
 
   def set_facet_options
-    @job_role_options = Vacancy.job_roles.except(:nqt_suitable).keys.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_details_form.job_roles_options.#{option}")] }
+    @job_role_options = Vacancy.primary_job_role_options.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_role_form.primary_job_role_options.#{option}")] }
     @phase_options = [%w[primary Primary], %w[middle Middle], %w[secondary Secondary], %w[16-19 16-19]]
-    @nqt_suitable_options = Vacancy.job_roles.slice(:nqt_suitable).keys.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_details_form.job_roles_options.#{option}")] }
+    @nqt_suitable_options = Vacancy.job_roles.slice(:nqt_suitable).keys.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_role_details_form.additional_job_roles_options.#{option}")] }
     @working_pattern_options = Vacancy.working_patterns.keys.map do |option|
       [option, I18n.t("helpers.label.publishers_job_listing_job_details_form.working_patterns_options.#{option}")]
     end

--- a/app/form_models/publishers/job_listing/job_details_form.rb
+++ b/app/form_models/publishers/job_listing/job_details_form.rb
@@ -1,13 +1,11 @@
 class Publishers::JobListing::JobDetailsForm < Publishers::JobListing::VacancyForm
   include ActionView::Helpers::SanitizeHelper
 
-  attr_accessor :job_title, :job_roles, :suitable_for_nqt, :working_patterns, :contract_type, :contract_type_duration, :subjects, :job_location, :readable_job_location, :status
+  attr_accessor :job_title, :working_patterns, :contract_type, :contract_type_duration, :subjects, :job_location, :readable_job_location, :status
 
   validates :job_title, presence: true
   validates :job_title, length: { minimum: 4, maximum: 100 }, if: proc { job_title.present? }
   validate :job_title_has_no_tags?, if: proc { job_title.present? }
-
-  validates :suitable_for_nqt, inclusion: { in: %w[yes no] }
 
   validates :working_patterns, presence: true
 

--- a/app/form_models/publishers/job_listing/job_role_details_form.rb
+++ b/app/form_models/publishers/job_listing/job_role_details_form.rb
@@ -1,0 +1,39 @@
+class Publishers::JobListing::JobRoleDetailsForm < Publishers::JobListing::VacancyForm
+  attr_accessor :additional_job_roles
+  attr_writer :send_responsible
+
+  validates :send_responsible,
+            inclusion: { in: %w[yes no] },
+            if: -> { vacancy.primary_job_role != "teacher" }
+
+  def teacher_additional_job_roles_options
+    %w[nqt_suitable send_responsible]
+  end
+
+  def send_responsible
+    # If a value has been set because the form has been submitted, return that
+    return @send_responsible if @send_responsible
+
+    # If this step hasn't been completed before, return nil so the form doesn't assume "no"
+    # by default
+    return nil unless vacancy.completed_steps.include?("job_role_details")
+
+    # Otherwise, determine value based on presence in additional_job_roles
+    "send_responsible".in?(additional_job_roles) ? "yes" : "no"
+  end
+
+  def additional_job_roles_to_save
+    if vacancy.primary_job_role == "teacher"
+      additional_job_roles
+    else
+      @send_responsible == "yes" ? ["send_responsible"] : []
+    end
+  end
+
+  def params_to_save
+    {
+      completed_steps: completed_steps,
+      additional_job_roles: additional_job_roles_to_save,
+    }.compact
+  end
+end

--- a/app/form_models/publishers/job_listing/job_role_form.rb
+++ b/app/form_models/publishers/job_listing/job_role_form.rb
@@ -1,0 +1,12 @@
+class Publishers::JobListing::JobRoleForm < Publishers::JobListing::VacancyForm
+  attr_accessor :primary_job_role
+
+  validates :primary_job_role, inclusion: { in: Vacancy.primary_job_role_options }
+
+  def params_to_save
+    {
+      completed_steps: completed_steps,
+      primary_job_role: primary_job_role,
+    }.compact
+  end
+end

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -95,6 +95,6 @@ module VacanciesHelper
   end
 
   def total_steps(steps)
-    steps.values.map { |step| step[:number] }.max - steps_adjust
+    steps_to_display(steps).count + 1 # #steps_to_display excludes review step
   end
 end

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -90,7 +90,7 @@ module VacanciesHelper
   end
 
   def steps_to_display(steps)
-    steps_to_skip = current_organisation.is_a?(School) ? %i[job_location schools review] : %i[schools review]
+    steps_to_skip = current_organisation.is_a?(School) ? %i[job_role_details job_location schools review] : %i[job_role_details schools review]
     steps.except(*steps_to_skip).keys
   end
 

--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -75,6 +75,12 @@ class VacancyPresenter < BasePresenter
     I18n.t("helpers.label.publishers_job_listing_job_role_form.primary_job_role_options.#{primary_job_role}")
   end
 
+  def show_additional_job_roles
+    model.additional_job_roles.map { |role|
+      I18n.t("helpers.label.publishers_job_listing_job_role_details_form.additional_job_roles_options.#{role}")
+    }.join(", ")
+  end
+
   def show_subjects
     model.subjects&.join(", ")
   end

--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -68,7 +68,7 @@ class VacancyPresenter < BasePresenter
 
   def show_job_roles(exclude_nqt_suitable: false)
     roles = exclude_nqt_suitable ? model.job_roles.excluding("nqt_suitable") : model.job_roles
-    roles.map { |role| I18n.t("helpers.label.publishers_job_listing_job_role_form.primary_job_role_options.#{role}") }.join(", ")
+    roles.map { |role| I18n.t("helpers.label.publishers_job_listing_job_details_form.job_roles_options.#{role}") }.join(", ")
   end
 
   def show_primary_job_role

--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -68,7 +68,11 @@ class VacancyPresenter < BasePresenter
 
   def show_job_roles(exclude_nqt_suitable: false)
     roles = exclude_nqt_suitable ? model.job_roles.excluding("nqt_suitable") : model.job_roles
-    roles.map { |role| I18n.t("helpers.label.publishers_job_listing_job_details_form.job_roles_options.#{role}") }.join(", ")
+    roles.map { |role| I18n.t("helpers.label.publishers_job_listing_job_role_form.primary_job_role_options.#{role}") }.join(", ")
+  end
+
+  def show_primary_job_role
+    I18n.t("helpers.label.publishers_job_listing_job_role_form.primary_job_role_options.#{primary_job_role}")
   end
 
   def show_subjects

--- a/app/views/publishers/vacancies/build/job_details.html.slim
+++ b/app/views/publishers/vacancies/build/job_details.html.slim
@@ -4,8 +4,7 @@
   .govuk-grid-row
     .govuk-grid-column-full
       = render Publishers::VacancyFormPageHeadingComponent.new(vacancy, current_step_number, total_steps(steps_config))
-      - if session[:current_step] == :review || !current_organisation.school?
-        = govuk_back_link text: session[:current_step] == :review ? t("buttons.cancel_and_return") : t("buttons.back_to_previous_step"), href: back_path
+      = govuk_back_link text: session[:current_step] == :review ? t("buttons.cancel_and_return") : t("buttons.back_to_previous_step"), href: back_path
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
@@ -28,10 +27,6 @@
 
           = f.govuk_radio_button :contract_type, :fixed_term do
             = f.govuk_text_field :contract_type_duration, label: { size: "s" }
-
-        = f.govuk_collection_check_boxes :job_roles, Vacancy.job_roles.except("nqt_suitable").keys, :to_s, :to_s
-
-        = f.govuk_collection_radio_buttons :suitable_for_nqt, %w[yes no], :to_s, :capitalize
 
         = f.govuk_fieldset legend: { text: t("helpers.legend.publishers_job_listing_job_details_form.subjects_html") } do
 

--- a/app/views/publishers/vacancies/build/job_location.html.slim
+++ b/app/views/publishers/vacancies/build/job_location.html.slim
@@ -4,6 +4,7 @@
   .govuk-grid-row
     .govuk-grid-column-full
       = render Publishers::VacancyFormPageHeadingComponent.new(vacancy, current_step_number, total_steps(steps_config))
+      = govuk_back_link text: session[:current_step] == :review ? t("buttons.cancel_and_return") : t("buttons.back_to_previous_step"), href: back_path
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/publishers/vacancies/build/job_role.html.slim
+++ b/app/views/publishers/vacancies/build/job_role.html.slim
@@ -1,0 +1,22 @@
+- content_for :page_title_prefix, page_title_prefix(vacancy, form, t("publishers.vacancies.steps.job_role"))
+
+.govuk-main-wrapper
+  .govuk-grid-row
+    .govuk-grid-column-full
+      = render Publishers::VacancyFormPageHeadingComponent.new(vacancy, current_step_number, total_steps(steps_config))
+      = govuk_back_link text: t("buttons.cancel_and_return"), href: back_path if session[:current_step] == :review
+
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = form_for form, url: wizard_path, method: :patch do |f|
+        = f.govuk_error_summary
+
+        h2.govuk-heading-l = t("publishers.vacancies.steps.job_role")
+
+        = f.govuk_collection_radio_buttons :primary_job_role, Vacancy.primary_job_role_options, :to_s, bold_labels: true
+
+        = render "publishers/vacancies/vacancy_form_partials/submit", f: f
+
+    - unless vacancy.published?
+      .govuk-grid-column-one-third
+        = render "steps"

--- a/app/views/publishers/vacancies/build/job_role_details.html.slim
+++ b/app/views/publishers/vacancies/build/job_role_details.html.slim
@@ -4,7 +4,7 @@
   .govuk-grid-row
     .govuk-grid-column-full
       = render Publishers::VacancyFormPageHeadingComponent.new(vacancy, current_step_number, total_steps(steps_config))
-      = govuk_back_link text: t("buttons.cancel_and_return"), href: back_path if session[:current_step] == :review
+      = govuk_back_link text: t("buttons.back_to_previous_step"), href: back_path
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
@@ -13,9 +13,12 @@
 
         h2.govuk-heading-l = t("publishers.vacancies.steps.job_role")
 
-        = f.govuk_collection_radio_buttons :primary_job_role, Vacancy.primary_job_role_options, :to_s, bold_labels: true
+        - if vacancy.primary_job_role == "teacher"
+          = f.govuk_collection_check_boxes :additional_job_roles, form.teacher_additional_job_roles_options, :to_s, :to_s
+        - else
+          = f.govuk_collection_radio_buttons :send_responsible, %w[yes no], :to_s, :capitalize, form_group: { classes: "govuk-!-width-two-thirds" }
 
-        = f.govuk_submit t("buttons.continue")
+        = render "publishers/vacancies/vacancy_form_partials/submit", f: f
 
     - unless vacancy.published?
       .govuk-grid-column-one-third

--- a/app/views/publishers/vacancies/edit.html.slim
+++ b/app/views/publishers/vacancies/edit.html.slim
@@ -11,6 +11,7 @@
       = render "shared/error_messages", errors: @vacancy.errors
 
       ol.app-task-list
+        li = render "publishers/vacancies/edit_vacancy_sections/edit_job_role"
         - if current_organisation.school_group?
           li.multiline = render "publishers/vacancies/edit_vacancy_sections/edit_job_location"
         li = render "publishers/vacancies/edit_vacancy_sections/edit_job_details"

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_details.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_details.html.slim
@@ -13,11 +13,6 @@
         html_attributes: { id: "job_title" })
 
       - component.slot(:row,
-        key: t("jobs.job_roles"),
-        value: @vacancy.show_job_roles(exclude_nqt_suitable: true).presence || t("jobs.not_defined"),
-        html_attributes: { id: "job_roles" })
-
-      - component.slot(:row,
         key: t("jobs.suitable_for_nqt"),
         value: @vacancy.suitable_for_nqt&.capitalize || t("jobs.not_defined"),
         html_attributes: { id: "suitable_for_nqt" })

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_role.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_role.html.slim
@@ -1,0 +1,13 @@
+= render "publishers/vacancies/error_tag", attributes: job_role_fields
+
+= render ReviewComponent.new id: "job_role" do |review|
+  - review.heading title: t("publishers.vacancies.steps.job_role"),
+                   text: t("buttons.change"),
+                   href: organisation_job_build_path(@vacancy.id, :job_role)
+
+  - review.body do
+    = govuk_summary_list do |component|
+      - component.slot(:row,
+        key: t("jobs.job_role"),
+        value: @vacancy.show_primary_job_role || t("jobs.not_defined"),
+        html_attributes: { id: "primary_job_role" })

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_role.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_role.html.slim
@@ -8,6 +8,10 @@
   - review.body do
     = govuk_summary_list do |component|
       - component.slot(:row,
-        key: t("jobs.job_role"),
+        key: t("jobs.primary_job_role"),
         value: @vacancy.show_primary_job_role || t("jobs.not_defined"),
         html_attributes: { id: "primary_job_role" })
+      - component.slot(:row,
+        key: t("jobs.additional_job_roles"),
+        value: @vacancy.show_additional_job_roles.presence || t("jobs.not_defined"),
+        html_attributes: { id: "additional_job_roles" })

--- a/app/views/publishers/vacancies/review.html.slim
+++ b/app/views/publishers/vacancies/review.html.slim
@@ -17,6 +17,8 @@
           = t("jobs.review_future")
 
       ol.app-task-list
+        li = render "publishers/vacancies/edit_vacancy_sections/edit_job_role"
+
         - if current_organisation.school_group?
           li.multiline = render "publishers/vacancies/edit_vacancy_sections/edit_job_location"
 

--- a/app/views/publishers/vacancies/show.html.slim
+++ b/app/views/publishers/vacancies/show.html.slim
@@ -18,6 +18,7 @@
         = govuk_link_to(t("buttons.delete"), organisation_job_path(vacancy.id), method: :delete, data: { confirm: t("jobs.manage.are_you_sure", job_title: vacancy.job_title) }, button: true, class: "govuk-button--secondary")
 
     ol.app-task-list
+      li = render "publishers/vacancies/edit_vacancy_sections/edit_job_role"
       - if current_organisation.school_group?
         li.multiline = render "publishers/vacancies/edit_vacancy_sections/edit_job_location"
       li = render "publishers/vacancies/edit_vacancy_sections/edit_job_details"

--- a/app/views/publishers/vacancies/vacancy_form_partials/_save_and_return_submit.html.slim
+++ b/app/views/publishers/vacancies/vacancy_form_partials/_save_and_return_submit.html.slim
@@ -1,2 +1,2 @@
-- unless vacancy.published?
+- unless vacancy.published? || !vacancy.completed_steps.include?("job_details")
   = f.govuk_submit t("buttons.save_and_return_later"), secondary: true, classes: "button-link save-and-return-listing-gtm"

--- a/app/views/vacancies/_search.html.slim
+++ b/app/views/vacancies/_search.html.slim
@@ -13,7 +13,7 @@ ruby:
     {
       title: t("jobs.filters.nqt_suitable"),
       key: "nqt_suitable",
-      hidden_text: t("helpers.label.publishers_job_listing_job_details_form.job_roles_options.nqt_suitable_hidden_prefix"),
+      hidden_text: t("jobs.filters.nqt_suitable_hidden_prefix"),
       attribute: :job_roles,
       selected: @form.job_roles.include?("nqt_suitable") ? @form.job_roles : [],
       options: @form.nqt_suitable_options,

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -115,6 +115,9 @@ en:
     primary_job_role:
       inclusion: Select a job role
       blank: Select a job role
+  job_role_details_errors: &job_role_details_errors
+    send_responsible:
+      inclusion: Select whether the role has SEND responsibilities
   job_location_errors: &job_location_errors
     job_location:
       inclusion: Select the location where the job will be based
@@ -232,6 +235,9 @@ en:
         publishers/job_listing/job_role_form:
           attributes:
             <<: *job_role_errors
+        publishers/job_listing/job_role_details_form:
+          attributes:
+            <<: *job_role_details_errors
         publishers/job_listing/job_location_form:
           attributes:
             <<: *job_location_errors

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -495,6 +495,8 @@ en:
               too_short: Enter a password that is at least 8 characters long
         vacancy:
           attributes:
+            <<: *job_role_errors
+            <<: *job_role_details_errors
             <<: *job_location_errors
             <<: *schools_errors
             <<: *job_details_errors

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -111,6 +111,10 @@ en:
       inclusion: Please indicate if you'd like to participate in user research
 
   # Publishers journey
+  job_role_errors: &job_role_errors
+    primary_job_role:
+      inclusion: Select a job role
+      blank: Select a job role
   job_location_errors: &job_location_errors
     job_location:
       inclusion: Select the location where the job will be based
@@ -129,10 +133,6 @@ en:
       too_short: Job title must be at least %{count} characters
       too_long: Job title must not be more than %{count} characters
       invalid_characters: Job title must not contain any HTML tags
-    job_roles:
-      blank: Select a job role
-    suitable_for_nqt:
-      inclusion: Please indicate whether or not the job is suitable for NQTs
     working_patterns:
       blank: Select a working pattern
   pay_package_errors: &pay_package_errors
@@ -229,6 +229,9 @@ en:
               blank: Enter your school, trust or local authority name
 
         # Publishers journey
+        publishers/job_listing/job_role_form:
+          attributes:
+            <<: *job_role_errors
         publishers/job_listing/job_location_form:
           attributes:
             <<: *job_location_errors

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -674,7 +674,7 @@ en:
       publishers_job_listing_job_role_form:
         primary_job_role: What is the job role?
       publishers_job_listing_job_role_details_form:
-        additional_job_roles: Tell us more about the role
+        additional_job_roles_html: Tell us more about the role (optional<span class='govuk-visually-hidden'> field</span>)</span>
         send_responsible: Does the role have SEND responsibilities (special educational needs and disabilities)?
       publishers_job_listing_job_location_form:
         job_location: Where will the job be based?

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -232,6 +232,8 @@ en:
           leadership: Includes Head of Year/Subject, Deputy/Assistant Head, Headteacher, and trust-level roles
           education_support: Includes Teaching assistant and Learning support
           sendco: Special educational needs and disabilities coordinator
+      publishers_job_listing_job_role_details_form:
+        additional_job_roles: Select all that apply
       publishers_job_listing_job_summary_form:
         about_organisation: >-
           This will appear next to the job details under ‘%{organisation_type} overview’. Feel free to adapt this text
@@ -543,7 +545,6 @@ en:
           fixed_term: Fixed term
           permanent: Permanent
         job_title: Job title
-        suitable_for_nqt: Is this job suitable for NQTs?
         working_patterns_options:
           full_time: Full-time
           part_time: Part-time
@@ -554,6 +555,10 @@ en:
           leadership: Leadership
           sendco: SENDCo
           education_support: Education support
+      publishers_job_listing_job_role_details_form:
+        additional_job_roles_options:
+          nqt_suitable: Suitable for early career teachers
+          send_responsible: SEND responsibilities (special educational needs and disabilities)
       publishers_job_listing_job_summary_form:
         about_organisation: About %{organisation}
         job_advert: Job advert
@@ -658,6 +663,9 @@ en:
         working_patterns: Working patterns
       publishers_job_listing_job_role_form:
         primary_job_role: What is the job role?
+      publishers_job_listing_job_role_details_form:
+        additional_job_roles: Tell us more about the role
+        send_responsible: Does the role have SEND responsibilities (special educational needs and disabilities)?
       publishers_job_listing_job_location_form:
         job_location: Where will the job be based?
       publishers_job_listing_schools_form:

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -220,7 +220,6 @@ en:
       publishers_job_listing_job_details_form:
         contract_type_duration: >-
           Contract length should be more than 12 weeks. Short term cover should not be advertised on Teaching Vacancies
-        job_roles: Select all that describe the role
         job_title: >-
           For secondary school roles include subject and, if relevant,
           level of seniority (‘Subject leader for science’, for example).
@@ -228,6 +227,11 @@ en:
         working_patterns: >-
           Select all working patterns you will consider for the role.
           Flexible working options may attract more candidates.
+      publishers_job_listing_job_role_form:
+        primary_job_role_options:
+          leadership: Includes Head of Year/Subject, Deputy/Assistant Head, Headteacher, and trust-level roles
+          education_support: Includes Teaching assistant and Learning support
+          sendco: Special educational needs and disabilities coordinator
       publishers_job_listing_job_summary_form:
         about_organisation: >-
           This will appear next to the job details under ‘%{organisation_type} overview’. Feel free to adapt this text
@@ -538,18 +542,18 @@ en:
         contract_type_options:
           fixed_term: Fixed term
           permanent: Permanent
-        job_roles_options:
-          teacher: Teacher
-          leadership: Leadership
-          sen_specialist: Special educational needs (SEN) specialist
-          nqt_suitable: Suitable for early career teachers
-          nqt_suitable_hidden_prefix: Only show results
         job_title: Job title
         suitable_for_nqt: Is this job suitable for NQTs?
         working_patterns_options:
           full_time: Full-time
           part_time: Part-time
           job_share: Job share
+      publishers_job_listing_job_role_form:
+        primary_job_role_options:
+          teacher: Teacher
+          leadership: Leadership
+          sendco: SENDCo
+          education_support: Education support
       publishers_job_listing_job_summary_form:
         about_organisation: About %{organisation}
         job_advert: Job advert
@@ -649,10 +653,11 @@ en:
         starts_on_html: Date job starts (optional<span class='govuk-visually-hidden'> field</span>)</span>
       publishers_job_listing_job_details_form:
         contract_type: Contract type
-        job_roles: Job role
         suitable_for_nqt: Is this job suitable for NQTs?
         subjects_html: Subject(s) (optional<span class='govuk-visually-hidden'> field</span>)</span>
         working_patterns: Working patterns
+      publishers_job_listing_job_role_form:
+        primary_job_role: What is the job role?
       publishers_job_listing_job_location_form:
         job_location: Where will the job be based?
       publishers_job_listing_schools_form:

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -549,6 +549,16 @@ en:
           full_time: Full-time
           part_time: Part-time
           job_share: Job share
+        # TODO: These job_roles_options are no longer on this form, but are used throughout the
+        #  app and need to be refactored later
+        job_roles_options:
+          education_support: Education support
+          leadership: Leadership
+          nqt_suitable: Suitable for early career teachers
+          sen_specialist: Special educational needs (SEN) specialist
+          send_responsible: SEND responsibilities (special educational needs and disabilities)
+          sendco: SENDCo
+          teacher: Teacher
       publishers_job_listing_job_role_form:
         primary_job_role_options:
           teacher: Teacher

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -14,6 +14,7 @@ en:
       job_filters: Job Filters
       job_roles: Job role
       nqt_suitable: Suitable for early career teachers
+      nqt_suitable_hidden_prefix: Only show results
       phases: Education phase
       working_patterns: Working pattern
 

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -180,6 +180,8 @@ en:
 
     job_title: Job title
     job_role: Job role
+    primary_job_role: Job role
+    additional_job_roles: Job role details
     suitable_for_nqt: Is this job suitable for NQTs?
     subjects: Subject(s)
     subject:

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -179,7 +179,7 @@ en:
     location: Location
 
     job_title: Job title
-    job_roles: Job role
+    job_role: Job role
     suitable_for_nqt: Is this job suitable for NQTs?
     subjects: Subject(s)
     subject:

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -179,6 +179,8 @@ en:
           step_title: Job details
         job_location:
           step_title: Job location
+        job_role:
+          step_title: Job role
         job_summary:
           step_title: Job summary
         pay_package:
@@ -266,6 +268,7 @@ en:
         view_live_listing_link: View this listing
         view_live_listing_title: View the live listing
       steps:
+        job_role: Job role
         job_location: Job location
         schools: Job location
         job_details: Job details

--- a/spec/components/jobseekers/vacancy_details_component_spec.rb
+++ b/spec/components/jobseekers/vacancy_details_component_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Jobseekers::VacancyDetailsComponent, type: :component do
 
   context "when a job role is present" do
     it "renders the job title label" do
-      expect(rendered_component).to include(I18n.t("jobs.job_roles"))
+      expect(rendered_component).to include(I18n.t("jobs.job_role"))
     end
 
     it "renders the job role" do
@@ -24,7 +24,7 @@ RSpec.describe Jobseekers::VacancyDetailsComponent, type: :component do
     let(:vacancy) { create(:vacancy, job_roles: %w[]) }
 
     it "does not render the job title label" do
-      expect(rendered_component).not_to include(I18n.t("jobs.job_roles"))
+      expect(rendered_component).not_to include(I18n.t("jobs.job_role"))
     end
   end
 

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -29,7 +29,19 @@ FactoryBot.define do
     expires_at { 6.months.from_now.change(hour: 9, minute: 0, second: 0) }
     hired_status { nil }
     job_advert { Faker::Lorem.paragraph(sentence_count: rand(50..300)) }
-    job_roles { Vacancy.job_roles.keys.first(3).sample(rand(1..3)) }
+
+    primary_job_role { Vacancy.primary_job_role_options.sample }
+    additional_job_roles do
+      case primary_job_role
+      when "teacher"
+        Vacancy.additional_job_role_options.sample(rand(0..2))
+      when "sendco"
+        []
+      else
+        ["send_responsible"].sample(rand(0..1))
+      end
+    end
+
     job_title { JOB_TITLES.sample }
     listed_elsewhere { nil }
     personal_statement_guidance { Faker::Lorem.paragraph(sentence_count: rand(5..10)) }

--- a/spec/form_models/publishers/job_listing/job_details_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/job_details_form_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe Publishers::JobListing::JobDetailsForm, type: :model do
   it { is_expected.to allow_value("Job &amp; another job").for(:job_title) }
   it { is_expected.not_to allow_value("Title with <p>tags</p>").for(:job_title).with_message(I18n.t("job_details_errors.job_title.invalid_characters")) }
 
-  it { is_expected.to validate_inclusion_of(:suitable_for_nqt).in_array(%w[yes no]) }
   it { is_expected.to validate_presence_of(:working_patterns) }
 
   # it { is_expected.to validate_inclusion_of(:contract_type).in_array(Vacancy.contract_types.keys) }

--- a/spec/services/search/criteria_deviser_spec.rb
+++ b/spec/services/search/criteria_deviser_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Search::CriteriaDeviser do
   let(:working_patterns) { %w[full_time part_time] }
   let(:subjects) { %w[English Maths] }
   let(:job_title) { "A wonderful job" }
-  let(:job_roles) { %w[teacher sen_specialist leadership] }
+  let(:job_roles) { %w[teacher send_responsible] }
   let(:vacancy) do
     create(:vacancy, :at_one_school, organisation_vacancies_attributes: [{ organisation: school }],
                                      working_patterns: working_patterns,

--- a/spec/services/search/filters_builder_spec.rb
+++ b/spec/services/search/filters_builder_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Search::FiltersBuilder do
 
   let(:from_date) { Date.current }
   let(:to_date) { Date.current }
-  let(:job_roles) { %w[teacher sen_specialist] }
+  let(:job_roles) { %w[teacher send_responsible] }
   let(:phases) { %w[secondary primary] }
   let(:working_patterns) { %w[full_time part_time] }
   let(:subjects) { %w[Science Biology] }
@@ -104,7 +104,7 @@ RSpec.describe Search::FiltersBuilder do
           " expires_at_timestamp > #{expired_now_filter}) AND "\
           "(publication_date_timestamp >= #{from_date.to_time.to_i} AND" \
           " publication_date_timestamp <= #{to_date.to_time.to_i}) AND " \
-          "(job_roles:'teacher' OR job_roles:'sen_specialist') AND " \
+          "(job_roles:'teacher' OR job_roles:'send_responsible') AND " \
           "(education_phases:'secondary' OR education_phases:'primary') AND " \
           "(working_patterns:'full_time' OR working_patterns:'part_time') AND " \
           "(subjects:'Science' OR subjects:'Biology')",

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -14,6 +14,21 @@ module VacancyHelpers
     choose school.name
   end
 
+  def fill_in_job_role_form_fields(vacancy)
+    choose I18n.t("helpers.label.publishers_job_listing_job_role_form.primary_job_role_options.#{vacancy.primary_job_role}")
+  end
+
+  def fill_in_job_role_details_form_fields(vacancy)
+    if vacancy.primary_job_role == "teacher"
+      vacancy.additional_job_roles&.each do |job_role|
+        check I18n.t("helpers.label.publishers_job_listing_job_role_details_form.additional_job_roles_options.#{job_role}")
+      end
+    elsif vacancy.primary_job_role.in?(%w[leadership education_support])
+      value = vacancy.job_roles.include?("send_responsible") ? "yes" : "no"
+      find("label[for='publishers-job-listing-job-role-details-form-send-responsible-#{value}-field']").click
+    end
+  end
+
   def fill_in_job_details_form_fields(vacancy)
     fill_in "publishers_job_listing_job_details_form[job_title]", with: vacancy.job_title
 
@@ -23,14 +38,6 @@ module VacancyHelpers
             name: "publishers_job_listing_job_details_form[working_patterns][]",
             visible: false
     end
-
-    vacancy.job_roles.excluding("nqt_suitable")&.each do |job_role|
-      check I18n.t("helpers.label.publishers_job_listing_job_details_form.job_roles_options.#{job_role}"),
-            name: "publishers_job_listing_job_details_form[job_roles][]",
-            visible: false
-    end
-
-    find("label[for='publishers-job-listing-job-details-form-suitable-for-nqt-#{vacancy.suitable_for_nqt}-field']").click
 
     vacancy.subjects&.each do |subject|
       check subject,
@@ -127,7 +134,8 @@ module VacancyHelpers
     end
 
     expect(page).to have_content(vacancy.job_title)
-    expect(page).to have_content(vacancy.show_job_roles)
+    expect(page).to have_content(vacancy.show_primary_job_role)
+    expect(page).to have_content(vacancy.show_additional_job_roles)
     expect(page).to have_content(vacancy.show_subjects)
     expect(page).to have_content(vacancy.working_patterns)
 

--- a/spec/system/application_sitemap_spec.rb
+++ b/spec/system/application_sitemap_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Application sitemap" do
       document = Nokogiri::XML::Document.parse(body)
       nodes = document.search("url")
 
-      expect(nodes.count).to eq(290)
+      expect(nodes.count).to eq(292)
       expect(nodes.search("loc[text()='#{root_url(protocol: 'https')}']").text)
         .to eq(root_url(protocol: "https"))
 

--- a/spec/system/publishers_can_edit_a_draft_vacancy_as_a_school_group_spec.rb
+++ b/spec/system/publishers_can_edit_a_draft_vacancy_as_a_school_group_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Editing a draft vacancy" do
   let(:school_group) { create(:trust) }
   let(:school1) { create(:school, name: "First school") }
   let(:school2) { create(:school, name: "Second school") }
-  let(:vacancy) { create(:vacancy, :central_office, :draft) }
+  let(:vacancy) { create(:vacancy, :central_office, :draft, job_roles: %w[teacher]) }
 
   before do
     login_publisher(publisher: publisher, organisation: school_group)

--- a/spec/system/publishers_can_edit_a_draft_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers_can_edit_a_draft_vacancy_as_a_school_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe "Publishers can edit a draft vacancy" do
   let!(:vacancy) do
     VacancyPresenter.new(build(:vacancy,
                                job_title: "Draft vacancy",
-                               working_patterns: %w[full_time part_time]))
+                               working_patterns: %w[full_time part_time],
+                               job_roles: %w[teacher]))
   end
   let(:draft_vacancy) { Vacancy.find_by(job_title: vacancy.job_title) }
 
@@ -16,6 +17,11 @@ RSpec.describe "Publishers can edit a draft vacancy" do
     before do
       visit organisation_path
       click_on I18n.t("buttons.create_job")
+
+      fill_in_job_role_form_fields(vacancy)
+      click_on I18n.t("buttons.continue")
+      click_on I18n.t("buttons.continue")
+
       fill_in_job_details_form_fields(vacancy)
       click_on I18n.t("buttons.continue")
     end
@@ -24,7 +30,7 @@ RSpec.describe "Publishers can edit a draft vacancy" do
       scenario "incomplete pay package step" do
         visit edit_organisation_job_path(id: draft_vacancy.id)
 
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 7))
+        expect(page).to have_content(I18n.t("jobs.current_step", step: 3, total: 8))
         within("h2.govuk-heading-l") do
           expect(page).to have_content(I18n.t("publishers.vacancies.steps.pay_package"))
         end
@@ -39,7 +45,7 @@ RSpec.describe "Publishers can edit a draft vacancy" do
         fill_in_pay_package_form_fields(draft_vacancy)
         click_on I18n.t("buttons.continue")
 
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 3, total: 7))
+        expect(page).to have_content(I18n.t("jobs.current_step", step: 4, total: 8))
         within("h2.govuk-heading-l") do
           expect(page).to have_content(I18n.t("publishers.vacancies.steps.important_dates"))
         end
@@ -61,7 +67,7 @@ RSpec.describe "Publishers can edit a draft vacancy" do
         fill_in_important_dates_fields(draft_vacancy)
         click_on I18n.t("buttons.continue")
 
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 4, total: 7))
+        expect(page).to have_content(I18n.t("jobs.current_step", step: 5, total: 8))
         within("h2.govuk-heading-l") do
           expect(page).to have_content(I18n.t("publishers.vacancies.steps.documents"))
         end
@@ -85,7 +91,7 @@ RSpec.describe "Publishers can edit a draft vacancy" do
 
         click_on I18n.t("buttons.continue")
 
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 5, total: 7))
+        expect(page).to have_content(I18n.t("jobs.current_step", step: 6, total: 8))
         within("h2.govuk-heading-l") do
           expect(page).to have_content(I18n.t("publishers.vacancies.steps.applying_for_the_job"))
         end
@@ -115,7 +121,7 @@ RSpec.describe "Publishers can edit a draft vacancy" do
         fill_in_applying_for_the_job_form_fields(draft_vacancy)
         click_on I18n.t("buttons.continue")
 
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 6, total: 7))
+        expect(page).to have_content(I18n.t("jobs.current_step", step: 7, total: 8))
         within("h2.govuk-heading-l") do
           expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_summary"))
         end
@@ -147,7 +153,7 @@ RSpec.describe "Publishers can edit a draft vacancy" do
 
       scenario "then editing the draft redirects to incomplete step" do
         visit edit_organisation_job_path(id: draft_vacancy.id)
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 5, total: 7))
+        expect(page).to have_content(I18n.t("jobs.current_step", step: 6, total: 8))
       end
 
       def edit_a_published_vacancy
@@ -165,7 +171,7 @@ RSpec.describe "Publishers can edit a draft vacancy" do
   end
 
   context "editing a complete draft vacancy" do
-    let(:vacancy) { create(:vacancy, :draft) }
+    let(:vacancy) { create(:vacancy, :draft, job_roles: %w[teacher]) }
 
     before { vacancy.organisation_vacancies.create(organisation: school) }
 

--- a/spec/system/publishers_can_edit_a_published_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers_can_edit_a_published_vacancy_as_a_school_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Publishers can edit a vacancy" do
     let(:vacancy) do
       VacancyPresenter.new(
         create(:vacancy, job_location: "at_one_school",
-                         job_roles: %i[teacher sen_specialist], working_patterns: %w[full_time part_time],
+                         job_roles: %i[teacher send_responsible], working_patterns: %w[full_time part_time],
                          publish_on: Date.current, expires_at: 1.day.from_now.change(hour: 9, minute: 0)),
       )
     end

--- a/spec/system/publishers_can_preview_a_vacancy_spec.rb
+++ b/spec/system/publishers_can_preview_a_vacancy_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Publishers can preview a vacancy" do
   let(:publisher) { create(:publisher) }
   let(:school) { create(:school) }
-  let(:vacancy) { create(:vacancy, :draft) }
+  let(:vacancy) { create(:vacancy, :draft, job_roles: %w[teacher]) }
 
   before do
     login_publisher(publisher: publisher, organisation: school)

--- a/spec/system/publishers_can_publish_a_vacancy_as_a_local_authority_spec.rb
+++ b/spec/system/publishers_can_publish_a_vacancy_as_a_local_authority_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Creating a vacancy" do
   let(:school_group) { create(:local_authority) }
   let(:school1) { create(:school, name: "First school") }
   let(:school2) { create(:school, name: "Second school") }
-  let(:vacancy) { build(:vacancy, :at_one_school, :no_tv_applications) }
+  let(:vacancy) { build(:vacancy, :at_one_school, :no_tv_applications, job_roles: %w[teacher]) }
   let(:created_vacancy) { Vacancy.last }
 
   before do
@@ -24,21 +24,25 @@ RSpec.describe "Creating a vacancy" do
     visit organisation_path
     click_on I18n.t("buttons.create_job")
 
-    fill_in_job_location_form_field(vacancy, "local_authority")
+    fill_in_job_role_form_fields(vacancy)
     click_on I18n.t("buttons.continue")
 
     expect(page.get_rack_session["current_step"]).to be nil
   end
 
   context "when job is located at a single school in the local authority" do
-    let(:vacancy) { build(:vacancy, :at_one_school) }
+    let(:vacancy) { build(:vacancy, :at_one_school, job_roles: %w[teacher]) }
 
     describe "#job_location" do
       scenario "displays error message unless a school is selected" do
         visit organisation_path
         click_on I18n.t("buttons.create_job")
 
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 8))
+        fill_in_job_role_form_fields(vacancy)
+        click_on I18n.t("buttons.continue")
+        click_on I18n.t("buttons.continue")
+
+        expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 9))
         within("h2.govuk-heading-l") do
           expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_location"))
         end
@@ -46,14 +50,14 @@ RSpec.describe "Creating a vacancy" do
         fill_in_job_location_form_field(vacancy, "local_authority")
         click_on I18n.t("buttons.continue")
 
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 8))
+        expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 9))
         within("h2.govuk-heading-l") do
           expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_location"))
         end
 
         click_on I18n.t("buttons.continue")
 
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 8))
+        expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 9))
         within("h2.govuk-heading-l") do
           expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_location"))
         end
@@ -64,7 +68,7 @@ RSpec.describe "Creating a vacancy" do
         fill_in_school_form_field(school2)
         click_on I18n.t("buttons.continue")
 
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 8))
+        expect(page).to have_content(I18n.t("jobs.current_step", step: 3, total: 9))
         within("h2.govuk-heading-l") do
           expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_details"))
         end
@@ -73,14 +77,18 @@ RSpec.describe "Creating a vacancy" do
   end
 
   context "when job is located at multiple schools in the local authority" do
-    let(:vacancy) { build(:vacancy, :at_multiple_schools) }
+    let(:vacancy) { build(:vacancy, :at_multiple_schools, job_roles: %w[teacher]) }
 
     describe "#job_location" do
       scenario "displays error message unless at least 2 schools are selected" do
         visit organisation_path
         click_on I18n.t("buttons.create_job")
 
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 8))
+        fill_in_job_role_form_fields(vacancy)
+        click_on I18n.t("buttons.continue")
+        click_on I18n.t("buttons.continue")
+
+        expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 9))
         within("h2.govuk-heading-l") do
           expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_location"))
         end
@@ -88,7 +96,7 @@ RSpec.describe "Creating a vacancy" do
         fill_in_job_location_form_field(vacancy, "local_authority")
         click_on I18n.t("buttons.continue")
 
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 8))
+        expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 9))
         within("h2.govuk-heading-l") do
           expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_location"))
         end
@@ -96,7 +104,7 @@ RSpec.describe "Creating a vacancy" do
         check school1.name, name: "publishers_job_listing_schools_form[organisation_ids][]", visible: false
         click_on I18n.t("buttons.continue")
 
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 8))
+        expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 9))
         within("h2.govuk-heading-l") do
           expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_location"))
         end
@@ -108,7 +116,7 @@ RSpec.describe "Creating a vacancy" do
         check school2.name, name: "publishers_job_listing_schools_form[organisation_ids][]", visible: false
         click_on I18n.t("buttons.continue")
 
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 8))
+        expect(page).to have_content(I18n.t("jobs.current_step", step: 3, total: 9))
         within("h2.govuk-heading-l") do
           expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_details"))
         end
@@ -119,6 +127,16 @@ RSpec.describe "Creating a vacancy" do
   scenario "publishes a vacancy" do
     visit organisation_path
     click_on I18n.t("buttons.create_job")
+    expect(current_path).to eq(organisation_job_build_path(created_vacancy.id, :job_role))
+
+    click_on I18n.t("buttons.continue")
+    expect(page).to have_content("There is a problem")
+
+    fill_in_job_role_form_fields(vacancy)
+    click_on I18n.t("buttons.continue")
+    expect(current_path).to eq(organisation_job_build_path(created_vacancy.id, :job_role_details))
+
+    click_on I18n.t("buttons.continue")
     expect(current_path).to eq(organisation_job_build_path(created_vacancy.id, :job_location))
 
     click_on I18n.t("buttons.continue")

--- a/spec/system/publishers_can_publish_a_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers_can_publish_a_vacancy_as_a_school_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe "Creating a vacancy" do
 
     click_on I18n.t("buttons.create_job")
 
-    expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 7))
+    expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 8))
   end
 
   context "creating a new vacancy" do
-    let(:job_roles) { %i[teacher sen_specialist] }
+    let(:job_roles) { %i[teacher send_responsible] }
     let(:vacancy) do
       VacancyPresenter.new(build(:vacancy,
                                  job_roles: job_roles,
@@ -28,368 +28,111 @@ RSpec.describe "Creating a vacancy" do
     end
     let(:created_vacancy) { Vacancy.last }
 
-    scenario "redirects to step 1, job details" do
+    scenario "follows the flow" do
       visit organisation_path
       click_on I18n.t("buttons.create_job")
+      expect(current_path).to eq(organisation_job_build_path(created_vacancy.id, :job_role))
 
-      expect(page.current_path).to eq(organisation_job_build_path(Vacancy.last.id, :job_details))
-      expect(page).to have_content(I18n.t("jobs.create_a_job_title_no_org"))
-      expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 7))
+      click_on I18n.t("buttons.continue")
+      expect(page).to have_content("There is a problem")
+      expect(current_path).to eq(organisation_job_build_path(created_vacancy.id, :job_role))
+
+      fill_in_job_role_form_fields(vacancy)
+      click_on I18n.t("buttons.continue")
+      expect(current_path).to eq(organisation_job_build_path(created_vacancy.id, :job_role_details))
+
+      click_on I18n.t("buttons.continue")
+      expect(current_path).to eq(organisation_job_build_path(created_vacancy.id, :job_details))
+
+      click_on I18n.t("buttons.continue")
+      expect(page).to have_content("There is a problem")
+      expect(current_path).to eq(organisation_job_build_path(created_vacancy.id, :job_details))
+
+      fill_in_job_details_form_fields(vacancy)
+      click_on I18n.t("buttons.continue")
+      expect(current_path).to eq(organisation_job_build_path(created_vacancy.id, :pay_package))
+
+      click_on I18n.t("buttons.continue")
+      expect(page).to have_content("There is a problem")
+      expect(current_path).to eq(organisation_job_build_path(created_vacancy.id, :pay_package))
+
+      fill_in_pay_package_form_fields(vacancy)
+      click_on I18n.t("buttons.continue")
+      expect(current_path).to eq(organisation_job_build_path(created_vacancy.id, :important_dates))
+
+      click_on I18n.t("buttons.continue")
+      expect(page).to have_content("There is a problem")
+      expect(current_path).to eq(organisation_job_build_path(created_vacancy.id, :important_dates))
+
+      fill_in_important_dates_fields(vacancy)
+      click_on I18n.t("buttons.continue")
+      expect(current_path).to eq(organisation_job_documents_path(created_vacancy.id))
+
+      click_on I18n.t("buttons.continue")
+      expect(current_path).to eq(organisation_job_build_path(created_vacancy.id, :applying_for_the_job))
+
+      click_on I18n.t("buttons.continue")
+      expect(page).to have_content("There is a problem")
+      expect(current_path).to eq(organisation_job_build_path(created_vacancy.id, :applying_for_the_job))
+
+      fill_in_applying_for_the_job_form_fields(vacancy)
+      click_on I18n.t("buttons.continue")
+      expect(current_path).to eq(organisation_job_build_path(created_vacancy.id, :job_summary))
+
+      click_on I18n.t("buttons.continue")
+      expect(page).to have_content("There is a problem")
+      expect(current_path).to eq(organisation_job_build_path(created_vacancy.id, :job_summary))
+
+      fill_in_job_summary_form_fields(vacancy)
+      click_on I18n.t("buttons.continue")
+      expect(current_path).to eq(organisation_job_review_path(created_vacancy.id))
+      verify_all_vacancy_details(created_vacancy)
+
+      click_on I18n.t("buttons.submit_job_listing")
+      expect(current_path).to eq(organisation_job_summary_path(created_vacancy.id))
     end
 
-    scenario "resets session current_step" do
-      page.set_rack_session(current_step: :review)
-
+    scenario "redirects to the vacancy review page when submitted successfully" do
       visit organisation_path
       click_on I18n.t("buttons.create_job")
+
+      fill_in_job_role_form_fields(vacancy)
+      click_on I18n.t("buttons.continue")
+      click_on I18n.t("buttons.continue")
 
       fill_in_job_details_form_fields(vacancy)
       click_on I18n.t("buttons.continue")
 
-      expect(page.get_rack_session["current_step"]).to be nil
-    end
+      fill_in_pay_package_form_fields(vacancy)
+      click_on I18n.t("buttons.continue")
 
-    describe "#job_details" do
-      scenario "is invalid unless all mandatory fields are submitted" do
-        visit organisation_path
-        click_on I18n.t("buttons.create_job")
+      fill_in_important_dates_fields(vacancy)
+      click_on I18n.t("buttons.continue")
 
-        click_on I18n.t("buttons.continue")
+      click_on I18n.t("buttons.continue")
 
-        mandatory_fields = %w[job_title working_patterns]
+      fill_in_applying_for_the_job_form_fields(vacancy)
+      click_on I18n.t("buttons.continue")
 
-        within(".govuk-error-summary") do
-          expect(page).to have_content("There is a problem")
-        end
+      fill_in_job_summary_form_fields(vacancy)
+      click_on I18n.t("buttons.continue")
 
-        mandatory_fields.each do |field|
-          within_row_for(element: field == "job_title" ? "label" : "legend", text: I18n.t("jobs.#{field}")) do
-            expect(page).to have_content(I18n.t("activerecord.errors.models.vacancy.attributes.#{field}.blank"))
-          end
-        end
+      expect(page).to have_content(I18n.t("jobs.current_step", step: 8, total: 8))
+      within("h2.govuk-heading-l") do
+        expect(page).to have_content(I18n.t("publishers.vacancies.steps.review_heading"))
       end
-
-      scenario "redirects to step 2, pay package, when submitted successfully" do
-        visit organisation_path
-        click_on I18n.t("buttons.create_job")
-
-        fill_in_job_details_form_fields(vacancy)
-        click_on I18n.t("buttons.continue")
-
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 7))
-        within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("publishers.vacancies.steps.pay_package"))
-        end
-      end
-
-      context "when job is selected as suitable for NQTs" do
-        let(:job_roles) { %i[nqt_suitable teacher sen_specialist] }
-
-        scenario "Suitable for NQTs is appended to the job roles" do
-          visit organisation_path
-          click_on I18n.t("buttons.create_job")
-
-          fill_in_job_details_form_fields(vacancy)
-          click_on I18n.t("buttons.continue")
-
-          expect(Vacancy.last.job_roles).to include("nqt_suitable")
-        end
-      end
-    end
-
-    describe "#pay_package" do
-      scenario "is invalid unless all mandatory fields are submitted" do
-        visit organisation_path
-        click_on I18n.t("buttons.create_job")
-
-        fill_in_job_details_form_fields(vacancy)
-        click_on I18n.t("buttons.continue")
-
-        click_on I18n.t("buttons.continue")
-
-        within(".govuk-error-summary") do
-          expect(page).to have_content("There is a problem")
-        end
-
-        within_row_for(text: I18n.t("helpers.label.publishers_job_listing_pay_package_form.salary")) do
-          expect(page).to have_content(I18n.t("activerecord.errors.models.vacancy.attributes.salary.blank"))
-        end
-      end
-
-      scenario "redirects to step 3, important dates, when submitted successfuly" do
-        visit organisation_path
-        click_on I18n.t("buttons.create_job")
-
-        fill_in_job_details_form_fields(vacancy)
-        click_on I18n.t("buttons.continue")
-
-        fill_in_pay_package_form_fields(vacancy)
-        click_on I18n.t("buttons.continue")
-
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 3, total: 7))
-        within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("publishers.vacancies.steps.important_dates"))
-        end
-      end
-    end
-
-    describe "#important_dates" do
-      scenario "is invalid unless all mandatory fields are submitted" do
-        visit organisation_path
-        click_on I18n.t("buttons.create_job")
-
-        fill_in_job_details_form_fields(vacancy)
-        click_on I18n.t("buttons.continue")
-
-        fill_in_pay_package_form_fields(vacancy)
-        click_on I18n.t("buttons.continue")
-
-        click_on I18n.t("buttons.continue")
-
-        within(".govuk-error-summary") do
-          expect(page).to have_content("There is a problem")
-        end
-
-        within_row_for(element: "legend",
-                       text: strip_tags(I18n.t("helpers.legend.publishers_job_listing_important_dates_form.publish_on_day"))) do
-          expect(page).to have_content(I18n.t("important_dates_errors.publish_on_day.inclusion"))
-        end
-
-        within_row_for(element: "legend",
-                       text: strip_tags(I18n.t("helpers.legend.publishers_job_listing_important_dates_form.expires_at"))) do
-          expect(page).to have_content(I18n.t("important_dates_errors.expires_at.blank"))
-        end
-
-        within_row_for(element: "legend",
-                       text: strip_tags(I18n.t("helpers.legend.publishers_job_listing_important_dates_form.expiry_time"))) do
-          expect(page).to have_content(I18n.t("activerecord.errors.models.vacancy.attributes.expiry_time.inclusion"))
-        end
-      end
-
-      scenario "redirects to step 4, supporting documents, when submitted successfuly" do
-        visit organisation_path
-        click_on I18n.t("buttons.create_job")
-
-        fill_in_job_details_form_fields(vacancy)
-        click_on I18n.t("buttons.continue")
-
-        fill_in_pay_package_form_fields(vacancy)
-        click_on I18n.t("buttons.continue")
-
-        fill_in_important_dates_fields(vacancy)
-        click_on I18n.t("buttons.continue")
-
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 4, total: 7))
-        within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("publishers.vacancies.steps.documents"))
-        end
-      end
-    end
-
-    describe "#documents" do
-      let(:documents_vacancy) { create(:vacancy) }
-
-      before { documents_vacancy.organisation_vacancies.create(organisation: school) }
-
-      scenario "Publishers can select a file for upload" do
-        visit organisation_job_documents_path(documents_vacancy.id)
-        page.attach_file("publishers-job-listing-documents-form-documents-field", Rails.root.join("spec/fixtures/files/blank_job_spec.pdf"))
-        expect(page.find("#publishers-job-listing-documents-form-documents-field").value).to_not be nil
-      end
-
-      context "when uploading files" do
-        let(:filename) { "blank_job_spec.pdf" }
-
-        scenario "displays uploaded file in a table" do
-          visit organisation_job_documents_path(documents_vacancy.id)
-
-          allow(Publishers::DocumentVirusCheck).to receive(:new).and_return(double(safe?: true))
-          upload_document(
-            "new_publishers_job_listing_documents_form",
-            "publishers-job-listing-documents-form-documents-field",
-            "spec/fixtures/files/#{filename}",
-          )
-
-          expect(page).to have_content(filename)
-        end
-
-        scenario "displays error message when invalid file type is uploaded" do
-          visit organisation_job_documents_path(documents_vacancy.id)
-
-          upload_document(
-            "new_publishers_job_listing_documents_form",
-            "publishers-job-listing-documents-form-documents-field",
-            "spec/fixtures/files/mime_types/invalid_plain_text_file.txt",
-          )
-
-          expect(page).to have_content(I18n.t("jobs.file_type_error_message", filename: "invalid_plain_text_file.txt"))
-        end
-
-        scenario "displays error message when large file is uploaded" do
-          stub_const("#{Publishers::JobListing::DocumentsForm}::FILE_SIZE_LIMIT", 1.kilobyte)
-          visit organisation_job_documents_path(documents_vacancy.id)
-
-          upload_document(
-            "new_publishers_job_listing_documents_form",
-            "publishers-job-listing-documents-form-documents-field",
-            "spec/fixtures/files/#{filename}",
-          )
-
-          expect(page).to have_content(I18n.t("jobs.file_size_error_message", filename: filename, size_limit: "1 KB"))
-        end
-
-        scenario "displays error message when virus file is uploaded" do
-          allow(Publishers::DocumentVirusCheck).to receive(:new).and_return(double(safe?: false))
-
-          visit organisation_job_documents_path(documents_vacancy.id)
-
-          upload_document(
-            "new_publishers_job_listing_documents_form",
-            "publishers-job-listing-documents-form-documents-field",
-            "spec/fixtures/files/#{filename}",
-          )
-
-          expect(page).to have_content(I18n.t("jobs.file_virus_error_message", filename: filename))
-        end
-      end
-
-      context "when deleting uploaded files", js: true do
-        before do
-          documents_vacancy.supporting_documents.attach(io: StringIO.new("delete_me"), filename: "delete_me.pdf", content_type: "application/pdf")
-          documents_vacancy.supporting_documents.attach(io: StringIO.new("do_not_delete_me"), filename: "do_not_delete_me.pdf", content_type: "application/pdf")
-
-          visit organisation_job_documents_path(documents_vacancy.id)
-        end
-
-        scenario "deletes them" do
-          attachment = documents_vacancy.supporting_documents.first { |doc| doc.filename == "delete_me.pdf" }
-          find("tr[data-document-id=\"#{attachment.id}\"] a[data-method=delete]").click
-          expect(page).to have_content "delete_me.pdf was removed"
-          expect(documents_vacancy.supporting_documents.count).to eq(1)
-        end
-      end
-    end
-
-    describe "#applying_for_the_job" do
-      scenario "is invalid unless all mandatory fields are submitted" do
-        visit organisation_path
-        click_on I18n.t("buttons.create_job")
-
-        fill_in_job_details_form_fields(vacancy)
-        click_on I18n.t("buttons.continue")
-
-        fill_in_pay_package_form_fields(vacancy)
-        click_on I18n.t("buttons.continue")
-
-        fill_in_important_dates_fields(vacancy)
-        click_on I18n.t("buttons.continue")
-
-        click_on I18n.t("buttons.continue")
-
-        click_on I18n.t("buttons.continue")
-
-        within(".govuk-error-summary") do
-          expect(page).to have_content("There is a problem")
-        end
-
-        within_row_for(text: strip_tags(I18n.t("helpers.label.publishers_job_listing_applying_for_the_job_form.contact_email"))) do
-          expect(page).to have_content(I18n.t("applying_for_the_job_errors.contact_email.blank"))
-        end
-      end
-
-      scenario "redirects to the job summary page when submitted successfully" do
-        visit organisation_path
-        click_on I18n.t("buttons.create_job")
-
-        fill_in_job_details_form_fields(vacancy)
-        click_on I18n.t("buttons.continue")
-
-        fill_in_pay_package_form_fields(vacancy)
-        click_on I18n.t("buttons.continue")
-
-        fill_in_important_dates_fields(vacancy)
-        click_on I18n.t("buttons.continue")
-
-        click_on I18n.t("buttons.continue")
-
-        fill_in_applying_for_the_job_form_fields(vacancy)
-        click_on I18n.t("buttons.continue")
-
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 6, total: 7))
-        within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_summary"))
-        end
-      end
-    end
-
-    describe "#job_summary" do
-      scenario "is invalid unless all mandatory fields are submitted" do
-        visit organisation_path
-        click_on I18n.t("buttons.create_job")
-
-        fill_in_job_details_form_fields(vacancy)
-        click_on I18n.t("buttons.continue")
-
-        fill_in_pay_package_form_fields(vacancy)
-        click_on I18n.t("buttons.continue")
-
-        fill_in_important_dates_fields(vacancy)
-        click_on I18n.t("buttons.continue")
-
-        click_on I18n.t("buttons.continue")
-
-        fill_in_applying_for_the_job_form_fields(vacancy)
-        click_on I18n.t("buttons.continue")
-
-        click_on I18n.t("buttons.continue")
-
-        within(".govuk-error-summary") do
-          expect(page).to have_content("There is a problem")
-        end
-
-        within_row_for(text: I18n.t("jobs.job_advert")) do
-          expect(page).to have_content(I18n.t("activerecord.errors.models.vacancy.attributes.job_advert.blank"))
-        end
-
-        within_row_for(text: I18n.t("jobs.about_school", school: school.name)) do
-          expect(page).to have_content(school.description)
-        end
-      end
-
-      scenario "redirects to the vacancy review page when submitted successfully" do
-        visit organisation_path
-        click_on I18n.t("buttons.create_job")
-
-        fill_in_job_details_form_fields(vacancy)
-        click_on I18n.t("buttons.continue")
-
-        fill_in_pay_package_form_fields(vacancy)
-        click_on I18n.t("buttons.continue")
-
-        fill_in_important_dates_fields(vacancy)
-        click_on I18n.t("buttons.continue")
-
-        click_on I18n.t("buttons.continue")
-
-        fill_in_applying_for_the_job_form_fields(vacancy)
-        click_on I18n.t("buttons.continue")
-
-        fill_in_job_summary_form_fields(vacancy)
-        click_on I18n.t("buttons.continue")
-
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 7, total: 7))
-        within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("publishers.vacancies.steps.review_heading"))
-        end
-        verify_all_vacancy_details(created_vacancy)
-      end
+      verify_all_vacancy_details(created_vacancy)
     end
 
     describe "#review" do
       context "redirects the user back to the last incomplete step" do
-        scenario "redirects to step 2, pay package, when that step has not been completed" do
+        scenario "redirects to pay package when that step has not been completed" do
           visit organisation_path
           click_on I18n.t("buttons.create_job")
+
+          fill_in_job_role_form_fields(vacancy)
+          click_on I18n.t("buttons.continue")
+          click_on I18n.t("buttons.continue")
 
           fill_in_job_details_form_fields(vacancy)
           click_on I18n.t("buttons.continue")
@@ -397,15 +140,19 @@ RSpec.describe "Creating a vacancy" do
           v = Vacancy.find_by(job_title: vacancy.job_title)
           visit edit_organisation_job_path(id: v.id)
 
-          expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 7))
+          expect(page).to have_content(I18n.t("jobs.current_step", step: 3, total: 8))
           within("h2.govuk-heading-l") do
             expect(page).to have_content(I18n.t("publishers.vacancies.steps.pay_package"))
           end
         end
 
-        scenario "redirects to step 5, application details, when that step has not been completed" do
+        scenario "redirects to application details when that step has not been completed" do
           visit organisation_path
           click_on I18n.t("buttons.create_job")
+
+          fill_in_job_role_form_fields(vacancy)
+          click_on I18n.t("buttons.continue")
+          click_on I18n.t("buttons.continue")
 
           fill_in_job_details_form_fields(vacancy)
           click_on I18n.t("buttons.continue")
@@ -421,15 +168,19 @@ RSpec.describe "Creating a vacancy" do
           v = Vacancy.find_by(job_title: vacancy.job_title)
           visit edit_organisation_job_path(id: v.id)
 
-          expect(page).to have_content(I18n.t("jobs.current_step", step: 5, total: 7))
+          expect(page).to have_content(I18n.t("jobs.current_step", step: 6, total: 8))
           within("h2.govuk-heading-l") do
             expect(page).to have_content(I18n.t("publishers.vacancies.steps.applying_for_the_job"))
           end
         end
 
-        scenario "redirects to step 6, job summary, when that step has not been completed" do
+        scenario "redirects to job summary, when that step has not been completed" do
           visit organisation_path
           click_on I18n.t("buttons.create_job")
+
+          fill_in_job_role_form_fields(vacancy)
+          click_on I18n.t("buttons.continue")
+          click_on I18n.t("buttons.continue")
 
           fill_in_job_details_form_fields(vacancy)
           click_on I18n.t("buttons.continue")
@@ -448,7 +199,7 @@ RSpec.describe "Creating a vacancy" do
           v = Vacancy.find_by(job_title: vacancy.job_title)
           visit edit_organisation_job_path(id: v.id)
 
-          expect(page).to have_content(I18n.t("jobs.current_step", step: 6, total: 7))
+          expect(page).to have_content(I18n.t("jobs.current_step", step: 7, total: 8))
           within("h2.govuk-heading-l") do
             expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_summary"))
           end
@@ -539,12 +290,12 @@ RSpec.describe "Creating a vacancy" do
 
       context "edit job_details_details" do
         scenario "updates the vacancy details" do
-          vacancy = create(:vacancy, :draft)
+          vacancy = create(:vacancy, :draft, job_roles: %w[teacher])
           vacancy.organisation_vacancies.create(organisation: school)
           visit organisation_job_review_path(vacancy.id)
           click_header_link(I18n.t("publishers.vacancies.steps.job_details"))
 
-          expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 7))
+          expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 8))
 
           fill_in "publishers_job_listing_job_details_form[job_title]", with: "An edited job title"
           click_on I18n.t("buttons.update_job")
@@ -554,7 +305,7 @@ RSpec.describe "Creating a vacancy" do
         end
 
         scenario "fails validation until values are set correctly" do
-          vacancy = create(:vacancy, :draft)
+          vacancy = create(:vacancy, :draft, job_roles: %w[teacher])
           vacancy.organisation_vacancies.create(organisation: school)
           visit organisation_job_review_path(vacancy.id)
           click_header_link(I18n.t("publishers.vacancies.steps.job_details"))
@@ -577,6 +328,10 @@ RSpec.describe "Creating a vacancy" do
           visit organisation_path
           click_on I18n.t("buttons.create_job")
 
+          fill_in_job_role_form_fields(vacancy)
+          click_on I18n.t("buttons.continue")
+          click_on I18n.t("buttons.continue")
+
           fill_in_job_details_form_fields(vacancy)
           click_on I18n.t("buttons.continue")
 
@@ -598,7 +353,7 @@ RSpec.describe "Creating a vacancy" do
 
           click_header_link(I18n.t("publishers.vacancies.steps.documents"))
 
-          expect(page).to have_content(I18n.t("jobs.current_step", step: 4, total: 7))
+          expect(page).to have_content(I18n.t("jobs.current_step", step: 5, total: 8))
           expect(page).to have_content(I18n.t("helpers.label.publishers_job_listing_documents_form.documents"))
 
           click_on I18n.t("buttons.update_job")
@@ -609,12 +364,12 @@ RSpec.describe "Creating a vacancy" do
 
       context "editing applying_for_the_job" do
         scenario "fails validation until values are set correctly" do
-          vacancy = create(:vacancy, :draft)
+          vacancy = create(:vacancy, :draft, job_roles: %w[teacher])
           vacancy.organisation_vacancies.create(organisation: school)
           visit organisation_job_review_path(vacancy.id)
           click_header_link(I18n.t("publishers.vacancies.steps.applying_for_the_job"))
 
-          expect(page).to have_content(I18n.t("jobs.current_step", step: 5, total: 7))
+          expect(page).to have_content(I18n.t("jobs.current_step", step: 6, total: 8))
 
           fill_in "publishers_job_listing_applying_for_the_job_form[contact_email]", with: "not a valid email"
           click_on I18n.t("buttons.update_job")
@@ -629,12 +384,12 @@ RSpec.describe "Creating a vacancy" do
         end
 
         scenario "updates the vacancy details" do
-          vacancy = create(:vacancy, :draft)
+          vacancy = create(:vacancy, :draft, job_roles: %w[teacher])
           vacancy.organisation_vacancies.create(organisation: school)
           visit organisation_job_review_path(vacancy.id)
           click_header_link(I18n.t("publishers.vacancies.steps.applying_for_the_job"))
 
-          expect(page).to have_content(I18n.t("jobs.current_step", step: 5, total: 7))
+          expect(page).to have_content(I18n.t("jobs.current_step", step: 6, total: 8))
 
           fill_in "publishers_job_listing_applying_for_the_job_form[contact_email]", with: "an@email.com"
           click_on I18n.t("buttons.update_job")
@@ -645,7 +400,7 @@ RSpec.describe "Creating a vacancy" do
       end
 
       scenario "redirects to the summary page when published" do
-        vacancy = create(:vacancy, :draft)
+        vacancy = create(:vacancy, :draft, job_roles: %w[teacher])
         vacancy.organisation_vacancies.create(organisation: school)
         visit organisation_job_review_path(vacancy.id)
         click_on I18n.t("buttons.submit_job_listing")
@@ -657,14 +412,14 @@ RSpec.describe "Creating a vacancy" do
     describe "#publish" do
       scenario "cannot be published unless the details are valid" do
         yesterday_date = Time.zone.yesterday
-        vacancy = create(:vacancy, :draft, publish_on: Time.zone.tomorrow)
+        vacancy = create(:vacancy, :draft, publish_on: Time.zone.tomorrow, job_roles: %w[teacher])
         vacancy.organisation_vacancies.create(organisation: school)
         vacancy.assign_attributes expires_at: yesterday_date
         vacancy.save(validate: false)
 
         visit organisation_job_review_path(vacancy.id)
 
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 3, total: 7))
+        expect(page).to have_content(I18n.t("jobs.current_step", step: 4, total: 8))
         within("h2.govuk-heading-l") do
           expect(page).to have_content(I18n.t("publishers.vacancies.steps.important_dates"))
         end
@@ -698,7 +453,7 @@ RSpec.describe "Creating a vacancy" do
       end
 
       scenario "can be published at a later date" do
-        vacancy = create(:vacancy, :draft, publish_on: Time.zone.tomorrow)
+        vacancy = create(:vacancy, :draft, publish_on: Time.zone.tomorrow, job_roles: %w[teacher])
         vacancy.organisation_vacancies.create(organisation: school)
 
         visit organisation_job_review_path(vacancy.id)
@@ -710,7 +465,7 @@ RSpec.describe "Creating a vacancy" do
       end
 
       scenario "displays the expiration date and time on the confirmation page" do
-        vacancy = create(:vacancy, :draft, expires_at: 5.days.from_now.change(hour: 9, minute: 0))
+        vacancy = create(:vacancy, :draft, expires_at: 5.days.from_now.change(hour: 9, minute: 0), job_roles: %w[teacher])
         vacancy.organisation_vacancies.create(organisation: school)
         visit organisation_job_review_path(vacancy.id)
         click_on I18n.t("buttons.submit_job_listing")
@@ -721,7 +476,7 @@ RSpec.describe "Creating a vacancy" do
       end
 
       scenario "a published vacancy cannot be republished" do
-        vacancy = create(:vacancy, :draft, publish_on: Time.zone.tomorrow)
+        vacancy = create(:vacancy, :draft, publish_on: Time.zone.tomorrow, job_roles: %w[teacher])
         vacancy.organisation_vacancies.create(organisation: school)
 
         visit organisation_job_review_path(vacancy.id)
@@ -744,7 +499,7 @@ RSpec.describe "Creating a vacancy" do
 
       context "adds a job to update the Google index in the queue" do
         scenario "if the vacancy is published immediately" do
-          vacancy = create(:vacancy, :draft, publish_on: Date.current)
+          vacancy = create(:vacancy, :draft, publish_on: Date.current, job_roles: %w[teacher])
           vacancy.organisation_vacancies.create(organisation: school)
 
           expect_any_instance_of(Publishers::Vacancies::BaseController)

--- a/spec/system/publishers_can_publish_a_vacancy_as_a_trust_spec.rb
+++ b/spec/system/publishers_can_publish_a_vacancy_as_a_trust_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Creating a vacancy" do
   let(:school1) { create(:school, name: "First school") }
   let(:school2) { create(:school, name: "Second school") }
   let(:school3) { create(:school, :closed, name: "Closed school") }
-  let(:vacancy) { build(:vacancy, :central_office) }
+  let(:vacancy) { build(:vacancy, :central_office, job_roles: %w[teacher]) }
   let(:created_vacancy) { Vacancy.last }
 
   before do
@@ -23,21 +23,25 @@ RSpec.describe "Creating a vacancy" do
     visit organisation_path
     click_on I18n.t("buttons.create_job")
 
-    fill_in_job_location_form_field(vacancy, "Multi-academy trust")
+    fill_in_job_role_form_fields(vacancy)
     click_on I18n.t("buttons.continue")
 
     expect(page.get_rack_session["current_step"]).to be nil
   end
 
   context "when job is located at trust central office" do
-    let(:vacancy) { build(:vacancy, :central_office) }
+    let(:vacancy) { build(:vacancy, :central_office, job_roles: %w[teacher]) }
 
     describe "#job_location" do
       scenario "redirects to job details when submitted successfully" do
         visit organisation_path
         click_on I18n.t("buttons.create_job")
 
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 8))
+        fill_in_job_role_form_fields(vacancy)
+        click_on I18n.t("buttons.continue")
+        click_on I18n.t("buttons.continue")
+
+        expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 9))
         within("h2.govuk-heading-l") do
           expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_location"))
         end
@@ -45,7 +49,7 @@ RSpec.describe "Creating a vacancy" do
         fill_in_job_location_form_field(vacancy, "Multi-academy trust")
         click_on I18n.t("buttons.continue")
 
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 8))
+        expect(page).to have_content(I18n.t("jobs.current_step", step: 3, total: 9))
         within("h2.govuk-heading-l") do
           expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_details"))
         end
@@ -54,14 +58,18 @@ RSpec.describe "Creating a vacancy" do
   end
 
   context "when job is located at a single school in the local authority" do
-    let(:vacancy) { build(:vacancy, :at_one_school) }
+    let(:vacancy) { build(:vacancy, :at_one_school, job_roles: %w[teacher]) }
 
     describe "#job_location" do
       scenario "displays error message unless a school is selected" do
         visit organisation_path
         click_on I18n.t("buttons.create_job")
 
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 8))
+        fill_in_job_role_form_fields(vacancy)
+        click_on I18n.t("buttons.continue")
+        click_on I18n.t("buttons.continue")
+
+        expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 9))
         within("h2.govuk-heading-l") do
           expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_location"))
         end
@@ -69,14 +77,14 @@ RSpec.describe "Creating a vacancy" do
         fill_in_job_location_form_field(vacancy, "Multi-academy trust")
         click_on I18n.t("buttons.continue")
 
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 8))
+        expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 9))
         within("h2.govuk-heading-l") do
           expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_location"))
         end
 
         click_on I18n.t("buttons.continue")
 
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 8))
+        expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 9))
         within("h2.govuk-heading-l") do
           expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_location"))
         end
@@ -87,7 +95,7 @@ RSpec.describe "Creating a vacancy" do
         fill_in_school_form_field(school2)
         click_on I18n.t("buttons.continue")
 
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 8))
+        expect(page).to have_content(I18n.t("jobs.current_step", step: 3, total: 9))
         within("h2.govuk-heading-l") do
           expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_details"))
         end
@@ -96,14 +104,18 @@ RSpec.describe "Creating a vacancy" do
   end
 
   context "when job is located at multiple schools in the trust" do
-    let(:vacancy) { build(:vacancy, :at_multiple_schools) }
+    let(:vacancy) { build(:vacancy, :at_multiple_schools, job_roles: %w[teacher]) }
 
     describe "#job_location" do
       scenario "displays error message unless at least 2 schools are selected" do
         visit organisation_path
         click_on I18n.t("buttons.create_job")
 
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 8))
+        fill_in_job_role_form_fields(vacancy)
+        click_on I18n.t("buttons.continue")
+        click_on I18n.t("buttons.continue")
+
+        expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 9))
         within("h2.govuk-heading-l") do
           expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_location"))
         end
@@ -111,7 +123,7 @@ RSpec.describe "Creating a vacancy" do
         fill_in_job_location_form_field(vacancy, "Multi-academy trust")
         click_on I18n.t("buttons.continue")
 
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 8))
+        expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 9))
         within("h2.govuk-heading-l") do
           expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_location"))
         end
@@ -119,7 +131,7 @@ RSpec.describe "Creating a vacancy" do
         check school1.name, name: "publishers_job_listing_schools_form[organisation_ids][]", visible: false
         click_on I18n.t("buttons.continue")
 
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 8))
+        expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 9))
         within("h2.govuk-heading-l") do
           expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_location"))
         end
@@ -131,7 +143,7 @@ RSpec.describe "Creating a vacancy" do
         check school2.name, name: "publishers_job_listing_schools_form[organisation_ids][]", visible: false
         click_on I18n.t("buttons.continue")
 
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 2, total: 8))
+        expect(page).to have_content(I18n.t("jobs.current_step", step: 3, total: 9))
         within("h2.govuk-heading-l") do
           expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_details"))
         end
@@ -142,6 +154,16 @@ RSpec.describe "Creating a vacancy" do
   scenario "publishes a vacancy" do
     visit organisation_path
     click_on I18n.t("buttons.create_job")
+    expect(current_path).to eq(organisation_job_build_path(created_vacancy.id, :job_role))
+
+    click_on I18n.t("buttons.continue")
+    expect(page).to have_content("There is a problem")
+
+    fill_in_job_role_form_fields(vacancy)
+    click_on I18n.t("buttons.continue")
+    expect(current_path).to eq(organisation_job_build_path(created_vacancy.id, :job_role_details))
+
+    click_on I18n.t("buttons.continue")
     expect(current_path).to eq(organisation_job_build_path(created_vacancy.id, :job_location))
 
     click_on I18n.t("buttons.continue")

--- a/spec/system/publishers_can_save_and_return_later_spec.rb
+++ b/spec/system/publishers_can_save_and_return_later_spec.rb
@@ -6,43 +6,18 @@ RSpec.describe "Publishers can save and return later" do
 
   before do
     login_publisher(publisher: publisher, organisation: school)
-    @vacancy = VacancyPresenter.new(build(:vacancy, :draft, working_patterns: %w[full_time part_time]))
+    @vacancy = VacancyPresenter.new(build(:vacancy, :draft, working_patterns: %w[full_time part_time], job_roles: %w[teacher]))
   end
 
   context "Create a job journey" do
-    describe "#job_details" do
-      scenario "can save and return later" do
-        visit organisation_path
-        click_on I18n.t("buttons.create_job")
-
-        expect(page.current_path).to eq(organisation_job_build_path(Vacancy.last.id, :job_details))
-        expect(page).to have_content(I18n.t("jobs.create_a_job_title_no_org"))
-        expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 7))
-        within("h2.govuk-heading-l") do
-          expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_details"))
-        end
-
-        fill_in "publishers_job_listing_job_details_form[job_title]", with: @vacancy.job_title
-        click_on I18n.t("buttons.save_and_return_later")
-        created_vacancy = Vacancy.find_by(job_title: @vacancy.job_title)
-
-        expect(page.current_path).to eq(jobs_with_type_organisation_path("draft"))
-        expect(page.body).to include(I18n.t("messages.jobs.draft_saved_html", job_title: @vacancy.job_title))
-
-        click_on @vacancy.job_title
-        within("#job_details") do
-          click_on I18n.t("buttons.change")
-        end
-
-        expect(page.current_path).to eq(organisation_job_build_path(created_vacancy.id, :job_details))
-        expect(find_field("publishers_job_listing_job_details_form[job_title]").value).to eq(@vacancy.job_title)
-      end
-    end
-
     describe "#pay_package" do
       scenario "can save and return later" do
         visit organisation_path
         click_on I18n.t("buttons.create_job")
+
+        fill_in_job_role_form_fields(@vacancy)
+        click_on I18n.t("buttons.continue")
+        click_on I18n.t("buttons.continue")
 
         fill_in_job_details_form_fields(@vacancy)
         click_on I18n.t("buttons.continue")
@@ -70,6 +45,10 @@ RSpec.describe "Publishers can save and return later" do
       scenario "can save and return later" do
         visit organisation_path
         click_on I18n.t("buttons.create_job")
+
+        fill_in_job_role_form_fields(@vacancy)
+        click_on I18n.t("buttons.continue")
+        click_on I18n.t("buttons.continue")
 
         fill_in_job_details_form_fields(@vacancy)
         click_on I18n.t("buttons.continue")
@@ -102,6 +81,10 @@ RSpec.describe "Publishers can save and return later" do
       scenario "redirected to important_dates if not valid" do
         visit organisation_path
         click_on I18n.t("buttons.create_job")
+
+        fill_in_job_role_form_fields(@vacancy)
+        click_on I18n.t("buttons.continue")
+        click_on I18n.t("buttons.continue")
 
         fill_in_job_details_form_fields(@vacancy)
         click_on I18n.t("buttons.continue")
@@ -138,6 +121,10 @@ RSpec.describe "Publishers can save and return later" do
         visit organisation_path
         click_on I18n.t("buttons.create_job")
 
+        fill_in_job_role_form_fields(@vacancy)
+        click_on I18n.t("buttons.continue")
+        click_on I18n.t("buttons.continue")
+
         fill_in_job_details_form_fields(@vacancy)
         click_on I18n.t("buttons.continue")
         created_vacancy = Vacancy.find_by(job_title: @vacancy.job_title)
@@ -168,6 +155,10 @@ RSpec.describe "Publishers can save and return later" do
       scenario "can save and return later" do
         visit organisation_path
         click_on I18n.t("buttons.create_job")
+
+        fill_in_job_role_form_fields(@vacancy)
+        click_on I18n.t("buttons.continue")
+        click_on I18n.t("buttons.continue")
 
         fill_in_job_details_form_fields(@vacancy)
         click_on I18n.t("buttons.continue")
@@ -203,6 +194,10 @@ RSpec.describe "Publishers can save and return later" do
       scenario "can save and return later" do
         visit organisation_path
         click_on I18n.t("buttons.create_job")
+
+        fill_in_job_role_form_fields(@vacancy)
+        click_on I18n.t("buttons.continue")
+        click_on I18n.t("buttons.continue")
 
         fill_in_job_details_form_fields(@vacancy)
         click_on I18n.t("buttons.continue")
@@ -241,13 +236,19 @@ RSpec.describe "Publishers can save and return later" do
   end
 
   describe "can temporarily omit a step by saving at an earlier step and returning on a later step" do
-    scenario "can edit the job details step and then the applying for this job step" do
+    scenario "can edit the pay package step and then the applying for this job step" do
       visit organisation_path
       click_on I18n.t("buttons.create_job")
 
-      fill_in "publishers_job_listing_job_details_form[job_title]", with: @vacancy.job_title
+      fill_in_job_role_form_fields(@vacancy)
+      click_on I18n.t("buttons.continue")
+      click_on I18n.t("buttons.continue")
+
+      fill_in_job_details_form_fields(@vacancy)
+      click_on I18n.t("buttons.continue")
+
       click_on I18n.t("buttons.save_and_return_later")
-      created_vacancy = Vacancy.find_by(job_title: @vacancy.job_title)
+      created_vacancy = Vacancy.last
 
       expect(page.current_path).to eq(jobs_with_type_organisation_path("draft"))
 

--- a/spec/system/publishers_session_timeout_spec.rb
+++ b/spec/system/publishers_session_timeout_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Publisher session" do
     travel(Publisher.timeout_in - 1.minute) do
       click_on I18n.t("buttons.continue")
 
-      expect(page.current_path).to eq organisation_job_build_path(Vacancy.last.id, :job_details)
+      expect(page.current_path).to eq organisation_job_build_path(Vacancy.last.id, :job_role)
     end
   end
 end


### PR DESCRIPTION
### Introduce "job roles" step and primary job role
- Create new "job role" step at the beginning of job creation flow
- Move job roles from "job details" step to new step
- Introduce concept of a primary job role, which is selected and
  persisted into `job_roles` in this step, and turn checkboxes into
  radios as only one can be selected in this step (implemented as
  a virtual attribute on `Vacancy` which munges the `job_roles` array
  until we improve the data schema)
- Move job role into its own section on review page
- Add new "Education support" and "SENDCo" primary job roles
- Remove ability to "save and return" until job details step has been
  completed

### Introduce "job role details" step and additional job roles

- Change existing "SEN specialist" job role to "SEND responsible"
- Add virtual attribute for additional job roles to `Vacancy`
- Create a new "job role details" sub-step of "job roles" step
- Create a form model dealing with additional job roles (and a
  virtual attribute to handle the "SEND responsible" role being
  yes/no radio buttons
- Show "job role details" step as part of "job roles" step unless
  the primary job role is a SENDCo
- Show check boxes for additional job roles if primary job role is
  teacher
- Show yes/no radio buttons for SEND responsibilities if primary
  job role is leadership or education support

### Update job display page and filters to reflect new roles

- Change "job role" search filters to only include primary roles
- Fix translations (and keep old job_roles_options translations for
  now to avoid having to change use everywhere)

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2871