### PR TITLE
[TEVA-3305] Updates to Jobseeker Flows

### DIFF
--- a/app/controllers/jobseekers/sessions_controller.rb
+++ b/app/controllers/jobseekers/sessions_controller.rb
@@ -11,6 +11,11 @@ class Jobseekers::SessionsController < Devise::SessionsController
     invalid not_found_in_database last_attempt
   ].map { |error| I18n.t("devise.failure.#{error}") }.freeze
 
+  def destroy
+    session.delete(:jobseeker_return_to)
+    super
+  end
+
   private
 
   def render_resource_with_errors

--- a/spec/accessibility/jobseekers_dashboard_experience_spec.rb
+++ b/spec/accessibility/jobseekers_dashboard_experience_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Jobseeker dashboardexperience", type: :system, accessibility: tr
     before do
       visit job_path(vacancy)
       click_on I18n.t("jobseekers.saved_jobs.save")
-      visit jobseeker_root_path
+      visit jobseekers_saved_jobs_path
     end
 
     it "it meets accessibility standards" do

--- a/spec/system/jobseekers_can_change_email_spec.rb
+++ b/spec/system/jobseekers_can_change_email_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Jobseekers can change email" do
 
       expect(subscription.reload.email).to eq(new_email_address)
       expect(created_jobseeker.reload.email).to eq(new_email_address)
-      expect(current_path).to eq(jobseeker_root_path)
+      expect(current_path).to eq(jobseekers_saved_jobs_path)
       expect(page).to have_content(I18n.t("devise.confirmations.confirmed"))
     end
   end

--- a/spec/system/jobseekers_can_give_account_feedback_spec.rb
+++ b/spec/system/jobseekers_can_give_account_feedback_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Jobseekers can give account feedback" do
 
   before do
     login_as(jobseeker, scope: :jobseeker)
-    visit jobseeker_root_path
+    visit jobseekers_account_path
   end
 
   it "submits account feedback" do
@@ -20,7 +20,7 @@ RSpec.describe "Jobseekers can give account feedback" do
     expect { click_button I18n.t("buttons.submit") }.to change {
       jobseeker.feedbacks.where(comment: comment, email: jobseeker.email, rating: "somewhat_satisfied", feedback_type: "jobseeker_account", user_participation_response: "interested").count
     }.by(1)
-    expect(current_path).to eq(jobseeker_root_path)
+    expect(current_path).to eq(jobseekers_account_path)
     expect(page).to have_content(I18n.t("jobseekers.account_feedbacks.create.success"))
   end
 end

--- a/spec/system/jobseekers_can_sign_in_to_their_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_in_to_their_account_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe "Jobseekers can sign in to their account" do
 
     it "signs in the jobseeker" do
       sign_in_jobseeker(email: email, password: password)
-      expect(current_path).to eq(jobseeker_root_path)
       expect(page).to have_content(I18n.t("devise.sessions.signed_in"))
     end
 
@@ -108,10 +107,9 @@ RSpec.describe "Jobseekers can sign in to their account" do
     let(:email) { jobseeker.email }
     let(:password) { "incorrect_password" }
 
-    it "does not sign in the jobseeker, displays error messages, then signs in the jobseeker" do
+    it "signs in the jobseeker on the second attempt" do
       sign_in_jobseeker(email: email, password: password)
       sign_in_jobseeker(email: email, password: jobseeker.password)
-      expect(current_path).to eq(jobseeker_root_path)
       expect(page).to have_content(I18n.t("devise.sessions.signed_in"))
     end
   end

--- a/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
@@ -24,11 +24,11 @@ RSpec.describe "Jobseekers can sign up to an account" do
     end
 
     context "when the confirmation token is valid" do
-      it "confirms email, triggers email confirmed event and redirects to jobseeker root page" do
+      it "confirms email, triggers email confirmed event and redirects to jobseeker saved jobs page" do
         expect { visit first_link_from_last_mail }.to have_triggered_event(:jobseeker_email_confirmed).with_base_data(
           user_anonymised_jobseeker_id: StringAnonymiser.new(created_jobseeker.id).to_s,
         )
-        expect(current_path).to eq(jobseeker_root_path)
+        expect(current_path).to eq(jobseekers_saved_jobs_path)
         expect(page).to have_content(I18n.t("devise.confirmations.confirmed"))
       end
     end

--- a/spec/system/jobseekers_session_timeout_spec.rb
+++ b/spec/system/jobseekers_session_timeout_spec.rb
@@ -7,24 +7,24 @@ RSpec.describe "Jobseekers session timeout" do
   before { login_as(jobseeker, scope: :jobseeker) }
 
   it "expires after the desired timeout period" do
-    visit jobseeker_root_path
+    visit jobseekers_saved_jobs_path
     expect(page).to have_content(jobseeker.email)
 
     travel(timeout_period + 10.seconds) do
-      visit jobseeker_root_path
+      visit jobseekers_saved_jobs_path
 
       expect(current_path).to eq(new_jobseeker_session_path)
     end
   end
 
   it "doesn't expire before the desired timeout period" do
-    visit jobseeker_root_path
+    visit jobseekers_saved_jobs_path
     expect(page).to have_content(jobseeker.email)
 
     travel(timeout_period - 1.day) do
-      visit jobseeker_root_path
+      visit jobseekers_saved_jobs_path
 
-      expect(current_path).to eq(jobseeker_root_path)
+      expect(current_path).to eq(jobseekers_saved_jobs_path)
       expect(page).to have_content(jobseeker.email)
     end
   end

--- a/spec/system/users_can_only_be_signed_in_to_one_type_of_account_spec.rb
+++ b/spec/system/users_can_only_be_signed_in_to_one_type_of_account_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "Users can only be signed in to one type of account" do
         visit new_jobseeker_session_path
         sign_in_jobseeker
 
-        expect(current_path).to eq(jobseeker_root_path)
+        expect(current_path).to eq(jobseekers_saved_jobs_path)
 
         visit organisation_path
         expect(current_path).to eq(new_publisher_session_path)
@@ -92,7 +92,7 @@ RSpec.describe "Users can only be signed in to one type of account" do
         visit new_jobseeker_session_path
         sign_in_jobseeker
 
-        expect(current_path).to eq(jobseeker_root_path)
+        expect(current_path).to eq(jobseekers_saved_jobs_path)
 
         visit organisation_path
         expect(current_path).to eq(new_login_key_path)


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3305

## Changes in this PR:

- Ensures that unless a user signs in from an "Apply for this job" or "Save this job for later" link, they are directed to either the "My applications" dashboard (if they have any applications) or the "Saved jobs" dashboard (if they have no applications. 
- Ensures that the `:jobseeker_root_path` session variable is destroyed upon signing out.
- Ensures that the `:jobseeker_root_path` session variable does not persist if a user navigates away from the sign in page after being sent there after clicking an "Apply for this job" or "Save this job for later" link - meaning if they sign in from elsewhere, they will be directed to the correct page on their dashboard.
