### PR TITLE
[TEVA-2391] Add date validation to prevent far future dates

### DIFF
--- a/app/form_models/publishers/job_listing/extend_deadline_form.rb
+++ b/app/form_models/publishers/job_listing/extend_deadline_form.rb
@@ -6,9 +6,9 @@ class Publishers::JobListing::ExtendDeadlineForm
   attr_accessor :expiry_time, :starts_asap, :previous_deadline
   attr_reader :expires_at, :starts_on
 
-  validates :expires_at, date: { on_or_after: :now, after: :previous_deadline }
+  validates :expires_at, date: { on_or_after: :now, on_or_before: :far_future, after: :previous_deadline }
   validates :expiry_time, inclusion: { in: Vacancy::EXPIRY_TIME_OPTIONS }
-  validates :starts_on, date: { on_or_after: :today, after: :expires_at }, allow_blank: true,
+  validates :starts_on, date: { on_or_after: :today, on_or_before: :far_future, after: :expires_at }, allow_blank: true,
                         if: proc { starts_asap == "0" }
   validate :starts_on_and_starts_asap_not_present
 

--- a/app/form_models/publishers/job_listing/important_dates_form.rb
+++ b/app/form_models/publishers/job_listing/important_dates_form.rb
@@ -7,10 +7,10 @@ class Publishers::JobListing::ImportantDatesForm < Publishers::JobListing::Vacan
   attr_writer :publish_on_day
 
   validates :publish_on_day, inclusion: { in: %w[today tomorrow another_day] }, unless: :disable_editing_publish_on?
-  validates :publish_on, date: { on_or_after: :today }, if: proc { !disable_editing_publish_on? && publish_on_day == "another_day" }
-  validates :expires_at, date: { on_or_after: :now, after: :publish_on }
+  validates :publish_on, date: { on_or_after: :today, on_or_before: :far_future }, if: proc { !disable_editing_publish_on? && publish_on_day == "another_day" }
+  validates :expires_at, date: { on_or_after: :now, on_or_before: :far_future, after: :publish_on }
   validates :expiry_time, inclusion: { in: Vacancy::EXPIRY_TIME_OPTIONS }
-  validates :starts_on, date: { on_or_after: :today, after: :expires_at }, allow_blank: true,
+  validates :starts_on, date: { on_or_after: :today, on_or_before: :far_future, after: :expires_at }, allow_blank: true,
                         if: proc { starts_asap == "0" }
   validate :starts_on_and_starts_asap_not_present
 

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -9,6 +9,7 @@ class DateValidator < ActiveModel::EachValidator
   DEFAULT_CHECK_VALUES = {
     today: Date.current,
     now: Time.current,
+    far_future: 2.years.from_now,
   }.freeze
 
   def validate_each(record, attribute, value)

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -151,6 +151,7 @@ en:
       blank: Enter a closing date
       invalid: Enter a date in the correct format
       on_or_after: The closing date must be in the future
+      on_or_before: The closing date must be less than two years in the future
     expiry_time:
       inclusion: Choose the time the application is due from the options provided
     publish_on_day:
@@ -159,11 +160,13 @@ en:
       blank: Enter the date the job will be listed
       invalid: Enter a date in the correct format
       on_or_after: The date the job will be listed must be either today or in the future
+      on_or_before: The date the job will be listed must be less than two years in the future
     starts_on:
       after: The date the job starts must be after the closing date
       date_and_asap: Select either a start date or 'As soon as possible'
       invalid: Enter a date in the correct format
       on_or_after: The date the job starts must be in the future
+      on_or_before: The date the job starts must be less than two years in the future
   applying_for_the_job_errors: &applying_for_the_job_errors
     application_link:
       url: Enter a link in the correct format, like http://www.school.ac.uk
@@ -285,6 +288,7 @@ en:
               blank: Enter a closing date
               invalid: Enter a date in the correct format
               on_or_after: The closing date must be in the future
+              on_or_before: The closing date must be less than two years in the future
         publishers/organisation_form:
           attributes:
             <<: *organisation_errors

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -133,8 +133,8 @@ FactoryBot.define do
     trait :future_publish do
       status { :published }
       publish_on { Date.current + 6.months }
