### PR TITLE
Tighten rubocop method length metric

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -83,40 +83,39 @@ Naming/AccessorMethodName:
 # We should consider slowly moving closer to the default settings.
 
 Metrics/AbcSize:
-  Max: 40
+  Max: 40 # Default 17
   Exclude:
     - "config/**/*"
     - "lib/**/*"
     - "spec/**/*"
 
 Metrics/BlockLength:
-  Max: 75
+  Max: 75 # Default 25
   Exclude:
     - "config/**/*"
     - "spec/**/*"
 
 Metrics/ClassLength:
-  Max: 200
+  Max: 200 # Default 100
 
 Metrics/CyclomaticComplexity:
-  Max: 20
+  Max: 20 # Default 7
   Exclude:
     - "spec/**/*"
 
 Metrics/MethodLength:
-  Max: 25
+  Max: 18 # Default 10
   Exclude:
     - "config/**/*"
-    - "lib/**/*"
     - "spec/**/*"
 
 Metrics/ModuleLength:
-  Max: 210
+  Max: 210 # Default 100
 
 Metrics/ParameterLists:
-  Max: 8
+  Max: 8 # Default 5
 
 Metrics/PerceivedComplexity:
-  Max: 20
+  Max: 20 # Default 8
   Exclude:
     - "spec/**/*"

--- a/app/components/jobseekers/search_results/heading_component.rb
+++ b/app/components/jobseekers/search_results/heading_component.rb
@@ -6,27 +6,28 @@ class Jobseekers::SearchResults::HeadingComponent < ViewComponent::Base
     @polygon_boundaries = @vacancies_search.location_search.polygon_boundaries
     @radius = @vacancies_search.search_criteria[:radius]
     @total_count = @vacancies_search.total_count
+    @readable_count = number_with_delimiter(@total_count)
   end
 
   def heading
     if @keyword.present? && @polygon_boundaries.present?
-      t("jobs.search_result_heading.keyword_location_polygon_html",
-        jobs_count: number_with_delimiter(@total_count), location: @location, keyword: @keyword, count: @total_count, radius: @radius, units: t("jobs.search_result_heading.unit_of_length").pluralize(@radius.to_i))
+      t("jobs.search_result_heading.keyword_location_polygon_html", jobs_count: @readable_count, location: @location, keyword: @keyword, count: @total_count, radius: @radius, units: units)
     elsif @keyword.present? && @location.present?
-      t("jobs.search_result_heading.keyword_location_html",
-        jobs_count: number_with_delimiter(@total_count), location: @location, keyword: @keyword, count: @total_count, radius: @radius, units: t("jobs.search_result_heading.unit_of_length").pluralize(@radius.to_i))
+      t("jobs.search_result_heading.keyword_location_html", jobs_count: @readable_count, location: @location, keyword: @keyword, count: @total_count, radius: @radius, units: units)
     elsif @keyword.present?
-      t("jobs.search_result_heading.keyword_html",
-        jobs_count: number_with_delimiter(@total_count), keyword: @keyword, count: @total_count)
+      t("jobs.search_result_heading.keyword_html", jobs_count: @readable_count, keyword: @keyword, count: @total_count)
     elsif @polygon_boundaries.present?
-      t("jobs.search_result_heading.location_polygon_html",
-        jobs_count: number_with_delimiter(@total_count), location: @location, count: @total_count, radius: @radius, units: t("jobs.search_result_heading.unit_of_length").pluralize(@radius.to_i))
+      t("jobs.search_result_heading.location_polygon_html", jobs_count: @readable_count, location: @location, count: @total_count, radius: @radius, units: units)
     elsif @location.present?
-      t("jobs.search_result_heading.location_html",
-        jobs_count: number_with_delimiter(@total_count), location: @location, count: @total_count, radius: @radius, units: t("jobs.search_result_heading.unit_of_length").pluralize(@radius.to_i))
+      t("jobs.search_result_heading.location_html", jobs_count: @readable_count, location: @location, count: @total_count, radius: @radius, units: units)
     else
