### PR TITLE
Disable subject filtering from search keywords

### DIFF
--- a/app/form_models/jobseekers/search_form.rb
+++ b/app/form_models/jobseekers/search_form.rb
@@ -58,7 +58,7 @@ class Jobseekers::SearchForm
     # Do not apply filters on landing pages, even if they have a keyword set (as landing pages
     # should always be 100% manually configured) OR if the user changes the filters *without*
     # changing their keywords, do not override their decision
-    return if @keyword.blank? || @landing_page || @previous_keyword == @keyword
+    return if @keyword.blank? || @landing_page.present? || @previous_keyword == @keyword
 
     @filters_from_keyword = Search::KeywordFilterGeneration::QueryParser.filters_from_query(@keyword)
     return unless @filters_from_keyword

--- a/app/form_models/jobseekers/search_form.rb
+++ b/app/form_models/jobseekers/search_form.rb
@@ -63,7 +63,6 @@ class Jobseekers::SearchForm
     @filters_from_keyword = Search::KeywordFilterGeneration::QueryParser.filters_from_query(@keyword)
     return unless @filters_from_keyword
 
-    @subjects += filters_from_keyword["subjects"]
     @job_roles += filters_from_keyword["job_roles"]
     @ect_statuses += filters_from_keyword["ect_statuses"]
     @phases += filters_from_keyword["phases"]
@@ -76,7 +75,6 @@ class Jobseekers::SearchForm
     previous_filters = Search::KeywordFilterGeneration::QueryParser.filters_from_query(@previous_keyword)
     return unless previous_filters
 
-    @subjects -= previous_filters["subjects"]
     @job_roles -= previous_filters["job_roles"]
     @ect_statuses -= previous_filters["ect_statuses"]
     @phases -= previous_filters["phases"]

--- a/spec/form_models/jobseekers/search_form_spec.rb
+++ b/spec/form_models/jobseekers/search_form_spec.rb
@@ -57,52 +57,52 @@ RSpec.describe Jobseekers::SearchForm, type: :model do
   end
 
   describe "#set_filters_from_keyword" do
-    let(:params) { { keyword: keyword, previous_keyword: previous_keyword, landing_page: landing_page, subjects: subjects } }
+    let(:params) { { keyword: keyword, previous_keyword: previous_keyword, landing_page: landing_page, phases: phases } }
 
     context "when landing_page is not present" do
-      let(:keyword) { "math" }
+      let(:keyword) { "biology" }
       let(:previous_keyword) { "" }
       let(:landing_page) { "" }
-      let(:subjects) { %w[Mathematics Statistics] }
+      let(:phases) { [] }
 
       it "sets the filters from the keyword" do
-        expect(subject.subjects).to eq %w[Mathematics Statistics]
+        expect(subject.phases).to eq %w[secondary sixth_form_or_college]
       end
     end
 
     context "when landing_page is present" do
-      let(:keyword) { "math" }
+      let(:keyword) { "biology" }
       let(:previous_keyword) { "" }
       let(:landing_page) { "landing_page" }
-      let(:subjects) { %w[Computing] }
+      let(:phases) { %w[middle_school] }
 
       it "does not set the filters from the keyword" do
-        expect(subject.subjects).to eq %w[Computing]
+        expect(subject.phases).to eq %w[middle_school]
       end
     end
 
     context "when keyword is the same as previous_keyword" do
-      let(:keyword) { "math" }
-      let(:previous_keyword) { "math" }
+      let(:keyword) { "biology" }
+      let(:previous_keyword) { "biology" }
       let(:landing_page) { "" }
-      let(:subjects) { %w[Computing] }
+      let(:phases) { %w[middle_school] }
 
       it "does not set the filters from the keyword" do
-        expect(subject.subjects).to eq %w[Computing]
+        expect(subject.phases).to eq %w[middle_school]
       end
     end
   end
 
   describe "#unset_filters_from_previous_keyword" do
-    let(:params) { { keyword: keyword, previous_keyword: previous_keyword, subjects: subjects } }
+    let(:params) { { keyword: keyword, previous_keyword: previous_keyword, phases: phases } }
 
     context "when keyword is blank and previous_keyword is present" do
       let(:keyword) { "" }
-      let(:previous_keyword) { "maths" }
-      let(:subjects) { %w[Mathematics Statistics] }
+      let(:previous_keyword) { "biology" }
+      let(:phases) { %w[secondary sixth_form_or_college] }
 
       it "unsets the filters set from the previous keyword" do
-        expect(subject.subjects).to eq []
+        expect(subject.phases).to eq []
       end
     end
   end

--- a/spec/system/jobseekers_can_search_for_jobs_spec.rb
+++ b/spec/system/jobseekers_can_search_for_jobs_spec.rb
@@ -30,7 +30,6 @@ RSpec.shared_examples "a successful search" do
     let(:keyword) { "Maths Teacher" }
 
     it "adds the expected filters" do
-      expect(page).to have_css("a", text: "Remove this filter Mathematics")
       expect(page).to have_css("a", text: "Remove this filter Teacher")
     end
 
@@ -56,17 +55,15 @@ RSpec.shared_examples "a successful search" do
       before { click_on I18n.t("shared.filter_group.clear_all_filters") }
 
       it "displays no remove filter links" do
-        expect(page).to_not have_css("a", text: "Remove this filter Mathematics")
         expect(page).to_not have_css("a", text: "Remove this filter Teacher")
       end
     end
 
     context "when removing a filter" do
-      before { click_on "Remove this filter Mathematics" }
+      before { click_on "Remove this filter Teacher" }
 
       it "removes the filter" do
-        expect(page).to_not have_css("a", text: "Remove this filter Mathematics")
-        expect(page).to have_css("a", text: "Remove this filter Teacher")
+        expect(page).to_not have_css("a", text: "Remove this filter Teacher")
       end
     end
   end


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/0jafOSoD
## Changes in this PR:

Some posted jobs don't have a subject.

If the filtering by subject is automatically applied to the search based on the search keywords, those jobs are excluded from the search results.

We are disabling this automatic keyword-based subject filtering to avoid this situation after receiving complaints from affected job posters.

## Screenshots of UI changes:

Before/after, show how the search results filtering for the subject "art and design" stop ped being automatically applied when searching the "art" keyword.

### Before
![Screenshot from 2023-05-15 16-40-46](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/6bb61bf8-f7c1-4706-aec0-0a308693ddbd)

### After
![Screenshot from 2023-05-15 17-04-07](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/8563b432-b296-4050-aa27-aa4efbccb0bb)

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
