### PR TITLE
[TEVA-3618] Update new features page and application feature reminder page

### DIFF
--- a/app/controllers/publishers/new_features_controller.rb
+++ b/app/controllers/publishers/new_features_controller.rb
@@ -3,6 +3,7 @@ class Publishers::NewFeaturesController < Publishers::BaseController
 
   # TODO: update the date here before merging this PR.
   NEW_FEATURES_PAGE_UPDATED_AT = DateTime.new(2021, 12, 21).freeze # This constant lives here so that we remember to update it.
+  raise "Do not merge until you have updated the constant to the date of merging"
 
   def show
     @new_features_form = Publishers::NewFeaturesForm.new

--- a/app/controllers/publishers/new_features_controller.rb
+++ b/app/controllers/publishers/new_features_controller.rb
@@ -1,9 +1,7 @@
 class Publishers::NewFeaturesController < Publishers::BaseController
   skip_before_action :check_terms_and_conditions, only: %i[show update reminder]
 
-  # TODO: update the date here before merging this PR.
-  NEW_FEATURES_PAGE_UPDATED_AT = DateTime.new(2021, 12, 21).freeze # This constant lives here so that we remember to update it.
-  raise "Do not merge until you have updated the constant to the date of merging"
+  NEW_FEATURES_PAGE_UPDATED_AT = DateTime.new(2022, 1, 7).freeze # This constant lives here so that we remember to update it.
 
   def show
     @new_features_form = Publishers::NewFeaturesForm.new

--- a/app/controllers/publishers/new_features_controller.rb
+++ b/app/controllers/publishers/new_features_controller.rb
@@ -1,9 +1,11 @@
 class Publishers::NewFeaturesController < Publishers::BaseController
   skip_before_action :check_terms_and_conditions, only: %i[show update reminder]
 
+  # TODO: update the date here before merging this PR.
+  NEW_FEATURES_PAGE_UPDATED_AT = DateTime.new(2021, 12, 21).freeze # This constant lives here so that we remember to update it.
+
   def show
     @new_features_form = Publishers::NewFeaturesForm.new
-    current_publisher.update(viewed_new_features_page_at: Time.current)
     session[:visited_new_features_page] = true
   end
 
@@ -15,7 +17,7 @@ class Publishers::NewFeaturesController < Publishers::BaseController
   end
 
   def reminder
-    session[:viewed_new_features_reminder_at] = Time.current
+    session[:visited_application_feature_reminder_page] = true
   end
 
   private

--- a/app/controllers/publishers/sessions_controller.rb
+++ b/app/controllers/publishers/sessions_controller.rb
@@ -21,7 +21,7 @@ class Publishers::SessionsController < Devise::SessionsController
     @publisher_dsi_token = session[:publisher_dsi_token]
     session.delete(:publisher_organisation_id)
     session.delete(:visited_new_features_page)
-    session.delete(:viewed_new_features_reminder_at)
+    session.delete(:visited_application_feature_reminder_page)
     super
   end
 

--- a/app/controllers/publishers/vacancies_controller.rb
+++ b/app/controllers/publishers/vacancies_controller.rb
@@ -66,13 +66,16 @@ class Publishers::VacanciesController < Publishers::Vacancies::BaseController
   end
 
   def redirect_to_new_features_reminder
-    redirect_to reminder_new_features_path if show_application_reminder_page?
+    redirect_to reminder_new_features_path if show_application_feature_reminder_page?
   end
 
-  def show_application_reminder_page?
-    return false if session[:viewed_new_features_reminder_at].present?
-    return false if (viewed_at = current_publisher.viewed_new_features_page_at).blank?
+  def show_application_feature_reminder_page?
+    return false if session[:visited_application_feature_reminder_page] || session[:visited_new_features_page]
 
-    Vacancy.published.where(publisher_id: current_publisher.id, enable_job_applications: false, created_at: viewed_at..).any?
+    Vacancy.published.where(
+      publisher_id: current_publisher.id,
+      enable_job_applications: true,
+      created_at: Publishers::NewFeaturesController::NEW_FEATURES_PAGE_UPDATED_AT..,
+    ).none?
   end
 end

--- a/app/views/publishers/new_features/reminder.html.slim
+++ b/app/views/publishers/new_features/reminder.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, t("jobs.reminder_title")
+- content_for :page_title_prefix, t(".page_title")
 
 .govuk-main-wrapper
   .govuk-grid-row
