### PR TITLE
Add quick apply inset text to job alert emails

### DIFF
--- a/app/views/jobseekers/alert_mailer/alert.text.erb
+++ b/app/views/jobseekers/alert_mailer/alert.text.erb
@@ -1,7 +1,6 @@
 # <%= t(".summary.#{subscription.frequency}", count: @vacancies.count) %>
 
 ---
-
 <%- @vacancies.each do |vacancy| %>
   <%= show_link(vacancy) %>
   <%= vacancy_location_with_organisation_link(vacancy) %>
@@ -10,9 +9,7 @@
   <%= t(".working_pattern", working_pattern: VacancyPresenter.new(vacancy).readable_working_patterns_with_details) %>
   <%= t(".closing_date", closing_date: format_time_to_datetime_at(vacancy.expires_at)) %>
 
-  <% if vacancy.enable_job_applications? %>
-    ^ <%= t(".quick_apply") %>  
-  <% end %>
+  ^ <%= t(".quick_apply") if vacancy.enable_job_applications? %>
 
   ---
 <% end %>

--- a/app/views/jobseekers/alert_mailer/alert.text.erb
+++ b/app/views/jobseekers/alert_mailer/alert.text.erb
@@ -1,7 +1,7 @@
 # <%= t(".summary.#{subscription.frequency}", count: @vacancies.count) %>
 
 ---
-<%- @vacancies.each do |vacancy| %>
+<%- @vacancies.each_with_index do |vacancy, index| %>
   <%= show_link(vacancy) %>
   <%= vacancy_location_with_organisation_link(vacancy) %>
 
@@ -9,7 +9,7 @@
   <%= t(".working_pattern", working_pattern: VacancyPresenter.new(vacancy).readable_working_patterns_with_details) %>
   <%= t(".closing_date", closing_date: format_time_to_datetime_at(vacancy.expires_at)) %>
 
-  ^ <%= t(".quick_apply") if vacancy.enable_job_applications? %>
+   <%= '^ ' + t(".quick_apply") if vacancy.enable_job_applications? %>
 
   ---
 <% end %>

--- a/app/views/jobseekers/alert_mailer/alert.text.erb
+++ b/app/views/jobseekers/alert_mailer/alert.text.erb
@@ -10,6 +10,10 @@
   <%= t(".working_pattern", working_pattern: VacancyPresenter.new(vacancy).readable_working_patterns_with_details) %>
   <%= t(".closing_date", closing_date: format_time_to_datetime_at(vacancy.expires_at)) %>
 
+  <% if vacancy.enable_job_applications? %>
+    ^ <%= t(".quick_apply") %>  
+  <% end %>
+
   ---
 <% end %>
 

--- a/app/views/jobseekers/alert_mailer/alert.text.erb
+++ b/app/views/jobseekers/alert_mailer/alert.text.erb
@@ -9,7 +9,7 @@
   <%= t(".working_pattern", working_pattern: VacancyPresenter.new(vacancy).readable_working_patterns_with_details) %>
   <%= t(".closing_date", closing_date: format_time_to_datetime_at(vacancy.expires_at)) %>
 
-   <%= '^ ' + t(".quick_apply") if vacancy.enable_job_applications? %>
+  <%= '^ ' + t(".quick_apply") if vacancy.enable_job_applications? %>
 
   ---
 <% end %>

--- a/app/views/jobseekers/alert_mailer/alert.text.erb
+++ b/app/views/jobseekers/alert_mailer/alert.text.erb
@@ -1,7 +1,7 @@
 # <%= t(".summary.#{subscription.frequency}", count: @vacancies.count) %>
 
 ---
-<%- @vacancies.each_with_index do |vacancy, index| %>
+<%- @vacancies.each do |vacancy| %>
   <%= show_link(vacancy) %>
   <%= vacancy_location_with_organisation_link(vacancy) %>
 

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -103,6 +103,7 @@ en:
             one: A new job matching your search criteria was listed in the last week
             other: "%{count} new jobs matching your search criteria were listed in the last week"
         title: This job alert
+        quick_apply: You can use quick apply for this job which allows you to apply simply and quickly using your profile.
         unsubscribe: Don’t want to receive these email alerts? %{unsubscribe_link}
         unsubscribe_link_text: Unsubscribe here
         working_pattern: "Working pattern: %{working_pattern}"


### PR DESCRIPTION
https://trello.com/c/Do3p7IXC/424-add-a-quick-apply-blockquote-to-job-alert-email

## Changes in this PR:
Add an inset block with a message about quick apply to relevant vacancies in our job alert emails


## Screenshots of UI changes:

### Before
![Screenshot 2023-07-10 at 09 37 54](https://github.com/DFE-Digital/teaching-vacancies/assets/13124899/4c26e036-cfb5-45ec-84fc-96bf07f73950)

### After
![Screenshot 2023-07-10 at 09 37 29](https://github.com/DFE-Digital/teaching-vacancies/assets/13124899/9f3254be-2578-4509-9a5f-af90e09f1e13)

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
