### PR TITLE
Add missing not null DB restrictions

### DIFF
--- a/.database_consistency.todo.yml
+++ b/.database_consistency.todo.yml
@@ -1,12 +1,4 @@
 ---
-AlertRun:
-  subscription:
-    ColumnPresenceChecker:
-      enabled: false
-EmergencyLoginKey:
-  publisher:
-    ColumnPresenceChecker:
-      enabled: false
 FailedImportedVacancy:
   source:
     NullConstraintChecker:
@@ -15,32 +7,12 @@ Feedback:
   relevant_to_user:
     ThreeStateBooleanChecker:
       enabled: false
-InvitationToApply:
-  invited_by:
-    ColumnPresenceChecker:
-      enabled: false
-  jobseeker:
-    ColumnPresenceChecker:
-      enabled: false
-  vacancy:
-    ColumnPresenceChecker:
-      enabled: false
 JobApplication:
   employment_history_section_completed:
     ThreeStateBooleanChecker:
       enabled: false
-  jobseeker:
-    ColumnPresenceChecker:
-      enabled: false
   qualifications_section_completed:
     ThreeStateBooleanChecker:
-      enabled: false
-  vacancy:
-    ColumnPresenceChecker:
-      enabled: false
-JobPreferences:
-  jobseeker_profile:
-    ColumnPresenceChecker:
       enabled: false
 JobPreferences::Location:
   area:
@@ -52,23 +24,9 @@ JobPreferences::Location:
   radius:
     NullConstraintChecker:
       enabled: false
-Jobseeker:
-  email:
-    ColumnPresenceChecker:
-      enabled: false
 JobseekerProfile:
-  jobseeker:
-    ColumnPresenceChecker:
-      enabled: false
   requested_hidden_profile:
     ThreeStateBooleanChecker:
-      enabled: false
-LocalAuthorityPublisherSchool:
-  publisher_preference:
-    ColumnPresenceChecker:
-      enabled: false
-  school:
-    ColumnPresenceChecker:
       enabled: false
 LocationPolygon:
   name:
@@ -78,40 +36,12 @@ Notification:
   type:
     NullConstraintChecker:
       enabled: false
-OrganisationPublisher:
-  organisation:
-    ColumnPresenceChecker:
-      enabled: false
-  publisher:
-    ColumnPresenceChecker:
-      enabled: false
-OrganisationPublisherPreference:
-  organisation:
-    ColumnPresenceChecker:
-      enabled: false
-  publisher_preference:
-    ColumnPresenceChecker:
-      enabled: false
-OrganisationVacancy:
-  organisation:
-    ColumnPresenceChecker:
-      enabled: false
-  vacancy:
-    ColumnPresenceChecker:
-      enabled: false
 PersonalDetails:
   phone_number_provided:
     ThreeStateBooleanChecker:
       enabled: false
   right_to_work_in_uk:
     ThreeStateBooleanChecker:
-      enabled: false
-PublisherPreference:
-  organisation:
-    ColumnPresenceChecker:
-      enabled: false
-  publisher:
-    ColumnPresenceChecker:
       enabled: false
 Qualification:
   finished_studying:
@@ -120,22 +50,9 @@ Qualification:
   qualification_results:
     ForeignKeyCascadeChecker:
       enabled: false
-SavedJob:
-  jobseeker:
-    ColumnPresenceChecker:
-      enabled: false
-  vacancy:
-    ColumnPresenceChecker:
-      enabled: false
 SchoolGroupMembership:
   do_not_delete:
     ThreeStateBooleanChecker:
-      enabled: false
-  school:
-    ColumnPresenceChecker:
-      enabled: false
-  school_group:
-    ColumnPresenceChecker:
       enabled: false
 Subscription:
   active:

--- a/db/migrate/20230728122530_change_school_group_memberships_school_id_null_constraint.rb
+++ b/db/migrate/20230728122530_change_school_group_memberships_school_id_null_constraint.rb
@@ -1,0 +1,15 @@
+class ChangeSchoolGroupMembershipsSchoolIdNullConstraint < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    add_not_null_constraint :school_group_memberships, :school_id, name: "school_group_memberships_school_id_null", validate: false
+    validate_not_null_constraint :school_group_memberships, :school_id, name: "school_group_memberships_school_id_null"
+
+    change_column_null :school_group_memberships, :school_id, false
+    remove_check_constraint :school_group_memberships, name: "school_group_memberships_school_id_null"
+  end
+
+  def down
+    change_column_null :school_group_memberships, :school_id, true
+  end
+end

