### PR TITLE
Update Zeitwerk and replace deprecated STI preload

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -621,7 +621,7 @@ GEM
       builder (>= 2.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.4.2)
+    zeitwerk (2.5.1)
 
 PLATFORMS
   ruby

--- a/config/initializers/zeitwerk_preload.rb
+++ b/config/initializers/zeitwerk_preload.rb
@@ -4,8 +4,6 @@
 # delegated types in the future, which won't require this workaround so we'll be able
 # to delete this.
 
-SINGLE_TABLE_INHERITANCE_LEAVES = %w[school school_group].freeze
-
-SINGLE_TABLE_INHERITANCE_LEAVES.each do |leaf|
-  Rails.autoloaders.main.preload(Rails.root.join("app", "models", "#{leaf}.rb"))
+Rails.autoloaders.main.on_setup do
+  [School, SchoolGroup]
 end


### PR DESCRIPTION
Zeitwerk 2.5 and above now have a different mechanism to deal with
preloading constants:
https://github.com/fxn/zeitwerk/blob/main/CHANGELOG.md#250-20-october-2021