### PR TITLE
Add vacancy count to api response

### DIFF
--- a/app/views/api/vacancies/index.json.jbuilder
+++ b/app/views/api/vacancies/index.json.jbuilder
@@ -28,4 +28,5 @@ end
 
 json.meta do
   json.totalPages @pagy.pages
+  json.count @pagy.count
 end

--- a/spec/requests/api/vacancies_spec.rb
+++ b/spec/requests/api/vacancies_spec.rb
@@ -88,6 +88,10 @@ RSpec.describe "Api::Vacancies" do
       it "includes the total pages" do
         expect(json[:meta]).to include(totalPages: 4)
       end
+
+      it "includes the count" do
+        expect(json[:meta]).to include(count: 16)
+      end
     end
 
     it "does not retrieve incomplete or deleted vacancies" do


### PR DESCRIPTION
## Changes in this PR:

This pull request adds the vacancy count to the metadata in the api response


