### PR TITLE
correct page wrapper top spacing

### DIFF
--- a/app/frontend/src/styles/application.scss
+++ b/app/frontend/src/styles/application.scss
@@ -21,7 +21,6 @@ $govuk-new-link-styles: true;
 @import 'application/footer';
 @import 'application/form';
 @import 'application/govuk-notification-banner';
-@import 'application/govuk-phase-banner';
 @import 'application/header';
 @import 'application/home';
 @import 'application/icons';

--- a/app/frontend/src/styles/application/govuk-phase-banner.scss
+++ b/app/frontend/src/styles/application/govuk-phase-banner.scss
@@ -1,5 +1,0 @@
-.home_index {
-  .govuk-phase-banner {
-    border-bottom: 0;
-  }
-}

--- a/app/frontend/src/styles/application/home.scss
+++ b/app/frontend/src/styles/application/home.scss
@@ -71,3 +71,7 @@
     display: flex;
   }
 }
+
+.home_index .govuk-main-wrapper {
+  padding-top: govuk-spacing(2);
+}


### PR DESCRIPTION
@cesidio  did a nice consistency clean up of `govuk-main-wrapper` usage but introduced a little visually unappealling layout  bug at top of page (not just me thinks its not right - cesi pointed it out, kirill agrees)

This gap doesnt look right

![Screenshot 2022-02-11 at 13 09 41](https://user-images.githubusercontent.com/1792451/153597422-f9516b47-e488-4341-b58f-6f8a6b317428.png)

Changes

- put back the default border at bottom of phase banner which we had overriding because of a previous home page design
- `govuk-main-wrapper` has a default padding top of 40px which is a little large on home page so have overidden that to 10px

when we do upcoming css rethink/restructure, it is not out of the question that we will have to have page specific styles for the home page only home_index as it is different that every other page aesthetically, so introducing one here isnt so bad, it might be located in another place thats all
