### PR TITLE
Allow downloading job alert and general feedback data by date range

### DIFF
--- a/app/views/support_users/feedbacks/general.html.slim
+++ b/app/views/support_users/feedbacks/general.html.slim
@@ -8,5 +8,5 @@
 
 .govuk-grid-row
   .govuk-grid-column-full = render "tables"
-
-= link_to "Download general feedback report", support_users_feedback_general_path(format: :csv, reporting_period_from: @reporting_period.from.to_s, reporting_period_to: @reporting_period.to.to_s)
+- download_params = { reporting_period: { from: @reporting_period.from, to: @reporting_period.to }, format: :csv }
+= link_to "Download general feedback report", support_users_feedback_general_path(download_params)

--- a/app/views/support_users/feedbacks/job_alerts.html.slim
+++ b/app/views/support_users/feedbacks/job_alerts.html.slim
@@ -3,5 +3,5 @@
 = render "tabs"
 = render "reporting_period_control"
 = render "tables", table_name: "job_alerts_feedback_table"
-
-= link_to "Download job alerts feedback report", support_users_feedback_job_alerts_path(format: :csv, reporting_period_from: @reporting_period.from.to_s, reporting_period_to: @reporting_period.to.to_s)
+- download_params = { reporting_period: { from: @reporting_period.from, to: @reporting_period.to }, format: :csv }
+= link_to "Download job alerts feedback report", support_users_feedback_job_alerts_path(download_params)

--- a/spec/system/support_users/feedback_spec.rb
+++ b/spec/system/support_users/feedback_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Feedback supportal section" do
       comment: "Highly satisfactory",
       occupation: "Student",
       rating: "highly_satisfied",
-      email: "faketestingemail@someemail.com",
+      email: "goodnews@someemail.com",
       user_participation_response: "interested",
       origin_path: "/jobs",
       created_at: "2022-03-16 10:00",
@@ -118,6 +118,15 @@ RSpec.describe "Feedback supportal section" do
       click_link "Download general feedback report"
       expect(csv.first).to eq ["Created at", "Source", "Who", "Type", "Origin path", "Contact email", "Occupation", "CSAT", "Comment", "Category"]
       expect(csv.second).to eq [other_feedback.created_at.to_s, "identified", "jobseeker", other_feedback.feedback_type, other_feedback.origin_path, other_feedback.email, other_feedback.occupation, other_feedback.rating, other_feedback.comment, other_feedback.category]
+      created_at_dates = csv.map(&:first).drop(1)
+
+      are_all_created_at_dates_after_target = created_at_dates.all? do |date|
+        date_parsed = Date.strptime(date.split.first, "%Y-%m-%d")
+        Date.current.beginning_of_month
+        date_parsed < Date.current.end_of_month
+      end
+
+      expect(are_all_created_at_dates_after_target).to eq(true)
     end
 
     it "allows user to download data for a specific date range" do
@@ -127,6 +136,15 @@ RSpec.describe "Feedback supportal section" do
       click_link "Download general feedback report"
       expect(csv.first).to eq ["Created at", "Source", "Who", "Type", "Origin path", "Contact email", "Occupation", "CSAT", "Comment", "Category"]
       expect(csv.second).to eq [old_general_feedback.created_at.to_s, "identified", "jobseeker", old_general_feedback.feedback_type, old_general_feedback.origin_path, old_general_feedback.email, old_general_feedback.occupation, old_general_feedback.rating, old_general_feedback.comment, old_general_feedback.category]
+
+      created_at_dates = csv.map(&:first).drop(1)
+      are_all_created_at_dates_after_target = created_at_dates.all? do |date|
+        date_parsed = Date.strptime(date.split.first, "%Y-%m-%d")
+        Date.new(2022, 3, 15)
+        date_parsed < Date.new(2022, 3, 21)
+      end
+
+      expect(are_all_created_at_dates_after_target).to eq(true)
     end
 
     it "shows feedback table" do
@@ -188,6 +206,15 @@ RSpec.describe "Feedback supportal section" do
       click_link "Download job alerts feedback report"
       expect(csv.first).to eq ["Timestamp", "Relevant?", "Comment", "Criteria", "Keyword", "Location", "Radius", "Working patterns", "Category"]
       expect(csv.second).to eq [job_alert_feedback.created_at.to_s, job_alert_feedback.relevant_to_user, job_alert_feedback.comment, "[]", nil, nil, nil, nil, job_alert_feedback.category]
+
+      created_at_dates = csv.map(&:first).drop(1)
+      are_all_created_at_dates_after_target = created_at_dates.all? do |date|
+        date_parsed = Date.strptime(date.split.first, "%Y-%m-%d")
+        Date.current.beginning_of_month
+        date_parsed < Date.current.end_of_month
+      end
+
+      expect(are_all_created_at_dates_after_target).to eq(true)
     end
 
     it "allows user to download data for a specific date range" do
@@ -197,6 +224,15 @@ RSpec.describe "Feedback supportal section" do
       click_link "Download job alerts feedback report"
       expect(csv.first).to eq ["Timestamp", "Relevant?", "Comment", "Criteria", "Keyword", "Location", "Radius", "Working patterns", "Category"]
       expect(csv.second).to eq [old_job_alert_feedback.created_at.to_s, old_job_alert_feedback.relevant_to_user, old_job_alert_feedback.comment, "[]", nil, nil, nil, nil, old_job_alert_feedback.category]
