### PR TITLE
[TEVA-2783] Allow hiring staff to download listing stats as csv

### DIFF
--- a/app/controllers/publishers/vacancies/statistics_controller.rb
+++ b/app/controllers/publishers/vacancies/statistics_controller.rb
@@ -1,6 +1,11 @@
 class Publishers::Vacancies::StatisticsController < Publishers::Vacancies::BaseController
   def show
-    @views_by_jobseeker = Publishers::VacancyStats.new(vacancy).number_of_unique_views
+    @number_of_unique_views = Publishers::VacancyStats.new(vacancy).number_of_unique_views
+
+    respond_to do |format|
+      format.html
+      format.csv { send_data Publishers::ExportVacancyToCsv.new(vacancy, @number_of_unique_views).call, filename: "#{vacancy.slug}-statistics.csv" }
+    end
   end
 
   def update

--- a/app/services/publishers/export_vacancy_to_csv.rb
+++ b/app/services/publishers/export_vacancy_to_csv.rb
@@ -1,0 +1,34 @@
+require "csv"
+
+class Publishers::ExportVacancyToCsv
+  attr_reader :vacancy
+
+  def initialize(vacancy, number_of_unique_views)
+    @vacancy = vacancy
+    @number_of_unique_views = number_of_unique_views
+  end
+
+  # rubocop:disable Metrics/AbcSize
+  def call
+    columns = {
+      "Organisation" => vacancy.organisation.name,
+      I18n.t("jobs.job_title") => vacancy.job_title,
+      I18n.t("publishers.vacancies.statistics.show.views_by_jobseeker") => @number_of_unique_views,
+      I18n.t("publishers.vacancies.statistics.show.saves_by_jobseeker") => vacancy.saved_jobs.count,
+    }
+
+    if vacancy.can_receive_job_applications?
+      columns.merge!({ I18n.t("publishers.vacancies.statistics.show.total_applications") => vacancy.job_applications.not_draft.count,
+                       I18n.t("publishers.vacancies.statistics.show.unread_applications") => vacancy.job_applications.submitted.count,
+                       I18n.t("publishers.vacancies.statistics.show.shortlisted_applications") => vacancy.job_applications.shortlisted.count,
+                       I18n.t("publishers.vacancies.statistics.show.rejected_applications") => vacancy.job_applications.unsuccessful.count,
+                       I18n.t("publishers.vacancies.statistics.show.withdrawn_applications") => vacancy.job_applications.withdrawn.count })
+    end
+
+    CSV.generate(headers: true) do |csv|
+      csv << columns.keys
+      csv << columns.values
+    end
+  end
+  # rubocop:enable Metrics/AbcSize
+end

--- a/app/views/publishers/vacancies/statistics/show.html.slim
+++ b/app/views/publishers/vacancies/statistics/show.html.slim
@@ -13,6 +13,8 @@
     - elsif vacancy.draft?
       = govuk_inset_text text: t(".draft_vacancy")
 
+    = govuk_link_to(t("buttons.download_stats"), organisation_job_statistics_path(vacancy.id, format: :csv), class: "govuk-button--secondary", button: true)
+
   .govuk-grid-column-two-thirds
     h3.govuk-heading-m = t(".listing_data")
 
@@ -21,7 +23,7 @@
         = govuk_summary_list classes: "govuk-!-margin-bottom-0", html_attributes: { id: "vacancy_statistics" } do |c|
           - c.slot(:row,
             key: t(".views_by_jobseeker"),
-            value: @views_by_jobseeker)
+            value: @number_of_unique_views)
           - c.slot(:row,
             key: t(".saves_by_jobseeker"),
             value: vacancy.saved_jobs.count)
@@ -34,7 +36,7 @@
           = govuk_summary_list classes: "govuk-!-margin-bottom-0", html_attributes: { id: "job_applications_statistics" } do |c|
             - c.slot(:row,
               key: t(".total_applications"),
-              value: vacancy.job_applications.count)
+              value: vacancy.job_applications.not_draft.count)
             - c.slot(:row,
               key: t(".unread_applications"),
               value: vacancy.job_applications.submitted.count)

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -33,6 +33,7 @@ en:
     delete: Delete
     delete_subject: Delete subject
     dismiss: Dismiss
+    download_stats: Download statistics (csv, 0.2KB)
     edit: Edit
     end_listing: End job listing
     end_listing_early: End listing early

