### PR TITLE
Remove unnecessary method

### DIFF
--- a/app/controllers/publishers/sessions_controller.rb
+++ b/app/controllers/publishers/sessions_controller.rb
@@ -35,10 +35,6 @@ class Publishers::SessionsController < Devise::SessionsController
     url.to_s
   end
 
-  def after_sign_in_path_for(_resource)
-    organisation_path
-  end
-
   def redirect_to_authentication_fallback
     return unless AuthenticationFallback.enabled?
 


### PR DESCRIPTION
The Devise method we overwrote with after_sign_in_for(resource) already points to publisher_root_path, which we have already defined in routes.rb.
