### PR TITLE
[TEVA-4356] Amend pay package question

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -138,7 +138,7 @@ Metrics/BlockLength:
     - "app/models/concerns/indexable.rb"
 
 Metrics/ClassLength:
-  Max: 167 # Default 100
+  Max: 174 # Default 100
 
 Metrics/CyclomaticComplexity:
   Max: 18 # Default 7

--- a/app/controllers/api/markers_controller.rb
+++ b/app/controllers/api/markers_controller.rb
@@ -49,6 +49,8 @@ class Api::MarkersController < Api::ApplicationController
 
     [
       { label: t("jobs.annual_salary"), value: vacancy.salary },
+      { label: t("jobs.actual_salary"), value: vacancy.actual_salary },
+      { label: t("jobs.pay_scale"), value: vacancy.pay_scale },
       { label: t("jobs.school_type"), value: organisation_type(organisation) },
       { label: t("jobs.working_patterns"), value: VacancyPresenter.new(vacancy).readable_working_patterns_with_details },
       { label: t("jobs.expires_at"), value: format_time_to_datetime_at(vacancy.expires_at) },

--- a/app/controllers/concerns/publishers/wizardable.rb
+++ b/app/controllers/concerns/publishers/wizardable.rb
@@ -4,6 +4,7 @@ module Publishers::Wizardable
     education_phases: %i[phases],
     job_details: %i[subjects key_stages],
     working_patterns: %i[working_patterns],
+    pay_package: %i[salary_types],
   }.freeze
 
   private
@@ -48,7 +49,7 @@ module Publishers::Wizardable
 
   def pay_package_params(params)
     params.require(:publishers_job_listing_pay_package_form)
-          .permit(:actual_salary, :salary, :benefits)
+          .permit(:actual_salary, :benefits, :benefits_details, :salary, :pay_scale, salary_types: [])
           .merge(completed_steps: completed_steps)
   end
 

--- a/app/form_models/publishers/job_listing/pay_package_form.rb
+++ b/app/form_models/publishers/job_listing/pay_package_form.rb
@@ -1,19 +1,32 @@
 class Publishers::JobListing::PayPackageForm < Publishers::JobListing::VacancyForm
   include ActionView::Helpers::SanitizeHelper
 
-  validates :salary, presence: true
-  validates :salary, length: { minimum: 1, maximum: 256 }, if: proc { salary.present? }
-  validate :salary_has_no_tags?, if: proc { salary.present? }
+  SALARIES = {
+    salary: "full_time",
+    actual_salary: "part_time",
+    pay_scale: "pay_scale",
+  }.freeze
+
+  validate :salary_presence
+  SALARIES.each do |key, value|
+    validates key, presence: true, length: { minimum: 1, maximum: 256 }, if: -> { params[:salary_types]&.include?(value) }
+  end
+  validates :benefits, inclusion: { in: [true, false, "true", "false"] }
+  validates :benefits_details, presence: true, length: { minimum: 1, maximum: 256 }, if: -> { benefits == "true" }
 
   def self.fields
-    %i[actual_salary salary benefits]
+    %i[actual_salary salary pay_scale benefits benefits_details salary_types]
   end
   attr_accessor(*fields)
 
-  def salary_has_no_tags?
-    salary_without_escaped_characters = salary.delete("&")
-    return if salary_without_escaped_characters == sanitize(salary_without_escaped_characters, tags: [])
+  def params_to_save
+    SALARIES.each { |salary, salary_type| params[salary] = nil unless params[:salary_types]&.include? salary_type }
+    params.except(:salary_types)
+  end
 
-    errors.add(:salary, I18n.t("pay_package_errors.salary.invalid_characters"))
+  private
+
+  def salary_presence
+    errors.add(:salary_types) if params[:salary_types].blank? || salary_types.none?
   end
 end

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -17,20 +17,21 @@ module VacanciesHelper
     "#{'Error: ' if vacancy.errors.present? && show_errors}#{page_title}"
   end
 
