### PR TITLE
Simplify robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -5,10 +5,4 @@ Disallow: /check
 Disallow: /subscriptions/
 Disallow: /documents/
 Disallow: /attachments/
-Disallow: /teaching-jobs-in-*?location*
-Disallow: /teaching-jobs-for-*?job_role*
-Disallow: /teaching-jobs-for-*?phase*
-Disallow: /teaching-jobs-for-*?subject*
-Disallow: /*-jobs*?job_role*
-Disallow: /*-jobs*?phase*
-Disallow: /*-jobs*?subject*
+Disallow: /*-jobs*?*


### PR DESCRIPTION
We don't actually want any landing pages with query parameters to be indexed by Google, since they will use up some of the indexing budget that we'd rather was spent on more valuable pages.
