### PR TITLE
Import vacancies from external feeds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem "kramdown"
 gem "lockbox"
 gem "mail-notify"
 gem "mimemagic"
+gem "nokogiri"
 gem "noticed"
 gem "omniauth", "< 2" # TODO: Pinned pending fixes
 gem "omniauth_openid_connect", "< 0.4" # TODO: Pinned pending fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -717,6 +717,7 @@ DEPENDENCIES
   net-imap
   net-pop
   net-smtp
+  nokogiri
   noticed
   omniauth (< 2)
   omniauth_openid_connect (< 0.4)

--- a/app/feeds/skywalker_feed.rb
+++ b/app/feeds/skywalker_feed.rb
@@ -1,0 +1,84 @@
+##
+# An experimental parser for a vacancy feed for "Skywalker".
+#
+# Allows enumerating over the feed's and yields intialized `Vacancy` objects that can be manipulated
+# and persisted by calling code (e.g. an import job).
+#
+# Notes:
+#   - Ruby's `RSS` class doesn't recognise the demo feed as an Atom feed for some reason, so this
+#     uses slightly uglier vanilla XML parsing
+class SkywalkerFeed
+  FEED_URL = ENV.fetch("VACANCIES_FEED_URL_SKYWALKER")
+
+  class FeedItem
+    def initialize(xml_node)
+      @xml_node = xml_node
+    end
+
+    def [](key, root: false)
+      @xml_node.at_xpath(root ? key : "a10:content/Vacancy/#{key}")&.text&.presence
+    end
+  end
+
+  include Enumerable
+
+  def each
+    items.each do |item|
+      v = Vacancy.find_or_initialize_by(
+        external_feed_source: "skywalker",
+        external_reference: item["VacancyID"],
+      )
+
+      # An external vacancy is by definition always published
+      v.status = :published
+      # Consider publish_on date to be the first time we saw this vacancy come through
+      # (i.e. today, unless it already has a publish on date set)
+      v.publish_on = v.publish_on || Date.today
+
+      v.assign_attributes(attributes_for(item))
+
+      yield v
+    end
+  end
+
+  private
+
+  def attributes_for(item)
+    {
+      # Base data
+      job_title: item["Vacancy_title"],
+      job_advert: item["Advert_text"],
+      salary: item["Salary"],
+      expires_at: Time.zone.parse(item["Expiry_date"]),
+      external_advert_url: item["link", root: true],
+
+      # New structured fields
+      job_roles: item["Job_roles"].presence&.split(","),
+      subjects: item["Subjects"].presence&.split(","),
+      working_patterns: item["Working_patterns"].presence&.split(","),
+      contract_type: item["Contract_type"].presence,
+      phase: item["Phase"].presence&.downcase,
+
+      # TODO: What about central office/multiple school vacancies?
+      job_location: :at_one_school,
+      organisations: organisations_for(item),
+      about_school: organisations_for(item).first&.description,
+    }
+  end
+
+  def organisations_for(item)
+    [school_group.schools.find_by(urn: item["URN"])]
+  end
+
+  def school_group
+    @school_group ||= SchoolGroup.find_by(uid: "5143")
+  end
+
+  def feed
+    @feed ||= Nokogiri::XML(HTTParty.get(FEED_URL))
+  end
+
+  def items
+    feed.xpath("//item").map { |fi| FeedItem.new(fi) }
+  end
+end

--- a/app/jobs/import_vacancies_from_feeds_job.rb
+++ b/app/jobs/import_vacancies_from_feeds_job.rb
@@ -1,0 +1,18 @@
+class ImportVacanciesFromFeedsJob < ApplicationJob
+  FEEDS = [SkywalkerFeed].freeze
+
+  queue_as :default
+
+  def perform
+    FEEDS.each do |feed_klass|
+      feed_klass.new.each do |vacancy|
+        # TODO: Basic validation would happen here
+        if vacancy.save
+          Rails.logger.info("Imported vacancy #{vacancy.id} from feed #{feed_klass.name}")
+        else
+          Rails.logger.error("Failed to save imported vacancy: #{vacancy.errors.inspect}")
+        end
+      end
+    end
+  end
+end

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -101,6 +101,10 @@ class Vacancy < ApplicationRecord # rubocop:disable Metrics/ClassLength
     ADDITIONAL_JOB_ROLES.keys.map(&:to_s)
   end
 
+  def external?
+    external_feed_source.present?
+  end
+
   def organisation
     @organisation ||= organisations.one? ? organisations.first : organisations.first&.school_groups&.first
   end

--- a/app/views/vacancies/listing/_job_details.html.slim
+++ b/app/views/vacancies/listing/_job_details.html.slim
@@ -66,6 +66,11 @@ section#job-details class="govuk-!-margin-bottom-5"
         h3.govuk-heading-m = t("publishers.vacancies.steps.applying_for_the_job")
         p.govuk-body = vacancy.how_to_apply
 
+      - if vacancy.external?
+        h4.govuk-heading-m = t("publishers.vacancies.steps.applying_for_the_job")
+        p This school accepts applications through their own website, where you may also find more information about this job.
+        = open_in_new_tab_button_link_to "View advert on school website", vacancy.external_advert_url, class: "govuk-!-margin-bottom-5"
+
       - if vacancy.application_link.present? && vacancy.application_form.present?
         = apply_link(vacancy, class: "govuk-button--secondary govuk-!-margin-bottom-5")
         br

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -28,6 +28,11 @@ import_polygon_data:
   class: 'ImportPolygonDataJob'
   queue: low
 
+import_vacancies_from_feeds:
+  cron: '7 * * * *'
+  class: 'ImportVacanciesFromFeedsJob'
+  queue: default
+
 queue_applications_received:
   cron: '0 6 * * *'
   class: 'SendApplicationsReceivedYesterdayJob'

--- a/db/migrate/20220427163022_add_imported_fields_to_vacancy.rb
+++ b/db/migrate/20220427163022_add_imported_fields_to_vacancy.rb
@@ -1,0 +1,7 @@
+class AddImportedFieldsToVacancy < ActiveRecord::Migration[6.1]
+  def change
+    add_column :vacancies, :external_feed_source, :string
+    add_column :vacancies, :external_reference, :string
+    add_column :vacancies, :external_advert_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_22_142612) do
+ActiveRecord::Schema.define(version: 2022_04_27_163022) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -489,6 +489,9 @@ ActiveRecord::Schema.define(version: 2022_03_22_142612) do
     t.boolean "google_index_removed", default: false
     t.string "parental_leave_cover_contract_duration"
     t.datetime "expired_vacancy_feedback_email_sent_at"
+    t.string "external_feed_source"
+    t.string "external_reference"
+    t.string "external_advert_url"
     t.index ["expires_at"], name: "index_vacancies_on_expires_at"
     t.index ["geolocation"], name: "index_vacancies_on_geolocation", using: :gist
     t.index ["publisher_id"], name: "index_vacancies_on_publisher_id"


### PR DESCRIPTION
Adds the ability to import vacancies from external data sources, and
adds an initial feed import for a trial launch. This will probably be
extended and refactored extensively in the future once we have
additional data sources that we integrate with.

- Add a concept of external sources to import data from
- Add an initial data source for United Learning
- Add some display tweaks for imported vacancies
- Add a job for running the import and add it to the schedule

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-4115