### PR TITLE
[TEVA-2538] Remove notification banner

### DIFF
--- a/app/frontend/src/styles/application.scss
+++ b/app/frontend/src/styles/application.scss
@@ -18,9 +18,10 @@ $govuk-new-link-styles: true;
 
 @import 'application/accordion';
 @import 'application/applications';
-@import 'application/govuk-notification-banner';
-@import 'application/full-width-mast';
 @import 'application/form';
+@import 'application/full-width-mast';
+@import 'application/govuk-notification-banner';
+@import 'application/govuk-phase-banner';
 @import 'application/icons';
 @import 'application/pagination';
 @import 'application/panel';
@@ -34,8 +35,8 @@ $govuk-new-link-styles: true;
 @import 'application/jobseekers/feedback-form';
 @import 'application/jobseekers/filter-vacancies';
 @import 'application/jobseekers/jobseeker';
-@import 'application/jobseekers/location-search';
 @import 'application/jobseekers/keyword-search';
+@import 'application/jobseekers/location-search';
 @import 'application/jobseekers/search-header';
 @import 'application/jobseekers/search-panel';
 @import 'application/jobseekers/vacancies';
@@ -164,10 +165,6 @@ b {
 }
 
 .home_index {
-  .govuk-phase-banner {
-    border-bottom: 0;
-  }
-
   .vacancy-facets {
     .govuk-link {
       display: inline-block;

--- a/app/frontend/src/styles/application/govuk-phase-banner.scss
+++ b/app/frontend/src/styles/application/govuk-phase-banner.scss
@@ -1,0 +1,6 @@
+.home_index,
+.publishers_organisations_show {
+  .govuk-phase-banner {
+    border-bottom: 0;
+  }
+}

--- a/app/views/publishers/organisations/show.html.slim
+++ b/app/views/publishers/organisations/show.html.slim
@@ -3,12 +3,6 @@
 - content_for :skip_links do
   a.govuk-skip-link href="#vacancy-results" Skip to #{t("publishers.vacancies_component.#{@selected_type}.tab_heading")}
 
-- unless current_organisation.local_authority?
-  = govuk_notification_banner title_text: t("banners.important"), classes: "govuk-!-margin-top-3" do
-    = t(".job_applications")
-    br
-    = open_in_new_tab_link_to t(".job_applications_link_text"), page_path("job-application-preview"), class: "govuk-link--no-visited-state"
-
 = render(Publishers::VacanciesComponent.new(organisation: current_organisation,
                                             sort: @sort,
                                             selected_type: @selected_type,


### PR DESCRIPTION
Banner no longer needed due to new features page.

Bottom border of phase banner should be omitted when it's adjacent to a block of solid color,
as in https://dfedigital.atlassian.net/browse/TEVA-3270

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2538

## Screenshots of UI changes:

<img width="1122" alt="Screenshot 2021-10-13 at 10 43 11" src="https://user-images.githubusercontent.com/60350599/137109501-5b629596-71d1-41a5-88df-795fa5ebb250.png">

