### PR TITLE
Import United Learning vacancies

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -4,3 +4,4 @@ DFE_SIGN_IN_SERVICE_ID=test-service-id
 DFE_SIGN_IN_SUPPORT_USER_ROLE_ID=test-support-user-role-id
 DFE_SIGN_IN_URL=https://test-url.local
 DOMAIN=localhost:3000
+VACANCY_SOURCE_UNITED_LEARNING_FEED_URL=http://example.com/feed.xml

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem "kramdown"
 gem "lockbox"
 gem "mail-notify"
 gem "mimemagic"
+gem "nokogiri"
 gem "noticed"
 gem "omniauth", "< 2" # TODO: Pinned pending fixes
 gem "omniauth_openid_connect", "< 0.4" # TODO: Pinned pending fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -717,6 +717,7 @@ DEPENDENCIES
   net-imap
   net-pop
   net-smtp
+  nokogiri
   noticed
   omniauth (< 2)
   omniauth_openid_connect (< 0.4)

--- a/app/components/dashboard_component/dashboard_component.html.slim
+++ b/app/components/dashboard_component/dashboard_component.html.slim
@@ -58,7 +58,12 @@
           - vacancies.each do |vacancy|
             - summary_list.row do |row|
               - row.key do
-                = govuk_link_to(vacancy.job_title, organisation_job_path(vacancy.id))
+                - if vacancy.external?
+                  = vacancy.job_title
+                  p class="govuk-!-margin-bottom-1"
+                    span.govuk-tag.govuk-tag--turquoise = t("jobs.manage.external_tag")
+                - else
+                  = govuk_link_to(vacancy.job_title, organisation_job_path(vacancy.id))
                 - if organisation.school_group?
                   p.govuk-body-s = vacancy.readable_job_location
 
@@ -100,6 +105,9 @@
                   dl
                     dt = "#{t('jobs.manage.draft.time_updated')}:"
                     dd = format_date(vacancy.updated_at.to_date)
+                - if vacancy.external?
+                  p.govuk-body-xs.external-notice
+                    = t("jobs.manage.external_notice")
 
     - unless @organisation.school_group?
       .govuk-grid-column-one-quarter

--- a/app/components/dashboard_component/dashboard_component.scss
+++ b/app/components/dashboard_component/dashboard_component.scss
@@ -7,4 +7,8 @@
       display: block;
     }
   }
+
+  .external-notice {
+    color: $govuk-secondary-text-colour;
+  }
 }

--- a/app/controllers/publishers/vacancies/base_controller.rb
+++ b/app/controllers/publishers/vacancies/base_controller.rb
@@ -21,7 +21,8 @@ class Publishers::Vacancies::BaseController < Publishers::BaseController
   end
 
   def vacancy
-    @vacancy ||= vacancies.find(params[:job_id].presence || params[:id])
+    # Scope to internal vacancies to disallow editing of external ones
+    @vacancy ||= vacancies.internal.find(params[:job_id].presence || params[:id])
   end
 
   def form_sequence

--- a/app/jobs/import_from_vacancy_sources_job.rb
+++ b/app/jobs/import_from_vacancy_sources_job.rb
@@ -1,0 +1,49 @@
+class ImportFromVacancySourcesJob < ApplicationJob
+  SOURCES = [UnitedLearningVacancySource].freeze
+
+  queue_as :default
+
+  def perform
+    return if DisableExpensiveJobs.enabled?
+
+    SOURCES.each do |source_klass|
+      import_start_time = Time.zone.now
+
+      source_klass.new.each do |vacancy|
+        PaperTrail.request(whodunnit: "Import from external source") do
+          if vacancy.save
+            Rails.logger.info("Imported vacancy #{vacancy.id} from feed #{source_klass.source_name}")
+          else
+            report_validation_errors(source_klass, vacancy)
+            Rails.logger.error("Failed to save imported vacancy: #{vacancy.errors.inspect}")
+          end
+        end
+      end
+
+      Vacancy.live.where(external_source: source_klass.source_name, updated_at: (...import_start_time)).find_each do |v|
+        Rails.logger.info("Set vacancy #{v.id} as removed from external system")
+        v.update(status: :removed_from_external_system)
+      end
+    end
+  end
+
+  private
+
+  def report_validation_errors(source_klass, vacancy)
+    Sentry.with_scope do |scope|
+      scope.set_tags(
+        source: source_klass.name,
+      )
+      scope.set_context(
+        "Validation errors",
+        vacancy.errors.to_hash,
+      )
+      scope.set_context(
+        "Vacancy data",
+        vacancy.attributes,
+      )
+
+      Sentry.capture_message("Vacancy failed to import")
+    end
+  end
+end

