### PR TITLE
Fix AKS Makefile & Introduce production docs info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,12 +278,10 @@ set-azure-account:
 production-cluster:
 	$(eval CLUSTER_RESOURCE_GROUP_NAME=s189p01-tsc-pd-rg)
 	$(eval CLUSTER_NAME=s189p01-tsc-production-aks)
-  $(eval AZURE_SUBSCRIPTION=s189-teacher-services-cloud-production)
 
 test-cluster:
 	$(eval CLUSTER_RESOURCE_GROUP_NAME=s189t01-tsc-ts-rg)
 	$(eval CLUSTER_NAME=s189t01-tsc-test-aks)
-  $(eval AZURE_SUBSCRIPTION=s189-teacher-services-cloud-test)
 
 get-cluster-credentials: set-azure-account
 	az aks get-credentials --overwrite-existing -g ${CLUSTER_RESOURCE_GROUP_NAME} -n ${CLUSTER_NAME}

--- a/documentation/aks.md
+++ b/documentation/aks.md
@@ -30,7 +30,30 @@ Teaching Vacancies service environments use 2 AKS clusters:
 
 1. Activate your access for our Test cluster (`s189-teacher-services-cloud-test`) through [Azure Privileged Identity Management (PIM) request](https://technical-guidance.education.gov.uk/infrastructure/hosting/azure-cip/#privileged-identity-management-pim-requests) in the [Azure Portal](https://portal.azure.com.mcas.ms/).
 
-2. Login into the testing tenant using the Azure Cli. This will launch your browser for the login.
+2. Login into the tenant using the Azure Cli. This will launch your browser for the login.
+
+    ```
+    az login --tenant 9c7d9dd3-840c-4b3f-818e-552865082e16
+    ```
+
+3. From Teaching Vacancies root directory, get the credentials for the environment.
+    ```
+    make review get-cluster-credentials
+    ```
+
+    ```
+    make qa get-cluster-credentials
+    ```
+
+    ```
+    make staging get-cluster-credentials
+    ```
+
+## Accessing AKS Production cluster
+
+1. Request access for our Production cluster (`s189-teacher-services-cloud-production`) through [Azure Privileged Identity Management (PIM) request](https://technical-guidance.education.gov.uk/infrastructure/hosting/azure-cip/#privileged-identity-management-pim-requests) in the [Azure Portal](https://portal.azure.com.mcas.ms/). You will receive an email when your request has been approved by a member of the infra team.
+
+2. Login into the tenant using the Azure Cli. This will launch your browser for the login.
 
     ```
     az login --tenant 9c7d9dd3-840c-4b3f-818e-552865082e16
@@ -39,8 +62,9 @@ Teaching Vacancies service environments use 2 AKS clusters:
 3. From Teaching Vacancies root directory, get the credentials for cluster.
 
     ```
-    make test-cluster get-cluster-credentials
+    make production get-cluster-credentials CONFIRM_PRODUCTION=YES
     ```
+
 Once you have the correct credentials, you can execute `kubectl` commands over the authenticated cluster.
 
 ## Accessing/Executing commands over our services


### PR DESCRIPTION
Some lines in the makefile were incorrectly tabbed and happened to be unnecessary. Corrected the makefile declaration.

After that, the commands in the AKS readme were adapted to use the correct calls.

Finally, added instructions on how to access/execute commands in the production environment.

