### PR TITLE
Only show change location link when is a trust

### DIFF
--- a/app/views/publishers/vacancies/vacancy_review_sections/_job_details.html.slim
+++ b/app/views/publishers/vacancies/vacancy_review_sections/_job_details.html.slim
@@ -8,7 +8,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
     - row.value
       ul.govuk-list.govuk-list--spaced
         = vacancy_job_locations(vacancy)
-    - unless vacancy.legacy_draft?
+    - unless vacancy.legacy_draft? || current_organisation.school?
       - row.action text: t("buttons.change"),
                   href: organisation_job_build_path(vacancy.id, :job_location, "back_to_#{action_name}": "true"),
                   visually_hidden_text: t("publishers.vacancies.steps.job_location")


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-4508

## Changes in this PR:
Only show change location link when it is NOT school. as you can't change the location of a vacancy if its under a school as that school only has one location

## Screenshots of UI changes:

### Before
![image-20221103-170316](https://user-images.githubusercontent.com/40758489/200313390-7f39250d-591b-4437-ad35-06909a4ef616.png)


### After
<img width="1113" alt="Screenshot 2022-11-07 at 12 31 17" src="https://user-images.githubusercontent.com/40758489/200313380-90f00a3e-7d41-4218-84fd-f6fbbcb314fc.png">

