### PR TITLE
Ensure that a jobseekers work history is displayed with the most rece…

### DIFF
--- a/app/services/jobseekers/job_applications/employment_gap_finder.rb
+++ b/app/services/jobseekers/job_applications/employment_gap_finder.rb
@@ -55,7 +55,7 @@ class Jobseekers::JobApplications::EmploymentGapFinder
   def gap_end_date(employment)
     return unless (next_start = next_employment_start(employment))
 
-    next_start - 1.day
+    next_start
   end
 
   def adjusted_end_date(employment)

--- a/app/views/jobseekers/job_applications/build/employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/build/employment_history.html.slim
@@ -62,7 +62,7 @@
             p.govuk-body
               = govuk_link_to t(employments.job.none? ? "buttons.add_job" : "buttons.add_another_job"), new_jobseekers_job_application_employment_path(job_application)
               = " or "
-              = govuk_link_to t("buttons.add_another_break"), new_jobseekers_job_application_break_path(job_application, started_on: employment.ended_on, ended_on: (employments[index + 1]&.started_on || Date.current))
+              = govuk_link_to t("buttons.add_reason_for_break"), new_jobseekers_job_application_break_path(job_application, started_on: gap[:started_on], ended_on: (gap[:ended_on] || Date.current))
 
       = govuk_button_link_to t(employments.job.none? ? "buttons.add_job" : "buttons.add_another_job"), new_jobseekers_job_application_employment_path(job_application), class: "govuk-button--secondary"
 

--- a/app/views/jobseekers/job_applications/build/employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/build/employment_history.html.slim
@@ -12,7 +12,7 @@
     p.govuk-body = t(".description2")
 
     - if employments.any?
-      - employments.reverse.each_with_index do |employment, index|
+      - employments.reverse_each do |employment|
         - if employment.job?
           = render DetailComponent.new title: employment.job_title do |detail|
             - detail.with_body do

--- a/app/views/jobseekers/job_applications/build/employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/build/employment_history.html.slim
@@ -12,7 +12,7 @@
     p.govuk-body = t(".description2")
 
     - if employments.any?
-      - employments.each_with_index do |employment, index|
+      - employments.reverse.each_with_index do |employment, index|
         - if employment.job?
           = render DetailComponent.new title: employment.job_title do |detail|
             - detail.with_body do

--- a/app/views/jobseekers/job_applications/review/_employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/review/_employment_history.html.slim
@@ -5,7 +5,7 @@
     - elsif publisher_signed_in?
       p.govuk-body = t("jobseekers.job_applications.show.employment_history.none")
   - else
-    - job_application.employments.sort_by { |r| r[:started_on] }.each_with_index do |employment, index|
+    - job_application.employments.sort_by { |r| r[:started_on] }.reverse.each_with_index do |employment, index|
       - if employment.job?
         = govuk_summary_list html_attributes: { id: "#{employment.job_title}-#{index}" } do |summary_list|
           - summary_list.row do |row|

--- a/app/views/jobseekers/profiles/_summary.html.slim
+++ b/app/views/jobseekers/profiles/_summary.html.slim
@@ -44,7 +44,7 @@ dl.govuk-summary-list
 
 - if profile.employments.any?
   h2.govuk-heading-m = t(".work_history")
-  - profile.employments.order(:started_on).each do |employment|
+  - profile.employments.order(:started_on).reverse.each do |employment|
     h3.govuk-heading-s class="govuk-!-padding-bottom-3"
       = employment.organisation
       p class="govuk-!-margin-bottom-0" = employment.job_title

--- a/app/views/jobseekers/profiles/_summary.html.slim
+++ b/app/views/jobseekers/profiles/_summary.html.slim
@@ -44,7 +44,7 @@ dl.govuk-summary-list
 
 - if profile.employments.any?
   h2.govuk-heading-m = t(".work_history")
-  - profile.employments.order(:started_on).reverse.each do |employment|
+  - profile.employments.order(:started_on).reverse_each do |employment|
     h3.govuk-heading-s class="govuk-!-padding-bottom-3"
       = employment.organisation
       p class="govuk-!-margin-bottom-0" = employment.job_title

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -2,7 +2,7 @@ en:
   buttons:
     accept_all_cookies: Accept all cookies
     accept_and_continue: Accept and continue
-    add_another_break: add a reason for this break
+    add_reason_for_break: add a reason for this break
     add_another_job: Add another job
     add_another_qualification: Add another qualification
     add_another_reference: Add another referee

