### PR TITLE
Use Noticed gem's has_noticed_notifications method again

### DIFF
--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -32,11 +32,7 @@ class JobApplication < ApplicationRecord
   has_many :employments, dependent: :destroy
   has_many :references, dependent: :destroy
 
-  # TODO: This is equivalent to the behaviour of the noticed` gem's `has_noticed_notification`
-  #       method. However, the gem does not support the PostGIS adapter so until that is fixed
-  #       we need to do this manually.
-  #       c.f. https://github.com/excid3/noticed/pull/150
-  before_destroy { Notification.where("params @> ?", Noticed::Coder.dump(job_application: self).to_json).destroy_all }
+  has_noticed_notifications
 
   scope :submitted_yesterday, -> { submitted.where("DATE(submitted_at) = ?", Date.yesterday) }
   scope :after_submission, -> { where(status: %w[submitted reviewed shortlisted unsuccessful withdrawn]) }

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -67,9 +67,8 @@ class Vacancy < ApplicationRecord
   validates :slug, presence: true
   validate :enable_job_applications_cannot_be_changed_once_listed
 
-  # TODO: This is equivalent to the behaviour of the noticed` gem's `has_noticed_notification` method. However, the gem
-  #       does not support the PostGIS adapter so until that is fixed we need to do this manually. c.f. https://github.com/excid3/noticed/pull/150
-  before_destroy { Notification.where("params @> ?", Noticed::Coder.dump(vacancy: self).to_json).destroy_all }
+  has_noticed_notifications
+
   before_save :on_expired_vacancy_feedback_submitted_update_stats_updated_at
   before_save :refresh_geolocation, if: -> { job_location_changed? }
 


### PR DESCRIPTION
Now that @csutter 's PR has been merged and we are on the latest version of the gem
we can use has_noticed_notifications again:

https://github.com/excid3/noticed/pull/150
