### PR TITLE
[TEVA-3276] Add link to create a job alert to nav

### DIFF
--- a/app/views/jobseekers/subscriptions/index.html.slim
+++ b/app/views/jobseekers/subscriptions/index.html.slim
@@ -25,7 +25,7 @@
           = f.govuk_submit t("jobs.sort_by.submit")
 
       .govuk-grid-column-one-third.create-alert__button
-        = govuk_button_link_to t(".button_create"), new_subscription_path(email: current_jobseeker.email, origin: jobseekers_subscriptions_path)
+        = govuk_button_link_to t(".button_create"), new_subscription_path(origin: jobseekers_subscriptions_path)
 
   .govuk-grid-row
     .govuk-grid-column-full
@@ -45,7 +45,7 @@
 
         - else
           = render EmptySectionComponent.new title: t(".zero_subscriptions_title") do
-            = t(".zero_subscriptions_body_html", link_to: govuk_link_to(t(".link_create"), new_subscription_path(email: current_jobseeker.email, origin: jobseekers_subscriptions_path)))
+            = t(".zero_subscriptions_body_html", link_to: govuk_link_to(t(".link_create"), new_subscription_path(origin: jobseekers_subscriptions_path)))
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -9,9 +9,11 @@
 
   - if jobseeker_signed_in?
     = header.navigation_item text: t("nav.find_job"), href: root_path, active: find_jobs_active?
+    = header.navigation_item text: t("nav.create_a_job_alert"), href: new_subscription_path
     = header.navigation_item text: t("footer.your_account"), href: jobseeker_root_path, active: your_account_active?
     = header.navigation_item text: t("nav.sign_out"), href: destroy_jobseeker_session_path, options: { method: :delete }, classes: "navigation-item--right"
 
   - if !jobseeker_signed_in? && !publisher_signed_in?
     = header.navigation_item text: t("nav.find_job"), href: root_path, active: find_jobs_active?
+    = header.navigation_item text: t("nav.create_a_job_alert"), href: new_subscription_path
     = header.navigation_item text: t("buttons.sign_in"), href: page_path("sign-in"), classes: "navigation-item--right"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -196,6 +196,7 @@ en:
     view_more_or_change: View more or change
 
   nav:
+    create_a_job_alert: Create a job alert
     find_job: Find a teaching job
     for_schools: For schools
     jobseekers_index_link: View public jobs

--- a/spec/system/jobseekers_can_create_a_job_alert_from_the_dashboard_spec.rb
+++ b/spec/system/jobseekers_can_create_a_job_alert_from_the_dashboard_spec.rb
@@ -18,7 +18,9 @@ RSpec.describe "Jobseekers can create a job alert from the dashboard", recaptcha
     end
 
     it "creates a job alert and redirects to the subscriptions index page" do
-      click_on I18n.t("jobseekers.subscriptions.index.link_create")
+      within ".empty-section-component" do
+        click_on I18n.t("jobseekers.subscriptions.index.link_create")
+      end
       an_invalid_form_is_rejected
       expect { create_a_job_alert }.to change { Subscription.count }.by(1)
       and_the_job_alert_is_on_the_index_page
@@ -30,7 +32,9 @@ RSpec.describe "Jobseekers can create a job alert from the dashboard", recaptcha
       end
 
       it "redirects to invalid_recaptcha path" do
-        click_on I18n.t("jobseekers.subscriptions.index.link_create")
+        within ".empty-section-component" do
+          click_on I18n.t("jobseekers.subscriptions.index.link_create")
+        end
         create_a_job_alert
         expect(page).to have_current_path(invalid_recaptcha_path(form_name: "Subscription"))
       end
@@ -47,7 +51,9 @@ RSpec.describe "Jobseekers can create a job alert from the dashboard", recaptcha
     end
 
     it "creates a job alert and redirects to the subscriptions index page" do
-      click_on I18n.t("jobseekers.subscriptions.index.button_create")
+      within ".create-alert__button" do
+        click_on I18n.t("jobseekers.subscriptions.index.button_create")
+      end
       an_invalid_form_is_rejected
       expect { create_a_job_alert }.to change { Subscription.count }.by(1)
       and_the_job_alert_is_on_the_index_page


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3276

## Screenshots of UI changes:

### Jobseeker logged in 

<img width="1207" alt="Screenshot 2021-10-13 at 17 27 04" src="https://user-images.githubusercontent.com/30624173/137174711-2e3d5792-199a-4de4-b44b-aae078b20499.png">


### Logged out 

<img width="1207" alt="Screenshot 2021-10-13 at 17 26 22" src="https://user-images.githubusercontent.com/30624173/137174630-a4cf7970-a7cc-4c52-bb1b-804d6c908ea8.png">


## Questions

- I assume I don't need to write tests for this?
- I notice that the origin is passed in everywhere else we use the `new_subscription_path`.  I assume this is used to assess the performance of the various CTAs? If so, should we be setting the origin when someone clicks on the Create a job alert link in the nav and what should it be set to?