### PR TITLE
Implement filter for SEND responsibilities

### DIFF
--- a/app/form_models/jobseekers/search_form.rb
+++ b/app/form_models/jobseekers/search_form.rb
@@ -4,7 +4,8 @@ class Jobseekers::SearchForm
   attr_reader :keyword,
               :location, :radius,
               :job_roles, :phases, :working_patterns,
-              :job_role_options, :nqt_suitable_options, :phase_options, :working_pattern_options,
+              :job_role_options, :nqt_suitable_options, :send_responsible_options,
+              :phase_options, :working_pattern_options,
               :total_filters, :jobs_sort
 
   def initialize(params = {})
@@ -45,7 +46,8 @@ class Jobseekers::SearchForm
   def set_facet_options
     @job_role_options = Vacancy.primary_job_role_options.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_role_form.primary_job_role_options.#{option}")] }
     @phase_options = [%w[primary Primary], %w[middle Middle], %w[secondary Secondary], %w[16-19 16-19]]
-    @nqt_suitable_options = Vacancy.job_roles.slice(:nqt_suitable).keys.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_role_details_form.additional_job_roles_options.#{option}")] }
+    @nqt_suitable_options = [["nqt_suitable", I18n.t("jobs.filters.nqt_suitable_only"), I18n.t("jobs.filters.nqt_suitable")]]
+    @send_responsible_options = [["send_responsible", I18n.t("jobs.filters.send_responsible_only"), I18n.t("jobs.filters.send_responsible")]]
     @working_pattern_options = Vacancy.working_patterns.keys.map do |option|
       [option, I18n.t("helpers.label.publishers_job_listing_job_details_form.working_patterns_options.#{option}")]
     end

--- a/app/form_models/jobseekers/subscription_form.rb
+++ b/app/form_models/jobseekers/subscription_form.rb
@@ -4,7 +4,8 @@ class Jobseekers::SubscriptionForm
   attr_accessor :email, :frequency,
                 :keyword, :location, :radius,
                 :job_roles, :phases, :working_patterns,
-                :job_role_options, :nqt_suitable_options, :phase_options, :working_pattern_options,
+                :job_role_options, :nqt_suitable_options, :send_responsible_options,
+                :phase_options, :working_pattern_options,
                 :variant
 
   validates :email, presence: true
@@ -55,7 +56,8 @@ class Jobseekers::SubscriptionForm
   def set_facet_options
     @job_role_options = Vacancy.primary_job_role_options.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_role_form.primary_job_role_options.#{option}")] }
     @phase_options = [%w[primary Primary], %w[middle Middle], %w[secondary Secondary], %w[16-19 16-19]]
-    @nqt_suitable_options = Vacancy.job_roles.slice(:nqt_suitable).keys.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_role_details_form.additional_job_roles_options.#{option}")] }
+    @nqt_suitable_options = [["nqt_suitable", I18n.t("jobs.filters.nqt_suitable")]]
+    @send_responsible_options = [["send_responsible", I18n.t("jobs.filters.send_responsible_option")]]
     @working_pattern_options = Vacancy.working_patterns.keys.map do |option|
       [option, I18n.t("helpers.label.publishers_job_listing_job_details_form.working_patterns_options.#{option}")]
     end

--- a/app/views/subscriptions/_fields.html.slim
+++ b/app/views/subscriptions/_fields.html.slim
@@ -26,6 +26,16 @@ ruby:
       selected_method: :last,
     },
     {
+      title: t("jobs.filters.send_responsible"),
+      key: "send_responsible",
+      attribute: :job_roles,
+      selected: @form.job_roles.include?("send_responsible") ? @form.job_roles : [],
+      options: @form.send_responsible_options,
+      value_method: :first,
+      text_method: :last,
+      selected_method: :last,
+    },
+    {
       title: t("jobs.filters.phases"),
       key: "education_phase",
       attribute: :phases,

--- a/app/views/vacancies/_search.html.slim
+++ b/app/views/vacancies/_search.html.slim
@@ -13,12 +13,21 @@ ruby:
     {
       title: t("jobs.filters.nqt_suitable"),
       key: "nqt_suitable",
-      hidden_text: t("jobs.filters.nqt_suitable_hidden_prefix"),
       attribute: :job_roles,
       selected: @form.job_roles.include?("nqt_suitable") ? @form.job_roles : [],
       options: @form.nqt_suitable_options,
       value_method: :first,
-      text_method: :last,
+      text_method: :second,
+      selected_method: :last,
+    },
+    {
+      title: t("jobs.filters.send_responsible"),
+      key: "send_responsible",
+      attribute: :job_roles,
+      selected: @form.job_roles.include?("send_responsible") ? @form.job_roles : [],
+      options: @form.send_responsible_options,
+      value_method: :first,
+      text_method: :second,
       selected_method: :last,
     },
     {

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -14,7 +14,10 @@ en:
       job_filters: Job Filters
       job_roles: Job role
       nqt_suitable: Suitable for early career teachers
-      nqt_suitable_hidden_prefix: Only show results
+      nqt_suitable_only: Only show results suitable for early career teachers
+      send_responsible: SEND responsibilities
+      send_responsible_option: Has SEND responsibilities (special educational needs and disabilities)
+      send_responsible_only: Only show results with SEND responsibilities (special educational needs and disabilities)
       phases: Education phase
       working_patterns: Working pattern
 

--- a/spec/system/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
+++ b/spec/system/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
@@ -157,7 +157,8 @@ RSpec.describe "Jobseekers can create a job alert from a search", recaptcha: tru
         select "25 miles", from: "radius"
       end
       check I18n.t("helpers.label.publishers_job_listing_job_details_form.job_roles_options.teacher")
-      check I18n.t("helpers.label.publishers_job_listing_job_details_form.job_roles_options.nqt_suitable")
+      check I18n.t("jobs.filters.nqt_suitable_only")
+      check I18n.t("jobs.filters.send_responsible_only")
       check I18n.t("helpers.label.publishers_job_listing_job_details_form.working_patterns_options.full_time")
       click_on I18n.t("buttons.search")
     end


### PR DESCRIPTION
Note that this does not yet include the work identified as part of
implementing this change to make the "primary" job role filters
work independently of the NQT/SEND filters (rather than being one
big OR across all of them).

- Add SEND responsibilities filter to search filters
- Add SEND responsibilities filter to job alert creation filters
- Change wording of filters

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2872