### PR TITLE
Set automated accessibility tests on ci

### DIFF
--- a/.github/workflows/accessibility_tests.yml
+++ b/.github/workflows/accessibility_tests.yml
@@ -1,0 +1,27 @@
+name: Accessibility Tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * 0' # Run every Sunday at 3am 
+
+jobs:
+  pally:
+    name: Pa11y accessibility tests
+    env:
+      RAILS_ENV: test
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Prepare application environment
+        uses: ./.github/actions/prepare-app-env
+        with:
+          skip-ruby: true
+    
+      - run: npm install
+      - name: Run Pa11y accessibility tests against QA sitemap pages
+        run: |
+          npm install -g pa11y-ci
+          pa11y-ci --sitemap https://qa.teaching-vacancies.service.gov.uk/sitemap.xml

--- a/.github/workflows/accessibility_tests.yml
+++ b/.github/workflows/accessibility_tests.yml
@@ -25,3 +25,25 @@ jobs:
         run: |
           npm install -g pa11y-ci
           pa11y-ci --sitemap https://qa.teaching-vacancies.service.gov.uk/sitemap.xml
+  axe:
+    name: Axe accessibility tests
+    env:
+      RAILS_ENV: test
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Prepare application environment
+        uses: ./.github/actions/prepare-app-env
+        with:
+          skip-ruby: true
+
+      - run: npm install
+      - name: Run Axe accessibility tests against QA sitemap pages
+        run: |
+          npm install -g @axe-core/cli sitemap-urls
+          # Gets all urls from sitemap in an array
+          urls=($(curl https://qa.teaching-vacancies.service.gov.uk/sitemap.xml | sitemap-urls))
+          # Runs axe against each url from the sitemap
+          axe $(for url in "${urls[@]}"; do echo $url, ; done;) --exit

--- a/.github/workflows/accessibility_tests.yml
+++ b/.github/workflows/accessibility_tests.yml
@@ -47,3 +47,22 @@ jobs:
           urls=($(curl https://qa.teaching-vacancies.service.gov.uk/sitemap.xml | sitemap-urls))
           # Runs axe against each url from the sitemap
           axe $(for url in "${urls[@]}"; do echo $url, ; done;) --exit
+  lighthouse:
+    name: Lighthouse tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Prepare application environment
+        uses: ./.github/actions/prepare-app-env
+        with:
+          skip-ruby: true
+      - run: npm install
+      - name: run Lighthouse Performance, Accessibility, Best Practices, SEO, and PWA tests
+        run: |
+          npm install -g @lhci/cli
+          lhci autorun \
+            --collect.url=https://qa.teaching-vacancies.service.gov.uk \
+            --collect.url=https://qa.teaching-vacancies.service.gov.uk/jobs \
+            --collect.url=https://qa.teaching-vacancies.service.gov.uk/schools \


### PR DESCRIPTION
## Trello card URL
Part of https://trello.com/c/vWHZ9Yb7

## Changes in this PR:

It introduces a new Github Workflow that will run 3 accessibility test suites in parallel against our `QA` page:
- Axe
- Pa11y
- Chrome Lighthouse

Axe and Pa11y will find accessibility issues across all the pages contained in Teaching Vacancies QA sitemap.

Chrome Lighthouse, will run against a few landing pages on TV QA site, and, on top of the accessibility checks, will also include performance, SEO, PWA and best practices tests.

These checks won't run per PR and won't be a condition/blocker to merge new code into the main branch. 
Instead, they are meant to be informative about the current state of our site. They will run weekly and also can be manually triggered from the workflow page.

### Pa11y tests 
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/6a2f048f-164a-4f0f-ac7a-62971ad67529)
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/1e6034c9-4364-4838-b205-bba027e05696)

### Axe tests
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/a1934de1-498c-42fd-a099-8e261be6c4ad)

### Chrome lighthouse tests
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/ef9f9a60-7138-4ba5-a16a-4b302bb0de50)
