### PR TITLE
[TEVA-3325] Trial update to breadcrumbs on teaching assistant jobs

### DIFF
--- a/app/views/shared/vacancy/_jobseeker_view.html.slim
+++ b/app/views/shared/vacancy/_jobseeker_view.html.slim
@@ -1,7 +1,12 @@
 = render BannerComponent.new do
-    = govuk_breadcrumbs breadcrumbs: { "#{t("breadcrumbs.home")}": root_path,
-                                       "#{t("breadcrumbs.jobs")}": referred_from_jobs_path? ? request.referrer : jobs_path,
-                                       "#{@vacancy.job_title}": "" }
+    - if !referred_from_jobs_path? && @vacancy.main_job_role == "teaching_assistant"
+      = govuk_breadcrumbs breadcrumbs: { "#{t("breadcrumbs.home")}": root_path,
+                                         "#{t("breadcrumbs.teaching_assistant")}": job_role_path("teaching_assistant".dasherize),
+                                         "#{@vacancy.job_title}": "" }
+    - else
+      = govuk_breadcrumbs breadcrumbs: { "#{t("breadcrumbs.home")}": root_path,
+                                         "#{t("breadcrumbs.jobs")}": referred_from_jobs_path? ? request.referrer : jobs_path,
+                                         "#{@vacancy.job_title}": "" }
 
     - if @vacancy.expired?
       = govuk_tag text: t("jobs.expired_tag").upcase,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,7 @@ en:
     home: Home
     job_applications: My applications
     jobs: Search results
+    teaching_assistant: Teaching assistant jobs
 
   cookies_preferences:
     banner:


### PR DESCRIPTION
Current implementation of breadcrumb links sends users to a generic https://teaching-vacancies.service.gov.uk/jobs link from the text 'Search results' - this link lacks relative context to the user journey (for humans and crawlers) - we should relate this back to a landing page that's more closely connected to the job.

This change is part of the trial changes being made to the Teaching Assistant landing page https://dfedigital.atlassian.net/browse/TEVA-3324 - breadcrumb link will benefit the landing page by creating a network of contextual internal links)

This is for any click-based user journeys. For users who complete a search (with location info, filters, etc) their breadcrumb should retain existing behaviou (eg, provide “Search results” that links back to their selected search filters.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3325
