### PR TITLE
Remove Cloudfoundry-Cli from Devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,12 +12,8 @@ RUN apt update -yq \
    && apt install curl gnupg -yq \
    && curl -sL https://deb.nodesource.com/setup_$NODEJS_MAJOR_VERSION.x | bash
 
-# Set up repository for CloudFoundry CLI
-RUN wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | apt-key add - \
-    && echo "deb https://packages.cloudfoundry.org/debian stable main" > /etc/apt/sources.list.d/cloudfoundry-cli.list
-
 # Set up dependencies
-RUN apt update && apt install -y cf8-cli nodejs postgresql-client redis-tools less vim sudo shared-mime-info man-db
+RUN apt update && apt install -y nodejs postgresql-client redis-tools less vim sudo shared-mime-info man-db
 RUN npm install -g yarn
 
 # Install Terraform


### PR DESCRIPTION
Since we do not use CF anymore.
