### PR TITLE
Enable AB test subject line variant 3

### DIFF
--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -74,6 +74,7 @@ en:
           reason: This feedback helps us improve our service.
         salary: "Salary: %{salary}"
         subject:
+          no_keywords: the latest roles
           present_subject_line: Your job alert from Teaching Vacancies
           subject_line_variant_1:
             one: "%{job_title} at %{school_name}"


### PR DESCRIPTION
## Changes in this PR:

This PR enables subject line variant 3 for the alert mailer subject lines ab test which we had disabled due to the bug occurring when calling `titleize` when `@subscription.search_criteria["keyword"]` was nil. This is resolved.

There is also now an alternative version of that subject line variant for when there are no search criteria keywords.

