### PR TITLE
[TEVA-4333] change instances of 16-19 -> 16 to 19

### DIFF
--- a/app/form_models/jobseekers/search_form.rb
+++ b/app/form_models/jobseekers/search_form.rb
@@ -85,7 +85,7 @@ class Jobseekers::SearchForm
 
   def set_facet_options
     @job_role_options = Vacancy.job_roles.keys.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_role_form.job_role_options.#{option}")] }
-    @phase_options = [%w[primary Primary], %w[middle Middle], %w[secondary Secondary], %w[16-19 16-19]]
+    @phase_options = [%w[primary Primary], %w[middle Middle], %w[secondary Secondary], ["16-19", "16 to 19"]]
     @ect_status_options = [["ect_suitable", I18n.t("jobs.filters.ect_suitable")]]
     @working_pattern_options = Vacancy.working_patterns.keys.map do |option|
       [option, I18n.t("helpers.label.publishers_job_listing_working_patterns_form.working_patterns_options.#{option}")]

--- a/app/form_models/jobseekers/subscription_form.rb
+++ b/app/form_models/jobseekers/subscription_form.rb
@@ -56,7 +56,7 @@ class Jobseekers::SubscriptionForm < BaseForm
 
   def set_facet_options
     @job_role_options = Vacancy.job_roles.keys.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_role_form.job_role_options.#{option}")] }
-    @phase_options = [%w[primary Primary], %w[middle Middle], %w[secondary Secondary], %w[16-19 16-19]]
+    @phase_options = [%w[primary Primary], %w[middle Middle], %w[secondary Secondary], ["16-19", "16 to 19"]]
     @ect_status_options = [["ect_suitable", I18n.t("jobs.filters.ect_suitable")]]
     @working_pattern_options = Vacancy.working_patterns.keys.map do |option|
       [option, I18n.t("helpers.label.publishers_job_listing_working_patterns_form.working_patterns_options.#{option}")]

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -24,8 +24,8 @@ class School < Organisation
     middle_deemed_primary: %w[middle],
     middle_deemed_secondary: %w[middle],
     secondary: %w[secondary],
-    "16-19": %w[16-19],
-    all_through: %w[primary middle secondary 16-19],
+    "16-19": ["16 to 19"],
+    all_through: ["primary", "middle", "secondary", "16 to 19"],
   }.freeze
 
   def religious_character

--- a/config/landing_pages.yml
+++ b/config/landing_pages.yml
@@ -54,7 +54,7 @@ shared:
       - secondary
   16-19-education-provider-jobs:
     phases:
-      - "16-19"
+      - "16 to 19"
 
   ### Subjects
   art-design-technology-teacher-jobs:

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -45,7 +45,7 @@ en:
       primary: Primary
       middle: Middle
       secondary: Secondary
-      16-19: 16-19
+      16-19: 16 to 19
 
     no_jobs:
       heading: Try another search

--- a/config/locales/landing_pages.yml
+++ b/config/locales/landing_pages.yml
@@ -95,8 +95,8 @@ en:
       meta_description: "Discover the latest jobs for maths teachers, science teachers, English teachers and more. Find your next secondary school job on Teaching Vacancies."
     16-19-education-provider-jobs:
       name: "16-19"
-      title: "16-19 Education Provider Jobs"
-      heading: "%{count} jobs with 16-19 education providers"
+      title: "16 to 19 Education Provider Jobs"
+      heading: "%{count} jobs with 16 to 19 education providers"
       meta_description: "Use Teaching Vacancies to find FE college teacher jobs and more roles near you at sixth-form colleges and other providers of 16 to 19 education."
 
     ### Subjects

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -59,7 +59,7 @@ FactoryBot.define do
 
     trait :all_through do
       phase { :all_through }
-      readable_phases { %w[primary middle secondary 16-19] }
+      readable_phases { ["primary", "middle", "secondary", "16 to 19"] }
     end
 
     trait :in_london do

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe School do
 
   describe ".available_readable_phases" do
     it "lists all the phases that can be used as human-readable versions of the underlying phase categories, in chronological order" do
-      expect(described_class.available_readable_phases).to eq(%w[primary middle secondary 16-19])
+      expect(described_class.available_readable_phases).to eq(["primary", "middle", "secondary", "16 to 19"])
     end
   end
 

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -510,12 +510,12 @@ RSpec.describe Vacancy do
 
     context "when the organisation changes" do
       let(:phase) { :multiple_phases }
-      let(:other_organisation) { create(:school, readable_phases: ["16-19"]) }
+      let(:other_organisation) { create(:school, readable_phases: ["16 to 19"]) }
 
       it "updates the phases on save" do
         expect(subject.readable_phases).to contain_exactly("primary", "middle")
         subject.update(organisations: [other_organisation])
-        expect(subject.readable_phases).to contain_exactly("16-19")
+        expect(subject.readable_phases).to contain_exactly("16 to 19")
       end
     end
   end

--- a/spec/presenters/subscription_presenter_spec.rb
+++ b/spec/presenters/subscription_presenter_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe SubscriptionPresenter do
       let(:search_criteria) { { phases: %w[secondary 16-19] } }
 
       it "formats and returns the phases" do
-        expect(presenter.filtered_search_criteria["education_phases"]).to eq("Secondary, 16-19")
+        expect(presenter.filtered_search_criteria["education_phases"]).to eq("Secondary, 16 to 19")
       end
     end
 

--- a/spec/queries/vacancy_filter_query_spec.rb
+++ b/spec/queries/vacancy_filter_query_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe VacancyFilterQuery do
   let(:organisation1) { create(:school, readable_phases: %w[primary middle]) }
-  let(:organisation2) { create(:school, readable_phases: %w[secondary 16-19]) }
+  let(:organisation2) { create(:school, readable_phases: ["secondary", "16 to 19"]) }
 
   let!(:vacancy1) { create(:vacancy, job_title: "Vacancy 1", subjects: %w[German French], working_patterns: %w[full_time], job_role: "senior_leader", ect_status: "ect_suitable", organisations: [organisation1]) }
   let!(:vacancy2) { create(:vacancy, job_title: "Vacancy 2", subjects: %w[English Spanish], working_patterns: %w[full_time], phase: :primary, job_role: "teacher", ect_status: "ect_suitable") }


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-4333

this is primarily for a11y reasons as 16-19 does not read well to a screen reader, for e.g on these form elements

![Screenshot 2022-07-27 at 10 03 24](https://user-images.githubusercontent.com/1792451/181207908-e349adc1-416d-49eb-b4b2-975edfd3ac3b.png)

but so far what ive done does not change what is sorted in DB, that is still 16-19. this means in places like this it is still 16-19 as it is the value that is used as it does not use a value -> label mapping for summary list row - AGREED THS CAN BE DONE AT FUTURE DATE

![Screenshot 2022-07-27 at 10 05 54](https://user-images.githubusercontent.com/1792451/181208582-efaf1323-09e0-419c-b98b-676c68b8dd76.png)




