### PR TITLE
Update sidekiq spec to check for misspelt cron key

### DIFF
--- a/spec/sidekiq/sidekiq_spec.rb
+++ b/spec/sidekiq/sidekiq_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Sidekiq configuration" do
     ApplicationJob.descendants.map(&:name)
   end
 
-  let(:scheduled_jobs) { YAML.load_file("./config/schedule.yml").map { |_, v| v["class"] } }
+  let(:scheduled_jobs) { YAML.load_file("./config/schedule.yml").select { |_, v| v["cron"].present? }.map { |_, v| v["class"] } }
   let(:unscheduled_jobs) do
     %w[
       AlertEmail::Base


### PR DESCRIPTION
- David noticed a spelling mistake in schedule.yml ("crom" instead of "cron") and thought it'd be helpful to check for such spelling mistakes in the spec. 