### PR TITLE
[TEVA-3541] Update disaster recovery documentation

### DIFF
--- a/documentation/maintenance-mode.md
+++ b/documentation/maintenance-mode.md
@@ -4,7 +4,15 @@ The application has a simple routing-level maintenance mode triggered by the `MA
 environment variable. This needs the app to be restarted to enable maintenance mode, e.g. via
 a deploy or a `cf restage`. This is handy in case of a critical bug being discovered where we need
 to take the service offline, or in case of maintenance where we want to avoid users interacting
-with the service while
+with the service.
 
 When enabled, all requests of all types will be routed to the maintenance page (found under
 `app/views/errors/maintenance.html.erb`).
+
+### Enable Maintenance mode
+
+Login to PaaS: `cf login --sso`
+
+set maintenance mode environment variable: `cf set-env teaching-vacancies-dev MAINTENANCE_MODE 1`
+
+restage app: cf restage: `cf restage teaching-vacancies-dev`

--- a/documentation/simulate-data-loss-disaster.md
+++ b/documentation/simulate-data-loss-disaster.md
@@ -1,0 +1,13 @@
+# Simulate Data loss Disaster
+
+To simulate disaster recovery, do the following:
+
+- Notify Devs of simulation
+- Create test data to verify after recovery
+- Wipe out data:
+    - Login to PaaS using conduit: `cf login --sso`
+    - Connect to PostgreDB instance: `cf conduit teaching-vacancies-postgres-dev -- psql`
+    - Get database `owner`: run `\dt` once connected to database. The owner is described in the fourth column of the schema
+    - Run command to drop table - `drop owned by rdsbroker_xxxxx_xxxx_xxxx_xxxxx_xxxxx_manager;`
+
+- Follow the [disaster recovery documentation](disaster-recovery.md) to recover data.


### PR DESCRIPTION
## Jira ticket URL

- Just add the ticket number to the end:

https://dfedigital.atlassian.net/browse/TEVA-3541

Update disaster recovery documentation to include:-

    - Documentation on how to start disaster recovery simulatation

    - Add instructions on how to delete old database instance

    - Improve documentation on how to switch web app to `MAINTENANCE_MODE`

    - Add instructions about keeping non-technical stakeholders abreast via #tv_product channel 