### PR TITLE
Require lib files from within individual specs

### DIFF
--- a/spec/lib/dfe_sign_in_api_spec.rb
+++ b/spec/lib/dfe_sign_in_api_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "dfe_sign_in_api"
 
 RSpec.shared_examples "a DFE Sign In endpoint" do
   context "when the external response status is 500" do

--- a/spec/lib/export_dsi_approver_records_to_big_query_spec.rb
+++ b/spec/lib/export_dsi_approver_records_to_big_query_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "export_dsi_approvers_to_big_query"
 
 RSpec.describe ExportDsiApproversToBigQuery do
   before do

--- a/spec/lib/export_dsi_user_to_big_query_spec.rb
+++ b/spec/lib/export_dsi_user_to_big_query_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "export_dsi_users_to_big_query"
 
 RSpec.describe ExportDsiUsersToBigQuery do
   before do

--- a/spec/lib/fail_safe_spec.rb
+++ b/spec/lib/fail_safe_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "fail_safe"
 
 RSpec.describe Kernel do
   context "when the block raises an error" do

--- a/spec/lib/flag_spec.rb
+++ b/spec/lib/flag_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "flag"
 
 RSpec.describe Flag do
   context "when the flag is a feature flag" do

--- a/spec/lib/geocoding_spec.rb
+++ b/spec/lib/geocoding_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "geocoding"
 
 RSpec.describe Geocoding, geocode: true do
   subject { described_class.new(location) }

--- a/spec/lib/indexing_spec.rb
+++ b/spec/lib/indexing_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "indexing"
 
 RSpec.describe Indexing do
   let(:url) { "https://google.com" }

--- a/spec/lib/message_encryptor_spec.rb
+++ b/spec/lib/message_encryptor_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
+require "message_encryptor"
 
-RSpec.describe "MessageEnryptor" do
+RSpec.describe MessageEncryptor do
   describe "it can #encrypt and #decrypt data" do
     it "an array" do
       data = %w[an array of data]

--- a/spec/lib/modules/aws_ip_ranges_spec.rb
+++ b/spec/lib/modules/aws_ip_ranges_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "modules/aws_ip_ranges"
 
 RSpec.describe AWSIpRanges do
   describe ".cloudfront_ips" do

--- a/spec/lib/remove_invalid_subscriptions_spec.rb
+++ b/spec/lib/remove_invalid_subscriptions_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "remove_invalid_subscriptions"
 
 RSpec.describe RemoveInvalidSubscriptions do
   subject { described_class.new }

--- a/spec/lib/update_dsi_users_in_db_spec.rb
+++ b/spec/lib/update_dsi_users_in_db_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "update_dsi_users_in_db"
 
 RSpec.describe UpdateDsiUsersInDb do
   let(:test_file_1_path) { Rails.root.join("spec/fixtures/dfe_sign_in_service_users_response_page_1.json") }

--- a/spec/lib/vcap_services_spec.rb
+++ b/spec/lib/vcap_services_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "vcap_services"
 
 RSpec.describe VcapServices do
   subject { described_class.new(env_var) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -43,7 +43,6 @@ Capybara.server = :puma, { Silent: true, Threads: "0:1" }
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 Dir[Rails.root.join("spec/components/shared_examples/*.rb")].each { |f| require f }
 Dir[Rails.root.join("spec/page_objects/**/*.rb")].each { |f| require f }
-Dir[Rails.root.join("lib/**/*.rb")].each { |f| require f }
 
 ActiveRecord::Migration.maintain_test_schema!
 


### PR DESCRIPTION
We almost had an issue in production because, while the test suite had automatically
loaded a file from lib, the app itself never did.

Tests should never autoload more than the app itself does, so that we can catch such
problems before it's too late in the future.

Reverts my mid-2020 PR: https://github.com/DFE-Digital/teaching-vacancies/pull/1844
