### PR TITLE
[TEVA-3943] Add links to help guides

### DIFF
--- a/app/components/dashboard_component.rb
+++ b/app/components/dashboard_component.rb
@@ -14,7 +14,7 @@ class DashboardComponent < ViewComponent::Base
   end
 
   def grid_column_class
-    organisation.school_group? ? "govuk-grid-column-two-thirds-at-desktop" : "govuk-grid-column-full"
+    organisation.school_group? ? "govuk-grid-column-two-thirds-at-desktop" : "govuk-grid-column-three-quarters"
   end
 
   def no_jobs_text

--- a/app/components/dashboard_component/dashboard_component.html.slim
+++ b/app/components/dashboard_component/dashboard_component.html.slim
@@ -1,5 +1,11 @@
 .govuk-grid-row
   .govuk-grid-column-three-quarters
+    .help-guide-container--mobile.help-guide-container--border-bottom
+      h3.govuk-heading-m = t("jobs.dashboard.how_to_accept_job_applications_guide.title")
+      p.govuk-body = t("jobs.dashboard.how_to_accept_job_applications_guide.description_mobile")
+      = govuk_link_to(t("jobs.dashboard.how_to_accept_job_applications_guide.link_text"),
+                      post_path(section: "get-help-hiring", post_name: "accepting-job-applications-on-teaching-vacancies"),
+                      class: "govuk-link--no-visited-state")
     span.govuk-caption-l = t("jobs.manage.heading_html", organisation: @organisation.name, email: @email)
     h1.govuk-heading-l = t("jobs.dashboard.#{@selected_type}.with_count_html", count: @vacancies.count)
   .govuk-grid-column-one-quarter
@@ -33,6 +39,13 @@
                       - filters_component.group key: "locations", component: f.govuk_collection_check_boxes(:organisation_ids, @organisation_options, :id, :label, small: true, legend: { text: "Locations" }, hint: nil, form_group: { data: { action: "change->form#submitListener" } })
 
           = f.hidden_field :jobs_type, value: @selected_type
+
+      .help-guide-container--desktop class="govuk-!-margin-top-4"
+        h3.govuk-heading-m = t("jobs.dashboard.how_to_accept_job_applications_guide.title")
+        p.govuk-body = t("jobs.dashboard.how_to_accept_job_applications_guide.description_desktop")
+        = govuk_link_to(t("jobs.dashboard.how_to_accept_job_applications_guide.link_text"),
+                        post_path(section: "get-help-hiring", post_name: "accepting-job-applications-on-teaching-vacancies"),
+                        class: "govuk-link--no-visited-state")
   .vacancies-component__content class=grid_column_class
     section#vacancy-results
       - if vacancies.none?
@@ -71,3 +84,11 @@
               - when "draft"
                 = tag.div(c.labelled_item(t("jobs.manage.draft.time_created"), format_date(vacancy.created_at.to_date)))
                 = tag.div(c.labelled_item(t("jobs.manage.draft.time_updated"), format_date(vacancy.updated_at.to_date)))
+  - unless @organisation.school_group?
+    .govuk-grid-column-one-quarter
+      .help-guide-container--desktop
+        h3.govuk-heading-m = t("jobs.dashboard.how_to_accept_job_applications_guide.title")
+        p.govuk-body = t("jobs.dashboard.how_to_accept_job_applications_guide.description_desktop")
+        = govuk_link_to(t("jobs.dashboard.how_to_accept_job_applications_guide.link_text"),
+                        post_path(section: "get-help-hiring", post_name: "accepting-job-applications-on-teaching-vacancies"),
+                        class: "govuk-link--no-visited-state")

--- a/app/frontend/src/styles/application/applications.scss
+++ b/app/frontend/src/styles/application/applications.scss
@@ -17,3 +17,27 @@
     }
   }
 }
+
+.help-guide-container {
+  &--border-bottom {
+    border-bottom: 1px solid $govuk-border-colour;
+  }
+
+  &--desktop {
+    background-color: govuk-colour('light-grey');
+    padding: govuk-spacing(3);
+
+    @include govuk-media-query($until: desktop) {
+      display: none;
+    }
+  }
+
+  &--mobile {
+    margin-bottom: govuk-spacing(3);
+    padding-bottom: govuk-spacing(4);
+
+    @include govuk-media-query($from: desktop) {
+      display: none;
+    }
+  }
+}

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -23,17 +23,19 @@
   .govuk-grid-column-one-half
     h2.govuk-heading-m = t(".title_h2")
     p.govuk-body = t(".description")
