### PR TITLE
Fix (hopefully) flaky `BaseForm` spec

### DIFF
--- a/spec/form_models/base_form_spec.rb
+++ b/spec/form_models/base_form_spec.rb
@@ -1,18 +1,17 @@
 require "rails_helper"
 
-RSpec.describe BaseForm, type: :model do
+class FakeFormForBaseFormSpec < BaseForm
+  attr_accessor :some_field
+
+  validates :some_field, presence: true
+end
+
+RSpec.describe FakeFormForBaseFormSpec, type: :model do
   describe "#send_errors_to_big_query" do
-    let(:form) { Publishers::JobListing::JobDetailsForm.new }
-    let(:event) { instance_double(Event) }
-    let(:event_data) { { form_name: "publishers/job_listing/job_details_form", job_title: :blank, contract_type: :inclusion } }
-
-    before do
-      expect(Event).to receive(:new).and_return(event)
-      expect(event).to receive(:trigger).with(:form_validation_failed, event_data)
-    end
-
     it "sends errors to BigQuery" do
-      form.validate
+      expect { subject.validate }
+        .to have_triggered_event(:form_validation_failed)
+        .with_data(form_name: "fake_form_for_base_form_spec", some_field: "blank")
     end
   end
 end


### PR DESCRIPTION
- Replace test of real form inheriting from `BaseForm` with a fake form
  to decouple from future implementation changes
- Use `have_triggered_event` matcher