### PR TITLE
Explicitly disable Sign-in fallback in test env

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,4 @@
+AUTHENTICATION_FALLBACK=false
 DFE_SIGN_IN_PUBLISHER_ROLE_ID=test-publisher-role-id
 DFE_SIGN_IN_PASSWORD=test-password
 DFE_SIGN_IN_SERVICE_ID=test-service-id


### PR DESCRIPTION
When local developing with the DFE-Sign-in fall back enabled through the .env flag, the test environment inherits this value, and makes many local tests (depending on DFE-Sign-in to be enabled as in production) to fail when running locally.

Explicitly disabling this for testing environment avoids any issue.
