### PR TITLE
Require all given additional job roles in search

### DIFF
--- a/app/queries/vacancy_filter_query.rb
+++ b/app/queries/vacancy_filter_query.rb
@@ -6,7 +6,7 @@ class VacancyFilterQuery < ApplicationQuery
   end
 
   # TODO: Refactor this to be cleaner - e.g. moving from/to_date into their own scope
-  def call(filters)
+  def call(filters) # rubocop:disable Metrics/AbcSize
     from_date = filters[:from_date]&.to_time
     to_date = filters[:to_date]&.to_time
 
@@ -18,8 +18,10 @@ class VacancyFilterQuery < ApplicationQuery
     built_scope = built_scope.where("subjects && ARRAY[?]::varchar[]", filters[:subjects]) if filters[:subjects].present?
 
     # General filters
-    job_roles = fix_legacy_job_roles(filters[:job_roles])
-    built_scope = built_scope.with_any_of_job_roles(job_roles) if job_roles.present?
+    main_job_roles = extract_main_job_roles(filters[:job_roles])
+    additional_job_roles = extract_additional_job_roles(filters[:job_roles])
+    built_scope = built_scope.with_any_of_job_roles(main_job_roles) if main_job_roles.present?
+    built_scope = built_scope.with_job_roles(additional_job_roles) if additional_job_roles.present?
 
     working_patterns = fix_legacy_working_patterns(filters[:working_patterns])
     built_scope = built_scope.with_any_of_working_patterns(working_patterns) if working_patterns.present?
@@ -31,13 +33,21 @@ class VacancyFilterQuery < ApplicationQuery
 
   private
 
-  def fix_legacy_job_roles(job_roles)
-    return nil unless job_roles
+  def extract_main_job_roles(job_roles)
+    return nil unless job_roles&.any?
 
-    job_roles.dup.tap do |roles|
-      roles.push("ect_suitable") if roles.delete("nqt_suitable")
-      roles.push("send_responsible") if roles.delete("sen_specialist")
-    end
+    job_roles.map(&:to_sym) & Vacancy::MAIN_JOB_ROLES.keys
+  end
+
+  def extract_additional_job_roles(job_roles)
+    return nil unless job_roles&.any?
+
+    additional_job_roles = job_roles.map(&:to_sym)
+    # Replace renamed job roles with their new equivalent
+    additional_job_roles.push(:ect_suitable) if additional_job_roles.delete(:nqt_suitable)
+    additional_job_roles.push(:send_responsible) if additional_job_roles.delete(:sen_specialist)
+
+    additional_job_roles & Vacancy::ADDITIONAL_JOB_ROLES.keys
   end
 
   def fix_legacy_working_patterns(working_patterns)

--- a/spec/queries/vacancy_filter_query_spec.rb
+++ b/spec/queries/vacancy_filter_query_spec.rb
@@ -4,11 +4,13 @@ RSpec.describe VacancyFilterQuery do
   let(:organisation1) { create(:school, readable_phases: %w[primary middle]) }
   let(:organisation2) { create(:school, readable_phases: %w[secondary 16-19]) }
 
-  let!(:vacancy1) { create(:vacancy, subjects: %w[German French], working_patterns: %w[full_time], job_roles: %w[leadership], organisations: [organisation1]) }
-  let!(:vacancy2) { create(:vacancy, subjects: %w[English Spanish], working_patterns: %w[full_time], phase: :primary, job_roles: %w[teacher]) }
-  let!(:vacancy3) { create(:vacancy, subjects: %w[German Spanish], working_patterns: %w[part_time], job_roles: %w[leadership], organisations: [organisation1]) }
-  let!(:vacancy4) { create(:vacancy, subjects: %w[Media German], working_patterns: %w[full_time part_time], job_roles: %w[send_responsible], organisations: [organisation2]) }
-  let!(:vacancy5) { create(:vacancy, subjects: %w[German Spanish], working_patterns: %w[term_time], job_roles: %w[leadership], organisations: [organisation2]) }
+  let!(:vacancy1) { create(:vacancy, job_title: "Vacancy 1", subjects: %w[German French], working_patterns: %w[full_time], job_roles: %w[leadership], organisations: [organisation1]) }
+  let!(:vacancy2) { create(:vacancy, job_title: "Vacancy 2", subjects: %w[English Spanish], working_patterns: %w[full_time], phase: :primary, job_roles: %w[teacher]) }
+  let!(:vacancy3) { create(:vacancy, job_title: "Vacancy 3", subjects: %w[German Spanish], working_patterns: %w[part_time], job_roles: %w[leadership], organisations: [organisation1]) }
+  let!(:vacancy4) { create(:vacancy, job_title: "Vacancy 4", subjects: %w[Media German], working_patterns: %w[full_time part_time], job_roles: %w[send_responsible], organisations: [organisation2]) }
+  let!(:vacancy5) { create(:vacancy, job_title: "Vacancy 5", subjects: %w[German Spanish], working_patterns: %w[term_time], job_roles: %w[leadership], organisations: [organisation2]) }
+  let!(:vacancy6) { create(:vacancy, job_title: "Vacancy 6", subjects: %w[English Spanish], working_patterns: %w[full_time], phase: :primary, job_roles: %w[teacher ect_suitable]) }
+  let!(:vacancy7) { create(:vacancy, job_title: "Vacancy 7", subjects: %w[English Spanish], working_patterns: %w[full_time], phase: :primary, job_roles: %w[teacher ect_suitable send_responsible]) }
 
   describe "#call" do
     it "queries based on the given filters" do
@@ -16,18 +18,26 @@ RSpec.describe VacancyFilterQuery do
         subjects: %w[Spanish German],
         working_patterns: %w[full_time],
         phases: %w[primary 16-19],
-        job_roles: %w[leadership send_responsible],
+        job_roles: %w[leadership],
         from_date: 5.days.ago,
         to_date: Date.today,
       }
-      expect(subject.call(filters)).to contain_exactly(vacancy1, vacancy4)
+      expect(subject.call(filters)).to contain_exactly(vacancy1)
     end
 
-    it "transforms legacy filters" do
+    it "transforms legacy job role filters to new ones" do
       filters = {
         job_roles: %w[nqt_suitable sen_specialist],
       }
-      expect(subject.call(filters)).to contain_exactly(vacancy4)
+      expect(subject.call(filters)).to contain_exactly(vacancy7)
+    end
+
+    it "requires *all* given additional job roles to be present" do
+      expect(subject.call(job_roles: %w[teacher])).to contain_exactly(vacancy2, vacancy6, vacancy7)
+      expect(subject.call(job_roles: %w[teacher ect_suitable]))
+        .to contain_exactly(vacancy6, vacancy7)
+      expect(subject.call(job_roles: %w[teacher ect_suitable send_responsible]))
+        .to contain_exactly(vacancy7)
     end
   end
 end


### PR DESCRIPTION
When selecting additional job roles (suitable for ECT/SEND responsible),
the most likely user intent is for all of these to work as "and"
rather than "or" filters when combined with main job roles such as
"Teacher".

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3042