### PR TITLE
[TEVA-4460] Change additional allowances input to text area

### DIFF
--- a/app/views/publishers/vacancies/build/pay_package.html.slim
+++ b/app/views/publishers/vacancies/build/pay_package.html.slim
@@ -20,7 +20,7 @@
 
       = f.govuk_radio_buttons_fieldset :benefits, legend: { size: "m", tag: nil } do
         = f.govuk_radio_button :benefits, "true" do
-          = f.govuk_text_field :benefits_details, label: { size: "s" }
+          = f.govuk_text_area :benefits_details, label: { size: "s" }
         = f.govuk_radio_button :benefits, "false", link_errors: true
 
       = render "publishers/vacancies/vacancy_form_partials/submit", f: f


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-4460

## Changes in this PR:

Changes the text field for additional allowances (`benefits_details`) from a `text_field` to a `text_area`.

## Screenshots of UI changes:

### Before
![image](https://user-images.githubusercontent.com/24639777/196678742-06175efb-c55f-40d8-ab00-0f65138317a5.png)

### After
![image](https://user-images.githubusercontent.com/24639777/196678685-f0548ab0-0188-42f0-a123-66b472198955.png)