### PR TITLE
[TRELLO-71] Create jobseeker profiles personal details section

### DIFF
--- a/app/controllers/jobseekers/profiles/personal_details_controller.rb
+++ b/app/controllers/jobseekers/profiles/personal_details_controller.rb
@@ -1,0 +1,27 @@
+require "multistep/controller"
+
+class Jobseekers::Profiles::PersonalDetailsController < Jobseekers::ProfilesController
+  include Multistep::Controller
+
+  multistep_form Jobseekers::Profile::PersonalDetailsForm, key: :personal_details_form
+
+  escape_path { jobseekers_profile_path }
+
+  def complete
+    render "review"
+  end
+
+  private
+
+  def store_form!
+    personal_details_record.update!(form.attributes.compact)
+  end
+
+  def personal_details_record
+    @personal_details_record ||= PersonalDetails.find_or_create_by(jobseeker_profile_id: current_jobseeker.jobseeker_profile.id)
+  end
+
+  def attributes_from_store
+    personal_details_record.attributes.slice(*self.class.multistep_form.attribute_names)
+  end
+end

--- a/app/controllers/jobseekers/profiles_controller.rb
+++ b/app/controllers/jobseekers/profiles_controller.rb
@@ -4,10 +4,10 @@ class Jobseekers::ProfilesController < Jobseekers::BaseController
   SECTIONS = [
     {
       title: "Personal details",
-      display_summary: -> { false },
-      key: "",
+      display_summary: -> { current_jobseeker.jobseeker_profile.personal_details&.completed_steps.present? },
+      key: "personal_details",
       link_text: "Add personal details",
-      page_path: -> { false },
+      page_path: -> { personal_details_jobseekers_profile_path },
     },
     {
       title: "Job preferences",
@@ -41,8 +41,10 @@ class Jobseekers::ProfilesController < Jobseekers::BaseController
       title: "About you",
       display_summary: -> { @profile.about_you.present? },
       key: "about_you",
+      condition: -> { current_jobseeker.jobseeker_profile.about_you.present? },
       link_text: "Add details about you",
       page_path: -> { edit_jobseekers_profile_about_you_path },
+      partial: "jobseekers/profiles/about_you/summary",
     },
     {
       title: "Hide profile from schools or trusts",

--- a/app/form_models/jobseekers/profile/personal_details_form.rb
+++ b/app/form_models/jobseekers/profile/personal_details_form.rb
@@ -1,0 +1,24 @@
+require "multistep/form"
+
+class Jobseekers::Profile::PersonalDetailsForm
+  include Multistep::Form
+
+  def self.from_record(record)
+    new record.attributes.slice(*attribute_names)
+  end
+
+  step :name do
+    attribute :first_name
+    attribute :last_name
+
+    validates :first_name, :last_name, presence: true
+  end
+
+  step :phone_number do
+    attribute :phone_number_provided
+    attribute :phone_number
+
+    validates :phone_number_provided, presence: true
+    validates :phone_number, presence: true, format: { with: /\A\+?(?:\d\s?){10,13}\z/ }, if: -> { phone_number_provided == "true" }
+  end
+end

--- a/app/models/jobseeker_profile.rb
+++ b/app/models/jobseeker_profile.rb
@@ -1,5 +1,6 @@
 class JobseekerProfile < ApplicationRecord
   belongs_to :jobseeker
+  has_one :personal_details
 
   enum qualified_teacher_status: { yes: 0, no: 1, on_track: 2 }
 end

--- a/app/models/personal_details.rb
+++ b/app/models/personal_details.rb
@@ -1,0 +1,9 @@
+class PersonalDetails < ApplicationRecord
+  belongs_to :jobseeker_profile
+
+  before_save :reset_phone_number
+
+  def reset_phone_number
+    self.phone_number = nil unless phone_number_provided
+  end
+end

--- a/app/views/jobseekers/profiles/personal_details/_summary.html.slim
+++ b/app/views/jobseekers/profiles/personal_details/_summary.html.slim
@@ -1,0 +1,48 @@
+ruby:
+  form = Jobseekers::Profile::PersonalDetailsForm.from_record(current_jobseeker.jobseeker_profile.personal_details)
+
+  attributes = {
+                 first_name: nil,
+                 last_name: nil,
+                 phone_number_provided: { map_values: ->(value) { t("helpers.label.personal_details_form.phone_number_provided_options.#{value}") } },
+                 phone_number: nil,
+               }
+
+  summary = govuk_summary_list do |summary_list|
+    attributes.each do |attribute, options|
+      step_name = form.class.delegated_attributes[attribute.to_s]
+      condition = ->(f) { f.completed?(step_name) }
+      next unless condition.call(form)
+
+      value = form.public_send(attribute)
+      next if value.nil?
+
+      if options && options[:map_values]
+        value = options[:map_values].call(value)
+      end
+
+      summary_list.row do |row|
+        row.key text: t(".#{attribute}")
+        row.value text: value
+        row.action(text: t("buttons.change"), href: edit_personal_details_jobseekers_profile_path(step: step_name))
+      end
+    end
+
+    summary_list.row do |row|
+      row.key text: t(".email")
+      row.value text: (current_jobseeker.email +
+                       govuk_inset_text(text: t("helpers.label.personal_details_form.change_email_html",
+                                              link: govuk_link_to(t("helpers.label.personal_details_form.change_email_link_text"),
+                                                    jobseekers_account_path)),
+                                        classes: "govuk-!-margin-top-3")).html_safe
+    end
+  end
+
+- if form.completed?
+  = summary
+- else
+  .govuk-inset-text.govuk-inset-text--incomplete
+    = summary
+    p.govuk-body-m.govuk-inset-text--header
+      strong = t("jobseekers.profiles.personal_details.incomplete_message")
+    = govuk_link_to t("buttons.complete_personal_details"), edit_personal_details_jobseekers_profile_path(step: form.next_step), class: "govuk-button"

--- a/app/views/jobseekers/profiles/personal_details/name.html.slim
+++ b/app/views/jobseekers/profiles/personal_details/name.html.slim
@@ -1,0 +1,19 @@
+- content_for :page_title_prefix, t(".page_title")
+
+- content_for :breadcrumbs do
+  = govuk_back_link text: t("buttons.back"), href: back_url
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    = form_for @step, url: { action: :update }, method: :post, as: :personal_details_form do |f|
+      = f.govuk_error_summary
+
+      = f.govuk_fieldset legend: { text: t(".heading"), tag: "h1", size: "l" }, caption: { text: t(".caption"), size: "l" } do
+        = f.govuk_text_field :first_name, label: { size: "m" }
+
+        = f.govuk_text_field :last_name, label: { size: "m" }
+
+        = f.govuk_submit t("buttons.save_and_continue"), classes: "govuk-!-margin-bottom-5"
+
+    .govuk-button-group
+      = govuk_link_to t("buttons.cancel"), jobseekers_profile_path

--- a/app/views/jobseekers/profiles/personal_details/phone_number.html.slim
+++ b/app/views/jobseekers/profiles/personal_details/phone_number.html.slim
@@ -1,0 +1,19 @@
+- content_for :page_title_prefix, t(".page_title")
+
+- content_for :breadcrumbs do
+  = govuk_back_link text: t("buttons.back"), href: back_url
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    = form_for @step, url: { action: :update }, method: :post, as: :personal_details_form do |f|
+      = f.govuk_error_summary
+
+      = f.govuk_radio_buttons_fieldset :phone_number_provided, legend: { text: t(".heading"), tag: "h1", size: "l" }, caption: { text: t(".caption"), size: "l" } do
+        = f.govuk_radio_button :phone_number_provided, "true", link_errors: true do
+          = f.govuk_text_field :phone_number, label: { class: "govuk-label govuk-label--s" }
+        = f.govuk_radio_button :phone_number_provided, "false"
+
+      = f.govuk_submit t("buttons.save_and_continue"), classes: "govuk-!-margin-bottom-5"
+
+    .govuk-button-group
+      = govuk_link_to t("buttons.cancel"), jobseekers_profile_path

--- a/app/views/jobseekers/profiles/personal_details/review.html.slim
+++ b/app/views/jobseekers/profiles/personal_details/review.html.slim
@@ -1,0 +1,9 @@
+- content_for :page_title_prefix, t(".page_title")
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    h1.govuk-heading-l = t(".heading")
+
+    = render "summary"
+
+    = govuk_button_link_to t("buttons.return_to_profile"), jobseekers_profile_path, classes: "govuk-!-margin-bottom-5"

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -358,3 +358,13 @@ shared:
     - updated_at
     - external_reference
     - vacancy
+  personal_details:
+    - id
+    - jobseeker_profile_id
+    - first_name
+    - last_name
+    - phone_number_provided
+    - phone_number
+    - completed_steps
+    - created_at
+    - updated_at

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -151,3 +151,4 @@
   - gias_data_hash
   - searchable_content
   - slug
+  

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -96,6 +96,20 @@ en:
     listed_elsewhere:
       inclusion: Select an option for how the job was listed
 
+  # Profiles
+  name_errors: &name_errors
+    first_name:
+      blank: Enter your first name
+    last_name:
+      blank: Enter your last name
+
+  phone_number_errors: &phone_number_errors
+    phone_number:
+      blank: Enter your phone number
+      invalid: Enter a phone number in the correct format
+    phone_number_provided:
+      inclusion: Select yes if you want to provide a phone number
+
   # Publishers journey
   job_role_errors: &job_role_errors
     job_role:
@@ -315,6 +329,15 @@ en:
         jobseekers/unsubscribe_feedback_form:
           attributes:
             <<: *unsubscribe_feedback_errors
+
+        # Profiles
+        jobseekers/profile/personal_details_form/name:
+          attributes:
+            <<: *name_errors
+
+        jobseekers/profile/personal_details_form/phone_number:
+          attributes:
+            <<: *phone_number_errors
 
         # Publishers journey
         publishers/job_listing/job_role_form:

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -22,6 +22,7 @@ en:
     change: Change
     choose_file: Choose a file
     close_account: Close account
+    complete_personal_details: Complete personal details
     complete_section: Complete section
     confirm_deletion: Delete job listing
     confirm_destroy: Yes I am sure - delete this entry
@@ -61,6 +62,7 @@ en:
     reminder_continue: Continue to create a job
     request_dsi_account: Request a DfE Sign-in account
     resend_email: Resend request
+    return_to_profile: Return to profile
     return_to_profile: Return to profile
     save: Save
     save_and_continue: Save and continue
@@ -168,6 +170,12 @@ en:
         email: >-
           We'll only use this to tell you about opportunities to take part in user research that helps us improve
           Department for Education services.
+
+      personal_details_form:
+        first_name: Or given names
+        last_name: Or family name
+        phone_number: Enter a phone number you are happy to be contacted on, like 01632 960 001, 07700 900 982 or +44 0808 157 0192.
+
       jobseekers_subscription_form:
         email: Enter your email address. We'll only use it to send you job alerts.
       jobseekers_unsubscribe_feedback_form:
@@ -473,6 +481,19 @@ en:
           "yes": "Yes"
           "no": "No"
           on_track: "I’m on track to receive QTS"
+
+      personal_details_form:
+        email: Email
+        change_email_html: Change your email address from within your %{link}
+        change_email_link_text: account
+        first_name: First name
+        last_name: Last name
+        phone_number: Phone number
+        phone_number_provided: Do you want to provide a phone number?
+        phone_number_provided_options:
+          false: "No"
+          true: "Yes"
+
       jobseekers_sign_in_form:
         email: Email address
         password: Password

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -498,6 +498,25 @@ en:
       success_html: >-
         You have saved this job. <a href="%{link}" class="govuk-link">View all your saved jobs</a> on your account.
     profiles:
+      personal_details:
+        incomplete_message: You must complete your personal details before you turn on your profile.
+        name:
+          caption: Personal details
+          heading: Name
+          page_title: Name
+        phone_number:
+          caption: Personal details
+          heading: Do you want to provide a phone number?
+          page_title: Do you want to provide a phone number?
+        review:
+          heading: Personal details
+          page_title: Personal details
+        summary:
+          email: Email
+          first_name: First name
+          last_name: Last name
+          phone_number: Phone number
+          phone_number_provided: Do you want to provide a phone number?
       show:
         page_title: Your profile
         page_description: Your profile allows schools to find and invite you to apply for their jobs.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,6 +81,9 @@ Rails.application.routes.draw do
     resource :profile, only: %i[show] do
       resource :about_you, only: %i[edit update show], controller: "profiles/about_you"
       resource :qualified_teacher_status, only: %i[edit update show], controller: "profiles/qualified_teacher_status"
+      get "personal-details", to: "profiles/personal_details#start"
+      get "personal-details/:step", to: "profiles/personal_details#edit", as: :edit_personal_details
+      post "personal-details/:step", to: "profiles/personal_details#update"
     end
 
     resources :saved_jobs, only: %i[index]

--- a/db/migrate/20230206153235_create_personal_details.rb
+++ b/db/migrate/20230206153235_create_personal_details.rb
@@ -1,0 +1,14 @@
+class CreatePersonalDetails < ActiveRecord::Migration[7.0]
+  def change
+    create_table :personal_details, id: :uuid do |t|
+      t.references :jobseeker_profile, null: false, foreign_key: true, type: :uuid
+      t.string :first_name
+      t.string :last_name
+      t.boolean :phone_number_provided
+      t.string :phone_number
+      t.json :completed_steps, default: {}, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -384,6 +384,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_07_091347) do
     t.index ["urn"], name: "index_organisations_on_urn", unique: true
   end
 
+  create_table "personal_details", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "jobseeker_profile_id", null: false
+    t.string "first_name"
+    t.string "last_name"
+    t.boolean "phone_number_provided"
+    t.string "phone_number"
+    t.json "completed_steps", default: {}, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["jobseeker_profile_id"], name: "index_personal_details_on_jobseeker_profile_id"
+  end
+
   create_table "publisher_preferences", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "publisher_id"
     t.uuid "organisation_id"
@@ -595,6 +607,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_07_091347) do
   add_foreign_key "markers", "vacancies"
   add_foreign_key "notes", "job_applications"
   add_foreign_key "notes", "publishers"
