### PR TITLE
Split up `VacanciesController#index`

### DIFF
--- a/app/components/panel_component/panel.scss
+++ b/app/components/panel_component/panel.scss
@@ -1,6 +1,7 @@
 @import 'base_component';
 
-.vacancies_index {
+.vacancies_index,
+.vacancies_index_landing {
   .search-controls {
     .search-controls__panel {
       border-bottom: 1px solid $govuk-border-colour;

--- a/app/frontend/src/styles/application.scss
+++ b/app/frontend/src/styles/application.scss
@@ -114,7 +114,8 @@ dd {
   background-color: govuk-colour('light-grey');
 }
 
-.vacancies_index {
+.vacancies_index,
+.vacancies_index_landing {
 
   @media only screen and (min-width: $small-screen) {
     .grid-row {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -228,7 +228,7 @@ Rails.application.routes.draw do
       to: redirect { |params| "/teaching-jobs-#{params[:not_normalized].parameterize.dasherize}" },
       constraints: ->(request) { request.params[:not_normalized] != request.params[:not_normalized].parameterize.dasherize }
 
-  with_options(to: "vacancies#index") do
+  with_options(to: "vacancies#index_landing") do
     # If parameters are used that are the same as those in the search form, pagination with kaminari will break
     get "teaching-jobs-in-:location_facet",
         as: :location,


### PR DESCRIPTION
This is in preparation for reworking the landing pages. The current
landing pages are handled as special cases of a regular search, which
has turned out to be an overly leaky abstraction.

- Split out `VacanciesController#index` into `#index` (for
  user-initiated searches) and `#index_landing` (for landing pages)
- Stop rewriting Rails's request parameters and override `search_params`
  instead for landing pages