### PR TITLE
[258] Only show full time and part time on subscription form

### DIFF
--- a/app/form_models/jobseekers/subscription_form.rb
+++ b/app/form_models/jobseekers/subscription_form.rb
@@ -58,7 +58,7 @@ class Jobseekers::SubscriptionForm < BaseForm
     @job_role_options = Vacancy.job_roles.keys.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_role_form.job_role_options.#{option}")] }
     @phase_options = Vacancy.phases.keys.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_education_phases_form.phases_options.#{option}")] }
     @ect_status_options = [["ect_suitable", I18n.t("jobs.filters.ect_suitable")]]
-    @working_pattern_options = Vacancy.working_patterns.keys.map do |option|
+    @working_pattern_options = %w[full_time part_time].map do |option|
       [option, I18n.t("helpers.label.publishers_job_listing_working_patterns_form.working_patterns_options.#{option}")]
     end
   end


### PR DESCRIPTION
NB: there is some tech debt here.  At some point we should change the enum of working pattern types in the `Vacancy` model to no longer have these, once we're sure they're not in use any more.

## Screenshots of UI changes:

### Before
<img width="369" alt="Screenshot 2023-03-31 at 10 08 57" src="https://user-images.githubusercontent.com/109225/229079472-c95804fc-acd3-4385-a53f-11e2add3d07c.png">

### After
<img width="379" alt="Screenshot 2023-03-31 at 10 13 08" src="https://user-images.githubusercontent.com/109225/229079490-146e6c59-5e69-466c-bf7b-ab9480421c13.png">
