### PR TITLE
Add full stop to This user has not been invited to apply to any roles…

### DIFF
--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -126,8 +126,8 @@ en:
     invitations:
       index:
         no_invitations:
-          school: This user has not been invited to apply to any roles at your school
-          organisation: This user has not been invited to apply to any roles at your organisation
+          school: This user has not been invited to apply to any roles at your school.
+          organisation: This user has not been invited to apply to any roles at your organisation.
     login_keys:
       new:
         notice: >-


### PR DESCRIPTION
… at your school/organisation

https://trello.com/c/foKptOW0/272-full-stop-missing-on-invitation-to-apply-page

## Changes in this PR:

Add a full stop to the his user has not been invited to apply to any roles… text

## Screenshots of UI changes:

### Before
<img width="1126" alt="Screenshot 2023-05-30 at 15 35 03" src="https://github.com/DFE-Digital/teaching-vacancies/assets/13124899/ff3a17a9-c9a7-4e88-899c-3970e83562ca">

### After
<img width="1204" alt="Screenshot 2023-05-30 at 15 34 42" src="https://github.com/DFE-Digital/teaching-vacancies/assets/13124899/ea0dcfcf-0f64-4a82-816d-5fa0fccc6824">

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
