### PR TITLE
KCSIE: update declaration section

### DIFF
--- a/app/form_models/jobseekers/job_application/declarations_form.rb
+++ b/app/form_models/jobseekers/job_application/declarations_form.rb
@@ -2,10 +2,12 @@ class Jobseekers::JobApplication::DeclarationsForm < Jobseekers::JobApplication:
   include ActiveModel::Model
 
   def self.fields
-    %i[close_relationships close_relationships_details right_to_work_in_uk]
+    %i[close_relationships close_relationships_details right_to_work_in_uk safeguarding_issue safeguarding_issue_details]
   end
   attr_accessor(*fields)
 
   validates :close_relationships, inclusion: { in: %w[yes no] }
   validates :close_relationships_details, presence: true, if: -> { close_relationships == "yes" }
+  validates :safeguarding_issue, inclusion: { in: %w[yes no] }
+  validates :safeguarding_issue_details, presence: true, if: -> { safeguarding_issue == "yes" }
 end

--- a/app/helpers/job_applications_helper.rb
+++ b/app/helpers/job_applications_helper.rb
@@ -60,6 +60,16 @@ module JobApplicationsHelper
     end
   end
 
+  def job_application_safeguarding_issues_info(job_application)
+    case job_application.close_relationships
+    when "yes"
+      safe_join([tag.div("Yes", class: "govuk-body", id: "safeguarding_issue"),
+                 tag.p(job_application.safeguarding_issue_details, class: "govuk-body", id: "safeguarding_issue_details")])
+    when "no"
+      tag.div("No", class: "govuk-body", id: "safeguarding_issue")
+    end
+  end
+
   def job_application_status_tag(status)
     govuk_tag text: JOBSEEKER_STATUS_MAPPINGS[status.to_sym],
               colour: JOB_APPLICATION_STATUS_TAG_COLOURS[JOBSEEKER_STATUS_MAPPINGS[status.to_sym].parameterize.underscore.to_sym],

--- a/app/views/jobseekers/job_applications/build/declarations.html.slim
+++ b/app/views/jobseekers/job_applications/build/declarations.html.slim
@@ -23,9 +23,9 @@
         = f.govuk_radio_button :close_relationships, :no
 
       = f.govuk_radio_buttons_fieldset :safeguarding_issue, legend: { text: t("helpers.legend.jobseekers_job_application_declarations_form.safeguarding_issue", organisation: vacancy.organisation_name) } do
-        = f.govuk_radio_button :safeguarding_issue, :yes, link_errors: true, label: { text: "Yes, I want to share something" } do
-          = f.govuk_text_area :safeguarding_issue_details, label: { text: "Give any relevant information" }
-        = f.govuk_radio_button :safeguarding_issue, :no, label: { text: "No" }
+        = f.govuk_radio_button :safeguarding_issue, :yes, link_errors: true, label: { text: t(".safeguarding_issue.yes") } do
+          = f.govuk_text_area :safeguarding_issue_details, label: { text: t(".safeguarding_issue.hint") }
+        = f.govuk_radio_button :safeguarding_issue, :no, label: { text: t(".safeguarding_issue.no") }
 
       = f.govuk_submit job_application_build_submit_button_text do
         = govuk_link_to t("buttons.cancel_and_return_to_account"), jobseekers_job_applications_path, class: "govuk-link--no-visited-state"

--- a/app/views/jobseekers/job_applications/build/declarations.html.slim
+++ b/app/views/jobseekers/job_applications/build/declarations.html.slim
@@ -7,6 +7,13 @@
     - if current_jobseeker.job_applications.not_draft.none?
       = render "caption"
     h2.govuk-heading-l = t(".heading")
