### PR TITLE
Add exception to paths ignored by build_and_deploy workflow

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -10,6 +10,7 @@ on:
     - 'documentation/**'
     - 'terraform/common/**'
     - '**.md'
+    - '!views/content/**/*.md'
 
   pull_request:
     branches:


### PR DESCRIPTION
After merging a pull request, if the only changes included are found at the paths included under paths-ignore, the changes are not deployed. Included in the path to ignore are all markdown files. This has meant that changes to long-form content
made by our content designers are not deployed (as these are markdown files). I have included another path to paths-ignore. Now, all markdown files except those found at views/content/**/*.md (ie. the long-form content) are ignored. This
should mean that any merges that only include changes to long-form content should now trigger a deployment.