### PR TITLE
Add extra data to failed validation form event

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,6 +15,7 @@ class ApplicationController < ActionController::Base
   before_action :redirect_to_canonical_domain, :set_headers
   before_action :trigger_click_event, if: -> { click_event_param.present? }
   before_action { EventContext.request_event = request_event }
+  before_action { EventContext.dfe_analytics_request_event = dfe_analytics_request_event }
   before_action :set_paper_trail_whodunnit
 
   after_action :trigger_page_visited_event, unless: :request_is_healthcheck?
@@ -88,6 +89,10 @@ class ApplicationController < ActionController::Base
 
   def request_event
     RequestEvent.new(request, response, session, current_jobseeker, current_publisher, current_support_user)
+  end
+
+  def dfe_analytics_request_event
+    DfeAnalyticsRequestEvent.new(request, response, session, current_jobseeker, current_publisher, current_support_user)
   end
 
   def trigger_page_visited_event

--- a/app/form_models/base_form.rb
+++ b/app/form_models/base_form.rb
@@ -17,8 +17,10 @@ class BaseForm
   end
 
   def send_errors_to_big_query
-    EventContext.trigger_event(:form_validation_failed, event_data) if errors.any?
-    EventContext.trigger_for_dfe_analytics(:form_validation_failed, event_data) if errors.any?
+    return if errors.none?
+
+    EventContext.trigger_event(:form_validation_failed, event_data)
+    EventContext.trigger_for_dfe_analytics(:form_validation_failed, event_data)
   end
 
   private

--- a/app/models/event_context.rb
+++ b/app/models/event_context.rb
@@ -1,5 +1,6 @@
 class EventContext < ActiveSupport::CurrentAttributes
   attribute :request_event
+  attribute :dfe_analytics_request_event
   attribute :events_suppressed
 
   # Stop sending events in the current context for the duration of a block
@@ -19,10 +20,9 @@ class EventContext < ActiveSupport::CurrentAttributes
   end
 
   def trigger_for_dfe_analytics(event_type, event_data = {})
-    return if events_suppressed
-    return if event.class != RequestEvent
+    return if dfe_analytics_request_event.nil?
 
-    event.trigger_for_dfe_analytics(event_type, event_data)
+    dfe_analytics_request_event.trigger_for_dfe_analytics(event_type, event_data)
   end
 
   private

--- a/app/services/dfe_analytics_request_event.rb
+++ b/app/services/dfe_analytics_request_event.rb
@@ -1,0 +1,15 @@
+class DfeAnalyticsRequestEvent < RequestEvent
+  def request_data
+    {}
+  end
+
+  def response_data
+    {}
+  end
+
+  def user_data
+    {
+      user_anonymised_session_id: anonymise(session.id),
+    }
+  end
+end

--- a/app/services/event.rb
+++ b/app/services/event.rb
@@ -27,15 +27,9 @@ class Event
 
   def trigger_for_dfe_analytics(event_type, event_data = {})
     fail_safe do
-      event_data = base_data.merge(
-        type: event_type,
-        occurred_at: occurred_at(event_data),
-        data: data.push(*event_data.map { |key, value| { key: key.to_s, value: formatted_value(value) } }),
-      )
-
       dfe_analytics_event = DfE::Analytics::Event.new
         .with_type(event_type)
-        .with_data(event_data)
+        .with_data(base_data.merge(event_data))
         .with_request_details(request)
         .with_response_details(response)
         .with_user(current_jobseeker)


### PR DESCRIPTION
This pull requests fixes the `form_validation_failed` custom event sent to Big Query.
This event needs to use the`Event` class originally built before the DfE Analytics gem was released. This is because, differently from other events we migrated, the `form_validation_failed` event does not have access to sessions and current users data, as the form objects don't inherit from `ApplicationController`.

Unfortunately, this PR adds a bit of duplication, but this is only a temporary measure as when we fully migrate to the new platform we should be able to remove a considerable amount of legacy code including the duplication