### PR TITLE
TEVA-3524 Fix landing page headings for ECT-suitable jobs

### DIFF
--- a/app/components/jobseekers/search_results/heading_component.rb
+++ b/app/components/jobseekers/search_results/heading_component.rb
@@ -53,8 +53,6 @@ class Jobseekers::SearchResults::HeadingComponent < ViewComponent::Base
   end
 
   def job_role(role)
-    return role.sub("-", " ") unless role == "sendco"
-
-    t("helpers.label.publishers_job_listing_job_details_form.job_roles_options.#{role}")
+    role.tr("-", " ").humanize(capitalize: false)
   end
 end

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -5,6 +5,7 @@ module ComponentsHelper
     empty_section: "EmptySectionComponent",
     filters: "FiltersComponent",
     job_application_review: "JobApplicationReviewComponent",
+    jobseekers_search_results_heading: "Jobseekers::SearchResults::HeadingComponent",
     map: "MapComponent",
     navigation_list: "NavigationListComponent",
     publishers_no_vacancies: "Publishers::NoVacanciesComponent",

--- a/app/views/vacancies/index.html.slim
+++ b/app/views/vacancies/index.html.slim
@@ -6,7 +6,7 @@
 .govuk-main-wrapper class="govuk-!-padding-top-3"
   = govuk_breadcrumbs breadcrumbs: { "#{t("breadcrumbs.home")}": root_path, "#{t("breadcrumbs.jobs")}": "" }
 
-  = render(Jobseekers::SearchResults::HeadingComponent.new(vacancies_search: @vacancies_search, landing_page: @landing_page))
+  = jobseekers_search_results_heading(vacancies_search: @vacancies_search, landing_page: @landing_page)
 
   .grid-row
     .grid-column-left class="govuk-!-margin-bottom-3"

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -17,4 +17,7 @@
 
 ActiveSupport::Inflector.inflections do |inflect|
   inflect.irregular "is", "are"
+
+  inflect.acronym "ECT"
+  inflect.acronym "SENDCo"
 end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3524

## Changes in this PR:

The addition of these acronyms (and initialisms) to the app may have effects elsewhere, but this is what it's designed for.

## Screenshots of UI changes:

### Before

<img width="359" alt="Screenshot 2022-01-13 at 10 53 54" src="https://user-images.githubusercontent.com/109225/149317168-f6a53a84-fdad-445f-bb91-28da1ccefb67.png">

### After

<img width="373" alt="Screenshot 2022-01-13 at 10 49 56" src="https://user-images.githubusercontent.com/109225/149317019-926a38f9-6adc-4b72-bdf2-fa72c63a237f.png">