-
+    p.govuk-body = t(".personal_statement_section.description_html",
+                     personal_statement_guide_link: govuk_link_to(t(".personal_statement_section.link_text"),
+                                                    post_path(section: "jobseeker-guides", post_name: "how-to-write-teacher-personal-statement"),
+                                                    class: "govuk-link--no-visited-state"))
   .govuk-grid-column-one-quarter
     h2.govuk-heading-m = t(".jobseeker_section.title")
     - if jobseeker_signed_in?
       p.govuk-body = t(".jobseeker_section.signed_in.description")
       .govuk-body class="govuk-!-margin-bottom-3" = govuk_link_to t("buttons.view_account"), jobseeker_root_path, class: "govuk-link--no-visited-state"
     - else
-      p.govuk-body = t(".jobseeker_section.signed_out.description_html",
-        sign_in_link: govuk_link_to(t("buttons.sign_in"), new_jobseeker_session_path, class: "govuk-link--no-visited-state"),
-        create_account_link: govuk_link_to(t(".jobseeker_section.signed_out.create_account"), new_jobseeker_registration_path, class: "govuk-link--no-visited-state"))
-
+      p.govuk-body = t(".jobseeker_section.signed_out.description_html")
+      = govuk_button_link_to(t("buttons.sign_in"), new_jobseeker_session_path, class: "govuk-!-margin-bottom-2")
+      p.govuk-body = t(".jobseeker_section.signed_out.create_account_html", create_account_link: govuk_link_to(t(".jobseeker_section.signed_out.link_text.create_account"), new_jobseeker_registration_path, class: "govuk-link--no-visited-state"))
   .govuk-grid-column-one-quarter
     h2.govuk-heading-m = t(".publisher_section.title")
     - if publisher_signed_in?
@@ -41,9 +43,9 @@
         create_job_link: govuk_link_to(t("buttons.create_job"), create_or_copy_organisation_jobs_path, class: "govuk-link--no-visited-state"),
         manage_jobs_link: govuk_link_to(t(".publisher_section.signed_in.link_text.manage_jobs"), organisation_path, class: "govuk-link--no-visited-state"))
     - else
-      p.govuk-body = t(".publisher_section.signed_out.description_html",
-        signin_link: govuk_link_to(t(".publisher_section.signed_out.link_text.sign_in"), publishers_sign_in_path, class: "govuk-link--no-visited-state"),
-        signup_link: govuk_link_to(t(".publisher_section.signed_out.link_text.sign_up"), page_path("dsi-account-request"), class: "govuk-link--no-visited-state"))
+      p.govuk-body = t(".publisher_section.signed_out.description_html")
+      = govuk_button_link_to(t(".publisher_section.signed_out.link_text.sign_in"), publishers_sign_in_path, class: "govuk-!-margin-bottom-2")
+      p.govuk-body = t(".publisher_section.signed_out.create_account_html", create_account_link: govuk_link_to(t(".publisher_section.signed_out.link_text.create_account"), page_path("dsi-account-request"), class: "govuk-link--no-visited-state"))
 
 hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
 

--- a/app/views/jobseekers/job_applications/build/personal_statement.html.slim
+++ b/app/views/jobseekers/job_applications/build/personal_statement.html.slim
@@ -17,10 +17,23 @@
       - else
         = t(".banner_no_documents_html", job_link: open_in_new_tab_link_to("‘#{job_application.vacancy.job_title}’", job_path(job_application.vacancy)))
 
+    .help-guide-container--mobile
+      h3.govuk-heading-m = t(".personal_statement_guide.title")
+      p.govuk-body = t(".personal_statement_guide.description_mobile")
+      = govuk_link_to(t(".personal_statement_guide.link_text"),
+                      post_path(section: "jobseeker-guides", post_name: "how-to-write-teacher-personal-statement"),
+                      class: "govuk-link--no-visited-state")
+
     - if job_application.vacancy.personal_statement_guidance.present?
       h3.govuk-heading-s = t(".additional_instructions")
       = govuk_inset_text text: job_application.vacancy.personal_statement_guidance
 
