### PR TITLE
[TEVA-3453] Add "maternity or parental leave cover" contract type

### DIFF
--- a/app/controllers/concerns/publishers/wizardable.rb
+++ b/app/controllers/concerns/publishers/wizardable.rb
@@ -72,7 +72,7 @@ module Publishers::Wizardable
       status: vacancy.status.blank? ? "draft" : nil,
     }
     params.require(:publishers_job_listing_job_details_form)
-          .permit(:job_title, :contract_type, :contract_type_duration, key_stages: [], subjects: [])
+          .permit(:job_title, :contract_type, :fixed_term_contract_duration, :parental_leave_cover_contract_duration, key_stages: [], subjects: [])
           .merge(attributes_to_merge.compact)
           .merge(key_stages: params[:publishers_job_listing_job_details_form][:key_stages]&.reject(&:blank?))
   end

--- a/app/form_models/publishers/job_listing/job_details_form.rb
+++ b/app/form_models/publishers/job_listing/job_details_form.rb
@@ -1,7 +1,7 @@
 class Publishers::JobListing::JobDetailsForm < Publishers::JobListing::VacancyForm
   include ActionView::Helpers::SanitizeHelper
 
-  attr_accessor :job_title, :contract_type, :contract_type_duration, :key_stages, :subjects, :job_location, :readable_job_location, :status
+  attr_accessor :job_title, :contract_type, :fixed_term_contract_duration, :parental_leave_cover_contract_duration, :key_stages, :subjects, :job_location, :readable_job_location, :status
 
   validates :job_title, presence: true
   validates :job_title, length: { minimum: 4, maximum: 100 }, if: -> { job_title.present? }
@@ -10,10 +10,11 @@ class Publishers::JobListing::JobDetailsForm < Publishers::JobListing::VacancyFo
   validates :key_stages, inclusion: { in: Vacancy.key_stages.keys }, if: -> { key_stages.present? }
 
   validates :contract_type, inclusion: { in: Vacancy.contract_types.keys }
-  validates :contract_type_duration, presence: true, if: -> { contract_type == "fixed_term" }
+  validates :fixed_term_contract_duration, presence: true, if: -> { contract_type == "fixed_term" }
+  validates :parental_leave_cover_contract_duration, presence: true, if: -> { contract_type == "parental_leave_cover" }
 
   def self.fields
-    %i[job_title contract_type contract_type_duration key_stages subjects]
+    %i[job_title contract_type fixed_term_contract_duration parental_leave_cover_contract_duration key_stages subjects]
   end
 
   def job_title_has_no_tags?

--- a/app/models/concerns/resettable.rb
+++ b/app/models/concerns/resettable.rb
@@ -7,7 +7,8 @@ module Resettable
 
   def reset_dependent_fields
     reset_actual_salary
-    reset_contract_type_duration
+    reset_fixed_term_contract_duration
+    reset_parental_leave_cover_contract_duration
     # Key stages and subjects are dependent on phase, so reset phase first
     reset_phase
     reset_key_stages
@@ -20,10 +21,16 @@ module Resettable
     self.actual_salary = ""
   end
 
-  def reset_contract_type_duration
-    return unless contract_type_changed? && contract_type == "permanent"
+  def reset_fixed_term_contract_duration
+    return unless contract_type_changed? && contract_type != "fixed_term"
 
-    self.contract_type_duration = ""
+    self.fixed_term_contract_duration = ""
+  end
+
+  def reset_parental_leave_cover_contract_duration
+    return unless contract_type_changed? && contract_type != "parental_leave_cover"
+
+    self.parental_leave_cover_contract_duration = ""
   end
 
   def reset_phase

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -24,7 +24,7 @@ class Vacancy < ApplicationRecord
   # Legacy vacancies can have these working_pattern options too: { compressed_hours: 102, staggered_hours: 103 }
 
   enum candidate_hired_from: { teaching_vacancies: 0, other_free: 1, other_paid: 2, unknown: 3 }
