### PR TITLE
Fix error on support dashboard date navigation

### DIFF
--- a/app/controllers/support_users/feedbacks_controller.rb
+++ b/app/controllers/support_users/feedbacks_controller.rb
@@ -111,8 +111,8 @@ class SupportUsers::FeedbacksController < SupportUsers::BaseController
 
   def set_reporting_period
     @reporting_period = FeedbackReportingPeriod.new(
-      from: reporting_period_params&.fetch(:from) || Date.today.at_beginning_of_month,
-      to: reporting_period_params&.fetch(:to) || Date.today,
+      from: reporting_period_params&.fetch(:from).presence || Date.today.at_beginning_of_month,
+      to: reporting_period_params&.fetch(:to).presence || Date.today,
     )
   end
 


### PR DESCRIPTION
When the user clears the date from the calendar date picker in the support dashboard, if they click "Go", the system raises an exception when trying to parse an empty date.

To resolve it, we use the default dates if the date selection is submitted but contains an empty date.

