### PR TITLE
Add `readable_phases` to Vacancy (step 1/2)

### DIFF
--- a/app/models/concerns/phaseable.rb
+++ b/app/models/concerns/phaseable.rb
@@ -1,6 +1,10 @@
 module Phaseable
   extend ActiveSupport::Concern
 
+  included do
+    before_save :update_readable_phases
+  end
+
   def allow_phase_to_be_set?
     central_office? || organisation_phases.many? || organisation_phases.none?
   end
@@ -19,7 +23,11 @@ module Phaseable
     [phase]
   end
 
+  def update_readable_phases
+    self.readable_phases = education_phases
+  end
+
   def organisation_phases
-    organisations.map(&:readable_phases).flatten.uniq
+    organisations.map(&:readable_phases).flatten.uniq.compact
   end
 end

--- a/db/migrate/20211025152805_add_readable_phases_to_vacancy.rb
+++ b/db/migrate/20211025152805_add_readable_phases_to_vacancy.rb
@@ -1,0 +1,5 @@
+class AddReadablePhasesToVacancy < ActiveRecord::Migration[6.1]
+  def change
+    add_column :vacancies, :readable_phases, :string, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_14_152432) do
+ActiveRecord::Schema.define(version: 2021_10_25_152805) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -466,6 +466,7 @@ ActiveRecord::Schema.define(version: 2021_10_14_152432) do
     t.integer "phase"
     t.integer "key_stages", array: true
     t.geography "geolocation", limit: {:srid=>4326, :type=>"geometry", :geographic=>true}
+    t.string "readable_phases", default: [], array: true
     t.index ["expires_at"], name: "index_vacancies_on_expires_at"
     t.index ["geolocation"], name: "index_vacancies_on_geolocation", using: :gist
     t.index ["initially_indexed"], name: "index_vacancies_on_initially_indexed"

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -19,6 +19,16 @@ namespace :algolia do
   end
 end
 
+namespace :data do
+  desc "Set `readable_location` column for all existing vacancies"
+  task populate_vacancy_readable_location: :environment do
+    Vacancy.find_each do |vacancy|
+      # update_column so as to not update timestamps/run other callbacks
+      vacancy.update_column(:readable_phases, vacancy.education_phases)
+    end
+  end
+end
+
 namespace :db do
   desc "Asynchronously import organisations from GIAS and seed the database"
   task async_seed: :environment do

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -475,6 +475,52 @@ RSpec.describe Vacancy do
     end
   end
 
+  describe "#readable_phases" do
+    subject { build(:vacancy, organisations: [organisation], phase: phase) }
+    let!(:organisation) { create(:school, readable_phases: %w[primary middle]) }
+
+    context "if the vacancy has a single phase" do
+      let(:phase) { :"16-19" }
+
+      it "is updated on save" do
+        expect(subject.readable_phases).to be_empty
+        subject.save
+        expect(subject.readable_phases).to contain_exactly("16-19")
+      end
+    end
+
+    context "if the vacancy has multiple phases" do
+      let(:phase) { :multiple_phases }
+
+      it "is updated on save" do
+        expect(subject.readable_phases).to be_empty
+        subject.save
+        expect(subject.readable_phases).to contain_exactly("primary", "middle")
+      end
+    end
+
+    context "if the vacancy has no phase" do
+      let(:phase) { nil }
+
+      it "is updated on save" do
+        expect(subject.readable_phases).to be_empty
+        subject.save
+        expect(subject.readable_phases).to contain_exactly("primary", "middle")
+      end
+    end
+
+    context "if neither vacancy nor organisation have a phase" do
+      let(:phase) { nil }
+      let!(:organisation) { create(:school, readable_phases: nil) }
+
+      it "is updated on save" do
+        expect(subject.readable_phases).to be_empty
+        subject.save
+        expect(subject.readable_phases).to be_empty
+      end
+    end
+  end
+
   describe "validations" do
     describe "changing enable_job_applications" do
       subject { build_stubbed(:vacancy, status, enable_job_applications: true) }


### PR DESCRIPTION
This adds a `readable_phases` attribute to Vacancy, analogous to the
attribute of the same name on Organisation/School, and mirroring the
current functionality of the `education_phases` method.

Once live and the `data:populate_vacancy_readable_location` task has
been run, the next step will be to move `Phaseable#education_phases`
functionality into the callback and update its uses across the board.

- Add `compact` to `Phaseable#organisation_phases` to deal with
  cases of organisation readable phases containing nil