### PR TITLE
Update CSP for new Google Analytics domains

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -12,7 +12,8 @@ Rails.application.configure do
     policy.connect_src :self,
                        "https://api.postcodes.io",
                        "https://*.sentry.io",
-                       "https://www.google-analytics.com",
+                       "https://*.google-analytics.com",
+                       "https://*.analytics.google.com",
                        *development_env_additional_connect_src # Allow using webpack-dev-server in development
 
     policy.font_src    :self,


### PR DESCRIPTION
GA have expanded the set of domains required to be allowlisted in
`connect-src` in our Content Security Policy.
