### PR TITLE
Add logging to identify maps performance issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "activestorage", RAILS_VERSION
 gem "activesupport", RAILS_VERSION
 gem "railties", RAILS_VERSION
 
+gem "activerecord-analyze"
 gem "activerecord-import"
 gem "activerecord-postgis-adapter"
 gem "activerecord-session_store"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,9 @@ GEM
     activerecord (6.1.4.7)
       activemodel (= 6.1.4.7)
       activesupport (= 6.1.4.7)
+    activerecord-analyze (0.10.1)
+      activerecord (>= 5.1.0)
+      railties (>= 5.1.0)
     activerecord-import (1.4.0)
       activerecord (>= 4.2)
     activerecord-postgis-adapter (7.1.1)
@@ -672,6 +675,7 @@ DEPENDENCIES
   activejob (~> 6.1.4.1)
   activemodel (~> 6.1.4.1)
   activerecord (~> 6.1.4.1)
+  activerecord-analyze
   activerecord-import
   activerecord-postgis-adapter
   activerecord-session_store

--- a/app/services/search/vacancy_search.rb
+++ b/app/services/search/vacancy_search.rb
@@ -69,6 +69,20 @@ class Search::VacancySearch
     scope = scope.search_by_filter(search_criteria) if search_criteria.any?
     scope = scope.search_by_full_text(keyword) if keyword.present?
     scope = scope.reorder(sort.by => sort.order) if sort&.by_db_column?
+
+    # TODO: This is temporary to identify performance bottlenecks
+    if location == "lincolnshire"
+      Rails.logger.info(scope.analyze(
+                          format: :text,
+                          verbose: true,
+                          costs: true,
+                          settings: true,
+                          buffers: true,
+                          timing: true,
+                          summary: true,
+                        ))
+    end
+
     scope
   end
 end


### PR DESCRIPTION
This adds some temporary logging for all searches for 'lincolnshire' to
help us identify a performance problem with SQL queries for displaying
maps.