### PR TITLE
Add cloudfront AKS configuration

### DIFF
--- a/terraform/app/modules/cloudfront/variables.tf
+++ b/terraform/app/modules/cloudfront/variables.tf
@@ -26,11 +26,11 @@ variable "route53_cname_record" {}
 variable "route53_a_records" {}
 
 locals {
-  route53_zones                                          = toset(var.route53_zones)
-  route53_zones_with_a_records                           = var.is_production ? local.route53_zones : toset([])
-  route53_zones_with_cnames                              = local.route53_zones
-  cloudfront_cert_cn                                     = "${var.service_name}.service.gov.uk"
-  domain                                                 = var.is_production ? local.cloudfront_cert_cn : "${var.environment}.${local.cloudfront_cert_cn}"
+  route53_zones                = toset(var.route53_zones)
+  route53_zones_with_a_records = var.is_production && length(var.route53_a_records) > 0 ? local.route53_zones : toset([])
+  route53_zones_with_cnames    = local.route53_zones
+  cloudfront_cert_cn           = "${var.service_name}.service.gov.uk"
+
   cloudfront_aliases_cnames                              = [for zone in var.route53_zones : "${var.route53_cname_record}.${zone}"]
   cloudfront_aliases                                     = concat(var.route53_a_records, local.cloudfront_aliases_cnames)
   cloudfront_viewer_certificate_minimum_protocol_version = "TLSv1.2_2021"

--- a/terraform/app/modules/paas/aks_application.tf
+++ b/terraform/app/modules/paas/aks_application.tf
@@ -41,9 +41,10 @@ module "web_application" {
   kubernetes_config_map_name = module.application_configuration.kubernetes_config_map_name
   kubernetes_secret_name     = module.application_configuration.kubernetes_secret_name
 
-  docker_image = var.app_docker_image
-  command      = var.aks_web_app_start_command
-  probe_path   = "/check"
+  docker_image           = var.app_docker_image
+  command                = var.aks_web_app_start_command
+  probe_path             = "/check"
+  web_external_hostnames = var.web_external_hostnames_aks
 }
 
 module "worker_application" {

--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -90,6 +90,9 @@ variable "route53_a_records" {
 variable "hostname_domain_map" {
   type = map(any)
 }
+variable "web_external_hostnames_aks" {
+  type = list(string)
+}
 variable "restore_from_db_guid" {
 
 }

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -51,6 +51,24 @@ module "cloudfront" {
   }
 }
 
+module "cloudfront_aks" {
+  source                        = "./modules/cloudfront"
+  for_each                      = var.distribution_list_aks
+  environment                   = var.environment
+  enable_cloudfront_compress    = var.enable_cloudfront_compress
+  service_name                  = local.service_name
+  cloudfront_origin_domain_name = each.value.cloudfront_origin_domain_name
+  offline_bucket_domain_name    = each.value.offline_bucket_domain_name
+  offline_bucket_origin_path    = each.value.offline_bucket_origin_path
+  route53_zones                 = var.route53_zones
+  is_production                 = local.is_production
+  route53_a_records             = local.route53_a_records_aks
+  route53_cname_record          = local.route53_cname_record_aks
+  providers = {
+    aws.aws_us_east_1 = aws.aws_us_east_1
+  }
+}
+
 module "cloudwatch" {
   source            = "./modules/cloudwatch"
   for_each          = var.channel_list
@@ -116,6 +134,7 @@ module "paas" {
   redis_queue_sku_name              = var.redis_queue_sku_name
   add_database_name_suffix          = var.add_database_name_suffix
   azure_enable_backup_storage       = var.azure_enable_backup_storage
+  web_external_hostnames_aks        = local.web_external_hostnames_aks
 }
 
 module "statuscake" {

--- a/terraform/workspace-variables/production.tfvars.json
+++ b/terraform/workspace-variables/production.tfvars.json
@@ -12,6 +12,13 @@
       "offline_bucket_origin_path": "/teaching-vacancies-offline"
     }
   },
+  "distribution_list_aks": {
+    "tvsprod_aks": {
+      "cloudfront_origin_domain_name": "teaching-vacancies-production.teacherservices.cloud",
+      "offline_bucket_domain_name": "530003481352-offline-site.s3.amazonaws.com",
+      "offline_bucket_origin_path": "/teaching-vacancies-offline"
+    }
+  },
   "documents_s3_bucket_force_destroy": false,
   "environment": "production",
   "paas_app_start_timeout": "180",

--- a/terraform/workspace-variables/production_app_env.yml
+++ b/terraform/workspace-variables/production_app_env.yml
@@ -8,7 +8,7 @@ DFE_SIGN_IN_REGISTRATION_URL: https://profile.signin.education.gov.uk/register
 DFE_SIGN_IN_URL: https://api.signin.education.gov.uk
 DISABLE_EXPENSIVE_JOBS: false
 DOMAIN: teaching-vacancies.service.gov.uk
-TEMP_DOMAIN: teaching-vacancies-production.teacherservices.cloud
+TEMP_DOMAIN: www2.teaching-vacancies.service.gov.uk
 ENFORCE_LOCAL_AUTHORITY_ALLOWLIST: true
 GOOGLE_TAG_MANAGER_CONTAINER_ID: GTM-P5L2QHV
 MALLOC_ARENA_MAX: 2

--- a/terraform/workspace-variables/qa.tfvars.json
+++ b/terraform/workspace-variables/qa.tfvars.json
@@ -13,6 +13,16 @@
         }
     }
   ,
