### PR TITLE
Update bullet point fixing logic

### DIFF
--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -121,10 +121,11 @@ class VacancyPresenter < BasePresenter
     # This is a band-aid solution for the problem where (particularly) job adverts contain bullet point characters
     # (not list elements), but do not contain corresponding newlines, resulting in inline bullets.
     bullet = "•"
+    text = normalize_newlines(text)
     text = normalize_bullets(text, bullet)
     return text unless text&.count(bullet)&.positive?
 
-    text.split("<br>").map { |para|
+    text.split("\n").map { |para|
       next para if para.count(bullet) <= 1 # If paragraph only has one bullet point it is probably correctly formatted
 
       first_bulleted_line_idx = strip(para).first == bullet ? 0 : 1
@@ -132,7 +133,7 @@ class VacancyPresenter < BasePresenter
         item = "<li>#{line.gsub(HTML_STRIP_REGEX, '')}</li>"
         index == first_bulleted_line_idx ? "<ul>#{item}" : item
       }.join.concat("</ul>")
-    }.join("<br>")
+    }.join("\n")
   end
 
   # rubocop:disable Style/AsciiComments
@@ -141,6 +142,11 @@ class VacancyPresenter < BasePresenter
     text&.gsub("⁃", normalized_bullet)&.gsub("·", normalized_bullet)&.gsub("∙", normalized_bullet)
   end
   # rubocop:enable Style/AsciiComments
+
+  def normalize_newlines(text)
+    # Required for backwards-compatibility for fields created with a rich-text editor
+    text&.gsub("<br>", "\n")
+  end
 
   def strip(text)
     text.gsub(/\s+/, "").gsub(HTML_STRIP_REGEX, "")

--- a/spec/presenters/vacancy_presenter_spec.rb
+++ b/spec/presenters/vacancy_presenter_spec.rb
@@ -39,48 +39,99 @@ RSpec.describe VacancyPresenter do
     context "when the advert is well-formatted (has line breaks between list items)" do
       let(:vacancy) do
         build(:vacancy, job_advert:
-         "<div><!--block-->&nbsp;</div><div><!--block--><strong>Deputy Head Teacher</strong>&nbsp;<br><br></div>" \
+          "Deputy Head Teacher\n" \
+         "To be successful, you will:\n" \
+         "·   Have quality one\n" \
+         "·   Have quality two\n" \
+         "·   Have quality three\n" \
+         "Apply now. ")
+      end
+
+      it "does not reformat" do
+        expect(subject.job_advert).to eq(
+          "<p>Deputy Head Teacher\n<br />" \
+          "To be successful, you will:\n<br />" \
+          "•   Have quality one\n<br />" \
+          "•   Have quality two\n<br />" \
+          "•   Have quality three\n<br />" \
+          "Apply now. </p>",
+        )
+      end
+    end
+
+    context "when the advert is badly formatted (no line breaks between list items)" do
+      let(:vacancy) do
+        build(:vacancy, job_advert:
+          " Sentence one. Sentence two.\n" \
+          "Paragraph two. Qualifications:\n" \
+          "•    Skill one." \
+          "•    Skill two." \
+          "•    Skill three.\n" \
+          "Penultimate paragraph.\n" \
+          "Last paragraph \n")
+      end
+
+      it "transforms badly formatted inline bullet point symbols into validly formatted <li> tags" do
+        expect(subject.job_advert).to eq(
+          "<p> Sentence one. Sentence two.\n<br />" \
+          "Paragraph two. Qualifications:\n<br />" \
+          "<ul>\n<br /><li>    Skill one.</li>\n<br />" \
+          "<li>    Skill two.</li>\n<br />" \
+          "<li>    Skill three.</li>\n<br /></ul>" \
+          "\n<br />Penultimate paragraph.\n<br />" \
+          "Last paragraph </p>",
+        )
+      end
+    end
+
+    # For backwards compatibility. Rich-text editing was removed 16th August 2021.
+    context "when the advert was made using a rich text editor" do
+      context "when the advert is well-formatted (has line breaks between list items)" do
+        let(:vacancy) do
+          build(:vacancy, job_advert:
+            "<div><!--block-->&nbsp;</div><div><!--block--><strong>Deputy Head Teacher</strong>&nbsp;<br><br></div>" \
          "<div><!--block-->To be successful, you will:&nbsp;<br><br></div>" \
          "<div><!--block-->· &nbsp; Have quality one;&nbsp;<br><br></div>" \
          "<div><!--block-->· &nbsp; Have quality two;&nbsp;<br><br></div>" \
          "<div><!--block-->· &nbsp; Have quality three;&nbsp;<br><br></div>" \
          "<div><!--block-->Apply now.&nbsp;</div>")
