### PR TITLE
Change how completed_steps are added for non-build steps

### DIFF
--- a/app/controllers/concerns/publishers/wizardable.rb
+++ b/app/controllers/concerns/publishers/wizardable.rb
@@ -104,12 +104,6 @@ module Publishers::Wizardable
           .merge(completed_steps: completed_steps, current_organisation: current_organisation)
   end
 
-  def application_form_params(params)
-    params.require(:publishers_job_listing_application_form_form)
-          .permit(:application_email, :other_application_email)
-          .merge(completed_steps: completed_steps, current_organisation: current_organisation)
-  end
-
   def school_visits_params(params)
     if params[:publishers_job_listing_school_visits_form]
       params.require(:publishers_job_listing_school_visits_form)

--- a/app/controllers/publishers/vacancies/documents_controller.rb
+++ b/app/controllers/publishers/vacancies/documents_controller.rb
@@ -10,7 +10,7 @@ class Publishers::Vacancies::DocumentsController < Publishers::Vacancies::BaseCo
         send_event(:supporting_document_created, document.original_filename, document.size, document.content_type)
       end
 
-      vacancy.update(completed_steps: completed_steps)
+      vacancy.update(documents_form.params_to_save)
 
       render :index
     else
@@ -47,7 +47,9 @@ class Publishers::Vacancies::DocumentsController < Publishers::Vacancies::BaseCo
   end
 
   def documents_form_params
-    (params[:publishers_job_listing_documents_form] || params).permit(documents: [])
+    (params[:publishers_job_listing_documents_form] || params)
+      .permit(documents: [])
+      .merge(completed_steps: completed_steps)
   end
 
   def confirmation_form

--- a/app/form_models/publishers/job_listing/application_form_form.rb
+++ b/app/form_models/publishers/job_listing/application_form_form.rb
@@ -45,6 +45,7 @@ class Publishers::JobListing::ApplicationFormForm < Publishers::JobListing::Uplo
   def params_to_save
     {
       application_email: params[:application_email] == "other" ? params[:other_application_email] : params[:application_email],
+      completed_steps: params[:completed_steps],
     }
   end
 

--- a/app/form_models/publishers/job_listing/documents_form.rb
+++ b/app/form_models/publishers/job_listing/documents_form.rb
@@ -20,6 +20,10 @@ class Publishers::JobListing::DocumentsForm < Publishers::JobListing::UploadBase
     :documents
   end
 
+  def params_to_save
+    { completed_steps: params[:completed_steps] }
+  end
+
   private
 
   def document_presence

--- a/app/form_models/publishers/job_listing/important_dates_form.rb
+++ b/app/form_models/publishers/job_listing/important_dates_form.rb
@@ -35,7 +35,6 @@ class Publishers::JobListing::ImportantDatesForm < Publishers::JobListing::Vacan
 
   def params_to_save
     {
-      completed_steps: completed_steps,
       publish_on: publish_on,
       expires_at: expires_at,
     }

--- a/app/form_models/publishers/job_listing/working_patterns_form.rb
+++ b/app/form_models/publishers/job_listing/working_patterns_form.rb
@@ -17,7 +17,6 @@ class Publishers::JobListing::WorkingPatternsForm < Publishers::JobListing::Vaca
 
   def params_to_save
     {
-      completed_steps: completed_steps,
       working_patterns: working_patterns,
       part_time_details: (part_time_details if working_patterns&.include?("part_time")),
       full_time_details: (full_time_details if working_patterns&.include?("full_time")),

--- a/spec/requests/publishers/vacancies/application_forms_spec.rb
+++ b/spec/requests/publishers/vacancies/application_forms_spec.rb
@@ -52,6 +52,12 @@ RSpec.describe "Documents" do
         expect(vacancy.reload.application_email).to eq(application_email)
       end
 
+      it "adds application_form to the completed steps" do
+        request
+
+        expect(vacancy.reload.completed_steps).to include("application_form")
+      end
+
       context "when the vacancy is listed" do
         before do
           allow(vacancy).to receive(:listed?).and_return(true)

--- a/spec/requests/publishers/vacancies/documents_spec.rb
+++ b/spec/requests/publishers/vacancies/documents_spec.rb
@@ -38,6 +38,12 @@ RSpec.describe "Documents" do
       it "renders the index page" do
         expect(request).to render_template(:index)
       end
+
+      it "adds documents to the completed steps" do
+        request
+
+        expect(vacancy.reload.completed_steps).to include("documents")
+      end
     end
 
     context "when the form is invalid" do


### PR DESCRIPTION
In our job creation journey we have two steps that live outside of the build process - application_form and documents. After noticing that the application_form step was not being correctly added to completed_steps I decided to look into what was causing this issue. I noticed that, in the case of a step being outside of the build controller / process, completed_steps needed to be set in the params_to_save, rather than being merged into the params before updating the vacancy (see app/controllers/publishers/vacancies/build_controller.rb:52).

There is no need for application_form_params(params) in wizardable.rb as this is only used to construct / configure the params for forms submitted for steps within the build process / controller. In the case of the application form, the configuration of params is done in the application_forms_contoller.  For this reason, it has been removed. I then did something similar with the documents controller and form to make it consistent.

I also removed completed_steps from the params to save for the important_dates and working patterns steps forms as the completed steps are added to the params in wizardable.rb.
