### PR TITLE
Rephrase the right to work questions

### DIFF
--- a/app/views/jobseekers/job_applications/build/personal_details.html.slim
+++ b/app/views/jobseekers/job_applications/build/personal_details.html.slim
@@ -24,17 +24,10 @@
       = f.govuk_email_field :email_address, value: (form.email_address.presence || job_application.email), label: { size: "s" }, width: "one-half", aria: { required: true }
       = f.govuk_radio_buttons_fieldset :right_to_work_in_uk,
         legend: { text: t("jobseekers.profiles.personal_details.work.page_title"), size: "s" },
-        hint: { text: t("jobseekers.profiles.personal_details.work.hint.text", link: govuk_link_to(t("jobseekers.profiles.personal_details.work.hint.link"), "https://getintoteaching.education.gov.uk/non-uk-teachers/teach-in-england-if-you-trained-overseas", target: "_blank")).html_safe } do
+        hint: { text: t("jobseekers.profiles.personal_details.work.hint.text", link: govuk_link_to(t("jobseekers.profiles.personal_details.work.hint.link"), "https://getintoteaching.education.gov.uk/non-uk-teachers/teach-in-england-if-you-trained-overseas#apply-for-your-visa", target: "_blank")).html_safe } do
 
         = f.govuk_radio_button :right_to_work_in_uk, "yes", label: { text: t("jobseekers.profiles.personal_details.work.options.true") }, link_errors: true
         = f.govuk_radio_button :right_to_work_in_uk, "no", label: { text: t("jobseekers.profiles.personal_details.work.options.false") }
-          p = t("jobseekers.profiles.personal_details.work.unlikely_unless_have_qts")
-          p = t("jobseekers.profiles.personal_details.work.may_be_able_to_apply_for_qts.text", link: govuk_link_to(t("jobseekers.profiles.personal_details.work.may_be_able_to_apply_for_qts.link"), "https://apply-for-qts-in-england.education.gov.uk/eligibility/start", target: "_blank")).html_safe
-          p = t("jobseekers.profiles.personal_details.work.schools_cannot_give_advice.text", link: govuk_link_to(t("jobseekers.profiles.personal_details.work.schools_cannot_give_advice.link"), "https://getintoteaching.education.gov.uk/non-uk-teachers/teach-in-england-if-you-trained-overseas", target: "_blank")).html_safe
-          ul.govuk-list.govuk-list--bullet
-            li = t("jobseekers.profiles.personal_details.work.learn_more.qualifications_and_experience")
-            li = t("jobseekers.profiles.personal_details.work.learn_more.visas")
-            li = t("jobseekers.profiles.personal_details.work.learn_more.other_routes_to_qts")
 
       = f.govuk_text_field :teacher_reference_number, hint: { text: t("helpers.hint.jobseekers_job_application_personal_details_form.teacher_reference_number_html") }, label: { size: "s" }, width: "one-half"
       = f.govuk_text_field :national_insurance_number, label: { size: "s" }, width: "one-half"

--- a/app/views/jobseekers/profiles/personal_details/work.html.slim
+++ b/app/views/jobseekers/profiles/personal_details/work.html.slim
@@ -11,17 +11,10 @@
       = f.govuk_radio_buttons_fieldset :right_to_work_in_uk,
         legend: { text: t(".page_title"), tag: "h1", size: "l" },
         caption: { text: t(".caption"), size: "l" },
-        hint: { text: t(".hint.text", link: govuk_link_to(t(".hint.link"), "https://getintoteaching.education.gov.uk/non-uk-teachers/teach-in-england-if-you-trained-overseas", target: "_blank")).html_safe } do
+        hint: { text: t(".hint.text", link: govuk_link_to(t(".hint.link"), "https://getintoteaching.education.gov.uk/non-uk-teachers/teach-in-england-if-you-trained-overseas#apply-for-your-visa", target: "_blank")).html_safe } do
 
         = f.govuk_radio_button :right_to_work_in_uk, "true", label: { text: t(".options.true") }, link_errors: true
         = f.govuk_radio_button :right_to_work_in_uk, "false", label: { text: t(".options.false") }
-          p = t(".unlikely_unless_have_qts")
-          p = t(".may_be_able_to_apply_for_qts.text", link: govuk_link_to(t(".may_be_able_to_apply_for_qts.link"), "https://apply-for-qts-in-england.education.gov.uk/eligibility/start", target: "_blank")).html_safe
-          p = t(".schools_cannot_give_advice.text", link: govuk_link_to(t(".schools_cannot_give_advice.link"), "https://getintoteaching.education.gov.uk/non-uk-teachers/teach-in-england-if-you-trained-overseas", target: "_blank")).html_safe
-          ul.govuk-list.govuk-list--bullet
-            li = t(".learn_more.qualifications_and_experience")
-            li = t(".learn_more.visas")
-            li = t(".learn_more.other_routes_to_qts")
 
       = f.govuk_submit t("buttons.save_and_continue"), classes: "govuk-!-margin-bottom-5"
 

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -808,7 +808,7 @@ en:
         support_needed: Do you want to ask for support so that you can attend an interview?
       jobseekers_job_application_declarations_form:
         close_relationships: Do you have any family or close relationship with people within %{organisation}?
