### PR TITLE
Assorted Sentry improvements

### DIFF
--- a/app/frontend/src/application.js
+++ b/app/frontend/src/application.js
@@ -1,5 +1,4 @@
 import * as Sentry from '@sentry/browser';
-import { BrowserTracing } from '@sentry/tracing';
 
 import 'core-js/modules/es.weak-map';
 import 'core-js/modules/es.weak-set';
@@ -28,8 +27,8 @@ Sentry.init({
   dsn: window.sentryConfig.dsn,
   environment: window.sentryConfig.environment,
   release: window.sentryConfig.release,
-  integrations: [new BrowserTracing()],
-  tracesSampleRate: 1.0, // Capture _all_ errors
+  integrations: [],
+  tracesSampleRate: 0, // Disable tracing (performance monitoring, doesn't impact errors)
 });
 
 const application = Application.start();

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@hotwired/stimulus": "^3.0.1",
     "@rails/webpacker": "^5.4.2",
     "@sentry/browser": "^6.17.9",
-    "@sentry/tracing": "^6.18.1",
     "@stimulus/polyfills": "^2.0.0",
     "accessible-autocomplete": "^2.0.4",
     "axios": "^0.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1335,17 +1335,6 @@
     "@sentry/types" "6.18.1"
     tslib "^1.9.3"
 
-"@sentry/tracing@^6.18.1":
-  version "6.18.1"
-  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.18.1.tgz#7cc54b328dd051102900ade53e907e7441426f83"
-  integrity sha512-OxozmSfxGx246Ae1XhO01I7ZWxO3briwMBh55E5KyjQb8fuS9gVE7Uy8ZRs5hhNjDutFAU7nMtC0zipfVxP6fg==
-  dependencies:
-    "@sentry/hub" "6.18.1"
-    "@sentry/minimal" "6.18.1"
-    "@sentry/types" "6.18.1"
-    "@sentry/utils" "6.18.1"
-    tslib "^1.9.3"
-
 "@sentry/types@6.18.1":
   version "6.18.1"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.18.1.tgz#e2de38dd0da8096a5d22f8effc6756c919266ede"


### PR DESCRIPTION
- Disable frontend performance monitoring (this was accidentally enabled
  and is costing $$$ when we don't really use it)
- Add more helpful tags to Omniauth error logging; remove use of word
  'auth' in log message to avoid triggering Sentry sensitive data
  filtering