### PR TITLE
Fix incorrect education phase landing pages

### DIFF
--- a/config/landing_pages.yml
+++ b/config/landing_pages.yml
@@ -41,16 +41,16 @@ shared:
 
   ### Phases
   primary-school-jobs:
-    readable_phases:
+    phases:
       - primary
   middle-school-jobs:
-    readable_phases:
+    phases:
       - middle
   secondary-school-jobs:
-    readable_phases:
+    phases:
       - secondary
   16-19-education-provider-jobs:
-    readable_phases:
+    phases:
       - "16-19"
 
   ### Subjects


### PR DESCRIPTION
These were using the wrong filter key in the configuration file - while
the field we're filtering on is called `readable_phases`, in the search
filters it's actually called just `phases`.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3891