### PR TITLE
Fix bug affecting seeds

### DIFF
--- a/spec/factories/support/random_helpers.rb
+++ b/spec/factories/support/random_helpers.rb
@@ -1,4 +1,6 @@
 module RandomHelpers
+  module_function
+
   def factory_rand(range)
     if Rails.env.test?
       range.min
@@ -7,11 +9,11 @@ module RandomHelpers
     end
   end
 
-  def factory_sample(things, num = 1)
+  def factory_sample(things, num = nil)
     if Rails.env.test?
-      num == 1 ? things.first : things.take(num)
+      (num || 1) == 1 ? things.first : things.take(num)
     else
-      num == 1 ? things.sample : things.sample(num)
+      num.nil? ? things.sample : things.sample(num)
     end
   end
 

--- a/spec/meta/factories/support/random_helpers_spec.rb
+++ b/spec/meta/factories/support/random_helpers_spec.rb
@@ -1,0 +1,108 @@
+require "rails_helper"
+
+RSpec.describe RandomHelpers do
+  let(:range) { 2..5 }
+  let(:things) { %i[a b c] }
+
+  describe "#factory_rand(range)" do
+    context "when in test mode" do
+      it "uses the minimum of the range every time" do
+        expect(described_class.factory_rand(range)).to eq(2)
+      end
+    end
+
+    context "when not in test mode" do
+      before do
+        allow(Rails.env).to receive(:test?).and_return(false)
+      end
+
+      it "picks a random number from the range" do
+        expect(RandomHelpers).to receive(:rand).with(range).and_call_original
+        described_class.factory_rand(range)
+      end
+    end
+  end
+
+  describe "#factory_sample(things, num = nil)" do
+    context "when in test mode" do
+      context "when `num` is not given" do
+        it "returns the first thing" do
+          expect(described_class.factory_sample(things)).to eq(:a)
+        end
+      end
+
+      context "when `num` is nil" do
+        it "returns the first thing" do
+          expect(described_class.factory_sample(things, nil)).to eq(:a)
+        end
+      end
+
+      context "when `num` is 1" do
+        it "returns the first thing" do
+          expect(described_class.factory_sample(things, 1)).to eq(:a)
+        end
+      end
+
+      context "when `num` is > 1" do
+        it "returns an array of the first `num` things" do
+          expect(described_class.factory_sample(things, 2)).to eq(%i[a b])
+        end
+      end
+    end
+
+    context "when not in test mode" do
+      before do
+        allow(Rails.env).to receive(:test?).and_return(false)
+      end
+
+      context "when `num` is not given" do
+        it "returns a random thing" do
+          expect(things).to receive(:sample).and_call_original
+          expect(things).to include(described_class.factory_sample(things))
+        end
+      end
+
+      context "when `num` is nil" do
+        it "returns a random thing" do
+          expect(things).to receive(:sample).and_call_original
+          expect(things).to include(described_class.factory_sample(things))
+        end
+      end
+
+      context "when `num` is 1" do
+        it "returns an array of a random thing" do
+          expect(things).to receive(:sample).with(1).and_call_original
+
+          result = described_class.factory_sample(things, 1)
+          expect(result.size).to eq(1)
+          expect(things & result).to eq(result)
+        end
+      end
+
+      context "when `num` is > 1" do
+        it "returns an array of a random things" do
+          expect(things).to receive(:sample).with(2).and_call_original
+
+          result = described_class.factory_sample(things, 2)
+          expect(result.size).to eq(2)
+          expect((things & result).sort).to eq(result.sort)
+        end
+      end
+    end
+  end
+
+  describe "#factory_rand_sample(things, range)" do
+    let(:random_number) { double }
+
+    it "combines `factory_rand` and `factory_sample`" do
+      expect(described_class).to receive(:factory_rand)
+        .with(range)
+        .and_return(random_number)
+
+      expect(described_class).to receive(:factory_sample)
+        .with(things, random_number)
+
+      described_class.factory_rand_sample(things, range)
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR:

```
Created database 'tvs_test'
rails aborted!
TypeError: no implicit conversion of String into Array
/Users/josephhull/Dev/teaching-vacancies/app/models/vacancy.rb:165:in `+'
/Users/josephhull/Dev/teaching-vacancies/app/models/vacancy.rb:165:in `additional_job_roles='
```

This bug was introduced after changes to `factory_sample` in `spec/factories/support/random_helpers.rb`.

In vacancies factory we have the following:

```
when "teacher"
        factory_rand_sample(Vacancy.additional_job_role_options, 0..2)
```

If `factory_rand` in `spec/factories/support/random_helpers.rb` returns 1, a string is returned by `factory_rand_sample`. In the `additional_job_roles=` we then attempt to add this string to an array, causing the error.

