### PR TITLE
[TEVA-3168] Change Action required summary banner title

### DIFF
--- a/app/views/shared/_error_messages.html.slim
+++ b/app/views/shared/_error_messages.html.slim
@@ -1,6 +1,5 @@
 - if errors.any?
-  = govuk_notification_banner title_text: t("banners.warning"), classes: "govuk-notification-banner--warning" do |banner|
-    - banner.heading text: t("messages.jobs.action_required.heading")
+  = govuk_notification_banner title_text: t("banners.action_required"), classes: "govuk-notification-banner--warning" do
     span class="govuk-!-margin-top-3" = t("messages.jobs.action_required.message")[user_type]
     div class="govuk-!-margin-top-3"
       - errors.each do |error|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,6 +18,7 @@ en:
     important: Important
     success: Success
     warning: Warning
+    action_required: Action required
 
   breadcrumbs:
     active_jobs: Active jobs

--- a/config/locales/notifications.yml
+++ b/config/locales/notifications.yml
@@ -5,7 +5,6 @@ en:
       publisher_signed_out_for_inactivity: You have been signed out because you have been inactive for %{duration}
     jobs:
       action_required:
-        heading: Action required
         label: action required
         message:
           jobseeker: You must complete the required actions below in order to submit this application.

--- a/spec/system/publishers_can_edit_a_published_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers_can_edit_a_published_vacancy_as_a_school_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Publishers can edit a vacancy" do
       scenario "shows action required error message" do
         visit organisation_job_path(vacancy.id)
 
-        expect(page).to have_content(I18n.t("messages.jobs.action_required.heading"))
+        expect(page).to have_content(I18n.t("banners.action_required"))
         expect(page).to have_content(I18n.t("messages.jobs.action_required.message.publisher"))
         expect(page).to have_content(I18n.t("job_summary_errors.about_school.blank", organisation: "school"))
         expect(page).to have_content(I18n.t("job_details_errors.contract_type.inclusion"))


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3168

## Changes in this PR:

This PR amends the banner title of the "Action required" summary to "Action required" rather than "Warning". It also removes the "Action required" heading.

## Screenshots of UI changes:

### Before

![image](https://user-images.githubusercontent.com/24639777/136187263-abb1e609-88a6-408d-8fb5-c55a38a02855.png)

### After

![image](https://user-images.githubusercontent.com/24639777/136187319-89e6038e-048d-4ad4-b132-36f8dad610be.png)

