### PR TITLE
[TRELLO #268] Rename hide_profile to requested_hidden_profile

### DIFF
--- a/app/controllers/jobseekers/profiles/hide_profile_controller.rb
+++ b/app/controllers/jobseekers/profiles/hide_profile_controller.rb
@@ -1,17 +1,17 @@
 class Jobseekers::Profiles::HideProfileController < Jobseekers::ProfilesController
   def show
-    @form = Jobseekers::Profile::HideProfileForm.new(hide_profile: profile.hide_profile)
+    @form = Jobseekers::Profile::HideProfileForm.new(requested_hidden_profile: profile.requested_hidden_profile)
   end
 
   def confirm_hide
     form_params = params
       .require(:jobseekers_profile_hide_profile_form)
-      .permit(:hide_profile)
+      .permit(:requested_hidden_profile)
 
     if (@form = Jobseekers::Profile::HideProfileForm.new(form_params)).valid?
-      profile.update!(hide_profile: @form.hide_profile)
+      profile.update!(requested_hidden_profile: @form.requested_hidden_profile)
 
-      if profile.hide_profile?
+      if profile.requested_hidden_profile?
         redirect_to add_jobseekers_profile_hide_profile_path
       else
         redirect_to review_jobseekers_profile_hide_profile_path

--- a/app/controllers/jobseekers/profiles_controller.rb
+++ b/app/controllers/jobseekers/profiles_controller.rb
@@ -52,7 +52,7 @@ class Jobseekers::ProfilesController < Jobseekers::BaseController
     },
     {
       title: I18n.t("jobseekers.profiles.show.hide_profile"),
-      display_summary: -> { !profile.hide_profile.nil? },
+      display_summary: -> { !profile.requested_hidden_profile.nil? },
       key: "hide_profile",
       link_text: I18n.t("jobseekers.profiles.show.set_up_profile_visibility"),
       page_path: -> { jobseekers_profile_hide_profile_path },

--- a/app/form_models/jobseekers/profile/hide_profile_form.rb
+++ b/app/form_models/jobseekers/profile/hide_profile_form.rb
@@ -1,12 +1,12 @@
 class Jobseekers::Profile::HideProfileForm < BaseForm
   include ActiveRecord::AttributeAssignment
 
-  attr_accessor :hide_profile
+  attr_accessor :requested_hidden_profile
 
-  validates :hide_profile, inclusion: { in: [true, false] }
+  validates :requested_hidden_profile, inclusion: { in: [true, false] }
 
   def initialize(attributes = {})
-    self.hide_profile = ActiveModel::Type::Boolean.new.cast(attributes.delete(:hide_profile))
+    self.requested_hidden_profile = ActiveModel::Type::Boolean.new.cast(attributes.delete(:requested_hidden_profile))
     super(attributes)
   end
 end

--- a/app/models/jobseeker_profile.rb
+++ b/app/models/jobseeker_profile.rb
@@ -77,4 +77,8 @@ class JobseekerProfile < ApplicationRecord
   def activable?
     !!personal_details&.complete? && !!job_preferences&.complete?
   end
+
+  def hidden_from_any_organisations?
+    requested_hidden_profile && excluded_organisations.any?
+  end
 end

--- a/app/views/jobseekers/profiles/hide_profile/_summary.html.slim
+++ b/app/views/jobseekers/profiles/hide_profile/_summary.html.slim
@@ -1,9 +1,9 @@
-p = govuk_link_to(t(".add_a_school"), add_jobseekers_profile_hide_profile_path) if profile.hide_profile?
+p = govuk_link_to(t(".add_a_school"), add_jobseekers_profile_hide_profile_path) if profile.requested_hidden_profile?
 
 = govuk_summary_list do |summary_list|
   = summary_list.row do |row|
     - row.key(text: t(".hide_profile"))
-    - row.value(text: profile.hide_profile? ? "Yes" : "No")
+    - row.value(text: profile.hidden_from_any_organisations? ? "Yes" : "No")
     - row.action(text: t("buttons.change"), href: jobseekers_profile_hide_profile_path)
 
   - profile.organisation_exclusions.each do |exclusion|

--- a/app/views/jobseekers/profiles/hide_profile/show.html.slim
+++ b/app/views/jobseekers/profiles/hide_profile/show.html.slim
@@ -8,7 +8,7 @@
     = form_for @form, url: confirm_hide_jobseekers_profile_hide_profile_path, method: :post do |f|
       = f.govuk_error_summary
 
-      = f.govuk_collection_radio_buttons :hide_profile,
+      = f.govuk_collection_radio_buttons :requested_hidden_profile,
         [["Yes", true], ["No", false]],
         :last,
         :first,

--- a/db/migrate/20230414110415_change_hide_profile_to_requested_hidden_profile_on_jobseeker_profile.rb
+++ b/db/migrate/20230414110415_change_hide_profile_to_requested_hidden_profile_on_jobseeker_profile.rb
@@ -1,0 +1,5 @@
+class ChangeHideProfileToRequestedHiddenProfileOnJobseekerProfile < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :jobseeker_profiles, :hide_profile, :requested_hidden_profile
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_03_092228) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_14_110415) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -287,7 +287,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_03_092228) do
     t.integer "qualified_teacher_status"
     t.string "qualified_teacher_status_year"
     t.boolean "active", default: false, null: false
-    t.boolean "hide_profile"
+    t.boolean "requested_hidden_profile"
     t.index ["jobseeker_id"], name: "index_jobseeker_profiles_on_jobseeker_id"
   end
 


### PR DESCRIPTION
## Changes in this PR:

- "Yes" or "No" displayed below now set based on value of `requested_hidden_profile` and whether the jobseeker profile is associated with any excluded organisations.

<img width="777" alt="Screenshot 2023-04-14 at 12 32 06" src="https://user-images.githubusercontent.com/30624173/232032747-76ba2e3c-1218-45a7-8434-309e4a3c7780.png">


Change to the column name came off the back of the conversation in this thread:  https://ukgovernmentdfe.slack.com/archives/C038BHC819S/p1681393988452299

At the moment, if a user selects "Yes" below

<img width="768" alt="Screenshot 2023-04-14 at 12 24 34" src="https://user-images.githubusercontent.com/30624173/232031373-7f385fca-a13e-42f5-bfcd-6744cfd8cce9.png">

`hidden_profile` is set to true. Despite this, the profile is not actually hidden until the jobseeker adds some excluded organisations (in the next step). Because of this, I felt this attribute was a little misleading. All it's really indicating is if the user has selected "yes" or "no" to the question above. It does not determine whether the profile should actually be hidden. For this reason, I have changed it to `requested_hidden_profile`. 

Open to suggestions for a better name!
