### PR TITLE
[TEVA-3682] Remove present ab test variant and ab test config

### DIFF
--- a/app/views/vacancies/_desktop_search.html.slim
+++ b/app/views/vacancies/_desktop_search.html.slim
@@ -1,0 +1,11 @@
+.search-results__header.search-results__header--border.desktop-only
+  h2.govuk-heading-m = t("jobs.search.title")
+  = render "shared/search/keyword", f: f
+  = render "shared/search/location", show_hint: false, desktop: true, f: f
+  = render "shared/search/radius", f: f, wide: true
+  = f.hidden_field :sort_by, value: @form.sort.by
+  = f.hidden_field :job_roles, value: @form.job_roles
+  = f.hidden_field :phases, value: @form.phases
+  = f.hidden_field :working_patterns, value: @form.working_patterns
+  .search-results__header__submit
+    = f.govuk_submit t("buttons.search"), classes: "govuk-button govuk-!-margin-bottom-0 govuk-!-margin-top-6 govuk-!-width-full"

--- a/app/views/vacancies/_search.html.slim
+++ b/app/views/vacancies/_search.html.slim
@@ -61,22 +61,10 @@ ruby:
   = f.hidden_field :keyword, value: @form.keyword
   = f.hidden_field :location, value: @form.location
   = f.hidden_field :radius, value: @form.radius
-  - if current_variant?(:"2021_11_desktop_search_results_page_test", :present)
-    .search-controls__panel
-      - if current_variant?(:"2021_10_mobile_search_panel_test", :overlay)
-        = render(PanelComponent.new(button_text: t("buttons.search_toggle_panel"), heading_text: t("jobs.search.title"))) do |panel|
-          - panel.body do
-            = render "shared/search/keyword", f: f
-            = render "shared/search/location", f: f
-            = render "shared/search/current_location", target: "location-field"
-            = render "shared/search/radius", f: f, wide: true
-
-            = f.hidden_field :sort_by, value: @form.sort.by
-            = f.govuk_submit t("buttons.search"), classes: "govuk-button govuk-!-margin-bottom-0 govuk-!-width-full"
-      - else
-        .search-controls__panel__filters
-          h2.govuk-heading-m = t("jobs.search.title")
-
+  .search-controls__panel.search-controls__panel--mobile
+    - if current_variant?(:"2021_10_mobile_search_panel_test", :overlay)
+      = render(PanelComponent.new(button_text: t("buttons.search_toggle_panel"), heading_text: t("jobs.search.title"))) do |panel|
+        - panel.body do
           = render "shared/search/keyword", f: f
           = render "shared/search/location", f: f
           = render "shared/search/current_location", target: "location-field"
@@ -84,29 +72,17 @@ ruby:
 
           = f.hidden_field :sort_by, value: @form.sort.by
           = f.govuk_submit t("buttons.search"), classes: "govuk-button govuk-!-margin-bottom-0 govuk-!-width-full"
-  - else
-    .search-controls__panel.search-controls__panel--mobile
-      - if current_variant?(:"2021_10_mobile_search_panel_test", :overlay)
-        = render(PanelComponent.new(button_text: t("buttons.search_toggle_panel"), heading_text: t("jobs.search.title"))) do |panel|
-          - panel.body do
-            = render "shared/search/keyword", f: f
-            = render "shared/search/location", f: f
-            = render "shared/search/current_location", target: "location-field"
-            = render "shared/search/radius", f: f, wide: true
+    - else
+      .search-controls__panel__filters
+        h2.govuk-heading-m = t("jobs.search.title")
 
-            = f.hidden_field :sort_by, value: @form.sort.by
-            = f.govuk_submit t("buttons.search"), classes: "govuk-button govuk-!-margin-bottom-0 govuk-!-width-full"
-      - else
-        .search-controls__panel__filters
-          h2.govuk-heading-m = t("jobs.search.title")
+        = render "shared/search/keyword", f: f
+        = render "shared/search/location", f: f
+        = render "shared/search/current_location", target: "location-field"
+        = render "shared/search/radius", f: f, wide: true
 
