### PR TITLE
Remove Job Application Country from Analytics PII

### DIFF
--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -20,7 +20,6 @@ shared:
     - previous_names
     - street_address
     - city
-    - country
     - postcode
     - phone_number
     - teacher_reference_number


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/ipHfO821

## Changes in this PR:

This information is too generic to identify an individual and the analytics team requested to be able to consult it to identify trends on international candidates' origin.