### PR TITLE
Remove unused helper

### DIFF
--- a/app/helpers/status_tag_helper.rb
+++ b/app/helpers/status_tag_helper.rb
@@ -1,12 +1,10 @@
 module StatusTagHelper
   def review_section_tag(resource, steps, form_classes)
-    return if (resource.is_a?(Vacancy) || resource.is_a?(VacancyPresenter)) && resource.published?
-
     if form_classes.all?(&:optional?)
       optional
     elsif resource.is_a?(JobApplication) && steps.all? { |step| job_application_step_in_progress?(resource, step) }
       in_progress
-    elsif steps.none? { |step| vacancy_step_completed?(resource, step) }
+    elsif steps.none? { |step| step_completed?(resource, step) }
       not_started
     elsif step_forms_contain_errors?(resource, form_classes)
       action_required
@@ -16,6 +14,10 @@ module StatusTagHelper
   end
 
   private
+
+  def step_completed?(resource, step)
+    resource.completed_steps.include?(step.to_s)
+  end
 
   def step_forms_contain_errors?(resource, form_classes)
     form_classes.any? do |form_class|

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -86,10 +86,6 @@ module VacanciesHelper
     "#{vacancy.job_title} - #{vacancy.organisation_name}"
   end
 
-  def vacancy_step_completed?(vacancy, step)
-    vacancy.completed_steps.include?(step.to_s)
-  end
-
   # Determines a set of breadcrumbs for a vacancy view page based on whether the user has arrived
   # there from a search results page (take them back to search results) or somewhere else (take
   # them to the appropriate landing page, or if all else fails, the "all jobs" page)

--- a/spec/helpers/status_tag_helper_spec.rb
+++ b/spec/helpers/status_tag_helper_spec.rb
@@ -43,46 +43,6 @@ RSpec.describe StatusTagHelper do
       end
     end
 
-    context "when it is passed a vacancy" do
-      let(:record) { build_stubbed(:vacancy, :draft, completed_steps: %w[job_role job_title]) }
-      let(:form_classes) { [Publishers::JobListing::JobTitleForm] }
-
-      context "when is published" do
-        let(:record) { build_stubbed(:vacancy) }
-        let(:steps) { [] }
-
-        it "returns nil" do
-          expect(subject).to be_nil
-        end
-      end
-
-      context "when there is an error on the step's form object" do
-        let(:steps) { %i[job_title] }
-
-        before { record.errors.add(:job_title) }
-
-        it "returns 'action required' tag" do
-          expect(subject).to eq(helper.govuk_tag(text: I18n.t("shared.status_tags.action_required"), colour: "red"))
-        end
-      end
-
-      context "when the step has been completed" do
-        let(:steps) { %i[job_title] }
-
-        it "returns 'complete' tag" do
-          expect(subject).to eq(helper.govuk_tag(text: I18n.t("shared.status_tags.complete")))
-        end
-      end
-
-      context "when the step has not been started" do
-        let(:steps) { %i[working_patterns] }
-
-        it "returns 'not started' tag" do
-          expect(subject).to eq(helper.govuk_tag(text: I18n.t("shared.status_tags.not_started"), colour: "grey"))
-        end
-      end
-    end
-
     context "when the whole section is optional" do
       let(:record) { build_stubbed(:vacancy, :draft, completed_steps: completed_steps) }
       let(:form_classes) { [Publishers::JobListing::SubjectsForm] }


### PR DESCRIPTION
Entire `status_tag_helper.rb` can be removed once we remove `app/components/review_component.rb`. 

This review component was once used for both the vacancy review page and the job application review page. It is now only used for job application. I'd imagine it will be removed once we align the job application review page and creation journey with the vacancy review page and creation journey.