### PR TITLE
Add occupation and reason to feedback

### DIFF
--- a/app/controllers/general_feedbacks_controller.rb
+++ b/app/controllers/general_feedbacks_controller.rb
@@ -22,7 +22,7 @@ class GeneralFeedbacksController < ApplicationController
 
   def general_feedback_form_params
     params.require(:general_feedback_form)
-          .permit(:comment, :email, :report_a_problem, :user_participation_response, :visit_purpose, :rating, :visit_purpose_comment)
+          .permit(:comment, :email, :report_a_problem, :user_participation_response, :visit_purpose, :rating, :visit_purpose_comment, :occupation)
   end
 
   def feedback_attributes

--- a/app/controllers/jobseekers/account_feedbacks_controller.rb
+++ b/app/controllers/jobseekers/account_feedbacks_controller.rb
@@ -17,7 +17,7 @@ class Jobseekers::AccountFeedbacksController < Jobseekers::BaseController
   private
 
   def account_feedback_form_params
-    params.require(:jobseekers_account_feedback_form).permit(:comment, :email, :origin, :rating, :report_a_problem, :user_participation_response)
+    params.require(:jobseekers_account_feedback_form).permit(:comment, :email, :origin, :rating, :report_a_problem, :user_participation_response, :occupation)
   end
 
   def feedback_attributes

--- a/app/controllers/jobseekers/job_applications/feedbacks_controller.rb
+++ b/app/controllers/jobseekers/job_applications/feedbacks_controller.rb
@@ -15,7 +15,7 @@ class Jobseekers::JobApplications::FeedbacksController < Jobseekers::BaseControl
   private
 
   def feedback_form_params
-    params.require(:jobseekers_job_application_feedback_form).permit(:email, :rating, :comment, :user_participation_response)
+    params.require(:jobseekers_job_application_feedback_form).permit(:email, :rating, :comment, :user_participation_response, :occupation)
   end
 
   def feedback_attributes

--- a/app/controllers/jobseekers/subscriptions/feedbacks/further_feedbacks_controller.rb
+++ b/app/controllers/jobseekers/subscriptions/feedbacks/further_feedbacks_controller.rb
@@ -19,7 +19,7 @@ class Jobseekers::Subscriptions::Feedbacks::FurtherFeedbacksController < Applica
   private
 
   def further_feedback_form_params
-    params.require(:jobseekers_job_alert_further_feedback_form).permit(:comment, :email, :user_participation_response)
+    params.require(:jobseekers_job_alert_further_feedback_form).permit(:comment, :email, :user_participation_response, :occupation)
   end
 
   def update_feedback

--- a/app/controllers/jobseekers/unsubscribe_feedbacks_controller.rb
+++ b/app/controllers/jobseekers/unsubscribe_feedbacks_controller.rb
@@ -36,6 +36,6 @@ class Jobseekers::UnsubscribeFeedbacksController < ApplicationController
 
   def unsubscribe_feedback_form_params
     params.require(:jobseekers_unsubscribe_feedback_form)
-          .permit(:comment, :email, :other_unsubscribe_reason_comment, :unsubscribe_reason, :user_participation_response)
+          .permit(:comment, :email, :other_unsubscribe_reason_comment, :unsubscribe_reason, :user_participation_response, :occupation)
   end
 end

--- a/app/controllers/publishers/vacancies/feedbacks_controller.rb
+++ b/app/controllers/publishers/vacancies/feedbacks_controller.rb
@@ -14,7 +14,7 @@ class Publishers::Vacancies::FeedbacksController < Publishers::Vacancies::BaseCo
   private
 
   def feedback_form_params
-    params.require(:publishers_job_listing_feedback_form).permit(:comment, :email, :rating, :report_a_problem, :user_participation_response)
+    params.require(:publishers_job_listing_feedback_form).permit(:comment, :email, :rating, :report_a_problem, :user_participation_response, :occupation)
   end
 
   def feedback_attributes

--- a/app/form_models/general_feedback_form.rb
+++ b/app/form_models/general_feedback_form.rb
@@ -10,5 +10,5 @@ class GeneralFeedbackForm < BaseForm
   validates :visit_purpose_comment, presence: true, if: -> { visit_purpose == "other_purpose" }
   validates :visit_purpose_comment, length: { maximum: 1200 }
   validates :rating, inclusion: { in: Feedback.ratings.keys }
-  validates :occupation, presence: true, length: { maximum: 30 }, if: -> { user_participation_response == "interested" }
+  validates :occupation, presence: true, if: -> { user_participation_response == "interested" }
 end

--- a/app/form_models/general_feedback_form.rb
+++ b/app/form_models/general_feedback_form.rb
@@ -1,5 +1,5 @@
 class GeneralFeedbackForm < BaseForm
-  attr_accessor :comment, :email, :report_a_problem, :user_participation_response, :visit_purpose, :visit_purpose_comment, :rating
+  attr_accessor :comment, :email, :report_a_problem, :user_participation_response, :visit_purpose, :visit_purpose_comment, :rating, :occupation
 
   validates :report_a_problem, inclusion: { in: %w[yes no] }
   validates :comment, presence: true, length: { maximum: 1200 }
@@ -10,4 +10,5 @@ class GeneralFeedbackForm < BaseForm
   validates :visit_purpose_comment, presence: true, if: -> { visit_purpose == "other_purpose" }
   validates :visit_purpose_comment, length: { maximum: 1200 }
   validates :rating, inclusion: { in: Feedback.ratings.keys }
+  validates :occupation, presence: true, if: -> { user_participation_response == "interested" }
 end

--- a/app/form_models/general_feedback_form.rb
+++ b/app/form_models/general_feedback_form.rb
@@ -10,5 +10,5 @@ class GeneralFeedbackForm < BaseForm
   validates :visit_purpose_comment, presence: true, if: -> { visit_purpose == "other_purpose" }
   validates :visit_purpose_comment, length: { maximum: 1200 }
   validates :rating, inclusion: { in: Feedback.ratings.keys }
-  validates :occupation, presence: true, if: -> { user_participation_response == "interested" }
+  validates :occupation, presence: true, length: { maximum: 30 }, if: -> { user_participation_response == "interested" }
 end

--- a/app/form_models/jobseekers/account_feedback_form.rb
+++ b/app/form_models/jobseekers/account_feedback_form.rb
@@ -5,7 +5,7 @@ class Jobseekers::AccountFeedbackForm < BaseForm
   validates :comment, length: { maximum: 1200 }, if: -> { comment.present? }
   validates :email, presence: true, if: -> { user_participation_response == "interested" }
   validates :email, email_address: true, if: -> { email.present? }
-  validates :occupation, presence: true, length: { maximum: 30 }, if: -> { user_participation_response == "interested" }
+  validates :occupation, presence: true, if: -> { user_participation_response == "interested" }
   validates :rating, inclusion: { in: Feedback.ratings.keys }
   validates :user_participation_response, inclusion: { in: Feedback.user_participation_responses.keys }
 end

--- a/app/form_models/jobseekers/account_feedback_form.rb
+++ b/app/form_models/jobseekers/account_feedback_form.rb
@@ -1,10 +1,11 @@
 class Jobseekers::AccountFeedbackForm < BaseForm
