### PR TITLE
Allow filters content to be passed in slots

### DIFF
--- a/app/components/filters_component.rb
+++ b/app/components/filters_component.rb
@@ -1,34 +1,57 @@
 class FiltersComponent < GovukComponent::Base
-  attr_accessor :filters, :form, :items, :options
+  attr_accessor :filters, :form, :options
 
   def self.variants
     %w[default]
   end
 
-  def initialize(filters:, form:, items:, options:, classes: [], html_attributes: {})
+  def initialize(form:, options:, filters: {}, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
 
     @filters = filters
     @form = form
-    @items = items
     @options = options
   end
 
-  def render?
-    filters.present?
+  renders_many :groups, lambda { |key:, component:|
+    tag.div(key, class: "filters-component__groups__group", data: { group: key }) do
+      tag.div(component)
+    end
+  }
+
+  renders_one :remove_buttons, "RemoveButtons"
+
+  class RemoveButtons < ApplicationComponent
+    def initialize(classes: [], html_attributes: {})
+      super(classes: classes, html_attributes: html_attributes)
+    end
+
+    renders_many :groups, lambda { |selected:, key:, options:, value_method:, selected_method:, legend: false|
+      if selected&.any?
+        safe_join([
+          tag.h4(legend, class: "govuk-heading-s"),
+          tag.ul(class: "filters-component__remove-tags") do
+            options.collect do |option|
+              next unless selected.include?(option.public_send(value_method))
+
+              concat(tag.li do
+                tag.button(class: "filters-component__remove-tags__tag icon icon--left icon--cross", data: { group: key, key: option.public_send(value_method) }) do
+                  safe_join([tag.span(t("shared.filter_group.remove_filter_hidden"), class: "govuk-visually-hidden"),
+                             option.public_send(selected_method)])
+                end
+              end)
+            end
+          end,
+        ])
+      end
+    }
   end
 
   def display_remove_buttons?
-    filters[:total_count].positive? && options[:remove_buttons]
-  end
-
-  def mobile_modifier(selector)
-    options[:mobile_variant] ? "#{selector}--mobile" : selector
+    options[:remove_buttons] && filters[:total_count]&.positive?
   end
 
   def default_classes
-    ["filters-component"].tap do |applied_classes|
-      applied_classes.push(mobile_modifier("filters-component")) if options[:mobile_variant]
-    end
+    %w[filters-component]
   end
 end

--- a/app/components/filters_component/filters_component.html.slim
+++ b/app/components/filters_component/filters_component.html.slim
@@ -5,43 +5,22 @@
       - if options[:publisher_preference]
         = govuk_link_to t(".add_or_remove_schools"), edit_publisher_preference_path(options[:publisher_preference]), class: "filters-component__link-button add-remove-schools govuk-link--no-visited-state govuk-!-margin-bottom-4"
       - elsif options[:heading_text]
-        h2.govuk-heading-m class="govuk-!-margin-bottom-4"
+        h2.govuk-heading-m
           = options[:heading_text]
 
   - if display_remove_buttons?
     .filters-component__remove
-      .filters-component-filter__selected
-        .filters-component__section-heading
-          .govuk-body class="govuk-!-margin-bottom-0"
-            = t("shared.filter_group.current_selected_filters")
-          button.filters-component__link-button.govuk-body.govuk-link id="filters-component-clear-all"
-            = t("shared.filter_group.clear_all_filters")
+      .filters-component__remove__heading
+        .govuk-body class="govuk-!-margin-bottom-0"
+          = t("shared.filter_group.current_selected_filters")
+        button.filters-component__link-button.govuk-body.govuk-link id="filters-component-clear-all"
+          = t("shared.filter_group.clear_all_filters")
 
-        - items.each do |group|
-          - if group[:selected]&.any?
-            .govuk-heading-s class="govuk-!-margin-bottom-0 govuk-!-font-weight-bold"
-              = group[:title]
-
-          ul.filters-component__remove-tags
-            - group[:options].each do |tag|
-              - if group[:selected]&.include?(tag.send(group[:value_method]))
-                li
-                  button.filters-component__remove-tags__tag.icon.icon--left.icon--cross data-group=group[:key] data-key=tag.send(group[:value_method])
-                    span.govuk-visually-hidden
-                      = t("shared.filter_group.remove_filter_hidden")
-                    = tag.send(group[:selected_method])
+      = remove_buttons
 
   .filters-component__groups
-    - items.each do |group|
-      .filters-component__groups__group class="#{"small" if group[:small]}" data-group=group[:key]
-        = form.govuk_collection_check_boxes group[:attribute],
-          group[:options],
-          group[:value_method],
-          group[:text_method],
-          small: group[:small],
-          legend: { text: group[:legend], size: (group[:small] ? "s" : "m") },
-          hint: nil,
-          form_group: (options[:autosubmit_form] ? { data: { action: "change->form#submitListener" } } : {})
+    - groups.each do |group|
+      = group
 
   .filters-component__submit
     = form.govuk_submit t("buttons.apply_filters"), classes: "govuk-!-margin-top-4 govuk-!-margin-bottom-2 filters-component__submit-button"

--- a/app/components/filters_component/filters_component.scss
+++ b/app/components/filters_component/filters_component.scss
@@ -17,7 +17,7 @@
     padding: 0;
     position: absolute;
     right: 0;
-    top: 0;
+    top: 2px;
 
     span {
       line-height: 1em;
@@ -29,6 +29,10 @@
     &__container {
       position: relative;
 
+      .govuk-heading-m {
+        margin-bottom: govuk-spacing(2);
+      }
+
       .govuk-heading-s {
         margin-bottom: govuk-spacing(2);
       }
@@ -38,23 +42,25 @@
   &__remove {
     box-shadow: none;
     padding: govuk-spacing(1) 0;
+    position: relative;
 
     @include govuk-media-query($until: desktop) {
       display: none;
     }
 
-    .filters-component-filter__selected {
-      box-shadow: none;
-      position: relative;
-    }
-
     .govuk-heading-s {
       font-size: 1rem;
+      margin-bottom: 0;
+      margin-top: govuk-spacing(4);
     }
 
     .govuk-body {
       font-size: 1rem;
       font-weight: normal;
+    }
+
+    &__heading {
+      margin-bottom: govuk-spacing(2);
     }
 
     &-tags {
@@ -106,11 +112,6 @@
   &__groups {
     padding: govuk-spacing(1) 0;
 
-    .govuk-accordion__section-button {
-      font-size: 1.2rem;
-      padding: 0 0 govuk-spacing(1) 0;
-    }
-
     .govuk-form-group {
       margin-bottom: govuk-spacing(2);
     }
@@ -123,25 +124,16 @@
 
     &__group {
       border-bottom: 1px solid govuk-colour('mid-grey');
-      margin-bottom: govuk-spacing(7);
+      margin-bottom: govuk-spacing(5);
 
       &:last-of-type {
         border-bottom: 0;
-      }
-
-      &.small {
-        margin-bottom: govuk-spacing(3);
-
-        .govuk-checkboxes__label {
-          font-size: 1rem;
-        }
+        margin-bottom: 0;
       }
     }
   }
 
-  
   &__submit {
-    
     bottom: 0;
     display: flex;
     position: sticky;
@@ -165,6 +157,10 @@
 .plain-styling .filters-component {
   background: none;
   padding: 0;
+
+  &__submit {
+    display: none;
+  }
 
   &__groups__group {
     border-bottom: 0;

--- a/app/components/filters_component/remove_buttons.html.slim
+++ b/app/components/filters_component/remove_buttons.html.slim
@@ -1,0 +1,2 @@
+- groups.each do |group|
+  = group

--- a/app/components/publishers/vacancies_component/vacancies_component.html.slim
+++ b/app/components/publishers/vacancies_component/vacancies_component.html.slim
@@ -11,27 +11,16 @@
 
 .govuk-grid-row.vacancies-component class="govuk-!-margin-top-7 govuk-!-margin-bottom-7"
   - if @organisation.school_group?
-    .govuk-grid-column-one-third
+    .govuk-grid-column-one-third class="govuk-!-margin-bottom-5"
       = form_for @publisher_preference, html: { data: { controller: "form", "hide-submit": true } } do |f|
-        = filters(filters: { total_count: @publisher_preference.organisations.count,
-                                      title: t("jobs.filters.job_filters") },
-                                      form: f,
-                                      items: [{ legend: "Locations",
-                                                key: "locations",
-                                                search: true,
-                                                scroll: true,
-                                                attribute: :organisation_ids,
-                                                selected: @publisher_preference.organisations.map(&:id),
-                                                options: @organisation_options,
-                                                value_method: :id,
-                                                text_method: :label,
-                                                selected_method: :name,
-                                                small: true }],
-                                      options: { remove_buttons: true,
-                                                mobile_variant: true,
-                                                autosubmit_form: true,
-                                                publisher_preference: (@publisher_preference if @organisation.local_authority?) },
-                  classes: "govuk-!-padding-left-3 govuk-!-padding-right-3 govuk-!-padding-top-0")
+        = filters(form: f,
+                  filters: { total_count: @publisher_preference.organisations.count },
+                  options: { remove_buttons: true, publisher_preference: (@publisher_preference if @organisation.local_authority?) },
+                  html_attributes: { tabindex: "-1" }) do |filters_component|
+                    - filters_component.remove_buttons do |rb|
+                      - rb.group(key: "locations", selected: @publisher_preference.organisations.map(&:id), options: @organisation_options, value_method: :id, selected_method: :name)
+
+                    - filters_component.group key: "locations", component: f.govuk_collection_check_boxes(:organisation_ids, @organisation_options, :id, :label, small: true, legend: { text: "Locations" }, hint: nil, form_group: { data: { action: "change->form#submitListener" } })
 
         = f.hidden_field :jobs_type, value: @selected_type
 

--- a/app/form_models/jobseekers/search_form.rb
+++ b/app/form_models/jobseekers/search_form.rb
@@ -42,8 +42,8 @@ class Jobseekers::SearchForm
   def set_facet_options
     @job_role_options = Vacancy.main_job_role_options.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_role_form.main_job_role_options.#{option}")] }
     @phase_options = [%w[primary Primary], %w[middle Middle], %w[secondary Secondary], %w[16-19 16-19]]
-    @ect_suitable_options = [["ect_suitable", I18n.t("jobs.filters.ect_suitable_only"), I18n.t("jobs.filters.ect_suitable")]]
-    @send_responsible_options = [["send_responsible", I18n.t("jobs.filters.send_responsible_only"), I18n.t("jobs.filters.send_responsible")]]
+    @ect_suitable_options = [["ect_suitable", I18n.t("jobs.filters.ect_suitable"), I18n.t("jobs.filters.ect_suitable_only")]]
+    @send_responsible_options = [["send_responsible", I18n.t("jobs.filters.send_responsible"), I18n.t("jobs.filters.send_responsible_only")]]
     @working_pattern_options = Vacancy.working_patterns.keys.map do |option|
       [option, I18n.t("helpers.label.publishers_job_listing_working_patterns_form.working_patterns_options.#{option}")]
     end

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -14,6 +14,7 @@ module ComponentsHelper
     publishers_vacancies: "Publishers::VacanciesComponent",
     publishers_vacancy_form_page_heading: "Publishers::VacancyFormPageHeadingComponent",
     review: "ReviewComponent",
+    searchable_collection: "SearchableCollectionComponent",
     tabs: "TabsComponent",
     vacancy_review: "VacancyReviewComponent",
     vacancy_selector: "VacancySelectorComponent",

--- a/app/views/subscriptions/_fields.html.slim
+++ b/app/views/subscriptions/_fields.html.slim
@@ -3,69 +3,18 @@
 = render "shared/search/current_location", target: "jobseekers-subscription-form-location-field"
 = render "shared/search/radius", f: f, wide: false
 
-div class="divider-bottom govuk-!-margin-top-6 govuk-!-margin-bottom-4"
-
-ruby:
-  items = [
-    {
-      legend: t("jobs.filters.job_roles"),
-      key: "job_roles",
-      attribute: :job_roles,
-      selected: @form.job_roles.reject { |role| role == "ect_suitable" },
-      options: @form.job_role_options,
-      value_method: :first,
-      text_method: :last,
-      selected_method: :last,
-    },
-    {
-      legend: t("jobs.filters.ect_suitable"),
-      key: "ect_suitable",
-      attribute: :job_roles,
-      selected: @form.job_roles.include?("ect_suitable") ? @form.job_roles : [],
-      options: @form.ect_suitable_options,
-      value_method: :first,
-      text_method: :last,
-      selected_method: :last,
-    },
-    {
-      legend: t("jobs.filters.send_responsible"),
-      key: "send_responsible",
-      attribute: :job_roles,
-      selected: @form.job_roles.include?("send_responsible") ? @form.job_roles : [],
-      options: @form.send_responsible_options,
-      value_method: :first,
-      text_method: :last,
-      selected_method: :last,
-    },
-    {
-      legend: t("jobs.filters.phases"),
-      key: "education_phase",
-      attribute: :phases,
-      selected: @form.phases,
-      options: @form.phase_options,
-      value_method: :first,
-      text_method: :last,
-      selected_method: :last,
-    },
-    {
-      legend: t("jobs.filters.working_patterns"),
-      key: "working_patterns",
-      attribute: :working_patterns,
-      selected: @form.working_patterns,
-      options: @form.working_pattern_options,
-      value_method: :first,
-      text_method: :last,
-      selected_method: :last,
-    },
-  ]
+.divider-bottom class="govuk-!-margin-top-6 govuk-!-margin-bottom-4"
 
 .plain-styling
   = filters(form: f,
-    filters: { total_count: 0, title: t("subscriptions.edit.filters") },
-    items: items,
-    options: { remove_buttons: false, mobile_variant: false, close_all: false, autosubmit_form: false })
+    options: { remove_buttons: false }) do |filters_component|
+      - filters_component.group key: "job_roles", component: f.govuk_collection_check_boxes(:job_roles, @form.job_role_options, :first, :last, small: false, legend: { text: t("jobs.filters.job_roles") }, hint: nil)
+      - filters_component.group key: "ect_suitable", component: f.govuk_collection_check_boxes(:job_roles, @form.ect_suitable_options, :first, :last, small: false, legend: { text: t("jobs.filters.ect_suitable") }, hint: nil)
+      - filters_component.group key: "send_responsible", component: f.govuk_collection_check_boxes(:job_roles, @form.send_responsible_options, :first, :last, small: false, legend: { text: t("jobs.filters.send_responsible") }, hint: nil)
+      - filters_component.group key: "education_phase", component: f.govuk_collection_check_boxes(:phases, @form.phase_options, :first, :last, small: false, legend: { text: t("jobs.filters.phases") }, hint: nil)
+      - filters_component.group key: "working_patterns", component: f.govuk_collection_check_boxes(:working_patterns, @form.working_pattern_options, :first, :last, small: false, legend: { text: t("jobs.filters.working_patterns") }, hint: nil)
 
-.divider-bottom
+.divider-bottom class="govuk-!-margin-top-4 govuk-!-margin-bottom-6"
 
 - if jobseeker_signed_in?
   = f.hidden_field :email, value: current_jobseeker.email

--- a/app/views/vacancies/_filters.html.slim
+++ b/app/views/vacancies/_filters.html.slim
@@ -1,64 +1,57 @@
 ruby:
-  items = [
+  filter_types = [
     {
       legend: t("jobs.filters.job_roles"),
       key: "job_roles",
-      attribute: :job_roles,
-      selected: @form.job_roles.reject { |role| role == "ect_suitable" },
+      selected: @form.job_roles.reject { |role| role.in?(%w[ect_suitable send_responsible]) },
       options: @form.job_role_options,
       value_method: :first,
-      text_method: :last,
       selected_method: :last,
-      small: true,
     },
     {
       legend: t("jobs.filters.ect_suitable"),
       key: "ect_suitable",
-      attribute: :job_roles,
       selected: @form.job_roles.include?("ect_suitable") ? @form.job_roles : [],
       options: @form.ect_suitable_options,
       value_method: :first,
-      text_method: :second,
       selected_method: :last,
-      small: true,
     },
     {
       legend: t("jobs.filters.send_responsible"),
       key: "send_responsible",
-      attribute: :job_roles,
       selected: @form.job_roles.include?("send_responsible") ? @form.job_roles : [],
       options: @form.send_responsible_options,
       value_method: :first,
-      text_method: :second,
       selected_method: :last,
-      small: true,
     },
     {
       legend: t("jobs.filters.phases"),
       key: "education_phase",
-      attribute: :phases,
       selected: @form.phases,
       options: @form.phase_options,
       value_method: :first,
-      text_method: :last,
       selected_method: :last,
-      small: true,
     },
     {
       legend: t("jobs.filters.working_patterns"),
       key: "working_patterns",
-      attribute: :working_patterns,
       selected: @form.working_patterns,
       options: @form.working_pattern_options,
       value_method: :first,
-      text_method: :last,
       selected_method: :last,
-      small: true,
     },
   ]
 
 = filters(form: f,
   filters: { total_count: @form.total_filters },
-  items: items,
-  options: { heading_text: "Filter results", remove_buttons: true, mobile_variant: true, close_all: true, autosubmit_form: true },
-  html_attributes: { tabindex: "-1", id: id })
+  options: { heading_text: "Filter results", remove_buttons: true },
+  html_attributes: { tabindex: "-1", id: id }) do |filters_component|
+    - filters_component.remove_buttons do |rb|
+      - filter_types.each do |filter_type|
+        - rb.group(**filter_type)
+
+    - filters_component.group key: "job_roles", component: f.govuk_collection_check_boxes(:job_roles, @form.job_role_options, :first, :last, small: true, legend: { text: t("jobs.filters.job_roles") }, hint: nil, form_group: { data: { action: "change->form#submitListener" } })
+    - filters_component.group key: "ect_suitable", component: f.govuk_collection_check_boxes(:job_roles, @form.ect_suitable_options, :first, :last, small: true, legend: { text: t("jobs.filters.ect_suitable") }, hint: nil, form_group: { data: { action: "change->form#submitListener" } })
+    - filters_component.group key: "send_responsible", component: f.govuk_collection_check_boxes(:job_roles, @form.send_responsible_options, :first, :last, small: true, legend: { text: t("jobs.filters.send_responsible") }, hint: nil, form_group: { data: { action: "change->form#submitListener" } })
+    - filters_component.group key: "education_phase", component: f.govuk_collection_check_boxes(:phases, @form.phase_options, :first, :last, small: true, legend: { text: t("jobs.filters.phases") }, hint: nil, form_group: { data: { action: "change->form#submitListener" } })
+    - filters_component.group key: "working_patterns", component: f.govuk_collection_check_boxes(:working_patterns, @form.working_pattern_options, :first, :last, small: true, legend: { text: t("jobs.filters.working_patterns") }, hint: nil, form_group: { data: { action: "change->form#submitListener" } })

--- a/app/views/vacancies/index.html.slim
+++ b/app/views/vacancies/index.html.slim
@@ -13,7 +13,7 @@
     = form_for @form, as: "", url: jobs_path, method: :get, html: { class: "search-and-filters-form", data: { controller: "form" }, role: "search", aria: { label: "Filter criteria" } } do |f|
       .govuk-grid-row
         .govuk-grid-column-one-third class="govuk-!-margin-bottom-3"
-          = render "filters", f: f, id: "filters-component"
+          = render "filters", f: f, id: "filters-component", classes: "govuk-!-padding-top-3"
 
         .govuk-grid-column-two-thirds
           .search-results


### PR DESCRIPTION
no ticket

Refactor filters view component to allow filter groups to passed in as slots so components are not hardcoded in the filters view, making it more flexible and hence no internal logic is needed.

we decided to refactor this in preparation for filters AB test but in a separate PR. Also regardless of AB test outcome, it makes filters more flexible for future changes

there were also a bunch of legacy arguments being passed to filters that were no longer used and so have removed them