### PR TITLE
[TEVA-4534] Fix subscription job roles translation path

### DIFF
--- a/app/presenters/subscription_presenter.rb
+++ b/app/presenters/subscription_presenter.rb
@@ -56,7 +56,7 @@ class SubscriptionPresenter < BasePresenter
   end
 
   def render_job_roles_filter(value)
-    { job_role: value.map { |role| I18n.t("helpers.label.publishers_job_listing_job_roleform.job_role_options.#{role}") }.join(", ") }
+    { job_role: value.map { |role| I18n.t("helpers.label.publishers_job_listing_job_role_form.job_role_options.#{role}") }.join(", ") }
   end
 
   def render_ect_statuses_filter(value)


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-4534

## Changes in this PR:

We were missing an underscore in the job role translation path for subscription presenters, causing missing translation errors.