### PR TITLE
Abstract multistep form - first draft

### DIFF
--- a/lib/form_object.rb
+++ b/lib/form_object.rb
@@ -2,6 +2,7 @@ module FormObject
   def self.included(mod)
     mod.include ActiveModel::Model
     mod.include ActiveModel::Attributes
+    mod.include ActiveModel::Validations::Callbacks
 
     mod.include Arrays
   end
@@ -11,13 +12,17 @@ module FormObject
 
     class_methods do
       def attribute(name, *args, array: false, **options)
-        options[:default] ||= [] if array
+        options[:default] ||= -> { [] } if array
         super(name, *args, **options)
         return unless array
 
-        define_method(:"#{name}=") do |value|
-          super value.reject(&:blank?)
+        mod = Module.new do
+          define_method(:"#{name}=") do |value|
+            super value.reject(&:blank?)
+          end
         end
+
+        include mod
       end
     end
   end

--- a/lib/form_object.rb
+++ b/lib/form_object.rb
@@ -13,6 +13,7 @@ module FormObject
       def attribute(name, *args, array: false, **options)
         options[:default] ||= [] if array
         super(name, *args, **options)
+        return unless array
 
         define_method(:"#{name}=") do |value|
           super value.reject(&:blank?)

--- a/lib/form_object.rb
+++ b/lib/form_object.rb
@@ -1,0 +1,23 @@
+module FormObject
+  def self.included(mod)
+    mod.include ActiveModel::Model
+    mod.include ActiveModel::Attributes
+
+    mod.include Arrays
+  end
+
+  module Arrays
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def attribute(name, *args, array: false, **options)
+        options[:default] ||= [] if array
+        super(name, *args, **options)
+
+        define_method(:"#{name}=") do |value|
+          super value.reject(&:blank?)
+        end
+      end
+    end
+  end
+end

--- a/lib/multistep/controller.rb
+++ b/lib/multistep/controller.rb
@@ -21,7 +21,7 @@ module Multistep
     def update
       @step = form.steps[current_step]
       # TODO: Move strong params inside the form implementation
-      @step.assign_attributes(params[self.class.multistep_form_key].to_unsafe_hash || {})
+      @step.assign_attributes(params[self.class.multistep_form_key]&.to_unsafe_hash || {})
 
       if @step.valid?
         form.complete_step! current_step

--- a/lib/multistep/controller.rb
+++ b/lib/multistep/controller.rb
@@ -49,6 +49,8 @@ module Multistep
     end
 
     def escape_path
+      return @escape_path if defined?(@escape_path)
+
       instance_exec(&self.class.escape_path)
     end
 

--- a/lib/multistep/controller.rb
+++ b/lib/multistep/controller.rb
@@ -1,0 +1,96 @@
+module Multistep
+  module Controller
+    extend ActiveSupport::Concern
+
+    included do
+      helper_method :back_url, :escape_path
+    end
+
+    def start
+      @form = self.class.multistep_form.new
+      store_form!
+
+      redirect_to action: :edit, step: all_steps.first
+    end
+
+    def edit
+      @step = form.steps[current_step]
+      render params[:step]
+    end
+
+    def update
+      @step = form.steps[current_step]
+      # TODO: Move strong params inside the form implementation
+      @step.assign_attributes(params[self.class.multistep_form_key].to_unsafe_hash)
+
+      if @step.valid?
+        form.complete_step! current_step
+        if (next_step = form.next_step(current_step: current_step))
+          store_form!
+          redirect_to action: :edit, step: next_step
+        else
+          complete
+        end
+      else
+        render current_step, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def current_step
+      params[:step].to_sym
+    end
+
+    def escape_path
+      instance_exec(&self.class.escape_path)
+    end
+
+    def form
+      @form ||= self.class.multistep_form.new(attributes_from_store)
+    end
+
+    # TODO: Convert store handling into a proper object!
+    def store_form!
+      session[:form] = form.attributes
+    end
+
+    def attributes_from_store
+      session[:form] || {}
+    end
+
+    def all_steps
+      @all_steps ||= self.class.multistep_form.steps.keys
+    end
+
+    def back_url
+      previous_step = form.previous_step(current_step: current_step)
+      return escape_path if previous_step.nil?
+
+      url_for action: :edit, step: previous_step
+    end
+
+    def complete
+      redirect_to escape_path
+    end
+
+    class_methods do
+      attr_reader :multistep_form_key, :escape_path
+
+      def multistep_form(form = nil, key: nil)
+        if form.nil?
+          @multistep_form
+        else
+          @multistep_form = form
+          @multistep_form_key = key
+        end
+      end
+
+      def escape_path(&block)
+        return @escape_path unless block
+
+        @escape_path ||= block
+      end
+    end
+  end
+end

