### PR TITLE
[TEVA-3189] Remove row.html_attributes and fix anchors

### DIFF
--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -1,0 +1,5 @@
+module FormsHelper
+  def render_divs_for_fields(form_model)
+    safe_join(form_model.fields.map { |field| tag.div(id: field) })
+  end
+end

--- a/app/views/jobseekers/job_applications/review.html.slim
+++ b/app/views/jobseekers/job_applications/review.html.slim
@@ -7,8 +7,6 @@
   .govuk-caption-l class="govuk-!-margin-top-5" = t("jobseekers.job_applications.caption", job_title: vacancy.job_title, organisation: vacancy.parent_organisation_name)
   h1.govuk-heading-xl class="govuk-!-margin-bottom-5" = t("jobseekers.job_applications.heading")
 
-- @job_application.errors.add(:gender, message: "this is an error")
-
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     / TODO: Confirm content

--- a/app/views/jobseekers/job_applications/review.html.slim
+++ b/app/views/jobseekers/job_applications/review.html.slim
@@ -7,6 +7,8 @@
   .govuk-caption-l class="govuk-!-margin-top-5" = t("jobseekers.job_applications.caption", job_title: vacancy.job_title, organisation: vacancy.parent_organisation_name)
   h1.govuk-heading-xl class="govuk-!-margin-bottom-5" = t("jobseekers.job_applications.heading")
 
+- @job_application.errors.add(:gender, message: "this is an error")
+
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     / TODO: Confirm content

--- a/app/views/jobseekers/job_applications/review/_ask_for_support.html.slim
+++ b/app/views/jobseekers/job_applications/review/_ask_for_support.html.slim
@@ -1,3 +1,5 @@
+= render_divs_for_fields(Jobseekers::JobApplication::AskForSupportForm)
+
 = render ReviewComponent.new id: "jobseekers-job-application-review-form-ask-for-support-error" do |review|
   - review.heading title: t("jobseekers.job_applications.build.ask_for_support.heading"),
                    text: job_application_review_edit_section_text(job_application, :ask_for_support),

--- a/app/views/jobseekers/job_applications/review/_declarations.html.slim
+++ b/app/views/jobseekers/job_applications/review/_declarations.html.slim
@@ -1,4 +1,5 @@
-#right_to_work_in_uk
+= render_divs_for_fields(Jobseekers::JobApplication::DeclarationsForm)
+
 = render ReviewComponent.new id: "jobseekers-job-application-review-form-declarations-field-error" do |review|
   - review.heading title: t("jobseekers.job_applications.build.declarations.heading"),
                    text: job_application_review_edit_section_text(job_application, :declarations),

--- a/app/views/jobseekers/job_applications/review/_declarations.html.slim
+++ b/app/views/jobseekers/job_applications/review/_declarations.html.slim
@@ -13,4 +13,3 @@
       - summary_list.row do |row|
         - row.key text: t("helpers.legend.jobseekers_job_application_declarations_form.right_to_work_in_uk")
         - row.value text: job_application.right_to_work_in_uk.humanize
-        - row.html_attributes { { id: "right_to_work_in_uk" } }

--- a/app/views/jobseekers/job_applications/review/_declarations.html.slim
+++ b/app/views/jobseekers/job_applications/review/_declarations.html.slim
@@ -1,3 +1,4 @@
+#right_to_work_in_uk
 = render ReviewComponent.new id: "jobseekers-job-application-review-form-declarations-field-error" do |review|
   - review.heading title: t("jobseekers.job_applications.build.declarations.heading"),
                    text: job_application_review_edit_section_text(job_application, :declarations),

--- a/app/views/jobseekers/job_applications/review/_employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/review/_employment_history.html.slim
@@ -1,3 +1,5 @@
+= render_divs_for_fields(Jobseekers::JobApplication::EmploymentHistoryForm)
+
 = render ReviewComponent.new id: "jobseekers-job-application-review-form-employment-history-field-error" do |review|
   - review.heading title: t("jobseekers.job_applications.build.employment_history.heading"),
                     text: job_application_review_edit_section_text(job_application, :employment_history),

