### PR TITLE
Implement basic "relevance" rank order for new search

### DIFF
--- a/app/queries/vacancy_full_text_search_query.rb
+++ b/app/queries/vacancy_full_text_search_query.rb
@@ -6,18 +6,32 @@ class VacancyFullTextSearchQuery < ApplicationQuery
   end
 
   def call(query)
-    # Perform full text search on the searchable_content column using Postgres `@@` operator
+    # Convert user input into a search query of Postgres type `tsquery`
     # TODO: `websearch_to_tsquery` used to get this up and running quickly, to be replaced soon
-    #       with a custom query taking synonyms etc into account.
+    #       with custom query logic taking synonyms etc into account.
+    tsquery = Arel::Nodes::NamedFunction.new(
+      "websearch_to_tsquery",
+      [
+        Arel::Nodes::Quoted.new("simple"),
+        Arel::Nodes::Quoted.new(query),
+      ],
+    )
+
     full_text_query = Arel::Nodes::InfixOperation.new(
       "@@",
       scope.arel_table[:searchable_content],
-      Arel::Nodes::NamedFunction.new(
-        "websearch_to_tsquery",
-        [Arel::Nodes::Quoted.new(query)],
-      ),
+      tsquery,
     )
 
-    scope.where(full_text_query)
+    rank_order = Arel::Nodes::NamedFunction.new(
+      "ts_rank",
+      [scope.arel_table[:searchable_content], tsquery],
+    )
+
+    # Order based on "relevance" (`ts_rank`) here because we don't have access to the `tsquery`
+    # outside of this query object. If the user chooses a different search order, the call to
+    # `reorder` in `PgSearch` will take precedence over this order. `order` does not directly
+    # take an Arel object, so convert it to a SQL string and mark it as safe using `Arel.sql`.
+    scope.where(full_text_query).order(Arel.sql(rank_order.to_sql) => :desc)
   end
 end

--- a/app/services/search/strategies/pg_search.rb
+++ b/app/services/search/strategies/pg_search.rb
@@ -28,7 +28,7 @@ class Search::Strategies::PgSearch
     scope = scope.search_by_location(location, radius) if location
     scope = scope.search_by_filter(filters) if filters.any?
     scope = scope.search_by_full_text(keyword) if keyword.present?
-    scope = scope.order(sort_by.column => sort_by.order) if sort_by&.column
+    scope = scope.reorder(sort_by.column => sort_by.order) if sort_by&.column
 
     # Adds an additional order by updated at for searches so a non-deterministic order column
     # (e.g. date instead of datetime) will still result in the same order as Algolia for


### PR DESCRIPTION
- Order all results that pass through `VacancyFullTextSearchQuery` by
  `ts_rank`
- Reorder in `PgSearch` if user has selected a specific, non-relevance
  search order