-  def salary_label(vacancy)
-    vacancy.actual_salary? ? t("jobs.annual_salary") : t("jobs.salary")
-  end
-
-  def salary_value(vacancy)
-    safe_join [vacancy.salary, actual_salary(vacancy)]
-  end
-
   def actual_salary(vacancy)
     return unless vacancy.actual_salary?
 
     [
       tag.div(t("jobs.actual_salary"), class: "govuk-hint govuk-!-margin-bottom-0 govuk-!-margin-top-1 govuk-!-font-size-16"),
       vacancy.actual_salary,
+    ]
+  end
+
+  def pay_scale(vacancy)
+    return unless vacancy.pay_scale?
+
+    [
+      tag.div(t("jobs.pay_scale"), class: "govuk-hint govuk-!-margin-bottom-0 govuk-!-margin-top-1 govuk-!-font-size-16"),
+      vacancy.pay_scale,
     ]
   end
 

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -195,6 +195,14 @@ class Vacancy < ApplicationRecord
     end
   end
 
+  def salary_types
+    [
+      salary.present? ? "full_time" : nil,
+      actual_salary.present? ? "part_time" : nil,
+      pay_scale.present? ? "pay_scale" : nil,
+    ]
+  end
+
   private
 
   def slug_candidates

--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -19,8 +19,8 @@ class VacancyPresenter < BasePresenter
     simple_format(fix_bullet_points(model.how_to_apply)) if model.how_to_apply.present?
   end
 
-  def benefits
-    simple_format(fix_bullet_points(model.benefits)) if model.benefits.present?
+  def benefits_details
+    simple_format(fix_bullet_points(model.benefits_details)) if model.benefits_details.present?
   end
 
   # TODO: Working Patterns: Remove this once all vacancies with legacy working patterns & working_pattern_details have expired

--- a/app/views/api/vacancies/_show.json.jbuilder
+++ b/app/views/api/vacancies/_show.json.jbuilder
@@ -3,6 +3,7 @@ json.set! "@type", "JobPosting"
 
 json.title vacancy.job_title
 json.jobBenefits vacancy.benefits
+json.jobBenefitsDetails vacancy.benefits_details
 json.datePosted vacancy.publish_on.to_time.iso8601
 json.description vacancy.job_advert
 json.occupationalCategory vacancy.job_role

--- a/app/views/publishers/vacancies/_vacancy_review_sections.html.slim
+++ b/app/views/publishers/vacancies/_vacancy_review_sections.html.slim
@@ -36,16 +36,46 @@
     - s.row :working_patterns_details
   - else
     = govuk_summary_list do |summary_list|
-        - summary_list.row do |row|
-          - row.key
-            h4.govuk-heading-s = t("jobs.working_patterns")
-          - row.value
-            ul.govuk-list = vacancy_working_patterns(vacancy)
+      - summary_list.row do |row|
+        - row.key
+          h4.govuk-heading-s = t("jobs.working_patterns")
+        - row.value
+          ul.govuk-list = vacancy_working_patterns(vacancy)
 
-- r.section :pay_package do |s|
-  - s.row :salary
-  - s.row :actual_salary, optional: true unless vacancy.working_patterns == ["full_time"]
-  - s.row :benefits, optional: true
+- r.section :pay_package do
+  = govuk_summary_list do |summary_list|
+    - summary_list.row do |row|
+      - row.key
+        h4.govuk-heading-s = t("jobs.salary_details")
+      - row.value
+        ul.govuk-list
+          - if vacancy.salary?
+            li class="govuk-!-margin-bottom-4"
+              div => "#{t('jobs.annual_salary')}:"
+              = vacancy.salary
+          - if vacancy.actual_salary?
+            li class="govuk-!-margin-bottom-4"
+              div => "#{t('jobs.actual_salary')}:"
+              = vacancy.actual_salary
+          - if vacancy.pay_scale?
+            li class="govuk-!-margin-bottom-4"
+              div => "#{t('jobs.pay_scale')}:"
+              = vacancy.pay_scale
+
+    - summary_list.row do |row|
+      - row.key
+        h4.govuk-heading-s class="govuk-!-margin-bottom-0"
+          = t("jobs.benefits")
+      - row.value
+        = vacancy.benefits? ? "Yes" : "No"
+
+    - if vacancy.benefits?
+      - summary_list.row do |row|
+        - row.key
+          h4.govuk-heading-s class="govuk-!-margin-bottom-0"
+            = t("jobs.benefits_details")
+        - row.value
+          = vacancy.benefits_details
 
 - r.section :important_dates do |s|
   - s.row :publish_on,

--- a/app/views/publishers/vacancies/build/pay_package.html.slim
+++ b/app/views/publishers/vacancies/build/pay_package.html.slim
@@ -9,11 +9,21 @@
 
       h2.govuk-heading-l = t("publishers.vacancies.steps.pay_package")
 
