### PR TITLE
Change support dashboard date filtering

### DIFF
--- a/app/controllers/support_users/feedbacks_controller.rb
+++ b/app/controllers/support_users/feedbacks_controller.rb
@@ -29,7 +29,7 @@ class SupportUsers::FeedbacksController < SupportUsers::BaseController
   end
 
   def recategorize
-    params.fetch(:feedbacks).each do |feedback_params|
+    params.fetch(:feedbacks, []).each do |feedback_params|
       next if (category = feedback_params[:category]).blank?
 
       Feedback

--- a/app/models/feedback_reporting_period.rb
+++ b/app/models/feedback_reporting_period.rb
@@ -4,23 +4,17 @@ class FeedbackReportingPeriod
   def self.for(dateish)
     date = parse_date(dateish)
 
-    date = date.prev_day until date.tuesday?
-
-    new(
-      from: date,
-      to: date + 6.days,
-    )
+    new(from: date.at_beginning_of_month, to: date.at_end_of_month)
   end
 
   def self.all
     first_feedback = Feedback.order(:created_at).first
-
     return [] if first_feedback.nil?
 
     first_period = self.for(first_feedback.created_at)
 
-    first_period.from.step(Date.today, 7).map do |tuesday|
-      self.for(tuesday)
+    first_period.from.step(Date.today.at_end_of_month, 31).map do |begining_of_month|
+      self.for(begining_of_month)
     end
   end
 

--- a/app/views/support_users/feedbacks/_reporting_period_control.html.slim
+++ b/app/views/support_users/feedbacks/_reporting_period_control.html.slim
@@ -1,3 +1,20 @@
-= form_tag url_for, method: "get" do
-  = select_tag :reporting_period, options_for_select(FeedbackReportingPeriod.all.reverse.map { |rp| [rp.to_s, rp.from.strftime("%F")] }, params[:reporting_period]), class: "govuk-select govuk-!-margin-right-2"
-  button.govuk-button.govuk-button--secondary = "Go"
+.govuk-form-group
+  = form_tag url_for, method: "get" do
+    fieldset class="govuk-fieldset govuk-!-margin-bottom-0"
+      div class="govuk-form-group govuk-!-display-inline-block govuk-!-margin-right-2"
+        label class="govuk-label" for="reporting-period-from" From
+        = date_field(:reporting_period,
+                     :from,
+                     max: Date.today,
+                     class: "govuk-input govuk-input--width-10",
+                     id: "reporting-period-from",
+                     value: @reporting_period.from)
+      div class="govuk-form-group govuk-!-display-inline-block"
+        label class="govuk-label" for="reporting-period-to" To
+        = date_field(:reporting_period,
+                     :to,
+                     max: Date.today,
+                     class: "govuk-input govuk-input--width-10",
+                     id: "reporting-period-to",
+                     value: @reporting_period.to)
+    button class="govuk-button govuk-button--secondary" = "Go"

--- a/app/views/support_users/feedbacks/_tables.html.slim
+++ b/app/views/support_users/feedbacks/_tables.html.slim
@@ -1,6 +1,7 @@
 = form_tag support_users_feedback_recategorize_path
   = hidden_field_tag :tab, params[:action]
-  = hidden_field_tag :reporting_period, params[:reporting_period]
+  = hidden_field_tag :reporting_period_from, @reporting_period.from
+  = hidden_field_tag :reporting_period_to, @reporting_period.to
 
   button.govuk-button.govuk-button--secondary = "Save changes"
 

--- a/app/views/support_users/feedbacks/_tabs.html.slim
+++ b/app/views/support_users/feedbacks/_tabs.html.slim
@@ -1,10 +1,11 @@
 h1.govuk-heading-xl = "User Feedback"
 
+- reporting_period_params = { reporting_period: { from: @reporting_period.from, to: @reporting_period.to } }
 .govuk-tabs
   ul.govuk-tabs__list
     li class="govuk-tabs__list-item #{"govuk-tabs__list-item--selected" if current_page?(support_users_feedback_general_path)}"
