### PR TITLE
Enable entity events for organisation import

### DIFF
--- a/app/jobs/refresh_organisations_gias_data_hash_job.rb
+++ b/app/jobs/refresh_organisations_gias_data_hash_job.rb
@@ -1,0 +1,5 @@
+class RefreshOrganisationsGiasDataHashJob < ApplicationJob
+  def perform
+    Organisation.find_each(&:refresh_gias_data_hash)
+  end
+end

--- a/app/services/gias/import_schools_and_local_authorities.rb
+++ b/app/services/gias/import_schools_and_local_authorities.rb
@@ -91,6 +91,7 @@ class Gias::ImportSchoolsAndLocalAuthorities
       local_authority_code: row["LA (code)"],
       name: row["LA (name)"],
       group_type: "local_authority",
+      gias_data: row.to_h.slice("LA (code)", "LA (name)"),
     }
   end
 

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -43,6 +43,11 @@ queue_weekly_alerts:
   class: 'SendWeeklyAlertEmailJob'
   queue: default
 
+refresh_organisations_gias_data_hash:
+  cron: '0 23 * * *'
+  class: 'RefreshOrganisationsGiasDataHashJob'
+  queue: low
+
 remove_invalid_subscriptions:
   cron: '0 05 * * *'
   class: 'RemoveInvalidSubscriptionsJob'

--- a/db/migrate/20211004133748_add_gias_data_hash_to_organisations.rb
+++ b/db/migrate/20211004133748_add_gias_data_hash_to_organisations.rb
@@ -1,0 +1,5 @@
+class AddGiasDataHashToOrganisations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :organisations, :gias_data_hash, :text, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_29_121317) do
+ActiveRecord::Schema.define(version: 2021_10_04_133748) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -321,6 +321,7 @@ ActiveRecord::Schema.define(version: 2021_09_29_121317) do
     t.string "local_authority_within"
     t.string "establishment_status"
     t.geography "geopoint", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}
+    t.text "gias_data_hash"
     t.index ["geopoint"], name: "index_organisations_on_geopoint", using: :gist
     t.index ["local_authority_code"], name: "index_organisations_on_local_authority_code", unique: true
     t.index ["uid"], name: "index_organisations_on_uid", unique: true

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -132,4 +132,35 @@ RSpec.describe Organisation do
       it { is_expected.to be_local_authority }
     end
   end
+
+  describe "#refresh_gias_data_hash" do
+    subject { create(:school, gias_data: { foo: "bar" }, gias_data_hash: hash) }
+
+    context "when the gias_data has changed" do
+      let(:hash) { "Foo" }
+
+      it "recomputes the hash" do
+        expect { subject.refresh_gias_data_hash }
+          .to change { subject.gias_data_hash }
+          .to("b8fd12f77d3a2614bcead8ab94c786c11b1bf6f2fdeb2d3801f316466f0fe4ee")
+      end
+
+      it "triggers an update event" do
+        expect { subject.refresh_gias_data_hash }.to have_triggered_event(:entity_updated)
+      end
+    end
+
+    context "when the gias_data has not changed" do
+      let(:hash) { "b8fd12f77d3a2614bcead8ab94c786c11b1bf6f2fdeb2d3801f316466f0fe4ee" }
+
+      it "does not change the hash" do
+        subject.refresh_gias_data_hash
+        expect(subject.gias_data_hash_previously_was).to be_nil
+      end
+
+      it "does not trigger an update event" do
+        expect { subject.refresh_gias_data_hash }.not_to have_triggered_event(:entity_updated)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Since we have refactored the organisation import logic, the import has
started working again, but we've lost the automatic entity events
fired from `ApplicationRecord` (due to the bulk import bypassing AR).

This adds a hash of GIAS data to organisation records, which is
refreshed on a nightly basis after the import scheduled job runs, and
triggers an update (and hence an event) if the GIAS data has changed.

It also adds `gias_data` for LAs (name and code) which wasn't there
previously.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3244