--- a/lib/multistep/form.rb
+++ b/lib/multistep/form.rb
@@ -1,0 +1,98 @@
+require "form_object"
+
+module Multistep
+  module Form
+    extend ActiveSupport::Concern
+
+    include FormObject
+
+    included do
+      attribute :completed_steps, default: []
+    end
+
+    def steps
+      @steps ||= self.class.steps.transform_values do |step_class|
+        step_class.new.tap { |form| form.instance_variable_set(:@multistep, self) }
+      end
+    end
+
+    def next_step(current_step: completed_steps.last&.to_sym)
+      return steps.keys.first if current_step.nil?
+      raise "Step not completed: #{current_step}" unless completed_steps.include?(current_step.to_s)
+
+      steps.keys[steps.keys.index(current_step.to_sym) + 1]
+    end
+
+    def previous_step(current_step:)
+      current_index = completed_steps.index(current_step.to_s)
+      if current_index.nil?
+        return completed_steps.last&.to_s if next_step == current_step
+
+        raise "Step not completed: #{current_step}"
+      end
+
+      steps.keys[current_index - 1] if current_index.positive?
+    end
+
+    def complete_step!(step)
+      if completed_steps.include?(step.to_s)
+        self.completed_steps = completed_steps[0..completed_steps.index(step.to_s)]
+      else
+        completed_steps << step.to_s
+      end
+    end
+
+    def attributes
+      super.merge(self.class.delegated_attributes.to_h { |name| [name.to_s, public_send(name)] })
+    end
+
+    module ClassMethods
+      def steps
+        @steps ||= {}
+      end
+
+      def delegated_attributes
+        @delegated_attributes ||= []
+      end
+
+      def delegate_attributes(*attributes, step:)
+        delegated_attributes.concat attributes.map(&:to_sym)
+
+        delegators = Module.new do
+          attributes.each do |attribute|
+            define_method attribute do
+              steps[step].public_send(attribute)
+            end
+
+            define_method :"#{attribute}=" do |value|
+              steps[step].public_send(:"#{attribute}=", value)
+            end
+          end
+        end
+
+        include delegators
+      end
+
+      def step(step_name, &block)
+        raise "Step #{name} already defined" if steps[step_name.to_sym].present?
+
+        step_class = steps[step_name.to_sym] = Class.new.include(Step)
+        const_set(step_name.to_s.classify, step_class)
+        step_class.class_eval(&block)
+
+        delegate_attributes(*step_class.attribute_names, step: step_name)
+        step_name.to_sym
+      end
+    end
+  end
+
+  module Step
+    extend ActiveSupport::Concern
+
+    included do
+      include FormObject
+    end
+
+    attr_reader :multistep
+  end
+end

--- a/lib/multistep/form.rb
+++ b/lib/multistep/form.rb
@@ -21,7 +21,7 @@ module Multistep
       return steps.keys.first if current_step.nil?
 
       current_step = current_step.to_sym
-      raise "Step not completed: #{current_step}" unless completed_steps.keys.include?(current_step)
+      raise "Step not completed: #{current_step}" unless completed_steps.key?(current_step)
 
       completed_steps.to_a[0..completed_steps.keys.index(current_step)].each do |step, status|
         return step if status == :invalidated
@@ -44,8 +44,8 @@ module Multistep
     def complete_step!(step)
       step = step.to_sym
       completed_steps[step] = :completed
-      completed_steps.keys[completed_steps.keys.index(step)+1..-1].each do |step|
-        completed_steps[step] = :invalidated if steps[step].invalidate?
+      completed_steps.keys[completed_steps.keys.index(step) + 1..].each do |completed_step|
+        completed_steps[completed_step] = :invalidated if steps[completed_step].invalidate?
       end
       step
     end
@@ -61,7 +61,7 @@ module Multistep
     end
 
     def completed_steps=(values)
-      super values.to_h { |k,v| [k.to_sym, v.to_sym] }
+      super values.to_h { |k, v| [k.to_sym, v.to_sym] }
     end
 
     module ClassMethods


### PR DESCRIPTION
# Example

## Form object

```ruby
require 'multistep/form'

class MyMultistepForm
  include Multistep::Form

  step :name do
    attribute :first_name
    attribute :last_name

    validate :first_name, :last_name, presence: true
  end

  step :contact do
    attribute :email
    attribute :lists, array: true

    validates :email, presence: true
  end
end
```

## Controller

```ruby
class MyMultistepController
  include Multstep::Controller

  multistep_form MyMultistepForm, key: :form_key
  escape_path { '/where/to/go/when/cancelled' }

  def complete
    # Called after the last step of the form has been submitted
    model = Model.create!(form.attributes)
    flash[:success] = ' Yeah!'
    redirect_to model
  end
```

## Routes

We need 3 routes for each multistep form. At the moment they need to be added manually, I'd probably add some helper for that later. Example

```ruby
      get 'my-multi', to: 'my_multistep_controller#start'
      get 'my-multi/:step', to: 'my_multistep_controller#edit'
      post 'my-multi/:step', to: 'my_multistep_controller#update'
```

## Preserving state

There are two methods in the controller responsible for data storage. Default implementation stores the state in the session, but they can be overridden to store state somewhere else.

`store_form!` method is called after each successful step submission and needs to save the state of the form.

```ruby
def stored_record
  @store_record ||= SomeRecord.find_or_create_by!(user: current_user)
end

def store_form!
  stored_record.update!(form.attributes)
end
```

`attributes_from_store` method return persisted attributes from the store, which will be used to rebuild the form

```ruby
def attributes_from_store
    stored_record.attributes.slice(form.attributes.keys)
end
```