### PR TITLE
[TEVA-4192] Make job application sections mandatory

### DIFF
--- a/app/controllers/jobseekers/job_applications/build_controller.rb
+++ b/app/controllers/jobseekers/job_applications/build_controller.rb
@@ -77,7 +77,23 @@ class Jobseekers::JobApplications::BuildController < Jobseekers::JobApplications
   end
 
   def update_params
-    form_params.merge(completed_steps: job_application.completed_steps.append(step.to_s).uniq)
+    if step_incomplete?
+      form_params.merge(
+        completed_steps: job_application.completed_steps.delete_if { |completed_step| completed_step == step.to_s },
+        in_progress_steps: job_application.in_progress_steps.append(step.to_s).uniq,
+      )
+    else
+      form_params.merge(
+        completed_steps: job_application.completed_steps.append(step.to_s).uniq,
+        in_progress_steps: job_application.in_progress_steps.delete_if { |in_progress_step| in_progress_step == step.to_s },
+      )
+    end
+  end
+
+  def step_incomplete?
+    return unless step.in? %i[qualifications employment_history]
+
+    form_params["#{step}_section_completed"] == "false"
   end
 
   def vacancy

--- a/app/form_models/jobseekers/job_application/employment_history_form.rb
+++ b/app/form_models/jobseekers/job_application/employment_history_form.rb
@@ -1,3 +1,10 @@
 class Jobseekers::JobApplication::EmploymentHistoryForm < Jobseekers::JobApplication::BaseForm
   include ActiveModel::Model
+
+  def self.fields
+    %i[employment_history_section_completed]
+  end
+  attr_accessor(*fields)
+
+  validates :employment_history_section_completed, presence: true
 end

--- a/app/form_models/jobseekers/job_application/qualifications_form.rb
+++ b/app/form_models/jobseekers/job_application/qualifications_form.rb
@@ -1,3 +1,10 @@
 class Jobseekers::JobApplication::QualificationsForm < Jobseekers::JobApplication::BaseForm
   include ActiveModel::Model
+
+  def self.fields
+    %i[qualifications_section_completed]
+  end
+  attr_accessor(*fields)
+
+  validates :qualifications_section_completed, presence: true
 end

--- a/app/helpers/job_applications_helper.rb
+++ b/app/helpers/job_applications_helper.rb
@@ -122,4 +122,8 @@ module JobApplicationsHelper
   def gap_duration(current_employment, next_employment)
     distance_of_time_in_words(current_employment.ended_on, next_employment&.started_on || Date.current)
   end
+
+  def job_application_step_in_progress?(job_application, step)
+    job_application.in_progress_steps.include?(step.to_s)
+  end
 end

--- a/app/helpers/status_tag_helper.rb
+++ b/app/helpers/status_tag_helper.rb
@@ -4,6 +4,8 @@ module StatusTagHelper
 
     if form_classes.all?(&:optional?)
       optional
+    elsif resource.is_a?(JobApplication) && steps.all? { |step| job_application_step_in_progress?(resource, step) }
+      in_progress
     elsif steps.none? { |step| vacancy_step_completed?(resource, step) }
       not_started
     elsif step_forms_contain_errors?(resource, form_classes)
@@ -35,5 +37,9 @@ module StatusTagHelper
 
   def complete
     govuk_tag(text: t("shared.status_tags.complete"))
+  end
+
+  def in_progress
+    govuk_tag(text: t("shared.status_tags.in_progress"), colour: "yellow")
   end
 end

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -17,6 +17,11 @@ class JobApplication < ApplicationRecord
     declarations: 8,
   }
 
+  array_enum in_progress_steps: {
+    qualifications: 0,
+    employment_history: 1,
+  }
+
   # If you want to add a status, be sure to add a `status_at` column to the `job_applications` table
   enum status: { draft: 0, submitted: 1, reviewed: 2, shortlisted: 3, unsuccessful: 4, withdrawn: 5 }, _default: 0
 

