### PR TITLE
Add job preferences jobseeker profile id to pii

### DIFF
--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -42,6 +42,8 @@ shared:
     - id
     - email
     - unconfirmed_email
+  job_preferences:
+    - jobseeker_profile_id
   notifications:
     - recipient_id
   organisations:


### PR DESCRIPTION
This adds consistency in sending record ids to BigQuery and helps our performance analyst cross-reference records.