### PR TITLE
Fix documents upload issues (third attempt!)

### DIFF
--- a/app/controllers/publishers/vacancies/documents_controller.rb
+++ b/app/controllers/publishers/vacancies/documents_controller.rb
@@ -5,7 +5,7 @@ class Publishers::Vacancies::DocumentsController < Publishers::Vacancies::BaseCo
 
   def create
     if documents_form.valid?
-      documents_form.documents.each do |document|
+      documents_form.supporting_documents.each do |document|
         vacancy.supporting_documents.attach(document)
         send_event(:supporting_document_created, document.original_filename, document.size, document.content_type)
         send_dfe_analytics_event(:supporting_document_created, document.original_filename, document.size, document.content_type)
@@ -50,7 +50,7 @@ class Publishers::Vacancies::DocumentsController < Publishers::Vacancies::BaseCo
 
   def documents_form_params
     (params[:publishers_job_listing_documents_form] || params)
-      .permit(documents: [])
+      .permit(supporting_documents: [])
       .merge(completed_steps: completed_steps)
   end
 

--- a/app/controllers/publishers/vacancies/documents_controller.rb
+++ b/app/controllers/publishers/vacancies/documents_controller.rb
@@ -68,7 +68,10 @@ class Publishers::Vacancies::DocumentsController < Publishers::Vacancies::BaseCo
 
   def after_document_delete_path
     if vacancy.supporting_documents.none?
-      new_organisation_job_document_path(vacancy.id, back_to_review: params[:back_to_review], back_to_show: params[:back_to_show])
+      organisation_job_build_path(vacancy.id,
+                                  :include_additional_documents,
+                                  back_to_review: params[:back_to_review],
+                                  back_to_show: params[:back_to_show])
     else
       organisation_job_documents_path(vacancy.id, back_to_review: params[:back_to_review], back_to_show: params[:back_to_show])
     end

--- a/app/controllers/publishers/vacancies/documents_controller.rb
+++ b/app/controllers/publishers/vacancies/documents_controller.rb
@@ -29,12 +29,12 @@ class Publishers::Vacancies::DocumentsController < Publishers::Vacancies::BaseCo
   end
 
   def confirm
-    if confirmation_form.valid?
-      return redirect_to_next_step unless uploading_more_documents?
+    return render :index unless confirmation_form.valid?
 
+    if uploading_more_documents?
       redirect_to new_organisation_job_document_path(vacancy.id)
     else
-      render :index
+      redirect_to_next_step
     end
   end
 

--- a/app/form_models/publishers/job_listing/documents_form.rb
+++ b/app/form_models/publishers/job_listing/documents_form.rb
@@ -1,11 +1,11 @@
 class Publishers::JobListing::DocumentsForm < Publishers::JobListing::VacancyForm
-  validates :documents, form_file: true
+  validates :supporting_documents, form_file: true
   validate :document_presence
 
-  attr_accessor :documents
+  attr_accessor :supporting_documents
 
   def self.fields
-    []
+    [:supporting_documents]
   end
 
   def self.optional?
@@ -36,8 +36,8 @@ class Publishers::JobListing::DocumentsForm < Publishers::JobListing::VacancyFor
 
   def document_presence
     return unless vacancy.include_additional_documents
-    return if documents.present?
+    return if supporting_documents.present?
 
-    errors.add(:documents, :blank)
+    errors.add(:supporting_documents, :blank)
   end
 end

--- a/app/form_models/publishers/job_listing/documents_form.rb
+++ b/app/form_models/publishers/job_listing/documents_form.rb
@@ -38,6 +38,6 @@ class Publishers::JobListing::DocumentsForm < Publishers::JobListing::VacancyFor
     return unless vacancy.include_additional_documents
     return if documents.present?
 
-    errors.add(:documents, :blank) unless vacancy.supporting_documents.any?
+    errors.add(:documents, :blank)
   end
 end

--- a/app/form_models/publishers/vacancy_form_sequence.rb
+++ b/app/form_models/publishers/vacancy_form_sequence.rb
@@ -63,8 +63,6 @@ class Publishers::VacancyFormSequence < FormSequence
   end
 
   def not_validatable_steps
-    %i[subjects review].tap do |steps|
-      steps << :documents if @vacancy.supporting_documents.any?
-    end
+    %i[subjects review].freeze
   end
 end