--- a/app/services/jobseekers/job_applications/quick_apply.rb
+++ b/app/services/jobseekers/job_applications/quick_apply.rb
@@ -7,7 +7,7 @@ class Jobseekers::JobApplications::QuickApply
   end
 
   def job_application
-    new_job_application.assign_attributes(recent_job_application.slice(*attributes_to_copy).merge(completed_steps: completed_steps))
+    new_job_application.assign_attributes(recent_job_application.slice(*attributes_to_copy).merge(completed_steps: completed_steps, in_progress_steps: in_progress_steps))
     copy_qualifications
     copy_employments
     copy_references
@@ -43,7 +43,11 @@ class Jobseekers::JobApplications::QuickApply
   end
 
   def completed_steps
-    %w[personal_details professional_status qualifications employment_history references ask_for_support].select { |step| relevant_steps.include?(step.to_sym) }
+    %w[personal_details professional_status references ask_for_support].select { |step| relevant_steps.include?(step.to_sym) }
+  end
+
+  def in_progress_steps
+    %w[qualifications employment_history]
   end
 
   def copy_qualifications
@@ -56,6 +60,7 @@ class Jobseekers::JobApplications::QuickApply
         new_result.update(qualification: new_qualification)
       end
     end
+    new_job_application.qualifications_section_completed = false
   end
 
   def copy_employments
@@ -63,6 +68,7 @@ class Jobseekers::JobApplications::QuickApply
       new_employment = employment.dup
       new_employment.update(job_application: new_job_application, salary: "")
     end
+    new_job_application.employment_history_section_completed = false
   end
 
   def copy_references

--- a/app/views/jobseekers/job_applications/build/employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/build/employment_history.html.slim
@@ -76,6 +76,8 @@
         = govuk_button_link_to t(employments.job.none? ? "buttons.add_job" : "buttons.add_another_job"), new_jobseekers_job_application_employment_path(job_application), class: "govuk-button--secondary govuk-!-margin-bottom-0"
 
     = form_for form, url: wizard_path, method: :patch do |f|
+      = f.govuk_error_summary
+      = f.govuk_collection_radio_buttons :employment_history_section_completed, %w[true false], :to_s
       = f.govuk_submit job_application_build_submit_button_text do
         = govuk_link_to t("buttons.cancel_and_return_to_account"), jobseekers_job_applications_path, class: "govuk-link--no-visited-state"
         span.govuk-caption-m

--- a/app/views/jobseekers/job_applications/build/qualifications.html.slim
+++ b/app/views/jobseekers/job_applications/build/qualifications.html.slim
@@ -45,7 +45,7 @@
 
     = form_for form, url: wizard_path, method: :patch do |f|
       = f.govuk_error_summary
-
+      = f.govuk_collection_radio_buttons :qualifications_section_completed, %w[true false], :to_s
       = f.govuk_submit job_application_build_submit_button_text do
         = govuk_link_to t("buttons.cancel_and_return_to_account"), jobseekers_job_applications_path, class: "govuk-link--no-visited-state"
         span.govuk-caption-m

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -306,6 +306,10 @@ en:
               blank: Give details about any close relationships with people within the organisation
             right_to_work_in_uk:
               inclusion: Select yes if you have the right to work in the UK
+        jobseekers/job_application/employment_history_form:
+          attributes:
+            employment_history_section_completed:
+              blank: Select yes if you have completed this section
         jobseekers/job_application/equal_opportunities_form:
           attributes:
             age:
@@ -364,6 +368,10 @@ en:
               not_a_number: Enter the year your QTS was awarded
             statutory_induction_complete:
               inclusion: Select yes if you have completed your statutory induction year
+        jobseekers/job_application/qualifications_form:
+          attributes:
+            qualifications_section_completed:
+              blank: Select yes if you have completed this section
         jobseekers/job_application/review_form:
           attributes:
             confirm_data_accurate:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -380,6 +380,7 @@ en:
     status_tags:
       action_required: action required
       complete: complete
+      in_progress: in progress
       not_started: not started
       optional: optional
 

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -133,6 +133,8 @@ en:
         institution: For example, a university or college
       jobseekers_job_application_details_reference_form:
         phone_number: Please only give a phone number that your referee is happy to be contacted on.
