### PR TITLE
Implement searching by location for PgSearch strategy

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -58,6 +58,8 @@ class Vacancy < ApplicationRecord
   scope :pending, (-> { published.where("publish_on > ?", Date.current) })
   scope :published_on_count, (->(date) { published.where(publish_on: date.all_day).count })
 
+  scope :search_by_location, VacancyLocationQuery
+
   paginates_per 10
 
   validates :slug, presence: true

--- a/app/queries/application_query.rb
+++ b/app/queries/application_query.rb
@@ -1,0 +1,8 @@
+class ApplicationQuery
+  # Delegate class-level call to a new instance - allows using class name as an argument
+  # to scope declaration, e.g:
+  #   scope :foo, FooQuery
+  def self.call(...)
+    new.call(...)
+  end
+end

--- a/app/queries/vacancy_location_query.rb
+++ b/app/queries/vacancy_location_query.rb
@@ -1,0 +1,39 @@
+class VacancyLocationQuery < ApplicationQuery
+  NATIONWIDE_LOCATIONS = ["england", "uk", "united kingdom", "britain", "great britain"].freeze
+
+  attr_reader :scope
+
+  include DistanceHelper
+
+  def initialize(scope = Vacancy.live)
+    @scope = scope
+  end
+
+  def call(location_query, radius_in_miles)
+    normalised_query = location_query&.strip&.downcase
+    radius = convert_miles_to_metres(radius_in_miles.to_i)
+
+    if normalised_query.blank? || NATIONWIDE_LOCATIONS.include?(normalised_query)
+      scope
+    elsif LocationPolygon.include?(normalised_query)
+      polygon = LocationPolygon.with_name(normalised_query)
+
+      scope
+        .joins("
+          INNER JOIN location_polygons
+          ON ST_DWithin(vacancies.geolocation, location_polygons.area, #{radius})
+        ")
+        .where("location_polygons.id = ?", polygon.id)
+    else
+      coordinates = Geocoding.new(normalised_query).coordinates
+
+      # TODO: Geocoding class currently returns this on error, it should probably raise a
+      # suitable error instead. Refactor later!
+      return scope.none if coordinates == [0, 0]
+
+      point = "POINT(#{coordinates.second} #{coordinates.first})"
+
+      scope.where("ST_DWithin(geolocation, ?, ?)", point, radius)
+    end
+  end
+end

--- a/app/services/search/strategies/pg_search.rb
+++ b/app/services/search/strategies/pg_search.rb
@@ -1,19 +1,35 @@
 class Search::Strategies::PgSearch
-  attr_reader :page, :per_page
+  attr_reader :keyword, :location, :radius, :page, :per_page, :sort_by
 
-  def initialize(keyword, page:, per_page:)
+  def initialize(keyword, location:, radius:, page:, per_page:, sort_by:)
     @keyword = keyword
+
+    @location = location
+    @radius = radius
+
     @page = page
     @per_page = per_page
+    @sort_by = sort_by
   end
 
   def vacancies
-    # TODO: Implement me
-    Kaminari.paginate_array([], total_count: total_count).page(page).per(per_page)
+    @vacancies ||= scope.page(page).per(per_page)
   end
 
   def total_count
-    # TODO: Implement me
-    0
+    vacancies.total_count
+  end
+
+  private
+
+  def scope
+    # This strategy can currently only search by location (not keywords yet) so this avoids
+    # polluting our metrics for now
+    return Vacancy.none if keyword.present?
+
+    scope = Vacancy.live
+    scope = scope.search_by_location(location, radius) if location
+    scope = scope.order(sort_by.column => sort_by.order) if sort_by&.column
+    scope
   end
 end

--- a/app/services/search/vacancy_search.rb
+++ b/app/services/search/vacancy_search.rb
@@ -64,7 +64,14 @@ class Search::VacancySearch
     @search_strategy ||= if active_criteria?
                            Search::Strategies::Experiment.new(
                              Search::Strategies::Algolia.new(algolia_params),
-                             Search::Strategies::PgSearch.new(keyword, page: page, per_page: per_page),
+                             Search::Strategies::PgSearch.new(
+                               keyword,
+                               location: search_criteria[:location],
+                               radius: search_criteria[:radius],
+                               page: page,
+                               per_page: per_page,
+                               sort_by: sort_by,
+                             ),
                              search_criteria: search_criteria,
                              use_experiment: pg_search,
                            )

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -71,8 +71,28 @@
       "user_input": "convert_miles_to_metres(radius_in_miles)",
       "confidence": "Medium",
       "note": "Helper forces conversion to integer, temporary method that will be removed so"
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "e78cf0e304d252b88e78e94073acc31bbcc36810630ecd67bdac0c44d50d1e75",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/queries/vacancy_location_query.rb",
+      "line": 24,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "scope.joins(\"\\n          INNER JOIN location_polygons\\n          ON ST_DWithin(vacancies.geolocation, location_polygons.area, #{convert_miles_to_metres(radius_in_miles.to_i)})\\n        \")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "VacancyLocationQuery",
+        "method": "call"
+      },
+      "user_input": "convert_miles_to_metres(radius_in_miles.to_i)",
+      "confidence": "Weak",
+      "note": "User input is coerced to integer"
     }
   ],
