### PR TITLE
Update bespoke events to be asyncrhonous

### DIFF
--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -13,6 +13,7 @@ class Api::EventsController < Api::ApplicationController
 
     data = event_params[:data].to_h.slice(*EVENT_ALLOWLIST[type])
     frontend_event.trigger(type, data)
+    dfe_analytics_event.trigger(type, data)
 
     head :no_content
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -86,11 +86,16 @@ class ApplicationController < ActionController::Base
     !verify_recaptcha(model: model, action: controller_name, minimum_score: SUSPICIOUS_RECAPTCHA_THRESHOLD) && recaptcha_reply
   end
 
+  def dfe_analytics_event
+    DfeAnalyticsEvent.new(request, response, session, current_jobseeker, current_publisher, current_support_user)
+  end
+
   def request_event
     RequestEvent.new(request, response, session, current_jobseeker, current_publisher, current_support_user)
   end
 
   def trigger_page_visited_event
+    dfe_analytics_event.trigger(:page_visited)
     request_event.trigger(:page_visited)
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -95,7 +95,6 @@ class ApplicationController < ActionController::Base
   end
 
   def trigger_page_visited_event
-    dfe_analytics_event.trigger(:page_visited)
     request_event.trigger(:page_visited)
   end
 

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -25,6 +25,15 @@ class AuthenticationController < ApplicationController
   end
 
   def trigger_jobseeker_sign_in_event(success_or_failure, errors = nil)