-  attr_accessor :comment, :email, :origin, :rating, :report_a_problem, :user_participation_response
+  attr_accessor :comment, :email, :origin, :rating, :report_a_problem, :user_participation_response, :occupation
 
   validates :report_a_problem, inclusion: { in: %w[yes no] }
   validates :comment, length: { maximum: 1200 }, if: -> { comment.present? }
   validates :email, presence: true, if: -> { user_participation_response == "interested" }
   validates :email, email_address: true, if: -> { email.present? }
+  validates :occupation, presence: true, if: -> { user_participation_response == "interested" }
   validates :rating, inclusion: { in: Feedback.ratings.keys }
   validates :user_participation_response, inclusion: { in: Feedback.user_participation_responses.keys }
 end

--- a/app/form_models/jobseekers/account_feedback_form.rb
+++ b/app/form_models/jobseekers/account_feedback_form.rb
@@ -5,7 +5,7 @@ class Jobseekers::AccountFeedbackForm < BaseForm
   validates :comment, length: { maximum: 1200 }, if: -> { comment.present? }
   validates :email, presence: true, if: -> { user_participation_response == "interested" }
   validates :email, email_address: true, if: -> { email.present? }
-  validates :occupation, presence: true, if: -> { user_participation_response == "interested" }
+  validates :occupation, presence: true, length: { maximum: 30 }, if: -> { user_participation_response == "interested" }
   validates :rating, inclusion: { in: Feedback.ratings.keys }
   validates :user_participation_response, inclusion: { in: Feedback.user_participation_responses.keys }
 end

--- a/app/form_models/jobseekers/job_alert_further_feedback_form.rb
+++ b/app/form_models/jobseekers/job_alert_further_feedback_form.rb
@@ -1,8 +1,9 @@
 class Jobseekers::JobAlertFurtherFeedbackForm < BaseForm
-  attr_accessor :comment, :email, :user_participation_response
+  attr_accessor :comment, :email, :user_participation_response, :occupation
 
   validates :comment, presence: true, length: { maximum: 1200 }
   validates :email, presence: true, if: -> { user_participation_response == "interested" }
+  validates :occupation, presence: true, if: -> { user_participation_response == "interested" }
   validates :email, email_address: true, if: -> { email.present? }
   validates :user_participation_response, inclusion: { in: Feedback.user_participation_responses.keys }
 end

--- a/app/form_models/jobseekers/job_alert_further_feedback_form.rb
+++ b/app/form_models/jobseekers/job_alert_further_feedback_form.rb
@@ -3,7 +3,7 @@ class Jobseekers::JobAlertFurtherFeedbackForm < BaseForm
 
   validates :comment, presence: true, length: { maximum: 1200 }
   validates :email, presence: true, if: -> { user_participation_response == "interested" }
-  validates :occupation, presence: true, length: { maximum: 30 }, if: -> { user_participation_response == "interested" }
+  validates :occupation, presence: true, if: -> { user_participation_response == "interested" }
   validates :email, email_address: true, if: -> { email.present? }
   validates :user_participation_response, inclusion: { in: Feedback.user_participation_responses.keys }
 end

--- a/app/form_models/jobseekers/job_alert_further_feedback_form.rb
+++ b/app/form_models/jobseekers/job_alert_further_feedback_form.rb
@@ -3,7 +3,7 @@ class Jobseekers::JobAlertFurtherFeedbackForm < BaseForm
 
   validates :comment, presence: true, length: { maximum: 1200 }
   validates :email, presence: true, if: -> { user_participation_response == "interested" }
-  validates :occupation, presence: true, if: -> { user_participation_response == "interested" }
+  validates :occupation, presence: true, length: { maximum: 30 }, if: -> { user_participation_response == "interested" }
   validates :email, email_address: true, if: -> { email.present? }
   validates :user_participation_response, inclusion: { in: Feedback.user_participation_responses.keys }
 end

--- a/app/form_models/jobseekers/job_application/feedback_form.rb
+++ b/app/form_models/jobseekers/job_application/feedback_form.rb
@@ -1,11 +1,12 @@
 class Jobseekers::JobApplication::FeedbackForm
   include ActiveModel::Model
 
-  attr_accessor :comment, :email, :rating, :user_participation_response
+  attr_accessor :comment, :email, :rating, :user_participation_response, :occupation
 
   validates :comment, length: { maximum: 1200 }, if: -> { comment.present? }
   validates :email, presence: true, if: -> { user_participation_response == "interested" }
   validates :email, email_address: true, if: -> { email.present? }
+  validates :occupation, presence: true, if: -> { user_participation_response == "interested" }
   validates :rating, inclusion: { in: Feedback.ratings.keys }
   validates :user_participation_response, inclusion: { in: Feedback.user_participation_responses.keys }
 end

--- a/app/form_models/jobseekers/unsubscribe_feedback_form.rb
+++ b/app/form_models/jobseekers/unsubscribe_feedback_form.rb
@@ -3,7 +3,7 @@ class Jobseekers::UnsubscribeFeedbackForm < BaseForm
 
   validates :comment, length: { maximum: 1200 }
   validates :email, presence: true, if: -> { user_participation_response == "interested" }
-  validates :occupation, presence: true, length: { maximum: 30 }, if: -> { user_participation_response == "interested" }
+  validates :occupation, presence: true, if: -> { user_participation_response == "interested" }
   validates :email, email_address: true, if: -> { email.present? }
   validates :other_unsubscribe_reason_comment, presence: true, if: -> { unsubscribe_reason == "other_reason" }
   validates :unsubscribe_reason, inclusion: { in: Feedback.unsubscribe_reasons.keys }

--- a/app/form_models/jobseekers/unsubscribe_feedback_form.rb
+++ b/app/form_models/jobseekers/unsubscribe_feedback_form.rb
@@ -3,7 +3,7 @@ class Jobseekers::UnsubscribeFeedbackForm < BaseForm
 
   validates :comment, length: { maximum: 1200 }
   validates :email, presence: true, if: -> { user_participation_response == "interested" }
-  validates :occupation, presence: true, if: -> { user_participation_response == "interested" }
+  validates :occupation, presence: true, length: { maximum: 30 }, if: -> { user_participation_response == "interested" }
   validates :email, email_address: true, if: -> { email.present? }
   validates :other_unsubscribe_reason_comment, presence: true, if: -> { unsubscribe_reason == "other_reason" }
   validates :unsubscribe_reason, inclusion: { in: Feedback.unsubscribe_reasons.keys }

--- a/app/form_models/jobseekers/unsubscribe_feedback_form.rb
+++ b/app/form_models/jobseekers/unsubscribe_feedback_form.rb
@@ -1,8 +1,9 @@
 class Jobseekers::UnsubscribeFeedbackForm < BaseForm
-  attr_accessor :comment, :email, :other_unsubscribe_reason_comment, :unsubscribe_reason, :user_participation_response
+  attr_accessor :comment, :email, :other_unsubscribe_reason_comment, :unsubscribe_reason, :user_participation_response, :occupation
 
   validates :comment, length: { maximum: 1200 }
   validates :email, presence: true, if: -> { user_participation_response == "interested" }
