### PR TITLE
Make `esbuild` use Babel for transpilation

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -1,0 +1,31 @@
+import esbuild from 'esbuild';
+import babel from 'esbuild-plugin-babel';
+
+const watch = process.argv[process.argv.length - 1] == '--watch';
+
+// Custom `esbuild` configuration to enable Babel plugin for IE11-compatible transpilation
+// TODO: When we decide we are happy to target ES6 and don't need Babel anymore, this file can be
+//       removed and the `build` task in `package.json` can be replaced with a simple command
+//       line invocation of `esbuild`, e.g.:
+//
+//          esbuild app/assets/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds \
+//          --public-path=assets --target=es6
+
+esbuild
+    .build({
+        entryPoints: ['app/assets/javascript/application.js'],
+        bundle: true,
+        outdir: 'app/assets/builds',
+        publicPath: 'assets',
+        watch: watch,
+        plugins: [
+          babel({
+            config: {
+              presets: ['@babel/preset-env'],
+              targets: '> 0.25%, not dead, IE 11'
+            }
+          })
+        ],
+        target: ['ie11']
+    })
+    .catch(() => process.exit(1));

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "teaching-vacancies",
+  "type": "module",
   "private": true,
   "engine": {
     "node": ">=16.0.0"
@@ -30,6 +31,7 @@
     "concurrently": "^7.2.2",
     "dotenv": "^16.0.1",
     "esbuild": "^0.14.47",
+    "esbuild-plugin-babel": "^0.2.3",
     "eslint": "^8.18.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.26.0",
@@ -44,7 +46,7 @@
     "yaml": "^2.1.1"
   },
   "scripts": {
-    "build": "esbuild app/assets/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds --public-path=assets --target=es6",
+    "build": "node esbuild.config.js",
     "build:css": "sass ./app/assets/stylesheets/application.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules --quiet-deps",
     "test": "concurrently \"yarn run js:test\" \"yarn run js:lint\" \"yarn run sass:lint\"",
     "js:test": "jest",
@@ -58,7 +60,9 @@
     "postvisual:test:approve": "node backstop/lib/clean.js"
   },
   "babel": {
-    "presets": ["@babel/preset-env"]
+    "presets": [
+      "@babel/preset-env"
+    ]
   },
   "jest": {
     "testMatch": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2489,6 +2489,11 @@ esbuild-openbsd-64@0.14.47:
   resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.47.tgz#309af806db561aa886c445344d1aacab850dbdc5"
   integrity sha512-QpgN8ofL7B9z8g5zZqJE+eFvD1LehRlxr25PBkjyyasakm4599iroUpaj96rdqRlO2ShuyqwJdr+oNqWwTUmQw==
 
+esbuild-plugin-babel@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/esbuild-plugin-babel/-/esbuild-plugin-babel-0.2.3.tgz#e6bce2ad9b962bf725700b6d0c803eed21b9fff6"
+  integrity sha512-hGLL31n+GvBhkHUpPCt1sU4ynzOH7I1IUkKhera66jigi4mHFPL6dfJo44L6/1rfcZudXx+wGdf9VOifzDPqYQ==
+
 esbuild-sunos-64@0.14.47:
   version "0.14.47"
   resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.47.tgz#3f19612dcdb89ba6c65283a7ff6e16f8afbf8aaa"


### PR DESCRIPTION
We still want to provide functional (but not necessarily 100% compliant)
support for IE11 for now, so need to add Babel back in to our Javascript
pipeline as `esbuild` is only able to transpile down to ES6 (which isn't
fully supported in IE11).

This doesn't add much code for now as we still use Babel for Jest anyway
which doesn't support ESM properly, so all we need to do is hook it up
and configure it.

- Add `esbuild-plugin-babel`
- Add custom `esbuild` configuration including Babel plugin and
  configure with IE11 target