### PR TITLE
Fix wrong field being validated on vac. import

### DIFF
--- a/app/validators/external_vacancy_validator.rb
+++ b/app/validators/external_vacancy_validator.rb
@@ -4,7 +4,7 @@ class ExternalVacancyValidator < ActiveModel::Validator
       record,
       :job_title, :job_advert, :salary, :publish_on, :expires_at,
       :external_reference, :external_advert_url,
-      :job_role, :contract_type, :phases, :working_patterns
+      :job_roles, :contract_type, :phases, :working_patterns
     )
 
     record.errors.add(:organisations, "No school(s) associated with vacancy") if record.organisations.empty?


### PR DESCRIPTION
The field to validate is job_roles, as job_role is not used anymore.

This is causing issues when importing vacancies from ATS.