+  validates :occupation, presence: true, if: -> { user_participation_response == "interested" }
   validates :email, email_address: true, if: -> { email.present? }
   validates :other_unsubscribe_reason_comment, presence: true, if: -> { unsubscribe_reason == "other_reason" }
   validates :unsubscribe_reason, inclusion: { in: Feedback.unsubscribe_reasons.keys }

--- a/app/form_models/publishers/job_listing/feedback_form.rb
+++ b/app/form_models/publishers/job_listing/feedback_form.rb
@@ -3,7 +3,7 @@ class Publishers::JobListing::FeedbackForm < BaseForm
 
   validates :rating, inclusion: { in: Feedback.ratings.keys }
   validates :email, presence: true, if: -> { user_participation_response == "interested" }
-  validates :occupation, presence: true, if: -> { user_participation_response == "interested" }
+  validates :occupation, presence: true, length: { maximum: 30 }, if: -> { user_participation_response == "interested" }
   validates :email, email_address: true, if: -> { email.present? }
   validates :user_participation_response, inclusion: { in: Feedback.user_participation_responses.keys }
 end

--- a/app/form_models/publishers/job_listing/feedback_form.rb
+++ b/app/form_models/publishers/job_listing/feedback_form.rb
@@ -1,8 +1,9 @@
 class Publishers::JobListing::FeedbackForm < BaseForm
-  attr_accessor :comment, :email, :rating, :report_a_problem, :user_participation_response
+  attr_accessor :comment, :email, :rating, :report_a_problem, :user_participation_response, :occupation
 
   validates :rating, inclusion: { in: Feedback.ratings.keys }
   validates :email, presence: true, if: -> { user_participation_response == "interested" }
+  validates :occupation, presence: true, if: -> { user_participation_response == "interested" }
   validates :email, email_address: true, if: -> { email.present? }
   validates :user_participation_response, inclusion: { in: Feedback.user_participation_responses.keys }
 end

--- a/app/form_models/publishers/job_listing/feedback_form.rb
+++ b/app/form_models/publishers/job_listing/feedback_form.rb
@@ -3,7 +3,7 @@ class Publishers::JobListing::FeedbackForm < BaseForm
 
   validates :rating, inclusion: { in: Feedback.ratings.keys }
   validates :email, presence: true, if: -> { user_participation_response == "interested" }
-  validates :occupation, presence: true, length: { maximum: 30 }, if: -> { user_participation_response == "interested" }
+  validates :occupation, presence: true, if: -> { user_participation_response == "interested" }
   validates :email, email_address: true, if: -> { email.present? }
   validates :user_participation_response, inclusion: { in: Feedback.user_participation_responses.keys }
 end

--- a/app/views/general_feedbacks/new.html.slim
+++ b/app/views/general_feedbacks/new.html.slim
@@ -40,7 +40,7 @@
       = f.govuk_radio_buttons_fieldset(:user_participation_response, legend: { size: "m" }) do
         = f.govuk_radio_button :user_participation_response, :interested, link_errors: true do
           = f.govuk_email_field :email, value: (@general_feedback_form.email.presence || current_user_email(current_jobseeker, current_publisher)), required: true
-          = f.govuk_text_area :occupation, required: true, max_chars: 30, rows: 1
+          = f.govuk_text_area :occupation, required: true, rows: 1
         = f.govuk_radio_button :user_participation_response, :uninterested
 
       = recaptcha

--- a/app/views/general_feedbacks/new.html.slim
+++ b/app/views/general_feedbacks/new.html.slim
@@ -40,7 +40,7 @@
       = f.govuk_radio_buttons_fieldset(:user_participation_response, legend: { size: "m" }) do
         = f.govuk_radio_button :user_participation_response, :interested, link_errors: true do
           = f.govuk_email_field :email, value: (@general_feedback_form.email.presence || current_user_email(current_jobseeker, current_publisher)), required: true
-          = f.govuk_text_area :occupation, required: true
+          = f.govuk_text_area :occupation, required: true, max_chars: 30, rows: 1
         = f.govuk_radio_button :user_participation_response, :uninterested
 
       = recaptcha

--- a/app/views/general_feedbacks/new.html.slim
+++ b/app/views/general_feedbacks/new.html.slim
@@ -40,6 +40,7 @@
       = f.govuk_radio_buttons_fieldset(:user_participation_response, legend: { size: "m" }) do
         = f.govuk_radio_button :user_participation_response, :interested, link_errors: true do
           = f.govuk_email_field :email, value: (@general_feedback_form.email.presence || current_user_email(current_jobseeker, current_publisher)), required: true
+          = f.govuk_text_area :occupation, required: true
         = f.govuk_radio_button :user_participation_response, :uninterested
 
       = recaptcha

--- a/app/views/jobseekers/account_feedbacks/new.html.slim
+++ b/app/views/jobseekers/account_feedbacks/new.html.slim
@@ -21,7 +21,7 @@
       = f.govuk_radio_buttons_fieldset(:user_participation_response, legend: { size: "s" }) do
         = f.govuk_radio_button :user_participation_response, :interested, link_errors: true do
           = f.govuk_email_field :email, value: (@account_feedback_form.email.presence || current_jobseeker.email), required: true
-          = f.govuk_text_area :occupation, required: true
+          = f.govuk_text_area :occupation, required: true, max_chars: 30, rows: 1
         = f.govuk_radio_button :user_participation_response, :uninterested
 
       = f.govuk_submit t("buttons.submit")

--- a/app/views/jobseekers/account_feedbacks/new.html.slim
+++ b/app/views/jobseekers/account_feedbacks/new.html.slim
@@ -21,6 +21,7 @@
       = f.govuk_radio_buttons_fieldset(:user_participation_response, legend: { size: "s" }) do
         = f.govuk_radio_button :user_participation_response, :interested, link_errors: true do
           = f.govuk_email_field :email, value: (@account_feedback_form.email.presence || current_jobseeker.email), required: true
+          = f.govuk_text_area :occupation, required: true
         = f.govuk_radio_button :user_participation_response, :uninterested
 
       = f.govuk_submit t("buttons.submit")

--- a/app/views/jobseekers/account_feedbacks/new.html.slim
+++ b/app/views/jobseekers/account_feedbacks/new.html.slim
@@ -21,7 +21,7 @@
       = f.govuk_radio_buttons_fieldset(:user_participation_response, legend: { size: "s" }) do
         = f.govuk_radio_button :user_participation_response, :interested, link_errors: true do
           = f.govuk_email_field :email, value: (@account_feedback_form.email.presence || current_jobseeker.email), required: true
-          = f.govuk_text_area :occupation, required: true, max_chars: 30, rows: 1
+          = f.govuk_text_area :occupation, required: true, rows: 1
         = f.govuk_radio_button :user_participation_response, :uninterested
 
       = f.govuk_submit t("buttons.submit")

