### PR TITLE
[TEVA-3786] Remove hint styling from job details text

### DIFF
--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -66,7 +66,7 @@ class VacancyPresenter < BasePresenter
 
   def show_working_patterns
     if model.working_patterns_details?
-      safe_join([working_patterns, tag.br, tag.span(model.working_patterns_details, class: "govuk-hint govuk-!-margin-bottom-0")])
+      safe_join([working_patterns, tag.br, tag.span(model.working_patterns_details, class: "govuk-!-margin-bottom-0")])
     else
       working_patterns
     end
@@ -81,7 +81,7 @@ class VacancyPresenter < BasePresenter
     #       and once people no longer need to view the legacy vacancies for reference.
     return show_job_roles unless main_job_role
 
-    safe_join [show_main_job_role, tag.br, model.additional_job_roles.map { |role| greyed_additional_job_role(role) }]
+    safe_join [show_main_job_role, tag.br, model.additional_job_roles.map { |role| tag.span additional_job_role(role), class: "govuk-!-margin-bottom-0" }]
   end
 
   def show_main_job_role
@@ -124,10 +124,6 @@ class VacancyPresenter < BasePresenter
   end
 
   private
-
-  def greyed_additional_job_role(role)
-    tag.span additional_job_role(role), class: "govuk-hint govuk-!-margin-bottom-0"
-  end
 
   def fix_bullet_points(text)
     # This is a band-aid solution for the problem where (particularly) job adverts contain bullet point characters

--- a/spec/presenters/vacancy_presenter_spec.rb
+++ b/spec/presenters/vacancy_presenter_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe VacancyPresenter do
       it "returns a string containing the working pattern and working_patterns_details" do
         expect(subject.show_working_patterns).to eq(safe_join([subject.working_patterns,
                                                                tag.br,
-                                                               tag.span(subject.working_patterns_details, class: "govuk-hint govuk-!-margin-bottom-0")]))
+                                                               tag.span(subject.working_patterns_details, class: "govuk-!-margin-bottom-0")]))
       end
     end
   end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3786

## Changes in this PR:

This PR changes the text colour of the additional _Job role_ and _Working patterns_ text in the _Job details_ section of a job listing.

## Screenshots of UI changes:

### Before
<img width="816" alt="image" src="https://user-images.githubusercontent.com/24639777/153446799-fc17c7bd-c69d-43bb-bcc2-f4493d31e291.png">

### After

<img width="831" alt="image" src="https://user-images.githubusercontent.com/24639777/153448409-d2d87439-dd8a-4871-8bc2-ef3b709d1934.png">
