### PR TITLE
Out of scope schools

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -47,7 +47,7 @@ class Organisation < ApplicationRecord
       .or(where(id: SchoolGroupMembership.select(:school_id).where(school_group_id: registered_organisations)))
   end)
 
-  scope :not_out_of_scope, -> { where.not(detailed_school_type: Organisation::OUT_OF_SCOPE_DETAILED_SCHOOL_TYPES) }
+  scope :not_out_of_scope, -> { where.not(detailed_school_type: Organisation::OUT_OF_SCOPE_DETAILED_SCHOOL_TYPES).or(where(detailed_school_type: nil)) }
 
   scope :visible_to_jobseekers, -> { schools.not_closed.not_out_of_scope.or(Organisation.trusts).registered_for_service }
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -8,6 +8,7 @@ class Organisation < ApplicationRecord
 
   SPECIAL_SCHOOL_TYPES = ["Community special school", "Foundation special school", "Non-maintained special school", "Academy special converter", "Academy special sponsor led", "Free schools special"].freeze
   NON_FAITH_RELIGIOUS_CHARACTER_TYPES = ["", "None", "Does not apply", "null"].freeze
+  OUT_OF_SCOPE_DETAILED_SCHOOL_TYPES = ["Further education", "Other independent school", "Miscellaneous", "Special post 16 institution", "Other independent special school", "Higher education institutions", "Welsh establishment"].freeze
 
   friendly_id :slug_candidates, use: :slugged
 
@@ -46,7 +47,9 @@ class Organisation < ApplicationRecord
       .or(where(id: SchoolGroupMembership.select(:school_id).where(school_group_id: registered_organisations)))
   end)
 
-  scope :visible_to_jobseekers, -> { schools.not_closed.or(Organisation.trusts).registered_for_service }
+  scope :not_out_of_scope, -> { where.not(detailed_school_type: Organisation::OUT_OF_SCOPE_DETAILED_SCHOOL_TYPES) }
+
+  scope :visible_to_jobseekers, -> { schools.not_closed.not_out_of_scope.or(Organisation.trusts).registered_for_service }
 
   alias_attribute :data, :gias_data
 

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -161,16 +161,16 @@ RSpec.describe Organisation do
 
   describe ".visible_to_jobseekers" do
     let!(:publisher) { create(:publisher, organisations: [trust, open_school, closed_school, out_of_scope_school1, out_of_scope_school2, out_of_scope_school3, out_of_scope_school4, out_of_scope_school5, out_of_scope_school6, out_of_scope_school7]) }
-    let!(:open_school) { create(:school, name: "1", establishment_status: "Open", detailed_school_type: "Primary school") }
-    let!(:closed_school) { create(:school, name: "2", establishment_status: "Closed", detailed_school_type: "Secondary school") }
-    let(:trust) { Organisation.create(type: "SchoolGroup", name: "Trust", name: "3", uid: "1") }
-    let!(:out_of_scope_school1) { create(:school, name: "4", establishment_status: "Open", detailed_school_type: "Further education") }
-    let!(:out_of_scope_school2) { create(:school, name: "5", establishment_status: "Open", detailed_school_type: "Other independent school") }
-    let!(:out_of_scope_school3) { create(:school, name: "6", establishment_status: "Open", detailed_school_type: "Miscellaneous") }
-    let!(:out_of_scope_school4) { create(:school, name: "7", establishment_status: "Open", detailed_school_type: "Special post 16 institution") }
-    let!(:out_of_scope_school5) { create(:school, name: "8", establishment_status: "Open", detailed_school_type: "Other independent special school") }
-    let!(:out_of_scope_school6) { create(:school, name: "9", establishment_status: "Open", detailed_school_type: "Higher education institutions") }
-    let!(:out_of_scope_school7) { create(:school, name: "10", establishment_status: "Open", detailed_school_type: "Welsh establishment") }
+    let!(:open_school) { create(:school, establishment_status: "Open", detailed_school_type: "Primary school") }
+    let!(:closed_school) { create(:school, establishment_status: "Closed", detailed_school_type: "Secondary school") }
+    let(:trust) { Organisation.create(type: "SchoolGroup", name: "Trust", uid: "1") }
+    let!(:out_of_scope_school1) { create(:school, establishment_status: "Open", detailed_school_type: "Further education") }
+    let!(:out_of_scope_school2) { create(:school, establishment_status: "Open", detailed_school_type: "Other independent school") }
+    let!(:out_of_scope_school3) { create(:school, establishment_status: "Open", detailed_school_type: "Miscellaneous") }
+    let!(:out_of_scope_school4) { create(:school, establishment_status: "Open", detailed_school_type: "Special post 16 institution") }
+    let!(:out_of_scope_school5) { create(:school, establishment_status: "Open", detailed_school_type: "Other independent special school") }
+    let!(:out_of_scope_school6) { create(:school, establishment_status: "Open", detailed_school_type: "Higher education institutions") }
+    let!(:out_of_scope_school7) { create(:school, establishment_status: "Open", detailed_school_type: "Welsh establishment") }
 
     it "returns open schools that are not out of scope" do
       expect(Organisation.visible_to_jobseekers).to include(open_school)

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -158,4 +158,34 @@ RSpec.describe Organisation do
       end
     end
   end