--- a/app/views/jobseekers/job_applications/review/_equal_opportunities.html.slim
+++ b/app/views/jobseekers/job_applications/review/_equal_opportunities.html.slim
@@ -1,3 +1,5 @@
+#disability
+#age
 = render ReviewComponent.new id: "jobseekers-job-application-review-form-equal-opportunities-field-error" do |review|
   - review.heading title: t("jobseekers.job_applications.build.equal_opportunities.heading"),
                    text: job_application_review_edit_section_text(job_application, :equal_opportunities),

--- a/app/views/jobseekers/job_applications/review/_equal_opportunities.html.slim
+++ b/app/views/jobseekers/job_applications/review/_equal_opportunities.html.slim
@@ -1,5 +1,5 @@
-#disability
-#age
+= render_divs_for_fields(Jobseekers::JobApplication::EqualOpportunitiesForm)
+
 = render ReviewComponent.new id: "jobseekers-job-application-review-form-equal-opportunities-field-error" do |review|
   - review.heading title: t("jobseekers.job_applications.build.equal_opportunities.heading"),
                    text: job_application_review_edit_section_text(job_application, :equal_opportunities),
@@ -18,16 +18,16 @@
 
       - summary_list.row do |row|
         - row.key text: t("helpers.legend.jobseekers_job_application_equal_opportunities_form.gender")
-        - row.value text: safe_join([tag.div(job_application.gender.humanize, class: "govuk-body", id: "gender"), tag.div(job_application.gender_description, class: "govuk-body", id: "gender_description")])
+        - row.value text: safe_join([tag.div(job_application.gender.humanize, class: "govuk-body"), tag.div(job_application.gender_description, class: "govuk-body")])
 
       - summary_list.row do |row|
         - row.key text: t("helpers.legend.jobseekers_job_application_equal_opportunities_form.orientation")
-        - row.value text: safe_join([tag.div(job_application.orientation.humanize, class: "govuk-body", id: "orientation"), tag.div(job_application.orientation_description, class: "govuk-body", id: "orientation_description")])
+        - row.value text: safe_join([tag.div(job_application.orientation.humanize, class: "govuk-body"), tag.div(job_application.orientation_description, class: "govuk-body")])
 
       - summary_list.row do |row|
         - row.key text: t("helpers.legend.jobseekers_job_application_equal_opportunities_form.ethnicity")
-        - row.value text: safe_join([tag.div(job_application.ethnicity.humanize, class: "govuk-body", id: "ethnicity"), tag.div(job_application.ethnicity_description, class: "govuk-body", id: "ethnicity_description")])
+        - row.value text: safe_join([tag.div(job_application.ethnicity.humanize, class: "govuk-body"), tag.div(job_application.ethnicity_description, class: "govuk-body")])
 
       - summary_list.row do |row|
         - row.key text: t("helpers.legend.jobseekers_job_application_equal_opportunities_form.religion")
-        - row.value text: safe_join([tag.div(job_application.religion.humanize, class: "govuk-body", id: "religion"), tag.div(job_application.religion_description, class: "govuk-body", id: "religion_description")])
+        - row.value text: safe_join([tag.div(job_application.religion.humanize, class: "govuk-body"), tag.div(job_application.religion_description, class: "govuk-body")])

--- a/app/views/jobseekers/job_applications/review/_equal_opportunities.html.slim
+++ b/app/views/jobseekers/job_applications/review/_equal_opportunities.html.slim
@@ -9,12 +9,10 @@
       - summary_list.row do |row|
         - row.key text: t("helpers.legend.jobseekers_job_application_equal_opportunities_form.disability")
         - row.value text: job_application.disability.humanize
-        - row.html_attributes { { id: "disability" } }
 
       - summary_list.row do |row|
         - row.key text: t("helpers.legend.jobseekers_job_application_equal_opportunities_form.age")
         - row.value text: job_application.age.humanize
-        - row.html_attributes { { id: "age" } }
 
       - summary_list.row do |row|
         - row.key text: t("helpers.legend.jobseekers_job_application_equal_opportunities_form.gender")