-      t("jobs.search_result_heading.without_search_html",
-        jobs_count: number_with_delimiter(@total_count), count: @total_count)
+      t("jobs.search_result_heading.without_search_html", jobs_count: @readable_count, count: @total_count)
     end
+  end
+
+  private
+
+  def units
+    t("jobs.search_result_heading.unit_of_length").pluralize(@radius.to_i)
   end
 end

--- a/app/controllers/jobseekers/sessions_controller.rb
+++ b/app/controllers/jobseekers/sessions_controller.rb
@@ -15,17 +15,20 @@ class Jobseekers::SessionsController < Devise::SessionsController
 
   def render_resource_with_errors
     self.resource = resource_class.new
-    form = Jobseekers::SignInForm.new(sign_in_params)
-    if params[:action] == "create" && form.invalid?
-      form.errors.each { |error| resource.errors.add(error.attribute, error.type) }
-      trigger_jobseeker_sign_in_event(:failure, resource.errors)
-      clear_flash_and_render(:new)
+    if params[:action] == "create" && sign_in_form.invalid?
+      sign_in_form.errors.each { |error| resource.errors.add(error.attribute, error.type) }
     elsif AUTHENTICATION_FAILURE_MESSAGES.include?(flash[:alert])
       resource.errors.add(:email, flash[:alert])
       resource.errors.add(:password, "")
-      trigger_jobseeker_sign_in_event(:failure, resource.errors)
-      clear_flash_and_render(:new)
+    else
+      return
     end
+    trigger_jobseeker_sign_in_event(:failure, resource.errors)
+    clear_flash_and_render(:new)
+  end
+
+  def sign_in_form
+    @sign_in_form ||= Jobseekers::SignInForm.new(sign_in_params)
   end
 
   def check_if_access_locked

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -17,8 +17,7 @@ class SubscriptionsController < ApplicationController
     elsif recaptcha_is_invalid?(subscription)
       redirect_to invalid_recaptcha_path(form_name: subscription.class.name.underscore.humanize)
     else
-      subscription.recaptcha_score = recaptcha_reply&.dig("score")
-      subscription.save
+      subscription.update(recaptcha_score: recaptcha_reply&.dig("score"))
       Jobseekers::SubscriptionMailer.confirmation(subscription.id).deliver_later
       trigger_subscription_event(:job_alert_subscription_created, subscription)
 

--- a/app/services/import_polygons.rb
+++ b/app/services/import_polygons.rb
@@ -79,17 +79,15 @@ class ImportPolygons
       "geometries" => [{ "rings" => [coords] }],
     }
 
-    params = { "geometries" => geometries_param.to_s,
-               "inSR" => "4326",
-               "outSR" => "4326",
-               "bufferSR" => "3857",
-               "distances" => distance.to_s,
-               "unit" => "",
-               "unionResults" => "true",
-               "geodesic" => "false",
-               "f" => "json" }.to_param
-
-    api_endpoint = BUFFER_API_URL + params
+    api_endpoint = BUFFER_API_URL + { "geometries" => geometries_param.to_s,
+                                      "inSR" => "4326",
+                                      "outSR" => "4326",
+                                      "bufferSR" => "3857",
+                                      "distances" => distance.to_s,
+                                      "unit" => "",
+                                      "unionResults" => "true",
+                                      "geodesic" => "false",
+                                      "f" => "json" }.to_param
 
     if api_endpoint.length > URL_MAXIMUM_LENGTH
       # Reduce number of coordinates in order to have not too many characters in request url

--- a/app/services/publishers/vacancy_sort.rb
+++ b/app/services/publishers/vacancy_sort.rb
@@ -19,31 +19,41 @@ class Publishers::VacancySort < RecordSort
   def base_options
     case @vacancy_type
     when "published"
-      [
-        SortOption.new("expires_at", "asc", I18n.t("jobs.sort_by.expires_at.ascending.vacancy.publisher")),
-        SortOption.new("job_title", "asc", I18n.t("jobs.sort_by.job_title.ascending")),
-      ]
+      [soonest_closing_date_option, job_title_option]
     when "pending"