+    - byebug
+    p.govuk-body = t(".description1", link_text: govuk_link_to(t(".dbs_link_text"), "https://www.gov.uk/government/organisations/disclosure-and-barring-service")).html_safe
+    p.govuk-body = t(".description2")
+    p.govuk-body = t(".description3")
+    p.govuk-body = govuk_link_to(t(".description4"), "https://www.gov.uk/tell-employer-or-college-about-criminal-record")
+    p.govuk-body = t(".description5", link_text: govuk_link_to(t(".keep_children_safe_link_text"), "https://www.gov.uk/government/publications/keeping-children-safe-in-education--2")).html_safe
+
 
     = form_for form, url: wizard_path, method: :patch do |f|
       = f.govuk_error_summary

--- a/app/views/jobseekers/job_applications/build/declarations.html.slim
+++ b/app/views/jobseekers/job_applications/build/declarations.html.slim
@@ -7,7 +7,7 @@
     - if current_jobseeker.job_applications.not_draft.none?
       = render "caption"
     h2.govuk-heading-l = t(".heading")
-    - byebug
+
     p.govuk-body = t(".description1", link_text: govuk_link_to(t(".dbs_link_text"), "https://www.gov.uk/government/organisations/disclosure-and-barring-service")).html_safe
     p.govuk-body = t(".description2")
     p.govuk-body = t(".description3")
@@ -22,6 +22,11 @@
         = f.govuk_radio_button :close_relationships, :yes, link_errors: true do
           = f.govuk_text_field :close_relationships_details
         = f.govuk_radio_button :close_relationships, :no
+
+      = f.govuk_radio_buttons_fieldset :safeguarding_issue, legend: { text: t("helpers.legend.jobseekers_job_application_declarations_form.safeguarding_issue", organisation: vacancy.organisation_name) } do
+        = f.govuk_radio_button :safeguarding_issue, :yes, link_errors: true, label: { text: "Yes, I want to share something" } do
+          = f.govuk_text_area :safeguarding_issue_details, label: { text: "Give any relevant information" }
+        = f.govuk_radio_button :safeguarding_issue, :no, label: { text: "No" }
 
       = f.govuk_submit job_application_build_submit_button_text do
         = govuk_link_to t("buttons.cancel_and_return_to_account"), jobseekers_job_applications_path, class: "govuk-link--no-visited-state"

--- a/app/views/jobseekers/job_applications/build/declarations.html.slim
+++ b/app/views/jobseekers/job_applications/build/declarations.html.slim
@@ -14,7 +14,6 @@
     p.govuk-body = govuk_link_to(t(".description4"), "https://www.gov.uk/tell-employer-or-college-about-criminal-record")
     p.govuk-body = t(".description5", link_text: govuk_link_to(t(".keep_children_safe_link_text"), "https://www.gov.uk/government/publications/keeping-children-safe-in-education--2")).html_safe
 
-
     = form_for form, url: wizard_path, method: :patch do |f|
       = f.govuk_error_summary
 

--- a/app/views/jobseekers/job_applications/build/declarations.html.slim
+++ b/app/views/jobseekers/job_applications/build/declarations.html.slim
@@ -17,15 +17,15 @@
     = form_for form, url: wizard_path, method: :patch do |f|
       = f.govuk_error_summary
 
-      = f.govuk_radio_buttons_fieldset :close_relationships, legend: { text: t("helpers.legend.jobseekers_job_application_declarations_form.close_relationships", organisation: vacancy.organisation_name) } do
-        = f.govuk_radio_button :close_relationships, :yes, link_errors: true do
-          = f.govuk_text_field :close_relationships_details
-        = f.govuk_radio_button :close_relationships, :no
-
       = f.govuk_radio_buttons_fieldset :safeguarding_issue, legend: { text: t("helpers.legend.jobseekers_job_application_declarations_form.safeguarding_issue", organisation: vacancy.organisation_name) } do
         = f.govuk_radio_button :safeguarding_issue, :yes, link_errors: true, label: { text: t(".safeguarding_issue.yes") } do
           = f.govuk_text_area :safeguarding_issue_details, label: { text: t(".safeguarding_issue.hint") }
         = f.govuk_radio_button :safeguarding_issue, :no, label: { text: t(".safeguarding_issue.no") }