--- a/app/vacancy_sources/united_learning_vacancy_source.rb
+++ b/app/vacancy_sources/united_learning_vacancy_source.rb
@@ -1,0 +1,99 @@
+##
+# An experimental vacancy source for a vacancy feed for United Learning.
+#
+# Allows enumerating over the feed's contents and yields intialized `Vacancy` objects that can be
+# manipulated and persisted by calling code (e.g. an import job).
+#
+# Notes:
+#   - Ruby's `RSS` class doesn't recognise the demo feed as an Atom feed for some reason, so this
+#     uses slightly uglier vanilla XML parsing
+class UnitedLearningVacancySource
+  FEED_URL = ENV.fetch("VACANCY_SOURCE_UNITED_LEARNING_FEED_URL").freeze
+  UNITED_LEARNING_TRUST_UID = "5143".freeze
+  SOURCE_NAME = "united_learning".freeze
+
+  # Helper class for less verbose handling of items in the feed
+  class FeedItem
+    def initialize(xml_node)
+      @xml_node = xml_node
+    end
+
+    def [](key, root: false)
+      @xml_node.at_xpath(root ? key : "a10:content/Vacancy/#{key}")&.text&.presence
+    end
+  end
+
+  include Enumerable
+
+  def self.source_name
+    SOURCE_NAME
+  end
+
+  def each
+    items.each do |item|
+      v = Vacancy.find_or_initialize_by(
+        external_source: SOURCE_NAME,
+        external_reference: item["VacancyID"],
+      )
+
+      # An external vacancy is by definition always published
+      v.status = :published
+      # Consider publish_on date to be the first time we saw this vacancy come through
+      # (i.e. today, unless it already has a publish on date set)
+      v.publish_on ||= Date.today
+
+      v.assign_attributes(attributes_for(item))
+
+      yield v
+    end
+  end
+
+  private
+
+  def attributes_for(item)
+    {
+      # Base data
+      job_title: item["Vacancy_title"],
+      job_advert: item["Advert_text"],
+      salary: item["Salary"],
+      expires_at: Time.zone.parse(item["Expiry_date"]),
+      external_advert_url: item["link", root: true],
+
+      # New structured fields
+      job_roles: job_roles_for(item),
+      subjects: item["Subjects"].presence&.split(","),
+      working_patterns: item["Working_patterns"].presence&.split(","),
+      contract_type: item["Contract_type"].presence,
+      phase: item["Phase"].presence&.downcase,
+
+      # TODO: What about central office/multiple school vacancies?
+      job_location: :at_one_school,
+      readable_job_location: organisations_for(item).first.name,
+      organisations: organisations_for(item),
+      about_school: organisations_for(item).first&.description,
+    }
+  end
+
+  def job_roles_for(item)
+    roles = item["Job_roles"].presence&.split(",")
+    roles.push("ect_suitable") if item["ect_suitable"] == "yes"
+    roles.push("send_responsible") if item["send_responsible"] == "yes"
+    roles
+  end
+
+  def organisations_for(item)
+    [school_group.schools.find_by(urn: item["URN"])]
+  end
+
+  def school_group
+    @school_group ||= SchoolGroup.find_by(uid: UNITED_LEARNING_TRUST_UID)
+  end
+
+  def feed
+    @feed ||= Nokogiri::XML(HTTParty.get(FEED_URL))
+  end
+
+  def items
+    feed.xpath("//item").map { |fi| FeedItem.new(fi) }
+  end
+end

--- a/app/validators/external_vacancy_validator.rb
+++ b/app/validators/external_vacancy_validator.rb
@@ -1,0 +1,19 @@
+class ExternalVacancyValidator < ActiveModel::Validator
+  def validate(record)
+    validate_presence(
+      record,
+      :job_title, :job_advert, :salary, :publish_on, :expires_at,
+      :external_reference, :external_advert_url
+    )
+
+    record.errors.add(:organisations, "No school(s) associated with vacancy") if record.organisations.empty?
+  end
+
+  private
+
+  def validate_presence(record, *fields)
+    ActiveModel::Validations::PresenceValidator
+      .new(attributes: fields)
+      .validate(record)
+  end
+end

