### PR TITLE
Migrate Smoke tests from PaaS to AKS hosting

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -2,7 +2,7 @@ name: smoke-test action
 description: smoke test application
 
 inputs:
-  paas_environment:
+  aks_environment:
     description: Environment
     required: true
   event_name:
@@ -21,13 +21,13 @@ runs:
     - name: set environment (scheduled smoke test)
       shell: bash
       if: ${{ inputs.event_name == 'schedule' }}
-      run: echo "PAAS_ENVIRONMENT=production" >> $GITHUB_ENV
+      run: echo "AKS_ENVIRONMENT=production" >> $GITHUB_ENV
 
     - name: set environment
       shell: bash
       if: ${{ inputs.event_name != 'schedule' }}
       run: |
-        echo "PAAS_ENVIRONMENT=${{ inputs.paas_environment }}" >> $GITHUB_ENV
+        echo "AKS_ENVIRONMENT=${{ inputs.aks_environment }}" >> $GITHUB_ENV
 
     - name: Run deployment smoke test
       shell: bash
@@ -35,4 +35,4 @@ runs:
 
     - name: print environment
       shell: bash
-      run: echo ${{ env.PAAS_ENVIRONMENT}}
+      run: echo ${{ env.AKS_ENVIRONMENT}}

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -262,7 +262,7 @@ jobs:
       id: smoke-test
       uses: ./.github/actions/smoke-test/
       with:
-        paas_environment: ${{ env.ENVIRONMENT }}
+        aks_environment: ${{ env.ENVIRONMENT }}
         event_name: ${{ github.event_name }}
 
     - name: Exit whole workflow if ${{ env.ENVIRONMENT }} smoke test was not successful

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -19,7 +19,7 @@ jobs:
         id: smoke-test
         uses: ./.github/actions/smoke-test/
         with:
-          paas_environment: 'production'
+          aks_environment: 'production'
           event_name: ${{ github.event_name }}
 
       - name: Slack notification
@@ -31,5 +31,5 @@ jobs:
           SLACK_USERNAME: Smoke Test
           SLACK_ICON_EMOJI: ':cry:'
           SLACK_TITLE: Smoke test failed
-          SLACK_MESSAGE: 'Smoke test failure in ${{ env.PAAS_ENVIRONMENT}} environment <!channel>'
+          SLACK_MESSAGE: 'Smoke test failure in ${{ env.AKS_ENVIRONMENT}} environment <!channel>'
           SLACK_WEBHOOK: ${{env.SLACK_WEBHOOK}}

--- a/spec/smoke_tests/jobseekers_can_view_homepage_spec.rb
+++ b/spec/smoke_tests/jobseekers_can_view_homepage_spec.rb
@@ -2,7 +2,7 @@ require "capybara/rspec"
 require "i18n_helper"
 require "yaml"
 
-CLOUDAPPS_DOMAIN = "london.cloudapps.digital".freeze
+CLOUD_DOMAIN = "test.teacherservices.cloud".freeze
 
 RSpec.describe "Page availability", js: true, smoke_test: true do
   after do |example|
@@ -12,11 +12,11 @@ RSpec.describe "Page availability", js: true, smoke_test: true do
 
   context "Jobseeker visits vacancy page" do
     let(:smoke_test_domain) do
-      paas_environment = ENV.fetch("PAAS_ENVIRONMENT")
+      aks_environment = ENV.fetch("AKS_ENVIRONMENT")
       begin
-        YAML.load_file("#{__dir__}/../../terraform/workspace-variables/#{paas_environment}_app_env.yml")["DOMAIN"]
+        YAML.load_file("#{__dir__}/../../terraform/workspace-variables/#{aks_environment}_app_env.yml")["DOMAIN"]
       rescue Errno::ENOENT
-        "teaching-vacancies-#{paas_environment}.#{CLOUDAPPS_DOMAIN}"
+        "teaching-vacancies-#{aks_environment}.#{CLOUD_DOMAIN}"
       end
     end
     let(:page) { Capybara::Session.new(:selenium_chrome_headless) }


### PR DESCRIPTION
The Smoke tests were still referencing and pointing to PaaS hosting. Replaced it with AKS.
