### PR TITLE
Add quick apply filter to job search

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -138,7 +138,7 @@ Metrics/BlockLength:
     - "app/models/concerns/indexable.rb"
 
 Metrics/ClassLength:
-  Max: 190 # Default 100
+  Max: 200 # Default 100
 
 Metrics/CyclomaticComplexity:
   Max: 18 # Default 7

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -25,12 +25,12 @@ class VacanciesController < ApplicationController
   def search_params
     return @landing_page.criteria if @landing_page
 
-    strip_empty_checkboxes(%i[job_roles ect_statuses subjects phases working_patterns organisation_types school_types]) unless params[:skip_strip_checkboxes]
-    %w[job_roles subjects phases working_patterns organisation_types].each do |facet|
+    strip_empty_checkboxes(%i[job_roles ect_statuses subjects phases quick_apply working_patterns organisation_types school_types]) unless params[:skip_strip_checkboxes]
+    %w[job_roles subjects phases working_patterns quick_apply organisation_types].each do |facet|
       params[facet] = params[facet].split if params[facet].is_a?(String)
     end
     params.permit(:keyword, :previous_keyword, :organisation_slug, :location, :radius, :subject, :sort_by,
-                  job_roles: [], ect_statuses: [], subjects: [], phases: [], working_patterns: [], organisation_types: [], school_types: [])
+                  job_roles: [], ect_statuses: [], subjects: [], phases: [], working_patterns: [], quick_apply: [], organisation_types: [], school_types: [])
   end
 
   def set_landing_page

--- a/app/form_models/jobseekers/search_form.rb
+++ b/app/form_models/jobseekers/search_form.rb
@@ -1,13 +1,29 @@
 class Jobseekers::SearchForm
   include ActiveModel::Model
 
-  attr_reader :keyword, :previous_keyword,
-              :location, :radius,
+  attr_reader :ect_status_options,
+              :ect_statuses,
+              :filters_from_keyword,
+              :job_role_options,
+              :job_roles,
+              :keyword,
+              :location,
               :organisation_slug,
-              :job_roles, :ect_statuses, :organisation_types, :organisation_type_options, :subjects, :phases, :working_patterns,
-              :job_role_options, :ect_status_options, :school_types, :school_type_options,
-              :phase_options, :working_pattern_options,
-              :filters_from_keyword, :total_filters, :sort
+              :organisation_type_options,
+              :organisation_types,
+              :phase_options,
+              :phases,
+              :previous_keyword,
+              :quick_apply,
+              :quick_apply_options,
+              :radius,
+              :school_type_options,
+              :school_types,
+              :sort,
+              :subjects,
+              :total_filters,
+              :working_pattern_options,
+              :working_patterns
 
   def initialize(params = {})
     strip_trailing_whitespaces_from_params(params)
@@ -31,6 +47,7 @@ class Jobseekers::SearchForm
       ect_statuses: @ect_statuses,
       subjects: @subjects,
       phases: @phases,
+      quick_apply: @quick_apply,
       working_patterns: @working_patterns,
       organisation_types: @organisation_types,
       school_types: @school_types,
@@ -76,6 +93,7 @@ class Jobseekers::SearchForm
     @job_role_options = Vacancy.job_roles.keys.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_role_form.job_role_options.#{option}")] }
     @phase_options = Vacancy.phases.keys.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_education_phases_form.phases_options.#{option}")] }
     @ect_status_options = [["ect_suitable", I18n.t("jobs.filters.ect_suitable")]]
+    set_quick_apply_options
     @working_pattern_options = Vacancy.working_patterns.keys.map do |option|
       [option, I18n.t("helpers.label.publishers_job_listing_working_patterns_form.working_patterns_options.#{option}")]
     end
@@ -92,6 +110,7 @@ class Jobseekers::SearchForm
     @ect_statuses = params[:ect_statuses] || []
     @subjects = params[:subjects] || []
     @phases = params[:phases] || []
+    @quick_apply = params[:quick_apply] || []
     @working_patterns = params[:working_patterns] || []
     @organisation_slug = params[:organisation_slug]
     @organisation_types = params[:organisation_types] || []
@@ -99,7 +118,7 @@ class Jobseekers::SearchForm
   end
 
   def set_total_filters
