### PR TITLE
Re-enable Google recaptcha

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,8 +2,6 @@ class ApplicationController < ActionController::Base
   include Pagy::Backend
   include DfE::Analytics::Requests
 
-  SUSPICIOUS_RECAPTCHA_THRESHOLD = 0.5
-
   add_flash_types :success, :warning
 
   protect_from_forgery with: :exception, except: :not_found
@@ -74,12 +72,6 @@ class ApplicationController < ActionController::Base
 
   def set_headers
     response.set_header("X-Robots-Tag", "noindex, nofollow")
-  end
-
-  # https://github.com/ambethia/recaptcha#verify_recaptcha
-  # https://github.com/ambethia/recaptcha#recaptcha_reply
-  def recaptcha_is_invalid?(model = nil)
-    !verify_recaptcha(model: model, action: controller_name, minimum_score: SUSPICIOUS_RECAPTCHA_THRESHOLD) && recaptcha_reply
   end
 
   def dfe_analytics_request_event

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   include Pagy::Backend
   include DfE::Analytics::Requests
 
-  SUSPICIOUS_RECAPTCHA_THRESHOLD = 0.1 # Default 0.5.Temporally set to 0.1 due to very high false positive rate on the last day.
+  SUSPICIOUS_RECAPTCHA_THRESHOLD = 0.5
 
   add_flash_types :success, :warning
 
@@ -78,9 +78,8 @@ class ApplicationController < ActionController::Base
 
   # https://github.com/ambethia/recaptcha#verify_recaptcha
   # https://github.com/ambethia/recaptcha#recaptcha_reply
-  def recaptcha_is_invalid?(_model = nil)
-    # temporarily ignore recaptcha scores until we can verify that issues with high recaptcha failure rate are fixed.
-    false
+  def recaptcha_is_invalid?(model = nil)
+    !verify_recaptcha(model: model, action: controller_name, minimum_score: SUSPICIOUS_RECAPTCHA_THRESHOLD) && recaptcha_reply
   end
 
   def dfe_analytics_request_event

--- a/app/controllers/concerns/recaptcha_checking.rb
+++ b/app/controllers/concerns/recaptcha_checking.rb
@@ -1,0 +1,20 @@
+module RecaptchaChecking
+  extend ActiveSupport::Concern
+
+  SUSPICIOUS_RECAPTCHA_THRESHOLD = 0.5
+
+  # https://github.com/ambethia/recaptcha#verify_recaptcha
+  # https://github.com/ambethia/recaptcha#recaptcha_reply
+  def recaptcha_is_invalid?(model = nil)
+    !verify_recaptcha(model: model, action: controller_name, minimum_score: SUSPICIOUS_RECAPTCHA_THRESHOLD) && recaptcha_reply
+  end
+
+  def handle_invalid_recaptcha(form: nil, score: nil)
+    form_name = form.class.name.gsub("::", "").underscore.humanize if form.present?
+    Sentry.with_scope do |scope|
+      scope.set_tags("form.name": form_name, "recaptcha.score": score)
+      Sentry.capture_message("Invalid recaptcha", level: :warning)
+    end
+    redirect_to invalid_recaptcha_path
+  end
+end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -35,13 +35,6 @@ class ErrorsController < ApplicationController
   end
 
   def invalid_recaptcha
-    @form = params[:form_name]
-    @recaptcha_score = params[:recaptcha_score]
-    Sentry.with_scope do |scope|
-      scope.set_tags("form.name": @form, "recaptcha.score": @recaptcha_score)
-      Sentry.capture_message("Invalid recaptcha", level: :warning)
-    end
-
     respond_to do |format|
       format.html { render status: :unauthorized }
     end

--- a/app/controllers/general_feedbacks_controller.rb
+++ b/app/controllers/general_feedbacks_controller.rb
@@ -1,4 +1,6 @@
 class GeneralFeedbacksController < ApplicationController
+  include RecaptchaChecking
+
   def new
     origin_path = URI.parse(request.referrer).path if request.referrer.present?
     @general_feedback_form = GeneralFeedbackForm.new(user_type: current_user&.class, origin_path:)
@@ -11,8 +13,7 @@ class GeneralFeedbacksController < ApplicationController
     if @general_feedback_form.invalid?
       render :new
     elsif recaptcha_is_invalid?
