### PR TITLE
Set log level to info in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -70,6 +70,7 @@ Rails.application.configure do
   config.active_support.deprecation = :notify
 
   # Use Semantic_Logger for cleaner logging
+  config.log_level = :info
   Rails.application.config.semantic_logger.application = ""
   config.rails_semantic_logger.format = :json
   config.rails_semantic_logger.add_file_appender = false


### PR DESCRIPTION
This is currently undefined so Rails vomits up more logs than you can
shake a stick at, overwhelming our logging platform.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3182