### PR TITLE
[TEVA-3946] Increase sort component limit for select dropdown

### DIFF
--- a/app/components/publishers/vacancies_component/vacancies_component.html.slim
+++ b/app/components/publishers/vacancies_component/vacancies_component.html.slim
@@ -13,6 +13,9 @@
     - tabs.navigation_item text: t(".#{vacancy_type}.tab_heading"), link: jobs_with_type_organisation_path(vacancy_type), active: selected_type == vacancy_type
 
 .govuk-grid-row.vacancies-component class="govuk-!-margin-bottom-7"
+  - if @vacancies.many?
+    .govuk-grid-column-full
+      = render SortComponent.new sort: @sort, url_params: { type: @selected_type }, path: method(:jobs_with_type_organisation_path)
   - if @organisation.school_group?
     .govuk-grid-column-one-third-at-desktop class="govuk-!-margin-bottom-4"
       - if @publisher_preference
@@ -30,10 +33,7 @@
                       - filters_component.group key: "locations", component: f.govuk_collection_check_boxes(:organisation_ids, @organisation_options, :id, :label, small: true, legend: { text: "Locations" }, hint: nil, form_group: { data: { action: "change->form#submitListener" } })
 
           = f.hidden_field :jobs_type, value: @selected_type
-
   .govuk-grid-column-two-thirds-at-desktop.vacancies-component__content
-    - if @vacancies.many?
-      = render SortComponent.new sort: @sort, url_params: { type: @selected_type }, path: method(:jobs_with_type_organisation_path)
     section#vacancy-results
       - if vacancies.none?
         = empty_section do

--- a/app/components/sort_component/sort_component.html.slim
+++ b/app/components/sort_component/sort_component.html.slim
@@ -1,5 +1,5 @@
 = tag.div(class: classes, **html_attributes) do
-  - if sort.count > 2
+  - if sort.count > 4
     = form_for sort_form, as: "", url: path.call(url_params), method: :get, data: { controller: "form", "hide-submit": true } do |f|
       = f.govuk_collection_select :sort_by,
         sort,

--- a/app/components/sort_component/sort_component.scss
+++ b/app/components/sort_component/sort_component.scss
@@ -14,7 +14,7 @@
   &__list-item {
     display: inline-block;
 
-    &:first-child::after {
+    &:not(:last-child)::after {
       border-right: 1px solid $govuk-border-colour;
       content: '';
       display: inline-block;

--- a/spec/components/sort_component_spec.rb
+++ b/spec/components/sort_component_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe SortComponent, type: :component do
     end
   end
 
-  context "when there are two sorting options available" do
-    let(:number_of_sorting_options) { 2 }
+  context "when there are four sorting options available" do
+    let(:number_of_sorting_options) { 4 }
 
     it "renders the list instead of the drop-down" do
       expect(page).to have_css("ul.sort-component__list")
@@ -57,8 +57,8 @@ RSpec.describe SortComponent, type: :component do
     end
   end
 
-  context "when there are more than two sorting options available" do
-    let(:number_of_sorting_options) { 3 }
+  context "when there are more than four sorting options available" do
+    let(:number_of_sorting_options) { 5 }
 
     it "renders the drop-down instead of the list" do
       expect(page).to have_css("select[name='sort_by']")


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3946

## Changes in this PR:

This PR changes the limit for the `SortComponent` to render a dropdown select rather than links from 2 to 4. This affects both the hiring staff dashboard and the jobseeker dashboard. The links on the hiring staff dashboard are now in a full width component to prevent wrapping on desktop.

## Screenshots of UI changes:

### Before
![image](https://user-images.githubusercontent.com/24639777/157700776-ef00f444-c42b-42f3-9fe9-2e125a1fdc4b.png)

### After
![image](https://user-images.githubusercontent.com/24639777/157700612-b5cafbde-51c4-436d-8ff3-f24d058ae9a3.png)