--- a/db/migrate/20230728122531_change_school_group_memberships_school_group_id_null_constraint.rb
+++ b/db/migrate/20230728122531_change_school_group_memberships_school_group_id_null_constraint.rb
@@ -1,0 +1,15 @@
+class ChangeSchoolGroupMembershipsSchoolGroupIdNullConstraint < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    add_not_null_constraint :school_group_memberships, :school_group_id, name: "school_group_memberships_school_group_id_null", validate: false
+    validate_not_null_constraint :school_group_memberships, :school_group_id, name: "school_group_memberships_school_group_id_null"
+
+    change_column_null :school_group_memberships, :school_group_id, false
+    remove_check_constraint :school_group_memberships, name: "school_group_memberships_school_group_id_null"
+  end
+
+  def down
+    change_column_null :school_group_memberships, :school_group_id, true
+  end
+end

--- a/db/migrate/20230728122532_change_saved_jobs_jobseeker_id_null_constraint.rb
+++ b/db/migrate/20230728122532_change_saved_jobs_jobseeker_id_null_constraint.rb
@@ -1,0 +1,16 @@
+class ChangeSavedJobsJobseekerIdNullConstraint < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    add_not_null_constraint :saved_jobs, :jobseeker_id, name: "saved_jobs_jobseeker_id_null", validate: false
+    validate_not_null_constraint :saved_jobs, :jobseeker_id, name: "saved_jobs_jobseeker_id_null"
+
+    change_column_null :saved_jobs, :jobseeker_id, false
+    remove_check_constraint :saved_jobs, name: "saved_jobs_jobseeker_id_null"
+  end
+
+  def down
+    change_column_null :saved_jobs, :jobseeker_id, true
+  end
+end
+

--- a/db/migrate/20230728122533_change_saved_jobs_vacancy_id_null_constraint.rb
+++ b/db/migrate/20230728122533_change_saved_jobs_vacancy_id_null_constraint.rb
@@ -1,0 +1,16 @@
+class ChangeSavedJobsVacancyIdNullConstraint < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    add_not_null_constraint :saved_jobs, :vacancy_id, name: "saved_jobs_vacancy_id_null", validate: false
+    validate_not_null_constraint :saved_jobs, :vacancy_id, name: "saved_jobs_vacancy_id_null"
+
+    change_column_null :saved_jobs, :vacancy_id, false
+    remove_check_constraint :saved_jobs, name: "saved_jobs_vacancy_id_null"
+  end
+
+  def down
+    change_column_null :saved_jobs, :vacancy_id, true
+  end
+end
+

--- a/db/migrate/20230728122534_change_publisher_preferences_publisher_id_null_constraint.rb
+++ b/db/migrate/20230728122534_change_publisher_preferences_publisher_id_null_constraint.rb
@@ -1,0 +1,15 @@
+class ChangePublisherPreferencesPublisherIdNullConstraint < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    add_not_null_constraint :publisher_preferences, :publisher_id, name: "publisher_preferences_publisher_id_null", validate: false
+    validate_not_null_constraint :publisher_preferences, :publisher_id, name: "publisher_preferences_publisher_id_null"
+
+    change_column_null :publisher_preferences, :publisher_id, false
+    remove_check_constraint :publisher_preferences, name: "publisher_preferences_publisher_id_null"
+  end
+
+  def down
+    change_column_null :publisher_preferences, :publisher_id, true
+  end
+end

--- a/db/migrate/20230728122535_change_publisher_preferences_organisation_id_null_constraint.rb
+++ b/db/migrate/20230728122535_change_publisher_preferences_organisation_id_null_constraint.rb
@@ -1,0 +1,15 @@
+class ChangePublisherPreferencesOrganisationIdNullConstraint < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    add_not_null_constraint :publisher_preferences, :organisation_id, name: "publisher_preferences_organisation_id_null", validate: false
+    validate_not_null_constraint :publisher_preferences, :organisation_id, name: "publisher_preferences_organisation_id_null"
+
+    change_column_null :publisher_preferences, :organisation_id, false
+    remove_check_constraint :publisher_preferences, name: "publisher_preferences_organisation_id_null"
+  end
+
+  def down
+    change_column_null :publisher_preferences, :organisation_id, true
+  end
+end

