### PR TITLE
Upgrade to Node.js 18

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,7 +4,7 @@ FROM ruby:${RUBY_VERSION}
 ARG USERNAME=teaching-vacancies
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
-ARG NODEJS_MAJOR_VERSION=16
+ARG NODEJS_MAJOR_VERSION=18
 
 # Set up NodeSource repository for newer Node.JS
 RUN apt update -yq \

--- a/.github/actions/prepare-app-env/action.yml
+++ b/.github/actions/prepare-app-env/action.yml
@@ -12,7 +12,7 @@ inputs:
   node-version:
     description: The version of Node.js to install
     required: false
-    default: "16.x"
+    default: "18.x"
 
 runs:
   using: composite

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 ruby 3.1.2
-nodejs 16.15.1
+nodejs 18.4.0
 yarn 1.22.17


### PR DESCRIPTION
Now that we no longer use Webpack, we can move to Node.js 18.