### PR TITLE
Anonymise ID for location_polygons when streaming

### DIFF
--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -49,6 +49,8 @@ shared:
     - id
     - publisher_preference_id
     - school_id
+  location_polygons:
+    - id
   notifications:
     - id
     - recipient_id


### PR DESCRIPTION
## Jira ticket URL

n/a

## Changes in this PR:

- Anonymise ID for location_polygons when streaming entity events to BigQuery

## Next steps:

- Delete all existing location polygon entity data from events table in BigQuery
- Re-touch all location polygons in database to trigger update events to be streamed to BigQuery
