### PR TITLE
Fix documents upload issues

### DIFF
--- a/app/controllers/publishers/vacancies/base_controller.rb
+++ b/app/controllers/publishers/vacancies/base_controller.rb
@@ -37,15 +37,19 @@ class Publishers::Vacancies::BaseController < Publishers::BaseController
     )
   end
 
+  def redirect_to_job_summary
+    if vacancy.published?
+      redirect_to organisation_job_path(vacancy.id), success: t("publishers.vacancies.show.success")
+    else
+      redirect_to organisation_job_review_path(vacancy.id)
+    end
+  end
+
   def redirect_to_next_step
     if save_and_finish_later?
       redirect_to organisation_job_path(vacancy.id), success: t("publishers.vacancies.show.success")
     elsif all_steps_valid?
-      if vacancy.published?
-        redirect_to organisation_job_path(vacancy.id), success: t("publishers.vacancies.show.success")
-      else
-        redirect_to organisation_job_review_path(vacancy.id)
-      end
+      redirect_to_job_summary
     else
       redirect_to organisation_job_build_path(vacancy.id, next_invalid_step)
     end

--- a/app/controllers/publishers/vacancies/documents_controller.rb
+++ b/app/controllers/publishers/vacancies/documents_controller.rb
@@ -29,12 +29,12 @@ class Publishers::Vacancies::DocumentsController < Publishers::Vacancies::BaseCo
   end
 
   def confirm
-    if confirmation_form.valid?
-      return redirect_to_next_step unless uploading_more_documents?
+    return render :index unless confirmation_form.valid?
 
+    if uploading_more_documents?
       redirect_to new_organisation_job_document_path(vacancy.id)
     else
-      render :index
+      redirect_to_job_summary
     end
   end
 

--- a/app/form_models/publishers/job_listing/documents_form.rb
+++ b/app/form_models/publishers/job_listing/documents_form.rb
@@ -38,6 +38,6 @@ class Publishers::JobListing::DocumentsForm < Publishers::JobListing::VacancyFor
     return unless vacancy.include_additional_documents
     return if documents.present?
 
-    errors.add(:documents, :blank) unless vacancy.supporting_documents.any?
+    errors.add(:documents, :blank)
   end
 end

--- a/spec/requests/publishers/vacancies/documents_spec.rb
+++ b/spec/requests/publishers/vacancies/documents_spec.rb
@@ -155,25 +155,25 @@ RSpec.describe "Documents" do
       }
     end
 
-    context "when the form is valid" do
+    context "when upload_additional_document is false" do
       let(:upload_additional_document) { "false" }
 
       context "when upload_additional_document is false" do
-        it "redirects to the new documents form" do
-          expect(request).to redirect_to(organisation_job_path(vacancy.id))
-        end
-      end
-
-      context "when upload_additional_document is true" do
-        let(:upload_additional_document) { "true" }
-
         it "redirects to the next step" do
-          expect(request).to redirect_to(new_organisation_job_document_path(vacancy.id))
+          expect(request).to redirect_to(organisation_job_path(vacancy.id))
         end
       end
     end
 
-    context "when the form is invalid" do
+    context "when upload_additional_document is true" do
+      let(:upload_additional_document) { "true" }
+
+      it "redirects to the new documents form" do
+        expect(request).to redirect_to(new_organisation_job_document_path(vacancy.id))
+      end
+    end
+
+    context "when upload_additional_document is not set" do
       let(:upload_additional_document) { nil }
 
       it "renders the documents index page" do

--- a/spec/system/publishers_can_add_aditional_documents_to_a_vacancy_spec.rb
+++ b/spec/system/publishers_can_add_aditional_documents_to_a_vacancy_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe "Publishers can add aditional documents to a vacancy" do
+  let(:publisher) { create(:publisher) }
+  let(:primary_school) { create(:school, name: "Primary school", phase: "primary") }
+  let(:organisation) { primary_school }
+
+  let!(:vacancy) { create(:vacancy, :draft, :teacher, :ect_suitable, organisations: [primary_school], phases: %w[primary], key_stages: %w[ks1]) }
+
+  scenario "can add an additional documents to a vacancy" do
+    allow(Publishers::DocumentVirusCheck).to receive(:new).and_return(double(safe?: true))
+
+    login_publisher(publisher: publisher, organisation: organisation)
+    visit organisation_jobs_with_type_path
+    click_on "Draft jobs"
+    click_on vacancy.job_title
+    click_review_page_change_link(section: "about_the_role", row: "include_additional_documents")
+    expect(current_path).to eq(organisation_job_build_path(vacancy.id, :include_additional_documents))
+
+    # Publisher can add a first additional document
+    answer_include_additional_documents(true)
+    expect(current_path).to eq(new_organisation_job_document_path(vacancy.id))
+
+    add_document
+    expect(current_path).to eq(organisation_job_documents_path(vacancy.id))
+
+    # Having a first additional document, cannot submit an empty form for a second additional document
+    answer_include_additional_documents(true)
+    expect(current_path).to eq(new_organisation_job_document_path(vacancy.id))
+
+    click_on I18n.t("buttons.save_and_continue")
+    expect(current_path).to eq(organisation_job_documents_path(vacancy.id))
+    expect(page).to have_content("There is a problem")
+
+    # Can continue after attaching a document
+    add_document
+    expect(current_path).to eq(organisation_job_documents_path(vacancy.id))
+
+    # Once decided not to include additional documents, can continue to the next step
+    answer_include_additional_documents(false)
+    expect(current_path).to eq(organisation_job_review_path(vacancy.id))
+    expect(page).to have_content(vacancy.job_role.humanize)
+  end
+
+  def answer_include_additional_documents(include_additional_documents)
+    vacancy.include_additional_documents = include_additional_documents
+    fill_in_include_additional_documents_form_fields(vacancy)
+    click_on I18n.t("buttons.save_and_continue")
+  end
+
+  def add_document
+    page.attach_file("publishers_job_listing_documents_form[documents][]",
+                     Rails.root.join("spec/fixtures/files/blank_job_spec.pdf"))
+    click_on I18n.t("buttons.save_and_continue")
+  end
+end


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/S2NOImgj

## Changes in this PR:

Follows up on:
- https://github.com/DFE-Digital/teaching-vacancies/pull/6048
- https://github.com/DFE-Digital/teaching-vacancies/pull/6056

The condition allowing to submit an empty "additional document" form as long as another document was already present in the vacancy was causing an exception down the controller.

We had two options:

Allow submitting the empty form while guarding the controller code against the exception.
Enforce the presence of a document on form submission through validation. Users can click "back" or "cancel" if they don't want to attach a document. The team decided to go with this option.


## Screenshots of UI changes:

### Before
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/d5b4f6f5-b49b-4183-bbf6-141bb920afef)


### After
![Screenshot_20230522_193525](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/fff8f260-5089-4d9a-b4e4-f45900e0e766)
