### PR TITLE
[TEVA-4468] Add bullet point toggle button to new fields

### DIFF
--- a/app/components/editor_component.rb
+++ b/app/components/editor_component.rb
@@ -14,4 +14,10 @@ class EditorComponent < ApplicationComponent
   def default_classes
     %w[editor-component]
   end
+
+  def label_classes
+    return %w[govuk-label govuk-label--m editor-component__label].join(" ") unless @label[:classes].present?
+
+    %w[editor-component__label].push(@label[:classes]).join(" ")
+  end
 end

--- a/app/components/editor_component/editor_component.html.slim
+++ b/app/components/editor_component/editor_component.html.slim
@@ -1,6 +1,6 @@
 = tag.div(class: classes, **html_attributes) do
   .editor-component__controls
-    label.govuk-label.govuk-label--m.editor-component__label data-action="click->editor#focus" for="#{@field_name}-field" id=@label[:id]
+    label class="#{label_classes}" data-action="click->editor#focus" for="#{@field_name}-field" id=@label[:id]
       = @label[:text]
     - if @hint.present?
       .govuk-hint id="#{@field_name}-hint"

--- a/app/form_models/publishers/job_listing/about_the_role_form.rb
+++ b/app/form_models/publishers/job_listing/about_the_role_form.rb
@@ -7,10 +7,10 @@ class Publishers::JobListing::AboutTheRoleForm < Publishers::JobListing::Vacancy
   validate :school_offer_presence, unless: -> { vacancy.about_school.present? }
   validate :school_offer_does_not_exceed_maximum_words, unless: -> { vacancy.about_school.present? }
   validates :safeguarding_information_provided, inclusion: { in: [true, false, "true", "false"] }, unless: -> { vacancy.job_advert.present? || vacancy.about_school.present? }
-  validates :safeguarding_information, presence: true, if: -> { safeguarding_information_provided == "true" }, unless: -> { vacancy.job_advert.present? || vacancy.about_school.present? }
+  validate :safeguarding_information_presence, if: -> { safeguarding_information_provided == "true" }, unless: -> { vacancy.job_advert.present? || vacancy.about_school.present? }
   validate :safeguarding_information_does_not_exceed_maximum_words, if: -> { safeguarding_information_provided == "true" }, unless: -> { vacancy.job_advert.present? || vacancy.about_school.present? }
   validates :further_details_provided, inclusion: { in: [true, false, "true", "false"] }, unless: -> { vacancy.job_advert.present? || vacancy.about_school.present? }
-  validates :further_details, presence: true, if: -> { further_details_provided == "true" }, unless: -> { vacancy.job_advert.present? || vacancy.about_school.present? }
+  validate :further_details_presence, if: -> { further_details_provided == "true" }, unless: -> { vacancy.job_advert.present? || vacancy.about_school.present? }
   validate :further_details_does_not_exceed_maximum_words, if: -> { further_details_provided == "true" }, unless: -> { vacancy.job_advert.present? || vacancy.about_school.present? }
 
   def self.fields
@@ -60,8 +60,20 @@ class Publishers::JobListing::AboutTheRoleForm < Publishers::JobListing::Vacancy
     errors.add(:skills_and_experience, :length) if number_of_words_exceeds_permitted_length?(150, skills_and_experience)
   end
 
+  def safeguarding_information_presence
+    return if remove_html_tags(safeguarding_information).present?
+
+    errors.add(:safeguarding_information, :blank)
+  end
+
   def safeguarding_information_does_not_exceed_maximum_words
     errors.add(:safeguarding_information, :length) if number_of_words_exceeds_permitted_length?(100, safeguarding_information)
+  end
+
+  def further_details_presence
+    return if remove_html_tags(further_details).present?
+
+    errors.add(:further_details, :blank)
   end
 
   def further_details_does_not_exceed_maximum_words
@@ -87,6 +99,6 @@ class Publishers::JobListing::AboutTheRoleForm < Publishers::JobListing::Vacancy
   end
 
   def number_of_words_exceeds_permitted_length?(number, attribute)
-    attribute&.split&.length&.>(number)
+    remove_html_tags(attribute)&.split&.length&.>(number)
   end
 end

--- a/app/views/publishers/vacancies/build/about_the_role.html.slim
+++ b/app/views/publishers/vacancies/build/about_the_role.html.slim
@@ -34,16 +34,18 @@
       - unless vacancy.job_advert.present?
         = f.govuk_radio_buttons_fieldset :safeguarding_information_provided, legend: { size: "m", tag: nil }, classes: ["safeguarding-information-provided-radios"] do
           = f.govuk_radio_button :safeguarding_information_provided, "true" do
