### PR TITLE
Fix workflow PR number brakets

### DIFF
--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -63,7 +63,7 @@ jobs:
 
     - name: check review status
       run: |
-        HTTP_CODE=$(curl -o/dev/null -s -w "%{http_code}" https://teaching-vacancies-review-pr-${env.PR_NUMBER}.london.cloudapps.digital)
+        HTTP_CODE=$(curl -o/dev/null -s -w "%{http_code}" https://teaching-vacancies-review-pr-${{env.PR_NUMBER}}.london.cloudapps.digital)
         echo "HTTP_CODE=$HTTP_CODE"  >> $GITHUB_ENV
 
     - name: Exit whole workflow if wait was not successful and review app is not up
@@ -99,12 +99,12 @@ jobs:
     - name: Terraform destroy (on PR closed)
       run: |
         export TF_VAR_environment=${{env.ENVIRONMENT}}
-        terraform init -reconfigure -input=false -backend-config="key=review/review-pr-${env.PR_NUMBER}.tfstate"
+        terraform init -reconfigure -input=false -backend-config="key=review/review-pr-${{env.PR_NUMBER}}.tfstate"
         terraform destroy -var-file ../workspace-variables/review.tfvars.json -auto-approve
       working-directory: terraform/app
 
     - name: Delete Terraform Statefile
-      run: ./bin/delete-state-file ${env.PR_NUMBER}
+      run: ./bin/delete-state-file ${{env.PR_NUMBER}}
 
     - name: Post sticky pull request comment
       uses: marocchino/sticky-pull-request-comment@v2
@@ -121,7 +121,7 @@ jobs:
         SLACK_ICON_EMOJI: ':cry:'
         SLACK_TITLE: Delete review app failure
         SLACK_MESSAGE: |
-          Failed deletion of review app PR ${env.PR_NUMBER}
+          Failed deletion of review app PR ${{env.PR_NUMBER}}
           See: <${{ env.LINK_TO_RUN }}|Workflow run> - <${{ env.LINK_TO_PR }}|Pull request> - <${{ env.LINK_TO_APP }}|Review app>
           <!channel>
         SLACK_WEBHOOK: ${{env.SLACK_WEBHOOK}}


### PR DESCRIPTION
Now that is called through `ENV`, needs `${{` access rather than `${`