+
+      = f.govuk_radio_buttons_fieldset :close_relationships, legend: { text: t("helpers.legend.jobseekers_job_application_declarations_form.close_relationships", organisation: vacancy.organisation_name) } do
+        = f.govuk_radio_button :close_relationships, :yes, link_errors: true do
+          = f.govuk_text_field :close_relationships_details
+        = f.govuk_radio_button :close_relationships, :no
 
       = f.govuk_submit job_application_build_submit_button_text do
         = govuk_link_to t("buttons.cancel_and_return_to_account"), jobseekers_job_applications_path, class: "govuk-link--no-visited-state"

--- a/app/views/jobseekers/job_applications/review/_declarations.html.slim
+++ b/app/views/jobseekers/job_applications/review/_declarations.html.slim
@@ -2,3 +2,7 @@
   - s.with_row do |row|
     - row.with_key text: t("helpers.legend.jobseekers_job_application_declarations_form.close_relationships", organisation: vacancy.organisation_name)
     - row.with_value text: job_application_close_relationships_info(job_application)
+  
+  - s.with_row do |row|
+    - row.with_key text: t("helpers.legend.jobseekers_job_application_declarations_form.safeguarding_issue")
+    - row.with_value text: job_application_safeguarding_issues_info(job_application)

--- a/app/views/jobseekers/job_applications/review/_declarations.html.slim
+++ b/app/views/jobseekers/job_applications/review/_declarations.html.slim
@@ -1,8 +1,8 @@
 - r.with_section :declarations do |s|
   - s.with_row do |row|
-    - row.with_key text: t("helpers.legend.jobseekers_job_application_declarations_form.close_relationships", organisation: vacancy.organisation_name)
-    - row.with_value text: job_application_close_relationships_info(job_application)
-
-  - s.with_row do |row|
     - row.with_key text: t("helpers.legend.jobseekers_job_application_declarations_form.safeguarding_issue")
     - row.with_value text: job_application_safeguarding_issues_info(job_application)
+
+  - s.with_row do |row|
+    - row.with_key text: t("helpers.legend.jobseekers_job_application_declarations_form.close_relationships", organisation: vacancy.organisation_name)
+    - row.with_value text: job_application_close_relationships_info(job_application)

--- a/app/views/jobseekers/job_applications/review/_declarations.html.slim
+++ b/app/views/jobseekers/job_applications/review/_declarations.html.slim
@@ -2,7 +2,7 @@
   - s.with_row do |row|
     - row.with_key text: t("helpers.legend.jobseekers_job_application_declarations_form.close_relationships", organisation: vacancy.organisation_name)
     - row.with_value text: job_application_close_relationships_info(job_application)
-  
+
   - s.with_row do |row|
     - row.with_key text: t("helpers.legend.jobseekers_job_application_declarations_form.safeguarding_issue")
     - row.with_value text: job_application_safeguarding_issues_info(job_application)

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -140,6 +140,8 @@ shared:
     - country
     - email_address
     - withdrawn_by_closing_account
+    - safeguarding_issue
+    - safeguarding_issue_details
   job_preferences_locations:
     - id
     - job_preferences_id

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -476,6 +476,10 @@ en:
               inclusion: Select yes if you have a close relationship with people within the organisation
             close_relationships_details:
               blank: Give details about any close relationships with people within the organisation
+            safeguarding_issue:
+              inclusion: Select yes if you have a safeguarding issue to declare
+            safeguarding_issue_details:
+              blank: Provide details about your safeguarding issue
         jobseekers/job_application/employment_history_form:
           attributes:
             employment_history_section_completed:

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -839,6 +839,7 @@ en:
       jobseekers_job_application_declarations_form:
         close_relationships: Do you have any family or close relationship with people within %{organisation}?
         right_to_work_in_uk: Do you currently have the right to work in the UK?