-      redirect_to invalid_recaptcha_path(form_name: @general_feedback_form.class.name.underscore.humanize,
-                                         recaptcha_score: recaptcha_reply["score"])
+      handle_invalid_recaptcha(form: @general_feedback_form, score: recaptcha_reply["score"])
     else
       @feedback.recaptcha_score = recaptcha_reply&.dig("score")
       @feedback.save

--- a/app/controllers/jobseekers/subscriptions/feedbacks/further_feedbacks_controller.rb
+++ b/app/controllers/jobseekers/subscriptions/feedbacks/further_feedbacks_controller.rb
@@ -1,4 +1,6 @@
 class Jobseekers::Subscriptions::Feedbacks::FurtherFeedbacksController < ApplicationController
+  include RecaptchaChecking
+
   def new
     @feedback_form = Jobseekers::JobAlertFurtherFeedbackForm.new
   end
@@ -9,8 +11,7 @@ class Jobseekers::Subscriptions::Feedbacks::FurtherFeedbacksController < Applica
     if @feedback_form.invalid?
       render :new
     elsif recaptcha_is_invalid?
-      redirect_to invalid_recaptcha_path(form_name: @feedback_form.class.name.gsub("::", "").underscore.humanize,
-                                         recaptcha_score: recaptcha_reply["score"])
+      handle_invalid_recaptcha(form: @feedback_form, score: recaptcha_reply["score"])
     else
       update_feedback
       redirect_to root_path, success: t(".success")

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,5 +1,7 @@
 class SubscriptionsController < ApplicationController
   include ReturnPathTracking
+  include RecaptchaChecking
+
   self.authentication_scope = :jobseeker
 
   before_action :trigger_create_job_alert_clicked_event, only: :new, if: -> { vacancy_id.present? }
@@ -20,8 +22,7 @@ class SubscriptionsController < ApplicationController
     if @form.invalid?
       render :new
     elsif recaptcha_is_invalid?
-      redirect_to invalid_recaptcha_path(form_name: subscription.class.name.underscore.humanize,
-                                         recaptcha_score: recaptcha_reply["score"])
+      handle_invalid_recaptcha(form: @form, score: recaptcha_reply["score"])
     else
       notify_new_subscription(subscription)
 

--- a/app/controllers/support_requests_controller.rb
+++ b/app/controllers/support_requests_controller.rb
@@ -1,4 +1,6 @@
 class SupportRequestsController < ApplicationController
+  include RecaptchaChecking
+
   def new
     @form = SupportRequestForm.new
   end
@@ -9,8 +11,7 @@ class SupportRequestsController < ApplicationController
     if @form.invalid?
       render :new
     elsif recaptcha_is_invalid?
