### PR TITLE
[TEVA-4099] Disable new features page

### DIFF
--- a/app/controllers/publishers/organisations_controller.rb
+++ b/app/controllers/publishers/organisations_controller.rb
@@ -1,6 +1,7 @@
 class Publishers::OrganisationsController < Publishers::BaseController
   before_action :show_publisher_preferences
-  before_action :redirect_to_new_features_page, only: %i[show]
+  # TODO: Temporarily disabled for TEVA-4099
+  # before_action :redirect_to_new_features_page, only: %i[show]
 
   helper_method :vacancy_statistics_form
 

--- a/spec/system/publishers_are_reminded_of_application_functionality_spec.rb
+++ b/spec/system/publishers_are_reminded_of_application_functionality_spec.rb
@@ -52,7 +52,8 @@ RSpec.describe "Application feature reminder" do
       expect(current_path).to eq(organisation_job_build_path(last_vacancy.id, :job_role))
     end
 
-    context "when the publisher has seen the new features page during the current session" do
+    # TODO: Temporarily disabled for TEVA-4099
+    xcontext "when the publisher has seen the new features page during the current session" do
       let(:publisher) { create(:publisher, dismissed_new_features_page_at: nil) }
 
       it "does not show the reminder page" do

--- a/spec/system/publishers_are_shown_new_features_page_spec.rb
+++ b/spec/system/publishers_are_shown_new_features_page_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
-RSpec.describe "Publishers are shown the new features page" do
+# TODO: Temporarily disabled for TEVA-4099
+RSpec.xdescribe "Publishers are shown the new features page" do
   let(:organisation) { create(:school) }
 
   before do


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-4099

## Changes in this PR:

This PR disables the `before_action` for the show action on the organisations controller which redirects to the 'new features' page for publishers, along with related specs. The new features page and related methods can be reinstated or deleted entirely when a decision had been made regarding its future.
