### PR TITLE
Track clicks on external advert links

### DIFF
--- a/app/helpers/links_helper.rb
+++ b/app/helpers/links_helper.rb
@@ -60,6 +60,16 @@ module LinksHelper
     )
   end
 
+  def external_advert_link(vacancy, **kwargs)
+    tracked_open_in_new_tab_button_link_to(
+      t("jobs.external.link"),
+      vacancy.external_advert_url,
+      link_type: :external_advert_link,
+      link_subject: anon(vacancy.id),
+      **kwargs,
+    )
+  end
+
   def apply_link(vacancy, **kwargs)
     tracked_open_in_new_tab_button_link_to(
       t("jobs.apply"),

--- a/app/views/vacancies/listing/_job_details.html.slim
+++ b/app/views/vacancies/listing/_job_details.html.slim
@@ -69,7 +69,7 @@ section#job-details class="govuk-!-margin-bottom-5"
       - if vacancy.external?
         h4.govuk-heading-m = t("publishers.vacancies.steps.applying_for_the_job")
         p = t("jobs.external.notice")
-        = open_in_new_tab_button_link_to t("jobs.external.link"), vacancy.external_advert_url, class: "govuk-!-margin-bottom-5"
+        = external_advert_link vacancy, class: "govuk-!-margin-bottom-5"
 
       - if vacancy.application_link.present? && vacancy.application_form.present?
         = apply_link(vacancy, class: "govuk-button--secondary govuk-!-margin-bottom-5")


### PR DESCRIPTION
Imported ("external") vacancies have a link to the school's recruitment
website, which we want to track like other external links.