### PR TITLE
Remove `bullet` gem for now

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,7 +96,6 @@ group :development, :test do
   gem "axe-core-capybara"
   gem "axe-core-rspec"
   gem "brakeman"
-  gem "bullet"
   gem "byebug", platforms: %i[mri mingw x64_mingw]
   gem "dotenv-rails"
   gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,9 +121,6 @@ GEM
     breasal (0.0.1)
     browser (5.3.1)
     builder (3.2.4)
-    bullet (7.0.1)
-      activesupport (>= 3.0.0)
-      uniform_notifier (~> 1.11)
     byebug (11.1.3)
     capybara (3.36.0)
       addressable
@@ -626,7 +623,6 @@ GEM
       unf_ext
     unf_ext (0.0.8)
     unicode-display_width (2.1.0)
-    uniform_notifier (1.14.2)
     validate_email (0.1.6)
       activemodel (>= 3.0)
       mail (>= 2.2.5)
@@ -705,7 +701,6 @@ DEPENDENCIES
   brakeman
   breasal
   browser
-  bullet
   byebug
   capybara
   climate_control

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -55,14 +55,6 @@ Rails.application.configure do
   # Use test geocoder lookup, unless otherwise specified
   config.geocoder_lookup = :test
 
-  # Bullet gem configuration
-  config.after_initialize do
-    Bullet.enable = true
-    # TODO: Causing lots of issues with FactoryBot-created qualification results
-    #   see: https://github.com/flyerhzm/bullet/issues/435
-    Bullet.raise = false
-  end
-
   config.active_storage.service = :test
 
   require "fake_dsi_sign_out_endpoint"


### PR DESCRIPTION
This was causing lots of issues with FactoryBot associations triggering
false positives (https://github.com/flyerhzm/bullet/issues/435) so we
disabled it.

There has been no progress on the issue, so having the gem around serves
little purpose. In addition, when we upgrade to Rails 7, we will be able
to take advantage of similar functionality that comes in the box.