### PR TITLE
[TEVA-3792] make map markers tabable/screen readable

### DIFF
--- a/app/components/jobseekers/organisation_overviews/base_component.rb
+++ b/app/components/jobseekers/organisation_overviews/base_component.rb
@@ -10,4 +10,11 @@ class Jobseekers::OrganisationOverviews::BaseComponent < ViewComponent::Base
     @vacancy = vacancy
     @organisation = vacancy.parent_organisation
   end
+
+  def map_links
+    @map_links ||=
+      vacancy.organisations.map do |organisation|
+        { text: "#{organisation.name}, #{full_address(organisation)}", url: organisation_url(organisation), id: organisation.id }
+      end
+  end
 end

--- a/app/components/jobseekers/organisation_overviews/school_component/school_component.html.slim
+++ b/app/components/jobseekers/organisation_overviews/school_component/school_component.html.slim
@@ -50,7 +50,5 @@ section#school-overview
 
   section#school-location
     h3.govuk-heading-l.section-heading = t("schools.school_location.one")
-    = govuk_link_to full_address(organisation), "https://www.google.com/maps/search/#{full_address(organisation)}+UK", "aria-label": t("schools.map_link_aria_label")
 
-    - if organisation.geopoint
-      = map(items: [{ type: "vacancy", params: { id: vacancy.id } }].to_json)
+    = map(items: [{ type: "vacancy", params: { id: vacancy.id }, links: map_links }], show_map: organisation.geopoint)

--- a/app/components/jobseekers/organisation_overviews/school_group_component/school_group_component.html.slim
+++ b/app/components/jobseekers/organisation_overviews/school_group_component/school_group_component.html.slim
@@ -35,7 +35,5 @@ section#school-overview class="govuk-!-margin-bottom-5"
 
   section#school-location
     h3.govuk-heading-l.section-heading = t("school_groups.school_group_location")
-    = govuk_link_to full_address(organisation), "https://www.google.com/maps/search/#{full_address(organisation)}+UK", "aria-label": t("schools.map_link_aria_label")
 
-    - if organisation.geopoint
-      = map(items: [{ type: "vacancy", params: { id: vacancy.id } }].to_json)
+    = map(items: [{ type: "vacancy", params: { id: vacancy.id }, links: map_links }], show_map: organisation.geopoint)

--- a/app/components/jobseekers/organisation_overviews/schools_component/schools_component.html.slim
+++ b/app/components/jobseekers/organisation_overviews/schools_component/schools_component.html.slim
@@ -73,8 +73,5 @@ section#school-overview class="govuk-!-margin-bottom-5"
   - if vacancy.organisations.any?(&:geopoint)
     section#school-location
       h3.govuk-heading-l.section-heading = t("schools.school_location.other")
-      - vacancy.organisations.each do |organisation|
-        = govuk_link_to full_address(organisation), "https://www.google.com/maps/search/#{full_address(organisation)}+UK", "aria-label": t("schools.map_link_aria_label")
-        br
 
-      = map(items: [{ type: "vacancy", params: { id: vacancy.id } }].to_json, zoom: 10)
+      = map(items: [{ type: "vacancy", params: { id: vacancy.id }, links: map_links }], zoom: 10)

--- a/app/components/map_component.rb
+++ b/app/components/map_component.rb
@@ -1,11 +1,20 @@
-class MapComponent < ViewComponent::Base
-  def initialize(items:, render: true, zoom: 13)
+class MapComponent < GovukComponent::Base
+  def initialize(items: [], render: true, show_map: true, zoom: 13, classes: [], html_attributes: {})
+    super(classes: classes, html_attributes: html_attributes)
+
     @render = render
+    @show_map = show_map
     @items = items
     @zoom = zoom
   end
 
   def render?
     @render
+  end
+
+  private
+
+  def default_classes
+    %w[map-component]
   end
 end

