### PR TITLE
Tweak content security policy

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -57,6 +57,7 @@ class ErrorsController < ApplicationController
 
     # Misbehaving browser plugin(s)
     return false if csp_details["document-uri"] == "about"
+    return false if csp_details["source-file"]&.start_with?("safari-web-extension")
     # Facebook in-app browser injecting its own scripts
     return false if csp_details["blocked-uri"]&.start_with?("https://connect.facebook.net")
 

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -43,4 +43,9 @@ Rails.application.configure do
 
   # Generate session nonces for permitted importmap and inline scripts
   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+
+  # Set nonce only for scripts
+  # TODO: We tried removing this and it caused a flood of CSP violations from Mobile Safari.
+  #       Investigate again later.
+  config.content_security_policy_nonce_directives = %w[script-src]
 end


### PR DESCRIPTION
- Revert nonce setting to try and mitigate Mobile Safari CSP issues
- Ignore Safari web extension CSP spam