### PR TITLE
Add origin URL to general feedback forms

### DIFF
--- a/app/controllers/general_feedbacks_controller.rb
+++ b/app/controllers/general_feedbacks_controller.rb
@@ -1,7 +1,7 @@
 class GeneralFeedbacksController < ApplicationController
   def new
-    @user_type = current_user&.class
-    @general_feedback_form = GeneralFeedbackForm.new
+    origin_path = URI.parse(request.referrer).path if request.referrer.present?
+    @general_feedback_form = GeneralFeedbackForm.new(user_type: current_user&.class, origin_path:)
   end
 
   def create
@@ -9,7 +9,6 @@ class GeneralFeedbacksController < ApplicationController
     @feedback = Feedback.new(feedback_attributes)
 
     if @general_feedback_form.invalid?
-      @user_type = current_user&.class
       render :new
     elsif recaptcha_is_invalid?
       redirect_to invalid_recaptcha_path(form_name: @general_feedback_form.class.name.underscore.humanize)
@@ -24,7 +23,16 @@ class GeneralFeedbacksController < ApplicationController
 
   def general_feedback_form_params
     params.require(:general_feedback_form)
-          .permit(:comment, :email, :report_a_problem, :user_participation_response, :visit_purpose, :rating, :visit_purpose_comment, :occupation, :user_type)
+          .permit(:comment,
+                  :email,
+                  :report_a_problem,
+                  :user_participation_response,
+                  :visit_purpose,
+                  :rating,
+                  :visit_purpose_comment,
+                  :occupation,
+                  :user_type,
+                  :origin_path)
   end
 
   def feedback_attributes

--- a/app/controllers/jobseekers/account_feedbacks_controller.rb
+++ b/app/controllers/jobseekers/account_feedbacks_controller.rb
@@ -1,14 +1,14 @@
 class Jobseekers::AccountFeedbacksController < Jobseekers::BaseController
   def new
-    @account_feedback_form = Jobseekers::AccountFeedbackForm.new(origin: params[:origin])
+    @account_feedback_form = Jobseekers::AccountFeedbackForm.new(origin_path: params[:origin])
   end
 
   def create
     @account_feedback_form = Jobseekers::AccountFeedbackForm.new(account_feedback_form_params)
 
     if @account_feedback_form.valid?
-      Feedback.create(feedback_attributes.except(:origin))
-      redirect_to @account_feedback_form.origin, success: t(".success")
+      Feedback.create(feedback_attributes)
+      redirect_to @account_feedback_form.origin_path, success: t(".success")
     else
       render :new
     end
@@ -17,7 +17,8 @@ class Jobseekers::AccountFeedbacksController < Jobseekers::BaseController
   private
 
   def account_feedback_form_params
-    params.require(:jobseekers_account_feedback_form).permit(:comment, :email, :origin, :rating, :report_a_problem, :user_participation_response, :occupation)
+    params.require(:jobseekers_account_feedback_form)
+          .permit(:comment, :email, :origin_path, :rating, :report_a_problem, :user_participation_response, :occupation)
   end
 
   def feedback_attributes

--- a/app/form_models/general_feedback_form.rb
+++ b/app/form_models/general_feedback_form.rb
@@ -1,5 +1,14 @@
 class GeneralFeedbackForm < BaseForm
-  attr_accessor :comment, :email, :report_a_problem, :user_participation_response, :visit_purpose, :visit_purpose_comment, :rating, :occupation, :user_type
+  attr_accessor :comment,
+                :email,
+                :report_a_problem,
+                :user_participation_response,
+                :visit_purpose,
+                :visit_purpose_comment,
+                :rating,
+                :occupation,
+                :user_type,
+                :origin_path
 
   validates :report_a_problem, inclusion: { in: %w[yes no] }
   validates :comment, presence: true, length: { maximum: 1200 }

--- a/app/form_models/jobseekers/account_feedback_form.rb
+++ b/app/form_models/jobseekers/account_feedback_form.rb
@@ -1,5 +1,5 @@
 class Jobseekers::AccountFeedbackForm < BaseForm
-  attr_accessor :comment, :email, :origin, :rating, :report_a_problem, :user_participation_response, :occupation
+  attr_accessor :comment, :email, :origin_path, :rating, :report_a_problem, :user_participation_response, :occupation
 
   validates :report_a_problem, inclusion: { in: %w[yes no] }
   validates :comment, length: { maximum: 1200 }, if: -> { comment.present? }

