### PR TITLE
[TEVA-3656] Update end listing form to align with expired vacancy feedback

### DIFF
--- a/app/controllers/publishers/vacancies/end_listing_controller.rb
+++ b/app/controllers/publishers/vacancies/end_listing_controller.rb
@@ -6,7 +6,7 @@ class Publishers::Vacancies::EndListingController < Publishers::Vacancies::BaseC
       vacancy.update(form_params.merge(expires_at: Time.current))
       update_google_index(vacancy)
       SendJobListingEndedEarlyNotificationJob.new.perform(vacancy)
-      redirect_to jobs_with_type_organisation_path(:expired), success: t(".success", job_title: vacancy.job_title)
+      redirect_to organisation_job_path(vacancy.id), success: t(".success", job_title: vacancy.job_title)
     else
       render :show
     end
@@ -28,7 +28,7 @@ class Publishers::Vacancies::EndListingController < Publishers::Vacancies::BaseC
   end
 
   def form_params
-    params.require(:publishers_job_listing_end_listing_form).permit(:end_listing_reason, :candidate_hired_from)
+    (params[:publishers_job_listing_end_listing_form] || params).permit(:hired_status, :listed_elsewhere)
   end
 
   def vacancy

--- a/app/form_models/publishers/job_listing/end_listing_form.rb
+++ b/app/form_models/publishers/job_listing/end_listing_form.rb
@@ -1,6 +1,6 @@
 class Publishers::JobListing::EndListingForm < BaseForm
-  attr_accessor :end_listing_reason, :candidate_hired_from
+  attr_accessor :hired_status, :listed_elsewhere
 
-  validates :end_listing_reason, inclusion: { in: Vacancy.end_listing_reasons.keys }
-  validates :candidate_hired_from, inclusion: { in: Vacancy.candidate_hired_froms.keys }, if: -> { end_listing_reason == "suitable_candidate_found" }
+  validates :hired_status, inclusion: { in: Vacancy.hired_statuses.keys }
+  validates :listed_elsewhere, inclusion: { in: Vacancy.listed_elsewheres.keys }
 end

--- a/app/helpers/vacancies_options_helper.rb
+++ b/app/helpers/vacancies_options_helper.rb
@@ -14,10 +14,4 @@ module VacanciesOptionsHelper
       radii << [t("jobs.search.number_of_miles", count: radius), radius]
     end
   end
-
-  def candidate_hired_from_options
-    Vacancy.candidate_hired_froms.keys
-      .map { |k| [t("helpers.options.publishers_job_listing_end_listing_form.candidate_hired_from.#{k}"), k] }
-      .unshift(["Select a service or application method", ""])
-  end
 end

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -23,9 +23,7 @@ class Vacancy < ApplicationRecord
   array_enum working_patterns: { full_time: 0, part_time: 100, job_share: 101, term_time: 102 }
   # Legacy vacancies can have these working_pattern options too: { compressed_hours: 102, staggered_hours: 103 }
 
-  enum candidate_hired_from: { teaching_vacancies: 0, other_free: 1, other_paid: 2, unknown: 3 }
   enum contract_type: { permanent: 0, fixed_term: 1, parental_leave_cover: 2 }
-  enum end_listing_reason: { suitable_candidate_found: 0, end_early: 1 }
   enum hired_status: { hired_tvs: 0, hired_other_free: 1, hired_paid: 2, hired_no_listing: 3, not_filled_ongoing: 4, not_filled_not_looking: 5, hired_dont_know: 6 }
   enum job_location: { at_one_school: 0, at_multiple_schools: 1, central_office: 2 }
   enum listed_elsewhere: { listed_paid: 0, listed_free: 1, listed_mix: 2, not_listed: 3, listed_dont_know: 4 }

--- a/app/views/publishers/vacancies/end_listing/show.html.slim
+++ b/app/views/publishers/vacancies/end_listing/show.html.slim
@@ -10,10 +10,23 @@
       = form_for form, url: organisation_job_end_listing_path(vacancy.id), method: :patch do |f|
         = f.govuk_error_summary
 
-        = f.govuk_radio_buttons_fieldset :end_listing_reason do
-          = f.govuk_radio_button :end_listing_reason, :suitable_candidate_found, link_errors: true do
-            = f.govuk_collection_select :candidate_hired_from, candidate_hired_from_options, :last, :first, label: { size: "s" }
-          = f.govuk_radio_button :end_listing_reason, :end_early
+        = f.govuk_radio_buttons_fieldset(:hired_status, legend: { size: "m" }) do
+          = f.govuk_radio_button :hired_status, :hired_tvs
+          = f.govuk_radio_button :hired_status, :hired_other_free
+          = f.govuk_radio_button :hired_status, :hired_paid
+          = f.govuk_radio_button :hired_status, :hired_no_listing
+          = f.govuk_radio_button :hired_status, :not_filled_ongoing
+          = f.govuk_radio_button :hired_status, :not_filled_not_looking
+          = f.govuk_radio_divider
+          = f.govuk_radio_button :hired_status, :hired_dont_know
+
+        = f.govuk_radio_buttons_fieldset(:listed_elsewhere, legend: { size: "m" }) do
+          = f.govuk_radio_button :listed_elsewhere, :listed_paid
+          = f.govuk_radio_button :listed_elsewhere, :listed_free
+          = f.govuk_radio_button :listed_elsewhere, :listed_mix
+          = f.govuk_radio_button :listed_elsewhere, :not_listed
+          = f.govuk_radio_divider
+          = f.govuk_radio_button :listed_elsewhere, :listed_dont_know
 
         = f.govuk_submit t("buttons.end_listing"), classes: "govuk-!-margin-bottom-5"
 

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -313,8 +313,6 @@ shared:
     - parental_leave_cover_contract_duration
     - enable_job_applications
     - personal_statement_guidance
