### PR TITLE
Show preferred subjects on jobseeker profiles

### DIFF
--- a/app/models/job_preferences.rb
+++ b/app/models/job_preferences.rb
@@ -22,6 +22,10 @@ class JobPreferences < ApplicationRecord
     working_patterns.map(&:humanize).join(", ")
   end
 
+  def all_subjects
+    subjects.map(&:humanize).join(", ")
+  end
+
   def complete?
     to_multistep.completed?
   end

--- a/app/views/jobseekers/profiles/_summary.html.slim
+++ b/app/views/jobseekers/profiles/_summary.html.slim
@@ -1,6 +1,7 @@
 p class="govuk-!-margin-bottom-3" = jobseeker_status(profile)
 
 - if (job_preferences = profile.job_preferences).present?
+
   h2.govuk-heading-m class="govuk-!-margin-bottom-5"
     = t(".job_preferences")
     = govuk_summary_list do |summary_list|
@@ -16,6 +17,10 @@ p class="govuk-!-margin-bottom-3" = jobseeker_status(profile)
         - summary_list.row do |row|
           - row.key text: t(".key_stages", count: stages.count)
           - row.value text: humanize_array(stages)
+      - if (subjects = job_preferences.subjects).present?
+        - summary_list.row do |row|
+          - row.key text: t(".subjects", count: subjects.count)
+          - row.value text: humanize_array(subjects)
       - if (patterns = job_preferences.working_patterns).present?
         - summary_list.row do |row|
           - row.key text: t(".working_patterns", count: patterns.count)

--- a/app/views/publishers/jobseeker_profiles/search/_results.html.slim
+++ b/app/views/publishers/jobseeker_profiles/search/_results.html.slim
@@ -21,3 +21,7 @@
           - summary_list.row do |row|
             - row.key text: t("publishers.jobseeker_profiles.preferred_working_patterns", count: preferences.working_patterns.count), classes: "govuk-body-s govuk-!-font-weight-bold govuk-!-padding-bottom-0"
             - row.value text: jobseeker_profile.job_preferences.all_working_patterns, classes: "govuk-body-s govuk-!-padding-bottom-0"
+
+          - summary_list.row do |row|
+            - row.key text: t("publishers.jobseeker_profiles.preferred_subjects", count: preferences.subjects.count), classes: "govuk-body-s govuk-!-font-weight-bold govuk-!-padding-bottom-0"
+            - row.value text: jobseeker_profile.job_preferences.all_subjects, classes: "govuk-body-s govuk-!-padding-bottom-0"

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -745,6 +745,9 @@ en:
         working_patterns:
           one: Working pattern
           other: Working patterns
+        subjects:
+          one: Subject
+          other: Subjects
 
     sessions:
       new:

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -80,6 +80,9 @@ en:
       preferred_working_patterns:
         one: Preferred working pattern
         other: Preferred working patterns
+      preferred_subjects:
+        one: Preferred subject
+        other: Preferred subjects
       search_result_heading: "Candidate profiles (%{count})"
       sort_result_text: "Ordered by most recently updated."
       filters:

--- a/spec/factories/job_preferences.rb
+++ b/spec/factories/job_preferences.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     roles { factory_rand_sample(Vacancy.job_roles.keys, 1..Vacancy.job_roles.keys.count) }
     phases { factory_rand_sample(Vacancy.phases.keys, 1..Vacancy.phases.keys.count) }
     key_stages { key_stages_for_phases }
-    subjects { factory_rand_sample(SUBJECT_OPTIONS.map(&:first), 1..3) }
+    subjects { ["English", "Maths"] }
     working_patterns { factory_rand_sample(%w[full_time part_time], 1..2) }
     builder_completed { true }
     completed_steps do

--- a/spec/factories/job_preferences.rb
+++ b/spec/factories/job_preferences.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     roles { factory_rand_sample(Vacancy.job_roles.keys, 1..Vacancy.job_roles.keys.count) }
     phases { factory_rand_sample(Vacancy.phases.keys, 1..Vacancy.phases.keys.count) }
     key_stages { key_stages_for_phases }
-    subjects { ["English", "Maths"] }
+    subjects { factory_rand_sample(SUBJECT_OPTIONS.map(&:first), 1..3) }
     working_patterns { factory_rand_sample(%w[full_time part_time], 1..2) }
     builder_completed { true }
     completed_steps do

