### PR TITLE
[TEVA-3770]-Upgrade Cloudfront-tls-policy-to TLSv1.2_2021

### DIFF
--- a/terraform/app/modules/cloudfront/variables.tf
+++ b/terraform/app/modules/cloudfront/variables.tf
@@ -33,7 +33,7 @@ locals {
   domain                                                 = var.is_production ? local.cloudfront_cert_cn : "${var.environment}.${local.cloudfront_cert_cn}"
   cloudfront_aliases_cnames                              = [for zone in var.route53_zones : "${var.route53_cname_record}.${zone}"]
   cloudfront_aliases                                     = concat(var.route53_a_records, local.cloudfront_aliases_cnames)
-  cloudfront_viewer_certificate_minimum_protocol_version = "TLSv1.2_2018"
+  cloudfront_viewer_certificate_minimum_protocol_version = "TLSv1.2_2021"
   cloudfront_custom_response = {
     404 = { ttl = "10" },
     500 = { ttl = "60", response_code = "500", page_path = "${var.offline_bucket_origin_path}/index.html" },


### PR DESCRIPTION


## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3770

Security policies determine the SSL/TLS protocol that CloudFront uses to communicate with viewers,
and the available ciphers that CloudFront can use to encrypt content sent to end users.
The TLSv1.2_2021 policy sets the minimum negotiated Transport Layer Security (TLS) version to 1.2 and supports the six ciphers listed above.
You can update your CloudFront distribution configuration to use this new security policy by
using the AWS Management Console, Amazon CloudFront APIs, or AWS CloudFormation.