### PR TITLE
[TEVA-4211] Remove flash notice from check your email page

### DIFF
--- a/app/controllers/jobseekers/registrations_controller.rb
+++ b/app/controllers/jobseekers/registrations_controller.rb
@@ -17,6 +17,7 @@ class Jobseekers::RegistrationsController < Devise::RegistrationsController
   end
 
   def check_your_email
+    flash.delete(:notice)
     @resource = Jobseeker.find(session[:jobseeker_id])
   end
 

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -32,7 +32,6 @@ en:
       signed_up: Welcome! You have signed up successfully.
       signed_up_but_inactive: You have signed up successfully. However, we could not sign you in because your account is not yet activated.
       signed_up_but_locked: You have signed up successfully. However, we could not sign you in because your account is locked.
-      signed_up_but_unconfirmed: A message with a confirmation link has been sent to your email address. Please follow the link to activate your account.
       update_needs_confirmation: You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address.
       updated: Your account has been updated successfully.
       updated_but_not_signed_in: Your account has been updated successfully, but since your password was changed, you need to sign in again


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-4211

## Changes in this PR:

Removes the "check your email" flash notification for jobseeker registrations.

## Screenshots of UI changes:

### Before
![image](https://user-images.githubusercontent.com/24639777/176705152-66f04068-c3f6-4b15-bbc4-1ecc00a2c801.png)

### After
![image](https://user-images.githubusercontent.com/24639777/176706419-0cc2c643-a4f3-4204-a676-6d5260b1f454.png)

