### PR TITLE
[TEVA-3598] Update hint text on job details and job advert

### DIFF
--- a/app/views/publishers/vacancies/build/job_details.html.slim
+++ b/app/views/publishers/vacancies/build/job_details.html.slim
@@ -21,7 +21,6 @@
           = f.govuk_text_field :job_title,
             label: { size: "s" },
             class: "govuk-input string required govuk-js-character-count",
-            hint: { text: t("helpers.hint.publishers_job_listing_job_details_form.job_title.#{vacancy.one_phase? ? vacancy.readable_phases.first : 'multiple_phases'}") },
             required: true
           span#publishers-job-listing-job-details-form-job-title-field-info.govuk-hint.govuk-character-count__message aria-live="polite"
             | You can enter up to 100 characters

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -209,16 +209,7 @@ en:
       publishers_job_listing_job_details_form:
         contract_type_duration: >-
           Contract length should be more than 12 weeks. Short term cover should not be advertised on Teaching Vacancies
-        job_title:
-          middle: >-
-            Include subject and level of seniority, if relevant. For example, ‘Subject leader for science’. You should
-            also include the key stage, if relevant.
-          multiple_phases: >-
-            Include subject and level of seniority, if relevant. For example, ‘Subject leader for science’. You should
-            also include the key stage, if relevant.
-          primary: Include key stage, if relevant.
-          secondary: Include subject and level of seniority, if relevant. For example, ‘Subject leader for science’.
-          16-19: Include subject and level of seniority, if relevant. For example, ‘Subject leader for science’.
+        job_title: Jobseekers respond better to short, simple job titles. You should include seniority level, subject or key stage, if relevant. Avoid start date, salary and responsibilities which will be covered in the job description.
         key_stages:
           middle: Only complete this field if it’s relevant to the role.
           multiple_phases: What key stages will the role focus on?
@@ -244,8 +235,9 @@ en:
           Give a brief summary of the schools where the jobseeker would be teaching and any relevant information about
           the %{organisation_type}
         job_advert: >-
-          Give a brief summary of the job that jobseekers can quickly scan.
-          This will be the first thing they see on the listing or in search engine results
+          Get jobseekers interested in the role by providing a brief summary of around 400 words.
+          You should cover what the role is and who you're looking to recruit.
+          The first 20 to 40 words will be shown in search results, so make them stand out.
       publishers_job_listing_pay_package_form:
         actual_salary: For part time or term time roles this is what the candidate will actually be paid
         benefits: >-


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3598

## Changes in this PR:

This PR updates the hint text on the "**Job title**" field in the _Job details_ section, and the "**Job advert"** field in the _Job summary_ section.

## Screenshots of UI changes:

### Before
![image](https://user-images.githubusercontent.com/24639777/146360087-736e0526-e6c1-4419-a811-1e8bb79b7a86.png)

![image](https://user-images.githubusercontent.com/24639777/146359973-ac339943-a279-4ee5-9484-14c979cd9ef8.png)

### After
![image](https://user-images.githubusercontent.com/24639777/146360049-7b7a3f01-b1b4-4966-bf6c-e25be30649eb.png)

![image](https://user-images.githubusercontent.com/24639777/146359770-9ff1b3c2-324e-4a47-a589-4dee5b12282f.png)
