### PR TITLE
Update Fusion Integration

### DIFF
--- a/app/vacancy_sources/fusion_vacancy_source.rb
+++ b/app/vacancy_sources/fusion_vacancy_source.rb
@@ -55,10 +55,14 @@ class FusionVacancySource
 
   def organisation_fields(item)
     {
-      readable_job_location: organisations_for(item).first&.name,
+      readable_job_location: main_organisation(item).name,
       organisations: organisations_for(item),
-      about_school: organisations_for(item).first&.description,
+      about_school: main_organisation(item).description,
     }
+  end
+
+  def main_organisation(item)
+    organisations_for(item).one? ? organisations_for(item).first : school_group(item)
   end
 
   def ect_status_for(item)
@@ -68,7 +72,11 @@ class FusionVacancySource
   end
 
   def organisations_for(item)
-    [school_group(item).schools.find_by(urn: item["schoolUrns"].first)]
+    if school_group(item).present?
+      school_group(item).schools.where(urn: item["schoolUrns"])
+    else
+      Organisation.where(urn: item["schoolUrns"])
+    end.to_a
   end
 
   def school_group(item)

--- a/spec/fixtures/files/vacancy_sources/fusion.json
+++ b/spec/fixtures/files/vacancy_sources/fusion.json
@@ -10,14 +10,14 @@
       "jobAdvert": "Lorem Ipsum dolor sit amet",
       "salary": "£25,714.00 to £41,604.00",
       "schoolUrns": [
-        "145506"
+        "111111", "222222"
       ],
       "keyStages": "ks1,ks2",
       "jobRole": "teacher",
       "workingPatterns": "full_time",
       "contractType": "fixed_term",
       "phase": "primary",
-      "trustId": "16614"
+      "trustId": "12345"
     }
   ],
   "targetUrl": null,


### PR DESCRIPTION
This pull request tackles multiple issues.

1. It decides to display trust information in case there are multiple vacancies associated to the Trust and school information in case there is only one school, wether that's associated to the trust or not.

2. It allows vacancies at individual schools with no trust.

## Jira ticket URLs

https://dfedigital.atlassian.net/browse/TEVA-4569
https://dfedigital.atlassian.net/browse/TEVA-4584