### PR TITLE
Change supportal feedback tables

### DIFF
--- a/app/components/supportal_table_component.rb
+++ b/app/components/supportal_table_component.rb
@@ -8,6 +8,8 @@ class SupportalTableComponent < GovukComponent::Base
     text
   ].freeze
 
+  TAG_COLOURS = { "jobseeker" => "blue", "hiring staff" => "green", "unknown" => "red" }.freeze
+
   def initialize(entries:, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
 
@@ -34,7 +36,7 @@ class SupportalTableComponent < GovukComponent::Base
   def govuk_tags(array)
     tag.ul(class: "govuk-list tags-list") do
       Array(array).compact.each do |text|
-        concat(tag.li { govuk_tag(text: text.humanize) })
+        concat(tag.li { govuk_tag(text: text.humanize, colour: TAG_COLOURS[text]) })
       end
     end
   end

--- a/app/controllers/concerns/support_users/satisfaction_rating_types.rb
+++ b/app/controllers/concerns/support_users/satisfaction_rating_types.rb
@@ -1,0 +1,40 @@
+module SupportUsers::SatisfactionRatingTypes
+  SATISFACTION_RATING_TYPES = [
+    {
+      feedback_responses: %w[highly_satisfied somewhat_satisfied neither somewhat_dissatisfied highly_dissatisfied],
+      feedback_type: :jobseeker_account,
+      grouping_key: :rating,
+      test_id: "satisfaction-rating-jobseekers",
+    },
+    {
+      feedback_responses: %w[highly_satisfied somewhat_satisfied neither somewhat_dissatisfied highly_dissatisfied],
+      feedback_type: :vacancy_publisher,
+      grouping_key: :rating,
+      test_id: "satisfaction-rating-hiring-staff",
+    },
+    {
+      feedback_responses: %w[highly_satisfied somewhat_satisfied neither somewhat_dissatisfied highly_dissatisfied],
+      feedback_type: :application,
+      grouping_key: :rating,
+      test_id: "satisfaction-rating-job-application",
+    },
+    {
+      feedback_responses: [true, false],
+      feedback_type: :job_alert,
+      grouping_key: :relevant_to_user,
+      test_id: "satisfaction-rating-job-alerts",
+    },
+    {
+      feedback_responses: %w[job_found circumstances_change not_relevant other_reason],
+      feedback_type: :unsubscribe,
+      grouping_key: :unsubscribe_reason,
+      test_id: "job-alert-unsubscribe-reason",
+    },
+    {
+      feedback_responses: %w[too_many_emails not_getting_any_value not_looking_for_job other_close_account_reason],
+      feedback_type: :close_account,
+      grouping_key: :close_account_reason,
+      test_id: "close-account-reason",
+    },
+  ].freeze
+end

--- a/app/frontend/src/styles/layouts/support_users/feedbacks.scss
+++ b/app/frontend/src/styles/layouts/support_users/feedbacks.scss
@@ -9,3 +9,9 @@
     background-color: govuk-colour('light-grey');
   }
 }
+
+.support_users_feedbacks_satisfaction_ratings {
+  .govuk-tabs {
+    margin-bottom: govuk-spacing(1);
+  }
+}

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -44,4 +44,6 @@ class Feedback < ApplicationRecord
   scope :job_alerts, -> { where(feedback_type: :job_alert) }
   scope :except_job_alerts, -> { where.not(feedback_type: :job_alert) }
   scope :with_comments, -> { except_job_alerts.where.not(comment: "") }
+  scope :contactable, -> { except_job_alerts.where(user_participation_response: :interested) }
+  scope :with_comments_or_contactable, -> { with_comments.or(contactable) }
 end

--- a/app/views/support_users/feedbacks/_feedback_table.html.slim
+++ b/app/views/support_users/feedbacks/_feedback_table.html.slim
@@ -2,6 +2,7 @@
   - t.datetime "Timestamp", :created_at
   - t.tags("Source") { |f| source_for(f) }
   - t.tags("Who") { |f| who(f) }
+  - t.text("Contact email") { |f| contact_email_for(f) }
   - t.text "Comment", :comment
   - t.column("Category") do |f|
     - capture do

--- a/app/views/support_users/feedbacks/general.html.slim
+++ b/app/views/support_users/feedbacks/general.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, "General feedback"
+- content_for :page_title_prefix, t(".title")
 
 .govuk-grid-row
   .govuk-grid-column-full = render "tabs"

