### PR TITLE
Remove relevance as a sorting option

### DIFF
--- a/app/services/search/vacancy_sort.rb
+++ b/app/services/search/vacancy_sort.rb
@@ -5,7 +5,6 @@ class Search::VacancySort < RecordSort
   end
 
   def options
-    # Do not allow relevance sort order when no keywords are given as it makes no sense
     [publish_on_desc_option]
   end
 

--- a/app/services/search/vacancy_sort.rb
+++ b/app/services/search/vacancy_sort.rb
@@ -6,24 +6,12 @@ class Search::VacancySort < RecordSort
 
   def options
     # Do not allow relevance sort order when no keywords are given as it makes no sense
-    if keyword.blank?
-      [publish_on_desc_option]
-    else
-      [relevance_option, publish_on_desc_option]
-    end
+    [publish_on_desc_option]
   end
 
   private
 
   attr_reader :keyword
-
-  def default_sort_option
-    options.include?(relevance_option) ? relevance_option : publish_on_desc_option
-  end
-
-  def relevance_option
-    @relevance_option ||= SortOption.new("relevance", I18n.t("jobs.sort_by.most_relevant"))
-  end
 
   def publish_on_desc_option
     SortOption.new("publish_on", I18n.t("jobs.sort_by.publish_on.descending"), "desc")

--- a/app/views/vacancies/index.html.slim
+++ b/app/views/vacancies/index.html.slim
@@ -29,7 +29,6 @@ h1 class="govuk-heading-l" role="heading" aria-level="1"
                                  link: tracked_link_to(t("vacancies.international_teacher_advice.link"), "https://getintoteaching.education.gov.uk/non-uk-teachers", link_type: :international_teacher_advice_link_search_results)))
       #search-results
         - if @vacancies.any?
-          = render "vacancies/search/sort", form: @form, vacancies_search: @vacancies_search, vacancies: @vacancies
           = render "vacancies/search/results", vacancies: @vacancies
         - elsif @vacancies_search.organisation_slug
           = render "vacancies/search/no_results_organisation", organisation_name: @vacancies_search.organisation.name

--- a/app/views/vacancies/search/_sort.html.slim
+++ b/app/views/vacancies/search/_sort.html.slim
@@ -1,2 +1,0 @@
-  - if vacancies_search.sort.many? && vacancies.many?
-    = render SortComponent.new path: method(:jobs_path), sort: vacancies_search.sort, url_params: form.to_hash

--- a/spec/services/search/vacancy_search_spec.rb
+++ b/spec/services/search/vacancy_search_spec.rb
@@ -30,9 +30,7 @@ RSpec.describe Search::VacancySearch do
   let(:working_patterns) { nil }
   let(:subjects) { nil }
   let(:organisation_types) { nil }
-
   let(:school) { create(:school) }
-
   let(:scope) { double("scope", count: 870) }
 
   before do

--- a/spec/services/search/vacancy_search_spec.rb
+++ b/spec/services/search/vacancy_search_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Search::VacancySearch do
     allow(scope).to receive(:search_by_filter).and_return(scope)
     allow(scope).to receive(:search_by_full_text).with("maths teacher").and_return(scope)
     allow(scope).to receive(:where).with(id: vacancy_ids).and_return(scope)
+    allow(scope).to receive(:reorder).with({ "publish_on" => "desc" }).and_return(scope)
   end
 
   describe "performing search" do

--- a/spec/services/search/vacancy_sort_spec.rb
+++ b/spec/services/search/vacancy_sort_spec.rb
@@ -20,9 +20,7 @@ RSpec.describe Search::VacancySort do
       context "and a keyword is specified" do
         let(:keyword) { "maths" }
 
-        it "sorts by relevance" do
-          expect(subject.sort_by).to eq("relevance")
-        end
+        it_behaves_like "sorts by publish_on"
       end
 
       context "and a keyword is NOT specified" do
@@ -34,9 +32,7 @@ RSpec.describe Search::VacancySort do
       let(:sort_by) { "worst_listing" }
       let(:keyword) { "maths" }
 
-      it "sorts by relevance" do
-        expect(subject.sort_by).to eq("relevance")
-      end
+      it_behaves_like "sorts by publish_on"
     end
   end
 
@@ -69,7 +65,7 @@ RSpec.describe Search::VacancySort do
       let(:sort_by) { "relevance" }
       let(:keyword) { "test" }
 
-      it { is_expected.not_to be_by_db_column }
+      it { is_expected.to be_by_db_column }
     end
 
     context "when sorting by publish_on" do

--- a/spec/system/jobseekers_can_search_for_jobs_spec.rb
+++ b/spec/system/jobseekers_can_search_for_jobs_spec.rb
@@ -43,14 +43,6 @@ RSpec.shared_examples "a successful search" do
       end
     end
 
-    context "when sorting by most relevant" do
-      before { click_on I18n.t("jobs.sort_by.most_relevant").humanize }
-
-      it "lists the most relevant jobs first" do
-        expect("Maths Teacher 2").to appear_before("Maths 1")
-      end
-    end
-
     context "when clearing all applied filters" do
       before { click_on I18n.t("shared.filter_group.clear_all_filters") }
 


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/uyeV5O5h/402-remove-relevance-sort-type

## Changes in this PR:

This PR removes the relevance as a sorting option on the vacancies search page. After this change results on the vacancies page will be sorted by newest first regardless if a search term has been entered.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
