### PR TITLE
Add jobseeker profiles service data to support dashboard

### DIFF
--- a/app/controllers/support_users/service_data/base_controller.rb
+++ b/app/controllers/support_users/service_data/base_controller.rb
@@ -1,0 +1,2 @@
+class SupportUsers::ServiceData::BaseController < SupportUsers::BaseController
+end

--- a/app/controllers/support_users/service_data/jobseeker_profiles_controller.rb
+++ b/app/controllers/support_users/service_data/jobseeker_profiles_controller.rb
@@ -1,0 +1,9 @@
+class SupportUsers::ServiceData::JobseekerProfilesController < SupportUsers::ServiceData::BaseController
+  def index
+    @jobseeker_profiles = JobseekerProfile.all.order(created_at: :desc)
+  end
+
+  def show
+    @jobseeker_profile = JobseekerProfile.find(params[:id])
+  end
+end

--- a/app/controllers/support_users/service_data/jobseeker_profiles_controller.rb
+++ b/app/controllers/support_users/service_data/jobseeker_profiles_controller.rb
@@ -1,6 +1,7 @@
 class SupportUsers::ServiceData::JobseekerProfilesController < SupportUsers::ServiceData::BaseController
   def index
-    @jobseeker_profiles = JobseekerProfile.all.order(created_at: :desc)
+    jobseeker_profiles = JobseekerProfile.includes(:personal_details, :jobseeker).all.order(created_at: :desc)
+    @pagy, @jobseeker_profiles = pagy(jobseeker_profiles)
   end
 
   def show

--- a/app/controllers/support_users/service_data/jobseeker_profiles_controller.rb
+++ b/app/controllers/support_users/service_data/jobseeker_profiles_controller.rb
@@ -6,5 +6,6 @@ class SupportUsers::ServiceData::JobseekerProfilesController < SupportUsers::Ser
 
   def show
     @jobseeker_profile = JobseekerProfile.find(params[:id])
+    Rails.logger.info("[Service Data] #{current_user.email} accessed Profile ID #{@jobseeker_profile.id} at #{Time.current}")
   end
 end

--- a/app/controllers/support_users/service_data_controller.rb
+++ b/app/controllers/support_users/service_data_controller.rb
@@ -1,0 +1,3 @@
+class SupportUsers::ServiceDataController < SupportUsers::BaseController
+  def index; end
+end

--- a/app/views/support_users/dashboard/dashboard.html.slim
+++ b/app/views/support_users/dashboard/dashboard.html.slim
@@ -10,6 +10,14 @@ nav
 
 hr.govuk-section-break.govuk-section-break--l
 
+h2.govuk-heading-m = t("support_users.dashboard.service_data_heading")
+nav
+  ul.govuk-list
+    li
+      = govuk_link_to t("support_users.dashboard.service_data_link"), support_users_service_data_path
+
+hr.govuk-section-break.govuk-section-break--l
+
 h2.govuk-heading-m = t("support_users.dashboard.development_tools_heading")
 nav
   ul.govuk-list

--- a/app/views/support_users/service_data/base/_db_info.html.slim
+++ b/app/views/support_users/service_data/base/_db_info.html.slim
@@ -1,0 +1,10 @@
+- if local_assigns[:object].present?
+  = render DetailComponent.new title: local_assigns[:title] do |detail|
+    - detail.with_body do
+      = govuk_summary_list do |summary_list|
+        - local_assigns[:object].class.column_names.each do |column_name|
+          - next if column_name.match?(/password|token/)
+          - column_name = column_name.remove("_ciphertext")
+          - summary_list.with_row do |row|
+            - row.with_key text: column_name.humanize
+            - row.with_value text: local_assigns[:object].send(column_name)&.to_s

--- a/app/views/support_users/service_data/index.html.slim
+++ b/app/views/support_users/service_data/index.html.slim
@@ -1,0 +1,8 @@
+- content_for :page_title_prefix, t("support_users.service_data.index.title")
+
+h1.govuk-heading-l = t("support_users.service_data.index.heading")
+
+nav
+  ul.govuk-list
+    li
+      = govuk_link_to t("support_users.service_data.index.jobseeker_profiles_link"), support_users_service_data_jobseeker_profiles_path

