### PR TITLE
Fix bug with Kaminari and Algolia

### DIFF
--- a/app/services/search/strategies/algolia.rb
+++ b/app/services/search/strategies/algolia.rb
@@ -15,7 +15,7 @@ class Search::Strategies::Algolia
     @vacancies ||= Vacancy.includes(:organisations).search(@keyword, search_arguments)
   rescue Algolia::AlgoliaProtocolError => e
     Rollbar.error("Algolia search error", details: e, search_arguments: search_arguments)
-    @vacancies = Vacancy.none
+    @vacancies = Vacancy.none.page(0).per(0)
   end
 
   def total_count


### PR DESCRIPTION
When an `Algolia::AlgoliaProtocolError` error is encountered while
loading vacancies, the `Vacancy.none` scope was being returned
without being run through Kaminari pagination.

This fixes that issue, meaning the returned scope will now
have the usual Kaminari methods like `total_pages`.

It should be noted that this error catching could be hiding a
variety of fixable issues with Algolia, for example these
particular calls are only erroring because there's no VCR cassette
for them.  In production there could be more significant errors.

It might be worth notifying an error capture service before returning
empty scopes in this way.