### PR TITLE
[TEVA-3257] Update turnstyle action in deploy-workflow

### DIFF
--- a/.github/workflows/deploy_app.yml
+++ b/.github/workflows/deploy_app.yml
@@ -17,22 +17,22 @@ env:
  DOCKER_REPOSITORY: ghcr.io/dfe-digital/teaching-vacancies
 
 jobs:
-  turnstyle:
+
+  deploy-app:
+    name: Deploy ${{ github.event.inputs.tag }} to ${{ github.event.inputs.environment }}
     runs-on: ubuntu-20.04
-    timeout-minutes: 20
     steps:
+
     - uses: DFE-Digital/github-actions/turnstyle@master
       name: Check workflow concurrency
       with:
         initial-wait-seconds: 12
         poll-interval-seconds: 20
+        abort-after-seconds: 3600
         same-branch-only: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  deploy-app:
-    name: Deploy ${{ github.event.inputs.tag }} to ${{ github.event.inputs.environment }}
-    runs-on: ubuntu-20.04
-    steps:
+
     - uses: actions/checkout@v2
       name: Checkout Code
 


### PR DESCRIPTION
By moving  the turnstyle action into step in the main
job instead, and by  utilising the new `abort-after-seconds:` feature
of the turnstyle action instead - this makes deployment faster

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3257

## Changes in this PR:

Move `turnstyle` operation into the main job and leverage the new `abort-after-seconds` feature of the action instead.
