### PR TITLE
Vacancy search: few improvements for performance gains

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -56,7 +56,7 @@ class VacanciesController < ApplicationController
         search_criteria: form.to_hash,
         sort_by: form.sort.by,
         page: params[:page] || 1,
-        total_count: @vacancies_search.total_count,
+        total_count: vacancy_ids.size,
         vacancies_on_page: vacancy_ids,
         location_polygon_used: polygon_id,
         landing_page: params[:landing_page_slug],

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -49,7 +49,7 @@ class VacanciesController < ApplicationController
 
   def trigger_search_performed_event
     fail_safe do
-      vacancy_ids = @vacancies_search.vacancies.pluck(:id)
+      vacancy_ids = @vacancies_search.vacancies.unscope(:order).pluck(:id)
       polygon_id = DfE::Analytics.anonymise(@vacancies_search.location_search.polygon.id) if @vacancies_search.location_search.polygon
 
       event_data = {

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -4,7 +4,7 @@ class VacanciesController < ApplicationController
 
   def index
     @vacancies_search = Search::VacancySearch.new(form.to_hash, sort: form.sort)
-    @pagy, @vacancies = pagy(@vacancies_search.vacancies)
+    @pagy, @vacancies = pagy(@vacancies_search.vacancies, count: @vacancies_search.total_count)
   end
 
   def show

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -49,7 +49,7 @@ class VacanciesController < ApplicationController
 
   def trigger_search_performed_event
     fail_safe do
-      vacancy_ids = @vacancies_search.vacancies.map(&:id)
+      vacancy_ids = @vacancies_search.vacancies.pluck(:id)
       polygon_id = DfE::Analytics.anonymise(@vacancies_search.location_search.polygon.id) if @vacancies_search.location_search.polygon
 
       event_data = {

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -49,14 +49,14 @@ class VacanciesController < ApplicationController
 
   def trigger_search_performed_event
     fail_safe do
-      vacancy_ids = @vacancies_search.vacancies.unscope(:order).pluck(:id)
+      vacancy_ids = @vacancies.pluck(:id)
       polygon_id = DfE::Analytics.anonymise(@vacancies_search.location_search.polygon.id) if @vacancies_search.location_search.polygon
 
       event_data = {
         search_criteria: form.to_hash,
         sort_by: form.sort.by,
         page: params[:page] || 1,
-        total_count: vacancy_ids.size,
+        total_count: @vacancies_search.total_count,
         vacancies_on_page: vacancy_ids,
         location_polygon_used: polygon_id,
         landing_page: params[:landing_page_slug],

--- a/app/services/search/similar_jobs.rb
+++ b/app/services/search/similar_jobs.rb
@@ -24,9 +24,9 @@ class Search::SimilarJobs
       Search::VacancySearch
         .new(criteria)
         .vacancies
+        .excluding(vacancy)
         .limit(NUMBER_OF_SIMILAR_JOBS * 3) # Fetch more than we need in case some expire while being cached
-        .reject { |job| job.id == vacancy.id }
-        .map(&:id)
+        .pluck(:id)
     end
   end
 end

--- a/app/services/search/vacancy_search.rb
+++ b/app/services/search/vacancy_search.rb
@@ -42,7 +42,7 @@ class Search::VacancySearch
   end
 
   def organisation
-    Organisation.find_by(slug: organisation_slug) if organisation_slug
+    @organisation ||= Organisation.find_by(slug: organisation_slug) if organisation_slug
   end
 
   def vacancies

--- a/app/services/search/vacancy_search.rb
+++ b/app/services/search/vacancy_search.rb
@@ -50,7 +50,7 @@ class Search::VacancySearch
   end
 
   def total_count
-    vacancies.count
+    @total_count ||= vacancies.count
   end
 
   private

--- a/app/services/search/vacancy_search.rb
+++ b/app/services/search/vacancy_search.rb
@@ -38,7 +38,7 @@ class Search::VacancySearch
   def wider_search_suggestions
     return unless total_count.zero? && search_criteria[:location].present?
 
-    Search::WiderSuggestionsBuilder.new(search_criteria).suggestions
+    @wider_search_suggestions ||= Search::WiderSuggestionsBuilder.new(search_criteria).suggestions
   end
 
   def organisation

--- a/app/services/search/vacancy_search.rb
+++ b/app/services/search/vacancy_search.rb
@@ -36,7 +36,7 @@ class Search::VacancySearch
   end
 
   def wider_search_suggestions
-    return unless vacancies.empty? && search_criteria[:location].present?
+    return unless total_count.zero? && search_criteria[:location].present?
 
     Search::WiderSuggestionsBuilder.new(search_criteria).suggestions
   end

--- a/app/services/search/wider_suggestions_builder.rb
+++ b/app/services/search/wider_suggestions_builder.rb
@@ -15,16 +15,15 @@ class Search::WiderSuggestionsBuilder
   end
 
   def suggestions
-    RADIUS_OPTIONS
-      .select { |r| r > initial_radius }
-      .map { |radius| [radius.to_s, wider_results(radius)] }
-      .uniq(&:second)
-      .reject { |options| options.second.zero? }
+    @suggestions ||= RADIUS_OPTIONS.select { |r| r > initial_radius }
+                                   .map { |radius| [radius.to_s, wider_results_count(radius)] }
+                                   .uniq(&:second)
+                                   .reject { |options| options.second.zero? }
   end
 
   private
 
-  def wider_results(radius)
+  def wider_results_count(radius)
     Search::VacancySearch.new(search_criteria.merge(radius: radius)).total_count
   end
 end

--- a/app/views/vacancies/index.html.slim
+++ b/app/views/vacancies/index.html.slim
@@ -9,7 +9,7 @@
 h1 class="govuk-heading-l" role="heading" aria-level="1"
   = t("jobs.search_result_heading", count: number_with_delimiter(@vacancies_search.total_count))
 
-- any_vacancies = @vacancies.any?
+- any_vacancies = @vacancies_search.total_count.positive?
 - if @vacancies_search.active_criteria? && any_vacancies
   p = t("subscriptions.link.help_text_html", link: govuk_link_to(t("subscriptions.link.text"), new_subscription_path(search_criteria: @vacancies_search.active_criteria, coordinates_present: @vacancies_search.point_coordinates.present?)))
 

--- a/app/views/vacancies/index.html.slim
+++ b/app/views/vacancies/index.html.slim
@@ -9,7 +9,8 @@
 h1 class="govuk-heading-l" role="heading" aria-level="1"
   = t("jobs.search_result_heading", count: number_with_delimiter(@vacancies_search.total_count))
 
-- if @vacancies_search.active_criteria? && @vacancies.count.positive?
+- any_vacancies = @vacancies.any?
+- if @vacancies_search.active_criteria? && any_vacancies
   p = t("subscriptions.link.help_text_html", link: govuk_link_to(t("subscriptions.link.text"), new_subscription_path(search_criteria: @vacancies_search.active_criteria, coordinates_present: @vacancies_search.point_coordinates.present?)))
 
 = form_for @form, as: "", url: jobs_path, method: :get, html: { data: { controller: "form" }, role: "search" } do |f|
@@ -28,7 +29,7 @@ h1 class="govuk-heading-l" role="heading" aria-level="1"
       = govuk_inset_text(text: t("vacancies.international_teacher_advice.text_html",
                                  link: tracked_link_to(t("vacancies.international_teacher_advice.link"), "https://getintoteaching.education.gov.uk/non-uk-teachers", link_type: :international_teacher_advice_link_search_results)))
       #search-results
-        - if @vacancies.any?
+        - if any_vacancies
           = render "vacancies/search/results", vacancies: @vacancies
         - elsif @vacancies_search.organisation_slug
           = render "vacancies/search/no_results_organisation", organisation_name: @vacancies_search.organisation.name
@@ -37,5 +38,5 @@ h1 class="govuk-heading-l" role="heading" aria-level="1"
         - else
           = render "vacancies/search/no_results"
       = govuk_pagination(pagy: @pagy)
-      - if @vacancies.any?
+      - if any_vacancies
         = render "vacancies/search/stats"

--- a/spec/services/search/vacancy_search_spec.rb
+++ b/spec/services/search/vacancy_search_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Search::VacancySearch do
 
   describe "wider suggestions" do
     context "when results are returned" do
-      let(:scope) { double("scope", empty?: false) }
+      let(:scope) { double("scope", count: 870) }
 
       it "does not offer suggestions" do
         expect(subject.wider_search_suggestions).to be_nil
@@ -66,7 +66,7 @@ RSpec.describe Search::VacancySearch do
     end
 
     context "when no results are returned" do
-      let(:scope) { double("scope", empty?: true) }
+      let(:scope) { double("scope", count: 0) }
       let(:suggestions_builder) { double(suggestions: [1, 2, 3]) }
 
       before do


### PR DESCRIPTION
## Trello card URL

- https://trello.com/c/MI8uwJte

## Review APP to check that things didn't break
- https://teaching-vacancies-review-pr-6226.london.cloudapps.digital/

## Changes in this PR:

Few bits to improve the performance of the Vacancy Search.
- Reduce the calls to DB for the whole search query when possible. 
  - Mainly by memoising the query results count on the first call and reusing this number instead of triggering new counts. 
- Reduce loading all the search results in memory when possible.
  - A few spots were loading all the search results and operating over them. We could avoid loading the whole search results into memory by directly filtering in the DB query.
- Sends only current page results ids to Analytics (To confirm this was a bug before releasing it). 

## What I discarded:
- I attempted to be smart by preloading organisations and the logo attachment retrieval, reducing the number of queries. But then I realised that:
  - Given that the results are paginated, the N+1 we're avoiding has a magnitude of... 10. Not big gains here.
  - Preloading gets all the results into memory, not the paginated subset. When run locally with a few vacancies was fast, but in production with thousands of vacancies, this probably will have worse performance than the 10 individual queries triggered per page.
   
## What I've learnt:
- `Search::WiderSuggestionsBuilder.new(search_criteria).suggestions`, called when no results were found for the desired location, triggers multiple search queries (one per radius option above the current radius). This very expensive call causes the slowest searches (as does the original search plus 1 to 9 further searches!).