### PR TITLE
Use upstream `array_enum` again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem "activerecord-import"
 gem "activerecord-postgis-adapter"
 gem "activerecord-session_store"
 gem "addressable"
-gem "array_enum", github: "DFE-Digital/array_enum"
+gem "array_enum"
 gem "aws-sdk-s3", require: false
 gem "breasal"
 gem "browser"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/DFE-Digital/array_enum.git
-  revision: 1ce3afcdc73e1ca873f92b59aae97f51c829fb4e
-  specs:
-    array_enum (1.3.0)
-      activemodel
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -82,6 +75,8 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     aes_key_wrap (1.1.0)
     amazing_print (1.4.0)
+    array_enum (1.4.0)
+      activemodel
     ast (2.4.2)
     attr_required (1.0.1)
     aws-eventstream (1.2.0)
@@ -670,7 +665,7 @@ DEPENDENCIES
   activesupport (~> 6.1.4.1)
   addressable
   amazing_print
-  array_enum!
+  array_enum
   aws-sdk-s3
   aws-sdk-ssm
   axe-core-api


### PR DESCRIPTION
The improvements we made to `array_enum` have been merged into 1.4.0
upstream:
https://github.com/freeletics/array_enum/pull/12