+        safeguarding_issue: Do you want to declare any safeguarding issues, such as a criminal record or professional misconduct?
       jobseekers_job_application_details_reference_form:
         phone_number: Phone number
       jobseekers_job_application_employment_history_form:

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -110,6 +110,10 @@ en:
           description4: Learn more about when you need to tell someone about your criminal record.
           keep_children_safe_link_text: keeping children safe in education obligations.
           description5: Schools may also conduct their own online checks as part of their %{link_text}
+          safeguarding_issue:
+            "yes": "Yes, I want to share something"
+            hint: "Give any relevant information"
+            "no": "No"
         employment_history:
           break: Break in work history
           description:

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -101,6 +101,15 @@ en:
           heading: Declarations
           step_title: Declarations
           title: Declarations — Application
+          dbs_link_text: Disclosure and Barring Service (DBS) check
+          description1: >-
+            You'll need to complete an enhanced %{link_text} if you're successful in this role. If you're outside the UK, you'll need to get a 
+            criminal record check from your home country.
+          description2: It's a criminal offence if you're barred by the DBS or court orders to apply for a role working with children.
+          description3: Not all convictions or police cautions on a criminal record will stop you from working in a school. But you will have to declare any convictions.
+          description4: Learn more about when you need to tell someone about your criminal record.
+          keep_children_safe_link_text: keeping children safe in education obligations.
+          description5: Schools may also conduct their own online checks as part of their %{link_text}
         employment_history:
           break: Break in work history
           description:

--- a/db/migrate/20240112164520_add_safeguarding_issues_to_job_applications.rb
+++ b/db/migrate/20240112164520_add_safeguarding_issues_to_job_applications.rb
@@ -1,0 +1,6 @@
+class AddSafeguardingIssuesToJobApplications < ActiveRecord::Migration[7.1]
+  def change
+    add_column :job_applications, :safeguarding_issue, :string
+    add_column :job_applications, :safeguarding_issue_details, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_05_161119) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_12_164520) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -239,6 +239,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_05_161119) do
     t.integer "in_progress_steps", default: [], null: false, array: true
     t.boolean "employment_history_section_completed"
     t.boolean "qualifications_section_completed"
+    t.string "safeguarding_issue"
+    t.text "safeguarding_issue_details"
     t.index ["jobseeker_id"], name: "index_job_applications_jobseeker_id"
     t.index ["vacancy_id"], name: "index_job_applications_on_vacancy_id"
   end

--- a/spec/factories/job_applications.rb
+++ b/spec/factories/job_applications.rb
@@ -55,6 +55,8 @@ FactoryBot.define do
     # Declarations
     close_relationships { "yes" }
     close_relationships_details { Faker::Lorem.paragraph(sentence_count: 1) }
+    safeguarding_issue { "yes" }
+    safeguarding_issue_details { Faker::Lorem.paragraph(sentence_count: 1) }
     right_to_work_in_uk { "yes" }
 
     completed_steps { JobApplication.completed_steps.keys }

--- a/spec/factories/job_applications.rb
+++ b/spec/factories/job_applications.rb
@@ -133,6 +133,8 @@ FactoryBot.define do
     # Declarations
     close_relationships { "" }
     close_relationships_details { "" }
+    safeguarding_issue { "" }
+    safeguarding_issue_details { "" }
     right_to_work_in_uk { "" }
 
     completed_steps { [] }

--- a/spec/form_models/jobseekers/job_application/declarations_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/declarations_form_spec.rb
@@ -8,4 +8,12 @@ RSpec.describe Jobseekers::JobApplication::DeclarationsForm, type: :model do
 
     it { is_expected.to validate_presence_of(:close_relationships_details) }
   end
+
+  it { is_expected.to validate_inclusion_of(:safeguarding_issue).in_array(%w[yes no]) }
+
+  context "when safeguarding_issue is yes" do
+    before { allow(subject).to receive(:safeguarding_issue).and_return("yes") }
+
+    it { is_expected.to validate_presence_of(:safeguarding_issue_details) }
+  end
 end