@@ -6,8 +6,8 @@
       h1.govuk-heading-m
         = t("jobs.create_a_job_title", organisation: current_organisation.name)
       h2.govuk-heading-l class="govuk-!-margin-top-7"
-        = t("jobs.reminder_title")
+        = t(".page_title")
       p.govuk-body
-        = t("jobs.reminder_body")
+        = t(".content")
       = govuk_link_to t("application_pack.link_text", size: application_pack_asset_size), application_pack_asset_path, target: "_blank", class: "govuk-body", download: t("application_pack.link_download_attr")
-      = govuk_button_to t("jobs.reminder_continue_button"), organisation_jobs_path, class: "govuk-!-margin-top-8"
+      = govuk_button_to t("buttons.reminder_continue"), organisation_jobs_path, class: "govuk-!-margin-top-8"

--- a/app/views/publishers/new_features/show.html.slim
+++ b/app/views/publishers/new_features/show.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, t("new_features.page_title")
+- content_for :page_title_prefix, t(".page_title")
 
 .govuk-main-wrapper
   .govuk-grid-row
@@ -6,11 +6,11 @@
       = form_for @new_features_form, url: new_features_path, method: :patch do |f|
         = f.govuk_error_summary
 
-        h1.govuk-heading-l = t("new_features.page_title")
+        h1.govuk-heading-l = t(".page_title")
 
-        h2.govuk-heading-m = t("new_features.applications")
+        h2.govuk-heading-m = t(".heading")
 
-        p.govuk-body = t("new_features.content")
+        p.govuk-body = t(".content")
 
         = govuk_link_to t("application_pack.link_text", size: application_pack_asset_size), application_pack_asset_path, target: "_blank", class: "govuk-body", download: t("application_pack.link_download_attr")
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -258,13 +258,6 @@ en:
         link: SEND responsibilities
       subjects: Current jobs by subject
 
-  new_features:
-    applications: Applications
-    content: >-
-      You can now receive and manage job applications on Teaching Vacancies. You can
-      do this for all jobs except education support roles.
-    page_title: New features for hiring staff
-
   pages:
     accessibility:
       page_description:

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -53,6 +53,7 @@ en:
     manage_listing: Manage job listing
     preview_job_listing: Preview job listing
     reject: Reject
+    reminder_continue: Continue to create a job
     request_dsi_account: Request a DfE Sign-in account
     resend_email: Resend request
     save: Save

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -155,9 +155,6 @@ en:
     copy_job_title: Copy %{job_title}
     manage_listing: Manage %{state} listing
     new_job_listing_details: New job listing details
-    reminder_body: You can now receive and manage job applications on Teaching Vacancies. You can do this for all jobs except education support roles.
-    reminder_continue_button: Continue to create a job
-    reminder_title: A reminder about applications
     review_page_title: Review the job listing — Create a job listing for %{organisation}
     edit_job_title: Edit %{job_title}
     current_step: Step %{step} of %{total}

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -1,5 +1,15 @@
 en:
   publishers:
+    new_features:
+      show:
+        heading: Applications for education support roles
+        content: >-
+          You can now receive and manage applications for education support roles on Teaching Vacancies.
+        page_title: New features for hiring staff
+      reminder:
+        content: You can now receive and manage job applications for all roles on Teaching Vacancies, including education support roles.
+        page_title: A reminder about applications
+
     notifications:
       index:
         heading: Notifications
@@ -9,26 +19,11 @@ en:
           zero: No unread notifications
           one: 1 unread notification
           other: "%{count} unread notifications"
+    no_vacancies_component:
+      heading: You have no job listings to manage
     omniauth_callbacks:
       failure:
         message: Your session has expired so you have been logged out. Please sign in again to your account below.
-    sessions:
-      create:
-        not_authorised: You are not authorised to log in
-      new:
-        no_account:
-          account_request_html: If you don't yet have access to Teaching Vacancies you can %{link}
-          account_request_link_text: request an account
-          content_html: If you have a DfE Sign-in account but can't access Teaching Vacancies, %{link} and select 'Request access to a service'
-          heading: Don't have an account yet?
-          login_link_text: log in
-        page_description: If you already have a Teaching Vacancies account you can sign in to the service here.
-        sign_in:
-          description: Use DfE Sign-in to access your Teaching Vacancies account.
-          description_fallback: Enter your email below and we will send you a link that will take you straight into your account.
-          title: Hiring staff sign in
-    no_vacancies_component:
-      heading: You have no job listings to manage
     organisations:
       aria_change_description: '%{organisation_type} description'
       aria_change_website: '%{organisation_type} website'
