### PR TITLE
[TEVA-3803]Fix GH Actions double run on PR on create and label

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -16,7 +16,6 @@ on:
     - main
     types:
       - labeled
-      - opened
       - synchronize
       - reopened
 


### PR DESCRIPTION
## Jira ticket URL

- Just add the ticket number to the end:

https://dfedigital.atlassian.net/browse/TEVA-3803

## Changes in this PR:

we have two event types at play here `opened` and `label` So, by opening a PR (`opened` event),
there is a “calibration phase”, the workflow tries to run, but the run (`job`) is negated (skipped)
by it not having the `label` applied.

This “calibration phase” i.e. opening a PR and the workflow trying to run and then detecting a constraint
it has not fulfilled, if a `label==deploy` is then applied in this period (within few seconds) –
this causes the workflow to potential run twice;  one for each event - `opened`  and `label==deploy`.