### PR TITLE
Revert to using paths-ignore on push

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -5,12 +5,11 @@ on:
     branches:
     - main
     - dev     # Push to branch other than main deploys directly to environment with the same name. ie 'dev' branch deploys to 'dev' environment
-    paths:
-    - '!bigquery/**'
-    - '!documentation/**'
-    - '!terraform/common/**'
-    - '!**.md'
-    - 'views/content/**/*.md'
+    paths-ignore:
+    - 'bigquery/**'
+    - 'documentation/**'
+    - 'terraform/common/**'
+    - '**.md'
 
   pull_request:
     branches:


### PR DESCRIPTION
We noticed a problem that was preventing pushes to main that only include changes to markdown files from being deployed. I've made numerous attempts to try to fix this using the documentation available but they don't appear to be working. I am reverting this for now pending further investigation.