### PR TITLE
Fix Docker image vulnerability on PostgreSQL client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
  # Alpine v3.18.
  # TODO: Regularly check in the alpine ruby "3.2.2-alpine3.18" images for its latest upgraded packages so we can remove
  # the hardcoded versions below when they have been updated in the alpine ruby image.
-ARG PROD_PACKAGES="imagemagick=7.1.1.13-r1 libxml2 libxslt libpq tzdata shared-mime-info libx11=1.8.7-r0"
+ARG PROD_PACKAGES="imagemagick=7.1.1.13-r1 libxml2 libxslt libpq tzdata shared-mime-info postgresql15=15.5-r0"
 
 FROM ruby:3.2.2-alpine3.18 AS builder
 


### PR DESCRIPTION
Postgres Client from Alpine Linux is vulnerable.
Hardcoding the patched version.
