### PR TITLE
TEVA-3497 Use dynamic dates on applicant and job listing forms

### DIFF
--- a/app/views/jobseekers/job_applications/breaks/_fields.html.slim
+++ b/app/views/jobseekers/job_applications/breaks/_fields.html.slim
@@ -1,3 +1,7 @@
-= f.govuk_date_field :started_on, omit_day: true
-= f.govuk_date_field :ended_on, omit_day: true
+= f.govuk_date_field :started_on,
+  omit_day: true,
+  hint: -> { t("helpers.hint.jobseekers_job_application_details_break_form.started_on", date: 15.months.ago.strftime("%m %Y")) }
+= f.govuk_date_field :ended_on,
+  omit_day: true,
+  hint: -> { t("helpers.hint.jobseekers_job_application_details_break_form.ended_on", date: 3.months.ago.strftime("%m %Y")) }
 = f.govuk_text_area :reason_for_break, label: { size: "s" }, required: true

--- a/app/views/jobseekers/job_applications/breaks/_fields.html.slim
+++ b/app/views/jobseekers/job_applications/breaks/_fields.html.slim
@@ -1,7 +1,7 @@
 = f.govuk_date_field :started_on,
   omit_day: true,
-  hint: -> { t("helpers.hint.jobseekers_job_application_details_break_form.started_on", date: 15.months.ago.strftime("%m %Y")) }
+  hint: -> { t("helpers.hint.date", date: 15.months.ago.strftime("%m %Y")) }
 = f.govuk_date_field :ended_on,
   omit_day: true,
-  hint: -> { t("helpers.hint.jobseekers_job_application_details_break_form.ended_on", date: 3.months.ago.strftime("%m %Y")) }
+  hint: -> { t("helpers.hint.date", date: 3.months.ago.strftime("%m %Y")) }
 = f.govuk_text_area :reason_for_break, label: { size: "s" }, required: true

--- a/app/views/jobseekers/job_applications/employments/_fields.html.slim
+++ b/app/views/jobseekers/job_applications/employments/_fields.html.slim
@@ -1,9 +1,13 @@
 = f.govuk_text_field :organisation, label: { size: "s" }, required: true
 = f.govuk_text_field :job_title, label: { size: "s" }, required: true
 = f.govuk_text_field :subjects, label: { size: "s" }
-= f.govuk_date_field :started_on, omit_day: true
+= f.govuk_date_field :started_on,
+  omit_day: true,
+  hint: -> { t("helpers.hint.jobseekers_job_application_details_employment_form.started_on", date: 15.months.ago.strftime("%m %Y")) }
 = f.govuk_radio_buttons_fieldset :current_role do
   = f.govuk_radio_button :current_role, :yes, link_errors: true
   = f.govuk_radio_button :current_role, :no do
-    = f.govuk_date_field :ended_on, omit_day: true
+    = f.govuk_date_field :ended_on,
+      omit_day: true,
+      hint: -> { t("helpers.hint.jobseekers_job_application_details_employment_form.ended_on", date: 3.months.ago.strftime("%m %Y")) }
 = f.govuk_text_area :main_duties, label: { size: "s" }, required: true

--- a/app/views/jobseekers/job_applications/employments/_fields.html.slim
+++ b/app/views/jobseekers/job_applications/employments/_fields.html.slim
@@ -3,11 +3,11 @@
 = f.govuk_text_field :subjects, label: { size: "s" }
 = f.govuk_date_field :started_on,
   omit_day: true,
-  hint: -> { t("helpers.hint.jobseekers_job_application_details_employment_form.started_on", date: 15.months.ago.strftime("%m %Y")) }
+  hint: -> { t("helpers.hint.date", date: 15.months.ago.strftime("%m %Y")) }
 = f.govuk_radio_buttons_fieldset :current_role do
   = f.govuk_radio_button :current_role, :yes, link_errors: true
   = f.govuk_radio_button :current_role, :no do
     = f.govuk_date_field :ended_on,
       omit_day: true,
-      hint: -> { t("helpers.hint.jobseekers_job_application_details_employment_form.ended_on", date: 3.months.ago.strftime("%m %Y")) }
+      hint: -> { t("helpers.hint.date", date: 3.months.ago.strftime("%m %Y")) }
 = f.govuk_text_area :main_duties, label: { size: "s" }, required: true

