### PR TITLE
Revert "Turn on authentication fallback due to dfe sign in failure"

### DIFF
--- a/terraform/workspace-variables/production_app_env.yml
+++ b/terraform/workspace-variables/production_app_env.yml
@@ -1,6 +1,6 @@
 ---
 APP_ROLE: production
-AUTHENTICATION_FALLBACK: true
+AUTHENTICATION_FALLBACK: false
 BIG_QUERY_DATASET: production_dataset
 DFE_SIGN_IN_ISSUER: https://oidc.signin.education.gov.uk
 DFE_SIGN_IN_REDIRECT_URL: https://teaching-vacancies.service.gov.uk/auth/dfe/callback


### PR DESCRIPTION
Reverts DFE-Digital/teaching-vacancies#6037

DFE Sign-in is back online.