### PR TITLE
[TEVA-4338] put page heading text into page title

### DIFF
--- a/app/components/search_results_heading_component.rb
+++ b/app/components/search_results_heading_component.rb
@@ -1,5 +1,5 @@
 class SearchResultsHeadingComponent < ViewComponent::Base
-  def initialize(vacancies_search:, landing_page:)
+  def initialize(vacancies_search:, landing_page:, strip_special_characters: false)
     @vacancies_search = vacancies_search
     @landing_page = landing_page
     @keyword = @vacancies_search.keyword
@@ -8,6 +8,7 @@ class SearchResultsHeadingComponent < ViewComponent::Base
     @total_count = @vacancies_search.total_count
     @readable_count = number_with_delimiter(@total_count)
     @organisation_slug = @vacancies_search.organisation_slug
+    @strip_special_characters = strip_special_characters
   end
 
   def heading
@@ -17,7 +18,9 @@ class SearchResultsHeadingComponent < ViewComponent::Base
       return t("jobs.search_result_heading.without_search", jobs_count: @readable_count, count: @total_count)
     end
 
-    [count_phrase, keyword_phrase, radius_phrase, location_phrase, organisation_phrase].compact.join(" ")
+    heading_text = [count_phrase, keyword_phrase, radius_phrase, location_phrase, organisation_phrase].compact.join(" ")
+
+    @strip_special_characters ? heading_text.gsub("&lsquo;", "").gsub("&rsquo;", "") : heading_text
   end
 
   private

--- a/app/components/search_results_heading_component/search_results_heading_component.html.slim
+++ b/app/components/search_results_heading_component/search_results_heading_component.html.slim
@@ -1,2 +1,1 @@
-h1 class="govuk-heading-l" role="heading" aria-level="1"
-  == heading
+== heading

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -4,7 +4,7 @@ html.govuk-template.app-html-class lang="en"
     = render "layouts/google_tag_manager_head" if include_google_tag_manager?
     = render "layouts/head_meta"
     = render "layouts/head_links"
-    title #{content_for :page_title_prefix} - #{t("app.title")}
+    title #{content_for :page_title_prefix} - #{t("app.title")} - GOV.UK
     = stylesheet_link_tag "application", media: "all"
     = csrf_meta_tags
     = render "layouts/sentry_js_config"

--- a/app/views/vacancies/index.html.slim
+++ b/app/views/vacancies/index.html.slim
@@ -7,7 +7,8 @@
 
 = render "vacancies/search/page_title_and_description", landing_page: @landing_page
 
-= search_results_heading(vacancies_search: @vacancies_search, landing_page: @landing_page)
+h1 class="govuk-heading-l" role="heading" aria-level="1"
+  = search_results_heading(vacancies_search: @vacancies_search, landing_page: @landing_page)
 
 - if @vacancies_search.active_criteria? && @vacancies.count.positive?
   p = t("subscriptions.link.help_text_html", link: govuk_link_to(t("subscriptions.link.text"), new_subscription_path(search_criteria: @vacancies_search.active_criteria, coordinates_present: @vacancies_search.point_coordinates.present?)))

--- a/app/views/vacancies/search/_page_title_and_description.html.slim
+++ b/app/views/vacancies/search/_page_title_and_description.html.slim
@@ -2,4 +2,4 @@
   - content_for :page_title_prefix, landing_page.title
   - content_for :page_description, landing_page.meta_description
 - else
-  - content_for :page_title_prefix, t(".title", count: params[:page].to_i)
+  - content_for :page_title_prefix, t(".title", count: params[:page].to_i, heading: search_results_heading(vacancies_search: @vacancies_search, landing_page: @landing_page, strip_special_characters: true))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -540,9 +540,9 @@ en:
             other: (%{count} results)
       page_title_and_description:
         title:
