### PR TITLE
Add monitoring to Postgres

### DIFF
--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -107,6 +107,7 @@ variable "azure_enable_backup_storage" {
 }
 variable "enable_monitoring" {
   description = "Enable monitoring and alerting"
+  default     = false
 }
 
 # AKS

--- a/terraform/workspace-variables/production.tfvars.json
+++ b/terraform/workspace-variables/production.tfvars.json
@@ -6,7 +6,10 @@
     }
   },
   "paas_route53_a_records": [],
-  "aks_route53_a_records": ["teaching-jobs.service.gov.uk", "teaching-vacancies.service.gov.uk"],
+  "aks_route53_a_records": [
+    "teaching-jobs.service.gov.uk",
+    "teaching-vacancies.service.gov.uk"
+  ],
   "paas_route53_cname_record": "www2",
   "aks_route53_cname_record": "www",
   "distribution_list": {
@@ -42,7 +45,7 @@
   "region": "eu-west-2",
   "cluster": "production",
   "namespace": "tv-production",
-  "enable_monitoring": false,
+  "enable_monitoring": true,
   "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
   "postgres_enable_high_availability": true,
   "redis_cache_capacity": 1,
@@ -51,9 +54,9 @@
   "redis_queue_capacity": 1,
   "redis_queue_family": "P",
   "redis_queue_sku_name": "Premium",
-  "aks_worker_app_instances" : 4,
-  "aks_web_app_instances"   : 8,
-  "aks_worker_app_memory" : "1.5Gi",
+  "aks_worker_app_instances": 4,
+  "aks_web_app_instances": 8,
+  "aks_worker_app_memory": "1.5Gi",
   "statuscake_alerts": {
     "PaaS500String": {
       "contact_group": [


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/3VmIE5FW/712-add-monitoring-for-postgres-and-redis

## Changes in this PR:
Adds Postgress monitoring to Production
