### PR TITLE
Remove NQT job alert page redirect

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -188,8 +188,6 @@ Rails.application.routes.draw do
   match "/500", as: :internal_server_error, to: "errors#internal_server_error", via: :all
   match "/maintenance", as: :maintenance, to: "errors#maintenance", via: :all
 
-  get "teaching-jobs-for-nqt_suitable", to: redirect("/teaching-jobs-for-ect-suitable")
-
   get "/teaching-jobs-:not_normalized",
       to: redirect { |params| "/teaching-jobs-#{params[:not_normalized].parameterize.dasherize}" },
       constraints: ->(request) { request.params[:not_normalized] != request.params[:not_normalized].parameterize.dasherize }


### PR DESCRIPTION
We allowed a few weeks for people to find the new url.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3132