### PR TITLE
Search by school type

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -25,6 +25,6 @@ class OrganisationsController < ApplicationController
   end
 
   def strip_empty_filter_checkboxes
-    strip_empty_checkboxes(%i[education_phase key_stage special_school job_availability organisation_types]) unless params[:skip_strip_checkboxes]
+    strip_empty_checkboxes(%i[education_phase key_stage special_school job_availability organisation_types school_types]) unless params[:skip_strip_checkboxes]
   end
 end

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -30,7 +30,7 @@ class VacanciesController < ApplicationController
       params[facet] = params[facet].split if params[facet].is_a?(String)
     end
     params.permit(:keyword, :previous_keyword, :organisation_slug, :location, :radius, :subject, :sort_by,
-                  job_roles: [], ect_statuses: [], subjects: [], phases: [], working_patterns: [], organisation_types: [])
+                  job_roles: [], ect_statuses: [], subjects: [], phases: [], working_patterns: [], organisation_types: [], school_types: [])
   end
 
   def set_landing_page

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -25,7 +25,7 @@ class VacanciesController < ApplicationController
   def search_params
     return @landing_page.criteria if @landing_page
 
-    strip_empty_checkboxes(%i[job_roles ect_statuses subjects phases working_patterns organisation_types]) unless params[:skip_strip_checkboxes]
+    strip_empty_checkboxes(%i[job_roles ect_statuses subjects phases working_patterns organisation_types school_types]) unless params[:skip_strip_checkboxes]
     %w[job_roles subjects phases working_patterns organisation_types].each do |facet|
       params[facet] = params[facet].split if params[facet].is_a?(String)
     end

--- a/app/form_models/jobseekers/search_form.rb
+++ b/app/form_models/jobseekers/search_form.rb
@@ -11,23 +11,10 @@ class Jobseekers::SearchForm
 
   def initialize(params = {})
     strip_trailing_whitespaces_from_params(params)
-    @keyword = params[:keyword] || params[:subject]
-    @previous_keyword = params[:previous_keyword]
-    @landing_page = params[:landing_page]
-    @location = params[:location]
-    @job_roles = params[:job_roles] || []
-    @ect_statuses = params[:ect_statuses] || []
-    @subjects = params[:subjects] || []
-    @phases = params[:phases] || []
-    @working_patterns = params[:working_patterns] || []
-    @organisation_slug = params[:organisation_slug]
-    @organisation_types = params[:organisation_types] || []
-    @school_types = params[:school_types] || []
+    set_filter_variables(params)
     @sort = Search::VacancySort.new(keyword: keyword).update(sort_by: params[:sort_by])
-
     set_filters_from_keyword
     unset_filters_from_previous_keyword
-
     set_radius(params[:radius])
     set_facet_options
     set_total_filters
@@ -46,7 +33,7 @@ class Jobseekers::SearchForm
       phases: @phases,
       working_patterns: @working_patterns,
       organisation_types: @organisation_types,
-      school_types: @school_types
+      school_types: @school_types,
     }.delete_if { |k, v| v.blank? || (k.eql?(:radius) && @location.blank?) }
   end
 
@@ -93,7 +80,22 @@ class Jobseekers::SearchForm
       [option, I18n.t("helpers.label.publishers_job_listing_working_patterns_form.working_patterns_options.#{option}")]
     end
     set_organisation_type_options
-    @school_type_options = ["faith_school", "special_school"].map { |school_type| [school_type, I18n.t("organisations.filters.#{school_type}")] }
+    @school_type_options = %w[faith_school special_school].map { |school_type| [school_type, I18n.t("organisations.filters.#{school_type}")] }
+  end
+
+  def set_filter_variables(params)
+    @keyword = params[:keyword] || params[:subject]
+    @previous_keyword = params[:previous_keyword]
+    @landing_page = params[:landing_page]
+    @location = params[:location]
+    @job_roles = params[:job_roles] || []
+    @ect_statuses = params[:ect_statuses] || []
+    @subjects = params[:subjects] || []
+    @phases = params[:phases] || []
+    @working_patterns = params[:working_patterns] || []
+    @organisation_slug = params[:organisation_slug]
+    @organisation_types = params[:organisation_types] || []
+    @school_types = params[:school_types] || []
   end
 
   def set_total_filters

--- a/app/form_models/jobseekers/search_form.rb
+++ b/app/form_models/jobseekers/search_form.rb
@@ -5,7 +5,7 @@ class Jobseekers::SearchForm
               :location, :radius,
               :organisation_slug,
               :job_roles, :ect_statuses, :organisation_types, :organisation_type_options, :subjects, :phases, :working_patterns,
-              :job_role_options, :ect_status_options,
+              :job_role_options, :ect_status_options, :school_types, :school_type_options,
               :phase_options, :working_pattern_options,
               :filters_from_keyword, :total_filters, :sort
 
@@ -22,6 +22,7 @@ class Jobseekers::SearchForm
     @working_patterns = params[:working_patterns] || []
     @organisation_slug = params[:organisation_slug]
     @organisation_types = params[:organisation_types] || []
+    @school_types = params[:school_types] || []
     @sort = Search::VacancySort.new(keyword: keyword).update(sort_by: params[:sort_by])
 
     set_filters_from_keyword
@@ -45,6 +46,7 @@ class Jobseekers::SearchForm
       phases: @phases,
       working_patterns: @working_patterns,
       organisation_types: @organisation_types,
+      school_types: @school_types
     }.delete_if { |k, v| v.blank? || (k.eql?(:radius) && @location.blank?) }
   end
 
@@ -91,10 +93,11 @@ class Jobseekers::SearchForm
       [option, I18n.t("helpers.label.publishers_job_listing_working_patterns_form.working_patterns_options.#{option}")]
     end
     set_organisation_type_options
+    @school_type_options = ["faith_school", "special_school"].map { |school_type| [school_type, I18n.t("organisations.filters.#{school_type}")] }
   end
 
   def set_total_filters
-    @total_filters = [@job_roles&.count, @ect_statuses&.count, @subjects&.count, @phases&.count, @working_patterns&.count, @organisation_types&.count].compact.sum
+    @total_filters = [@job_roles&.count, @ect_statuses&.count, @subjects&.count, @phases&.count, @working_patterns&.count, @organisation_types&.count, @school_types&.count].compact.sum
   end
 
   def set_radius(radius_param)

--- a/app/form_models/school_search_form.rb
+++ b/app/form_models/school_search_form.rb
@@ -10,6 +10,7 @@ class SchoolSearchForm
   attribute :special_school, default: []
   attribute :job_availability, default: []
   attribute :organisation_types, default: []
+  attribute :school_types, default: []
 
   def to_h
     attrs = attributes.symbolize_keys
@@ -49,6 +50,10 @@ class SchoolSearchForm
       [I18n.t("helpers.label.publishers_job_listing_working_patterns_form.organisation_type_options.academy"), "includes free schools"],
       [I18n.t("helpers.label.publishers_job_listing_working_patterns_form.organisation_type_options.local_authority"), nil],
     ]
+  end
+
+  def school_types_options
+    ["faith_school", "special_school"].map { |school_type| [school_type, I18n.t("organisations.filters.#{school_type}")] }
   end
 
   def assign_attributes(new_attributes)

--- a/app/form_models/school_search_form.rb
+++ b/app/form_models/school_search_form.rb
@@ -53,7 +53,7 @@ class SchoolSearchForm
   end
 
   def school_types_options
-    ["faith_school", "special_school"].map { |school_type| [school_type, I18n.t("organisations.filters.#{school_type}")] }
+    %w[faith_school special_school].map { |school_type| [school_type, I18n.t("organisations.filters.#{school_type}")] }
   end
 
   def assign_attributes(new_attributes)

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -6,6 +6,9 @@ class Organisation < ApplicationRecord
   include PgSearch::Model
   extend FriendlyId
 
+  SPECIAL_SCHOOL_TYPES = ["Community special school", "Foundation special school", "Non-maintained special school", "Academy special converter", "Academy special sponsor led", "Free schools special"].freeze
+  NON_FAITH_RELIGIOUS_CHARACTER_TYPES = ["", "None", "Does not apply", "null"].freeze
+
   friendly_id :slug_candidates, use: :slugged
 
   has_one_attached :logo, service: :amazon_s3_images_and_logos

--- a/app/queries/vacancy_filter_query.rb
+++ b/app/queries/vacancy_filter_query.rb
@@ -23,7 +23,7 @@ class VacancyFilterQuery < ApplicationQuery
     # TODO: Remove this scope when we do not have any more live SEND responsible jobs
     built_scope = built_scope.where(":job_roles = ANY (job_roles)", job_roles: 2) if filters[:job_roles]&.include?("send_responsible")
     built_scope = add_organisation_type_filters(filters, built_scope)
-    built_scope = add_special_school_filters(filters, built_scope)
+    built_scope = add_school_type_filters(filters, built_scope)
     working_patterns = fix_legacy_working_patterns(filters[:working_patterns])
     built_scope = built_scope.with_any_of_working_patterns(working_patterns) if working_patterns.present?
 
@@ -50,10 +50,21 @@ class VacancyFilterQuery < ApplicationQuery
     built_scope.joins(organisation_vacancies: :organisation).where(organisations: { school_type: selected_school_types }).distinct
   end
 
+  def add_school_type_filters(filters, built_scope)
+    built_scope = add_special_school_filters(filters, built_scope)
+    add_faith_school_filters(filters, built_scope)
+  end
+
   def add_special_school_filters(filters, built_scope)
-    return built_scope unless filters[:school_types].present?
+    return built_scope unless filters[:school_types].present? && filters[:school_types].include?("special_school")
 
     built_scope.joins(organisation_vacancies: :organisation).where(organisations: { school_type: ["Community special school", "Foundation special school", "Non-maintained special school", "Academy special converter",  "Academy special sponsor led", "Free schools special"] }).distinct
+  end
+
+  def add_faith_school_filters(filters, built_scope)
+    return built_scope unless filters[:school_types].present? && filters[:school_types].include?("faith_school")
+
+    built_scope.joins(organisation_vacancies: :organisation).where("organisations.gias_data -> 'ReligiousCharacter (name)' IS NOT NULL").distinct
   end
 
   def job_roles(filter)

