### PR TITLE
Move concerns out of vacancy subfolder

### DIFF
--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -1,4 +1,4 @@
-module Vacancy::Indexable
+module Indexable
   extend ActiveSupport::Concern
 
   INDEX_NAME = [Rails.configuration.algolia_index_prefix, DOMAIN, Vacancy].compact.join("-").freeze

--- a/app/models/concerns/phaseable.rb
+++ b/app/models/concerns/phaseable.rb
@@ -1,4 +1,4 @@
-module Vacancy::Phaseable
+module Phaseable
   extend ActiveSupport::Concern
 
   def allow_phase_to_be_set?

--- a/app/models/concerns/resettable.rb
+++ b/app/models/concerns/resettable.rb
@@ -1,4 +1,4 @@
-module Vacancy::Resettable
+module Resettable
   extend ActiveSupport::Concern
 
   included do


### PR DESCRIPTION
## Issue:

Whilst working on another ticket, when hitting a breakpoint I noticed that there appears to be an issue loading the concerns found in `app/models/concerns/vacancy` in the organisations controller.

## To reproduce the problem 

- Put a breakpoint in the organisation controller's show action.
- Login as a publisher. You should hit the breakpoint. Run `Vacancy.first`

- What I see:

```
[1] pry(#<Publishers::OrganisationsController>)> Vacancy.first
NameError: uninitialized constant Vacancy::Indexable
```

The changes included in this PR seem to fix this issue, but I'm not really sure what's causing it. Does anyone have any suggestions?