### PR TITLE
Set recaptcha failed attempts to Sentry as warning

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -38,7 +38,7 @@ class ErrorsController < ApplicationController
     @form = params[:form_name]
     Sentry.with_scope do |scope|
       scope.set_tags("form.name": @form)
-      Sentry.capture_message("Invalid recaptcha")
+      Sentry.capture_message("Invalid recaptcha", level: :warning)
     end
 
     respond_to do |format|

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Errors" do
 
   describe "GET #invalid_recaptcha" do
     it "sends the error to Sentry" do
-      expect(Sentry).to receive(:capture_message).with("Invalid recaptcha")
+      expect(Sentry).to receive(:capture_message).with("Invalid recaptcha", { level: :warning })
 
       get invalid_recaptcha_path, params: { form_name: "this form" }
     end


### PR DESCRIPTION
## Trello card URL

- https://trello.com/c/QYrQH8Fb/334-triage-and-tackle-sentry-errors

## Changes in this PR:
We are registering these failed attempts to fill the recaptcha as an exception/error.

This is not an exception we need to resolve. There is no point in alerting about individual failures.

Downgrading it to a warning will help us to have enough visibility, but knowing is not an exception we need to act on. Alerts here should be triggered based on hits/time. EG: 100 alerts in 1 hour. This would help us notice when a spam bot attempts to fill out our feedback forms.


### Current state
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/29a4bcfc-0d93-4ec0-823c-45167905137c)
