### PR TITLE
Visa application migration

### DIFF
--- a/app/vacancy_sources/vacancy_source/source/every.rb
+++ b/app/vacancy_sources/vacancy_source/source/every.rb
@@ -51,6 +51,7 @@ class VacancySource::Source::Every
       contract_type: item["contractType"].presence,
       phases: item["phase"].presence&.parameterize(separator: "_"),
       key_stages: item["keyStages"].presence&.split(","),
+      visa_sponsorship_available: false,
 
       # TODO: What about central office/multiple school vacancies?
       job_location: :at_one_school,

--- a/app/vacancy_sources/vacancy_source/source/fusion.rb
+++ b/app/vacancy_sources/vacancy_source/source/fusion.rb
@@ -51,6 +51,7 @@ class VacancySource::Source::Fusion
       contract_type: item["contractType"].presence,
       phases: item["phase"].presence&.parameterize(separator: "_"),
       key_stages: item["keyStages"].presence&.split(","),
+      visa_sponsorship_available: false,
 
       # TODO: What about central office/multiple school vacancies?
       job_location: :at_one_school,

--- a/app/vacancy_sources/vacancy_source/source/my_new_term.rb
+++ b/app/vacancy_sources/vacancy_source/source/my_new_term.rb
@@ -58,6 +58,7 @@ class VacancySource::Source::MyNewTerm
       phases: phases_for(item),
       key_stages: key_stages_for(item),
       job_location: :at_one_school,
+      visa_sponsorship_available: false,
     }.merge(organisation_fields(item))
      .merge(start_date_fields(item))
   end

--- a/app/vacancy_sources/vacancy_source/source/united_learning.rb
+++ b/app/vacancy_sources/vacancy_source/source/united_learning.rb
@@ -65,6 +65,7 @@ class VacancySource::Source::UnitedLearning
       phases: [organisations_for(item).first&.readable_phase],
       organisations: organisations_for(item),
       about_school: organisations_for(item).first&.description,
+      visa_sponsorship_available: false,
     }
   end
 

--- a/app/vacancy_sources/vacancy_source/source/ventrus.rb
+++ b/app/vacancy_sources/vacancy_source/source/ventrus.rb
@@ -57,6 +57,7 @@ class VacancySource::Source::Ventrus
       working_patterns: item["Working_Patterns"].presence&.split(","),
       contract_type: item["Contract_Type"].presence,
       phases: phases_for(item),
+      visa_sponsorship_available: false,
     }.merge(organisation_fields(item))
   end
 

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -407,6 +407,7 @@ shared:
     - further_details_provided
     - further_details
     - include_additional_documents
+    - visa_sponsorship_available
   failed_imported_vacancies:
     - id
     - import_errors

--- a/db/migrate/20230907153216_add_visa_sponsorship_available_to_vacancies.rb
+++ b/db/migrate/20230907153216_add_visa_sponsorship_available_to_vacancies.rb
@@ -1,0 +1,5 @@
+class AddVisaSponsorshipAvailableToVacancies < ActiveRecord::Migration[7.0]
+  def change
+    add_column :vacancies, :visa_sponsorship_available, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_28_122552) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_07_153216) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -641,6 +641,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_28_122552) do
     t.boolean "further_details_provided"
     t.string "further_details"
     t.boolean "include_additional_documents"
+    t.boolean "visa_sponsorship_available"
     t.index ["expires_at"], name: "index_vacancies_on_expires_at"
     t.index ["geolocation"], name: "index_vacancies_on_geolocation", using: :gist
     t.index ["publish_on"], name: "index_vacancies_on_publish_on"

--- a/lib/tasks/update_visa_sponsorship_available.rake
+++ b/lib/tasks/update_visa_sponsorship_available.rake
@@ -3,10 +3,6 @@
 namespace :vacancy do
   desc "Update vacancies with visa_sponsorship_available == nil to be false"
   task update_visa_sponsorship: :environment do
-    puts "Starting to update vacancies..."
-    
-    updated_count = Vacancy.where(visa_sponsorship_available: nil).update_all(visa_sponsorship_available: false)
-    
-    puts "Updated #{updated_count} vacancies."
+    Vacancy.where(visa_sponsorship_available: nil).update_all(visa_sponsorship_available: false)
   end
 end

--- a/lib/tasks/update_visa_sponsorship_available.rake
+++ b/lib/tasks/update_visa_sponsorship_available.rake
@@ -1,0 +1,12 @@
+# lib/tasks/update_vacancy.rake
+
+namespace :vacancy do
+  desc "Update vacancies with visa_sponsorship_available == nil to be false"
+  task update_visa_sponsorship: :environment do
+    puts "Starting to update vacancies..."
+    
+    updated_count = Vacancy.where(visa_sponsorship_available: nil).update_all(visa_sponsorship_available: false)
+    
+    puts "Updated #{updated_count} vacancies."
+  end
+end

--- a/spec/jobs/import_from_vacancy_sources_job_spec.rb
+++ b/spec/jobs/import_from_vacancy_sources_job_spec.rb
@@ -60,7 +60,8 @@ RSpec.describe ImportFromVacancySourcesJob do
               full_time_details: "Sapiente.",
               further_details: "details",
               how_to_apply: "Click button",
