### PR TITLE
Set landing page for account confirmation

### DIFF
--- a/app/controllers/jobseekers/confirmations_controller.rb
+++ b/app/controllers/jobseekers/confirmations_controller.rb
@@ -15,8 +15,7 @@ class Jobseekers::ConfirmationsController < Devise::ConfirmationsController
 
     # When landing on the confirmation page from the email link.
     if (user = Jobseeker.find_by(confirmation_token: params[:confirmation_token]))
-      # Doesn't allow to view the confirmation page if the user is already confirmed.
-      user.confirmed? ? render(:already_confirmed) : render(:show)
+      user.needs_email_confirmation? ? render(:show) : render(:already_confirmed)
     else
       not_found # Doesn't allow to view the confirmation page unless landing with a valid token.
     end

--- a/app/controllers/jobseekers/confirmations_controller.rb
+++ b/app/controllers/jobseekers/confirmations_controller.rb
@@ -10,11 +10,15 @@ class Jobseekers::ConfirmationsController < Devise::ConfirmationsController
   # link for security checks. That security check was consuming the user token and then redirecting the user to a
   # invalid link page.
   def show
-    if request.method == "POST" # When submitting confirmation from #show view.
-      super # Calls original Devise method to attempt to confirm the user.
-    else # When landing on the confirmation page from the email link.
-      user = Jobseeker.find_by(confirmation_token: params[:confirmation_token])
-      not_found unless user.present? # Doesn't allow the user to view the confirmation page unless landing with a valid token.
+    # When submitting confirmation from #show view calls Devise method to attempt to confirm the user.
+    return super if request.method == "POST"
+
+    # When landing on the confirmation page from the email link.
+    if (user = Jobseeker.find_by(confirmation_token: params[:confirmation_token]))
+      # Doesn't allow to view the confirmation page if the user is already confirmed.
+      user.confirmed? ? render(:already_confirmed) : render(:show)
+    else
+      not_found # Doesn't allow to view the confirmation page unless landing with a valid token.
     end
   end
 

--- a/app/controllers/jobseekers/confirmations_controller.rb
+++ b/app/controllers/jobseekers/confirmations_controller.rb
@@ -1,4 +1,23 @@
 class Jobseekers::ConfirmationsController < Devise::ConfirmationsController
+  # Overriden Devise method.
+  #
+  # Introduces a middle step to confirm the user account after following the email confirmation link.
+  #
+  # Instead of being directly confirmed when following the link, the users will be queried to press a 'Confirm' button
+  # that will trigger the user confirmation.
+  #
+  # This solves issues with some email cloud providers (Outlook) introducing a security messure that proxies any https
+  # link for security checks. That security check was consuming the user token and then redirecting the user to a
+  # invalid link page.
+  def show
+    if request.method == "POST" # When submitting confirmation from #show view.
+      super # Calls original Devise method to attempt to confirm the user.
+    else # When landing on the confirmation page from the email link.
+      user = Jobseeker.find_by(confirmation_token: params[:confirmation_token])
+      not_found unless user.present? # Doesn't allow the user to view the confirmation page unless landing with a valid token.
+    end
+  end
+
   protected
 
   def after_confirmation_path_for(_resource_name, resource)

--- a/app/controllers/jobseekers/confirmations_controller.rb
+++ b/app/controllers/jobseekers/confirmations_controller.rb
@@ -2,22 +2,16 @@ class Jobseekers::ConfirmationsController < Devise::ConfirmationsController
   # Overriden Devise method.
   #
   # Introduces a middle step to confirm the user account after following the email confirmation link.
-  #
-  # Instead of being directly confirmed when following the link, the users will be queried to press a 'Confirm' button
-  # that will trigger the user confirmation.
-  #
-  # This solves issues with some email cloud providers (Outlook) introducing a security messure that proxies any https
-  # link for security checks. That security check was consuming the user token and then redirecting the user to a
-  # invalid link page.
+  # This resolves issues with some email cloud providers (Outlook) security checks consuming the confirmation token and
+  # and then redirecting the user to the page, causing the user to land at a "link expired" error page.
   def show
-    # When submitting confirmation from #show view calls Devise method to attempt to confirm the user.
-    return super if request.method == "POST"
+    return super if request.method == "POST" # When clicking "Confirm" on the confirmation page, handles it to Devise.
 
     # When landing on the confirmation page from the email link.
     if (user = Jobseeker.find_by(confirmation_token: params[:confirmation_token]))
       user.needs_email_confirmation? ? render(:show) : render(:already_confirmed)
     else
