### PR TITLE
Changes to email confirmation flow

### DIFF
--- a/app/controllers/jobseekers/confirmations_controller.rb
+++ b/app/controllers/jobseekers/confirmations_controller.rb
@@ -1,8 +1,4 @@
 class Jobseekers::ConfirmationsController < Devise::ConfirmationsController
-  def show
-    super
-  end
-
   protected
 
   def after_confirmation_path_for(_resource_name, resource)

--- a/app/controllers/jobseekers/confirmations_controller.rb
+++ b/app/controllers/jobseekers/confirmations_controller.rb
@@ -5,7 +5,7 @@ class Jobseekers::ConfirmationsController < Devise::ConfirmationsController
 
   protected
 
-  def after_confirmation_path_for(resource_name, resource)
+  def after_confirmation_path_for(_resource_name, resource)
     sign_in(resource)
     request_event.trigger(:jobseeker_email_confirmed)
     flash.delete(:notice)

--- a/app/controllers/jobseekers/confirmations_controller.rb
+++ b/app/controllers/jobseekers/confirmations_controller.rb
@@ -1,6 +1,6 @@
 class Jobseekers::ConfirmationsController < Devise::ConfirmationsController
   def show
-    super if request.method == "POST"
+    super
   end
 
   protected
@@ -9,7 +9,7 @@ class Jobseekers::ConfirmationsController < Devise::ConfirmationsController
     sign_in(resource)
     request_event.trigger(:jobseeker_email_confirmed)
     flash.delete(:notice)
-    stored_location_for(resource_name) || confirmation_jobseekers_account_path
+    confirmation_jobseekers_account_path
   end
 
   def after_resending_confirmation_instructions_path_for(_resource)

--- a/app/controllers/jobseekers/registrations_controller.rb
+++ b/app/controllers/jobseekers/registrations_controller.rb
@@ -24,6 +24,7 @@ class Jobseekers::RegistrationsController < Devise::RegistrationsController
   def resend_instructions
     @resource = Jobseeker.find(session[:jobseeker_id])
     @resource.send_confirmation_instructions
+    flash[:success] = t("jobseekers.registrations.check_your_email.resent_email_confirmation")
     render :check_your_email
   end
 

--- a/app/helpers/notify_views_helper.rb
+++ b/app/helpers/notify_views_helper.rb
@@ -12,9 +12,9 @@ module NotifyViewsHelper
     notify_link(url)
   end
 
-  def email_confirmation_link(token, confirmation_type)
+  def email_confirmation_url(token)
     url = jobseeker_confirmation_url(confirmation_token: token, **utm_params)
-    notify_link(url, t("#{confirmation_type}.link"))
+    notify_link(url)
   end
 
   def expired_vacancy_feedback_link(vacancy)

--- a/app/mailers/jobseekers/devise_emails.rb
+++ b/app/mailers/jobseekers/devise_emails.rb
@@ -2,7 +2,7 @@ module Jobseekers::DeviseEmails
   def confirmation_instructions(record, token, _opts = {})
     to = subject = nil
 
-    if !record.confirmed? && record.confirmation_sent_at < 4.days.ago
+    if !record.confirmed? && record.confirmation_sent_at < 12.hours.ago
       to = record.unconfirmed_email
       subject = t(".reminder.subject")
       @confirmation_type = ".reminder"

--- a/app/views/jobseekers/account_mailer/confirmation_instructions.text.erb
+++ b/app/views/jobseekers/account_mailer/confirmation_instructions.text.erb
@@ -1,6 +1,6 @@
 <%= t(".body") %>
 
-<%= email_confirmation_link(@token, @confirmation_type) %>
+<%= email_confirmation_url(@token) %>
 
 ---
 

--- a/app/views/jobseekers/account_mailer/confirmation_instructions.text.erb
+++ b/app/views/jobseekers/account_mailer/confirmation_instructions.text.erb
@@ -1,8 +1,4 @@
-# <%= t("#{@confirmation_type}.heading") %>
-
-<%= t("#{@confirmation_type}.intro") %>
-
-# <%= t(".what_to_do") %>
+<%= t(".body") %>
 
 <%= email_confirmation_link(@token, @confirmation_type) %>
 

