### PR TITLE
Stop sending origin param for job alert subscription events

### DIFF
--- a/app/components/jobseekers/search_results/job_alerts_link_component.rb
+++ b/app/components/jobseekers/search_results/job_alerts_link_component.rb
@@ -1,8 +1,7 @@
 class Jobseekers::SearchResults::JobAlertsLinkComponent < ViewComponent::Base
-  def initialize(vacancies_search:, count:, origin:)
+  def initialize(vacancies_search:, count:)
     @vacancies_search = vacancies_search
     @count = count
-    @origin = origin
   end
 
   def render?

--- a/app/components/jobseekers/search_results/job_alerts_link_component/job_alerts_link_component.html.slim
+++ b/app/components/jobseekers/search_results/job_alerts_link_component/job_alerts_link_component.html.slim
@@ -2,4 +2,4 @@
   .job-alert-cta__fade
   .job-alert-cta__content class="govuk-heading-s govuk-!-font-weight-regular govuk-!-margin-0" id="job-alert-cta"
     .icon.icon--left.icon--alert-white
-      = t("subscriptions.link.help_text_html", link: govuk_link_to(t("subscriptions.link.text"), new_subscription_path(search_criteria: @vacancies_search.active_criteria, origin: @origin, coordinates_present: @vacancies_search.point_coordinates.present?), id: "job-alert-link-sticky-gtm"))
+      = t("subscriptions.link.help_text_html", link: govuk_link_to(t("subscriptions.link.text"), new_subscription_path(search_criteria: @vacancies_search.active_criteria, coordinates_present: @vacancies_search.point_coordinates.present?), id: "job-alert-link-sticky-gtm"))

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,4 +1,6 @@
 class SubscriptionsController < ApplicationController
+  before_action :trigger_create_job_alert_clicked_event, only: :new, if: -> { vacancy_id.present? }
+
   def new
     @point_coordinates = params[:coordinates_present] == "true"
     @ect_job_alert = params[:ect_job_alert]
@@ -74,6 +76,10 @@ class SubscriptionsController < ApplicationController
 
   private
 