--- a/spec/requests/publishers/vacancies/statistics_spec.rb
+++ b/spec/requests/publishers/vacancies/statistics_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe "Job listing statistics" do
+  let(:organisation) { build(:school) }
+  let(:vacancy) { create(:vacancy, organisation_vacancies_attributes: [{ organisation: organisation }]) }
+  let(:publisher) { create(:publisher, accepted_terms_at: 1.day.ago) }
+
+  before do
+    allow_any_instance_of(Publishers::AuthenticationConcerns).to receive(:current_organisation).and_return(organisation)
+    sign_in(publisher, scope: :publisher)
+  end
+
+  describe "GET #show" do
+    context "when csv format is requested" do
+      it "returns a csv" do
+        get(organisation_job_statistics_path(vacancy.id, format: :csv))
+        expect(response.content_type).to include("text/csv")
+        expect(response.body).to include("Organisation,Job title,Views by jobseekers")
+      end
+    end
+
+    context "when no format is specified" do
+      it "returns an html page" do
+        get(organisation_job_statistics_path(vacancy.id))
+        expect(response.content_type).to include("text/html")
+        expect(response.body).to include(I18n.t("buttons.download_stats"))
+      end
+    end
+  end
+end

--- a/spec/services/publishers/export_vacancy_to_csv_spec.rb
+++ b/spec/services/publishers/export_vacancy_to_csv_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe Publishers::ExportVacancyToCsv do
+  subject { described_class.new(vacancy, number_of_unique_views) }
+
+  let(:school) { create(:school) }
+  let(:jobseeker) { create(:jobseeker) }
+  let(:job_title) { "Example job title without commas so we can ignore whether to expect this to be wrapped in quotes" }
+  let(:vacancy) { create(:vacancy, job_title: job_title, organisation_vacancies_attributes: [{ organisation: school }]) }
+  let(:number_of_unique_views) { 64 }
+  let(:number_of_saves) { 1 }
+
+  before do
+    number_of_saves.times { create(:saved_job, vacancy: vacancy, jobseeker: jobseeker) }
+    create(:job_application, :status_draft, vacancy: vacancy, jobseeker: jobseeker)
+    create(:job_application, :status_reviewed, vacancy: vacancy, jobseeker: jobseeker)
+    create(:job_application, :status_submitted, vacancy: vacancy, jobseeker: jobseeker)
+    create(:job_application, :status_shortlisted, vacancy: vacancy, jobseeker: jobseeker)
+    create(:job_application, :status_unsuccessful, vacancy: vacancy, jobseeker: jobseeker)
+    create(:job_application, :status_withdrawn, vacancy: vacancy, jobseeker: jobseeker)
+  end
+
+  describe "#call" do
+    before { allow(vacancy).to receive(:can_receive_job_applications?).and_return(can_receive_job_applications?) }
+
+    context "when the vacancy cannot receive job applications" do
+      let(:can_receive_job_applications?) { false }
+
+      it "returns a CSV of the vacancy views and saves" do
+        expect(subject.call).to eq(["Organisation,Job title,Views by jobseekers,Saves by jobseekers",
+                                    "#{school.name},#{job_title},#{number_of_unique_views},#{number_of_saves}\n"].join("\n"))
+      end
+    end
+
+    context "when the vacancy can receive job applications" do
+      let(:can_receive_job_applications?) { true }
+
+      it "returns a CSV of the vacancy statistics, excluding draft applications" do
+        expect(subject.call).to eq(["Organisation,Job title,Views by jobseekers,Saves by jobseekers,Total applications,Unread applications,Shortlisted applications,Rejected applications,Withdrawn applications",
+                                    "#{school.name},#{job_title},#{number_of_unique_views},#{number_of_saves},5,1,1,1,1\n"].join("\n"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hiring staff want to be able to view, analyse and share statistics. Downloading statistics will support hiring staff share this information with stakeholders such as colleagues, recruitment partners, school governors, to understand how well their recruitment strategy is performing.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2783

## Screenshots of UI changes:

![Screenshot 2021-08-31 at 18 37 21](https://user-images.githubusercontent.com/60350599/131549978-dc6036cd-6f55-4a01-a781-ae0b457ff48b.png)
![Screenshot 2021-08-31 at 18 37 48](https://user-images.githubusercontent.com/60350599/131549992-15454365-7e72-4130-9cc3-165001bc5690.png)
