### PR TITLE
Show visa sponsorship status on job listing

### DIFF
--- a/app/views/vacancies/listing/_job_details.html.slim
+++ b/app/views/vacancies/listing/_job_details.html.slim
@@ -7,6 +7,11 @@ section#job-details class="govuk-!-margin-bottom-5"
         h3.govuk-heading-s class="govuk-!-margin-bottom-0" = t("jobs.job_role")
       - row.value text: linked_job_roles_and_ect_status(vacancy)
 
+    - summary_list.row do |row|
+      - row.key do
+        h3.govuk-heading-s class="govuk-!-margin-bottom-0" = t("jobs.visa_sponsorship_row_title")
+      - row.value text: t("jobs.visa_sponsorship_#{vacancy.visa_sponsorship_available ? "available" : "unavailable"}")
+
     - if vacancy.allow_key_stages? && vacancy.key_stages.any?
       - summary_list.row do |row|
         - row.key do
@@ -83,14 +88,17 @@ section#job-details class="govuk-!-margin-bottom-5"
 
     - if vacancy.enable_job_applications?
       p.govuk-body = t("jobseekers.job_applications.applying_for_the_job_paragraph")
+      = govuk_inset_text text: t("vacancies.#{vacancy.visa_sponsorship_available ? "sponsorship_available" : "sponsorship_unavailable"}")
       = govuk_button_link_to t("jobseekers.job_applications.apply"), new_jobseekers_job_job_application_path(vacancy.id)
 
     - elsif vacancy.receive_applications == "website"
       p.govuk-body = t("jobs.apply_via_website")
+      = govuk_inset_text text: t("vacancies.#{vacancy.visa_sponsorship_available ? "sponsorship_available" : "sponsorship_unavailable"}")
       = apply_link(vacancy, class: "govuk-!-margin-bottom-5")
 
     - elsif vacancy.receive_applications == "email"
       p.govuk-body = t("jobs.apply_via_email_html", email: application_email_link(vacancy))
+      = govuk_inset_text text: t("vacancies.#{vacancy.visa_sponsorship_available ? "sponsorship_available" : "sponsorship_unavailable"}")
       = govuk_button_link_to t("buttons.download_application_form", size: number_to_human_size(vacancy.application_form.byte_size)), job_document_path(vacancy, vacancy.application_form.id)
 
     - else
@@ -100,15 +108,19 @@ section#job-details class="govuk-!-margin-bottom-5"
       - if vacancy.external?
         h4.govuk-heading-m = t("publishers.vacancies.steps.applying_for_the_job")
         p = t("jobs.external.notice")
+        = govuk_inset_text text: t("vacancies.#{vacancy.visa_sponsorship_available ? "sponsorship_available" : "sponsorship_unavailable"}")
         = external_advert_link vacancy, class: "govuk-!-margin-bottom-5"
 
       - if vacancy.application_link.present? && vacancy.application_form.present?
+        = govuk_inset_text text: t("vacancies.#{vacancy.visa_sponsorship_available ? "sponsorship_available" : "sponsorship_unavailable"}")
         = apply_link(vacancy, class: "govuk-button--secondary govuk-!-margin-bottom-5")
         br
         = govuk_button_link_to t("buttons.download_application_form", size: number_to_human_size(vacancy.application_form.byte_size)), job_document_path(vacancy, vacancy.application_form.id), class: "govuk-button--secondary"
       - elsif vacancy.application_link.present?
+        = govuk_inset_text text: t("vacancies.#{vacancy.visa_sponsorship_available ? "sponsorship_available" : "sponsorship_unavailable"}")
         = apply_link(vacancy, class: "govuk-!-margin-bottom-5")
       - elsif vacancy.application_form.present?
+        = govuk_inset_text text: t("vacancies.#{vacancy.visa_sponsorship_available ? "sponsorship_available" : "sponsorship_unavailable"}")
         = govuk_button_link_to t("buttons.download_application_form", size: number_to_human_size(vacancy.application_form.byte_size)), job_document_path(vacancy, vacancy.application_form.id)
   - else
     = govuk_inset_text text: t("jobs.expired_listing.notification"), classes: "govuk-!-font-weight-bold"

--- a/app/views/vacancies/listing/_job_details.html.slim
+++ b/app/views/vacancies/listing/_job_details.html.slim
@@ -10,7 +10,7 @@ section#job-details class="govuk-!-margin-bottom-5"
     - summary_list.row do |row|
       - row.key do
         h3.govuk-heading-s class="govuk-!-margin-bottom-0" = t("jobs.visa_sponsorship_row_title")
-      - row.value text: t("jobs.visa_sponsorship_#{vacancy.visa_sponsorship_available ? "available" : "unavailable"}")
+      - row.value text: t("jobs.visa_sponsorship_#{vacancy.visa_sponsorship_available ? 'available' : 'unavailable'}")
 
     - if vacancy.allow_key_stages? && vacancy.key_stages.any?
       - summary_list.row do |row|
