### PR TITLE
Add columns to job applications table

### DIFF
--- a/db/migrate/20220616154050_add_in_progress_steps_and_confirmations_to_job_applications.rb
+++ b/db/migrate/20220616154050_add_in_progress_steps_and_confirmations_to_job_applications.rb
@@ -1,0 +1,7 @@
+class AddInProgressStepsAndConfirmationsToJobApplications < ActiveRecord::Migration[6.1]
+  def change
+    add_column :job_applications, :in_progress_steps, :integer, array: true, default: [], null: false
+    add_column :job_applications, :employment_history_section_completed, :boolean
+    add_column :job_applications, :qualifications_section_completed, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_08_084016) do
+ActiveRecord::Schema.define(version: 2022_06_16_154050) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -217,6 +217,9 @@ ActiveRecord::Schema.define(version: 2022_06_08_084016) do
     t.text "further_instructions_ciphertext"
     t.text "rejection_reasons_ciphertext"
     t.text "gaps_in_employment_details_ciphertext"
+    t.integer "in_progress_steps", default: [], null: false, array: true
+    t.boolean "employment_history_section_completed"
+    t.boolean "qualifications_section_completed"
     t.index ["vacancy_id"], name: "index_job_applications_on_vacancy_id"
   end
 


### PR DESCRIPTION
## Changes in this PR:

This PR adds three columns to the job application table:

- `:in_progress_steps` is re-added in order to allow the qualifications and employment history steps to be "in progress" as per the requirements for [TEVA-4192](https://dfedigital.atlassian.net/jira/software/c/projects/TEVA/boards/21?modal=detail&selectedIssue=TEVA-4192)
- `:employment_history_section_completed` and `:qualifications_section_completed` will allow the user to mark those sections as complete.