### PR TITLE
Fix factorybot exceptions in production

### DIFF
--- a/spec/factories/job_applications.rb
+++ b/spec/factories/job_applications.rb
@@ -233,5 +233,7 @@ FactoryBot.define do
         association(:qualification, :category_gcse),
       ]
     end
+
+    association :vacancy, factory: %i[vacancy non_sequential_job_title]
   end
 end

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -200,5 +200,9 @@ FactoryBot.define do
       external_reference { "J3D1" }
       external_advert_url { "https://example.com/jobs/123" }
     end
+
+    trait :non_sequential_job_title do
+      job_title { factory_sample(job_titles) }
+    end
   end
 end


### PR DESCRIPTION
Related exception: https://teaching-vacancies.sentry.io/issues/4305126444/

Surprisingly our service is invoking Factorybot in production environment to generate job application samples displayed to the users.

As production is multi-threaded, using Sequence calls in FactoryBot causes thread exceptions when used in production.

The production code uses a particular factory trait, so I am modifying it to avoid sequencing the job titles in that factory initialisation.

This way, we still have the factories able to use sequence calls in test environments, while the production job application sample is safe as it doesn't sequence over the sample data.
