### PR TITLE
Set filters based on keywords when searching

### DIFF
--- a/app/services/search/keyword_filter_generation/query_parser.rb
+++ b/app/services/search/keyword_filter_generation/query_parser.rb
@@ -1,0 +1,32 @@
+class Search::KeywordFilterGeneration::QueryParser < Parslet::Parser
+  root(:query)
+
+  rule(:query) { (space | term).repeat(0).as(:query) }
+
+  rule(:space) { match('\s').repeat(1) }
+
+  rule(:term) { filterable_term | plain_term }
+  rule(:term_terminator) { match("$") | space }
+
+  rule(:filterable_term) { filterable_term_tokens.as(:filterable_term) >> term_terminator }
+
+  rule(:plain_term) do
+    match('\S').repeat(1) >> term_terminator
+  end
+
+  # Convenience method to parse and transform in one step
+  def self.filters_from_query(query)
+    parsed_query = new.parse(query)
+    Search::KeywordFilterGeneration::QueryTransformer.apply(parsed_query)
+  end
+
+  def filterable_term_tokens
+    Rails.application.config.x.search.keyword_filter_mapping_triggers
+      .map { |s| str(s) }
+      .reduce(:|)
+  end
+
+  def parse(query)
+    super(query.downcase.delete("."))
+  end
+end

--- a/app/services/search/keyword_filter_generation/query_transformer.rb
+++ b/app/services/search/keyword_filter_generation/query_transformer.rb
@@ -1,0 +1,17 @@
+class Search::KeywordFilterGeneration::QueryTransformer < Parslet::Transform
+  rule(filterable_term: simple(:term)) do |captures|
+    term = captures[:term].to_s
+    Rails.application.config.x.search.keyword_filter_mappings[term]
+  end
+
+  def self.apply(parsed_query)
+    # Only transform query if query contains any matches
+    return nil unless parsed_query[:query].is_a?(Array)
+
+    new
+      .apply(parsed_query)[:query]
+      .each_with_object(Hash.new([])) do |item, acc|
+        item.each { |k, v| acc[k] |= v }
+      end
+  end
+end

--- a/app/views/vacancies/index.html.slim
+++ b/app/views/vacancies/index.html.slim
@@ -18,6 +18,9 @@
   .govuk-grid-row
     .govuk-grid-column-one-third-at-desktop class="govuk-!-margin-bottom-3"
       = render "vacancies/search/filters", f: f, form: @form
+      / When the user refines their search, this helps us figure out if they've changed the
+      / keyword(s), or just adjusted the filters
+      = f.hidden_field :previous_keyword, value: @vacancies_search.keyword
 
     .govuk-grid-column-two-thirds-at-desktop
       = render "vacancies/search/fields_and_button", f: f, form: @form

--- a/config/initializers/search.rb
+++ b/config/initializers/search.rb
@@ -3,6 +3,7 @@ Rails.application.configure do
 
   synonyms = YAML.load_file(config_dir.join("synonyms.yml"))
   oneway_synonyms = YAML.load_file(config_dir.join("oneway_synonyms.yml"))
+  keyword_filter_mappings = YAML.load_file(config_dir.join("keyword_filter_mappings.yml"))
 
   # Generate lists of all terms that have synonyms so we can look for them in search queries and
   # trigger our synonym logic
@@ -18,10 +19,18 @@ Rails.application.configure do
     .uniq
     .sort_by { |phrase| phrase.count(" ") }
     .reverse
+  keyword_filter_mapping_triggers = keyword_filter_mappings
+    .keys
+    .uniq
+    .sort_by { |phrase| phrase.count(" ") }
+    .reverse
 
   config.x.search.synonyms = synonyms
   config.x.search.synonym_triggers = synonym_triggers
 
   config.x.search.oneway_synonyms = oneway_synonyms
   config.x.search.oneway_synonym_triggers = oneway_synonym_triggers
+
+  config.x.search.keyword_filter_mappings = keyword_filter_mappings
+  config.x.search.keyword_filter_mapping_triggers = keyword_filter_mapping_triggers
 end

