### PR TITLE
Temporarily Increase Worker Count for BigQuery Backfill Operation

### DIFF
--- a/terraform/workspace-variables/production.tfvars.json
+++ b/terraform/workspace-variables/production.tfvars.json
@@ -25,7 +25,7 @@
   "paas_web_app_instances": 8,
   "paas_web_app_memory": 1536,
   "paas_worker_app_deployment_strategy": "blue-green-v2",
-  "paas_worker_app_instances": 4,
+  "paas_worker_app_instances": 8,
   "paas_worker_app_memory": 1536,
   "parameter_store_environment": "production",
   "region": "eu-west-2",


### PR DESCRIPTION
This PR increases the number of workers from 4 to 8 in the production environment. This temporary change is intended to speed up a Rake task, which is responsible for backfilling entities from our production database to Big Query.

### Changes Details

- Increase worker count to 8 in the specific configuration file.

### Impact

This change will expedite the Rake task and make the backfill operation more efficient. However, the increased worker count might increase resource usage temporarily.

### Reverting Plan

After the backfill operation is completed, we will revert the worker count back to 4. This plan will ensure that the system resources will not be unnecessarily consumed after the backfill process.

