### PR TITLE
Turn on authentication fallback due to dfe sign in failure

### DIFF
--- a/terraform/workspace-variables/production_app_env.yml
+++ b/terraform/workspace-variables/production_app_env.yml
@@ -1,6 +1,6 @@
 ---
 APP_ROLE: production
-AUTHENTICATION_FALLBACK: false
+AUTHENTICATION_FALLBACK: true
 BIG_QUERY_DATASET: production_dataset
 DFE_SIGN_IN_ISSUER: https://oidc.signin.education.gov.uk
 DFE_SIGN_IN_REDIRECT_URL: https://teaching-vacancies.service.gov.uk/auth/dfe/callback


### PR DESCRIPTION
## Changes in this PR:

Due to the DFE sign in issues that are currently going on, we may want to turn on fallback authentication by setting `AUTHENTICATION_FALLBACK: true` as instructed [here](https://github.com/DFE-Digital/teaching-vacancies/blob/main/documentation/dsi-integration.md)

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