--- a/db/migrate/20230728122536_change_organisation_vacancies_organisation_id_null_constraint.rb
+++ b/db/migrate/20230728122536_change_organisation_vacancies_organisation_id_null_constraint.rb
@@ -1,0 +1,15 @@
+class ChangeOrganisationVacanciesOrganisationIdNullConstraint < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    add_not_null_constraint :organisation_vacancies, :organisation_id, name: "organisation_vacancies_organisation_id_null", validate: false
+    validate_not_null_constraint :organisation_vacancies, :organisation_id, name: "organisation_vacancies_organisation_id_null"
+
+    change_column_null :organisation_vacancies, :organisation_id, false
+    remove_check_constraint :organisation_vacancies, name: "organisation_vacancies_organisation_id_null"
+  end
+
+  def down
+    change_column_null :organisation_vacancies, :organisation_id, true
+  end
+end

--- a/db/migrate/20230728122537_change_organisation_vacancies_vacancy_id_null_constraint.rb
+++ b/db/migrate/20230728122537_change_organisation_vacancies_vacancy_id_null_constraint.rb
@@ -1,0 +1,15 @@
+class ChangeOrganisationVacanciesVacancyIdNullConstraint < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    add_not_null_constraint :organisation_vacancies, :vacancy_id, name: "organisation_vacancies_vacancy_id_null", validate: false
+    validate_not_null_constraint :organisation_vacancies, :vacancy_id, name: "organisation_vacancies_vacancy_id_null"
+
+    change_column_null :organisation_vacancies, :vacancy_id, false
+    remove_check_constraint :organisation_vacancies, name: "organisation_vacancies_vacancy_id_null"
+  end
+
+  def down
+    change_column_null :organisation_vacancies, :vacancy_id, true
+  end
+end

--- a/db/migrate/20230728122538_change_organisation_publisher_preferences_organisation_id_null_constraint.rb
+++ b/db/migrate/20230728122538_change_organisation_publisher_preferences_organisation_id_null_constraint.rb
@@ -1,0 +1,15 @@
+class ChangeOrganisationPublisherPreferencesOrganisationIdNullConstraint < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    add_not_null_constraint :organisation_publisher_preferences, :organisation_id, name: "organisation_publisher_preferences_organisation_id_null", validate: false
+    validate_not_null_constraint :organisation_publisher_preferences, :organisation_id, name: "organisation_publisher_preferences_organisation_id_null"
+
+    change_column_null :organisation_publisher_preferences, :organisation_id, false
+    remove_check_constraint :organisation_publisher_preferences, name: "organisation_publisher_preferences_organisation_id_null"
+  end
+
+  def down
+    change_column_null :organisation_publisher_preferences, :organisation_id, true
+  end
+end

--- a/db/migrate/20230728122539_change_organisation_publisher_preferences_publisher_preference_id_null_constraint.rb
+++ b/db/migrate/20230728122539_change_organisation_publisher_preferences_publisher_preference_id_null_constraint.rb
@@ -1,0 +1,15 @@
+class ChangeOrganisationPublisherPreferencesPublisherPreferenceIdNullConstraint < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    add_not_null_constraint :organisation_publisher_preferences, :publisher_preference_id, name: "organisation_publisher_preferences_publisher_preference_id_null", validate: false
+    validate_not_null_constraint :organisation_publisher_preferences, :publisher_preference_id, name: "organisation_publisher_preferences_publisher_preference_id_null"
+
+    change_column_null :organisation_publisher_preferences, :publisher_preference_id, false
+    remove_check_constraint :organisation_publisher_preferences, name: "organisation_publisher_preferences_publisher_preference_id_null"
+  end
+
+  def down
+    change_column_null :organisation_publisher_preferences, :publisher_preference_id, true
+  end
+end

