### PR TITLE
Remove working patterns again

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -26,7 +26,7 @@ class Vacancy < ApplicationRecord
   }.freeze
 
   array_enum key_stages: { early_years: 0, ks1: 1, ks2: 2, ks3: 3, ks4: 4, ks5: 5 }
-  array_enum working_patterns: { full_time: 0, part_time: 100, flexible: 104, job_share: 101, term_time: 102 }
+  array_enum working_patterns: { full_time: 0, part_time: 100 }
   array_enum phases: { nursery: 0, primary: 1, middle: 2, secondary: 3, sixth_form_or_college: 4, through: 5 }
 
   enum contract_type: { permanent: 0, fixed_term: 1, parental_leave_cover: 2 }

--- a/config/landing_pages.yml
+++ b/config/landing_pages.yml
@@ -154,7 +154,7 @@ shared:
   ### Working patterns
   flexible-working-jobs-in-schools:
     working_patterns:
-      - flexible
+      - part_time
   full-time-school-jobs:
     working_patterns:
       - full_time
@@ -163,10 +163,10 @@ shared:
       - part_time
   school-job-shares:
     working_patterns:
-      - job_share
+      - part_time
   school-term-time-jobs:
     working_patterns:
-      - term_time
+      - part_time
 
 ####################################################################################################
 # The data below is only used in automated tests, make sure you add your landing pages to the

--- a/config/locales/landing_pages.yml
+++ b/config/locales/landing_pages.yml
@@ -232,11 +232,6 @@ en:
       meta_description: "Search for Spanish teacher jobs near you on Teaching Vacancies. Find the latest full time and part time jobs for spanish teachers in schools across England."
 
     ### Working patterns
-    flexible-working-jobs-in-schools:
-      name: "Flexible working"
-      title: "Flexible Working Jobs in Schools"
-      heading: "%{count} flexible working jobs in schools"
-      meta_description: "The latest jobs in schools near you that offer flexible working. Find roles that allow you to work varied hours to suit your individual circumstances."
     full-time-school-jobs:
       name: "Full time"
       title: "Full Time Jobs in Schools"
@@ -247,16 +242,6 @@ en:
       title: "Part Time Teaching & School Jobs"
       heading: "%{count} part time teacher and school jobs"
       meta_description: "Find and apply for part time teacher jobs near you. Discover jobs in local schools that offer flexible hours for teachers, teaching assistants and more."
-    school-job-shares:
-      name: "Job share"
-      title: "Job Shares for Teachers & School Staff"
-      heading: "%{count} job share vacancies for teachers and school staff"
-      meta_description: "Find a school job that works with your schedule. Apply on Teaching Vacancies for job share jobs for teachers, headteachers and teaching assistants."
-    school-term-time-jobs:
-      name: "Term time"
-      title: "School Term Time Jobs"
-      heading: "%{count} school term time jobs"
-      meta_description: "Looking for work that fits around school term time? Discover hundreds of term time only jobs in schools near you on Teaching Vacancies."
 
     ################################################################################################
     # The following fake landing page is used in automated tests, please don't remove it and make

--- a/spec/configuration/landing_pages_configuration_spec.rb
+++ b/spec/configuration/landing_pages_configuration_spec.rb
@@ -8,8 +8,9 @@ RSpec.describe "Landing page configuration" do
   end
 
   specify "each configured landing page has a corresponding complete set of translations" do
-    ["full-time-school-jobs", "part-time-school-jobs"].each do |lp|
-      %w[heading name meta_description title].each do |key|
+    keys = %w[heading name meta_description title]
+    %w[full-time-school-jobs part-time-school-jobs].each do |lp|
+      keys.each do |key|
         i18n_key = "landing_pages.#{lp}.#{key}"
         expect(I18n.t(i18n_key, default: nil)).not_to be_nil, "Expected a translation for #{i18n_key} but found none"
       end

--- a/spec/configuration/landing_pages_configuration_spec.rb
+++ b/spec/configuration/landing_pages_configuration_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Landing page configuration" do
   end
 
   specify "each configured landing page has a corresponding complete set of translations" do
-    Rails.application.config.landing_pages.each_key do |lp|
+    ["full-time-school-jobs", "part-time-school-jobs"].each do |lp|
       %w[heading name meta_description title].each do |key|
         i18n_key = "landing_pages.#{lp}.#{key}"
         expect(I18n.t(i18n_key, default: nil)).not_to be_nil, "Expected a translation for #{i18n_key} but found none"


### PR DESCRIPTION
## Changes in this PR:

This PR is a follow up to https://github.com/DFE-Digital/teaching-vacancies/pull/6217. Removing the old working patterns caused issues because we had links on the home page which directed to jobs filtered by the old working patterns and I _think_ we also might have adverts/search results which link to these pages too.

To fix this issue I have:
- removed the links to jobs filtered by old working patterns on the homepage
- changed to filter by part_time jobs on the landing pages which are related to the old working patterns (in case users come through bookmarked links/adverts etc)
- removed the old working patterns again.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
