### PR TITLE
[TEVA-3523] Remove manage jobs grey banner

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -130,7 +130,7 @@ Metrics/BlockLength:
     - "app/models/concerns/indexable.rb"
 
 Metrics/ClassLength:
-  Max: 156 # Default 100
+  Max: 166 # Default 100
 
 Metrics/CyclomaticComplexity:
   Max: 18 # Default 7

--- a/app/controllers/publishers/vacancies/base_controller.rb
+++ b/app/controllers/publishers/vacancies/base_controller.rb
@@ -65,7 +65,7 @@ class Publishers::Vacancies::BaseController < Publishers::BaseController
                 success: t("messages.jobs.listing_updated_html",
                            job_title: vacancy.job_title,
                            link_to: helpers.govuk_link_to(t("messages.jobs.listing_updated_link_text"),
-                                                          helpers.back_to_manage_jobs_link(vacancy),
+                                                          jobs_with_type_organisation_path(vacancy.publication_status),
                                                           class: "govuk-link--no-visited-state"))
   end
 

--- a/app/frontend/src/styles/application/publishers/publisher.scss
+++ b/app/frontend/src/styles/application/publishers/publisher.scss
@@ -15,52 +15,8 @@ $desktop-container-width: 1200px;
     }
   }
 
-  .vacancy-deadline {
-    margin-top: 0;
-    padding: govuk-spacing(3) 0;
-
-    &--passed {
-      h4 {
-        color: $govuk-error-colour;
-      }
-    }
-  }
-
-  .application-count {
-    display: block;
-    margin: govuk-spacing(3);
-    padding: govuk-spacing(3);
-    text-transform: none;
-
-    @include govuk-media-query($from: tablet) {
-      height: 50%;
-      padding-bottom: govuk-spacing(4);
-    }
-
-    @include govuk-media-query($until: desktop) {
-      margin: govuk-spacing(3) 0;
-    }
-
-    .govuk-heading-l,
-    .govuk-caption-s {
-      color: inherit;
-      margin: 0;
-    }
-
-    .govuk-caption-s {
-      font-weight: normal;
-      letter-spacing: normal;
-    }
-  }
-
   .job-application-actions {
     display: flex;
   }
   
-}
-
-.job-applications-summary {
-  @include govuk-media-query($from: tablet) {
-    display: flex;
-  }
 }

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -27,19 +27,6 @@ module VacanciesHelper
     "#{'Error: ' if vacancy.errors.present? && show_errors}#{page_title}"
   end
 
-  def back_to_manage_jobs_link(vacancy)
-    state = if vacancy.listed?
-              "published"
-            elsif vacancy.published? && vacancy.expires_at.future?
-              "pending"
-            elsif vacancy.published? && vacancy.expires_at.past?
-              "expired"
-            else
-              "draft"
-            end
-    jobs_with_type_organisation_path(state)
-  end
-
   def vacancy_or_organisation_description(vacancy)
     vacancy.about_school.presence || vacancy.parent_organisation.description.presence
   end

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -58,7 +58,7 @@ class JobApplication < ApplicationRecord
   end
 
   def deadline_passed?
-    draft? && vacancy&.expires_at&.past?
+    draft? && vacancy&.expired?
   end
 
   private

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -107,13 +107,10 @@ class Vacancy < ApplicationRecord
   end
 
   def publication_status
-    if expired?
-      "expired"
-    elsif pending?
-      "pending"
-    else
-      status
-    end
+    return "expired" if expired?
+    return "pending" if pending?
+
+    status
   end
 
   def can_receive_job_applications?

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -102,6 +102,20 @@ class Vacancy < ApplicationRecord
     published? && publish_on&.future?
   end
 
+  def expired?
+    published? && expires_at&.past?
+  end
+
+  def publication_status
+    if expired?
+      "expired"
+    elsif pending?
+      "pending"
+    else
+      status
+    end
+  end
+
   def can_receive_job_applications?
     enable_job_applications? && published? && !pending?
   end