+    dfe_analytics_event.trigger(
+      :jobseeker_sign_in_attempt,
+      {
+        email_identifier: StringAnonymiser.new(params.dig(:jobseeker, :email)),
+        success: success_or_failure == :success,
+        errors: errors,
+      },
+    )
+
     request_event.trigger(
       :jobseeker_sign_in_attempt,
       email_identifier: StringAnonymiser.new(params.dig(:jobseeker, :email)),
@@ -34,6 +43,11 @@ class AuthenticationController < ApplicationController
   end
 
   def trigger_successful_publisher_sign_in_event(sign_in_type, publisher_oid = nil)
+    dfe_analytics_event.trigger(
+      :successful_publisher_sign_in_attempt,
+      { user_anonymised_publisher_id: StringAnonymiser.new(publisher_oid), sign_in_type: sign_in_type },
+    )
+
     request_event.trigger(
       :successful_publisher_sign_in_attempt,
       user_anonymised_publisher_id: StringAnonymiser.new(publisher_oid),
@@ -50,6 +64,11 @@ class AuthenticationController < ApplicationController
   end
 
   def trigger_failed_dsi_sign_in_event(sign_in_type, oid = nil)
+    dfe_analytics_event.trigger(
+      :failed_dsi_sign_in_attempt,
+      { user_anonymised_id: StringAnonymiser.new(oid), sign_in_type: sign_in_type },
+    )
+
     request_event.trigger(
       :failed_dsi_sign_in_attempt,
       user_anonymised_id: StringAnonymiser.new(oid),

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -26,19 +26,17 @@ class DocumentsController < ApplicationController
   end
 
   def send_custom_event
-    event = DfE::Analytics::Event.new
-      .with_type(:vacancy_document_downloaded)
-      .with_request_details(request)
-      .with_response_details(response)
-      .with_user(current_user)
-      .with_data(
-        vacancy_id: StringAnonymiser.new(vacancy.id),
-        document_type: application_form? ? :application_form : :supporting_document,
-        document_id: StringAnonymiser.new(file.id),
-        filename: file.filename,
+    fail_safe do
+      dfe_analytics_event.trigger(
+        :vacancy_document_downloaded,
+        {
+          vacancy_id: StringAnonymiser.new(vacancy.id),
+          document_type: application_form? ? :application_form : :supporting_document,
+          document_id: StringAnonymiser.new(file.id),
+          filename: file.filename,
+        },
       )
-
-    DfE::Analytics::SendEvents.do([event])
+    end
   end
 
   def send_event

--- a/app/controllers/jobseekers/job_applications_controller.rb
+++ b/app/controllers/jobseekers/job_applications_controller.rb
@@ -8,7 +8,9 @@ class Jobseekers::JobApplicationsController < Jobseekers::JobApplications::BaseC
   helper_method :employments, :job_application, :qualification_form_param_key, :review_form, :vacancy, :withdraw_form
 
   def new
+    dfe_analytics_event.trigger(:vacancy_apply_clicked, { vacancy_id: StringAnonymiser.new(vacancy.id) })
     request_event.trigger(:vacancy_apply_clicked, vacancy_id: StringAnonymiser.new(vacancy.id))
+
     redirect_to new_quick_apply_jobseekers_job_job_application_path(vacancy.id) if
       current_jobseeker.job_applications.not_draft.any?
   end

--- a/app/controllers/publishers/vacancies/documents_controller.rb
+++ b/app/controllers/publishers/vacancies/documents_controller.rb
@@ -23,7 +23,7 @@ class Publishers::Vacancies::DocumentsController < Publishers::Vacancies::BaseCo
     document = vacancy.supporting_documents.find(params[:id])
     document.purge_later
     send_event(:supporting_document_deleted, document.filename, document.byte_size, document.content_type)
-    send_dfe_analytics_event(:supporting_document_deleted, document.original_filename, document.size, document.content_type)
+    send_dfe_analytics_event(:supporting_document_deleted, document.filename, document.byte_size, document.content_type)
 
     redirect_to after_document_delete_path, flash: { success: t("jobs.file_delete_success_message", filename: document.filename) }
   end
@@ -75,7 +75,7 @@ class Publishers::Vacancies::DocumentsController < Publishers::Vacancies::BaseCo
   end
 
   def send_dfe_analytics_event(event_type, name, size, content_type)
-    fail_safe
+    fail_safe do
       event_details = {
         vacancy_id: StringAnonymiser.new(vacancy.id),
         document_type: "supporting_document",

--- a/app/controllers/publishers/vacancies/documents_controller.rb
+++ b/app/controllers/publishers/vacancies/documents_controller.rb
@@ -8,6 +8,7 @@ class Publishers::Vacancies::DocumentsController < Publishers::Vacancies::BaseCo
       documents_form.documents.each do |document|
         vacancy.supporting_documents.attach(document)
         send_event(:supporting_document_created, document.original_filename, document.size, document.content_type)
+        send_dfe_analytics_event(:supporting_document_created, document.original_filename, document.size, document.content_type)
       end
 
       vacancy.update(documents_form.params_to_save)
@@ -22,6 +23,7 @@ class Publishers::Vacancies::DocumentsController < Publishers::Vacancies::BaseCo
     document = vacancy.supporting_documents.find(params[:id])
     document.purge_later
     send_event(:supporting_document_deleted, document.filename, document.byte_size, document.content_type)
+    send_dfe_analytics_event(:supporting_document_deleted, document.original_filename, document.size, document.content_type)
 
     redirect_to after_document_delete_path, flash: { success: t("jobs.file_delete_success_message", filename: document.filename) }
   end
@@ -69,6 +71,20 @@ class Publishers::Vacancies::DocumentsController < Publishers::Vacancies::BaseCo
       new_organisation_job_document_path(vacancy.id, back_to_review: params[:back_to_review], back_to_show: params[:back_to_show])
     else
       organisation_job_documents_path(vacancy.id, back_to_review: params[:back_to_review], back_to_show: params[:back_to_show])
+    end
+  end
+
+  def send_dfe_analytics_event(event_type, name, size, content_type)
+    fail_safe
+      event_details = {
+        vacancy_id: StringAnonymiser.new(vacancy.id),
+        document_type: "supporting_document",
+        name: name,
+        size: size,
+        content_type: content_type,
+      }
+
+      dfe_analytics_event.trigger(event_type, event_details)
     end
   end
 

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -82,10 +82,27 @@ class SubscriptionsController < ApplicationController
     subscription.update(recaptcha_score: recaptcha_reply&.dig("score"))
     Jobseekers::SubscriptionMailer.confirmation(subscription.id).deliver_later
     trigger_subscription_event(:job_alert_subscription_created, subscription)
+    trigger_dfe_analytics_event(:job_alert_subscription_created, subscription)
   end
 
   def trigger_create_job_alert_clicked_event
     request_event.trigger(:vacancy_create_job_alert_clicked, vacancy_id: StringAnonymiser.new(vacancy_id))
+  end
+
+  def trigger_dfe_analytics_event(type, subscription)
+    fail_safe do
+      dfe_analytics_event.trigger(
+        type,
+        {
+          autopopulated: session.delete(:subscription_autopopulated),
+          email_identifier: StringAnonymiser.new(subscription.email),
+          frequency: subscription.frequency,
+          recaptcha_score: subscription.recaptcha_score,
+          search_criteria: subscription.search_criteria,
+          subscription_identifier: StringAnonymiser.new(subscription.id),
+        },
+      )
+    end
   end
 
   def trigger_subscription_event(type, subscription)

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -56,6 +56,8 @@ class VacanciesController < ApplicationController
       vacancy_ids = @vacancies_search.vacancies.map(&:id).map { |s| StringAnonymiser.new(s).to_s }
       polygon_id = StringAnonymiser.new(@vacancies_search.location_search.polygon.id).to_s if @vacancies_search.location_search.polygon
 
+      trigger_dfe_analytics_event(vacancy_ids, polygon_id)
+
       request_event.trigger(
         :search_performed,
         search_criteria: form.to_hash,
@@ -68,5 +70,21 @@ class VacanciesController < ApplicationController
         filters_set_from_keywords: form.filters_from_keyword.present?,
       )
     end
+  end
+
+  def trigger_dfe_analytics_event(vacancy_ids, polygon_id)
+    dfe_analytics_event.trigger(
+      :search_peformed,
+      {
+        search_criteria: form.to_hash,
+        sort_by: form.sort.by,
+        page: params[:page] || 1,
+        total_count: @vacancies_search.total_count,
+        vacancies_on_page: vacancy_ids,
+        location_polygon_used: polygon_id,
+        landing_page: params[:landing_page_slug],
+        filters_set_from_keywords: form.filters_from_keyword.present?,
+      },
+    )
   end
 end

--- a/app/jobs/send_dfe_analytics_event_job.rb
+++ b/app/jobs/send_dfe_analytics_event_job.rb
@@ -1,0 +1,11 @@
+class SendDfeAnalyticsEventJob < SendEventToDataWarehouseJob
+  def perform(data)
+    dfe_analytic_event = DfE::Analytics::Event.new
+       .with_type(data.fetch(:type))
+       .with_request_details(data.fetch(:request))
+       .with_response_details(data.fetch(:response))
+       .with_data(data.fetch(:data))
+
+    DfE::Analytics::SendEvents.do([dfe_analytic_event])
+  end
+end

--- a/app/jobs/send_event_to_data_warehouse_job.rb
+++ b/app/jobs/send_event_to_data_warehouse_job.rb
@@ -4,10 +4,23 @@ class SendEventToDataWarehouseJob < ApplicationJob
   self.logger = ActiveSupport::TaggedLogging.new(Logger.new(IO::NULL))
 
   def perform(table_name, data)
+    if ready_for_new_platform?(data.fetch(:type))
+      dfe_analytic_event = DfE::Analytics::Event.new
+        .with_type(data.fetch(:type))
+        .with_data(data: data.fetch(:data))
+
+      DfE::Analytics::SendEvents.do([dfe_analytic_event])
+    end
+
     bq = Google::Cloud::Bigquery.new
     dataset = bq.dataset(Rails.configuration.big_query_dataset, skip_lookup: true)
     table = dataset.table(table_name, skip_lookup: true)
 
     table.insert(data)
+  end
+
+  def ready_for_new_platform?(type)
+    allowed_types = DfE::Analytics::Event::EVENT_TYPES + DfE::Analytics.custom_events
+    allowed_types.include?(type.to_s)
   end
 end

--- a/app/jobs/send_event_to_data_warehouse_job.rb
+++ b/app/jobs/send_event_to_data_warehouse_job.rb
@@ -4,23 +4,10 @@ class SendEventToDataWarehouseJob < ApplicationJob
   self.logger = ActiveSupport::TaggedLogging.new(Logger.new(IO::NULL))
 
   def perform(table_name, data)
-    if ready_for_new_platform?(data.fetch(:type))
-      dfe_analytic_event = DfE::Analytics::Event.new
-        .with_type(data.fetch(:type))
-        .with_data(data: data.fetch(:data))
-
-      DfE::Analytics::SendEvents.do([dfe_analytic_event])
-    end
-
     bq = Google::Cloud::Bigquery.new
     dataset = bq.dataset(Rails.configuration.big_query_dataset, skip_lookup: true)
     table = dataset.table(table_name, skip_lookup: true)
 
     table.insert(data)
-  end
-
-  def ready_for_new_platform?(type)
-    allowed_types = DfE::Analytics::Event::EVENT_TYPES + DfE::Analytics.custom_events
-    allowed_types.include?(type.to_s)
   end
 end

--- a/app/services/dfe_analytics_event.rb
+++ b/app/services/dfe_analytics_event.rb
@@ -1,0 +1,27 @@
+class DfeAnalyticsEvent < RequestEvent
+  def trigger(event_type, event_data = {})
+    fail_safe do
+      event_data = base_data.merge(
+        type: event_type,
+        occurred_at: occurred_at(event_data),
+        data: data.push(*event_data.map { |key, value| { key: key.to_s, value: formatted_value(value) } }),
+      )
+
+      SendDfeAnalyticsEventJob.perform_now(event_data)
+    end
+  end
+
+  private
+
+  def request_data
+    { request: request }
+  end
+
+  def response_data
+    { response: response }
+  end
+
+  def user_data
+    { user: super }
+  end
+end

--- a/config/analytics_custom_events.yml
+++ b/config/analytics_custom_events.yml
@@ -1,17 +1,26 @@
 shared:
+  - failed_dsi_sign_in_attempt
   - page_visited
   - publisher_sign_in_fallback
   - publisher_applications_received
   - publisher_prompt_for_feedback
+  - job_alert_subscription_created
   - jobseeker_email_changed
   - jobseeker_unlock_instructions
   - jobseeker_subscription_alert
   - jobseeker_application_shortlisted
   - jobseeker_application_unsuccessful
   - jobseeker_reset_password_instructions
+  - jobseeker_sign_in_attempt
   - jobseeker_subscription_confirmation
   - jobseeker_application_submitted
   - jobseeker_subscription_update
   - jobseeker_confirmation_instructions
+  - search_peformed
   - support_user_sign_in_fallback
+  - supporting_document_created
+  - supporting_document_deleted
+  - successful_publisher_sign_in_attempt
+  - tracked_link_clicked
+  - vacancy_apply_clicked
   - vacancy_document_downloaded

--- a/config/analytics_custom_events.yml
+++ b/config/analytics_custom_events.yml
@@ -1,2 +1,17 @@
 shared:
+  - page_visited
+  - publisher_sign_in_fallback
+  - publisher_applications_received
+  - publisher_prompt_for_feedback
+  - jobseeker_email_changed
+  - jobseeker_unlock_instructions
+  - jobseeker_subscription_alert
+  - jobseeker_application_shortlisted
+  - jobseeker_application_unsuccessful
+  - jobseeker_reset_password_instructions
+  - jobseeker_subscription_confirmation
+  - jobseeker_application_submitted
+  - jobseeker_subscription_update
+  - jobseeker_confirmation_instructions
+  - support_user_sign_in_fallback
   - vacancy_document_downloaded

--- a/spec/configuration/sidekiq_scheduled_jobs_spec.rb
+++ b/spec/configuration/sidekiq_scheduled_jobs_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe "Sidekiq configuration" do
       SeedDatabaseJob
       SendEntityImportedEventsToDataWarehouseJob
       SendEventToDataWarehouseJob
+      SendDfeAnalyticsEventJob
       SendJobListingEndedEarlyNotificationJob
       UpdateGoogleIndexQueueJob
       Noticed::DeliveryMethods::Base

--- a/spec/jobs/send_dfe_analytics_event_job_spec.rb
+++ b/spec/jobs/send_dfe_analytics_event_job_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe SendDfeAnalyticsEventJob do
+  let(:event_details) do
+    {
+      type: "Page Visited",
+      request: {},
+      response: {},
+      data: {},
+    }
+  end
+
+  let(:event) { double("Event") }
+
+  before do
+    allow(DfE::Analytics::Event).to receive(:new).and_return(event)
+    allow(event).to receive(:with_type).with("Page Visited").and_return(event)
+    allow(event).to receive(:with_request_details).with({}).and_return(event)
+    allow(event).to receive(:with_response_details).with({}).and_return(event)
+    allow(event).to receive(:with_data).with({}).and_return(event)
+  end
+
+  describe "#perform" do
+    it "inserts the data into the BigQuery table" do
+      expect(DfE::Analytics::SendEvents).to receive(:do).with([event])
+
+      subject.perform(event_details)
+    end
+  end
+end

--- a/spec/jobs/send_event_to_data_warehouse_job_spec.rb
+++ b/spec/jobs/send_event_to_data_warehouse_job_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe SendEventToDataWarehouseJob do
   let(:dataset) { double("Dataset") }
   let(:table) { double("Table") }
 
+  let(:type) { DfE::Analytics::Event::EVENT_TYPES.sample }
+
   before do
     allow(Google::Cloud::Bigquery).to receive(:new).and_return(big_query)
   end
@@ -13,9 +15,9 @@ RSpec.describe SendEventToDataWarehouseJob do
     it "inserts the data into the BigQuery table" do
       expect(big_query).to receive(:dataset).with("test_dataset", skip_lookup: true).and_return(dataset)
       expect(dataset).to receive(:table).with("a_fancy_table", skip_lookup: true).and_return(table)
-      expect(table).to receive(:insert).with(hash_including(foo: "bar"))
+      expect(table).to receive(:insert).with(hash_including(type: type, data: { foo: "bar" }))
 
-      subject.perform("a_fancy_table", { foo: "bar" })
+      subject.perform("a_fancy_table", { type: type, data: { foo: "bar" } })
     end
   end
 end


### PR DESCRIPTION
This PR duplicates most of the events sent to BigQuery. 
Old events sent to the old BigQuery events table will be removed after we proved the new ones are working.

