### PR TITLE
TEVA-4407: Add Ofsted report row to the school/organisation profile page

### DIFF
--- a/app/views/publishers/schools/_organisation.html.slim
+++ b/app/views/publishers/schools/_organisation.html.slim
@@ -36,3 +36,7 @@
     - row.key text: t(".description.label.#{organisation.school? ? :school : :organisation}")
     - row.value text: organisation.description? ? truncate(organisation.description, length: 130) : t(".not_provided")
     - row.action text: t("buttons.change"), href: edit_publishers_school_path(organisation), classes: "govuk-link--no-visited-state"
+
+  - summary_list.row do |row|
+    - row.key text: t("schools.ofsted_report")
+    - row.value text: organisation.has_ofsted_report? ? ofsted_report_link(organisation, class: "wordwrap") : t("schools.no_information")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,7 +10,7 @@ en:
     environment_html: This is not the live Teaching Vacancies website. You are currently viewing the <span class="govuk-!-font-weight-bold">%{environment}</span> version of the site.
     govuk: GOV.UK
     menu: Menu
-    opens_in_new_tab: "%{link_text} (opens in a new tab)"
+    opens_in_new_tab: "%{link_text} (opens in new tab)"
     pagy_stats_html: >-
       Showing <span class='govuk-!-font-weight-bold'>%{from}</span>
       to <span class='govuk-!-font-weight-bold'>%{to}</span>

--- a/spec/helpers/links_helper_spec.rb
+++ b/spec/helpers/links_helper_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe LinksHelper do
     let(:kwargs) { { class: "special-class", data: { awesome: "true" } } }
 
     it "returns a link with (open in a new tab) text and correct class" do
-      expect(subject).to have_link("#{text} (opens in a new tab)", href: href, class: "govuk-link special-class")
+      expect(subject).to have_link("#{text} (opens in new tab)", href: href, class: "govuk-link special-class")
     end
 
     it "returns a link with correct attributes" do
@@ -26,7 +26,7 @@ RSpec.describe LinksHelper do
     let(:link_text) { "#{URI(root_url).host}/organisations/#{organisation.slug}" }
 
     it "generates a link with the URL included in the link text" do
-      expect(subject).to have_link("#{link_text} (opens in a new tab)", href: helper.organisation_landing_page_path(organisation))
+      expect(subject).to have_link("#{link_text} (opens in new tab)", href: helper.organisation_landing_page_path(organisation))
     end
   end
 end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-4407

## Changes in this PR:

We add the ofsted report to the school/organisation profile page, if there is no ofsted report it shows `No information available` in its place. This also takes the user to a new tab when clicked.

## Screenshots of UI changes:

### Before
<img width="1048" alt="Screenshot 2022-11-10 at 14 57 48" src="https://user-images.githubusercontent.com/40758489/201132921-e4bf981c-2d18-4cfd-a930-6e4f32c4a5d2.png">

### After

<img width="1038" alt="Screenshot 2022-11-10 at 14 57 10" src="https://user-images.githubusercontent.com/40758489/201132936-ef5848b5-536a-4911-8b0d-cbda7f85d5f8.png">
