### PR TITLE
Add whitespace to posts show page

### DIFF
--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -20,4 +20,4 @@
       span.govuk-body-s
         = t(".published_on")
         time datetime=@post.date_posted.to_formatted_s(:db)
-          = @post.date_posted.to_formatted_s
+          =< @post.date_posted.to_formatted_s


### PR DESCRIPTION
The space added ensures sufficient spacing between the translation text and the date

## Screenshots of UI changes:

### Before
<img width="302" alt="image" src="https://user-images.githubusercontent.com/24639777/158426201-9f56ee19-397b-464a-8245-28dd76e5c955.png">

### After
<img width="287" alt="image" src="https://user-images.githubusercontent.com/24639777/158426142-03b5d6eb-4002-4781-a1ee-b0b9debf88ec.png">
