### PR TITLE
Add deployments and administrator roles to docs

### DIFF
--- a/documentation/aws-roles-and-cli-tools.md
+++ b/documentation/aws-roles-and-cli-tools.md
@@ -160,6 +160,22 @@ role_arn=arn:aws:iam::530003481352:role/SecretEditor
 source_profile=teaching-vacancies
 ```
 
+If needed, two other profiles can also be included for the Deployments and Administrator roles. 
+
+```
+[profile Deployments]
+mfa_serial=arn:aws:iam::530003481352:mfa/<YOUR-AWS-USERNAME>
+region=eu-west-2
+role_arn=arn:aws:iam::530003481352:role/Deployments
+source_profile=teaching-vacancies
+
+[profile Administrator]
+mfa_serial=arn:aws:iam::530003481352:mfa/<YOUR-AWS-USERNAME>
+region=eu-west-2
+role_arn=arn:aws:iam::530003481352:role/Administrator
+source_profile=teaching-vacancies
+```
+
 Then use AWS Vault to set the credentials:
 ```bash
 aws-vault add teaching-vacancies


### PR DESCRIPTION
## Changes in this PR:

- Whilst getting some help from Colin with setting up aws-vault and the aws-cli, he mentioned that it could be helpful to include some of the other profiles that can be added to `.aws/config`.
