### PR TITLE
Rename things that have "algolia" in the name

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -38,7 +38,7 @@ class VacanciesController < ApplicationController
     params[:subject]&.titleize
   end
 
-  def algolia_search_params
+  def search_params
     strip_empty_checkboxes(%i[job_roles phases working_patterns])
     %w[job_role job_roles phases working_patterns].each do |facet|
       params[facet] = params[facet].split if params[facet].is_a?(String)
@@ -48,7 +48,7 @@ class VacanciesController < ApplicationController
   end
 
   def search_form
-    @form = Jobseekers::SearchForm.new(algolia_search_params)
+    @form = Jobseekers::SearchForm.new(search_params)
   end
 
   def job_application

--- a/app/services/vacancy_facets.rb
+++ b/app/services/vacancy_facets.rb
@@ -44,26 +44,26 @@ class VacancyFacets
   end
 
   def city_facet
-    CITIES.each_with_object({}) { |city, facets| facets[city] = algolia_facet_count(location: city) }
+    CITIES.each_with_object({}) { |city, facets| facets[city] = facet_counts(location: city) }
   end
 
   def county_facet
-    COUNTIES.each_with_object({}) { |county, facets| facets[county] = algolia_facet_count(location: county) }
+    COUNTIES.each_with_object({}) { |county, facets| facets[county] = facet_counts(location: county) }
   end
 
   def education_phase_facet
-    School.available_readable_phases.each_with_object({}) { |phase, facets| facets[phase] = algolia_facet_count(phases: [phase]) }
+    School.available_readable_phases.each_with_object({}) { |phase, facets| facets[phase] = facet_counts(phases: [phase]) }
   end
 
   def job_role_facet
-    Vacancy.job_roles.keys.each_with_object({}) { |job_role, facets| facets[job_role] = algolia_facet_count(job_roles: [job_role]) }
+    Vacancy.job_roles.keys.each_with_object({}) { |job_role, facets| facets[job_role] = facet_counts(job_roles: [job_role]) }
   end
 
   def subject_facet
-    SUBJECT_OPTIONS.each_with_object({}) { |subject, facets| facets[subject.first] = algolia_facet_count(keyword: subject.first) }
+    SUBJECT_OPTIONS.each_with_object({}) { |subject, facets| facets[subject.first] = facet_counts(keyword: subject.first) }
   end
 
-  def algolia_facet_count(query)
+  def facet_counts(query)
     # Disable this very expensive operation unless caching is enabled (e.g. in dev, system tests)
     return 0 unless Rails.application.config.action_controller.perform_caching
 

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Subscription do
     let(:vacancies) { double("vacancies") }
     let(:vacancy_search) { double(vacancies: vacancies) }
 
-    it "calls out to algolia search" do
+    it "searches with an appropriate date range" do
       expect(Search::VacancySearch).to receive(:new).with(
         {
           keyword: "english",


### PR DESCRIPTION
These things are named after Algolia but actually have nothing to do
with it.