### PR TITLE
Improve breadcrumb "parent" for job listings

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -108,10 +108,4 @@ class ApplicationController < ActionController::Base
     @current_organisation ||= Organisation.find_by(id: session[:publisher_organisation_id])
   end
   helper_method :current_organisation
-
-  def referred_from_jobs_path?
-    request_uri = URI(request.referrer || "")
-    request.host == request_uri.host && request_uri.path == jobs_path
-  end
-  helper_method :referred_from_jobs_path?
 end

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -85,4 +85,26 @@ module VacanciesHelper
       { text: "#{organisation.name}, #{full_address(organisation)}", url: organisation_url(organisation), id: organisation.id }
     end
   end
+
+  # Determines a set of breadcrumbs for a vacancy view page based on whether the user has arrived
+  # there from a search results page (take them back to search results) or somewhere else (take
+  # them to the appropriate landing page, or if all else fails, the "all jobs" page)
+  def vacancy_breadcrumbs(vacancy)
+    referrer = URI(request.referrer || "")
+    referred_from_jobs_path = referrer.host == request.host && referrer.path == jobs_path
+
+    parent_breadcrumb = if referred_from_jobs_path
+                          { t("breadcrumbs.jobs") => request.referrer }
+                        elsif (lp = LandingPage.matching(job_roles: [vacancy.main_job_role]))
+                          { lp.title => landing_page_path(lp.slug) }
+                        else
+                          { t("breadcrumbs.jobs") => jobs_path }
+                        end
+
+    {
+      "#{t("breadcrumbs.home")}": root_path,
+      **parent_breadcrumb,
+      "#{vacancy.job_title}": "",
+    }
+  end
 end

--- a/app/views/shared/vacancy/_jobseeker_view.html.slim
+++ b/app/views/shared/vacancy/_jobseeker_view.html.slim
@@ -1,7 +1,5 @@
 - content_for :breadcrumbs do
-  = govuk_breadcrumbs breadcrumbs: { "#{t("breadcrumbs.home")}": root_path,
-                                      "#{t("breadcrumbs.jobs")}": referred_from_jobs_path? ? request.referrer : jobs_path,
-                                      "#{@vacancy.job_title}": "" }
+  = govuk_breadcrumbs breadcrumbs: vacancy_breadcrumbs(@vacancy)
 
 - if @vacancy.expired?
   = govuk_tag text: t("jobs.expired_listing.tag").upcase,

--- a/spec/helpers/vacancies_helper_spec.rb
+++ b/spec/helpers/vacancies_helper_spec.rb
@@ -22,4 +22,45 @@ RSpec.describe VacanciesHelper do
       end
     end
   end
+
+  describe "#vacancy_breadcrumbs" do
+    subject { vacancy_breadcrumbs(vacancy).to_a }
+    let(:vacancy) { build_stubbed(:vacancy, job_title: "A Job", job_roles: %w[teacher]) }
+    let(:request) { double("request", host: "example.com", referrer: referrer) }
+    let(:referrer) { "http://www.example.com/foo" }
+    let(:landing_page) { instance_double(LandingPage, title: "Landing Page", slug: "landing") }
+
+    before do
+      allow(helper).to receive(:request).and_return(request)
+      allow(LandingPage).to receive(:matching).with(job_roles: %w[teacher]).and_return(landing_page)
+    end
+
+    it "has the homepage as its first breadcrumb" do
+      expect(subject[0].last).to eq(root_path)
+    end
+
+    it "has the landing page as its second breadcrumb" do
+      expect(subject[1]).to eq(["Landing Page", landing_page_path("landing")])
+    end
+
+    it "has the job as its last breadcrumb" do
+      expect(subject[2]).to eq([:"A Job", ""])
+    end
+
+    context "when the user comes from the search page" do
+      let(:referrer) { jobs_url(foo: "bar", host: "example.com") }
+
+      it "has the search as its second breadcrumb" do
+        expect(subject[1]).to eq([t("breadcrumbs.jobs"), referrer])
+      end
+    end
+
+    context "when there is no landing page" do
+      let(:landing_page) { nil }
+
+      it "has the expected parent breadcrumb" do
+        expect(subject[1]).to eq([t("breadcrumbs.jobs"), jobs_path])
+      end
+    end
+  end
 end


### PR DESCRIPTION
This should go to a relevant landing page (not the "all jobs") page,
unless the user has come from a search.

- Move breadcrumb handling into `VacanciesHelper`
- Decide based on referrer and existence of landing page what breadcrumb
  to show as the parent of the listing
- Remove referrer helper method from `ApplicationController`

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3668

<img width="757" alt="image" src="https://user-images.githubusercontent.com/72141/155155308-820085b4-b48c-4da4-9e21-ff832ffc2f90.png">
