### PR TITLE
[TEVA-3614] Fix for duplicate params bug

### DIFF
--- a/app/views/vacancies/_mobile_search.html.slim
+++ b/app/views/vacancies/_mobile_search.html.slim
@@ -1,7 +1,3 @@
-= f.hidden_field :keyword, value: @form.keyword
-= f.hidden_field :location, value: @form.location
-= f.hidden_field :radius, value: @form.radius
-
 .search-controls__panel.search-controls__panel--mobile
   .search-controls__panel__filters
     h2.govuk-heading-m = t("jobs.search.title")


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3614

This bug occurs when clicking on one of the filter checkboxes after making a search.

An example of the URL: `http://localhost:3000/jobs?keyword=&location=london&radius=25&keyword=&location=london&radius=25&sort_by=publish_on&job_roles%5B%5D=&job_roles%5B%5D=leadership&job_roles%5B%5D=&job_roles%5B%5D=&phases%5B%5D=&working_patterns%5B%5D=`

It seems these hidden fields were responsible for this. With these hidden fields present, these fields and the visible form fields (with the same name) were being submitted.

I notice that job_roles appears 3 times as well. I assume this is a bug?
