### PR TITLE
Add incremental backoff blocking to Rack::Attack

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -14,7 +14,11 @@ Rack::Attack.throttled_responder = lambda do |_request|
 end
 
 # Throttle general requests by IP
-Rack::Attack.throttle("requests by remote ip", limit: 10, period: 4, &:remote_ip)
+Rack::Attack.throttle("requests by remote ip per 4 secs", limit: 10, period: 4, &:remote_ip) # Allow 10 requests in 4 seconds (2.5 req/sec)
+Rack::Attack.throttle("requests by remote ip per minute", limit: 105, period: 60, &:remote_ip) # Allow 105 requests in 1 minute (1.75 req/sec over 1 minute)
+Rack::Attack.throttle("requests by remote ip per 10 minutes", limit: 900, period: 600, &:remote_ip) # Allow 900 requests in 10 minutes (1.5 req/sec over 10 minutes)
+Rack::Attack.throttle("requests by remote ip per hour", limit: 4500, period: 3600, &:remote_ip) # Allow 4500 requests in 1 hour (1.25 req/sec over an hour)
+Rack::Attack.throttle("requests by remote ip per 12 hours", limit: 43_200, period: 43_200, &:remote_ip) # Allow 43200 requests in 12 hours (1 req/sec over 12 hours)
 
 # Throttle login/password reset attempts for jobseekers by IP
 Rack::Attack.throttle("limit jobseeker logins/password resets by IP", limit: 5, period: 60) do |request|


### PR DESCRIPTION
Throttling the connections per 4 seconds was enough for normal use cases, but some uncontrolled spider bot triggers this multiple times within a second (every 0.1 sec or less) to the point that this clogs our logs and servers.

These changes enable incremental backoff blocking. When it increases, a higher limit will be blocked for the rest of the period during the rule and incrementally per period rule.

The allowed requests per period and second on each period are quite generous.

Aiming to mitigate the current service instance crashes due to high traffic created by a bot.

Inspired by [exponential backoff example config](https://github.com/rack/rack-attack/blob/main/docs/advanced_configuration.md#exponential-backoff)