### PR TITLE
Docker image build is failing due to a vulnerable libwebp version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-# TODO: Remove procps-ng from this list once we upgrade to alpine > v3.18
-# The package is defined here with a hardcoded version to resolve a vulnerability in the procps-ng package coming with
+# TODO: Remove procps-ng and libwebp from this list once we upgrade to alpine > v3.18
+# The packages are defined here with a hardcoded version to resolve a vulnerability in the procps-ng and libwebp packages coming with
 # Alpine v3.18.
-ARG PROD_PACKAGES="imagemagick libxml2 libxslt libpq tzdata shared-mime-info procps-ng=4.0.4-r0"
+ARG PROD_PACKAGES="imagemagick libxml2 libxslt libpq tzdata shared-mime-info procps-ng=4.0.4-r0 libwebp=1.3.1-r1"
 
 FROM ruby:3.2.2-alpine3.18 AS builder
 


### PR DESCRIPTION
## Changes in this PR:

Fixes docker image build failures such as this: https://github.com/DFE-Digital/teaching-vacancies/actions/runs/6195731468/job/16820995886 by updating libwebp

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