@@ -75,6 +70,21 @@ en:
         description_2: >-
           Once you have selected a school, you will be able to post and edit jobs listings for that school.
         page_title: Add or remove schools from your account
+    sessions:
+      create:
+        not_authorised: You are not authorised to log in
+      new:
+        no_account:
+          account_request_html: If you don't yet have access to Teaching Vacancies you can %{link}
+          account_request_link_text: request an account
+          content_html: If you have a DfE Sign-in account but can't access Teaching Vacancies, %{link} and select 'Request access to a service'
+          heading: Don't have an account yet?
+          login_link_text: log in
+        page_description: If you already have a Teaching Vacancies account you can sign in to the service here.
+        sign_in:
+          description: Use DfE Sign-in to access your Teaching Vacancies account.
+          description_fallback: Enter your email below and we will send you a link that will take you straight into your account.
+          title: Hiring staff sign in
     temp_login:
       check_your_email:
         check_spam_html: >-

--- a/db/migrate/20211216161208_remove_viewed_new_features_page_at_from_publishers.rb
+++ b/db/migrate/20211216161208_remove_viewed_new_features_page_at_from_publishers.rb
@@ -1,0 +1,5 @@
+class RemoveViewedNewFeaturesPageAtFromPublishers < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :publishers, :viewed_new_features_page_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_09_154121) do
+ActiveRecord::Schema.define(version: 2021_12_16_161208) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -348,7 +348,6 @@ ActiveRecord::Schema.define(version: 2021_12_09_154121) do
     t.text "family_name_ciphertext"
     t.text "given_name_ciphertext"
     t.datetime "dismissed_new_features_page_at"
-    t.datetime "viewed_new_features_page_at"
     t.index ["oid"], name: "index_publishers_on_oid", unique: true
   end
 

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -63,6 +63,6 @@ end
 namespace :publishers do
   desc "Reset 'New features' attributes so all publishers are shown 'New features' page"
   task reset_new_features_attributes: :environment do
-    Publisher.update_all(dismissed_new_features_page_at: nil, viewed_new_features_page_at: nil)
+    Publisher.update_all(dismissed_new_features_page_at: nil)
   end
 end

--- a/spec/factories/publishers.rb
+++ b/spec/factories/publishers.rb
@@ -6,6 +6,5 @@ FactoryBot.define do
     family_name { Faker::Name.last_name.delete("'") }
     given_name { Faker::Name.first_name }
     oid { Faker::Crypto.md5 }
-    viewed_new_features_page_at { 2.days.ago }
   end
 end

--- a/spec/support/auth_helpers.rb
+++ b/spec/support/auth_helpers.rb
@@ -1,5 +1,6 @@
 module AuthHelpers
-  def login_publisher(publisher:, organisation:)
+  def login_publisher(publisher:, organisation:, allow_reminders: false)
+    page.set_rack_session(visited_application_feature_reminder_page: true) unless allow_reminders
     page.set_rack_session(publisher_organisation_id: organisation.id)
     login_as(publisher, scope: :publisher)
   end

--- a/spec/system/publishers_are_reminded_of_application_functionality_spec.rb
+++ b/spec/system/publishers_are_reminded_of_application_functionality_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Application feature reminder" do
   let(:publisher) { create(:publisher) }
   let(:last_vacancy) { Vacancy.order("created_at").last }
 
-  before { login_publisher(publisher: publisher, organisation: organisation) }
+  before { login_publisher(publisher: publisher, organisation: organisation, allow_reminders: true) }
 
   context "when at least one vacancy has been published that accepts applications through TV" do
     let!(:vacancy) { create(:vacancy, :published, enable_job_applications: true, publisher: publisher, organisations: [organisation]) }

--- a/spec/system/publishers_are_reminded_of_application_functionality_spec.rb
+++ b/spec/system/publishers_are_reminded_of_application_functionality_spec.rb
@@ -7,56 +7,62 @@ RSpec.describe "Application feature reminder" do
 
   before { login_publisher(publisher: publisher, organisation: organisation) }
 