-      not_found # Doesn't allow to view the confirmation page unless landing with a valid token.
+      not_found
     end
   end
 

--- a/app/controllers/jobseekers/unlocks_controller.rb
+++ b/app/controllers/jobseekers/unlocks_controller.rb
@@ -1,5 +1,10 @@
 class Jobseekers::UnlocksController < Devise::UnlocksController
   def show
-    super if request.method == "POST"
+    if request.method == "POST"
+      super
+    else
+      enc_token = Devise.token_generator.digest(Jobseeker, :unlock_token, params[:unlock_token])
+      super unless Jobseeker.find_by(unlock_token: enc_token)
+    end
   end
 end

--- a/app/models/jobseeker.rb
+++ b/app/models/jobseeker.rb
@@ -30,4 +30,8 @@ class Jobseeker < ApplicationRecord
   def account_closed?
     !!account_closed_on
   end
+
+  def needs_email_confirmation?
+    !confirmed? || unconfirmed_email.present?
+  end
 end

--- a/app/views/jobseekers/confirmations/already_confirmed.html.slim
+++ b/app/views/jobseekers/confirmations/already_confirmed.html.slim
@@ -1,0 +1,8 @@
+- content_for :page_title_prefix, t(".title")
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    h1.govuk-heading-xl = t(".title")
+
+    p.govuk-body = t(".description")
+    p.govuk-body You can #{govuk_link_to("return to the homepage", "/")} to use the service.

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -35,6 +35,9 @@ en:
       survey_link_text: Give feedback
       survey_text: Take our quick survey about your experience of using Teaching Vacancies
     confirmations:
+      already_confirmed:
+        description: Your email address has already been confirmed.
+        title: Email already confirmed
       new:
         description: We need to email another link to %{email} so you can activate your account.
         title: Link has expired

--- a/spec/models/jobseeker_spec.rb
+++ b/spec/models/jobseeker_spec.rb
@@ -16,4 +16,36 @@ RSpec.describe Jobseeker do
       }.to change { subscription.reload.email }.to(new_email_address)
     end
   end
+
+  describe "#needs_email_confirmation?" do
+    subject(:jobseeker) { build_stubbed(:jobseeker) }
+
+    context "when the user is confirmed" do
+      before { jobseeker.confirmed_at = Time.current }
+
+      context "when the user does not have a new unconfirmed email address" do
+        before { jobseeker.unconfirmed_email = nil }
+        it { is_expected.not_to be_needs_email_confirmation }
+      end
+
+      context "when the user has a new unconfirmed email address" do
+        before { jobseeker.unconfirmed_email = "foobar@example.com" }
+        it { is_expected.to be_needs_email_confirmation }
+      end
+    end
+
+    context "when the user is not confirmed" do
+      before { jobseeker.confirmed_at = nil }
+
+      context "when the user does not have a new unconfirmed email address" do
+        before { jobseeker.unconfirmed_email = nil }
+        it { is_expected.to be_needs_email_confirmation }
+      end
+
+      context "when the user has a new unconfirmed email address" do
+        before { jobseeker.unconfirmed_email = "foobar@example.com" }
+        it { is_expected.to be_needs_email_confirmation }
+      end
+    end
+  end
 end

--- a/spec/support/jobseeker_helpers.rb
+++ b/spec/support/jobseeker_helpers.rb
@@ -1,6 +1,8 @@
 module JobseekerHelpers
   def confirm_email_address
     visit first_link_from_last_mail
+    expect(page).to have_css("h1", text: I18n.t("jobseekers.confirmations.show.title"))
+    click_on I18n.t("jobseekers.confirmations.show.confirm")
   end
 
   def sign_up_jobseeker(email: jobseeker.email, password: jobseeker.password)

--- a/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
@@ -50,6 +50,14 @@ RSpec.describe "Jobseekers can sign up to an account" do
         expect(page).to have_link(I18n.t("jobseekers.accounts.confirmation.create_profile.heading"), href: jobseekers_profile_path)
         expect(page).not_to have_content(I18n.t("devise.confirmations.confirmed"))
       end
+
+      it "shows an error when trying to visit the confirmation link after a successfull confirmation" do
+        confirm_email_address
+        visit first_link_from_last_mail
+
+        expect(page).to have_css("h1", text: I18n.t("jobseekers.confirmations.already_confirmed.title"))
+        expect(page).to have_content(I18n.t("jobseekers.confirmations.already_confirmed.description"))
+      end
     end
 
     context "when the user attempts to sign in without confirming their email" do

