### PR TITLE
Change Food Technology to Food technology as per govuk style guide

### DIFF
--- a/config/data/subjects.yml
+++ b/config/data/subjects.yml
@@ -13,7 +13,7 @@
 - ['Economics', '']
 - ['Engineering', '']
 - ['English', 'includes English language and literature']
-- ['Food Technology', 'includes Hospitality and catering']
+- ['Food technology', 'includes Hospitality and catering']
 - ['French', '']
 - ['Geography', '']
 - ['German', '']

--- a/config/landing_pages.yml
+++ b/config/landing_pages.yml
@@ -100,7 +100,7 @@ shared:
       - Media studies
   food-technology-teacher-jobs:
     subjects:
-      - Food Technology
+      - Food technology
   french-teacher-jobs:
     subjects:
       - French

--- a/config/locales/landing_pages.yml
+++ b/config/locales/landing_pages.yml
@@ -161,8 +161,8 @@ en:
       heading: "%{count} English and media studies teacher jobs"
       meta_description: "Find English teacher jobs in London, Birmingham, Liverpool and across England. Apply for media studies teaching jobs and set up alerts for the latest roles."
     food-technology-teacher-jobs:
-      name: "Food Technology"
-      title: "Food Technology Teacher Jobs"
+      name: "Food technology"
+      title: "Food technology Teacher Jobs"
       heading: "%{count} food technology teacher jobs"
       meta_description: "Discover jobs for food technology teachers on Teaching Vacancies. Browse job descriptions and apply to get your next food technology teaching job."
     french-teacher-jobs:


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/TvMSBjdg/601-update-subject-list-to-correct-grammar

## Changes in this PR:

Change "Food Technology" to "Food technology" as per [govuk style guide](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#school-subjects). All other subjects currently confirm to the style guide already!

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
