### PR TITLE
Fix resend email confirmation link

### DIFF
--- a/app/controllers/jobseekers/confirmations_controller.rb
+++ b/app/controllers/jobseekers/confirmations_controller.rb
@@ -1,6 +1,8 @@
 class Jobseekers::ConfirmationsController < Devise::ConfirmationsController
-  # Overriden Devise method.
   #
+  # Overriden Devise methods.
+  #
+
   # Introduces a middle step to confirm the user account after following the email confirmation link.
   # This resolves issues with some email cloud providers (Outlook) security checks consuming the confirmation token and
   # and then redirecting the user to the page, causing the user to land at a "link expired" error page.
@@ -17,6 +19,22 @@ class Jobseekers::ConfirmationsController < Devise::ConfirmationsController
     end
   end
 
+  # Completely replaces the Devise definition
+  # Takes user to "check your email" page even if they introduced the wrong email address.
+  # This is to avoid an attacker discovering registered email addresses on the service through this form.
+  def create
+    if resource_params[:email].blank?
+      self.resource = Jobseeker.new
+      resource.errors.add(:email, :blank)
+      return render(:new)
+    end
+    self.resource = Jobseeker.send_confirmation_instructions(resource_params)
+
+    session[:jobseeker_id] = resource.id if resource # Ensures that the jobseeker is identified on following pages.
+    flash[:success] = t("jobseekers.registrations.check_your_email.resent_email_confirmation")
+    respond_with({}, location: jobseekers_check_your_email_path)
+  end
+
   protected
 
   def after_confirmation_path_for(_resource_name, resource)
@@ -24,9 +42,5 @@ class Jobseekers::ConfirmationsController < Devise::ConfirmationsController
     request_event.trigger(:jobseeker_email_confirmed)
     flash.delete(:notice)
     confirmation_jobseekers_account_path
-  end
-
-  def after_resending_confirmation_instructions_path_for(_resource)
-    jobseekers_check_your_email_path
   end
 end

--- a/app/controllers/jobseekers/confirmations_controller.rb
+++ b/app/controllers/jobseekers/confirmations_controller.rb
@@ -8,6 +8,8 @@ class Jobseekers::ConfirmationsController < Devise::ConfirmationsController
     return super if request.method == "POST" # When clicking "Confirm" on the confirmation page, handles it to Devise.
 
     # When landing on the confirmation page from the email link.
+    return not_found unless params[:confirmation_token].present?
+
     if (user = Jobseeker.find_by(confirmation_token: params[:confirmation_token]))
       user.needs_email_confirmation? ? render(:show) : render(:already_confirmed)
     else

--- a/app/controllers/jobseekers/registrations_controller.rb
+++ b/app/controllers/jobseekers/registrations_controller.rb
@@ -18,14 +18,18 @@ class Jobseekers::RegistrationsController < Devise::RegistrationsController
 
   def check_your_email
     flash.delete(:notice)
-    @resource = Jobseeker.find(session[:jobseeker_id])
+    @resource = Jobseeker.find_by(id: session[:jobseeker_id])
   end
 
   def resend_instructions
-    @resource = Jobseeker.find(session[:jobseeker_id])
-    @resource.send_confirmation_instructions
-    flash[:success] = t("jobseekers.registrations.check_your_email.resent_email_confirmation")
-    render :check_your_email
+    if session[:jobseeker_id].blank?
+      redirect_to new_jobseeker_confirmation_path
+    else
+      @resource = Jobseeker.find(session[:jobseeker_id])
+      @resource.send_confirmation_instructions
+      flash[:success] = t("jobseekers.registrations.check_your_email.resent_email_confirmation")
+      render :check_your_email
+    end
   end
 
   protected

--- a/app/views/jobseekers/confirmations/_new_hidden_email.html.slim
+++ b/app/views/jobseekers/confirmations/_new_hidden_email.html.slim
@@ -1,0 +1,11 @@
+- content_for :page_title_prefix, t(".title")
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    h1.govuk-heading-xl = t(".title")
+    p.govuk-body = t(".description", email: resource.email)
+
+    = form_for resource, url: jobseeker_confirmation_path, method: :post do |f|
+      = f.hidden_field :email
+
+      = f.govuk_submit t("buttons.resend_email"), class: "govuk-!-margin-bottom-0"

--- a/app/views/jobseekers/confirmations/_new_with_email.html.slim
+++ b/app/views/jobseekers/confirmations/_new_with_email.html.slim
@@ -1,0 +1,11 @@
+- content_for :page_title_prefix, t(".title")
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    h1.govuk-heading-xl = t(".title")
+    p.govuk-body = t(".description")
+
+    = form_for resource, url: jobseeker_confirmation_path, method: :post do |f|
+      = f.govuk_error_summary
+      = f.govuk_email_field :email, label: { size: "s" }, width: "two-thirds", required: true
+      = f.govuk_submit t("buttons.resend_email"), class: "govuk-!-margin-bottom-0"

