### PR TITLE
[TEVA-3352] Vary the default search radius depending on location type

### DIFF
--- a/app/components/jobseekers/search_results/heading_component.rb
+++ b/app/components/jobseekers/search_results/heading_component.rb
@@ -4,18 +4,18 @@ class Jobseekers::SearchResults::HeadingComponent < ViewComponent::Base
     @landing_page = landing_page
     @keyword = @vacancies_search.keyword
     @location = @vacancies_search.location_search.location
-    @radius = @vacancies_search.search_criteria[:radius]
+    @radius = @vacancies_search.location_search.radius
     @total_count = @vacancies_search.total_count
     @readable_count = number_with_delimiter(@total_count)
   end
 
   def heading
-    if @keyword.blank? && @location.blank?
-      return t("jobs.search_result_heading.without_search_html", jobs_count: @readable_count, count: @total_count)
+    if @landing_page.present? && Vacancy.job_roles.key?(@landing_page.underscore)
+      return t("jobs.search_result_heading.landing_page_html", jobs_count: @readable_count, landing_page: job_role(@landing_page), count: @total_count)
     end
 
-    if @landing_page.present? && Vacancy.job_roles.key?(@landing_page.underscore)
-      t("jobs.search_result_heading.landing_page_html", jobs_count: @readable_count, landing_page: job_role(@landing_page), count: @total_count)
+    if @keyword.blank? && @location.blank?
+      return t("jobs.search_result_heading.without_search_html", jobs_count: @readable_count, count: @total_count)
     end
 
     [count_phrase, keyword_phrase, radius_phrase, location_phrase].compact.join(" ")
@@ -36,17 +36,16 @@ class Jobseekers::SearchResults::HeadingComponent < ViewComponent::Base
   end
 
   def location_phrase
-    if @location.present?
-      t("jobs.search_result_heading.location_html", location: @location)
-    end
+    return unless @location.present?
+
+    t("jobs.search_result_heading.location_html", location: @location)
   end
 
   def radius_phrase
-    # A radius of 0 is only possible for polygon searches.
+    return unless @location.present?
 
-    if @location.present?
-      t("jobs.search_result_heading.radius_html", count: @radius, units: units)
-    end
+    # A radius of 0 is only possible for polygon searches.
+    t("jobs.search_result_heading.radius_html", count: @radius, units: units)
   end
 
   def units

--- a/app/components/jobseekers/search_results/heading_component.rb
+++ b/app/components/jobseekers/search_results/heading_component.rb
@@ -4,31 +4,50 @@ class Jobseekers::SearchResults::HeadingComponent < ViewComponent::Base
     @landing_page = landing_page
     @keyword = @vacancies_search.keyword
     @location = @vacancies_search.location_search.location
-    @polygon_boundaries = @vacancies_search.location_search.polygon_boundaries
     @radius = @vacancies_search.search_criteria[:radius]
     @total_count = @vacancies_search.total_count
     @readable_count = number_with_delimiter(@total_count)
   end
 
   def heading
+    if @keyword.blank? && @location.blank?
+      return t("jobs.search_result_heading.without_search_html", jobs_count: @readable_count, count: @total_count)
+    end
+
     if @landing_page.present? && Vacancy.job_roles.key?(@landing_page.underscore)
       t("jobs.search_result_heading.landing_page_html", jobs_count: @readable_count, landing_page: job_role(@landing_page), count: @total_count)
-    elsif @keyword.present? && @polygon_boundaries.present?
-      t("jobs.search_result_heading.keyword_location_polygon_html", jobs_count: @readable_count, location: @location, keyword: @keyword, count: @total_count, radius: @radius, units: units)
-    elsif @keyword.present? && @location.present?
-      t("jobs.search_result_heading.keyword_location_html", jobs_count: @readable_count, location: @location, keyword: @keyword, count: @total_count, radius: @radius, units: units)
-    elsif @keyword.present?
-      t("jobs.search_result_heading.keyword_html", jobs_count: @readable_count, keyword: @keyword, count: @total_count)
-    elsif @polygon_boundaries.present?
-      t("jobs.search_result_heading.location_polygon_html", jobs_count: @readable_count, location: @location, count: @total_count, radius: @radius, units: units)
-    elsif @location.present?
-      t("jobs.search_result_heading.location_html", jobs_count: @readable_count, location: @location, count: @total_count, radius: @radius, units: units)
-    else
-      t("jobs.search_result_heading.without_search_html", jobs_count: @readable_count, count: @total_count)
     end
+
+    [count_phrase, keyword_phrase, radius_phrase, location_phrase].compact.join(" ")
   end
 
   private
