### PR TITLE
Bugfix: polygon import task

### DIFF
--- a/app/services/import_polygons.rb
+++ b/app/services/import_polygons.rb
@@ -14,7 +14,7 @@ class ImportPolygons
   end
 
   def call
-    response = JSON.parse(HTTParty.get(LOCATION_POLYGON_SETTINGS[api_location_type][:boundary_api]))
+    response = JSON.parse(HTTParty.get(LOCATION_POLYGON_SETTINGS[api_location_type][:boundary_api]).to_s)
 
     raise ArcgisResponseError, response.dig("error", "message") if response.dig("error", "code").present?
 


### PR DESCRIPTION
This was throwing an error locally and on production. The task still works locally

[TypeError: no implicit conversion of HTTParty::Response into String](https://rollbar.com/dfe/teacher-vacancies/items/10648/?utm_campaign=exp_repeat_item_message&utm_medium=slack&utm_source=rollbar-notification)