### PR TITLE
Import polygon data from ONS into PostGIS

### DIFF
--- a/app/jobs/import_polygon_data_job.rb
+++ b/app/jobs/import_polygon_data_job.rb
@@ -2,6 +2,12 @@ class ImportPolygonDataJob < ApplicationJob
   queue_as :low
 
   def perform
+    OnsDataImport::ImportCounties.new.call
+    OnsDataImport::ImportCities.new.call
+    OnsDataImport::ImportRegions.new.call
+
+    # TODO: Below is the legacy import code which can be removed once we have moved away from
+    #       Algolia and the need for legacy polygon data
     return if DisableExpensiveJobs.enabled?
 
     %i[regions counties cities].each { |api_location_type| ImportPolygons.new(api_location_type: api_location_type).call }

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -12,6 +12,7 @@ class Organisation < ApplicationRecord
   scope :school_groups, -> { where(type: "SchoolGroup") }
   scope :trusts, -> { school_groups.where.not(uid: nil) }
   scope :local_authorities, -> { school_groups.where.not(local_authority_code: nil) }
+  scope :within_polygon, ->(location_polygon) { where("ST_Covers(?, geopoint)", location_polygon.area) }
 
   alias_attribute :data, :gias_data
 

--- a/app/services/ons_data_import/base.rb
+++ b/app/services/ons_data_import/base.rb
@@ -1,0 +1,49 @@
+class OnsDataImport::Base
+  # Security note: "ESMARspQHYMw9BZ9" looks like an API key, but it's just a service name
+  ARCGIS_BASE_URL = "https://services1.arcgis.com/ESMARspQHYMw9BZ9/arcgis/rest/services/".freeze
+
+  PER_PAGE = 20
+
+  def call
+    (0..).each do |offset|
+      response = HTTParty.get(arcgis_url(offset * PER_PAGE))
+      raise "Unexpected ArcGIS response: #{response.code}" unless response.success?
+
+      data = JSON.parse(response)
+      break if data["features"].none?
+
+      data["features"].each do |feature|
+        name = feature["properties"][name_field].downcase
+        next unless in_scope?(name)
+
+        location_polygon = LocationPolygon.find_or_create_by(name: name)
+        type = LOCATIONS_MAPPED_TO_HUMAN_FRIENDLY_TYPES[name]
+        quoted_geometry = ActiveRecord::Base.connection.quote(feature["geometry"].to_json)
+        quoted_type = ActiveRecord::Base.connection.quote(type)
+
+        Rails.logger.info("Persisting new area data for '#{name}' (#{type})")
+        ActiveRecord::Base.connection.exec_update("
+          UPDATE location_polygons
+          SET area=ST_GeomFromGeoJSON(#{quoted_geometry}),
+              location_type=#{quoted_type}
+          WHERE id='#{location_polygon.id}'
+        ")
+      end
+    end
+  end
+
+  private
+
+  def arcgis_url(offset)
+    params = [
+      "where=1%3D1",
+      "outSR=4326",
+      "f=pgeojson",
+      "outFields=#{name_field}",
+      "resultRecordCount=#{PER_PAGE}",
+      "resultOffset=#{offset}",
+    ].join("&")
+
+    "#{ARCGIS_BASE_URL}#{api_name}/FeatureServer/0/query?#{params}"
+  end
+end

--- a/app/services/ons_data_import/import_cities.rb
+++ b/app/services/ons_data_import/import_cities.rb
@@ -1,0 +1,17 @@
+class OnsDataImport::ImportCities < OnsDataImport::Base
+  def location_type
+    :cities
+  end
+
+  def api_name
+    "Major_Towns_and_Cities_December_2015_Boundaries"
+  end
+
+  def name_field
+    "TCITY15NM"
+  end
+
+  def in_scope?(location_name)
+    DOWNCASE_ONS_CITIES.include?(location_name)
+  end
+end

--- a/app/services/ons_data_import/import_counties.rb
+++ b/app/services/ons_data_import/import_counties.rb
@@ -1,0 +1,17 @@
+class OnsDataImport::ImportCounties < OnsDataImport::Base
+  def location_type
+    :counties
+  end
+
+  def api_name
+    "Counties_and_Unitary_Authorities_April_2019_EW_BUC_v2"
+  end
+
+  def name_field
+    "CTYUA19NM"
+  end
+
+  def in_scope?(location_name)
+    DOWNCASE_ONS_COUNTIES_AND_UNITARY_AUTHORITIES.include?(location_name)
+  end
+end

--- a/app/services/ons_data_import/import_regions.rb
+++ b/app/services/ons_data_import/import_regions.rb
@@ -1,0 +1,17 @@
+class OnsDataImport::ImportRegions < OnsDataImport::Base
+  def location_type
+    :regions
+  end
+
+  def api_name
+    "regions"
+  end
+
+  def name_field
+    "GOR10NM"
+  end
+
+  def in_scope?(location_name)
+    DOWNCASE_ONS_REGIONS.include?(location_name)
+  end
+end

--- a/db/migrate/20210917134224_add_geo_polygons_to_location_polygons.rb
+++ b/db/migrate/20210917134224_add_geo_polygons_to_location_polygons.rb
@@ -1,0 +1,6 @@
+class AddGeoPolygonsToLocationPolygons < ActiveRecord::Migration[6.1]
+  def change
+    add_column :location_polygons, :area, :geometry, geographic: true
+    add_index :location_polygons, :area, using: :gist
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -256,6 +256,8 @@ ActiveRecord::Schema.define(version: 2021_10_06_100816) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "buffers"
+    t.geography "area", limit: {:srid=>4326, :type=>"geometry", :geographic=>true}
+    t.index ["area"], name: "index_location_polygons_on_area", using: :gist
   end
 
   create_table "notifications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -35,8 +35,28 @@ namespace :gias do
 end
 
 namespace :ons do
+  # TODO: Legacy task - remove after Algolia migration. Depends on the new task to make them both
+  # run.
   desc "Import all location polygons"
-  task import_location_polygons: :environment do
+  task import_location_polygons: %i[environment import_all] do
     %i[regions counties cities].each { |api_location_type| ImportPolygons.new(api_location_type: api_location_type).call }
+  end
+
+  desc "Import all ONS areas"
+  task import_all: %i[import_counties import_cities import_regions]
+
+  desc "Import ONS counties"
+  task import_counties: :environment do
+    OnsDataImport::ImportCounties.new.call
+  end
+
+  desc "Import ONS cities"
+  task import_cities: :environment do
+    OnsDataImport::ImportCities.new.call
+  end
+
+  desc "Import ONS regions"
+  task import_regions: :environment do
+    OnsDataImport::ImportRegions.new.call
   end
 end


### PR DESCRIPTION
- Add a new geographic `area` column on `LocationPolygon` model to
  supersede legacy raw JSON `buffer` data
- Rewrite import of ONS data to be more efficient and import data
  directly as GeoJSON into the geographic column

This keeps the legacy task and column around for now until we have
verified everything works as intended and we can do buffer caluclation
directly in PostGIS.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3221