### PR TITLE
Hide list of schools on LA profile

### DIFF
--- a/app/views/publishers/organisations/show.html.slim
+++ b/app/views/publishers/organisations/show.html.slim
@@ -15,13 +15,12 @@
 
     = render "organisation", organisation: @organisation
 
-    - if @organisation.school_group?
-
+    - if current_organisation.trust?
       h2.govuk-heading-m class="govuk-!-margin-top-8"
         = t(".schools")
 
       = govuk_summary_list do |summary_list|
-        - @organisation.schools.not_closed.order(:name).partition(&:profile_complete?).reverse.flatten.each do |school|
+        - current_organisation.schools.not_closed.order(:name).partition(&:profile_complete?).reverse.flatten.each do |school|
           - summary_list.row do |row|
             - row.with_value do
               - if school.profile_complete?

--- a/spec/system/publishers_can_manage_settings_spec.rb
+++ b/spec/system/publishers_can_manage_settings_spec.rb
@@ -86,19 +86,5 @@ RSpec.describe "Publishers can manage organisation/school profile" do
       expect(page).to have_content("Details updated for #{organisation.name}")
       expect(page.current_path).to eq(publishers_organisation_path(organisation))
     end
-
-    it "allows to edit details of a school in the local_authority" do
-      click_on school1.name
-      click_link "Change", match: :first
-
-      expect(find_field("publishers_organisation_form[url_override]").value).to eq(school1.url_override)
-
-      fill_in "publishers_organisation_form[description]", with: "Our school prides itself on excellence."
-      fill_in "publishers_organisation_form[url_override]", with: "https://www.this-is-a-test-url.example.com"
-      click_on I18n.t("buttons.save_changes")
-
-      expect(page).to have_content("Details updated for #{school1.name}")
-      expect(page.current_path).to eq(publishers_organisation_path(school1))
-    end
   end
 end


### PR DESCRIPTION
## Changes in this PR:

We now hide the list of associated schools from a hiring staff user on a school group's profile if the school group is a local authority. This is because all schools are associated with the LA they are within, geographically. This means that all local authority users will be able to change the profiles of all schools within their geographic area.

We are unsure of the policy implications for this, so, for now, have decided to take the ability to do this away whilst we explore this issue. This PR only hides the list of schools on a school group's profile page if that school group is an LA. 

We should probably prevent LAs from being able to reach the edit page full stop (although it's quite unlikely that they would visit it as they would need the direct URL). This will be easier as a result of changes I will (hopefully) shortly introduce with a PR for https://dfedigital.atlassian.net/browse/TEVA-4476
