### PR TITLE
Fix basic legacy browser support

### DIFF
--- a/app/assets/javascript/application.js
+++ b/app/assets/javascript/application.js
@@ -3,9 +3,8 @@ import * as Sentry from '@sentry/browser';
 import 'core-js/modules/es.weak-map';
 import 'core-js/modules/es.weak-set';
 import '@stimulus/polyfills';
-import { initAll } from 'govuk-frontend';
+
 import { Application } from '@hotwired/stimulus';
-import Rails from 'rails-ujs';
 
 // view components
 import FiltersController from './components/filters_component/filters_component';
@@ -52,6 +51,3 @@ application.register('show-hidden-content', ShowHiddenContentController);
 application.register('tracked-link', TrackedLinkController);
 application.register('upload-documents', UploadDocumentsController);
 application.register('utils', UtilsController);
-
-Rails.start();
-initAll();

--- a/app/assets/javascript/basic.js
+++ b/app/assets/javascript/basic.js
@@ -1,0 +1,19 @@
+// Entrypoint for "basic" Javascript
+
+// This will be transpiled to ES5 and provides some minimal functionality for very outdated legacy
+// browsers still supported by GOV.UK Frontend for now so we don't *completely* leave them hanging.
+// This is separate from the more advanced javascript in the regular entrypoint, which is transpiled
+// only to ES6 and will thus refuse to run on IE11 or other unsupported browsers.
+
+// Note that this gets compiled in a NPM `pre` script, so any changes you make in here will not be
+// picked up by the `--watch` option as part of the dev workflow (which shouldn't be an issue as
+// this is unlikely to change)
+
+// TODO: This needs to go, and the contents moved into the regular `application.js`, ideally no
+//       later than when GOV.UK Frontend stops supporting IE11 (planned for v5.x)
+
+import Rails from 'rails-ujs';
+import { initAll } from 'govuk-frontend';
+
+Rails.start();
+initAll();

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -24,4 +24,5 @@ html.govuk-template.app-html-class lang="en"
       = content_for :after_main
     = render "layouts/footer"
     = render "layouts/cookies_banner"
+    = javascript_include_tag "basic", defer: true
     = javascript_include_tag "application", defer: true

--- a/app/views/layouts/application_supportal.html.slim
+++ b/app/views/layouts/application_supportal.html.slim
@@ -21,4 +21,5 @@ html.govuk-template.app-html-class lang="en"
         = yield
       = content_for :after_main
     = govuk_footer
+    = javascript_include_tag "basic", defer: true
     = javascript_include_tag "application", defer: true

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "yaml": "^2.1.1"
   },
   "scripts": {
-    "build": "esbuild app/assets/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds --public-path=assets --target=es6",
+    "prebuild": "esbuild app/assets/javascript/basic.js --bundle --outdir=app/assets/builds --public-path=assets --target=es5,ie11",
+    "build": "esbuild app/assets/javascript/application.js --bundle --sourcemap --outdir=app/assets/builds --public-path=assets --target=es6",
     "build:css": "sass ./app/assets/stylesheets/application.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules --quiet-deps",
     "test": "concurrently \"yarn run js:test\" \"yarn run js:lint\" \"yarn run sass:lint\"",
     "js:test": "jest",


### PR DESCRIPTION
IE11 support for our service has been hit-and-miss for a while since it
is no longer officially supported and about to be completely eradicated
by Microsoft themselves. This tries to add some basic support back in to
ensure users of some legacy browsers get at least a slightly more
tolerable experience.

- Split out "basic" Javascript (GOV.UK Frontend and Rails UJS) that
  should still work okay-ish on some legacy browsers
- Add a `prebuild` script to compile this basic Javascript with an ES5
  target as part of the build flow