### PR TITLE
TEVA-3720 Fix job application editability bugs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,10 +26,10 @@ jobs:
             params: 'spec/system/jobseekers_*_spec.rb spec/system/jobseekers'
           -
             name: system - publishers
-            params: 'spec/system/publishers_*_spec.rb'
+            params: 'spec/system/publishers_*_spec.rb spec/system/publishers'
           -
             name: system - other & a11y
-            params: '--exclude-pattern "spec/system/jobseekers, spec/system/{jobseekers,publishers}_*_spec.rb" spec/system spec/accessibility'
+            params: '--exclude-pattern "spec/system/{jobseekers,publishers}, spec/system/{jobseekers,publishers}_*_spec.rb" spec/system spec/accessibility'
           -
             name: unit
             params: '--exclude-pattern "spec/{accessibility,system}/*_spec.rb"'

--- a/app/components/job_application_review_component.rb
+++ b/app/components/job_application_review_component.rb
@@ -2,12 +2,13 @@ class JobApplicationReviewComponent < ReviewComponent
   renders_many(:sections, lambda do |section_name, **kwargs|
     JobApplicationReviewComponent::Section.new(
       @job_application,
+      allow_edit: @allow_edit,
       name: section_name,
       **kwargs,
     )
   end)
 
-  def initialize(job_application, step_process:, classes: [], html_attributes: {}, **kwargs)
+  def initialize(job_application, step_process:, allow_edit: nil, classes: [], html_attributes: {}, **kwargs)
     super(
       classes: classes,
       html_attributes: html_attributes,
@@ -15,6 +16,7 @@ class JobApplicationReviewComponent < ReviewComponent
       **kwargs,
     )
 
+    @allow_edit = allow_edit
     @job_application = job_application
     @step_process = step_process
   end

--- a/app/components/job_application_review_component/section.rb
+++ b/app/components/job_application_review_component/section.rb
@@ -43,6 +43,6 @@ class JobApplicationReviewComponent::Section < ReviewComponent::Section
   end
 
   def allow_edit?
-    !@job_application.deadline_passed?
+    !@job_application.deadline_passed? && !@job_application.submitted?
   end
 end

--- a/app/components/job_application_review_component/section.rb
+++ b/app/components/job_application_review_component/section.rb
@@ -2,7 +2,7 @@ class JobApplicationReviewComponent::Section < ReviewComponent::Section
   include JobApplicationsHelper
   include VacanciesHelper
 
-  def initialize(job_application, forms: [], classes: [], html_attributes: {}, **kwargs)
+  def initialize(job_application, allow_edit: nil, forms: [], classes: [], html_attributes: {}, **kwargs)
     super(
       job_application,
       forms: forms,
@@ -11,6 +11,7 @@ class JobApplicationReviewComponent::Section < ReviewComponent::Section
       **kwargs,
     )
 
+    @allow_edit = allow_edit
     @job_application = job_application
   end
 
@@ -43,6 +44,8 @@ class JobApplicationReviewComponent::Section < ReviewComponent::Section
   end
 
   def allow_edit?
+    return @allow_edit unless @allow_edit.nil?
+
     !@job_application.deadline_passed? && !@job_application.submitted?
   end
 end

--- a/app/views/publishers/vacancies/job_applications/show.html.slim
+++ b/app/views/publishers/vacancies/job_applications/show.html.slim
@@ -24,7 +24,7 @@
         = govuk_button_link_to t("buttons.reject"), organisation_job_job_application_reject_path(vacancy.id, job_application.id), class: "govuk-button--warning govuk-!-margin-right-3"
       = govuk_button_link_to t("buttons.download_application"), "#", class: "govuk-button--secondary js-action print-application", "data-controller": "utils", "data-action": "click->utils#print"
 
-    = render "shared/job_application/show"
+    = render "shared/job_application/show", allow_edit: false
 
   .govuk-grid-column-one-third
     .account-sidebar class="govuk-!-display-none-print"