-      = f.govuk_text_field :salary, label: { size: "s" }, required: true
-      - unless vacancy.working_patterns == ["full_time"]
-        = f.govuk_text_field :actual_salary, label: { size: "s" }
+      = f.govuk_check_boxes_fieldset :salary_types, legend: { size: "m" } do
+        = f.govuk_check_box :salary_types, "full_time", link_errors: true do
+          = f.govuk_text_field :salary, label: { size: "s" }
 
-      = f.govuk_text_area :benefits, label: { size: "s", id: "benefits-label" }
+        - if vacancy.working_patterns.include? "part_time"
+          = f.govuk_check_box :salary_types, "part_time" do
+            = f.govuk_text_field :actual_salary, label: { size: "s" }
+
+        = f.govuk_check_box :salary_types, "pay_scale" do
+          = f.govuk_text_field :pay_scale, label: { size: "s" }
+
+      = f.govuk_radio_buttons_fieldset :benefits, legend: { size: "m" } do
+        = f.govuk_radio_button :benefits, "true" do
+          = f.govuk_text_field :benefits_details, label: { size: "s" }
+        = f.govuk_radio_button :benefits, "false", link_errors: true
 
       = render "publishers/vacancies/vacancy_form_partials/submit", f: f
 

--- a/app/views/vacancies/listing/_job_details.html.slim
+++ b/app/views/vacancies/listing/_job_details.html.slim
@@ -30,29 +30,32 @@ section#job-details class="govuk-!-margin-bottom-5"
           h3.govuk-heading-s class="govuk-!-margin-bottom-0" = t("jobs.contract_type")
         - row.value text: vacancy.contract_type_with_duration
 
-    - if vacancy.actual_salary?
+    - if vacancy.salary?
       - summary_list.row do |row|
         - row.key do
           h3.govuk-heading-s class="govuk-!-margin-bottom-0" = t("jobs.annual_salary")
         - row.value text: vacancy.salary
 
+    - if vacancy.actual_salary?
       - summary_list.row do |row|
         - row.key do
           h3.govuk-heading-s class="govuk-!-margin-bottom-0" = t("jobs.actual_salary")
         - row.value text: vacancy.actual_salary
 
-    - else
+    - if vacancy.pay_scale?
       - summary_list.row do |row|
         - row.key do
-          h3.govuk-heading-s class="govuk-!-margin-bottom-0" = t("jobs.salary")
-        - row.value text: vacancy.salary
+          h3.govuk-heading-s class="govuk-!-margin-bottom-0" = t("jobs.pay_scale")
+        - row.value text: vacancy.pay_scale
+
+    - if vacancy.benefits_details.present?
+      - summary_list.row do |row|
+        - row.key do
+          h3.govuk-heading-s class="govuk-!-margin-bottom-0" = t("jobs.benefits_details")
+        - row.value text: vacancy.benefits_details
 
   h2.govuk-heading-m = t("jobs.job_summary", job_title: vacancy.job_title)
   == vacancy.job_advert
-
-  - if vacancy.benefits.present?
-    h4.govuk-heading-m = t("jobs.benefits")
-    p.govuk-body = vacancy.benefits
 
   - if vacancy.expires_at.future?
     - if vacancy.enable_job_applications?

--- a/app/views/vacancies/search/_results.html.slim
+++ b/app/views/vacancies/search/_results.html.slim
@@ -5,9 +5,18 @@ ul.search-results role="list"
         = results_link(vacancy, class: "view-vacancy-link")
       p.govuk-body
         = vacancy_full_job_location(vacancy)
-      dl
-        dt class="govuk-!-font-weight-bold" = salary_label(vacancy)
-        dd = salary_value(vacancy)
+      - if vacancy.salary?
+        dl
+          dt class="govuk-!-font-weight-bold" = t("jobs.annual_salary")
+          dd = vacancy.salary
+      - if vacancy.actual_salary?
+        dl
+          dt class="govuk-!-font-weight-bold" = t("jobs.actual_salary")
+          dd = vacancy.actual_salary
+      - if vacancy.pay_scale?
+        dl
+          dt class="govuk-!-font-weight-bold" = t("jobs.pay_scale")
+          dd = vacancy.pay_scale
       dl
         dt class="govuk-!-font-weight-bold" = organisation_type_label(vacancy)
         dd = organisation_type_value(vacancy)

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -281,6 +281,7 @@ shared:
     - slug
     - job_advert
     - benefits
