### PR TITLE
Make homepage location facets more resilient

### DIFF
--- a/app/services/vacancy_facets.rb
+++ b/app/services/vacancy_facets.rb
@@ -64,11 +64,13 @@ class VacancyFacets
   end
 
   def facet_counts(query)
-    # Disable this very expensive operation unless caching is enabled (e.g. in dev, system tests)
-    return 0 unless Rails.application.config.action_controller.perform_caching
+    fail_safe(0) do
+      # Disable this very expensive operation unless caching is enabled (e.g. in dev, system tests)
+      return 0 unless Rails.application.config.action_controller.perform_caching
 
-    return 0 if query[:location] && LocationPolygon.none?
+      return 0 if query[:location] && LocationPolygon.none?
 
-    Search::VacancySearch.new(query).total_count || 0
+      Search::VacancySearch.new(query).total_count || 0
+    end
   end
 end


### PR DESCRIPTION
These should degrade gracefully if an error occurs in searching for
a facet value.