--- a/db/migrate/20230728122540_change_organisation_publishers_organisation_id_null_constraint.rb
+++ b/db/migrate/20230728122540_change_organisation_publishers_organisation_id_null_constraint.rb
@@ -1,0 +1,15 @@
+class ChangeOrganisationPublishersOrganisationIdNullConstraint < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    add_not_null_constraint :organisation_publishers, :organisation_id, name: "organisation_publishers_organisation_id_null", validate: false
+    validate_not_null_constraint :organisation_publishers, :organisation_id, name: "organisation_publishers_organisation_id_null"
+
+    change_column_null :organisation_publishers, :organisation_id, false
+    remove_check_constraint :organisation_publishers, name: "organisation_publishers_organisation_id_null"
+  end
+
+  def down
+    change_column_null :organisation_publishers, :organisation_id, true
+  end
+end

--- a/db/migrate/20230728122541_change_organisation_publishers_publisher_id_null_constraint.rb
+++ b/db/migrate/20230728122541_change_organisation_publishers_publisher_id_null_constraint.rb
@@ -1,0 +1,15 @@
+class ChangeOrganisationPublishersPublisherIdNullConstraint < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    add_not_null_constraint :organisation_publishers, :publisher_id, name: "organisation_publishers_publisher_id_null", validate: false
+    validate_not_null_constraint :organisation_publishers, :publisher_id, name: "organisation_publishers_publisher_id_null"
+
+    change_column_null :organisation_publishers, :publisher_id, false
+    remove_check_constraint :organisation_publishers, name: "organisation_publishers_publisher_id_null"
+  end
+
+  def down
+    change_column_null :organisation_publishers, :publisher_id, true
+  end
+end

--- a/db/migrate/20230728122542_change_local_authority_publisher_schools_publisher_preference_id_null_constraint.rb
+++ b/db/migrate/20230728122542_change_local_authority_publisher_schools_publisher_preference_id_null_constraint.rb
@@ -1,0 +1,15 @@
+class ChangeLocalAuthorityPublisherSchoolsPublisherPreferenceIdNullConstraint < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    add_not_null_constraint :local_authority_publisher_schools, :publisher_preference_id, name: "local_authority_publisher_schools_publisher_preference_id_null", validate: false
+    validate_not_null_constraint :local_authority_publisher_schools, :publisher_preference_id, name: "local_authority_publisher_schools_publisher_preference_id_null"
+
+    change_column_null :local_authority_publisher_schools, :publisher_preference_id, false
+    remove_check_constraint :local_authority_publisher_schools, name: "local_authority_publisher_schools_publisher_preference_id_null"
+  end
+
+  def down
+    change_column_null :local_authority_publisher_schools, :publisher_preference_id, true
+  end
+end

--- a/db/migrate/20230728122543_change_local_authority_publisher_schools_school_id_null_constraint.rb
+++ b/db/migrate/20230728122543_change_local_authority_publisher_schools_school_id_null_constraint.rb
@@ -1,0 +1,15 @@
+class ChangeLocalAuthorityPublisherSchoolsSchoolIdNullConstraint < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    add_not_null_constraint :local_authority_publisher_schools, :school_id, name: "local_authority_publisher_schools_school_id_null", validate: false
+    validate_not_null_constraint :local_authority_publisher_schools, :school_id, name: "local_authority_publisher_schools_school_id_null"
+
+    change_column_null :local_authority_publisher_schools, :school_id, false
+    remove_check_constraint :local_authority_publisher_schools, name: "local_authority_publisher_schools_school_id_null"
+  end
+
+  def down
+    change_column_null :local_authority_publisher_schools, :school_id, true
+  end
+end

--- a/db/migrate/20230728122544_change_jobseeker_profiles_jobseeker_id_null_constraint.rb
+++ b/db/migrate/20230728122544_change_jobseeker_profiles_jobseeker_id_null_constraint.rb
@@ -1,0 +1,15 @@
+class ChangeJobseekerProfilesJobseekerIdNullConstraint < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    add_not_null_constraint :jobseeker_profiles, :jobseeker_id, name: "jobseeker_profiles_jobseeker_id_null", validate: false
+    validate_not_null_constraint :jobseeker_profiles, :jobseeker_id, name: "jobseeker_profiles_jobseeker_id_null"
+
+    change_column_null :jobseeker_profiles, :jobseeker_id, false
+    remove_check_constraint :jobseeker_profiles, name: "jobseeker_profiles_jobseeker_id_null"
+  end
+
+  def down
+    change_column_null :jobseeker_profiles, :jobseeker_id, true
+  end
+end

