### PR TITLE
Fix special school filter

### DIFF
--- a/app/queries/vacancy_filter_query.rb
+++ b/app/queries/vacancy_filter_query.rb
@@ -56,11 +56,11 @@ class VacancyFilterQuery < ApplicationQuery
 
     if school_types.include?("faith_school") && school_types.include?("special_school")
       built_scope.joins(organisation_vacancies: :organisation).where.not("organisations.gias_data ->> 'ReligiousCharacter (name)' IN (?)", Organisation::NON_FAITH_RELIGIOUS_CHARACTER_TYPES)
-                                                              .or(built_scope.where("organisations.school_type IN (?)", Organisation::SPECIAL_SCHOOL_TYPES)).distinct
+                                                              .or(built_scope.where("organisations.detailed_school_type IN (?)", Organisation::SPECIAL_SCHOOL_TYPES)).distinct
     elsif school_types.include?("faith_school")
       built_scope.joins(organisation_vacancies: :organisation).where.not("organisations.gias_data ->> 'ReligiousCharacter (name)' IN (?)", Organisation::NON_FAITH_RELIGIOUS_CHARACTER_TYPES).distinct
     elsif school_types.include?("special_school")
-      built_scope.joins(organisation_vacancies: :organisation).where(organisations: { school_type: Organisation::SPECIAL_SCHOOL_TYPES }).distinct
+      built_scope.joins(organisation_vacancies: :organisation).where(organisations: { detailed_school_type: Organisation::SPECIAL_SCHOOL_TYPES }).distinct
     else
       built_scope
     end

--- a/app/services/search/school_search.rb
+++ b/app/services/search/school_search.rb
@@ -114,9 +114,9 @@ class Search::SchoolSearch
 
     if school_types.include?("special_school") && school_types.include?("faith_school")
       scope.where.not("gias_data ->> 'ReligiousCharacter (name)' IN (?)", Organisation::NON_FAITH_RELIGIOUS_CHARACTER_TYPES)
-           .or(scope.where(school_type: Organisation::SPECIAL_SCHOOL_TYPES))
+           .or(scope.where(detailed_school_type: Organisation::SPECIAL_SCHOOL_TYPES))
     elsif school_types.include?("special_school")
-      scope.where(school_type: Organisation::SPECIAL_SCHOOL_TYPES)
+      scope.where(detailed_school_type: Organisation::SPECIAL_SCHOOL_TYPES)
     elsif school_types.include?("faith_school")
       scope.where.not("gias_data ->> 'ReligiousCharacter (name)' IN (?)", Organisation::NON_FAITH_RELIGIOUS_CHARACTER_TYPES)
     else

--- a/spec/queries/vacancy_filter_query_spec.rb
+++ b/spec/queries/vacancy_filter_query_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe VacancyFilterQuery do
   let(:free_school) { create(:school, name: "Freeschool1", school_type: "Free schools") }
   let(:free_schools) { create(:school, name: "Freeschool2", school_type: "Free school") }
   let(:local_authority_school) { create(:school, name: "local authority", school_type: "Local authority maintained schools") }
-  let(:special_school1) { create(:school, name: "Community special school", school_type: "Community special school") }
-  let(:special_school2) { create(:school, name: "Foundation special school", school_type: "Foundation special school") }
-  let(:special_school3) { create(:school, name: "Non-maintained special school", school_type: "Non-maintained special school") }
-  let(:special_school4) { create(:school, name: "Academy special converter", school_type: "Academy special converter") }
-  let(:special_school5) { create(:school, name: "Academy special sponsor led", school_type: "Academy special sponsor led") }
-  let(:special_school6) { create(:school, name: "Non-maintained special school", school_type: "Free schools special") }
+  let(:special_school1) { create(:school, name: "Community special school", detailed_school_type: "Community special school") }
+  let(:special_school2) { create(:school, name: "Foundation special school", detailed_school_type: "Foundation special school") }
+  let(:special_school3) { create(:school, name: "Non-maintained special school", detailed_school_type: "Non-maintained special school") }
+  let(:special_school4) { create(:school, name: "Academy special converter", detailed_school_type: "Academy special converter") }
+  let(:special_school5) { create(:school, name: "Academy special sponsor led", detailed_school_type: "Academy special sponsor led") }
+  let(:special_school6) { create(:school, name: "Non-maintained special school", detailed_school_type: "Free schools special") }
   let(:faith_school) { create(:school, name: "Religious", gias_data: { "ReligiousCharacter (name)" => "anything" }) }
   let(:faith_school2) { create(:school, name: "Religious", gias_data: { "ReligiousCharacter (name)" => "somethingelse" }) }
   let(:non_faith_school1) { create(:school, name: "nonfaith1", gias_data: { "ReligiousCharacter (name)" => "" }) }

