### PR TITLE
AKS production migration

### DIFF
--- a/.github/workflows/database-copy.yml
+++ b/.github/workflows/database-copy.yml
@@ -10,7 +10,7 @@ jobs:
     name: Restore DB
     strategy:
       matrix:
-        environment: [production]
+        environment: []
       max-parallel: 1
     uses: ./.github/workflows/restore-paas-db-to-aks.yml
     with:

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -14,7 +14,8 @@ html.govuk-template.app-html-class lang="en"
     = render "layouts/add_js_enabled_class_to_body"
     = render "layouts/skip_links"
     = render EnvironmentBannerComponent.new
-    = render ScheduledMaintenanceBannerComponent.new(date: "5th October 2023", start_time: "08:00", end_time: "09:30")
+    / Uncomment the line below to display a banner announcing future period where the page will be in maintenance mode
+    / = render ScheduledMaintenanceBannerComponent.new(date: "5th October 2023", start_time: "08:00", end_time: "09:30")
     = render "layouts/header"
     .govuk-width-container
       = render "layouts/phase_banner"

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -240,7 +240,7 @@ locals {
   paas_app_env_values        = yamldecode(file("${path.module}/../workspace-variables/${var.app_environment}_app_env.yml"))
   infra_secrets              = yamldecode(data.aws_ssm_parameter.infra_secrets.value)
   is_production              = var.environment == "production"
-  web_external_hostnames_aks = [for zone in var.route53_zones : "${var.aks_route53_cname_record}.${zone}"]
+  web_external_hostnames_aks = concat([for zone in var.route53_zones : "${var.aks_route53_cname_record}.${zone}"], var.aks_route53_a_records)
   service_name               = "teaching-vacancies"
   service_abbreviation       = "tv"
   hostname_domain_map = {

--- a/terraform/workspace-variables/production.tfvars.json
+++ b/terraform/workspace-variables/production.tfvars.json
@@ -5,10 +5,10 @@
       "cloudwatch_slack_channel": "twd_tv_dev"
     }
   },
-  "paas_route53_a_records": ["teaching-jobs.service.gov.uk", "teaching-vacancies.service.gov.uk"],
-  "aks_route53_a_records": [],
-  "paas_route53_cname_record": "www",
-  "aks_route53_cname_record": "www2",
+  "paas_route53_a_records": [],
+  "aks_route53_a_records": ["teaching-jobs.service.gov.uk", "teaching-vacancies.service.gov.uk"],
+  "paas_route53_cname_record": "www2",
+  "aks_route53_cname_record": "www",
   "distribution_list": {
     "tvsprod": {
       "cloudfront_origin_domain_name": "teaching-vacancies-production.london.cloudapps.digital",
@@ -33,10 +33,10 @@
   "paas_redis_queue_service_plan": "tiny-ha-5_x",
   "paas_space_name": "teaching-vacancies-production",
   "paas_web_app_deployment_strategy": "blue-green-v2",
-  "paas_web_app_instances": 8,
+  "paas_web_app_instances": 0,
   "paas_web_app_memory": 1536,
   "paas_worker_app_deployment_strategy": "blue-green-v2",
-  "paas_worker_app_instances": 4,
+  "paas_worker_app_instances": 0,
   "paas_worker_app_memory": 1536,
   "parameter_store_environment": "production",
   "region": "eu-west-2",

--- a/terraform/workspace-variables/production_app_env.yml
+++ b/terraform/workspace-variables/production_app_env.yml
@@ -5,14 +5,12 @@ BIG_QUERY_DATASET: production_dataset
 TEMP_BIGQUERY_DATASET: testing_dataset
 DFE_SIGN_IN_ISSUER: https://oidc.signin.education.gov.uk
 DFE_SIGN_IN_REDIRECT_URL: https://teaching-vacancies.service.gov.uk/auth/dfe/callback
-TEMP_DFE_SIGN_IN_REDIRECT_URL: https://www2.teaching-vacancies.service.gov.uk/auth/dfe/callback
 DFE_SIGN_IN_REGISTRATION_URL: https://profile.signin.education.gov.uk/register
 DFE_SIGN_IN_URL: https://api.signin.education.gov.uk
 DISABLE_EMAILS: false
 TEMP_DISABLE_EMAILS: true
 DISABLE_EXPENSIVE_JOBS: false
 DOMAIN: teaching-vacancies.service.gov.uk
-TEMP_DOMAIN: www2.teaching-vacancies.service.gov.uk
 ENFORCE_LOCAL_AUTHORITY_ALLOWLIST: true
 GOOGLE_TAG_MANAGER_CONTAINER_ID: GTM-P5L2QHV
 MALLOC_ARENA_MAX: 2

--- a/terraform/workspace-variables/production_app_env.yml
+++ b/terraform/workspace-variables/production_app_env.yml
@@ -2,13 +2,11 @@
 APP_ROLE: production
 AUTHENTICATION_FALLBACK: false
 BIG_QUERY_DATASET: production_dataset
-TEMP_BIGQUERY_DATASET: testing_dataset
 DFE_SIGN_IN_ISSUER: https://oidc.signin.education.gov.uk
 DFE_SIGN_IN_REDIRECT_URL: https://teaching-vacancies.service.gov.uk/auth/dfe/callback
 DFE_SIGN_IN_REGISTRATION_URL: https://profile.signin.education.gov.uk/register
 DFE_SIGN_IN_URL: https://api.signin.education.gov.uk
 DISABLE_EMAILS: false
-TEMP_DISABLE_EMAILS: true
 DISABLE_EXPENSIVE_JOBS: false
 DOMAIN: teaching-vacancies.service.gov.uk
 ENFORCE_LOCAL_AUTHORITY_ALLOWLIST: true


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/MGdwoQ6m/707-migrate-each-environment-sequentially-production


## Changes in this PR:

Removes the staging DB copy from Paas to AKS
Update configuration for staging migration
Update domains app configuration
Migrate the domain to point at AKS
Disable paas webapp and worker
