### PR TITLE
Set logo img max width and height to 100%

### DIFF
--- a/app/assets/stylesheets/base/_utilities.scss
+++ b/app/assets/stylesheets/base/_utilities.scss
@@ -147,10 +147,12 @@
 }
 
 .logo-image {
+  display: flex;
   height: 70px;
+  justify-content: center;
   margin-right: govuk-spacing(3);
   width: 70px;
-  
+
   .logo-spacer {
     display: inline-block;
     height: 100%;
@@ -158,6 +160,7 @@
   }
 
   img {
-    width: 100%;
+    max-height: 100%;
+    max-width: 100%;
   }
 }


### PR DESCRIPTION
## Changes in this PR:

- Some logos were appearing to spill out of their container and were not aligned centrally. Hopefully this should fix the problems seen with some of the logos hiring staff have uploaded.