### PR TITLE
[TEVA-4386] new summary copy and separate feedback page

### DIFF
--- a/app/components/dashboard_component/dashboard_component.html.slim
+++ b/app/components/dashboard_component/dashboard_component.html.slim
@@ -8,7 +8,7 @@
                         post_path(section: "get-help-hiring", post_name: "accepting-job-applications-on-teaching-vacancies"),
                         class: "govuk-link--no-visited-state")
       span.govuk-caption-l = @organisation.name
-      h1.govuk-heading-l = t("jobs.dashboard.#{@selected_type}.with_count_html", count: @vacancies.count)
+      h1.govuk-heading-l = t("jobs.dashboard.#{@selected_type}.with_count", count: @vacancies.count)
     .govuk-grid-column-one-quarter
       = govuk_button_to t("buttons.create_job"), organisation_jobs_path, class: "float-right"
 

--- a/app/controllers/publishers/vacancies/feedbacks_controller.rb
+++ b/app/controllers/publishers/vacancies/feedbacks_controller.rb
@@ -1,13 +1,16 @@
 class Publishers::Vacancies::FeedbacksController < Publishers::Vacancies::BaseController
+  def new
+    @feedback_form = Publishers::JobListing::FeedbackForm.new
+  end
+
   def create
-    @vacancy = VacancyPresenter.new(Vacancy.published.find(params[:job_id]))
     @feedback_form = Publishers::JobListing::FeedbackForm.new(feedback_form_params)
 
     if @feedback_form.valid?
       @feedback = Feedback.create(feedback_attributes)
-      redirect_to jobs_with_type_organisation_path(:published), success: t("messages.jobs.feedback.success")
+      redirect_to jobs_with_type_organisation_path(:published), success: t("messages.jobs.feedback.success_html")
     else
-      render "publishers/vacancies/summary"
+      render "publishers/vacancies/feedbacks/new"
     end
   end
 
@@ -18,6 +21,6 @@ class Publishers::Vacancies::FeedbacksController < Publishers::Vacancies::BaseCo
   end
 
   def feedback_attributes
-    feedback_form_params.except("report_a_problem").merge(feedback_type: "vacancy_publisher", publisher_id: current_publisher&.id, vacancy_id: @vacancy.id)
+    feedback_form_params.except("report_a_problem").merge(feedback_type: "vacancy_publisher", publisher_id: current_publisher&.id, vacancy_id: vacancy.id)
   end
 end

--- a/app/controllers/publishers/vacancies_controller.rb
+++ b/app/controllers/publishers/vacancies_controller.rb
@@ -44,9 +44,6 @@ class Publishers::VacanciesController < Publishers::Vacancies::BaseController
 
   def summary
     return redirect_to organisation_job_review_path(vacancy.id) unless vacancy.published?
-
-    @vacancy = VacancyPresenter.new(vacancy)
-    @feedback_form = Publishers::JobListing::FeedbackForm.new
   end
 
   private

--- a/app/views/publishers/vacancies/feedbacks/new.html.slim
+++ b/app/views/publishers/vacancies/feedbacks/new.html.slim
@@ -1,0 +1,24 @@
+- content_for :page_title_prefix, t(".page_title", organisation: current_organisation.name)
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    h1.govuk-heading-xl = t(".heading")
+
+    = form_for @feedback_form, url: organisation_job_feedback_path(vacancy.id) do |f|
+      = f.govuk_error_summary
+
+      = f.govuk_radio_buttons_fieldset(:report_a_problem, legend: { size: "s" }) do
+        = f.govuk_radio_button :report_a_problem, :yes, link_errors: true do
+          p.govuk-body = t("help.report_a_problem_html", get_help_link: govuk_link_to(t("help.get_help_form"), new_support_request_path))
+        = f.govuk_radio_button :report_a_problem, :no, link_errors: true
+
+      = f.govuk_collection_radio_buttons :rating, Feedback.ratings.keys, :to_s
+
+      = f.govuk_text_area :comment, label: { size: "s" }, rows: 10
+
+      = f.govuk_radio_buttons_fieldset(:user_participation_response, legend: { size: "s" }) do
+        = f.govuk_radio_button :user_participation_response, :interested, link_errors: true do
+          = f.govuk_email_field :email, value: (@feedback_form.email.presence || current_publisher.email), required: true
+        = f.govuk_radio_button :user_participation_response, :uninterested
+
+      = f.govuk_submit t("buttons.submit_feedback")

