### PR TITLE
Ensure assets can be compiled during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN yarn install --check-files
 
 COPY . .
 
-RUN RAILS_ENV=production SECRET_KEY_BASE=required-to-run-but-not-used bundle exec rake webpacker:compile
+RUN RAILS_ENV=production SECRET_KEY_BASE=required-to-run-but-not-used RAILS_SERVE_STATIC_FILES=1 bundle exec rake webpacker:compile
 
 RUN rm -rf node_modules log tmp yarn.lock && \
       rm -rf /usr/local/bundle/cache && \


### PR DESCRIPTION
Previously `govuk-components` or `view_component` seem to have caused
the Rails `ActionDispatch::Static` middleware to get included
regardless of environment configuration.

This doesn't seem to be the case anymore with versions of these gems
we're about to upgrade to, so we need to make sure the compilation
of Webpacker assets as part of the Docker build sets the
`RAILS_SERVE_STATIC_FILES` environment variable.