### PR TITLE
Add hidden text to invite to apply for job link

### DIFF
--- a/app/views/publishers/jobseeker_profiles/_layout.html.slim
+++ b/app/views/publishers/jobseeker_profiles/_layout.html.slim
@@ -7,7 +7,8 @@
   .govuk-grid-column-two-thirds
     h1.govuk-heading-xl class="govuk-!-margin-bottom-4" = profile.full_name
     - if Publishers::InviteForm.new(organisation_id: current_organisation.id, jobseeker_profile_id: profile.id).applicable_jobs.any?
-      = govuk_link_to "Invite to apply for a job", invite_to_apply_publishers_jobseeker_profile_path, class: %i[govuk-button govuk-!-margin-bottom-6]
+      = govuk_link_to invite_to_apply_publishers_jobseeker_profile_path, class: %i[govuk-button govuk-!-margin-bottom-6] do
+        - "Invite ".html_safe + content_tag(:span, profile.full_name, class: 'govuk-visually-hidden') + " to apply for a job".html_safe
 
     = tabs do |tabs|
       - tabs.navigation_item text: "Profile", link: publishers_jobseeker_profile_path(profile)

--- a/app/views/publishers/jobseeker_profiles/_layout.html.slim
+++ b/app/views/publishers/jobseeker_profiles/_layout.html.slim
@@ -8,7 +8,7 @@
     h1.govuk-heading-xl class="govuk-!-margin-bottom-4" = profile.full_name
     - if Publishers::InviteForm.new(organisation_id: current_organisation.id, jobseeker_profile_id: profile.id).applicable_jobs.any?
       = govuk_link_to invite_to_apply_publishers_jobseeker_profile_path, class: %i[govuk-button govuk-!-margin-bottom-6] do
-        - "Invite ".html_safe + content_tag(:span, profile.full_name, class: 'govuk-visually-hidden') + " to apply for a job".html_safe
+        - "Invite ".html_safe + content_tag(:span, profile.full_name, class: "govuk-visually-hidden") + " to apply for a job".html_safe
 
     = tabs do |tabs|
       - tabs.navigation_item text: "Profile", link: publishers_jobseeker_profile_path(profile)


### PR DESCRIPTION
https://trello.com/c/dFamxFCS/271-add-hidden-text-that-specifies-who-you-are-inviting-to-apply-for-a-job

This PR adds hidden text to the "Invite to apply for a job" button to specify which jobseeker is being invited for accessibility reasons.

## Screenshots of UI changes:

<img width="1161" alt="Screenshot 2023-04-28 at 09 06 41" src="https://user-images.githubusercontent.com/13124899/235091970-338b98d6-5777-4884-b811-ab212b18a800.png">


## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
