### PR TITLE
align cancel button correctly and consistently

### DIFF
--- a/app/views/publishers/vacancies/confirm_destroy.html.slim
+++ b/app/views/publishers/vacancies/confirm_destroy.html.slim
@@ -11,6 +11,7 @@
 
     h3.govuk-heading-m = t(".are_you_sure")
 
-    = govuk_button_link_to t("buttons.confirm_deletion"), organisation_job_path(vacancy.id), method: :delete, class: "govuk-button--warning"
+    .govuk-button-group
+      = govuk_button_link_to t("buttons.confirm_deletion"), organisation_job_path(vacancy.id), method: :delete, class: "govuk-button--warning"
 
-    = govuk_link_to t("buttons.cancel"), organisation_job_path(vacancy.id), class: "govuk-link--no-visited-state"
+      = govuk_link_to t("buttons.cancel"), organisation_job_path(vacancy.id), class: "govuk-link--no-visited-state"

--- a/app/views/subscriptions/unsubscribe.html.slim
+++ b/app/views/subscriptions/unsubscribe.html.slim
@@ -8,5 +8,7 @@
 
     p.govuk-body = t(".confirmation")
 
-    = govuk_button_to t("buttons.unsubscribe"), subscription_path(@subscription.token), method: :delete, class: "govuk-button--warning govuk-!-margin-top-2"
-    = govuk_link_to t("buttons.cancel"), root_path
+    .govuk-button-group
+      = govuk_button_link_to t("buttons.unsubscribe"), subscription_path(@subscription.token), method: :delete, class: "govuk-button--warning"
+
+      = govuk_link_to t("buttons.cancel"), root_path, class: "govuk-link--no-visited-state"


### PR DESCRIPTION
from bug party

use govuk button group for consistent/correct layout

before

![Screenshot 2022-02-28 at 11 15 57](https://user-images.githubusercontent.com/1792451/155974230-bd9bdb04-22f7-4237-893a-595dd1f4ffea.png)
![Screenshot 2022-02-28 at 11 13 57](https://user-images.githubusercontent.com/1792451/155974049-b6c29234-7513-4306-88ac-21c6bcb2deee.png)

after

![Screenshot 2022-02-28 at 11 14 15](https://user-images.githubusercontent.com/1792451/155974044-b4e99611-887b-4328-a741-5edb16c4ba66.png)
![Screenshot 2022-02-28 at 11 13 24](https://user-images.githubusercontent.com/1792451/155974050-0e553f7c-bff9-4fae-8829-5ca37b5d3e12.png)


