### PR TITLE
Gem updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem "geocoder"
 gem "google-apis-drive_v3"
 gem "google-apis-indexing_v3"
 gem "google-cloud-bigquery"
-gem "govuk-components"
+gem "govuk-components", "3.0.4" # TODO: Pinned pending fixes for incompatible 3.0.6
 gem "govuk_design_system_formbuilder"
 gem "high_voltage"
 gem "httparty"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,8 +80,8 @@ GEM
     ast (2.4.2)
     attr_required (1.0.1)
     aws-eventstream (1.2.0)
-    aws-partitions (1.595.0)
-    aws-sdk-core (3.131.1)
+    aws-partitions (1.600.0)
+    aws-sdk-core (3.131.2)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)
       aws-sigv4 (~> 1.1)
@@ -186,8 +186,8 @@ GEM
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.3)
-      multipart-post (>= 1.2, < 3)
+    faraday-multipart (1.0.4)
+      multipart-post (~> 2)
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
@@ -206,9 +206,9 @@ GEM
     geocoder (1.8.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    google-apis-bigquery_v2 (0.33.0)
-      google-apis-core (>= 0.4, < 2.a)
-    google-apis-core (0.5.0)
+    google-apis-bigquery_v2 (0.34.0)
+      google-apis-core (>= 0.5, < 2.a)
+    google-apis-core (0.6.0)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.16.2, < 2.a)
       httpclient (>= 2.8.1, < 3.a)
@@ -217,10 +217,10 @@ GEM
       retriable (>= 2.0, < 4.a)
       rexml
       webrick
-    google-apis-drive_v3 (0.22.0)
-      google-apis-core (>= 0.4, < 2.a)
-    google-apis-indexing_v3 (0.7.0)
-      google-apis-core (>= 0.4, < 2.a)
+    google-apis-drive_v3 (0.24.0)
+      google-apis-core (>= 0.6, < 2.a)
+    google-apis-indexing_v3 (0.8.0)
+      google-apis-core (>= 0.5, < 2.a)
     google-cloud-bigquery (1.38.1)
       concurrent-ruby (~> 1.0)
       google-apis-bigquery_v2 (~> 0.1)
@@ -254,7 +254,7 @@ GEM
     high_voltage (3.1.2)
     html-attributes-utils (0.9.0)
       activesupport (>= 6.1.4.4)
-    http (5.0.4)
+    http (5.1.0)
       addressable (~> 2.8)
       http-cookie (~> 1.0)
       http-form_data (~> 2.2)
@@ -281,7 +281,7 @@ GEM
       activesupport (>= 4.2)
       aes_key_wrap
       bindata
-    jwt (2.3.0)
+    jwt (2.4.1)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)
@@ -331,10 +331,10 @@ GEM
       rake
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
-    minitest (5.15.0)
+    minitest (5.16.1)
     multi_json (1.15.0)
     multi_xml (0.6.0)
-    multipart-post (2.2.0)
+    multipart-post (2.2.3)
     net-imap (0.2.3)
       digest
       net-protocol
@@ -387,7 +387,7 @@ GEM
     parser (3.1.2.0)
       ast (~> 2.4.1)
     parslet (2.0.0)
-    pg (1.3.5)
+    pg (1.4.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -443,7 +443,7 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.4.2)
+    rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
     rails_semantic_logger (4.10.0)
       rack
@@ -511,10 +511,10 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.18.0)
       parser (>= 3.1.1.0)
-    rubocop-performance (1.14.1)
+    rubocop-performance (1.14.2)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
-    rubocop-rails (2.14.2)
+    rubocop-rails (2.15.0)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
@@ -547,11 +547,11 @@ GEM
       sidekiq (>= 3.0)
     shoulda-matchers (5.1.0)
       activesupport (>= 5.2.0)
-    sidekiq (6.4.2)
+    sidekiq (6.5.1)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
-    sidekiq-cron (1.4.0)
+    sidekiq-cron (1.5.1)
       fugit (~> 1)
       sidekiq (>= 4.2.1)
     signet (0.16.1)
@@ -660,7 +660,7 @@ GEM
       nokogiri (~> 1.8)
     yard (0.9.28)
       webrick (~> 1.7.0)
-    zeitwerk (2.5.4)
+    zeitwerk (2.6.0)
     zendesk_api (1.36.0)
       faraday (>= 0.9.0, < 2.0.0)
       hashie (>= 3.5.2, < 6.0.0)
@@ -706,7 +706,7 @@ DEPENDENCIES
   google-apis-drive_v3
   google-apis-indexing_v3
   google-cloud-bigquery
-  govuk-components
+  govuk-components (= 3.0.4)
   govuk_design_system_formbuilder
   high_voltage
   httparty


### PR DESCRIPTION
- Update all gems
- Pin `govuk-components` until we fix the incompatibility issue