--- a/app/views/publishers/vacancies/build/important_dates.html.slim
+++ b/app/views/publishers/vacancies/build/important_dates.html.slim
@@ -24,10 +24,10 @@
             = f.govuk_radio_button :publish_on_day, :tomorrow
             = f.govuk_radio_button :publish_on_day, :another_day do
               = f.govuk_date_field :publish_on,
-                hint: -> { t("helpers.hint.publishers_job_listing_important_dates_form.publish_on", date: 1.week.from_now.strftime("%d %m %Y")) }
+                hint: -> { t("helpers.hint.date", date: 1.week.from_now.strftime("%d %m %Y")) }
 
         = f.govuk_date_field :expires_at,
-          hint: -> { t("helpers.hint.publishers_job_listing_important_dates_form.expires_at", date: 1.month.from_now.strftime("%d %m %Y")) }
+          hint: -> { t("helpers.hint.date", date: 1.month.from_now.strftime("%d %m %Y")) }
 
         = f.govuk_collection_radio_buttons :expiry_time,
           Vacancy::EXPIRY_TIME_OPTIONS,
@@ -38,7 +38,7 @@
           = f.govuk_radio_button :starts_asap, "false", link_errors: true, label: { text: t("helpers.legend.publishers_job_listing_important_dates_form.start_date_specific") } do
             = f.govuk_date_field :starts_on,
               legend: { text: "Enter date" },
-              hint: -> { t("helpers.hint.publishers_job_listing_important_dates_form.starts_on", date: 2.months.from_now.strftime("%d %m %Y")) }
+              hint: -> { t("helpers.hint.date", date: 2.months.from_now.strftime("%d %m %Y")) }
           = f.govuk_radio_button :starts_asap, "true", class: "clear-form__checkbox", label: { text: t("helpers.legend.publishers_job_listing_important_dates_form.start_asap") }
 
         = render "publishers/vacancies/vacancy_form_partials/submit", f: f

--- a/app/views/publishers/vacancies/build/important_dates.html.slim
+++ b/app/views/publishers/vacancies/build/important_dates.html.slim
@@ -23,9 +23,11 @@
             = f.govuk_radio_button :publish_on_day, :today, link_errors: true
             = f.govuk_radio_button :publish_on_day, :tomorrow
             = f.govuk_radio_button :publish_on_day, :another_day do
-              = f.govuk_date_field :publish_on
+              = f.govuk_date_field :publish_on,
+                hint: -> { t("helpers.hint.publishers_job_listing_important_dates_form.publish_on", date: 1.week.from_now.strftime("%d %m %Y")) }
 
-        = f.govuk_date_field :expires_at
+        = f.govuk_date_field :expires_at,
+          hint: -> { t("helpers.hint.publishers_job_listing_important_dates_form.expires_at", date: 1.month.from_now.strftime("%d %m %Y")) }
 
         = f.govuk_collection_radio_buttons :expiry_time,
           Vacancy::EXPIRY_TIME_OPTIONS,
@@ -34,7 +36,9 @@
 
         = f.govuk_radio_buttons_fieldset :starts_asap, legend: { text: t("helpers.legend.publishers_job_listing_important_dates_form.starts_on") }, classes: "clear-form" do
           = f.govuk_radio_button :starts_asap, "false", link_errors: true, label: { text: t("helpers.legend.publishers_job_listing_important_dates_form.start_date_specific") } do
-            = f.govuk_date_field :starts_on, legend: { text: "Enter date" }
+            = f.govuk_date_field :starts_on,
+              legend: { text: "Enter date" },
+              hint: -> { t("helpers.hint.publishers_job_listing_important_dates_form.starts_on", date: 2.months.from_now.strftime("%d %m %Y")) }
           = f.govuk_radio_button :starts_asap, "true", class: "clear-form__checkbox", label: { text: t("helpers.legend.publishers_job_listing_important_dates_form.start_asap") }
 
         = render "publishers/vacancies/vacancy_form_partials/submit", f: f

--- a/app/views/publishers/vacancies/copy/new.html.slim
+++ b/app/views/publishers/vacancies/copy/new.html.slim
@@ -25,10 +25,10 @@
           = f.govuk_radio_button :publish_on_day, :tomorrow
           = f.govuk_radio_button :publish_on_day, :another_day do
             = f.govuk_date_field :publish_on,
