### PR TITLE
Fix missing translation on reference form

### DIFF
--- a/app/validators/email_address_validator.rb
+++ b/app/validators/email_address_validator.rb
@@ -52,10 +52,10 @@ class EmailAddressValidator < ActiveModel::EachValidator
   private
 
   def blank_email_message
-    I18n.t("activerecord.errors.models.general_feedback.attributes.email.blank")
+    I18n.t("activerecord.errors.models.jobseeker.attributes.email.blank")
   end
 
   def invalid_error_message
-    I18n.t("activerecord.errors.models.general_feedback.attributes.email.invalid")
+    I18n.t("activerecord.errors.models.jobseeker.attributes.email.invalid")
   end
 end

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -32,13 +32,11 @@ en:
   subscription_errors: &subscription_errors
     email:
       blank: Enter your email address
-      invalid: Enter an email address in the correct format, like name@example.com
     frequency:
       blank: Select when you want to receive job alert emails
   unsubscribe_feedback_errors: &unsubscribe_feedback_errors
     email:
       blank: Enter your email address
-      invalid: Enter an email address in the correct format, like name@example.com
     other_unsubscribe_reason_comment:
       blank: Tell us why you want to unsubscribe
     unsubscribe_reason:
@@ -52,7 +50,6 @@ en:
       too_long: Feedback must not be more than 1,200 characters
     email:
       blank: Enter your email address
-      invalid: Enter an email address in the correct format, like name@example.com
     rating:
       inclusion: Select how satisfied or dissatisfied you are
     report_a_problem:
@@ -64,7 +61,6 @@ en:
       inclusion: Please indicate if you'd like to participate in user research
     email:
       blank: Enter your email address
-      invalid: Enter an email address in the correct format, like name@example.com
     comment:
       blank: Enter your feedback
       too_long: Feedback must not be more than 1,200 characters
@@ -92,7 +88,6 @@ en:
   jobseekers_job_application_feedback_form: &jobseekers_job_application_feedback_form_errors
     email:
       blank: Enter your email address
-      invalid: Enter an email address in the correct format, like name@example.com
     rating:
       inclusion: Choose how satisfied you are with the application process
     comment:
@@ -102,7 +97,6 @@ en:
   publisher_job_listing_feedback_form: &publisher_job_listing_feedback_form_errors
     email:
       blank: Enter your email address
-      invalid: Enter an email address in the correct format, like name@example.com
     rating:
       inclusion: Choose how satisfied you are with the job listing process
     report_a_problem:
@@ -180,7 +174,6 @@ en:
       inclusion: Select how you would like candidates to apply
     contact_email:
       blank: Enter a contact email
-      invalid: Enter an email address in the correct format, like name@example.com
     contact_number:
       invalid: Contact number must be a valid phone number
     how_to_apply:
@@ -341,7 +334,6 @@ en:
               blank: Enter your country
             email_address:
               blank: Enter your email address
-              invalid: Enter an email address in the correct format, like name@example.com
             first_name:
               blank: Enter your first name
             last_name:
@@ -464,7 +456,6 @@ en:
           attributes:
             email:
               blank: Enter your referee's email address
-              invalid: Enter an email address in the correct format, like name@example.com
             job_title:
               blank: Enter your referee's job title
             name:
@@ -481,7 +472,6 @@ en:
           attributes:
             email_address:
               blank: Enter your email address
-              invalid: Enter an email address in the correct format, like name@example.com
             is_for_whole_site:
               inclusion: Choose whether this issue is for the whole site or a specific page
             issue:

--- a/spec/validators/email_address_validator_spec.rb
+++ b/spec/validators/email_address_validator_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe EmailAddressValidator do
     expect(Jobseekers::SignInForm.new(email: "test@example", password: "password")).not_to be_valid
   end
 
+  it "can supply an error message translation to a form" do
+    form = Jobseekers::SubscriptionForm.new(email: "test")
+    form.valid?
+    expect(form.errors.messages[:email].first).to eq("Enter an email address in the correct format, like name@example.com")
+  end
+
   context "with a valid email address" do
     let(:email_address) { "test@example.com" }
 


### PR DESCRIPTION
For some reason the EmailAddressValidator couldn't find the translation so I have pointed it to a different one. I have also removed redundant error message translations where we are using this one from the EmailAddressValidator.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3444

## Screenshots of UI changes:

![Screenshot 2021-11-11 at 10 52 00](https://user-images.githubusercontent.com/60350599/141301609-f6dafb91-6218-4381-8f5f-3c5e991e1c91.png)

![Screenshot 2021-11-11 at 11 04 05](https://user-images.githubusercontent.com/60350599/141301617-3e84d77c-53cd-48c2-9077-aea4c7fb7613.png)
