### PR TITLE
[TEVA-3203] remove salary from google jobs

### DIFF
--- a/app/views/api/vacancies/_show.json.jbuilder
+++ b/app/views/api/vacancies/_show.json.jbuilder
@@ -2,7 +2,6 @@ json.set! "@context", "http://schema.org"
 json.set! "@type", "JobPosting"
 
 json.title vacancy.job_title
-json.salary vacancy.salary
 json.jobBenefits vacancy.benefits
 json.datePosted vacancy.publish_on.to_time.iso8601
 json.description vacancy.job_advert

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -214,7 +214,6 @@ module VacancyHelpers
       "@context": "http://schema.org",
       "@type": "JobPosting",
       title: vacancy.job_title,
-      salary: vacancy.salary,
       jobBenefits: vacancy.benefits,
       datePosted: vacancy.publish_on.to_time.iso8601,
       description: vacancy.job_advert,


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-3203

removing this field as our salary data is not in a format where we can utilise it