--- a/app/queries/vacancy_filter_query.rb
+++ b/app/queries/vacancy_filter_query.rb
@@ -54,7 +54,7 @@ class VacancyFilterQuery < ApplicationQuery
     return built_scope unless filters[:school_types].present?
 
     special_school_types = ["Community special school", "Foundation special school", "Non-maintained special school", "Academy special converter", "Academy special sponsor led", "Free schools special"]
-    
+
     if filters[:school_types].include?("faith_school") && filters[:school_types].include?("special_school")
       return built_scope.joins(organisation_vacancies: :organisation).where("organisations.school_type IN (?) OR organisations.gias_data -> 'ReligiousCharacter (name)' IS NOT NULL", special_school_types).distinct
     end

--- a/app/queries/vacancy_filter_query.rb
+++ b/app/queries/vacancy_filter_query.rb
@@ -23,6 +23,7 @@ class VacancyFilterQuery < ApplicationQuery
     # TODO: Remove this scope when we do not have any more live SEND responsible jobs
     built_scope = built_scope.where(":job_roles = ANY (job_roles)", job_roles: 2) if filters[:job_roles]&.include?("send_responsible")
     built_scope = add_organisation_type_filters(filters, built_scope)
+    built_scope = add_special_school_filters(filters, built_scope)
     working_patterns = fix_legacy_working_patterns(filters[:working_patterns])
     built_scope = built_scope.with_any_of_working_patterns(working_patterns) if working_patterns.present?
 
@@ -47,6 +48,12 @@ class VacancyFilterQuery < ApplicationQuery
     end
 
     built_scope.joins(organisation_vacancies: :organisation).where(organisations: { school_type: selected_school_types }).distinct
+  end
+
+  def add_special_school_filters(filters, built_scope)
+    return built_scope unless filters[:school_types].present?
+
+    built_scope.joins(organisation_vacancies: :organisation).where(organisations: { school_type: ["Community special school", "Foundation special school", "Non-maintained special school", "Academy special converter",  "Academy special sponsor led", "Free schools special"] }).distinct
   end
 
   def job_roles(filter)

--- a/app/services/search/school_search.rb
+++ b/app/services/search/school_search.rb
@@ -112,12 +112,12 @@ class Search::SchoolSearch
   def apply_school_type_filter(scope)
     return scope unless school_types.present?
 
-    special_school_types = ["Community special school", "Foundation special school", "Non-maintained special school", "Academy special converter", "Academy special sponsor led", "Free schools special"]
+    if school_types.include?("special_school") && school_types.include?("faith_school")
+      return scope.where.not("gias_data ->> 'ReligiousCharacter (name)' IN (?)", Organisation::NON_FAITH_RELIGIOUS_CHARACTER_TYPES).or(scope.where(school_type: Organisation::SPECIAL_SCHOOL_TYPES))
+    end
 
-    return scope.where("school_type IN (?) OR gias_data -> 'ReligiousCharacter (name)' IS NOT NULL", special_school_types) if school_types.include?("special_school") && school_types.include?("faith_school")
+    return scope.where(school_type: Organisation::SPECIAL_SCHOOL_TYPES) if school_types.include?("special_school")
 
-    return scope.where(school_type: special_school_types) if school_types.include?("special_school")
-
-    scope.where("gias_data -> 'ReligiousCharacter (name)' IS NOT NULL")
+    scope.where.not("gias_data ->> 'ReligiousCharacter (name)' IN (?)", Organisation::NON_FAITH_RELIGIOUS_CHARACTER_TYPES)
   end
 end

--- a/app/services/search/school_search.rb
+++ b/app/services/search/school_search.rb
@@ -56,7 +56,7 @@ class Search::SchoolSearch
     scope = scope.where(phase: education_phase) if education_phase
     scope = scope.where(phase: key_stage_phases) if key_stage_phases
     scope = apply_organisation_type_filter(scope)
-    scope = apply_special_school_filter(scope)
+    scope = apply_school_type_filter(scope)
     apply_job_availability_filter(scope)
   end
 
@@ -108,10 +108,20 @@ class Search::SchoolSearch
 
     scope.where(school_type: selected_school_types)
   end
+  
+  def apply_school_type_filter(scope)
+    scope = apply_special_school_filter(scope)
+    apply_faith_school_filter(scope)
+  end
 
   def apply_special_school_filter(scope)
-    return scope unless school_types.present?
-
+    return scope unless school_types.present? && school_types.include?("special_school")
+    
     scope.where(school_type: ["Community special school", "Foundation special school", "Non-maintained special school", "Academy special converter",  "Academy special sponsor led", "Free schools special"])
+  end
+
+  def apply_faith_school_filter(scope)
+    return scope unless school_types.present? && school_types.include?("faith_school")
+    scope.where("gias_data -> 'ReligiousCharacter (name)' IS NOT NULL")
   end
 end

--- a/app/services/search/school_search.rb
+++ b/app/services/search/school_search.rb
@@ -113,11 +113,11 @@ class Search::SchoolSearch
     return scope unless school_types.present?
 
     special_school_types = ["Community special school", "Foundation special school", "Non-maintained special school", "Academy special converter", "Academy special sponsor led", "Free schools special"]
-    
+
     return scope.where("school_type IN (?) OR gias_data -> 'ReligiousCharacter (name)' IS NOT NULL", special_school_types) if school_types.include?("special_school") && school_types.include?("faith_school")
 
     return scope.where(school_type: special_school_types) if school_types.include?("special_school")
-      
+
     scope.where("gias_data -> 'ReligiousCharacter (name)' IS NOT NULL")
   end
 end

--- a/app/services/search/school_search.rb
+++ b/app/services/search/school_search.rb
@@ -43,7 +43,7 @@ class Search::SchoolSearch
   end
 
   def clear_filters_params
-    active_criteria.merge({ education_phase: [], key_stage: [], special_school: [], job_availability: [], organisation_types: [] })
+    active_criteria.merge({ education_phase: [], key_stage: [], job_availability: [], organisation_types: [], school_types: [] })
   end
 
   private
@@ -108,20 +108,16 @@ class Search::SchoolSearch
 
     scope.where(school_type: selected_school_types)
   end
-  
+
   def apply_school_type_filter(scope)
-    scope = apply_special_school_filter(scope)
-    apply_faith_school_filter(scope)
-  end
+    return scope unless school_types.present?
 
-  def apply_special_school_filter(scope)
-    return scope unless school_types.present? && school_types.include?("special_school")
+    special_school_types = ["Community special school", "Foundation special school", "Non-maintained special school", "Academy special converter", "Academy special sponsor led", "Free schools special"]
     
-    scope.where(school_type: ["Community special school", "Foundation special school", "Non-maintained special school", "Academy special converter",  "Academy special sponsor led", "Free schools special"])
-  end
+    return scope.where("school_type IN (?) OR gias_data -> 'ReligiousCharacter (name)' IS NOT NULL", special_school_types) if school_types.include?("special_school") && school_types.include?("faith_school")
 
-  def apply_faith_school_filter(scope)
-    return scope unless school_types.present? && school_types.include?("faith_school")
+    return scope.where(school_type: special_school_types) if school_types.include?("special_school")
+      
     scope.where("gias_data -> 'ReligiousCharacter (name)' IS NOT NULL")
   end
 end

--- a/app/services/search/school_search.rb
+++ b/app/services/search/school_search.rb
@@ -2,7 +2,7 @@ class Search::SchoolSearch
   extend Forwardable
   def_delegators :location_search, :point_coordinates
 
-  attr_reader :search_criteria, :name, :location, :radius, :organisation_types
+  attr_reader :search_criteria, :name, :location, :radius, :organisation_types, :school_types
 
   def initialize(search_criteria, scope: Organisation.all)
     @search_criteria = search_criteria
@@ -10,6 +10,7 @@ class Search::SchoolSearch
     @location = search_criteria[:location]
     @radius = search_criteria[:radius]
     @organisation_types = search_criteria[:organisation_types]
+    @school_types = search_criteria[:school_types]
     @scope = scope
   end
 
@@ -37,7 +38,7 @@ class Search::SchoolSearch
   end
 
   def total_filters
-    filter_counts = %i[education_phase key_stage special_school job_availability organisation_types].map { |filter| search_criteria[filter]&.count || 0 }
+    filter_counts = %i[education_phase key_stage special_school job_availability organisation_types school_types].map { |filter| search_criteria[filter]&.count || 0 }
     filter_counts.sum
   end
 
@@ -54,8 +55,8 @@ class Search::SchoolSearch
     scope = scope.search_by_location(*location) if location.present?
     scope = scope.where(phase: education_phase) if education_phase
     scope = scope.where(phase: key_stage_phases) if key_stage_phases
-    scope = scope.where("organisations.gias_data->>'SpecialClasses (code)' = ?", "1") if special_school?
     scope = apply_organisation_type_filter(scope)
+    scope = apply_special_school_filter(scope)
     apply_job_availability_filter(scope)
   end
 
@@ -77,12 +78,6 @@ class Search::SchoolSearch
     return unless @search_criteria.key?(:key_stage)
 
     School::PHASE_TO_KEY_STAGES_MAPPINGS.select { |_, v| @search_criteria[:key_stage].intersect?(v.map(&:to_s)) }.map(&:first).map(&:to_s)
-  end
-
-  def special_school?
-    return unless @search_criteria.key?(:special_school)
-
-    @search_criteria[:special_school].first == "1"
   end
 
   def apply_job_availability_filter(scope)
@@ -112,5 +107,11 @@ class Search::SchoolSearch
     end
 
     scope.where(school_type: selected_school_types)
+  end
+
+  def apply_special_school_filter(scope)
+    return scope unless school_types.present?
+
+    scope.where(school_type: ["Community special school", "Foundation special school", "Non-maintained special school", "Academy special converter",  "Academy special sponsor led", "Free schools special"])
   end
 end

--- a/app/services/search/vacancy_search.rb
+++ b/app/services/search/vacancy_search.rb
@@ -20,7 +20,7 @@ class Search::VacancySearch
   end
 
   def clear_filters_params
