### PR TITLE
Fix new features page loop bug

### DIFF
--- a/app/controllers/publishers/new_features_controller.rb
+++ b/app/controllers/publishers/new_features_controller.rb
@@ -4,6 +4,7 @@ class Publishers::NewFeaturesController < Publishers::BaseController
   def show
     @new_features_form = Publishers::NewFeaturesForm.new
     current_publisher.update(viewed_new_features_page_at: Time.current)
+    session[:visited_new_features_page] = true
   end
 
   def update

--- a/spec/system/publishers_are_shown_new_features_page_spec.rb
+++ b/spec/system/publishers_are_shown_new_features_page_spec.rb
@@ -7,22 +7,29 @@ RSpec.describe "Publishers are shown the new features page" do
   before do
     allow(PublisherPreference).to receive(:find_by).and_return(instance_double(PublisherPreference))
     login_publisher(publisher: publisher, organisation: organisation)
-    visit organisation_path
   end
 
-  it "redirects them to the new features page" do
-    expect(current_path).to eq(new_features_path)
+  context "when the publisher has not dismissed the new features page" do
+    before { visit organisation_path }
 
-    check I18n.t("new_features.label")
-    click_on I18n.t("buttons.continue_to_account")
+    it "redirects them to the new features page after logging in" do
+      expect(current_path).to eq(new_features_path)
+      expect(page.get_rack_session_key("visited_new_features_page")).to eq(true)
 
-    publisher.reload
-    expect(current_path).to eq(organisation_path)
-    expect(publisher).to be_dismissed_new_features_page_at
+      visit new_features_path
+      check I18n.t("helpers.label.publishers_new_features_form.dismiss_options.true")
+      click_on I18n.t("buttons.continue_to_account")
+
+      publisher.reload
+      expect(current_path).to eq(organisation_path)
+      expect(publisher).to be_dismissed_new_features_page_at
+    end
   end
 
   context "when logged in as a local authority" do
     let(:organisation) { create(:local_authority) }
+
+    before { visit organisation_path }
 
     it "does not redirect them to the new features page" do
       expect(current_path).to eq(organisation_path)
@@ -33,6 +40,8 @@ RSpec.describe "Publishers are shown the new features page" do
     let(:organisation) { create(:school) }
     let!(:vacancy) { create(:vacancy, publisher: publisher, organisations: [organisation], enable_job_applications: true) }
 
+    before { visit organisation_path }
+
     it "does not redirect them to the new features page" do
       expect(current_path).to eq(organisation_path)
     end
@@ -41,6 +50,8 @@ RSpec.describe "Publishers are shown the new features page" do
   context "when they have previously dismissed the new features page" do
     let(:organisation) { create(:school) }
     let(:publisher) { create(:publisher, dismissed_new_features_page_at: 2.days.ago) }
+
+    before { visit organisation_path }
 
     it "does not redirect them to the new features page" do
       expect(current_path).to eq(organisation_path)


### PR DESCRIPTION
Whilst working on another ticket, I noticed that when visiting the new features page after logging in, I got stuck in a loop:

https://user-images.githubusercontent.com/30624173/139918223-3e8e7518-869a-4af0-8194-931cc311ae6a.mov

Before redirecting to the new features page, we check session[:visited_new_features_page]. If it is nil then we redirect to the new features page. 

To prevent the loop, session[:visited_new_features_page] was set to true when the new features controller's show action was hit. It appears someone removed this at some point, causing this bug.
