### PR TITLE
[112] Pre-fill jobseeker profiles on first visit

### DIFF
--- a/app/controllers/jobseekers/profiles/job_preferences_controller.rb
+++ b/app/controllers/jobseekers/profiles/job_preferences_controller.rb
@@ -1,7 +1,7 @@
 require "multistep/controller"
 
 module Jobseekers::Profiles
-  class JobPreferencesController < ApplicationController
+  class JobPreferencesController < Jobseekers::ProfilesController
     include Multistep::Controller
 
     multistep_form Jobseekers::JobPreferencesForm, key: :job_preferences
@@ -88,7 +88,7 @@ module Jobseekers::Profiles
     end
 
     def job_preference_record
-      @job_preference_record ||= JobPreferences.find_or_create_by(jobseeker_profile: profile)
+      @job_preference_record ||= profile.job_preferences
     end
 
     def force_location_added
@@ -103,10 +103,6 @@ module Jobseekers::Profiles
 
     helper_method def location_form
       @location_form ||= form.build_location_form(location_id)
-    end
-
-    helper_method def profile
-      @profile ||= JobseekerProfile.find_or_create_by!(jobseeker: current_jobseeker)
     end
   end
 end

--- a/app/controllers/jobseekers/profiles/personal_details_controller.rb
+++ b/app/controllers/jobseekers/profiles/personal_details_controller.rb
@@ -18,7 +18,7 @@ class Jobseekers::Profiles::PersonalDetailsController < Jobseekers::ProfilesCont
   end
 
   def personal_details_record
-    @personal_details_record ||= PersonalDetails.find_or_create_by(jobseeker_profile_id: current_jobseeker.jobseeker_profile.id)
+    @personal_details_record ||= profile.personal_details
   end
 
   def attributes_from_store

--- a/app/controllers/jobseekers/profiles/preview_controller.rb
+++ b/app/controllers/jobseekers/profiles/preview_controller.rb
@@ -2,13 +2,7 @@ class Jobseekers::Profiles::PreviewController < Jobseekers::ProfilesController
   include VacanciesHelper
 
   def show
-    @personal_details = PersonalDetails.where(jobseeker_profile_id: jobseeker_profile.id).first
-    @job_preferences = JobPreferences.where(jobseeker_profile_id: jobseeker_profile.id).first
-  end
-
-  private
-
-  def jobseeker_profile
-    JobseekerProfile.find_by!(jobseeker: current_jobseeker)
+    @personal_details = profile.personal_details
+    @job_preferences = profile.job_preferences
   end
 end

--- a/app/controllers/jobseekers/profiles_controller.rb
+++ b/app/controllers/jobseekers/profiles_controller.rb
@@ -3,12 +3,10 @@ class Jobseekers::ProfilesController < Jobseekers::BaseController
 
   helper_method :qualification_form_param_key
 
