### PR TITLE
[TEVA-4539] Add safeguarding information to school profiles

### DIFF
--- a/app/controllers/publishers/organisations/safeguarding_information_controller.rb
+++ b/app/controllers/publishers/organisations/safeguarding_information_controller.rb
@@ -1,0 +1,26 @@
+class Publishers::Organisations::SafeguardingInformationController < Publishers::OrganisationsController
+  def edit
+    organisation
+    @safeguarding_information_form = Publishers::Organisation::SafeguardingInformationForm.new(safeguarding_information: organisation.safeguarding_information)
+  end
+
+  def update
+    @safeguarding_information_form = Publishers::Organisation::SafeguardingInformationForm.new(safeguarding_information_form_params)
+
+    if @safeguarding_information_form.valid?
+      organisation.update(safeguarding_information: @safeguarding_information_form.safeguarding_information)
+
+      redirect_to publishers_organisation_path(organisation), success: t("publishers.organisations.update_success", organisation_type: organisation.school? ? "School" : "Organisation")
+    else
+      organisation
+
+      render :edit
+    end
+  end
+
+  private
+
+  def safeguarding_information_form_params
+    params.require(:publishers_organisation_safeguarding_information_form).permit(:safeguarding_information)
+  end
+end

--- a/app/controllers/publishers/organisations_controller.rb
+++ b/app/controllers/publishers/organisations_controller.rb
@@ -22,6 +22,6 @@ class Publishers::OrganisationsController < Publishers::BaseController
   end
 
   def organisation_params
-    params.require(:publishers_organisation_form).permit(:description, :url_override, :email)
+    params.require(:publishers_organisation_form).permit(:description, :email, :safeguarding_information, :url_override)
   end
 end

--- a/app/form_models/publishers/organisation/safeguarding_information_form.rb
+++ b/app/form_models/publishers/organisation/safeguarding_information_form.rb
@@ -1,0 +1,28 @@
+class Publishers::Organisation::SafeguardingInformationForm < BaseForm
+  validate :safeguarding_information_presence
+  validate :safeguarding_information_does_not_exceed_maximum_words
+
+  attr_accessor :safeguarding_information
+
+  private
+
+  def safeguarding_information_presence
+    return if remove_html_tags(safeguarding_information).present?
+
+    errors.add(:safeguarding_information, :blank)
+  end
+
+  def safeguarding_information_does_not_exceed_maximum_words
+    errors.add(:safeguarding_information, :length) if number_of_words_exceeds_permitted_length?(100, safeguarding_information)
+  end
+
+  def remove_html_tags(field)
+    regex = /<("[^"]*"|'[^']*'|[^'">])*>/
+
+    field&.gsub(regex, "")
+  end
+
+  def number_of_words_exceeds_permitted_length?(number, attribute)
+    remove_html_tags(attribute)&.split&.length&.>(number)
+  end
+end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -98,7 +98,7 @@ class Organisation < ApplicationRecord
   end
 
   def profile_complete?
-    %i[url description].all? { |attribute| send(attribute).present? }
+    %i[email description safeguarding_information url].all? { |attribute| send(attribute).present? }
   end
 
   private

--- a/app/views/organisations/_organisation.html.slim
+++ b/app/views/organisations/_organisation.html.slim
@@ -69,6 +69,13 @@
           - row.value
             = organisation.description
 
+      - if organisation.safeguarding_information?
+        - summary_list.row do |row|
+          - row.key
+            = t("organisations.show.summary.safeguarding_information")
+          - row.value
+            = organisation.safeguarding_information
+
 - if organisation.geopoint?
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/publishers/organisations/_organisation.html.slim
+++ b/app/views/publishers/organisations/_organisation.html.slim
@@ -47,6 +47,12 @@
       = required_profile_info(value: truncate(organisation.description, length: 130), missing_prompt: t(".description.missing_prompt.#{organisation.school? ? :school : :organisation}"), missing_text: t(".not_provided"))
     - row.action text: t("buttons.change"), href: edit_publishers_organisation_description_path(organisation), classes: "govuk-link--no-visited-state"
 
