### PR TITLE
make map side bar aria live region more succinct

### DIFF
--- a/app/components/map_component/map.js
+++ b/app/components/map_component/map.js
@@ -64,7 +64,6 @@ const Map = class {
       }
 
       if (['Escape', 'Esc'].includes(e.originalEvent.key)) {
-        target.eventHandlers.close();
         this.activeMarker(marker);
       }
     });

--- a/app/components/map_component/map.test.js
+++ b/app/components/map_component/map.test.js
@@ -84,7 +84,6 @@ describe('when map is initialised with layers', () => {
         data: expect.any(Function),
         eventHandlers: {
           open: expect.any(Function),
-          close: expect.any(Function),
           focus: expect.any(Function),
           interaction: expect.any(Function),
         },
@@ -104,7 +103,6 @@ describe('when map is initialised with layers', () => {
         data: expect.any(Function),
         eventHandlers: {
           open: expect.any(Function),
-          close: expect.any(Function),
           focus: expect.any(Function),
           interaction: expect.any(Function),
         },

--- a/app/components/map_component/map_component.html.slim
+++ b/app/components/map_component/map_component.html.slim
@@ -1,4 +1,4 @@
-= tag.div(class: classes, **html_attributes.merge(data: { controller: "map map-sidebar", action: "map-sidebar:closed->map#focusMarker map-sidebar:opened->map#focusMarker map:sidebar:update->map-sidebar#update map:sidebar:focus->map-sidebar#focus map:sidebar:close->map-sidebar#close map:interaction->map-sidebar#blur map:interaction->map#blurMarker", point: @point, polygons: @polygon, radius: radius })) do
+= tag.div(class: classes, **html_attributes.merge(data: { controller: "map map-sidebar", action: "map-sidebar:closed->map#focusMarker map-sidebar:opened->map#focusMarker map:sidebar:update->map-sidebar#update map:sidebar:focus->map-sidebar#focus map:interaction->map-sidebar#blur map:interaction->map#blurMarker", point: @point, polygons: @polygon, radius: radius })) do
 
   .markers data-map-target="markers" data-marker-tracking=@marker[:tracking].to_json
     - @markers.each do |marker|
@@ -6,7 +6,7 @@
         .markers__marker data-map-target="marker" data-marker-type=@marker[:type] data-id=marker[:id] data-parent-id=marker[:parent_id] data-point=marker[:geopoint]
 
   .map-component__container
-    .sidebar-component data-map-sidebar-target="container" tabindex="-1" id="sidebar-content" role="dialog" aria-live="polite"
+    .sidebar-component data-map-sidebar-target="container" tabindex="-1"
       .sidebar-component__content data-map-sidebar-target="content"
       button.sidebar-component__close.icon.icon--close.govuk-body-s data-action="click->map-sidebar#close" data-map-sidebar-target="close" type="button"
         = "Close"

--- a/app/components/map_component/map_component.js
+++ b/app/components/map_component/map_component.js
@@ -77,7 +77,6 @@ const MapController = class extends Controller {
                   });
                 }
                 : (markerData) => template.popup({ ...markerData, ...{ trackingType: tracking.link } }),
-              close: () => this.dispatch('sidebar:close'),
               focus: () => this.dispatch('sidebar:focus'),
               interaction: () => this.dispatch('interaction'),
             },

--- a/app/components/map_component/marker/template.js
+++ b/app/components/map_component/marker/template.js
@@ -14,11 +14,13 @@ const popup = (data) => {
 
 const sidebar = (data) => {
   const html = `<div class="sidebar">
+                <div id="sidebar-content" role="dialog" aria-live="polite">
                 <h2 class="popup-title govuk-!-margin-bottom-1 govuk-!-font-size-16">
                 <a class="tracked govuk-link govuk-!-font-weight-bold"
                 href="${data.heading_url}">${data.heading_text}</a>
                 </h2>
                 <p class="govuk-body-s govuk-!-margin-bottom-2">${data.name}, ${data.address}</p>
+                </div>
                 ${Array.isArray(data.details) ? data.details.map((detail) => `<dl><dt class="govuk-!-font-weight-bold">${detail.label}</dt><dd>${detail.value}</dt></dd></dl>`).join('') : ''}
                 </div>`;
 


### PR DESCRIPTION
aria live region inform screenreader of information for marker on focus

previously it would read

```Director of Learning - Science
St Catherine's CofE Primary School, Greenstone Avenue, Bolton, Lancashire, BL6 5SJ
Annual or full time equivalent salary
Main pay range 1 to Upper pay range 3, £30,480 to £49,571
School type
Primary
Working pattern
Term time, part time
Closing date
24 November 2022 at 9:00am
```

which is too verbose. now it reads:

```Director of Learning - Science
St Catherine's CofE Primary School, Greenstone Avenue, Bolton, Lancashire, BL6 5SJ
```

i also removed one stimulus event that was not needed and doing nothing