### PR TITLE
refactor/reduce searchable collection args

### DIFF
--- a/app/components/searchable_collection_component.rb
+++ b/app/components/searchable_collection_component.rb
@@ -1,36 +1,19 @@
 class SearchableCollectionComponent < GovukComponent::Base
-  attr_accessor :form, :input_type, :attribute_name, :collection, :value_method, :text_method, :hint_method, :threshold, :border, :small, :label_text, :form_group, :options, :scrollable
+  attr_accessor :collection, :collection_count, :threshold, :border, :label_text, :options, :scrollable
 
-  # rubocop:disable Metrics/ParameterLists
-  def initialize(form:, input_type:, attribute_name:, collection:, value_method:, text_method:, hint_method:, threshold: 10, border: true, small: nil, options: {}, form_group: {}, scrollable: false, label_text: nil, classes: [], html_attributes: {})
-    # rubocop:enable Metrics/ParameterLists
-    super(classes: classes, html_attributes: html_attributes)
+  def initialize(collection:, collection_count:, options: {}, label_text: nil, classes: [], html_attributes: {})
+    super(classes: classes, html_attributes: html_attributes.merge({ data: { controller: "searchable-collection" } }))
 
-    @form = form
-    @attribute_name = attribute_name
     @collection = collection
-    @value_method = value_method
-    @text_method = text_method
-    @hint_method = hint_method
-    @form_group = form_group
-
-    @input_type = input_type
-    @threshold = threshold
+    @threshold = options[:threshold] || 10
     @label_text = label_text
-    @border = border
-    @small = small
-    @options = options
-    @scrollable = scrollable || searchable?
+    @border = options[:border] || false
+    @collection_count = collection_count
+    @scrollable = options[:scrollable] || searchable?
   end
 
   def searchable?
-    collection.count >= threshold
-  end
-
-  def small_items?
-    return searchable? if small.nil?
-
-    small
+    collection_count >= threshold
   end
 
   def scrollable_class

--- a/app/components/searchable_collection_component/searchable_collection_component.html.slim
+++ b/app/components/searchable_collection_component/searchable_collection_component.html.slim
@@ -5,26 +5,4 @@
         input.govuk-input.searchable-collection-component__search-input.icon.icon--left.icon--search.js-action placeholder=t("helpers.hint.publishers_job_listing_job_details_form.subjects_placeholder") aria-label="#{label_text}" aria-expanded="true" aria-describedby="publishers-job-listing-job-details-form-subjects-hint" aria-owns="subjects__listbox" role="combobox"
         .govuk-visually-hidden aria-live="polite" role="status" id="search-results"
 
-    - case input_type
-    - when :checkbox
-      = form.govuk_collection_check_boxes attribute_name,
-        collection,
-        value_method,
-        text_method,
-        hint_method,
-        small: small_items?,
-        classes: ("checkbox-label__bold" if options[:bold_items]),
-        legend: nil,
-        hint: nil,
-        form_group: form_group
-
-    - when :radio_button
-      = form.govuk_collection_radio_buttons attribute_name,
-        collection,
-        value_method,
-        text_method,
-        hint_method,
-        small: small_items?,
-        classes: ("radiobutton-label__bold" if options[:bold_items]),
-        legend: nil,
-        hint: nil
+    = collection

--- a/app/components/searchable_collection_component/searchable_collection_component.scss
+++ b/app/components/searchable_collection_component/searchable_collection_component.scss
@@ -24,7 +24,7 @@
     }
 
     .searchable-collection-component__search {
-      margin: govuk-spacing(2);
+      margin: govuk-spacing(2) govuk-spacing(2) govuk-spacing(3);
     }
   }
 

--- a/app/views/publishers/publisher_preferences/_form.html.slim
+++ b/app/views/publishers/publisher_preferences/_form.html.slim
@@ -3,16 +3,18 @@
     legend: { text: t(".schools_in", organisation: current_organisation.name) },
     classes: "checkbox-label__bold govuk-!-margin-top-5" do
 
