### PR TITLE
Replace deprecated methods

### DIFF
--- a/app/components/account_survey_link_component.rb
+++ b/app/components/account_survey_link_component.rb
@@ -1,4 +1,4 @@
-class AccountSurveyLinkComponent 
+class AccountSurveyLinkComponent
   def initialize(origin:)
     @origin = origin
   end

--- a/app/components/account_survey_link_component.rb
+++ b/app/components/account_survey_link_component.rb
@@ -1,4 +1,4 @@
-class AccountSurveyLinkComponent
+class AccountSurveyLinkComponent < ViewComponent::Base
   def initialize(origin:)
     @origin = origin
   end

--- a/app/components/account_survey_link_component.rb
+++ b/app/components/account_survey_link_component.rb
@@ -1,5 +1,4 @@
 class AccountSurveyLinkComponent 
-  warn_on_deprecated_slot_setter
   def initialize(origin:)
     @origin = origin
   end

--- a/app/components/account_survey_link_component.rb
+++ b/app/components/account_survey_link_component.rb
@@ -1,4 +1,5 @@
-class AccountSurveyLinkComponent < ViewComponent::Base
+class AccountSurveyLinkComponent 
+  warn_on_deprecated_slot_setter
   def initialize(origin:)
     @origin = origin
   end

--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -1,5 +1,4 @@
 class ApplicationComponent < GovukComponent::Base
-  warn_on_deprecated_slot_setter
   attr_reader :classes
 
   def initialize(classes: [], html_attributes: {})

--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -1,4 +1,5 @@
 class ApplicationComponent < GovukComponent::Base
+  warn_on_deprecated_slot_setter
   attr_reader :classes
 
   def initialize(classes: [], html_attributes: {})

--- a/app/components/cookies_banner_component/cookies_banner_component.html.slim
+++ b/app/components/cookies_banner_component/cookies_banner_component.html.slim
@@ -1,8 +1,8 @@
 = tag.div(**html_attributes) do
   = govuk_cookie_banner do |cookie_banner|
-    - cookie_banner.message(heading_text: t("cookies_preferences.banner.heading"), text: t("cookies_preferences.banner.body").join(" ")) do |message|
-      - message.action { govuk_button_to t("cookies_preferences.banner.buttons.accept"), create_path, id: "cookie-consent", data: { action: "click->cookies-banner#submit" } }
-      - message.action { govuk_button_to t("cookies_preferences.banner.buttons.reject"), reject_path, data: { action: "click->cookies-banner#submit" } }
-      - message.action { govuk_link_to t("cookies_preferences.banner.buttons.view"), preferences_path }
+    - cookie_banner.with_message(heading_text: t("cookies_preferences.banner.heading"), text: t("cookies_preferences.banner.body").join(" ")) do |message|
+      - message.with_action { govuk_button_to t("cookies_preferences.banner.buttons.accept"), create_path, id: "cookie-consent", data: { action: "click->cookies-banner#submit" } }
+      - message.with_action { govuk_button_to t("cookies_preferences.banner.buttons.reject"), reject_path, data: { action: "click->cookies-banner#submit" } }
+      - message.with_action { govuk_link_to t("cookies_preferences.banner.buttons.view"), preferences_path }
   end
 end

--- a/app/components/dashboard_component/dashboard_component.html.slim
+++ b/app/components/dashboard_component/dashboard_component.html.slim
@@ -14,7 +14,7 @@
 
   = tabs do |tabs|
     - @vacancy_types.each do |vacancy_type|
-      - tabs.navigation_item text: t("jobs.dashboard.#{vacancy_type}.tab_heading"), link: organisation_jobs_with_type_path(vacancy_type), active: selected_type == vacancy_type
+      - tabs.with_navigation_item text: t("jobs.dashboard.#{vacancy_type}.tab_heading"), link: organisation_jobs_with_type_path(vacancy_type), active: selected_type == vacancy_type
 
   .govuk-grid-row class="govuk-!-margin-bottom-7"
     - if @vacancies.many?
@@ -32,15 +32,15 @@
                       clear_filters_link: { text: t("shared.filter_group.clear_all_filters"), url: publishers_publisher_preference_path(@publisher_preference), method: :delete },
                       options: { remove_filter_links: true, publisher_preference: (@publisher_preference if @organisation.local_authority?) },
                       html_attributes: { tabindex: "-1" }) do |filters_component|
