### PR TITLE
Refactor editing an organisation profile

### DIFF
--- a/app/controllers/publishers/organisations/description_controller.rb
+++ b/app/controllers/publishers/organisations/description_controller.rb
@@ -1,0 +1,26 @@
+class Publishers::Organisations::DescriptionController < Publishers::OrganisationsController
+  def edit
+    organisation
+    @description_form = Publishers::Organisation::DescriptionForm.new(description: organisation.description)
+  end
+
+  def update
+    @description_form = Publishers::Organisation::DescriptionForm.new(description_form_params)
+
+    if @description_form.valid?
+      organisation.update(description: params[:publishers_organisation_description_form][:description])
+
+      redirect_to publishers_organisation_path(organisation), success: t("publishers.organisations.update_success", organisation_type: organisation.school? ? "School" : "Organisation")
+    else
+      organisation
+
+      render :edit
+    end
+  end
+
+  private
+
+  def description_form_params
+    params.require(:publishers_organisation_description_form).permit(:description)
+  end
+end

--- a/app/controllers/publishers/organisations/url_override_controller.rb
+++ b/app/controllers/publishers/organisations/url_override_controller.rb
@@ -1,0 +1,26 @@
+class Publishers::Organisations::UrlOverrideController < Publishers::OrganisationsController
+  def edit
+    organisation
+    @url_override_form = Publishers::Organisation::UrlOverrideForm.new(url_override: organisation.url_override)
+  end
+
+  def update
+    @url_override_form = Publishers::Organisation::UrlOverrideForm.new(url_override_form_params)
+
+    if @url_override_form.valid?
+      organisation.update(url_override: params[:publishers_organisation_url_override_form][:url_override])
+
+      redirect_to publishers_organisation_path(organisation), success: t("publishers.organisations.update_success", organisation_type: organisation.school? ? "School" : "Organisation")
+    else
+      organisation
+
+      render :edit
+    end
+  end
+
+  private
+
+  def url_override_form_params
+    params.require(:publishers_organisation_url_override_form).permit(:url_override)
+  end
+end

--- a/app/controllers/publishers/organisations_controller.rb
+++ b/app/controllers/publishers/organisations_controller.rb
@@ -3,23 +3,6 @@ class Publishers::OrganisationsController < Publishers::BaseController
     organisation
   end
 
-  def edit
-    @organisation_form = Publishers::OrganisationForm.new(
-      description: organisation.description, url_override: organisation.url_override,
-    )
-  end
-
-  def update
-    @organisation_form = Publishers::OrganisationForm.new(organisation_params)
-
-    if organisation && @organisation_form.valid?
-      organisation.update(organisation_params)
-      redirect_to publishers_organisation_path(organisation), success: t(".success", organisation_type: organisation.school? ? "School" : "Organisation")
-    else
-      render :edit
-    end
-  end
-
   def preview
     @organisation = Organisation.friendly.find(params[:organisation_id])
   end

--- a/app/form_models/publishers/organisation/description_form.rb
+++ b/app/form_models/publishers/organisation/description_form.rb
@@ -1,0 +1,3 @@
+class Publishers::Organisation::DescriptionForm < BaseForm
+  attr_accessor :description
+end

--- a/app/form_models/publishers/organisation/url_override_form.rb
+++ b/app/form_models/publishers/organisation/url_override_form.rb
@@ -1,0 +1,5 @@
+class Publishers::Organisation::UrlOverrideForm < BaseForm
+  attr_accessor :url_override
+
+  validates :url_override, url: { allow_blank: true }
+end

--- a/app/form_models/publishers/organisation/url_override_form.rb
+++ b/app/form_models/publishers/organisation/url_override_form.rb
@@ -1,5 +1,11 @@
 class Publishers::Organisation::UrlOverrideForm < BaseForm
-  attr_accessor :url_override
+  attr_reader :url_override
 
   validates :url_override, url: { allow_blank: true }
+
+  def url_override=(link)
+    @url_override = Addressable::URI.heuristic_parse(link).to_s
+  rescue Addressable::URI::InvalidURIError
+    @url_override = link
+  end
 end

--- a/app/form_models/publishers/organisation_form.rb
+++ b/app/form_models/publishers/organisation_form.rb
@@ -1,5 +1,0 @@
-class Publishers::OrganisationForm < BaseForm
-  attr_accessor :description, :url_override
-
-  validates :url_override, url: { allow_blank: true }
-end

