### PR TITLE
Removed long obsolete, hardcoded aria-describedby attribute from SearchableCollection component

### DIFF
--- a/app/components/searchable_collection_component/searchable_collection_component.html.slim
+++ b/app/components/searchable_collection_component/searchable_collection_component.html.slim
@@ -2,7 +2,7 @@
   div class="#{border_class} #{scrollable_class}"
     - if searchable?
       .searchable-collection-component__search
-        input.govuk-input.icon.icon--left.icon--search.js-action data-searchable-collection-target="input" data-action="input->searchable-collection#input" placeholder=@text[:placeholder] aria-label=@text[:aria_label] aria-expanded="true" aria-describedby="publishers-job-listing-job-details-form-subjects-hint" aria-owns="subjects__listbox" role="combobox"
+        input.govuk-input.icon.icon--left.icon--search.js-action data-searchable-collection-target="input" data-action="input->searchable-collection#input" placeholder=@text[:placeholder] aria-label=@text[:aria_label] aria-expanded="true" aria-describedby=@text[:aria_describedby] aria-owns="subjects__listbox" role="combobox"
         .govuk-visually-hidden aria-live="assertive" role="status" class="collection-match"
 
     = collection


### PR DESCRIPTION
The element matching hardcoded id has been removed in September last year at a291c5224ccaf0f18f5a0f2508d85da4caab628d. 

In any case, this attribute should be dynamic.