### PR TITLE
[TEVA-3635]-remove-secrets-from-GH_secrets

### DIFF
--- a/.github/workflows/TV-check-users-in-space-developer-role.yml
+++ b/.github/workflows/TV-check-users-in-space-developer-role.yml
@@ -11,10 +11,45 @@ jobs:
       CF_SPACE_NAME: teaching-vacancies-production
 
     steps:
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+          role-to-assume: Deployments
+          role-duration-seconds: 3600
+          role-skip-session-tagging: true
+
+      - name: Get CF_USERNAME From ParameterStore
+        uses: marvinpinto/action-inject-ssm-secrets@latest
+        with:
+          ssm_parameter: /teaching-vacancies/github_action/infra/cf_username_prod
+          env_variable_name: CF_USERNAME_PROD
+
+      - name: Get CF_PASSWORD From ParameterStore
+        uses: marvinpinto/action-inject-ssm-secrets@latest
+        with:
+          ssm_parameter: /teaching-vacancies/github_action/infra/cf_password_prod
+          env_variable_name: CF_PASSWORD
+
+      - name: Get PAAS_USER_WHITELIST From ParameterStore
+        uses: marvinpinto/action-inject-ssm-secrets@latest
+        with:
+          ssm_parameter: "/teaching-vacancies/github_action/infra/slack_paas_user_whitelist"
+          env_variable_name: PAAS_USER_WHITELIST
+
+      - name: Get SLACK_WEBHOOK From ParameterStore
+        uses: marvinpinto/action-inject-ssm-secrets@latest
+        with:
+          ssm_parameter: /teaching-vacancies/github_action/infra/slack_webhook
+          env_variable_name: SLACK_WEBHOOK
+
       - uses: DFE-Digital/github-actions/setup-cf-cli@master
         with:
-          CF_USERNAME: ${{ secrets.CF_USERNAME_PROD }}
-          CF_PASSWORD: ${{ secrets.CF_PASSWORD_PROD }}
+          CF_USERNAME: "${{env.CF_USERNAME_PROD}}"
+          CF_PASSWORD: "${{env.CF_PASSWORD}}"
           CF_SPACE_NAME: "${{ env.CF_SPACE_NAME }}"
           CF_ORG_NAME: dfe
           CF_API_URL:  https://api.london.cloud.service.gov.uk
@@ -30,6 +65,6 @@ jobs:
         run: |
           ./remote-checkout/scripts/check-users-in-space-developer-role.ps1 \
             -space "${{ env.CF_SPACE_NAME }}" \
-            -slack_webhook "${{secrets.SLACK_WEBHOOK}}" \
+            -slack_webhook "${{env.SLACK_WEBHOOK}}" \
             -unset true \
-            -whitelist "${{secrets.PAAS_USER_WHITELIST}}"
+            -whitelist "${{env.PAAS_USER_WHITELIST}}"

--- a/.github/workflows/backup_production_db.yml
+++ b/.github/workflows/backup_production_db.yml
@@ -34,11 +34,29 @@ jobs:
         role-duration-seconds: 3600
         role-skip-session-tagging: true
 
+    - name: Get CF_USERNAME From ParameterStore
+      uses: marvinpinto/action-inject-ssm-secrets@latest
+      with:
+        ssm_parameter: /teaching-vacancies/github_action/infra/cf_username_prod
+        env_variable_name: CF_USERNAME_PROD
+
+    - name: Get CF_PASSWORD From ParameterStore
+      uses: marvinpinto/action-inject-ssm-secrets@latest
+      with:
+        ssm_parameter: /teaching-vacancies/github_action/infra/cf_password_prod
+        env_variable_name: CF_PASSWORD
+
+    - name: Get SLACK_WEBHOOK From ParameterStore
+      uses: marvinpinto/action-inject-ssm-secrets@latest
+      with:
+        ssm_parameter: /teaching-vacancies/github_action/infra/slack_webhook
+        env_variable_name: SLACK_WEBHOOK
+
     - name: Setup cf cli
       uses: DFE-Digital/github-actions/setup-cf-cli@master
       with:
-        CF_USERNAME: ${{ secrets.CF_USERNAME_PROD }}
-        CF_PASSWORD: ${{ secrets.CF_PASSWORD_PROD }}
+        CF_USERNAME: ${{env.CF_USERNAME_PROD}}
+        CF_PASSWORD: ${{env.CF_PASSWORD}}
         CF_SPACE_NAME: teaching-vacancies-production
         INSTALL_CONDUIT: true
 
