### PR TITLE
Add custom layout for supportal

### DIFF
--- a/app/controllers/support_users/base_controller.rb
+++ b/app/controllers/support_users/base_controller.rb
@@ -2,5 +2,7 @@ class SupportUsers::BaseController < ApplicationController
   include ReturnPathTracking
   include Authenticated
 
+  layout "application_supportal"
+
   self.authentication_scope = :support_user
 end

--- a/app/controllers/support_users/sessions_controller.rb
+++ b/app/controllers/support_users/sessions_controller.rb
@@ -1,6 +1,8 @@
 class SupportUsers::SessionsController < Devise::SessionsController
   include ReturnPathTracking::Helpers
 
+  layout "application_supportal"
+
   def new
     if (login_failure = params[:login_failure])
       flash.now[:alert] = t("devise.failure.#{login_failure}")

--- a/app/views/layouts/application_supportal.html.slim
+++ b/app/views/layouts/application_supportal.html.slim
@@ -1,0 +1,24 @@
+doctype html
+html.govuk-template.app-html-class lang="en"
+  head
+    title #{content_for :page_title_prefix} - #{t("app.support_title")}
+    = stylesheet_pack_tag "application", media: "all"
+    = csrf_meta_tags
+    = render "layouts/sentry_js_config"
+
+  body class=body_class
+    = render "layouts/add_js_enabled_class_to_body"
+    = render "layouts/skip_links"
+    = render EnvironmentBannerComponent.new
+    = govuk_header(logotype: "", homepage_url: support_user_root_path) do |header|
+      - header.product_name(name: t("app.support_title"))
+      - header.navigation_item(text: t("nav.support_user_return_to_service"), href: root_path)
+      - header.navigation_item(text: t("nav.sign_out"), href: destroy_support_user_session_path, options: { method: :delete }) if support_user_signed_in?
+    div class="govuk-width-container"
+      = content_for :breadcrumbs
+      = render "layouts/flash_messages"
+      main#main-content.govuk-main-wrapper role="main"
+        = yield
+      = content_for :after_main
+    = govuk_footer
+    = javascript_pack_tag "application"

--- a/app/views/robots/show.text.erb
+++ b/app/views/robots/show.text.erb
@@ -9,6 +9,7 @@ Disallow: /attachments/
 Disallow: /*-jobs*?*
 Disallow: /*/sign-in
 Disallow: /jobs*radius=*
+Disallow: /support-users
 <%- else %>
 Disallow: /
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,6 +15,7 @@ en:
       cookie: Skip to cookie consent
       main: Skip to main content
     title: Teaching Vacancies
+    support_title: Support for Teaching Vacancies
 
   banners:
     alert: Warning
@@ -226,7 +227,8 @@ en:
     school_hiring_guides: School hiring guides
     sign_in: Sign in
     sign_out: Sign out
-    support_user_dashboard: Dashboard
+    support_user_dashboard: Support dashboard
+    support_user_return_to_service: Return to Teaching Vacancies
     your_account: My account
 
   number:

--- a/spec/system/support_users/dfe_sign_in_spec.rb
+++ b/spec/system/support_users/dfe_sign_in_spec.rb
@@ -13,7 +13,7 @@ RSpec.shared_examples "a successful Support User sign in" do
       .with_data(sign_in_type: "dsi")
 
     within(".govuk-header__navigation") { expect(page).to have_selector(:link_or_button, I18n.t("nav.sign_out")) }
-    within(".govuk-header__navigation") { expect(page).to have_selector(:link_or_button, I18n.t("nav.support_user_dashboard")) }
+    within(".govuk-header__navigation") { expect(page).to have_selector(:link_or_button, I18n.t("nav.support_user_return_to_service")) }
   end
 end
 

--- a/spec/system/support_users/dfe_sign_out_spec.rb
+++ b/spec/system/support_users/dfe_sign_out_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Support users can sign out with DfE Sign In" do
 
     click_on(I18n.t("nav.sign_out"))
 
-    within("nav") { expect(page).to have_content(I18n.t("buttons.sign_in")) }
+    within("nav") { expect(page).not_to have_content(I18n.t("nav.sign_out")) }
     expect(page).to have_content(I18n.t("devise.sessions.signed_out"))
   end
 end


### PR DESCRIPTION
Make the supportal more visually distinct from the rest of the service
by using a custom layout without the regular header/footer and with a
custom product name as suggested by Adam.

## Screenshots of UI changes:

### Before
<img width="1011" alt="image" src="https://user-images.githubusercontent.com/72141/173312924-5f423bee-c538-436c-9fec-a250fd8d5fa3.png">

### After
<img width="1013" alt="image" src="https://user-images.githubusercontent.com/72141/173312819-74247e07-2885-40ab-badc-2beed7e2ba6a.png">
