### PR TITLE
Improve email generation in factories

### DIFF
--- a/spec/factories/account_requests.rb
+++ b/spec/factories/account_requests.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :account_request do
     full_name { Faker::Name.last_name.delete("'") }
-    email { Faker::Internet.email }
+    email { Faker::Internet.email(domain: "example.com") }
     organisation_name { Faker::Company.name }
     organisation_identifier { Faker::Number.number(digits: 3).to_s }
   end

--- a/spec/factories/job_applications.rb
+++ b/spec/factories/job_applications.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
     city { Faker::Address.city }
     postcode { Faker::Address.postcode }
     country { Faker::Address.country }
-    email_address { Faker::Internet.email }
+    email_address { Faker::Internet.email(domain: "example.com") }
     phone_number { "01234 567890" }
     teacher_reference_number { "1234567" }
     national_insurance_number { "QQ 12 34 56 C" }

--- a/spec/factories/jobseekers.rb
+++ b/spec/factories/jobseekers.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :jobseeker do
-    email { Faker::Internet.email }
+    email { Faker::Internet.email(domain: "example.com") }
     password { "passw0rd" }
     confirmed_at { 1.hour.ago }
   end

--- a/spec/factories/publishers.rb
+++ b/spec/factories/publishers.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :publisher do
     accepted_terms_at { Date.current - 5.months }
-    email { Faker::Internet.email }
+    email { Faker::Internet.email(domain: "example.com") }
     family_name { Faker::Name.last_name.delete("'") }
     given_name { Faker::Name.first_name }
     oid { Faker::Crypto.md5 }

--- a/spec/factories/references.rb
+++ b/spec/factories/references.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     job_title { Faker::Company.profession }
     organisation { Faker::Educator.secondary_school }
     relationship { "Line Manager" }
-    email { Faker::Internet.email }
+    email { Faker::Internet.email(domain: "example.com") }
     phone_number { "01234 567890" }
 
     job_application

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :subscription do
-    email { Faker::Internet.email }
+    email { Faker::Internet.email(domain: "example.com") }
     frequency { %i[daily weekly].sample }
     search_criteria do
       { keyword: Faker::Lorem.word,

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
     completed_steps do
       %w[job_role job_role_details job_location schools job_details working_patterns pay_package important_dates documents applying_for_the_job job_summary]
     end
-    contact_email { Faker::Internet.email }
+    contact_email { Faker::Internet.email(domain: "example.com") }
     contact_number { "01234 123456" }
     contract_type { Vacancy.contract_types.keys.sample }
     contract_type_duration { "6 months" }

--- a/spec/lib/export_dsi_approver_records_to_big_query_spec.rb
+++ b/spec/lib/export_dsi_approver_records_to_big_query_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ExportDsiApproversToBigQuery do
       "update_datetime" => 2.weeks.ago,
       "given_name" => Faker::Name.first_name,
       "family_name" => Faker::Name.last_name,
-      "email" => Faker::Internet.email,
+      "email" => Faker::Internet.email(domain: "example.com"),
       "organisation" => {
         "urn" => 100_000,
         "uid" => 999_999,

--- a/spec/lib/export_dsi_user_records_to_big_query_spec.rb
+++ b/spec/lib/export_dsi_user_records_to_big_query_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe ExportDsiUsersToBigQuery do
       "update_datetime" => 2.weeks.ago,
       "given_name" => Faker::Name.first_name,
       "family_name" => Faker::Name.last_name,
-      "email" => Faker::Internet.email,
+      "email" => Faker::Internet.email(domain: "example.com"),
       "organisation" => {
         "URN" => 100_000,
         "UID" => 999_999,

--- a/spec/system/publishers_can_sign_in_with_dfe_spec.rb
+++ b/spec/system/publishers_can_sign_in_with_dfe_spec.rb
@@ -31,7 +31,7 @@ end
 
 RSpec.describe "Publishers can sign in with DfE Sign In" do
   let(:user_oid) { "161d1f6a-44f1-4a1a-940d-d1088c439da7" }
-  let(:dsi_email_address) { Faker::Internet.email }
+  let(:dsi_email_address) { Faker::Internet.email(domain: "example.com") }
 
   before do
     allow(AuthenticationFallback).to receive(:enabled?) { false }

--- a/spec/system/users_can_only_be_signed_in_to_one_type_of_account_spec.rb
+++ b/spec/system/users_can_only_be_signed_in_to_one_type_of_account_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Users can only be signed in to one type of account" do
     before { login_as(jobseeker, scope: :jobseeker) }
 
     context "when email fallback is disabled" do
-      let(:dsi_email_address) { Faker::Internet.email }
+      let(:dsi_email_address) { Faker::Internet.email(domain: "example.com") }
 
       before do
         OmniAuth.config.test_mode = true


### PR DESCRIPTION
- Ensure all email addresses we generate in factories are on the
  `example.com` domain
- Rename publishers factory to what it actually contains