-    active_criteria.merge(job_roles: [], ect_statuses: [], phases: [], working_patterns: [], subjects: [], organisation_types: [], previous_keyword: keyword, skip_strip_checkboxes: true)
+    active_criteria.merge(job_roles: [], ect_statuses: [], phases: [], working_patterns: [], subjects: [], organisation_types: [], school_types: [], previous_keyword: keyword, skip_strip_checkboxes: true)
   end
 
   def remove_filter_params

--- a/app/views/organisations/search/_filters.html.slim
+++ b/app/views/organisations/search/_filters.html.slim
@@ -49,7 +49,7 @@ ruby:
       selected_method: :last,
     },
   ]
-  
+
 = filters(submit_button: f.govuk_submit(t("buttons.apply_filters")),
   filters: { total_count: @school_search.total_filters },
   clear_filters_link: { text: t("shared.filter_group.clear_all_filters"), url: organisations_path(@school_search.clear_filters_params) },

--- a/app/views/organisations/search/_filters.html.slim
+++ b/app/views/organisations/search/_filters.html.slim
@@ -25,6 +25,14 @@ ruby:
       selected_method: :first,
     },
     {
+      legend: t("jobs.filters.school_type"),
+      key: :school_types,
+      selected: @search_form.school_types,
+      options: @search_form.school_types_options,
+      value_method: :first,
+      selected_method: :last,
+    },
+    {
       legend: t("organisations.filters.special_school"),
       key: :special_school,
       selected: @search_form.special_school,
@@ -41,7 +49,7 @@ ruby:
       selected_method: :last,
     },
   ]
-
+  
 = filters(submit_button: f.govuk_submit(t("buttons.apply_filters")),
   filters: { total_count: @school_search.total_filters },
   clear_filters_link: { text: t("shared.filter_group.clear_all_filters"), url: organisations_path(@school_search.clear_filters_params) },
@@ -52,6 +60,6 @@ ruby:
         - rb.group(**filter_type.merge(remove_filter_link: { url_helper: :organisations_path, params: @school_search.active_criteria }))
     - filters_component.with_group key: "education_phase", component: f.govuk_collection_check_boxes(:education_phase, f.object.education_phase_options, :first, :last, small: true, legend: { text: t("organisations.filters.education_phase") }, hint: nil)
     - filters_component.with_group key: "key_stage", component: f.govuk_collection_check_boxes(:key_stage, f.object.key_stage_options, :first, :last, small: true, legend: { text: t("organisations.filters.key_stage") }, hint: nil)
-    - filters_component.with_group key: "organisation_types", component: f.govuk_collection_check_boxes(:organisation_types, f.object.organisation_type_options, :first, :first, :last, small: true, legend: { text: t("jobs.filters.organisation_type") }, hint: nil)
-    - filters_component.with_group key: "special_school", component: f.govuk_collection_check_boxes(:special_school, [["1", t("organisations.filters.special_school")]], :first, :last, small: true, legend: { text: t("organisations.filters.special_school") })
+    - filters_component.with_group key: "organisation_types", component: f.govuk_collection_check_boxes(:organisation_types, f.object.organisation_type_options, :first, :first, :last, small: true, legend: { text: t("jobs.filters.organisation_type") })
+    - filters_component.with_group key: "school_types", component: f.govuk_collection_check_boxes(:school_types, f.object.school_types_options, :first, :last, small: true, legend: { text: t("jobs.filters.school_type") })
     - filters_component.with_group key: "job_availability", component: f.govuk_collection_check_boxes(:job_availability, f.object.job_availability_options, :first, :last, small: true, legend: { text: t("organisations.filters.job_availability.label") })

--- a/app/views/vacancies/search/_filters.html.slim
+++ b/app/views/vacancies/search/_filters.html.slim
@@ -41,6 +41,14 @@ ruby:
       selected_method: :first,
     },
     {
+      legend: t("jobs.filters.school_type"),
+      key: :school_types,
+      selected: form.school_types,
+      options: form.school_type_options,
+      value_method: :first,
+      selected_method: :last,
+    },
+    {
       legend: t("jobs.filters.working_patterns"),
       key: :working_patterns,
       selected: form.working_patterns,
@@ -63,4 +71,5 @@ ruby:
     = render "shared/subjects_filter", filters_component: filters_component, f: f
     - filters_component.with_group key: "ect_statuses", component: f.govuk_collection_check_boxes(:ect_statuses, form.ect_status_options, :first, :last, small: true, legend: { text: t("jobs.filters.ect_suitable") }, hint: nil)
     - filters_component.with_group key: "organisation_types", component: f.govuk_collection_check_boxes(:organisation_types, form.organisation_type_options, :first, :first, :last, small: true, legend: { text: t("jobs.filters.organisation_type") }, hint: nil)
+    - filters_component.with_group key: "school_types", component: f.govuk_collection_check_boxes(:school_types, f.object.school_type_options, :first, :last, small: true, legend: { text: t("jobs.filters.school_type") }, hint: nil)
     - filters_component.with_group key: "working_patterns", component: f.govuk_collection_check_boxes(:working_patterns, form.working_pattern_options, :first, :last, small: true, legend: { text: t("jobs.filters.working_patterns") }, hint: nil)

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -41,6 +41,7 @@ en:
       phases: Education phase
       working_patterns: Working pattern
       organisation_type: Organisation type
+      school_type: School type
 
     education_phase_options:
       middle: Middle

--- a/config/locales/organisations.yml
+++ b/config/locales/organisations.yml
@@ -7,6 +7,8 @@ en:
       education_phase: Phase of education
       key_stage: Key stage
       special_school: Special school
+      faith_school: Faith school
+      school_type: School type
       job_availability:
         label: Job availability
         options:

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   ofsted_ratings = ["Outstanding", "Good", "Requires Improvement", "Inadequate"].freeze
-  religious_characters = ["Church of England", "Roman Catholic", "None", "Does not apply"].freeze
 
   factory :school do
     address { Faker::Address.street_name.delete("'") }

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -19,7 +19,6 @@ FactoryBot.define do
         NumberOfPupils: Faker::Number.number(digits: 3),
         "OfstedRating (name)": factory_sample(ofsted_ratings),
         OpenDate: Faker::Date.between(from: 10_000.days.ago, to: 1000.days.ago),
-        "ReligiousCharacter (name)": factory_sample(religious_characters),
         SchoolCapacity: Faker::Number.number(digits: 4),
         TelephoneNum: Faker::Number.number(digits: 11).to_s,
         "Trusts (name)": "#{Faker::Company.name.delete("'")} Trust",

--- a/spec/presenters/vacancy_presenter_spec.rb
+++ b/spec/presenters/vacancy_presenter_spec.rb
@@ -402,7 +402,7 @@ RSpec.describe VacancyPresenter do
                     publisher_organisation: publisher_organisation,
                     publisher: publisher)
     end
-    let(:school) { build(:school) }
+    let(:school) { build(:school, gias_data: { "ReligiousCharacter (name)" => "Church of England" }) }
     let(:organisations) { [school] }
     let(:publisher_organisation) { school }
     let(:publisher) { build_stubbed(:publisher) }

--- a/spec/queries/vacancy_filter_query_spec.rb
+++ b/spec/queries/vacancy_filter_query_spec.rb
@@ -13,6 +13,9 @@ RSpec.describe VacancyFilterQuery do
   let(:special_school5) { create(:school, name: "Academy special sponsor led", school_type: "Academy special sponsor led") }
   let(:special_school6) { create(:school, name: "Non-maintained special school", school_type: "Free schools special") }
   let(:faith_school) { create(:school, name: "Religious", gias_data: { "ReligiousCharacter (name)" => "anything" }) }
+  let(:non_faith_school1) { create(:school, name: "nonfaith1", gias_data: { "ReligiousCharacter (name)" => "" }) }
+  let(:non_faith_school2) { create(:school, name: "nonfaith2", gias_data: { "ReligiousCharacter (name)" => "Does not apply" }) }
+  let(:non_faith_school3) { create(:school, name: "nonfaith3", gias_data: { "ReligiousCharacter (name)" => "None" }) }
 
   let!(:vacancy1) { create(:vacancy, job_title: "Vacancy 1", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[secondary], job_role: "teacher", ect_status: "ect_suitable", organisations: [academy]) }
   let!(:vacancy2) { create(:vacancy, job_title: "Vacancy 2", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[sixth_form_or_college], job_role: "teacher", ect_status: "ect_unsuitable", organisations: [free_school]) }
@@ -27,6 +30,9 @@ RSpec.describe VacancyFilterQuery do
   let!(:special_vacancy5) { create(:vacancy, job_title: "Vacancy 11", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [special_school5]) }
   let!(:special_vacancy6) { create(:vacancy, job_title: "Vacancy 12", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [special_school6]) }
   let!(:faith_vacancy) { create(:vacancy, job_title: "Vacancy 13", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [faith_school]) }
+  let!(:non_faith_vacancy1) { create(:vacancy, job_title: "Vacancy 14", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [non_faith_school1]) }
+  let!(:non_faith_vacancy2) { create(:vacancy, job_title: "Vacancy 15", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [non_faith_school2]) }
+  let!(:non_faith_vacancy3) { create(:vacancy, job_title: "Vacancy 14", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [non_faith_school3]) }
 
   describe "#call" do
     it "queries based on the given filters" do
@@ -65,7 +71,7 @@ RSpec.describe VacancyFilterQuery do
         it "will return vacancies associated with all schools" do
           filters = {}
           expect(subject.call(filters)).to contain_exactly(vacancy1, vacancy2, vacancy3, vacancy4, vacancy5, vacancy6, special_vacancy1, special_vacancy2,
-                                                           special_vacancy3, special_vacancy4, special_vacancy5, special_vacancy6, faith_vacancy)
+                                                           special_vacancy3, special_vacancy4, special_vacancy5, special_vacancy6, faith_vacancy, non_faith_vacancy1, non_faith_vacancy2, non_faith_vacancy3)
         end
       end
 
@@ -81,7 +87,7 @@ RSpec.describe VacancyFilterQuery do
     end
 
     context "when school_types filter is selected" do
