### PR TITLE
Remove all remaining legacy asset configuration

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       - ..:/workspace:cached
       - bundle:/usr/local/bundle
       - node_modules:/workspace/node_modules
-      - packs:/workspace/public/packs
       - tmp:/workspace/tmp
     working_dir: /workspace
     command: sleep infinity
@@ -66,7 +65,5 @@ volumes:
   # Caches for Bundler/NPM/Yarn-installed dependencies to persist across rebuilds and install faster
   bundle:
   node_modules:
-  # Tempfile and packs directories are IO-heavy and we don't need to have their contents
-  # replicated on host
+  # Tempfile directory is IO-heavy and we don't need to have its contents replicated on host
   tmp:
-  packs:

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,6 +34,5 @@
         "no-unused-expressions": ["error", { "allowTernary": true }],
         "no-param-reassign": [2, { "props": false }]
     },
-    "ignorePatterns": ["app/assets/javascript/packs/*.js"],
     "root": true
 }

--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,6 @@
 
 /node_modules
 /public/assets
-/public/packs
-/public/packs-test
 /yarn-error.log
 /vendor/cache
 yarn-debug.log*

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,7 +45,7 @@ Rails.application.configure do
 
   config.cache_store = :redis_cache_store, { url: config.redis_cache_url, pool_size: ENV.fetch("RAILS_MAX_THREADS", 5) }
 
-  # This will affect assets in /public, /packs e.g. Webpack assets to be cached in Cloudfront
+  # This will affect assets in /public to be cached in Cloudfront
   config.public_file_server.headers = { "Cache-Control" => "public, max-age=#{1.year.seconds}" }
 
   # Use a real queuing backend for Active Job

--- a/terraform/app/modules/cloudfront/main.tf
+++ b/terraform/app/modules/cloudfront/main.tf
@@ -64,18 +64,6 @@ resource "aws_cloudfront_distribution" "default" {
   ordered_cache_behavior {
     allowed_methods        = ["GET", "HEAD"]
     cached_methods         = ["GET", "HEAD"]
-    path_pattern           = "/packs/*"
-    target_origin_id       = "${var.service_name}-${var.environment}-default-origin"
-    viewer_protocol_policy = "redirect-to-https"
-    cache_policy_id        = data.aws_cloudfront_cache_policy.managed-caching-optimized.id
-    # Packs are pre-compressed by Rails (and will be removed soon)
-    compress = false
-  }
-
-  ordered_cache_behavior {
-
-    allowed_methods        = ["GET", "HEAD"]
-    cached_methods         = ["GET", "HEAD"]
     path_pattern           = "/attachments/*"
     target_origin_id       = "${var.service_name}-${var.environment}-default-origin"
     viewer_protocol_policy = "redirect-to-https"


### PR DESCRIPTION
- Remove Webpack build folder caching from devcontainer
- Remove Cloudfront caching configuration for `/packs` folder
- Remove assorted pack-related configuration