### PR TITLE
Add internal landing page links for education phase

### DIFF
--- a/app/helpers/organisations_helper.rb
+++ b/app/helpers/organisations_helper.rb
@@ -82,8 +82,17 @@ module OrganisationsHelper
     end
   end
 
-  def school_phase(school)
-    school.readable_phases&.map(&:capitalize)&.reject(&:blank?)&.join(", ")
+  def linked_school_phases(school)
+    safe_join(
+      (school.readable_phases || []).map do |phase|
+        lp = LandingPage.matching(phases: [phase])
+        if lp
+          govuk_link_to(lp.name, landing_page_path(lp.slug))
+        else
+          tag.span { phase.capitalize }
+        end
+      end, ", "
+    )
   end
 
   def school_size(school)

--- a/app/services/landing_page.rb
+++ b/app/services/landing_page.rb
@@ -15,8 +15,15 @@ class LandingPage
     new(slug, criteria)
   end
 
+  def self.matching(criteria)
+    slug = Rails.application.config.landing_pages.key(criteria)
+    return unless slug
+
+    self[slug]
+  end
+
   def initialize(slug, criteria)
-    @slug = slug
+    @slug = slug.to_s
     @criteria = criteria
   end
 

--- a/app/views/vacancies/_overview_at_multiple_schools.html.slim
+++ b/app/views/vacancies/_overview_at_multiple_schools.html.slim
@@ -46,7 +46,7 @@ section#school-overview class="govuk-!-margin-bottom-5"
 
             - summary_list.row do |row|
               - row.key text: t("schools.phase")
-              - row.value text: school_phase(organisation)
+              - row.value text: linked_school_phases(organisation)
 
             - summary_list.row do |row|
               - row.key text: t("schools.school_size")

--- a/app/views/vacancies/_overview_at_one_school.html.slim
+++ b/app/views/vacancies/_overview_at_one_school.html.slim
@@ -9,7 +9,7 @@ section#school-overview
 
     - summary_list.row do |row|
       - row.key text: t("schools.phase")
-      - row.value text: school_phase(vacancy.parent_organisation)
+      - row.value text: linked_school_phases(vacancy.parent_organisation)
 
     - summary_list.row do |row|
       - row.key text: t("schools.school_size")

--- a/spec/services/landing_page_spec.rb
+++ b/spec/services/landing_page_spec.rb
@@ -35,6 +35,21 @@ RSpec.describe LandingPage do
     end
   end
 
+  describe ".matching" do
+    it "returns the first landing page exactly matching the given criteria, or nil if none matches" do
+      expect(
+        described_class
+          .matching(working_patterns: %w[part_time], subjects: %w[Potions Sorcery])
+          .slug,
+      ).to eq("part-time-potions-and-sorcery-teacher-jobs")
+
+      # Do not find based on partially matching criteria:
+      expect(described_class.matching(subjects: %w[Potions Sorcery])).to be_nil
+
+      expect(described_class.matching(foo: %w[bar])).to be_nil
+    end
+  end
+
   describe "#count" do
     it "performs a search and returns its total count" do
       expect(subject.count).to eq(42)

--- a/spec/system/jobseekers_can_create_a_job_alert_from_a_listing_spec.rb
+++ b/spec/system/jobseekers_can_create_a_job_alert_from_a_listing_spec.rb
@@ -12,11 +12,6 @@ RSpec.describe "Jobseekers can create a job alert from a listing", recaptcha: tr
   end
 
   before do
-    allow(Rails.cache)
-      .to receive(:fetch)
-      .with([:similar_job_ids, vacancy.id], expires_in: Search::SimilarJobs::CACHE_DURATION)
-      .and_return([])
-
     visit job_path(vacancy)
   end
 


### PR DESCRIPTION
We want to add links to the relevant landing pages where appropriate to
the job listing pages to help improve SEO.

- Add `LandingPage.matching` to find landing pages matching a certain
  set of criteria
- Link school phases in "School overview" to education phase landing
  pages

## Jira ticket URL
https://dfedigital.atlassian.net/browse/TEVA-3636

## Screenshots of UI changes:

<img width="495" alt="image" src="https://user-images.githubusercontent.com/72141/154973049-d7a4bab2-9ae4-4ea6-8001-1946c3e9cdeb.png">