### PR TITLE
add focus of marker in cluster on cluster zoom

### DIFF
--- a/app/components/map_component/cluster.js
+++ b/app/components/map_component/cluster.js
@@ -16,9 +16,23 @@ const Cluster = class {
     this.group = L.markerClusterGroup({
       iconCreateFunction: (cluster) => {
         cluster.on('add', () => {
-          cluster.getElement().addEventListener('focus', () => {
-            eventHandlers.focus();
-          });
+          cluster.getElement().addEventListener('focus', eventHandlers.focus);
+        });
+
+        cluster.on('click keydown', (c) => {
+          if (c.target.getAllChildMarkers().length) {
+            const [marker] = c.target.getAllChildMarkers();
+
+            marker.once('add', () => {
+              eventHandlers.enter({
+                detail: {
+                  id: marker.getElement().id,
+                },
+              });
+            });
+
+            marker.once('remove', eventHandlers.leave);
+          }
         });
 
         const properties = Cluster.icon(cluster.getChildCount());
@@ -55,3 +69,4 @@ const Cluster = class {
 };
 
 export default Cluster;
+

--- a/app/components/map_component/map.js
+++ b/app/components/map_component/map.js
@@ -7,12 +7,14 @@ const Map = class {
   constructor(point, zoom) {
     L.Map.addInitHook('addHandler', 'gestureHandling', GestureHandling);
     this.centerPoint = point.coordinates.reverse();
-    this.container = L.map('map', { tap: false, gestureHandling: true }).setView(this.centerPoint, zoom);
+    this.container = L.map('map', { tap: false, gestureHandling: true, zoomControl: false }).setView(this.centerPoint, zoom);
 
     L.tileLayer(
       'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
       { attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors' },
     ).addTo(this.container);
+
+    L.control.zoom({ position: 'topright' }).addTo(this.container);
 
     this.markerOffset = { x: 0, y: 0 };
   }

--- a/app/components/map_component/map_component.js
+++ b/app/components/map_component/map_component.js
@@ -112,6 +112,10 @@ const MapController = class extends Controller {
     this.cluster = new Cluster({
       eventHandlers: {
         focus: () => this.dispatch('interaction'),
+        enter: ({ detail }) => {
+          this.dispatch('sidebar:update', { detail: { id: detail.id } });
+        },
+        leave: () => this.dispatch('interaction'),
       },
     });
   }


### PR DESCRIPTION
this adds behaviour when a user enters a cluster to put focus on the first marker within that cluster. otherwise the focused marker is elsewhere on the map and makes keyboard navigation confusing.

when an expanded cluster becomes clustered again (on zoomout) the popup/sidebar is closed

events are removed from markers when they become clustered (using marker.once) so browser memory usage doesnt increase exponentially with cluster interaction

the zoom control has been moved to right hand side so users can use it and the popup doesnt have to be positioned to take up map space

**before when cluster is entered**

![Screenshot 2022-06-08 at 08 21 14](https://user-images.githubusercontent.com/1792451/172557292-eff9d065-0710-4944-b59d-8eba92be7b7c.png)

**after when cluster is entered**

![Screenshot 2022-06-08 at 08 22 07](https://user-images.githubusercontent.com/1792451/172557301-52c5adf2-1ac0-485c-876c-078368cf50b9.png)

