### PR TITLE
[TEVA-3183] Remove salary question from application form

### DIFF
--- a/app/controllers/jobseekers/job_applications/employments_controller.rb
+++ b/app/controllers/jobseekers/job_applications/employments_controller.rb
@@ -36,7 +36,7 @@ class Jobseekers::JobApplications::EmploymentsController < Jobseekers::BaseContr
 
   def employment_params
     params.require(:jobseekers_job_application_details_employment_form)
-          .permit(:organisation, :job_title, :salary, :subjects, :main_duties, :started_on, :current_role, :ended_on)
+          .permit(:organisation, :job_title, :subjects, :main_duties, :started_on, :current_role, :ended_on)
           .merge("started_on(3i)" => "1", "ended_on(3i)" => "1")
   end
 
@@ -49,7 +49,7 @@ class Jobseekers::JobApplications::EmploymentsController < Jobseekers::BaseContr
     when "new"
       {}
     when "edit"
-      employment.slice(:organisation, :job_title, :salary, :subjects, :main_duties, :started_on, :current_role, :ended_on)
+      employment.slice(:organisation, :job_title, :subjects, :main_duties, :started_on, :current_role, :ended_on)
     when "create", "update"
       employment_params
     end

--- a/app/form_models/jobseekers/job_application/details/employment_form.rb
+++ b/app/form_models/jobseekers/job_application/details/employment_form.rb
@@ -3,7 +3,7 @@ class Jobseekers::JobApplication::Details::EmploymentForm
   include ActiveRecord::AttributeAssignment
   include DateAttributeAssignment
 
-  attr_accessor :organisation, :job_title, :salary, :subjects, :main_duties, :current_role
+  attr_accessor :organisation, :job_title, :subjects, :main_duties, :current_role
   attr_reader :started_on, :ended_on
 
   validates :organisation, :job_title, :main_duties, presence: true

--- a/app/services/jobseekers/job_applications/quick_apply.rb
+++ b/app/services/jobseekers/job_applications/quick_apply.rb
@@ -28,7 +28,6 @@ class Jobseekers::JobApplications::QuickApply
   def attributes_to_copy
     Jobseekers::JobApplication::PersonalDetailsForm.fields +
       Jobseekers::JobApplication::ProfessionalStatusForm.fields +
-      Jobseekers::JobApplication::EmploymentHistoryForm.fields +
       Jobseekers::JobApplication::AskForSupportForm.fields
   end
 
@@ -51,7 +50,7 @@ class Jobseekers::JobApplications::QuickApply
   def copy_employments
     recent_job_application.employments.each do |employment|
       new_employment = employment.dup
-      new_employment.update(job_application: new_job_application)
+      new_employment.update(job_application: new_job_application, salary: "")
     end
   end
 

--- a/app/views/jobseekers/job_applications/build/employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/build/employment_history.html.slim
@@ -20,12 +20,12 @@
           = render DetailComponent.new title: employment.job_title do |detail|
             - detail.body do
               = govuk_summary_list classes: "govuk-!-margin-bottom-0" do |summary_list|
-                - attributes = %w[organisation salary subjects]
-                - attributes.each do |attribute|
-                  - summary_list.row do |row|
-                    - row.key text: t("jobseekers.job_applications.employments.#{attribute}")
-                    - row.value text: employment[attribute].presence || t("jobseekers.job_applications.not_defined")
-
+                - summary_list.row do |row|
+                  - row.key text: t("jobseekers.job_applications.employments.organisation")
+                  - row.value text: employment.organisation.presence
+                - summary_list.row do |row|
+                  - row.key text: t("jobseekers.job_applications.employments.subjects")
+                  - row.value text: employment.subjects.presence || t("jobseekers.job_applications.not_defined")
                 - summary_list.row do |row|
                   - row.key text: t("jobseekers.job_applications.employments.started_on")
                   - row.value text: employment.started_on.to_s(:month_year)

--- a/app/views/jobseekers/job_applications/employments/_fields.html.slim
+++ b/app/views/jobseekers/job_applications/employments/_fields.html.slim
@@ -1,6 +1,5 @@
 = f.govuk_text_field :organisation, label: { size: "s" }, required: true
 = f.govuk_text_field :job_title, label: { size: "s" }, required: true
