### PR TITLE
Replace Jira with Trello in Pull Request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,4 @@
-## Jira ticket URL
-
-- Just add the ticket number to the end:
-
-https://dfedigital.atlassian.net/browse/TEVA-
+## Trello card URL
 
 ## Changes in this PR:
 


### PR DESCRIPTION
## Changes in this PR:

Our service is using Trello instead of Jira.

Since Trello card URLs are more convoluted than Jira ticket numeration, I removed any partial link. As probably, the developer using the template will copy&paste a full URL from Trello instead of typing a ticket 'number'.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
