### PR TITLE
Add Fusion vacancy source

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -5,3 +5,4 @@ DFE_SIGN_IN_SUPPORT_USER_ROLE_ID=test-support-user-role-id
 DFE_SIGN_IN_URL=https://test-url.local
 DOMAIN=localhost:3000
 VACANCY_SOURCE_UNITED_LEARNING_FEED_URL=http://example.com/feed.xml
+VACANCY_SOURCE_FUSION_FEED_URL=http://example.com/feed.json

--- a/app/jobs/import_from_vacancy_sources_job.rb
+++ b/app/jobs/import_from_vacancy_sources_job.rb
@@ -1,5 +1,5 @@
 class ImportFromVacancySourcesJob < ApplicationJob
-  SOURCES = [UnitedLearningVacancySource].freeze
+  SOURCES = [UnitedLearningVacancySource, FusionVacancySource].freeze
 
   queue_as :default
 

--- a/app/vacancy_sources/fusion_vacancy_source.rb
+++ b/app/vacancy_sources/fusion_vacancy_source.rb
@@ -1,0 +1,89 @@
+class FusionVacancySource
+  FEED_URL = ENV.fetch("VACANCY_SOURCE_FUSION_FEED_URL").freeze
+  SOURCE_NAME = "fusion".freeze
+
+  class FusionImportError < StandardError; end
+
+  include Enumerable
+
+  def self.source_name
+    SOURCE_NAME
+  end
+
+  def each
+    results.each do |result|
+      v = Vacancy.find_or_initialize_by(
+        external_source: SOURCE_NAME,
+        external_reference: result["reference"],
+      )
+
+      # An external vacancy is by definition always published
+      v.status = :published
+      # Consider publish_on date to be the first time we saw this vacancy come through
+      # (i.e. today, unless it already has a publish on date set)
+      v.publish_on ||= Date.today
+
+      v.assign_attributes(attributes_for(result))
+
+      yield v
+    rescue StandardError => e
+      Sentry.capture_exception(e)
+    end
+  end
+
+  private
+
+  def attributes_for(item)
+    {
+      job_title: item["jobTitle"],
+      job_advert: item["jobAdvert"],
+      salary: item["salary"],
+      expires_at: Time.zone.parse(item["expiresAt"]),
+      external_advert_url: item["advertUrl"],
+      job_role: item["jobRole"].presence&.gsub("leadership", "senior_leader")&.gsub(/\s+/, ""),
+      ect_status: ect_status_for(item),
+      subjects: item["subjects"].presence&.split(","),
+      working_patterns: item["workingPatterns"].presence&.split(","),
+      contract_type: item["contractType"].presence,
+      phases: item["phase"].presence&.parameterize(separator: "_"),
+
+      # TODO: What about central office/multiple school vacancies?
+      job_location: :at_one_school,
+      readable_job_location: organisations_for(item).first&.name,
+      organisations: organisations_for(item),
+      about_school: organisations_for(item).first&.description,
+    }
+  end
+
+  def ect_status_for(item)
+    return unless item["ect_suitable"].presence
+
+    item["ect_suitable"] == "yes" ? "ect_suitable" : "ect_unsuitable"
+  end
+
+  def organisations_for(item)
+    [school_group(item).schools.find_by(urn: item["schoolUrns"].first)]
+  end
+
+  def school_group(item)
+    @school_group ||= SchoolGroup.find_by!(uid: item["trustId"])
+  end
+
+  def results
+    feed["result"]
+  end
+
+  def feed
+    response = HTTParty.get(FEED_URL)
+    raise HTTParty::ResponseError, error_message unless response.success?
+
+    parsed_response = JSON.parse(response.body)
+    raise FusionImportError, error_message if parsed_response["error"]
+
+    parsed_response
+  end
+
+  def error_message
+    "Something went wrong with Fusion Import"
+  end
+end

--- a/app/vacancy_sources/united_learning_vacancy_source.rb
+++ b/app/vacancy_sources/united_learning_vacancy_source.rb
@@ -1,12 +1,3 @@
-##
-# An experimental vacancy source for a vacancy feed for United Learning.
-#
-# Allows enumerating over the feed's contents and yields intialized `Vacancy` objects that can be
-# manipulated and persisted by calling code (e.g. an import job).
-#
-# Notes:
-#   - Ruby's `RSS` class doesn't recognise the demo feed as an Atom feed for some reason, so this
-#     uses slightly uglier vanilla XML parsing
 class UnitedLearningVacancySource
   FEED_URL = ENV.fetch("VACANCY_SOURCE_UNITED_LEARNING_FEED_URL").freeze
   UNITED_LEARNING_TRUST_UID = "5143".freeze

--- a/spec/fixtures/files/vacancy_sources/fusion.json
+++ b/spec/fixtures/files/vacancy_sources/fusion.json
@@ -1,0 +1,27 @@
+{
+  "result": [
+    {
+      "reference": "0044",
+      "advertUrl": "http://testurl.com",
+      "applicationUrl": "http://testurl.com",
+      "expiresAt": "2022-10-28T12:00:00",
+      "startDate": "2022-11-21T00:00:00",
+      "jobTitle": "Class Teacher",
+      "jobAdvert": "Lorem Ipsum dolor sit amet",
+      "salary": "£25,714.00 to £41,604.00",
+      "schoolUrns": [
+        "145506"
+      ],
+      "jobRole": "teacher",
+      "workingPatterns": "full_time",
+      "contractType": "fixed_term",
+      "phase": "primary",
+      "trustId": "16614"
+    }
+  ],
+  "targetUrl": null,
+  "success": true,
+  "error": null,
+  "unAuthorizedRequest": false,
+  "__abp": true
+}

--- a/spec/vacancy_sources/fusion_vacancy_source_spec.rb
+++ b/spec/vacancy_sources/fusion_vacancy_source_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.describe FusionVacancySource do
+  let!(:school) { create(:school, name: "Test School", urn: "145506", phase: :primary) }
+  let!(:school_group) { create(:school_group, name: "E-ACT", uid: "16614", schools: [school]) }
+
+  let(:response) { double("FusionHttpResponse", success?: true, body: file_fixture("vacancy_sources/fusion.json").read) }
+
+  before do
+    expect(HTTParty).to receive(:get).with("http://example.com/feed.json").and_return(response)
+  end
+
+  describe "enumeration" do
+    let(:vacancy) { subject.first }
+    let(:expected_vacancy) do
+      {
+        job_title: "Class Teacher",
+        job_advert: "Lorem Ipsum dolor sit amet",
+        salary: "£25,714.00 to £41,604.00",
+        job_role: "teacher",
+        working_patterns: %w[full_time],
+        contract_type: "fixed_term",
+        phases: %w[primary],
+      }
+    end
+
+    it "has the correct number of vacancies" do
+      expect(subject.count).to eq(1)
+    end
+
+    it "yield a newly built vacancy the correct vacancy information" do
+      expect(vacancy).not_to be_persisted
+      expect(vacancy).to be_changed
+    end
+
+    it "assigns correct attributes from the feed" do
+      expect(vacancy).to have_attributes(expected_vacancy)
+    end
+
+    it "assigns the vacancy to the correct school and organisation" do
+      expect(vacancy.organisations.first).to eq(school)
+
+      expect(vacancy.external_source).to eq("fusion")
+      expect(vacancy.external_advert_url).to eq("http://testurl.com")
+      expect(vacancy.external_reference).to eq("0044")
+
+      expect(vacancy.organisations).to eq([school])
+    end
+
+    it "sets important dates" do
+      expect(vacancy.expires_at).to eq(Time.zone.parse("2022-10-28T12:00:00"))
+      expect(vacancy.publish_on).to eq(Date.today)
+    end
+
+    context "when the same vacancy has been imported previously" do
+      let!(:existing_vacancy) do
+        create(
+          :vacancy,
+          :external,
+          phases: %w[primary],
+          external_source: "fusion",
+          external_reference: "0044",
+          organisations: [school],
+          job_title: "Out of date",
+        )
+      end
+
+      it "yields the existing vacancy with updated information" do
+        expect(vacancy.id).to eq(existing_vacancy.id)
+        expect(vacancy).to be_persisted
+        expect(vacancy).to be_changed
+
+        expect(vacancy.job_title).to eq("Class Teacher")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-4321

## Changes in this PR:

This adds another external source for vacancies to be imported in Teaching Vacancies. The source is Fusion an Application Tracking System (ATS) which works with many Trusts. 

In order for the integration to work a new environment variable needs to be set up called: VACANCY_SOURCE_FUSION_FEED_URL