### PR TITLE
duplicate ids breaking skip links

### DIFF
--- a/app/components/searchable_collection_component/searchable_collection_component.html.slim
+++ b/app/components/searchable_collection_component/searchable_collection_component.html.slim
@@ -3,6 +3,6 @@
     - if searchable?
       .searchable-collection-component__search
         input.govuk-input.searchable-collection-component__search-input.icon.icon--left.icon--search.js-action placeholder=t("helpers.hint.publishers_job_listing_job_details_form.subjects_placeholder") aria-label="#{label_text}" aria-expanded="true" aria-describedby="publishers-job-listing-job-details-form-subjects-hint" aria-owns="subjects__listbox" role="combobox"
-        .govuk-visually-hidden aria-live="polite" role="status" id="search-results"
+        .govuk-visually-hidden aria-live="polite" role="status" class="collection-match"
 
     = collection

--- a/app/components/searchable_collection_component/searchable_collection_component.js
+++ b/app/components/searchable_collection_component/searchable_collection_component.js
@@ -35,9 +35,9 @@ export const init = (container, classNames) => {
     });
 
     if (e.target.value.length) {
-      document.getElementById('search-results').innerHTML = `${visibleItems.length} subjects match ${e.target.value}`;
+      container.querySelector('.collection-match').innerHTML = `${visibleItems.length} subjects match ${e.target.value}`;
     } else {
-      document.getElementById('search-results').innerHTML = '';
+      container.querySelector('.collection-match').innerHTML = '';
     }
   });
 

--- a/app/components/searchable_collection_component/searchable_collection_component.test.js
+++ b/app/components/searchable_collection_component/searchable_collection_component.test.js
@@ -8,7 +8,7 @@ describe('searchCheckbox', () => {
   beforeEach(() => {
     document.body.innerHTML = `<div class="accordion-content__group">
 <input type="text" class="searchable-collection-component__search-input" />
-<div class="govuk-visually-hidden" aria-live="polite" role="status" id="search-results"></div>
+<div class="govuk-visually-hidden collection-match" aria-live="polite" role="status"></div>
 <div class="govuk-checkboxes__item">
 <input type="checkbox" value="abc" class="govuk-checkboxes__input" />
 </div>
@@ -31,7 +31,7 @@ describe('searchCheckbox', () => {
       expect(document.getElementsByClassName('govuk-radios__input')[0].parentElement.style.display).toBe('none');
       expect(document.getElementsByClassName('govuk-checkboxes__input')[1].parentElement.style.display).toBe('block');
 
-      expect(document.getElementById('search-results').innerHTML).toBe('2 subjects match abc');
+      expect(document.querySelector('.collection-match').innerHTML).toBe('2 subjects match abc');
     });
   });
 


### PR DESCRIPTION
no ticket

bug detected where duplicate html ids were causing skip links to navigate to wrong part of the page