### PR TITLE
Fix vacancy phases in United Learning source

### DIFF
--- a/app/vacancy_sources/united_learning_vacancy_source.rb
+++ b/app/vacancy_sources/united_learning_vacancy_source.rb
@@ -64,7 +64,9 @@ class UnitedLearningVacancySource
       subjects: item["Subjects"].presence&.split(","),
       working_patterns: item["Working_patterns"].presence&.split(","),
       contract_type: item["Contract_type"].presence,
-      phase: item["Phase"].presence&.downcase,
+      # TODO: This is coming through unexpectedly in the feed - the parameterize call can be removed
+      #       when the correct values are coming through
+      phase: item["Phase"].presence&.parameterize(separator: "_"),
 
       # TODO: What about central office/multiple school vacancies?
       job_location: :at_one_school,

--- a/spec/fixtures/files/vacancy_sources/united_learning.xml
+++ b/spec/fixtures/files/vacancy_sources/united_learning.xml
@@ -25,7 +25,7 @@
                    <Subjects>Geography</Subjects>
                    <Job_location>at_one_school</Job_location>
                    <Contract_type>permanent</Contract_type>
-                   <Phase>Secondary</Phase>
+                   <Phase>Multiple phases</Phase>
                    <URN>136636</URN>
                    <Key_stages>ks2</Key_stages>
                    <Documents>

--- a/spec/vacancy_sources/united_learning_vacancy_source_spec.rb
+++ b/spec/vacancy_sources/united_learning_vacancy_source_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe UnitedLearningVacancySource do
       expect(vacancy.subjects).to eq(%w[Geography])
       expect(vacancy.working_patterns).to eq(%w[full_time])
       expect(vacancy.contract_type).to eq("permanent")
-      expect(vacancy.phase).to eq("secondary")
+      expect(vacancy.phase).to eq("multiple_phases")
 
       expect(vacancy.job_location).to eq("at_one_school")
       expect(vacancy.organisations.first).to eq(school)


### PR DESCRIPTION
This is coming through unexpectedly as `Multiple phases` instead of
`multiple_phases` (ditto for capitalised other phases). They are looking
into it but in the meantime this makes the phase import able to handle
this.