### PR TITLE
Customer satisfaction question

### DIFF
--- a/app/controllers/general_feedbacks_controller.rb
+++ b/app/controllers/general_feedbacks_controller.rb
@@ -22,7 +22,7 @@ class GeneralFeedbacksController < ApplicationController
 
   def general_feedback_form_params
     params.require(:general_feedback_form)
-          .permit(:comment, :email, :report_a_problem, :user_participation_response, :visit_purpose, :visit_purpose_comment)
+          .permit(:comment, :email, :report_a_problem, :user_participation_response, :visit_purpose, :rating, :visit_purpose_comment)
   end
 
   def feedback_attributes

--- a/app/form_models/general_feedback_form.rb
+++ b/app/form_models/general_feedback_form.rb
@@ -1,5 +1,5 @@
 class GeneralFeedbackForm < BaseForm
-  attr_accessor :comment, :email, :report_a_problem, :user_participation_response, :visit_purpose, :visit_purpose_comment
+  attr_accessor :comment, :email, :report_a_problem, :user_participation_response, :visit_purpose, :visit_purpose_comment, :rating
 
   validates :report_a_problem, inclusion: { in: %w[yes no] }
   validates :comment, presence: true, length: { maximum: 1200 }
@@ -9,4 +9,5 @@ class GeneralFeedbackForm < BaseForm
   validates :visit_purpose, inclusion: { in: Feedback.visit_purposes.keys }
   validates :visit_purpose_comment, presence: true, if: -> { visit_purpose == "other_purpose" }
   validates :visit_purpose_comment, length: { maximum: 1200 }
+  validates :rating, inclusion: { in: Feedback.ratings.keys }
 end

--- a/app/views/general_feedbacks/new.html.slim
+++ b/app/views/general_feedbacks/new.html.slim
@@ -26,7 +26,7 @@
       = f.govuk_radio_buttons_fieldset(:rating, legend: { size: "m" }) do
         = f.govuk_radio_button :rating, :highly_satisfied, label: { text: t("helpers.label.general_feedback_form.rating.highly_satisfied") }, link_errors: true
         = f.govuk_radio_button :rating, :somewhat_satisfied, label: { text: t("helpers.label.general_feedback_form.rating.somewhat_satisfied") }
-        = f.govuk_radio_button :rating, :neither_satisfied_or_unsatisfied, label: { text: t("helpers.label.general_feedback_form.rating.neither_satisfied_or_unsatisfied") }
+        = f.govuk_radio_button :rating, :neither, label: { text: t("helpers.label.general_feedback_form.rating.neither") }
         = f.govuk_radio_button :rating, :somewhat_dissatisfied, label: { text: t("helpers.label.general_feedback_form.rating.somewhat_dissatisfied") }
         = f.govuk_radio_button :rating, :highly_dissatisfied, label: { text: t("helpers.label.general_feedback_form.rating.highly_dissatisfied") }
       end

--- a/app/views/general_feedbacks/new.html.slim
+++ b/app/views/general_feedbacks/new.html.slim
@@ -22,6 +22,14 @@
                 max_chars: 1200
           - else
             = f.govuk_radio_button :visit_purpose, visit_purpose, link_errors: idx.zero?
+      
+      = f.govuk_radio_buttons_fieldset(:rating, legend: { size: "m" }) do
+        = f.govuk_radio_button :rating, :highly_satisfied, label: { text: t("helpers.label.general_feedback_form.rating.highly_satisfied") }, link_errors: true
+        = f.govuk_radio_button :rating, :somewhat_satisfied, label: { text: t("helpers.label.general_feedback_form.rating.somewhat_satisfied") }
+        = f.govuk_radio_button :rating, :neither_satisfied_or_unsatisfied, label: { text: t("helpers.label.general_feedback_form.rating.neither_satisfied_or_unsatisfied") }
+        = f.govuk_radio_button :rating, :somewhat_dissatisfied, label: { text: t("helpers.label.general_feedback_form.rating.somewhat_dissatisfied") }
+        = f.govuk_radio_button :rating, :highly_dissatisfied, label: { text: t("helpers.label.general_feedback_form.rating.highly_dissatisfied") }
+      end
 
       = f.govuk_text_area :comment,
         label: { size: "m" },

--- a/app/views/general_feedbacks/new.html.slim
+++ b/app/views/general_feedbacks/new.html.slim
@@ -22,7 +22,7 @@
                 max_chars: 1200
           - else
             = f.govuk_radio_button :visit_purpose, visit_purpose, link_errors: idx.zero?
-      
+
       = f.govuk_radio_buttons_fieldset(:rating, legend: { size: "m" }) do
         = f.govuk_radio_button :rating, :highly_satisfied, label: { text: t("helpers.label.general_feedback_form.rating.highly_satisfied") }, link_errors: true
         = f.govuk_radio_button :rating, :somewhat_satisfied, label: { text: t("helpers.label.general_feedback_form.rating.somewhat_satisfied") }

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -67,6 +67,8 @@ en:
     visit_purpose_comment:
       blank: Enter the reason for your visit
       too_long: Purpose of visit must not be more than 1,200 characters
+    rating:
+      inclusion: Select how satisfied or dissatisfied you are
   jobseekers_job_alert_further_feedback_form: &job_alert_further_feedback_form_errors
     comment:
       blank: Tell us about the relevancy of your job alerts

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -110,7 +110,7 @@ en:
       date: For example, %{date}
       general_feedback_form:
         comment_html: >-
