### PR TITLE
Add missing association indexes in DB

### DIFF
--- a/.database_consistency.todo.yml
+++ b/.database_consistency.todo.yml
@@ -29,9 +29,6 @@ JobApplication:
   employment_history_section_completed:
     ThreeStateBooleanChecker:
       enabled: false
-  feedbacks:
-    MissingIndexChecker:
-      enabled: false
   jobseeker:
     ColumnPresenceChecker:
       enabled: false
@@ -59,9 +56,6 @@ Jobseeker:
   email:
     ColumnPresenceChecker:
       enabled: false
-  feedbacks:
-    MissingIndexChecker:
-      enabled: false
   index_jobseekers_on_confirmation_token:
     UniqueIndexChecker:
       enabled: false
@@ -71,21 +65,9 @@ Jobseeker:
   index_jobseekers_on_unlock_token:
     UniqueIndexChecker:
       enabled: false
-  job_applications:
-    MissingIndexChecker:
-      enabled: false
-  jobseeker_profile:
-    MissingIndexChecker:
-      enabled: false
 JobseekerProfile:
-  job_preferences:
-    MissingIndexChecker:
-      enabled: false
   jobseeker:
     ColumnPresenceChecker:
-      enabled: false
-  personal_details:
-    MissingIndexChecker:
       enabled: false
   requested_hidden_profile:
     ThreeStateBooleanChecker:
@@ -117,9 +99,6 @@ Organisation:
       enabled: false
   index_organisations_on_urn:
     UniqueIndexChecker:
-      enabled: false
-  organisation_publishers:
-    MissingIndexChecker:
       enabled: false
 OrganisationPublisher:
   organisation:
@@ -156,24 +135,12 @@ PersonalDetails:
     ThreeStateBooleanChecker:
       enabled: false
 Publisher:
-  feedbacks:
-    MissingIndexChecker:
-      enabled: false
   index_publishers_on_oid:
     UniqueIndexChecker:
       enabled: false
-  organisation_publishers:
-    MissingIndexChecker:
-      enabled: false
 PublisherPreference:
-  local_authority_publisher_schools:
-    MissingIndexChecker:
-      enabled: false
   organisation:
     ColumnPresenceChecker:
-      enabled: false
-  organisation_publisher_preferences:
-    MissingIndexChecker:
       enabled: false
   publisher:
     ColumnPresenceChecker:
@@ -209,9 +176,6 @@ Subscription:
   active:
     ThreeStateBooleanChecker:
       enabled: false
-  feedbacks:
-    MissingIndexChecker:
-      enabled: false
 Vacancy:
   benefits:
     ThreeStateBooleanChecker:
@@ -221,9 +185,6 @@ Vacancy:
       enabled: false
   enable_job_applications:
     ThreeStateBooleanChecker:
-      enabled: false
-  equal_opportunities_report:
-    MissingIndexChecker:
       enabled: false
   further_details_provided:
     ThreeStateBooleanChecker:
@@ -237,14 +198,8 @@ Vacancy:
   safeguarding_information_provided:
     ThreeStateBooleanChecker:
       enabled: false
-  saved_jobs:
-    MissingIndexChecker:
-      enabled: false
   school_visits:
     ThreeStateBooleanChecker:
-      enabled: false
-  slugs:
-    MissingIndexChecker:
       enabled: false
   starts_asap:
     ThreeStateBooleanChecker:

--- a/db/migrate/20230725115015_add_feedbacks_subscription_id_index.rb
+++ b/db/migrate/20230725115015_add_feedbacks_subscription_id_index.rb
@@ -1,0 +1,7 @@
+class AddFeedbacksSubscriptionIdIndex < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :feedbacks, ["subscription_id"], name: :index_feedbacks_subscription_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20230725115016_add_organisation_publisher_preferences_publisher_preference_id_index.rb
+++ b/db/migrate/20230725115016_add_organisation_publisher_preferences_publisher_preference_id_index.rb
@@ -1,0 +1,7 @@
+class AddOrganisationPublisherPreferencesPublisherPreferenceIdIndex < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :organisation_publisher_preferences, ["publisher_preference_id"], name: :index_organisation_publisher_preferences_publisher_preference_i, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20230725115017_add_local_authority_publisher_schools_publisher_preference_id_index.rb
+++ b/db/migrate/20230725115017_add_local_authority_publisher_schools_publisher_preference_id_index.rb
@@ -1,0 +1,7 @@
+class AddLocalAuthorityPublisherSchoolsPublisherPreferenceIdIndex < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :local_authority_publisher_schools, ["publisher_preference_id"], name: :index_local_authority_publisher_schools_publisher_preference_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20230725115018_add_personal_details_jobseeker_profile_id_index.rb
+++ b/db/migrate/20230725115018_add_personal_details_jobseeker_profile_id_index.rb
@@ -1,0 +1,8 @@
+class AddPersonalDetailsJobseekerProfileIdIndex < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :personal_details, ["jobseeker_profile_id"], name: :index_personal_details_jobseeker_profile_id, unique: true, algorithm: :concurrently
+    remove_index :personal_details, name: :index_personal_details_on_jobseeker_profile_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20230725115019_add_job_preferences_jobseeker_profile_id_index.rb
+++ b/db/migrate/20230725115019_add_job_preferences_jobseeker_profile_id_index.rb
@@ -1,0 +1,8 @@
+class AddJobPreferencesJobseekerProfileIdIndex < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :job_preferences, ["jobseeker_profile_id"], name: :index_job_preferences_jobseeker_profile_id, unique: true, algorithm: :concurrently
+    remove_index :job_preferences, name: :index_job_preferences_on_jobseeker_profile_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20230725115020_add_feedbacks_job_application_id_index.rb
+++ b/db/migrate/20230725115020_add_feedbacks_job_application_id_index.rb
@@ -1,0 +1,7 @@
+class AddFeedbacksJobApplicationIdIndex < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :feedbacks, ["job_application_id"], name: :index_feedbacks_job_application_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20230725115021_add_friendly_id_slugs_sluggable_id_sluggable_type_index.rb
+++ b/db/migrate/20230725115021_add_friendly_id_slugs_sluggable_id_sluggable_type_index.rb
@@ -1,0 +1,7 @@
+class AddFriendlyIdSlugsSluggableIdSluggableTypeIndex < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :friendly_id_slugs, ["sluggable_id", "sluggable_type"], name: :index_friendly_id_slugs_sluggable_id_sluggable_type, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20230725115022_add_saved_jobs_vacancy_id_index.rb
+++ b/db/migrate/20230725115022_add_saved_jobs_vacancy_id_index.rb
@@ -1,0 +1,7 @@
+class AddSavedJobsVacancyIdIndex < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :saved_jobs, ["vacancy_id"], name: :index_saved_jobs_vacancy_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20230725115023_add_equal_opportunities_reports_vacancy_id_index.rb
+++ b/db/migrate/20230725115023_add_equal_opportunities_reports_vacancy_id_index.rb
@@ -1,0 +1,8 @@
+class AddEqualOpportunitiesReportsVacancyIdIndex < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :equal_opportunities_reports, ["vacancy_id"], name: :index_equal_opportunities_reports_vacancy_id, unique: true, algorithm: :concurrently
+    remove_index :equal_opportunities_reports, name: :index_equal_opportunities_reports_on_vacancy_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20230725115024_add_feedbacks_publisher_id_index.rb
+++ b/db/migrate/20230725115024_add_feedbacks_publisher_id_index.rb
@@ -1,0 +1,7 @@
+class AddFeedbacksPublisherIdIndex < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :feedbacks, ["publisher_id"], name: :index_feedbacks_publisher_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20230725115025_add_organisation_publishers_publisher_id_index.rb
+++ b/db/migrate/20230725115025_add_organisation_publishers_publisher_id_index.rb
@@ -1,0 +1,7 @@
+class AddOrganisationPublishersPublisherIdIndex < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :organisation_publishers, ["publisher_id"], name: :index_organisation_publishers_publisher_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20230725115026_add_feedbacks_jobseeker_id_index.rb
+++ b/db/migrate/20230725115026_add_feedbacks_jobseeker_id_index.rb
@@ -1,0 +1,7 @@
+class AddFeedbacksJobseekerIdIndex < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :feedbacks, ["jobseeker_id"], name: :index_feedbacks_jobseeker_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20230725115027_add_job_applications_jobseeker_id_index.rb
+++ b/db/migrate/20230725115027_add_job_applications_jobseeker_id_index.rb
@@ -1,0 +1,7 @@
+class AddJobApplicationsJobseekerIdIndex < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :job_applications, ["jobseeker_id"], name: :index_job_applications_jobseeker_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20230725115028_add_jobseeker_profiles_jobseeker_id_index.rb
+++ b/db/migrate/20230725115028_add_jobseeker_profiles_jobseeker_id_index.rb
@@ -1,0 +1,8 @@
+class AddJobseekerProfilesJobseekerIdIndex < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :jobseeker_profiles, ["jobseeker_id"], name: :index_jobseeker_profiles_jobseeker_id, unique: true, algorithm: :concurrently
+    remove_index :jobseeker_profiles, name: :index_jobseeker_profiles_on_jobseeker_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20230725115029_add_organisation_publishers_organisation_id_index.rb
+++ b/db/migrate/20230725115029_add_organisation_publishers_organisation_id_index.rb
@@ -1,0 +1,7 @@
+class AddOrganisationPublishersOrganisationIdIndex < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :organisation_publishers, ["organisation_id"], name: :index_organisation_publishers_organisation_id, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_24_180478) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_25_115029) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -128,7 +128,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_24_180478) do
     t.integer "age_forty_to_forty_nine", default: 0, null: false
     t.integer "age_fifty_to_fifty_nine", default: 0, null: false
     t.integer "age_sixty_and_over", default: 0, null: false
