### PR TITLE
Add styling to content images

### DIFF
--- a/app/assets/stylesheets/layouts/posts/index.scss
+++ b/app/assets/stylesheets/layouts/posts/index.scss
@@ -17,6 +17,10 @@
       @extend .govuk-heading-m;
     }
 
+    img {
+      width: 100%;
+    }
+
     ol {
       @extend .govuk-list, .govuk-list--number;
     }


### PR DESCRIPTION
## Changes in this PR:

Adds styling to images in long form content posts, setting the width to 100% of the container

