### PR TITLE
Remove explicit mail gem dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,13 +71,6 @@ gem "wicked"
 gem "xml-sitemap"
 gem "zendesk_api"
 
-# TODO: These are required by Ruby 3.1, but not automatically pulled in by Rails right now
-#  c.f. https://github.com/rails/rails/commit/5dd292f5511fedd91833dc8482baf696cb821af6
-#  This can be removed once we have a version of Rails that includes them in its dependencies.
-gem "net-imap", require: false
-gem "net-pop", require: false
-gem "net-smtp", require: false
-
 group :development do
   gem "amazing_print" # optional dependency of `rails_semantic_logger`
   gem "aws-sdk-ssm"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -726,9 +726,6 @@ DEPENDENCIES
   lockbox
   mail-notify
   mimemagic
-  net-imap
-  net-pop
-  net-smtp
   nokogiri
   noticed
   omniauth (< 2)


### PR DESCRIPTION
These are no longer needed as of Rails 7.