### PR TITLE
Fix bug causing nil values in streamed events

### DIFF
--- a/spec/requests/publishers/vacancies/application_forms_spec.rb
+++ b/spec/requests/publishers/vacancies/application_forms_spec.rb
@@ -107,6 +107,22 @@ RSpec.describe "Documents" do
           expect(request).to redirect_to(organisation_job_path(vacancy.id))
         end
       end
+
+      context "when only the application email has been changed" do
+        let(:vacancy) { create(:vacancy, :with_application_form, enable_job_applications: false, receive_applications: "email", organisations: [organisation]) }
+        let(:request) do
+          post organisation_job_application_forms_path(vacancy.id), params: {
+            publishers_job_listing_application_form_form: {
+              application_form: nil,
+              application_email: application_email,
+            },
+          }
+        end
+
+        it "does not send a supporting_document_created event" do
+          expect { request }.to_not have_triggered_event(:supporting_document_created)
+        end
+      end
     end
 
     context "when the form is invalid" do


### PR DESCRIPTION
We investigated an issue our performance analyst highlighted with our data warehouse's events table. We were sending supporting_document_created events to this table with nil values in the event data.

This was because hiring staff were going back to the application_form step from the review page and updating the `application_email` without providing a new file. Despite the lack of an `application_form` in the params when the form was submitted, the form would pass validation as we also check the `vacancy` for an `application_form`. We would then send an event, passing in `form.application` to the `send_event` method. In this case, as `form.application` was nil, some of the data we'd send in the event was also nil.

To prevent this, we now only send an event if there is an `application_form` in the params.

I've also done some tidying to make it a bit more readable. 
 