-      [
-        SortOption.new("publish_on", "desc", I18n.t("jobs.sort_by.published_date.descending")),
-        SortOption.new("expires_at", "asc", I18n.t("jobs.sort_by.expires_at.ascending.vacancy.publisher")),
-        SortOption.new("job_title", "asc", I18n.t("jobs.sort_by.job_title.ascending")),
-      ]
+      [soonest_publication_date_option, soonest_closing_date_option, job_title_option]
     when "draft"
-      [
-        SortOption.new("created_at", "desc", I18n.t("jobs.sort_by.created_at.descending.vacancy")),
-        SortOption.new("updated_at", "desc", I18n.t("jobs.sort_by.updated_at.descending")),
-        SortOption.new("job_title", "asc", I18n.t("jobs.sort_by.job_title.ascending")),
-      ]
+      [most_recent_draft_date_option, most_recent_update_option, job_title_option]
     when "expired", "awaiting_feedback"
-      [
-        SortOption.new("expires_at", "desc", I18n.t("jobs.sort_by.expires_at.descending.vacancy.publisher")),
-        SortOption.new("job_title", "asc", I18n.t("jobs.sort_by.job_title.ascending")),
-      ]
+      [most_recent_end_date_option, job_title_option]
     end
+  end
+
+  def job_title_option
+    SortOption.new("job_title", "asc", I18n.t("jobs.sort_by.job_title_option.ascending"))
+  end
+
+  def most_recent_draft_date_option
+    SortOption.new("created_at", "desc", I18n.t("jobs.sort_by.created_at.descending.vacancy"))
+  end
+
+  def most_recent_end_date_option
+    SortOption.new("expires_at", "desc", I18n.t("jobs.sort_by.expires_at.descending.vacancy.publisher"))
+  end
+
+  def most_recent_update_option
+    SortOption.new("updated_at", "desc", I18n.t("jobs.sort_by.updated_at.descending"))
   end
 
   def readable_job_location_option
     SortOption.new("readable_job_location", "asc", I18n.t("jobs.sort_by.location.ascending"))
+  end
+
+  def soonest_closing_date_option
+    SortOption.new("expires_at", "asc", I18n.t("jobs.sort_by.expires_at.ascending.vacancy.publisher"))
+  end
+
+  def soonest_publication_date_option
+    SortOption.new("publish_on", "desc", I18n.t("jobs.sort_by.published_date.descending"))
   end
 end

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -67,52 +67,52 @@ en:
 
     search_result_heading:
       without_search_html:
-        one: There is <span class='govuk-!-font-weight-bold'>%{count}</span> job listed
-        other: There are <span class='govuk-!-font-weight-bold'>%{count}</span> jobs listed
+        one: There is <span class='govuk-!-font-weight-bold'>%{jobs_count}</span> job listed
+        other: There are <span class='govuk-!-font-weight-bold'>%{jobs_count}</span> jobs listed
       keyword_html:
         one: >-
-          <span class='govuk-!-font-weight-bold'>%{count}</span> job matches
+          <span class='govuk-!-font-weight-bold'>%{jobs_count}</span> job matches
           <span class='govuk-!-font-weight-bold text-wrap-apostrophe'>%{keyword}</span>
         other: >-
-          <span class='govuk-!-font-weight-bold'>%{count}</span> jobs match
+          <span class='govuk-!-font-weight-bold'>%{jobs_count}</span> jobs match
           <span class='govuk-!-font-weight-bold text-wrap-apostrophe'>%{keyword}</span>
       location_html:
         one: >-
-          <span class="govuk-!-font-weight-bold">%{count}</span> job found within
+          <span class="govuk-!-font-weight-bold">%{jobs_count}</span> job found within
           <span class='govuk-!-font-weight-bold'>%{radius} %{units}</span> of
           <span class='govuk-!-font-weight-bold text-capitalize text-wrap-apostrophe'>%{location}</span>
         other: >-
