### PR TITLE
Tighten rubocop ABC size metric

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -83,23 +83,23 @@ Naming/AccessorMethodName:
 # We should consider slowly moving closer to the default settings.
 
 Metrics/AbcSize:
-  Max: 40 # Default 17
+  Max: 32 # Default 17
   Exclude:
     - "config/**/*"
     - "lib/**/*"
     - "spec/**/*"
 
 Metrics/BlockLength:
-  Max: 75 # Default 25
+  Max: 70 # Default 25
   Exclude:
     - "config/**/*"
     - "spec/**/*"
 
 Metrics/ClassLength:
-  Max: 200 # Default 100
+  Max: 156 # Default 100
 
 Metrics/CyclomaticComplexity:
-  Max: 20 # Default 7
+  Max: 18 # Default 7
   Exclude:
     - "spec/**/*"
 
@@ -110,12 +110,14 @@ Metrics/MethodLength:
     - "spec/**/*"
 
 Metrics/ModuleLength:
-  Max: 210 # Default 100
+  Max: 113 # Default 100
+  Exclude:
+    - "spec/**/*"
 
 Metrics/ParameterLists:
-  Max: 8 # Default 5
+  Max: 7 # Default 5
 
 Metrics/PerceivedComplexity:
-  Max: 20 # Default 8
+  Max: 18 # Default 8
   Exclude:
     - "spec/**/*"

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -57,10 +57,6 @@ module Indexable
           towns: organisations.map(&:town).reject(&:blank?).uniq }
       end
 
-      attribute :permalink do
-        slug
-      end
-
       attribute :publication_date do
         publish_on&.to_s
       end


### PR DESCRIPTION
Refactor by tightening rubocop metrics

    A few things are rewritten to decrease ABC size.

    Other metrics are reduced to as low as they can go without forcing me to
    refactor more things, in order to keep the code relatively simple going
    forwards.

    We do not need to index the slug as 'permalink': this is a hangover
    from the initial migration from ElasticSearch to Algolia, when there
    was a possibility that we would use Algolia javascript in the front end
    to update search results without reloading the page. This is not going
    to happen.

    https://github.com/DFE-Digital/teaching-vacancies/commit/1ebc5b3fcfbda8580d5cfb803829616af4a8b256
    is the commit when we renamed 'slug' to 'permalink' for the sake of readability
    on the Algolia dashboard, but we don't need to index this attribute, as I say.
