### PR TITLE
Update review app worker memory

### DIFF
--- a/terraform/workspace-variables/review.tfvars.json
+++ b/terraform/workspace-variables/review.tfvars.json
@@ -1,9 +1,7 @@
 {
   "app_environment": "review",
-  "channel_list":
-    {},
-  "distribution_list":
-    {},
+  "channel_list": {},
+  "distribution_list": {},
   "documents_s3_bucket_force_destroy": true,
   "paas_app_start_timeout": "180",
   "paas_app_stopped": false,
@@ -14,10 +12,11 @@
   "paas_space_name": "teaching-vacancies-review",
   "paas_web_app_deployment_strategy": "blue-green-v2",
   "paas_web_app_instances": 2,
+  "paas_web_app_memory": 1024,
   "paas_web_app_start_command": "bundle exec rails cf:on_first_instance db:migrate db:async_seed && rails s",
   "paas_worker_app_deployment_strategy": "blue-green-v2",
   "paas_worker_app_instances": 2,
-  "paas_worker_app_memory": 512,
+  "paas_worker_app_memory": 1024,
   "parameter_store_environment": "dev",
   "region": "eu-west-2"
 }


### PR DESCRIPTION
We are updating the requirements for memory for the review apps because
we had some issues in processing expensive jobs, specifically loading
organisations in batches, caused by the GIAS import.

We also struggle in simply loading the Rails Console. This should not
increase the cost too much and will make our life easier.