+  - summary_list.row(html_attributes: { id: "safeguarding_information" }) do |row|
+    - row.key text: t(".safeguarding_information.label")
+    - row.with_value do
+      = required_profile_info(value: truncate(organisation.safeguarding_information, length: 130), missing_prompt: t(".safeguarding_information.missing_prompt"), missing_text: t(".not_provided"))
+    - row.action text: t("buttons.change"), href: edit_publishers_organisation_safeguarding_information_path(organisation), classes: "govuk-link--no-visited-state"
+
   - if organisation.has_ofsted_report?
     - summary_list.row do |row|
       - row.key text: t(".ofsted_report.label")

--- a/app/views/publishers/organisations/safeguarding_information/edit.html.slim
+++ b/app/views/publishers/organisations/safeguarding_information/edit.html.slim
@@ -1,0 +1,15 @@
+- content_for :page_title_prefix, @organisation.name.titlecase
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    = form_for @safeguarding_information_form, url: publishers_organisation_safeguarding_information_path(@organisation), method: :patch do |f|
+      = f.govuk_error_summary
+
+      span.govuk-caption-l = t(".caption")
+
+      = f.govuk_text_area :safeguarding_information,
+        label: { text: t("helpers.label.publishers_organisation_form.safeguarding_information"), size: "l" },
+        rows: 10,
+        max_words: 100
+
+      = f.govuk_submit t("buttons.save_changes")

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -163,6 +163,7 @@ shared:
     - type
     - name
     - description
+    - safeguarding_information
     - urn
     - uid
     - phase

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -250,8 +250,8 @@ en:
     safeguarding_information_provided:
       inclusion: Select yes if you want to add information about your commitment to safeguarding
     safeguarding_information:
-      blank: Enter the information about your commitment to safeguarding
-      length: Safeguarding information must be 100 words or less
+      blank: Enter information about your commitment to safeguarding
+      length: Commitment to safeguarding must be 100 words or less
     further_details_provided:
       inclusion: Select yes if you want to add further details about the role
     further_details:

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -21,6 +21,10 @@ en:
     year:
       less_than_or_equal_to: The year the qualification was awarded must be the current year or in the past
       not_a_number: Enter the year the qualification was awarded
+  safeguarding_information_errors: &safeguarding_information_errors
+    safeguarding_information:
+      blank: Enter information about your commitment to safeguarding
+      length: Commitment to safeguarding must be 100 words or less
   subscription_errors: &subscription_errors
     email:
       blank: Enter your email address
@@ -391,6 +395,9 @@ en:
         publishers/organisation/email_form:
           attributes:
             <<: *email_errors
+        publishers/organisation/safeguarding_information_form:
+          attributes:
+            <<: *safeguarding_information_errors
         publishers/organisation/url_override_form:
           attributes:
             <<: *url_override_errors

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -373,6 +373,7 @@ en:
         email_address: Email address
         heading: Summary
         name: Name
+        safeguarding_information: Commitment to safeguarding
         size: Size
         type: Type
         website_address: Website address

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -486,6 +486,7 @@ en:
       publishers_organisation_form:
         description: Description of %{organisation_type}
         email: Email address
+        safeguarding_information: Commitment to safeguarding
         url_override: "Override the %{organisation_type}'s website (defaults to \"%{gias_url}\")"
 
       publishers_job_application_notes_form:

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -101,6 +101,9 @@ en:
           heading:
             caption_with_link_html: Part of %{link}
             link_text: '%{organisation_name}'
+      safeguarding_information:
+        edit:
+          caption: Organisation profile
       schools:
         preview:
           exit_preview_link_text: Exit preview
@@ -140,6 +143,9 @@ en:
             through: Through
             middle_deemed_secondary: Middle deamed secondary school
             middle_deemed_primary: Middle deamed primary school
+        safeguarding_information:
+          missing_prompt: Enter information about your commitment to safeguarding
+          label: Commitment to safeguarding
         school_age:
           label: Age group
         size:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,6 +107,7 @@ Rails.application.routes.draw do
     resources :organisations, only: %i[show] do
       resource :description, only: %i[edit update], controller: "organisations/description"
       resource :email, only: %i[edit update], controller: "organisations/email"
+      resource :safeguarding_information, only: %i[edit update], controller: "organisations/safeguarding_information"
       resource :website, only: %i[edit update], controller: "organisations/url_override"
 
       get :preview

