### PR TITLE
Implement basic formatting on the About You section of the Candidate Profile

### DIFF
--- a/app/views/jobseekers/profiles/_summary.html.slim
+++ b/app/views/jobseekers/profiles/_summary.html.slim
@@ -46,7 +46,7 @@
     - if profile.about_you.present?
       h2.govuk-heading-m class="govuk-!-padding-bottom-2"
         = t(".about")
-      p = profile.about_you
+      p = simple_format(profile.about_you)
 
     h2.govuk-heading-m class="govuk-!-padding-bottom-3"
       = t(".contact_details")

--- a/app/views/jobseekers/profiles/about_you/_summary.html.slim
+++ b/app/views/jobseekers/profiles/about_you/_summary.html.slim
@@ -1,5 +1,5 @@
 = govuk_summary_list do |summary_list|
   - summary_list.row do |row|
     - row.key text: t(".about_you_title")
-    - row.value text: profile.about_you
+    - row.value text: simple_format(profile.about_you)
     - row.action(text: t("buttons.change"), href: edit_jobseekers_profile_about_you_path)


### PR DESCRIPTION
## Jira ticket URL

https://trello.com/c/EBj6yd9B/234-implement-basic-formatting-on-the-about-you-section-of-the-candidate-profile

## Changes in this PR:

Implement basic formatting on the About You section of the Candidate Profile by using the Using the `simple_format` method  to account for new line breaks
