### PR TITLE
De-indent paths in build_and_deploy.yml

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -6,11 +6,11 @@ on:
     - main
     - dev     # Push to branch other than main deploys directly to environment with the same name. ie 'dev' branch deploys to 'dev' environment
     paths:
-      - '!bigquery/**'
-      - '!documentation/**'
-      - '!terraform/common/**'
-      - '!**.md'
-      - 'views/content/**/*.md'
+    - '!bigquery/**'
+    - '!documentation/**'
+    - '!terraform/common/**'
+    - '!**.md'
+    - 'views/content/**/*.md'
 
   pull_request:
     branches:


### PR DESCRIPTION
Previous attempts to fix this issue have been unsuccessful (see https://github.com/DFE-Digital/teaching-vacancies/pull/5767 and https://github.com/DFE-Digital/teaching-vacancies/pull/5765\). The previous attempt indented the path patterns passed to paths as this is how it is done in the documentation. Previously we did not indent these values. I have now de-indented them in the hope that this will fix the issue and allow changes in branches only including changes to long-form content to be deployed after merging.
