### PR TITLE
[TEVA-4378] add addressCountry to google job schema

### DIFF
--- a/app/views/api/vacancies/_show.json.jbuilder
+++ b/app/views/api/vacancies/_show.json.jbuilder
@@ -19,6 +19,7 @@ json.jobLocation do
     json.addressRegion vacancy.organisation&.region
     json.streetAddress vacancy.organisation&.address
     json.postalCode vacancy.organisation&.postcode
+    json.addressCountry "GB"
   end
 end
 

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -243,6 +243,7 @@ module VacancyHelpers
           addressRegion: vacancy.organisation.region,
           streetAddress: vacancy.organisation.address,
           postalCode: vacancy.organisation.postcode,
+          addressCountry: "GB",
         },
       },
       url: job_url(vacancy),


### PR DESCRIPTION
this field has been id'd as missing/now needed as part of google job schema

https://dfedigital.atlassian.net/browse/TEVA-4378
