### PR TITLE
Fix bug with feedback reporting period date range

### DIFF
--- a/app/models/feedback_reporting_period.rb
+++ b/app/models/feedback_reporting_period.rb
@@ -42,7 +42,7 @@ class FeedbackReportingPeriod
   end
 
   def date_range
-    @from..@to
+    (@from.beginning_of_day)..(@to.end_of_day)
   end
 
   def self.parse_date(dateish)

--- a/spec/models/feedback_reporting_period_spec.rb
+++ b/spec/models/feedback_reporting_period_spec.rb
@@ -76,9 +76,11 @@ RSpec.describe FeedbackReportingPeriod do
   end
 
   describe "#date_range" do
+    let(:period_start) { Date.new(2022, 1, 4).beginning_of_day }
+    let(:period_end) { Date.new(2022, 1, 10).end_of_day }
+
     it "returns the date range" do
-      expect(described_class.new(from: "2022-01-04", to: "2022-01-10").date_range)
-        .to eq(Date.new(2022, 1, 4)..Date.new(2022, 1, 10))
+      expect(described_class.new(from: "2022-01-04", to: "2022-01-10").date_range).to eq(period_start..period_end)
     end
   end
 end


### PR DESCRIPTION
## Comments

- Date range was not capturing feedbacks created on Mondays as date range returned by FeedbackReportingPeriod#date_range did not include Mondays. This was causing tests to fail on Mondays.