### PR TITLE
Add "Quick Apply" tags to vacancies displayed for JobSeekers.

### DIFF
--- a/app/views/organisations/_organisation.html.slim
+++ b/app/views/organisations/_organisation.html.slim
@@ -94,6 +94,7 @@
       - organisation.vacancies.live.each do |vacancy|
         h3.govuk-heading-s class="govuk-!-margin-bottom-0"
           = results_link(vacancy, class: "view-vacancy-link")
+          =< govuk_tag(text: t("vacancies.listing.enable_job_applications_tag"), colour: "green") if vacancy.enable_job_applications?
 
         = govuk_summary_list(classes: "govuk-summary-list--no-border") do |summary_list|
           - summary_list.row do |row|

--- a/app/views/organisations/_organisation.html.slim
+++ b/app/views/organisations/_organisation.html.slim
@@ -93,8 +93,8 @@
 
       - organisation.vacancies.live.each do |vacancy|
         h3.govuk-heading-s class="govuk-!-margin-bottom-0"
-          = results_link(vacancy, class: "view-vacancy-link")
-          =< govuk_tag(text: t("vacancies.listing.enable_job_applications_tag"), colour: "green") if vacancy.enable_job_applications?
+          span class="govuk-!-margin-right-2" = results_link(vacancy, class: "view-vacancy-link")
+          = govuk_tag(text: t("vacancies.listing.enable_job_applications_tag"), colour: "green") if vacancy.enable_job_applications?
 
         = govuk_summary_list(classes: "govuk-summary-list--no-border") do |summary_list|
           - summary_list.row do |row|

--- a/app/views/vacancies/listing/_banner.html.slim
+++ b/app/views/vacancies/listing/_banner.html.slim
@@ -6,6 +6,8 @@
     .header-with-logo-logo
       = image_tag(vacancy.organisation.logo, alt: t("publishers.organisations.organisation.logo.alt_text", organisation_name: vacancy.organisation.name))
   .header-with-logo-title
+    - if vacancy.enable_job_applications?
+      div class="govuk-!-margin-bottom-2" = govuk_tag(text: t("vacancies.listing.enable_job_applications_tag"), colour: "green")
     h1.govuk-heading-xl class="govuk-!-margin-bottom-2"
       = vacancy.job_title
     span.govuk-caption-l class="govuk-!-margin-top-0"

--- a/app/views/vacancies/listing/_similar_jobs.html.slim
+++ b/app/views/vacancies/listing/_similar_jobs.html.slim
@@ -5,6 +5,9 @@
       - similar_jobs.each do |vacancy|
         .similar-jobs__job class="govuk-grid-column-one-half"
           p.govuk-body class="govuk-!-margin-bottom-1" = similar_job_link(vacancy)
+          - if vacancy.enable_job_applications?
+            p.govuk-body class="govuk-!-margin-bottom-1"
+              = govuk_tag(text: t("vacancies.listing.enable_job_applications_tag"), colour: "green")
           p.govuk-body class="govuk-!-margin-bottom-0 govuk-!-font-weight-bold"
             = vacancy.organisation_name
           p.govuk-body class=" govuk-!-margin-bottom-0"

--- a/app/views/vacancies/search/_results.html.slim
+++ b/app/views/vacancies/search/_results.html.slim
@@ -7,8 +7,8 @@
             = image_tag(vacancy.organisation.logo, alt: t("publishers.organisations.organisation.logo.alt_text", organisation_name: vacancy.organisation.name))
         .header-with-logo-title
           h2.govuk-heading-m class="govuk-!-margin-bottom-0"
-            = results_link(vacancy, class: "view-vacancy-link")
-            =< govuk_tag(text: t("vacancies.listing.enable_job_applications_tag"), colour: "green") if vacancy.enable_job_applications?
+            span class="govuk-!-margin-right-2" = results_link(vacancy, class: "view-vacancy-link")
+            = govuk_tag(text: t("vacancies.listing.enable_job_applications_tag"), colour: "green") if vacancy.enable_job_applications?
           p.govuk-body.address class="govuk-!-margin-bottom-0"
             = vacancy_full_job_location(vacancy)
 

--- a/app/views/vacancies/search/_results.html.slim
+++ b/app/views/vacancies/search/_results.html.slim
@@ -8,6 +8,7 @@
         .header-with-logo-title
           h2.govuk-heading-m class="govuk-!-margin-bottom-0"
             = results_link(vacancy, class: "view-vacancy-link")
+            =< govuk_tag(text: t("vacancies.listing.enable_job_applications_tag"), colour: "green") if vacancy.enable_job_applications?
           p.govuk-body.address class="govuk-!-margin-bottom-0"
             = vacancy_full_job_location(vacancy)
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -575,6 +575,7 @@ en:
         link: help you understand your next steps
         text_html: If you're interested in teaching or training to teach in England as an international citizen, we can %{link}.
     listing:
