### PR TITLE
[TEVA-3987] Change "date drafted" to "date created" for draft vacancies

### DIFF
--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -99,7 +99,7 @@ en:
         descending:
           saved_job: date added (most recent)
           subscription: date subscribed (most recent)
-          vacancy: date drafted (most recent)
+          vacancy: date created (most recent)
       expires_at:
         ascending:
           saved_job: application deadline (soonest)
@@ -302,7 +302,7 @@ en:
         no_jobs:
           no_filters: You currently have no draft jobs.
           with_filters: There are no draft jobs for the schools you have selected.
-        time_created: Date drafted
+        time_created: Date created
         time_updated: Date last updated
       edit_link_text: Edit listing
       extend_link_text: Extend deadline


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3987

## Screenshots of UI changes:

### Before
<img width="626" alt="Screenshot 2022-03-17 at 11 15 40" src="https://user-images.githubusercontent.com/109225/158797709-80aaa56d-4277-4ee2-a0ef-89267fea97d5.png">

### After
<img width="429" alt="Screenshot 2022-03-17 at 11 14 44" src="https://user-images.githubusercontent.com/109225/158797724-1b2e7d7e-030f-4dc5-8d60-3c38ee7eeccf.png">

