### PR TITLE
Allowing trusts to invite candidated to apply for all their roles

### DIFF
--- a/app/form_models/publishers/invite_form.rb
+++ b/app/form_models/publishers/invite_form.rb
@@ -51,7 +51,7 @@ module Publishers
     def applicable_jobs
       existing_invitations = InvitationToApply.where(jobseeker_id: jobseeker_profile.jobseeker_id)
       @applicable_jobs ||= job_preferences
-        .vacancies(organisation.vacancies.active)
+        .vacancies(organisation.all_vacancies.active)
         .where.not(id: existing_invitations.select(:vacancy_id))
     end
 


### PR DESCRIPTION
https://trello.com/c/xrfhJtzo/246-trust-level-access-is-only-showing-candidates-that-match-with-head-office-not-constituent-academies-within-the-trust