### PR TITLE
Upgrade scheduled maintenance banner wording

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -14,7 +14,7 @@ html.govuk-template.app-html-class lang="en"
     = render "layouts/add_js_enabled_class_to_body"
     = render "layouts/skip_links"
     = render EnvironmentBannerComponent.new
-    = render ScheduledMaintenanceBannerComponent.new(date: "5th October 2023", start_time: "8:00", end_time: "9:30")
+    = render ScheduledMaintenanceBannerComponent.new(date: "5th October 2023", start_time: "08:00", end_time: "09:30")
     = render "layouts/header"
     .govuk-width-container
       = render "layouts/phase_banner"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -301,7 +301,7 @@ en:
 
   scheduled_maintenance_banner_component:
     tag: Scheduled maintenance
-    text: The service will be undergoing a maintenance update on %{date} between %{start_time} and %{end_time}.
+    text: There will be a maintenance update on %{date} between %{start_time} and %{end_time}.
 
   shared:
     filter_group:


### PR DESCRIPTION
Improve time format and reduce wording to avoid line splitting on desktop.


![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/699f7496-1b84-42f3-8ec0-995ae17588a8)