-          <p class="govuk-hint">Please do not include any information that could identify you personally
+          <p class="govuk-hint">Do not include any information that could identify you personally
           (such as your name or the name of your school).</p><p class="govuk-hint">(Limit is 1,200 characters)</p>
         email: >-
           We'll only use this to tell you about opportunities to take part in user research that helps us improve
@@ -759,7 +759,7 @@ en:
 
     legend:
       general_feedback_form:
-        report_a_problem: Do you need to report a problem, or request support with using Teaching Vacancies?
+        report_a_problem: Do you need to report a problem or request support with using Teaching Vacancies?
         visit_purpose: What did you come to Teaching Vacancies to do?
         user_participation_response: Would you like to participate in our research?
         rating: How satisfied are you with using Teaching Vacancies?
@@ -769,7 +769,7 @@ en:
 
       jobseekers_account_feedback_form:
         rating: How satisfied are you with your experience of using Teaching Vacancies?
-        report_a_problem: Do you need to report a problem, or request support with using Teaching Vacancies?
+        report_a_problem: Do you need to report a problem or request support with using Teaching Vacancies?
         user_participation_response: Would you like to participate in our research?
 
       jobseekers_close_account_feedback_form:
@@ -874,7 +874,7 @@ en:
         starts_on_html: Date job starts (optional<span class='govuk-visually-hidden'> field</span>)</span>
       publishers_job_listing_feedback_form:
         rating: How satisfied are you with the job listing process on Teaching Vacancies?
-        report_a_problem: Do you need to report a problem, or request support with using Teaching Vacancies?
+        report_a_problem: Do you need to report a problem or request support with using Teaching Vacancies?
         user_participation_response: Would you like to participate in our research?
       publishers_job_listing_how_to_receive_applications_form:
         receive_applications: How do you want to receive applications?

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -296,7 +296,7 @@ en:
         rating:
           highly_satisfied: Highly satisfied
           somewhat_satisfied: Somewhat satisfied
-          neither_satisfied_or_unsatisfied: Neither satisfied nor dissatisfied
+          neither: Neither satisfied nor dissatisfied
           somewhat_dissatisfied: Somewhat dissatisfied
           highly_dissatisfied: Highly dissatisfied
 

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -293,6 +293,12 @@ en:
         user_participation_response_options:
           interested: 'Yes'
           uninterested: 'No'
+        rating:
+          highly_satisfied: Highly satisfied
+          somewhat_satisfied: Somewhat satisfied
+          neither_satisfied_or_unsatisfied: Neither satisfied nor dissatisfied
+          somewhat_dissatisfied: Somewhat dissatisfied
+          highly_dissatisfied: Highly dissatisfied
 
       jobseeker:
         email: Email address
@@ -756,6 +762,7 @@ en:
         report_a_problem: Do you need to report a problem, or request support with using Teaching Vacancies?
         visit_purpose: What did you come to Teaching Vacancies to do?
         user_participation_response: Would you like to participate in our research?
+        rating: How satisfied are you with using Teaching Vacancies?
 
       jobseekers_job_alert_further_feedback_form:
         user_participation_response: Would you like to participate in our research?

--- a/spec/form_models/general_feedback_form_spec.rb
+++ b/spec/form_models/general_feedback_form_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe GeneralFeedbackForm, type: :model do
   }
   it { is_expected.to validate_inclusion_of(:visit_purpose).in_array(Feedback.visit_purposes.keys) }
   it { is_expected.to validate_length_of(:visit_purpose_comment).is_at_most(1200) }
+  it { is_expected.to validate_inclusion_of(:rating).in_array(Feedback.ratings.keys) }
 
   describe "#visit_purpose_comment" do
     context "when the visit purpose is not 'other_purpose'" do

--- a/spec/system/general_feedback_spec.rb
+++ b/spec/system/general_feedback_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "Giving general feedback for the service", recaptcha: true do
         Feedback.where(comment: comment,
                        email: email,
                        feedback_type: "general",
+                       rating: "highly_satisfied",
                        recaptcha_score: 0.9,
                        user_participation_response: "interested",
                        visit_purpose: "other_purpose",
@@ -60,6 +61,7 @@ RSpec.describe "Giving general feedback for the service", recaptcha: true do
   def fill_in_general_feedback
     choose name: "general_feedback_form[report_a_problem]", option: "yes"
     choose I18n.t("helpers.label.general_feedback_form.visit_purpose_options.other_purpose")
+    choose I18n.t("helpers.label.general_feedback_form.rating.highly_satisfied")
 
     fill_in "general_feedback_form[visit_purpose_comment]", with: visit_purpose_comment
     fill_in "general_feedback_form[comment]", with: comment


### PR DESCRIPTION
https://trello.com/c/9t7JDhmS/317-add-customer-satisfaction-question-onto-the-general-feedback-form

## Changes in this PR:

This change adds a customer feedback radio button on the general feedback form.

## Screenshots of UI changes:

### Before
<img width="964" alt="Screenshot 2023-05-11 at 09 36 35" src="https://github.com/DFE-Digital/teaching-vacancies/assets/13124899/608fd92e-1270-4a30-83ad-b3765a69097f">

### After
<img width="909" alt="Screenshot 2023-05-11 at 09 34 59" src="https://github.com/DFE-Digital/teaching-vacancies/assets/13124899/e83a65d8-e1a4-45b8-adb8-ea793cb17f0b">


## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
