### PR TITLE
Use `Vacancy#readable_phases` across the board (part 2/2)

### DIFF
--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -11,7 +11,7 @@ module Indexable
     scope :unindexed, (-> { live.where(initially_indexed: false) })
 
     algoliasearch index_name: INDEX_NAME, auto_index: !Rails.env.test?, auto_remove: !Rails.env.test?, if: :listed? do
-      attributes :education_phases, :job_roles, :job_title, :parent_organisation_name, :salary, :subjects, :working_patterns, :_geoloc
+      attributes :job_roles, :job_title, :parent_organisation_name, :salary, :subjects, :working_patterns, :_geoloc
 
       attribute :about_school do
         strip_tags(about_school)&.truncate(256)
@@ -19,6 +19,10 @@ module Indexable
 
       attribute :benefits do
         strip_tags(benefits)
+      end
+
+      attribute :education_phases do
+        readable_phases
       end
 
       attribute :expires_at do

--- a/app/models/concerns/phaseable.rb
+++ b/app/models/concerns/phaseable.rb
@@ -5,6 +5,13 @@ module Phaseable
     before_save :update_readable_phases
   end
 
+  def phase=(phase)
+    # Ensure readable phases are updated as soon as a new phase is assigned
+    # (not just in before_save)
+    write_attribute(:phase, phase)
+    update_readable_phases
+  end
+
   def allow_phase_to_be_set?
     central_office? || organisation_phases.many? || organisation_phases.none?
   end
@@ -12,19 +19,17 @@ module Phaseable
   def one_phase?
     # Check that the number of phases isn't zero or more than one.
     # A few dozen organisations have a phase of 'not_applicable' and hence an empty 'readable_phases' attribute,
-    # resulting in vacancy.education_phases.count likewise being zero. Treat vacancies of unknown phase in the same way
+    # resulting in vacancy.readable_phases.count likewise being zero. Treat vacancies of unknown phase in the same way
     # as vacancies of multiple phases, including allowing the user to select a phase in the education_phases step.
-    phase != "multiple_phases" && education_phases.one?
-  end
-
-  def education_phases
-    return organisation_phases if phase == "multiple_phases" || phase.blank?
-
-    [phase]
+    phase != "multiple_phases" && readable_phases.one?
   end
 
   def update_readable_phases
-    self.readable_phases = education_phases
+    self.readable_phases = if phase == "multiple_phases" || phase.blank?
+                             organisation_phases
+                           else
+                             [phase].compact
+                           end
   end
 
   def organisation_phases

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -111,11 +111,11 @@ class Vacancy < ApplicationRecord
   end
 
   def allow_key_stages?
-    !one_phase? || education_phases == %w[primary] || education_phases == %w[middle]
+    !one_phase? || readable_phases == %w[primary] || readable_phases == %w[middle]
   end
 
   def allow_subjects?
-    education_phases != ["primary"]
+    readable_phases != ["primary"]
   end
 
   def within_data_access_period?

--- a/app/services/search/criteria_inventor.rb
+++ b/app/services/search/criteria_inventor.rb
@@ -17,7 +17,7 @@ class Search::CriteriaInventor
     { location: @location,
       radius: (@location.present? ? DEFAULT_RADIUS_IN_MILES.to_s : nil),
       working_patterns: [],
-      phases: @vacancy.education_phases,
+      phases: @vacancy.readable_phases,
       job_roles: @vacancy.job_roles,
       subjects: @subjects,
       keyword: keyword }.delete_if { |_k, v| v.blank? }

--- a/app/views/publishers/vacancies/build/job_details.html.slim
+++ b/app/views/publishers/vacancies/build/job_details.html.slim
@@ -13,7 +13,7 @@
         = govuk_inset_text do
           - link = vacancy.allow_phase_to_be_set? ? govuk_link_to(t("publishers.vacancies.build.job_details.phase_inset_text.link_text"), organisation_job_build_path(vacancy.id, :education_phases)) : ""
           - if vacancy.one_phase?
-            = t("publishers.vacancies.build.job_details.phase_inset_text.one_phase_html", phase: vacancy.education_phases.first.humanize, link: link)
+            = t("publishers.vacancies.build.job_details.phase_inset_text.one_phase_html", phase: vacancy.readable_phases.first.humanize, link: link)
           - else
             = t("publishers.vacancies.build.job_details.phase_inset_text.multiple_phases_html", link: link)
 
