### PR TITLE
TEVA-3432 Always show "optional" section tag for wholly optional sections

### DIFF
--- a/app/form_models/base_form.rb
+++ b/app/form_models/base_form.rb
@@ -8,6 +8,10 @@ class BaseForm
     model_name.element.split("_")[0..-2].join("_").to_s
   end
 
+  def self.optional?
+    new.valid?
+  end
+
   def send_errors_to_big_query
     EventContext.trigger_event(:form_validation_failed, event_data) if errors.any?
   end

--- a/app/form_models/publishers/job_listing/applying_for_the_job_form.rb
+++ b/app/form_models/publishers/job_listing/applying_for_the_job_form.rb
@@ -20,6 +20,6 @@ class Publishers::JobListing::ApplyingForTheJobForm < Publishers::JobListing::Va
     # but then changes the job role to one that does, enable_job_applications is nil, meaning the validation
     # for this field does not pass. We want the validations for the enable_job_applications field to pass
     # to prevent an error from being displayed on the review page in this situation when validate_all_steps is run.
-    self.enable_job_applications = false if (params[:current_organisation].local_authority? || vacancy.listed?) && enable_job_applications.blank?
+    self.enable_job_applications = false if (params[:current_organisation]&.local_authority? || vacancy&.listed?) && enable_job_applications.blank?
   end
 end

--- a/app/form_models/publishers/job_listing/important_dates_form.rb
+++ b/app/form_models/publishers/job_listing/important_dates_form.rb
@@ -20,6 +20,10 @@ class Publishers::JobListing::ImportantDatesForm < Publishers::JobListing::Vacan
     %i[starts_asap starts_on publish_on expires_at]
   end
 
+  def self.optional?
+    new({}, Vacancy.new).valid?
+  end
+
   def initialize(params, vacancy)
     @expiry_time = params[:expiry_time] || vacancy.expires_at&.strftime("%k:%M")&.strip
 

--- a/app/form_models/publishers/job_listing/job_summary_form.rb
+++ b/app/form_models/publishers/job_listing/job_summary_form.rb
@@ -10,7 +10,7 @@ class Publishers::JobListing::JobSummaryForm < Publishers::JobListing::VacancyFo
   def about_school_must_not_be_blank
     return if about_school.present?
 
-    case vacancy.job_location
+    case vacancy&.job_location
     when "central_office"
       organisation = "trust"
     when "at_one_school"

--- a/app/helpers/status_tag_helper.rb
+++ b/app/helpers/status_tag_helper.rb
@@ -2,11 +2,15 @@ module StatusTagHelper
   def review_section_tag(resource, steps, form_classes)
     return if (resource.is_a?(Vacancy) || resource.is_a?(VacancyPresenter)) && resource.published?
 
-    return govuk_tag(text: t("shared.status_tags.not_started"), colour: "grey") if steps.none? { |step| vacancy_step_completed?(resource, step) }
-
-    return govuk_tag(text: t("shared.status_tags.action_required"), colour: "red") if step_forms_contain_errors?(resource, form_classes)
-
-    govuk_tag text: t("shared.status_tags.complete")
+    if form_classes.all?(&:optional?)
+      optional
+    elsif steps.none? { |step| vacancy_step_completed?(resource, step) }
+      not_started
+    elsif step_forms_contain_errors?(resource, form_classes)
+      action_required
+    else
+      complete
+    end
   end
 
   private
@@ -15,5 +19,21 @@ module StatusTagHelper
     form_classes.any? do |form_class|
       form_class.fields.any? { |field| resource.errors.include?(field) }
     end
+  end
+
+  def optional
+    govuk_tag(text: t("shared.status_tags.optional"), colour: "grey")
+  end
+
+  def not_started
+    govuk_tag(text: t("shared.status_tags.not_started"), colour: "grey")
+  end
+
+  def action_required
+    govuk_tag(text: t("shared.status_tags.action_required"), colour: "red")
+  end
+
+  def complete
+    govuk_tag(text: t("shared.status_tags.complete"))
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -275,7 +275,7 @@ en:
     terms-and-conditions:
       page_description:
         Read Teaching Vacancies' terms of use for jobseekers and schools. You must agree to these to use the service.
-    
+
   posts:
     show:
       contents: Contents
@@ -388,6 +388,7 @@ en:
       action_required: action required
       complete: complete
       not_started: not started
+      optional: optional
 
   shares:
     new:

--- a/spec/helpers/status_tag_helper_spec.rb
+++ b/spec/helpers/status_tag_helper_spec.rb
@@ -2,16 +2,16 @@ require "rails_helper"
 
 RSpec.describe StatusTagHelper do
   describe "#review_section_tag" do
