### PR TITLE
Bugfix: Allow legacy roles in vacancy search filter queries

### DIFF
--- a/app/queries/vacancy_filter_query.rb
+++ b/app/queries/vacancy_filter_query.rb
@@ -81,7 +81,7 @@ class VacancyFilterQuery < ApplicationQuery
       when "middle_leader" then Vacancy::MIDDLE_LEADER_JOB_ROLES
       else job_role
       end
-    }&.reject { |job_role| job_role == "ect_suitable" }
+    }&.reject { |job_role| Vacancy.job_roles.exclude? job_role }
   end
 
   def phases(filter)

--- a/app/queries/vacancy_filter_query.rb
+++ b/app/queries/vacancy_filter_query.rb
@@ -69,9 +69,19 @@ class VacancyFilterQuery < ApplicationQuery
     end
   end
 
+  # Keeps compatibility with legacy job roles filters that have been removed but they are still used by users.
+  # EG: Bookmarked results page for a search with the old job roles filters.
+  # EG2: Job alerts with the old job roles filters.
+  # Without mapping, the legacy values would trigger an exception due to the value not being in the defined list of job
+  # roles.
   def job_roles(filter)
-    filter&.flat_map { |job_role| job_role == "leadership" ? Vacancy::SENIOR_LEADER_JOB_ROLES : job_role }
-          &.reject { |job_role| job_role == "ect_suitable" }
+    filter&.flat_map { |job_role|
+      case job_role
+      when "leadership", "senior_leader" then Vacancy::SENIOR_LEADER_JOB_ROLES
+      when "middle_leader" then Vacancy::MIDDLE_LEADER_JOB_ROLES
+      else job_role
+      end
+    }&.reject { |job_role| job_role == "ect_suitable" }
   end
 
   def phases(filter)

--- a/app/queries/vacancy_filter_query.rb
+++ b/app/queries/vacancy_filter_query.rb
@@ -72,8 +72,6 @@ class VacancyFilterQuery < ApplicationQuery
   # Keeps compatibility with legacy job roles filters that have been removed but they are still used by users.
   # EG: Bookmarked results page for a search with the old job roles filters.
   # EG2: Job alerts with the old job roles filters.
-  # Without mapping, the legacy values would trigger an exception due to the value not being in the defined list of job
-  # roles.
   def job_roles(filter)
     filter&.flat_map { |job_role|
       case job_role
@@ -81,7 +79,7 @@ class VacancyFilterQuery < ApplicationQuery
       when "middle_leader" then Vacancy::MIDDLE_LEADER_JOB_ROLES
       else job_role
       end
-    }&.reject { |job_role| Vacancy.job_roles.exclude? job_role }
+    }&.reject { |job_role| Vacancy.job_roles.exclude? job_role } # Avoids exceptions raised by ArrayEnum when the job role is not valid
   end
 
   def phases(filter)

--- a/spec/queries/vacancy_filter_query_spec.rb
+++ b/spec/queries/vacancy_filter_query_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe VacancyFilterQuery do
   let!(:vacancy2) { create(:vacancy, job_title: "Vacancy 2", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[sixth_form_or_college], job_roles: ["teacher"], ect_status: "ect_unsuitable", organisations: [free_school], enable_job_applications: true) }
   let!(:vacancy3) { create(:vacancy, job_title: "Vacancy 3", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "sendco", ect_status: nil, organisations: [local_authority_school], enable_job_applications: true) }
   let!(:vacancy4) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 4", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["teacher"], ect_status: nil) }
-  let!(:vacancy5) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 5", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["teacher"], ect_status: nil, organisations: [academies]) }
-  let!(:vacancy6) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 6", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["teacher"], ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
+  let!(:vacancy5) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 5", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["head_of_year_or_phase"], ect_status: nil, organisations: [academies]) }
+  let!(:vacancy6) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 6", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["head_of_department_or_curriculum"], ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
   let!(:vacancy7) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 7", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["headteacher"], ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
   let!(:vacancy8) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 8", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["assistant_headteacher"], ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
   let!(:vacancy9) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 9", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["deputy_headteacher"], ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
