### PR TITLE
Remove CSP violation reporting

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -36,9 +36,6 @@ Rails.application.configure do
                        "https://www.recaptcha.net"
 
     policy.style_src   :self
-
-    # Specify URI for violation reports
-    policy.report_uri "/errors/csp_violation"
   end
 
   # Generate session nonces for permitted importmap and inline scripts

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -214,7 +214,6 @@ Rails.application.routes.draw do
   # Well known URLs
   get ".well-known/change-password", to: redirect(status: 302) { Rails.application.routes.url_helpers.edit_jobseeker_registration_path(password_update: true) }
 
-  post "/errors/csp_violation", to: "errors#csp_violation"
   get "/invalid-recaptcha", to: "errors#invalid_recaptcha", as: "invalid_recaptcha"
   match "/401", as: :unauthorised, to: "errors#unauthorised", via: :all
   match "/404", as: :not_found, to: "errors#not_found", via: :all

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -26,16 +26,6 @@ RSpec.describe "Errors" do
     end
   end
 
-  describe "POST #csp_violation" do
-    let(:violation) { { "csp-report": { foo: "bar" } }.to_json }
-    it "sends the error to Rollbar" do
-      expect(Rollbar).to receive(:error).with("CSP Violation", details: violation)
-
-      post errors_csp_violation_path, params: violation
-      expect(response).to have_http_status(:no_content)
-    end
-  end
-
   describe "GET #invalid_recaptcha" do
     it "sends the error to Rollbar" do
       expect(Rollbar).to receive(:error).with("Invalid recaptcha", details: "this form")


### PR DESCRIPTION
This was very useful back when we started implementing CSP, but now it's
just lots of false positives from misbehaving and/or poorly implemented
web extensions.