### PR TITLE
Switch vacancy sources importing errors to once per source and import

### DIFF
--- a/app/jobs/import_from_vacancy_sources_job.rb
+++ b/app/jobs/import_from_vacancy_sources_job.rb
@@ -11,60 +11,68 @@ class ImportFromVacancySourcesJob < ApplicationJob
   def perform
     return if DisableExpensiveJobs.enabled?
 
-    SOURCES.each do |source_klass|
-      import_start_time = Time.zone.now
-
-      source_klass.new.each do |vacancy|
-        PaperTrail.request(whodunnit: "Import from external source") do
-          if vacancy.valid?
-            import_vacancy(source_klass, vacancy)
-          else
-            report_validation_errors(source_klass, vacancy)
-            create_failed_imported_vacancy(source_klass, vacancy)
-          end
-        end
-      end
-
-      Vacancy.live.where(external_source: source_klass.source_name, updated_at: (...import_start_time)).find_each do |v|
-        Rails.logger.info("Set vacancy #{v.id} as removed from external system")
-        v.update_attribute(:status, :removed_from_external_system)
-      end
-    end
+    SOURCES.each { |source_klass| import_from_source(source_klass) }
   end
 
   private
 
-  def import_vacancy(source_klass, vacancy)
-    vacancy.save
-    Rails.logger.info("Imported vacancy #{vacancy.id} from feed #{source_klass.source_name}")
+  def import_from_source(source_klass)
+    source_name = source_klass.source_name
+    import_start_time = Time.zone.now
+    total_count = 0
+    errors = {}
+
+    source_klass.new.each do |vacancy|
+      total_count += 1
+
+      PaperTrail.request(whodunnit: "Import from external source") do
+        if vacancy.save
+          Rails.logger.info("Imported vacancy #{vacancy.id} from feed #{source_name}")
+        else
+          failure = create_failed_imported_vacancy(source_name, vacancy)
+          errors[failure.external_reference] = failure.import_errors
+        end
+      end
+    end
+    report_validation_errors(source_name, total_count, errors)
+    mark_removed_vacancies_from_source(source_name, import_start_time)
   end
 
-  def create_failed_imported_vacancy(source_klass, vacancy)
-    if FailedImportedVacancy.find_by(external_reference: vacancy.external_reference)
-      Rails.logger.info("Vacancy #{vacancy.external_reference} failed to save as its a duplicate")
+  def mark_removed_vacancies_from_source(source_name, import_start_time)
+    Vacancy.live.where(external_source: source_name, updated_at: (...import_start_time)).find_each do |v|
+      Rails.logger.info("Set vacancy #{v.id} as removed from external system")
+      v.update_attribute(:status, :removed_from_external_system)
+    end
+  end
+
+  def create_failed_imported_vacancy(source_name, vacancy)
+    failed_imported_vacancy = FailedImportedVacancy.find_by(external_reference: vacancy.external_reference)
+
+    if failed_imported_vacancy.present?
+      Rails.logger.info("FailedImportedVacancy for #{vacancy.external_reference} from #{source_name} already exists.")
+      failed_imported_vacancy
     else
-      FailedImportedVacancy.create(source: source_klass.source_name,
+      FailedImportedVacancy.create(source: source_name,
                                    external_reference: vacancy.external_reference,
                                    import_errors: vacancy.errors.to_json,
                                    vacancy: vacancy)
     end
   end
 
-  def report_validation_errors(source_klass, vacancy)
-    Sentry.with_scope do |scope|
-      scope.set_tags(
-        source: source_klass.name,
-      )
-      scope.set_context(
-        "Validation errors",
-        vacancy.errors.to_hash,
-      )
-      scope.set_context(
-        "Vacancy data",
-        vacancy.attributes,
-      )
+  def report_validation_errors(source_name, total_count, errors)
+    return if errors.none?
 
-      Sentry.capture_message("Vacancy failed to import", level: :warning)
+    failed_percentage = ((errors.count.to_f / total_count) * 100).round(1)
+    Sentry.with_scope do |scope|
+      scope.set_tags(source: source_name)
+      scope.set_context("Import failure rate", { vacancies_in_feed: total_count,
+                                                 failed_vacancies_to_import: errors.count,
+                                                 failed_percentage: })
+      scope.set_context("Validation errors for each external source reference", errors.to_hash)
+
+      Sentry.capture_message("#{source_name} source: #{failed_percentage}% of vacancies failed to import",
+                             level: :warning,
+                             fingerprint: ["{{ tags.source }}"]) # Groups all the sentry messages for each source
     end
   end
 end


### PR DESCRIPTION
## Trello card URL

## Changes in this PR:

With the increase in the number of external vacancy sources to import from and the increased rate of errors from some of the sources, reporting a new transaction/error to Sentry for each of the failed vacancies on every source and every import run is quickly consuming our Sentry transaction quota.

Even if we increased the quota, this approach does not scale.

Instead, we are going to report a single transaction/error to Sentry, containing data like:
- The total number of vacancies listed in the feed.
- The total number of vacancies that weren't valid/failed.
- The percentage of failed vacancies over the total.
- A list of all the failed external source references, together with
  their validation errors so that we can check the original feed (or the
  ImportedFailedVacancy associated object in our DB) to debug the issue.

This way, we reduce the number of transactions sent to Sentry from hundreds/thousands per hour to 4,5,6.. (the number of different source providers) per hour.
