### PR TITLE
Fix vulnerable Alpine procps-ng version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-ARG PROD_PACKAGES="imagemagick libxml2 libxslt libpq tzdata shared-mime-info"
+# TODO: Remove procps-ng from this list once we upgrade to alpine > v3.18
+# The package is defined here with a hardcoded version to resolve a vulnerability in the procps-ng package coming with
+# Alpine v3.18.
+ARG PROD_PACKAGES="imagemagick libxml2 libxslt libpq tzdata shared-mime-info procps-ng=4.0.4-r0"
 
 FROM ruby:3.2.2-alpine3.18 AS builder
 


### PR DESCRIPTION
The Docker image build is failing due to a vulnerable procps-ng version. This forces a higher non-vulnerable version.

EG: https://github.com/DFE-Digital/teaching-vacancies/actions/runs/6047703062/job/16411649310?pr=6323