### PR TITLE
Use step process for vacancy flow header

### DIFF
--- a/app/components/publishers/vacancy_form_page_heading_component.rb
+++ b/app/components/publishers/vacancy_form_page_heading_component.rb
@@ -1,10 +1,9 @@
 class Publishers::VacancyFormPageHeadingComponent < ViewComponent::Base
   delegate :current_organisation, to: :helpers
 
-  def initialize(vacancy, current, total)
+  def initialize(vacancy, step_process)
     @vacancy = vacancy
-    @current = current
-    @total = total
+    @step_process = step_process
   end
 
   def heading

--- a/app/components/publishers/vacancy_form_page_heading_component/vacancy_form_page_heading_component.html.slim
+++ b/app/components/publishers/vacancy_form_page_heading_component/vacancy_form_page_heading_component.html.slim
@@ -2,4 +2,4 @@ h1.govuk-heading-m
   = heading
   - unless vacancy.published?
     span.govuk-caption-m
-      = t("jobs.current_step", step: @current, total: @total)
+      = t("jobs.current_step", step: @step_process.current_step_group_number, total: @step_process.total_step_groups)

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -93,8 +93,4 @@ module VacanciesHelper
     steps_to_skip = current_organisation.is_a?(School) ? %i[job_role_details job_location schools review] : %i[job_role_details schools review]
     steps.except(*steps_to_skip).keys
   end
-
-  def total_steps(steps)
-    steps_to_display(steps).count + 1 # #steps_to_display excludes review step
-  end
 end

--- a/app/services/publishers/vacancies/vacancy_step_process.rb
+++ b/app/services/publishers/vacancies/vacancy_step_process.rb
@@ -1,9 +1,10 @@
 class Publishers::Vacancies::VacancyStepProcess < StepProcess
-  attr_reader :vacancy, :organisation
+  attr_reader :vacancy, :organisation, :session
 
-  def initialize(current_step, vacancy:, organisation:)
+  def initialize(current_step, vacancy:, organisation:, session:)
     @vacancy = vacancy
     @organisation = organisation
