### PR TITLE
Do not send Google Tag Manager  JS error to Sentry

### DIFF
--- a/app/assets/javascript/application.js
+++ b/app/assets/javascript/application.js
@@ -34,6 +34,7 @@ Sentry.init({
   release: window.sentryConfig.release,
   integrations: [],
   tracesSampleRate: 0, // Disable tracing (performance monitoring, doesn't impact errors)
+  ignoreErrors: [/'Object\.prototype\.hasOwnProperty\.call\(o,"telephone"\)'/],
 });
 
 const application = Application.start();


### PR DESCRIPTION
This error is rapidly consuming our Sentry quota. It is independent of the service functionality and is code injected from Google Tag Manager for iPhone users.

Ignoring this particular pattern in our code to avoid sending them as transactions to Sentry.
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/cabf34f0-c728-41a2-8935-056289f1fb50)

- Sentry issue: https://teaching-vacancies.sentry.io/issues/3951739124/?project=6328520&query=is%3Aignored&referrer=issue-stream&stream_index=0

## Trello card URL
- https://trello.com/c/QYrQH8Fb/334-triage-and-tackle-sentry-errors