### PR TITLE
Fix legacy working patterns for United Learning

### DIFF
--- a/app/vacancy_sources/vacancy_source/source/united_learning.rb
+++ b/app/vacancy_sources/vacancy_source/source/united_learning.rb
@@ -58,7 +58,7 @@ class VacancySource::Source::UnitedLearning
       job_roles: job_roles_for(item),
       ect_status: ect_status_for(item),
       subjects: item["Subjects"].presence&.split(","),
-      working_patterns: item["Working_patterns"].presence&.split(","),
+      working_patterns: working_patterns_for(item),
       contract_type: item["Contract_type"].presence,
       phases: phase_for(item),
       visa_sponsorship_available: false,
@@ -85,6 +85,17 @@ class VacancySource::Source::UnitedLearning
     return Vacancy::MIDDLE_LEADER_JOB_ROLES if role.include? "middle_leader"
 
     Array.wrap(role.gsub(/\s+/, ""))
+  end
+
+  def working_patterns_for(item)
+    return [] if item["Working_patterns"].blank?
+
+    item["Working_patterns"].gsub("flexible", "part_time")
+                            .gsub("term_time", "part_time")
+                            .gsub("job_share", "part_time")
+                            .delete(" ")
+                            .split(",")
+                            .uniq
   end
 
   def ect_status_for(item)


### PR DESCRIPTION
United Learning integration is still sending some working patterns values that have been marked as legacy and migrated to "part_time" in our system.

We need to map them to "part_time", as with their original value the vacancy fails from being created.

![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/ff7083ef-405c-48a6-9357-64c6a840fbd8)