--- a/config/search/keyword_filter_mappings.yml
+++ b/config/search/keyword_filter_mappings.yml
@@ -1,0 +1,620 @@
+# Map keyword "trigger" terms to search filters
+"16-19":
+  phases:
+    - 16-19
+"accounting teacher":
+  phases:
+    - secondary
+    - 16-19
+  subjects:
+    - Accounting
+"art":
+  subjects:
+    - Art and design
+"assistant head":
+  job_roles:
+    - leadership
+"biology":
+  phases:
+    - secondary
+    - 16-19
+  subjects:
+    - Biology
+"business studies":
+  phases:
+    - secondary
+    - 16-19
+  subjects:
+    - Business studies
+"ceo":
+  job_roles:
+    - leadership
+"chemistry":
+  phases:
+    - secondary
+    - 16-19
+  subjects:
+    - Chemistry
+"citizenship":
+  phases:
+    - secondary
+    - 16-19
+  subjects:
+    - Citizenship
+"classics":
+  subjects:
+    - Classics
+"computer":
+  subjects:
+    - Computing
+    - ICT
+"computing":
+  subjects:
+    - Computing
+    - ICT
+"control":
+  phases:
+    - secondary
+    - 16-19
+  subjects:
+    - Design and technology
+"dance":
+  subjects:
+    - Dance
+"deputy":
+  job_roles:
+    - leadership
+"design":
+  phases:
+    - secondary
+    - 16-19
+  subjects:
+    - Art and design
+    - Design and technology
+"drama":
+  subjects:
+    - Drama
+"dt":
+  subjects:
+    - Design and technology
+"early career teacher":
+  job_roles:
+    - ect_suitable
+"early career teachers":
+  job_roles:
+    - ect_suitable
+"early years":
+  phases:
+    - primary
+"ect":
+  job_roles:
+    - ect_suitable
+"ects":
+  job_roles:
+    - ect_suitable
+"english":
+  subjects:
+    - English
+"eyfs":
+  phases:
+    - primary
+"fe":
+  phases:
+    - 16-19
+"film":
+  subjects:
+    - Media studies
+"finance teacher":
+  phases:
+    - secondary
+    - 16-19
+  subjects:
+    - Accounting
+"flexible":
+  working_patterns:
+    - flexible
+"flexible working":
+  working_patterns:
+    - flexible
+"food technology":
+  phases:
+    - secondary
+    - 16-19
+  subjects:
+    - Food technology
+"french":
+  subjects:
+    - French
+"full time":
+  working_patterns:
+    - full_time
+"further education":
+  phases:
+    - 16-19
+"geography":
+  subjects:
+    - Geography
+"german":
+  subjects:
+    - German
+"greek":
+  subjects:
+    - Classics
+"head of english":
+  job_roles:
+    - middle_leader
+"head of history":
+  job_roles:
+    - middle_leader
+"head of maths":
+  job_roles:
+    - middle_leader
+"head of mfl":
+  job_roles:
+    - middle_leader
+"head of school":
+  job_roles:
+    - leadership
+"head of science":
+  job_roles:
+    - middle_leader
+"head of sixth form":
+  job_roles:
+    - middle_leader
+"head of year":
+  job_roles:
+    - middle_leader
+"head teacher":
+  job_roles:
+    - leadership
+"headteacher":
+  job_roles:
+    - leadership
+"health":
+  subjects:
+    - Health and social care
+"history":
+  subjects:
+    - History
+"hlta":
+  job_roles:
+    - teaching_assistant
+"hospitality":
+  phases:
+    - secondary
+    - 16-19
+  subjects:
+    - Food technology
+"humanities":
+  subjects:
+    - Humanities
+    - History
+    - Geography
+    - Law
+    - Health and Social Care
+    - Religious studies
+    - Sociology
+    - Psychology
+    - Social sciences
+    - Philosophy
+    - Politics
+"ict":
+  subjects:
+    - Computing
+    - ICT
+"it":
+  subjects:
+    - Computing
+    - ICT
+"job share":
+  working_patterns:
+    - job_share
+"key stage 1":
+  phases:
+    - primary
+"key stage 2":
+  phases:
+    - primary
+    - middle
+"key stage 3":
+  phases:
+    - middle
+    - secondary
+"key stage 4":
+  phases:
+    - secondary
+"key stage 5":
+  phases:
+    - secondary
+    - 16-19
+"ks1":
+  phases:
+    - primary
+"ks2":
+  phases:
+    - primary
+    - middle
+"ks3":
+  phases:
+    - middle
+    - secondary
+"ks4":
+  phases:
+    - secondary
+"ks5":
+  phases:
+    - secondary
+    - 16-19
+"languages":
+  subjects:
+    - Languages
+    - French
+    - German
+    - Spanish
+    - Mandarin
+"latin":
+  subjects:
+    - Classics
+"law":
+  phases:
+    - secondary
+    - 16-19
+  subjects:
+    - Law
+"leader":
+  job_roles:
+    - middle_leader
+    - leadership
+"leadership":
+  job_roles:
+    - middle_leader
+    - leadership
+"learning support assistant":
+  job_roles:
+    - teaching_assistant
+    - education_support
+"literacy":
+  phases:
+    - primary
+  subjects:
+    - English
+"literature":
+  phases:
+    - secondary
+    - 16-19
+  subjects:
+    - English
+"lsa":
+  job_roles:
+    - teaching_assistant
+    - education_support
+"mandarin":
+  subjects:
+    - Mandarin
+"math":
+  subjects:
+    - Mathematics
+    - Statistics
+"mathematics":
+  subjects:
+    - Mathematics
+    - Statistics
+"maths":
+  subjects:
+    - Mathematics
+    - Statistics
+"media":
+  phases:
+    - secondary
+    - 16-19
+  subjects:
+    - Media studies
+"mfl":
+  subjects:
+    - Languages
+    - French
+    - German
+    - Spanish
+    - Mandarin
+"middle leader":
+  job_roles:
+    - middle_leader
+"middle leadership":
+  job_roles:
+    - middle_leader
+"middle school":
+  phases:
+    - middle
+"middle schools":
+  phases:
+    - middle
+"music":
+  subjects:
+    - Music
+"newly qualified teacher":
+  job_roles:
+    - ect_suitable
+"newly qualified teachers":
+  job_roles:
+    - ect_suitable
+"nqt":
+  job_roles:
+    - ect_suitable
+"nqts":
+  job_roles:
+    - ect_suitable
+"numeracy":
+  phases:
+    - primary
+  subjects:
+    - Mathematics
+"nursery":
+  phases:
+    - primary
+"part time":
+  working_patterns:
+    - part_time
+    - job_share
+"pe":
+  subjects:
+    - Physical education
+"performing":
+  subjects:
+    - Drama
+"phase leader":
+  job_roles:
+    - middle_leader
+"philosophy":
+  phases:
+    - secondary
+    - 16-19
+  subjects:
+    - Philosophy
+"phonics":
+  phases:
+    - primary
+  subjects:
+    - English
+"photography":
+  subjects:
+    - Art and design
+    - Media studies
+"physical education":
+  subjects:
+    - Physical education
+"physics":
+  phases:
+    - secondary
+    - 16-19
+  subjects:
+    - Physics
+"politics":
+  phases:
+    - secondary
+    - 16-19
+  subjects:
+    - Politics
+"primary":
+  phases:
+    - primary
+"primary school":
+  phases:
+    - primary
+"primary schools":
+  phases:
+    - primary
+"principal":
+  job_roles:
+    - leadership
+"product":
+  phases:
+    - secondary
+    - 16-19
+  subjects:
+    - Design and technology
+"pshe":
+  subjects:
+    - Relationships and sex education
+"psychology":
+  phases:
+    - secondary
+    - 16-19
+  subjects:
+    - Psychology
+"re":
+  subjects:
+    - Religious education
+"reception":
+  phases:
+    - primary
+"relationships":
+  subjects:
+    - Relationships and sex education
+"religion":
+  subjects:
+    - Religious education
+"religious education":
+  subjects:
+    - Religious education
+"religious studies":
+  subjects:
+    - Religious education
+"rs":
+  subjects:
+    - Religious education
+"rse":
+  subjects:
+    - Relationships and sex education
+"russian":
+  subjects:
+    - Languages
+"science":
+  subjects:
+    - Science
+    - Biology
+    - Chemistry
+    - Physics
+"secondary":
+  phases:
+    - secondary
+"secondary school":
+  phases:
+    - secondary
+"secondary schools":
+  phases:
+    - secondary
+"sen":
+  job_roles:
+    - send_responsible
+"senco":
+  job_roles:
+    - sendco
+"send":
+  job_roles:
+    - send_responsible
+"sendco":
+  job_roles:
+    - sendco
+"senior leader":
+  job_roles:
+    - leadership
+"senior leadership":
+  job_roles:
+    - leadership
+"senior leadership team":
+  job_roles:
+    - leadership
+"sex education":
+  subjects:
+    - Relationships and sex education
+"sixth form":
+  phases:
+    - 16-19
+    - secondary
+"slt":
+  job_roles:
+    - leadership
+"social care":
+  phases:
+    - secondary
+    - 16-19
+  subjects:
+    - Health and social care
+"social science":
+  phases:
+    - secondary
+    - 16-19
+  subjects:
+    - Social sciences
+    - Sociology
+"social sciences":
+  phases:
+    - secondary
+    - 16-19
+  subjects:
+    - Social sciences
+    - Sociology
+"sociology":
+  phases:
+    - secondary
+    - 16-19
+  subjects:
+    - Social sciences
+    - Sociology
+"spanish":
+  subjects:
+    - Spanish
+"special educational needs":
+  job_roles:
+    - send_responsible
+"special educational needs co-ordinator":
+  job_roles:
+    - sendco
+"special educational needs coordinator":
+  job_roles:
+    - sendco
+"sport":
+  subjects:
+    - Physical education
+"sports":
+  subjects:
+    - Physical education
+"statistics":
+  phases:
+    - secondary
+    - 16-19
+  subjects:
+    - Statistics
+"suitable for ect":
+  job_roles:
+    - ect_suitable
+"suitable for ects":
+  job_roles:
+    - ect_suitable
+"suitable for nqt":
+  job_roles:
+    - ect_suitable
+"suitable for nqts":
+  job_roles:
+    - ect_suitable
+"support":
+  job_roles:
+    - education_support
+"systems":
+  phases:
+    - secondary
+    - 16-19
+  subjects:
+    - Design and technology
+"ta":
+  job_roles:
+    - teaching_assistant
+"teach":
+  job_roles:
+    - teacher
+    - middle_leader
+"teacher":
+  job_roles:
+    - teacher
+    - middle_leader
+"teacher of accounting":
+  phases:
+    - secondary
+    - 16-19
+  subjects:
+    - Accounting
+"teacher of finance":
+  phases:
+    - secondary
+    - 16-19
+  subjects:
+    - Accounting
+"teachers":
+  job_roles:
+    - teacher
+    - middle_leader
+"teaching":
+  job_roles:
+    - teacher
+    - middle_leader
+"teaching assistant":
+  job_roles:
+    - teaching_assistant
+"teaching assistants":
+  job_roles:
+    - teaching_assistant
+"term time":
+  working_patterns:
+    - term_time
+"textiles":
+  phases:
+    - secondary
+    - 16-19
+  subjects:
+    - Design and technology
+"theatre":
+  subjects:
+    - Drama
+"tlr":
+  job_roles:
+    - middle_leader

