### PR TITLE
Improve vacancy import resilience

### DIFF
--- a/app/jobs/import_from_vacancy_sources_job.rb
+++ b/app/jobs/import_from_vacancy_sources_job.rb
@@ -22,7 +22,7 @@ class ImportFromVacancySourcesJob < ApplicationJob
 
       Vacancy.live.where(external_source: source_klass.source_name, updated_at: (...import_start_time)).find_each do |v|
         Rails.logger.info("Set vacancy #{v.id} as removed from external system")
-        v.update(status: :removed_from_external_system)
+        v.update_attribute(:status, :removed_from_external_system)
       end
     end
   end

--- a/app/vacancy_sources/united_learning_vacancy_source.rb
+++ b/app/vacancy_sources/united_learning_vacancy_source.rb
@@ -70,7 +70,7 @@ class UnitedLearningVacancySource
 
       # TODO: What about central office/multiple school vacancies?
       job_location: :at_one_school,
-      readable_job_location: organisations_for(item).first.name,
+      readable_job_location: organisations_for(item).first&.name,
       organisations: organisations_for(item),
       about_school: organisations_for(item).first&.description,
     }

--- a/app/validators/external_vacancy_validator.rb
+++ b/app/validators/external_vacancy_validator.rb
@@ -3,7 +3,8 @@ class ExternalVacancyValidator < ActiveModel::Validator
     validate_presence(
       record,
       :job_title, :job_advert, :salary, :publish_on, :expires_at,
-      :external_reference, :external_advert_url
+      :external_reference, :external_advert_url,
+      :job_roles, :contract_type, :phase, :working_patterns
     )
 
     record.errors.add(:organisations, "No school(s) associated with vacancy") if record.organisations.empty?

--- a/spec/jobs/import_from_vacancy_sources_job_spec.rb
+++ b/spec/jobs/import_from_vacancy_sources_job_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe ImportFromVacancySourcesJob do
   before do
     stub_const("ImportFromVacancySourcesJob::SOURCES", [FakeVacancySource])
     FakeVacancySource.vacancies = vacancies_from_source
+    expect(DisableExpensiveJobs).to receive(:enabled?).and_return(false)
   end
 
   let(:school) { create(:school) }
@@ -23,7 +24,7 @@ RSpec.describe ImportFromVacancySourcesJob do
   describe "#perform" do
     context "when a new valid vacancy comes through" do
       let(:vacancies_from_source) { [vacancy] }
-      let(:vacancy) { build(:vacancy, :published, :external, organisations: [school]) }
+      let(:vacancy) { build(:vacancy, :published, :external, phase: "secondary", organisations: [school]) }
 
       it "saves the vacancy" do
         expect { described_class.perform_now }.to change { Vacancy.count }.by(1)
@@ -32,7 +33,7 @@ RSpec.describe ImportFromVacancySourcesJob do
 
     context "when a new vacancy comes through but isn't valid" do
       let(:vacancies_from_source) { [vacancy] }
-      let(:vacancy) { build(:vacancy, :published, :external, organisations: [school], job_title: "") }
+      let(:vacancy) { build(:vacancy, :published, :external, phase: "secondary", organisations: [school], job_title: "") }
 
       it "does not save the vacancy" do
         expect { described_class.perform_now }.to change { Vacancy.count }.by(0)
@@ -40,7 +41,7 @@ RSpec.describe ImportFromVacancySourcesJob do
     end
 
     context "when a live vacancy no longer comes through" do
-      let!(:vacancy) { create(:vacancy, :published, :external, organisations: [school], external_source: "fake_source", external_reference: "123", updated_at: 1.hour.ago) }
+      let!(:vacancy) { create(:vacancy, :published, :external, phase: "secondary", organisations: [school], external_source: "fake_source", external_reference: "123", updated_at: 1.hour.ago) }
       let(:vacancies_from_source) { [] }
 
       it "sets the vacancy to have the correct status" do
@@ -51,7 +52,7 @@ RSpec.describe ImportFromVacancySourcesJob do
     end
 
     context "when an expired vacancy no longer comes through" do
-      let!(:vacancy) { create(:vacancy, :expired_yesterday, :external, organisations: [school], external_source: "fake_source", external_reference: "123", updated_at: 1.hour.ago) }
+      let!(:vacancy) { create(:vacancy, :expired_yesterday, :external, phase: "secondary", organisations: [school], external_source: "fake_source", external_reference: "123", updated_at: 1.hour.ago) }
       let(:vacancies_from_source) { [] }
 
       it "does not change the vacancy's status" do

--- a/spec/system/publishers_can_edit_a_published_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers_can_edit_a_published_vacancy_as_a_school_spec.rb
@@ -333,6 +333,7 @@ RSpec.describe "Publishers can edit a vacancy" do
     let!(:vacancy) do
       create(
         :vacancy, :external, :at_one_school, :published, :expires_tomorrow,
+        phase: "secondary",
         job_title: "Imported vacancy",
         organisations: [school]
       )

--- a/spec/vacancy_sources/united_learning_vacancy_source_spec.rb
+++ b/spec/vacancy_sources/united_learning_vacancy_source_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe UnitedLearningVacancySource do
         create(
           :vacancy,
           :external,
+          phase: "secondary",
           external_source: "united_learning",
           external_reference: "751190",
           organisations: [school],


### PR DESCRIPTION
- Add stricter validations to `ExternalVacancyValidator`
- Add safe navigation to stop error on missing organisations (this
  should be caught by validations instead)