### PR TITLE
Update Terraform StatusCake provider to 2.0.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ dump.rdb
 # Propshaft asset pipeline folders
 /app/assets/builds/*
 !/app/assets/builds/.keep
+
+# Visual Studio Code
+.vscode

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,4 @@
 ruby 3.1.2
 nodejs 18.4.0
 yarn 1.22.17
+terraform 1.0.8

--- a/terraform/app/modules/statuscake/main.tf
+++ b/terraform/app/modules/statuscake/main.tf
@@ -1,13 +1,76 @@
-resource "statuscake_test" "alert" {
-  for_each       = var.statuscake_alerts
-  website_name   = each.value.website_name
-  website_url    = each.value.website_url
-  test_type      = "HTTP"
-  check_rate     = 30
-  contact_group  = each.value.contact_group
+resource "statuscake_uptime_check" "alert" {
+  for_each = var.statuscake_alerts
+
+  name           = each.value.website_name
+  contact_groups = each.value.contact_group
+  confirmation   = 1
   trigger_rate   = 0
-  find_string    = lookup(each.value, "find_string", null)
-  do_not_find    = lookup(each.value, "do_not_find", false)
-  confirmations  = 1
-  node_locations = ["EC1", "MAN1", "DUB2"]
+  check_interval = 30
+  regions        = ["london", "dublin"]
+
+  http_check {
+    follow_redirects = true
+    timeout          = 40
+    request_method   = "HTTP"
+    status_codes = [
+      "204",
+      "205",
+      "206",
+      "303",
+      "400",
+      "401",
+      "403",
+      "404",
+      "405",
+      "406",
+      "408",
+      "410",
+      "413",
+      "444",
+      "429",
+      "494",
+      "495",
+      "496",
+      "499",
+      "500",
+      "501",
+      "502",
+      "503",
+      "504",
+      "505",
+      "506",
+      "507",
+      "508",
+      "509",
+      "510",
+      "511",
+      "521",
+      "522",
+      "523",
+      "524",
+      "520",
+      "598",
+      "599"
+    ]
+
+    dynamic "content_matchers" {
+      for_each = contains(keys(each.value), "content_matchers") ? each.value.content_matchers : []
+      content {
+        content = content_matchers.value["content"]
+        matcher = content_matchers.value["matcher"]
+      }
+    }
+
+    dynamic "basic_authentication" {
+      for_each = var.statuscake_enable_basic_auth ? [1] : []
+      content {
+        username = local.application_secrets.SECURE_USERNAME
+        password = local.application_secrets.SECURE_PASSWORD
+      }
+    }
+  }
+
+  monitored_resource {
+    address = each.value.website_url
+  }
 }

--- a/terraform/app/modules/statuscake/variables.tf
+++ b/terraform/app/modules/statuscake/variables.tf
@@ -7,3 +7,8 @@ variable "service_name" {
 variable "statuscake_alerts" {
   description = "Define Statuscake alerts with the attributes below"
 }
+
+variable "statuscake_enable_basic_auth" {
+  type    = bool
+  default = false
+}

--- a/terraform/app/modules/statuscake/versions.tf
+++ b/terraform/app/modules/statuscake/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     statuscake = {
       source  = "StatusCakeDev/statuscake"
-      version = ">= 1.0.1"
+      version = "2.0.3"
     }
   }
 }

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -16,8 +16,7 @@ provider "cloudfoundry" {
 }
 
 provider "statuscake" {
-  username = local.infra_secrets.statuscake_username
-  apikey   = local.infra_secrets.statuscake_apikey
+  api_token = local.infra_secrets.statuscake_apikey
 }
 
 /*

--- a/terraform/app/versions.tf
+++ b/terraform/app/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     statuscake = {
       source  = "StatusCakeDev/statuscake"
-      version = "~> 1.0.1"
+      version = "2.0.3"
     }
   }
 }

--- a/terraform/workspace-variables/production.tfvars.json
+++ b/terraform/workspace-variables/production.tfvars.json
@@ -28,5 +28,40 @@
   "paas_worker_app_instances": 2,
   "paas_worker_app_memory": 1536,
   "parameter_store_environment": "production",
-  "region": "eu-west-2"
+  "region": "eu-west-2",
+  "statuscake_alerts": {
+    "PaaS500String": {
+      "contact_group": [
+        183741
+      ],
+      "content_matchers": [
+        {
+          "content": "500 Internal Server Error",
+          "matcher": "NOT_CONTAINS_STRING"
+        }
+      ],
+      "website_name": "Teaching Vacancies - PaaS 500 error",
+      "website_url": "https://teaching-vacancies.service.gov.uk"
+    },
+    "stringmatch": {
+      "contact_group": [
+        183741
+      ],
+      "content_matchers": [
+        {
+          "matcher": "CONTAINS_STRING",
+          "content": "create an account"
+        }
+      ],
+      "website_name": "Teaching Vacancies - homepage string",
+      "website_url": "https://teaching-vacancies.service.gov.uk"
+    },
+    "tvsprod": {
+      "contact_group": [
+        183741
+      ],
+      "website_name": "Teaching Vacancies - /check",
+      "website_url": "https://teaching-vacancies.service.gov.uk/check"
+    }
+  }
 }


### PR DESCRIPTION
Update the StatusCake provider to ensure it is not using a preview version.

## Trello ticket URL

- [Update StatusCake Terraform provider](https://trello.com/c/96qh0O74)

## Changes in this PR:

- Update StatusCake resource to be compatible with new API for version 2.0.3 of the provider

## Next steps:
- [x] Remove existing StatusCake alerts before deployment https://github.com/DFE-Digital/teaching-vacancies/pull/5378