### PR TITLE
search results visual tweaks

### DIFF
--- a/app/components/map_component/map.js
+++ b/app/components/map_component/map.js
@@ -2,6 +2,12 @@ import 'leaflet';
 import 'leaflet.markercluster/dist/leaflet.markercluster';
 import { GestureHandling } from 'leaflet-gesture-handling';
 
+const SHAPE_STYLES = {
+  color: '#505a5f',
+  weight: 2,
+  opacity: 0.4,
+};
+
 const map = {
   create: (point, zoom) => {
     L.Map.addInitHook('addHandler', 'gestureHandling', GestureHandling);
@@ -14,9 +20,9 @@ const map = {
 
     return m;
   },
-  createCluster: (iconCreateFunction) => L.markerClusterGroup({
+  createCluster: (clusterIcon) => L.markerClusterGroup({
     iconCreateFunction: (cluster) => {
-      const properties = iconCreateFunction(cluster.getChildCount());
+      const properties = clusterIcon(cluster.getChildCount());
 
       return L.divIcon({
         className: `map-component__map__cluster map-component__map__cluster--${properties.style}`,
@@ -26,8 +32,8 @@ const map = {
     },
     maxClusterRadius: 40,
   }),
-  createPolygon: ({ coordinates }) => L.polygon(coordinates.map((point) => point.reverse()), { color: '#0b0c0c', weight: 1, smoothFactor: 2 }),
-  createCircle: (radius, point) => L.circle(point, { radius, color: '#0b0c0c', weight: 1 }),
+  createPolygon: ({ coordinates }) => L.polygon(coordinates.map((point) => point.reverse()), Object.assign(SHAPE_STYLES, { smoothFactor: 2 })),
+  createCircle: (radius, point) => L.circle(point, Object.assign(SHAPE_STYLES, { radius })),
   layerBounds: (layer) => layer.getBounds(),
   createMarker: (point, variant, popupHandler) => {
     const marker = L.marker(point, { icon: map.markerIcon(variant) });

--- a/app/components/map_component/map.scss
+++ b/app/components/map_component/map.scss
@@ -28,7 +28,7 @@
           color: govuk-colour('white');
           display: block;
           font-size: 1.2em;
-          line-height: 2 !important;
+          line-height: 2.1 !important;
           text-align: center;
         }
 

--- a/app/components/map_component/map.test.js
+++ b/app/components/map_component/map.test.js
@@ -5,7 +5,7 @@
 import { Application } from '@hotwired/stimulus';
 
 import MapController from './map_component';
-import map from './leaflet';
+import map from './map';
 
 let application;
 
@@ -15,6 +15,7 @@ const initialiseStimulus = () => {
 };
 
 jest.mock('../../frontend/src/lib/api');
+
 const mockCreateMap = jest.fn();
 const mockAddToMap = jest.fn();
 const mockCreateCluster = jest.fn();
@@ -24,12 +25,13 @@ const mockLayerBounds = jest.fn();
 const mockAddMarkerToCluster = jest.fn();
 const mockSetMapBounds = jest.fn();
 const mockCreateMarker = jest.fn();
+
 let spies;
 
 const getMarkerHTML = (count) => {
   let markerHTML = '';
   for (let step = 0; step < count; step += 1) {
-    markerHTML += `<div data-map-target="marker" data-id="marker-${step}" data-lat="51" data-lon="0.14"></div>`;
+    markerHTML += '<div data-map-target="marker" data-lat="51" data-lon="0.14"></div>';
   }
   return markerHTML;
 };
@@ -49,7 +51,7 @@ beforeAll(() => {
     setMapBounds: mockSetMapBounds,
   })));
 
-  jest.mock('./leaflet', () => jest.fn().mockImplementation(() => ({
+  jest.mock('./map', () => jest.fn().mockImplementation(() => ({
     create: mockCreateMap,
     createCluster: mockCreateCluster,
     createMarker: mockCreateMarker,
@@ -71,17 +73,19 @@ beforeAll(() => {
   };
 });
 
-describe('when map is initialised with one item', () => {
+describe('when map is initialised with one marker', () => {
   beforeEach(() => {
     document.getElementById('markers').insertAdjacentHTML('afterbegin', getMarkerHTML(1));
     jest.resetAllMocks();
     initialiseStimulus();
   });
 
-  test('a map object is created with one marker', () => {
-    expect(spies.createMap).toHaveBeenCalledTimes(1);
+  test('a map object is created', () => {
     expect(spies.createMap).toHaveBeenCalledWith({ lat: '51', lon: '0.14' }, MapController.DEFAULT_ZOOM);
     expect(spies.createCluster).toHaveBeenCalledTimes(1);
+  });
+
+  test('one marker is added to map', () => {
     expect(spies.createMarker).toHaveBeenCalledTimes(1);
     expect(spies.addMarkerToCluster).not.toHaveBeenCalled();
     expect(spies.addToMap).toHaveBeenCalledTimes(1);
@@ -92,12 +96,17 @@ describe('when map is initialised with one item', () => {
 describe('when map is initialised with polygons', () => {
   beforeEach(() => {
     document.getElementById('markers').insertAdjacentHTML('afterbegin', getMarkerHTML(1));
-    document.getElementById('map-component').setAttribute('data-polygon', '[[[0, 0],[0, 2],[2, 2]], [[0, 0],[0, 1],[1, 1]]]');
+    document.getElementById('map-component').setAttribute('data-polygons', '[[[0, 0],[0, 2],[2, 2]], [[0, 0],[0, 1],[1, 1]]]');
     jest.resetAllMocks();
     initialiseStimulus();
   });
 
-  test('a map object is created with one marker and polygons', () => {
+  test('a map object is created', () => {
+    expect(spies.createMap).toHaveBeenCalledWith({ lat: '51', lon: '0.14' }, MapController.DEFAULT_ZOOM);
+    expect(spies.createCluster).toHaveBeenCalledTimes(1);
+  });
+
+  test('one marker and polygons are added to map', () => {
     expect(spies.createMarker).toHaveBeenCalledTimes(1);
     expect(spies.createPolygon).toHaveBeenNthCalledWith(1, { coordinates: [[0, 0], [0, 2], [2, 2]] });
     expect(spies.createPolygon).toHaveBeenNthCalledWith(2, { coordinates: [[0, 0], [0, 1], [1, 1]] });
@@ -132,16 +141,20 @@ describe('when map is initialised with a center point and radius', () => {
 
 describe('when map is initialised with more than one marker', () => {
   beforeEach(() => {
-    document.getElementById('markers').insertAdjacentHTML('afterbegin', getMarkerHTML(3));
+    document.getElementById('markers').insertAdjacentHTML('afterbegin', getMarkerHTML(2));
     jest.resetAllMocks();
     initialiseStimulus();
   });
 
-  test('a map object is created with markers added to cluster', () => {
+  test('a map object is created', () => {
+    expect(spies.createMap).toHaveBeenCalledWith({ lat: '51', lon: '0.14' }, MapController.DEFAULT_ZOOM);
     expect(spies.createCluster).toHaveBeenCalledTimes(1);
-    expect(spies.createMarker).toHaveBeenCalledTimes(3);
-    expect(spies.addMarkerToCluster).toHaveBeenCalledTimes(3);
+  });
+
+  test('markers are added to cluster', () => {
+    expect(spies.createMarker).toHaveBeenCalledTimes(2);
+    expect(spies.addMarkerToCluster).toHaveBeenCalledTimes(2);
     expect(spies.addToMap).toHaveBeenCalledTimes(1);
-    expect(spies.setMapBounds).toHaveBeenCalledWith([{ lat: '51', lon: '0.14' }, { lat: '51', lon: '0.14' }, { lat: '51', lon: '0.14' }]);
+    expect(spies.setMapBounds).toHaveBeenCalledWith([{ lat: '51', lon: '0.14' }, { lat: '51', lon: '0.14' }]);
   });
 });

--- a/app/components/map_component/map_component.html.slim
+++ b/app/components/map_component/map_component.html.slim
@@ -1,4 +1,4 @@
-= tag.div(class: classes, **html_attributes.merge(data: { controller: "map", zoom: @zoom, point: @point, polygon: @polygon, radius: radius })) do
+= tag.div(class: classes, **html_attributes.merge(data: { controller: "map", zoom: @zoom, point: @point, polygons: @polygon, radius: radius })) do
   .markers
     - @markers.each do |marker|
       - if marker[:geopoint]

--- a/app/frontend/src/styles/base/_utilities.scss
+++ b/app/frontend/src/styles/base/_utilities.scss
@@ -38,6 +38,7 @@
 
 .divider-bottom {
   border-bottom: 1px solid $govuk-border-colour;
+  margin-bottom: govuk-spacing(4);
 }
 
 .two-column-list {

--- a/app/views/publishers/organisations/_vacancies_awaiting_feedback.html.slim
+++ b/app/views/publishers/organisations/_vacancies_awaiting_feedback.html.slim
@@ -3,7 +3,7 @@ p.govuk-body#awaiting_feedback_intro class="govuk-!-margin-bottom-4" = t("jobs.m
 - vacancies.each do |vacancy|
   = form_for vacancy_statistics_form(vacancy), url: organisation_job_statistics_path(vacancy.id), html: { id: vacancy.id, method: "patch" } do |f|
     = f.govuk_error_summary(t("errors.publishers.job_statistics.error_summary", job_title: vacancy.job_title))
-    .feedback-row.divider-bottom class="govuk-!-margin-bottom-4" id=dom_id(vacancy)
+    .feedback-row.divider-bottom id=dom_id(vacancy)
       .govuk-grid-row
         .govuk-grid-column-one-third
           = govuk_link_to(vacancy.job_title, organisation_job_path(vacancy.id), class: "govuk-!-font-weight-bold govuk-!-font-size-24")

--- a/app/views/subscriptions/_fields.html.slim
+++ b/app/views/subscriptions/_fields.html.slim
@@ -3,7 +3,7 @@
 = render "vacancies/search/current_location", target: "jobseekers-subscription-form-location-field"
 = render "vacancies/search/radius", f: f, wide: false
 
-.divider-bottom class="govuk-!-margin-top-6 govuk-!-margin-bottom-4"
+.divider-bottom class="govuk-!-margin-top-6"
 
 .plain-styling
   = filters(submit_button: f.govuk_submit(t("buttons.apply_filters")),
@@ -25,7 +25,7 @@
       - filters_component.group key: "education_phase", component: f.govuk_collection_check_boxes(:phases, @form.phase_options, :first, :last, small: false, legend: { text: t("jobs.filters.phases") }, hint: nil)
       - filters_component.group key: "working_patterns", component: f.govuk_collection_check_boxes(:working_patterns, @form.working_pattern_options, :first, :last, small: false, legend: { text: t("jobs.filters.working_patterns") }, hint: nil)
 
-.divider-bottom class="govuk-!-margin-top-4 govuk-!-margin-bottom-6"
+.divider-bottom class="govuk-!-margin-top-4"
 
 - if jobseeker_signed_in?
   = f.hidden_field :email, value: current_jobseeker.email

--- a/app/views/subscriptions/confirm.html.slim
+++ b/app/views/subscriptions/confirm.html.slim
@@ -10,7 +10,7 @@
 
     = render "subscription_details", subscription: @subscription, current_subscription: false
 
-    .divider-bottom class="govuk-!-padding-bottom-5"
+    .divider-bottom
       p.govuk-body = t(".unsubscribe")
 
       = govuk_link_to t(".back_to_search_results"), jobs_path(@subscription.search_criteria), class: "govuk-!-font-size-19"


### PR DESCRIPTION
small visual tweaks to maps:

- lightened the polygon colour (i thought this was a no brainer from map bug party)
- changed the 5+/20+ cluster test to just have the actual number (again i thought this was a no brainer from map bug party)
- noticed and fixed a vertical margin missing from the search results no results UI that i think will have crept in during CSS refactoring a few weeks back

small improvements to map JS tests