@@ -86,4 +104,4 @@ jobs:
         SLACK_USERNAME: CI Deployment
         SLACK_TITLE: Deployment ${{ job.status }}
         SLACK_MESSAGE: 'Backup production database - ${{ job.status }}'
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        SLACK_WEBHOOK: ${{env.SLACK_WEBHOOK}}

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -51,6 +51,34 @@ jobs:
       - uses: actions/checkout@v2
         name: Checkout Code
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+          role-to-assume: Deployments
+          role-duration-seconds: 3600
+          role-skip-session-tagging: true
+
+      - name: Get GIT_HUB_SERVICE_ACCOUNT_TOKEN From ParameterStore
+        uses: marvinpinto/action-inject-ssm-secrets@latest
+        with:
+          ssm_parameter: /teaching-vacancies/github_action/infra/git_hub_service_account_token
+          env_variable_name: GIT_HUB_SERVICE_ACCOUNT_TOKEN
+
+      - name: Get SLACK_WEBHOOK From ParameterStore
+        uses: marvinpinto/action-inject-ssm-secrets@latest
+        with:
+          ssm_parameter: /teaching-vacancies/github_action/infra/slack_webhook
+          env_variable_name: SLACK_WEBHOOK
+
+      - name: Get SNYK_TOKEN From ParameterStore
+        uses: marvinpinto/action-inject-ssm-secrets@latest
+        with:
+          ssm_parameter: /teaching-vacancies/github_action/infra/snyk
+          env_variable_name: SNYK_TOKEN
+
       - name: Set environment variables (Push)
         if: github.event_name == 'push'
         run: |
@@ -80,7 +108,7 @@ jobs:
         with:
             registry: ghcr.io
             username: ${{ github.repository_owner }}