--- a/app/views/shared/job_application/_show.html.slim
+++ b/app/views/shared/job_application/_show.html.slim
@@ -9,5 +9,5 @@
     - navigation.anchor text: t(".ask_for_support.heading"), href: "#ask_for_support"
     - navigation.anchor text: t(".declarations.heading"), href: "#declarations"
 
-= job_application_review(job_application, step_process: step_process, show_tracks: false) do |r|
+= job_application_review(job_application, step_process: step_process, show_tracks: false, allow_edit: local_assigns[:allow_edit]) do |r|
   - render "jobseekers/job_applications/job_application_review_sections", r: r

--- a/spec/factories/publishers.rb
+++ b/spec/factories/publishers.rb
@@ -6,5 +6,9 @@ FactoryBot.define do
     family_name { Faker::Name.last_name.delete("'") }
     given_name { Faker::Name.first_name }
     oid { Faker::Crypto.md5 }
+
+    trait :with_organisation do
+      organisations { build_list(:school, 1) }
+    end
   end
 end

--- a/spec/support/auth_helpers.rb
+++ b/spec/support/auth_helpers.rb
@@ -1,5 +1,7 @@
 module AuthHelpers
-  def login_publisher(publisher:, organisation:, allow_reminders: false)
+  def login_publisher(publisher:, organisation: nil, allow_reminders: false)
+    organisation ||= publisher.organisations.first
+
     page.set_rack_session(visited_application_feature_reminder_page: true) unless allow_reminders
     page.set_rack_session(publisher_organisation_id: organisation.id)
     login_as(publisher, scope: :publisher)

--- a/spec/system/jobseekers/job_applications/deadline_passed_spec.rb
+++ b/spec/system/jobseekers/job_applications/deadline_passed_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Deadline-passed job applications for jobseekers" do
-  context "when an application is in “draft” status and the deadline for application has passed" do
+  context "when an application is in 'draft' status and the deadline for application has passed" do
     let(:deadline) { 1.week.ago }
 
     let(:vacancy) { create(:vacancy, :with_organisation, :published, expires_at: deadline) }
@@ -20,13 +20,13 @@ RSpec.describe "Deadline-passed job applications for jobseekers" do
       login_as(jobseeker, scope: :jobseeker)
     end
 
-    describe "on the “my applications“ page" do
+    describe "on the 'my applications' page" do
       before do
         visit jobseekers_job_applications_path
         expect(page).to have_css("#applications-results > .card-component", count: 1)
       end
 
-      it "shows a status “tag” of “deadline passed”" do
+      it "shows a status 'tag' of 'deadline passed'" do
         expect(page).to have_css("#applications-results .govuk-tag", text: "deadline passed")
       end
 
@@ -41,7 +41,7 @@ RSpec.describe "Deadline-passed job applications for jobseekers" do
         click_on job_application.vacancy.job_title
       end
 
-      it "has the application status of “deadline passed”" do
+      it "has the application status of 'deadline passed'" do
         expect(page).to have_css(".job-application-review-banner .govuk-tag", text: "deadline passed")
       end
 
@@ -53,7 +53,7 @@ RSpec.describe "Deadline-passed job applications for jobseekers" do
         expect(page).not_to have_css(".review-component__section__heading a")
       end
 
-      it "removes the “submit application” section" do
+      it "removes the 'submit application' section" do
         expect(page).not_to have_css(".new_jobseekers_job_application_review_form")
       end
     end

--- a/spec/system/jobseekers/job_applications/deadline_passed_spec.rb
+++ b/spec/system/jobseekers/job_applications/deadline_passed_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Deadline-passed job applications" do
+RSpec.describe "Deadline-passed job applications for jobseekers" do
   context "when an application is in “draft” status and the deadline for application has passed" do
     let(:deadline) { 1.week.ago }
 

--- a/spec/system/jobseekers/job_applications/submitted_spec.rb
+++ b/spec/system/jobseekers/job_applications/submitted_spec.rb
@@ -1,16 +1,14 @@
 require "rails_helper"
 