--- a/app/components/map_component/map.js
+++ b/app/components/map_component/map.js
@@ -7,23 +7,37 @@ import './map.scss';
 import api from '../../frontend/src/lib/api';
 
 const MapController = class extends Controller {
+  static targets = ['markersTextList'];
+
   connect() {
     const config = JSON.parse(this.element.dataset.config);
 
     api.getMapData(config).then((items) => {
+      if (!items.length) return;
+
       if (!this.map) {
         const [mapCenter] = items.filter((mapItem) => mapItem.data.point);
         this.create(mapCenter.data.point, this.element.dataset.zoom);
       }
 
-      items.forEach((item) => {
-        this[item.type](item.data);
+      const bounds = [];
+
+      this.markersTextListTarget.innerHTML = '';
+
+      items.forEach((item, index) => {
+        this[item.type](item.data, items.length === 1, index + 1);
+        bounds.push(item.data.point);
       });
+
+      if (items.length > 1) {
+        this.markersTextListTarget.classList.add('govuk-list--number');
+        this.setMapBounds(bounds);
+      }
     });
   }
 
   create(point, zoom) {
-    this.map = L.map('map').setView(point, zoom);
+    this.map = L.map('map', { tap: false }).setView(point, zoom);
 
     L.tileLayer(
       'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
@@ -35,17 +49,45 @@ const MapController = class extends Controller {
     L.polygon(coordinates, { color: 'green' }).addTo(this.map);
   }
 
-  marker({ point, meta }) {
-    const icon = L.divIcon({ className: 'map-component__map__marker--default', iconSize: [20, 20] });
+  marker({ point, meta }, showPopup, index) {
+    const marker = L.marker(point, {
+      icon: MapController.markerIcon(showPopup ? '' : `<span aria-label="${meta.name}, ${meta.address}">${index}</span>`),
+      riseOnHover: true,
+    });
 
-    if (!meta) {
-      L.marker(point, { icon }).addTo(this.map);
+    marker.addTo(this.map).bindPopup(
+      MapController.popupHTML(meta),
+      { className: 'map-component__map__popup' },
+    );
+
+    // use keydown event as leaflet doesnt recognise focus
+    marker.on('keydown', MapController.openMarkerPopup);
+
+    if (!showPopup) {
+      this.markerItemHtml(`${meta.name}, ${meta.address}`);
     } else {
-      L.marker(point, { icon }).addTo(this.map).bindPopup(
-        MapController.popupHTML(meta),
-        { className: 'map-component__map__popup' },
-      ).openPopup();
+      marker.openPopup();
     }
+  }
+
+  static markerIcon(html) {
+    return L.divIcon({
+      className: 'map-component__map__marker--default',
+      iconSize: [20, 20],
+      html,
+    });
+  }
+
+  setMapBounds(bounds) {
+    this.map.fitBounds(bounds);
+  }
+
+  markerItemHtml(text) {
+    this.markersTextListTarget.insertAdjacentHTML('beforeend', `<li>${text}</li>`);
+  }
+
+  static openMarkerPopup(e) {
+    e.target.openPopup();
   }
 
   static popupHTML(data) {

--- a/app/components/map_component/map.scss
+++ b/app/components/map_component/map.scss
@@ -1,21 +1,32 @@
 @import 'base_component';
 
-.map-component {
-  margin-bottom: govuk-spacing(4);
+.js-enabled {
+  .map-component {
+    &__map {
+      border: 1px solid $govuk-border-colour;
+      height: 400px;
+      margin-bottom: govuk-spacing(4);
+      margin-top: govuk-spacing(4);
+      width: 100%;
 
-  &__map {
-    height: 400px;
-    width: 100%;
+      &__marker--default {
+        background-color: govuk-colour('red');
+        border: 1px solid $govuk-input-border-colour;
+        border-radius: 12px;
 
-    &__marker--default {
-      background-color: govuk-colour('red');
-      border: 1px solid $govuk-input-border-colour;
-      border-radius: 12px;
-    }
+        span {
+          color: govuk-colour('light-grey');
+          display: block;
+          font-weight: bold;
+          line-height: govuk-spacing(4);
+          text-align: center;
+        }
+      }
 
-    &__popup {
-      margin-bottom: 32px;
-      margin-left: 2px;
+      &__popup {
+        margin-bottom: 32px;
+        margin-left: 2px;
+      }
     }
   }
 }

--- a/app/components/map_component/map.test.js
+++ b/app/components/map_component/map.test.js
@@ -16,13 +16,16 @@ jest.mock('../../frontend/src/lib/api');
 let createSpy;
 let markerSpy;
 let polygonSpy;
+let mapBoundsSpy;
 
 describe('map', () => {
   beforeAll(() => {
     initialiseStimulus();
 
     document.body.innerHTML = `<div class="map-component" data-controller="map" data-config={} data-zoom="12">
-    <div class=".map-component__map" id="map" role="presentation" data-map-target="map"></div></div>`;
+    <ol data-map-target="markersTextList"></ol>
+    <div class="map-component__map" id="map" role="presentation"></div>
+    </div>`;
 
     MapController.prototype.create = jest.fn();
     createSpy = jest.spyOn(MapController.prototype, 'create');
@@ -32,18 +35,22 @@ describe('map', () => {
 
     MapController.prototype.marker = jest.fn();
     markerSpy = jest.spyOn(MapController.prototype, 'marker');
+
+    MapController.prototype.setMapBounds = jest.fn();
+    mapBoundsSpy = jest.spyOn(MapController.prototype, 'setMapBounds');
   });
 
   describe('when map is initialised with several items', () => {
     test('a map object is created once', () => {
       expect(createSpy).toHaveBeenCalledTimes(1);
       expect(createSpy).toHaveBeenCalledWith([51, 0.14], '12');
+      expect(mapBoundsSpy).toHaveBeenCalledTimes(1);
     });
 
     test('correct number of items are added to map', () => {
       expect(markerSpy).toHaveBeenCalledTimes(3);
       expect(polygonSpy).toHaveBeenCalledTimes(1);
-      expect(polygonSpy).toHaveBeenCalledWith({ coordinates: [], point: [51.5, 0.14] });
+      expect(polygonSpy).toHaveBeenCalledWith({ coordinates: [], point: [51.5, 0.14] }, false, 3);
     });
   });
 });

--- a/app/components/map_component/map_component.html.slim
+++ b/app/components/map_component/map_component.html.slim
@@ -1,2 +1,7 @@
-.map-component data-controller="map" data-config=@items data-zoom=@zoom
-  .map-component__map id="map" role="presentation" data-map-target="map"
+= tag.div(class: classes, **html_attributes.merge({ data: { controller: "map", config: @items.to_json, zoom: @zoom } })) do
+  ol.govuk-list data-map-target="markersTextList"
+    - @items.each do |item|
+      - item[:links]&.each do |link|
+        li = govuk_link_to link[:text], link[:url], aria: { label: t("schools.map_link_aria_label") }
+  - if @show_map
+    .map-component__map id="map" role="presentation"

--- a/app/frontend/src/styles/application/jobseekers/vacancy.scss
+++ b/app/frontend/src/styles/application/jobseekers/vacancy.scss
@@ -6,25 +6,6 @@
     overflow-wrap: break-word;
   }
 
-  #map {
-    height: 500px;
-    margin-top: govuk-spacing(6);
-    width: 100%;
-
-    p {
-      @include govuk-font(16);
-      margin-bottom: govuk-spacing(1);
-    }
-
-    p:first-of-type {
-      margin-top: 0;
-    }
-
-    p:nth-of-type(3) {
-      margin-bottom: 0;
-    }
-  }
-
   .vacancy__banner-links {
     .govuk-grid-column-one-third {
       @media only screen and (max-width: $big-screen) {

--- a/app/views/vacancies/index.html.slim
+++ b/app/views/vacancies/index.html.slim
@@ -18,7 +18,7 @@
       = form_for @form, as: "", url: jobs_path, method: :get, html: { id: "desktop-search-form", class: "filters-form", role: "search", aria: { label: "Search criteria" } } do |f|
         = render "desktop_search", f: f
 
-      = map(items: [{ type: "location", params: { location: params[:location], radius: params[:radius] } }].to_json, render: @display_map, zoom: 8)
+      = map(items: [{ type: "location", params: { location: params[:location], radius: params[:radius] } }], render: @display_map, zoom: 8)
 
       .search-results__header class="govuk-!-margin-bottom-3"
         .search-results__header-sorting

--- a/spec/components/jobseekers/organisation_overviews/school_component_spec.rb
+++ b/spec/components/jobseekers/organisation_overviews/school_component_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Jobseekers::OrganisationOverviews::SchoolComponent, type: :compon
 
   describe "#render?" do
     context "when vacancy is at a trust head office" do
-      let(:organisation) { create(:trust) }
-      let(:vacancy) { create(:vacancy, :central_office) }
+      let(:organisation) { create(:trust, name: "Cambridge Uni") }
+      let(:vacancy) { create(:vacancy, :central_office, organisations: [organisation]) }
 
       it "does not render the component" do
         expect(rendered_component).to be_blank

--- a/spec/components/jobseekers/organisation_overviews/school_group_component_spec.rb
+++ b/spec/components/jobseekers/organisation_overviews/school_group_component_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Jobseekers::OrganisationOverviews::SchoolGroupComponent, type: :component do
-  let(:organisation) { create(:trust) }
+  let(:organisation) { create(:trust, name: "Cambridge Uni") }
   let(:vacancy) { create(:vacancy, :central_office, organisations: [organisation]) }
   let(:vacancy_presenter) { VacancyPresenter.new(vacancy) }
 
@@ -11,8 +11,8 @@ RSpec.describe Jobseekers::OrganisationOverviews::SchoolGroupComponent, type: :c
 
   describe "#render?" do
     context "when vacancy is at a school without a trust" do
-      let(:organisation) { create(:school) }
-      let(:vacancy) { create(:vacancy) }
+      let(:organisation) { create(:school, name: "Cambridge Uni") }
+      let(:vacancy) { create(:vacancy, organisations: [organisation]) }
 
       it "does not render the component" do
         expect(rendered_component).to be_blank
@@ -20,7 +20,7 @@ RSpec.describe Jobseekers::OrganisationOverviews::SchoolGroupComponent, type: :c
     end
 
     context "when vacancy is at a single school in a trust" do
-      let(:vacancy) { create(:vacancy, :at_one_school) }
+      let(:vacancy) { create(:vacancy, :at_one_school, organisations: [organisation]) }
 
       it "does not render the component" do
         expect(rendered_component).to be_blank

--- a/spec/components/map_component_spec.rb
+++ b/spec/components/map_component_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe MapComponent, type: :component do
+  let(:items) { [{ links: [{ text: "link text 1", url: "/link-url-1", id: 1 }] }] }
+  let(:kwargs) { { items: items, show_map: true, zoom: 10 } }
+
+  subject! { render_inline(described_class.new(**kwargs)) }
+
+  it_behaves_like "a component that accepts custom classes"
+  it_behaves_like "a component that accepts custom HTML attributes"
+
+  context "renders map component" do
+    it "that has correct data attributes" do
+      component = page.find(".map-component")
+
+      config = component["data-config"]
+      expect(config).to eq(items.to_json)
+
+      zoom = component["data-zoom"]
+      expect(zoom).to eq("10")
+    end
+
+    it "displays a list of marker links" do
+      expect(page).to have_css("ol") do |markers|
+        expect(markers).to have_css("li") do |marker|
+          expect(marker).to have_css("a[href='/link-url-1']", text: "link text 1")
+        end
+      end
+    end
+
+    it "renders a map container" do
+      expect(page).to have_css(".map-component__map")
+    end
+  end
+end


### PR DESCRIPTION
This builds upon leaflet/open maps less JS heavy approach to make maps accessible

- markers are now fully interactive using keyboard navigation
- screen readers read marker data when tabbed through
- map centers (sets bounds) to optimum for markers in view
- non JS scenario displays list of locations that are links to organisation websites
- list of locations is now part of the map view component
- improved testing

I have run these changes past Kirill and he is happy

tested in **Chrome, Edge, Firefox, Safari, IE11, IPhone 8 {IOS 12), IPhone 13 (IOS 15), Android 8-11**

## non JS view
<img width="690" alt="Screenshot 2022-01-27 at 16 47 14" src="https://user-images.githubusercontent.com/1792451/151404826-903be107-f878-4179-b93f-ff059d2f0930.png">

## JS view
<img width="691" alt="Screenshot 2022-01-27 at 16 46 54" src="https://user-images.githubusercontent.com/1792451/151404804-6594f6aa-00ef-47e2-a074-71414ffaa31b.png">

