### PR TITLE
TEVA-3608 Remove unused `ends_on` field on `Vacancy`

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -275,7 +275,6 @@ shared:
     - job_advert
     - benefits
     - starts_on
-    - ends_on
     - contact_email
     - status
     - publish_on

--- a/db/migrate/20211209154121_remove_ends_on_from_vacancy.rb
+++ b/db/migrate/20211209154121_remove_ends_on_from_vacancy.rb
@@ -1,0 +1,5 @@
+class RemoveEndsOnFromVacancy < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :vacancies, :ends_on, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_15_110318) do
+ActiveRecord::Schema.define(version: 2021_12_09_154121) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -429,7 +429,6 @@ ActiveRecord::Schema.define(version: 2021_11_15_110318) do
     t.text "job_advert"
     t.text "benefits"
     t.date "starts_on"
-    t.date "ends_on"
     t.string "contact_email"
     t.integer "status"
     t.date "publish_on"


### PR DESCRIPTION
Appears not to have been in use since 2019, and is confusing since we
also have `expires_at` which is actively used.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3608
