### PR TITLE
Improve organisation import scripts

### DIFF
--- a/lib/organisation_import/import_school_data.rb
+++ b/lib/organisation_import/import_school_data.rb
@@ -1,13 +1,15 @@
 require "organisation_import/import_organisation_data"
 
 class ImportSchoolData < ImportOrganisationData
-  private
-
-  def csv_metadata
-    [{ csv_url: "https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public/edubasealldata#{datestring}.csv",
-       csv_file_location: "./tmp/#{datestring}-schools-data.csv",
-       method: :create_school_and_local_authority }]
+  def run!
+    import_data(
+      csv_url: "#{GIAS_BASE_URL}edubasealldata#{datestring}.csv",
+      csv_file_location: "./tmp/#{datestring}-schools-data.csv",
+      method: :create_school_and_local_authority,
+    )
   end
+
+  private
 
   def create_school_and_local_authority(row)
     school = create_organisation(row)

--- a/lib/organisation_import/import_trust_data.rb
+++ b/lib/organisation_import/import_trust_data.rb
@@ -1,6 +1,22 @@
 require "organisation_import/import_organisation_data"
 
 class ImportTrustData < ImportOrganisationData
+  def run!
+    # Trust data
+    import_data(
+      csv_url: "#{GIAS_BASE_URL}allgroupsdata#{datestring}.csv",
+      csv_file_location: "./tmp/school-group-data.csv",
+      method: :create_organisation,
+    )
+
+    # Trust membership data
+    import_data(
+      csv_url: "#{GIAS_BASE_URL}alllinksdata#{datestring}.csv",
+      csv_file_location: "./tmp/school-group-membership-data.csv",
+      method: :create_school_group_membership,
+    )
+  end
+
   private
 
   def column_name_mappings
@@ -52,21 +68,5 @@ class ImportTrustData < ImportOrganisationData
     trust.postcode = postcode
     coordinates = Geocoding.new(trust.postcode).coordinates
     trust.geolocation = coordinates unless coordinates == [0, 0]
-  end
-
-  def csv_metadata
-    [trust_csv_metadata, membership_csv_metadata]
-  end
-
-  def trust_csv_metadata
-    { csv_url: "https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public/allgroupsdata#{datestring}.csv",
-      csv_file_location: "./tmp/school-group-data.csv",
-      method: :create_organisation }
-  end
-
-  def membership_csv_metadata
-    { csv_url: "https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public/alllinksdata#{datestring}.csv",
-      csv_file_location: "./tmp/school-group-membership-data.csv",
-      method: :create_school_group_membership }
   end
 end

--- a/spec/lib/organisation_import/import_school_data_spec.rb
+++ b/spec/lib/organisation_import/import_school_data_spec.rb
@@ -3,47 +3,6 @@ require "rails_helper"
 RSpec.describe ImportSchoolData do
   subject { described_class.new }
 
-  describe "#save_csv_file" do
-    let(:csv_url) { "https://csv_endpoint.csv/magic_endpoint/test.csv" }
-    let(:temp_file_location) { "/some_temporary_location/test.csv" }
-    let(:request_body) { "Not found" }
-
-    before do
-      stub_request(:get, csv_url).to_return(body: request_body, status: request_status)
-    end
-
-    context "when the csv file is unavailable" do
-      let(:request_status) { 404 }
-
-      it "raises an HTTP error" do
-        expect { subject.send(:save_csv_file, csv_url, temp_file_location) }
-          .to raise_error(HTTParty::ResponseError).with_message("CSV file not found at #{csv_url}.")
-      end
-    end
-
-    context "when an unexpected response is returned" do
-      let(:request_status) { 500 }
-
-      it "raises an HTTP error" do
-        expect { subject.send(:save_csv_file, csv_url, temp_file_location) }
-          .to raise_error(HTTParty::ResponseError).with_message("Unexpected problem downloading CSV file from #{csv_url}.")
-      end
-    end
-
-    context "when the request is OK" do
-      let(:request_status) { 200 }
-
-      before do
-        allow(File).to receive(:write).with(temp_file_location, request_body, hash_including(mode: "wb"))
-      end
-
-      it "opens a file" do
-        expect(File).to receive(:write).with(temp_file_location, request_body, hash_including(mode: "wb"))
-        subject.send(:save_csv_file, csv_url, temp_file_location)
-      end
-    end
-  end
-
   describe "#run!" do
     let(:csv) { File.read(test_file_path) }
     let(:datestring) { Time.current.strftime("%Y%m%d") }

--- a/spec/lib/organisation_import/import_trust_data_spec.rb
+++ b/spec/lib/organisation_import/import_trust_data_spec.rb
@@ -3,47 +3,6 @@ require "rails_helper"
 RSpec.describe ImportTrustData do
   subject { described_class.new }
 
-  describe "#save_csv_file" do
-    let(:csv_url) { "https://csv_endpoint.csv/magic_endpoint/test.csv" }
-    let(:temp_file_location) { "/some_temporary_location/test.csv" }
-    let(:request_body) { "Not found" }
-
-    before do
-      stub_request(:get, csv_url).to_return(body: request_body, status: request_status)
-    end
-
-    context "when the csv file is unavailable" do
-      let(:request_status) { 404 }
-
-      it "raises an HTTP error" do
-        expect { subject.send(:save_csv_file, csv_url, temp_file_location) }
-          .to raise_error(HTTParty::ResponseError).with_message("CSV file not found at #{csv_url}.")
-      end
-    end
-
-    context "when an unexpected response is returned" do
-      let(:request_status) { 500 }
-
-      it "raises an HTTP error" do
-        expect { subject.send(:save_csv_file, csv_url, temp_file_location) }
-          .to raise_error(HTTParty::ResponseError).with_message("Unexpected problem downloading CSV file from #{csv_url}.")
-      end
-    end
-
-    context "when the request is OK" do
-      let(:request_status) { 200 }
-
-      before do
-        allow(File).to receive(:write).with(temp_file_location, request_body, hash_including(mode: "wb"))
-      end
-
-      it "opens a file" do
-        expect(File).to receive(:write).with(temp_file_location, request_body, hash_including(mode: "wb"))
-        subject.send(:save_csv_file, csv_url, temp_file_location)
-      end
-    end
-  end
-
   describe "#set_geolocation" do
     let(:trust) { create(:trust, postcode: "some postcode") }
 


### PR DESCRIPTION
- Make `run!` methods more explicit
- Make `save_csv_file` less verbose and remove specs that test
  private method
- Extract repeated `GIAS_BASE_URL`
- Remove open-uri and superfluous use of #each on `CSV.foreach`