### PR TITLE
Add four more places to landing page links

### DIFF
--- a/app/views/home/_landing_page_links.html.slim
+++ b/app/views/home/_landing_page_links.html.slim
@@ -21,6 +21,8 @@
       = group.location_landing_page "bolton"
       = group.location_landing_page "brighton-and-hove"
       = group.location_landing_page "york"
+      = group.location_landing_page "bath"
+      = group.location_landing_page "coventry"
     = landing_page_link_group title: t(".counties"), list_class: "two-column-list" do |group|
       = group.location_landing_page "lancashire"
       = group.location_landing_page "hampshire"
@@ -42,6 +44,8 @@
       = group.location_landing_page "nottinghamshire"
       = group.location_landing_page "surrey"
       = group.location_landing_page "leicestershire"
+      = group.location_landing_page "lincolnshire"
+      = group.location_landing_page "somerset"
 
   .govuk-grid-column-one-half
     = landing_page_link_group title: t(".subjects"), list_class: "two-column-list" do |group|


### PR DESCRIPTION
This balances the landing page links out visually a bit now that we've
added working pattern links.