### PR TITLE
Fix visual bug job application show page

### DIFF
--- a/app/views/jobseekers/job_applications/show.html.slim
+++ b/app/views/jobseekers/job_applications/show.html.slim
@@ -14,7 +14,7 @@
         h3.govuk-heading-m = t(".feedback")
         p.govuk-body class="govuk-!-margin-bottom-0" = job_application.rejection_reasons
 
-    = render "shared/job_application/show"
+  = render "shared/job_application/show"
 
   .govuk-grid-column-one-third class="govuk-!-display-none-print"
     h2.govuk-heading-m = t(".timeline")


### PR DESCRIPTION
## Jira ticket URL

Noticed this whilst working on https://dfedigital.atlassian.net/browse/TEVA-3680

## Before:

- As you can see below, the review sections are not wide enough. This is because the review component (`app/components/review_component/review_component.html.slim`) renders the sections inside of a div with the class `govuk-grid-column-two-thirds`. The partial that renders the review component also sits within a div with the `govuk-grid-column-two-thirds` (see `app/views/jobseekers/job_applications/show.html.slim.`).

<img width="817" alt="Screenshot 2022-01-27 at 17 38 38" src="https://user-images.githubusercontent.com/30624173/151413523-605a8fc3-8678-4f63-b68d-b10e20f7d989.png">

## After

![Screenshot 2022-01-27 at 17 48 32](https://user-images.githubusercontent.com/30624173/151415003-26017d97-1036-455b-b722-86605ae3cad3.png)

## Comments

I'm not too sure if this solution is the best way to go about this. What are your thoughts?