### PR TITLE
Catch url parse errors and convert to validation error message

### DIFF
--- a/app/form_models/publishers/job_listing/applying_for_the_job_form.rb
+++ b/app/form_models/publishers/job_listing/applying_for_the_job_form.rb
@@ -4,6 +4,7 @@ class Publishers::JobListing::ApplyingForTheJobForm < Publishers::JobListing::Va
   validates :enable_job_applications, inclusion: { in: [true, false, "true", "false"] }, if: proc { vacancy.allow_enabling_job_applications? }
   validates :how_to_apply, presence: true, unless: proc { enable_job_applications.in?(["true", true]) }
   validates :application_link, url: true, if: proc { application_link.present? }
+  validate :application_link_valid_uri, if: proc { application_link.present? }
 
   validates :contact_email, presence: true
   validates :contact_email, email_address: true, if: proc { contact_email.present? }
@@ -20,9 +21,17 @@ class Publishers::JobListing::ApplyingForTheJobForm < Publishers::JobListing::Va
 
   def application_link=(link)
     @application_link = Addressable::URI.heuristic_parse(link).to_s
+  rescue Addressable::URI::InvalidURIError
+    @application_link = link
   end
 
   private
+
+  def application_link_valid_uri
+    Addressable::URI.heuristic_parse(application_link)
+  rescue Addressable::URI::InvalidURIError
+    errors.add(:application_link, I18n.t("applying_for_the_job_errors.application_link.url"))
+  end
 
   def override_enable_job_applications!
     # If a publisher is signed in as an LA, we do not allow them to set the job applications feature.

--- a/spec/form_models/publishers/job_listing/applying_for_the_job_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/applying_for_the_job_form_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Publishers::JobListing::ApplyingForTheJobForm, type: :model do
   it { is_expected.to allow_value("www.this-is-a-test-url.example.com").for(:application_link) }
   it { is_expected.to allow_value("").for(:application_link) }
   it { is_expected.not_to allow_value("invalid_link").for(:application_link) }
+  it { is_expected.not_to allow_value("A full application pack can be found at www.website.co.uk").for(:application_link) }
 
   it { is_expected.to validate_presence_of(:contact_email) }
   it { is_expected.to allow_value("thestrokes@example.com").for(:contact_email) }


### PR DESCRIPTION
Some users couldn't submit their forms because we did not catch this error.

The test is based on the instance that entered our error logs.