--- a/app/views/publishers/organisations/_organisation.html.slim
+++ b/app/views/publishers/organisations/_organisation.html.slim
@@ -27,18 +27,18 @@
         - row.key text: t(".size.label")
         - row.value text: text
 
-  - summary_list.row do |row|
+  - summary_list.row(html_attributes: { id: "website" }) do |row|
     - row.key text: t(".website.label")
     - row.with_value do
       - link = open_in_new_tab_link_to(organisation.url, organisation.url, class: "wordwrap") if organisation.url.present?
       = required_profile_info(value: link, missing_prompt: t(".website.missing_prompt"), missing_text: t(".not_provided"))
-    - row.action text: t("buttons.change"), href: edit_publishers_organisation_path(organisation), classes: "govuk-link--no-visited-state"
+    - row.action text: t("buttons.change"), href: edit_publishers_organisation_website_path(organisation), classes: "govuk-link--no-visited-state"
 
-  - summary_list.row do |row|
+  - summary_list.row(html_attributes: { id: "description" }) do |row|
     - row.key text: t(".description.label.#{organisation.school? ? :school : :organisation}")
     - row.with_value do
       = required_profile_info(value: truncate(organisation.description, length: 130), missing_prompt: t(".description.missing_prompt.#{organisation.school? ? :school : :organisation}"), missing_text: t(".not_provided"))
-    - row.action text: t("buttons.change"), href: edit_publishers_organisation_path(organisation), classes: "govuk-link--no-visited-state"
+    - row.action text: t("buttons.change"), href: edit_publishers_organisation_description_path(organisation), classes: "govuk-link--no-visited-state"
 
   - if organisation.has_ofsted_report?
     - summary_list.row do |row|

--- a/app/views/publishers/organisations/description/edit.html.slim
+++ b/app/views/publishers/organisations/description/edit.html.slim
@@ -1,0 +1,17 @@
+- content_for :page_title_prefix, @organisation.name.titlecase
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    h1.govuk-heading-l = t(".title", organisation_type: organisation_type_basic(@organisation))
+
+    = form_for @description_form, url: publishers_organisation_description_path(@organisation), method: :patch do |f|
+      = f.govuk_error_summary
+
+      h2.govuk-heading-m = @organisation.name
+
+      = f.govuk_text_area :description,
+        label: { text: t("helpers.label.publishers_organisation_form.description", organisation_type: organisation_type_basic(@organisation)), size: "s" },
+        hint: { text: t("helpers.hint.publishers_organisation_form.description", organisation_type: organisation_type_basic(@organisation)) },
+        rows: 10
+
+      = f.govuk_submit t("buttons.save_changes")

--- a/app/views/publishers/organisations/url_override/edit.html.slim
+++ b/app/views/publishers/organisations/url_override/edit.html.slim
@@ -1,0 +1,15 @@
+- content_for :page_title_prefix, @organisation.name.titlecase
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    h1.govuk-heading-l = t(".title", organisation_type: organisation_type_basic(@organisation))
+
+    = form_for @url_override_form, url: publishers_organisation_website_path(@organisation), method: :patch do |f|
+      = f.govuk_error_summary
+
+      h2.govuk-heading-m = @organisation.name
+
+      = f.govuk_url_field :url_override,
+        label: { text: t("helpers.label.publishers_organisation_form.url_override", organisation_type: organisation_type_basic(@organisation), gias_url: @organisation[:url]), size: "s" }
+
+      = f.govuk_submit t("buttons.save_changes")

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -18,9 +18,6 @@ en:
     year:
       less_than_or_equal_to: The year the qualification was awarded must be the current year or in the past
       not_a_number: Enter the year the qualification was awarded
-  organisation_errors: &organisation_errors
-    url_override:
-      url: Enter a link in the correct format, like www.school.ac.uk
   subscription_errors: &subscription_errors
     email:
       blank: Enter your email address
@@ -35,6 +32,9 @@ en:
       inclusion: Tell us why you want to unsubscribe
     user_participation_response:
       inclusion: Please indicate if you'd like to participate in user research
+  url_override_errors: &url_override_errors
+    url_override:
+      url: Enter a link in the correct format, like www.school.ac.uk
 
   # Feedback forms
   account_feedback_errors: &account_feedback_errors
@@ -385,9 +385,9 @@ en:
               invalid: Enter a date in the correct format
               on_or_after: The closing date must be in the future
               on_or_before: The closing date must be less than two years in the future
-        publishers/organisation_form:
+        publishers/organisation/url_override_form:
           attributes:
