### PR TITLE
[TEVA-3322] Remove meta keywords

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,11 +25,6 @@ module ApplicationHelper
     end
   end
 
-  def meta_keywords
-    "teacher,maths,primary,history,english,science,geography,\
-    teaching,assistant,headteacher,class,French,job,vacancy,school,nqt"
-  end
-
   def recaptcha
     recaptcha_v3(action: controller_name, nonce: request.content_security_policy_nonce)
   end

--- a/app/views/shared/_meta.html.slim
+++ b/app/views/shared/_meta.html.slim
@@ -1,2 +1,1 @@
 meta name="description" content=meta_description
-meta name="keywords" content=meta_keywords

--- a/spec/system/application_seo_spec.rb
+++ b/spec/system/application_seo_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe "Application meta tags" do
   context "when visiting the service start page" do
     scenario "meta tags are present" do
       visit root_path
-      expect(page.find('meta[name="keywords"]', visible: false)).to be_present
+      expect(page.find('meta[name="description"]', visible: false)).to be_present
     end
   end
 end


### PR DESCRIPTION
1) These keywords were not optimized per page but were catchall, so not
achieving much
2) Google no longer uses meta keywords

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3322