### PR TITLE
Docker cache buster

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -99,7 +99,7 @@ jobs:
         with:
             registry: ghcr.io
             username: ${{ github.repository_owner }}
-            password: ${{ env.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
+            password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push docker image from builder target
         uses: docker/build-push-action@v2

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -34,7 +34,6 @@ jobs:
       matrix_environments: ${{ env.MATRIX_ENVIRONMENTS }}
       docker_image_tag: ${{ env.DOCKER_IMAGE_TAG }}
       commit_sha: ${{ env.COMMIT_SHA }}
-      scan_docker_image: ${{ env.DOCKER_REPOSITORY }}:${{ env.DOCKER_IMAGE_TAG }}
       LINK_TO_RUN: ${{ env.LINK_TO_RUN }}
     runs-on: ubuntu-20.04
 
@@ -159,7 +158,6 @@ jobs:
         run: echo "MATRIX_ENVIRONMENTS={\"environment\":[\"review\"]}" >> $GITHUB_ENV
 
       - name: Scan ${{ env.DOCKER_REPOSITORY }}:${{ env.DOCKER_IMAGE_TAG }} image
-        id: scan_docker_image
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           docker run -t -e "SNYK_TOKEN=${{ env.SNYK_TOKEN }}" \

--- a/.github/workflows/rebuild_docker_cache.yml
+++ b/.github/workflows/rebuild_docker_cache.yml
@@ -1,0 +1,111 @@
+name: Rebuild docker cache
+
+on:
+
+  workflow_dispatch:
+
+  schedule: # At 12:00 on Sunday
+    - cron: '0 12 * * 0'
+
+concurrency: workflow-Build-and-deploy-main
+
+env:
+ DOCKER_REPOSITORY: ghcr.io/dfe-digital/teaching-vacancies
+
+jobs:
+  build:
+    name: Build docker image
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout Code
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+          role-to-assume: Deployments
+          role-duration-seconds: 3600
+          role-skip-session-tagging: true
+
+      - name: Get SLACK_WEBHOOK From ParameterStore
+        uses: marvinpinto/action-inject-ssm-secrets@latest
+        with:
+          ssm_parameter: /teaching-vacancies/github_action/infra/slack_webhook
+          env_variable_name: SLACK_WEBHOOK
+
+      - name: Get SNYK_TOKEN From ParameterStore
+        uses: marvinpinto/action-inject-ssm-secrets@latest
+        with:
+          ssm_parameter: /teaching-vacancies/github_action/infra/snyk
+          env_variable_name: SNYK_TOKEN
+
+      - name: Set environment variables
+        run: |
+          GIT_REF=${{ github.ref }}
+          GIT_BRANCH=${GIT_REF##*/}
+          echo "GIT_BRANCH=${GIT_BRANCH}" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE_TAG=${GIT_BRANCH}-${GITHUB_SHA}" >> $GITHUB_ENV
+          echo "LINK_TO_RUN=https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" >> $GITHUB_ENV
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+            registry: ghcr.io
+            username: ${{ github.repository_owner }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push docker image from builder target
+        uses: docker/build-push-action@v2
+        with:
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+          push: true
+          # Tag with branch name for reuse
+          tags: ${{ env.DOCKER_REPOSITORY }}:builder-${{ env.GIT_BRANCH }}
+          target: builder
+
+      - name: Build and push docker image from production target
+        uses: docker/build-push-action@v2
+        with:
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+            COMMIT_SHA=${{ env.COMMIT_SHA }}
+          push: false
+          load: true
+          # Tag with branch name for reuse
+          # Tag with branch name and commit sha for unique identification
+          tags: |
+            ${{ env.DOCKER_REPOSITORY }}:${{ env.GIT_BRANCH }}
+            ${{ env.DOCKER_REPOSITORY }}:${{ env.DOCKER_IMAGE_TAG }}
+          target: production
+
+      - name: Scan ${{ env.DOCKER_REPOSITORY }}:${{ env.DOCKER_IMAGE_TAG }} image
+        run: |
+          docker run -t -e "SNYK_TOKEN=${{ env.SNYK_TOKEN }}" \
+            -v "/var/run/docker.sock:/var/run/docker.sock" \
+            -v "$GITHUB_WORKSPACE:/project"  \
+            snyk/snyk-cli:docker test --docker ${{ env.DOCKER_REPOSITORY }}:${{ env.DOCKER_IMAGE_TAG }} --file=Dockerfile
+
+      - name: Push ${{ env.DOCKER_REPOSITORY }} images
+        if: ${{ success() }}
+        run: docker image push --all-tags ${{ env.DOCKER_REPOSITORY }}
+
+      - name: Notify twd_tv_dev channel on build workflow failure
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_CHANNEL: twd_tv_dev
+          SLACK_USERNAME: CI Deployment
+          SLACK_TITLE: Build failure on Rebuild cache workflow
+          SLACK_MESSAGE: |
+            Build failure on branch ${{env.GIT_BRANCH}} <!channel>
+            See: <${{ env.LINK_TO_RUN }}|Workflow run>
+          SLACK_WEBHOOK: ${{env.SLACK_WEBHOOK}}
+          SLACK_COLOR: failure

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-ARG PROD_PACKAGES="libxml2=2.9.12-r2 libxslt=1.1.34-r1 libpq=14.1-r5 tzdata=2021e-r0 shared-mime-info=2.1-r0 gmp=6.2.1-r1"
+ARG PROD_PACKAGES="libxml2 libxslt libpq tzdata shared-mime-info"
 
 FROM ruby:3.1.0-alpine3.15 AS builder
 
 WORKDIR /app
 
 ARG PROD_PACKAGES
-ENV DEV_PACKAGES="gcc=10.3.1_git20211027-r0 libc-dev=0.7.2-r3 make=4.3-r0 yarn=1.22.17-r0 postgresql13-dev=13.5-r1 gmp=6.2.1-r1 build-base=0.5-r2 git"
+ENV DEV_PACKAGES="gcc libc-dev make yarn postgresql13-dev build-base git"
 RUN apk add --no-cache $PROD_PACKAGES $DEV_PACKAGES
 RUN echo "Europe/London" > /etc/timezone && \
         cp /usr/share/zoneinfo/Europe/London /etc/localtime

--- a/documentation/deployments.md
+++ b/documentation/deployments.md
@@ -36,6 +36,12 @@ Furthermore, to help with workflow code reuse, we trigger a separate deployment 
 
 To block the calling workflow until the triggered workflow is completed, we use `action-wait-for-check`. This checks and waits on a `sha` (commit) instead of `ref` (branch), which is a moving target.
 
+
+### Refresh cached docker image: `ghcr.io/dfe-digital/teaching-vacancies:main`
+
+Refresh the cached `ghcr.io/dfe-digital/teaching-vacancies:main` image on Github packages. In case the build workflow fails at the `Scan ghcr.io/dfe-digital/teaching-vacancies:main image` stage, it may be that a fix is available but our cache is stale; with the vulnerable dependency. In this case use the [rebuild_docker_cache_workflow](../.github/workflows/rebuild_docker_cache.yml) to refresh the cache with updated packages. The rebuild_docker_cache_workflow is scheduled on a weekly run (12 noon on Sundays) and can also be triggered manaully via workflow dispatch.
+
+
 ### Build and deploy to an environment - Makefile
 
 This builds and deploys a Docker image from local code, then updates the environment to use that image


### PR DESCRIPTION
## Jira ticket URL

- Just add the ticket number to the end:

https://dfedigital.atlassian.net/browse/TEVA-

We pin to specific version of alpine packages for both `PROD_PACKAGES` and `DEV_PACKAGES`
in dockerfile. This is no longer required as we now build against a
`ghcr.io/dfe-digital/teaching-vacancies:main` cache, which is refreshed weekly, which
includes latest and updated packages - which makes pinning unnecessary.