### PR TITLE
Increase Dependabot open PR limits for NPM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,4 +30,4 @@ updates:
     schedule:
       interval: "weekly"
       day: "wednesday"
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Trello ticket URL

https://trello.com/c/ljvasEsG

## Changes in this PR:

Since the bot runs once per week, a limit of 2 open PRs it is causing the bot not to be able to keep up with how frequently NPM packages are upgraded.