-= f.govuk_text_field :salary, label: { size: "s" }
 = f.govuk_text_field :subjects, label: { size: "s" }
 = f.govuk_date_field :started_on, omit_day: true
 = f.govuk_radio_buttons_fieldset :current_role do

--- a/app/views/jobseekers/job_applications/review/_employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/review/_employment_history.html.slim
@@ -19,10 +19,6 @@
                   - row.value text: employment.organisation
 
                 - summary_list.row do |row|
-                  - row.key text: t("helpers.label.jobseekers_job_application_details_employment_form.salary_html")
-                  - row.value text: employment.salary.presence || t("jobseekers.job_applications.not_defined")
-
-                - summary_list.row do |row|
                   - row.key text: t("helpers.label.jobseekers_job_application_details_employment_form.subjects_html")
                   - row.value text: employment.subjects.presence || t("jobseekers.job_applications.not_defined")
 

--- a/app/views/pages/job-application-preview.html.slim
+++ b/app/views/pages/job-application-preview.html.slim
@@ -131,7 +131,6 @@
       ul.govuk-list.govuk-list--bullet
         li School or organisation
         li Job title
-        li Salary
         li Subjects and key stages taught (if applicable)
         li Start date
         li End date (if applicable)

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -6,7 +6,6 @@ en:
     add_another_job: Add another job
     add_another_qualification: Add another qualification
     add_another_reference: Add another referee
-    add_employment: Add a role
     add_qualification: Add a qualification
     add_reference: Add a referee
     add_another_subject: + Add another subject

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -27,15 +27,6 @@ namespace :dsi do
   end
 end
 
-namespace :column_encryption do
-  desc "Migrate encrypted columns"
-  task migrate: :environment do
-    [
-      Employment, JobApplication, Jobseeker, Publisher, Qualification, Reference
-    ].each { |klass| Lockbox.migrate(klass, batch_size: 100) }
-  end
-end
-
 namespace :gias do
   desc "Import schools, trusts and local authorities data"
   task import_schools: :environment do
@@ -53,5 +44,14 @@ namespace :ons do
   desc "Import all location polygons"
   task import_location_polygons: :environment do
     %i[regions counties cities].each { |api_location_type| ImportPolygons.new(api_location_type: api_location_type).call }
+  end
+end
+
+namespace :job_application_schema do
+  desc "Remove salary data from all draft applications"
+  task remove_salary: :environment do
+    Employment.includes(:job_application).find_each(batch_size: 100) do |employment|
+      employment.update_columns(salary: "") if employment.job_application.draft?
+    end
   end
 end

--- a/spec/services/jobseekers/job_applications/quick_apply_spec.rb
+++ b/spec/services/jobseekers/job_applications/quick_apply_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Jobseekers::JobApplications::QuickApply do
     end
 
     it "copies employments" do
-      attributes_to_copy = %i[organisation job_title salary subjects current_role main_duties started_on ended_on]
+      attributes_to_copy = %i[organisation job_title subjects current_role main_duties started_on ended_on]
 
       expect(subject.employments.map { |employment| employment.slice(*attributes_to_copy) })
         .to eq(recent_job_application.employments.map { |employment| employment.slice(*attributes_to_copy) })

--- a/spec/system/jobseekers_can_review_a_job_application_spec.rb
+++ b/spec/system/jobseekers_can_review_a_job_application_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe "Jobseekers can review a job application" do
       job_application.employments.job.each do |employment|
         expect(page).to have_content(employment.job_title)
         expect(page).to have_content(employment.organisation)
-        expect(page).to have_content(employment.salary)
         expect(page).to have_content(employment.subjects)
         expect(page).to have_content(employment.main_duties)
         expect(page).to have_content(employment.started_on)


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3183

## Changes in this PR:

- Remove salary question from application form

- Also remove salary data from all unsubmitted (draft) applications. (The data remains for submitted applications.)

This decision is justified below:

"Following a conversation with the leader of The Women in Ed network, we have removed the previous salary question that was asked in the Current role and employment history section of the application form.

This is to position DFE as a leader in this space, as the Women in Ed network are releasing a report in October championing the removal of this question across the industry."