### PR TITLE
Map new roles from integration sources

### DIFF
--- a/app/vacancy_sources/fusion_vacancy_source.rb
+++ b/app/vacancy_sources/fusion_vacancy_source.rb
@@ -80,11 +80,13 @@ class FusionVacancySource
   end
 
   def job_role(item)
-    item["jobRole"].presence
-      &.gsub("headteacher", "senior_leader")
-      &.gsub("head_of_year", "middle_leader")
-      &.gsub("learning_support", "education_support")
-      &.gsub(/\s+/, "")
+    return if item["jobRole"].blank?
+
+    item["jobRole"]
+      .gsub(/deputy_headteacher|assistant_headteacher|headteacher/, "senior_leader")
+      .gsub(/head_of_year_or_phase|head_of_department_or_curriculum|head_of_year/, "middle_leader")
+      .gsub("learning_support", "education_support")
+      .gsub(/\s+/, "")
   end
 
   def ect_status_for(item)

--- a/app/vacancy_sources/my_new_term_vacancy_source.rb
+++ b/app/vacancy_sources/my_new_term_vacancy_source.rb
@@ -80,17 +80,13 @@ class MyNewTermVacancySource
   end
 
   def job_role(item)
-    item["jobRole"].presence
-    &.gsub("headteacher", "senior_leader")
-    &.gsub("headteacher_principal", "senior_leader")
-    &.gsub("deputy_headteacher_principal", "senior_leader")
-    &.gsub("head_of_year", "middle_leader")
-    &.gsub("assistant_headteacher_principal", "middle_leader")
-    &.gsub("deputy_headteacher_principal", "middle_leader")
-    &.gsub("learning_support", "education_support")
-    &.gsub("other_support", "education_support")
-    &.gsub("science_technician", "other_education_role")
-    &.gsub(/\s+/, "")
+    return if item["jobRole"].blank?
+
+    item["jobRole"]
+     .gsub(/deputy_headteacher_principal|assistant_headteacher_principal|headteacher_principal|deputy_headteacher|assistant_headteacher|headteacher/, "senior_leader")
+     .gsub(/head_of_year_or_phase|head_of_department_or_curriculum|head_of_year/, "middle_leader")
+     .gsub(/learning_support|other_support|science_technician/, "education_support")
+     .gsub(/\s+/, "")
   end
 
   def ect_status_for(item)

--- a/app/vacancy_sources/united_learning_vacancy_source.rb
+++ b/app/vacancy_sources/united_learning_vacancy_source.rb
@@ -55,7 +55,7 @@ class UnitedLearningVacancySource
       external_advert_url: item["link", root: true],
 
       # New structured fields
-      job_role: item["Job_roles"].presence&.gsub("leadership", "senior_leader")&.gsub(/\s+/, ""),
+      job_role: job_role_for(item),
       ect_status: ect_status_for(item),
       subjects: item["Subjects"].presence&.split(","),
       working_patterns: item["Working_patterns"].presence&.split(","),
@@ -66,6 +66,14 @@ class UnitedLearningVacancySource
       organisations: organisations_for(item),
       about_school: organisations_for(item).first&.description,
     }
+  end
+
+  def job_role_for(item)
+    return if item["Job_roles"].blank?
+
+    item["Job_roles"].gsub(/leadership|deputy_headteacher|assistant_headteacher|headteacher/, "senior_leader")
+                     .gsub(/head_of_year_or_phase|head_of_department_or_curriculum/, "middle_leader")
+                     .gsub(/\s+/, "")
   end
 
   def ect_status_for(item)

--- a/spec/vacancy_sources/fusion_vacancy_source_spec.rb
+++ b/spec/vacancy_sources/fusion_vacancy_source_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe FusionVacancySource do
   let!(:school_group) { create(:school_group, name: "E-ACT", uid: "12345", schools: schools) }
   let(:schools) { [school1] }
 
-  let(:response) { double("FusionHttpResponse", success?: true, body: file_fixture("vacancy_sources/fusion.json").read) }
+  let(:response_body) { file_fixture("vacancy_sources/fusion.json").read }
+  let(:response) { double("FusionHttpResponse", success?: true, body: response_body) }
   let(:argument_error_response) { double("FusionHttpResponse", success?: true, body: file_fixture("vacancy_sources/fusion_argument_error.json").read) }
 
   describe "enumeration" do
