### PR TITLE
[TEVA-3776] Fix date job starts pre-selected radio bug

### DIFF
--- a/app/controllers/publishers/vacancies/copy_controller.rb
+++ b/app/controllers/publishers/vacancies/copy_controller.rb
@@ -36,6 +36,7 @@ class Publishers::Vacancies::CopyController < Publishers::Vacancies::BaseControl
 
   def reset_date_fields
     vacancy.expires_at = nil
+    vacancy.starts_asap = nil
     vacancy.starts_on = nil
     vacancy.publish_on = nil
   end

--- a/app/frontend/src/styles/application/form.scss
+++ b/app/frontend/src/styles/application/form.scss
@@ -20,32 +20,6 @@
   text-decoration: underline;
 }
 
-.clear-form {
-  @media only screen and (max-width: 882px) {
-    flex-wrap: wrap;
-
-    .govuk-form-group {
-      flex-basis: 100%;
-    }
-  }
-
-  .govuk-checkboxes__item {
-    margin-bottom: govuk-spacing(6);
-    margin-left: govuk-spacing(4);
-  }
-
-  .clear-form__checkbox {
-    align-items: baseline;
-    align-self: flex-end;
-    display: flex;
-
-    &::before {
-      @include govuk-font($size: 19);
-      content: 'Or';
-    }
-  }
-}
-
 .inline-fields-container {
   display: flex;
 

--- a/app/views/publishers/vacancies/build/important_dates.html.slim
+++ b/app/views/publishers/vacancies/build/important_dates.html.slim
@@ -34,7 +34,7 @@
         ->(option) { t("helpers.options.publishers_job_listing_extend_deadline_form.expiry_time.#{option}") }
 
       = f.govuk_radio_buttons_fieldset :starts_asap, legend: { text: t("helpers.legend.publishers_job_listing_important_dates_form.starts_on") }, form_group: { data: { controller: "form" } } do
-        = f.govuk_radio_button :starts_asap, "false", checked: "false", link_errors: true, label: { text: t("helpers.legend.publishers_job_listing_important_dates_form.start_date_specific") } do
+        = f.govuk_radio_button :starts_asap, "false", link_errors: true, label: { text: t("helpers.legend.publishers_job_listing_important_dates_form.start_date_specific") } do
           = f.govuk_date_field :starts_on,
             legend: { text: "Enter date" },
             hint: -> { t("helpers.hint.date", date: 2.months.from_now.strftime("%d %m %Y")) },

--- a/app/views/publishers/vacancies/build/important_dates.html.slim
+++ b/app/views/publishers/vacancies/build/important_dates.html.slim
@@ -33,13 +33,13 @@
         ->(option) { option },
         ->(option) { t("helpers.options.publishers_job_listing_extend_deadline_form.expiry_time.#{option}") }
 
-      = f.govuk_radio_buttons_fieldset :starts_asap, legend: { text: t("helpers.legend.publishers_job_listing_important_dates_form.starts_on") }, classes: "clear-form", form_group: { data: { controller: "form" } } do
-        = f.govuk_radio_button :starts_asap, "false", link_errors: true, label: { text: t("helpers.legend.publishers_job_listing_important_dates_form.start_date_specific") } do
+      = f.govuk_radio_buttons_fieldset :starts_asap, legend: { text: t("helpers.legend.publishers_job_listing_important_dates_form.starts_on") }, form_group: { data: { controller: "form" } } do
+        = f.govuk_radio_button :starts_asap, "false", checked: "false", link_errors: true, label: { text: t("helpers.legend.publishers_job_listing_important_dates_form.start_date_specific") } do
           = f.govuk_date_field :starts_on,
             legend: { text: "Enter date" },
             hint: -> { t("helpers.hint.date", date: 2.months.from_now.strftime("%d %m %Y")) },
             data: { "form-target": "inputText" }
-        = f.govuk_radio_button :starts_asap, "true", class: "clear-form__checkbox", label: { text: t("helpers.legend.publishers_job_listing_important_dates_form.start_asap") }, data: { action: "click->form#clearListener" }
+        = f.govuk_radio_button :starts_asap, "true", label: { text: t("helpers.legend.publishers_job_listing_important_dates_form.start_asap") }, data: { action: "click->form#clearListener" }
 
       = render "publishers/vacancies/vacancy_form_partials/submit", f: f
 

--- a/app/views/publishers/vacancies/copy/new.html.slim
+++ b/app/views/publishers/vacancies/copy/new.html.slim
@@ -33,14 +33,13 @@
         ->(option) { option },
         ->(option) { t("helpers.options.publishers_job_listing_extend_deadline_form.expiry_time.#{option}") }
 
-      .clear-form data-controller="form"
-        = f.govuk_date_field :starts_on,
-          hint: -> { t("helpers.hint.date", date: 2.months.from_now.strftime("%d %m %Y")) },
-          data: { "form-target": "inputText" }
-
-        .clear-form__checkbox
-          = f.govuk_check_box :starts_asap, "true", 0, multiple: false, link_errors: false,
-          data: { action: "click->form#clearListener" }
+      = f.govuk_radio_buttons_fieldset :starts_asap, legend: { text: t("helpers.legend.publishers_job_listing_important_dates_form.starts_on") }, form_group: { data: { controller: "form" } } do
+        = f.govuk_radio_button :starts_asap, "false", link_errors: true, label: { text: t("helpers.legend.publishers_job_listing_important_dates_form.start_date_specific") } do
+          = f.govuk_date_field :starts_on,
+            legend: { text: "Enter date" },
+            hint: -> { t("helpers.hint.date", date: 2.months.from_now.strftime("%d %m %Y")) },
+            data: { "form-target": "inputText" }
+        = f.govuk_radio_button :starts_asap, "true", label: { text: t("helpers.legend.publishers_job_listing_important_dates_form.start_asap") }, data: { action: "click->form#clearListener" }
 
       = f.govuk_submit classes: "govuk-!-margin-bottom-5"
 

--- a/app/views/publishers/vacancies/extend_deadline/show.html.slim
+++ b/app/views/publishers/vacancies/extend_deadline/show.html.slim
@@ -20,14 +20,13 @@
         ->(option) { option },
         ->(option) { t("helpers.options.publishers_job_listing_extend_deadline_form.expiry_time.#{option}") }
 
-      .clear-form data-controller="form"
-        = f.govuk_date_field :starts_on,
-          hint: -> { t("helpers.hint.date", date: 2.months.from_now.strftime("%d %m %Y")) },
-          data: { "form-target": "inputText" }
-
-        .clear-form__checkbox
-          = f.govuk_check_box :starts_asap, "true", 0, multiple: false, link_errors: false,
-          data: { action: "click->form#clearListener" }
+      = f.govuk_radio_buttons_fieldset :starts_asap, legend: { text: t("helpers.legend.publishers_job_listing_important_dates_form.starts_on") }, form_group: { data: { controller: "form" } } do
+        = f.govuk_radio_button :starts_asap, "false", link_errors: true, label: { text: t("helpers.legend.publishers_job_listing_important_dates_form.start_date_specific") } do
+          = f.govuk_date_field :starts_on,
+            legend: { text: "Enter date" },
+            hint: -> { t("helpers.hint.date", date: 2.months.from_now.strftime("%d %m %Y")) },
+            data: { "form-target": "inputText" }
+        = f.govuk_radio_button :starts_asap, "true", label: { text: t("helpers.legend.publishers_job_listing_important_dates_form.start_asap") }, data: { action: "click->form#clearListener" }
 
       = f.govuk_submit t("buttons.extend_deadline"), classes: "govuk-!-margin-bottom-5"
 

--- a/db/migrate/20220216122359_change_vacancies_starts_asap_default_to_nil.rb
+++ b/db/migrate/20220216122359_change_vacancies_starts_asap_default_to_nil.rb
@@ -1,0 +1,5 @@
+class ChangeVacanciesStartsAsapDefaultToNil < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :vacancies, :starts_asap, from: false, to: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_01_101037) do
+ActiveRecord::Schema.define(version: 2022_02_16_122359) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -451,7 +451,7 @@ ActiveRecord::Schema.define(version: 2022_02_01_101037) do
     t.integer "job_roles", array: true
     t.string "contact_number"
     t.uuid "publisher_organisation_id"
