### PR TITLE
DO NOT MERGE: Explore generating CSV as views

### DIFF
--- a/app/controllers/support_users/feedbacks_controller.rb
+++ b/app/controllers/support_users/feedbacks_controller.rb
@@ -1,3 +1,5 @@
+require "csv"
+
 class SupportUsers::FeedbacksController < SupportUsers::BaseController
   include SupportUsers::SatisfactionRatingTypes
 
@@ -14,7 +16,7 @@ class SupportUsers::FeedbacksController < SupportUsers::BaseController
 
     respond_to do |format|
       format.html
-      format.csv { send_data general_feedback_csv(@feedbacks), filename: "general-feedback-#{Date.today}.csv" }
+      format.csv { feedback_csv("general") }
     end
   end
 
@@ -66,6 +68,12 @@ class SupportUsers::FeedbacksController < SupportUsers::BaseController
   end
 
   private
+
+  def feedback_csv(type)
+    response.headers["Content-Type"] = "text/csv"
+    response.headers["Content-Disposition"] = "attachment; filename=#{type}-feedback-#{Date.today}.csv"
+    render type
+  end
 
   def general_feedback_csv(feedbacks)
     generate_csv(feedbacks, "general")

--- a/app/views/support_users/feedbacks/general.csv.slim
+++ b/app/views/support_users/feedbacks/general.csv.slim
@@ -1,0 +1,14 @@
+- headers = ["Created at", "Source", "Who", "Type", "Origin path", "Contact email", "Occupation", "CSAT", "Comment", "Category"]
+= CSV.generate_line headers
+- @feedbacks.each do |feedback|
+  = CSV.generate_line([feedback.created_at, 
+                       source_for(feedback), 
+                       who(feedback), 
+                       feedback.feedback_type, 
+                       feedback.origin_path, 
+                       contact_email_for(feedback), 
+                       feedback.occupation, 
+                       feedback.rating, 
+                       feedback.comment, 
+                       feedback.category])
+


### PR DESCRIPTION
This proof of concept is not complete or meant to be merged, but to discuss a different approach.

Given that the code to generate CSVs depends on helpers, and conceptually we could take the CSV as an "output format" (as a JSON formatter or XML formatter could be), I've explored building the CSV as a view for a different format.

Advantages I find with this approach:
- It doesn't require external dependencies/gems.
- It only adds controller logic related to response headers, render...
- Contains each CSV attributes logic in its respective view template, which loads the controller's data as an HTML template would do.

Source of inspiration: https://testsuite.io/build-export-to-csv-with-rails

