### PR TITLE
[TEVA-3634] Configure web app to use service_key as database connection string

### DIFF
--- a/terraform/app/modules/paas/main.tf
+++ b/terraform/app/modules/paas/main.tf
@@ -10,6 +10,11 @@ resource "cloudfoundry_service_instance" "postgres_instance" {
   }
 }
 
+resource "cloudfoundry_service_key" "postgres_instance_service_key" {
+  name             = "postgres_instance_service_key-${var.environment}"
+  service_instance = cloudfoundry_service_instance.postgres_instance.id
+}
+
 resource "cloudfoundry_service_instance" "redis_cache_instance" {
   name         = local.redis_cache_service_name
   space        = data.cloudfoundry_space.space.id
@@ -122,6 +127,7 @@ resource "cloudfoundry_route" "web_app_route" {
   space    = data.cloudfoundry_space.space.id
   hostname = local.web_app_name
 }
+
 
 resource "cloudfoundry_route" "web_app_route_cloudfront_apex" {
   for_each = toset(var.route53_a_records)

--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -95,6 +95,7 @@ variable "db_backup_before_point_in_time" {
 
 }
 
+
 locals {
   app_env_api_keys = merge(
     yamldecode(data.aws_ssm_parameter.app_env_api_key_big_query.value),
@@ -112,13 +113,16 @@ locals {
     local.app_env_secrets,
     local.app_env_documents_bucket_credentials,
     local.app_env_domain,
+    local.postgres_instance_service_key,
     var.app_env_values #Because of merge order, if present, the value of DOMAIN in .tfvars.json will overwrite app_env_domain
   )
   app_cloudfoundry_service_instances = [
-    cloudfoundry_service_instance.postgres_instance.id,
     cloudfoundry_service_instance.redis_cache_instance.id,
     cloudfoundry_service_instance.redis_queue_instance.id,
   ]
+
+  postgres_instance_service_key = { DATABASE_URL = cloudfoundry_service_key.postgres_instance_service_key.credentials.uri }
+
   app_user_provided_service_bindings = var.logging_service_binding_enable ? [cloudfoundry_user_provided_service.logging.id] : []
   app_service_bindings               = concat(local.app_cloudfoundry_service_instances, local.app_user_provided_service_bindings)
   logging_service_name               = "${var.service_name}-logging-${var.environment}"


### PR DESCRIPTION
…stead of service_binding

## Jira ticket URL

- Just add the ticket number to the end:

https://dfedigital.atlassian.net/browse/TEVA-3634

During every deployment, we get "InsufficientPrivilege error", which results in users being kicked off, which is not a good a user experience. This PR is to fix this issue by using `service_key` in-place of `service_binding`.