### PR TITLE
[TEVA-3380] Tell robots not to crawl duplicate pages

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -6,4 +6,9 @@ Disallow: /subscriptions/
 Disallow: /documents/
 Disallow: /attachments/
 Disallow: /teaching-jobs-in-*?location*
-Disallow: /teaching-jobs-for-*?job_roles*
+Disallow: /teaching-jobs-for-*?job_role*
+Disallow: /teaching-jobs-for-*?phase*
+Disallow: /teaching-jobs-for-*?subject*
+Disallow: /*-jobs*?job_role*
+Disallow: /*-jobs*?phase*
+Disallow: /*-jobs*?subject*


### PR DESCRIPTION
Add further patterns to robots.txt in order to exclude pages that show as duplicates in SEO analysis.

Pages appear as duplicates whenever a search filter is both part of the url and part of
the query parameters, e.g.:

/ect-suitable-jobs?job_roles[]=ect_suitable

I am defensively excluding patterns that are not currently possible (e.g. using 'subjects' in case we in future add back in the subjects filter we got rid of before).

This approach also excludes non-duplicate pages such as:

/ect-suitable-jobs?phases[]=primary

These are excluded as a side-effect.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3380
