### PR TITLE
[TEVA-3247] Allow less strict URLs on job listings

### DIFF
--- a/app/form_models/publishers/job_listing/applying_for_the_job_form.rb
+++ b/app/form_models/publishers/job_listing/applying_for_the_job_form.rb
@@ -18,6 +18,10 @@ class Publishers::JobListing::ApplyingForTheJobForm < Publishers::JobListing::Va
   end
   attr_accessor(*fields)
 
+  def application_link=(link)
+    @application_link = Addressable::URI.heuristic_parse(link).to_s
+  end
+
   private
 
   def override_enable_job_applications!

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -28,7 +28,7 @@ en:
       not_a_number: Enter the year the qualification was awarded
   organisation_errors: &organisation_errors
     website:
-      url: Enter a link in the correct format, like http://www.school.ac.uk
+      url: Enter a link in the correct format, like www.school.ac.uk
   subscription_errors: &subscription_errors
     email:
       blank: Enter your email address
@@ -173,7 +173,7 @@ en:
       on_or_before: The date the job starts must be less than two years in the future
   applying_for_the_job_errors: &applying_for_the_job_errors
     application_link:
-      url: Enter a link in the correct format, like http://www.school.ac.uk
+      url: Enter a link in the correct format, like www.school.ac.uk
     enable_job_applications:
       cannot_be_changed_once_listed: >-
         You cannot change how you would like candidates to apply now that your listing is published

--- a/spec/form_models/publishers/job_listing/applying_for_the_job_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/applying_for_the_job_form_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Publishers::JobListing::ApplyingForTheJobForm, type: :model do
   let(:vacancy) { build_stubbed(:vacancy) }
 
   it { is_expected.to allow_value("https://www.this-is-a-test-url.tvs").for(:application_link) }
+  it { is_expected.to allow_value("www.this-is-a-test-url.tvs").for(:application_link) }
   it { is_expected.to allow_value("").for(:application_link) }
   it { is_expected.not_to allow_value("invalid_link").for(:application_link) }
 


### PR DESCRIPTION
This uses the same normalization logic as during school imports.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3247

## Changes in this PR:

- Job listings are no longer so strict about requiring a full URL (e.g. http://)
- The error message for an invalid URL no longer includes the http part

## Screenshots of UI changes:

### Before

<img width="836" alt="Screenshot 2021-10-12 at 15 56 57" src="https://user-images.githubusercontent.com/109225/136980628-d2b8cadd-38bf-46b2-a663-16e6ed262fe6.png">

### After

<img width="836" alt="Screenshot 2021-10-12 at 15 56 29" src="https://user-images.githubusercontent.com/109225/136980585-230a34e1-3049-48bc-a6f8-0f1c94874ffa.png">
