### PR TITLE
Exclude specific out of scope vacancies from my new term import

### DIFF
--- a/app/vacancy_sources/vacancy_source/source/my_new_term.rb
+++ b/app/vacancy_sources/vacancy_source/source/my_new_term.rb
@@ -8,6 +8,13 @@ class VacancySource::Source::MyNewTerm
   BASE_URI = ENV.fetch("VACANCY_SOURCE_MY_NEW_TERM_FEED_URL").freeze
   API_KEY = ENV.fetch("VACANCY_SOURCE_MY_NEW_TERM_API_KEY").freeze
   SOURCE_NAME = "my_new_term".freeze
+  EXTERNAL_REFERENCES_TO_EXCLUDE = %w[
+    10e5719e-6685-46e6-9393-e231ff905fd8
+    807ea98e-07c2-4e7d-a2a2-75ad471fba3d
+    098bb02b-86ef-4a19-a148-b959213a3e33
+    a94c389e-030d-4244-b42d-4ee804d2859c
+    5430a89c-c838-4bad-8732-7eb73e9d6533
+  ].freeze
 
   def self.source_name
     SOURCE_NAME
@@ -20,8 +27,7 @@ class VacancySource::Source::MyNewTerm
 
   def each
     results.each do |result|
-      external_references_to_exclude = %w[10e5719e-6685-46e6-9393-e231ff905fd8 807ea98e-07c2-4e7d-a2a2-75ad471fba3d 098bb02b-86ef-4a19-a148-b959213a3e33 a94c389e-030d-4244-b42d-4ee804d2859c 5430a89c-c838-4bad-8732-7eb73e9d6533]
-      next if external_references_to_exclude.include?(result["external_reference"])
+      next if EXTERNAL_REFERENCES_TO_EXCLUDE.include?(result["reference"])
 
       v = Vacancy.find_or_initialize_by(
         external_source: SOURCE_NAME,

--- a/app/vacancy_sources/vacancy_source/source/my_new_term.rb
+++ b/app/vacancy_sources/vacancy_source/source/my_new_term.rb
@@ -20,7 +20,7 @@ class VacancySource::Source::MyNewTerm
 
   def each
     results.each do |result|
-      external_references_to_exclude = ["10e5719e-6685-46e6-9393-e231ff905fd8", "807ea98e-07c2-4e7d-a2a2-75ad471fba3d", "098bb02b-86ef-4a19-a148-b959213a3e33", "a94c389e-030d-4244-b42d-4ee804d2859c", "5430a89c-c838-4bad-8732-7eb73e9d6533"]
+      external_references_to_exclude = %w[10e5719e-6685-46e6-9393-e231ff905fd8 807ea98e-07c2-4e7d-a2a2-75ad471fba3d 098bb02b-86ef-4a19-a148-b959213a3e33 a94c389e-030d-4244-b42d-4ee804d2859c 5430a89c-c838-4bad-8732-7eb73e9d6533]
       next if external_references_to_exclude.include?(result["external_reference"])
 
       v = Vacancy.find_or_initialize_by(

--- a/app/vacancy_sources/vacancy_source/source/my_new_term.rb
+++ b/app/vacancy_sources/vacancy_source/source/my_new_term.rb
@@ -20,6 +20,9 @@ class VacancySource::Source::MyNewTerm
 
   def each
     results.each do |result|
+      external_references_to_exclude = ["10e5719e-6685-46e6-9393-e231ff905fd8", "807ea98e-07c2-4e7d-a2a2-75ad471fba3d", "098bb02b-86ef-4a19-a148-b959213a3e33", "a94c389e-030d-4244-b42d-4ee804d2859c", "5430a89c-c838-4bad-8732-7eb73e9d6533"]
+      next if external_references_to_exclude.include?(result["external_reference"])
+
       v = Vacancy.find_or_initialize_by(
         external_source: SOURCE_NAME,
         external_reference: result["reference"],

--- a/lib/tasks/trash_specific_vacancies.rake
+++ b/lib/tasks/trash_specific_vacancies.rake
@@ -10,7 +10,7 @@ namespace :vacancies do
     ]
 
     Vacancy.where(external_reference: external_references_to_trash).each do |vacancy|
-      vacancy.update(status: "trashed")
+      vacancy.update!(status: "trashed")
     end
   end
 end

--- a/lib/tasks/trash_specific_vacancies.rake
+++ b/lib/tasks/trash_specific_vacancies.rake
@@ -1,0 +1,16 @@
+namespace :vacancies do
+  desc "Trash vacancies with specific external references"
+  task trash_specific: :environment do
+    external_references_to_trash = [
+      "10e5719e-6685-46e6-9393-e231ff905fd8",
+      "807ea98e-07c2-4e7d-a2a2-75ad471fba3d",
+      "098bb02b-86ef-4a19-a148-b959213a3e33",
+      "a94c389e-030d-4244-b42d-4ee804d2859c",
+      "5430a89c-c838-4bad-8732-7eb73e9d6533"
+    ]
+
+    Vacancy.where(external_reference: external_references_to_trash).each do |vacancy|
+      vacancy.update(status: "trashed")
+    end
+  end
+end

--- a/lib/tasks/trash_specific_vacancies.rake
+++ b/lib/tasks/trash_specific_vacancies.rake
@@ -1,12 +1,12 @@
 namespace :vacancies do
   desc "Trash vacancies with specific external references"
   task trash_specific: :environment do
-    external_references_to_trash = [
-      "10e5719e-6685-46e6-9393-e231ff905fd8",
-      "807ea98e-07c2-4e7d-a2a2-75ad471fba3d",
-      "098bb02b-86ef-4a19-a148-b959213a3e33",
-      "a94c389e-030d-4244-b42d-4ee804d2859c",
-      "5430a89c-c838-4bad-8732-7eb73e9d6533"
+    external_references_to_trash = %w[
+      10e5719e-6685-46e6-9393-e231ff905fd8
+      807ea98e-07c2-4e7d-a2a2-75ad471fba3d
+      098bb02b-86ef-4a19-a148-b959213a3e33
+      a94c389e-030d-4244-b42d-4ee804d2859c
+      5430a89c-c838-4bad-8732-7eb73e9d6533
     ]
 
     Vacancy.where(external_reference: external_references_to_trash).each do |vacancy|


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/hAhGYuZp/636-delete-independent-vacancies

## Changes in this PR:

My new term have sent us some vacancies which do not fit into our scope. This change adds a rake task to set them to status: "trashed" and excludes them from future imports so that this status does not change.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
