### PR TITLE
Fix busybox base-image vulnerability

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -155,7 +155,7 @@ jobs:
           docker run -t -e "SNYK_TOKEN=${{ env.SNYK_TOKEN }}" \
             -v "/var/run/docker.sock:/var/run/docker.sock" \
             -v "$GITHUB_WORKSPACE:/project"  \
-            snyk/snyk-cli:docker test --docker ${{ env.DOCKER_REPOSITORY }}:${{ env.DOCKER_IMAGE_TAG }} --file=Dockerfile
+            snyk/snyk-cli:docker test --docker ${{ env.DOCKER_REPOSITORY }}:${{ env.DOCKER_IMAGE_TAG }} --file=Dockerfile --fail-on=all
 
       - name: Push ${{ env.DOCKER_REPOSITORY }} images
         if: ${{ success() }}


### PR DESCRIPTION
## Changes in this PR:

SNYK vulnerability on busybox 1.35.0-r15
requires at least 1.35.0-r17 to fix

This isn't available yet, so added --fail-on=all to the docker test command which should only fail if a vulnerability can be patched or upgraded

https://docs.snyk.io/snyk-cli/commands/test#fail-on-less-than-all-or-upgradable-or-patchable-greater-than 

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
