### PR TITLE
[TEVA-4136] Prevent non production envs from being crawled

### DIFF
--- a/app/controllers/robots_controller.rb
+++ b/app/controllers/robots_controller.rb
@@ -1,0 +1,3 @@
+class RobotsController < ApplicationController
+  def show; end
+end

--- a/app/views/robots/show.text.erb
+++ b/app/views/robots/show.text.erb
@@ -1,3 +1,4 @@
+<%- if Rails.configuration.app_role.production? %>
 SITEMAP: https://teaching-vacancies.service.gov.uk/sitemap.xml
 User-agent: *
 Allow: /
@@ -7,3 +8,6 @@ Disallow: /documents/
 Disallow: /attachments/
 Disallow: /*-jobs*?*
 Disallow: /*/sign-in
+<%- else %>
+Disallow: /
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,8 @@ Rails.application.routes.draw do
 
   get "/sha", to: "sha#sha"
 
+  get "/robots.txt", to: "robots#show"
+
   namespace :jobseekers do
     devise_scope :jobseeker do
       get :check_your_email, to: "registrations#check_your_email", as: :check_your_email


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-4136

## Changes in this PR:

- Requests sent to /robots.txt now handled by RobotsController. Content of txt file now dependent on environment. 