-  enum contract_type: { permanent: 0, fixed_term: 1 }
+  enum contract_type: { permanent: 0, fixed_term: 1, parental_leave_cover: 2 }
   enum end_listing_reason: { suitable_candidate_found: 0, end_early: 1 }
   enum hired_status: { hired_tvs: 0, hired_other_free: 1, hired_paid: 2, hired_no_listing: 3, not_filled_ongoing: 4, not_filled_not_looking: 5, hired_dont_know: 6 }
   enum job_location: { at_one_school: 0, at_multiple_schools: 1, central_office: 2 }

--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -118,7 +118,11 @@ class VacancyPresenter < BasePresenter
 
   def contract_type_with_duration
     type = model.contract_type ? I18n.t("helpers.label.publishers_job_listing_job_details_form.contract_type_options.#{model.contract_type}") : nil
-    duration = model.fixed_term? ? "(#{model.contract_type_duration})" : nil
+    duration = if model.fixed_term?
+                 "(#{model.fixed_term_contract_duration})"
+               elsif model.parental_leave_cover?
+                 "(#{model.parental_leave_cover_contract_duration})"
+               end
     [type, duration].compact.join(" ")
   end
 

--- a/app/views/publishers/vacancies/build/job_details.html.slim
+++ b/app/views/publishers/vacancies/build/job_details.html.slim
@@ -30,7 +30,10 @@
           = f.govuk_radio_button :contract_type, :permanent, link_errors: true
 
           = f.govuk_radio_button :contract_type, :fixed_term do
-            = f.govuk_text_field :contract_type_duration, label: { size: "s" }
+            = f.govuk_text_field :fixed_term_contract_duration, label: { size: "s" }
+
+          = f.govuk_radio_button :contract_type, :parental_leave_cover do
+            = f.govuk_text_field :parental_leave_cover_contract_duration, label: { size: "s" }
 
         - if vacancy.allow_key_stages?
           = f.govuk_collection_check_boxes :key_stages, Vacancy.key_stages.keys, :to_s, :to_s,

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -302,7 +302,8 @@ shared:
     - publisher_organisation_id
     - starts_asap
     - contract_type
-    - contract_type_duration
+    - fixed_term_contract_duration
+    - parental_leave_cover_contract_duration
     - enable_job_applications
     - personal_statement_guidance
     - end_listing_reason

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -109,9 +109,11 @@ en:
       inclusion: Select an education phase
   job_details_errors: &job_details_errors
     contract_type:
-      inclusion: Select if the contract type is permanent or fixed term
-    contract_type_duration:
-      blank: Enter a description of the fixed term contract
+      inclusion: Select if the contract type is permanent, fixed term or parental leave cover
+    fixed_term_contract_duration:
+      blank: Enter the duration of the fixed term contract
+    parental_leave_cover_contract_duration:
+      blank: Enter the duration of the maternity or parental leave cover contract
     job_title:
       blank: Enter a job title
       too_short: Job title must be at least %{count} characters

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -207,7 +207,9 @@ en:
           We'll only use this to tell you about opportunities to take part in user research that helps us improve
           Department for Education services.
       publishers_job_listing_job_details_form:
-        contract_type_duration: >-
+        fixed_term_contract_duration: >-
+          Contract length should be more than 12 weeks. Short term cover should not be advertised on Teaching Vacancies
+        parental_leave_cover_contract_duration: >-
           Contract length should be more than 12 weeks. Short term cover should not be advertised on Teaching Vacancies
         job_title:
           middle: >-
@@ -546,9 +548,11 @@ en:
         starts_asap_options:
           "true": As soon as possible
       publishers_job_listing_job_details_form:
-        contract_type_duration: Duration of fixed term contract
+        fixed_term_contract_duration: Duration of contract
+        parental_leave_cover_contract_duration: Duration of contract
         contract_type_options:
           fixed_term: Fixed term
+          parental_leave_cover: Maternity or parental leave cover
           permanent: Permanent
         job_title: Job title
         # TODO: These job_roles_options are no longer on this form, but are used throughout the