--- a/app/views/vacancies/listing/_job_details.html.slim
+++ b/app/views/vacancies/listing/_job_details.html.slim
@@ -66,6 +66,11 @@ section#job-details class="govuk-!-margin-bottom-5"
         h3.govuk-heading-m = t("publishers.vacancies.steps.applying_for_the_job")
         p.govuk-body = vacancy.how_to_apply
 
+      - if vacancy.external?
+        h4.govuk-heading-m = t("publishers.vacancies.steps.applying_for_the_job")
+        p = t("jobs.external.notice")
+        = open_in_new_tab_button_link_to t("jobs.external.link"), vacancy.external_advert_url, class: "govuk-!-margin-bottom-5"
+
       - if vacancy.application_link.present? && vacancy.application_form.present?
         = apply_link(vacancy, class: "govuk-button--secondary govuk-!-margin-bottom-5")
         br

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -177,6 +177,14 @@ en:
       blank: Enter a job advert
     about_school:
       blank: Enter a description of the %{organisation}
+
+  # External vacancies errors
+  external_errors: &external_errors
+    external_reference:
+      blank: Enter an external reference
+    external_advert_url:
+      blank: Enter an external advert URL
+
   errors:
     format: "%{message}"
     title:
@@ -513,3 +521,4 @@ en:
             <<: *applying_for_the_job_errors
             <<: *job_summary_errors
             <<: *select_a_job_for_copying_errors
+            <<: *external_errors

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -278,6 +278,10 @@ en:
     share_on_twitter: Share to Twitter
     share_this_job: Share this job
 
+    external:
+      notice: This school accepts applications through their own website, where you may also find more information about this job.
+      link: View advert on school website
+
     preview_listing:
       heading: Preview this job listing
       message: See how this job listing will appear to jobseekers on Teaching Vacancies
@@ -329,6 +333,8 @@ en:
         time_updated: Date last updated
       edit_link_text: Edit listing
       extend_link_text: Extend deadline
+      external_notice: This job listing was imported from your organisation's recruitment system and cannot be changed on Teaching Vacancies.
+      external_tag: Imported
       heading_html: "%{email} <span class='govuk-!-font-weight-regular'>- %{organisation}</span>"
       expired:
         expired_on: Listing ended

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -28,6 +28,11 @@ import_polygon_data:
   class: 'ImportPolygonDataJob'
   queue: low
 
+import_from_vacancy_sources:
+  cron: '55 6-21 * * *'
+  class: 'ImportFromVacancySourcesJob'
+  queue: default
+
 queue_applications_received:
   cron: '0 6 * * *'
   class: 'SendApplicationsReceivedYesterdayJob'

--- a/db/migrate/20220427163022_add_imported_fields_to_vacancy.rb
+++ b/db/migrate/20220427163022_add_imported_fields_to_vacancy.rb
@@ -1,0 +1,7 @@
+class AddImportedFieldsToVacancy < ActiveRecord::Migration[6.1]
+  def change
+    add_column :vacancies, :external_source, :string
+    add_column :vacancies, :external_reference, :string
+    add_column :vacancies, :external_advert_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_22_142612) do
+ActiveRecord::Schema.define(version: 2022_04_27_163022) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -489,6 +489,9 @@ ActiveRecord::Schema.define(version: 2022_03_22_142612) do
     t.boolean "google_index_removed", default: false
     t.string "parental_leave_cover_contract_duration"
     t.datetime "expired_vacancy_feedback_email_sent_at"
+    t.string "external_source"
+    t.string "external_reference"
+    t.string "external_advert_url"
     t.index ["expires_at"], name: "index_vacancies_on_expires_at"
     t.index ["geolocation"], name: "index_vacancies_on_geolocation", using: :gist
     t.index ["publisher_id"], name: "index_vacancies_on_publisher_id"

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -174,5 +174,11 @@ FactoryBot.define do
         )
       end
     end
+
+    trait :external do
+      external_source { "may_the_feed_be_with_you" }
+      external_reference { "J3D1" }
+      external_advert_url { "https://example.com/jobs/123" }
+    end
   end
 end

