### PR TITLE
[TEVA-4448] Fix job location legend and hint position for LAs

### DIFF
--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -69,6 +69,13 @@ module VacanciesHelper
     address_join([organisation.name, organisation.town, organisation.county])
   end
 
+  def local_authority_job_location_hint(current_publisher_preference)
+    t("helpers.hint.publishers_job_listing_schools_form.edit_schools_html",
+      link: govuk_link_to(t("helpers.hint.publishers_job_listing_schools_form.add_school"),
+                          edit_publishers_publisher_preference_path(current_publisher_preference),
+                          class: "govuk-link--no-visited-state"))
+  end
+
   def vacancy_full_job_location(vacancy)
     organisation = vacancy.organisation
     return "#{t('organisations.job_location_summary.at_multiple_locations')}, #{govuk_link_to(organisation.name, organisation_landing_page_path(organisation))}".html_safe if vacancy.organisations.many?

--- a/app/views/publishers/vacancies/build/job_location.html.slim
+++ b/app/views/publishers/vacancies/build/job_location.html.slim
@@ -5,20 +5,18 @@
     = form_for form, url: wizard_path(current_step), method: :patch do |f|
       = f.govuk_error_summary
 
-      = f.govuk_fieldset legend: nil do
-        - if current_organisation.local_authority?
+      = f.govuk_fieldset legend: ({ text: vacancy_form_page_heading(vacancy, step_process, params: params), tag: "h1", size: "l" } if @school_options.count >= 10) do
+        - if current_organisation.local_authority? && @school_options.count >= 10
           span.govuk-hint
-            = t("helpers.hint.publishers_job_listing_schools_form.edit_schools")
-            =< govuk_link_to t("helpers.hint.publishers_job_listing_schools_form.add_school"),
-                               edit_publishers_publisher_preference_path(current_publisher_preference), class: "govuk-link--no-visited-state"
+            = local_authority_job_location_hint(current_publisher_preference)
 
         = searchable_collection(collection: f.govuk_collection_check_boxes(:organisation_ids,
           @school_options,
           :id,
           :name,
           :address,
-          legend: { text: vacancy_form_page_heading(vacancy, step_process, params: params), tag: "h1", size: "l" },
-          hint: nil,
+          legend: ({ text: vacancy_form_page_heading(vacancy, step_process, params: params), tag: "h1", size: "l" } if @school_options.count < 10),
+          hint: ({ text: local_authority_job_location_hint(current_publisher_preference) } if current_organisation.local_authority? && @school_options.count < 10),
           classes: "checkbox-label__bold govuk-!-margin-top-2"),
           collection_count: @school_options.count,
           options: { border: true },

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -221,7 +221,7 @@ en:
           part_time: This is the annual amount someone will take home
       publishers_job_listing_schools_form:
         add_school: Add a school to your account
-        edit_schools: "Can't see the school you are looking for?"
+        edit_schools_html: "Can't see the school you are looking for? %{link}"
       publishers_job_listing_subjects_form:
         subjects_placeholder: Search
       publishers_job_listing_job_title_form:


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-4448

## Changes in this PR:

This PR ensures the legend for the job location form is not placed inside of the searchable collection for local authorities (or organisations with 10 or more schools). The local authority hint text for adding schools is moved into a helper.

## Screenshots of UI changes:

### Before
![image](https://user-images.githubusercontent.com/24639777/198301784-2249a54d-bdce-4bba-ac16-dfe45d3dad5e.png)

### After
![image](https://user-images.githubusercontent.com/24639777/198301470-ebdbc574-4a9b-48a4-9cbf-544550482a8d.png)