### PR TITLE
[TEVA-3928] Remove flash message for jobseeker signin/up

### DIFF
--- a/app/controllers/jobseekers/sessions_controller.rb
+++ b/app/controllers/jobseekers/sessions_controller.rb
@@ -32,6 +32,8 @@ class Jobseekers::SessionsController < Devise::SessionsController
         store_return_location(jobseeker_root_path, scope: :jobseeker)
       end
     end
+
+    flash.delete(:notice)
   end
 
   private

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -34,7 +34,6 @@ en:
       updated: Your account has been updated successfully.
       updated_but_not_signed_in: Your account has been updated successfully, but since your password was changed, you need to sign in again
     sessions:
-      signed_in: Welcome to your Teaching Vacancies account.
       signed_out: You have been successfully signed out.
       already_signed_out: Signed out successfully.
     unlocks:


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3928

## Changes in this PR:

This PR removes the blue-bordered flash message shown upon a jobseeker signing in or signing up.
