### PR TITLE
[TEVA-3299] Include line breaks in personal statement when displaying it

### DIFF
--- a/app/views/shared/job_application/_show.html.slim
+++ b/app/views/shared/job_application/_show.html.slim
@@ -142,7 +142,7 @@
   - review.heading title: t(".personal_statement.heading")
 
   - review.body do
-    p.govuk-body.review-component__body--border class="govuk-!-padding-bottom-3" = job_application.personal_statement
+    p.govuk-body.review-component__body--border class="govuk-!-padding-bottom-3" = simple_format(job_application.personal_statement)
 
 = render ReviewComponent.new id: "references_summary" do |review|
   - review.heading title: t(".references.heading")


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3299

## Changes in this PR:

Include line breaks in personal statement when displaying it. Currently this file is the only place where we display the personal statement; if we did it across multiple files I might make a job application presenter.

## Screenshots of UI changes:

### Before

<img width="832" alt="Screenshot 2021-11-09 at 12 51 26" src="https://user-images.githubusercontent.com/60350599/140927793-6d6c07b6-7e48-455b-83dc-cd350fb50d06.png">

### After

<img width="831" alt="Screenshot 2021-11-09 at 12 51 53" src="https://user-images.githubusercontent.com/60350599/140927750-a3c39b9f-b2ad-4a53-9c76-62401439075a.png">

