### PR TITLE
Summarise failed vacancy imports

### DIFF
--- a/app/jobs/import_from_vacancy_sources_job.rb
+++ b/app/jobs/import_from_vacancy_sources_job.rb
@@ -15,7 +15,7 @@ class ImportFromVacancySourcesJob < ApplicationJob
             Rails.logger.info("Imported vacancy #{vacancy.id} from feed #{source_klass.source_name}")
           else
             report_validation_errors(source_klass, vacancy)
-            FailedImportedVacancy.create(source: source_klass.source_name, external_reference: vacancy.external_reference, import_errors: vacancy.errors.to_json)
+            create_failed_imported_vacancy(source_klass, vacancy)
           end
         end
       end
@@ -28,6 +28,16 @@ class ImportFromVacancySourcesJob < ApplicationJob
   end
 
   private
+
+  def create_failed_imported_vacancy(source_klass, vacancy)
+    if FailedImportedVacancy.find_by(external_reference: vacancy.external_reference)
+      Rails.logger.info("Vacancy #{vacancy.external_reference} failed to save as its a duplicate")
+    else
+      FailedImportedVacancy.create(source: source_klass.source_name,
+                                   external_reference: vacancy.external_reference,
+                                   import_errors: vacancy.errors.to_json)
+    end
+  end
 
   def report_validation_errors(source_klass, vacancy)
     Sentry.with_scope do |scope|

--- a/app/jobs/import_from_vacancy_sources_job.rb
+++ b/app/jobs/import_from_vacancy_sources_job.rb
@@ -15,7 +15,7 @@ class ImportFromVacancySourcesJob < ApplicationJob
             Rails.logger.info("Imported vacancy #{vacancy.id} from feed #{source_klass.source_name}")
           else
             report_validation_errors(source_klass, vacancy)
-            FailedImportedVacancy.create(source: source_klass.source_name, import_errors: vacancy.errors.to_json)
+            FailedImportedVacancy.create(source: source_klass.source_name, external_reference: vacancy.external_reference, import_errors: vacancy.errors.to_json)
           end
         end
       end

--- a/app/jobs/import_from_vacancy_sources_job.rb
+++ b/app/jobs/import_from_vacancy_sources_job.rb
@@ -15,7 +15,7 @@ class ImportFromVacancySourcesJob < ApplicationJob
             Rails.logger.info("Imported vacancy #{vacancy.id} from feed #{source_klass.source_name}")
           else
             report_validation_errors(source_klass, vacancy)
-            Rails.logger.error("Failed to save imported vacancy: #{vacancy.errors.inspect}")
+            FailedImportedVacancy.create(source: source_klass.source_name, import_errors: vacancy.errors.to_json)
           end
         end
       end

--- a/app/models/failed_imported_vacancy.rb
+++ b/app/models/failed_imported_vacancy.rb
@@ -1,0 +1,2 @@
+class FailedImportedVacancy < ActiveRecord::Base
+end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -346,3 +346,4 @@ shared:
     - source
     - created_at
     - updated_at
+    - external_reference

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -340,3 +340,9 @@ shared:
     - further_details_provided
     - further_details
     - include_additional_documents
+  failed_imported_vacancies:
+    - id
+    - import_errors
+    - source
+    - created_at
+    - updated_at

--- a/db/migrate/20221201160022_add_failed_imported_vacancy_table.rb
+++ b/db/migrate/20221201160022_add_failed_imported_vacancy_table.rb
@@ -1,0 +1,9 @@
+class AddFailedImportedVacancyTable < ActiveRecord::Migration[7.0]
+  def change
+    create_table :failed_imported_vacancies, id: :uuid do |t|
+      t.string :import_errors, array: true, default: []
+      t.string :source, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20221202125452_add_external_reference_to_add_failed_imported_vacancy_table.rb
+++ b/db/migrate/20221202125452_add_external_reference_to_add_failed_imported_vacancy_table.rb
@@ -1,0 +1,5 @@
+class AddExternalReferenceToAddFailedImportedVacancyTable < ActiveRecord::Migration[7.0]
+  def change
+    add_column :failed_imported_vacancies, :external_reference, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_01_160022) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_02_125452) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -134,6 +134,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_01_160022) do
     t.string "source", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "external_reference"
   end
 
   create_table "feedbacks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_08_153545) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_01_160022) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -127,6 +127,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_08_153545) do
     t.integer "age_fifty_to_fifty_nine", default: 0, null: false
     t.integer "age_sixty_and_over", default: 0, null: false
     t.index ["vacancy_id"], name: "index_equal_opportunities_reports_on_vacancy_id"
+  end
+
+  create_table "failed_imported_vacancies", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "import_errors", default: [], array: true
+    t.string "source", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "feedbacks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/jobs/import_from_vacancy_sources_job_spec.rb
+++ b/spec/jobs/import_from_vacancy_sources_job_spec.rb
@@ -43,10 +43,11 @@ RSpec.describe ImportFromVacancySourcesJob do
         expect { described_class.perform_now }.to change { FailedImportedVacancy.count }.by(1)
       end
 
-      it "saves the vacancy in the FailedVacancyImports with the import errors" do
+      it "saves the vacancy in the FailedVacancyImports with the import errors and identifiable info" do
         described_class.perform_now
 
         expect(FailedImportedVacancy.first.source).to eq("fake_source")
+        expect(FailedImportedVacancy.first.external_reference).to eq("J3D1")
         expect(FailedImportedVacancy.first.import_errors.first).to eq("job_title:[can't be blank]")
         expect(FailedImportedVacancy.first.import_errors.last).to eq("phases:[can't be blank]")
       end

--- a/spec/jobs/import_from_vacancy_sources_job_spec.rb
+++ b/spec/jobs/import_from_vacancy_sources_job_spec.rb
@@ -53,6 +53,18 @@ RSpec.describe ImportFromVacancySourcesJob do
       end
     end
 
+    context "when there is already a duplicate vacancy in the FailedImportedVacancy table" do
+      let(:vacancies_from_source) { [vacancy1, vacancy2] }
+      let(:vacancy1) { build(:vacancy, :published, :external, external_reference: "123", phases: [], organisations: [school], job_title: "") }
+      let(:vacancy2) { build(:vacancy, :published, :external, external_reference: "123", phases: [], organisations: [school], job_title: "") }
+
+      it "does not save the second vacancy" do
+        described_class.perform_now
+
+        expect(FailedImportedVacancy.count).to eq(1)
+      end
+    end
+
     context "when a live vacancy no longer comes through" do
       let!(:vacancy) { create(:vacancy, :published, :external, phases: %w[secondary], organisations: [school], external_source: "fake_source", external_reference: "123", updated_at: 1.hour.ago) }
       let(:vacancies_from_source) { [] }


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-4567

## Changes in this PR:

When a vacancy is attempted to be imported we now store it in a separate table if it fails, alongside this we store the source of the vacancy and the errors associated with it. 

This will now allow us to go back and look at why a vacancy has failed, and do checks against batches of failed imports, which we can then send back to the source and ask them to make adjustments to then reduce these errors going forward.

We also don't save duplicate failed vacancies, thus reducing duplicate failures.