-          zero: Find a job in teaching - Search results
-          one: Find a job in teaching - Search results
-          other: Find a job in teaching - Search results page %{count}
+          zero: "%{heading} - Find a job in teaching"
+          one: "%{heading} - Find a job in teaching"
+          other: "%{heading} page %{count} - Find a job in teaching"
     show:
       page_description: '%{job_title} job from %{organisation}. Apply by %{deadline}.'
 

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -85,8 +85,8 @@ en:
 
     search_result_heading:
       count_html:
-        one: <span class='govuk-!-font-weight-bold'>%{jobs_count}</span> job
-        other: <span class='govuk-!-font-weight-bold'>%{jobs_count}</span> jobs
+        one: "%{jobs_count} job"
+        other: "%{jobs_count} jobs"
       keyword_html:
         one: matches <span class='govuk-!-font-weight-bold'>&lsquo;%{keyword}&rsquo;</span>
         other: match <span class='govuk-!-font-weight-bold'>&lsquo;%{keyword}&rsquo;</span>
@@ -94,10 +94,10 @@ en:
       radius_html:
         zero: in
         one: >-
-          within <span class='govuk-!-font-weight-bold'>%{count} %{units}</span> of
+          within %{count} %{units} of
         other: >-
-          within <span class='govuk-!-font-weight-bold'>%{count} %{units}</span> of
-      location_html: <span class='govuk-!-font-weight-bold text-capitalize'>&lsquo;%{location}&rsquo;</span>
+          within %{count} %{units} of
+      location_html: "&lsquo;%{location}&rsquo;"
       organisation_html: at <span class='govuk-!-font-weight-bold'>%{organisation}</span>
       unit_of_length: mile
       without_search:

--- a/spec/system/jobseekers_can_view_landing_pages_spec.rb
+++ b/spec/system/jobseekers_can_view_landing_pages_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Jobseekers can view landing pages" do
   it "contains the expected content and vacancies" do
     visit landing_page_path("part-time-potions-and-sorcery-teacher-jobs")
 
-    expect(page.title).to eq("Spiffy Part Time Potions and Sorcery Jobs - Teaching Vacancies")
+    expect(page.title).to eq("Spiffy Part Time Potions and Sorcery Jobs - Teaching Vacancies - GOV.UK")
 
     expect(page).to have_css("h1", text: "1 amazing jobs APPLY NOW")
     expect(page).to have_link("Head of Hogwarts")

--- a/spec/system/jobseekers_can_view_organisation_landing_pages_spec.rb
+++ b/spec/system/jobseekers_can_view_organisation_landing_pages_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Jobseekers can view organisation landing pages" do
     it "contains the expected content and vacancies" do
       visit organisation_landing_page_path(school.slug)
 
-      expect(page.title).to eq("School & Teaching Jobs at #{school.name} - Teaching Vacancies")
+      expect(page.title).to eq("School & Teaching Jobs at #{school.name} - Teaching Vacancies - GOV.UK")
       expect(page).to have_css("h1", text: "1 job found at #{school.name}")
       expect(page).to have_link(vacancy.job_title.to_s)
       expect(page).to have_link(school.name, href: organisation_landing_page_path(school.slug))
@@ -22,7 +22,7 @@ RSpec.describe "Jobseekers can view organisation landing pages" do
     it "contains the expected content and vacancies" do
       visit organisation_landing_page_path(school_group.slug)
 
-      expect(page.title).to eq("School & Teaching Jobs at #{school_group.name} - Teaching Vacancies")
+      expect(page.title).to eq("School & Teaching Jobs at #{school_group.name} - Teaching Vacancies - GOV.UK")
 
       expect(page).to have_css("h1", text: "2 jobs found at #{school_group.name}")
       expect(page).to have_link(vacancy.job_title.to_s)


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-4338

all page titles should also be
- postfixed with `GOV.UK` as this is standard for gov pages
- have h1 prefixed as this gives better screenreader experience

page heading

`231 jobs found within 15 miles of 'London'`

will have page title of

`231 jobs found within 15 miles of London - Find a job in teaching - Teaching Vacancies - GOV.UK`

or for paginated result pages 2 onwards

`231 jobs found within 15 miles of London page 2 - Find a job in teaching - Teaching Vacancies - GOV.UK`