### PR TITLE
[TEVA-2679] Reduce chance of encoding errors with open/close quotes

### DIFF
--- a/app/frontend/src/styles/base/_utilities.scss
+++ b/app/frontend/src/styles/base/_utilities.scss
@@ -78,16 +78,6 @@
   text-transform: capitalize;
 }
 
-.text-wrap-apostrophe {
-  &::before {
-    content: '\2018';
-  }
-
-  &::after {
-    content: '\2019';
-  }
-}
-
 .divider-bottom {
   border-bottom: 3px solid $govuk-border-colour;
   margin-bottom: $govuk-gutter;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -498,7 +498,7 @@ en:
         other: Find a job in teaching - Search results page %{count}
       wider_search_suggestions:
         heading:
-          keyword_html: Try browsing for <span class='text-wrap-apostrophe'>%{keyword}</span> in a wider location search
+          keyword_html: Try browsing for &lsquo;%{keyword}&rsquo; in a wider location search
           no_keyword: Try browsing in a wider location search
         suggestion_html: '%{search_link} %{count}'
         radius_distance: '%{radius} miles'

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -72,50 +72,50 @@ en:
       keyword_html:
         one: >-
           <span class='govuk-!-font-weight-bold'>%{jobs_count}</span> job matches
-          <span class='govuk-!-font-weight-bold text-wrap-apostrophe'>%{keyword}</span>
+          <span class='govuk-!-font-weight-bold'>&lsquo;%{keyword}&rsquo;</span>
         other: >-
           <span class='govuk-!-font-weight-bold'>%{jobs_count}</span> jobs match
-          <span class='govuk-!-font-weight-bold text-wrap-apostrophe'>%{keyword}</span>
+          <span class='govuk-!-font-weight-bold'>&lsquo;%{keyword}&rsquo;</span>
       location_html:
         one: >-
           <span class="govuk-!-font-weight-bold">%{jobs_count}</span> job found within
           <span class='govuk-!-font-weight-bold'>%{radius} %{units}</span> of
-          <span class='govuk-!-font-weight-bold text-capitalize text-wrap-apostrophe'>%{location}</span>
+          <span class='govuk-!-font-weight-bold text-capitalize'>&lsquo;%{location}&rsquo;</span>
         other: >-
           <span class="govuk-!-font-weight-bold">%{jobs_count}</span> jobs found within
           <span class='govuk-!-font-weight-bold'>%{radius} %{units}</span> of
-          <span class="govuk-!-font-weight-bold text-capitalize text-wrap-apostrophe">%{location}</span>
+          <span class="govuk-!-font-weight-bold text-capitalize">&lsquo;%{location}&rsquo;</span>
       location_polygon_html:
         one: >-
           <span class="govuk-!-font-weight-bold">%{jobs_count}</span> job found within
           <span class='govuk-!-font-weight-bold'>%{radius} %{units}</span> of
-          <span class='govuk-!-font-weight-bold text-capitalize text-wrap-apostrophe'>%{location}</span>
+          <span class='govuk-!-font-weight-bold text-capitalize'>&lsquo;%{location}&rsquo;</span>
         other: >-
           <span class="govuk-!-font-weight-bold">%{jobs_count}</span> jobs found within
           <span class='govuk-!-font-weight-bold'>%{radius} %{units}</span> of
-          <span class="govuk-!-font-weight-bold text-capitalize text-wrap-apostrophe">%{location}</span>
+          <span class="govuk-!-font-weight-bold text-capitalize">&lsquo;%{location}&rsquo;</span>
       keyword_location_html:
         one: >-
           <span class='govuk-!-font-weight-bold'>%{jobs_count}</span> job matches
-          <span class='govuk-!-font-weight-bold text-wrap-apostrophe'>%{keyword}</span> within
+          <span class='govuk-!-font-weight-bold'>&lsquo;%{keyword}&rsquo;</span> within
           <span class='govuk-!-font-weight-bold'>%{radius} %{units}</span> of
-          <span class='govuk-!-font-weight-bold text-wrap-apostrophe text-capitalize'>%{location}</span>
+          <span class='govuk-!-font-weight-bold text-capitalize'>&lsquo;%{location}&rsquo;</span>
         other: >-
           <span class="govuk-!-font-weight-bold">%{jobs_count}</span> jobs match
-          <span class='govuk-!-font-weight-bold text-wrap-apostrophe'>%{keyword}</span> within
+          <span class='govuk-!-font-weight-bold'>&lsquo;%{keyword}&rsquo;</span> within
           <span class='govuk-!-font-weight-bold'>%{radius} %{units}</span> of
-          <span class="govuk-!-font-weight-bold text-wrap-apostrophe text-capitalize">%{location}</span>
+          <span class="govuk-!-font-weight-bold text-capitalize">&lsquo;%{location}&rsquo;</span>
       keyword_location_polygon_html:
         one: >-
           <span class='govuk-!-font-weight-bold'>%{jobs_count}</span> job matches
-          <span class='govuk-!-font-weight-bold text-wrap-apostrophe'>%{keyword}</span> within
+          <span class='govuk-!-font-weight-bold'>&lsquo;%{keyword}&rsquo;</span> within
           <span class='govuk-!-font-weight-bold'>%{radius} %{units}</span> of
-          <span class='govuk-!-font-weight-bold text-wrap-apostrophe text-capitalize'>%{location}</span>
+          <span class='govuk-!-font-weight-bold text-capitalize'>&lsquo;%{location}&rsquo;</span>
         other: >-
           <span class="govuk-!-font-weight-bold">%{jobs_count}</span> jobs match
-          <span class='govuk-!-font-weight-bold text-wrap-apostrophe'>%{keyword}</span> within
+          <span class='govuk-!-font-weight-bold'>&lsquo;%{keyword}&rsquo;</span> within
           <span class='govuk-!-font-weight-bold'>%{radius} %{units}</span> of
-          <span class="govuk-!-font-weight-bold text-wrap-apostrophe text-capitalize">%{location}</span>
+          <span class="govuk-!-font-weight-bold text-capitalize">&lsquo;%{location}&rsquo;</span>
       unit_of_length: mile
 
     legacy_job_alert:


### PR DESCRIPTION
Using the html & character directly, rather than appending something using css pseudo
classes, is more conventional and removes an encoding step.

I was unable to duplicate the reported bug where these quotes had been seen in a mangled
form: â€™

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2679
