### PR TITLE
Profile location update mats

### DIFF
--- a/app/views/publishers/jobseeker_profiles/index.html.slim
+++ b/app/views/publishers/jobseeker_profiles/index.html.slim
@@ -10,7 +10,7 @@ h1 class="govuk-heading-l" role="heading" aria-level="1"
 
   .govuk-grid-column-two-thirds-at-desktop
     - if current_organisation.trust?
-      p.govuk-body-l = t("publishers.jobseeker_profiles.trusts.available_to_travel_text.#{@form.locations.present? ? "selected_locations" : "all_locations"}")
+      p.govuk-body-l = t("publishers.jobseeker_profiles.trusts.available_to_travel_text.#{@form.locations.present? ? 'selected_locations' : 'all_locations'}")
     - else
       p.govuk-body-l = t("publishers.jobseeker_profiles.non_trusts.available_to_travel_text")
     - if @jobseeker_profiles.any?

--- a/app/views/publishers/jobseeker_profiles/index.html.slim
+++ b/app/views/publishers/jobseeker_profiles/index.html.slim
@@ -10,6 +10,10 @@ h1 class="govuk-heading-l" role="heading" aria-level="1"
 
   .govuk-grid-column-two-thirds-at-desktop
     p.govuk-body-l = t("publishers.jobseeker_profiles.available_to_travel_text")
+    - if current_organisation.trust?
+      p.govuk-body-l = t("publishers.jobseeker_profiles.trusts.available_to_travel_text.#{@form.locations.present? ? "selected_locations" : "all_locations"}")
+    - else
+      p.govuk-body-l = t("publishers.jobseeker_profiles.non_trusts.available_to_travel_text")
     - if @jobseeker_profiles.any?
       p = t("publishers.jobseeker_profiles.sort_result_text")
       #search-results

--- a/app/views/publishers/jobseeker_profiles/index.html.slim
+++ b/app/views/publishers/jobseeker_profiles/index.html.slim
@@ -9,7 +9,6 @@ h1 class="govuk-heading-l" role="heading" aria-level="1"
       = render "publishers/jobseeker_profiles/search/filters", f: f, form: @form, jobseeker_profile_search: @jobseeker_profile_search
 
   .govuk-grid-column-two-thirds-at-desktop
-    p.govuk-body-l = t("publishers.jobseeker_profiles.available_to_travel_text")
     - if current_organisation.trust?
       p.govuk-body-l = t("publishers.jobseeker_profiles.trusts.available_to_travel_text.#{@form.locations.present? ? "selected_locations" : "all_locations"}")
     - else

--- a/app/views/publishers/jobseeker_profiles/index.html.slim
+++ b/app/views/publishers/jobseeker_profiles/index.html.slim
@@ -14,7 +14,7 @@ h1 class="govuk-heading-l" role="heading" aria-level="1"
         p.govuk-body-l = t("publishers.jobseeker_profiles.trusts.available_to_travel_text.all_locations")
       - elsif @form.locations.count > 1
         p.govuk-body-l = t("publishers.jobseeker_profiles.trusts.available_to_travel_text.selected_locations")
-      - else 
+      - else
         p.govuk-body-l = t("publishers.jobseeker_profiles.trusts.available_to_travel_text.single_selected_location")
     - else
       p.govuk-body-l = t("publishers.jobseeker_profiles.non_trusts.available_to_travel_text")

--- a/app/views/publishers/jobseeker_profiles/index.html.slim
+++ b/app/views/publishers/jobseeker_profiles/index.html.slim
@@ -10,9 +10,15 @@ h1 class="govuk-heading-l" role="heading" aria-level="1"
 
   .govuk-grid-column-two-thirds-at-desktop
     - if current_organisation.trust?
-      p.govuk-body-l = t("publishers.jobseeker_profiles.trusts.available_to_travel_text.#{@form.locations.present? ? 'selected_locations' : 'all_locations'}")
+      - if @form.locations.blank?
+        p.govuk-body-l = t("publishers.jobseeker_profiles.trusts.available_to_travel_text.all_locations")
+      - elsif @form.locations.count > 1
+        p.govuk-body-l = t("publishers.jobseeker_profiles.trusts.available_to_travel_text.selected_locations")
+      - else 
+        p.govuk-body-l = t("publishers.jobseeker_profiles.trusts.available_to_travel_text.single_selected_location")
     - else
       p.govuk-body-l = t("publishers.jobseeker_profiles.non_trusts.available_to_travel_text")
