### PR TITLE
Babel config update

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -44,7 +44,7 @@ module.exports = function(api) {
       [
         '@babel/plugin-proposal-class-properties',
         {
-          loose: true
+          loose: false
         }
       ],
       [


### PR DESCRIPTION
make babel class properties config stricter so warnings dont mess with output (as per instruction in warning)

removes all this kind of nonsense :)

![Screenshot 2021-12-01 at 00 01 26](https://user-images.githubusercontent.com/1792451/144147355-f6a80c61-2f06-4902-adb0-ead1682c599b.png)

