### PR TITLE
Upgrade Terraform to version 1.2.8

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,7 +5,7 @@ ARG USERNAME=teaching-vacancies
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 ARG NODEJS_MAJOR_VERSION=18
-ARG TERRAFORM_VERSION=1.0.8
+ARG TERRAFORM_VERSION=1.2.8
 
 # Set up NodeSource repository for newer Node.JS
 RUN apt update -yq \

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -37,9 +37,9 @@ runs:
         role-skip-session-tagging: true
 
     - name: Pin Terraform version
-      uses: hashicorp/setup-terraform@v1
+      uses: hashicorp/setup-terraform@v2
       with:
-        terraform_version: 1.0.8
+        terraform_version: 1.2.8
 
     - name: Set environment variables for review
       if: startsWith( inputs.environment, 'review')

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -323,7 +323,7 @@ jobs:
       - name: Terraform pin version
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.0.8
+          terraform_version: 1.2.8
 
       - name: Deploy monitoring
         run: |

--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -87,7 +87,7 @@ jobs:
     - name: Terraform pin version
       uses: hashicorp/setup-terraform@v2
       with:
-        terraform_version: 1.0.8
+        terraform_version: 1.2.8
 
     - name: Terraform destroy (on PR closed)
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -58,9 +58,6 @@ terraform.tfstate.d/
 .terraform.tfstate.lock.info
 tokens
 
-# Ignore Terraform lock files while they conflict with local plugin cache
-/terraform/**/.terraform.lock.hcl
-
 # ENV files
 .env*
 !.env.development

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 ruby 3.1.2
 nodejs 18.4.0
 yarn 1.22.17
-terraform 1.0.8
+terraform 1.2.8

--- a/documentation/deployments.md
+++ b/documentation/deployments.md
@@ -59,7 +59,7 @@ performs these steps:
 
 Requirements:
 - docker CLI of at least version `19.03`