--- a/app/views/publishers/vacancies/summary.html.slim
+++ b/app/views/publishers/vacancies/summary.html.slim
@@ -2,45 +2,19 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = govuk_panel title_text: t(".success"), text: ""
-
-    h2.govuk-heading-m = t(".what_happens_next")
-
     - if @vacancy.publish_on.today?
-      p.govuk-body = t(".date_posted_now")
+      = govuk_panel title_text: t(".heading.published"), text: ""
     - else
+      = govuk_panel title_text: t(".heading.scheduled"), text: ""
       p.govuk-body = t(".date_posted", date: @vacancy.publish_on.to_formatted_s)
 
-    p.govuk-body
-      = t(".date_expires", application_deadline: format_time_to_datetime_at(@vacancy.expires_at))
+    h2.govuk-heading-m = t(".next_steps")
+    p = t(".you_can")
 
-    = govuk_button_link_to t(".view_jobs"), jobs_with_type_organisation_path(:published), class: "govuk-button--secondary"
-    = govuk_button_link_to t(".create_another_job_listing"), organisation_jobs_path, class: "govuk-button--secondary govuk-!-margin-left-3"
+    ul.govuk-list.govuk-list--bullet
+      li = govuk_link_to t(".view_listing"), job_path(@vacancy.id)
+      li = govuk_link_to t(".make_changes"), organisation_job_path(@vacancy.id)
+      li = govuk_link_to t(".manage_jobs"), jobs_with_type_organisation_path(:published)
 
-    .divider-bottom
-
-    = render "vacancies/listing/copy_vacancy_link", vacancy: @vacancy
-
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    h2.govuk-heading-m = t(".feedback.heading")
-    p.govuk-body = t(".feedback.description")
-
-    = form_for @feedback_form, url: organisation_job_feedback_path(@vacancy.id) do |f|
-      = f.govuk_error_summary
-
-      = f.govuk_radio_buttons_fieldset(:report_a_problem, legend: { size: "s" }) do
-        = f.govuk_radio_button :report_a_problem, :yes, link_errors: true do
-          p.govuk-body = t("help.report_a_problem_html", get_help_link: govuk_link_to(t("help.get_help_form"), new_support_request_path))
-        = f.govuk_radio_button :report_a_problem, :no, link_errors: true
-
-      = f.govuk_collection_radio_buttons :rating, Feedback.ratings.keys, :to_s
-
-      = f.govuk_text_area :comment, label: { size: "s" }, rows: 10
-
-      = f.govuk_radio_buttons_fieldset(:user_participation_response, legend: { size: "s" }) do
-        = f.govuk_radio_button :user_participation_response, :interested, link_errors: true do
-          = f.govuk_email_field :email, value: (@feedback_form.email.presence || current_publisher.email), required: true
-        = f.govuk_radio_button :user_participation_response, :uninterested
-
-      = f.govuk_submit t("buttons.submit_feedback")
+    h2.govuk-heading-m = t(".give_feedback")
+    p.govuk-body = t(".feedback_link_html", url: new_organisation_job_feedback_path(@vacancy.id))

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -11,13 +11,13 @@ en:
       add_or_remove_schools: Add or remove schools
       awaiting_feedback:
         tab_heading: Jobs awaiting feedback
-        with_count_html: Awaiting feedback <span class='govuk-body-l govuk-!-font-size-36'>(%{count})</span>
+        with_count: Awaiting feedback (%{count})
       draft:
         tab_heading: Draft jobs
-        with_count_html: Draft jobs <span class='govuk-body-l govuk-!-font-size-36'>(%{count})</span>
+        with_count: Draft jobs (%{count})
       expired:
         tab_heading: Closed jobs
