### PR TITLE
Switch over to Postgres search for `VacancySearch`

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -8,7 +8,6 @@ class VacanciesController < ApplicationController
       search_form.to_hash,
       sort_by: search_form.jobs_sort,
       page: params[:page],
-      pg_search: current_variant?(:"2021_12_new_search", :postgres),
     )
     @vacancies = VacanciesPresenter.new(@vacancies_search.vacancies)
   end

--- a/config/ab_tests.yml
+++ b/config/ab_tests.yml
@@ -39,9 +39,6 @@ shared:
   2021_11_desktop_search_results_page_test:
     present: 1
     right_column: 1
-  2021_12_new_search:
-    algolia: 1
-    postgres: 1
 test:
   2021_04_cookie_consent_test:
     none: 0
@@ -59,6 +56,3 @@ test:
   2021_11_desktop_search_results_page_test:
     present: 1
     right_column: 0
-  2021_12_new_search:
-    algolia: 0
-    postgres: 1


### PR DESCRIPTION
This is the first step towards getting rid of Algolia, with many more
to follow.

- Remove use of `Algolia` and `Database` search strategies in
  `VacancySearch` in favour of always using `PgSearch`
- End AB test of Postgres vs Algolia