-      = link_to_unless_current("General", support_users_feedback_general_path(reporting_period: params[:reporting_period]), class: "govuk-tabs__tab")
+      = link_to_unless_current("General", support_users_feedback_general_path(reporting_period_params), class: "govuk-tabs__tab")
     li class="govuk-tabs__list-item #{"govuk-tabs__list-item--selected" if current_page?(support_users_feedback_job_alerts_path)}"
-      = link_to_unless_current("Job alerts", support_users_feedback_job_alerts_path(reporting_period: params[:reporting_period]), class: "govuk-tabs__tab")
+      = link_to_unless_current("Job alerts", support_users_feedback_job_alerts_path(reporting_period_params), class: "govuk-tabs__tab")
     li class="govuk-tabs__list-item #{"govuk-tabs__list-item--selected" if current_page?(support_users_feedback_satisfaction_ratings_path)}"
-      = link_to_unless_current("Satisfaction ratings", support_users_feedback_satisfaction_ratings_path(reporting_period: params[:reporting_period]), class: "govuk-tabs__tab")
+      = link_to_unless_current("Satisfaction ratings", support_users_feedback_satisfaction_ratings_path(reporting_period_params), class: "govuk-tabs__tab")

--- a/spec/models/feedback_reporting_period_spec.rb
+++ b/spec/models/feedback_reporting_period_spec.rb
@@ -1,18 +1,18 @@
 require "rails_helper"
 
 RSpec.describe FeedbackReportingPeriod do
-  let!(:oldest_feedback) { create(:feedback, created_at: "2022-01-09") } # Sunday
-  let!(:newest_feedback) { create(:feedback, created_at: "2022-03-23") } # Wednesday
+  let!(:oldest_feedback) { create(:feedback, created_at: "2022-01-09") }
+  let!(:newest_feedback) { create(:feedback, created_at: "2022-03-23") }
 
   describe ".all" do
     subject(:all_periods) { described_class.all }
 
-    it "returns inclusive two-week periods from the oldest to the newest feedback, starting on Tuesdays and ending on Mondays" do
-      expect(all_periods.first)
-        .to eq(described_class.new(from: "2022-01-04", to: "2022-01-10"))
-
-      expect(all_periods.last).to eq(described_class.for(Date.today))
-      expect(all_periods.count).to eq(((all_periods.first.from...all_periods.last.from).count / 7) + 1)
+    it "returns inclusive one per month periods from the oldest feedback to the current month" do
+      travel_to(Time.zone.local(2022, 6, 10, 10, 4, 3)) do
+        expect(all_periods.first).to eq(described_class.new(from: "2022-01-01", to: "2022-01-31"))
+        expect(all_periods.last).to eq(described_class.new(from: "2022-06-01", to: "2022-06-30"))
+        expect(all_periods.count).to eq(6)
+      end
     end
 
     context "when there is no feedback" do
@@ -33,23 +33,23 @@ RSpec.describe FeedbackReportingPeriod do
   end
 
   describe ".for(date)" do
-    it "returns a two-week Tueday-starting range that includes the given date" do
-      expect(described_class.for("2022-01-09"))
-        .to eq(described_class.new(from: "2022-01-04", to: "2022-01-10"))
+    it "returns the calendar month date range that includes the given date" do
+      expect(described_class.for("2022-02-09"))
+        .to eq(described_class.new(from: "2022-02-01", to: "2022-02-28"))
     end
 
     it "accepts a date, a datetime, a time or a string for its values" do
       expect(described_class.for("2022-01-09"))
-        .to eq(described_class.new(from: "2022-01-04", to: "2022-01-10"))
+        .to eq(described_class.new(from: "2022-01-01", to: "2022-01-31"))
 
       expect(described_class.for(Date.new(2022, 1, 9)))
-        .to eq(described_class.new(from: "2022-01-04", to: "2022-01-10"))
+        .to eq(described_class.new(from: "2022-01-01", to: "2022-01-31"))
 
       expect(described_class.for(DateTime.new(2022, 1, 9, 10, 3)))
