### PR TITLE
Change wording on QTS question

### DIFF
--- a/app/views/jobseekers/job_applications/build/professional_status.html.slim
+++ b/app/views/jobseekers/job_applications/build/professional_status.html.slim
@@ -11,7 +11,7 @@
     = form_for form, url: wizard_path, method: :patch do |f|
       = f.govuk_error_summary
 
-      = f.govuk_radio_buttons_fieldset :qualified_teacher_status do
+      = f.govuk_radio_buttons_fieldset :qualified_teacher_status, hint: -> { tag.p(t("helpers.label.jobseekers_job_application_professional_status_form.hint", link: govuk_link_to(t("helpers.label.jobseekers_job_application_professional_status_form.link_text"), "https://apply-for-qts-in-england.education.gov.uk/eligibility/start", target: "_blank")).html_safe) } do
         = f.govuk_radio_button :qualified_teacher_status, :yes, link_errors: true do
           = f.govuk_text_field :qualified_teacher_status_year
         = f.govuk_radio_button :qualified_teacher_status, :no do

--- a/app/views/jobseekers/job_applications/build/professional_status.html.slim
+++ b/app/views/jobseekers/job_applications/build/professional_status.html.slim
@@ -11,7 +11,7 @@
     = form_for form, url: wizard_path, method: :patch do |f|
       = f.govuk_error_summary
 
-      = f.govuk_radio_buttons_fieldset :qualified_teacher_status, hint: -> { tag.p(t("helpers.label.jobseekers_job_application_professional_status_form.hint", link: govuk_link_to(t("helpers.label.jobseekers_job_application_professional_status_form.link_text"), "https://apply-for-qts-in-england.education.gov.uk/eligibility/start", target: "_blank")).html_safe) } do
+      = f.govuk_radio_buttons_fieldset :qualified_teacher_status, hint: -> { tag.p(t("helpers.label.jobseekers_job_application_professional_status_form.hint", link: govuk_link_to(t("helpers.label.jobseekers_job_application_professional_status_form.link_text"), "https://www.gov.uk/guidance/qualified-teacher-status-qts", target: "_blank")).html_safe) } do
         = f.govuk_radio_button :qualified_teacher_status, :yes, link_errors: true do
           = f.govuk_text_field :qualified_teacher_status_year
         = f.govuk_radio_button :qualified_teacher_status, :no do

--- a/app/views/jobseekers/profiles/qualified_teacher_status/edit.html.slim
+++ b/app/views/jobseekers/profiles/qualified_teacher_status/edit.html.slim
@@ -8,7 +8,7 @@
     = form_for form, url: jobseekers_profile_qualified_teacher_status_path, method: "patch" do |f|
       = f.govuk_error_summary
 
-      = f.govuk_radio_buttons_fieldset :qualified_teacher_status, hint: -> { tag.p(t("helpers.label.jobseekers_job_application_professional_status_form.hint", link: govuk_link_to(t("helpers.label.jobseekers_job_application_professional_status_form.link_text"), "https://apply-for-qts-in-england.education.gov.uk/eligibility/start", target: "_blank")).html_safe) }, legend: { size: "l", tag: "h1" } do
+      = f.govuk_radio_buttons_fieldset :qualified_teacher_status, hint: -> { tag.p(t("helpers.label.jobseekers_job_application_professional_status_form.hint", link: govuk_link_to(t("helpers.label.jobseekers_job_application_professional_status_form.link_text"), "https://www.gov.uk/guidance/qualified-teacher-status-qts", target: "_blank")).html_safe) }, legend: { size: "l", tag: "h1" } do
         = f.govuk_radio_button :qualified_teacher_status, "yes", link_errors: true
           = f.govuk_text_field :qualified_teacher_status_year
 

--- a/app/views/jobseekers/profiles/qualified_teacher_status/edit.html.slim
+++ b/app/views/jobseekers/profiles/qualified_teacher_status/edit.html.slim
@@ -8,9 +8,7 @@
     = form_for form, url: jobseekers_profile_qualified_teacher_status_path, method: "patch" do |f|
       = f.govuk_error_summary
 
-      span.govuk-caption-l = t(".page_title")
-
-      = f.govuk_radio_buttons_fieldset :qualified_teacher_status, legend: { size: "l", tag: "h1" } do
+      = f.govuk_radio_buttons_fieldset :qualified_teacher_status,  hint: -> { tag.p(t("helpers.label.jobseekers_job_application_professional_status_form.hint", link: govuk_link_to(t("helpers.label.jobseekers_job_application_professional_status_form.link_text"), "https://apply-for-qts-in-england.education.gov.uk/eligibility/start", target: "_blank")).html_safe) }, legend: { size: "l", tag: "h1" } do
         = f.govuk_radio_button :qualified_teacher_status, "yes", link_errors: true
           = f.govuk_text_field :qualified_teacher_status_year
 

--- a/app/views/jobseekers/profiles/qualified_teacher_status/edit.html.slim
+++ b/app/views/jobseekers/profiles/qualified_teacher_status/edit.html.slim
@@ -8,7 +8,7 @@
     = form_for form, url: jobseekers_profile_qualified_teacher_status_path, method: "patch" do |f|
       = f.govuk_error_summary
 
-      = f.govuk_radio_buttons_fieldset :qualified_teacher_status,  hint: -> { tag.p(t("helpers.label.jobseekers_job_application_professional_status_form.hint", link: govuk_link_to(t("helpers.label.jobseekers_job_application_professional_status_form.link_text"), "https://apply-for-qts-in-england.education.gov.uk/eligibility/start", target: "_blank")).html_safe) }, legend: { size: "l", tag: "h1" } do
+      = f.govuk_radio_buttons_fieldset :qualified_teacher_status, hint: -> { tag.p(t("helpers.label.jobseekers_job_application_professional_status_form.hint", link: govuk_link_to(t("helpers.label.jobseekers_job_application_professional_status_form.link_text"), "https://apply-for-qts-in-england.education.gov.uk/eligibility/start", target: "_blank")).html_safe) }, legend: { size: "l", tag: "h1" } do
         = f.govuk_radio_button :qualified_teacher_status, "yes", link_errors: true
           = f.govuk_text_field :qualified_teacher_status_year
 

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -494,6 +494,8 @@ en:
           on_track: I'm on track to receive my QTS
           "yes": "Yes"
         qualified_teacher_status_year: Year QTS was awarded
+        hint: You're unlikely to get a teaching job in England unless you have QTS. Find out %{link}.
+        link_text: how to get QTS
       jobseekers_job_application_qualifications_form:
         qualifications_section_completed_options:
           false: No, I'll come back to it later


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/l3aVGtah/560-reword-qts-guidance

## Changes in this PR:

This PR updates the wording of the QTS question to add a hint to explain to users the significance of QTS.

## Screenshots of UI changes:
<img width="1079" alt="Screenshot 2023-10-04 at 09 18 21" src="https://github.com/DFE-Digital/teaching-vacancies/assets/13124899/a80ac4cd-d8c5-40ad-8646-caab10fbf345">

<img width="994" alt="Screenshot 2023-10-04 at 09 18 31" src="https://github.com/DFE-Digital/teaching-vacancies/assets/13124899/989ecdef-563a-4628-9b3f-3afd7b9fae1e">


## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
