### PR TITLE
Temporally lower recaptcha minimum score

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   include Pagy::Backend
   include DfE::Analytics::Requests
 
-  SUSPICIOUS_RECAPTCHA_THRESHOLD = 0.5
+  SUSPICIOUS_RECAPTCHA_THRESHOLD = 0.1 # Default 0.5.Temporally set to 0.1 due to very high false positive rate on the last day.
   VALID_CLICK_EVENT_TYPES = %w[vacancy_save_to_account_clicked].freeze
 
   add_flash_types :success, :warning


### PR DESCRIPTION
Set it to a minimum 0.1 as seems all the users have been consistently getting 0.1 and 0.3 scores over the las 24h and it is blocking legitimate traffic.
