### PR TITLE
Create composite polygons on import

### DIFF
--- a/app/jobs/import_polygon_data_job.rb
+++ b/app/jobs/import_polygon_data_job.rb
@@ -5,5 +5,6 @@ class ImportPolygonDataJob < ApplicationJob
     OnsDataImport::ImportCounties.new.call
     OnsDataImport::ImportCities.new.call
     OnsDataImport::ImportRegions.new.call
+    OnsDataImport::CreateComposites.new.call
   end
 end

--- a/app/services/ons_data_import/create_composites.rb
+++ b/app/services/ons_data_import/create_composites.rb
@@ -1,0 +1,21 @@
+class OnsDataImport::CreateComposites
+  def call
+    DOWNCASE_COMPOSITE_LOCATIONS.each do |name, constituents|
+      Rails.logger.info("Creating composite polygon for '#{name}'")
+
+      composite = LocationPolygon.find_or_create_by(name: name)
+      quoted_constituents = constituents.map { |c| ActiveRecord::Base.connection.quote(c.downcase) }
+
+      ActiveRecord::Base.connection.exec_update("
+        UPDATE location_polygons
+        SET area=(
+              SELECT ST_Union(area::geometry)::geography
+              FROM location_polygons
+              WHERE name IN (#{quoted_constituents.join(', ')})
+            ),
+            location_type='composite'
+        WHERE id='#{composite.id}'
+      ")
+    end
+  end
+end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -35,6 +35,26 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
+      "fingerprint": "549d2779be79702f98156c6ec1a388b35ff19d87b0978910d4fad9d59a424cb9",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/services/ons_data_import/create_composites.rb",
+      "line": 14,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "ActiveRecord::Base.connection.exec_update(\"\\n        UPDATE location_polygons\\n        SET area=(\\n              SELECT ST_Union(area::geometry)::geography\\n              FROM location_polygons\\n              WHERE name IN (#{constituents.map do\n ActiveRecord::Base.connection.quote(c.downcase)\n end.join(\", \")})\\n            ),\\n            location_type='composite'\\n        WHERE id='#{LocationPolygon.find_or_create_by(:name => name).id}'\\n      \")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "OnsDataImport::CreateComposites",
+        "method": "call"
+      },
+      "user_input": "constituents.map do\n ActiveRecord::Base.connection.quote(c.downcase)\n end.join(\", \")",
+      "confidence": "Medium",
+      "note": "This is our own static data with no user input provided in the query"
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
       "fingerprint": "8e2c1f91d02bb1633f5456dc0983e24f4972cf73213afa01b9e7bcdf7b1c3fcc",
       "check_name": "SQL",
       "message": "Possible SQL injection",
@@ -53,6 +73,6 @@
       "note": "Helper forces conversion to integer, temporary method that will be removed so"
     }
   ],
-  "updated": "2021-10-11 16:38:31 +0100",
+  "updated": "2021-10-14 17:41:12 +0100",
   "brakeman_version": "5.1.1"
 }

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -43,7 +43,7 @@ end
 
 namespace :ons do
   desc "Import all ONS areas"
-  task import_all: %i[import_counties import_cities import_regions]
+  task import_all: %i[import_counties import_cities import_regions create_composites]
 
   desc "Import ONS counties"
   task import_counties: :environment do
@@ -58,5 +58,10 @@ namespace :ons do
   desc "Import ONS regions"
   task import_regions: :environment do
     OnsDataImport::ImportRegions.new.call
+  end
+
+  desc "Create composites from ONS polygons"
+  task create_composites: :environment do
+    OnsDataImport::CreateComposites.new.call
   end
 end

--- a/spec/services/ons_data_import/create_composites_spec.rb
+++ b/spec/services/ons_data_import/create_composites_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe OnsDataImport::CreateComposites do
+  let!(:somewhereshire) { create(:location_polygon, name: "somewhereshire", area: "POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))") }
+  let!(:elsewhereshire) { create(:location_polygon, name: "elsewhereshire", area: "POLYGON((0 0, 0 -1, -1 -1, -1 0, 0 0))") }
+
+  let(:composite_locations) { { "other realm" => %w[Somewhereshire Elsewhereshire] } }
+  let(:other_realm) { LocationPolygon.find_by(name: "other realm") }
+
+  before do
+    stub_const("DOWNCASE_COMPOSITE_LOCATIONS", composite_locations)
+  end
+
+  describe "#call" do
+    it "generates a composite polygon" do
+      subject.call
+
+      expect(other_realm.location_type).to eq("composite")
+      expect(other_realm.area.coordinates.sort.flatten).to eq([
+        0.0, -1.0,
+        -1.0, -1.0,
+        -1.0, 0.0,
+        0.0, 0.0,
+        0.0, -1.0,
+        0.0, 1.0,
+        1.0, 1.0,
+        1.0, 0.0,
+        0.0, 0.0,
+        0.0, 1.0
+      ])
+    end
+  end
+end


### PR DESCRIPTION
This creates composite polygons on import by using PostGIS's `ST_Union`
to merge their constituent polygons, allowing us to remove a lot of
code dealing with finding and handling multiple `LocationPolygon`s at
search time.