### PR TITLE
[TEVA-3904]-remove-passing-aws-secrets-a-inputs-to-workflow-dispatch

### DIFF
--- a/.github/workflows/deploy_app_via_workflow_dispatch.yml
+++ b/.github/workflows/deploy_app_via_workflow_dispatch.yml
@@ -12,12 +12,7 @@ on:
       pr_id:
         description: Pull Request
         required: false
-      aws-access-key-id:
-        description: AWS-ID
-        required: true
-      aws-secret-access-key:
-        description: AWS-KEY
-        required: true
+
 
 env:
  DOCKER_REPOSITORY: ghcr.io/dfe-digital/teaching-vacancies
@@ -35,5 +30,5 @@ jobs:
         environment: ${{ env.ENVIRONMENT }}
         tag: ${{ env.DOCKER_IMAGE_TAG }}
         pr_id: ${{ github.event.number }}
-        aws-access-key-id: ${{ inputs.aws-access-key-id}}
-        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Jira ticket URL

- Just add the ticket number to the end:

https://dfedigital.atlassian.net/browse/TEVA-3904

## Changes in this PR:

As is, the `deploy job` of the `build and deploy` workflow passes aws secrets as inputs as into the `Deploy App via workflow Dispatch` worklow. This is not necessary as the `Deploy App via workflow Dispatch` can read the secrets itself.