### PR TITLE
Refactor `_field` methods and use of `send`

### DIFF
--- a/app/controllers/concerns/publishers/wizardable.rb
+++ b/app/controllers/concerns/publishers/wizardable.rb
@@ -23,50 +23,6 @@ module Publishers::Wizardable
     }.freeze
   end
 
-  def job_role_fields
-    %i[main_job_role]
-  end
-
-  def job_role_details_fields
-    %i[additional_job_roles]
-  end
-
-  def job_location_fields
-    %i[job_location]
-  end
-
-  def schools_fields
-    %i[organisation_ids]
-  end
-
-  def working_patterns_fields
-    %i[working_patterns working_patterns_details]
-  end
-
-  def job_details_fields
-    %i[job_title contract_type contract_type_duration subjects]
-  end
-
-  def pay_package_fields
-    %i[actual_salary salary benefits]
-  end
-
-  def documents_fields
-    []
-  end
-
-  def important_dates_fields
-    %i[starts_asap starts_on publish_on expires_at]
-  end
-
-  def applying_for_the_job_fields
-    %i[application_link enable_job_applications contact_email contact_number personal_statement_guidance school_visits how_to_apply]
-  end
-
-  def job_summary_fields
-    %i[job_advert about_school]
-  end
-
   def job_role_params(params)
     params.require(:publishers_job_listing_job_role_form)
           .permit(:main_job_role).merge(completed_steps: completed_steps)

--- a/app/controllers/publishers/vacancies/base_controller.rb
+++ b/app/controllers/publishers/vacancies/base_controller.rb
@@ -30,7 +30,7 @@ class Publishers::Vacancies::BaseController < Publishers::BaseController
     step_form = "publishers/job_listing/#{step}_form".camelize.constantize
 
     # We need to merge in the current organisation otherwise the form will always be invalid for local authority users
-    form = step_form.new(vacancy.slice(*send("#{step}_fields")).merge(current_organisation: current_organisation), vacancy)
+    form = step_form.new(vacancy.slice(*step_form.fields).merge(current_organisation: current_organisation), vacancy)
 
     form.valid?.tap do
       vacancy.errors.merge!(form.errors)

--- a/app/controllers/publishers/vacancies/build_controller.rb
+++ b/app/controllers/publishers/vacancies/build_controller.rb
@@ -50,13 +50,17 @@ class Publishers::Vacancies::BuildController < Publishers::Vacancies::BaseContro
   end
 
   def form
-    @form ||= "Publishers::JobListing::#{step.to_s.camelize}Form".constantize.new(form_attributes, vacancy)
+    @form ||= form_class.new(form_attributes, vacancy)
+  end
+
+  def form_class
+    "publishers/job_listing/#{step}_form".camelize.constantize
   end
 
   def form_attributes
     case action_name
     when "show"
-      vacancy.slice(*send("#{step}_fields"))
+      vacancy.slice(*form_class.fields)
     when "update"
       form_params
     end

--- a/app/controllers/publishers/vacancies_controller.rb
+++ b/app/controllers/publishers/vacancies_controller.rb
@@ -1,10 +1,6 @@
 class Publishers::VacanciesController < Publishers::Vacancies::BaseController
-  include Publishers::Wizardable
-
   before_action :redirect_if_published, only: %i[preview review]
   before_action :devise_job_alert_search_criteria, only: %i[show preview]
-
-  helper_method :applying_for_the_job_fields, :documents_fields, :important_dates_fields, :job_details_fields, :job_location_fields, :job_role_fields, :job_summary_fields, :pay_package_fields, :schools_fields
 
   def show
     session[:current_step] = :review

--- a/app/form_models/publishers/job_listing/applying_for_the_job_form.rb
+++ b/app/form_models/publishers/job_listing/applying_for_the_job_form.rb
@@ -12,6 +12,13 @@ class Publishers::JobListing::ApplyingForTheJobForm < Publishers::JobListing::Va
 
   validates :contact_number, format: { with: /\A\+?(?:\d\s?){10,12}\z/ }, if: proc { contact_number.present? }
 
+  def self.fields
+    %i[
+      application_link enable_job_applications contact_email contact_number
+      personal_statement_guidance school_visits how_to_apply
+    ]
+  end
+
   private
 
   def override_enable_job_applications!

--- a/app/form_models/publishers/job_listing/documents_form.rb
+++ b/app/form_models/publishers/job_listing/documents_form.rb
@@ -16,6 +16,10 @@ class Publishers::JobListing::DocumentsForm < Publishers::JobListing::VacancyFor
 
   attr_accessor :documents
 