-      context "when organisation_types == ['faith_school']" do
+      context "when school_types == ['faith_school']" do
         it "will return vacancies associated with faith schools" do
           filters = {
             school_types: ["faith_school"],
@@ -90,7 +96,7 @@ RSpec.describe VacancyFilterQuery do
         end
       end
 
-      context "when organisation_types = ['special_school']" do
+      context "when school_types = ['special_school']" do
         it "will return vacancies associated with faith schools" do
           filters = {
             school_types: ["special_school"],
@@ -99,7 +105,7 @@ RSpec.describe VacancyFilterQuery do
         end
       end
 
-      context "when organisation_types includes 'special_school' and 'faith_school" do
+      context "when school_types includes 'special_school' and 'faith_school" do
         it "will return vacancies associated with both faith schools and special schools" do
           filters = {
             school_types: %w[special_school faith_school],

--- a/spec/queries/vacancy_filter_query_spec.rb
+++ b/spec/queries/vacancy_filter_query_spec.rb
@@ -6,12 +6,27 @@ RSpec.describe VacancyFilterQuery do
   let(:free_school) { create(:school, name: "Freeschool1", school_type: "Free schools") }
   let(:free_schools) { create(:school, name: "Freeschool2", school_type: "Free school") }
   let(:local_authority_school) { create(:school, name: "local authority", school_type: "Local authority maintained schools") }
+  let(:special_school1) { create(:school, name: "Community special school", school_type: "Community special school") }
+  let(:special_school2) { create(:school, name: "Foundation special school", school_type: "Foundation special school") }
+  let(:special_school3) { create(:school, name: "Non-maintained special school", school_type: "Non-maintained special school") }
+  let(:special_school4) { create(:school, name: "Academy special converter", school_type: "Academy special converter") }
+  let(:special_school5) { create(:school, name: "Academy special sponsor led", school_type: "Academy special sponsor led") }
+  let(:special_school6) { create(:school, name: "Non-maintained special school", school_type: "Free schools special") }
+  let(:faith_school) { create(:school, name: "Religious", gias_data: {"ReligiousCharacter (name)" => "anything"}) }
+
   let!(:vacancy1) { create(:vacancy, job_title: "Vacancy 1", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[secondary], job_role: "teacher", ect_status: "ect_suitable", organisations: [academy]) }
   let!(:vacancy2) { create(:vacancy, job_title: "Vacancy 2", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[sixth_form_or_college], job_role: "teacher", ect_status: "ect_unsuitable", organisations: [free_school]) }
   let!(:vacancy3) { create(:vacancy, job_title: "Vacancy 3", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "sendco", ect_status: nil, organisations: [local_authority_school]) }
   let!(:vacancy4) { create(:vacancy, job_title: "Vacancy 4", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil) }
   let!(:vacancy5) { create(:vacancy, job_title: "Vacancy 5", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [academies]) }
   let!(:vacancy6) { create(:vacancy, job_title: "Vacancy 6", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [free_schools]) }
+  let!(:special_vacancy1) { create(:vacancy, job_title: "Vacancy 7", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [special_school1]) }
+  let!(:special_vacancy2) { create(:vacancy, job_title: "Vacancy 8", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [special_school2]) }
+  let!(:special_vacancy3) { create(:vacancy, job_title: "Vacancy 9", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [special_school3]) }
+  let!(:special_vacancy4) { create(:vacancy, job_title: "Vacancy 10", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [special_school4]) }
+  let!(:special_vacancy5) { create(:vacancy, job_title: "Vacancy 11", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [special_school5]) }
+  let!(:special_vacancy6) { create(:vacancy, job_title: "Vacancy 12", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [special_school6]) }
+  let!(:faith_vacancy) { create(:vacancy, job_title: "Vacancy 13", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [faith_school]) }
 
   describe "#call" do
     it "queries based on the given filters" do
@@ -22,7 +37,7 @@ RSpec.describe VacancyFilterQuery do
         job_roles: %w[teacher],
         ect_statuses: %w[ect_suitable],
         from_date: 5.days.ago,
-        to_date: Date.today,
+        to_date: Date.today
       }
       expect(subject.call(filters)).to contain_exactly(vacancy1)
     end
@@ -49,7 +64,8 @@ RSpec.describe VacancyFilterQuery do
       context "when organisation_types is empty" do
         it "will return vacancies associated with all schools" do
           filters = {}
-          expect(subject.call(filters)).to contain_exactly(vacancy1, vacancy2, vacancy3, vacancy4, vacancy5, vacancy6)
+          expect(subject.call(filters)).to contain_exactly(vacancy1, vacancy2, vacancy3, vacancy4, vacancy5, vacancy6, special_vacancy1, special_vacancy2, 
+                                                           special_vacancy3, special_vacancy4, special_vacancy5, special_vacancy6, faith_vacancy)
         end
       end
 
@@ -60,6 +76,35 @@ RSpec.describe VacancyFilterQuery do
 
           }
           expect(subject.call(filters)).to contain_exactly(vacancy1, vacancy2, vacancy3, vacancy5, vacancy6)
+        end
+      end
+    end
+
+    context "when school_types filter is selected" do
+      context "when organisation_types == ['faith_school']" do
+        it "will return vacancies associated with faith schools" do
+          filters = {
+            school_types: ["faith_school"],
+          }
+          expect(subject.call(filters)).to contain_exactly(faith_vacancy)
+        end
+      end
+
+      context "when organisation_types = ['special_school']" do
+        it "will return vacancies associated with faith schools" do
+          filters = {
+            school_types: ["special_school"],
+          }
+          expect(subject.call(filters)).to contain_exactly(special_vacancy1, special_vacancy2, special_vacancy3, special_vacancy4, special_vacancy5, special_vacancy6)
+        end
+      end
+
+      context "when organisation_types includes 'special_school' and 'faith_school" do
+        it "will return vacancies associated with both faith schools and special schools" do
+          filters = {
+            school_types: ["special_school", "faith_school"],
+          }
+          expect(subject.call(filters)).to contain_exactly(special_vacancy1, special_vacancy2, special_vacancy3, special_vacancy4, special_vacancy5, special_vacancy6, faith_vacancy)
         end
       end
     end

--- a/spec/queries/vacancy_filter_query_spec.rb
+++ b/spec/queries/vacancy_filter_query_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe VacancyFilterQuery do
   let(:special_school4) { create(:school, name: "Academy special converter", school_type: "Academy special converter") }
   let(:special_school5) { create(:school, name: "Academy special sponsor led", school_type: "Academy special sponsor led") }
   let(:special_school6) { create(:school, name: "Non-maintained special school", school_type: "Free schools special") }
-  let(:faith_school) { create(:school, name: "Religious", gias_data: {"ReligiousCharacter (name)" => "anything"}) }
+  let(:faith_school) { create(:school, name: "Religious", gias_data: { "ReligiousCharacter (name)" => "anything" }) }
 
   let!(:vacancy1) { create(:vacancy, job_title: "Vacancy 1", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[secondary], job_role: "teacher", ect_status: "ect_suitable", organisations: [academy]) }
   let!(:vacancy2) { create(:vacancy, job_title: "Vacancy 2", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[sixth_form_or_college], job_role: "teacher", ect_status: "ect_unsuitable", organisations: [free_school]) }
@@ -37,7 +37,7 @@ RSpec.describe VacancyFilterQuery do
         job_roles: %w[teacher],
         ect_statuses: %w[ect_suitable],
         from_date: 5.days.ago,
-        to_date: Date.today
+        to_date: Date.today,
       }
       expect(subject.call(filters)).to contain_exactly(vacancy1)
     end
@@ -64,7 +64,7 @@ RSpec.describe VacancyFilterQuery do
       context "when organisation_types is empty" do
         it "will return vacancies associated with all schools" do
           filters = {}
-          expect(subject.call(filters)).to contain_exactly(vacancy1, vacancy2, vacancy3, vacancy4, vacancy5, vacancy6, special_vacancy1, special_vacancy2, 
+          expect(subject.call(filters)).to contain_exactly(vacancy1, vacancy2, vacancy3, vacancy4, vacancy5, vacancy6, special_vacancy1, special_vacancy2,
                                                            special_vacancy3, special_vacancy4, special_vacancy5, special_vacancy6, faith_vacancy)
         end
       end
@@ -102,7 +102,7 @@ RSpec.describe VacancyFilterQuery do
       context "when organisation_types includes 'special_school' and 'faith_school" do
         it "will return vacancies associated with both faith schools and special schools" do
           filters = {
-            school_types: ["special_school", "faith_school"],
+            school_types: %w[special_school faith_school],
           }
           expect(subject.call(filters)).to contain_exactly(special_vacancy1, special_vacancy2, special_vacancy3, special_vacancy4, special_vacancy5, special_vacancy6, faith_vacancy)
         end

--- a/spec/services/search/school_search_spec.rb
+++ b/spec/services/search/school_search_spec.rb
@@ -93,6 +93,9 @@ RSpec.describe Search::SchoolSearch do
     let(:special_school5) { create(:school, name: "Academy special sponsor led", school_type: "Academy special sponsor led") }
     let(:special_school6) { create(:school, name: "Non-maintained special school", school_type: "Free schools special") }
     let(:faith_school) { create(:school, name: "Religious", gias_data: { "ReligiousCharacter (name)" => "anything" }) }
+    let(:non_faith_school1) { create(:school, name: "nonfaith1", gias_data: { "ReligiousCharacter (name)" => "" }) }
+    let(:non_faith_school2) { create(:school, name: "nonfaith2", gias_data: { "ReligiousCharacter (name)" => "Does not apply" }) }
+    let(:non_faith_school3) { create(:school, name: "nonfaith3", gias_data: { "ReligiousCharacter (name)" => "None" }) }
     let!(:other_school) { create(:school, name: "other", school_type: "Something else") }
 
     context "when school_types == ['faith_school']" do
@@ -113,7 +116,7 @@ RSpec.describe Search::SchoolSearch do
 
     context "when school_types is empty" do
       it "will return all schools" do
-        expect(subject.organisations).to contain_exactly(special_school1, special_school2, special_school3, special_school4, special_school5, special_school6, faith_school, other_school)
+        expect(subject.organisations).to contain_exactly(special_school1, special_school2, special_school3, special_school4, special_school5, special_school6, faith_school, other_school, non_faith_school1, non_faith_school2, non_faith_school3)
       end
     end
 

--- a/spec/services/search/school_search_spec.rb
+++ b/spec/services/search/school_search_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Search::SchoolSearch do
       organisation_types: organisation_types,
       key_stage: key_stage,
       job_availability: job_availability,
-      school_types: school_types
+      school_types: school_types,
     }.compact
   end
 
