### PR TITLE
[TEVA-3251] Change link to application pack

### DIFF
--- a/app/views/publishers/new_features/show.html.slim
+++ b/app/views/publishers/new_features/show.html.slim
@@ -12,7 +12,7 @@
 
         p.govuk-body-l = t("new_features.content")
 
-        = govuk_link_to(t("new_features.application_pack_link"), "teaching-vacancies-application-form-guide-sept-21.pdf", target: "_blank")
+        = t("application_pack.link_html")
 
         = f.govuk_check_boxes_fieldset :dismiss,
           legend: nil,

--- a/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
+++ b/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
@@ -21,7 +21,8 @@
             = f.govuk_text_area :how_to_apply, label: { size: "s" }, rows: 10, required: true
             = f.govuk_url_field :application_link, label: { size: "s" }
         - else
-          = f.govuk_radio_buttons_fieldset :enable_job_applications do
+          = f.govuk_radio_buttons_fieldset :enable_job_applications,
+            hint: { text: t("helpers.hint.publishers_job_listing_applying_for_the_job_form.enable_job_applications_html", link: t("application_pack.link_html")) } do
             = f.govuk_radio_button :enable_job_applications, true, link_errors: true do
               = f.govuk_text_area :personal_statement_guidance, label: { size: "s" }
             = f.govuk_radio_button :enable_job_applications, "false" do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,6 +14,9 @@ en:
     title: Teaching Vacancies
     environment_html: This is not the live Teaching Vacancies website. You are currently viewing the <strong>%{environment}</strong> version of the site.
 
+  application_pack:
+    link_html: <a class="govuk-link" download="Teaching Vacancies application form guide" href="/teaching-vacancies-application-form-guide-sept-21.pdf">Download more information about the application form (2.7 MB, PDF)</a>
+
   banners:
     important: Important
     success: Success

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -175,7 +175,7 @@ en:
         enable_job_applications_html: >-
           Candidates can apply using the Teaching Vacancies application form,
           or you can direct them to another service, like the local authority or a school's website.
-          <a class="govuk-link" target="_blank" href="/pages/job-application-preview">Preview the application form (opens in new tab)</a>
+          %{link}
         how_to_apply: Explain how to apply for the job, referring to any relevant documents
         local_authority_visits: >-
           Explain how a candidate can arrange visits within the local authority (give a phone number if possible)


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3251

## Changes in this PR:

This PR replaces the "application preview" link in the "Applying for the job" step in the Create a job journey with a link to download the new application pack.

## Screenshots of UI changes:

### Before

![image](https://user-images.githubusercontent.com/24639777/136776217-9d366dfb-d154-436e-8734-9b36086c138a.png)

### After

![image](https://user-images.githubusercontent.com/24639777/136777016-5ddc15c7-cfd6-4555-a02b-8ac1456513d4.png)