-          <span class="govuk-!-font-weight-bold">%{count}</span> jobs found within
+          <span class="govuk-!-font-weight-bold">%{jobs_count}</span> jobs found within
           <span class='govuk-!-font-weight-bold'>%{radius} %{units}</span> of
           <span class="govuk-!-font-weight-bold text-capitalize text-wrap-apostrophe">%{location}</span>
       location_polygon_html:
         one: >-
-          <span class="govuk-!-font-weight-bold">%{count}</span> job found within
+          <span class="govuk-!-font-weight-bold">%{jobs_count}</span> job found within
           <span class='govuk-!-font-weight-bold'>%{radius} %{units}</span> of
           <span class='govuk-!-font-weight-bold text-capitalize text-wrap-apostrophe'>%{location}</span>
         other: >-
-          <span class="govuk-!-font-weight-bold">%{count}</span> jobs found within
+          <span class="govuk-!-font-weight-bold">%{jobs_count}</span> jobs found within
           <span class='govuk-!-font-weight-bold'>%{radius} %{units}</span> of
           <span class="govuk-!-font-weight-bold text-capitalize text-wrap-apostrophe">%{location}</span>
       keyword_location_html:
         one: >-
-          <span class='govuk-!-font-weight-bold'>%{count}</span> job matches
+          <span class='govuk-!-font-weight-bold'>%{jobs_count}</span> job matches
           <span class='govuk-!-font-weight-bold text-wrap-apostrophe'>%{keyword}</span> within
           <span class='govuk-!-font-weight-bold'>%{radius} %{units}</span> of
           <span class='govuk-!-font-weight-bold text-wrap-apostrophe text-capitalize'>%{location}</span>
         other: >-
-          <span class="govuk-!-font-weight-bold">%{count}</span> jobs match
+          <span class="govuk-!-font-weight-bold">%{jobs_count}</span> jobs match
           <span class='govuk-!-font-weight-bold text-wrap-apostrophe'>%{keyword}</span> within
           <span class='govuk-!-font-weight-bold'>%{radius} %{units}</span> of
           <span class="govuk-!-font-weight-bold text-wrap-apostrophe text-capitalize">%{location}</span>
       keyword_location_polygon_html:
         one: >-
-          <span class='govuk-!-font-weight-bold'>%{count}</span> job matches
+          <span class='govuk-!-font-weight-bold'>%{jobs_count}</span> job matches
           <span class='govuk-!-font-weight-bold text-wrap-apostrophe'>%{keyword}</span> within
           <span class='govuk-!-font-weight-bold'>%{radius} %{units}</span> of
           <span class='govuk-!-font-weight-bold text-wrap-apostrophe text-capitalize'>%{location}</span>
         other: >-
-          <span class="govuk-!-font-weight-bold">%{count}</span> jobs match
+          <span class="govuk-!-font-weight-bold">%{jobs_count}</span> jobs match
           <span class='govuk-!-font-weight-bold text-wrap-apostrophe'>%{keyword}</span> within
           <span class='govuk-!-font-weight-bold'>%{radius} %{units}</span> of
           <span class="govuk-!-font-weight-bold text-wrap-apostrophe text-capitalize">%{location}</span>

--- a/lib/organisation_import/import_school_data.rb
+++ b/lib/organisation_import/import_school_data.rb
@@ -21,6 +21,8 @@ class ImportSchoolData < ImportOrganisationData
     membership.update!(do_not_delete: true)
   end
 
+  # No point refactoring this method to be shorter as this class is currently being rewritten elsewhere.
+  # rubocop:disable Metrics/MethodLength
   def column_name_mappings
     {
       address: "Street",
@@ -43,6 +45,7 @@ class ImportSchoolData < ImportOrganisationData
       url: "SchoolWebsite",
     }.freeze
   end