--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -5,6 +5,7 @@ class VacancyPresenter < BasePresenter
   delegate :location, to: :organisation
   delegate :working_patterns, to: :model, prefix: true
   delegate :job_roles, to: :model, prefix: true
+  delegate :expired?, to: :model
 
   HTML_STRIP_REGEX = %r{(&nbsp;|<div>|</div>|<!--block-->)+}
 
@@ -43,10 +44,6 @@ class VacancyPresenter < BasePresenter
 
   def benefits
     simple_format(fix_bullet_points(model.benefits)) if model.benefits.present?
-  end
-
-  def expired?
-    model.expires_at < Time.current
   end
 
   def publish_today?

--- a/app/views/jobseekers/job_applications/_job_application.html.slim
+++ b/app/views/jobseekers/job_applications/_job_application.html.slim
@@ -18,7 +18,7 @@
 
     = tag.div(card.labelled_item(t(".closing_date"), OrganisationVacancyPresenter.new(job_application.vacancy).application_deadline))
 
-  - if job_application.draft? && job_application.vacancy.expires_at.past?
+  - if job_application.draft? && job_application.vacancy.expired?
     - card.action_item link: job_application_status_tag(:deadline_passed)
   - else
     - card.action_item link: job_application_status_tag(job_application.status)

--- a/app/views/jobseekers/saved_jobs/index.html.slim
+++ b/app/views/jobseekers/saved_jobs/index.html.slim
@@ -28,7 +28,7 @@
 
                 - card.body do
                   = tag.div(card.labelled_item(t(".added"), format_date(saved_job.created_at, :date_only)))
-                  - if saved_job.vacancy.expires_at.past?
+                  - if saved_job.vacancy.expired?
                     = tag.div(t(".deadline_passed"), class: "govuk-!-font-weight-bold text-red")
                   = tag.div(card.labelled_item(t(".application_deadline"), OrganisationVacancyPresenter.new(saved_job.vacancy).application_deadline))
 

--- a/app/views/publishers/vacancies/_banner.html.slim
+++ b/app/views/publishers/vacancies/_banner.html.slim
@@ -1,0 +1,19 @@
+.govuk-grid-row
+  .govuk-grid-column-full
+    = govuk_breadcrumbs breadcrumbs: { "#{t("publishers.vacancies_component.#{vacancy.publication_status}.tab_heading")}": jobs_with_type_organisation_path(vacancy.publication_status),
+                                       "#{vacancy.job_title}": "" }
+
+    - if current_organisation.school_group?
+      h2.govuk-caption-l = current_organisation.name
+    h1.govuk-heading-l class="govuk-!-margin-bottom-2" = vacancy.job_title
+
+    - if vacancy.expires_at.present?
+      p.govuk-body.govuk-caption-s
+        span class="govuk-!-font-weight-bold"
+          - if vacancy.expired?
+            = t(".deadline.after")
+          - else
+            = t(".deadline.before")
+        span class="govuk-!-margin-left-1" = format_time_to_datetime_at(vacancy.expires_at)
+
+= render "publishers/vacancies/tabs_show"

--- a/app/views/publishers/vacancies/_tabs_show.html.slim
+++ b/app/views/publishers/vacancies/_tabs_show.html.slim
@@ -1,21 +1,5 @@
 .govuk-grid-row
   .govuk-grid-column-full
