### PR TITLE
Update GOV.UK Components and fix compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem "geocoder"
 gem "google-apis-drive_v3"
 gem "google-apis-indexing_v3"
 gem "google-cloud-bigquery"
-gem "govuk-components", "3.0.4" # TODO: Pinned pending fixes for incompatible 3.0.6
+gem "govuk-components"
 gem "govuk_design_system_formbuilder"
 gem "high_voltage"
 gem "httparty"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,10 +255,13 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
-    govuk-components (3.0.4)
+    govuk-components (3.1.2)
+      actionpack (>= 6.1)
       activemodel (>= 6.1)
+      html-attributes-utils (~> 0.9, >= 0.9.2)
+      pagy (~> 5.10.1)
       railties (>= 6.1)
-      view_component (~> 2.49.1)
+      view_component (~> 2.56.2)
     govuk_design_system_formbuilder (3.1.0)
       actionview (>= 6.1)
       activemodel (>= 6.1)
@@ -392,6 +395,8 @@ GEM
       webfinger (>= 1.0.1)
     orm_adapter (0.5.0)
     os (1.1.4)
+    pagy (5.10.1)
+      activesupport
     paper_trail (12.3.0)
       activerecord (>= 5.2)
       request_store (~> 1.1)
@@ -632,7 +637,7 @@ GEM
       activemodel (>= 3.0.0)
       public_suffix
     vcr (6.1.0)
-    view_component (2.49.1)
+    view_component (2.56.2)
       activesupport (>= 5.0.0, < 8.0)
       method_source (~> 1.0)
     virtus (2.0.0)
@@ -712,7 +717,7 @@ DEPENDENCIES
   google-apis-drive_v3
   google-apis-indexing_v3
   google-cloud-bigquery
-  govuk-components (= 3.0.4)
+  govuk-components
   govuk_design_system_formbuilder
   high_voltage
   httparty

--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -1,5 +1,24 @@
 class ApplicationComponent < GovukComponent::Base
+  attr_reader :classes
+
   def initialize(classes: [], html_attributes: {})
+    # TODO: Workaround for GOV.UK Components changes - this doesn't exist anymore but we still rely
+    #  on it.
+    @classes = Array(classes)
+
     super(classes: classes, html_attributes: html_attributes)
+  end
+
+  private
+
+  # TODO: Workaround for GOV.UK Components changes
+  #  GOV.UK Components migrated from `default_classes` to `default_attributes`, this is a temporary
+  #  fix until we decide whether to follow their new internal API or decouple ourselves from it.
+  def default_attributes
+    { class: default_classes }
+  end
+
+  def default_classes
+    []
   end
 end

--- a/app/components/banner_button_component.rb
+++ b/app/components/banner_button_component.rb
@@ -4,34 +4,34 @@ class BannerButtonComponent < ApplicationComponent
   ICONS = %w[alert-white alert-blue apply check cross document green-tick info notice save saved search start success warning].freeze
 
   def initialize(text:, href:, method: :get, params: nil, icon: nil, classes: [], html_attributes: {})
-    super(classes: classes, html_attributes: html_attributes.merge(default_html_attributes))
-
     @text = text
     @href = href
     @method = method
     @params = params
     @icon = icon
+
+    super(classes: classes, html_attributes: html_attributes.merge(default_html_attributes))
   end
 
   def call
-    button_to text, href, method: method, params: params, class: classes.append(icon_class), **html_attributes
+    button_to text, href, method: method, params: params, **html_attributes
   end
 
   private
 
   def default_classes
-    %w[banner-button-component__button]
+    %w[banner-button-component__button] + icon_classes.compact
   end
 
   def default_html_attributes
     { form_class: "banner-button-component" }
   end
 
-  def icon_class
-    return nil if icon.blank?
+  def icon_classes
+    return [] if icon.blank?
 
     raise "invalid icon #{icon}, supported icons are #{ICONS.to_sentence}" unless icon.in?(ICONS)
 
-    "icon icon--left icon--#{icon}"
+    ["icon", "icon--left", "icon--#{icon}"]
   end
 end

--- a/app/components/card_component/card_component.html.slim
+++ b/app/components/card_component/card_component.html.slim
@@ -1,4 +1,4 @@
-= tag.div(class: classes, **html_attributes) do
+= tag.div(**html_attributes) do
   .card-component__content
     .card-component__header
       == header

