### PR TITLE
[TEVA-4323] refactor useless has_css blocks in system specs

### DIFF
--- a/spec/system/jobseekers_can_manage_their_job_applications_spec.rb
+++ b/spec/system/jobseekers_can_manage_their_job_applications_spec.rb
@@ -21,17 +21,27 @@ RSpec.describe "Jobseekers can manage their job applications" do
       before { visit jobseekers_job_applications_path }
 
       context "when the jobseeker views job applications" do
-        it "shows draft job applications then submitted job applications" do
+        it "shows job applications in draft/submitted/shortlisted/passed order" do
           expect(page).to have_css("h1.govuk-heading-l", text: I18n.t("jobseekers.job_applications.index.page_title"))
-          expect(page).to have_css(".card-component", count: 4) do |cards|
-            expect(cards[0]).to have_css(".card-component__header", text: draft_job_application.vacancy.job_title)
-            expect(cards[0]).to have_css(".card-component__body", text: "draft")
-            expect(cards[1]).to have_css(".card-component__header", text: deadline_passed_job_application.vacancy.job_title)
-            expect(cards[1]).to have_css(".card-component__body", text: "deadline passed")
-            expect(cards[2]).to have_css(".card-component__header", text: submitted_job_application.vacancy.job_title)
-            expect(cards[2]).to have_css(".card-component__body", text: "submitted")
-            expect(cards[1]).to have_css(".card-component__header", text: shortlisted_job_application.vacancy.job_title)
-            expect(cards[1]).to have_css(".card-component__body", text: "shortlisted")
+
+          within ".card-component:nth-child(1)" do
+            expect(page).to have_css(".card-component__header", text: draft_job_application.vacancy.job_title)
+            expect(page).to have_css(".card-component__actions", text: "draft")
+          end
+
+          within ".card-component:nth-child(2)" do
+            expect(page).to have_css(".card-component__header", text: submitted_job_application.vacancy.job_title)
+            expect(page).to have_css(".card-component__actions", text: "submitted")
+          end
+
+          within ".card-component:nth-child(3)" do
+            expect(page).to have_css(".card-component__header", text: shortlisted_job_application.vacancy.job_title)
+            expect(page).to have_css(".card-component__actions", text: "shortlisted")
+          end
+
+          within ".card-component:nth-child(4)" do
+            expect(page).to have_css(".card-component__header", text: deadline_passed_job_application.vacancy.job_title)
+            expect(page).to have_css(".card-component__actions", text: "deadline passed")
           end
         end
 

--- a/spec/system/jobseekers_can_manage_their_saved_jobs_spec.rb
+++ b/spec/system/jobseekers_can_manage_their_saved_jobs_spec.rb
@@ -24,50 +24,46 @@ RSpec.describe "Jobseekers can manage their saved jobs" do
         it "shows saved jobs" do
           expect(page).to have_content(I18n.t("jobseekers.saved_jobs.index.page_title"))
           expect(page).to have_css("h1.govuk-heading-l", text: I18n.t("jobseekers.saved_jobs.index.page_title"))
-          expect(page).to have_css(".card-component", count: 3) do |cards|
-            expect(cards[0]).to have_css(".card-component__header", text: expired_vacancy.job_title)
-            expect(cards[1]).to have_css(".card-component__header", text: vacancy2.job_title)
-            expect(cards[2]).to have_css(".card-component__header", text: vacancy1.job_title)
+          expect(page).to have_css(".card-component", count: 3)
+
+          within ".card-component:nth-child(1)" do
+            expect(page).to have_css(".card-component__header", text: expired_vacancy.job_title)
+          end
+
+          within ".card-component:nth-child(2)" do
+            expect(page).to have_css(".card-component__header", text: vacancy2.job_title)
+          end
+
+          within ".card-component:nth-child(3)" do
+            expect(page).to have_css(".card-component__header", text: vacancy1.job_title)
           end
         end
 
         it "shows deadline passed label for expired jobs" do
