### PR TITLE
Remove `solargraph` as an application dependency

### DIFF
--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -15,6 +15,9 @@ sudo chown -R $(id -u):$(id -g) .
 log 'Install Ruby dependencies'
 bundle install
 
+log 'Install optional devcontainer Ruby dependencies'
+gem install solargraph
+
 log 'Install Javascript dependencies'
 yarn install
 

--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,6 @@ group :development do
   gem "amazing_print" # optional dependency of `rails_semantic_logger`
   gem "aws-sdk-ssm"
   gem "listen"
-  gem "solargraph", require: false
   gem "spring"
   gem "spring-commands-rspec"
   # TODO: Pinned until Spring >= 3 compatible version released

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,9 +126,7 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
-    backport (1.2.0)
     bcrypt (3.1.18)
-    benchmark (0.2.0)
     bindata (2.4.10)
     bindex (0.8.1)
     brakeman (5.2.3)
@@ -174,7 +172,6 @@ GEM
       dotenv (= 2.7.6)
       railties (>= 3.2)
     dumb_delegator (1.0.0)
-    e2mmap (0.1.0)
     erubi (1.10.0)
     et-orbi (1.2.7)
       tzinfo
@@ -289,7 +286,6 @@ GEM
     ice_nine (0.11.2)
     inflection (1.0.0)
     ipaddr (1.2.4)
-    jaro_winkler (1.5.4)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -304,8 +300,6 @@ GEM
     jwt (2.4.1)
     kramdown (2.4.0)
       rexml
-    kramdown-parser-gfm (1.1.0)
-      kramdown (~> 2.0)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -491,8 +485,6 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     retriable (3.1.2)
-    reverse_markdown (2.1.1)
-      nokogiri
     rexml (3.2.5)
     rgeo (2.4.0)
     rgeo-activerecord (7.0.1)
@@ -588,21 +580,6 @@ GEM
     slim_lint (0.22.1)
       rubocop (>= 0.78.0)
       slim (>= 3.0, < 5.0)
-    solargraph (0.45.0)
-      backport (~> 1.2)
-      benchmark
-      bundler (>= 1.17.2)
-      diff-lcs (~> 1.4)
-      e2mmap
-      jaro_winkler (~> 1.5)
-      kramdown (~> 2.3)
-      kramdown-parser-gfm (~> 1.1)
-      parser (~> 3.0)
-      reverse_markdown (>= 1.0.5, < 3)
-      rubocop (>= 0.52)
-      thor (~> 1.0)
-      tilt (~> 2.0)
-      yard (~> 0.9, >= 0.9.24)
     spring (3.1.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -663,8 +640,6 @@ GEM
       builder (>= 2.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
     zeitwerk (2.6.0)
     zendesk_api (1.36.0)
       faraday (>= 0.9.0, < 2.0.0)
@@ -763,7 +738,6 @@ DEPENDENCIES
   skylight
   slim-rails
   slim_lint
-  solargraph
   spring
   spring-commands-rspec
   spring-watcher-listen!


### PR DESCRIPTION
This is only used by the devcontainer so can just be installed as a
dependency of that.