### PR TITLE
[TEVA-3931] Enable long term metrics in grafana

### DIFF
--- a/terraform/monitoring/resources.tf
+++ b/terraform/monitoring/resources.tf
@@ -13,6 +13,7 @@ module "prometheus_all" {
   alertmanager_slack_channel   = local.alertmanager_slack_channel
   grafana_google_client_id     = local.secrets.grafana_google_client_id
   grafana_google_client_secret = local.secrets.grafana_google_client_secret
+  enable_prometheus_yearly     = true
   redis_services = [
     "${local.service_name}-production/${local.service_name}-redis-queue-production",
     "${local.service_name}-production/${local.service_name}-redis-cache-production",


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3931

## Changes in this PR:

Allow displaying billing data for the past 12 months
See: https://github.com/DFE-Digital/cf-monitoring/#retention-policy

## How to review
Run plan:

```
aws-vault exec Deployments -- make terraform-monitoring-plan passcode=xxx
```
It should show the new "prometheus yearly" components