### PR TITLE
Split out a new "teaching assistant" job role

### DIFF
--- a/app/form_models/publishers/job_listing/applying_for_the_job_form.rb
+++ b/app/form_models/publishers/job_listing/applying_for_the_job_form.rb
@@ -3,7 +3,7 @@ class Publishers::JobListing::ApplyingForTheJobForm < Publishers::JobListing::Va
 
   before_validation :override_enable_job_applications_for_local_authority!
 
-  validates :enable_job_applications, inclusion: { in: [true, false, "true", "false"] }
+  validates :enable_job_applications, inclusion: { in: [true, false, "true", "false"] }, if: proc { vacancy.allow_enabling_job_applications? }
   validates :how_to_apply, presence: true, unless: proc { enable_job_applications.in?(["true", true]) }
   validates :application_link, url: true, if: proc { application_link.present? }
 

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -11,7 +11,7 @@ class Vacancy < ApplicationRecord
   # we used to allow multiple.
   # TODO: This is a compromise to keep changes to the data model minimal for now. Once
   # the legacy vacancies are gone, we should refactor the data model.
-  PRIMARY_JOB_ROLES =  { teacher: 0, leadership: 1, education_support: 4, sendco: 5 }.freeze
+  PRIMARY_JOB_ROLES =  { teacher: 0, leadership: 1, teaching_assistant: 6, education_support: 4, sendco: 5 }.freeze
   ADDITIONAL_JOB_ROLES = { send_responsible: 2, nqt_suitable: 3 }.freeze
   array_enum job_roles: PRIMARY_JOB_ROLES.merge(ADDITIONAL_JOB_ROLES)
 
@@ -105,6 +105,10 @@ class Vacancy < ApplicationRecord
 
   def pending?
     published? && publish_on&.future?
+  end
+
+  def allow_enabling_job_applications?
+    %w[teacher leadership sendco].include?(primary_job_role)
   end
 
   def can_receive_job_applications?

--- a/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
+++ b/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
@@ -13,7 +13,7 @@
 
         h2.govuk-heading-l = t("publishers.vacancies.steps.applying_for_the_job")
 
-        - if vacancy.primary_job_role == "education_support"
+        - if !vacancy.allow_enabling_job_applications?
           details class="govuk-details" data-module="govuk-details"
             summary.govuk-details__summary
               .govuk-details__summary-text = t(".education_support.reveal")

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -230,7 +230,7 @@ en:
       publishers_job_listing_job_role_form:
         primary_job_role_options:
           leadership: Includes Head of Year/Subject, Deputy/Assistant Head, Headteacher, and trust-level roles
-          education_support: Includes Teaching assistant and Learning support
+          education_support: Includes Learning support
           sendco: Special educational needs and disabilities coordinator
       publishers_job_listing_job_role_details_form:
         additional_job_roles: Select all that apply
@@ -557,12 +557,14 @@ en:
           nqt_suitable: Suitable for early career teachers
           sen_specialist: Special educational needs (SEN) specialist
           send_responsible: SEND responsibilities (special educational needs and disabilities)
+          teaching_assistant: Teaching assistant
           sendco: SENDCo
           teacher: Teacher
       publishers_job_listing_job_role_form:
         primary_job_role_options:
           teacher: Teacher
           leadership: Leadership
+          teaching_assistant: Teaching assistant
           sendco: SENDCo
           education_support: Education support
       publishers_job_listing_job_role_details_form:

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -171,7 +171,7 @@ en:
               content_with_no_link: You can choose for candidates to apply for the job through Teaching Vacancies.
               link: Preview the application form
           education_support:
-            reveal: You can't accept Education support applications directly through Teaching Vacancies at this time
+            reveal: You can't accept Teaching assistant or Education support applications directly through Teaching Vacancies at this time
             infomation:
               - This option will be available to hiring staff in the future.
               - For now ensure to include details on how candidates can apply through your own process.

--- a/spec/form_models/publishers/job_listing/applying_for_the_job_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/applying_for_the_job_form_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe Publishers::JobListing::ApplyingForTheJobForm, type: :model do
+  subject { described_class.new(vacancy: vacancy) }
+
+  let(:vacancy) { build_stubbed(:vacancy) }
+
   it { is_expected.to allow_value("https://www.this-is-a-test-url.tvs").for(:application_link) }
   it { is_expected.to allow_value("").for(:application_link) }
   it { is_expected.not_to allow_value("invalid_link").for(:application_link) }
@@ -14,13 +18,13 @@ RSpec.describe Publishers::JobListing::ApplyingForTheJobForm, type: :model do
   it { is_expected.not_to allow_value("invalid-01234").for(:contact_number) }
 
   context "when enable_job_applications is false" do
-    subject { described_class.new(enable_job_applications: "false") }
+    subject { described_class.new(enable_job_applications: "false", vacancy: vacancy) }
 
     it { is_expected.to validate_presence_of(:how_to_apply) }
   end
 
   describe "enable job applications override" do
-    subject { described_class.new(current_organisation: organisation) }
+    subject { described_class.new(current_organisation: organisation, vacancy: vacancy) }
 
     context "when the current organisation given is a local authority" do
       let(:organisation) { build_stubbed(:local_authority) }

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -81,7 +81,7 @@ module VacancyHelpers
   end
 
   def fill_in_applying_for_the_job_form_fields(vacancy, local_authority_vacancy: false)
-    if !local_authority_vacancy && vacancy.enable_job_applications? && vacancy.primary_job_role != "education_support"
+    if !local_authority_vacancy && vacancy.enable_job_applications? && vacancy.allow_enabling_job_applications?
       choose strip_tags(I18n.t("helpers.label.publishers_job_listing_applying_for_the_job_form.enable_job_applications_options.true"))
       fill_in "publishers_job_listing_applying_for_the_job_form[personal_statement_guidance]", with: vacancy.personal_statement_guidance
     else

--- a/spec/system/application_sitemap_spec.rb
+++ b/spec/system/application_sitemap_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Application sitemap" do
       document = Nokogiri::XML::Document.parse(body)
       nodes = document.search("url")
 
-      expect(nodes.count).to eq(292)
+      expect(nodes.count).to eq(293)
       expect(nodes.search("loc[text()='#{root_url(protocol: 'https')}']").text)
         .to eq(root_url(protocol: "https"))
 


### PR DESCRIPTION
We've decided it makes more sense to have this as a separate (primary)
job role, otherwise behaving like education support roles (i.e. ask
SEND question, don't allow enabling job applications).