### PR TITLE
Devops label on dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,8 @@ updates:
       interval: "weekly"
       day: "thursday"
     open-pull-requests-limit: 2
+    labels:
+    - DevOps
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -34,3 +36,5 @@ updates:
       interval: "weekly"
       day: "wednesday"
     open-pull-requests-limit: 2
+    labels:
+    - DevOps


### PR DESCRIPTION
## Changes in this PR:
Add devops label on terraform and github action PRs so they notify the devops team

