### PR TITLE
Align test/devcontainer PG version with Production

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - selenium-chrome
 
   db:
-    image: postgis/postgis:12-3.1-alpine
+    image: postgis/postgis:14-3.4-alpine
     restart: unless-stopped
     volumes:
       - postgres_data:/var/lib/postgresql/data

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -77,7 +77,7 @@ jobs:
 
     services:
       postgres:
-        image: postgis/postgis:12-3.1-alpine
+        image: postgis/postgis:14-3.4-alpine
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
 
     services:
       postgres:
-        image: postgis/postgis:12-3.1-alpine
+        image: postgis/postgis:14-3.4-alpine
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
Our hosting PostgreSQL runs with v14. The CI/Devcontainer PG was running on v12.
