### PR TITLE
Add return to teaching link to footer

### DIFF
--- a/app/views/layouts/_footer.html.slim
+++ b/app/views/layouts/_footer.html.slim
@@ -21,6 +21,8 @@
           li.govuk-footer__list-item
             = link_to t("footer.search_teaching_vacancies"), root_url, class: "govuk-footer__link"
           li.govuk-footer__list-item
+            = link_to t("footer.return_to_teaching"), "https://teaching-vacancies.campaign.gov.uk/return-to-teaching/", class: "govuk-footer__link"
+          li.govuk-footer__list-item
             = tracked_link_to(t("footer.international_teacher_advice_link_text"), "https://getintoteaching.education.gov.uk/non-uk-teachers", class: "govuk-footer__link", link_type: :international_teacher_advice_link_footer)
           li.govuk-footer__list-item
             - if jobseeker_signed_in?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,6 +82,7 @@ en:
     hiring_guides: Hiring guides
     search_teaching_vacancies: Find a job
     service_support: Get support
+    return_to_teaching: Return to teaching
 
   general_feedbacks:
     create:


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/4Y6b4SS9/616-add-link-in-footer-to-returners-guidance

## Changes in this PR:

Add "Return to teaching" link in footer.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
