### PR TITLE
Change wording on visa sponsorship responses

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -483,8 +483,8 @@ en:
     international_teacher_advice:
         link: help you understand your next steps
         text_html: If you're interested in teaching or training to teach in England as an international citizen, we can %{link}.
-    sponsorship_available: Skilled worker visa sponsorship is available for this job.
-    sponsorship_unavailable: Skilled worker visa sponsorship is not available for this job.
+    sponsorship_available: Skilled Worker visas can be sponsored.
+    sponsorship_unavailable: Visas cannot be sponsored.
     listing:
       enable_job_applications_tag: "Quick Apply"
       schools:

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -222,8 +222,8 @@ en:
     expires_at: Closing date
     time_at: at
     visa_sponsorship_row_title: Visa sponsorship
-    visa_sponsorship_available: Yes, visa sponsorship available
-    visa_sponsorship_unavailable: No, visa sponsorship not available
+    visa_sponsorship_available: Skilled Worker visa can be sponsored
+    visa_sponsorship_unavailable: Visas cannot be sponsored
     supporting_documents: Supporting documents
     supporting_documents_accessibility: If you need these documents in an accessible format, please contact the school.
     no_files_message: No files selected

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -222,7 +222,7 @@ en:
     expires_at: Closing date
     time_at: at
     visa_sponsorship_row_title: Visa sponsorship
-    visa_sponsorship_available: Skilled Worker visa can be sponsored
+    visa_sponsorship_available: Skilled Worker visas can be sponsored
     visa_sponsorship_unavailable: Visas cannot be sponsored
     supporting_documents: Supporting documents
     supporting_documents_accessibility: If you need these documents in an accessible format, please contact the school.

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -227,7 +227,7 @@ module VacancyHelpers
     vacancy = VacancyPresenter.new(vacancy)
     expect(page).to have_content(vacancy.job_title)
     expect(page).to have_content(vacancy.readable_job_roles)
-    sponsorship_text = vacancy.visa_sponsorship_available ? "Yes, visa sponsorship available" : "No, visa sponsorship not available"
+    sponsorship_text = vacancy.visa_sponsorship_available ? "Skilled Worker visa can be sponsored" : "Visas cannot be sponsored"
     expect(page).to have_content(sponsorship_text)
     vacancy.subjects.each { |subject| expect(page).to have_content subject }
 

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -227,7 +227,7 @@ module VacancyHelpers
     vacancy = VacancyPresenter.new(vacancy)
     expect(page).to have_content(vacancy.job_title)
     expect(page).to have_content(vacancy.readable_job_roles)
-    sponsorship_text = vacancy.visa_sponsorship_available ? "Skilled Worker visa can be sponsored" : "Visas cannot be sponsored"
+    sponsorship_text = vacancy.visa_sponsorship_available ? "Skilled Worker visas can be sponsored" : "Visas cannot be sponsored"
     expect(page).to have_content(sponsorship_text)
     vacancy.subjects.each { |subject| expect(page).to have_content subject }
 
@@ -257,7 +257,7 @@ module VacancyHelpers
     expect(page).to have_content(I18n.t("publishers.vacancies.steps.documents")) if vacancy.supporting_documents.any?
 
     if vacancy.enable_job_applications?
-      sponsorship_inset_text = vacancy.visa_sponsorship_available ? "Skilled worker visa sponsorship is available for this job." : "Skilled worker visa sponsorship is not available for this job."
+      sponsorship_inset_text = vacancy.visa_sponsorship_available ? "Skilled Worker visas can be sponsored." : "Visas cannot be sponsored"
       expect(page).to have_content sponsorship_inset_text
       expect(page).to have_link(I18n.t("jobseekers.job_applications.apply"), href: new_jobseekers_job_job_application_path(vacancy.id))
     else


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/rMV3ff62/643-visa-sponsorship-search-results-page-wording

## Changes in this PR:

This PR changes some text around visa sponsorship availability.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
