### PR TITLE
Rename primary job roles to main job roles

### DIFF
--- a/app/controllers/concerns/publishers/wizardable.rb
+++ b/app/controllers/concerns/publishers/wizardable.rb
@@ -22,7 +22,7 @@ module Publishers::Wizardable
   end
 
   def job_role_fields
-    %i[primary_job_role]
+    %i[main_job_role]
   end
 
   def job_role_details_fields
@@ -63,7 +63,7 @@ module Publishers::Wizardable
 
   def job_role_params(params)
     params.require(:publishers_job_listing_job_role_form)
-          .permit(:primary_job_role).merge(completed_steps: completed_steps)
+          .permit(:main_job_role).merge(completed_steps: completed_steps)
   end
 
   def job_role_details_params(params)

--- a/app/controllers/publishers/vacancies/build_controller.rb
+++ b/app/controllers/publishers/vacancies/build_controller.rb
@@ -16,7 +16,7 @@ class Publishers::Vacancies::BuildController < Publishers::Vacancies::BaseContro
   def show
     case step
     when :job_role_details
-      skip_step if vacancy.primary_job_role == "sendco"
+      skip_step if vacancy.main_job_role == "sendco"
     when :job_location
       skip_step if current_organisation.school?
     when :schools
@@ -52,12 +52,12 @@ class Publishers::Vacancies::BuildController < Publishers::Vacancies::BaseContro
     case step
     when :job_details
       if current_organisation.school?
-        vacancy.primary_job_role == "sendco" ? wizard_path(:job_role) : wizard_path(:job_role_details)
+        vacancy.main_job_role == "sendco" ? wizard_path(:job_role) : wizard_path(:job_role_details)
       else
         vacancy.central_office? ? wizard_path(:job_location) : wizard_path(:schools)
       end
     when :job_location
-      vacancy.primary_job_role == "sendco" ? wizard_path(:job_role) : wizard_path(:job_role_details)
+      vacancy.main_job_role == "sendco" ? wizard_path(:job_role) : wizard_path(:job_role_details)
     else
       previous_wizard_path
     end
@@ -123,7 +123,7 @@ class Publishers::Vacancies::BuildController < Publishers::Vacancies::BaseContro
     vacancy.save
     if step == :job_location && job_location != "central_office"
       redirect_to wizard_path(:schools)
-    elsif step == :job_role && vacancy.primary_job_role != "sendco"
+    elsif step == :job_role && vacancy.main_job_role != "sendco"
       redirect_to wizard_path(:job_role_details)
     else
       redirect_updated_job_with_message

--- a/app/form_models/jobseekers/search_form.rb
+++ b/app/form_models/jobseekers/search_form.rb
@@ -44,7 +44,7 @@ class Jobseekers::SearchForm
   end
 
   def set_facet_options
-    @job_role_options = Vacancy.primary_job_role_options.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_role_form.primary_job_role_options.#{option}")] }
+    @job_role_options = Vacancy.main_job_role_options.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_role_form.main_job_role_options.#{option}")] }
     @phase_options = [%w[primary Primary], %w[middle Middle], %w[secondary Secondary], %w[16-19 16-19]]
     @nqt_suitable_options = [["nqt_suitable", I18n.t("jobs.filters.nqt_suitable_only"), I18n.t("jobs.filters.nqt_suitable")]]
     @send_responsible_options = [["send_responsible", I18n.t("jobs.filters.send_responsible_only"), I18n.t("jobs.filters.send_responsible")]]

--- a/app/form_models/jobseekers/subscription_form.rb
+++ b/app/form_models/jobseekers/subscription_form.rb
@@ -54,7 +54,7 @@ class Jobseekers::SubscriptionForm
   private
 
   def set_facet_options
-    @job_role_options = Vacancy.primary_job_role_options.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_role_form.primary_job_role_options.#{option}")] }
+    @job_role_options = Vacancy.main_job_role_options.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_role_form.main_job_role_options.#{option}")] }
     @phase_options = [%w[primary Primary], %w[middle Middle], %w[secondary Secondary], %w[16-19 16-19]]
     @nqt_suitable_options = [["nqt_suitable", I18n.t("jobs.filters.nqt_suitable")]]
     @send_responsible_options = [["send_responsible", I18n.t("jobs.filters.send_responsible_option")]]

