### PR TITLE
[TEVA-3290] Map all possible location parameters to their polygons

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -4,8 +4,6 @@ class VacanciesController < ApplicationController
   before_action :set_landing_page_description, :set_map_display, :set_params_from_pretty_landing_page_params, only: %i[index]
 
   def index
-    set_params_from_pretty_landing_page_params
-
     @vacancies_search = Search::VacancySearch.new(
       search_form.to_hash,
       sort_by: search_form.jobs_sort,

--- a/config/initializers/location_data.rb
+++ b/config/initializers/location_data.rb
@@ -15,8 +15,12 @@ DOWNCASE_COMPOSITE_LOCATIONS = composite_locations.transform_keys(&:downcase).fr
 ALL_IMPORTED_LOCATIONS =
   (DOWNCASE_ONS_REGIONS + DOWNCASE_COMPOSITE_LOCATIONS.keys + DOWNCASE_ONS_COUNTIES_AND_UNITARY_AUTHORITIES + DOWNCASE_ONS_CITIES).uniq.freeze
 
-# See documentation/business-analyst-activities.md
-MAPPED_LOCATIONS = YAML.load_file(base_path.join("mapped_locations.yml"))
+# Map from a user-inputted search term to a location polygon's name.
+# We also need to map landing page location params to the location polygon's name, since these are `#parameterize`d in
+# the routes and `#titleize`d in VacanciesController, but those operations are not symmetrical.
+# See also documentation/business-analyst-activities.md
+landing_page_location_params_mapping = ALL_IMPORTED_LOCATIONS.map { |location| [location.parameterize.titleize.downcase, location] }.to_h
+MAPPED_LOCATIONS = YAML.load_file(base_path.join("mapped_locations.yml")).merge(landing_page_location_params_mapping)
 
 # Locations with the location type from a human point of view for VacancyFacets
 LOCATIONS_MAPPED_TO_HUMAN_FRIENDLY_TYPES = [

--- a/spec/requests/location_landing_page_spec.rb
+++ b/spec/requests/location_landing_page_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe "Location landing pages" do
+  describe "GET #index" do
+    before { create(:location_polygon, name: "stoke-on-trent") }
+
+    it "can find location polygons which have non-letter characters in their name" do
+      get "/teaching-jobs-in-stoke-on-trent"
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3290

## Changes in this PR:

Some location landing pages threw 'not found' errors because we had not correctly mapped from the location parameter to the polygon's names.

For example, /teaching-jobs-in-stoke-on-trent was looking for a polygon called 'stoke on trent', but the polygon's actual name is 'stoke-on-trent' - the hyphens are really in the town's name.

I solved this issue by programmatically adding all the mappings from location parameters to original polygon names into the MAPPED_LOCATIONS constant, which is used by LocationPolygon.include? and by LocationPolygon.with_name to look up polygons using likely/frequently used variations on their names.

The reason this had been working most of the time is that, mostly, calling .parameterize and then .titleize on something has no net effect.

I also removed an unnecessary second call of set_params_from_pretty_landing_page_params which is already called by a before action.

## Screenshots of UI changes:

### Before

![Screenshot 2021-10-25 at 19 15 14](https://user-images.githubusercontent.com/60350599/138752876-7b2d4074-681d-4787-a64e-99aca1c24b71.png)

### After

![Screenshot 2021-10-25 at 19 38 58](https://user-images.githubusercontent.com/60350599/138752905-f7b11dbc-1f4b-49f5-8146-c4fe98804b3c.png)