+  add_foreign_key "personal_details", "jobseeker_profiles"
   add_foreign_key "publisher_preferences", "publishers"
   add_foreign_key "qualification_results", "qualifications"
   add_foreign_key "qualifications", "job_applications"

--- a/spec/factories/jobseeker_profiles.rb
+++ b/spec/factories/jobseeker_profiles.rb
@@ -1,3 +1,5 @@
 FactoryBot.define do
-  factory :jobseeker_profile
+  factory :jobseeker_profile do
+    jobseeker
+  end
 end

--- a/spec/factories/personal_details.rb
+++ b/spec/factories/personal_details.rb
@@ -1,0 +1,18 @@
+FactoryBot.define do
+  factory :personal_details do
+    first_name { "Frodo" }
+    last_name { "Baggins" }
+    phone_number_provided { true }
+    phone_number { "07777777777" }
+    completed_steps { { "name" => "completed", "phone_number" => "completed" } }
+    jobseeker_profile
+  end
+
+  trait :not_started do
+    first_name { nil }
+    last_name { nil }
+    phone_number_provided { nil }
+    phone_number { nil }
+    completed_steps { {} }
+  end
+end

--- a/spec/system/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers_can_manage_a_profile_spec.rb
@@ -5,12 +5,78 @@ RSpec.describe "Jobseekers can manage their profile" do
 
   before do
     login_as(jobseeker, scope: :jobseeker)
