### PR TITLE
Gem cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem "addressable"
 gem "array_enum"
 gem "aws-sdk-s3", require: false
 gem "breasal"
-gem "browser"
 gem "devise"
 gem "factory_bot_rails"
 gem "faker"
@@ -53,7 +52,6 @@ gem "pg"
 gem "puma"
 gem "rack-attack"
 gem "rack-cors"
-gem "rails-html-sanitizer"
 gem "rails_semantic_logger"
 gem "recaptcha"
 gem "redis"
@@ -76,7 +74,6 @@ gem "zendesk_api"
 group :development do
   gem "amazing_print" # optional dependency of `rails_semantic_logger`
   gem "aws-sdk-ssm"
-  gem "launchy"
   gem "listen"
   gem "solargraph", require: false
   gem "spring"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,6 @@ GEM
     bindex (0.8.1)
     brakeman (5.2.3)
     breasal (0.0.1)
-    browser (5.3.1)
     builder (3.2.4)
     byebug (11.1.3)
     capybara (3.37.1)
@@ -312,8 +311,6 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    launchy (2.5.0)
-      addressable (~> 2.7)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -704,7 +701,6 @@ DEPENDENCIES
   axe-core-rspec
   brakeman
   breasal
-  browser
   byebug
   capybara
   climate_control
@@ -726,7 +722,6 @@ DEPENDENCIES
   jbuilder
   kaminari
   kramdown
-  launchy
   listen
   lockbox
   mail-notify
@@ -749,7 +744,6 @@ DEPENDENCIES
   rack-mini-profiler
   rack_session_access
   rails-controller-testing
-  rails-html-sanitizer
   rails_semantic_logger
   railties (~> 7.0.3)
   recaptcha

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -45,9 +45,6 @@ Dir[Rails.root.join("spec/page_objects/**/*.rb")].each { |f| require f }
 
 ActiveRecord::Migration.maintain_test_schema!
 
-user_agents ||= YAML.load_file(Browser.root.join("test/ua.yml")).freeze
-USER_AGENTS = user_agents
-
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
 


### PR DESCRIPTION
- Remove `rails-html-sanitizer` gem (unused)
- Remove `launchy` gem (unused and unhelpful in devcontainer)
- Remove `browser` gem and unused UA code in tests