### PR TITLE
[207] Sort profile employments newest to oldest

### DIFF
--- a/app/models/employment.rb
+++ b/app/models/employment.rb
@@ -19,4 +19,8 @@ class Employment < ApplicationRecord
       subjects:,
     )
   end
+
+  def current_role?
+    current_role == "yes"
+  end
 end

--- a/app/views/jobseekers/employments/_employments.html.slim
+++ b/app/views/jobseekers/employments/_employments.html.slim
@@ -1,4 +1,4 @@
-- employments.sort_by { |r| r[:started_on] }.each do |employment|
+- employments.sort_by { |e| e.current_role? ? Float::INFINITY : e.started_on }.reverse_each do |employment|
   = render DetailComponent.new(title: employment.job_title) do |detail_component|
     - detail_component.body do
       = govuk_summary_list(classes: "govuk-!-margin-bottom-0") do |summary_list|


### PR DESCRIPTION
## Screenshots of UI changes:

### Before
<img width="1036" alt="Screenshot 2023-03-15 at 09 01 11" src="https://user-images.githubusercontent.com/109225/225259954-b17d65fb-f7dd-422b-8eda-464c547ef2ed.png">

<img width="889" alt="Screenshot 2023-03-15 at 09 00 50" src="https://user-images.githubusercontent.com/109225/225259995-b9ccefed-f37f-4750-8c1b-dbd9e24bc9b4.png">

### After
<img width="912" alt="Screenshot 2023-03-15 at 09 03 29" src="https://user-images.githubusercontent.com/109225/225260035-6edf9359-88a0-4442-82f7-ebdc63f7d135.png">

<img width="966" alt="Screenshot 2023-03-15 at 09 03 42" src="https://user-images.githubusercontent.com/109225/225260061-ba9d40d1-52bd-4d28-aa5d-4b4a2088c503.png">