+
+  describe ".visible_to_jobseekers" do
+    let!(:publisher) { create(:publisher, organisations: [trust, open_school, closed_school, out_of_scope_school1, out_of_scope_school2, out_of_scope_school3, out_of_scope_school4, out_of_scope_school5, out_of_scope_school6, out_of_scope_school7]) }
+    let!(:open_school) { create(:school, name: "1", establishment_status: "Open", detailed_school_type: "Primary school") }
+    let!(:closed_school) { create(:school, name: "2", establishment_status: "Closed", detailed_school_type: "Secondary school") }
+    let(:trust) { Organisation.create(type: "SchoolGroup", name: "Trust", name: "3", uid: "1") }
+    let!(:out_of_scope_school1) { create(:school, name: "4", establishment_status: "Open", detailed_school_type: "Further education") }
+    let!(:out_of_scope_school2) { create(:school, name: "5", establishment_status: "Open", detailed_school_type: "Other independent school") }
+    let!(:out_of_scope_school3) { create(:school, name: "6", establishment_status: "Open", detailed_school_type: "Miscellaneous") }
+    let!(:out_of_scope_school4) { create(:school, name: "7", establishment_status: "Open", detailed_school_type: "Special post 16 institution") }
+    let!(:out_of_scope_school5) { create(:school, name: "8", establishment_status: "Open", detailed_school_type: "Other independent special school") }
+    let!(:out_of_scope_school6) { create(:school, name: "9", establishment_status: "Open", detailed_school_type: "Higher education institutions") }
+    let!(:out_of_scope_school7) { create(:school, name: "10", establishment_status: "Open", detailed_school_type: "Welsh establishment") }
+
+    it "returns open schools that are not out of scope" do
+      expect(Organisation.visible_to_jobseekers).to include(open_school)
+    end
+
+    it "excludes closed schools" do
+      expect(Organisation.visible_to_jobseekers).not_to include(closed_school)
+    end
+
+    it "includes trusts" do
+      expect(Organisation.visible_to_jobseekers).to include(trust)
+    end
+
+    it "excludes schools that are out of scope" do
+      expect(Organisation.visible_to_jobseekers).not_to include(out_of_scope_school1, out_of_scope_school2, out_of_scope_school3, out_of_scope_school4, out_of_scope_school5, out_of_scope_school6, out_of_scope_school7)
+    end
+  end
 end


### PR DESCRIPTION
## Trello card URL

https://trello.com/b/1QyLnb9W/teaching-vacancies-sprint-board

## Changes in this PR:

Prior to this change some schools were being shown on our schools page which are out of scope for the teaching vacancies app. This change stops these types or organisation which are out of scope for us from showing on the schools page.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
