### PR TITLE
Fix Subscription Confirmation Page Bug

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -59,6 +59,6 @@ class Subscription < ApplicationRecord
   end
 
   def organisation
-    Organisation.find_by(slug: search_criteria["organisation_slug"])
+    Organisation.find_by(slug: search_criteria["organisation_slug"]) if search_criteria["organisation_slug"]
   end
 end


### PR DESCRIPTION
## Changes in this PR:

Added a condition to the query so that it returns nil when there is no organisation slug in the search criteria. Previously the query was retrieving the first organisation with organisation_slug set to nil.