+      jobseekers_job_application_employment_history_form:
+        employment_history_section_completed: Ensure you've added all your employment history.
       jobseekers_job_application_equal_opportunities_form:
         gender: If the options below do not reflect how you identify, please select ‘Other gender identity’.
         ethnicity: If the options below do not reflect how you identify, please select ‘Other ethnic group’.
@@ -154,6 +156,8 @@ en:
         phone_number: Enter a phone number you are happy to be contacted on, like 01632 960 001, 07700 900 982 or +44 0808 157 0192.
         previous_names: For example maiden name or name at birth, if different from the name you have now.
         teacher_reference_number: Enter the 7 numbers of your TRN, excluding any letters and symbols.
+      jobseekers_job_application_qualifications_form:
+        qualifications_section_completed: Ensure you've added all the education and qualifications you've done.
       jobseekers_job_alert_further_feedback_form:
         comment: This is optional, but the information will help us to make improvements.
         email: >-
@@ -333,6 +337,10 @@ en:
         organisation: School or other organisation
         subjects_review: Subjects and key stages taught
         subjects_html: Subjects and key stages taught (optional<span class='govuk-visually-hidden'> field</span>)</span>
+      jobseekers_job_application_employment_history_form:
+        employment_history_section_completed_options:
+          false: No, I'll come back to it later
+          true: Yes, I've completed this section
       jobseekers_job_application_details_qualifications_category_form:
         category_options:
           gcse: GCSEs
@@ -452,6 +460,10 @@ en:
           on_track: I'm on track to receive my QTS
           "yes": "Yes"
         qualified_teacher_status_year: Year QTS was awarded
+      jobseekers_job_application_qualifications_form:
+        qualifications_section_completed_options:
+          false: No, I'll come back to it later
+          true: Yes, I've completed this section
       jobseekers_job_application_review_form:
         confirm_data_accurate_options:
           "1": I confirm that the above information is accurate and complete
@@ -660,6 +672,8 @@ en:
       jobseekers_job_application_declarations_form:
         close_relationships: Do you have any family or close relationship with people within %{organisation}?
         right_to_work_in_uk: Do you have the right to work in the UK?
+      jobseekers_job_application_employment_history_form:
+        employment_history_section_completed: Have you completed this section?
       jobseekers_job_application_equal_opportunities_form:
         age: How old are you?
         disability: Do you consider yourself to have a disability as defined by the Equality Act 2010?
@@ -691,6 +705,8 @@ en:
       jobseekers_job_application_professional_status_form:
         statutory_induction_complete: Have you completed your statutory induction year?
         qualified_teacher_status: Do you have qualified teacher status (QTS)?
+      jobseekers_job_application_qualifications_form:
+        qualifications_section_completed: Have you completed this section?
       jobseekers_job_application_withdraw_form:
         withdraw_reason: Why would you like to withdraw your application?
 

--- a/spec/factories/job_applications.rb
+++ b/spec/factories/job_applications.rb
@@ -27,6 +27,12 @@ FactoryBot.define do
     qualified_teacher_status_year { "1990" }
     statutory_induction_complete { "yes" }
 
+    # Education and qualifications
+    qualifications_section_completed { true }
+
+    # Employment history
+    employment_history_section_completed { true }
+
     # Personal statement
     personal_statement { Faker::Lorem.paragraph(sentence_count: 8) }
 
@@ -52,6 +58,7 @@ FactoryBot.define do
     right_to_work_in_uk { "yes" }
 
     completed_steps { JobApplication.completed_steps.keys }
+    in_progress_steps { [] }
 
     after :create do |job_application, options|
       if options.create_details
@@ -96,6 +103,12 @@ FactoryBot.define do
     qualified_teacher_status { "" }
     qualified_teacher_status_year { "" }
     statutory_induction_complete { "" }
