### PR TITLE
Fix a Kaminari bug

### DIFF
--- a/app/services/search/strategies/algolia.rb
+++ b/app/services/search/strategies/algolia.rb
@@ -15,7 +15,7 @@ class Search::Strategies::Algolia
     @vacancies ||= Vacancy.includes(:organisations).search(@keyword, search_arguments)
   rescue Algolia::AlgoliaProtocolError => e
     Rollbar.error("Algolia search error", details: e, search_arguments: search_arguments)
-    @vacancies = Vacancy.none.page(0).per(0)
+    @vacancies = Vacancy.none.page(1)
   end
 
   def total_count


### PR DESCRIPTION
`.page(0).per(0)` is apparently not good, so let's just select the first
page (of these empty results).  We don't actually care about the page
number or size, we just want Kaminari to process it.

Also, I previously said we should probably notify e.g. rollbar about these, somehow missing that we were already doing that.  Oops!
