### PR TITLE
[TEVA-4462] Copy documents when copying a vacancy

### DIFF
--- a/app/services/copy_vacancy.rb
+++ b/app/services/copy_vacancy.rb
@@ -15,11 +15,28 @@ class CopyVacancy
   def setup_new_vacancy
     @new_vacancy = @vacancy.dup
     @new_vacancy.status = :draft
+    copy_application_form if @vacancy.application_form.attachments&.any?
+
+    if @vacancy.supporting_documents.attachments&.any?
+      copy_supporting_documents
+    else
+      @new_vacancy.include_additional_documents = nil
+    end
+
     reset_date_fields if @vacancy.publish_on&.past?
     reset_legacy_fields
-    @new_vacancy.include_additional_documents = nil
     @new_vacancy.completed_steps = current_steps
     @new_vacancy.organisations = @vacancy.organisations
+  end
+
+  def copy_application_form
+    @new_vacancy.application_form.attach(@vacancy.application_form.blob)
+  end
+
+  def copy_supporting_documents
+    @vacancy.supporting_documents.each { |supporting_document| @new_vacancy.supporting_documents.attach(supporting_document.blob) }
+
+    @new_vacancy.include_additional_documents = true
   end
 
   def reset_date_fields

--- a/spec/services/copy_vacancy_spec.rb
+++ b/spec/services/copy_vacancy_spec.rb
@@ -29,6 +29,34 @@ RSpec.describe CopyVacancy do
       end
     end
 
+    context "when there are supporting documents" do
+      let(:vacancy) { create(:vacancy, :with_supporting_documents, organisations: [school]) }
+      let(:supporting_documents) { vacancy.supporting_documents.attachments }
+
+      it "copies supporting_documents" do
+        copied_vacancy = described_class.new(vacancy).call
+
+        expect(copied_vacancy.supporting_documents.attachments.map(&:blob_id)).to eq(supporting_documents.map(&:blob_id))
+      end
+
+      it "sets include_additional_documents" do
+        copied_vacancy = described_class.new(vacancy).call
+
+        expect(copied_vacancy.include_additional_documents).to be true
+      end
+    end
+
+    context "when an application form has been attached" do
+      let(:vacancy) { create(:vacancy, :with_application_form, organisations: [school]) }
+      let(:application_form) { vacancy.application_form.attachments }
+
+      it "copies the application form" do
+        copied_vacancy = described_class.new(vacancy).call
+
+        expect(copied_vacancy.application_form.attachments.map(&:blob_id)).to eq(application_form.map(&:blob_id))
+      end
+    end
+
     context "not all fields are copied" do
       let(:vacancy) do
         create(:vacancy,


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-4462

## Changes in this PR:

- Added some extra steps to `setup_new_vacancy` to copy documents over to the new vacancy
- Added some tests