### PR TITLE
Remove vacancy steps partial

### DIFF
--- a/app/views/publishers/vacancies/build/_steps.html.slim
+++ b/app/views/publishers/vacancies/build/_steps.html.slim
@@ -1,7 +1,0 @@
-= render StepsComponent.new title: t("publishers.vacancies.steps_component.title"), classes: "govuk-!-margin-top-6" do |component|
-  - step_process.step_groups.each_key do |vacancy_step|
-    - component.step( \
-        label: t("publishers.vacancies.build.#{vacancy_step}.step_title"), \
-        current: (vacancy_step == step_process.current_step_group), \
-        completed: vacancy_step_completed?(vacancy, vacancy_step), \
-      )


### PR DESCRIPTION
Does what it says on the tin

Looks like we can't get rid of the steps component yet as it's still used as part of the job application creation journey