-  before_action :profile, only: %i[show]
-
   SECTIONS = [
     {
       title: "Personal details",
-      display_summary: -> { current_jobseeker.jobseeker_profile.personal_details&.completed_steps.present? },
+      display_summary: -> { profile.personal_details&.completed_steps.present? },
       key: "personal_details",
       link_text: "Add personal details",
       page_path: -> { personal_details_jobseekers_profile_path },
@@ -22,30 +20,30 @@ class Jobseekers::ProfilesController < Jobseekers::BaseController
     },
     {
       title: "Qualified teacher status (QTS)",
-      display_summary: -> { @profile.qualified_teacher_status.present? },
+      display_summary: -> { profile.qualified_teacher_status.present? },
       key: "qualified_teacher_status",
       link_text: "Add qualified teacher status",
       page_path: -> { edit_jobseekers_profile_qualified_teacher_status_path },
     },
     {
       title: "Qualifications",
-      display_summary: -> { @profile.qualifications.present? },
+      display_summary: -> { profile.qualifications.present? },
       key: "qualifications",
       link_text: "Add qualifications",
       page_path: -> { select_category_jobseekers_profile_qualifications_path },
     },
     {
       title: "Work history",
-      display_summary: -> { @profile.employments.any? },
+      display_summary: -> { profile.employments.any? },
       key: "employments",
       link_text: "Add roles",
       page_path: -> { new_jobseekers_profile_work_history_path },
     },
     {
       title: "About you",
-      display_summary: -> { @profile.about_you.present? },
+      display_summary: -> { profile.about_you.present? },
       key: "about_you",
-      condition: -> { current_jobseeker.jobseeker_profile.about_you.present? },
+      condition: -> { profile.about_you.present? },
       link_text: "Add details about you",
       page_path: -> { edit_jobseekers_profile_about_you_path },
       partial: "jobseekers/profiles/about_you/summary",
@@ -72,9 +70,10 @@ class Jobseekers::ProfilesController < Jobseekers::BaseController
 
   private
 
-  helper_method :profile
-
   def profile
-    @profile ||= JobseekerProfile.prepare(jobseeker: current_jobseeker)
+    @profile ||= JobseekerProfile.prepare(jobseeker: current_jobseeker) do
+      flash.now[:success] = t("jobseekers.profiles.show.imported")
+    end
   end
+  helper_method :profile
 end

--- a/app/controllers/jobseekers/profiles_controller.rb
+++ b/app/controllers/jobseekers/profiles_controller.rb
@@ -75,6 +75,6 @@ class Jobseekers::ProfilesController < Jobseekers::BaseController
   helper_method :profile
 
   def profile
-    @profile ||= JobseekerProfile.find_or_create_by(jobseeker_id: current_jobseeker.id)
+    @profile ||= JobseekerProfile.prepare(jobseeker: current_jobseeker)
   end
 end

--- a/app/models/concerns/profile_section.rb
+++ b/app/models/concerns/profile_section.rb
@@ -9,6 +9,10 @@ module ProfileSection
             attributes_to_copy.each do |attribute|
               record.assign_attributes(attribute => previous_application.public_send(attribute))
             end
+
+            steps_to_complete.each do |step|
+              record.completed_steps[step] = :completed
+            end
           end
 
           yield record if block_given?
@@ -20,6 +24,10 @@ module ProfileSection
 
     def attributes_to_copy
       %w[]
+    end
+
+    def steps_to_complete
+      %i[]
     end
   end
 end

--- a/app/models/concerns/profile_section.rb
+++ b/app/models/concerns/profile_section.rb
@@ -1,0 +1,25 @@
+module ProfileSection
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def prepare(profile:)
+      find_or_initialize_by(jobseeker_profile: profile).tap do |record|
+        if record.new_record?
+          if (previous_application = profile.jobseeker.job_applications.last)
+            attributes_to_copy.each do |attribute|
+              record.assign_attributes(attribute => previous_application.public_send(attribute))
+            end
+          end
+
+          yield record if block_given?
+
+          record.save!
+        end
+      end
+    end
+
+    def attributes_to_copy
+      %w[]
+    end
+  end
+end

--- a/app/models/employment.rb
+++ b/app/models/employment.rb
@@ -4,4 +4,19 @@ class Employment < ApplicationRecord
   has_encrypted :organisation, :job_title, :main_duties
 
   enum employment_type: { job: 0, break: 1 }
+
+  def duplicate
+    self.class.new(
+      current_role:,
+      employment_type:,
+      ended_on:,
+      job_title:,
+      main_duties:,
+      organisation:,
+      reason_for_break:,
+      salary:,
+      started_on:,
+      subjects:,
+    )
+  end
 end

--- a/app/models/job_preferences.rb
+++ b/app/models/job_preferences.rb
@@ -1,3 +1,5 @@
 class JobPreferences < ApplicationRecord
+  include ProfileSection
+
   belongs_to :jobseeker_profile
 end

--- a/app/models/jobseeker_profile.rb
+++ b/app/models/jobseeker_profile.rb
@@ -25,6 +25,8 @@ class JobseekerProfile < ApplicationRecord
           personal_details: PersonalDetails.prepare(profile: record),
         )
 
+        yield record if block_given?
+
         record.save!
       end
     end

--- a/app/models/jobseeker_profile.rb
+++ b/app/models/jobseeker_profile.rb
@@ -4,13 +4,35 @@ class JobseekerProfile < ApplicationRecord
   has_one :personal_details
   has_one :job_preferences
   has_many :employments
+  has_many :qualifications
 
   enum qualified_teacher_status: { yes: 0, no: 1, on_track: 2 }
+
+  def self.prepare(jobseeker:)
+    find_or_initialize_by(jobseeker:).tap do |record|
+      if record.new_record?
+        if (previous_application = jobseeker.job_applications.last)
+          record.assign_attributes(
+            employments: previous_application.employments.map(&:duplicate),
+            qualifications: previous_application.qualifications.map(&:duplicate),
+            qualified_teacher_status_year: previous_application.qualified_teacher_status_year,
+            qualified_teacher_status: previous_application.qualified_teacher_status,
+          )
+        end
+
+        record.assign_attributes(
+          job_preferences: JobPreferences.prepare(profile: record),
+          personal_details: PersonalDetails.prepare(profile: record),
+        )
+
+        record.save!
+      end
+    end
+  end
 
   def deactivate!
     return unless active?
 
     update_column(:active, false)
   end
-  has_many :qualifications
 end

--- a/app/models/personal_details.rb
+++ b/app/models/personal_details.rb
@@ -19,6 +19,13 @@ class PersonalDetails < ApplicationRecord
     ]
   end
 
