### PR TITLE
Update synonyms.yml

### DIFF
--- a/config/search/synonyms.yml
+++ b/config/search/synonyms.yml
@@ -89,6 +89,7 @@
   - assistant head
   - assistant headteacher
 -
+  - a level
   - alevel
   - a-level
   - ks5


### PR DESCRIPTION
The most common spelling of A Level was absent
