### PR TITLE
add full screen plugin for leaflet maps

### DIFF
--- a/app/components/map_component/map.js
+++ b/app/components/map_component/map.js
@@ -34,7 +34,7 @@ const MapController = class extends Controller {
   }
 
   create(point, zoom) {
-    this.map = L.map('map', { tap: false }).setView(point, zoom);
+    this.map = L.map('map', { tap: false, fullscreenControl: true }).setView(point, zoom);
 
     L.tileLayer(
       'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',

--- a/app/components/map_component/map.scss
+++ b/app/components/map_component/map.scss
@@ -2,11 +2,12 @@
 
 .js-enabled {
   .map-component {
+    margin-bottom: govuk-spacing(4);
+    margin-top: govuk-spacing(4);
+
     &__map {
       border: 1px solid $govuk-border-colour;
       height: 400px;
-      margin-bottom: govuk-spacing(4);
-      margin-top: govuk-spacing(4);
       width: 100%;
 
       &__marker--default {

--- a/app/frontend/packs/application.js
+++ b/app/frontend/packs/application.js
@@ -6,9 +6,12 @@ import Rails from 'rails-ujs';
 import { initAll } from 'govuk-frontend';
 
 import 'leaflet/dist/leaflet.css';
+import 'leaflet.fullscreen/Control.FullScreen.css';
 
 import 'src/application';
 import 'src/components';
+
+import 'leaflet.fullscreen/Control.FullScreen';
 
 import 'src/styles/application.scss';
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "jquery": "^3.5.0",
     "jsdom": "^19.0.0",
     "leaflet": "^1.7.1",
+    "leaflet.fullscreen": "^2.2.0",
     "rails-ujs": "^5.2.7"
   },
   "devDependencies": {
@@ -48,7 +49,7 @@
     "js:test": "jest",
     "js:test:coverage": "jest --coverage",
     "js:lint": "eslint ./app/frontend/src ./app/components",
-    "sass:lint": "yarn stylelint app/frontend/**/*.scss app/components/*/*.scss -q",
+    "sass:lint": "yarn stylelint app/frontend/**/*.scss app/components/**/*.scss -q",
     "backstop:execute": "backstop $CMD --config='app/frontend/backstop/backstop.config.js'",
     "visual:test:reference": "CMD=reference yarn run backstop:execute",
     "visual:test:run": "CMD=test yarn run backstop:execute",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6063,6 +6063,11 @@ last-call-webpack-plugin@^3.0.0:
     lodash "^4.17.5"
     webpack-sources "^1.1.0"
 
+leaflet.fullscreen@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/leaflet.fullscreen/-/leaflet.fullscreen-2.2.0.tgz#6843a0347c4212e9c5081ea9362843f4df2342ad"
+  integrity sha512-qfL+vE6wRJX85aWNBag1Je5+W7niTtraFu4EkLIO6XSgN2pEsL/XefjOSIh/CFM00aaxbOpN6Rr2vZpvnpWWDQ==
+
 leaflet@^1.7.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.7.1.tgz#10d684916edfe1bf41d688a3b97127c0322a2a19"


### PR DESCRIPTION
no ticket

LeafletJs is a quality library and there is a plethora of functionality and plugins that we could take advantage of. obviously dont want to go overboard but i thought this (as a simple plugin introduction) was quite neat and i feel is of benefit for a mobile/small screen user to use. use the control to toggle default/full screen view and works smoothly cross browser.

these screen shots probably not the best example, would be useful more on busy maps with many markers/polygons

![Screenshot 2022-03-30 at 23 56 44](https://user-images.githubusercontent.com/1792451/160944913-c6af0c40-6628-490c-ab5d-9d879c58a1da.png)

![Screenshot 2022-03-30 at 23 57 22](https://user-images.githubusercontent.com/1792451/160944918-cd475f47-57ab-4a70-aaeb-ab12af95fb89.png)

![Screenshot 2022-03-30 at 23 57 51](https://user-images.githubusercontent.com/1792451/160944928-d4554d38-acdb-4a14-9d6a-cd0353336f42.png)

