### PR TITLE
[TEVA-3358] Remove expired job urls from Google index and sitemap

### DIFF
--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -16,7 +16,7 @@ class SitemapController < ApplicationController
   private
 
   def add_vacancies(map)
-    Vacancy.listed.applicable.find_each do |vacancy|
+    Vacancy.live.applicable.find_each do |vacancy|
       map.add job_path(vacancy), updated: vacancy.updated_at, expires: vacancy.expires_at, period: "hourly", priority: 0.7
     end
   end

--- a/app/jobs/remove_expired_vacancies_from_google_index_job.rb
+++ b/app/jobs/remove_expired_vacancies_from_google_index_job.rb
@@ -1,0 +1,11 @@
+class RemoveExpiredVacanciesFromGoogleIndexJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Rails.logger.info("Removing expired jobs from Google index")
+    Vacancy.expired.find_each do |vacancy|
+      RemoveGoogleIndexQueueJob.perform_now(Rails.application.routes.url_helpers.job_url(vacancy))
+    end
+    Rails.logger.info("Finished removing expired jobs from Google index")
+  end
+end

--- a/app/jobs/remove_vacancies_that_expired_yesterday_from_algolia_job.rb
+++ b/app/jobs/remove_vacancies_that_expired_yesterday_from_algolia_job.rb
@@ -1,4 +1,4 @@
-class RemoveVacanciesThatExpiredYesterday < ApplicationJob
+class RemoveVacanciesThatExpiredYesterdayFromAlgoliaJob < ApplicationJob
   queue_as :low
 
   def perform

--- a/app/jobs/remove_vacancies_that_expired_yesterday_from_google_index_job.rb
+++ b/app/jobs/remove_vacancies_that_expired_yesterday_from_google_index_job.rb
@@ -1,0 +1,10 @@
+class RemoveVacanciesThatExpiredYesterdayFromGoogleIndexJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Vacancy.expired_yesterday.find_each do |vacancy|
+      RemoveGoogleIndexQueueJob.perform_now(Rails.application.routes.url_helpers.job_url(vacancy))
+    end
+    Rails.logger.info("Finished removing jobs that expired on #{Date.yesterday} from Google index")
+  end
+end

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -51,7 +51,7 @@ class Vacancy < ApplicationRecord # rubocop:disable Metrics/ClassLength
   scope :applicable, (-> { where("expires_at >= ?", Time.current) })
   scope :awaiting_feedback, (-> { expired.where(listed_elsewhere: nil, hired_status: nil) })
   scope :expired, (-> { published.where("expires_at < ?", Time.current) })
-  scope :expired_yesterday, (-> { where("expires_at BETWEEN ? AND ?", Time.zone.yesterday.midnight, Date.current.midnight) })
+  scope :expired_yesterday, (-> { where("DATE(expires_at) = ?", 1.day.ago.to_date) })
   scope :expires_within_data_access_period, (-> { where("expires_at >= ?", Time.current - DATA_ACCESS_PERIOD_FOR_PUBLISHERS) })
   scope :in_organisation_ids, (->(ids) { joins(:organisation_vacancies).where(organisation_vacancies: { organisation_id: ids }).distinct })
   scope :listed, (-> { published.where("publish_on <= ?", Date.current) })

--- a/app/views/shared/_meta.html.slim
+++ b/app/views/shared/_meta.html.slim
@@ -1,1 +1,3 @@
 meta name="description" content=meta_description
+- if content_for?(:no_index)
+  = yield(:no_index)

--- a/app/views/shared/vacancy/_jobseeker_view.html.slim
+++ b/app/views/shared/vacancy/_jobseeker_view.html.slim
@@ -86,8 +86,8 @@
     = render(Jobseekers::OrganisationOverviews::SchoolsComponent.new(vacancy: @vacancy))
 
     - if @similar_jobs.present?
-      section.similar-jobs class="govuk-!-margin-bottom-5"
-        h3.govuk-heading-m = t("jobs.similar_jobs")
+      section#similar-jobs.similar-jobs class="govuk-!-margin-bottom-5"
+        h3.govuk-heading-m = t("jobs.similar_jobs.heading")
         - @similar_jobs.in_groups_of(2, false).each do |row|
           .govuk-grid-row
             = render Jobseekers::SimilarJobComponent.with_collection(row)

