### PR TITLE
Reason for leaving profile

### DIFF
--- a/app/controllers/jobseekers/profiles/employments_controller.rb
+++ b/app/controllers/jobseekers/profiles/employments_controller.rb
@@ -56,7 +56,7 @@ class Jobseekers::Profiles::EmploymentsController < Jobseekers::ProfilesControll
 
   def employment_form_params
     params.require(:jobseekers_profile_employment_form)
-          .permit(:organisation, :job_title, :started_on, :current_role, :ended_on, :main_duties, :subjects)
+          .permit(:organisation, :job_title, :started_on, :current_role, :ended_on, :main_duties, :subjects, :reason_for_leaving)
           .merge("started_on(3i)" => "1", "ended_on(3i)" => "1")
   end
 end

--- a/app/form_models/jobseekers/profile/employment_form.rb
+++ b/app/form_models/jobseekers/profile/employment_form.rb
@@ -3,13 +3,13 @@ class Jobseekers::Profile::EmploymentForm < BaseForm
   include DateAttributeAssignment
 
   def self.fields
-    %i[organisation job_title main_duties current_role jobseeker_profile_id subjects]
+    %i[organisation job_title main_duties current_role jobseeker_profile_id subjects reason_for_leaving]
   end
   attr_accessor(*fields)
 
   attr_reader :started_on, :ended_on
 
-  validates :organisation, :job_title, :main_duties, presence: true
+  validates :organisation, :job_title, :main_duties, :reason_for_leaving, presence: true
   validates :started_on, date: { before: :today }
   validates :current_role, inclusion: { in: %w[yes no] }
   validates :ended_on, date: { before: :today, after: :started_on }, if: -> { current_role == "no" }

--- a/app/views/jobseekers/employments/_employments.html.slim
+++ b/app/views/jobseekers/employments/_employments.html.slim
@@ -21,5 +21,8 @@
         - summary_list.with_row(classes: "govuk-summary-list__row--no-actions") do |row|
           - row.with_key text: t("jobseekers.employments.main_duties")
           - row.with_value text: employment.main_duties
+        - summary_list.with_row(classes: "govuk-summary-list__row--no-actions") do |row|
+          - row.with_key text: t("jobseekers.employments.reason_for_leaving")
+          - row.with_value text: employment.reason_for_leaving
     - detail_component.with_action govuk_link_to(t("buttons.change_hidden_text_html", hidden_text: employment.job_title), edit_jobseekers_profile_work_history_path(employment))
     - detail_component.with_action govuk_link_to(t("buttons.delete_hidden_text_html", hidden_text: employment.job_title), jobseekers_profile_work_history_path(employment), method: :delete)

--- a/app/views/jobseekers/profiles/employments/_fields.html.slim
+++ b/app/views/jobseekers/profiles/employments/_fields.html.slim
@@ -19,4 +19,6 @@
 
 = f.govuk_text_area :main_duties, label: { size: "m" }
 
+= f.govuk_text_area :reason_for_leaving, label: { size: "m" }
+
 = f.govuk_submit t("buttons.save_and_continue")

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -33,6 +33,7 @@ shared:
     - created_at
     - updated_at
     - jobseeker_profile_id
+    - reason_for_leaving
   equal_opportunities_reports:
     - id
     - vacancy_id

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -680,6 +680,8 @@ en:
               before: The date the role started must be in the past
               blank: Enter the date you started at this school or organisation
               invalid: Enter a date in the correct format
+            reason_for_leaving:
+              blank: Enter your reason for leaving the role
 
         publishers/job_application/notes_form:
           attributes:

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -188,7 +188,7 @@ en:
         last_name: Or family name
         phone_number: Enter a phone number you are happy to be contacted on. For example, 01632 960 001, 07700 900 982 or +44 0808 157 0192.
       jobseekers_profile_employment_form:
-        main_duties: Give a brief summary of your key responsibilities
+        main_duties: Give a brief summary of your key responsibilities.
         organisation_name: If you worked for yourself, enter ‘self-employed’
         started_on: For example, %{date}
         reason_for_leaving: If you're still in the role, give a brief summary of your reasons for wanting to leave.

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -188,10 +188,10 @@ en:
         last_name: Or family name
         phone_number: Enter a phone number you are happy to be contacted on. For example, 01632 960 001, 07700 900 982 or +44 0808 157 0192.
       jobseekers_profile_employment_form:
-        main_duties: List all the responsibilities this role involved
+        main_duties: Give a brief summary of your key responsibilities
         organisation_name: If you worked for yourself, enter ‘self-employed’
         started_on: For example, %{date}
