### PR TITLE
Move concerns out of vacancy directory

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -93,7 +93,7 @@ Metrics/BlockLength:
   Exclude:
     - "config/**/*"
     - "spec/**/*"
-    - "app/models/concerns/vacancy/indexable.rb"
+    - "app/models/concerns/indexable.rb"
 
 Metrics/ClassLength:
   Max: 156 # Default 100

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -1,4 +1,4 @@
-module Vacancy::Indexable
+module Indexable
   extend ActiveSupport::Concern
 
   INDEX_NAME = [Rails.configuration.algolia_index_prefix, DOMAIN, Vacancy].compact.join("-").freeze

--- a/app/models/concerns/phaseable.rb
+++ b/app/models/concerns/phaseable.rb
@@ -1,4 +1,4 @@
-module Vacancy::Phaseable
+module Phaseable
   extend ActiveSupport::Concern
 
   def allow_phase_to_be_set?

--- a/app/models/concerns/resettable.rb
+++ b/app/models/concerns/resettable.rb
@@ -1,4 +1,4 @@
-module Vacancy::Resettable
+module Resettable
   extend ActiveSupport::Concern
 
   included do

--- a/app/services/search/vacancy_search_sort.rb
+++ b/app/services/search/vacancy_search_sort.rb
@@ -56,6 +56,6 @@ class Search::VacancySearchSort
   def algolia_replica
     return nil unless algolia_replica_suffix.present?
 
-    [Vacancy::Indexable::INDEX_NAME, algolia_replica_suffix].join("_")
+    [Indexable::INDEX_NAME, algolia_replica_suffix].join("_")
   end
 end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -8,7 +8,7 @@ namespace :algolia do
   task remove_indices: :environment do
     replicas = Vacancy.index.get_settings["replicas"]
     Vacancy.index.set_settings({ replicas: [] })
-    Algolia.client.delete_index(Vacancy::Indexable::INDEX_NAME)
+    Algolia.client.delete_index(Indexable::INDEX_NAME)
     sleep(5) # Needed otherwise replicas are still bound to the primary
     replicas.each { |replica| Algolia.client.delete_index(replica) }
   end

--- a/spec/services/search/vacancy_search_sort_spec.rb
+++ b/spec/services/search/vacancy_search_sort_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Search::VacancySearchSort do
       it { is_expected.to eq(Search::VacancySearchSort::PUBLISH_ON_DESC) }
 
       it "uses the default search replica" do
-        expect(subject.algolia_replica).to eq("#{Vacancy::Indexable::INDEX_NAME}_publish_on_desc")
+        expect(subject.algolia_replica).to eq("#{Indexable::INDEX_NAME}_publish_on_desc")
       end
     end
   end
@@ -31,7 +31,7 @@ RSpec.describe Search::VacancySearchSort do
     it { is_expected.to eq(Search::VacancySearchSort::PUBLISH_ON_DESC) }
 
     it "uses the default search replica" do
-      expect(subject.algolia_replica).to eq("#{Vacancy::Indexable::INDEX_NAME}_publish_on_desc")
+      expect(subject.algolia_replica).to eq("#{Indexable::INDEX_NAME}_publish_on_desc")
     end
   end
 
@@ -41,7 +41,7 @@ RSpec.describe Search::VacancySearchSort do
     it { is_expected.to eq(Search::VacancySearchSort::EXPIRES_AT_DESC) }
 
     it "uses the specified search replica" do
-      expect(subject.algolia_replica).to eq("#{Vacancy::Indexable::INDEX_NAME}_expires_at_desc")
+      expect(subject.algolia_replica).to eq("#{Indexable::INDEX_NAME}_expires_at_desc")
     end
 
     context "and a keyword is specified" do
@@ -50,7 +50,7 @@ RSpec.describe Search::VacancySearchSort do
       it { is_expected.to eq(Search::VacancySearchSort::EXPIRES_AT_DESC) }
 
       it "uses the specified search replica" do
-        expect(subject.algolia_replica).to eq("#{Vacancy::Indexable::INDEX_NAME}_expires_at_desc")
+        expect(subject.algolia_replica).to eq("#{Indexable::INDEX_NAME}_expires_at_desc")
       end
     end
   end


### PR DESCRIPTION
## Issue:

Whilst working on another ticket, when hitting a breakpoint I noticed that there appears to be an issue loading the concerns found in `app/models/concerns/vacancy` in the organisations controller.

## To reproduce the problem 

- Put a breakpoint in the organisation controller's show action.
- Login as a publisher. You should hit the breakpoint. Run `Vacancy.first`

- What I see:

```
[1] pry(#<Publishers::OrganisationsController>)> Vacancy.first
NameError: uninitialized constant Vacancy::Indexable
```

The changes included in this PR seem to fix this issue, but I'm not really sure what's causing it. Does anyone have any suggestions?