### PR TITLE
[606] Configure DFE Sign-in redirect URL for AKS environments

### DIFF
--- a/terraform/app/modules/paas/aks_application.tf
+++ b/terraform/app/modules/paas/aks_application.tf
@@ -13,9 +13,10 @@ module "application_configuration" {
   config_variables = merge(
     var.app_env_values,
     {
-      ENVIRONMENT_NAME = var.environment
-      PGSSLMODE        = local.postgres_ssl_mode
-      DOMAIN           = local.web_app_domain
+      ENVIRONMENT_NAME         = var.environment
+      PGSSLMODE                = local.postgres_ssl_mode
+      DOMAIN                   = local.web_app_domain
+      DFE_SIGN_IN_REDIRECT_URL = local.web_app_dfe_sign_in_redirect_url
   })
   secret_variables = merge({
     REDIS_URL    = module.redis-cache.url

--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -209,6 +209,10 @@ locals {
     var.app_env_values["TEMP_DOMAIN"],
     try(var.app_env_values["DOMAIN"], local.web_app_aks_domain)
   )
+  web_app_dfe_sign_in_redirect_url = try(
+    var.app_env_values["TEMP_DFE_SIGN_IN_REDIRECT_URL"],
+    var.app_env_values["DFE_SIGN_IN_REDIRECT_URL"],
+  )
 
   database_name_suffix = var.add_database_name_suffix ? "${var.environment}" : null
 }

--- a/terraform/workspace-variables/production_app_env.yml
+++ b/terraform/workspace-variables/production_app_env.yml
@@ -4,6 +4,7 @@ AUTHENTICATION_FALLBACK: false
 BIG_QUERY_DATASET: production_dataset
 DFE_SIGN_IN_ISSUER: https://oidc.signin.education.gov.uk
 DFE_SIGN_IN_REDIRECT_URL: https://teaching-vacancies.service.gov.uk/auth/dfe/callback
+TEMP_DFE_SIGN_IN_REDIRECT_URL: https://www2.teaching-vacancies.service.gov.uk/auth/dfe/callback
 DFE_SIGN_IN_REGISTRATION_URL: https://profile.signin.education.gov.uk/register
 DFE_SIGN_IN_URL: https://api.signin.education.gov.uk
 DISABLE_EXPENSIVE_JOBS: false

--- a/terraform/workspace-variables/qa_app_env.yml
+++ b/terraform/workspace-variables/qa_app_env.yml
@@ -4,6 +4,7 @@ AUTHENTICATION_FALLBACK: false
 BIG_QUERY_DATASET: staging_dataset
 DFE_SIGN_IN_ISSUER: https://test-oidc.signin.education.gov.uk
 DFE_SIGN_IN_REDIRECT_URL: https://qa.teaching-vacancies.service.gov.uk/auth/dfe/callback
+TEMP_DFE_SIGN_IN_REDIRECT_URL: https://qa2.teaching-vacancies.service.gov.uk/auth/dfe/callback
 DFE_SIGN_IN_REGISTRATION_URL: https://test-profile.signin.education.gov.uk/register
 DFE_SIGN_IN_URL: https://test-api.signin.education.gov.uk
 DISABLE_EXPENSIVE_JOBS: true

--- a/terraform/workspace-variables/sandbox_app_env.yml
+++ b/terraform/workspace-variables/sandbox_app_env.yml
@@ -4,6 +4,7 @@ AUTHENTICATION_FALLBACK: false
 BIG_QUERY_DATASET: staging_dataset
 DFE_SIGN_IN_ISSUER: https://oidc.signin.education.gov.uk
 DFE_SIGN_IN_REDIRECT_URL: https://sandbox.teaching-vacancies.service.gov.uk/auth/dfe/callback
+TEMP_DFE_SIGN_IN_REDIRECT_URL: https://sandbox2.teaching-vacancies.service.gov.uk/auth/dfe/callback
 DFE_SIGN_IN_REGISTRATION_URL: https://profile.signin.education.gov.uk/register
 DFE_SIGN_IN_URL: https://api.signin.education.gov.uk
 DISABLE_EXPENSIVE_JOBS: true

--- a/terraform/workspace-variables/staging_app_env.yml
+++ b/terraform/workspace-variables/staging_app_env.yml
@@ -4,6 +4,7 @@ AUTHENTICATION_FALLBACK: false
 BIG_QUERY_DATASET: staging_dataset
 DFE_SIGN_IN_ISSUER: https://pp-oidc.signin.education.gov.uk
 DFE_SIGN_IN_REDIRECT_URL: https://staging.teaching-vacancies.service.gov.uk/auth/dfe/callback
+TEMP_DFE_SIGN_IN_REDIRECT_URL: https://staging2.teaching-vacancies.service.gov.uk/auth/dfe/callback
 DFE_SIGN_IN_REGISTRATION_URL: https://pp-profile.signin.education.gov.uk/register
 DFE_SIGN_IN_URL: https://pp-api.signin.education.gov.uk
 DISABLE_EXPENSIVE_JOBS: true


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/QvrkR3vd

## Changes in this PR:
Add a new variable to override DFE_SIGN_IN_REDIRECT_URL only on AKS

## How to review
Deployed manually to qa2: https://qa2.teaching-vacancies.service.gov.uk/
