### PR TITLE
[TEVA-3359] Update home page CTAs for hiring staff

### DIFF
--- a/app/frontend/src/styles/application.scss
+++ b/app/frontend/src/styles/application.scss
@@ -18,6 +18,7 @@ $govuk-new-link-styles: true;
 
 @import 'application/accordion';
 @import 'application/applications';
+@import 'application/footer';
 @import 'application/form';
 @import 'application/full-width-mast';
 @import 'application/govuk-notification-banner';

--- a/app/frontend/src/styles/application/footer.scss
+++ b/app/frontend/src/styles/application/footer.scss
@@ -1,0 +1,3 @@
+.govuk-footer__link.button-as-link {
+  font-size: inherit;
+}

--- a/app/frontend/src/styles/application/signin.scss
+++ b/app/frontend/src/styles/application/signin.scss
@@ -6,4 +6,11 @@
     margin-bottom: govuk-spacing(2);
     margin-top: govuk-spacing(3);
   }
+
+  &--publisher {
+    p,
+    form {
+      display: inline;
+    }
+  }
 }

--- a/app/frontend/src/styles/base/_utilities.scss
+++ b/app/frontend/src/styles/base/_utilities.scss
@@ -1,3 +1,12 @@
+input.button-as-link {
+  background: none;
+  border: 0;
+  cursor: pointer;
+  margin-bottom: 0;
+  outline: inherit;
+  padding: 0;
+}
+
 .wordwrap {
   word-wrap: break-word;
 }

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -11,12 +11,17 @@
               = render "signed_in_jobseeker"
           - else
               = render "signed_out_jobseeker"
-        - unless signed_in?
-          .signin
-            h2.govuk-heading-m = t(".publisher_signin.title")
-            p.govuk-body = t(".publisher_signin.description_html",
-              signin_link: govuk_link_to(t(".publisher_signin.link_text.sign_in"), publishers_sign_in_path, class: "govuk-link--no-visited-state"),
-              signup_link: govuk_link_to(t(".publisher_signin.link_text.sign_up"), page_path("dsi-account-request"), class: "govuk-link--no-visited-state"))
+        - unless jobseeker_signed_in?
+          .signin.signin--publisher
+            h2.govuk-heading-m = t(".publisher_section.title")
+            - if publisher_signed_in?
+              = button_to(t("buttons.create_job"), organisation_jobs_path, class: "govuk-body govuk-link button-as-link")
+              p.govuk-body = t(".publisher_section.signed_in.description_html",
+                manage_jobs_link: govuk_link_to(t(".publisher_section.signed_in.link_text.manage_jobs"), organisation_path, class: "govuk-link--no-visited-state"))
+            - else
+              p.govuk-body = t(".publisher_section.signed_out.description_html",
+                signin_link: govuk_link_to(t(".publisher_section.signed_out.link_text.sign_in"), publishers_sign_in_path, class: "govuk-link--no-visited-state"),
+                signup_link: govuk_link_to(t(".publisher_section.signed_out.link_text.sign_up"), page_path("dsi-account-request"), class: "govuk-link--no-visited-state"))
 
 .govuk-main-wrapper class="govuk-!-padding-top-0"
   .govuk-grid-row

--- a/app/views/layouts/_footer.html.slim
+++ b/app/views/layouts/_footer.html.slim
@@ -32,7 +32,7 @@
         ul.govuk-footer__list
           - if publisher_signed_in?
             li.govuk-footer__list-item
-              = link_to t("footer.list_a_teaching_job"), organisation_path, class: "govuk-footer__link"
+              = button_to(t("footer.list_a_teaching_job"), organisation_jobs_path, class: "govuk-footer__link button-as-link")
             li.govuk-footer__list-item
               = link_to t("footer.manage_job_listings"), organisation_path, class: "govuk-footer__link"
           - else

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -226,12 +226,17 @@ en:
   home:
     index:
       browse_all: Browse all teaching jobs in England
-      publisher_signin:
+      publisher_section:
         title: Advertise a school job
-        description_html: "%{signin_link} to manage your job listings and applicants or %{signup_link}."
-        link_text:
-          sign_in: Sign in
-          sign_up: sign up
+        signed_in:
+          description_html: " or %{manage_jobs_link}."
+          link_text:
+            manage_jobs: manage your jobs
+        signed_out:
+          description_html: "%{signin_link} to manage your job listings and applicants or %{signup_link}."
+          link_text:
+            sign_in: Sign in
+            sign_up: sign up
       title: Find a job in teaching
     signed_in_jobseeker:
       description: Apply for jobs you are interested in, and check the status of your applications.

--- a/spec/system/jobseekers_can_sign_in_to_their_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_in_to_their_account_spec.rb
@@ -39,12 +39,7 @@ RSpec.describe "Jobseekers can sign in to their account" do
       visit root_path
 
       within ".search-panel-banner .govuk-grid-column-one-third" do
-        expect(page).not_to have_content(I18n.t("home.index.publisher_signin.title"))
-        expect(page).not_to have_content(I18n.t("home.index.publisher_signin.description_html",
-                                                signin_link: I18n.t("home.index.publisher_signin.link_text.sign_in"),
-                                                signup_link: I18n.t("home.index.publisher_signin.link_text.sign_up")))
-        expect(page).not_to have_link(I18n.t("home.index.publisher_signin.link_text.sign_in"), href: publishers_sign_in_path)
-        expect(page).not_to have_link(I18n.t("home.index.publisher_signin.link_text.sign_up"), href: page_path("dsi-account-request"))
+        expect(page).not_to have_content(I18n.t("home.index.publisher_section.title"))
       end
     end
   end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3359

## Changes in this PR:

The ticket wants the 'create a job listing' link to go the first step of the create a job listing process. This page requires a POST request as it creates a vacancy. This means we have to use a button in a form to create a post request, and style it like a link.

An alternative idea would be to create a get action that redirects to a POST request.

Open to further alternative ideas!

## Screenshots of UI changes:

### Signed in as a jobseeker

<img width="1214" alt="Screenshot 2021-11-02 at 12 04 38" src="https://user-images.githubusercontent.com/60350599/139858600-6eeeb8fd-ac65-4f93-9cc8-228ce752250e.png">

### Signed out of everything

<img width="1214" alt="Screenshot 2021-11-02 at 12 04 55" src="https://user-images.githubusercontent.com/60350599/139858692-a067cb08-70a5-436a-85fb-913146b1aae1.png">

### Signed in as a publisher

<img width="1214" alt="Screenshot 2021-11-02 at 12 05 21" src="https://user-images.githubusercontent.com/60350599/139858768-11e55cc6-27c5-4608-8620-be1edbe79c3b.png">


