### PR TITLE
[TEVA-3442] Convert form.js to use Stimulus

### DIFF
--- a/app/components/filters_component/filters_component.html.slim
+++ b/app/components/filters_component/filters_component.html.slim
@@ -37,7 +37,8 @@
           group[:text_method],
           small: group[:small],
           legend: { text: group[:legend], size: (group[:small] ? "s" : "m") },
-          hint: nil
+          hint: nil,
+          form_group: { data: { action: "change->form#submitListener" } }
 
   .filters-component__submit
     = form.govuk_submit t("buttons.apply_filters"), classes: "govuk-!-margin-top-4 govuk-!-margin-bottom-2 filters-component__submit-button"

--- a/app/components/filters_component/filters_component.js
+++ b/app/components/filters_component/filters_component.js
@@ -49,12 +49,12 @@ export const init = (removeButtonSelector, clearButtonId) => {
 };
 
 const mobileFiltersBehaviour = (filtersEl) => {
-  filtersEl.closest('form').removeAttribute('data-auto-submit');
+  filtersEl.closest('form').removeAttribute('data-controller');
   filtersEl.setAttribute('tabindex', '-1');
 };
 
 const desktopFiltersBehaviour = (filtersEl) => {
-  filtersEl.closest('form').setAttribute('data-auto-submit', 'true');
+  filtersEl.closest('form').setAttribute('data-controller', 'form');
   filtersEl.removeAttribute('tabindex');
 };
 

