### PR TITLE
Add Floodlight to CSP

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -19,12 +19,14 @@ Rails.application.configure do
                        :data
 
     policy.frame_src   :self,
+                       "https://2673654.fls.doubleclick.net", # Floodlight
                        "https://www.recaptcha.net",
                        "https://www.googletagmanager.com"
 
     policy.img_src     :self,
                        :https,
-                       :data
+                       :data,
+                       "https://2673654.fls.doubleclick.net" # Floodlight
 
     policy.object_src  :none
 


### PR DESCRIPTION
Allows for Floodlight beacons to be loaded for users who consent to
tracking.