--- a/app/views/jobseekers/job_applications/review/_personal_details.html.slim
+++ b/app/views/jobseekers/job_applications/review/_personal_details.html.slim
@@ -1,3 +1,10 @@
+#first_name
+#last_name
+#previous_names
+#phone_number
+#email_address
+#teacher_reference_number
+#national_insurance_number
 = render ReviewComponent.new id: "jobseekers-job-application-review-form-personal-details-field-error" do |review|
   - review.heading title: t("jobseekers.job_applications.build.personal_details.heading"),
                     text: job_application_review_edit_section_text(job_application, :personal_details),

--- a/app/views/jobseekers/job_applications/review/_personal_details.html.slim
+++ b/app/views/jobseekers/job_applications/review/_personal_details.html.slim
@@ -9,17 +9,14 @@
       - summary_list.row do |row|
         - row.key text: t("helpers.label.jobseekers_job_application_personal_details_form.first_name")
         - row.value text: job_application.first_name
-        - row.html_attributes { { id: "first_name" } }
 
       - summary_list.row do |row|
         - row.key text: t("helpers.label.jobseekers_job_application_personal_details_form.last_name")
         - row.value text: job_application.last_name
-        - row.html_attributes { { id: "last_name" } }
 
       - summary_list.row do |row|
         - row.key text: t("helpers.label.jobseekers_job_application_personal_details_form.previous_names_html")
         - row.value text: job_application.previous_names.presence || t("jobseekers.job_applications.not_defined")
-        - row.html_attributes { { id: "previous_names" } }
 
       - summary_list.row do |row|
         - row.key text: t("helpers.legend.jobseekers_job_application_personal_details_form.your_address")
@@ -28,19 +25,15 @@
       - summary_list.row do |row|
         - row.key text: t("helpers.label.jobseekers_job_application_personal_details_form.phone_number")
         - row.value text: job_application.phone_number
-        - row.html_attributes { { id: "phone_number" } }
 
       - summary_list.row do |row|
         - row.key text: t("helpers.label.jobseekers_job_application_personal_details_form.email_address")
         - row.value text: job_application.email
-        - row.html_attributes { { id: "email_address" } }
 
       - summary_list.row do |row|
         - row.key text: t("helpers.label.jobseekers_job_application_personal_details_form.teacher_reference_number_html")
         - row.value text: job_application.teacher_reference_number.presence || t("jobseekers.job_applications.not_defined")
-        - row.html_attributes { { id: "teacher_reference_number" } }
 
       - summary_list.row do |row|
         - row.key text: t("helpers.label.jobseekers_job_application_personal_details_form.national_insurance_number_html")
         - row.value text: job_application.national_insurance_number.presence || t("jobseekers.job_applications.not_defined")
-        - row.html_attributes { { id: "national_insurance_number" } }

--- a/app/views/jobseekers/job_applications/review/_personal_details.html.slim
+++ b/app/views/jobseekers/job_applications/review/_personal_details.html.slim
@@ -1,10 +1,5 @@
-#first_name
-#last_name
-#previous_names
-#phone_number
-#email_address
-#teacher_reference_number
-#national_insurance_number
+= render_divs_for_fields(Jobseekers::JobApplication::PersonalDetailsForm)
+
 = render ReviewComponent.new id: "jobseekers-job-application-review-form-personal-details-field-error" do |review|
   - review.heading title: t("jobseekers.job_applications.build.personal_details.heading"),
                     text: job_application_review_edit_section_text(job_application, :personal_details),
@@ -27,7 +22,7 @@
 
       - summary_list.row do |row|
         - row.key text: t("helpers.legend.jobseekers_job_application_personal_details_form.your_address")
