### PR TITLE
[TEVA-4470] use skills and experience for new schema job listings to populate goo…

### DIFF
--- a/app/views/api/vacancies/_show.json.jbuilder
+++ b/app/views/api/vacancies/_show.json.jbuilder
@@ -4,7 +4,7 @@ json.set! "@type", "JobPosting"
 json.title vacancy.job_title
 json.jobBenefits vacancy.benefits_details
 json.datePosted vacancy.publish_on.to_time.iso8601
-json.description vacancy.job_advert
+json.description vacancy.skills_and_experience.present? ? vacancy.skills_and_experience : vacancy.job_advert
 json.occupationalCategory vacancy.job_role
 json.directApply vacancy.enable_job_applications
 

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -264,7 +264,7 @@ module VacancyHelpers
       title: vacancy.job_title,
       jobBenefits: vacancy.benefits_details,
       datePosted: vacancy.publish_on.to_time.iso8601,
-      description: vacancy.job_advert,
+      description: vacancy.skills_and_experience.present? ? vacancy.skills_and_experience : vacancy.job_advert,
       occupationalCategory: vacancy.job_role,
       directApply: vacancy.enable_job_applications,
       employmentType: vacancy.working_patterns_for_job_schema,


### PR DESCRIPTION
with new vacancy schema the description of the schema.org job listing data is blank so use skills and experience field data