-            password: ${{ secrets.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
+            password: ${{ env.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
 
       - name: Build and push docker image from builder target
         uses: docker/build-push-action@v2
@@ -142,7 +170,7 @@ jobs:
         id: scan_docker_image
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
-          docker run -t -e "SNYK_TOKEN=${{ secrets.SNYK_TOKEN }}" \
+          docker run -t -e "SNYK_TOKEN=${{ env.SNYK_TOKEN }}" \
             -v "/var/run/docker.sock:/var/run/docker.sock" \
             -v "$GITHUB_WORKSPACE:/project"  \
             snyk/snyk-cli:docker test --docker ${{ env.DOCKER_REPOSITORY }}:${{ env.DOCKER_IMAGE_TAG }} --file=Dockerfile
@@ -161,7 +189,7 @@ jobs:
           SLACK_MESSAGE: |
             Build failure on branch ${{env.GIT_BRANCH}} <!channel>
             See: <${{ env.LINK_TO_RUN }}|Workflow run>
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{env.SLACK_WEBHOOK}}
           SLACK_COLOR: failure
 
   deploy:
@@ -177,6 +205,28 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       name: Checkout Code
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: eu-west-2
+        role-to-assume: Deployments
+        role-duration-seconds: 3600
+        role-skip-session-tagging: true
+
+    - name: Get SLACK_WEBHOOK From ParameterStore
+      uses: marvinpinto/action-inject-ssm-secrets@latest
+      with:
+        ssm_parameter: /teaching-vacancies/github_action/infra/slack_webhook
+        env_variable_name: SLACK_WEBHOOK
+
+    - name: Get GIT_HUB_SERVICE_ACCOUNT_TOKEN From ParameterStore
+      uses: marvinpinto/action-inject-ssm-secrets@latest
+      with:
+        ssm_parameter: /teaching-vacancies/github_action/infra/git_hub_service_account_token
+        env_variable_name: GIT_HUB_SERVICE_ACCOUNT_TOKEN
 
     - name: Set environment variables from build output
       run: |
@@ -201,7 +251,7 @@ jobs:
       uses: benc-uk/workflow-dispatch@v1.1
       with:
         workflow: Deploy App to Environment   # Name of the triggered workflow
-        token: ${{ secrets.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
+        token: ${{ env.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
         ref: ${{ env.BUILD_GIT_TAG }}         # Different than branch HEAD SHA in case of a PR
         inputs: '{"environment": "${{ env.ENVIRONMENT }}", "tag": "${{ env.DOCKER_IMAGE_TAG }}", "pr_id": "${{ github.event.number }}" }'
 
@@ -209,7 +259,7 @@ jobs:
       id: wait_for_deploy_app
       uses: fountainhead/action-wait-for-check@v1.0.0
       with:
-        token: ${{ secrets.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
+        token: ${{ env.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
         checkName: Deploy ${{ env.DOCKER_IMAGE_TAG }} to ${{ env.ENVIRONMENT }} # Job name within triggered workflow
         ref: ${{ env.BUILD_GIT_TAG }}
         timeoutSeconds: 1200
@@ -223,7 +273,7 @@ jobs:
         SLACK_USERNAME: CI Deployment
         SLACK_TITLE: Deployment failure
         SLACK_MESSAGE: 'Deployment of Docker image ${{ env.DOCKER_IMAGE_TAG }} to ${{ env.ENVIRONMENT }} - unsuccessful <!channel>'
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        SLACK_WEBHOOK: ${{env.SLACK_WEBHOOK}}
 
     - name: Exit whole workflow if ${{ env.ENVIRONMENT }} deployment was not successful
       if: steps.wait_for_deploy_app.outputs.conclusion != 'success'
@@ -233,7 +283,7 @@ jobs:
       uses: benc-uk/workflow-dispatch@v1.1
       with:
         workflow: Smoke Test
-        token: ${{ secrets.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
+        token: ${{ env.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
         inputs: '{"paas_environment": "${{ env.ENVIRONMENT }}", "sha": "${{ env.COMMIT_SHA }}"}'
         ref: ${{ env.BUILD_GIT_TAG }}
 
@@ -241,7 +291,7 @@ jobs:
       id: wait_for_smoke_test
       uses: fountainhead/action-wait-for-check@v1.0.0
       with:
-        token: ${{ secrets.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
+        token: ${{ env.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
         checkName: Smoke Test ${{ env.ENVIRONMENT }} ${{ env.COMMIT_SHA }}
         ref: ${{ env.BUILD_GIT_TAG }}
         timeoutSeconds: 300
@@ -268,7 +318,7 @@ jobs:
         SLACK_MESSAGE: |
           Deployment of Docker image ${{ env.DOCKER_IMAGE_TAG }} to ${{matrix.environment}} - ${{ job.status }}
           See: <${{ env.LINK_TO_RUN }}|Workflow run>
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        SLACK_WEBHOOK: ${{env.SLACK_WEBHOOK}}
         SLACK_COLOR: failure
 
   post_deployment:
@@ -295,6 +345,18 @@ jobs:
           role-to-assume: Deployments
           role-duration-seconds: 3600
           role-skip-session-tagging: true
+
+      - name: Get SLACK_WEBHOOK From ParameterStore
+        uses: marvinpinto/action-inject-ssm-secrets@latest
+        with:
+          ssm_parameter: /teaching-vacancies/github_action/infra/slack_webhook
+          env_variable_name: SLACK_WEBHOOK
+
+      - name: Get GIT_HUB_SERVICE_ACCOUNT_TOKEN From ParameterStore
+        uses: marvinpinto/action-inject-ssm-secrets@latest
+        with:
+          ssm_parameter: /teaching-vacancies/github_action/infra/git_hub_service_account_token
+          env_variable_name: GIT_HUB_SERVICE_ACCOUNT_TOKEN
 
       - name: Terraform pin version
         uses: hashicorp/setup-terraform@v1
@@ -323,5 +385,5 @@ jobs:
           SLACK_MESSAGE: |
             Deployment of Docker tag ${{ env.DOCKER_IMAGE_TAG }} - ${{ job.status }}
             See: <${{ env.LINK_TO_RUN }}|Workflow run>
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{env.SLACK_WEBHOOK}}
           SLACK_COLOR: ${{ job.status }}

--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -29,11 +29,34 @@ jobs:
         echo "LINK_TO_PR=https://github.com/${GITHUB_REPOSITORY}/pull/${{ github.event.number }}" >> $GITHUB_ENV
         echo "LINK_TO_APP=https://teaching-vacancies-${ENVIRONMENT}.london.cloudapps.digital" >> $GITHUB_ENV
 
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: eu-west-2
+        role-to-assume: Deployments
+        role-duration-seconds: 3600
+        role-skip-session-tagging: true
+
+    - name: Get SLACK_WEBHOOK From ParameterStore
+      uses: marvinpinto/action-inject-ssm-secrets@latest
+      with:
+        ssm_parameter: /teaching-vacancies/github_action/infra/slack_webhook
+        env_variable_name: SLACK_WEBHOOK
+
+    - name: Get GIT_HUB_SERVICE_ACCOUNT_TOKEN From ParameterStore
+      uses: marvinpinto/action-inject-ssm-secrets@latest
+      with:
+        ssm_parameter: /teaching-vacancies/github_action/infra/git_hub_service_account_token
+        env_variable_name: GIT_HUB_SERVICE_ACCOUNT_TOKEN
+
+
     - name: Wait for this review app 'Deploy app' job to finish
       id: wait_for_deployment
       uses: fountainhead/action-wait-for-check@v1.0.0
       with:
-       token: ${{ secrets.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
+       token: ${{ env.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
        checkName: Deploy app (review)                   # Matrix job name within deploy_app workflow
        ref: ${{ github.event.pull_request.head.sha }}   # The deploy_app job is linked to the PR branch HEAD SHA
        timeoutSeconds: 1800
@@ -50,16 +73,6 @@ jobs:
 
     - uses: actions/checkout@v2
       name: Checkout Code
-
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: eu-west-2
-        role-to-assume: Deployments
-        role-duration-seconds: 3600
-        role-skip-session-tagging: true
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
@@ -112,5 +125,5 @@ jobs:
           Failed deletion of review app PR ${{ github.event.number }}
           See: <${{ env.LINK_TO_RUN }}|Workflow run> - <${{ env.LINK_TO_PR }}|Pull request> - <${{ env.LINK_TO_APP }}|Review app>
           <!channel>
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        SLACK_WEBHOOK: ${{env.SLACK_WEBHOOK}}
         SLACK_COLOR: ${{ job.status }}

--- a/.github/workflows/dump_db.yml
+++ b/.github/workflows/dump_db.yml
@@ -22,13 +22,32 @@ jobs:
         role-duration-seconds: 3600
         role-skip-session-tagging: true
 
+    - name: Get CF_USERNAME From ParameterStore
+      uses: marvinpinto/action-inject-ssm-secrets@latest
+      with:
+        ssm_parameter: /teaching-vacancies/github_action/infra/cf_username_prod
+        env_variable_name: CF_USERNAME_PROD
+
+    - name: Get CF_PASSWORD From ParameterStore
+      uses: marvinpinto/action-inject-ssm-secrets@latest
+      with:
+        ssm_parameter: /teaching-vacancies/github_action/infra/cf_password_prod
+        env_variable_name: CF_PASSWORD
+
+    - name: Get SLACK_WEBHOOK From ParameterStore
+      uses: marvinpinto/action-inject-ssm-secrets@latest
+      with:
+        ssm_parameter: /teaching-vacancies/github_action/infra/slack_webhook
+        env_variable_name: SLACK_WEBHOOK
+
     - name: Setup cf cli
       uses: DFE-Digital/github-actions/setup-cf-cli@master
       with:
-        CF_USERNAME: ${{ secrets.CF_USERNAME }}
-        CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
+        CF_USERNAME: ${{env.CF_USERNAME_PROD}}
+        CF_PASSWORD: ${{env.CF_PASSWORD}}
         CF_SPACE_NAME: teaching-vacancies-production
         INSTALL_CONDUIT: true
+
 
     - name: Install postgres client
       uses: DFE-Digital/github-actions/install-postgres-client@master
@@ -50,4 +69,4 @@ jobs:
         SLACK_USERNAME: CI Deployment
         SLACK_TITLE: Deployment ${{ job.status }}
         SLACK_MESSAGE: 'Dump production database to S3 bucket - ${{ job.status }}'
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        SLACK_WEBHOOK: ${{env.SLACK_WEBHOOK}}

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -28,6 +28,18 @@ jobs:
           role-duration-seconds: 3600
           role-skip-session-tagging: true
 
+      - name: Get SLACK_WEBHOOK From ParameterStore
+        uses: marvinpinto/action-inject-ssm-secrets@latest
+        with:
+          ssm_parameter: /teaching-vacancies/github_action/infra/slack_webhook
+          env_variable_name: SLACK_WEBHOOK
+
+      - name: Get GIT_HUB_SERVICE_ACCOUNT_TOKEN From ParameterStore
+        uses: marvinpinto/action-inject-ssm-secrets@latest
+        with:
+          ssm_parameter: /teaching-vacancies/github_action/infra/git_hub_service_account_token
+          env_variable_name: GIT_HUB_SERVICE_ACCOUNT_TOKEN
+
       - name: Pin Terraform version
         uses: hashicorp/setup-terraform@v1
         with:
@@ -45,14 +57,14 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1.1
         with:
           workflow: Deploy App to Environment # Workflow name
-          token: ${{ secrets.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
+          token: ${{ env.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
           inputs: '{"environment": "${{ github.event.inputs.environment }}", "tag": "${{ steps.get_docker_tag.outputs.tag }}"}'
 
       - name: Wait for Deploy App Workflow
         id: wait_for_deploy_app
         uses: fountainhead/action-wait-for-check@v1.0.0
         with:
-          token: ${{ secrets.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
+          token: ${{ env.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
           checkName: Deploy app to environment # Job name within workflow
           ref: ${{ github.sha }}
           timeoutSeconds: 300
@@ -66,4 +78,4 @@ jobs:
           SLACK_USERNAME: CI Deployment
           SLACK_TITLE: ${{ github.event.inputs.environment }} env vars refresh ${{ job.status }}
           SLACK_MESSAGE: 'Deployment of Docker tag ${{ steps.get_docker_tag.outputs.tag }} to ${{ github.event.inputs.environment }} - ${{ job.status }}'
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{env.SLACK_WEBHOOK}}

--- a/.github/workflows/restore_db.yml
+++ b/.github/workflows/restore_db.yml
@@ -35,12 +35,30 @@ jobs:
         PAAS_SPACE_NAME=$(jq -r .paas_space_name terraform/workspace-variables/${{ github.event.inputs.environment }}.tfvars.json)
         echo "PAAS_SPACE_NAME=${PAAS_SPACE_NAME}" >> $GITHUB_ENV
 
+    - name: Get CF_USERNAME From ParameterStore
+      uses: marvinpinto/action-inject-ssm-secrets@latest
+      with:
+        ssm_parameter: /teaching-vacancies/github_action/infra/cf_username_prod
+        env_variable_name: CF_USERNAME_PROD
+
+    - name: Get CF_PASSWORD From ParameterStore
+      uses: marvinpinto/action-inject-ssm-secrets@latest
+      with:
+        ssm_parameter: /teaching-vacancies/github_action/infra/cf_password_prod
+        env_variable_name: CF_PASSWORD
+
+    - name: Get SLACK_WEBHOOK From ParameterStore
+      uses: marvinpinto/action-inject-ssm-secrets@latest
+      with:
+        ssm_parameter: /teaching-vacancies/github_action/infra/slack_webhook
+        env_variable_name: SLACK_WEBHOOK
+
     - name: Setup cf cli
       uses: DFE-Digital/github-actions/setup-cf-cli@master
       with:
-        CF_USERNAME: ${{ secrets.CF_USERNAME_PROD }}
-        CF_PASSWORD: ${{ secrets.CF_PASSWORD_PROD }}
-        CF_SPACE_NAME: ${{ env.PAAS_SPACE_NAME }}
+        CF_USERNAME: ${{env.CF_USERNAME_PROD}}
+        CF_PASSWORD: ${{env.CF_PASSWORD}}
+        CF_SPACE_NAME: teaching-vacancies-production
         INSTALL_CONDUIT: true
 
     - name: Install postgres client
@@ -69,4 +87,4 @@ jobs:
         SLACK_USERNAME: CI Deployment
         SLACK_TITLE: Deployment ${{ job.status }}
         SLACK_MESSAGE: 'Restore sanitised production DB to ${{ github.event.inputs.environment }} - ${{ job.status }}'
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        SLACK_WEBHOOK: ${{env.SLACK_WEBHOOK}}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -26,6 +26,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+          role-to-assume: Deployments
+          role-duration-seconds: 3600
+          role-skip-session-tagging: true
+
+      - name: Get SLACK_WEBHOOK From ParameterStore
+        uses: marvinpinto/action-inject-ssm-secrets@latest
+        with:
+          ssm_parameter: /teaching-vacancies/github_action/infra/slack_webhook
+          env_variable_name: SLACK_WEBHOOK
+
       - name: Prepare application environment
         uses: ./.github/actions/prepare-app-env
 
@@ -54,4 +70,4 @@ jobs:
           SLACK_ICON_EMOJI: ':cry:'
           SLACK_TITLE: Smoke test failed
           SLACK_MESSAGE: 'Smoke test failure in ${{ env.PAAS_ENVIRONMENT}} environment <!channel>'
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{env.SLACK_WEBHOOK}}


### PR DESCRIPTION
## Jira ticket URL

- Just add the ticket number to the end:

https://dfedigital.atlassian.net/browse/TEVA-3635

Move secrets from GH Secrets to AWS ParameterStore, gives the flexibility
in managing secrets i.e. version control, visibility, partitioning secrets into categories.

This is achieved with the use of `marvinpinto/action-inject-ssm-secrets@latest`
