### PR TITLE
Stop using Algolia for all searches

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -8,7 +8,6 @@ class VacanciesController < ApplicationController
       search_form.to_hash,
       sort_by: search_form.jobs_sort,
       page: params[:page],
-      pg_search: current_variant?(:"2021_12_new_search", :postgres),
     )
     @vacancies = VacanciesPresenter.new(@vacancies_search.vacancies)
   end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -37,7 +37,7 @@ class Subscription < ApplicationRecord
 
   def vacancies_for_range(date_from, date_to)
     criteria = search_criteria.symbolize_keys.merge(from_date: date_from, to_date: date_to)
-    Search::VacancySearch.new(criteria, per_page: MAXIMUM_RESULTS_PER_RUN, fuzzy: false).vacancies
+    Search::VacancySearch.new(criteria, per_page: MAXIMUM_RESULTS_PER_RUN).vacancies
   end
 
   def alert_run_today

--- a/app/services/search/vacancy_search.rb
+++ b/app/services/search/vacancy_search.rb
@@ -6,17 +6,15 @@ class Search::VacancySearch
   def_delegators :search_strategy, :vacancies, :total_count
   def_delegators :location_search, :point_coordinates
 
-  attr_reader :search_criteria, :keyword, :sort_by, :page, :per_page, :fuzzy, :pg_search
+  attr_reader :search_criteria, :keyword, :sort_by, :page, :per_page
 
-  def initialize(search_criteria, sort_by: nil, page: nil, per_page: nil, fuzzy: true, pg_search: false)
+  def initialize(search_criteria, sort_by: nil, page: nil, per_page: nil)
     @search_criteria = search_criteria
     @keyword = search_criteria[:keyword]
 
     @sort_by = sort_by || Search::VacancySearchSort::RELEVANCE
     @per_page = (per_page || DEFAULT_HITS_PER_PAGE).to_i
     @page = (page || DEFAULT_PAGE).to_i
-    @fuzzy = fuzzy
-    @pg_search = pg_search
   end
 
   def active_criteria
@@ -57,16 +55,7 @@ class Search::VacancySearch
   private
 
   def search_strategy
-    @search_strategy ||= if active_criteria?
-                           Search::Strategies::Experiment.new(
-                             Search::Strategies::Algolia.new(algolia_params),
-                             Search::Strategies::PgSearch.new(**search_params),
-                             search_criteria: search_criteria,
-                             use_experiment: pg_search,
-                           )
-                         else
-                           Search::Strategies::Database.new(page, per_page, sort_by)
-                         end
+    @search_strategy ||= Search::Strategies::PgSearch.new(**search_params)
   end
 
   def search_params
@@ -79,19 +68,5 @@ class Search::VacancySearch
       per_page: per_page,
       sort_by: sort_by,
     }
-  end
-
-  def algolia_params
-    {
-      keyword: keyword,
-      coordinates: location_search.location_filter[:point_coordinates],
-      radius: location_search.location_filter[:radius],
-      polygons: location_search.polygon_boundaries,
-      filters: search_filters,
-      replica: sort_by.algolia_replica,
-      per_page: per_page,
-      page: page,
-      typo_tolerance: fuzzy,
-    }.compact
   end
 end

--- a/config/ab_tests.yml
+++ b/config/ab_tests.yml
@@ -39,9 +39,6 @@ shared:
   2021_11_desktop_search_results_page_test:
     present: 1
     right_column: 1
-  2021_12_new_search:
-    algolia: 1
-    postgres: 1
 test:
   2021_04_cookie_consent_test:
     none: 0
@@ -59,6 +56,3 @@ test:
   2021_11_desktop_search_results_page_test:
     present: 1
     right_column: 0
-  2021_12_new_search:
-    algolia: 0
-    postgres: 1

