### PR TITLE
[TEVA-4486] add secondary jobseeker navigation

### DIFF
--- a/app/assets/stylesheets/components/tabs.scss
+++ b/app/assets/stylesheets/components/tabs.scss
@@ -17,10 +17,6 @@
 
     &:visited {
       color: $govuk-link-colour;
-
-      &[aria-current] {
-        color: govuk-colour('black');
-      }
     }
 
     &:focus {
@@ -42,12 +38,6 @@
       margin-bottom: 0;
       margin-right: govuk-spacing(4);
       margin-top: 0;
-
-      @include govuk-media-query ($until: desktop) {
-        display: block;
-        line-height: 1;
-        margin-bottom: 0;
-      }
     }
 
     &__link {
@@ -60,15 +50,7 @@
       position: relative;
       text-decoration: none;
 
-      @include govuk-media-query ($until: desktop) {
-        padding: govuk-spacing(2);
-      }
-
       &[aria-current] {
-        @include govuk-media-query ($until: desktop) {
-          border-left: govuk-spacing(1) solid govuk-colour('light-blue');
-        }
-
         &::before {
           background-color: govuk-colour('light-blue');
           bottom: 0;
@@ -78,10 +60,6 @@
           left: 0;
           position: absolute;
           width: 100%;
-
-          @include govuk-media-query ($until: desktop) {
-            background: none;
-          }
         }
       }
     }

--- a/app/assets/stylesheets/layouts/_header.scss
+++ b/app/assets/stylesheets/layouts/_header.scss
@@ -32,3 +32,16 @@
     }
   }
 }
+
+.sub-navigation {
+  background-color: govuk-colour('light-grey');
+
+  .tabs-component {
+    border-bottom: 0;
+    margin-bottom: 0;
+  }
+}
+
+.govuk-phase-banner {
+  border-bottom: 0;
+}