--- a/app/views/general_feedbacks/new.html.slim
+++ b/app/views/general_feedbacks/new.html.slim
@@ -3,7 +3,8 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     = form_for @general_feedback_form, url: feedback_path do |f|
-      = f.hidden_field :user_type, value: @user_type
+      = f.hidden_field :user_type, value: @general_feedback_form.user_type
+      = f.hidden_field :origin_path, value: @general_feedback_form.origin_path
       = f.govuk_error_summary
 
       h1.govuk-heading-xl = t(".heading")

--- a/app/views/jobseekers/account_feedbacks/new.html.slim
+++ b/app/views/jobseekers/account_feedbacks/new.html.slim
@@ -3,7 +3,7 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     = form_for @account_feedback_form, url: jobseekers_account_feedback_path do |f|
-      = f.hidden_field :origin
+      = f.hidden_field :origin_path
 
       = f.govuk_error_summary
 

--- a/app/views/support_users/feedbacks/_feedback_table.html.slim
+++ b/app/views/support_users/feedbacks/_feedback_table.html.slim
@@ -3,6 +3,7 @@
   - t.tags("Source") { |f| source_for(f) }
   - t.tags("Who") { |f| who(f) }
   - t.text "Type", :feedback_type
+  - t.text "Originated from", :origin_path
   - t.text("Contact email") { |f| contact_email_for(f) }
   - t.text "Occupation", :occupation
   - t.text("CSAT") { |f| t("helpers.label.general_feedback_form.rating.#{f.rating}") if f.rating }

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -82,6 +82,7 @@ shared:
     - close_account_reason
     - close_account_reason_comment
     - occupation
+    - origin_path
   invitation_to_applies:
     - id
     - jobseeker_id

--- a/db/migrate/20230710104904_add_origin_path_to_feedbacks.rb
+++ b/db/migrate/20230710104904_add_origin_path_to_feedbacks.rb
@@ -1,0 +1,5 @@
+class AddOriginPathToFeedbacks < ActiveRecord::Migration[7.0]
+  def change
+    add_column :feedbacks, :origin_path, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_11_113514) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_10_104904) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -165,6 +165,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_11_113514) do
     t.text "close_account_reason_comment"
     t.string "category"
     t.text "occupation"
+    t.string "origin_path"
     t.index ["vacancy_id"], name: "index_feedbacks_on_vacancy_id"
   end
 

--- a/spec/system/general_feedback_spec.rb
+++ b/spec/system/general_feedback_spec.rb
@@ -6,35 +6,30 @@ RSpec.describe "Giving general feedback for the service", recaptcha: true do
   let(:occupation) { "teacher" }
   let(:visit_purpose_comment) { "testing" }
 
-  context "when all required fields are complete" do
-    scenario "can submit feedback" do
-      visit new_feedback_path
-      expect(page).to have_content(I18n.t("general_feedbacks.new.heading"))
+  scenario "can submit general feedback from any page" do
+    visit jobs_path
+    click_on I18n.t("footer.provide_feedback")
+    expect(page).to have_content(I18n.t("general_feedbacks.new.heading"))
 
-      fill_in_general_feedback
+    click_on I18n.t("buttons.submit_feedback")
+    expect(page).to have_content("There is a problem")
 
-      expect { click_button I18n.t("buttons.submit_feedback") }.to change {
-        Feedback.where(comment: comment,
-                       email: email,
-                       occupation: occupation,
-                       feedback_type: "general",
-                       rating: "highly_satisfied",
-                       recaptcha_score: 0.9,
-                       user_participation_response: "interested",
-                       visit_purpose: "other_purpose",
-                       visit_purpose_comment: visit_purpose_comment).count
-      }.by(1)
+    fill_in_general_feedback
 
-      expect(page).to have_content(I18n.t("general_feedbacks.create.success"))
-    end
-  end
+    expect { click_button I18n.t("buttons.submit_feedback") }.to change {
+      Feedback.where(comment: comment,
+                     email: email,
+                     occupation: occupation,
+                     feedback_type: "general",
+                     rating: "highly_satisfied",
+                     recaptcha_score: 0.9,
+                     user_participation_response: "interested",
+                     visit_purpose: "other_purpose",
+                     visit_purpose_comment: visit_purpose_comment,
+                     origin_path: jobs_path).count
+    }.by(1)
 
-  context "when all required fields are not complete" do
-    scenario "can not submit feedback" do
-      visit new_feedback_path
-      click_on I18n.t("buttons.submit_feedback")
-      expect(page).to have_content("There is a problem")
-    end
+    expect(page).to have_content(I18n.t("general_feedbacks.create.success"))
   end
 
   context "when recaptcha is invalid" do
