### PR TITLE
Replace basic uses of `School#geolocation` with `geopoint`

### DIFF
--- a/app/components/jobseekers/organisation_overviews/base_component.rb
+++ b/app/components/jobseekers/organisation_overviews/base_component.rb
@@ -12,6 +12,6 @@ class Jobseekers::OrganisationOverviews::BaseComponent < ViewComponent::Base
   end
 
   def organisation_map_data
-    { name: organisation&.name, lat: organisation.geolocation&.x, lng: organisation.geolocation&.y }.to_json
+    { name: organisation&.name, lat: organisation.geopoint&.lat, lng: organisation.geopoint&.lon }.to_json
   end
 end

--- a/app/components/jobseekers/organisation_overviews/school_component/school_component.html.slim
+++ b/app/components/jobseekers/organisation_overviews/school_component/school_component.html.slim
@@ -52,6 +52,6 @@ section#school-overview class="govuk-!-margin-bottom-5"
     h3.govuk-heading-l.section-heading = t("schools.school_location.one")
     = govuk_link_to full_address(organisation), "https://www.google.com/maps/search/#{full_address(organisation)}+UK", "aria-label": t("schools.map_link_aria_label")
 
-    - if organisation.geolocation
+    - if organisation.geopoint
       div id="map" aria-label=t("schools.map_aria_label") data-school=organisation_map_data
       script defer=true title=t("schools.map_aria_label") src="https://maps.googleapis.com/maps/api/js?key=#{GOOGLE_MAPS_API_KEY}&callback=initMap"

--- a/app/components/jobseekers/organisation_overviews/school_group_component/school_group_component.html.slim
+++ b/app/components/jobseekers/organisation_overviews/school_group_component/school_group_component.html.slim
@@ -37,6 +37,6 @@ section#school-overview class="govuk-!-margin-bottom-5"
     h3.govuk-heading-l.section-heading = t("school_groups.school_group_location")
     p = full_address(organisation)
 
-    - if organisation.geolocation
+    - if organisation.geopoint
       div id="map" role="presentation" aria-hidden="true" aria-label=t("school_groups.map_aria_label") data-school=organisation_map_data
       script defer=true src="https://maps.googleapis.com/maps/api/js?key=#{GOOGLE_MAPS_API_KEY}&callback=initMap"

--- a/app/components/jobseekers/organisation_overviews/schools_component.rb
+++ b/app/components/jobseekers/organisation_overviews/schools_component.rb
@@ -5,13 +5,13 @@ class Jobseekers::OrganisationOverviews::SchoolsComponent < Jobseekers::Organisa
 
   def organisation_map_data
     schools = []
-    vacancy.organisations.select(&:geolocation).each do |school|
+    vacancy.organisations.select(&:geopoint).each do |school|
       schools.push({ name: school.name,
                      name_link: link_to(school.name, (school.website || school.url)),
                      address: full_address(school),
                      school_type: organisation_type(school),
-                     lat: school.geolocation.x,
-                     lng: school.geolocation.y })
+                     lat: school.geopoint.lat,
+                     lng: school.geopoint.lon })
     end
     schools.to_json
   end

--- a/app/components/jobseekers/organisation_overviews/schools_component/schools_component.html.slim
+++ b/app/components/jobseekers/organisation_overviews/schools_component/schools_component.html.slim
@@ -70,7 +70,7 @@ section#school-overview class="govuk-!-margin-bottom-5"
       = t("schools.schools_visits")
     = vacancy.school_visits
 
-  - if vacancy.organisations.any?(&:geolocation)
+  - if vacancy.organisations.any?(&:geopoint)
     section#school-location
       h3.govuk-heading-l.section-heading = t("schools.school_location.other")
 

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -136,7 +136,7 @@ module Indexable
   end
 
   def _geoloc
-    organisations.select { |organisation| organisation.geolocation.present? }
-                 .map { |organisation| { lat: organisation.geolocation.x.to_f, lng: organisation.geolocation.y.to_f } }
+    organisations.select { |organisation| organisation.geopoint.present? }
+                 .map { |organisation| { lat: organisation.geopoint.lat, lng: organisation.geopoint.lon } }
   end
 end

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     description { Faker::Lorem.paragraph(sentence_count: 1) }
     establishment_status { "Open" }
     geolocation { [1, 2] }
+    geopoint { "POINT(2 1)" }
     gias_data do
       {
         CloseDate: nil,
@@ -84,6 +85,7 @@ FactoryBot.define do
 
     trait :no_geolocation do
       geolocation { nil }
+      geopoint { nil }
     end
   end
 

--- a/spec/system/jobseekers_can_see_a_map_spec.rb
+++ b/spec/system/jobseekers_can_see_a_map_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Viewing a vacancy" do
   it "displays a map when a school has geocoding" do
-    school = create(:school, geolocation: "51.4788757883318, 0.0253328559417984")
+    school = create(:school, geopoint: "POINT(51.4788757883318 0.0253328559417984)")
     vacancy = create(:vacancy)
     vacancy.organisation_vacancies.create(organisation: school)
     visit job_path(vacancy)
@@ -10,7 +10,7 @@ RSpec.describe "Viewing a vacancy" do
   end
 
   it "does not display a map when a school has no geocoding" do
-    school = create(:school, geolocation: nil)
+    school = create(:school, geopoint: nil)
     vacancy = create(:vacancy)
     vacancy.organisation_vacancies.create(organisation: school)
     visit job_path(vacancy)


### PR DESCRIPTION
This replaces the use of the `geolocation` column on schools with the
new, PostGIS-backed `geopoint` column, with the exception of the
recent mean geolocation code which will need some more work.