### PR TITLE
Increase the character count to 300 for school_offer, skills_and_experience and further_details sections of the vacancy creation process

### DIFF
--- a/app/assets/javascript/components/editor/editor.js
+++ b/app/assets/javascript/components/editor/editor.js
@@ -140,19 +140,20 @@ const EditorController = class extends Controller {
   };
 
   wordCount(content) {
+    const MAX_WORDS = 300
     const strippedContent = content.replace(/<(.|\n)*?>/g, ' ');
     const numberwords = strippedContent.trim().split(/\s+/);
 
     let message;
 
-    if (numberwords.length > 300) {
-      message = `You have ${numberwords.length - 300} words too many`;
+    if (numberwords.length > MAX_WORDS) {
+      message = `You have ${numberwords.length - MAX_WORDS} words too many`;
       this.wordCountErrorState();
-    } else if (numberwords.length <= 300 && numberwords[0].length > 0) {
-      message = `You have ${300 - numberwords.length} words remaining`;
+    } else if (numberwords.length <= MAX_WORDS && numberwords[0].length > 0) {
+      message = `You have ${MAX_WORDS - numberwords.length} words remaining`;
       this.wordCountDefaultState();
     } else {
-      message = 'You have 300 words remaining';
+      message = `You have ${MAX_WORDS} words remaining`;
       this.wordCountDefaultState();
     }
 

--- a/app/assets/javascript/components/editor/editor.js
+++ b/app/assets/javascript/components/editor/editor.js
@@ -140,7 +140,7 @@ const EditorController = class extends Controller {
   };
 
   wordCount(content) {
-    const MAX_WORDS = 300
+    const MAX_WORDS = 300;
     const strippedContent = content.replace(/<(.|\n)*?>/g, ' ');
     const numberwords = strippedContent.trim().split(/\s+/);
 

--- a/app/assets/javascript/components/editor/editor.js
+++ b/app/assets/javascript/components/editor/editor.js
@@ -145,14 +145,14 @@ const EditorController = class extends Controller {
 
     let message;
 
-    if (numberwords.length > 150) {
-      message = `You have ${numberwords.length - 150} words too many`;
+    if (numberwords.length > 300) {
+      message = `You have ${numberwords.length - 300} words too many`;
       this.wordCountErrorState();
-    } else if (numberwords.length <= 150 && numberwords[0].length > 0) {
-      message = `You have ${150 - numberwords.length} words remaining`;
+    } else if (numberwords.length <= 300 && numberwords[0].length > 0) {
+      message = `You have ${300 - numberwords.length} words remaining`;
       this.wordCountDefaultState();
     } else {
-      message = 'You have 150 words remaining';
+      message = 'You have 300 words remaining';
       this.wordCountDefaultState();
     }
 

--- a/app/form_models/publishers/job_listing/about_the_role_form.rb
+++ b/app/form_models/publishers/job_listing/about_the_role_form.rb
@@ -47,7 +47,7 @@ class Publishers::JobListing::AboutTheRoleForm < Publishers::JobListing::Vacancy
   end
 
   def school_offer_does_not_exceed_maximum_words
-    errors.add(:school_offer, :length, organisation: organisation_type.capitalize) if number_of_words_exceeds_permitted_length?(150, school_offer)
+    errors.add(:school_offer, :length, organisation: organisation_type.capitalize) if number_of_words_exceeds_permitted_length?(300, school_offer)
   end
 
   def skills_and_experience_presence
@@ -57,7 +57,7 @@ class Publishers::JobListing::AboutTheRoleForm < Publishers::JobListing::Vacancy
   end
 
   def skills_and_experience_does_not_exceed_maximum_words
-    errors.add(:skills_and_experience, :length) if number_of_words_exceeds_permitted_length?(150, skills_and_experience)
+    errors.add(:skills_and_experience, :length) if number_of_words_exceeds_permitted_length?(300, skills_and_experience)
   end
 
   def safeguarding_information_presence
@@ -77,7 +77,7 @@ class Publishers::JobListing::AboutTheRoleForm < Publishers::JobListing::Vacancy
   end
 
   def further_details_does_not_exceed_maximum_words
-    errors.add(:further_details, :length) if number_of_words_exceeds_permitted_length?(100, further_details)
+    errors.add(:further_details, :length) if number_of_words_exceeds_permitted_length?(300, further_details)
   end
 
   def about_school_presence

--- a/app/views/publishers/vacancies/build/about_the_role.html.slim
+++ b/app/views/publishers/vacancies/build/about_the_role.html.slim
@@ -18,7 +18,7 @@
         = editor(form_input: f.govuk_text_area(:job_advert, label: { size: "s", id: "job-advert-label" }, rows: 5, required: true, aria: { hidden: false }), value: form.job_advert, field_name: "publishers_job_listing_about_the_role_form[job_advert]", label: { text: t("helpers.label.publishers_job_listing_about_the_role_form.job_advert"), size: "s", id: "job-advert-label" })
 
       - else
-        = editor(form_input: f.govuk_text_area(:skills_and_experience, max_words: 150, label: { size: "s", id: "skills-and-experience-label" }, rows: 5, required: true, aria: { hidden: false }), value: form.skills_and_experience, field_name: "publishers_job_listing_about_the_role_form[skills_and_experience]", label: { text: t("helpers.label.publishers_job_listing_about_the_role_form.skills_and_experience"), size: "s", id: "skills-and-experience-label" })
+        = editor(form_input: f.govuk_text_area(:skills_and_experience, max_words: 300, label: { size: "s", id: "skills-and-experience-label" }, rows: 5, required: true, aria: { hidden: false }), value: form.skills_and_experience, field_name: "publishers_job_listing_about_the_role_form[skills_and_experience]", label: { text: t("helpers.label.publishers_job_listing_about_the_role_form.skills_and_experience"), size: "s", id: "skills-and-experience-label" })
 
       - if vacancy.about_school.present?
         = f.govuk_text_area :about_school,
@@ -29,7 +29,7 @@
                 required: true
 
       - else
-        = editor(form_input: f.govuk_text_area(:school_offer, max_words: 150, label: { size: "s", id: "school-offer-label" }, rows: 5, required: true, aria: { hidden: false }), value: form.school_offer, field_name: "publishers_job_listing_about_the_role_form[school_offer]", label: { text: t("jobs.school_offer.publisher"), size: "s", id: "school-offer-label" })
+        = editor(form_input: f.govuk_text_area(:school_offer, max_words: 300, label: { size: "s", id: "school-offer-label" }, rows: 5, required: true, aria: { hidden: false }), value: form.school_offer, field_name: "publishers_job_listing_about_the_role_form[school_offer]", label: { text: t("jobs.school_offer.publisher"), size: "s", id: "school-offer-label" })
 
       - unless vacancy.job_advert.present?
         = f.govuk_radio_buttons_fieldset :safeguarding_information_provided, legend: { size: "m", tag: nil }, classes: ["safeguarding-information-provided-radios"] do

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -234,10 +234,10 @@ en:
       blank: Enter a job advert
     skills_and_experience:
       blank: Enter the skills and experience you’re looking for
-      length: Skills and experience must be 150 words or less
+      length: Skills and experience must be 300 words or less
     school_offer:
       blank: Enter the information about what your %{organisation} offers
-      length: "%{organisation} offer must be 150 words or less"
+      length: "%{organisation} offer must be 300 words or less"
     schools_offer:
       blank: Enter the information about what your %{organisation} offer
     safeguarding_information_provided:
@@ -249,7 +249,7 @@ en:
       inclusion: Select yes if you want to add further details about the role
     further_details:
       blank: Enter further details about the role
-      length: Further details must be 100 words or less
+      length: Further details must be 300 words or less
   include_additional_documents_errors: &include_additional_documents_errors
     include_additional_documents:
       inclusion: Select yes if want to upload additional documents

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -28,7 +28,7 @@ FactoryBot.define do
     contract_type { factory_sample(Vacancy.contract_types.keys) }
     fixed_term_contract_duration { "6 months" }
     further_details_provided { true }
-    further_details { Faker::Lorem.sentence(word_count: factory_rand(50..100)) }
+    further_details { Faker::Lorem.sentence(word_count: factory_rand(50..300)) }
     parental_leave_cover_contract_duration { "6 months" }
     expires_at { 6.months.from_now.change(hour: 9, minute: 0, second: 0) }
     hired_status { nil }

--- a/spec/form_models/publishers/job_listing/about_the_role_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/about_the_role_form_spec.rb
@@ -60,9 +60,9 @@ RSpec.describe Publishers::JobListing::AboutTheRoleForm, type: :model do
       end
     end
 
-    context "when skills_and_experience is over 150 words" do
+    context "when skills_and_experience is over 300 words" do
       let(:error) { %i[skills_and_experience length] }
-      let(:params) { { skills_and_experience: Faker::Lorem.sentence(word_count: 151) } }
+      let(:params) { { skills_and_experience: Faker::Lorem.sentence(word_count: 301) } }
 
       it "fails validation" do
         expect(subject.errors.added?(*error)).to be true
@@ -121,9 +121,9 @@ RSpec.describe Publishers::JobListing::AboutTheRoleForm, type: :model do
       end
     end
 
-    context "when school_offer is over 150 words" do
+    context "when school_offer is over 300 words" do
       let(:error) { [:school_offer, :length, { organisation: "School" }] }
-      let(:params) { { school_offer: Faker::Lorem.sentence(word_count: 151) } }
+      let(:params) { { school_offer: Faker::Lorem.sentence(word_count: 301) } }
 
       it "fails validation" do
         expect(subject.errors.added?(*error)).to be true
@@ -204,9 +204,9 @@ RSpec.describe Publishers::JobListing::AboutTheRoleForm, type: :model do
         it { is_expected.not_to validate_presence_of(:further_details) }
       end
 
-      context "when further_details is over 100 words" do
+      context "when further_details is over 300 words" do
         let(:error) { %i[further_details length] }
-        let(:params) { { further_details: Faker::Lorem.sentence(word_count: 101), further_details_provided: "true" } }
+        let(:params) { { further_details: Faker::Lorem.sentence(word_count: 301), further_details_provided: "true" } }
 
         it "fails validation" do
           expect(subject.errors.added?(*error)).to be true


### PR DESCRIPTION
Increase the character count to 300 for school_offer, skills_and_experience and further_details sections of the vacancy creation process

## Changes in this PR:

We have increased the character count for `school_offer` `skills_and_experience` from 150 to 300 and 100 to 300 for `further_details`

## Screenshots of UI changes:

### Before
![Screenshot 2022-11-04 at 08 30 30@2x](https://user-images.githubusercontent.com/40758489/199953917-2dd9f9aa-ac3a-4923-a233-1781006a0d95.png)

![Screenshot 2022-11-04 at 08 33 31@2x](https://user-images.githubusercontent.com/40758489/199953921-3f6c907a-106c-4e7d-b9c8-f920e7995e85.png)

### After


<img width="848" alt="Screenshot 2022-11-04 at 10 44 10" src="https://user-images.githubusercontent.com/40758489/199954411-1fee3914-df44-4063-b858-2a429a763375.png">

<img width="830" alt="Screenshot 2022-11-04 at 10 45 08" src="https://user-images.githubusercontent.com/40758489/199954416-6393ed49-c95b-4235-85bb-9c928b8d4c2c.png">
