### PR TITLE
[TEVA-3213] Add callback to reset dependent fields

### DIFF
--- a/app/models/concerns/vacancy/resettable.rb
+++ b/app/models/concerns/vacancy/resettable.rb
@@ -1,0 +1,24 @@
+module Vacancy::Resettable
+  extend ActiveSupport::Concern
+
+  included do
+    before_save :reset_dependent_fields
+  end
+
+  def reset_dependent_fields
+    reset_actual_salary
+    reset_contract_type_duration
+  end
+
+  def reset_actual_salary
+    return unless working_patterns_changed? && working_patterns == ["full_time"]
+
+    self.actual_salary = ""
+  end
+
+  def reset_contract_type_duration
+    return unless contract_type_changed? && contract_type == "permanent"
+
+    self.contract_type_duration = ""
+  end
+end

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -5,6 +5,7 @@ class Vacancy < ApplicationRecord
   extend ArrayEnum
 
   include Indexable
+  include Resettable
 
   friendly_id :slug_candidates, use: %w[slugged history]
 

--- a/app/views/publishers/vacancies/edit_vacancy_sections/_edit_pay_package.html.slim
+++ b/app/views/publishers/vacancies/edit_vacancy_sections/_edit_pay_package.html.slim
@@ -13,9 +13,10 @@
         - row.key text: t("jobs.annual_salary")
         - row.value text: vacancy.salary
 
-      - summary_list.row do |row|
-        - row.key text: t("jobs.actual_salary")
-        - row.value text: vacancy.actual_salary.presence || t("jobs.not_defined")
+      - unless vacancy.model_working_patterns == ["full_time"]
+        - summary_list.row do |row|
+          - row.key text: t("jobs.actual_salary")
+          - row.value text: vacancy.actual_salary.presence || t("jobs.not_defined")
 
       - summary_list.row do |row|
         - row.key text: t("jobs.benefits")

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -410,6 +410,28 @@ RSpec.describe Vacancy do
     end
   end
 
+  describe "#reset_dependent_fields" do
+    context "when changing working pattern to full time" do
+      subject { create(:vacancy, working_patterns: ["part_time"], actual_salary: "50000") }
+
+      before { subject.update working_patterns: ["full_time"] }
+
+      it "resets actual_salary field" do
+        expect(subject.actual_salary).to be_blank
+      end
+    end
+
+    context "when changing contract type to permanent" do
+      subject { create(:vacancy, contract_type: "fixed_term", contract_type_duration: "8 months") }
+
+      before { subject.update contract_type: "permanent" }
+
+      it "resets contract_type_duration field" do
+        expect(subject.contract_type_duration).to be_blank
+      end
+    end
+  end
+
   describe "validations" do
     describe "changing enable_job_applications" do
       subject { build_stubbed(:vacancy, status, enable_job_applications: true) }


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3213

## Changes in this PR:

This PR adds a module, Resettable, which is included by the Vacancy model and implements a callback which ensures that the Actual Salary field is reset and hidden if a job listing is changed to Full-time working pattern from any working pattern which uses Actual Salary.

The callback also ensures that if a job listing with a Fixed Term contract and defined contract_type_duration is changed to a Permanent contract, then the contract_type_duration is reset.