### PR TITLE
[TEVA-4016] Skip big query validation callback in optional method

### DIFF
--- a/app/form_models/base_form.rb
+++ b/app/form_models/base_form.rb
@@ -1,15 +1,19 @@
 class BaseForm
+  attr_accessor :skip_after_validation_big_query_callback
+
   include ActiveModel::Model
   include ActiveModel::Validations::Callbacks
 
-  after_validation :send_errors_to_big_query
+  after_validation :send_errors_to_big_query, unless: :skip_after_validation_big_query_callback
 
   def self.target_name
     model_name.element.split("_")[0..-2].join("_").to_s
   end
 
   def self.optional?
-    new.valid?
+    form_section = new
+    form_section.skip_after_validation_big_query_callback = true
+    form_section.valid?
   end
 
   def send_errors_to_big_query

--- a/app/form_models/publishers/job_listing/important_dates_form.rb
+++ b/app/form_models/publishers/job_listing/important_dates_form.rb
@@ -21,7 +21,9 @@ class Publishers::JobListing::ImportantDatesForm < Publishers::JobListing::Vacan
   end
 
   def self.optional?
-    new({}, Vacancy.new).valid?
+    form_section = new({}, Vacancy.new)
+    form_section.skip_after_validation_big_query_callback = true
+    form_section.valid?
   end
 
   def initialize(params, vacancy)


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-4016

## Changes in this PR:

The `after_validation :send_errors_to_big_query` callback was being triggered upon `new.valid?` in the `self.optional?` method, meaning that form validation errors were being sent to big query for every non-optional form section. A flag to skip the callback has been added to the `self.optional?` method where defined.

