### PR TITLE
Remove useless FE api error logs from Sentry

### DIFF
--- a/app/assets/javascript/js_components/autocomplete/api.js
+++ b/app/assets/javascript/js_components/autocomplete/api.js
@@ -1,12 +1,11 @@
 import axios from 'axios';
-import logger from '../../lib/logging';
 
 export const getLocationSuggestions = ({ query, populateResults }) => axios.get(`/api/v1/location_suggestion/${query}?format=json`)
   .then((response) => response.data)
   .then((data) => data.suggestions)
   .then(populateResults)
-  .catch((error) => {
-    logger.log(`${error} Search query: ${query}`);
+  .catch(() => {
+
   });
 
 const api = {

--- a/app/assets/javascript/js_components/locationFinder/api.js
+++ b/app/assets/javascript/js_components/locationFinder/api.js
@@ -1,11 +1,10 @@
 import axios from 'axios';
-import logger from '../../lib/logging';
 
 export const getPostcodeFromCoordinates = (latitude, longitude) => axios.get('https://api.postcodes.io/postcodes', {
   params: { latitude, longitude },
 }).then((response) => response.data.result[0].postcode)
-  .catch((error) => {
-    logger.log(`${error} Postcodes API`);
+  .catch(() => {
+
   });
 
 const api = {

--- a/app/assets/javascript/js_components/locationFinder/locationFinder.js
+++ b/app/assets/javascript/js_components/locationFinder/locationFinder.js
@@ -2,7 +2,6 @@ import { Controller } from '@hotwired/stimulus';
 
 import loader from '../loadingIndicator/loadingIndicator';
 import api from './api';
-import logger from '../../lib/logging';
 
 export const ERROR_MESSAGE = 'Unable to find your location';
 export const LOGGING_MESSAGE = '[component: locationFinder]: Unable to find user location';
@@ -43,13 +42,11 @@ const LocationFinder = class extends Controller {
   onFailure() {
     this.showErrorMessage();
     this.stopLoading();
-    logger.log(LOGGING_MESSAGE);
   }
 
   onSuccess(postcode) {
     this.input.value = postcode;
     this.stopLoading();
-    logger.log('location finder usage: success');
   }
 
   removeErrorMessage() {

--- a/app/assets/javascript/lib/events.js
+++ b/app/assets/javascript/lib/events.js
@@ -1,5 +1,4 @@
 import axios from 'axios';
-import logger from './logging';
 
 const EVENTS_ENDPOINT = '/api/events';
 
@@ -15,9 +14,7 @@ export const triggerEvent = (type, data) => {
   return new Promise((resolve) => {
     axios.post(EVENTS_ENDPOINT, { type, data }, { headers })
       .then(resolve)
-      .catch((error) => {
-        logger.log(`Event trigger request: ${error}`);
-
+      .catch(() => {
         // Events are not mission-critical: always resolve regardless of outcome
         resolve();
       });


### PR DESCRIPTION
no ticket

remove useless logs from API request errors. they provide nothing useful and the useful error info would only ever come from back end logs. keep the catch blocks in place however to silence them being reported as uncaught errors