### PR TITLE
[TEVA-3078] Update bullet formatting rules

### DIFF
--- a/spec/presenters/vacancy_presenter_spec.rb
+++ b/spec/presenters/vacancy_presenter_spec.rb
@@ -1,96 +1,115 @@
 require "rails_helper"
 
 RSpec.describe VacancyPresenter do
-  describe "#expired?" do
-    it "returns true when the vacancy has expired by now" do
-      vacancy = VacancyPresenter.new(build(:vacancy, expires_at: 1.hour.ago))
+  subject { described_class.new(vacancy) }
 
-      expect(vacancy).to be_expired
+  describe "#expired?" do
+    context "when the vacancy has expired by now" do
+      let(:vacancy) { build(:vacancy, expires_at: 1.hour.ago) }
+
+      it "returns true" do
+        expect(subject).to be_expired
+      end
     end
 
-    it "returns false when the vacancy expires later today" do
-      vacancy = VacancyPresenter.new(build(:vacancy, expires_at: 1.hour.from_now))
+    context "when the vacancy expires later today" do
+      let(:vacancy) { build(:vacancy, expires_at: 1.hour.from_now) }
 
-      expect(vacancy).not_to be_expired
+      it "returns false" do
+        expect(subject).not_to be_expired
+      end
     end
   end
 
   describe "#publish_today?" do
-    it "verifies that the publish_on is set to today" do
-      vacancy = VacancyPresenter.new(build(:vacancy, publish_on: Date.current))
+    let(:vacancy) { build(:vacancy, publish_on: Date.current) }
 
-      expect(vacancy.publish_today?).to eq(true)
+    it "verifies that the publish_on is set to today" do
+      expect(subject.publish_today?).to eq(true)
     end
   end
 
   describe "#job_advert" do
-    it "sanitizes and transforms the job_advert into HTML" do
-      vacancy = build(:vacancy, job_advert: "<script> call();</script>Sanitized content")
-      presenter = VacancyPresenter.new(vacancy)
+    let(:vacancy) { build(:vacancy, job_advert: "<script> call();</script>Sanitized content") }
 
-      expect(presenter.job_advert).to eq("<p> call();Sanitized content</p>")
+    it "sanitizes and transforms the job_advert into HTML" do
+      expect(subject.job_advert).to eq("<p> call();Sanitized content</p>")
     end
 
-    it "transforms badly formatted inline `•` symbols into validly formatted <li> tags" do
-      vacancy = build(:vacancy, job_advert:
-        "Required skills: \n\n• Skill • Competency \n" \
-        "This is a paragraph that's not part of the bullet pointy bit. \n" \
-        "And this is going to have some more bullet points... \n" \
-        "• Interpersonal skills • Wonderfulness • Skill three \n" \
-        "There you go. No more bullet points.")
-      presenter = VacancyPresenter.new(vacancy)
+    context "when the advert is well-formatted (has line breaks between list items)" do
+      let(:vacancy) do
+        build(:vacancy, job_advert:
+         "<div><!--block-->&nbsp;</div><div><!--block--><strong>Deputy Head Teacher</strong>&nbsp;<br><br></div>" \
+         "<div><!--block-->To be successful, you will:&nbsp;<br><br></div>" \
+         "<div><!--block-->· &nbsp; Have quality one;&nbsp;<br><br></div>" \
+         "<div><!--block-->· &nbsp; Have quality two;&nbsp;<br><br></div>" \
+         "<div><!--block-->· &nbsp; Have quality three;&nbsp;<br><br></div>" \
+         "<div><!--block-->Apply now.&nbsp;</div>")
+      end
 
