### PR TITLE
Enable caching for content assets

### DIFF
--- a/terraform/app/modules/cloudfront/main.tf
+++ b/terraform/app/modules/cloudfront/main.tf
@@ -70,6 +70,15 @@ resource "aws_cloudfront_distribution" "default" {
     cache_policy_id        = data.aws_cloudfront_cache_policy.managed-caching-optimized.id
   }
 
+  ordered_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    path_pattern           = "/content-assets/*"
+    target_origin_id       = "${var.service_name}-${var.environment}-default-origin"
+    viewer_protocol_policy = "redirect-to-https"
+    cache_policy_id        = data.aws_cloudfront_cache_policy.managed-caching-optimized.id
+    compress               = var.enable_cloudfront_compress
+  }
 
   default_cache_behavior {
     allowed_methods          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]


### PR DESCRIPTION
## Changes in this PR:

This PR enables cloudfront caching for assets in `public/content-assets` which will be where our content team uploads images for long form content.
