### PR TITLE
Stop using set-output in workflow

### DIFF
--- a/.github/actions/prepare-app-env/action.yml
+++ b/.github/actions/prepare-app-env/action.yml
@@ -37,7 +37,7 @@ runs:
     - name: Yarn cache
       if: ${{ inputs.skip-node == 'false' }}
       id: yarn-cache
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Set up yarn cache


### PR DESCRIPTION
The set-output command is being deprecated soon so needs updating as per [GitHub guidance](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).


## Trello ticket URL

https://trello.com/c/3s3iC7UV

## Changes in this PR:

Use $GITHUB_OUTPUT as per the workflow commands docs.

## Next steps:

- [x] Tested prepare-app-env action (https://github.com/DFE-Digital/teaching-vacancies/actions/runs/3408707583/jobs/5669603773#step:4:327)
