### PR TITLE
[TEVA-3025] Update the URL of the NQT job alert subscription form

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -3,7 +3,7 @@ class SubscriptionsController < ApplicationController
 
   def new
     @point_coordinates = params[:coordinates_present] == "true"
-    @nqt_job_alert = params[:nqt_job_alert]
+    @ect_job_alert = params[:ect_job_alert]
     @form = Jobseekers::SubscriptionForm.new(params[:search_criteria].present? ? search_criteria_params : email)
   end
 

--- a/app/views/shared/search/_keyword.html.slim
+++ b/app/views/shared/search/_keyword.html.slim
@@ -1,4 +1,4 @@
 = f.govuk_text_field :keyword,
   label: { text: t("jobs.search.keyword"), size: "s" },
-  hint: { text: (@nqt_job_alert ? t("jobs.search.keyword_nqt_hint") : nil) },
+  hint: { text: (@ect_job_alert ? t("jobs.search.keyword_ect_hint") : nil) },
   form_group: { classes: "keyword-text" }

--- a/app/views/updates/update_files/_nqt_job_alerts_2020_07_29.html.erb
+++ b/app/views/updates/update_files/_nqt_job_alerts_2020_07_29.html.erb
@@ -1,2 +1,2 @@
-Newly qualified teachers (NQTs) can now set up a <%= govuk_link_to('job alert', nqt_job_alerts_path) %> that will notify them of any jobs that are suitable for NQTs.
+Newly qualified teachers (NQTs) can now set up a <%= govuk_link_to('job alert', ect_job_alerts_path) %> that will notify them of any jobs that are suitable for NQTs.
 Users will receive an email each morning with any new roles that have been listed.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -204,28 +204,6 @@ en:
     sign_in: List a teaching job
     sign_out: Sign out
 
-  nqt_job_alerts:
-    confirm:
-      heading: What happens next
-      splash:
-        heading: Your job alert has been set up
-        message: We sent a confirmation email to %{email}
-      keywords: "Keywords:"
-      location: "Location:"
-      intro: "We'll email you any teaching jobs suitable for NQTs that match your search criteria:"
-      unsubscribe: You can unsubscribe by following the link at the bottom of the email.
-    heading: Sign up for NQT job alerts
-    intro:
-      content: >-
-        Setting up an alert can help make your search for a teaching job easier. You’ll receive an email every morning
-        with any new job that’s been listed that matches your search criteria.
-      teaching_vacancies: >-
-        Teaching Vacancies is a free national job-listing service from the Department for Education. It helps schools to
-        save money on recruitment and is here to help you to take the first step in your career.
-      unsubscribe: >-
-        You can unsubscribe at any time by following the instructions in the job alert
-    page_title: Sign up for NQT job alerts
-
   number:
     currency:
       format:

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -52,7 +52,7 @@ en:
 
     search:
       keyword: Keywords
-      keyword_nqt_hint: >-
+      keyword_ect_hint: >-
         Tell us what teaching job you’re looking for and what kind of school you’d like to teach in.
         You can use any keywords that describe your ideal role.
         This alert is especially for jobs suitable for early career teachers, so you don’t need to add early career teacher or ECT as a keyword.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -125,7 +125,9 @@ Rails.application.routes.draw do
     resources :unsubscribe_feedbacks, only: %i[new create], controller: "jobseekers/unsubscribe_feedbacks"
   end
 
-  get "sign-up-for-NQT-job-alerts", to: "subscriptions#new", as: "nqt_job_alerts", defaults: { nqt_job_alert: true, origin: "/sign-up-for-NQT-job-alerts", search_criteria: { job_roles: ["nqt_suitable"] } }
+  get "sign-up-for-NQT-job-alerts", to: redirect("/sign-up-for-ECT-job-alerts")
+
+  get "sign-up-for-ECT-job-alerts", to: "subscriptions#new", as: "ect_job_alerts", defaults: { ect_job_alert: true, origin: "/sign-up-for-ECT-job-alerts", search_criteria: { job_roles: ["nqt_suitable"] } }
 
   namespace :api do
     scope "v:api_version", api_version: /1/ do

--- a/spec/requests/subscriptions_spec.rb
+++ b/spec/requests/subscriptions_spec.rb
@@ -23,12 +23,18 @@ RSpec.describe "Subscriptions" do
     end
 
     context "when hit via the nqt job alerts url" do
-      let(:origin) { "/sign-up-for-NQT-job-alerts" }
-      let(:params) { { "nqt_job_alert" => true, "origin" => "/sign-up-for-NQT-job-alerts", "search_criteria" => { "job_roles" => ["nqt_suitable"] } } }
+      before { get "/sign-up-for-NQT-job-alerts" }
 
-      before do
-        get nqt_job_alerts_path
+      it "redirects to the ect job alerts url" do
+        expect(response).to redirect_to(ect_job_alerts_path)
       end
+    end
+
+    context "when hit via the ECT job alerts url" do
+      let(:origin) { "/sign-up-for-ECT-job-alerts" }
+      let(:params) { { "ect_job_alert" => true, "origin" => "/sign-up-for-ECT-job-alerts", "search_criteria" => { "job_roles" => ["nqt_suitable"] } } }
+
+      before { get ect_job_alerts_path }
 
       it "includes the correct parameters" do
         expect(request.parameters).to include(params)


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3025

## Changes in this PR:

- Added route for new ECT job alert URL
- Redirect from old URL
- Rename keys in params to use ECT instead of NQT 

## Comments: 

- Haven't changed the value in the job_roles array as the job role is still called nqt_suitable. I think this may change as part of the work on: https://dfedigital.atlassian.net/browse/TEVA-3075 