### PR TITLE
Revert "Add logging to help debug new error"

### DIFF
--- a/app/services/search/location_builder.rb
+++ b/app/services/search/location_builder.rb
@@ -44,12 +44,8 @@ class Search::LocationBuilder
     @polygon_boundaries = []
     locations.compact.each do |location|
       polygons = location.buffers[radius.to_s]
-      begin
-        polygons.each do |polygon|
-          @polygon_boundaries.push(polygon)
-        end
-      rescue NoMethodError
-        Rollbar.log(:error, "LocationPolygon buffer missing for radius #{radius} for LocationPolygon #{location.name}") if polygons.nil?
+      polygons.each do |polygon|
+        @polygon_boundaries.push(polygon)
       end
     end
   end


### PR DESCRIPTION
Reverts DFE-Digital/teaching-vacancies#4060

We found that these errors aren't 'real', they are the result of bingbot inventing new parameters to throw at our search while crawling (specifically, non-existent radiuses such as 576 miles). Now our error logging is very noisy because each error has a different error message. So stop logging these errors.