### PR TITLE
Correct Makefile documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ staging: ## staging
 		$(eval backend_config=-backend-config="key=$(env)/app.tfstate")
 
 .PHONY: production
-production: ## production # Requires `CONFIRM_PRODUCTION=true`
+production: ## production # Requires `CONFIRM_PRODUCTION` to be present (any value)
 		$(if $(CONFIRM_PRODUCTION), , $(error Can only run with CONFIRM_PRODUCTION))
 		$(eval env=production)
 		$(eval space=teaching-vacancies-production)


### PR DESCRIPTION
CONFIRM_PRODUCTION only needs to be present. If CONFIRM_PRODUCTION is
'false', the command will treat it as if we had written 'true', since
'false' is a string and strings are present.

This is not a permanent solution; I think CONFIRM_PRODUCTION should
be checked to be true, not to be present.