--- a/spec/services/search/school_search_spec.rb
+++ b/spec/services/search/school_search_spec.rb
@@ -86,17 +86,17 @@ RSpec.describe Search::SchoolSearch do
   end
 
   context "when school_types are given" do
-    let(:special_school1) { create(:school, name: "Community special school", school_type: "Community special school") }
-    let(:special_school2) { create(:school, name: "Foundation special school", school_type: "Foundation special school") }
-    let(:special_school3) { create(:school, name: "Non-maintained special school", school_type: "Non-maintained special school") }
-    let(:special_school4) { create(:school, name: "Academy special converter", school_type: "Academy special converter") }
-    let(:special_school5) { create(:school, name: "Academy special sponsor led", school_type: "Academy special sponsor led") }
-    let(:special_school6) { create(:school, name: "Non-maintained special school", school_type: "Free schools special") }
+    let(:special_school1) { create(:school, name: "Community special school", detailed_school_type: "Community special school") }
+    let(:special_school2) { create(:school, name: "Foundation special school", detailed_school_type: "Foundation special school") }
+    let(:special_school3) { create(:school, name: "Non-maintained special school", detailed_school_type: "Non-maintained special school") }
+    let(:special_school4) { create(:school, name: "Academy special converter", detailed_school_type: "Academy special converter") }
+    let(:special_school5) { create(:school, name: "Academy special sponsor led", detailed_school_type: "Academy special sponsor led") }
+    let(:special_school6) { create(:school, name: "Non-maintained special school", detailed_school_type: "Free schools special") }
     let(:faith_school) { create(:school, name: "Religious", gias_data: { "ReligiousCharacter (name)" => "anything" }) }
     let(:non_faith_school1) { create(:school, name: "nonfaith1", gias_data: { "ReligiousCharacter (name)" => "" }) }
     let(:non_faith_school2) { create(:school, name: "nonfaith2", gias_data: { "ReligiousCharacter (name)" => "Does not apply" }) }
     let(:non_faith_school3) { create(:school, name: "nonfaith3", gias_data: { "ReligiousCharacter (name)" => "None" }) }
-    let!(:other_school) { create(:school, name: "other", school_type: "Something else") }
+    let!(:other_school) { create(:school, name: "other", detailed_school_type: "Something else") }
 
     context "when school_types == ['faith_school']" do
       let(:school_types) { ["faith_school"] }

--- a/spec/system/jobseekers_can_search_for_jobs_spec.rb
+++ b/spec/system/jobseekers_can_search_for_jobs_spec.rb
@@ -158,12 +158,12 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
   end
 
   context "when filtering by school type" do
