### PR TITLE
[TEVA-3414] Fix calculations in prometheus slow request alert

### DIFF
--- a/terraform/monitoring/config/alert.rules.yml
+++ b/terraform/monitoring/config/alert.rules.yml
@@ -33,7 +33,7 @@ groups:
 
   - alert: ProdSlowRequests
   # Condition for alerting
-    expr: histogram_quantile(0.9, sum(rate(response_time_bucket{app="teaching-vacancies-production", status_range="2xx"}[5m])) by (le)) > 2
+    expr: histogram_quantile(0.9, sum(rate(response_time_bucket{app="teaching-vacancies-production", status_range="2xx"}[5m])) by (le)) > 3
     # Annotation - additional informational labels to store more information
     annotations:
       summary: Identify slow running request above 95 percentile


### PR DESCRIPTION
## Jira ticket URL

- Just add the ticket number to the end:

https://dfedigital.atlassian.net/browse/TEVA-3414

The correct alert is setup to trigger if the last 5min 95 percentile is lower than 2 sececond. Howerver, the text in the alert says 3 seconds.

Hence - we need to either change the alert to > 3 or change the txt in the alert to 2 seconds

