### PR TITLE
Add IP blocking to Rack Attack

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -5,6 +5,11 @@ class Rack::Attack
       @remote_ip ||= (env["action_dispatch.remote_ip"] || ip).to_s
     end
   end
+
+  BLOCKED_IPS = ENV.fetch("RACK_ATTACK_BLOCKED_IPS", "").split(",").map(&:strip).freeze # Array of IPs to block
+  blocklist("block all request from a banned list of remote IPs") do |request|
+    BLOCKED_IPS.include?(request.remote_ip)
+  end
 end
 
 # Override response to return 204 No Content (instead of 429) so our monitoring doesn't count it


### PR DESCRIPTION
The list of IPs to block is configurable through an ENV variable. Any IP listed there will have all its incoming traffic to the service blocked through Rack Attack.


Adding this capability to block a spider bot flooding our services with continuous requests (multiple per millisecond) 24/7 and hasn't modified its request rate even when we added extended throttling periods.