### PR TITLE
Supportal changes

### DIFF
--- a/app/views/support_users/feedbacks/_feedback_table.html.slim
+++ b/app/views/support_users/feedbacks/_feedback_table.html.slim
@@ -2,9 +2,9 @@
   - t.datetime "Timestamp", :created_at
   - t.tags("Source") { |f| source_for(f) }
   - t.tags("Who") { |f| who(f) }
-  - t.text("Type") { |f| f.feedback_type }
+  - t.text "Type", :feedback_type
   - t.text("Contact email") { |f| contact_email_for(f) }
-  - t.text("Occupation") { |f| f.occupation }
+  - t.text "Occupation", :occupation
   - t.text("CSAT") { |f| t("helpers.label.general_feedback_form.rating.#{f.rating}") if f.rating }
   - t.text "Comment", :comment
   - t.column("Category") do |f|

--- a/app/views/support_users/feedbacks/_feedback_table.html.slim
+++ b/app/views/support_users/feedbacks/_feedback_table.html.slim
@@ -2,7 +2,9 @@
   - t.datetime "Timestamp", :created_at
   - t.tags("Source") { |f| source_for(f) }
   - t.tags("Who") { |f| who(f) }
+  - t.text("Type") { |f| f.feedback_type }
   - t.text("Contact email") { |f| contact_email_for(f) }
+  - t.text("Occupation") { |f| f.occupation }
   - t.text("CSAT") { |f| t("helpers.label.general_feedback_form.rating.#{f.rating}") if f.rating }
   - t.text "Comment", :comment
   - t.column("Category") do |f|

--- a/spec/system/support_users/feedback_spec.rb
+++ b/spec/system/support_users/feedback_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Feedback supportal section" do
       :feedback,
       feedback_type: :job_alert,
       comment: "Some job alert feedback text",
-      occupation: "Teacher",
+      occupation: "Teacher"
     )
   end
 
@@ -42,6 +42,9 @@ RSpec.describe "Feedback supportal section" do
       feedback_type: :general,
       comment: "Some other feedback text",
       occupation: "Student",
+      rating: "highly_satisfied",
+      email: "faketestingemail@someemail.com",
+      user_participation_response: "interested"
     )
   end
 
@@ -85,26 +88,26 @@ RSpec.describe "Feedback supportal section" do
       end
     end
 
-    it "shows feedback tables" do
-      within("table.govuk-table") do
-        within("tbody.govuk-table__body") do
-          within("tr:first-child") do
-            timestamp = find("td:nth-child(1)").text
-            source = find("td:nth-child(2)").text
-            who = find("td:nth-child(3)").text
-            feedback_type = find("td:nth-child(4)").text
-            contact_email = find("td:nth-child(5)").text
-            occupation = find("td:nth-child(6)").text
-            csat = find("td:nth-child(7)").text
-            comment = find("td:nth-child(8)").text
-
+    it "shows feedback table" do
+      within('table.govuk-table') do
+        within('tbody.govuk-table__body') do
+          within('tr:first-child') do
+            timestamp = find('td:nth-child(1)').text
+            source = find('td:nth-child(2)').text
+            who = find('td:nth-child(3)').text
+            feedback_type = find('td:nth-child(4)').text
+            contact_email = find('td:nth-child(5)').text
+            occupation = find('td:nth-child(6)').text
+            csat = find('td:nth-child(7)').text
+            comment = find('td:nth-child(8)').text
+            
             expect(timestamp).to eq(other_feedback.created_at.to_s)
             expect(source).to eq("Identified")
             expect(who).to eq("Jobseeker")
             expect(occupation).to eq(other_feedback.occupation)
             expect(contact_email).to eq(other_feedback.email)
             expect(feedback_type).to eq(other_feedback.feedback_type)
-            expect(csat).to eq(t("helpers.label.general_feedback_form.rating.#{other_feedback.rating}"))
+            expect(csat).to eq(I18n.t("helpers.label.general_feedback_form.rating.#{other_feedback.rating}"))
             expect(comment).to eq(other_feedback.comment)
           end
         end

--- a/spec/system/support_users/feedback_spec.rb
+++ b/spec/system/support_users/feedback_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe "Feedback supportal section" do
       :feedback,
       feedback_type: :job_alert,
       comment: "Some job alert feedback text",
+      occupation: "Teacher"
     )
   end
 
@@ -40,6 +41,7 @@ RSpec.describe "Feedback supportal section" do
       :feedback,
       feedback_type: :general,
       comment: "Some other feedback text",
+      occupation: "Student"
     )
   end
 
@@ -80,6 +82,28 @@ RSpec.describe "Feedback supportal section" do
 
       within ".supportal-table-component--formatting" do
         expect(page).to have_text("Some other feedback text")
