### PR TITLE
[TEVA-3188] Fix check paas users workflow

### DIFF
--- a/.github/workflows/TV-check-users-in-space-developer-role.yml
+++ b/.github/workflows/TV-check-users-in-space-developer-role.yml
@@ -27,8 +27,9 @@ jobs:
           path: ./remote-checkout
 
       - name: Run powershell script
-        run: ./remote-checkout/scripts/check-users-in-space-developer-role.ps1 \
-          -space "${{ env.CF_SPACE_NAME }}" \
-          -slack_webhook "${{secrets.SLACK_WEBHOOK}}" \
-          -unset true \
-          -whitelist "${{secrets.PAAS_USER_WHITELIST}}"
+        run: |
+          ./remote-checkout/scripts/check-users-in-space-developer-role.ps1 \
+            -space "${{ env.CF_SPACE_NAME }}" \
+            -slack_webhook "${{secrets.SLACK_WEBHOOK}}" \
+            -unset true \
+            -whitelist "${{secrets.PAAS_USER_WHITELIST}}"


### PR DESCRIPTION
Syntax error causing:
check-users-in-space-developer-role.ps1: A positional parameter cannot be found that accepts argument ' -space'.

See: https://github.com/DFE-Digital/teaching-vacancies/runs/3669593954?check_suite_focus=true

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-3188

## Changes in this PR:
Changed like working example: https://github.com/DFE-Digital/bat-infrastructure/blob/main/.github/workflows/check-users-in-space-developer-role.yml#L25
