### PR TITLE
Always use the singular form of school_type for Organisations of type School

### DIFF
--- a/app/helpers/organisations_helper.rb
+++ b/app/helpers/organisations_helper.rb
@@ -48,7 +48,7 @@ module OrganisationsHelper
     return organisation.group_type if organisation.school_group?
 
     school_type_details = [
-      organisation.school_type.singularize,
+      organisation.school_type,
       organisation.religious_character,
       "ages #{organisation.minimum_age} to #{organisation.maximum_age}",
     ]

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -57,7 +57,7 @@ module Indexable
           local_authorities_within: organisations.map(&:local_authority_within).reject(&:blank?).uniq,
           religious_characters: organisations.schools.map(&:religious_character).reject(&:blank?).uniq,
           regions: organisations.schools.map(&:region).uniq,
-          school_types: organisations.schools.map { |org| org.school_type&.singularize }.uniq,
+          school_types: organisations.schools.map(&:school_type).uniq,
           towns: organisations.map(&:town).reject(&:blank?).uniq }
       end
 

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -35,6 +35,10 @@ class School < Organisation
     gias_data["ReligiousCharacter (name)"]
   end
 
+  def school_type
+    read_attribute(:school_type).singularize
+  end
+
   def self.available_readable_phases
     READABLE_PHASE_MAPPINGS.values.flatten.uniq
   end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -10,6 +10,14 @@ RSpec.describe School do
     end
   end
 
+  describe "#school_type" do
+    subject { build(:school, school_type: "Academies") }
+
+    it "singularizes any plural school type" do
+      expect(subject.school_type).to eq("Academy")
+    end
+  end
+
   describe "#religious_character" do
     let(:religious_character) { "Roman Catholic" }
     let(:gias_data) { { "ReligiousCharacter (name)" => religious_character } }

--- a/spec/services/gias/import_schools_and_local_authorities_spec.rb
+++ b/spec/services/gias/import_schools_and_local_authorities_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Gias::ImportSchoolsAndLocalAuthorities do
       expect(example_school.name).to eq("Sir John Cass's Foundation Primary School")
       expect(example_school.phase).to eq("primary")
       expect(example_school.region).to eq("London")
-      expect(example_school.school_type).to eq("LA maintained schools")
+      expect(example_school.school_type).to eq("LA maintained school")
       expect(example_school.url).to eq("http://www.sirjohncassprimary.org")
     end
 


### PR DESCRIPTION
Doing this at the model level so that we don't have to think about
it whenever we use a School's school_type.

No ticket, just based on Slack conv here: https://ukgovernmentdfe.slack.com/archives/CG9A8H1HP/p1636124821086900?thread_ts=1636124353.086400&cid=CG9A8H1HP

## Before

<img width="1263" alt="Screenshot 2021-11-05 at 15 42 05" src="https://user-images.githubusercontent.com/60350599/140538353-0bf6997f-9f1c-4657-98df-2717c3a9b677.png">

## After

<img width="1263" alt="Screenshot 2021-11-05 at 15 43 15" src="https://user-images.githubusercontent.com/60350599/140538372-4728deaf-2775-4797-8712-3869e8bd9a7a.png">
