### PR TITLE
Remove field names from NoVacanciesComponent

### DIFF
--- a/app/components/publishers/no_vacancies_component/no_vacancies_component.html.slim
+++ b/app/components/publishers/no_vacancies_component/no_vacancies_component.html.slim
@@ -4,18 +4,4 @@
   .govuk-grid-column-full
     h2.govuk-heading-m = t(".heading")
 
-    = govuk_button_to t("buttons.create_job"), organisation_jobs_path, class: "govuk-!-margin-bottom-0"
-
-    p = t(".intro")
-
-  .govuk-grid-column-one-third
-    h2.govuk-heading-s Required
-    ul.govuk-list.govuk-list--bullet
-      - t(".bullets.required").each do |bullet|
-        li = bullet
-
-  .govuk-grid-column-one-third
-    h2.govuk-heading-s Optional
-    ul.govuk-list.govuk-list--bullet
-      - t(".bullets.optional").each do |bullet|
-        li = bullet
+    = govuk_button_to t("buttons.create_job"), organisation_jobs_path

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -47,28 +47,7 @@ en:
           description_fallback: Enter your email below and we will send you a link that will take you straight into your account.
           title: Hiring staff sign in
     no_vacancies_component:
-      bullets:
-        required:
-          - job title
-          - job role
-          - working pattern
-          - salary
-          - date job will be listed
-          - closing date
-          - time application is due
-          - contact email
-          - job summary
-          - information about the school
-        optional:
-          - subject
-          - employee benefits
-          - date job starts
-          - supporting documents to attach
-          - how to arrange a school visit
-          - how to apply
-          - link to online application
       heading: You have no job listings to manage
-      intro: 'To create a job listing for your school, you will need the following information:'
     organisations:
       aria_change_description: '%{organisation_type} description'
       aria_change_website: '%{organisation_type} website'

--- a/spec/components/publishers/no_vacancies_component_spec.rb
+++ b/spec/components/publishers/no_vacancies_component_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Publishers::NoVacanciesComponent, type: :component do
     let(:no_vacancies) { true }
 
     it "renders the no vacancies component" do
-      expect(rendered_component).to include(I18n.t("publishers.no_vacancies_component.intro"))
+      expect(rendered_component).to include(I18n.t("publishers.no_vacancies_component.heading"))
     end
   end
 end


### PR DESCRIPTION
These are a faff to keep up to date and not particularly helpful for
hiring staff.