--- a/db/migrate/20230728122545_change_job_applications_jobseeker_id_null_constraint.rb
+++ b/db/migrate/20230728122545_change_job_applications_jobseeker_id_null_constraint.rb
@@ -1,0 +1,15 @@
+class ChangeJobApplicationsJobseekerIdNullConstraint < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    add_not_null_constraint :job_applications, :jobseeker_id, name: "job_applications_jobseeker_id_null", validate: false
+    validate_not_null_constraint :job_applications, :jobseeker_id, name: "job_applications_jobseeker_id_null"
+
+    change_column_null :job_applications, :jobseeker_id, false
+    remove_check_constraint :job_applications, name: "job_applications_jobseeker_id_null"
+  end
+
+  def down
+    change_column_null :job_applications, :jobseeker_id, true
+  end
+end

--- a/db/migrate/20230728122546_change_job_applications_vacancy_id_null_constraint.rb
+++ b/db/migrate/20230728122546_change_job_applications_vacancy_id_null_constraint.rb
@@ -1,0 +1,15 @@
+class ChangeJobApplicationsVacancyIdNullConstraint < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    add_not_null_constraint :job_applications, :vacancy_id, name: "job_applications_vacancy_id_null", validate: false
+    validate_not_null_constraint :job_applications, :vacancy_id, name: "job_applications_vacancy_id_null"
+
+    change_column_null :job_applications, :vacancy_id, false
+    remove_check_constraint :job_applications, name: "job_applications_vacancy_id_null"
+  end
+
+  def down
+    change_column_null :job_applications, :vacancy_id, true
+  end
+end

--- a/db/migrate/20230728122547_change_invitation_to_applies_vacancy_id_null_constraint.rb
+++ b/db/migrate/20230728122547_change_invitation_to_applies_vacancy_id_null_constraint.rb
@@ -1,0 +1,15 @@
+class ChangeInvitationToAppliesVacancyIdNullConstraint < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    add_not_null_constraint :invitation_to_applies, :vacancy_id, name: "invitation_to_applies_vacancy_id_null", validate: false
+    validate_not_null_constraint :invitation_to_applies, :vacancy_id, name: "invitation_to_applies_vacancy_id_null"
+
+    change_column_null :invitation_to_applies, :vacancy_id, false
+    remove_check_constraint :invitation_to_applies, name: "invitation_to_applies_vacancy_id_null"
+  end
+
+  def down
+    change_column_null :invitation_to_applies, :vacancy_id, true
+  end
+end

--- a/db/migrate/20230728122548_change_invitation_to_applies_jobseeker_id_null_constraint.rb
+++ b/db/migrate/20230728122548_change_invitation_to_applies_jobseeker_id_null_constraint.rb
@@ -1,0 +1,15 @@
+class ChangeInvitationToAppliesJobseekerIdNullConstraint < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    add_not_null_constraint :invitation_to_applies, :jobseeker_id, name: "invitation_to_applies_jobseeker_id_null", validate: false
+    validate_not_null_constraint :invitation_to_applies, :jobseeker_id, name: "invitation_to_applies_jobseeker_id_null"
+
+    change_column_null :invitation_to_applies, :jobseeker_id, false
+    remove_check_constraint :invitation_to_applies, name: "invitation_to_applies_jobseeker_id_null"
+  end
+
+  def down
+    change_column_null :invitation_to_applies, :jobseeker_id, true
+  end
+end

