### PR TITLE
allow for first marker being another cluster on cluster zoom

### DIFF
--- a/app/components/map_component/cluster.js
+++ b/app/components/map_component/cluster.js
@@ -21,17 +21,17 @@ const Cluster = class {
 
         cluster.on('click keydown', (c) => {
           if (c.target.getAllChildMarkers().length) {
-            const [marker] = c.target.getAllChildMarkers();
-
-            marker.once('add', () => {
-              eventHandlers.enter({
-                detail: {
-                  id: marker.getElement().id,
-                },
+            c.target.getAllChildMarkers().forEach((marker) => {
+              marker.once('add', () => {
+                eventHandlers.enter({
+                  detail: {
+                    id: marker.getElement().id,
+                  },
+                });
               });
-            });
 
-            marker.once('remove', eventHandlers.leave);
+              marker.once('remove', eventHandlers.leave);
+            });
           }
         });
 
@@ -69,4 +69,3 @@ const Cluster = class {
 };
 
 export default Cluster;
-


### PR DESCRIPTION
update to ealier PR regarding cluster click/marker focus. it didnt account for clusters within clusters, so these are ignored as only want to focus on individual markers with this change