### PR TITLE
Fix Sidekiq deprecation warning

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -23,6 +23,3 @@ if File.exist?(schedule_file) && Sidekiq.server?
     Sidekiq::Cron::Job.load_from_hash! YAML.load_file(schedule_file)
   end
 end
-
-require "sidekiq/web"
-Sidekiq::Web.disable(:sessions)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ require "sidekiq/cron/web"
 
 Rails.application.routes.draw do
   unless Rails.env.development?
+    Sidekiq::Web.use ActionDispatch::Session::ActiveRecordStore
     Sidekiq::Web.use Rack::Auth::Basic do |username, password|
       ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_USERNAME"])) &
         ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_PASSWORD"]))


### PR DESCRIPTION
We are currently running `Sidekiq::Web.disable(:sessions)` in an
initialiser, which has been deprecated. This seems to be a workaround
for potential interference of the Sidekiq Web UI with the main Rails
app session cookie.

This removes the deprecated code and adds use of our session handler
`ActionDispatch::Session::ActiveRecordStore` to the mounting of
`Sidekiq::Web` in case that was a fix for a genuine issue and not
just code copy-pasted from the Sidekiq wiki.