### PR TITLE
[TEVA-2999] Change the threshold to remove memberships

### DIFF
--- a/lib/organisation_import/import_organisation_data.rb
+++ b/lib/organisation_import/import_organisation_data.rb
@@ -19,7 +19,7 @@ class ImportOrganisationData
                                                                       .transform_values(&:length)
     Rollbar.log(:info, "The number of memberships to delete, by SchoolGroup: #{school_group_name_and_count_of_memberships}")
 
-    raise SuspiciouslyHighNumberOfRecordsToDelete, memberships_to_delete.count if memberships_to_delete.count > 10
+    raise SuspiciouslyHighNumberOfRecordsToDelete, memberships_to_delete.count if memberships_to_delete.count > 150
 
     memberships_to_delete.delete_all
   end


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-2999

## Changes in this PR:
At the moment we have 104 SchoolGroupMemebership that should have been removed as a result of the import, but we had a very low threshold of just 10 that probably got deleted in one day and since then we haven't removed these records

memberships_to_delete.count => 104