### PR TITLE
Remove StatusCake alert

### DIFF
--- a/terraform/workspace-variables/production.tfvars.json
+++ b/terraform/workspace-variables/production.tfvars.json
@@ -1,22 +1,17 @@
 {
   "app_environment": "production",
-  "channel_list":
-    {
-      "tvsprod":
-        {
-          "cloudwatch_slack_channel": "twd_tv_dev"
-        }
+  "channel_list": {
+    "tvsprod": {
+      "cloudwatch_slack_channel": "twd_tv_dev"
     }
-  ,
-  "distribution_list":
-    {
-      "tvsprod":
-        {
-          "cloudfront_origin_domain_name": "teaching-vacancies-production.london.cloudapps.digital",
-          "offline_bucket_domain_name": "530003481352-offline-site.s3.amazonaws.com",
-          "offline_bucket_origin_path": "/teaching-vacancies-offline"
-        }
-    },
+  },
+  "distribution_list": {
+    "tvsprod": {
+      "cloudfront_origin_domain_name": "teaching-vacancies-production.london.cloudapps.digital",
+      "offline_bucket_domain_name": "530003481352-offline-site.s3.amazonaws.com",
+      "offline_bucket_origin_path": "/teaching-vacancies-offline"
+    }
+  },
   "documents_s3_bucket_force_destroy": false,
   "environment": "production",
   "paas_app_start_timeout": "180",
@@ -33,37 +28,5 @@
   "paas_worker_app_instances": 2,
   "paas_worker_app_memory": 1536,
   "parameter_store_environment": "production",
-  "region": "eu-west-2",
-  "statuscake_alerts":
-    {
-      "PaaS500String":
-        {
-          "contact_group": [
-            183741
-          ],
-          "do_not_find": true,
-          "find_string": "500 Internal Server Error",
-          "website_name": "Teaching Vacancies - PaaS 500 error",
-          "website_url": "https://teaching-vacancies.service.gov.uk"
-        }
-      ,
-      "stringmatch":
-        {
-          "contact_group": [
-            183741
-          ],
-          "find_string": "create an account",
-          "website_name": "Teaching Vacancies - homepage string",
-          "website_url": "https://teaching-vacancies.service.gov.uk"
-        }
-      ,
-      "tvsprod":
-        {
-          "contact_group": [
-            183741
-          ],
-          "website_name": "Teaching Vacancies - /check",
-          "website_url": "https://teaching-vacancies.service.gov.uk/check"
-        }
-    }
+  "region": "eu-west-2"
 }


### PR DESCRIPTION
Remove the StatusCake alerts created through the 1.0.1 provider so they
can be replaced by the new alert created through the new provider.

## Changes in this PR:

- Remove the production StatusCake alert

## Next steps:

- [ ] Merge the PR with the new alert https://github.com/DFE-Digital/teaching-vacancies/pull/5354
