### PR TITLE
Extract common action setup into custom action

### DIFF
--- a/.github/actions/prepare-app-env/action.yml
+++ b/.github/actions/prepare-app-env/action.yml
@@ -1,0 +1,55 @@
+name: Prepare application environment
+description: Performs setup steps common to jobs that need to run the application
+inputs:
+  skip-ruby:
+    description: Allows skipping Ruby setup for jobs where it isn't required
+    required: false
+    default: "false"
+  skip-node:
+    description: Allows skipping Node.js setup for jobs where it isn't required
+    required: false
+    default: "false"
+  node-version:
+    description: The version of Node.js to install
+    required: false
+    default: "12.x"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Ruby
+      if: ${{ inputs.skip-ruby == 'false' }}
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+
+    - name: Set up Node
+      if: ${{ inputs.skip-node == 'false' }}
+      uses: actions/setup-node@v2.5.0
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Install yarn
+      if: ${{ inputs.skip-node == 'false' }}
+      run: npm install yarn -g
+      shell: bash
+
+    - name: Yarn cache
+      if: ${{ inputs.skip-node == 'false' }}
+      id: yarn-cache
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+      shell: bash
+
+    - name: Set up yarn cache
+      if: ${{ inputs.skip-node == 'false' }}
+      uses: actions/cache@v2.1.7
+      with:
+        path: ${{ steps.yarn-cache.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+
+    - name: Install node.js dependencies
+      if: ${{ inputs.skip-node == 'false' }}
+      run: yarn install
+      shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+      - name: Prepare application environment
+        uses: ./.github/actions/prepare-app-env
         with:
-          bundler-cache: true
+          skip-node: true
 
       - name: Run Rubocop
         run: bundle exec rubocop
@@ -39,28 +39,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Set up Node
-        uses: actions/setup-node@v2.5.0
+      - name: Prepare application environment
+        uses: ./.github/actions/prepare-app-env
         with:
-          node-version: '12.x'
-
-      - name: Install yarn
-        run: npm install yarn -g
-
-      - name: Yarn cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Set up yarn cache
-        uses: actions/cache@v2.1.7
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Install node.js dependencies
-        run: yarn install
+          skip-ruby: true
 
       - name: Run SASS lint
         run: yarn run sass:lint && yarn run js:lint

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -26,15 +26,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-
-      - name: Set up Node
-        uses: actions/setup-node@v2.5.0
-        with:
-          node-version: '12.x'
+      - name: Prepare application environment
+        uses: ./.github/actions/prepare-app-env
 
       - name: set environment (scheduled smoke test)
         if: ${{ github.event_name == 'schedule' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,33 +52,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-
-      - name: Set up Node
-        uses: actions/setup-node@v2.5.0
-        with:
-          node-version: '12.x'
-
-      - name: Install yarn
-        run: npm install yarn -g
-
-      - name: Yarn cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Set up yarn cache
-        uses: actions/cache@v2.1.7
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Install node.js dependencies
-        run: yarn install
+      - name: Prepare application environment
+        uses: ./.github/actions/prepare-app-env
 
       - name: Set up test database
         run: bin/rails db:create db:schema:load
@@ -95,28 +70,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Set up Node
-        uses: actions/setup-node@v2.5.0
+      - name: Prepare application environment
+        uses: ./.github/actions/prepare-app-env
         with:
-          node-version: '12.x'
-
-      - name: Install yarn
-        run: npm install yarn -g
-
-      - name: Yarn cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Set up yarn cache
-        uses: actions/cache@v2.1.7
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Install node.js dependencies
-        run: yarn install
+          skip-ruby: true
 
       - name: run frontend tests and linting
         run: yarn run js:test


### PR DESCRIPTION
There is a lot of repetitive setup in our various testing and linting
jobs in Github Actions. This extracts this setup into a custom action
so all the logic is in one place and can be reused across jobs.