### PR TITLE
Fix phase mapping for all sources

### DIFF
--- a/app/vacancy_sources/vacancy_source/source/broadbean.rb
+++ b/app/vacancy_sources/vacancy_source/source/broadbean.rb
@@ -58,7 +58,7 @@ class VacancySource::Source::Broadbean
       subjects: item["subjects"].presence&.split(","),
       working_patterns: item["workingPatterns"].presence&.split(","),
       contract_type: item["contractType"].presence,
-      phases: phases_for(item),
+      phases: phase_for(item),
     }.merge(organisation_fields(item))
      .merge(start_date_fields(item))
   end
@@ -96,10 +96,12 @@ class VacancySource::Source::Broadbean
     item["ectSuitable"] == "yes" ? "ect_suitable" : "ect_unsuitable"
   end
 
-  def phases_for(item)
-    item["phase"].presence
-    &.gsub("all_through", "through")
-    &.gsub(/\s+/, "")
+  def phase_for(item)
+    return if item["phase"].blank?
+
+    item["phase"].strip
+                 .gsub(/all_through|through_school/, "through")
+                 .gsub(/16-19|16_19/, "sixth_form_or_college")
   end
 
   def organisation_fields(item)

--- a/app/vacancy_sources/vacancy_source/source/every.rb
+++ b/app/vacancy_sources/vacancy_source/source/every.rb
@@ -49,7 +49,7 @@ class VacancySource::Source::Every
       subjects: item["subjects"].presence&.split(","),
       working_patterns: item["workingPatterns"].presence&.split(","),
       contract_type: item["contractType"].presence,
-      phases: item["phase"].presence&.parameterize(separator: "_"),
+      phases: phase_for(item),
       key_stages: item["keyStages"].presence&.split(","),
       visa_sponsorship_available: false,
 
@@ -114,6 +114,15 @@ class VacancySource::Source::Every
     return unless item["ectSuitable"].presence
 
     item["ectSuitable"].to_s == "true" ? "ect_suitable" : "ect_unsuitable"
+  end
+
+  def phase_for(item)
+    return if item["phase"].blank?
+
+    item["phase"].strip
+                 .parameterize(separator: "_")
+                 .gsub("through_school", "through")
+                 .gsub(/16-19|16_19/, "sixth_form_or_college")
   end
 
   def results

--- a/app/vacancy_sources/vacancy_source/source/fusion.rb
+++ b/app/vacancy_sources/vacancy_source/source/fusion.rb
@@ -49,7 +49,7 @@ class VacancySource::Source::Fusion
       subjects: item["subjects"].presence&.split(","),
       working_patterns: item["workingPatterns"].presence&.split(","),
       contract_type: item["contractType"].presence,
-      phases: item["phase"].presence&.parameterize(separator: "_"),
+      phases: phase_for(item),
       key_stages: item["keyStages"].presence&.split(","),
       visa_sponsorship_available: false,
 
@@ -111,6 +111,15 @@ class VacancySource::Source::Fusion
     return unless item["ect_suitable"].presence
 
     item["ectSuitable"] == "yes" ? "ect_suitable" : "ect_unsuitable"
+  end
+
+  def phase_for(item)
+    return if item["phase"].blank?
+
+    item["phase"].strip
+                 .parameterize(separator: "_")
+                 .gsub("through_school", "through")
+                 .gsub(/16-19|16_19/, "sixth_form_or_college")
   end
 
   def results

--- a/app/vacancy_sources/vacancy_source/source/my_new_term.rb
+++ b/app/vacancy_sources/vacancy_source/source/my_new_term.rb
@@ -55,7 +55,7 @@ class VacancySource::Source::MyNewTerm
       subjects: item["subjects"].presence,
       working_patterns: item["workingPatterns"].presence,
       contract_type: item["contractType"]&.first,
-      phases: phases_for(item),
+      phases: phase_for(item),
       key_stages: key_stages_for(item),
       job_location: :at_one_school,
       visa_sponsorship_available: false,
@@ -126,10 +126,12 @@ class VacancySource::Source::MyNewTerm
     end
   end
 
-  def phases_for(item)
-    item["phase"].presence
-    &.gsub("all_through", "through")
-    &.gsub(/\s+/, "")
+  def phase_for(item)
+    return if item["phase"].blank?
+
+    item["phase"].strip
+                 .gsub(/all_through|through_school/, "through")
+                 .gsub(/16-19|16_19/, "sixth_form_or_college")
   end
 
   def results