--- a/app/views/vacancies/_key_dates_sidebar.html.slim
+++ b/app/views/vacancies/_key_dates_sidebar.html.slim
@@ -1,6 +1,8 @@
 = render TimelineComponent.new do |timeline|
   - if @vacancy.expired?
-    - timeline.heading(title: t("jobs.listing_expired_on_html", date: format_date(@vacancy.expires_at, :date_only)))
+    - timeline.heading(title: t("jobs.listing_expired_on_html",
+                        date: format_date(@vacancy.expires_at, :date_only),
+                        similar_jobs_link: govuk_link_to(t("jobs.similar_jobs.anchor_link_text"), "#similar-jobs", { no_visited_state: true })))
   - else
     - timeline.heading(title: OrganisationVacancyPresenter.new(@vacancy).days_to_apply)
   - if @vacancy.starts_on.present?

--- a/app/views/vacancies/_show.html.slim
+++ b/app/views/vacancies/_show.html.slim
@@ -4,5 +4,9 @@
                                                         organisation: @vacancy.parent_organisation.name,
                                                         deadline: format_date(@vacancy.expires_at, :date_only_shorthand))
 
+- if @vacancy.expired?
+  - content_for :no_index do
+    meta name="robots" content="noindex"
+
 .vacancy
   = render "/shared/vacancy/jobseeker_view"

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -141,12 +141,14 @@ en:
           reminder: when similar jobs are listed
 
     contents: Contents
-    similar_jobs: Similar jobs nearby
+    similar_jobs:
+      anchor_link_text: see similar jobs
+      heading: Similar jobs nearby
     school_type: School type
     trust_type: Trust type
     expired_tag: expired
     listing_expired: This job post has expired.
-    listing_expired_on_html: "This job expired on <span class='govuk-!-font-weight-regular'>%{date}</span>"
+    listing_expired_on_html: This job expired on <span class='govuk-!-font-weight-regular'>%{date} – %{similar_jobs_link}</span>
 
     create_a_job_title: Create a job listing for %{organisation}
     create_a_job_title_no_org: Create a job listing

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -58,9 +58,14 @@ remove_stale_vacancies:
   class: 'RemoveStaleVacanciesJob'
   queue: low
 
-remove_vacancies_that_expired_yesterday:
+remove_vacancies_that_expired_yesterday_from_algolia:
   cron: '0 03 * * *'
-  class: 'RemoveVacanciesThatExpiredYesterday'
+  class: 'RemoveVacanciesThatExpiredYesterdayFromAlgoliaJob'
+  queue: low
+
+remove_vacancies_that_expired_yesterday_from_google_index:
+  cron: '0 04 * * *'
+  class: 'RemoveVacanciesThatExpiredYesterdayFromGoogleIndexJob'
   queue: low
 
 reset_sessions:

--- a/documentation/search.md
+++ b/documentation/search.md
@@ -61,7 +61,7 @@ There are two timed jobs that run in sidekiq cron:
 
 This runs every five minutes and add vacancies with matured `publish_on` times to the index.
 
-### `RemoveVacanciesThatExpiredYesterday`
+### `RemoveVacanciesThatExpiredYesterdayFromAlgolia`
 
 This runs at 03:00 every day and does exactly what the name says it does. Daily removal is not a problem because expired vacancies that have not yet been removed will be filtered out by the search client and do not show to jobseekers.
 

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -41,6 +41,13 @@ namespace :gias do
   end
 end
 
+namespace :google do
+  desc "Remove expired vacancies from the Google index"
+  task remove_expired_vacancies_google_index: :environment do
+    RemoveExpiredVacanciesFromGoogleIndexJob.perform_later
+  end
+end
+
 namespace :ons do
   desc "Import all ONS areas"
   task import_all: %i[import_counties import_cities import_regions create_composites]

--- a/spec/jobs/remove_vacancies_that_expired_yesterday_from_algolia_job_spec.rb
+++ b/spec/jobs/remove_vacancies_that_expired_yesterday_from_algolia_job_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe RemoveVacanciesThatExpiredYesterday do
+RSpec.describe RemoveVacanciesThatExpiredYesterdayFromAlgoliaJob do
   subject(:job) { described_class.perform_later }
 
   it "invokes Vacancy#remove_vacancies_that_expired_yesterday!" do