--- a/spec/services/search/vacancy_search_spec.rb
+++ b/spec/services/search/vacancy_search_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Search::VacancySearch do
-  subject { described_class.new(form_hash, sort_by: jobs_sort, page: page, per_page: per_page, fuzzy: fuzzy) }
+  subject { described_class.new(form_hash, sort_by: jobs_sort, page: page, per_page: per_page) }
 
   let(:form_hash) do
     {
@@ -12,23 +12,21 @@ RSpec.describe Search::VacancySearch do
   end
 
   let(:keyword) { "maths teacher" }
-  let(:location) { "" }
+  let(:location) { "Louth" }
   let(:radius) { 10 }
   let(:jobs_sort) { Search::VacancySearchSort::RELEVANCE }
   let(:per_page) { nil }
   let(:page) { 1 }
-  let(:fuzzy) { true }
-  let(:filter_query) { Search::FiltersBuilder.new(form_hash).filter_query }
-  let!(:location_polygon) { create(:location_polygon, name: "london") }
-  let(:buffered_polygon) { LocationPolygon.buffered(radius).find(location_polygon.id) }
+
+  before do
+    allow(Search::Strategies::PgSearch).to receive(:new).and_return(pg_search)
+  end
 
   describe "pagination helpers" do
     let(:per_page) { 20 }
     let(:page) { 3 }
 
-    before do
-      mock_algolia_search(double(none?: false), 50, keyword, anything)
-    end
+    let(:pg_search) { double(total_count: 50) }
 
     it "returns the expected bounds" do
       expect(subject).not_to be_out_of_bounds
@@ -38,9 +36,7 @@ RSpec.describe Search::VacancySearch do
     end
 
     context "when out of bounds" do
-      before do
-        mock_algolia_search(double(none?: false), 20, keyword, anything)
-      end
+      let(:pg_search) { double(total_count: 20) }
 
       it "returns the expected bounds" do
         expect(subject).to be_out_of_bounds
@@ -51,198 +47,47 @@ RSpec.describe Search::VacancySearch do
     end
   end
 
-  describe "building location search" do
-    let(:location) { location_polygon.name }
-
-    context "when a polygon search is carried out" do
-      before { allow_any_instance_of(Search::LocationBuilder).to receive(:search_with_polygons?).and_return(true) }
-
-      it "sets location in the active params hash to the polygon's name" do
-        expect(subject.active_criteria[:location]).to eq("london")
-      end
-    end
-  end
-
-  describe "building filters" do
-    it "calls the filters builder" do
-      expect(Search::FiltersBuilder).to receive(:new).with(form_hash).and_call_original
-      subject.search_filters
-    end
-  end
-
   describe "performing search" do
-    describe "fuzziness" do
-      before do
-        mock_algolia_search(double(raw_answer: nil), 50, keyword, anything)
-      end
+    let(:vacancies) { [build_stubbed(:vacancy)] * 3 }
+    let(:pg_search) { double(vacancies: vacancies, total_count: 3) }
 
-      context "when enabled" do
-        let(:fuzzy) { true }
-
-        it "sets Algolia typo tolerance to true" do
-          expect(Search::Strategies::Algolia).to receive(:new).with(hash_including(typo_tolerance: true)).and_call_original
-          subject.vacancies
-        end
-      end
-
-      context "when disabled" do
-        let(:fuzzy) { false }
-
-        it "sets Algolia typo tolerance to false" do
-          expect(Search::Strategies::Algolia).to receive(:new).with(hash_including(typo_tolerance: false)).and_call_original
-          subject.vacancies
-        end
-      end
+    before do
+      expect(Search::Strategies::PgSearch).to receive(:new).with(
+        keyword: "maths teacher",
+        location: "Louth",
+        radius: 10,
+        filters: hash_including(keyword: "maths teacher"),
+        page: 1,
+        per_page: 20,
+        sort_by: Search::VacancySearchSort::RELEVANCE,
+      ).and_return(pg_search)
     end
 
-    context "when there is any search criteria" do
-      context "when location matches a location polygon" do
-        let(:location) { location_polygon.name }
-        let(:search_params) do
-          {
-            keyword: keyword,
-            polygons: buffered_polygon.to_algolia_polygons,
-            filters: filter_query,
-            per_page: 20,
-            page: page,
-            typo_tolerance: true,
-          }
-        end
-
-        it "calls algolia search with the correct parameters" do
-          expect(Search::Strategies::Algolia).to receive(:new).with(search_params).and_call_original
-          subject.vacancies
-        end
-      end
-
-      context "when location does not match a location polygon" do
-        let(:location) { "SW1A 1AA" }
-        let(:radius) { 10 }
-        let(:search_params) do
-          {
-            keyword: keyword,
-            coordinates: Geocoder::DEFAULT_STUB_COORDINATES,
-            radius: convert_miles_to_metres(radius),
-            filters: filter_query,
-            per_page: 20,
-            page: page,
-            typo_tolerance: true,
-          }
-        end
-
-        it "calls algolia search with the correct parameters" do
-          expect(Search::Strategies::Algolia).to receive(:new).with(search_params).and_call_original
-          subject.vacancies
-        end
-      end
-    end
-
-    context "when there is not any search criteria" do
-      let(:keyword) { "" }
-      let(:jobs_sort) { Search::VacancySearchSort::PUBLISH_ON_DESC }
-
-      it "calls `Search::Strategies::Database` with the correct parameters" do
-        expect(Search::Strategies::Database).to receive(:new).with(1, 20, an_instance_of(Search::VacancySearchSort)).and_call_original
-        subject.vacancies
-      end
+    it "uses the PgSearch strategy" do
+      expect(subject.vacancies).to eq(vacancies)
+      expect(subject.total_count).to eq(3)
     end
   end
 
   describe "wider suggestions" do
-    context "when location matches a location polygon" do
-      let(:location) { location_polygon.name }
+    context "when results are returned" do
+      let(:pg_search) { double(vacancies: [double("vacancy")], total_count: 1) }
 
-      context "when vacancies is not empty" do
-        let(:vacancies) { double("vacancies") }
-
-        let(:arguments_to_algolia) do
-          {
-            insidePolygon: buffered_polygon.to_algolia_polygons,
-            filters: filter_query,
-            hitsPerPage: 20,
-            page: page,
-            typoTolerance: true,
-          }
-        end
-
-        before do
-          allow(vacancies).to receive(:empty?).and_return(false)
-          mock_algolia_search(vacancies, 1, keyword, arguments_to_algolia)
-          freeze_time
-        end
-
-        it "does not call the wider suggestions builder" do
-          expect(Search::WiderSuggestionsBuilder).not_to receive(:new)
-          subject.wider_search_suggestions
-        end
-      end
-
-      context "when vacancies is empty" do
-        let(:search_params) do
-          {
-            keyword: keyword,
-            polygons: buffered_polygon.to_algolia_polygons,
-            filters: filter_query,
-            per_page: 20,
-            page: page,
-            typo_tolerance: true,
-          }
-        end
-
-        before { freeze_time }
-
-        it "calls the wider suggestions builder" do
-          expect(Search::WiderSuggestionsBuilder).to receive(:new).and_call_original
-          subject.wider_search_suggestions
-        end
+      it "does not offer suggestions" do
+        expect(subject.wider_search_suggestions).to be_nil
       end
     end
 
-    context "when location does not match a location polygon" do
-      let(:location) { "SW1A 1AA" }
-      let(:radius) { 10 }
-      let(:search_params) do
-        {
-          keyword: keyword,
-          coordinates: Geocoder::DEFAULT_STUB_COORDINATES,
-          radius: convert_miles_to_metres(radius),
-          filters: filter_query,
-          per_page: 20,
-          page: page,
-          typo_tolerance: true,
-        }
+    context "when no results are returned" do
+      let(:pg_search) { double(vacancies: [], total_count: 0) }
+      let(:suggestions_builder) { double(suggestions: [1, 2, 3]) }
+
+      before do
+        allow(Search::WiderSuggestionsBuilder).to receive(:new).and_return(suggestions_builder)
       end
 
-      context "when vacancies is not empty" do
-        let(:vacancies) { double("vacancies") }
-
-        let(:arguments_to_algolia) do
-          {
-            aroundLatLng: Geocoder::DEFAULT_STUB_COORDINATES,
-            aroundRadius: convert_miles_to_metres(radius),
-            filters: filter_query,
-            hitsPerPage: 20,
-            page: page,
-            typoTolerance: true,
-          }
-        end
-
-        before do
-          allow(vacancies).to receive(:empty?).and_return(false)
-          mock_algolia_search(vacancies, 1, keyword, arguments_to_algolia)
-        end
-
-        it "does not call the wider suggestions builder" do
-          expect(Search::WiderSuggestionsBuilder).not_to receive(:new)
-          subject.wider_search_suggestions
-        end
-      end
-
-      context "when vacancies is empty" do
-        it "calls the wider suggestions builder" do
-          expect(Search::WiderSuggestionsBuilder).to receive(:new).and_call_original
-          subject.wider_search_suggestions
-        end
+      it "offers suggestions" do
+        expect(subject.wider_search_suggestions).to eq([1, 2, 3])
       end
     end
   end


### PR DESCRIPTION
- Use `PgSearch` strategy exclusively in `VacancySearch`
- Remove search AB test
- Simplify `VacancySearch` specs
- Fix `Subscription` spec to not rely on Algolia