-    - end_listing_reason
-    - candidate_hired_from
     - completed_steps
     - working_patterns_details
     - phase

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -88,9 +88,9 @@ en:
       inclusion: Please indicate if you'd like to participate in user research
   publisher_job_listing_expired_feedback_form: &publisher_job_listing_expired_feedback_form_errors
     hired_status:
-      inclusion: Please make sure you have submitted an answer for both questions
+      inclusion: Select an option for how the job was filled
     listed_elsewhere:
-      inclusion: Please make sure you have submitted an answer for both questions
+      inclusion: Select an option for how the job was listed
 
   # Publishers journey
   job_role_errors: &job_role_errors
@@ -257,10 +257,7 @@ en:
             <<: *publisher_job_listing_expired_feedback_form_errors
         publishers/job_listing/end_listing_form:
           attributes:
-            end_listing_reason:
-              inclusion: Select why you would like to end this job listing early
-            candidate_hired_from:
-              inclusion: Select how the successful candidate applied for the role
+            <<: *publisher_job_listing_expired_feedback_form_errors
         publishers/job_listing/extend_deadline_form:
           attributes:
             <<: *important_dates_errors

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -510,12 +510,7 @@ en:
           "true": As soon as possible
       publishers_job_listing_documents_form:
         documents: Upload files
-      publishers_job_listing_end_listing_form:
-        candidate_hired_from: Select how the successful candidate applied for the role
-        end_listing_reason_options:
-          suitable_candidate_found: We have found a suitable candidate and are no longer accepting applications
-          end_early: We are no longer listing this role and want to end it earlier than the deadline
-      publishers_job_listing_expired_feedback_form:
+      publishers_job_listing_expired_feedback_form: &expired_vacancy_feedback_shared_labels
         hired_status_options:
           hired_dont_know: I don't know
           hired_no_listing: No, we hired, but not through a listing or service
@@ -533,6 +528,8 @@ en:
       publishers_job_listing_extend_deadline_form:
         starts_asap_options:
           "true": As soon as possible
+      publishers_job_listing_end_listing_form:
+        <<: *expired_vacancy_feedback_shared_labels
       publishers_job_listing_feedback_form:
         email: What is your email address?
         comment_html: Do you have any suggestions on how we should improve the service? (optional<span class='govuk-visually-hidden'> field</span>)</span>
@@ -696,11 +693,11 @@ en:
         starts_on_html: Date job starts (optional<span class='govuk-visually-hidden'> field</span>)</span>
       publishers_job_listing_education_phases_form:
         phase:  What education phase will the role be covering?
-      publishers_job_listing_end_listing_form:
-        end_listing_reason: Why would you like to end this job listing early?
-      publishers_job_listing_expired_feedback_form:
+      publishers_job_listing_expired_feedback_form: &expired_vacancy_feedback_shared_legends
         hired_status: Was the job filled on Teaching Vacancies?
         listed_elsewhere: Was the job listed elsewhere?
+      publishers_job_listing_end_listing_form:
+        <<: *expired_vacancy_feedback_shared_legends
       publishers_job_listing_extend_deadline_form:
         expires_at: Closing date
         expiry_time: Time application is due
@@ -740,12 +737,6 @@ en:
         screenshot: Upload screenshots (optional)
 
     options:
-      publishers_job_listing_end_listing_form:
-        candidate_hired_from:
-          teaching_vacancies: Teaching Vacancies
-          other_free: We hired through a different free service
-          other_paid: We hired through a paid service
-          unknown: I don't know
       publishers_job_listing_copy_vacancy_form:
         expiry_time:
           "7:00": 7am

--- a/db/migrate/20220117134852_remove_end_listing_reason_and_candidate_hired_from_from_vacancies.rb
+++ b/db/migrate/20220117134852_remove_end_listing_reason_and_candidate_hired_from_from_vacancies.rb
@@ -1,0 +1,6 @@
+class RemoveEndListingReasonAndCandidateHiredFromFromVacancies < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :vacancies, :end_listing_reason, :integer
+    remove_column :vacancies, :candidate_hired_from, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_16_161208) do
+ActiveRecord::Schema.define(version: 2022_01_17_134852) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -456,8 +456,6 @@ ActiveRecord::Schema.define(version: 2021_12_16_161208) do
     t.integer "contract_type"
     t.string "fixed_term_contract_duration"
     t.text "personal_statement_guidance"
