### PR TITLE
Increase ruby docker alpine image version

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -155,7 +155,6 @@ jobs:
         run: echo "MATRIX_ENVIRONMENTS={\"environment\":[\"review\"]}" >> $GITHUB_ENV
 
       - name: Scan ${{ env.DOCKER_REPOSITORY }}:${{ env.DOCKER_IMAGE_TAG }} image
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           docker run -t -e "SNYK_TOKEN=${{ env.SNYK_TOKEN }}" \
             -v "/var/run/docker.sock:/var/run/docker.sock" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG PROD_PACKAGES="imagemagick libxml2 libxslt libpq tzdata shared-mime-info"
 
-FROM ruby:3.2.2-alpine3.16 AS builder
+FROM ruby:3.2.2-alpine3.18 AS builder
 
 WORKDIR /app
 
@@ -44,7 +44,7 @@ RUN rm -rf node_modules log tmp yarn.lock && \
 
 
 # this stage reduces the image size.
-FROM ruby:3.2.2-alpine3.16 AS production
+FROM ruby:3.2.2-alpine3.18 AS production
 
 WORKDIR /app
 


### PR DESCRIPTION
The previous version fails security checks on deployment due to a vulnerability in its PostgreSQL version.

It also ensures the Docker Image security scan runs in every image build, so we can detect & test fixes on security issues at Pull Request & Review app level, not only when we merge the PR in production.