### PR TITLE
Add A:B for search and job alert subject filters

### DIFF
--- a/app/components/filters_component.rb
+++ b/app/components/filters_component.rb
@@ -1,21 +1,25 @@
 class FiltersComponent < GovukComponent::Base
-  attr_accessor :filters, :form, :options
+  attr_accessor :filters, :form, :options, :title
 
   def self.variants
     %w[default]
   end
 
-  def initialize(form:, options:, filters: {}, classes: [], html_attributes: {})
+  def initialize(form:, options:, filters: {}, title: nil, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
 
-    @filters = filters
     @form = form
     @options = options
+    @filters = filters
+    @title = title
   end
 
-  renders_many :groups, lambda { |key:, component:|
+  renders_many :groups, lambda { |key:, component:, title: nil|
     tag.div(key, class: "filters-component__groups__group", data: { group: key }) do
-      tag.div(component)
+      safe_join([
+        tag.h1(title, class: "govuk-fieldset__legend govuk-fieldset__legend--s"),
+        tag.div(component),
+      ])
     end
   }
 

--- a/app/components/searchable_collection_component.rb
+++ b/app/components/searchable_collection_component.rb
@@ -1,27 +1,36 @@
 class SearchableCollectionComponent < GovukComponent::Base
-  attr_accessor :form, :input_type, :label_text, :attribute_name, :collection, :value_method, :text_method, :hint_method, :threshold, :small, :scrollable
+  attr_accessor :form, :input_type, :attribute_name, :collection, :value_method, :text_method, :hint_method, :threshold, :border, :small, :label_text, :form_group, :options, :scrollable
 
   # rubocop:disable Metrics/ParameterLists
-  def initialize(form:, input_type:, attribute_name:, collection:, value_method:, text_method:, hint_method:, threshold: 10, scrollable: false, label_text: nil, classes: [], html_attributes: {})
+  def initialize(form:, input_type:, attribute_name:, collection:, value_method:, text_method:, hint_method:, threshold: 10, border: true, small: nil, options: {}, form_group: {}, scrollable: false, label_text: nil, classes: [], html_attributes: {})
     # rubocop:enable Metrics/ParameterLists
     super(classes: classes, html_attributes: html_attributes)
 
     @form = form
-    @input_type = input_type
-    @label_text = label_text
-    @threshold = threshold
     @attribute_name = attribute_name
     @collection = collection
     @value_method = value_method
     @text_method = text_method
     @hint_method = hint_method
+    @form_group = form_group
 
-    @small = searchable
-    @scrollable = scrollable || searchable
+    @input_type = input_type
+    @threshold = threshold
+    @label_text = label_text
+    @border = border
+    @small = small
+    @options = options
+    @scrollable = scrollable || searchable?
   end
 
-  def searchable
+  def searchable?
     collection.count >= threshold
+  end
+
+  def small_items?
+    return searchable? if small.nil?
+
+    small
   end
 
   def scrollable_class
@@ -29,7 +38,9 @@ class SearchableCollectionComponent < GovukComponent::Base
   end
 
   def border_class
-    return "searchable-collection-component--border" if searchable
+    return nil unless border
+
+    return "searchable-collection-component--border" if searchable?
   end
 
   private

--- a/app/components/searchable_collection_component/searchable_collection_component.html.slim
+++ b/app/components/searchable_collection_component/searchable_collection_component.html.slim
@@ -1,6 +1,6 @@
 = tag.div(class: classes, **html_attributes) do
   div class="#{border_class} #{scrollable_class}"
-    - if searchable
+    - if searchable?
       .searchable-collection-component__search
         input.govuk-input.searchable-collection-component__search-input.icon.icon--left.icon--search.js-action placeholder=t("helpers.hint.publishers_job_listing_job_details_form.subjects_placeholder") aria-label="#{label_text}" aria-expanded="true" aria-describedby="publishers-job-listing-job-details-form-subjects-hint" aria-owns="subjects__listbox" role="combobox"
         .govuk-visually-hidden aria-live="polite" role="status" id="search-results"
@@ -12,10 +12,11 @@
         value_method,
         text_method,
         hint_method,
-        small: small,
-        classes: "checkbox-label__bold",
+        small: small_items?,
+        classes: ("checkbox-label__bold" if options[:bold_items]),
         legend: nil,
-        hint: nil
+        hint: nil,
+        form_group: form_group
 
     - when :radio_button
       = form.govuk_collection_radio_buttons attribute_name,
@@ -23,7 +24,7 @@
         value_method,
         text_method,
         hint_method,
-        small: small,
-        classes: "radiobutton-label__bold",
+        small: small_items?,
+        classes: ("radiobutton-label__bold" if options[:bold_items]),
         legend: nil,
         hint: nil

--- a/app/components/searchable_collection_component/searchable_collection_component.scss
+++ b/app/components/searchable_collection_component/searchable_collection_component.scss
@@ -15,17 +15,22 @@
   &--border {
     background-color: #fff;
     border: 2px solid $govuk-border-colour;
+    margin-top: govuk-spacing(2);
     padding: 0;
 
     .govuk-checkboxes__item,
     .govuk-radios__item {
       margin-left: govuk-spacing(2);
     }
+
+    .searchable-collection-component__search {
+      margin: govuk-spacing(2);
+    }
   }
 
   &__search {
     background: #fff;
-    margin: govuk-spacing(2);
+    margin: govuk-spacing(2) 0;
     position: relative;
 
     .searchable-collection-component__search-input {

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -98,12 +98,12 @@ class SubscriptionsController < ApplicationController
 
   def search_criteria_params
     params.require(:search_criteria)
-          .permit(:keyword, :location, :radius, job_roles: [], phases: [], working_patterns: [])
+          .permit(:keyword, :location, :radius, job_roles: [], subjects: [], phases: [], working_patterns: [])
   end
 
   def subscription_params
     params.require(:jobseekers_subscription_form)
-          .permit(:email, :frequency, :keyword, :location, :radius, job_roles: [], phases: [], working_patterns: [])
+          .permit(:email, :frequency, :keyword, :location, :radius, job_roles: [], subjects: [], phases: [], working_patterns: [])
   end
 
   def token

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -48,12 +48,12 @@ class VacanciesController < ApplicationController
   def search_params
     return landing_page_search_params if params[:pretty].present? || params[:location_facet].present?
 
-    strip_empty_checkboxes(%i[job_roles phases working_patterns])
-    %w[job_role job_roles phases working_patterns].each do |facet|
+    strip_empty_checkboxes(%i[job_roles subjects phases working_patterns])
+    %w[job_role job_roles subjects phases working_patterns].each do |facet|
       params[facet] = params[facet].split if params[facet].is_a?(String)
     end
     params.permit(:keyword, :location, :radius, :subject, :sort_by,
-                  job_role: [], job_roles: [], phases: [], working_patterns: [])
+                  job_role: [], job_roles: [], subjects: [], phases: [], working_patterns: [])
   end
 
   def landing_page_search_params

--- a/app/form_models/jobseekers/search_form.rb
+++ b/app/form_models/jobseekers/search_form.rb
@@ -3,7 +3,7 @@ class Jobseekers::SearchForm
 
   attr_reader :keyword,
               :location, :radius,
-              :job_roles, :phases, :working_patterns,
+              :job_roles, :subjects, :phases, :working_patterns,
               :job_role_options, :ect_suitable_options, :send_responsible_options,
               :phase_options, :working_pattern_options,
               :total_filters, :sort
@@ -13,6 +13,7 @@ class Jobseekers::SearchForm
     @keyword = params[:keyword] || params[:subject]
     @location = params[:location]
     @job_roles = params[:job_roles] || params[:job_role] || []
+    @subjects = params[:subjects]
     @phases = params[:phases]
     @working_patterns = params[:working_patterns]
     @sort = Search::VacancySort.new(keyword: keyword).update(sort_by: params[:sort_by])
@@ -28,6 +29,7 @@ class Jobseekers::SearchForm
       location: @location,
       radius: @radius,
       job_roles: @job_roles,
+      subjects: @subjects,
       phases: @phases,
       working_patterns: @working_patterns,
     }.delete_if { |k, v| v.blank? || (k.eql?(:radius) && @location.blank?) }
@@ -50,7 +52,7 @@ class Jobseekers::SearchForm
   end
 
   def set_total_filters
-    @total_filters = [@job_roles&.count, @phases&.count, @working_patterns&.count].compact.sum
+    @total_filters = [@job_roles&.count, @subjects&.count, @phases&.count, @working_patterns&.count].compact.sum
   end
 
   def set_radius(radius_param)

--- a/app/form_models/jobseekers/subscription_form.rb
+++ b/app/form_models/jobseekers/subscription_form.rb
@@ -1,7 +1,7 @@
 class Jobseekers::SubscriptionForm < BaseForm
   attr_accessor :email, :frequency,
                 :keyword, :location, :radius,
-                :job_roles, :phases, :working_patterns,
+                :job_roles, :subjects, :phases, :working_patterns,
                 :job_role_options, :ect_suitable_options, :send_responsible_options,
                 :phase_options, :working_pattern_options
 
@@ -11,7 +11,7 @@ class Jobseekers::SubscriptionForm < BaseForm
   validate :unique_job_alert
   validate :location_and_one_other_criterion_selected
 
-  def initialize(params = {})
+  def initialize(params = {}) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
     search_criteria = params[:search_criteria]&.symbolize_keys || {}
 
     @email = params[:email]
@@ -19,6 +19,7 @@ class Jobseekers::SubscriptionForm < BaseForm
     @keyword = params[:keyword] || search_criteria[:keyword]
     @location = params[:location] || search_criteria[:location]
     @job_roles = params[:job_roles]&.reject(&:blank?) || search_criteria[:job_roles] || []
+    @subjects = params[:subjects]&.reject(&:blank?) || search_criteria[:subjects]
     @phases = params[:phases]&.reject(&:blank?) || search_criteria[:phases]
     @working_patterns = params[:working_patterns]&.reject(&:blank?) || search_criteria[:working_patterns]
 
@@ -40,6 +41,7 @@ class Jobseekers::SubscriptionForm < BaseForm
       location: location,
       radius: (@location.present? ? radius : nil),
       job_roles: job_roles,
+      subjects: subjects,
       phases: phases,
       working_patterns: working_patterns,
     }.compact.delete_if { |_k, v| v.blank? || v.empty? }
@@ -59,7 +61,7 @@ class Jobseekers::SubscriptionForm < BaseForm
 
   def location_and_one_other_criterion_selected
     errors.add(:base, I18n.t("subscriptions.errors.no_location_and_other_criterion_selected")) unless
-      location.present? && %i[keyword job_roles phases working_patterns].any? { |criterion| public_send(criterion).present? }
+      location.present? && %i[keyword job_roles subjects phases working_patterns].any? { |criterion| public_send(criterion).present? }
   end
 
   def unique_job_alert

--- a/app/presenters/subscription_presenter.rb
+++ b/app/presenters/subscription_presenter.rb
@@ -39,6 +39,8 @@ class SubscriptionPresenter < BasePresenter
       render_location_filter(value, search_criteria["radius"])
     when "job_roles"
       render_job_roles_filter(value)
+    when "subjects"
+      render_subjects_filter(value)
     when "working_patterns"
       render_working_patterns_filter(value)
     when "phases"
@@ -62,6 +64,10 @@ class SubscriptionPresenter < BasePresenter
 
   def render_job_roles_filter(value)
     { job_roles: value.map { |role| I18n.t("helpers.label.publishers_job_listing_job_details_form.job_roles_options.#{role}") }.join(", ") }
+  end
+
+  def render_subjects_filter(value)
+    { subjects: value.join(", ") }
   end
 
   def render_working_patterns_filter(value)

--- a/app/views/publishers/publisher_preferences/_form.html.slim
+++ b/app/views/publishers/publisher_preferences/_form.html.slim
@@ -11,7 +11,8 @@
       collection: current_organisation.schools.not_universities.not_closed.order(:name),
       value_method: :id,
       text_method: :name,
-      hint_method: :address
+      hint_method: :address,
+      options: { bold_items: true }
 
   - if current_organisation.schools_outside_local_authority.not_closed.any?
     = f.govuk_check_boxes_fieldset :school_ids_fieldset,
@@ -27,7 +28,8 @@
         collection: current_organisation.schools_outside_local_authority.not_closed.order(:name),
         value_method: :id,
         text_method: :name,
-        hint_method: :address
+        hint_method: :address,
+        options: { bold_items: true }
   - else
     h3.govuk-heading-s = t(".schools_out", organisation: current_organisation.name)
     p.govuk-body = t(".schools_out_hint_html", email: govuk_mail_to(t("help.email"), t("help.email")))

--- a/app/views/publishers/vacancies/build/job_details.html.slim
+++ b/app/views/publishers/vacancies/build/job_details.html.slim
@@ -45,17 +45,18 @@
           span.govuk-hint#publishers-job-listing-job-details-form-subjects-hint
             = t("helpers.hint.publishers_job_listing_job_details_form.subjects")
 
-          div class="govuk-!-margin-bottom-6"
-            = render SearchableCollectionComponent.new form: f,
-              input_type: :checkbox,
-              label_text: "search subjects",
-              threshold: 10,
-              scrollable: true,
-              attribute_name: :subjects,
-              collection: SUBJECT_OPTIONS,
-              value_method: :first,
-              text_method: :first,
-              hint_method: :last
+            div class="govuk-!-margin-bottom-6"
+              = render SearchableCollectionComponent.new form: f,
+                input_type: :checkbox,
+                label_text: "search subjects",
+                threshold: 10,
+                scrollable: true,
+                attribute_name: :subjects,
+                collection: SUBJECT_OPTIONS,
+                value_method: :first,
+                text_method: :first,
+                hint_method: :last,
+                options: { bold_items: true }
 
       = render "publishers/vacancies/vacancy_form_partials/submit", f: f
 

--- a/app/views/publishers/vacancies/build/schools.html.slim
+++ b/app/views/publishers/vacancies/build/schools.html.slim
@@ -25,6 +25,7 @@
           value_method: :id,
           text_method: :name,
           hint_method: :address,
+          options: { bold_items: true },
           classes: "govuk-!-margin-top-4"
 
       div class="govuk-!-margin-top-6"

--- a/app/views/subscriptions/_fields.html.slim
+++ b/app/views/subscriptions/_fields.html.slim
@@ -9,6 +9,19 @@
   = filters(form: f,
     options: { remove_buttons: false }) do |filters_component|
       - filters_component.group key: "job_roles", component: f.govuk_collection_check_boxes(:job_roles, @form.job_role_options, :first, :last, small: false, legend: { text: t("jobs.filters.job_roles") }, hint: nil)
+      - if current_variant?(:"2022_01_subjects_filters_test", :subjects_filters) || @form.subjects&.any?
+        - filters_component.group key: "subjects", title: t("jobs.filters.subject"), component: searchable_collection(form: f,
+                                                                                                                      input_type: :checkbox,
+                                                                                                                      attribute_name: :subjects,
+                                                                                                                      collection: SUBJECT_OPTIONS,
+                                                                                                                      value_method: :first,
+                                                                                                                      text_method: :first,
+                                                                                                                      hint_method: :last,
+                                                                                                                      threshold: 10,
+                                                                                                                      label_text: "Subject",
+                                                                                                                      small: false,
+                                                                                                                      scrollable: true,
+                                                                                                                      options: { bold_items: false, heading: t("jobs.filters.subject") })
       - filters_component.group key: "ect_suitable", component: f.govuk_collection_check_boxes(:job_roles, @form.ect_suitable_options, :first, :last, small: false, legend: { text: t("jobs.filters.ect_suitable") }, hint: nil)
       - filters_component.group key: "send_responsible", component: f.govuk_collection_check_boxes(:job_roles, @form.send_responsible_options, :first, :last, small: false, legend: { text: t("jobs.filters.send_responsible") }, hint: nil)
       - filters_component.group key: "education_phase", component: f.govuk_collection_check_boxes(:phases, @form.phase_options, :first, :last, small: false, legend: { text: t("jobs.filters.phases") }, hint: nil)

--- a/app/views/vacancies/_filters.html.slim
+++ b/app/views/vacancies/_filters.html.slim
@@ -42,6 +42,18 @@ ruby:
     },
   ]
 
