### PR TITLE
Lint code

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -83,17 +83,17 @@ Naming/AccessorMethodName:
 # We should consider slowly moving closer to the default settings.
 
 Metrics/AbcSize:
-  Max: 32 # Default 17
+  Max: 31 # Default 17
   Exclude:
     - "config/**/*"
-    - "lib/**/*"
     - "spec/**/*"
 
 Metrics/BlockLength:
-  Max: 70 # Default 25
+  Max: 25 # Default 25
   Exclude:
     - "config/**/*"
     - "spec/**/*"
+    - "app/models/concerns/indexable.rb"
 
 Metrics/ClassLength:
   Max: 156 # Default 100

--- a/app/services/publishers/export_vacancy_to_csv.rb
+++ b/app/services/publishers/export_vacancy_to_csv.rb
@@ -8,27 +8,32 @@ class Publishers::ExportVacancyToCsv
     @number_of_unique_views = number_of_unique_views
   end
 
-  # rubocop:disable Metrics/AbcSize
   def call
-    columns = {
-      "Organisation" => vacancy.organisation.name,
-      I18n.t("jobs.job_title") => vacancy.job_title,
-      I18n.t("publishers.vacancies.statistics.show.views_by_jobseeker") => @number_of_unique_views,
-      I18n.t("publishers.vacancies.statistics.show.saves_by_jobseeker") => vacancy.saved_jobs.count,
-    }
-
-    if vacancy.can_receive_job_applications?
-      columns.merge!({ I18n.t("publishers.vacancies.statistics.show.total_applications") => vacancy.job_applications.not_draft.count,
-                       I18n.t("publishers.vacancies.statistics.show.unread_applications") => vacancy.job_applications.submitted.count,
-                       I18n.t("publishers.vacancies.statistics.show.shortlisted_applications") => vacancy.job_applications.shortlisted.count,
-                       I18n.t("publishers.vacancies.statistics.show.rejected_applications") => vacancy.job_applications.unsuccessful.count,
-                       I18n.t("publishers.vacancies.statistics.show.withdrawn_applications") => vacancy.job_applications.withdrawn.count })
-    end
+    columns = base_columns
+    columns.merge!(job_application_columns) if vacancy.can_receive_job_applications?
 
     CSV.generate(headers: true) do |csv|
       csv << columns.keys
       csv << columns.values
     end
   end
-  # rubocop:enable Metrics/AbcSize
+
+  private
+
+  def base_columns
+    {
+      "Organisation" => vacancy.organisation.name,
+      I18n.t("jobs.job_title") => vacancy.job_title,
+      I18n.t("publishers.vacancies.statistics.show.views_by_jobseeker") => @number_of_unique_views,
+      I18n.t("publishers.vacancies.statistics.show.saves_by_jobseeker") => vacancy.saved_jobs.count,
+    }
+  end
+
+  def job_application_columns
+    { I18n.t("publishers.vacancies.statistics.show.total_applications") => vacancy.job_applications.not_draft.count,
+      I18n.t("publishers.vacancies.statistics.show.unread_applications") => vacancy.job_applications.submitted.count,
+      I18n.t("publishers.vacancies.statistics.show.shortlisted_applications") => vacancy.job_applications.shortlisted.count,
+      I18n.t("publishers.vacancies.statistics.show.rejected_applications") => vacancy.job_applications.unsuccessful.count,
+      I18n.t("publishers.vacancies.statistics.show.withdrawn_applications") => vacancy.job_applications.withdrawn.count }
+  end
 end

--- a/app/services/request_event.rb
+++ b/app/services/request_event.rb
@@ -27,11 +27,15 @@ class RequestEvent < Event
       request_ab_tests: ab_tests,
       response_content_type: response.content_type,
       response_status: response.status,
-      user_anonymised_request_identifier: anonymise([user_agent, request.remote_ip].join),
+      user_anonymised_request_identifier: anonymise(request_identifier),
       user_anonymised_session_id: anonymise(session.id),
       user_anonymised_jobseeker_id: anonymise(current_jobseeker&.id),
       user_anonymised_publisher_id: anonymise(current_publisher&.oid),
     )
+  end
+
+  def request_identifier
+    [user_agent, request.remote_ip].join
   end
 
   def user_agent

--- a/lib/organisation_import/import_school_data.rb
+++ b/lib/organisation_import/import_school_data.rb
@@ -21,7 +21,6 @@ class ImportSchoolData < ImportOrganisationData
     membership.update!(do_not_delete: true)
   end
 
-  # No point refactoring this method to be shorter as this class is currently being rewritten elsewhere.
   # rubocop:disable Metrics/MethodLength
   def column_name_mappings
     {


### PR DESCRIPTION
Tighten rubocop metrics. Exclude algolia from block length metric as it is an extreme outlier (70 or so lines), and because we are planning to remove this code soon.