--- a/app/views/jobseekers/accounts/confirmation.html.slim
+++ b/app/views/jobseekers/accounts/confirmation.html.slim
@@ -2,12 +2,11 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = govuk_panel title_text: t(".page_title")
+    h2.govuk-heading-l = t(".page_title")
 
     p.govuk-body
-      = t(".apply_for_jobs", link_text: govuk_link_to(t(".apply_for_jobs_link_text"), jobs_path)).html_safe
+      = t(".apply_for_jobs", apply_for_jobs_link_text: govuk_link_to(t(".apply_for_jobs_link_text"), jobs_path), create_a_profile_link_text: govuk_link_to(t(".create_a_profile_link_text"), jobseekers_profile_path)).html_safe
 
-    h2.govuk-heading-m = t(".create_profile.heading")
     p.govuk-body = t(".create_profile.lead_in")
     ul.govuk-list.govuk-list--bullet
       li = t(".create_profile.share_your_qualifications")

--- a/app/views/layouts/_flash_messages.html.slim
+++ b/app/views/layouts/_flash_messages.html.slim
@@ -1,7 +1,8 @@
 - flash.each do |variant, message|
   - next unless variant.in? t("banners").keys.map(&:to_s)
-  = govuk_notification_banner title_text: t("banners.#{variant}"), classes: "govuk-notification-banner--#{variant} govuk-!-margin-top-3 govuk-!-margin-bottom-0" do |notification_banner|
-    - if message == t("devise.failure.unconfirmed")
+  - if message == t("devise.failure.unconfirmed")
+    = govuk_notification_banner title_text: t("banners.important"), classes: "govuk-notification-banner--#{variant} govuk-!-margin-top-3 govuk-!-margin-bottom-0" do |notification_banner|
       - notification_banner.with_heading(text: t("devise.failure.unconfirmed"), link_text: t("devise.failure.unconfirmed_link_text"), link_href: jobseekers_resend_instructions_url)
-    - else
+  - else
+    = govuk_notification_banner title_text: t("banners.#{variant}"), classes: "govuk-notification-banner--#{variant} govuk-!-margin-top-3 govuk-!-margin-bottom-0" do |notification_banner|
       - notification_banner.with_heading(text: message)

--- a/app/views/layouts/_flash_messages.html.slim
+++ b/app/views/layouts/_flash_messages.html.slim
@@ -3,6 +3,5 @@
   = govuk_notification_banner title_text: t("banners.#{variant}"), classes: "govuk-notification-banner--#{variant} govuk-!-margin-top-3 govuk-!-margin-bottom-0" do |notification_banner|
     - if message == t("devise.failure.unconfirmed")
       - notification_banner.with_heading(text: t("devise.failure.unconfirmed"), link_text: "resend the email", link_href: jobseekers_resend_instructions_url)
-    - else 
+    - else
       - notification_banner.with_heading(text: message)
-

--- a/app/views/layouts/_flash_messages.html.slim
+++ b/app/views/layouts/_flash_messages.html.slim
@@ -2,6 +2,6 @@
   - next unless variant.in? t("banners").keys.map(&:to_s)
   = govuk_notification_banner title_text: t("banners.#{variant}"), classes: "govuk-notification-banner--#{variant} govuk-!-margin-top-3 govuk-!-margin-bottom-0" do |notification_banner|
     - if message == t("devise.failure.unconfirmed")
-      - notification_banner.with_heading(text: t("devise.failure.unconfirmed"), link_text: "resend the email", link_href: jobseekers_resend_instructions_url)
+      - notification_banner.with_heading(text: t("devise.failure.unconfirmed"), link_text: t("devise.failure.unconfirmed_link_text"), link_href: jobseekers_resend_instructions_url)
     - else
       - notification_banner.with_heading(text: message)