--- a/app/form_models/publishers/job_listing/job_role_details_form.rb
+++ b/app/form_models/publishers/job_listing/job_role_details_form.rb
@@ -4,7 +4,7 @@ class Publishers::JobListing::JobRoleDetailsForm < Publishers::JobListing::Vacan
 
   validates :send_responsible,
             inclusion: { in: %w[yes no] },
-            if: -> { vacancy.primary_job_role.in?(%w[leadership teaching_assistant education_support]) }
+            if: -> { vacancy.main_job_role.in?(%w[leadership teaching_assistant education_support]) }
 
   def teacher_additional_job_roles_options
     %w[nqt_suitable send_responsible]
@@ -23,7 +23,7 @@ class Publishers::JobListing::JobRoleDetailsForm < Publishers::JobListing::Vacan
   end
 
   def additional_job_roles_to_save
-    if vacancy.primary_job_role == "teacher"
+    if vacancy.main_job_role == "teacher"
       additional_job_roles
     else
       @send_responsible == "yes" ? ["send_responsible"] : []

--- a/app/form_models/publishers/job_listing/job_role_form.rb
+++ b/app/form_models/publishers/job_listing/job_role_form.rb
@@ -1,12 +1,12 @@
 class Publishers::JobListing::JobRoleForm < Publishers::JobListing::VacancyForm
-  attr_accessor :primary_job_role
+  attr_accessor :main_job_role
 
-  validates :primary_job_role, inclusion: { in: Vacancy.primary_job_role_options }
+  validates :main_job_role, inclusion: { in: Vacancy.main_job_role_options }
 
   def params_to_save
     {
       completed_steps: completed_steps,
-      primary_job_role: primary_job_role,
+      main_job_role: main_job_role,
     }.compact
   end
 end

--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -71,8 +71,8 @@ class VacancyPresenter < BasePresenter
     roles.map { |role| I18n.t("helpers.label.publishers_job_listing_job_details_form.job_roles_options.#{role}") }.join(", ")
   end
 
-  def show_primary_job_role
-    I18n.t("helpers.label.publishers_job_listing_job_role_form.primary_job_role_options.#{primary_job_role}")
+  def show_main_job_role
+    I18n.t("helpers.label.publishers_job_listing_job_role_form.main_job_role_options.#{main_job_role}")
   end
 
   def show_additional_job_roles
@@ -87,9 +87,9 @@ class VacancyPresenter < BasePresenter
 
   def all_job_roles
     # TODO: This line can go after the 30th of September 2021 when all the legacy vacancies have expired
-    return show_job_roles unless primary_job_role
+    return show_job_roles unless main_job_role
 
-    safe_join [show_primary_job_role, tag.br, model.additional_job_roles.map { |role| greyed_additional_job_role(role) }]
+    safe_join [show_main_job_role, tag.br, model.additional_job_roles.map { |role| greyed_additional_job_role(role) }]
   end
 
   def show_subjects

--- a/app/services/vacancy_facets.rb
+++ b/app/services/vacancy_facets.rb
@@ -2,7 +2,7 @@ class VacancyFacets
   CACHE_DURATION = 24.hours
 
   def job_roles
-    cached(:job_roles) { sort_and_limit(job_role_facet.select { |role| role.in?(Vacancy.primary_job_role_options) }, Vacancy.primary_job_role_options.count) }
+    cached(:job_roles) { sort_and_limit(job_role_facet.select { |role| role.in?(Vacancy.main_job_role_options) }, Vacancy.main_job_role_options.count) }
   end
 
   def subjects

--- a/app/views/publishers/vacancies/build/job_role.html.slim
+++ b/app/views/publishers/vacancies/build/job_role.html.slim
@@ -13,7 +13,7 @@
 
         h2.govuk-heading-l = t("publishers.vacancies.steps.job_role")
 