@@ -85,20 +85,20 @@ section#job-details class="govuk-!-margin-bottom-5"
     h3.govuk-heading-m = t("jobseekers.job_applications.applying_for_the_job_heading")
 
     .govuk-body = t("vacancies.international_teacher_advice.text_html", link: tracked_link_to(t("vacancies.international_teacher_advice.link"), "https://getintoteaching.education.gov.uk/non-uk-teachers", link_type: :international_teacher_advice_link_job_listing))
-
+    - inset_text = t("vacancies.#{vacancy.visa_sponsorship_available ? 'sponsorship_available' : 'sponsorship_unavailable'}")
     - if vacancy.enable_job_applications?
       p.govuk-body = t("jobseekers.job_applications.applying_for_the_job_paragraph")
-      = govuk_inset_text text: t("vacancies.#{vacancy.visa_sponsorship_available ? "sponsorship_available" : "sponsorship_unavailable"}")
+      = govuk_inset_text text: inset_text
       = govuk_button_link_to t("jobseekers.job_applications.apply"), new_jobseekers_job_job_application_path(vacancy.id)
 
     - elsif vacancy.receive_applications == "website"
       p.govuk-body = t("jobs.apply_via_website")
-      = govuk_inset_text text: t("vacancies.#{vacancy.visa_sponsorship_available ? "sponsorship_available" : "sponsorship_unavailable"}")
+      = govuk_inset_text text: inset_text
       = apply_link(vacancy, class: "govuk-!-margin-bottom-5")
 
     - elsif vacancy.receive_applications == "email"
       p.govuk-body = t("jobs.apply_via_email_html", email: application_email_link(vacancy))
-      = govuk_inset_text text: t("vacancies.#{vacancy.visa_sponsorship_available ? "sponsorship_available" : "sponsorship_unavailable"}")
+      = govuk_inset_text text: inset_text
       = govuk_button_link_to t("buttons.download_application_form", size: number_to_human_size(vacancy.application_form.byte_size)), job_document_path(vacancy, vacancy.application_form.id)
 
     - else
@@ -108,19 +108,19 @@ section#job-details class="govuk-!-margin-bottom-5"
       - if vacancy.external?
         h4.govuk-heading-m = t("publishers.vacancies.steps.applying_for_the_job")
         p = t("jobs.external.notice")
-        = govuk_inset_text text: t("vacancies.#{vacancy.visa_sponsorship_available ? "sponsorship_available" : "sponsorship_unavailable"}")
+        = govuk_inset_text text: inset_text
         = external_advert_link vacancy, class: "govuk-!-margin-bottom-5"
 
       - if vacancy.application_link.present? && vacancy.application_form.present?
-        = govuk_inset_text text: t("vacancies.#{vacancy.visa_sponsorship_available ? "sponsorship_available" : "sponsorship_unavailable"}")
+        = govuk_inset_text text: inset_text
         = apply_link(vacancy, class: "govuk-button--secondary govuk-!-margin-bottom-5")
         br
         = govuk_button_link_to t("buttons.download_application_form", size: number_to_human_size(vacancy.application_form.byte_size)), job_document_path(vacancy, vacancy.application_form.id), class: "govuk-button--secondary"
       - elsif vacancy.application_link.present?
-        = govuk_inset_text text: t("vacancies.#{vacancy.visa_sponsorship_available ? "sponsorship_available" : "sponsorship_unavailable"}")
+        = govuk_inset_text text: inset_text
         = apply_link(vacancy, class: "govuk-!-margin-bottom-5")
       - elsif vacancy.application_form.present?
-        = govuk_inset_text text: t("vacancies.#{vacancy.visa_sponsorship_available ? "sponsorship_available" : "sponsorship_unavailable"}")
+        = govuk_inset_text text: inset_text
         = govuk_button_link_to t("buttons.download_application_form", size: number_to_human_size(vacancy.application_form.byte_size)), job_document_path(vacancy, vacancy.application_form.id)
   - else
     = govuk_inset_text text: t("jobs.expired_listing.notification"), classes: "govuk-!-font-weight-bold"

--- a/app/views/vacancies/search/_results.html.slim
+++ b/app/views/vacancies/search/_results.html.slim
@@ -44,3 +44,7 @@
             - summary_list.row do |row|
               - row.key text: t("jobs.distance"), classes: "govuk-body-s govuk-!-font-weight-bold govuk-!-padding-bottom-0"
               - row.value text: t("jobs.distance_from_location", distance: vacancy.distance_in_miles_to(@search_coordinates).round(1)), classes: "govuk-body-s govuk-!-padding-bottom-0"
+
+        - summary_list.row do |row|
+          - row.key text: t("jobs.visa_sponsorship_row_title"), classes: "govuk-body-s govuk-!-font-weight-bold govuk-!-padding-bottom-0"
+          - row.value text: t("jobs.visa_sponsorship_#{vacancy.visa_sponsorship_available ? "available" : "unavailable"}"), classes: "govuk-body-s govuk-!-padding-bottom-0"

--- a/app/views/vacancies/search/_results.html.slim
+++ b/app/views/vacancies/search/_results.html.slim
@@ -47,4 +47,4 @@
 
         - summary_list.row do |row|
           - row.key text: t("jobs.visa_sponsorship_row_title"), classes: "govuk-body-s govuk-!-font-weight-bold govuk-!-padding-bottom-0"
