### PR TITLE
Add missing subject to landing page

### DIFF
--- a/config/landing_pages.yml
+++ b/config/landing_pages.yml
@@ -57,6 +57,7 @@ shared:
   art-design-technology-teacher-jobs:
     subjects:
       - Art and design
+      - Design and technology
   biology-teacher-jobs:
     subjects:
       - Biology


### PR DESCRIPTION
The "Art and Design Technology" didn't actually include Design
Technology, oops!