### PR TITLE
[TRELLO #262] Show qualification name instead of "other" category

### DIFF
--- a/app/helpers/qualifications_helper.rb
+++ b/app/helpers/qualifications_helper.rb
@@ -12,4 +12,8 @@ module QualificationsHelper
   def qualifications_sort_and_group(qualifications)
     qualifications.sort_by { |q| QUALIFICATIONS_ORDER.index(q[:category]) }.group_by { |q| q[:category] }
   end
+
+  def qualifications_group_category_other?(qualifications)
+    qualifications.all? { |qualification| qualification.category == "other" }
+  end
 end

--- a/app/views/jobseekers/job_applications/review/_qualifications.html.slim
+++ b/app/views/jobseekers/job_applications/review/_qualifications.html.slim
@@ -6,9 +6,12 @@
       p.govuk-body = t("jobseekers.job_applications.show.qualifications.none")
   - else
     - qualifications_sort_and_group(job_application.qualifications).each_value do |qualification_group|
-      h3 class="govuk-heading-s" class="govuk-!-margin-top-0 govuk-!-margin-bottom-1"
-        = t("helpers.label.jobseekers_qualifications_category_form.category_options.#{qualification_group.first[:category]}")
       - qualification_group.each do |qualification|
+        h3 class="govuk-heading-s" class="govuk-!-margin-top-0 govuk-!-margin-bottom-1"
+          - if qualifications_group_category_other?(qualification_group)
+            = qualification.name
+          - else
+            = t("helpers.label.jobseekers_qualifications_category_form.category_options.#{qualification_group.first[:category]}")
         div class="govuk-!-margin-bottom-6"
           - if qualification.secondary?
             = render "jobseekers/job_applications/review/qualifications/secondary_qualification", qualification: qualification


### PR DESCRIPTION
## Jira ticket URL

https://trello.com/c/SbPM7BCL/262-other-qualification-or-course-not-displaying-on-application-form

## Changes in this PR:

### Before

<img width="548" alt="Screenshot 2023-04-03 at 13 04 04" src="https://user-images.githubusercontent.com/30624173/229503766-96124d56-ca25-4364-b9fe-c983aa3b8696.png">

### After

<img width="576" alt="Screenshot 2023-04-03 at 13 04 35" src="https://user-images.githubusercontent.com/30624173/229503868-351c9bf8-131e-40c6-9883-c82e80a4d3ce.png">
