### PR TITLE
Avoiding rejecting all trusts in school search scope

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -15,7 +15,7 @@ class OrganisationsController < ApplicationController
   end
 
   def search_scope
-    Organisation.schools.or(Organisation.trusts).not_closed.registered_for_service.order(:name)
+    Organisation.schools.not_closed.or(Organisation.trusts).registered_for_service.order(:name)
   end
 
   def organisation


### PR DESCRIPTION
`Organisation.trusts.not_closed #=> []`

`not_closed` scope depends on != operator, which returns false if any of the sides is NULL - which is the case for all trusts.