### PR TITLE
Remove staging from DB copy to AKS

### DIFF
--- a/.github/workflows/database-copy.yml
+++ b/.github/workflows/database-copy.yml
@@ -10,7 +10,7 @@ jobs:
     name: Restore DB
     strategy:
       matrix:
-        environment: [staging, production]
+        environment: [production]
       max-parallel: 1
     uses: ./.github/workflows/restore-paas-db-to-aks.yml
     with:

--- a/terraform/workspace-variables/staging.tfvars.json
+++ b/terraform/workspace-variables/staging.tfvars.json
@@ -7,8 +7,8 @@
           "cloudwatch_slack_channel": "twd_tv_dev"
         }
     },
-  "paas_route53_cname_record": "staging",
-  "aks_route53_cname_record": "staging2",
+  "paas_route53_cname_record": "staging2",
+  "aks_route53_cname_record": "staging",
   "distribution_list":
     {
       "tvsstaging":
@@ -39,9 +39,9 @@
   "paas_redis_queue_service_plan": "micro-5_x",
   "paas_space_name": "teaching-vacancies-staging",
   "paas_web_app_deployment_strategy": "blue-green-v2",
-  "paas_web_app_instances": 2,
+  "paas_web_app_instances": 0,
   "paas_worker_app_deployment_strategy": "blue-green-v2",
-  "paas_worker_app_instances": 2,
+  "paas_worker_app_instances": 0,
   "parameter_store_environment": "staging",
   "region": "eu-west-2",
   "cluster": "test",

--- a/terraform/workspace-variables/staging_app_env.yml
+++ b/terraform/workspace-variables/staging_app_env.yml
@@ -4,12 +4,10 @@ AUTHENTICATION_FALLBACK: false
 BIG_QUERY_DATASET: staging_dataset
 DFE_SIGN_IN_ISSUER: https://pp-oidc.signin.education.gov.uk
 DFE_SIGN_IN_REDIRECT_URL: https://staging.teaching-vacancies.service.gov.uk/auth/dfe/callback
-TEMP_DFE_SIGN_IN_REDIRECT_URL: https://staging2.teaching-vacancies.service.gov.uk/auth/dfe/callback
 DFE_SIGN_IN_REGISTRATION_URL: https://pp-profile.signin.education.gov.uk/register
 DFE_SIGN_IN_URL: https://pp-api.signin.education.gov.uk
 DISABLE_EXPENSIVE_JOBS: true
 DOMAIN: staging.teaching-vacancies.service.gov.uk
-TEMP_DOMAIN: staging2.teaching-vacancies.service.gov.uk
 ENFORCE_LOCAL_AUTHORITY_ALLOWLIST: false
 MALLOC_ARENA_MAX: 2
 RAILS_ENV: production


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/bxR0ADFl/706-migrate-each-environment-sequentially-staging

## Changes in this PR:
Removes the staging DB copy from Paas to AKS
Update configuration for staging migration
Update domains app configuration
Migrate the domain to point at AKS
Disable paas webapp and worker
