### PR TITLE
Sign in users the first time they follow the account confirmation link

### DIFF
--- a/app/controllers/jobseekers/confirmations_controller.rb
+++ b/app/controllers/jobseekers/confirmations_controller.rb
@@ -1,12 +1,44 @@
 class Jobseekers::ConfirmationsController < Devise::ConfirmationsController
   after_action :remove_devise_flash!, only: %i[create]
 
+  def show
+    super { |jobseeker| skip_errors_when_already_confirmed(jobseeker) }
+  end
+
   protected
 
-  def after_confirmation_path_for(resource_name, resource)
-    sign_in(resource)
-    request_event.trigger(:jobseeker_email_confirmed)
-    stored_location_for(resource_name) || jobseeker_root_path
+  # Skip dead-end 'Your request is no longer valid' page when account is already confirmed
+  #
+  # We have a hypothesis that email clients automatically click confirmation links before users get to them
+  # in order to preload the images, and that this may be the reason some users always see the error page.
+  def skip_errors_when_already_confirmed(jobseeker)
+    return unless jobseeker.errors.added?(:email, :already_confirmed)
+
+    jobseeker.errors.delete(:email, :already_confirmed)
+    session[:require_auth_after_confirming] = true
+  end
+
+  def after_confirmation_path_for(resource_name, _resource)
+    sign_in_on_first_confirmation
+    if signed_in?(resource_name)
+      stored_location_for(resource_name) || jobseeker_root_path
+    else
+      new_session_path(resource_name)
+    end
+  end
+
+  # Sign in users the first time they follow the account confirmation link
+  #
+  # Prevent account confirmation links in emails from becoming everlasting password-equivalents
+  # by requiring users to authenticate if the link is followed again.
+  def sign_in_on_first_confirmation
+    if session.delete(:require_auth_after_confirming) == true
+      # Track whether we need this custom code or not
+      request_event.trigger(:jobseeker_email_confirmed_redundantly, jobseeker_id: StringAnonymiser.new(resource.id))
+    else
+      sign_in(resource)
+      request_event.trigger(:jobseeker_email_confirmed)
+    end
   end
 
   def after_resending_confirmation_instructions_path_for(_resource)

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -1,7 +1,7 @@
 en:
   devise:
     confirmations:
-      confirmed: Welcome to your Teaching Vacancies account
+      confirmed: Your Teaching Vacancies account has been verified
       send_instructions: You will receive an email with instructions for how to confirm your email address in a few minutes.
       send_paranoid_instructions: If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes.
     failure:

--- a/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Jobseekers can sign up to an account" do
     end
 
     context "when the confirmation token is valid" do
-      it "confirms email, triggers email confirmed event and redirects to jobseeker saved jobs page" do
+      it "confirms email, triggers email confirmed event, signs in the user, and redirects to jobseeker root page" do
         expect { visit first_link_from_last_mail }.to have_triggered_event(:jobseeker_email_confirmed).with_base_data(
           user_anonymised_jobseeker_id: StringAnonymiser.new(created_jobseeker.id).to_s,
         )
@@ -48,6 +48,19 @@ RSpec.describe "Jobseekers can sign up to an account" do
         it "resends confirmation email and redirects to check your email page" do
           expect { resend_confirmation_email }.to change { delivered_emails.count }.by(1)
           expect(current_path).to eq(jobseekers_check_your_email_path)
+        end
+      end
+    end
+
+    context "when the confirmation link is followed after the account has already been confirmed" do
+      before { created_jobseeker.confirm }
+
+      it "redirects the user to authenticate" do
+        visit first_link_from_last_mail
+        expect(current_path).to eq(new_jobseeker_session_path)
+        expect(page).to have_content(I18n.t("devise.confirmations.confirmed"))
+        within("#navigation") do
+          expect(page).to have_content(I18n.t("buttons.sign_in"))
         end
       end
     end


### PR DESCRIPTION
Rethinking the approach in https://github.com/DFE-Digital/teaching-vacancies/pull/4318 - feel free to read that for context.

Regarding the POST button option, it ended up looking very gnarly code-wise and I wasn’t happy with the level of time needed to build / maintain the departure from Devise, all for this specific scenario.

It occurred to me that we can make my original proposal more secure by, instead of signing the user in (when they follow a link for an already-confirmed account), forwarding them to the sign in page. This will be subject to review by product people.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3446

## Changes in this PR:

The first time a user follows the account confirmation link, sign them in and skip dead-end 'Your request is no longer valid' page when account is already confirmed

We have a hypothesis that email clients automatically click confirmation links before users get to them
in order to preload the images, and that this may be the reason some users always see the error page.

Prevent account confirmation links in emails from becoming everlasting password-equivalents
by requiring users to authenticate if the link is followed again.

This solution will allow users to sign up successfully if suffering from a BingPreview style
bot that is overly eager to confirm their account on their behalf, without departing too far
from Devise's defaults (i.e. still using a GET request for the confirmations controller's
'show' action)

## Screenshots of UI changes

### Before

#### Second time following confirmation link

<img width="734" alt="Screenshot 2021-12-08 at 11 47 38" src="https://user-images.githubusercontent.com/60350599/145203429-bbd9df0d-fdb0-4325-a47a-e9d90459fdcf.png">

### After

#### First time following confirmation link

<img width="1215" alt="Screenshot 2021-12-08 at 11 43 55" src="https://user-images.githubusercontent.com/60350599/145203469-f56baa63-09c7-4f59-8116-01047295c53d.png">

#### Second time following confirmation link

<img width="1215" alt="Screenshot 2021-12-08 at 11 46 24" src="https://user-images.githubusercontent.com/60350599/145203492-d975297d-550b-412a-be27-739923bc1a0e.png">