+  - if current_jobseeker.job_applications.not_draft.none?
+    .govuk-grid-column-one-third
+      = render "steps"
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
     = form_for form, url: wizard_path, method: :patch do |f|
       = f.govuk_error_summary
 
@@ -30,7 +43,10 @@
         = govuk_link_to t("buttons.cancel_and_return_to_account"), jobseekers_job_applications_path, class: "govuk-link--no-visited-state"
         span.govuk-caption-m
           = t("jobseekers.job_applications.cancel_caption")
-
-  - if current_jobseeker.job_applications.not_draft.none?
-    .govuk-grid-column-one-third
-      = render "steps"
+  .govuk-grid-column-one-third
+    .help-guide-container--desktop class="govuk-!-margin-top-6"
+      h3.govuk-heading-m = t(".personal_statement_guide.title")
+      p.govuk-body = t(".personal_statement_guide.description_desktop")
+      = govuk_link_to(t(".personal_statement_guide.link_text"),
+                      post_path(section: "jobseeker-guides", post_name: "how-to-write-teacher-personal-statement"),
+                      class: "govuk-link--no-visited-state")

--- a/app/views/layouts/_footer.html.slim
+++ b/app/views/layouts/_footer.html.slim
@@ -25,6 +25,10 @@
               = link_to t("nav.create_a_job_alert"), jobseekers_account_path, class: "govuk-footer__link"
             - else
               = link_to t("nav.sign_in"), new_jobseeker_session_path, class: "govuk-footer__link"
+          li.govuk-footer__list-item
+            = link_to t("nav.personal_statement"),
+                      post_path(section: "jobseeker-guides", post_name: "how-to-write-teacher-personal-statement"),
+                      class: "govuk-footer__link"
 
       .govuk-grid-column-three-quarters
         span.govuk-footer__heading.govuk-heading-m
@@ -35,6 +39,14 @@
               = button_to(t("footer.list_a_teaching_job"), organisation_jobs_path, class: "govuk-footer__link govuk-body-s")
             li.govuk-footer__list-item
               = link_to t("footer.manage_job_listings"), organisation_path, class: "govuk-footer__link"
+            li.govuk-footer__list-item
+              = link_to t("footer.job_ad_guide"),
+                        post_path(section: "get-help-hiring", post_name: "creating-the-perfect-teacher-job-advert"),
+                        class: "govuk-footer__link"
+            li.govuk-footer__list-item
+              = link_to t("footer.job_application_guide"),
+                        post_path(section: "get-help-hiring", post_name: "accepting-job-applications-on-teaching-vacancies"),
+                        class: "govuk-footer__link"
           - else
             li.govuk-footer__list-item
               = link_to t("nav.sign_in"), new_publisher_session_path, class: "govuk-footer__link"

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -7,6 +7,7 @@
     - else
       = header.navigation_item text: t("nav.manage_settings"), href: publishers_school_path(current_organisation), active: schools_in_your_trust_active?
     = header.navigation_item text: t("nav.notifications_html", count: current_publisher.notifications.unread.count), href: publishers_notifications_path
+    = header.navigation_item text: t("nav.school_hiring_guide"), href: posts_path(section: "get-help-hiring")
     = header.navigation_item text: t("nav.sign_out"), href: destroy_publisher_session_path, options: { method: :delete }
   - elsif jobseeker_signed_in?
     = header.navigation_item text: t("nav.find_job"), href: root_path, active: find_jobs_active?

--- a/app/views/posts/index.html.slim
+++ b/app/views/posts/index.html.slim
@@ -5,8 +5,9 @@
                                      params[:section].titleize.capitalize => "" }
 
 .govuk-grid-row
-  .govuk-grid-column-two-thirds
+  .govuk-grid-column-full
     h1.govuk-heading-xl = t(".#{params[:section]}.title")
+    p.govuk-body = t(".#{params[:section]}.description")
     ul.govuk-list
       - @posts.sort.each do |post|
         li = govuk_link_to(post.title, post_path(section: post.section, post_name: post.post_name))

