### PR TITLE
[TRELLO #267] Display reminder when profile not completed

### DIFF
--- a/app/controllers/jobseekers/saved_jobs_controller.rb
+++ b/app/controllers/jobseekers/saved_jobs_controller.rb
@@ -22,17 +22,12 @@ class Jobseekers::SavedJobsController < Jobseekers::BaseController
 
   private
 
-  def candidate_profile_complete?
-    profile = current_jobseeker.jobseeker_profile
+  def profile_complete?
+    return false unless (profile = current_jobseeker.jobseeker_profile)
 
-    return unless profile
-
-    personal_details = profile.personal_details
-    job_preferences = profile.job_preferences
-
-    section_completed(personal_details) && section_completed(job_preferences)
+    profile.personal_details.complete? && profile.job_preferences.complete?
   end
-  helper_method :candidate_profile_complete?
+  helper_method :profile_complete?
 
   def saved_job
     @saved_job ||= current_jobseeker.saved_jobs.find_or_initialize_by(vacancy_id: vacancy.id)
@@ -52,12 +47,5 @@ class Jobseekers::SavedJobsController < Jobseekers::BaseController
 
   def vacancy
     @vacancy ||= Vacancy.listed.find(saved_job_params[:job_id])
-  end
-
-  def section_completed(record)
-    return if record.completed_steps.blank?
-
-    step_phases = %w[completed skipped]
-    record.completed_steps.values.all? { |step| step_phases.include?(step) }
   end
 end

--- a/app/views/jobseekers/saved_jobs/index.html.slim
+++ b/app/views/jobseekers/saved_jobs/index.html.slim
@@ -13,7 +13,7 @@ h1.govuk-heading-l = t(".page_title")
 
 .govuk-grid-row
   .govuk-grid-column-full
-    = render "candidiate_profiles_banner" unless candidate_profile_complete?
+    = render "candidiate_profiles_banner" unless profile_complete?
     - if saved_jobs.any?
       #vacancy-results
         - saved_jobs.each do |saved_job|

--- a/spec/requests/jobseekers/saved_jobs_spec.rb
+++ b/spec/requests/jobseekers/saved_jobs_spec.rb
@@ -28,6 +28,28 @@ RSpec.describe "Saved jobs" do
     end
   end
 
+  describe "GET #index" do
+    before { sign_in(jobseeker, scope: :jobseeker) }
+
+    context "when a jobseeker has completed their profile" do
+      let!(:completed_profile) { create(:jobseeker_profile, :completed, jobseeker_id: jobseeker.id) }
+
+      before { get jobseekers_saved_jobs_path }
+
+      it "does not display a reminder to create a profile" do
+        expect(response).to_not render_template(partial: "_candidiate_profiles_banner")
+      end
+    end
+
+    context "when a jobseeker has not completed their profile" do
+      before { get jobseekers_saved_jobs_path }
+
+      it "displays a reminder to create a profile" do
+        expect(response).to render_template(partial: "_candidiate_profiles_banner")
+      end
+    end
+  end
+
   describe "DELETE #destroy" do
     let!(:saved_job) { create(:saved_job, jobseeker: jobseeker, vacancy: vacancy) }
 


### PR DESCRIPTION
## Trello ticket URL

https://trello.com/c/MGGd1HWB/267-create-a-profile-interstitial-incorrectly-shown-even-after-profile-has-been-created


## Comments:

Unable to recreate this bug as it was working for me. Previously we used `section_completed` in the controller to determine whether a section was completed. If both the personal details and job preferences sections were complete (at least as far as `section_completed` was concerned), the reminder is not displayed. I have now removed `section_compelted`. Instead, we pass the responsibility for determining whether a section is complete to the respective models - PersonalDetails and JobPeference. 