-    let(:special_school1) { create(:school, name: "Community special school", school_type: "Community special school") }
-    let(:special_school2) { create(:school, name: "Foundation special school", school_type: "Foundation special school") }
-    let(:special_school3) { create(:school, name: "Non-maintained special school", school_type: "Non-maintained special school") }
-    let(:special_school4) { create(:school, name: "Academy special converter", school_type: "Academy special converter") }
-    let(:special_school5) { create(:school, name: "Academy special sponsor led", school_type: "Academy special sponsor led") }
-    let(:special_school6) { create(:school, name: "Non-maintained special school", school_type: "Free schools special") }
+    let(:special_school1) { create(:school, name: "Community special school", detailed_school_type: "Community special school") }
+    let(:special_school2) { create(:school, name: "Foundation special school", detailed_school_type: "Foundation special school") }
+    let(:special_school3) { create(:school, name: "Non-maintained special school", detailed_school_type: "Non-maintained special school") }
+    let(:special_school4) { create(:school, name: "Academy special converter", detailed_school_type: "Academy special converter") }
+    let(:special_school5) { create(:school, name: "Academy special sponsor led", detailed_school_type: "Academy special sponsor led") }
+    let(:special_school6) { create(:school, name: "Non-maintained special school", detailed_school_type: "Free schools special") }
     let(:faith_school) { create(:school, name: "Religious", gias_data: { "ReligiousCharacter (name)" => "anything" }) }
     let(:faith_school2) { create(:school, name: "ABCDEF", gias_data: { "ReligiousCharacter (name)" => "somethingelse" }) }
     let(:non_faith_school1) { create(:school, name: "nonfaith1", gias_data: { "ReligiousCharacter (name)" => "" }) }

--- a/spec/system/jobseekers_can_search_for_schools_spec.rb
+++ b/spec/system/jobseekers_can_search_for_schools_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Searching on the schools page" do
   let(:secondary_school) { create(:school, name: "Oxford") }
   let(:primary_school) { create(:school, name: "St Peters", phase: "primary") }
-  let(:special_school1) { create(:school, name: "Community special school", school_type: "Community special school") }
+  let(:special_school1) { create(:school, name: "Community special school", detailed_school_type: "Community special school") }
 
   before do
     [secondary_school, primary_school, special_school1].each do |school|
@@ -108,11 +108,11 @@ RSpec.describe "Searching on the schools page" do
     let(:non_faith_school1) { create(:school, name: "nonfaith1", gias_data: { "ReligiousCharacter (name)" => "" }) }
     let(:non_faith_school2) { create(:school, name: "nonfaith2", gias_data: { "ReligiousCharacter (name)" => "Does not apply" }) }
     let(:non_faith_school3) { create(:school, name: "nonfaith3", gias_data: { "ReligiousCharacter (name)" => "None" }) }
-    let(:special_school2) { create(:school, name: "Foundation special school", school_type: "Foundation special school") }
-    let(:special_school3) { create(:school, name: "Non-maintained special school", school_type: "Non-maintained special school") }
-    let(:special_school4) { create(:school, name: "Academy special converter", school_type: "Academy special converter") }
-    let(:special_school5) { create(:school, name: "Academy special sponsor led", school_type: "Academy special sponsor led") }
-    let(:special_school6) { create(:school, name: "Non-maintained special school", school_type: "Free schools special") }
+    let(:special_school2) { create(:school, name: "Foundation special school", detailed_school_type: "Foundation special school") }
+    let(:special_school3) { create(:school, name: "Non-maintained special school", detailed_school_type: "Non-maintained special school") }
+    let(:special_school4) { create(:school, name: "Academy special converter", detailed_school_type: "Academy special converter") }
+    let(:special_school5) { create(:school, name: "Academy special sponsor led", detailed_school_type: "Academy special sponsor led") }
+    let(:special_school6) { create(:school, name: "Non-maintained special school", detailed_school_type: "Free schools special") }
 
     before do
       [faith_school, special_school2, special_school3, special_school4, special_school5, special_school6, non_faith_school1, non_faith_school2, non_faith_school3].each do |school|


### PR DESCRIPTION
## Trello card URL

## Changes in this PR:

Currently selecting 'Special school' in the school type filter on jobs/schools pages is returning no results. This is because we are querying where school_type field is equal to one of the special school types, however we should be querying where detailed_school_type field is equal to one of the special school types as illustrated below:

<img width="661" alt="Screenshot 2023-06-22 at 11 59 45" src="https://github.com/DFE-Digital/teaching-vacancies/assets/13124899/ff03dc14-9ca4-4a7c-acc5-6fbe59f9fc88">
<img width="597" alt="Screenshot 2023-06-22 at 12 00 15" src="https://github.com/DFE-Digital/teaching-vacancies/assets/13124899/7f2c9aac-2425-4db6-941e-b68cf8d7fffa">



## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
