### PR TITLE
[TEVA-3447] Implement job alert banner location AB test

### DIFF
--- a/app/mailers/jobseekers/base_mailer.rb
+++ b/app/mailers/jobseekers/base_mailer.rb
@@ -2,7 +2,11 @@ class Jobseekers::BaseMailer < ApplicationMailer
   private
 
   def email_event
-    @email_event ||= EmailEvent.new(template, to, uid, jobseeker: @jobseeker)
+    @email_event ||= EmailEvent.new(template, to, uid, jobseeker: @jobseeker, ab_tests: ab_tests)
+  end
+
+  def ab_tests
+    {}
   end
 
   def email_event_prefix

--- a/app/services/email_event.rb
+++ b/app/services/email_event.rb
@@ -3,17 +3,24 @@
 #
 # This event should only be triggered in mailers.
 class EmailEvent < Event
-  def initialize(notify_template, email, uid, jobseeker: nil, publisher: nil)
+  def initialize(notify_template, email, uid, jobseeker: nil, publisher: nil, ab_tests: nil)
     @notify_template = notify_template
     @email = email
     @uid = uid
     @jobseeker = jobseeker
     @publisher = publisher
+    @ab_tests = ab_tests
   end
 
   private
 
-  attr_reader :notify_template, :email, :uid, :jobseeker, :publisher
+  attr_reader :notify_template, :email, :uid, :jobseeker, :publisher, :ab_tests
+
+  def base_data
+    @base_data ||= super.merge(
+      request_ab_tests: ab_tests&.map { |test, variant| { test: test, variant: variant } },
+    )
+  end
 
   def data
     @data ||= super.push(

--- a/app/views/jobseekers/alert_mailer/alert.text.erb
+++ b/app/views/jobseekers/alert_mailer/alert.text.erb
@@ -1,6 +1,19 @@
 # <%= t(".summary.#{subscription.frequency}", count: @vacancies.count) %>
 
 ---
+# <%= t(".title") %>
+<%= t("subscriptions.intro") %>
+
+<%- subscription.filtered_search_criteria.each_pair do |filter, value| %>
+  <%= "- #{filter.humanize}: #{value}" %>
+<% end %>
+
+<%= t(".alert_frequency", frequency: subscription.frequency) %>
+
+# <%= t(".alert_relevance") %>
+<%= t(".edit_alert", edit_link_text: edit_subscription_link(subscription))%>
+
+---
 
 <%- @vacancies.each do |vacancy| %>
   <%= show_link(vacancy) %>
@@ -13,19 +26,7 @@
   <%= t(".closing_date", closing_date: format_time_to_datetime_at(vacancy.expires_at)) %>
 
   ---
-
 <% end %>
-
-# <%= t(".title") %>
-<%= t("subscriptions.intro") %>
-
-<%- subscription.filtered_search_criteria.each_pair do |filter, value| %>
-  <%= "- #{filter.humanize}: #{value}" %>
-<% end %>
-
-<%= [t(".alert_frequency", frequency: subscription.frequency), t(".edit_alert", edit_link: edit_subscription_link(subscription))].join(" ") %>
-
----
 
 # <%= t(".feedback.heading") %>
 

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -63,9 +63,10 @@ en:
       alert:
         alert_frequency: >-
           You have set to receive this job alert %{frequency} when any jobs matching your criteria are listed.
+        alert_relevance: Get more relevant job alerts
         closing_date: "Closing date: %{closing_date}"
-        edit_alert: You can %{edit_link} here.
-        edit_link_text: manage your alert
+        edit_alert: "%{edit_link_text} to get job alerts that are more relevant to you. You can filter by keyword, location, job role, education phase or working pattern."
+        edit_link_text: Change your alert criteria
         feedback:
           heading: Are these job listings relevant to your search?
           irrelevant_link_text: No, they are not relevant

--- a/spec/services/email_event_spec.rb
+++ b/spec/services/email_event_spec.rb
@@ -1,13 +1,14 @@
 require "rails_helper"
 
 RSpec.describe EmailEvent do
-  subject { described_class.new(notify_template, email, uid, jobseeker: jobseeker, publisher: publisher) }
+  subject { described_class.new(notify_template, email, uid, jobseeker: jobseeker, publisher: publisher, ab_tests: ab_tests) }
 
   let(:notify_template) { "test_template" }
   let(:email) { "test@example.net" }
   let(:jobseeker) { instance_double(Jobseeker, id: 1234, email: "test@example.net") }
   let(:publisher) { instance_double(Publisher, oid: 4321) }
   let(:uid) { SecureRandom.uuid }
+  let(:ab_tests) { { example_AB_test: "present" } }
 
   describe "#trigger" do
     let(:expected_data) do
@@ -22,6 +23,7 @@ RSpec.describe EmailEvent do
           { key: "user_anonymised_publisher_id", value: anonymised_form_of("4321") },
           { key: "foozy", value: "barzy" },
         ],
+        request_ab_tests: [{ test: :example_AB_test, variant: "present" }],
       }
     end
 


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3447

## Changes in this PR:

This PR originally implemented an AB test which changes the location "Job alert" banner on the job alerts email and changes the copy. We have decided that this test would not be able to obtain statistically significant data in a reasonable time, so this PR now implements the proposed content changes directly.

As upcoming tickets will implement AB tests in mailers, the code which allows for AB tests to be added to mailers has been retained.

## Screenshots of UI changes:

### Before

![image](https://user-images.githubusercontent.com/24639777/145442900-4f49db02-adc2-4a68-a4bb-cc95403094cc.png)

### After

![image](https://user-images.githubusercontent.com/24639777/145442994-9f646d20-aafb-4b9a-b865-43d0805df84d.png)