### PR TITLE
Corrected vacancy scope for school's job availability filter

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -129,6 +129,7 @@ class Vacancy < ApplicationRecord
     organisations.one? && organisations.first.trust?
   end
 
+  # TODO: This method matches conditions of :live scope, not :listed. We should rename it
   def listed?
     published? && expires_at&.future? && (publish_on&.today? || publish_on&.past?)
   end

--- a/app/services/search/school_search.rb
+++ b/app/services/search/school_search.rb
@@ -70,7 +70,7 @@ class Search::SchoolSearch
   def apply_job_availability_filter(scope)
     return scope unless @search_criteria.key?(:job_availability)
 
-    vacancy_ids = Vacancy.listed.select(:id)
+    vacancy_ids = Vacancy.live.select(:id)
     organisation_ids = OrganisationVacancy.where(vacancy_id: vacancy_ids).select(:organisation_id)
 
     if @search_criteria[:job_availability]


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-4474

## Changes in this PR:

Initial PR is using `listed` scope to match `listed?` method used for displaying roles associated with the school. It seems however that conditions of `listed?` are better match for `live` scope as `listed` scope also includes expired roles.