-    = govuk_breadcrumbs breadcrumbs: { "#{t("publishers.vacancies_component.#{vacancy.publication_status}.tab_heading")}": jobs_with_type_organisation_path(vacancy.publication_status), "#{vacancy.job_title}": "" }
-    - if current_organisation.school_group?
-      h2.govuk-caption-l = current_organisation.name
-    h1.govuk-heading-l class="govuk-!-margin-bottom-2" = vacancy.job_title
-
-    - if vacancy.expires_at.present?
-        p.govuk-body.govuk-caption-s
-          span class="govuk-!-font-weight-bold"
-            - if vacancy.expired?
-              = t(".deadline.after")
-            - else
-              = t(".deadline.before")
-          span class="govuk-!-margin-left-1" = format_time_to_datetime_at(vacancy.expires_at)
-
-.govuk-grid-row
-  .govuk-grid-column-full
     = render(DashboardComponent.new) do |dashboard|
       - dashboard.navigation_item item: (govuk_link_to t("buttons.manage_listing"), organisation_job_path(vacancy.id), class: "dashboard-component-navigation__link", "aria-current": ("page" if controller_name == "vacancies"))
       - if vacancy.can_receive_job_applications? && !current_organisation.local_authority?

--- a/app/views/publishers/vacancies/extend_deadline/show.html.slim
+++ b/app/views/publishers/vacancies/extend_deadline/show.html.slim
@@ -7,7 +7,7 @@
       h1.govuk-heading-xl = t(".heading")
 
       = govuk_inset_text do
-        = vacancy.expires_at.past? ? t(".deadline.past") : t(".deadline.future")
+        = vacancy.expired? ? t(".deadline.past") : t(".deadline.future")
         strong =< OrganisationVacancyPresenter.new(vacancy).application_deadline
 
       = form_for form, url: organisation_job_extend_deadline_path(vacancy.id), method: :patch do |f|

--- a/app/views/publishers/vacancies/job_applications/_banner.html.slim
+++ b/app/views/publishers/vacancies/job_applications/_banner.html.slim
@@ -8,7 +8,7 @@
     - if vacancy.expires_at.present?
         p.govuk-body.govuk-caption-s
           span class="govuk-!-font-weight-bold"
-            - if vacancy.expires_at.past?
+            - if vacancy.expired?
               = t(".deadline.after")
             - else
               = t(".deadline.before")

--- a/app/views/publishers/vacancies/job_applications/_banner.html.slim
+++ b/app/views/publishers/vacancies/job_applications/_banner.html.slim
@@ -1,46 +1,18 @@
-= render BannerComponent.new do
-  - if vacancy.expires_at&.past?
-    = govuk_breadcrumbs breadcrumbs: { "#{t("publishers.vacancies_component.expired.tab_heading")}": jobs_with_type_organisation_path(:expired), "#{vacancy.job_title}": "" }
-  - elsif vacancy.pending?
-    = govuk_breadcrumbs breadcrumbs: { "#{t("publishers.vacancies_component.pending.tab_heading")}": jobs_with_type_organisation_path(:pending), "#{vacancy.job_title}": "" }
-  - elsif vacancy.draft?
-    = govuk_breadcrumbs breadcrumbs: { "#{t("publishers.vacancies_component.draft.tab_heading")}": jobs_with_type_organisation_path(:draft), "#{vacancy.job_title}": "" }
-  - else
-    = govuk_breadcrumbs breadcrumbs: { "#{t("publishers.vacancies_component.published.tab_heading")}": organisation_path, "#{vacancy.job_title}": "" }
+.govuk-grid-row
+  .govuk-grid-column-full
+    = govuk_breadcrumbs breadcrumbs: { "#{t("publishers.vacancies_component.#{vacancy.publication_status}.tab_heading")}": jobs_with_type_organisation_path(vacancy.publication_status), "#{vacancy.job_title}": "" }
+    - if current_organisation.school_group?
+      h2.govuk-caption-l = current_organisation.name
+    h1.govuk-heading-l class="govuk-!-margin-bottom-2" = vacancy.job_title
 
-  .govuk-grid-row
-    .govuk-grid-column-full
-      - if current_organisation.school_group?
-        h2.govuk-caption-l = current_organisation.name
-      h1.govuk-heading-l = vacancy.job_title
-
-  - if vacancy.enable_job_applications?
-    .govuk-grid-row.job-applications-summary
-      - if vacancy.expires_at.present?
-        .govuk-grid-column-one-quarter
-          .vacancy-deadline class=("vacancy-deadline--passed" if vacancy.expires_at.past?)
-            h4.govuk-body.govuk-caption-s class="govuk-!-font-weight-bold govuk-!-margin-bottom-0"
-              - if vacancy.expires_at.past?
-                = t(".deadline.after")
-              - else
-                = t(".deadline.before")
-            span.govuk-body = format_time_to_datetime_at(vacancy.expires_at)
-
-      - unless vacancy.draft? || !vacancy.within_data_access_period?
-        .govuk-grid-column-one-quarter
-          .application-count.govuk-tag class="govuk-tag--#{status_tag_colour(:submitted)}"
-            .govuk-heading-l = job_applications.submitted.count
-            h3.govuk-caption-s = t(".submitted", count: job_applications.submitted.count)
-
-        .govuk-grid-column-one-quarter
-          .application-count.govuk-tag class="govuk-tag--#{status_tag_colour(:shortlisted)}"
-            .govuk-heading-l = job_applications.shortlisted.count
-            h3.govuk-caption-s = t(".shortlisted", count: job_applications.shortlisted.count)
-
-        .govuk-grid-column-one-quarter
-          .application-count.govuk-tag class="govuk-tag--#{status_tag_colour(:unsuccessful)}"
-            .govuk-heading-l = job_applications.unsuccessful.count
-            h3.govuk-caption-s = t(".rejected", count: job_applications.unsuccessful.count)
+    - if vacancy.expires_at.present?
+        p.govuk-body.govuk-caption-s
+          span class="govuk-!-font-weight-bold"
+            - if vacancy.expires_at.past?
+              = t(".deadline.after")
+            - else
+              = t(".deadline.before")
+          span class="govuk-!-margin-left-1" = format_time_to_datetime_at(vacancy.expires_at)
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/app/views/publishers/vacancies/job_applications/index.html.slim
+++ b/app/views/publishers/vacancies/job_applications/index.html.slim
@@ -1,6 +1,6 @@
 - content_for :page_title_prefix, current_organisation.name
 
-= render "banner", vacancy: vacancy, job_applications: job_applications
+= render "publishers/vacancies/banner", vacancy: vacancy, job_applications: job_applications
 
 - if vacancy.within_data_access_period? && job_applications.many?
   .govuk-grid-row class="govuk-!-margin-top-7"

--- a/app/views/publishers/vacancies/show.html.slim
+++ b/app/views/publishers/vacancies/show.html.slim
@@ -4,7 +4,7 @@
 = vacancy_review(vacancy, step_process: step_process, back_to: "manage_draft", show_errors: params[:show_errors]) do |r|
   - r.header
     div class="govuk-!-margin-bottom-4"
-      = render "publishers/vacancies/job_applications/banner", vacancy: vacancy, job_applications: vacancy.job_applications
+      = render "banner", vacancy: vacancy, job_applications: vacancy.job_applications
 
   - r.above
     h2.govuk-heading-l = t("jobs.manage_listing", state: (vacancy.draft? ? "draft" : "job"))

--- a/app/views/publishers/vacancies/show.html.slim
+++ b/app/views/publishers/vacancies/show.html.slim
@@ -17,7 +17,7 @@
 
   - r.below
     = render "publish_buttons", back_to: "manage_draft" if vacancy.draft?
-    = govuk_link_to(t("buttons.back_to_manage_jobs"), back_to_manage_jobs_link(vacancy), class: "govuk-link--no-visited-state")
+    = govuk_link_to(t("buttons.back_to_manage_jobs"), jobs_with_type_organisation_path(vacancy.publication_status), class: "govuk-link--no-visited-state")
 
   - if vacancy.published? && !vacancy.pending?
     - r.sidebar(classes: %w[grey-cta-container govuk-!-padding-bottom-4])

--- a/app/views/publishers/vacancies/statistics/show.html.slim
+++ b/app/views/publishers/vacancies/statistics/show.html.slim
@@ -1,6 +1,6 @@
 - content_for :page_title_prefix, t(".title")
 
-= render "publishers/vacancies/job_applications/banner", vacancy: vacancy, job_applications: vacancy.job_applications
+= render "publishers/vacancies/banner", vacancy: vacancy, job_applications: vacancy.job_applications
 
 .govuk-grid-row.vacancy class="govuk-!-margin-top-7"
   - if vacancy.draft? || vacancy.pending?

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -145,6 +145,10 @@ en:
         tab_heading: Active jobs
         with_count_html: Active jobs <span class='govuk-body-l govuk-!-font-size-36'>(%{count})</span>
     vacancies:
+      banner:
+        deadline:
+          after: Deadline passed
+          before: Application deadline
       build:
         applying_for_the_job:
           banner:
@@ -236,23 +240,6 @@ en:
             body: Thank you
           title: Feedback submitted
       job_applications:
-        banner:
-          applications:
-            hide_count: Applications
-            show_count: Applications (%{count})
-          deadline:
-            after: Deadline passed
-            before: Application deadline
-          rejected:
-            one: Rejected application
-            other: Rejected applications
-          shortlisted:
-            one: Shortlisted application
-            other: Shortlisted applications
-          submitted:
-            one: Unread application
-            other: Unread applications
-          statistics: Statistics
         index:
           deadline:
             after: Deadline passed
@@ -350,7 +337,11 @@ en:
           withdrawn_applications: Withdrawn applications
         update:
           success: Thank you for submitting your feedback for %{job_title}
-
+      tabs_show:
+        applications:
+          hide_count: Applications
+          show_count: Applications (%{count})
+        statistics: Statistics
       vacancy_publisher_feedbacks:
         new:
           already_submitted: Feedback for this job has already been submitted

--- a/spec/helpers/vacancies_helper_spec.rb
+++ b/spec/helpers/vacancies_helper_spec.rb
@@ -1,37 +1,6 @@
 require "rails_helper"
 
 RSpec.describe VacanciesHelper do
-  describe "#back_to_manage_jobs_link" do
-    let(:vacancy) { double("vacancy").as_null_object }
-
-    before do
-      allow(vacancy).to receive(:listed?).and_return(false)
-      allow(vacancy).to receive(:published?).and_return(false)
-      allow(vacancy).to receive_message_chain(:expires_at, :future?).and_return(false)
-    end
-
-    it "returns draft jobs link for draft jobs" do
-      expect(back_to_manage_jobs_link(vacancy)).to eq(jobs_with_type_organisation_path("draft"))
-    end
-
-    it "returns pending jobs link for scheduled jobs" do
-      allow(vacancy).to receive(:published?).and_return(true)
-      allow(vacancy).to receive_message_chain(:expires_at, :future?).and_return(true)
-      expect(back_to_manage_jobs_link(vacancy)).to eq(jobs_with_type_organisation_path("pending"))
-    end
-
-    it "returns published jobs link for published jobs" do
-      allow(vacancy).to receive(:listed?).and_return(true)
-      expect(back_to_manage_jobs_link(vacancy)).to eq(jobs_with_type_organisation_path("published"))
-    end
-
-    it "returns expired jobs link for expired jobs" do
-      allow(vacancy).to receive(:published?).and_return(true)
-      allow(vacancy).to receive_message_chain(:expires_at, :past?).and_return(true)
-      expect(back_to_manage_jobs_link(vacancy)).to eq(jobs_with_type_organisation_path("expired"))
-    end
-  end
-
   describe "#vacancy_full_job_location" do
     subject { vacancy_full_job_location(vacancy) }
 

--- a/spec/system/publishers_can_manage_job_applications_for_a_vacancy_spec.rb
+++ b/spec/system/publishers_can_manage_job_applications_for_a_vacancy_spec.rb
@@ -32,27 +32,8 @@ RSpec.describe "Publishers can manage job applications for a vacancy" do
           expect(page).to have_content(vacancy.job_title)
         end
 
-        within(".vacancy-deadline") do
-          expect(page).to have_content(format_time_to_datetime_at(vacancy.expires_at))
-          expect(page).to have_content(I18n.t("publishers.vacancies.job_applications.index.deadline.after"))
-        end
-      end
-
-      it "shows total of each status for all applications" do
-        within(".application-count.govuk-tag--green") do
-          expect(page).to have_content("1")
-          expect(page).to have_content(I18n.t("publishers.vacancies.job_applications.index.shortlisted", count: 1))
-        end
-
-        within(".application-count.govuk-tag--blue") do
-          expect(page).to have_content("1")
-          expect(page).to have_content(I18n.t("publishers.vacancies.job_applications.index.submitted", count: 1))
-        end
-
-        within(".application-count.govuk-tag--red") do
-          expect(page).to have_content("1")
-          expect(page).to have_content(I18n.t("publishers.vacancies.job_applications.index.rejected", count: 1))
-        end
+        expect(page).to have_content(format_time_to_datetime_at(vacancy.expires_at))
+        expect(page).to have_content(I18n.t("publishers.vacancies.job_applications.index.deadline.after"))
       end
 
       it "shows a card for each application that has been submitted and no draft applications" do
@@ -207,7 +188,7 @@ RSpec.describe "Publishers can manage job applications for a vacancy" do
     describe "the summary section" do
       it "shows breadcrumb with link to active jobs in dashboard" do
         within(".govuk-breadcrumbs") do
-          expect(page).to have_link(I18n.t("publishers.vacancies_component.published.tab_heading"), href: organisation_path)
+          expect(page).to have_link(I18n.t("publishers.vacancies_component.published.tab_heading"), href: jobs_with_type_organisation_path(:published))
         end
       end
 
@@ -216,27 +197,8 @@ RSpec.describe "Publishers can manage job applications for a vacancy" do
           expect(page).to have_content(vacancy.job_title)
         end
 
-        within(".vacancy-deadline") do
-          expect(page).to have_content(format_time_to_datetime_at(vacancy.expires_at))
-          expect(page).to have_content(I18n.t("publishers.vacancies.job_applications.index.deadline.before"))
-        end
-      end
-
-      it "shows total of each status for all applications" do
-        within(".application-count.govuk-tag--green") do
-          expect(page).to have_content("0")
-          expect(page).to have_content(I18n.t("publishers.vacancies.job_applications.index.shortlisted", count: 0))
-        end
-
-        within(".application-count.govuk-tag--blue") do
-          expect(page).to have_content("0")
-          expect(page).to have_content(I18n.t("publishers.vacancies.job_applications.index.submitted", count: 0))
-        end
-
-        within(".application-count.govuk-tag--red") do
-          expect(page).to have_content("0")
-          expect(page).to have_content(I18n.t("publishers.vacancies.job_applications.index.rejected", count: 0))
-        end
+        expect(page).to have_content(format_time_to_datetime_at(vacancy.expires_at))
+        expect(page).to have_content(I18n.t("publishers.vacancies.job_applications.index.deadline.before"))
       end
 
       it "shows that there are no applicants" do
@@ -258,10 +220,6 @@ RSpec.describe "Publishers can manage job applications for a vacancy" do
 
       it "shows no sort applications control" do
         expect(page).not_to have_css("#sort-column-field")
-      end
-
-      it "shows no application counts" do
-        expect(page).to have_css(".job-applications-summary .govuk-grid-column-one-quarter", count: 1)
       end
 
       it "shows text to tell user can no longer see applications" do


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3523

## Changes in this PR:

This PR streamlines the banner for the "Manage job listing" pages by removing the grey box and the application counters.

## Screenshots of UI changes:

### Before
![image](https://user-images.githubusercontent.com/24639777/152180726-0ec3526c-a225-49ac-8d31-d76e0400cdb2.png)

### After
![image](https://user-images.githubusercontent.com/24639777/152180395-bd8756f6-cd2b-4f09-9926-3d564d7eb8d1.png)