-      expires_at { 2.years.from_now.change(hour: 9, minute: 0) }
-      starts_on { 2.years.from_now + 2.months }
+      expires_at { 18.months.from_now.change(hour: 9, minute: 0) }
+      starts_on { 18.months.from_now + 2.months }
     end
 
     trait :past_publish do

--- a/spec/form_models/publishers/job_listing/extend_deadline_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/extend_deadline_form_spec.rb
@@ -79,6 +79,15 @@ RSpec.describe Publishers::JobListing::ExtendDeadlineForm, type: :model do
         expect(subject.errors.of_kind?(:expires_at, :on_or_after)).to be true
       end
     end
+
+    context "when date is too far in the future" do
+      let(:expires_at) { 25.months.from_now }
+
+      it "is invalid" do
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:expires_at, :on_or_before)).to be true
+      end
+    end
   end
 
   describe "starts_on" do
@@ -106,6 +115,15 @@ RSpec.describe Publishers::JobListing::ExtendDeadlineForm, type: :model do
       it "is invalid" do
         expect(subject).not_to be_valid
         expect(subject.errors.of_kind?(:starts_on, :on_or_after)).to be true
+      end
+    end
+
+    context "when date is too far in the future" do
+      let(:starts_on) { 25.months.from_now }
+
+      it "is invalid" do
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:starts_on, :on_or_before)).to be true
       end
     end
 

--- a/spec/form_models/publishers/job_listing/important_dates_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/important_dates_form_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
   let(:publish_on_day) { "another_day" }
   let(:publish_on) { 6.months.from_now }
   let(:expires_at) { 1.year.from_now }
-  let(:starts_on) { 2.years.from_now }
+  let(:starts_on) { 18.months.from_now }
   let(:starts_asap) { "0" }
 
   let(:params) do
@@ -71,7 +71,7 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
         let(:vacancy) { build_stubbed(:vacancy, :published, publish_on: Date.current + 1.day) }
 
         it "is invalid" do
-          expect(subject).not_to be_valid
+          expect(subject).to be_invalid
           expect(subject.errors.of_kind?(:publish_on, :blank)).to be true
         end
       end
@@ -80,7 +80,7 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
         let(:vacancy) { build_stubbed(:vacancy, :draft) }
 
         it "is invalid" do
-          expect(subject).not_to be_valid
+          expect(subject).to be_invalid
           expect(subject.errors.of_kind?(:publish_on, :blank)).to be true
         end
       end
@@ -101,7 +101,7 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
         let(:vacancy) { build_stubbed(:vacancy, :published, publish_on: Date.current + 1.day) }
 
         it "is invalid" do
-          expect(subject).not_to be_valid
+          expect(subject).to be_invalid
           expect(subject.errors.of_kind?(:publish_on, :invalid)).to be true
         end
       end
@@ -110,7 +110,7 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
         let(:vacancy) { build_stubbed(:vacancy, :draft) }
 
         it "is invalid" do
-          expect(subject).not_to be_valid
+          expect(subject).to be_invalid
           expect(subject.errors.of_kind?(:publish_on, :invalid)).to be true
         end
       end
@@ -131,7 +131,7 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
         let(:vacancy) { build_stubbed(:vacancy, :published, publish_on: Date.current + 1.day) }
 
         it "is invalid" do
-          expect(subject).not_to be_valid
+          expect(subject).to be_invalid
           expect(subject.errors.of_kind?(:publish_on, :invalid)).to be true
         end
       end
@@ -140,7 +140,7 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
         let(:vacancy) { build_stubbed(:vacancy, :draft) }
 
         it "is invalid" do
-          expect(subject).not_to be_valid
+          expect(subject).to be_invalid
           expect(subject.errors.of_kind?(:publish_on, :invalid)).to be true
         end
       end
@@ -161,9 +161,18 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
         let(:vacancy) { build_stubbed(:vacancy, :draft) }
 
         it "is invalid" do
-          expect(subject).not_to be_valid
+          expect(subject).to be_invalid
           expect(subject.errors.of_kind?(:publish_on, :on_or_after)).to be true
         end
+      end
+    end
+
+    context "when date is too far in the future" do
+      let(:publish_on) { 25.months.from_now }
+
+      it "is invalid" do
+        expect(subject).to be_invalid
+        expect(subject.errors.of_kind?(:publish_on, :on_or_before)).to be true
       end
     end
   end
