### PR TITLE
[TEVA-3434] Re-order create a job listing steps

### DIFF
--- a/app/controllers/publishers/vacancies/application_forms_controller.rb
+++ b/app/controllers/publishers/vacancies/application_forms_controller.rb
@@ -57,7 +57,7 @@ class Publishers::Vacancies::ApplicationFormsController < Publishers::Vacancies:
       if session[:current_step] == :review
         redirect_updated_job_with_message
       else
-        redirect_to organisation_job_build_path(vacancy.id, :job_summary)
+        redirect_to organisation_job_build_path(vacancy.id, :documents)
       end
     else
       render "publishers/vacancies/build/applying_for_the_job_details"

--- a/app/controllers/publishers/vacancies/build_controller.rb
+++ b/app/controllers/publishers/vacancies/build_controller.rb
@@ -3,7 +3,7 @@ class Publishers::Vacancies::BuildController < Publishers::Vacancies::BaseContro
   include OrganisationsHelper
 
   steps :job_role, :job_role_details, :job_location, :schools, :education_phases, :job_details, :working_patterns,
-        :pay_package, :important_dates, :documents, :applying_for_the_job, :applying_for_the_job_details, :job_summary
+        :pay_package, :important_dates, :applying_for_the_job, :applying_for_the_job_details, :documents, :job_summary
 
   helper_method :back_path, :form
 

--- a/app/controllers/publishers/vacancies/documents_controller.rb
+++ b/app/controllers/publishers/vacancies/documents_controller.rb
@@ -58,7 +58,7 @@ class Publishers::Vacancies::DocumentsController < Publishers::Vacancies::BaseCo
     if session[:current_step] == :review
       redirect_updated_job_with_message
     else
-      redirect_to organisation_job_build_path(vacancy.id, :applying_for_the_job)
+      redirect_to organisation_job_build_path(vacancy.id, :job_summary)
     end
   end
 end

--- a/app/services/publishers/vacancies/vacancy_step_process.rb
+++ b/app/services/publishers/vacancies/vacancy_step_process.rb
@@ -13,8 +13,8 @@ class Publishers::Vacancies::VacancyStepProcess < StepProcess
       working_patterns: %i[working_patterns],
       pay_package: %i[pay_package],
       important_dates: %i[important_dates],
-      documents: %i[documents],
       applying_for_the_job: applying_for_the_job_steps,
+      documents: %i[documents],
       job_summary: %i[job_summary],
       review: %i[review],
     })

--- a/spec/requests/publishers/vacancies/application_forms_spec.rb
+++ b/spec/requests/publishers/vacancies/application_forms_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe "Documents" do
       end
 
       it "redirects to next step" do
-        expect(response).to redirect_to(organisation_job_build_path(vacancy.id, :job_summary))
+        expect(response).to redirect_to(organisation_job_build_path(vacancy.id, :documents))
       end
     end
   end

--- a/spec/services/publishers/vacancies/vacancy_step_process_spec.rb
+++ b/spec/services/publishers/vacancies/vacancy_step_process_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe Publishers::Vacancies::VacancyStepProcess do
   describe "#step_groups" do
     let(:all_possible_step_groups) do
       %i[
-        job_role job_location job_details working_patterns pay_package important_dates documents
-        applying_for_the_job job_summary review
+        job_role job_location job_details working_patterns pay_package important_dates
+        applying_for_the_job documents job_summary review
       ]
     end
 
@@ -46,7 +46,7 @@ RSpec.describe Publishers::Vacancies::VacancyStepProcess do
     let(:all_possible_steps) do
       %i[
         job_role job_role_details job_location schools education_phases job_details working_patterns
-        pay_package important_dates documents applying_for_the_job applying_for_the_job_details job_summary review
+        pay_package important_dates applying_for_the_job applying_for_the_job_details documents job_summary review
       ]
     end
 

--- a/spec/system/publishers_can_publish_a_vacancy_as_a_local_authority_spec.rb
+++ b/spec/system/publishers_can_publish_a_vacancy_as_a_local_authority_spec.rb
@@ -181,9 +181,6 @@ RSpec.describe "Creating a vacancy" do
 
     fill_in_important_dates_fields(vacancy)
     click_on I18n.t("buttons.continue")