--- a/spec/services/search/keyword_filter_generation/query_parser_spec.rb
+++ b/spec/services/search/keyword_filter_generation/query_parser_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe Search::KeywordFilterGeneration::QueryParser do
+  before do
+    allow(Rails.application.config.x.search).to receive(:keyword_filter_mapping_triggers)
+      .and_return(%w[foo bar baz])
+
+    allow(Rails.application.config.x.search).to receive(:keyword_filter_mappings)
+      .and_return({
+        "foo" => { phases: ["16-19"] },
+        "bar" => { subjects: ["French"] },
+        "baz" => { job_roles: %w[leadership sendco] },
+      })
+  end
+
+  describe ".filters_from_query" do
+    it "turns a query into filters" do
+      expect(described_class.filters_from_query("baz bar quux"))
+        .to eq({ job_roles: %w[leadership sendco], :subjects => %w[French] })
+    end
+  end
+end

--- a/spec/system/jobseekers_can_search_for_jobs_spec.rb
+++ b/spec/system/jobseekers_can_search_for_jobs_spec.rb
@@ -4,6 +4,10 @@ RSpec.shared_examples "a successful search" do
   context "when searching for teacher jobs" do
     let(:keyword) { "Teacher" }
 
+    it "adds the expected filters" do
+      expect(page).to have_css("button", text: "Remove this filterTeacher")
+    end
+
     it "displays page 1 jobs" do
       within("ul.search-results") { expect(page).to have_css("li", count: 2) }
       expect(page).to have_css(".search-results-sorting__stats", text: strip_tags(I18n.t("jobs.number_of_results_html", first: 1, last: 2, count: 6)))
