### PR TITLE
BugFix: filter leadership jobs

### DIFF
--- a/spec/queries/vacancy_filter_query_spec.rb
+++ b/spec/queries/vacancy_filter_query_spec.rb
@@ -18,22 +18,25 @@ RSpec.describe VacancyFilterQuery do
   let(:non_faith_school2) { create(:school, name: "nonfaith2", gias_data: { "ReligiousCharacter (name)" => "Does not apply" }) }
   let(:non_faith_school3) { create(:school, name: "nonfaith3", gias_data: { "ReligiousCharacter (name)" => "None" }) }
 
-  let!(:vacancy1) { create(:vacancy, job_title: "Vacancy 1", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[secondary], job_role: "teacher", ect_status: "ect_suitable", organisations: [academy], enable_job_applications: true) }
-  let!(:vacancy2) { create(:vacancy, job_title: "Vacancy 2", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[sixth_form_or_college], job_role: "teacher", ect_status: "ect_unsuitable", organisations: [free_school], enable_job_applications: true) }
+  let!(:vacancy1) { create(:vacancy, job_title: "Vacancy 1", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[secondary], job_roles: ["teacher"], ect_status: "ect_suitable", organisations: [academy], enable_job_applications: true) }
+  let!(:vacancy2) { create(:vacancy, job_title: "Vacancy 2", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[sixth_form_or_college], job_roles: ["teacher"], ect_status: "ect_unsuitable", organisations: [free_school], enable_job_applications: true) }
   let!(:vacancy3) { create(:vacancy, job_title: "Vacancy 3", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "sendco", ect_status: nil, organisations: [local_authority_school], enable_job_applications: true) }
-  let!(:vacancy4) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 4", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil) }
-  let!(:vacancy5) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 5", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [academies]) }
-  let!(:vacancy6) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 6", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
-  let!(:special_vacancy1) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 7", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [special_school1]) }
-  let!(:special_vacancy2) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 8", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [special_school2]) }
-  let!(:special_vacancy3) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 9", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [special_school3]) }
-  let!(:special_vacancy4) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 10", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [special_school4]) }
-  let!(:special_vacancy5) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 11", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [special_school5]) }
-  let!(:special_vacancy6) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 12", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [special_school6]) }
-  let!(:faith_vacancy) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 13", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, publisher_organisation: faith_school, organisations: [faith_school, faith_school2]) }
-  let!(:non_faith_vacancy1) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 14", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [non_faith_school1]) }
-  let!(:non_faith_vacancy2) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 15", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [non_faith_school2]) }
-  let!(:non_faith_vacancy3) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 14", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "teacher", ect_status: nil, organisations: [non_faith_school3]) }
+  let!(:vacancy4) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 4", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["teacher"], ect_status: nil) }
+  let!(:vacancy5) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 5", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["teacher"], ect_status: nil, organisations: [academies]) }
+  let!(:vacancy6) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 6", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["teacher"], ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
+  let!(:vacancy7) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 7", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["headteacher"], ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
+  let!(:vacancy8) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 8", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["assistant_headteacher"], ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
+  let!(:vacancy9) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 9", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["deputy_headteacher"], ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
+  let!(:special_vacancy1) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 7", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["teacher"], ect_status: nil, organisations: [special_school1]) }
+  let!(:special_vacancy2) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 8", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["teacher"], ect_status: nil, organisations: [special_school2]) }
+  let!(:special_vacancy3) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 9", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["teacher"], ect_status: nil, organisations: [special_school3]) }
+  let!(:special_vacancy4) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 10", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["teacher"], ect_status: nil, organisations: [special_school4]) }
+  let!(:special_vacancy5) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 11", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["teacher"], ect_status: nil, organisations: [special_school5]) }
+  let!(:special_vacancy6) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 12", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["teacher"], ect_status: nil, organisations: [special_school6]) }
+  let!(:faith_vacancy) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 13", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["teacher"], ect_status: nil, publisher_organisation: faith_school, organisations: [faith_school, faith_school2]) }
+  let!(:non_faith_vacancy1) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 14", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["teacher"], ect_status: nil, organisations: [non_faith_school1]) }
+  let!(:non_faith_vacancy2) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 15", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["teacher"], ect_status: nil, organisations: [non_faith_school2]) }
+  let!(:non_faith_vacancy3) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 14", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["teacher"], ect_status: nil, organisations: [non_faith_school3]) }
 
   describe "#call" do
     it "queries based on the given filters" do
@@ -55,7 +58,8 @@ RSpec.describe VacancyFilterQuery do
           filters = {
             organisation_types: ["Academy"],
           }
-          expect(subject.call(filters)).to contain_exactly(vacancy1, vacancy2, vacancy5, vacancy6)
+          expect(subject.call(filters))
+            .to contain_exactly(vacancy1, vacancy2, vacancy5, vacancy6, vacancy7, vacancy8, vacancy9)
         end
       end
 
@@ -71,8 +75,11 @@ RSpec.describe VacancyFilterQuery do
       context "when organisation_types is empty" do
         it "will return vacancies associated with all schools" do
           filters = {}
-          expect(subject.call(filters)).to contain_exactly(vacancy1, vacancy2, vacancy3, vacancy4, vacancy5, vacancy6, special_vacancy1, special_vacancy2,
-                                                           special_vacancy3, special_vacancy4, special_vacancy5, special_vacancy6, faith_vacancy, non_faith_vacancy1, non_faith_vacancy2, non_faith_vacancy3)
+          expect(subject.call(filters)).to contain_exactly(
+            vacancy1, vacancy2, vacancy3, vacancy4, vacancy5, vacancy6, vacancy7, vacancy8, vacancy9, special_vacancy1,
+            special_vacancy2, special_vacancy3, special_vacancy4, special_vacancy5, special_vacancy6, faith_vacancy,
+            non_faith_vacancy1, non_faith_vacancy2, non_faith_vacancy3
+          )
         end
       end
 
@@ -80,9 +87,9 @@ RSpec.describe VacancyFilterQuery do
         it "will return vacancies associated with local authority maintained schools, academies and free schools" do
           filters = {
             organisation_types: ["Academy", "Local authority maintained schools"],
-
           }
-          expect(subject.call(filters)).to contain_exactly(vacancy1, vacancy2, vacancy3, vacancy5, vacancy6)
+          expect(subject.call(filters))
+            .to contain_exactly(vacancy1, vacancy2, vacancy3, vacancy5, vacancy6, vacancy7, vacancy8, vacancy9)
         end
       end
     end
@@ -130,6 +137,13 @@ RSpec.describe VacancyFilterQuery do
         phases: %w[16-19],
       }
       expect(subject.call(filters)).to contain_exactly(vacancy2)
+    end
+
+    it "maps removed leadership job role to all senior leadership roles" do
+      filters = {
+        job_roles: %w[leadership],
+      }
+      expect(subject.call(filters)).to contain_exactly(vacancy7, vacancy8, vacancy9)
     end
   end
 end


### PR DESCRIPTION
[Error in Sentry](https://teaching-vacancies.sentry.io/issues/4417538910/events/cd8bd5187c2449e0a89a348705710ff6)

Mapping to senior_leadership raises an error as senior_leadership has been removed from the job_roles.

Map it to all the senior_leadership new granular roles instead.
