### PR TITLE
Reword Job Application work history description

### DIFF
--- a/app/views/jobseekers/job_applications/build/employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/build/employment_history.html.slim
@@ -8,8 +8,11 @@
       = render "caption"
     h2.govuk-heading-l = t(".heading")
 
-    p.govuk-body = t(".description1")
-    p.govuk-body = t(".description2")
+    p.govuk-body = t(".description.opening")
+    ul.govuk-list.govuk-list--bullet
+      - t(".description.jobs_bullets").each do |job_bullet|
+        li = job_bullet
+    p.govuk-body = t(".description.closing")
 
     - if employments.any?
       - employments.reverse_each do |employment|

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -102,13 +102,15 @@ en:
           title: Declarations — Application
         employment_history:
           break: Break in work history
-          description1: >-
-            Add details of all jobs you have had since you left full time education. This should include all teaching
-            roles, as well as any other jobs you have had. You can also include voluntary work if it is relevant to your
-            application.
-          description2: >-
-            Schools need a complete picture of your work history, including time out of the workplace, in order to
-            safeguard children.
+          description:
+            opening: >-
+              Add details of all jobs you have had since you left full-time education. This should include:
+            jobs_bullets:
+              - all teaching roles
+              - any other jobs you've had
+              - voluntary work, if it's relevant to your application
+            closing: >-
+              You will need to explain any gaps in your work history and the reason you left each role.
           gap_with_duration: You have a break in your work history (%{duration})
           heading: Work history
           no_employments: No employment specified


### PR DESCRIPTION
Changes the text displayed when a jobseeker applies for a job and lands in the step requesting them to provide their work history.

## Trello card URL
- https://trello.com/c/cIPLqiNH

## Changes in this PR:

- Is there anything specific you want feedback on?

## Screenshots of UI changes:

### Before

### After
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/fb9d8c19-db9f-41ea-8695-103d56ccbb6c)
