### PR TITLE
[TEVA-4309] improvements to bullet point copy and paste

### DIFF
--- a/app/assets/javascript/components/editor/editor.js
+++ b/app/assets/javascript/components/editor/editor.js
@@ -47,6 +47,7 @@ const EditorController = class extends Controller {
     }
 
     this.removeEmptyParagraphs();
+    this.removeNbsp();
     this.replaceBullets();
     this.wrapOrphanedText();
 
@@ -56,8 +57,8 @@ const EditorController = class extends Controller {
   static sanitize(clipboardData) {
     return DOMPurify.sanitize(clipboardData, {
       ALLOWED_TAGS: EditorController.ALLOWED_TAGS,
-      FORBID_TAGS: ['link', 'script', 'strong', 'br'],
-      FORBID_ATTR: ['style', 'font', 'dir', 'role', 'class', 'id'],
+      FORBID_TAGS: ['link', 'script', 'strong', 'br', 'font'],
+      FORBID_ATTR: ['style', 'font', 'dir', 'role', 'class', 'id', 'align'],
       ALLOW_ARIA_ATTR: false,
       RETURN_DOM_FRAGMENT: true,
     });
@@ -99,14 +100,20 @@ const EditorController = class extends Controller {
     this.editorTarget.focus();
   }
 
+  removeNbsp() {
+    this.editorTarget.innerHTML = this.editorTarget.innerHTML.replace(/&nbsp;/g, '');
+  }
+
   replaceBullets() {
     let ul = null;
     const bulletUnicode = '\u2022';
     const bulletOperatorUnicode = '\u00B7';
-    const replace = new RegExp(`(${bulletUnicode}|${bulletOperatorUnicode})`);
+    const blackCircleUnicode = '\u25CF';
+    const bulletUnicodes = [bulletUnicode, bulletOperatorUnicode, blackCircleUnicode];
+    const replace = new RegExp(`(${bulletUnicodes.join('|')})`);
 
     Array.from(this.editorTarget.getElementsByTagName('p')).forEach((node) => {
-      if (node.textContent.charAt(0) === bulletUnicode || node.textContent.charAt(0) === bulletOperatorUnicode) {
+      if (bulletUnicodes.filter((bu) => node.textContent.charAt(0) === bu).length > 0) {
         if (!ul) {
           ul = document.createElement('ul');
           node.parentNode.insertBefore(ul, node.nextSibling);

--- a/app/assets/javascript/components/editor/editor.test.js
+++ b/app/assets/javascript/components/editor/editor.test.js
@@ -102,7 +102,7 @@ describe('Content editable form control', () => {
   });
 
   it('should replace bullet characters with html list', () => {
-    controller.editorTarget.innerHTML = '<p>para text</p><p>• 1</p><p>• 2</p><p>para text 2</p><p>· 3</p>';
+    controller.editorTarget.innerHTML = '<p>para text</p><p>• 1</p><p>● 2</p><p>para text 2</p><p>· 3</p>';
     controller.replaceBullets();
     expect(controller.editorTarget.innerHTML).toBe('<p>para text</p><ul><li>1</li><li>2</li></ul><p>para text 2</p><ul><li>3</li></ul>');
   });


### PR DESCRIPTION
- remove a few for unwanted HTML attributes
- remove non breaking space characters `&nbsp;`
- account for another potential bullet point character:

before
![Screenshot 2022-07-07 at 11 35 50](https://user-images.githubusercontent.com/1792451/177754577-39843fdd-943a-451d-bcca-83edb12eea45.png)

after
![Screenshot 2022-07-07 at 11 36 57](https://user-images.githubusercontent.com/1792451/177754574-2dbfd6f1-a35c-4639-98b8-f37d77f2784e.png)