-      redirect_to invalid_recaptcha_path(form_name: @form.class.name.underscore.humanize,
-                                         recaptcha_score: recaptcha_reply["score"])
+      handle_invalid_recaptcha(form: @form, score: recaptcha_reply["score"])
     else
       Zendesk.create_request!(
         attachments: [@form.screenshot],

--- a/spec/controllers/jobseekers/subscriptions_controller_spec.rb
+++ b/spec/controllers/jobseekers/subscriptions_controller_spec.rb
@@ -1,0 +1,104 @@
+require "rails_helper"
+
+RSpec.describe SubscriptionsController, recaptcha: true do
+  describe "#create" do
+    let(:params) do
+      {
+        jobseekers_subscription_form: {
+          email: "foo@example.net",
+          frequency: "daily",
+          keyword: "english",
+        }.symbolize_keys,
+      }
+    end
+    subject { post :create, params: params }
+    let(:created_subscription) { Subscription.last }
+
+    before do
+      session[:subscription_origin] = "/some/where"
+    end
+
+    context "when verifying recaptcha" do
+      let(:recaptcha_score) { 0.9 }
+      let(:job_alert_params) do
+        {
+          email: "foo@example.net",
+          frequency: "daily",
+          search_criteria: { keyword: "english" },
+        }
+      end
+
+      let(:subscription) { instance_double(Subscription).as_null_object }
+      let(:form) { instance_double(Jobseekers::SubscriptionForm) }
+      let(:subscription_form_valid?) { true }
+
+      before do
+        allow(Subscription).to receive(:new).and_return(subscription)
+        allow(subscription).to receive(:id).and_return("abc123")
+        allow(subscription).to receive(:class).and_return(Subscription)
+        allow(Jobseekers::SubscriptionForm).to receive(:new).and_return(form)
+        allow(form).to receive(:job_alert_params).and_return(job_alert_params)
+        allow(form).to receive(:invalid?).and_return(!subscription_form_valid?)
+        allow(form).to receive(:class).and_return(Jobseekers::SubscriptionForm)
+        allow(controller).to receive(:recaptcha_reply).and_return({ "score" => recaptcha_score })
+        allow(controller).to receive(:verify_recaptcha).and_return(verify_recaptcha)
+      end
+
+      context "when verify_recaptcha is true" do
+        let(:verify_recaptcha) { true }
+
+        it "verifies the recaptcha" do
+          expect(controller).to receive(:verify_recaptcha)
+          subject
+        end
+
+        it "sends the action when it verifies the recaptcha" do
+          expect(controller).to receive(:verify_recaptcha)
+                                  .with(model: nil,
+                                        action: "subscriptions",
+                                        minimum_score: ApplicationController::SUSPICIOUS_RECAPTCHA_THRESHOLD)
+          subject
+        end
+
+        it "sets the recaptcha score on the Subscription record" do
+          expect(subscription).to receive(:update).with(recaptcha_score: recaptcha_score)
+          subject
+        end
+      end
+
+      context "when verify_recaptcha is false" do
+        let(:verify_recaptcha) { false }
+
+        before do
+          allow_any_instance_of(ApplicationController).to receive(:verify_recaptcha).and_return(false)
+        end
+
+        context "and subscription form is valid" do
+          it "redirects to invalid_recaptcha_path" do
+            subject
+            expect(response).to redirect_to(invalid_recaptcha_path(form_name: "Subscription", recaptcha_score: 0.9))
+          end
+
+          it "does not save the Subscription record" do
+            expect(subscription).not_to receive(:save)
+            subject
+          end
+        end
+
+        context "and subscription is not valid" do
+          let(:subscription_form_valid?) { false }
+
+          it "does not save the Subscription record" do
+            expect(subscription).not_to receive(:save)
+            subject
+          end
+
+          it "renders :new" do
+            subject
+            expect(response).to render_template(:new)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -23,12 +23,6 @@ RSpec.describe "Errors" do
   end
 
   describe "GET #invalid_recaptcha" do
-    it "sends the error to Sentry" do
-      expect(Sentry).to receive(:capture_message).with("Invalid recaptcha", { level: :warning })
-
-      get invalid_recaptcha_path, params: { form_name: "this form" }
-    end
-
     it "returns unauthorised" do
       get invalid_recaptcha_path
       expect(response).to have_http_status(:unauthorized)

--- a/spec/requests/recaptcha_spec.rb
+++ b/spec/requests/recaptcha_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe "General feedback can interface with recaptcha", recaptcha: true do
+  let(:feedback) { instance_double(Feedback).as_null_object }
+  let(:feedback_form) { instance_double(GeneralFeedbackForm) }
+
+  before do
+    allow(Feedback).to receive(:new).and_return(feedback)
+    allow(GeneralFeedbackForm).to receive(:new).and_return(feedback_form)
+    allow(feedback_form).to receive(:invalid?).and_return(false)
+    allow(feedback_form).to receive(:class).and_return(GeneralFeedbackForm)
+  end
+
+  it "sends the action, and minimum score (all required) when it verifies the recaptcha" do
+    expect_any_instance_of(ApplicationController).to receive(:verify_recaptcha)
+                      .with(model: nil,
+                            action: "general_feedbacks",
+                            minimum_score: ApplicationController::SUSPICIOUS_RECAPTCHA_THRESHOLD)
+    post feedback_path, params: { general_feedback_form: attributes_for(:feedback) }
+  end
+
+  it "sets the recaptcha score on the Feedback record" do
+    expect(feedback).to receive(:recaptcha_score=).with(0.9)
+    post feedback_path, params: { general_feedback_form: attributes_for(:feedback) }
+  end
+end

--- a/spec/requests/recaptcha_spec.rb
+++ b/spec/requests/recaptcha_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "General feedback can interface with recaptcha", recaptcha: true 
     expect_any_instance_of(ApplicationController).to receive(:verify_recaptcha)
                       .with(model: nil,
                             action: "general_feedbacks",
-                            minimum_score: ApplicationController::SUSPICIOUS_RECAPTCHA_THRESHOLD)
+                            minimum_score: GeneralFeedbacksController::SUSPICIOUS_RECAPTCHA_THRESHOLD)
     post feedback_path, params: { general_feedback_form: attributes_for(:feedback) }
   end
 

--- a/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
@@ -8,6 +8,21 @@ RSpec.describe "Jobseekers can create a job alert from a search", recaptcha: tru
   let(:jobseeker_signed_in?) { false }
   let(:jobseeker) { build_stubbed(:jobseeker) }
 
