### PR TITLE
[TEVA-3838] Fix name method bug

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -22,7 +22,7 @@ class Organisation < ApplicationRecord
   end
 
   def name
-    @name ||= read_attribute(:name)&.concat(local_authority? ? " local authority" : "")
+    local_authority? ? "#{read_attribute(:name)} local authority" : read_attribute(:name)
   end
 
   def schools_outside_local_authority


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3838

## Changes in this PR:

This PR fixes the bug causing "local authority" to be added to the end of a local authority name and then persisted in the database.
