### PR TITLE
Use paths instead of paths-ignore in workflow

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -5,12 +5,12 @@ on:
     branches:
     - main
     - dev     # Push to branch other than main deploys directly to environment with the same name. ie 'dev' branch deploys to 'dev' environment
-    paths-ignore:
-    - 'bigquery/**'
-    - 'documentation/**'
-    - 'terraform/common/**'
-    - '**.md'
-    - '!views/content/**/*.md'
+    paths:
+      - '!bigquery/**'
+      - '!documentation/**'
+      - '!terraform/common/**'
+      - '!**.md'
+      - 'views/content/**/*.md'
 
   pull_request:
     branches:


### PR DESCRIPTION
A previous attempt (commit 7253545dc1db67d09c7b52e456459ccc3a8539e9) to fix a problem with changes to long-form content being deployed was unsuccesful. After viewing some of the documentation, it seems that paths must be used along with negative patterns (prefixed with !) if we want to ignore changes to files in certain locations but add exceptions.