-        right_to_work_in_uk: Do you have the right to work in the UK?
+        right_to_work_in_uk: Do you currently have the right to work in the UK?
       jobseekers_job_application_details_reference_form:
         phone_number: Phone number
       jobseekers_job_application_employment_history_form:

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -604,7 +604,7 @@ en:
           caption: Personal details
           hint:
             text: If you are a non-UK citizen you will need a visa or immigration status which allows you to work as a teacher in England. Learn more about %{link}
-            link: teaching in England as a non-UK citizen (opens in a new tab).
+            link: teaching in England as a non-UK citizen (opens in new tab).
           learn_more:
             other_routes_to_qts: other routes to QTS
             qualifications_and_experience: the qualifications and experience you’ll need

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -603,8 +603,8 @@ en:
         work:
           caption: Personal details
           hint:
-            text: There is %{link} if you qualified outside the UK.
-            link: guidance for working as a teacher in England (link opens in a new tab)
+            text: If you are a non-UK citizen you will need a visa or immigration status which allows you to work as a teacher in England. Learn more about %{link}
+            link: teaching in England as a non-UK citizen.
           learn_more:
             other_routes_to_qts: other routes to QTS
             qualifications_and_experience: the qualifications and experience you’ll need
@@ -615,7 +615,7 @@ en:
           options:
             false: "No"
             true: "Yes"
-          page_title: Do you have the right to work in the UK?
+          page_title: Do you currently have the right to work in the UK?
           schools_cannot_give_advice:
             text: "Schools cannot give you advice about becoming a teacher in England. However, you can visit %{link} to learn more about:"
             link: Teach in England if you trained overseas (link opens in new tab)

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -377,7 +377,7 @@ en:
         declarations:
           close_relationships: Do you have any family or close relationship with people within %{organisation}
           heading: Declarations
-          right_to_work_in_uk: Do you have the right to work in the UK?
+          right_to_work_in_uk: Do you currently have the right to work in the UK?
         employment_history:
           current_role: Is this your current role?
           ended_on: End date
@@ -599,7 +599,7 @@ en:
           last_name: Last name
           phone_number: Phone number
           phone_number_provided: Do you want to provide a phone number?
-          right_to_work_in_uk: Do you have the right to work in the UK?
+          right_to_work_in_uk: Do you currently have the right to work in the UK?
         work:
           caption: Personal details
           hint:

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -604,7 +604,7 @@ en:
           caption: Personal details
           hint:
             text: If you are a non-UK citizen you will need a visa or immigration status which allows you to work as a teacher in England. Learn more about %{link}
-            link: teaching in England as a non-UK citizen.
+            link: teaching in England as a non-UK citizen (opens in a new tab).
           learn_more:
             other_routes_to_qts: other routes to QTS
             qualifications_and_experience: the qualifications and experience you’ll need

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -603,7 +603,7 @@ en:
         work:
           caption: Personal details
           hint:
-            text: If you are a non-UK citizen you will need a visa or immigration status which allows you to work as a teacher in England. Learn more about %{link}
+            text: If you're a non-UK citizen you will need a visa or immigration status which allows you to work as a teacher in England. Learn more about %{link}
             link: teaching in England as a non-UK citizen (opens in new tab).
           learn_more:
             other_routes_to_qts: other routes to QTS

--- a/spec/system/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers_can_manage_a_profile_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Jobseekers can manage their profile" do
         fill_in "personal_details_form[phone_number]", with: phone_number
         click_on I18n.t("buttons.save_and_continue")
 
-        expect(page).to have_content("Do you have the right to work in the UK?")
+        expect(page).to have_content("Do you currently have the right to work in the UK?")
         choose "Yes"
         click_on I18n.t("buttons.save_and_continue")
 
@@ -88,7 +88,6 @@ RSpec.describe "Jobseekers can manage their profile" do
         click_on I18n.t("buttons.save_and_continue")
 
         choose "No"
-        expect(page).to have_content("You are unlikely to be given a teaching job in England unless you have qualified teacher status")
         click_on I18n.t("buttons.save_and_continue")
 
         expect(page).to have_content(new_first_name)

--- a/spec/system/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers_can_manage_a_profile_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Jobseekers can manage their profile" do
         expect(page).to have_content(first_name)
         expect(page).to have_content(last_name)
         expect(page).to have_content(phone_number)
-        expect(page).to have_content("Do you have the right to work in the UK?Yes")
+        expect(page).to have_content("Do you currently have the right to work in the UK?Yes")
       end
 
       it "does not display a notice to inform the user about prefilling" do
@@ -94,7 +94,7 @@ RSpec.describe "Jobseekers can manage their profile" do
         expect(page).to have_content(new_last_name)
         expect(page).to have_content("Do you want to provide a phone number?No")
         expect(page).not_to have_content(old_phone_number)
-        expect(page).to have_content("Do you have the right to work in the UK?No")
+        expect(page).to have_content("Do you currently have the right to work in the UK?No")
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/5y6UCGrU/517-reword-right-to-work-question

## Changes in this PR:

Rewording of the right to work question/hint text and removing the hidden text shown when the user selects the no radio on the job application and jobseeker profile journies.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
