### PR TITLE
[TEVA-3007] fix missing notification count in main nav

### DIFF
--- a/app/components/navbar_component.rb
+++ b/app/components/navbar_component.rb
@@ -7,7 +7,7 @@ class NavbarComponent < GovukComponent::Base
     if link_text == :spacer
       tag.li class: "navbar-component__items-spacer", "aria-hidden": "true", "tab-index": "-1"
     else
-      tag.li class: "navbar-component__navigation-item--#{align} govuk-header__navigation-item #{active_link_class(path)}" do
+      tag.li class: "navbar-component__navigation-item--#{align} navbar-component-#{link_text.downcase} govuk-header__navigation-item #{active_link_class(path)}" do
         link_to link_text, path, class: "govuk-header__link", method: method, aria: aria
       end
     end

--- a/app/components/navbar_component/navbar_component.scss
+++ b/app/components/navbar_component/navbar_component.scss
@@ -3,10 +3,10 @@
 nav.navbar-component {
   .notification-badge {
     background-color: govuk-colour('white');
-    border-radius: 75%;
+    border-radius: govuk-spacing(1);
     color: govuk-colour('black');
     font-weight: bold;
-    margin-left: govuk-spacing(2);
+    margin-left: govuk-spacing(1);
     padding: 0 govuk-spacing(1);
   }
 

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -47,9 +47,10 @@ html.govuk-template.app-html-class lang="en"
               - if current_organisation.school_group?
                 - navigation.item link_text: t("nav.school_group_index_link", organisation_type: organisation_type_basic(current_organisation)), align: :left, path: organisation_schools_path
               - navigation.item link_text: t("nav.jobseekers_index_link"), align: :left, path: root_path
-              - navigation.item link_text: t("nav.notifications_index_link"), aria: { label: "#{current_publisher.notifications.unread.count} unread notifications" }, align: :left, path: publishers_notifications_path
-              - if current_publisher.notifications.unread.any?
-                span.notification-badge = current_publisher.notifications.unread.count
+              - navigation.item link_text: t("nav.notifications_index_link_html", count: current_publisher.notifications.unread.count),
+                  aria: { label: "#{current_publisher.notifications.unread.count} unread notifications" },
+                  align: :left,
+                  path: publishers_notifications_path
               - navigation.item link_text: :spacer
               - navigation.item link_text: t("nav.sign_out"), align: :right, path: destroy_publisher_session_path, method: :delete
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -192,7 +192,10 @@ en:
     find_job: Find a teaching job
     for_schools: For schools
     jobseekers_index_link: View public jobs
-    notifications_index_link: Notifications
+    notifications_index_link_html:
+      zero: Notifications
+      one: Notifications <span class="notification-badge">%{count}<span class="govuk-visually-hidden"> unread</span></span>
+      other: Notifications <span class="notification-badge">%{count}<span class="govuk-visually-hidden"> unread</span></span>
     school_group_index_link: Schools in your %{organisation_type}
     school_page_link: Manage jobs
     sign_in: List a teaching job

--- a/spec/components/navbar_component_spec.rb
+++ b/spec/components/navbar_component_spec.rb
@@ -18,14 +18,14 @@ RSpec.describe NavbarComponent, type: :component do
     end
 
     it "renders the navigation items" do
-      expect(page).to have_css("nav", class: "navbar-component") do |items|
-        expect(items).to have_css("ul", class: "navbar-component__items") do |item|
-          expect(item).to have_css("li", class: "navbar-component__navigation-item--left", text: "A nav item") do |link|
-            expect(link).to have_css("a[href='/1']")
+      expect(page).to have_css("nav", class: "navbar-component") do |nav|
+        expect(nav).to have_css("ul", class: "navbar-component__items") do |list|
+          expect(list).to have_css("li", class: "navbar-component__navigation-item--left", text: "A nav item") do |item|
+            expect(item).to have_css("a[href='/1']")
           end
-          expect(item).to have_css("li", class: "navbar-component__items-spacer")
-          expect(item).to have_css("li", class: "navbar-component__navigation-item--right", text: "Another nav item") do |link|
-            expect(link).to have_css("a[href='/2']")
+          expect(list).to have_css("li", class: "navbar-component__items-spacer")
+          expect(list).to have_css("li", class: "navbar-component__navigation-item--right", text: "Another nav item") do |item|
+            expect(item).to have_css("a[href='/2']")
           end
         end
       end

--- a/spec/system/main_navigation_spec.rb
+++ b/spec/system/main_navigation_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Main navigation for users to sign in and out" do
       within ".navbar-component" do
         expect(page).to have_content(I18n.t("nav.school_page_link"))
         expect(page).to have_content(I18n.t("nav.jobseekers_index_link"))
-        expect(page).to have_content(I18n.t("nav.notifications_index_link"))
+        expect(page).to have_content(I18n.t("nav.notifications_index_link_html", count: 0))
         expect(page).to have_content(I18n.t("nav.sign_out"))
       end
     end

--- a/spec/system/publishers_can_view_their_notifications_spec.rb
+++ b/spec/system/publishers_can_view_their_notifications_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Publishers can view their notifications" do
     end
 
     it "clicks notifications link, renders the notifications, paginates, and marks as read" do
-      click_on I18n.t("nav.notifications_index_link")
+      find(".navbar-component-notifications .govuk-header__link").click
 
       expect(page).to have_css("div", class: "notification-component", count: 1) do |notification|
         expect(notification).to have_css("div", class: "notification-component__tag", text: "new", count: 1)


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-3007

with hidden text so screen reader reads `notifications 2000 unread`

![Screenshot 2021-08-20 at 14 27 42](https://user-images.githubusercontent.com/1792451/130240403-c044ab54-be4d-4782-8870-d478e45103a0.png)

