### PR TITLE
Remove `simplecov` for the time being

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -115,7 +115,6 @@ group :test do
   gem "rack_session_access"
   gem "selenium-webdriver"
   gem "shoulda-matchers"
-  gem "simplecov"
   gem "vcr"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,7 +153,6 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
     digest (3.1.0)
-    docile (1.4.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.6)
@@ -556,12 +555,6 @@ GEM
       faraday (>= 0.17.5, < 3.0)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
-    simplecov (0.21.2)
-      docile (~> 1.1)
-      simplecov-html (~> 0.11)
-      simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.12.3)
-    simplecov_json_formatter (0.1.4)
     skylight (5.3.2)
       activesupport (>= 5.2.0)
     slim (4.1.0)
@@ -757,7 +750,6 @@ DEPENDENCIES
   shoulda-matchers
   sidekiq
   sidekiq-cron
-  simplecov
   skylight
   slim-rails
   slim_lint

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,3 @@
-require "simplecov"
-SimpleCov.start
-
 require "spec_helper"
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path("../config/environment", __dir__)


### PR DESCRIPTION
We don't actively monitor coverage at the moment, and `simplecov` is
causing issues with our split tests on CI. While we care about coverage,
we value mean-time-to-deploy more, and are making this temporary
tradeoff until we have a quieter period to revisit how to measure and
act on coverage.