-    visit jobseekers_profile_path
+  end
+
+  describe "changing personal details" do
+    let(:profile) { create(:jobseeker_profile, jobseeker: jobseeker) }
+
+    context "when filling in the profile for the first time" do
+      let(:personal_details) { create(:personal_details, :not_started, jobseeker_profile: profile) }
+      let(:first_name) { "Frodo" }
+      let(:last_name) { "Baggins" }
+      let(:phone_number) { "07777777777" }
+
+      before { visit jobseekers_profile_path }
+
+      it "allows the jobseeker to fill in their personal details" do
+        click_link("Add personal details")
+        fill_in "personal_details_form[first_name]", with: first_name
+        fill_in "personal_details_form[last_name]", with: last_name
+        click_on I18n.t("buttons.save_and_continue")
+
+        expect(page).to have_content("Do you want to provide a phone number?")
+        choose "Yes"
+        fill_in "personal_details_form[phone_number]", with: phone_number
+        click_on I18n.t("buttons.save_and_continue")
+        click_on I18n.t("buttons.return_to_profile")
+
+        expect(page).to have_content(first_name)
+        expect(page).to have_content(last_name)
+        expect(page).to have_content(phone_number)
+      end
+    end
+
+    context "when editing a profile that has already been completed" do
+      let!(:personal_details) do
+        create(:personal_details,
+               jobseeker_profile: profile,
+               first_name: "Frodo",
+               last_name: "Baggins",
+               phone_number_provided: true,
+               phone_number: old_phone_number,
+               completed_steps: { "name" => "completed", "phone_number" => "completed" })
+      end
+
+      let(:new_first_name) { "Samwise" }
+      let(:new_last_name) { "Gamgee" }
+      let(:old_phone_number) { "07777777777" }
+
+      before { visit jobseekers_profile_path }
+
+      it "allows the jobseeker to edit their profile" do
+        within ".govuk-summary-list__row:nth-child(1)" do
+          click_on "Change"
+        end
+
+        fill_in "personal_details_form[first_name]", with: new_first_name
+        fill_in "personal_details_form[last_name]", with: new_last_name
+        click_on I18n.t("buttons.save_and_continue")
+
+        choose "No"
+        click_on I18n.t("buttons.save_and_continue")
+
+        expect(page).to have_content(new_first_name)
+        expect(page).to have_content(new_last_name)
+        expect(page).to have_content("No")
+        expect(page).not_to have_content(old_phone_number)
+      end
+    end
   end
 
   describe "changing the jobseekers's about you" do
     let(:profile) { create(:jobseeker_profile, jobseeker_id: jobseeker.id) }
     let(:jobseeker_about_you) { "I am an amazing teacher" }
