### PR TITLE
Upgrade npm jest to v29.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint": "^8.39.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.27.5",
-    "jest": "^29.4.3",
+    "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.2.2",
     "jsdom": "^21.1.1",
     "postcss": "^8.4.23",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.27.5",
     "jest": "^29.5.0",
-    "jest-environment-jsdom": "^29.2.2",
+    "jest-environment-jsdom": "29.2.2",
     "jsdom": "^21.1.1",
     "postcss": "^8.4.23",
     "sass": "^1.62.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4046,7 +4046,7 @@ jest-worker@^29.5.0:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jest@^29.4.3:
+jest@^29.5.0:
   version "29.5.0"
   resolved "https://registry.yarnpkg.com/jest/-/jest-29.5.0.tgz#f75157622f5ce7ad53028f2f8888ab53e1f1f24e"
   integrity sha512-juMg3he2uru1QoXX078zTa7pO85QyB9xajZc6bU+d9yEGwrKX6+vGmJQ3UdVZsvTEUARIdObzH68QItim6OSSQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3753,7 +3753,7 @@ jest-each@^29.5.0:
     jest-util "^29.5.0"
     pretty-format "^29.5.0"
 
-jest-environment-jsdom@^29.2.2:
+jest-environment-jsdom@29.2.2:
   version "29.2.2"
   resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-29.2.2.tgz#1e2d9f1f017fbaa7362a83e670b569158b4b8527"
   integrity sha512-5mNtTcky1+RYv9kxkwMwt7fkzyX4EJUarV7iI+NQLigpV4Hz4sgfOdP4kOpCHXbkRWErV7tgXoXLm2CKtucr+A==


### PR DESCRIPTION
## Trello card URL

Part of cleaning up done through: https://trello.com/c/ljvasEsG

## Changes in this PR:

This PR just specifies the latest `jest` and `jest-environment-jsdom` versions that run without breaking our test suite.

The jump to `jest-environment-jsdom` v29.3 breaks the test suite on `app/assets/javascript/components/map/map.test.js` 

Needs a follow-up to investigate and address the upgrade issues.

### Related PRs:
- https://github.com/DFE-Digital/teaching-vacancies/pull/5929 (The issue is on the `jest-environment-jsdom` upgrade, though).
- https://github.com/DFE-Digital/teaching-vacancies/pull/5865

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