--- a/app/views/layouts/_flash_messages.html.slim
+++ b/app/views/layouts/_flash_messages.html.slim
@@ -1,4 +1,8 @@
 - flash.each do |variant, message|
   - next unless variant.in? t("banners").keys.map(&:to_s)
   = govuk_notification_banner title_text: t("banners.#{variant}"), classes: "govuk-notification-banner--#{variant} govuk-!-margin-top-3 govuk-!-margin-bottom-0" do |notification_banner|
-    - notification_banner.with_heading(text: message)
+    - if message == t("devise.failure.unconfirmed")
+      - notification_banner.with_heading(text: t("devise.failure.unconfirmed"), link_text: "resend the email", link_href: jobseekers_resend_instructions_url)
+    - else 
+      - notification_banner.with_heading(text: message)
+

--- a/app/views/layouts/_flash_messages.html.slim
+++ b/app/views/layouts/_flash_messages.html.slim
@@ -2,7 +2,8 @@
   - next unless variant.in? t("banners").keys.map(&:to_s)
   - if message == t("devise.failure.unconfirmed")
     = govuk_notification_banner title_text: t("banners.important"), classes: "govuk-notification-banner--#{variant} govuk-!-margin-top-3 govuk-!-margin-bottom-0" do |notification_banner|
-      - notification_banner.with_heading(text: t("devise.failure.unconfirmed"), link_text: t("devise.failure.unconfirmed_link_text"), link_href: jobseekers_resend_instructions_url)
+      - notification_banner.with_heading(text: t("devise.failure.unconfirmed"))
+      p = t("devise.failure.unconfirmed_body", link: govuk_link_to(t("devise.failure.unconfirmed_link_text"), jobseekers_resend_instructions_path)).html_safe
   - else
     = govuk_notification_banner title_text: t("banners.#{variant}"), classes: "govuk-notification-banner--#{variant} govuk-!-margin-top-3 govuk-!-margin-bottom-0" do |notification_banner|
       - notification_banner.with_heading(text: message)

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -150,7 +150,7 @@ Devise.setup do |config|
   # their account can't be confirmed with the token any more.
   # Default is nil, meaning there is no restriction on how long a user can take
   # before confirming their account.
-  config.confirm_within = 5.minutes
+  config.confirm_within = 24.hours
 
   # If true, requires any email changes to be confirmed (exactly the same way as
   # initial account confirmation) to be applied. Requires additional unconfirmed_email

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -150,7 +150,7 @@ Devise.setup do |config|
   # their account can't be confirmed with the token any more.
   # Default is nil, meaning there is no restriction on how long a user can take
   # before confirming their account.
-  config.confirm_within = 24.hours
+  config.confirm_within = 5.minutes
 
   # If true, requires any email changes to be confirmed (exactly the same way as
   # initial account confirmation) to be applied. Requires additional unconfirmed_email

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -150,7 +150,7 @@ Devise.setup do |config|
   # their account can't be confirmed with the token any more.
   # Default is nil, meaning there is no restriction on how long a user can take
   # before confirming their account.
-  config.confirm_within = 2.weeks
+  config.confirm_within = 24.hours
 
   # If true, requires any email changes to be confirmed (exactly the same way as
   # initial account confirmation) to be applied. Requires additional unconfirmed_email

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -18,6 +18,7 @@ en:
         You need to confirm your email address to sign in. You should have received a link by email.
 
         If the link has expired, you can
+      unconfirmed_link_text: resend the email
 
     omniauth_callbacks:
       failure: "Could not authenticate you from %{kind} because \"%{reason}\"."

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -16,8 +16,7 @@ en:
       unauthenticated: You need to sign in or create an account before continuing.
       unconfirmed: >-
         You need to confirm your email address to sign in. You should have received a link by email.
-
-        If the link has expired, you can
+      unconfirmed_body: If the link has expired you can %{link}
       unconfirmed_link_text: resend the email
 
     omniauth_callbacks:

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -14,10 +14,11 @@ en:
       not_found_in_database: We did not recognise your sign-in details.
       timeout: Your session expired. Please sign in again to continue.
       unauthenticated: You need to sign in or create an account before continuing.
