### PR TITLE
Add a env var for disabling ActionMailer

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -10,3 +10,4 @@ VACANCY_SOURCE_EVERY_FEED_URL=http://example.com/feed.json
 VACANCY_SOURCE_MY_NEW_TERM_FEED_URL=https://example.com
 VACANCY_SOURCE_BROADBEAN_FEED_URL=http://example.com/feed.xml
 VACANCY_SOURCE_MY_NEW_TERM_API_KEY=api_key
+DISABLE_EMAILS=false

--- a/config/application.rb
+++ b/config/application.rb
@@ -53,6 +53,7 @@ module TeachingVacancies
     config.action_mailer.notify_settings = {
       api_key: ENV.fetch("NOTIFY_KEY", nil),
     }
+    config.action_mailer.perform_deliveries = ENV.fetch("DISABLE_EMAILS", false) ? false : true
 
     config.active_storage.routes_prefix = "/attachments"
     config.active_storage.resolve_model_to_route = :rails_storage_proxy

--- a/terraform/workspace-variables/production_app_env.yml
+++ b/terraform/workspace-variables/production_app_env.yml
@@ -7,6 +7,7 @@ DFE_SIGN_IN_REDIRECT_URL: https://teaching-vacancies.service.gov.uk/auth/dfe/cal
 TEMP_DFE_SIGN_IN_REDIRECT_URL: https://www2.teaching-vacancies.service.gov.uk/auth/dfe/callback
 DFE_SIGN_IN_REGISTRATION_URL: https://profile.signin.education.gov.uk/register
 DFE_SIGN_IN_URL: https://api.signin.education.gov.uk
+DISABLE_EMAILS: false
 DISABLE_EXPENSIVE_JOBS: false
 DOMAIN: teaching-vacancies.service.gov.uk
 TEMP_DOMAIN: www2.teaching-vacancies.service.gov.uk


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/Iui14uNW/646-disable-notifications-in-production

## Changes in this PR:
When this variable is 'true', emails won't be sent through ActionMailer.
