### PR TITLE
Improve error experience for unconfirmed jobseekers

### DIFF
--- a/app/controllers/jobseekers/sessions_controller.rb
+++ b/app/controllers/jobseekers/sessions_controller.rb
@@ -5,12 +5,12 @@ class Jobseekers::SessionsController < Devise::SessionsController
     if (attempted_path = params[:attempted_path])
       alert_text = t("jobseekers.forced_login.#{forced_login_resource(attempted_path)}",
                      account_creation_link: helpers.govuk_link_to(t("jobseekers.forced_login.create_account"), new_jobseeker_registration_url))
+      flash.now[:alert] = alert_text
     elsif (login_failure = params[:login_failure])
       alert_text = t("devise.failure.#{login_failure}")
       trigger_jobseeker_sign_in_event(:failure, alert_text)
+      flash.now[:alert] = alert_text
     end
-
-    flash.now[:alert] = alert_text
 
     super do
       unless redirected?

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -150,7 +150,7 @@ Devise.setup do |config|
   # their account can't be confirmed with the token any more.
   # Default is nil, meaning there is no restriction on how long a user can take
   # before confirming their account.
-  config.confirm_within = 2.days
+  config.confirm_within = 2.weeks
 
   # If true, requires any email changes to be confirmed (exactly the same way as
   # initial account confirmation) to be applied. Requires additional unconfirmed_email

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -14,7 +14,10 @@ en:
       not_found_in_database: We did not recognise your sign-in details.
       timeout: Your session expired. Please sign in again to continue.
       unauthenticated: You need to sign in or create an account before continuing.
-      unconfirmed: You have to confirm your email address before continuing.
+      unconfirmed: |
+        You cannot sign in because you have not yet confirmed your email address using the link in the email we sent you when you signed up for Teaching Vacancies.
+
+        If you signed up more than two weeks ago, or have lost the email, contact us using the 'Get help or report a problem' link on the bottom of this page.
     omniauth_callbacks:
       failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
       success: "Successfully authenticated from %{kind} account."

--- a/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Jobseekers can sign up to an account" do
 
     context "when the confirmation token is invalid" do
       context "when the confirmation period has expired" do
-        before { travel_to 3.days.from_now }
+        before { travel_to 15.days.from_now }
 
         context "when the confirmation email is resent" do
           it "resends confirmation email and redirects to check your email page" do


### PR DESCRIPTION
- Fix a bug that caused the error flash message for unconfirmed
  jobseeker accounts not to be shown
- Increase the grace period for confirming your account to two weeks
- Improve the error message for unconfirmed accounts until we find a
  better long-term solution to improve the experience