### PR TITLE
[TEVA-3186] Create delete draft page

### DIFF
--- a/app/views/publishers/vacancies/_actions.html.slim
+++ b/app/views/publishers/vacancies/_actions.html.slim
@@ -6,4 +6,4 @@
     - unless vacancy.expired? || vacancy.pending?
       = govuk_button_link_to t("buttons.end_listing_early"), organisation_job_end_listing_path(vacancy.id), class: "govuk-button--secondary"
   - if vacancy.draft? || vacancy.pending?
-    = govuk_button_link_to t("buttons.delete"), organisation_job_path(vacancy.id), method: :delete, data: { confirm: t("jobs.manage.are_you_sure", job_title: vacancy.job_title) }, class: "govuk-button--secondary"
+    = govuk_button_link_to t("buttons.delete_draft"), organisation_job_confirm_destroy_path(vacancy.id), class: "govuk-button--warning"

--- a/app/views/publishers/vacancies/confirm_destroy.html.slim
+++ b/app/views/publishers/vacancies/confirm_destroy.html.slim
@@ -1,0 +1,15 @@
+- content_for :page_title_prefix, t(".page_title")
+
+.govuk-main-wrapper class="govuk-!-padding-top-0"
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = govuk_back_link text: t("buttons.back"), href: organisation_job_path(vacancy.id), classes: "govuk-!-margin-bottom-7"
+
+      h2.govuk-caption-l = "#{vacancy.job_title} at #{vacancy_job_location(vacancy)}"
+      h1.govuk-heading-l = t(".page_title")
+
+      h3.govuk-heading-m = t(".are_you_sure")
+
+      = govuk_button_link_to t("buttons.confirm_deletion"), organisation_job_path(vacancy.id), method: :delete, class: "govuk-button--warning"
+
+  = govuk_link_to t("buttons.cancel"), organisation_job_path(vacancy.id), class: "govuk-link--no-visited-state"

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -24,6 +24,7 @@ en:
     close_account: Close account
     change: Change
     complete_section: Complete section
+    confirm_deletion: Confirm deletion
     confirm_destroy: Yes I am sure - delete this entry
     confirm_rejection: Confirm rejection
     continue: Continue
@@ -32,6 +33,7 @@ en:
     create_job: Create a job listing
     create_account: Create an account
     delete: Delete
+    delete_draft: Delete draft
     delete_subject: Delete subject
     dismiss: Dismiss
     download_stats: Download statistics (csv, 0.2KB)

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -169,6 +169,9 @@ en:
           step_title: Review the job listing
         working_patterns:
           step_title: Working patterns
+      confirm_destroy:
+        are_you_sure: Are you sure you want to delete the draft listing?
+        page_title: Delete draft listing
       destroy:
         success_html: >-
           %{job_title} has been <span class="govuk-!-font-weight-bold delete-listing-success-gtm">deleted</span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -146,11 +146,12 @@ Rails.application.routes.draw do
     resources :jobs, only: %i[create destroy delete show], controller: "publishers/vacancies" do
       resources :build, only: %i[show update], controller: "publishers/vacancies/build"
       resource :documents, only: %i[create destroy show], controller: "publishers/vacancies/documents"
-      get :review
+      get :confirm_destroy
       get :preview
-      get :summary
       post :publish, to: "publishers/vacancies/publish#create"
       get :publish, to: "publishers/vacancies/publish#create"
+      get :review
+      get :summary
       resource :feedback, only: %i[create], controller: "publishers/vacancies/feedbacks"
       resource :statistics, only: %i[show update], controller: "publishers/vacancies/statistics"
       resource :copy, only: %i[new create], controller: "publishers/vacancies/copy"

--- a/spec/system/publishers_can_delete_vacancies_spec.rb
+++ b/spec/system/publishers_can_delete_vacancies_spec.rb
@@ -12,16 +12,17 @@ RSpec.describe "School deleting vacancies" do
   end
 
   scenario "A school can delete a vacancy from a list" do
-    click_on I18n.t("buttons.delete")
+    click_on I18n.t("buttons.delete_draft")
+    click_on I18n.t("buttons.confirm_deletion")
 
     expect(page).to have_content(
       strip_tags(I18n.t("publishers.vacancies.destroy.success_html", job_title: vacancy.job_title)),
     )
-    expect(page).to have_content(I18n.t("publishers.no_vacancies_component.heading"))
   end
 
   scenario "Deleting a vacancy triggers deletion of its supporting documents" do
-    click_on I18n.t("buttons.delete")
+    click_on I18n.t("buttons.delete_draft")
+    click_on I18n.t("buttons.confirm_deletion")
 
     expect(vacancy.supporting_documents.count).to be_zero
   end
@@ -29,6 +30,7 @@ RSpec.describe "School deleting vacancies" do
   scenario "Notifies the Google index service" do
     expect_any_instance_of(Publishers::Vacancies::BaseController).to receive(:remove_google_index).with(vacancy)
 
-    click_on I18n.t("buttons.delete")
+    click_on I18n.t("buttons.delete_draft")
+    click_on I18n.t("buttons.confirm_deletion")
   end
 end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3046

## Changes in this PR:

- Add a page to confirm the deletion of a draft vacancy

## Screenshots of UI changes:

### Single school

<img width="1058" alt="Screenshot 2021-09-28 at 17 41 40" src="https://user-images.githubusercontent.com/30624173/135129848-5b8e0960-7ea3-4cab-a61f-9287c451d593.png">

### Central office

<img width="1033" alt="Screenshot 2021-09-28 at 17 40 59" src="https://user-images.githubusercontent.com/30624173/135129881-7d62fe7c-d7b3-49a4-9be2-7c3837fa0f2d.png">

### Multiple schools

<img width="1082" alt="Screenshot 2021-09-28 at 17 41 52" src="https://user-images.githubusercontent.com/30624173/135129901-210b41a5-f4c2-43d2-aaba-d75906a56532.png">