--- a/db/migrate/20211209142008_add_contract_durations_to_vacancies.rb
+++ b/db/migrate/20211209142008_add_contract_durations_to_vacancies.rb
@@ -1,0 +1,6 @@
+class AddContractDurationsToVacancies < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :vacancies, :contract_type_duration, :fixed_term_contract_duration
+    add_column :vacancies, :parental_leave_cover_contract_duration, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -454,7 +454,7 @@ ActiveRecord::Schema.define(version: 2021_12_09_154121) do
     t.uuid "publisher_organisation_id"
     t.boolean "starts_asap", default: false
     t.integer "contract_type"
-    t.string "contract_type_duration"
+    t.string "fixed_term_contract_duration"
     t.text "personal_statement_guidance"
     t.integer "end_listing_reason"
     t.integer "candidate_hired_from"
@@ -469,6 +469,7 @@ ActiveRecord::Schema.define(version: 2021_12_09_154121) do
     t.string "readable_phases", default: [], array: true
     t.tsvector "searchable_content"
     t.boolean "google_index_removed", default: false
+    t.string "parental_leave_cover_contract_duration"
     t.index ["expires_at"], name: "index_vacancies_on_expires_at"
     t.index ["geolocation"], name: "index_vacancies_on_geolocation", using: :gist
     t.index ["initially_indexed"], name: "index_vacancies_on_initially_indexed"

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -24,7 +24,8 @@ FactoryBot.define do
     contact_email { Faker::Internet.email(domain: "example.com") }
     contact_number { "01234 123456" }
     contract_type { factory_sample(Vacancy.contract_types.keys) }
-    contract_type_duration { "6 months" }
+    fixed_term_contract_duration { "6 months" }
+    parental_leave_cover_contract_duration { "6 months" }
     expires_at { 6.months.from_now.change(hour: 9, minute: 0, second: 0) }
     hired_status { nil }
     job_advert { Faker::Lorem.paragraph(sentence_count: factory_rand(50..300)) }

--- a/spec/form_models/publishers/job_listing/job_details_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/job_details_form_spec.rb
@@ -12,7 +12,13 @@ RSpec.describe Publishers::JobListing::JobDetailsForm, type: :model do
   context "when contract_type is fixed_term" do
     before { allow(subject).to receive(:contract_type).and_return("fixed_term") }
 
-    it { is_expected.to validate_presence_of(:contract_type_duration) }
+    it { is_expected.to validate_presence_of(:fixed_term_contract_duration) }
+  end
+
+  context "when contract_type is parental_leave_cover" do
+    before { allow(subject).to receive(:contract_type).and_return("parental_leave_cover") }
+
+    it { is_expected.to validate_presence_of(:parental_leave_cover_contract_duration) }
   end
 
   context "when key stages is not present" do

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -421,12 +421,36 @@ RSpec.describe Vacancy do
     end
 
     context "when changing contract type to permanent" do
-      subject { create(:vacancy, contract_type: "fixed_term", contract_type_duration: "8 months") }
+      subject { create(:vacancy, contract_type: "fixed_term", fixed_term_contract_duration: "8 months", parental_leave_cover_contract_duration: "8 months") }
 
       before { subject.update contract_type: "permanent" }
 
-      it "resets contract_type_duration field" do
-        expect(subject.contract_type_duration).to be_blank
+      it "resets fixed_term_contract_duration field" do
+        expect(subject.fixed_term_contract_duration).to be_blank
+      end
+
+      it "resets parental_leave_cover_contract_duration field" do
+        expect(subject.parental_leave_cover_contract_duration).to be_blank
+      end
+    end
+
+    context "when changing contract type from fixed_term to parental_leave_cover" do
+      subject { create(:vacancy, contract_type: "fixed_term", fixed_term_contract_duration: "8 months") }
+
+      before { subject.update contract_type: "parental_leave_cover" }
+
+      it "resets fixed_term_contract_duration field" do
+        expect(subject.fixed_term_contract_duration).to be_blank
+      end
+    end
+
+    context "when changing contract type from parental_leave_cover to fixed_term" do
+      subject { create(:vacancy, contract_type: "parental_leave_cover", parental_leave_cover_contract_duration: "8 months") }
+
+      before { subject.update contract_type: "fixed_term" }
+
+      it "resets parental_leave_cover_contract_duration field" do
+        expect(subject.parental_leave_cover_contract_duration).to be_blank
       end
     end
 

