### PR TITLE
Add Kernel#fail_safe for graceful degradation

### DIFF
--- a/app/components/fail_safe.rb
+++ b/app/components/fail_safe.rb
@@ -3,11 +3,8 @@
 # even if the non-critical component raised an error, rather than serving a 500 page.
 module FailSafe
   def render_in(...)
-    super
-  rescue StandardError => e
-    raise e unless Rails.env.production?
-
-    Rollbar.error(e)
-    nil
+    fail_safe do
+      super
+    end
   end
 end

--- a/app/services/event.rb
+++ b/app/services/event.rb
@@ -14,14 +14,14 @@ class Event
   # @param [Symbol, String] event_type The type of event (e.g. `:page_visited`) to trigger
   # @param [Hash{Symbol => Object}] event_data An optional hash of data to include with the event
   def trigger(event_type, event_data = {})
-    event_data = base_data.merge(
-      type: event_type,
-      occurred_at: occurred_at(event_data),
-      data: data.push(*event_data.map { |key, value| { key: key.to_s, value: formatted_value(value) } }),
-    )
-    SendEventToDataWarehouseJob.perform_later(TABLE_NAME, event_data)
-  rescue StandardError => e
-    Rollbar.error(e)
+    fail_safe do
+      event_data = base_data.merge(
+        type: event_type,
+        occurred_at: occurred_at(event_data),
+        data: data.push(*event_data.map { |key, value| { key: key.to_s, value: formatted_value(value) } }),
+      )
+      SendEventToDataWarehouseJob.perform_later(TABLE_NAME, event_data)
+    end
   end
 
   private

--- a/lib/fail_safe.rb
+++ b/lib/fail_safe.rb
@@ -1,0 +1,21 @@
+module Kernel
+  ##
+  # Wraps a block of code and rescues any errors that may occur if running in production, optionally
+  # returning a default value. Allows us to gracefully degrade in situations where there's a risk of
+  # errors occurring in non-critical code.
+  #
+  # @param default [Object] The default value to return on failure
+  # @param error_klass [Exception] A specific error class to rescue from
+  # @yieldreturn [Object] The value to return unless an error is raised
+  # @return The result of the block (if no error is raised), or the value passed in as `default`
+  def fail_safe(default = nil, error_klass = StandardError)
+    yield
+  rescue error_klass => e
+    # Only rescue errors in production - when developing locally, it's normally desired to see
+    # errors immediately
+    raise e unless Rails.env.production?
+
+    Rollbar.error(e)
+    default
+  end
+end

--- a/spec/components/fail_safe_spec.rb
+++ b/spec/components/fail_safe_spec.rb
@@ -34,11 +34,6 @@ RSpec.describe FailSafe, type: :component do
       expect { try_render }.not_to raise_error
     end
 
-    it "notifies Rollbar of errors raised during rendering" do
-      expect(Rollbar).to receive(:error).with(an_instance_of(RuntimeError))
-      try_render
-    end
-
     it "renders nothing" do
       expect(try_render.to_html).to be_blank
     end

--- a/spec/lib/fail_safe_spec.rb
+++ b/spec/lib/fail_safe_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe Kernel do
+  context "when the block raises an error" do
+    subject do
+      fail_safe(42) do
+        raise "But the plans were on display..."
+      end
+    end
+
+    context "when not in production" do
+      it "does not capture errors occurring in the block" do
+        expect { subject }.to raise_error(RuntimeError, "But the plans were on display...")
+      end
+    end
+
+    context "when in production" do
+      before do
+        allow(Rails.env).to receive(:production?).and_return(true)
+      end
+
+      it "hides errors raised in the block" do
+        expect { subject }.not_to raise_error
+      end
+
+      it "notifies Rollbar of errors raised in the block" do
+        expect(Rollbar).to receive(:error).with(an_instance_of(RuntimeError))
+        subject
+      end
+
+      it "returns the default value" do
+        expect(subject).to eq(42)
+      end
+    end
+  end
+
+  context "when the block does not raise an error" do
+    subject do
+      fail_safe(42) do
+        "A. Dent"
+      end
+    end
+
+    it "returns the block's return value" do
+      expect(subject).to eq("A. Dent")
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,6 +59,10 @@ RSpec.configure do |config|
 
   config.before do
     ActiveJob::Base.queue_adapter = :test
+
+    allow(Google::Cloud::Bigquery).to receive(:new).and_return(
+      double("BigQuery", dataset: double("BigQuery dataset", table: double.as_null_object)),
+    )
   end
 
   config.before(:each, type: :system) do

--- a/spec/requests/publishers/vacancies/statistics_spec.rb
+++ b/spec/requests/publishers/vacancies/statistics_spec.rb
@@ -4,9 +4,11 @@ RSpec.describe "Job listing statistics" do
   let(:organisation) { build(:school) }
   let(:vacancy) { create(:vacancy, organisations: [organisation]) }
   let(:publisher) { create(:publisher, accepted_terms_at: 1.day.ago) }
+  let(:vacancy_stats) { double(number_of_unique_views: 42) }
 
   before do
     allow_any_instance_of(Publishers::AuthenticationConcerns).to receive(:current_organisation).and_return(organisation)
+    allow(Publishers::VacancyStats).to receive(:new).and_return(vacancy_stats)
     sign_in(publisher, scope: :publisher)
   end
 

--- a/spec/services/event_spec.rb
+++ b/spec/services/event_spec.rb
@@ -23,16 +23,5 @@ RSpec.describe Event do
                         params: { foo: "bar" })
       end
     end
-
-    context "when an error occurs when the event is triggered" do
-      let(:error) { StandardError.new("Splines are insufficiently reticulated") }
-
-      it "ignores the error but reports it to Rollbar" do
-        allow(SendEventToDataWarehouseJob).to receive(:perform_later).and_raise(error)
-        expect(Rollbar).to receive(:error).with(error)
-
-        subject.trigger(:reticulated_splines)
-      end
-    end
   end
 end


### PR DESCRIPTION
- Add `FailSafe` lib file to add `Kernel#fail_safe`
- Refactor existing uses of rescuing-and-sending-to-Rollbar to use new
  method
- Refactor `FailSafe` view component module to use `Kernel#fail_safe`
- Fix several specs that were only passing because unrelated code was
  silently swallowing errors
- Stub out BigQuery in test environment