-    expect(current_path).to eq(organisation_job_documents_path(created_vacancy.id))
-
-    click_on I18n.t("buttons.continue")
     expect(current_path).to eq(organisation_job_build_path(created_vacancy.id, :applying_for_the_job_details))
 
     click_on I18n.t("buttons.continue")
@@ -191,6 +188,9 @@ RSpec.describe "Creating a vacancy" do
     expect(current_path).to eq(organisation_job_application_forms_path(created_vacancy.id))
 
     fill_in_applying_for_the_job_details_form_fields(vacancy, local_authority_vacancy: true)
+    click_on I18n.t("buttons.continue")
+    expect(current_path).to eq(organisation_job_documents_path(created_vacancy.id))
+
     click_on I18n.t("buttons.continue")
     expect(current_path).to eq(organisation_job_build_path(created_vacancy.id, :job_summary))
 

--- a/spec/system/publishers_can_publish_a_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers_can_publish_a_vacancy_as_a_school_spec.rb
@@ -83,9 +83,6 @@ RSpec.describe "Creating a vacancy" do
 
       fill_in_important_dates_fields(vacancy)
       click_on I18n.t("buttons.continue")
-      expect(current_path).to eq(organisation_job_documents_path(created_vacancy.id))
-
-      click_on I18n.t("buttons.continue")
       expect(current_path).to eq(organisation_job_build_path(created_vacancy.id, :applying_for_the_job))
 
       click_on I18n.t("buttons.continue")
@@ -101,6 +98,9 @@ RSpec.describe "Creating a vacancy" do
       expect(current_path).to eq(organisation_job_application_forms_path(created_vacancy.id))
 
       fill_in_applying_for_the_job_details_form_fields(vacancy, local_authority_vacancy: false)
+      click_on I18n.t("buttons.continue")
+      expect(current_path).to eq(organisation_job_documents_path(created_vacancy.id))
+
       click_on I18n.t("buttons.continue")
       expect(current_path).to eq(organisation_job_build_path(created_vacancy.id, :job_summary))
 
@@ -141,12 +141,12 @@ RSpec.describe "Creating a vacancy" do
       fill_in_important_dates_fields(vacancy)
       click_on I18n.t("buttons.continue")
 
-      click_on I18n.t("buttons.continue")
-
       fill_in_applying_for_the_job_form_fields(vacancy)
       click_on I18n.t("buttons.continue")
 
       fill_in_applying_for_the_job_details_form_fields(vacancy)
+      click_on I18n.t("buttons.continue")
+
       click_on I18n.t("buttons.continue")
 
       fill_in_job_summary_form_fields(vacancy)

--- a/spec/system/publishers_can_publish_a_vacancy_as_a_trust_spec.rb
+++ b/spec/system/publishers_can_publish_a_vacancy_as_a_trust_spec.rb
@@ -209,9 +209,6 @@ RSpec.describe "Creating a vacancy" do
 
     fill_in_important_dates_fields(vacancy)
     click_on I18n.t("buttons.continue")
-    expect(current_path).to eq(organisation_job_documents_path(created_vacancy.id))
-
-    click_on I18n.t("buttons.continue")
     expect(current_path).to eq(organisation_job_build_path(created_vacancy.id, :applying_for_the_job))
 
     click_on I18n.t("buttons.continue")
@@ -227,6 +224,9 @@ RSpec.describe "Creating a vacancy" do
     expect(current_path).to eq(organisation_job_application_forms_path(created_vacancy.id))
 
     fill_in_applying_for_the_job_details_form_fields(vacancy, local_authority_vacancy: false)
+    click_on I18n.t("buttons.continue")
+    expect(current_path).to eq(organisation_job_documents_path(created_vacancy.id))
+
     click_on I18n.t("buttons.continue")
     expect(current_path).to eq(organisation_job_build_path(created_vacancy.id, :job_summary))
 


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3434

## Changes in this PR:

This PR moves the "Supporting documents" step of the Create a job listing journey to after the "Applying for the job details" steps.

## Screenshots of UI changes:

### Before

![image](https://user-images.githubusercontent.com/24639777/148357710-902b0b55-5939-40cf-bb34-1b442f8047fa.png)

### After

![image](https://user-images.githubusercontent.com/24639777/148357635-ed3772cc-4ce3-42b9-98b7-912296a13224.png)