-    @total_filters = [@job_roles&.count, @ect_statuses&.count, @subjects&.count, @phases&.count, @working_patterns&.count, @organisation_types&.count, @school_types&.count].compact.sum
+    @total_filters = [@job_roles&.count, @ect_statuses&.count, @subjects&.count, @phases&.count, @quick_apply&.count, @working_patterns&.count, @organisation_types&.count, @school_types&.count].compact.sum
   end
 
   def set_radius(radius_param)
@@ -112,4 +131,16 @@ class Jobseekers::SearchForm
       [I18n.t("helpers.label.publishers_job_listing_working_patterns_form.organisation_type_options.local_authority"), nil],
     ]
   end
+
+  # rubocop:disable Style/OpenStructUse
+  def set_quick_apply_options
+    @quick_apply_options = [
+      OpenStruct.new(
+        value: "quick_apply",
+        text: I18n.t("helpers.label.publishers_job_listing_applying_for_the_job_form.quick_apply"),
+        hint: I18n.t("helpers.label.publishers_job_listing_applying_for_the_job_form.quick_apply_hint"),
+      ),
+    ]
+  end
+  # rubocop:enable Style/OpenStructUse
 end

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -66,6 +66,7 @@ class Vacancy < ApplicationRecord
   scope :listed, (-> { published.where("publish_on <= ?", Date.current) })
   scope :live, (-> { listed.applicable })
   scope :pending, (-> { published.where("publish_on > ?", Date.current) })
+  scope :quick_apply, (-> { where(enable_job_applications: true) })
   scope :published_on_count, (->(date) { published.where(publish_on: date.all_day).count })
 
   scope :internal, (-> { where(external_source: nil) })

--- a/app/queries/vacancy_filter_query.rb
+++ b/app/queries/vacancy_filter_query.rb
@@ -23,6 +23,7 @@ class VacancyFilterQuery < ApplicationQuery
     # TODO: Remove this scope when we do not have any more live SEND responsible jobs
     built_scope = built_scope.where(":job_roles = ANY (job_roles)", job_roles: 2) if filters[:job_roles]&.include?("send_responsible")
     built_scope = add_organisation_type_filters(filters, built_scope)
+    built_scope = built_scope.quick_apply if filters[:quick_apply]
     built_scope = add_school_type_filters(filters, built_scope)
     working_patterns = fix_legacy_working_patterns(filters[:working_patterns])
     built_scope = built_scope.with_any_of_working_patterns(working_patterns) if working_patterns.present?

--- a/app/services/search/vacancy_search.rb
+++ b/app/services/search/vacancy_search.rb
@@ -20,7 +20,7 @@ class Search::VacancySearch
   end
 
   def clear_filters_params
-    active_criteria.merge(job_roles: [], ect_statuses: [], phases: [], working_patterns: [], subjects: [], organisation_types: [], school_types: [], previous_keyword: keyword, skip_strip_checkboxes: true)
+    active_criteria.merge(job_roles: [], ect_statuses: [], phases: [], working_patterns: [], quick_apply: [], subjects: [], organisation_types: [], school_types: [], previous_keyword: keyword, skip_strip_checkboxes: true)
   end
 
   def remove_filter_params

