### PR TITLE
Add csat score to feedback table

### DIFF
--- a/app/views/support_users/feedbacks/_feedback_table.html.slim
+++ b/app/views/support_users/feedbacks/_feedback_table.html.slim
@@ -3,6 +3,7 @@
   - t.tags("Source") { |f| source_for(f) }
   - t.tags("Who") { |f| who(f) }
   - t.text("Contact email") { |f| contact_email_for(f) }
+  - t.text("CSAT") { |f| t("helpers.label.general_feedback_form.rating.#{f.rating}") if f.rating }
   - t.text "Comment", :comment
   - t.column("Category") do |f|
     - capture do


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/REoWBbLt/363-correlate-csat-scores-with-user-comments-on-the-support-dashboard

## Changes in this PR:

Add CSAT to the support dashboard

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
