### PR TITLE
Re-disable logging on event sending jobs

### DIFF
--- a/app/jobs/send_entity_imported_events_to_data_warehouse_job.rb
+++ b/app/jobs/send_entity_imported_events_to_data_warehouse_job.rb
@@ -3,6 +3,8 @@ class SendEntityImportedEventsToDataWarehouseJob < ApplicationJob
 
   queue_as :low
 
+  self.logger = ActiveSupport::TaggedLogging.new(Logger.new(IO::NULL))
+
   def perform
     bq = Google::Cloud::Bigquery.new
     dataset = bq.dataset(Rails.configuration.big_query_dataset, skip_lookup: true)

--- a/app/jobs/send_event_to_data_warehouse_job.rb
+++ b/app/jobs/send_event_to_data_warehouse_job.rb
@@ -1,6 +1,8 @@
 class SendEventToDataWarehouseJob < ApplicationJob
   queue_as :low
 
+  self.logger = ActiveSupport::TaggedLogging.new(Logger.new(IO::NULL))
+
   def perform(table_name, data)
     bq = Google::Cloud::Bigquery.new
     dataset = bq.dataset(Rails.configuration.big_query_dataset, skip_lookup: true)


### PR DESCRIPTION
We removed this in #3934 because the previous way of doing it was not
working with `rails_semantic_logger`, but this has caused lots of log
spam again.

This time, instead of setting the logger to `nil`, we set it to a
proper null logger.