-      expect(presenter.job_advert).to eq(
-        "<p>Required skills: </p>\n\n" \
-        "<p>" \
-          "<ul>\n<br />" \
-            "<li> Skill </li>\n<br />" \
-            "<li> Competency </li>\n<br />" \
-          "</ul>\n" \
-          "<br />This is a paragraph that's not part of the bullet pointy bit. \n" \
-          "<br />And this is going to have some more bullet points... \n<br />" \
-          "<ul>\n" \
-            "<br /><li> Interpersonal skills </li>\n" \
-            "<br /><li> Wonderfulness </li>\n" \
-            "<br /><li> Skill three </li>\n" \
-            "<br />" \
-          "</ul>\n" \
-        "<br />There you go. No more bullet points." \
-        "</p>",
-      )
+      it "does not reformat" do
+        expect(subject.job_advert).to eq(
+          "<p> <strong>Deputy Head Teacher</strong> <br><br>" \
+          "To be successful, you will: <br><br>" \
+          "•   Have quality one; <br><br>" \
+          "•   Have quality two; <br><br>" \
+          "•   Have quality three; <br><br>" \
+          "Apply now. </p>",
+        )
+      end
+    end
+
+    context "when the advert is badly formatted" do
+      let(:vacancy) do
+        build(:vacancy, job_advert:
+          "<div><!--block-->&nbsp;</div><div><!--block-->Sentence one. Sentence two.&nbsp;<br><br></div>" \
+          "<div><!--block-->Paragraph two. Qualifications:&nbsp;<br><br></div>" \
+          "<div><!--block-->•&nbsp; &nbsp; Skill one.&nbsp;</div>" \
+          "<div><!--block-->•&nbsp; &nbsp; Skill two.&nbsp;</div>" \
+          "<div><!--block-->•&nbsp; &nbsp; Skill three.&nbsp;<br><br></div>" \
+          "<div><!--block-->Penultimate paragraph.&nbsp;<br><br>" \
+          "Last paragraph &nbsp;<br><br></div><div>")
+      end
+
+      it "transforms badly formatted inline bullet point symbols into validly formatted <li> tags" do
+        expect(subject.job_advert).to eq(
+          "<p> Sentence one. Sentence two. <br><br>" \
+          "Paragraph two. Qualifications: <br><br>" \
+          "<ul>\n<br /><li>  Skill one.</li>\n<br />" \
+          "<li>  Skill two.</li>\n<br />" \
+          "<li>  Skill three.</li>\n<br /></ul>" \
+          "<br><br>Penultimate paragraph. <br><br>" \
+          "Last paragraph  <br><br></p>",
+        )
+      end
     end
   end
 
   describe "#about_school" do
-    it "sanitizes and transforms about_school into HTML" do
-      vacancy = build(:vacancy, about_school: "<script> call();</script>Sanitized content")
-      presenter = VacancyPresenter.new(vacancy)
+    let(:vacancy) { build(:vacancy, about_school: "<script> call();</script>Sanitized content") }
 
-      expect(presenter.about_school).to eq("<p> call();Sanitized content</p>")
+    it "sanitizes and transforms about_school into HTML" do
+      expect(subject.about_school).to eq("<p> call();Sanitized content</p>")
     end
   end
 
   describe "#school_visits" do
-    it "sanitizes and transforms school_visits into HTML" do
-      vacancy = build(:vacancy, school_visits: "<script> call();</script>Sanitized content")
-      presenter = VacancyPresenter.new(vacancy)
+    let(:vacancy) { build(:vacancy, school_visits: "<script> call();</script>Sanitized content") }
 
-      expect(presenter.school_visits).to eq("<p> call();Sanitized content</p>")
+    it "sanitizes and transforms school_visits into HTML" do
+      expect(subject.school_visits).to eq("<p> call();Sanitized content</p>")
     end
   end
 
   describe "#how_to_apply" do
-    it "sanitizes and transforms school_visits into HTML" do
-      vacancy = build(:vacancy, how_to_apply: "<script> call();</script>Sanitized content")
-      presenter = VacancyPresenter.new(vacancy)
+    let(:vacancy) { build(:vacancy, how_to_apply: "<script> call();</script>Sanitized content") }
 
-      expect(presenter.how_to_apply).to eq("<p> call();Sanitized content</p>")
+    it "sanitizes and transforms school_visits into HTML" do
+      expect(subject.how_to_apply).to eq("<p> call();Sanitized content</p>")
     end
   end
 
   describe "#all_job_roles" do