+  def self.fields
+    []
+  end
+
   def valid_documents
     @valid_documents ||= documents&.select { |doc| valid_file_size?(doc) && valid_file_type?(doc) && virus_free?(doc) } || []
   end

--- a/app/form_models/publishers/job_listing/important_dates_form.rb
+++ b/app/form_models/publishers/job_listing/important_dates_form.rb
@@ -14,6 +14,10 @@ class Publishers::JobListing::ImportantDatesForm < Publishers::JobListing::Vacan
                         if: proc { starts_asap == "0" }
   validate :starts_on_and_starts_asap_not_present
 
+  def self.fields
+    %i[starts_asap starts_on publish_on expires_at]
+  end
+
   def initialize(params, vacancy)
     @expiry_time = params[:expiry_time] || vacancy.expires_at&.strftime("%k:%M")&.strip
 

--- a/app/form_models/publishers/job_listing/job_details_form.rb
+++ b/app/form_models/publishers/job_listing/job_details_form.rb
@@ -10,6 +10,10 @@ class Publishers::JobListing::JobDetailsForm < Publishers::JobListing::VacancyFo
   validates :contract_type, inclusion: { in: Vacancy.contract_types.keys }
   validates :contract_type_duration, presence: true, if: -> { contract_type == "fixed_term" }
 
+  def self.fields
+    %i[job_title contract_type contract_type_duration subjects]
+  end
+
   def job_title_has_no_tags?
     job_title_without_escaped_characters = job_title.delete("&")
     return if job_title_without_escaped_characters == sanitize(job_title_without_escaped_characters, tags: [])

--- a/app/form_models/publishers/job_listing/job_location_form.rb
+++ b/app/form_models/publishers/job_listing/job_location_form.rb
@@ -3,6 +3,10 @@ class Publishers::JobListing::JobLocationForm < Publishers::JobListing::VacancyF
 
   validates :job_location, presence: true
 
