### PR TITLE
Fix warning displayed when running tests

### DIFF
--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -135,7 +135,7 @@ module VacancyHelpers
 
     expect(page).to have_content(vacancy.job_title)
     expect(page).to have_content(vacancy.show_primary_job_role)
-    expect(page).to have_content(strip_tags(vacancy.show_additional_job_roles))
+    expect(page).to have_content(strip_tags(vacancy.show_additional_job_roles)) if vacancy.additional_job_roles.any?
     expect(page).to have_content(vacancy.show_subjects)
     expect(page).to have_content(vacancy.working_patterns)
 


### PR DESCRIPTION
When running tests, the following warning is displayed:

![Screenshot 2021-09-03 at 14 10 46](https://user-images.githubusercontent.com/30624173/132012738-33e6bb96-6d8d-4ffa-989c-d4e5508fb24e.png)

## Changes in this PR:

- Added conditional so that this expectation is only run when additional_job_roles is not nil
