### PR TITLE
remove links for old working patterns

### DIFF
--- a/app/views/home/_landing_page_links.html.slim
+++ b/app/views/home/_landing_page_links.html.slim
@@ -21,9 +21,6 @@
       = landing_page_link_group title: t(".working_patterns"), classes: "govuk-grid-column-one-third" do |group|
         = group.with_landing_page "full-time-school-jobs"
         = group.with_landing_page "part-time-school-jobs"
-        = group.with_landing_page "flexible-working-jobs-in-schools"
-        = group.with_landing_page "school-job-shares"
-        = group.with_landing_page "school-term-time-jobs"
 
     - accordion.with_section(heading_text: t(".jobs_by_location")) do
       .govuk-grid-column-one-third

--- a/config/locales/landing_pages.yml
+++ b/config/locales/landing_pages.yml
@@ -232,11 +232,6 @@ en:
       meta_description: "Search for Spanish teacher jobs near you on Teaching Vacancies. Find the latest full time and part time jobs for spanish teachers in schools across England."
 
     ### Working patterns
-    flexible-working-jobs-in-schools:
-      name: "Flexible working"
-      title: "Flexible Working Jobs in Schools"
-      heading: "%{count} flexible working jobs in schools"
-      meta_description: "The latest jobs in schools near you that offer flexible working. Find roles that allow you to work varied hours to suit your individual circumstances."
     full-time-school-jobs:
       name: "Full time"
       title: "Full Time Jobs in Schools"
@@ -247,16 +242,6 @@ en:
       title: "Part Time Teaching & School Jobs"
       heading: "%{count} part time teacher and school jobs"
       meta_description: "Find and apply for part time teacher jobs near you. Discover jobs in local schools that offer flexible hours for teachers, teaching assistants and more."
-    school-job-shares:
-      name: "Job share"
-      title: "Job Shares for Teachers & School Staff"
-      heading: "%{count} job share vacancies for teachers and school staff"
-      meta_description: "Find a school job that works with your schedule. Apply on Teaching Vacancies for job share jobs for teachers, headteachers and teaching assistants."
-    school-term-time-jobs:
-      name: "Term time"
-      title: "School Term Time Jobs"
-      heading: "%{count} school term time jobs"
-      meta_description: "Looking for work that fits around school term time? Discover hundreds of term time only jobs in schools near you on Teaching Vacancies."
 
     ################################################################################################
     # The following fake landing page is used in automated tests, please don't remove it and make

--- a/config/locales/landing_pages.yml
+++ b/config/locales/landing_pages.yml
@@ -232,6 +232,11 @@ en:
       meta_description: "Search for Spanish teacher jobs near you on Teaching Vacancies. Find the latest full time and part time jobs for spanish teachers in schools across England."
 
     ### Working patterns
+    flexible-working-jobs-in-schools:
+      name: "Flexible working"
+      title: "Flexible Working Jobs in Schools"
+      heading: "%{count} flexible working jobs in schools"
+      meta_description: "The latest jobs in schools near you that offer flexible working. Find roles that allow you to work varied hours to suit your individual circumstances."
     full-time-school-jobs:
       name: "Full time"
       title: "Full Time Jobs in Schools"
@@ -242,6 +247,16 @@ en:
       title: "Part Time Teaching & School Jobs"
       heading: "%{count} part time teacher and school jobs"
       meta_description: "Find and apply for part time teacher jobs near you. Discover jobs in local schools that offer flexible hours for teachers, teaching assistants and more."
+    school-job-shares:
+      name: "Job share"
+      title: "Job Shares for Teachers & School Staff"
+      heading: "%{count} job share vacancies for teachers and school staff"
+      meta_description: "Find a school job that works with your schedule. Apply on Teaching Vacancies for job share jobs for teachers, headteachers and teaching assistants."
+    school-term-time-jobs:
+      name: "Term time"
+      title: "School Term Time Jobs"
+      heading: "%{count} school term time jobs"
+      meta_description: "Looking for work that fits around school term time? Discover hundreds of term time only jobs in schools near you on Teaching Vacancies."
 
     ################################################################################################
     # The following fake landing page is used in automated tests, please don't remove it and make


### PR DESCRIPTION
## Changes in this PR:

Add translations for the old working patterns so that we don't see translation errors in the links on the homepage. 

![Screenshot 2023-07-25 at 11 43 43](https://github.com/DFE-Digital/teaching-vacancies/assets/13124899/6dbbd048-c117-452e-92ff-fc0335e137e8)

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
