### PR TITLE
[TEVA-3680] Align styling of govuk summary lists

### DIFF
--- a/app/components/jobseekers/organisation_overviews/school_group_component/school_group_component.html.slim
+++ b/app/components/jobseekers/organisation_overviews/school_group_component/school_group_component.html.slim
@@ -1,5 +1,5 @@
 section#school-overview class="govuk-!-margin-bottom-5"
-  h3.govuk-heading-l.section-heading
+  h3.govuk-heading-l.govuk-heading--summary-list
     = t("school_groups.trust_overview")
 
   = govuk_summary_list do |summary_list|
@@ -34,6 +34,8 @@ section#school-overview class="govuk-!-margin-bottom-5"
     p = vacancy.school_visits
 
   section#school-location
-    h3.govuk-heading-l.section-heading = t("school_groups.school_group_location")
+    h3.govuk-heading-l.govuk-heading--summary-list
+      = t("school_groups.school_group_location")
+    = govuk_link_to full_address(organisation), "https://www.google.com/maps/search/#{full_address(organisation)}+UK", "aria-label": t("schools.map_link_aria_label")
 
     = map(items: [{ type: "vacancy", params: { id: vacancy.id }, links: map_links }], show_map: organisation.geopoint)

--- a/app/components/jobseekers/organisation_overviews/schools_component/schools_component.html.slim
+++ b/app/components/jobseekers/organisation_overviews/schools_component/schools_component.html.slim
@@ -1,5 +1,5 @@
 section#school-overview class="govuk-!-margin-bottom-5"
-  h3.govuk-heading-l.section-heading
+  h3.govuk-heading-l.govuk-heading--summary-list
     = t("schools.schools_overview")
 
   = govuk_summary_list do |summary_list|

--- a/app/components/jobseekers/vacancy_details_component/vacancy_details_component.html.slim
+++ b/app/components/jobseekers/vacancy_details_component/vacancy_details_component.html.slim
@@ -1,5 +1,5 @@
 section#job-details class="govuk-!-margin-bottom-5"
-  h3.govuk-heading-l.section-heading
+  h3.govuk-heading-l.govuk-heading--summary-list
     = t("publishers.vacancies.steps.job_details")
 
   = govuk_summary_list do |summary_list|
@@ -72,7 +72,8 @@ section#job-details class="govuk-!-margin-bottom-5"
 
   - if @vacancy.supporting_documents.any?
     section#supporting-documents
-      h3.govuk-heading-l.section-heading = t("publishers.vacancies.steps.documents")
+      h3.govuk-heading-l.govuk-heading--summary-list
+        = t("publishers.vacancies.steps.documents")
       p.govuk-body = t("jobs.supporting_documents_accessibility")
       .grey-border-box--thin
         = render SupportingDocumentComponent.with_collection(@vacancy.supporting_documents)

--- a/app/components/publishers/school_overview_component/school_overview_component.html.slim
+++ b/app/components/publishers/school_overview_component/school_overview_component.html.slim
@@ -1,4 +1,5 @@
-h2.govuk-heading-m = t("schools.info", organisation: @organisation.name)
+h2.govuk-heading-m.govuk-heading--summary-list
+  = t("schools.info", organisation: @organisation.name)
 
 = govuk_summary_list do |summary_list|
   - summary_list.row do |row|

