### PR TITLE
[239] Remove blank space on profile search results

### DIFF
--- a/app/views/publishers/jobseeker_profiles/search/_results.html.slim
+++ b/app/views/publishers/jobseeker_profiles/search/_results.html.slim
@@ -5,7 +5,7 @@
       h2.govuk-heading-m class="govuk-!-margin-bottom-0"
         = govuk_link_to jobseeker_profile.full_name, publishers_jobseeker_profile_path(jobseeker_profile)
 
-      = govuk_summary_list(classes: "govuk-summary-list--no-border search-results__summary-list--compact") do |summary_list|
+      = govuk_summary_list(actions: false, classes: "govuk-summary-list--no-border search-results__summary-list--compact") do |summary_list|
         - summary_list.row do |row|
           - row.value text: jobseeker_profile.qts_status, classes: "govuk-body-s govuk-!-padding-bottom-0"
 


### PR DESCRIPTION
See https://govuk-components.netlify.app/components/summary-list/#summary-lists-without-actions

## Changes in this PR:

### Before
<img width="1169" alt="Screenshot 2023-03-24 at 10 02 09" src="https://user-images.githubusercontent.com/109225/227491373-471677b4-3684-47b1-b5d4-0405f90adde1.png">

### After
<img width="1155" alt="Screenshot 2023-03-24 at 10 02 22" src="https://user-images.githubusercontent.com/109225/227491388-72aa175e-18d1-46d2-a1df-e81c4e0db16a.png">