+    - benefits_details
     - starts_on
     - contact_email
     - status

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -133,10 +133,24 @@ en:
       blank: Select a working pattern
       inclusion: Select a working pattern
   pay_package_errors: &pay_package_errors
+    actual_salary:
+      blank: Enter actual salary
+      too_long: Actual salary must not be more than %{count} characters
+      invalid_characters: Actual salary must not contain any HTML tags
+    benefits:
+      inclusion: Select yes if you want to include additional allowances
+    benefits_details:
+      blank: Enter additional allowances
+    pay_scale:
+      blank: Enter pay scale
+      too_long: Pay scale must not be more than %{count} characters
+      invalid_characters: Pay scale must not contain any HTML tags
     salary:
-      blank: Enter a salary
+      blank: Enter full-time salary
       too_long: Salary must not be more than %{count} characters
       invalid_characters: Salary must not contain any HTML tags
+    salary_types:
+      invalid: Select salary details
   important_dates_errors: &important_dates_errors
     expires_at:
       after: The closing date must be after the date the job will be listed

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -249,10 +249,11 @@ en:
           You should cover what the role is and who you're looking to recruit.
           The first 20 to 40 words will be shown in search results, so make them stand out.
       publishers_job_listing_pay_package_form:
-        actual_salary: For part time or term time roles this is what the candidate will actually be paid
-        benefits: >-
-          Include special educational needs (SEN) allowances and teaching and learning responsibility (TLR) payments,
-          for example
+        benefits: For example, special educational needs (SEN) or teaching and learning responsibility (TLR) payments
+        salary_types: Select all that apply
+        salary_types_options:
+          full_time: This is what the annual salary would be for someone working full time
+          part_time: This is the annual amount someone will take home
       publishers_job_listing_schools_form:
         add_school: Add a school to your account
         edit_schools: "Can't see the school you are looking for?"
@@ -627,9 +628,17 @@ en:
         about_organisation: About %{organisation}
         job_advert: Job advert
       publishers_job_listing_pay_package_form:
-        actual_salary_html: Actual salary (optional<span class='govuk-visually-hidden'> field</span>)</span>
-        benefits_html: Additional allowances (optional<span class='govuk-visually-hidden'> field</span>)</span>
-        salary: Annual or full time equivalent (FTE) salary
+        actual_salary: Actual salary
+        benefits_details: Additional allowances
+        benefits_options:
+          false: "No"
+          true: "Yes"
+        pay_scale: Pay scale
+        salary: Full-time equivalent salary
+        salary_types_options:
+          full_time: Full-time equivalent salary
+          part_time: Actual salary
+          pay_scale: Pay scale
       publishers_job_listing_working_patterns_form:
         full_time_details: Details
         part_time_details: Details
@@ -767,6 +776,9 @@ en:
         ect_status: Is this role suitable for an early career teacher (ECT)?
       publishers_job_listing_schools_form:
         organisations: Locations where the job is based
+      publishers_job_listing_pay_package_form:
+        salary_types: Salary details
+        benefits: Do you want to include additional allowances?
       publishers_job_listing_working_patterns_form:
         working_patterns: Working patterns
       subscription:

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -201,9 +201,12 @@ en:
     contract_type: Contract type
 
     actual_salary: Actual salary
-    annual_salary: Annual or full time equivalent salary
+    annual_salary: Full-time equivalent salary
+    benefits: Do you want to include additional allowances?
+    benefits_details: Additional allowances
+    pay_scale: Pay scale
     salary: Salary
-    benefits: Additional allowances
+    salary_details: Salary details
 
     school_visits_html: School visits
     trust_visits_html: Trust visits

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -191,7 +191,7 @@ en:
         job_summary:
           step_title: Job summary
         pay_package:
-          step_title: Pay package
+          step_title: Salary and allowances
         review:
           step_title: Review the job listing
         working_patterns:
@@ -310,7 +310,7 @@ en:
         education_phases: Job details
         job_details: Job details
         working_patterns: Working pattern
-        pay_package: Pay package
+        pay_package: Salary and allowances
         important_dates: Important dates and deadlines
         documents: Supporting documents
         applying_for_the_job: Applying for the job

--- a/db/migrate/20220804150101_add_pay_scale_to_vacancies.rb
+++ b/db/migrate/20220804150101_add_pay_scale_to_vacancies.rb
@@ -1,0 +1,5 @@
+class AddPayScaleToVacancies < ActiveRecord::Migration[7.0]
+  def change
+    add_column :vacancies, :pay_scale, :string
+  end
+end

