### PR TITLE
[TEVA-3450] Changes to job application review and show pages

### DIFF
--- a/app/frontend/src/styles/application/applications.scss
+++ b/app/frontend/src/styles/application/applications.scss
@@ -7,3 +7,15 @@
 .employment-history-gap {
   border-left: 10px solid govuk-colour('light-blue');
 }
+
+.job-application-review-banner {
+  background-color: govuk-colour('white');
+
+  .govuk-button-group {
+    border-bottom: 1px solid $govuk-border-colour;
+
+    .view-listing-link {
+      margin-left: auto;
+    }
+  }
+}

--- a/app/helpers/job_applications_helper.rb
+++ b/app/helpers/job_applications_helper.rb
@@ -8,6 +8,7 @@ module JobApplicationsHelper
   }.freeze
 
   JOBSEEKER_STATUS_MAPPINGS = {
+    deadline_passed: "deadline passed",
     draft: "draft",
     submitted: "submitted",
     reviewed: "submitted",
@@ -17,6 +18,7 @@ module JobApplicationsHelper
   }.freeze
 
   JOB_APPLICATION_STATUS_TAG_COLOURS = {
+    deadline_passed: "grey",
     draft: "pink",
     submitted: "blue",
     reviewed: "purple",
@@ -60,7 +62,7 @@ module JobApplicationsHelper
 
   def job_application_status_tag(status)
     govuk_tag text: JOBSEEKER_STATUS_MAPPINGS[status.to_sym],
-              colour: JOB_APPLICATION_STATUS_TAG_COLOURS[JOBSEEKER_STATUS_MAPPINGS[status.to_sym].to_sym],
+              colour: JOB_APPLICATION_STATUS_TAG_COLOURS[JOBSEEKER_STATUS_MAPPINGS[status.to_sym].parameterize.underscore.to_sym],
               classes: "govuk-!-margin-bottom-2"
   end
 

--- a/app/views/jobseekers/job_applications/_banner.html.slim
+++ b/app/views/jobseekers/job_applications/_banner.html.slim
@@ -1,0 +1,22 @@
+= render BannerComponent.new(classes: ["job-application-review-banner"]) do
+
+  div class="govuk-!-display-none-print"
+    = govuk_breadcrumbs breadcrumbs: { "#{t("breadcrumbs.job_applications")}": jobseekers_job_applications_path, "#{vacancy.job_title}": "" }
+
+  h1.govuk-heading-xl class="govuk-!-margin-top-5 govuk-!-margin-bottom-4" = t("jobseekers.job_applications.caption", job_title: vacancy.job_title, organisation: vacancy.parent_organisation_name)
+
+  .govuk-body class="govuk-!-margin-bottom-0 govuk-!-font-weight-bold govuk-!-display-none-print"
+    = t("jobseekers.job_applications.closing_date")
+  .govuk-body class="govuk-!-margin-bottom-5 govuk-!-display-none-print" = format_time_to_datetime_at(job_application.vacancy.expires_at)
+
+  .status-tag
+    = job_application_status_tag(job_application.vacancy.expires_at.past? && job_application.draft? ? :deadline_passed : job_application.status)
+
+  .govuk-button-group class="govuk-!-margin-bottom-0 govuk-!-margin-top-3 govuk-!-display-none-print"
+    - if job_application.draft?
+      = govuk_button_link_to t("buttons.delete_application"), jobseekers_job_application_confirm_destroy_path(job_application), class: "govuk-button--warning govuk-!-margin-bottom-4"
+    - if job_application.status.in?(%w[reviewed shortlisted submitted])
+      = govuk_button_link_to t("buttons.withdraw_application"), jobseekers_job_application_confirm_withdraw_path(job_application), class: "govuk-button--warning govuk-!-margin-bottom-4"
+    - unless job_application.draft?
+      = govuk_button_link_to t("buttons.download_application"), "#", class: "govuk-button--secondary js-action print-application", "data-controller": "utils", "data-action": "click->utils#print"
+    = open_in_new_tab_link_to "View this listing", job_path(job_application.vacancy), class: "govuk-!-margin-bottom-0 view-listing-link"

--- a/app/views/jobseekers/job_applications/_job_application.html.slim
+++ b/app/views/jobseekers/job_applications/_job_application.html.slim
@@ -19,6 +19,6 @@
     = tag.div(card.labelled_item(t(".closing_date"), OrganisationVacancyPresenter.new(job_application.vacancy).application_deadline))
 
   - if job_application.draft? && job_application.vacancy.expires_at.past?
-    - card.action_item link: govuk_tag(text: "deadline passed", colour: "grey", classes: "govuk-!-margin-bottom-2")
+    - card.action_item link: job_application_status_tag(:deadline_passed)
   - else
     - card.action_item link: job_application_status_tag(job_application.status)

--- a/app/views/jobseekers/job_applications/review.html.slim
+++ b/app/views/jobseekers/job_applications/review.html.slim
@@ -1,17 +1,9 @@
 - content_for :page_title_prefix, job_application_page_title_prefix(review_form, t(".title"))
 
-= render BannerComponent.new do
-  - if current_jobseeker.job_applications.not_draft.none?
-    = govuk_back_link text: t("buttons.back"), href: request.referrer, classes: "govuk-!-margin-top-3"
-
-  .govuk-caption-l class="govuk-!-margin-top-5" = t("jobseekers.job_applications.caption", job_title: vacancy.job_title, organisation: vacancy.parent_organisation_name)
-  h1.govuk-heading-xl class="govuk-!-margin-bottom-5" = t("jobseekers.job_applications.heading")
+= render "banner"
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    - if job_application.draft?
-      = govuk_button_link_to t("buttons.delete_application"), jobseekers_job_application_confirm_destroy_path(job_application), class: "govuk-button--warning"
-
     / TODO: Confirm content
     - unless vacancy.listed?
       = govuk_notification_banner title_text: t("banners.important") do

--- a/app/views/jobseekers/job_applications/show.html.slim
+++ b/app/views/jobseekers/job_applications/show.html.slim
@@ -1,65 +1,23 @@
 - content_for :page_title_prefix, t(".page_title")
 
-= render BannerComponent.new do
-  = govuk_breadcrumbs breadcrumbs: { "#{t("breadcrumbs.job_applications")}": jobseekers_job_applications_path,
-                                      "#{vacancy.job_title}": "" }
-
-  .govuk-caption-l class="govuk-!-margin-top-5" = t("jobseekers.job_applications.heading")
-
-  h1.govuk-heading-xl class="govuk-!-margin-bottom-5 govuk-!-margin-top-0" = vacancy.job_title
-
-  div
-    span.govuk-body class="govuk-!-margin-right-5" = t(".status_heading")
-    = job_application_status_tag(job_application.status)
+= render "banner"
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    - if job_application.status.in?(%w[shortlisted submitted reviewed])
-      = govuk_button_link_to t("buttons.withdraw_application"), jobseekers_job_application_confirm_withdraw_path(job_application), class: "govuk-button--warning"
-
     - if job_application.shortlisted?
       = govuk_notification_banner title_text: t("banners.important"), classes: "govuk-!-margin-bottom-5" do |banner|
         - banner.heading text: t(".shortlist_alert.title")
         span class="govuk-!-margin-top-3" = t(".shortlist_alert.body", organisation: vacancy.parent_organisation_name)
 
-    .grey-border-box
-      h3.govuk-heading-m = t(".school_details.heading")
-      = govuk_summary_list classes: "govuk-!-margin-bottom-0" do |summary_list|
-        - summary_list.row do |row|
-          - row.key text: t(".school_details.name")
-          - row.value text: vacancy.parent_organisation_name
-
-        - summary_list.row do |row|
-          - row.key text: t(".school_details.type")
-          - row.value text: vacancy.parent_organisation.school_type
-
-        - summary_list.row do |row|
-          - row.key text: t(".school_details.number")
-          - row.value text: vacancy.contact_number
-
-        - summary_list.row do |row|
-          - row.key text: t(".school_details.email")
-          - row.value text: govuk_mail_to(vacancy.contact_email, vacancy.contact_email)
-
-        - if vacancy.parent_organisation.website.present? || vacancy.parent_organisation.url.present?
-          - summary_list.row do |row|
-            - row.key text: t(".school_details.website")
-            - row.value text: govuk_link_to(vacancy.parent_organisation.website.presence || vacancy.parent_organisation.url, vacancy.parent_organisation.website.presence || vacancy.parent_organisation.url)
-
-        - summary_list.row do |row|
-          - row.key text: t(".school_details.address")
-          - row.value text: full_address(vacancy.parent_organisation)
-
     - if job_application.unsuccessful? && job_application.rejection_reasons.present?
-      .grey-border-box
+      .grey-border-box class="govuk-!-display-none-print"
         h3.govuk-heading-m = t(".feedback")
         p.govuk-body class="govuk-!-margin-bottom-0" = job_application.rejection_reasons
 
     = render "shared/job_application/show"
 
-  .govuk-grid-column-one-third
-    .account-sidebar
-      h2.account-sidebar__heading = t(".timeline")
+  .govuk-grid-column-one-third class="govuk-!-display-none-print"
+    h2.govuk-heading-m = t(".timeline")
 
     = render TimelineComponent.new do |timeline|
       - if job_application.withdrawn_at?

--- a/app/views/publishers/vacancies/job_applications/show.html.slim
+++ b/app/views/publishers/vacancies/job_applications/show.html.slim
@@ -22,7 +22,7 @@
         = govuk_button_link_to t("buttons.shortlist"), organisation_job_job_application_shortlist_path(vacancy.id, job_application.id), class: "govuk-!-margin-right-3"
       - if job_application.status.in?(%w[submitted reviewed shortlisted])
         = govuk_button_link_to t("buttons.reject"), organisation_job_job_application_reject_path(vacancy.id, job_application.id), class: "govuk-button--warning govuk-!-margin-right-3"
-      = govuk_button_link_to t("buttons.print_download_application"), "#", class: "govuk-button--secondary js-action print-application", "data-controller": "utils", "data-action": "click->utils#print"
+      = govuk_button_link_to t("buttons.download_application"), "#", class: "govuk-button--secondary js-action print-application", "data-controller": "utils", "data-action": "click->utils#print"
 
     = render "shared/job_application/show"
 

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -49,7 +49,7 @@ en:
     make_changes: Make changes
     manage_listing: Manage job listing
     preview_job_listing: Preview job listing
-    print_download_application: Print or download
+    download_application: Download application
     reject: Reject
     request_dsi_account: Request a DfE Sign-in account
     resend_email: Resend request

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -139,6 +139,7 @@ en:
           step_title: References
           title: References — Application
       caption: "%{job_title} at %{organisation}"
+      closing_date: Closing date
       confirm_destroy:
         title: Delete draft
         heading: Delete draft
@@ -333,14 +334,6 @@ en:
       show:
         feedback: Feedback on your application
         page_title: View application
-        school_details:
-          address: School address
-          email: Contact email
-          heading: School details
-          name: School name
-          number: Telephone number
-          type: School type
-          website: School website
         shortlist_alert:
           title: What happens next with shortlisting?
           body: "%{organisation} will be in touch soon with more information about next steps."

--- a/spec/system/jobseekers_can_view_a_job_application_spec.rb
+++ b/spec/system/jobseekers_can_view_a_job_application_spec.rb
@@ -16,15 +16,6 @@ RSpec.describe "Jobseekers can view a job application" do
       expect(page).to have_content(job_application.status)
     end
 
-    within ".grey-border-box", text: I18n.t("jobseekers.job_applications.show.school_details.heading") do
-      expect(page).to have_content(vacancy.parent_organisation_name)
-      expect(page).to have_content(vacancy.parent_organisation.school_type)
-      expect(page).to have_content(vacancy.contact_number)
-      expect(page).to have_content(vacancy.contact_email)
-      expect(page).to have_content(vacancy.parent_organisation.url)
-      expect(page).to have_content(full_address(vacancy.parent_organisation))
-    end
-
     within ".navigation-list-component", text: I18n.t("shared.job_application.show.application_sections") do
       expect(page).to have_link(I18n.t("shared.job_application.show.personal_details.heading"), href: "#personal_details_summary")
       expect(page).to have_link(I18n.t("shared.job_application.show.professional_status.heading"), href: "#professional_status_summary")

--- a/spec/system/publishers_can_view_a_job_application_spec.rb
+++ b/spec/system/publishers_can_view_a_job_application_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Publishers can view a job application" do
       expect(page).to have_css(".job-application-actions") do |actions|
         expect(actions).not_to have_css("a", class: "govuk-button", text: I18n.t("buttons.shortlist"))
         expect(actions).not_to have_css("a", class: "govuk-button--warning", text: I18n.t("buttons.reject"))
-        expect(actions).to have_css("a", class: "govuk-button--secondary", text: I18n.t("buttons.print_download_application"))
+        expect(actions).to have_css("a", class: "govuk-button--secondary", text: I18n.t("buttons.download_application"))
       end
     end
   end
@@ -59,7 +59,7 @@ RSpec.describe "Publishers can view a job application" do
       expect(page).to have_css(".job-application-actions") do |actions|
         expect(actions).not_to have_css("a", class: "govuk-button", text: I18n.t("buttons.shortlist"))
         expect(actions).to have_css("a", class: "govuk-button--warning", text: I18n.t("buttons.reject"))
-        expect(actions).to have_css("a", class: "govuk-button--secondary", text: I18n.t("buttons.print_download_application"))
+        expect(actions).to have_css("a", class: "govuk-button--secondary", text: I18n.t("buttons.download_application"))
       end
     end
   end
@@ -73,7 +73,7 @@ RSpec.describe "Publishers can view a job application" do
       expect(page).to have_css(".job-application-actions") do |actions|
         expect(actions).to have_css("a", class: "govuk-button", text: I18n.t("buttons.shortlist"))
         expect(actions).to have_css("a", class: "govuk-button--warning", text: I18n.t("buttons.reject"))
-        expect(actions).to have_css("a", class: "govuk-button--secondary", text: I18n.t("buttons.print_download_application"))
+        expect(actions).to have_css("a", class: "govuk-button--secondary", text: I18n.t("buttons.download_application"))
       end
     end
   end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3450

## Changes in this PR:

- Updated the review and show pages according to designs
- Conditionally show actions depending on the state of the application
- Added 'Download application' button. Updated text on publisher's download application button to make it consistent 
- Removed the school details box from the show page
- Removed the blue line from the timeline

## Screenshots

### Draft

![Screenshot 2021-11-22 at 17 58 58](https://user-images.githubusercontent.com/30624173/142911749-baf09488-c7cb-450f-a837-7527aee65768.png)

### Shortlisted 

![Screenshot 2021-11-22 at 18 00 42](https://user-images.githubusercontent.com/30624173/142911974-7517ee24-5df1-42ac-ba3f-c90dce59714d.png)

### Submitted

![Screenshot 2021-11-22 at 17 59 49](https://user-images.githubusercontent.com/30624173/142911860-3a071d9d-aadc-4769-89dd-4de5801bdebe.png)

### Unsuccessful

![Screenshot 2021-11-22 at 17 59 25](https://user-images.githubusercontent.com/30624173/142911811-cab923ce-f335-45a3-9012-2449a093a508.png)

### Withdrawn

![Screenshot 2021-11-22 at 18 00 06](https://user-images.githubusercontent.com/30624173/142911894-14202901-253b-400c-b2aa-fde18edde9b5.png)


