### PR TITLE
Get rid of the final use of `steps_config` for publishers

### DIFF
--- a/app/controllers/concerns/publishers/wizardable.rb
+++ b/app/controllers/concerns/publishers/wizardable.rb
@@ -6,23 +6,6 @@ module Publishers::Wizardable
     working_patterns: %i[working_patterns],
   }.freeze
 
-  def steps_config
-    {
-      job_role: { number: 1, title: I18n.t("publishers.vacancies.steps.job_role") },
-      job_role_details: { number: 1, title: I18n.t("publishers.vacancies.steps.job_role") },
-      job_location: { number: 2, title: I18n.t("publishers.vacancies.steps.job_location") },
-      schools: { number: 2, title: I18n.t("publishers.vacancies.steps.job_location") },
-      job_details: { number: 3, title: I18n.t("publishers.vacancies.steps.job_details") },
-      working_patterns: { number: 4, title: I18n.t("publishers.vacancies.steps.working_patterns") },
-      pay_package: { number: 5, title: I18n.t("publishers.vacancies.steps.pay_package") },
-      important_dates: { number: 6, title: I18n.t("publishers.vacancies.steps.important_dates") },
-      documents: { number: 7, title: I18n.t("publishers.vacancies.steps.documents") },
-      applying_for_the_job: { number: 8, title: I18n.t("publishers.vacancies.steps.applying_for_the_job") },
-      job_summary: { number: 9, title: I18n.t("publishers.vacancies.steps.job_summary") },
-      review: { number: 10, title: I18n.t("publishers.vacancies.steps.review_heading") },
-    }.freeze
-  end
-
   def job_role_params(params)
     params.require(:publishers_job_listing_job_role_form)
           .permit(:main_job_role).merge(completed_steps: completed_steps)

--- a/app/controllers/publishers/vacancies/base_controller.rb
+++ b/app/controllers/publishers/vacancies/base_controller.rb
@@ -3,7 +3,7 @@ require "indexing"
 class Publishers::Vacancies::BaseController < Publishers::BaseController
   include Publishers::Wizardable
 
-  helper_method :steps_config, :step_process, :vacancy
+  helper_method :step_process, :vacancy
 
   def step_process
     # TODO: We currently have to do this kinda thing in a lot of places thanks to `wicked`

--- a/app/controllers/publishers/vacancies/copy_controller.rb
+++ b/app/controllers/publishers/vacancies/copy_controller.rb
@@ -26,7 +26,6 @@ class Publishers::Vacancies::CopyController < Publishers::Vacancies::BaseControl
   def copy_form_params
     params.require(:publishers_job_listing_copy_vacancy_form)
           .permit(:job_title, :publish_on, :publish_on_day, :expires_at, :expiry_time, :starts_on, :starts_asap)
-          .merge(completed_steps: [])
   end
 
   def set_up_copy_form

--- a/app/controllers/publishers/vacancies/documents_controller.rb
+++ b/app/controllers/publishers/vacancies/documents_controller.rb
@@ -1,8 +1,6 @@
 require "google/apis/drive_v3"
 
 class Publishers::Vacancies::DocumentsController < Publishers::Vacancies::BaseController
-  include Publishers::Wizardable
-
   helper_method :form
 
   before_action :redirect_to_next_step, only: %i[create]

--- a/app/form_models/publishers/job_listing/copy_vacancy_form.rb
+++ b/app/form_models/publishers/job_listing/copy_vacancy_form.rb
@@ -1,6 +1,5 @@
 class Publishers::JobListing::CopyVacancyForm < Publishers::JobListing::ImportantDatesForm
   include ActionView::Helpers::SanitizeHelper
-  include Publishers::Wizardable
 
   attr_accessor :job_title
 
@@ -9,7 +8,8 @@ class Publishers::JobListing::CopyVacancyForm < Publishers::JobListing::Importan
   validate :job_title_has_no_tags?, if: proc { job_title.present? }
 
   def params_to_save
-    super.merge(job_title: job_title, completed_steps: steps_config.except(:review).keys)
+    # `completed_steps` is nil by default and would overwrite the copied vacancy's value
+    super.except(:completed_steps).merge(job_title: job_title)
   end
 
   private


### PR DESCRIPTION
- Make `CopyVacancyForm` not overwrite the `completed_steps`
  being copied from the original vacancy (this is probably better
  than the current way of setting it to all the steps that exist
  as the set of steps may have changed anyway since the vacancy
  was created)
- Stop including `Wizardable` in controllers that inherit from
  `BaseController` (which includes it anyway)

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3101