+
+      created_at_dates = csv.map(&:first).drop(1)
+      are_all_created_at_dates_after_target = created_at_dates.all? do |date|
+        date_parsed = Date.strptime(date.split.first, "%Y-%m-%d")
+        Date.new(2022, 3, 15)
+        date_parsed < Date.new(2022, 3, 21)
+      end
+
+      expect(are_all_created_at_dates_after_target).to eq(true)
     end
   end
 

--- a/spec/system/support_users/feedback_spec.rb
+++ b/spec/system/support_users/feedback_spec.rb
@@ -48,6 +48,30 @@ RSpec.describe "Feedback supportal section" do
       origin_path: "/jobs",
     )
   end
+
+  let!(:old_general_feedback) do
+    create(
+      :feedback,
+      feedback_type: :general,
+      comment: "Some other feedback text",
+      occupation: "Student",
+      rating: "highly_satisfied",
+      email: "faketestingemail@someemail.com",
+      user_participation_response: "interested",
+      origin_path: "/jobs",
+      created_at: "2022-03-16 10:00"
+    )
+  end
+
+  let!(:old_job_alert_feedback) do
+    create(
+      :feedback,
+      feedback_type: :job_alert,
+      comment: "Some job alert feedback text",
+      occupation: "Teacher",
+      created_at: "2022-03-17 10:00"
+    )
+  end
   let(:csv) { CSV.parse(page.body) }
 
   before do
@@ -94,6 +118,15 @@ RSpec.describe "Feedback supportal section" do
       click_link "Download general feedback report"
       expect(csv.first).to eq ["Created at", "Source", "Who", "Type", "Origin path", "Contact email", "Occupation", "CSAT", "Comment", "Category"]
       expect(csv.second).to eq [other_feedback.created_at.to_s, "identified", "jobseeker", other_feedback.feedback_type, other_feedback.origin_path, other_feedback.email, other_feedback.occupation, other_feedback.rating, other_feedback.comment, other_feedback.category]
+    end
+
+    it "allows user to download data for a specific date range" do
+      fill_in "From", with: "2022-03-15"
+      fill_in "To", with: "2022-03-21"
+      click_on "Go"
+      click_link "Download general feedback report"
+      expect(csv.first).to eq ["Created at", "Source", "Who", "Type", "Origin path", "Contact email", "Occupation", "CSAT", "Comment", "Category"]
+      expect(csv.second).to eq [old_general_feedback.created_at.to_s, "identified", "jobseeker", old_general_feedback.feedback_type, old_general_feedback.origin_path, old_general_feedback.email, old_general_feedback.occupation, old_general_feedback.rating, old_general_feedback.comment, old_general_feedback.category]
     end
 
     it "shows feedback table" do
@@ -155,6 +188,15 @@ RSpec.describe "Feedback supportal section" do
       click_link "Download job alerts feedback report"
       expect(csv.first).to eq ["Timestamp", "Relevant?", "Comment", "Criteria", "Keyword", "Location", "Radius", "Working patterns", "Category"]
       expect(csv.second).to eq [job_alert_feedback.created_at.to_s, job_alert_feedback.relevant_to_user, job_alert_feedback.comment, "[]", nil, nil, nil, nil, job_alert_feedback.category]
+    end
+
+    it "allows user to download data for a specific date range" do
+      fill_in "From", with: "2022-03-15"
+      fill_in "To", with: "2022-03-21"
+      click_on "Go"
+      click_link "Download job alerts feedback report"
+      expect(csv.first).to eq ["Timestamp", "Relevant?", "Comment", "Criteria", "Keyword", "Location", "Radius", "Working patterns", "Category"]
+      expect(csv.second).to eq [old_job_alert_feedback.created_at.to_s, old_job_alert_feedback.relevant_to_user, old_job_alert_feedback.comment, "[]", nil, nil, nil, nil, old_job_alert_feedback.category]
     end
   end
 

--- a/spec/system/support_users/feedback_spec.rb
+++ b/spec/system/support_users/feedback_spec.rb
@@ -53,13 +53,13 @@ RSpec.describe "Feedback supportal section" do
     create(
       :feedback,
       feedback_type: :general,
-      comment: "Some other feedback text",
+      comment: "Highly satisfactory",
       occupation: "Student",
       rating: "highly_satisfied",
       email: "faketestingemail@someemail.com",
       user_participation_response: "interested",
       origin_path: "/jobs",
-      created_at: "2022-03-16 10:00"
+      created_at: "2022-03-16 10:00",
     )
   end
 
@@ -67,9 +67,9 @@ RSpec.describe "Feedback supportal section" do
     create(
       :feedback,
       feedback_type: :job_alert,
-      comment: "Some job alert feedback text",
+      comment: "Oh wow!",
       occupation: "Teacher",
-      created_at: "2022-03-17 10:00"
+      created_at: "2022-03-17 10:00",
     )
   end
   let(:csv) { CSV.parse(page.body) }


### PR DESCRIPTION
https://trello.com/c/WHuTu8TM/504-fix-download-function-on-supportal

## Changes in this PR:

Allow users to download general and job alert feedback using the date ranges provided.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
