### PR TITLE
Avoid Redis and Sidekiq major version Dependabot upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,21 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 10
+    ignore:
+      # TODO: Remove this ignore config once moved to a Redis v6.2+ instance in AKS.
+      # The version is currently pinned to <7. We're unable to upgrade sidekiq as it requires out Redis service
+      # instance to be 6.2+ https://github.com/sidekiq/sidekiq/blob/main/docs/7.0-Upgrade.md#version-support.
+      # Our current Redis service instance is 5.0.6. This will be upgraded when we migrate from GOVuk PaaS to AKS.
+      - dependency-name: "sidekiq"
+        update-types: ["version-update:semver-major"]
+
+      # TODO: Remove this ignore config once moved to a Redis v6.2+ instance in AKS.
+      # The version is currently pinned to <5 by sidekiq (version 6.5.8).
+      # It seems this pin is removed by later sidekiq versions, but we're unable to upgrade sidekiq as it requires out
+      # Redis service instance to be 6.2+ https://github.com/sidekiq/sidekiq/blob/main/docs/7.0-Upgrade.md#version-support.
+      # Our current Redis service instance is 5.0.6. This will be upgraded when we migrate from GOVuk PaaS to AKS.
+      - dependency-name: "redis"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
## Trello ticket URL
https://trello.com/c/ljvasEsG

## Changes on this pr

We cannot upgrade Redis & Sidekiq major gem versions until we use a Redis service instance at version 6.2 or greater.

Our current Redis service instance on GovUK PaaS is v5.0.6.

Dependabot is opening PRs trying to upgrade both gems to their latest versions. And when the PR gets closed/blocked by a developer, Dependabot overseeds/reopens a new PR with a further patch version increase.

This causes the developer visibility on "why we cannot upgrade these" to get lost as soon as a new version triggers a PR.

To avoid the hassle of managing this on each version and mitigate the risk of merging a PR that would break our builds, we ignore any major version upgrades for both gems.

Opted for explicit configuration file definitions instead of simply calling a "@dependabot ignore xxx" in the PR comment. This allows us to have an explicit configuration in our code with comments reminding us about the need to upgrade these gems in the future once the blocker is removed.

A "@dependabot ignore xxx" call would put us at risk of completely forgetting to upgrade the affected gems.


