### PR TITLE
change expiry times

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -98,7 +98,7 @@ class Vacancy < ApplicationRecord
   after_save :reset_markers, if: -> { saved_change_to_status? && (listed? || pending?) }
 
   EQUAL_OPPORTUNITIES_PUBLICATION_THRESHOLD = 5
-  EXPIRY_TIME_OPTIONS = %w[9:00 12:00 17:00 23:59].freeze
+  EXPIRY_TIME_OPTIONS = %w[8:00 9:00 12:00 15:00 23:59].freeze
 
   # Class method added to help with the mapping of array_enums for paper_trail, which stores the changes
   # as an array of integers in the version.

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -962,21 +962,24 @@ en:
     options:
       publishers_job_listing_copy_vacancy_form:
         expiry_time:
+          "8:00": 8am
           "9:00": 9am
           "12:00": 12pm (midday)
-          "17:00": 5pm
+          "15:00": 3pm
           "23:59": 11:59pm
       publishers_job_listing_extend_deadline_form:
         expiry_time:
+          "8:00": 8am
           "9:00": 9am
           "12:00": 12pm (midday)
-          "17:00": 5pm
+          "15:00": 3pm
           "23:59": 11:59pm
       publishers_job_listing_important_dates_form:
         expiry_time:
+          "8:00": 8am
           "9:00": 9am
           "12:00": 12pm (midday)
-          "17:00": 5pm
+          "15:00": 3pm
           "23:59": 11:59pm
 
     placeholder:

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -77,7 +77,7 @@ module VacancyHelpers
     fill_in "publishers_job_listing_important_dates_form[expires_at(2i)]", with: vacancy.expires_at.month
     fill_in "publishers_job_listing_important_dates_form[expires_at(1i)]", with: vacancy.expires_at.year
 
-    choose "9am", name: "publishers_job_listing_important_dates_form[expiry_time]"
+    choose "3pm", name: "publishers_job_listing_important_dates_form[expiry_time]"
   end
 
   def fill_in_start_date_form_fields(vacancy)

--- a/spec/system/publishers_can_publish_a_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers_can_publish_a_vacancy_as_a_school_spec.rb
@@ -261,7 +261,7 @@ RSpec.describe "Creating a vacancy" do
         fill_in "publishers_job_listing_important_dates_form[expires_at(3i)]", with: expiry_date.day
         fill_in "publishers_job_listing_important_dates_form[expires_at(2i)]", with: expiry_date.month
         fill_in "publishers_job_listing_important_dates_form[expires_at(1i)]", with: expiry_date.year
-        choose "9am", name: "publishers_job_listing_important_dates_form[expiry_time]"
+        choose "8am", name: "publishers_job_listing_important_dates_form[expiry_time]"
 
         click_on I18n.t("buttons.save_and_continue")
 


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/9DPmRzUr/489-update-listing-closing-times

## Changes in this PR:

Change the options for closing dates on vacancies to include 8am and 3pm and remove 5pm.

## Screenshots of UI changes:

### Before
<img width="809" alt="Screenshot 2023-10-25 at 14 48 16" src="https://github.com/DFE-Digital/teaching-vacancies/assets/13124899/fb33344d-b362-4da0-82a4-e850fffd31a3">

##
<img width="659" alt="Screenshot 2023-10-25 at 12 33 13" src="https://github.com/DFE-Digital/teaching-vacancies/assets/13124899/125ffc64-25ee-401e-b8a0-ba05a515e33c">
# After


## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
