### PR TITLE
[TEVA-3789]-fix gmp vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM ruby:3.1.0-alpine3.15 AS builder
 WORKDIR /app
 
 ARG PROD_PACKAGES
-ENV DEV_PACKAGES="gcc=10.3.1_git20211027-r0 libc-dev=0.7.2-r3 make=4.3-r0 yarn=1.22.17-r0 postgresql13-dev=13.5-r1 build-base=0.5-r2 git"
+ENV DEV_PACKAGES="gcc=10.3.1_git20211027-r0 libc-dev=0.7.2-r3 make=4.3-r0 yarn=1.22.17-r0 postgresql13-dev=13.5-r1 gmp=6.2.1-r1 build-base=0.5-r2 git"
 RUN apk add --no-cache $PROD_PACKAGES $DEV_PACKAGES
 RUN echo "Europe/London" > /etc/timezone && \
         cp /usr/share/zoneinfo/Europe/London /etc/localtime


### PR DESCRIPTION
## Jira ticket URL

- Just add the ticket number to the end:

https://dfedigital.atlassian.net/browse/TEVA-3789

Update gmp version in docker file

High severity vulnerability found in gmp/gmp
  Description: Integer Overflow or Wraparound
  Info: https://snyk.io/vuln/SNYK-ALPINE315-GMP-2386788
  Introduced through: gmp/gmp@6.2.1-r0, .ruby-rundeps@20211227.203644, gmp/libgmpxx@6.2.1-r0, gmp/gmp-dev@6.2.1-r0
  From: gmp/gmp@6.2.1-r0
  From: .ruby-rundeps@20211227.203644 > gmp/gmp@6.2.1-r0
  From: gmp/libgmpxx@6.2.1-r0 > gmp/gmp@6.2.1-r0
  and 4 more...
  Fixed in: 6.2.1-r1