### PR TITLE
[TEVA-3751] Add weakset and weakmap polyfills to support IE11

### DIFF
--- a/app/frontend/src/application.js
+++ b/app/frontend/src/application.js
@@ -1,3 +1,5 @@
+import 'core-js/modules/es.weak-map';
+import 'core-js/modules/es.weak-set';
 import '@stimulus/polyfills';
 import { Application } from '@hotwired/stimulus';
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "accessible-autocomplete": "^2.0.3",
     "axios": "^0.25.0",
     "classlist-polyfill": "^1.2.0",
+    "core-js": "^3.20.3",
     "govuk-frontend": "^4.0.0",
     "jquery": "^3.5.0",
     "jsdom": "^19.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2892,6 +2892,11 @@ core-js@^3.16.2, core-js@^3.4.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.20.2.tgz#46468d8601eafc8b266bd2dd6bf9dee622779581"
   integrity sha512-nuqhq11DcOAbFBV4zCbKeGbKQsUDRqTX0oqx7AttUBuqe3h20ixsE039QHelbL6P4h+9kytVqyEtyZ6gsiwEYw==
 
+core-js@^3.20.3:
+  version "3.20.3"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.20.3.tgz#c710d0a676e684522f3db4ee84e5e18a9d11d69a"
+  integrity sha512-vVl8j8ph6tRS3B8qir40H7yw7voy17xL0piAjlbBUsH7WIfzoedL/ZOr1OV9FyZQLWXsayOJyV4tnRyXR85/ag==
+
 core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3751

## Changes in this PR:

This PR implements the WeakMap and WeakSet polyfills required to support IE11