-    t.boolean "starts_asap", default: false
+    t.boolean "starts_asap"
     t.integer "contract_type"
     t.string "fixed_term_contract_duration"
     t.text "personal_statement_guidance"

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -131,6 +131,8 @@ module VacancyHelpers
     fill_in "publishers_job_listing_copy_vacancy_form[publish_on(2i)]", with: vacancy.publish_on&.strftime("%m")
     fill_in "publishers_job_listing_copy_vacancy_form[publish_on(1i)]", with: vacancy.publish_on&.year
 
+    choose I18n.t("helpers.legend.publishers_job_listing_important_dates_form.start_date_specific")
+
     fill_in "publishers_job_listing_copy_vacancy_form[starts_on(3i)]", with: vacancy.starts_on.day if vacancy.starts_on
     fill_in "publishers_job_listing_copy_vacancy_form[starts_on(2i)]", with: vacancy.starts_on.strftime("%m") if vacancy.starts_on
     fill_in "publishers_job_listing_copy_vacancy_form[starts_on(1i)]", with: vacancy.starts_on.year if vacancy.starts_on

--- a/spec/system/publishers_can_copy_a_vacancy_spec.rb
+++ b/spec/system/publishers_can_copy_a_vacancy_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "Copying a vacancy" do
     new_vacancy.job_title = "A new job title"
     new_vacancy.starts_on = 35.days.from_now
     new_vacancy.publish_on = 0.days.from_now
-    new_vacancy.expires_at = new_vacancy.expires_at = 30.days.from_now.change(hour: 9, minute: 0)
+    new_vacancy.expires_at = 30.days.from_now.change(hour: 9, minute: 0)
 
     visit organisation_path
     click_on original_vacancy.job_title


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3776

## Changes in this PR:

- Previously the default value for `starts_asap` was false, causing the radio that submitted the value "false" to be pre-selected.
- Whilst working on this I noticed that the same radios were not present in `app/views/publishers/vacancies/copy/new.html.slim` or `app/views/publishers/vacancies/extend_deadline/show.html.slim,` so I've changed that to be consistent with `app/views/publishers/vacancies/build/important_dates.html.slim`. I assume at some point we decided to change to radios but didn't update the other pages. 
