### PR TITLE
Consolidate Imported Vacancies errors

### DIFF
--- a/app/jobs/import_from_vacancy_sources_job.rb
+++ b/app/jobs/import_from_vacancy_sources_job.rb
@@ -11,8 +11,8 @@ class ImportFromVacancySourcesJob < ApplicationJob
 
       source_klass.new.each do |vacancy|
         PaperTrail.request(whodunnit: "Import from external source") do
-          if vacancy.save
-            Rails.logger.info("Imported vacancy #{vacancy.id} from feed #{source_klass.source_name}")
+          if vacancy.valid?
+            import_vacancy(source_klass, vacancy)
           else
             report_validation_errors(source_klass, vacancy)
             create_failed_imported_vacancy(source_klass, vacancy)
@@ -28,6 +28,11 @@ class ImportFromVacancySourcesJob < ApplicationJob
   end
 
   private
+
+  def import_vacancy(source_klass, vacancy)
+    vacancy.save
+    Rails.logger.info("Imported vacancy #{vacancy.id} from feed #{source_klass.source_name}")
+  end
 
   def create_failed_imported_vacancy(source_klass, vacancy)
     if FailedImportedVacancy.find_by(external_reference: vacancy.external_reference)

--- a/app/vacancy_sources/fusion_vacancy_source.rb
+++ b/app/vacancy_sources/fusion_vacancy_source.rb
@@ -23,11 +23,13 @@ class FusionVacancySource
       # (i.e. today, unless it already has a publish on date set)
       v.publish_on ||= Date.today
 
-      v.assign_attributes(attributes_for(result))
+      begin
+        v.assign_attributes(attributes_for(result))
+      rescue ArgumentError => e
+        v.errors.add(:base, e)
+      end
 
       yield v
-    rescue StandardError => e
-      Sentry.capture_exception(e)
     end
   end
 

--- a/app/vacancy_sources/united_learning_vacancy_source.rb
+++ b/app/vacancy_sources/united_learning_vacancy_source.rb
@@ -33,11 +33,13 @@ class UnitedLearningVacancySource
       # (i.e. today, unless it already has a publish on date set)
       v.publish_on ||= Date.today
 
-      v.assign_attributes(attributes_for(item))
+      begin
+        v.assign_attributes(attributes_for(item))
+      rescue ArgumentError => e
+        v.errors.add(:base, e)
+      end
 
       yield v
-    rescue StandardError => e
-      Sentry.capture_exception(e)
     end
   end
 

--- a/spec/fixtures/files/vacancy_sources/fusion_argument_error.json
+++ b/spec/fixtures/files/vacancy_sources/fusion_argument_error.json
@@ -1,0 +1,28 @@
+{
+  "result": [
+    {
+      "reference": "0044",
+      "advertUrl": "http://testurl.com",
+      "applicationUrl": "http://testurl.com",
+      "expiresAt": "2022-10-28T12:00:00",
+      "startDate": "2022-11-21T00:00:00",
+      "jobTitle": "Class Teacher",
+      "jobAdvert": "Lorem Ipsum dolor sit amet",
+      "salary": "£25,714.00 to £41,604.00",
+      "schoolUrns": [
+        "111111", "222222"
+      ],
+      "keyStages": "ks1,ks2",
+      "jobRole": "teacher",
+      "workingPatterns": "full_time",
+      "contractType": "fixed_term",
+      "phase": "Incorrect value provided",
+      "trustId": "12345"
+    }
+  ],
+  "targetUrl": null,
+  "success": true,
+  "error": null,
+  "unAuthorizedRequest": false,
+  "__abp": true
+}

