### PR TITLE
Explicitly ignore specific markdown files.

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -9,7 +9,12 @@ on:
     - 'bigquery/**'
     - 'documentation/**'
     - 'terraform/common/**'
-    - '**.md'
+    - 'spec/fixtures/files/*.md'
+    - 'app/mailers/previewing_emails.md'
+    - 'README.md'
+    - 'app/assets/stylesheets/README.md'
+    - 'app/components/README.md'
+    - '.github/pull_request_template.md'
 
   pull_request:
     branches:


### PR DESCRIPTION
https://trello.com/c/YFqNVsGm/304-md-files-are-not-being-deployed-to-prod

## Changes in this PR:

Prior to this change, making changes to markdown files did not trigger the build and deploy step. However we want the build and deploy step to trigger if we make changes to the markdown files within the content directory. 

There have been a couple of previous attempts (see the trello ticket) to do this by ignoring all files with the `.md` extension and then making exceptions for the .md files in the content directory. This did not work, and after experimenting with it myself, I could not get it to work either so I have taken the approach of explicitly ignoring all the markdown files we currently have that are outside of the content directory. 

This approach means that we achieve our goals of triggering a build when markdown files are changed in the content directory, but not if the explicitly markdown files are changed. Right now, this is all our other markdown files, however in the future if new markdown files are added they will also trigger a build until they're explicity ignored in the build_and_deploy.yml file. I think this is a decent trade off to fix this issue without taking up any extra developer time.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
