### PR TITLE
remove old abtest cookie config

### DIFF
--- a/config/ab_tests.yml
+++ b/config/ab_tests.yml
@@ -37,13 +37,6 @@ shared:
     default: 1
     subjects_filters: 1
 test:
-  2021_04_cookie_consent_test:
-    none: 0
-    default: 1
-    bottom_black: 0
-    bottom_blue: 0
-    modal: 0
-    gds: 0
   2022_01_homepage_quick_links_test:
     without_quick_links: 1
     with_quick_links: 0


### PR DESCRIPTION
self explanatory, this was from ages ago and no longer needed