+    before { visit jobseekers_profile_path }
 
     it "allows the jobseeker to edit their about you text" do
       click_link("Add details about you")
@@ -27,6 +93,7 @@ RSpec.describe "Jobseekers can manage their profile" do
 
   describe "changing the jobseekers's QTS status" do
     let(:profile) { create(:jobseeker_profile, jobseeker_id: jobseeker.id) }
+    before { visit jobseekers_profile_path }
 
     it "allows the jobseeker to edit their QTS status to yes with year acheived" do
       click_link("Add qualified teacher status")


### PR DESCRIPTION
## Trello ticket URL

https://trello.com/c/R4oFJOxc/71-create-the-personal-details-section-of-the-candidate-profile

## Changes in this PR:

- Is there anything specific you want feedback on?

## Screenshots of UI changes:
<img width="848" alt="image" src="https://user-images.githubusercontent.com/24639777/218454676-bdafcda8-dbb8-4f22-8f63-5a55bfff08a4.png">

<img width="837" alt="image" src="https://user-images.githubusercontent.com/24639777/218454797-b4f2ecaf-9a57-4047-b292-580b7be52bfe.png">

<img width="827" alt="image" src="https://user-images.githubusercontent.com/24639777/218488357-39e5da00-8d9c-4d23-902b-25f390e2ae72.png">

<img width="840" alt="image" src="https://user-images.githubusercontent.com/24639777/218488289-9bb82ad2-fcc3-4865-a065-4301ee2fa011.png">

<img width="827" alt="image" src="https://user-images.githubusercontent.com/24639777/218488409-4a842fdf-a839-40d0-89b3-c8c534cfd8fa.png">

