### PR TITLE
Fix configuration of sensitive log filter

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -3,19 +3,13 @@
 # Configure sensitive parameters which will be filtered from the log file.
 Rails.application.config.filter_parameters += %i[
   email
-  email_address
   password
-
   national_insurance_number
-
-  age
   disability
   ethnicity
-  ethnicity_description
   gender
-  gender_description
   orientation
-  orientation_description
   religion
-  religion_description
+] + [
+  /^age$/i,
 ]


### PR DESCRIPTION
When passing symbols to `Rails.application.config.filter_parameters`,
any parameter with a name _containing_ this text will be filtered. This
was causing issues with Sentry, whose `message` field gets filtered out
because it contains the string "age" (which we do want to filter).

- Move `age` filter to be a regex instead that only applies to the whole
  word "age"
- Remove redundant filters that are covered by other filters anyway

<img width="643" alt="image" src="https://user-images.githubusercontent.com/72141/156781765-48b69711-6049-4121-8b9f-d4811e0a2e7e.png">