### PR TITLE
Extend readme docs with basic AKS info

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ bar, using the VS Code "Run task" option, or the Rails convention `bin/dev` scri
 * [Onboarding](/documentation/onboarding.md)
 * [Search](/documentation/search.md)
 * [Disaster Recovery](/documentation/disaster-recovery.md)
+* [Azure Kubernetes Service (AKS)](/documentation/aks.md)
 
 ---
 

--- a/documentation/aks.md
+++ b/documentation/aks.md
@@ -1,0 +1,53 @@
+# Azure Kubernetes Service (AKS)
+
+Teaching Vacancies is hosted on [Azure Kubernetes Service (AKS)](https://learn.microsoft.com/en-us/azure/aks/).
+
+### Installing the Azure Client and Kubectl
+1. Install the [Azure Client](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
+2. Install `kubectl`
+    ```
+    az aks install-cli
+    ```
+
+## Accessing AKS Test cluster
+
+1. Activate your access for our Test cluster (`s189-teacher-services-cloud-test`) through [Azure Privileged Identity Management (PIM) request](https://technical-guidance.education.gov.uk/infrastructure/hosting/azure-cip/#privileged-identity-management-pim-requests) in the [Azure Portal](https://portal.azure.com.mcas.ms/).
+
+2. Login into the testing tenant using the Azure Cli. This will launch your browser for the login.
+
+    ```
+    az login --tenant 9c7d9dd3-840c-4b3f-818e-552865082e16
+    ```
+
+3. From Teaching Vacancies root directory, get the credentials for cluster.
+
+    ```
+    make test-cluster get-cluster-credentials
+    ```
+
+## Opening a console in a Review App
+
+Once you have the correct credentials, you can execute `kubectl` commands over the authenticated cluster.
+
+To list the application pods in the cluster:
+
+```
+kubectl -n tv-development get pods
+```
+
+To open a console in the particular pod:
+
+```
+kubectl -n tv-development exec -ti teaching-vacancies-review-example -- /bin/sh
+```
+
+## Executing commands in a Review App
+
+```
+kubectl -n tv-development exec teaching-vacancies-review-example -- ps aux
+```
+
+## Other documentation
+
+- [Infra Team Developer onboarding into AKS](https://github.com/DFE-Digital/teacher-services-cloud/blob/main/documentation/developer-onboarding.md#developer-onboarding). This has extended info on our AKS setup and commands.
+- [Azure AKS Client reference](https://learn.microsoft.com/en-us/cli/azure/aks?view=azure-cli-latest)

--- a/documentation/bot-mitigation.md
+++ b/documentation/bot-mitigation.md
@@ -5,6 +5,8 @@ Currently there are several forms on the service that can be accessed and submit
 
 Google's recaptcha v3 was implemented on these forms in order to start obtaining recaptcha 'scores' which would help identify suspicious requests.
 
+[Link to our recaptcha settings](https://www.google.com/u/2/recaptcha/admin/site/674609893)
+
 ## Why
 This version of the recaptcha does not obstruct the user (or bot) in any way and as a result we still receive some spam. Notably this results in bots creating job alert subscriptions.
 

--- a/documentation/onboarding.md
+++ b/documentation/onboarding.md
@@ -60,7 +60,9 @@ Someone on the support team can add developers to Zendesk as and when needed (as
 
 Any team member can invite the new developer to the following services:
 
-* GOV.UK Notify
+* [GOV.UK Notify](https://www.notifications.service.gov.uk/services/786d369d-11d1-4c7e-9a11-ef06aab2978b)
 * Skylight (Access through Github user with access to TV project).
 * Google Analytics
-* Google BigQ Looker studio
+* [Google Tag Manager](https://tagmanager.google.com/?authuser=2#/container/accounts/4702787029/containers/12903245/workspaces/103)
+* [Google BigQ Looker studio](https://lookerstudio.google.com/u/2/reporting/1X_lrbWUn7Nw5LZnRWynJKtalYg6-L4Oi)
+* [Google reCAPTCHA](https://www.google.com/u/2/recaptcha/admin/site/674609893)


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/jOfMpNGW/551-add-aks-commands-info-to-project-documentation


## Changes in this PR:

Extend ReCaptcha docs.
Add some basic documentation on how to login into AKS and login into a review app pod.