### PR TITLE
Don't fail subsequent items on source import

### DIFF
--- a/app/vacancy_sources/united_learning_vacancy_source.rb
+++ b/app/vacancy_sources/united_learning_vacancy_source.rb
@@ -45,6 +45,8 @@ class UnitedLearningVacancySource
       v.assign_attributes(attributes_for(item))
 
       yield v
+    rescue StandardError => e
+      Sentry.capture_exception(e)
     end
   end
 


### PR DESCRIPTION
When an error occurs when iterating over the items in the United
Learning feed (such as attempting to set an invalid value for an enum
field), the error is not `rescue`d and as a result the whole job fails
and all subsequent items after the "broken" item aren't imported.

This adds a `rescue` block that reports errors for individual items to
Sentry but allows the iteration to continue for the next item.