### PR TITLE
correct odd autocomplete behaviour

### DIFF
--- a/app/frontend/src/components/autocomplete/autocomplete.js
+++ b/app/frontend/src/components/autocomplete/autocomplete.js
@@ -33,7 +33,6 @@ export default class extends Controller {
         element: this.element.getElementsByClassName(SUGGESTIONS_CLASSNAME).item(0),
         id: formInput.id,
         name: formInput.name,
-        defaultValue: currentInputValue,
         displayMenu: position,
         source: (query, populateResults) => {
           currentInputValue = query;
@@ -43,7 +42,6 @@ export default class extends Controller {
         templates: {
           suggestion: (value) => suggestionHTML(value, currentInputValue),
         },
-        tNoResults: () => 'Loading...',
       });
     }
   }


### PR DESCRIPTION
from bug party, a little bit of strange behaviour i noticed on location autocomplete

basically when the input goes above the threshold to find locations, the input value is set as the autocomplete default value. then when you delete characters to go under the threshold that value remains in the script and odd behaviour like re-quering the API can happen. bit tricky to describe

basically `defaultValue` should not be used like this, i am not entirely sure why i put it there in the first place!

just used accessible autocomplete defaults for state text - removed `tNoResults`