### PR TITLE
[530] Deploy AKS postgres using paas terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ terraform.tfstate.d/
 .terraform/
 .terraform.tfstate.lock.info
 terraform/aks/vendor
+terraform/app/vendor/
 terraform/domains/environment_domains/vendor
 terraform.tfstate*
 tokens

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,8 @@ review: ## review # Requires `pr_id=NNNN`
 		$(eval var_file=review)
 		$(eval backend_config=-backend-config="key=review/$(env).tfstate")
 
+		$(eval include global_config/review.sh)
+
 .PHONY: review_aks
 review_aks:
 	$(eval include global_config/review.sh)
@@ -171,8 +173,15 @@ ci:	## Run in automation environment
 	$(eval export AUTO_APPROVE=-auto-approve)
 
 .PHONY: terraform-app-init
-terraform-app-init:
-		terraform -chdir=terraform/app init -reconfigure -input=false $(backend_config)
+terraform-app-init: bin/terrafile set-azure-account
+	./bin/terrafile -p terraform/app/vendor/modules -f terraform/workspace-variables/$(var_file)_Terrafile
+	terraform -chdir=terraform/app init -reconfigure -input=false $(backend_config)
+
+	$(eval export TF_VAR_azure_resource_prefix=${AZURE_RESOURCE_PREFIX})
+	$(eval export TF_VAR_config_short=${CONFIG_SHORT})
+	$(eval export TF_VAR_service_name=${SERVICE_NAME})
+	$(eval export TF_VAR_service_short=${SERVICE_SHORT})
+
 
 .PHONY: terraform-app-plan
 terraform-app-plan: terraform-app-init check-terraform-variables ## make passcode=MyPasscode tag=dev-08406f04dd9eadb7df6fcda5213be880d7df37ed-20201022090714 <env> terraform-app-plan

