### PR TITLE
[TEVA-3209] prevent google indexing jobs with duplcate query params

### DIFF
--- a/app/views/kaminari/_page.html.slim
+++ b/app/views/kaminari/_page.html.slim
@@ -7,4 +7,7 @@
 /    per_page:      number of items to fetch per page
 /    remote:        data-remote
 li
-  = link_to page, url, remote: remote, rel: page.rel, class: "pagination__item#{' current' if page.current?}"
+  - if page.current?
+    span.pagination__item.current = page
+  - else
+    = link_to page, url, remote: remote, rel: page.rel, class: "pagination__item"

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -5,3 +5,4 @@ Disallow: /check
 Disallow: /subscriptions/
 Disallow: /documents/
 Disallow: /attachments/
+Disallow: /teaching-jobs-in-*?location=*


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-3209

## Changes in this PR:

- prevent google indexing teaching-jobs-in-lalaland/?location=lalaland urls
- prevent paginated results pages linking to themselves
