### PR TITLE
Default text boxes on the about the role page to 400px height

### DIFF
--- a/app/assets/stylesheets/components/editor.scss
+++ b/app/assets/stylesheets/components/editor.scss
@@ -25,7 +25,7 @@
   &__content {
     @extend .govuk-textarea;
 
-    height: 130px;
+    height: 400px;
     margin-bottom: govuk-spacing(1);
     overflow: scroll;
 


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/Ka8bAnE9/603-change-text-box-size-on-listing-journey

## Changes in this PR:

This PR increases the height of the text areas on page 4 of the job listing journey.

Note: The editor component is only used on this page so changing the height in the editor css file only affects the text areas on this page.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
