### PR TITLE
Update data sent to Big Query

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -1,5 +1,22 @@
 # This file lists all the attributes to be exported, including those to be anonymised.
 shared:
+  :active_storage_attachments:
+    - id
+    - name
+    - record_type
+    - record_id
+    - blob_id
+    - created_at
+  :active_storage_blobs:
+    - id
+    - key
+    - filename
+    - content_type
+    - metadata
+    - service_name
+    - byte_size
+    - checksum
+    - created_at
   employments:
     - id
     - employment_type
@@ -171,6 +188,18 @@ shared:
     - created_at
     - updated_at
     - account_closed_on
+  job_preferences:
+    - id
+    - roles
+    - phases
+    - key_stages
+    - subjects
+    - working_patterns
+    - completed_steps
+    - builder_completed
+    - created_at
+    - updated_at
+    - jobseeker_profile_id
   local_authority_publisher_schools:
     - id
     - publisher_preference_id

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -26,23 +26,6 @@
   - id
   - blob_id
   - variation_digest
-  :active_storage_attachments:
-  - id
-  - name
-  - record_type
-  - record_id
-  - blob_id
-  - created_at
-  :active_storage_blobs:
-  - id
-  - key
-  - filename
-  - content_type
-  - metadata
-  - service_name
-  - byte_size
-  - checksum
-  - created_at
   :school_group_memberships:
   - do_not_delete
   :references:
@@ -151,18 +134,6 @@
   - last_sign_in_ip_ciphertext
   - last_sign_in_ip
   - current_sign_in_ip
-  :job_preferences:
-  - id
-  - roles
-  - phases
-  - key_stages
-  - subjects
-  - working_patterns
-  - completed_steps
-  - builder_completed
-  - created_at
-  - updated_at
-  - jobseeker_profile_id
   :organisations:
   - gias_data_hash
   - slug


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/ECSUc6PZ/498-pulling-over-data-to-bq

## Changes in this PR:

This Pull Request address lack of data for Job Preferences and Attachments (specifically logos for Organisations)
There is no personal data being streamed to Big Query as consequence of this PR.

It's worth highlighting how we're not streaming the actual attachment file (stored in S3) but just the metadata associated with it per record. 
