### PR TITLE
Group Dependabot Bundler and NPM updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,17 @@ updates:
       # Our current Redis service instance is 5.0.6. This will be upgraded when we migrate from GOVuk PaaS to AKS.
       - dependency-name: "redis"
         update-types: ["version-update:semver-major"]
-
+    groups:
+      gem-dependencies:
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "govuk"
+          - "noticed"
+        
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
@@ -46,3 +56,14 @@ updates:
       interval: "weekly"
       day: "wednesday"
     open-pull-requests-limit: 10
+    groups:
+      npm-dependencies:
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "govuk"
+          - "jest"
+


### PR DESCRIPTION
Every week, we get flooded with PRs from Dependabot. For every PR, we need to run the whole deploy pipeline, and it takes a long time to go through them. It is taking a lot of time to catch up with the PRs, and some gems are constantly getting updates.

This turned out to be very disruptive towards our release pace, and 99% of the time, we just approved and merged the PR.

So what we will do here is for both gem and npm package updates:
- Excluding some specific libraries (govuk ones, packages that tend to break in updates...) , open a single PR for all the gem updates by Dependabot that upgrade a minor/patch version. Same for the npm packages.
- Major versions or excluded packages for grouping will get their own PR.

This way, we expect to drastically reduce the amount of PRs opened by Dependabot and the deploy queues.


Documentation about dependency grouping: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups