### PR TITLE
[185] Add key-stage acronym inflections

### DIFF
--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -21,4 +21,6 @@ ActiveSupport::Inflector.inflections do |inflect|
   inflect.acronym "ECT"
   inflect.acronym "SENDCo"
   inflect.acronym "DSI"
+
+  1.upto(5) { |n| inflect.acronym "KS#{n}" }
 end


### PR DESCRIPTION
This makes `humanize` correctly upcase them.

## Changes in this PR:

### Before

```
[1] pry(main)> "ks1".humanize
=> "Ks1"
```

### After

```
[1] pry(main)> "ks1".humanize
=> "KS1"
```
