### PR TITLE
Patch security vulnerability in Alpine image Openssl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
  # Alpine v3.18.
  # TODO: Regularly check in the alpine ruby "3.3.0-alpine3.18" images for its latest upgraded packages so we can remove
  # the hardcoded versions below when they have been updated in the alpine ruby image.
-ARG PROD_PACKAGES="libxml2 libxslt libpq tzdata shared-mime-info openssl=3.1.4-r3"
+ARG PROD_PACKAGES="libxml2 libxslt libpq tzdata shared-mime-info openssl=3.1.4-r4"
 
 FROM ruby:3.3.0-alpine3.18 AS builder
 


### PR DESCRIPTION
## Changes in this PR:

Looks like we need to patch openssl again after getting this snyk failure in the review app build: https://github.com/DFE-Digital/teaching-vacancies/actions/runs/7547222007/job/20564781875?pr=6609

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