-        - row.value text: safe_join([tag.div(job_application.street_address, class: "govuk-body", id: "street_address"), tag.div(job_application.city, class: "govuk-body", id: "city"), tag.div(job_application.postcode, class: "govuk-body", id: "postcode"), tag.div(job_application.country, class: "govuk-body", id: "country")])
+        - row.value text: safe_join([tag.div(job_application.street_address, class: "govuk-body"), tag.div(job_application.city, class: "govuk-body"), tag.div(job_application.postcode, class: "govuk-body"), tag.div(job_application.country, class: "govuk-body")])
 
       - summary_list.row do |row|
         - row.key text: t("helpers.label.jobseekers_job_application_personal_details_form.phone_number")

--- a/app/views/jobseekers/job_applications/review/_personal_statement.html.slim
+++ b/app/views/jobseekers/job_applications/review/_personal_statement.html.slim
@@ -1,3 +1,5 @@
+= render_divs_for_fields(obseekers::JobApplication::PersonalStatementForm)
+
 = render ReviewComponent.new id: "jobseekers-job-application-review-form-personal-statement-field-error" do |review|
   - review.heading title: t("jobseekers.job_applications.build.personal_statement.heading"),
                    text: job_application_review_edit_section_text(job_application, :personal_statement),

--- a/app/views/jobseekers/job_applications/review/_personal_statement.html.slim
+++ b/app/views/jobseekers/job_applications/review/_personal_statement.html.slim
@@ -1,4 +1,4 @@
-= render_divs_for_fields(obseekers::JobApplication::PersonalStatementForm)
+= render_divs_for_fields(Jobseekers::JobApplication::PersonalStatementForm)
 
 = render ReviewComponent.new id: "jobseekers-job-application-review-form-personal-statement-field-error" do |review|
   - review.heading title: t("jobseekers.job_applications.build.personal_statement.heading"),

--- a/app/views/jobseekers/job_applications/review/_professional_status.html.slim
+++ b/app/views/jobseekers/job_applications/review/_professional_status.html.slim
@@ -13,4 +13,3 @@
       - summary_list.row do |row|
         - row.key text: t("helpers.legend.jobseekers_job_application_professional_status_form.statutory_induction_complete")
         - row.value text: job_application.statutory_induction_complete.humanize
-        - row.html_attributes { { id: "statutory_induction_complete" } }

--- a/app/views/jobseekers/job_applications/review/_professional_status.html.slim
+++ b/app/views/jobseekers/job_applications/review/_professional_status.html.slim
@@ -1,4 +1,5 @@
-#statutory_induction_complete
+= render_divs_for_fields(Jobseekers::JobApplication::ProfessionalStatusForm)
+
 = render ReviewComponent.new id: "jobseekers-job-application-review-form-professional-status-field-error" do |review|
   - review.heading title: t("jobseekers.job_applications.build.professional_status.heading"),
                     text: job_application_review_edit_section_text(job_application, :professional_status),

--- a/app/views/jobseekers/job_applications/review/_professional_status.html.slim
+++ b/app/views/jobseekers/job_applications/review/_professional_status.html.slim
@@ -1,3 +1,4 @@
+#statutory_induction_complete
 = render ReviewComponent.new id: "jobseekers-job-application-review-form-professional-status-field-error" do |review|
   - review.heading title: t("jobseekers.job_applications.build.professional_status.heading"),
                     text: job_application_review_edit_section_text(job_application, :professional_status),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_applying_for_the_job.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_applying_for_the_job.html.slim
@@ -1,5 +1,12 @@
 = render "publishers/vacancies/error_tag", attributes: Publishers::JobListing::ApplyingForTheJobForm.fields
 
+#enable_job_applications
+#personal_statement_guidance
+#application_link
+#how_to_apply
+#contact_email
+#contact_number
+#school_visits
 = render ReviewComponent.new id: "applying_for_the_job" do |review|
   - review.heading title: t("publishers.vacancies.steps.applying_for_the_job"),
                    text: t("buttons.change"),
@@ -11,37 +18,30 @@
         - summary_list.row do |row|
           - row.key text: t("jobs.enable_job_applications")
           - row.value text: @vacancy.enable_job_applications? ? "Yes" : "No"
-          - row.html_attributes { { id: "enable_job_applications" } }
 
       - if @vacancy.enable_job_applications?
         - summary_list.row do |row|
           - row.key text: t("jobs.personal_statement_guidance")
           - row.value text: @vacancy.personal_statement_guidance.presence || t("jobs.not_defined")