--- a/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
@@ -28,8 +28,7 @@ RSpec.describe "Jobseekers can sign up to an account" do
       click_on I18n.t("jobseekers.registrations.check_your_email.resend_link")
       expect(page).to have_content I18n.t("jobseekers.registrations.check_your_email.resent_email_confirmation")
 
-      visit first_link_from_last_mail
-
+      confirm_email_address
       expect(current_path).to eq(confirmation_jobseekers_account_path)
     end
   end
@@ -67,30 +66,35 @@ RSpec.describe "Jobseekers can sign up to an account" do
       end
     end
 
-    context "when the confirmation token is invalid" do
-      context "when the confirmation period has expired" do
-        before { travel_to 25.hours.from_now }
+    context "when the existing confirmation period has expired" do
+      before { travel_to 25.hours.from_now }
 
-        context "when jobseeker tries to confirm their email" do
-          before do
-            confirm_email_address
-          end
-
-          it "informs user that the link has expired and allows them to resend email and confirm their email" do
-            expect(page).to have_content("Link has expired")
-            expect { click_on "Resend email" }.to change { delivered_emails.count }.by(1)
-            expect(current_path).to eq(jobseekers_check_your_email_path)
-            confirm_email_address
-            expect(current_path).to eq(confirmation_jobseekers_account_path)
-          end
+      context "when jobseeker tries to confirm their email" do
+        before do
+          confirm_email_address
         end
 
-        context "when the confirmation email is resent" do
-          it "resends confirmation email and redirects to check your email page" do
-            expect { click_on "resend the email" }.to change { delivered_emails.count }.by(1)
-            expect(page).to have_content "Email has been resent"
-          end
+        it "informs user that the link has expired and allows them to resend email and confirm their email" do
+          expect(page).to have_content("Link has expired")
+          expect { click_on "Resend email" }.to change { delivered_emails.count }.by(1)
+          expect(current_path).to eq(jobseekers_check_your_email_path)
+          confirm_email_address
+          expect(current_path).to eq(confirmation_jobseekers_account_path)
         end
+      end
+
+      context "when the confirmation email is resent" do
+        it "resends confirmation email and redirects to check your email page" do
+          expect { click_on "resend the email" }.to change { delivered_emails.count }.by(1)
+          expect(page).to have_content "Email has been resent"
+        end
+      end
+    end
+
+    context "when the confirmation token does not exist" do
+      it "takes the user to the 'not found' page" do
+        visit jobseeker_confirmation_path(confirmation_token: "fooBar")
+        expect(page).to have_content("Page not found")
       end
     end
   end

--- a/spec/system/jobseekers_can_unlock_their_account_spec.rb
+++ b/spec/system/jobseekers_can_unlock_their_account_spec.rb
@@ -45,9 +45,9 @@ RSpec.describe "Jobseekers can unlock their account" do
           delivered_emails.count
         }.by(1)
 
-        confirm_email_address
-
-        click_button "Confirm"
+        visit first_link_from_last_mail
+        expect(page).to have_css("h1", text: I18n.t("jobseekers.unlocks.show.title"))
+        click_button I18n.t("jobseekers.unlocks.show.confirm")
 
         expect(jobseeker.reload).not_to be_access_locked
 

--- a/spec/system/jobseekers_can_unlock_their_account_spec.rb
+++ b/spec/system/jobseekers_can_unlock_their_account_spec.rb
@@ -12,10 +12,28 @@ RSpec.describe "Jobseekers can unlock their account" do
   context "when the jobseeker has one sign-in attempt remaining" do
     before { jobseeker.update!(failed_attempts: Devise.maximum_attempts) }
 
-    scenario "they receive an email with unlocking instructions after their final failed attempt" do
+    scenario "they can unlock their account following the unlock email instructions received after their final failed attempt" do
       expect { sign_in_jobseeker(password: "wrong password") }.to change { delivered_emails.count }.by(1)
 
       expect(page).to have_content("too many attempts")
