### PR TITLE
[TEVA-3467] Track subscription origin better

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -4,6 +4,7 @@ class SubscriptionsController < ApplicationController
   def new
     @point_coordinates = params[:coordinates_present] == "true"
     @ect_job_alert = params[:ect_job_alert]
+    session[:subscription_autopopulated] = params[:search_criteria].present?
     @form = Jobseekers::SubscriptionForm.new(params[:search_criteria].present? ? search_criteria_params : email)
   end
 
@@ -89,12 +90,13 @@ class SubscriptionsController < ApplicationController
   def trigger_subscription_event(type, subscription)
     request_event.trigger(
       type,
-      subscription_identifier: StringAnonymiser.new(subscription.id),
+      autopopulated: session.delete(:subscription_autopopulated),
       email_identifier: StringAnonymiser.new(subscription.email),
-      recaptcha_score: subscription.recaptcha_score,
       frequency: subscription.frequency,
-      search_criteria: subscription.search_criteria,
       origin: session.delete(:subscription_origin),
+      recaptcha_score: subscription.recaptcha_score,
+      search_criteria: subscription.search_criteria,
+      subscription_identifier: StringAnonymiser.new(subscription.id),
     )
   end
 

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -9,11 +9,11 @@
 
   - if jobseeker_signed_in?
     = header.navigation_item text: t("nav.find_job"), href: root_path, active: find_jobs_active?
-    = header.navigation_item text: t("nav.create_a_job_alert"), href: new_subscription_path
+    = header.navigation_item text: t("nav.create_a_job_alert"), href: new_subscription_path(origin: request.original_fullpath)
     = header.navigation_item text: t("footer.your_account"), href: jobseeker_root_path, active: your_account_active?
     = header.navigation_item text: t("nav.sign_out"), href: destroy_jobseeker_session_path, options: { method: :delete }, classes: "navigation-item--right"
 
   - if !jobseeker_signed_in? && !publisher_signed_in?
     = header.navigation_item text: t("nav.find_job"), href: root_path, active: find_jobs_active?
-    = header.navigation_item text: t("nav.create_a_job_alert"), href: new_subscription_path
+    = header.navigation_item text: t("nav.create_a_job_alert"), href: new_subscription_path(origin: request.original_fullpath)
     = header.navigation_item text: t("buttons.sign_in"), href: page_path("sign-in"), classes: "navigation-item--right"

--- a/spec/requests/subscriptions_spec.rb
+++ b/spec/requests/subscriptions_spec.rb
@@ -20,6 +20,22 @@ RSpec.describe "Subscriptions" do
       end
     end
 
+    context "with search criteria pre-populated" do
+      it "sets subscription_autopopulated in the session so we can track it with subscription events" do
+        get new_subscription_path(origin: "/", search_criteria: { key: "value" })
+
+        expect(session[:subscription_autopopulated]).to eq(true)
+      end
+    end
+
+    context "with search criteria not pre-populated" do
+      it "sets subscription_autopopulated in the session so we can track it with subscription events" do
+        get new_subscription_path(origin: "/")
+
+        expect(session[:subscription_autopopulated]).to eq(false)
+      end
+    end
+
     context "when hit via the nqt job alerts url" do
       before { get "/sign-up-for-NQT-job-alerts" }
 
@@ -87,6 +103,7 @@ RSpec.describe "Subscriptions" do
 
     it "triggers a `job_alert_subscription_created` event" do
       expect { subject }.to have_triggered_event(:job_alert_subscription_created).and_data(
+        autopopulated: "false",
         email_identifier: anonymised_form_of("foo@example.net"),
         frequency: "daily",
         subscription_identifier: anything,
@@ -136,6 +153,7 @@ RSpec.describe "Subscriptions" do
 
     it "triggers a `job_alert_subscription_updated` event" do
       expect { subject }.to have_triggered_event(:job_alert_subscription_updated).and_data(
+        autopopulated: nil,
         email_identifier: anonymised_form_of("jimi@hendrix.com"),
         frequency: "weekly",
         subscription_identifier: anonymised_form_of(subscription.id),
@@ -165,6 +183,7 @@ RSpec.describe "Subscriptions" do
 
     it "triggers a `job_alert_subscription_unsubscribed` event" do
       expect { subject }.to have_triggered_event(:job_alert_subscription_unsubscribed).and_data(
+        autopopulated: nil,
         email_identifier: anonymised_form_of("bob@dylan.com"),
         frequency: "daily",
         subscription_identifier: anonymised_form_of(subscription.id),


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3467

## Changes in this PR:

- Add missing origin param to header links

- Track whether form is autopopulated in job_alert_subscription_created events

    This is to make Performance Analysis' life easier, by simplying the logic in PA that
    works out whether we expect the form to be autopopulated, into a progammatic check
    whether the form is in fact autopopulated, which is streamed as part of the event data
    for the job_alert_subscription_created event.
