### PR TITLE
[TEVA-3944] Add action to strip whitespace from attributes

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,6 +1,8 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
+  before_save :strip_attributes
+
   after_create { EventContext.trigger_event(:entity_created, event_data) }
   after_update { EventContext.trigger_event(:entity_updated, event_data) unless saved_change_to_attribute?(:last_activity_at) }
   after_destroy { EventContext.trigger_event(:entity_destroyed, event_data) }
@@ -41,5 +43,9 @@ class ApplicationRecord < ActiveRecord::Base
     when Array
       value.map { |string| StringAnonymiser.new(string).to_s }
     end
+  end
+
+  def strip_attributes
+    attributes.each_value { |value| value.try(:strip!) unless value.frozen? }
   end
 end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3944

## Changes in this PR:

This PR adds a `before_save` action to the `ApplicationRecord` model to ensure that leading or trailing whitespace (such as that added by user input) is stripped from model parameters before saving to the database.