--- a/app/views/support_users/feedbacks/job_alerts.html.slim
+++ b/app/views/support_users/feedbacks/job_alerts.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, "Job alert feedback"
+- content_for :page_title_prefix, t(".title")
 
 = render "tabs"
 = render "reporting_period_control"

--- a/app/views/support_users/feedbacks/satisfaction_ratings.html.slim
+++ b/app/views/support_users/feedbacks/satisfaction_ratings.html.slim
@@ -1,130 +1,24 @@
-- content_for :page_title_prefix, "Satisfaction ratings"
+- content_for :page_title_prefix, t(".title")
 
 = render "tabs"
-= govuk_table html_attributes: { "data-testid": "job-alert-unsubscribe-reason" } do |table|
-  - table.caption(size: "m", text: "Job alert unsubscribe - reason given")
 
+= tabs do |tabs|
+  - @satisfaction_ratings.each do |satisfaction_rating_type|
+    - tabs.navigation_item text: t(".#{satisfaction_rating_type[:feedback_type]}.tab_heading"),
+                           link: support_users_feedback_satisfaction_ratings_path(satisfaction_rating_type: satisfaction_rating_type[:feedback_type]),
+                           active: @satisfaction_rating_type[:feedback_type] == satisfaction_rating_type[:feedback_type]
+
+= govuk_table html_attributes: { "data-testid": @satisfaction_rating_type[:test_id] } do |table|
   - table.head do |head|
     - head.row do |row|
-      - row.cell(header: true, text: "Reporting period")
-      - row.cell(header: true, text: "Job found")
-      - row.cell(header: true, text: "Circumstances change")
-      - row.cell(header: true, text: "Not relevant")
-      - row.cell(header: true, text: "Other reason")
+      - row.cell(header: true, text: t("support_users.feedbacks.satisfaction_ratings.reporting_period"))
+      - @satisfaction_rating_type[:feedback_responses].each do |feedback_response|
+        - row.cell(header: true, text: t(".#{@satisfaction_rating_type[:feedback_type]}.table_headings.#{feedback_response}"))
 
   - table.body do |body|
     - FeedbackReportingPeriod.all.last(52).reverse_each do |period|
-      - results = reporting_period_summary(period, feedback_type: :unsubscribe, grouping_key: :unsubscribe_reason)
+      - results = reporting_period_summary(period, feedback_type: @satisfaction_rating_type[:feedback_type], grouping_key: @satisfaction_rating_type[:grouping_key])
       - body.row html_attributes: { "data-testid": period.to_s } do |row|
         - row.cell(header: true, text: period.to_s)