-              job_advert: "Aut repellat vel. Nesciunt exercitationem et. Numquam a corrupti. Et minus hic. Perspiciatis dolor neque. Sit est nemo. Ut ex officiis. Illum et mollitia. Quia qui qui. Debitis totam odio. Consequatur eum iste. Aut ex et. Quo explicabo quae. Aut id laborum. Occaecati quod sit. Laudantium ipsum placeat. Et sed nesciunt. Ut iste maxime. Ea repudiandae rem. Qui fugit adipisci. Vero fugiat dolor. Nesciunt eum et. Molestias nulla facere. Aliquid dolore assumenda. Aut repudiandae iusto. Quia aut maxime. Consequatur voluptates facere. Facere eius asperiores. Fugiat occaecati assumenda. Maiores consequatur architecto. Perferendis sint ut. Est odio dolorem. Aliquid fugiat iusto. Eaque fugiat voluptas. Eos velit assumenda. Nesciunt minus quia. Cupiditate vero dolor. Quos temporibus consequuntur. Vel cupiditate eos. Dolore dolores repellat. Ex ipsam consequuntur. Dolores harum voluptatem. Temporibus neque quis. Vero soluta sunt. Voluptas laboriosam modi. Quod ut nostrum. Veniam voluptatem et. Explicabo necessitatibus ex. Ut architecto placeat. Neque velit et.")
+              job_advert: "Aut repellat vel. Nesciunt exercitationem et. Numquam a corrupti. Et minus hic. Perspiciatis dolor neque. Sit est nemo. Ut ex officiis. Illum et mollitia. Quia qui qui. Debitis totam odio. Consequatur eum iste. Aut ex et. Quo explicabo quae. Aut id laborum. Occaecati quod sit. Laudantium ipsum placeat. Et sed nesciunt. Ut iste maxime. Ea repudiandae rem. Qui fugit adipisci. Vero fugiat dolor. Nesciunt eum et. Molestias nulla facere. Aliquid dolore assumenda. Aut repudiandae iusto. Quia aut maxime. Consequatur voluptates facere. Facere eius asperiores. Fugiat occaecati assumenda. Maiores consequatur architecto. Perferendis sint ut. Est odio dolorem. Aliquid fugiat iusto. Eaque fugiat voluptas. Eos velit assumenda. Nesciunt minus quia. Cupiditate vero dolor. Quos temporibus consequuntur. Vel cupiditate eos. Dolore dolores repellat. Ex ipsam consequuntur. Dolores harum voluptatem. Temporibus neque quis. Vero soluta sunt. Voluptas laboriosam modi. Quod ut nostrum. Veniam voluptatem et. Explicabo necessitatibus ex. Ut architecto placeat. Neque velit et.",
+              visa_sponsorship_available: false)
       end
 
       it "does not save the vacancy to the Vacancies table" do
@@ -148,6 +149,7 @@ RSpec.describe ImportFromVacancySourcesJob do
           "updated_at" => nil,
           "working_patterns" => ["full_time"],
           "working_patterns_details" => nil,
+          "visa_sponsorship_available" => false,
         )
       end
 

--- a/spec/vacancy_sources/vacancy_source/source/every_spec.rb
+++ b/spec/vacancy_sources/vacancy_source/source/every_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe VacancySource::Source::Every do
         working_patterns: %w[full_time],
         contract_type: "fixed_term",
         phases: %w[primary],
+        visa_sponsorship_available: false,
       }
     end
 

--- a/spec/vacancy_sources/vacancy_source/source/fusion_spec.rb
+++ b/spec/vacancy_sources/vacancy_source/source/fusion_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe VacancySource::Source::Fusion do
         working_patterns: %w[full_time],
         contract_type: "fixed_term",
         phases: %w[primary],
+        visa_sponsorship_available: false,
       }
     end
 

--- a/spec/vacancy_sources/vacancy_source/source/my_new_term_spec.rb
+++ b/spec/vacancy_sources/vacancy_source/source/my_new_term_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe VacancySource::Source::MyNewTerm do
           contract_type: "permanent",
           phases: %w[primary],
           subjects: %w[Geography],
+          visa_sponsorship_available: false,
         }
       end
 

--- a/spec/vacancy_sources/vacancy_source/source/united_learning_spec.rb
+++ b/spec/vacancy_sources/vacancy_source/source/united_learning_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe VacancySource::Source::UnitedLearning do
       expect(vacancy.working_patterns).to eq(%w[full_time])
       expect(vacancy.contract_type).to eq("permanent")
       expect(vacancy.phases).to eq(%w[secondary])
+      expect(vacancy.visa_sponsorship_available).to eq false
 
       expect(vacancy.organisations.first).to eq(school)
 

--- a/spec/vacancy_sources/vacancy_source/source/ventrus_spec.rb
+++ b/spec/vacancy_sources/vacancy_source/source/ventrus_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe VacancySource::Source::Ventrus do
         working_patterns: %w[part_time],
         contract_type: "permanent",
         phases: %w[secondary],
+        visa_sponsorship_available: false,
       }
     end
 


### PR DESCRIPTION
https://trello.com/c/B5CoLcGQ/518-add-visa-sponsorship-question-to-job-listing-journey

## Changes in this PR:
This is the set up work to allow completion of the above ticket.

In this PR I:
- Add migration to add visa_sponsorship_available column to vacancies table
- Add rake task to backfill all vacancies with visa_sponsorship_available: false
- Hardcode ATS files so that new vacancies coming via these sources have visa_sponsorship_available: false
- Add tests for the ATS files
- Add visa_sponsorship_available to analytics

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
