### PR TITLE
Make legacy role landing page redirects explicit

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -249,8 +249,4 @@ Rails.application.routes.draw do
         constraints: ->(request) { SUBJECT_OPTIONS.map(&:first).map(&:parameterize).include?(request.params[:subject].parameterize) },
         defaults: { pretty: :subject }
   end
-
-  get "/teaching-jobs-for-:job_role",
-      to: redirect { |params| "/#{params[:job_role].parameterize.dasherize}-jobs" },
-      constraints: ->(request) { Vacancy.job_roles.keys.map(&:dasherize).include?(request.params[:job_role].dasherize) }
 end

--- a/config/routes/legacy_redirects.rb
+++ b/config/routes/legacy_redirects.rb
@@ -9,5 +9,20 @@ get "/publishers/account_requests/new", to: redirect("/publishers/account-reques
 get "/jobseekers/sign_in", to: redirect("/jobseekers/sign-in")
 
 # NQT is now called ECT
-get "teaching-jobs-for-nqt_suitable", to: redirect("teaching-jobs-for-ect-suitable")
+get "teaching-jobs-for-nqt-suitable", to: redirect("ect-suitable-jobs")
+get "teaching-jobs-for-nqt_suitable", to: redirect("ect-suitable-jobs")
 get "sign-up-for-NQT-job-alerts", to: redirect("/sign-up-for-ECT-job-alerts")
+
+# Legacy landing pages
+## Job roles
+get "teaching-jobs-for-teacher", to: redirect("teacher-jobs")
+get "teaching-jobs-for-leadership", to: redirect("leadership-jobs")
+get "teaching-jobs-for-teaching_assistant", to: redirect("teaching-assistant-jobs")
+get "teaching-jobs-for-teaching-assistant", to: redirect("teaching-assistant-jobs")
+get "teaching-jobs-for-education_support", to: redirect("education-support-jobs")
+get "teaching-jobs-for-education-support", to: redirect("education-support-jobs")
+get "teaching-jobs-for-sendco", to: redirect("sendco-jobs")
+get "teaching-jobs-for-send_responsible", to: redirect("send-responsible-jobs")
+get "teaching-jobs-for-send-responsible", to: redirect("send-responsible-jobs")
+get "teaching-jobs-for-ect_suitable", to: redirect("ect-suitable-jobs")
+get "teaching-jobs-for-ect-suitable", to: redirect("ect-suitable-jobs")


### PR DESCRIPTION
As part of the landing pages refactor, we want to make the routes for
landing pages, both existing and legacy redirects, more explicit.

This replaces the generic redirect for legacy job roles with an explicit
set of rules in the legacy redirect routes file for those routes that
have changed.