### PR TITLE
Change method call to blank? to avoid errors when nil

### DIFF
--- a/app/services/ons_data_import/base.rb
+++ b/app/services/ons_data_import/base.rb
@@ -7,7 +7,7 @@ class OnsDataImport::Base
   def call
     (0..).each do |offset|
       features = arcgis_features(offset)
-      break if features.none?
+      break if features.blank?
 
       features.each do |feature|
         name = feature["properties"][name_field].downcase


### PR DESCRIPTION
## Changes in this PR:

This PR changes the method we use on `features` (brought through from the ArcGIS APIs) from `none?` to `blank?`. `none?` was causing an error when `features` was nil (see [Sentry error](https://sentry.io/organizations/teaching-vacancies/issues/3788126575/?environment=review&project=6212514&query=is%3Aunresolved&referrer=issue-stream)).
