### PR TITLE
Fix issue allowing no application form for published job

### DIFF
--- a/app/controllers/publishers/vacancies/application_forms_controller.rb
+++ b/app/controllers/publishers/vacancies/application_forms_controller.rb
@@ -5,28 +5,22 @@ class Publishers::Vacancies::ApplicationFormsController < Publishers::Vacancies:
 
   def create
     if form.valid?
+      # See commit message for 1aa28cce3239c42b1af23d61ae08add3e8c51e5e for context
       vacancy.application_form.attach(form.application_form)
-      send_event(:supporting_document_created, vacancy.application_form)
+      if application_form_staged_for_replacement?
+        send_event(:supporting_document_replaced, vacancy.application_form)
+      else
+        send_event(:supporting_document_created, vacancy.application_form)
+      end
 
       vacancy.update(form.params_to_save)
       update_google_index(vacancy) if vacancy.listed?
 
       redirect_to_next_step
     else
-      render "publishers/vacancies/build/application_form"
+      # See commit message for 1aa28cce3239c42b1af23d61ae08add3e8c51e5e for context
+      render "publishers/vacancies/build/application_form", locals: { application_form_staged_for_replacement: application_form_staged_for_replacement? }
     end
-  end
-
-  def destroy
-    raise "Missing application form" unless vacancy.application_form.id == params[:id]
-
-    send_event(:supporting_document_deleted, vacancy.application_form)
-    filename = vacancy.application_form.filename
-    vacancy.application_form.purge_later
-
-    redirect_to organisation_job_build_path(vacancy.id, :application_form, back_to_review: params[:back_to_review], back_to_show: params[:back_to_show]), flash: {
-      success: t("jobs.file_delete_success_message", filename: filename),
-    }
   end
 
   private
@@ -41,7 +35,7 @@ class Publishers::Vacancies::ApplicationFormsController < Publishers::Vacancies:
 
   def application_form_params
     params.require(:publishers_job_listing_application_form_form)
-          .permit(:application_form, :application_email, :other_application_email)
+          .permit(:application_form, :application_email, :other_application_email, :application_form_staged_for_replacement)
           .merge(completed_steps: completed_steps, current_organisation: current_organisation)
   end
 
@@ -64,5 +58,9 @@ class Publishers::Vacancies::ApplicationFormsController < Publishers::Vacancies:
     elsif params[:publishers_job_listing_application_form_form][:back_to_show]
       :show
     end
+  end
+
+  def application_form_staged_for_replacement?
+    params[:publishers_job_listing_application_form_form][:application_form_staged_for_replacement].present?
   end
 end

--- a/app/form_models/publishers/job_listing/application_form_form.rb
+++ b/app/form_models/publishers/job_listing/application_form_form.rb
@@ -8,7 +8,7 @@ class Publishers::JobListing::ApplicationFormForm < Publishers::JobListing::Uplo
   def self.fields
     %i[application_email]
   end
-  attr_accessor(:application_form, *fields)
+  attr_accessor(:application_form, :application_form_staged_for_replacement, *fields)
   attr_writer(:other_application_email)
 
   def valid_application_form
@@ -63,6 +63,7 @@ class Publishers::JobListing::ApplicationFormForm < Publishers::JobListing::Uplo
   def application_form_presence
     return if application_form.present?
 
-    errors.add(:application_form, :blank) unless vacancy.application_form&.attached?
+    # See commit message for 1aa28cce3239c42b1af23d61ae08add3e8c51e5e for context
+    errors.add(:application_form, :blank) if vacancy.application_form&.blank? || application_form_staged_for_replacement
   end
 end

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -6,10 +6,10 @@ module DocumentsHelper
     end
   end
 
-  def remove_application_form_link(application_form, vacancy)
-    govuk_link_to organisation_job_application_forms_path(id: application_form.id, job_id: vacancy.id, back_to_review: params[:back_to_review], back_to_show: params[:back_to_show]), method: :delete do
-      safe_join [t("jobs.upload_documents_table.actions.delete"),
-                 tag.span(" #{application_form.filename} supporting document", class: "govuk-visually-hidden")]
+  def remove_application_form_link
+    # See commit message for 1aa28cce3239c42b1af23d61ae08add3e8c51e5e for context
+    govuk_link_to organisation_job_build_path(vacancy.id, :application_form, application_form_staged_for_replacement: true, back_to_review: params[:back_to_review], back_to_show: params[:back_to_show]) do
+      safe_join [t("jobs.upload_documents_table.actions.delete"), tag.span("application form", class: "govuk-visually-hidden")]
     end
   end
 end

--- a/app/views/publishers/vacancies/build/application_form.html.slim
+++ b/app/views/publishers/vacancies/build/application_form.html.slim
@@ -10,17 +10,21 @@
       - if params["back_to_#{action_name}"]
         = f.hidden_field "back_to_#{action_name}", value: "true"
 
-      - if vacancy.application_form.present?
+      / See commit message for 1aa28cce3239c42b1af23d61ae08add3e8c51e5e for context
+      - if params[:application_form_staged_for_replacement] || local_assigns[:application_form_staged_for_replacement]
+        = f.hidden_field "application_form_staged_for_replacement", value: "true"
+
+      - if vacancy.application_form.blank? || (params[:application_form_staged_for_replacement].present? || local_assigns[:application_form_staged_for_replacement])
+        = f.govuk_file_field :application_form,
+            label: { size: "m" },
+            accept: ".doc, .docx, .pdf",
+            enctype: "multipart/form-data"
+      - else
         h2.govuk-heading-m = "Upload application form"
         dl.govuk-summary-list
           .govuk-summary-list__row
             dt.govuk-summary-list__value == govuk_link_to("#{vacancy.application_form.filename}  (#{number_to_human_size(vacancy.application_form.byte_size)})", vacancy.application_form, download: "true")
-            dd.govuk-summary-list__actions = remove_application_form_link(vacancy.application_form, vacancy)
-      - else
-        = f.govuk_file_field :application_form,
-          label: { size: "m" },
-          accept: ".doc, .docx, .pdf",
-          enctype: "multipart/form-data"
+            dd.govuk-summary-list__actions = remove_application_form_link
 
       = f.govuk_radio_buttons_fieldset :application_email, legend: { size: "m", tag: nil } do
         = f.govuk_radio_button :application_email, current_publisher.email, label: { text: current_publisher.email }, link_errors: true


### PR DESCRIPTION
Noticed this bug after seeing  errors seen in sentry (https://sentry.io/organizations/teaching-vacancies/issues/3725374099/?project=6212514).

If a hiring staff user publishes a job, decides to change an application form and then deletes the application form without providing replacement, the error above is caused. This could be done because after deleting the file, the user could move away from the page, leaving the published job without an application form.

In the event of a user wishing to delete an application form, we want to force them to provide a replacement. To do this, when clicking the "Delete" link, we reload the page with extra param application_form_staged_for_replacement: true (see app/helpers/documents_helper.rb:9). If this param is present, we hide the document (a sort of "soft" delete - see app/views/publishers/vacancies/build/application_form.html.slim:16). If it's present we also add a hidden field to the form. This added field forces validation to fail if present (see app/form_models/publishers/job_listing/application_form_form.rb:63), forcing the user to provide another application form to replace the existing one attached to the vacancy. This param is passed on to the view as a local variable below so that the vacancy's application form remains hidden after rendering the view as a result of failing validation. This also ensures that validation fails again if they don't provide a replacement application form.