### PR TITLE
Merge current organisation into jobseeker_profile_search_params

### DIFF
--- a/app/controllers/publishers/jobseeker_profiles_controller.rb
+++ b/app/controllers/publishers/jobseeker_profiles_controller.rb
@@ -1,6 +1,6 @@
 class Publishers::JobseekerProfilesController < Publishers::BaseController
   def index
-    @pagy, @jobseeker_profiles = pagy(Search::JobseekerProfileSearch.new(filters).jobseeker_profiles)
+    @pagy, @jobseeker_profiles = pagy(Search::JobseekerProfileSearch.new(jobseeker_profile_search_params).jobseeker_profiles)
     @form = Publishers::JobseekerProfileSearchForm.new(jobseeker_profile_search_params)
   end
 
@@ -11,15 +11,13 @@ class Publishers::JobseekerProfilesController < Publishers::BaseController
   private
 
   def jobseeker_profile_search_params
-    params.permit(locations: [], qualified_teacher_status: [], roles: [], working_patterns: [], education_phases: [], key_stages: [], subjects: []).transform_values(&:compact_blank)
+    params.permit(locations: [], qualified_teacher_status: [], roles: [], working_patterns: [], education_phases: [], key_stages: [], subjects: [])
+          .transform_values(&:compact_blank)
+          .merge(current_organisation:)
   end
 
   def profile
     @profile ||= JobseekerProfile.find(params[:id])
   end
   helper_method :profile
-
-  def filters
-    jobseeker_profile_search_params.merge(current_organisation:)
-  end
 end


### PR DESCRIPTION
## Changes in this PR:

- removed `filters`. `current_organisation` needs to be available to the form and the search service