### PR TITLE
Remove Map from Jobs search results

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -1,14 +1,10 @@
 class VacanciesController < ApplicationController
-  MAX_TOTAL_RESULTS_FOR_MAP = 500
-
   before_action :set_landing_page, only: %i[index]
   after_action :trigger_search_performed_event, only: %i[index]
 
   def index
     @vacancies_search = Search::VacancySearch.new(form.to_hash, sort: form.sort)
     @pagy, @vacancies = pagy(@vacancies_search.vacancies)
-
-    @show_map = @vacancies_search.location && @vacancies_search.total_count <= MAX_TOTAL_RESULTS_FOR_MAP
   end
 
   def show

--- a/app/services/search/vacancy_search.rb
+++ b/app/services/search/vacancy_search.rb
@@ -49,13 +49,6 @@ class Search::VacancySearch
     @vacancies ||= scope
   end
 
-  def markers
-    @markers ||= Marker.search_by_location(location, radius)
-                       .where(vacancy_id: scope.pluck(:id))
-                       .pluck(:vacancy_id, :organisation_id, :geopoint)
-                       .map { |marker| marker_for_map(*marker) }
-  end
-
   def total_count
     vacancies.count
   end
@@ -70,13 +63,5 @@ class Search::VacancySearch
     scope = scope.search_by_full_text(keyword) if keyword.present?
     scope = scope.reorder(sort.by => sort.order) if sort&.by_db_column?
     scope
-  end
-
-  def marker_for_map(vacancy_id, organisation_id, geopoint)
-    {
-      id: vacancy_id,
-      parent_id: organisation_id,
-      geopoint: RGeo::GeoJSON.encode(geopoint)&.to_json,
-    }
   end
 end

--- a/app/views/vacancies/index.html.slim
+++ b/app/views/vacancies/index.html.slim
@@ -1,5 +1,4 @@
 - content_for :skip_links do
-  = govuk_skip_link(href: "#map-results", text: t("jobs.skip_link_map"))
   = govuk_skip_link(href: "#search-results", text: t("jobs.skip_link_list"))
 
 - content_for :breadcrumbs do
@@ -25,14 +24,6 @@ h1 class="govuk-heading-l" role="heading" aria-level="1"
     .govuk-grid-column-two-thirds-at-desktop
       = render "vacancies/search/fields_and_button", f: f, form: @form
       = render "vacancies/search/open_filters_button", form: @form
-
-      - if @show_map
-        #map-results
-          = map(markers: @vacancies_search.markers,
-                polygon: @vacancies_search.location_search.geojson_polygon,
-                point: @vacancies_search.location_search.geojson_point,
-                radius: @vacancies_search.location_search.radius_in_meters,
-                marker: { type: "vacancy", tracking: { link: "vacancy_visited_from_map", marker: "vacancy_popup_opened_from_map" } })
 
       = govuk_inset_text(text: t("vacancies.international_teacher_advice.text_html",
                                  link: tracked_link_to(t("vacancies.international_teacher_advice.link"), "https://getintoteaching.education.gov.uk/non-uk-teachers", link_type: :international_teacher_advice_link_search_results)))


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/DZ6fcfvw

## Changes in this PR:

Removes the map displayed when a job search includes a search keyword and a location.

## Screenshots of UI changes:

### Before
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/ad70b0e8-2380-493d-890c-b8936b2c8998)

### After
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/2df47fe1-50ab-4f98-85ed-82df5f212be4)

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
