### PR TITLE
Assorted devcontainer improvements

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,25 +2,30 @@
   "name": "DfE Teaching Vacancies",
   "dockerComposeFile": "docker-compose.yml",
   "service": "app",
-  "workspaceFolder": "/app",
+  "workspaceFolder": "/workspace",
+  "remoteEnv": {
+    "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}"
+  },
   "forwardPorts": [
     3000,
     3035,
     5432,
     6379
   ],
-  "postCreateCommand": "/bin/bash /app/.devcontainer/post_create.sh",
+  "postCreateCommand": "/bin/bash .devcontainer/post_create.sh",
   "remoteUser": "teaching-vacancies",
   "extensions": [
     "actboy168.tasks",
     "aki77.rails-db-schema",
     "aki77.rails-i18n",
     "aki77.rails-routes",
+    "castwide.solargraph",
+    "kaiwood.endwise",
     "mtxr.sqltools",
     "mtxr.sqltools-driver-pg",
     "rebornix.Ruby",
     "redhat.vscode-yaml",
-    "sianglim.slim"
+    "sianglim.slim",
   ],
   "settings": {
     // Get highlighting for local env files

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -7,12 +7,12 @@ services:
       context: .
       dockerfile: Dockerfile
     volumes:
-      - ..:/app:cached
+      - ..:/workspace:cached
       - bundle:/usr/local/bundle
-      - node_modules:/app/node_modules
-      - packs:/app/public/packs
-      - tmp:/app/tmp
-    working_dir: /app
+      - node_modules:/workspace/node_modules
+      - packs:/workspace/public/packs
+      - tmp:/workspace/tmp
+    working_dir: /workspace
     command: sleep infinity
     user: teaching-vacancies
     ports:

--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -6,15 +6,11 @@ function log() {
 if ! grep teaching_vacancies_bashrc /etc/bash.bashrc; then
   log 'Adding sourcing of barebones bashrc to /etc/bash.bashrc'
 
-  echo -e "\nsource /app/.devcontainer/teaching_vacancies_bashrc.sh" | sudo tee -a /etc/bash.bashrc
+  echo -e "\nsource $PWD/.devcontainer/teaching_vacancies_bashrc.sh" | sudo tee -a /etc/bash.bashrc
 fi
 
-log 'Ensure directories mounted via Docker volumes are owned by non-privileged user'
-sudo chown $(id -u):$(id -g) /app/node_modules /app/public/packs /app/tmp
-
-log 'Ensure Bundler directory is owned by `bundler` group and has group write permissions'
-sudo chgrp -R bundler /usr/local/bundle
-sudo chmod -R g+w /usr/local/bundle
+log 'Ensure entire workspace (including mounted Docker volumes) is owned by non-privileged user'
+sudo chown -R $(id -u):$(id -g) .
 
 log 'Install Ruby dependencies'
 bundle install
@@ -25,7 +21,7 @@ yarn install
 log 'Ensure `tmp` folder has a `.keep` file'
 # (this is present on the host, but the container uses a volume for the `tmp` directory,
 # leading Git to believe the `.keep` file has gone missing)
-touch /app/tmp/.keep
+touch tmp/.keep
 
 log 'Allow using `psql` without needing to enter a password'
 echo "db:5432:*:postgres:postgres" > $HOME/.pgpass

--- a/.devcontainer/teaching_vacancies_bashrc.sh
+++ b/.devcontainer/teaching_vacancies_bashrc.sh
@@ -2,4 +2,9 @@
 # Intended to be sourced into /etc/bash.bashrc so it can be overridden by user dotfiles
 
 ## Add Rails `bin` and Bundler `bin` directories to PATH
-PATH=/app/bin:/usr/local/bundle/bin:$PATH
+##   Adds `$PWD/bin` to support checking out a repository into a Docker volume through VS Code
+##   (which results in the workspace not living in the default `/workspace` directory)
+PATH=$PWD/bin:/workspace/bin:/usr/local/bundle/bin:$PATH
+
+## Enable Git bash completion
+source /usr/share/bash-completion/completions/git

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -16,8 +16,8 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
 
-  # Allow
-  config.web_console.permissions = "172.18.0.0/16"
+  # Allow Web Console from outside devcontainer
+  config.web_console.permissions = "172.0.0.0/8" if ENV["DEVCONTAINER"].present?
 
   # Enable/disable caching. By default caching is disabled.
   if Rails.root.join("tmp/caching-dev.txt").exist?

--- a/documentation/devcontainer.md
+++ b/documentation/devcontainer.md
@@ -1,47 +1,103 @@
 # Devcontainer
 
-> 🚧 TODO: These notes are a work in progress!
+## Why use devcontainers?
 
-## Quickstart
+Devcontainers provide completely isolated environments for development on a specific project. Read
+more about our motivations in the [ADR](adr/0011_use_devcontainers.md).
 
-- Install the following tools:
-  - [Docker Desktop](https://www.docker.com/products/docker-desktop)
-  - [Git](https://github.com/git-guides/install-git)
-  - [Visual Studio Code](https://code.visualstudio.com)
-- Clone this repository onto your machine
-- Ask a developer for a `.env` file and place it in the repository folder
-  - _Optional_: get onboarded on AWS and set up `aws-vault` to fetch dev credentials yourself
-- Open the repository in Visual Studio Code and choose "Reopen in container" when prompted
-  (in the bottom right corner of the application window)
-- Indulge in a caffeinated beverage while the container builds for the first time (5-10 minutes)
-- You're ready to go!
+## How it works
 
-## Use without VS Code
+See [Developing inside a Container](https://code.visualstudio.com/docs/remote/containers) in the VS
+Code documentation.
 
-_TODO_
+## Container setup script and environment
 
-## Personal dotfiles
+After building the container, a [custom `postCreate` script](../.devcontainer/post_create.sh) is
+executed against it for initial setup (installing dependencies, creating and seeding the database,
+and setting up the environment).
 
-Make sure your dotfiles are sufficiently Debian-friendly, have an `install.sh` script to get things
-up and running (you can also use this to install custom packages) and add the following settings
-to your VS Code configuration:
+## Working in the container
 
-```json
-{
-  "dotfiles.repository": "my_github_username/my_repo_name",
-  "dotfiles.installCommand": "path_to_script.sh"
-}
-```
+### Running things
 
-## Environment
+The container includes a very basic bootstrap `bashrc` which adds the Rails `bin/` directory (for
+binstubs for `rails`, `rspec`, etc.) as well as Bundler's bin directory to the `PATH`.
 
-TODO: Explain how `PATH` is set up
+For performance reasons, we recommend you use the binstubs over `bundle exec [command]` for those
+commands that have a binstub.
 
-## System tests
+### System tests
 
 System tests with `js: true` are run on a "standalone" (no hub) Selenium Chrome container. If you
 want to watch the tests as they happen, a web VNC viewer is exposed by that container on port
 7900, which is published to the host: http://localhost:7900
+
+### Personal dotfiles
+
+Make your devcontainer feel like home by setting up your dotfiles inside the container using VS
+Code:
+
+- Make sure your dotfiles are sufficiently Debian-friendly (e.g. don't rely on things that only
+  work on other Linux distributions or macOS)
+- Have an install script to get things bootstrapped (with one of the default names, or you can
+  specify a manual installation command)
+  - Pro tip: You can also use this install script/command to install custom software, e.g. if
+    you use a dotfiles manager like [rcm](https://github.com/thoughtbot/rcm).
+
+Configure your VS Code as follows:
+
+```json
+{
+  "dotfiles.repository": "my_github_username/my_repo_name",
+  "dotfiles.installCommand": "path_to_script.sh" // Optional
+}
+```
+
+## Optional advanced setup
+
+### Using a volume as workspace root
+
+At their core, containers are a Linux technology - running them on macOS or Windows requires an
+intermediate virtual machine. A significant area of performance overhead with this arrangement is
+IO between the host and the container, which means that having your workspace bind mounted into
+the container makes everything run slower than if you ran it straight on the host.
+
+When used by non-developers, that performance hit is acceptable given all the other benefits
+devcontainers bring. If you want to e.g. frequently run RSpec though, or have a slightly slower
+machine and see multi-second page load times, you may want to consider using a volume for the root
+of your workspace, instead of bind mounting a host folder into the container.
+
+This provides near-native performance, but there are two minor downsides to the workspace living
+in a volume:
+- You cannot easily interact with the filesystem in the volume from your host OS anymore
+- You run the risk of losing changes if you e.g. accidentally delete the volume (make sure to
+  frequently push your changes to Github)
+
+The simplest way to do so is:
+- Before you start, ensure you have committed and pushed all your changes as you'll start from a
+  fresh checkout of the repository
+- From the VS Code Command Palette (`Cmd-Shift-P` or `Ctrl-Shift-P`), choose "Remote-Containers:
+  Clone repository in Container Volume"
+- Choose "Github", then find this repository in the dropdown (`DFE-Digital/teaching-vacancies`)
+- Wait while the container rebuilds
+- VS Code will have checked out the repository using HTTPS, replace `origin` with a Git-over-SSH
+  URL:
+  ```
+  git remote rm origin
+  git remote add origin git@github.com:DFE-Digital/teaching-vacancies.git
+  ```
+- Reminder: You will need to create a `.env` file in the new volume-based workspace again
+
+> ⚠️ **Gotcha:** If you get a Docker error "`Mounts denied: The path /workspaces/teaching-vacancies
+> is not shared from the host and is not known to Docker.`", you may be experiencing the following
+> issue: https://github.com/microsoft/vscode-remote-release/issues/5388
+>
+> Until this is fixed, you can work around this by adding `/workspaces` under `Preferences >
+> Resources > File Sharing` in Docker Desktop.
+
+
+
+More details: https://code.visualstudio.com/remote/advancedcontainers/improve-performance
 
 ## Gotchas
 


### PR DESCRIPTION
- Improve devcontainer documentation and add section on mounting
  workspace as a Docker volume
- Tweak `devcontainer.json` to make it more independent of the mounts
  in the container
- Add Solargraph and Endwise extensions
- Source `git` command completion in default bashrc
- Allow web console for requests from a wider network (entire `/8`)

Bind vs Docker volume spec performance:
```
Finished in 29 minutes 17 seconds (files took 44.36 seconds to load) 🐢
Finished in 9 minutes 20 seconds (files took 5.08 seconds to load) 🐇
```