--- a/app/views/jobseekers/job_applications/submit.html.slim
+++ b/app/views/jobseekers/job_applications/submit.html.slim
@@ -26,6 +26,7 @@
       = f.govuk_radio_buttons_fieldset(:user_participation_response, legend: { size: "s" }) do
         = f.govuk_radio_button :user_participation_response, :interested, link_errors: true do
           = f.govuk_email_field :email, value: (@application_feedback_form.email.presence || current_jobseeker.email), required: true
+          = f.govuk_text_area :occupation, required: true, rows: 1
         = f.govuk_radio_button :user_participation_response, :uninterested
 
       = f.govuk_submit t("buttons.submit_feedback")

--- a/app/views/jobseekers/subscriptions/feedbacks/further_feedbacks/new.html.slim
+++ b/app/views/jobseekers/subscriptions/feedbacks/further_feedbacks/new.html.slim
@@ -16,7 +16,7 @@
       = f.govuk_radio_buttons_fieldset(:user_participation_response, legend: { size: "s" }) do
         = f.govuk_radio_button :user_participation_response, :interested, link_errors: true do
           = f.govuk_email_field :email, value: (@feedback_form.email.presence || current_jobseeker&.email), required: true
-          = f.govuk_text_area :occupation, required: true, max_chars: 30, rows: 1
+          = f.govuk_text_area :occupation, required: true, rows: 1
         = f.govuk_radio_button :user_participation_response, :uninterested
 
       = recaptcha

--- a/app/views/jobseekers/subscriptions/feedbacks/further_feedbacks/new.html.slim
+++ b/app/views/jobseekers/subscriptions/feedbacks/further_feedbacks/new.html.slim
@@ -16,6 +16,7 @@
       = f.govuk_radio_buttons_fieldset(:user_participation_response, legend: { size: "s" }) do
         = f.govuk_radio_button :user_participation_response, :interested, link_errors: true do
           = f.govuk_email_field :email, value: (@feedback_form.email.presence || current_jobseeker&.email), required: true
+          = f.govuk_text_area :occupation, required: true
         = f.govuk_radio_button :user_participation_response, :uninterested
 
       = recaptcha

--- a/app/views/jobseekers/subscriptions/feedbacks/further_feedbacks/new.html.slim
+++ b/app/views/jobseekers/subscriptions/feedbacks/further_feedbacks/new.html.slim
@@ -16,7 +16,7 @@
       = f.govuk_radio_buttons_fieldset(:user_participation_response, legend: { size: "s" }) do
         = f.govuk_radio_button :user_participation_response, :interested, link_errors: true do
           = f.govuk_email_field :email, value: (@feedback_form.email.presence || current_jobseeker&.email), required: true
-          = f.govuk_text_area :occupation, required: true
+          = f.govuk_text_area :occupation, required: true, max_chars: 30, rows: 1
         = f.govuk_radio_button :user_participation_response, :uninterested
 
       = recaptcha

--- a/app/views/jobseekers/unsubscribe_feedbacks/new.html.slim
+++ b/app/views/jobseekers/unsubscribe_feedbacks/new.html.slim
@@ -28,7 +28,7 @@
       = f.govuk_radio_buttons_fieldset(:user_participation_response, legend: { size: "s" }) do
         = f.govuk_radio_button :user_participation_response, :interested, link_errors: true do
           = f.govuk_email_field :email, value: (@unsubscribe_feedback_form.email.presence || current_jobseeker&.email), required: true
-          = f.govuk_text_area :occupation, required: true, max_chars: 30, rows: 1
+          = f.govuk_text_area :occupation, required: true, rows: 1
         = f.govuk_radio_button :user_participation_response, :uninterested
 
       = f.govuk_submit t("buttons.submit_feedback")

--- a/app/views/jobseekers/unsubscribe_feedbacks/new.html.slim
+++ b/app/views/jobseekers/unsubscribe_feedbacks/new.html.slim
@@ -28,7 +28,7 @@
       = f.govuk_radio_buttons_fieldset(:user_participation_response, legend: { size: "s" }) do
         = f.govuk_radio_button :user_participation_response, :interested, link_errors: true do
           = f.govuk_email_field :email, value: (@unsubscribe_feedback_form.email.presence || current_jobseeker&.email), required: true
-          = f.govuk_text_area :occupation, required: true
+          = f.govuk_text_area :occupation, required: true, max_chars: 30, rows: 1
         = f.govuk_radio_button :user_participation_response, :uninterested
 
       = f.govuk_submit t("buttons.submit_feedback")

--- a/app/views/jobseekers/unsubscribe_feedbacks/new.html.slim
+++ b/app/views/jobseekers/unsubscribe_feedbacks/new.html.slim
@@ -28,6 +28,7 @@
       = f.govuk_radio_buttons_fieldset(:user_participation_response, legend: { size: "s" }) do
         = f.govuk_radio_button :user_participation_response, :interested, link_errors: true do
           = f.govuk_email_field :email, value: (@unsubscribe_feedback_form.email.presence || current_jobseeker&.email), required: true
+          = f.govuk_text_area :occupation, required: true
         = f.govuk_radio_button :user_participation_response, :uninterested
 
       = f.govuk_submit t("buttons.submit_feedback")

--- a/app/views/publishers/vacancies/summary.html.slim
+++ b/app/views/publishers/vacancies/summary.html.slim
@@ -36,6 +36,7 @@
       = f.govuk_radio_buttons_fieldset(:user_participation_response, legend: { size: "s" }) do
         = f.govuk_radio_button :user_participation_response, :interested, link_errors: true do
           = f.govuk_email_field :email, value: (@feedback_form.email.presence || current_publisher.email), required: true
+          = f.govuk_text_area :occupation, required: true, max_chars: 30, rows: 1
         = f.govuk_radio_button :user_participation_response, :uninterested
 
       = f.govuk_submit t("buttons.submit_feedback")

--- a/app/views/publishers/vacancies/summary.html.slim
+++ b/app/views/publishers/vacancies/summary.html.slim
@@ -36,7 +36,7 @@
       = f.govuk_radio_buttons_fieldset(:user_participation_response, legend: { size: "s" }) do
         = f.govuk_radio_button :user_participation_response, :interested, link_errors: true do
           = f.govuk_email_field :email, value: (@feedback_form.email.presence || current_publisher.email), required: true
-          = f.govuk_text_area :occupation, required: true, max_chars: 30, rows: 1
+          = f.govuk_text_area :occupation, required: true, rows: 1
         = f.govuk_radio_button :user_participation_response, :uninterested
 
       = f.govuk_submit t("buttons.submit_feedback")

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -81,6 +81,7 @@ shared:
     - vacancy_id
     - close_account_reason
     - close_account_reason_comment
+    - occupation
   invitation_to_applies:
     - id
     - jobseeker_id

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -33,6 +33,8 @@ en:
   unsubscribe_feedback_errors: &unsubscribe_feedback_errors
     email:
       blank: Enter your email address
+    occupation:
+      blank: Enter your occupation
     other_unsubscribe_reason_comment:
       blank: Tell us why you want to unsubscribe
     unsubscribe_reason:

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -86,6 +86,9 @@ en:
   jobseekers_job_application_feedback_form: &jobseekers_job_application_feedback_form_errors
     email:
       blank: Enter your email address