+
     - if @jobseeker_profiles.any?
       p = t("publishers.jobseeker_profiles.sort_result_text")
       #search-results

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -63,7 +63,12 @@ en:
     job_listing_process_changed_draft_banner:
       heading_html: "You cannot make changes to this draft job listing. %{create_new_link} or %{contact_support_link}."
     jobseeker_profiles:
-      available_to_travel_text: "These candidates are willing to travel to a location that’s near to your school."
+      trusts:
+        available_to_travel_text:
+          selected_locations: "These candidates are willing to travel to your selected school locations."
+          all_locations:  "These candidates are willing to travel to a locations that's near at least one of your schools."
+      non_trusts:
+        available_to_travel_text: "These candidates are willing to travel to a location that’s near to your school."
       index:
         no_results:
           heading: No candidates found

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -66,7 +66,7 @@ en:
       trusts:
         available_to_travel_text:
           selected_locations: "These candidates are willing to travel to your selected school locations."
-          all_locations:  "These candidates are willing to travel to a locations that's near at least one of your schools."
+          all_locations:  "These candidates are willing to travel to a location that's near to at least one of your schools."
       non_trusts:
         available_to_travel_text: "These candidates are willing to travel to a location that’s near to your school."
       index:

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -65,7 +65,8 @@ en:
     jobseeker_profiles:
       trusts:
         available_to_travel_text:
-          selected_locations: "These candidates are willing to travel to your selected school locations."
+          single_selected_location: "These candidates are willing to travel to your selected school location."
+          selected_locations: "These candidates are willing to travel to at least one of your selected school locations."
           all_locations:  "These candidates are willing to travel to a location that's near to at least one of your schools."
       non_trusts:
         available_to_travel_text: "These candidates are willing to travel to a location that’s near to your school."

--- a/spec/system/publishers/publishers_can_search_for_jobseeker_profiles_spec.rb
+++ b/spec/system/publishers/publishers_can_search_for_jobseeker_profiles_spec.rb
@@ -3,6 +3,10 @@ require "rails_helper"
 RSpec.describe "Publishers searching for Jobseeker profiles", type: :system do
   let(:publisher) { create(:publisher, organisations: [organisation]) }
   let(:organisation) { create(:school, geopoint: "POINT (-0.108267 51.506438)") }
+  let(:school_oxford) { create(:school, name: "Oxford", geopoint: "POINT (-0.108267 51.506438)") }
+  let(:school_cambridge) { create(:school, name: "Cambridge", geopoint: "POINT (-0.108267 51.506438)") }
+  let(:trust_publisher) { create(:publisher, organisations: [trust]) }
+  let(:trust) { create(:trust, schools: [school_oxford, school_cambridge], geopoint: "POINT (-0.108267 51.506438)") }
 
   let!(:jobseeker_profile) { create(:jobseeker_profile, :with_personal_details, qualified_teacher_status: "yes", qualified_teacher_status_year: "2000", job_preferences: job_preferences) }
   let(:job_preferences) { create(:job_preferences, roles: %w[teacher], key_stages: %w[ks1], working_patterns: %w[full_time], locations: [location_preference_containing_school]) }
@@ -17,9 +21,10 @@ RSpec.describe "Publishers searching for Jobseeker profiles", type: :system do
   let(:no_right_to_work_in_uk_preferences) { create(:job_preferences, roles: %w[teacher], key_stages: %w[ks1], working_patterns: %w[part_time], locations: [no_right_to_work_in_uk_containing_school]) }
   let(:no_right_to_work_in_uk_containing_school) { create(:job_preferences_location, name: "London", radius: 100) }
 
-  before { login_publisher(publisher:, organisation:) }
-
   describe "Visiting the publisher's jobseeker profiles start page" do
+    before { login_publisher(publisher:, organisation:) }
+    context "when user is not a MAT" do
+    end
     it "will display all jobseeker profiles with location preference areas containing the school" do
       visit publishers_jobseeker_profiles_path
 
@@ -91,6 +96,38 @@ RSpec.describe "Publishers searching for Jobseeker profiles", type: :system do
         expect(page).not_to have_link(I18n.t("publishers.jobseeker_profiles.filters.key_stage_options.ks5"))
         expect(page).not_to have_link(I18n.t("publishers.jobseeker_profiles.filters.right_to_work_in_uk_options.true"))
       end
