### PR TITLE
Assorted landing page link improvements

### DIFF
--- a/app/components/landing_page_link_component/landing_page_link_component.html.slim
+++ b/app/components/landing_page_link_component/landing_page_link_component.html.slim
@@ -1,9 +1,6 @@
 li
   = govuk_link_to(href) do
-    / Make link text more meaningful for screenreaders
-    span.govuk-visually-hidden = "view #{@landing_page.count} "
-    = @landing_page.name
-    span.govuk-visually-hidden = " jobs"
+    = t("landing_pages.accessible_link_text_with_count_html", name: @landing_page.name, count: @landing_page.count)
 
   / Hide count from a11y tree as it's included in link text
   span aria-hidden="true" = " (#{@landing_page.count})"

--- a/app/frontend/src/styles/application.scss
+++ b/app/frontend/src/styles/application.scss
@@ -31,6 +31,7 @@ $govuk-new-link-styles: true;
 @import 'application/signin';
 @import 'application/tabs';
 @import 'application/timeline';
+@import 'application/typography';
 
 @import 'application/jobseekers/cookies-banner';
 @import 'application/jobseekers/feedback-form';

--- a/app/frontend/src/styles/application/typography.scss
+++ b/app/frontend/src/styles/application/typography.scss
@@ -1,0 +1,9 @@
+.govuk-link--text-colour {
+  color: $govuk-text-colour;
+
+  :hover,
+  :active,
+  :visited {
+    color: $govuk-text-colour;
+  }
+}

--- a/app/helpers/links_helper.rb
+++ b/app/helpers/links_helper.rb
@@ -1,4 +1,12 @@
 module LinksHelper
+  def landing_page_link_or_text(landing_page_criteria, text)
+    lp = LandingPage.matching(landing_page_criteria)
+    return tag.span { text } unless lp
+
+    link_text = t("landing_pages.accessible_link_text_html", name: lp.name)
+    govuk_link_to(link_text, landing_page_path(lp.slug), class: "govuk-link--text-colour")
+  end
+
   def tracked_link_to(text, href, **kwargs)
     govuk_link_to(text, href, **kwargs.deep_merge(data: {
       controller: "tracked-link",

--- a/app/helpers/organisations_helper.rb
+++ b/app/helpers/organisations_helper.rb
@@ -85,12 +85,7 @@ module OrganisationsHelper
   def linked_school_phases(school)
     safe_join(
       (school.readable_phases || []).map do |phase|
-        lp = LandingPage.matching(phases: [phase])
-        if lp
-          govuk_link_to(lp.name, landing_page_path(lp.slug))
-        else
-          tag.span { phase.capitalize }
-        end
+        landing_page_link_or_text({ phases: [phase] }, phase.capitalize)
       end, ", "
     )
   end

--- a/config/locales/landing_pages.yml
+++ b/config/locales/landing_pages.yml
@@ -1,6 +1,13 @@
 en:
   landing_pages:
     ##
+    # Link text for screenreaders
+    #   Having links that just say e.g. "Teacher" is not very accessible out of context. This markup
+    #   helps users relying on screenreaders to make sense of links to landing pages.
+    #   Don't edit this unless you know what you are doing!
+    accessible_link_text_html: '<span class="visually-hidden">View all </span>%{name}<span class="visually-hidden">jobs</span>'
+    accessible_link_text_with_count_html: '<span class="visually-hidden">View %{count} </span>%{name}<span class="visually-hidden">jobs</span>'
+    ##
     # Content for location landing pages
     #   These are dynamic and will exist for any `LocationPolygon` in the database.
     #   Any fields may contain `%{location}` to interpolate the location name, and heading may


### PR DESCRIPTION
- Ensure landing page links have a11y text to make sense out of context
  (and make the text consistent by using translations)
- Create `LinksHelper#landing_page_link_or_text` to show a link to a
  landing page given some criteria if that landing page exists,
  otherwise show some fallback text
- Use new helper when showing phase landing page links
- Make landing page links on job listings slightly less prominent by
  using text colour for links