--- a/spec/jobs/remove_vacancies_that_expired_yesterday_from_google_index_job_spec.rb
+++ b/spec/jobs/remove_vacancies_that_expired_yesterday_from_google_index_job_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe RemoveVacanciesThatExpiredYesterdayFromGoogleIndexJob do
+  let(:urls_expired_yesterday) { Vacancy.expired_yesterday.map { |vacancy| Rails.application.routes.url_helpers.job_url(vacancy) } }
+  let(:urls_for_other_vacancies) do
+    Vacancy.where.not("DATE(expires_at) = ?", 1.day.ago.to_date).map { |vacancy| Rails.application.routes.url_helpers.job_url(vacancy) }
+  end
+
+  before do
+    create_list(:vacancy, 5, expires_at: 1.day.ago)
+    create_list(:vacancy, 1, expires_at: 2.days.ago)
+    create_list(:vacancy, 1, :published)
+  end
+
+  it "removes the url for each expired vacancy" do
+    urls_expired_yesterday.each { |url| expect(RemoveGoogleIndexQueueJob).to receive(:perform_now).with(url) }
+
+    perform_enqueued_jobs { described_class.perform_later }
+  end
+
+  it "only removes the urls of vacancies that expired yesterday" do
+    urls_for_other_vacancies.each { |url| expect(RemoveGoogleIndexQueueJob).to_not receive(:perform_now).with(url) }
+
+    perform_enqueued_jobs { described_class.perform_later }
+  end
+end

--- a/spec/sidekiq/sidekiq_spec.rb
+++ b/spec/sidekiq/sidekiq_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "Sidekiq configuration" do
       AlertEmail::Base
       MigrateVacancyDocumentsToActiveStorageJob
       PerformancePlatformTransactionsQueueJob
+      RemoveExpiredVacanciesFromGoogleIndexJob
       RemoveGoogleIndexQueueJob
       SeedDatabaseJob
       SendEntityImportedEventsToDataWarehouseJob

--- a/spec/system/application_seo_spec.rb
+++ b/spec/system/application_seo_spec.rb
@@ -6,4 +6,15 @@ RSpec.describe "Application meta tags" do
       expect(page.find('meta[name="description"]', visible: false)).to be_present
     end
   end
+
+  context "when viewing an expired vacancy" do
+    let(:organisation) { create(:school) }
+    let(:expired_vacancy) { create(:vacancy, :expired, organisations: [organisation]) }
+
+    scenario "the correct meta tag is present" do
+      visit job_path(expired_vacancy)
+
+      expect(page.find('meta[content="noindex"]', visible: false)).to be_present
+    end
+  end
 end

--- a/spec/system/application_sitemap_spec.rb
+++ b/spec/system/application_sitemap_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe "Application sitemap" do
   context "sitemap.xml" do
     scenario "generates a sitemap of the application" do
       published_jobs = (1..4).map { |i| create(:vacancy, :published, job_title: "Title#{i}") }
-      build_list(:vacancy, 2, :expired).each { |j| j.save(validate: false) }
+      expired_jobs = create_list(:vacancy, 2, :expired).each { |j| j.save(validate: false) }
 
       visit sitemap_path(format: :xml)
       document = Nokogiri::XML::Document.parse(body)
@@ -13,9 +13,13 @@ RSpec.describe "Application sitemap" do
       expect(nodes.search("loc[text()='#{root_url(protocol: 'https')}']").text)
         .to eq(root_url(protocol: "https"))
 
-      published_jobs.each do |job|
-        expect(nodes.search("loc:contains('#{job_path(job, protocol: 'https')}')").text)
-          .to eq(job_url(job, protocol: "https"))
+      published_jobs.each do |published_job|
+        expect(nodes.search("loc:contains('#{job_path(published_job, protocol: 'https')}')").text)
+          .to eq(job_url(published_job, protocol: "https"))
+      end
+
+      expired_jobs.each do |expired_job|
+        expect(nodes.search("loc:contains('#{job_path(expired_job, protocol: 'https')}')").text).to be_blank
       end
 
       ALL_IMPORTED_LOCATIONS.each do |location|


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3358

## Changes in this PR:

- Removed expired jobs from the sitemap by using the live scope instead of the listed scope in `add_vacancies`
- Created one-off job to remove all expired vacancies from the Google index
- Created scheduled job to remove all vacancies that expired yesterday from the Google index
- Added noindex meta tag to expired job pages
- Added anchor link to similar jobs nearby in the key dates sidebar for expired vacancies
- Renamed job and related spec for removing expired jobs from Algolia

