### PR TITLE
Add subjects to jobseeker profiles

### DIFF
--- a/app/controllers/jobseekers/profiles/employments_controller.rb
+++ b/app/controllers/jobseekers/profiles/employments_controller.rb
@@ -44,7 +44,7 @@ class Jobseekers::Profiles::EmploymentsController < Jobseekers::ProfilesControll
     when "new"
       {}
     when "edit"
-      employment.slice(:organisation, :job_title, :started_on, :current_role, :ended_on, :main_duties)
+      employment.slice(:organisation, :job_title, :started_on, :current_role, :ended_on, :main_duties, :subjects)
     when "create", "update"
       employment_form_params
     end
@@ -56,7 +56,7 @@ class Jobseekers::Profiles::EmploymentsController < Jobseekers::ProfilesControll
 
   def employment_form_params
     params.require(:jobseekers_profile_employment_form)
-          .permit(:organisation, :job_title, :started_on, :current_role, :ended_on, :main_duties)
+          .permit(:organisation, :job_title, :started_on, :current_role, :ended_on, :main_duties, :subjects)
           .merge("started_on(3i)" => "1", "ended_on(3i)" => "1")
   end
 end

--- a/app/form_models/jobseekers/profile/employment_form.rb
+++ b/app/form_models/jobseekers/profile/employment_form.rb
@@ -3,7 +3,7 @@ class Jobseekers::Profile::EmploymentForm < BaseForm
   include DateAttributeAssignment
 
   def self.fields
-    %i[organisation job_title main_duties current_role jobseeker_profile_id]
+    %i[organisation job_title main_duties current_role jobseeker_profile_id subjects]
   end
   attr_accessor(*fields)
 

--- a/app/views/jobseekers/employments/_employments.html.slim
+++ b/app/views/jobseekers/employments/_employments.html.slim
@@ -6,6 +6,9 @@
           - row.key text: t("jobseekers.employments.organisation")
           - row.value text: employment.organisation
         - summary_list.row(classes: "govuk-summary-list__row--no-actions") do |row|
+          - row.key text: t("jobseekers.employments.subjects")
+          - row.value text: employment.subjects
+        - summary_list.row(classes: "govuk-summary-list__row--no-actions") do |row|
           - row.key text: t("jobseekers.employments.started_on")
           - row.value text: employment.started_on.to_formatted_s(:month_year)
         - summary_list.row do |row|

--- a/app/views/jobseekers/profiles/_summary.html.slim
+++ b/app/views/jobseekers/profiles/_summary.html.slim
@@ -48,6 +48,8 @@ dl.govuk-summary-list
     h3.govuk-heading-s class="govuk-!-padding-bottom-3"
       = employment.organisation
       p class="govuk-!-margin-bottom-0" = employment.job_title
+      - if employment.subjects.present?
+        p class="govuk-!-margin-bottom-0" = employment.subjects
       p.govuk-hint #{employment.started_on.to_formatted_s(:month_year)} to #{employment.ended_on&.to_formatted_s(:month_year) || "present"}
       hr.govuk-section-break.govuk-section-break--s.govuk-section-break--visible
 

--- a/app/views/jobseekers/profiles/employments/_fields.html.slim
+++ b/app/views/jobseekers/profiles/employments/_fields.html.slim
@@ -2,6 +2,8 @@
 
 = f.govuk_text_field :job_title, label: { size: "m" }
 
+= f.govuk_text_field :subjects, label: { size: "m" }
+
 = f.govuk_date_field :started_on,
   omit_day: true,
   legend: { tag: nil, size: "m" },

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -563,6 +563,7 @@ en:
         job_title: Role
         main_duties: Main duties
         organisation: Name of school or employer
+        subjects: Subjects and key stages taught (optional)
       jobseekers_sign_in_form:
         email: Email address
         password: Password

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -47,6 +47,7 @@ en:
       main_duties: Main duties
       organisation: School or employer
       started_on: Start date
+      subjects: Subjects and key stages taught (optional)
     forced_login:
       create_account: create an account
       job_application_html: You need to login or %{account_creation_link} with Teaching Vacancies to apply for this job.

--- a/spec/support/jobseeker_helpers.rb
+++ b/spec/support/jobseeker_helpers.rb
@@ -38,6 +38,7 @@ module JobseekerHelpers
     fill_in "School or other organisation", with: "The Best School"
     fill_in "Job title", with: "The Best Teacher"
     fill_in "Main duties", with: "Some details about what the main duties were"
+    fill_in "Subjects and key stages taught (optional field)", with: "English KS1"
     fill_in "jobseekers_job_application_details_employment_form[started_on(1i)]", with: "2019"
     fill_in "jobseekers_job_application_details_employment_form[started_on(2i)]", with: "09"
     choose "Yes", name: "jobseekers_job_application_details_employment_form[current_role]"

--- a/spec/system/jobseekers/prefilling_applications_spec.rb
+++ b/spec/system/jobseekers/prefilling_applications_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe "Jobseekers can prefill applications" do
       expect(page).to have_content(profile.qualified_teacher_status_year)
       expect(page).to have_content(profile.qualifications.first.institution)
       expect(page).to have_content(profile.employments.first.job_title)
+      expect(page).to have_content(profile.employments.first.subjects)
     end
 
     context "and the jobseeker has a previous application" do

--- a/spec/system/jobseekers_can_add_employments_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers_can_add_employments_to_their_job_application_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe "Jobseekers can add employments and breaks to their job applicati
 
     expect(current_path).to eq(jobseekers_job_application_build_path(job_application, :employment_history))
     expect(page).to have_content("The Best Teacher")
+    expect(page).to have_content("English KS1")
   end
 
   it "allows jobseekers to add employment history" do

--- a/spec/system/publishers/publishers_can_view_a_jobseeker_profile_spec.rb
+++ b/spec/system/publishers/publishers_can_view_a_jobseeker_profile_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "Jobseeker profiles", type: :system do
     expect(page).to have_content(jobseeker_profile.qualified_teacher_status_year)
     expect(page).to have_content(jobseeker_profile.about_you)
     expect(page).to have_content(jobseeker_profile.job_preferences.subjects.map(&:humanize).join(", "))
+    expect(page).to have_content(jobseeker_profile.employments.first.subjects)
     expect(page).not_to have_content("Location")
   end
 end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/evoiNeEN/546-hiring-staff-align-role-page-between-the-application-form-and-candidate-profile
https://trello.com/c/mB52q0mA/545-jobseeker-align-role-page-between-the-application-form-and-candidate-profile

## Changes in this PR:

This PR adds a subjects field to the jobseeker profile journey to allow jobseekers to enter the subjects and key stages taught at previous jobs, shows the info to hiring staff when they view the user profile and automatically populates the quick apply journey with the information when the user applies via that method

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
