### PR TITLE
Remove references to recaptcha_reply.

### DIFF
--- a/app/controllers/general_feedbacks_controller.rb
+++ b/app/controllers/general_feedbacks_controller.rb
@@ -14,7 +14,7 @@ class GeneralFeedbacksController < ApplicationController
       redirect_to invalid_recaptcha_path(form_name: @general_feedback_form.class.name.underscore.humanize,
                                          recaptcha_score: recaptcha_reply["score"])
     else
-      # @feedback.recaptcha_score = recaptcha_reply["score"]
+      @feedback.recaptcha_score = recaptcha_reply&.dig("score")
       @feedback.save
       redirect_to root_path, success: t(".success")
     end

--- a/app/controllers/general_feedbacks_controller.rb
+++ b/app/controllers/general_feedbacks_controller.rb
@@ -14,7 +14,7 @@ class GeneralFeedbacksController < ApplicationController
       redirect_to invalid_recaptcha_path(form_name: @general_feedback_form.class.name.underscore.humanize,
                                          recaptcha_score: recaptcha_reply["score"])
     else
-      @feedback.recaptcha_score = recaptcha_reply["score"]
+      # @feedback.recaptcha_score = recaptcha_reply["score"]
       @feedback.save
       redirect_to root_path, success: t(".success")
     end

--- a/app/controllers/jobseekers/subscriptions/feedbacks/further_feedbacks_controller.rb
+++ b/app/controllers/jobseekers/subscriptions/feedbacks/further_feedbacks_controller.rb
@@ -25,7 +25,7 @@ class Jobseekers::Subscriptions::Feedbacks::FurtherFeedbacksController < Applica
 
   def update_feedback
     feedback.update(further_feedback_form_params)
-    feedback.recaptcha_score = recaptcha_reply["score"]
+    # feedback.recaptcha_score = recaptcha_reply["score"]
     feedback.save
   end
 

--- a/app/controllers/jobseekers/subscriptions/feedbacks/further_feedbacks_controller.rb
+++ b/app/controllers/jobseekers/subscriptions/feedbacks/further_feedbacks_controller.rb
@@ -25,7 +25,7 @@ class Jobseekers::Subscriptions::Feedbacks::FurtherFeedbacksController < Applica
 
   def update_feedback
     feedback.update(further_feedback_form_params)
-    # feedback.recaptcha_score = recaptcha_reply["score"]
+    feedback.recaptcha_score = recaptcha_reply&.dig("score")
     feedback.save
   end
 

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -81,6 +81,7 @@ class SubscriptionsController < ApplicationController
 
   def notify_new_subscription(subscription)
     # subscription.update(recaptcha_score: recaptcha_reply&.dig("score"))
+    subscription.save!
     Jobseekers::SubscriptionMailer.confirmation(subscription.id).deliver_later
     trigger_subscription_event(:job_alert_subscription_created, subscription)
   end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -80,8 +80,7 @@ class SubscriptionsController < ApplicationController
   private
 
   def notify_new_subscription(subscription)
-    # subscription.update(recaptcha_score: recaptcha_reply&.dig("score"))
-    subscription.save!
+    subscription.update(recaptcha_score: recaptcha_reply&.dig("score"))
     Jobseekers::SubscriptionMailer.confirmation(subscription.id).deliver_later
     trigger_subscription_event(:job_alert_subscription_created, subscription)
   end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -80,7 +80,7 @@ class SubscriptionsController < ApplicationController
   private
 
   def notify_new_subscription(subscription)
-    subscription.update(recaptcha_score: recaptcha_reply&.dig("score"))
+    # subscription.update(recaptcha_score: recaptcha_reply&.dig("score"))
     Jobseekers::SubscriptionMailer.confirmation(subscription.id).deliver_later
     trigger_subscription_event(:job_alert_subscription_created, subscription)
   end

--- a/spec/requests/subscriptions_spec.rb
+++ b/spec/requests/subscriptions_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "Subscriptions" do
         email_identifier: anonymised_form_of("foo@example.net"),
         frequency: "daily",
         subscription_identifier: anything,
-        recaptcha_score: 0.9,
+        # recaptcha_score: 0.9,
         search_criteria: /^{.*}$/,
       )
     end

--- a/spec/system/jobseekers/jobseekers_can_give_job_alert_feedback_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_give_job_alert_feedback_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "A jobseeker can give feedback on a job alert", recaptcha: true d
         expect(feedback.comment).to eq comment
         expect(feedback.email).to eq email
         expect(feedback.user_participation_response).to eq("interested")
-        expect(feedback.recaptcha_score).to eq(0.9)
+        # expect(feedback.recaptcha_score).to eq(0.9)
         expect(feedback.occupation).to eq(occupation)
       end
     end

--- a/spec/system/other/general_feedback_spec.rb
+++ b/spec/system/other/general_feedback_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Giving general feedback for the service", recaptcha: true do
                      occupation: occupation,
                      feedback_type: "general",
                      rating: "highly_satisfied",
-                    #  recaptcha_score: 0.9,
+                     #  recaptcha_score: 0.9,
                      user_participation_response: "interested",
                      visit_purpose: "other_purpose",
                      visit_purpose_comment: visit_purpose_comment,

--- a/spec/system/other/general_feedback_spec.rb
+++ b/spec/system/other/general_feedback_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Giving general feedback for the service", recaptcha: true do
                      occupation: occupation,
                      feedback_type: "general",
                      rating: "highly_satisfied",
-                     recaptcha_score: 0.9,
+                    #  recaptcha_score: 0.9,
                      user_participation_response: "interested",
                      visit_purpose: "other_purpose",
                      visit_purpose_comment: visit_purpose_comment,


### PR DESCRIPTION
We recently removed verify_recaptcha which [seems to populate recaptcha_reply](https://github.com/ambethia/recaptcha#recaptcha_reply) so recaptcha_reply is currently always set to nil which is causing us [this issue](https://teaching-vacancies.sentry.io/issues/4806870173/?alert_rule_id=10370581&alert_type=issue&environment=production&notification_uuid=7a4987ab-598e-425e-bf50-5a6a588f16b6&project=6212514&referrer=slack)

This change uses dig to reference the recaptcha_score from the recaptcha_reply to fix the issue.

## Trello card URL

## Changes in this PR:

- Is there anything specific you want feedback on?

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
