### PR TITLE
Add DfE Analytics gem

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -6,3 +6,7 @@ DFE_SIGN_IN_URL=https://test-url.local
 DOMAIN=localhost:3000
 VACANCY_SOURCE_UNITED_LEARNING_FEED_URL=http://example.com/feed.xml
 VACANCY_SOURCE_FUSION_FEED_URL=http://example.com/feed.json
+BIGQUERY_TABLE_NAME=test_events
+BIGQUERY_PROJECT_ID=teacher-vacancy-service
+BIGQUERY_DATASET=testing_dataset
+BIG_QUERY_API_JSON_KEY={}

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem "array_enum"
 gem "aws-sdk-s3", require: false
 gem "breasal"
 gem "devise"
+gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.5.3"
 gem "factory_bot_rails"
 gem "faker"
 gem "friendly_id"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/DFE-Digital/dfe-analytics.git
+  revision: bfa569a60b4fca7545ca7b72764c526b65d913b9
+  tag: v1.5.3
+  specs:
+    dfe-analytics (1.5.3)
+      google-cloud-bigquery (~> 1.38)
+      request_store_rails (~> 2)
+
+GIT
   remote: https://github.com/rails/spring-watcher-listen.git
   revision: 5c8aa810b723dec01a12dbb33d1722d097994ebe
   specs:
@@ -218,9 +227,9 @@ GEM
     geocoder (1.8.1)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    google-apis-bigquery_v2 (0.40.0)
-      google-apis-core (>= 0.7, < 2.a)
-    google-apis-core (0.9.0)
+    google-apis-bigquery_v2 (0.42.0)
+      google-apis-core (>= 0.9.0, < 2.a)
+    google-apis-core (0.9.1)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.16.2, < 2.a)
       httpclient (>= 2.8.1, < 3.a)
@@ -245,7 +254,7 @@ GEM
     google-cloud-env (1.6.0)
       faraday (>= 0.17.3, < 3.0)
     google-cloud-errors (1.3.0)
-    googleauth (1.2.0)
+    googleauth (1.3.0)
       faraday (>= 0.17.3, < 3.a)
       jwt (>= 1.4, < 3.0)
       memoist (~> 0.16)
@@ -485,6 +494,8 @@ GEM
       uber (< 0.2.0)
     request_store (1.5.1)
       rack (>= 1.4)
+    request_store_rails (2.0.0)
+      concurrent-ruby (~> 1.0)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -679,6 +690,7 @@ DEPENDENCIES
   climate_control
   cssbundling-rails
   devise
+  dfe-analytics!
   dotenv-rails
   factory_bot_rails
   faker

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   include Pagy::Backend
+  include DfE::Analytics::Requests
 
   SUSPICIOUS_RECAPTCHA_THRESHOLD = 0.5
   VALID_CLICK_EVENT_TYPES = %w[vacancy_save_to_account_clicked].freeze

--- a/app/models/location_polygon.rb
+++ b/app/models/location_polygon.rb
@@ -13,6 +13,8 @@ class LocationPolygon < ApplicationRecord
   end
 
   def self.include?(location)
+    return super unless location.is_a? String
+
     ALL_IMPORTED_LOCATIONS.include?(mapped_name(location))
   end
 

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -324,3 +324,20 @@ shared:
     - external_source
     - external_reference
     - external_advert_url
