### PR TITLE
Reorder sections on vacancy review page

### DIFF
--- a/app/views/publishers/vacancies/_vacancy_review_sections.html.slim
+++ b/app/views/publishers/vacancies/_vacancy_review_sections.html.slim
@@ -45,19 +45,6 @@
     label: t("jobs.application_deadline")
   - s.row :starts_on, text: vacancy.starts_asap? ? t("jobs.starts_asap") : format_date(vacancy.starts_on)
 
-- r.section :documents
-  dl.govuk-summary-list
-    - if vacancy.supporting_documents.none?
-      .govuk-summary-list__row
-        dt.govuk-summary-list__key class="govuk-!-font-weight-regular"
-          = t("jobs.no_supporting_documents")
-    - else
-      - vacancy.supporting_documents.each_with_index do |document, index|
-        .govuk-summary-list__row
-          dt.govuk-summary-list__key class=(index.zero? && "first-question")
-            h4.govuk-heading-s = "Document #{index + 1}"
-          dd.govuk-summary-list__value class=(index.zero? && "first-question") = document.filename
-
 - r.section :applying_for_the_job do |s|
   - unless current_organisation.group_type == "local_authority"
     - s.row :enable_job_applications
@@ -72,6 +59,19 @@
   - s.row :contact_email, text: govuk_mail_to(vacancy.contact_email, nil, "aria-label": t("jobs.aria_labels.contact_email_link", email: vacancy.contact_email))
   - s.row :contact_number, value_if_attribute_present: govuk_link_to(vacancy.contact_number, "tel:#{vacancy.contact_number}"), optional: true
   - s.row :school_visits, label: t("jobs.#{school_or_trust_visits(vacancy.parent_organisation)}"), optional: true
+
+- r.section :documents
+  dl.govuk-summary-list
+    - if vacancy.supporting_documents.none?
+      .govuk-summary-list__row
+        dt.govuk-summary-list__key class="govuk-!-font-weight-regular"
+          = t("jobs.no_supporting_documents")
+    - else
+      - vacancy.supporting_documents.each_with_index do |document, index|
+        .govuk-summary-list__row
+          dt.govuk-summary-list__key class=(index.zero? && "first-question")
+            h4.govuk-heading-s = "Document #{index + 1}"
+          dd.govuk-summary-list__value class=(index.zero? && "first-question") = document.filename
 
 - r.section :job_summary do |s|
   - s.row :job_advert


### PR DESCRIPTION
## Changes in this PR:

This PR swaps the order of the _Supporting documents_ and _Applying for the job_ steps (missed from my PR for [TEVA-3434](https://dfedigital.atlassian.net/browse/TEVA-3434))

## Screenshots of UI changes:

### Before

![image](https://user-images.githubusercontent.com/24639777/149538115-f208b9d6-2f99-4175-9cea-415f9a0a7364.png)

### After

![image](https://user-images.githubusercontent.com/24639777/149538022-18825f25-6ae7-450f-ae35-e7f40be16ade.png)