+  describe "recaptcha" do
+    context "when verify_recaptcha is false" do
+      before do
+        allow_any_instance_of(ApplicationController).to receive(:verify_recaptcha).and_return(false)
+      end
+
+      scenario "redirects to invalid_recaptcha path" do
+        visit new_subscription_path(search_criteria: { keyword: "test", location: "London" })
+        fill_in_subscription_fields
+        click_on I18n.t("buttons.subscribe")
+        expect(page).to have_current_path(invalid_recaptcha_path(form_name: "Subscription", recaptcha_score: 0.9))
+      end
+    end
+  end
+
   describe "job alert confirmation page" do
     before do
       login_as(jobseeker, scope: :jobseeker) if jobseeker_signed_in?

--- a/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Jobseekers can create a job alert from a search", recaptcha: tru
         visit new_subscription_path(search_criteria: { keyword: "test", location: "London" })
         fill_in_subscription_fields
         click_on I18n.t("buttons.subscribe")
-        expect(page).to have_current_path(invalid_recaptcha_path(form_name: "Subscription", recaptcha_score: 0.9))
+        expect(page).to have_current_path(invalid_recaptcha_path)
       end
     end
   end

--- a/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_the_dashboard_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_the_dashboard_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Jobseekers can create a job alert from the dashboard", recaptcha
           click_on I18n.t("jobseekers.subscriptions.index.link_create")
         end
         create_a_job_alert
-        expect(page).to have_current_path(invalid_recaptcha_path(form_name: "Subscription", recaptcha_score: 0.9))
+        expect(page).to have_current_path(invalid_recaptcha_path)
       end
     end
   end

--- a/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_the_dashboard_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_the_dashboard_spec.rb
@@ -25,6 +25,20 @@ RSpec.describe "Jobseekers can create a job alert from the dashboard", recaptcha
       expect { create_a_job_alert }.to change { Subscription.count }.by(1)
       and_the_job_alert_is_on_the_index_page
     end
+
+    context "when verify_recaptcha is false" do
+      before do
+        allow_any_instance_of(ApplicationController).to receive(:verify_recaptcha).and_return(false)
+      end
+
+      it "redirects to invalid_recaptcha path" do
+        within ".empty-section-component" do
+          click_on I18n.t("jobseekers.subscriptions.index.link_create")
+        end
+        create_a_job_alert
+        expect(page).to have_current_path(invalid_recaptcha_path(form_name: "Subscription", recaptcha_score: 0.9))
+      end
+    end
   end
 
   context "when the jobseeker has job alerts" do

--- a/spec/system/jobseekers/jobseekers_can_give_job_alert_feedback_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_give_job_alert_feedback_spec.rb
@@ -79,8 +79,28 @@ RSpec.describe "A jobseeker can give feedback on a job alert", recaptcha: true d
         expect(feedback.comment).to eq comment
         expect(feedback.email).to eq email
         expect(feedback.user_participation_response).to eq("interested")
-        # expect(feedback.recaptcha_score).to eq(0.9)
+        expect(feedback.recaptcha_score).to eq(0.9)
         expect(feedback.occupation).to eq(occupation)
+      end
+
+      context "when recaptcha is invalid" do
+        let(:verify_recaptcha) { false }
+
+        before { click_button I18n.t("buttons.submit") }
+
+        context "and the form is valid" do
+          scenario "redirects to invalid_recaptcha path" do
+            expect(page).to have_current_path(invalid_recaptcha_path(form_name: "Jobseekers job alert further feedback form", recaptcha_score: 0.9))
+          end
+        end
+
+        context "and the form is invalid" do
+          let(:comment) { nil }
+
+          scenario "does not redirect to invalid_recaptcha path" do
+            expect(page).to have_content("There is a problem")
+          end
+        end
       end
     end
   end

--- a/spec/system/jobseekers/jobseekers_can_give_job_alert_feedback_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_give_job_alert_feedback_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe "A jobseeker can give feedback on a job alert", recaptcha: true d
 
         context "and the form is valid" do
           scenario "redirects to invalid_recaptcha path" do
-            expect(page).to have_current_path(invalid_recaptcha_path(form_name: "Jobseekers job alert further feedback form", recaptcha_score: 0.9))
+            expect(page).to have_current_path(invalid_recaptcha_path)
           end
         end
 

