### PR TITLE
Update school phase label from sixteen_plus to 16-19

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -13,7 +13,7 @@ class School < Organisation
     middle_deemed_primary: 3,
     secondary: 4,
     middle_deemed_secondary: 5,
-    sixteen_plus: 6,
+    "16-19": 6,
     all_through: 7,
   }
 
@@ -24,7 +24,7 @@ class School < Organisation
     middle_deemed_primary: %w[middle],
     middle_deemed_secondary: %w[middle],
     secondary: %w[secondary],
-    sixteen_plus: %w[16-19],
+    "16-19": %w[16-19],
     all_through: %w[primary secondary 16-19],
   }.freeze
 


### PR DESCRIPTION
Rename the “sixteen_plus” phase to “16-19” to make the phase name consistent across our app. (This seems the simpler way to achieve consistency, because our search index uses “16-19” and so do our job alert search criteria.) This will make the code around a new phase column on vacancy (added in in-progress PR https://github.com/DFE-Digital/teaching-vacancies/pull/4043) a lot simpler to write, because the new code will require me to fall back to the organisation phase(s) when the vacancy does not have its own phase. Consistency will mean I won’t have to write things like

```ruby
if vacancy.education_phases.include?(“16-19”) || vacancy.education_phases.include?(“sixteen_plus”)
```
or create other workarounds.