+    occupation:
+      blank: Enter your occupation
+      too_long: Occupation must not be more than 30 characters
     rating:
       inclusion: Choose how satisfied you are with the application process
     comment:

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -35,6 +35,7 @@ en:
       blank: Enter your email address
     occupation:
       blank: Enter your occupation
+      too_long: Occupation must not be more than 30 characters
     other_unsubscribe_reason_comment:
       blank: Tell us why you want to unsubscribe
     unsubscribe_reason:
@@ -56,6 +57,7 @@ en:
       inclusion: Please indicate if you'd like to participate in user research
     occupation:
       blank: Enter your occupation
+      too_long: Occupation must not be more than 30 characters
   general_feedback_errors: &general_feedback_errors
     user_participation_response:
       inclusion: Please indicate if you'd like to participate in user research
@@ -63,6 +65,7 @@ en:
       blank: Enter your email address
     occupation:
       blank: Enter your occupation
+      too_long: Occupation must not be more than 30 characters
     comment:
       blank: Enter your feedback
       too_long: Feedback must not be more than 1,200 characters
@@ -94,6 +97,7 @@ en:
       blank: Enter your email address
     occupation:
       blank: Enter your occupation
+      too_long: Occupation must not be more than 30 characters
     rating:
       inclusion: Choose how satisfied you are with the job listing process
     report_a_problem:

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -92,6 +92,8 @@ en:
   publisher_job_listing_feedback_form: &publisher_job_listing_feedback_form_errors
     email:
       blank: Enter your email address
+    occupation:
+      blank: Enter your occupation
     rating:
       inclusion: Choose how satisfied you are with the job listing process
     report_a_problem:

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -57,6 +57,8 @@ en:
       inclusion: Please indicate if you'd like to participate in user research
     email:
       blank: Enter your email address
+    occupation:
+      blank: Enter your occupation
     comment:
       blank: Enter your feedback
       too_long: Feedback must not be more than 1,200 characters

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -52,6 +52,8 @@ en:
       inclusion: Select yes if you want to report a problem or request support
     user_participation_response:
       inclusion: Please indicate if you'd like to participate in user research
+    occupation:
+      blank: Enter your occupation
   general_feedback_errors: &general_feedback_errors
     user_participation_response:
       inclusion: Please indicate if you'd like to participate in user research

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -115,6 +115,8 @@ en:
         email: >-
           We'll only use this to tell you about opportunities to take part in user research that helps us improve
           Department for Education services.
+        occupation: >-
+          We'll only use this to tell you about opportunities to take part in user research that is relevant to you.
         visit_purpose_comment: >-
           Please tell us what you came here to do. Do not include any information that could identify you personally
           (such as your name or the name of your school).
@@ -299,6 +301,7 @@ en:
           neither: Neither satisfied nor dissatisfied
           somewhat_dissatisfied: Somewhat dissatisfied
           highly_dissatisfied: Highly dissatisfied
+        occupation: What is your occupation?
 
       jobseeker:
         email: Email address

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -127,6 +127,8 @@ en:
         email: >-
           We'll only use this to tell you about opportunities to take part in user research that helps us improve
           Department for Education services.
+        occupation: >-
+          We'll only use this to tell you about opportunities to take part in user research that is relevant to you.
 
       jobseekers_close_account_feedback_form:
         close_account_reason_comment: Your feedback will help us improve the service
@@ -161,6 +163,8 @@ en:
         email: >-
           We'll only use this to tell you about opportunities to take part in user research that helps us improve
           Department for Education services.
+        occupation: >-
+          We'll only use this to tell you about opportunities to take part in user research that is relevant to you.
       jobseekers_job_application_personal_details_form:
         national_insurance_number: >-
           If you have a National Insurance number you should enter it here. It's on your National Insurance card,
@@ -176,6 +180,8 @@ en:
         email: >-
           We'll only use this to tell you about opportunities to take part in user research that helps us improve
           Department for Education services.
+        occupation: >-
+          We'll only use this to tell you about opportunities to take part in user research that is relevant to you.
 
       personal_details_form:
         first_name: Or given names
@@ -195,6 +201,8 @@ en:
         email: >-
           We'll only use this to tell you about opportunities to take part in user research that helps us improve
           Department for Education services.
+        occupation: >-
+          We'll only use this to tell you about opportunities to take part in user research that is relevant to you.
 
       publishers_organisation_form:
         description: Jobseekers will see this description of the %{organisation_type} in the job listing
@@ -231,6 +239,8 @@ en:
         email: >-
           We'll only use this to tell you about opportunities to take part in user research that helps us improve
           Department for Education services.
+        occupation: >-
+          We'll only use this to tell you about opportunities to take part in user research that is relevant to you.
       publishers_job_listing_how_to_receive_applications_form:
         receive_applications_options:
           email: You’ll need to upload an application form

--- a/db/migrate/20230511113514_add_occupation_to_feedbacks.rb
+++ b/db/migrate/20230511113514_add_occupation_to_feedbacks.rb
@@ -1,0 +1,5 @@
+class AddOccupationToFeedbacks < ActiveRecord::Migration[7.0]
+  def change
+    add_column :feedbacks, :occupation, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_14_110415) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_11_113514) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -164,6 +164,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_14_110415) do
     t.integer "close_account_reason"
     t.text "close_account_reason_comment"
     t.string "category"
+    t.text "occupation"
     t.index ["vacancy_id"], name: "index_feedbacks_on_vacancy_id"
   end
 

--- a/spec/form_models/general_feedback_form_spec.rb
+++ b/spec/form_models/general_feedback_form_spec.rb
@@ -19,9 +19,6 @@ RSpec.describe GeneralFeedbackForm, type: :model do
 
   it { is_expected.to validate_presence_of(:comment) }
   it { is_expected.to validate_length_of(:comment).is_at_most(1200) }
