### PR TITLE
[TEVA-3418] correct padding of filters side bar on MAT publisher dashboard

### DIFF
--- a/app/components/publishers/vacancies_component/vacancies_component.html.slim
+++ b/app/components/publishers/vacancies_component/vacancies_component.html.slim
@@ -28,7 +28,8 @@
                                                                         small: true }],
                                                               options: { remove_buttons: true,
                                                                         mobile_variant: true,
-                                                                        publisher_preference: (@publisher_preference if @organisation.local_authority?) }))
+                                                                        publisher_preference: (@publisher_preference if @organisation.local_authority?) },
+                                          classes: "govuk-!-padding-left-3 govuk-!-padding-right-3 govuk-!-padding-top-1"))
 
             = f.hidden_field :jobs_type, value: @selected_type
 


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-3418

after

![Screenshot 2021-11-09 at 17 38 49](https://user-images.githubusercontent.com/1792451/140975983-7c76c548-7729-4f1d-a902-eb8ead07f648.png)

