### PR TITLE
TEVA-4481: Remove links to schools/trusts from the job listings page

### DIFF
--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -78,9 +78,9 @@ module VacanciesHelper
 
   def vacancy_full_job_location(vacancy)
     organisation = vacancy.organisation
-    return "#{t('organisations.job_location_summary.at_multiple_locations')}, #{govuk_link_to(organisation.name, organisation_landing_page_path(organisation))}".html_safe if vacancy.organisations.many?
+    return "#{t('organisations.job_location_summary.at_multiple_locations')}, #{organisation.name}" if vacancy.organisations.many?
 
-    address_join([govuk_link_to(organisation.name, organisation_landing_page_path(organisation)), organisation.town, organisation.county, organisation.postcode]).html_safe
+    address_join([organisation.name, organisation.town, organisation.county, organisation.postcode])
   end
 
   def vacancy_listing_page_title_prefix(vacancy)

--- a/spec/helpers/vacancies_helper_spec.rb
+++ b/spec/helpers/vacancies_helper_spec.rb
@@ -82,7 +82,6 @@ RSpec.describe VacanciesHelper do
 
   describe "#vacancy_full_job_location" do
     subject { helper.vacancy_full_job_location(vacancy) }
-    let(:organisation_link) { helper.govuk_link_to(vacancy.organisation.name, organisation_landing_page_path(vacancy.organisation.slug)) }
 
     context "when the vacancy is at multiple schools" do
       let(:school_group) { create(:school_group) }
@@ -91,7 +90,7 @@ RSpec.describe VacanciesHelper do
       let(:vacancy) { build(:vacancy, organisations: [school, school2]) }
 
       it "returns the multiple schools location" do
-        expect(subject).to eq("More than one location, #{organisation_link}")
+        expect(subject).to eq("More than one location, #{vacancy.organisation.name}")
       end
     end
 
@@ -100,7 +99,7 @@ RSpec.describe VacanciesHelper do
       let(:vacancy) { build(:vacancy, organisations: [school]) }
 
       it "returns the full location" do
-        expect(subject).to eq("#{organisation_link}, Cool Town, Orange County, SW1A")
+        expect(subject).to eq("#{vacancy.organisation.name}, Cool Town, Orange County, SW1A")
       end
     end
   end

--- a/spec/system/jobseekers_can_view_organisation_landing_pages_spec.rb
+++ b/spec/system/jobseekers_can_view_organisation_landing_pages_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Jobseekers can view organisation landing pages" do
       expect(page.title).to eq("School & Teaching Jobs at #{school.name} - Teaching Vacancies - GOV.UK")
       expect(page).to have_css("h1", text: "1 job found at #{school.name}")
       expect(page).to have_link(vacancy.job_title.to_s)
-      expect(page).to have_link(school.name, href: organisation_landing_page_path(school.slug))
+      expect(page).to have_css("p", text: school.name)
     end
   end
 
@@ -27,17 +27,8 @@ RSpec.describe "Jobseekers can view organisation landing pages" do
       expect(page).to have_css("h1", text: "2 jobs found at #{school_group.name}")
       expect(page).to have_link(vacancy.job_title.to_s)
       expect(page).to have_link(vacancy2.job_title.to_s)
-      expect(page).to have_link(school.name, href: organisation_landing_page_path(school.slug))
-      expect(page).to have_link(school_group.name, href: organisation_landing_page_path(school_group.slug))
-    end
-  end
-
-  context "when clicking on an organisation link from the search results page" do
-    it "takes you to the organisation landing page" do
-      visit root_path
-      click_on I18n.t("buttons.search")
-      click_on school.name
-      expect(current_path).to eq(organisation_landing_page_path(school.slug))
+      expect(page).to have_css("p", text: school.name)
+      expect(page).to have_css("p", text: school_group.name)
     end
   end
 end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-4481

## Changes in this PR:

Remove links to schools/trusts from the job listings page

## Screenshots of UI changes:

### Before
<img width="612" alt="Screenshot 2022-11-04 at 15 07 20" src="https://user-images.githubusercontent.com/40758489/200008652-b4ed357b-61cf-44aa-b2d8-ddb179e326d3.png">

<img width="884" alt="Screenshot 2022-11-04 at 15 07 26" src="https://user-images.githubusercontent.com/40758489/200008655-5cb33b17-910c-47b6-8b7d-3e6c1a9ee9c3.png">

### After
<img width="657" alt="Screenshot 2022-11-04 at 15 08 32" src="https://user-images.githubusercontent.com/40758489/200008940-bd2216ec-d877-42fe-97c6-1bb233dcf39d.png">

<img width="1014" alt="Screenshot 2022-11-04 at 15 08 39" src="https://user-images.githubusercontent.com/40758489/200008944-c4c4038d-1025-4f18-84e4-a1882953c44f.png">