-  context "when publisher has not seen the new features page" do
-    let(:publisher) { create(:publisher, viewed_new_features_page_at: nil) }
+  context "when at least one vacancy has been published that accepts applications through TV" do
+    let!(:vacancy) { create(:vacancy, :published, enable_job_applications: true, publisher: publisher, organisations: [organisation]) }
 
-    it "does not show reminder page when visiting create job link" do
+    it "does not show reminder page when creating a job" do
       visit organisation_path
       click_on I18n.t("buttons.create_job")
-      expect(current_path).to eq(organisation_job_build_path(last_vacancy.id, :job_role))
+      expect(current_path).to eq(create_or_copy_organisation_jobs_path)
     end
   end
 
-  context "when publisher has seen the new features page" do
-    let(:publisher) { create(:publisher, viewed_new_features_page_at: 1.days.ago) }
+  context "when no vacancy that accepts applications through TV has been published since the last update to the new features page" do
+    before { stub_const("Publishers::NewFeaturesController::NEW_FEATURES_PAGE_UPDATED_AT", DateTime.new(2020, 1, 1).freeze) }
 
-    context "when there are vacancies published since that accept applications through teacher vacancies" do
-      let!(:vacancy) { create(:vacancy, :published, enable_job_applications: true, created_at: Time.now, publisher: publisher, organisations: [organisation]) }
+    let!(:vacancy) { create(:vacancy, :published, enable_job_applications: false, publisher: publisher, organisations: [organisation]) }
 
-      it "does not show reminder page when creating a job" do
+    it "shows reminder page before first step of create job and does not show it twice in the same session" do
+      visit organisation_path
+      click_on I18n.t("buttons.create_job")
+      click_on "Continue"
+
+      expect(page).to have_content(I18n.t("publishers.new_features.reminder.page_title"))
+      expect(page).to have_link(I18n.t("application_pack.link_text", size: application_pack_asset_size), href: application_pack_asset_path)
+
+      click_on I18n.t("buttons.reminder_continue")
+
+      expect(current_path).to eq(organisation_job_build_path(last_vacancy.id, :job_role))
+
+      choose find(:css, ".govuk-radios .govuk-radios__item label", match: :first).text
+      click_on I18n.t("buttons.continue")
+
+      expect(page).not_to have_content(I18n.t("publishers.new_features.reminder.page_title"))
+
+      visit organisation_path
+      click_on I18n.t("buttons.create_job")
+      expect(current_path).to eq(create_or_copy_organisation_jobs_path)
+    end
+
+    it "does not show reminder page when editing a job" do
+      visit organisation_job_path(vacancy.id)
+
+      click_on "Change", match: :first
+
+      expect(current_path).to eq(organisation_job_build_path(last_vacancy.id, :job_role))
+    end
+
+    context "when the publisher has seen the new features page during the current session" do
+      let(:publisher) { create(:publisher, dismissed_new_features_page_at: nil) }
+
+      it "does not show the reminder page" do
+        visit organisation_path
+        expect(current_path).to eq(new_features_path)
+        check I18n.t("helpers.label.publishers_new_features_form.dismiss_options.true")
+        click_on I18n.t("buttons.continue_to_account")
         visit organisation_path
         click_on I18n.t("buttons.create_job")
         expect(current_path).to eq(create_or_copy_organisation_jobs_path)
-      end
-    end
-
-    context "when there are vacancies published since that do not accept applications through teacher vacancies" do
-      let!(:vacancy) { create(:vacancy, :published, enable_job_applications: false, created_at: Time.now, publisher: publisher, organisations: [organisation]) }
-
-      it "shows reminder page before first step of create job" do
-        visit organisation_path
-        click_on I18n.t("buttons.create_job")
-        click_on "Continue"
-
-        expect(page).to have_content(I18n.t("jobs.reminder_title"))
-        expect(page).to have_link(I18n.t("application_pack.link_text", size: application_pack_asset_size), href: application_pack_asset_path)
-
-        click_on I18n.t("jobs.reminder_continue_button")
-
-        expect(current_path).to eq(organisation_job_build_path(last_vacancy.id, :job_role))
-
-        choose find(:css, ".govuk-radios .govuk-radios__item label", match: :first).text
-        click_on I18n.t("buttons.continue")
-
-        expect(page).not_to have_content(I18n.t("jobs.reminder_title"))
-      end
-
-      it "does not show reminder page when editing a job" do
-        visit organisation_job_path(vacancy.id)
-
-        click_on "Change", match: :first
-
-        expect(current_path).to eq(organisation_job_build_path(last_vacancy.id, :job_role))
       end
     end
   end

