### PR TITLE
Fix location mapping bug

### DIFF
--- a/config/initializers/location_data.rb
+++ b/config/initializers/location_data.rb
@@ -18,9 +18,10 @@ ALL_IMPORTED_LOCATIONS =
 # Map from a user-inputted search term to a location polygon's name.
 # We also need to map landing page location params to the location polygon's name, since these are `#parameterize`d in
 # the routes and `#titleize`d in VacanciesController, but those operations are not symmetrical.
+# Some of these basic mappings are overwritten in mapped_locations.yml, e.g. "manchester": "greater manchester".
 # See also documentation/business-analyst-activities.md
 landing_page_location_params_mapping = ALL_IMPORTED_LOCATIONS.map { |location| [location.parameterize.titleize.downcase, location] }.to_h
-MAPPED_LOCATIONS = YAML.load_file(base_path.join("mapped_locations.yml")).merge(landing_page_location_params_mapping)
+MAPPED_LOCATIONS = landing_page_location_params_mapping.merge(YAML.load_file(base_path.join("mapped_locations.yml")))
 
 # Locations with the location type from a human point of view for VacancyFacets
 LOCATIONS_MAPPED_TO_HUMAN_FRIENDLY_TYPES = [


### PR DESCRIPTION
We had been overwriting some of our mappings with the new programmatically generated landing_page_location_params_mapping.

Using a different merge order we can make the manually generated mappings take priority. E.g. 'manchester' should be mapped to the composite location 'greater manchester' rather than to the polygon with name 'manchester'.

## Screenshots of UI changes:

### Before

<img width="914" alt="Screenshot 2021-10-26 at 12 28 20" src="https://user-images.githubusercontent.com/60350599/138870567-ff54ac3f-c1b3-4249-a04b-14dda253911a.png">

### After

<img width="914" alt="Screenshot 2021-10-26 at 12 32 17" src="https://user-images.githubusercontent.com/60350599/138870610-2567e7c8-2694-428f-ac04-586c3d6f112c.png">
