### PR TITLE
Add geolocation field to `Vacancy` model

### DIFF
--- a/db/migrate/20211008104739_add_geolocation_to_vacancy.rb
+++ b/db/migrate/20211008104739_add_geolocation_to_vacancy.rb
@@ -1,0 +1,6 @@
+class AddGeolocationToVacancy < ActiveRecord::Migration[6.1]
+  def change
+    add_column :vacancies, :geolocation, :geometry, geographic: true
+    add_index :vacancies, :geolocation, using: :gist
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_07_155322) do
+ActiveRecord::Schema.define(version: 2021_10_08_104739) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -466,7 +466,9 @@ ActiveRecord::Schema.define(version: 2021_10_07_155322) do
     t.string "postcode_from_mean_geolocation"
     t.integer "phase"
     t.integer "key_stages", array: true
+    t.geography "geolocation", limit: {:srid=>4326, :type=>"geometry", :geographic=>true}
     t.index ["expires_at"], name: "index_vacancies_on_expires_at"
+    t.index ["geolocation"], name: "index_vacancies_on_geolocation", using: :gist
     t.index ["initially_indexed"], name: "index_vacancies_on_initially_indexed"
     t.index ["publisher_id"], name: "index_vacancies_on_publisher_id"
     t.index ["publisher_organisation_id"], name: "index_vacancies_on_publisher_organisation_id"

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -654,4 +654,56 @@ RSpec.describe Vacancy do
       end
     end
   end
+
+  describe "#geolocation" do
+    subject { create(:vacancy, job_location: job_location, organisations: organisations) }
+
+    context "for single school vacancies" do
+      let(:job_location) { :at_one_school }
+      let(:organisations) { [create(:school, geopoint: "POINT(1 2)")] }
+
+      it "is set to a point" do
+        expect(subject.geolocation.lat).to eq(2)
+        expect(subject.geolocation.lon).to eq(1)
+      end
+    end
+
+    context "for trust central office vacancies" do
+      let(:job_location) { :central_office }
+      let(:organisations) { [create(:trust, geopoint: "POINT(1 2)")] }
+
+      it "is set to a point" do
+        expect(subject.geolocation.lat).to eq(2)
+        expect(subject.geolocation.lon).to eq(1)
+      end
+    end
+
+    context "for multi school vacancies" do
+      let(:job_location) { :at_multiple_schools }
+      let(:organisations) { [create(:school, geopoint: "POINT(1 2)"), create(:school, geopoint: "POINT(3 4)")] }
+
+      it "is set to a multipoint" do
+        expect(subject.geolocation.map(&:lat)).to contain_exactly(2, 4)
+        expect(subject.geolocation.map(&:lon)).to contain_exactly(1, 3)
+      end
+    end
+
+    context "if there is no organisation" do
+      let(:job_location) { :at_one_school }
+      let(:organisations) { [] }
+
+      it "is set to nil" do
+        expect(subject.geolocation).to be_nil
+      end
+    end
+
+    context "if all organisations have no geopoint" do
+      let(:job_location) { :at_multiple_schools }
+      let(:organisations) { [create(:school, geopoint: nil)] }
+
+      it "is set to nil" do
+        expect(subject.geolocation).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
This denormalises our data model a bit to make querying for vacancies
more efficient, by adding a `geolocation` column to vacancies that is
populated whenever the organisations or job location for the vacancy
change.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3222