### PR TITLE
[TRELLO #278] Update job alert email

### DIFF
--- a/app/helpers/notify_views_helper.rb
+++ b/app/helpers/notify_views_helper.rb
@@ -12,11 +12,6 @@ module NotifyViewsHelper
     notify_link(url)
   end
 
-  def edit_subscription_link(subscription)
-    url = edit_subscription_url(subscription.token, **utm_params)
-    notify_link(url, t(".edit_link_text"))
-  end
-
   def email_confirmation_link(token, confirmation_type)
     url = jobseeker_confirmation_url(confirmation_token: token, **utm_params)
     notify_link(url, t("#{confirmation_type}.link"))
@@ -62,6 +57,11 @@ module NotifyViewsHelper
   def jobseeker_job_application_link(job_application)
     url = jobseekers_job_application_url(job_application, **utm_params)
     notify_link(url, t(".job_application.link_text"))
+  end
+
+  def jobseeker_profile_link
+    url = jobseekers_profile_url(**utm_params)
+    notify_link(url, t(".create_a_profile.link_text"))
   end
 
   def privacy_policy_link

--- a/app/mailers/jobseekers/alert_mailer.rb
+++ b/app/mailers/jobseekers/alert_mailer.rb
@@ -5,7 +5,7 @@ class Jobseekers::AlertMailer < Jobseekers::BaseMailer
   helper DatesHelper
   helper VacanciesHelper
 
-  helper_method :subscription, :jobseeker
+  helper_method :subscription, :jobseeker, :jobseeker_has_profile?
 
   def alert(subscription_id, vacancy_ids)
     @subscription_id = subscription_id
@@ -44,6 +44,12 @@ class Jobseekers::AlertMailer < Jobseekers::BaseMailer
 
   def subscription
     @subscription ||= SubscriptionPresenter.new(Subscription.find(subscription_id))
+  end
+
+  def jobseeker_has_profile?
+    return false unless jobseeker
+
+    jobseeker.jobseeker_profile.present?
   end
 
   def utm_campaign

--- a/app/views/jobseekers/alert_mailer/alert.text.erb
+++ b/app/views/jobseekers/alert_mailer/alert.text.erb
@@ -23,13 +23,20 @@
 <%= t(".alert_frequency", frequency: subscription.frequency) %>
 
 ---
+<%- unless jobseeker_has_profile? %>
+  # <%= t(".create_a_profile.heading") %>
 
-# <%= t(".alert_relevance") %>
-<%= t(".edit_alert")%>
+  <%= t(".create_a_profile.intro")%>
 
-<%= edit_subscription_link(subscription)%>
+  * <%= t(".create_a_profile.bullet_points.share_qualifications_and_experience")%>
+  * <%= t(".create_a_profile.bullet_points.specify_preferences")%>
+  * <%= t(".create_a_profile.bullet_points.apply_quickly")%>
 
----
+<%= t(".create_a_profile.further_information")%>
+
+<%= jobseeker_profile_link %>
+  ---
+<% end %>
 
 # <%= t(".relevance_feedback.heading") %>
 

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -68,10 +68,20 @@ en:
       alert:
         alert_frequency: >-
           You have set to receive this job alert %{frequency} when any jobs matching your criteria are listed.
-        alert_relevance: Get more relevant job alerts
         closing_date: "Closing date: %{closing_date}"
-        edit_alert: Change your alert criteria to get job alerts that are more relevant to you. You can filter by keyword, location, job role, education phase or working pattern.
-        edit_link_text: Manage your alert
+        create_a_profile:
+          heading: Create a profile
+          bullet_points:
+            apply_quickly: apply for roles more quickly by pre-filling your information
+            share_qualifications_and_experience: share your qualifications and experience with schools
+            specify_preferences: specify the types of teaching jobs you’re looking for
+          further_information: >-
+            When you turn on your profile, it will be visible to hiring staff in schools and trusts. They can
+            get in touch by email to invite you to apply for roles where they think you’d be a great fit.
+          intro: >-
+            Create a profile on Teaching Vacancies and let schools come to you. You will need to create an account
+            to build your profile. With a profile, you can:
+          link_text: Create a profile
         relevance_feedback:
           heading: Are these job listings relevant to your search?
           feedback_link:


### PR DESCRIPTION
## Trello ticket URL

https://trello.com/c/iYRLTrB3/278-update-job-alert-email-with-profile-nudge

## Changes in this PR:

## Jobseeker has profile

<img width="723" alt="Screenshot 2023-04-13 at 15 34 36" src="https://user-images.githubusercontent.com/30624173/231793553-d0d8aa05-69c7-49e9-8f46-51e3e67478e6.png">

##  Jobseeker does not have profile

<img width="647" alt="Screenshot 2023-04-13 at 15 34 14" src="https://user-images.githubusercontent.com/30624173/231793462-911fdfa3-12c2-4d94-b9f1-fbe27d007a38.png">
