### PR TITLE
[TEVA-3594] Add captions to create job/job application journey

### DIFF
--- a/app/views/jobseekers/job_applications/build/ask_for_support.html.slim
+++ b/app/views/jobseekers/job_applications/build/ask_for_support.html.slim
@@ -28,6 +28,8 @@
 
       = f.govuk_submit job_application_build_submit_button_text do
         = govuk_link_to t("buttons.cancel_and_return_to_account"), jobseekers_job_applications_path, class: "govuk-link--no-visited-state"
+        span.govuk-caption-m
+          = t("jobseekers.job_applications.cancel_caption")
 
   - if current_jobseeker.job_applications.not_draft.none?
     .govuk-grid-column-one-third

--- a/app/views/jobseekers/job_applications/build/declarations.html.slim
+++ b/app/views/jobseekers/job_applications/build/declarations.html.slim
@@ -23,6 +23,8 @@
 
       = f.govuk_submit job_application_build_submit_button_text do
         = govuk_link_to t("buttons.cancel_and_return_to_account"), jobseekers_job_applications_path, class: "govuk-link--no-visited-state"
+        span.govuk-caption-m
+          = t("jobseekers.job_applications.cancel_caption")
 
   - if current_jobseeker.job_applications.not_draft.none?
     .govuk-grid-column-one-third

--- a/app/views/jobseekers/job_applications/build/employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/build/employment_history.html.slim
@@ -81,6 +81,8 @@
     = form_for form, url: wizard_path, method: :patch do |f|
       = f.govuk_submit job_application_build_submit_button_text do
         = govuk_link_to t("buttons.cancel_and_return_to_account"), jobseekers_job_applications_path, class: "govuk-link--no-visited-state"
+        span.govuk-caption-m
+          = t("jobseekers.job_applications.cancel_caption")
 
   - if current_jobseeker.job_applications.not_draft.none?
     .govuk-grid-column-one-third

--- a/app/views/jobseekers/job_applications/build/equal_opportunities.html.slim
+++ b/app/views/jobseekers/job_applications/build/equal_opportunities.html.slim
@@ -76,6 +76,8 @@
 
       = f.govuk_submit job_application_build_submit_button_text do
         = govuk_link_to t("buttons.cancel_and_return_to_account"), jobseekers_job_applications_path, class: "govuk-link--no-visited-state"
+        span.govuk-caption-m
+          = t("jobseekers.job_applications.cancel_caption")
 
   - if current_jobseeker.job_applications.not_draft.none?
     .govuk-grid-column-one-third

--- a/app/views/jobseekers/job_applications/build/personal_details.html.slim
+++ b/app/views/jobseekers/job_applications/build/personal_details.html.slim
@@ -30,6 +30,8 @@
 
       = f.govuk_submit job_application_build_submit_button_text do
         = govuk_link_to t("buttons.cancel_and_return_to_account"), jobseekers_job_applications_path, class: "govuk-link--no-visited-state"
+        span.govuk-caption-m
+          = t("jobseekers.job_applications.cancel_caption")
 
   - if current_jobseeker.job_applications.not_draft.none?
     .govuk-grid-column-one-third

--- a/app/views/jobseekers/job_applications/build/personal_statement.html.slim
+++ b/app/views/jobseekers/job_applications/build/personal_statement.html.slim
@@ -31,6 +31,8 @@
 
       = f.govuk_submit job_application_build_submit_button_text do
         = govuk_link_to t("buttons.cancel_and_return_to_account"), jobseekers_job_applications_path, class: "govuk-link--no-visited-state"
+        span.govuk-caption-m
+          = t("jobseekers.job_applications.cancel_caption")
 
   - if current_jobseeker.job_applications.not_draft.none?
     .govuk-grid-column-one-third

--- a/app/views/jobseekers/job_applications/build/qualifications.html.slim
+++ b/app/views/jobseekers/job_applications/build/qualifications.html.slim
@@ -49,6 +49,8 @@
 
       = f.govuk_submit job_application_build_submit_button_text do
         = govuk_link_to t("buttons.cancel_and_return_to_account"), jobseekers_job_applications_path, class: "govuk-link--no-visited-state"
+        span.govuk-caption-m
+          = t("jobseekers.job_applications.cancel_caption")
 
   - if current_jobseeker.job_applications.not_draft.none?
     .govuk-grid-column-one-third

--- a/app/views/jobseekers/job_applications/build/references.html.slim
+++ b/app/views/jobseekers/job_applications/build/references.html.slim
@@ -39,8 +39,12 @@
       - if job_application.references.many?
         = f.govuk_submit job_application_build_submit_button_text do
           = govuk_link_to t("buttons.cancel_and_return_to_account"), jobseekers_job_applications_path, class: "govuk-link--no-visited-state"
+          span.govuk-caption-m
+            = t("jobseekers.job_applications.cancel_caption")
       - else
         = govuk_link_to t("buttons.cancel_and_return_to_account"), jobseekers_job_applications_path, class: "govuk-link--no-visited-state"
+        span.govuk-caption-m
+          = t("jobseekers.job_applications.cancel_caption")
 
   - if current_jobseeker.job_applications.not_draft.none?
     .govuk-grid-column-one-third

--- a/app/views/publishers/vacancies/build/job_role.html.slim
+++ b/app/views/publishers/vacancies/build/job_role.html.slim
@@ -16,6 +16,8 @@
           = f.govuk_submit t("buttons.continue")
           - unless vacancy.published?
             = govuk_link_to t("buttons.cancel_and_return_to_jobs"), jobs_with_type_organisation_path(:draft), class: "govuk-link--no-visited-state"
+            span.govuk-caption-m
+              = t("publishers.vacancies.create_or_copy.cancel_caption")
 
     - unless vacancy.published?
       .govuk-grid-column-one-third

--- a/app/views/publishers/vacancies/vacancy_form_partials/_submit.html.slim
+++ b/app/views/publishers/vacancies/vacancy_form_partials/_submit.html.slim
@@ -4,3 +4,5 @@
   - else
     = f.govuk_submit t("buttons.continue"), classes: "govuk-!-margin-bottom-5", "data-upload-documents-target": "saveListingButton"
     = govuk_link_to t("buttons.cancel_and_return_to_jobs"), jobs_with_type_organisation_path(:draft), class: "govuk-link--no-visited-state"
+    span.govuk-caption-m
+      = t("publishers.vacancies.create_or_copy.cancel_caption")

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -141,6 +141,7 @@ en:
           title: References — Application
         review:
           step_title: Review your application
+      cancel_caption: If you click cancel you will lose any unsaved information from this step. Completed details from previous steps will be saved in your draft applications.
       caption: "%{job_title} at %{organisation}"
       closing_date: Closing date
       confirm_destroy:

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -162,6 +162,7 @@ en:
         page_title: Delete draft listing
       create_or_copy:
         cancel: Cancel and return to manage jobs
+        cancel_caption: If you click cancel you will lose any unsaved information from this step. Completed details from previous steps will be saved in your draft jobs.
         form:
           options:
             copy_existing: Copy an existing job listing


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3594

## Changes in this PR:

This PR adds a caption underneath the Submit and Cancel buttons for the Create a Job journey and Job Application journey, informing the user what happens when they cancel the step.

## Screenshots of UI changes:

### Before
![image](https://user-images.githubusercontent.com/24639777/147261613-c7981cb7-7dce-41b3-8e67-40e413ff12e9.png)

### After
![image](https://user-images.githubusercontent.com/24639777/147261653-4e737ebb-2890-4ba1-a65f-dde4366641a6.png)