--- a/app/components/cookies_banner_component/cookies_banner_component.html.slim
+++ b/app/components/cookies_banner_component/cookies_banner_component.html.slim
@@ -1,4 +1,4 @@
-= tag.div(class: classes, **html_attributes) do
+= tag.div(**html_attributes) do
   = govuk_cookie_banner do |cookie_banner|
     - cookie_banner.message(heading_text: t("cookies_preferences.banner.heading"), text: t("cookies_preferences.banner.body").join(" ")) do |message|
       - message.action { govuk_button_to t("cookies_preferences.banner.buttons.accept"), create_path, id: "cookie-consent" }

--- a/app/components/dashboard_component/dashboard_component.html.slim
+++ b/app/components/dashboard_component/dashboard_component.html.slim
@@ -1,4 +1,4 @@
-= tag.div(class: classes, **html_attributes) do
+= tag.div(**html_attributes) do
   .govuk-grid-row
     .govuk-grid-column-three-quarters
       .help-guide--mobile.help-guide--border-bottom

--- a/app/components/detail_component/detail_component.html.slim
+++ b/app/components/detail_component/detail_component.html.slim
@@ -1,4 +1,4 @@
-= tag.div(class: classes, **html_attributes) do
+= tag.div(**html_attributes) do
   - if title
     .detail-component__title
       h3.govuk-heading-s = title

--- a/app/components/empty_section_component/empty_section_component.html.slim
+++ b/app/components/empty_section_component/empty_section_component.html.slim
@@ -1,4 +1,4 @@
-= tag.div(class: classes, **html_attributes) do
+= tag.div(**html_attributes) do
   - if title
     h3.govuk-heading-m = title
 

--- a/app/components/filters_component/filters_component.html.slim
+++ b/app/components/filters_component/filters_component.html.slim
@@ -1,4 +1,4 @@
-= tag.div(class: classes, **html_attributes) do
+= tag.div(**html_attributes) do
 
   .filters-component__heading
     - if options[:heading_text]

--- a/app/components/landing_page_link_group_component/landing_page_link_group_component.html.slim
+++ b/app/components/landing_page_link_group_component/landing_page_link_group_component.html.slim
@@ -1,4 +1,4 @@
-= tag.div(class: classes, **html_attributes)
+= tag.div(**html_attributes)
   - if @title
     h3.govuk-heading-s = @title
   - elsif @subgroup

--- a/app/components/map_component/map_component.html.slim
+++ b/app/components/map_component/map_component.html.slim
@@ -1,4 +1,4 @@
-= tag.div(class: classes, **html_attributes.merge(data: { controller: "map map-sidebar", action: "map-sidebar:closed->map#focusMarker map-sidebar:opened->map#focusMarker map:sidebar:update->map-sidebar#update map:sidebar:focus->map-sidebar#focus map:interaction->map-sidebar#blur map:interaction->map#blurMarker", point: @point, polygons: @polygon, radius: radius })) do
+= tag.div(**html_attributes.merge(data: { controller: "map map-sidebar", action: "map-sidebar:closed->map#focusMarker map-sidebar:opened->map#focusMarker map:sidebar:update->map-sidebar#update map:sidebar:focus->map-sidebar#focus map:interaction->map-sidebar#blur map:interaction->map#blurMarker", point: @point, polygons: @polygon, radius: radius })) do
 
   .markers data-map-target="markers" data-marker-tracking=@marker[:tracking].to_json
     - @markers.each do |marker|

--- a/app/components/navigation_list_component/navigation_list_component.html.slim
+++ b/app/components/navigation_list_component/navigation_list_component.html.slim
@@ -1,4 +1,4 @@
-= tag.div(class: classes, **html_attributes) do
+= tag.div(**html_attributes) do
   - if title
     h2.govuk-heading-m = title
 

--- a/app/components/notification_component/notification_component.html.slim
+++ b/app/components/notification_component/notification_component.html.slim
@@ -1,4 +1,4 @@
-= tag.div(class: classes, **html_attributes) do
+= tag.div(**html_attributes) do
   .notification-component__content
     - unless notification.read?
       .notification-component__tag

--- a/app/components/review_component/review_component.html.slim
+++ b/app/components/review_component/review_component.html.slim
@@ -1,4 +1,4 @@
-= tag.div(class: classes, **html_attributes)
+= tag.div(**html_attributes)
   = header
 
   .govuk-grid-row

--- a/app/components/review_component/section/heading/heading.html.slim
+++ b/app/components/review_component/section/heading/heading.html.slim
@@ -1,4 +1,4 @@
-= tag.div(class: classes, **html_attributes)
+= tag.div(**html_attributes)
   .review-component__section__heading__title
     h3.govuk-heading-m = title
     = edit_link if allow_edit?

--- a/app/components/review_component/section/section.html.slim
+++ b/app/components/review_component/section/section.html.slim
@@ -2,6 +2,6 @@ li
   - field_div_sets.each do |field_div_set|
     = field_div_set
 