-              hint: -> { t("helpers.hint.publishers_job_listing_copy_vacancy_form.publish_on", date: 1.week.from_now.strftime("%d %m %Y")) }
+              hint: -> { t("helpers.hint.date", date: 1.week.from_now.strftime("%d %m %Y")) }
 
         = f.govuk_date_field :expires_at,
-          hint: -> { t("helpers.hint.publishers_job_listing_copy_vacancy_form.expires_at", date: 1.month.from_now.strftime("%d %m %Y")) }
+          hint: -> { t("helpers.hint.date", date: 1.month.from_now.strftime("%d %m %Y")) }
 
         = f.govuk_collection_radio_buttons :expiry_time,
           Vacancy::EXPIRY_TIME_OPTIONS,
@@ -37,7 +37,7 @@
 
         .clear-form
           = f.govuk_date_field :starts_on,
-            hint: -> { t("helpers.hint.publishers_job_listing_copy_vacancy_form.starts_on", date: 2.months.from_now.strftime("%d %m %Y")) }
+            hint: -> { t("helpers.hint.date", date: 2.months.from_now.strftime("%d %m %Y")) }
 
           .clear-form__checkbox
             = f.govuk_check_box :starts_asap, "true", 0, multiple: false, link_errors: false

--- a/app/views/publishers/vacancies/copy/new.html.slim
+++ b/app/views/publishers/vacancies/copy/new.html.slim
@@ -24,9 +24,11 @@
           = f.govuk_radio_button :publish_on_day, :today, link_errors: true
           = f.govuk_radio_button :publish_on_day, :tomorrow
           = f.govuk_radio_button :publish_on_day, :another_day do
-            = f.govuk_date_field :publish_on
+            = f.govuk_date_field :publish_on,
+              hint: -> { t("helpers.hint.publishers_job_listing_copy_vacancy_form.publish_on", date: 1.week.from_now.strftime("%d %m %Y")) }
 
-        = f.govuk_date_field :expires_at
+        = f.govuk_date_field :expires_at,
+          hint: -> { t("helpers.hint.publishers_job_listing_copy_vacancy_form.expires_at", date: 1.month.from_now.strftime("%d %m %Y")) }
 
         = f.govuk_collection_radio_buttons :expiry_time,
           Vacancy::EXPIRY_TIME_OPTIONS,
@@ -34,7 +36,8 @@
           ->(option) { t("helpers.options.publishers_job_listing_extend_deadline_form.expiry_time.#{option}") }
 
         .clear-form
-          = f.govuk_date_field :starts_on
+          = f.govuk_date_field :starts_on,
+            hint: -> { t("helpers.hint.publishers_job_listing_copy_vacancy_form.starts_on", date: 2.months.from_now.strftime("%d %m %Y")) }
 
           .clear-form__checkbox
             = f.govuk_check_box :starts_asap, "true", 0, multiple: false, link_errors: false

--- a/app/views/publishers/vacancies/extend_deadline/show.html.slim
+++ b/app/views/publishers/vacancies/extend_deadline/show.html.slim
@@ -13,7 +13,8 @@
       = form_for form, url: organisation_job_extend_deadline_path(vacancy.id), method: :patch do |f|
         = f.govuk_error_summary
 
-        = f.govuk_date_field :expires_at
+        = f.govuk_date_field :expires_at,
+          hint: -> { t("helpers.hint.publishers_job_listing_extend_deadline_form.expires_at", date: 1.month.from_now.strftime("%d %m %Y")) }
 
         = f.govuk_collection_radio_buttons :expiry_time,
           Vacancy::EXPIRY_TIME_OPTIONS,
@@ -21,7 +22,8 @@
           ->(option) { t("helpers.options.publishers_job_listing_extend_deadline_form.expiry_time.#{option}") }
 
         .clear-form
-          = f.govuk_date_field :starts_on
+          = f.govuk_date_field :starts_on,
+            hint: -> { t("helpers.hint.publishers_job_listing_extend_deadline_form.starts_on", date: 2.months.from_now.strftime("%d %m %Y")) }
 
           .clear-form__checkbox
             = f.govuk_check_box :starts_asap, "true", 0, multiple: false, link_errors: false

--- a/app/views/publishers/vacancies/extend_deadline/show.html.slim
+++ b/app/views/publishers/vacancies/extend_deadline/show.html.slim
@@ -14,7 +14,7 @@
         = f.govuk_error_summary
 
         = f.govuk_date_field :expires_at,
