### PR TITLE
Switch GH actions Rspec format to default progress

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
         run: bin/rails assets:precompile
 
       - name: Run tests
-        run: bundle exec rspec --format documentation ${{ matrix.test_params.params }}
+        run: bundle exec rspec ${{ matrix.test_params.params }}
 
   frontend-tests:
     name: Run frontend JS unit tests


### PR DESCRIPTION
The "documentation" output is causing us to have to scroll through thousands of output lines to find a failed test.

We are not getting any value from this detailed output, so switching back to the more compact default output will help us quickly identify failed specs.
