### PR TITLE
Remove use of `steps_config` in vacancy validation

### DIFF
--- a/app/controllers/publishers/vacancies/base_controller.rb
+++ b/app/controllers/publishers/vacancies/base_controller.rb
@@ -23,13 +23,7 @@ class Publishers::Vacancies::BaseController < Publishers::BaseController
   end
 
   def all_steps_valid?
-    steps_to_skip = if current_organisation.is_a?(School)
-                      []
-                    else
-                      vacancy.job_location == "at_central_office" ? [:job_location] : %i[job_location schools]
-                    end
-    steps_to_skip.push(:documents, :review)
-    steps_config.except(*steps_to_skip).keys.all? { |step| step_valid?(step) }
+    step_process.validatable_steps.all? { |step| step_valid?(step) }
   end
 
   def step_valid?(step)

--- a/app/controllers/publishers/vacancies_controller.rb
+++ b/app/controllers/publishers/vacancies_controller.rb
@@ -80,7 +80,7 @@ class Publishers::VacanciesController < Publishers::Vacancies::BaseController
   end
 
   def validate_all_steps
-    steps_config.except(:job_location, :schools, :supporting_documents, :documents, :review).each_key do |step|
+    step_process.validatable_steps.each do |step|
       step_valid?(step)
     end
   end

--- a/app/services/publishers/vacancies/vacancy_step_process.rb
+++ b/app/services/publishers/vacancies/vacancy_step_process.rb
@@ -20,6 +20,10 @@ class Publishers::Vacancies::VacancyStepProcess < StepProcess
     })
   end
 
+  def validatable_steps
+    steps - %i[documents review]
+  end
+
   private
 
   def job_role_steps


### PR DESCRIPTION
- Add `VacancyStepProcess#validatable_steps` to define steps that
  should be validated when validating all steps for a vacancy
- Use this instead of `steps_config`
- Simplify `all_steps_valid?` to not skip steps that are no longer
  included

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3101