### PR TITLE
[TEVA-3446] Sign in user after account confirmation even when already confirmed

### DIFF
--- a/app/controllers/jobseekers/confirmations_controller.rb
+++ b/app/controllers/jobseekers/confirmations_controller.rb
@@ -1,6 +1,12 @@
 class Jobseekers::ConfirmationsController < Devise::ConfirmationsController
   after_action :remove_devise_flash!, only: %i[create]
 
+  def show
+    super do |jobseeker|
+      jobseeker.errors.delete(:email, :already_confirmed) if jobseeker.errors.added?(:email, :already_confirmed)
+    end
+  end
+
   protected
 
   def after_confirmation_path_for(resource_name, resource)

--- a/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
@@ -51,5 +51,15 @@ RSpec.describe "Jobseekers can sign up to an account" do
         end
       end
     end
+
+    context "when the confirmation link is followed after the account has already been confirmed" do
+      before { jobseeker.confirm }
+
+      it "still signs them in" do
+        visit first_link_from_last_mail
+        expect(current_path).to eq(jobseekers_saved_jobs_path)
+        expect(page).to have_content(I18n.t("devise.confirmations.confirmed"))
+      end
+    end
   end
 end


### PR DESCRIPTION
This is one possible approach to the problem we suspect is caused by BingPreview clicking on one-time-use links in confirmation emails. As things stand, for some users the link will not work (will show as 'expired') when the account is already confirmed, because of BingPreview (or similar bots).

The Devise controller’s ‘show’ action has a yield resource if block_given? which I am hooking into here, in order to (in effect) remove any check that the account has already been confirmed. If the account’s already confirmed, the user has the same experience as when they are confirming for the first time: they are signed in.

## Alternative ideas

Feel free to suggest alternative ideas.

We could instead block the page from requests with BingPreview in the user agent, but then we'd have to keep a denylist of bots, which could never be exhaustive; and it might play havoc with the bots' intended behaviour.

We could also vary the content on the 'confirmation invalid' page depending if the jobseeker is confirmed yet or not, but that would have the downsides of interrupting the users and of requiring new content to be written for this very rare scenario.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3446