+        end
+
+        it "does not reformat" do
+          expect(subject.job_advert).to eq(
+            "<p> <strong>Deputy Head Teacher</strong> </p>\n\n" \
+          "<p>To be successful, you will: </p>\n\n" \
+          "<p>•   Have quality one; </p>\n\n" \
+          "<p>•   Have quality two; </p>\n\n" \
+          "<p>•   Have quality three; </p>\n\n" \
+          "<p>Apply now. </p>",
+          )
+        end
       end
 
-      it "does not reformat" do
-        expect(subject.job_advert).to eq(
-          "<p> <strong>Deputy Head Teacher</strong> <br><br>" \
-          "To be successful, you will: <br><br>" \
-          "•   Have quality one; <br><br>" \
-          "•   Have quality two; <br><br>" \
-          "•   Have quality three; <br><br>" \
-          "Apply now. </p>",
-        )
-      end
-    end
-
-    context "when the advert is badly formatted" do
-      let(:vacancy) do
-        build(:vacancy, job_advert:
-          "<div><!--block-->&nbsp;</div><div><!--block-->Sentence one. Sentence two.&nbsp;<br><br></div>" \
+      context "when the advert is badly formatted" do
+        let(:vacancy) do
+          build(:vacancy, job_advert:
+            "<div><!--block-->&nbsp;</div><div><!--block-->Sentence one. Sentence two.&nbsp;<br><br></div>" \
           "<div><!--block-->Paragraph two. Qualifications:&nbsp;<br><br></div>" \
           "<div><!--block-->•&nbsp; &nbsp; Skill one.&nbsp;</div>" \
           "<div><!--block-->•&nbsp; &nbsp; Skill two.&nbsp;</div>" \
           "<div><!--block-->•&nbsp; &nbsp; Skill three.&nbsp;<br><br></div>" \
           "<div><!--block-->Penultimate paragraph.&nbsp;<br><br>" \
           "Last paragraph &nbsp;<br><br></div><div>")
-      end
+        end
 
-      it "transforms badly formatted inline bullet point symbols into validly formatted <li> tags" do
-        expect(subject.job_advert).to eq(
-          "<p> Sentence one. Sentence two. <br><br>" \
-          "Paragraph two. Qualifications: <br><br>" \
-          "<ul>\n<br /><li>  Skill one.</li>\n<br />" \
+        it "transforms badly formatted inline bullet point symbols into validly formatted <li> tags" do
+          expect(subject.job_advert).to eq(
+            "<p> Sentence one. Sentence two. </p>\n\n" \
+          "<p>Paragraph two. Qualifications: </p>\n\n" \
+          "<p><ul>\n<br /><li>  Skill one.</li>\n<br />" \
           "<li>  Skill two.</li>\n<br />" \
-          "<li>  Skill three.</li>\n<br /></ul>" \
-          "<br><br>Penultimate paragraph. <br><br>" \
-          "Last paragraph  <br><br></p>",
-        )
+          "<li>  Skill three.</li>\n<br />" \
+          "</ul></p>\n\n<p>Penultimate paragraph. </p>\n\n" \
+          "<p>Last paragraph  </p>",
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
We removed rich text editing one month ago, but we didn't update this logic.

## Screenshots of UI changes:

### Before

![Screenshot 2021-09-22 at 15 26 06](https://user-images.githubusercontent.com/60350599/134362463-b51edbaa-9e2d-4065-90df-e5127af00154.png)

### After

![Screenshot 2021-09-22 at 15 24 33](https://user-images.githubusercontent.com/60350599/134362146-3dd6f65d-b7df-4bca-9145-abe8d89b7fbe.png)


## Next steps:

- [ ] Tell the user who fed back about this thank you for their feedback
