### PR TITLE
Fix Job Application seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -82,7 +82,8 @@ JobApplication.statuses.count.times { |i| Jobseeker.create(email: "jobseeker#{i}
 Vacancy.listed.each do |vacancy|
   statuses = JobApplication.statuses.keys
   Jobseeker.where.not(email: "jobseeker@example.com").each do |jobseeker|
-    application_status = statuses.delete(statuses.sample)
+    # Ensures each one of the statuses gets used. When no unused statuses are left, takes random ones from the list for further new applications.
+    application_status = statuses.delete(statuses.sample) || JobApplication.statuses.keys.sample
     FactoryBot.create(:job_application, :"status_#{application_status}", jobseeker: jobseeker, vacancy: vacancy)
   end
 end


### PR DESCRIPTION
- Fixes sentry issue: https://teaching-vacancies.sentry.io/issues/3596332871

The code generating the job applications was creating, for each vacancy, an application for each one of the seeded Jobseekers. Each application has one of the possible different statuses.

The problem is that this only worked as long as there were more listed statuses than Jobseekers in the seeds. 
The moment we had more Jobseekers than statuses, the attempt to create an application for a new jobseeker after consuming all the possible application status values caused an exception when creating the factory.

We resolved it by reusing existing random status values once we have run over the whole values list and are still jobseekers left to create applications for.

