### PR TITLE
TEVA-3544 Don't run sonarqube for dependabot

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
 
       - name: Setup sonarqube
         uses: warchant/setup-sonar-scanner@v3
+        if: ${{ github.actor != 'dependabot[bot]' }}
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -88,6 +89,7 @@ jobs:
            -Dsonar.projectKey=DFE-Digital_teaching-vacancies
            -Dsonar.testExecutionReportPaths=${{ github.workspace }}/out/test-report.xml
            -Dsonar.ruby.coverage.reportPaths=${{ github.workspace }}/coverage/.resultset.json
+        if: ${{ github.actor != 'dependabot[bot]' }}
 
   frontend-tests:
     name: Run frontend JS unit tests


### PR DESCRIPTION
A dependabot change to tighten security means that the bot
doesn't have access to secrets when running, so it can't
use the sonarqube token.

We don't really need to check coverage etc for dependency
updates, so a reasonable workaround is to skip that step
for dependabot PRs.

https://community.sonarsource.com/t/youre-not-authorized-to-run-analysis-and-github-bots/41994/8

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3544