### PR TITLE
Fix United Learning organisation mapping

### DIFF
--- a/app/vacancy_sources/vacancy_source/source/united_learning.rb
+++ b/app/vacancy_sources/vacancy_source/source/united_learning.rb
@@ -61,9 +61,18 @@ class VacancySource::Source::UnitedLearning
       working_patterns: item["Working_patterns"].presence&.split(","),
       contract_type: item["Contract_type"].presence,
       phases: phase_for(item),
-      organisations: organisations_for(item),
-      about_school: organisations_for(item).first&.description,
       visa_sponsorship_available: false,
+    }.merge(organisation_fields(item))
+  end
+
+  def organisation_fields(item)
+    # TODO: What about central office/multiple school vacancies?
+    organisation = school_group.schools.find_by(urn: item["URN"])
+    return {} if organisation.blank?
+
+    {
+      organisations: [organisation],
+      about_school: organisation.description,
     }
   end
 
@@ -82,11 +91,6 @@ class VacancySource::Source::UnitedLearning
     return unless item["ect_suitable"].presence
 
     item["ect_suitable"] == "yes" ? "ect_suitable" : "ect_unsuitable"
-  end
-
-  def organisations_for(item)
-    # TODO: What about central office/multiple school vacancies?
-    [school_group.schools.find_by(urn: item["URN"])]
   end
 
   def school_group

--- a/spec/vacancy_sources/vacancy_source/source/united_learning_spec.rb
+++ b/spec/vacancy_sources/vacancy_source/source/united_learning_spec.rb
@@ -44,6 +44,14 @@ RSpec.describe VacancySource::Source::UnitedLearning do
       expect(vacancy.publish_on).to eq(Date.today)
     end
 
+    context "whente there is no school matching the source URN" do
+      let!(:school) { create(:school, name: "Test School", urn: "wrong_urn", phase: :secondary) }
+
+      it "the vacancy does not has any associated organisation" do
+        expect(vacancy.organisations).to be_empty
+      end
+    end
+
     describe "mappings" do
       let(:item_stub) { instance_double(described_class::FeedItem, :[] => "") }
 


### PR DESCRIPTION
When there is no associated organisation, instead of trying to save an array containing a null value, we don't try to assign anything to the vacancy organisations.

Fixes: https://teaching-vacancies.sentry.io/issues/4497043596/events/df495a91b9844b17a20ab043802dcdee/?environment=production&project=6212514&query=is%3Aunresolved&referrer=next-event&statsPeriod=1h&stream_index=1