@@ -92,7 +92,7 @@ RSpec.describe Search::SchoolSearch do
     let(:special_school4) { create(:school, name: "Academy special converter", school_type: "Academy special converter") }
     let(:special_school5) { create(:school, name: "Academy special sponsor led", school_type: "Academy special sponsor led") }
     let(:special_school6) { create(:school, name: "Non-maintained special school", school_type: "Free schools special") }
-    let(:faith_school) { create(:school, name: "Religious", gias_data: {"ReligiousCharacter (name)" => "anything"}) }
+    let(:faith_school) { create(:school, name: "Religious", gias_data: { "ReligiousCharacter (name)" => "anything" }) }
     let!(:other_school) { create(:school, name: "other", school_type: "Something else") }
 
     context "when school_types == ['faith_school']" do
@@ -118,7 +118,7 @@ RSpec.describe Search::SchoolSearch do
     end
 
     context "when school_types includes both 'faith_school' and 'special_school'" do
-      let(:school_types) { ["faith_school", "special_school"] }
+      let(:school_types) { %w[faith_school special_school] }
       it "will return special schools and faith schools" do
         expect(subject.organisations).to contain_exactly(special_school1, special_school2, special_school3, special_school4, special_school5, special_school6, faith_school)
       end

--- a/spec/services/search/vacancy_search_spec.rb
+++ b/spec/services/search/vacancy_search_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Search::VacancySearch do
       working_patterns: working_patterns,
       subjects: subjects,
       organisation_types: organisation_types,
-      school_types: school_types
+      school_types: school_types,
     }.compact
   end
 
@@ -88,7 +88,7 @@ RSpec.describe Search::VacancySearch do
     let(:organisation_types) { ["faith_school"] }
 
     it "clears selected filters " do
-      expect(subject.active_criteria).to eq({ location: location, organisation_types: organisation_types, organisation_slug: organisation_slug, ect_statuses: ect_statuses, job_roles: job_roles, keyword: keyword, phases: phases, radius: 10, subjects: subjects, working_patterns: working_patterns, organisation_types: organisation_types })
+      expect(subject.active_criteria).to eq({ location: location, organisation_types: organisation_types, organisation_slug: organisation_slug, ect_statuses: ect_statuses, job_roles: job_roles, keyword: keyword, phases: phases, radius: 10, subjects: subjects, working_patterns: working_patterns, school_types: school_types })
       expect(subject.clear_filters_params).to eq({ keyword: keyword, location: location, radius: 10, organisation_slug: organisation_slug, job_roles: [], ect_statuses: [], phases: [], working_patterns: [], subjects: [], organisation_types: [], school_types: [], previous_keyword: keyword, skip_strip_checkboxes: true })
     end
   end

--- a/spec/services/search/vacancy_search_spec.rb
+++ b/spec/services/search/vacancy_search_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Search::VacancySearch do
       working_patterns: working_patterns,
       subjects: subjects,
       organisation_types: organisation_types,
+      school_types: school_types
     }.compact
   end
 
@@ -30,6 +31,7 @@ RSpec.describe Search::VacancySearch do
   let(:working_patterns) { nil }
   let(:subjects) { nil }
   let(:organisation_types) { nil }
+  let(:school_types) { nil }
 
   let(:school) { create(:school) }
 
@@ -83,10 +85,11 @@ RSpec.describe Search::VacancySearch do
     let(:working_patterns) { ["full_time"] }
     let(:subjects) { ["Maths"] }
     let(:organisation_types) { ["Academy"] }
+    let(:organisation_types) { ["faith_school"] }
 
     it "clears selected filters " do
-      expect(subject.active_criteria).to eq({ location: location, organisation_types: organisation_types, organisation_slug: organisation_slug, ect_statuses: ect_statuses, job_roles: job_roles, keyword: keyword, phases: phases, radius: 10, subjects: subjects, working_patterns: working_patterns })
-      expect(subject.clear_filters_params).to eq({ keyword: keyword, location: location, radius: 10, organisation_slug: organisation_slug, job_roles: [], ect_statuses: [], phases: [], working_patterns: [], subjects: [], organisation_types: [], previous_keyword: keyword, skip_strip_checkboxes: true })
+      expect(subject.active_criteria).to eq({ location: location, organisation_types: organisation_types, organisation_slug: organisation_slug, ect_statuses: ect_statuses, job_roles: job_roles, keyword: keyword, phases: phases, radius: 10, subjects: subjects, working_patterns: working_patterns, organisation_types: organisation_types })
+      expect(subject.clear_filters_params).to eq({ keyword: keyword, location: location, radius: 10, organisation_slug: organisation_slug, job_roles: [], ect_statuses: [], phases: [], working_patterns: [], subjects: [], organisation_types: [], school_types: [], previous_keyword: keyword, skip_strip_checkboxes: true })
     end
   end
 end

--- a/spec/system/jobseekers_can_search_for_jobs_spec.rb
+++ b/spec/system/jobseekers_can_search_for_jobs_spec.rb
@@ -154,6 +154,9 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
     let(:special_school5) { create(:school, name: "Academy special sponsor led", school_type: "Academy special sponsor led") }
     let(:special_school6) { create(:school, name: "Non-maintained special school", school_type: "Free schools special") }
     let(:faith_school) { create(:school, name: "Religious", gias_data: { "ReligiousCharacter (name)" => "anything" }) }
+    let(:non_faith_school1) { create(:school, name: "nonfaith1", gias_data: { "ReligiousCharacter (name)" => "" }) }
+    let(:non_faith_school2) { create(:school, name: "nonfaith2", gias_data: { "ReligiousCharacter (name)" => "Does not apply" }) }
+    let(:non_faith_school3) { create(:school, name: "nonfaith3", gias_data: { "ReligiousCharacter (name)" => "None" }) }
 
     let!(:special_job1) { create(:vacancy, :past_publish, :teacher, job_title: "AAAA", subjects: [], organisations: [special_school1]) }
     let!(:special_job2) { create(:vacancy, :past_publish, :teacher, job_title: "BBBB", subjects: [], organisations: [special_school2]) }
@@ -162,6 +165,9 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
     let!(:special_job5) { create(:vacancy, :past_publish, :teacher, job_title: "EEEE", subjects: [], organisations: [special_school5]) }
     let!(:special_job6) { create(:vacancy, :past_publish, :teacher, job_title: "FFFF", subjects: [], organisations: [special_school6]) }
     let!(:faith_job) { create(:vacancy, :past_publish, :teacher, job_title: "religious", subjects: [], organisations: [faith_school]) }
+    let!(:non_faith_job1) { create(:vacancy, :past_publish, :teacher, job_title: "nonfaith1", subjects: [], organisations: [non_faith_school1]) }
+    let!(:non_faith_job2) { create(:vacancy, :past_publish, :teacher, job_title: "nonfaith2", subjects: [], organisations: [non_faith_school2]) }
+    let!(:non_faith_job3) { create(:vacancy, :past_publish, :teacher, job_title: "nonfaith3", subjects: [], organisations: [non_faith_school3]) }
 
     it "allows user to filter by special schools" do
       visit jobs_path
@@ -169,7 +175,7 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
       click_on I18n.t("buttons.search")
 
       expect_page_to_show_jobs([special_job1, special_job2, special_job3, special_job4, special_job5, special_job6])
-      expect_page_not_to_show_jobs([job1, job2, job3, job4, maths_job1, maths_job2, faith_job])
+      expect_page_not_to_show_jobs([job1, job2, job3, job4, maths_job1, maths_job2, faith_job, non_faith_job1, non_faith_job2, non_faith_job3])
     end
 
     it "allows user to filter by faith schools" do
@@ -178,7 +184,7 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
       click_on I18n.t("buttons.search")
 
       expect_page_to_show_jobs([faith_job])
-      expect_page_not_to_show_jobs([special_job1, special_job2, special_job3, special_job4, special_job5, special_job6, job1, job2, job3, job4, maths_job1, maths_job2])
+      expect_page_not_to_show_jobs([special_job1, special_job2, special_job3, special_job4, special_job5, special_job6, job1, job2, job3, job4, maths_job1, maths_job2, non_faith_job1, non_faith_job2, non_faith_job3])
     end
 
     it "allows users to filter by both faith and special schools" do

--- a/spec/system/jobseekers_can_search_for_jobs_spec.rb
+++ b/spec/system/jobseekers_can_search_for_jobs_spec.rb
@@ -76,6 +76,12 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
   let(:free_school2) { create(:school, school_type: "Free school") }
   let(:local_authority_school1) { create(:school, school_type: "Local authority maintained schools") }
   let(:school) { create(:school) }
+  let(:special_school1) { create(:school, name: "Community special school", school_type: "Community special school") }
+  let(:special_school2) { create(:school, name: "Foundation special school", school_type: "Foundation special school") }
+  let(:special_school3) { create(:school, name: "Non-maintained special school", school_type: "Non-maintained special school") }
+  let(:special_school4) { create(:school, name: "Academy special converter", school_type: "Academy special converter") }
+  let(:special_school5) { create(:school, name: "Academy special sponsor led", school_type: "Academy special sponsor led") }
+  let(:special_school6) { create(:school, name: "Non-maintained special school", school_type: "Free schools special") }
   let!(:maths_job1) { create(:vacancy, :past_publish, :teacher, publish_on: Date.current - 1, job_title: "Maths 1", subjects: %w[Mathematics], organisations: [school], phases: %w[secondary]) }
   let!(:maths_job2) { create(:vacancy, :past_publish, :teacher, publish_on: Date.current - 2, job_title: "Maths Teacher 2", subjects: %w[Mathematics], organisations: [school], phases: %w[secondary]) }
   let!(:job1) { create(:vacancy, :past_publish, :teacher, job_title: "Physics Teacher", subjects: [], organisations: [academy1]) }
@@ -142,6 +148,31 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
         expect_page_to_show_jobs([job1, job2, job3, job4, job5])
         expect_page_not_to_show_jobs([maths_job1, maths_job2])
       end
