### PR TITLE
Add scheduled maintenance banner

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -50,6 +50,7 @@ $govuk-assets-path: "/";
 @import 'components/navigation_list';
 @import 'components/notification';
 @import 'components/review';
+@import 'components/scheduled_maintenance_banner';
 @import 'components/searchable_collection';
 @import 'components/sort';
 @import 'components/steps';

--- a/app/assets/stylesheets/components/scheduled_maintenance_banner.scss
+++ b/app/assets/stylesheets/components/scheduled_maintenance_banner.scss
@@ -1,0 +1,18 @@
+@import 'base';
+
+.scheduled-maintenance-banner-component {
+  @include govuk-font(16);
+
+  background-color: $govuk-brand-colour;
+  background-size: govuk-spacing(9) govuk-spacing(9);
+
+  padding: govuk-spacing(2);
+  color: govuk-colour('white');
+
+  .govuk-tag {
+    background-color: govuk-colour('white');
+    color: govuk-shade($govuk-brand-colour, 25);
+
+    margin-right: govuk-spacing(2);
+  }
+}

--- a/app/components/scheduled_maintenance_banner_component.rb
+++ b/app/components/scheduled_maintenance_banner_component.rb
@@ -1,0 +1,18 @@
+class ScheduledMaintenanceBannerComponent < ApplicationComponent
+  include FailSafe
+
+  def initialize(classes: [], html_attributes: {}, date: nil, start_time: nil, end_time: nil)
+    @date = date
+    @start_time = start_time
+    @end_time = end_time
+
+    super(classes: classes, html_attributes: html_attributes)
+  end
+
+  def render?
+    return false unless @date.present? && @start_time.present? && @end_time.present?
+    return false unless Rails.configuration.app_role.production?
+
+    true
+  end
+end

--- a/app/components/scheduled_maintenance_banner_component/scheduled_maintenance_banner_component.html.slim
+++ b/app/components/scheduled_maintenance_banner_component/scheduled_maintenance_banner_component.html.slim
@@ -1,0 +1,5 @@
+.scheduled-maintenance-banner-component
+  .govuk-width-container
+    .govuk-tag.govuk-tag--maintenance class="govuk-!-font-weight-bold"
+      = t("scheduled_maintenance_banner_component.tag")
+    = t("scheduled_maintenance_banner_component.text", date: @date, start_time: @start_time, end_time: @end_time)

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -14,6 +14,7 @@ html.govuk-template.app-html-class lang="en"
     = render "layouts/add_js_enabled_class_to_body"
     = render "layouts/skip_links"
     = render EnvironmentBannerComponent.new
+    = render ScheduledMaintenanceBannerComponent.new(date: "5th October 2023", start_time: "8:00", end_time: "9:30")
     = render "layouts/header"
     .govuk-width-container
       = render "layouts/phase_banner"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -299,6 +299,10 @@ en:
         at_multiple_schools: Arranging a visit to one of the schools
         central_office: Arranging a visit to %{organisation}
 
+  scheduled_maintenance_banner_component:
+    tag: Scheduled maintenance
+    text: The service will be undergoing a maintenance update on %{date} between %{start_time} and %{end_time}.
+
   shared:
     filter_group:
       clear_all_filters: Clear filters

--- a/documentation/maintenance-mode.md
+++ b/documentation/maintenance-mode.md
@@ -16,3 +16,20 @@ Login to PaaS: `cf login --sso`
 set maintenance mode environment variable: `cf set-env teaching-vacancies-dev MAINTENANCE_MODE 1`
 
 restage app: cf restage: `cf restage teaching-vacancies-dev`
+
+
+### Let users know a for future maintenance
+
+We can let users know in advance about a future maintenance period for the service through the 
+[Scheduled Maintenance Banner Component](/app/components/scheduled_maintenance_banner_component.rb).
+
+Rendering this component above the header layout in the [application layout](/app/views/layouts/application.html.slim) will
+display the banner on top of the website on production environment.
+
+Remember to remove this component from the layout once the maintenance has been finished.
+
+EG:
+```
+= render ScheduledMaintenanceBannerComponent.new(date: "5th October 2023", start_time: "8:00", end_time: "9:30")
+= render "layouts/header"
+```

--- a/spec/components/scheduled_maintenance_banner_component_spec.rb
+++ b/spec/components/scheduled_maintenance_banner_component_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe ScheduledMaintenanceBannerComponent, type: :component do
+  describe "#render" do
+    RSpec.shared_examples "does not render" do
+      it "does not render" do
+        expect(component.render?).to eq(false)
+      end
+    end
+
+    subject(:component) { described_class.new(date:, start_time:, end_time:) }
+
+    let(:app_role) { "production" }
+    let(:date) { "5th October 2023" }
+    let(:start_time) { "8:00" }
+    let(:end_time) { "11:00" }
+
+    before do
+      allow(Rails.configuration).to receive(:app_role).and_return(ActiveSupport::StringInquirer.new(app_role))
+    end
+
+    context "when the maintenance date is not present" do
+      let(:date) { nil }
+
+      include_examples "does not render"
+    end
+
+    context "when the maintenance start time is not present" do
+      let(:start_time) { nil }
+
+      include_examples "does not render"
+    end
+
+    context "when the maintenance end time is not present" do
+      let(:end_time) { nil }
+
+      include_examples "does not render"
+    end
+
+    context "when app_role is unknown" do
+      let(:app_role) { "unknown" }
+
+      include_examples "does not render"
+    end
+
+    context "when app_role is anything else" do
+      let(:app_role) { "wow" }
+
+      include_examples "does not render"
+    end
+
+    context "when app_role is production" do
+      let(:app_role) { "production" }
+
+      it "does render" do
+        expect(component.render?).to eq(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Trello card URL

- https://trello.com/c/WEHGk27C

## Changes in this PR:

- Creates a new component on the service for notifying production users about future scheduled maintenance downtimes.
- Uses the new component for scheduled downtime happening this Thursday.

The component has been copied and adapted from the existing Environment Banner component. 

## Screenshots of UI changes:

![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/454d2de5-2290-41ca-80ec-934df58dfbe9)


## Next steps:
