### PR TITLE
Fix flaky test on order

### DIFF
--- a/spec/system/publishers_can_provide_feedback_on_expired_vacancies_via_prompt_email_spec.rb
+++ b/spec/system/publishers_can_provide_feedback_on_expired_vacancies_via_prompt_email_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Publishers can provide feedback on expired vacancies via the pro
     let!(:first_vacancy_in_email) { create(:vacancy, :published, publisher: publisher, expires_at: 5.weeks.ago) }
 
     before do
-      create_list(:vacancy, 5, :published, publisher: publisher, expires_at: 4.weeks.ago)
+      create(:vacancy, :published, publisher: publisher, expires_at: 4.weeks.ago)
       perform_enqueued_jobs do
         SendExpiredVacancyFeedbackPromptJob.new.perform
       end
@@ -58,8 +58,8 @@ RSpec.describe "Publishers can provide feedback on expired vacancies via the pro
     let(:second_publisher) { create(:publisher, email: "test2@example.com") }
 
     before do
-      create_list(:vacancy, 5, :published, publisher: publisher, expires_at: 4.weeks.ago)
-      create_list(:vacancy, 5, :published, publisher: second_publisher, expires_at: 4.weeks.ago)
+      create_list(:vacancy, 2, :published, publisher: publisher, expires_at: 4.weeks.ago)
+      create_list(:vacancy, 2, :published, publisher: second_publisher, expires_at: 4.weeks.ago)
       perform_enqueued_jobs do
         SendExpiredVacancyFeedbackPromptJob.new.perform
       end

--- a/spec/system/publishers_can_provide_feedback_on_expired_vacancies_via_prompt_email_spec.rb
+++ b/spec/system/publishers_can_provide_feedback_on_expired_vacancies_via_prompt_email_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Publishers can provide feedback on expired vacancies via the pro
   end
 
   context "when a publisher has vacancies that expired between 2 and 6 weeks ago" do
-    let(:first_vacancy_in_email) { Vacancy.order(:expires_at).first }
+    let!(:first_vacancy_in_email) { create(:vacancy, :published, publisher: publisher, expires_at: 5.weeks.ago) }
 
     before do
       create_list(:vacancy, 5, :published, publisher: publisher, expires_at: 4.weeks.ago)


### PR DESCRIPTION
This test is intermittently failing on CI runs.
We are ensuring the first vacancy is really the first vacancy by providing a different expiration date from the other
vacancies instead of relying on a collection creation and picking up the first from the collection of objects with millisecond differences.