+  def trigger_create_job_alert_clicked_event
+    request_event.trigger(:vacancy_create_job_alert_clicked, vacancy_id: StringAnonymiser.new(vacancy_id))
+  end
+
   def trigger_subscription_event(type, subscription)
     request_event.trigger(
       type,
@@ -102,5 +108,9 @@ class SubscriptionsController < ApplicationController
 
   def token
     params.require(:id)
+  end
+
+  def vacancy_id
+    params.permit(:vacancy_id)[:vacancy_id]
   end
 end

--- a/app/views/jobseekers/subscriptions/index.html.slim
+++ b/app/views/jobseekers/subscriptions/index.html.slim
@@ -25,7 +25,7 @@
           = f.govuk_submit t("jobs.sort_by.submit")
 
       .govuk-grid-column-one-third.create-alert__button
-        = govuk_button_link_to t(".button_create"), new_subscription_path(origin: jobseekers_subscriptions_path)
+        = govuk_button_link_to t(".button_create"), new_subscription_path
 
   .govuk-grid-row
     .govuk-grid-column-full
@@ -45,7 +45,7 @@
 
         - else
           = render EmptySectionComponent.new title: t(".zero_subscriptions_title") do
-            = t(".zero_subscriptions_body_html", link_to: govuk_link_to(t(".link_create"), new_subscription_path(origin: jobseekers_subscriptions_path)))
+            = t(".zero_subscriptions_body_html", link_to: govuk_link_to(t(".link_create"), new_subscription_path))
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -9,11 +9,11 @@
 
   - if jobseeker_signed_in?
     = header.navigation_item text: t("nav.find_job"), href: root_path, active: find_jobs_active?
-    = header.navigation_item text: t("nav.create_a_job_alert"), href: new_subscription_path(origin: request.original_fullpath)
+    = header.navigation_item text: t("nav.create_a_job_alert"), href: new_subscription_path
     = header.navigation_item text: t("footer.your_account"), href: jobseeker_root_path, active: your_account_active?
     = header.navigation_item text: t("nav.sign_out"), href: destroy_jobseeker_session_path, options: { method: :delete }, classes: "navigation-item--right"
 
   - if !jobseeker_signed_in? && !publisher_signed_in?
     = header.navigation_item text: t("nav.find_job"), href: root_path, active: find_jobs_active?
-    = header.navigation_item text: t("nav.create_a_job_alert"), href: new_subscription_path(origin: request.original_fullpath)
+    = header.navigation_item text: t("nav.create_a_job_alert"), href: new_subscription_path
     = header.navigation_item text: t("buttons.sign_in"), href: page_path("sign-in"), classes: "navigation-item--right"

--- a/app/views/shared/vacancy/_jobseeker_view.html.slim
+++ b/app/views/shared/vacancy/_jobseeker_view.html.slim
@@ -43,7 +43,7 @@
         = render BannerButtonComponent.new text: t("jobs.alert.similar.terse"),
           href: new_subscription_path,
           icon: "alert-blue",
-          params: { search_criteria: @invented_job_alert_search_criteria }
+          params: { search_criteria: @invented_job_alert_search_criteria, vacancy_id: @vacancy.id }
 
       - unless defined?(job_application) && job_application.present?
         .govuk-grid-column-one-third
@@ -93,7 +93,7 @@
 
     section
       p.icon.icon--left.icon--alert-blue
-        = govuk_link_to(t("jobs.alert.similar.verbose.link_text"), new_subscription_path(search_criteria: @invented_job_alert_search_criteria), id: "job-alert-link-from-bottom-of-job-listing-gtm")
+        = govuk_link_to(t("jobs.alert.similar.verbose.link_text"), new_subscription_path(search_criteria: @invented_job_alert_search_criteria, vacancy_id: @vacancy.id), id: "job-alert-link-from-bottom-of-job-listing-gtm")
         =< t("jobs.alert.similar.verbose.reminder")
 
     = render "shared/vacancy/copy_vacancy_link"

--- a/app/views/shared/vacancy/_jobseeker_view.html.slim
+++ b/app/views/shared/vacancy/_jobseeker_view.html.slim
@@ -40,11 +40,10 @@
               icon: "apply"
 
       .govuk-grid-column-one-third
-        / The "origin" param is used both for the back button on the subsequent page and for performance analysis.
         = render BannerButtonComponent.new text: t("jobs.alert.similar.terse"),
           href: new_subscription_path,
           icon: "alert-blue",
-          params: { search_criteria: @invented_job_alert_search_criteria, origin: request.original_fullpath }
+          params: { search_criteria: @invented_job_alert_search_criteria }
 
       - unless defined?(job_application) && job_application.present?
         .govuk-grid-column-one-third
@@ -94,7 +93,7 @@
 
     section
       p.icon.icon--left.icon--alert-blue
-        = govuk_link_to(t("jobs.alert.similar.verbose.link_text"), new_subscription_path(search_criteria: @invented_job_alert_search_criteria, origin: request.original_fullpath), id: "job-alert-link-from-bottom-of-job-listing-gtm")
+        = govuk_link_to(t("jobs.alert.similar.verbose.link_text"), new_subscription_path(search_criteria: @invented_job_alert_search_criteria), id: "job-alert-link-from-bottom-of-job-listing-gtm")
         =< t("jobs.alert.similar.verbose.reminder")
 
     = render "shared/vacancy/copy_vacancy_link"

--- a/app/views/vacancies/index.html.slim
+++ b/app/views/vacancies/index.html.slim
@@ -49,7 +49,7 @@
                                                         search_link: govuk_link_to(t(".wider_search_suggestions.radius_distance", radius: wider_radius.first), jobs_path(@vacancies_search.search_criteria.merge(radius: wider_radius.first)), class: "wider-radius-gtm"),
                                                         count: t(".wider_search_suggestions.results", count: wider_radius.last))
           span.govuk-heading-m
-            = t("subscriptions.link.no_search_results.text_html", link_to: govuk_link_to(t("subscriptions.link.no_search_results.link"), new_subscription_path(search_criteria: @vacancies_search.active_criteria, origin: request.original_fullpath), id: "job-alert-link-no-search-results-gtm"))
+            = t("subscriptions.link.no_search_results.text_html", link_to: govuk_link_to(t("subscriptions.link.no_search_results.link"), new_subscription_path(search_criteria: @vacancies_search.active_criteria), id: "job-alert-link-no-search-results-gtm"))
           p class="govuk-!-margin-1"
             = t("subscriptions.benefits.title")
             ul.govuk-list.govuk-list--bullet
