### PR TITLE
[TEVA-4077] Edit school hiring advice links

### DIFF
--- a/app/helpers/links_helper.rb
+++ b/app/helpers/links_helper.rb
@@ -114,17 +114,6 @@ module LinksHelper
     )
   end
 
-  def application_pack_link(vacancy, **kwargs)
-    tracked_open_in_new_tab_link_to(
-      t("application_pack.link_text", size: application_pack_asset_size),
-      application_pack_asset_path,
-      download: t("application_pack.link_download_attr"),
-      link_type: :application_form_info,
-      link_subject: anon(vacancy.id),
-      **kwargs,
-    )
-  end
-
   def document_accessibility_link(vacancy, **kwargs)
     tracked_open_in_new_tab_link_to(
       t("publishers.vacancies.build.documents.accessibility_link_text"),

--- a/app/helpers/organisations_helper.rb
+++ b/app/helpers/organisations_helper.rb
@@ -2,7 +2,6 @@ module OrganisationsHelper
   include AddressHelper
 
   OFSTED_REPORT_ENDPOINT = "https://reports.ofsted.gov.uk/oxedu_providers/full/(urn)/".freeze
-  APPLICATION_PACK_FILENAME = "teaching-vacancies-application-form-guide-feb-22.pdf".freeze
 
   def age_range(school)
     return t("schools.not_given") unless school.minimum_age? && school.maximum_age?
@@ -66,14 +65,6 @@ module OrganisationsHelper
       return school_capacity(school) if school.gias_data["SchoolCapacity"].present?
     end
     I18n.t("schools.no_information")
-  end
-
-  def application_pack_asset_size
-    (File.size("public/#{APPLICATION_PACK_FILENAME}") / 1.0.megabyte).round(1)
-  end
-
-  def application_pack_asset_path
-    ActionController::Base.helpers.asset_path(APPLICATION_PACK_FILENAME)
   end
 
   private

--- a/app/views/layouts/_footer.html.slim
+++ b/app/views/layouts/_footer.html.slim
@@ -39,14 +39,8 @@
               = button_to(t("footer.list_a_teaching_job"), organisation_jobs_path, class: "govuk-footer__link govuk-body-s")
             li.govuk-footer__list-item
               = link_to t("footer.manage_job_listings"), organisation_path, class: "govuk-footer__link"
-            li.govuk-footer__list-item
-              = link_to t("footer.job_ad_guide"),
-                        post_path(section: "get-help-hiring", post_name: "creating-the-perfect-teacher-job-advert"),
-                        class: "govuk-footer__link"
-            li.govuk-footer__list-item
-              = link_to t("footer.job_application_guide"),
-                        post_path(section: "get-help-hiring", post_name: "accepting-job-applications-on-teaching-vacancies"),
-                        class: "govuk-footer__link"
           - else
             li.govuk-footer__list-item
               = link_to t("nav.sign_in"), new_publisher_session_path, class: "govuk-footer__link"
+          li.govuk-footer__list-item
+            = link_to t("footer.school_hiring_guides"), posts_path(section: "get-help-hiring"), class: "govuk-footer__link"

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -7,7 +7,7 @@
     - else
       = header.navigation_item text: t("nav.manage_settings"), href: publishers_school_path(current_organisation), active: schools_in_your_trust_active?
     = header.navigation_item text: t("nav.notifications_html", count: current_publisher.notifications.unread.count), href: publishers_notifications_path
-    = header.navigation_item text: t("nav.school_hiring_guide"), href: posts_path(section: "get-help-hiring")
+    = header.navigation_item text: t("nav.school_hiring_guides"), href: posts_path(section: "get-help-hiring")
     = header.navigation_item text: t("nav.sign_out"), href: destroy_publisher_session_path, options: { method: :delete }
   - elsif jobseeker_signed_in?
     = header.navigation_item text: t("nav.find_job"), href: root_path, active: find_jobs_active?

--- a/app/views/publishers/new_features/reminder.html.slim
+++ b/app/views/publishers/new_features/reminder.html.slim
@@ -8,5 +8,5 @@
       = t(".page_title")
     p.govuk-body
       = t(".content")
-    = govuk_link_to t("application_pack.link_text", size: application_pack_asset_size), application_pack_asset_path, target: "_blank", class: "govuk-body", download: t("application_pack.link_download_attr")
+    = open_in_new_tab_link_to(t(".how_applications_work_link"), post_path(section: "get-help-hiring", post_name: "accepting-job-applications-on-teaching-vacancies"), class: "govuk-body")
     = govuk_button_to t("buttons.reminder_continue"), organisation_jobs_path, class: "govuk-!-margin-top-8"

--- a/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
+++ b/app/views/publishers/vacancies/build/applying_for_the_job.html.slim
@@ -8,8 +8,10 @@
       = f.govuk_error_summary
 
       h2.govuk-heading-l = t("publishers.vacancies.steps.applying_for_the_job")
-      p.govuk-body = t(".enable_job_applications_html", link: application_pack_link(vacancy, class: "govuk-body"))
-
+      p.govuk-body = t(".enable_job_applications_html",
+                       link: open_in_new_tab_link_to(t(".accepting_job_applications_link_text"),
+                                                     post_path(section: "get-help-hiring",
+                                                               post_name: "accepting-job-applications-on-teaching-vacancies")))
       - if vacancy.listed? || current_organisation.local_authority?
         = f.hidden_field :enable_job_applications
       - else

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,10 +16,6 @@ en:
       main: Skip to main content
     title: Teaching Vacancies
 
-  application_pack:
-    link_text: Download more information about the application form (%{size} MB, PDF)
-    link_download_attr: Teaching Vacancies application form guide
-
   banners:
     alert: Warning
     error: Error
@@ -159,12 +155,11 @@ en:
       for_job_seekers: Job seekers
       for_schools: Hiring staff
       support: Support
-    job_ad_guide: How to create the perfect teacher job ad
-    job_application_guide: How to accept job applications on Teaching Vacancies
     list_a_teaching_job: List a job
     manage_job_listings: Manage job listings
     provide_feedback: Provide feedback on Teaching Vacancies
     request_support: Get help or report a problem
+    school_hiring_guides: School hiring guides
     search_teaching_vacancies: Find a job
     service_support: Get support
 
@@ -220,7 +215,7 @@ en:
       one: Notifications <span class="count-badge">%{count}<span class="govuk-visually-hidden"> unread</span></span>
       other: Notifications <span class="count-badge">%{count}<span class="govuk-visually-hidden"> unread</span></span>
     personal_statement: Writing a personal statement
-    school_hiring_guide: School hiring guide
+    school_hiring_guides: School hiring guides
     sign_in: Sign in
     sign_out: Sign out
     support_user_dashboard: Hello support user

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -53,6 +53,7 @@ en:
         page_title: New features for hiring staff
       reminder:
         content: You can now receive and manage job applications for all roles on Teaching Vacancies, including education support roles.
+        how_applications_work_link: How applications work on Teaching Vacancies
         page_title: A reminder about applications
 
     notifications:
@@ -164,6 +165,7 @@ en:
           before: Application deadline
       build:
         applying_for_the_job:
+          accepting_job_applications_link_text: why you should use Teaching Vacancies for applications
           banner:
             heading: Teaching Vacancies application form
             description:
@@ -173,7 +175,7 @@ en:
           enable_job_applications_html: >-
             Candidates can apply using the Teaching Vacancies application form,
             or you can direct them to another service, like the local authority or a school's website.
-            %{link}
+            Read about %{link}.
           step_title: Applying for the job
         documents:
           accessibility_link_text: How to make documents accessible

--- a/spec/system/publishers_are_reminded_of_application_functionality_spec.rb
+++ b/spec/system/publishers_are_reminded_of_application_functionality_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Application feature reminder" do
       click_on "Continue"
 
       expect(page).to have_content(I18n.t("publishers.new_features.reminder.page_title"))
-      expect(page).to have_link(I18n.t("application_pack.link_text", size: application_pack_asset_size), href: application_pack_asset_path)
+      expect(page).to have_link(I18n.t("publishers.new_features.reminder.how_applications_work_link"), href: post_path(section: "get-help-hiring", post_name: "accepting-job-applications-on-teaching-vacancies"))
 
       click_on I18n.t("buttons.reminder_continue")
 


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-4077

## Changes in this PR:

This PR changes links in the footer and nav, and changes links in the "Reminder" and "Applying for the job" steps of the job listing journey to point towards the new long form content guides. Links helpers concerning the application guide pdf are removed.

## Screenshots of UI changes:

### Before
<img width="420" alt="image" src="https://user-images.githubusercontent.com/24639777/161504449-5987c8bb-fd90-4cb3-b466-8554619c9376.png">

<img width="671" alt="image" src="https://user-images.githubusercontent.com/24639777/161504550-df8a1a8d-4daf-43b4-857d-e40adafc83f8.png">

<img width="676" alt="image" src="https://user-images.githubusercontent.com/24639777/161504674-341469e8-8cac-4727-9028-06291276bcf9.png">

### After
<img width="375" alt="image" src="https://user-images.githubusercontent.com/24639777/161504286-7d4583af-b6eb-4c3f-b12c-1aee2c9ed475.png">

<img width="820" alt="image" src="https://user-images.githubusercontent.com/24639777/161504783-ed2ea76a-0b6e-4379-a69b-3bc1fdcd01b9.png">

<img width="832" alt="image" src="https://user-images.githubusercontent.com/24639777/161504876-504bf2ac-5e97-4952-81de-ea023e9df7ff.png">