--- a/spec/system/publishers_are_shown_new_features_page_spec.rb
+++ b/spec/system/publishers_are_shown_new_features_page_spec.rb
@@ -2,15 +2,15 @@ require "rails_helper"
 
 RSpec.describe "Publishers are shown the new features page" do
   let(:organisation) { create(:school) }
-  let(:publisher) { create(:publisher, dismissed_new_features_page_at: nil) }
 
   before do
     allow(PublisherPreference).to receive(:find_by).and_return(instance_double(PublisherPreference))
     login_publisher(publisher: publisher, organisation: organisation)
+    visit organisation_path
   end
 
   context "when the publisher has not dismissed the new features page" do
-    before { visit organisation_path }
+    let(:publisher) { create(:publisher, dismissed_new_features_page_at: nil) }
 
     it "redirects them to the new features page after logging in" do
       expect(current_path).to eq(new_features_path)
@@ -24,34 +24,28 @@ RSpec.describe "Publishers are shown the new features page" do
       expect(current_path).to eq(organisation_path)
       expect(publisher).to be_dismissed_new_features_page_at
     end
-  end
 
-  context "when logged in as a local authority" do
-    let(:organisation) { create(:local_authority) }
+    context "when logged in as a local authority" do
+      let(:organisation) { create(:local_authority) }
 
-    before { visit organisation_path }
-
-    it "does not redirect them to the new features page" do
-      expect(current_path).to eq(organisation_path)
+      it "does not redirect them to the new features page" do
+        expect(current_path).to eq(organisation_path)
+      end
     end
-  end
 
-  context "when they have already published jobs that enable applications" do
-    let(:organisation) { create(:school) }
-    let!(:vacancy) { create(:vacancy, publisher: publisher, organisations: [organisation], enable_job_applications: true) }
+    context "when they have already used the new feature (published jobs that enable applications for education support roles)" do
+      let!(:vacancy) { create(:vacancy, enable_job_applications: true, main_job_role: "education_support", publisher: publisher, organisations: [organisation]) }
 
-    before { visit organisation_path }
+      before { visit organisation_path }
 
-    it "does not redirect them to the new features page" do
-      expect(current_path).to eq(organisation_path)
+      it "does not redirect them to the new features page" do
+        expect(current_path).to eq(organisation_path)
+      end
     end
   end
 
   context "when they have previously dismissed the new features page" do
-    let(:organisation) { create(:school) }
     let(:publisher) { create(:publisher, dismissed_new_features_page_at: 2.days.ago) }
-
-    before { visit organisation_path }
 
     it "does not redirect them to the new features page" do
       expect(current_path).to eq(organisation_path)


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3618

## Changes in this PR:

We recently allowed education support roles to be applied to through TV.

As well as updating the content, this commit changes the logic of:

- Who is shown the new features page. We will reset all publishers' dismissed_new_features_page_at attributes to nil, and will omit the page only for those who have used the application feature with education support, not merely those who have used the application feature at all.

- Who is shown the application feature reminder page. Previously we were rather 'clingy' and showed this reminder if the publisher had *ever* published a listing without using the application feature *since they last saw the new features page*. Now we will show the reminder if they *have never used* the application feature since we updated the new features page.

Note that this is not entirely encompassed by the description in the Jira ticket, but partly informed by discussion with Ben: https://ukgovernmentdfe.slack.com/archives/C02B0LJ7E2F/p1639476312018700

## Screenshots of UI changes:

![Screenshot 2021-12-20 at 12 07 04](https://user-images.githubusercontent.com/60350599/146766296-dbb82382-ebe1-4e34-bb4d-765f30c21b3d.png)

<img width="1256" alt="Screenshot 2021-12-20 at 12 18 48" src="https://user-images.githubusercontent.com/60350599/146766301-1fc6986c-2f22-4e5d-823c-46e01e8b6e15.png">

## Next steps (hence 'do not merge' label):

- [ ] Mergre https://github.com/DFE-Digital/teaching-vacancies/pull/4452 first (this branch is rebased on that one since that one fixes a test this one would otherwise break)

- [ ] Update the new constant to the date this PR is merged.

- [ ] Test out, and run, the task that resets all publishers' `dismissed_new_features_page_at` to nil (updated in this PR).

- [ ] Product review