@@ -139,11 +139,27 @@ RSpec.describe VacancyFilterQuery do
       expect(subject.call(filters)).to contain_exactly(vacancy2)
     end
 
-    it "maps removed leadership job role to all senior leadership roles" do
-      filters = {
-        job_roles: %w[leadership],
-      }
-      expect(subject.call(filters)).to contain_exactly(vacancy7, vacancy8, vacancy9)
+    describe "legacy roles mapping" do
+      it "transforms 'leadership' to all senior leadership roles" do
+        filters = {
+          job_roles: %w[leadership],
+        }
+        expect(subject.call(filters)).to contain_exactly(vacancy7, vacancy8, vacancy9)
+      end
+
+      it "transforms 'senior_leader' to all senior leadership roles" do
+        filters = {
+          job_roles: %w[senior_leader],
+        }
+        expect(subject.call(filters)).to contain_exactly(vacancy7, vacancy8, vacancy9)
+      end
+
+      it "transforms 'middle_leader' to all middle leadership roles" do
+        filters = {
+          job_roles: %w[middle_leader],
+        }
+        expect(subject.call(filters)).to contain_exactly(vacancy5, vacancy6)
+      end
     end
   end
 end

--- a/spec/queries/vacancy_filter_query_spec.rb
+++ b/spec/queries/vacancy_filter_query_spec.rb
@@ -139,26 +139,37 @@ RSpec.describe VacancyFilterQuery do
       expect(subject.call(filters)).to contain_exactly(vacancy2)
     end
 
-    describe "legacy roles mapping" do
-      it "transforms 'leadership' to all senior leadership roles" do
+    describe "roles mapping" do
+      it "transforms legacy 'leadership' to all senior leadership roles" do
         filters = {
           job_roles: %w[leadership],
         }
         expect(subject.call(filters)).to contain_exactly(vacancy7, vacancy8, vacancy9)
       end
 
-      it "transforms 'senior_leader' to all senior leadership roles" do
+      it "transforms legacy 'senior_leader' to all senior leadership roles" do
         filters = {
           job_roles: %w[senior_leader],
         }
         expect(subject.call(filters)).to contain_exactly(vacancy7, vacancy8, vacancy9)
       end
 
-      it "transforms 'middle_leader' to all middle leadership roles" do
+      it "transforms legacy 'middle_leader' to all middle leadership roles" do
         filters = {
           job_roles: %w[middle_leader],
         }
         expect(subject.call(filters)).to contain_exactly(vacancy5, vacancy6)
+      end
+
+      it "doesn't filter by role if it is not included in current job roles list" do
+        filters = {
+          job_roles: %w[non_valid_role],
+        }
+        expect(subject.call(filters)).to contain_exactly(
+          vacancy1, vacancy2, vacancy3, vacancy4, vacancy5, vacancy6, vacancy7, vacancy8, vacancy9, special_vacancy1,
+          special_vacancy2, special_vacancy3, special_vacancy4, special_vacancy5, special_vacancy6, faith_vacancy,
+          non_faith_vacancy1, non_faith_vacancy2, non_faith_vacancy3
+        )
       end
     end
   end


### PR DESCRIPTION
## Bug tracking error:

- [Error in Sentry](https://teaching-vacancies.sentry.io/issues/4472377452/?environment=production&project=6212514&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=2)

## Changes in this PR:

Some users keep landing on the vacancy search page with `job_roles` filter containing `senior_leader` and `middle_leader` legacy (recently removed) values.
This may be happening:
- To users that bookmarked a particular search in the browser some time ago.
- Users with alerts created over those roles in the past.

This PR:
- Maps those values to all the senior/middle leadership current granular role filters.
- Does not filter by a role when it is invalid, avoiding exceptions in the service and error pages shown to users.

## Screenshots of UI changes:

### Before
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/8187a0d5-a909-4762-b460-b04c6a3a32ff)


### After
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/b9539119-7480-4b25-8d04-02c84939b476)