-        reason_for_leaving: Please specify why you have decided to leave this role.
+        reason_for_leaving: If you're still in the role, give a brief summary of your reasons for wanting to leave.
 
       jobseekers_qualifications_degree_form:
         institution: For example, a university or college

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -191,6 +191,7 @@ en:
         main_duties: List all the responsibilities this role involved
         organisation_name: If you worked for yourself, enter ‘self-employed’
         started_on: For example, %{date}
+        reason_for_leaving: Please specify why you have decided to leave this role.
 
       jobseekers_qualifications_degree_form:
         institution: For example, a university or college
@@ -564,6 +565,7 @@ en:
           "yes": "Yes"
         job_title: Role
         main_duties: Main duties
+        reason_for_leaving: Reason for leaving role
         organisation: Name of school or employer
         subjects: Subjects and key stages taught (optional)
       jobseekers_sign_in_form:

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -54,6 +54,7 @@ en:
       organisation: School or employer
       started_on: Start date
       subjects: Subjects and key stages taught (optional)
+      reason_for_leaving: Reason for leaving
     forced_login:
       create_account: create an account
       job_application_html: You need to login or %{account_creation_link} with Teaching Vacancies to apply for this job.
@@ -220,6 +221,7 @@ en:
         ended_on: End date
         job_title: Job title
         main_duties: Main duties
+        reason_for_leaving: Reason for leaving role
         new:
           caption: Current role and employment history
           heading: Add a role

--- a/db/migrate/20240105161119_add_reason_for_leaving_to_employments.rb
+++ b/db/migrate/20240105161119_add_reason_for_leaving_to_employments.rb
@@ -1,0 +1,5 @@
+class AddReasonForLeavingToEmployments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :employments, :reason_for_leaving, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_09_165757) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_05_161119) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -81,6 +81,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_09_165757) do
     t.text "job_title_ciphertext"
     t.text "main_duties_ciphertext"
     t.uuid "jobseeker_profile_id"
+    t.text "reason_for_leaving"
     t.index ["job_application_id"], name: "index_employments_on_job_application_id"
     t.index ["jobseeker_profile_id"], name: "index_employments_on_jobseeker_profile_id"
   end

--- a/spec/requests/jobseekers/profiles/employments_spec.rb
+++ b/spec/requests/jobseekers/profiles/employments_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "Jobseeker profile employments" do
   let(:ended_on_year) { "2002" }
   let(:main_duties) { "Scoring goals" }
   let(:days) { { "started_on(3i)": "1", "ended_on(3i)": "1" } }
+  let(:reason_for_leaving) { "relocating" }
   let(:params) do
     {
       jobseekers_profile_employment_form: {
@@ -23,6 +24,7 @@ RSpec.describe "Jobseeker profile employments" do
         "ended_on(2i)": ended_on_month,
         "ended_on(1i)": ended_on_year,
         main_duties: main_duties,
+        reason_for_leaving: reason_for_leaving
       }.merge(days),
     }
   end

--- a/spec/requests/jobseekers/profiles/employments_spec.rb
+++ b/spec/requests/jobseekers/profiles/employments_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Jobseeker profile employments" do
         "ended_on(2i)": ended_on_month,
         "ended_on(1i)": ended_on_year,
         main_duties: main_duties,
-        reason_for_leaving: reason_for_leaving
+        reason_for_leaving: reason_for_leaving,
       }.merge(days),
     }
   end

--- a/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
@@ -234,6 +234,7 @@ RSpec.describe "Jobseekers can manage their profile" do
       let!(:employment) { create(:employment, :jobseeker_profile_employment, jobseeker_profile: profile) }
       let(:new_employer) { "NASA" }
       let(:new_job_role) { "Chief ET locator" }
+      let(:new_reason_for_leaving) { "Relocating" }
 
       it "successfully changes the employment record" do
         visit jobseekers_profile_path
@@ -244,6 +245,7 @@ RSpec.describe "Jobseekers can manage their profile" do
 
         fill_in I18n.t("helpers.label.jobseekers_profile_employment_form.organisation"), with: new_employer
         fill_in I18n.t("helpers.label.jobseekers_profile_employment_form.job_title"), with: new_job_role
+        fill_in I18n.t("helpers.label.jobseekers_profile_employment_form.reason_for_leaving"), with: new_reason_for_leaving
 
         click_on I18n.t("buttons.save_and_continue")
 

--- a/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
@@ -187,6 +187,22 @@ RSpec.describe "Jobseekers can manage their profile" do
 
       before { visit jobseekers_profile_path }
 