-    context "when it is passed a job application" do
-      let(:job_application) { build_stubbed(:job_application, completed_steps: %w[personal_details professional_status]) }
-      let(:form_classes) { [Jobseekers::JobApplication::PersonalDetailsForm] }
+    subject { helper.review_section_tag(record, steps, form_classes) }
 
-      subject { helper.review_section_tag(job_application, steps, form_classes) }
+    context "when it is passed a job application" do
+      let(:record) { build_stubbed(:job_application, completed_steps: %w[personal_details professional_status]) }
+      let(:form_classes) { [Jobseekers::JobApplication::PersonalDetailsForm] }
 
       context "when there is an error on the step's form object" do
         let(:steps) { [:personal_details] }
 
-        before { job_application.errors.add(:city) }
+        before { record.errors.add(:city) }
 
         it "returns 'action required' tag" do
           expect(subject).to eq(helper.govuk_tag(text: I18n.t("shared.status_tags.action_required"), colour: "red"))
@@ -36,13 +36,11 @@ RSpec.describe StatusTagHelper do
     end
 
     context "when it is passed a vacancy" do
-      let(:vacancy) { build_stubbed(:vacancy, :draft, completed_steps: %w[job_role job_details]) }
+      let(:record) { build_stubbed(:vacancy, :draft, completed_steps: %w[job_role job_details]) }
       let(:form_classes) { [Publishers::JobListing::JobDetailsForm] }
 
-      subject { helper.review_section_tag(vacancy, steps, form_classes) }
-
       context "when is published" do
-        let(:vacancy) { build_stubbed(:vacancy) }
+        let(:record) { build_stubbed(:vacancy) }
         let(:steps) { [] }
 
         it "returns nil" do
@@ -53,7 +51,7 @@ RSpec.describe StatusTagHelper do
       context "when there is an error on the step's form object" do
         let(:steps) { %i[job_details] }
 
-        before { vacancy.errors.add(:job_title) }
+        before { record.errors.add(:job_title) }
 
         it "returns 'action required' tag" do
           expect(subject).to eq(helper.govuk_tag(text: I18n.t("shared.status_tags.action_required"), colour: "red"))
@@ -73,6 +71,28 @@ RSpec.describe StatusTagHelper do
 
         it "returns 'not started' tag" do
           expect(subject).to eq(helper.govuk_tag(text: I18n.t("shared.status_tags.not_started"), colour: "grey"))
+        end
+      end
+    end
+
+    context "when the whole section is optional" do
+      let(:record) { build_stubbed(:vacancy, :draft, completed_steps: completed_steps) }
+      let(:form_classes) { [Publishers::JobListing::DocumentsForm] }
+      let(:steps) { %w[documents] }
+
+      context "and it is not started" do
+        let(:completed_steps) { [] }
+
+        it "shows as 'optional'" do
+          expect(subject).to eq(helper.govuk_tag(text: I18n.t("shared.status_tags.optional"), colour: "grey"))
+        end
+      end
+
+      context "and it is completed" do
+        let(:completed_steps) { steps }
+
+        it "shows as 'optional'" do
+          expect(subject).to eq(helper.govuk_tag(text: I18n.t("shared.status_tags.optional"), colour: "grey"))
         end
       end
     end


### PR DESCRIPTION
## Jira ticket URL

First part of https://dfedigital.atlassian.net/browse/TEVA-3432

## Changes in this PR:

```
StatusTagHelper
  #review_section_tag
    when the whole section is optional
      and it is not started
        shows as 'optional'
      and it is completed
        shows as 'optional'

2 examples, 0 failures
```

## Screenshots of UI changes:

### Publisher

#### Before

<img width="830" alt="Screenshot 2022-01-25 at 10 52 15" src="https://user-images.githubusercontent.com/109225/150964288-dbfb907a-aada-4fff-bbe4-a6ee9ef53705.png">

#### After

<img width="827" alt="Screenshot 2022-01-25 at 10 51 55" src="https://user-images.githubusercontent.com/109225/150964380-56c58580-71cc-4a7f-9a6d-35d5deb9434e.png">

### Applicant

#### Before

<img width="886" alt="Screenshot 2022-01-25 at 10 47 14" src="https://user-images.githubusercontent.com/109225/150964488-85540a00-3412-40d7-b3f0-4a9282397caa.png">

#### After

<img width="893" alt="Screenshot 2022-01-25 at 10 47 30" src="https://user-images.githubusercontent.com/109225/150964477-3c5fe9b4-e0c7-4b10-a5b6-13cb3bce3bb8.png">

