### PR TITLE
Profile location update

### DIFF
--- a/app/views/jobseekers/profiles/_summary.html.slim
+++ b/app/views/jobseekers/profiles/_summary.html.slim
@@ -20,13 +20,6 @@ p class="govuk-!-margin-bottom-3" = jobseeker_status(profile)
         - summary_list.row do |row|
           - row.key text: t(".working_patterns", count: patterns.count)
           - row.value text: humanize_array(patterns)
-      - if (locations = job_preferences.locations).present?
-        - summary_list.row do |row|
-          - row.key text: t(".locations", count: locations.count)
-          - row.value do
-            .govuk-list
-              - locations.each do |location|
-                li = "#{location.name} (#{t('jobs.search.number_of_miles', count: location.radius&.to_i)})"
 
 - if profile.about_you.present?
   h2.govuk-heading-m class="govuk-!-padding-bottom-2"

--- a/app/views/jobseekers/profiles/job_preferences/_summary.html.slim
+++ b/app/views/jobseekers/profiles/job_preferences/_summary.html.slim
@@ -21,11 +21,6 @@ ruby:
       map_values: ->(value, step) { step.options[value] },
       join_with: ", ",
     },
-    locations: {
-      if: ->(form) { form.locations.any? },
-      map_values: ->((_, value), _) { "#{value[:location]} (#{t('jobs.search.number_of_miles', count: value[:radius].to_i)})" },
-      join_with: "</br>",
-    },
   }
 
   list = govuk_summary_list do |summary_list|

--- a/app/views/jobseekers/profiles/job_preferences/_summary.html.slim
+++ b/app/views/jobseekers/profiles/job_preferences/_summary.html.slim
@@ -21,6 +21,11 @@ ruby:
       map_values: ->(value, step) { step.options[value] },
       join_with: ", ",
     },
+    locations: {
+      if: ->(form) { form.locations.any? },
+      map_values: ->((_, value), _) { "#{value[:location]} (#{t('jobs.search.number_of_miles', count: value[:radius].to_i)})" },
+      join_with: "</br>",
+    },
   }
 
   list = govuk_summary_list do |summary_list|

--- a/app/views/publishers/jobseeker_profiles/index.html.slim
+++ b/app/views/publishers/jobseeker_profiles/index.html.slim
@@ -3,14 +3,13 @@
 h1 class="govuk-heading-l" role="heading" aria-level="1"
   = t("publishers.jobseeker_profiles.search_result_heading", count: number_with_delimiter(@pagy.count))
 
-p = t("publishers.jobseeker_profiles.available_to_travel_text")
-
 .govuk-grid-row
   .govuk-grid-column-one-third-at-desktop class="govuk-!-margin-bottom-3"
     = form_for @form, as: "", url: url_for, method: "get", html: { data: { controller: "form" }, role: "search" } do |f|
       = render "publishers/jobseeker_profiles/search/filters", f: f, form: @form, jobseeker_profile_search: @jobseeker_profile_search
 
   .govuk-grid-column-two-thirds-at-desktop
+    p = t("publishers.jobseeker_profiles.available_to_travel_text")
     - if @jobseeker_profiles.any?
       p = t("publishers.jobseeker_profiles.sort_result_text")
       #search-results

--- a/app/views/publishers/jobseeker_profiles/index.html.slim
+++ b/app/views/publishers/jobseeker_profiles/index.html.slim
@@ -9,7 +9,7 @@ h1 class="govuk-heading-l" role="heading" aria-level="1"
       = render "publishers/jobseeker_profiles/search/filters", f: f, form: @form, jobseeker_profile_search: @jobseeker_profile_search
 
   .govuk-grid-column-two-thirds-at-desktop
-    p = t("publishers.jobseeker_profiles.available_to_travel_text")
+    p.govuk-body-l = t("publishers.jobseeker_profiles.available_to_travel_text")
     - if @jobseeker_profiles.any?
       p = t("publishers.jobseeker_profiles.sort_result_text")
       #search-results

--- a/spec/factories/jobseeker_profiles.rb
+++ b/spec/factories/jobseeker_profiles.rb
@@ -15,6 +15,10 @@ FactoryBot.define do
       job_preferences { build(:job_preferences, jobseeker_profile: instance) }
     end
 
+    trait :with_location_preferences do
+      job_preferences { build(:job_preferences, :with_locations, jobseeker_profile: instance) }
+    end
+
     trait :with_qualifications do
       qualifications { [build(:qualification, jobseeker_profile: instance)] }
     end

--- a/spec/system/publishers/publishers_can_view_a_jobseeker_profile_spec.rb
+++ b/spec/system/publishers/publishers_can_view_a_jobseeker_profile_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Jobseeker profiles", type: :system do
   let(:publisher) { create(:publisher) }
   let(:organisation) { create(:school) }
-  let(:jobseeker_profile) { create(:jobseeker_profile, :completed) }
+  let(:jobseeker_profile) { create(:jobseeker_profile, :completed, :with_location_preferences) }
 
   scenario "A publisher can view a jobseeker's profile" do
     login_publisher(publisher:, organisation:)
@@ -13,5 +13,6 @@ RSpec.describe "Jobseeker profiles", type: :system do
     expect(page).to have_content(jobseeker_profile.jobseeker.email)
     expect(page).to have_content(jobseeker_profile.qualified_teacher_status_year)
     expect(page).to have_content(jobseeker_profile.about_you)
+    expect(page).not_to have_content("Location")
   end
 end


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/KSrpBpIO/535-profiles-location-updates-hiring-staff-one-school-sat

## Changes in this PR:
This PR changes the location of the hint text on the jobseeker profiles search page and removes the location information on the jobseeker profile page.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