--- a/app/views/jobseekers/confirmations/new.html.slim
+++ b/app/views/jobseekers/confirmations/new.html.slim
@@ -1,12 +1,4 @@
-- content_for :page_title_prefix, t(".title")
-
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
-    h1.govuk-heading-xl = t(".title")
-
-    p.govuk-body = t(".description", email: resource.email)
-
-    = form_for resource, url: jobseeker_confirmation_path, method: :post do |f|
-      = f.hidden_field :email
-
-      = f.govuk_submit t("buttons.resend_email"), class: "govuk-!-margin-bottom-0"
+- if resource&.email.present?
+  = render "new_hidden_email"
+- else
+  = render "new_with_email"

--- a/app/views/layouts/_head_meta.html.slim
+++ b/app/views/layouts/_head_meta.html.slim
@@ -6,6 +6,6 @@ meta name="theme-color" content="#0B0C0C"
 
 meta property="og:url" content=request.original_url
 meta property="og:type" content="article"
-meta property="og:title" content=content_for(:page_title_prefix).strip
+meta property="og:title" content=content_for(:page_title_prefix)&.strip
 meta property="og:description" content=meta_description
 meta property="og:image" content=image_path("og_image.jpg")

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -38,7 +38,10 @@ en:
       already_confirmed:
         description: Your email address has already been confirmed.
         title: Email already confirmed
-      new:
+      new_with_email:
+        description: We need to email another link so you can activate your account.
+        title: Resend confirmation
+      new_hidden_email:
         description: We need to email another link to %{email} so you can activate your account.
         title: Link has expired
       show:

--- a/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
@@ -64,13 +64,47 @@ RSpec.describe "Jobseekers can sign up to an account" do
       it "does not allow user to sign in and shows the relevant error message" do
         within(".govuk-header__navigation") { click_on I18n.t("buttons.sign_in") }
         click_on I18n.t("buttons.sign_in_jobseeker")
+
         sign_in_jobseeker
         expect(page).to have_content "You need to confirm your email address to sign in. You should have received a link by email."
         expect(page).to have_content "If the link has expired, you can resend the email"
+
         click_link "resend the email"
         expect(page).to have_content "Email has been resent"
+
         confirm_email_address
         expect(current_path).to eq(confirmation_jobseekers_account_path)
+      end
+
+      context "when the user session does not contain the jobseeker information" do
+        before do
+          logout
+        end
+
+        it "asks the jobseeker to introduce their email address to receive the confirmation link" do
+          within(".govuk-header__navigation") { click_on I18n.t("buttons.sign_in") }
+          click_on I18n.t("buttons.sign_in_jobseeker")
+
+          sign_in_jobseeker
+          expect(page).to have_content "You need to confirm your email address to sign in. You should have received a link by email."
+          expect(page).to have_content "If the link has expired, you can resend the email"
+
+          click_link "resend the email"
+          expect(page).to have_css("h1", text: "Resend confirmation")
+
+          click_on "Resend email"
+          expect(page).to have_css("h1", text: "Resend confirmation")
+          expect(page).to have_css("h2", text: "There is a problem")
+          expect(page).to have_content("Enter your email address")
+
+          fill_in "Email address", with: jobseeker.email
+          click_on "Resend email"
+          expect(page).to have_css("h1", text: "Check your email")
+          expect(page).to have_content "Email has been resent"
+
+          confirm_email_address
+          expect(current_path).to eq(confirmation_jobseekers_account_path)
+        end
       end
     end
 

--- a/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
+++ b/spec/system/jobseekers_can_sign_up_to_an_account_spec.rb
@@ -105,5 +105,14 @@ RSpec.describe "Jobseekers can sign up to an account" do
         expect(page).to have_content("Page not found")
       end
     end
+
+    context "without confirmation token with existing confirmed users" do
+      let!(:other_confirmed_jobseeker) { create(:jobseeker, confirmation_token: nil) }
+
+      it "takes the user to the 'not found' page" do
+        visit jobseeker_confirmation_path
+        expect(page).to have_content("Page not found")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/GvMOZhbA

## Changes in this PR:
Solving 2 bugs:
- **Fix confirmation URL without confirmation token**
  It was redirecting to "Already confirmed" page as it was finding the first user without any confirmation token, so finding the first unrelated confirmed user.

- **Fix resend confirmation when email is not available in the session**
  If the user tries to sign-in on an unconfirmed account while their session was previously clean from any user, Devise doesn't know where to send the reconfirmation email.

  Attempting to follow the reconfirmation process was causing the users to get a 404 page.

  We have resolved this by identifying this case and requesting the introduction of the email to send the reconfirmation.

  The email will only be sent if it belongs to a real unconfirmed user, but we won't let the users know if they have introduced right/wrong emails to avoid disclosing service emails information to third parties testing email addresses through this form.

## Screenshots of UI changes:
<img src="https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/11df16b1-a001-444c-8171-3d142237ce8c" width=60% height=60%>

### Before
<img src="https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/c7d7bb13-b9a8-4bd4-92c5-c652150f2c03" width=60% height=60%>

### After
<img src="https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/bbe073f6-5710-4ae3-9d76-529ea51f7c77" width=60% height=60%>

<img src="https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/f6b80380-c8db-4be3-b199-d416d2bbaa18" width=60% height=60%>

