### PR TITLE
Remove manual engine load for view component gem

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -13,7 +13,6 @@ require "active_storage/engine"
 # require "action_cable/engine"
 # require 'sprockets/railtie'
 # require "rails/test_unit/railtie"
-require "view_component/engine"
 require "view_component/compile_cache"
 
 # Require the gems listed in Gemfile, including any gems


### PR DESCRIPTION
This is deprecated.

```
DEPRECATION WARNING: This manually engine loading is deprecated and will be removed in v3.0.0. Remove `require "view_component/engine"`. (called from <top (required)> at teaching-vacancies/config/application.rb:16)
```