-          = render "shared/search/keyword", f: f
-          = render "shared/search/location", f: f
-          = render "shared/search/current_location", target: "location-field"
-          = render "shared/search/radius", f: f, wide: true
-
-          = f.hidden_field :sort_by, value: @form.sort.by
-          = f.govuk_submit t("buttons.search"), classes: "govuk-button govuk-!-margin-bottom-0 govuk-!-width-full"
+        = f.hidden_field :sort_by, value: @form.sort.by
+        = f.govuk_submit t("buttons.search"), classes: "govuk-button govuk-!-margin-bottom-0 govuk-!-width-full"
 
   .search-controls__panel
     = render(PanelComponent.new(button_text: t("buttons.filters_toggle_panel", count: @form.total_filters), heading_text: "Filter results")) do |panel|

--- a/app/views/vacancies/index.html.slim
+++ b/app/views/vacancies/index.html.slim
@@ -10,22 +10,11 @@
 
   .grid-row
     .grid-column-left class="govuk-!-margin-bottom-3"
-      = form_for @form, as: "", url: jobs_path, method: :get, html: { id: "filter-form", data: { controller: "form" }, class: "filters-form", role: "search", aria: { label: "Filter criteria" } } do |f|
+      = form_for @form, as: "", url: jobs_path, method: :get, html: { id: "mobile-search-and-filters-form", data: { controller: "form" }, class: "filters-form", role: "search", aria: { label: "Filter criteria" } } do |f|
         = render "search", f: f
     .grid-column-right
-      - if current_variant?(:"2021_11_desktop_search_results_page_test", :right_column)
-        = form_for @form, as: "", url: jobs_path, method: :get, html: { id: "search-form", class: "filters-form", role: "search", aria: { label: "Search criteria" } } do |f|
-          .search-results__header.search-results__header--border.desktop-only
-            h2.govuk-heading-m = t("jobs.search.title")
-            = render "shared/search/keyword", f: f
-            = render "shared/search/location", show_hint: false, desktop: true, f: f
-            = render "shared/search/radius", f: f, wide: true
-            = f.hidden_field :sort_by, value: @form.sort.by
-            = f.hidden_field :job_roles, value: @form.job_roles
-            = f.hidden_field :phases, value: @form.phases
-            = f.hidden_field :working_patterns, value: @form.working_patterns
-            .search-results__header__submit
-              = f.govuk_submit t("buttons.search"), classes: "govuk-button govuk-!-margin-bottom-0 govuk-!-margin-top-6 govuk-!-width-full"
+      = form_for @form, as: "", url: jobs_path, method: :get, html: { id: "desktop-search-form", class: "filters-form", role: "search", aria: { label: "Search criteria" } } do |f|
+        = render "desktop_search", f: f
 
       = map(items: [{ type: "location", params: { location: params[:location], radius: params[:radius] } }].to_json, render: @display_map, zoom: 8)
 

--- a/config/ab_tests.yml
+++ b/config/ab_tests.yml
@@ -33,9 +33,6 @@ shared:
   2021_10_mobile_search_panel_test:
     present: 1
     overlay: 1
-  2021_11_desktop_search_results_page_test:
-    present: 1
-    right_column: 1
 test:
   2021_04_cookie_consent_test:
     none: 0
@@ -47,6 +44,3 @@ test:
   2021_10_mobile_search_panel_test:
     present: 1
     overlay: 0
-  2021_11_desktop_search_results_page_test:
-    present: 1
-    right_column: 0

--- a/spec/system/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
+++ b/spec/system/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe "Jobseekers can create a job alert from a search", recaptcha: tru
   end
 
   def and_perform_a_search
-    within ".filters-form" do
+    within "#mobile-search-and-filters-form" do
       fill_in "keyword", with: "english"
       fill_in "location", with: location
       if search_with_polygons?

