### PR TITLE
[TEVA-3929] Replace mail links with support request form links

### DIFF
--- a/app/views/errors/invalid_recaptcha.html.slim
+++ b/app/views/errors/invalid_recaptcha.html.slim
@@ -21,4 +21,4 @@
         | disabling any browser plugins that can interfere with websites, such as ad blockers
 
     p.govuk-body
-      | If you still cannot use the service, get in touch: #{govuk_mail_to(t("help.email"), t("help.email"), class: "link-wrap", subject: t("error_pages.invalid_recaptcha.email_subject", form: @form))}.
+      | If you still cannot use the service, #{govuk_link_to(t("error_pages.invalid_recaptcha.request_support_link"), new_support_request_path)}.

--- a/app/views/jobseekers/accounts/show.html.slim
+++ b/app/views/jobseekers/accounts/show.html.slim
@@ -19,6 +19,6 @@
 
   .govuk-grid-column-one-third
     h2.govuk-heading-m = t(".assistance.heading")
-    p.govuk-body-s = t(".assistance.content_html", link: govuk_mail_to(t("help.email"), t(".assistance.link_text")))
+    p.govuk-body-s = t(".assistance.content_html", link: govuk_link_to(t(".assistance.link_text"), new_support_request_path))
 
 - content_for :after_main, jobseekers_account_survey_link(origin: url_for)

--- a/app/views/jobseekers/passwords/check_your_email_password.html.slim
+++ b/app/views/jobseekers/passwords/check_your_email_password.html.slim
@@ -6,4 +6,4 @@
 
     p.govuk-body = t(".description")
 
-    p.govuk-body-s = t(".having_trouble_html", mail_to: govuk_mail_to(t("help.email"), t(".report_it")))
+    p.govuk-body-s = t(".having_trouble_html", request_support_link: govuk_link_to(t(".request_support_link"), new_support_request_path))

--- a/app/views/jobseekers/registrations/check_your_email.html.slim
+++ b/app/views/jobseekers/registrations/check_your_email.html.slim
@@ -12,4 +12,4 @@
 
     = govuk_details summary_text: t(".resend_summary"), text: t(".resend_text_html", resend_link: govuk_link_to(t(".resend_link"), jobseekers_resend_instructions_path),
                                                                                      restart_link: govuk_link_to(t(".restart_link"), new_jobseeker_registration_path),
-                                                                                     mail_to: govuk_mail_to(t("help.email")))
+                                                                                     request_support_link: govuk_link_to(t(".request_support_link"), new_support_request_path))

--- a/app/views/jobseekers/sessions/locked.html.slim
+++ b/app/views/jobseekers/sessions/locked.html.slim
@@ -8,4 +8,4 @@
 
     p.govuk-body-s = t(".instructions")
 
-    p.govuk-body-s = t(".having_trouble_html", mail_to: govuk_mail_to(t("help.email"), t(".report_it")))
+    p.govuk-body-s = t(".having_trouble_html", request_support_link: govuk_link_to(t(".request_support_link"), new_support_request_path))

--- a/app/views/publishers/schools/index.html.slim
+++ b/app/views/publishers/schools/index.html.slim
@@ -20,4 +20,4 @@
 
   .govuk-grid-column-one-third
     h3.govuk-heading-m = t(".missing_information_title")
-    p = t(".missing_information_description_html", organisation_type: organisation_type_basic(@organisation), mail_to: govuk_mail_to(t("help.email"), t(".contact_support")))
+    p = t(".missing_information_description_html", organisation_type: organisation_type_basic(@organisation), contact_support_link: govuk_link_to(t(".contact_support"), new_support_request_path))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -133,6 +133,7 @@ en:
   error_pages:
     invalid_recaptcha:
       email_subject: ReCAPTCHA issue - %{form}
+      request_support_link: request support
       title: Sorry, we cannot process your request
     not_found: Page not found.
     server_error: Sorry, there’s a technical issue at our end
@@ -178,6 +179,7 @@ en:
     gias_url: https://www.get-information-schools.service.gov.uk/
     report_a_problem_html: To report a problem, or for support using Teaching Vacancies, please use the %{get_help_link}
     get_help_form: support form
+    request_support_link: request support
 
   jobseekers:
     passwords:

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -372,8 +372,8 @@ en:
     passwords:
       check_your_email_password:
         description: We have sent you an email with instructions on how to reset your password.
-        having_trouble_html: Still having trouble? %{mail_to} to our support team.
-        report_it: Report it
+        having_trouble_html: Still having trouble? %{request_support_link}.
+        request_support_link: Request support
         title: Check your email
       edit:
         new_password: New password
@@ -392,8 +392,9 @@ en:
         description: "We have sent you an email with instructions on how to verify your email address. We sent the email to:"
         having_trouble_html: Still having trouble? %{mail_to} to our support team.
         report_it: Report it
+        request_support_link: Request support
         resend_summary: Need us to resend the email?
-        resend_text_html: If you did not receive the email, you can %{resend_link} or %{restart_link}.<br><br>Need help? Email us at %{mail_to}
+        resend_text_html: If you did not receive the email, you can %{resend_link} or %{restart_link}.<br><br>Need help? %{request_support_link}.
         resend_link: request a new one
         restart_link: provide another email address
         title: Check your email
@@ -455,10 +456,10 @@ en:
         title: Jobseeker sign in
       locked:
         description: You have been locked out of your account because you have made too many attempts to log in.
-        having_trouble_html: Still having trouble? %{mail_to} to our support team.
+        having_trouble_html: Still having trouble? %{request_support_link}.
         heading: Too many password attempts
         instructions: We have sent an email to your registered email address with instructions on how to unlock your account.
-        report_it: Report it
+        request_support_link: Request support
         title: Too many password attempts
     subscriptions:
       index:

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -60,7 +60,7 @@ en:
         missing_information_title: Is information missing or incorrect?
         missing_information_description_html: >-
           If a school in your %{organisation_type} is missing from this list,
-          or the information isn't correct, please %{mail_to}.
+          or the information isn't correct, please %{contact_support_link}.
         schools: Schools (%{count})
         title: Schools in your %{organisation_type}
       edit:


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3929

## Changes in this PR:

This PR replaces mailto links in a support context with a link to the support form - `new_support_request_path`