### PR TITLE
Fix display issues for job roles

### DIFF
--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -76,12 +76,11 @@ class VacancyPresenter < BasePresenter
     model_working_patterns.compact.map(&:upcase).join(", ")
   end
 
-  def all_job_roles
-    # TODO: This line can go at some point after the 30th of September 2021 (when all the legacy vacancies have expired)
-    #       and once people no longer need to view the legacy vacancies for reference.
-    return show_job_roles unless main_job_role
-
-    safe_join [show_main_job_role, tag.br, model.additional_job_roles.map { |role| tag.span additional_job_role(role), class: "govuk-!-margin-bottom-0" }]
+  def job_role_names
+    [
+      show_main_job_role,
+      *additional_job_roles.map { |role| additional_job_role(role) },
+    ]
   end
 
   def show_main_job_role

--- a/app/views/vacancies/_job_details.html.slim
+++ b/app/views/vacancies/_job_details.html.slim
@@ -6,7 +6,10 @@ section#job-details class="govuk-!-margin-bottom-5"
     - if vacancy.job_roles.any?
       - summary_list.row do |row|
         - row.key text: t("jobs.job_role")
-        - row.value text: vacancy.all_job_roles
+        - row.value do
+          ul.govuk-list
+            - vacancy.job_role_names.each do |role|
+              li = role
 
     - if vacancy.key_stages.any?
       - summary_list.row do |row|

--- a/spec/presenters/vacancy_presenter_spec.rb
+++ b/spec/presenters/vacancy_presenter_spec.rb
@@ -162,20 +162,6 @@ RSpec.describe VacancyPresenter do
     end
   end
 
-  describe "#all_job_roles" do
-    let(:vacancy) { build_stubbed(:vacancy) }
-
-    it "returns the main job role" do
-      expect(subject.all_job_roles).to include subject.show_main_job_role
-    end
-
-    it "returns the additional job roles" do
-      vacancy.additional_job_roles.each do |additional_job_role|
-        expect(subject.all_job_roles).to include subject.additional_job_role(additional_job_role)
-      end
-    end
-  end
-
   describe "#working_patterns" do
     context "when working_patterns is unset" do
       let(:vacancy) { build_stubbed(:vacancy, :without_working_patterns) }

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -195,7 +195,7 @@ module VacancyHelpers
   def verify_vacancy_show_page_details(vacancy)
     vacancy = VacancyPresenter.new(vacancy)
     expect(page).to have_content(vacancy.job_title)
-    expect(page).to have_content(strip_tags(vacancy.all_job_roles))
+    expect(page).to have_content(vacancy.show_main_job_role)
     expect(page).to have_content(vacancy.show_subjects)
 
     expect(page).to have_content(strip_tags(vacancy.show_working_patterns))


### PR DESCRIPTION
These are currently a bunch of spans separated (or not) by `<br>`s.
This turns them into a list, but ideally the whole code for presenters
needs refactoring in the future.

### Before
<img width="638" alt="image" src="https://user-images.githubusercontent.com/72141/155324684-0afb9bc6-b6fe-4d0a-8c4c-4a3d87b4c445.png">

### After
<img width="726" alt="image" src="https://user-images.githubusercontent.com/72141/155324621-0e81b735-4795-4826-9d11-e2355128423f.png">
