### PR TITLE
[TEVA-3448] Add job alert mailer subject line AB test

### DIFF
--- a/app/mailers/jobseekers/alert_mailer.rb
+++ b/app/mailers/jobseekers/alert_mailer.rb
@@ -14,8 +14,20 @@ class Jobseekers::AlertMailer < Jobseekers::BaseMailer
     @to = subscription.email
 
     @vacancies = VacanciesPresenter.new(Vacancy.where(id: vacancy_ids).order(:expires_at))
+    view_mail(@template,
+              to: @to,
+              subject: I18n.t("jobseekers.alert_mailer.alert.subject.#{ab_tests[:"2022_01_alert_mailer_subject_lines_ab_test"]}",
+                              count: @vacancies.count,
+                              count_minus_one: @vacancies.count - 1,
+                              job_title: @vacancies.first.job_title,
+                              keywords: @subscription.search_criteria["keyword"].titleize,
+                              school_name: @vacancies.first.parent_organisation_name))
+  end
 
-    view_mail(@template, to: @to, subject: I18n.t("jobseekers.alert_mailer.alert.subject"))
+  def ab_tests
+    @alert_mailer_subject_lines_ab_test ||= %w[present_subject_line subject_line_variant_1 subject_line_variant_2 subject_line_variant_3 subject_line_variant_4 subject_line_variant_5].sample
+
+    { :"2022_01_alert_mailer_subject_lines_ab_test" => @alert_mailer_subject_lines_ab_test }
   end
 
   private

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -73,7 +73,21 @@ en:
           relevant_link_text: Yes, they are relevant
           reason: This feedback helps us improve our service.
         salary: "Salary: %{salary}"
-        subject: Your job alert from Teaching Vacancies
+        subject:
+          present_subject_line: Your job alert from Teaching Vacancies
+          subject_line_variant_1:
+            one: "%{job_title} at %{school_name}"
+            other: "%{job_title} at %{school_name} and %{count_minus_one} other new job(s)"
+          subject_line_variant_2:
+            one: "%{school_name} is hiring for a %{job_title}"
+            other: "%{school_name} is hiring for a %{job_title} - and %{count_minus_one} other new job(s)"
+          subject_line_variant_3: Your job alert for %{keywords}
+          subject_line_variant_4:
+            one: "%{count} new job matches your criteria"
+            other: "%{count} new jobs match your criteria"
+          subject_line_variant_5:
+            one: "Your job alert: %{count} new job matches your criteria"
+            other: "Your job alert: %{count} new jobs match your criteria"
         summary:
           daily:
             one: A new job matching your search criteria was listed in the last day

--- a/spec/mailers/jobseekers/alert_mailer_spec.rb
+++ b/spec/mailers/jobseekers/alert_mailer_spec.rb
@@ -53,6 +53,8 @@ RSpec.describe Jobseekers::AlertMailer do
   end
 
   before do
+    # Ensure present variant of ab test is used
+    allow_any_instance_of(described_class).to receive(:ab_tests).and_return({ :"2022_01_alert_mailer_subject_lines_ab_test" => "present_subject_line" })
     # Stub the uid so that we can test links more easily
     allow_any_instance_of(ApplicationMailer).to receive(:uid).and_return("a_unique_identifier")
     subscription.create_alert_run
@@ -63,7 +65,7 @@ RSpec.describe Jobseekers::AlertMailer do
     let(:frequency) { "daily" }
 
     it "sends a job alert email" do
-      expect(mail.subject).to eq(I18n.t("jobseekers.alert_mailer.alert.subject"))
+      expect(mail.subject).to eq(I18n.t("jobseekers.alert_mailer.alert.subject.present_subject_line"))
       expect(mail.to).to eq([subscription.email])
       expect(body).to include(I18n.t("jobseekers.alert_mailer.alert.summary.daily", count: 1))
                   .and include(vacancies.first.job_title)
@@ -111,7 +113,7 @@ RSpec.describe Jobseekers::AlertMailer do
     let(:frequency) { "weekly" }
 
     it "sends a job alert email" do
-      expect(mail.subject).to eq(I18n.t("jobseekers.alert_mailer.alert.subject"))
+      expect(mail.subject).to eq(I18n.t("jobseekers.alert_mailer.alert.subject.present_subject_line"))
       expect(mail.to).to eq([subscription.email])
       expect(body).to include(I18n.t("jobseekers.alert_mailer.alert.summary.weekly", count: 1))
                   .and include(vacancies.first.job_title)


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3448

## Changes in this PR:

This PR implements an AB test for the subject lines in Job alert emails. 5 test variants (plus the present variant) are implemented.
