### PR TITLE
Send Vacancy import validation errors and DFE-Sign-in failures as "warning" to Sentry

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -154,7 +154,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
         )
       end
 
-      Sentry.capture_message("User failed to sign in with DfE Sign In")
+      Sentry.capture_message("User failed to sign in with DfE Sign In", level: :warning)
     end
   end
 end

--- a/app/jobs/import_from_vacancy_sources_job.rb
+++ b/app/jobs/import_from_vacancy_sources_job.rb
@@ -59,7 +59,7 @@ class ImportFromVacancySourcesJob < ApplicationJob
         vacancy.attributes,
       )
 
-      Sentry.capture_message("Vacancy failed to import")
+      Sentry.capture_message("Vacancy failed to import", level: :warning)
     end
   end
 end


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/QYrQH8Fb/334-triage-and-tackle-sentry-errors

## Changes in this PR:

**TLDR**: Turn regular expected controlled third-party dependant errors into warnings to stop cluttering our dev's alerts channel while still tracking them.

[Classify DFE-Sign-in errors as warnings for Sentry](https://github.com/DFE-Digital/teaching-vacancies/commit/c97cdc4231385209778d92e010737ada050c2fe2) 

An individual error on the Sign-in means nothing. It doesn't imply we need to fix anything in our code/service, hence the warning level.

We will define alerts on Sentry based on the number of errors per time. So we will be able to know if the Sign-in service goes down.

[Classify Vacancy import errors as Sentry warning](https://github.com/DFE-Digital/teaching-vacancies/commit/5ff86b26f6e73861f2cd19836f729f1dd0c9bbb9) 

These alerts are for validation errors when importing vacancies from external sources.

Some vacancies failing to be imported due to missing info from the source is a regular thing that doesn't need immediate action on our side. We want to register it, be able to inspect it, etc. But an
occurrence of this is not an exception that needs to be raised in our devs channel.

We are re-classifying these errors as "warnings" and will create alerts based on occurrences per time. So we can notice if many imports fail during an import.

## Screenshots of UI changes:

### Before
Affected exceptions:
![Screenshot from 2023-05-23 10-28-36](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/ee615f77-e868-498e-a74e-eac3c866ecb7)

Slack channel noise:
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/7d9680e3-b648-4b4c-88d8-b4019ae33f12)


## Next steps:
We will set specific rules for sentry alerts on both errors. They will be based on the number of errors triggered in a time window.