### PR TITLE
Add Rack mini profiler to development gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,7 @@ group :development, :test do
   gem "pry"
   gem "pry-byebug"
   gem "pry-rails"
+  gem "rack-mini-profiler"
   gem "rails-controller-testing"
   gem "rspec-rails"
   gem "rspec-sonarqube-formatter", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -388,6 +388,8 @@ GEM
       rack (>= 1.0, < 3)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
+    rack-mini-profiler (2.3.3)
+      rack (>= 1.2.0)
     rack-oauth2 (1.18.0)
       activesupport
       attr_required
@@ -680,6 +682,7 @@ DEPENDENCIES
   puma
   rack-attack
   rack-cors
+  rack-mini-profiler
   rack_session_access
   rails-controller-testing
   rails-html-sanitizer


### PR DESCRIPTION
## Jira ticket URL

No ticket

## Changes in this PR:

- Add rack mini profiler gem.
- This makes it easy to see what pages are slow, and what makes them slow.
- Do you like it?

## Screenshots of UI changes:

![Screenshot 2021-09-17 at 12 47 47](https://user-images.githubusercontent.com/60350599/133777923-e0d8f5cd-a3ac-4f27-a999-6191b1745f75.png)
![Screenshot 2021-09-17 at 12 47 36](https://user-images.githubusercontent.com/60350599/133777948-8c86f8b0-ad2d-4b38-ac7e-a325742263f6.png)

