### PR TITLE
[TEVA-4318] refactor deprecated syntax in component tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,6 +90,7 @@ group :development, :test do
   gem "brakeman"
   gem "byebug", platforms: %i[mri mingw x64_mingw]
   gem "dotenv-rails"
+  gem "launchy", "~> 2.5"
   gem "pry"
   gem "pry-byebug"
   gem "pry-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -300,6 +300,8 @@ GEM
     jwt (2.4.1)
     kramdown (2.4.0)
       rexml
+    launchy (2.5.0)
+      addressable (~> 2.7)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -694,6 +696,7 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   kramdown
+  launchy (~> 2.5)
   listen
   lockbox
   mail-notify

--- a/spec/components/dashboard_component_spec.rb
+++ b/spec/components/dashboard_component_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe DashboardComponent, type: :component do
     before { render_inline(subject) }
 
     it "renders the Create a job listing button that skips the copy existing page" do
-      expect(rendered_component).to include(Rails.application.routes.url_helpers.organisation_jobs_path)
+      expect(page).to have_link(href: Rails.application.routes.url_helpers.organisation_jobs_path)
     end
   end
 
@@ -33,7 +33,7 @@ RSpec.describe DashboardComponent, type: :component do
         let!(:inline_component) { render_inline(subject) }
 
         it "renders the Create a job listing button that does not skip the copy existing page" do
-          expect(rendered_component).to include(Rails.application.routes.url_helpers.create_or_copy_organisation_jobs_path)
+          expect(page).to have_link(href: Rails.application.routes.url_helpers.create_or_copy_organisation_jobs_path)
         end
 
         it "renders the number of jobs in the heading" do
@@ -45,16 +45,16 @@ RSpec.describe DashboardComponent, type: :component do
         end
 
         it "renders the link to view applicants" do
-          expect(rendered_component).to include(I18n.t("jobs.manage.view_applicants", count: 1))
-          expect(rendered_component).to include(Rails.application.routes.url_helpers.organisation_job_job_applications_path(vacancy.id))
+          expect(page).to have_content(I18n.t("jobs.manage.view_applicants", count: 1))
+          expect(page).to have_link(href: Rails.application.routes.url_helpers.organisation_job_job_applications_path(vacancy.id))
         end
 
         context "when withdrawn applications have also been received" do
           let(:withdrawn_job_application) { create(:job_application, :status_withdrawn, vacancy: vacancy) }
 
           it "does not affect the count" do
-            expect(rendered_component).to include(I18n.t("jobs.manage.view_applicants", count: 1))
-            expect(rendered_component).to include(Rails.application.routes.url_helpers.organisation_job_job_applications_path(vacancy.id))
+            expect(page).to have_content(I18n.t("jobs.manage.view_applicants", count: 1))
+            expect(page).to have_link(href: Rails.application.routes.url_helpers.organisation_job_job_applications_path(vacancy.id))
           end
         end
 
@@ -70,7 +70,7 @@ RSpec.describe DashboardComponent, type: :component do
           let(:selected_type) { "draft" }
 
           it "uses the correct 'no jobs' text ('no filters')" do
-            expect(rendered_component).to include(I18n.t("jobs.manage.draft.no_jobs.no_filters"))
+            expect(page).to have_content(I18n.t("jobs.manage.draft.no_jobs.no_filters"))
           end
         end
       end
@@ -99,8 +99,8 @@ RSpec.describe DashboardComponent, type: :component do
         end
 
         it "renders the link to view applicants" do
-          expect(rendered_component).to include(I18n.t("jobs.manage.view_applicants", count: 1))
-          expect(rendered_component).to include(Rails.application.routes.url_helpers.organisation_job_job_applications_path(vacancy.id))
+          expect(page).to have_content(I18n.t("jobs.manage.view_applicants", count: 1))
+          expect(page).to have_link(href: Rails.application.routes.url_helpers.organisation_job_job_applications_path(vacancy.id))
         end
 
         it "renders the filters sidebar" do
@@ -141,7 +141,7 @@ RSpec.describe DashboardComponent, type: :component do
         end
 
         it "does not render the link to view applicants" do
-          expect(rendered_component).not_to include(I18n.t("jobs.manage.view_applicants", count: 1))
+          expect(page).not_to have_content(I18n.t("jobs.manage.view_applicants", count: 1))
         end
 
         it "renders the vacancy readable job location in the table" do
@@ -172,7 +172,7 @@ RSpec.describe DashboardComponent, type: :component do
           let(:selected_type) { "draft" }
 
           it "uses the correct 'no jobs' text ('no filters')" do
-            expect(rendered_component).to include(I18n.t("jobs.manage.draft.no_jobs.no_filters"))
+            expect(page).to have_content(I18n.t("jobs.manage.draft.no_jobs.no_filters"))
           end
         end
       end
