### PR TITLE
Update user confirmation token expiry time

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -150,7 +150,7 @@ Devise.setup do |config|
   # their account can't be confirmed with the token any more.
   # Default is nil, meaning there is no restriction on how long a user can take
   # before confirming their account.
-  config.confirm_within = 2.hours
+  config.confirm_within = 2.days
 
   # If true, requires any email changes to be confirmed (exactly the same way as
   # initial account confirmation) to be applied. Requires additional unconfirmed_email

--- a/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Jobseekers can sign up to an account" do
 
     context "when the confirmation token is invalid" do
       context "when the confirmation period has expired" do
-        before { travel_to 3.hours.from_now }
+        before { travel_to 3.days.from_now }
 
         context "when the confirmation email is resent" do
           it "resends confirmation email and redirects to check your email page" do


### PR DESCRIPTION
There are occurences of jobseekers registering to our website without
confirming with the link in the email sent to them.

This causes the user to be stuck in some sort of limbo where if they try
to log into TV again they are not able to and receive no feedback/error
message too.
This behaviour requires more investigation but for the time being
extending the expiration time of the confirmation token should reduce
the incidence of these errors.

## For reference this is the Jira ticket related to behaviour described here ☝🏻 ☝🏻 ☝🏻 

- https://dfedigital.atlassian.net/browse/TEVA-4173

