### PR TITLE
Reinstate sorting options for mobile vacancies index

### DIFF
--- a/app/frontend/src/styles/application/jobseekers/search-header.scss
+++ b/app/frontend/src/styles/application/jobseekers/search-header.scss
@@ -24,7 +24,7 @@
       display: none;
     }
   }
-  
+
   &-stats {
     @include govuk-media-query($from: tablet) {
       order: 2;
@@ -48,11 +48,5 @@
     .govuk-label {
       display: inline;
     }
-  }
-}
-
-.grid-column-right .search-results__header {
-  @include govuk-media-query($until: desktop) {
-    display: none;
   }
 }

--- a/app/frontend/src/styles/base/_utilities.scss
+++ b/app/frontend/src/styles/base/_utilities.scss
@@ -1,3 +1,9 @@
+.desktop-only {
+  @include govuk-media-query($until: desktop) {
+    display: none !important;
+  }
+}
+
 input.button-as-link {
   background: none;
   border: 0;

--- a/app/views/vacancies/index.html.slim
+++ b/app/views/vacancies/index.html.slim
@@ -15,7 +15,7 @@
     .grid-column-right
       - if current_variant?(:"2021_11_desktop_search_results_page_test", :right_column)
         = form_for @form, as: "", url: jobs_path, method: :get, html: { id: "search-form", data: { "auto-submit": true }, class: "filters-form", role: "search", aria: { label: "Search criteria" } } do |f|
-          .search-results__header.search-results__header--border
+          .search-results__header.search-results__header--border.desktop-only
             h2.govuk-heading-m = t("jobs.search.title")
             = render "shared/search/keyword", f: f
             = render "shared/search/location", show_hint: false, desktop: true, f: f


### PR DESCRIPTION
We lost the sorting options for mobile view of the main search page on 16 Nov when
we introduced an A/B test on the desktop without checking the impact on mobile:

https://github.com/DFE-Digital/teaching-vacancies/pull/4276

This happened because a css style had a selector that captured two elements when it
was only meant to capture one. I have abstracted the display: none style to a utility
class so it can be directly applied to only the element that needs it.

I have tested all 8 possible permutations of:

- mobile/desktop views
- both A/B test variants of 2021_10_mobile_search_panel_test
- both A/B test variants of 2021_11_desktop_search_results_page_test