--- a/app/views/publishers/vacancies/create_or_copy.html.slim
+++ b/app/views/publishers/vacancies/create_or_copy.html.slim
@@ -2,6 +2,13 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
+    .help-guide-container--mobile.help-guide-container--border-bottom
+      h3.govuk-heading-m = t(".job_ad_guide.title")
+      p.govuk-body = t(".job_ad_guide.description_mobile")
+      = govuk_link_to(t(".job_ad_guide.link_text"),
+                                                      post_path(section: "get-help-hiring", post_name: "creating-the-perfect-teacher-job-advert"),
+                                                      class: "govuk-link--no-visited-state")
+
     = form_tag organisation_jobs_path do
       .govuk-form-group
         fieldset.govuk-fieldset
@@ -18,3 +25,10 @@
       button.govuk-button = t(".form.submit")
       p class="govuk-!-margin-top-0"
         = govuk_link_to t(".cancel"), organisation_jobs_path
+  .govuk-grid-column-one-third
+    .help-guide-container--desktop
+      h3.govuk-heading-m = t(".job_ad_guide.title")
+      p.govuk-body = t(".job_ad_guide.description_desktop")
+      = govuk_link_to(t(".job_ad_guide.link_text"),
+                                                      post_path(section: "get-help-hiring", post_name: "creating-the-perfect-teacher-job-advert"),
+                                                      class: "govuk-link--no-visited-state")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -159,6 +159,8 @@ en:
       for_job_seekers: Job seekers
       for_schools: Hiring staff
       support: Support
+    job_ad_guide: How to create the perfect teacher job ad
+    job_application_guide: How to accept job applications on Teaching Vacancies
     list_a_teaching_job: List a job
     manage_job_listings: Manage job listings
     provide_feedback: Provide feedback on Teaching Vacancies
@@ -217,6 +219,8 @@ en:
       zero: Notifications
       one: Notifications <span class="count-badge">%{count}<span class="govuk-visually-hidden"> unread</span></span>
       other: Notifications <span class="count-badge">%{count}<span class="govuk-visually-hidden"> unread</span></span>
+    personal_statement: Writing a personal statement
+    school_hiring_guide: School hiring guide
     sign_in: Sign in
     sign_out: Sign out
     support_user_dashboard: Hello support user
@@ -232,26 +236,33 @@ en:
   home:
     index:
       browse_all: Browse all teaching jobs in England
-      description: Search for teaching, school leadership and education support jobs in England. You can also apply for jobs, save jobs and set up job alerts.
+      description: Search for teaching, school leadership and education support jobs in England.
       jobseeker_section:
         signed_in:
           description: Apply for jobs you are interested in, and check the status of your applications.
         signed_out:
-          create_account: create an account
-          description_html: "%{sign_in_link} or %{create_account_link} to apply for jobs that use the Teaching Vacancies application form."
-        title: Apply for jobs
+          create_account_html: or %{create_account_link}.
+          description_html: Save and apply for jobs in schools.
+          link_text:
+            create_account: create an account
+        title: For jobseekers
       location_label: City, county or postcode
+      personal_statement_section:
+        description_html: You can also apply for jobs, set up job alerts and %{personal_statement_guide_link}.
+        link_text: read advice for jobseekers
       publisher_section:
         signed_in:
           description_html: "%{create_job_link} or %{manage_jobs_link}."
           link_text:
             manage_jobs: manage your jobs
         signed_out:
-          description_html: "%{signin_link} to manage your job listings and applicants or %{signup_link}."
+          create_account_html: or %{create_account_link}.
+          description_html: Post jobs and manage applications.
           link_text:
+            create_account: create an account
             sign_in: Sign in
             sign_up: sign up
-        title: Advertise a job
+        title: For hiring staff
       title: Find a job in teaching
       title_h1: Find teacher and school jobs near you
       title_h2: Welcome to Teaching Vacancies
@@ -286,8 +297,13 @@ en:
   posts:
     index:
       get-help-hiring:
-        title: Get help with hiring
+        title: School hiring guides
+        description: >-
+          Read expert advice on how to hire excellent staff for your school.
+          Get tips on various aspects of the recruitment process and guidance on how to use the Teaching Vacancies service.
       jobseeker-guides:
+        # TODO: Add jobseeker guides description
+        description: ""
         title: Jobseeker guides
     show:
       contents: Contents

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -17,6 +17,11 @@ en:
       expired:
         tab_heading: Closed jobs
         with_count_html: Closed jobs <span class='govuk-body-l govuk-!-font-size-36'>(%{count})</span>