@@ -24,6 +28,11 @@ RSpec.shared_examples "a successful search" do
   context "when searching for maths jobs" do
     let(:per_page) { 100 }
     let(:keyword) { "Maths Teacher" }
+
+    it "adds the expected filters" do
+      expect(page).to have_css("button", text: "Remove this filterMathematics")
+      expect(page).to have_css("button", text: "Remove this filterTeacher")
+    end
 
     it "displays only the Maths jobs" do
       expect(page).to have_css(".search-results-sorting__stats", text: strip_tags(I18n.t("jobs.number_of_results_one_page_html", count: 2)))
@@ -49,13 +58,13 @@ end
 
 RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
   let(:school) { create(:school) }
-  let!(:maths_job1) { create(:vacancy, :past_publish, publish_on: Date.current - 1, id: "67991ea9-431d-4d9d-9c99-a78b80108fe1", job_title: "Maths 1", subjects: [], organisations: [school]) }
-  let!(:maths_job2) { create(:vacancy, :past_publish, publish_on: Date.current - 2, id: "7bfadb84-cf30-4121-88bd-a9f958440cc9", job_title: "Maths Teacher 2", subjects: [], organisations: [school]) }
-  let!(:job1) { create(:vacancy, :past_publish, id: "20cc99ff-4fdb-4637-851a-68cf5f8fea9f", job_title: "Physics Teacher", subjects: [], organisations: [school]) }
-  let!(:job2) { create(:vacancy, :past_publish, id: "9910d184-5686-4ffc-9322-69aa150c19d3", job_title: "PE Teacher", subjects: [], organisations: [school]) }
-  let!(:job3) { create(:vacancy, :past_publish, id: "3bf67da6-039c-4ee1-bf59-8475672a0d2b", job_title: "Chemistry Teacher", subjects: [], organisations: [school]) }
-  let!(:job4) { create(:vacancy, :past_publish, id: "e750baf6-cc9a-4b93-84cf-ee4e5f8a7ee4", job_title: "Geography Teacher", subjects: [], organisations: [school]) }
-  let!(:expired_job) { create(:vacancy, :expired, id: "0f86d38c-56d4-48d3-b8a2-474f19d4908e", job_title: "Maths Teacher", subjects: [], organisations: [school]) }
+  let!(:maths_job1) { create(:vacancy, :past_publish, publish_on: Date.current - 1, id: "67991ea9-431d-4d9d-9c99-a78b80108fe1", job_title: "Maths 1", job_roles: %i[teacher], subjects: %w[Mathematics], organisations: [school]) }
+  let!(:maths_job2) { create(:vacancy, :past_publish, publish_on: Date.current - 2, id: "7bfadb84-cf30-4121-88bd-a9f958440cc9", job_title: "Maths Teacher 2", job_roles: %i[teacher], subjects: %w[Mathematics], organisations: [school]) }
+  let!(:job1) { create(:vacancy, :past_publish, id: "20cc99ff-4fdb-4637-851a-68cf5f8fea9f", job_title: "Physics Teacher", job_roles: %i[teacher], subjects: [], organisations: [school]) }
+  let!(:job2) { create(:vacancy, :past_publish, id: "9910d184-5686-4ffc-9322-69aa150c19d3", job_title: "PE Teacher", job_roles: %i[teacher], subjects: [], organisations: [school]) }
+  let!(:job3) { create(:vacancy, :past_publish, id: "3bf67da6-039c-4ee1-bf59-8475672a0d2b", job_title: "Chemistry Teacher", job_roles: %i[teacher], subjects: [], organisations: [school]) }
+  let!(:job4) { create(:vacancy, :past_publish, id: "e750baf6-cc9a-4b93-84cf-ee4e5f8a7ee4", job_title: "Geography Teacher", job_roles: %i[teacher], subjects: [], organisations: [school]) }
+  let!(:expired_job) { create(:vacancy, :expired, id: "0f86d38c-56d4-48d3-b8a2-474f19d4908e", job_title: "Maths Teacher", job_roles: %i[teacher], subjects: [], organisations: [school]) }
   let(:per_page) { 2 }
 
   context "when searching using the mobile search fields" do


### PR DESCRIPTION
A common problem jobseekers encounter with our search functionality is
vacancies being returned because their content matches some keyword, but
that match doesn't actually reflect their intent (e.g. a search for
"teaching" matching "Teaching Assistant" in the job title, or a search
for "english" matching "requires GCSE English" in the job description).

This adds logic to automatically set search filters when certain trigger
phrases that have been configured are encountered in the keyword search.

- Add a query parser and transformer inspired by the existing synonym
  logic to turn a keyword query into a set of filters if trigger phrases
  configured in a YAML file are encountered
- Add ability for users to adjust the automatically applied filters by
  not reapplying them if the user performs another search by only
  changing the filters, not the keyword(s) (e.g. by unticking an
  automatically selected filter)
- Add an initial phrases-to-filters mapping based on data analysis