--- a/terraform/app/.terraform.lock.hcl
+++ b/terraform/app/.terraform.lock.hcl
@@ -45,6 +45,63 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version = "3.70.0"
+  hashes = [
+    "h1:8wMNNHTEVr3dKPdDfIjDhXdymCc9L65MlYZLZivzzo0=",
+    "zh:0b8a1fdce4406e066ad3f4cfe7217cdde83ff980c9d145dcea3de715b211bd46",
+    "zh:0cd04221c0242c579a4ab27aeb6f4d97cff26a23e8863d38d32c06a339791356",
+    "zh:4afa2e6d89f9e352402caee1a93ebe239218fb54c761d3170ed6acb70929455d",
+    "zh:62ba9870786632150ea806fa3e034fa4f822b8f4d17422033b21ed98001994cf",
+    "zh:762502f741936f4831692b32e7fe2f665001eec83cd18e65804fa04a02a0a311",
+    "zh:887c0e35e79fdb4a6740c232c683adc5344067f0297c28646d6f811b33501c6c",
+    "zh:927baea8f6a399782c9f53f8035f8abe306cdde2382b31ab982a0b5a975a98ab",
+    "zh:9d10f8821b23c331cb39fa275aaa298968344a7849ca72dc5dc7d6c04b4df4ec",
+    "zh:a6d907e78f78dc944c941d9853836b08f1402727026f9b9183a33f4302e39e1b",
+    "zh:a8f81fd109c3e0e662a0067cc5a2d4828f4906c07cb05d8e91a1c5b3fa09818f",
+    "zh:ba89168e9ca8144c84503071fe0498cced288965314cba40962a6b71cfcd5a4b",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version = "2.23.0"
+  hashes = [
+    "h1:cMs2scNCSgQhGamomGT5Ag4i8ms/mql1AR7NJc2hmbA=",
+    "zh:10488a12525ed674359585f83e3ee5e74818b5c98e033798351678b21b2f7d89",
+    "zh:1102ba5ca1a595f880e67102bbf999cc8b60203272a078a5b1e896d173f3f34b",
+    "zh:1347cf958ed3f3f80b3c7b3e23ddda3d6c6573a81847a8ee92b7df231c238bf6",
+    "zh:2cb18e9f5156bc1b1ee6bc580a709f7c2737d142722948f4a6c3c8efe757fa8d",
+    "zh:5506aa6f28dcca2a265ccf8e34478b5ec2cb43b867fe6d93b0158f01590fdadd",
+    "zh:6217a20686b631b1dcb448ee4bc795747ebc61b56fbe97a1ad51f375ebb0d996",
+    "zh:8accf916c00579c22806cb771e8909b349ffb7eb29d9c5468d0a3f3166c7a84a",
+    "zh:9379b0b54a0fa030b19c7b9356708ec8489e194c3b5e978df2d31368563308e5",
+    "zh:aa99c580890691036c2931841e88e7ee80d59ae52289c8c2c28ea0ac23e31520",
+    "zh:c57376d169875990ac68664d227fb69cd0037b92d0eba6921d757c3fd1879080",
+    "zh:e6068e3f94f6943b5586557b73f109debe19d1a75ca9273a681d22d1ce066579",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.5.1"
+  hashes = [
+    "h1:sZ7MTSD4FLekNN2wSNFGpM+5slfvpm5A/NLVZiB7CO0=",
+    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
+    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
+    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
+    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
+    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
+    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
+    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
+    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
+    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
+    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
+  ]
+}
+
 provider "registry.terraform.io/statuscakedev/statuscake" {
   version     = "2.0.4"
   constraints = "2.0.4"

--- a/terraform/app/cluster_data.tf
+++ b/terraform/app/cluster_data.tf
@@ -1,0 +1,4 @@
+module "cluster_data" {
+  source = "./vendor/modules/aks//aks/cluster_data"
+  name   = var.cluster
+}

--- a/terraform/app/modules/paas/aks_cluster_data.tf
+++ b/terraform/app/modules/paas/aks_cluster_data.tf
@@ -1,0 +1,4 @@
+module "cluster_data" {
+  source = "../../vendor/modules/aks//aks/cluster_data"
+  name   = var.cluster
+}

--- a/terraform/app/modules/paas/aks_database.tf
+++ b/terraform/app/modules/paas/aks_database.tf
@@ -1,0 +1,13 @@
+module "postgres" {
+  source = "../../vendor/modules/aks//aks/postgres"
+
+  namespace                   = var.namespace
+  environment                 = var.environment
+  azure_resource_prefix       = var.azure_resource_prefix
+  service_name                = var.service_name
+  service_short               = var.service_short
+  config_short                = var.config_short
+  cluster_configuration_map   = module.cluster_data.configuration_map
+  use_azure                   = var.deploy_azure_backing_services
+  azure_enable_backup_storage = var.azure_enable_backup_storage
+}

--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -98,7 +98,31 @@ variable "restore_from_db_guid" {
 variable "db_backup_before_point_in_time" {
 
 }
+variable "azure_enable_backup_storage" {
+  default     = true
+  description = "Create storage account for database backup"
+}
 
+# AKS
+variable "namespace" {
+  description = "AKS namespace where this app is deployed"
+}
+variable "azure_resource_prefix" {
+  description = "Standard resource prefix. Usually s189t01 (test) or s189p01 (production)"
+}
+variable "config_short" {
+  description = "Short name of the environment configuration, e.g. dv, st, pd..."
+}
+variable "service_short" {
+  description = "Short name to identify the service. Up to 6 charcters."
+}
+variable "deploy_azure_backing_services" {
+  default     = true
+  description = "Deploy real Azure backing services like databases, as opposed to containers inside of AKS"
+}
+variable "cluster" {
+  description = "AKS cluster where this app is deployed. Either 'test' or 'production'"
+}
 
 locals {
   app_env_api_keys = merge(

--- a/terraform/app/provider.tf
+++ b/terraform/app/provider.tf
@@ -14,3 +14,19 @@ provider "aws" {
   alias  = "aws_us_east_1"
   region = "us-east-1"
 }
+provider "azurerm" {
+  features {}
+
+  skip_provider_registration = true
+  subscription_id            = try(local.azure_credentials.subscriptionId, null)
+  client_id                  = try(local.azure_credentials.clientId, null)
+  client_secret              = try(local.azure_credentials.clientSecret, null)
+  tenant_id                  = try(local.azure_credentials.tenantId, null)
+}
+
+provider "kubernetes" {
+  host                   = module.cluster_data.kubernetes_host
+  client_certificate     = module.cluster_data.kubernetes_client_certificate
+  client_key             = module.cluster_data.kubernetes_client_key
+  cluster_ca_certificate = module.cluster_data.kubernetes_cluster_ca_certificate
+}

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -94,6 +94,13 @@ module "paas" {
   db_backup_before_point_in_time               = var.paas_db_backup_before_point_in_time
   documents_s3_bucket_force_destroy            = var.documents_s3_bucket_force_destroy
   schools_images_logos_s3_bucket_force_destroy = var.schools_images_logos_s3_bucket_force_destroy
+  # AKS
+  namespace                     = var.namespace
+  azure_resource_prefix         = var.azure_resource_prefix
+  config_short                  = var.config_short
+  service_short                 = var.service_short
+  deploy_azure_backing_services = var.deploy_azure_backing_services
+  cluster                       = var.cluster
 }
 
 module "statuscake" {

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -132,6 +132,39 @@ variable "statuscake_alerts" {
   default     = {}
 }
 
+# AKS
+variable "cluster" {
+  description = "AKS cluster where this app is deployed. Either 'test' or 'production'"
+}
+variable "enable_monitoring" {
+  default     = false
+  description = "Enable monitoring and alerting"
+}
+variable "deploy_azure_backing_services" {
+  default     = true
+  description = "Deploy real Azure backing services like databases, as opposed to containers inside of AKS"
+}
+variable "azure_enable_backup_storage" {
+  default     = true
+  description = "Create storage account for database backup"
+}
+variable "namespace" {
+  description = "AKS namespace where this app is deployed"
+}
+variable "azure_credentials_json" {
+  default     = null
+  description = "JSON containing the service principal authentication key when running in automation"
+}
+variable "azure_resource_prefix" {
+  description = "Standard resource prefix. Usually s189t01 (test) or s189p01 (production)"
+}
+variable "config_short" {
+  description = "Short name of the environment configuration, e.g. dv, st, pd..."
+}
+variable "service_short" {
+  description = "Short name to identify the service. Up to 6 charcters."
+}
+
 locals {
   paas_api_url         = "https://api.london.cloud.service.gov.uk"
   paas_app_env_values  = yamldecode(file("${path.module}/../workspace-variables/${var.app_environment}_app_env.yml"))
@@ -148,4 +181,7 @@ locals {
       domain   = zone
     }
   }
+
+  # AKS
+  azure_credentials = try(jsondecode(var.azure_credentials_json), null)
 }

--- a/terraform/workspace-variables/review.tfvars.json
+++ b/terraform/workspace-variables/review.tfvars.json
@@ -17,5 +17,10 @@
   "paas_worker_app_deployment_strategy": "blue-green-v2",
   "paas_worker_app_instances": 1,
   "parameter_store_environment": "dev",
-  "region": "eu-west-2"
+  "region": "eu-west-2",
+  "cluster": "test",
+  "namespace": "tv-development",
+  "azure_enable_backup_storage": false,
+  "deploy_azure_backing_services": false,
+  "enable_monitoring": false
 }

--- a/terraform/workspace-variables/review_Terrafile
+++ b/terraform/workspace-variables/review_Terrafile
@@ -1,0 +1,3 @@
+aks:
+    source:  "https://github.com/DFE-Digital/terraform-modules"
+    version: "main"


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/fVBiyDuu

## Changes in this PR:
Refactor AKS code to use the existing paas terraform. This will avoid recreating the existing AWS resources.
This PR deploys postgtes only.
