### PR TITLE
Update international advice tracked link types

### DIFF
--- a/app/views/layouts/_footer.html.slim
+++ b/app/views/layouts/_footer.html.slim
@@ -24,7 +24,7 @@
           li.govuk-footer__list-item
             = link_to t("footer.search_teaching_vacancies"), root_url, class: "govuk-footer__link"
           li.govuk-footer__list-item
-            = link_to t("footer.international_teacher_advice_link_text"), "https://getintoteaching.education.gov.uk/non-uk-teachers", class: "govuk-footer__link"
+            = tracked_link_to(t("footer.international_teacher_advice_link_text"), "https://getintoteaching.education.gov.uk/non-uk-teachers", class: "govuk-footer__link", link_type: :international_teacher_advice_link_footer)
           li.govuk-footer__list-item
             - if jobseeker_signed_in?
               = link_to t("nav.create_a_job_alert"), jobseekers_account_path, class: "govuk-footer__link"

--- a/app/views/vacancies/index.html.slim
+++ b/app/views/vacancies/index.html.slim
@@ -35,7 +35,7 @@ h1 class="govuk-heading-l" role="heading" aria-level="1"
                 marker: { type: "vacancy", tracking: { link: "vacancy_visited_from_map", marker: "vacancy_popup_opened_from_map" } })
 
       = govuk_inset_text(text: t("vacancies.international_teacher_advice.text_html",
-                                 link: tracked_link_to(t("vacancies.international_teacher_advice.link"), "https://getintoteaching.education.gov.uk/non-uk-teachers", link_type: :international_teacher_advice_link)))
+                                 link: tracked_link_to(t("vacancies.international_teacher_advice.link"), "https://getintoteaching.education.gov.uk/non-uk-teachers", link_type: :international_teacher_advice_link_search_results)))
       #search-results
         - if @vacancies.any?
           = render "vacancies/search/sort", form: @form, vacancies_search: @vacancies_search, vacancies: @vacancies

--- a/app/views/vacancies/listing/_job_details.html.slim
+++ b/app/views/vacancies/listing/_job_details.html.slim
@@ -79,7 +79,7 @@ section#job-details class="govuk-!-margin-bottom-5"
   - if vacancy.expires_at.future?
     h3.govuk-heading-m = t("jobseekers.job_applications.applying_for_the_job_heading")
 
-    .govuk-body = t("vacancies.international_teacher_advice.text_html", link: tracked_link_to(t("vacancies.international_teacher_advice.link"), "https://getintoteaching.education.gov.uk/non-uk-teachers", link_type: :international_teacher_advice_link))
+    .govuk-body = t("vacancies.international_teacher_advice.text_html", link: tracked_link_to(t("vacancies.international_teacher_advice.link"), "https://getintoteaching.education.gov.uk/non-uk-teachers", link_type: :international_teacher_advice_link_job_listing))
 
     - if vacancy.enable_job_applications?
       p.govuk-body = t("jobseekers.job_applications.applying_for_the_job_paragraph")


### PR DESCRIPTION
## Changes in this PR:

Performance analyst wants to be able to tell where clicks on links to advice for international teachers are coming from so each tracked link now has a unique link_type providing the origin of the link click.