### PR TITLE
do not show cookie banners if user has disabled cookies

### DIFF
--- a/app/assets/javascript/components/cookiesBanner/enhance.js
+++ b/app/assets/javascript/components/cookiesBanner/enhance.js
@@ -4,6 +4,12 @@ import axios from 'axios';
 import logger from '../../lib/logging';
 
 const CookiesBannerController = class extends Controller {
+  connect() {
+    if (!navigator.cookieEnabled) {
+      this.element.parentElement.removeChild(this.element);
+    }
+  }
+
   submit(e) {
     const form = e.target.closest('form');
     const token = form.querySelector('input[name="authenticity_token"]').value;


### PR DESCRIPTION
no ticket

Sentry is reporting a cookie consent request failure if user has disabled cookies and the cookie banner will always be present on pages. this removes the banner in that scenario, which GDS told me is an acceptable thing to do