### PR TITLE
JS fix for ie11

### DIFF
--- a/app/frontend/src/application.js
+++ b/app/frontend/src/application.js
@@ -20,7 +20,7 @@ window.Stimulus = application;
 
 application.register('autocomplete', AutocompleteController);
 application.register('clipboard', ClipboardController);
-application.register('locationFinder', LocationFinderController);
+application.register('location-finder', LocationFinderController);
 application.register('manage-qualifications', ManageQualificationsController);
 application.register('panel', PanelController);
 application.register('upload-documents', UploadDocumentsController);

--- a/app/frontend/src/components/loadingIndicator/loadingIndicator.js
+++ b/app/frontend/src/components/loadingIndicator/loadingIndicator.js
@@ -22,7 +22,7 @@ const loadingIndicator = class {
 
   static add(targetEl) {
     targetEl.insertAdjacentHTML('beforeend', loadingIndicator.svg);
-    [loadingIndicator.element] = targetEl.getElementsByClassName(CLASS_NAME);
+    [loadingIndicator.element] = Array.from(targetEl.getElementsByClassName(CLASS_NAME));
   }
 
   static remove() {

--- a/app/frontend/src/components/locationFinder/locationFinder.js
+++ b/app/frontend/src/components/locationFinder/locationFinder.js
@@ -1,7 +1,5 @@
 import { Controller } from '@hotwired/stimulus';
 
-import 'es6-promise/auto';
-
 import loader from '../loadingIndicator/loadingIndicator';
 import api from '../../lib/api';
 import logger from '../../lib/logging';
@@ -17,7 +15,7 @@ const LocationFinder = class extends Controller {
   static loader = loader;
 
   connect() {
-    [this.inputContainer] = document.getElementsByClassName('location-field__container');
+    [this.inputContainer] = Array.from(document.getElementsByClassName('location-field__container'));
     this.input = document.getElementById(this.element.dataset.target);
 
     this.input.addEventListener('focus', () => {

--- a/app/views/shared/search/_current_location.html.slim
+++ b/app/views/shared/search/_current_location.html.slim
@@ -1,3 +1,3 @@
 .location-finder.govuk-body.js-action class="govuk-!-margin-top-1 govuk-!-margin-bottom-4"
   span.location-finder__link-prefix = "or "
-  =< govuk_link_to(t("jobs.search.use_current_location_html"), "#", class: "govuk-link--no-visited-state", data: { target: target, controller: "locationFinder", source: "getPostcodeFromCoordinates", action: "click->locationFinder#findLocation" })
+  =< govuk_link_to(t("jobs.search.use_current_location_html"), "#", class: "govuk-link--no-visited-state", data: { target: target, controller: "location-finder", source: "getPostcodeFromCoordinates", action: "click->location-finder#findLocation" })

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "accessible-autocomplete": "^2.0.3",
     "axios": "^0.24.0",
     "classlist-polyfill": "^1.2.0",
-    "es6-promise": "^4.2.8",
     "govuk-frontend": "^3.14.0",
     "jquery": "^3.5.0",
     "jsdom": "^18.1.1",


### PR DESCRIPTION
needed to convert the nodelist from getelementsbyclassname to array to assign, ie11 didnt like it

removed promise polyfill, not needed, stimulus polyfills handle all this