### PR TITLE
Rename docker image refs in infra code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,10 +121,7 @@ deploy-local-image: push-local-image terraform-app-plan## make passcode=MyPassco
 .PHONY: check-terraform-variables
 check-terraform-variables:
 		$(if $(tag), , $(eval export tag=main))
-		$(eval export TF_VAR_paas_app_docker_image=$(DOCKER_REPOSITORY):$(tag))
-
-
-
+		$(eval export TF_VAR_app_docker_image=$(DOCKER_REPOSITORY):$(tag))
 
 ci:	## Run in automation environment
 	$(eval export AUTO_APPROVE=-auto-approve)

--- a/documentation/terraform.md
+++ b/documentation/terraform.md
@@ -76,7 +76,7 @@ The equivalent of the Makefile `dev terraform-app-plan` is:
 cd terraform/app
 rm -f .terraform.lock.hcl
 terraform init -reconfigure -backend-config="key=dev/app.tfstate"
-terraform plan -var="paas_sso_passcode=MyPasscode" -var="paas_app_docker_image=dfedigital/teaching-vacancies:dev-08406f04dd9eadb7df6fcda5213be880d7df37ed-20201022090714" -var-file ../workspace-variables/dev.tfvars.json
+terraform plan -var="paas_sso_passcode=MyPasscode" -var="app_docker_image=dfedigital/teaching-vacancies:dev-08406f04dd9eadb7df6fcda5213be880d7df37ed-20201022090714" -var-file ../workspace-variables/dev.tfvars.json
 ```
 
 ## Planning out to a file, and using `terraform show`
@@ -98,7 +98,7 @@ How do we get visibility of what the `(sensitive value)` change will be?
 In the `terraform/app` directory:
 
 ```
-terraform plan -var="paas_sso_passcode=MyPasscode" -var="paas_app_docker_image=dfedigital/teaching-vacancies:dev-08406f04dd9eadb7df6fcda5213be880d7df37ed-20201022090714" -var-file ../workspace-variables/dev.tfvars.json -out dev.plan
+terraform plan -var="paas_sso_passcode=MyPasscode" -var="app_docker_image=dfedigital/teaching-vacancies:dev-08406f04dd9eadb7df6fcda5213be880d7df37ed-20201022090714" -var-file ../workspace-variables/dev.tfvars.json -out dev.plan
 ```
 Then we can use `terraform show` to render as JSON
 ```

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -65,7 +65,7 @@ module "cloudwatch" {
 module "paas" {
   source                                       = "./modules/paas"
   environment                                  = var.environment
-  app_docker_image                             = var.paas_app_docker_image
+  app_docker_image                             = var.app_docker_image
   app_env_values                               = local.app_env_values
   parameter_store_environment                  = var.parameter_store_environment
   service_name                                 = local.service_name

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -48,7 +48,7 @@ variable "schools_images_logos_s3_bucket_force_destroy" {
 
 # Gov.UK PaaS
 
-variable "paas_app_docker_image" {
+variable "app_docker_image" {
   default = "ghcr.io/dfe-digital/teaching-vacancies:placeholder"
 }
 variable "app_environment" {


### PR DESCRIPTION
Remove reference to PAAS in its name as it may cause confusion. The docker image is independent of the service hosting and we moved on from PAAS to AKS.
