### PR TITLE
Update cf dependant app start command

### DIFF
--- a/documentation/terraform.md
+++ b/documentation/terraform.md
@@ -85,7 +85,7 @@ Occasionally we see `terraform plan` output like this
 ```
 # module.paas.cloudfoundry_app.web_app will be updated in-place
   ~ resource "cloudfoundry_app" "web_app" {
-        command                    = "bundle exec rake cf:on_first_instance db:migrate && rails s"
+        command                    = "bundle exec rake db:migrate:ignore_concurrent_migration_exceptions && rails s"
         disk_quota                 = 1024
         docker_image               = "dfedigital/teaching-vacancies:dev-08406f04dd9eadb7df6fcda5213be880d7df37ed-20201022090714"
         enable_ssh                 = true

--- a/lib/tasks/cloudfoundry.rake
+++ b/lib/tasks/cloudfoundry.rake
@@ -1,6 +1,0 @@
-namespace :cf do
-  desc "Only run on the first application instance"
-  task :on_first_instance do
-    exit(0) unless ENV.fetch("CF_INSTANCE_INDEX", nil) == "0"
-  end
-end

--- a/lib/tasks/migrate_swallowing_concurrent_migration_exceptions.rake
+++ b/lib/tasks/migrate_swallowing_concurrent_migration_exceptions.rake
@@ -1,0 +1,10 @@
+namespace :db do
+  namespace :migrate do
+    desc "Run db:migrate but ignore ActiveRecord::ConcurrentMigrationError errors"
+    task ignore_concurrent_migration_exceptions: :environment do
+      Rake::Task["db:migrate"].invoke
+    rescue ActiveRecord::ConcurrentMigrationError
+      # Do nothing
+    end
+  end
+end

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -103,7 +103,7 @@ variable "paas_web_app_memory" {
 }
 
 variable "paas_web_app_start_command" {
-  default = "bundle exec rake cf:on_first_instance db:migrate && rails s"
+  default = "bundle exec rake db:migrate:ignore_concurrent_migration_exceptions && rails s"
 }
 variable "aks_web_app_start_command" {
   default = ["/bin/sh", "-c", "bundle exec rake db:migrate && rails s"]

--- a/terraform/workspace-variables/review.tfvars.json
+++ b/terraform/workspace-variables/review.tfvars.json
@@ -13,7 +13,7 @@
   "paas_space_name": "teaching-vacancies-review",
   "paas_web_app_deployment_strategy": "blue-green-v2",
   "paas_web_app_instances": 1,
-  "paas_web_app_start_command": "bundle exec rails cf:on_first_instance db:migrate db:async_seed && rails s",
+  "paas_web_app_start_command": "bundle exec rails db:migrate:ignore_concurrent_migration_exceptions db:async_seed && rails s",
   "aks_web_app_start_command": ["/bin/sh", "-c", "bundle exec rails db:migrate db:async_seed && rails s"],
   "paas_worker_app_deployment_strategy": "blue-green-v2",
   "paas_worker_app_instances": 1,


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/gBFEak7S
## Changes in this PR:

The way the deployment command only runs DB migrations on the first DB instance was dependent on CloudFoundry commands.
We replace it with a non-platform dependent solution that works for both CF and AKS:
It will attempt to run the migration in all the instances but will ignore any concurrent migration errors. So the original migration will run while the other instances will be able to run.

We got this approach from Registree Trainee Teachers Service [Link](https://github.com/DFE-Digital/register-trainee-teachers/blob/597443aaeccc8f5d79e3d097bed0bede72f2f439/lib/tasks/migrate_swallowing_concurrent_migration_exceptions.rake)

## How we tested it

1 - Aded a migration with a new field for Vacancies in the PR.
2 - Modified the number of web app instances for review in the PR.
3 - Checked that the Review App was created with the correct number of instances running.
4 - Connected to a Rails console in the Review App, and checked that the new attribute was available for Vacancies (migration ran successfully).
5 - Removed the web app instances/migration changes from the branch.