-            <<: *organisation_errors
+            <<: *url_override_errors
         publishers/terms_and_conditions_form:
           attributes:
             terms:

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -83,8 +83,9 @@ en:
           one: 1 unread notification
           other: "%{count} unread notifications"
     organisations:
-      edit:
-        title: Change %{organisation_type} details
+      description:
+        edit:
+           title: Change %{organisation_type} details
       preview:
         exit_preview_link_text: Exit preview
         page_title: Preview %{organisation_name}
@@ -103,8 +104,10 @@ en:
         profile_incomplete_banner:
           title: Complete your %{organisation_type} profile
         complete_school_profile: Complete your school profile
-      update:
-        success: "%{organisation_type} details updated"
+      update_success: "%{organisation_type} details updated"
+      url_override:
+        edit:
+          title: Change %{organisation_type} details
       organisation:
         not_provided: Not entered
         name:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,7 +104,10 @@ Rails.application.routes.draw do
     end
     resources :notifications, only: %i[index]
     resources :publisher_preferences, only: %i[new create edit update destroy]
-    resources :organisations, only: %i[show edit update] do
+    resources :organisations, only: %i[show] do
+      resource :description, only: %i[edit update], controller: "organisations/description"
+      resource :website, only: %i[edit update], controller: "organisations/url_override"
+
       get :preview
       get "schools/preview", to: "/publishers/organisations/schools#preview"
     end

--- a/spec/form_models/publishers/organisation/url_override_form_spec.rb
+++ b/spec/form_models/publishers/organisation/url_override_form_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe Publishers::Organisation::UrlOverrideForm, type: :model do
   it { is_expected.to allow_value("https://www.this-is-a-test-url.example.com").for(:url_override) }
+  it { is_expected.to allow_value("www.this-is-a-test-url.example.com").for(:url_override) }
   it { is_expected.to allow_value("").for(:url_override) }
   it { is_expected.not_to allow_value("invalid_url_override").for(:url_override) }
 end

--- a/spec/form_models/publishers/organisation/url_override_form_spec.rb
+++ b/spec/form_models/publishers/organisation/url_override_form_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Publishers::OrganisationForm, type: :model do
+RSpec.describe Publishers::Organisation::UrlOverrideForm, type: :model do
   it { is_expected.to allow_value("https://www.this-is-a-test-url.example.com").for(:url_override) }
   it { is_expected.to allow_value("").for(:url_override) }
   it { is_expected.not_to allow_value("invalid_url_override").for(:url_override) }

--- a/spec/system/publishers_can_manage_a_profile_spec.rb
+++ b/spec/system/publishers_can_manage_a_profile_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Publishers can manage an organisation or school profile" do
           click_link("Change")
         end
 
-        expect(find_field("publishers_organisation_url_override_form[url_override]").value).to be_nil
+        expect(find_field("publishers_organisation_url_override_form[url_override]").value).to be_blank
 
         fill_in "publishers_organisation_url_override_form[url_override]", with: school_website_url
         click_on I18n.t("buttons.save_changes")
@@ -86,7 +86,7 @@ RSpec.describe "Publishers can manage an organisation or school profile" do
           click_link("Change")
         end
 
-        expect(find_field("publishers_organisation_url_override_form[url_override]").value).to be_nil
+        expect(find_field("publishers_organisation_url_override_form[url_override]").value).to be_blank
 
         fill_in "publishers_organisation_url_override_form[url_override]", with: local_authority_website
         click_on I18n.t("buttons.save_changes")


### PR DESCRIPTION
Some tests need to be fixed / added in order to finish this. 

## Changes in this PR:

At first, I tried to add params to the change links found on the publisher organisation show page. Based on these params, we'd show render a partial which would show the form field for the field specified in the params. However, after playing around with this I quickly found that this was going to be a messy solution, requiring us to pass params around everywhere, add hidden fields to forms, create a bunch of partials and add a bunch of logic to the publishers organisations controller. 

Because of this, I decided to create separate resource routes for each field nested within publishers/organisations. I have used `resource` instead of `resources` so an id for the resource isn't required (we don't have them in this case... obviously 😅). This may help explain: https://guides.rubyonrails.org/routing.html#singular-resources. 

This simplifies things and allows us to set a pattern which can be followed when adding the ability to add a logo or photo to a profile. The controllers which will handle logos and photos separately should probably follow the pattern set in `app/controllers/publishers/vacancies/application_forms_controller.rb`.