### PR TITLE
Add Vacancy geolocation to analytics.yml

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -312,3 +312,4 @@ shared:
     - working_patterns_details
     - phase
     - key_stages
+    - geolocation


### PR DESCRIPTION
This new field was missing from the fields we send to the data warehouse