-        .to eq(described_class.new(from: "2022-01-04", to: "2022-01-10"))
+        .to eq(described_class.new(from: "2022-01-01", to: "2022-01-31"))
 
       expect(described_class.for(Time.new(2022, 1, 9, 10, 3)))
-        .to eq(described_class.new(from: "2022-01-04", to: "2022-01-10"))
+        .to eq(described_class.new(from: "2022-01-01", to: "2022-01-31"))
     end
   end
 

--- a/spec/system/support_users/feedback_spec.rb
+++ b/spec/system/support_users/feedback_spec.rb
@@ -254,9 +254,12 @@ RSpec.describe "Feedback supportal section" do
       expect(page).not_to have_text(old_other_feedback.comment)
       expect(page).not_to have_text(older_other_feedback.comment)
 
-      select "2022-03-15 -> 2022-03-21", from: "reporting_period"
+      fill_in "From", with: "2022-03-15"
+      fill_in "To", with: "2022-03-21"
       click_on "Go"
 
+      expect(page).to have_field("From", with: "2022-03-15")
+      expect(page).to have_field("To", with: "2022-03-21")
       expect(page).not_to have_text(other_feedback.comment)
       expect(page).to have_text(old_other_feedback.comment)
       expect(page).not_to have_text(older_other_feedback.comment)
@@ -267,15 +270,20 @@ RSpec.describe "Feedback supportal section" do
       expect(page).to have_text(old_job_alert_feedback.comment)
       expect(page).not_to have_text(older_job_alert_feedback.comment)
 
-      select "2022-01-04 -> 2022-01-10", from: "reporting_period"
+      fill_in "From", with: "2022-01-04"
+      fill_in "To", with: "2022-01-10"
       click_on "Go"
 
+      expect(page).to have_field("From", with: "2022-01-04")
+      expect(page).to have_field("To", with: "2022-01-10")
       expect(page).not_to have_text(job_alert_feedback.comment)
       expect(page).not_to have_text(old_job_alert_feedback.comment)
       expect(page).to have_text(older_job_alert_feedback.comment)
 
       click_on "General"
 
+      expect(page).to have_field("From", with: "2022-01-04")
+      expect(page).to have_field("To", with: "2022-01-10")
       expect(page).not_to have_text(other_feedback.comment)
       expect(page).not_to have_text(old_other_feedback.comment)
       expect(page).to have_text(older_other_feedback.comment)

--- a/spec/system/support_users/feedback_spec.rb
+++ b/spec/system/support_users/feedback_spec.rb
@@ -22,7 +22,7 @@ RSpec.shared_examples "has a satisfaction rating table" do |data_testid, number_
   end
 
   def testid_for(time)
-    [time.to_date.beginning_of_week(:tuesday), time.to_date.end_of_week(:tuesday)].map(&:to_s).join(" -> ")
+    [time.to_date.beginning_of_month, time.to_date.end_of_month].map(&:to_s).join(" -> ")
   end
 end
 


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/NO7V3wZC

## Changes in this PR:

There are two main changes on the support user's dashboards:
- For General and Job alerts tabs, changes the date selection from a predefined selector by week to a free start and end date selection. It defaults to filtering from the start of the current month until the current day.
- For Satisfaction ratings, change the reporting period groupings from biweekly (starting on Tuesdays) to calendar months.

## Screenshots of UI changes:

### Before
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/359e83f1-ab1b-4133-be3e-7a6f4b05fd9a)

![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/00abfe2e-6cb1-4ec6-9a88-b407a39777ca)

![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/aa7fdbf8-c1f2-4e86-8236-ca39c1711269)

### After
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/68a6fbec-1690-490e-923b-fb0301bf8e31)

![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/5c1a5086-70fe-41e9-9279-1a77d45988ce)

![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/0bc423cd-cece-44dd-9737-6010b048b3b0)