--- a/app/form_models/publishers/vacancy_form_sequence.rb
+++ b/app/form_models/publishers/vacancy_form_sequence.rb
@@ -63,6 +63,8 @@ class Publishers::VacancyFormSequence < FormSequence
   end
 
   def not_validatable_steps
-    %i[subjects review].freeze
+    %i[subjects review].tap do |steps|
+      steps << :documents if @vacancy.supporting_documents.any?
+    end
   end
 end

--- a/app/views/publishers/vacancies/documents/new.html.slim
+++ b/app/views/publishers/vacancies/documents/new.html.slim
@@ -8,7 +8,7 @@
       - if params["back_to_#{action_name}"]
         = f.hidden_field "back_to_#{action_name}", value: "true"
 
-      = f.govuk_file_field :documents,
+      = f.govuk_file_field :supporting_documents,
         label: { text: vacancy_form_page_heading(vacancy, step_process, back_path: back_path), tag: "h1", size: "l" },
         hint: { text: t("helpers.hint.publishers_job_listing_documents_form.documents") },
         accept: ".doc, .docx, .pdf",

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -290,7 +290,7 @@ en:
     include_additional_documents:
       inclusion: Select yes if want to upload additional documents
   documents_errors: &documents_errors
-    documents:
+    supporting_documents:
       blank: Select an additional document
   documents_confirmation_errors: &documents_confirmation_errors
     upload_additional_document:

--- a/spec/form_models/publishers/job_listing/documents_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/documents_form_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 RSpec.describe Publishers::JobListing::DocumentsForm do
-  let(:documents_form) { described_class.new(vacancy: vacancy, documents: [document]) }
+  let(:documents_form) { described_class.new(vacancy: vacancy, supporting_documents: [document]) }
   let(:vacancy) { create(:vacancy) }
-  let(:attribute) { :documents }
+  let(:attribute) { :supporting_documents }
   let(:document) { File.open(Rails.root.join("spec/fixtures/files/blank_job_spec.pdf")) }
 
   it "runs the validations in the form file validator" do

--- a/spec/requests/publishers/vacancies/documents_spec.rb
+++ b/spec/requests/publishers/vacancies/documents_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Documents" do
     context "when the form is valid" do
       let(:request) do
         post organisation_job_documents_path(vacancy.id), params: {
-          publishers_job_listing_documents_form: { documents: [fixture_file_upload("blank_job_spec.pdf", "application/pdf")] },
+          publishers_job_listing_documents_form: { supporting_documents: [fixture_file_upload("blank_job_spec.pdf", "application/pdf")] },
         }
       end
 
@@ -67,7 +67,7 @@ RSpec.describe "Documents" do
 
       before do
         post organisation_job_documents_path(vacancy.id), params: {
-          publishers_job_listing_documents_form: { documents: [file] },
+          publishers_job_listing_documents_form: { supporting_documents: [file] },
         }
       end
 

--- a/spec/requests/publishers/vacancies/documents_spec.rb
+++ b/spec/requests/publishers/vacancies/documents_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe "Documents" do
 
     context "when there are no longer any documents attached to the vacancy" do
       it "redirects to the new documents form" do
-        expect(request).to redirect_to(new_organisation_job_document_path(vacancy.id))
+        expect(request).to redirect_to(organisation_job_build_path(vacancy.id, :include_additional_documents))
       end
     end
 

--- a/spec/requests/publishers/vacancies/documents_spec.rb
+++ b/spec/requests/publishers/vacancies/documents_spec.rb
@@ -155,25 +155,25 @@ RSpec.describe "Documents" do
       }
     end
 
-    context "when the form is valid" do
+    context "when upload_additional_document is false" do
       let(:upload_additional_document) { "false" }
 
       context "when upload_additional_document is false" do
-        it "redirects to the new documents form" do
-          expect(request).to redirect_to(organisation_job_path(vacancy.id))
-        end
-      end
-
-      context "when upload_additional_document is true" do
-        let(:upload_additional_document) { "true" }
-
         it "redirects to the next step" do
-          expect(request).to redirect_to(new_organisation_job_document_path(vacancy.id))
+          expect(request).to redirect_to(organisation_job_path(vacancy.id))
         end
       end
     end
 