+    - school_visits_details
+    - school_visits_details
+    - job_location
+    - job_roles
+    - starts_asap
+    - phase
+    - pay_scale
+    - receive_applications
+    - application_email
+    - contact_number_provided
+    - skills_and_experience
+    - school_offer
+    - safeguarding_information_provided
+    - safeguarding_information
+    - further_details_provided
+    - further_details
+    - include_additional_documents

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -1,0 +1,152 @@
+---
+shared:
+  :friendly_id_slugs:
+    - id
+    - slug
+    - sluggable_id
+    - sluggable_type
+    - scope
+    - created_at
+  :versions:
+    - id
+    - item_type
+    - item_id
+    - event
+    - whodunnit
+    - object
+    - created_at
+    - object_changes
+  :sessions:
+    - id
+    - session_id
+    - data
+    - created_at
+    - updated_at
+  :active_storage_variant_records:
+    - id
+    - blob_id
+    - variation_digest
+  :active_storage_blobs:
+    - id
+    - key
+    - filename
+    - content_type
+    - metadata
+    - service_name
+    - byte_size
+    - checksum
+    - created_at
+  :active_storage_attachments:
+    - id
+    - name
+    - record_type
+    - record_id
+    - blob_id
+    - created_at
+  :vacancies:
+    - readable_job_location
+    - readable_phases
+    - searchable_content
+    - google_index_removed
+    - expired_vacancy_feedback_email_sent_at
+  :school_group_memberships:
+    - do_not_delete
+  :references:
+    - name_ciphertext
+    - job_title_ciphertext
+    - organisation_ciphertext
+    - email_ciphertext
+    - phone_number_ciphertext
+  :qualifications:
+    - finished_studying_details_ciphertext
+  :notifications:
+    - params
+  :notes:
+    - id
+    - content
+    - publisher_id
+    - job_application_id
+    - created_at
+    - updated_at
+  :markers:
+    - id
+    - vacancy_id
+    - organisation_id
+    - geopoint
+    - created_at
+    - updated_at
+  :job_applications:
+    - qualified_teacher_status_details
+    - disability
+    - gender
+    - gender_description
+    - orientation
+    - orientation_description
+    - ethnicity
+    - ethnicity_description
+    - religion
+    - religion_description
+    - age
+    - first_name_ciphertext
+    - last_name_ciphertext
+    - previous_names_ciphertext
+    - street_address_ciphertext
+    - city_ciphertext
+    - postcode_ciphertext
+    - phone_number_ciphertext
+    - teacher_reference_number_ciphertext
+    - national_insurance_number_ciphertext
+    - personal_statement_ciphertext
+    - support_needed_details_ciphertext
+    - close_relationships_details_ciphertext
+    - further_instructions_ciphertext
+    - rejection_reasons_ciphertext
+    - gaps_in_employment_details_ciphertext
+    - in_progress_steps
+    - employment_history_section_completed
+    - qualifications_section_completed
+  :employments:
+    - organisation_ciphertext
+    - job_title_ciphertext
+    - main_duties_ciphertext
+  :emergency_login_keys:
+    - id
+    - not_valid_after
+    - publisher_id
+    - created_at
+    - updated_at
+  :alert_runs:
+    - id
+    - subscription_id
+    - run_on
+    - job_id
+    - created_at
+    - updated_at
+    - status
+  :feedbacks:
+    - comment
+    - other_unsubscribe_reason_comment
+    - visit_purpose_comment
+    - category
+  :support_users:
+    - id
+    - oid
+    - email
+    - given_name
+    - family_name
+    - created_at
+    - updated_at
+  :publishers:
+    - family_name_ciphertext
+    - given_name_ciphertext
+    - dismissed_new_features_page_at
+    - unsubscribed_from_expired_vacancy_prompt_at
+  :jobseekers:
+    - encrypted_password
+    - current_sign_in_ip_ciphertext
+    - last_sign_in_ip_ciphertext
+    - last_sign_in_ip
+    - current_sign_in_ip
+  :organisations:
+    - gias_data_hash
+    - slug

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -1,0 +1,49 @@
+DfE::Analytics.configure do |config|
+  # Whether to log events instead of sending them to BigQuery.
+  #
+  config.log_only = false
+
+  # Whether to use ActiveJob or dispatch events immediately.
+  #
+  config.async = false
+
+  # Which ActiveJob queue to put events on
+  #
+  # config.queue = :default
+
+  # The name of the BigQuery table we’re writing to.
+  #
+  config.bigquery_table_name = ENV.fetch("BIGQUERY_TABLE_NAME", nil)
+
+  # The name of the BigQuery project we’re writing to.
+  #
+  config.bigquery_project_id = ENV.fetch("BIGQUERY_PROJECT_ID", nil)
+
+  # The name of the BigQuery dataset we're writing to.
+  #
+  config.bigquery_dataset = ENV.fetch("BIGQUERY_DATASET", nil)
+
+  # Service account JSON key for the BigQuery API. See
+  # https://cloud.google.com/bigquery/docs/authentication/service-account-file
+  #
+  config.bigquery_api_json_key = ENV.fetch("BIG_QUERY_API_JSON_KEY", nil)
+
+  # Passed directly to the retries: option on the BigQuery client
+  #
+  # config.bigquery_retries = 3
+
+  # Passed directly to the timeout: option on the BigQuery client
+  #
+  # config.bigquery_timeout = 120
+
+  # A proc which returns true or false depending on whether you want to
+  # enable analytics. You might want to hook this up to a feature flag or
+  # environment variable.
+  #
+  # config.enable_analytics = proc { true }
+
+  # The environment we’re running in. This value will be attached
+  # to all events we send to BigQuery.
+  #
+  config.environment = ENV.fetch("RAILS_ENV", "development")
+end

--- a/spec/jobs/alert_mailer_job_spec.rb
+++ b/spec/jobs/alert_mailer_job_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe AlertMailerJob do
     allow_any_instance_of(AlertMailerJob).to receive(:provider_job_id) { job_id }
 
     allow_any_instance_of(AlertMailerJob).to receive(:subscription) { subscription }
-    expect(AlertMailerJob.queue_adapter).to receive(:enqueue).twice.ordered
+    expect(AlertMailerJob.queue_adapter).to receive(:enqueue).exactly(3).times.ordered
     expect(subscription).to receive(:alert_run_today) { alert_run }
     expect(alert_run).to receive(:update).with(job_id: job_id).ordered
     job

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 require "axe-rspec"
+require "dfe/analytics/testing"
 require "factory_bot_rails"
 require "geocoder"
 require "geocoding"

--- a/spec/system/dfe_analytics_spec.rb
+++ b/spec/system/dfe_analytics_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+require "dfe/analytics/rspec/matchers"
+
+RSpec.describe "dfe analytics integration" do
+  context "events being sent from creating new entities" do
+    it "sends a DFE Analytics web request event" do
+      expect {  create(:vacancy) }.to have_sent_analytics_event_types(:create_entity)
+    end
+  end
+
+  context "events being sent from updating entities" do
+    let(:vacancy) { create(:vacancy) }
+
+    it "sends a DFE Analytics web request event" do
+      expect { vacancy.update!(job_title: "test") }.to have_sent_analytics_event_types(:update_entity)
+    end
+  end
+
+  context "events being sent from deleting entities" do
+    let(:vacancy) { create(:vacancy) }
+
+    it "sends a DFE Analytics web request event" do
+      expect { vacancy.destroy! }.to have_sent_analytics_event_types(:delete_entity)
+    end
+  end
+
+  context "events being sent for Web requests" do
+    it "sends a DFE Analytics web request event" do
+      expect { get "/api/test" }.to have_sent_analytics_event_types(:web_request)
+    end
+  end
+end


### PR DESCRIPTION
The Data & Insights team have recently released this new gem to streamline the way teams in Teacher Services sends data to the analytical platform in BigQuery. This work migrates our custom bespoke streaming code to the gem built by the data team.

## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-4467

## How to review this PR?

It's fairly straight forward but if you're lost you can review commit by commit