-          - row.value text: t("jobs.visa_sponsorship_#{vacancy.visa_sponsorship_available ? "available" : "unavailable"}"), classes: "govuk-body-s govuk-!-padding-bottom-0"
+          - row.value text: t("jobs.visa_sponsorship_#{vacancy.visa_sponsorship_available ? 'available' : 'unavailable'}"), classes: "govuk-body-s govuk-!-padding-bottom-0"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -479,6 +479,8 @@ en:
     international_teacher_advice:
         link: help you understand your next steps
         text_html: If you're interested in teaching or training to teach in England as an international citizen, we can %{link}.
+    sponsorship_available: Skilled worker sponsorship is available for this job.
+    sponsorship_unavailable: Skilled worker sponsorship is not available for this job.
     listing:
       enable_job_applications_tag: "Quick Apply"
       schools:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -479,8 +479,8 @@ en:
     international_teacher_advice:
         link: help you understand your next steps
         text_html: If you're interested in teaching or training to teach in England as an international citizen, we can %{link}.
-    sponsorship_available: Skilled worker sponsorship is available for this job.
-    sponsorship_unavailable: Skilled worker sponsorship is not available for this job.
+    sponsorship_available: Skilled worker visa sponsorship is available for this job.
+    sponsorship_unavailable: Skilled worker visa sponsorship is not available for this job.
     listing:
       enable_job_applications_tag: "Quick Apply"
       schools:

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -221,7 +221,9 @@ en:
     publish_on: Publish on
     expires_at: Closing date
     time_at: at
-
+    visa_sponsorship_row_title: Visa sponsorship
+    visa_sponsorship_available: Yes, visa sponsorship available
+    visa_sponsorship_unavailable: No, visa sponsorship not available
     supporting_documents: Supporting documents
     supporting_documents_accessibility: If you need these documents in an accessible format, please contact the school.
     no_files_message: No files selected

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -226,7 +226,9 @@ module VacancyHelpers
   def verify_vacancy_show_page_details(vacancy)
     vacancy = VacancyPresenter.new(vacancy)
     expect(page).to have_content(vacancy.job_title)
-    expect(page).to have_content(vacancy.readable_job_roles)
+    expect(page).to have_content(vacancy.readable_job_role)
+    sponsorship_text = vacancy.visa_sponsorship_available ? "Yes, visa sponsorship available" : "No, visa sponsorship not available"
+    expect(page).to have_content(sponsorship_text)
     vacancy.subjects.each { |subject| expect(page).to have_content subject }
 
     expect(page).to have_content(vacancy.readable_working_patterns)
@@ -255,6 +257,8 @@ module VacancyHelpers
     expect(page).to have_content(I18n.t("publishers.vacancies.steps.documents")) if vacancy.supporting_documents.any?
 
     if vacancy.enable_job_applications?
+      sponsorship_inset_text = vacancy.visa_sponsorship_available ? "Skilled worker sponsorship is available for this job." : "Skilled worker sponsorship is not available for this job."
+      expect(page).to have_content sponsorship_inset_text
       expect(page).to have_link(I18n.t("jobseekers.job_applications.apply"), href: new_jobseekers_job_job_application_path(vacancy.id))
     else
       expect(page).to have_content(I18n.t("jobs.apply_via_website"))

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -226,7 +226,7 @@ module VacancyHelpers
   def verify_vacancy_show_page_details(vacancy)
     vacancy = VacancyPresenter.new(vacancy)
     expect(page).to have_content(vacancy.job_title)
-    expect(page).to have_content(vacancy.readable_job_role)
+    expect(page).to have_content(vacancy.readable_job_roles)
     sponsorship_text = vacancy.visa_sponsorship_available ? "Yes, visa sponsorship available" : "No, visa sponsorship not available"
     expect(page).to have_content(sponsorship_text)
     vacancy.subjects.each { |subject| expect(page).to have_content subject }

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -257,7 +257,7 @@ module VacancyHelpers
     expect(page).to have_content(I18n.t("publishers.vacancies.steps.documents")) if vacancy.supporting_documents.any?
 
     if vacancy.enable_job_applications?
-      sponsorship_inset_text = vacancy.visa_sponsorship_available ? "Skilled worker sponsorship is available for this job." : "Skilled worker sponsorship is not available for this job."
+      sponsorship_inset_text = vacancy.visa_sponsorship_available ? "Skilled worker visa sponsorship is available for this job." : "Skilled worker visa sponsorship is not available for this job."
       expect(page).to have_content sponsorship_inset_text
       expect(page).to have_link(I18n.t("jobseekers.job_applications.apply"), href: new_jobseekers_job_job_application_path(vacancy.id))
     else


### PR DESCRIPTION
https://trello.com/c/gdfiLyHX/519-add-visa-sponsorship-onto-search-results-and-job-listing

## Changes in this PR:

This PR adds details of the visa sponsorship availability for vacancies on the vacancy search page and the vacancy listing page.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
