### PR TITLE
minor a11y improvements

### DIFF
--- a/app/components/map_component/map.scss
+++ b/app/components/map_component/map.scss
@@ -1,7 +1,13 @@
 @import 'base_component';
 
+.map-component {
+  display: none;
+}
+
 .js-enabled {
   .map-component {
+    display: block;
+
     &__container {
       position: relative;
 

--- a/app/components/map_component/marker/template.js
+++ b/app/components/map_component/marker/template.js
@@ -14,7 +14,7 @@ const popup = (data) => {
 
 const sidebar = (data) => {
   const html = `<div class="sidebar">
-                <div id="sidebar-content" role="dialog" aria-live="polite">
+                <div id="sidebar-content" role="dialog" aria-live="assertive">
                 <h2 class="popup-title govuk-!-margin-bottom-1 govuk-!-font-size-16">
                 <a class="tracked govuk-link govuk-!-font-weight-bold"
                 href="${data.heading_url}">${data.heading_text}</a>

--- a/app/components/searchable_collection_component/searchable_collection_component.html.slim
+++ b/app/components/searchable_collection_component/searchable_collection_component.html.slim
@@ -3,6 +3,6 @@
     - if searchable?
       .searchable-collection-component__search
         input.govuk-input.searchable-collection-component__search-input.icon.icon--left.icon--search.js-action placeholder=t("helpers.hint.publishers_job_listing_job_details_form.subjects_placeholder") aria-label="#{label_text}" aria-expanded="true" aria-describedby="publishers-job-listing-job-details-form-subjects-hint" aria-owns="subjects__listbox" role="combobox"
-        .govuk-visually-hidden aria-live="polite" role="status" class="collection-match"
+        .govuk-visually-hidden aria-live="assertive" role="status" class="collection-match"
 
     = collection

--- a/app/components/searchable_collection_component/searchable_collection_component.test.js
+++ b/app/components/searchable_collection_component/searchable_collection_component.test.js
@@ -8,7 +8,7 @@ describe('searchCheckbox', () => {
   beforeEach(() => {
     document.body.innerHTML = `<div class="accordion-content__group">
 <input type="text" class="searchable-collection-component__search-input" />
-<div class="govuk-visually-hidden collection-match" aria-live="polite" role="status"></div>
+<div class="govuk-visually-hidden collection-match" aria-live="assertive" role="status"></div>
 <div class="govuk-checkboxes__item">
 <input type="checkbox" value="abc" class="govuk-checkboxes__input" />
 </div>

--- a/app/views/publishers/vacancies/build/job_details.html.slim
+++ b/app/views/publishers/vacancies/build/job_details.html.slim
@@ -21,7 +21,7 @@
           label: { size: "s" },
           class: "govuk-input string required govuk-js-character-count",
           required: true
-        span#publishers-job-listing-job-details-form-job-title-field-info.govuk-hint.govuk-character-count__message aria-live="polite"
+        span#publishers-job-listing-job-details-form-job-title-field-info.govuk-hint.govuk-character-count__message aria-live="assertive"
           | You can enter up to 100 characters
 
       = f.govuk_radio_buttons_fieldset :contract_type do

--- a/app/views/publishers/vacancies/copy/new.html.slim
+++ b/app/views/publishers/vacancies/copy/new.html.slim
@@ -15,7 +15,7 @@
           label: { size: "s" },
           class: "govuk-input string required govuk-js-character-count",
           required: true
-        span#publishers-job-listing-copy-vacancy-form-job-title-field-info.govuk-hint.govuk-character-count__message aria-live="polite"
+        span#publishers-job-listing-copy-vacancy-form-job-title-field-info.govuk-hint.govuk-character-count__message aria-live="assertive"
           | You can enter up to 100 characters
 
       = f.govuk_radio_buttons_fieldset :publish_on_day do


### PR DESCRIPTION
role="polite" is ignored by some screen readers (JAWS), role="assertive" is better
map component (and some of its children which were displayed when JS if off) should not be displayed with no JS