### PR TITLE
Upgrade Omniauth and related gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,8 +44,9 @@ gem "mail-notify"
 gem "mimemagic"
 gem "nokogiri"
 gem "noticed"
-gem "omniauth", "< 2" # TODO: Pinned pending fixes
-gem "omniauth_openid_connect", "< 0.4" # TODO: Pinned pending fixes
+gem "omniauth"
+gem "omniauth_openid_connect"
+gem "omniauth-rails_csrf_protection", "~> 1.0"
 gem "paper_trail"
 gem "paper_trail-globalid"
 gem "parslet"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -373,12 +373,16 @@ GEM
       rails (>= 5.2.0)
     notifications-ruby-client (5.3.0)
       jwt (>= 1.5, < 3)
-    omniauth (1.9.1)
+    omniauth (2.1.0)
       hashie (>= 3.4.6)
-      rack (>= 1.6.2, < 3)
-    omniauth_openid_connect (0.3.5)
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-rails_csrf_protection (1.0.1)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
+    omniauth_openid_connect (0.4.0)
       addressable (~> 2.5)
-      omniauth (~> 1.9)
+      omniauth (>= 1.9, < 3)
       openid_connect (~> 1.1)
     openid_connect (1.3.0)
       activemodel
@@ -434,6 +438,8 @@ GEM
       httpclient
       json-jwt (>= 1.11.0)
       rack (>= 2.1.0)
+    rack-protection (2.2.0)
+      rack
     rack-test (2.0.2)
       rack (>= 1.3)
     rack_session_access (0.2.0)
@@ -727,8 +733,9 @@ DEPENDENCIES
   mimemagic
   nokogiri
   noticed
-  omniauth (< 2)
-  omniauth_openid_connect (< 0.4)
+  omniauth
+  omniauth-rails_csrf_protection (~> 1.0)
+  omniauth_openid_connect
   paper_trail
   paper_trail-globalid
   parslet

--- a/app/views/pages/dsi-account-request.html.slim
+++ b/app/views/pages/dsi-account-request.html.slim
@@ -24,7 +24,7 @@
     h3.govuk-heading-m If you already have a DfE Sign-in account
 
     p.govuk-body
-      | #{govuk_link_to("Sign in", auth_dfe_path)} to your account, then click 'Request access to a service'. Choose Teaching Vacancies from the
+      | #{govuk_link_to("Sign in", auth_dfe_path, method: :post)} to your account, then click 'Request access to a service'. Choose Teaching Vacancies from the
       |  list.
 
     p.govuk-body

--- a/app/views/publishers/login_keys/new.html.slim
+++ b/app/views/publishers/login_keys/new.html.slim
@@ -15,5 +15,5 @@
 
   .govuk-grid-column-one-third
     h2.govuk-heading-m = t("publishers.sessions.new.no_account.heading")
-    p.govuk-body = t("publishers.sessions.new.no_account.content_html", link: govuk_link_to(t("publishers.sessions.new.no_account.login_link_text"), auth_dfe_path))
+    p.govuk-body = t("publishers.sessions.new.no_account.content_html", link: govuk_link_to(t("publishers.sessions.new.no_account.login_link_text"), auth_dfe_path, method: :post))
     p.govuk-body = t("publishers.sessions.new.no_account.account_request_html", link: govuk_link_to(t("publishers.sessions.new.no_account.account_request_link_text"), page_path("dsi-account-request")))

--- a/app/views/publishers/sessions/new.html.slim
+++ b/app/views/publishers/sessions/new.html.slim
@@ -13,6 +13,6 @@
   .govuk-grid-column-one-third
     h2.govuk-heading-m = t(".no_account.heading")
 
-    p.govuk-body = t(".no_account.content_html", link: govuk_link_to(t(".no_account.login_link_text"), auth_dfe_path))
+    p.govuk-body = t(".no_account.content_html", link: govuk_link_to(t(".no_account.login_link_text"), auth_dfe_path, method: :post))
 
     p.govuk-body = t(".no_account.account_request_html", link: govuk_link_to(t(".no_account.account_request_link_text"), page_path("dsi-account-request")))


### PR DESCRIPTION
## Changes in this PR:

This PR adds the `omniauth-rails_csrf_protection` gem which allows us to upgrade to the latest version of `omniauth`.

From the [`omniauth-rails_csrf_protection` readme:](https://github.com/cookpad/omniauth-rails_csrf_protection#readme)

> This gem does a few things to your application:
> 
> - Disable access to the OAuth request phase using HTTP GET method.
> - Insert a Rails CSRF token verifier at the before request phase.
> - These actions mitigate you from the attack vector described in [CVE-2015-9284](https://nvd.nist.gov/vuln/detail/CVE-2015-9284).

Our main hiring staff login link uses `govuk_button_to` which wraps the link in a form, and so uses POST with an authenticity token to initiate the OAuth request phase. There are a few other login links using `govuk_link_to` to which `method: :post` has been added as an argument.
