### PR TITLE
Update robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -5,5 +5,5 @@ Disallow: /check
 Disallow: /subscriptions/
 Disallow: /documents/
 Disallow: /attachments/
-Disallow: /teaching-jobs-in-*?location=*
-Disallow: /teaching-jobs-for-*?job_roles[]=*
+Disallow: /teaching-jobs-in-*?location*
+Disallow: /teaching-jobs-for-*?job_roles*


### PR DESCRIPTION
The robots.txt failed to stop a crawler from crawling this url:
https://teaching-vacancies.service.gov.uk/ect-suitable-jobs?job_roles%5B%5D=ect_suitable

Make the match pattern less specific.

Building on https://github.com/DFE-Digital/teaching-vacancies/pull/4237

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3380