+    subject_filters =
+      {
+        legend: t("jobs.filters.subject"),
+        key: "subjects",
+        selected: @form.subjects,
+        options: SUBJECT_OPTIONS,
+        value_method: :first,
+        selected_method: :first,
+      }
+
+  filter_types.insert(1, subject_filters) if current_variant?(:"2022_01_subjects_filters_test", :subjects_filters)
+
 = filters(form: f,
   filters: { total_count: @form.total_filters },
   options: { heading_text: "Filter results", remove_buttons: true },
@@ -49,8 +61,22 @@ ruby:
     - filters_component.remove_buttons do |rb|
       - filter_types.each do |filter_type|
         - rb.group(**filter_type)
-
     - filters_component.group key: "job_roles", component: f.govuk_collection_check_boxes(:job_roles, @form.job_role_options, :first, :last, small: true, legend: { text: t("jobs.filters.job_roles") }, hint: nil, form_group: { data: { action: "change->form#submitListener" } })
+    - if current_variant?(:"2022_01_subjects_filters_test", :subjects_filters)
+      - filters_component.group key: "subjects", title: t("jobs.filters.subject"), component: searchable_collection(form: f,
+                                                                                                                    input_type: :checkbox,
+                                                                                                                    attribute_name: :subjects,
+                                                                                                                    collection: SUBJECT_OPTIONS,
+                                                                                                                    value_method: :first,
+                                                                                                                    text_method: :first,
+                                                                                                                    hint_method: :last,
+                                                                                                                    threshold: 10,
+                                                                                                                    label_text: "Subject",
+                                                                                                                    border: false,
+                                                                                                                    small: true,
+                                                                                                                    scrollable: true,
+                                                                                                                    form_group: { data: { action: "change->form#submitListener" } },
+                                                                                                                    options: { bold_items: false, heading: t("jobs.filters.subject") })
     - filters_component.group key: "ect_suitable", component: f.govuk_collection_check_boxes(:job_roles, @form.ect_suitable_options, :first, :last, small: true, legend: { text: t("jobs.filters.ect_suitable") }, hint: nil, form_group: { data: { action: "change->form#submitListener" } })
     - filters_component.group key: "send_responsible", component: f.govuk_collection_check_boxes(:job_roles, @form.send_responsible_options, :first, :last, small: true, legend: { text: t("jobs.filters.send_responsible") }, hint: nil, form_group: { data: { action: "change->form#submitListener" } })
     - filters_component.group key: "education_phase", component: f.govuk_collection_check_boxes(:phases, @form.phase_options, :first, :last, small: true, legend: { text: t("jobs.filters.phases") }, hint: nil, form_group: { data: { action: "change->form#submitListener" } })

--- a/config/ab_tests.yml
+++ b/config/ab_tests.yml
@@ -33,6 +33,9 @@ shared:
   2022_01_homepage_quick_links_test:
     without_quick_links: 1
     with_quick_links: 1
+  2022_01_subjects_filters_test:
+    default: 1
+    subjects_filters: 1
 test:
   2021_04_cookie_consent_test:
     none: 0
@@ -44,3 +47,6 @@ test:
   2022_01_homepage_quick_links_test:
     without_quick_links: 1
     with_quick_links: 0
+  2022_01_subjects_filters_test:
+    default: 1
+    subjects_filters: 0

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -19,6 +19,7 @@ en:
       send_responsible: SEND responsibilities
       send_responsible_option: Has SEND responsibilities (special educational needs and disabilities)
       send_responsible_only: Only show results with SEND responsibilities
+      subject: Subject
       phases: Education phase
       working_patterns: Working pattern
 

--- a/spec/components/searchable_collection_component_spec.rb
+++ b/spec/components/searchable_collection_component_spec.rb
@@ -1,9 +1,13 @@
 require "rails_helper"
 
 RSpec.describe SearchableCollectionComponent, type: :component do
-  let(:form) { instance_double(GOVUKDesignSystemFormBuilder::FormBuilder) }
+  let(:subject) { described_class.new(**base.merge!(options)) }
 
+  let(:form) { instance_double(GOVUKDesignSystemFormBuilder::FormBuilder) }
   let(:collection) { [1, 2, 3, 4, 5].freeze }
+  let(:options) { { threshold: 10, input_type: :radio_button } }
+
+  let(:inline_component) { render_inline(subject) }
 
   before do
     allow(form).to receive(:govuk_collection_radio_buttons)
@@ -13,7 +17,6 @@ RSpec.describe SearchableCollectionComponent, type: :component do
   let(:base) do
     {
       form: form,
-      input_type: input_type,
       label_text: "search colllection",
       attribute_name: :attributes,
       collection: collection,
@@ -28,38 +31,23 @@ RSpec.describe SearchableCollectionComponent, type: :component do
   it_behaves_like "a component that accepts custom classes"
   it_behaves_like "a component that accepts custom HTML attributes"
 
-  context "when using an item threshold of higher than collection size" do
-    let(:input_type) { :radio_button }
-    let(:options) { { threshold: 10 } }
-    let(:radio_collection) { described_class.new(**base.merge(options)) }
-
-    let!(:inline_component) { render_inline(radio_collection) }
-
+  context "when providing an item threshold higher in number than the collection size" do
     it "is not searchable" do
-      expect(radio_collection.searchable).to be_falsey
+      expect(subject.searchable?).to be_falsey
       expect(inline_component.css(".searchable-collection-component__search")).to be_blank
       expect(inline_component.css(".searchable-collection-component--border")).to be_blank
     end
 
-    it "has large collection items" do
-      expect(radio_collection.small).to be_falsey
-    end
-
     it "is not scrollable" do
-      expect(radio_collection.scrollable).to be_falsey
+      expect(subject.scrollable).to be_falsey
     end
   end
 
   context "when using an item threshold of lower or equal than collection size" do
-    let(:input_type) { :checkbox }
-    let(:options) { { threshold: 5 } }
-
-    let(:checkbox_collection) { described_class.new(**base.merge(options)) }
-
-    let!(:inline_component) { render_inline(checkbox_collection) }
+    let(:options) { { threshold: collection.size, input_type: :checkbox } }
 
     it "is searchable" do
-      expect(checkbox_collection.searchable).to be_truthy
+      expect(subject.searchable?).to be_truthy
       expect(inline_component.css(".searchable-collection-component__search").count).to eq(1)
       expect(inline_component.css(".searchable-collection-component--border").count).to eq(1)
     end
@@ -68,12 +56,56 @@ RSpec.describe SearchableCollectionComponent, type: :component do
       expect(inline_component.css(".searchable-collection-component__search-input").attribute("aria-label").value).to eq("search colllection")
     end
 
-    it "has small collection items" do
-      expect(checkbox_collection.small).to be_truthy
+    it "is scrollable" do
+      expect(subject.scrollable).to be_truthy
+    end
+  end
+
+  context "when the size of the collection items required has not been not specified" do
+    before { allow(subject).to receive(:searchable?).and_return(false) }
+
+    it "sets small to nil" do
+      expect(subject.small).to be_nil
     end
 
-    it "is scrollable" do
-      expect(checkbox_collection.scrollable).to be_truthy
+    it "sets the size of the collection items to the value returned by #searchable?" do
+      expect(subject.small_items?).to eq(false)
+    end
+  end
+
+  context "when the size of the collection items required is specified" do
+    context "when small is true" do
+      before { options.merge!(small: true) }
+
+      it "sets the size of the collection items to be small" do
+        expect(subject.small_items?).to be_truthy
+      end
+    end
+
+    context "when small is false" do
+      before { options.merge!(small: false) }
+
+      it "sets the size of the collection items to be large" do
+        expect(subject.small_items?).to be_falsey
+      end
+    end
+  end
+
+  context "when the input type provided is :radio_button" do
+    it "renders a collection of radio buttons" do
+      expect(form).to receive(:govuk_collection_radio_buttons)
+
+      render_inline(subject)
+    end
+  end
+
+  context "when the input type provided is :checkbox" do
+    before { options.merge!(input_type: :checkbox) }
+
+    it "renders a collection of checkboxes" do
+      expect(form).to receive(:govuk_collection_check_boxes)
+
+      render_inline(subject)
     end
   end
 end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3752

## Changes in this PR:

The changes I've made feel a bit messy, but given the fact that this is for an A:B test, I think it's fine. What are your thoughts?

The SearchableCollectionComponent is used in the following places:
- `app/components/filters_component/filters_component.html.slim`
- `app/views/publishers/publisher_preferences/_form.html.slim`
- `app/views/publishers/vacancies/build/job_details.html.slim`
- `app/views/publishers/vacancies/build/schools.html.slim`

In some cases, the collection items are bold. I have tried to make sure they are still bold.

### Bold
- `app/views/publishers/publisher_preferences/_form.html.slim`

<img width="1075" alt="Screenshot 2022-02-07 at 12 20 29" src="https://user-images.githubusercontent.com/30624173/152787438-cbd572a1-93e0-47bb-bb97-7ae79941f5ef.png">

- `app/views/publishers/vacancies/build/schools.html.slim`

![Screenshot 2022-02-07 at 12 24 30](https://user-images.githubusercontent.com/30624173/152787608-bcd7c8ad-2b53-47f5-aec4-ae1b65827c0e.png)

- `app/views/publishers/vacancies/build/job_details.html.slim`

![Screenshot 2022-02-07 at 12 30 10](https://user-images.githubusercontent.com/30624173/152788456-d216b7a7-4680-48fa-9038-69a67a047c83.png)

## Subject Filters Variant

### Search Form

![Screenshot 2022-02-07 at 12 37 33](https://user-images.githubusercontent.com/30624173/152789423-6430d6af-e48f-4eb2-9884-374a9d5e519a.png)

### Job Alert Form

![Screenshot 2022-02-07 at 12 38 11](https://user-images.githubusercontent.com/30624173/152789514-7747c827-b0bb-44b6-82f9-74c7bac97220.png)

### Test Variant URLs

- `/subscriptions/new?ab_test_override[2022_01_subjects_filters_test]=subjects_filters `

- `/jobs?ab_test_override[2022_01_subjects_filters_test]=subjects_filters&keyword=&location=`