### PR TITLE
Fix format on plain text external job adverts

### DIFF
--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -19,6 +19,13 @@ class VacancyPresenter < BasePresenter
     simple_format(fix_bullet_points(model.benefits_details)) if model.benefits_details.present?
   end
 
+  def job_advert
+    return if model.job_advert.blank?
+
+    # Basic HTML formatting of text if it is not already HTML
+    model.job_advert.strip.starts_with?("<") ? model.job_advert : simple_format(model.job_advert)
+  end
+
   # TODO: Working Patterns: Remove this once all vacancies with legacy working patterns & working_pattern_details have expired
   def readable_working_patterns
     model.working_patterns.map { |working_pattern|

--- a/spec/presenters/vacancy_presenter_spec.rb
+++ b/spec/presenters/vacancy_presenter_spec.rb
@@ -124,7 +124,7 @@ end
 RSpec.describe VacancyPresenter do
   subject { described_class.new(vacancy) }
 
-  let(:vacancy) { build(:vacancy) }
+  let(:vacancy) { build_stubbed(:vacancy) }
 
   describe "#about_school" do
     it_behaves_like "a fields that outputs the correct HTML", :about_school
@@ -136,6 +136,20 @@ RSpec.describe VacancyPresenter do
 
   describe "#benefits_details" do
     it_behaves_like "a fields that outputs the correct HTML", :benefits_details
+  end
+
+  describe "#job_advert" do
+    it "adds line breaks and paragraphs to plain text adverts" do
+      vacancy.job_advert = "This is an example job advert without HTML.\n\nThe advert includes:\nFirst line.\nSecond line."
+      expect(subject.job_advert).to eq(
+        "<p>This is an example job advert without HTML.</p>\n\n<p>The advert includes:\n<br />First line.\n<br />Second line.</p>",
+      )
+    end
+
+    it "does not modify HTML adverts" do
+      vacancy.job_advert = "<p>This is an example job advert with HTML.</p><p>The advert includes:<br />First line.<br />Second line.</p>"
+      expect(subject.job_advert).to eq(vacancy.job_advert)
+    end
   end
 
   # TODO: Working Patterns: Remove this test once all vacancies with legacy working patterns & working_pattern_details have expired


### PR DESCRIPTION
## Trello card URL

- https://trello.com/c/tVgl54Ti

## Changes in this PR:

Some adverts from Broadbean and Every vacancy sources come as plain text, without any HTML paragraph or line break code, but plain text return characters.

That is causing them to be displayed as a single line, breaking their formatting.

We are using simple_format to add the appropriate paragraph and line text HTML tags to display those adverts.
