### PR TITLE
[TEVA-3136] Change PaaS authentication credentials

### DIFF
--- a/.github/workflows/restore_db.yml
+++ b/.github/workflows/restore_db.yml
@@ -38,8 +38,8 @@ jobs:
     - name: Setup cf cli
       uses: DFE-Digital/github-actions/setup-cf-cli@master
       with:
-        CF_USERNAME: ${{ secrets.CF_USERNAME }}
-        CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
+        CF_USERNAME: ${{ secrets.CF_USERNAME_PROD }}
+        CF_PASSWORD: ${{ secrets.CF_PASSWORD_PROD }}
         CF_SPACE_NAME: ${{ env.PAAS_SPACE_NAME }}
         INSTALL_CONDUIT: true
 

--- a/.github/workflows/sync_staging_db.yml
+++ b/.github/workflows/sync_staging_db.yml
@@ -37,8 +37,8 @@ jobs:
     - name: Setup cf cli
       uses: DFE-Digital/github-actions/setup-cf-cli@master
       with:
-        CF_USERNAME: ${{ secrets.CF_USERNAME }}
-        CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
+        CF_USERNAME: ${{ secrets.CF_USERNAME_PROD }}
+        CF_PASSWORD: ${{ secrets.CF_PASSWORD_PROD }}
         CF_SPACE_NAME: teaching-vacancies-production
         INSTALL_CONDUIT: true
 

--- a/documentation/hosting.md
+++ b/documentation/hosting.md
@@ -84,7 +84,7 @@ cf login --sso -a $CF_API_ENDPOINT -o $CF_ORG -s $CF_SPACE
 If you need to login with a service account to access production environment:
 
 ```bash
-cf login -a $CF_API_ENDPOINT -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE
+cf login -a $CF_API_ENDPOINT -u $CF_USERNAME_PROD -p $CF_PASSWORD_PROD -o $CF_ORG -s $CF_SPACE
 ```
 
 ## Check space users


### PR DESCRIPTION
There were too many services, the old service account before this
change is now superceded by service account used in this update.
The old service account would be deleted.

## Jira ticket URL

- Just add the ticket number to the end:

https://dfedigital.atlassian.net/browse/TEVA-3136

## Changes in this PR:

Up date the credentials used by:- restore_db.ym and .github/workflows/sync_staging_db.yml to use the correct service account.