-    subject { VacancyPresenter.new(vacancy) }
-
     let(:vacancy) { build(:vacancy) }
 
     it "returns the main job role" do
@@ -105,75 +124,76 @@ RSpec.describe VacancyPresenter do
   end
 
   describe "#working_patterns" do
-    it "returns nil if working_patterns is unset" do
-      vacancy = VacancyPresenter.new(create(:vacancy, :without_working_patterns))
-      vacancy.organisation_vacancies.create(organisation: create(:school, name: "Smith High School"))
+    context "when working_patterns is unset" do
+      let(:vacancy) { create(:vacancy, :without_working_patterns) }
 
-      expect(vacancy.working_patterns).to be_nil
+      it "returns nil" do
+        expect(subject.working_patterns).to be_nil
+      end
     end
 
     context "when only working_patterns is set" do
-      it "returns a string only containing the working pattern" do
-        vacancy = VacancyPresenter.new(create(:vacancy, working_patterns: %w[full_time part_time], working_patterns_details: nil))
-        vacancy.organisation_vacancies.create(organisation: create(:school, name: "Smith High School"))
+      let(:vacancy) { create(:vacancy, working_patterns: %w[full_time part_time], working_patterns_details: nil) }
 
-        expect(vacancy.show_working_patterns).to eq(I18n.t("jobs.working_patterns_info", patterns: "full-time, part-time", count: vacancy.model_working_patterns.count))
+      it "returns a string only containing the working pattern" do
+        expect(subject.show_working_patterns).to eq(I18n.t("jobs.working_patterns_info", patterns: "full-time, part-time", count: 2))
       end
     end
 
     context "when both working_patterns and working_patterns_details have been set" do
-      it "returns a string containing the working pattern and working_patterns_details" do
-        vacancy = VacancyPresenter.new(create(:vacancy, working_patterns: %w[full_time part_time]))
-        vacancy.organisation_vacancies.create(organisation: create(:school, name: "Smith High School"))
+      let(:vacancy) { create(:vacancy, working_patterns: %w[full_time part_time]) }
 
-        expect(vacancy.show_working_patterns).to eq(safe_join([vacancy.working_patterns,
+      it "returns a string containing the working pattern and working_patterns_details" do
+        expect(subject.show_working_patterns).to eq(safe_join([subject.working_patterns,
                                                                tag.br,
-                                                               tag.span(vacancy.working_patterns_details, class: "govuk-hint govuk-!-margin-bottom-0")]))
+                                                               tag.span(subject.working_patterns_details, class: "govuk-hint govuk-!-margin-bottom-0")]))
       end
     end
   end
 
   describe "#working_patterns_for_job_schema" do
-    it "returns blank if working_patterns is unset" do
-      vacancy = VacancyPresenter.new(create(:vacancy, :without_working_patterns))
-      vacancy.organisation_vacancies.create(organisation: create(:school, name: "Smith High School"))
+    context "when working_patterns is unset" do
+      let(:vacancy) { create(:vacancy, :without_working_patterns) }
 
-      expect(vacancy.working_patterns_for_job_schema).to be_blank
+      it "returns blank" do
+        expect(subject.working_patterns_for_job_schema).to be_blank
+      end
     end
 
-    it "returns a working patterns string if working_patterns is set" do
-      vacancy = VacancyPresenter.new(create(:vacancy, working_patterns: %w[full_time part_time]))
-      vacancy.organisation_vacancies.create(organisation: create(:school, name: "Smith High School"))
+    context "when working_patterns is set" do
+      let(:vacancy) { create(:vacancy, working_patterns: %w[full_time part_time]) }
 
-      expect(vacancy.working_patterns_for_job_schema).to eq("FULL_TIME, PART_TIME")
+      it "returns a string containing the working pattern" do
+        expect(subject.working_patterns_for_job_schema).to eq("FULL_TIME, PART_TIME")
+      end
     end
   end
 
   describe "#share_url" do
