### PR TITLE
Update Algolia gem to latest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "railties", RAILS_VERSION
 gem "activerecord-postgis-adapter"
 gem "activerecord-session_store"
 gem "addressable"
-gem "algoliasearch-rails", "~> 1.25.0"
+gem "algoliasearch-rails", "~> 1.26.0"
 gem "array_enum"
 gem "aws-sdk-s3", require: false
 gem "breasal"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
-    algoliasearch-rails (1.25.0)
+    algoliasearch-rails (1.26.0)
       algoliasearch (>= 1.26.0, < 2.0.0)
       json (>= 1.5.1)
     amazing_print (1.3.0)
@@ -639,7 +639,7 @@ DEPENDENCIES
   activestorage (~> 6.1.4.1)
   activesupport (~> 6.1.4.1)
   addressable
-  algoliasearch-rails (~> 1.25.0)
+  algoliasearch-rails (~> 1.26.0)
   amazing_print
   array_enum
   aws-sdk-s3

--- a/config/initializers/algoliasearch.rb
+++ b/config/initializers/algoliasearch.rb
@@ -3,14 +3,3 @@ AlgoliaSearch.configuration = {
   api_key: Rails.env.test? ? "Placeholder" : ENV.fetch("ALGOLIA_WRITE_API_KEY", "Placeholder"),
   pagination_backend: :kaminari,
 }
-
-# Fix for Ruby 3.0+
-# The original relies on kwargs munging behaviour that is no longer possible in Ruby 3.
-# We'd fix this upstream but we plan to migrate away from Algolia soon anyway so this
-# monkey-patches it instead.
-# c.f. https://github.com/algolia/algoliasearch-rails/blob/master/lib/algoliasearch/pagination/kaminari.rb#L12
-class AlgoliaSearch::Pagination::Kaminari < ::Kaminari::PaginatableArray
-  def initialize(array, options)
-    super(array, **options)
-  end
-end


### PR DESCRIPTION
This does away with the need for the Ruby 3.0 monkeypatch.