--- a/spec/system/jobseekers_can_search_for_jobs_spec.rb
+++ b/spec/system/jobseekers_can_search_for_jobs_spec.rb
@@ -1,23 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
-  let(:school) { create(:school) }
-  let!(:maths_job1) { create(:vacancy, :past_publish, publish_on: Date.current - 1, id: "67991ea9-431d-4d9d-9c99-a78b80108fe1", job_title: "Maths Teacher 1", subjects: [], organisations: [school]) }
-  let!(:maths_job2) { create(:vacancy, :past_publish, publish_on: Date.current - 2, id: "7bfadb84-cf30-4121-88bd-a9f958440cc9", job_title: "Maths Teacher 2: The Return of Maths", subjects: [], organisations: [school]) }
-  let!(:job1) { create(:vacancy, :past_publish, id: "20cc99ff-4fdb-4637-851a-68cf5f8fea9f", job_title: "Physics Teacher", subjects: [], organisations: [school]) }
-  let!(:job2) { create(:vacancy, :past_publish, id: "9910d184-5686-4ffc-9322-69aa150c19d3", job_title: "PE Teacher", subjects: [], organisations: [school]) }
-  let!(:job3) { create(:vacancy, :past_publish, id: "3bf67da6-039c-4ee1-bf59-8475672a0d2b", job_title: "Chemistry Teacher", subjects: [], organisations: [school]) }
-  let!(:job4) { create(:vacancy, :past_publish, id: "e750baf6-cc9a-4b93-84cf-ee4e5f8a7ee4", job_title: "Geography Teacher", subjects: [], organisations: [school]) }
-  let!(:expired_job) { create(:vacancy, :expired, id: "0f86d38c-56d4-48d3-b8a2-474f19d4908e", job_title: "Maths Teacher", subjects: [], organisations: [school]) }
-  let(:per_page) { 2 }
-
-  before do
-    stub_const("Search::VacancySearch::DEFAULT_HITS_PER_PAGE", per_page)
-    visit jobs_path
-    fill_in "Keyword", with: keyword
-    click_on I18n.t("buttons.search")
-  end
-
+RSpec.shared_examples "a successful search" do
   context "when searching for teacher jobs" do
     let(:keyword) { "Teacher" }
 
@@ -61,5 +44,39 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
         expect("Maths Teacher 2: The Return of Maths").to appear_before("Maths Teacher 1")
       end
     end
+  end
+end
+
+RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
+  let(:school) { create(:school) }
+  let!(:maths_job1) { create(:vacancy, :past_publish, publish_on: Date.current - 1, id: "67991ea9-431d-4d9d-9c99-a78b80108fe1", job_title: "Maths Teacher 1", subjects: [], organisations: [school]) }
+  let!(:maths_job2) { create(:vacancy, :past_publish, publish_on: Date.current - 2, id: "7bfadb84-cf30-4121-88bd-a9f958440cc9", job_title: "Maths Teacher 2: The Return of Maths", subjects: [], organisations: [school]) }
+  let!(:job1) { create(:vacancy, :past_publish, id: "20cc99ff-4fdb-4637-851a-68cf5f8fea9f", job_title: "Physics Teacher", subjects: [], organisations: [school]) }
+  let!(:job2) { create(:vacancy, :past_publish, id: "9910d184-5686-4ffc-9322-69aa150c19d3", job_title: "PE Teacher", subjects: [], organisations: [school]) }
+  let!(:job3) { create(:vacancy, :past_publish, id: "3bf67da6-039c-4ee1-bf59-8475672a0d2b", job_title: "Chemistry Teacher", subjects: [], organisations: [school]) }
+  let!(:job4) { create(:vacancy, :past_publish, id: "e750baf6-cc9a-4b93-84cf-ee4e5f8a7ee4", job_title: "Geography Teacher", subjects: [], organisations: [school]) }
+  let!(:expired_job) { create(:vacancy, :expired, id: "0f86d38c-56d4-48d3-b8a2-474f19d4908e", job_title: "Maths Teacher", subjects: [], organisations: [school]) }
+  let(:per_page) { 2 }
+
+  context "when searching using the mobile search fields" do
+    before do
+      stub_const("Search::VacancySearch::DEFAULT_HITS_PER_PAGE", per_page)
+      visit jobs_path
+      page.find("#mobile-search-and-filters-form").fill_in "Keyword", with: keyword
+      page.find("#mobile-search-and-filters-form").click_on I18n.t("buttons.search")
+    end
+
+    it_behaves_like "a successful search"
+  end
+
+  context "when searching using the desktop search field" do
+    before do
+      stub_const("Search::VacancySearch::DEFAULT_HITS_PER_PAGE", per_page)
+      visit jobs_path
+      page.find("#desktop-search-form").fill_in "Keyword", with: keyword
+      page.find("#desktop-search-form").click_on I18n.t("buttons.search")
+    end
+
+    it_behaves_like "a successful search"
   end
 end

