### PR TITLE
Add working_patterns to redirect_to_incomplete_step

### DIFF
--- a/app/controllers/publishers/vacancies_controller.rb
+++ b/app/controllers/publishers/vacancies_controller.rb
@@ -66,13 +66,13 @@ class Publishers::VacanciesController < Publishers::Vacancies::BaseController
   end
 
   def redirect_to_incomplete_step
-    return redirect_to organisation_job_build_path(vacancy.id, :job_role) unless step_valid?(:job_role)
-    return redirect_to organisation_job_build_path(vacancy.id, :job_details) unless step_valid?(:job_details)
-    return redirect_to organisation_job_build_path(vacancy.id, :pay_package) unless step_valid?(:pay_package)
-    return redirect_to organisation_job_build_path(vacancy.id, :important_dates) unless step_valid?(:important_dates)
-    return redirect_to organisation_job_build_path(vacancy.id, :documents) unless vacancy.completed_steps.include?("documents")
-    return redirect_to organisation_job_build_path(vacancy.id, :applying_for_the_job) unless step_valid?(:applying_for_the_job)
-    return redirect_to organisation_job_build_path(vacancy.id, :job_summary) unless step_valid?(:job_summary)
+    step_process.steps.excluding(:review).each do |step|
+      if step == :documents
+        return redirect_to organisation_job_build_path(vacancy.id, :documents) unless vacancy.completed_steps.include?("documents")
+      else
+        return redirect_to organisation_job_build_path(vacancy.id, step) unless step_valid?(step)
+      end
+    end
   end
 
   def validate_all_steps

--- a/spec/system/publishers_can_publish_a_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers_can_publish_a_vacancy_as_a_school_spec.rb
@@ -137,6 +137,26 @@ RSpec.describe "Creating a vacancy" do
 
     describe "#review" do
       context "redirects the user back to the last incomplete step" do
+        scenario "redirects to working patterns when that step has not been completed" do
+          visit organisation_path
+          click_on I18n.t("buttons.create_job")
+
+          fill_in_job_role_form_fields(vacancy)
+          click_on I18n.t("buttons.continue")
+          click_on I18n.t("buttons.continue")
+
+          fill_in_job_details_form_fields(vacancy)
+          click_on I18n.t("buttons.continue")
+
+          v = Vacancy.find_by(job_title: vacancy.job_title)
+          visit edit_organisation_job_path(id: v.id)
+
+          expect(page).to have_content(I18n.t("jobs.current_step", step: 3, total: 9))
+          within("h2.govuk-heading-l") do
+            expect(page).to have_content(I18n.t("publishers.vacancies.steps.working_patterns"))
+          end
+        end
+
         scenario "redirects to pay package when that step has not been completed" do
           visit organisation_path
           click_on I18n.t("buttons.create_job")
@@ -146,6 +166,9 @@ RSpec.describe "Creating a vacancy" do
           click_on I18n.t("buttons.continue")
 
           fill_in_job_details_form_fields(vacancy)
+          click_on I18n.t("buttons.continue")
+
+          fill_in_working_patterns_form_fields(vacancy)
           click_on I18n.t("buttons.continue")
 
           v = Vacancy.find_by(job_title: vacancy.job_title)


### PR DESCRIPTION
## Changes in this PR:

- Working patterns was missing from `redirect_to_incomplete_step`. I've added the step by iterating through all of the steps in the step process' steps.

