### PR TITLE
Fix bug with positioning of non-train-track sidebar content

### DIFF
--- a/app/components/review_component.rb
+++ b/app/components/review_component.rb
@@ -6,11 +6,21 @@ class ReviewComponent < GovukComponent::Base
   renders_one :above
   renders_one :below
 
+  renders_one :sidebar, ReviewComponent::Sidebar
+
   def initialize(namespace:, show_tracks:, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
 
     @namespace = namespace
     @show_tracks = show_tracks
+  end
+
+  def before_render
+    return unless show_tracks?
+
+    sidebar do
+      render("#{namespace}/build/steps", track_assigns)
+    end
   end
 
   private

--- a/app/components/review_component/review_component.html.slim
+++ b/app/components/review_component/review_component.html.slim
@@ -12,6 +12,4 @@
 
       = below
 
-    - if show_tracks?
-      .govuk-grid-column-one-third
-        = render "#{namespace}/build/steps", track_assigns
+    = sidebar

--- a/app/components/review_component/sidebar.rb
+++ b/app/components/review_component/sidebar.rb
@@ -1,0 +1,5 @@
+class ReviewComponent::Sidebar < ApplicationComponent
+  def default_classes
+    %w[govuk-grid-column-one-third]
+  end
+end

--- a/app/components/review_component/sidebar/sidebar.html.slim
+++ b/app/components/review_component/sidebar/sidebar.html.slim
@@ -1,0 +1,2 @@
+= tag.div(class: classes, **html_attributes) do
+  = content

--- a/app/views/publishers/vacancies/show.html.slim
+++ b/app/views/publishers/vacancies/show.html.slim
@@ -19,7 +19,7 @@
     = render "publish_buttons", back_to: "manage_draft" if vacancy.draft?
     = govuk_link_to(t("buttons.back_to_manage_jobs"), back_to_manage_jobs_link(vacancy), class: "govuk-link--no-visited-state")
 
-    - if vacancy.published? && !vacancy.pending?
-      .govuk-grid-column-one-third.grey-cta-container class="govuk-!-padding-bottom-4"
-        h3 = t(".view_live_listing_title")
-        = open_in_new_tab_link_to(t(".view_live_listing_link"), job_path(vacancy.id))
+  - if vacancy.published? && !vacancy.pending?
+    - r.sidebar(classes: %w[grey-cta-container govuk-!-padding-bottom-4])
+      h3 = t(".view_live_listing_title")
+      = open_in_new_tab_link_to(t(".view_live_listing_link"), job_path(vacancy.id))


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3706

## Changes in this PR:

Fix to appearance of "active job" summary page.

## Screenshots of UI changes:

### Before

<img width="1356" alt="Screenshot 2022-01-11 at 15 19 25" src="https://user-images.githubusercontent.com/109225/148973512-83051dce-a47a-45a9-a4fb-376ed59c73ce.png">
<img width="543" alt="Screenshot 2022-01-11 at 15 19 21" src="https://user-images.githubusercontent.com/109225/148973538-fb908fdd-8fb1-446a-997b-e8edb3922266.png">

### After

<img width="1299" alt="Screenshot 2022-01-11 at 15 31 57" src="https://user-images.githubusercontent.com/109225/148973563-38af53f9-46d0-4ffe-88bf-34cce5d9add0.png">
<img width="1008" alt="Screenshot 2022-01-11 at 15 32 01" src="https://user-images.githubusercontent.com/109225/148973580-0eeb1f78-572b-421c-80ca-78263cde8b10.png">