@@ -177,7 +186,7 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
       end
 
       it "is invalid" do
-        expect(subject).not_to be_valid
+        expect(subject).to be_invalid
         expect(subject.errors.of_kind?(:expires_at, :blank)).to be true
       end
     end
@@ -186,7 +195,7 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
       before { params["expires_at(2i)"] = "" }
 
       it "is invalid" do
-        expect(subject).not_to be_valid
+        expect(subject).to be_invalid
         expect(subject.errors.of_kind?(:expires_at, :invalid)).to be true
       end
     end
@@ -195,7 +204,7 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
       before { params["expires_at(2i)"] = "100" }
 
       it "is invalid" do
-        expect(subject).not_to be_valid
+        expect(subject).to be_invalid
         expect(subject.errors.of_kind?(:expires_at, :invalid)).to be true
       end
     end
@@ -204,8 +213,17 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
       let(:expires_at) { 1.month.ago }
 
       it "is invalid" do
-        expect(subject).not_to be_valid
+        expect(subject).to be_invalid
         expect(subject.errors.of_kind?(:expires_at, :on_or_after)).to be true
+      end
+    end
+
+    context "when date is too far in the future" do
+      let(:expires_at) { 25.months.from_now }
+
+      it "is invalid" do
+        expect(subject).to be_invalid
+        expect(subject.errors.of_kind?(:expires_at, :on_or_before)).to be true
       end
     end
 
@@ -213,7 +231,7 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
       let(:expires_at) { 3.months.from_now }
 
       it "is invalid" do
-        expect(subject).not_to be_valid
+        expect(subject).to be_invalid
         expect(subject.errors.of_kind?(:expires_at, :after)).to be true
       end
     end
@@ -224,7 +242,7 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
       before { params["starts_on(2i)"] = "" }
 
       it "is invalid" do
-        expect(subject).not_to be_valid
+        expect(subject).to be_invalid
         expect(subject.errors.of_kind?(:starts_on, :invalid)).to be true
       end
     end
@@ -233,7 +251,7 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
       before { params["starts_on(2i)"] = "100" }
 
       it "is invalid" do
-        expect(subject).not_to be_valid
+        expect(subject).to be_invalid
         expect(subject.errors.of_kind?(:starts_on, :invalid)).to be true
       end
     end
@@ -242,8 +260,17 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
       let(:starts_on) { 1.year.ago }
 
       it "is invalid" do
-        expect(subject).not_to be_valid
+        expect(subject).to be_invalid
         expect(subject.errors.of_kind?(:starts_on, :on_or_after)).to be true
+      end
+    end
+
+    context "when date is too far in the future" do
+      let(:starts_on) { 25.months.from_now }
+
+      it "is invalid" do
+        expect(subject).to be_invalid
+        expect(subject.errors.of_kind?(:starts_on, :on_or_before)).to be true
       end
     end
 
@@ -251,7 +278,7 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
       let(:starts_on) { 9.months.from_now }
 
       it "is invalid" do
-        expect(subject).not_to be_valid
+        expect(subject).to be_invalid
         expect(subject.errors.of_kind?(:starts_on, :after)).to be true
       end
     end
@@ -260,7 +287,7 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
       let(:starts_asap) { "true" }
 
       it "is invalid" do
-        expect(subject).not_to be_valid
+        expect(subject).to be_invalid
         expect(subject.errors.of_kind?(:starts_on, :date_and_asap)).to be true
       end
     end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2391

## Changes in this PR:

Hiring staff had accidentally entered dates such as 20221, resulting in interesting job listings that said things like '1,323,345,450 days remaining to apply'.

By the year 20221, we might be using a different calendar system (I consider this unlikely, due to path dependence); or humanity itself may have been superseded.

Therefore we should check that these dates are no more than two years in the future.

## Screenshots of UI changes:

<img width="620" alt="Screenshot 2021-09-23 at 17 08 22" src="https://user-images.githubusercontent.com/60350599/134543803-2de71ba6-2dd0-4843-98b7-f5b1352bb59d.png">

<img width="620" alt="Screenshot 2021-09-23 at 17 09 14" src="https://user-images.githubusercontent.com/60350599/134543942-34932022-bea9-41ae-9ac6-2012c6fa8737.png">


