### PR TITLE
Links & URL tidy up for job share, flexible and term time filters

### DIFF
--- a/config/landing_pages.yml
+++ b/config/landing_pages.yml
@@ -158,6 +158,15 @@ shared:
   part-time-school-jobs:
     working_patterns:
       - part_time
+  school-job-shares:
+    working_patterns:
+      - part_time
+  school-term-time-jobs:
+    working_patterns:
+      - part_time
+  flexible-working-jobs-in-schools:
+    working_patterns:
+      - part_time
 
 ####################################################################################################
 # The data below is only used in automated tests, make sure you add your landing pages to the

--- a/config/landing_pages.yml
+++ b/config/landing_pages.yml
@@ -152,19 +152,10 @@ shared:
       - Spanish
 
   ### Working patterns
-  flexible-working-jobs-in-schools:
-    working_patterns:
-      - part_time
   full-time-school-jobs:
     working_patterns:
       - full_time
   part-time-school-jobs:
-    working_patterns:
-      - part_time
-  school-job-shares:
-    working_patterns:
-      - part_time
-  school-term-time-jobs:
     working_patterns:
       - part_time
 

--- a/config/locales/landing_pages.yml
+++ b/config/locales/landing_pages.yml
@@ -232,6 +232,11 @@ en:
       meta_description: "Search for Spanish teacher jobs near you on Teaching Vacancies. Find the latest full time and part time jobs for spanish teachers in schools across England."
 
     ### Working patterns
+    flexible-working-jobs-in-schools:
+      name: "Flexible working"
+      title: "Flexible Working Jobs in Schools"
+      heading: "%{count} flexible working jobs in schools"
+      meta_description: "The latest jobs in schools near you that offer flexible working. Find roles that allow you to work varied hours to suit your individual circumstances."
     full-time-school-jobs:
       name: "Full time"
       title: "Full Time Jobs in Schools"
@@ -242,6 +247,16 @@ en:
       title: "Part Time Teaching & School Jobs"
       heading: "%{count} part time teacher and school jobs"
       meta_description: "Find and apply for part time teacher jobs near you. Discover jobs in local schools that offer flexible hours for teachers, teaching assistants and more."
+    school-job-shares:
+      name: "Job share"
+      title: "Job Shares for Teachers & School Staff"
+      heading: "%{count} job share vacancies for teachers and school staff"
+      meta_description: "Find a school job that works with your schedule. Apply on Teaching Vacancies for job share jobs for teachers, headteachers and teaching assistants."
+    school-term-time-jobs:
+      name: "Term time"
+      title: "School Term Time Jobs"
+      heading: "%{count} school term time jobs"
+      meta_description: "Looking for work that fits around school term time? Discover hundreds of term time only jobs in schools near you on Teaching Vacancies."
 
     ################################################################################################
     # The following fake landing page is used in automated tests, please don't remove it and make

--- a/spec/system/jobseekers_can_view_a_vacancy_spec.rb
+++ b/spec/system/jobseekers_can_view_a_vacancy_spec.rb
@@ -41,6 +41,8 @@ RSpec.describe "Viewing a single published vacancy" do
       let(:vacancy) { create(:vacancy, organisations: [school], working_patterns: %w[full_time part_time]) }
 
       scenario "the page contains correct JobPosting schema.org mark up" do
+        expect(page).to have_link "View all Full timejobs"
+        expect(page).to have_link "View all Part timejobs"
         expect(script_tag_content(wrapper_class: ".jobref"))
           .to eq(vacancy_json_ld(VacancyPresenter.new(vacancy)).to_json)
       end


### PR DESCRIPTION
https://trello.com/c/DRQbSwpj/466-links-url-tidy-up-for-job-share-flexible-and-term-time-filters

## Changes in this PR:

This PR fixes the following issues:
1. Translation missing when a user views a vacancy with a part time working pattern. This was because of the change to `config/landing_pages.yml`. 
2. Translation missing in the chrome tab.
3. Google search results were showing translation errors because we removed translations for the removed working pattern filters. I have added these translations back in just so that google results won't show these errors.

## Screenshots of UI changes:

### Before
![pr1](https://github.com/DFE-Digital/teaching-vacancies/assets/13124899/4eb43724-86a7-43a8-99f7-81c798781821)
![pr2](https://github.com/DFE-Digital/teaching-vacancies/assets/13124899/2e037e5a-4ae0-4be8-82a4-4e86ab76767c)
![Screenshot 2023-08-03 at 15 53 36](https://github.com/DFE-Digital/teaching-vacancies/assets/13124899/6a2408f5-925a-43cf-a60a-bc72a9b54d21)



### After
![Screenshot 2023-08-03 at 15 49 50](https://github.com/DFE-Digital/teaching-vacancies/assets/13124899/1b7a0765-765a-4f78-a70f-f47a53a2c8b9)
![Screenshot 2023-08-03 at 15 51 47](https://github.com/DFE-Digital/teaching-vacancies/assets/13124899/d0f43f17-df63-44a1-9949-f952169776bb)
![Screenshot 2023-08-03 at 15 58 12](https://github.com/DFE-Digital/teaching-vacancies/assets/13124899/baf70cb6-6c50-42a8-9fe6-b9ad442287fc)

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
