### PR TITLE
[TEVA-3291] Use GDS font for all buttons

### DIFF
--- a/app/frontend/src/styles/application.scss
+++ b/app/frontend/src/styles/application.scss
@@ -97,6 +97,10 @@ body {
   }
 }
 
+button:not(.govuk-button) {
+  font-family: 'GDS Transport', arial, sans-serif;
+}
+
 input[type='search'] {
   box-sizing: border-box;
 }


### PR DESCRIPTION
This is primarily to fix the issue whereby filter tags are underlyingly buttons, buttons
do not inherit font-family, and so filter tags come out in the system font.

In general buttons use the gov-uk-button class and so font is already accounted for there.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3291

## Screenshots of UI changes:

### Before

<img width="135" alt="Screenshot 2021-10-13 at 10 58 18" src="https://user-images.githubusercontent.com/60350599/137111801-06cd5c72-69a5-4852-93e0-3d7b0af31b01.png">

### After

<img width="135" alt="Screenshot 2021-10-13 at 10 53 21" src="https://user-images.githubusercontent.com/60350599/137111388-960c21a8-8664-4d02-95f6-6a19ee9076f0.png">