+
+  def count_phrase
+    t("jobs.search_result_heading.count_html", jobs_count: @readable_count, count: @total_count)
+  end
+
+  def keyword_phrase
+    if @keyword.present?
+      t("jobs.search_result_heading.keyword_html", keyword: @keyword, count: @total_count)
+    else
+      t("jobs.search_result_heading.no_keyword")
+    end
+  end
+
+  def location_phrase
+    if @location.present?
+      t("jobs.search_result_heading.location_html", location: @location)
+    end
+  end
+
+  def radius_phrase
+    # A radius of 0 is only possible for polygon searches.
+
+    if @location.present?
+      t("jobs.search_result_heading.radius_html", count: @radius, units: units)
+    end
+  end
 
   def units
     t("jobs.search_result_heading.unit_of_length").pluralize(@radius.to_i)

--- a/app/form_models/jobseekers/search_form.rb
+++ b/app/form_models/jobseekers/search_form.rb
@@ -11,17 +11,13 @@ class Jobseekers::SearchForm
   def initialize(params = {})
     strip_trailing_whitespaces_from_params(params)
     @keyword = params[:keyword] || params[:subject]
-
     @location = params[:location]
-
-    @radius = (params[:radius].presence if @location.present?) || Search::LocationBuilder::DEFAULT_RADIUS.to_s
-
     @job_roles = params[:job_roles] || params[:job_role] || []
     @phases = params[:phases]
     @working_patterns = params[:working_patterns]
+    @jobs_sort = Search::VacancySearchSort.for(params[:jobs_sort], keyword: keyword)
 
-    @jobs_sort = Search::VacancySearchSort.for(params[:jobs_sort], keyword: @keyword)
-
+    set_radius(params[:radius])
     set_facet_options
     set_total_filters
   end
@@ -55,5 +51,9 @@ class Jobseekers::SearchForm
 
   def set_total_filters
     @total_filters = [@job_roles&.count, @phases&.count, @working_patterns&.count].reject(&:nil?).sum
+  end
+
+  def set_radius(radius_param)
+    @radius = Search::RadiusBuilder.new(location, radius_param).radius.to_s
   end
 end

--- a/app/form_models/jobseekers/subscription_form.rb
+++ b/app/form_models/jobseekers/subscription_form.rb
@@ -18,11 +18,11 @@ class Jobseekers::SubscriptionForm < BaseForm
     @frequency = params[:frequency]
     @keyword = params[:keyword] || search_criteria[:keyword]
     @location = params[:location] || search_criteria[:location]
-    @radius = ((params[:radius] || search_criteria[:radius]) if @location.present?) || Search::LocationBuilder::DEFAULT_RADIUS.to_s
     @job_roles = params[:job_roles]&.reject(&:blank?) || search_criteria[:job_roles] || []
     @phases = params[:phases]&.reject(&:blank?) || search_criteria[:phases]
     @working_patterns = params[:working_patterns]&.reject(&:blank?) || search_criteria[:working_patterns]
 
+    set_radius((params[:radius] || search_criteria[:radius]))
     set_facet_options
   end
 
@@ -67,5 +67,9 @@ class Jobseekers::SubscriptionForm < BaseForm
     return unless Subscription.where(job_alert_params).exists?
 
     errors.add(:base, I18n.t("subscriptions.errors.duplicate_alert"))
+  end
+
+  def set_radius(radius_param)
+    @radius = Search::RadiusBuilder.new(location, radius_param).radius.to_s
   end
 end

--- a/app/helpers/vacancies_options_helper.rb
+++ b/app/helpers/vacancies_options_helper.rb
@@ -1,4 +1,6 @@
 module VacanciesOptionsHelper
+  RADIUS_OPTIONS = [0, 1, 5, 10, 25, 50, 100, 200].freeze
+
   def hired_status_options
     Vacancy.hired_statuses.keys.map { |k| [t("jobs.feedback.hired_status.#{k}"), k] }.unshift(["--", ""])
   end
@@ -8,7 +10,7 @@ module VacanciesOptionsHelper
   end
 
   def radius_filter_options
-    Search::RadiusSuggestionsBuilder::RADIUS_OPTIONS.inject([]) do |radii, radius|
+    RADIUS_OPTIONS.inject([]) do |radii, radius|
       radii << [t("jobs.search.number_of_miles", count: radius), radius]
     end
   end

--- a/app/presenters/subscription_presenter.rb
+++ b/app/presenters/subscription_presenter.rb
@@ -47,8 +47,11 @@ class SubscriptionPresenter < BasePresenter
   def render_location_filter(location, radius)
     return if location.blank?
 
