### PR TITLE
DO NOT MERGE: Create prototype for Supportal service data display

### DIFF
--- a/app/controllers/support_users/service_data/base_controller.rb
+++ b/app/controllers/support_users/service_data/base_controller.rb
@@ -1,0 +1,2 @@
+class SupportUsers::ServiceData::BaseController < SupportUsers::BaseController
+end

--- a/app/controllers/support_users/service_data/vacancies_controller.rb
+++ b/app/controllers/support_users/service_data/vacancies_controller.rb
@@ -1,0 +1,10 @@
+class SupportUsers::ServiceData::VacanciesController < SupportUsers::ServiceData::BaseController
+  def index
+    @vacancies = Vacancy.all.order(created_at: :desc)
+  end
+
+  def show
+    vacancy = Vacancy.friendly.find(params[:id])
+    @vacancy = VacancyPresenter.new(vacancy)
+  end
+end

--- a/app/views/support_users/dashboard/dashboard.html.slim
+++ b/app/views/support_users/dashboard/dashboard.html.slim
@@ -10,6 +10,14 @@ nav
 
 hr.govuk-section-break.govuk-section-break--l
 
+h2.govuk-heading-m = t("support_users.dashboard.service_data_heading")
+nav
+  ul.govuk-list
+    li
+      = govuk_link_to t("support_users.dashboard.service_data_link"), support_users_service_data_vacancies_path
+
+hr.govuk-section-break.govuk-section-break--l
+
 h2.govuk-heading-m = t("support_users.dashboard.development_tools_heading")
 nav
   ul.govuk-list

--- a/app/views/support_users/service_data/vacancies/index.html.slim
+++ b/app/views/support_users/service_data/vacancies/index.html.slim
@@ -1,0 +1,10 @@
+- content_for :page_title_prefix, "Service Vacancies"
+
+h1.govuk-heading-l = "Service Vacancies"
+= supportal_table(entries: @vacancies, classes: (["supportal-table-component--#{type}"] if local_assigns[:type])) do |t|
+  - t.column "Job Title" do |vacancy|
+    - capture do
+      = govuk_link_to(vacancy.job_title || vacancy.slug, support_users_service_data_vacancy_path(vacancy))
+  - t.tags "Status", :status
+  - t.tags("Source") { |v| v.external_source.presence || "Internal" }
+  - t.datetime "Created", :created_at

--- a/app/views/support_users/service_data/vacancies/show.html.slim
+++ b/app/views/support_users/service_data/vacancies/show.html.slim
@@ -1,0 +1,12 @@
+- title = @vacancy.job_title || @vacancy.slug
+- content_for :page_title_prefix, title
+
+h1.govuk-heading-l = title
+
+= render DetailComponent.new title: title do |detail|
+  - detail.with_body do
+    = govuk_summary_list do |summary_list|
+      - Vacancy.column_names.each do |column_name|
+        - summary_list.with_row do |row|
+          - row.with_key text: column_name.humanize
+          - row.with_value text: @vacancy.send(column_name)

--- a/config/locales/support_users.yml
+++ b/config/locales/support_users.yml
@@ -6,6 +6,8 @@ en:
       user_feedback_heading: User feedback
       user_feedback_link: View user feedback
       development_tools_heading: Developer tools
+      service_data_heading: Service data
+      service_data_link: View service data
       sidekiq_link: View Sidekiq dashboard
     feedbacks:
       general:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -207,6 +207,10 @@ Rails.application.routes.draw do
     get "feedback/satisfaction-ratings", to: "feedbacks#satisfaction_ratings"
 
     post "feedback/recategorize", to: "feedbacks#recategorize"
+
+    namespace :service_data, path: "service-data" do
+      resources :vacancies, only: %i[index show]
+    end
   end
 
   devise_for :support_users


### PR DESCRIPTION


## Trello card URL
- https://trello.com/c/7GBZOX6s
## Changes in this PR:
This prototype users "Vacancies" model as an example, adding a service data section in Supportal to list all the vacancies and display each individual vacancy raw data from DB.

This is a prototype, not meant to be merged into master.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
