### PR TITLE
Remove tutor from 'Learning support or cover supervisor' text

### DIFF
--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -371,7 +371,7 @@ en:
           true: Yes, I've completed this section
       jobseekers_job_preferences_form:
         role_options:
-          education_support: Learning support, cover supervisor or tutor
+          education_support: Learning support or cover supervisor
           head_of_year_or_phase: Head of year or phase
           head_of_department_or_curriculum: Head of department or curriculum
           headteacher: Headteacher
@@ -718,7 +718,7 @@ en:
         job_role_options:
           ect_suitable: Suitable for early career teachers
           ect_suitable_hidden_prefix: Only show results
-          education_support: Learning support, cover supervisor or tutor
+          education_support: Learning support or cover supervisor
           higher_level_teaching_assistant: HLTA (higher level teaching assistant)
           leadership: Senior leader
           middle_leader: Head of year, department, curriculum or phase

--- a/config/locales/landing_pages.yml
+++ b/config/locales/landing_pages.yml
@@ -47,7 +47,7 @@ en:
       heading: "%{count} early career teacher (ECT) jobs"
       meta_description: "Find early career teacher (ECT, formerly known as NQT) jobs in local primary and secondary schools. Get your teaching career off to a great start."
     education-support-jobs:
-      name: "Learning support, cover supervisor or tutor"
+      name: "Learning support or cover supervisor"
       title: "Education & School Support Jobs"
       heading: "%{count} education and school support jobs"
       meta_description: "Find jobs for LSAs, HR managers, finance officers, admin assistants, cover supervisors and other non-teaching vacancies in schools near you."

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -116,7 +116,7 @@ en:
           headteacher: Headteacher
           teaching_assistant: Teaching assistant
           higher_level_teaching_assistant: HLTA (higher level teaching assistant)
-          education_support: Learning support, cover supervisor or tutor
+          education_support: Learning support or cover supervisor
           sendco: SENDCo (special educational needs and disabilities coordinator)
         schools: Locations
         working_pattern_options:


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/m4VGbvIF/401-remove-the-word-tutor-from-filter

## Changes in this PR:

Changing the wording of 'Learning support, cover supervisor or tutor' to 'Learning support or cover supervisor'.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