--- a/spec/system/other/general_feedback_spec.rb
+++ b/spec/system/other/general_feedback_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Giving general feedback for the service", recaptcha: true do
 
       fill_in_general_feedback
       click_on I18n.t("buttons.submit_feedback")
-      expect(page).to have_current_path(invalid_recaptcha_path(form_name: "General feedback form", recaptcha_score: 0.9))
+      expect(page).to have_current_path(invalid_recaptcha_path)
     end
   end
 

--- a/spec/system/other/general_feedback_spec.rb
+++ b/spec/system/other/general_feedback_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Giving general feedback for the service", recaptcha: true do
                      occupation: occupation,
                      feedback_type: "general",
                      rating: "highly_satisfied",
-                     #  recaptcha_score: 0.9,
+                     recaptcha_score: 0.9,
                      user_participation_response: "interested",
                      visit_purpose: "other_purpose",
                      visit_purpose_comment: visit_purpose_comment,
@@ -30,6 +30,22 @@ RSpec.describe "Giving general feedback for the service", recaptcha: true do
     }.by(1)
 
     expect(page).to have_content(I18n.t("general_feedbacks.create.success"))
+  end
+
+  context "when recaptcha is invalid" do
+    before do
+      allow_any_instance_of(ApplicationController).to receive(:verify_recaptcha).and_return(false)
+    end
+
+    scenario "redirects to invalid_recaptcha path" do
+      visit new_feedback_path
+      click_on I18n.t("buttons.submit_feedback")
+      expect(page).to have_content("There is a problem")
+
+      fill_in_general_feedback
+      click_on I18n.t("buttons.submit_feedback")
+      expect(page).to have_current_path(invalid_recaptcha_path(form_name: "General feedback form", recaptcha_score: 0.9))
+    end
   end
 
   def fill_in_general_feedback

--- a/spec/system/other/get_help_spec.rb
+++ b/spec/system/other/get_help_spec.rb
@@ -59,6 +59,39 @@ RSpec.describe "Requesting support", recaptcha: true, vcr: true, zendesk: true d
     end
   end
 
+  context "when recaptcha is invalid" do
+    before do
+      allow_any_instance_of(ApplicationController).to receive(:verify_recaptcha).and_return(false)
+    end
+
+    context "and the form is valid" do
+      scenario "redirects to invalid_recaptcha path" do
+        visit root_path
+
+        click_on "Get help or report a problem"
+
+        expect(page).to have_content("Get help")
+
+        fill_in_required_fields
+
+        click_on "Send message"
+
+        expect(page).to have_current_path(invalid_recaptcha_path(form_name: "Support request form", recaptcha_score: 0.9))
+      end
+    end
+
+    context "and the form is invalid" do
+      scenario "does not redirect to invalid_recaptcha path" do
+        visit root_path
+
+        click_on "Get help or report a problem"
+        click_on "Send message"
+
+        expect(page).to have_content("There is a problem")
+      end
+    end
+  end
+
   def fill_in_required_fields(page: nil, screenshot: nil)
     fill_in "Name", with: "User In-Need"
     fill_in "Email", with: email

--- a/spec/system/other/get_help_spec.rb
+++ b/spec/system/other/get_help_spec.rb
@@ -67,16 +67,12 @@ RSpec.describe "Requesting support", recaptcha: true, vcr: true, zendesk: true d
     context "and the form is valid" do
       scenario "redirects to invalid_recaptcha path" do
         visit root_path
-
         click_on "Get help or report a problem"
-
         expect(page).to have_content("Get help")
 
         fill_in_required_fields
-
         click_on "Send message"
-
-        expect(page).to have_current_path(invalid_recaptcha_path(form_name: "Support request form", recaptcha_score: 0.9))
+        expect(page).to have_current_path(invalid_recaptcha_path)
       end
     end
 


### PR DESCRIPTION
## Trello card URL
Two tickets in one PR:
- https://trello.com/c/8jalfCz0
- https://trello.com/c/wSpTxvaZ

## Changes in this PR:
Recaptcha was disabled due to lots of false positives after a mailing list communication. Restoring it back.

We also noticed that every visit to the "recaptcha failed" page caused a new error being logged into Sentry.
If you're on the page and reload it, it sends a new "recaptcha error" to Sentry.
This causes lots of false positives due to bots visiting the page.

I resolved it by sending the error to Sentry only on the source of the error when the check was done and failed.

As part of this work, we extracted all the recaptcha-related controller code to a controller concern, and only included it on the relevant controllers that use recaptcha checks on their forms.