+    end
+  end
+
+  context "when filtering by school type" do
+    let(:special_school1) { create(:school, name: "Community special school", school_type: "Community special school") }
+    let(:special_school2) { create(:school, name: "Foundation special school", school_type: "Foundation special school") }
+    let(:special_school3) { create(:school, name: "Non-maintained special school", school_type: "Non-maintained special school") }
+    let(:special_school4) { create(:school, name: "Academy special converter", school_type: "Academy special converter") }
+    let(:special_school5) { create(:school, name: "Academy special sponsor led", school_type: "Academy special sponsor led") }
+    let(:special_school6) { create(:school, name: "Non-maintained special school", school_type: "Free schools special") }
+
+    let!(:special_job1) { create(:vacancy, :past_publish, :teacher, job_title: "AAAA", subjects: [], organisations: [special_school1]) }
+    let!(:special_job2) { create(:vacancy, :past_publish, :teacher, job_title: "BBBB", subjects: [], organisations: [special_school1]) }
+    let!(:special_job3) { create(:vacancy, :past_publish, :teacher, job_title: "CCCC", subjects: [], organisations: [special_school1]) }
+    let!(:special_job4) { create(:vacancy, :past_publish, :teacher, job_title: "DDDD", subjects: [], organisations: [special_school1]) }
+    let!(:special_job5) { create(:vacancy, :past_publish, :teacher, job_title: "EEEE", subjects: [], organisations: [special_school1]) }
+    let!(:special_job6) { create(:vacancy, :past_publish, :teacher, job_title: "FFFF", subjects: [], organisations: [special_school1]) }
+
+    it "allows user to filter by special schools" do
+      visit jobs_path
+      check "Special school"
+      click_on I18n.t("buttons.search")
+
+      expect_page_to_show_jobs([special_job1, special_job2, special_job3, special_job4, special_job5, special_job6])
+      expect_page_not_to_show_jobs([job1, job2, job3, job4, maths_job1, maths_job2])
     end
   end
 

--- a/spec/system/jobseekers_can_search_for_jobs_spec.rb
+++ b/spec/system/jobseekers_can_search_for_jobs_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
   let(:free_school2) { create(:school, school_type: "Free school") }
   let(:local_authority_school1) { create(:school, school_type: "Local authority maintained schools") }
   let(:school) { create(:school) }
-  
+
   let!(:maths_job1) { create(:vacancy, :past_publish, :teacher, publish_on: Date.current - 1, job_title: "Maths 1", subjects: %w[Mathematics], organisations: [school], phases: %w[secondary]) }
   let!(:maths_job2) { create(:vacancy, :past_publish, :teacher, publish_on: Date.current - 2, job_title: "Maths Teacher 2", subjects: %w[Mathematics], organisations: [school], phases: %w[secondary]) }
   let!(:job1) { create(:vacancy, :past_publish, :teacher, job_title: "Physics Teacher", subjects: [], organisations: [academy1]) }
@@ -153,7 +153,7 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
     let(:special_school4) { create(:school, name: "Academy special converter", school_type: "Academy special converter") }
     let(:special_school5) { create(:school, name: "Academy special sponsor led", school_type: "Academy special sponsor led") }
     let(:special_school6) { create(:school, name: "Non-maintained special school", school_type: "Free schools special") }
-    let(:faith_school) { create(:school, name: "Religious", gias_data: {"ReligiousCharacter (name)" => "anything"}) }
+    let(:faith_school) { create(:school, name: "Religious", gias_data: { "ReligiousCharacter (name)" => "anything" }) }
 
     let!(:special_job1) { create(:vacancy, :past_publish, :teacher, job_title: "AAAA", subjects: [], organisations: [special_school1]) }
     let!(:special_job2) { create(:vacancy, :past_publish, :teacher, job_title: "BBBB", subjects: [], organisations: [special_school2]) }
@@ -165,7 +165,7 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
 
     it "allows user to filter by special schools" do
       visit jobs_path
-      check "Special school"
+      check I18n.t("organisations.filters.special_school")
       click_on I18n.t("buttons.search")
 
       expect_page_to_show_jobs([special_job1, special_job2, special_job3, special_job4, special_job5, special_job6])
@@ -174,7 +174,7 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
 
     it "allows user to filter by faith schools" do
       visit jobs_path
-      check "Faith school"
+      check I18n.t("organisations.filters.faith_school")
       click_on I18n.t("buttons.search")
 
       expect_page_to_show_jobs([faith_job])
@@ -183,8 +183,8 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
 
     it "allows users to filter by both faith and special schools" do
       visit jobs_path
-      check "Faith school"
-      check "Special school"
+      check I18n.t("organisations.filters.faith_school")
+      check I18n.t("organisations.filters.special_school")
       click_on I18n.t("buttons.search")
 
       expect_page_to_show_jobs([special_job1, special_job2, special_job3, special_job4, special_job5, special_job6, faith_job])

--- a/spec/system/jobseekers_can_search_for_jobs_spec.rb
+++ b/spec/system/jobseekers_can_search_for_jobs_spec.rb
@@ -76,12 +76,7 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
   let(:free_school2) { create(:school, school_type: "Free school") }
   let(:local_authority_school1) { create(:school, school_type: "Local authority maintained schools") }
   let(:school) { create(:school) }
-  let(:special_school1) { create(:school, name: "Community special school", school_type: "Community special school") }
-  let(:special_school2) { create(:school, name: "Foundation special school", school_type: "Foundation special school") }
-  let(:special_school3) { create(:school, name: "Non-maintained special school", school_type: "Non-maintained special school") }
-  let(:special_school4) { create(:school, name: "Academy special converter", school_type: "Academy special converter") }
-  let(:special_school5) { create(:school, name: "Academy special sponsor led", school_type: "Academy special sponsor led") }
-  let(:special_school6) { create(:school, name: "Non-maintained special school", school_type: "Free schools special") }
+  
   let!(:maths_job1) { create(:vacancy, :past_publish, :teacher, publish_on: Date.current - 1, job_title: "Maths 1", subjects: %w[Mathematics], organisations: [school], phases: %w[secondary]) }
   let!(:maths_job2) { create(:vacancy, :past_publish, :teacher, publish_on: Date.current - 2, job_title: "Maths Teacher 2", subjects: %w[Mathematics], organisations: [school], phases: %w[secondary]) }
   let!(:job1) { create(:vacancy, :past_publish, :teacher, job_title: "Physics Teacher", subjects: [], organisations: [academy1]) }
@@ -174,7 +169,7 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
       click_on I18n.t("buttons.search")
 
       expect_page_to_show_jobs([special_job1, special_job2, special_job3, special_job4, special_job5, special_job6])
-      expect_page_not_to_show_jobs([job1, job2, job3, job4, maths_job1, maths_job2])
+      expect_page_not_to_show_jobs([job1, job2, job3, job4, maths_job1, maths_job2, faith_job])
     end
 
     it "allows user to filter by faith schools" do
@@ -184,6 +179,16 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
 
       expect_page_to_show_jobs([faith_job])
       expect_page_not_to_show_jobs([special_job1, special_job2, special_job3, special_job4, special_job5, special_job6, job1, job2, job3, job4, maths_job1, maths_job2])
+    end
+
+    it "allows users to filter by both faith and special schools" do
+      visit jobs_path
+      check "Faith school"
+      check "Special school"
+      click_on I18n.t("buttons.search")
+
+      expect_page_to_show_jobs([special_job1, special_job2, special_job3, special_job4, special_job5, special_job6, faith_job])
+      expect_page_not_to_show_jobs([job1, job2, job3, job4, maths_job1, maths_job2])
     end
   end
 

--- a/spec/system/jobseekers_can_search_for_jobs_spec.rb
+++ b/spec/system/jobseekers_can_search_for_jobs_spec.rb
@@ -158,13 +158,15 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
     let(:special_school4) { create(:school, name: "Academy special converter", school_type: "Academy special converter") }
     let(:special_school5) { create(:school, name: "Academy special sponsor led", school_type: "Academy special sponsor led") }
     let(:special_school6) { create(:school, name: "Non-maintained special school", school_type: "Free schools special") }
+    let(:faith_school) { create(:school, name: "Religious", gias_data: {"ReligiousCharacter (name)" => "anything"}) }
 
     let!(:special_job1) { create(:vacancy, :past_publish, :teacher, job_title: "AAAA", subjects: [], organisations: [special_school1]) }
-    let!(:special_job2) { create(:vacancy, :past_publish, :teacher, job_title: "BBBB", subjects: [], organisations: [special_school1]) }
-    let!(:special_job3) { create(:vacancy, :past_publish, :teacher, job_title: "CCCC", subjects: [], organisations: [special_school1]) }
-    let!(:special_job4) { create(:vacancy, :past_publish, :teacher, job_title: "DDDD", subjects: [], organisations: [special_school1]) }
-    let!(:special_job5) { create(:vacancy, :past_publish, :teacher, job_title: "EEEE", subjects: [], organisations: [special_school1]) }
-    let!(:special_job6) { create(:vacancy, :past_publish, :teacher, job_title: "FFFF", subjects: [], organisations: [special_school1]) }
+    let!(:special_job2) { create(:vacancy, :past_publish, :teacher, job_title: "BBBB", subjects: [], organisations: [special_school2]) }
+    let!(:special_job3) { create(:vacancy, :past_publish, :teacher, job_title: "CCCC", subjects: [], organisations: [special_school3]) }
+    let!(:special_job4) { create(:vacancy, :past_publish, :teacher, job_title: "DDDD", subjects: [], organisations: [special_school4]) }
+    let!(:special_job5) { create(:vacancy, :past_publish, :teacher, job_title: "EEEE", subjects: [], organisations: [special_school5]) }
+    let!(:special_job6) { create(:vacancy, :past_publish, :teacher, job_title: "FFFF", subjects: [], organisations: [special_school6]) }
+    let!(:faith_job) { create(:vacancy, :past_publish, :teacher, job_title: "religious", subjects: [], organisations: [faith_school]) }
 
     it "allows user to filter by special schools" do
       visit jobs_path
@@ -173,6 +175,15 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
 
       expect_page_to_show_jobs([special_job1, special_job2, special_job3, special_job4, special_job5, special_job6])
       expect_page_not_to_show_jobs([job1, job2, job3, job4, maths_job1, maths_job2])