-  = tag.div(class: classes, id: id, **html_attributes) do
+  = tag.div(id: id, **html_attributes) do
     = heading
     .review-component__section__body = content

--- a/app/components/review_component/sidebar/sidebar.html.slim
+++ b/app/components/review_component/sidebar/sidebar.html.slim
@@ -1,2 +1,2 @@
-= tag.div(class: classes, **html_attributes) do
+= tag.div(**html_attributes) do
   = content

--- a/app/components/searchable_collection_component/searchable_collection_component.html.slim
+++ b/app/components/searchable_collection_component/searchable_collection_component.html.slim
@@ -1,4 +1,4 @@
-= tag.div(class: classes, **html_attributes.merge(data: { controller: "searchable-collection" })) do
+= tag.div(**html_attributes.merge(data: { controller: "searchable-collection" })) do
   div class="#{border_class} #{scrollable_class}"
     - if searchable?
       .searchable-collection-component__search

--- a/app/components/sort_component/sort_component.html.slim
+++ b/app/components/sort_component/sort_component.html.slim
@@ -1,4 +1,4 @@
-= tag.div(class: classes, **html_attributes) do
+= tag.div(**html_attributes) do
   - if sort.count > 4
     = form_for sort_form, as: "", url: path.call(url_params), method: :get, data: { controller: "form", "hide-submit": true } do |f|
       = f.govuk_collection_select :sort_by,

--- a/app/components/steps_component/steps_component.html.slim
+++ b/app/components/steps_component/steps_component.html.slim
@@ -1,4 +1,4 @@
-= tag.div(class: classes, **html_attributes) do
+= tag.div(**html_attributes) do
   - if title
     h2.govuk-heading-s class="govuk-!-margin-top-4 govuk-!-margin-bottom-2"
       = title

--- a/app/components/supporting_document_component/supporting_document_component.html.slim
+++ b/app/components/supporting_document_component/supporting_document_component.html.slim
@@ -1,2 +1,2 @@
-= tag.div(class: classes, **html_attributes) do
+= tag.div(**html_attributes) do
   = open_in_new_tab_link_to "#{supporting_document.filename} - #{document_size}", job_document_path(supporting_document.record, supporting_document), class: "supporting-document-component__link"

--- a/app/components/tabs_component/tabs_component.html.slim
+++ b/app/components/tabs_component/tabs_component.html.slim
@@ -1,4 +1,4 @@
-= tag.div(class: classes, **html_attributes) do
+= tag.div(**html_attributes) do
   ul.tabs-component-navigation__list
     - navigation_items.each do |item|
       = item

--- a/app/components/timeline_component/timeline_component.html.slim
+++ b/app/components/timeline_component/timeline_component.html.slim
@@ -1,4 +1,4 @@
-= tag.div(class: classes, **html_attributes) do
+= tag.div(**html_attributes) do
   - if heading.present?
     = heading
   - if items.present?

--- a/app/components/validatable_summary_list_component/row_component.html.slim
+++ b/app/components/validatable_summary_list_component/row_component.html.slim
@@ -1,4 +1,4 @@
-= tag.div(class: classes, **html_attributes) do
+= tag.div(**html_attributes) do
   = key text: label
   - if @errors.present?
     = value do

--- a/spec/components/banner_button_component_spec.rb
+++ b/spec/components/banner_button_component_spec.rb
@@ -24,13 +24,13 @@ RSpec.describe BannerButtonComponent, type: :component do
   end
 
   describe "#icon_class" do
-    subject { described_class.new(**kwargs).send(:icon_class) }
+    subject { described_class.new(**kwargs).send(:icon_classes) }
 
     context "when no icon is specified" do
       let(:icon) { nil }
 
-      it "returns nil" do
-        expect(subject).to be_nil
+      it "returns an empty array" do
+        expect(subject).to be_empty
       end
     end
 

--- a/spec/components/validatable_summary_list_component_spec.rb
+++ b/spec/components/validatable_summary_list_component_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ValidatableSummaryListComponent, type: :component do
   let(:show_errors) { false }
   let(:error_path) { "/test-path" }
 
-  let(:list_kwargs) { { html_attributes: "a-value" } }
+  let(:list_kwargs) { { html_attributes: { key: "a-value" } } }
 
   let(:list) do
     described_class.new(


### PR DESCRIPTION
Since GOV.UK Components 3.0.6, `GovukComponents::Base` has a different
internal API than the one we previously relied on.

This adds a workaround for the new internal API until we decide whether
to follow the new internal API, or decouple ourselves from it.