### PR TITLE
Amend tests to fix rspec warnings

### DIFF
--- a/spec/components/dashboard_component_spec.rb
+++ b/spec/components/dashboard_component_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe DashboardComponent, type: :component do
         let!(:inline_component) { render_inline(subject) }
 
         it "renders the Create a job listing button" do
-          expect(rendered_component).to include(Rails.application.routes.url_helpers.organisation_jobs_path)
+          expect(rendered_content).to include(Rails.application.routes.url_helpers.organisation_jobs_path)
         end
 
         it "renders the number of jobs in the heading" do

--- a/spec/form_models/publishers/job_listing/pay_package_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/pay_package_form_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-SALARIES = {
+SALARY_OPTIONS = {
   salary: "full_time",
   actual_salary: "part_time",
   pay_scale: "pay_scale",
@@ -16,7 +16,7 @@ RSpec.describe Publishers::JobListing::PayPackageForm, type: :model do
                   pay_scale: nil)
   end
 
-  SALARIES.each do |salary_value, salary_type|
+  SALARY_OPTIONS.each do |salary_value, salary_type|
     context "when only #{salary_type} salary is selected" do
       let(:params) { { salary_types: [salary_type], benefits: "false" } }
 
@@ -24,7 +24,7 @@ RSpec.describe Publishers::JobListing::PayPackageForm, type: :model do
       it { is_expected.to validate_length_of(salary_value).is_at_least(1).is_at_most(256) }
       it { is_expected.to validate_inclusion_of(:benefits).in_array([true, false, "true", "false"]) }
 
-      (SALARIES.keys - [salary_value]).each do |other_salary_type|
+      (SALARY_OPTIONS.keys - [salary_value]).each do |other_salary_type|
         it { is_expected.not_to validate_presence_of(other_salary_type) }
       end
     end

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -198,9 +198,7 @@ module VacancyHelpers
       expect(page).to have_content(vacancy.starts_on.to_formatted_s.strip)
     end
 
-    if vacancy.enable_job_applications?
-      expect(page).to have_content(vacancy.personal_statement_guidance)
-    else
+    unless vacancy.enable_job_applications?
       expect(page.html).to include(I18n.t("helpers.label.publishers_job_listing_how_to_receive_applications_form.receive_applications_options.#{vacancy.receive_applications}"))
       expect(page).to have_content(vacancy.application_link) if vacancy.receive_applications == "website"
       expect(page).to have_content(vacancy.application_email) if vacancy.receive_applications == "email"


### PR DESCRIPTION
## Changes in this PR:

Fixes:
- The deprecation warning for `rendered_component` in `dashboard_component_spec.rb`. 
- "Checking for expected text of nil" warnings for specs which use  the`verify_all_vacancy_details` method in `vacancy_helpers.rb` .
- The "already initialized constant `SALARIES`" warning in `pay_package_form_spec.rb`
