### PR TITLE
Do not merge: Proof of concept - exclude towns and cities outside englad

### DIFF
--- a/app/controllers/api/location_suggestion_controller.rb
+++ b/app/controllers/api/location_suggestion_controller.rb
@@ -8,10 +8,12 @@ class Api::LocationSuggestionController < Api::ApplicationController
     rescue HTTParty::ResponseError, LocationSuggestion::GooglePlacesAutocompleteError => e
       return render(json: { error: e }, status: :bad_request)
     end
+    
+    filtered_suggestions = exclude_welsh_locations(suggestions)
 
     render json: {
       query: location,
-      suggestions: suggestions,
+      suggestions: filtered_suggestions,
       matched_terms: matched_terms,
     }
   end
@@ -26,5 +28,20 @@ class Api::LocationSuggestionController < Api::ApplicationController
     return render(json: { error: "Missing location input" }, status: :bad_request) if location.nil?
 
     render(json: { error: "Insufficient location input" }, status: :bad_request) if location.length < 3
+  end
+
+  def exclude_welsh_locations(suggestions)
+    places_to_exclude = [
+      "Wales", "Cardiff", "Saint Asaph", "Swansea", "Denbigh", "Newport", "St Davids", "Caerlon", "Lampeter", "Bala", "Pembroke", "Rhayader",
+      "Bangor", "Welshpool", "Llanfyllin", "Rhondaa", "Gelligaer", "Machynlleth", "Kidwelly", "Aberaeron", "Cardigan", "Narberth", "Harlech", "Talgarth",
+      "Gwersyllt", "Aberaman", "Bagillt", "Flint", "Carmarthen", "Buckley", "Neath", "Aberystwyth", "Llantwit Major", "Milford Haven", "Caerphilly", "Tonyrefail",
+      "Maesteg", "Haverfordwest", "Aberdare", "Connah's Quay", "Barry", "Rhyl", "Risca", "Prestatyn", "Brackla", "Conwy", "Flintshire"
+    ]
+
+    postcode_pattern_to_exclude = /(LL|SY|LD|SA|CF|NP)\d/
+
+    suggestions.reject do |str|
+      str.match?(postcode_pattern_to_exclude) || places_to_exclude.include?(str)
+    end
   end
 end

--- a/app/form_models/jobseekers/job_preferences_form.rb
+++ b/app/form_models/jobseekers/job_preferences_form.rb
@@ -128,9 +128,18 @@ module Jobseekers
       attribute :radius
 
       validates :location, :radius, presence: true
+      validate :location_within_united_kingdom
 
       def radius_options
         [0, 1, 5, 10, 15, 20, 25, 50, 100, 200].map { |radius| [radius, I18n.t("jobs.search.number_of_miles", count: radius)] }
+      end
+
+      private
+
+      def location_within_united_kingdom
+        unless Geocoder.search(location).map(&:country).include?("United Kingdom")
+          errors.add(:location, 'Location is not within United Kingdom')
+        end
       end
     end
 


### PR DESCRIPTION
## Trello card URL

## Changes in this PR:

This PR is not meant to be merged. It is being used to deploy a review app as a proof of concept of how we may be able to exclude Welsh towns, cities and postcodes which, if successful, could be extended to ensure that we don't show auto completion suggestions for towns, cities and postcodes outside of England.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