--- a/app/components/review_component/review_component.scss
+++ b/app/components/review_component/review_component.scss
@@ -42,32 +42,20 @@
     &__body {
       margin-bottom: govuk-spacing(8);
 
-      .govuk-summary-list {
-        @include govuk-font(19);
+      @include govuk-media-query($from: tablet) {
+        border-top: 1px solid $govuk-border-colour;
 
-        border-collapse: collapse;
-        margin-bottom: 0;
-        margin-top: 0;
-
-        @include govuk-media-query($from: tablet) {
-          border-top: 1px solid $govuk-border-colour;
+        > p {
+          padding-top: govuk-spacing(2);
         }
+      }
 
-        @include govuk-media-query($from: desktop) {
-          display: table;
-        }
+      .govuk-summary-list__value {
+        padding-right: 0;
+      }
 
-        .govuk-summary-list__row {
-          .govuk-summary-list__value {
-            border: 0;
-            padding-right: 0;
-          }
-
-          .govuk-summary-list__key {
-            border: 0;
-            padding-right: 20px;
-          }
-        }
+      .govuk-summary-list__key {
+        padding-right: govuk-spacing(2);
       }
     }
   }

--- a/app/frontend/src/styles/application.scss
+++ b/app/frontend/src/styles/application.scss
@@ -131,17 +131,16 @@ dd {
   margin: 0;
 }
 
-.govuk-section-break {
-  &--thick {
-    border-bottom: 5px solid #b1b4b6;
+.govuk-heading {
+  &--summary-list {
+    border-bottom: 6px solid $govuk-border-colour;
+    padding-bottom: govuk-spacing(2);
   }
 }
 
-.govuk-summary-list {
-  border-collapse: collapse;
-
-  .govuk-summary-list__row {
-    border-bottom: 1px solid $govuk-border-colour;
+.govuk-section-break {
+  &--thick {
+    border-bottom: 5px solid #b1b4b6;
   }
 }
 

--- a/app/frontend/src/styles/application/publishers/awaiting-feedback.scss
+++ b/app/frontend/src/styles/application/publishers/awaiting-feedback.scss
@@ -1,8 +1,5 @@
 .publisher {
   .awaiting-feedback {
-    display: block;
-    padding: govuk-spacing(4) 0;
-
     .govuk-form-group {
       margin-bottom: govuk-spacing(2);
     }
@@ -39,6 +36,11 @@
       .govuk-button {
         margin: 0;
       }
+    }
+
+    &__row {
+      border-bottom: 1px solid $govuk-border-colour;
+      padding: govuk-spacing(4) 0;
     }
   }
 }

--- a/app/frontend/src/styles/application/publishers/publisher.scss
+++ b/app/frontend/src/styles/application/publishers/publisher.scss
@@ -56,40 +56,7 @@ $desktop-container-width: 1200px;
   .job-application-actions {
     display: flex;
   }
-
-  .govuk-summary-list {
-    &.summary-list--no-divider {
-      border-top: 0;
-
-      .govuk-summary-list__row {
-        border-top: 0;
-
-        @include govuk-media-query($until: desktop) {
-          border-bottom: 0;
-        }
-
-        .govuk-summary-list__key,
-        .govuk-summary-list__value,
-        .govuk-summary-list__actions {
-          border-bottom: 0;
-        }
-
-        &:last-child {
-          @include govuk-media-query($until: desktop) {
-            .govuk-summary-list__value {
-              padding-bottom: govuk-spacing(3);
-            }
-          }
-
-          .govuk-summary-list__key,
-          .govuk-summary-list__value,
-          .govuk-summary-list__actions {
-            border-bottom: 1px solid $govuk-border-colour;
-          }
-        }
-      }
-    }
-  }
+  
 }
 
 .job-applications-summary {

--- a/app/views/jobseekers/accounts/show.html.slim
+++ b/app/views/jobseekers/accounts/show.html.slim
@@ -5,25 +5,20 @@
 .govuk-main-wrapper class="govuk-!-padding-bottom-0"
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      h1.govuk-heading-l = t(".page_title")
+      h1.govuk-heading-l.govuk-heading--summary-list
+        = t(".page_title")
 
-      dl.govuk-summary-list
-        .govuk-summary-list__row
-          dt.govuk-summary-list__key = t(".summary_list.email")
-          dd.govuk-summary-list__value = current_jobseeker.email
-          dd.govuk-summary-list__actions
-            = govuk_link_to edit_jobseeker_registration_path do
-              = t(".summary_list.change")
-              span.govuk-visually-hidden
-                = t(".summary_list.email")
-        .govuk-summary-list__row
-          dt.govuk-summary-list__key = t(".summary_list.password")
-          dd.govuk-summary-list__value = t(".summary_list.password_placeholder")
-          dd.govuk-summary-list__actions
-            = govuk_link_to edit_jobseeker_registration_path(password_update: true) do
-              = t(".summary_list.change")
-              span.govuk-visually-hidden
-                = t(".summary_list.password")
+      = govuk_summary_list do |summary_list|
+        - summary_list.row do |row|
+          - row.key text: t(".summary_list.email")
+          - row.value text: current_jobseeker.email
+          - row.action(text: t("buttons.change"), href: edit_jobseeker_registration_path, visually_hidden_text: t(".summary_list.email"))
+
+        - summary_list.row do |row|
+          - row.key text: t(".summary_list.password")
+          - row.value text: t(".summary_list.password_placeholder")
+          - row.action(text: t("buttons.change"), href: edit_jobseeker_registration_path(password_update: true), visually_hidden_text: t(".summary_list.password"))
+
       p = govuk_link_to t(".close_account"), jobseekers_confirm_destroy_account_path
 
     .govuk-grid-column-one-third

--- a/app/views/pages/ab-tests.html.slim
+++ b/app/views/pages/ab-tests.html.slim
@@ -16,9 +16,9 @@
 
   p.govuk-body For more information on our A/B and multivariate tests email #{govuk_mail_to(t("help.email"), t("help.email"))}.
 
-  dl.govuk-summary-list
+  = govuk_summary_list do |summary_list|
     - current_ab_variants.each do |test, variant|
-      .govuk-summary-list__row
-        dt.govuk-summary-list__key = test
-        dd.govuk-summary-list__value
+      - summary_list.row do |row|
+        - row.key text: test
+        - row.value
           span.govuk-tag.govuk-tag--blue = variant

--- a/app/views/pages/job-application-preview.html.slim
+++ b/app/views/pages/job-application-preview.html.slim
@@ -69,39 +69,39 @@
 
       .govuk-section-break.govuk-section-break--visible
 
-      dl.govuk-summary-list
-        .govuk-summary-list__row
-          dt.govuk-summary-list__key GCSEs, AS levels, A levels
-          dd.govuk-summary-list__value.qualifications__value
+      = govuk_summary_list do |summary_list|
+        - summary_list.row do |row|
+          - row.key text: "GCSEs, AS levels, A levels"
+          - row.value
             ul.govuk-list.govuk-list--bullet
               li School, college or organisation
-              li Subjects and grades
+              li Subjects and grade"
               li Year the qualifications were awarded
 
-        .govuk-summary-list__row
-          dt.govuk-summary-list__key Other UK qualification
-          dd.govuk-summary-list__value.qualifications__value
+        - summary_list.row do |row|
+          - row.key text: "Other UK qualification"
+          - row.value
             ul.govuk-list.govuk-list--bullet
               li Type of qualification
               li School, college, or organisation
               li Subjects and grades
               li Year the qualifications were awarded
 
-        .govuk-summary-list__row
-          dt.govuk-summary-list__key Undergraduate and postgraduate degrees
-          dd.govuk-summary-list__value.qualifications__value
+        - summary_list.row do |row|
+          - row.key text: "Undergraduate and postgraduate degrees"
+          - row.value
             ul.govuk-list.govuk-list--bullet
               li Subject
               li Awarding body
               li
                 | Candidates are asked whether they have finished studying for
-                |  this qualification. If they have, they are asked for the grade and
-                |  year of the qualification. If they have not, they are asked to give
-                |  further details.
+                |    this qualification. If they have, they are asked for the grade and
+                |    year of the qualification. If they have not, they are asked to give
+                |   further details."
 
-        .govuk-summary-list__row
-          dt.govuk-summary-list__key Any other qualification
-          dd.govuk-summary-list__value.qualifications__value
+        - summary_list.row do |row|
+          - row.key text: "Any other qualification"
+          - row.value
             ul.govuk-list.govuk-list--bullet
               li Name of the qualification or course
               li Subject
@@ -109,8 +109,8 @@
               li
                 | Candidates are asked whether they have finished studying for
                 |  this qualification. If they have, they are asked for the grade and
-                |  year of the qualification. If they have not, they are asked to give
-                |  further details.
+                |   year of the qualification. If they have not, they are asked to give
+                |   further details.
 
       = govuk_link_to "Back to top", "#heading", class: "govuk-link govuk-body"
 

--- a/app/views/publishers/organisations/_vacancies_awaiting_feedback.html.slim
+++ b/app/views/publishers/organisations/_vacancies_awaiting_feedback.html.slim
@@ -1,10 +1,10 @@
 p.govuk-body#awaiting_feedback_intro class="govuk-!-margin-bottom-4" = t("jobs.manage.awaiting_feedback.intro")
 
-.govuk-summary-list
+.awaiting-feedback
   - vacancies.each do |vacancy|
     = form_for vacancy_statistics_form(vacancy), url: organisation_job_statistics_path(vacancy.id), html: { id: vacancy.id, method: "patch" } do |f|
       = f.govuk_error_summary(t("errors.publishers.job_statistics.error_summary", job_title: vacancy.job_title))
-      .govuk-summary-list__row.awaiting-feedback id=dom_id(vacancy)
+      .awaiting-feedback__row id=dom_id(vacancy)
         .govuk-grid-row
           .govuk-grid-column-one-third
             = govuk_link_to(vacancy.job_title, organisation_job_path(vacancy.id), class: "govuk-!-font-weight-bold govuk-!-font-size-24")

--- a/app/views/publishers/vacancies/_vacancy_review_sections.html.slim
+++ b/app/views/publishers/vacancies/_vacancy_review_sections.html.slim
@@ -4,13 +4,12 @@
     - s.row :show_additional_job_roles, label: t("jobs.additional_job_roles"), optional: true
 
 - unless current_organisation.school?
-  - r.section :job_location, forms: %w[JobLocationForm SchoolsForm]
-    dl.govuk-summary-list
-      .govuk-summary-list__row
-        dt.govuk-summary-list__key
+  - r.section :job_location, forms: %w[JobLocationForm SchoolsForm] do
+    = govuk_summary_list do |summary_list|
+      - summary_list.row do |row|
+        - row.key
           h4.govuk-heading-s = vacancy_job_location_heading(vacancy)
-
-        dd.govuk-summary-list__value
+        - row.value
           ul.govuk-list
             - vacancy.organisations.each do |organisation|
               li class="govuk-!-font-weight-bold govuk-!-margin-bottom-4"
@@ -61,17 +60,15 @@
   - s.row :school_visits, label: t("jobs.#{school_or_trust_visits(vacancy.parent_organisation)}"), optional: true
 
 - r.section :documents
-  dl.govuk-summary-list
+  = govuk_summary_list do |summary_list|
     - if vacancy.supporting_documents.none?
-      .govuk-summary-list__row
-        dt.govuk-summary-list__key class="govuk-!-font-weight-regular"
-          = t("jobs.no_supporting_documents")
+      - summary_list.row do |row|
+        - row.key classes: ["govuk-!-font-weight-regular"], text: t("jobs.no_supporting_documents")
     - else
       - vacancy.supporting_documents.each_with_index do |document, index|
-        .govuk-summary-list__row
-          dt.govuk-summary-list__key class=(index.zero? && "first-question")
-            h4.govuk-heading-s = "Document #{index + 1}"
-          dd.govuk-summary-list__value class=(index.zero? && "first-question") = document.filename
+        - summary_list.row do |row|
+          - row.key text: "Document #{index + 1}"
+          - row.value text: document.filename
 
 - r.section :job_summary do |s|
   - s.row :job_advert

--- a/app/views/publishers/vacancies/statistics/show.html.slim
+++ b/app/views/publishers/vacancies/statistics/show.html.slim
@@ -20,41 +20,39 @@
       = govuk_button_link_to t("buttons.download_stats"), organisation_job_statistics_path(vacancy.id, format: :csv), class: "govuk-button--secondary"
 
     .govuk-grid-column-two-thirds
-      h3.govuk-heading-m = t(".listing_data")
+      h3.govuk-heading-m.govuk-heading--summary-list
+        = t(".listing_data")
 
-      = render DetailComponent.new do |detail|
-        - detail.body do
-          = govuk_summary_list classes: "govuk-!-margin-bottom-0", html_attributes: { id: "vacancy_statistics" } do |summary_list|
-            - summary_list.row do |row|
-              - row.key text: t(".views_by_jobseeker")
-              - row.value text: @number_of_unique_views
+      = govuk_summary_list html_attributes: { id: "vacancy_statistics" } do |summary_list|
+        - summary_list.row do |row|
+          - row.key text: t(".views_by_jobseeker")
+          - row.value text: @number_of_unique_views
 
-            - summary_list.row do |row|
-              - row.key text: t(".saves_by_jobseeker")
-              - row.value text: vacancy.saved_jobs.count
+        - summary_list.row do |row|
+          - row.key text: t(".saves_by_jobseeker")
+          - row.value text: vacancy.saved_jobs.count
 
       - if vacancy.can_receive_job_applications?
-        h3.govuk-heading-m = t(".application_data")
+        h3.govuk-heading-m.govuk-heading--summary-list
+          = t(".application_data")
 
-        = render DetailComponent.new do |detail|
-          - detail.body do
-            = govuk_summary_list classes: "govuk-!-margin-bottom-0", html_attributes: { id: "job_applications_statistics" } do |summary_list|
-              - summary_list.row do |row|
-                - row.key text: t(".total_applications")
-                - row.value text: vacancy.job_applications.not_draft.count
+        = govuk_summary_list html_attributes: { id: "job_applications_statistics" } do |summary_list|
+          - summary_list.row do |row|
+            - row.key text: t(".total_applications")
+            - row.value text: vacancy.job_applications.not_draft.count
 
-              - summary_list.row do |row|
-                - row.key text: t(".unread_applications")
-                - row.value text: vacancy.job_applications.submitted.count
+          - summary_list.row do |row|
+            - row.key text: t(".unread_applications")
+            - row.value text: vacancy.job_applications.submitted.count
 
-              - summary_list.row do |row|
-                - row.key text: t(".shortlisted_applications")
-                - row.value text: vacancy.job_applications.shortlisted.count
+          - summary_list.row do |row|
+            - row.key text: t(".shortlisted_applications")
+            - row.value text: vacancy.job_applications.shortlisted.count
 
-              - summary_list.row do |row|
-                - row.key text: t(".rejected_applications")
-                - row.value text: vacancy.job_applications.unsuccessful.count
+          - summary_list.row do |row|
+            - row.key text: t(".rejected_applications")
+            - row.value text: vacancy.job_applications.unsuccessful.count
 
-              - summary_list.row do |row|
-                - row.key text: t(".withdrawn_applications")
-                - row.value text: vacancy.job_applications.withdrawn.count
+          - summary_list.row do |row|
+            - row.key text: t(".withdrawn_applications")
+            - row.value text: vacancy.job_applications.withdrawn.count

--- a/spec/system/publishers_can_add_stats_to_a_vacancy_spec.rb
+++ b/spec/system/publishers_can_add_stats_to_a_vacancy_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Submitting effectiveness statistics on expired vacancies" do
       before do
         visit jobs_with_type_organisation_path(type: :awaiting_feedback)
 
-        within(".awaiting-feedback", text: vacancy.job_title) do
+        within(".awaiting-feedback__row", text: vacancy.job_title) do
           click_on I18n.t("buttons.submit")
         end
       end
@@ -88,7 +88,7 @@ RSpec.describe "Submitting effectiveness statistics on expired vacancies" do
   end
 
   def submit_feedback_for(vacancy)
-    within(".awaiting-feedback", text: vacancy.job_title) do
+    within(".awaiting-feedback__row", text: vacancy.job_title) do
       select I18n.t("jobs.feedback.hired_status.hired_tvs"), from: "publishers_vacancy_statistics_form[hired_status]"
       select I18n.t("jobs.feedback.listed_elsewhere.listed_paid"), from: "publishers_vacancy_statistics_form[listed_elsewhere]"
       click_on I18n.t("buttons.submit")


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3680

## Changes in this PR

- Aligned styling of summary lists shown here: https://www.figma.com/file/exXOSAK84DIAqahszhoJ0n/Sprint-97?node-id=580%3A5082
- We now use the govuk-summary-list component . 

## Screenshots of UI changes:

### Job details

![Screenshot 2022-01-24 at 17 52 47](https://user-images.githubusercontent.com/30624173/150837301-479c9d6e-1068-49f7-a2b5-e18253487f20.png)

### School overview

![Screenshot 2022-01-24 at 17 52 59](https://user-images.githubusercontent.com/30624173/150837332-898c017c-9e21-49de-933e-21b5cc3fd58b.png)

### Statistics page

![Screenshot 2022-01-24 at 17 53 30](https://user-images.githubusercontent.com/30624173/150837415-0f513a86-7d02-44a4-b72c-a537c63a0a14.png)

### About school

![Screenshot 2022-01-24 at 17 53 52](https://user-images.githubusercontent.com/30624173/150837459-4d7cf73f-790f-4631-a79c-8d8d45b43638.png)

 ### Jobseeker account details

<img width="1306" alt="Screenshot 2022-01-25 at 09 39 58" src="https://user-images.githubusercontent.com/30624173/151026499-0880c773-fa68-40b6-b9c1-e71abffe0927.png">