-        with_count_html: Closed jobs <span class='govuk-body-l govuk-!-font-size-36'>(%{count})</span>
+        with_count: Closed jobs (%{count})
       how_to_accept_job_applications_guide:
         description_desktop: Find out the simplest way to get candidates to apply for your jobs.
         description_mobile: Get guidance around how to accept vacancies
@@ -25,10 +25,10 @@ en:
         title: How to accept job applications on Teaching Vacancies
       pending:
         tab_heading: Scheduled jobs
-        with_count_html: Scheduled jobs <span class='govuk-body-l govuk-!-font-size-36'>(%{count})</span>
+        with_count: Scheduled jobs (%{count})
       published:
         tab_heading: Active jobs
-        with_count_html: Active jobs <span class='govuk-body-l govuk-!-font-size-36'>(%{count})</span>
+        with_count: Active jobs (%{count})
 
     filters:
       job_filters: Job Filters

--- a/config/locales/notifications.yml
+++ b/config/locales/notifications.yml
@@ -12,7 +12,7 @@ en:
       already_published: This job has already been published
       draft_saved_html: <span class="govuk-!-font-weight-bold">Draft saved</span> for %{job_title}
       feedback:
-        success: Thank you for your feedback
+        success_html: <h2 class="govuk-heading-m">Feedback sent</h2>
       listing_updated_html: >-
         <span class="govuk-!-font-weight-bold">Listing updated</span> for %{job_title}. Back to %{link_to}.
       listing_updated_link_text: manage jobs

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -319,20 +319,26 @@ en:
       submit:
         cancel_caption: If you click cancel you will lose any unsaved information from this step. Completed details from previous steps will be saved in your draft jobs.
       summary:
-        create_another_job_listing: Create another job listing
-        date_expires: >-
-          The job listing will appear on the service until %{application_deadline}, after which it will no longer be
-          visible to jobseekers.
-        date_posted: Your job listing will be posted on %{date}.
-        date_posted_now: Your job listing has been posted.
-        feedback:
+        date_posted: Your job listing will be published on %{date}.
+        feedback_link_html: <a href="%{url}" class="govuk-link">Give feedback about this service</a> (takes 30 seconds).
+        give_feedback: Give feedback
+        heading:
+          published: Job listing published
+          scheduled: Job listing scheduled
+        make_changes: make changes to the job listing
+        manage_jobs: manage jobs
+        next_steps: Next steps
+        page_title: The job listing for %{organisation} has been completed
+        view_listing: view the job listing
+        you_can: "You can:"
+      feedbacks:
+        new:
           description: >-
             Your feedback can help us improve the service to better support you as well as schools around England.
-          heading: Have time to share some feedback?
-        page_title: The job listing for %{organisation} has been completed
-        success: The job listing has been completed
-        view_jobs: View your job listings
-        what_happens_next: What happens next
+          heading: Give feedback
+          page_title: Feedback
+          success: The job listing has been completed
+          view_jobs: View your job listings
       statistics:
         show:
           application_data: Application data

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -207,7 +207,7 @@ Rails.application.routes.draw do
       get :review
       get :summary
       resource :activity_log, only: %i[show], controller: "publishers/vacancies/activity_log"
-      resource :feedback, only: %i[create], controller: "publishers/vacancies/feedbacks"
+      resource :feedback, only: %i[new create], controller: "publishers/vacancies/feedbacks"
       resource :expired_feedback, only: %i[new create], controller: "publishers/vacancies/expired_feedbacks", path: "expired-feedback" do
         get :submitted
       end

--- a/spec/system/publishers_can_copy_a_vacancy_spec.rb
+++ b/spec/system/publishers_can_copy_a_vacancy_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Copying a vacancy" do
     end
     click_on I18n.t("buttons.submit_job_listing")
 
-    expect(page).to have_content(I18n.t("publishers.vacancies.summary.success"))
+    expect(page).to have_content(I18n.t("publishers.vacancies.summary.heading.published"))
   end
 
   scenario "a job can be copied from the dashboard" do
