### PR TITLE
[TEVA-3167] Stop semantic logger from draining to log file

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,6 +72,8 @@ Rails.application.configure do
   # Use Semantic_Logger for cleaner logging
   Rails.application.config.semantic_logger.application = ""
   config.rails_semantic_logger.format = :json
+  config.rails_semantic_logger.add_file_appender = false
+  config.active_record.logger = nil # Don't log SQL in production
   config.semantic_logger.backtrace_level = :error
   config.semantic_logger.add_appender(io: $stdout, level: config.log_level, formatter: config.rails_semantic_logger.format)
 


### PR DESCRIPTION
## Jira ticket URL

- Just add the ticket number to the end:

https://dfedigital.atlassian.net/browse/TEVA-

## Changes in this PR:

set semantic logger config to drain to file as `false`