--- a/db/migrate/20220805104147_rename_benefits_to_benefits_details.rb
+++ b/db/migrate/20220805104147_rename_benefits_to_benefits_details.rb
@@ -1,0 +1,5 @@
+class RenameBenefitsToBenefitsDetails < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :vacancies, :benefits, :benefits_details
+  end
+end

--- a/db/migrate/20220805104356_add_benefits_to_vacancies.rb
+++ b/db/migrate/20220805104356_add_benefits_to_vacancies.rb
@@ -1,0 +1,5 @@
+class AddBenefitsToVacancies < ActiveRecord::Migration[7.0]
+  def change
+    add_column :vacancies, :benefits, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -474,7 +474,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_12_123147) do
     t.string "job_title"
     t.string "slug", null: false
     t.text "job_advert"
-    t.text "benefits"
+    t.text "benefits_details"
     t.date "starts_on"
     t.string "contact_email"
     t.integer "status"
@@ -522,6 +522,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_12_123147) do
     t.integer "phases", array: true
     t.text "full_time_details"
     t.text "part_time_details"
+    t.string "pay_scale"
+    t.boolean "benefits"
     t.index ["expires_at"], name: "index_vacancies_on_expires_at"
     t.index ["geolocation"], name: "index_vacancies_on_geolocation", using: :gist
     t.index ["publish_on"], name: "index_vacancies_on_publish_on"

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -17,7 +17,8 @@ FactoryBot.define do
     about_school { Faker::Lorem.paragraph(sentence_count: factory_rand(5..10)) }
     actual_salary { factory_rand(20_000..100_000) }
     enable_job_applications { true }
-    benefits { Faker::Lorem.paragraph(sentence_count: factory_rand(1..3)) }
+    benefits { true }
+    benefits_details { Faker::Lorem.paragraph(sentence_count: factory_rand(1..3)) }
     completed_steps do
       %w[job_role job_role_details job_location job_details working_patterns pay_package important_dates documents applying_for_the_job job_summary]
     end
@@ -33,6 +34,7 @@ FactoryBot.define do
     listed_elsewhere { nil }
     job_role { factory_sample(Vacancy.job_roles.keys) }
     ect_status { factory_sample(Vacancy.ect_statuses.keys) if job_role == "teacher" }
+    pay_scale { factory_sample(SALARIES) }
     personal_statement_guidance { Faker::Lorem.paragraph(sentence_count: factory_rand(5..10)) }
     publish_on { Date.current }
     salary { factory_sample(SALARIES) }

--- a/spec/form_models/publishers/job_listing/pay_package_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/pay_package_form_spec.rb
@@ -1,8 +1,47 @@
 require "rails_helper"
 
+SALARIES = {
+  salary: "full_time",
+  actual_salary: "part_time",
+  pay_scale: "pay_scale",
+}.freeze
+
 RSpec.describe Publishers::JobListing::PayPackageForm, type: :model do
-  it { is_expected.to validate_presence_of(:salary) }
-  it { is_expected.to validate_length_of(:salary).is_at_most(256) }
-  it { is_expected.to allow_value("Job &amp; another job").for(:salary) }
-  it { is_expected.not_to allow_value("Title with <p>tags</p>").for(:salary).with_message(I18n.t("pay_package_errors.salary.invalid_characters")) }
+  subject { described_class.new(params, vacancy) }
+
+  let(:vacancy) do
+    build_stubbed(:vacancy,
+                  salary: nil,
+                  actual_salary: nil,
+                  pay_scale: nil)
+  end
+
+  SALARIES.each do |salary_value, salary_type|
+    context "when only #{salary_type} salary is selected" do
+      let(:params) { { salary_types: [salary_type], benefits: "false" } }
+
+      it { is_expected.to validate_presence_of(salary_value) }
+      it { is_expected.to validate_length_of(salary_value).is_at_least(1).is_at_most(256) }
+      it { is_expected.to validate_inclusion_of(:benefits).in_array([true, false, "true", "false"]) }
+
+      (SALARIES.keys - [salary_value]).each do |other_salary_type|
+        it { is_expected.not_to validate_presence_of(other_salary_type) }
+      end
+    end
+  end
+
+  context "when there are no benefits" do
+    let(:params) { { salary_types: nil, benefits: "false" } }
+
+    it { is_expected.to validate_inclusion_of(:benefits).in_array([true, false, "true", "false"]) }
+    it { is_expected.not_to validate_presence_of(:benefits_details) }
+  end
+
+  context "when there are benefits" do
+    let(:params) { { salary_types: nil, benefits: "true" } }
+
+    it { is_expected.to validate_inclusion_of(:benefits).in_array([true, false, "true", "false"]) }
+    it { is_expected.to validate_presence_of(:benefits_details) }
+    it { is_expected.to validate_length_of(:benefits_details).is_at_least(1).is_at_most(256) }
+  end
 end