-          expect(page).to have_css(".card-component", count: 3) do |cards|
-            expect(cards[0]).to have_css(".card-component__body", text: I18n.t("jobseekers.saved_jobs.index.deadline_passed"))
-            expect(cards[1]).not_to have_css(".card-component__body", text: I18n.t("jobseekers.saved_jobs.index.deadline_passed"))
-            expect(cards[2]).not_to have_css(".card-component__body", text: I18n.t("jobseekers.saved_jobs.index.deadline_passed"))
+          within ".card-component:nth-child(1)" do
+            expect(page).to have_css(".card-component__body", text: I18n.t("jobseekers.saved_jobs.index.deadline_passed"))
+          end
+
+          within ".card-component:nth-child(2)" do
+            expect(page).not_to have_css(".card-component__body", text: I18n.t("jobseekers.saved_jobs.index.deadline_passed"))
+          end
+
+          within ".card-component:nth-child(3)" do
+            expect(page).not_to have_css(".card-component__body", text: I18n.t("jobseekers.saved_jobs.index.deadline_passed"))
           end
         end
 
         it "does not show apply for this job links" do
-          expect(page).to have_css(".card-component", count: 3) do |cards|
-            expect(cards[0]).to have_css(".card-component__actions") do |actions|
-              expect(actions).not_to have_link(I18n.t("jobseekers.saved_jobs.index.apply"))
-            end
-
-            expect(cards[1]).to have_css(".card-component__actions") do |actions|
-              expect(actions).not_to have_link(I18n.t("jobseekers.saved_jobs.index.apply"))
-            end
-
-            expect(cards[2]).to have_css(".card-component__actions") do |actions|
-              expect(actions).not_to have_link(I18n.t("jobseekers.saved_jobs.index.apply"))
-            end
+          within ".card-component:nth-child(1)" do
+            expect(page).not_to have_link(I18n.t("jobseekers.saved_jobs.index.apply"))
           end
-        end
 
-        it "shows apply for this job link for live jobs that can be applied to" do
-          expect(page).to have_css(".card-component", count: 3) do |cards|
-            expect(cards[0]).to have_css(".card-component__actions") do |actions|
-              expect(actions).not_to have_link(I18n.t("jobseekers.saved_jobs.index.apply"))
-            end
+          within ".card-component:nth-child(2)" do
+            expect(page).to have_link(I18n.t("jobseekers.saved_jobs.index.apply"))
+          end
 
-            expect(cards[1]).to have_css(".card-component__actions") do |actions|
-              expect(actions).to have_link(I18n.t("jobseekers.saved_jobs.index.apply"))
-            end
-
-            expect(cards[2]).to have_css(".card-component__actions") do |actions|
-              expect(actions).not_to have_link(I18n.t("jobseekers.saved_jobs.index.apply"))
-            end
+          within ".card-component:nth-child(3)" do
+            expect(page).not_to have_link(I18n.t("jobseekers.saved_jobs.index.apply"))
           end
         end
 

--- a/spec/system/publishers_can_view_their_notifications_spec.rb
+++ b/spec/system/publishers_can_view_their_notifications_spec.rb
@@ -32,20 +32,20 @@ RSpec.describe "Publishers can view their notifications" do
     it "clicks notifications link, renders the notifications, paginates, and marks as read" do
       click_on strip_tags(I18n.t("nav.notifications_html", count: 2))
 
-      expect(page).to have_css("div", class: "notification", count: 1) do |notification|
-        expect(notification).to have_css("div", class: "notification__tag", text: "new", count: 1)
+      within first(".notification") do
+        expect(page).to have_css("div", class: "notification__tag", text: "new", count: 1)
       end
 
       click_on "Next"
 
-      expect(page).to have_css("div", class: "notification", count: 1) do |notification|
-        expect(notification).to have_css("div", class: "notification__tag", text: "new", count: 1)
+      within first(".notification") do
+        expect(page).to have_css("div", class: "notification__tag", text: "new", count: 1)
       end
 
       click_on "Previous"
 
-      expect(page).to have_css("div", class: "notification", count: 1) do |notification|
-        expect(notification).not_to have_css("div", class: "notification__tag", text: "new", count: 1)
+      within first(".notification") do
+        expect(page).not_to have_css("div", class: "notification__tag", text: "new", count: 1)
       end
     end
   end


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-4323

## before/wrong

`expect(page).to have_css(".card-component", count: 4) do |cards|`

this tests only that there are 4 cards, nothing in the do |cards| block is executed and hence some tests giving false positives

## after/correct

`expect(page).to have_css(".card-component", count: 4)`

`within ".card-component:nth-child(1)" do`
or
`within first(".card-component") do`

this tests that there are 4 cards, within blocks are executed separately


