### PR TITLE
[TEVA-4325] Set publisher and publisher_organisation when vacancy created

### DIFF
--- a/app/controllers/publishers/vacancies_controller.rb
+++ b/app/controllers/publishers/vacancies_controller.rb
@@ -7,7 +7,8 @@ class Publishers::VacanciesController < Publishers::Vacancies::BaseController
   end
 
   def create
-    vacancy = Vacancy.create
+    vacancy = Vacancy.create(publisher: current_publisher, publisher_organisation: current_organisation)
+
     if current_organisation.school?
       vacancy.update(organisations: [current_organisation])
       vacancy.update(phases: [current_organisation.readable_phase]) if current_organisation.readable_phase

--- a/spec/system/publishers_can_publish_a_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers_can_publish_a_vacancy_as_a_school_spec.rb
@@ -211,6 +211,29 @@ RSpec.describe "Creating a vacancy" do
         expect(current_path).to eq(organisation_job_summary_path(vacancy.id))
       end
 
+      context "when publishing a vacancy" do
+        let(:publisher_that_created_vacancy) { create(:publisher, organisations: [trust]) }
+        let(:publisher_that_publishes_vacancy) { create(:publisher, organisations: [school]) }
+        let(:school) { create(:school) }
+        let(:trust) { create(:trust, schools: [school]) }
+        let(:vacancy) { create(:vacancy, :draft, organisations: [school], publisher: publisher_that_created_vacancy, publisher_organisation: trust) }
+
+        before { login_publisher(publisher: publisher_that_publishes_vacancy, organisation: school) }
+
+        scenario "the publisher and organisation_publisher are reset" do
+          visit organisation_job_path(vacancy.id)
+
+          has_complete_draft_vacancy_review_heading?(vacancy)
+
+          click_on I18n.t("publishers.vacancies.show.heading_component.action.publish")
+
+          vacancy.reload
+
+          expect(vacancy.publisher).to eq(publisher_that_publishes_vacancy)
+          expect(vacancy.publisher_organisation).to eq(school)
+        end
+      end
+
       scenario "can be published at a later date" do
         vacancy = create(:vacancy, :draft, :teacher, :ect_suitable, organisations: [school], publish_on: Time.zone.tomorrow, phases: %w[secondary], key_stages: %w[ks3])
 


### PR DESCRIPTION
## Related to:

https://dfedigital.atlassian.net/browse/TEVA-4325

## Notes

Need to talk to the performance analyst because they may use this to track the publishing of jobs.

## Changes in this PR:

After working through a solution to the ticket above, I noticed a problem. 

We want to delete draft jobs after 60 days. Before this, we want to send an email 7 days before this deletion date and 1 day before.

We want to send the email to all of the publishers associated with the organisation that created the draft job - the organisation the user who created the job was signed in as. 

However, at the moment, we do not know this for draft jobs. At the point where a job is published, we set `publisher` and `publisher_organisation` on the vacancy. `publisher` is the publisher who clicked published and `publisher_organisation` is the organisation they're signed in as.

In order for us to do this: 

> We want to send the email to all of the publishers associated with the organisation that created the draft job - the organisation the user who created the job was signed in as. 

we need to set publisher_organisation when a job is created, rather than when it's published. We can then reset `publisher` and `publisher_organisation` when the job is published, in case it's published by an organisation different from the one that created the draft - by someone signed in as a school that is associated with a trust, for example.

Once this change has been released, any drafts that have these fields set (drafts created after these changes are introduced) will have emails sent to the desired publishers, if they also have not been updated in 53 days (7 days before the 60-day inactivity deadline described in the ticket). 

**What we do with draft jobs created before these changes is yet to be decided**