--- a/db/migrate/20230728122549_change_invitation_to_applies_invited_by_id_null_constraint.rb
+++ b/db/migrate/20230728122549_change_invitation_to_applies_invited_by_id_null_constraint.rb
@@ -1,0 +1,15 @@
+class ChangeInvitationToAppliesInvitedByIdNullConstraint < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    add_not_null_constraint :invitation_to_applies, :invited_by_id, name: "invitation_to_applies_invited_by_id_null", validate: false
+    validate_not_null_constraint :invitation_to_applies, :invited_by_id, name: "invitation_to_applies_invited_by_id_null"
+
+    change_column_null :invitation_to_applies, :invited_by_id, false
+    remove_check_constraint :invitation_to_applies, name: "invitation_to_applies_invited_by_id_null"
+  end
+
+  def down
+    change_column_null :invitation_to_applies, :invited_by_id, true
+  end
+end

--- a/db/migrate/20230728122550_change_emergency_login_keys_publisher_id_null_constraint.rb
+++ b/db/migrate/20230728122550_change_emergency_login_keys_publisher_id_null_constraint.rb
@@ -1,0 +1,15 @@
+class ChangeEmergencyLoginKeysPublisherIdNullConstraint < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    add_not_null_constraint :emergency_login_keys, :publisher_id, name: "emergency_login_keys_publisher_id_null", validate: false
+    validate_not_null_constraint :emergency_login_keys, :publisher_id, name: "emergency_login_keys_publisher_id_null"
+
+    change_column_null :emergency_login_keys, :publisher_id, false
+    remove_check_constraint :emergency_login_keys, name: "emergency_login_keys_publisher_id_null"
+  end
+
+  def down
+    change_column_null :emergency_login_keys, :publisher_id, true
+  end
+end

--- a/db/migrate/20230728122551_change_alert_runs_subscription_id_null_constraint.rb
+++ b/db/migrate/20230728122551_change_alert_runs_subscription_id_null_constraint.rb
@@ -1,0 +1,15 @@
+class ChangeAlertRunsSubscriptionIdNullConstraint < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    add_not_null_constraint :alert_runs, :subscription_id, name: "alert_runs_subscription_id_null", validate: false
+    validate_not_null_constraint :alert_runs, :subscription_id, name: "alert_runs_subscription_id_null"
+
+    change_column_null :alert_runs, :subscription_id, false
+    remove_check_constraint :alert_runs, name: "alert_runs_subscription_id_null"
+  end
+
+  def down
+    change_column_null :alert_runs, :subscription_id, true
+  end
+end

--- a/db/migrate/20230728122552_change_job_preferences_jobseeker_profile_id_null_constraint.rb
+++ b/db/migrate/20230728122552_change_job_preferences_jobseeker_profile_id_null_constraint.rb
@@ -1,0 +1,15 @@
+class ChangeJobPreferencesJobseekerProfileIdNullConstraint < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    add_not_null_constraint :job_preferences, :jobseeker_profile_id, name: "job_preferences_jobseeker_profile_id_null", validate: false
+    validate_not_null_constraint :job_preferences, :jobseeker_profile_id, name: "job_preferences_jobseeker_profile_id_null"
+
+    change_column_null :job_preferences, :jobseeker_profile_id, false
+    remove_check_constraint :job_preferences, name: "job_preferences_jobseeker_profile_id_null"
+  end
+
+  def down
+    change_column_null :job_preferences, :jobseeker_profile_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_25_115029) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_28_122552) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -49,7 +49,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_25_115029) do
   end
 
   create_table "alert_runs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "subscription_id"
+    t.uuid "subscription_id", null: false
     t.date "run_on"
     t.string "job_id"
     t.datetime "created_at", precision: nil, null: false
@@ -60,7 +60,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_25_115029) do
 
   create_table "emergency_login_keys", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "not_valid_after", precision: nil, null: false
-    t.uuid "publisher_id"
+    t.uuid "publisher_id", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["publisher_id"], name: "index_emergency_login_keys_on_publisher_id"
@@ -187,9 +187,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_25_115029) do
   end
 
   create_table "invitation_to_applies", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "jobseeker_id"
-    t.uuid "vacancy_id"
-    t.uuid "invited_by_id"
+    t.uuid "jobseeker_id", null: false
+    t.uuid "vacancy_id", null: false
+    t.uuid "invited_by_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["invited_by_id"], name: "index_invitation_to_applies_on_invited_by_id"
@@ -201,8 +201,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_25_115029) do
     t.integer "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "jobseeker_id"
