### PR TITLE
[111] Add a profile-nudge interstitial after jobseeker account creation

### DIFF
--- a/app/controllers/jobseekers/accounts_controller.rb
+++ b/app/controllers/jobseekers/accounts_controller.rb
@@ -1,3 +1,5 @@
 class Jobseekers::AccountsController < Jobseekers::BaseController
   def show; end
+
+  def confirmation; end
 end

--- a/app/controllers/jobseekers/confirmations_controller.rb
+++ b/app/controllers/jobseekers/confirmations_controller.rb
@@ -8,7 +8,8 @@ class Jobseekers::ConfirmationsController < Devise::ConfirmationsController
   def after_confirmation_path_for(resource_name, resource)
     sign_in(resource)
     request_event.trigger(:jobseeker_email_confirmed)
-    stored_location_for(resource_name) || jobseeker_root_path
+    flash.delete(:notice)
+    stored_location_for(resource_name) || confirmation_jobseekers_account_path
   end
 
   def after_resending_confirmation_instructions_path_for(_resource)

--- a/app/views/jobseekers/accounts/confirmation.html.slim
+++ b/app/views/jobseekers/accounts/confirmation.html.slim
@@ -1,0 +1,17 @@
+- content_for :page_title_prefix, t(".page_title")
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    = govuk_panel title_text: t(".page_title")
+
+    p.govuk-body
+      = t(".apply_for_jobs", link_text: govuk_link_to(t(".apply_for_jobs_link_text"), jobs_path)).html_safe
+
+    h2.govuk-heading-m = t(".create_profile.heading")
+    p.govuk-body = t(".create_profile.lead_in")
+    ul.govuk-list.govuk-list--bullet
+      li = t(".create_profile.share_your_qualifications")
+      li = t(".create_profile.specify_jobs")
+    p.govuk-body = t(".create_profile.functionality_guidance")
+
+    = govuk_button_link_to t(".create_profile.heading"), jobseekers_profile_path

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -12,6 +12,16 @@ en:
           email: Email address
           password: Account password
           password_placeholder: "**************"
+      confirmation:
+        page_title: Account created
+        apply_for_jobs_link_text: search and apply for teaching jobs
+        apply_for_jobs: You can %{link_text}.
+        create_profile:
+          functionality_guidance: When you turn on your profile, schools can contact you about relevant jobs.
+          heading: Create a profile
+          lead_in: "With a profile, you can:"
+          share_your_qualifications: share your qualifications and experience with schools
+          specify_jobs: specify the types of teaching jobs you’re looking for
     account_feedbacks:
       create:
         success: Thank you for your feedback

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -118,7 +118,11 @@ Rails.application.routes.draw do
     end
 
     resources :subscriptions, only: %i[index]
-    resource :account, only: %i[show]
+    resource :account, only: %i[show] do
+      member do
+        get :confirmation
+      end
+    end
     resource :account_feedback, only: %i[new create]
   end
 

--- a/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
@@ -24,12 +24,15 @@ RSpec.describe "Jobseekers can sign up to an account" do
     end
 
     context "when the confirmation token is valid" do
-      it "confirms email, triggers email confirmed event and redirects to jobseeker saved jobs page" do
+      it "confirms email, triggers email confirmed event and redirects to jobseeker account confirmation interstitial" do
         expect { confirm_email_address }.to have_triggered_event(:jobseeker_email_confirmed).with_base_data(
           user_anonymised_jobseeker_id: StringAnonymiser.new(created_jobseeker.id).to_s,
         )
-        expect(current_path).to eq(jobseekers_saved_jobs_path)
-        expect(page).to have_content(I18n.t("devise.confirmations.confirmed"))
+        expect(current_path).to eq(confirmation_jobseekers_account_path)
+        expect(page).to have_content(I18n.t("jobseekers.accounts.confirmation.page_title"))
+        expect(page).to have_link(I18n.t("jobseekers.accounts.confirmation.apply_for_jobs_link_text"), href: jobs_path)
+        expect(page).to have_link(I18n.t("jobseekers.accounts.confirmation.create_profile.heading"), href: jobseekers_profile_path)
+        expect(page).not_to have_content(I18n.t("devise.confirmations.confirmed"))
       end
     end
 


### PR DESCRIPTION
DO NOT MERGE until we're ready to go live with this feature.

## Screenshots of UI changes:

### Before

<img width="1287" alt="Screenshot 2023-03-01 at 09 32 54" src="https://user-images.githubusercontent.com/109225/222117082-0626f01f-2d8e-478c-95fb-cc7d85ead490.png">

### After

<img width="964" alt="Screenshot 2023-03-01 at 10 32 21" src="https://user-images.githubusercontent.com/109225/222117110-7c0b4d67-555a-4b7e-a218-bf2d0d418929.png">
