### PR TITLE
[TEVA-3439] Pin util-linux package version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PROD_PACKAGES="libxml2=2.9.12-r1 libxslt=1.1.34-r1 libpq=13.4-r0 tzdata=2021e-r0 shared-mime-info=2.1-r0"
+ARG PROD_PACKAGES="libxml2=2.9.12-r1 libxslt=1.1.34-r1 libpq=13.4-r0 tzdata=2021e-r0 shared-mime-info=2.1-r0 util-linux=2.37.2-r0"
 
 FROM ruby:3.0.2-alpine3.14 AS builder
 


### PR DESCRIPTION
## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-3439

## Changes in this PR:
Use updated version as the previous one has a vulnerability which was detected by Snyk

Successful scan:
```
 % docker scan tv

Testing tv...

Organization:      saliceti
Package manager:   apk
Project name:      docker-image|tv
Docker image:      tv
Platform:          linux/amd64
Base image:        ruby:3.0.2-alpine3.14
Licenses:          enabled

✓ Tested 69 dependencies for known issues, no vulnerable paths found.

According to our scan, you are currently using the most secure version of the selected base image
```

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
