### PR TITLE
Use explicit `lockbox_encrypts` method in models

### DIFF
--- a/app/models/employment.rb
+++ b/app/models/employment.rb
@@ -1,6 +1,6 @@
 class Employment < ApplicationRecord
   belongs_to :job_application
-  encrypts :organisation, :job_title, :main_duties
+  lockbox_encrypts :organisation, :job_title, :main_duties
 
   enum employment_type: { job: 0, break: 1 }
 end

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -20,10 +20,10 @@ class JobApplication < ApplicationRecord
   # If you want to add a status, be sure to add a `status_at` column to the `job_applications` table
   enum status: { draft: 0, submitted: 1, reviewed: 2, shortlisted: 3, unsuccessful: 4, withdrawn: 5 }, _default: 0
 
-  encrypts :first_name, :last_name, :previous_names, :street_address, :city, :postcode, :phone_number,
-           :teacher_reference_number, :national_insurance_number, :personal_statement, :support_needed_details,
-           :close_relationships_details, :further_instructions, :rejection_reasons,
-           :gaps_in_employment_details
+  lockbox_encrypts :first_name, :last_name, :previous_names, :street_address, :city, :postcode, :phone_number,
+                   :teacher_reference_number, :national_insurance_number, :personal_statement, :support_needed_details,
+                   :close_relationships_details, :further_instructions, :rejection_reasons,
+                   :gaps_in_employment_details
 
   belongs_to :jobseeker
   belongs_to :vacancy

--- a/app/models/jobseeker.rb
+++ b/app/models/jobseeker.rb
@@ -1,5 +1,5 @@
 class Jobseeker < ApplicationRecord
-  encrypts :last_sign_in_ip, :current_sign_in_ip
+  lockbox_encrypts :last_sign_in_ip, :current_sign_in_ip
 
   devise :database_authenticatable, :registerable, :recoverable, :validatable,
          :confirmable, :lockable, :trackable, :timeoutable

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -7,7 +7,7 @@ class Publisher < ApplicationRecord
   has_many :publisher_preferences, dependent: :destroy
   has_many :vacancies
 
-  encrypts :family_name, :given_name
+  lockbox_encrypts :family_name, :given_name
 
   devise :omniauthable, :timeoutable, omniauth_providers: %i[dfe]
   self.timeout_in = 60.minutes # Overrides default Devise configuration

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -4,7 +4,7 @@ class Qualification < ApplicationRecord
   belongs_to :job_application
   has_many :qualification_results, dependent: :delete_all, autosave: true
   accepts_nested_attributes_for :qualification_results
-  encrypts :finished_studying_details
+  lockbox_encrypts :finished_studying_details
 
   SECONDARY_QUALIFICATIONS = %w[gcse as_level a_level other_secondary].freeze
 

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -1,5 +1,5 @@
 class Reference < ApplicationRecord
   belongs_to :job_application
 
-  encrypts :name, :job_title, :organisation, :email, :phone_number
+  lockbox_encrypts :name, :job_title, :organisation, :email, :phone_number
 end


### PR DESCRIPTION
Rails 7 will introduce native ActiveRecord encryption, which we may want
to move to in the future, but in the meantime the `encrypts` method from
Lockbox conflicts with it.

This changes the models to use the fully named `lockbox_encrypts` method
instead.