### PR TITLE
[TEVA-3118] Pin ruby-alpine image to 3.0.2-alpine3.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG PROD_PACKAGES="libxml2=2.9.12-r1 libxslt=1.1.34-r1 libpq=13.4-r0 tzdata=2021a-r0 shared-mime-info=2.1-r0"
 
-FROM ruby:3.0.2-alpine AS builder
+FROM ruby:3.0.2-alpine3.14 AS builder
 
 WORKDIR /app
 
@@ -33,7 +33,7 @@ RUN rm -rf node_modules log tmp yarn.lock && \
 
 
 # this stage reduces the image size.
-FROM ruby:3.0.2-alpine AS production
+FROM ruby:3.0.2-alpine3.14 AS production
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-ARG PROD_PACKAGES="libxml2 libxslt libpq tzdata shared-mime-info"
+ARG PROD_PACKAGES="libxml2=2.9.12-r1 libxslt=1.1.34-r1 libpq=13.4-r0 tzdata=2021a-r0 shared-mime-info=2.1-r0"
 
 FROM ruby:3.0.2-alpine AS builder
 
 WORKDIR /app
 
 ARG PROD_PACKAGES
-ENV DEV_PACKAGES="gcc libc-dev make yarn postgresql-dev build-base libxml2-dev libxslt-dev"
+ENV DEV_PACKAGES="gcc=10.3.1_git20210424-r2 libc-dev=0.7.2-r3 make=4.3-r0 yarn=1.22.10-r0 postgresql-dev=13.4-r0 build-base=0.5-r2 libxml2-dev=2.9.12-r1 libxslt-dev=1.1.34-r1"
 RUN apk add --no-cache $PROD_PACKAGES $DEV_PACKAGES
 RUN echo "Europe/London" > /etc/timezone && \
         cp /usr/share/zoneinfo/Europe/London /etc/localtime


### PR DESCRIPTION
## Jira ticket URL

- Just add the ticket number to the end:

https://dfedigital.atlassian.net/browse/TEVA-3118

## Changes in this PR:
Pin docker alpine image to `ruby:3.0.2-alpine3.14`