+
+    # Education and qualifications
+    qualifications_section_completed { nil }
+
+    # Employment history
+    employment_history_section_completed { nil }
 
     # Personal statement
     personal_statement { "" }

--- a/spec/form_models/jobseekers/job_application/employment_history_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/employment_history_form_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe Jobseekers::JobApplication::EmploymentHistoryForm, type: :model do
+  it { is_expected.to validate_presence_of(:employment_history_section_completed) }
+end

--- a/spec/form_models/jobseekers/qualifications_form_spec.rb
+++ b/spec/form_models/jobseekers/qualifications_form_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe Jobseekers::JobApplication::QualificationsForm, type: :model do
+  it { is_expected.to validate_presence_of(:qualifications_section_completed) }
+end

--- a/spec/helpers/job_applications_helper_spec.rb
+++ b/spec/helpers/job_applications_helper_spec.rb
@@ -172,4 +172,26 @@ RSpec.describe JobApplicationsHelper do
       end
     end
   end
+
+  describe "#job_application_step_in_progress?" do
+    subject { helper.job_application_step_in_progress?(job_application, step) }
+
+    let(:step) { :qualifications }
+
+    context "when step is in progress" do
+      let(:job_application) { create(:job_application, in_progress_steps: %w[qualifications]) }
+
+      it "returns true" do
+        expect(subject).to eq(true)
+      end
+    end
+
+    context "when step is completed" do
+      let(:job_application) { create(:job_application) }
+
+      it "returns false" do
+        expect(subject).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/helpers/status_tag_helper_spec.rb
+++ b/spec/helpers/status_tag_helper_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe StatusTagHelper do
     subject { helper.review_section_tag(record, steps, form_classes) }
 
     context "when it is passed a job application" do
-      let(:record) { build_stubbed(:job_application, completed_steps: %w[personal_details professional_status]) }
+      let(:record) { build_stubbed(:job_application, completed_steps: %w[personal_details professional_status], in_progress_steps: %w[qualifications]) }
       let(:form_classes) { [Jobseekers::JobApplication::PersonalDetailsForm] }
 
       context "when there is an error on the step's form object" do
@@ -31,6 +31,14 @@ RSpec.describe StatusTagHelper do
 
         it "returns 'not started' tag" do
           expect(subject).to eq(helper.govuk_tag(text: I18n.t("shared.status_tags.not_started"), colour: "grey"))
+        end
+      end
+
+      context "when the step is in progress" do
+        let(:steps) { [:qualifications] }
+
+        it "returns 'in progress' tag" do
+          expect(subject).to eq(helper.govuk_tag(text: I18n.t("shared.status_tags.in_progress"), colour: "yellow"))
         end
       end
     end

--- a/spec/services/jobseekers/job_applications/quick_apply_spec.rb
+++ b/spec/services/jobseekers/job_applications/quick_apply_spec.rb
@@ -35,9 +35,14 @@ RSpec.describe Jobseekers::JobApplications::QuickApply do
         expect(subject.slice(attributes_to_copy)).to eq(recent_job_application.slice(attributes_to_copy))
       end
 
-      it "copies completed steps" do
+      it "copies completed steps except qualifications and employment history" do
         expect(subject.completed_steps)
-          .to eq(%w[personal_details professional_status qualifications employment_history references ask_for_support])
+          .to eq(%w[personal_details professional_status references ask_for_support])
+      end
+
+      it "sets in progress steps as qualifications and employment history" do
+        expect(subject.in_progress_steps)
+          .to eq(%w[qualifications employment_history])
       end
     end
 
@@ -65,11 +70,19 @@ RSpec.describe Jobseekers::JobApplications::QuickApply do
         .to eq(recent_job_application.qualifications.map { |qualification| qualification.slice(*attributes_to_copy) })
     end
 
+    it "sets qualifications section completed to false" do
+      expect(subject.qualifications_section_completed).to eq(false)
+    end
+
     it "copies employments" do
       attributes_to_copy = %i[organisation job_title subjects current_role main_duties started_on ended_on]
 
       expect(subject.employments.map { |employment| employment.slice(*attributes_to_copy) })
         .to eq(recent_job_application.employments.map { |employment| employment.slice(*attributes_to_copy) })