--- a/spec/presenters/vacancy_presenter_spec.rb
+++ b/spec/presenters/vacancy_presenter_spec.rb
@@ -138,8 +138,8 @@ RSpec.describe VacancyPresenter do
     it_behaves_like "a fields that outputs the correct HTML", :how_to_apply
   end
 
-  describe "#benefits" do
-    it_behaves_like "a fields that outputs the correct HTML", :benefits
+  describe "#benefits_details" do
+    it_behaves_like "a fields that outputs the correct HTML", :benefits_details
   end
 
   # TODO: Working Patterns: Remove this test once all vacancies with legacy working patterns & working_pattern_details have expired

--- a/spec/requests/api/markers_spec.rb
+++ b/spec/requests/api/markers_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe "Api::Markers" do
 
     context "when marker_type is vacancy" do
       it "returns the JSON marker" do
+        number_of_salary_fields_set = number_of_salary_fields_set(vacancy)
+
         subject
         expect(json).to include(heading_text: vacancy.job_title)
         expect(json).to include(heading_url: job_path(vacancy))
@@ -38,7 +40,15 @@ RSpec.describe "Api::Markers" do
         expect(json).to include(anonymised_id: StringAnonymiser.new(vacancy.id).to_s)
         expect(json).to include(address: full_address(organisation))
         expect(json).to include(description: nil)
-        expect(json[:details].size).to be 4
+
+        case number_of_salary_fields_set
+        when 6
+          expect(json[:details].size).to be 6
+        when 5
+          expect(json[:details].size).to be 5
+        when 4
+          expect(json[:details].size).to be 4
+        end
       end
     end
 
@@ -63,6 +73,10 @@ RSpec.describe "Api::Markers" do
         expect(response).to have_http_status(:bad_request)
         expect(json[:error]).to eq("Missing params")
       end
+    end
+
+    def number_of_salary_fields_set(vacancy)
+      [vacancy.salary, vacancy.actual_salary, vacancy.pay_scale].compact_blank.count
     end
   end
 end

--- a/spec/support/shared_examples/system/editing_a_draft_vacancy.rb
+++ b/spec/support/shared_examples/system/editing_a_draft_vacancy.rb
@@ -10,13 +10,13 @@ RSpec.shared_examples "provides an overview of the draft vacancy form" do
   before do
     # Create a "not started" group
     vacancy.update(
-      salary: nil,
-      benefits: nil,
-      completed_steps: vacancy.completed_steps - %w[pay_package],
+      publish_on: nil,
+      expires_at: nil,
+      completed_steps: vacancy.completed_steps - %w[important_dates],
     )
 
     # Create an "action required" group
-    vacancy.update(working_patterns: nil)
+    vacancy.update(job_advert: nil)
 
     visit organisation_path(organisation)
     click_on "Draft jobs"
@@ -29,14 +29,16 @@ RSpec.shared_examples "provides an overview of the draft vacancy form" do
 
   it "shows the status of each stage" do
     top_level_steps = step_process.step_groups.keys - %i[documents review]
-    completed_steps = top_level_steps - %i[pay_package working_patterns]
+    invalid_steps = %i[job_summary]
+    incomplete_steps = %i[important_dates]
+    completed_and_valid_steps = top_level_steps - invalid_steps - incomplete_steps
 
-    completed_steps.each do |step_name|
+    completed_and_valid_steps.each do |step_name|
       expect(page).to have_step_status(step_name, status: "complete")
     end
 
-    expect(page).to have_step_status(:pay_package, status: "not started")
-    expect(page).to have_step_status(:working_patterns, status: "action required")
+    expect(page).to have_step_status(:important_dates, status: "not started")
+    expect(page).to have_step_status(:job_summary, status: "action required")
   end
 
   it "shows the overview without errors when updating a section" do