--- a/spec/presenters/vacancy_presenter_spec.rb
+++ b/spec/presenters/vacancy_presenter_spec.rb
@@ -238,12 +238,12 @@ RSpec.describe VacancyPresenter do
     end
   end
 
-  describe "#contract_type_with_duration" do
-    let(:vacancy) { build_stubbed(:vacancy, contract_type: contract_type, contract_type_duration: contract_type_duration) }
+  describe "#fixed_term_contract_duration" do
+    let(:vacancy) { build_stubbed(:vacancy, contract_type: contract_type, fixed_term_contract_duration: fixed_term_contract_duration) }
 
     context "when permanent" do
       let(:contract_type) { :permanent }
-      let(:contract_type_duration) { nil }
+      let(:fixed_term_contract_duration) { nil }
 
       it "returns Permanent" do
         expect(subject.contract_type_with_duration).to eq "Permanent"
@@ -252,10 +252,32 @@ RSpec.describe VacancyPresenter do
 
     context "when fixed term" do
       let(:contract_type) { :fixed_term }
-      let(:contract_type_duration) { "6 months" }
+      let(:fixed_term_contract_duration) { "6 months" }
 
       it "returns Fixed term (duration)" do
         expect(subject.contract_type_with_duration).to eq "Fixed term (6 months)"
+      end
+    end
+  end
+
+  describe "#parental_leave_cover_contract_duration" do
+    let(:vacancy) { build_stubbed(:vacancy, contract_type: contract_type, parental_leave_cover_contract_duration: parental_leave_cover_contract_duration) }
+
+    context "when permanent" do
+      let(:contract_type) { :permanent }
+      let(:parental_leave_cover_contract_duration) { nil }
+
+      it "returns Permanent" do
+        expect(subject.contract_type_with_duration).to eq "Permanent"
+      end
+    end
+
+    context "when parental_leave cover" do
+      let(:contract_type) { :parental_leave_cover }
+      let(:parental_leave_cover_contract_duration) { "6 months" }
+
+      it "returns Maternity or parental leave cover (duration)" do
+        expect(subject.contract_type_with_duration).to eq "Maternity or parental leave cover (6 months)"
       end
     end
   end

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -48,7 +48,8 @@ module VacancyHelpers
         check I18n.t("helpers.label.publishers_job_listing_job_role_details_form.additional_job_roles_options.#{key_stage}")
       end
     end
-    fill_in "publishers_job_listing_job_details_form[contract_type_duration]", with: vacancy.contract_type_duration
+    fill_in "publishers_job_listing_job_details_form[fixed_term_contract_duration]", with: vacancy.fixed_term_contract_duration
+    fill_in "publishers_job_listing_job_details_form[parental_leave_cover_contract_duration]", with: vacancy.parental_leave_cover_contract_duration
   end
 
   def fill_in_working_patterns_form_fields(vacancy)


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3453

## Changes in this PR:

This PR adds "Maternity or parental leave cover" as a contract type. `:contract_type_duration` is removed and replaced by two attributes reflect the two different temporary contract types: `:fixed_term_contract_duration` and `:parental_leave_cover_contract_duration`. 

## Screenshots of UI changes:

### Before

![image](https://user-images.githubusercontent.com/24639777/146178351-127daea8-80e6-4ed3-a2ea-b17053ddf440.png)

### After

![image](https://user-images.githubusercontent.com/24639777/146161330-407466ce-07d4-47f2-adf7-13dd5f0c5ae9.png)