+  def self.steps_to_complete
+    %i[
+      name
+      phone_number
+    ]
+  end
+
   def reset_phone_number
     self.phone_number = nil unless phone_number_provided
   end

--- a/app/models/personal_details.rb
+++ b/app/models/personal_details.rb
@@ -1,7 +1,23 @@
 class PersonalDetails < ApplicationRecord
+  include ProfileSection
+
   belongs_to :jobseeker_profile
 
   before_save :reset_phone_number
+
+  def self.prepare(...)
+    super do |record|
+      record.phone_number_provided = record.phone_number.present?
+    end
+  end
+
+  def self.attributes_to_copy
+    %w[
+      first_name
+      last_name
+      phone_number
+    ]
+  end
 
   def reset_phone_number
     self.phone_number = nil unless phone_number_provided

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -22,6 +22,7 @@ class Qualification < ApplicationRecord
       grade:,
       institution:,
       name:,
+      qualification_results: qualification_results.map(&:duplicate),
       subject:,
       year:,
     )

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -14,6 +14,19 @@ class Qualification < ApplicationRecord
 
   before_validation :remove_inapplicable_data, :mark_emptied_qualification_results_for_destruction
 
+  def duplicate
+    self.class.new(
+      category:,
+      finished_studying_details:,
+      finished_studying:,
+      grade:,
+      institution:,
+      name:,
+      subject:,
+      year:,
+    )
+  end
+
   def name
     return read_attribute(:name) if read_attribute(:name).present? || other? || other_secondary?
 

--- a/app/models/qualification_result.rb
+++ b/app/models/qualification_result.rb
@@ -4,6 +4,13 @@ class QualificationResult < ApplicationRecord
   validates :subject, presence: true
   validates :grade, presence: true
 
+  def duplicate
+    self.class.new(
+      grade:,
+      subject:,
+    )
+  end
+
   def empty?
     subject.blank? && grade.blank?
   end

--- a/app/views/jobseekers/profiles/about_you/show.html.slim
+++ b/app/views/jobseekers/profiles/about_you/show.html.slim
@@ -7,6 +7,6 @@
   .govuk-grid-column-two-thirds
     h1.govuk-heading-l = t(".page_title")
 
-    == render(partial: "summary", locals: { profile: @profile, title: t(".summary_title") })
+    == render(partial: "summary", locals: { profile:, title: t(".summary_title") })
 
     = govuk_button_link_to t("buttons.return_to_profile"), jobseekers_profile_path

--- a/app/views/jobseekers/profiles/preview/show.html.slim
+++ b/app/views/jobseekers/profiles/preview/show.html.slim
@@ -7,11 +7,11 @@
   .govuk-grid-column-two-thirds
     - unless @personal_details.nil?
       h1.govuk-heading-xl class="govuk-!-margin-bottom-5" = "#{@personal_details.first_name} #{@personal_details.last_name} "