--- a/app/views/support_users/service_data/jobseeker_profiles/index.html.slim
+++ b/app/views/support_users/service_data/jobseeker_profiles/index.html.slim
@@ -7,3 +7,4 @@ h1.govuk-heading-l = "Service Jobseeker Profiles"
       = govuk_link_to(jobseeker_profile.id, support_users_service_data_jobseeker_profile_path(jobseeker_profile))
   - t.boolean "Active", :active
   - t.datetime "Created", :created_at
+= govuk_pagination(pagy: @pagy)

--- a/app/views/support_users/service_data/jobseeker_profiles/index.html.slim
+++ b/app/views/support_users/service_data/jobseeker_profiles/index.html.slim
@@ -1,0 +1,9 @@
+- content_for :page_title_prefix, "Service Jobseeker Profiles"
+
+h1.govuk-heading-l = "Service Jobseeker Profiles"
+= supportal_table(entries: @jobseeker_profiles) do |t|
+  - t.column "Id" do |jobseeker_profile|
+    - capture do
+      = govuk_link_to(jobseeker_profile.id, support_users_service_data_jobseeker_profile_path(jobseeker_profile))
+  - t.boolean "Active", :active
+  - t.datetime "Created", :created_at

--- a/app/views/support_users/service_data/jobseeker_profiles/index.html.slim
+++ b/app/views/support_users/service_data/jobseeker_profiles/index.html.slim
@@ -2,9 +2,11 @@
 
 h1.govuk-heading-l = "Service Jobseeker Profiles"
 = supportal_table(entries: @jobseeker_profiles) do |t|
-  - t.column "Id" do |jobseeker_profile|
+  - t.column "Jobseeker" do |jobseeker_profile|
     - capture do
-      = govuk_link_to(jobseeker_profile.id, support_users_service_data_jobseeker_profile_path(jobseeker_profile))
+      - pd = jobseeker_profile.personal_details
+      - link_text = pd&.first_name? ? "#{pd.first_name} #{pd.last_name}" : jobseeker_profile.jobseeker.email
+      = govuk_link_to(link_text, support_users_service_data_jobseeker_profile_path(jobseeker_profile))
   - t.boolean "Active", :active
   - t.datetime "Created", :created_at
 = govuk_pagination(pagy: @pagy)

--- a/app/views/support_users/service_data/jobseeker_profiles/index.html.slim
+++ b/app/views/support_users/service_data/jobseeker_profiles/index.html.slim
@@ -1,6 +1,6 @@
-- content_for :page_title_prefix, "Service Jobseeker Profiles"
+- content_for :page_title_prefix, t(".title")
 
-h1.govuk-heading-l = "Service Jobseeker Profiles"
+h1.govuk-heading-l = t(".title")
 = supportal_table(entries: @jobseeker_profiles) do |t|
   - t.column "Jobseeker" do |jobseeker_profile|
     - capture do

--- a/app/views/support_users/service_data/jobseeker_profiles/show.html.slim
+++ b/app/views/support_users/service_data/jobseeker_profiles/show.html.slim
@@ -1,12 +1,19 @@
-- title = @jobseeker_profile.id
+- personal_details = @jobseeker_profile.personal_details
+- jobseeker = @jobseeker_profile.jobseeker
+- title = personal_details&.first_name? ? "#{personal_details.first_name} #{personal_details.last_name} profile" : "#{jobseeker.email} profile"
 - content_for :page_title_prefix, title
 
 h1.govuk-heading-l = title
 
-= render DetailComponent.new title: title do |detail|
-  - detail.with_body do
-    = govuk_summary_list do |summary_list|
-      - JobseekerProfile.column_names.each do |column_name|
-        - summary_list.with_row do |row|
-          - row.with_key text: column_name.humanize
-          - row.with_value text: @jobseeker_profile.send(column_name)&.to_s
+= render "db_info", title: "Jobseeker", object: jobseeker
+= render "db_info", title: "Personal Details", object: personal_details
+= render "db_info", title: "Jobseeker Profile", object: @jobseeker_profile
+= render "db_info", title: "Job Preferences", object: @jobseeker_profile.job_preferences
+
+h2.govuk-heading-m = "Qualifications"
+- @jobseeker_profile.qualifications.each do |qualification|
+  = render "db_info", title: qualification.name, object: qualification
+
+h2.govuk-heading-m = "Work History"
+- @jobseeker_profile.employments.each do |employment|
+  = render "db_info", title: employment.job_title, object: employment

