### PR TITLE
Disable Postgres AB test in test suite

### DIFF
--- a/config/ab_tests.yml
+++ b/config/ab_tests.yml
@@ -59,3 +59,6 @@ test:
   2021_11_desktop_search_results_page_test:
     present: 1
     right_column: 0
+  2021_12_new_search:
+    algolia: 1
+    postgres: 0


### PR DESCRIPTION
This is causing flaky tests as the results from Postgres in the system
specs are different from the VCR-stubbed Algolia ones.

The tests will need rewriting anyway when we remove all the Algolia
code.