-        = f.govuk_collection_radio_buttons :primary_job_role, Vacancy.primary_job_role_options, :to_s, bold_labels: true
+        = f.govuk_collection_radio_buttons :main_job_role, Vacancy.main_job_role_options, :to_s, bold_labels: true
 
         = f.govuk_submit t("buttons.continue")
 

--- a/app/views/publishers/vacancies/build/job_role_details.html.slim
+++ b/app/views/publishers/vacancies/build/job_role_details.html.slim
@@ -13,7 +13,7 @@
 
         h2.govuk-heading-l = t("publishers.vacancies.steps.job_role")
 
-        - if vacancy.primary_job_role == "teacher"
+        - if vacancy.main_job_role == "teacher"
           = f.govuk_collection_check_boxes :additional_job_roles, form.teacher_additional_job_roles_options, :to_s, :to_s
         - else
           = f.govuk_collection_radio_buttons :send_responsible, %w[yes no], :to_s, :capitalize, form_group: { classes: "govuk-!-width-two-thirds" }

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_role.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_role.html.slim
@@ -8,10 +8,10 @@
   - review.body do
     = govuk_summary_list do |component|
       - component.slot(:row,
-        key: t("jobs.primary_job_role"),
-        value: @vacancy.show_primary_job_role || t("jobs.not_defined"),
-        html_attributes: { id: "primary_job_role" })
-      - unless @vacancy.primary_job_role == "sendco"
+        key: t("jobs.main_job_role"),
+        value: @vacancy.show_main_job_role || t("jobs.not_defined"),
+        html_attributes: { id: "main_job_role" })
+      - unless @vacancy.main_job_role == "sendco"
         - component.slot(:row,
           key: t("jobs.additional_job_roles"),
           value: @vacancy.show_additional_job_roles.presence || t("jobs.not_defined"),

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -112,7 +112,7 @@ en:
 
   # Publishers journey
   job_role_errors: &job_role_errors
-    primary_job_role:
+    main_job_role:
       inclusion: Select a job role
       blank: Select a job role
   job_role_details_errors: &job_role_details_errors

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -231,7 +231,7 @@ en:
           Select all working patterns you will consider for the role.
           Flexible working options may attract more candidates.
       publishers_job_listing_job_role_form:
-        primary_job_role_options:
+        main_job_role_options:
           leadership: Includes Head of Year/Subject, Deputy/Assistant Head, Headteacher, and trust-level roles
           education_support: Includes learning support and tutors
           sendco: Special educational needs and disabilities coordinator
@@ -565,7 +565,7 @@ en:
           sendco: SENDCo
           teacher: Teacher
       publishers_job_listing_job_role_form:
-        primary_job_role_options:
+        main_job_role_options:
           teacher: Teacher
           leadership: Leadership
           teaching_assistant: Teaching assistant
@@ -678,7 +678,7 @@ en:
         subjects_html: Subject(s) (optional<span class='govuk-visually-hidden'> field</span>)</span>
         working_patterns: Working patterns
       publishers_job_listing_job_role_form:
-        primary_job_role: What is the job role?
+        main_job_role: What is the job role?
       publishers_job_listing_job_role_details_form:
         additional_job_roles_html: Tell us more about the role (optional<span class='govuk-visually-hidden'> field</span>)</span>
         send_responsible: Does the role have SEND responsibilities (special educational needs and disabilities)?

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -184,7 +184,7 @@ en:
 
     job_title: Job title
     job_role: Job role
-    primary_job_role: Job role
+    main_job_role: Job role
     additional_job_roles: Job role details
     suitable_for_nqt: Is this job suitable for NQTs?
     subjects: Subject(s)

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -30,9 +30,9 @@ FactoryBot.define do
     hired_status { nil }
     job_advert { Faker::Lorem.paragraph(sentence_count: rand(50..300)) }
 
-    primary_job_role { Vacancy.primary_job_role_options.sample }
+    main_job_role { Vacancy.main_job_role_options.sample }
     additional_job_roles do
-      case primary_job_role
+      case main_job_role
       when "teacher"
         Vacancy.additional_job_role_options.sample(rand(0..2))
       when "sendco"

--- a/spec/form_models/publishers/job_listing/job_role_details_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/job_role_details_form_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe Publishers::JobListing::JobRoleDetailsForm, type: :model do
     end
   end
 
-  context "when primary job role is teacher" do
-    let(:vacancy) { build(:vacancy, primary_job_role: "teacher") }
+  context "when main job role is teacher" do
+    let(:vacancy) { build(:vacancy, main_job_role: "teacher") }
 
     it { is_expected.not_to validate_inclusion_of(:send_responsible).in_array(%w[yes no]) }
 
@@ -44,20 +44,20 @@ RSpec.describe Publishers::JobListing::JobRoleDetailsForm, type: :model do
     end
   end
 
-  context "when primary job role is sendco" do
-    let(:vacancy) { build(:vacancy, primary_job_role: "sendco") }
+  context "when main job role is sendco" do
+    let(:vacancy) { build(:vacancy, main_job_role: "sendco") }
 
     it { is_expected.not_to validate_inclusion_of(:send_responsible).in_array(%w[yes no]) }
   end
 
-  context "when primary job role is leadership" do
-    let(:vacancy) { build(:vacancy, primary_job_role: "leadership") }
+  context "when main job role is leadership" do
+    let(:vacancy) { build(:vacancy, main_job_role: "leadership") }
 
     it_behaves_like "a form with send_responsible radios"
   end
 
-  context "when primary job role is education support" do
-    let(:vacancy) { build(:vacancy, primary_job_role: "education_support") }
+  context "when main job role is education support" do
+    let(:vacancy) { build(:vacancy, main_job_role: "education_support") }
 
     it_behaves_like "a form with send_responsible radios"
   end

--- a/spec/form_models/publishers/job_listing/job_role_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/job_role_form_spec.rb
@@ -1,5 +1,5 @@
 require "rails_helper"
 
 RSpec.describe Publishers::JobListing::JobRoleForm, type: :model do
-  it { is_expected.to validate_presence_of(:primary_job_role) }
+  it { is_expected.to validate_presence_of(:main_job_role) }
 end

--- a/spec/presenters/vacancy_presenter_spec.rb
+++ b/spec/presenters/vacancy_presenter_spec.rb
@@ -93,8 +93,8 @@ RSpec.describe VacancyPresenter do
 
     let(:vacancy) { build(:vacancy) }
 
-    it "returns the primary job role" do
-      expect(subject.all_job_roles).to include subject.show_primary_job_role
+    it "returns the main job role" do
+      expect(subject.all_job_roles).to include subject.show_main_job_role
     end
 
     it "returns the additional job roles" do

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -15,15 +15,15 @@ module VacancyHelpers
   end
 
   def fill_in_job_role_form_fields(vacancy)
-    choose I18n.t("helpers.label.publishers_job_listing_job_role_form.primary_job_role_options.#{vacancy.primary_job_role}")
+    choose I18n.t("helpers.label.publishers_job_listing_job_role_form.main_job_role_options.#{vacancy.main_job_role}")
   end
 
   def fill_in_job_role_details_form_fields(vacancy)
-    if vacancy.primary_job_role == "teacher"
+    if vacancy.main_job_role == "teacher"
       vacancy.additional_job_roles&.each do |job_role|
         check I18n.t("helpers.label.publishers_job_listing_job_role_details_form.additional_job_roles_options.#{job_role}")
       end
-    elsif vacancy.primary_job_role.in?(%w[leadership education_support])
+    elsif vacancy.main_job_role.in?(%w[leadership education_support])
       value = vacancy.job_roles.include?("send_responsible") ? "yes" : "no"
       find("label[for='publishers-job-listing-job-role-details-form-send-responsible-#{value}-field']").click
     end
@@ -134,7 +134,7 @@ module VacancyHelpers
     end
 
     expect(page).to have_content(vacancy.job_title)
-    expect(page).to have_content(vacancy.show_primary_job_role)
+    expect(page).to have_content(vacancy.show_main_job_role)
     expect(page).to have_content(strip_tags(vacancy.show_additional_job_roles)) if vacancy.additional_job_roles.any?
     expect(page).to have_content(vacancy.show_subjects)
     expect(page).to have_content(vacancy.working_patterns)


### PR DESCRIPTION
Avoid name collision with education phase 'primary'