@@ -47,7 +49,7 @@ RSpec.shared_examples "provides an overview of the draft vacancy form" do
     click_on "Update listing"
 
     expect(page).to have_css("h1", text: "Manage draft listing")
-    expect(page).not_to have_link("Enter a salary")
+    expect(page).not_to have_link("Select yes if you want to include additional allowances")
   end
 
   context "when incomplete and submitted for publication" do
@@ -58,13 +60,13 @@ RSpec.shared_examples "provides an overview of the draft vacancy form" do
 
     it "provides top-of-page validation errors which link to the relevant form parts" do
       within ".govuk-error-summary" do
-        expect(page).to have_link("Enter a salary", href: organisation_job_build_path(job_id: vacancy.id, id: "pay_package", back_to: "manage_draft"))
+        expect(page).to have_link("Enter a job advert", href: organisation_job_build_path(job_id: vacancy.id, id: "job_summary", back_to: "manage_draft"))
       end
     end
 
     it "provides inline validation errors which link to the relevant form parts" do
-      within "#pay_package .inset-text--error" do
-        expect(page).to have_link("Enter a salary", href: organisation_job_build_path(job_id: vacancy.id, id: "pay_package", back_to: "manage_draft"))
+      within "#job_summary .inset-text--error" do
+        expect(page).to have_link("Enter a job advert", href: organisation_job_build_path(job_id: vacancy.id, id: "job_summary", back_to: "manage_draft"))
       end
     end
   end
@@ -77,34 +79,34 @@ RSpec.shared_examples "provides an overview of the draft vacancy form" do
 
     it "provides top-of-page validation errors which link to the relevant form parts" do
       within ".govuk-error-summary" do
-        expect(page).to have_link("Enter a salary", href: organisation_job_build_path(job_id: vacancy.id, id: "pay_package", back_to: "manage_draft"))
+        expect(page).to have_link("Enter a job advert", href: organisation_job_build_path(job_id: vacancy.id, id: "job_summary", back_to: "manage_draft"))
       end
     end
 
     it "provides inline validation errors which link to the relevant form parts" do
-      within "#pay_package .inset-text--error" do
-        expect(page).to have_link("Enter a salary", href: organisation_job_build_path(job_id: vacancy.id, id: "pay_package", back_to: "manage_draft"))
+      within "#job_summary .inset-text--error" do
+        expect(page).to have_link("Enter a job advert", href: organisation_job_build_path(job_id: vacancy.id, id: "job_summary", back_to: "manage_draft"))
       end
     end
   end
 
   context "when completed and submitted" do
     before do
+      vacancy.update(publish_on: Date.current, expires_at: 2.weeks.from_now)
       click_on "Confirm and submit job"
       expect(vacancy).not_to be_published
 
-      within "#pay_package" do
-        click_on "Enter a salary"
+      within "#job_summary" do
+        click_on "Enter a job advert"
       end
 
-      fill_in "Annual or full time equivalent (FTE) salary", with: "£60,000"
+      fill_in "Job advert", with: "It's not a bad place to work"
       click_on "Update listing"
 
       click_on "Confirm and submit job"
 
-      click_on "Select a working pattern"
-
-      check "Full time"
+      click_on "Choose the time the application is due from the options provided"
+      choose "9am"
       click_on "Update listing"
 
       click_on "Confirm and submit job"
@@ -117,21 +119,21 @@ RSpec.shared_examples "provides an overview of the draft vacancy form" do
 
   context "when completed and previewed" do
     before do
+      vacancy.update(publish_on: Date.current, expires_at: 2.weeks.from_now)
       click_on "Preview job listing"
       expect(page).not_to have_text("Preview of ‘#{vacancy.job_title}’")
 
-      within "#pay_package" do
-        click_on "Enter a salary"
+      within "#job_summary" do
+        click_on "Enter a job advert"
       end
 
-      fill_in "Annual or full time equivalent (FTE) salary", with: "£60,000"
+      fill_in "Job advert", with: "It's not a bad place to work"
       click_on "Update listing"
 
       click_on "Preview job listing"
 
-      click_on "Select a working pattern"
-
-      check "Full time"
+      click_on "Choose the time the application is due from the options provided"
+      choose "9am"
       click_on "Update listing"
 
       click_on "Preview job listing"

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -56,9 +56,19 @@ module VacancyHelpers
   end
 
   def fill_in_pay_package_form_fields(vacancy)