-      unconfirmed: |
-        You cannot sign in because you have not yet confirmed your email address using the link in the email we sent you when you signed up for Teaching Vacancies.
+      unconfirmed: >-
+        You need to confirm your email address to sign in. You should have received a link by email.
 
-        If you signed up more than two weeks ago, or have lost the email, contact us using the 'Get help or report a problem' link on the bottom of this page.
+        If the link has expired, you can
+
     omniauth_callbacks:
       failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
       success: "Successfully authenticated from %{kind} account."

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -16,7 +16,7 @@ en:
       unauthenticated: You need to sign in or create an account before continuing.
       unconfirmed: >-
         You need to confirm your email address to sign in. You should have received a link by email.
-      unconfirmed_body: If the link has expired you can %{link}
+      unconfirmed_body: If the link has expired, you can %{link}
       unconfirmed_link_text: resend the email
 
     omniauth_callbacks:

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -63,7 +63,7 @@ en:
     reject: Reject
     reminder_continue: Continue to create a job
     request_dsi_account: Request a DfE Sign-in account
-    resend_email: Resend request
+    resend_email: Resend email
     return_to_profile: Return to profile
     return_to_profile: Return to profile
     save: Save

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -36,8 +36,8 @@ en:
       survey_text: Take our quick survey about your experience of using Teaching Vacancies
     confirmations:
       new:
-        description: The link has expired. You need to request that a new link is sent to your email address (%{email}).
-        title: Your request is no longer valid
+        description: We need to email another link to %{email} so you can activate your account.
+        title: Link has expired
       show:
         confirm: Confirm
         title: Confirm your email address

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -462,9 +462,9 @@ en:
         title: Reset your password
     registrations:
       check_your_email:
-        description: "Finish setting up your account by clicking the link in the email you've been sent."
+        description: "You should have received a link by email. Follow the link to confirm your email address. The link will expire in 24 hours"
         having_trouble_html: Still having trouble? %{mail_to} to our support team.
-        instructions_html: Check your spam folder if you cannot find the email, or %{resend_link}.
+        instructions_html: If it does not arrive in 5 minutes, check your junk folder or %{resend_link}.
         report_it: Report it
         request_support_link: Request support
         resend_summary: Need us to resend the email?

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -473,6 +473,7 @@ en:
         resend_link: resend the email
         restart_link: provide another email address
         title: Check your email
+        resent_email_confirmation: Email has been resent
       confirm_destroy:
         feedback_title: Tell us why you are closing your account
         page_title: Close account

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -15,13 +15,14 @@ en:
       confirmation:
         page_title: Account created
         apply_for_jobs_link_text: search and apply for teaching jobs
-        apply_for_jobs: You can %{link_text}.
+        apply_for_jobs: You can now %{apply_for_jobs_link_text} or %{create_a_profile_link_text}.
+        create_a_profile_link_text: create a profile
         create_profile:
           functionality_guidance: >-
             When you turn on your profile it will be only be visible to hiring staff in schools and trusts.
             They can get in touch by email to invite you apply for roles.
           heading: Create a profile
-          lead_in: "With a profile, you can:"
+          lead_in: "A profile will let you:"
           prefill: apply for roles more quickly by pre-filling your information
           share_your_qualifications: share your qualifications and experience with schools
           specify_jobs: specify the types of teaching jobs you’re looking for
@@ -462,7 +463,7 @@ en:
         title: Reset your password
     registrations:
       check_your_email:
-        description: "You should have received a link by email. Follow the link to confirm your email address. The link will expire in 24 hours"
+        description: You should have received a link by email. Follow the link to confirm your email address. The link will expire in 24 hours.
         having_trouble_html: Still having trouble? %{mail_to} to our support team.
         instructions_html: If it does not arrive in 5 minutes, check your junk folder or %{resend_link}.
         report_it: Report it

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -18,6 +18,7 @@ en:
         delete: If you want us to delete your data, please email %{mail_to}
         subject: Your Teaching Vacancies account has been closed
       confirmation_instructions:
+        body: "Confirm that you want to create a Teaching Vacancies account:"
         heading: Verify your email to create an account with Teaching Vacancies
         intro: You have requested to create an account with this email address.
         link: Verify email and create account

--- a/spec/mailers/jobseekers/account_mailer_spec.rb
+++ b/spec/mailers/jobseekers/account_mailer_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Jobseekers::AccountMailer do
       it "sends confirmation_instructions email" do
         expect(mail.subject).to eq(I18n.t("jobseekers.account_mailer.confirmation_instructions.reconfirmation.subject"))
         expect(mail.to).to eq(["unconfirmed@example.net"])
-        expect(mail.body.encoded).to include(I18n.t("jobseekers.account_mailer.confirmation_instructions.reconfirmation.heading"))
+        expect(mail.body.encoded).to include(I18n.t("jobseekers.account_mailer.confirmation_instructions.body"))
                                  .and include(jobseeker_confirmation_path(confirmation_token: token))
       end
 
@@ -52,7 +52,7 @@ RSpec.describe Jobseekers::AccountMailer do
       it "sends a `jobseeker_confirmation_instructions` email" do
         expect(mail.subject).to eq(I18n.t("jobseekers.account_mailer.confirmation_instructions.subject"))
         expect(mail.to).to eq(["test@example.net"])
-        expect(mail.body.encoded).to include(I18n.t("jobseekers.account_mailer.confirmation_instructions.heading"))
+        expect(mail.body.encoded).to include(I18n.t("jobseekers.account_mailer.confirmation_instructions.body"))
                                  .and include(jobseeker_confirmation_path(confirmation_token: token))
       end
 
@@ -62,12 +62,12 @@ RSpec.describe Jobseekers::AccountMailer do
     end
 
     context "when the jobseeker is being reminded to confirm" do
-      let(:jobseeker) { create(:jobseeker, email: "test@example.net", confirmation_token: token, unconfirmed_email: "test@example.net", confirmed_at: nil, confirmation_sent_at: 5.days.ago) }
+      let(:jobseeker) { create(:jobseeker, email: "test@example.net", confirmation_token: token, unconfirmed_email: "test@example.net", confirmed_at: nil, confirmation_sent_at: 18.hours.ago) }
 
       it "sends a `jobseeker_confirmation_instructions` email" do
         expect(mail.subject).to eq(I18n.t("jobseekers.account_mailer.confirmation_instructions.reminder.subject"))
         expect(mail.to).to eq(["test@example.net"])
-        expect(mail.body.encoded).to include(I18n.t("jobseekers.account_mailer.confirmation_instructions.reminder.heading"))
+        expect(mail.body.encoded).to include(I18n.t("jobseekers.account_mailer.confirmation_instructions.body"))
                                  .and include(jobseeker_confirmation_path(confirmation_token: token))
       end
 

--- a/spec/support/jobseeker_helpers.rb
+++ b/spec/support/jobseeker_helpers.rb
@@ -1,12 +1,6 @@
 module JobseekerHelpers
-  def resend_confirmation_email
-    confirm_email_address
-    click_on I18n.t("buttons.resend_email")
-  end
-
   def confirm_email_address
     visit first_link_from_last_mail
-    click_on "Confirm"
   end
 
   def sign_up_jobseeker(email: jobseeker.email, password: jobseeker.password)

--- a/spec/system/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
+++ b/spec/system/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
@@ -68,28 +68,6 @@ RSpec.describe "Jobseekers can create a job alert from a search", recaptcha: tru
         end
       end
     end
