### PR TITLE
fix a11y autocomplete overidding location param

### DIFF
--- a/app/frontend/src/components/autocomplete/autocomplete.js
+++ b/app/frontend/src/components/autocomplete/autocomplete.js
@@ -33,6 +33,7 @@ export default class extends Controller {
         element: this.element.getElementsByClassName(SUGGESTIONS_CLASSNAME).item(0),
         id: formInput.id,
         name: formInput.name,
+        defaultValue: currentInputValue,
         displayMenu: position,
         source: (query, populateResults) => {
           currentInputValue = query;

--- a/app/frontend/src/components/autocomplete/autocomplete.scss
+++ b/app/frontend/src/components/autocomplete/autocomplete.scss
@@ -9,6 +9,7 @@
 
   &__menu {
     position: relative;
+    z-index: 1;
   }
 
   &__suggestions--highlight {


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-3999

adjustment to previous bugfix as location param was being overwritten

also fixes z-index issue observed

before
<img width="353" alt="Screenshot 2022-03-23 at 23 56 02" src="https://user-images.githubusercontent.com/1792451/159818826-355a76c1-4517-4679-80fd-90ec2b57d1b6.png">

after
<img width="344" alt="Screenshot 2022-03-23 at 23 56 53" src="https://user-images.githubusercontent.com/1792451/159818825-236ada4d-1598-4355-9275-3ec731bfcfc9.png">


