### PR TITLE
Enforce document presence when submitting form

### DIFF
--- a/app/form_models/publishers/job_listing/documents_form.rb
+++ b/app/form_models/publishers/job_listing/documents_form.rb
@@ -38,6 +38,6 @@ class Publishers::JobListing::DocumentsForm < Publishers::JobListing::VacancyFor
     return unless vacancy.include_additional_documents
     return if documents.present?
 
-    errors.add(:documents, :blank) unless vacancy.supporting_documents.any?
+    errors.add(:documents, :blank)
   end
 end


### PR DESCRIPTION
## Trello card URL

- https://trello.com/c/S2NOImgj/338-bug-exception-when-submitting-empty-upload-additional-documents
- Bug in Sentry: https://teaching-vacancies.sentry.io/issues/3868404686

## Changes in this PR:

The condition allowing to submit an empty "additional document" form as long as another document was already present in the vacancy was causing an exception down the controller.

We had two options:
- Allow submitting the empty form while guarding the controller code against the exception.
- Enforce the presence of a document on form submission through validation. Users can click "back" or "cancel" if they don't want to attach a document. **Team decided to go with this option**.


## Screenshots of UI changes:

### Before
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/d5b4f6f5-b49b-4183-bbf6-141bb920afef)


### After
![Screenshot_20230522_193525](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/fff8f260-5089-4d9a-b4e4-f45900e0e766)