-RSpec.describe "Deadline-passed job applications" do
-  context "when an application is in “draft” status and the deadline for application has passed" do
-    let(:deadline) { 1.week.ago }
-
-    let(:vacancy) { create(:vacancy, :with_organisation, :published, expires_at: deadline) }
+RSpec.describe "Submitted job applications" do
+  context "when an application is in submitted status" do
+    let(:vacancy) { create(:vacancy, :with_organisation, :published) }
 
     let(:jobseeker) { create(:jobseeker) }
     let!(:job_application) do
       create(
         :job_application,
-        draft_at: deadline - 1.week,
+        :submitted,
         jobseeker: jobseeker,
         vacancy: vacancy,
       )
@@ -26,12 +24,12 @@ RSpec.describe "Deadline-passed job applications" do
         expect(page).to have_css("#applications-results > .card-component", count: 1)
       end
 
-      it "shows a status “tag” of “deadline passed”" do
-        expect(page).to have_css("#applications-results .govuk-tag", text: "deadline passed")
+      it "shows a status “tag” of “submitted”" do
+        expect(page).to have_css("#applications-results .govuk-tag", text: "submitted")
       end
 
       it "has a link to view the application" do
-        expect(page).to have_link(job_application.vacancy.job_title, href: jobseekers_job_application_review_path(job_application))
+        expect(page).to have_link(job_application.vacancy.job_title, href: jobseekers_job_application_path(job_application))
       end
     end
 
@@ -41,8 +39,8 @@ RSpec.describe "Deadline-passed job applications" do
         click_on job_application.vacancy.job_title
       end
 
-      it "has the application status of “deadline passed”" do
-        expect(page).to have_css(".job-application-review-banner .govuk-tag", text: "deadline passed")
+      it "has the application status of “submitted”" do
+        expect(page).to have_css(".job-application-review-banner .govuk-tag", text: "submitted")
       end
 
       it "does not show the section status indicators" do

--- a/spec/system/jobseekers/job_applications/submitted_spec.rb
+++ b/spec/system/jobseekers/job_applications/submitted_spec.rb
@@ -18,13 +18,13 @@ RSpec.describe "Submitted job applications for jobseekers" do
       login_as(jobseeker, scope: :jobseeker)
     end
 
-    describe "on the “my applications“ page" do
+    describe "on the 'my applications' page" do
       before do
         visit jobseekers_job_applications_path
         expect(page).to have_css("#applications-results > .card-component", count: 1)
       end
 
-      it "shows a status “tag” of “submitted”" do
+      it "shows a status 'tag' of 'submitted'" do
         expect(page).to have_css("#applications-results .govuk-tag", text: "submitted")
       end
 
@@ -39,7 +39,7 @@ RSpec.describe "Submitted job applications for jobseekers" do
         click_on job_application.vacancy.job_title
       end
 
-      it "has the application status of “submitted”" do
+      it "has the application status of 'submitted'" do
         expect(page).to have_css(".job-application-review-banner .govuk-tag", text: "submitted")
       end
 
@@ -51,7 +51,7 @@ RSpec.describe "Submitted job applications for jobseekers" do
         expect(page).not_to have_css(".review-component__section__heading a")
       end
 
-      it "removes the “submit application” section" do
+      it "removes the 'submit application' section" do
         expect(page).not_to have_css(".new_jobseekers_job_application_review_form")
       end
     end

--- a/spec/system/jobseekers/job_applications/submitted_spec.rb
+++ b/spec/system/jobseekers/job_applications/submitted_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Submitted job applications" do
+RSpec.describe "Submitted job applications for jobseekers" do
   context "when an application is in submitted status" do
     let(:vacancy) { create(:vacancy, :with_organisation, :published) }
 

