### PR TITLE
[TEVA-3219] Add hiring staff sign-in section

### DIFF
--- a/app/frontend/src/styles/application/jobseekers/search-panel.scss
+++ b/app/frontend/src/styles/application/jobseekers/search-panel.scss
@@ -7,6 +7,18 @@
   padding-top: govuk-spacing(1);
   position: relative;
   width: 100vw;
+
+  h1,
+  h2,
+  label,
+  p,
+  .govuk-hint,
+  .govuk-link,
+  .govuk-link:not(:focus),
+  .govuk-label.govuk-label--s,
+  .js-location-finder__link {
+    color: govuk-colour('white');
+  }
 }
 
 .search-panel {
@@ -15,16 +27,6 @@
 
   h1 {
     margin-bottom: govuk-spacing(3);
-  }
-
-  h1,
-  label,
-  p,
-  .govuk-hint,
-  .govuk-link,
-  .govuk-label.govuk-label--s,
-  .js-location-finder__link {
-    color: govuk-colour('white');
   }
 
   .govuk-button--start {

--- a/app/frontend/src/styles/application/signin.scss
+++ b/app/frontend/src/styles/application/signin.scss
@@ -1,12 +1,9 @@
 .signin {
   @include govuk-responsive-padding(5);
-  background-color: govuk-colour('dark-blue');
   margin-bottom: govuk-spacing(5);
   margin-top: govuk-spacing(3);
 
-  h2,
-  p,
-  .govuk-link:not(:focus) {
-    color: govuk-colour('white');
+  &__jobseeker {
+    background-color: govuk-colour('dark-blue');
   }
 }

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -6,11 +6,17 @@
       .govuk-grid-column-two-thirds
         .search-panel.location-search = render "search"
       .govuk-grid-column-one-third
-        .signin
+        .signin.signin__jobseeker
           - if jobseeker_signed_in?
-            = render "signed_in_jobseeker"
+              = render "signed_in_jobseeker"
           - else
-            = render "signed_out_jobseeker"
+              = render "signed_out_jobseeker"
+        - unless signed_in?
+          .signin
+            h2.govuk-heading-m = t(".publisher_signin.title")
+            p.govuk-body = t(".publisher_signin.description_html",
+              signin_link: govuk_link_to(t(".publisher_signin.link_text.sign_in"), publishers_sign_in_path, class: "govuk-link--no-visited-state"),
+              signup_link: govuk_link_to(t(".publisher_signin.link_text.sign_up"), page_path("dsi-account-request"), class: "govuk-link--no-visited-state"))
 
 .govuk-main-wrapper class="govuk-!-padding-top-0"
   .govuk-grid-row

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -215,6 +215,12 @@ en:
   home:
     index:
       browse_all: Browse all teaching jobs in England
+      publisher_signin: 
+        title: Advertise a school job
+        description_html: "%{signin_link} to manage your job listings and applicants or %{signup_link}."
+        link_text:
+          sign_in: Sign in
+          sign_up: sign up
       title: Find a job in teaching
     signed_in_jobseeker:
       description: Apply for jobs you are interested in, and check the status of your applications.

--- a/spec/system/jobseekers_can_sign_in_to_their_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_in_to_their_account_spec.rb
@@ -33,6 +33,20 @@ RSpec.describe "Jobseekers can sign in to their account" do
         .to have_triggered_event(:jobseeker_sign_in_attempt)
         .with_data(expected_data)
     end
+
+    it "does not display the Hiring staff sign-in section" do
+      sign_in_jobseeker(email: email, password: password)
+      visit root_path
+
+      within ".search-panel-banner .govuk-grid-column-one-third" do
+        expect(page).not_to have_content(I18n.t("home.index.publisher_signin.title"))
+        expect(page).not_to have_content(I18n.t("home.index.publisher_signin.description_html",
+                                                signin_link: I18n.t("home.index.publisher_signin.link_text.sign_in"),
+                                                signup_link: I18n.t("home.index.publisher_signin.link_text.sign_up")))
+        expect(page).not_to have_link(I18n.t("home.index.publisher_signin.link_text.sign_in"), href: publishers_sign_in_path)
+        expect(page).not_to have_link(I18n.t("home.index.publisher_signin.link_text.sign_up"), href: page_path("dsi-account-request"))
+      end
+    end
   end
 
   context "when entering incorrect details" do

--- a/spec/system/publishers_can_sign_in_with_dfe_spec.rb
+++ b/spec/system/publishers_can_sign_in_with_dfe_spec.rb
@@ -2,9 +2,22 @@ require "rails_helper"
 require "message_encryptor"
 
 RSpec.shared_examples "a successful sign in" do
-  scenario "it signs in the user successfully" do
+  before do
     visit root_path
+  end
 
+  scenario "it displays the Hiring staff sign-in section" do
+    within ".search-panel-banner .govuk-grid-column-one-third" do
+      expect(page).to have_content(I18n.t("home.index.publisher_signin.title"))
+      expect(page).to have_content(I18n.t("home.index.publisher_signin.description_html",
+                                          signin_link: I18n.t("home.index.publisher_signin.link_text.sign_in"),
+                                          signup_link: I18n.t("home.index.publisher_signin.link_text.sign_up")))
+      expect(page).to have_link(I18n.t("home.index.publisher_signin.link_text.sign_in"), href: publishers_sign_in_path)
+      expect(page).to have_link(I18n.t("home.index.publisher_signin.link_text.sign_up"), href: page_path("dsi-account-request"))
+    end
+  end
+
+  scenario "it signs in the user successfully" do
     expect { sign_in_publisher }
       .to have_triggered_event(:publisher_sign_in_attempt)
       .with_base_data(user_anonymised_publisher_id: anonymised_form_of(user_oid))
@@ -12,6 +25,20 @@ RSpec.shared_examples "a successful sign in" do
 
     within("nav") { expect(page).to have_selector(:link_or_button, I18n.t("nav.sign_out")) }
     within("nav") { expect(page).to have_selector(:link_or_button, I18n.t("nav.school_page_link")) }
+  end
+
+  scenario "it does not display the Hiring staff sign-in section" do
+    sign_in_publisher
+    visit root_path
+
+    within ".search-panel-banner .govuk-grid-column-one-third" do
+      expect(page).not_to have_content(I18n.t("home.index.publisher_signin.title"))
+      expect(page).not_to have_content(I18n.t("home.index.publisher_signin.description_html",
+                                              signin_link: I18n.t("home.index.publisher_signin.link_text.sign_in"),
+                                              signup_link: I18n.t("home.index.publisher_signin.link_text.sign_up")))
+      expect(page).not_to have_link(I18n.t("home.index.publisher_signin.link_text.sign_in"), href: publishers_sign_in_path)
+      expect(page).not_to have_link(I18n.t("home.index.publisher_signin.link_text.sign_up"), href: page_path("dsi-account-request"))
+    end
   end
 end
 


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3219

## Changes in this PR:

This PR adds the Hiring staff sign-in section ("Advertise a school job") on the main page. This section contains links directing the user to the pages where they can sign in to a Hiring staff account or request a Hiring staff account. This section only appears when a user is not signed in to either a jobseeker or a hiring staff account.

## Screenshots of UI changes:

### Before

![image](https://user-images.githubusercontent.com/24639777/136573599-7ea50f8f-aadb-4d55-9a3a-45102da18372.png)

### After

![image](https://user-images.githubusercontent.com/24639777/136573294-e568317f-8c93-4b4a-a801-f6b6aea7e949.png)
