### PR TITLE
Remove breadcrumbs from search results page

### DIFF
--- a/app/views/vacancies/index.html.slim
+++ b/app/views/vacancies/index.html.slim
@@ -1,9 +1,6 @@
 - content_for :skip_links do
   a.govuk-skip-link href="#search-results" = t("jobs.skip_link")
 
-- content_for :breadcrumbs do
-  = govuk_breadcrumbs breadcrumbs: { "#{t("breadcrumbs.home")}": root_path, "#{t("breadcrumbs.jobs")}": "" }
-
 = render "title_and_description"
 
 .govuk-grid-row


### PR DESCRIPTION
<img width="1087" alt="Screenshot 2022-04-01 at 10 14 51" src="https://user-images.githubusercontent.com/7215/161233912-82e4a267-0aa9-4fd4-ad36-68f00693b616.png">
<img width="1076" alt="Screenshot 2022-04-01 at 10 15 09" src="https://user-images.githubusercontent.com/7215/161233930-2ee15917-5665-4f36-ac79-c99df6df9690.png">
