### PR TITLE
Fix bug with education phase landing pages

### DIFF
--- a/app/services/vacancy_facets.rb
+++ b/app/services/vacancy_facets.rb
@@ -52,7 +52,7 @@ class VacancyFacets
   end
 
   def education_phase_facet
-    School.available_readable_phases.each_with_object({}) { |phase, facets| facets[phase] = algolia_facet_count(education_phases: [phase]) }
+    School.available_readable_phases.each_with_object({}) { |phase, facets| facets[phase] = algolia_facet_count(phases: [phase]) }
   end
 
   def job_role_facet


### PR DESCRIPTION
These were sending malformed arguments to the Search::FiltersBuilder.