-    return { location: I18n.t("subscriptions.location_polygon_text", location: location) } if LocationPolygon.include?(location)
-    return { location: I18n.t("subscriptions.location_radius_text", radius: radius, location: location) } if radius
+    if radius.present? && radius.to_s != "0"
+      { location: I18n.t("subscriptions.location_with_radius", radius: radius, location: location) }
+    elsif LocationPolygon.include?(location)
+      { location: I18n.t("subscriptions.location_in", location: location) }
+    end
   end
 
   def render_job_roles_filter(value)

--- a/app/services/search/buffer_suggestions_builder.rb
+++ b/app/services/search/buffer_suggestions_builder.rb
@@ -1,4 +1,6 @@
 class Search::BufferSuggestionsBuilder
+  include VacanciesOptionsHelper
+
   attr_reader :location, :buffer_suggestions, :search_params
 
   def initialize(location, search_params)
@@ -8,7 +10,7 @@ class Search::BufferSuggestionsBuilder
   end
 
   def get_buffers_suggestions
-    buffer_vacancy_count = Search::RadiusSuggestionsBuilder::RADIUS_OPTIONS.map do |distance|
+    buffer_vacancy_count = (RADIUS_OPTIONS - [0]).map do |distance|
       polygons = LocationPolygon.buffered(distance).with_name(location).to_algolia_polygons
 
       [distance.to_s, Search::Strategies::Algolia.new(search_params.merge(polygons: polygons)).total_count]

--- a/app/services/search/location_builder.rb
+++ b/app/services/search/location_builder.rb
@@ -1,7 +1,6 @@
 require "geocoding"
 
 class Search::LocationBuilder
-  DEFAULT_RADIUS = 10
   NATIONWIDE_LOCATIONS = ["england", "uk", "united kingdom", "britain", "great britain"].freeze
 
   include DistanceHelper
@@ -10,7 +9,7 @@ class Search::LocationBuilder
 
   def initialize(location, radius)
     @location = location
-    @radius = Integer(radius || DEFAULT_RADIUS).abs
+    @radius = Search::RadiusBuilder.new(location, radius).radius
     @location_filter = {}
 
     if NATIONWIDE_LOCATIONS.include?(@location&.downcase)
@@ -23,7 +22,7 @@ class Search::LocationBuilder
   end
 
   def search_with_polygons?
-    location && LocationPolygon.include?(location)
+    location.present? && LocationPolygon.include?(location)
   end
 
   def point_coordinates

--- a/app/services/search/radius_builder.rb
+++ b/app/services/search/radius_builder.rb
@@ -1,0 +1,33 @@
+class Search::RadiusBuilder
+  DEFAULT_RADIUS_FOR_POINT_SEARCHES = 10
+  DEFAULT_BUFFER_FOR_POLYGON_SEARCHES = 0
+
+  attr_reader :radius
+
+  def initialize(location, radius)
+    @location = location
+    @radius = get_radius(radius)
+  end
+
+  private
+
+  attr_reader :location
+
+  def get_radius(radius)
+    return DEFAULT_BUFFER_FOR_POLYGON_SEARCHES unless location.present?
+
+    if !search_with_polygons? && radius.to_s == DEFAULT_BUFFER_FOR_POLYGON_SEARCHES.to_s
+      DEFAULT_RADIUS_FOR_POINT_SEARCHES
+    else
+      Integer(radius || default_radius).abs
+    end
+  end
+
+  def default_radius
+    search_with_polygons? ? DEFAULT_BUFFER_FOR_POLYGON_SEARCHES : DEFAULT_RADIUS_FOR_POINT_SEARCHES
+  end
+
+  def search_with_polygons?
+    location.present? && LocationPolygon.include?(location)
+  end
+end

--- a/app/services/search/radius_suggestions_builder.rb
+++ b/app/services/search/radius_suggestions_builder.rb
@@ -1,5 +1,4 @@
 class Search::RadiusSuggestionsBuilder
-  LEGACY_RADIUS_OPTIONS = [1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 70, 80, 90, 100, 200].freeze
   RADIUS_OPTIONS = [1, 5, 10, 25, 50, 100, 200].freeze
 
   include DistanceHelper

--- a/app/services/search/radius_suggestions_builder.rb
+++ b/app/services/search/radius_suggestions_builder.rb
@@ -1,7 +1,6 @@
 class Search::RadiusSuggestionsBuilder
-  RADIUS_OPTIONS = [1, 5, 10, 25, 50, 100, 200].freeze
-
   include DistanceHelper
+  include VacanciesOptionsHelper
 
   attr_reader :radius, :radius_suggestions, :search_params
 

