### PR TITLE
TEVA-3779 Override `ReferencesForm.optional?` to `false`

### DIFF
--- a/app/form_models/jobseekers/job_application/references_form.rb
+++ b/app/form_models/jobseekers/job_application/references_form.rb
@@ -1,3 +1,7 @@
 class Jobseekers::JobApplication::ReferencesForm < Jobseekers::JobApplication::BaseForm
   include ActiveModel::Model
+
+  def self.optional?
+    false
+  end
 end


### PR DESCRIPTION
This will make the UI behave as before we introduced the "optional"
state, because a proper fix for this may be disrupted by potential
changes to the wizard/step approach coming soon.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3779

## Screenshots of UI changes:

### Before
<img width="874" alt="Screenshot 2022-02-01 at 15 56 17" src="https://user-images.githubusercontent.com/109225/152004015-c6ec0628-5c2d-4f57-8713-e692921f135a.png">

### After
<img width="891" alt="Screenshot 2022-02-01 at 15 58 38" src="https://user-images.githubusercontent.com/109225/152004026-18b4eddd-ff3a-412a-a3d8-647821f3c1ed.png">
