### PR TITLE
Revert "Enforce document presence when submitting form"

### DIFF
--- a/app/form_models/publishers/job_listing/documents_form.rb
+++ b/app/form_models/publishers/job_listing/documents_form.rb
@@ -38,6 +38,6 @@ class Publishers::JobListing::DocumentsForm < Publishers::JobListing::VacancyFor
     return unless vacancy.include_additional_documents
     return if documents.present?
 
-    errors.add(:documents, :blank)
+    errors.add(:documents, :blank) unless vacancy.supporting_documents.any?
   end
 end


### PR DESCRIPTION
Reverts DFE-Digital/teaching-vacancies#6048 
This change causes some flow issues when selecting "no" to add another document ("No" still redirects the user to the upload documents form and doesn't let them go on without uploading a document).