--- a/app/components/filters_component/filters_component.test.js
+++ b/app/components/filters_component/filters_component.test.js
@@ -34,7 +34,7 @@ describe('filterGroup', () => {
       filterGroup.addRemoveAllFiltersEvent = jest.fn();
       const addRemoveAllFiltersEventMock = jest.spyOn(filterGroup, 'addRemoveAllFiltersEvent');
 
-      document.body.innerHTML = `<form data-auto-submit="true"><div class='filters-component'>
+      document.body.innerHTML = `<form data-controller="form"><div class='filters-component'>
 <h2 id="filters-component-show-mobile"></h2>
 <button class="${REMOVE_FILTER_CLASS_SELECTOR}">remove</button>
 <button class="${REMOVE_FILTER_CLASS_SELECTOR}">remove</button>

--- a/app/components/publishers/vacancies_component/vacancies_component.html.slim
+++ b/app/components/publishers/vacancies_component/vacancies_component.html.slim
@@ -11,7 +11,7 @@
     .govuk-grid-row
       - if @organisation.school_group?
         .govuk-grid-column-one-third class="govuk-!-margin-bottom-5"
-          = form_for @publisher_preference, html: { data: { "auto-submit": true, "hide-submit": true } } do |f|
+          = form_for @publisher_preference, html: { data: { controller: "form", "hide-submit": true } } do |f|
             = render(FiltersComponent.new(filters: { total_count: @publisher_preference.organisations.count,
                                                               title: t("jobs.filters.job_filters") },
                                                               form: f,
@@ -35,12 +35,13 @@
 
       .vacancies-component__content class=grid_column_class
         - if @vacancies.any?
-          = form_for @sort_form, as: "", url: jobs_with_type_organisation_path(@selected_type), method: :get, data: { "auto-submit": true, "hide-submit": true } do |f|
+          = form_for @sort_form, as: "", url: jobs_with_type_organisation_path(@selected_type), method: :get, data: { controller: "form", "hide-submit": true } do |f|
             = f.govuk_collection_select :sort_column,
               vacancy_sort_options,
               :column,
               :display_name,
-              label: { text: t("jobs.sort_by.label"), size: "s", class: "govuk-label inline govuk-!-margin-right-2" }
+              label: { text: t("jobs.sort_by.label"), size: "s", class: "govuk-label inline govuk-!-margin-right-2" },
+              data: { action: "change->form#submitListener" }
 
             = f.govuk_submit t("jobs.sort_by.submit")
         section#vacancy-results

--- a/app/frontend/src/application.js
+++ b/app/frontend/src/application.js
@@ -7,6 +7,7 @@ import PanelController from '../../components/panel_component/panel';
 // js components
 import AutocompleteController from './components/autocomplete/autocomplete';
 import ClipboardController from './components/clipboard/clipboard';
+import FormController from './components/form/form';
 import LocationFinderController from './components/locationFinder/locationFinder';
 import ManageQualificationsController from './components/manageQualifications/manageQualifications';
 import UploadDocumentsController from './components/uploadDocuments/uploadDocuments';
@@ -20,6 +21,7 @@ window.Stimulus = application;
 
 application.register('autocomplete', AutocompleteController);
 application.register('clipboard', ClipboardController);
+application.register('form', FormController);
 application.register('location-finder', LocationFinderController);
 application.register('manage-qualifications', ManageQualificationsController);
 application.register('panel', PanelController);

--- a/app/frontend/src/application/init.js
+++ b/app/frontend/src/application/init.js
@@ -1,2 +1,1 @@
-import '../components/form/form';
 import './jobseekers/map';

--- a/app/frontend/src/components/form/form.js
+++ b/app/frontend/src/components/form/form.js
@@ -1,73 +1,42 @@
-export const CHECKBOX_CLASS = 'govuk-checkboxes__input';
-export const RADIO_CLASS = 'govuk-radios__input';
-export const SELECT_CLASS = 'govuk-select';
-export const CLEARFORM_CLASS = 'clear-form';
-export const AUTOSUBMIT_ATTR_KEY = 'auto-submit';
+import { Controller } from '@hotwired/stimulus';
 
-document.addEventListener('DOMContentLoaded', () => {
-  initClearForm();
-  initAutoSubmit();
-});
+export default class extends Controller {
+  static targets = ['inputText'];
 
-export const initClearForm = () => {
-  Array.from(document.getElementsByClassName(CLEARFORM_CLASS)).forEach((clearFormEl) => {
-    Array.from(clearFormEl.querySelectorAll(`.${RADIO_CLASS}, .${CHECKBOX_CLASS}`)).forEach((controlEl) => {
-      controlEl.addEventListener('click', (event) => {
-        form.checkboxClickHandler(clearFormEl, event.target.checked);
-      });
-    });
-  });
-};
-
-export const initAutoSubmit = () => {
-  Array.from(document.querySelectorAll(`[data-${AUTOSUBMIT_ATTR_KEY}="true"]`)).forEach((formEl) => {
-    Array.from(formEl.querySelectorAll(`.${SELECT_CLASS}, .${CHECKBOX_CLASS}`)).forEach((el) => {
-      el.addEventListener('change', (e) => {
-        if (e.target.dataset.changeSubmit !== 'false') {
-          form.formSubmit(e.target.closest('form'));
-        }
-      });
-    });
-  });
-};
-
-export const formSubmit = (formEl) => {
-  if (formEl.dataset.autoSubmit) {
-    formEl.submit();
+  submitListener(e) {
+    this.formEl = e.target;
+    this.submitHandler();
   }
-};
 
-export const disableInputs = (inputs) => {
-  inputs.forEach((input) => {
-    input.value = '';
-  });
-};
-
-export const enableInputs = (inputs) => {
-  inputs.forEach((input) => {
-    input.disabled = false;
-    input.value = input.getAttribute('value');
-  });
-};
-
-export const checkboxClickHandler = (element, checked) => {
-  const fields = Array.from(element.querySelectorAll('input[type="text"]'));
-  if (checked) {
-    form.disableInputs(fields);
-  } else {
-    form.enableInputs(fields);
+  submitHandler() {
+    this.formEl.closest('form').submit();
   }
-};
 
-const form = {
-  disableInputs,
-  enableInputs,
-  checkboxClickHandler,
-  formSubmit,
-  CHECKBOX_CLASS,
-  SELECT_CLASS,
-  CLEARFORM_CLASS,
-  AUTOSUBMIT_ATTR_KEY,
-};
+  clearListener(e) {
+    this.inputTextTargets.forEach((inputTextTarget) => {
+      this.clearHandler(inputTextTarget, e.target.checked);
+    });
+  }
 
-export default form;
+  clearHandler(el, checked) {
+    this.fields = Array.from(el.querySelectorAll('input[type="text"]'));
+    if (checked) {
+      this.disableInputs();
+    } else {
+      this.enableInputs();
+    }
+  }
+
+  enableInputs() {
+    this.fields.forEach((input) => {
+      input.disabled = false;
+      input.value = input.getAttribute('value');
+    });
+  }
+
+  disableInputs() {
+    this.fields.forEach((input) => {
+      input.value = '';
+    });
+  }
+}

--- a/app/frontend/src/styles/application/form.scss
+++ b/app/frontend/src/styles/application/form.scss
@@ -76,7 +76,7 @@
 }
 
 .js-enabled {
-  form[data-auto-submit='true'][data-hide-submit='true'] {
+  form[data-controller='form'][data-hide-submit='true'] {
     .govuk-button {
       display: none;
     }

--- a/app/views/jobseekers/saved_jobs/index.html.slim
+++ b/app/views/jobseekers/saved_jobs/index.html.slim
@@ -14,13 +14,14 @@
   - if saved_jobs.any?
     .govuk-grid-row class="govuk-!-margin-top-0"
       .govuk-grid-column-full
-        = form_for sort_form, as: "", url: jobseekers_saved_jobs_path, method: :get, data: { "auto-submit": true, "hide-submit": true } do |f|
+        = form_for sort_form, as: "", url: jobseekers_saved_jobs_path, method: :get, data: { controller: "form", "hide-submit": true } do |f|
           = f.govuk_collection_select :sort_column,
             sort,
             :column,
             :display_name,
             label: { text: t("jobs.sort_by.label"), size: "s", class: "govuk-label inline govuk-!-margin-right-2" },
-            form_group: { classes: "govuk-!-margin-bottom-2" }
+            form_group: { classes: "govuk-!-margin-bottom-2" },
+            data: { action: "change->form#submitListener" }
 
           = f.govuk_submit t("jobs.sort_by.submit")
 

--- a/app/views/jobseekers/subscriptions/index.html.slim
+++ b/app/views/jobseekers/subscriptions/index.html.slim
@@ -14,13 +14,14 @@
   - if subscriptions.any?
     .govuk-grid-row class="govuk-!-margin-top-0"
       .govuk-grid-column-two-thirds
-        = form_for sort_form, as: "", url: jobseekers_subscriptions_path, method: :get, data: { "auto-submit": true, "hide-submit": true } do |f|
+        = form_for sort_form, as: "", url: jobseekers_subscriptions_path, method: :get, data: { controller: "form", "hide-submit": true } do |f|
           = f.govuk_collection_select :sort_column,
             sort,
             :column,
             :display_name,
             label: { text: t("jobs.sort_by.label"), size: "s", class: "govuk-label inline govuk-!-margin-right-2" },
-            form_group: { classes: "govuk-!-margin-bottom-2" }
+            form_group: { classes: "govuk-!-margin-bottom-2" },
+            data: { action: "change->form#submitListener" }
 
           = f.govuk_submit t("jobs.sort_by.submit")
 

--- a/app/views/publishers/vacancies/build/important_dates.html.slim
+++ b/app/views/publishers/vacancies/build/important_dates.html.slim
@@ -34,12 +34,13 @@
           ->(option) { option },
           ->(option) { t("helpers.options.publishers_job_listing_extend_deadline_form.expiry_time.#{option}") }
 
-        = f.govuk_radio_buttons_fieldset :starts_asap, legend: { text: t("helpers.legend.publishers_job_listing_important_dates_form.starts_on") }, classes: "clear-form" do
+        = f.govuk_radio_buttons_fieldset :starts_asap, legend: { text: t("helpers.legend.publishers_job_listing_important_dates_form.starts_on") }, classes: "clear-form", form_group: { data: { controller: "form" } } do
           = f.govuk_radio_button :starts_asap, "false", link_errors: true, label: { text: t("helpers.legend.publishers_job_listing_important_dates_form.start_date_specific") } do
             = f.govuk_date_field :starts_on,
               legend: { text: "Enter date" },
-              hint: -> { t("helpers.hint.date", date: 2.months.from_now.strftime("%d %m %Y")) }
-          = f.govuk_radio_button :starts_asap, "true", class: "clear-form__checkbox", label: { text: t("helpers.legend.publishers_job_listing_important_dates_form.start_asap") }
+              hint: -> { t("helpers.hint.date", date: 2.months.from_now.strftime("%d %m %Y")) },
+              data: { "form-target": "inputText" }
+          = f.govuk_radio_button :starts_asap, "true", class: "clear-form__checkbox", label: { text: t("helpers.legend.publishers_job_listing_important_dates_form.start_asap") }, data: { action: "click->form#clearListener" }
 
         = render "publishers/vacancies/vacancy_form_partials/submit", f: f
 

--- a/app/views/publishers/vacancies/copy/new.html.slim
+++ b/app/views/publishers/vacancies/copy/new.html.slim
@@ -35,12 +35,14 @@
           ->(option) { option },
           ->(option) { t("helpers.options.publishers_job_listing_extend_deadline_form.expiry_time.#{option}") }
 
-        .clear-form
+        .clear-form data-controller="form"
           = f.govuk_date_field :starts_on,
-            hint: -> { t("helpers.hint.date", date: 2.months.from_now.strftime("%d %m %Y")) }
+            hint: -> { t("helpers.hint.date", date: 2.months.from_now.strftime("%d %m %Y")) },
+            data: { "form-target": "inputText" }
 
           .clear-form__checkbox
-            = f.govuk_check_box :starts_asap, "true", 0, multiple: false, link_errors: false
+            = f.govuk_check_box :starts_asap, "true", 0, multiple: false, link_errors: false,
+            data: { action: "click->form#clearListener" }
 
         = f.govuk_submit classes: "govuk-!-margin-bottom-5"
 

--- a/app/views/publishers/vacancies/extend_deadline/show.html.slim
+++ b/app/views/publishers/vacancies/extend_deadline/show.html.slim
@@ -21,12 +21,14 @@
           ->(option) { option },
           ->(option) { t("helpers.options.publishers_job_listing_extend_deadline_form.expiry_time.#{option}") }
 
-        .clear-form
+        .clear-form data-controller="form"
           = f.govuk_date_field :starts_on,
-            hint: -> { t("helpers.hint.date", date: 2.months.from_now.strftime("%d %m %Y")) }
+            hint: -> { t("helpers.hint.date", date: 2.months.from_now.strftime("%d %m %Y")) },
+            data: { "form-target": "inputText" }
 
           .clear-form__checkbox
-            = f.govuk_check_box :starts_asap, "true", 0, multiple: false, link_errors: false
+            = f.govuk_check_box :starts_asap, "true", 0, multiple: false, link_errors: false,
+            data: { action: "click->form#clearListener" }
 
         = f.govuk_submit t("buttons.extend_deadline"), classes: "govuk-!-margin-bottom-5"
 

--- a/app/views/publishers/vacancies/job_applications/index.html.slim
+++ b/app/views/publishers/vacancies/job_applications/index.html.slim
@@ -5,13 +5,14 @@
 - if vacancy.within_data_access_period? && job_applications.any?
   .govuk-grid-row class="govuk-!-margin-top-7"
     .govuk-grid-column-full
-      = form_for sort_form, as: "", url: organisation_job_job_applications_path(vacancy.id), method: :get, data: { "auto-submit": true, "hide-submit": true } do |f|
+      = form_for sort_form, as: "", url: organisation_job_job_applications_path(vacancy.id), method: :get, data: { controller: "form", "hide-submit": true } do |f|
         = f.govuk_collection_select :sort_column,
           sort,
           :column,
           :display_name,
           label: { text: t("jobs.sort_by.label"), size: "s", class: "govuk-label inline govuk-!-margin-right-2" },
-          selected: :last
+          selected: :last,
+          data: { action: "change->form#submitListener" }
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/app/views/vacancies/_sorting_options.html.slim
+++ b/app/views/vacancies/_sorting_options.html.slim
@@ -1,4 +1,4 @@
-= form_for @form, as: "", url: jobs_path, method: :get, html: { id: "sorting-options-form", data: { "auto-submit": true, "hide-submit": true } } do |f|
+= form_for @form, as: "", url: jobs_path, method: :get, html: { id: "sorting-options-form", data: { controller: "form", "hide-submit": true } } do |f|
   = f.hidden_field :keyword, value: @form.keyword
   = f.hidden_field :location, value: @form.location
   = f.hidden_field :radius, value: @form.radius
@@ -14,7 +14,8 @@
       label: { text: t("jobs.sort_by.label"), size: "s", class: "govuk-label govuk-!-margin-right-2", id: "jobs_sort_label" },
       form_group: { classes: "govuk-!-margin-bottom-0" },
       class: %w[govuk-input--width-10],
-      disabled: @vacancies.none?
+      disabled: @vacancies.none?,
+      data: { action: "change->form#submitListener" }
 
     = f.govuk_submit t("jobs.sort_by.submit"),
       classes: "govuk-button govuk-!-margin-0 govuk-input--width-5",

--- a/app/views/vacancies/index.html.slim
+++ b/app/views/vacancies/index.html.slim
@@ -10,11 +10,11 @@
 
   .grid-row
     .grid-column-left class="govuk-!-margin-bottom-3"
-      = form_for @form, as: "", url: jobs_path, method: :get, html: { id: "filter-form", data: { "auto-submit": true }, class: "filters-form", role: "search", aria: { label: "Filter criteria" } } do |f|
+      = form_for @form, as: "", url: jobs_path, method: :get, html: { id: "filter-form", data: { controller: "form" }, class: "filters-form", role: "search", aria: { label: "Filter criteria" } } do |f|
         = render "search", f: f
     .grid-column-right
       - if current_variant?(:"2021_11_desktop_search_results_page_test", :right_column)
-        = form_for @form, as: "", url: jobs_path, method: :get, html: { id: "search-form", data: { "auto-submit": true }, class: "filters-form", role: "search", aria: { label: "Search criteria" } } do |f|
+        = form_for @form, as: "", url: jobs_path, method: :get, html: { id: "search-form", class: "filters-form", role: "search", aria: { label: "Search criteria" } } do |f|
           .search-results__header.search-results__header--border
             h2.govuk-heading-m = t("jobs.search.title")
             = render "shared/search/keyword", f: f


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3442

## Changes in this PR:

This PR converts form.js to use Stimulus - the auto submit and form clear functionality are now implemented using methods on a Stimulus controller in form.js and data-* attributes in the views. The jest tests have been updated.