### PR TITLE
Remove composite location handling from search

### DIFF
--- a/app/models/location_polygon.rb
+++ b/app/models/location_polygon.rb
@@ -16,14 +16,6 @@ class LocationPolygon < ApplicationRecord
     ALL_IMPORTED_LOCATIONS.include?(mapped_name(location))
   end
 
-  def self.composite?(location)
-    component_location_names(location).present?
-  end
-
-  def self.component_location_names(location)
-    DOWNCASE_COMPOSITE_LOCATIONS[mapped_name(location)]
-  end
-
   def self.mapped_name(location)
     (MAPPED_LOCATIONS[location&.downcase].presence || location)&.downcase
   end

--- a/app/services/search/buffer_suggestions_builder.rb
+++ b/app/services/search/buffer_suggestions_builder.rb
@@ -8,14 +8,10 @@ class Search::BufferSuggestionsBuilder
   end
 
   def get_buffers_suggestions
-    location_names = LocationPolygon.component_location_names(location) ||
-                     [LocationPolygon.mapped_name(location)]
-
     buffer_vacancy_count = Search::RadiusSuggestionsBuilder::RADIUS_OPTIONS.map do |distance|
-      locations = LocationPolygon.buffered(distance).where(name: location_names.map(&:downcase))
-      polygon_boundaries = locations.compact.flat_map(&:to_algolia_polygons)
+      polygons = LocationPolygon.buffered(distance).with_name(location).to_algolia_polygons
 
-      [distance.to_s, Search::Strategies::Algolia.new(search_params.merge(polygons: polygon_boundaries)).total_count]
+      [distance.to_s, Search::Strategies::Algolia.new(search_params.merge(polygons: polygons)).total_count]
     end
 
     buffer_vacancy_count&.uniq(&:last)&.reject { |array| array.last.zero? }

--- a/app/services/search/location_builder.rb
+++ b/app/services/search/location_builder.rb
@@ -33,11 +33,7 @@ class Search::LocationBuilder
   private
 
   def initialize_polygon_boundaries
-    location_names = LocationPolygon.component_location_names(location) ||
-                     [LocationPolygon.mapped_name(location)]
-    locations = LocationPolygon.buffered(radius).where(name: location_names.map(&:downcase))
-
-    @polygon_boundaries = locations.compact.flat_map(&:to_algolia_polygons)
+    @polygon_boundaries = LocationPolygon.buffered(radius).with_name(location).to_algolia_polygons
   end
 
   def build_location_filter

--- a/spec/models/location_polygon_spec.rb
+++ b/spec/models/location_polygon_spec.rb
@@ -37,31 +37,6 @@ RSpec.describe LocationPolygon do
     end
   end
 
-  describe ".component_location_names" do
-    before do
-      stub_const("DOWNCASE_COMPOSITE_LOCATIONS", downcase_composite_locations)
-    end
-
-    let(:downcase_composite_locations) do
-      { "yorkshire" => ["west yorkshire", "rest of yorkshire"],
-        "greater manchester" => ["west manchester", "rest of manchester"] }
-    end
-
-    context "when location is a composite location" do
-      context "when location is mapped" do
-        it "returns the list of component locations" do
-          expect(described_class.component_location_names("Manchester")).to eq(["west manchester", "rest of manchester"])
-        end
-      end
-
-      context "when location is not mapped" do
-        it "returns the list of component locations" do
-          expect(described_class.component_location_names("Yorkshire")).to eq(["west yorkshire", "rest of yorkshire"])
-        end
-      end
-    end
-  end
-
   describe "#to_algolia_polygons" do
     before do
       subject.area = "POLYGON((0 0, 1 1, 0 1, 0 0))"

--- a/spec/services/search/buffer_suggestions_builder_spec.rb
+++ b/spec/services/search/buffer_suggestions_builder_spec.rb
@@ -50,30 +50,5 @@ RSpec.describe Search::BufferSuggestionsBuilder do
         end
       end
     end
