### PR TITLE
Add error tracking for post-sign in 404 issues

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,7 +23,7 @@ class ApplicationController < ActionController::Base
     render json: { status: "OK" }, status: :ok
   end
 
-  def not_found
+  def not_found(_error = nil)
     respond_to do |format|
       format.html { render "errors/not_found", status: :not_found }
       format.json do

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -107,5 +107,28 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     session.update(publisher_organisation_id: publisher_organisation.id) if publisher_organisation
   end
 
+  def not_found(error)
+    # Overrides `ApplicationController`, which globally rescues all `ActiveRecord::RecordNotFound`
+    # errors and shows a "page not found" error page to the user.
+    # It's unexpected for a record to not be found as part of the sign in process, so send this
+    # error to our error tracking system so it can be investigated.
+    Sentry.with_scope do |scope|
+      scope.set_context(
+        "Authentication Context",
+        {
+          user_id: user_id,
+          auth_hash_info: auth_hash["info"],
+          auth_hash_extra: auth_hash["extra"],
+        },
+      )
+
+      Sentry.capture_exception(error)
+    end
+
+    Rails.logger.error("Not found error encountered during sign in", error)
+
+    super
+  end
+
   class OrganisationCategoryNotFound < StandardError; end
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -6,6 +6,13 @@ Sentry.init do |config|
 
   config.breadcrumbs_logger = %i[active_support_logger http_logger]
 
+  # Modify default excluded exceptions
+  # We do not want to exclude `ActiveRecord::RecordNotFound` - most of the time, this is
+  # automatically called (and disregarded) by the `rescue_from` in `ApplicationController`
+  # anyway, but on occasion we want to perform a query that we expect *never* to fail, and
+  # send the error through to Sentry if it does fail so that we have visibility into it.
+  config.excluded_exceptions -= ["ActiveRecord::RecordNotFound"]
+
   config.environment = Rails.application.config.app_role
   config.release = ENV["COMMIT_SHA"]
 end


### PR DESCRIPTION
We are experiencing a surprising level of publishers encountering "page
not found" errors after signing in with DfE Sign In. This adds some
tracking to help us identify the root cause.

- Override `not_found` in `OmniauthCallbacksController` to send errors
  to Sentry before its default behaviour
- Modify `ApplicationController#not_found` to have the same method
  signature as the overridden version for consistency
- Stop Sentry from automatically discarding `RecordNotFound` errors