-  it { is_expected.to validate_presence_of(:email) }
-  it { is_expected.to allow_value("email@example.com").for(:email) }
-  it { is_expected.to_not allow_value("invalid@email@com").for(:email) }
   it { is_expected.to validate_inclusion_of(:report_a_problem).in_array(%w[yes no]) }
   it {
     is_expected.to validate_inclusion_of(:user_participation_response)
@@ -41,5 +38,20 @@ RSpec.describe GeneralFeedbackForm, type: :model do
 
       it { is_expected.to validate_presence_of(:visit_purpose_comment) }
     end
+  end
+
+  context "when the user_participation_response == 'interested'" do
+    it { is_expected.to validate_presence_of(:occupation) }
+    it { is_expected.to validate_presence_of(:email) }
+    it { is_expected.to allow_value("email@example.com").for(:email) }
+    it { is_expected.to_not allow_value("invalid@email@com").for(:email) }
+  end
+
+  context "when the user_participation_response != 'interested'" do
+    let(:user_participation_response) { "uninterested" }
+
+    it { is_expected.not_to validate_presence_of(:occupation) }
+
+    it { is_expected.not_to validate_presence_of(:email) }
   end
 end

--- a/spec/form_models/jobseekers/account_feedback_form_spec.rb
+++ b/spec/form_models/jobseekers/account_feedback_form_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Jobseekers::AccountFeedbackForm, type: :model do
   subject { described_class.new(params) }
-  let(:user_participation_response) {"interested"}
+  let(:user_participation_response) { "interested" }
   let(:params) do
     {
       comment: "Fancy",

--- a/spec/form_models/jobseekers/account_feedback_form_spec.rb
+++ b/spec/form_models/jobseekers/account_feedback_form_spec.rb
@@ -2,24 +2,36 @@ require "rails_helper"
 
 RSpec.describe Jobseekers::AccountFeedbackForm, type: :model do
   subject { described_class.new(params) }
+  let(:user_participation_response) {"interested"}
   let(:params) do
     {
       comment: "Fancy",
       email: "email@example.com",
       rating: "neither",
       report_a_problem: "no",
-      user_participation_response: "interested",
+      user_participation_response: user_participation_response,
     }
   end
 
   it { is_expected.to validate_inclusion_of(:rating).in_array(Feedback.ratings.keys) }
   it { is_expected.to validate_length_of(:comment).is_at_most(1200) }
-  it { is_expected.to validate_presence_of(:email) }
-  it { is_expected.to allow_value("email@example.com").for(:email) }
-  it { is_expected.to_not allow_value("invalid@email@com").for(:email) }
   it { is_expected.to validate_inclusion_of(:report_a_problem).in_array(%w[yes no]) }
   it {
     is_expected.to validate_inclusion_of(:user_participation_response)
                     .in_array(Feedback.user_participation_responses.keys)
   }
+
+  context "when the user_participation_response == 'interested'" do
+    it { is_expected.to validate_presence_of(:occupation) }
+    it { is_expected.to validate_presence_of(:email) }
+    it { is_expected.to allow_value("email@example.com").for(:email) }
+    it { is_expected.to_not allow_value("invalid@email@com").for(:email) }
+  end
+
+  context "when the user_participation_response != 'interested'" do
+    let(:user_participation_response) { "uninterested" }
+
+    it { is_expected.not_to validate_presence_of(:email) }
+    it { is_expected.not_to validate_presence_of(:occupation) }
+  end
 end

--- a/spec/form_models/jobseekers/job_alert_further_feedback_form_spec.rb
+++ b/spec/form_models/jobseekers/job_alert_further_feedback_form_spec.rb
@@ -2,21 +2,34 @@ require "rails_helper"
 
 RSpec.describe Jobseekers::JobAlertFurtherFeedbackForm, type: :model do
   subject { described_class.new(params) }
+  let(:user_participation_response) { "interested" }
   let(:params) do
     {
       comment: "Found a job mate",
       email: "email@example.com",
-      user_participation_response: "interested",
+      user_participation_response: user_participation_response,
     }
   end
 
-  it { is_expected.to validate_presence_of(:email) }
-  it { is_expected.to allow_value("email@example.com").for(:email) }
-  it { is_expected.to_not allow_value("invalid@email@com").for(:email) }
   it { is_expected.to validate_presence_of(:comment) }
   it { is_expected.to validate_length_of(:comment).is_at_most(1200) }
   it {
     is_expected.to validate_inclusion_of(:user_participation_response)
                   .in_array(Feedback.user_participation_responses.keys)
   }
+
+
+  context "when the user_participation_response == 'interested'" do
+    it { is_expected.to validate_presence_of(:occupation) }
+    it { is_expected.to validate_presence_of(:email) }
+    it { is_expected.to allow_value("email@example.com").for(:email) }
+    it { is_expected.to_not allow_value("invalid@email@com").for(:email) }
+  end
+
+  context "when the user_participation_response != 'interested'" do
+    let(:user_participation_response) { "uninterested" }
+
+    it { is_expected.not_to validate_presence_of(:email) }
+    it { is_expected.not_to validate_presence_of(:occupation) }
+  end
 end

--- a/spec/form_models/jobseekers/job_alert_further_feedback_form_spec.rb
+++ b/spec/form_models/jobseekers/job_alert_further_feedback_form_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe Jobseekers::JobAlertFurtherFeedbackForm, type: :model do
                   .in_array(Feedback.user_participation_responses.keys)
   }
 
-
   context "when the user_participation_response == 'interested'" do
     it { is_expected.to validate_presence_of(:occupation) }
     it { is_expected.to validate_presence_of(:email) }

--- a/spec/form_models/jobseekers/job_application/application_feedback_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/application_feedback_form_spec.rb
@@ -2,21 +2,34 @@ require "rails_helper"
 
 RSpec.describe Jobseekers::JobApplication::FeedbackForm, type: :model do
   subject { described_class.new(params) }
+  let(:user_participation_response) { "interested" }
   let(:params) do
     {
       email: "email@example.com",
       rating: "neither",
-      user_participation_response: "interested",
+      user_participation_response: user_participation_response,
     }
   end
 
-  it { is_expected.to validate_presence_of(:email) }
-  it { is_expected.to allow_value("email@example.com").for(:email) }
-  it { is_expected.to_not allow_value("invalid@email@com").for(:email) }
   it { is_expected.to validate_inclusion_of(:rating).in_array(Feedback.ratings.keys) }
   it { is_expected.to validate_length_of(:comment).is_at_most(1200) }
   it {
     is_expected.to validate_inclusion_of(:user_participation_response)
                     .in_array(Feedback.user_participation_responses.keys)
   }
+
+  context "when the user_participation_response == 'interested'" do
+    it { is_expected.to validate_presence_of(:occupation) }
+    it { is_expected.to validate_presence_of(:email) }
+    it { is_expected.to allow_value("email@example.com").for(:email) }
+    it { is_expected.to_not allow_value("invalid@email@com").for(:email) }
+  end
+
+  context "when the user_participation_response != 'interested'" do
+    let(:user_participation_response) { "uninterested" }
+
+    it { is_expected.not_to validate_presence_of(:occupation) }
+
+    it { is_expected.not_to validate_presence_of(:email) }
+  end
 end

--- a/spec/form_models/jobseekers/unsubscribe_feedback_form_spec.rb
+++ b/spec/form_models/jobseekers/unsubscribe_feedback_form_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe Jobseekers::UnsubscribeFeedbackForm, type: :model do
   subject { described_class.new(params) }
+  let(:user_participation_response) {"interested"}
   let(:params) do
     {
       comment: "Found a job mate",
@@ -11,9 +12,6 @@ RSpec.describe Jobseekers::UnsubscribeFeedbackForm, type: :model do
     }
   end
 
-  it { is_expected.to validate_presence_of(:email) }
-  it { is_expected.to allow_value("email@example.com").for(:email) }
-  it { is_expected.to_not allow_value("invalid@email@com").for(:email) }
   it { is_expected.to validate_inclusion_of(:unsubscribe_reason).in_array(Feedback.unsubscribe_reasons.keys) }
   it { is_expected.to validate_length_of(:comment).is_at_most(1200) }
   it {
@@ -32,4 +30,19 @@ RSpec.describe Jobseekers::UnsubscribeFeedbackForm, type: :model do
 
     it { is_expected.to validate_presence_of(:other_unsubscribe_reason_comment) }
   end
+
+  context "when the user_participation_response == 'interested'" do
+    it { is_expected.to validate_presence_of(:occupation) }
+    it { is_expected.to validate_presence_of(:email) }
+    it { is_expected.to allow_value("email@example.com").for(:email) }
+    it { is_expected.to_not allow_value("invalid@email@com").for(:email) }
+  end
+
+  context "when the user_participation_response != 'interested'" do
+    let(:user_participation_response) { "uninterested" }
+
+    it { is_expected.not_to validate_presence_of(:email) }
+    it { is_expected.not_to validate_presence_of(:occupation) }
+  end
+
 end

--- a/spec/form_models/jobseekers/unsubscribe_feedback_form_spec.rb
+++ b/spec/form_models/jobseekers/unsubscribe_feedback_form_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Jobseekers::UnsubscribeFeedbackForm, type: :model do
   subject { described_class.new(params) }
-  let(:user_participation_response) {"interested"}
+  let(:user_participation_response) { "interested" }
   let(:params) do
     {
       comment: "Found a job mate",
@@ -44,5 +44,4 @@ RSpec.describe Jobseekers::UnsubscribeFeedbackForm, type: :model do
     it { is_expected.not_to validate_presence_of(:email) }
     it { is_expected.not_to validate_presence_of(:occupation) }
   end
-
 end

--- a/spec/form_models/jobseekers/unsubscribe_feedback_form_spec.rb
+++ b/spec/form_models/jobseekers/unsubscribe_feedback_form_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Jobseekers::UnsubscribeFeedbackForm, type: :model do
       comment: "Found a job mate",
       email: "email@example.com",
       unsubscribe_reason: "job_found",
-      user_participation_response: "interested",
+      user_participation_response: user_participation_response,
     }
   end
 

--- a/spec/form_models/publishers/job_listing/feedback_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/feedback_form_spec.rb
@@ -31,5 +31,4 @@ RSpec.describe Publishers::JobListing::FeedbackForm, type: :model do
     it { is_expected.not_to validate_presence_of(:email) }
     it { is_expected.not_to validate_presence_of(:occupation) }
   end
-
 end

--- a/spec/form_models/publishers/job_listing/feedback_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/feedback_form_spec.rb
@@ -2,21 +2,34 @@ require "rails_helper"
 
 RSpec.describe Publishers::JobListing::FeedbackForm, type: :model do
   subject { described_class.new(params) }
+  let(:user_participation_response) { "interested" }
   let(:params) do
     {
       email: "email@example.com",
       rating: "neither",
       report_a_problem: "no",
-      user_participation_response: "interested",
+      user_participation_response: user_participation_response,
     }
   end
 
-  it { is_expected.to validate_presence_of(:email) }
-  it { is_expected.to allow_value("email@example.com").for(:email) }
-  it { is_expected.to_not allow_value("invalid@email@com").for(:email) }
   it { is_expected.to validate_inclusion_of(:rating).in_array(Feedback.ratings.keys) }
   it {
     is_expected.to validate_inclusion_of(:user_participation_response)
                     .in_array(Feedback.user_participation_responses.keys)
   }
+
+  context "when the user_participation_response == 'interested'" do
+    it { is_expected.to validate_presence_of(:occupation) }
+    it { is_expected.to validate_presence_of(:email) }
+    it { is_expected.to allow_value("email@example.com").for(:email) }
+    it { is_expected.to_not allow_value("invalid@email@com").for(:email) }
+  end
+
+  context "when the user_participation_response != 'interested'" do
+    let(:user_participation_response) { "uninterested" }
+
+    it { is_expected.not_to validate_presence_of(:email) }
+    it { is_expected.not_to validate_presence_of(:occupation) }
+  end
+
 end

--- a/spec/system/general_feedback_spec.rb
+++ b/spec/system/general_feedback_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe "Giving general feedback for the service", recaptcha: true do
   let(:comment) { "Keep going!" }
   let(:email) { "test@example.com" }
+  let(:teacher) { "teacher" }
   let(:visit_purpose_comment) { "testing" }
 
   context "when all required fields are complete" do
@@ -68,5 +69,6 @@ RSpec.describe "Giving general feedback for the service", recaptcha: true do
 
     choose name: "general_feedback_form[user_participation_response]", option: "interested"
     fill_in "email", with: email
+    fill_in "occupation", with: email
   end
 end

--- a/spec/system/general_feedback_spec.rb
+++ b/spec/system/general_feedback_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Giving general feedback for the service", recaptcha: true do
   let(:comment) { "Keep going!" }
   let(:email) { "test@example.com" }
-  let(:teacher) { "teacher" }
+  let(:occupation) { "teacher" }
   let(:visit_purpose_comment) { "testing" }
 
   context "when all required fields are complete" do
@@ -16,6 +16,7 @@ RSpec.describe "Giving general feedback for the service", recaptcha: true do
       expect { click_button I18n.t("buttons.submit_feedback") }.to change {
         Feedback.where(comment: comment,
                        email: email,
+                       occupation: occupation,
                        feedback_type: "general",
                        rating: "highly_satisfied",
                        recaptcha_score: 0.9,
@@ -69,6 +70,6 @@ RSpec.describe "Giving general feedback for the service", recaptcha: true do
 
     choose name: "general_feedback_form[user_participation_response]", option: "interested"
     fill_in "email", with: email
-    fill_in "occupation", with: email
+    fill_in "occupation", with: occupation
   end
 end

--- a/spec/system/jobseekers_can_give_account_feedback_spec.rb
+++ b/spec/system/jobseekers_can_give_account_feedback_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe "Jobseekers can give account feedback" do
   let(:jobseeker) { create(:jobseeker) }
   let(:comment) { "amazing account features!" }
+  let(:occupation) { "Teaching assistant" }
 
   before do
     login_as(jobseeker, scope: :jobseeker)
@@ -16,9 +17,10 @@ RSpec.describe "Jobseekers can give account feedback" do
     choose I18n.t("helpers.label.jobseekers_account_feedback_form.rating_options.somewhat_satisfied")
     choose name: "jobseekers_account_feedback_form[user_participation_response]", option: "interested"
     fill_in "jobseekers_account_feedback_form[comment]", with: comment
+    fill_in "jobseekers_account_feedback_form[occupation]", with: occupation
 
     expect { click_button I18n.t("buttons.submit") }.to change {
-      jobseeker.feedbacks.where(comment: comment, email: jobseeker.email, rating: "somewhat_satisfied", feedback_type: "jobseeker_account", user_participation_response: "interested").count
+      jobseeker.feedbacks.where(comment: comment, email: jobseeker.email, rating: "somewhat_satisfied", feedback_type: "jobseeker_account", user_participation_response: "interested", occupation: occupation).count
     }.by(1)
     expect(current_path).to eq(jobseekers_account_path)
     expect(page).to have_content(I18n.t("jobseekers.account_feedbacks.create.success"))

--- a/spec/system/jobseekers_can_give_application_feedback_spec.rb
+++ b/spec/system/jobseekers_can_give_application_feedback_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Jobseekers can give job application feedback after submitting th
   let(:vacancy) { create(:vacancy, organisations: [build(:school)]) }
   let(:job_application) { create(:job_application, jobseeker: jobseeker, vacancy: vacancy) }
   let(:comment) { "I will never use any other website again" }
+  let(:occupation) { "teacher" }
 
   before { login_as(jobseeker, scope: :jobseeker) }
 
@@ -22,9 +23,10 @@ RSpec.describe "Jobseekers can give job application feedback after submitting th
     choose I18n.t("helpers.label.jobseekers_job_application_feedback_form.rating_options.somewhat_satisfied")
     choose I18n.t("helpers.label.jobseekers_job_application_feedback_form.user_participation_response_options.interested")
     fill_in "jobseekers_job_application_feedback_form[comment]", with: comment
+    fill_in "jobseekers_job_application_feedback_form[occupation]", with: occupation
 
     expect { click_on I18n.t("buttons.submit_feedback") }.to change {
-      jobseeker.feedbacks.where(comment: comment, email: jobseeker.email, feedback_type: "application", rating: "somewhat_satisfied", user_participation_response: "interested").count
+      jobseeker.feedbacks.where(comment: comment, email: jobseeker.email, feedback_type: "application", rating: "somewhat_satisfied", user_participation_response: "interested", occupation: occupation).count
     }.by(1)
 
     expect(current_path).to eq(jobseekers_job_applications_path)

--- a/spec/system/jobseekers_can_give_job_alert_feedback_spec.rb
+++ b/spec/system/jobseekers_can_give_job_alert_feedback_spec.rb
@@ -62,12 +62,14 @@ RSpec.describe "A jobseeker can give feedback on a job alert", recaptcha: true d
     context "when submitting further feedback" do
       let(:comment) { "Excellent" }
       let(:email) { subscription.email }
+      let(:occupation) { "teacher" }
 
       before do
         follow_the_link_in_the_job_alert_email
         fill_in "jobseekers_job_alert_further_feedback_form[comment]", with: comment
         choose name: "jobseekers_job_alert_further_feedback_form[user_participation_response]", option: "interested"
         fill_in "email", with: email
+        fill_in "jobseekers_job_alert_further_feedback_form[occupation]", with: occupation
       end
 
       it "allows the user to submit further feedback" do
@@ -78,6 +80,7 @@ RSpec.describe "A jobseeker can give feedback on a job alert", recaptcha: true d
         expect(feedback.email).to eq email
         expect(feedback.user_participation_response).to eq("interested")
         expect(feedback.recaptcha_score).to eq(0.9)
+        expect(feedback.occupation).to eq(occupation)
       end
 
       context "when recaptcha is invalid" do

--- a/spec/system/jobseekers_can_manage_their_job_alerts_from_the_dashboard_spec.rb
+++ b/spec/system/jobseekers_can_manage_their_job_alerts_from_the_dashboard_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe "Jobseekers can manage their job alerts from the dashboard" do
           click_on I18n.t("buttons.unsubscribe")
           choose I18n.t("helpers.label.jobseekers_unsubscribe_feedback_form.unsubscribe_reason_options.job_found")
           choose name: "jobseekers_unsubscribe_feedback_form[user_participation_response]", option: "interested"
+          fill_in "jobseekers_unsubscribe_feedback_form[occupation]", with: "teacher"
           click_button I18n.t("buttons.submit_feedback")
 
           expect(page).to have_css("h1.govuk-heading-l", text: I18n.t("jobseekers.subscriptions.index.page_title"))

--- a/spec/system/jobseekers_can_unsubscribe_from_subscriptions_spec.rb
+++ b/spec/system/jobseekers_can_unsubscribe_from_subscriptions_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe "A jobseeker can unsubscribe from subscriptions" do
   let(:subscription) { create(:subscription) }
   let(:email) { "email@example.com" }
+  let(:occupation) { "teacher" }
 
   context "with the correct token" do
     before do
@@ -35,6 +36,7 @@ RSpec.describe "A jobseeker can unsubscribe from subscriptions" do
         fill_in "jobseekers_unsubscribe_feedback_form[comment]", with: "Eggs"
         choose name: "jobseekers_unsubscribe_feedback_form[user_participation_response]", option: "interested"
         fill_in "jobseekers_unsubscribe_feedback_form[email]", with: email
+        fill_in "jobseekers_unsubscribe_feedback_form[occupation]", with: occupation
 
         expect { click_on I18n.t("buttons.submit_feedback") }.to change {
           subscription.feedbacks.where(comment: "Eggs",
@@ -42,7 +44,8 @@ RSpec.describe "A jobseeker can unsubscribe from subscriptions" do
                                        feedback_type: "unsubscribe",
                                        other_unsubscribe_reason_comment: "Spam",
                                        search_criteria: subscription.search_criteria,
-                                       unsubscribe_reason: "other_reason").count
+                                       unsubscribe_reason: "other_reason",
+                                       occupation: occupation).count
         }.by(1)
 
         click_on I18n.t("jobseekers.unsubscribe_feedbacks.confirmation.new_search_link")

--- a/spec/system/publishers_can_give_job_listing_feedback_spec.rb
+++ b/spec/system/publishers_can_give_job_listing_feedback_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe "Publishers can give job listing feedback" do
   let(:publisher) { create(:publisher) }
   let(:organisation) { create(:school) }
   let(:comment) { "I love this service!" }
+  let(:occupation) { "Teaching assistant" }
 
   before do
     login_publisher(publisher: publisher, organisation: organisation)
@@ -29,9 +30,10 @@ RSpec.describe "Publishers can give job listing feedback" do
       choose I18n.t("helpers.label.publishers_job_listing_feedback_form.rating_options.somewhat_satisfied")
       choose name: "publishers_job_listing_feedback_form[user_participation_response]", option: "interested"
       fill_in "publishers_job_listing_feedback_form[comment]", with: comment
+      fill_in "publishers_job_listing_feedback_form[occupation]", with: occupation
 
       expect { click_on I18n.t("buttons.submit_feedback") }.to change {
-        publisher.feedbacks.where(comment: comment, email: publisher.email, feedback_type: "vacancy_publisher", user_participation_response: "interested", vacancy_id: vacancy.id).count
+        publisher.feedbacks.where(comment: comment, email: publisher.email, feedback_type: "vacancy_publisher", user_participation_response: "interested", vacancy_id: vacancy.id, occupation: occupation).count
       }.by(1)
 
       expect(current_path).to eq(organisation_jobs_with_type_path(:published))


### PR DESCRIPTION
https://trello.com/c/xGfym78g/311-adding-occupation-and-reason-why-when-opting-into-research-participation-on-feedback-form

## Changes in this PR:

This PR adds an occupation field, which is has a character limit of 30 chars and only visible if the user chooses "yes" to "Would you like to participate in our research", to the following feedback forms:

- general feedback
- subscriptions further feedback
- unsubscribe feedback
- jobseekers account feedback
- job alert further feedback
- publishers job listing feedback

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
