### PR TITLE
Fix broken link on scheduled job listing summary

### DIFF
--- a/app/views/publishers/vacancies/summary.html.slim
+++ b/app/views/publishers/vacancies/summary.html.slim
@@ -12,7 +12,10 @@
     p = t(".you_can")
 
     ul.govuk-list.govuk-list--bullet
-      li = govuk_link_to t(".view_listing"), job_path(@vacancy.id)
+      - if vacancy.publish_on.future?
+        li = open_in_new_tab_link_to t(".preview_listing"), organisation_job_preview_path(@vacancy.id)
+      - else
+        li = govuk_link_to t(".view_listing"), job_path(@vacancy.id)
       li = govuk_link_to t(".make_changes"), organisation_job_path(@vacancy.id)
       li = govuk_link_to t(".manage_jobs"), jobs_with_type_organisation_path(:published)
 

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -366,6 +366,7 @@ en:
         manage_jobs: manage jobs
         next_steps: Next steps
         page_title: The job listing for %{organisation} has been completed
+        preview_listing: preview the job listing
         view_listing: view the job listing
         you_can: "You can:"
       feedbacks:


### PR DESCRIPTION
Previously, when you got to the summary page, you had the option of viewing the job listing, regardless of whether the job was published or scheduled. When scheduled, clicking this link cause a 404.