### PR TITLE
Implement frontend event tracking

### DIFF
--- a/app/components/jobseekers/organisation_overviews/base_component.rb
+++ b/app/components/jobseekers/organisation_overviews/base_component.rb
@@ -2,7 +2,7 @@ class Jobseekers::OrganisationOverviews::BaseComponent < ViewComponent::Base
   include OrganisationsHelper
   include VacanciesHelper
 
-  delegate :open_in_new_tab_link_to, to: :helpers
+  delegate :open_in_new_tab_link_to, :tracked_open_in_new_tab_link_to, to: :helpers
 
   attr_accessor :organisation, :vacancy
 

--- a/app/components/jobseekers/organisation_overviews/school_component/school_component.html.slim
+++ b/app/components/jobseekers/organisation_overviews/school_component/school_component.html.slim
@@ -26,7 +26,7 @@ section#school-overview
     - if organisation.website.present? || organisation.url.present?
       - summary_list.row do |row|
         - row.key text: t("schools.website")
-        - row.value text: open_in_new_tab_link_to(t("schools.website_link_text", organisation_name: organisation.name), organisation.website.presence || organisation.url, class: "wordwrap")
+        - row.value text: tracked_open_in_new_tab_link_to(t("schools.website_link_text", organisation_name: organisation.name), organisation.website.presence || organisation.url, link_type: :school_website, link_subject: StringAnonymiser.new(@vacancy.id).to_s, class: "wordwrap")
 
     - if @vacancy.contact_email.present?
       - summary_list.row do |row|

--- a/app/components/jobseekers/organisation_overviews/school_group_component/school_group_component.html.slim
+++ b/app/components/jobseekers/organisation_overviews/school_group_component/school_group_component.html.slim
@@ -11,7 +11,7 @@ section#school-overview class="govuk-!-margin-bottom-5"
     - if organisation.website.present? || organisation.url.present?
       - summary_list.row do |row|
         - row.key text: t("school_groups.website", organisation_type: organisation_type_basic(organisation).humanize)
-        - row.value text: open_in_new_tab_link_to(t("schools.website_link_text", organisation_name: organisation.name), organisation.website.presence || organisation.url, class: "link-wrap")
+        - row.value text: tracked_open_in_new_tab_link_to(t("schools.website_link_text", organisation_name: organisation.name), organisation.website.presence || organisation.url, link_type: :school_website, link_subject: StringAnonymiser.new(@vacancy.id).to_s, class: "link-wrap")
 
     - if @vacancy.contact_email.present?
       - summary_list.row do |row|

--- a/app/components/jobseekers/organisation_overviews/schools_component/schools_component.html.slim
+++ b/app/components/jobseekers/organisation_overviews/schools_component/schools_component.html.slim
@@ -11,7 +11,7 @@ section#school-overview class="govuk-!-margin-bottom-5"
     - if organisation.website.present? || organisation.url.present?
       - summary_list.row do |row|
         - row.key text: t("school_groups.website", organisation_type: organisation_type_basic(organisation).humanize)
-        - row.value text: open_in_new_tab_link_to(t("schools.website_link_text", organisation_name: organisation.name), organisation.website.presence || organisation.url, class: "link-wrap")
+        - row.value text: tracked_open_in_new_tab_link_to(t("schools.website_link_text", organisation_name: organisation.name), organisation.website.presence || organisation.url, link_type: :school_website, link_subject: StringAnonymiser.new(@vacancy.id).to_s, class: "link-wrap")
 
     - if @vacancy.contact_email.present?
       - summary_list.row do |row|

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -1,0 +1,32 @@
+class Api::EventsController < Api::ApplicationController
+  # Prevent arbitrary events/data from being triggered by the frontend
+  EVENT_ALLOWLIST = {
+    tracked_link_clicked: %i[link_type link_subject text href mouse_button],
+  }.freeze
+
+  rescue_from ActionController::InvalidAuthenticityToken, with: :bad_request
+
+  def create
+    type = event_params[:type].to_sym
+    return bad_request unless EVENT_ALLOWLIST.key?(type)
+
+    data = event_params[:data].to_h.slice(*EVENT_ALLOWLIST[type])
+    frontend_event.trigger(type, data)
+
+    head :no_content
+  end
+
+  private
+
+  def event_params
+    params.require(:event).permit(:type, data: {})
+  end
+
+  def frontend_event
+    FrontendEvent.new(request, response, session, current_jobseeker, current_publisher)
+  end
+
+  def bad_request
+    head(:bad_request)
+  end
+end

