### PR TITLE
Revert jest to 29.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint": "^8.34.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.27.5",
-    "jest": "^29.5.0",
+    "jest": "^29.4.3",
     "jest-environment-jsdom": "^29.2.2",
     "jsdom": "^20.0.1",
     "postcss": "^8.4.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3878,7 +3878,7 @@ jest-worker@^29.5.0:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jest@^29.5.0:
+jest@^29.4.3:
   version "29.5.0"
   resolved "https://registry.yarnpkg.com/jest/-/jest-29.5.0.tgz#f75157622f5ce7ad53028f2f8888ab53e1f1f24e"
   integrity sha512-juMg3he2uru1QoXX078zTa7pO85QyB9xajZc6bU+d9yEGwrKX6+vGmJQ3UdVZsvTEUARIdObzH68QItim6OSSQ==


### PR DESCRIPTION
For whatever reason, jest 29.5.0 is causing a few tests in app/assets/javascript/components/map/map.test.js to fail. It seems that this TypeError (Cannot use 'in' operator to search for '_leaflet_id' in null) is raised at teaching-vacancies/node_modules/leaflet/src/core/Util.js:55:21, so it could be that leaflet doesn't work particularly well with the latest minor version of jest.

Became aware of this whilst investigating failures here: https://github.com/DFE-Digital/teaching-vacancies/pull/5865

Jest's version was bumped to 24.5.0 some weeks ago and it appears that the tests in `app/assets/javascript/components/map/map.test.js` are failing on main (at least locally). Nos sure why we've not seen these tests fail in CI.