### PR TITLE
Remove call to `@organisation.trust` in templates

### DIFF
--- a/app/views/organisations/schools/index.html.slim
+++ b/app/views/organisations/schools/index.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, t(".page_title", school_group_name: @organisation.trust.name)
+- content_for :page_title_prefix, t(".page_title", school_group_name: @organisation.name)
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/publishers/organisations/schools/preview.html.slim
+++ b/app/views/publishers/organisations/schools/preview.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, t(".page_title", school_group_name: @organisation.trust.name)
+- content_for :page_title_prefix, t(".page_title", school_group_name: @organisation.name)
 
 - content_for :breadcrumbs do
   = govuk_back_link text: t(".exit_preview_link_text"), href: publishers_organisation_path(@organisation)


### PR DESCRIPTION
## Changes in this PR:

When we call the `trust` method, the `@organisation` object is a SchoolGroup, so we are in fact calling `Kernel#trust` rather than a method we have defined (like on the School model). `Kernel#trust` is removed in Ruby 3.2.0 and so will throw an error when we upgrade.