### PR TITLE
Add Key Stages for Fusion

### DIFF
--- a/app/vacancy_sources/fusion_vacancy_source.rb
+++ b/app/vacancy_sources/fusion_vacancy_source.rb
@@ -46,9 +46,15 @@ class FusionVacancySource
       working_patterns: item["workingPatterns"].presence&.split(","),
       contract_type: item["contractType"].presence,
       phases: item["phase"].presence&.parameterize(separator: "_"),
+      key_stages: item["keyStages"].presence&.split(","),
 
       # TODO: What about central office/multiple school vacancies?
       job_location: :at_one_school,
+    }.merge(organisation_fields(item))
+  end
+
+  def organisation_fields(item)
+    {
       readable_job_location: organisations_for(item).first&.name,
       organisations: organisations_for(item),
       about_school: organisations_for(item).first&.description,

--- a/spec/fixtures/files/vacancy_sources/fusion.json
+++ b/spec/fixtures/files/vacancy_sources/fusion.json
@@ -12,6 +12,7 @@
       "schoolUrns": [
         "145506"
       ],
+      "keyStages": "ks1,ks2",
       "jobRole": "teacher",
       "workingPatterns": "full_time",
       "contractType": "fixed_term",

--- a/spec/vacancy_sources/fusion_vacancy_source_spec.rb
+++ b/spec/vacancy_sources/fusion_vacancy_source_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe FusionVacancySource do
         job_advert: "Lorem Ipsum dolor sit amet",
         salary: "£25,714.00 to £41,604.00",
         job_role: "teacher",
+        key_stages: %w[ks1 ks2],
         working_patterns: %w[full_time],
         contract_type: "fixed_term",
         phases: %w[primary],


### PR DESCRIPTION
# What does this do?

Fusion is adding key stages to their feed so we can starting parsing it and persist vacancies with the values

