### PR TITLE
[TEVA-3854] Add teaching assistant hint text

### DIFF
--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -235,6 +235,7 @@ en:
           leadership: Includes Deputy/Assistant Head, Headteacher, and trust-level roles
           education_support: Includes learning support and tutors
           sendco: Special educational needs and disabilities coordinator
+          teaching_assistant: Includes Higher Level Teaching Assistants (HLTAs) and SEND teaching assistants
       publishers_job_listing_job_role_details_form:
         additional_job_roles: Select all that apply
       publishers_job_listing_job_summary_form:


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3854

## Changes in this PR:

Add hint text to teaching assistant job role option in create a job journey

## Screenshots of UI changes:

### Before
<img width="825" alt="image" src="https://user-images.githubusercontent.com/24639777/153461194-a7ed2aaa-7dba-4417-95fa-384f2f719ec1.png">

### After
<img width="838" alt="image" src="https://user-images.githubusercontent.com/24639777/153461131-5f3e5b97-5eaa-42c9-8f06-34f13e5cc310.png">