### PR TITLE
Fix home page 'create a job listing' link

### DIFF
--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -15,8 +15,8 @@
           .signin.signin--publisher
             h2.govuk-heading-m = t(".publisher_section.title")
             - if publisher_signed_in?
-              = button_to(t("buttons.create_job"), organisation_jobs_path, class: "govuk-body govuk-link button-as-link")
               p.govuk-body = t(".publisher_section.signed_in.description_html",
+                create_job_link: govuk_link_to(t("buttons.create_job"), create_or_copy_organisation_jobs_path, class: "govuk-link--no-visited-state"),
                 manage_jobs_link: govuk_link_to(t(".publisher_section.signed_in.link_text.manage_jobs"), organisation_path, class: "govuk-link--no-visited-state"))
             - else
               p.govuk-body = t(".publisher_section.signed_out.description_html",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -229,7 +229,7 @@ en:
       publisher_section:
         title: Advertise a school job
         signed_in:
-          description_html: " or %{manage_jobs_link}."
+          description_html: "%{create_job_link} or %{manage_jobs_link}."
           link_text:
             manage_jobs: manage your jobs
         signed_out:

--- a/spec/system/publishers_can_sign_in_with_dfe_spec.rb
+++ b/spec/system/publishers_can_sign_in_with_dfe_spec.rb
@@ -89,7 +89,8 @@ RSpec.describe "Publishers can sign in with DfE Sign In" do
       within ".search-panel-banner .govuk-grid-column-one-third" do
         expect(page).to have_content(I18n.t("home.index.publisher_section.title"))
         expect(page).to have_link(I18n.t("home.index.publisher_section.signed_in.link_text.manage_jobs"), href: organisation_path)
-        expect { click_on I18n.t("buttons.create_job") }.to change { Vacancy.count }.by(1)
+        click_on I18n.t("buttons.create_job")
+        expect(current_path).to eq(create_or_copy_organisation_jobs_path)
       end
     end
   end


### PR DESCRIPTION
This used to be a button that submitted a post request to step 1 of the create a job journey,
but now we have a sort of 'step 0' where users choose whether to copy or create.

Update the link from the home page to point to step 0 instead of step 1.