--- a/spec/services/jobseekers/job_applications/employment_gap_finder_spec.rb
+++ b/spec/services/jobseekers/job_applications/employment_gap_finder_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Jobseekers::JobApplications::EmploymentGapFinder do
         expect(gaps).to eq(
           employments.first => {
             started_on: employments.first.ended_on + 1.day,
-            ended_on: employments.second.started_on - 1.day,
+            ended_on: employments.second.started_on,
           },
         )
       end
@@ -171,7 +171,7 @@ RSpec.describe Jobseekers::JobApplications::EmploymentGapFinder do
         expect(gaps).to eq(
           employments.first => {
             started_on: employments.first.ended_on + 1.day,
-            ended_on: employments.second.started_on - 1.day,
+            ended_on: employments.second.started_on,
           },
           employments.second => {
             started_on: employments.second.ended_on + 1.day,

--- a/spec/support/jobseeker_helpers.rb
+++ b/spec/support/jobseeker_helpers.rb
@@ -49,15 +49,15 @@ module JobseekerHelpers
     fill_in "Please give details", with: "Some details of the relationship"
   end
 
-  def fill_in_employment_history
+  def fill_in_employment_history(job_title: "The Best Teacher", start_month: "09", start_year: "2019", end_month: "07", end_year: "2020")
     fill_in "School or other organisation", with: "The Best School"
-    fill_in "Job title", with: "The Best Teacher"
+    fill_in "Job title", with: job_title
     fill_in "Main duties", with: "Some details about what the main duties were"
-    fill_in "jobseekers_job_application_details_employment_form[started_on(1i)]", with: "2019"
-    fill_in "jobseekers_job_application_details_employment_form[started_on(2i)]", with: "09"
+    fill_in "jobseekers_job_application_details_employment_form[started_on(1i)]", with: start_year
+    fill_in "jobseekers_job_application_details_employment_form[started_on(2i)]", with: start_month
     choose "No", name: "jobseekers_job_application_details_employment_form[current_role]"
-    fill_in "jobseekers_job_application_details_employment_form[ended_on(1i)]", with: "2020"
-    fill_in "jobseekers_job_application_details_employment_form[ended_on(2i)]", with: "07"
+    fill_in "jobseekers_job_application_details_employment_form[ended_on(1i)]", with: end_year
+    fill_in "jobseekers_job_application_details_employment_form[ended_on(2i)]", with: end_month
   end
 
   def fill_in_break_in_employment

--- a/spec/support/jobseeker_helpers.rb
+++ b/spec/support/jobseeker_helpers.rb
@@ -144,4 +144,12 @@ module JobseekerHelpers
     choose "No", name: "jobseekers_qualifications_other_form[finished_studying]"
     fill_in "Please give details", with: "I expect to finish next year"
   end
+
+  def expect_work_history_to_be_ordered_most_recent_first
+    start_dates = all(".govuk-summary-list__row dt", text: "Start date").map { |dt| dt.find("+ dd").text }
+
+    parsed_dates = start_dates.map { |date| Date.strptime(date, "%B %Y") }
+
+    expect(parsed_dates).to eq parsed_dates.sort.reverse
+  end
 end

--- a/spec/system/jobseekers_can_add_employments_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers_can_add_employments_to_their_job_application_spec.rb
@@ -40,6 +40,37 @@ RSpec.describe "Jobseekers can add employments and breaks to their job applicati
     expect(page).to have_content(Date.new(2020, 0o7, 1).to_formatted_s(:month_year))
   end
 
+  it "displays employment history from newest to oldest job" do
+    visit jobseekers_job_application_build_path(job_application, :employment_history)
+
+    click_on I18n.t("buttons.add_job")
+    validates_step_complete(button: I18n.t("buttons.save_employment"))
+
+    fill_in_employment_history(job_title: "Old job")
+
+    click_on I18n.t("buttons.save_employment")
+
+    all(:link, "Add another job").first.click
+
+    fill_in_employment_history(job_title: "Oldest job", start_month: "09", start_year: "2015", end_month: "06", end_year: "2019")
+
+    click_on I18n.t("buttons.save_employment")
+
+    all(:link, "Add another job").first.click
+
+    fill_in_current_role
+
+    click_on I18n.t("buttons.save_employment")
+
+    oldest_job = find("h3", text: "Oldest job").path
+    middle_job = find("h3", text: "Old job").path
+    newest_job = find("h3", text: "The Best Teacher").path
+  
+    expect(newest_job).to be < middle_job
+    expect(newest_job).to be < oldest_job
+    expect(middle_job).to be < oldest_job
+  end
+
   context "managing employment history gaps" do
     before do
       create(:employment, :job, job_application: job_application, started_on: Date.parse("2021-01-01"), ended_on: Date.parse("2021-02-01"))

--- a/spec/system/jobseekers_can_add_employments_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers_can_add_employments_to_their_job_application_spec.rb
@@ -79,8 +79,8 @@ RSpec.describe "Jobseekers can add employments and breaks to their job applicati
 
     it "allows jobseekers to add, change and delete gaps in employment with prefilled start and end date" do
       visit jobseekers_job_application_build_path(job_application, :employment_history)
-
-      click_on I18n.t("buttons.add_another_break")
+      expect(page).to have_content "You have a break in your work history (4 months)"
+      click_on I18n.t("buttons.add_reason_for_break")
 
       expect(page).to have_field("jobseekers_job_application_details_break_form_started_on_1i", with: "2021")
       expect(page).to have_field("jobseekers_job_application_details_break_form_started_on_2i", with: "2")

--- a/spec/system/jobseekers_can_add_employments_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers_can_add_employments_to_their_job_application_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Jobseekers can add employments and breaks to their job applicati
     oldest_job = find("h3", text: "Oldest job").path
     middle_job = find("h3", text: "Old job").path
     newest_job = find("h3", text: "The Best Teacher").path
-  
+
     expect(newest_job).to be < middle_job
     expect(newest_job).to be < oldest_job
     expect(middle_job).to be < oldest_job

--- a/spec/system/jobseekers_can_complete_a_job_application_spec.rb
+++ b/spec/system/jobseekers_can_complete_a_job_application_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Jobseekers can complete a job application" do
     expect(page).to have_content("There is a problem")
     fill_in_employment_history
     click_on I18n.t("buttons.save_employment")
-    click_on I18n.t("buttons.add_another_break")
+    click_on I18n.t("buttons.add_reason_for_break")
     fill_in_break_in_employment
     click_on I18n.t("buttons.continue")
     choose I18n.t("helpers.label.jobseekers_job_application_employment_history_form.employment_history_section_completed_options.true")

--- a/spec/system/jobseekers_can_review_a_job_application_spec.rb
+++ b/spec/system/jobseekers_can_review_a_job_application_spec.rb
@@ -90,12 +90,4 @@ RSpec.describe "Jobseekers can review a job application" do
       expect(page).to have_content(job_application.right_to_work_in_uk.humanize)
     end
   end
-
-  def expect_work_history_to_be_ordered_most_recent_first
-    start_dates = all(".govuk-summary-list__row dt", text: "Start date").map { |dt| dt.find("+ dd").text }
-      
-    parsed_dates = start_dates.map { |date| Date.strptime(date, "%B %Y") }
-
-    expect(parsed_dates).to eq parsed_dates.sort.reverse
-  end
 end

--- a/spec/system/jobseekers_can_review_a_job_application_spec.rb
+++ b/spec/system/jobseekers_can_review_a_job_application_spec.rb
@@ -40,6 +40,8 @@ RSpec.describe "Jobseekers can review a job application" do
         expect(page).to have_content(employment.current_role.humanize)
         expect(page).to have_content(employment.ended_on.to_formatted_s(:month_year))
       end
+
+      expect_work_history_to_be_ordered_most_recent_first
     end
 
     within ".review-component__section", text: I18n.t("jobseekers.job_applications.build.employment_history.heading") do
@@ -87,5 +89,13 @@ RSpec.describe "Jobseekers can review a job application" do
       expect(page).to have_content(job_application.close_relationships_details)
       expect(page).to have_content(job_application.right_to_work_in_uk.humanize)
     end
+  end
+
+  def expect_work_history_to_be_ordered_most_recent_first
+    start_dates = all(".govuk-summary-list__row dt", text: "Start date").map { |dt| dt.find("+ dd").text }
+      
+    parsed_dates = start_dates.map { |date| Date.strptime(date, "%B %Y") }
+
+    expect(parsed_dates).to eq parsed_dates.sort.reverse
   end
 end

--- a/spec/system/jobseekers_can_view_a_job_application_spec.rb
+++ b/spec/system/jobseekers_can_view_a_job_application_spec.rb
@@ -73,12 +73,4 @@ RSpec.describe "Jobseekers can view a job application" do
       end
     end
   end
-
-  def expect_work_history_to_be_ordered_most_recent_first
-    start_dates = all(".govuk-summary-list__row dt", text: "Start date").map { |dt| dt.find("+ dd").text }
-      
-    parsed_dates = start_dates.map { |date| Date.strptime(date, "%B %Y") }
-
-    expect(parsed_dates).to eq parsed_dates.sort.reverse
-  end
 end

--- a/spec/system/jobseekers_can_view_a_job_application_spec.rb
+++ b/spec/system/jobseekers_can_view_a_job_application_spec.rb
@@ -34,6 +34,8 @@ RSpec.describe "Jobseekers can view a job application" do
     expect(page).to have_css(".review-component__section", text: I18n.t("jobseekers.job_applications.show.ask_for_support.heading"))
     expect(page).to have_css(".review-component__section", text: I18n.t("jobseekers.job_applications.show.declarations.heading"))
 
+    expect_work_history_to_be_ordered_most_recent_first
+
     within ".timeline-component__item", text: I18n.t("jobseekers.job_applications.status_timestamps.submitted") do
       expect(page).to have_content("#{format_date(job_application.submitted_at.to_date)} at #{format_time(job_application.submitted_at)}")
     end
@@ -70,5 +72,13 @@ RSpec.describe "Jobseekers can view a job application" do
         end
       end
     end
+  end
+
+  def expect_work_history_to_be_ordered_most_recent_first
+    start_dates = all(".govuk-summary-list__row dt", text: "Start date").map { |dt| dt.find("+ dd").text }
+      
+    parsed_dates = start_dates.map { |date| Date.strptime(date, "%B %Y") }
+
+    expect(parsed_dates).to eq parsed_dates.sort.reverse
   end
 end

--- a/spec/system/publishers_can_view_a_job_application_spec.rb
+++ b/spec/system/publishers_can_view_a_job_application_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe "Publishers can view a job application" do
   it "shows the timeline" do
     visit organisation_job_job_application_path(vacancy.id, job_application)
 
+    expect_work_history_to_be_ordered_most_recent_first
+
     click_on I18n.t("buttons.shortlist")
     fill_in "publishers_job_application_update_status_form[further_instructions]", with: "Some further instructions"
     click_on I18n.t("buttons.shortlist")
@@ -98,5 +100,13 @@ RSpec.describe "Publishers can view a job application" do
         expect(actions).to have_css("a", class: "govuk-button--secondary", text: I18n.t("buttons.download_application"))
       end
     end
+  end
+
+  def expect_work_history_to_be_ordered_most_recent_first
+    start_dates = all(".govuk-summary-list__row dt", text: "Start date").map { |dt| dt.find("+ dd").text }
+      
+    parsed_dates = start_dates.map { |date| Date.strptime(date, "%B %Y") }
+
+    expect(parsed_dates).to eq parsed_dates.sort.reverse
   end
 end

--- a/spec/system/publishers_can_view_a_job_application_spec.rb
+++ b/spec/system/publishers_can_view_a_job_application_spec.rb
@@ -101,12 +101,4 @@ RSpec.describe "Publishers can view a job application" do
       end
     end
   end
-
-  def expect_work_history_to_be_ordered_most_recent_first
-    start_dates = all(".govuk-summary-list__row dt", text: "Start date").map { |dt| dt.find("+ dd").text }
-      
-    parsed_dates = start_dates.map { |date| Date.strptime(date, "%B %Y") }
-
-    expect(parsed_dates).to eq parsed_dates.sort.reverse
-  end
 end


### PR DESCRIPTION
…nt job first

## Trello card URL

https://trello.com/c/GLu1nwaG/589-bug-fix-work-history-ordering

## Changes in this PR:

The main change in this PR is reversing the ordering of the work history of a jobseeker as displayed to a jobseeker themselves when viewing or previewing their applications/profiles and to a publisher via the jobseeker application.

As part of this ticket I found the following areas which I felt like I could refactor:
- a misnamed i18n variable. It is named add_another_break but it actually refers to the "Add reason for the break" button. I renamed this in this PR.
- using employment dates, rather than the calculated break dates to display breaks in employment to the user.
- miscalculating break dates.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
