### PR TITLE
[TEVA-2982] Add text to statistics page when vacancy is in draft status

### DIFF
--- a/app/views/publishers/vacancies/statistics/show.html.slim
+++ b/app/views/publishers/vacancies/statistics/show.html.slim
@@ -10,6 +10,8 @@
         = t(".intro")
         br
         = t(".explanation")
+    - elsif vacancy.draft?
+      = govuk_inset_text text: t(".draft_vacancy")
 
   .govuk-grid-column-two-thirds
     h3.govuk-heading-m = t(".listing_data")

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -295,6 +295,7 @@ en:
       statistics:
         show:
           application_data: Application data
+          draft_vacancy: Once you have published the vacancy you will be able to see how many jobseekers are viewing and saving this job
           explanation: This is to ensure the anonymity of applicants who submit equal opportunities information.
           intro: This may include data from candidates who have withdrawn their applications.
           listing_data: Listing data


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2982

## Screenshot:

<img width="1119" alt="Screenshot 2021-08-24 at 09 29 51" src="https://user-images.githubusercontent.com/30624173/130584829-c8cfaf17-7b6f-4224-bc7d-67612f719bb2.png">


