### PR TITLE
[TEVA-3364] Allow GH Delete workflow check review app's http status

### DIFF
--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -39,8 +39,13 @@ jobs:
        timeoutSeconds: 1800
        intervalSeconds: 15
 
-    - name: Exit whole workflow if wait was not successful
-      if: steps.wait_for_deployment.outputs.conclusion != 'success'
+    - name: check review status
+      run: |
+        HTTP_CODE=$(curl -o/dev/null -s -w "%{http_code}" https://teaching-vacancies-review-pr-${{ github.event.number }}.london.cloudapps.digital)
+        echo "HTTP_CODE=$HTTP_CODE"  >> $GITHUB_ENV
+
+    - name: Exit whole workflow if wait was not successful and review app is not up
+      if: steps.wait_for_deployment.outputs.conclusion != 'success' && env.HTTP_CODE != '200'
       run: exit 1
 
     - uses: actions/checkout@v2


### PR DESCRIPTION
As part of the delete workflow, an extra check would be conduted such that
alongside checking if `checkrun` fails, a new condition would be be added
to allow delete workflow to check http status of review app.
In instances where `checkrun` fails and the http_status of the
review app is 200, the delete workflow would be allowed to run and delete the review app.

## Jira ticket URL

- Just add the ticket number to the end:

https://dfedigital.atlassian.net/browse/TEVA-3364