-    context "when the form is invalid" do
+    context "when upload_additional_document is true" do
+      let(:upload_additional_document) { "true" }
+
+      it "redirects to the new documents form" do
+        expect(request).to redirect_to(new_organisation_job_document_path(vacancy.id))
+      end
+    end
+
+    context "when upload_additional_document is not set" do
       let(:upload_additional_document) { nil }
 
       it "renders the documents index page" do

--- a/spec/system/publishers_can_add_aditional_documents_to_a_vacancy_spec.rb
+++ b/spec/system/publishers_can_add_aditional_documents_to_a_vacancy_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Publishers can add aditional documents to a vacancy" do
   end
 
   def add_document
-    page.attach_file("publishers_job_listing_documents_form[documents][]",
+    page.attach_file("publishers_job_listing_documents_form[supporting_documents][]",
                      Rails.root.join("spec/fixtures/files/blank_job_spec.pdf"))
     click_on I18n.t("buttons.save_and_continue")
   end

--- a/spec/system/publishers_can_add_aditional_documents_to_a_vacancy_spec.rb
+++ b/spec/system/publishers_can_add_aditional_documents_to_a_vacancy_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe "Publishers can add aditional documents to a vacancy" do
+  let(:publisher) { create(:publisher) }
+  let(:primary_school) { create(:school, name: "Primary school", phase: "primary") }
+  let(:organisation) { primary_school }
+
+  let!(:vacancy) { create(:vacancy, :draft, :teacher, :ect_suitable, organisations: [primary_school], phases: %w[primary], key_stages: %w[ks1]) }
+
+  scenario "can add an additional documents to a vacancy" do
+    allow(Publishers::DocumentVirusCheck).to receive(:new).and_return(double(safe?: true))
+
+    login_publisher(publisher: publisher, organisation: organisation)
+    visit organisation_jobs_with_type_path
+    click_on "Draft jobs"
+    click_on vacancy.job_title
+    click_review_page_change_link(section: "about_the_role", row: "include_additional_documents")
+    expect(current_path).to eq(organisation_job_build_path(vacancy.id, :include_additional_documents))
+
+    # Publisher can add a first additional document
+    answer_include_additional_documents(true)
+    expect(current_path).to eq(new_organisation_job_document_path(vacancy.id))
+
+    add_document
+    expect(current_path).to eq(organisation_job_documents_path(vacancy.id))
+
+    # Having a first additional document, cannot submit an empty form for a second additional document
+    answer_include_additional_documents(true)
+    expect(current_path).to eq(new_organisation_job_document_path(vacancy.id))
+
+    click_on I18n.t("buttons.save_and_continue")
+    expect(current_path).to eq(organisation_job_documents_path(vacancy.id))
+    expect(page).to have_content("There is a problem")
+
+    # Can continue after attaching a document
+    add_document
+    expect(current_path).to eq(organisation_job_documents_path(vacancy.id))
+
+    # Once decided not to include additional documents, can continue to the next step
+    answer_include_additional_documents(false)
+    expect(current_path).to eq(organisation_job_review_path(vacancy.id))
+    expect(page).to have_content(vacancy.job_role.humanize)
+
+    # Can publish the job listing
+    click_on I18n.t("publishers.vacancies.show.heading_component.action.publish")
+    expect(current_path).to eq(organisation_job_summary_path(vacancy.id))
+  end
+
+  def answer_include_additional_documents(include_additional_documents)
+    vacancy.include_additional_documents = include_additional_documents
+    fill_in_include_additional_documents_form_fields(vacancy)
+    click_on I18n.t("buttons.save_and_continue")
+  end
+
+  def add_document
+    page.attach_file("publishers_job_listing_documents_form[documents][]",
+                     Rails.root.join("spec/fixtures/files/blank_job_spec.pdf"))
+    click_on I18n.t("buttons.save_and_continue")
+  end
+end

--- a/spec/system/publishers_can_edit_a_published_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers_can_edit_a_published_vacancy_as_a_school_spec.rb
@@ -269,7 +269,7 @@ RSpec.describe "Publishers can edit a vacancy" do
         allow(Publishers::DocumentVirusCheck).to receive(:new).and_return(double(safe?: true))
         upload_file(
           "new_publishers_job_listing_documents_form",
-          "publishers-job-listing-documents-form-documents-field",
+          "publishers-job-listing-documents-form-supporting-documents-field",
           "spec/fixtures/files/#{filename}",
         )
         click_on I18n.t("buttons.save_and_continue")

--- a/spec/validators/form_file_validator_spec.rb
+++ b/spec/validators/form_file_validator_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe FormFileValidator do
   describe "#validate_each" do
     before { allow_any_instance_of(described_class).to receive(:validating_files_after_form_submission?).and_return(true) }
 
-    context "when the form's file type is :document" do
+    context "when the form's file type is a document" do
       let(:subject) { described_class.new(attributes: [attribute]) }
-      let(:form_with_documents) { Publishers::JobListing::DocumentsForm.new(documents: [uploaded_document]) }
-      let(:attribute) { :documents }
+      let(:form_with_documents) { Publishers::JobListing::DocumentsForm.new(supporting_documents: [uploaded_document]) }
+      let(:attribute) { :supporting_documents }
       let(:uploaded_document) { fixture_file_upload("blank_job_spec.pdf", "application/pdf") }
 
       before { allow_any_instance_of(Publishers::DocumentVirusCheck).to receive(:safe?).and_return(true) }
@@ -34,7 +34,7 @@ RSpec.describe FormFileValidator do
         end
 
         it "adds an error to the form object for the documents field" do
-          expect(form_with_documents.errors.full_messages_for(:documents)).to include("The selected file must be smaller than 5 MB")
+          expect(form_with_documents.errors.full_messages_for(attribute)).to include("The selected file must be smaller than 5 MB")
         end
       end
 
@@ -46,7 +46,7 @@ RSpec.describe FormFileValidator do
         before { subject.validate_each(form_with_documents, attribute, invalid_document) }
 
         it "adds an error to the form object for the documents field" do
-          expect(form_with_documents.errors.full_messages_for(:documents)).to include(error_message)
+          expect(form_with_documents.errors.full_messages_for(attribute)).to include(error_message)
         end
       end
 
@@ -59,12 +59,12 @@ RSpec.describe FormFileValidator do
         end
 
         it "adds an error to the form object for the documents field" do
-          expect(form_with_documents.errors.full_messages_for(:documents)).to include(error_message)
+          expect(form_with_documents.errors.full_messages_for(attribute)).to include(error_message)
         end
       end
     end
 
-    context "when the form's file type is :image" do
+    context "when the form's file type is an image" do
       let(:subject) { described_class.new(attributes: [attribute]) }
       let(:form_with_image) { Publishers::Organisation::LogoForm.new(logo: uploaded_image) }
       let(:attribute) { :logo }


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/S2NOImgj
## Changes in this PR:

Context of previous attempts:
- First attempt: https://github.com/DFE-Digital/teaching-vacancies/pull/6048
- Second attempt:  https://github.com/DFE-Digital/teaching-vacancies/pull/6057

### Context 
The validation bypass on the form was causing an exception on the service, as users were selecting "yes" to upload an additional document question and then submitting the form without any file attached.

This resulted in an exception being raised: https://teaching-vacancies.sentry.io/issues/3868404686



This bypass on the documents form validation was introduced to force the vacancy flow control method `all_steps_valid?` to be successful so the flow can move to the next step after choosing "no" when enquired about wanting to add additional documents or to allow to publish the job vacancy draft.

### What are we doing
- We are removing the validation bypass so forms cannot be submitted without an attached document. 
  - This resolves the original bug.
- We are aligning the `DocumentsForm` attribute naming with `Vacancy` documents attribute naming. 
  - This allows us to align this step with the rest regarding the `FormSequence#all_steps_valid?` validations. With the renaming from `documents` to `supporting_documents` and exposing it as a field, the FormSequence will be able to automatically map the Vacancy supporting documents into the DocumentForm supporting documents and identify the step as valid/already completed.
  - This way, we won't need to bypass or ignore the step validation to check if all the vacancy steps are valid and the vacancy can be progressed/published.

## Exception when allowing the user to submit an empty document form

### Before
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/ad667e93-9323-4aca-a1ad-61c5fffd81ee)

### After
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/d17f0f89-4a57-4fe1-8cba-9614746e0bf4)

## New redirection after deleting all the documents from the vacancy documents list page

### After
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/61e6e1b0-9d4d-4772-9263-ea09096630be)