--- a/app/frontend/src/application.js
+++ b/app/frontend/src/application.js
@@ -12,6 +12,7 @@ import ClipboardController from './components/clipboard/clipboard';
 import FormController from './components/form/form';
 import LocationFinderController from './components/locationFinder/locationFinder';
 import ManageQualificationsController from './components/manageQualifications/manageQualifications';
+import TrackedLinkController from './components/trackedLink/trackedLink';
 import UploadDocumentsController from './components/uploadDocuments/uploadDocuments';
 import UtilsController from './components/utils';
 
@@ -28,6 +29,7 @@ application.register('location-finder', LocationFinderController);
 application.register('manage-qualifications', ManageQualificationsController);
 application.register('map', MapController);
 application.register('panel', PanelController);
+application.register('tracked-link', TrackedLinkController);
 application.register('upload-documents', UploadDocumentsController);
 application.register('utils', UtilsController);
 application.register('vacancy-selector', VacancySelectorController);

--- a/app/frontend/src/components/trackedLink/trackedLink.js
+++ b/app/frontend/src/components/trackedLink/trackedLink.js
@@ -1,0 +1,49 @@
+import { Controller } from '@hotwired/stimulus';
+import { triggerEvent } from '../../lib/events';
+
+const EVENT_TYPE = 'tracked_link_clicked';
+
+// Stimulus controller to send link click data to the app's events endpoint
+export default class extends Controller {
+  static targets = ['link'];
+
+  // Tracks a user click on the link connected to this controller
+  track(e) {
+    // Whether or not we should briefly inhibit the default behaviour of the click (i.e. the browser
+    // following the link) so we have a chance to send event data.
+    // True if and only if the user has used the primary mouse button (or tapped the link on a
+    // touchscreen device) AND the link is not intended to open in a new tab via a target attribute.
+    // Otherwise on e.g. a middle click to open in new tab, or a right click (which for
+    // simplicity's sake we also count as a click as the most likely reason is the user is opening
+    // in a new tab or copying the URL) we are happy for the default behaviour to go ahead normally
+    // (because the page isn't going away and there is ample opportunity for the event to complete).
+    const shouldWaitAndRedirect = e.button === 0 && !this.linkTarget.target === '_blank';
+
+    if (shouldWaitAndRedirect) {
+      // Don't let the browser follow the link immediately (before our event request has had a
+      // chance to be initiated)
+      e.preventDefault();
+
+      // Set a (hopefully) barely noticeable timeout for the redirect to happen anyway regardless
+      // of whether or not the event request has completed, so our users don't have to wait around.
+      setTimeout(() => { this.redirect(); }, 100);
+    }
+
+    triggerEvent(
+      EVENT_TYPE,
+      {
+        link_type: this.linkTarget.dataset.linkType,
+        text: this.linkTarget.innerText,
+        href: this.linkTarget.href,
+        mouse_button: e.button,
+      },
+    ).then(() => {
+      if (shouldWaitAndRedirect) this.redirect();
+    });
+  }
+
+  // Redirect to the target of the link (used if default behaviour has been inhibited)
+  redirect() {
+    window.location = this.linkTarget.href;
+  }
+}

--- a/app/frontend/src/lib/events.js
+++ b/app/frontend/src/lib/events.js
@@ -1,0 +1,21 @@
+import axios from 'axios';
+import logger from './logging';
+import { railsCsrfToken } from './utils';
+
+const EVENTS_ENDPOINT = '/api/events';
+
+// Triggers an event and makes a request to the backend endpoint with the event data.
+export const triggerEvent = (type, data) => {
+  const headers = { 'X-CSRF-Token': railsCsrfToken() };
+
+  return new Promise((resolve) => {
+    axios.post(EVENTS_ENDPOINT, { type, data }, { headers })
+      .then(resolve)
+      .catch((error) => {
+        logger.log(`Event trigger request: ${error}`);
+
+        // Events are not mission-critical: always resolve regardless of outcome
+        resolve();
+      });
+  });
+};

--- a/app/frontend/src/lib/utils.js
+++ b/app/frontend/src/lib/utils.js
@@ -61,3 +61,8 @@ export const storageAvailable = (type, logMessage = false) => {
           && (storage && storage.length !== 0);
   }
 };
+
+export const railsCsrfToken = () => {
+  const tokenElem = document.getElementsByName('csrf-token')[0];
+  return tokenElem && tokenElem.content;
+};

