### PR TITLE
Add check before organisation map section is shown

### DIFF
--- a/app/helpers/maps_helper.rb
+++ b/app/helpers/maps_helper.rb
@@ -8,4 +8,10 @@ module MapsHelper
       }
     end
   end
+
+  def organisation_map_can_be_displayed?(vacancy)
+    return true unless vacancy.central_office?
+
+    vacancy.organisation.geopoint.present?
+  end
 end

--- a/app/views/vacancies/listing/_organisation_details.html.slim
+++ b/app/views/vacancies/listing/_organisation_details.html.slim
@@ -33,13 +33,14 @@ section#school-overview
 
     p.govuk-body = vacancy.school_visits
 
-  section#school-location
-    h3.govuk-heading-l.heading--border-bottom
-      - if vacancy.central_office?
-        = t("organisations.locations.central_office", organisation: vacancy.organisation_name)
-      - elsif vacancy.organisations.many?
-        = t("organisations.locations.at_multiple_schools")
-      - else
-        = t("organisations.locations.at_one_school", organisation: vacancy.organisation_name)
+  - if organisation_map_can_be_displayed?(vacancy)
+    section#school-location
+      h3.govuk-heading-l.heading--border-bottom
+        - if vacancy.central_office?
+          = t("organisations.locations.central_office", organisation: vacancy.organisation_name)
+        - elsif vacancy.organisations.many?
+          = t("organisations.locations.at_multiple_schools")
+        - else
+          = t("organisations.locations.at_one_school", organisation: vacancy.organisation_name)
 
-    = map(markers: organisation_map_markers(vacancy), marker: { type: "organisation", tracking: { link: "school_website_from_map" } })
+      = map(markers: organisation_map_markers(vacancy), marker: { type: "organisation", tracking: { link: "school_website_from_map" } })


### PR DESCRIPTION
## Changes in this PR:

Noticed the bug below where we render mark up for the school locations section and the heading, but do not display the map. This occurred because many SchoolGroups do not have geopoints. 

<img width="686" alt="Screenshot 2022-10-12 at 15 21 20" src="https://user-images.githubusercontent.com/30624173/195368554-cff8fa1c-53b1-4a5f-a1dc-bf220f0031e6.png">

I have added a check for the presence of the organisation's geopoint (if the job is at the trust's central office) before rending the section to prevent this. 

```
[5] pry(main)> School.where(geopoint: nil).count
=> 0
[6] pry(main)> SchoolGroup.where(geopoint: nil).count
=> 1877
```
