### PR TITLE
Improve Content Security Policy

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,50 +4,43 @@
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-Rails.application.config.content_security_policy do |policy|
-  policy.default_src :self
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self
 
-  development_env_additional_connect_src = %w[http://localhost:3035 ws://localhost:3035] if Rails.env.development?
+    development_env_additional_connect_src = %w[http://localhost:3035 ws://localhost:3035] if Rails.env.development?
+    policy.connect_src :self,
+                       "https://api.postcodes.io",
+                       "https://api.rollbar.com",
+                       "https://www.google-analytics.com",
+                       *development_env_additional_connect_src # Allow using webpack-dev-server in development
 
-  policy.connect_src :self,
-                     "https://api.postcodes.io",
-                     "https://api.rollbar.com",
-                     "https://www.google-analytics.com",
-                     *development_env_additional_connect_src # Allow using webpack-dev-server in development
+    policy.font_src    :self,
+                       :data
 
-  policy.font_src    :self,
-                     :data
+    policy.frame_src   :self,
+                       "https://www.recaptcha.net",
+                       "https://www.googletagmanager.com"
 
-  policy.frame_src   :self,
-                     "https://www.recaptcha.net",
-                     "https://www.googletagmanager.com"
+    policy.img_src     :self,
+                       :https,
+                       :data
 
-  policy.img_src     :self,
-                     :https,
-                     :data
+    policy.object_src  :none
 
-  policy.object_src  :none
+    policy.script_src  :self,
+                       :unsafe_inline, # Backwards compatibility; ignored by modern browsers as we set a nonce for scripts
+                       "https://cdn.rollbar.com",
+                       "https://www.google-analytics.com",
+                       "https://www.googletagmanager.com",
+                       "https://www.recaptcha.net"
 
-  policy.script_src  :self,
-                     :unsafe_inline, # Backwards compatibility; ignored by modern browsers as we set a nonce for scripts
-                     "https://cdn.rollbar.com",
-                     "https://www.google-analytics.com",
-                     "https://www.googletagmanager.com",
-                     "https://www.recaptcha.net"
+    policy.style_src   :self
 
-  # Google Maps embed will not work without 'unsafe-inline' styles
-  #   see: https://issuetracker.google.com/issues/132600807
-  policy.style_src   :self
+    # Specify URI for violation reports
+    policy.report_uri "/errors/csp_violation"
+  end
 
-  # Specify URI for violation reports
-  policy.report_uri "/errors/csp_violation"
+  # Generate session nonces for permitted importmap and inline scripts
+  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
 end
-
-# Enable automatic nonce generation for <script> tags
-Rails.application.config.content_security_policy_nonce_generator = ->(_) { SecureRandom.base64(16) }
-
-# Set the nonce only to `script-src` directive (because of Google Maps issue detailed above)
-Rails.application.config.content_security_policy_nonce_directives = %w[script-src]
-
-# Make the CSP report only (default is `false`, commented out to make it enforce)
-# Rails.application.config.content_security_policy_report_only = true


### PR DESCRIPTION
- Reformat and nest in a `Rails.application.configure` à la Rails 7 to
  make it easier to read
- Remove stray leftover Google Maps configuration and comments
- Move to from per-request to per-session nonces (default in future
  versions of Rails, would help us adopt e.g. Turbo and importmaps in
  the future if we so wish)