--- a/app/frontend/src/lib/utils.test.js
+++ b/app/frontend/src/lib/utils.test.js
@@ -3,7 +3,7 @@
  */
 
 import {
-  getNewState, getUnixTimestampForDayStart, stringMatchesPostcode, convertMilesToMetres, convertEpochToUnixTimestamp, stringContainsNumber,
+  getNewState, getUnixTimestampForDayStart, stringMatchesPostcode, convertMilesToMetres, convertEpochToUnixTimestamp, stringContainsNumber, railsCsrfToken,
 } from './utils';
 
 describe('getNewState', () => {
@@ -96,5 +96,27 @@ describe('convertEpochToUnixTimestamp', () => {
 describe('getUnixTimestampForDayStart', () => {
   test('get the UNIX timestamp of the beggining of a supplied date', () => {
     expect(getUnixTimestampForDayStart(new Date('2020-05-28T18:45:34.181Z'))).toBe(1590624000);
+  });
+});
+
+describe('railsCsrfToken', () => {
+  describe('when the token is present in the document', () => {
+    beforeEach(() => {
+      document.head.innerHTML = '<meta name="csrf-token" content="aloha">';
+    });
+
+    test('extracts the Rails CSRF token from the HTML', () => {
+      expect(railsCsrfToken()).toBe('aloha');
+    });
+  });
+
+  describe('when the token is missing from the document', () => {
+    beforeEach(() => {
+      document.head.innerHTML = '<html><blink>Nothing to see here</blink></html>';
+    });
+
+    test('returns undefined', () => {
+      expect(railsCsrfToken()).toBeUndefined();
+    });
   });
 });

--- a/app/helpers/links_helper.rb
+++ b/app/helpers/links_helper.rb
@@ -1,6 +1,20 @@
 module LinksHelper
+  def tracked_link_to(text, href, **kwargs)
+    govuk_link_to(text, href, **kwargs.deep_merge(data: {
+      controller: "tracked-link",
+      action: %w[click auxclick contextmenu].map { |a| "#{a}->tracked-link#track" }.join(" "),
+      "tracked-link-target": "link",
+      "link-type": kwargs.delete(:link_type),
+      "link-subject": kwargs.delete(:link_subject),
+    }))
+  end
+
   def open_in_new_tab_link_to(text, href, **kwargs)
     govuk_link_to("#{text} (opens in new tab)", href, target: "_blank", rel: "noreferrer noopener", **kwargs)
+  end
+
+  def tracked_open_in_new_tab_link_to(text, href, **kwargs)
+    tracked_link_to("#{text} (opens in new tab)", href, target: "_blank", rel: "noreferrer noopener", **kwargs)
   end
 
   def open_in_new_tab_button_link_to(text, href, **kwargs)

--- a/app/services/frontend_event.rb
+++ b/app/services/frontend_event.rb
@@ -1,0 +1,28 @@
+##
+# Represents events triggered from the frontend through the events API endpoint.
+# Overrides some of the original event data with the data for the page the event was triggered on,
+# and removes data that isn't relevant for frontend-triggered events that aren't "full" requests.
+class FrontendEvent < RequestEvent
+  private
+
+  def base_data
+    # These are set from the referrer because that is where the event was originally triggered
+    # (the actual request itself is to the events API endpoint)
+    referer = URI(request.referer)
+    path = referer.path
+    query_string = referer.query
+
+    super.merge(
+      request_path: path,
+      request_query: query_string,
+
+      # This data is coming through for the XHR request that triggers the event, but isn't relevant
+      # for events triggered on the frontend. The fields are set to `nil` to avoid confusion.
+      response_status: nil,
+      request_uuid: nil,
+      request_referer: nil,
+      request_method: nil,
+      response_content_type: nil,
+    )
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -162,6 +162,8 @@ Rails.application.routes.draw do
         resources :vacancies, only: %i[show]
       end
     end
+
+    resources :events, only: %i[create]
   end
 
   resource :new_features, only: %i[show update], controller: "publishers/new_features" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -95,6 +95,17 @@ RSpec.configure do |config|
     allow(Rails.application.config).to receive(:geocoder_lookup).and_return(:default)
   end
 
+  config.around(:each, :with_csrf_protection) do |example|
+    orig = ActionController::Base.allow_forgery_protection
+
+    begin
+      ActionController::Base.allow_forgery_protection = true
+      example.run
+    ensure
+      ActionController::Base.allow_forgery_protection = orig
+    end
+  end
+
   config.around(:each, zendesk: true) do |example|
     with_env("ZENDESK_API_KEY" => SecureRandom.uuid) do
       example.run

--- a/spec/requests/api/events_spec.rb
+++ b/spec/requests/api/events_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe "Events API" do
+  describe "#create" do
+    let(:event_type) { :tracked_link_clicked }
+    let(:event_data) { { link_type: "foo" } }
+
+    let(:request) do
+      post api_events_path,
+           params: { event: { type: event_type, data: event_data } },
+           headers: { "Referer" => "http://example.com/foo?bar" }
+    end
+
+    it "triggers an event" do
+      expect { request }.to have_triggered_event(:tracked_link_clicked)
+        .with_data(link_type: "foo")
+    end
+
+    it "requires a CSRF token", with_csrf_protection: true do
+      expect { request }.not_to have_triggered_event(:invalid_event)
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    context "when given an invalid event type" do
+      let(:event_type) { :invalid_event }
+
+      it "does not accept the event" do
+        expect { request }.not_to have_triggered_event(:invalid_event)
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+  end
+end

--- a/spec/services/frontend_event_spec.rb
+++ b/spec/services/frontend_event_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe FrontendEvent do
+  subject do
+    described_class.new(request, response, session, jobseeker, publisher)
+  end
+
+  let(:request) do
+    instance_double(
+      ActionDispatch::Request,
+      headers: { "User-Agent" => "Mozilla/4.0 (compatible; MSIE 5.5; Windows 95)" },
+      uuid: "00000000-0000-0000-0000-000000000000",
+      remote_ip: "255.255.255.255",
+      referer: "https://tv.gov.uk/blah-di?blub",
+      method: "DELETE",
+      path: "/foo/bar",
+      query_string: "foo=bar&baz=bat",
+    )
+  end
+
+  let(:response) do
+    instance_double(ActionDispatch::Response, content_type: "image/gif", status: 418)
+  end
+
+  let(:session) do
+    instance_double(ActionDispatch::Request::Session, id: "1337")
+  end
+
+  let(:publisher) { instance_double(Publisher, oid: 1234) }
+  let(:jobseeker) { instance_double(Jobseeker, id: 4321) }
+
+  let(:ab_tests) { double(AbTests, current_variants: { foo: :bar }) }
+
+  before do
+    allow(AbTests).to receive(:new).with(session).and_return(ab_tests)
+  end
+
+  describe "#trigger" do
+    let(:expected_data) do
+      {
+        type: :reticulated_splines,
+        occurred_at: "1999-12-31T23:59:59.000000Z",
+        request_uuid: nil,
+        request_user_agent: "Mozilla/4.0 (compatible; MSIE 5.5; Windows 95)",
+        request_referer: nil,
+        request_method: nil,
+        request_path: "/blah-di",
+        request_query: "blub",
+        request_ab_tests: [{ test: :foo, variant: :bar }],
+        response_content_type: nil,
+        response_status: nil,
+        user_anonymised_request_identifier: anonymised_form_of("Mozilla/4.0 (compatible; MSIE 5.5; Windows 95)255.255.255.255"),
+        user_anonymised_session_id: anonymised_form_of("1337"),
+        user_anonymised_jobseeker_id: anonymised_form_of("4321"),
+        user_anonymised_publisher_id: anonymised_form_of("1234"),
+        data: [{ key: "foo", value: "Bar" }],
+      }
+    end
+
+    it "enqueues a SendEventToDataWarehouseJob with the expected payload" do
+      expect(SendEventToDataWarehouseJob).to receive(:perform_later).with("events", expected_data)
+
+      travel_to(Time.zone.local(1999, 12, 31, 23, 59, 59)) do
+        subject.trigger(:reticulated_splines, foo: "Bar")
+      end
+    end
+  end
+end


### PR DESCRIPTION
We want to be able to track some user interactions on the frontend in a
more coherent way than we currently do (a `click_event` param on some
requests, and redirecting some external links through the backend). This
adds a lightweight frontend event tracking framework to achieve this.

- Add an "events" API endpoint to receive events from the frontend
- Add a `FrontendEvent` subtype of `RequestEvent` that overrides it to
  have the correct event data for frontend events
- Add `triggerEvent` function to allow sending an event from Javascript
- Add `trackedLink` Stimulus component to encapsulate links that should
  be tracked
- Add `LinksHelper#tracked_link_to`/`#tracked_open_in_new_tab_link_to`
  to mark up links with the Stimulus controller and event data
- Start tracking link clicks for links to organisation websites on
  job listings

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-2627