-        - row.cell(text: results["job_found"])
-        - row.cell(text: results["circumstances_change"])
-        - row.cell(text: results["not_relevant"])
-        - row.cell(text: results["other_reason"])
-
-= govuk_table html_attributes: { "data-testid": "satisfaction-rating-jobseekers" } do |table|
-  - table.caption(size: "m", text: "Satisfaction rating - jobseekers")
-
-  - table.head do |head|
-    - head.row do |row|
-      - row.cell(header: true, text: "Reporting period")
-      - row.cell(header: true, text: "Highly satisfied")
-      - row.cell(header: true, text: "Somewhat satisfied")
-      - row.cell(header: true, text: "Neither")
-      - row.cell(header: true, text: "Somewhat dissatisfied")
-      - row.cell(header: true, text: "Highly dissatisfied")
-
-  - table.body do |body|
-    - FeedbackReportingPeriod.all.last(52).reverse_each do |period|
-      - results = reporting_period_summary(period, feedback_type: :jobseeker_account, grouping_key: :rating)
-      - body.row html_attributes: { "data-testid": period.to_s } do |row|
-        - row.cell(header: true, text: period.to_s)
-        - row.cell(text: results["highly_satisfied"])
-        - row.cell(text: results["somewhat_satisfied"])
-        - row.cell(text: results["neither"])
-        - row.cell(text: results["somewhat_dissatisfied"])
-        - row.cell(text: results["highly_dissatisfied"])
-
-= govuk_table html_attributes: { "data-testid": "satisfaction-rating-hiring-staff" } do |table|
-  - table.caption(size: "m", text: "Satisfaction rating - hiring staff")
-
-  - table.head do |head|
-    - head.row do |row|
-      - row.cell(header: true, text: "Reporting period")
-      - row.cell(header: true, text: "Highly satisfied")
-      - row.cell(header: true, text: "Somewhat satisfied")
-      - row.cell(header: true, text: "Neither")
-      - row.cell(header: true, text: "Somewhat dissatisfied")
-      - row.cell(header: true, text: "Highly dissatisfied")
-
-  - table.body do |body|
-    - FeedbackReportingPeriod.all.last(52).reverse_each do |period|
-      - results = reporting_period_summary(period, feedback_type: :vacancy_publisher, grouping_key: :rating)
-      - body.row html_attributes: { "data-testid": period.to_s } do |row|
-        - row.cell(header: true, text: period.to_s)
-        - row.cell(text: results["highly_satisfied"])
-        - row.cell(text: results["somewhat_satisfied"])
-        - row.cell(text: results["neither"])
-        - row.cell(text: results["somewhat_dissatisfied"])
-        - row.cell(text: results["highly_dissatisfied"])
-
-= govuk_table html_attributes: { "data-testid": "satisfaction-rating-job-alerts" } do |table|
-  - table.caption(size: "m", text: "Satisfaction rating - job alerts")
-
-  - table.head do |head|
-    - head.row do |row|
-      - row.cell(header: true, text: "Reporting period")
-      - row.cell(header: true, text: "Relevant")
-      - row.cell(header: true, text: "Not relevant")
-
-  - table.body do |body|
-    - FeedbackReportingPeriod.all.last(52).reverse_each do |period|
-      - results = reporting_period_summary(period, feedback_type: :job_alert, grouping_key: :relevant_to_user)
-      - body.row html_attributes: { "data-testid": period.to_s } do |row|
-        - row.cell(header: true, text: period.to_s)
-        - row.cell(text: results[true].to_s)
-        - row.cell(text: results[false].to_s)
-
-= govuk_table html_attributes: { "data-testid": "close-account-reason" } do |table|
-  - table.caption(size: "m", text: "Close account reason")
-
-  - table.head do |head|
-    - head.row do |row|
-      - row.cell(header: true, text: "Reporting period")
-      - row.cell(header: true, text: "Too many emails")
-      - row.cell(header: true, text: "Not getting any value")
-      - row.cell(header: true, text: "Not looking for job")
-      - row.cell(header: true, text: "Other")
-
-  - table.body do |body|
-    - FeedbackReportingPeriod.all.last(52).reverse_each do |period|
-      - results = reporting_period_summary(period, feedback_type: :close_account, grouping_key: :close_account_reason)
-      - body.row html_attributes: { "data-testid": period.to_s } do |row|
-        - row.cell(header: true, text: period.to_s)
-        - row.cell(text: results["too_many_emails"])
-        - row.cell(text: results["not_getting_any_value"])
-        - row.cell(text: results["not_looking_for_job"])
-        - row.cell(text: results["other_close_account_reason"])
-
-= govuk_table html_attributes: { "data-testid": "satisfaction-rating-job-application" } do |table|
-  - table.caption(size: "m", text: "Satisfaction rating - job application")
-
-  - table.head do |head|
-    - head.row do |row|
-      - row.cell(header: true, text: "Reporting period")
-      - row.cell(header: true, text: "Highly satisfied")
-      - row.cell(header: true, text: "Somewhat satisfied")
-      - row.cell(header: true, text: "Neither")
-      - row.cell(header: true, text: "Somewhat dissatisfied")
-      - row.cell(header: true, text: "Highly dissatisfied")
-
-  - table.body do |body|
-    - FeedbackReportingPeriod.all.last(52).reverse_each do |period|
-      - results = reporting_period_summary(period, feedback_type: :application, grouping_key: :rating)
-      - body.row html_attributes: { "data-testid": period.to_s } do |row|
-        - row.cell(header: true, text: period.to_s)
-        - row.cell(text: results["highly_satisfied"])
-        - row.cell(text: results["somewhat_satisfied"])
-        - row.cell(text: results["neither"])
-        - row.cell(text: results["somewhat_dissatisfied"])
-        - row.cell(text: results["highly_dissatisfied"])
+        - @satisfaction_rating_type[:feedback_responses].each do |feedback_response|
+          - row.cell(text: results[feedback_response])

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -472,6 +472,57 @@ en:
       heading: Dashboard
       title: Support user dashboard
       user_feedback_link: View user feedback
