### PR TITLE
[TEVA-3380] Remove pages from robots.txt that appear as duplicates

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -6,3 +6,4 @@ Disallow: /subscriptions/
 Disallow: /documents/
 Disallow: /attachments/
 Disallow: /teaching-jobs-in-*?location=*
+Disallow: /teaching-jobs-for-*?job_roles[]=*


### PR DESCRIPTION
All job role landing pages were showing as duplicates in SEO analysis, e.g.
https://teaching-vacancies.service.gov.uk/teaching-jobs-for-16-19
https://teaching-vacancies.service.gov.uk/teaching-jobs-for-16-19?job_roles[]=16-19

These pages are in fact the same as each other, so we'll tell crawlers not to index
the latter.

This is the same approach as for the location landing pages.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3380