+      how_to_accept_job_applications_guide:
+        description_desktop: Find out the simplest way to get candidates to apply for your jobs.
+        description_mobile: Get guidance around how to accept vacancies
+        link_text: View article
+        title: How to accept job applications on Teaching Vacancies
       pending:
         tab_heading: Scheduled jobs
         with_count_html: Scheduled jobs <span class='govuk-body-l govuk-!-font-size-36'>(%{count})</span>

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -114,6 +114,11 @@ en:
             Please explain why you are suitable for this role. You should refer to the person specification in the job
             description, and include any relevant personal qualities and experiences.
           heading: Personal statement
+          personal_statement_guide:
+            description_desktop: Find out how to sell your skills and experience to school recruiters.
+            description_mobile: Get guidance around creating the perfect personal statement.
+            link_text: View article
+            title: How to write a teacher personal statement
           step_title: Personal statement
           title: Personal statement — Application
         process_title: Application steps

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -210,6 +210,11 @@ en:
             create_new: Start with a blank template
           submit: Continue
         heading: What do you want to do?
+        job_ad_guide:
+          description_desktop: Find out the essential things to include to attract the right candidates for your role.
+          description_mobile: Get guidance around how to attract top talent.
+          link_text: View article
+          title: How to create the perfect teacher job ad
         page_title: Create or copy a job listing
       destroy:
         success_html: >-

--- a/documentation/content-markdown-sample.md
+++ b/documentation/content-markdown-sample.md
@@ -1,0 +1,22 @@
+---
+order: 999
+title: Sample title
+meta_description: Sample meta-description
+date_posted: 01/01/2022
+category_tags: Category 1, Category 2, Category 3
+---
+## This is an example subtitle
+Example text
+
+## This is another example subtitle
+More example text
+
+* One
+* Two
+* Three
+
+1. One
+2. Two
+3. Three
+
+[This is a link](http://example.com)

--- a/spec/system/jobseekers_can_register_spec.rb
+++ b/spec/system/jobseekers_can_register_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Jobseekers can register" do
 
   it "allows jobseekers to reset their password" do
     visit root_path
-    click_on I18n.t("home.index.jobseeker_section.signed_out.create_account")
+    find(:xpath, "//a[@href='/jobseekers/sign_up']").click
     fill_in "jobseeker[email]", with: email
     fill_in "jobseeker[password]", with: "Jobseeker1234"
     click_on I18n.t("buttons.create_account")

--- a/spec/system/publishers_can_sign_in_with_dfe_spec.rb
+++ b/spec/system/publishers_can_sign_in_with_dfe_spec.rb
@@ -52,11 +52,9 @@ RSpec.describe "Publishers can sign in with DfE Sign In" do
       visit root_path
 
       expect(page).to have_content(I18n.t("home.index.publisher_section.title"))
-      expect(page).to have_content(I18n.t("home.index.publisher_section.signed_out.description_html",
-                                          signin_link: I18n.t("home.index.publisher_section.signed_out.link_text.sign_in"),
-                                          signup_link: I18n.t("home.index.publisher_section.signed_out.link_text.sign_up")))
+      expect(page).to have_content(I18n.t("home.index.publisher_section.signed_out.description_html"))
       expect(page).to have_link(I18n.t("home.index.publisher_section.signed_out.link_text.sign_in"), href: publishers_sign_in_path)
-      expect(page).to have_link(I18n.t("home.index.publisher_section.signed_out.link_text.sign_up"), href: page_path("dsi-account-request"))
+      expect(page).to have_link(I18n.t("home.index.publisher_section.signed_out.link_text.create_account"), href: page_path("dsi-account-request"))
     end
   end
 


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-3943

## Changes in this PR:

This PR makes some changes to the home page (see screenshots). It also adds several links to help guides published by the content team (on the publisher dashboard, the personal statement section of the job application journey, the footer, and the hiring staff header). Sample markdown documentation is added to the documentation directory.

## Screenshots of UI changes:

### Before
![image](https://user-images.githubusercontent.com/24639777/158852290-9be65e95-0166-4a01-8acd-6bf8af7e9c15.png)

### After
![image](https://user-images.githubusercontent.com/24639777/158852242-f46b92d8-0c94-4f0a-890a-a890b65c4984.png)