-    - case @profile.qualified_teacher_status
+    - case profile.qualified_teacher_status
       - when "on_track"
         p class="govuk-!-margin-bottom-3" = "On track to receive QTS"
       - when "yes"
-        p class="govuk-!-margin-bottom-3" = "QTS awarded in #{@profile.qualified_teacher_status_year}."
+        p class="govuk-!-margin-bottom-3" = "QTS awarded in #{profile.qualified_teacher_status_year}."
       - when "no"
         p class="govuk-!-margin-bottom-3" = "Does not have QTS"
 
@@ -40,10 +40,10 @@
               - row.key text: t(".location")
               - row.value text: location_formatter(@job_preferences.locations)
 
-    - if @profile.about_you.present?
+    - if profile.about_you.present?
       h2.govuk-heading-m class="govuk-!-padding-bottom-2"
         = t(".about")
-      p = @profile.about_you
+      p = profile.about_you
 
     h2.govuk-heading-m class="govuk-!-padding-bottom-3"
       = t(".contact_details")
@@ -56,15 +56,15 @@
           dt.govuk-summary-list__key == t(".phone_number")
           dd.govuk-summary-list__value = @personal_details.phone_number
 
-    - if @profile.employments.any?
+    - if profile.employments.any?
       h2.govuk-heading-m = t(".work_history")
-      - @profile.employments.order(:started_on).each do |employment|
+      - profile.employments.order(:started_on).each do |employment|
         h3.govuk-heading-s class="govuk-!-padding-bottom-3"
           = employment.organisation
           p class="govuk-!-margin-bottom-0" = employment.job_title
           p.govuk-hint #{employment.started_on.to_formatted_s(:month_year)} to #{employment.ended_on&.to_formatted_s(:month_year) || "present"}
           hr.govuk-section-break.govuk-section-break--s.govuk-section-break--visible
 
-    - if @profile.qualifications.any?
+    - if profile.qualifications.any?
       h2.govuk-heading-m class="govuk-!-padding-bottom-3" = t(".qualifications")
-      = render "jobseekers/qualifications/preview_qualifications", qualifications: @profile.qualifications
+      = render "jobseekers/qualifications/preview_qualifications", qualifications: profile.qualifications

--- a/app/views/jobseekers/profiles/qualifications/new.html.slim
+++ b/app/views/jobseekers/profiles/qualifications/new.html.slim
@@ -5,7 +5,7 @@
     span.govuk-caption-l = t(".caption")
     h1.govuk-heading-xl = t(".heading.#{category}")
 
-    = form_for form, url: jobseekers_profile_qualifications_path(@profile, category: category), method: :post do |f|
+    = form_for form, url: jobseekers_profile_qualifications_path(profile, category: category), method: :post do |f|
       = f.govuk_error_summary link_base_errors_to: :subject
 
       = render "jobseekers/qualifications/fields", f: f

--- a/app/views/jobseekers/profiles/qualified_teacher_status/show.html.slim
+++ b/app/views/jobseekers/profiles/qualified_teacher_status/show.html.slim
@@ -7,6 +7,6 @@
   .govuk-grid-column-two-thirds
     h1.govuk-heading-l = t(".page_title")
 
-    == render(partial: "summary", locals: { profile: @profile, title: t(".summary_title") })
+    == render(partial: "summary", locals: { profile:, title: t(".summary_title") })
 
     = govuk_button_link_to t("buttons.return_to_profile"), jobseekers_profile_path

--- a/app/views/jobseekers/profiles/show.html.slim
+++ b/app/views/jobseekers/profiles/show.html.slim
@@ -10,7 +10,7 @@
         = section[:title]
 
       - if section[:display_summary] && instance_exec(&section[:display_summary])
-        = render(partial: "jobseekers/profiles/#{section[:key]}/summary", locals: { profile: @profile, section: section })
+        = render(partial: "jobseekers/profiles/#{section[:key]}/summary", locals: { profile:, section: })
       - else
         p = govuk_link_to section[:link_text], instance_exec(&section[:page_path])
 

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -540,9 +540,10 @@ en:
           phone_number: Phone number
           phone_number_provided: Do you want to provide a phone number?
       show:
-        page_title: Your profile
-        page_description: Your profile allows schools to find and invite you to apply for their jobs.
         activate_profile_text: When you turn on your profile, it'll be visible to hiring staff.
+        imported: You have recently submitted a job application, so some of your details have been imported into your profile.
+        page_description: Your profile allows schools to find and invite you to apply for their jobs.
+        page_title: Your profile
       about_you:
         edit:
           page_title: About You

--- a/spec/factories/qualification_results.rb
+++ b/spec/factories/qualification_results.rb
@@ -1,56 +1,58 @@
 FactoryBot.define do
   factory :qualification_result do
+    qualification
+
     subject { Faker::Educator.subject }
     grade { factory_sample(%w[A B C D E F]) }
-  end
 
-  trait :category_gcse_sample1 do
-    subject { "Maths" }
-    grade { "A" }
-  end
+    trait :category_gcse_sample1 do
+      subject { "Maths" }
+      grade { "A" }
+    end
 
-  trait :category_gcse_sample2 do
-    subject { "English Literature" }
-    grade { "A" }
-  end
+    trait :category_gcse_sample2 do
+      subject { "English Literature" }
+      grade { "A" }
+    end
 
-  trait :category_gcse_sample3 do
-    subject { "English Language" }
-    grade { "B" }
-  end
+    trait :category_gcse_sample3 do
+      subject { "English Language" }
+      grade { "B" }
+    end
 
-  trait :category_gcse_sample4 do
-    subject { "History" }
-    grade { "C" }
-  end
+    trait :category_gcse_sample4 do
+      subject { "History" }
+      grade { "C" }
+    end
 
-  trait :category_gcse_sample5 do
-    subject { "French" }
-    grade { "A" }
-  end
+    trait :category_gcse_sample5 do
+      subject { "French" }
+      grade { "A" }
+    end
 
-  trait :category_gcse_sample6 do
-    subject { "Music" }
-    grade { "B" }
-  end
+    trait :category_gcse_sample6 do
+      subject { "Music" }
+      grade { "B" }
+    end
 
-  trait :category_gcse_sample7 do
-    subject { "Geography" }
-    grade { "C" }
-  end
+    trait :category_gcse_sample7 do
+      subject { "Geography" }
+      grade { "C" }
+    end
 
-  trait :category_alevel_sample1 do
-    subject { "English Literature" }
-    grade { "A" }
-  end
+    trait :category_alevel_sample1 do
+      subject { "English Literature" }
+      grade { "A" }
+    end
 
-  trait :category_alevel_sample2 do
-    subject { "History" }
-    grade { "B" }
-  end
+    trait :category_alevel_sample2 do
+      subject { "History" }
+      grade { "B" }
+    end
 
-  trait :category_alevel_sample3 do
-    subject { "French" }
-    grade { "A" }
+    trait :category_alevel_sample3 do
+      subject { "French" }
+      grade { "A" }
+    end
   end
 end

--- a/spec/models/employment_spec.rb
+++ b/spec/models/employment_spec.rb
@@ -3,4 +3,38 @@ require "rails_helper"
 RSpec.describe Employment do
   it { is_expected.to belong_to(:job_application).optional }
   it { is_expected.to belong_to(:jobseeker_profile).optional }
+
+  describe "#duplicate" do
+    subject(:duplicate) { employment.duplicate }
+    let(:employment) { create(:employment) }
+
+    it "returns a new Employment with the same attributes" do
+      %i[
+        current_role
+        employment_type
+        ended_on
+        job_title
+        main_duties
+        organisation
+        reason_for_break
+        salary
+        started_on
+        subjects
+      ].each do |attribute|
+        expect(duplicate.public_send(attribute)).to eq(employment.public_send(attribute))
+      end
+    end
+
+    it "returns a new unsaved Employment" do
+      expect(duplicate).to be_new_record
+    end
+
+    it "does not copy job application associations" do
+      expect(duplicate.job_application).to be_nil
+    end
+
+    it "does not copy jobseeker profile associations" do
+      expect(duplicate.jobseeker_profile).to be_nil
+    end
+  end
 end

