### PR TITLE
[TEVA-3772]migrate workflow to native concurrency

### DIFF
--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -11,6 +11,8 @@ on:
       - 'terraform/monitoring/**'
       - '**.md'
 
+concurrency: workflow-Build-and-deploy-${{ github.ref }}
+
 env:
   DOCKER_REPOSITORY: ghcr.io/dfe-digital/teaching-vacancies
 
@@ -51,16 +53,6 @@ jobs:
         ssm_parameter: /teaching-vacancies/github_action/infra/git_hub_service_account_token
         env_variable_name: GIT_HUB_SERVICE_ACCOUNT_TOKEN
 
-
-    - name: Wait for this review app 'Deploy app' job to finish
-      id: wait_for_deployment
-      uses: fountainhead/action-wait-for-check@v1.0.0
-      with:
-       token: ${{ env.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
-       checkName: Deploy app (review)                   # Matrix job name within deploy_app workflow
-       ref: ${{ github.event.pull_request.head.sha }}   # The deploy_app job is linked to the PR branch HEAD SHA
-       timeoutSeconds: 1800
-       intervalSeconds: 15
 
     - name: check review status
       run: |


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3772


Integrate native `concurrency` into workflow that could benefit from it.

  .github/workflows/delete_review_app.yml : Delete workflow will not run at the same time while the deployment is in flight.
  .github/workflows/refresh.yml: Secrete Refresh workflow will not run at the same time while the deployment workflow is running.