--- a/app/views/support_users/service_data/jobseeker_profiles/show.html.slim
+++ b/app/views/support_users/service_data/jobseeker_profiles/show.html.slim
@@ -1,0 +1,12 @@
+- title = @jobseeker_profile.id
+- content_for :page_title_prefix, title
+
+h1.govuk-heading-l = title
+
+= render DetailComponent.new title: title do |detail|
+  - detail.with_body do
+    = govuk_summary_list do |summary_list|
+      - JobseekerProfile.column_names.each do |column_name|
+        - summary_list.with_row do |row|
+          - row.with_key text: column_name.humanize
+          - row.with_value text: @jobseeker_profile.send(column_name)&.to_s

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -81,6 +81,29 @@
       "note": "This is our own static data with no user input provided in the query"
     },
     {
+      "warning_type": "Unscoped Find",
+      "warning_code": 82,
+      "fingerprint": "58f3df7253d0dfa30ca15dd14b17c6e3c5f8f5760b5363c3df49a692a1c74195",
+      "check_name": "UnscopedFind",
+      "message": "Unscoped call to `JobseekerProfile#find`",
+      "file": "app/controllers/support_users/service_data/jobseeker_profiles_controller.rb",
+      "line": 8,
+      "link": "https://brakemanscanner.org/docs/warning_types/unscoped_find/",
+      "code": "JobseekerProfile.find(params[:id])",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "SupportUsers::ServiceData::JobseekerProfilesController",
+        "method": "show"
+      },
+      "user_input": "params[:id]",
+      "confidence": "Weak",
+      "cwe_id": [
+        285
+      ],
+      "note": "Support users are meant to be able to see jobseeker profiles"
+    },
+    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "807960ad995ced9524fef98fa8770d355bd5f44365c88ad4eba82831afcb9258",
@@ -242,6 +265,6 @@
       "note": "Neither field_name or the coordinates come directly from user input. field_name is hardcoded in the child classes of LocationQuery and the coordinates come from Geocoding#coordinates which returns an array with coordinates returned by our cache or third party geocoding APIs. It defaults to [0,0] if relevant coordinates are not found."
     }
   ],
-  "updated": "2023-08-30 17:07:26 +0100",
-  "brakeman_version": "6.0.1"
+  "updated": "2024-01-15 11:25:34 +0000",
+  "brakeman_version": "6.1.1"
 }

--- a/config/locales/support_users.yml
+++ b/config/locales/support_users.yml
@@ -6,7 +6,20 @@ en:
       user_feedback_heading: User feedback
       user_feedback_link: View user feedback
       development_tools_heading: Developer tools
+      service_data_heading: Service data
+      service_data_link: View service data
       sidekiq_link: View Sidekiq dashboard
+
+    fallback_sessions:
+      create:
+        check_spam_html: >-
+          If our email doesn’t arrive within 5 minutes, check your spam or junk folder, or %{try_again}.
+        title: Check your email
+        sent: >-
+          If you have access to the support dashboard, we’ve sent you an email.
+          Click on the link in the email to sign in and return to this service.
+          You do not need to keep this page open.
+
     feedbacks:
       general:
         title: General feedback
@@ -61,15 +74,11 @@ en:
 
     papertrail_display_name: "%{first_name} %{last_name} (DfE Teaching Vacancies team)"
 
-    fallback_sessions:
-      create:
-        check_spam_html: >-
-          If our email doesn’t arrive within 5 minutes, check your spam or junk folder, or %{try_again}.
-        title: Check your email
-        sent: >-
-          If you have access to the support dashboard, we’ve sent you an email.
-          Click on the link in the email to sign in and return to this service.
-          You do not need to keep this page open.
+    service_data:
+      index:
+        heading: Service data
+        jobseeker_profiles_link: Jobseeker profiles
+        title: Service data
 
     sessions:
       new:

--- a/config/locales/support_users.yml
+++ b/config/locales/support_users.yml
@@ -79,6 +79,9 @@ en:
         heading: Service data
         jobseeker_profiles_link: Jobseeker profiles
         title: Service data
+      jobseeker_profiles:
+        index:
+          title: Service Jobseeker Profiles
 
     sessions:
       new:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -207,6 +207,11 @@ Rails.application.routes.draw do
     get "feedback/satisfaction-ratings", to: "feedbacks#satisfaction_ratings"
 
     post "feedback/recategorize", to: "feedbacks#recategorize"
+
+    get "service-data", to: "service_data#index"
+    namespace :service_data, path: "service-data" do
+      resources :jobseeker_profiles, only: %i[index show]
+    end
   end
 
   devise_for :support_users

--- a/spec/requests/support_users/service_data/jobseeker_profiles_spec.rb
+++ b/spec/requests/support_users/service_data/jobseeker_profiles_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+
+RSpec.describe "Accessign the service data jobseeker profiles" do
+  context "when signed in as a support user" do
+    let(:support_user) { create(:support_user, email: "test@example.com") }
+    let(:personal_details) { create(:personal_details, first_name: "John", last_name: "Smith") }
+    let!(:jobseeker_profile) { create(:jobseeker_profile, :completed, personal_details: personal_details) }
+
+    before do
+      sign_in(support_user, scope: :support_user)
+    end
+
+    it "can access the service data jobseeker profiles list" do
+      get support_users_service_data_jobseeker_profiles_path
+
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template(:index)
+      expect(response.body).to include("Jobseeker Profiles")
+      expect(response.body).to include("John Smith")
+    end
+
+    it "can access a Jobseeker Profile information in the profiles list" do
+      get support_users_service_data_jobseeker_profile_path(jobseeker_profile)
+
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template(:show)
+      expect(response.body).to include("John Smith")
+    end
+
+    it "gets their access to a Jobseeker Profile logged" do
+      allow(Rails.logger).to receive(:info).with(anything)
+      expect(Rails.logger).to receive(:info)
+        .with("[Service Data] #{support_user.email} accessed Profile ID #{jobseeker_profile.id} at #{Time.current}")
+
+      get support_users_service_data_jobseeker_profile_path(jobseeker_profile)
+    end
+  end
+
+  context "when not signed in" do
+    it "cannot access the service data jobseeker profiles list" do
+      get support_users_service_data_jobseeker_profiles_path
+
+      expect(response).to redirect_to(new_support_user_session_path(redirected: true))
+    end
+  end
+
+  context "when signed in as a publisher" do
+    let(:publisher) { create(:publisher) }
+
+    before do
+      sign_in(publisher, scope: :publisher)
+    end
+
+    it "cannot access the service data jobseeker profiles list" do
+      get support_users_service_data_jobseeker_profiles_path
+
+      expect(response).to redirect_to(new_support_user_session_path(redirected: true))
+    end
+  end
+
+  context "when signed in as a jobseeker" do
+    let(:jobseeker) { create(:jobseeker) }
+
+    before do
+      sign_in(jobseeker, scope: :jobseeker)
+    end
+
+    it "cannot access the service data jobseeker profiles list" do
+      get support_users_service_data_jobseeker_profiles_path
+
+      expect(response).to redirect_to(new_support_user_session_path(redirected: true))
+    end
+  end
+end

--- a/spec/smoke_tests/jobseekers_can_view_homepage_spec.rb
+++ b/spec/smoke_tests/jobseekers_can_view_homepage_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe "Page availability", js: true, smoke_test: true do
 
       page.visit "https://#{smoke_test_domain}/jobs?keyword=Maths"
 
+      expect(page).to have_css("h1", text: "Jobs")
       if page.has_css?(".search-results")
         expect(page).to have_content(I18n.t("subscriptions.link.text"))
       else