-            = f.govuk_text_area :safeguarding_information,
-                                label: -> { tag.label(t("helpers.label.publishers_job_listing_about_the_role_form.safeguarding_information"), class: ["govuk-label", "govuk-!-font-weight-bold"]) },
-                                max_words: 100
+            = editor(form_input: f.govuk_text_area(:safeguarding_information),
+                     value: form.safeguarding_information,
+                     field_name: "publishers_job_listing_about_the_role_form[safeguarding_information]",
+                     label: { text: t("helpers.label.publishers_job_listing_about_the_role_form.safeguarding_information"), classes: ["govuk-label", "govuk-label--s", "govuk-!-margin-bottom-2", "govuk-!-font-weight-bold"], id: "safeguarding-information-label" })
           = f.govuk_radio_button :safeguarding_information_provided, "false", link_errors: true
 
         = f.govuk_radio_buttons_fieldset :further_details_provided, legend: { size: "m", tag: nil }, classes: ["further-details-provided-radios"] do
           = f.govuk_radio_button :further_details_provided, "true" do
-            = f.govuk_text_area :further_details,
-                                label: -> { tag.label(t("helpers.label.publishers_job_listing_about_the_role_form.further_details"), class: ["govuk-label", "govuk-!-font-weight-bold"]) },
-                                max_words: 100
+            = editor(form_input: f.govuk_text_area(:further_details),
+                     value: form.further_details,
+                     field_name: "publishers_job_listing_about_the_role_form[further_details]",
+                     label: { text: t("helpers.label.publishers_job_listing_about_the_role_form.further_details"), classes: ["govuk-label", "govuk-label--s", "govuk-!-margin-bottom-2", "govuk-!-font-weight-bold"], id: "further-details-label" })
           = f.govuk_radio_button :further_details_provided, "false", link_errors: true
 
       = render "publishers/vacancies/vacancy_form_partials/submit", f: f

--- a/app/views/vacancies/listing/_job_details.html.slim
+++ b/app/views/vacancies/listing/_job_details.html.slim
@@ -67,11 +67,11 @@ section#job-details class="govuk-!-margin-bottom-5"
 
   - if vacancy.further_details_provided?
     h2.govuk-heading-m = t("jobs.further_details")
-    p.govuk-body = vacancy.further_details
+    p.govuk-body == vacancy.further_details
 
   - if vacancy.safeguarding_information_provided?
     h2.govuk-heading-m = t("jobs.safeguarding_information.jobseeker")
-    p.govuk-body = vacancy.safeguarding_information
+    p.govuk-body == vacancy.safeguarding_information
 
   - if vacancy.expires_at.future?
     h3.govuk-heading-m = t("jobseekers.job_applications.applying_for_the_job_heading")

--- a/spec/form_models/publishers/job_listing/about_the_role_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/about_the_role_form_spec.rb
@@ -142,14 +142,34 @@ RSpec.describe Publishers::JobListing::AboutTheRoleForm, type: :model do
     end
 
     context "when safeguarding_information_provided is true" do
-      before { allow(subject).to receive(:safeguarding_information_provided).and_return("true") }
+      let(:error) { %i[safeguarding_information blank] }
+      let(:params) { { safeguarding_information: safeguarding_information, safeguarding_information_provided: "true" } }
 
-      it { is_expected.to validate_presence_of(:safeguarding_information) }
+      context "when safeguarding_information has been provided" do
+        let(:error) { %i[safeguarding_information blank] }
+        let(:safeguarding_information) { Faker::Lorem.sentence(word_count: 99) }
+
+        it "passes validation" do
+          expect(subject.errors.added?(*error)).to be false
+        end
+      end
+
+      context "when safeguarding_information has not been provided" do
+        let(:error) { %i[safeguarding_information blank] }
+        let(:safeguarding_information) { nil }
+
+        it "fails validation" do
+          expect(subject.errors.added?(*error)).to be true
+        end
+      end
 
       context "when either job_advert or about_school is present" do
         let(:vacancy) { build_stubbed(:vacancy, :at_one_school, job_role: "teacher", about_school: "Test") }
+        let(:safeguarding_information) { nil }
 
-        it { is_expected.not_to validate_presence_of(:safeguarding_information) }
+        it "does not fail validation" do
+          expect(subject.errors.added?(*error)).to be false
+        end
       end
 
       context "when safeguarding_information is over 100 words" do


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-4468

## Changes in this PR:

- Made some changes to the editor component to so custom styles can be added to the label
- Added the bullet point toggle button to the `safeguarding_information` and `further_details` fields
- Added some tests