+    end
+  end
+
+  context "when organisation is a trust" do
+    before do 
+      login_publisher(publisher: trust_publisher, organisation: trust)
+      visit publishers_jobseeker_profiles_path
+    end
+
+    context "when no locations are selected in the filters" do
+      it "shows text explaining that the candidates are willing travel to one of more of the locations" do
+        expect(page).to have_selector('p', text: "These candidates are willing to travel to a locations that's near at least one of your schools.")
+      end
+    end
+
+    context "when locations are selected in the filters" do
+      it "shows text explaining that the candidates are willing travel to selected locations" do
+        check "Oxford"
+        click_button "Apply filters"
+        expect(page).to have_selector('p', text: "These candidates are willing to travel to your selected school locations.")
+      end
+    end
+  end
+
+  context "when organisation is not a trust" do
+    before do 
+      login_publisher(publisher:, organisation:)
+      visit publishers_jobseeker_profiles_path
+    end
+
+    it "shows text explaining that the candidates are willing to travel to the school" do
+      expect(page).to have_selector('p', text: "These candidates are willing to travel to a location that’s near to your school.")
     end
   end
 end

--- a/spec/system/publishers/publishers_can_search_for_jobseeker_profiles_spec.rb
+++ b/spec/system/publishers/publishers_can_search_for_jobseeker_profiles_spec.rb
@@ -106,15 +106,24 @@ RSpec.describe "Publishers searching for Jobseeker profiles", type: :system do
 
     context "when no locations are selected in the filters" do
       it "shows text explaining that the candidates are willing travel to one of more of the locations" do
-        expect(page).to have_selector("p", text: "These candidates are willing to travel to a locations that's near at least one of your schools.")
+        expect(page).to have_selector("p", text: "These candidates are willing to travel to a location that's near to at least one of your schools.")
       end
     end
 
-    context "when locations are selected in the filters" do
-      it "shows text explaining that the candidates are willing travel to selected locations" do
+    context "when 1 location is selected in the filters" do
+      it "shows text explaining that the candidates are willing travel to the selected location" do
         check "Oxford"
         click_button "Apply filters"
-        expect(page).to have_selector("p", text: "These candidates are willing to travel to your selected school locations.")
+        expect(page).to have_selector("p", text: "These candidates are willing to travel to your selected school location.")
+      end
+    end
+
+    context "when multiple locations are selected in the filters" do
+      it "shows text explaining that the candidates are willing travel to at least one of the selected locations" do
+        check "Oxford"
+        check "Cambridge"
+        click_button "Apply filters"
+        expect(page).to have_selector("p", text: "These candidates are willing to travel to at least one of your selected school locations.")
       end
     end
   end

--- a/spec/system/publishers/publishers_can_search_for_jobseeker_profiles_spec.rb
+++ b/spec/system/publishers/publishers_can_search_for_jobseeker_profiles_spec.rb
@@ -23,8 +23,7 @@ RSpec.describe "Publishers searching for Jobseeker profiles", type: :system do
 
   describe "Visiting the publisher's jobseeker profiles start page" do
     before { login_publisher(publisher:, organisation:) }
-    context "when user is not a MAT" do
-    end
+
     it "will display all jobseeker profiles with location preference areas containing the school" do
       visit publishers_jobseeker_profiles_path
 
@@ -100,14 +99,14 @@ RSpec.describe "Publishers searching for Jobseeker profiles", type: :system do
   end
 
   context "when organisation is a trust" do
-    before do 
+    before do
       login_publisher(publisher: trust_publisher, organisation: trust)
       visit publishers_jobseeker_profiles_path
     end
 
     context "when no locations are selected in the filters" do
       it "shows text explaining that the candidates are willing travel to one of more of the locations" do
-        expect(page).to have_selector('p', text: "These candidates are willing to travel to a locations that's near at least one of your schools.")
+        expect(page).to have_selector("p", text: "These candidates are willing to travel to a locations that's near at least one of your schools.")
       end
     end
 
@@ -115,19 +114,19 @@ RSpec.describe "Publishers searching for Jobseeker profiles", type: :system do
       it "shows text explaining that the candidates are willing travel to selected locations" do
         check "Oxford"
         click_button "Apply filters"
-        expect(page).to have_selector('p', text: "These candidates are willing to travel to your selected school locations.")
+        expect(page).to have_selector("p", text: "These candidates are willing to travel to your selected school locations.")
       end
     end
   end
 
   context "when organisation is not a trust" do
-    before do 
+    before do
       login_publisher(publisher:, organisation:)
       visit publishers_jobseeker_profiles_path
     end
 
     it "shows text explaining that the candidates are willing to travel to the school" do
-      expect(page).to have_selector('p', text: "These candidates are willing to travel to a location that’s near to your school.")
+      expect(page).to have_selector("p", text: "These candidates are willing to travel to a location that’s near to your school.")
     end
   end
 end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/aSlYhJ7l/536-profiles-location-updates-hiring-staff-multiple-schools-mat

## Changes in this PR:

This PR adds additional functionality for trusts, changing the hint text at the top of the candidate profiles search results.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
