### PR TITLE
Remove terraform from dependabot checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,36 +31,3 @@ updates:
       interval: "weekly"
       day: "wednesday"
     open-pull-requests-limit: 2
-
-  - package-ecosystem: "terraform"
-    directory: "/terraform/app"
-    schedule:
-      interval: "weekly"
-      day: "wednesday"
-    open-pull-requests-limit: 2
-    labels:
-    - devops
-    - dependencies
-    - terraform-app
-
-  - package-ecosystem: "terraform"
-    directory: "/terraform/common"
-    schedule:
-      interval: "weekly"
-      day: "wednesday"
-    open-pull-requests-limit: 2
-    labels:
-    - devops
-    - dependencies
-    - terraform-common
-
-  - package-ecosystem: "terraform"
-    directory: "/terraform/monitoring"
-    schedule:
-      interval: "weekly"
-      day: "wednesday"
-    open-pull-requests-limit: 2
-    labels:
-    - devops
-    - dependencies
-    - terraform-monitoring


### PR DESCRIPTION
## Context
Dependabot checks would fail for Terraform providers depending on the pinned version of Terraform used by dependabot-core. Removing these checks until the issue is addressed or workaround found.
See: dependabot/dependabot-core#5797

## Trello ticket URL

https://trello.com/c/zlOBSIOJ

## Changes in this PR:

terraform package ecosystem removed from dependabot.yml

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