-    = render SearchableCollectionComponent.new form: f,
-      input_type: :checkbox,
-      label_text: "search organisation schools",
-      threshold: 10,
-      attribute_name: :school_ids,
-      collection: current_organisation.schools.not_universities.not_closed.order(:name),
-      value_method: :id,
-      text_method: :name,
-      hint_method: :address,
-      options: { bold_items: true }
+    = searchable_collection(collection: f.govuk_collection_check_boxes(:school_ids,
+          current_organisation.schools.not_universities.not_closed.order(:name),
+          :id,
+          :name,
+          :address,
+          legend: nil,
+          hint: nil,
+          small: true,
+          classes: "checkbox-label__bold"),
+          collection_count: current_organisation.schools.not_universities.not_closed.order(:name).count,
+          options: { border: true },
+          label_text: "search organisation schools")
 
   - if current_organisation.schools_outside_local_authority.not_closed.any?
     = f.govuk_check_boxes_fieldset :school_ids_fieldset,
@@ -20,16 +22,17 @@
       hint: { text: t(".schools_out_hint_html", email: govuk_mail_to(t("help.email"), t("help.email"))) },
       classes: "checkbox-label__bold govuk-!-margin-top-5" do
 
-      = render SearchableCollectionComponent.new form: f,
-        input_type: :checkbox,
-        label_text: "search schools outside local authority",
-        threshold: 10,
-        attribute_name: :school_ids,
-        collection: current_organisation.schools_outside_local_authority.not_closed.order(:name),
-        value_method: :id,
-        text_method: :name,
-        hint_method: :address,
-        options: { bold_items: true }
+      = searchable_collection(collection: f.govuk_collection_check_boxes(:school_ids,
+          current_organisation.schools_outside_local_authority.not_closed.order(:name),
+          :id,
+          :name,
+          :address,
+          legend: nil,
+          hint: nil,
+          classes: "checkbox-label__bold"),
+          collection_count: current_organisation.schools_outside_local_authority.not_closed.order(:name).count,
+          options: { border: true },
+          label_text: "search schools outside local authority")
   - else
     h3.govuk-heading-s = t(".schools_out", organisation: current_organisation.name)
     p.govuk-body = t(".schools_out_hint_html", email: govuk_mail_to(t("help.email"), t("help.email")))

--- a/app/views/publishers/vacancies/build/job_details.html.slim
+++ b/app/views/publishers/vacancies/build/job_details.html.slim
@@ -46,17 +46,17 @@
             = t("helpers.hint.publishers_job_listing_job_details_form.subjects")
 
             div class="govuk-!-margin-bottom-6"
-              = render SearchableCollectionComponent.new form: f,
-                input_type: :checkbox,
-                label_text: "search subjects",
-                threshold: 10,
-                scrollable: true,
-                attribute_name: :subjects,
-                collection: SUBJECT_OPTIONS,
-                value_method: :first,
-                text_method: :first,
-                hint_method: :last,
-                options: { bold_items: true }
+              = searchable_collection(collection: f.govuk_collection_check_boxes(:subjects,
+                SUBJECT_OPTIONS,
+                :first,
+                :first,
+                :last,
+                legend: nil,
+                hint: nil,
+                classes: "checkbox-label__bold"),
+                collection_count: SUBJECT_OPTIONS.count,
+                options: { border: true },
+                label_text: "search subjects")
 
       = render "publishers/vacancies/vacancy_form_partials/submit", f: f
 

--- a/app/views/publishers/vacancies/build/schools.html.slim
+++ b/app/views/publishers/vacancies/build/schools.html.slim
@@ -16,17 +16,30 @@
             =< govuk_link_to t("helpers.hint.publishers_job_listing_schools_form.add_school"),
                                edit_publishers_publisher_preference_path(current_publisher_preference), class: "govuk-link--no-visited-state"
 
-        = render SearchableCollectionComponent.new form: f,
-          input_type: @multiple_schools ? :checkbox : :radio_button,
-          label_text: "search schools",
-          threshold: 10,
-          attribute_name: :organisation_ids,
-          collection: @school_options,
-          value_method: :id,
-          text_method: :name,
-          hint_method: :address,
-          options: { bold_items: true },
-          classes: "govuk-!-margin-top-4"
+        - if @multiple_schools
+          = searchable_collection(collection: f.govuk_collection_check_boxes(:organisation_ids,
+            @school_options,
+            :id,
+            :name,
+            :address,
+            legend: nil,
+            hint: nil,
+            classes: "checkbox-label__bold govuk-!-margin-top-2"),
+            collection_count: @school_options.count,
+            options: { border: true },
+            label_text: "search schools")
+        - else
+          = searchable_collection(collection: f.govuk_collection_radio_buttons(:organisation_ids,
+            @school_options,
+            :id,
+            :name,
+            :address,
+            legend: nil,
+            hint: nil,
+            classes: "checkbox-label__bold govuk-!-margin-top-2"),
+            collection_count: @school_options.count,
+            options: { border: true },
+            label_text: "search schools")
 
       div class="govuk-!-margin-top-6"
         = render "publishers/vacancies/vacancy_form_partials/submit", f: f

