### PR TITLE
Update terraform template provider

### DIFF
--- a/terraform/app/modules/cloudwatch/versions.tf
+++ b/terraform/app/modules/cloudwatch/versions.tf
@@ -4,9 +4,5 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 3.28.0"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.0.0"
-    }
   }
 }

--- a/terraform/app/versions.tf
+++ b/terraform/app/versions.tf
@@ -13,9 +13,5 @@ terraform {
       source  = "StatusCakeDev/statuscake"
       version = "~> 1.0.1"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = "~> 2.1.2"
-    }
   }
 }


### PR DESCRIPTION
The current template provider for Terraform has been archived in
favour of native functionality in Terraform.
We don't use any of the functions that have been replaced hence this PR
simply remove the provider itself.

You can read more about it here:

* https://github.com/hashicorp/terraform-provider-template
* https://github.com/hashicorp/terraform-provider-template/issues/85
* https://registry.terraform.io/providers/hashicorp/template/latest/docs