### PR TITLE
[TEVA-2895] use formbuilder legend param so a11y compliant

### DIFF
--- a/app/components/filters_component/filters_component.html.slim
+++ b/app/components/filters_component/filters_component.html.slim
@@ -39,17 +39,13 @@
 
   .filters-component__groups
     - items.each do |group|
-      legend.govuk-fieldset__legend.govuk-fieldset__legend--s
-        - if group[:hidden_text]
-          span.govuk-visually-hidden = "#{group[:hidden_text]} "
-        = group[:title]
       .filters-component__groups__group data-group=group[:key]
         = form.govuk_collection_check_boxes group[:attribute],
           group[:options],
           group[:value_method],
           group[:text_method],
           small: true,
-          legend: nil,
+          legend: { text: group[:legend] },
           hint: nil
 
   .filters-component__submit

--- a/app/components/publishers/vacancies_component/vacancies_component.html.slim
+++ b/app/components/publishers/vacancies_component/vacancies_component.html.slim
@@ -15,7 +15,7 @@
             = render(FiltersComponent.new(filters: { total_count: @publisher_preference.organisations.count,
                                                               title: t("jobs.filters.job_filters") },
                                                               form: f,
-                                                              items: [{ title: "Locations",
+                                                              items: [{ legend: "Locations",
                                                                         key: "locations",
                                                                         search: true,
                                                                         scroll: true,

--- a/app/views/subscriptions/_fields.html.slim
+++ b/app/views/subscriptions/_fields.html.slim
@@ -6,7 +6,7 @@
 ruby:
   items = [
     {
-      title: t("jobs.filters.job_roles"),
+      legend: t("jobs.filters.job_roles"),
       key: "job_roles",
       attribute: :job_roles,
       selected: @form.job_roles.reject { |role| role == "nqt_suitable" },
@@ -16,7 +16,7 @@ ruby:
       selected_method: :last,
     },
     {
-      title: t("jobs.filters.nqt_suitable"),
+      legend: t("jobs.filters.nqt_suitable"),
       key: "nqt_suitable",
       attribute: :job_roles,
       selected: @form.job_roles.include?("nqt_suitable") ? @form.job_roles : [],
@@ -26,7 +26,7 @@ ruby:
       selected_method: :last,
     },
     {
-      title: t("jobs.filters.send_responsible"),
+      legend: t("jobs.filters.send_responsible"),
       key: "send_responsible",
       attribute: :job_roles,
       selected: @form.job_roles.include?("send_responsible") ? @form.job_roles : [],
@@ -36,7 +36,7 @@ ruby:
       selected_method: :last,
     },
     {
-      title: t("jobs.filters.phases"),
+      legend: t("jobs.filters.phases"),
       key: "education_phase",
       attribute: :phases,
       selected: @form.phases,
@@ -46,7 +46,7 @@ ruby:
       selected_method: :last,
     },
     {
-      title: t("jobs.filters.working_patterns"),
+      legend: t("jobs.filters.working_patterns"),
       key: "working_patterns",
       attribute: :working_patterns,
       selected: @form.working_patterns,

--- a/app/views/vacancies/_search.html.slim
+++ b/app/views/vacancies/_search.html.slim
@@ -1,7 +1,7 @@
 ruby:
   items = [
     {
-      title: t("jobs.filters.job_roles"),
+      legend: t("jobs.filters.job_roles"),
       key: "job_roles",
       attribute: :job_roles,
       selected: @form.job_roles.reject { |role| role == "nqt_suitable" },
@@ -11,7 +11,7 @@ ruby:
       selected_method: :last,
     },
     {
-      title: t("jobs.filters.nqt_suitable"),
+      legend: t("jobs.filters.nqt_suitable"),
       key: "nqt_suitable",
       attribute: :job_roles,
       selected: @form.job_roles.include?("nqt_suitable") ? @form.job_roles : [],
@@ -21,7 +21,7 @@ ruby:
       selected_method: :last,
     },
     {
-      title: t("jobs.filters.send_responsible"),
+      legend: t("jobs.filters.send_responsible"),
       key: "send_responsible",
       attribute: :job_roles,
       selected: @form.job_roles.include?("send_responsible") ? @form.job_roles : [],
@@ -31,7 +31,7 @@ ruby:
       selected_method: :last,
     },
     {
-      title: t("jobs.filters.phases"),
+      legend: t("jobs.filters.phases"),
       key: "education_phase",
       attribute: :phases,
       selected: @form.phases,
@@ -41,7 +41,7 @@ ruby:
       selected_method: :last,
     },
     {
-      title: t("jobs.filters.working_patterns"),
+      legend: t("jobs.filters.working_patterns"),
       key: "working_patterns",
       attribute: :working_patterns,
       selected: @form.working_patterns,


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-2895

use formbuilder legend param rather than custom so the markup is semantically correct. the hidden text bit isnt actually used so removed it
