### PR TITLE
Fix translation for previous misspelled landing page

### DIFF
--- a/config/locales/landing_pages.yml
+++ b/config/locales/landing_pages.yml
@@ -188,7 +188,7 @@ en:
       title: "Humanities & Social Sciences teacher jobs"
       heading: "%{count} politics, humanities and social sciences teacher jobs"
       meta_description: "Search the latest jobs for humanities and politics teachers near you. Set up alerts and apply for roles teaching the various areas of social science."
-    psychology-philosophy-sociology-re-teacher jobs:
+    psychology-philosophy-sociology-re-teacher-jobs:
       name: "Psychology, Sociology and RE"
       title: "Psychology, Sociology & RE Teacher Jobs"
       heading: "%{count} psychology, philosophy, sociology and RE teacher jobs"


### PR DESCRIPTION
I fixed it in one file but it was also broken in the other.