--- a/app/vacancy_sources/vacancy_source/source/united_learning.rb
+++ b/app/vacancy_sources/vacancy_source/source/united_learning.rb
@@ -60,9 +60,7 @@ class VacancySource::Source::UnitedLearning
       subjects: item["Subjects"].presence&.split(","),
       working_patterns: item["Working_patterns"].presence&.split(","),
       contract_type: item["Contract_type"].presence,
-      # TODO: This is coming through unexpectedly in the feed - the parameterize call can be removed
-      #       when the correct values are coming through
-      phases: [organisations_for(item).first&.readable_phase],
+      phases: phase_for(item),
       organisations: organisations_for(item),
       about_school: organisations_for(item).first&.description,
       visa_sponsorship_available: false,
@@ -93,6 +91,15 @@ class VacancySource::Source::UnitedLearning
 
   def school_group
     @school_group ||= SchoolGroup.find_by(uid: UNITED_LEARNING_TRUST_UID)
+  end
+
+  def phase_for(item)
+    return if item["Phase"].blank?
+
+    item["Phase"].strip
+                 .parameterize(separator: "_")
+                 .gsub("through_school", "through")
+                 .gsub(/16-19|16_19/, "sixth_form_or_college")
   end
 
   def feed

--- a/app/vacancy_sources/vacancy_source/source/ventrus.rb
+++ b/app/vacancy_sources/vacancy_source/source/ventrus.rb
@@ -56,7 +56,7 @@ class VacancySource::Source::Ventrus
       # subjects: item["Subjects"].presence&.split(","),
       working_patterns: item["Working_Patterns"].presence&.split(","),
       contract_type: item["Contract_Type"].presence,
-      phases: phases_for(item),
+      phases: phase_for(item),
       visa_sponsorship_available: false,
     }.merge(organisation_fields(item))
   end
@@ -102,8 +102,13 @@ class VacancySource::Source::Ventrus
                    .gsub(/\s+/, ""))
   end
 
-  def phases_for(item)
-    Array(item["Phase_"]).presence
+  def phase_for(item)
+    return if item["Phase_"].blank?
+
+    item["Phase_"].strip
+                 .parameterize(separator: "_")
+                 .gsub("through_school", "through")
+                 .gsub(/16-19|16_19/, "sixth_form_or_college")
   end
 
   def items

--- a/spec/fixtures/files/vacancy_sources/united_learning.xml
+++ b/spec/fixtures/files/vacancy_sources/united_learning.xml
@@ -24,7 +24,7 @@
                    <Working_patterns>full_time</Working_patterns>
                    <Subjects>Geography</Subjects>
                    <Contract_type>permanent</Contract_type>
-                   <Phase>Multiple phases</Phase>
+                   <Phase>Secondary</Phase>
                    <URN>136636</URN>
                    <Key_stages>ks2</Key_stages>
                    <Documents>

--- a/spec/vacancy_sources/vacancy_source/source/broadbean_spec.rb
+++ b/spec/vacancy_sources/vacancy_source/source/broadbean_spec.rb
@@ -192,6 +192,30 @@ RSpec.describe VacancySource::Source::Broadbean do
       end
     end
 