+    check I18n.t("helpers.label.publishers_job_listing_pay_package_form.salary_types_options.full_time")
     fill_in "publishers_job_listing_pay_package_form[salary]", with: vacancy.salary
-    fill_in "publishers_job_listing_pay_package_form[actual_salary]", with: vacancy.actual_salary unless vacancy.working_patterns == ["full_time"]
-    fill_in "publishers_job_listing_pay_package_form[benefits]", with: vacancy.benefits
+
+    if vacancy.working_patterns.include? "part_time"
+      check I18n.t("helpers.label.publishers_job_listing_pay_package_form.salary_types_options.part_time")
+      fill_in "publishers_job_listing_pay_package_form[actual_salary]", with: vacancy.actual_salary
+    end
+
+    check I18n.t("helpers.label.publishers_job_listing_pay_package_form.salary_types_options.pay_scale")
+    fill_in "publishers_job_listing_pay_package_form[pay_scale]", with: vacancy.pay_scale
+
+    choose I18n.t("helpers.label.publishers_job_listing_pay_package_form.benefits_options.true")
+    fill_in "publishers_job_listing_pay_package_form[benefits_details]", with: vacancy.benefits_details
   end
 
   def fill_in_important_dates_fields(vacancy)
@@ -163,7 +173,7 @@ module VacancyHelpers
     expect(page).to have_content(vacancy.part_time_details) if vacancy.working_patterns.include?("part_time")
 
     expect(page).to have_content(vacancy.salary)
-    expect(page.html).to include(vacancy.benefits)
+    expect(page.html).to include(vacancy.benefits_details)
 
     expect(page).to have_content(vacancy.publish_on.to_formatted_s.strip)
     expect(page).to have_content(vacancy.expires_at.to_date.to_formatted_s.strip)
@@ -199,7 +209,7 @@ module VacancyHelpers
     expect(page).to have_content(vacancy.readable_working_patterns)
 
     expect(page).to have_content(vacancy.salary)
-    expect(page.html).to include(vacancy.benefits)
+    expect(page.html).to include(vacancy.benefits_details)
 
     expect(page).to have_content(vacancy.publish_on.to_formatted_s.strip)
     expect(page).to have_content(vacancy.expires_at.to_date.to_formatted_s.strip)
@@ -234,6 +244,7 @@ module VacancyHelpers
       "@type": "JobPosting",
       title: vacancy.job_title,
       jobBenefits: vacancy.benefits,
+      jobBenefitsDetails: vacancy.benefits_details,
       datePosted: vacancy.publish_on.to_time.iso8601,
       description: vacancy.job_advert,
       occupationalCategory: vacancy.job_role,

--- a/spec/system/publishers_can_edit_a_published_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers_can_edit_a_published_vacancy_as_a_school_spec.rb
@@ -113,7 +113,8 @@ RSpec.describe "Publishers can edit a vacancy" do
         fill_in "publishers_job_listing_pay_package_form[salary]", with: ""
         click_on I18n.t("buttons.update_job")
 
-        within_row_for(text: I18n.t("helpers.label.publishers_job_listing_pay_package_form.salary")) do
+        within_row_for(text: I18n.t("helpers.label.publishers_job_listing_pay_package_form.salary"),
+                       element: ".govuk-checkboxes__label") do
           expect(page).to have_content(I18n.t("pay_package_errors.salary.blank"))
         end
       end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-4356

## Changes in this PR:

This PR makes changes to the "Pay package" question of the vacancy listing process.

- There are now three salary checkboxes; one for each salary "type" that the user would like to add. At least one salary type must be provided by the user, and they can provide all three if they wish. The "Actual salary" checkbox is only shown if a user has selected "Part-time" as a working pattern.

- The "additional allowances" text field (previously saved as `benefits` in the database) is now only shown if the user selects "Yes" on the new radio button question asking if there are any. The `benefits` field has been renamed to `benefits_details` and a new boolean field `benefits` has been added, which stores the user's response to the Yes/No radio button question.

## Screenshots of UI changes:

### Before
![image](https://user-images.githubusercontent.com/24639777/184618380-1b116846-f2c4-4494-943c-7cd79416cb81.png)

### After
![image](https://user-images.githubusercontent.com/24639777/184618083-8867c4e0-99d1-49c2-9aad-e8854ff91e0a.png)

## Next steps:

- [ ] Run a job to set the new boolean field `benefits` to the correct value for existing vacancies.
- [ ] Update guidance in `creating-the-perfect-teacher-job-advert.md`

