### PR TITLE
Add Google Recaptcha Scores to Sentry issues

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -36,8 +36,9 @@ class ErrorsController < ApplicationController
 
   def invalid_recaptcha
     @form = params[:form_name]
+    @recaptcha_score = params[:recaptcha_score]
     Sentry.with_scope do |scope|
-      scope.set_tags("form.name": @form)
+      scope.set_tags("form.name": @form, "recaptcha.score": @recaptcha_score)
       Sentry.capture_message("Invalid recaptcha", level: :warning)
     end
 

--- a/app/controllers/general_feedbacks_controller.rb
+++ b/app/controllers/general_feedbacks_controller.rb
@@ -11,7 +11,8 @@ class GeneralFeedbacksController < ApplicationController
     if @general_feedback_form.invalid?
       render :new
     elsif recaptcha_is_invalid?
-      redirect_to invalid_recaptcha_path(form_name: @general_feedback_form.class.name.underscore.humanize)
+      redirect_to invalid_recaptcha_path(form_name: @general_feedback_form.class.name.underscore.humanize,
+                                         recaptcha_score: recaptcha_reply["score"])
     else
       @feedback.recaptcha_score = recaptcha_reply["score"]
       @feedback.save

--- a/app/controllers/jobseekers/subscriptions/feedbacks/further_feedbacks_controller.rb
+++ b/app/controllers/jobseekers/subscriptions/feedbacks/further_feedbacks_controller.rb
@@ -9,7 +9,8 @@ class Jobseekers::Subscriptions::Feedbacks::FurtherFeedbacksController < Applica
     if @feedback_form.invalid?
       render :new
     elsif recaptcha_is_invalid?
-      redirect_to invalid_recaptcha_path(form_name: @feedback_form.class.name.gsub("::", "").underscore.humanize)
+      redirect_to invalid_recaptcha_path(form_name: @feedback_form.class.name.gsub("::", "").underscore.humanize,
+                                         recaptcha_score: recaptcha_reply["score"])
     else
       update_feedback
       redirect_to root_path, success: t(".success")

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -20,7 +20,8 @@ class SubscriptionsController < ApplicationController
     if @form.invalid?
       render :new
     elsif recaptcha_is_invalid?
-      redirect_to invalid_recaptcha_path(form_name: subscription.class.name.underscore.humanize)
+      redirect_to invalid_recaptcha_path(form_name: subscription.class.name.underscore.humanize,
+                                         recaptcha_score: recaptcha_reply["score"])
     else
       notify_new_subscription(subscription)
 

--- a/app/controllers/support_requests_controller.rb
+++ b/app/controllers/support_requests_controller.rb
@@ -9,7 +9,8 @@ class SupportRequestsController < ApplicationController
     if @form.invalid?
       render :new
     elsif recaptcha_is_invalid?
-      redirect_to invalid_recaptcha_path(form_name: @form.class.name.underscore.humanize)
+      redirect_to invalid_recaptcha_path(form_name: @form.class.name.underscore.humanize,
+                                         recaptcha_score: recaptcha_reply["score"])
     else
       Zendesk.create_request!(
         attachments: [@form.screenshot],

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe SubscriptionsController, recaptcha: true do
         context "and subscription form is valid" do
           it "redirects to invalid_recaptcha_path" do
             subject
-            expect(response).to redirect_to(invalid_recaptcha_path(form_name: "Subscription"))
+            expect(response).to redirect_to(invalid_recaptcha_path(form_name: "Subscription", recaptcha_score: 0.9))
           end
 
           it "does not save the Subscription record" do

--- a/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Jobseekers can create a job alert from a search", recaptcha: tru
         visit new_subscription_path(search_criteria: { keyword: "test", location: "London" })
         fill_in_subscription_fields
         click_on I18n.t("buttons.subscribe")
-        expect(page).to have_current_path(invalid_recaptcha_path(form_name: "Subscription"))
+        expect(page).to have_current_path(invalid_recaptcha_path(form_name: "Subscription", recaptcha_score: 0.9))
       end
     end
   end

--- a/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_the_dashboard_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_the_dashboard_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Jobseekers can create a job alert from the dashboard", recaptcha
           click_on I18n.t("jobseekers.subscriptions.index.link_create")
         end
         create_a_job_alert
-        expect(page).to have_current_path(invalid_recaptcha_path(form_name: "Subscription"))
+        expect(page).to have_current_path(invalid_recaptcha_path(form_name: "Subscription", recaptcha_score: 0.9))
       end
     end
   end

--- a/spec/system/jobseekers/jobseekers_can_give_job_alert_feedback_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_give_job_alert_feedback_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe "A jobseeker can give feedback on a job alert", recaptcha: true d
 
         context "and the form is valid" do
           scenario "redirects to invalid_recaptcha path" do
-            expect(page).to have_current_path(invalid_recaptcha_path(form_name: "Jobseekers job alert further feedback form"))
+            expect(page).to have_current_path(invalid_recaptcha_path(form_name: "Jobseekers job alert further feedback form", recaptcha_score: 0.9))
           end
         end
 

--- a/spec/system/other/general_feedback_spec.rb
+++ b/spec/system/other/general_feedback_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Giving general feedback for the service", recaptcha: true do
 
       fill_in_general_feedback
       click_on I18n.t("buttons.submit_feedback")
-      expect(page).to have_current_path(invalid_recaptcha_path(form_name: "General feedback form"))
+      expect(page).to have_current_path(invalid_recaptcha_path(form_name: "General feedback form", recaptcha_score: 0.9))
     end
   end
 

--- a/spec/system/other/get_help_spec.rb
+++ b/spec/system/other/get_help_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "Requesting support", recaptcha: true, vcr: true, zendesk: true d
 
         click_on "Send message"
 
-        expect(page).to have_current_path(invalid_recaptcha_path(form_name: "Support request form"))
+        expect(page).to have_current_path(invalid_recaptcha_path(form_name: "Support request form", recaptcha_score: 0.9))
       end
     end
 


### PR DESCRIPTION
When we log a Google v3 Recaptcha error, we do not include the request score.

Recording this will give us more context on Recaptcha failure rates.