--- a/app/views/subscriptions/_fields.html.slim
+++ b/app/views/subscriptions/_fields.html.slim
@@ -10,18 +10,17 @@
     options: { remove_buttons: false }) do |filters_component|
       - filters_component.group key: "job_roles", component: f.govuk_collection_check_boxes(:job_roles, @form.job_role_options, :first, :last, small: false, legend: { text: t("jobs.filters.job_roles") }, hint: nil)
       - if current_variant?(:"2022_01_subjects_filters_test", :subjects_filters) || @form.subjects&.any?
-        - filters_component.group key: "subjects", title: t("jobs.filters.subject"), component: searchable_collection(form: f,
-                                                                                                                      input_type: :checkbox,
-                                                                                                                      attribute_name: :subjects,
-                                                                                                                      collection: SUBJECT_OPTIONS,
-                                                                                                                      value_method: :first,
-                                                                                                                      text_method: :first,
-                                                                                                                      hint_method: :last,
-                                                                                                                      threshold: 10,
-                                                                                                                      label_text: "Subject",
-                                                                                                                      small: false,
-                                                                                                                      scrollable: true,
-                                                                                                                      options: { bold_items: false, heading: t("jobs.filters.subject") })
+        - filters_component.group key: "subjects", title: t("jobs.filters.subject"), component: searchable_collection(collection: f.govuk_collection_check_boxes(:subjects,
+          SUBJECT_OPTIONS,
+          :first,
+          :first,
+          :last,
+          small: false,
+          legend: nil,
+          hint: nil),
+          collection_count: SUBJECT_OPTIONS.count,
+          options: { scrollable: true, border: true },
+          label_text: t("jobs.filters.subject"))
       - filters_component.group key: "ect_suitable", component: f.govuk_collection_check_boxes(:job_roles, @form.ect_suitable_options, :first, :last, small: false, legend: { text: t("jobs.filters.ect_suitable") }, hint: nil)
       - filters_component.group key: "send_responsible", component: f.govuk_collection_check_boxes(:job_roles, @form.send_responsible_options, :first, :last, small: false, legend: { text: t("jobs.filters.send_responsible") }, hint: nil)
       - filters_component.group key: "education_phase", component: f.govuk_collection_check_boxes(:phases, @form.phase_options, :first, :last, small: false, legend: { text: t("jobs.filters.phases") }, hint: nil)

--- a/app/views/vacancies/_filters.html.slim
+++ b/app/views/vacancies/_filters.html.slim
@@ -63,20 +63,18 @@ ruby:
         - rb.group(**filter_type)
     - filters_component.group key: "job_roles", component: f.govuk_collection_check_boxes(:job_roles, @form.job_role_options, :first, :last, small: true, legend: { text: t("jobs.filters.job_roles") }, hint: nil, form_group: { data: { action: "change->form#submitListener" } })
     - if current_variant?(:"2022_01_subjects_filters_test", :subjects_filters)
-      - filters_component.group key: "subjects", title: t("jobs.filters.subject"), component: searchable_collection(form: f,
-                                                                                                                    input_type: :checkbox,
-                                                                                                                    attribute_name: :subjects,
-                                                                                                                    collection: SUBJECT_OPTIONS,
-                                                                                                                    value_method: :first,
-                                                                                                                    text_method: :first,
-                                                                                                                    hint_method: :last,
-                                                                                                                    threshold: 10,
-                                                                                                                    label_text: "Subject",
-                                                                                                                    border: false,
-                                                                                                                    small: true,
-                                                                                                                    scrollable: true,
-                                                                                                                    form_group: { data: { action: "change->form#submitListener" } },
-                                                                                                                    options: { bold_items: false, heading: t("jobs.filters.subject") })
+      - filters_component.group key: "subjects", title: t("jobs.filters.subject"), component: searchable_collection(collection: f.govuk_collection_check_boxes(:subjects,
+          SUBJECT_OPTIONS,
+          :first,
+          :first,
+          :last,
+          small: true,
+          legend: nil,
+          hint: nil,
+          form_group: { data: { action: "change->form#submitListener" } }),
+          collection_count: SUBJECT_OPTIONS.count,
+          options: { scrollable: true },
+          label_text: t("jobs.filters.subject"))
     - filters_component.group key: "ect_suitable", component: f.govuk_collection_check_boxes(:job_roles, @form.ect_suitable_options, :first, :last, small: true, legend: { text: t("jobs.filters.ect_suitable") }, hint: nil, form_group: { data: { action: "change->form#submitListener" } })
     - filters_component.group key: "send_responsible", component: f.govuk_collection_check_boxes(:job_roles, @form.send_responsible_options, :first, :last, small: true, legend: { text: t("jobs.filters.send_responsible") }, hint: nil, form_group: { data: { action: "change->form#submitListener" } })
     - filters_component.group key: "education_phase", component: f.govuk_collection_check_boxes(:phases, @form.phase_options, :first, :last, small: true, legend: { text: t("jobs.filters.phases") }, hint: nil, form_group: { data: { action: "change->form#submitListener" } })

