### PR TITLE
[TEVA-3753]-Unpin Grafana Runtime version

### DIFF
--- a/terraform/monitoring/resources.tf
+++ b/terraform/monitoring/resources.tf
@@ -11,7 +11,6 @@ module "prometheus_all" {
   alert_rules                  = file("${path.module}/config/alert.rules.yml")
   alertmanager_slack_url       = local.alertmanager_slack_url
   alertmanager_slack_channel   = local.alertmanager_slack_channel
-  grafana_runtime_version      = "7.2.2"
   grafana_google_client_id     = local.secrets.grafana_google_client_id
   grafana_google_client_secret = local.secrets.grafana_google_client_secret
   redis_services = [


### PR DESCRIPTION
The TV Grafana version is controlled via (terraform module = prometheus_all) cf monitoring repo, which them calls other modules, in the same repo.
This PR is to remove potential drift between TV Grafana version and Cf_monitoring. E.g. Incompatibility issue between Granfa version and Dashboard code.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3753

