### PR TITLE
Align PostgreSQL QA/Review version with other envs

### DIFF
--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -72,7 +72,7 @@ variable "paas_logging_service_binding_enable" {
 }
 
 variable "paas_postgres_service_plan" {
-  default = "tiny-unencrypted-11"
+  default = "tiny-unencrypted-12"
 }
 
 variable "paas_redis_cache_service_plan" {

--- a/terraform/workspace-variables/qa.tfvars.json
+++ b/terraform/workspace-variables/qa.tfvars.json
@@ -18,7 +18,7 @@
   "paas_app_start_timeout": "180",
   "paas_app_stopped": false,
   "paas_logging_service_binding_enable": false,
-  "paas_postgres_service_plan": "tiny-unencrypted-11",
+  "paas_postgres_service_plan": "tiny-unencrypted-12",
   "paas_redis_cache_service_plan": "micro-5_x",
   "paas_redis_queue_service_plan": "micro-5_x",
   "paas_space_name": "teaching-vacancies-dev",

--- a/terraform/workspace-variables/review.tfvars.json
+++ b/terraform/workspace-variables/review.tfvars.json
@@ -7,7 +7,7 @@
   "paas_app_start_timeout": "180",
   "paas_app_stopped": false,
   "paas_logging_service_binding_enable": true,
-  "paas_postgres_service_plan": "tiny-unencrypted-11",
+  "paas_postgres_service_plan": "tiny-unencrypted-12",
   "paas_redis_cache_service_plan": "micro-5_x",
   "paas_redis_queue_service_plan": "micro-5_x",
   "paas_space_name": "teaching-vacancies-review",


### PR DESCRIPTION
Development/Staging/Prod use PostgreSQL 12, while our review apps and QA environments run over PostgreSQL 11 instances.

This caused some issues with different safety migration tool check outputs in the review app environment.