+    feedbacks:
+      general:
+        title: General feedback
+      job_alerts:
+        title: Job alerts feedback
+      satisfaction_ratings:
+        application:
+          tab_heading: Job applications
+          table_headings:
+            highly_satisfied: Highly satisfied
+            somewhat_satisfied: Somewhat satisfied
+            neither: Neither
+            somewhat_dissatisfied: Somewhat dissatisfied
+            highly_dissatisfied: Highly dissatisfied
+        reporting_period: Reporting period
+        close_account:
+          tab_heading: Close account reason
+          table_headings:
+            too_many_emails: Too many emails
+            not_getting_any_value: Not getting any value
+            not_looking_for_job: Not looking for job
+            other_close_account_reason: Other
+        job_alert:
+          tab_heading: Job alert relevance
+          table_headings:
+            true: Relevant
+            false: Not relevant
+        jobseeker_account:
+          tab_heading: Jobseeker satisfaction
+          table_headings:
+            highly_satisfied: Highly satisfied
+            somewhat_satisfied: Somewhat satisfied
+            neither: Neither
+            somewhat_dissatisfied: Somewhat dissatisfied
+            highly_dissatisfied: Highly dissatisfied
+        title: Satisfaction ratings
+        unsubscribe:
+          tab_heading: Job alert unsubscribe reason
+          table_headings:
+            job_found: Job found
+            circumstances_change: Circumstances change
+            not_relevant: Not relevant
+            other_reason: Other reason
+        vacancy_publisher:
+          tab_heading: Hiring staff satisfaction
+          table_headings:
+            highly_satisfied: Highly satisfied
+            somewhat_satisfied: Somewhat satisfied
+            neither: Neither
+            somewhat_dissatisfied: Somewhat dissatisfied
+            highly_dissatisfied: Highly dissatisfied
 
     papertrail_display_name: "%{first_name} %{last_name} (DfE Teaching Vacancies team)"
     sessions:

--- a/spec/system/support_users/feedback_spec.rb
+++ b/spec/system/support_users/feedback_spec.rb
@@ -145,26 +145,32 @@ RSpec.describe "Feedback supportal section" do
     end
 
     context "'Job alert unsubscribe - reason given' table" do
+      before { click_on "Job alert unsubscribe" }
       include_examples "has a satisfaction rating table", "job-alert-unsubscribe-reason", 4
     end
 
     context "'Satisfaction rating - jobseekers' table" do
+      before { click_on "Jobseeker" }
       include_examples "has a satisfaction rating table", "satisfaction-rating-jobseekers", 5
     end
 
     context "'Satisfaction rating - hiring staff' table" do
+      before { click_on "Hiring staff" }
       include_examples "has a satisfaction rating table", "satisfaction-rating-hiring-staff", 5
     end
 
     context "'Satisfaction rating - job alerts' table" do
+      before { click_on "Job alert relevance" }
       include_examples "has a satisfaction rating table", "satisfaction-rating-job-alerts", 2
     end
 
     context "'Satisfaction rating - job application' table" do
+      before { click_on "Job applications" }
       include_examples "has a satisfaction rating table", "satisfaction-rating-job-application", 5
     end
 
     context "'Close account reason' table" do
+      before { click_on "Close account reason" }
       include_examples "has a satisfaction rating table", "close-account-reason", 4
     end
   end


### PR DESCRIPTION
## Changes in this PR:

This PR adds different colours for the "Who" category tags in the general feedback page. The repetition of the "Who" category tag in the "Source" column is removed. 

Additionally, the `unauthenticated_user_type` method is now able to determine if a user is a jobseeker or hiring staff based on their answer to the `visit_purpose` question; a new `"unknown"` value is added for users who do not specify this answer.

A "Contact email" column is added to the table, displaying the user's email address _if they have opted-in to being contacted._

The satisfaction rating tables are moved into sub-tabs.

## Screenshots of UI changes:

### Before
<img width="875" alt="image" src="https://user-images.githubusercontent.com/24639777/164488083-71d9c8c3-ce43-420b-9b7d-262af6ae9c8f.png">

![image](https://user-images.githubusercontent.com/24639777/165508152-dfb2d1de-5d0c-440a-bd7e-80e9625bef81.png)

### After
<img width="1061" alt="image" src="https://user-images.githubusercontent.com/24639777/165111893-84f47a0d-447d-44e2-9a02-e7ae6078ac3f.png">

![image](https://user-images.githubusercontent.com/24639777/165508069-97e892c8-feec-4b2c-bd7f-b91206d8d38a.png)
