### PR TITLE
Forcing user to enter protocol for organisation website

### DIFF
--- a/app/controllers/publishers/organisations/url_override_controller.rb
+++ b/app/controllers/publishers/organisations/url_override_controller.rb
@@ -8,7 +8,7 @@ class Publishers::Organisations::UrlOverrideController < Publishers::Organisatio
     @url_override_form = Publishers::Organisation::UrlOverrideForm.new(url_override_form_params)
 
     if @url_override_form.valid?
-      organisation.update(url_override: params[:publishers_organisation_url_override_form][:url_override])
+      organisation.update!(url_override: @url_override_form.url_override)
 
       redirect_to publishers_organisation_path(organisation), success: t("publishers.organisations.update_success", organisation_type: organisation.school? ? "School" : "Organisation")
     else

--- a/app/form_models/publishers/job_listing/application_link_form.rb
+++ b/app/form_models/publishers/job_listing/application_link_form.rb
@@ -1,14 +1,8 @@
 class Publishers::JobListing::ApplicationLinkForm < Publishers::JobListing::VacancyForm
-  validates :application_link, presence: true, url: true
+  validates :application_link, presence: true, url: { allow_blank: true }
 
   def self.fields
     %i[application_link]
   end
   attr_accessor(*fields)
-
-  def application_link=(link)
-    @application_link = Addressable::URI.heuristic_parse(link).to_s
-  rescue Addressable::URI::InvalidURIError
-    @application_link = link
-  end
 end

--- a/app/form_models/publishers/organisation/url_override_form.rb
+++ b/app/form_models/publishers/organisation/url_override_form.rb
@@ -1,11 +1,5 @@
 class Publishers::Organisation::UrlOverrideForm < BaseForm
-  attr_reader :url_override
+  attr_accessor :url_override
 
   validates :url_override, url: { allow_blank: true }
-
-  def url_override=(link)
-    @url_override = Addressable::URI.heuristic_parse(link).to_s
-  rescue Addressable::URI::InvalidURIError
-    @url_override = link
-  end
 end

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -34,7 +34,7 @@ en:
       inclusion: Please indicate if you'd like to participate in user research
   url_override_errors: &url_override_errors
     url_override:
-      url: Enter a link in the correct format, like www.school.ac.uk
+      url: Enter a link in the correct format, like https://www.school.ac.uk
 
   # Feedback forms
   account_feedback_errors: &account_feedback_errors
@@ -209,7 +209,7 @@ en:
   application_link_errors: &application_link_errors
     application_link:
       blank: Enter the link to the application website
-      url: Enter a link in the correct format, like www.school.ac.uk
+      url: Enter a link in the correct format, like https://www.school.ac.uk
   school_visits_errors: &school_visits_errors
     school_visits:
       inclusion: Select yes if school visits are offered

--- a/spec/form_models/publishers/job_listing/application_link_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/application_link_form_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Publishers::JobListing::ApplicationLinkForm, type: :model do
   let(:enable_job_applications) { true }
 
   it { is_expected.to allow_value("https://www.this-is-a-test-url.example.com").for(:application_link) }
-  it { is_expected.to allow_value("www.this-is-a-test-url.example.com").for(:application_link) }
+  it { is_expected.not_to allow_value("www.this-is-a-test-url.example.com").for(:application_link) }
   it { is_expected.not_to allow_value("").for(:application_link) }
   it { is_expected.not_to allow_value("email@school.com").for(:application_link) }
   it { is_expected.not_to allow_value("A full application pack can be found at www.website.co.uk").for(:application_link) }

--- a/spec/form_models/publishers/organisation/url_override_form_spec.rb
+++ b/spec/form_models/publishers/organisation/url_override_form_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Publishers::Organisation::UrlOverrideForm, type: :model do
   it { is_expected.to allow_value("https://www.this-is-a-test-url.example.com").for(:url_override) }
-  it { is_expected.to allow_value("www.this-is-a-test-url.example.com").for(:url_override) }
+  it { is_expected.not_to allow_value("www.this-is-a-test-url.example.com").for(:url_override) }
   it { is_expected.to allow_value("").for(:url_override) }
   it { is_expected.not_to allow_value("invalid_url_override").for(:url_override) }
 end


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-4590

## Changes in this PR:

We should not allow urls without protocol to be entered as url_override, not should we guess the protocol as we don't know how the school website will handle it.