### PR TITLE
Add a FailSafe module for view components

### DIFF
--- a/app/components/environment_banner_component.rb
+++ b/app/components/environment_banner_component.rb
@@ -1,4 +1,6 @@
 class EnvironmentBannerComponent < GovukComponent::Base
+  include FailSafe
+
   def initialize(classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
   end

--- a/app/components/fail_safe.rb
+++ b/app/components/fail_safe.rb
@@ -1,0 +1,13 @@
+# Include this module in a ViewComponent when that component is deemed not to be
+# mission-critical. Then a page containing that component will still be able to render,
+# even if the non-critical component raised an error, rather than serving a 500 page.
+module FailSafe
+  def render_in(...)
+    super
+  rescue StandardError => e
+    raise e unless Rails.env.production?
+
+    Rollbar.error(e)
+    nil
+  end
+end

--- a/spec/components/fail_safe_spec.rb
+++ b/spec/components/fail_safe_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe FailSafe, type: :component do
+  let(:my_component_class) do
+    Class.new(GovukComponent::Base) do
+      include FailSafe
+
+      def self.name
+        "TestComponent"
+      end
+
+      def call
+        raise "an error"
+      end
+    end
+  end
+
+  def try_render
+    render_inline(my_component_class.new(classes: [], html_attributes: {}))
+  end
+
+  context "when not in production" do
+    it "doesn't hide errors during rendering" do
+      expect { try_render }.to raise_error(RuntimeError)
+    end
+  end
+
+  context "when in production" do
+    before do
+      allow(Rails.env).to receive(:production?).and_return(true)
+    end
+
+    it "hides errors raised during rendering" do
+      expect { try_render }.not_to raise_error
+    end
+
+    it "notifies Rollbar of errors raised during rendering" do
+      expect(Rollbar).to receive(:error).with(an_instance_of(RuntimeError))
+      try_render
+    end
+
+    it "renders nothing" do
+      expect(try_render.to_html).to be_blank
+    end
+  end
+end


### PR DESCRIPTION
When included, this module will prevent errors from
causing a 500 response in production.

This allows us to flag certain components as non-critical
so the page continues to render correctly (absent the non-critical
component's HTML).

Co-authored-by: Elliot Crosby-McCullough <elliot.cm@gmail.com>
