### PR TITLE
Add "right to work in UK" to Personal Details fields exported to analytics

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -368,6 +368,7 @@ shared:
     - last_name
     - phone_number_provided
     - phone_number
+    - right_to_work_in_uk
     - completed_steps
     - created_at
     - updated_at


### PR DESCRIPTION
## Trello card URL

## Changes in this PR:

The field was added in DB but not included in the Analytics configuration for the Personal Details table. So it wasn't being sent to BigQuery.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
