### PR TITLE
Org filter bug

### DIFF
--- a/app/queries/vacancy_filter_query.rb
+++ b/app/queries/vacancy_filter_query.rb
@@ -46,9 +46,9 @@ class VacancyFilterQuery < ApplicationQuery
       selected_school_types << "Local authority maintained schools"
     end
 
-    subquery = OrganisationVacancy.joins(:organisation).where(organisations: { school_type: selected_school_types }).select(:vacancy_id)
+    vacancy_ids = OrganisationVacancy.joins(:organisation).where(organisations: { school_type: selected_school_types }).pluck(:vacancy_id)
 
-    built_scope.joins(:organisation_vacancies).where(organisation_vacancies: { vacancy_id: subquery })
+    built_scope.where(id: vacancy_ids)
   end
 
   def job_roles(filter)

--- a/spec/queries/vacancy_filter_query_spec.rb
+++ b/spec/queries/vacancy_filter_query_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe VacancyFilterQuery do
   let!(:vacancy3) { create(:vacancy, job_title: "Vacancy 3", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "sendco", ect_status: nil, organisations: [local_authority_school]) }
   let!(:vacancy4) { create(:vacancy, job_title: "Vacancy 4", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil) }
   let!(:vacancy5) { create(:vacancy, job_title: "Vacancy 5", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [academies]) }
-  let!(:vacancy6) { create(:vacancy, job_title: "Vacancy 6", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [free_schools]) }
+  let!(:vacancy6) { create(:vacancy, job_title: "Vacancy 6", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
 
   describe "#call" do
     it "queries based on the given filters" do

--- a/spec/system/jobseekers_can_search_for_jobs_spec.rb
+++ b/spec/system/jobseekers_can_search_for_jobs_spec.rb
@@ -75,13 +75,14 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
   let(:free_school1) { create(:school, school_type: "Free schools") }
   let(:free_school2) { create(:school, school_type: "Free school") }
   let(:local_authority_school1) { create(:school, school_type: "Local authority maintained schools") }
+  let(:local_authority_school2) { create(:school, school_type: "Local authority maintained schools") }
   let(:school) { create(:school) }
   let!(:maths_job1) { create(:vacancy, :past_publish, :teacher, publish_on: Date.current - 1, job_title: "Maths 1", subjects: %w[Mathematics], organisations: [school], phases: %w[secondary]) }
   let!(:maths_job2) { create(:vacancy, :past_publish, :teacher, publish_on: Date.current - 2, job_title: "Maths Teacher 2", subjects: %w[Mathematics], organisations: [school], phases: %w[secondary]) }
   let!(:job1) { create(:vacancy, :past_publish, :teacher, job_title: "Physics Teacher", subjects: ["Physics"], organisations: [academy1], phases: %w[secondary]) }
   let!(:job2) { create(:vacancy, :past_publish, :teacher, job_title: "PE Teacher", subjects: [], organisations: [academy2]) }
   let!(:job3) { create(:vacancy, :past_publish, :teacher, job_title: "Chemistry Teacher", subjects: [], organisations: [free_school1]) }
-  let!(:job4) { create(:vacancy, :past_publish, :teacher, job_title: "Geography Teacher", subjects: [], organisations: [free_school2]) }
+  let!(:job4) { create(:vacancy, :past_publish, :teacher, job_title: "Geography Teacher", subjects: [], publisher_organisation: free_school1, organisations: [free_school1, free_school2]) }
   let!(:expired_job) { create(:vacancy, :expired, :teacher, job_title: "Maths Teacher", subjects: [], organisations: [school]) }
   let(:per_page) { 2 }
 
@@ -108,7 +109,7 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
   end
 
   context "jobseekers can use the organisation type filter to search for jobs" do
-    let!(:job5) { create(:vacancy, :past_publish, :teacher, job_title: "History Teacher", subjects: [], organisations: [local_authority_school1]) }
+    let!(:job5) { create(:vacancy, :past_publish, :teacher, job_title: "History Teacher", subjects: [], publisher_organisation: local_authority_school1, organisations: [local_authority_school1, local_authority_school2]) }
 
     context "when academy is selected" do
       it "only shows vacancies from academies" do
@@ -165,7 +166,7 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
 
   def expect_page_to_show_jobs(jobs)
     jobs.each do |job|
-      expect(page).to have_link job.job_title
+      expect(page).to have_link(job.job_title, count: 1)
     end
   end
 


### PR DESCRIPTION
## Changes in this PR:

I noticed what I believe is a bug in the newly added organisations filter on the schools and jobs pages for jobseekers. Currently, on production, duplicate vacancies are shown if the vacancy is associated with multiple organisations. This PR adds tests to ensure duplicate vacancies are not shown, and fixes this issue.

An example of the bug can be found [here](https://teaching-vacancies.service.gov.uk/jobs?job_roles[]=&phases[]=&subjects[]=&ect_statuses[]=&organisation_types[]=&organisation_types[]=Local+authority+maintained+schools&working_patterns[]=&previous_keyword=&organisation_slug=&keyword=&location=&radius=0&sort_by=publish_on&page=2). 

<img width="735" alt="Screenshot 2023-06-19 at 17 30 13" src="https://github.com/DFE-Digital/teaching-vacancies/assets/13124899/cd728990-c9c7-4054-a787-35c83788fea4">

The 'Teacher of History (Humanities)' vacancy is a job which is working across both Solway Community School and Beacon Hill Community School. Due to it being associated with two schools it is being shown twice, but it is in fact only one vacancy. This is an example of the bug that this PR fixes.

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