+
+      visit first_link_from_last_mail
+      expect(page).to have_css("h1", text: I18n.t("jobseekers.unlocks.show.title"))
+
+      click_button I18n.t("jobseekers.unlocks.show.confirm")
+      expect(jobseeker.reload).not_to be_access_locked
+      expect(page).to have_css("h1", text: I18n.t("jobseekers.sessions.new.title"))
+      expect(page).to have_content(I18n.t("devise.unlocks.unlocked"))
+    end
+
+    scenario "following the unlock link for a second time takes them directly to an error page" do
+      sign_in_jobseeker(password: "wrong password")
+      visit first_link_from_last_mail
+      click_button I18n.t("jobseekers.unlocks.show.confirm")
+
+      visit first_link_from_last_mail
+      expect(page).to have_css("h1", text: I18n.t("jobseekers.unlocks.new.heading"))
+      expect(page).to have_content(I18n.t("jobseekers.unlocks.new.description"))
     end
   end
 
@@ -27,7 +45,6 @@ RSpec.describe "Jobseekers can unlock their account" do
     context "when the unlock token is invalid" do
       before do
         visit jobseeker_unlock_url(unlock_token: "invalid token")
-        click_on "Confirm"
       end
 
       scenario "they are locked out of their account" do


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/0yIQ0BaW

## Changes in this PR:

### Fix the issue with one-time token links for Outlook email clients.

This PR resolves users with Outlook mail clients getting shown a "Link has expired" page when following the account confirmation link.

The issue happened because Microsoft Cloud security would alter the original link and mask it through a proxied address. When clicking the link, Microsoft software visits it to check the HTTPS certificate security and then redirects the user to the page.
The HTTPS check visit before the redirection consumed the confirmation token. So when the user gets redirected, they get a "Link has expired" page.

To resolve it, we are re-introducing a confirmation landing page. So the token only gets consumed once the user confirms it.

### Introduce an "Already confirmed" page

Users with confirmed accounts following the email link for a second time were presented with a "Link has expired" page. This confused them, as they didn't realise their account was already confirmed.

We have introduced an explicit page letting them know.

### Show "Page not found" for an incorrect one-time token.

Displaying the "Link has expired" page or the confirmation page itself when the One-time token is wrong is confusing, as many times there is not even a user session to resend the email to, which gets users into a navigation loop and frustrated as they don't get a new email.

If the link points to an inexistent token, it sends them to a 404 Not found page.
This simplifies the flow with an earlier clear end page.


## Confirming account registration
### After following the email confirmation link
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/64fa92e7-f2aa-4a09-b244-0e0d01819bca)

### After clicking on the "Confirm" button
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/1dce85a5-33b2-4b62-b5a0-5e360ef274a1)

### If following the email link again after already confirmed
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/216b0161-13b8-42cc-bcb3-2ac618215cb1)

----

## Confirming email change
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/dc969f3f-4fa6-4ad7-9914-0e3b4841eaf8)

### Old email address receives an alert
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/49ed8732-8845-4a72-89bf-7ac71115cef4)

### New email address receives confirmation email
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/857eb57f-c85f-416b-b042-a5017a4c84c5)

### Landing page after following the link. Email has still not changed/confirmed at this stage.
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/9d468a9f-9090-46b3-baa6-0a944ce02db5)

### When clicking on the confirmation link from the email after confirming the first time
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/06947216-bab5-4c87-a87f-f6e6f82058a1)

### When clicking on the email link again
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/1f037ff5-4113-4c40-b828-c0465ce95e79)

----

## Confirming password reset

### The user introduces the email for receiving a password reset link
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/f6bf34a9-4c4e-482b-a9a0-e680dec77982)

### Email sent
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/f3dfe6fa-2640-4a78-b764-cb2c1476ba4f)

### Password update following the email
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/6dfbb363-4a25-476c-a38a-7be1c6c04035)

### Confirmation after setting a new email
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/4e3e0f1d-4526-44c6-87f7-c07939b23cec)

----

## Unlocking account

### Account gets locked
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/8c921c30-62bf-41a0-8f92-1cd3e7176048)

### Receive an email to unlock the account
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/dedb5d4d-bb12-408a-9a74-a16c3d76baba)

### The link takes to an unlock confirmation page
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/bc867b06-b712-4e23-8819-39f63a900f02)

### After confirming the user sees a confirmation message
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/a4e4c266-98dc-4b91-8f65-08476448ef02)

### Visiting the unlock link from the email after already unlocked
#### When signed in
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/d986af0e-49f6-478d-8073-b909b71fe9e9)
#### When not signed in
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/8e900a6c-674d-4f4e-a27b-fb0e75870b4f)
