### PR TITLE
add error class to editor component when form builder error

### DIFF
--- a/app/assets/javascript/components/editor/editor.js
+++ b/app/assets/javascript/components/editor/editor.js
@@ -23,6 +23,10 @@ const EditorController = class extends Controller {
       this.toolbarTarget.style.display = 'block';
     }
 
+    if (this.hasErrorState()) {
+      this.element.classList.add('govuk-form-group', 'govuk-form-group--error');
+    }
+
     // Ensure paragraphs are created instead of divs
     document.execCommand('defaultParagraphSeparator', false, 'p');
 
@@ -37,6 +41,10 @@ const EditorController = class extends Controller {
     this.formInput.insertAdjacentHTML('beforeBegin', editableAreaHhtml);
 
     this.update();
+  }
+
+  hasErrorState() {
+    return this.formInputTarget.querySelector('textarea').closest('.govuk-form-group').classList.contains('govuk-form-group--error');
   }
 
   handlePaste(event) {

--- a/app/assets/javascript/components/editor/editor.test.js
+++ b/app/assets/javascript/components/editor/editor.test.js
@@ -37,16 +37,18 @@ const editorValue = generateContent(5, false);
 
 beforeAll(() => {
   document.body.innerHTML = `<div class="editor-component" data-controller="editor">
-  <label data-action="click->editor#focus" for="">Editor label text</label>
-  <div class="govuk-hint" id="editor-hint">Editor hint text</div>
-  ${createEditorToolbar(EditorController.TOOLBAR_ACTIONS)}
-  <div class="editor-component__form-input" data-editor-target="formInput">
-  <div class="editor-component__content-container">
-  <div class="editor-component__content" contenteditable="true" data-action="input->editor#update paste->editor#handlePaste blur->editor#tidy" data-editor-target="editor">${editorValue}</div>
-  </div>
-  <textarea name="input-test" id="input-test"></textarea>
-  <div class="govuk-hint govuk-character-count__message govuk-character-count__status"></div>
-  </div>
+    <label data-action="click->editor#focus" for="">Editor label text</label>
+    <div class="govuk-hint" id="editor-hint">Editor hint text</div>
+    ${createEditorToolbar(EditorController.TOOLBAR_ACTIONS)}
+    <div class="editor-component__form-input" data-editor-target="formInput">
+      <div class="govuk-form-group govuk-form-group--error">
+        <div class="editor-component__content-container">
+          <div class="editor-component__content" contenteditable="true" data-action="input->editor#update paste->editor#handlePaste blur->editor#tidy" data-editor-target="editor">${editorValue}</div>
+        </div>
+        <textarea name="input-test" id="input-test"></textarea>
+        <div class="govuk-hint govuk-character-count__message govuk-character-count__status"></div>
+      </div>
+    </div>
   </div>`;
 
   document.execCommand = jest.fn();
@@ -68,6 +70,10 @@ describe('Content editable form control', () => {
 
   it('should set form input value when component is first rendered', () => {
     expect(document.getElementById('input-test').value).toBe(editorValue);
+  });
+
+  it('should add error class to element when form group has error', () => {
+    expect(controller.element.classList.contains('govuk-form-group--error')).toBe(true);
   });
 
   it('should update hidden form input value when user updates content', () => {

--- a/app/assets/stylesheets/components/editor.scss
+++ b/app/assets/stylesheets/components/editor.scss
@@ -2,7 +2,8 @@
 
 .js-enabled {
   .editor-component {
-    &__controls {
+    &__controls,
+    &__content-container {
       display: block;
     }
 
@@ -16,7 +17,8 @@
 }
 
 .editor-component {
-  &__controls {
+  &__controls,
+  &__content-container {
     display: none;
   }
 


### PR DESCRIPTION
**Before**

![Screenshot 2022-11-16 at 17 35 55](https://user-images.githubusercontent.com/1792451/202252894-2b8bd66f-dc25-42d0-8335-d7252bd6e956.png)

**After**

![Screenshot 2022-11-16 at 17 36 11](https://user-images.githubusercontent.com/1792451/202252888-17019f97-8cba-4bf8-89a5-fe6f22c88484.png)

This PR also fixes a small CSS problem i noticed for non JS situation as the editor JS component content editable div should not be visible and this broke in previous work
