### PR TITLE
Revert "Bump selenium-webdriver from 4.9.0 to 4.9.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -531,7 +531,7 @@ GEM
     sanitize (6.0.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    selenium-webdriver (4.9.1)
+    selenium-webdriver (4.9.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)


### PR DESCRIPTION
Reverts DFE-Digital/teaching-vacancies#6025

It breaks Smoke tests: https://github.com/DFE-Digital/teaching-vacancies/actions/runs/4978333587/jobs/8909064991
Need to re-open the upgrade PR including the smoke test changes.