### PR TITLE
Fix N+1 query in `VacancySearch`

### DIFF
--- a/app/services/search/vacancy_search.rb
+++ b/app/services/search/vacancy_search.rb
@@ -60,7 +60,7 @@ class Search::VacancySearch
   private
 
   def scope
-    scope = Vacancy.live
+    scope = Vacancy.live.includes(:organisations)
     scope = scope.search_by_location(location, radius) if location
     scope = scope.search_by_filter(search_criteria) if search_criteria.any?
     scope = scope.search_by_full_text(keyword) if keyword.present?

--- a/spec/services/search/vacancy_search_spec.rb
+++ b/spec/services/search/vacancy_search_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Search::VacancySearch do
 
   before do
     allow(Vacancy).to receive(:live).and_return(scope)
+    allow(scope).to receive(:includes).with(:organisations).and_return(scope)
     allow(scope).to receive(:search_by_location).with("Louth", 10).and_return(scope)
     allow(scope).to receive(:search_by_filter).and_return(scope)
     allow(scope).to receive(:search_by_full_text).with("maths teacher").and_return(scope)


### PR DESCRIPTION
In almost all situations where we search for a set of vacancies, we are
interested in the organisation data these vacancies belong to. Currently
this suffers from an N+1 query situation because we do not include the
organisations as part of the generated scope.

### Search results page: Before (65 SQL queries 🤯)

<img width="565" alt="image" src="https://user-images.githubusercontent.com/72141/156795809-d2eaa6e5-64da-41d1-aba7-d7384e9c68b3.png">

### Search results page: After (15 SQL queries 😅)

<img width="568" alt="image" src="https://user-images.githubusercontent.com/72141/156795896-64e6234f-fcb9-4f84-be2b-d407afdfcfda.png">