### PR TITLE
Replace 'School hiring guides' with 'Hiring guides'

### DIFF
--- a/app/views/layouts/_footer.html.slim
+++ b/app/views/layouts/_footer.html.slim
@@ -46,7 +46,7 @@
             li.govuk-footer__list-item
               = link_to t("nav.sign_in"), new_publisher_session_path, class: "govuk-footer__link"
           li.govuk-footer__list-item
-            = link_to t("footer.school_hiring_guides"), posts_path(section: "get-help-hiring"), class: "govuk-footer__link"
+            = link_to t("footer.hiring_guides"), posts_path(section: "get-help-hiring"), class: "govuk-footer__link"
           - if Rails.configuration.app_role == "sandbox"
             li.govuk-footer__list-item
               = link_to "Sandbox guidance", page_path("sandbox"), class: "govuk-footer__link"

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -6,7 +6,7 @@
                              href: publishers_organisation_path(current_organisation),
                              active: schools_in_your_trust_active?
     = header.navigation_item text: t("nav.notifications_html", count: current_publisher.notifications.unread.count), href: publishers_notifications_path
-    = header.navigation_item text: t("nav.school_hiring_guides"), href: posts_path(section: "get-help-hiring")
+    = header.navigation_item text: t("nav.hiring_guides"), href: posts_path(section: "get-help-hiring")
     = header.navigation_item text: t("nav.sign_out"), href: destroy_publisher_session_path, options: { method: :delete }
   - elsif jobseeker_signed_in?
     = header.navigation_item text: t("nav.find_job"), href: root_path, active: find_jobs_active?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -173,7 +173,7 @@ en:
     manage_job_listings: Manage job listings
     provide_feedback: Provide feedback on Teaching Vacancies
     request_support: Get help or report a problem
-    school_hiring_guides: School hiring guides
+    hiring_guides: Hiring guides
     search_teaching_vacancies: Find a job
     service_support: Get support
 
@@ -220,7 +220,7 @@ en:
       one: Notifications <span class="count-badge">%{count}<span class="govuk-visually-hidden"> unread</span></span>
       other: Notifications <span class="count-badge">%{count}<span class="govuk-visually-hidden"> unread</span></span>
     personal_statement: Writing a personal statement
-    school_hiring_guides: School hiring guides
+    hiring_guides: Hiring guides
     sign_in: Sign in
     sign_out: Sign out
     support_user_dashboard: Support dashboard
@@ -303,7 +303,7 @@ en:
         meta_description: >-
           Expert advice on how to hire excellent staff for your school. Get tips on the recruitment process and guidance on how to use Teaching Vacancies.
         page_title: Hiring Advice for Schools
-        title: School hiring guides
+        title: Hiring guides
       jobseeker-guides:
         description: >-
           Looking for your next teaching job, or another role within a school? Take a look at our expert advice covering applications, interviews, and more


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-4536

## Changes in this PR:

Replace 'School hiring guides' with 'Hiring guides'

## Screenshots of UI changes:

### Before
<img width="1042" alt="Screenshot 2022-11-16 at 13 55 43" src="https://user-images.githubusercontent.com/40758489/202199442-ade95692-5cff-4c7c-a20d-38682773e94e.png">

### After
<img width="1023" alt="Screenshot 2022-11-16 at 13 55 22" src="https://user-images.githubusercontent.com/40758489/202199424-3de0f3f9-3583-4301-9ad1-4a9fd6e77398.png">

