### PR TITLE
Split 2 of the jobseeker profile preference roles

### DIFF
--- a/app/form_models/jobseekers/job_preferences_form.rb
+++ b/app/form_models/jobseekers/job_preferences_form.rb
@@ -4,7 +4,8 @@ module Jobseekers
   class JobPreferencesForm
     include Multistep::Form
 
-    ROLES = %i[teacher senior_leader middle_leader teaching_assistant higher_level_teaching_assistant education_support sendco].freeze
+    ROLES = %i[teacher head_of_year head_of_department headteacher_assistant headteacher_deputy headteacher
+               teaching_assistant higher_level_teaching_assistant education_support sendco].freeze
     PHASES = %i[nursery primary middle secondary through].freeze
     WORKING_PATTERNS = %i[full_time part_time].freeze
 
@@ -22,7 +23,7 @@ module Jobseekers
       validate :validate_roles
 
       def options
-        ROLES.to_h { |opt| [opt.to_s, I18n.t("helpers.label.publishers_job_listing_job_role_form.job_role_options.#{opt}")] }
+        ROLES.to_h { |opt| [opt.to_s, I18n.t("helpers.label.jobseekers_job_preferences_form.role_options.#{opt}")] }
       end
 
       def validate_roles

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -369,6 +369,18 @@ en:
         employment_history_section_completed_options:
           false: No, I'll come back to it later
           true: Yes, I've completed this section
+      jobseekers_job_preferences_form:
+        role_options:
+          education_support: Learning support, cover supervisor or tutor
+          head_of_year: Head of year or phase
+          head_of_department: Head of department or curriculum
+          headteacher: Headteacher
+          headteacher_assistant: Assistant headteacher
+          headteacher_deputy: Deputy headteacher
+          higher_level_teaching_assistant: HLTA (higher level teaching assistant)
+          sendco: SENDCo (special educational needs and disabilities coordinator)
+          teacher: Teacher
+          teaching_assistant: Teaching assistant
       jobseekers_qualifications_shared_labels: &jobseekers_qualifications_shared_labels
         category_options:
           gcse: GCSEs

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -22,6 +22,18 @@ namespace :db do # rubocop:disable Metrics/BlockLength
     end
   end
 
+  desc "Replaces removed jobseeker job preferences roles with all the roles they were split into"
+  task split_jobseeker_job_preferences_roles: :environment do
+    # Senior leader got split into 3 new roles.
+    JobPreferences.where("'senior_leader' = ANY(roles)")
+                  .update_all("roles = array_cat(array_remove(roles, 'senior_leader'),
+                                                 '{headteacher, headteacher_deputy, headteacher_assistant}')")
+    # Middle leader got split into 2 new roles.
+    JobPreferences.where("'middle_leader' = ANY(roles)")
+                  .update_all("roles = array_cat(array_remove(roles, 'middle_leader'),
+                                                '{head_of_year, head_of_department}')")
+  end
+
   desc "Asynchronously import organisations from GIAS and seed the database"
   task async_seed: :environment do
     SeedDatabaseJob.perform_later

--- a/spec/lib/tasks/data_spec.rb
+++ b/spec/lib/tasks/data_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "data.rake" do
+  describe ".split_jobseeker_job_preferences_roles" do
+    let(:roles_with_senior_leader) { %w[senior_leader teacher sendco] }
+    let(:job_preferences) { create(:job_preferences, roles: roles_with_senior_leader) }
+
+    subject(:task) { Rake::Task["db:split_jobseeker_job_preferences_roles"] }
+
+    after { task.reenable }
+
+    it "replaces any appearance of 'senior_leader' role with three different roles" do
+      roles = %w[senior_leader teacher sendco]
+      job_preferences = create(:job_preferences, roles: roles)
+
+      expect { task.invoke }
+        .to change { job_preferences.reload.roles }
+        .from(roles)
+        .to(%w[teacher sendco headteacher headteacher_deputy headteacher_assistant])
+    end
+
+    it "replaces any appearance of 'middle_leader' role with two different roles" do
+      roles = %w[teacher middle_leader]
+      job_preferences = create(:job_preferences, roles: roles)
+
+      expect { task.invoke }
+        .to change { job_preferences.reload.roles }
+        .from(roles)
+        .to(%w[teacher head_of_year head_of_department])
+    end
+
+    it "does not change other roles" do
+      roles = %w[teacher sendco]
+      job_preferences = create(:job_preferences, roles: roles)
+      expect { task.invoke }.not_to(change { job_preferences.reload.roles })
+    end
+  end
+end


### PR DESCRIPTION
Two of the jobseeker profiles preferrence roles are bein split into multiple roles.
- "Headteacher, deputy or assistant headteacher" split into 3 roles:
  - "Headteacher"
  - "Deputy headteacher"
  - "Assistant headteacher"
- "Head of year, department, curriculum or phase" split into 2 roles:
  - "Head of year or phase"
  - "Head of department or curriculum"

We are backfilling any existing user preference selecting the replaced broad roles with all the more granular roles they were split into.

## Trello card URL

## Changes in this PR:

- Is there anything specific you want feedback on?

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