-- [terraform CLI](https://www.terraform.io/downloads.html) of at least version `1.0.8`
+- [terraform CLI](https://www.terraform.io/downloads.html) of at least version `1.2.8`
 - Write access to Docker Hub `dfedigital/teaching-vacancies` repository. Ask in #digital-tools-support should you require it.
 - Log in to Container registry (with `docker login ghcr.io -u USERNAME` - use PAT token as passoword)
 - Log in to GOV.UK PaaS (with `cf login --sso`). You will need a [Passcode](https://login.london.cloud.service.gov.uk/passcode)

--- a/terraform/app/.terraform.lock.hcl
+++ b/terraform/app/.terraform.lock.hcl
@@ -1,0 +1,67 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/cloudfoundry-community/cloudfoundry" {
+  version     = "0.15.5"
+  constraints = ">= 0.13.0, ~> 0.14"
+  hashes = [
+    "h1:FYXLCAr6F/5+Bbp7XV8EB74vsym0YtY3hoIKI9l9nFs=",
+    "zh:0f4384d5aedd17cd8ec8827db4075890bdebe151d5f2300669c28d5021ef67cf",
+    "zh:164f74e6297b398f7d695c38bffc696fbb25377bc815a5f0a25d41da1085e771",
+    "zh:337332a1bfcda419d6a0bf758a131631eb977eb830525e759213ed7d1d84aa10",
+    "zh:488820c337cd5032335d0dede08aee717b5c089c7ac6c30f0b75fba9cf36bb53",
+    "zh:4e5003af86bf3ec19ad3d8b659ba1e357ab52092ea3b606c2f20e232768a71fa",
+    "zh:5ec1186931bc2b42313b2d2589df5c084909a7cecafc1c0bb112e326fad877c1",
+    "zh:613942f7da3fb818f884fd464a7da6bcb6ecffb9e83f2eb3ec26f67d052419c3",
+    "zh:6764f9d2a88e39230384cb742a46063257602c19827d1570020a93ef190ca380",
+    "zh:770b0bb30b1b9301b197aa8907f1e46a4f82869febb6c03eb64fc8efaca4961d",
+    "zh:77cf66c586f3dec13e43580ba854d0c5cdde71d4ffa10f9ca4609bdf1d3f300b",
+    "zh:7914f451b19285132e93804b88fefbeff9a75b22d8321fafde048cbed87f1169",
+    "zh:8b8c919b13210fe6f8ade33e00c6ddfe1277ae9414fdacd7b955703570120526",
+    "zh:db06d1f2aa10be7600769e8d2d90acf2fc72de5424cd7fda8718acaf00922616",
+    "zh:f9c897cfa4cb952eac54208b2ee0bce00234323d77aabb664170f1a953698d2a",
+    "zh:fb50ad7f4de74761af8c4af5a99a5f3abce6a39feb330d36272e9d8238583a0c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.45.0"
+  constraints = ">= 3.28.0, >= 3.45.0, ~> 3.45.0"
+  hashes = [
+    "h1:u1fmVwS10RxbjJEMz43bmRYkhRUuWymNpf1Ci6bBjuM=",
+    "zh:0fdbb3af75ff55807466533f97eb314556ec41a908a543d7cafb06546930f7c6",
+    "zh:20656895744fa0f4607096b9681c77b2385f450b1577f9151d3070818378a724",
+    "zh:390f316d00f25a5e45ef5410961fd05bf673068c1b701dc752d11df6d8e741d7",
+    "zh:3da70f9de241d5f66ea9994ef1e0beddfdb005fa2d2ef6712392f57c5d2e4844",
+    "zh:65de63cc0f97c85c28a19db560c546aa25f4f403dbf4783ac53c3918044cf180",
+    "zh:6fc52072e5a66a5d0510aaa2b373a2697895f51398613c68619d8c0c95fc75f5",
+    "zh:7c1da61092bd1206a020e3ee340ab11be8a4f9bb74e925ca1229ea5267fb3a62",
+    "zh:94e533d86ce3c08e7102dcabe34ba32ae7fd7819fd0aedef28f48d29e635eae2",
+    "zh:a3180d4826662e19e71cf20e925a2be8613a51f2f3f7b6d2643ac1418b976d58",
+    "zh:c783df364928c77fd4dec5419533b125bebe2d50212c4ad609f83b701c2d981a",
+    "zh:e1279bde388cb675d324584d965c6d22c3ec6890b13de76a50910a3bcd84ed64",
+  ]
+}
+
+provider "registry.terraform.io/statuscakedev/statuscake" {
+  version     = "2.0.3"
+  constraints = "2.0.3"
+  hashes = [
+    "h1:ZNNSZPh5y2oKtAckHd/c6X4xOBKYbG8CC9OH0KVe7AU=",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:23c8c0aba2079500e762f4222a52faa015d256315298677f02ed9669c28671ed",
+    "zh:401de1618e1deedd22e77a0a2473a12d2ea5e818fd1e3406012b1c87d8459dc7",
+    "zh:439c34178b9e23dbe6853631eac5adab95498f45b6adbcfb4246ecb160365cd2",
+    "zh:47abf79a5a890a25123ebca80c313a8c5c2161e5e7cd33d06614fa3ad0383aad",
+    "zh:47be434f8587ce1573734c44560da08c718e5dcd5278e227aa9b0211afd387fb",
+    "zh:4a4aa5ea94d18cc4de2099134d6d486f6e41f39e6f1888ceac85137ba9aadcd7",
+    "zh:74fde1491dc16d375b3b2c47fb94045b32d8db3fdb22afe67c873bcfd1551dbe",
+    "zh:9c1e2845201206f0c5f9c4aba6fd7ed04e81c2e8b38ad2adfcedc6cbf4b65691",
+    "zh:a1f1854e1d2ab7987fd90d31b35a22ffb82ac1d25ceca80cbfd3bdc23e8b004d",
+    "zh:b0c72443d93289de234f5831234c1dcfa53718cb976f6635f0e52103915c6abb",
+    "zh:bae9b4a0052362ea315b76243c4caee65e5512951d77a90eb8fc2130b8d70d01",
+    "zh:c0a4543bf17478ffcf78102cb4281757ebc8d98eb1919faad83ea30ea103b0ec",
+    "zh:e3660bec86147264afdf29df714d3aa8468a7e3c4d1ab6e4e032d1002d3f5f75",
+    "zh:f8e414cf2e8d27748557c64899f257cebe4f95a41f54e272f6820cd2273bbcff",
+  ]
+}

--- a/terraform/app/versions.tf
+++ b/terraform/app/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.0.8"
+  required_version = "~> 1.2.8"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/common/.terraform.lock.hcl
+++ b/terraform/common/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.45.0"
+  constraints = ">= 3.45.0, ~> 3.45.0"
+  hashes = [
+    "h1:u1fmVwS10RxbjJEMz43bmRYkhRUuWymNpf1Ci6bBjuM=",
+    "zh:0fdbb3af75ff55807466533f97eb314556ec41a908a543d7cafb06546930f7c6",
+    "zh:20656895744fa0f4607096b9681c77b2385f450b1577f9151d3070818378a724",
+    "zh:390f316d00f25a5e45ef5410961fd05bf673068c1b701dc752d11df6d8e741d7",
+    "zh:3da70f9de241d5f66ea9994ef1e0beddfdb005fa2d2ef6712392f57c5d2e4844",
+    "zh:65de63cc0f97c85c28a19db560c546aa25f4f403dbf4783ac53c3918044cf180",
+    "zh:6fc52072e5a66a5d0510aaa2b373a2697895f51398613c68619d8c0c95fc75f5",
+    "zh:7c1da61092bd1206a020e3ee340ab11be8a4f9bb74e925ca1229ea5267fb3a62",
+    "zh:94e533d86ce3c08e7102dcabe34ba32ae7fd7819fd0aedef28f48d29e635eae2",
+    "zh:a3180d4826662e19e71cf20e925a2be8613a51f2f3f7b6d2643ac1418b976d58",
+    "zh:c783df364928c77fd4dec5419533b125bebe2d50212c4ad609f83b701c2d981a",
+    "zh:e1279bde388cb675d324584d965c6d22c3ec6890b13de76a50910a3bcd84ed64",
+  ]
+}

--- a/terraform/common/versions.tf
+++ b/terraform/common/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.0.8"
+  required_version = "~> 1.2.8"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/monitoring/.terraform.lock.hcl
+++ b/terraform/monitoring/.terraform.lock.hcl
@@ -1,0 +1,63 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/cloudfoundry-community/cloudfoundry" {
+  version     = "0.15.5"
+  constraints = ">= 0.12.6, ~> 0.14, >= 0.14.2"
+  hashes = [
+    "h1:FYXLCAr6F/5+Bbp7XV8EB74vsym0YtY3hoIKI9l9nFs=",
+    "zh:0f4384d5aedd17cd8ec8827db4075890bdebe151d5f2300669c28d5021ef67cf",
+    "zh:164f74e6297b398f7d695c38bffc696fbb25377bc815a5f0a25d41da1085e771",
+    "zh:337332a1bfcda419d6a0bf758a131631eb977eb830525e759213ed7d1d84aa10",
+    "zh:488820c337cd5032335d0dede08aee717b5c089c7ac6c30f0b75fba9cf36bb53",
+    "zh:4e5003af86bf3ec19ad3d8b659ba1e357ab52092ea3b606c2f20e232768a71fa",
+    "zh:5ec1186931bc2b42313b2d2589df5c084909a7cecafc1c0bb112e326fad877c1",
+    "zh:613942f7da3fb818f884fd464a7da6bcb6ecffb9e83f2eb3ec26f67d052419c3",
+    "zh:6764f9d2a88e39230384cb742a46063257602c19827d1570020a93ef190ca380",
+    "zh:770b0bb30b1b9301b197aa8907f1e46a4f82869febb6c03eb64fc8efaca4961d",
+    "zh:77cf66c586f3dec13e43580ba854d0c5cdde71d4ffa10f9ca4609bdf1d3f300b",
+    "zh:7914f451b19285132e93804b88fefbeff9a75b22d8321fafde048cbed87f1169",
+    "zh:8b8c919b13210fe6f8ade33e00c6ddfe1277ae9414fdacd7b955703570120526",
+    "zh:db06d1f2aa10be7600769e8d2d90acf2fc72de5424cd7fda8718acaf00922616",
+    "zh:f9c897cfa4cb952eac54208b2ee0bce00234323d77aabb664170f1a953698d2a",
+    "zh:fb50ad7f4de74761af8c4af5a99a5f3abce6a39feb330d36272e9d8238583a0c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.2.0"
+  constraints = "~> 2.2.0"
+  hashes = [
+    "h1:62mVchC1L6vOo5QS9uUf52uu0emsMM+LsPQJ1BEaTms=",
+    "zh:06bd875932288f235c16e2237142b493c2c2b6aba0e82e8c85068332a8d2a29e",
+    "zh:0c681b481372afcaefddacc7ccdf1d3bb3a0c0d4678a526bc8b02d0c331479bc",
+    "zh:100fc5b3fc01ea463533d7bbfb01cb7113947a969a4ec12e27f5b2be49884d6c",
+    "zh:55c0d7ddddbd0a46d57c51fcfa9b91f14eed081a45101dbfc7fd9d2278aa1403",
+    "zh:73a5dd68379119167934c48afa1101b09abad2deb436cd5c446733e705869d6b",
+    "zh:841fc4ac6dc3479981330974d44ad2341deada8a5ff9e3b1b4510702dfbdbed9",
+    "zh:91be62c9b41edb137f7f835491183628d484e9d6efa82fcb75cfa538c92791c5",
+    "zh:acd5f442bd88d67eb948b18dc2ed421c6c3faee62d3a12200e442bfff0aa7d8b",
+    "zh:ad5720da5524641ad718a565694821be5f61f68f1c3c5d2cfa24426b8e774bef",
+    "zh:e63f12ea938520b3f83634fc29da28d92eed5cfbc5cc8ca08281a6a9c36cca65",
+    "zh:f6542918faa115df46474a36aabb4c3899650bea036b5f8a5e296be6f8f25767",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.45.0"
+  constraints = "~> 3.45.0"
+  hashes = [
+    "h1:u1fmVwS10RxbjJEMz43bmRYkhRUuWymNpf1Ci6bBjuM=",
+    "zh:0fdbb3af75ff55807466533f97eb314556ec41a908a543d7cafb06546930f7c6",
+    "zh:20656895744fa0f4607096b9681c77b2385f450b1577f9151d3070818378a724",
+    "zh:390f316d00f25a5e45ef5410961fd05bf673068c1b701dc752d11df6d8e741d7",
+    "zh:3da70f9de241d5f66ea9994ef1e0beddfdb005fa2d2ef6712392f57c5d2e4844",
+    "zh:65de63cc0f97c85c28a19db560c546aa25f4f403dbf4783ac53c3918044cf180",
+    "zh:6fc52072e5a66a5d0510aaa2b373a2697895f51398613c68619d8c0c95fc75f5",
+    "zh:7c1da61092bd1206a020e3ee340ab11be8a4f9bb74e925ca1229ea5267fb3a62",
+    "zh:94e533d86ce3c08e7102dcabe34ba32ae7fd7819fd0aedef28f48d29e635eae2",
+    "zh:a3180d4826662e19e71cf20e925a2be8613a51f2f3f7b6d2643ac1418b976d58",
+    "zh:c783df364928c77fd4dec5419533b125bebe2d50212c4ad609f83b701c2d981a",
+    "zh:e1279bde388cb675d324584d965c6d22c3ec6890b13de76a50910a3bcd84ed64",
+  ]
+}

--- a/terraform/monitoring/versions.tf
+++ b/terraform/monitoring/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = "~> 1.0.8"
+  required_version = "~> 1.2.8"
   required_providers {
     archive = {
       source  = "hashicorp/archive"
-      version = "~> 2.0.0"
+      version = "~> 2.2.0"
     }
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
Ensure the Terraform version contains the latest fixes and supports Apple processors

## Changes in this PR:

- Upgrade Terraform version to 1.2.8
- Update hashicorp/archive to 2.2.0 (from 2.0.0) to support M1/M2 processors
  - [2.1.0 includes support for darwin_arm64 platform](https://github.com/hashicorp/terraform-provider-archive/commit/982982a1ae403caa653c53070b69ef6c379f3741)
  - 2.2.0 includes [bugfixes, enhancements](https://github.com/hashicorp/terraform-provider-archive/pull/95) and [new functionality](https://github.com/hashicorp/terraform-provider-archive/pull/90)

## Next steps:

- [x] Manually deploy common from main to update AWS certificate verification `aws_acm_certificate_validation`
- [ ] Merge PR in to main
- [ ] Allow CI/CD to run for app and monitoring
- [ ] Manually deploy common from main with Terraform 1.2.8

## Testing completed:

- [x] `terraform-app-plan` against review environment
- [x] `terraform-common-plan` with SpaceDeveloper CF permissions against staging, production and monitoring spaces
- [x] `terraform-monitoring-plan` with SpaceDeveloper CF permissions against staging, production and monitoring spaces