-    t.uuid "vacancy_id"
+    t.uuid "jobseeker_id", null: false
+    t.uuid "vacancy_id", null: false
     t.integer "completed_steps", default: [], null: false, array: true
     t.datetime "submitted_at", precision: nil
     t.datetime "draft_at", precision: nil
@@ -263,7 +263,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_25_115029) do
     t.boolean "builder_completed", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "jobseeker_profile_id"
+    t.uuid "jobseeker_profile_id", null: false
     t.index ["jobseeker_profile_id"], name: "index_job_preferences_jobseeker_profile_id", unique: true
   end
 
@@ -290,7 +290,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_25_115029) do
   create_table "jobseeker_profiles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "jobseeker_id"
+    t.uuid "jobseeker_id", null: false
     t.string "about_you"
     t.integer "qualified_teacher_status"
     t.string "qualified_teacher_status_year"
@@ -326,8 +326,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_25_115029) do
   end
 
   create_table "local_authority_publisher_schools", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "publisher_preference_id"
-    t.uuid "school_id"
+    t.uuid "publisher_preference_id", null: false
+    t.uuid "school_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["publisher_preference_id"], name: "index_local_authority_publisher_schools_publisher_preference_id"
@@ -377,16 +377,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_25_115029) do
   end
 
   create_table "organisation_publisher_preferences", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "organisation_id"
-    t.uuid "publisher_preference_id"
+    t.uuid "organisation_id", null: false
+    t.uuid "publisher_preference_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["publisher_preference_id"], name: "index_organisation_publisher_preferences_publisher_preference_i"
   end
 
   create_table "organisation_publishers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "organisation_id"
-    t.uuid "publisher_id"
+    t.uuid "organisation_id", null: false
+    t.uuid "publisher_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["organisation_id"], name: "index_organisation_publishers_organisation_id"
@@ -394,8 +394,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_25_115029) do
   end
 
   create_table "organisation_vacancies", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "organisation_id"
-    t.uuid "vacancy_id"
+    t.uuid "organisation_id", null: false
+    t.uuid "vacancy_id", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["organisation_id", "vacancy_id"], name: "index_organisation_vacancies_on_organisation_id_and_vacancy_id", unique: true
@@ -459,8 +459,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_25_115029) do
   end
 
   create_table "publisher_preferences", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "publisher_id"
-    t.uuid "organisation_id"
+    t.uuid "publisher_id", null: false
+    t.uuid "organisation_id", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["organisation_id"], name: "index_publisher_preferences_on_organisation_id"
@@ -523,8 +523,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_25_115029) do
   end
 
   create_table "saved_jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "jobseeker_id"
-    t.uuid "vacancy_id"
+    t.uuid "jobseeker_id", null: false
+    t.uuid "vacancy_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["jobseeker_id"], name: "index_saved_jobs_on_jobseeker_id"
@@ -532,8 +532,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_25_115029) do
   end
 
   create_table "school_group_memberships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "school_id"
-    t.uuid "school_group_id"
+    t.uuid "school_id", null: false
+    t.uuid "school_group_id", null: false
     t.boolean "do_not_delete"
     t.datetime "created_at"
     t.datetime "updated_at"

--- a/spec/services/publishers/vacancies/vacancy_step_process_spec.rb
+++ b/spec/services/publishers/vacancies/vacancy_step_process_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Publishers::Vacancies::VacancyStepProcess do
   let(:current_step) { :job_role }
 
   let(:vacancy) { build_stubbed(:vacancy, :draft, :teacher) }
-  let(:organisation) { build_stubbed(:school) }
+  let(:organisation) { build(:school) }
 
   describe "#step_groups" do
     let(:all_possible_step_groups) { %i[job_details important_dates application_process about_the_role review] }


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/ZFVIvvfF

## Changes in this PR:
Tons of migrations adding not null restrictions to attributes.

Mainly needed to match rails ActiveRecord "presence" validations or "belongs_to" associations.

I have checked in the production console one by one that no table currently violates the constraint. So it should be migrated without issues.

The format of the migrations is as follows:
- Defining a constraint.
- Validating the constraint
- Changing the column to NOT NULL.
- Removing the constraint

This avoids locking the tables while the `NOT NULL` is applied.
