### PR TITLE
Save vacancy before sending document created or replaced event

### DIFF
--- a/app/controllers/publishers/vacancies/application_forms_controller.rb
+++ b/app/controllers/publishers/vacancies/application_forms_controller.rb
@@ -7,14 +7,14 @@ class Publishers::Vacancies::ApplicationFormsController < Publishers::Vacancies:
     if form.valid?
       # See commit message for 1aa28cce3239c42b1af23d61ae08add3e8c51e5e for context
       vacancy.application_form.attach(form.application_form)
+      vacancy.update(form.params_to_save)
+      update_google_index(vacancy) if vacancy.listed?
+
       if application_form_staged_for_replacement?
         send_event(:supporting_document_replaced, vacancy.application_form)
       else
         send_event(:supporting_document_created, vacancy.application_form)
       end
-
-      vacancy.update(form.params_to_save)
-      update_google_index(vacancy) if vacancy.listed?
 
       redirect_to_next_step
     else


### PR DESCRIPTION
Our team's performance analyst noticed a problem with supporting document created events coming from the application forms controller. Many of the events contained null values. After investigating this issue, I found it was caused by the order in which things are done in the create action of the application forms controller.

Looking at the docs for ActiveStorage::Attached::One's attach method revealed the following:

"If the record is persisted and unchanged, the attachment is saved to the database immediately. Otherwise, it'll be saved to the DB when the record is next saved."

In our case, the form which contains the file upload field also contains another field - the application email field. If I user were to attach an application form and at the same time change the value for application_email, this record (the vacancy) will be in a changed state, meaning the attached file will be saved when the record is next saved.

As the record is saved in the create action (`vacancy.update(form.params_to_save)`) after the event is sent, the application form isn't actually attached at the point where the event is sent, causing the null values.