### PR TITLE
[TEVA-3208] Add task to fix subscriptions search criteria bug

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -15,10 +15,12 @@ class Vacancy < ApplicationRecord
   # the legacy vacancies are gone, we should refactor the data model.
   MAIN_JOB_ROLES = { teacher: 0, leadership: 1, teaching_assistant: 6, education_support: 4, sendco: 5 }.freeze
   ADDITIONAL_JOB_ROLES = { send_responsible: 2, ect_suitable: 3 }.freeze
-  array_enum job_roles: MAIN_JOB_ROLES.merge(ADDITIONAL_JOB_ROLES)
 
+  # When removing a job_role or working_pattern, remember to update *subscriptions* that have the old values.
+  array_enum job_roles: MAIN_JOB_ROLES.merge(ADDITIONAL_JOB_ROLES)
   array_enum working_patterns: { full_time: 0, part_time: 100, job_share: 101, term_time: 102 }
   # Legacy vacancies can have these working_pattern options too: { compressed_hours: 102, staggered_hours: 103 }
+
   enum contract_type: { permanent: 0, fixed_term: 1 }
   enum status: { published: 0, draft: 1, trashed: 2 }
   enum job_location: { at_one_school: 0, at_multiple_schools: 1, central_office: 2 }


### PR DESCRIPTION
We had a 'translation missing' in job alert emails; this was due to old subscriptions containing an outdated job role for which we no longer have a translation. So update the job roles in each subscriptions search criteria so that all 'nqt_suitable' are replaced by 'ect_suitable'.

Tested task on dev with 20,000 or so subscriptions:

Before:

```
Subscription.first(1000).pluck(:search_criteria).map{ |s| s["job_roles"] }.compact.uniq
=>
[["teacher"],
 ["teacher", "nqt_suitable"],
 ["teacher", "leadership"],
 ["leadership"],
 ["leadership", "sen_specialist"],
 ["teacher", "sen_specialist", "nqt_suitable"],
 ["nqt_suitable"],
 ["teacher", "leadership", "sen_specialist", "nqt_suitable"],
 ["teacher", "leadership", "sen_specialist"],
 ["sen_specialist"],
 ["sen_specialist", "nqt_suitable"],
 ["teacher", "sen_specialist"]]
```
 
 After:
 
 ```
[["teacher"],
 ["teacher", "ect_suitable"],
 ["teacher", "leadership"],
 ["leadership"],
 ["leadership", "sen_specialist"],
 ["teacher", "sen_specialist", "ect_suitable"],
 ["ect_suitable"],
 ["teacher", "leadership", "sen_specialist", "ect_suitable"],
 ["teacher", "leadership", "sen_specialist"],
 ["sen_specialist"],
 ["sen_specialist", "ect_suitable"],
 ["teacher", "sen_specialist"]]
```
