### PR TITLE
Redirect to authentication fallback if enabled

### DIFF
--- a/app/controllers/publishers/login_keys_controller.rb
+++ b/app/controllers/publishers/login_keys_controller.rb
@@ -27,11 +27,15 @@ class Publishers::LoginKeysController < ApplicationController
   private
 
   def redirect_signed_in_publishers
-    redirect_to organisation_path if publisher_signed_in? && current_organisation.present?
+    return unless publisher_signed_in? && current_organisation.present?
+
+    redirect_to organisation_path
   end
 
   def redirect_for_dsi_authentication
-    redirect_to new_publisher_session_path unless AuthenticationFallback.enabled?
+    return if AuthenticationFallback.enabled?
+
+    redirect_to new_publisher_session_path
   end
 
   def send_login_key(publisher:)

--- a/app/controllers/publishers/sessions_controller.rb
+++ b/app/controllers/publishers/sessions_controller.rb
@@ -1,4 +1,6 @@
 class Publishers::SessionsController < Devise::SessionsController
+  before_action :redirect_to_authentication_fallback, only: %i[new]
+
   def create
     publisher = Publisher.find(session[:publisher_id])
     organisation = publisher.organisations.find(params[:organisation_id])
@@ -34,5 +36,11 @@ class Publishers::SessionsController < Devise::SessionsController
 
   def after_sign_in_path_for(_resource)
     organisation_path
+  end
+
+  def redirect_to_authentication_fallback
+    return unless AuthenticationFallback.enabled?
+
+    redirect_to new_login_key_path
   end
 end

--- a/app/views/pages/sign-in.html.slim
+++ b/app/views/pages/sign-in.html.slim
@@ -20,4 +20,4 @@
 
       p.govuk-body Sign in here to manage your job listings and applicants.
 
-      = govuk_button_link_to t("buttons.sign_in_publisher"), (AuthenticationFallback.enabled? ? new_login_key_path : new_publisher_session_path)
+      = govuk_button_link_to t("buttons.sign_in_publisher"), new_publisher_session_path

--- a/spec/requests/publishers/sessions_spec.rb
+++ b/spec/requests/publishers/sessions_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe "Redirect to correct authentication method" do
+  before do
+    allow(AuthenticationFallback).to receive(:enabled?).and_return(authentication_fallback_enabled?)
+  end
+
+  context "when authentication fallback is enabled" do
+    let(:authentication_fallback_enabled?) { true }
+
+    context "when trying to sign in via DfE Sign In" do
+      before { get new_publisher_session_path }
+
+      it "redirects to the fallback authentication domain" do
+        expect(response).to redirect_to(new_login_key_path)
+      end
+    end
+
+    context "when trying to sign in via fallback authentication method" do
+      before { get new_login_key_path }
+
+      it "does not redirect" do
+        expect(response.status).not_to eq(302)
+      end
+    end
+  end
+
+  context "when authentication fallback is not enabled" do
+    let(:authentication_fallback_enabled?) { false }
+
+    context "when trying to sign in via DfE Sign In" do
+      before { get new_publisher_session_path }
+
+      it "does not redirect" do
+        expect(response.status).not_to eq(302)
+      end
+    end
+
+    context "when trying to sign in via fallback authentication method" do
+      before { get new_login_key_path }
+
+      it "redirects to the DfE Sign In authentication domain" do
+        expect(response).to redirect_to(new_publisher_session_path)
+      end
+    end
+  end
+end

--- a/spec/system/users_can_only_be_signed_in_to_one_type_of_account_spec.rb
+++ b/spec/system/users_can_only_be_signed_in_to_one_type_of_account_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe "Users can only be signed in to one type of account" do
         expect(current_path).to eq(jobseeker_root_path)
 
         visit organisation_path
-        expect(current_path).to eq(new_publisher_session_path)
+        expect(current_path).to eq(new_login_key_path)
       end
     end
   end


### PR DESCRIPTION
We had forgotten to use the authentication fallback in two places:
- The footer link to new_publisher_session_path
- The 'Advertise a school job' section in the homepage

Instead of manually remembering to include logic for authentication fallback in every place we link to the publisher sign in, we should just redirect from the DSI sign in page to the email sign in page, when authentication fallback is switched on.

To review, compare the sign in journeys* of this review app and any other review app.

*one via footer and one via blue home page box