### PR TITLE
Fix issue with case-insensitive location landing pages

### DIFF
--- a/app/services/location_landing_page.rb
+++ b/app/services/location_landing_page.rb
@@ -3,7 +3,9 @@ class LocationLandingPage < LandingPage
 
   def self.exists?(location)
     # TODO: This is the logic that previously was in the routes, should be tidied up
-    LocationPolygon.include?(location.titleize)
+    # Landing page slugs may only contain lowercase characters and dashes
+    # (avoids duplicate landing pages for e.g. "Narnia" and "narnia")
+    location.match?(/^[a-z-]+$/) && LocationPolygon.include?(location.titleize)
   end
 
   def self.[](location)

--- a/spec/services/location_landing_page_spec.rb
+++ b/spec/services/location_landing_page_spec.rb
@@ -17,8 +17,9 @@ RSpec.describe LocationLandingPage do
   end
 
   describe ".exists?" do
-    it "returns whether the location polygon exists" do
+    it "returns whether a landing page exists for the given location name" do
       expect(described_class.exists?("narnia")).to be(true)
+      expect(described_class.exists?("Narnia")).to be(false)
       expect(described_class.exists?("blahrnia")).to be(false)
     end
   end


### PR DESCRIPTION
Location landing pages should only exist for lowercase slugs, otherwise
we end up with duplicates.