+  # rubocop:enable Metrics/MethodLength
 
   def column_value_transformations
     {

--- a/spec/components/jobseekers/search_results/heading_component_spec.rb
+++ b/spec/components/jobseekers/search_results/heading_component_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Jobseekers::SearchResults::HeadingComponent, type: :component do
   context "when keyword and search polygon boundaries are present" do
     it "renders correct heading" do
       expect(rendered_component).to include(
-        I18n.t("jobs.search_result_heading.keyword_location_polygon_html", keyword: keyword, location: location, count: count, radius: radius, units: I18n.t("jobs.search_result_heading.unit_of_length").pluralize(radius.to_i)),
+        I18n.t("jobs.search_result_heading.keyword_location_polygon_html", jobs_count: count, keyword: keyword, location: location, count: count, radius: radius, units: I18n.t("jobs.search_result_heading.unit_of_length").pluralize(radius.to_i)),
       )
     end
   end
@@ -32,7 +32,7 @@ RSpec.describe Jobseekers::SearchResults::HeadingComponent, type: :component do
 
     it "renders correct heading" do
       expect(rendered_component).to include(
-        I18n.t("jobs.search_result_heading.keyword_location_html", keyword: keyword, location: location, count: count, radius: radius, units: I18n.t("jobs.search_result_heading.unit_of_length").pluralize(radius.to_i)),
+        I18n.t("jobs.search_result_heading.keyword_location_html", jobs_count: count, keyword: keyword, location: location, count: count, radius: radius, units: I18n.t("jobs.search_result_heading.unit_of_length").pluralize(radius.to_i)),
       )
     end
   end
@@ -43,7 +43,7 @@ RSpec.describe Jobseekers::SearchResults::HeadingComponent, type: :component do
 
     it "renders correct heading" do
       expect(rendered_component).to include(
-        I18n.t("jobs.search_result_heading.keyword_html", keyword: keyword, count: count),
+        I18n.t("jobs.search_result_heading.keyword_html", jobs_count: count, keyword: keyword, count: count),
       )
     end
   end
@@ -55,7 +55,7 @@ RSpec.describe Jobseekers::SearchResults::HeadingComponent, type: :component do
 
     it "renders correct heading" do
       expect(rendered_component).to include(
-        I18n.t("jobs.search_result_heading.location_polygon_html", location: location, count: count, radius: radius, units: I18n.t("jobs.search_result_heading.unit_of_length").pluralize(radius.to_i)),
+        I18n.t("jobs.search_result_heading.location_polygon_html", jobs_count: count, location: location, count: count, radius: radius, units: I18n.t("jobs.search_result_heading.unit_of_length").pluralize(radius.to_i)),
       )
     end
   end
@@ -68,7 +68,7 @@ RSpec.describe Jobseekers::SearchResults::HeadingComponent, type: :component do
 
     it "renders correct heading" do
       expect(rendered_component).to include(
-        I18n.t("jobs.search_result_heading.location_html", location: location, count: count, radius: radius, units: I18n.t("jobs.search_result_heading.unit_of_length").pluralize(radius.to_i)),
+        I18n.t("jobs.search_result_heading.location_html", jobs_count: count, location: location, count: count, radius: radius, units: I18n.t("jobs.search_result_heading.unit_of_length").pluralize(radius.to_i)),
       )
     end
   end
@@ -80,7 +80,7 @@ RSpec.describe Jobseekers::SearchResults::HeadingComponent, type: :component do
 
     it "renders correct heading" do
       expect(rendered_component).to include(
-        I18n.t("jobs.search_result_heading.without_search_html", count: count),
+        I18n.t("jobs.search_result_heading.without_search_html", jobs_count: count, count: count),
       )
     end
   end

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe SubscriptionsController, recaptcha: true do
         end
 
         it "sets the recaptcha score on the Subscription record" do
-          expect(subscription).to receive(:recaptcha_score=).with(recaptcha_score)
+          expect(subscription).to receive(:update).with(recaptcha_score: recaptcha_score)
           subject
         end
       end


### PR DESCRIPTION
Some minor refactoring on theme of reducing method lengths.

Hopefully these methods are more readable, and the improved metric, being one notch closer to the rubocop default, will encourage us to keep methods concise in the future.