### PR TITLE
silence known caught api request failiures from FE

### DIFF
--- a/app/assets/javascript/components/cookiesBanner/enhance.js
+++ b/app/assets/javascript/components/cookiesBanner/enhance.js
@@ -26,7 +26,9 @@ const CookiesBannerController = class extends Controller {
         }
       })
       .catch((error) => {
-        logger.warn(error.message);
+        if (error.response.status !== 200 || error.response.status !== 204) {
+          logger.warn(error.message);
+        }
       });
   }
 };

--- a/app/assets/javascript/components/map/marker/service.js
+++ b/app/assets/javascript/components/map/marker/service.js
@@ -15,7 +15,9 @@ const Service = class {
     })
       .then((response) => response.data)
       .catch((error) => {
-        logger.warn(error.message);
+        if (error.response.status !== 200 || error.response.status !== 204) {
+          logger.warn(error.message);
+        }
       });
 
     return request;

--- a/app/assets/javascript/js_components/autocomplete/api.js
+++ b/app/assets/javascript/js_components/autocomplete/api.js
@@ -7,7 +7,9 @@ export const getLocationSuggestions = ({ query, populateResults }) => axios.get(
   .then((data) => data.suggestions)
   .then(populateResults)
   .catch((error) => {
-    logger.warn(error.message);
+    if (error.response.status !== 200 || error.response.status !== 204) {
+      logger.warn(error.message);
+    }
   });
 
 const api = {

--- a/app/assets/javascript/js_components/locationFinder/api.js
+++ b/app/assets/javascript/js_components/locationFinder/api.js
@@ -6,7 +6,9 @@ export const getPostcodeFromCoordinates = (latitude, longitude) => axios.get('ht
   params: { latitude, longitude },
 }).then((response) => response.data.result[0].postcode)
   .catch((error) => {
-    logger.warn(error.message);
+    if (error.response.status !== 200 || error.response.status !== 204) {
+      logger.warn(error.message);
+    }
   });
 
 const api = {

--- a/app/assets/javascript/js_components/locationFinder/locationFinder.js
+++ b/app/assets/javascript/js_components/locationFinder/locationFinder.js
@@ -36,7 +36,7 @@ const LocationFinder = class extends Controller {
         postcode ? this.onSuccess(postcode) : this.onFailure();
       }).catch((error) => {
         this.onFailure();
-        logger.info(`${LOGGING_MESSAGE}: ${error.message}`);
+        logger.log(`${LOGGING_MESSAGE}: ${error.message}`);
       });
     });
   }

--- a/app/assets/javascript/lib/logging.js
+++ b/app/assets/javascript/lib/logging.js
@@ -19,7 +19,7 @@ const consoleLogger = {
 /* eslint-enable no-console */
 
 const sentryLogger = {
-  log: (msg = '[Sentry captureMessage] log unknown message') => Sentry.captureMessage(msg),
+  log: noop,
   info: (msg = '[Sentry captureMessage] info unknown message') => Sentry.captureMessage(msg),
   warn: (msg = '[Sentry captureMessage] warn unknown message') => Sentry.captureMessage(msg),
   error: (error) => Sentry.captureException(error),


### PR DESCRIPTION
silences caught errors for 200 or 204 responses and logging otherwise to sentry gives no value. if the response then causes issue in Frontend code it will be logged in sentry as uncaught error