### PR TITLE
Update job to remove jobs from google index

### DIFF
--- a/app/jobs/remove_expired_vacancies_from_google_index_job.rb
+++ b/app/jobs/remove_expired_vacancies_from_google_index_job.rb
@@ -3,8 +3,9 @@ class RemoveExpiredVacanciesFromGoogleIndexJob < ApplicationJob
 
   def perform
     Rails.logger.info("Removing expired jobs from Google index")
-    Vacancy.expired.find_each do |vacancy|
-      RemoveGoogleIndexQueueJob.perform_later(Rails.application.routes.url_helpers.job_url(vacancy))
+    Vacancy.expired.where(google_index_removed: false).limit(500).each do |vacancy|
+      RemoveGoogleIndexQueueJob.perform_now(Rails.application.routes.url_helpers.job_url(vacancy))
+      vacancy.update_column(:google_index_removed, true)
     end
     Rails.logger.info("Finished removing expired jobs from Google index")
   end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -58,6 +58,11 @@ remove_stale_vacancies:
   class: 'RemoveStaleVacanciesJob'
   queue: low
 
+remove_expired_vacancies_from_google_index:
+  cron: '0 07 * * *'
+  class: 'RemoveExpiredVacanciesFromGoogleIndexJob'
+  queue: low
+
 remove_vacancies_that_expired_yesterday_from_algolia:
   cron: '0 03 * * *'
   class: 'RemoveVacanciesThatExpiredYesterdayFromAlgoliaJob'

--- a/db/migrate/20211115110318_add_google_index_removed_to_vacancies.rb
+++ b/db/migrate/20211115110318_add_google_index_removed_to_vacancies.rb
@@ -1,0 +1,5 @@
+class AddGoogleIndexRemovedToVacancies < ActiveRecord::Migration[6.1]
+  def change
+    add_column :vacancies, :google_index_removed, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_26_151619) do
+ActiveRecord::Schema.define(version: 2021_11_15_110318) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -469,6 +469,7 @@ ActiveRecord::Schema.define(version: 2021_10_26_151619) do
     t.geography "geolocation", limit: {:srid=>4326, :type=>"geometry", :geographic=>true}
     t.string "readable_phases", default: [], array: true
     t.tsvector "searchable_content"
+    t.boolean "google_index_removed", default: false
     t.index ["expires_at"], name: "index_vacancies_on_expires_at"
     t.index ["geolocation"], name: "index_vacancies_on_geolocation", using: :gist
     t.index ["initially_indexed"], name: "index_vacancies_on_initially_indexed"

--- a/spec/sidekiq/sidekiq_spec.rb
+++ b/spec/sidekiq/sidekiq_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe "Sidekiq configuration" do
       AlertEmail::Base
       MigrateVacancyDocumentsToActiveStorageJob
       PerformancePlatformTransactionsQueueJob
-      RemoveExpiredVacanciesFromGoogleIndexJob
       RemoveGoogleIndexQueueJob
       SeedDatabaseJob
       SendEntityImportedEventsToDataWarehouseJob


### PR DESCRIPTION
## Changes 

- We now batch the requests sent to the Indexing API to batches of 500. This is because we were hitting our daily limit of 1000 requests per day. 

- We set a flag on the vacancies that have been removed so that we only send one request per job.