-
-    context "when jobseeker does not have an account" do
-      scenario "renders a create an account prompt form that redirects to job alerts dashboard" do
-        within "div[data-account-prompt='sign-up']" do
-          expect(page).to have_content(I18n.t("subscriptions.jobseeker_account_prompt.heading.sign_up"))
-          fill_in "Password", with: jobseeker.password
-          click_on I18n.t("buttons.create_account")
-        end
-        confirm_email_address
-        expect(current_path).to eq(jobseekers_subscriptions_path)
-      end
-
-      scenario "renders a create an account prompt form that redirects to sign up page on error then redirects to job alerts dashboard" do
-        within "div[data-account-prompt='sign-up']" do
-          expect(page).to have_content(I18n.t("subscriptions.jobseeker_account_prompt.heading.sign_up"))
-          click_on I18n.t("buttons.create_account")
-        end
-        sign_up_jobseeker
-        confirm_email_address
-        expect(current_path).to eq(jobseekers_subscriptions_path)
-      end
-    end
   end
 
   describe "location search" do

--- a/spec/system/jobseekers_can_manage_their_job_alerts_from_the_email_spec.rb
+++ b/spec/system/jobseekers_can_manage_their_job_alerts_from_the_email_spec.rb
@@ -58,28 +58,6 @@ RSpec.describe "Jobseekers can manage their job alerts from the email" do
           end
         end
       end
-
-      context "when jobseeker does not have an account" do
-        it "renders a create an account prompt form that redirects to job alerts dashboard" do
-          within "div[data-account-prompt='sign-up']" do
-            expect(page).to have_content(I18n.t("subscriptions.jobseeker_account_prompt.heading.sign_up"))
-            fill_in "Password", with: jobseeker.password
-            click_on I18n.t("buttons.create_account")
-          end
-          confirm_email_address
-          expect(current_path).to eq(jobseekers_subscriptions_path)
-        end
-
-        it "renders a create an account prompt form that redirects to sign up page on error then redirects to job alerts dashboard" do
-          within "div[data-account-prompt='sign-up']" do
-            expect(page).to have_content(I18n.t("subscriptions.jobseeker_account_prompt.heading.sign_up"))
-            click_on I18n.t("buttons.create_account")
-          end
-          sign_up_jobseeker
-          confirm_email_address
-          expect(current_path).to eq(jobseekers_subscriptions_path)
-        end
-      end
     end
 
     it "shows the page title" do

--- a/spec/system/jobseekers_can_save_a_job_spec.rb
+++ b/spec/system/jobseekers_can_save_a_job_spec.rb
@@ -49,18 +49,6 @@ RSpec.describe "Jobseekers can save a job" do
     end
   end
 
-  context "when a jobseeker does not have an account" do
-    let(:jobseeker) { build(:jobseeker) }
-
-    it "saves the job after signing up" do
-      save_job
-      click_on I18n.t("jobseekers.sessions.new.no_account.link")
-      sign_up_jobseeker
-      confirm_email_address
-      and_the_job_is_saved
-    end
-  end
-
   def save_job
     visit job_path(vacancy)
     click_on I18n.t("jobseekers.saved_jobs.save")

--- a/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe "Jobseekers can sign up to an account" do
       expect(page).to have_content I18n.t("jobseekers.registrations.check_your_email.title")
 
       click_on I18n.t("jobseekers.registrations.check_your_email.resend_link")
+      expect(page).to have_content I18n.t("jobseekers.registrations.check_your_email.resent_email_confirmation")
+
       visit first_link_from_last_mail
       click_on "Confirm"
 

--- a/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
@@ -58,7 +58,8 @@ RSpec.describe "Jobseekers can sign up to an account" do
         within(".govuk-header__navigation") { click_on I18n.t("buttons.sign_in") }
         click_on I18n.t("buttons.sign_in_jobseeker")
         sign_in_jobseeker
-        expect(page).to have_content "You need to confirm your email address to sign in. You should have received a link by email. If the link has expired, you can resend the email"
+        expect(page).to have_content "You need to confirm your email address to sign in. You should have received a link by email."
+        expect(page).to have_content "If the link has expired, you can resend the email"
         click_link "resend the email"
         expect(page).to have_content "Email has been resent"
         confirm_email_address

--- a/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
@@ -55,10 +55,12 @@ RSpec.describe "Jobseekers can sign up to an account" do
 
     context "when the user attempts to sign in without confirming their email" do
       it "does not allow user to sign in and shows the relevant error message" do
