### PR TITLE
use re-usable action

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -1,27 +1,27 @@
-name: Deploy App to Environment
+name: deploy workflow
+description: deploy's application
 
-on:
-  workflow_dispatch:
-    inputs:
-      environment:
-        description: Environment
-        required: true
-      tag:
-        description: Docker tag
-        required: true
-      pr_id:
-        description: Pull Request
-        required: false
+inputs:
+  environment:
+    description: Environment
+    required: true
+  tag:
+    description: Docker tag
+    required: true
+  pr_id:
+    description: Pull Request
+    required: false
+  aws-access-key-id:
+    description: AWS-ID
+    required: true
+  aws-secret-access-key:
+    description: AWS-KEY
+    required: true
 
-env:
- DOCKER_REPOSITORY: ghcr.io/dfe-digital/teaching-vacancies
 
-jobs:
-
-  deploy-app:
-    name: Deploy ${{ github.event.inputs.tag }} to ${{ github.event.inputs.environment }}
-    runs-on: ubuntu-20.04
-    steps:
+runs:
+  using: composite
+  steps:
 
     - uses: actions/checkout@v2
       name: Checkout Code
@@ -29,8 +29,8 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
         aws-region: eu-west-2
         role-to-assume: Deployments
         role-duration-seconds: 3600
@@ -42,21 +42,23 @@ jobs:
         terraform_version: 1.0.8
 
     - name: Set environment variables for review
-      if: startsWith(github.event.inputs.environment, 'review')
+      if: startsWith( inputs.environment, 'review')
+      shell: bash
       run: |
         PARAMETER_STORE_ENVIRONMENT=dev
-        TF_VAR_environment=${{ github.event.inputs.environment }}
+        TF_VAR_environment=${{ inputs.environment }}
         echo "DEPLOY_ENV=review" >> $GITHUB_ENV
-        pr_id=${{ github.event.inputs.pr_id }}
+        pr_id=${{ inputs.pr_id }}
         echo "pr_id=${pr_id}" >> $GITHUB_ENV
         echo "PARAMETER_STORE_ENVIRONMENT=${PARAMETER_STORE_ENVIRONMENT}" >> $GITHUB_ENV
         echo "TF_VAR_environment=${TF_VAR_environment}" >> $GITHUB_ENV
 
     - name: Set environment variables for non-review environments
-      if: startsWith(github.event.inputs.environment, 'review') != true
+      if: startsWith(inputs.environment, 'review') != true
+      shell: bash
       run: |
-        PARAMETER_STORE_ENVIRONMENT=${{ github.event.inputs.environment }}
-        DEPLOY_ENV=${{ github.event.inputs.environment }}
+        PARAMETER_STORE_ENVIRONMENT=${{ inputs.environment }}
+        DEPLOY_ENV=${{ inputs.environment }}
         echo "PARAMETER_STORE_ENVIRONMENT=${PARAMETER_STORE_ENVIRONMENT}" >> $GITHUB_ENV
         echo "DEPLOY_ENV=${DEPLOY_ENV}" >> $GITHUB_ENV
         CONFIRM_PRODUCTION=YES
@@ -82,5 +84,7 @@ jobs:
           && echo Data in "/teaching-vacancies/${{ env.PARAMETER_STORE_ENVIRONMENT }}" looks valid
 
     - name: Deploy to environment
+      id: deployment-conclusion
+      shell: bash
       run: |
-        make ${{ env.DEPLOY_ENV }} ci tag=${{ github.event.inputs.tag }} terraform-app-apply
+        make ${{ env.DEPLOY_ENV }} ci tag=${{ inputs.tag }} terraform-app-apply

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -1,0 +1,38 @@
+name: smoke-test action
+description: smoke test application
+
+inputs:
+  paas_environment:
+    description: Environment
+    required: true
+  event_name:
+    description: type of event that triggred the smoke test
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Prepare application environment
+      uses: ./.github/actions/prepare-app-env
+
+    - name: set environment (scheduled smoke test)
+      shell: bash
+      if: ${{ inputs.event_name == 'schedule' }}
+      run: echo "PAAS_ENVIRONMENT=production" >> $GITHUB_ENV
+
+    - name: set environment (workflow dispatch)
+      shell: bash
+      if: ${{ inputs.event_name != 'schedule' }}
+      run: |
+        echo "PAAS_ENVIRONMENT=${{ inputs.paas_environment }}" >> $GITHUB_ENV
+
+    - name: Run deployment smoke test
+      shell: bash
+      run:  bundle exec rspec spec/smoke_tests/jobseekers_can_view_homepage_spec.rb --tag smoke_test
+
+    - name: print environment
+      shell: bash
+      run: echo ${{ env.PAAS_ENVIRONMENT}}

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -237,26 +237,18 @@ jobs:
         ENVIRONMENT=review-pr-${{ github.event.number }}
         echo "ENVIRONMENT=${ENVIRONMENT}" >> $GITHUB_ENV
 
