### PR TITLE
[TEVA-3469] Update Alpine packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-ARG PROD_PACKAGES="libxml2=2.9.12-r1 libxslt=1.1.34-r1 libpq=13.4-r0 tzdata=2021e-r0 shared-mime-info=2.1-r0 util-linux=2.37.2-r0 busybox=1.33.1-r6"
+ARG PROD_PACKAGES="libxml2=2.9.12-r1 libxslt=1.1.34-r1 libpq=13.5-r0 tzdata=2021e-r0 shared-mime-info=2.1-r0 util-linux=2.37.2-r0 busybox=1.33.1-r6"
 
 FROM ruby:3.0.2-alpine3.14 AS builder
 
 WORKDIR /app
 
 ARG PROD_PACKAGES
-ENV DEV_PACKAGES="gcc=10.3.1_git20210424-r2 libc-dev=0.7.2-r3 make=4.3-r0 yarn=1.22.10-r0 postgresql-dev=13.4-r0 build-base=0.5-r2 libxml2-dev=2.9.12-r1 libxslt-dev=1.1.34-r1 git"
+ENV DEV_PACKAGES="gcc=10.3.1_git20210424-r2 libc-dev=0.7.2-r3 make=4.3-r0 yarn=1.22.10-r0 postgresql-dev=13.5-r0 build-base=0.5-r2 libxml2-dev=2.9.12-r1 libxslt-dev=1.1.34-r1 git"
 RUN apk add --no-cache $PROD_PACKAGES $DEV_PACKAGES
 RUN echo "Europe/London" > /etc/timezone && \
         cp /usr/share/zoneinfo/Europe/London /etc/localtime


### PR DESCRIPTION
Since we pin to specific alpine package verisons in our docker file,
the version we pin to has been removed from alpine's branch 3.14, we needed to remedy accordingly.

libpq on alpine3.14 changed from ver 13.4.-ro to 13.5-r0
postgresql-dev on alpine3.14 changed from ver 13.4.-ro to 13.5-r0

## Jira ticket URL

- Just add the ticket number to the end:

https://dfedigital.atlassian.net/browse/TEVA-3469