--- a/spec/fixtures/files/vacancy_sources/united_learning_argument_error.xml
+++ b/spec/fixtures/files/vacancy_sources/united_learning_argument_error.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss xmlns:a10="http://www.w3.org/2005/Atom" version="2.0">
+   <channel>
+       <title>United Learning RSS Feed</title>
+       <link>https://unitedlearning.current-vacancies.com/RSSFeeds/Vacancies/UNITEDLEAR?feedID=C8E62F84748A4306A68C06C1C583F242</link>
+       <description>United Learning RSS Feed</description>
+       <item>
+           <link>https://unitedlearning.current-vacancies.com/Jobs/FeedLink/2648837</link>
+           <title>Head of Geography</title>
+           <a10:updated>2022-04-29T10:29:57Z</a10:updated>
+           <a10:content type="text/xml">
+               <Vacancy>
+                   <VacancyID>751190</VacancyID>
+                   <vTitle>Head of Geography</vTitle>
+                   <VacancyPublishInfoID>2648837</VacancyPublishInfoID>
+                   <Vacancy_title>Head of Geography</Vacancy_title>
+                   <Salary>PT/EPT + TLR 2B</Salary>
+                   <Advert_text>Lorem ipsum dolor sit amet</Advert_text>
+                   <Vacancy_ID>NTXTP751190</Vacancy_ID>
+                   <Expiry_date>15/05/2022 12:00:00</Expiry_date>
+                   <Job_roles>teacher</Job_roles>
+                   <ect_suitable>yes</ect_suitable>
+                   <send_responsible>yes</send_responsible>
+                   <Working_patterns>full_time</Working_patterns>
+                   <Subjects>Geography</Subjects>
+                   <Contract_type>Incorrect value provided</Contract_type>
+                   <Phase>Multiple phases</Phase>
+                   <URN>136636</URN>
+                   <Key_stages>ks2</Key_stages>
+                   <Documents>
+                      <document>
+                          <name><![CDATA[Job Description - Head of Department Final April 21 TCC (6) (3) (1).pdf]]></name>
+                          <extension>pdf</extension>
+                          <size>225131</size>
+                          <url><![CDATA[https://unitedlearning.current-vacancies.com/Jobs/DownloadDocument/934437?cid=1567&pubid=2648837]]></url>
+                      </document>
+                   </Documents>
+               </Vacancy>
+           </a10:content>
+       </item>
+   </channel>
+</rss>

--- a/spec/jobs/import_from_vacancy_sources_job_spec.rb
+++ b/spec/jobs/import_from_vacancy_sources_job_spec.rb
@@ -142,6 +142,15 @@ RSpec.describe ImportFromVacancySourcesJob do
           "working_patterns_details" => nil,
         )
       end
+
+      it "does not save the vacancy if it has errors attached to the vacancy" do
+        vacancy.errors.add(:base, "blah")
+        described_class.perform_now
+
+        expect(vacancy).to_not be_valid
+        expect(Vacancy.count).to eq(0)
+        expect(FailedImportedVacancy.count).to eq(1)
+      end
     end
 
     context "when there is already a duplicate vacancy in the FailedImportedVacancy table" do

--- a/spec/vacancy_sources/fusion_vacancy_source_spec.rb
+++ b/spec/vacancy_sources/fusion_vacancy_source_spec.rb
@@ -6,12 +6,13 @@ RSpec.describe FusionVacancySource do
   let(:schools) { [school1] }
 
   let(:response) { double("FusionHttpResponse", success?: true, body: file_fixture("vacancy_sources/fusion.json").read) }
-
-  before do
-    expect(HTTParty).to receive(:get).with("http://example.com/feed.json").and_return(response)
-  end
+  let(:argument_error_response) { double("FusionHttpResponse", success?: true, body: file_fixture("vacancy_sources/fusion_argument_error.json").read) }
 
   describe "enumeration" do
+    before do
+      expect(HTTParty).to receive(:get).with("http://example.com/feed.json").and_return(response)
+    end
+
     let(:vacancy) { subject.first }
     let(:expected_vacancy) do
       {
@@ -82,6 +83,20 @@ RSpec.describe FusionVacancySource do
 
       it "assigns the vacancy job location to the central trust" do
         expect(vacancy.readable_job_location).to eq(school_group.name)
+      end
+    end
+  end
+
+  describe "enumeration error" do
+    before do
+      expect(HTTParty).to receive(:get).with("http://example.com/feed.json").and_return(argument_error_response)
+    end
+
+    let(:vacancy) { subject.first }
+
+    context "when incorrect values are provided" do
+      it "adds an error to the vacancy object" do
+        expect(vacancy.errors.count).to eq(1)
       end
     end
   end

--- a/spec/vacancy_sources/united_learning_vacancy_source_spec.rb
+++ b/spec/vacancy_sources/united_learning_vacancy_source_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe UnitedLearningVacancySource do
   let!(:school) { create(:school, name: "Test School", urn: "136636", phase: :secondary) }
   let!(:school_group) { create(:school_group, name: "United Learning", uid: "5143", schools: [school]) }
 
-  before do
-    # FIXME: Manually stubbing HTTParty because of weird interactions between VCR and Webmock
-    expect(HTTParty).to receive(:get).with("http://example.com/feed.xml").and_return(file_fixture("vacancy_sources/united_learning.xml").read)
-  end
-
   describe "enumeration" do
+    before do
+      # FIXME: Manually stubbing HTTParty because of weird interactions between VCR and Webmock
+      expect(HTTParty).to receive(:get).with("http://example.com/feed.xml").and_return(file_fixture("vacancy_sources/united_learning.xml").read)
+    end
+
     let(:vacancy) { subject.first }
 
     it "has the correct number of vacancies" do
@@ -62,6 +62,21 @@ RSpec.describe UnitedLearningVacancySource do
         expect(vacancy).to be_changed
 
         expect(vacancy.job_title).to eq("Head of Geography")
+      end
+    end
+  end
+
+  describe "enumeration error" do
+    before do
+      # FIXME: Manually stubbing HTTParty because of weird interactions between VCR and Webmock
+      expect(HTTParty).to receive(:get).with("http://example.com/feed.xml").and_return(file_fixture("vacancy_sources/united_learning_argument_error.xml").read)
+    end
+
+    let(:vacancy) { subject.first }
+
+    context "when incorrect values are provided" do
+      it "adds an error to the vacancy object" do
+        expect(vacancy.errors.count).to eq(1)
       end
     end
   end


### PR DESCRIPTION
## Trello ticket URL

https://trello.com/c/3oKaRkaC/67-consolidate-imported-vacancies-errors

## Changes in this PR:

This PR consolidates where we raise any errors when we are importing vacancies. We now catch the `ArgumentError` and add it to the vacancies `errors` attribute. Then when we hit the `app/jobs/import_from_vacancy_sources_job.rb` we check to see if the vacancy contains any errors using `.valid?`. If it does not we save it as usual, if it has any errors we then report the validation error to sentry and save it to the FailedImportedVacancy table. This way we catch the errors in one place instead of raising two types of errors as mentioned in the ticket.
