### PR TITLE
[TEVA-4263] Implement jobseeker account confirmation reminder

### DIFF
--- a/app/jobs/send_account_confirmation_reminder_email_job.rb
+++ b/app/jobs/send_account_confirmation_reminder_email_job.rb
@@ -1,0 +1,12 @@
+class SendAccountConfirmationReminderEmailJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    jobseekers.each(&:resend_confirmation_instructions)
+  end
+
+  def jobseekers
+    Jobseeker.where(confirmation_sent_at: 5.days.ago.beginning_of_day..5.days.ago.end_of_day,
+                    confirmed_at: nil)
+  end
+end

--- a/app/mailers/jobseekers/devise_emails.rb
+++ b/app/mailers/jobseekers/devise_emails.rb
@@ -2,7 +2,11 @@ module Jobseekers::DeviseEmails
   def confirmation_instructions(record, token, _opts = {})
     to = subject = nil
 
-    if record.pending_reconfirmation?
+    if !record.confirmed? && record.confirmation_sent_at < 4.days.ago
+      to = record.unconfirmed_email
+      subject = t(".reminder.subject")
+      @confirmation_type = ".reminder"
+    elsif record.pending_reconfirmation?
       to = record.unconfirmed_email
       subject = t(".reconfirmation.subject")
       @confirmation_type = ".reconfirmation"

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -31,6 +31,11 @@ en:
           intro: You have requested to change your email address to this address
           link: Confirm new email address
           subject: Confirm your new email for Teaching Vacancies
+        reminder:
+          heading: This is a reminder to verify your account with Teaching Vacancies
+          intro: You have requested to create an account with this email address.
+          link: Verify email and create account
+          subject: "Reminder: verify your account with teaching vacancies"
       email_changed:
         heading: The email for your Teaching Vacancies account has been updated
         intro: Your email has been successfully updated

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -83,6 +83,11 @@ send_inactive_account_email:
   class: 'SendInactiveAccountEmailJob'
   queue: low
 
+send_account_confirmation_reminder_email:
+  cron: '0 9 * * *'
+  class: 'SendAccountConfirmationReminderEmailJob'
+  queue: default
+
 send_job_application_data_expiry_notification:
   cron: '0 6 * * *'
   class: 'SendJobApplicationDataExpiryNotificationJob'

--- a/spec/mailers/jobseekers/account_mailer_spec.rb
+++ b/spec/mailers/jobseekers/account_mailer_spec.rb
@@ -60,6 +60,21 @@ RSpec.describe Jobseekers::AccountMailer do
         expect { mail.deliver_now }.to have_triggered_event(:jobseeker_confirmation_instructions).with_data(expected_data)
       end
     end
+
+    context "when the jobseeker is being reminded to confirm" do
+      let(:jobseeker) { create(:jobseeker, email: "test@example.net", confirmation_token: token, unconfirmed_email: "test@example.net", confirmed_at: nil, confirmation_sent_at: 5.days.ago) }
+
+      it "sends a `jobseeker_confirmation_instructions` email" do
+        expect(mail.subject).to eq(I18n.t("jobseekers.account_mailer.confirmation_instructions.reminder.subject"))
+        expect(mail.to).to eq(["test@example.net"])
+        expect(mail.body.encoded).to include(I18n.t("jobseekers.account_mailer.confirmation_instructions.reminder.heading"))
+                                 .and include(jobseeker_confirmation_path(confirmation_token: token))
+      end
+
+      it "triggers a `jobseeker_confirmation_instructions` email event" do
+        expect { mail.deliver_now }.to have_triggered_event(:jobseeker_confirmation_instructions).with_data(expected_data)
+      end
+    end
   end
 
   describe "#email_changed" do

--- a/spec/mailers/previews/jobseekers/account_preview.rb
+++ b/spec/mailers/previews/jobseekers/account_preview.rb
@@ -8,6 +8,16 @@ class Jobseekers::AccountPreview < ActionMailer::Preview
     Jobseekers::AccountMailer.confirmation_instructions(Jobseeker.first, "fake_token")
   end
 
+  def confirmation_instructions_reminder
+    jobseeker = FactoryBot.build(:jobseeker, confirmed_at: nil, confirmation_sent_at: 5.days.ago)
+    Jobseekers::AccountMailer.confirmation_instructions(jobseeker, "fake_token")
+  end
+
+  def reconfirmation_instructions
+    jobseeker = FactoryBot.build(:jobseeker, email: "oldemail@example.com", unconfirmed_email: "newemail@example.com")
+    Jobseekers::AccountMailer.confirmation_instructions(jobseeker, "fake_token")
+  end
+
   def email_changed
     Jobseekers::AccountMailer.email_changed(Jobseeker.first)
   end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-4263

## Changes in this PR:

This PR implements a daily task which sends a reminder email with confirmation instructions to jobseekers that have not yet confirmed their email address.

## Screenshots of UI changes:

<img width="782" alt="image" src="https://user-images.githubusercontent.com/24639777/174991625-72b080f9-58ec-43be-baba-eaeb448068e6.png">
