### PR TITLE
Add back in old working patterns

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -26,7 +26,7 @@ class Vacancy < ApplicationRecord
   }.freeze
 
   array_enum key_stages: { early_years: 0, ks1: 1, ks2: 2, ks3: 3, ks4: 4, ks5: 5 }
-  array_enum working_patterns: { full_time: 0, part_time: 100 }
+  array_enum working_patterns: { full_time: 0, part_time: 100, flexible: 104, job_share: 101, term_time: 102 }
   array_enum phases: { nursery: 0, primary: 1, middle: 2, secondary: 3, sixth_form_or_college: 4, through: 5 }
 
   enum contract_type: { permanent: 0, fixed_term: 1, parental_leave_cover: 2 }


### PR DESCRIPTION
## Changes in this PR:

This PR fixes [this bug](https://teaching-vacancies.sentry.io/issues/4321307220/?alert_rule_id=10370581&alert_type=issue&project=6212514&referrer=slack). The bug seems to be occuring when users come via links such as https://teaching-vacancies.service.gov.uk/school-job-shares, this is because we removed job_share, term_time and flexible working patterns

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
