### PR TITLE
Format the break in work history date

### DIFF
--- a/app/views/jobseekers/job_applications/_unexplained_employment_break.html.slim
+++ b/app/views/jobseekers/job_applications/_unexplained_employment_break.html.slim
@@ -1,3 +1,3 @@
 = govuk_inset_text classes: "govuk-!-margin-top-3 govuk-!-margin-bottom-3 govuk-inset-text--blue", id: "employment-break-#{index}" do
   h2.govuk-heading-s class="govuk-!-margin-bottom-1" = t("jobseekers.job_applications.build.employment_history.break")
-  p.govuk-hint class="govuk-!-margin-top-1 govuk-!-margin-bottom-1" #{employment.ended_on} to #{employments[index + 1]&.started_on || "present"}
+  p.govuk-hint class="govuk-!-margin-top-1 govuk-!-margin-bottom-1" #{employment.ended_on.to_formatted_s(:month_year)} to #{employments[index + 1]&.started_on&.to_formatted_s(:month_year) || "present"}

--- a/app/views/jobseekers/job_applications/review/_employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/review/_employment_history.html.slim
@@ -25,7 +25,7 @@
 
           - summary_list.row do |row|
             - row.key text: t("helpers.legend.jobseekers_job_application_details_employment_form.started_on")
-            - row.value text: employment.started_on
+            - row.value text: employment.started_on.to_formatted_s(:month_year)
 
           - summary_list.row do |row|
             - row.key text: t("helpers.legend.jobseekers_job_application_details_employment_form.current_role")
@@ -34,7 +34,7 @@
           - if employment.current_role == "no"
             - summary_list.row do |row|
               - row.key text: t("helpers.legend.jobseekers_job_application_details_employment_form.ended_on")
-              - row.value text: employment.ended_on
+              - row.value text: employment.ended_on.to_formatted_s(:month_year)
 
       - elsif employment.break?
         = render "jobseekers/job_applications/explained_employment_break", employment: employment, index: index

--- a/spec/system/jobseekers_can_review_a_job_application_spec.rb
+++ b/spec/system/jobseekers_can_review_a_job_application_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe "Jobseekers can review a job application" do
         expect(page).to have_content(employment.organisation)
         expect(page).to have_content(employment.subjects)
         expect(page).to have_content(employment.main_duties)
-        expect(page).to have_content(employment.started_on)
+        expect(page).to have_content(employment.started_on.to_formatted_s(:month_year))
         expect(page).to have_content(employment.current_role.humanize)
-        expect(page).to have_content(employment.ended_on)
+        expect(page).to have_content(employment.ended_on.to_formatted_s(:month_year))
       end
     end
 


### PR DESCRIPTION
## Jira ticket URL

https://trello.com/c/OXNVYUPy/85-issues-inputting-dates-to-work-history

## Changes in this PR:

Format the Format the break in work history date

## Screenshots of UI changes:

### Before
![Screenshot 2023-02-01 at 14 18 25](https://user-images.githubusercontent.com/40758489/216067884-96e391e6-04f9-46db-974f-9ba46317d10a.png)


### After
![Screenshot 2023-02-01 at 14 16 58](https://user-images.githubusercontent.com/40758489/216067668-06f9a23d-65ff-4299-89fd-a969217edaf9.png)