--- a/spec/models/qualification_result_spec.rb
+++ b/spec/models/qualification_result_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe QualificationResult do
+  describe "#duplicate" do
+    subject(:duplicate) { result.duplicate }
+    let(:result) { create(:qualification_result) }
+
+    it "returns a new QualificationResult with the same attributes" do
+      %i[
+        grade
+        subject
+      ].each do |attribute|
+        expect(duplicate.public_send(attribute)).to eq(result.public_send(attribute))
+      end
+    end
+
+    it "returns a new unsaved QualificationResult" do
+      expect(duplicate).to be_new_record
+    end
+  end
+end

--- a/spec/models/qualification_spec.rb
+++ b/spec/models/qualification_spec.rb
@@ -35,4 +35,36 @@ RSpec.describe Qualification do
       end
     end
   end
+
+  describe "#duplicate" do
+    subject(:duplicate) { qualification.duplicate }
+    let(:qualification) { create(:qualification) }
+
+    it "returns a new Qualification with the same attributes" do
+      %i[
+        category
+        finished_studying_details
+        finished_studying
+        grade
+        institution
+        name
+        subject
+        year
+      ].each do |attribute|
+        expect(duplicate.public_send(attribute)).to eq(qualification.public_send(attribute))
+      end
+    end
+
+    it "returns a new unsaved Qualification" do
+      expect(duplicate).to be_new_record
+    end
+
+    it "does not copy job application associations" do
+      expect(duplicate.job_application).to be_nil
+    end
+
+    it "does not copy jobseeker profile associations" do
+      expect(duplicate.jobseeker_profile).to be_nil
+    end
+  end
 end

--- a/spec/models/qualification_spec.rb
+++ b/spec/models/qualification_spec.rb
@@ -55,6 +55,11 @@ RSpec.describe Qualification do
       end
     end
 
+    it "copies over the qualification results" do
+      expect(duplicate.qualification_results.flat_map(&:subject).sort)
+        .to eq(qualification.qualification_results.flat_map(&:subject).sort)
+    end
+
     it "returns a new unsaved Qualification" do
       expect(duplicate).to be_new_record
     end

--- a/spec/system/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers_can_manage_a_profile_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe "Jobseekers can manage their profile" do
       let(:new_employer) { "NASA" }
       let(:new_job_role) { "Chief ET locator" }
 
-      it "succesfully changes the employment record" do
+      it "successfully changes the employment record" do
         visit jobseekers_profile_path
 
         within(".govuk-summary-card", match: :first) { click_link I18n.t("buttons.change") }

--- a/spec/system/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers_can_manage_a_profile_spec.rb
@@ -83,6 +83,10 @@ RSpec.describe "Jobseekers can manage their profile" do
       expect(page).to have_content(previous_application.last_name)
       expect(page).to have_content(previous_application.phone_number)
     end
+
+    it "adds a notice to inform the user" do
+      expect(page).to have_content("your details have been imported into your profile")
+    end
   end
 
   describe "#about_you" do

--- a/spec/system/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers_can_manage_a_profile_spec.rb
@@ -79,20 +79,9 @@ RSpec.describe "Jobseekers can manage their profile" do
     before { visit jobseekers_profile_path }
 
     it "prefills the form with the jobseeker's personal details" do
-      click_link "Add personal details"
-      expect(page).to have_field("personal_details_form[first_name]", with: previous_application.first_name)
-      expect(page).to have_field("personal_details_form[last_name]", with: previous_application.last_name)
-
-      click_on I18n.t("buttons.save_and_continue")
-      expect(page).to have_field("personal_details_form[phone_number]", with: previous_application.phone_number)
-    end
-
-    it "doesn't overwrite the jobseeker's personal details if they have already been filled in" do
-      click_link "Add personal details"
-      fill_in "personal_details_form[first_name]", with: "Alan"
-      click_on I18n.t("buttons.save_and_continue")
-      click_on "Back"
-      expect(page).to have_field("personal_details_form[first_name]", with: "Alan")
+      expect(page).to have_content(previous_application.first_name)
+      expect(page).to have_content(previous_application.last_name)
+      expect(page).to have_content(previous_application.phone_number)
     end
   end
 


### PR DESCRIPTION
Copies over relevant data from a previous application (if present).  Duplicates qualifications and employment history records.