### PR TITLE
Fix deprecated use of `Date#to_s`

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -21,7 +21,7 @@ class ApplicationRecord < ActiveRecord::Base
     attributes_except_ciphertext.each_with_object({}) do |(key, value), anonymised|
       next unless export?(key)
 
-      value = value.to_s(:iso8601) if value.respond_to?(:strftime)
+      value = value.to_formatted_s(:iso8601) if value.respond_to?(:strftime)
       anonymised[key] = anonymise?(key) ? anonymise_value(value) : value
     end
   end

--- a/app/views/jobseekers/account_mailer/inactive_account.text.erb
+++ b/app/views/jobseekers/account_mailer/inactive_account.text.erb
@@ -4,6 +4,6 @@
 
 <%= t(".explanation") %>
 
-<%= t(".reactivate", date: 2.weeks.from_now.to_date.to_s(:day_month)) %>
+<%= t(".reactivate", date: 2.weeks.from_now.to_date.to_formatted_s(:day_month)) %>
 
 <%= sign_in_link %>

--- a/app/views/jobseekers/job_applications/build/employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/build/employment_history.html.slim
@@ -28,7 +28,7 @@
                   - row.value text: employment.subjects.presence || t("jobseekers.job_applications.not_defined")
                 - summary_list.row do |row|
                   - row.key text: t("jobseekers.job_applications.employments.started_on")
-                  - row.value text: employment.started_on.to_s(:month_year)
+                  - row.value text: employment.started_on.to_formatted_s(:month_year)
 
                 - case employment.current_role
                 - when "yes"
@@ -38,7 +38,7 @@
                 - when "no"
                   - summary_list.row do |row|
                     - row.key text: t("jobseekers.job_applications.employments.ended_on")
-                    - row.value text: employment.ended_on.to_s(:month_year)
+                    - row.value text: employment.ended_on.to_formatted_s(:month_year)
 
                 - summary_list.row do |row|
                   - row.key text: t("jobseekers.job_applications.employments.main_duties")
@@ -56,7 +56,7 @@
           = govuk_inset_text do
             h2.govuk-heading-s class="govuk-!-margin-bottom-1" = t(".break")
             p.govuk-body class="govuk-!-margin-bottom-0" = employment.reason_for_break
-            p.govuk-hint class="govuk-!-margin-top-0 govuk-!-margin-bottom-1" #{employment.started_on.to_s(:month_year)} to #{employment.ended_on.to_s(:month_year)}
+            p.govuk-hint class="govuk-!-margin-top-0 govuk-!-margin-bottom-1" #{employment.started_on.to_formatted_s(:month_year)} to #{employment.ended_on.to_formatted_s(:month_year)}
             = govuk_link_to edit_jobseekers_job_application_break_path(job_application, employment), class: "govuk-link--no-visited-state govuk-!-margin-right-3"
               = t("buttons.change")
               span.govuk-visually-hidden = " #{t('.break')} #{employment.started_on} to #{employment.ended_on}"

--- a/app/views/publishers/job_application_data_expiry_mailer/job_application_data_expiry.text.erb
+++ b/app/views/publishers/job_application_data_expiry_mailer/job_application_data_expiry.text.erb
@@ -1,4 +1,4 @@
-# <%= t(".title", job_title: @vacancy.job_title, publish_date: @vacancy.publish_on.to_s(:month_year), expiration_date: data_expiration_date) %>
+# <%= t(".title", job_title: @vacancy.job_title, publish_date: @vacancy.publish_on.to_formatted_s(:month_year), expiration_date: data_expiration_date) %>
 
 <%= t(".expiry", job_title: @vacancy.job_title, expiration_date: data_expiration_date) %>
 

--- a/app/views/shared/job_application/_explained_employment_break.html.slim
+++ b/app/views/shared/job_application/_explained_employment_break.html.slim
@@ -2,4 +2,4 @@
   = govuk_inset_text classes: "govuk-!-margin-top-3 govuk-!-margin-bottom-3" do
     h2.govuk-heading-s class="govuk-!-margin-bottom-1" = t("jobseekers.job_applications.build.employment_history.break")
     p.govuk-body class="govuk-!-margin-bottom-0" = employment.reason_for_break