-
-    context "when searching in a composite location" do
-      let(:location) { "Bedfordshire" }
-      let(:districts) { ["Bedford", "Central Bedfordshire", "Luton"] }
-      let(:search_hits) { [0, 1, 1, 2, 3, 0, 0] }
-
-      before do
-        districts.each do |name|
-          create(:location_polygon, name: name.downcase, location_type: "counties")
-        end
-
-        Search::RadiusSuggestionsBuilder::RADIUS_OPTIONS.each_with_index do |radius, idx|
-          buffered_polygons = LocationPolygon.buffered(radius).where(name: districts.map(&:downcase))
-
-          mock_algolia_search(
-            double("vacancies", none?: false), search_hits[idx], nil,
-            arguments_for_algolia.merge(insidePolygon: buffered_polygons.flat_map(&:to_algolia_polygons))
-          )
-        end
-      end
-
-      it "returns the appropriate buffer suggestions" do
-        expect(subject.buffer_suggestions).to eq([["5", 1], ["25", 2], ["50", 3]])
-      end
-    end
   end
 end

--- a/spec/services/search/location_builder_spec.rb
+++ b/spec/services/search/location_builder_spec.rb
@@ -24,33 +24,6 @@ RSpec.describe Search::LocationBuilder do
       it_behaves_like "a search using polygons"
     end
 
-    context "when a composite location is specified" do
-      let(:location) { "Bedfordshire" }
-
-      before do
-        create(:location_polygon,
-               name: "bedford",
-               location_type: "counties")
-        create(:location_polygon,
-               name: "central bedfordshire",
-               location_type: "counties")
-        create(:location_polygon,
-               name: "luton",
-               location_type: "counties")
-      end
-
-      it "sets the correct attributes" do
-        expect(subject.location).to eq(location)
-        expect(subject.polygon_boundaries).to contain_exactly(
-          *LocationPolygon.buffered(radius).where(name: [
-            "bedford", "central bedfordshire", "luton"
-          ]).flat_map(&:to_algolia_polygons),
-        )
-        expect(subject.location_filter).to eq({})
-        expect(subject.radius).to eq(radius)
-      end
-    end
-
     context "when a mapped location is specified" do
       let(:location) { "Map this location" }
 

--- a/spec/system/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
+++ b/spec/system/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 
 RSpec.describe "Jobseekers can create a job alert from a search", recaptcha: true, vcr: { cassette_name: "algoliasearch" } do
   let(:location) { "London" }
+  let!(:location_polygon) { create(:location_polygon, name: "london") }
+
   let(:search_with_polygons?) { false }
   let(:jobseeker_signed_in?) { false }
   let(:jobseeker) { build_stubbed(:jobseeker) }
@@ -92,7 +94,6 @@ RSpec.describe "Jobseekers can create a job alert from a search", recaptcha: tru
     context "when a polygon search is carried out" do
       let(:search_with_polygons?) { true }
       let(:location) { "London" }
-      let!(:location_polygon) { create(:location_polygon, name: "london") }
 
       it "successfully creates a job alert" do
         visit jobs_path

--- a/spec/system/jobseekers_can_search_from_home_page_spec.rb
+++ b/spec/system/jobseekers_can_search_from_home_page_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "Searching on the home page", vcr: { cassette_name: "algoliasearch" } do
+  let!(:bristol) { create(:location_polygon, name: "bristol") }
+
   before do
     visit root_path
   end

--- a/spec/system/jobseekers_can_view_and_visit_homepage_facets_spec.rb
+++ b/spec/system/jobseekers_can_view_and_visit_homepage_facets_spec.rb
@@ -14,6 +14,9 @@ RSpec.describe "Jobseekers can view and visit homepage facets", vcr: { cassette_
     )
   end
 
+  let!(:london) { create(:location_polygon, name: "london") }
+  let!(:devon) { create(:location_polygon, name: "devon") }
+
   before do
     allow(VacancyFacets).to receive(:new).and_return(vacancy_facets)
     visit root_path


### PR DESCRIPTION
Composite locations are now imported as a polygon of their own, so
we no longer need to take them into account when searching.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3223