### PR TITLE
Switch filtering order to put education phase above subject

### DIFF
--- a/app/views/vacancies/search/_filters.html.slim
+++ b/app/views/vacancies/search/_filters.html.slim
@@ -42,7 +42,6 @@ ruby:
     },
   ]
 
-
 = filters(submit_button: f.govuk_submit(t("buttons.apply_filters")),
   filters: { total_count: form.total_filters },
   clear_filters_link: { text: t("shared.filter_group.clear_all_filters"), url: jobs_path(vacancies_search.clear_filters_params) },

--- a/app/views/vacancies/search/_filters.html.slim
+++ b/app/views/vacancies/search/_filters.html.slim
@@ -9,6 +9,14 @@ ruby:
       selected_method: :last,
     },
     {
+      legend: t("jobs.filters.phases"),
+      key: :phases,
+      selected: form.phases,
+      options: form.phase_options,
+      value_method: :first,
+      selected_method: :last,
+    },
+    {
       legend: t("jobs.filters.subject"),
       key: :subjects,
       selected: form.subjects,
@@ -25,14 +33,6 @@ ruby:
       selected_method: :last,
     },
     {
-      legend: t("jobs.filters.phases"),
-      key: :phases,
-      selected: form.phases,
-      options: form.phase_options,
-      value_method: :first,
-      selected_method: :last,
-    },
-    {
       legend: t("jobs.filters.working_patterns"),
       key: :working_patterns,
       selected: form.working_patterns,
@@ -41,6 +41,7 @@ ruby:
       selected_method: :last,
     },
   ]
+
 
 = filters(submit_button: f.govuk_submit(t("buttons.apply_filters")),
   filters: { total_count: form.total_filters },
@@ -51,7 +52,7 @@ ruby:
       - filter_types.each do |filter_type|
         - rb.with_group(**filter_type.merge(remove_filter_link: { url_helper: :jobs_path, params: vacancies_search.remove_filter_params }))
     - filters_component.with_group key: "job_roles", component: f.govuk_collection_check_boxes(:job_roles, form.job_role_options, :first, :last, small: true, legend: { text: t("jobs.filters.job_roles") }, hint: nil)
+    - filters_component.with_group key: "education_phase", component: f.govuk_collection_check_boxes(:phases, form.phase_options, :first, :last, small: true, legend: { text: t("jobs.filters.phases") }, hint: nil)
     = render "shared/subjects_filter", filters_component: filters_component, f: f
     - filters_component.with_group key: "ect_statuses", component: f.govuk_collection_check_boxes(:ect_statuses, form.ect_status_options, :first, :last, small: true, legend: { text: t("jobs.filters.ect_suitable") }, hint: nil)
-    - filters_component.with_group key: "education_phase", component: f.govuk_collection_check_boxes(:phases, form.phase_options, :first, :last, small: true, legend: { text: t("jobs.filters.phases") }, hint: nil)
     - filters_component.with_group key: "working_patterns", component: f.govuk_collection_check_boxes(:working_patterns, form.working_pattern_options, :first, :last, small: true, legend: { text: t("jobs.filters.working_patterns") }, hint: nil)


### PR DESCRIPTION
https://trello.com/c/3evIa4Rz/341-move-education-phase-further-up-the-filters-above-subject-on-the-jobs-page

## Changes in this PR:

Move the education phase filter on the jobs page to just below the job role filter.

## Screenshots of UI changes:
<img width="1274" alt="Screenshot 2023-05-24 at 11 44 41" src="https://github.com/DFE-Digital/teaching-vacancies/assets/13124899/cf26d25f-1571-4d17-b62f-6edaf74d4688">

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
