### PR TITLE
Fix: Do not override vacancy source parsing errors

### DIFF
--- a/app/jobs/import_from_vacancy_sources_job.rb
+++ b/app/jobs/import_from_vacancy_sources_job.rb
@@ -28,7 +28,10 @@ class ImportFromVacancySourcesJob < ApplicationJob
       total_count += 1
 
       PaperTrail.request(whodunnit: "Import from external source") do
-        if vacancy.save
+        # Only attempt to save if there are no errors coming from the source parsing.
+        # If we save a vacancy that had custom errors, they get removed with the saving validation and we will miss
+        # valuable error debugging information.
+        if vacancy.errors.none? && vacancy.save
           log(source_name, "Imported vacancy #{vacancy.id}.")
         else
           failure = create_failed_imported_vacancy(source_name, vacancy)

--- a/spec/jobs/import_from_vacancy_sources_job_spec.rb
+++ b/spec/jobs/import_from_vacancy_sources_job_spec.rb
@@ -160,6 +160,7 @@ RSpec.describe ImportFromVacancySourcesJob do
         expect(vacancy).to_not be_valid
         expect(Vacancy.count).to eq(0)
         expect(FailedImportedVacancy.count).to eq(1)
+        expect(FailedImportedVacancy.first.import_errors).to eq(["base:[blah]"])
       end
     end
 

--- a/spec/vacancy_sources/vacancy_source/source/broadbean_spec.rb
+++ b/spec/vacancy_sources/vacancy_source/source/broadbean_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe VacancySource::Source::Broadbean do
   let(:response_body) { file_fixture("vacancy_sources/broadbean.xml").read }
   let(:response) { double("BroadbeanHttpResponse", success?: true, body: response_body) }
 
-  let!(:school1) { create(:school, name: "Test School", urn: "111111", phase: :primary) }
+  let!(:school1) { create(:school, name: "Test School", urn: "111111", phase: :primary, created_at: 1.week.ago) }
   let!(:school_group) { create(:school_group, name: "E-ACT", uid: "12345", schools: schools) }
   let(:schools) { [school1] }
 


### PR DESCRIPTION

## Trello card URL
- https://trello.com/c/YvKSN890

## Changes in this PR:
When the source parsing adds an error to a Vacancy, this custom error was getting overridden with the blind attempt to save the vacancy from the orchestrator class in a later stage.

The attempt to save triggers its own validation that erases any existing error message attached to the vacancy object.

Example:
A vacancy containing an invalid job "FooBar" would get an error attached as "base: ['FooBar is not a valid job_roles']" when trying to assign the import source attributes to a new Vacancy object.

Then, the field itself would become empty due to the failed assignation: "vacancy.job_roles -> []"

If we try to do "vacancy.save" , it fails validation but tells us that job_roles and any other following field in the assignation are Empty.

So the consequences are:

1 - We get a "cannot be blank" error for a field that wasn't blank but
  contained wrong information. Missing essential information for its
  debugging.
2 - WE get a bunch of other field errors for the following fields that were
  present but didn't get assigned due to the first error. These are not
  real errors and only add noise and confusion.

Solution:
If a Vacancy comes from the parsing stage with existing errors, do not attempt to save it and just create a FailedImportedVacancy object with the incoming error. This error will highlight the issue with the source data.

