### PR TITLE
show all roles with vacancies in footer links

### DIFF
--- a/app/services/vacancy_facets.rb
+++ b/app/services/vacancy_facets.rb
@@ -2,7 +2,7 @@ class VacancyFacets
   CACHE_DURATION = 24.hours
 
   def job_roles
-    cached(:job_roles) { sort_and_limit(job_role_facet.select { |role| role.in?(Vacancy.primary_job_role_options) }, 4) }
+    cached(:job_roles) { sort_and_limit(job_role_facet.select { |role| role.in?(Vacancy.primary_job_role_options) }, Vacancy.primary_job_role_options.count) }
   end
 
   def subjects


### PR DESCRIPTION
no ticket

change criteria for showing fotter role links to show all roles that have a count.