### PR TITLE
Update Node.js version in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,10 +4,16 @@ FROM ruby:${RUBY_VERSION}
 ARG USERNAME=teaching-vacancies
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
+ARG NODEJS_MAJOR_VERSION=14
+
+# Set up NodeSource repository for newer Node.JS
+RUN apt update -yq \
+   && apt install curl gnupg -yq \
+   && curl -sL https://deb.nodesource.com/setup_$NODEJS_MAJOR_VERSION.x | bash
 
 # Set up dependencies
-RUN apt update && apt install -y nodejs yarnpkg postgresql-client redis-tools \
-      less vim sudo shared-mime-info man-db
+RUN apt install -y nodejs postgresql-client redis-tools less vim sudo shared-mime-info man-db
+RUN npm install -g yarn
 
 # Set up unprivileged local user
 RUN groupadd --gid $USER_GID $USERNAME \
@@ -15,10 +21,6 @@ RUN groupadd --gid $USER_GID $USERNAME \
     && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME --shell /bin/bash --groups bundler \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
-
-# Debian has Yarn as `yarnpkg`, so symlink it to a more expected `yarn` command
-# TODO: Replace with `bin/yarn`
-RUN ln -s /usr/bin/yarnpkg /usr/local/bin/yarn
 
 # Set unprivileged user as default user
 USER $USERNAME


### PR DESCRIPTION
Our Javascript dependencies now require Node 14, but this isn't
available in the default Debian repositories. This adds the appropriate
NodeSource repository to the devcontainer so we can use newer Node
versions.