### PR TITLE
Implement reset_ect_status method in resettable

### DIFF
--- a/app/models/concerns/resettable.rb
+++ b/app/models/concerns/resettable.rb
@@ -12,6 +12,7 @@ module Resettable
     reset_subjects
     set_default_key_stage
     reset_keystages
+    reset_ect_status
   end
 
   def reset_actual_salary
@@ -42,5 +43,11 @@ module Resettable
 
   def set_default_key_stage
     self.key_stages = key_stages_for_phases if key_stages_for_phases.one?
+  end
+
+  def reset_ect_status
+    return unless job_role_changed? && job_role != "teacher"
+
+    self.ect_status = nil
   end
 end

--- a/spec/queries/vacancy_filter_query_spec.rb
+++ b/spec/queries/vacancy_filter_query_spec.rb
@@ -1,20 +1,17 @@
 require "rails_helper"
 
 RSpec.describe VacancyFilterQuery do
-  let!(:vacancy1) { create(:vacancy, job_title: "Vacancy 1", subjects: %w[German French], working_patterns: %w[full_time], phases: %w[secondary], job_role: "senior_leader", ect_status: "ect_suitable") }
-  let!(:vacancy2) { create(:vacancy, job_title: "Vacancy 2", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: "ect_suitable") }
-  let!(:vacancy3) { create(:vacancy, job_title: "Vacancy 3", subjects: %w[German Spanish], working_patterns: %w[part_time], phases: %w[secondary], job_role: "senior_leader", ect_status: "ect_unsuitable") }
-  let!(:vacancy4) { create(:vacancy, job_title: "Vacancy 4", subjects: %w[German Spanish], working_patterns: %w[term_time], phases: %w[primary], job_role: "senior_leader", ect_status: "ect_suitable") }
-  let!(:vacancy5) { create(:vacancy, job_title: "Vacancy 5", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[sixth_form_or_college], job_role: "teacher", ect_status: "ect_unsuitable") }
-  let!(:vacancy6) { create(:vacancy, job_title: "Vacancy 6", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "sendco", ect_status: "ect_suitable") }
+  let!(:vacancy1) { create(:vacancy, job_title: "Vacancy 1", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[secondary], job_role: "teacher", ect_status: "ect_suitable") }
+  let!(:vacancy2) { create(:vacancy, job_title: "Vacancy 2", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[sixth_form_or_college], job_role: "teacher", ect_status: "ect_unsuitable") }
+  let!(:vacancy3) { create(:vacancy, job_title: "Vacancy 3", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "sendco", ect_status: nil) }
 
   describe "#call" do
     it "queries based on the given filters" do
       filters = {
-        subjects: %w[Spanish German],
+        subjects: %w[English Spanish],
         working_patterns: %w[full_time],
-        phases: %w[secondary middle],
-        job_roles: %w[senior_leader],
+        phases: %w[secondary],
+        job_roles: %w[teacher],
         ect_statuses: %w[ect_suitable],
         from_date: 5.days.ago,
         to_date: Date.today,
@@ -22,18 +19,18 @@ RSpec.describe VacancyFilterQuery do
       expect(subject.call(filters)).to contain_exactly(vacancy1)
     end
 
-    it "transforms legacy job role filters to new ones" do
-      filters = {
-        job_roles: %w[sen_specialist],
-      }
-      expect(subject.call(filters)).to contain_exactly(vacancy6)
-    end
-
     it "transforms legacy phases filters to new ones" do
       filters = {
         phases: %w[16-19],
       }
-      expect(subject.call(filters)).to contain_exactly(vacancy5)
+      expect(subject.call(filters)).to contain_exactly(vacancy2)
+    end
+
+    it "transforms legacy job role filters to new ones" do
+      filters = {
+        job_roles: %w[sen_specialist],
+      }
+      expect(subject.call(filters)).to contain_exactly(vacancy3)
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR:

This PR implements the method `reset_ect_status` in `resettable.rb` which sets `ect_status` to `nil` when job role is changed. This ensures that if the user changes back to "teacher" in the future, they are prompted to answer the `ect_status` question again.