--- a/spec/fixtures/files/vacancy_sources/united_learning.xml
+++ b/spec/fixtures/files/vacancy_sources/united_learning.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss xmlns:a10="http://www.w3.org/2005/Atom" version="2.0">
+   <channel>
+       <title>United Learning RSS Feed</title>
+       <link>https://unitedlearning.current-vacancies.com/RSSFeeds/Vacancies/UNITEDLEAR?feedID=C8E62F84748A4306A68C06C1C583F242</link>
+       <description>United Learning RSS Feed</description>
+       <item>
+           <link>https://unitedlearning.current-vacancies.com/Jobs/FeedLink/2648837</link>
+           <title>Head of Geography</title>
+           <a10:updated>2022-04-29T10:29:57Z</a10:updated>
+           <a10:content type="text/xml">
+               <Vacancy>
+                   <VacancyID>751190</VacancyID>
+                   <vTitle>Head of Geography</vTitle>
+                   <VacancyPublishInfoID>2648837</VacancyPublishInfoID>
+                   <Vacancy_title>Head of Geography</Vacancy_title>
+                   <Salary>PT/EPT + TLR 2B</Salary>
+                   <Advert_text>Lorem ipsum dolor sit amet</Advert_text>
+                   <Vacancy_ID>NTXTP751190</Vacancy_ID>
+                   <Expiry_date>15/05/2022 12:00:00</Expiry_date>
+                   <Job_roles>teacher</Job_roles>
+                   <ect_suitable>yes</ect_suitable>
+                   <send_responsible>yes</send_responsible>
+                   <Working_patterns>full_time</Working_patterns>
+                   <Subjects>Geography</Subjects>
+                   <Job_location>at_one_school</Job_location>
+                   <Contract_type>permanent</Contract_type>
+                   <Phase>Secondary</Phase>
+                   <URN>136636</URN>
+                   <Key_stages>ks2</Key_stages>
+                   <Documents>
+                      <document>
+                          <name><![CDATA[Job Description - Head of Department Final April 21 TCC (6) (3) (1).pdf]]></name>
+                          <extension>pdf</extension>
+                          <size>225131</size>
+                          <url><![CDATA[https://unitedlearning.current-vacancies.com/Jobs/DownloadDocument/934437?cid=1567&pubid=2648837]]></url>
+                      </document>
+                   </Documents>
+               </Vacancy>
+           </a10:content>
+       </item>
+   </channel>
+</rss>

--- a/spec/jobs/import_from_vacancy_sources_job_spec.rb
+++ b/spec/jobs/import_from_vacancy_sources_job_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+class FakeVacancySource
+  cattr_writer :vacancies
+
+  def self.source_name
+    "fake_source"
+  end
+
+  def each(...)
+    @@vacancies.each(...)
+  end
+end
+
+RSpec.describe ImportFromVacancySourcesJob do
+  before do
+    stub_const("ImportFromVacancySourcesJob::SOURCES", [FakeVacancySource])
+    FakeVacancySource.vacancies = vacancies_from_source
+  end
+
+  let(:school) { create(:school) }
+
+  describe "#perform" do
+    context "when a new valid vacancy comes through" do
+      let(:vacancies_from_source) { [vacancy] }
+      let(:vacancy) { build(:vacancy, :published, :external, organisations: [school]) }
+
+      it "saves the vacancy" do
+        expect { described_class.perform_now }.to change { Vacancy.count }.by(1)
+      end
+    end
+
+    context "when a new vacancy comes through but isn't valid" do
+      let(:vacancies_from_source) { [vacancy] }
+      let(:vacancy) { build(:vacancy, :published, :external, organisations: [school], job_title: "") }
+
+      it "does not save the vacancy" do
+        expect { described_class.perform_now }.to change { Vacancy.count }.by(0)
+      end
+    end
+
+    context "when a live vacancy no longer comes through" do
+      let!(:vacancy) { create(:vacancy, :published, :external, organisations: [school], external_source: "fake_source", external_reference: "123", updated_at: 1.hour.ago) }
+      let(:vacancies_from_source) { [] }
+
+      it "sets the vacancy to have the correct status" do
+        expect { described_class.perform_now }
+          .to change { vacancy.reload.status }
+          .from("published").to("removed_from_external_system")
+      end
+    end
+
+    context "when an expired vacancy no longer comes through" do
+      let!(:vacancy) { create(:vacancy, :expired_yesterday, :external, organisations: [school], external_source: "fake_source", external_reference: "123", updated_at: 1.hour.ago) }
+      let(:vacancies_from_source) { [] }
+
+      it "does not change the vacancy's status" do
+        expect { described_class.perform_now }.not_to(change { vacancy.reload.status })
+      end
+    end
+  end
+end

--- a/spec/system/publishers_can_edit_a_published_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers_can_edit_a_published_vacancy_as_a_school_spec.rb
@@ -328,4 +328,23 @@ RSpec.describe "Publishers can edit a vacancy" do
       end
     end
   end
+
+  context "when a vacancy is external" do
+    let!(:vacancy) do
+      create(
+        :vacancy, :external, :at_one_school, :published, :expires_tomorrow,
+        job_title: "Imported vacancy",
+        organisations: [school]
+      )
+    end
+
+    scenario "it is visible on the dashboard but cannot be edited" do
+      visit organisation_path
+      expect(page).to have_content("Imported vacancy")
+      expect(page).not_to have_link("Imported vacancy")
+
+      visit organisation_job_path(vacancy.id)
+      expect(page).to have_content(I18n.t("error_pages.not_found"))
+    end
+  end
 end

--- a/spec/vacancy_sources/united_learning_vacancy_source_spec.rb
+++ b/spec/vacancy_sources/united_learning_vacancy_source_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.describe UnitedLearningVacancySource do
+  let!(:school) { create(:school, name: "Test School", urn: "136636") }
+  let!(:school_group) { create(:school_group, name: "United Learning", uid: "5143", schools: [school]) }
+
+  before do
+    # FIXME: Manually stubbing HTTParty because of weird interactions between VCR and Webmock
+    expect(HTTParty).to receive(:get).with("http://example.com/feed.xml").and_return(file_fixture("vacancy_sources/united_learning.xml").read)
+  end
+
+  describe "enumeration" do
+    let(:vacancy) { subject.first }
+
+    it "has the correct number of vacancies" do
+      expect(subject.count).to eq(1)
+    end
+
+    it "yield a newly built vacancy the correct vacancy information" do
+      expect(vacancy).not_to be_persisted
+      expect(vacancy).to be_changed
+
+      expect(vacancy.job_title).to eq("Head of Geography")
+      expect(vacancy.job_advert).to eq("Lorem ipsum dolor sit amet")
+      expect(vacancy.salary).to eq("PT/EPT + TLR 2B")
+
+      expect(vacancy.job_roles).to eq(%w[teacher ect_suitable send_responsible])
+      expect(vacancy.subjects).to eq(%w[Geography])
+      expect(vacancy.working_patterns).to eq(%w[full_time])
+      expect(vacancy.contract_type).to eq("permanent")
+      expect(vacancy.phase).to eq("secondary")
+
+      expect(vacancy.job_location).to eq("at_one_school")
+      expect(vacancy.organisations.first).to eq(school)
+
+      expect(vacancy.external_source).to eq("united_learning")
+      expect(vacancy.external_advert_url).to eq("https://unitedlearning.current-vacancies.com/Jobs/FeedLink/2648837")
+      expect(vacancy.external_reference).to eq("751190")
+
+      expect(vacancy.organisations).to eq([school])
+
+      expect(vacancy.expires_at).to eq(Time.zone.parse("2022-05-15 12:00:00"))
+      expect(vacancy.publish_on).to eq(Date.today)
+    end
+
+    context "when the same vacancy has been imported previously" do
+      let!(:existing_vacancy) do
+        create(
+          :vacancy,
+          :external,
+          external_source: "united_learning",
+          external_reference: "751190",
+          organisations: [school],
+          job_title: "Out of date",
+        )
+      end
+
+      it "yields the existing vacancy with updated information" do
+        expect(vacancy.id).to eq(existing_vacancy.id)
+        expect(vacancy).to be_persisted
+        expect(vacancy).to be_changed
+
+        expect(vacancy.job_title).to eq("Head of Geography")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds the ability to import vacancies from external data sources such as
XML feeds or APIs, and adds an initial feed import for a trial launch.

This will probably be extended and refactored extensively in the future
once we have additional data sources that we integrate with and can
abstract/extract common code.

- Add a concept of external sources to import data from
- Add an initial data source for United Learning based on an XML feed
- Add some display tweaks for imported vacancies
- Add a job for running the import and add it to the schedule
- De-link imported vacancies in publisher dashboard component (and add
  notice that they are imported and cannot be edited)
- Scope vacancy lookup in publisher dashboard to only internal vacancies
  (so that they cannot edit imported vacancies)

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-4115

## Screenshots

#### Hiring staff dashboard showing imported vacancies
<img width="1038" alt="image" src="https://user-images.githubusercontent.com/72141/165931600-12366b05-2bcb-439e-b06a-114fefa23e7f.png">