-          - row.html_attributes { { id: "personal_statement_guidance" } }
 
       - else
         - summary_list.row do |row|
           - row.key text: t("jobs.application_link")
           - row.value text: @vacancy.application_link.present? ? open_in_new_tab_link_to(@vacancy.application_link, @vacancy.application_link, "aria-label": t("jobs.aria_labels.apply_link")) : t("jobs.not_defined")
-          - row.html_attributes { { id: "application_link" } }
 
       - if @vacancy.how_to_apply.present?
         - summary_list.row do |row|
           - row.key text: t("jobs.how_to_apply")
           - row.value text: @vacancy.how_to_apply
-          - row.html_attributes { { id: "how_to_apply" } }
 
       - summary_list.row do |row|
         - row.key text: t("jobs.contact_email")
         - row.value text: govuk_mail_to("Job contact email", @vacancy.contact_email, "aria-label": t("jobs.aria_labels.contact_email_link", email: @vacancy.contact_email))
-        - row.html_attributes { { id: "contact_email" } }
 
       - summary_list.row do |row|
         - row.key text: t("jobs.contact_number")
         - row.value text: @vacancy.contact_number.present? ? govuk_link_to(@vacancy.contact_number, "tel:#{@vacancy.contact_number}") : t("jobs.not_defined")
-        - row.html_attributes { { id: "contact_number" } }
 
       - summary_list.row do |row|
         - row.key text: t("jobs.#{school_or_trust_visits(@vacancy.parent_organisation)}")
         - row.value text: @vacancy.school_visits.presence || t("jobs.not_defined")
-        - row.html_attributes { { id: "school_visits" } }

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_applying_for_the_job.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_applying_for_the_job.html.slim
@@ -1,12 +1,7 @@
 = render "publishers/vacancies/error_tag", attributes: Publishers::JobListing::ApplyingForTheJobForm.fields
 
