### PR TITLE
Configure Ruby extension to use Rubocop `forceExclusion`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -44,7 +44,8 @@
     "ruby.format": "rubocop",
     "ruby.lint": {
       "rubocop": {
-        "useBundler": false
+        "useBundler": false,
+        "forceExclusion": true
       }
     },
     "ruby.useLanguageServer": true,


### PR DESCRIPTION
This means when viewing files such as `db/schema.rb` that are excluded
from all cops in `.rubocop.yml`, VS Code won't start squiggly
underlining everything and showing it in the "problems" view.