+  "distribution_list_aks":
+    {
+      "tvsqaaks":
+        {
+          "cloudfront_origin_domain_name": "teaching-vacancies-qa.test.teacherservices.cloud",
+          "offline_bucket_domain_name": "530003481352-offline-site.s3.amazonaws.com",
+          "offline_bucket_origin_path": "/teaching-vacancies-offline"
+        }
+    }
+  ,
   "documents_s3_bucket_force_destroy": false,
   "environment": "qa",
   "paas_app_start_timeout": "180",

--- a/terraform/workspace-variables/qa_app_env.yml
+++ b/terraform/workspace-variables/qa_app_env.yml
@@ -8,7 +8,7 @@ DFE_SIGN_IN_REGISTRATION_URL: https://test-profile.signin.education.gov.uk/regis
 DFE_SIGN_IN_URL: https://test-api.signin.education.gov.uk
 DISABLE_EXPENSIVE_JOBS: true
 DOMAIN: qa.teaching-vacancies.service.gov.uk
-TEMP_DOMAIN: teaching-vacancies-qa.test.teacherservices.cloud
+TEMP_DOMAIN: qa2.teaching-vacancies.service.gov.uk
 ENFORCE_LOCAL_AUTHORITY_ALLOWLIST: false
 RAILS_ENV: production
 RAILS_LOG_TO_STDOUT: true

--- a/terraform/workspace-variables/sandbox.tfvars.json
+++ b/terraform/workspace-variables/sandbox.tfvars.json
@@ -1,13 +1,23 @@
 {
     "app_environment": "sandbox",
-    "channel_list": {},
+    "channel_list": {}
+    ,
     "distribution_list": {
         "tvssandbox": {
             "cloudfront_origin_domain_name": "teaching-vacancies-sandbox.london.cloudapps.digital",
             "offline_bucket_domain_name": "530003481352-offline-site.s3.amazonaws.com",
             "offline_bucket_origin_path": "/teaching-vacancies-offline"
         }
-    },
+    }
+    ,
+    "distribution_list_aks": {
+        "tvssandboxaks": {
+            "cloudfront_origin_domain_name": "teaching-vacancies-sandbox.teacherservices.cloud",
+            "offline_bucket_domain_name": "530003481352-offline-site.s3.amazonaws.com",
+            "offline_bucket_origin_path": "/teaching-vacancies-offline"
+        }
+    }
+    ,
     "documents_s3_bucket_force_destroy": false,
     "environment": "sandbox",
     "paas_app_start_timeout": "180",

--- a/terraform/workspace-variables/sandbox_app_env.yml
+++ b/terraform/workspace-variables/sandbox_app_env.yml
@@ -8,7 +8,7 @@ DFE_SIGN_IN_REGISTRATION_URL: https://profile.signin.education.gov.uk/register
 DFE_SIGN_IN_URL: https://api.signin.education.gov.uk
 DISABLE_EXPENSIVE_JOBS: true
 DOMAIN: sandbox.teaching-vacancies.service.gov.uk
-TEMP_DOMAIN: teaching-vacancies-sandbox.teacherservices.cloud
+TEMP_DOMAIN: sandbox2.teaching-vacancies.service.gov.uk
 ENFORCE_LOCAL_AUTHORITY_ALLOWLIST: true
 RAILS_ENV: production
 RAILS_LOG_TO_STDOUT: true

--- a/terraform/workspace-variables/staging.tfvars.json
+++ b/terraform/workspace-variables/staging.tfvars.json
@@ -18,6 +18,16 @@
         }
     }
   ,
+  "distribution_list_aks":
+    {
+      "tvsstagingaks":
+        {
+          "cloudfront_origin_domain_name": "teaching-vacancies-staging.test.teacherservices.cloud",
+          "offline_bucket_domain_name": "530003481352-offline-site.s3.amazonaws.com",
+          "offline_bucket_origin_path": "/teaching-vacancies-offline"
+        }
+    }
+  ,
   "documents_s3_bucket_force_destroy": false,
   "environment": "staging",
   "paas_app_start_timeout": "180",

--- a/terraform/workspace-variables/staging_app_env.yml
+++ b/terraform/workspace-variables/staging_app_env.yml
@@ -8,7 +8,7 @@ DFE_SIGN_IN_REGISTRATION_URL: https://pp-profile.signin.education.gov.uk/registe
 DFE_SIGN_IN_URL: https://pp-api.signin.education.gov.uk
 DISABLE_EXPENSIVE_JOBS: true
 DOMAIN: staging.teaching-vacancies.service.gov.uk
-TEMP_DOMAIN: teaching-vacancies-staging.test.teacherservices.cloud
+TEMP_DOMAIN: staging2.teaching-vacancies.service.gov.uk
 ENFORCE_LOCAL_AUTHORITY_ALLOWLIST: false
 MALLOC_ARENA_MAX: 2
 RAILS_ENV: production


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/QvrkR3vd/606-create-dns-zone-in-azure-dns-via-terraform-and-migrate
## Changes in this PR:
Create a new Cloudfront pointing at AKS. Duplicate the domains eg "staging becomes staging2"


## How to review 
Already deployed: https://www2.teaching-vacancies.service.gov.uk/
