### PR TITLE
Authenticate Sidekiq Web UI using supportal auth

### DIFF
--- a/app/views/support_users/dashboard/dashboard.html.slim
+++ b/app/views/support_users/dashboard/dashboard.html.slim
@@ -2,7 +2,16 @@
 
 h1.govuk-heading-l = t("support_users.dashboard.heading")
 
+h2.govuk-heading-m = t("support_users.dashboard.user_feedback_heading")
 nav
   ul.govuk-list
     li
       = govuk_link_to t("support_users.dashboard.user_feedback_link"), support_users_feedback_general_path
+
+hr.govuk-section-break.govuk-section-break--l
+
+h2.govuk-heading-m = t("support_users.dashboard.development_tools_heading")
+nav
+  ul.govuk-list
+    li
+      = govuk_link_to t("support_users.dashboard.sidekiq_link"), "/sidekiq"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -483,7 +483,10 @@ en:
     dashboard:
       heading: Dashboard
       title: Support user dashboard
+      user_feedback_heading: User feedback
       user_feedback_link: View user feedback
+      development_tools_heading: Developer tools
+      sidekiq_link: View Sidekiq dashboard
     feedbacks:
       general:
         title: General feedback


### PR DESCRIPTION
- Change the Sidekiq Web UI away from basic auth to allowing it to be
  accessed by support users using DSI
- Add link to Sidekiq Web UI to supportal dashboard