-          hint: -> { t("helpers.hint.publishers_job_listing_extend_deadline_form.expires_at", date: 1.month.from_now.strftime("%d %m %Y")) }
+          hint: -> { t("helpers.hint.date", date: 1.month.from_now.strftime("%d %m %Y")) }
 
         = f.govuk_collection_radio_buttons :expiry_time,
           Vacancy::EXPIRY_TIME_OPTIONS,
@@ -23,7 +23,7 @@
 
         .clear-form
           = f.govuk_date_field :starts_on,
-            hint: -> { t("helpers.hint.publishers_job_listing_extend_deadline_form.starts_on", date: 2.months.from_now.strftime("%d %m %Y")) }
+            hint: -> { t("helpers.hint.date", date: 2.months.from_now.strftime("%d %m %Y")) }
 
           .clear-form__checkbox
             = f.govuk_check_box :starts_asap, "true", 0, multiple: false, link_errors: false

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -193,12 +193,12 @@ en:
         school_visits: Explain how a candidate can arrange a visit to the school (give a phone number if possible)
         trust_visits: Explain how a candidate can arrange a visit to the trust (give a phone number if possible)
       publishers_job_listing_copy_vacancy_form:
-        expires_at: For example, 01 05 2021
+        expires_at: For example, %{date}
         job_title: >-
           For secondary school roles include subject and, if relevant,
           level of seniority (‘Subject leader for science’, for example).
-        publish_on: For example, 01 01 2021
-        starts_on: For example, 01 09 2021
+        publish_on: For example, %{date}
+        starts_on: For example, %{date}
       publishers_job_listing_documents_form:
         documents_html: >-
           <p class="govuk-body">You can upload files such as a job description or person specification.</p>
@@ -209,16 +209,16 @@ en:
           <li>accessible for users with disabilities or impairments - <a class="govuk-link" target="_blank" href="https://www.gov.uk/guidance/publishing-accessible-documents#writing-accessible-documents">how to make documents accessible (opens in new tab)</a>.</li>
           </ul>
       publishers_job_listing_extend_deadline_form:
-        expires_at: For example, 01 05 2021
-        starts_on: For example, 01 09 2021
+        expires_at: For example, %{date}
+        starts_on: For example, %{date}
       publishers_job_listing_feedback_form:
         email: >-
           We'll only use this to tell you about opportunities to take part in user research that helps us improve
           Department for Education services.
       publishers_job_listing_important_dates_form:
-        expires_at: For example, 01 05 2021
-        publish_on: For example, 01 01 2021
-        starts_on: For example, 01 09 2021
+        expires_at: For example, %{date}
+        publish_on: For example, %{date}
+        starts_on: For example, %{date}
       publishers_job_listing_job_details_form:
         contract_type_duration: >-
           Contract length should be more than 12 weeks. Short term cover should not be advertised on Teaching Vacancies

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -93,6 +93,7 @@ en:
   helpers:
     optional_field_html: "%{label} (optional<span class='govuk-visually-hidden'> field</span>)"
     hint:
+      date: For example, %{date}
       general_feedback_form:
         comment_html: >-
           <p>Please do not include any information that could identify you personally
@@ -119,14 +120,10 @@ en:
           <a href="https://www.gov.uk/" target="_blank" class="govuk-link">GOV.UK website (opens in new tab)</a>. You can apply for this role even if you do not have the
           right to work in the UK.
       jobseekers_job_application_details_break_form:
-        ended_on: For example, %{date}
         reason_for_break: "For example, 'I was unemployed', 'I had health issues' or 'I was caring for a child'"
-        started_on: For example, %{date}
       jobseekers_job_application_details_employment_form:
-        ended_on: For example, %{date}
         main_duties: A very brief summary
         organisation: For a non-teaching job, tell us the name of the organisation you worked at
-        started_on: For example, %{date}
       jobseekers_job_application_details_qualifications_degree_form:
         institution: For example, a university or college
       jobseekers_job_application_details_reference_form:
@@ -193,12 +190,9 @@ en:
         school_visits: Explain how a candidate can arrange a visit to the school (give a phone number if possible)
         trust_visits: Explain how a candidate can arrange a visit to the trust (give a phone number if possible)
       publishers_job_listing_copy_vacancy_form:
-        expires_at: For example, %{date}
         job_title: >-
           For secondary school roles include subject and, if relevant,
           level of seniority (‘Subject leader for science’, for example).
-        publish_on: For example, %{date}
-        starts_on: For example, %{date}
       publishers_job_listing_documents_form:
         documents_html: >-
           <p class="govuk-body">You can upload files such as a job description or person specification.</p>
@@ -208,17 +202,10 @@ en:
           <li>smaller than 10 MB</li>
           <li>accessible for users with disabilities or impairments - <a class="govuk-link" target="_blank" href="https://www.gov.uk/guidance/publishing-accessible-documents#writing-accessible-documents">how to make documents accessible (opens in new tab)</a>.</li>
           </ul>
-      publishers_job_listing_extend_deadline_form:
-        expires_at: For example, %{date}
-        starts_on: For example, %{date}
       publishers_job_listing_feedback_form:
         email: >-
           We'll only use this to tell you about opportunities to take part in user research that helps us improve
           Department for Education services.
-      publishers_job_listing_important_dates_form:
-        expires_at: For example, %{date}
-        publish_on: For example, %{date}
-        starts_on: For example, %{date}
       publishers_job_listing_job_details_form:
         contract_type_duration: >-
           Contract length should be more than 12 weeks. Short term cover should not be advertised on Teaching Vacancies

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -119,14 +119,14 @@ en:
           <a href="https://www.gov.uk/" target="_blank" class="govuk-link">GOV.UK website (opens in new tab)</a>. You can apply for this role even if you do not have the
           right to work in the UK.
       jobseekers_job_application_details_break_form:
-        ended_on: For example, 01 2020
+        ended_on: For example, %{date}
         reason_for_break: "For example, 'I was unemployed', 'I had health issues' or 'I was caring for a child'"
-        started_on: For example, 01 2020
+        started_on: For example, %{date}
       jobseekers_job_application_details_employment_form:
-        ended_on: For example, 01 2020
+        ended_on: For example, %{date}
         main_duties: A very brief summary
         organisation: For a non-teaching job, tell us the name of the organisation you worked at
-        started_on: For example, 01 2020
+        started_on: For example, %{date}
       jobseekers_job_application_details_qualifications_degree_form:
         institution: For example, a university or college
       jobseekers_job_application_details_reference_form:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3683,11 +3683,6 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-es6-promise@^4.2.8:
-  version "4.2.8"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
-  integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
-
 escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"


### PR DESCRIPTION
In addition to the two places described in the ticket, I also made this change to the "break in employment" applicant form, and the "copy job" & "extend deadline" job listing forms.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3497

## Screenshots of UI changes:

### Employment history

<img width="409" alt="Screenshot 2021-12-02 at 16 43 50" src="https://user-images.githubusercontent.com/109225/144469414-a7d1f32a-5ddc-44ef-a4db-9d5f08c84c6e.png">

### Employment breaks

<img width="422" alt="Screenshot 2021-12-02 at 16 50 09" src="https://user-images.githubusercontent.com/109225/144469458-f5e1c191-f174-4f03-8f4b-8ca1027636d1.png">

### Create job listing

<img width="451" alt="Screenshot 2021-12-02 at 17 04 38" src="https://user-images.githubusercontent.com/109225/144469567-f7564913-f49c-469b-b344-15b52e6c726a.png">
<img width="570" alt="Screenshot 2021-12-02 at 17 04 42" src="https://user-images.githubusercontent.com/109225/144469582-5795f435-9216-4397-8382-82f942e00f68.png">

### Copy job listing

<img width="580" alt="Screenshot 2021-12-02 at 16 58 47" src="https://user-images.githubusercontent.com/109225/144469627-2bc89276-3867-454b-b4fb-4cc652d306e4.png">
<img width="492" alt="Screenshot 2021-12-02 at 16 58 52" src="https://user-images.githubusercontent.com/109225/144469630-2f7d9778-561f-4b3b-8616-2118aba166b4.png">

### Extend deadline

<img width="569" alt="Screenshot 2021-12-02 at 17 02 03" src="https://user-images.githubusercontent.com/109225/144469697-78928578-04c2-4cd9-82b9-ff954ebcdab0.png">
<img width="453" alt="Screenshot 2021-12-02 at 17 02 07" src="https://user-images.githubusercontent.com/109225/144469702-71f710cd-95da-4b12-92da-b4739e94ed6c.png">