--- a/app/views/vacancies/search/_filters.html.slim
+++ b/app/views/vacancies/search/_filters.html.slim
@@ -17,6 +17,14 @@ ruby:
       selected_method: :last,
     },
     {
+      legend: t("jobs.filters.quick_apply"),
+      key: :quick_apply,
+      selected: form.quick_apply,
+      options: form.quick_apply_options,
+      value_method: :value,
+      selected_method: :text,
+    },
+    {
       legend: t("jobs.filters.subject"),
       key: :subjects,
       selected: form.subjects,
@@ -70,6 +78,7 @@ ruby:
     - filters_component.with_group key: "education_phase", component: f.govuk_collection_check_boxes(:phases, form.phase_options, :first, :last, small: true, legend: { text: t("jobs.filters.phases") }, hint: nil)
     = render "shared/subjects_filter", filters_component: filters_component, f: f
     - filters_component.with_group key: "ect_statuses", component: f.govuk_collection_check_boxes(:ect_statuses, form.ect_status_options, :first, :last, small: true, legend: { text: t("jobs.filters.ect_suitable") }, hint: nil)
+    - filters_component.with_group key: "quick_apply", component: f.govuk_collection_check_boxes(:quick_apply, form.quick_apply_options, :value, :text, :hint, small: true, legend: { text: t("jobs.filters.quick_apply") }, hint: nil)
     - filters_component.with_group key: "organisation_types", component: f.govuk_collection_check_boxes(:organisation_types, form.organisation_type_options, :first, :first, :last, small: true, legend: { text: t("jobs.filters.organisation_type") }, hint: nil)
     - filters_component.with_group key: "school_types", component: f.govuk_collection_check_boxes(:school_types, f.object.school_type_options, :first, :last, small: true, legend: { text: t("jobs.filters.school_type") }, hint: nil)
     - filters_component.with_group key: "working_patterns", component: f.govuk_collection_check_boxes(:working_patterns, form.working_pattern_options, :first, :last, small: true, legend: { text: t("jobs.filters.working_patterns") }, hint: nil)

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -627,6 +627,8 @@ en:
           other: Another email address
         other_application_email: Email address
       publishers_job_listing_applying_for_the_job_form:
+        quick_apply: Only show quick apply jobs
+        quick_apply_hint: Apply for jobs simply and quickly using your profile
         enable_job_applications_options:
           false: "No"
           true: "Yes"

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -39,6 +39,7 @@ en:
       send_responsible_only: With SEND responsibilities
       subject: Subject
       phases: Education phase
+      quick_apply: Application method
       working_patterns: Working pattern
       organisation_type: Organisation type
       school_type: School type

--- a/spec/queries/vacancy_filter_query_spec.rb
+++ b/spec/queries/vacancy_filter_query_spec.rb
@@ -18,22 +18,22 @@ RSpec.describe VacancyFilterQuery do
   let(:non_faith_school2) { create(:school, name: "nonfaith2", gias_data: { "ReligiousCharacter (name)" => "Does not apply" }) }
   let(:non_faith_school3) { create(:school, name: "nonfaith3", gias_data: { "ReligiousCharacter (name)" => "None" }) }
 
-  let!(:vacancy1) { create(:vacancy, job_title: "Vacancy 1", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[secondary], job_role: "teacher", ect_status: "ect_suitable", organisations: [academy]) }
-  let!(:vacancy2) { create(:vacancy, job_title: "Vacancy 2", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[sixth_form_or_college], job_role: "teacher", ect_status: "ect_unsuitable", organisations: [free_school]) }
-  let!(:vacancy3) { create(:vacancy, job_title: "Vacancy 3", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "sendco", ect_status: nil, organisations: [local_authority_school]) }
-  let!(:vacancy4) { create(:vacancy, job_title: "Vacancy 4", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil) }
-  let!(:vacancy5) { create(:vacancy, job_title: "Vacancy 5", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [academies]) }
-  let!(:vacancy6) { create(:vacancy, job_title: "Vacancy 6", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
-  let!(:special_vacancy1) { create(:vacancy, job_title: "Vacancy 7", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [special_school1]) }
-  let!(:special_vacancy2) { create(:vacancy, job_title: "Vacancy 8", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [special_school2]) }
-  let!(:special_vacancy3) { create(:vacancy, job_title: "Vacancy 9", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [special_school3]) }
-  let!(:special_vacancy4) { create(:vacancy, job_title: "Vacancy 10", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [special_school4]) }
-  let!(:special_vacancy5) { create(:vacancy, job_title: "Vacancy 11", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [special_school5]) }
-  let!(:special_vacancy6) { create(:vacancy, job_title: "Vacancy 12", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [special_school6]) }
-  let!(:faith_vacancy) { create(:vacancy, job_title: "Vacancy 13", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, publisher_organisation: faith_school, organisations: [faith_school, faith_school2]) }
-  let!(:non_faith_vacancy1) { create(:vacancy, job_title: "Vacancy 14", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [non_faith_school1]) }
-  let!(:non_faith_vacancy2) { create(:vacancy, job_title: "Vacancy 15", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [non_faith_school2]) }
-  let!(:non_faith_vacancy3) { create(:vacancy, job_title: "Vacancy 14", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [non_faith_school3]) }
+  let!(:vacancy1) { create(:vacancy, job_title: "Vacancy 1", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[secondary], job_role: "teacher", ect_status: "ect_suitable", organisations: [academy], enable_job_applications: true) }
+  let!(:vacancy2) { create(:vacancy, job_title: "Vacancy 2", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[sixth_form_or_college], job_role: "teacher", ect_status: "ect_unsuitable", organisations: [free_school], enable_job_applications: true) }
+  let!(:vacancy3) { create(:vacancy, job_title: "Vacancy 3", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "sendco", ect_status: nil, organisations: [local_authority_school], enable_job_applications: true) }
+  let!(:vacancy4) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 4", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil) }
+  let!(:vacancy5) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 5", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [academies]) }
+  let!(:vacancy6) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 6", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
+  let!(:special_vacancy1) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 7", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [special_school1]) }
+  let!(:special_vacancy2) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 8", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [special_school2]) }
+  let!(:special_vacancy3) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 9", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [special_school3]) }
+  let!(:special_vacancy4) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 10", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [special_school4]) }
+  let!(:special_vacancy5) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 11", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [special_school5]) }
+  let!(:special_vacancy6) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 12", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [special_school6]) }
+  let!(:faith_vacancy) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 13", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, publisher_organisation: faith_school, organisations: [faith_school, faith_school2]) }
+  let!(:non_faith_vacancy1) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 14", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [non_faith_school1]) }
+  let!(:non_faith_vacancy2) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 15", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [non_faith_school2]) }
+  let!(:non_faith_vacancy3) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 14", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [non_faith_school3]) }
 
   describe "#call" do
     it "queries based on the given filters" do
@@ -84,6 +84,15 @@ RSpec.describe VacancyFilterQuery do
           }
           expect(subject.call(filters)).to contain_exactly(vacancy1, vacancy2, vacancy3, vacancy5, vacancy6)
         end
+      end
+    end
+
+    context "when a quick apply filter is selected" do
+      it "will return vacancies with TV quick apply status only" do
+        filters = {
+          quick_apply: ["quick_apply"],
+        }
+        expect(subject.call(filters)).to contain_exactly(vacancy1, vacancy2, vacancy3)
       end
     end
 

--- a/spec/services/search/vacancy_search_spec.rb
+++ b/spec/services/search/vacancy_search_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Search::VacancySearch do
       ect_statuses: ect_statuses,
       phases: phases,
       working_patterns: working_patterns,
+      quick_apply: quick_apply,
       subjects: subjects,
       organisation_types: organisation_types,
       school_types: school_types,
@@ -31,6 +32,7 @@ RSpec.describe Search::VacancySearch do
   let(:working_patterns) { nil }
   let(:subjects) { nil }
   let(:organisation_types) { nil }
+  let(:quick_apply) { nil }
   let(:school_types) { nil }
   let(:school) { create(:school) }
   let(:scope) { double("scope", count: 870) }
@@ -82,13 +84,14 @@ RSpec.describe Search::VacancySearch do
     let(:ect_statuses) { ["ect_suitable"] }
     let(:phases) { ["ks1"] }
     let(:working_patterns) { ["full_time"] }
+    let(:quick_apply) { ["quick_apply"] }
     let(:subjects) { ["Maths"] }
     let(:organisation_types) { ["Academy"] }
     let(:school_types) { ["faith_school"] }
 
     it "clears selected filters " do
-      expect(subject.active_criteria).to eq({ location: location, organisation_types: organisation_types, organisation_slug: organisation_slug, ect_statuses: ect_statuses, job_roles: job_roles, keyword: keyword, phases: phases, radius: 10, subjects: subjects, working_patterns: working_patterns, school_types: school_types })
-      expect(subject.clear_filters_params).to eq({ keyword: keyword, location: location, radius: 10, organisation_slug: organisation_slug, job_roles: [], ect_statuses: [], phases: [], working_patterns: [], subjects: [], organisation_types: [], school_types: [], previous_keyword: keyword, skip_strip_checkboxes: true })
+      expect(subject.active_criteria).to eq({ location: location, organisation_types: organisation_types, organisation_slug: organisation_slug, ect_statuses: ect_statuses, job_roles: job_roles, keyword: keyword, phases: phases, radius: 10, subjects: subjects, working_patterns: working_patterns, quick_apply: quick_apply, school_types: school_types })
+      expect(subject.clear_filters_params).to eq({ keyword: keyword, location: location, radius: 10, organisation_slug: organisation_slug, job_roles: [], ect_statuses: [], phases: [], working_patterns: [], quick_apply: [], subjects: [], organisation_types: [], school_types: [], previous_keyword: keyword, skip_strip_checkboxes: true })
     end
   end
 end

--- a/spec/system/jobseekers_can_search_for_jobs_spec.rb
+++ b/spec/system/jobseekers_can_search_for_jobs_spec.rb
@@ -70,12 +70,12 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
   let(:local_authority_school2) { create(:school, school_type: "Local authority maintained schools") }
   let(:school) { create(:school) }
 
-  let!(:maths_job1) { create(:vacancy, :past_publish, :teacher, publish_on: Date.current - 1, job_title: "Maths 1", subjects: %w[Mathematics], organisations: [school], phases: %w[secondary]) }
-  let!(:maths_job2) { create(:vacancy, :past_publish, :teacher, publish_on: Date.current - 2, job_title: "Maths Teacher 2", subjects: %w[Mathematics], organisations: [school], phases: %w[secondary]) }
-  let!(:job1) { create(:vacancy, :past_publish, :teacher, job_title: "Physics Teacher", subjects: ["Physics"], organisations: [academy1], phases: %w[secondary]) }
-  let!(:job2) { create(:vacancy, :past_publish, :teacher, job_title: "PE Teacher", subjects: [], organisations: [academy2]) }
-  let!(:job3) { create(:vacancy, :past_publish, :teacher, job_title: "Chemistry Teacher", subjects: [], organisations: [free_school1]) }
-  let!(:job4) { create(:vacancy, :past_publish, :teacher, job_title: "Geography Teacher", subjects: [], publisher_organisation: free_school1, organisations: [free_school1, free_school2]) }
+  let!(:maths_job1) { create(:vacancy, :past_publish, :no_tv_applications, :teacher, publish_on: Date.current - 1, job_title: "Maths 1", subjects: %w[Mathematics], organisations: [school], phases: %w[secondary]) }
+  let!(:maths_job2) { create(:vacancy, :past_publish, :no_tv_applications, :teacher, publish_on: Date.current - 2, job_title: "Maths Teacher 2", subjects: %w[Mathematics], organisations: [school], phases: %w[secondary]) }
+  let!(:job1) { create(:vacancy, :past_publish, :no_tv_applications, :teacher, job_title: "Physics Teacher", subjects: ["Physics"], organisations: [academy1], phases: %w[secondary]) }
+  let!(:job2) { create(:vacancy, :past_publish, :no_tv_applications, :teacher, job_title: "PE Teacher", subjects: [], organisations: [academy2]) }
+  let!(:job3) { create(:vacancy, :past_publish, :no_tv_applications, :teacher, job_title: "Chemistry Teacher", subjects: [], organisations: [free_school1]) }
+  let!(:job4) { create(:vacancy, :past_publish, :no_tv_applications, :teacher, job_title: "Geography Teacher", subjects: [], publisher_organisation: free_school1, organisations: [free_school1, free_school2]) }
   let!(:expired_job) { create(:vacancy, :expired, :teacher, job_title: "Maths Teacher", subjects: [], organisations: [school]) }
   let(:per_page) { 2 }
 
@@ -99,6 +99,21 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
     end
 
     it_behaves_like "a successful search"
+  end
+
+  context "jobseekers can use the quick apply type filter to search for jobs" do
+    let!(:quick_apply_job) { create(:vacancy, job_title: "Quick Apply Job", organisations: [school], enable_job_applications: true) }
+
+    context "when quick apply is selected" do
+      it "only shows vacancies that are quick apply" do
+        visit jobs_path
+        check I18n.t("helpers.label.publishers_job_listing_applying_for_the_job_form.quick_apply")
+        click_on I18n.t("buttons.search")
+
+        expect_page_to_show_jobs([quick_apply_job])
+        expect_page_not_to_show_jobs([job1, job2, job3, job4, maths_job1, maths_job2])
+      end
+    end
   end
 
   context "jobseekers can use the organisation type filter to search for jobs" do


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/zFzfpUTp/423-add-a-quick-apply-filter

## Changes in this PR:

Adds a quick apply filter to the jobs page for jobseekers. 

## Screenshots of UI changes:
<img width="1230" alt="Screenshot 2023-07-11 at 13 20 50" src="https://github.com/DFE-Digital/teaching-vacancies/assets/1470166/4d10265c-54c5-480e-80b1-91815111d728">
<img width="1079" alt="Screenshot 2023-07-11 at 13 21 17" src="https://github.com/DFE-Digital/teaching-vacancies/assets/1470166/93ac0f63-0dce-48d5-ab6e-e9b05b7cbb79">

