### PR TITLE
[TEVA-3778] vacancy page header links overlap bug

### DIFF
--- a/app/frontend/src/styles/application/jobseekers/vacancy.scss
+++ b/app/frontend/src/styles/application/jobseekers/vacancy.scss
@@ -25,6 +25,14 @@
     }
   }
 
+  .vacancy__banner-links {
+    .govuk-grid-column-one-third {
+      @media only screen and (max-width: $big-screen) {
+        width: 100%;
+      }
+    }
+  }
+
   .section-heading {
     border-bottom: 6px solid $govuk-border-colour;
     padding-bottom: govuk-spacing(2);

--- a/app/views/shared/vacancy/_jobseeker_view.html.slim
+++ b/app/views/shared/vacancy/_jobseeker_view.html.slim
@@ -1,57 +1,57 @@
 = render BannerComponent.new do
-    - if !referred_from_jobs_path? && @vacancy.main_job_role == "teaching_assistant"
-      = govuk_breadcrumbs breadcrumbs: { "#{t("breadcrumbs.home")}": root_path,
-                                         "#{t("breadcrumbs.teaching_assistant")}": job_role_path("teaching_assistant".dasherize),
-                                         "#{@vacancy.job_title}": "" }
-    - else
-      = govuk_breadcrumbs breadcrumbs: { "#{t("breadcrumbs.home")}": root_path,
-                                         "#{t("breadcrumbs.jobs")}": referred_from_jobs_path? ? request.referrer : jobs_path,
-                                         "#{@vacancy.job_title}": "" }
+  - if !referred_from_jobs_path? && @vacancy.main_job_role == "teaching_assistant"
+    = govuk_breadcrumbs breadcrumbs: { "#{t("breadcrumbs.home")}": root_path,
+                                        "#{t("breadcrumbs.teaching_assistant")}": job_role_path("teaching_assistant".dasherize),
+                                        "#{@vacancy.job_title}": "" }
+  - else
+    = govuk_breadcrumbs breadcrumbs: { "#{t("breadcrumbs.home")}": root_path,
+                                        "#{t("breadcrumbs.jobs")}": referred_from_jobs_path? ? request.referrer : jobs_path,
+                                        "#{@vacancy.job_title}": "" }
 
-    - if @vacancy.expired?
-      = govuk_tag text: t("jobs.expired_tag").upcase,
-                  colour: "orange",
-                  classes: "govuk-!-margin-bottom-2 govuk-!-margin-top-4"
+  - if @vacancy.expired?
+    = govuk_tag text: t("jobs.expired_tag").upcase,
+                colour: "orange",
+                classes: "govuk-!-margin-bottom-2 govuk-!-margin-top-4"
 
-    h1.govuk-heading-xl class="govuk-!-margin-bottom-2"
-      = @vacancy.job_title
-    h2.govuk-caption-l.job-caption class="govuk-!-margin-bottom-5 govuk-!-margin-top-0"
-      = vacancy_full_job_location(@vacancy)
+  h1.govuk-heading-xl class="govuk-!-margin-bottom-2"
+    = @vacancy.job_title
+  h2.govuk-caption-l.job-caption class="govuk-!-margin-bottom-5 govuk-!-margin-top-0"
+    = vacancy_full_job_location(@vacancy)
 
-    .govuk-grid-row
-      - if @vacancy.enable_job_applications? && @vacancy.expires_at.future?
-        .govuk-grid-column-one-third
-          - if defined?(job_application) && job_application.present?
-            - if job_application.draft?
-              = render BannerButtonComponent.new text: t("jobseekers.job_applications.banner_links.draft"),
-                href: jobseekers_job_application_review_path(job_application),
-                icon: "green-tick"
-            - elsif job_application.withdrawn?
-              = render BannerButtonComponent.new text: t("jobseekers.job_applications.banner_links.withdrawn"),
-                href: jobseekers_job_application_path(job_application),
-                icon: "green-tick"
-            - else
-              = render BannerButtonComponent.new text: t("jobseekers.job_applications.banner_links.submitted"),
-                href: jobseekers_job_application_path(job_application),
-                icon: "green-tick"
-          - else
-            = render BannerButtonComponent.new text: t("jobseekers.job_applications.banner_links.apply"),
-              href: new_jobseekers_job_job_application_path(@vacancy.id),
-              icon: "apply"
-
+  .govuk-grid-row.vacancy__banner-links
+    - if @vacancy.enable_job_applications? && @vacancy.expires_at.future?
       .govuk-grid-column-one-third
-        = render BannerButtonComponent.new text: t("jobs.alert.similar.terse"),
-          href: new_subscription_path,
-          icon: "alert-blue",
-          params: { search_criteria: @invented_job_alert_search_criteria, vacancy_id: @vacancy.id }
+        - if defined?(job_application) && job_application.present?
+          - if job_application.draft?
+            = render BannerButtonComponent.new text: t("jobseekers.job_applications.banner_links.draft"),
+              href: jobseekers_job_application_review_path(job_application),
+              icon: "green-tick"
+          - elsif job_application.withdrawn?
+            = render BannerButtonComponent.new text: t("jobseekers.job_applications.banner_links.withdrawn"),
+              href: jobseekers_job_application_path(job_application),
+              icon: "green-tick"
+          - else
+            = render BannerButtonComponent.new text: t("jobseekers.job_applications.banner_links.submitted"),
+              href: jobseekers_job_application_path(job_application),
+              icon: "green-tick"
+        - else
+          = render BannerButtonComponent.new text: t("jobseekers.job_applications.banner_links.apply"),
+            href: new_jobseekers_job_job_application_path(@vacancy.id),
+            icon: "apply"
 
-      - unless defined?(job_application) && job_application.present?
-        .govuk-grid-column-one-third
-          = render BannerButtonComponent.new text: t("jobseekers.saved_jobs.#{@saved_job.present? ? 'saved' : 'save'}"),
-            href: @saved_job.present? ? jobseekers_saved_job_path(@vacancy.id, @saved_job) : new_jobseekers_saved_job_path(@vacancy.id),
-            icon: @saved_job.present? ? "saved" : "save",
-            method: @saved_job.present? ? :delete : :get,
-            params: { click_event: "vacancy_save_to_account_clicked", click_event_data: { vacancy_id: StringAnonymiser.new(@vacancy.id) } }
+    .govuk-grid-column-one-third
+      = render BannerButtonComponent.new text: t("jobs.alert.similar.terse"),
+        href: new_subscription_path,
+        icon: "alert-blue",
+        params: { search_criteria: @invented_job_alert_search_criteria, vacancy_id: @vacancy.id }
+
+    - unless defined?(job_application) && job_application.present?
+      .govuk-grid-column-one-third
+        = render BannerButtonComponent.new text: t("jobseekers.saved_jobs.#{@saved_job.present? ? 'saved' : 'save'}"),
+          href: @saved_job.present? ? jobseekers_saved_job_path(@vacancy.id, @saved_job) : new_jobseekers_saved_job_path(@vacancy.id),
+          icon: @saved_job.present? ? "saved" : "save",
+          method: @saved_job.present? ? :delete : :get,
+          params: { click_event: "vacancy_save_to_account_clicked", click_event_data: { vacancy_id: StringAnonymiser.new(@vacancy.id) } }
 
 .govuk-grid-row
 


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-3778

### Before
![Screenshot 2022-01-31 at 07 05 15](https://user-images.githubusercontent.com/1792451/151752020-aec91fa1-5b77-4d30-a652-3c80d451d455.png)

problem is the text `Get a job alert for similar jobs` is too wide for container and at a point over laps the link to the right. making the test wrap to another line would not look right with the other links on one line


### After
![Screenshot 2022-01-31 at 07 08 42](https://user-images.githubusercontent.com/1792451/151752373-424c9319-e577-433e-a75b-076dd37d0e28.png)

the solution in this PR is to make the links snap to pull width sooner (1024px)

