### PR TITLE
Fix bug related to rendering withdraw link

### DIFF
--- a/app/views/jobseekers/job_applications/index.html.slim
+++ b/app/views/jobseekers/job_applications/index.html.slim
@@ -42,7 +42,7 @@
                 = tag.div(card.labelled_item(t(".closing_date"), OrganisationVacancyPresenter.new(submitted_application.vacancy).application_deadline))
 
               - card.action_item link: govuk_link_to(safe_join([t(".view_application"), tag.span(" for #{submitted_application.vacancy.job_title}", class: "govuk-visually-hidden")]), jobseekers_job_application_path(submitted_application))
-              - if submitted_application.status.in?(%w[shortlisted submitted])
+              - if submitted_application.status.in?(%w[reviewed shortlisted submitted])
                 - card.action_item link: govuk_link_to(safe_join([t(".withdraw"), tag.span(" application for #{submitted_application.vacancy.job_title}", class: "govuk-visually-hidden")]), jobseekers_job_application_confirm_withdraw_path(submitted_application))
 
       - else


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3493

## Changes in this PR:

- Before these changes, if a job application had the status 'reviewed', the link to withdraw the application was not rendered. 

## Before

<img width="1025" alt="Screenshot 2021-11-18 at 11 31 25" src="https://user-images.githubusercontent.com/30624173/142416339-cb5a8c41-3e92-48be-8b8b-647144f53ad3.png">

## After

<img width="975" alt="Screenshot 2021-11-18 at 12 36 09" src="https://user-images.githubusercontent.com/30624173/142416388-d5164ba8-8ef1-4767-b9f3-d67e7077b316.png">