+    end
+
+    it "allows user to filter by faith schools" do
+      visit jobs_path
+      check "Faith school"
+      click_on I18n.t("buttons.search")
+
+      expect_page_to_show_jobs([faith_job])
+      expect_page_not_to_show_jobs([special_job1, special_job2, special_job3, special_job4, special_job5, special_job6, job1, job2, job3, job4, maths_job1, maths_job2])
     end
   end
 

--- a/spec/system/jobseekers_can_search_for_schools_spec.rb
+++ b/spec/system/jobseekers_can_search_for_schools_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Searching on the schools page" do
   let(:free_school1) { create(:school, name: "Free school 1", school_type: "Free schools") }
   let(:free_school2) { create(:school, name: "Free school 1", school_type: "Free school") }
   let(:local_authority_school) { create(:school, name: "Local authority school 1", school_type: "Local authority maintained schools") }
-  let(:faith_school) { create(:school, name: "Faith school", gias_data: {"ReligiousCharacter (name)" => "anything"}) }
+  let(:faith_school) { create(:school, name: "Religious", gias_data: {"ReligiousCharacter (name)" => "anything"}) }
   let(:special_school1) { create(:school, name: "Community special school", school_type: "Community special school") }
   let(:special_school2) { create(:school, name: "Foundation special school", school_type: "Foundation special school") }
   let(:special_school3) { create(:school, name: "Non-maintained special school", school_type: "Non-maintained special school") }
@@ -18,7 +18,7 @@ RSpec.describe "Searching on the schools page" do
 
 
   before do
-    [secondary_school, primary_school, academy_school1, academy_school2, free_school1, free_school2, local_authority_school,special_school1, special_school2,special_school3, special_school4, special_school5, special_school6].each do |school|
+    [secondary_school, primary_school, academy_school1, academy_school2, free_school1, free_school2, local_authority_school, faith_school, special_school1, special_school2, special_school3, special_school4, special_school5, special_school6].each do |school|
       create(:publisher, organisations: [school])
       create(:vacancy, organisations: [school])
     end
@@ -110,6 +110,14 @@ RSpec.describe "Searching on the schools page" do
 
       expect_page_to_show_schools([special_school1, special_school2, special_school3, special_school4, special_school5, special_school6])
       expect_page_not_to_show_schools([local_authority_school, secondary_school, primary_school])
+    end
+
+    it "allows users to filter by faith schools" do
+      check "Faith school"
+      click_on I18n.t("buttons.search")
+
+      expect_page_to_show_schools([faith_school])
+      expect_page_not_to_show_schools([local_authority_school, secondary_school, primary_school, special_school1, special_school2, special_school3, special_school4, special_school5, special_school6])
     end
   end
 

--- a/spec/system/jobseekers_can_search_for_schools_spec.rb
+++ b/spec/system/jobseekers_can_search_for_schools_spec.rb
@@ -2,17 +2,23 @@ require "rails_helper"
 
 RSpec.describe "Searching on the schools page" do
   let(:secondary_school) { create(:school, name: "Oxford") }
-  let(:secondary_special_school) { create(:school, name: "Cambridge", gias_data: { "SpecialClasses (code)" => "1" }) }
   let(:primary_school) { create(:school, name: "St Peters", phase: "primary") }
-
   let(:academy_school1) { create(:school, name: "Academy1", school_type: "Academies") }
   let(:academy_school2) { create(:school, name: "Academy2", school_type: "Academy") }
   let(:free_school1) { create(:school, name: "Free school 1", school_type: "Free schools") }
   let(:free_school2) { create(:school, name: "Free school 1", school_type: "Free school") }
   let(:local_authority_school) { create(:school, name: "Local authority school 1", school_type: "Local authority maintained schools") }
+  let(:faith_school) { create(:school, name: "Faith school", gias_data: {"ReligiousCharacter (name)" => "anything"}) }
+  let(:special_school1) { create(:school, name: "Community special school", school_type: "Community special school") }
+  let(:special_school2) { create(:school, name: "Foundation special school", school_type: "Foundation special school") }
+  let(:special_school3) { create(:school, name: "Non-maintained special school", school_type: "Non-maintained special school") }
+  let(:special_school4) { create(:school, name: "Academy special converter", school_type: "Academy special converter") }
+  let(:special_school5) { create(:school, name: "Academy special sponsor led", school_type: "Academy special sponsor led") }
+  let(:special_school6) { create(:school, name: "Non-maintained special school", school_type: "Free schools special") }
+
 
   before do
-    [secondary_school, secondary_special_school, primary_school, academy_school1, academy_school2, free_school1, free_school2, local_authority_school].each do |school|
+    [secondary_school, primary_school, academy_school1, academy_school2, free_school1, free_school2, local_authority_school,special_school1, special_school2,special_school3, special_school4, special_school5, special_school6].each do |school|
       create(:publisher, organisations: [school])
       create(:vacancy, organisations: [school])
     end
@@ -94,6 +100,16 @@ RSpec.describe "Searching on the schools page" do
 
       expect_page_to_show_schools([local_authority_school, academy_school1, academy_school2, free_school1, free_school2])
       expect_page_not_to_show_schools([secondary_school, secondary_special_school, primary_school])
+    end
+  end
+
+  context "when filtering by school type" do
+    it "allows user to filter by special schools" do
+      check "Special school"
+      click_on I18n.t("buttons.search")
+
+      expect_page_to_show_schools([special_school1, special_school2, special_school3, special_school4, special_school5, special_school6])
+      expect_page_not_to_show_schools([local_authority_school, secondary_school, primary_school])
     end
   end
 

--- a/spec/system/jobseekers_can_search_for_schools_spec.rb
+++ b/spec/system/jobseekers_can_search_for_schools_spec.rb
@@ -103,6 +103,9 @@ RSpec.describe "Searching on the schools page" do
 
   context "when filtering by school type" do
     let(:faith_school) { create(:school, name: "Religious", gias_data: { "ReligiousCharacter (name)" => "anything" }) }
+    let(:non_faith_school1) { create(:school, name: "nonfaith1", gias_data: { "ReligiousCharacter (name)" => "" }) }
+    let(:non_faith_school2) { create(:school, name: "nonfaith2", gias_data: { "ReligiousCharacter (name)" => "Does not apply" }) }
+    let(:non_faith_school3) { create(:school, name: "nonfaith3", gias_data: { "ReligiousCharacter (name)" => "None" }) }
     let(:special_school2) { create(:school, name: "Foundation special school", school_type: "Foundation special school") }
     let(:special_school3) { create(:school, name: "Non-maintained special school", school_type: "Non-maintained special school") }
     let(:special_school4) { create(:school, name: "Academy special converter", school_type: "Academy special converter") }
@@ -110,7 +113,7 @@ RSpec.describe "Searching on the schools page" do
     let(:special_school6) { create(:school, name: "Non-maintained special school", school_type: "Free schools special") }
 
     before do
-      [faith_school, special_school2, special_school3, special_school4, special_school5, special_school6].each do |school|
+      [faith_school, special_school2, special_school3, special_school4, special_school5, special_school6, non_faith_school1, non_faith_school2, non_faith_school3].each do |school|
         create(:publisher, organisations: [school])
         create(:vacancy, organisations: [school])
       end
@@ -122,7 +125,7 @@ RSpec.describe "Searching on the schools page" do
       click_on I18n.t("buttons.search")
 
       expect_page_to_show_schools([special_school1, special_school2, special_school3, special_school4, special_school5, special_school6])
-      expect_page_not_to_show_schools([secondary_school, primary_school, faith_school])
+      expect_page_not_to_show_schools([secondary_school, primary_school, faith_school, non_faith_school1, non_faith_school2, non_faith_school3])
     end
 
     it "allows users to filter by faith schools" do
@@ -130,7 +133,8 @@ RSpec.describe "Searching on the schools page" do
       click_on I18n.t("buttons.search")
 
       expect_page_to_show_schools([faith_school])
-      expect_page_not_to_show_schools([secondary_school, primary_school, special_school1, special_school2, special_school3, special_school4, special_school5, special_school6])
+      expect_page_not_to_show_schools([secondary_school, primary_school, special_school1, special_school2, special_school3, special_school4, special_school5,
+                                       special_school6, non_faith_school1, non_faith_school2, non_faith_school3])
     end
 
     it "allows users to filter by faith schools AND special schools" do
@@ -139,7 +143,18 @@ RSpec.describe "Searching on the schools page" do
       click_on I18n.t("buttons.search")
 
       expect_page_to_show_schools([faith_school, special_school1, special_school2, special_school3, special_school4, special_school5, special_school6])
-      expect_page_not_to_show_schools([secondary_school, primary_school])
+      expect_page_not_to_show_schools([secondary_school, primary_school, non_faith_school1, non_faith_school2, non_faith_school3])
+    end
+
+    it "shows all schools if neither filter is selected" do
+      click_on I18n.t("buttons.search")
+
+      expect_page_to_show_schools([faith_school, special_school1, special_school2, special_school3, special_school4, special_school5, special_school6,
+                                   secondary_school, primary_school, non_faith_school1])
+
+      click_link "2"
+
+      expect_page_to_show_schools([non_faith_school2, non_faith_school3])
     end
   end
 

--- a/spec/system/jobseekers_can_search_for_schools_spec.rb
+++ b/spec/system/jobseekers_can_search_for_schools_spec.rb
@@ -3,22 +3,11 @@ require "rails_helper"
 RSpec.describe "Searching on the schools page" do
   let(:secondary_school) { create(:school, name: "Oxford") }
   let(:primary_school) { create(:school, name: "St Peters", phase: "primary") }
-  let(:academy_school1) { create(:school, name: "Academy1", school_type: "Academies") }
-  let(:academy_school2) { create(:school, name: "Academy2", school_type: "Academy") }
-  let(:free_school1) { create(:school, name: "Free school 1", school_type: "Free schools") }
-  let(:free_school2) { create(:school, name: "Free school 1", school_type: "Free school") }
-  let(:local_authority_school) { create(:school, name: "Local authority school 1", school_type: "Local authority maintained schools") }
-  let(:faith_school) { create(:school, name: "Religious", gias_data: {"ReligiousCharacter (name)" => "anything"}) }
   let(:special_school1) { create(:school, name: "Community special school", school_type: "Community special school") }