--- a/app/services/search/vacancy_search.rb
+++ b/app/services/search/vacancy_search.rb
@@ -67,8 +67,8 @@ class Search::VacancySearch
                              Search::Strategies::PgSearch.new(
                                keyword,
                                filters: search_criteria,
-                               location: search_criteria[:location],
-                               radius: search_criteria[:radius],
+                               location: location_search.location_filter[:location],
+                               radius: location_search.radius,
                                page: page,
                                per_page: per_page,
                                sort_by: sort_by,

--- a/app/views/shared/search/_radius.html.slim
+++ b/app/views/shared/search/_radius.html.slim
@@ -6,4 +6,4 @@
   class: "govuk-!-width-#{wide ? 'full' : 'one-half'}",
   data: { "change-submit": "false" },
   form_group: { classes: "location-radius-select" },
-  options: { selected: @form.radius || Search::LocationBuilder::DEFAULT_RADIUS }
+  options: { selected: @form.radius || Search::LocationBuilder::DEFAULT_BUFFER_FOR_POLYGON_SEARCHES }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -451,8 +451,8 @@ en:
         link: get notified
         text_html: Or %{link_to} when a job like this gets listed
       text: Receive a job alert
-    location_polygon_text: In %{location}
-    location_radius_text: Within %{radius} miles of %{location}
+    location_in: In %{location}
+    location_with_radius: Within %{radius} miles of %{location}
     manage: Manage your subscription
     new:
       description: You can change the search criteria you have used by amending the keywords, location or filters before you create your alert.

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -66,16 +66,9 @@ en:
       within_radius: Search radius
 
     search_result_heading:
-      without_search_html:
-        one: There is <span class='govuk-!-font-weight-bold'>%{jobs_count}</span> job listed
-        other: There are <span class='govuk-!-font-weight-bold'>%{jobs_count}</span> jobs listed
-      keyword_html:
-        one: >-
-          <span class='govuk-!-font-weight-bold'>%{jobs_count}</span> job matches
-          <span class='govuk-!-font-weight-bold'>&lsquo;%{keyword}&rsquo;</span>
-        other: >-
-          <span class='govuk-!-font-weight-bold'>%{jobs_count}</span> jobs match
-          <span class='govuk-!-font-weight-bold'>&lsquo;%{keyword}&rsquo;</span>
+      count_html:
+        one: <span class='govuk-!-font-weight-bold'>%{jobs_count}</span> job
+        other: <span class='govuk-!-font-weight-bold'>%{jobs_count}</span> jobs
       landing_page_html:
         one: >-
           <span class='govuk-!-font-weight-bold'>%{jobs_count}</span>
@@ -83,47 +76,22 @@ en:
         other: >-
           <span class='govuk-!-font-weight-bold'>%{jobs_count}</span>
           <span class='govuk-!-font-weight-bold'>%{landing_page} jobs</span>
-      location_html:
+      keyword_html:
+        one: matches <span class='govuk-!-font-weight-bold'>&lsquo;%{keyword}&rsquo;</span>
+        other: match <span class='govuk-!-font-weight-bold'>&lsquo;%{keyword}&rsquo;</span>
+      no_keyword: found
+      radius_html:
+        zero: in
         one: >-
-          <span class="govuk-!-font-weight-bold">%{jobs_count}</span> job found within
-          <span class='govuk-!-font-weight-bold'>%{radius} %{units}</span> of
-          <span class='govuk-!-font-weight-bold text-capitalize'>&lsquo;%{location}&rsquo;</span>
+          within <span class='govuk-!-font-weight-bold'>%{count} %{units}</span> of
         other: >-
-          <span class="govuk-!-font-weight-bold">%{jobs_count}</span> jobs found within
-          <span class='govuk-!-font-weight-bold'>%{radius} %{units}</span> of
-          <span class="govuk-!-font-weight-bold text-capitalize">&lsquo;%{location}&rsquo;</span>
-      location_polygon_html:
-        one: >-
-          <span class="govuk-!-font-weight-bold">%{jobs_count}</span> job found within
-          <span class='govuk-!-font-weight-bold'>%{radius} %{units}</span> of
-          <span class='govuk-!-font-weight-bold text-capitalize'>&lsquo;%{location}&rsquo;</span>
-        other: >-
-          <span class="govuk-!-font-weight-bold">%{jobs_count}</span> jobs found within
-          <span class='govuk-!-font-weight-bold'>%{radius} %{units}</span> of
-          <span class="govuk-!-font-weight-bold text-capitalize">&lsquo;%{location}&rsquo;</span>
-      keyword_location_html:
-        one: >-
-          <span class='govuk-!-font-weight-bold'>%{jobs_count}</span> job matches
-          <span class='govuk-!-font-weight-bold'>&lsquo;%{keyword}&rsquo;</span> within
-          <span class='govuk-!-font-weight-bold'>%{radius} %{units}</span> of
-          <span class='govuk-!-font-weight-bold text-capitalize'>&lsquo;%{location}&rsquo;</span>
-        other: >-
-          <span class="govuk-!-font-weight-bold">%{jobs_count}</span> jobs match
-          <span class='govuk-!-font-weight-bold'>&lsquo;%{keyword}&rsquo;</span> within
-          <span class='govuk-!-font-weight-bold'>%{radius} %{units}</span> of
-          <span class="govuk-!-font-weight-bold text-capitalize">&lsquo;%{location}&rsquo;</span>
-      keyword_location_polygon_html:
-        one: >-
-          <span class='govuk-!-font-weight-bold'>%{jobs_count}</span> job matches
-          <span class='govuk-!-font-weight-bold'>&lsquo;%{keyword}&rsquo;</span> within
-          <span class='govuk-!-font-weight-bold'>%{radius} %{units}</span> of
-          <span class='govuk-!-font-weight-bold text-capitalize'>&lsquo;%{location}&rsquo;</span>
-        other: >-
-          <span class="govuk-!-font-weight-bold">%{jobs_count}</span> jobs match
-          <span class='govuk-!-font-weight-bold'>&lsquo;%{keyword}&rsquo;</span> within
-          <span class='govuk-!-font-weight-bold'>%{radius} %{units}</span> of
-          <span class="govuk-!-font-weight-bold text-capitalize">&lsquo;%{location}&rsquo;</span>
+          within <span class='govuk-!-font-weight-bold'>%{count} %{units}</span> of
+      location_html: <span class='govuk-!-font-weight-bold text-capitalize'>&lsquo;%{location}&rsquo;</span>
       unit_of_length: mile
+      without_search_html:
+        one: There is <span class='govuk-!-font-weight-bold'>%{jobs_count}</span> job listed
+        other: There are <span class='govuk-!-font-weight-bold'>%{jobs_count}</span> jobs listed
+
 
     legacy_job_alert:
       link: Receive a job alert

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -59,6 +59,7 @@ en:
       location: Location
       location_hint: For example, city, county or postcode
       number_of_miles:
+        zero: This area only
         one: '%{count} mile'
         other: '%{count} miles'
       title: Search job listings

--- a/spec/components/jobseekers/search_results/heading_component_spec.rb
+++ b/spec/components/jobseekers/search_results/heading_component_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe Jobseekers::SearchResults::HeadingComponent, type: :component do
     allow(vacancies_search).to receive(:keyword).and_return(keyword)
     allow(vacancies_search).to receive_message_chain(:location_search, :location).and_return(location)
     allow(vacancies_search).to receive_message_chain(:total_count).and_return(count)
-    allow(vacancies_search).to receive_message_chain(:search_criteria, :[]).and_return(radius)
+    allow(vacancies_search).to receive_message_chain(:location_search, :radius).and_return(radius)
   end
 
   context "when landing_page is a job role" do
     let(:landing_page) { "teaching-assistant" }
 
     it "renders correct heading" do
-      expect(subject.text).to eq(I18n.t("jobs.search_result_heading.landing_page_html", jobs_count: count, landing_page: landing_page.titleize.downcase, count: count))
+      expect(subject.text).to eq("10 teaching assistant jobs")
     end
   end
 

--- a/spec/components/jobseekers/search_results/heading_component_spec.rb
+++ b/spec/components/jobseekers/search_results/heading_component_spec.rb
@@ -1,93 +1,64 @@
 require "rails_helper"
 
 RSpec.describe Jobseekers::SearchResults::HeadingComponent, type: :component do
-  subject { described_class.new(vacancies_search: vacancies_search, landing_page: landing_page) }
+  subject { render_inline(described_class.new(vacancies_search: vacancies_search, landing_page: landing_page)) }
 
   let(:vacancies_search) { instance_double(Search::VacancySearch) }
   let(:landing_page) { nil }
   let(:keyword) { "maths" }
   let(:location) { "London" }
-  let(:polygon_boundaries) { [[51.0, 51.0]] }
   let(:count) { 10 }
   let(:radius) { 10 }
 
   before do
     allow(vacancies_search).to receive(:keyword).and_return(keyword)
     allow(vacancies_search).to receive_message_chain(:location_search, :location).and_return(location)
-    allow(vacancies_search).to receive_message_chain(:location_search, :polygon_boundaries).and_return(polygon_boundaries)
     allow(vacancies_search).to receive_message_chain(:total_count).and_return(count)
     allow(vacancies_search).to receive_message_chain(:search_criteria, :[]).and_return(radius)
-    render_inline(subject)
   end
 
   context "when landing_page is a job role" do
     let(:landing_page) { "teaching-assistant" }
 
     it "renders correct heading" do
-      expect(rendered_component).to include(
-        I18n.t("jobs.search_result_heading.landing_page_html", jobs_count: count, landing_page: landing_page.titleize.downcase, count: count),
-      )
+      expect(subject.text).to eq(I18n.t("jobs.search_result_heading.landing_page_html", jobs_count: count, landing_page: landing_page.titleize.downcase, count: count))
     end
   end
 
-  context "when keyword and search polygon boundaries are present" do
-    it "renders correct heading" do
-      expect(rendered_component).to include(
-        I18n.t("jobs.search_result_heading.keyword_location_polygon_html", jobs_count: count, keyword: keyword, location: location, count: count, radius: radius, units: I18n.t("jobs.search_result_heading.unit_of_length").pluralize(radius.to_i)),
-      )
+  context "when searching with a keyword and a location with no radius (a polygon search)" do
+    let(:radius) { 0 }
+
+    it "renders correct heading text" do
+      expect(subject.text).to eq("#{count} jobs match ‘#{keyword}’ in ‘#{location}’")
     end
   end
 
-  context "when keyword and location are present" do
-    let(:polygon_boundaries) { nil }
-
-    it "renders correct heading" do
-      expect(rendered_component).to include(
-        I18n.t("jobs.search_result_heading.keyword_location_html", jobs_count: count, keyword: keyword, location: location, count: count, radius: radius, units: I18n.t("jobs.search_result_heading.unit_of_length").pluralize(radius.to_i)),
-      )
+  context "when searching with a keyword and a location with a radius (polygon or point)" do
+    it "renders correct heading text" do
+      expect(subject.text).to eq("#{count} jobs match ‘#{keyword}’ within #{radius} miles of ‘#{location}’")
     end
   end
 
-  context "when only keyword is present" do
+  context "when searching with a keyword and no location" do
     let(:location) { nil }
-    let(:polygon_boundaries) { nil }
 
-    it "renders correct heading" do
-      expect(rendered_component).to include(
-        I18n.t("jobs.search_result_heading.keyword_html", jobs_count: count, keyword: keyword, count: count),
-      )
+    it "renders correct heading text" do
+      expect(subject.text).to eq("#{count} jobs match ‘#{keyword}’")
     end
   end
 
-  context "when search polygon boundaries is present but keyword is not present" do
-    let(:keyword) do
-      nil
-    end
+  context "when searching with a location and no keyword" do
+    let(:keyword) { nil }
 
-    it "renders correct heading" do
-      expect(rendered_component).to include(
-        I18n.t("jobs.search_result_heading.location_polygon_html", jobs_count: count, location: location, count: count, radius: radius, units: I18n.t("jobs.search_result_heading.unit_of_length").pluralize(radius.to_i)),
-      )
-    end
-  end
-
-  context "when only location is present" do
-    let(:keyword) do
-      nil
-    end
-    let(:polygon_boundaries) { nil }
-
-    it "renders correct heading" do
-      expect(rendered_component).to include(
-        I18n.t("jobs.search_result_heading.location_html", jobs_count: count, location: location, count: count, radius: radius, units: I18n.t("jobs.search_result_heading.unit_of_length").pluralize(radius.to_i)),
-      )
+    it "renders correct heading text" do
+      expect(subject.text).to eq("#{count} jobs found within #{radius} miles of ‘#{location}’")
     end
   end
 
   context "when neither keyword and location are present" do
     let(:keyword) { nil }
     let(:location) { nil }
-    let(:polygon_boundaries) { nil }
+    before { subject }
 
     it "renders correct heading" do
       expect(rendered_component).to include(

--- a/spec/form_models/jobseekers/search_form_spec.rb
+++ b/spec/form_models/jobseekers/search_form_spec.rb
@@ -1,44 +1,52 @@
 require "rails_helper"
 
+RSpec.shared_examples "a form that correctly calls Search::RadiusBuilder" do
+  it "sets the radius and location attributes" do
+    expect(Search::RadiusBuilder).to receive(:new).with(location, radius).and_return(radius_builder)
+    expect(subject.radius).to eq(expected_radius)
+    expect(subject.location).to eq(location)
+  end
+end
+
 RSpec.describe Jobseekers::SearchForm, type: :model do
   subject { described_class.new(params) }
 
   describe "#initialize" do
-    before { stub_const("Search::LocationBuilder::DEFAULT_RADIUS", "32") }
+    let(:radius_builder) { instance_double(Search::RadiusBuilder) }
+    let(:expected_radius) { "1000" }
+    let(:params) { { radius: radius, location: location } }
 
-    context "when a radius is provided" do
-      context "when a location is provided" do
-        let(:params) { { radius: "1", location: "North Nowhere" } }
+    before { allow(radius_builder).to receive(:radius).and_return(expected_radius) }
 
-        it "assigns the radius attribute to the radius param" do
-          expect(subject.radius).to eq("1")
-        end
+    context "when location param is provided" do
+      let(:location) { "North Nowhere" }
+
+      context "when radius param is provided" do
+        let(:radius) { "1" }
+
+        it_behaves_like "a form that correctly calls Search::RadiusBuilder"
       end
 
-      context "when a location is not provided" do
-        let(:params) { { radius: "1" } }
+      context "when radius param is not provided" do
+        let(:radius) { nil }
 
-        it "assigns the radius to the default radius" do
-          expect(subject.radius).to eq("32")
-        end
+        it_behaves_like "a form that correctly calls Search::RadiusBuilder"
       end
     end
 
-    context "when a radius is not provided" do
-      context "when a location is provided" do
-        let(:params) { { location: "North Nowhere" } }
+    context "when location param is not provided" do
+      let(:location) { nil }
 
-        it "assigns the radius attribute to the default radius" do
-          expect(subject.radius).to eq("32")
-        end
+      context "when radius param is provided" do
+        let(:radius) { "1" }
+
+        it_behaves_like "a form that correctly calls Search::RadiusBuilder"
       end
 
-      context "when a location is not provided" do
-        let(:params) { {} }
+      context "when radius param is not provided" do
+        let(:radius) { nil }
 
-        it "assigns the radius to the default radius" do
-          expect(subject.radius).to eq("32")
-        end
+        it_behaves_like "a form that correctly calls Search::RadiusBuilder"
       end
     end
   end

--- a/spec/presenters/subscription_presenter_spec.rb
+++ b/spec/presenters/subscription_presenter_spec.rb
@@ -15,10 +15,28 @@ RSpec.describe SubscriptionPresenter do
     end
 
     context "when the location is a LocationPolygon" do
-      let(:search_criteria) { { location: "Barnet" } }
+      context "when the radius is present" do
+        let(:search_criteria) { { location: "Barnet", radius: "10" } }
 
-      it "formats and returns the search criteria" do
-        expect(presenter.filtered_search_criteria["location"]).to eq("In Barnet")
+        it "formats and returns the search criteria" do
+          expect(presenter.filtered_search_criteria["location"]).to eq("Within 10 miles of Barnet")
+        end
+
+        context "when the radius is 0" do
+          let(:search_criteria) { { location: "Barnet", radius: "0" } }
+
+          it "formats and returns the search criteria" do
+            expect(presenter.filtered_search_criteria["location"]).to eq("In Barnet")
+          end
+        end
+      end
+
+      context "when the radius does not exist" do
+        let(:search_criteria) { { location: "Barnet" } }
+
+        it "formats and returns the search criteria" do
+          expect(presenter.filtered_search_criteria["location"]).to eq("In Barnet")
+        end
       end
     end
 

--- a/spec/requests/subscriptions_spec.rb
+++ b/spec/requests/subscriptions_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "Subscriptions" do
     it "creates a subscription" do
       expect { subject }.to change { Subscription.count }.by(1)
       expect(created_subscription.email).to eq("foo@example.net")
-      expect(created_subscription.search_criteria.symbolize_keys).to eq({ keyword: "english", location: "London", radius: "10" })
+      expect(created_subscription.search_criteria.symbolize_keys).to eq({ keyword: "english", location: "London", radius: "0" })
     end
 
     it "triggers a `job_alert_subscription_created` event" do
@@ -131,7 +131,7 @@ RSpec.describe "Subscriptions" do
     it "updates the subscription" do
       expect { subject }.not_to(change { Subscription.count })
       expect(subscription.reload.email).to eq("jimi@hendrix.com")
-      expect(subscription.reload.search_criteria.symbolize_keys).to eq({ keyword: "english", location: "London", radius: "10" })
+      expect(subscription.reload.search_criteria.symbolize_keys).to eq({ keyword: "english", location: "London", radius: "0" })
     end
 
     it "triggers a `job_alert_subscription_updated` event" do

--- a/spec/services/search/buffer_suggestions_builder_spec.rb
+++ b/spec/services/search/buffer_suggestions_builder_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Search::BufferSuggestionsBuilder do
       let!(:polygon) { create(:location_polygon, name: "tower hamlets") }
 
       before do
-        Search::RadiusSuggestionsBuilder::RADIUS_OPTIONS.each_with_index do |radius, idx|
+        (VacanciesOptionsHelper::RADIUS_OPTIONS - [0]).each_with_index do |radius, idx|
           buffered_polygon = LocationPolygon.buffered(radius).with_name(location)
 
           mock_algolia_search(

--- a/spec/services/search/radius_builder_spec.rb
+++ b/spec/services/search/radius_builder_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe Search::RadiusBuilder do
+  subject { described_class.new(location, radius) }
+
+  let(:location) { "placename" }
+
+  before do
+    stub_const("Search::RadiusBuilder::DEFAULT_RADIUS_FOR_POINT_SEARCHES", 32)
+    stub_const("Search::RadiusBuilder::DEFAULT_BUFFER_FOR_POLYGON_SEARCHES", 64)
+  end
+
+  describe "#initialize" do
+    context "when a non-polygonable location is specified" do
+      context "when no radius is specified" do
+        let(:radius) { nil }
+
+        it "sets radius attribute to the default radius for point location searches" do
+          expect(subject.radius).to eq(32)
+        end
+      end
+
+      context "when a radius is specified" do
+        let(:radius) { 1024 }
+
+        it "sets radius attribute to the specified radius" do
+          expect(subject.radius).to eq(1024)
+        end
+
+        context "when the radius is the same as DEFAULT_BUFFER_FOR_POLYGON_SEARCHES" do
+          let(:radius) { 64 }
+
+          it "sets radius attribute to the default radius for point location searches" do
+            expect(subject.radius).to eq(32)
+          end
+        end
+      end
+    end
+
+    context "when a polygonable location is specified" do
+      before { allow(LocationPolygon).to receive(:include?).with(location).and_return(true) }
+
+      context "when no radius is specified" do
+        let(:radius) { nil }
+
+        it "sets radius attribute to the default radius for polygon location searches" do
+          expect(subject.radius).to eq(64)
+        end
+      end
+
+      context "when a radius is specified" do
+        let(:radius) { 1024 }
+
+        it "sets radius attribute to the specified radius" do
+          expect(subject.radius).to eq(1024)
+        end
+
+        context "when the radius is the same as DEFAULT_BUFFER_FOR_POLYGON_SEARCHES" do
+          let(:radius) { 64 }
+
+          it "preserves the radius attribute" do
+            expect(subject.radius).to eq(64)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/system/jobseekers_can_search_from_home_page_spec.rb
+++ b/spec/system/jobseekers_can_search_from_home_page_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe "Searching on the home page", vcr: { cassette_name: "algoliasearc
     visit root_path
   end
 
-  it "defaults to a radius of 10 miles" do
-    expect(page.find("#radius-field").value).to eq("10")
+  scenario "defaults to a radius of 0 miles" do
+    expect(page.find("#radius-field").value).to eq("0")
   end
 
-  it "persists search terms to the jobs index page" do
+  scenario "persists search terms to the jobs index page" do
     fill_in "Keyword", with: "math"
     fill_in "Location", with: "bristol"
     select "25 miles", from: "radius"
@@ -22,5 +22,20 @@ RSpec.describe "Searching on the home page", vcr: { cassette_name: "algoliasearc
     expect(page.find("#keyword-field").value).to eq("math")
     expect(page.find("#location-field").value).to eq("bristol")
     expect(page.find("#radius-field").value).to eq("25")
+  end
+
+  context "when the location is not a polygon and the radius is 0" do
+    scenario "resets radius to a default radius" do
+      fill_in "Keyword", with: "math"
+      fill_in "Location", with: "my house"
+      select I18n.t("jobs.search.number_of_miles", count: 0), from: "radius"
+
+      click_on I18n.t("buttons.search")
+
+      expect(current_path).to eq(jobs_path)
+      expect(page.find("#keyword-field").value).to eq("math")
+      expect(page.find("#location-field").value).to eq("my house")
+      expect(page.find("#radius-field").value).to eq(Search::RadiusBuilder::DEFAULT_RADIUS_FOR_POINT_SEARCHES.to_s)
+    end
   end
 end


### PR DESCRIPTION
Do so by splitting out some new radius logic from Search::LocationBuilder into a Search::RadiusBuilder class, which is consumed by LocationBuilder, SubscriptionForm, and SearchForm.

The logic is as follows:

If a user has selected the (new) '0' option ('This area only') for the radius of a search/job alert, we change this to a default value for point-based location searches. Otherwise, we keep the radius entered.

Other changes:

- Set the default radius to the default for polygon searches, which is now 0.

- Fix bug in subscription presenter

The render_location_filter was ignoring radiuses for polygon-based location searches, e.g. said 'In Oxford' when the search was for Oxford plus 100 miles radius.

-  Update and refactor search heading component

We can drop the logic related to distinguishing between polygon and location searches, and also simplify by creating each section of the heading separately before stringing them together (rather than writing out every possible permutation in the translations).

I have written the tests for the search heading component to test the strings directly rather than to test against a translation, primarily because the translations are more brittle than the strings themselves (if the tests had already been strings I would have had to change very few of them in this commit) and secondarily because it is safer to test the strings because translations, when not found, return a string rather than an error.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3352