@@ -53,6 +54,50 @@ RSpec.describe FusionVacancySource do
     it "sets important dates" do
       expect(vacancy.expires_at).to eq(Time.zone.parse("2022-10-28T12:00:00"))
       expect(vacancy.publish_on).to eq(Date.today)
+    end
+
+    describe "job roles mapping" do
+      let(:response_body) { super().gsub("teacher", source_role) }
+
+      ["null", "", " "].each do |role|
+        context "when the source role is '#{role}'" do
+          let(:source_role) { role }
+
+          it "the vacancy role is null" do
+            expect(vacancy.job_role).to eq(nil)
+          end
+        end
+      end
+
+      %w[headteacher deputy_headteacher assistant_headteacher].each do |role|
+        context "when the source role is '#{role}'" do
+          let(:source_role) { role }
+
+          it "maps the source role to 'senior_leader' in the vacancy" do
+            expect(vacancy.job_role).to eq("senior_leader")
+          end
+        end
+      end
+
+      %w[head_of_year head_of_year_or_phase head_of_department_or_curriculum].each do |role|
+        context "when the source role is '#{role}'" do
+          let(:source_role) { role }
+
+          it "maps the source role to 'middle_leader' in the vacancy" do
+            expect(vacancy.job_role).to eq("middle_leader")
+          end
+        end
+      end
+
+      %w[learning_support].each do |role|
+        context "when the source role is '#{role}'" do
+          let(:source_role) { role }
+
+          it "maps the source role to 'education_support' in the vacancy" do
+            expect(vacancy.job_role).to eq("education_support")
+          end
+        end
+      end
     end
 
     context "when the same vacancy has been imported previously" do

--- a/spec/vacancy_sources/united_learning_vacancy_source_spec.rb
+++ b/spec/vacancy_sources/united_learning_vacancy_source_spec.rb
@@ -43,6 +43,45 @@ RSpec.describe UnitedLearningVacancySource do
       expect(vacancy.publish_on).to eq(Date.today)
     end
 
+    describe "job roles mapping" do
+      let(:item_stub) { instance_double(UnitedLearningVacancySource::FeedItem, :[] => "") }
+
+      before do
+        allow(item_stub).to receive(:[]).with("Job_roles").and_return(source_role)
+        allow(UnitedLearningVacancySource::FeedItem).to receive(:new).and_return(item_stub)
+      end
+
+      [nil, "", " "].each do |role|
+        context "when the source role is '#{role}'" do
+          let(:source_role) { role }
+
+          it "the vacancy role is null" do
+            expect(vacancy.job_role).to eq(nil)
+          end
+        end
+      end
+
+      %w[leadership headteacher deputy_headteacher assistant_headteacher].each do |role|
+        context "when the source role is '#{role}'" do
+          let(:source_role) { role }
+
+          it "maps the source role to 'senior_leader' in the vacancy" do
+            expect(vacancy.job_role).to eq("senior_leader")
+          end
+        end
+      end
+
+      %w[head_of_year_or_phase head_of_department_or_curriculum].each do |role|
+        context "when the source role is '#{role}'" do
+          let(:source_role) { role }
+
+          it "maps the source role to 'middle_leader' in the vacancy" do
+            expect(vacancy.job_role).to eq("middle_leader")
+          end
+        end
+      end
+    end
+
     context "when the same vacancy has been imported previously" do
       let!(:existing_vacancy) do
         create(


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/38zxki3U

## Changes in this PR:
- Allows ATS to send us:
  - `deputy_headteacher`, `assistant_headteacher` and `headteacher` for `senior_leader` TV job roles. 
  - `head_of_year_or_phase` and `head_of_department_or_curriculum` for `middle_leader` TV job roles. 
- Fixes issues with the current mapping on `MyNewTerm` source:
  - The initial substitutions of partial roles were causing invalid job roles. Eg: incoming `deputy_headteacher_principal` turns into `deputy_senior_leader_principal` instead of `senior_leader` and is rejected when creating the vacancy.
  - Some of the current mappings were not matching the right roles in our DB. Re-mapped them after consulting our BAs.