-  let(:special_school2) { create(:school, name: "Foundation special school", school_type: "Foundation special school") }
-  let(:special_school3) { create(:school, name: "Non-maintained special school", school_type: "Non-maintained special school") }
-  let(:special_school4) { create(:school, name: "Academy special converter", school_type: "Academy special converter") }
-  let(:special_school5) { create(:school, name: "Academy special sponsor led", school_type: "Academy special sponsor led") }
-  let(:special_school6) { create(:school, name: "Non-maintained special school", school_type: "Free schools special") }
 
 
   before do
-    [secondary_school, primary_school, academy_school1, academy_school2, free_school1, free_school2, local_authority_school, faith_school, special_school1, special_school2, special_school3, special_school4, special_school5, special_school6].each do |school|
+    [secondary_school, primary_school, special_school1].each do |school|
       create(:publisher, organisations: [school])
       create(:vacancy, organisations: [school])
     end
@@ -40,16 +29,13 @@ RSpec.describe "Searching on the schools page" do
 
   context "when filters are selected" do
     before do
-      expect_page_to_show_schools([secondary_special_school, secondary_school, primary_school])
-
       check I18n.t("organisations.search.results.phases.secondary")
       check I18n.t("organisations.filters.special_school")
 
       click_on I18n.t("buttons.search")
 
-      expect(page).to have_link secondary_special_school.name
-      expect(page).not_to have_link secondary_school.name
-      expect(page).not_to have_link primary_school.name
+      expect_page_to_show_schools([special_school1,])
+      expect_page_not_to_show_schools([secondary_school, primary_school])
 
       expect(page).to have_link(I18n.t("organisations.search.results.phases.secondary"))
       expect(page).to have_link(I18n.t("organisations.filters.special_school"))
@@ -58,9 +44,8 @@ RSpec.describe "Searching on the schools page" do
     it "allows jobseeker to clear a filter" do
       click_link I18n.t("organisations.filters.special_school")
 
-      expect(page).to have_link secondary_special_school.name
-      expect(page).to have_link secondary_school.name
-      expect(page).not_to have_link primary_school.name
+      expect_page_to_show_schools([special_school1, secondary_school])
+      expect_page_not_to_show_schools([primary_school])
 
       expect(page).to have_link(I18n.t("organisations.search.results.phases.secondary"))
       expect(page).not_to have_link(I18n.t("organisations.filters.special_school"))
@@ -69,7 +54,7 @@ RSpec.describe "Searching on the schools page" do
     it "allows jobseeker to clear all filters" do
       click_link "Clear filters"
 
-      expect_page_to_show_schools([secondary_special_school, secondary_school, primary_school])
+      expect_page_to_show_schools([special_school1, secondary_school, primary_school])
 
       expect(page).not_to have_link(I18n.t("organisations.search.results.phases.secondary"))
       expect(page).not_to have_link(I18n.t("organisations.filters.special_school"))
@@ -77,12 +62,26 @@ RSpec.describe "Searching on the schools page" do
   end
 
   context "when filtering by organisation type" do
+    let(:academy_school1) { create(:school, name: "Academy1", school_type: "Academies") }
+    let(:academy_school2) { create(:school, name: "Academy2", school_type: "Academy") }
+    let(:free_school1) { create(:school, name: "Free school 1", school_type: "Free schools") }
+    let(:free_school2) { create(:school, name: "Free school 1", school_type: "Free school") }
+    let(:local_authority_school) { create(:school, name: "Local authority school 1", school_type: "Local authority maintained schools") }
+
+    before do
+      [academy_school1, academy_school2, free_school1, free_school2, local_authority_school].each do |school|
+        create(:publisher, organisations: [school])
+        create(:vacancy, organisations: [school])
+      end
+      visit organisations_path
+    end
+
     it "allows user to filter by academies" do
       check I18n.t("helpers.label.publishers_job_listing_working_patterns_form.organisation_type_options.academy")
       click_on I18n.t("buttons.search")
 
       expect_page_to_show_schools([academy_school1, academy_school2, free_school1, free_school2])
-      expect_page_not_to_show_schools([local_authority_school, secondary_school, secondary_special_school, primary_school])
+      expect_page_not_to_show_schools([local_authority_school, secondary_school, special_school1, primary_school])
     end
 
     it "allows user to filter by local authorities" do
@@ -90,7 +89,7 @@ RSpec.describe "Searching on the schools page" do
       click_on I18n.t("buttons.search")
 
       expect_page_to_show_schools([local_authority_school])
-      expect_page_not_to_show_schools([academy_school1, academy_school2, free_school1, free_school2, secondary_school, secondary_special_school, primary_school])
+      expect_page_not_to_show_schools([academy_school1, academy_school2, free_school1, free_school2, secondary_school, special_school1, primary_school])
     end
 
     it "allows user to filter by both academies and local authorities" do
@@ -99,17 +98,32 @@ RSpec.describe "Searching on the schools page" do
       click_on I18n.t("buttons.search")
 
       expect_page_to_show_schools([local_authority_school, academy_school1, academy_school2, free_school1, free_school2])
-      expect_page_not_to_show_schools([secondary_school, secondary_special_school, primary_school])
+      expect_page_not_to_show_schools([secondary_school, special_school1, primary_school])
     end
   end
 
   context "when filtering by school type" do
+    let(:faith_school) { create(:school, name: "Religious", gias_data: {"ReligiousCharacter (name)" => "anything"}) }
+    let(:special_school2) { create(:school, name: "Foundation special school", school_type: "Foundation special school") }
+    let(:special_school3) { create(:school, name: "Non-maintained special school", school_type: "Non-maintained special school") }
+    let(:special_school4) { create(:school, name: "Academy special converter", school_type: "Academy special converter") }
+    let(:special_school5) { create(:school, name: "Academy special sponsor led", school_type: "Academy special sponsor led") }
+    let(:special_school6) { create(:school, name: "Non-maintained special school", school_type: "Free schools special") }
+
+    before do
+      [faith_school, special_school2, special_school3, special_school4, special_school5, special_school6].each do |school|
+        create(:publisher, organisations: [school])
+        create(:vacancy, organisations: [school])
+      end
+      visit organisations_path
+    end
+
     it "allows user to filter by special schools" do
       check "Special school"
       click_on I18n.t("buttons.search")
 
       expect_page_to_show_schools([special_school1, special_school2, special_school3, special_school4, special_school5, special_school6])
-      expect_page_not_to_show_schools([local_authority_school, secondary_school, primary_school])
+      expect_page_not_to_show_schools([secondary_school, primary_school, faith_school])
     end
 
     it "allows users to filter by faith schools" do
@@ -117,7 +131,16 @@ RSpec.describe "Searching on the schools page" do
       click_on I18n.t("buttons.search")
 
       expect_page_to_show_schools([faith_school])
-      expect_page_not_to_show_schools([local_authority_school, secondary_school, primary_school, special_school1, special_school2, special_school3, special_school4, special_school5, special_school6])
+      expect_page_not_to_show_schools([secondary_school, primary_school, special_school1, special_school2, special_school3, special_school4, special_school5, special_school6])
+    end
+
+    it "allows users to filter by faith schools AND special schools" do
+      check "Faith school"
+      check "Special school"
+      click_on I18n.t("buttons.search")
+
+      expect_page_to_show_schools([faith_school, special_school1, special_school2, special_school3, special_school4, special_school5, special_school6])
+      expect_page_not_to_show_schools([secondary_school, primary_school])
     end
   end
 

--- a/spec/system/jobseekers_can_search_for_schools_spec.rb
+++ b/spec/system/jobseekers_can_search_for_schools_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe "Searching on the schools page" do
   let(:primary_school) { create(:school, name: "St Peters", phase: "primary") }
   let(:special_school1) { create(:school, name: "Community special school", school_type: "Community special school") }
 
-
   before do
     [secondary_school, primary_school, special_school1].each do |school|
       create(:publisher, organisations: [school])
@@ -34,7 +33,7 @@ RSpec.describe "Searching on the schools page" do
 
       click_on I18n.t("buttons.search")
 
-      expect_page_to_show_schools([special_school1,])
+      expect_page_to_show_schools([special_school1])
       expect_page_not_to_show_schools([secondary_school, primary_school])
 
       expect(page).to have_link(I18n.t("organisations.search.results.phases.secondary"))
@@ -103,7 +102,7 @@ RSpec.describe "Searching on the schools page" do
   end
 
   context "when filtering by school type" do
-    let(:faith_school) { create(:school, name: "Religious", gias_data: {"ReligiousCharacter (name)" => "anything"}) }
+    let(:faith_school) { create(:school, name: "Religious", gias_data: { "ReligiousCharacter (name)" => "anything" }) }
     let(:special_school2) { create(:school, name: "Foundation special school", school_type: "Foundation special school") }
     let(:special_school3) { create(:school, name: "Non-maintained special school", school_type: "Non-maintained special school") }
     let(:special_school4) { create(:school, name: "Academy special converter", school_type: "Academy special converter") }
@@ -119,7 +118,7 @@ RSpec.describe "Searching on the schools page" do
     end
 
     it "allows user to filter by special schools" do
-      check "Special school"
+      check I18n.t("organisations.filters.special_school")
       click_on I18n.t("buttons.search")
 
       expect_page_to_show_schools([special_school1, special_school2, special_school3, special_school4, special_school5, special_school6])
@@ -127,7 +126,7 @@ RSpec.describe "Searching on the schools page" do
     end
 
     it "allows users to filter by faith schools" do
-      check "Faith school"
+      check I18n.t("organisations.filters.faith_school")
       click_on I18n.t("buttons.search")
 
       expect_page_to_show_schools([faith_school])
@@ -135,8 +134,8 @@ RSpec.describe "Searching on the schools page" do
     end
 
     it "allows users to filter by faith schools AND special schools" do
-      check "Faith school"
-      check "Special school"
+      check I18n.t("organisations.filters.faith_school")
+      check I18n.t("organisations.filters.special_school")
       click_on I18n.t("buttons.search")
 
       expect_page_to_show_schools([faith_school, special_school1, special_school2, special_school3, special_school4, special_school5, special_school6])


### PR DESCRIPTION
https://trello.com/c/HsRBoggC/364-add-a-school-type-filter

## Changes in this PR:

This PR adds a schools type filter to the schools and jobs pages so that jobseekers can filter by schools type (either faith schools or special schools or both).

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