--- a/spec/support/jobseeker_helpers.rb
+++ b/spec/support/jobseeker_helpers.rb
@@ -50,6 +50,8 @@ module JobseekerHelpers
   def fill_in_declarations
     choose "Yes", name: "jobseekers_job_application_declarations_form[close_relationships]"
     fill_in "Please give details", with: "Some details of the relationship"
+    choose "Yes, I want to share something"
+    fill_in "Give any relevant information", with: "Criminal record"
   end
 
   def fill_in_employment_history(job_title: "The Best Teacher", start_month: "09", start_year: "2019", end_month: "07", end_year: "2020")

--- a/spec/system/jobseekers/jobseekers_can_add_declarations_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_declarations_to_their_job_application_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe "Jobseekers can disclose close relationships or safeguarding issues on a job application" do
+  let(:jobseeker) { create(:jobseeker) }
+  let(:vacancy) { create(:vacancy, organisations: [build(:school)]) }
+  let!(:job_application) { create(:job_application, :status_draft, jobseeker: jobseeker, vacancy: vacancy) }
+
+  before { login_as(jobseeker, scope: :jobseeker) }
+
+  it "allows jobseekers to add their declarations" do
+    visit jobseekers_job_application_build_path(job_application, :declarations)
+
+    click_on "Save and continue"
+
+    expect(page).to have_css("h2", text: "There is a problem")
+
+    within "ul.govuk-list.govuk-error-summary__list" do
+      expect(page).to have_link("Select yes if you have a close relationship with people within the organisation", href: "#jobseekers-job-application-declarations-form-close-relationships-field-error")
+      expect(page).to have_link("Select yes if you have a safeguarding issue to declare", href: "#jobseekers-job-application-declarations-form-safeguarding-issue-field-error")
+    end
+
+    choose("Yes")
+    choose("Yes, I want to share something")
+
+    click_on "Save and continue"
+
+    expect(page).to have_css("h2", text: "There is a problem")
+
+    within "ul.govuk-list.govuk-error-summary__list" do
+      expect(page).to have_link("Give details about any close relationships with people within the organisation", href: "#jobseekers-job-application-declarations-form-close-relationships-details-field-error")
+      expect(page).to have_link("Provide details about your safeguarding issue", href: "#jobseekers-job-application-declarations-form-safeguarding-issue-details-field-error")
+    end
+
+    fill_in 'jobseekers_job_application_declarations_form[close_relationships_details]', with: 'My dad is the head teacher'
+    fill_in 'jobseekers_job_application_declarations_form[safeguarding_issue_details]', with: "I have a criminal record"
+
+    click_on "Save and continue"
+
+    expect(page).not_to have_css("h2", text: "There is a problem")
+  end
+end

--- a/spec/system/jobseekers/jobseekers_can_add_declarations_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_declarations_to_their_job_application_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe "Jobseekers can disclose close relationships or safeguarding issu
       expect(page).to have_link("Provide details about your safeguarding issue", href: "#jobseekers-job-application-declarations-form-safeguarding-issue-details-field-error")
     end
 
-    fill_in 'jobseekers_job_application_declarations_form[close_relationships_details]', with: 'My dad is the head teacher'
-    fill_in 'jobseekers_job_application_declarations_form[safeguarding_issue_details]', with: "I have a criminal record"
+    fill_in "jobseekers_job_application_declarations_form[close_relationships_details]", with: "My dad is the head teacher"
+    fill_in "jobseekers_job_application_declarations_form[safeguarding_issue_details]", with: "I have a criminal record"
 
     click_on "Save and continue"
 


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/Ka8N1wZj/708-kcsie-update-declaration-section

## Changes in this PR:

This ticket updates the declaration section of a jobseekers job application form. It adds additional description text and links for the section and adds a new question: "“Do you want to declare any safeguarding issues, such as a criminal record or professional misconduct?” and a conditionally hidden text area in which the jobseeker can enter details.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