--- a/db/migrate/20221208134937_add_safeguarding_information_to_organisation.rb
+++ b/db/migrate/20221208134937_add_safeguarding_information_to_organisation.rb
@@ -1,0 +1,5 @@
+class AddSafeguardingInformationToOrganisation < ActiveRecord::Migration[7.0]
+  def change
+    add_column :organisations, :safeguarding_information, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_08_092637) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_08_134937) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -363,6 +363,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_08_092637) do
     t.text "gias_data_hash"
     t.string "slug"
     t.string "email"
+    t.string "safeguarding_information"
     t.index ["geopoint"], name: "index_organisations_on_geopoint", using: :gist
     t.index ["local_authority_code"], name: "index_organisations_on_local_authority_code", unique: true
     t.index ["slug"], name: "index_organisations_on_slug", unique: true

--- a/spec/factories/school_groups.rb
+++ b/spec/factories/school_groups.rb
@@ -6,6 +6,8 @@ FactoryBot.define do
   factory :trust, parent: :school_group do
     address { Faker::Address.street_name.delete("'") }
     county { Faker::Address.state_abbr }
+    description { Faker::Lorem.paragraph(sentence_count: 1) }
+    email { Faker::Internet.email }
     gias_data do
       {
         "Group UID": uid,
@@ -21,15 +23,21 @@ FactoryBot.define do
     group_type { "Multi-academy trust" }
     name { "#{Faker::Company.name.delete("'")} Trust" }
     postcode { Faker::Address.postcode }
+    safeguarding_information { Faker::Lorem.paragraph(sentence_count: 1) }
     sequence(:slug) { |n| "#{name.parameterize}-#{n}" }
     town { Faker::Address.city.delete("'") }
     uid { Faker::Number.number(digits: 5).to_s }
-    url_override { Faker::Internet.url(host: "example.com") }
+    url { Faker::Internet.url(host: "example.com") }
+
+    trait :profile_incomplete do
+      description { nil }
+    end
   end
 
   factory :local_authority, parent: :school_group do
     name { "#{Faker::Address.state_abbr} LA" }
     group_type { "local_authority" }
     local_authority_code { Faker::Number.number(digits: 3).to_s }
+    safeguarding_information { Faker::Lorem.paragraph(sentence_count: 1) }
   end
 end

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     address { Faker::Address.street_name.delete("'") }
     county { Faker::Address.state_abbr }
     description { Faker::Lorem.paragraph(sentence_count: 1) }
+    email { Faker::Internet.email }
     establishment_status { "Open" }
     geopoint { "POINT(2 1)" }
     gias_data do
@@ -31,6 +32,7 @@ FactoryBot.define do
     phase { :secondary }
     readable_phases { %w[secondary] }
     region { "South-East England" }
+    safeguarding_information { Faker::Lorem.paragraph(sentence_count: 1) }
     sequence(:slug) { |n| "#{name.parameterize}-#{n}" }
     school_type { "LA maintained school" }
     postcode { Faker::Address.postcode }
@@ -71,6 +73,10 @@ FactoryBot.define do
 
     trait :no_geolocation do
       geopoint { nil }
+    end
+
+    trait :profile_incomplete do
+      description { nil }
     end
   end
 

--- a/spec/form_models/publishers/organisation/safeguarding_information_form_spec.rb
+++ b/spec/form_models/publishers/organisation/safeguarding_information_form_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe Publishers::Organisation::SafeguardingInformationForm, type: :model do
+  it { is_expected.to allow_value(Faker::Lorem.sentence(word_count: 99)).for(:safeguarding_information) }
+  it { is_expected.not_to allow_value(Faker::Lorem.sentence(word_count: 101)).for(:safeguarding_information) }
+  it { is_expected.not_to allow_value("").for(:safeguarding_information) }
+end

--- a/spec/system/publishers_can_filter_vacancies_in_their_dashboard_spec.rb
+++ b/spec/system/publishers_can_filter_vacancies_in_their_dashboard_spec.rb
@@ -52,7 +52,6 @@ RSpec.describe "Publishers can filter vacancies in their dashboard" do
 
         it "shows all published vacancies again" do
           expect(page).to_not have_css(".filters-component__remove-tags__tag")
-          click_on I18n.t("publishers.incomplete_profile.skip_to_link_text")
           expect(page).to have_content(school_group_vacancy.job_title)
           expect(page).to have_content(school1_vacancy.job_title)
         end

--- a/spec/system/publishers_can_manage_a_profile_spec.rb
+++ b/spec/system/publishers_can_manage_a_profile_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe "Publishers can manage an organisation or school profile" do
           click_link("Change")
         end
 
-        expect(find_field("publishers_organisation_description_form[description]").value).to be_empty
+        expect(find_field("publishers_organisation_description_form[description]").value).to eq(organisation.description)
 
         fill_in "publishers_organisation_description_form[description]", with: new_trust_description
         click_on I18n.t("buttons.save_changes")
@@ -223,7 +223,7 @@ RSpec.describe "Publishers can manage an organisation or school profile" do
           click_link("Change")
         end
 
-        expect(find_field("publishers_organisation_email_form[email]").value).to be_blank
+        expect(find_field("publishers_organisation_email_form[email]").value).to eq(organisation.email)
 
         fill_in "publishers_organisation_email_form[email]", with: new_trust_email
         click_on I18n.t("buttons.save_changes")
@@ -268,6 +268,94 @@ RSpec.describe "Publishers can manage an organisation or school profile" do
         click_on I18n.t("buttons.save_changes")
 
         expect(page).to have_content(local_authority_email)
+        expect(page).to have_content(I18n.t("publishers.organisations.update_success", organisation_type: "Organisation"))
+        expect(page.current_path).to eq(publishers_organisation_path(organisation))
+      end
+    end
+  end
+
+  describe "changing the organisation's safeguarding information" do
+    context "when the publisher is signed in as a school" do
+      let(:organisation) { create(:school) }
+      let(:school_safeguarding_information) { "A very safe school" }
+
+      before { click_link I18n.t("nav.school_profile") }
+
+      it "allows the publisher to edit the school's safeguarding information" do
+        within("div.govuk-summary-list__row#safeguarding_information") do
+          click_link("Change")
+        end
+
+        expect(find_field("publishers_organisation_safeguarding_information_form[safeguarding_information]").value).to eq(organisation.safeguarding_information)
+
+        fill_in "publishers_organisation_safeguarding_information_form[safeguarding_information]", with: school_safeguarding_information
+        click_on I18n.t("buttons.save_changes")
+
+        expect(page).to have_content(school_safeguarding_information)
+        expect(page).to have_content(I18n.t("publishers.organisations.update_success", organisation_type: "School"))
+        expect(page.current_path).to eq(publishers_organisation_path(organisation))
+      end
+    end
+
+    context "when the publisher is signed in as a trust" do
+      let(:organisation) { create(:trust, schools: [school1, school2]) }
+      let(:school1) { create(:school) }
+      let(:school2) { create(:school) }
+      let(:new_trust_safeguarding_information) { "This trust is very safe" }
+      let(:new_school_safeguarding_information) { "This school is very safe" }
+
+      before { click_link I18n.t("nav.organisation_profile") }
+
+      it "allows the publisher to edit the trust's safeguarding information" do
+        within("div.govuk-summary-list__row#safeguarding_information") do
+          click_link("Change")
+        end
+
+        expect(find_field("publishers_organisation_safeguarding_information_form[safeguarding_information]").value).to eq(organisation.safeguarding_information)
+
+        fill_in "publishers_organisation_safeguarding_information_form[safeguarding_information]", with: new_trust_safeguarding_information
+        click_on I18n.t("buttons.save_changes")
+
+        expect(page).to have_content(new_trust_safeguarding_information)
+        expect(page).to have_content(I18n.t("publishers.organisations.update_success", organisation_type: "Organisation"))
+        expect(page.current_path).to eq(publishers_organisation_path(organisation))
+      end
+
+      it "allows the publisher to navigate and edit a school's description" do
+        click_on school1.name
+
+        within("div.govuk-summary-list__row#safeguarding_information") do
+          click_link("Change")
+        end
+
+        expect(find_field("publishers_organisation_safeguarding_information_form[safeguarding_information]").value).to eq(school1.safeguarding_information)
+
+        fill_in "publishers_organisation_safeguarding_information_form[safeguarding_information]", with: new_school_safeguarding_information
+        click_on I18n.t("buttons.save_changes")
+
+        expect(page).to have_content(new_school_safeguarding_information)
+        expect(page).to have_content(I18n.t("publishers.organisations.update_success", organisation_type: "School"))
+        expect(page.current_path).to eq(publishers_organisation_path(school1))
+      end
+    end
+
+    context "when the publisher is signed in as a local authority" do
+      let(:organisation) { create(:local_authority) }
+      let(:local_authority_safeguarding_information) { "A very safe local authority" }
+
+      before { click_link I18n.t("nav.organisation_profile") }
+
+      it "allows the publisher to edit the local authority's safeguarding information" do
+        within("div.govuk-summary-list__row#safeguarding_information") do
+          click_link("Change")
+        end
+
+        expect(find_field("publishers_organisation_safeguarding_information_form[safeguarding_information]").value).to eq(organisation.safeguarding_information)
+
+        fill_in "publishers_organisation_safeguarding_information_form[safeguarding_information]", with: local_authority_safeguarding_information
+        click_on I18n.t("buttons.save_changes")
+
+        expect(page).to have_content(local_authority_safeguarding_information)
         expect(page).to have_content(I18n.t("publishers.organisations.update_success", organisation_type: "Organisation"))
         expect(page.current_path).to eq(publishers_organisation_path(organisation))
       end

--- a/spec/system/publishers_can_sign_in_by_email_spec.rb
+++ b/spec/system/publishers_can_sign_in_by_email_spec.rb
@@ -155,7 +155,6 @@ RSpec.describe "Publishers can sign in with fallback email authentication" do
               .with_base_data(user_anonymised_publisher_id: anonymised_form_of(publisher.oid))
               .and_data(sign_in_type: "email")
 
-            click_on I18n.t("publishers.incomplete_profile.skip_to_link_text")
             expect(page).not_to have_content("Choose your organisation")
             expect(page).to have_content(trust.name)
             expect { login_key.reload }.to raise_error ActiveRecord::RecordNotFound

--- a/spec/system/publishers_can_sign_in_with_dfe_spec.rb
+++ b/spec/system/publishers_can_sign_in_with_dfe_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe "Publishers can sign in with DfE Sign In" do
 
   context "with DSI data including a school group (trust or local authority) that the school belongs to" do
     let!(:publisher) { Publisher.find_by(oid: user_oid) }
-    let!(:school) { create(:school, urn: "246757") }
+    let!(:school) { create(:school, :profile_incomplete, urn: "246757") }
 
     before do
       publisher.update organisations: [school, school_group]
@@ -135,7 +135,7 @@ RSpec.describe "Publishers can sign in with DfE Sign In" do
   end
 
   context "with valid credentials that match a Trust" do
-    let(:organisation) { create(:trust) }
+    let(:organisation) { create(:trust, :profile_incomplete) }
     let(:publisher_preference) { instance_double(PublisherPreference) }
 
     before do


### PR DESCRIPTION
## Jira ticket URL

https://dfedigital.atlassian.net/browse/TEVA-4539

## Changes in this PR:

This PR adds the `safeguarding_information` to the Organisation model, and allows users to update this field on the school/organisation "manage profile" page. The safeguarding information is then displayed on the school profile page. School groups can also update their schools' safeguarding information via the manage profile page.

## Screenshots of UI changes:

### Before
"Manage profile"
![image](https://user-images.githubusercontent.com/24639777/207050312-ee1013ed-0aad-45c8-9abd-8e74cc2d73b5.png)

"Preview profile"
![image](https://user-images.githubusercontent.com/24639777/207050425-a1bfb260-dbc3-49a6-abcc-447b8d177a84.png)

"School profile (jobseeker perspective)"
![image](https://user-images.githubusercontent.com/24639777/207050568-1f582d77-ecf7-4c67-81f2-390803026c16.png)

### After
"Manage profile (before adding safeguarding info)"
![image](https://user-images.githubusercontent.com/24639777/207050803-3877cd4d-dd89-4bae-b002-251cd6962466.png)

"Safeguarding information form"
<img width="812" alt="image" src="https://user-images.githubusercontent.com/24639777/207104938-ba50ba4f-db0b-443a-8a5b-782baebf4aec.png">

"Manage profile (after adding safeguarding info)"
![image](https://user-images.githubusercontent.com/24639777/207050964-95ed0bab-5ca3-4108-bf76-c58e8c130fb1.png)

"Preview profile"
![image](https://user-images.githubusercontent.com/24639777/207051126-3d1166a4-e8d6-4c89-a1ff-21cdd6abc678.png)

"School profile (jobseeker perspective)"
![image](https://user-images.githubusercontent.com/24639777/207051226-64bad901-0958-48dd-a511-d2bddaefd85e.png)