-  "updated": "2021-10-14 17:41:12 +0100",
+  "updated": "2021-10-22 13:54:05 +0100",
   "brakeman_version": "5.1.1"
 }

--- a/spec/queries/vacancy_location_query_spec.rb
+++ b/spec/queries/vacancy_location_query_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.describe VacancyLocationQuery do
+  subject { described_class.new(default_scope) }
+
+  let(:default_scope) { double("ActiveRecord scope") }
+
+  describe "#call" do
+    let(:result_scope) { subject.call(location, radius) }
+
+    context "when not given any search location" do
+      let(:location) { "" }
+      let(:radius) { nil }
+
+      it "returns the default scope" do
+        expect(result_scope).to eq(default_scope)
+      end
+    end
+
+    context "when given a nationwide location" do
+      let(:location) { "england" }
+      let(:radius) { 100 }
+
+      it "returns the default scope" do
+        expect(result_scope).to eq(default_scope)
+      end
+    end
+
+    context "when given a location that resolves to a LocationPolygon" do
+      let(:location) { "Lincolnshire" }
+      let(:radius) { 42 }
+
+      let!(:location_polygon) { create(:location_polygon, name: "lincolnshire") }
+
+      let(:join_scope) { double("join scope") }
+      let(:where_scope) { double("where scope") }
+
+      before do
+        expect(default_scope).to receive(:joins).with(
+          /ST_DWithin\(vacancies.geolocation, location_polygons.area, 67578\)/i,
+        ).and_return(join_scope)
+        expect(join_scope).to receive(:where).with("location_polygons.id = ?", location_polygon.id).and_return(where_scope)
+      end
+
+      it "returns a scope for searching within a location polygon" do
+        expect(result_scope).to eq(where_scope)
+      end
+    end
+
+    context "when given a location that resolves to a point" do
+      let(:location) { "Louth" }
+      let(:radius) { 89 }
+
+      let(:where_scope) { double("where scope") }
+
+      let(:geocoder) { double(Geocoding, coordinates: [-7, 7]) }
+
+      before do
+        expect(Geocoding).to receive(:new).with("louth").and_return(geocoder)
+
+        expect(default_scope).to receive(:where).with(
+          "ST_DWithin(geolocation, ?, ?)",
+          "POINT(7 -7)",
+          143_201,
+        ).and_return(where_scope)
+      end
+
+      it "returns a scope for searching around a point" do
+        expect(result_scope).to eq(where_scope)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Add `Vacancy.search_by_location` scope to allow searching based on a
  location and radius with identical behaviour to existing
  `LocationBuilder` for Algolia search
- Add `VacancyLocationQuery` query object to implement this new scope
- Make `PgSearch` strategy return results for queries without a keyword
  based on new scope
- Make `PgSearch` strategy order results like other strategies do

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3227