### PR TITLE
[TEVA-3624] Fix subject params bug

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -36,7 +36,7 @@ class VacanciesController < ApplicationController
     params[:location] = params[:location_facet].titleize if params[:location_facet]
     params[:job_roles] = params[:job_role].parameterize.underscore if params[:job_role]
     params[:phases] = params[:education_phase].parameterize if params[:education_phase]
-    params[:subject]&.titleize
+    params[:subject] = params[:subject].tr("-", " ").gsub(" and ", " ") if params[:subject]
   end
 
   def search_params


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3624

## Changes in this PR:

This PR fixes the issue of the `:subject` param not being correctly set using `titleize` for the pretty landing page job roles. This was causing an issue where the keyword was still hyphenated and therefore not showing any results.

We also keep the search term lower case (rather than using `titleize`) and get rid of the word `and` if it appears.

## Screenshots of UI changes:

### Before

![image](https://user-images.githubusercontent.com/24639777/148577215-bee3231a-f1d2-4905-9da4-9e0551eb3d54.png)

### After

![image](https://user-images.githubusercontent.com/24639777/148577136-c75a71a9-316a-4bb0-b61e-f8453f0e0156.png)
