### PR TITLE
Update rspec-support to 3.12.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -523,7 +523,7 @@ GEM
       rspec-expectations (~> 3.11)
       rspec-mocks (~> 3.11)
       rspec-support (~> 3.11)
-    rspec-support (3.11.1)
+    rspec-support (3.12.0)
     rubocop (1.39.0)
       json (~> 2.3)
       parallel (~> 1.10)


### PR DESCRIPTION
Updated rspec support to 3.12.1. 

Depedabot, at some point, created pull-requests updated `rspec-core`,` rspec-expectations` and `rspec-mocks`. These updated the version of rspec-support they depend on, without updating our version of `rspec-support`, causing the following message to be shown when running `bundle install`.

```
Your lockfile doesn't include a valid resolution.
You can fix this by regenerating your lockfile or trying to manually editing the bad locked gems to a version that satisfies all dependencies.
The unmet dependencies are:
* rspec-support (~> 3.12.0), depended upon rspec-core-3.12.0, unsatisfied by rspec-support-3.11.1
* rspec-support (~> 3.12.0), depended upon rspec-expectations-3.12.0, unsatisfied by rspec-support-3.11.1
* rspec-support (~> 3.12.0), depended upon rspec-mocks-3.12.0, unsatisfied by rspec-support-3.11.1
```