-                        - filters_component.remove_filter_links do |rb|
-                          - rb.group(key: "locations",
+                        - filters_component.with_remove_filter_links do |rb|
+                          - rb.with_group(key: "locations",
                                      selected: @publisher_preference.organisations.map(&:id),
                                      options: @organisation_options,
                                      value_method: :id,
                                      selected_method: :name,
                                      remove_filter_link: { url_helper: :publishers_remove_organisation_filter_path })
 
-                        - filters_component.group key: "locations", component: f.govuk_collection_check_boxes(:organisation_ids, @organisation_options, :id, :label, small: true, legend: { text: "Locations" }, hint: nil, form_group: { data: { action: "change->form#submitListener" } })
+                        - filters_component.with_group key: "locations", component: f.govuk_collection_check_boxes(:organisation_ids, @organisation_options, :id, :label, small: true, legend: { text: "Locations" }, hint: nil, form_group: { data: { action: "change->form#submitListener" } })
 
             = f.hidden_field :jobs_type, value: @selected_type
 
@@ -59,7 +59,7 @@
       - else
         = govuk_summary_list do |summary_list|
           - vacancies.each do |vacancy|
-            - summary_list.row do |row|
+            - summary_list.with_row do |row|
               - row.key do
                 - if vacancy.external?
                   = vacancy.job_title
@@ -112,7 +112,7 @@
                   p.govuk-body-xs.external-notice
                     = t("jobs.manage.external_notice")
               - unless vacancy.external? || vacancy.draft?
-                - row.action(text: t("buttons.copy_listing"),
+                - row.with_action(text: t("buttons.copy_listing"),
                              href: organisation_job_copy_path(vacancy.id),
                              visually_hidden_text: "#{t('buttons.copy_listing')} #{vacancy.job_title}",
                              html_attributes: { "data-method": "post" })

--- a/app/components/previews/filters_component_preview/preview.html.slim
+++ b/app/components/previews/filters_component_preview/preview.html.slim
@@ -3,8 +3,8 @@
 
 = form_for @preview_form, url: preview_view_component_path("#{@preview.preview_name}/#{@example_name}"), html: { method: "get" } do |f|
   = render(@preview_class.new(submit_button: f.govuk_submit(t("buttons.apply_filters")), clear_filters_link: { text: "clear filters", url: "/" }, filters: { total_count: 1 }, options: { heading_text: "Filters preview", remove_filter_links: true })) do |filters_component|
-    - filters_component.remove_filter_links do |rb|
+    - filters_component.with_remove_filter_links do |rb|
       - @preview.options.each do |filter_type|
         - rb.group(**filter_type.merge(remove_filter_link: { url_helper: :jobs_path }))
-    - filters_component.group key: "preview_group_1", component: f.govuk_collection_check_boxes(:options, @preview.options[0][:options], :first, :last, small: true, legend: { text: "filter group" }, hint: nil)
-    - filters_component.group key: "preview_group_2", component: f.govuk_collection_check_boxes(:options, @preview.options[1][:options], :first, :last, small: true, legend: { text: "filter group" }, hint: nil)
+    - filters_component.with_group key: "preview_group_1", component: f.govuk_collection_check_boxes(:options, @preview.options[0][:options], :first, :last, small: true, legend: { text: "filter group" }, hint: nil)
+    - filters_component.with_group key: "preview_group_2", component: f.govuk_collection_check_boxes(:options, @preview.options[1][:options], :first, :last, small: true, legend: { text: "filter group" }, hint: nil)

--- a/app/components/review_component.rb
+++ b/app/components/review_component.rb
@@ -19,7 +19,7 @@ class ReviewComponent < ApplicationComponent
   def before_render
     return unless show_tracks?
 
-    sidebar do
+    with_sidebar do
       render("#{namespace}/build/steps", track_assigns)
     end
   end

--- a/app/components/review_component/section.rb
+++ b/app/components/review_component/section.rb
@@ -23,9 +23,9 @@ class ReviewComponent::Section < ApplicationComponent
   private
 
   def before_render
-    field_div_sets(@forms.map { |f| { form: f } })
+    with_field_div_sets(@forms.map { |f| { form: f } })
 
-    heading(title: heading_text, link_to: [error_link_text, error_path], allow_edit: allow_edit?) do
+    with_heading(title: heading_text, link_to: [error_link_text, error_path], allow_edit: allow_edit?) do
       review_section_tag(@record, @forms.map(&:target_name), @forms)
     end
 

--- a/app/components/supportal_table_component/supportal_table_component.html.slim
+++ b/app/components/supportal_table_component/supportal_table_component.html.slim
@@ -4,7 +4,7 @@
       - @columns.each do |(header, _, type)|
         - row.cell(header: true, text: header, classes: ("column-width--#{type}" if type))
 
-  - table.body do |body|
+  - table.with_body do |body|
     - @entries.each do |entry|
       - body.row do |row|
         - @columns.each do |(_, value_block, _)|

--- a/app/components/vacancy_form_page_heading_component.rb
+++ b/app/components/vacancy_form_page_heading_component.rb
@@ -1,5 +1,6 @@
 class VacancyFormPageHeadingComponent < ViewComponent::Base
   delegate :current_organisation, to: :helpers
+  warn_on_deprecated_slot_setter
 
   def initialize(vacancy, step_process, back_path:, fieldset: true)
     @vacancy = vacancy

--- a/app/components/vacancy_form_page_heading_component.rb
+++ b/app/components/vacancy_form_page_heading_component.rb
@@ -1,6 +1,5 @@
 class VacancyFormPageHeadingComponent < ViewComponent::Base
   delegate :current_organisation, to: :helpers
-  warn_on_deprecated_slot_setter
 
   def initialize(vacancy, step_process, back_path:, fieldset: true)
     @vacancy = vacancy

--- a/app/components/validatable_summary_list_component/error_component.rb
+++ b/app/components/validatable_summary_list_component/error_component.rb
@@ -1,4 +1,5 @@
 class ValidatableSummaryListComponent::ErrorComponent < ViewComponent::Base
+  warn_on_deprecated_slot_setter
   def initialize(*args, errors:, error_path:, **kwargs)
     super(*args, **kwargs)
 

--- a/app/components/validatable_summary_list_component/error_component.rb
+++ b/app/components/validatable_summary_list_component/error_component.rb
@@ -1,5 +1,4 @@
 class ValidatableSummaryListComponent::ErrorComponent < ViewComponent::Base
-  warn_on_deprecated_slot_setter
   def initialize(*args, errors:, error_path:, **kwargs)
     super(*args, **kwargs)
 

--- a/app/views/home/_landing_page_links.html.slim
+++ b/app/views/home/_landing_page_links.html.slim
@@ -1,134 +1,134 @@
 .landing-page-links
   = govuk_accordion do |accordion|
-    - accordion.section(heading_text: t(".jobs_by_school_type_and_role")) do
+    - accordion.with_section(heading_text: t(".jobs_by_school_type_and_role")) do
       = landing_page_link_group title: t(".job_roles"), classes: "govuk-grid-column-one-third" do |group|
-        - group.landing_page "teacher-jobs"
-        - group.landing_page "senior-leader-jobs"
-        - group.landing_page "middle-leader-jobs"
-        - group.landing_page "higher-level-teaching-assistant-jobs"
-        - group.landing_page "teaching-assistant-jobs"
-        - group.landing_page "sendco-jobs"
-        - group.landing_page "education-support-jobs"
-        - group.landing_page "send-responsible-jobs"
-        - group.landing_page "ect-suitable-jobs"
+        - group.with_landing_page "teacher-jobs"
+        - group.with_landing_page "senior-leader-jobs"
+        - group.with_landing_page "middle-leader-jobs"
+        - group.with_landing_page "higher-level-teaching-assistant-jobs"
+        - group.with_landing_page "teaching-assistant-jobs"
+        - group.with_landing_page "sendco-jobs"
+        - group.with_landing_page "education-support-jobs"
+        - group.with_landing_page "send-responsible-jobs"
+        - group.with_landing_page "ect-suitable-jobs"
       = landing_page_link_group title: t(".education_phases"), classes: "govuk-grid-column-one-third" do |group|
-        = group.landing_page "nursery-jobs"
-        = group.landing_page "primary-school-jobs"
-        = group.landing_page "middle-school-jobs"
-        = group.landing_page "secondary-school-jobs"
-        = group.landing_page "sixth-form-or-college-jobs"
-        = group.landing_page "through-school-jobs"
+        = group.with_landing_page "nursery-jobs"
+        = group.with_landing_page "primary-school-jobs"
+        = group.with_landing_page "middle-school-jobs"
+        = group.with_landing_page "secondary-school-jobs"
+        = group.with_landing_page "sixth-form-or-college-jobs"
+        = group.with_landing_page "through-school-jobs"
       = landing_page_link_group title: t(".working_patterns"), classes: "govuk-grid-column-one-third" do |group|
-        = group.landing_page "full-time-school-jobs"
-        = group.landing_page "part-time-school-jobs"
-        = group.landing_page "flexible-working-jobs-in-schools"
-        = group.landing_page "school-job-shares"
-        = group.landing_page "school-term-time-jobs"
+        = group.with_landing_page "full-time-school-jobs"
+        = group.with_landing_page "part-time-school-jobs"
+        = group.with_landing_page "flexible-working-jobs-in-schools"
+        = group.with_landing_page "school-job-shares"
+        = group.with_landing_page "school-term-time-jobs"
 
-    - accordion.section(heading_text: t(".jobs_by_location")) do
+    - accordion.with_section(heading_text: t(".jobs_by_location")) do
       .govuk-grid-column-one-third
         = landing_page_link_group(use_locations: true) do |group|
-          - group.title_landing_page "north-west"
-          - group.landing_page "liverpool"
-          - group.landing_page "manchester"
-          - group.landing_page "lancashire"
-          - group.landing_page "cheshire-east"
-          - group.landing_page "cheshire-west-and-chester"
+          - group.with_title_landing_page "north-west"
+          - group.with_landing_page "liverpool"
+          - group.with_landing_page "manchester"
+          - group.with_landing_page "lancashire"
+          - group.with_landing_page "cheshire-east"
+          - group.with_landing_page "cheshire-west-and-chester"
 
         = landing_page_link_group(use_locations: true) do |group|
-          - group.title_landing_page "yorkshire-and-the-humber"
-          - group.landing_page "sheffield"
-          - group.landing_page "leeds"
-          - group.landing_page "bradford"
-          - group.landing_page "doncaster"
-          - group.landing_page "north-yorkshire"
+          - group.with_title_landing_page "yorkshire-and-the-humber"
+          - group.with_landing_page "sheffield"
+          - group.with_landing_page "leeds"
+          - group.with_landing_page "bradford"
+          - group.with_landing_page "doncaster"
+          - group.with_landing_page "north-yorkshire"
 
         = landing_page_link_group(use_locations: true) do |group|
-          - group.title_landing_page "north-east"
-          - group.landing_page "newcastle-upon-tyne"
-          - group.landing_page "middlesbrough"
-          - group.landing_page "sunderland"
-          - group.landing_page "north-tyneside"
-          - group.landing_page "northumberland"
-
-      .govuk-grid-column-one-third
-        = landing_page_link_group(use_locations: true) do |group|
-          - group.title_landing_page "london"
-          - group.landing_page "bexley"
-          - group.landing_page "havering"
-          - group.landing_page "barnet"
-          - group.landing_page "enfield"
-          - group.landing_page "bromley"
-
-        = landing_page_link_group(use_locations: true) do |group|
-          - group.title_landing_page "south-east"
-          - group.landing_page "hampshire"
-          - group.landing_page "surrey"
-          - group.landing_page "kent"
-          - group.landing_page "west-sussex"
-          - group.landing_page "east-sussex"
-
-        = landing_page_link_group(use_locations: true) do |group|
-          - group.title_landing_page "south-west"
-          - group.landing_page "bristol"
-          - group.landing_page "gloucestershire"
-          - group.landing_page "devon"
-          - group.landing_page "cornwall"
-          - group.landing_page "dorset"
+          - group.with_title_landing_page "north-east"
+          - group.with_landing_page "newcastle-upon-tyne"
+          - group.with_landing_page "middlesbrough"
+          - group.with_landing_page "sunderland"
+          - group.with_landing_page "north-tyneside"
+          - group.with_landing_page "northumberland"
 
       .govuk-grid-column-one-third
         = landing_page_link_group(use_locations: true) do |group|
-          - group.title_landing_page "west-midlands"
-          - group.landing_page "birmingham"
-          - group.landing_page "worcestershire"
-          - group.landing_page "shropshire"
-          - group.landing_page "staffordshire"
-          - group.landing_page "warwickshire"
+          - group.with_title_landing_page "london"
+          - group.with_landing_page "bexley"
+          - group.with_landing_page "havering"
+          - group.with_landing_page "barnet"
+          - group.with_landing_page "enfield"
+          - group.with_landing_page "bromley"
 
         = landing_page_link_group(use_locations: true) do |group|
-          - group.title_landing_page "east-midlands"
-          - group.landing_page "derby"
-          - group.landing_page "nottingham"
-          - group.landing_page "leicester"
-          - group.landing_page "lincolnshire"
-          - group.landing_page "northamptonshire"
+          - group.with_title_landing_page "south-east"
+          - group.with_landing_page "hampshire"
+          - group.with_landing_page "surrey"
+          - group.with_landing_page "kent"
+          - group.with_landing_page "west-sussex"
+          - group.with_landing_page "east-sussex"
 
         = landing_page_link_group(use_locations: true) do |group|
-          - group.title_landing_page "east-of-england"
-          - group.landing_page "essex"
-          - group.landing_page "bedfordshire"
-          - group.landing_page "hertfordshire"
-          - group.landing_page "suffolk"
-          - group.landing_page "norfolk"
+          - group.with_title_landing_page "south-west"
+          - group.with_landing_page "bristol"
+          - group.with_landing_page "gloucestershire"
+          - group.with_landing_page "devon"
+          - group.with_landing_page "cornwall"
+          - group.with_landing_page "dorset"
 
-    - accordion.section(heading_text: t(".jobs_by_subject")) do
+      .govuk-grid-column-one-third
+        = landing_page_link_group(use_locations: true) do |group|
+          - group.with_title_landing_page "west-midlands"
+          - group.with_landing_page "birmingham"
+          - group.with_landing_page "worcestershire"
+          - group.with_landing_page "shropshire"
+          - group.with_landing_page "staffordshire"
+          - group.with_landing_page "warwickshire"
+
+        = landing_page_link_group(use_locations: true) do |group|
+          - group.with_title_landing_page "east-midlands"
+          - group.with_landing_page "derby"
+          - group.with_landing_page "nottingham"
+          - group.with_landing_page "leicester"
+          - group.with_landing_page "lincolnshire"
+          - group.with_landing_page "northamptonshire"
+
+        = landing_page_link_group(use_locations: true) do |group|
+          - group.with_title_landing_page "east-of-england"
+          - group.with_landing_page "essex"
+          - group.with_landing_page "bedfordshire"
+          - group.with_landing_page "hertfordshire"
+          - group.with_landing_page "suffolk"
+          - group.with_landing_page "norfolk"
+
+    - accordion.with_section(heading_text: t(".jobs_by_subject")) do
       = landing_page_link_group classes: "govuk-grid-column-one-third" do |group|
-        - group.landing_page "maths-teacher-jobs"
-        - group.landing_page "english-media-studies-teacher-jobs"
-        - group.landing_page "physical-education-teacher-jobs"
-        - group.landing_page "dance-drama-music-teacher-jobs"
-        - group.landing_page(subgroup: true) do |subgroup|
-          - subgroup.title_landing_page "science-teacher-jobs"
-          - subgroup.landing_page "chemistry-teacher-jobs"
-          - subgroup.landing_page "biology-teacher-jobs"
-          - subgroup.landing_page "physics-teacher-jobs"
+        - group.with_landing_page "maths-teacher-jobs"
+        - group.with_landing_page "english-media-studies-teacher-jobs"
+        - group.with_landing_page "physical-education-teacher-jobs"
+        - group.with_landing_page "dance-drama-music-teacher-jobs"
+        - group.with_landing_page(subgroup: true) do |subgroup|
+          - subgroup.with_title_landing_page "science-teacher-jobs"
+          - subgroup.with_landing_page "chemistry-teacher-jobs"
+          - subgroup.with_landing_page "biology-teacher-jobs"
+          - subgroup.with_landing_page "physics-teacher-jobs"
 
       = landing_page_link_group classes: "govuk-grid-column-one-third" do |group|
-        - group.landing_page "history-teacher-jobs"
-        - group.landing_page "geography-teacher-jobs"
-        - group.landing_page(subgroup: true) do |subgroup|
-          - subgroup.title_landing_page "mfl-teacher-jobs"
-          - subgroup.landing_page "french-teacher-jobs"
-          - subgroup.landing_page "spanish-teacher-jobs"
-          - subgroup.landing_page "german-teacher-jobs"
-          - subgroup.landing_page "mandarin-teacher-jobs"
-          - subgroup.landing_page "classics-latin-teacher-jobs"
+        - group.with_landing_page "history-teacher-jobs"
+        - group.with_landing_page "geography-teacher-jobs"
+        - group.with_landing_page(subgroup: true) do |subgroup|
+          - subgroup.with_title_landing_page "mfl-teacher-jobs"
+          - subgroup.with_landing_page "french-teacher-jobs"
+          - subgroup.with_landing_page "spanish-teacher-jobs"
+          - subgroup.with_landing_page "german-teacher-jobs"
+          - subgroup.with_landing_page "mandarin-teacher-jobs"
+          - subgroup.with_landing_page "classics-latin-teacher-jobs"
 
       = landing_page_link_group classes: "govuk-grid-column-one-third" do |group|
-        - group.landing_page "ict-computer-science-teacher-jobs"
-        - group.landing_page "economics-business-studies-teacher-jobs"
-        - group.landing_page "art-design-technology-teacher-jobs"
-        - group.landing_page "food-technology-teacher-jobs"
-        - group.landing_page "politics-humanities-social-sciences-teacher-jobs"
-        - group.landing_page "psychology-philosophy-sociology-re-teacher-jobs"
-        - group.landing_page "health-relationships-social-care-teacher-jobs"
+        - group.with_landing_page "ict-computer-science-teacher-jobs"
+        - group.with_landing_page "economics-business-studies-teacher-jobs"
+        - group.with_landing_page "art-design-technology-teacher-jobs"
+        - group.with_landing_page "food-technology-teacher-jobs"
+        - group.with_landing_page "politics-humanities-social-sciences-teacher-jobs"
+        - group.with_landing_page "psychology-philosophy-sociology-re-teacher-jobs"
+        - group.with_landing_page "health-relationships-social-care-teacher-jobs"

--- a/app/views/jobseekers/accounts/show.html.slim
+++ b/app/views/jobseekers/accounts/show.html.slim
@@ -5,14 +5,14 @@ h1.govuk-heading-l = t(".page_title")
 .govuk-grid-row
   .govuk-grid-column-full
     = govuk_summary_list do |summary_list|
-      - summary_list.row(html_attributes: { id: "email_address" }) do |row|
-        - row.key text: t(".summary_list.email")
-        - row.value text: current_jobseeker.email
-        - row.action(text: t("buttons.change"), href: edit_jobseeker_registration_path, visually_hidden_text: t(".summary_list.email"))
+      - summary_list.with_row(html_attributes: { id: "email_address" }) do |row|
+        - row.with_key text: t(".summary_list.email")
+        - row.with_value text: current_jobseeker.email
+        - row.with_action(text: t("buttons.change"), href: edit_jobseeker_registration_path, visually_hidden_text: t(".summary_list.email"))
 
-      - summary_list.row(html_attributes: { id: "password" }) do |row|
-        - row.key text: t(".summary_list.password")
-        - row.value text: t(".summary_list.password_placeholder")
-        - row.action(text: t("buttons.change"), href: edit_jobseeker_registration_path(password_update: true), visually_hidden_text: t(".summary_list.password"))
+      - summary_list.with_row(html_attributes: { id: "password" }) do |row|
+        - row.with_key text: t(".summary_list.password")
+        - row.with_value text: t(".summary_list.password_placeholder")
+        - row.with_action(text: t("buttons.change"), href: edit_jobseeker_registration_path(password_update: true), visually_hidden_text: t(".summary_list.password"))
 
     p = govuk_link_to t(".close_account"), jobseekers_confirm_destroy_account_path

--- a/app/views/jobseekers/employments/_employments.html.slim
+++ b/app/views/jobseekers/employments/_employments.html.slim
@@ -1,6 +1,6 @@
 - employments.sort_by { |e| e.current_role? ? Float::INFINITY : e.started_on }.reverse_each do |employment|
   = render DetailComponent.new(title: employment.job_title) do |detail_component|
-    - detail_component.body do
+    - detail_component.with_body do
       = govuk_summary_list(classes: "govuk-!-margin-bottom-0") do |summary_list|
         - summary_list.row(classes: "govuk-summary-list__row--no-actions") do |row|
           - row.key text: t("jobseekers.employments.organisation")
@@ -18,5 +18,5 @@
         - summary_list.row(classes: "govuk-summary-list__row--no-actions") do |row|
           - row.key text: t("jobseekers.employments.main_duties")
           - row.value text: employment.main_duties
-    - detail_component.action govuk_link_to(t("buttons.change_hidden_text_html", hidden_text: employment.job_title), edit_jobseekers_profile_work_history_path(employment))
-    - detail_component.action govuk_link_to(t("buttons.delete_hidden_text_html", hidden_text: employment.job_title), jobseekers_profile_work_history_path(employment), method: :delete)
+    - detail_component.with_action govuk_link_to(t("buttons.change_hidden_text_html", hidden_text: employment.job_title), edit_jobseekers_profile_work_history_path(employment))
+    - detail_component.with_action govuk_link_to(t("buttons.delete_hidden_text_html", hidden_text: employment.job_title), jobseekers_profile_work_history_path(employment), method: :delete)

--- a/app/views/jobseekers/job_applications/_job_application.html.slim
+++ b/app/views/jobseekers/job_applications/_job_application.html.slim
@@ -1,11 +1,11 @@
 - job_application_link = job_application.draft? ? jobseekers_job_application_review_path(job_application) : jobseekers_job_application_path(job_application)
 
 = render CardComponent.new do |card|
-  - card.header do
+  - card.with_header do
     = tag.div(govuk_link_to(job_application.vacancy.job_title, job_application_link, class: "govuk-link--no-visited-state"))
     = tag.div(vacancy_job_location(job_application.vacancy))
 
-  - card.body do
+  - card.with_body do
     - case job_application.status
     - when "draft"
       = tag.div(card.labelled_item(t(".last_edited"), format_time_to_datetime_at(job_application.updated_at)))
@@ -19,6 +19,6 @@
     = tag.div(card.labelled_item(t(".closing_date"), format_time_to_datetime_at(job_application.vacancy.expires_at)))
 
   - if job_application.draft? && job_application.vacancy.expired?
-    - card.action_item link: job_application_status_tag(:deadline_passed)
+    - card.with_action_item link: job_application_status_tag(:deadline_passed)
   - else
-    - card.action_item link: job_application_status_tag(job_application.status)
+    - card.with_action_item link: job_application_status_tag(job_application.status)

--- a/app/views/jobseekers/job_applications/_show.html.slim
+++ b/app/views/jobseekers/job_applications/_show.html.slim
@@ -1,34 +1,34 @@
 = job_application_review(job_application, step_process: step_process, show_tracks: false, allow_edit: local_assigns[:allow_edit]) do |r|
   - render "jobseekers/job_applications/job_application_review_sections", r: r
-  - r.above do
+  - r.with_above do
     = yield
 
-    .anchor-link-list class="govuk-!-display-none-print"
+    .with_anchor-link-list class="govuk-!-display-none-print"
       = navigation_list(title: t(".application_sections")) do |navigation|
-        - navigation.anchor text: t(".personal_details.heading"), href: "#personal_details"
-        - navigation.anchor text: t(".professional_status.heading"), href: "#professional_status"
-        - navigation.anchor text: t(".qualifications.heading"), href: "#qualifications"
-        - navigation.anchor text: t(".employment_history.heading"), href: "#employment_history"
-        - navigation.anchor text: t(".personal_statement.heading"), href: "#personal_statement"
-        - navigation.anchor text: t(".references.heading"), href: "#references"
-        - navigation.anchor text: t(".ask_for_support.heading"), href: "#ask_for_support"
-        - navigation.anchor text: t(".declarations.heading"), href: "#declarations"
+        - navigation.with_anchor text: t(".personal_details.heading"), href: "#personal_details"
+        - navigation.with_anchor text: t(".professional_status.heading"), href: "#professional_status"
+        - navigation.with_anchor text: t(".qualifications.heading"), href: "#qualifications"
+        - navigation.with_anchor text: t(".employment_history.heading"), href: "#employment_history"
+        - navigation.with_anchor text: t(".personal_statement.heading"), href: "#personal_statement"
+        - navigation.with_anchor text: t(".references.heading"), href: "#references"
+        - navigation.with_anchor text: t(".ask_for_support.heading"), href: "#ask_for_support"
+        - navigation.with_anchor text: t(".declarations.heading"), href: "#declarations"
 
-  - r.sidebar(classes: %w[govuk-!-display-none-print]) do
+  - r.with_sidebar(classes: %w[govuk-!-display-none-print]) do
     h2.govuk-heading-m = t(".timeline")
 
     = render TimelineComponent.new do |timeline|
       - if job_application.withdrawn_at?
-        - timeline.item(key: t("jobseekers.job_applications.status_timestamps.withdrawn"),
+        - timeline.with_item(key: t("jobseekers.job_applications.status_timestamps.withdrawn"),
                         value: format_time_to_datetime_at(job_application.withdrawn_at))
       - if job_application.unsuccessful_at?
-        - timeline.item(key: t("jobseekers.job_applications.status_timestamps.#{current_jobseeker.present? ? 'unsuccessful' : 'rejected'}"),
+        - timeline.with_item(key: t("jobseekers.job_applications.status_timestamps.#{current_jobseeker.present? ? 'unsuccessful' : 'rejected'}"),
                         value: format_time_to_datetime_at(job_application.unsuccessful_at))
       - if job_application.shortlisted_at?
-        - timeline.item(key: t("jobseekers.job_applications.status_timestamps.shortlisted"),
+        - timeline.with_item(key: t("jobseekers.job_applications.status_timestamps.shortlisted"),
                         value: format_time_to_datetime_at(job_application.shortlisted_at))
       - if job_application.reviewed_at?
-        - timeline.item(key: t("jobseekers.job_applications.status_timestamps.reviewed"),
+        - timeline.with_item(key: t("jobseekers.job_applications.status_timestamps.reviewed"),
                         value: format_time_to_datetime_at(job_application.reviewed_at))
-      - timeline.item(key: t("jobseekers.job_applications.status_timestamps.submitted"),
+      - timeline.with_item(key: t("jobseekers.job_applications.status_timestamps.submitted"),
                       value: format_time_to_datetime_at(job_application.submitted_at))

--- a/app/views/jobseekers/job_applications/build/_steps.html.slim
+++ b/app/views/jobseekers/job_applications/build/_steps.html.slim
@@ -1,4 +1,4 @@
 = render StepsComponent.new title: t("jobseekers.job_applications.review.steps"), classes: "govuk-!-margin-top-6" do |component|
   - step_process.step_groups.keys.excluding(:review).each do |wizard_step|
-    - component.step(label: t("jobseekers.job_applications.build.#{wizard_step}.step_title"), current: (wizard_step == step_process.current_step_group), completed: wizard_step.to_s.in?(job_application.completed_steps))
-  - component.step(label: t("jobseekers.job_applications.review.heading"), current: false, completed: false)
+    - component.with_step(label: t("jobseekers.job_applications.build.#{wizard_step}.step_title"), current: (wizard_step == step_process.current_step_group), completed: wizard_step.to_s.in?(job_application.completed_steps))
+  - component.with_step(label: t("jobseekers.job_applications.review.heading"), current: false, completed: false)

--- a/app/views/jobseekers/job_applications/build/employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/build/employment_history.html.slim
@@ -15,7 +15,7 @@
       - employments.each_with_index do |employment, index|
         - if employment.job?
           = render DetailComponent.new title: employment.job_title do |detail|
-            - detail.body do
+            - detail.with_body do
               = govuk_summary_list classes: "govuk-!-margin-bottom-0" do |summary_list|
                 - summary_list.row do |row|
                   - row.key text: t("jobseekers.job_applications.employments.organisation")
@@ -41,8 +41,8 @@
                   - row.key text: t("jobseekers.job_applications.employments.main_duties")
                   - row.value text: employment.main_duties
 
-            - detail.action govuk_link_to t("buttons.change_hidden_text_html", hidden_text: employment.job_title), edit_jobseekers_job_application_employment_path(job_application, employment), class: "govuk-link--no-visited-state"
-            - detail.action govuk_link_to t("buttons.delete_hidden_text_html", hidden_text: employment.job_title), jobseekers_job_application_employment_path(job_application, employment), method: :delete
+            - detail.with_action govuk_link_to t("buttons.change_hidden_text_html", hidden_text: employment.job_title), edit_jobseekers_job_application_employment_path(job_application, employment), class: "govuk-link--no-visited-state"
+            - detail.with_action govuk_link_to t("buttons.delete_hidden_text_html", hidden_text: employment.job_title), jobseekers_job_application_employment_path(job_application, employment), method: :delete
 
         - elsif employment.break?
           = govuk_inset_text do

--- a/app/views/jobseekers/job_applications/build/qualifications.html.slim
+++ b/app/views/jobseekers/job_applications/build/qualifications.html.slim
@@ -16,7 +16,7 @@
       - qualifications_sort_and_group(job_application.qualifications).each_value do |qualification_group|
         - qualification_group.each do |qualification|
           = render DetailComponent.new title: qualification.name do |detail|
-            - detail.body do
+            - detail.with_body do
               = govuk_summary_list classes: "govuk-!-margin-bottom-0" do |summary_list|
                 - if qualification.secondary?
                   - summary_list.row do |row|
@@ -34,9 +34,9 @@
                     - row.value text: safe_join([tag.div(t("helpers.label.jobseekers_qualifications_shared_labels.finished_studying_options.#{qualification.finished_studying}"), class: "govuk-body"), tag.div(qualification.finished_studying_details.presence, class: "govuk-body")])
 
             - if qualification.secondary?
-              - detail.action govuk_link_to t("buttons.add_another_subject"), edit_jobseekers_job_application_qualification_path(job_application, qualification, new_subject: true), class: "govuk-link--no-visited-state"
-            - detail.action govuk_link_to t("buttons.change"), edit_jobseekers_job_application_qualification_path(job_application, qualification), class: "govuk-link--no-visited-state"
-            - detail.action govuk_link_to t("buttons.delete"), jobseekers_job_application_qualification_path(job_application, qualification), method: :delete
+              - detail.with_action govuk_link_to t("buttons.add_another_subject"), edit_jobseekers_job_application_qualification_path(job_application, qualification, new_subject: true), class: "govuk-link--no-visited-state"
+            - detail.with_action govuk_link_to t("buttons.change"), edit_jobseekers_job_application_qualification_path(job_application, qualification), class: "govuk-link--no-visited-state"
+            - detail.with_action govuk_link_to t("buttons.delete"), jobseekers_job_application_qualification_path(job_application, qualification), method: :delete
 
       = govuk_button_link_to t("buttons.add_another_qualification"), select_category_jobseekers_job_application_qualifications_path(job_application), class: "govuk-button--secondary"
     - else

--- a/app/views/jobseekers/job_applications/build/references.html.slim
+++ b/app/views/jobseekers/job_applications/build/references.html.slim
@@ -13,7 +13,7 @@
     - if job_application.references.any?
       - job_application.references.each do |reference|
         = render DetailComponent.new title: reference.name do |detail|
-          - detail.body do
+          - detail.with_body do
             = govuk_summary_list classes: "govuk-!-margin-bottom-0" do |summary_list|
               - attributes = %w[job_title organisation relationship email phone_number]
               - attributes.each do |attribute|
@@ -22,8 +22,8 @@
                     - row.key text: t("jobseekers.job_applications.references.#{attribute}")
                     - row.value text: reference[attribute]
 
-          - detail.action govuk_link_to t("buttons.change"), edit_jobseekers_job_application_reference_path(job_application, reference), class: "govuk-link--no-visited-state"
-          - detail.action govuk_link_to t("buttons.delete"), jobseekers_job_application_reference_path(job_application, reference), method: :delete
+          - detail.with_action govuk_link_to t("buttons.change"), edit_jobseekers_job_application_reference_path(job_application, reference), class: "govuk-link--no-visited-state"
+          - detail.with_action govuk_link_to t("buttons.delete"), jobseekers_job_application_reference_path(job_application, reference), method: :delete
 
       = govuk_button_link_to t("buttons.add_another_reference"), new_jobseekers_job_application_reference_path(job_application)
     - else

--- a/app/views/jobseekers/job_applications/review.html.slim
+++ b/app/views/jobseekers/job_applications/review.html.slim
@@ -1,10 +1,10 @@
 - content_for :page_title_prefix, job_application_page_title_prefix(review_form, t(".title"))
 
 = job_application_review(@job_application, step_process: step_process, show_tracks: current_jobseeker.job_applications.not_draft.none?) do |r|
-  - r.header do
+  - r.with_header do
     = render "banner"
 
-  - r.above do
+  - r.with_above do
     - unless vacancy.listed?
       = govuk_notification_banner title_text: t("banners.important") do
         p.govuk-body = t(".deadline_passed")
@@ -20,7 +20,7 @@
 
   - render "job_application_review_sections", r: r
 
-  - r.below do
+  - r.with_below do
     - unless @job_application.deadline_passed?
       = form_for review_form, url: jobseekers_job_application_submit_path(job_application), method: :post do |f|
         = f.govuk_error_summary

--- a/app/views/jobseekers/job_applications/review/_ask_for_support.html.slim
+++ b/app/views/jobseekers/job_applications/review/_ask_for_support.html.slim
@@ -1,4 +1,4 @@
-- r.section :ask_for_support do |s|
+- r.with_section :ask_for_support do |s|
   - s.row do |row|
     - row.key text: t("helpers.legend.jobseekers_job_application_ask_for_support_form.support_needed")
     - row.value text: job_application_support_needed_info(job_application)

--- a/app/views/jobseekers/job_applications/review/_declarations.html.slim
+++ b/app/views/jobseekers/job_applications/review/_declarations.html.slim
@@ -1,4 +1,4 @@
-- r.section :declarations do |s|
+- r.with_section :declarations do |s|
   - s.row do |row|
     - row.key text: t("helpers.legend.jobseekers_job_application_declarations_form.close_relationships", organisation: vacancy.organisation_name)
     - row.value text: job_application_close_relationships_info(job_application)

--- a/app/views/jobseekers/job_applications/review/_employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/review/_employment_history.html.slim
@@ -1,4 +1,4 @@
-- r.section :employment_history
+- r.with_section :employment_history
   - if job_application.employments.none?
     - if jobseeker_signed_in?
       p.govuk-body = t("jobseekers.job_applications.review.employment_history.none")

--- a/app/views/jobseekers/job_applications/review/_equal_opportunities.html.slim
+++ b/app/views/jobseekers/job_applications/review/_equal_opportunities.html.slim
@@ -1,4 +1,4 @@
-- r.section :equal_opportunities do |s|
+- r.with_section :equal_opportunities do |s|
   - s.row do |row|
     - row.key text: t("helpers.legend.jobseekers_job_application_equal_opportunities_form.disability")
     - row.value text: job_application.disability.humanize

--- a/app/views/jobseekers/job_applications/review/_personal_details.html.slim
+++ b/app/views/jobseekers/job_applications/review/_personal_details.html.slim
@@ -1,4 +1,4 @@
-- r.section :personal_details do |s|
+- r.with_section :personal_details do |s|
   - s.row do |row|
     - row.key text: t("helpers.label.jobseekers_job_application_personal_details_form.first_name")
     - row.value text: job_application.first_name

--- a/app/views/jobseekers/job_applications/review/_personal_statement.html.slim
+++ b/app/views/jobseekers/job_applications/review/_personal_statement.html.slim
@@ -1,4 +1,4 @@
-- r.section :personal_statement
+- r.with_section :personal_statement
   - if job_application.personal_statement.present?
     .govuk-body.review-component__section__body--border = simple_format(job_application.personal_statement)
   - else

--- a/app/views/jobseekers/job_applications/review/_professional_status.html.slim
+++ b/app/views/jobseekers/job_applications/review/_professional_status.html.slim
@@ -1,4 +1,4 @@
-- r.section :professional_status do |s|
+- r.with_section :professional_status do |s|
   - s.row do |row|
     - row.key text: t("helpers.legend.jobseekers_job_application_professional_status_form.qualified_teacher_status")
     - row.value text: job_application_qualified_teacher_status_info(job_application)

--- a/app/views/jobseekers/job_applications/review/_qualifications.html.slim
+++ b/app/views/jobseekers/job_applications/review/_qualifications.html.slim
@@ -1,4 +1,4 @@
-- r.section :qualifications
+- r.with_section :qualifications
   - if job_application.qualifications.none?
     - if jobseeker_signed_in?
       p.govuk-body = t("jobseekers.job_applications.review.qualifications.none")

--- a/app/views/jobseekers/job_applications/review/_references.html.slim
+++ b/app/views/jobseekers/job_applications/review/_references.html.slim
@@ -1,4 +1,4 @@
-- r.section :references
+- r.with_section :references
   - if job_application.references.none?
     - if jobseeker_signed_in?
       p.govuk-body = t("jobseekers.job_applications.review.employment_history.none")

--- a/app/views/jobseekers/job_applications/show.html.slim
+++ b/app/views/jobseekers/job_applications/show.html.slim
@@ -5,7 +5,7 @@
 = render "jobseekers/job_applications/show" do
   - if job_application.shortlisted?
     = govuk_notification_banner title_text: t("banners.important"), classes: "govuk-!-margin-bottom-5" do |banner|
-      - banner.heading text: t(".shortlist_alert.title")
+      - banner.with_heading text: t(".shortlist_alert.title")
       span class="govuk-!-margin-top-3" = t(".shortlist_alert.body", organisation: vacancy.organisation_name)
 
   - if job_application.unsuccessful? && job_application.rejection_reasons.present?

--- a/app/views/jobseekers/profiles/about_you/_summary.html.slim
+++ b/app/views/jobseekers/profiles/about_you/_summary.html.slim
@@ -1,5 +1,5 @@
 = govuk_summary_list do |summary_list|
   - summary_list.row do |row|
-    - row.key text: t(".about_you_title")
-    - row.value text: simple_format(profile.about_you)
-    - row.action(text: t("buttons.change"), href: edit_jobseekers_profile_about_you_path)
+    - row.with_key text: t(".about_you_title")
+    - row.with_value text: simple_format(profile.about_you)
+    - row.with_action(text: t("buttons.change"), href: edit_jobseekers_profile_about_you_path)

--- a/app/views/jobseekers/profiles/hide_profile/_summary.html.slim
+++ b/app/views/jobseekers/profiles/hide_profile/_summary.html.slim
@@ -2,12 +2,12 @@ p = govuk_link_to(t(".add_a_school"), add_jobseekers_profile_hide_profile_path) 
 
 = govuk_summary_list do |summary_list|
   = summary_list.row do |row|
-    - row.key(text: t(".hide_profile"))
-    - row.value(text: profile.hidden_from_any_organisations? ? "Yes" : "No")
-    - row.action(text: t("buttons.change"), href: jobseekers_profile_hide_profile_path)
+    - row.with_key(text: t(".hide_profile"))
+    - row.with_value(text: profile.hidden_from_any_organisations? ? "Yes" : "No")
+    - row.with_action(text: t("buttons.change"), href: jobseekers_profile_hide_profile_path)
 
   - profile.organisation_exclusions.each do |exclusion|
     = summary_list.row do |row|
-      - row.key(text: exclusion.organisation.name)
-      - row.value(text: exclusion.organisation.address)
-      - row.action(text: t("buttons.change"), href: schools_jobseekers_profile_hide_profile_path)
+      - row.with_key(text: exclusion.organisation.name)
+      - row.with_value(text: exclusion.organisation.address)
+      - row.with_action(text: t("buttons.change"), href: schools_jobseekers_profile_hide_profile_path)

--- a/app/views/jobseekers/profiles/hide_profile/schools.html.slim
+++ b/app/views/jobseekers/profiles/hide_profile/schools.html.slim
@@ -13,12 +13,12 @@
       = govuk_summary_list do |summary_list|
         - profile.organisation_exclusions.each do |exclusion|
           = summary_list.row do |row|
-            - row.key(text: exclusion.organisation.name)
-            - row.value do
+            - row.with_key(text: exclusion.organisation.name)
+            - row.with_value do
               = exclusion.organisation.address
               - if exclusion.organisation.trust?
                 = govuk_inset_text(text: t(".hidden_from_trust_and_schools"), classes: "govuk-!-margin-top-6")
-            - row.action(text: t("buttons.delete"), href: delete_jobseekers_profile_hide_profile_path(exclusion))
+            - row.with_action(text: t("buttons.delete"), href: delete_jobseekers_profile_hide_profile_path(exclusion))
 
       = f.govuk_collection_radio_buttons :add_another,
         [["Yes", true], ["No", false]],

--- a/app/views/jobseekers/profiles/job_preferences/_summary.html.slim
+++ b/app/views/jobseekers/profiles/job_preferences/_summary.html.slim
@@ -43,9 +43,9 @@ ruby:
       end
 
       summary_list.row do |row|
-        row.key text: t(".#{attribute}", count:)
-        row.value text: value.presence || options[:blank]
-        row.action(text: t("buttons.change"), href: jobseekers_job_preferences_step_path(step: step_name))
+        row.with_key text: t(".#{attribute}", count:)
+        row.with_value text: value.presence || options[:blank]
+        row.with_action(text: t("buttons.change"), href: jobseekers_job_preferences_step_path(step: step_name))
       end
     end
   end

--- a/app/views/jobseekers/profiles/job_preferences/locations.html.slim
+++ b/app/views/jobseekers/profiles/job_preferences/locations.html.slim
@@ -14,10 +14,10 @@
       = govuk_summary_list(classes: "locations-summary-list") do |summary_list|
         = @form.locations.each.with_index do |(id, location), index|
           - summary_list.row do |row|
-            - row.key text: "Location #{index + 1}"
-            - row.value text: "#{location[:location]} (#{t 'jobs.search.number_of_miles', count: location[:radius].to_i})"
-            - row.action(text: t("buttons.change"), href: { action: :update_location, id: id })
-            - row.action(text: t("buttons.delete"), href: { action: :delete_location, id: id })
+            - row.with_key text: "Location #{index + 1}"
+            - row.with_value text: "#{location[:location]} (#{t 'jobs.search.number_of_miles', count: location[:radius].to_i})"
+            - row.with_action(text: t("buttons.change"), href: { action: :update_location, id: id })
+            - row.with_action(text: t("buttons.delete"), href: { action: :delete_location, id: id })
 
       = f.hidden_field :add_location, value: ""
       = f.govuk_radio_buttons_fieldset(:add_location, legend: { size: "m", text: "Do you want to add another location?" }) do

--- a/app/views/jobseekers/profiles/personal_details/_summary.html.slim
+++ b/app/views/jobseekers/profiles/personal_details/_summary.html.slim
@@ -19,15 +19,15 @@ ruby:
       end
 
       summary_list.row do |row|
-        row.key text: t(".#{attribute}")
-        row.value text: value
-        row.action(text: t("buttons.change"), href: edit_personal_details_jobseekers_profile_path(step: step_name))
+        row.with_key text: t(".#{attribute}")
+        row.with_value text: value
+        row.with_action(text: t("buttons.change"), href: edit_personal_details_jobseekers_profile_path(step: step_name))
       end
     end
 
     summary_list.row do |row|
-      row.key text: t(".email")
-      row.value text: (current_jobseeker.email +
+      row.with_key text: t(".email")
+      row.with_value text: (current_jobseeker.email +
                        govuk_inset_text(text: t("helpers.label.personal_details_form.change_email_html",
                                               link: govuk_link_to(t("helpers.label.personal_details_form.change_email_link_text"),
                                                     jobseekers_account_path)),

--- a/app/views/jobseekers/profiles/qualified_teacher_status/_summary.html.slim
+++ b/app/views/jobseekers/profiles/qualified_teacher_status/_summary.html.slim
@@ -1,11 +1,11 @@
 = govuk_summary_list do |summary_list|
   - summary_list.row do |row|
-    - row.key text: t(".status_title")
-    - row.value text: t("helpers.label.jobseekers_profile_qualified_teacher_status_form.qualified_teacher_status_options.#{profile.qualified_teacher_status}")
-    - row.action(text: t("buttons.change"), href: edit_jobseekers_profile_qualified_teacher_status_path)
+    - row.with_key text: t(".status_title")
+    - row.with_value text: t("helpers.label.jobseekers_profile_qualified_teacher_status_form.qualified_teacher_status_options.#{profile.qualified_teacher_status}")
+    - row.with_action(text: t("buttons.change"), href: edit_jobseekers_profile_qualified_teacher_status_path)
 
   - if profile.qualified_teacher_status_year.present?
     - summary_list.row do |row|
-      - row.key text: t(".year_title")
-      - row.value text: profile.qualified_teacher_status_year
-      - row.action(text: t("buttons.change"), href: edit_jobseekers_profile_qualified_teacher_status_path)
+      - row.with_key text: t(".year_title")
+      - row.with_value text: profile.qualified_teacher_status_year
+      - row.with_action(text: t("buttons.change"), href: edit_jobseekers_profile_qualified_teacher_status_path)

--- a/app/views/jobseekers/qualifications/_qualifications.html.slim
+++ b/app/views/jobseekers/qualifications/_qualifications.html.slim
@@ -1,24 +1,24 @@
 - qualifications_sort_and_group(qualifications).each_value do |qualification_group|
   - qualification_group.each do |qualification|
     = render DetailComponent.new title: qualification.name do |detail|
-      - detail.body do
+      - detail.with_body do
         = govuk_summary_list classes: "govuk-!-margin-bottom-0" do |summary_list|
           - if qualification.secondary?
             - summary_list.row do |row|
-              - row.key text: t("jobseekers.profiles.qualifications.subjects_and_grades")
-              - row.value text: safe_join(qualification.qualification_results.map { |res| tag.div("#{res.subject} – #{res.grade}", class: "govuk-body govuk-!-margin-bottom-1") })
+              - row.with_key text: t("jobseekers.profiles.qualifications.subjects_and_grades")
+              - row.with_value text: safe_join(qualification.qualification_results.map { |res| tag.div("#{res.subject} – #{res.grade}", class: "govuk-body govuk-!-margin-bottom-1") })
 
           - qualification.display_attributes.each do |attribute|
             - summary_list.row do |row|
-              - row.key text: t("helpers.label.#{qualification_form_param_key(qualification.category)}.#{attribute}")
-              - row.value text: qualification[attribute]
+              - row.with_key text: t("helpers.label.#{qualification_form_param_key(qualification.category)}.#{attribute}")
+              - row.with_value text: qualification[attribute]
 
           - unless qualification.finished_studying.nil?
             - summary_list.row do |row|
-              - row.key text: t("helpers.legend.#{qualification_form_param_key(qualification.category)}.finished_studying")
-              - row.value text: safe_join([tag.div(t("helpers.label.jobseekers_qualifications_shared_labels.finished_studying_options.#{qualification.finished_studying}"), class: "govuk-body"), tag.div(qualification.finished_studying_details.presence, class: "govuk-body")])
+              - row.with_key text: t("helpers.legend.#{qualification_form_param_key(qualification.category)}.finished_studying")
+              - row.with_value text: safe_join([tag.div(t("helpers.label.jobseekers_qualifications_shared_labels.finished_studying_options.#{qualification.finished_studying}"), class: "govuk-body"), tag.div(qualification.finished_studying_details.presence, class: "govuk-body")])
 
       - if qualification.secondary?
-        - detail.action govuk_link_to t("buttons.add_another_subject"), edit_jobseekers_profile_qualification_path(qualification, new_subject: true), class: "govuk-link--no-visited-state"
-      - detail.action govuk_link_to t("buttons.change"), edit_jobseekers_profile_qualification_path(qualification), class: "govuk-link--no-visited-state"
-      - detail.action govuk_link_to t("buttons.delete"), jobseekers_profile_qualification_confirm_destroy_path(qualification)
+        - detail.with_action govuk_link_to t("buttons.add_another_subject"), edit_jobseekers_profile_qualification_path(qualification, new_subject: true), class: "govuk-link--no-visited-state"
+      - detail.with_action govuk_link_to t("buttons.change"), edit_jobseekers_profile_qualification_path(qualification), class: "govuk-link--no-visited-state"
+      - detail.with_action govuk_link_to t("buttons.delete"), jobseekers_profile_qualification_confirm_destroy_path(qualification)

--- a/app/views/jobseekers/saved_jobs/index.html.slim
+++ b/app/views/jobseekers/saved_jobs/index.html.slim
@@ -18,23 +18,23 @@ h1.govuk-heading-l = t(".page_title")
       #vacancy-results
         - saved_jobs.each do |saved_job|
           = render CardComponent.new do |card|
-            - card.header do
+            - card.with_header do
               = tag.div(govuk_link_to(saved_job.vacancy.job_title, job_path(saved_job.vacancy), class: "govuk-link--no-visited-state"))
               = tag.div(vacancy_job_location(saved_job.vacancy))
 
-            - card.body do
+            - card.with_body do
               = tag.div(card.labelled_item(t(".added"), format_date(saved_job.created_at, :date_only)))
               - if saved_job.vacancy.expired?
                 = tag.div(t(".deadline_passed"), class: "govuk-!-font-weight-bold text-red")
               = tag.div(card.labelled_item(t(".application_deadline"), format_time_to_datetime_at(saved_job.vacancy.expires_at)))
 
             - if saved_job.vacancy.enable_job_applications? && Vacancy.live.exists?(saved_job.vacancy.id) && current_jobseeker.job_applications.after_submission.find_by(vacancy_id: saved_job.vacancy.id).present?
-              - card.action_item link: govuk_link_to(safe_join([t(".view"), tag.span(" for #{saved_job.vacancy.job_title}", class: "govuk-visually-hidden")]), jobseekers_job_application_path(JobApplication.find_by(vacancy_id: saved_job.vacancy.id)))
+              - card.with_action_item link: govuk_link_to(safe_join([t(".view"), tag.span(" for #{saved_job.vacancy.job_title}", class: "govuk-visually-hidden")]), jobseekers_job_application_path(JobApplication.find_by(vacancy_id: saved_job.vacancy.id)))
             - elsif saved_job.vacancy.enable_job_applications? && Vacancy.live.exists?(saved_job.vacancy.id) && current_jobseeker.job_applications.draft.find_by(vacancy_id: saved_job.vacancy.id).present?
-              - card.action_item link: govuk_link_to(safe_join([t(".continue"), tag.span(" for #{saved_job.vacancy.job_title}", class: "govuk-visually-hidden")]), jobseekers_job_application_review_path(JobApplication.find_by(vacancy_id: saved_job.vacancy.id)))
+              - card.with_action_item link: govuk_link_to(safe_join([t(".continue"), tag.span(" for #{saved_job.vacancy.job_title}", class: "govuk-visually-hidden")]), jobseekers_job_application_review_path(JobApplication.find_by(vacancy_id: saved_job.vacancy.id)))
             - elsif saved_job.vacancy.enable_job_applications? && Vacancy.live.exists?(saved_job.vacancy.id)
-              - card.action_item link: govuk_link_to(safe_join([t(".apply"), tag.span(" for #{saved_job.vacancy.job_title}", class: "govuk-visually-hidden")]), new_jobseekers_job_job_application_path(saved_job.vacancy.id))
-            - card.action_item link: govuk_link_to(safe_join([t(".delete"), tag.span(" for #{saved_job.vacancy.job_title}", class: "govuk-visually-hidden")]), jobseekers_saved_job_path(saved_job.vacancy.id, saved_job, redirect_to_dashboard: true), method: :delete)
+              - card.with_action_item link: govuk_link_to(safe_join([t(".apply"), tag.span(" for #{saved_job.vacancy.job_title}", class: "govuk-visually-hidden")]), new_jobseekers_job_job_application_path(saved_job.vacancy.id))
+            - card.with_action_item link: govuk_link_to(safe_join([t(".delete"), tag.span(" for #{saved_job.vacancy.job_title}", class: "govuk-visually-hidden")]), jobseekers_saved_job_path(saved_job.vacancy.id, saved_job, redirect_to_dashboard: true), method: :delete)
 
     - else
       = render EmptySectionComponent.new title: t(".zero_saved_jobs_title") do

--- a/app/views/jobseekers/subscriptions/index.html.slim
+++ b/app/views/jobseekers/subscriptions/index.html.slim
@@ -13,14 +13,14 @@ h1.govuk-heading-l = t(".page_title")
           = govuk_button_link_to t(".button_create"), new_subscription_path
           - subscriptions.each do |subscription|
             = render CardComponent.new do |card|
-              - card.header do
+              - card.with_header do
                 - subscription.filtered_search_criteria.each_pair do |filter, value|
                   = tag.div(card.labelled_item(filter.humanize, value))
                 .govuk-button-group class="govuk-!-margin-top-2"
                   = govuk_button_link_to(t(".link_manage"), edit_subscription_path(subscription.token), secondary: true)
                   = govuk_link_to(t(".link_unsubscribe"), unsubscribe_subscription_path(subscription.token))
 
-              - card.body do
+              - card.with_body do
                 section data-controller="form"
                   = form_for subscription, url: subscription_path(subscription.token), html: { method: "patch", data: { "hide-submit": true } } do |f|
                     = f.govuk_collection_radio_buttons :frequency, Subscription.frequencies.keys, :to_s, form_group: { data: { action: "change->form#submitListener" } }, inline: true

--- a/app/views/layouts/_flash_messages.html.slim
+++ b/app/views/layouts/_flash_messages.html.slim
@@ -1,4 +1,4 @@
 - flash.each do |variant, message|
   - next unless variant.in? t("banners").keys.map(&:to_s)
   = govuk_notification_banner title_text: t("banners.#{variant}"), classes: "govuk-notification-banner--#{variant} govuk-!-margin-top-3 govuk-!-margin-bottom-0" do |notification_banner|
-    - notification_banner.heading(text: message)
+    - notification_banner.with_heading(text: message)

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -1,21 +1,21 @@
 = govuk_header do |header|
-  - header.product_name(name: t("app.title"))
+  - header.with_product_name(name: t("app.title"))
   - if publisher_signed_in?
-    = header.navigation_item text: t("nav.manage_jobs"), href: organisation_jobs_with_type_path, active: manage_jobs_active?
-    = header.navigation_item text: (current_organisation.school_group? ? t("nav.organisation_profile") : t("nav.school_profile")),
+    = header.with_navigation_item text: t("nav.manage_jobs"), href: organisation_jobs_with_type_path, active: manage_jobs_active?
+    = header.with_navigation_item text: (current_organisation.school_group? ? t("nav.organisation_profile") : t("nav.school_profile")),
                              href: publishers_organisation_path(current_organisation),
                              active: schools_in_your_trust_active?
-    = header.navigation_item text: t("nav.notifications_html", count: current_publisher.notifications.unread.count), href: publishers_notifications_path
-    = header.navigation_item text: t("nav.hiring_guides"), href: posts_path(section: "get-help-hiring")
-    = header.navigation_item text: t("nav.sign_out"), href: destroy_publisher_session_path, options: { method: :delete }
+    = header.with_navigation_item text: t("nav.notifications_html", count: current_publisher.notifications.unread.count), href: publishers_notifications_path
+    = header.with_navigation_item text: t("nav.hiring_guides"), href: posts_path(section: "get-help-hiring")
+    = header.with_navigation_item text: t("nav.sign_out"), href: destroy_publisher_session_path, options: { method: :delete }
   - elsif jobseeker_signed_in?
-    = header.navigation_item text: t("nav.create_a_job_alert"), href: new_subscription_path
-    = header.navigation_item text: t("nav.your_profile"), href: jobseekers_profile_path
-    = header.navigation_item text: t("nav.your_account"), href: jobseekers_account_path, active: your_account_active?
-    = header.navigation_item text: t("nav.sign_out"), href: destroy_jobseeker_session_path, options: { method: :delete }
+    = header.with_navigation_item text: t("nav.create_a_job_alert"), href: new_subscription_path
+    = header.with_navigation_item text: t("nav.your_profile"), href: jobseekers_profile_path
+    = header.with_navigation_item text: t("nav.your_account"), href: jobseekers_account_path, active: your_account_active?
+    = header.with_navigation_item text: t("nav.sign_out"), href: destroy_jobseeker_session_path, options: { method: :delete }
   - elsif support_user_signed_in?
-    = header.navigation_item text: t("nav.support_user_dashboard"), href: support_user_root_path, active: current_page?(support_user_root_path)
-    = header.navigation_item text: t("nav.sign_out"), href: destroy_support_user_session_path, options: { method: :delete }
+    = header.with_navigation_item text: t("nav.support_user_dashboard"), href: support_user_root_path, active: current_page?(support_user_root_path)
+    = header.with_navigation_item text: t("nav.sign_out"), href: destroy_support_user_session_path, options: { method: :delete }
   - else
-    = header.navigation_item text: t("nav.create_a_job_alert"), href: new_subscription_path
-    = header.navigation_item text: t("nav.sign_in"), href: page_path("sign-in")
+    = header.with_navigation_item text: t("nav.create_a_job_alert"), href: new_subscription_path
+    = header.with_navigation_item text: t("nav.sign_in"), href: page_path("sign-in")

--- a/app/views/layouts/_publisher_secondary_nav.html.slim
+++ b/app/views/layouts/_publisher_secondary_nav.html.slim
@@ -2,5 +2,5 @@
   .sub-navigation
     .govuk-width-container
       = tabs html_attributes: { "aria-label": "publisher nav", id: "publisher-nav" } do |tabs|
-        - tabs.navigation_item text: "Job listings", link: organisation_jobs_with_type_path
-        - tabs.navigation_item text: "Candidate profiles", link: publishers_jobseeker_profiles_path
+        - tabs.with_navigation_item text: "Job listings", link: organisation_jobs_with_type_path
+        - tabs.with_navigation_item text: "Candidate profiles", link: publishers_jobseeker_profiles_path

--- a/app/views/layouts/_sub_navigation.html.slim
+++ b/app/views/layouts/_sub_navigation.html.slim
@@ -2,9 +2,9 @@
   .sub-navigation
     .govuk-width-container
       = tabs html_attributes: { "aria-label": "main menu" } do |tabs|
-        - tabs.navigation_item text: t("sub_nav.jobs"), link: jobs_path
-        - tabs.navigation_item text: t("sub_nav.schools"), link: organisations_path
+        - tabs.with_navigation_item text: t("sub_nav.jobs"), link: jobs_path
+        - tabs.with_navigation_item text: t("sub_nav.schools"), link: organisations_path
         - if jobseeker_signed_in?
-          - tabs.navigation_item text: t("sub_nav.jobseekers.applications"), link: jobseekers_job_applications_path
-          - tabs.navigation_item text: t("sub_nav.jobseekers.saved_jobs"), link: jobseekers_saved_jobs_path
-          - tabs.navigation_item text: t("sub_nav.jobseekers.job_alerts"), link: jobseekers_subscriptions_path
+          - tabs.with_navigation_item text: t("sub_nav.jobseekers.applications"), link: jobseekers_job_applications_path
+          - tabs.with_navigation_item text: t("sub_nav.jobseekers.saved_jobs"), link: jobseekers_saved_jobs_path
+          - tabs.with_navigation_item text: t("sub_nav.jobseekers.job_alerts"), link: jobseekers_subscriptions_path

--- a/app/views/organisations/schools/index.html.slim
+++ b/app/views/organisations/schools/index.html.slim
@@ -8,7 +8,7 @@
       p.govuk-body-m = full_address(@organisation)
 
 = tabs(html_attributes: { "aria-label": "organisation menu", class: "organisation-navigation" }) do |tabs|
-  - tabs.navigation_item text: t("organisations.show.tabs.organisation"), link: organisation_path(@organisation)
-  - tabs.navigation_item text: t("organisations.show.tabs.schools"), link: organisation_schools_path(@organisation)
+  - tabs.with_navigation_item text: t("organisations.show.tabs.organisation"), link: organisation_path(@organisation)
+  - tabs.with_navigation_item text: t("organisations.show.tabs.schools"), link: organisation_schools_path(@organisation)
 
 = render "schools", preview: false, organisation: @organisation

--- a/app/views/organisations/search/_filters.html.slim
+++ b/app/views/organisations/search/_filters.html.slim
@@ -1,7 +1,7 @@
 = filters(submit_button: f.govuk_submit(t("buttons.apply_filters")),
   options: { heading_text: "Filter", remove_filter_links: false },
   html_attributes: { tabindex: "-1", id: "filters-component" }) do |filters_component|
-    - filters_component.group key: "education_phase", component: f.govuk_collection_check_boxes(:education_phase, f.object.education_phase_options, :first, :last, small: true, legend: { text: t("organisations.filters.education_phase") }, hint: nil)
-    - filters_component.group key: "key_stage", component: f.govuk_collection_check_boxes(:key_stage, f.object.key_stage_options, :first, :last, small: true, legend: { text: t("organisations.filters.key_stage") }, hint: nil)
-    - filters_component.group key: "special_school", component: f.govuk_collection_check_boxes(:special_school, [["1", t("organisations.filters.special_school")]], :first, :last, small: true, legend: { text: t("organisations.filters.special_school") })
-    - filters_component.group key: "job_availability", component: f.govuk_collection_check_boxes(:job_availability, f.object.job_availability_options, :first, :last, small: true, legend: { text: t("organisations.filters.job_availability.label") })
+    - filters_component.with_group key: "education_phase", component: f.govuk_collection_check_boxes(:education_phase, f.object.education_phase_options, :first, :last, small: true, legend: { text: t("organisations.filters.education_phase") }, hint: nil)
+    - filters_component.with_group key: "key_stage", component: f.govuk_collection_check_boxes(:key_stage, f.object.key_stage_options, :first, :last, small: true, legend: { text: t("organisations.filters.key_stage") }, hint: nil)
+    - filters_component.with_group key: "special_school", component: f.govuk_collection_check_boxes(:special_school, [["1", t("organisations.filters.special_school")]], :first, :last, small: true, legend: { text: t("organisations.filters.special_school") })
+    - filters_component.with_group key: "job_availability", component: f.govuk_collection_check_boxes(:job_availability, f.object.job_availability_options, :first, :last, small: true, legend: { text: t("organisations.filters.job_availability.label") })

--- a/app/views/organisations/show.html.slim
+++ b/app/views/organisations/show.html.slim
@@ -13,7 +13,7 @@
 
 - if @organisation.school_group?
     = tabs(html_attributes: { "aria-label": "organisation menu", class: "organisation-navigation" }) do |tabs|
-      - tabs.navigation_item text: t("organisations.show.tabs.organisation"), link: organisation_path(@organisation)
-      - tabs.navigation_item text: t("organisations.show.tabs.schools"), link: organisation_schools_path(@organisation)
+      - tabs.with_navigation_item text: t("organisations.show.tabs.organisation"), link: organisation_path(@organisation)
+      - tabs.with_navigation_item text: t("organisations.show.tabs.schools"), link: organisation_schools_path(@organisation)
 
 = render "organisation", preview: false, organisation: @organisation

--- a/app/views/pages/job-application-preview.html.slim
+++ b/app/views/pages/job-application-preview.html.slim
@@ -18,15 +18,15 @@
 
     .anchor-link-list
       = render NavigationListComponent.new title: "Application sections" do |navigation|
-        - navigation.anchor text: "Personal details", href: "#personal_details_summary"
-        - navigation.anchor text: "Professional status", href: "#professional_status_summary"
-        - navigation.anchor text: "Education and qualifications", href: "#qualifications_summary"
-        - navigation.anchor text: "Current role and employment history", href: "#employment_history_summary"
-        - navigation.anchor text: "Personal statement", href: "#personal_statement_summary"
-        - navigation.anchor text: "References", href: "#references_summary"
-        - navigation.anchor text: "Equal opportunities and recruitment monitoring", href: "#equal_opportunities_summary"
-        - navigation.anchor text: "Ask for support if you have a disability or other needs", href: "#ask_for_support_summary"
-        - navigation.anchor text: "Declarations", href: "#declarations_summary"
+        - navigation.with_anchor text: "Personal details", href: "#personal_details_summary"
+        - navigation.with_anchor text: "Professional status", href: "#professional_status_summary"
+        - navigation.with_anchor text: "Education and qualifications", href: "#qualifications_summary"
+        - navigation.with_anchor text: "Current role and employment history", href: "#employment_history_summary"
+        - navigation.with_anchor text: "Personal statement", href: "#personal_statement_summary"
+        - navigation.with_anchor text: "References", href: "#references_summary"
+        - navigation.with_anchor text: "Equal opportunities and recruitment monitoring", href: "#equal_opportunities_summary"
+        - navigation.with_anchor text: "Ask for support if you have a disability or other needs", href: "#ask_for_support_summary"
+        - navigation.with_anchor text: "Declarations", href: "#declarations_summary"
 
     h2.govuk-heading-m#personal_details_summary class="govuk-!-margin-top-8" Personal Details
 

--- a/app/views/publishers/accounts/confirm_unsubscribe.html.slim
+++ b/app/views/publishers/accounts/confirm_unsubscribe.html.slim
@@ -1,7 +1,7 @@
 - content_for :page_title_prefix, t(".title")
 
 = govuk_notification_banner title_text: t("banners.important"), classes: "govuk-!-margin-top-2" do |banner|
-  - banner.heading(text: t(".notification_banner.heading"))
+  - banner.with_heading(text: t(".notification_banner.heading"))
 
   p.govuk-body
     = t(".notification_banner.body")

--- a/app/views/publishers/invitations/index.html.slim
+++ b/app/views/publishers/invitations/index.html.slim
@@ -12,7 +12,7 @@
           - row.cell(header: true, text: "Invited by")
           - row.cell(header: true, text: "Date")
 
-      - table.body do |body|
+      - table.with_body do |body|
         - @invitations.each do |invitation|
           - body.row do |row|
             - row.cell(text: invitation.vacancy.job_title)

--- a/app/views/publishers/invitations/review.html.slim
+++ b/app/views/publishers/invitations/review.html.slim
@@ -8,9 +8,9 @@
     h1.govuk-heading-l = t(".header")
     = govuk_summary_list do |summary|
       - summary.row do |row|
-        - row.key text: t(".summary.jobs")
-        - row.value text: @form.selected_jobs.map(&:job_title).map { |title| "".html_safe + title }.join("<br/>").html_safe
-        - row.action text: t("buttons.change"), href: { action: :edit, step: @form.class.delegated_attributes["job_ids"] }
+        - row.with_key text: t(".summary.jobs")
+        - row.with_value text: @form.selected_jobs.map(&:job_title).map { |title| "".html_safe + title }.join("<br/>").html_safe
+        - row.with_action text: t("buttons.change"), href: { action: :edit, step: @form.class.delegated_attributes["job_ids"] }
 
     h2.govuk-heading-m Preview
     .govuk-inset-text

--- a/app/views/publishers/jobseeker_profiles/_layout.html.slim
+++ b/app/views/publishers/jobseeker_profiles/_layout.html.slim
@@ -10,7 +10,7 @@
       = govuk_link_to "Invite to apply for a job", invite_to_apply_publishers_jobseeker_profile_path, class: %i[govuk-button govuk-!-margin-bottom-6]
 
     = tabs do |tabs|
-      - tabs.navigation_item text: "Profile", link: publishers_jobseeker_profile_path(profile)
-      - tabs.navigation_item text: "Invitations to apply", link: publishers_invitations_path(profile)
+      - tabs.with_navigation_item text: "Profile", link: publishers_jobseeker_profile_path(profile)
+      - tabs.with_navigation_item text: "Invitations to apply", link: publishers_invitations_path(profile)
 
     = yield

--- a/app/views/publishers/jobseeker_profiles/index.html.slim
+++ b/app/views/publishers/jobseeker_profiles/index.html.slim
@@ -12,17 +12,17 @@ p = t("publishers.jobseeker_profiles.available_to_travel_text")
         options: { heading_text: "Filter", remove_filter_links: false },
         html_attributes: { tabindex: "-1", id: "filters-component" }) do |filters_component|
         - if current_organisation.trust?
-          - filters_component.group key: "location", component: searchable_collection(collection: f.govuk_collection_check_boxes(:locations,
+          - filters_component.with_group key: "location", component: searchable_collection(collection: f.govuk_collection_check_boxes(:locations,
             f.object.school_options,
             :first, :last,
             small: true, legend: { text: t("publishers.jobseeker_profiles.filters.schools") }),
             collection_count: f.object.school_options.count,
             options: { scrollable: true })
-        - filters_component.group key: "qualified_teacher_status", component: f.govuk_collection_check_boxes(:qualified_teacher_status, f.object.qts_options, :first, :last, small: true, legend: { text: t("publishers.jobseeker_profiles.filters.qualified_teacher_status") }, hint: nil)
-        - filters_component.group key: "roles", component: f.govuk_collection_check_boxes(:roles, f.object.role_options, :first, :last, small: true, legend: { text: t("publishers.jobseeker_profiles.filters.preferred_roles") }, hint: nil)
-        - filters_component.group key: "working_patterns", component: f.govuk_collection_check_boxes(:working_patterns, f.object.working_pattern_options, :first, :last, small: true, legend: { text: t("publishers.jobseeker_profiles.filters.preferred_working_patterns") }, hint: nil)
-        - filters_component.group key: "education_phases", component: f.govuk_collection_check_boxes(:education_phases, f.object.education_phase_options, :first, :last, small: true, legend: { text: t("publishers.jobseeker_profiles.filters.preferred_education_phases") }, hint: nil)
-        - filters_component.group key: "key_stages", component: f.govuk_collection_check_boxes(:key_stages, f.object.key_stage_options, :first, :last, small: true, legend: { text: t("publishers.jobseeker_profiles.filters.preferred_key_stages") }, hint: nil)
+        - filters_component.with_group key: "qualified_teacher_status", component: f.govuk_collection_check_boxes(:qualified_teacher_status, f.object.qts_options, :first, :last, small: true, legend: { text: t("publishers.jobseeker_profiles.filters.qualified_teacher_status") }, hint: nil)
+        - filters_component.with_group key: "roles", component: f.govuk_collection_check_boxes(:roles, f.object.role_options, :first, :last, small: true, legend: { text: t("publishers.jobseeker_profiles.filters.preferred_roles") }, hint: nil)
+        - filters_component.with_group key: "working_patterns", component: f.govuk_collection_check_boxes(:working_patterns, f.object.working_pattern_options, :first, :last, small: true, legend: { text: t("publishers.jobseeker_profiles.filters.preferred_working_patterns") }, hint: nil)
+        - filters_component.with_group key: "education_phases", component: f.govuk_collection_check_boxes(:education_phases, f.object.education_phase_options, :first, :last, small: true, legend: { text: t("publishers.jobseeker_profiles.filters.preferred_education_phases") }, hint: nil)
+        - filters_component.with_group key: "key_stages", component: f.govuk_collection_check_boxes(:key_stages, f.object.key_stage_options, :first, :last, small: true, legend: { text: t("publishers.jobseeker_profiles.filters.preferred_key_stages") }, hint: nil)
         = render "shared/subjects_filter", filters_component: filters_component, f: f
 
   .govuk-grid-column-two-thirds-at-desktop

--- a/app/views/publishers/login_keys/show.html.slim
+++ b/app/views/publishers/login_keys/show.html.slim
@@ -4,7 +4,7 @@
   .govuk-grid-column-two-thirds
     - if @reason_for_failing_sign_in
       = govuk_notification_banner title_text: t("banners.important") do |banner|
-        - banner.heading text: t("publishers.temp_login.choose_organisation.denial.title")
+        - banner.with_heading text: t("publishers.temp_login.choose_organisation.denial.title")
         = t("publishers.temp_login.choose_organisation.denial.#{@reason_for_failing_sign_in}_html", try_again: govuk_link_to("try again", new_publisher_session_path))
 
     - else

--- a/app/views/publishers/organisations/_organisation.html.slim
+++ b/app/views/publishers/organisations/_organisation.html.slim
@@ -1,75 +1,75 @@
 = govuk_summary_list do |summary_list|
   - summary_list.row do |row|
-    - row.key text: t(".name.label")
-    - row.value text: organisation.name
+    - row.with_key text: t(".name.label")
+    - row.with_value text: organisation.name
 
   - unless organisation.local_authority?
     - summary_list.row do |row|
-      - row.key text: t(".address.label")
-      - row.value text: full_address(organisation)
+      - row.with_key text: t(".address.label")
+      - row.with_value text: full_address(organisation)
 
   - if organisation.school?
     - summary_list.row do |row|
-      - row.key text: t(".type.label")
-      - row.value text: organisation.school_type
+      - row.with_key text: t(".type.label")
+      - row.with_value text: organisation.school_type
 
     - if organisation.phase.present?
       - summary_list.row do |row|
-        - row.key text: t(".phase.label")
-        - row.value text: t(".phase.values.#{organisation.phase}")
+        - row.with_key text: t(".phase.label")
+        - row.with_value text: t(".phase.values.#{organisation.phase}")
 
     - summary_list.row do |row|
-      - row.key text: t(".school_age.label")
-      - row.value text: age_range(organisation)
+      - row.with_key text: t(".school_age.label")
+      - row.with_value text: age_range(organisation)
 
     - if (text = number_of_pupils(organisation))
       - summary_list.row do |row|
-        - row.key text: t(".size.label")
-        - row.value text: text
+        - row.with_key text: t(".size.label")
+        - row.with_value text: text
 
   - summary_list.row(html_attributes: { id: "email" }) do |row|
-    - row.key text: t(".email.label")
+    - row.with_key text: t(".email.label")
     - row.with_value do
       - link = govuk_mail_to(organisation.email, organisation.email, class: "wordwrap") if organisation.email.present?
       = required_profile_info(value: link, missing_prompt: t(".email.missing_prompt"))
-    - row.action text: t("buttons.change"), href: edit_publishers_organisation_email_path(organisation), classes: "govuk-link--no-visited-state"
+    - row.with_action text: t("buttons.change"), href: edit_publishers_organisation_email_path(organisation), classes: "govuk-link--no-visited-state"
 
   - summary_list.row(html_attributes: { id: "website" }) do |row|
-    - row.key text: t(".website.label")
+    - row.with_key text: t(".website.label")
     - row.with_value do
       - link = open_in_new_tab_link_to(organisation.url, organisation.url, class: "wordwrap") if organisation.url.present?
       = required_profile_info(value: link, missing_prompt: t(".website.missing_prompt"))
-    - row.action text: t("buttons.change"), href: edit_publishers_organisation_website_path(organisation), classes: "govuk-link--no-visited-state"
+    - row.with_action text: t("buttons.change"), href: edit_publishers_organisation_website_path(organisation), classes: "govuk-link--no-visited-state"
 
   - summary_list.row(html_attributes: { id: "description" }) do |row|
-    - row.key text: t(".description.label.#{organisation.school? ? :school : :organisation}")
+    - row.with_key text: t(".description.label.#{organisation.school? ? :school : :organisation}")
     - row.with_value do
       = required_profile_info(value: truncate(organisation.description, length: 130), missing_prompt: t(".description.missing_prompt.#{organisation.school? ? :school : :organisation}"))
-    - row.action text: t("buttons.change"), href: edit_publishers_organisation_description_path(organisation), classes: "govuk-link--no-visited-state"
+    - row.with_action text: t("buttons.change"), href: edit_publishers_organisation_description_path(organisation), classes: "govuk-link--no-visited-state"
 
   - summary_list.row(html_attributes: { id: "safeguarding_information" }) do |row|
-    - row.key text: t(".safeguarding_information.label")
+    - row.with_key text: t(".safeguarding_information.label")
     - row.with_value do
       = required_profile_info(value: truncate(organisation.safeguarding_information, length: 130), missing_prompt: t(".safeguarding_information.missing_prompt"))
-    - row.action text: t("buttons.change"), href: edit_publishers_organisation_safeguarding_information_path(organisation), classes: "govuk-link--no-visited-state"
+    - row.with_action text: t("buttons.change"), href: edit_publishers_organisation_safeguarding_information_path(organisation), classes: "govuk-link--no-visited-state"
 
   - summary_list.row(html_attributes: { id: "logo" }) do |row|
-    - row.key text: t(".logo.label")
+    - row.with_key text: t(".logo.label")
     - row.with_value classes: "vertical-align-top" do
       = required_profile_image(image: @organisation.logo,
                                missing_prompt: t(".logo.missing_prompt.#{organisation.school? ? :school : :organisation}"),
                                alt_text: t(".logo.alt_text", organisation_name: @organisation.name))
-    - row.action text: t("buttons.change"), href: edit_publishers_organisation_logo_path(organisation), classes: "govuk-link--no-visited-state"
+    - row.with_action text: t("buttons.change"), href: edit_publishers_organisation_logo_path(organisation), classes: "govuk-link--no-visited-state"
 
   - summary_list.row(html_attributes: { id: "photo" }) do |row|
-    - row.key text: t(".photo.label")
+    - row.with_key text: t(".photo.label")
     - row.with_value classes: "vertical-align-top" do
       = required_profile_image(image: @organisation.photo,
                                missing_prompt: t(".photo.missing_prompt.#{organisation.school? ? :school : :organisation}"),
                                alt_text: t(".photo.alt_text", organisation_name: @organisation.name))
-    - row.action text: t("buttons.change"), href: edit_publishers_organisation_photo_path(organisation), classes: "govuk-link--no-visited-state"
+    - row.with_action text: t("buttons.change"), href: edit_publishers_organisation_photo_path(organisation), classes: "govuk-link--no-visited-state"
 
   - if organisation.has_ofsted_report?
     - summary_list.row do |row|
-      - row.key text: t(".ofsted_report.label")
-      - row.value text: ofsted_report_link(organisation, class: "wordwrap")
+      - row.with_key text: t(".ofsted_report.label")
+      - row.with_value text: ofsted_report_link(organisation, class: "wordwrap")

--- a/app/views/publishers/organisations/preview.html.slim
+++ b/app/views/publishers/organisations/preview.html.slim
@@ -17,7 +17,7 @@
 
 - if @organisation.school_group?
   = tabs(html_attributes: { "aria-label": "organisation menu", class: "organisation-navigation" }) do |tabs|
-    - tabs.navigation_item text: t("organisations.show.tabs.organisation"), link: publishers_organisation_preview_path(@organisation)
-    - tabs.navigation_item text: t("organisations.show.tabs.schools"), link: publishers_organisation_schools_preview_path(@organisation)
+    - tabs.with_navigation_item text: t("organisations.show.tabs.organisation"), link: publishers_organisation_preview_path(@organisation)
+    - tabs.with_navigation_item text: t("organisations.show.tabs.schools"), link: publishers_organisation_schools_preview_path(@organisation)
 
 = render "organisations/organisation", preview: true, organisation: @organisation

--- a/app/views/publishers/organisations/schools/preview.html.slim
+++ b/app/views/publishers/organisations/schools/preview.html.slim
@@ -11,7 +11,7 @@
       p.govuk-body-m = full_address(@organisation)
 
 = tabs(html_attributes: { "aria-label": "organisation menu", class: "organisation-navigation" }) do |tabs|
-  - tabs.navigation_item text: t("organisations.show.tabs.organisation"), link: publishers_organisation_preview_path(@organisation)
-  - tabs.navigation_item text: t("organisations.show.tabs.schools"), link: publishers_organisation_schools_preview_path(@organisation)
+  - tabs.with_navigation_item text: t("organisations.show.tabs.organisation"), link: publishers_organisation_preview_path(@organisation)
+  - tabs.with_navigation_item text: t("organisations.show.tabs.schools"), link: publishers_organisation_schools_preview_path(@organisation)
 
 = render "organisations/schools/schools", preview: true, organisation: @organisation

--- a/app/views/publishers/organisations/show.html.slim
+++ b/app/views/publishers/organisations/show.html.slim
@@ -6,7 +6,7 @@
 
 - unless @organisation.profile_complete?
   = govuk_notification_banner title_text: t("banners.important"), classes: "govuk-!-margin-bottom-5" do |banner|
-    - banner.heading text: t(".profile_incomplete_banner.title", organisation_type: @organisation.school? ? :school : :organisation)
+    - banner.with_heading text: t(".profile_incomplete_banner.title", organisation_type: @organisation.school? ? :school : :organisation)
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/publishers/vacancies/_tabs.html.slim
+++ b/app/views/publishers/vacancies/_tabs.html.slim
@@ -1,8 +1,8 @@
 = tabs do |tabs|
-  - tabs.navigation_item text: t("buttons.job_listing"), link: organisation_job_path(vacancy.id), active: controller_name == "vacancies"
+  - tabs.with_navigation_item text: t("buttons.job_listing"), link: organisation_job_path(vacancy.id), active: controller_name == "vacancies"
   - if vacancy.can_receive_job_applications? && !current_organisation.local_authority?
-    - tabs.navigation_item text: t("tabs.applications.hide_count"), link: organisation_job_job_applications_path(vacancy.id), active: controller_name == "job_applications"
+    - tabs.with_navigation_item text: t("tabs.applications.hide_count"), link: organisation_job_job_applications_path(vacancy.id), active: controller_name == "job_applications"
   - if vacancy.published?
-    - tabs.navigation_item text: t("tabs.statistics"), link: organisation_job_statistics_path(vacancy.id), active: controller_name == "statistics"
+    - tabs.with_navigation_item text: t("tabs.statistics"), link: organisation_job_statistics_path(vacancy.id), active: controller_name == "statistics"
   - if vacancy.listed? || vacancy.expired?
-    = tabs.navigation_item text: t("tabs.activity_log"), link: organisation_job_activity_log_path(vacancy.id), active: controller_name == "activity_log"
+    = tabs.with_navigation_item text: t("tabs.activity_log"), link: organisation_job_activity_log_path(vacancy.id), active: controller_name == "activity_log"

--- a/app/views/publishers/vacancies/job_applications/_header.html.slim
+++ b/app/views/publishers/vacancies/job_applications/_header.html.slim
@@ -14,5 +14,5 @@ h1.govuk-heading-xl class="govuk-!-margin-bottom-5 govuk-!-margin-top-0"
   = publisher_job_application_status_tag(job_application.status)
 
 = tabs do |tabs|
-  - tabs.navigation_item text: t(".tabs.application"), link: organisation_job_job_application_path(vacancy.id, job_application)
-  - tabs.navigation_item text: t(".tabs.notes"), link: organisation_job_job_application_notes_path(vacancy.id, job_application), active: controller_name == "notes"
+  - tabs.with_navigation_item text: t(".tabs.application"), link: organisation_job_job_application_path(vacancy.id, job_application)
+  - tabs.with_navigation_item text: t(".tabs.notes"), link: organisation_job_job_application_notes_path(vacancy.id, job_application), active: controller_name == "notes"

--- a/app/views/publishers/vacancies/job_applications/index.html.slim
+++ b/app/views/publishers/vacancies/job_applications/index.html.slim
@@ -24,8 +24,8 @@
 
             - if application.status.in?(%w[reviewed shortlisted submitted])
               - if application.reviewed? || application.submitted?
-                - row.action text: t("buttons.shortlist"), href: organisation_job_job_application_shortlist_path(vacancy.id, application.id), visually_hidden_text: " #{application.name}"
-              - row.action text: t("buttons.reject"), href: organisation_job_job_application_reject_path(vacancy.id, application.id), visually_hidden_text: " #{application.name}"
+                - row.with_action text: t("buttons.shortlist"), href: organisation_job_job_application_shortlist_path(vacancy.id, application.id), visually_hidden_text: " #{application.name}"
+              - row.with_action text: t("buttons.reject"), href: organisation_job_job_application_reject_path(vacancy.id, application.id), visually_hidden_text: " #{application.name}"
 
     - elsif !vacancy.within_data_access_period?
       = govuk_inset_text do

--- a/app/views/publishers/vacancies/show.html.slim
+++ b/app/views/publishers/vacancies/show.html.slim
@@ -3,10 +3,10 @@
 - if vacancy.legacy? && flash.none?
   - if vacancy.legacy_draft?
     = govuk_notification_banner(title_text: t("banners.important")) do |banner|
-      - banner.heading(text: t("publishers.job_listing_process_changed_draft_banner.heading_html", contact_support_link: govuk_link_to("contact support", new_support_request_path), create_new_link: govuk_link_to("Create a new job listing", organisation_jobs_path, method: "post")))
+      - banner.with_heading(text: t("publishers.job_listing_process_changed_draft_banner.heading_html", contact_support_link: govuk_link_to("contact support", new_support_request_path), create_new_link: govuk_link_to("Create a new job listing", organisation_jobs_path, method: "post")))
   - else
     = govuk_notification_banner(title_text: t("banners.important")) do |banner|
-      - banner.heading(text: t("publishers.job_listing_process_changed_published_banner.heading_html", contact_support_link: govuk_link_to("Contact support", new_support_request_path)))
+      - banner.with_heading(text: t("publishers.job_listing_process_changed_published_banner.heading_html", contact_support_link: govuk_link_to("Contact support", new_support_request_path)))
 
 = render "review_banner"
 

--- a/app/views/publishers/vacancies/vacancy_review_sections/_about_the_role.html.slim
+++ b/app/views/publishers/vacancies/vacancy_review_sections/_about_the_role.html.slim
@@ -10,7 +10,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
       - row.value
         = vacancy.ect_status == "ect_suitable" ? "Yes" : "No"
       - unless vacancy.legacy_draft?
-        - row.action text: t("buttons.change"),
+        - row.with_action text: t("buttons.change"),
                     href: organisation_job_build_path(vacancy.id, :about_the_role, "back_to_#{action_name}": "true"),
                     visually_hidden_text: t("jobs.ect_status")
 
@@ -21,7 +21,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
       - row.value
         .editor-rendered-content == vacancy.job_advert
       - unless vacancy.legacy_draft?
-        - row.action text: t("buttons.change"),
+        - row.with_action text: t("buttons.change"),
                     href: organisation_job_build_path(vacancy.id, :about_the_role, "back_to_#{action_name}": "true"),
                     visually_hidden_text: t("jobs.job_advert")
 
@@ -32,7 +32,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
       - row.value
         .editor-rendered-content == vacancy.skills_and_experience
       - unless vacancy.legacy_draft?
-        - row.action text: t("buttons.change"),
+        - row.with_action text: t("buttons.change"),
                     href: organisation_job_build_path(vacancy.id, :about_the_role, "back_to_#{action_name}": "true"),
                     visually_hidden_text: t("jobs.skills_and_experience.publisher")
 
@@ -43,7 +43,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
       - row.value
         = vacancy.about_school
       - unless vacancy.legacy_draft?
-        - row.action text: t("buttons.change"),
+        - row.with_action text: t("buttons.change"),
                     href: organisation_job_build_path(vacancy.id, :about_the_role, "back_to_#{action_name}": "true"),
                     visually_hidden_text: t("jobs.about_school")
 
@@ -54,7 +54,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
       - row.value
         .editor-rendered-content == vacancy.school_offer
       - unless vacancy.legacy_draft?
-        - row.action text: t("buttons.change"),
+        - row.with_action text: t("buttons.change"),
                     href: organisation_job_build_path(vacancy.id, :about_the_role, "back_to_#{action_name}": "true"),
                     visually_hidden_text: t("jobs.school_offer.publisher", organisation: vacancy.organisation.type.downcase)
 
@@ -66,7 +66,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
         - row.value
           = vacancy.safeguarding_information_provided ? "Yes" : "No"
         - unless vacancy.legacy_draft?
-          - row.action text: t("buttons.change"),
+          - row.with_action text: t("buttons.change"),
                       href: organisation_job_build_path(vacancy.id, :about_the_role, "back_to_#{action_name}": "true"),
                       visually_hidden_text: t("jobs.safeguarding_information_provided")
 
@@ -76,7 +76,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
       - row.value
         .editor-rendered-content == vacancy.safeguarding_information
       - unless vacancy.legacy_draft?
-        - row.action text: t("buttons.change"),
+        - row.with_action text: t("buttons.change"),
                     href: organisation_job_build_path(vacancy.id, :about_the_role, "back_to_#{action_name}": "true"),
                     visually_hidden_text: t("jobs.safeguarding_information.publisher")
 
@@ -98,7 +98,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
       - row.value
         = vacancy.further_details_provided ? "Yes" : "No"
       - unless vacancy.legacy_draft?
-        - row.action text: t("buttons.change"),
+        - row.with_action text: t("buttons.change"),
                     href: organisation_job_build_path(vacancy.id, :about_the_role, "back_to_#{action_name}": "true"),
                     visually_hidden_text: t("jobs.further_details_provided")
 
@@ -109,7 +109,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
       - row.value
         .editor-rendered-content == vacancy.further_details
       - unless vacancy.legacy_draft?
-        - row.action text: t("buttons.change"),
+        - row.with_action text: t("buttons.change"),
                     href: organisation_job_build_path(vacancy.id, :about_the_role, "back_to_#{action_name}": "true"),
                     visually_hidden_text: t("jobs.further_details")
 
@@ -120,7 +120,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
       - row.value
         = vacancy.include_additional_documents || vacancy.supporting_documents.any? ? "Yes" : "No"
       - unless vacancy.legacy_draft?
-        - row.action text: t("buttons.change"),
+        - row.with_action text: t("buttons.change"),
                     href: organisation_job_build_path(vacancy.id, :include_additional_documents, "back_to_#{action_name}": "true"),
                     visually_hidden_text: t("jobs.include_additional_documents")
 
@@ -136,6 +136,6 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
         - else
           = t("jobs.not_defined")
       - unless vacancy.legacy_draft?
-        - row.action text: t("buttons.change"),
+        - row.with_action text: t("buttons.change"),
                     href: organisation_job_documents_path(vacancy.id, "back_to_#{action_name}": "true"),
                     visually_hidden_text: t("jobs.additional_documents")

--- a/app/views/publishers/vacancies/vacancy_review_sections/_application_process.html.slim
+++ b/app/views/publishers/vacancies/vacancy_review_sections/_application_process.html.slim
@@ -9,7 +9,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
       - row.value
         = vacancy.enable_job_applications ? "Yes" : "No"
       - unless vacancy.published? || vacancy.legacy_draft?
-        - row.action text: t("buttons.change"),
+        - row.with_action text: t("buttons.change"),
                     href: organisation_job_build_path(vacancy.id, :applying_for_the_job, "back_to_#{action_name}": "true"),
                     visually_hidden_text: t("jobs.enable_job_applications")
 
@@ -20,7 +20,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
         - row.value
           = vacancy.personal_statement_guidance
         - unless vacancy.published? || vacancy.legacy_draft?
-          - row.action text: t("buttons.change"),
+          - row.with_action text: t("buttons.change"),
                       href: organisation_job_build_path(vacancy.id, :applying_for_the_job, "back_to_#{action_name}": "true"),
                       visually_hidden_text: t("jobs.personal_statement_guidance")
 
@@ -31,7 +31,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
         - row.value
           = vacancy.how_to_apply
         - unless vacancy.legacy?
-          - row.action text: t("buttons.change"),
+          - row.with_action text: t("buttons.change"),
                       href: organisation_job_build_path(vacancy.id, vacancy_how_to_apply_step(vacancy), "back_to_#{action_name}": "true"),
                       visually_hidden_text: t("jobs.how_to_apply")
 
@@ -43,7 +43,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
         - row.value
           = t("helpers.label.publishers_job_listing_how_to_receive_applications_form.receive_applications_options.#{vacancy.receive_applications}")
         - unless vacancy.legacy_draft?
-          - row.action text: t("buttons.change"),
+          - row.with_action text: t("buttons.change"),
                       href: organisation_job_build_path(vacancy.id, :how_to_receive_applications, "back_to_#{action_name}": "true"),
                       visually_hidden_text: t("jobs.how_to_receive_applications")
 
@@ -55,7 +55,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
             - row.value
               = govuk_link_to("#{vacancy.application_form.filename}, #{number_to_human_size(vacancy.application_form.byte_size)}", job_document_path(vacancy, vacancy.application_form.id))
             - unless vacancy.legacy_draft?
-              - row.action text: t("buttons.change"),
+              - row.with_action text: t("buttons.change"),
                             href: organisation_job_build_path(vacancy.id, :application_form, "back_to_#{action_name}": "true"),
                             visually_hidden_text: t("jobs.application_form")
 
@@ -66,7 +66,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
             - row.value
               = vacancy.application_email
             - unless vacancy.legacy_draft?
-              - row.action text: t("buttons.change"),
+              - row.with_action text: t("buttons.change"),
                             href: organisation_job_build_path(vacancy.id, :application_form, "back_to_#{action_name}": "true"),
                             visually_hidden_text: t("jobs.application_email")
 
@@ -77,7 +77,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
         - row.value
           = vacancy.application_link
         - unless vacancy.legacy_draft?
-          - row.action text: t("buttons.change"),
+          - row.with_action text: t("buttons.change"),
                         href: organisation_job_build_path(vacancy.id, :application_link, "back_to_#{action_name}": "true"),
                         visually_hidden_text: t("jobs.application_link")
 
@@ -88,7 +88,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
       - row.value
         = vacancy.school_visits || vacancy.school_visits_details.present? ? "Yes" : "No"
       - unless vacancy.legacy_draft?
-        - row.action text: t("buttons.change"),
+        - row.with_action text: t("buttons.change"),
                       href: organisation_job_build_path(vacancy.id, :school_visits, "back_to_#{action_name}": "true"),
                       visually_hidden_text: t("jobs.school_visits")
 
@@ -99,7 +99,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
       - row.value
         = vacancy.school_visits_details
       - unless vacancy.legacy_draft?
-        - row.action text: t("buttons.change"),
+        - row.with_action text: t("buttons.change"),
                       href: organisation_job_build_path(vacancy.id, :school_visits, "back_to_#{action_name}": "true"),
                       visually_hidden_text: "School visits details"
 
@@ -110,7 +110,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
       - row.value
         = vacancy.contact_email
       - unless vacancy.legacy_draft?
-        - row.action text: t("buttons.change"),
+        - row.with_action text: t("buttons.change"),
                       href: organisation_job_build_path(vacancy.id, :contact_details, "back_to_#{action_name}": "true"),
                       visually_hidden_text: t("jobs.contact_email")
 
@@ -121,7 +121,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
       - row.value
         = vacancy.contact_number_provided? || vacancy.contact_number.present? ? "Yes" : "No"
       - unless vacancy.legacy_draft?
-        - row.action text: t("buttons.change"),
+        - row.with_action text: t("buttons.change"),
                     href: organisation_job_build_path(vacancy.id, :contact_details, "back_to_#{action_name}": "true"),
                     visually_hidden_text: t("jobs.contact_number_provided")
 
@@ -132,6 +132,6 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
       - row.value
         = vacancy.contact_number
       - unless vacancy.legacy_draft?
-        - row.action text: t("buttons.change"),
+        - row.with_action text: t("buttons.change"),
                     href: organisation_job_build_path(vacancy.id, :contact_details, "back_to_#{action_name}": "true"),
                     visually_hidden_text: t("jobs.contact_number")

--- a/app/views/publishers/vacancies/vacancy_review_sections/_documents.html.slim
+++ b/app/views/publishers/vacancies/vacancy_review_sections/_documents.html.slim
@@ -6,7 +6,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
     - summary_list.row do |row|
       - row.key classes: ["govuk-!-font-weight-regular"]
         = t("jobs.no_supporting_documents")
-      - row.action text: t("buttons.change"),
+      - row.with_action text: t("buttons.change"),
                     href: organisation_job_build_path(vacancy.id, :documents, "back_to_#{action_name}": "true"),
                     visually_hidden_text: t("jobs.supporting_documents")
   - else
@@ -14,6 +14,6 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
       - summary_list.row do |row|
         - row.key text: "Document #{index + 1}"
         - row.value text: document.filename
-        - row.action text: t("buttons.change"),
+        - row.with_action text: t("buttons.change"),
                       href: organisation_job_build_path(vacancy.id, :documents, "back_to_#{action_name}": "true"),
                       visually_hidden_text: t("jobs.supporting_documents")

--- a/app/views/publishers/vacancies/vacancy_review_sections/_important_dates.html.slim
+++ b/app/views/publishers/vacancies/vacancy_review_sections/_important_dates.html.slim
@@ -9,7 +9,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
       - row.value
         = format_date(vacancy.publish_on)
       - unless vacancy.legacy_draft? || vacancy.listed?
-        - row.action text: t("buttons.change"),
+        - row.with_action text: t("buttons.change"),
                     href: organisation_job_build_path(vacancy.id, :important_dates, "back_to_#{action_name}": "true"),
                     visually_hidden_text: t("jobs.publication_date")
 
@@ -20,7 +20,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
       - row.value
         = format_time_to_datetime_at(vacancy.expires_at)
       - unless vacancy.legacy_draft?
-        - row.action text: t("buttons.change"),
+        - row.with_action text: t("buttons.change"),
                     href: organisation_job_build_path(vacancy.id, :important_dates, "back_to_#{action_name}": "true"),
                     visually_hidden_text: t("jobs.application_deadline")
 
@@ -39,6 +39,6 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
         - else
           = t("jobs.not_defined")
       - unless vacancy.legacy_draft?
-        - row.action text: t("buttons.change"),
+        - row.with_action text: t("buttons.change"),
                     href: organisation_job_build_path(vacancy.id, :start_date, "back_to_#{action_name}": "true"),
                     visually_hidden_text: t("jobs.starts_on")

--- a/app/views/publishers/vacancies/vacancy_review_sections/_job_details.html.slim
+++ b/app/views/publishers/vacancies/vacancy_review_sections/_job_details.html.slim
@@ -10,7 +10,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
         = vacancy_job_locations(vacancy)
     - unless vacancy.legacy_draft? || current_organisation.school?
       - row.with_action text: t("buttons.change"),
-                  href: organisation_job_build_path(vacancy.id, :job_location, "back_to_#{with_action_name}": "true"),
+                  href: organisation_job_build_path(vacancy.id, :job_location, "back_to_#{action_name}": "true"),
                   visually_hidden_text: t("publishers.vacancies.steps.job_location")
 
   - summary_list.row(html_attributes: { id: "job_role" }) do |row|
@@ -20,7 +20,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
       = t("helpers.label.publishers_job_listing_job_role_form.job_role_options.#{vacancy.job_role}") if vacancy.job_role?
     - unless vacancy.legacy_draft?
       - row.with_action text: t("buttons.change"),
-                  href: organisation_job_build_path(vacancy.id, :job_role, "back_to_#{with_action_name}": "true"),
+                  href: organisation_job_build_path(vacancy.id, :job_role, "back_to_#{action_name}": "true"),
                   visually_hidden_text: t("publishers.vacancies.steps.job_role")
 
   - summary_list.row(html_attributes: { id: "job_title" }) do |row|
@@ -30,7 +30,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
       = vacancy.job_title
     - unless vacancy.legacy_draft?
       - row.with_action text: t("buttons.change"),
-                  href: organisation_job_build_path(vacancy.id, :job_title, "back_to_#{with_action_name}": "true"),
+                  href: organisation_job_build_path(vacancy.id, :job_title, "back_to_#{action_name}": "true"),
                   visually_hidden_text: t("jobs.job_title")
 
   - if vacancy.allow_key_stages? && vacancy.key_stages.any?
@@ -41,7 +41,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
         = vacancy.readable_key_stages
       - unless vacancy.legacy_draft?
         - row.with_action text: t("buttons.change"),
-                    href: organisation_job_build_path(vacancy.id, :key_stages, "back_to_#{with_action_name}": "true"),
+                    href: organisation_job_build_path(vacancy.id, :key_stages, "back_to_#{action_name}": "true"),
                     visually_hidden_text: t("jobs.key_stage", count: vacancy.key_stages.count)
 
   - if vacancy.allow_subjects? && (vacancy.completed_steps.include?("subjects") || vacancy.completed_steps.include?("job_details"))
@@ -52,7 +52,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
         = vacancy.subjects.any? ? vacancy.readable_subjects : t("jobs.not_defined")
       - unless vacancy.legacy_draft?
         - row.with_action text: t("buttons.change"),
-                    href: organisation_job_build_path(vacancy.id, :subjects, "back_to_#{with_action_name}": "true"),
+                    href: organisation_job_build_path(vacancy.id, :subjects, "back_to_#{action_name}": "true"),
                     visually_hidden_text: t("jobs.subjects", count: vacancy.subjects.count)
 
   - unless vacancy.contract_type.nil?
@@ -63,7 +63,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
         = vacancy.contract_type_with_duration
       - unless vacancy.legacy_draft?
         - row.with_action text: t("buttons.change"),
-                    href: organisation_job_build_path(vacancy.id, :contract_type, "back_to_#{with_action_name}": "true"),
+                    href: organisation_job_build_path(vacancy.id, :contract_type, "back_to_#{action_name}": "true"),
                     visually_hidden_text: t("jobs.contract_type")
 
   - if vacancy.working_patterns.any?
@@ -75,7 +75,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
           = vacancy.readable_working_patterns
         - unless vacancy.legacy_draft?
           - row.with_action text: t("buttons.change"),
-                      href: organisation_job_build_path(vacancy.id, :working_patterns, "back_to_#{with_action_name}": "true"),
+                      href: organisation_job_build_path(vacancy.id, :working_patterns, "back_to_#{action_name}": "true"),
                       visually_hidden_text: t("jobs.working_patterns")
 
       - summary_list.row(html_attributes: { id: "working_patterns_details" }) do |row|
@@ -85,7 +85,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
           = vacancy.working_patterns_details? ? vacancy.working_patterns_details : t("jobs.not_defined")
         - unless vacancy.legacy_draft?
           - row.with_action text: t("buttons.change"),
-                      href: organisation_job_build_path(vacancy.id, :working_patterns, "back_to_#{with_action_name}": "true"),
+                      href: organisation_job_build_path(vacancy.id, :working_patterns, "back_to_#{action_name}": "true"),
                       visually_hidden_text: t("jobs.working_patterns")
 
     - else
@@ -96,7 +96,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
             ul.govuk-list.govuk-list--spaced = vacancy_working_patterns(vacancy)
         - unless vacancy.legacy_draft?
           - row.with_action text: t("buttons.change"),
-                      href: organisation_job_build_path(vacancy.id, :working_patterns, "back_to_#{with_action_name}": "true"),
+                      href: organisation_job_build_path(vacancy.id, :working_patterns, "back_to_#{action_name}": "true"),
                       visually_hidden_text: t("jobs.working_patterns")
 
   - if vacancy.salary_types.any?
@@ -119,7 +119,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
               = vacancy.pay_scale
       - unless vacancy.legacy_draft?
         - row.with_action text: t("buttons.change"),
-                      href: organisation_job_build_path(vacancy.id, :pay_package, "back_to_#{with_action_name}": "true"),
+                      href: organisation_job_build_path(vacancy.id, :pay_package, "back_to_#{action_name}": "true"),
                       visually_hidden_text: t("jobs.salary_details")
 
   - unless vacancy.benefits.nil?
@@ -131,7 +131,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
         = vacancy.benefits? ? "Yes" : "No"
       - unless vacancy.legacy_draft?
         - row.with_action text: t("buttons.change"),
-                      href: organisation_job_build_path(vacancy.id, :pay_package, "back_to_#{with_action_name}": "true"),
+                      href: organisation_job_build_path(vacancy.id, :pay_package, "back_to_#{action_name}": "true"),
                       visually_hidden_text: t("jobs.benefits")
 
   - if vacancy.benefits == true

--- a/app/views/publishers/vacancies/vacancy_review_sections/_job_details.html.slim
+++ b/app/views/publishers/vacancies/vacancy_review_sections/_job_details.html.slim
@@ -9,8 +9,8 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
       ul.govuk-list.govuk-list--spaced
         = vacancy_job_locations(vacancy)
     - unless vacancy.legacy_draft? || current_organisation.school?
-      - row.action text: t("buttons.change"),
-                  href: organisation_job_build_path(vacancy.id, :job_location, "back_to_#{action_name}": "true"),
+      - row.with_action text: t("buttons.change"),
+                  href: organisation_job_build_path(vacancy.id, :job_location, "back_to_#{with_action_name}": "true"),
                   visually_hidden_text: t("publishers.vacancies.steps.job_location")
 
   - summary_list.row(html_attributes: { id: "job_role" }) do |row|
@@ -19,8 +19,8 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
     - row.value
       = t("helpers.label.publishers_job_listing_job_role_form.job_role_options.#{vacancy.job_role}") if vacancy.job_role?
     - unless vacancy.legacy_draft?
-      - row.action text: t("buttons.change"),
-                  href: organisation_job_build_path(vacancy.id, :job_role, "back_to_#{action_name}": "true"),
+      - row.with_action text: t("buttons.change"),
+                  href: organisation_job_build_path(vacancy.id, :job_role, "back_to_#{with_action_name}": "true"),
                   visually_hidden_text: t("publishers.vacancies.steps.job_role")
 
   - summary_list.row(html_attributes: { id: "job_title" }) do |row|
@@ -29,8 +29,8 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
     - row.value
       = vacancy.job_title
     - unless vacancy.legacy_draft?
-      - row.action text: t("buttons.change"),
-                  href: organisation_job_build_path(vacancy.id, :job_title, "back_to_#{action_name}": "true"),
+      - row.with_action text: t("buttons.change"),
+                  href: organisation_job_build_path(vacancy.id, :job_title, "back_to_#{with_action_name}": "true"),
                   visually_hidden_text: t("jobs.job_title")
 
   - if vacancy.allow_key_stages? && vacancy.key_stages.any?
@@ -40,8 +40,8 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
       - row.value
         = vacancy.readable_key_stages
       - unless vacancy.legacy_draft?
-        - row.action text: t("buttons.change"),
-                    href: organisation_job_build_path(vacancy.id, :key_stages, "back_to_#{action_name}": "true"),
+        - row.with_action text: t("buttons.change"),
+                    href: organisation_job_build_path(vacancy.id, :key_stages, "back_to_#{with_action_name}": "true"),
                     visually_hidden_text: t("jobs.key_stage", count: vacancy.key_stages.count)
 
   - if vacancy.allow_subjects? && (vacancy.completed_steps.include?("subjects") || vacancy.completed_steps.include?("job_details"))
@@ -51,8 +51,8 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
       - row.value
         = vacancy.subjects.any? ? vacancy.readable_subjects : t("jobs.not_defined")
       - unless vacancy.legacy_draft?
-        - row.action text: t("buttons.change"),
-                    href: organisation_job_build_path(vacancy.id, :subjects, "back_to_#{action_name}": "true"),
+        - row.with_action text: t("buttons.change"),
+                    href: organisation_job_build_path(vacancy.id, :subjects, "back_to_#{with_action_name}": "true"),
                     visually_hidden_text: t("jobs.subjects", count: vacancy.subjects.count)
 
   - unless vacancy.contract_type.nil?
@@ -62,8 +62,8 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
       - row.value
         = vacancy.contract_type_with_duration
       - unless vacancy.legacy_draft?
-        - row.action text: t("buttons.change"),
-                    href: organisation_job_build_path(vacancy.id, :contract_type, "back_to_#{action_name}": "true"),
+        - row.with_action text: t("buttons.change"),
+                    href: organisation_job_build_path(vacancy.id, :contract_type, "back_to_#{with_action_name}": "true"),
                     visually_hidden_text: t("jobs.contract_type")
 
   - if vacancy.working_patterns.any?
@@ -74,8 +74,8 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
         - row.value
           = vacancy.readable_working_patterns
         - unless vacancy.legacy_draft?
-          - row.action text: t("buttons.change"),
-                      href: organisation_job_build_path(vacancy.id, :working_patterns, "back_to_#{action_name}": "true"),
+          - row.with_action text: t("buttons.change"),
+                      href: organisation_job_build_path(vacancy.id, :working_patterns, "back_to_#{with_action_name}": "true"),
                       visually_hidden_text: t("jobs.working_patterns")
 
       - summary_list.row(html_attributes: { id: "working_patterns_details" }) do |row|
@@ -84,8 +84,8 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
         - row.value
           = vacancy.working_patterns_details? ? vacancy.working_patterns_details : t("jobs.not_defined")
         - unless vacancy.legacy_draft?
-          - row.action text: t("buttons.change"),
-                      href: organisation_job_build_path(vacancy.id, :working_patterns, "back_to_#{action_name}": "true"),
+          - row.with_action text: t("buttons.change"),
+                      href: organisation_job_build_path(vacancy.id, :working_patterns, "back_to_#{with_action_name}": "true"),
                       visually_hidden_text: t("jobs.working_patterns")
 
     - else
@@ -95,8 +95,8 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
         - row.value
             ul.govuk-list.govuk-list--spaced = vacancy_working_patterns(vacancy)
         - unless vacancy.legacy_draft?
-          - row.action text: t("buttons.change"),
-                      href: organisation_job_build_path(vacancy.id, :working_patterns, "back_to_#{action_name}": "true"),
+          - row.with_action text: t("buttons.change"),
+                      href: organisation_job_build_path(vacancy.id, :working_patterns, "back_to_#{with_action_name}": "true"),
                       visually_hidden_text: t("jobs.working_patterns")
 
   - if vacancy.salary_types.any?
@@ -118,8 +118,8 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
               div => "#{t('jobs.pay_scale')}:"
               = vacancy.pay_scale
       - unless vacancy.legacy_draft?
-        - row.action text: t("buttons.change"),
-                      href: organisation_job_build_path(vacancy.id, :pay_package, "back_to_#{action_name}": "true"),
+        - row.with_action text: t("buttons.change"),
+                      href: organisation_job_build_path(vacancy.id, :pay_package, "back_to_#{with_action_name}": "true"),
                       visually_hidden_text: t("jobs.salary_details")
 
   - unless vacancy.benefits.nil?
@@ -130,8 +130,8 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
       - row.value
         = vacancy.benefits? ? "Yes" : "No"
       - unless vacancy.legacy_draft?
-        - row.action text: t("buttons.change"),
-                      href: organisation_job_build_path(vacancy.id, :pay_package, "back_to_#{action_name}": "true"),
+        - row.with_action text: t("buttons.change"),
+                      href: organisation_job_build_path(vacancy.id, :pay_package, "back_to_#{with_action_name}": "true"),
                       visually_hidden_text: t("jobs.benefits")
 
   - if vacancy.benefits == true
@@ -142,6 +142,6 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
       - row.value
         = vacancy.benefits_details
       - unless vacancy.legacy_draft?
-        - row.action text: t("buttons.change"),
+        - row.with_action text: t("buttons.change"),
                       href: organisation_job_build_path(vacancy.id, :pay_package),
                       visually_hidden_text: t("jobs.benefits_details")

--- a/app/views/shared/_subjects_filter.html.slim
+++ b/app/views/shared/_subjects_filter.html.slim
@@ -1,4 +1,4 @@
-- filters_component.group key: "subjects", title: t("jobs.filters.subject"), component: searchable_collection(collection: f.govuk_collection_check_boxes(:subjects,
+- filters_component.with_group key: "subjects", title: t("jobs.filters.subject"), component: searchable_collection(collection: f.govuk_collection_check_boxes(:subjects,
     SUBJECT_OPTIONS,
     :first,
     :first,

--- a/app/views/subscriptions/_fields.html.slim
+++ b/app/views/subscriptions/_fields.html.slim
@@ -9,11 +9,11 @@
 .plain-styling
   = filters(submit_button: f.govuk_submit(t("buttons.apply_filters")),
     options: { remove_filter_links: false }) do |filters_component|
-      - filters_component.group key: "job_roles", component: f.govuk_collection_check_boxes(:job_roles, @form.job_role_options, :first, :last, small: false, legend: { text: t("jobs.filters.job_roles") }, hint: nil)
+      - filters_component.with_group key: "job_roles", component: f.govuk_collection_check_boxes(:job_roles, @form.job_role_options, :first, :last, small: false, legend: { text: t("jobs.filters.job_roles") }, hint: nil)
       = render "shared/subjects_filter", filters_component: filters_component, f: f
-      - filters_component.group key: "ect_statuses", component: f.govuk_collection_check_boxes(:ect_statuses, @form.ect_status_options, :first, :last, small: false, legend: { text: t("jobs.filters.ect_suitable") }, hint: nil)
-      - filters_component.group key: "education_phase", component: f.govuk_collection_check_boxes(:phases, @form.phase_options, :first, :last, small: false, legend: { text: t("jobs.filters.phases") }, hint: nil)
-      - filters_component.group key: "working_patterns", component: f.govuk_collection_check_boxes(:working_patterns, @form.working_pattern_options, :first, :last, small: false, legend: { text: t("jobs.filters.working_patterns") }, hint: nil)
+      - filters_component.with_group key: "ect_statuses", component: f.govuk_collection_check_boxes(:ect_statuses, @form.ect_status_options, :first, :last, small: false, legend: { text: t("jobs.filters.ect_suitable") }, hint: nil)
+      - filters_component.with_group key: "education_phase", component: f.govuk_collection_check_boxes(:phases, @form.phase_options, :first, :last, small: false, legend: { text: t("jobs.filters.phases") }, hint: nil)
+      - filters_component.with_group key: "working_patterns", component: f.govuk_collection_check_boxes(:working_patterns, @form.working_pattern_options, :first, :last, small: false, legend: { text: t("jobs.filters.working_patterns") }, hint: nil)
 
 .divider-bottom class="govuk-!-margin-top-4"
 

--- a/app/views/support_users/feedbacks/satisfaction_ratings.html.slim
+++ b/app/views/support_users/feedbacks/satisfaction_ratings.html.slim
@@ -4,7 +4,7 @@
 
 = tabs do |tabs|
   - @satisfaction_ratings.each do |satisfaction_rating_type|
-    - tabs.navigation_item text: t(".#{satisfaction_rating_type[:feedback_type]}.tab_heading"),
+    - tabs.with_navigation_item text: t(".#{satisfaction_rating_type[:feedback_type]}.tab_heading"),
                            link: support_users_feedback_satisfaction_ratings_path(satisfaction_rating_type: satisfaction_rating_type[:feedback_type]),
                            active: @satisfaction_rating_type[:feedback_type] == satisfaction_rating_type[:feedback_type]
 
@@ -15,7 +15,7 @@
       - @satisfaction_rating_type[:feedback_responses].each do |feedback_response|
         - row.cell(header: true, text: t(".#{@satisfaction_rating_type[:feedback_type]}.table_headings.#{feedback_response}"))
 
-  - table.body do |body|
+  - table.with_body do |body|
     - FeedbackReportingPeriod.all.last(52).reverse_each do |period|
       - results = reporting_period_summary(period, feedback_type: @satisfaction_rating_type[:feedback_type], grouping_key: @satisfaction_rating_type[:grouping_key])
       - body.row html_attributes: { "data-testid": period.to_s } do |row|

--- a/app/views/vacancies/listing/_key_dates_sidebar.html.slim
+++ b/app/views/vacancies/listing/_key_dates_sidebar.html.slim
@@ -1,19 +1,19 @@
 = render TimelineComponent.new do |timeline|
   - if vacancy.expired? && similar_jobs.present?
-    - timeline.heading(title: t("jobs.expired_listing.timeline_heading_with_similar_jobs_link_html",
+    - timeline.with_heading(title: t("jobs.expired_listing.timeline_heading_with_similar_jobs_link_html",
                        date: format_date(vacancy.expires_at, :date_only),
                        similar_jobs_link: govuk_link_to(t("jobs.similar_jobs.anchor_link_text"), "#similar-jobs", { no_visited_state: true })))
   - elsif vacancy.expired?
-    - timeline.heading(title: t("jobs.expired_listing.timeline_heading_html", date: format_date(vacancy.expires_at, :date_only)))
+    - timeline.with_heading(title: t("jobs.expired_listing.timeline_heading_html", date: format_date(vacancy.expires_at, :date_only)))
   - else
-    - timeline.heading(title: days_to_apply(vacancy.expires_at.to_date))
+    - timeline.with_heading(title: days_to_apply(vacancy.expires_at.to_date))
   - case vacancy.start_date_type
     - when "specific_date"
-      - timeline.item(key: t("jobs.starts_on"), value: format_date(vacancy.starts_on))
+      - timeline.with_item(key: t("jobs.starts_on"), value: format_date(vacancy.starts_on))
     - when "date_range"
-      - timeline.item(key: t("jobs.earliest_start_date"), value: format_date(vacancy.earliest_start_date))
-      - timeline.item(key: t("jobs.latest_start_date"), value: format_date(vacancy.latest_start_date))
+      - timeline.with_item(key: t("jobs.earliest_start_date"), value: format_date(vacancy.earliest_start_date))
+      - timeline.with_item(key: t("jobs.latest_start_date"), value: format_date(vacancy.latest_start_date))
     - when "other"
-      - timeline.item(key: t("jobs.other_start_date_details"), value: vacancy.other_start_date_details)
-  - timeline.item(key: t("jobs.application_deadline"), value: format_time_to_datetime_at(vacancy.expires_at))
-  - timeline.item(key: t("jobs.date_listed"), value: format_date(vacancy.publish_on))
+      - timeline.with_item(key: t("jobs.other_start_date_details"), value: vacancy.other_start_date_details)
+  - timeline.with_item(key: t("jobs.application_deadline"), value: format_time_to_datetime_at(vacancy.expires_at))
+  - timeline.with_item(key: t("jobs.date_listed"), value: format_date(vacancy.publish_on))

--- a/app/views/vacancies/search/_filters.html.slim
+++ b/app/views/vacancies/search/_filters.html.slim
@@ -47,11 +47,11 @@ ruby:
   clear_filters_link: { text: t("shared.filter_group.clear_all_filters"), url: jobs_path(vacancies_search.clear_filters_params) },
   options: { heading_text: "Filter", remove_filter_links: true },
   html_attributes: { tabindex: "-1", id: "filters-component" }) do |filters_component|
-    - filters_component.remove_filter_links do |rb|
+    - filters_component.with_remove_filter_links do |rb|
       - filter_types.each do |filter_type|
-        - rb.group(**filter_type.merge(remove_filter_link: { url_helper: :jobs_path, params: vacancies_search.remove_filter_params }))
-    - filters_component.group key: "job_roles", component: f.govuk_collection_check_boxes(:job_roles, form.job_role_options, :first, :last, small: true, legend: { text: t("jobs.filters.job_roles") }, hint: nil)
+        - rb.with_group(**filter_type.merge(remove_filter_link: { url_helper: :jobs_path, params: vacancies_search.remove_filter_params }))
+    - filters_component.with_group key: "job_roles", component: f.govuk_collection_check_boxes(:job_roles, form.job_role_options, :first, :last, small: true, legend: { text: t("jobs.filters.job_roles") }, hint: nil)
     = render "shared/subjects_filter", filters_component: filters_component, f: f
-    - filters_component.group key: "ect_statuses", component: f.govuk_collection_check_boxes(:ect_statuses, form.ect_status_options, :first, :last, small: true, legend: { text: t("jobs.filters.ect_suitable") }, hint: nil)
-    - filters_component.group key: "education_phase", component: f.govuk_collection_check_boxes(:phases, form.phase_options, :first, :last, small: true, legend: { text: t("jobs.filters.phases") }, hint: nil)
-    - filters_component.group key: "working_patterns", component: f.govuk_collection_check_boxes(:working_patterns, form.working_pattern_options, :first, :last, small: true, legend: { text: t("jobs.filters.working_patterns") }, hint: nil)
+    - filters_component.with_group key: "ect_statuses", component: f.govuk_collection_check_boxes(:ect_statuses, form.ect_status_options, :first, :last, small: true, legend: { text: t("jobs.filters.ect_suitable") }, hint: nil)
+    - filters_component.with_group key: "education_phase", component: f.govuk_collection_check_boxes(:phases, form.phase_options, :first, :last, small: true, legend: { text: t("jobs.filters.phases") }, hint: nil)
+    - filters_component.with_group key: "working_patterns", component: f.govuk_collection_check_boxes(:working_patterns, form.working_pattern_options, :first, :last, small: true, legend: { text: t("jobs.filters.working_patterns") }, hint: nil)

--- a/spec/components/card_component_spec.rb
+++ b/spec/components/card_component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CardComponent, type: :component do
       render_inline(described_class.new) do |card|
         card.header { tag.h2 "Hello" }
         card.body { tag.p "World!" }
-        card.action_item(link: tag.a("Click this", href: "/test-url"))
+        card.with_action_item(link: tag.a("Click this", href: "/test-url"))
       end
     end
 

--- a/spec/components/tabs_component_spec.rb
+++ b/spec/components/tabs_component_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe TabsComponent, type: :component do
   context "when navigation items are defined" do
     subject! do
       render_inline(described_class.new(**kwargs)) do |tabs|
-        tabs.navigation_item(text: "A dashboard item", link: "/item", active: true)
-        tabs.navigation_item(text: "Another dashboard item", link: "/another-item", active: false)
+        tabs.with_navigation_item(text: "A dashboard item", link: "/item", active: true)
+        tabs.with_navigation_item(text: "Another dashboard item", link: "/another-item", active: false)
       end
     end
 


### PR DESCRIPTION
https://trello.com/c/SMoYZ3RF/322-upgrade-govuk-components-gem-from-330-400

## Changes in this PR:

Version 3.0.0 of the view-component gem removes the deprecated slots setter method, now we need to use with_SLOT_NAME instead. See here: https://github.com/ViewComponent/view_component/releases/tag/v3.0.0.

We need to make this change in order to be able to [Bump govuk-components from 3.3.0 to 4.0.0](https://github.com/DFE-Digital/teaching-vacancies/pull/5993). I have made these changes in a separate PR in order to keep the dependabot PR clean and understandable.

NOTE: I found the uses of the deprecated methods by running the specs while using the `warn_on_deprecated_slot_setter` flag set in our components. There may be deprecated methods used on pages that are not touched by the tests that will still break if/when we upgrade to govuk-components 4.0.0. 

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
