### PR TITLE
Add tests for missing TrustUID on Every source

### DIFF
--- a/spec/fixtures/files/vacancy_sources/every_without_trust.json
+++ b/spec/fixtures/files/vacancy_sources/every_without_trust.json
@@ -1,0 +1,21 @@
+{
+  "result": [
+    {
+      "reference": "0044",
+      "advertUrl": "http://testurl.com",
+      "applicationUrl": "http://testurl.com",
+      "expiresAt": "2022-10-28T12:00:00",
+      "startDate": "2022-11-21T00:00:00",
+      "jobTitle": "Class Teacher",
+      "jobAdvert": "Lorem Ipsum dolor sit amet",
+      "salary": "£25,714.00 to £41,604.00",
+      "schoolUrns": ["222222"],
+      "keyStages": "ks1,ks2",
+      "jobRole": "teacher",
+      "workingPatterns": "full_time",
+      "contractType": "fixed_term",
+      "phase": "primary",
+      "trustUID": null
+    }
+  ]
+}

--- a/spec/vacancy_sources/vacancy_source/source/every_spec.rb
+++ b/spec/vacancy_sources/vacancy_source/source/every_spec.rb
@@ -65,6 +65,23 @@ RSpec.describe VacancySource::Source::Every do
     end
   end
 
+  context "when the school doesn't belong to a school group" do
+    let(:response_body) { file_fixture("vacancy_sources/every_without_trust.json").read }
+    let!(:school2) { create(:school, name: "Test School 2", urn: "222222", phase: :primary) }
+
+    it "the vacancy is valid" do
+      expect(vacancy).to be_valid
+    end
+
+    it "assigns the vacancy to the school" do
+      expect(vacancy.organisations).to eq([school2])
+    end
+
+    it "assigns the vacancy job location to the school" do
+      expect(vacancy.readable_job_location).to eq(school2.name)
+    end
+  end
+
   context "when the same vacancy has been imported previously" do
     let!(:existing_vacancy) do
       create(


### PR DESCRIPTION
Since Every contacted us asking for the feasibility of publishing job averts for individual schools non-belonging to any Trust, I've added tests to cover that situation.
