### PR TITLE
Deliver job application notification emails later

### DIFF
--- a/app/controllers/publishers/vacancies/job_applications_controller.rb
+++ b/app/controllers/publishers/vacancies/job_applications_controller.rb
@@ -27,7 +27,7 @@ class Publishers::Vacancies::JobApplicationsController < Publishers::Vacancies::
       job_application.draft? || job_application.withdrawn?
 
     job_application.update(form_params.merge(status: status))
-    Jobseekers::JobApplicationMailer.send("application_#{status}".to_sym, job_application).deliver_now
+    Jobseekers::JobApplicationMailer.send("application_#{status}".to_sym, job_application).deliver_later
     redirect_to organisation_job_job_applications_path(vacancy.id), success: t(".#{status}", name: job_application.name)
   end
 


### PR DESCRIPTION
We should deliver emails asynchronously anyway, but in this case it's
causing issues with QA and other non-prod environments raising an
error as part of shortlisting/rejecting an application (because it
can't send to non-team email addresses).