### PR TITLE
Fix N+1 issue in API controller

### DIFF
--- a/app/controllers/api/vacancies_controller.rb
+++ b/app/controllers/api/vacancies_controller.rb
@@ -5,7 +5,7 @@ class Api::VacanciesController < Api::ApplicationController
   MAX_API_RESULTS_PER_PAGE = 100
 
   def index
-    records = Vacancy.includes(organisation_vacancies: :organisation)
+    records = Vacancy.includes(:organisations)
                      .live
                      .page(page_number)
                      .per(MAX_API_RESULTS_PER_PAGE)


### PR DESCRIPTION
The way this controller was including the organisations didn't actually
do so, causing an N+1 issue leading to slow performance on API requests.