+      enable_job_applications_tag: "Quick Apply"
       schools:
         address: Address
         age_range: Age range

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -5,15 +5,22 @@ FactoryBot.define do
       "PROGRESS LEADER (HEAD OF DEPARTMENT)",
       "Tutor of Music (Part time, permanent)",
       "Tutor of Maths MPS",
-      "Tutor of PE (male)", "Games Design Tutor", "Team Leader of Maths", "KEY STAGE 2 Tutor",
-      "Lead in Health and Social Care", "Director of Learning - Science"
+      "Tutor of PE (male)",
+      "Games Design Tutor",
+      "Team Leader of Maths",
+      "KEY STAGE 2 Tutor",
+      "Lead in Health and Social Care",
+      "Director of Learning - Science",
     ].freeze
 
     salaries = [
       "Main pay range 1 to Upper pay range 3, £23,719 to £39,406 per year (full time equivalent)",
-      "£6,084 to £6,084 per year (full time equivalent)", "Main pay range 2 to Upper pay range 3, £30,113 to £44,541",
-      "Main pay range 1 to Upper pay range 3, £30,480 to £49,571", "MPR / UPR",
-      "MPS/UPS", "£25,543 to £41,635 per year (full time equivalent)"
+      "£6,084 to £6,084 per year (full time equivalent)",
+      "Main pay range 2 to Upper pay range 3, £30,113 to £44,541",
+      "Main pay range 1 to Upper pay range 3, £30,480 to £49,571",
+      "MPR / UPR",
+      "MPS/UPS",
+      "£25,543 to £41,635 per year (full time equivalent)",
     ].freeze
 
     publisher
@@ -37,7 +44,7 @@ FactoryBot.define do
     expires_at { 6.months.from_now.change(hour: 9, minute: 0, second: 0) }
     hired_status { nil }
     include_additional_documents { false }
-    job_title { factory_sample(job_titles) }
+    sequence :job_title, job_titles.cycle
     listed_elsewhere { nil }
     job_role { factory_sample(Vacancy.job_roles.keys) }
     ect_status { factory_sample(Vacancy.ect_statuses.keys) if job_role == "teacher" }

--- a/spec/system/jobseekers_can_view_a_vacancy_spec.rb
+++ b/spec/system/jobseekers_can_view_a_vacancy_spec.rb
@@ -86,6 +86,18 @@ RSpec.describe "Viewing a single published vacancy" do
                                                            deadline: format_date(vacancy.expires_at, :date_only_shorthand)))
       end
     end
+
+    scenario "jobseeker sees a tag on jobs that allow to apply through Teaching Vacancies" do
+      visit job_path(vacancy)
+      expect(page).to have_css("strong.govuk-tag--green", text: I18n.t("vacancies.listing.enable_job_applications_tag"))
+    end
+
+    scenario "jobseeker does not see a tag on jobs that don't allow to apply through Teaching Vacancies" do
+      vacancy_without_apply = create(:vacancy, :published, :no_tv_applications, organisations: [school])
+
+      visit job_path(vacancy_without_apply)
+      expect(page).not_to have_css("strong.govuk-tag--green", text: I18n.t("vacancies.listing.enable_job_applications_tag"))
+    end
   end
 
   context "when the vacancy status is draft" do

--- a/spec/system/jobseekers_can_view_all_the_jobs_spec.rb
+++ b/spec/system/jobseekers_can_view_all_the_jobs_spec.rb
@@ -35,10 +35,10 @@ RSpec.describe "Jobseekers can view all the jobs" do
     visit jobs_path
 
     published_jobs.each do |job|
-      expect(page.find("h2 a", text: job.job_title))
+      expect(page.find("h2 span", text: job.job_title))
         .to have_sibling("strong.govuk-tag--green", text: I18n.t("vacancies.listing.enable_job_applications_tag"))
     end
-    expect(page.find("h2 a", text: job_without_apply.job_title))
+    expect(page.find("h2 span", text: job_without_apply.job_title))
       .not_to have_sibling("strong.govuk-tag--green", text: I18n.t("vacancies.listing.enable_job_applications_tag"))
   end
 

--- a/spec/system/jobseekers_can_view_all_the_jobs_spec.rb
+++ b/spec/system/jobseekers_can_view_all_the_jobs_spec.rb
@@ -30,6 +30,18 @@ RSpec.describe "Jobseekers can view all the jobs" do
     end
   end
 
+  it "jobseekers can distinguish between the listed jobs that allow to apply through Teaching Vacancies and the ones who don't" do
+    job_without_apply = create(:vacancy, :no_tv_applications, :past_publish, expires_at: 2.years.from_now, organisations: [school])
+    visit jobs_path
+
+    published_jobs.each do |job|
+      expect(page.find("h2 a", text: job.job_title))
+        .to have_sibling("strong.govuk-tag--green", text: I18n.t("vacancies.listing.enable_job_applications_tag"))
+    end
+    expect(page.find("h2 a", text: job_without_apply.job_title))
+      .not_to have_sibling("strong.govuk-tag--green", text: I18n.t("vacancies.listing.enable_job_applications_tag"))
+  end
+
   describe "pagination" do
     shared_examples "jobseekers can view jobs and navigate between pages" do
       scenario "jobseekers can view jobs and navigate between pages" do