@@ -66,4 +66,4 @@
           = paginate @vacancies_search.vacancies
         span.govuk-body#vacancies-stats-bottom
 
-      = render(Jobseekers::SearchResults::JobAlertsLinkComponent.new(vacancies_search: @vacancies_search, count: @vacancies.count, origin: request.original_fullpath))
+      = render(Jobseekers::SearchResults::JobAlertsLinkComponent.new(vacancies_search: @vacancies_search, count: @vacancies.count))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -134,7 +134,7 @@ Rails.application.routes.draw do
 
   get "sign-up-for-NQT-job-alerts", to: redirect("/sign-up-for-ECT-job-alerts")
 
-  get "sign-up-for-ECT-job-alerts", to: "subscriptions#new", as: "ect_job_alerts", defaults: { ect_job_alert: true, origin: "/sign-up-for-ECT-job-alerts", search_criteria: { job_roles: ["ect_suitable"] } }
+  get "sign-up-for-ECT-job-alerts", to: "subscriptions#new", as: "ect_job_alerts", defaults: { ect_job_alert: true, search_criteria: { job_roles: ["ect_suitable"] } }
 
   namespace :api do
     scope "v:api_version", api_version: /1/ do

--- a/spec/components/jobseekers/search_results/job_alerts_link_component_spec.rb
+++ b/spec/components/jobseekers/search_results/job_alerts_link_component_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Jobseekers::SearchResults::JobAlertsLinkComponent, type: :component do
-  subject { described_class.new(vacancies_search: vacancies_search, count: 1, origin: "/foo/bar") }
+  subject { described_class.new(vacancies_search: vacancies_search, count: 1) }
 
   let(:vacancies_search) { instance_double(Search::VacancySearch) }
   let(:active_hash) { { keyword: "maths" } }
@@ -20,7 +20,7 @@ RSpec.describe Jobseekers::SearchResults::JobAlertsLinkComponent, type: :compone
     it "renders the job alerts link" do
       expect(inline_component.css(
         "a#job-alert-link-sticky-gtm[href="\
-        "'#{Rails.application.routes.url_helpers.new_subscription_path(search_criteria: active_hash, origin: '/foo/bar', coordinates_present: true)}']",
+        "'#{Rails.application.routes.url_helpers.new_subscription_path(search_criteria: active_hash, coordinates_present: true)}']",
       ).to_html).to include(I18n.t("subscriptions.link.text"))
     end
   end

--- a/spec/system/jobseekers_can_create_a_job_alert_from_a_listing_spec.rb
+++ b/spec/system/jobseekers_can_create_a_job_alert_from_a_listing_spec.rb
@@ -21,7 +21,10 @@ RSpec.describe "Jobseekers can create a job alert from a listing", recaptcha: tr
   end
 
   scenario "can click on the first link to create a job alert using data from the vacancy" do
-    click_on I18n.t("jobs.alert.similar.terse")
+    expect { click_on I18n.t("jobs.alert.similar.terse") }
+      .to have_triggered_event(:vacancy_create_job_alert_clicked)
+      .and_data(vacancy_id: anonymised_form_of(vacancy.id))
+
     expect(page).to have_content(I18n.t("subscriptions.new.title"))
     and_the_search_criteria_are_populated
     click_on I18n.t("buttons.subscribe")
@@ -36,7 +39,9 @@ RSpec.describe "Jobseekers can create a job alert from a listing", recaptcha: tr
   end
 
   scenario "can click on the second link to create a job alert using data from the vacancy" do
-    click_on I18n.t("jobs.alert.similar.verbose.link_text")
+    expect { click_on I18n.t("jobs.alert.similar.verbose.link_text") }
+      .to have_triggered_event(:vacancy_create_job_alert_clicked)
+      .and_data(vacancy_id: anonymised_form_of(vacancy.id))
     expect(page).to have_content(I18n.t("subscriptions.new.title"))
     and_the_search_criteria_are_populated
   end


### PR DESCRIPTION
Performance Analysis will now rely solely on the new `autopopulated` parameter for these events, until such time as we deem it necessary to track the origin (this is unlikely as page_view events contain the request referer).

## Slack conversation

https://ukgovernmentdfe.slack.com/archives/CG9A8H1HP/p1637078984243600?thread_ts=1636970213.215900&cid=CG9A8H1HP

## Next

- [ ] Let Steven know when the PR is merged.