### PR TITLE
fix-gmp-vulnerability-docker-image2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PROD_PACKAGES="libxml2=2.9.12-r2 libxslt=1.1.34-r1 libpq=14.1-r5 tzdata=2021e-r0 shared-mime-info=2.1-r0"
+ARG PROD_PACKAGES="libxml2=2.9.12-r2 libxslt=1.1.34-r1 libpq=14.1-r5 tzdata=2021e-r0 shared-mime-info=2.1-r0 gmp=6.2.1-r1"
 
 FROM ruby:3.1.0-alpine3.15 AS builder
 


### PR DESCRIPTION
## Jira ticket URL

- Just add the ticket number to the end:

https://dfedigital.atlassian.net/browse/TEVA-3789

Update gmp version in docker file

High severity vulnerability found in gmp/gmp
Description: Integer Overflow or Wraparound
Info: https://snyk.io/vuln/SNYK-ALPINE315-GMP-2386788
Introduced through: gmp/gmp@6.2.1-r0, .ruby-rundeps@20211227.203644, gmp/libgmpxx@6.2.1-r0, gmp/gmp-dev@6.2.1-r0
From: gmp/gmp@6.2.1-r0
From: .ruby-rundeps@20211227.203644 > gmp/gmp@6.2.1-r0
From: gmp/libgmpxx@6.2.1-r0 > gmp/gmp@6.2.1-r0
and 4 more...
Fixed in: 6.2.1-r1