### PR TITLE
Fix lack of default ActiveStorage service in dev

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -4,6 +4,10 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in
   # config/application.rb.
 
+  # The application uses multiple services for storing files. This sets up a default value which gets overridden
+  # in every specific use case.
+  config.active_storage.service = :amazon_s3_documents
+
   # Configure the domains permitted to access coordinates API
   config.allowed_cors_origin = proc { "https://#{DOMAIN}" }
 


### PR DESCRIPTION
Since Rails 7.1 this config is required. Local development environment was failing due to this being missing. So we aligned it with the rest of environments configurations.
