### PR TITLE
Add condition for displaying logo on job listings

### DIFF
--- a/app/views/vacancies/listing/_banner.html.slim
+++ b/app/views/vacancies/listing/_banner.html.slim
@@ -2,7 +2,8 @@
   = govuk_tag text: t("jobs.expired_listing.tag").upcase, colour: "orange"
 
 .banner-header
-  = image_tag(vacancy.organisation.logo.attachment, size: "70", class: "govuk-!-margin-right-3")
+  - if vacancy.organisation.logo.attached?
+    = image_tag(vacancy.organisation.logo, size: "70", class: "govuk-!-margin-right-3")
   .banner__header-title
     h1.govuk-heading-xl class="govuk-!-margin-bottom-2"
       = vacancy.job_title


### PR DESCRIPTION
## Changes in this PR:

- Without the condition added in `_banner.html.slim`, we were, when the vacancy's organisation did not have a logo, passing nil to `image_tag`. This was causing a smoke test to fail, preventing deployment to production: https://github.com/DFE-Digital/teaching-vacancies/actions/runs/3901068617/jobs/6663262967 