@@ -42,21 +37,14 @@ RSpec.describe "Giving general feedback for the service", recaptcha: true do
       allow_any_instance_of(ApplicationController).to receive(:verify_recaptcha).and_return(false)
     end
 
-    context "and the form is valid" do
-      scenario "redirects to invalid_recaptcha path" do
-        visit new_feedback_path
-        fill_in_general_feedback
-        click_on I18n.t("buttons.submit_feedback")
-        expect(page).to have_current_path(invalid_recaptcha_path(form_name: "General feedback form"))
-      end
-    end
+    scenario "redirects to invalid_recaptcha path" do
+      visit new_feedback_path
+      click_on I18n.t("buttons.submit_feedback")
+      expect(page).to have_content("There is a problem")
 
-    context "and the form is invalid" do
-      scenario "does not redirect to invalid_recaptcha path" do
-        visit new_feedback_path
-        click_on I18n.t("buttons.submit_feedback")
-        expect(page).to have_content("There is a problem")
-      end
+      fill_in_general_feedback
+      click_on I18n.t("buttons.submit_feedback")
+      expect(page).to have_current_path(invalid_recaptcha_path(form_name: "General feedback form"))
     end
   end
 

--- a/spec/system/jobseekers_can_give_account_feedback_spec.rb
+++ b/spec/system/jobseekers_can_give_account_feedback_spec.rb
@@ -20,7 +20,13 @@ RSpec.describe "Jobseekers can give account feedback" do
     fill_in "jobseekers_account_feedback_form[occupation]", with: occupation
 
     expect { click_button I18n.t("buttons.submit") }.to change {
-      jobseeker.feedbacks.where(comment: comment, email: jobseeker.email, rating: "somewhat_satisfied", feedback_type: "jobseeker_account", user_participation_response: "interested", occupation: occupation).count
+      jobseeker.feedbacks.where(comment: comment,
+                                email: jobseeker.email,
+                                rating: "somewhat_satisfied",
+                                feedback_type: "jobseeker_account",
+                                user_participation_response: "interested",
+                                occupation: occupation,
+                                origin_path: jobseekers_account_path).count
     }.by(1)
     expect(current_path).to eq(jobseekers_account_path)
     expect(page).to have_content(I18n.t("jobseekers.account_feedbacks.create.success"))

--- a/spec/system/support_users/feedback_spec.rb
+++ b/spec/system/support_users/feedback_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe "Feedback supportal section" do
       rating: "highly_satisfied",
       email: "faketestingemail@someemail.com",
       user_participation_response: "interested",
+      origin_path: "/jobs",
     )
   end
 
@@ -96,10 +97,11 @@ RSpec.describe "Feedback supportal section" do
             source = find("td:nth-child(2)").text
             who = find("td:nth-child(3)").text
             feedback_type = find("td:nth-child(4)").text
-            contact_email = find("td:nth-child(5)").text
-            occupation = find("td:nth-child(6)").text
-            csat = find("td:nth-child(7)").text
-            comment = find("td:nth-child(8)").text
+            origin = find("td:nth-child(5)").text
+            contact_email = find("td:nth-child(6)").text
+            occupation = find("td:nth-child(7)").text
+            csat = find("td:nth-child(8)").text
+            comment = find("td:nth-child(9)").text
 
             expect(timestamp).to eq(other_feedback.created_at.to_s)
             expect(source).to eq("Identified")
@@ -107,6 +109,7 @@ RSpec.describe "Feedback supportal section" do
             expect(occupation).to eq(other_feedback.occupation)
             expect(contact_email).to eq(other_feedback.email)
             expect(feedback_type).to eq(other_feedback.feedback_type)
+            expect(origin).to eq(other_feedback.origin_path)
             expect(csat).to eq(I18n.t("helpers.label.general_feedback_form.rating.#{other_feedback.rating}"))
             expect(comment).to eq(other_feedback.comment)
           end


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/RicQOBTI

## Changes in this PR:
When we receive general feedback (accessed from the TV site footer), it would be helpful to know from which page the user opened the feedback form, as it gives better context.

We are adding the origin URL when available to view it in the general feedback dashboard.

**Note: We also include it in the Jobseeker Account Feedback form, used in the footer as general feedback for signed-in jobseekers.**

## Screenshots of UI changes:
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/6a038889-7be4-407f-9b70-c83948dd9859)
