### PR TITLE
Move to matrix strategy for RSpec tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -54,9 +54,6 @@ config/localhost/https/*.crt
 .stylelintrc.json
 .tool-versions
 
-# Ignore Sonar
-sonar-project.properties
-
 # Ignore BigQuery
 bigquery/*
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,26 @@ on:
 
 jobs:
   backend-tests:
-    name: Run rspec
+    name: Run RSpec (${{ matrix.test_params.name }})
 
     runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        test_params:
+          -
+            name: system - jobseekers
+            params: 'spec/system/jobseekers_*_spec.rb'
+          -
+            name: system - publishers
+            params: 'spec/system/publishers_*_spec.rb'
+          -
+            name: system - other & a11y
+            params: '--exclude-pattern "spec/system/{jobseekers,publishers}_*_spec.rb" spec/system spec/accessibility'
+          -
+            name: unit
+            params: '--exclude-pattern "spec/{accessibility,system}/*_spec.rb"'
 
     env:
       RAILS_ENV: test
@@ -34,10 +51,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-
-      - name: Setup sonarqube
-        uses: warchant/setup-sonar-scanner@v3
-        if: ${{ github.actor != 'dependabot[bot]' }}
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -71,25 +84,7 @@ jobs:
         run: bin/rails db:create db:schema:load
 
       - name: Run tests
-        run: bundle exec rspec --format RspecSonarqubeFormatter --out ${{ github.workspace }}/out/test-report.xml --format documentation
-
-      - name: Keep Code Coverage Report
-        uses: actions/upload-artifact@v2
-        with:
-          name: Code_Coverage
-          path: ${{ github.workspace }}/coverage/*
-
-      - name: Run sonarqube
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: sonar-scanner
-           -Dsonar.login=${{ secrets.SONAR_TOKEN }}
-           -Dsonar.organization=dfe-digital
-           -Dsonar.host.url=https://sonarcloud.io/
-           -Dsonar.projectKey=DFE-Digital_teaching-vacancies
-           -Dsonar.testExecutionReportPaths=${{ github.workspace }}/out/test-report.xml
-           -Dsonar.ruby.coverage.reportPaths=${{ github.workspace }}/coverage/.resultset.json
-        if: ${{ github.actor != 'dependabot[bot]' }}
+        run: bundle exec rspec --format documentation ${{ matrix.test_params.params }}
 
   frontend-tests:
     name: Run frontend JS unit tests

--- a/Gemfile
+++ b/Gemfile
@@ -94,7 +94,6 @@ group :development, :test do
   gem "rack-mini-profiler"
   gem "rails-controller-testing"
   gem "rspec-rails"
-  gem "rspec-sonarqube-formatter", require: false
   gem "rubocop-performance"
   gem "rubocop-rails"
   gem "rubocop-rspec"
@@ -107,7 +106,7 @@ group :test do
   gem "rack_session_access"
   gem "selenium-webdriver"
   gem "shoulda-matchers"
-  gem "simplecov", "<= 0.17.1", require: false # Newer versions of simplecov are not compatible with Sonarqube
+  gem "simplecov"
   gem "vcr"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,7 +270,6 @@ GEM
     hashdiff (1.0.1)
     hashie (4.1.0)
     high_voltage (3.1.2)
-    htmlentities (4.3.4)
     http (5.0.4)
       addressable (~> 2.8)
       http-cookie (~> 1.0)
@@ -480,10 +479,6 @@ GEM
       activerecord (>= 5.0)
       rgeo (>= 1.0.0)
     rollbar (3.3.0)
-    rspec (3.10.0)
-      rspec-core (~> 3.10.0)
-      rspec-expectations (~> 3.10.0)
-      rspec-mocks (~> 3.10.0)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.1)
@@ -500,9 +495,6 @@ GEM
       rspec-expectations (~> 3.10)
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
-    rspec-sonarqube-formatter (1.5.0)
-      htmlentities (~> 4.3.3)
-      rspec (~> 3.0)
     rspec-support (3.10.3)
     rubocop (1.23.0)
       parallel (~> 1.10)
@@ -741,7 +733,6 @@ DEPENDENCIES
   redis
   rollbar
   rspec-rails
-  rspec-sonarqube-formatter
   rubocop-performance
   rubocop-rails
   rubocop-rspec
@@ -750,7 +741,7 @@ DEPENDENCIES
   shoulda-matchers
   sidekiq
   sidekiq-cron
-  simplecov (<= 0.17.1)
+  simplecov
   skylight
   slim-rails
   slim_lint

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,0 @@
-sonar.coverage.exclusions=config/**/*,app/frontend/**/*,lib/tasks/**/*,spec/support/**/*,app/components/**/*.js,app/components/previews/**/*
-sonar.sourceEncoding=UTF-8
-sonar.sources=app,lib,config
-sonar.tests=spec
-sonar.ruby.file.suffixes=rb,ruby
-sonar.ruby.coverage.framework=RSpec


### PR DESCRIPTION
- Split up test suite into unit, system, and a11y tests and run them in
  parallel using a Github Actions matrix strategy
- Remove Sonarqube as it doesn't provide enough marginal benefit over
  our other static analysis tools