-        login_as(jobseeker, scope: :jobseeker)
+        within(".govuk-header__navigation") { click_on I18n.t("buttons.sign_in") }
+        click_on I18n.t("buttons.sign_in_jobseeker")
+        sign_in_jobseeker
         expect(page).to have_content "You need to confirm your email address to sign in. You should have received a link by email. If the link has expired, you can resend the email"
         click_link "resend the email"
-        expect(current_path).to eq(jobseekers_check_your_email_path)
+        expect(page).to have_content "Email has been resent"
         confirm_email_address
         expect(current_path).to eq(confirmation_jobseekers_account_path)
       end

--- a/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
@@ -86,8 +86,8 @@ RSpec.describe "Jobseekers can sign up to an account" do
 
         context "when the confirmation email is resent" do
           it "resends confirmation email and redirects to check your email page" do
-            expect { confirm_email_address }.to change { delivered_emails.count }.by(1)
-            expect(current_path).to eq(jobseekers_check_your_email_path)
+            expect { click_on "resend the email" }.to change { delivered_emails.count }.by(1)
+            expect(page).to have_content "Email has been resent"
           end
         end
       end

--- a/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Jobseekers can sign up to an account" do
 
       click_on I18n.t("jobseekers.registrations.check_your_email.resend_link")
       expect(page).to have_content I18n.t("jobseekers.registrations.check_your_email.resent_email_confirmation")
- 
+
       visit first_link_from_last_mail
 
       expect(current_path).to eq(confirmation_jobseekers_account_path)
@@ -75,8 +75,8 @@ RSpec.describe "Jobseekers can sign up to an account" do
             confirm_email_address
           end
 
-          it 'informs user that the link has expired and allows them to resend email and confirm their email' do
-            expect(page).to have_content('Link has expired')
+          it "informs user that the link has expired and allows them to resend email and confirm their email" do
+            expect(page).to have_content("Link has expired")
             expect { click_on "Resend email" }.to change { delivered_emails.count }.by(1)
             expect(current_path).to eq(jobseekers_check_your_email_path)
             confirm_email_address

--- a/spec/system/jobseekers_can_start_a_job_application_spec.rb
+++ b/spec/system/jobseekers_can_start_a_job_application_spec.rb
@@ -53,32 +53,6 @@ RSpec.describe "Jobseekers can start or continue a job application" do
         end
       end
     end
-
-    context "when the jobseeker does not have an account" do
-      context "when clicking 'apply' on the job page" do
-        before do
-          visit job_path(vacancy)
-          within ".banner-buttons" do
-            click_on I18n.t("jobseekers.job_applications.banner_links.apply")
-          end
-        end
-
-        it "starts a job application after signing up" do
-          expect(current_path).not_to eq(new_jobseekers_job_job_application_path(vacancy.id))
-
-          click_on I18n.t("jobseekers.sessions.new.no_account.link")
-          sign_up_jobseeker
-          confirm_email_address
-
-          expect(current_path).to eq(new_jobseekers_job_job_application_path(vacancy.id))
-          expect(page).to have_css(".govuk-caption-l", text: vacancy.job_title)
-
-          expect { click_on I18n.t("buttons.start_application") }.to change { JobApplication.count }.by(1)
-
-          expect(current_path).to eq(jobseekers_job_application_build_path(created_job_application, :personal_details))
-        end
-      end
-    end
   end
 
   context "when the jobseeker has a draft application for the job" do

--- a/spec/system/jobseekers_can_unlock_their_account_spec.rb
+++ b/spec/system/jobseekers_can_unlock_their_account_spec.rb
@@ -47,6 +47,8 @@ RSpec.describe "Jobseekers can unlock their account" do
 
         confirm_email_address
 
+        click_button "Confirm"
+
         expect(jobseeker.reload).not_to be_access_locked
 
         expect(current_path).to eq(jobseeker_session_path)


### PR DESCRIPTION
https://trello.com/c/4wOtzUFz/378-functionality-to-re-send-verification-link-for-jobseeker-users

## Changes in this PR:

This PR changes the flow when users confirm their account after signing up.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
