### PR TITLE
Assorted improvements to keywords-to-filters

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -39,7 +39,7 @@ class VacanciesController < ApplicationController
     %w[job_role job_roles subjects phases working_patterns].each do |facet|
       params[facet] = params[facet].split if params[facet].is_a?(String)
     end
-    params.permit(:keyword, :location, :radius, :subject, :sort_by,
+    params.permit(:keyword, :previous_keyword, :location, :radius, :subject, :sort_by,
                   job_role: [], job_roles: [], subjects: [], phases: [], working_patterns: [])
   end
 

--- a/app/form_models/jobseekers/search_form.rb
+++ b/app/form_models/jobseekers/search_form.rb
@@ -1,7 +1,7 @@
 class Jobseekers::SearchForm
   include ActiveModel::Model
 
-  attr_reader :keyword,
+  attr_reader :keyword, :previous_keyword,
               :location, :radius,
               :job_roles, :subjects, :phases, :working_patterns,
               :job_role_options, :ect_suitable_options, :send_responsible_options,
@@ -11,6 +11,7 @@ class Jobseekers::SearchForm
   def initialize(params = {})
     strip_trailing_whitespaces_from_params(params)
     @keyword = params[:keyword] || params[:subject]
+    @previous_keyword = params[:previous_keyword]
     @location = params[:location]
     @job_roles = params[:job_roles] || params[:job_role] || []
     @subjects = params[:subjects]
@@ -26,6 +27,7 @@ class Jobseekers::SearchForm
   def to_hash
     {
       keyword: @keyword,
+      previous_keyword: @previous_keyword,
       location: @location,
       radius: @radius,
       job_roles: @job_roles,

--- a/app/services/search/keyword_filter_generation/query_parser.rb
+++ b/app/services/search/keyword_filter_generation/query_parser.rb
@@ -27,6 +27,6 @@ class Search::KeywordFilterGeneration::QueryParser < Parslet::Parser
   end
 
   def parse(query)
-    super(query.downcase.delete("."))
+    super(query.downcase.delete(".,;"))
   end
 end

--- a/config/initializers/search.rb
+++ b/config/initializers/search.rb
@@ -12,17 +12,17 @@ Rails.application.configure do
   synonym_triggers = synonyms
     .flatten
     .uniq
-    .sort_by { |phrase| phrase.count(" ") }
+    .sort_by { |phrase| [phrase.count(" "), phrase.length] }
     .reverse
   oneway_synonym_triggers = oneway_synonyms
     .keys
     .uniq
-    .sort_by { |phrase| phrase.count(" ") }
+    .sort_by { |phrase| [phrase.count(" "), phrase.length] }
     .reverse
   keyword_filter_mapping_triggers = keyword_filter_mappings
     .keys
     .uniq
-    .sort_by { |phrase| phrase.count(" ") }
+    .sort_by { |phrase| [phrase.count(" "), phrase.length] }
     .reverse
 
   config.x.search.synonyms = synonyms


### PR DESCRIPTION
- Remove more punctuation before parsing keywords (comma, semicolon)
- Ensure longest words match first so e.g. a failed match for "teach"
  doesn't stop "teacher" from matching
- Feed `previous_keyword` through to `SearchForm` to make sure changing
  sort order doesn't reset previously discarded filters

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-4186