-#enable_job_applications
-#personal_statement_guidance
-#application_link
-#how_to_apply
-#contact_email
-#contact_number
-#school_visits
+= render_divs_for_fields(Publishers::JobListing::ApplyingForTheJobForm)
+
 = render ReviewComponent.new id: "applying_for_the_job" do |review|
   - review.heading title: t("publishers.vacancies.steps.applying_for_the_job"),
                    text: t("buttons.change"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_important_dates.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_important_dates.html.slim
@@ -1,6 +1,10 @@
 = render "publishers/vacancies/error_tag", attributes: Publishers::JobListing::ImportantDatesForm.fields
 
 #expiry_time
+#publish_on
+#publish_on_day
+#expires_at
+#starts_on
 = render ReviewComponent.new id: "important_dates" do |review|
   - review.heading title: t("publishers.vacancies.steps.important_dates"),
                    text: t("buttons.change"),
@@ -11,14 +15,11 @@
       - summary_list.row do |row|
         - row.key text: t("jobs.publication_date")
         - row.value text: format_date(@vacancy.publish_on)
-        - row.html_attributes { { id: "publish_on" } }
 
       - summary_list.row do |row|
         - row.key text: t("jobs.application_deadline")
         - row.value text: format_time_to_datetime_at(@vacancy.expires_at)
-        - row.html_attributes { { id: "expires_at" } }
 
       - summary_list.row do |row|
         - row.key text: t("jobs.starts_on")
         - row.value text: @vacancy.starts_asap? ? t("jobs.starts_asap") : format_date(@vacancy.starts_on)
-        - row.html_attributes { { id: "starts_on" } }

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_important_dates.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_important_dates.html.slim
@@ -1,10 +1,7 @@
 = render "publishers/vacancies/error_tag", attributes: Publishers::JobListing::ImportantDatesForm.fields
 
-#expiry_time
-#publish_on
-#publish_on_day
-#expires_at
-#starts_on
+= render_divs_for_fields(Publishers::JobListing::ImportantDatesForm)
+
 = render ReviewComponent.new id: "important_dates" do |review|
   - review.heading title: t("publishers.vacancies.steps.important_dates"),
                    text: t("buttons.change"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_details.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_details.html.slim
@@ -1,5 +1,8 @@
 = render "publishers/vacancies/error_tag", attributes: Publishers::JobListing::JobDetailsForm.fields
 
+#job_title
+#subjects
+#contract_type
 = render ReviewComponent.new id: "job_details" do |review|
   - review.heading title: t("publishers.vacancies.steps.job_details"),
                    text: t("buttons.change"),
@@ -10,14 +13,11 @@
       - summary_list.row do |row|
         - row.key text: t("jobs.job_title")
         - row.value text: @vacancy.job_title
-        - row.html_attributes { { id: "job_title" } }
 
       - summary_list.row do |row|
         - row.key text: t("jobs.subjects")
         - row.value text: @vacancy.show_subjects.presence || t("jobs.not_defined")
-        - row.html_attributes { { id: "subjects" } }
 
       - summary_list.row do |row|
         - row.key text: t("jobs.contract_type")
         - row.value text: @vacancy.contract_type_with_duration
-        - row.html_attributes { { id: "contract_type" } }

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_details.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_details.html.slim
@@ -1,8 +1,7 @@
 = render "publishers/vacancies/error_tag", attributes: Publishers::JobListing::JobDetailsForm.fields
 
-#job_title
-#subjects
-#contract_type
+= render_divs_for_fields(Publishers::JobListing::JobDetailsForm)
+
 = render ReviewComponent.new id: "job_details" do |review|
   - review.heading title: t("publishers.vacancies.steps.job_details"),
                    text: t("buttons.change"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_location.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_location.html.slim
@@ -1,5 +1,7 @@
 = render "publishers/vacancies/error_tag", attributes: (Publishers::JobListing::JobLocationForm.fields + Publishers::JobListing::SchoolsForm.fields)
 
+= render_divs_for_fields(Publishers::JobListing::JobLocationForm)
+
 = render ReviewComponent.new id: "job_location" do |review|
   - review.heading title: t("publishers.vacancies.steps.job_location"),
                    text: t("buttons.change"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_role.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_role.html.slim
@@ -1,5 +1,7 @@
 = render "publishers/vacancies/error_tag", attributes: Publishers::JobListing::JobRoleForm.fields
 
+#main_job_role
+#additional_job_roles
 = render ReviewComponent.new id: "job_role" do |review|
   - review.heading title: t("publishers.vacancies.steps.job_role"),
                    text: t("buttons.change"),
@@ -10,10 +12,8 @@
       - summary_list.row do |row|
         - row.key text: t("jobs.main_job_role")
         - row.value text: @vacancy.show_main_job_role || t("jobs.not_defined")
-        - row.html_attributes { { id: "main_job_role" } }
 
       - unless @vacancy.main_job_role == "sendco"
         - summary_list.row do |row|
           - row.key text: t("jobs.additional_job_roles")
           - row.value text: @vacancy.show_additional_job_roles.presence || t("jobs.not_defined")
-          - row.html_attributes { { id: "additional_job_roles" } }

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_role.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_role.html.slim
@@ -1,7 +1,7 @@
 = render "publishers/vacancies/error_tag", attributes: Publishers::JobListing::JobRoleForm.fields
 
-#main_job_role
-#additional_job_roles
+= render_divs_for_fields(Publishers::JobListing::JobRoleForm)
+
 = render ReviewComponent.new id: "job_role" do |review|
   - review.heading title: t("publishers.vacancies.steps.job_role"),
                    text: t("buttons.change"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_summary.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_summary.html.slim
@@ -1,7 +1,7 @@
 = render "publishers/vacancies/error_tag", attributes: Publishers::JobListing::JobSummaryForm.fields
 
-#job_advert
-#about_school
+= render_divs_for_fields(Publishers::JobListing::JobSummaryForm)
+
 = render ReviewComponent.new id: "job_summary" do |review|
   - review.heading title: t("publishers.vacancies.steps.job_summary"),
                    text: t("buttons.change"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_summary.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_job_summary.html.slim
@@ -1,5 +1,7 @@
 = render "publishers/vacancies/error_tag", attributes: Publishers::JobListing::JobSummaryForm.fields
 
+#job_advert
+#about_school
 = render ReviewComponent.new id: "job_summary" do |review|
   - review.heading title: t("publishers.vacancies.steps.job_summary"),
                    text: t("buttons.change"),
@@ -10,9 +12,7 @@
       - summary_list.row do |row|
         - row.key text: t("jobs.job_advert")
         - row.value text: @vacancy.job_advert
-        - row.html_attributes { { id: "job_advert" } }
 
       - summary_list.row do |row|
         - row.key text: t("jobs.about_school", school: vacancy_about_school_label_organisation(@vacancy))
         - row.value text: @vacancy.about_school
-        - row.html_attributes { { id: "about_school" } }

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_pay_package.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_pay_package.html.slim
@@ -1,8 +1,7 @@
 = render "publishers/vacancies/error_tag", attributes: Publishers::JobListing::PayPackageForm.fields
 
-#salary
-#actual_salary
-#benefits
+= render_divs_for_fields(Publishers::JobListing::PayPackageForm)
+
 = render ReviewComponent.new id: "pay_package" do |review|
   - review.heading title: t("publishers.vacancies.steps.pay_package"),
                    text: t("buttons.change"),

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_pay_package.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_pay_package.html.slim
@@ -1,5 +1,8 @@
 = render "publishers/vacancies/error_tag", attributes: Publishers::JobListing::PayPackageForm.fields
 
+#salary
+#actual_salary
+#benefits
 = render ReviewComponent.new id: "pay_package" do |review|
   - review.heading title: t("publishers.vacancies.steps.pay_package"),
                    text: t("buttons.change"),
@@ -10,14 +13,11 @@
       - summary_list.row do |row|
         - row.key text: t("jobs.annual_salary")
         - row.value text: @vacancy.salary
-        - row.html_attributes { { id: "salary" } }
 
       - summary_list.row do |row|
         - row.key text: t("jobs.actual_salary")
         - row.value text: @vacancy.actual_salary.presence || t("jobs.not_defined")
-        - row.html_attributes { { id: "actual_salary" } }
 
       - summary_list.row do |row|
         - row.key text: t("jobs.benefits")
         - row.value text: @vacancy.benefits.presence || t("jobs.not_defined")
-        - row.html_attributes { { id: "benefits" } }

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_working_patterns.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_working_patterns.html.slim
@@ -1,5 +1,6 @@
 = render "publishers/vacancies/error_tag", attributes: Publishers::JobListing::WorkingPatternsForm.fields
 
+#working_patterns_details
 = render ReviewComponent.new id: "working_patterns" do |review|
   - review.heading title: t("publishers.vacancies.steps.working_patterns"),
                    text: t("buttons.change"),
@@ -10,9 +11,7 @@
       - summary_list.row do |row|
         - row.key text: t("jobs.working_patterns")
         - row.value text: @vacancy.working_patterns
-        - row.html_attributes { { id: "working_patterns" } }
 
       - summary_list.row do |row|
         - row.key text: t("jobs.working_patterns_details")
         - row.value text: @vacancy.working_patterns_details
-        - row.html_attributes { { id: "working_patterns_details" } }

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_working_patterns.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_working_patterns.html.slim
@@ -1,6 +1,7 @@
 = render "publishers/vacancies/error_tag", attributes: Publishers::JobListing::WorkingPatternsForm.fields
 
-#working_patterns_details
+= render_divs_for_fields(Publishers::JobListing::WorkingPatternsForm)
+
 = render ReviewComponent.new id: "working_patterns" do |review|
   - review.heading title: t("publishers.vacancies.steps.working_patterns"),
                    text: t("buttons.change"),


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3189

## Changes in this PR:
This PR fixes the links in the error summary by adding divs corresponding to each anchor to the top of the relevant section.
It also removes the row.html_attributes calls when the summary list rows are generated (these calls do not generate any html attributes).
