### PR TITLE
Replace CF-dependant command for app start

### DIFF
--- a/db/migrate/20230913134332_add_test_migration_to_vacancies.rb
+++ b/db/migrate/20230913134332_add_test_migration_to_vacancies.rb
@@ -1,0 +1,4 @@
+class AddTestMigrationToVacancies < ActiveRecord::Migration[7.0]
+  def change
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_07_153216) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_13_134332) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_13_134332) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_13_142613) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -642,6 +642,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_13_134332) do
     t.string "further_details"
     t.boolean "include_additional_documents"
     t.boolean "visa_sponsorship_available"
+    t.boolean "second_new_test_migration"
     t.index ["expires_at"], name: "index_vacancies_on_expires_at"
     t.index ["geolocation"], name: "index_vacancies_on_geolocation", using: :gist
     t.index ["publish_on"], name: "index_vacancies_on_publish_on"

--- a/documentation/terraform.md
+++ b/documentation/terraform.md
@@ -85,7 +85,7 @@ Occasionally we see `terraform plan` output like this
 ```
 # module.paas.cloudfoundry_app.web_app will be updated in-place
   ~ resource "cloudfoundry_app" "web_app" {
-        command                    = "bundle exec rake cf:on_first_instance db:migrate && rails s"
+        command                    = "bundle exec rake db:migrate:ignore_concurrent_migration_exceptions && rails s"
         disk_quota                 = 1024
         docker_image               = "dfedigital/teaching-vacancies:dev-08406f04dd9eadb7df6fcda5213be880d7df37ed-20201022090714"
         enable_ssh                 = true

--- a/lib/tasks/cloudfoundry.rake
+++ b/lib/tasks/cloudfoundry.rake
@@ -1,6 +1,0 @@
-namespace :cf do
-  desc "Only run on the first application instance"
-  task :on_first_instance do
-    exit(0) unless ENV.fetch("CF_INSTANCE_INDEX", nil) == "0"
-  end
-end

--- a/lib/tasks/migrate_swallowing_concurrent_migration_exceptions.rake
+++ b/lib/tasks/migrate_swallowing_concurrent_migration_exceptions.rake
@@ -1,0 +1,10 @@
+namespace :db do
+  namespace :migrate do
+    desc "Run db:migrate but ignore ActiveRecord::ConcurrentMigrationError errors"
+    task ignore_concurrent_migration_exceptions: :environment do
+      Rake::Task["db:migrate"].invoke
+    rescue ActiveRecord::ConcurrentMigrationError
+      # Do nothing
+    end
+  end
+end

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -103,7 +103,7 @@ variable "paas_web_app_memory" {
 }
 
 variable "paas_web_app_start_command" {
-  default = "bundle exec rake cf:on_first_instance db:migrate && rails s"
+  default = "bundle exec rake db:migrate:ignore_concurrent_migration_exceptions && rails s"
 }
 variable "aks_web_app_start_command" {
   default = ["/bin/sh", "-c", "bundle exec rake db:migrate && rails s"]

--- a/terraform/workspace-variables/review.tfvars.json
+++ b/terraform/workspace-variables/review.tfvars.json
@@ -13,7 +13,7 @@
   "paas_space_name": "teaching-vacancies-review",
   "paas_web_app_deployment_strategy": "blue-green-v2",
   "paas_web_app_instances": 1,
-  "paas_web_app_start_command": "bundle exec rails cf:on_first_instance db:migrate db:async_seed && rails s",
+  "paas_web_app_start_command": "bundle exec rails db:migrate:ignore_concurrent_migration_exceptions db:async_seed && rails s",
   "aks_web_app_start_command": ["/bin/sh", "-c", "bundle exec rails db:migrate db:async_seed && rails s"],
   "paas_worker_app_deployment_strategy": "blue-green-v2",
   "paas_worker_app_instances": 1,

--- a/terraform/workspace-variables/review.tfvars.json
+++ b/terraform/workspace-variables/review.tfvars.json
@@ -12,7 +12,7 @@
   "paas_redis_queue_service_plan": "micro-5_x",
   "paas_space_name": "teaching-vacancies-review",
   "paas_web_app_deployment_strategy": "blue-green-v2",
-  "paas_web_app_instances": 1,
+  "paas_web_app_instances": 2,
   "paas_web_app_start_command": "bundle exec rails db:migrate:ignore_concurrent_migration_exceptions db:async_seed && rails s",
   "aks_web_app_start_command": ["/bin/sh", "-c", "bundle exec rails db:migrate db:async_seed && rails s"],
   "paas_worker_app_deployment_strategy": "blue-green-v2",


### PR DESCRIPTION
The current way to run the migrations in a multi-instance service without having errors that break the app start run is dependant on CloudFoundry software.

As we are migrating to AKS, we need something compatible with both CF and AKS platforms. 
Instead of monitoring the first instance, and until a better solution is found, we are just ignoring the migration error that will be triggered over the following instances.

I got this approach from Registree Trainee Teachers Service [Link](https://github.com/DFE-Digital/register-trainee-teachers/blob/597443aaeccc8f5d79e3d097bed0bede72f2f439/lib/tasks/migrate_swallowing_concurrent_migration_exceptions.rake)
