### PR TITLE
Use `pagy` to paginate Vacancies API

### DIFF
--- a/app/controllers/api/vacancies_controller.rb
+++ b/app/controllers/api/vacancies_controller.rb
@@ -5,11 +5,7 @@ class Api::VacanciesController < Api::ApplicationController
   MAX_API_RESULTS_PER_PAGE = 100
 
   def index
-    @vacancies = Vacancy.includes(:organisations)
-                        .live
-                        .page(page_number)
-                        .per(MAX_API_RESULTS_PER_PAGE)
-                        .order(publish_on: :desc)
+    @pagy, @vacancies = pagy(vacancies, items: MAX_API_RESULTS_PER_PAGE)
 
     respond_to do |format|
       format.json
@@ -17,21 +13,17 @@ class Api::VacanciesController < Api::ApplicationController
   end
 
   def show
-    vacancy = Vacancy.listed.friendly.find(id)
+    vacancy = Vacancy.listed.friendly.find(params[:id])
     @vacancy = VacancyPresenter.new(vacancy)
   end
 
   private
 
+  def vacancies
+    Vacancy.includes(:organisations).live.order(publish_on: :desc)
+  end
+
   def trigger_api_queried_event(event_data = {})
     request_event.trigger(:api_queried, event_data)
-  end
-
-  def id
-    params[:id]
-  end
-
-  def page_number
-    params[:page] || 1
   end
 end

--- a/app/views/api/vacancies/index.json.jbuilder
+++ b/app/views/api/vacancies/index.json.jbuilder
@@ -19,13 +19,13 @@ json.data @vacancies.each do |vacancy|
 end
 
 json.links do
-  json.self  api_jobs_url(page: @vacancies.current_page, format: :json)
+  json.self  api_jobs_url(page: @pagy.page, format: :json)
   json.first api_jobs_url(page: 1, format: :json)
-  json.last  api_jobs_url(page: @vacancies.total_pages, format: :json)
-  json.prev((api_jobs_url(page: @vacancies.prev_page, format: :json) if @vacancies.prev_page))
-  json.next((api_jobs_url(page: @vacancies.next_page, format: :json) if @vacancies.next_page))
+  json.last  api_jobs_url(page: @pagy.last, format: :json)
+  json.prev((api_jobs_url(page: @pagy.prev, format: :json) if @pagy.prev))
+  json.next((api_jobs_url(page: @pagy.next, format: :json) if @pagy.next))
 end
 
 json.meta do
-  json.totalPages @vacancies.total_pages
+  json.totalPages @pagy.pages
 end


### PR DESCRIPTION
Removes use of Kaminari from Vacancies API