### PR TITLE
Remove `initially_indexed` field from Vacancy

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -301,7 +301,6 @@ shared:
     - subjects
     - school_visits
     - how_to_apply
-    - initially_indexed
     - job_location
     - readable_job_location
     - job_roles

--- a/db/migrate/20220201101037_remove_initially_indexed_from_vacancies.rb
+++ b/db/migrate/20220201101037_remove_initially_indexed_from_vacancies.rb
@@ -1,0 +1,6 @@
+class RemoveInitiallyIndexedFromVacancies < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :vacancies, :initially_indexed
+    remove_column :vacancies, :initially_indexed, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_17_134852) do
+ActiveRecord::Schema.define(version: 2022_02_01_101037) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -446,7 +446,6 @@ ActiveRecord::Schema.define(version: 2022_01_17_134852) do
     t.string "subjects", array: true
     t.text "school_visits"
     t.text "how_to_apply"
-    t.boolean "initially_indexed", default: false
     t.integer "job_location"
     t.string "readable_job_location"
     t.integer "job_roles", array: true
@@ -471,7 +470,6 @@ ActiveRecord::Schema.define(version: 2022_01_17_134852) do
     t.datetime "expired_vacancy_feedback_email_sent_at"
     t.index ["expires_at"], name: "index_vacancies_on_expires_at"
     t.index ["geolocation"], name: "index_vacancies_on_geolocation", using: :gist
-    t.index ["initially_indexed"], name: "index_vacancies_on_initially_indexed"
     t.index ["publisher_id"], name: "index_vacancies_on_publisher_id"
     t.index ["publisher_organisation_id"], name: "index_vacancies_on_publisher_organisation_id"
     t.index ["searchable_content"], name: "index_vacancies_on_searchable_content", using: :gin


### PR DESCRIPTION
This was used way back when as part of the Algolia migration and is no
longer needed.