### PR TITLE
Tweaks for Devcontainer env

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,62 +14,67 @@
   ],
   "postCreateCommand": "/bin/bash .devcontainer/post_create.sh",
   "remoteUser": "teaching-vacancies",
-  "extensions": [
-    "actboy168.tasks",
-    "aki77.rails-db-schema",
-    "aki77.rails-i18n",
-    "aki77.rails-routes",
-    "castwide.solargraph",
-    "davidpallinder.rails-test-runner",
-    "jemmyw.rails-fast-nav",
-    "kaiwood.endwise",
-    "mtxr.sqltools",
-    "mtxr.sqltools-driver-pg",
-    "rebornix.Ruby",
-    "redhat.vscode-yaml",
-    "sianglim.slim",
-  ],
-  "settings": {
-    // Get highlighting for local env files
-    "files.associations": {
-      ".env.development": "env",
-      ".env.local": "env",
-      ".env.test": "env",
-      ".env.test.local": "env"
-    },
-    "rails.viewFileExtension": "html.slim",
-    "railsRoutes.railsCommand": "bin/rails",
-    "railsTestRunner.rspecCommand": "bin/rspec",
-    // Set up Ruby extension
-    "ruby.format": "rubocop",
-    "ruby.lint": {
-      "rubocop": {
-        "useBundler": false,
-        "forceExclusion": true
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "actboy168.tasks",
+        "aki77.rails-db-schema",
+        "aki77.rails-i18n",
+        "aki77.rails-routes",
+        "castwide.solargraph",
+        "davidpallinder.rails-test-runner",
+        "jemmyw.rails-fast-nav",
+        "kaiwood.endwise",
+        "mtxr.sqltools",
+        "mtxr.sqltools-driver-pg",
+        "rebornix.Ruby",
+        "redhat.vscode-yaml",
+        "sianglim.slim",
+        "LoranKloeze.ruby-rubocop-revived"
+      ],
+      "settings": {
+        // Get highlighting for local env files
+        "files.associations": {
+          ".env.development": "env",
+          ".env.local": "env",
+          ".env.test": "env",
+          ".env.test.local": "env"
+        },
+        "rails.viewFileExtension": "html.slim",
+        "railsRoutes.railsCommand": "bin/rails",
+        "railsTestRunner.rspecCommand": "bin/rspec",
+        // Set up Ruby extension
+        "ruby.format": "rubocop",
+        "ruby.lint": {
+          "rubocop": {
+            "useBundler": false,
+            "forceExclusion": true
+          }
+        },
+        "ruby.useLanguageServer": true,
+        "sqltools.connections": [
+          {
+            "name": "Rails Development Database",
+            "driver": "PostgreSQL",
+            "previewLimit": 50,
+            "server": "db",
+            "port": 5432,
+            "database": "tvs_development",
+            "username": "postgres",
+            "password": "postgres"
+          },
+          {
+            "name": "Rails Test Database",
+            "driver": "PostgreSQL",
+            "previewLimit": 50,
+            "server": "db",
+            "port": 5432,
+            "database": "tvs_test",
+            "username": "postgres",
+            "password": "postgres"
+          }
+        ]
       }
-    },
-    "ruby.useLanguageServer": true,
-    "sqltools.connections": [
-      {
-        "name": "Rails Development Database",
-        "driver": "PostgreSQL",
-        "previewLimit": 50,
-        "server": "db",
-        "port": 5432,
-        "database": "tvs_development",
-        "username": "postgres",
-        "password": "postgres"
-      },
-      {
-        "name": "Rails Test Database",
-        "driver": "PostgreSQL",
-        "previewLimit": 50,
-        "server": "db",
-        "port": 5432,
-        "database": "tvs_test",
-        "username": "postgres",
-        "password": "postgres"
-      }
-    ]
+    }
   }
 }

--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,7 @@ group :development do
   gem "amazing_print" # optional dependency of `rails_semantic_logger`
   gem "aws-sdk-ssm"
   gem "listen"
+  gem "solargraph"
   gem "spring"
   gem "spring-commands-rspec"
   # TODO: Pinned until Spring >= 3 compatible version released

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,7 +121,9 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.5.2)
       aws-eventstream (~> 1, >= 1.0.2)
+    backport (1.2.0)
     bcrypt (3.1.18)
+    benchmark (0.2.1)
     bindata (2.4.15)
     bindex (0.8.1)
     brakeman (5.4.1)
@@ -161,6 +163,7 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
+    e2mmap (0.1.0)
     erubi (1.12.0)
     et-orbi (1.2.7)
       tzinfo
@@ -257,6 +260,7 @@ GEM
       concurrent-ruby (~> 1.0)
     inflection (1.0.0)
     ipaddr (1.2.5)
+    jaro_winkler (1.5.4)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -273,6 +277,8 @@ GEM
     jwt (2.7.0)
     kramdown (2.4.0)
       rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     launchy (2.5.2)
       addressable (~> 2.8)
     listen (3.8.0)
@@ -450,6 +456,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    rbs (2.8.2)
     recaptcha (5.14.0)
     redis (4.8.1)
     regexp_parser (2.8.0)
@@ -465,6 +472,8 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     retriable (3.1.2)
+    reverse_markdown (2.1.1)
+      nokogiri
     rexml (3.2.5)
     rgeo (3.0.0)
     rgeo-activerecord (7.0.1)
@@ -560,6 +569,22 @@ GEM
     slim_lint (0.24.0)
       rubocop (>= 1.0, < 2.0)
       slim (>= 3.0, < 6.0)
+    solargraph (0.49.0)
+      backport (~> 1.2)
+      benchmark
+      bundler (~> 2.0)
+      diff-lcs (~> 1.4)
+      e2mmap
+      jaro_winkler (~> 1.5)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.1)
+      parser (~> 3.0)
+      rbs (~> 2.0)
+      reverse_markdown (~> 2.0)
+      rubocop (~> 1.38)
+      thor (~> 1.0)
+      tilt (~> 2.0)
+      yard (~> 0.9, >= 0.9.24)
     spring (4.1.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -618,6 +643,7 @@ GEM
       builder (>= 2.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yard (0.9.34)
     zeitwerk (2.6.8)
     zendesk_api (2.0.1)
       faraday (> 2.0.0)
@@ -719,6 +745,7 @@ DEPENDENCIES
   skylight
   slim-rails
   slim_lint
+  solargraph
   spring
   spring-commands-rspec
   spring-watcher-listen!


### PR DESCRIPTION
## Changes in this PR:

There were a couple of small issues on the Devcontainers development:
- Rubocop extension was omitted.
- It was required to have Solargraph installed (as it uses Solargraph extension), while Solargraph gem wasn't required in the Gemfile for development.

This PR
- Includes Solargraph gem for the Gemfile Development group.
- Adds Rubocop extension to VSCode devcontainer.
- Based on the Rubocop feedback, gets devcontainer settings syntax up to speed.