### PR TITLE
Use a subquery to avoid using distinct in the organisation type filter

### DIFF
--- a/app/queries/vacancy_filter_query.rb
+++ b/app/queries/vacancy_filter_query.rb
@@ -35,18 +35,20 @@ class VacancyFilterQuery < ApplicationQuery
 
   def add_organisation_type_filters(filters, built_scope)
     return built_scope unless filters[:organisation_types].present?
-
+  
     selected_school_types = []
-
+  
     if filters[:organisation_types].include?("Academy")
       selected_school_types.push("Academy", "Academies", "Free schools", "Free school")
     end
-
+  
     if filters[:organisation_types].include?("Local authority maintained schools")
       selected_school_types << "Local authority maintained schools"
     end
-
-    built_scope.joins(organisation_vacancies: :organisation).where(organisations: { school_type: selected_school_types }).distinct
+  
+    subquery = OrganisationVacancy.joins(:organisation).where(organisations: { school_type: selected_school_types }).select(:vacancy_id)
+  
+    built_scope.joins(:organisation_vacancies).where(organisation_vacancies: { vacancy_id: subquery })
   end
 
   def job_roles(filter)

--- a/spec/system/jobseekers_can_search_for_jobs_spec.rb
+++ b/spec/system/jobseekers_can_search_for_jobs_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
   let(:school) { create(:school) }
   let!(:maths_job1) { create(:vacancy, :past_publish, :teacher, publish_on: Date.current - 1, job_title: "Maths 1", subjects: %w[Mathematics], organisations: [school], phases: %w[secondary]) }
   let!(:maths_job2) { create(:vacancy, :past_publish, :teacher, publish_on: Date.current - 2, job_title: "Maths Teacher 2", subjects: %w[Mathematics], organisations: [school], phases: %w[secondary]) }
-  let!(:job1) { create(:vacancy, :past_publish, :teacher, job_title: "Physics Teacher", subjects: [], organisations: [academy1]) }
+  let!(:job1) { create(:vacancy, :past_publish, :teacher, job_title: "Physics Teacher", subjects: ["Physics"], organisations: [academy1], phases: %w[secondary]) }
   let!(:job2) { create(:vacancy, :past_publish, :teacher, job_title: "PE Teacher", subjects: [], organisations: [academy2]) }
   let!(:job3) { create(:vacancy, :past_publish, :teacher, job_title: "Chemistry Teacher", subjects: [], organisations: [free_school1]) }
   let!(:job4) { create(:vacancy, :past_publish, :teacher, job_title: "Geography Teacher", subjects: [], organisations: [free_school2]) }
@@ -141,6 +141,24 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
 
         expect_page_to_show_jobs([job1, job2, job3, job4, job5])
         expect_page_not_to_show_jobs([maths_job1, maths_job2])
+      end
+    end
+
+    context "when used in conjunction with a search term" do
+      # testing this unusual edge case around removing auto-populated search terms because it was raising exceptions for us in the past.
+      it "returns the correct vacancies even after removing auto-populated search terms" do
+        visit jobs_path
+        fill_in "Keyword", with: "Physics teacher"
+        check "Academy"
+  
+        click_on I18n.t("buttons.search")
+
+        click_link "Remove this filter Teacher"
+        click_link "Remove this filter Head of year, department, curriculum or phase"
+        click_on I18n.t("buttons.search")
+
+        expect_page_to_show_jobs([job1])
+        expect_page_not_to_show_jobs([job2, job3, job4, job5, maths_job1, maths_job2])
       end
     end
   end


### PR DESCRIPTION
https://trello.com/b/1QyLnb9W/teaching-vacancies-sprint-board

## Changes in this PR:

This PR adds filtering by organisation to the jobs and schools pages for jobseekers.

The previous deployment of this caused the following error: 

https://teaching-vacancies.sentry.io/issues/4247141352/?project=6212514&query=firstRelease%3A907efda2c98b69ce1c68445013ac84ebf9f608dc&referrer=issue-stream&sort=freq&stream_index=0

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