-    let(:presenter) { VacancyPresenter.new(create(:vacancy, job_title: "PE Teacher")) }
+    let(:vacancy) { create(:vacancy, job_title: "PE Teacher") }
 
     it "returns the absolute public url for the job post" do
       expected_url = URI("localhost:3000/jobs/pe-teacher")
-      expect(presenter.share_url).to match(expected_url.to_s)
+      expect(subject.share_url).to match(expected_url.to_s)
     end
 
     context "when campaign parameters are passed" do
       it "builds the campaign URL" do
         expected_campaign_url = URI("http://localhost:3000/jobs/pe-teacher?utm_medium=interpretative_dance&utm_source=alert_run_id")
-        expect(presenter.share_url(utm_source: "alert_run_id", utm_medium: "interpretative_dance")).to match(expected_campaign_url.to_s)
+        expect(subject.share_url(utm_source: "alert_run_id", utm_medium: "interpretative_dance")).to match(expected_campaign_url.to_s)
       end
     end
   end
 
   describe "#contract_type_with_duration" do
-    let(:presenter) { VacancyPresenter.new(create(:vacancy, contract_type: contract_type, contract_type_duration: contract_type_duration)) }
+    let(:vacancy) { create(:vacancy, contract_type: contract_type, contract_type_duration: contract_type_duration) }
 
     context "when permanent" do
       let(:contract_type) { :permanent }
       let(:contract_type_duration) { nil }
 
       it "returns Permanent" do
-        expect(presenter.contract_type_with_duration).to eq "Permanent"
+        expect(subject.contract_type_with_duration).to eq "Permanent"
       end
     end
 
@@ -182,7 +202,7 @@ RSpec.describe VacancyPresenter do
       let(:contract_type_duration) { "6 months" }
 
       it "returns Fixed term (duration)" do
-        expect(presenter.contract_type_with_duration).to eq "Fixed term (6 months)"
+        expect(subject.contract_type_with_duration).to eq "Fixed term (6 months)"
       end
     end
   end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3078

## Changes in this PR:

- Update bullet formatting rules to fix below-pictured problems.

Commit message:

Job adverts nowadays contain a lot of html elements instead of the newline characters they formerly used.

Do not mess with the formatting when the unit we're operating on
(named 'paragraph') contains one bullet point, since the formatting
is probably already correct.

## Screenshots of UI changes:

### Before

<img width="621" alt="Screenshot 2021-09-16 at 13 47 34" src="https://user-images.githubusercontent.com/60350599/133618106-bb91d2d8-7c3d-44d9-9dd4-e27439267986.png">
<img width="621" alt="Screenshot 2021-09-16 at 13 51 00" src="https://user-images.githubusercontent.com/60350599/133618138-14760e04-b6cb-49bb-9792-08b6611939f8.png">
<img width="533" alt="Screenshot 2021-09-16 at 14 07 52" src="https://user-images.githubusercontent.com/60350599/133618164-810247ab-1e80-4a5d-b5e8-bdaffee0afdf.png">
<img width="621" alt="Screenshot 2021-09-16 at 13 47 45" src="https://user-images.githubusercontent.com/60350599/133618188-f953b593-ccbf-4fa6-9c99-8c707ad08bdf.png">


### After

<img width="621" alt="Screenshot 2021-09-16 at 13 44 12" src="https://user-images.githubusercontent.com/60350599/133618233-1ba39b95-7e5d-4554-88c7-13dabd8ca6f5.png">
<img width="533" alt="Screenshot 2021-09-16 at 14 05 07" src="https://user-images.githubusercontent.com/60350599/133618292-22a1f1fc-43dd-481a-9495-a9db68806385.png">
<img width="533" alt="Screenshot 2021-09-16 at 14 07 20" src="https://user-images.githubusercontent.com/60350599/133618310-ad3285ba-e381-48d0-952e-d642b7f38570.png">
<img width="621" alt="Screenshot 2021-09-16 at 13 44 30" src="https://user-images.githubusercontent.com/60350599/133618353-4b8b48ae-b6d3-49cf-984c-867654315dad.png">
