### PR TITLE
Remove SetOrganisationSlugsOfBatch job

### DIFF
--- a/app/jobs/set_organisation_slugs_job.rb
+++ b/app/jobs/set_organisation_slugs_job.rb
@@ -2,8 +2,6 @@ class SetOrganisationSlugsJob < ApplicationJob
   queue_as :default
 
   def perform
-    Organisation.find_in_batches do |batch|
-      SetOrganisationSlugsOfBatchJob.perform_later(batch.pluck(:id))
-    end
+    Organisation.where(slug: nil).find_each(batch_size: 50, &:save)
   end
 end

--- a/app/jobs/set_organisation_slugs_of_batch_job.rb
+++ b/app/jobs/set_organisation_slugs_of_batch_job.rb
@@ -1,7 +1,0 @@
-class SetOrganisationSlugsOfBatchJob < ApplicationJob
-  queue_as :default
-
-  def perform(ids)
-    Organisation.where(id: ids).find_each(batch_size: 50, &:save)
-  end
-end

--- a/spec/configuration/sidekiq_scheduled_jobs_spec.rb
+++ b/spec/configuration/sidekiq_scheduled_jobs_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe "Sidekiq configuration" do
       Noticed::DeliveryMethods::Email
       Sentry::SendEventJob
       SetOrganisationSlugsJob
-      SetOrganisationSlugsOfBatchJob
     ]
   end
 


### PR DESCRIPTION
## Changes in this PR:

This PR removes SetOrganisationSlugsOfBatchJob which is no longer needed as we have increased the memory in review apps.