@@ -185,8 +185,8 @@ RSpec.describe DashboardComponent, type: :component do
       before { render_inline(subject) }
 
       it "renders plain text of 0 applicants" do
-        expect(rendered_component).to include(I18n.t("jobs.manage.view_applicants", count: 0))
-        expect(rendered_component).not_to include(Rails.application.routes.url_helpers.organisation_job_job_applications_path(vacancy.id))
+        expect(page).to have_content(I18n.t("jobs.manage.view_applicants", count: 0))
+        expect(page).not_to have_link(href: Rails.application.routes.url_helpers.organisation_job_job_applications_path(vacancy.id))
       end
     end
   end
@@ -205,11 +205,11 @@ RSpec.describe DashboardComponent, type: :component do
       let!(:inline_component) { render_inline(subject) }
 
       it "renders the vacancy in Oxford" do
-        expect(rendered_component).to include(vacancy_oxford.job_title)
+        expect(page).to have_content(vacancy_oxford.job_title)
       end
 
       it "does not render the vacancy in Cambridge" do
-        expect(rendered_component).not_to include(vacancy_cambridge.job_title)
+        expect(page).not_to have_content(vacancy_cambridge.job_title)
       end
     end
 
@@ -217,7 +217,7 @@ RSpec.describe DashboardComponent, type: :component do
       let!(:inline_component) { render_inline(subject) }
 
       it "uses the correct no jobs text ('with filters')" do
-        expect(rendered_component).to include(I18n.t("jobs.manage.published.no_jobs.with_filters"))
+        expect(page).to have_content(I18n.t("jobs.manage.published.no_jobs.with_filters"))
       end
     end
   end

--- a/spec/components/job_alert_link_component_spec.rb
+++ b/spec/components/job_alert_link_component_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe JobAlertLinkComponent, type: :component do
     let(:search_params_present?) { false }
 
     it "does not render the job alerts link" do
-      expect(rendered_component).to be_blank
+      expect(page).to_not have_css(".job-alert-cta")
     end
   end
 end

--- a/spec/components/search_results_heading_component_spec.rb
+++ b/spec/components/search_results_heading_component_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe SearchResultsHeadingComponent, type: :component do
     before { subject }
 
     it "renders correct heading" do
-      expect(rendered_component).to include(
+      expect(page).to have_content(
         I18n.t("jobs.search_result_heading.without_search", jobs_count: count, count: count),
       )
     end
@@ -76,9 +76,7 @@ RSpec.describe SearchResultsHeadingComponent, type: :component do
     end
 
     it "renders correct heading" do
-      expect(rendered_component).to include(
-        I18n.t("jobs.search_result_heading.organisation_html", organisation: vacancies_search.organisation.name),
-      )
+      expect(page).to have_content(vacancies_search.organisation.name)
     end
   end
 end

--- a/spec/components/vacancy_form_page_heading_component_spec.rb
+++ b/spec/components/vacancy_form_page_heading_component_spec.rb
@@ -34,13 +34,13 @@ RSpec.describe VacancyFormPageHeadingComponent, type: :component do
       let(:status) { :draft }
 
       it "shows the current step" do
-        expect(rendered_component).to include(I18n.t("jobs.current_step", step: 1, total: 2))
+        expect(page).to have_content(I18n.t("jobs.current_step", step: 1, total: 2))
       end
     end
 
     context "when vacancy is published" do
       it "does not show the current step" do
-        expect(rendered_component).not_to include("Step")
+        expect(page).not_to have_content("Step")
       end
     end
   end
@@ -50,7 +50,7 @@ RSpec.describe VacancyFormPageHeadingComponent, type: :component do
 
     context "when the vacancy is published" do
       it "returns edit job title" do
-        expect(rendered_component).to include(I18n.t("jobs.edit_job_title", job_title: "Test job title"))
+        expect(page).to have_content(I18n.t("jobs.edit_job_title", job_title: "Test job title"))
       end
     end
 
@@ -58,7 +58,7 @@ RSpec.describe VacancyFormPageHeadingComponent, type: :component do
       let(:status) { :draft }
 
       it "returns create a job title" do
-        expect(rendered_component).to include(I18n.t("jobs.create_a_job_title", organisation: "Teaching Vacancies Academy"))
+        expect(page).to have_content(I18n.t("jobs.create_a_job_title", organisation: "Teaching Vacancies Academy"))
       end
     end
   end


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-4318

refactor component tests that use deprecated syntax shown in warnings `DEPRECATION WARNING: rendered_component is deprecated and will be removed in v3.0.0`

added `launchy` gem so that `save_and_open_page` opens snapshots automatically in browser