--- a/spec/system/support_users/service_data_spec.rb
+++ b/spec/system/support_users/service_data_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe "Service Data supportal section" do
+  before do
+    OmniAuth.config.test_mode = true
+
+    stub_support_user_authentication_step
+    stub_support_user_authorisation_step
+
+    sign_in_support_user(navigate: true)
+  end
+
+  after do
+    OmniAuth.config.mock_auth[:default] = nil
+    OmniAuth.config.mock_auth[:dfe] = nil
+    OmniAuth.config.test_mode = false
+  end
+
+  scenario "support users can list and see the Jobseekers Profile information through the Supportal" do
+    profile = create(:jobseeker_profile,
+                     :completed,
+                     about_you: "I am a jobseeker",
+                     qualified_teacher_status: "yes",
+                     qualified_teacher_status_year: "2010")
+
+    click_on "View service data"
+    expect(page).to have_css("h1", text: "Service data")
+
+    click_link "Jobseeker profiles"
+    expect(page).to have_css("h1", text: "Service Jobseeker Profiles")
+
+    click_link profile.id
+    expect(page).to have_css("h1", text: profile.id)
+
+    within(".govuk-summary-list") do
+      expect(page).to have_row("Id", profile.id)
+      expect(page).to have_row("Active", "true")
+      expect(page).to have_row("About you", "I am a jobseeker")
+      expect(page).to have_row("Qualified teacher status", "yes")
+      expect(page).to have_row("Qualified teacher status year", "2010")
+    end
+  end
+
+  matcher :have_row do |key, value|
+    match_unless_raises do |page|
+      expect(page.find("dt.govuk-summary-list__key", text: key, exact_text: true))
+        .to have_sibling("dd.govuk-summary-list__value", text: value, exact_text: true)
+    end
+
+    failure_message do |page|
+      if page.has_css?("dt.govuk-summary-list__key", text: key, exact_text: true, wait: 0)
+        value_content = page.first(:css, "dt.govuk-summary-list__key", text: key, exact_text: true)
+                            .sibling("dd.govuk-summary-list__value").text
+        "Expected page to have a row for '#{key}' with value '#{value}', but contained '#{value_content}'"
+      else
+        "Expected page to have a row for '#{key}' with value '#{value}', but there is no row for '#{key}'"
+      end
+    end
+  end
+end

--- a/spec/system/support_users/service_data_spec.rb
+++ b/spec/system/support_users/service_data_spec.rb
@@ -22,6 +22,9 @@ RSpec.describe "Service Data supportal section" do
                      about_you: "I am a jobseeker",
                      qualified_teacher_status: "yes",
                      qualified_teacher_status_year: "2010")
+    jobseeker = profile.jobseeker
+    personal_details = profile.personal_details
+    jobseeker_name = "#{personal_details.first_name} #{personal_details.last_name}"
 
     click_on "View service data"
     expect(page).to have_css("h1", text: "Service data")
@@ -29,16 +32,76 @@ RSpec.describe "Service Data supportal section" do
     click_link "Jobseeker profiles"
     expect(page).to have_css("h1", text: "Service Jobseeker Profiles")
 
-    click_link profile.id
-    expect(page).to have_css("h1", text: profile.id)
+    click_link jobseeker_name
+    expect(page).to have_css("h1", text: jobseeker_name)
 
-    within(".govuk-summary-list") do
-      expect(page).to have_row("Id", profile.id)
+    within(summary_card("Jobseeker")) do
+      expect(page).to have_row("Id", jobseeker.id)
+      expect(page).to have_row("Email", jobseeker.email)
+      expect(page).to have_row("Sign in count", "0")
+      expect(page).to have_row("Failed attempts", "0")
+      expect(page).to have_row("Confirmed at", jobseeker.confirmed_at)
+    end
+
+    within(summary_card("Personal Details")) do
+      expect(page).to have_row("Id", personal_details.id)
+      expect(page).to have_row("Phone number provided", "true")
+      expect(page).to have_row("First name", personal_details.first_name)
+      expect(page).to have_row("Last name", personal_details.last_name)
+      expect(page).to have_row("Phone number", personal_details.phone_number)
+      expect(page).to have_row("Right to work in uk", "true")
+    end
+
+    within(summary_card("Jobseeker Profile")) do
+      expect(page).to have_row("Jobseeker", jobseeker.id)
       expect(page).to have_row("Active", "true")
       expect(page).to have_row("About you", "I am a jobseeker")
       expect(page).to have_row("Qualified teacher status", "yes")
       expect(page).to have_row("Qualified teacher status year", "2010")
     end
