### PR TITLE
[850] Update ACM policy

### DIFF
--- a/terraform/common/iam.tf
+++ b/terraform/common/iam.tf
@@ -83,7 +83,8 @@ data "aws_iam_policy_document" "deployments_role_policy" {
     actions = [
       "acm:DescribeCertificate",
       "acm:ListCertificates",
-      "acm:ListTagsForCertificate"
+      "acm:ListTagsForCertificate",
+      "acm:GetCertificate"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
The AWS provider update caused this issue:
```
│ Error: reading ACM Certificate (arn:aws:acm:us-east-1:***:certificate/e39aab35-6d1c-4c9a-a499-15811ed3a482): operation error ACM: GetCertificate, https response error StatusCode: 400, RequestID: 9686ea16-bb48-4948-9df3-a3c37e599229, api error AccessDeniedException: User: arn:aws:sts::***:assumed-role/Deployments/GitHubActions is not authorized to perform: acm:GetCertificate on resource: arn:aws:acm:us-east-1:***:certificate/e39aab35-6d1c-4c9a-a499-15811ed3a482 because no identity-based policy allows the acm:GetCertificate action
```

## Trello card URL
https://trello.com/c/K0jRnB8S

## Changes in this PR:
Add acm:GetCertificate to the IAM policy
Successful run: https://github.com/DFE-Digital/teaching-vacancies/actions/runs/7197631659
