### PR TITLE
TEVA-3741 Ensure spans within summary list values break onto new lines

### DIFF
--- a/app/frontend/src/styles/application/jobseekers/vacancy.scss
+++ b/app/frontend/src/styles/application/jobseekers/vacancy.scss
@@ -55,4 +55,10 @@
       margin: 0;
     }
   }
+
+  .govuk-summary-list__value {
+    .govuk-hint {
+      display: block;
+    }
+  }
 }


### PR DESCRIPTION
This was seemingly introduced after an update to the govuk-components gem.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3741

## Screenshots of UI changes:

### Before

<img width="705" alt="Screenshot 2022-01-27 at 12 27 06" src="https://user-images.githubusercontent.com/109225/151359249-3b0373c6-459e-46e2-8d85-15bb93178880.png">

### After

<img width="735" alt="Screenshot 2022-01-27 at 12 26 48" src="https://user-images.githubusercontent.com/109225/151359188-fc318ef1-194c-43db-addc-61ad42db989a.png">
