### PR TITLE
[TEVA-3441] convert autocomplete to stimulus component

### DIFF
--- a/app/frontend/src/application.js
+++ b/app/frontend/src/application.js
@@ -2,6 +2,7 @@ import { Application } from '@hotwired/stimulus';
 
 import PanelController from '../../components/panel_component/panel';
 import UtilsController from './components/utils';
+import AutocompleteController from './components/autocomplete/autocomplete';
 
 const application = Application.start();
 
@@ -11,3 +12,4 @@ window.Stimulus = application;
 
 application.register('panel', PanelController);
 application.register('utils', UtilsController);
+application.register('autocomplete', AutocompleteController);

--- a/app/frontend/src/application/init.js
+++ b/app/frontend/src/application/init.js
@@ -1,12 +1,6 @@
-import autocomplete from '../components/autocomplete/autocomplete';
-
 import '../components/form/form';
 import '../components/clipboard/clipboard';
 import '../components/uploadDocuments/uploadDocuments';
 import '../components/locationFinder/locationFinder';
 import './jobseekers/map';
 import '../components/manageQualifications/manageQualifications';
-
-window.addEventListener('DOMContentLoaded', () => {
-  autocomplete();
-});

--- a/app/frontend/src/components/autocomplete/autocomplete.scss
+++ b/app/frontend/src/components/autocomplete/autocomplete.scss
@@ -1,33 +1,29 @@
 @import '~govuk-frontend/govuk/base';
 
-.accessible-autocomplete {
-  &__container {
-    position: relative;
+.autocomplete {
+  &__suggestions {
+    margin-bottom: 0;
   }
 
-  &__suggestion-highlight {
+  &__suggestions--highlight {
     font-weight: bold;
   }
-}
 
-.accessible-autocomplete__container--desktop .autocomplete__menu {
-  position: absolute;
-}
+  &__wrapper {
+    .autocomplete__input {
+      background-color: govuk-colour('white');
+      font-family: 'GDS Transport', arial, sans-serif;
+      height: 2.5rem;
+    }
 
-.autocomplete__wrapper {
-  .autocomplete__input {
-    background-color: govuk-colour('white');
-    font-family: 'GDS Transport', arial, sans-serif;
-    height: 2.5rem;
-  }
+    .autocomplete__option--focused,
+    .autocomplete__option:hover {
+      background-color: #c2dff4;
+      border-color: $govuk-border-colour;
+    }
 
-  .autocomplete__option--focused,
-  .autocomplete__option:hover {
-    background-color: #c2dff4;
-    border-color: $govuk-border-colour;
-  }
-
-  .autocomplete__option {
-    color: $govuk-text-colour;
+    .autocomplete__option {
+      color: $govuk-text-colour;
+    }
   }
 }

--- a/app/views/shared/search/_location.html.slim
+++ b/app/views/shared/search/_location.html.slim
@@ -1,13 +1,10 @@
 - desktop = false if local_assigns[:desktop].nil?
 - show_hint = true if local_assigns[:show_hint].nil?
 
-.autocomplete data-source="getLocationSuggestions"
+.autocomplete data-source="getLocationSuggestions" data-controller="autocomplete" data-autocomplete-position="#{desktop ? "overlay" : "inline"}"
   = f.govuk_text_field :location,
     label: { text: t("jobs.search.location"), size: "s" },
     hint: { text: show_hint ? t("jobs.search.location_hint") : nil, size: "s" },
     class: %w[js-location-finder__input],
     form_group: { classes: "js-location-finder location-text govuk-!-margin-bottom-0" },
     "data-coordinates": @vacancies_search&.point_coordinates || @point_coordinates
-
-  .accessible-autocomplete__container class="#{desktop ? "accessible-autocomplete__container--desktop" : ""}"
-    .accessible-autocomplete.govuk-body class="govuk-!-margin-bottom-1"


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-3441

## Changes in this PR:

- make autocomplete a stimulus controller
- make controller responsible for adding markup as is JS only
- utilise the autocomplete `displayMenu` config for positioning

