### PR TITLE
Remove Algolia polygon logic

### DIFF
--- a/app/controllers/api/map/locations_controller.rb
+++ b/app/controllers/api/map/locations_controller.rb
@@ -18,7 +18,7 @@ class Api::Map::LocationsController < Api::ApplicationController
   end
 
   def polygons
-    location_search.polygon_boundaries.map { |boundary| polygon(boundary) }
+    location_search.polygon.area.coordinates.map { |boundary| polygon(boundary) }
   end
 
   def polygon(boundary)
@@ -41,6 +41,6 @@ class Api::Map::LocationsController < Api::ApplicationController
   end
 
   def coordinates(boundary)
-    boundary.each_slice(2).map { |lat, lng| { lat: lat, lng: lng } }
+    boundary.map { |lng, lat| { lat: lat, lng: lng } }
   end
 end

--- a/app/models/location_polygon.rb
+++ b/app/models/location_polygon.rb
@@ -19,10 +19,4 @@ class LocationPolygon < ApplicationRecord
   def self.mapped_name(location)
     (MAPPED_LOCATIONS[location&.downcase].presence || location)&.downcase
   end
-
-  # Returns the coordinates of this location (multi)polygon in the format expected by Algolia
-  def to_algolia_polygons
-    # Reversing original coordinates as PostGIS uses lon,lat whereas Algolia uses lat,lon
-    area.coordinates.map { |polygon| polygon.flatten.reverse }
-  end
 end

--- a/app/services/search/location_builder.rb
+++ b/app/services/search/location_builder.rb
@@ -5,7 +5,7 @@ class Search::LocationBuilder
 
   include DistanceHelper
 
-  attr_reader :location, :location_filter, :polygon_boundaries, :radius
+  attr_reader :location, :location_filter, :polygon, :radius
 
   def initialize(location, radius)
     @location = location
@@ -15,7 +15,7 @@ class Search::LocationBuilder
     if NATIONWIDE_LOCATIONS.include?(@location&.downcase)
       @location = nil
     elsif search_with_polygons?
-      initialize_polygon_boundaries
+      @polygon = LocationPolygon.buffered(radius).with_name(location)
     elsif @location.present?
       @location_filter = build_location_filter
     end
@@ -30,10 +30,6 @@ class Search::LocationBuilder
   end
 
   private
-
-  def initialize_polygon_boundaries
-    @polygon_boundaries = LocationPolygon.buffered(radius).with_name(location).to_algolia_polygons
-  end
 
   def build_location_filter
     {

--- a/spec/models/location_polygon_spec.rb
+++ b/spec/models/location_polygon_spec.rb
@@ -36,14 +36,4 @@ RSpec.describe LocationPolygon do
       end
     end
   end
-
-  describe "#to_algolia_polygons" do
-    before do
-      subject.area = "POLYGON((0 0, 1 1, 0 1, 0 0))"
-    end
-
-    it "returns an Algolia representation of the area field" do
-      expect(subject.to_algolia_polygons).to eq([[0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0]])
-    end
-  end
 end

--- a/spec/requests/api/map/locations_spec.rb
+++ b/spec/requests/api/map/locations_spec.rb
@@ -6,9 +6,10 @@ RSpec.describe "Api::Map::Locations" do
   let(:point) { [1.0, 2.0] }
   let(:search_with_polygons) { true }
   let(:json) { JSON.parse(response.body, symbolize_names: true) }
+  let(:polygon) { double(area: double(coordinates: [[[2.0, 1.0]], [[3.0, 2.0]], [[4.0, 3.0]]])) }
   let(:location_builder_double) do
     instance_double Search::LocationBuilder, search_with_polygons?: search_with_polygons,
-                                             polygon_boundaries: [[1.0, 2.0], [2.0, 3.0], [3.0, 4.0]],
+                                             polygon: polygon,
                                              point_coordinates: point
   end
 

--- a/spec/services/search/location_builder_spec.rb
+++ b/spec/services/search/location_builder_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.shared_examples "a search using polygons" do
   it "sets the correct attributes" do
     buffered_polygon = LocationPolygon.buffered(expected_radius).find_by(name: location_polygon.name)
-    expect(subject.polygon_boundaries).to eq(buffered_polygon.to_algolia_polygons)
+    expect(subject.polygon).to eq(buffered_polygon)
     expect(subject.location_filter).to eq({})
     expect(subject.radius).to eq(expected_radius)
   end
@@ -45,7 +45,7 @@ RSpec.describe Search::LocationBuilder do
       let(:location) { point_location }
 
       it "sets radius attribute, and location filter around the location" do
-        expect(subject.polygon_boundaries).to be_nil
+        expect(subject.polygon).to be_nil
         expect(subject.location_filter).to eq({
           point_coordinates: Geocoder::DEFAULT_STUB_COORDINATES,
           radius: radius_in_metres,
@@ -59,7 +59,7 @@ RSpec.describe Search::LocationBuilder do
 
       it "does not set location filters" do
         expect(subject.location).to be nil
-        expect(subject.polygon_boundaries).to be nil
+        expect(subject.polygon).to be nil
         expect(subject.location_filter).to eq({})
       end
     end


### PR DESCRIPTION
- Remove `LocationPolygon#to_algolia_polygons`
- Change location map code that relied on this method to directly use
  the polygon coordinates instead