+      it "raises errors for missing fields" do
+        click_link("Add roles")
+        click_on I18n.t("buttons.save_and_continue")
+
+        expect(page).to have_css('ul.govuk-list.govuk-error-summary__list')
+
+        within 'ul.govuk-list.govuk-error-summary__list' do
+          expect(page).to have_link('Enter a school or other organisation', href: '#jobseekers-profile-employment-form-organisation-field-error')
+          expect(page).to have_link('Enter your job title', href: '#jobseekers-profile-employment-form-job-title-field-error')
+          expect(page).to have_link('Tell us briefly what your main duties were', href: '#jobseekers-profile-employment-form-main-duties-field-error')
+          expect(page).to have_link('Enter your reason for leaving the role', href: '#jobseekers-profile-employment-form-reason-for-leaving-field-error')
+          expect(page).to have_link('Enter a date in the correct format', href: '#jobseekers-profile-employment-form-started-on-field-error')
+          expect(page).to have_link('Select yes if this is your current role', href: '#jobseekers-profile-employment-form-current-role-field-error')
+        end
+      end
+
       it "associates an 'employment' with their jobseeker profile" do
         expect { add_jobseeker_profile_employment }.to change { profile.employments.count }.by(1)
       end
@@ -207,6 +223,7 @@ RSpec.describe "Jobseekers can manage their profile" do
             expect(page).to have_content(employment.started_on.to_formatted_s(:month_year))
             expect(page).to have_content(employment.ended_on.to_formatted_s(:month_year)) unless employment.current_role == "yes"
             expect(page).to have_content(employment.main_duties)
+            expect(page).to have_content(employment.reason_for_leaving)
           end
         end
       end
@@ -759,6 +776,7 @@ RSpec.describe "Jobseekers can manage their profile" do
     fill_in "jobseekers_profile_employment_form[started_on(2i)]", with: "09"
     choose "Yes", name: "jobseekers_profile_employment_form[current_role]"
     fill_in I18n.t("helpers.label.jobseekers_profile_employment_form.main_duties"), with: "Goals and that"
+    fill_in I18n.t("helpers.label.jobseekers_profile_employment_form.reason_for_leaving"), with: "I hate it there"
 
     click_on I18n.t("buttons.save_and_continue")
   end

--- a/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
@@ -191,15 +191,15 @@ RSpec.describe "Jobseekers can manage their profile" do
         click_link("Add roles")
         click_on I18n.t("buttons.save_and_continue")
 
-        expect(page).to have_css('ul.govuk-list.govuk-error-summary__list')
+        expect(page).to have_css("ul.govuk-list.govuk-error-summary__list")
 
-        within 'ul.govuk-list.govuk-error-summary__list' do
-          expect(page).to have_link('Enter a school or other organisation', href: '#jobseekers-profile-employment-form-organisation-field-error')
-          expect(page).to have_link('Enter your job title', href: '#jobseekers-profile-employment-form-job-title-field-error')
-          expect(page).to have_link('Tell us briefly what your main duties were', href: '#jobseekers-profile-employment-form-main-duties-field-error')
-          expect(page).to have_link('Enter your reason for leaving the role', href: '#jobseekers-profile-employment-form-reason-for-leaving-field-error')
-          expect(page).to have_link('Enter a date in the correct format', href: '#jobseekers-profile-employment-form-started-on-field-error')
-          expect(page).to have_link('Select yes if this is your current role', href: '#jobseekers-profile-employment-form-current-role-field-error')
+        within "ul.govuk-list.govuk-error-summary__list" do
+          expect(page).to have_link("Enter a school or other organisation", href: "#jobseekers-profile-employment-form-organisation-field-error")
+          expect(page).to have_link("Enter your job title", href: "#jobseekers-profile-employment-form-job-title-field-error")
+          expect(page).to have_link("Tell us briefly what your main duties were", href: "#jobseekers-profile-employment-form-main-duties-field-error")
+          expect(page).to have_link("Enter your reason for leaving the role", href: "#jobseekers-profile-employment-form-reason-for-leaving-field-error")
+          expect(page).to have_link("Enter a date in the correct format", href: "#jobseekers-profile-employment-form-started-on-field-error")
+          expect(page).to have_link("Select yes if this is your current role", href: "#jobseekers-profile-employment-form-current-role-field-error")
         end
       end
 


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/f4IAMbFS/703-kcsie-add-reason-for-leaving-profile

## Changes in this PR:

This PR adds an additional field to the employment history section of jobseeker profiles which records the reason for jobseekers leaving, or wanting to leave, their last job.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
