### PR TITLE
Improve Terraform Makefile documentation

### DIFF
--- a/documentation/terraform.md
+++ b/documentation/terraform.md
@@ -2,7 +2,24 @@
 
 ## `terraform plan` via the Makefile
 
-To run the commands below, you will first need to assume the `Deployments` role with [aws-vault](./aws-roles-and-cli-tools.md)
+To run the commands below, you will first need to assume the `Deployments` role. If you are using
+[aws-vault](./aws-roles-and-cli-tools.md), this is as easy as running the make command through
+`aws-vault exec`:
+
+```
+aws-vault exec Deployments -- [make invocation from below]
+```
+
+For example:
+
+```
+aws-vault exec Deployments -- make passcode=MyPasscode terraform-monitoring-plan
+```
+
+You will also need a [GOV.UK PaaS authentication code](https://login.london.cloud.service.gov.uk/passcode),
+which you need to substitute for `MyPasscode` in the `passcode` variable.
+
+---
 
 Dev
 ```
@@ -21,7 +38,7 @@ make passcode=MyPasscode tag=dev-08406f04dd9eadb7df6fcda5213be880d7df37ed-202010
 
 Review app
 ```
-make passcode=MyPasscode pr=2086 tag=review-pr-2086-e4c2c4afd991161f88808c907b4c66a30e5f3ef4-20201002203641 review terraform-app-plan
+make passcode=MyPasscode pr_id=2086 tag=review-pr-2086-e4c2c4afd991161f88808c907b4c66a30e5f3ef4-20201002203641 review terraform-app-plan
 ```
 
 Staging
@@ -39,6 +56,16 @@ To run the commands below, you will first need to assume the `Administrator` rol
 Common
 ```
 make terraform-common-plan
+```
+
+## Cleaning up after review apps that failed to destroy on PR close
+
+Occasionally, some issue will prevent a review app and its associated worker and services from
+getting destroyed. To clean up manually, use the `terraform-app-destroy` make target and set the
+`pr_id` variable to the PR ID from Github:
+
+```
+make passcode=MyPasscode pr_id=1234 review terraform-app-destroy
 ```
 
 ## `terraform plan` with Terraform CLI commands


### PR DESCRIPTION
- Make `aws-vault` role assumption documentation more helpful
- Fix incorrect `pr` variable (it's actually `pr_id`)
- Make it clear `passcode` refers to the GOV.UK PaaS authentication code
- Add section on destroying zombie review apps