@@ -114,7 +114,7 @@ RSpec.describe "Copying a vacancy" do
 
       click_on I18n.t("buttons.submit_job_listing")
 
-      expect(page).to have_content(I18n.t("publishers.vacancies.summary.success"))
+      expect(page).to have_content(I18n.t("publishers.vacancies.summary.heading.published"))
     end
   end
 

--- a/spec/system/publishers_can_give_job_listing_feedback_spec.rb
+++ b/spec/system/publishers_can_give_job_listing_feedback_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe "Publishers can give job listing feedback" do
     let(:vacancy) { create(:vacancy, :published, organisations: [organisation], publisher: publisher) }
 
     it "submits blank feedback, renders error and then submits feedback successfully" do
+      visit new_organisation_job_feedback_path(vacancy.id)
       click_on I18n.t("buttons.submit_feedback")
 
       expect(page).to have_content("There is a problem")
@@ -37,7 +38,7 @@ RSpec.describe "Publishers can give job listing feedback" do
 
       expect(current_path).to eq(jobs_with_type_organisation_path(:published))
 
-      expect(page).to have_content(I18n.t("messages.jobs.feedback.success"))
+      expect(page).to have_content(strip_tags(I18n.t("messages.jobs.feedback.success_html")))
     end
   end
 end

--- a/spec/system/publishers_can_preview_a_vacancy_spec.rb
+++ b/spec/system/publishers_can_preview_a_vacancy_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Publishers can preview a vacancy" do
     scenario "users can submit the listing" do
       click_on I18n.t("buttons.submit_job_listing")
       expect(page).to have_current_path(organisation_job_summary_path(vacancy.id))
-      expect(page).to have_content(I18n.t("publishers.vacancies.summary.success"))
+      expect(page).to have_content(I18n.t("publishers.vacancies.summary.heading.published"))
     end
 
     scenario "users can navigate back to manage jobs page" do

--- a/spec/system/publishers_can_publish_a_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers_can_publish_a_vacancy_as_a_school_spec.rb
@@ -241,17 +241,9 @@ RSpec.describe "Creating a vacancy" do
         visit organisation_job_review_path(vacancy.id)
         click_on "Confirm and submit job"
 
-        expect(page).to have_content("Your job listing will be posted on #{format_date(vacancy.publish_on)}.")
+        expect(page).to have_content(I18n.t("publishers.vacancies.summary.date_posted", date: vacancy.publish_on.to_formatted_s.strip!))
         visit organisation_job_path(vacancy.id)
         expect(page).to have_content(format_date(vacancy.publish_on).to_s)
-      end
-
-      scenario "displays the expiration date and time on the confirmation page" do
-        vacancy = create(:vacancy, :draft, :teacher, :ect_suitable, organisations: [school], expires_at: 5.days.from_now.change(hour: 9, minute: 0), phases: %w[secondary])
-        visit organisation_job_review_path(vacancy.id)
-        click_on I18n.t("buttons.submit_job_listing")
-
-        expect(page).to have_content(I18n.t("publishers.vacancies.summary.date_expires", application_deadline: format_time_to_datetime_at(vacancy.expires_at)))
       end
 
       scenario "a published vacancy cannot be republished" do
@@ -259,7 +251,7 @@ RSpec.describe "Creating a vacancy" do
 
         visit organisation_job_review_path(vacancy.id)
         click_on "Confirm and submit job"
-        expect(page).to have_content("The job listing has been completed")
+        expect(page).to have_content(I18n.t("publishers.vacancies.summary.date_posted", date: vacancy.publish_on.to_formatted_s.strip!))
 
         visit organisation_job_publish_path(vacancy.id)
 


### PR DESCRIPTION
![Screenshot 2022-08-30 at 15 56 00](https://user-images.githubusercontent.com/1792451/187470413-af97cbaf-572a-4fdf-8eb6-b7f73b1a7544.png)

https://dfedigital.atlassian.net/browse/TEVA-4386

(Also little change for @adamsilver as he wants Active Jobs (19) for e.g to be all bold text)