+    end
+
+    it "sets employment history section completed to false" do
+      expect(subject.employment_history_section_completed).to eq(false)
     end
 
     it "copies references" do

--- a/spec/system/jobseekers_can_complete_a_job_application_spec.rb
+++ b/spec/system/jobseekers_can_complete_a_job_application_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe "Jobseekers can complete a job application" do
     click_on I18n.t("buttons.save_and_continue")
 
     expect(page).to have_content(I18n.t("jobseekers.job_applications.build.qualifications.heading"))
+    validates_step_complete
+    choose I18n.t("helpers.label.jobseekers_job_application_qualifications_form.qualifications_section_completed_options.true")
     click_on I18n.t("buttons.save_and_continue")
     expect(page).not_to have_content("There is a problem")
     click_on I18n.t("buttons.back")
@@ -35,6 +37,7 @@ RSpec.describe "Jobseekers can complete a job application" do
     click_on I18n.t("buttons.save_and_continue")
 
     expect(page).to have_content(I18n.t("jobseekers.job_applications.build.employment_history.heading"))
+    validates_step_complete
     click_on I18n.t("buttons.add_job")
     click_on I18n.t("buttons.save_employment")
     expect(page).to have_content("There is a problem")
@@ -43,6 +46,7 @@ RSpec.describe "Jobseekers can complete a job application" do
     click_on I18n.t("buttons.add_another_break")
     fill_in_break_in_employment
     click_on I18n.t("buttons.continue")
+    choose I18n.t("helpers.label.jobseekers_job_application_employment_history_form.employment_history_section_completed_options.true")
     click_on I18n.t("buttons.save_and_continue")
 
     expect(page).to have_content(I18n.t("jobseekers.job_applications.build.personal_statement.heading"))


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-4192

## Changes in this PR:

This pull request makes the "Qualifications" and "Employment history" sections of a job application mandatory. A radio button is added to each form section asking the user if they have completed the section, and they must answer before proceeding.

- If the user answers "Yes" then the relevant step is added to `completed_steps` and will show as "COMPLETED" on the review page. The user can submit the application provided all sections are completed.

- If the user answers "No" then the relevant step is added to `in_progress_steps` and will show as "IN PROGRESS" on the review page. The user cannot submit the application until marking the step as completed.

- If the user has not yet answered or visited the form section yet, the step will show as "NOT STARTED" on the review page.

- When a user has previously submitted a job application and attempts to apply for another job, `quick_apply` is used and will copy their details from the previous job application. However, both steps will be marked as "IN PROGRESS" and the user will need to confirm that those steps are completed before being able to submit their application.

## Screenshots of UI changes:

### Before

![image](https://user-images.githubusercontent.com/24639777/174118768-b5c34336-56c7-4692-b635-c11f865318cd.png)

![image](https://user-images.githubusercontent.com/24639777/174118843-cb78f81e-8389-4d9a-a45b-513ed4851a18.png)

### After
**New completion confirmation question added (same for employment history):**
![image](https://user-images.githubusercontent.com/24639777/174119021-4048a277-6f6e-4a99-b4f0-ad39495f4869.png)

**Validation message:**
![image](https://user-images.githubusercontent.com/24639777/174599028-31928442-59e8-4b2c-bde0-23afbb4cbdc5.png)

**When user has not started the steps yet (has not answered yet):**
![image](https://user-images.githubusercontent.com/24639777/174118588-ef575beb-7f0f-4f26-be42-9e83c13fe6db.png)

**When steps "in progress" i.e. user has answered "No, I'll come back to it later":**
![image](https://user-images.githubusercontent.com/24639777/174118262-742e7c8d-4979-4da0-8ad2-2c0d217a19bf.png)

**When steps "completed" i.e. user has answered "Yes, I have completed this section":**
![image](https://user-images.githubusercontent.com/24639777/174118359-d3a5fa78-6dfd-4e9c-a95d-115bfb3c687e.png)