+      end
+    end
+
+    it "shows occupation of the user filling out the feedback" do
+      within('table.govuk-table') do
+        within('tbody.govuk-table__body') do
+          within('tr:first-child') do
+            occupation = find('td:nth-child(6)').text
+            expect(occupation).to eq('dev')
+          end
+        end
+      end
+    end
+
+    it "shows type of feedback" do
+      within('table.govuk-table') do
+        within('tbody.govuk-table__body') do
+          within('tr:first-child') do
+            occupation = find('td:nth-child(4)').text
+            expect(occupation).to eq('dev')
+          end
+        end
       end
     end
   end

--- a/spec/system/support_users/feedback_spec.rb
+++ b/spec/system/support_users/feedback_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Feedback supportal section" do
       :feedback,
       feedback_type: :job_alert,
       comment: "Some job alert feedback text",
-      occupation: "Teacher"
+      occupation: "Teacher",
     )
   end
 
@@ -44,7 +44,7 @@ RSpec.describe "Feedback supportal section" do
       occupation: "Student",
       rating: "highly_satisfied",
       email: "faketestingemail@someemail.com",
-      user_participation_response: "interested"
+      user_participation_response: "interested",
     )
   end
 
@@ -89,18 +89,18 @@ RSpec.describe "Feedback supportal section" do
     end
 
     it "shows feedback table" do
-      within('table.govuk-table') do
-        within('tbody.govuk-table__body') do
-          within('tr:first-child') do
-            timestamp = find('td:nth-child(1)').text
-            source = find('td:nth-child(2)').text
-            who = find('td:nth-child(3)').text
-            feedback_type = find('td:nth-child(4)').text
-            contact_email = find('td:nth-child(5)').text
-            occupation = find('td:nth-child(6)').text
-            csat = find('td:nth-child(7)').text
-            comment = find('td:nth-child(8)').text
-            
+      within("table.govuk-table") do
+        within("tbody.govuk-table__body") do
+          within("tr:first-child") do
+            timestamp = find("td:nth-child(1)").text
+            source = find("td:nth-child(2)").text
+            who = find("td:nth-child(3)").text
+            feedback_type = find("td:nth-child(4)").text
+            contact_email = find("td:nth-child(5)").text
+            occupation = find("td:nth-child(6)").text
+            csat = find("td:nth-child(7)").text
+            comment = find("td:nth-child(8)").text
+
             expect(timestamp).to eq(other_feedback.created_at.to_s)
             expect(source).to eq("Identified")
             expect(who).to eq("Jobseeker")

--- a/spec/system/support_users/feedback_spec.rb
+++ b/spec/system/support_users/feedback_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Feedback supportal section" do
       :feedback,
       feedback_type: :job_alert,
       comment: "Some job alert feedback text",
-      occupation: "Teacher"
+      occupation: "Teacher",
     )
   end
 
@@ -41,7 +41,7 @@ RSpec.describe "Feedback supportal section" do
       :feedback,
       feedback_type: :general,
       comment: "Some other feedback text",
-      occupation: "Student"
+      occupation: "Student",
     )
   end
 
@@ -85,23 +85,27 @@ RSpec.describe "Feedback supportal section" do
       end
     end
 
-    it "shows occupation of the user filling out the feedback" do
-      within('table.govuk-table') do
-        within('tbody.govuk-table__body') do
-          within('tr:first-child') do
-            occupation = find('td:nth-child(6)').text
-            expect(occupation).to eq('dev')
-          end
-        end
-      end
-    end
+    it "shows feedback tables" do
+      within("table.govuk-table") do
+        within("tbody.govuk-table__body") do
+          within("tr:first-child") do
+            timestamp = find("td:nth-child(1)").text
+            source = find("td:nth-child(2)").text
+            who = find("td:nth-child(3)").text
+            feedback_type = find("td:nth-child(4)").text
+            contact_email = find("td:nth-child(5)").text
+            occupation = find("td:nth-child(6)").text
+            csat = find("td:nth-child(7)").text
+            comment = find("td:nth-child(8)").text
 
-    it "shows type of feedback" do
-      within('table.govuk-table') do
-        within('tbody.govuk-table__body') do
-          within('tr:first-child') do
-            occupation = find('td:nth-child(4)').text
-            expect(occupation).to eq('dev')
+            expect(timestamp).to eq(other_feedback.created_at.to_s)
+            expect(source).to eq("Identified")
+            expect(who).to eq("Jobseeker")
+            expect(occupation).to eq(other_feedback.occupation)
+            expect(contact_email).to eq(other_feedback.email)
+            expect(feedback_type).to eq(other_feedback.feedback_type)
+            expect(csat).to eq(t("helpers.label.general_feedback_form.rating.#{other_feedback.rating}"))
+            expect(comment).to eq(other_feedback.comment)
           end
         end
       end


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/jrkpDuZz/367-add-occupation-to-supportal
https://trello.com/c/ZhIALZdH/372-adding-type-of-feedback-form-used-to-user-feedback-support-dashboard

## Changes in this PR:

Adding two new fields to the general tab on the support dashboard which show type of feedback and occupation of the user giving feedback.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
