### PR TITLE
Make pagination show last page on overflow

### DIFF
--- a/app/controllers/api/vacancies_controller.rb
+++ b/app/controllers/api/vacancies_controller.rb
@@ -5,7 +5,7 @@ class Api::VacanciesController < Api::ApplicationController
   MAX_API_RESULTS_PER_PAGE = 100
 
   def index
-    @pagy, @vacancies = pagy(vacancies, items: MAX_API_RESULTS_PER_PAGE)
+    @pagy, @vacancies = pagy(vacancies, items: MAX_API_RESULTS_PER_PAGE, overflow: :empty_page)
 
     respond_to do |format|
       format.json

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,5 +1,9 @@
+require "pagy/extras/overflow"
+
 Pagy::DEFAULT[:items] = 10
 Pagy::DEFAULT[:size] = [1, 1, 1, 1] # Design system recommendation
+
+Pagy::DEFAULT[:overflow] = :last_page
 
 # When you are done setting your own default freeze it, so it will not get changed accidentally
 Pagy::DEFAULT.freeze


### PR DESCRIPTION
This configures `pagy` to:
- by default, show the last page when a higher page number than the
  total number of pages is provided by the user (instead of raising an
  error) for a better user experience
- on the API, show an empty page of results instead so consumers who
  rely on increasing page number don't get confused