### PR TITLE
Fix display of organisation description and safeguarding info

### DIFF
--- a/app/views/organisations/_organisation.html.slim
+++ b/app/views/organisations/_organisation.html.slim
@@ -72,12 +72,11 @@
                     alt: t("publishers.organisations.organisation.photo.alt_text", organisation_name: @organisation.name),
                     class: "contained-image govuk-!-margin-bottom-5")
       p.govuk-body
-        = organisation.description
+        = simple_format(organisation.description)
 
     - if organisation.safeguarding_information?
       h2.govuk-heading-m = t("organisations.show.summary.safeguarding_information")
-      p.govuk-body = organisation.safeguarding_information
-
+      p.govuk-body = simple_format(organisation.safeguarding_information)
 - if organisation.geopoint?
   .govuk-grid-row class="govuk-!-margin-bottom-7"
     .govuk-grid-column-two-thirds

--- a/app/views/publishers/vacancies/build/about_the_role.html.slim
+++ b/app/views/publishers/vacancies/build/about_the_role.html.slim
@@ -10,7 +10,7 @@
       - if vacancy.organisation&.description.present?
         p.govuk-body = t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.description", organisation: vacancy.organisation.school? ? "school" : "organisation")
         = govuk_details(summary_text: t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.description_summary_text", organisation: vacancy.organisation.school? ? "school" : "organisation")) do
-          = vacancy.organisation.description
+          = simple_format(vacancy.organisation.description)
       - else
         p.govuk-body = t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.no_description", organisation: vacancy.organisation.school? ? "school" : "organisation")
         p = govuk_link_to t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.no_description_link.#{vacancy.organisation.school? ? 'school' : 'organisation'}"), edit_publishers_organisation_description_path(vacancy.organisation, vacancy_id: vacancy.id)
@@ -19,7 +19,7 @@
         - if vacancy.organisation&.safeguarding_information.present?
           p.govuk-body = t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.safeguarding_information", organisation: vacancy.organisation.school? ? "school" : "organisation")
           = govuk_details(summary_text: t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.safeguarding_information_summary_text")) do
-            = vacancy.organisation&.safeguarding_information
+            = simple_format(vacancy.organisation&.safeguarding_information)
         - else
           p.govuk-body = t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.no_safeguarding_information", organisation: vacancy.organisation.school? ? "school" : "organisation")
           p = govuk_link_to t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.no_safeguarding_information_link"), edit_publishers_organisation_safeguarding_information_path(vacancy.organisation, vacancy_id: vacancy.id)

--- a/app/views/vacancies/listing/_job_details.html.slim
+++ b/app/views/vacancies/listing/_job_details.html.slim
@@ -76,7 +76,7 @@ section#job-details class="govuk-!-margin-bottom-5"
 
   - if vacancy.organisation&.safeguarding_information.present?
     h2.govuk-heading-m = t("jobs.safeguarding_information.jobseeker")
-    .govuk-body == vacancy.organisation.safeguarding_information
+    .govuk-body == simple_format(vacancy.organisation.safeguarding_information)
   - elsif vacancy.safeguarding_information_provided?
     h2.govuk-heading-m = t("jobs.safeguarding_information.jobseeker")
     .govuk-body == vacancy.safeguarding_information

--- a/app/views/vacancies/listing/_organisation_details.html.slim
+++ b/app/views/vacancies/listing/_organisation_details.html.slim
@@ -13,7 +13,7 @@ section#school-overview
     = render "vacancies/listing/school", organisation: vacancy.organisation, vacancy: vacancy, contact_details: true
 
   - if vacancy_or_organisation_description(vacancy).present?
-    p.govuk-body = vacancy_or_organisation_description(vacancy)
+    p.govuk-body = simple_format(vacancy_or_organisation_description(vacancy))
 
   - if vacancy.organisations.many?
     h4.govuk-heading-m = t(".schools.school_details")


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/Zt5f0tyE


## Changes in this PR:
It correctly formats the information entered on the organisation description and safeguarding information text boxes.

It breaks lines and respects spaces when displaying this info in the HTML pages.

## Screenshots of UI changes:

### Before

#### Publisher view
![Screenshot from 2023-12-11 17-29-19](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/627e54e2-756c-4d37-a3bd-52f57a84d94f)

#### Jobseeker view
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/e364e01d-6a13-4f48-a47e-4ef314787aa9)

### After

#### Publisher view
![Screenshot from 2023-12-11 17-30-19](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/8e03c56d-b560-474b-933a-a51ee0551b5f)

#### Jobseeker view
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/fc7fb048-b111-4f9c-b79f-b61542fafab5)