--- a/app/assets/stylesheets/layouts/home/index.scss
+++ b/app/assets/stylesheets/layouts/home/index.scss
@@ -1,9 +1,6 @@
 .home_index {
   @import './search';
 
-  .govuk-main-wrapper {
-    padding-top: govuk-spacing(2);
-  }
 
   &.js-enabled .landing-page-links .govuk-accordion__section-content {
     padding: 0;

--- a/app/components/tabs_component/tabs_component.html.slim
+++ b/app/components/tabs_component/tabs_component.html.slim
@@ -1,4 +1,4 @@
-= tag.div(**html_attributes) do
+= tag.nav(**html_attributes) do
   ul.tabs-component-navigation__list
     - navigation_items.each do |item|
       = item

--- a/app/views/jobseekers/sessions/new.html.slim
+++ b/app/views/jobseekers/sessions/new.html.slim
@@ -1,8 +1,5 @@
 - content_for :page_title_prefix, t(".title")
 
-- content_for :breadcrumbs do
-  = govuk_back_link text: t("buttons.back"), href: page_path("sign-in")
-
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     h1.govuk-heading-l = t(".title")

--- a/app/views/layouts/_sub_navigation.html.slim
+++ b/app/views/layouts/_sub_navigation.html.slim
@@ -1,0 +1,6 @@
+- unless publisher_signed_in?
+  .sub-navigation
+    .govuk-width-container
+      = tabs html_attributes: { "aria-label": "main menu" } do |tabs|
+        - tabs.navigation_item text: t("jobseekers.sub_navigation.jobs"), link: jobs_path
+        - tabs.navigation_item text: t("jobseekers.sub_navigation.schools"), link: organisations_path

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -15,11 +15,14 @@ html.govuk-template.app-html-class lang="en"
     = render "layouts/skip_links"
     = render EnvironmentBannerComponent.new
     = render "layouts/header"
-    div class="govuk-width-container"
+    .govuk-width-container
       = render "layouts/phase_banner"
+    = render "layouts/sub_navigation"
+
+    .govuk-width-container
       = content_for :breadcrumbs
       = render "layouts/flash_messages"
-      main#main-content.govuk-main-wrapper role="main"
+      main#main-content.govuk-main-wrapper.govuk-main-wrapper--auto-spacing role="main"
         = yield
       = content_for :after_main
     = render "layouts/footer"

--- a/app/views/organisations/index.html.slim
+++ b/app/views/organisations/index.html.slim
@@ -14,7 +14,11 @@ h1 class="govuk-heading-l" role="heading" aria-level="1"
         - if @schools.any?
           = render "organisations/search/results", schools: @schools
         - else
-          p = t("schools.no_results")
+          p.govuk-heading-m = t("organisations.search.no_results_heading")
+          p = t("organisations.search.no_results_text")
+          ul.govuk-list.govuk-list--bullet
+            - t("organisations.search.no_results_hints").each do |hint|
+              li = hint
 
       = govuk_pagination(pagy: @pagy)
 

--- a/app/views/organisations/schools/index.html.slim
+++ b/app/views/organisations/schools/index.html.slim
@@ -7,7 +7,7 @@
         = @organisation.name
       p.govuk-body-m = full_address(@organisation)
 
-= tabs(html_attributes: { "aria-label": "organisation menu" }) do |tabs|
+= tabs(html_attributes: { "aria-label": "organisation menu", class: "organisation-navigation" }) do |tabs|
   - tabs.navigation_item text: t("organisations.show.tabs.organisation"), link: organisation_path(@organisation)
   - tabs.navigation_item text: t("organisations.show.tabs.schools"), link: organisation_schools_path(@organisation)
 

--- a/app/views/organisations/search/_filters.html.slim
+++ b/app/views/organisations/search/_filters.html.slim
@@ -1,7 +1,7 @@
 = filters(submit_button: f.govuk_submit(t("buttons.apply_filters")),
   options: { heading_text: "Filter", remove_filter_links: false },
   html_attributes: { tabindex: "-1", id: "filters-component" }) do |filters_component|
-    - filters_component.group key: "education_phase", component: f.govuk_collection_check_boxes(:education_phase, f.object.education_phase_options, :first, :last, small: true, legend: { text: t("schools.filters.education_phase") }, hint: nil)
-    - filters_component.group key: "key_stage", component: f.govuk_collection_check_boxes(:key_stage, f.object.key_stage_options, :first, :last, small: true, legend: { text: t("schools.filters.key_stage") }, hint: nil)
-    - filters_component.group key: "special_school", component: f.govuk_collection_check_boxes(:special_school, [["1", t("schools.filters.special_school")]], :first, :last, small: true, legend: { text: t("schools.filters.special_school") })
-    - filters_component.group key: "job_availability", component: f.govuk_collection_check_boxes(:job_availability, f.object.job_availability_options, :first, :last, small: true, legend: { text: t("schools.filters.job_availability.label") })
+    - filters_component.group key: "education_phase", component: f.govuk_collection_check_boxes(:education_phase, f.object.education_phase_options, :first, :last, small: true, legend: { text: t("organisations.filters.education_phase") }, hint: nil)
+    - filters_component.group key: "key_stage", component: f.govuk_collection_check_boxes(:key_stage, f.object.key_stage_options, :first, :last, small: true, legend: { text: t("organisations.filters.key_stage") }, hint: nil)
+    - filters_component.group key: "special_school", component: f.govuk_collection_check_boxes(:special_school, [["1", t("organisations.filters.special_school")]], :first, :last, small: true, legend: { text: t("organisations.filters.special_school") })
+    - filters_component.group key: "job_availability", component: f.govuk_collection_check_boxes(:job_availability, f.object.job_availability_options, :first, :last, small: true, legend: { text: t("organisations.filters.job_availability.label") })

--- a/app/views/organisations/show.html.slim
+++ b/app/views/organisations/show.html.slim
@@ -8,7 +8,7 @@
       p.govuk-body-m = full_address(@organisation)
 
 - if @organisation.school_group?
-    = tabs(html_attributes: { "aria-label": "organisation menu" }) do |tabs|
+    = tabs(html_attributes: { "aria-label": "organisation menu", class: "organisation-navigation" }) do |tabs|
       - tabs.navigation_item text: t("organisations.show.tabs.organisation"), link: organisation_path(@organisation)
       - tabs.navigation_item text: t("organisations.show.tabs.schools"), link: organisation_schools_path(@organisation)
 

--- a/app/views/pages/sign-in.html.slim
+++ b/app/views/pages/sign-in.html.slim
@@ -1,9 +1,6 @@
 - content_for :page_title_prefix do
   | Sign in to Teaching Vacancies
 
-- content_for :breadcrumbs do
-  = govuk_back_link text: t("buttons.back"), href: root_path
-
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     h1.govuk-heading-l Sign in to Teaching Vacancies

--- a/app/views/publishers/organisations/preview.html.slim
+++ b/app/views/publishers/organisations/preview.html.slim
@@ -11,7 +11,7 @@
       p.govuk-body-m = full_address(@organisation)
 
 - if @organisation.school_group?
-  = tabs(html_attributes: { "aria-label": "organisation menu" }) do |tabs|
+  = tabs(html_attributes: { "aria-label": "organisation menu", class: "organisation-navigation" }) do |tabs|
     - tabs.navigation_item text: t("organisations.show.tabs.organisation"), link: publishers_organisation_preview_path(@organisation)
     - tabs.navigation_item text: t("organisations.show.tabs.schools"), link: publishers_organisation_schools_preview_path(@organisation)
 

--- a/app/views/publishers/organisations/schools/preview.html.slim
+++ b/app/views/publishers/organisations/schools/preview.html.slim
@@ -10,7 +10,7 @@
         = @organisation.name
       p.govuk-body-m = full_address(@organisation)
 
-= tabs(html_attributes: { "aria-label": "organisation menu" }) do |tabs|
+= tabs(html_attributes: { "aria-label": "organisation menu", class: "organisation-navigation" }) do |tabs|
   - tabs.navigation_item text: t("organisations.show.tabs.organisation"), link: publishers_organisation_preview_path(@organisation)
   - tabs.navigation_item text: t("organisations.show.tabs.schools"), link: publishers_organisation_schools_preview_path(@organisation)
 

--- a/app/views/publishers/sessions/new.html.slim
+++ b/app/views/publishers/sessions/new.html.slim
@@ -1,8 +1,5 @@
 - content_for :page_title_prefix, t(".sign_in.title")
 
-- content_for :breadcrumbs do
-  = govuk_back_link text: t("buttons.back"), href: page_path("sign-in")
-
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     h1.govuk-heading-l = t(".sign_in.title")

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -531,6 +531,9 @@ en:
         skip_link: Skip to my job alerts
         zero_subscriptions_body_html: '%{link_to} to be made aware of future listings.'
         zero_subscriptions_title: You have no job alerts set up
+    sub_navigation:
+      jobs: "Jobs"
+      schools: "Schools"
     unlocks:
       new:
         description: This link has already been used or is incorrect. If you still want to unlock your Teaching Vacancies account enter your email below.

--- a/config/locales/organisations.yml
+++ b/config/locales/organisations.yml
@@ -9,3 +9,9 @@ en:
         options:
           true: Has jobs
           false: Does not have any jobs
+    search:
+      no_results_heading: No schools found
+      no_results_text: "You may get more results if you:"
+      no_results_hints:
+        - change the radius of your search
+        - look at a wider geographical location, for example West Yorkshire instead of Leeds

--- a/spec/components/tabs_component_spec.rb
+++ b/spec/components/tabs_component_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe TabsComponent, type: :component do
     end
 
     it "renders the navigation items" do
-      expect(page).to have_css("div", class: "tabs-component") do |tabs|
+      expect(page).to have_css("nav", class: "tabs-component") do |tabs|
         expect(tabs).to have_css("li", class: "tabs-component-navigation__item", text: "A dashboard item") do |item|
           expect(item).to have_link("A dashboard item", href: "/item", class: "tabs-component-navigation__link")
           expect(item).to have_xpath("//a[@aria-current=\"page\"]")

--- a/spec/system/jobseekers_can_close_and_reactivate_account_spec.rb
+++ b/spec/system/jobseekers_can_close_and_reactivate_account_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Jobseekers can close and reactivate their account" do
 
     expect(page).to have_content(I18n.t("jobseekers.registrations.destroy.success"))
 
-    within("nav") { click_link I18n.t("buttons.sign_in") }
+    within(".govuk-header__navigation") { click_link I18n.t("buttons.sign_in") }
     click_on I18n.t("buttons.sign_in_jobseeker")
     sign_in_jobseeker(email: jobseeker.email, password: jobseeker.password)
 

--- a/spec/system/jobseekers_can_sign_in_to_their_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_in_to_their_account_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Jobseekers can sign in to their account" do
 
   before do
     visit root_path
-    within("nav") { click_on I18n.t("buttons.sign_in") }
+    within(".govuk-header__navigation") { click_on I18n.t("buttons.sign_in") }
     click_on I18n.t("buttons.sign_in_jobseeker")
   end
 

--- a/spec/system/jobseekers_can_sign_out_from_their_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_out_from_their_account_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Jobseekers can sign out from their account" do
 
   scenario "signing out takes them to sign in page with banner" do
     visit root_path
-    within("nav") do
+    within(".govuk-header__navigation") do
       click_on I18n.t("nav.sign_out")
     end
 

--- a/spec/system/jobseekers_can_unlock_their_account_spec.rb
+++ b/spec/system/jobseekers_can_unlock_their_account_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Jobseekers can unlock their account" do
 
   before do
     visit root_path
-    within("nav") { click_on I18n.t("buttons.sign_in") }
+    within(".govuk-header__navigation") { click_on I18n.t("buttons.sign_in") }
     click_on I18n.t("buttons.sign_in_jobseeker")
   end
 

--- a/spec/system/jobseekers_can_view_all_the_jobs_spec.rb
+++ b/spec/system/jobseekers_can_view_all_the_jobs_spec.rb
@@ -12,6 +12,24 @@ RSpec.describe "Jobseekers can view all the jobs" do
     expect(current_path).to eq(jobs_path)
   end
 
+  it "jobseekers can visit the home page and use secondary navigation to view jobs" do
+    visit root_path
+
+    within ".sub-navigation" do
+      click_on I18n.t("jobseekers.sub_navigation.jobs")
+      expect(current_path).to eq(jobs_path)
+    end
+  end
+
+  it "jobseekers can visit the home page and use secondary navigation to view schools" do
+    visit root_path
+
+    within ".sub-navigation" do
+      click_on I18n.t("jobseekers.sub_navigation.schools")
+      expect(current_path).to eq(organisations_path)
+    end
+  end
+
   describe "pagination" do
     shared_examples "jobseekers can view jobs and navigate between pages" do
       scenario "jobseekers can view jobs and navigate between pages" do

--- a/spec/system/jobseekers_can_view_an_organisation_spec.rb
+++ b/spec/system/jobseekers_can_view_an_organisation_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "Viewing an organisation" do
     end
 
     it "displays a list of schools associated with the school group" do
-      within("div.tabs-component") do
+      within(".organisation-navigation") do
         expect(page).to have_content(I18n.t("organisations.show.tabs.schools"))
 
         click_on I18n.t("organisations.show.tabs.schools")

--- a/spec/system/jobseekers_can_view_their_dashboard_spec.rb
+++ b/spec/system/jobseekers_can_view_their_dashboard_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Jobseekers can view their dashboard" do
   end
 
   it "shows `Applications` tab" do
-    within ".tabs-component" do
+    within ".govuk-main-wrapper .tabs-component" do
       expect(page).to have_link(I18n.t("jobseekers.accounts.show.page_title"))
       expect(page).to_not have_link(I18n.t("jobseekers.job_applications.index.page_title"))
       expect(page).to_not have_link(I18n.t("jobseekers.saved_jobs.index.page_title"))

--- a/spec/system/main_navigation_spec.rb
+++ b/spec/system/main_navigation_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Main navigation for users to sign in and out" do
     before { visit root_path }
 
     it "renders the correct links" do
-      within "nav" do
+      within ".govuk-header__navigation" do
         expect(page).to have_content(I18n.t("nav.create_a_job_alert"))
         expect(page).to have_content(I18n.t("buttons.sign_in"))
       end
@@ -23,7 +23,7 @@ RSpec.describe "Main navigation for users to sign in and out" do
     end
 
     it "renders the correct links" do
-      within "nav" do
+      within ".govuk-header__navigation" do
         expect(page).to have_content(I18n.t("nav.find_job"))
         expect(page).to have_content(I18n.t("nav.your_account"))
         expect(page).to have_content(I18n.t("nav.sign_out"))
@@ -38,7 +38,7 @@ RSpec.describe "Main navigation for users to sign in and out" do
     end
 
     it "renders the correct links" do
-      within "nav" do
+      within ".govuk-header__navigation" do
         expect(page).to have_content(I18n.t("nav.manage_jobs"))
         expect(page).to have_content(I18n.t("nav.notifications_html", count: 0))
         expect(page).to have_content(I18n.t("nav.sign_out"))

--- a/spec/system/publishers_can_preview_a_profile_spec.rb
+++ b/spec/system/publishers_can_preview_a_profile_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "Publishers can preview an organisation or school profile" do
       let!(:vacancy) { create(:vacancy, organisations: [school_one]) }
 
       before do
-        within("div.tabs-component") do
+        within(".organisation-navigation") do
           click_on I18n.t("organisations.show.tabs.schools")
         end
 

--- a/spec/system/publishers_can_sign_in_by_email_spec.rb
+++ b/spec/system/publishers_can_sign_in_by_email_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Publishers can sign in with fallback email authentication" do
 
   it "can reach email authentication page" do
     visit root_path
-    within("nav") { click_on I18n.t("buttons.sign_in") }
+    within(".govuk-header__navigation") { click_on I18n.t("buttons.sign_in") }
     click_on I18n.t("buttons.sign_in_publisher")
 
     expect(page).to have_content(I18n.t("publishers.login_keys.new.notice"))
@@ -50,7 +50,7 @@ RSpec.describe "Publishers can sign in with fallback email authentication" do
       it "can sign in, choose an org, sign out" do
         freeze_time do
           visit root_path
-          within("nav") { click_on I18n.t("buttons.sign_in") }
+          within(".govuk-header__navigation") { click_on I18n.t("buttons.sign_in") }
           click_on I18n.t("buttons.sign_in_publisher")
 
           # Expect to send an email
@@ -79,7 +79,7 @@ RSpec.describe "Publishers can sign in with fallback email authentication" do
           # Can sign out
           click_on(I18n.t("nav.sign_out"))
 
-          within("nav") { expect(page).to have_content(I18n.t("buttons.sign_in")) }
+          within(".govuk-header__navigation") { expect(page).to have_content(I18n.t("buttons.sign_in")) }
 
           # Login link no longer works
           visit publishers_login_key_path(login_key)
@@ -108,7 +108,7 @@ RSpec.describe "Publishers can sign in with fallback email authentication" do
         it "can sign in and bypass choice of org" do
           freeze_time do
             visit root_path
-            within("nav") { click_on I18n.t("buttons.sign_in") }
+            within(".govuk-header__navigation") { click_on I18n.t("buttons.sign_in") }
             click_on I18n.t("buttons.sign_in_publisher")
 
             # Expect to send an email
@@ -139,7 +139,7 @@ RSpec.describe "Publishers can sign in with fallback email authentication" do
         it "can sign in and bypass choice of org" do
           freeze_time do
             visit root_path
-            within("nav") { click_on I18n.t("buttons.sign_in") }
+            within(".govuk-header__navigation") { click_on I18n.t("buttons.sign_in") }
             click_on I18n.t("buttons.sign_in_publisher")
 
             # Expect to send an email
@@ -173,7 +173,7 @@ RSpec.describe "Publishers can sign in with fallback email authentication" do
         it "can sign in and bypass choice of org" do
           freeze_time do
             visit root_path
-            within("nav") { click_on I18n.t("buttons.sign_in") }
+            within(".govuk-header__navigation") { click_on I18n.t("buttons.sign_in") }
             click_on I18n.t("buttons.sign_in_publisher")
 
             # Expect to send an email

--- a/spec/system/publishers_can_sign_in_with_dfe_spec.rb
+++ b/spec/system/publishers_can_sign_in_with_dfe_spec.rb
@@ -12,8 +12,8 @@ RSpec.shared_examples "a successful Publisher sign in" do
       .with_base_data(user_anonymised_publisher_id: anonymised_form_of(user_oid))
       .and_data(sign_in_type: "dsi")
 
-    within("nav") { expect(page).to have_selector(:link_or_button, I18n.t("nav.sign_out")) }
-    within("nav") { expect(page).to have_selector(:link_or_button, I18n.t("nav.manage_jobs")) }
+    within(".govuk-header__navigation") { expect(page).to have_selector(:link_or_button, I18n.t("nav.sign_out")) }
+    within(".govuk-header__navigation") { expect(page).to have_selector(:link_or_button, I18n.t("nav.manage_jobs")) }
   end
 end
 
@@ -27,7 +27,7 @@ RSpec.shared_examples "a failed Publisher sign in" do |options|
 
     expect(page).to have_content(/The email you're signed in with isn't authorised to list jobs for this school/i)
     expect(page).to have_content(options[:email])
-    within("nav") { expect(page).not_to have_content(I18n.t("nav.manage_jobs")) }
+    within(".govuk-header__navigation") { expect(page).not_to have_content(I18n.t("nav.manage_jobs")) }
   end
 end
 

--- a/spec/system/publishers_can_sign_out_with_dfe_spec.rb
+++ b/spec/system/publishers_can_sign_out_with_dfe_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Publishers can sign out with DfE Sign In" do
 
     click_on(I18n.t("nav.sign_out"))
 
-    within("nav") { expect(page).to have_content(I18n.t("buttons.sign_in")) }
+    within(".govuk-header__navigation") { expect(page).to have_content(I18n.t("buttons.sign_in")) }
     expect(page).to have_content(I18n.t("devise.sessions.signed_out"))
   end
 end

--- a/spec/system/publishers_can_visit_the_public_listings_spec.rb
+++ b/spec/system/publishers_can_visit_the_public_listings_spec.rb
@@ -37,12 +37,12 @@ RSpec.describe "School viewing public listings" do
 
   def link_to_dashboard_is_visible_to_publishers?
     expect(page).to have_content(school.name)
-    within("nav") { expect(page).to have_content(I18n.t("nav.manage_jobs")) }
+    within(".govuk-header__navigation") { expect(page).to have_content(I18n.t("nav.manage_jobs")) }
 
     within("header") { click_on(I18n.t("app.title")) }
     expect(page).to have_content(I18n.t("jobs.heading"))
 
-    within("nav") { click_on(I18n.t("nav.manage_jobs")) }
+    within(".govuk-header__navigation") { click_on(I18n.t("nav.manage_jobs")) }
     expect(page).to have_content(school.name)
   end
 end

--- a/spec/system/publishers_have_to_accept_terms_spec.rb
+++ b/spec/system/publishers_have_to_accept_terms_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "Publishers can accept terms and conditions" do
         visit publishers_terms_and_conditions_path
         click_on(I18n.t("nav.sign_out"))
 
-        within("nav") { expect(page).to have_content(I18n.t("buttons.sign_in")) }
+        within(".govuk-header__navigation") { expect(page).to have_content(I18n.t("buttons.sign_in")) }
       end
 
       scenario "without authentication fallback" do

--- a/spec/system/support_users/dfe_sign_out_spec.rb
+++ b/spec/system/support_users/dfe_sign_out_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Support users can sign out with DfE Sign In" do
 
     click_on(I18n.t("nav.sign_out"))
 
-    within("nav") { expect(page).not_to have_content(I18n.t("nav.sign_out")) }
+    within(".govuk-header__navigation") { expect(page).not_to have_content(I18n.t("nav.sign_out")) }
     expect(page).to have_content(I18n.t("devise.sessions.signed_out"))
   end
 end


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/TEVA-4866

- add navigation for jobs/schools pages
- navigation is not visible to publishers
- back links removed from sign pages (at @adamsilver request)
- styling/markup of tabs component updated as per prototype

### Mobile

![Screenshot 2022-11-22 at 11 12 58](https://user-images.githubusercontent.com/1792451/203300156-70296562-bdd4-4ced-b397-bc028caf5c9c.png)

![Screenshot 2022-11-22 at 11 12 32](https://user-images.githubusercontent.com/1792451/203300169-c19cc671-4853-4f68-9b77-e2052f50ce2e.png)

### Desktop

![Screenshot 2022-11-22 at 11 12 51](https://user-images.githubusercontent.com/1792451/203300166-60dfba5c-3db9-4bd6-9aa4-7335e72acfb7.png)

![Screenshot 2022-11-22 at 11 12 24](https://user-images.githubusercontent.com/1792451/203300171-2c5af917-bf01-4118-bb52-6a2285a8a900.png)


