### PR TITLE
Increase production web app instances to 8

### DIFF
--- a/terraform/workspace-variables/production.tfvars.json
+++ b/terraform/workspace-variables/production.tfvars.json
@@ -22,7 +22,7 @@
   "paas_redis_queue_service_plan": "tiny-ha-5_x",
   "paas_space_name": "teaching-vacancies-production",
   "paas_web_app_deployment_strategy": "blue-green-v2",
-  "paas_web_app_instances": 4,
+  "paas_web_app_instances": 8,
   "paas_web_app_memory": 1536,
   "paas_worker_app_deployment_strategy": "blue-green-v2",
   "paas_worker_app_instances": 4,


### PR DESCRIPTION
We have been receiving spikes of traffic daily that caused our app instances to crash due to high CPU usage.

The mitigation has been temporarily scaling the application web instances from 4 to 8 by hand.

As this is becoming a daily issue, we are permanently setting the number of instances to 8.


## Screenshots of UI changes:
- The blue top chart shows the web requests.
- The middle green chart shows the response time from our service.
- The bottom green chart shows the CPU % usage from our web instances.

You can see how, on the first two spikes between 11:50 and 12:00, with 4 web instances, the response times and CPU usage dramatically increased (and StatusCake triggered a bunch of alerts on Slack and SMS).

The following spike at 12:20 was received by 8 web instances instead. In this case the response times and CPU usage barely increased.

![Screenshot_20230510_123626](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/c09ed7df-06e8-45fa-90d7-4768c09ec17f)

