### PR TITLE
Load stimulus components asap to remove page load flicker

### DIFF
--- a/app/frontend/packs/application.js
+++ b/app/frontend/packs/application.js
@@ -5,11 +5,10 @@ import Rails from 'rails-ujs';
 
 import { initAll } from 'govuk-frontend';
 
+import 'src/application';
 import 'src/components';
 
 import 'src/styles/application.scss';
-
-import 'src/application';
 import 'src/application/init';
 
 Rails.start();

--- a/app/frontend/src/components/autocomplete/autocomplete.scss
+++ b/app/frontend/src/components/autocomplete/autocomplete.scss
@@ -3,7 +3,7 @@
 .autocomplete {
   position: relative;
 
-  &__suggestions {
+  .govuk-body {
     margin-bottom: 0;
   }
 


### PR DESCRIPTION
i have observed that as we have refactoring more JS to stimulus controllers that a noticable and ugly flicker is seen at page load time (see movie). i have noticed this seems to be particuarly evident on Chrome but happens on all browsers to a degree. this will be JS interacting with the DOM when the controllers are being bound to the HTML.

this PR just pushes the stimulus code up to be executed as soon as it can be, As a result the flicker is barely noticable now, if at all

(also small tweak to location finder css as spacing not quite right)




https://user-images.githubusercontent.com/1792451/144141457-121e0710-e8c5-4736-8326-a7f1a3ae887e.mov

## Before 
the red highlights the browser painting by JS (green blocks) that causes flicker.

![Screenshot 2021-11-30 at 23 02 26](https://user-images.githubusercontent.com/1792451/144142205-7cbc8f16-5fd4-4f92-b514-15b1d98743a6.png)

## After
the JS painting is done well before render time as is not present in same section of timeline.

![Screenshot 2021-11-30 at 23 03 04](https://user-images.githubusercontent.com/1792451/144142206-07768eb9-4fc8-4b59-8cad-762bdccc1e8c.png)