@@ -22,7 +22,7 @@
             id: "publishers_job_listing_job_details_form_job_title",
             label: { size: "s" },
             class: "govuk-input string required govuk-js-character-count",
-            hint: { text: t("helpers.hint.publishers_job_listing_job_details_form.job_title.#{vacancy.one_phase? ? vacancy.education_phases.first : 'multiple_phases'}") },
+            hint: { text: t("helpers.hint.publishers_job_listing_job_details_form.job_title.#{vacancy.one_phase? ? vacancy.readable_phases.first : 'multiple_phases'}") },
             required: true
           span#publishers_job_listing_job_details_form_job_title-info.govuk-hint.govuk-character-count__message aria-live="polite"
             | You can enter up to 100 characters
@@ -35,7 +35,7 @@
 
         - if vacancy.allow_key_stages?
           = f.govuk_collection_check_boxes :key_stages, Vacancy.key_stages.keys, :to_s, :to_s,
-            hint: { text: t("helpers.hint.publishers_job_listing_job_details_form.key_stages.#{vacancy.one_phase? ? vacancy.education_phases.first : 'multiple_phases'}") }
+            hint: { text: t("helpers.hint.publishers_job_listing_job_details_form.key_stages.#{vacancy.one_phase? ? vacancy.readable_phases.first : 'multiple_phases'}") }
 
         - if vacancy.allow_subjects?
           = f.govuk_fieldset legend: { text: t("helpers.legend.publishers_job_listing_job_details_form.subjects_html") } do

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -19,16 +19,6 @@ namespace :algolia do
   end
 end
 
-namespace :data do
-  desc "Set `readable_location` column for all existing vacancies"
-  task populate_vacancy_readable_location: :environment do
-    Vacancy.find_each do |vacancy|
-      # update_column so as to not update timestamps/run other callbacks
-      vacancy.update_column(:readable_phases, vacancy.education_phases)
-    end
-  end
-end
-
 namespace :db do
   desc "Asynchronously import organisations from GIAS and seed the database"
   task async_seed: :environment do

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -482,9 +482,7 @@ RSpec.describe Vacancy do
     context "if the vacancy has a single phase" do
       let(:phase) { :"16-19" }
 
-      it "is updated on save" do
-        expect(subject.readable_phases).to be_empty
-        subject.save
+      it "has the expected phases" do
         expect(subject.readable_phases).to contain_exactly("16-19")
       end
     end
@@ -492,9 +490,7 @@ RSpec.describe Vacancy do
     context "if the vacancy has multiple phases" do
       let(:phase) { :multiple_phases }
 
-      it "is updated on save" do
-        expect(subject.readable_phases).to be_empty
-        subject.save
+      it "has the expected phases" do
         expect(subject.readable_phases).to contain_exactly("primary", "middle")
       end
     end
@@ -502,9 +498,7 @@ RSpec.describe Vacancy do
     context "if the vacancy has no phase" do
       let(:phase) { nil }
 
-      it "is updated on save" do
-        expect(subject.readable_phases).to be_empty
-        subject.save
+      it "has the expected phases" do
         expect(subject.readable_phases).to contain_exactly("primary", "middle")
       end
     end
@@ -513,10 +507,19 @@ RSpec.describe Vacancy do
       let(:phase) { nil }
       let!(:organisation) { create(:school, readable_phases: nil) }
 
-      it "is updated on save" do
+      it "has no phases" do
         expect(subject.readable_phases).to be_empty
-        subject.save
-        expect(subject.readable_phases).to be_empty
+      end
+    end
+
+    context "when the organisation changes" do
+      let(:phase) { :multiple_phases }
+      let(:other_organisation) { create(:school, readable_phases: ["16-19"]) }
+
+      it "updates the phases on save" do
+        expect(subject.readable_phases).to contain_exactly("primary", "middle")
+        subject.update(organisations: [other_organisation])
+        expect(subject.readable_phases).to contain_exactly("16-19")
       end
     end
   end


### PR DESCRIPTION
- Remove `Phaseable#education_phase` and replace its usage with the new
  `readable_phases` field
- Add custom setter `Vacancy#phase=` to ensure that new readable phases
  are already available when the phase is set on a Vacancy before save
- Remove no longer needed data update task