### PR TITLE
[TEVA-4458] Replace 'Trust head office' with 'Head office'

### DIFF
--- a/app/components/dashboard_component.rb
+++ b/app/components/dashboard_component.rb
@@ -78,7 +78,7 @@ class DashboardComponent < ApplicationComponent
 
     count = organisation.vacancies.send(selected_scope).count
     @organisation_options.unshift(
-      Option.new(id: organisation.id, name: "Trust head office", label: "Trust head office (#{count})"),
+      Option.new(id: organisation.id, name: "Head office", label: "Head office (#{count})"),
     )
   end
 

--- a/app/views/pages/list-school-job.html.slim
+++ b/app/views/pages/list-school-job.html.slim
@@ -104,7 +104,7 @@
           | List teaching, leadership or education support roles.
 
         p.govuk-body
-          | List a job at a single school, multiple schools or the trust head office.
+          | List a job at a single school, multiple schools or the head office.
 
         p.govuk-body
           | You can specify working pattern, contract type and pay package.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -322,11 +322,11 @@ en:
     job_location_heading:
       at_multiple_locations: At more than one location in the %{organisation_type}
       at_one_location: Single location
-      central_office: Trust head office
+      central_office: Head office
     job_location_summary:
       at_multiple_locations: More than one location
       at_multiple_locations_with_count: More than one location (%{count})
-      central_office: Trust head office
+      central_office: Head office
     locations:
       at_one_school: School location
       at_multiple_schools: School locations

--- a/spec/components/dashboard_component_spec.rb
+++ b/spec/components/dashboard_component_spec.rb
@@ -109,8 +109,8 @@ RSpec.describe DashboardComponent, type: :component do
           ).to eq(I18n.t("buttons.apply_filters"))
         end
 
-        it "renders the trust head office as a filter option" do
-          expect(inline_component.css(".edit_publisher_preference").to_html).to include("Trust head office")
+        it "renders the head office as a filter option" do
+          expect(inline_component.css(".edit_publisher_preference").to_html).to include("Head office")
         end
 
         it "renders the open school as a filter option" do
@@ -156,8 +156,8 @@ RSpec.describe DashboardComponent, type: :component do
           ).to eq(I18n.t("buttons.apply_filters"))
         end
 
-        it "does not render the trust head office as a filter option" do
-          expect(inline_component.css(".edit_publisher_preference").to_html).not_to include("Trust head office")
+        it "does not render the head office as a filter option" do
+          expect(inline_component.css(".edit_publisher_preference").to_html).not_to include("Head office")
         end
 
         it "renders the open school as a filter option" do


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-4458

## Changes in this PR:

Replaces "Trust head office" with "Head office" across the site.

## Screenshots of UI changes:

### After

![image](https://user-images.githubusercontent.com/24639777/196667856-99c0a369-da0c-4d58-a85c-cac8f1185eca.png)

![image](https://user-images.githubusercontent.com/24639777/196667917-789d4f66-24aa-4ea7-9188-7a9a97f5457c.png)

![image](https://user-images.githubusercontent.com/24639777/196668022-dffc187a-ec62-4bc5-b631-b2ee115ad556.png)

![image](https://user-images.githubusercontent.com/24639777/196668389-5ffefddb-7ee6-4dcf-b24e-42eff0a91775.png)

