### PR TITLE
[707] Fix missing aks_web_app_instances variable

### DIFF
--- a/terraform/app/modules/paas/aks_application.tf
+++ b/terraform/app/modules/paas/aks_application.tf
@@ -18,7 +18,8 @@ module "application_configuration" {
       DOMAIN           = local.web_app_domain
     },
     local.dfe_sign_in_map,
-    local.disable_emails_map
+    local.disable_emails_map,
+    local.disable_analytics_map
   )
   secret_variables = merge({
     REDIS_URL    = module.redis-cache.url

--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -225,5 +225,10 @@ locals {
     {}
   )
 
+  disable_analytics_map = (contains(keys(var.app_env_values), "TEMP_BIGQUERY_DATASET") ?
+    { BIGQUERY_DATASET = var.app_env_values["TEMP_BIGQUERY_DATASET"] } :
+    {}
+  )
+
   database_name_suffix = var.add_database_name_suffix ? "${var.environment}" : null
 }

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -212,6 +212,9 @@ variable "add_database_name_suffix" {
   default     = false
   description = "Add optional suffix to the postgres instance name to differentiate between environments"
 }
+variable "aks_web_app_instances" {
+  default = 1
+}
 variable "aks_worker_app_instances" {
   default = 1
 }

--- a/terraform/workspace-variables/production_app_env.yml
+++ b/terraform/workspace-variables/production_app_env.yml
@@ -2,6 +2,7 @@
 APP_ROLE: production
 AUTHENTICATION_FALLBACK: false
 BIG_QUERY_DATASET: production_dataset
+TEMP_BIGQUERY_DATASET: testing_dataset
 DFE_SIGN_IN_ISSUER: https://oidc.signin.education.gov.uk
 DFE_SIGN_IN_REDIRECT_URL: https://teaching-vacancies.service.gov.uk/auth/dfe/callback
 TEMP_DFE_SIGN_IN_REDIRECT_URL: https://www2.teaching-vacancies.service.gov.uk/auth/dfe/callback


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/MGdwoQ6m

## Changes in this PR:
Fix error:
```
Error: Reference to undeclared input variable
│ 
│   on terraform.tf line 125, in module "paas":
│  125:   aks_web_app_instances             = var.aks_web_app_instances
│ 
│ An input variable with the name "aks_web_app_instances" has not been
│ declared. Did you mean "paas_web_app_instances"?
```