--- a/spec/system/jobseekers_can_search_from_home_page_spec.rb
+++ b/spec/system/jobseekers_can_search_from_home_page_spec.rb
@@ -14,8 +14,10 @@ RSpec.describe "Searching on the home page" do
     click_on I18n.t("buttons.search")
 
     expect(current_path).to eq(jobs_path)
-    expect(page.find("#keyword-field").value).to eq("math")
-    expect(page.find("#location-field").value).to eq("bristol")
+    expect(page.find("#mobile-search-and-filters-form").find("#keyword-field").value).to eq("math")
+    expect(page.find("#desktop-search-form").find("#keyword-field").value).to eq("math")
+    expect(page.find("#mobile-search-and-filters-form").find("#location-field").value).to eq("bristol")
+    expect(page.find("#desktop-search-form").find("#location-field").value).to eq("bristol")
   end
 
   context "when the location is not a polygon" do
@@ -26,9 +28,12 @@ RSpec.describe "Searching on the home page" do
       click_on I18n.t("buttons.search")
 
       expect(current_path).to eq(jobs_path)
-      expect(page.find("#keyword-field").value).to eq("math")
-      expect(page.find("#location-field").value).to eq("my house")
-      expect(page.find("#radius-field").value).to eq(Search::RadiusBuilder::DEFAULT_RADIUS_FOR_POINT_SEARCHES.to_s)
+      expect(page.find("#mobile-search-and-filters-form").find("#keyword-field").value).to eq("math")
+      expect(page.find("#desktop-search-form").find("#keyword-field").value).to eq("math")
+      expect(page.find("#mobile-search-and-filters-form").find("#location-field").value).to eq("my house")
+      expect(page.find("#desktop-search-form").find("#location-field").value).to eq("my house")
+      expect(page.find("#mobile-search-and-filters-form").find("#radius-field").value).to eq(Search::RadiusBuilder::DEFAULT_RADIUS_FOR_POINT_SEARCHES.to_s)
+      expect(page.find("#desktop-search-form").find("#radius-field").value).to eq(Search::RadiusBuilder::DEFAULT_RADIUS_FOR_POINT_SEARCHES.to_s)
     end
   end
 end

--- a/spec/system/jobseekers_can_view_and_visit_homepage_facets_spec.rb
+++ b/spec/system/jobseekers_can_view_and_visit_homepage_facets_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe "Jobseekers can view and visit homepage facets" do
       click_on "London"
 
       expect(current_path).to eq(location_path("london"))
-      expect(page.find("#location-field").value).to eq("London")
+      expect(page.find("#mobile-search-and-filters-form").find("#location-field").value).to eq("London")
+      expect(page.find("#desktop-search-form").find("#location-field").value).to eq("London")
     end
   end
 
@@ -44,7 +45,8 @@ RSpec.describe "Jobseekers can view and visit homepage facets" do
       click_on "Devon"
 
       expect(current_path).to eq(location_path("devon"))
-      expect(page.find("#location-field").value).to eq("Devon")
+      expect(page.find("#mobile-search-and-filters-form").find("#location-field").value).to eq("Devon")
+      expect(page.find("#desktop-search-form").find("#location-field").value).to eq("Devon")
     end
   end
 
@@ -107,7 +109,8 @@ RSpec.describe "Jobseekers can view and visit homepage facets" do
 
       expect(current_path).to eq(subject_path("english"))
       expect(page.title).to include(I18n.t("landing_pages.title", landing_page: "English"))
-      expect(page.find("#keyword-field").value).to eq("english")
+      expect(page.find("#mobile-search-and-filters-form").find("#keyword-field").value).to eq("english")
+      expect(page.find("#desktop-search-form").find("#keyword-field").value).to eq("english")
     end
   end
 end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3682

## Changes in this PR:

This PR removes the AB test which had 2 variants for desktop users: the search fields being in the left column, and the search fields being in the right column (above the search results).

We retain the variant which puts the search fields in the right column (above the results). There is also some refactoring: the search fields are moved into a partial. Tests are updated to use successful AB test variant.

## Screenshots of UI changes:

### Before

![image](https://user-images.githubusercontent.com/24639777/149325464-d96eb526-44d6-4a1c-9560-fbc28facc555.png)

### After

![image](https://user-images.githubusercontent.com/24639777/149325295-d4b7b10e-8216-4191-be21-e6dda2a32df7.png)