-    t.integer "end_listing_reason"
-    t.integer "candidate_hired_from"
     t.boolean "enable_job_applications"
     t.string "completed_steps", default: [], null: false, array: true
     t.string "actual_salary"

--- a/spec/form_models/publishers/job_listing/end_listing_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/end_listing_form_spec.rb
@@ -1,12 +1,6 @@
 require "rails_helper"
 
 RSpec.describe Publishers::JobListing::EndListingForm, type: :model do
-  it { is_expected.to validate_inclusion_of(:end_listing_reason).in_array(Vacancy.end_listing_reasons.keys) }
-  it { is_expected.not_to validate_inclusion_of(:candidate_hired_from).in_array(Vacancy.candidate_hired_froms.keys) }
-
-  context "when `end_listing_reason` is `suitable_candidate_found`" do
-    before { allow(subject).to receive(:end_listing_reason).and_return("suitable_candidate_found") }
-
-    it { is_expected.to validate_inclusion_of(:candidate_hired_from).in_array(Vacancy.candidate_hired_froms.keys) }
-  end
+  it { is_expected.to validate_inclusion_of(:hired_status).in_array(Vacancy.hired_statuses.keys) }
+  it { is_expected.to validate_inclusion_of(:listed_elsewhere).in_array(Vacancy.listed_elsewheres.keys) }
 end

--- a/spec/requests/publishers/vacancies/end_listing_spec.rb
+++ b/spec/requests/publishers/vacancies/end_listing_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "End job listing early" do
   end
 
   describe "PATCH #update" do
-    let(:params) { { publishers_job_listing_end_listing_form: { end_listing_reason: "end_early" } } }
+    let(:params) { { publishers_job_listing_end_listing_form: { hired_status: "hired_other_free", listed_elsewhere: "listed_free" } } }
 
     context "when the vacancy does not belong to the current organisation" do
       let(:vacancy) { create(:vacancy, organisations: [build(:school)]) }
@@ -60,14 +60,15 @@ RSpec.describe "End job listing early" do
       end
     end
 
-    it "updates expires_at, end_listing_reason, google index and redirects to the dashboard" do
+    it "updates expires_at, hired_status, listed_elsewhere, google index and redirects to the dashboard" do
       freeze_time do
         expect { patch(organisation_job_end_listing_path(vacancy.id), params: params) }
           .to change { vacancy.reload.expires_at }.from(1.week.from_now).to(Time.current)
-          .and change { vacancy.reload.end_listing_reason }.from(nil).to("end_early")
+          .and change { vacancy.reload.hired_status }.from(nil).to("hired_other_free")
+          .and change { vacancy.reload.listed_elsewhere }.from(nil).to("listed_free")
           .and have_enqueued_job(UpdateGoogleIndexQueueJob)
 
-        expect(response).to redirect_to(jobs_with_type_organisation_path(:expired))
+        expect(response).to redirect_to(organisation_job_path(vacancy.id))
       end
     end
   end

--- a/spec/system/publishers_can_end_a_job_listing_early_spec.rb
+++ b/spec/system/publishers_can_end_a_job_listing_early_spec.rb
@@ -17,12 +17,12 @@ RSpec.describe "Publishers can end a job listing early" do
 
     expect(page).to have_content("There is a problem")
 
-    choose I18n.t("helpers.label.publishers_job_listing_end_listing_form.end_listing_reason_options.suitable_candidate_found")
-    select "Teaching Vacancies"
+    choose I18n.t("helpers.label.publishers_job_listing_end_listing_form.hired_status_options.hired_other_free")
+    choose I18n.t("helpers.label.publishers_job_listing_end_listing_form.listed_elsewhere_options.listed_free")
 
     expect { click_on I18n.t("buttons.end_listing") }.to change { Vacancy.live.count }.from(1).to(0)
 
-    expect(current_path).to eq(jobs_with_type_organisation_path(:expired))
+    expect(current_path).to eq(organisation_job_path(vacancy.id))
   end
 
   context "when there are draft applications for the listing" do
@@ -35,8 +35,8 @@ RSpec.describe "Publishers can end a job listing early" do
     it "sends an email to jobseekers with draft applications" do
       click_on vacancy.job_title
       click_on I18n.t("buttons.end_listing_early")
-      choose I18n.t("helpers.label.publishers_job_listing_end_listing_form.end_listing_reason_options.suitable_candidate_found")
-      select "Teaching Vacancies"
+      choose I18n.t("helpers.label.publishers_job_listing_end_listing_form.hired_status_options.hired_other_free")
+      choose I18n.t("helpers.label.publishers_job_listing_end_listing_form.listed_elsewhere_options.listed_free")
 
       expect(job).to receive(:perform).with(vacancy)
 


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3656

## Questions

- I considered removing the EndListingForm and using the ExpiredFeedbackForm instead, but decided to stick with the EndListingForm. I did this because it seemed to make more sense (to me anyway) to render a form with the same name as the controller.  What are your thoughts?