-    - name: Trigger Deploy App Workflow for ${{ env.ENVIRONMENT }}
-      uses: benc-uk/workflow-dispatch@v1.1
+    - name: Deploy App to ${{ env.ENVIRONMENT }} environment
+      id: deploy_app_to_env
+      uses: ./.github/actions/deploy/
       with:
-        workflow: Deploy App to Environment   # Name of the triggered workflow
-        token: ${{ env.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
-        ref: ${{ env.BUILD_GIT_TAG }}         # Different than branch HEAD SHA in case of a PR
-        inputs: '{"environment": "${{ env.ENVIRONMENT }}", "tag": "${{ env.DOCKER_IMAGE_TAG }}", "pr_id": "${{ github.event.number }}" }'
-
-    - name: Wait for Deploy App Workflow for ${{ env.ENVIRONMENT }}
-      id: wait_for_deploy_app
-      uses: fountainhead/action-wait-for-check@v1.0.0
-      with:
-        token: ${{ env.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
-        checkName: Deploy ${{ env.DOCKER_IMAGE_TAG }} to ${{ env.ENVIRONMENT }} # Job name within triggered workflow
-        ref: ${{ env.BUILD_GIT_TAG }}
-        timeoutSeconds: 1200
-        intervalSeconds: 14
+        environment: ${{ env.ENVIRONMENT }}
+        tag: ${{ env.DOCKER_IMAGE_TAG }}
+        pr_id: ${{ github.event.number }}
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
     - name: Notify twd_tv_dev channel on ${{ env.ENVIRONMENT }} deployment failure
-      if: steps.wait_for_deploy_app.outputs.conclusion != 'success'
+      if: steps.deploy_app_to_env.conclusion != 'success'
       uses: rtCamp/action-slack-notify@v2.2.0
       env:
         SLACK_CHANNEL: twd_tv_dev
@@ -266,29 +258,18 @@ jobs:
         SLACK_WEBHOOK: ${{env.SLACK_WEBHOOK}}
 
     - name: Exit whole workflow if ${{ env.ENVIRONMENT }} deployment was not successful
-      if: steps.wait_for_deploy_app.outputs.conclusion != 'success'
+      if: steps.deploy_app_to_env.conclusion != 'success'
       run: exit 1
 
-    - name: Trigger Smoke Test
-      uses: benc-uk/workflow-dispatch@v1.1
+    - name: Trigger Smoke Test action
+      id: smoke-test
+      uses: ./.github/actions/smoke-test/
       with:
-        workflow: Smoke Test
-        token: ${{ env.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
-        inputs: '{"paas_environment": "${{ env.ENVIRONMENT }}", "sha": "${{ env.COMMIT_SHA }}"}'
-        ref: ${{ env.BUILD_GIT_TAG }}
-
-    - name: Wait for smoke test
-      id: wait_for_smoke_test
-      uses: fountainhead/action-wait-for-check@v1.0.0
-      with:
-        token: ${{ env.GIT_HUB_SERVICE_ACCOUNT_TOKEN }}
-        checkName: Smoke Test ${{ env.ENVIRONMENT }} ${{ env.COMMIT_SHA }}
-        ref: ${{ env.BUILD_GIT_TAG }}
-        timeoutSeconds: 300
-        intervalSeconds: 15
+        paas_environment: ${{ env.ENVIRONMENT }}
+        event_name: ${{ github.event_name }}
 
     - name: Exit whole workflow if ${{ env.ENVIRONMENT }} smoke test was not successful
-      if: steps.wait_for_smoke_test.outputs.conclusion != 'success'
+      if: steps.smoke-test.conclusion != 'success'
       run: exit 1
 
     - name: Post sticky pull request comment

--- a/.github/workflows/deploy_app_via_workflow_dispatch.yml
+++ b/.github/workflows/deploy_app_via_workflow_dispatch.yml
@@ -1,0 +1,39 @@
+name: Deploy App via workflow Dispatch
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Environment
+        required: true
+      tag:
+        description: Docker tag
+        required: true
+      pr_id:
+        description: Pull Request
+        required: false
+      aws-access-key-id:
+        description: AWS-ID
+        required: true
+      aws-secret-access-key:
+        description: AWS-KEY
+        required: true
+
+env:
+ DOCKER_REPOSITORY: ghcr.io/dfe-digital/teaching-vacancies
+
+jobs:
+
+  deploy-app:
+    name: Deploy ${{ github.event.inputs.tag }} to ${{ github.event.inputs.environment }}
+    runs-on: ubuntu-20.04
+    steps:
+
+    - name: Deploy App to ${{ env.ENVIRONMENT }} environment
+      uses: ./.github/actions/deploy/
+      with:
+        environment: ${{ env.ENVIRONMENT }}
+        tag: ${{ env.DOCKER_IMAGE_TAG }}
+        pr_id: ${{ github.event.number }}
+        aws-access-key-id: ${{ inputs.aws-access-key-id}}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,67 +1,29 @@
-name: Smoke Test
+name: Smoke Test workflow
 
 on:
   schedule:
     - cron: '*/5 * * * *'
-  workflow_dispatch:
-    inputs:
-      sha:
-        description: GitHub SHA
-        required: true
-      paas_environment:
-        default: 'production'
-        required: true
-        description: Environment to test
 
 jobs:
   smoke-test:
-
-    name: Smoke Test ${{ github.event.inputs.paas_environment }} ${{ github.event.inputs.sha }}
-
-    runs-on: ubuntu-20.04
-
+    name: Smoke Test Production
     env:
       RAILS_ENV: test
+    runs-on: ubuntu-20.04
     steps:
+
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+      - name: Trigger Smoke Test action
+        id: smoke-test
+        uses: ./.github/actions/smoke-test/
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-2
-          role-to-assume: Deployments
-          role-duration-seconds: 3600
-          role-skip-session-tagging: true
-
-      - name: Get SLACK_WEBHOOK From ParameterStore
-        uses: marvinpinto/action-inject-ssm-secrets@latest
-        with:
-          ssm_parameter: /teaching-vacancies/github_action/infra/slack_webhook
-          env_variable_name: SLACK_WEBHOOK
-
-      - name: Prepare application environment
-        uses: ./.github/actions/prepare-app-env
-
-      - name: set environment (scheduled smoke test)
-        if: ${{ github.event_name == 'schedule' }}
-        run: echo "PAAS_ENVIRONMENT=production" >> $GITHUB_ENV
-
-      - name: set environment (workflow dispatch)
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          echo "PAAS_ENVIRONMENT=${{ github.event.inputs.paas_environment }}" >> $GITHUB_ENV
-
-      - name: Run deployment smoke test
-        run:  bundle exec rspec spec/smoke_tests/jobseekers_can_view_homepage_spec.rb --tag smoke_test
-
-      - name: print environment
-        run: echo ${{ env.PAAS_ENVIRONMENT}}
+          paas_environment: 'production'
+          event_name: ${{ github.event_name }}
 
       - name: Slack notification
-        if: failure()
+        if: steps.smoke-test.conclusion != 'success'
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_CHANNEL: twd_tv_dev


### PR DESCRIPTION
## Jira ticket URL

- Just add the ticket number to the end:

https://dfedigital.atlassian.net/browse/TEVA-3771

## Changes in this PR:

We used third party action such as benc-uk/workflow-dispatch@v1.1, to trigger `workflow dispatch` event on some workflows
since then, GitHub Action has become matured and has introduced features such as re-usable actions with inputs. This means
we can do away with `benc-uk/workflow-dispatch@v1.1` and redesign the workflow such that `re-usable actions` now acts like
a `method` with inputs from the calling workflow; and with the desired logic to execute.