### PR TITLE
Align designs of organisation profile edit forms

### DIFF
--- a/app/views/publishers/organisations/description/edit.html.slim
+++ b/app/views/publishers/organisations/description/edit.html.slim
@@ -1,13 +1,15 @@
 - content_for :page_title_prefix, @organisation.name.titlecase
 
+- content_for :breadcrumbs do
+  = govuk_back_link text: t("buttons.back"), href: publishers_organisation_path(@organisation)
+
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    h1.govuk-heading-l = t("publishers.organisations.edit_organisation_title", organisation_type: organisation_type_basic(@organisation))
-
     = form_for @description_form, url: publishers_organisation_description_path(@organisation), method: :patch do |f|
       = f.govuk_error_summary
 
-      h2.govuk-heading-m = @organisation.name
+      span.govuk-caption-l = t("publishers.organisations.profile_caption", organisation_type: @organisation.school? ? "School" : "Organisation")
+      label.govuk-heading-l = t(".title", organisation_type: @organisation.school? ? "School" : "Organisation")
 
       = f.govuk_text_area :description,
         label: { text: t("helpers.label.publishers_organisation_form.description", organisation_type: organisation_type_basic(@organisation)), size: "s" },

--- a/app/views/publishers/organisations/email/edit.html.slim
+++ b/app/views/publishers/organisations/email/edit.html.slim
@@ -1,13 +1,15 @@
 - content_for :page_title_prefix, @organisation.name.titlecase
 
+- content_for :breadcrumbs do
+  = govuk_back_link text: t("buttons.back"), href: publishers_organisation_path(@organisation)
+
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    h1.govuk-heading-l = t("publishers.organisations.edit_organisation_title", organisation_type: organisation_type_basic(@organisation))
-
     = form_for @email_form, url: publishers_organisation_email_path(@organisation), method: :patch do |f|
       = f.govuk_error_summary
 
-      h2.govuk-heading-m = @organisation.name
+      span.govuk-caption-l = t("publishers.organisations.profile_caption", organisation_type: @organisation.school? ? "School" : "Organisation")
+      label.govuk-heading-l = t(".title")
 
       = f.govuk_email_field :email,
         label: { text: t("helpers.label.publishers_organisation_form.email", organisation_type: organisation_type_basic(@organisation), gias_url: @organisation[:url]), size: "s" }

--- a/app/views/publishers/organisations/safeguarding_information/edit.html.slim
+++ b/app/views/publishers/organisations/safeguarding_information/edit.html.slim
@@ -1,14 +1,18 @@
 - content_for :page_title_prefix, @organisation.name.titlecase
 
+- content_for :breadcrumbs do
+  = govuk_back_link text: t("buttons.back"), href: publishers_organisation_path(@organisation)
+
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     = form_for @safeguarding_information_form, url: publishers_organisation_safeguarding_information_path(@organisation), method: :patch do |f|
       = f.govuk_error_summary
 
-      span.govuk-caption-l = t("publishers.organisations.profile_caption")
+      span.govuk-caption-l = t("publishers.organisations.profile_caption", organisation_type: @organisation.school? ? "School" : "Organisation")
+      label.govuk-heading-l = t(".title")
 
       = f.govuk_text_area :safeguarding_information,
-        label: { text: t("helpers.label.publishers_organisation_form.safeguarding_information"), size: "l" },
+        label: nil,
         rows: 10,
         max_words: 100
 

--- a/app/views/publishers/organisations/url_override/edit.html.slim
+++ b/app/views/publishers/organisations/url_override/edit.html.slim
@@ -1,13 +1,15 @@
 - content_for :page_title_prefix, @organisation.name.titlecase
 
+- content_for :breadcrumbs do
+  = govuk_back_link text: t("buttons.back"), href: publishers_organisation_path(@organisation)
+
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    h1.govuk-heading-l = t("publishers.organisations.edit_organisation_title", organisation_type: organisation_type_basic(@organisation))
-
     = form_for @url_override_form, url: publishers_organisation_website_path(@organisation), method: :patch do |f|
       = f.govuk_error_summary
 
-      h2.govuk-heading-m = @organisation.name
+      span.govuk-caption-l = t("publishers.organisations.profile_caption", organisation_type: @organisation.school? ? "School" : "Organisation")
+      label.govuk-heading-l = t(".title", organisation_type: @organisation.school? ? "School" : "Organisation")
 
       = f.govuk_url_field :url_override,
         label: { text: t("helpers.label.publishers_organisation_form.url_override", organisation_type: organisation_type_basic(@organisation), gias_url: @organisation[:url]), size: "s" }

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -88,7 +88,9 @@ en:
           one: 1 unread notification
           other: "%{count} unread notifications"
     organisations:
-      edit_organisation_title: Change %{organisation_type} details
+      description:
+        edit:
+          title: '%{organisation_type} description'
       logo:
         confirm_destroy:
           caption: Delete logo
@@ -110,7 +112,7 @@ en:
           title: Organisation logo
       email:
         edit:
-          title: Change %{organisation_type} details
+          title: Email address
       photo:
         confirm_destroy:
           caption: Delete photo
@@ -136,7 +138,10 @@ en:
           heading:
             caption_with_link_html: Part of %{link}
             link_text: '%{organisation_name}'
-      profile_caption: Organisation profile
+      profile_caption: '%{organisation_type} profile'
+      safeguarding_information:
+        edit:
+          title: Commitment to safeguarding
       schools:
         preview:
           exit_preview_link_text: Exit preview
@@ -152,7 +157,7 @@ en:
       upload_a_file: Upload a file
       url_override:
         edit:
-          title: Change %{organisation_type} details
+          title: Website address
       organisation:
         address:
           label: Address


### PR DESCRIPTION
## Changes in this PR:

- Noticed that a fair few of the edit forms did not match the designs in the prototype and didn't feature back links. These pages had now been made consistent with the prototype and backlinks have been added.