### PR TITLE
Add current step method to controller

### DIFF
--- a/app/controllers/publishers/vacancies/application_forms_controller.rb
+++ b/app/controllers/publishers/vacancies/application_forms_controller.rb
@@ -25,6 +25,10 @@ class Publishers::Vacancies::ApplicationFormsController < Publishers::Vacancies:
 
   private
 
+  def current_step
+    :applying_for_the_job_details
+  end
+
   def form
     @form ||= Publishers::JobListing::ApplyingForTheJobDetailsForm.new(applying_for_the_job_details_form_params, vacancy)
   end


### PR DESCRIPTION
## Changes in this PR:

This PR adds a `current_step` method to the `application_forms_controller` to ensure it returns the correct step. This fixes an issue where it was being returned as nil and breaking the step process by adding review to completed steps.
