### PR TITLE
[230] Don't trigger JS-only buttons when pressing enter in the quals form

### DIFF
--- a/app/views/jobseekers/qualifications/fields/_secondary_school.html.slim
+++ b/app/views/jobseekers/qualifications/fields/_secondary_school.html.slim
@@ -10,11 +10,11 @@
         = result_form.govuk_text_field :subject, label: { text: "Subject #{idx + 1}" }, aria: { required: idx.zero? }, form_group: { classes: "govuk-!-width-two-thirds" }
         = result_form.govuk_text_field :grade, aria: { required: idx.zero? }, form_group: { classes: "govuk-!-width-one-third" }, label: { text: "Subject #{idx + 1} Grade" }
         .govuk-form-group.button_to
-          button.govuk-button.js-action.govuk-button--secondary class="govuk-!-margin-bottom-0" data-action="manage-qualifications#deleteRow"
+          button.govuk-button.js-action.govuk-button--secondary class="govuk-!-margin-bottom-0" data-action="manage-qualifications#deleteRow" type="button"
             = "#{t('buttons.delete_subject')} #{idx + 1}"
 
   span class="govuk-!-margin-bottom-6 govuk-!-margin-top-0 js-action button_to"
-    button.govuk-button.govuk-button--secondary id="add_subject" data-action="manage-qualifications#addRow"
+    button.govuk-button.govuk-button--secondary id="add_subject" data-action="manage-qualifications#addRow" type="button"
       = t("buttons.add_another_subject")
 
 = f.govuk_number_field :year, label: { size: "s" }, aria: { required: true }, width: 4


### PR DESCRIPTION
Implicit form submission will find the first "submit" button and `click` it.  We don't want either of these two buttons to submit the form, so turning them into `type="button"` prevents this.