### PR TITLE
Restore Terraform app docker image variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,7 @@ deploy-local-image: push-local-image terraform-app-plan## make passcode=MyPassco
 .PHONY: check-terraform-variables
 check-terraform-variables:
 		$(if $(tag), , $(eval export tag=main))
+		$(eval export TF_VAR_app_docker_image=$(DOCKER_REPOSITORY):$(tag))
 
 
 ci:	## Run in automation environment


### PR DESCRIPTION
So Terraform can point to the right docker images during the deployment process.

Related PR/Change: https://github.com/DFE-Digital/teaching-vacancies/pull/6486/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L139