-    t.index ["vacancy_id"], name: "index_equal_opportunities_reports_on_vacancy_id"
+    t.index ["vacancy_id"], name: "index_equal_opportunities_reports_vacancy_id", unique: true
   end
 
   create_table "failed_imported_vacancies", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -166,6 +166,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_24_180478) do
     t.string "category"
     t.text "occupation"
     t.string "origin_path"
+    t.index ["job_application_id"], name: "index_feedbacks_job_application_id"
+    t.index ["jobseeker_id"], name: "index_feedbacks_jobseeker_id"
+    t.index ["publisher_id"], name: "index_feedbacks_publisher_id"
+    t.index ["subscription_id"], name: "index_feedbacks_subscription_id"
     t.index ["vacancy_id"], name: "index_feedbacks_on_vacancy_id"
   end
 
@@ -177,6 +181,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_24_180478) do
     t.datetime "created_at", precision: nil
     t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true
     t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
+    t.index ["sluggable_id", "sluggable_type"], name: "index_friendly_id_slugs_sluggable_id_sluggable_type"
     t.index ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id"
     t.index ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type"
   end
@@ -244,6 +249,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_24_180478) do
     t.integer "in_progress_steps", default: [], null: false, array: true
     t.boolean "employment_history_section_completed"
     t.boolean "qualifications_section_completed"
+    t.index ["jobseeker_id"], name: "index_job_applications_jobseeker_id"
     t.index ["vacancy_id"], name: "index_job_applications_on_vacancy_id"
   end
 
@@ -258,7 +264,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_24_180478) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "jobseeker_profile_id"
-    t.index ["jobseeker_profile_id"], name: "index_job_preferences_on_jobseeker_profile_id"
+    t.index ["jobseeker_profile_id"], name: "index_job_preferences_jobseeker_profile_id", unique: true
   end
 
   create_table "job_preferences_locations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -290,7 +296,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_24_180478) do
     t.string "qualified_teacher_status_year"
     t.boolean "active", default: false, null: false
     t.boolean "requested_hidden_profile"
-    t.index ["jobseeker_id"], name: "index_jobseeker_profiles_on_jobseeker_id"
+    t.index ["jobseeker_id"], name: "index_jobseeker_profiles_jobseeker_id", unique: true
   end
 
   create_table "jobseekers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -324,6 +330,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_24_180478) do
     t.uuid "school_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["publisher_preference_id"], name: "index_local_authority_publisher_schools_publisher_preference_id"
   end
 
   create_table "location_polygons", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -374,6 +381,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_24_180478) do
     t.uuid "publisher_preference_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["publisher_preference_id"], name: "index_organisation_publisher_preferences_publisher_preference_i"
   end
 
   create_table "organisation_publishers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -381,6 +389,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_24_180478) do
     t.uuid "publisher_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["organisation_id"], name: "index_organisation_publishers_organisation_id"
+    t.index ["publisher_id"], name: "index_organisation_publishers_publisher_id"
   end
 
   create_table "organisation_vacancies", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -445,7 +455,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_24_180478) do
     t.text "last_name_ciphertext"
     t.text "phone_number_ciphertext"
     t.boolean "right_to_work_in_uk"
-    t.index ["jobseeker_profile_id"], name: "index_personal_details_on_jobseeker_profile_id"
+    t.index ["jobseeker_profile_id"], name: "index_personal_details_jobseeker_profile_id", unique: true
   end
 
   create_table "publisher_preferences", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -518,6 +528,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_24_180478) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["jobseeker_id"], name: "index_saved_jobs_on_jobseeker_id"
+    t.index ["vacancy_id"], name: "index_saved_jobs_vacancy_id"
   end
 
   create_table "school_group_memberships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/models/personal_details_spec.rb
+++ b/spec/models/personal_details_spec.rb
@@ -50,14 +50,6 @@ RSpec.describe PersonalDetails do
         end
       end
 
-      context "when there's an existing profile" do
-        before { create(:jobseeker_profile, jobseeker:) }
-
-        it "does not set completed steps" do
-          expect(personal_details.completed_steps).to be_empty
-        end
-      end
-
       context "when the name step is partially prefilled" do
         before { create(:job_application, :status_submitted, jobseeker:, last_name: nil) }
 


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/ZFVIvvfF

## Changes in this PR:
Add missing indexes corresponding to active record associations. Replace existing indexes for unique ones when appropriate (for has_one associations).

