### PR TITLE
Add missing link subject to trackedLink

### DIFF
--- a/app/frontend/src/components/trackedLink/trackedLink.js
+++ b/app/frontend/src/components/trackedLink/trackedLink.js
@@ -33,6 +33,7 @@ export default class extends Controller {
       EVENT_TYPE,
       {
         link_type: this.linkTarget.dataset.linkType,
+        link_subject: this.linkTarget.dataset.linkSubject,
         text: this.linkTarget.innerText,
         href: this.linkTarget.href,
         mouse_button: e.button,


### PR DESCRIPTION
This wasn't sent through in the triggered event because it was missing
in the payload.