### PR TITLE
Add secondary sort order to Algolia "most recent" replica

### DIFF
--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -88,7 +88,7 @@ module Indexable
       attributesForFaceting %i[job_roles working_patterns education_phases subjects]
 
       add_replica "#{INDEX_NAME}_publish_on_desc", inherit: true do
-        ranking ["desc(publication_date_timestamp)"]
+        ranking %w[desc(publication_date_timestamp) desc(last_updated_at)]
       end
 
       add_replica "#{INDEX_NAME}_expires_at_desc", inherit: true do


### PR DESCRIPTION
This is sorted on a date field which leads to a non-deterministic sort
order (i.e. there is no guaranteed order between vacancies listed on
the same day).

This adds a secondary order to the replica (by updated_at timestamp)
to guarantee they will always be returned in the same order so we can
better compare between Algolia and Postgres results.

N.B. This has already been updated on production Algolia, this config
will only apply to newly created replicas.