### PR TITLE
[TEVA-4566] handle sentry FE exceptions

### DIFF
--- a/app/assets/javascript/lib/logging.js
+++ b/app/assets/javascript/lib/logging.js
@@ -19,8 +19,8 @@ const consoleLogger = {
 /* eslint-enable no-console */
 
 const sentryLogger = {
-  log: Sentry.captureMessage,
-  error: Sentry.captureException,
+  log: () => Sentry.captureMessage(new Error('sentry fetch error captureMessage')),
+  error: () => Sentry.captureException(new Error('sentry fetch error captureException')),
 };
 
 const mockLogger = environment === 'test' ? silentLogger : consoleLogger;


### PR DESCRIPTION
this should get rid of `failed to fetch` errors being logged in sentry which bizarrely seems to come from the sentry API conflicting with GTM/ad blockers. This code might be updated to just pass `new Error` but i want to see if passing error message gets logged

See here for details
https://github.com/getsentry/sentry-javascript/issues/6376
https://docs.sentry.io/platforms/javascript/troubleshooting/#dealing-with-ad-blockers