### PR TITLE
Upgrade Spring to 4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,9 @@ group :development do
   gem "solargraph", require: false
   gem "spring"
   gem "spring-commands-rspec"
-  gem "spring-watcher-listen"
+  # TODO: Add back when version supporting Spring >= 4.0 is released
+  #       see https://github.com/rails/spring-watcher-listen/issues/27
+  # gem "spring-watcher-listen"
   gem "web-console"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -587,12 +587,9 @@ GEM
       thor (~> 1.0)
       tilt (~> 2.0)
       yard (~> 0.9, >= 0.9.24)
-    spring (2.1.1)
+    spring (4.0.0)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
-    spring-watcher-listen (2.0.1)
-      listen (>= 2.7, < 4.0)
-      spring (>= 1.2, < 3.0)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -765,7 +762,6 @@ DEPENDENCIES
   solargraph
   spring
   spring-commands-rspec
-  spring-watcher-listen
   tzinfo-data
   validate_url
   vcr

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -9,7 +9,8 @@ Rails.application.configure do
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs. Don't rely on the data there!
-  config.cache_classes = true
+  # Set to `false` to support Spring preloading in test
+  config.cache_classes = false
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that


### PR DESCRIPTION
- Change `config.cache_classes` to `false` in test environments as this
  is the new required config for Spring
- Temporarily disable the `spring-watcher-listen` gem as it hasn't seen
  a release in a long time and isn't compatible with recent Spring