### PR TITLE
Fix a bug which occurs when we filter by both school types and includ…

### DIFF
--- a/app/queries/vacancy_filter_query.rb
+++ b/app/queries/vacancy_filter_query.rb
@@ -54,13 +54,15 @@ class VacancyFilterQuery < ApplicationQuery
     school_types = filters[:school_types]
     return built_scope unless school_types.present?
 
+    built_scope = built_scope.joins(organisation_vacancies: :organisation)
+
     if school_types.include?("faith_school") && school_types.include?("special_school")
-      built_scope.joins(organisation_vacancies: :organisation).where.not("organisations.gias_data ->> 'ReligiousCharacter (name)' IN (?)", Organisation::NON_FAITH_RELIGIOUS_CHARACTER_TYPES)
-                                                              .or(built_scope.where("organisations.detailed_school_type IN (?)", Organisation::SPECIAL_SCHOOL_TYPES)).distinct
+      built_scope.where.not("organisations.gias_data ->> 'ReligiousCharacter (name)' IN (?)", Organisation::NON_FAITH_RELIGIOUS_CHARACTER_TYPES)
+                 .or(built_scope.where("organisations.detailed_school_type IN (?)", Organisation::SPECIAL_SCHOOL_TYPES)).distinct
     elsif school_types.include?("faith_school")
-      built_scope.joins(organisation_vacancies: :organisation).where.not("organisations.gias_data ->> 'ReligiousCharacter (name)' IN (?)", Organisation::NON_FAITH_RELIGIOUS_CHARACTER_TYPES).distinct
+      built_scope.where.not("organisations.gias_data ->> 'ReligiousCharacter (name)' IN (?)", Organisation::NON_FAITH_RELIGIOUS_CHARACTER_TYPES).distinct
     elsif school_types.include?("special_school")
-      built_scope.joins(organisation_vacancies: :organisation).where(organisations: { detailed_school_type: Organisation::SPECIAL_SCHOOL_TYPES }).distinct
+      built_scope.where(organisations: { detailed_school_type: Organisation::SPECIAL_SCHOOL_TYPES }).distinct
     else
       built_scope
     end


### PR DESCRIPTION
## Changes in this PR:

[This bug](https://teaching-vacancies.sentry.io/issues/4281634716/?project=6212514&referrer=slack&rule_id=10370581) occurs when a user has selected both options in the schools type filter and added a location. This PR fixes this issue by building a common scope with the relevant joins once and modifying it based on the conditionals in the `add_school_type_filters` method.

Note: I could replicate this issue locally, but could not replicate it in our feature tests.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
