### PR TITLE
Add rake task to delete orphan feedbacks

### DIFF
--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -91,6 +91,11 @@ namespace :db do # rubocop:disable Metrics/BlockLength
   task delete_alert_runs_for_deleted_subscriptions: :environment do
     AlertRun.left_joins(:subscription).where(subscription: { id: nil }).delete_all
   end
+
+  task delete_feedbacks_for_deleted_associations: :environment do
+    Feedback.left_joins(:jobseeker).where.not(jobseeker_id: nil).where(jobseeker: { id: nil }).delete_all
+    Feedback.left_joins(:subscription).where.not(subscription_id: nil).where(subscription: { id: nil }).delete_all
+  end
 end
 
 namespace :dsi do


### PR DESCRIPTION
The associated objects were deleted but the feedback wasn't, becoming an orphan with an association pointing to an inexistent object.

```
Feedback.left_joins(:job_application).where.not(job_application_id: nil).where(job_application: { id: nil }).count
0

Feedback.left_joins(:jobseeker).where.not(jobseeker_id: nil).where(jobseeker: { id: nil }).count
1

Feedback.left_joins(:publisher).where.not(publisher_id: nil).where(publisher: { id: nil }).count
0

Feedback.left_joins(:subscription).where.not(subscription_id: nil).where(subscription: { id: nil }).count

211

Feedback.left_joins(:vacancy).where.not(vacancy_id: nil).where(vacancy: { id: nil }).count
0
```