+    describe "phase mapping" do
+      let(:response_body) { super().gsub("primary", phase) }
+
+      %w[16-19 16_19].each do |phase|
+        context "when the phase is '#{phase}'" do
+          let(:phase) { phase }
+
+          it "maps the phase to '[sixth_form_or_college]' in the vacancy" do
+            expect(vacancy.phases).to eq(["sixth_form_or_college"])
+          end
+        end
+      end
+
+      %w[through_school all_through].each do |phase|
+        context "when the phase is '#{phase}'" do
+          let(:phase) { phase }
+
+          it "maps the phase to '[through]' in the vacancy" do
+            expect(vacancy.phases).to eq(["through"])
+          end
+        end
+      end
+    end
+
     context "when the same vacancy has been imported previously" do
       let!(:existing_vacancy) do
         create(

--- a/spec/vacancy_sources/vacancy_source/source/every_spec.rb
+++ b/spec/vacancy_sources/vacancy_source/source/every_spec.rb
@@ -217,4 +217,26 @@ RSpec.describe VacancySource::Source::Every do
       end
     end
   end
+
+  describe "phase mapping" do
+    let(:response_body) { super().gsub("primary", phase) }
+
+    %w[16-19 16_19].each do |phase|
+      context "when the phase is '#{phase}'" do
+        let(:phase) { phase }
+
+        it "maps the phase to '[sixth_form_or_college]' in the vacancy" do
+          expect(vacancy.phases).to eq(["sixth_form_or_college"])
+        end
+      end
+    end
+
+    context "when the phase is 'through_school'" do
+      let(:phase) { "through_school" }
+
+      it "maps the phase to '[through]' in the vacancy" do
+        expect(vacancy.phases).to eq(["through"])
+      end
+    end
+  end
 end

--- a/spec/vacancy_sources/vacancy_source/source/fusion_spec.rb
+++ b/spec/vacancy_sources/vacancy_source/source/fusion_spec.rb
@@ -170,6 +170,28 @@ RSpec.describe VacancySource::Source::Fusion do
       end
     end
 
+    describe "phase mapping" do
+      let(:response_body) { super().gsub("primary", phase) }
+
+      %w[16-19 16_19].each do |phase|
+        context "when the phase is '#{phase}'" do
+          let(:phase) { phase }
+
+          it "maps the phase to '[sixth_form_or_college]' in the vacancy" do
+            expect(vacancy.phases).to eq(["sixth_form_or_college"])
+          end
+        end
+      end
+
+      context "when the phase is 'through_school'" do
+        let(:phase) { "through_school" }
+
+        it "maps the phase to '[through]' in the vacancy" do
+          expect(vacancy.phases).to eq(["through"])
+        end
+      end
+    end
+
     context "when the same vacancy has been imported previously" do
       let!(:existing_vacancy) do
         create(

--- a/spec/vacancy_sources/vacancy_source/source/my_new_term_spec.rb
+++ b/spec/vacancy_sources/vacancy_source/source/my_new_term_spec.rb
@@ -227,6 +227,30 @@ RSpec.describe VacancySource::Source::MyNewTerm do
           end
         end
       end
+
+      describe "phase mapping" do
+        let(:job_listings_response_body) { super().gsub("primary", phase) }
+
+        %w[16-19 16_19].each do |phase|
+          context "when the phase is '#{phase}'" do
+            let(:phase) { phase }
+
+            it "maps the phase to '[sixth_form_or_college]' in the vacancy" do
+              expect(vacancy.phases).to eq(["sixth_form_or_college"])
+            end
+          end
+        end
+
+        %w[through_school all_through].each do |phase|
+          context "when the phase is '#{phase}'" do
+            let(:phase) { phase }
+
+            it "maps the phase to '[through]' in the vacancy" do
+              expect(vacancy.phases).to eq(["through"])
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/spec/vacancy_sources/vacancy_source/source/ventrus_spec.rb
+++ b/spec/vacancy_sources/vacancy_source/source/ventrus_spec.rb
@@ -135,6 +135,28 @@ RSpec.describe VacancySource::Source::Ventrus do
       end
     end
 
+    describe "phase mapping" do
+      let(:response_body) { super().gsub("secondary", phase) }
+
+      %w[16-19 16_19].each do |phase|
+        context "when the phase is '#{phase}'" do
+          let(:phase) { phase }
+
+          it "maps the phase to '[sixth_form_or_college]' in the vacancy" do
+            expect(vacancy.phases).to eq(["sixth_form_or_college"])
+          end
+        end
+      end
+
+      context "when the phase is 'through_school'" do
+        let(:phase) { "through_school" }
+
+        it "maps the phase to '[through]' in the vacancy" do
+          expect(vacancy.phases).to eq(["through"])
+        end
+      end
+    end
+
     context "when the same vacancy has been imported previously" do
       let!(:existing_vacancy) do
         create(


### PR DESCRIPTION
## Trello card URL

- https://trello.com/c/w9rQOj3T

## Changes in this PR:

Maps the incoming `phase` from all the sources to ensure that the specified values from our TV integration document match the correct value in the DB.

Currently, this is failing in multiple sources, where, for example, they send "through_school" as specified in the integration document. Still, it fails to be imported due to the value in our system only being accepted as `through`.

This mapping resolves this and similar issues.

## Screenshots of UI changes:

### Before
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/22ded7a5-1b14-4aca-a7f1-78be276004eb)

### After