--- a/spec/components/searchable_collection_component_spec.rb
+++ b/spec/components/searchable_collection_component_spec.rb
@@ -5,28 +5,27 @@ RSpec.describe SearchableCollectionComponent, type: :component do
 
   let(:form) { instance_double(GOVUKDesignSystemFormBuilder::FormBuilder) }
   let(:collection) { [1, 2, 3, 4, 5].freeze }
-  let(:options) { { threshold: 10, input_type: :radio_button } }
+  let(:options) { {} }
 
   let(:inline_component) { render_inline(subject) }
 
   before do
-    allow(form).to receive(:govuk_collection_radio_buttons)
     allow(form).to receive(:govuk_collection_check_boxes)
   end
 
   let(:base) do
     {
-      form: form,
       label_text: "search colllection",
-      attribute_name: :attributes,
-      collection: collection,
-      text_method: :first,
-      hint_method: :first,
-      value_method: :first,
+      collection: form.govuk_collection_check_boxes(:attributes,
+                                                    collection,
+                                                    :first,
+                                                    :first,
+                                                    :first),
+      collection_count: collection.count,
     }
   end
 
-  let(:kwargs) { { collection: collection, form: form, input_type: :checkbox, attribute_name: :attributes, text_method: :first, hint_method: :first, value_method: :first } }
+  let(:kwargs) { { collection: collection, collection_count: collection.count } }
 
   it_behaves_like "a component that accepts custom classes"
   it_behaves_like "a component that accepts custom HTML attributes"
@@ -44,7 +43,7 @@ RSpec.describe SearchableCollectionComponent, type: :component do
   end
 
   context "when using an item threshold of lower or equal than collection size" do
-    let(:options) { { threshold: collection.size, input_type: :checkbox } }
+    let(:options) { { options: { threshold: collection.size, border: true } } }
 
     it "is searchable" do
       expect(subject.searchable?).to be_truthy
@@ -58,54 +57,6 @@ RSpec.describe SearchableCollectionComponent, type: :component do
 
     it "is scrollable" do
       expect(subject.scrollable).to be_truthy
-    end
-  end
-
-  context "when the size of the collection items required has not been not specified" do
-    before { allow(subject).to receive(:searchable?).and_return(false) }
-
-    it "sets small to nil" do
-      expect(subject.small).to be_nil
-    end
-
-    it "sets the size of the collection items to the value returned by #searchable?" do
-      expect(subject.small_items?).to eq(false)
-    end
-  end
-
-  context "when the size of the collection items required is specified" do
-    context "when small is true" do
-      before { options.merge!(small: true) }
-
-      it "sets the size of the collection items to be small" do
-        expect(subject.small_items?).to be_truthy
-      end
-    end
-
-    context "when small is false" do
-      before { options.merge!(small: false) }
-
-      it "sets the size of the collection items to be large" do
-        expect(subject.small_items?).to be_falsey
-      end
-    end
-  end
-
-  context "when the input type provided is :radio_button" do
-    it "renders a collection of radio buttons" do
-      expect(form).to receive(:govuk_collection_radio_buttons)
-
-      render_inline(subject)
-    end
-  end
-
-  context "when the input type provided is :checkbox" do
-    before { options.merge!(input_type: :checkbox) }
-
-    it "renders a collection of checkboxes" do
-      expect(form).to receive(:govuk_collection_check_boxes)
-
-      render_inline(subject)
     end
   end
 end


### PR DESCRIPTION
this i felt needed doing before i do any stimulus JS on this component

a stab at simplfying and removing unused arguments

also injects collection components to remove internal logic that is nothing to do with searchable collection. Also i felt injecting a form into this should not be neccessary for what this does.