### PR TITLE
Mitigate Support Users sign-in email issue

### DIFF
--- a/app/helpers/notify_views_helper.rb
+++ b/app/helpers/notify_views_helper.rb
@@ -96,7 +96,7 @@ module NotifyViewsHelper
 
   def support_user_fallback_sign_in_link(signed_id)
     url = support_users_fallback_session_url(signed_id)
-    notify_link(url, t(".link"))
+    notify_link(url)
   end
 
   def unlock_account_link(token)


### PR DESCRIPTION
When trying to sign in as a support user in our review apps, the DFE-Sign-in is disabled, and the login is done through one-off login links sent by email.

Since our recent migration to Microsoft email hosting, Microsoft introduced a certificate checker that proxies the sign-in links, and results in the links becoming invalid when clicked as the proxy does a double render that consumes the one-off link before redirecting the user to it.

This is causing a lot of headaches in our review environments, and as the link is proxied, trying to find out the real link wrapped in the proxy URL is nightmarish and unrealistic for non-devs.

The solution directly shows the link as text as done on the publisher's one-off login links. If you directly click the link, it will go through the proxy and fail, but at least here, you can see the whole URL as a link, copy the text and paste it on your browser, achieving the login.

This is not a proper fix to the root issue, but as it depends on third parties to fix it and it seems it will take a while, let's make our team life less difficult.