+
+    preferences = profile.job_preferences
+    within(summary_card("Job Preferences")) do
+      expect(page).to have_row("Id", preferences.id)
+      expect(page).to have_row("Roles", preferences.roles)
+      expect(page).to have_row("Phases", preferences.phases)
+      expect(page).to have_row("Key stages", preferences.key_stages)
+      expect(page).to have_row("Subjects", preferences.subjects)
+      expect(page).to have_row("Working patterns", preferences.working_patterns)
+      expect(page).to have_row("Completed steps", preferences.completed_steps)
+      expect(page).to have_row("Builder completed", preferences.builder_completed)
+    end
+
+    qualification = profile.qualifications.first
+    within(summary_card(qualification.name)) do
+      expect(page).to have_row("Id", qualification.id)
+      expect(page).to have_row("Category", qualification.category)
+      expect(page).to have_row("Finished studying", qualification.finished_studying)
+      expect(page).to have_row("Finished studying details", qualification.finished_studying_details)
+      expect(page).to have_row("Grade", qualification.grade)
+      expect(page).to have_row("Institution", qualification.institution)
+      expect(page).to have_row("Name", qualification.name)
+      expect(page).to have_row("Subject", qualification.subject)
+      expect(page).to have_row("Year", qualification.year)
+    end
+
+    employment = profile.employments.first
+    within(summary_card(employment.job_title)) do
+      expect(page).to have_row("Id", employment.id)
+      expect(page).to have_row("Salary", employment.salary)
+      expect(page).to have_row("Current role", employment.current_role)
+      expect(page).to have_row("Started on", employment.started_on)
+      expect(page).to have_row("Ended on", employment.ended_on)
+      expect(page).to have_row("Employment type", employment.employment_type)
+      expect(page).to have_row("Organisation", employment.organisation)
+      expect(page).to have_row("Job title", employment.job_title)
+      expect(page).to have_row("Main duties", employment.main_duties)
+      expect(page).to have_row("Reason for leaving", employment.reason_for_leaving)
+    end
+  end
+
+  def summary_card(title)
+    find(".govuk-summary-card h3", text: title, exact_text: true).ancestor(".govuk-summary-card")
   end
 
   matcher :have_row do |key, value|


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/MdJEC9H6

## Changes in this PR:

It creates a new section in the Support Users Dashboard that displays the Service Data.

The main goal is to allow support users to analyse the information from the system without requiring a developer to pull data from production.

The Dashboard currently includes only information for Jobseeker Profiles (and their associated Jobseeker info). The idea is to show everything in the DB tables we are consulting, besides not showing some critical info from DB like passwords, tokens, etc.

There is very little personalisation,  and the generic shared `_db_info.html.slim` partial allows to build a view with multiple tables as:

```
= render "db_info", title: "Jobseeker", object: jobseeker
= render "db_info", title: "Personal Details", object: personal_details
= render "db_info", title: "Jobseeker Profile", object: @jobseeker_profile
= render "db_info", title: "Job Preferences", object: @jobseeker_profile.job_preferences
```


## Screenshots of UI changes:
### Support Dashboard with new Service Data link
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/ebb04a44-6501-435a-ad27-d431d70356fa)

### Service Data portal containing Jobseeker Profiles link
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/b5c41c8e-9c99-4e3c-85f0-dc42f4c2aec2)

### Service Data Jobseeker Profiles list
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/82d1f24b-eec4-4b52-9d77-422cc8e180ac)

### Service Data page for a particular jobseeker profile
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/7c7fce01-5106-4b14-bc04-d2c4a9cc6b3f)
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/d42a913b-7635-44df-b924-cb6e137eca90)
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/28845db8-44f1-4814-941b-5913308655ad)
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/93c73262-7d7d-4b53-89ae-6815a79dce71)


### Logging the access
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/f989845f-5cf9-41ef-a612-b3aa7c246dfe)
