### PR TITLE
fit bounds for any layer if more than one marker

### DIFF
--- a/app/components/map_component/map.test.js
+++ b/app/components/map_component/map.test.js
@@ -32,13 +32,13 @@ beforeAll(() => {
   </div>`;
 
   jest.mock('./map_component', () => jest.fn().mockImplementation(() => ({
-    addShape: jest.fn(),
+    addLayer: jest.fn(),
     addMarker: jest.fn(),
   })));
 
   spies = {
     addMarker: jest.spyOn(MapController.prototype, 'addMarker'),
-    addShape: jest.spyOn(MapController.prototype, 'addShape'),
+    addLayer: jest.spyOn(MapController.prototype, 'addLayer'),
   };
 });
 
@@ -73,6 +73,6 @@ describe('when map is initialised', () => {
   });
 
   test('polygons and radius circles are added to map', () => {
-    expect(spies.addShape).toHaveBeenCalledTimes(2);
+    expect(spies.addLayer).toHaveBeenCalledTimes(3);
   });
 });

--- a/app/components/map_component/map_component.js
+++ b/app/components/map_component/map_component.js
@@ -21,7 +21,7 @@ const MapController = class extends Controller {
 
     if (this.element.dataset.radius) {
       this.addMarker({ point: this.point, variant: 'location' });
-      this.addShape(Map.createCircle(this.radius, this.point, MapController.SHAPE_STYLES));
+      this.addLayer(Map.createCircle(this.radius, this.point, MapController.SHAPE_STYLES));
     }
 
     this.markerTargets.forEach((markerTarget) => {
@@ -37,7 +37,7 @@ const MapController = class extends Controller {
     });
 
     if (this.polygons) {
-      this.addShape(Map.createPolygon(this.polygons, MapController.SHAPE_STYLES));
+      this.addLayer(Map.createPolygon(this.polygons, MapController.SHAPE_STYLES));
     }
 
     this.addLayer(this.cluster.group);
@@ -64,13 +64,12 @@ const MapController = class extends Controller {
     this.map.createMarker(options);
   }
 
-  addShape(layer) {
-    this.addLayer(layer);
-    this.map.container.fitBounds(layer.getBounds());
-  }
-
   addLayer(layer) {
     this.map.container.addLayer(layer);
+
+    if (this.markerTargets.length > 1) {
+      this.map.container.fitBounds(layer.getBounds());
+    }
   }
 };
 


### PR DESCRIPTION
no ticket makes sure bounds are set for all map views where there is more than one marker i.e even if there is no polygon or circle like when a search for England is performed.