### PR TITLE
Do not autosubmit form on new subscription page

### DIFF
--- a/app/components/filters_component.rb
+++ b/app/components/filters_component.rb
@@ -18,7 +18,7 @@ class FiltersComponent < GovukComponent::Base
     filters.present?
   end
 
-  def display_remove_buttons
+  def display_remove_buttons?
     filters[:total_count].positive? && options[:remove_buttons]
   end
 

--- a/app/components/filters_component/filters_component.html.slim
+++ b/app/components/filters_component/filters_component.html.slim
@@ -5,7 +5,7 @@
       .filters-component__heading-container
         = govuk_link_to t(".add_or_remove_schools"), edit_publisher_preference_path(options[:publisher_preference]), class: "filters-component__link-button add-remove-schools govuk-link--no-visited-state"
 
-  - if display_remove_buttons
+  - if display_remove_buttons?
     .filters-component__remove
       .filters-component-filter__selected
         .filters-component__section-heading class="govuk-!-margin-bottom-2"
@@ -38,7 +38,7 @@
           small: group[:small],
           legend: { text: group[:legend], size: (group[:small] ? "s" : "m") },
           hint: nil,
-          form_group: { data: { action: "change->form#submitListener" } }
+          form_group: (options[:autosubmit_form] ? { data: { action: "change->form#submitListener" } } : {})
 
   .filters-component__submit
     = form.govuk_submit t("buttons.apply_filters"), classes: "govuk-!-margin-top-4 govuk-!-margin-bottom-2 filters-component__submit-button"

--- a/app/views/subscriptions/_fields.html.slim
+++ b/app/views/subscriptions/_fields.html.slim
@@ -63,7 +63,7 @@ ruby:
   = render(FiltersComponent.new(form: f,
     filters: { total_count: 0, title: t("subscriptions.edit.filters") },
     items: items,
-    options: { remove_buttons: false, mobile_variant: false, close_all: false }))
+    options: { remove_buttons: false, mobile_variant: false, close_all: false, autosubmit_form: false }))
 
 .divider-bottom
 

--- a/app/views/vacancies/_search.html.slim
+++ b/app/views/vacancies/_search.html.slim
@@ -114,5 +114,5 @@ ruby:
         = render(FiltersComponent.new(form: f,
           filters: { total_count: @form.total_filters },
           items: items,
-          options: { remove_buttons: true, mobile_variant: true, close_all: true },
+          options: { remove_buttons: true, mobile_variant: true, close_all: true, autosubmit_form: true },
           html_attributes: { tabindex: "-1", id: "filters-component" }))


### PR DESCRIPTION
We need to be able to toggle the autosubmit JS on and off depending whether the FiltersComponent is displayed on the new suscription page or on the jobs search results page.

No ticket. Just spotted this bug and wanted to fix it.