+  def self.fields
+    %i[job_location]
+  end
+
   def params_to_save
     {
       completed_steps: params[:completed_steps],

--- a/app/form_models/publishers/job_listing/job_role_details_form.rb
+++ b/app/form_models/publishers/job_listing/job_role_details_form.rb
@@ -6,6 +6,10 @@ class Publishers::JobListing::JobRoleDetailsForm < Publishers::JobListing::Vacan
             inclusion: { in: %w[yes no] },
             if: -> { vacancy.main_job_role.in?(%w[leadership teaching_assistant education_support]) }
 
+  def self.fields
+    %i[additional_job_roles]
+  end
+
   def teacher_additional_job_roles_options
     %w[nqt_suitable send_responsible]
   end

--- a/app/form_models/publishers/job_listing/job_role_form.rb
+++ b/app/form_models/publishers/job_listing/job_role_form.rb
@@ -3,6 +3,10 @@ class Publishers::JobListing::JobRoleForm < Publishers::JobListing::VacancyForm
 
   validates :main_job_role, inclusion: { in: Vacancy.main_job_role_options }
 
+  def self.fields
+    %i[main_job_role]
+  end
+
   def params_to_save
     {
       completed_steps: completed_steps,

--- a/app/form_models/publishers/job_listing/job_summary_form.rb
+++ b/app/form_models/publishers/job_listing/job_summary_form.rb
@@ -4,6 +4,10 @@ class Publishers::JobListing::JobSummaryForm < Publishers::JobListing::VacancyFo
   validates :job_advert, presence: true
   validate :about_school_must_not_be_blank
 
+  def self.fields
+    %i[job_advert about_school]
+  end
+
   def about_school_must_not_be_blank
     return if about_school.present?
 

--- a/app/form_models/publishers/job_listing/pay_package_form.rb
+++ b/app/form_models/publishers/job_listing/pay_package_form.rb
@@ -7,6 +7,10 @@ class Publishers::JobListing::PayPackageForm < Publishers::JobListing::VacancyFo
   validates :salary, length: { minimum: 1, maximum: 256 }, if: proc { salary.present? }
   validate :salary_has_no_tags?, if: proc { salary.present? }
 
+  def self.fields
+    %i[actual_salary salary benefits]
+  end
+
   def salary_has_no_tags?
     salary_without_escaped_characters = salary.delete("&")
     return if salary_without_escaped_characters == sanitize(salary_without_escaped_characters, tags: [])

--- a/app/form_models/publishers/job_listing/schools_form.rb
+++ b/app/form_models/publishers/job_listing/schools_form.rb
@@ -4,6 +4,10 @@ class Publishers::JobListing::SchoolsForm < Publishers::JobListing::VacancyForm
   validates :organisation_ids, presence: true
   validate :more_than_one_school_present_multiple_schools, if: proc { organisation_ids.present? }
 
+  def self.fields
+    %i[organisation_ids]
+  end
+
   def initialize(params, vacancy)
     @organisation_ids = if params[:job_location] == "at_one_school" && params[:organisation_ids].is_a?(Array)
                           params[:organisation_ids].first

--- a/app/form_models/publishers/job_listing/working_patterns_form.rb
+++ b/app/form_models/publishers/job_listing/working_patterns_form.rb
@@ -2,4 +2,8 @@ class Publishers::JobListing::WorkingPatternsForm < Publishers::JobListing::Vaca
   attr_accessor :working_patterns, :working_patterns_details
 
   validates :working_patterns, presence: true, inclusion: { in: Vacancy.working_patterns.keys }
+
+  def self.fields
+    %i[working_patterns working_patterns_details]
+  end
 end

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_applying_for_the_job.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_applying_for_the_job.html.slim
@@ -1,4 +1,4 @@
-= render "publishers/vacancies/error_tag", attributes: applying_for_the_job_fields
+= render "publishers/vacancies/error_tag", attributes: Publishers::JobListing::ApplyingForTheJobForm.fields
 
 = render ReviewComponent.new id: "applying_for_the_job" do |review|
   - review.heading title: t("publishers.vacancies.steps.applying_for_the_job"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_documents.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_documents.html.slim
@@ -1,4 +1,4 @@
-= render "publishers/vacancies/error_tag", attributes: documents_fields
+= render "publishers/vacancies/error_tag", attributes: Publishers::JobListing::DocumentsForm.fields
 
 = render ReviewComponent.new id: "documents" do |review|
   - review.heading title: t("publishers.vacancies.steps.documents"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_important_dates.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_important_dates.html.slim
@@ -1,4 +1,4 @@
-= render "publishers/vacancies/error_tag", attributes: important_dates_fields
+= render "publishers/vacancies/error_tag", attributes: Publishers::JobListing::ImportantDatesForm.fields
 
 #expiry_time
 = render ReviewComponent.new id: "important_dates" do |review|

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_details.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_details.html.slim
@@ -1,4 +1,4 @@
-= render "publishers/vacancies/error_tag", attributes: job_details_fields
+= render "publishers/vacancies/error_tag", attributes: Publishers::JobListing::JobDetailsForm.fields
 
 = render ReviewComponent.new id: "job_details" do |review|
   - review.heading title: t("publishers.vacancies.steps.job_details"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_location.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_location.html.slim
@@ -1,4 +1,4 @@
-= render "publishers/vacancies/error_tag", attributes: (job_location_fields + schools_fields)
+= render "publishers/vacancies/error_tag", attributes: (Publishers::JobListing::JobLocationForm.fields + Publishers::JobListing::SchoolsForm.fields)
 
 = render ReviewComponent.new id: "job_location" do |review|
   - review.heading title: t("publishers.vacancies.steps.job_location"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_role.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_role.html.slim
@@ -1,4 +1,4 @@
-= render "publishers/vacancies/error_tag", attributes: job_role_fields
+= render "publishers/vacancies/error_tag", attributes: Publishers::JobListing::JobRoleForm.fields
 
 = render ReviewComponent.new id: "job_role" do |review|
   - review.heading title: t("publishers.vacancies.steps.job_role"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_summary.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_summary.html.slim
@@ -1,4 +1,4 @@
-= render "publishers/vacancies/error_tag", attributes: job_summary_fields
+= render "publishers/vacancies/error_tag", attributes: Publishers::JobListing::JobSummaryForm.fields
 
 = render ReviewComponent.new id: "job_summary" do |review|
   - review.heading title: t("publishers.vacancies.steps.job_summary"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_pay_package.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_pay_package.html.slim
@@ -1,4 +1,4 @@
-= render "publishers/vacancies/error_tag", attributes: pay_package_fields
+= render "publishers/vacancies/error_tag", attributes: Publishers::JobListing::PayPackageForm.fields
 
 = render ReviewComponent.new id: "pay_package" do |review|
   - review.heading title: t("publishers.vacancies.steps.pay_package"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_working_patterns.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_working_patterns.html.slim
@@ -1,4 +1,4 @@
-= render "publishers/vacancies/error_tag", attributes: job_details_fields
+= render "publishers/vacancies/error_tag", attributes: Publishers::JobListing::WorkingPatternsForm.fields
 
 = render ReviewComponent.new id: "working_patterns" do |review|
   - review.heading title: t("publishers.vacancies.steps.working_patterns"),


### PR DESCRIPTION
`Wizardable` has methods for the fields (`Vacancy` model attributes)
for each individual form which are then invoked using `send`  - these
should just be owned by each form model itself.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3101