### PR TITLE
missing translation for form legend on QTS edit page

### DIFF
--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -816,7 +816,7 @@ en:
         <<: *jobseekers_qualifications_shared_legends
       jobseekers_qualifications_other_form:
         <<: *jobseekers_qualifications_shared_legends
-      jobseekers_qualified_teacher_status_form:
+      jobseekers_profile_qualified_teacher_status_form:
         qualified_teacher_status: Do you have qualified teacher status (QTS)?
 
       jobseekers_profile_employment_form:


### PR DESCRIPTION
fixes this

<img width="645" alt="Screenshot 2023-02-24 at 11 23 19" src="https://user-images.githubusercontent.com/1792451/221167356-ebb83415-f845-47b0-b438-5faf9f4037d3.png">

![Screenshot 2023-02-24 at 11 50 19](https://user-images.githubusercontent.com/1792451/221172304-e16ef193-5f84-40b1-8ac3-fe9248c63255.png)

