### PR TITLE
[TEVA-3069] Bug related to changing published vacancy's job role

### DIFF
--- a/spec/form_models/publishers/job_listing/applying_for_the_job_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/applying_for_the_job_form_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 
 RSpec.describe Publishers::JobListing::ApplyingForTheJobForm, type: :model do
-  subject { described_class.new(vacancy: vacancy) }
+  subject { described_class.new(current_organisation: organisation, vacancy: vacancy) }
 
+  let(:organisation) { build_stubbed(:trust) }
   let(:vacancy) { build_stubbed(:vacancy) }
 
   it { is_expected.to allow_value("https://www.this-is-a-test-url.tvs").for(:application_link) }
@@ -18,34 +19,62 @@ RSpec.describe Publishers::JobListing::ApplyingForTheJobForm, type: :model do
   it { is_expected.not_to allow_value("invalid-01234").for(:contact_number) }
 
   context "when enable_job_applications is false" do
-    subject { described_class.new(enable_job_applications: "false", vacancy: vacancy) }
+    subject { described_class.new(current_organisation: organisation, enable_job_applications: "false", vacancy: vacancy) }
 
     it { is_expected.to validate_presence_of(:how_to_apply) }
   end
 
   describe "enable job applications override" do
-    subject { described_class.new(current_organisation: organisation, vacancy: vacancy) }
-
     context "when the current organisation given is a local authority" do
       let(:organisation) { build_stubbed(:local_authority) }
 
-      it "overrides enable_job_applications to false" do
+      it "overrides enable_job_applications and sets it to false" do
         subject.valid?
 
         expect(subject.enable_job_applications).to eq(false)
-        expect(subject.errors).not_to include(:enable_job_applications)
+        expect(subject.errors).to_not include(:enable_job_applications)
       end
     end
 
     context "when the current organisation given is not a local authority" do
-      let(:organisation) { build_stubbed(:trust) }
-      let(:vacancy) { build_stubbed(:vacancy, job_roles: %w[teacher]) }
+      context "when the vacancy is in draft" do
+        let(:vacancy) { build_stubbed(:vacancy, :draft, job_roles: %w[teacher]) }
 
-      it "does not override enable_job_applications" do
-        subject.valid?
+        it "does not override enable_job_applications" do
+          subject.enable_job_applications = true
 
-        expect(subject.enable_job_applications).to be_nil
-        expect(subject.errors).to include(:enable_job_applications)
+          expect { subject.valid? }.to_not(change { subject.enable_job_applications })
+        end
+
+        it "is not valid" do
+          subject.valid?
+
+          expect(subject).to_not be_valid
+          expect(subject.errors).to include(:enable_job_applications)
+        end
+      end
+
+      context "when the vacancy has been listed and enable_job_applications is nil" do
+        subject do
+          described_class.new(current_organisation: organisation,
+                              vacancy: vacancy,
+                              enable_job_applications: nil,
+                              how_to_apply: "Test",
+                              contact_email: "test@example.com")
+        end
+
+        let(:vacancy) { build_stubbed(:vacancy, :past_publish, job_roles: %w[teacher]) }
+
+        it "overrides enable_job_applications" do
+          expect { subject.valid? }.to change { subject.enable_job_applications }.from(nil).to(false)
+        end
+
+        it "is valid" do
+          subject.valid?
+
+          expect(subject).to be_valid
+          expect(subject.errors).to_not include(:enable_job_applications)
+        end
       end
     end
   end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3069

- When a vacancy is edited, we validate_all_steps. One of these validations, on the applying_for_job_form, checks that the value of enable_job_applications is one of [true, false, "true", "false"]. 

- When a job role has been selected that doesn't allow applications, the enable_job_applications field is not rendered, so enable_job_applications is nil. In this case the validation for enable_job_applications is not run as vacancy.allow_enabling_job_applications? = false

- When a hiring staff user changes the job role to one that does accept applications, vacancy.allow_enabling_job_applications? = true, so the validation is run. However, as the value of enable_job_applications is still nil, the validation does not pass, causing an error to be displayed.

## Changes in this PR

- Added a before_validation callback to set enable_job_applications to false if the current user is from an LA, the vacancy is listed and enable_job_applications is nil.

## Error message displayed previously

<img width="914" alt="Screenshot 2021-09-07 at 11 00 46" src="https://user-images.githubusercontent.com/30624173/132325958-fd84786f-ed9c-4b29-9318-43de9ca42124.png">


