### PR TITLE
[TEVA-3180] Redirect to documents with a 301 'moved permanently' status

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -4,7 +4,7 @@ class DocumentsController < ApplicationController
                           vacancy_id: StringAnonymiser.new(vacancy.id),
                           document_id: StringAnonymiser.new(document.id),
                           filename: document.filename)
-    redirect_to(document)
+    redirect_to document, status: :moved_permanently
   end
 
   private

--- a/spec/requests/documents_spec.rb
+++ b/spec/requests/documents_spec.rb
@@ -5,10 +5,11 @@ RSpec.describe "Documents" do
   let(:document) { vacancy.supporting_documents.first }
 
   describe "GET #show" do
-    it "redirects to the document link" do
+    it "redirects to the document link, with a 301 status (in order to save it from being crawled)" do
       get job_document_path(vacancy, document)
 
       expect(response).to redirect_to(document)
+      expect(response.status).to eq(301)
     end
 
     it "triggers a `vacancy_document_downloaded` event" do


### PR DESCRIPTION
We want to exclude documents from crawling since it uses up crawl budget that would be better spent elsewhere.

Our first try to fix this is to use a 301 instead of a 302 redirect.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3180

## Next steps:

- [ ] Check that it worked

- [ ] If it doesn't, try some other options mentioned in the discussion on the ticket