--- a/spec/system/publishers/publishers_can_search_for_jobseeker_profiles_spec.rb
+++ b/spec/system/publishers/publishers_can_search_for_jobseeker_profiles_spec.rb
@@ -5,16 +5,16 @@ RSpec.describe "Publishers searching for Jobseeker profiles", type: :system do
   let(:organisation) { create(:school, geopoint: "POINT (-0.108267 51.506438)") }
 
   let!(:jobseeker_profile) { create(:jobseeker_profile, :with_personal_details, qualified_teacher_status: "yes", qualified_teacher_status_year: "2000", job_preferences: job_preferences) }
-  let(:job_preferences) { create(:job_preferences, roles: %w[teacher], key_stages: %w[ks1], working_patterns: %w[full_time], locations: [location_preference_containing_school]) }
+  let(:job_preferences) { create(:job_preferences, roles: %w[teacher], key_stages: %w[ks1], working_patterns: %w[full_time], locations: [location_preference_containing_school], subjects: ["English"]) }
   let(:location_preference_containing_school) { create(:job_preferences_location, name: "London", radius: 100) }
 
   let!(:part_time_jobseeker_profile) { create(:jobseeker_profile, :with_personal_details, qualified_teacher_status: "yes", qualified_teacher_status_year: "2000", job_preferences: part_time_job_preferences) }
-  let(:part_time_job_preferences) { create(:job_preferences, roles: %w[teacher], key_stages: %w[ks1], working_patterns: %w[part_time], locations: [part_time_preference_containing_school]) }
+  let(:part_time_job_preferences) { create(:job_preferences, roles: %w[teacher], key_stages: %w[ks1], working_patterns: %w[part_time], locations: [part_time_preference_containing_school], subjects: ["Physics"]) }
   let(:part_time_preference_containing_school) { create(:job_preferences_location, name: "London", radius: 100) }
 
   let!(:no_right_to_work_in_uk_profile) { create(:jobseeker_profile, personal_details: personal_details, qualified_teacher_status: "yes", qualified_teacher_status_year: "2000", job_preferences: no_right_to_work_in_uk_preferences) }
   let(:personal_details) { create(:personal_details, right_to_work_in_uk: false) }
-  let(:no_right_to_work_in_uk_preferences) { create(:job_preferences, roles: %w[teacher], key_stages: %w[ks1], working_patterns: %w[part_time], locations: [no_right_to_work_in_uk_containing_school]) }
+  let(:no_right_to_work_in_uk_preferences) { create(:job_preferences, roles: %w[teacher], key_stages: %w[ks1], working_patterns: %w[part_time], locations: [no_right_to_work_in_uk_containing_school], subjects: ["Geography"]) }
   let(:no_right_to_work_in_uk_containing_school) { create(:job_preferences_location, name: "London", radius: 100) }
 
   before { login_publisher(publisher:, organisation:) }
@@ -29,6 +29,7 @@ RSpec.describe "Publishers searching for Jobseeker profiles", type: :system do
         expect(page).to have_content(jobseeker_profile.job_preferences.roles.first.humanize)
         expect(page).to have_content(jobseeker_profile.job_preferences.key_stages.first.humanize)
         expect(page).to have_content(jobseeker_profile.job_preferences.working_patterns.first.humanize)
+        expect(page).to have_content(jobseeker_profile.job_preferences.subjects.first.humanize)
       end
     end
 

--- a/spec/system/publishers/publishers_can_view_a_jobseeker_profile_spec.rb
+++ b/spec/system/publishers/publishers_can_view_a_jobseeker_profile_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "Jobseeker profiles", type: :system do
     expect(page).to have_content(jobseeker_profile.jobseeker.email)
     expect(page).to have_content(jobseeker_profile.qualified_teacher_status_year)
     expect(page).to have_content(jobseeker_profile.about_you)
+    expect(page).to have_content(jobseeker_profile.job_preferences.subjects.map(&:humanize).join(", "))
     expect(page).not_to have_content("Location")
   end
 end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/NNtXzg8A/547-enable-hiring-staff-to-view-subjects-on-candidate-profiles

## Changes in this PR:

This PR adds preferred subjects to the jobseeker profiles, both on the search page and on the individual jobseeker profile page to allow hiring staff to understand better the preferences of jobseekers that they may want to hire.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