+    @session = session
 
     super(current_step, {
       job_role: job_role_steps,
@@ -32,7 +33,9 @@ class Publishers::Vacancies::VacancyStepProcess < StepProcess
   def job_location_steps
     return nil if organisation.school?
 
-    if vacancy.job_location == "central_office"
+    job_location_changed_in_session = session[:job_location].present? && session[:job_location] != vacancy.job_location
+
+    if vacancy.job_location == "central_office" && !job_location_changed_in_session
       %i[job_location]
     else
       %i[job_location schools]

--- a/app/services/step_process.rb
+++ b/app/services/step_process.rb
@@ -4,6 +4,8 @@ class StepProcess
   def initialize(current_step, step_groups = {})
     @current_step = current_step.to_sym
     @step_groups = step_groups.select { |_, steps| steps.present? }
+
+    raise ArgumentError, "Current step `#{current_step}` missing from steps (#{steps.join(', ')})" unless current_step.in?(steps)
   end
 
   # Returns the keys of all individual steps in order

--- a/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
+++ b/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
@@ -3,7 +3,7 @@
 .govuk-main-wrapper
   .govuk-grid-row
     .govuk-grid-column-full
-      = render Publishers::VacancyFormPageHeadingComponent.new(vacancy, current_step_number, total_steps(steps_config))
+      = render Publishers::VacancyFormPageHeadingComponent.new(vacancy, step_process)
       = govuk_back_link text: session[:current_step] == :review ? t("buttons.cancel_and_return") : t("buttons.back_to_previous_step"), href: back_path
 
   .govuk-grid-row

--- a/app/views/publishers/vacancies/build/important_dates.html.slim
+++ b/app/views/publishers/vacancies/build/important_dates.html.slim
@@ -3,7 +3,7 @@
 .govuk-main-wrapper
   .govuk-grid-row
     .govuk-grid-column-full
-      = render Publishers::VacancyFormPageHeadingComponent.new(vacancy, current_step_number, total_steps(steps_config))
+      = render Publishers::VacancyFormPageHeadingComponent.new(vacancy, step_process)
       = govuk_back_link text: session[:current_step] == :review ? t("buttons.cancel_and_return") : t("buttons.back_to_previous_step"), href: back_path
 
   .govuk-grid-row

--- a/app/views/publishers/vacancies/build/job_details.html.slim
+++ b/app/views/publishers/vacancies/build/job_details.html.slim
@@ -3,7 +3,7 @@
 .govuk-main-wrapper
   .govuk-grid-row
     .govuk-grid-column-full
-      = render Publishers::VacancyFormPageHeadingComponent.new(vacancy, current_step_number, total_steps(steps_config))
+      = render Publishers::VacancyFormPageHeadingComponent.new(vacancy, step_process)
       = govuk_back_link text: session[:current_step] == :review ? t("buttons.cancel_and_return") : t("buttons.back_to_previous_step"), href: back_path
 
   .govuk-grid-row

--- a/app/views/publishers/vacancies/build/job_location.html.slim
+++ b/app/views/publishers/vacancies/build/job_location.html.slim
@@ -3,7 +3,7 @@
 .govuk-main-wrapper
   .govuk-grid-row
     .govuk-grid-column-full
-      = render Publishers::VacancyFormPageHeadingComponent.new(vacancy, current_step_number, total_steps(steps_config))
+      = render Publishers::VacancyFormPageHeadingComponent.new(vacancy, step_process)
       = govuk_back_link text: session[:current_step] == :review ? t("buttons.cancel_and_return") : t("buttons.back_to_previous_step"), href: back_path
 
   .govuk-grid-row

--- a/app/views/publishers/vacancies/build/job_role.html.slim
+++ b/app/views/publishers/vacancies/build/job_role.html.slim
@@ -3,7 +3,7 @@
 .govuk-main-wrapper
   .govuk-grid-row
     .govuk-grid-column-full
-      = render Publishers::VacancyFormPageHeadingComponent.new(vacancy, current_step_number, total_steps(steps_config))
+      = render Publishers::VacancyFormPageHeadingComponent.new(vacancy, step_process)
       = govuk_back_link text: t("buttons.cancel_and_return"), href: back_path if session[:current_step] == :review
 
   .govuk-grid-row

--- a/app/views/publishers/vacancies/build/job_role_details.html.slim
+++ b/app/views/publishers/vacancies/build/job_role_details.html.slim
@@ -3,7 +3,7 @@
 .govuk-main-wrapper
   .govuk-grid-row
     .govuk-grid-column-full
-      = render Publishers::VacancyFormPageHeadingComponent.new(vacancy, current_step_number, total_steps(steps_config))
+      = render Publishers::VacancyFormPageHeadingComponent.new(vacancy, step_process)
       = govuk_back_link text: t("buttons.back_to_previous_step"), href: back_path
 
   .govuk-grid-row

--- a/app/views/publishers/vacancies/build/job_summary.html.slim
+++ b/app/views/publishers/vacancies/build/job_summary.html.slim
@@ -3,7 +3,7 @@
 .govuk-main-wrapper
   .govuk-grid-row
     .govuk-grid-column-full
-      = render Publishers::VacancyFormPageHeadingComponent.new(vacancy, current_step_number, total_steps(steps_config))
+      = render Publishers::VacancyFormPageHeadingComponent.new(vacancy, step_process)
       = govuk_back_link text: session[:current_step] == :review ? t("buttons.cancel_and_return") : t("buttons.back_to_previous_step"), href: back_path
 
   .govuk-grid-row

--- a/app/views/publishers/vacancies/build/pay_package.html.slim
+++ b/app/views/publishers/vacancies/build/pay_package.html.slim
@@ -3,7 +3,7 @@
 .govuk-main-wrapper
   .govuk-grid-row
     .govuk-grid-column-full
-      = render Publishers::VacancyFormPageHeadingComponent.new(vacancy, current_step_number, total_steps(steps_config))
+      = render Publishers::VacancyFormPageHeadingComponent.new(vacancy, step_process)
       = govuk_back_link text: session[:current_step] == :review ? t("buttons.cancel_and_return") : t("buttons.back_to_previous_step"), href: back_path
 
   .govuk-grid-row

--- a/app/views/publishers/vacancies/build/schools.html.slim
+++ b/app/views/publishers/vacancies/build/schools.html.slim
@@ -3,7 +3,7 @@
 .govuk-main-wrapper
   .govuk-grid-row
     .govuk-grid-column-full
-      = render Publishers::VacancyFormPageHeadingComponent.new(vacancy, current_step_number, total_steps(steps_config))
+      = render Publishers::VacancyFormPageHeadingComponent.new(vacancy, step_process)
       = govuk_back_link text: session[:current_step] == :review ? t("buttons.cancel_and_return") : t("buttons.back_to_previous_step"), href: back_path
 
   .govuk-grid-row

--- a/app/views/publishers/vacancies/build/working_patterns.html.slim
+++ b/app/views/publishers/vacancies/build/working_patterns.html.slim
@@ -3,7 +3,7 @@
 .govuk-main-wrapper
   .govuk-grid-row
     .govuk-grid-column-full
-      = render Publishers::VacancyFormPageHeadingComponent.new(vacancy, current_step_number, total_steps(steps_config))
+      = render Publishers::VacancyFormPageHeadingComponent.new(vacancy, step_process)
       = govuk_back_link text: session[:current_step] == :review ? t("buttons.cancel_and_return") : t("buttons.back_to_previous_step"), href: back_path
 
   .govuk-grid-row

--- a/app/views/publishers/vacancies/documents/show.html.slim
+++ b/app/views/publishers/vacancies/documents/show.html.slim
@@ -3,7 +3,7 @@
 .govuk-main-wrapper
   .govuk-grid-row
     .govuk-grid-column-full
-      = render Publishers::VacancyFormPageHeadingComponent.new(vacancy, current_step_number, total_steps(steps_config))
+      = render Publishers::VacancyFormPageHeadingComponent.new(vacancy, step_process)
       = govuk_back_link text: session[:current_step] == :review ? t("buttons.cancel_and_return") : t("buttons.back_to_previous_step"),
                         href: session[:current_step] == :review ? edit_organisation_job_path(vacancy.id) : organisation_job_build_path(vacancy.id, :important_dates)
 

--- a/app/views/publishers/vacancies/edit.html.slim
+++ b/app/views/publishers/vacancies/edit.html.slim
@@ -3,7 +3,7 @@
 .govuk-main-wrapper
   .govuk-grid-row
     .govuk-grid-column-full
-      = render Publishers::VacancyFormPageHeadingComponent.new(vacancy, current_step_number, total_steps(steps_config))
+      = render Publishers::VacancyFormPageHeadingComponent.new(vacancy, step_process)
 
   .vacancy.govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/publishers/vacancies/review.html.slim
+++ b/app/views/publishers/vacancies/review.html.slim
@@ -3,7 +3,7 @@
 .govuk-main-wrapper
   .govuk-grid-row
     .govuk-grid-column-full
-      = render Publishers::VacancyFormPageHeadingComponent.new(vacancy, current_step_number, total_steps(steps_config))
+      = render Publishers::VacancyFormPageHeadingComponent.new(vacancy, step_process)
 
   .vacancy.govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/spec/components/publishers/vacancy_form_page_heading_component_spec.rb
+++ b/spec/components/publishers/vacancy_form_page_heading_component_spec.rb
@@ -4,10 +4,9 @@ RSpec.describe Publishers::VacancyFormPageHeadingComponent, type: :component do
   let(:organisation) { create(:school, name: "Teaching Vacancies Academy") }
   let(:vacancy) { create(:vacancy, status, job_title: "Test job title") }
   let(:status) { :published }
-  let(:current_step_number) { 1 }
   let(:current_publisher_is_part_of_school_group?) { true }
-  let(:steps_adjust) { current_publisher_is_part_of_school_group? ? 0 : 1 }
-  let(:total_steps) { 2 }
+
+  let(:step_process) { instance_double(StepProcess, current_step_group_number: 1, total_step_groups: 2) }
 
   let(:steps) do
     {
@@ -16,7 +15,7 @@ RSpec.describe Publishers::VacancyFormPageHeadingComponent, type: :component do
     }.freeze
   end
 
-  subject { described_class.new(vacancy, current_step_number, total_steps) }
+  subject { described_class.new(vacancy, step_process) }
 
   before do
     allow(subject).to receive(:current_organisation).and_return(organisation)
@@ -29,7 +28,7 @@ RSpec.describe Publishers::VacancyFormPageHeadingComponent, type: :component do
       let(:status) { :draft }
 
       it "shows the current step" do
-        expect(rendered_component).to include(I18n.t("jobs.current_step", step: current_step_number, total: total_steps))
+        expect(rendered_component).to include(I18n.t("jobs.current_step", step: 1, total: 2))
       end
     end
 

--- a/spec/services/publishers/vacancies/vacancy_step_process_spec.rb
+++ b/spec/services/publishers/vacancies/vacancy_step_process_spec.rb
@@ -1,12 +1,13 @@
 require "rails_helper"
 
 RSpec.describe Publishers::Vacancies::VacancyStepProcess do
-  subject { described_class.new(current_step, vacancy: vacancy, organisation: organisation) }
+  subject { described_class.new(current_step, vacancy: vacancy, organisation: organisation, session: session) }
 
   let(:current_step) { :job_details }
 
   let(:vacancy) { build_stubbed(:vacancy, job_roles: %w[teacher]) }
   let(:organisation) { build_stubbed(:school) }
+  let(:session) { {} }
 
   describe "#step_groups" do
     let(:all_possible_step_groups) do
@@ -77,6 +78,15 @@ RSpec.describe Publishers::Vacancies::VacancyStepProcess do
 
         it "skips the `schools` step" do
           expect(subject.steps).to eq(all_possible_steps - %i[schools])
+        end
+      end
+
+      context "when the job location has changed from central_office in the session" do
+        let(:vacancy) { build_stubbed(:vacancy, job_roles: %w[teacher], job_location: "central_office") }
+        let(:session) { { job_location: "at_multiple_schools" } }
+
+        it "skips the `schools` step" do
+          expect(subject.steps).to eq(all_possible_steps)
         end
       end
     end

--- a/spec/services/step_process_spec.rb
+++ b/spec/services/step_process_spec.rb
@@ -14,6 +14,12 @@ RSpec.describe StepProcess do
     }
   end
 
+  describe "#initialize" do
+    it "makes sure the current step is included in all steps" do
+      expect { described_class.new(:seven, step_groups) }.to raise_error(ArgumentError)
+    end
+  end
+
   describe "#step_groups" do
     it "excludes step groups without steps" do
       expect(subject.step_groups).to eq({


### PR DESCRIPTION
- Change `VacancyFormPageHeadingComponent` to use step process instead
  of manually passed in numbers, and change usage everywhere
- Expose step process to step views
- Remove `Publishers::Vacancies::BaseController#current_step_number`
  and `#steps_adjust`
- Remove `VacanciesHelper#total_steps`
- Make `StepProcess` raise a more informative error if the current step
  that is passed in does not exist in the set of steps
- Take session into account when determining steps (needed for
  `job_location` step)

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3101