-    p.govuk-hint class="govuk-!-margin-top-1 govuk-!-margin-bottom-1" #{employment.started_on.to_s(:month_year)} to #{employment.ended_on.to_s(:month_year) || "present"}
+    p.govuk-hint class="govuk-!-margin-top-1 govuk-!-margin-bottom-1" #{employment.started_on.to_formatted_s(:month_year)} to #{employment.ended_on.to_formatted_s(:month_year) || "present"}

--- a/spec/mailers/jobseekers/account_mailer_spec.rb
+++ b/spec/mailers/jobseekers/account_mailer_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Jobseekers::AccountMailer do
       expect(mail.body.encoded).to include(I18n.t("jobseekers.account_mailer.inactive_account.subject"))
       expect(mail.body.encoded).to include(I18n.t("jobseekers.account_mailer.inactive_account.intro"))
       expect(mail.body.encoded).to include(I18n.t("jobseekers.account_mailer.inactive_account.explanation"))
-      expect(mail.body.encoded).to include(I18n.t("jobseekers.account_mailer.inactive_account.reactivate", date: 2.weeks.from_now.to_date.to_s(:day_month)))
+      expect(mail.body.encoded).to include(I18n.t("jobseekers.account_mailer.inactive_account.reactivate", date: 2.weeks.from_now.to_date.to_formatted_s(:day_month)))
       expect(mail.body.encoded).to include(new_jobseeker_session_path)
     end
   end

--- a/spec/mailers/publishers/job_application_data_expiry_mailer_spec.rb
+++ b/spec/mailers/publishers/job_application_data_expiry_mailer_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Publishers::JobApplicationDataExpiryMailer do
       expect(mail.to).to eq(["test@example.com"])
       expect(mail.body.encoded).to include(vacancy.job_title)
                                .and include(I18n.t("publishers.job_application_data_expiry_mailer.job_application_data_expiry.title", job_title: vacancy.job_title,
-                                                                                                                                      publish_date: vacancy.publish_on.to_s(:month_year),
+                                                                                                                                      publish_date: vacancy.publish_on.to_formatted_s(:month_year),
                                                                                                                                       expiration_date: vacancy_data_expiration_date))
                                .and include(I18n.t("publishers.job_application_data_expiry_mailer.job_application_data_expiry.expiry", job_title: vacancy.job_title,
                                                                                                                                        expiration_date: vacancy_data_expiration_date))

--- a/spec/models/application_record_spec.rb
+++ b/spec/models/application_record_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ApplicationRecord do
                     "email" => StringAnonymiser.new(model.email).to_s,
                     "given_name" => StringAnonymiser.new(model.given_name).to_s,
                     "family_name" => StringAnonymiser.new(model.family_name).to_s,
-                    "accepted_terms_at" => model.accepted_terms_at.to_s(:iso8601))
+                    "accepted_terms_at" => model.accepted_terms_at.to_formatted_s(:iso8601))
       end
 
       it "anonymises data" do

--- a/spec/system/jobseekers_can_add_employments_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers_can_add_employments_to_their_job_application_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Jobseekers can add employments and breaks to their job applicati
 
     expect(current_path).to eq(jobseekers_job_application_build_path(job_application, :employment_history))
     expect(page).to have_content("The Best Teacher")
-    expect(page).to have_content(Date.new(2020, 0o7, 1).to_s(:month_year))
+    expect(page).to have_content(Date.new(2020, 0o7, 1).to_formatted_s(:month_year))
   end
 
   context "managing employment history gaps" do

--- a/spec/system/jobseekers_can_review_a_job_application_spec.rb
+++ b/spec/system/jobseekers_can_review_a_job_application_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe "Jobseekers can review a job application" do
     within ".review-component__section", text: I18n.t("jobseekers.job_applications.build.employment_history.heading") do
       job_application.employments.break.each do |employment|
         expect(page).to have_content(employment.reason_for_break)
-        expect(page).to have_content(employment.started_on.to_s(:month_year))
-        expect(page).to have_content(employment.ended_on.to_s(:month_year))
+        expect(page).to have_content(employment.started_on.to_formatted_s(:month_year))
+        expect(page).to have_content(employment.ended_on.to_formatted_s(:month_year))
       end
     end
 


### PR DESCRIPTION
Using `#to_s` on `Date`/`Time`/`TimeWithZone` with a format argument is
fully deprecated in future versions of Rails in favour of
`#to_formatted_s`.