--- a/spec/system/jobseekers_can_view_an_organisation_spec.rb
+++ b/spec/system/jobseekers_can_view_an_organisation_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe "Viewing an organisation" do
   end
 
   it "flags the jobs that allow applications through Teaching Vacancies" do
-    expect(page.find("h3 a", text: vacancy.job_title))
+    expect(page.find("h3 span", text: vacancy.job_title))
       .to have_sibling("strong.govuk-tag--green", text: I18n.t("vacancies.listing.enable_job_applications_tag"))
-    expect(page.find("h3 a", text: vacancy_without_apply.job_title))
+    expect(page.find("h3 span", text: vacancy_without_apply.job_title))
       .not_to have_sibling("strong.govuk-tag--green", text: I18n.t("vacancies.listing.enable_job_applications_tag"))
   end
 
@@ -82,9 +82,9 @@ RSpec.describe "Viewing an organisation" do
     end
 
     it "flags the jobs that allow applications through Teaching Vacancies" do
-      expect(page.find("h3 a", text: vacancy.job_title))
+      expect(page.find("h3 span", text: vacancy.job_title))
         .to have_sibling("strong.govuk-tag--green", text: I18n.t("vacancies.listing.enable_job_applications_tag"))
-      expect(page.find("h3 a", text: vacancy_without_apply.job_title))
+      expect(page.find("h3 span", text: vacancy_without_apply.job_title))
         .not_to have_sibling("strong.govuk-tag--green", text: I18n.t("vacancies.listing.enable_job_applications_tag"))
     end
 

--- a/spec/system/jobseekers_can_view_an_organisation_spec.rb
+++ b/spec/system/jobseekers_can_view_an_organisation_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe "Viewing an organisation" do
   let(:school_group) { create(:trust) }
   let(:organisation) { create(:school, school_groups: [school_group]) }
   let!(:vacancy) { create(:vacancy, organisations: [organisation]) }
+  let!(:vacancy_without_apply) { create(:vacancy, :no_tv_applications, organisations: [organisation]) }
 
   before do
     Organisation.subclasses.each do |klass|
@@ -27,6 +28,13 @@ RSpec.describe "Viewing an organisation" do
 
   it "has a list of live jobs at the organisation" do
     has_list_of_live_jobs?(organisation)
+  end
+
+  it "flags the jobs that allow applications through Teaching Vacancies" do
+    expect(page.find("h3 a", text: vacancy.job_title))
+      .to have_sibling("strong.govuk-tag--green", text: I18n.t("vacancies.listing.enable_job_applications_tag"))
+    expect(page.find("h3 a", text: vacancy_without_apply.job_title))
+      .not_to have_sibling("strong.govuk-tag--green", text: I18n.t("vacancies.listing.enable_job_applications_tag"))
   end
 
   it "has a map showing the organisation's location" do
@@ -71,6 +79,13 @@ RSpec.describe "Viewing an organisation" do
 
     it "has a list of live jobs at the organisation" do
       has_list_of_live_jobs?(organisation)
+    end
+
+    it "flags the jobs that allow applications through Teaching Vacancies" do
+      expect(page.find("h3 a", text: vacancy.job_title))
+        .to have_sibling("strong.govuk-tag--green", text: I18n.t("vacancies.listing.enable_job_applications_tag"))
+      expect(page.find("h3 a", text: vacancy_without_apply.job_title))
+        .not_to have_sibling("strong.govuk-tag--green", text: I18n.t("vacancies.listing.enable_job_applications_tag"))
     end
 
     it "has a map showing the organisation's location" do


### PR DESCRIPTION
## Trello card URL

- https://trello.com/c/rOnbCApS/394-add-a-quick-apply-banner

## Changes in this PR:
- Adds a `QUICK APPLY` tag on vacancy titles across multiple pages/listings for job seekers.
- Extra work: Tweaks vacancy fixture `job_name` to iterate over the list of possible names instead of using the same across multiple vacancies. This causes system specs to fail due to an `ambiguous match`.

## Screenshots of UI changes:

### Job list/Search results
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/892f7449-5b6d-40a2-b28b-4d8b121c5437)


### Vacancy page
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/75e90da9-d79b-42ca-857d-8ae8cd73ada1)

### Vacancy page. Similar Jobs list
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/ac6398fc-7aa6-471f-8872-94b3cb8d9a82)

### Organisation/School Current Vacancies list
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/035828d5-0eb3-44f6-933e-fc3b55ce766e)