--- a/spec/system/publishers/job_applications/draft_spec.rb
+++ b/spec/system/publishers/job_applications/draft_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe "Draft job applications for publishers" do
+  context "when an application is in “submitted” status" do
+    let(:publisher) { create(:publisher, :with_organisation) }
+
+    let(:vacancy) do
+      create(:vacancy, :published, publisher: publisher, organisations: publisher.organisations)
+    end
+
+    let!(:job_application) do
+      create(:job_application, :submitted, vacancy: vacancy)
+    end
+
+    before do
+      login_publisher(publisher: publisher)
+    end
+
+    describe "on the “manage jobs“ page" do
+      before do
+        visit organisation_path
+        click_on vacancy.job_title
+        click_on "Applications"
+        expect(page).to have_css(".card-component", count: 1)
+      end
+
+      it "shows a status “tag” of “unread”" do
+        expect(page).to have_css(".card-component .govuk-tag", text: "unread")
+      end
+
+      it "has a link to view the application" do
+        expect(page).to have_link(job_application.name, href: organisation_job_job_application_path(job_application, job_id: vacancy.id))
+      end
+    end
+
+    describe "on the application page" do
+      before do
+        visit organisation_path
+        click_on vacancy.job_title
+        click_on "Applications"
+        click_on job_application.name
+      end
+
+      it "has the application status of “reviewed”" do
+        expect(page).to have_css(".application-status .govuk-tag", text: "reviewed")
+      end
+
+      it "does not show the section status indicators" do
+        expect(page).not_to have_css(".review-component__section__heading .govuk-tag")
+      end
+
+      it "does not allow the jobseeker to edit or update any sections" do
+        expect(page).not_to have_css(".review-component__section__heading a")
+      end
+
+      it "removes the “submit application” section" do
+        expect(page).not_to have_css(".new_jobseekers_job_application_review_form")
+      end
+    end
+  end
+end

--- a/spec/system/publishers/job_applications/draft_spec.rb
+++ b/spec/system/publishers/job_applications/draft_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Draft job applications for publishers" do
-  context "when an application is in “submitted” status" do
+  context "when an application is in 'submitted' status" do
     let(:publisher) { create(:publisher, :with_organisation) }
 
     let(:vacancy) do
@@ -16,7 +16,7 @@ RSpec.describe "Draft job applications for publishers" do
       login_publisher(publisher: publisher)
     end
 
-    describe "on the “manage jobs“ page" do
+    describe "on the 'manage jobs' page" do
       before do
         visit organisation_path
         click_on vacancy.job_title
@@ -24,7 +24,7 @@ RSpec.describe "Draft job applications for publishers" do
         expect(page).to have_css(".card-component", count: 1)
       end
 
-      it "shows a status “tag” of “unread”" do
+      it "shows a status 'tag' of 'unread'" do
         expect(page).to have_css(".card-component .govuk-tag", text: "unread")
       end
 
@@ -41,7 +41,7 @@ RSpec.describe "Draft job applications for publishers" do
         click_on job_application.name
       end
 
-      it "has the application status of “reviewed”" do
+      it "has the application status of 'reviewed'" do
         expect(page).to have_css(".application-status .govuk-tag", text: "reviewed")
       end
 
@@ -53,7 +53,7 @@ RSpec.describe "Draft job applications for publishers" do
         expect(page).not_to have_css(".review-component__section__heading a")
       end
 
-      it "removes the “submit application” section" do
+      it "removes the 'submit application' section" do
         expect(page).not_to have_css(".new_jobseekers_job_application_review_form")
       end
     end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3720

## Changes in this PR:

```
Draft job applications for publishers
  when an application is in “submitted” status
    on the “manage jobs“ page
      has a link to view the application
      shows a status “tag” of “unread”
    on the application page
      does not allow the jobseeker to edit or update any sections
      has the application status of “reviewed”
      does not show the section status indicators
      removes the “submit application” section

6 examples, 0 failures
```
```
Submitted job applications for jobseekers
  when an application is in submitted status
    on the application page
      has the application status of “submitted”
      does not allow the jobseeker to edit or update any sections
      removes the “submit application” section
      does not show the section status indicators
    on the “my applications“ page
      has a link to view the application
      shows a status “tag” of “submitted”

6 examples, 0 failures
```