### PR TITLE
Use original location search criterion for `PgSearch`

### DIFF
--- a/app/services/search/vacancy_search.rb
+++ b/app/services/search/vacancy_search.rb
@@ -67,7 +67,7 @@ class Search::VacancySearch
                              Search::Strategies::PgSearch.new(
                                keyword,
                                filters: search_criteria,
-                               location: location_search.location_filter[:location],
+                               location: search_criteria[:location],
                                radius: location_search.radius,
                                page: page,
                                per_page: per_page,


### PR DESCRIPTION
This was returning `nil`, leading to results for all locations being
returned regardless of the user's location query