### PR TITLE
KCSIE: gaps in employment (profile)

### DIFF
--- a/app/controllers/jobseekers/profiles/breaks_controller.rb
+++ b/app/controllers/jobseekers/profiles/breaks_controller.rb
@@ -1,9 +1,9 @@
-class Jobseekers::JobApplications::BreaksController < Jobseekers::BaseController
-  helper_method :back_path, :employment_break, :form, :job_application
+class Jobseekers::Profiles::BreaksController < Jobseekers::ProfilesController
+  helper_method :back_path, :employment_break, :form
 
   def create
     if form.valid?
-      job_application.employments.break.create(employment_break_params)
+      profile.employments.break.create(employment_break_params)
       redirect_to back_path
     else
       render :new
@@ -11,6 +11,7 @@ class Jobseekers::JobApplications::BreaksController < Jobseekers::BaseController
   end
 
   def update
+    pry
     if form.valid?
       employment_break.update(employment_break_params)
       redirect_to back_path
@@ -27,11 +28,11 @@ class Jobseekers::JobApplications::BreaksController < Jobseekers::BaseController
   private
 
   def back_path
-    @back_path ||= jobseekers_job_application_build_path(job_application, :employment_history)
+    jobseekers_profile_path
   end
 
   def employment_break
-    job_application.employments.break.find(params[:id] || params[:break_id])
+    profile.employments.break.find(params[:id] || params[:break_id])
   end
 
   def employment_break_params
@@ -57,9 +58,5 @@ class Jobseekers::JobApplications::BreaksController < Jobseekers::BaseController
     when "create", "update"
       employment_break_params
     end
-  end
-
-  def job_application
-    @job_application ||= current_jobseeker.job_applications.draft.find(params[:job_application_id])
   end
 end

--- a/app/controllers/jobseekers/profiles/breaks_controller.rb
+++ b/app/controllers/jobseekers/profiles/breaks_controller.rb
@@ -11,7 +11,6 @@ class Jobseekers::Profiles::BreaksController < Jobseekers::ProfilesController
   end
 
   def update
-    pry
     if form.valid?
       employment_break.update(employment_break_params)
       redirect_to back_path

--- a/app/form_models/jobseekers/break_form.rb
+++ b/app/form_models/jobseekers/break_form.rb
@@ -1,4 +1,4 @@
-class Jobseekers::JobApplication::Details::BreakForm
+class Jobseekers::BreakForm
   include ActiveModel::Model
   include ActiveRecord::AttributeAssignment
   include DateAttributeAssignment

--- a/app/models/jobseeker_profile.rb
+++ b/app/models/jobseeker_profile.rb
@@ -83,4 +83,8 @@ class JobseekerProfile < ApplicationRecord
   def hidden_from_any_organisations?
     requested_hidden_profile && excluded_organisations.any?
   end
+
+  def unexplained_employment_gaps
+    @unexplained_employment_gaps ||= Jobseekers::JobApplications::EmploymentGapFinder.new(self).significant_gaps
+  end
 end

--- a/app/services/jobseekers/job_applications/employment_gap_finder.rb
+++ b/app/services/jobseekers/job_applications/employment_gap_finder.rb
@@ -1,11 +1,11 @@
 class Jobseekers::JobApplications::EmploymentGapFinder
-  def initialize(job_application)
-    @job_application = job_application
+  def initialize(record)
+    @record = record
     @today = Time.zone.today
   end
 
   def significant_gaps(threshold: 3.months)
-    job_application.employments.each_with_object({}) do |employment, gaps|
+    record.employments.each_with_object({}) do |employment, gaps|
       next if employment.current_role?
       next if gap_to_today_is_less_than_threshold?(employment, threshold)
       next if overlapping_employment?(employment)
@@ -20,14 +20,14 @@ class Jobseekers::JobApplications::EmploymentGapFinder
 
   private
 
-  attr_reader :job_application, :today
+  attr_reader :record, :today
 
   def gap_to_today_is_less_than_threshold?(employment, threshold)
     employment.ended_on + threshold >= today
   end
 
   def overlapping_employment?(employment)
-    job_application.employments.any? do |other|
+    record.employments.any? do |other|
       next if employment == other
       next if other.started_on.nil?
 
@@ -45,7 +45,7 @@ class Jobseekers::JobApplications::EmploymentGapFinder
   end
 
   def next_employment_start(employment)
-    job_application.employments
+    record.employments
       .reject { |other| other == employment }
       .map(&:started_on)
       .select { |started_on| started_on >= employment.ended_on }

--- a/app/views/jobseekers/employments/_employments.html.slim
+++ b/app/views/jobseekers/employments/_employments.html.slim
@@ -1,31 +1,44 @@
 - employments.sort_by { |e| e.current_role? ? Float::INFINITY : e.started_on }.reverse.each_with_index do |employment, index|
-  = render DetailComponent.new(title: employment.job_title) do |detail_component|
-    - detail_component.with_body do
-      = govuk_summary_list(classes: "govuk-!-margin-bottom-0") do |summary_list|
-        - summary_list.with_row(classes: "govuk-summary-list__row--no-actions") do |row|
-          - row.with_key text: t("jobseekers.employments.organisation")
-          - row.with_value text: employment.organisation
-        - summary_list.with_row(classes: "govuk-summary-list__row--no-actions") do |row|
-          - row.with_key text: t("jobseekers.employments.subjects")
-          - row.with_value text: employment.subjects
-        - summary_list.with_row(classes: "govuk-summary-list__row--no-actions") do |row|
-          - row.with_key text: t("jobseekers.employments.started_on")
-          - row.with_value text: employment.started_on.to_formatted_s(:month_year)
-        - summary_list.with_row do |row|
-          - row.with_key text: t("jobseekers.employments.current_role")
-          - row.with_value text: employment.current_role.humanize
-        - if employment.current_role == "no"
+  - if employment.job?
+    = render DetailComponent.new(title: employment.job_title) do |detail_component|
+      - detail_component.with_body do
+        = govuk_summary_list(classes: "govuk-!-margin-bottom-0") do |summary_list|
           - summary_list.with_row(classes: "govuk-summary-list__row--no-actions") do |row|
-            - row.with_key text: t("jobseekers.employments.ended_on")
-            - row.with_value text: employment.ended_on.to_formatted_s(:month_year)
-        - summary_list.with_row(classes: "govuk-summary-list__row--no-actions") do |row|
-          - row.with_key text: t("jobseekers.employments.main_duties")
-          - row.with_value text: employment.main_duties
-        - summary_list.with_row(classes: "govuk-summary-list__row--no-actions") do |row|
-          - row.with_key text: t(t("jobseekers.employments.reason_for_leaving"))
-          - row.with_value text: employment.reason_for_leaving
-    - detail_component.with_action govuk_link_to(t("buttons.change_hidden_text_html", hidden_text: employment.job_title), edit_jobseekers_profile_work_history_path(employment))
-    - detail_component.with_action govuk_link_to(t("buttons.delete_hidden_text_html", hidden_text: employment.job_title), jobseekers_profile_work_history_path(employment), method: :delete)
+            - row.with_key text: t("jobseekers.employments.organisation")
+            - row.with_value text: employment.organisation
+          - summary_list.with_row(classes: "govuk-summary-list__row--no-actions") do |row|
+            - row.with_key text: t("jobseekers.employments.subjects")
+            - row.with_value text: employment.subjects
+          - summary_list.with_row(classes: "govuk-summary-list__row--no-actions") do |row|
+            - row.with_key text: t("jobseekers.employments.started_on")
+            - row.with_value text: employment.started_on.to_formatted_s(:month_year)
+          - summary_list.with_row do |row|
+            - row.with_key text: t("jobseekers.employments.current_role")
+            - row.with_value text: employment.current_role.humanize
+          - if employment.current_role == "no"
+            - summary_list.with_row(classes: "govuk-summary-list__row--no-actions") do |row|
+              - row.with_key text: t("jobseekers.employments.ended_on")
+              - row.with_value text: employment.ended_on.to_formatted_s(:month_year)
+          - summary_list.with_row(classes: "govuk-summary-list__row--no-actions") do |row|
+            - row.with_key text: t("jobseekers.employments.main_duties")
+            - row.with_value text: employment.main_duties
+          - summary_list.with_row(classes: "govuk-summary-list__row--no-actions") do |row|
+            - row.with_key text: t(t("jobseekers.employments.reason_for_leaving"))
+            - row.with_value text: employment.reason_for_leaving
+      - detail_component.with_action govuk_link_to(t("buttons.change_hidden_text_html", hidden_text: employment.job_title), edit_jobseekers_profile_work_history_path(employment))
+      - detail_component.with_action govuk_link_to(t("buttons.delete_hidden_text_html", hidden_text: employment.job_title), jobseekers_profile_work_history_path(employment), method: :delete)
+  - elsif employment.break?
+    = govuk_inset_text do
+      h2.govuk-heading-s class="govuk-!-margin-bottom-1" = t(".break")
+      p.govuk-body class="govuk-!-margin-bottom-0" = employment.reason_for_break
+      p.govuk-hint class="govuk-!-margin-top-0 govuk-!-margin-bottom-1" #{employment.started_on.to_formatted_s(:month_year)} to #{employment.ended_on.to_formatted_s(:month_year)}
+      = govuk_link_to edit_jobseekers_profile_break_path(employment), class: "govuk-link--no-visited-state govuk-!-margin-right-3"
+        = t("buttons.change")
+        span.govuk-visually-hidden = " #{t('.break')} #{employment.started_on} to #{employment.ended_on}"
+      = govuk_link_to jobseekers_profile_break_confirm_destroy_path(employment)
+        = t("buttons.delete")
+        span.govuk-visually-hidden = " #{t('.break')} #{employment.started_on} to #{employment.ended_on}"
+
   - gap = employment.jobseeker_profile.unexplained_employment_gaps[employment]
   - if gap.present?
     = govuk_inset_text classes: "govuk-inset-text--blue" do

--- a/app/views/jobseekers/employments/_employments.html.slim
+++ b/app/views/jobseekers/employments/_employments.html.slim
@@ -23,7 +23,7 @@
             - row.with_key text: t("jobseekers.employments.main_duties")
             - row.with_value text: employment.main_duties
           - summary_list.with_row(classes: "govuk-summary-list__row--no-actions") do |row|
-            - row.with_key text: t(t("jobseekers.employments.reason_for_leaving"))
+            - row.with_key text: t("jobseekers.employments.reason_for_leaving")
             - row.with_value text: employment.reason_for_leaving
       - detail_component.with_action govuk_link_to(t("buttons.change_hidden_text_html", hidden_text: employment.job_title), edit_jobseekers_profile_work_history_path(employment))
       - detail_component.with_action govuk_link_to(t("buttons.delete_hidden_text_html", hidden_text: employment.job_title), jobseekers_profile_work_history_path(employment), method: :delete)

--- a/app/views/jobseekers/employments/_employments.html.slim
+++ b/app/views/jobseekers/employments/_employments.html.slim
@@ -1,4 +1,4 @@
-- employments.sort_by { |e| e.current_role? ? Float::INFINITY : e.started_on }.reverse.each_with_index do |employment, index|
+- employments.sort_by { |e| e.current_role? ? Float::INFINITY : e.started_on }.reverse_each do |employment|
   - if employment.job?
     = render DetailComponent.new(title: employment.job_title) do |detail_component|
       - detail_component.with_body do
@@ -34,10 +34,10 @@
       p.govuk-hint class="govuk-!-margin-top-0 govuk-!-margin-bottom-1" #{employment.started_on.to_formatted_s(:month_year)} to #{employment.ended_on.to_formatted_s(:month_year)}
       = govuk_link_to edit_jobseekers_profile_break_path(employment), class: "govuk-link--no-visited-state govuk-!-margin-right-3"
         = t("buttons.change")
-        span.govuk-visually-hidden = " #{t("jobseekers.employments.break")} #{employment.started_on} to #{employment.ended_on}"
+        span.govuk-visually-hidden = " #{t('jobseekers.employments.break')} #{employment.started_on} to #{employment.ended_on}"
       = govuk_link_to jobseekers_profile_break_confirm_destroy_path(employment)
         = t("buttons.delete")
-        span.govuk-visually-hidden = " #{t("jobseekers.employments.break")} #{employment.started_on} to #{employment.ended_on}"
+        span.govuk-visually-hidden = " #{t('jobseekers.employments.break')} #{employment.started_on} to #{employment.ended_on}"
 
   - gap = employment.jobseeker_profile.unexplained_employment_gaps[employment]
   - if gap.present?

--- a/app/views/jobseekers/employments/_employments.html.slim
+++ b/app/views/jobseekers/employments/_employments.html.slim
@@ -22,15 +22,15 @@
           - row.with_key text: t("jobseekers.employments.main_duties")
           - row.with_value text: employment.main_duties
         - summary_list.with_row(classes: "govuk-summary-list__row--no-actions") do |row|
-          - row.with_key text: t("jobseekers.employments.reason_for_leaving")
+          - row.with_key text: t(t("jobseekers.employments.reason_for_leaving"))
           - row.with_value text: employment.reason_for_leaving
     - detail_component.with_action govuk_link_to(t("buttons.change_hidden_text_html", hidden_text: employment.job_title), edit_jobseekers_profile_work_history_path(employment))
     - detail_component.with_action govuk_link_to(t("buttons.delete_hidden_text_html", hidden_text: employment.job_title), jobseekers_profile_work_history_path(employment), method: :delete)
   - gap = employment.jobseeker_profile.unexplained_employment_gaps[employment]
   - if gap.present?
     = govuk_inset_text classes: "govuk-inset-text--blue" do
-      p.govuk-body class="govuk-!-margin-bottom-0" = t(".gap_with_duration", duration: distance_of_time_in_words(gap[:started_on], gap[:ended_on]))
+      p.govuk-body class="govuk-!-margin-bottom-0" = t("jobseekers.employments.gap_with_duration", duration: distance_of_time_in_words(gap[:started_on], gap[:ended_on]))
       p.govuk-body
-        = govuk_link_to t(employments.job.none? ? "buttons.add_job" : "buttons.add_another_job"), new_jobseekers_job_application_employment_path(job_application)
+        = govuk_link_to t(employments.job.none? ? "buttons.add_job" : "buttons.add_another_job"), new_jobseekers_profile_work_history_path
         = " or "
-        = govuk_link_to t("buttons.add_reason_for_break"), new_jobseekers_job_application_break_path(job_application, started_on: gap[:started_on], ended_on: gap[:ended_on] || Date.current)
+        = govuk_link_to t("buttons.add_reason_for_break"), new_jobseekers_profile_break_path(started_on: gap[:started_on], ended_on: gap[:ended_on] || Date.current)

--- a/app/views/jobseekers/employments/_employments.html.slim
+++ b/app/views/jobseekers/employments/_employments.html.slim
@@ -1,4 +1,4 @@
-- employments.sort_by { |e| e.current_role? ? Float::INFINITY : e.started_on }.reverse_each do |employment|
+- employments.sort_by { |e| e.current_role? ? Float::INFINITY : e.started_on }.reverse.each_with_index do |employment, index|
   = render DetailComponent.new(title: employment.job_title) do |detail_component|
     - detail_component.with_body do
       = govuk_summary_list(classes: "govuk-!-margin-bottom-0") do |summary_list|
@@ -26,3 +26,11 @@
           - row.with_value text: employment.reason_for_leaving
     - detail_component.with_action govuk_link_to(t("buttons.change_hidden_text_html", hidden_text: employment.job_title), edit_jobseekers_profile_work_history_path(employment))
     - detail_component.with_action govuk_link_to(t("buttons.delete_hidden_text_html", hidden_text: employment.job_title), jobseekers_profile_work_history_path(employment), method: :delete)
+  - gap = employment.jobseeker_profile.unexplained_employment_gaps[employment]
+  - if gap.present?
+    = govuk_inset_text classes: "govuk-inset-text--blue" do
+      p.govuk-body class="govuk-!-margin-bottom-0" = t(".gap_with_duration", duration: distance_of_time_in_words(gap[:started_on], gap[:ended_on]))
+      p.govuk-body
+        = govuk_link_to t(employments.job.none? ? "buttons.add_job" : "buttons.add_another_job"), new_jobseekers_job_application_employment_path(job_application)
+        = " or "
+        = govuk_link_to t("buttons.add_reason_for_break"), new_jobseekers_job_application_break_path(job_application, started_on: gap[:started_on], ended_on: gap[:ended_on] || Date.current)

--- a/app/views/jobseekers/employments/_employments.html.slim
+++ b/app/views/jobseekers/employments/_employments.html.slim
@@ -29,15 +29,15 @@
       - detail_component.with_action govuk_link_to(t("buttons.delete_hidden_text_html", hidden_text: employment.job_title), jobseekers_profile_work_history_path(employment), method: :delete)
   - elsif employment.break?
     = govuk_inset_text do
-      h2.govuk-heading-s class="govuk-!-margin-bottom-1" = t(".break")
+      h2.govuk-heading-s class="govuk-!-margin-bottom-1" = t("jobseekers.employments.break")
       p.govuk-body class="govuk-!-margin-bottom-0" = employment.reason_for_break
       p.govuk-hint class="govuk-!-margin-top-0 govuk-!-margin-bottom-1" #{employment.started_on.to_formatted_s(:month_year)} to #{employment.ended_on.to_formatted_s(:month_year)}
       = govuk_link_to edit_jobseekers_profile_break_path(employment), class: "govuk-link--no-visited-state govuk-!-margin-right-3"
         = t("buttons.change")
-        span.govuk-visually-hidden = " #{t('.break')} #{employment.started_on} to #{employment.ended_on}"
+        span.govuk-visually-hidden = " #{t("jobseekers.employments.break")} #{employment.started_on} to #{employment.ended_on}"
       = govuk_link_to jobseekers_profile_break_confirm_destroy_path(employment)
         = t("buttons.delete")
-        span.govuk-visually-hidden = " #{t('.break')} #{employment.started_on} to #{employment.ended_on}"
+        span.govuk-visually-hidden = " #{t("jobseekers.employments.break")} #{employment.started_on} to #{employment.ended_on}"
 
   - gap = employment.jobseeker_profile.unexplained_employment_gaps[employment]
   - if gap.present?

--- a/app/views/jobseekers/job_applications/review/_employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/review/_employment_history.html.slim
@@ -42,7 +42,9 @@
             - row.with_value text: employment.reason_for_leaving
 
       - elsif employment.break?
+        / maybe this too?
         = render "jobseekers/job_applications/explained_employment_break", employment: employment, index: index
 
       - if (gap = job_application.unexplained_employment_gaps[employment]).present?
+        / this is what we need.
         = render("jobseekers/job_applications/unexplained_employment_break", gap:, index:)

--- a/app/views/jobseekers/job_applications/review/_employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/review/_employment_history.html.slim
@@ -42,9 +42,7 @@
             - row.with_value text: employment.reason_for_leaving
 
       - elsif employment.break?
-        / maybe this too?
         = render "jobseekers/job_applications/explained_employment_break", employment: employment, index: index
 
       - if (gap = job_application.unexplained_employment_gaps[employment]).present?
-        / this is what we need.
         = render("jobseekers/job_applications/unexplained_employment_break", gap:, index:)

--- a/app/views/jobseekers/profiles/breaks/_fields.html.slim
+++ b/app/views/jobseekers/profiles/breaks/_fields.html.slim
@@ -1,0 +1,7 @@
+= f.govuk_date_field :started_on,
+  omit_day: true,
+  hint: -> { t("helpers.hint.date", date: 15.months.ago.strftime("%m %Y")) }
+= f.govuk_date_field :ended_on,
+  omit_day: true,
+  hint: -> { t("helpers.hint.date", date: 3.months.ago.strftime("%m %Y")) }
+= f.govuk_text_area :reason_for_break, label: { size: "s" }, required: true

--- a/app/views/jobseekers/profiles/breaks/confirm_destroy.html.slim
+++ b/app/views/jobseekers/profiles/breaks/confirm_destroy.html.slim
@@ -1,0 +1,11 @@
+- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    span.govuk-caption-l = t(".caption")
+    h1.govuk-heading-xl = t(".heading")
+
+    = form_for form, url: jobseekers_profile_break_path(employment_break), method: :delete do |f|
+      = f.govuk_submit t("buttons.confirm_destroy"), class: "govuk-button--warning"
+
+    = govuk_link_to t("buttons.cancel"), jobseekers_profile_path

--- a/app/views/jobseekers/profiles/breaks/edit.html.slim
+++ b/app/views/jobseekers/profiles/breaks/edit.html.slim
@@ -1,0 +1,15 @@
+- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    span.govuk-caption-l = t(".caption")
+    h1.govuk-heading-xl = t(".heading")
+
+    = form_for form, url: jobseekers_profile_break_path(employment_break), method: :patch do |f|
+      = f.govuk_error_summary
+
+      = render "fields", f: f
+
+      = f.govuk_submit t("buttons.continue")
+
+    = govuk_link_to t("buttons.cancel"), jobseekers_profile_path(:employment_history)

--- a/app/views/jobseekers/profiles/breaks/new.html.slim
+++ b/app/views/jobseekers/profiles/breaks/new.html.slim
@@ -1,0 +1,15 @@
+- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    span.govuk-caption-l = t(".caption")
+    h1.govuk-heading-xl = t(".heading")
+
+    = form_for form, url: jobseekers_profile_breaks_path, method: :post do |f|
+      = f.govuk_error_summary
+
+      = render "fields", f: f
+
+      = f.govuk_submit t("buttons.continue")
+
+    = govuk_link_to t("buttons.cancel"), "/"

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -580,14 +580,14 @@ en:
           attributes:
             ended_on:
               after: End date must be after the start date
-              on_or_before: "The end of break can't be in the future"
-              blank: Enter the date the break finished
+              on_or_before: "The end of gap can't be in the future"
+              blank: Enter the date the gap finished
               invalid: Enter a date in the correct format
             reason_for_break:
               blank: Enter a reason for this gap
             started_on:
-              before: The date the break started must be in the past
-              blank: Enter the date you started the break
+              before: The date the gap started must be in the past
+              blank: Enter the date you started the gap
               invalid: Enter a date in the correct format
         jobseekers/job_application/details/employment_form:
           attributes:

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -576,7 +576,7 @@ en:
           attributes:
             withdraw_reason:
               inclusion: Select why you are withdrawing your application
-        jobseekers/job_application/details/break_form:
+        jobseekers/break_form:
           attributes:
             ended_on:
               after: End date must be after the start date
@@ -584,7 +584,7 @@ en:
               blank: Enter the date the break finished
               invalid: Enter a date in the correct format
             reason_for_break:
-              blank: Enter a reason for this break
+              blank: Enter a reason for this gap
             started_on:
               before: The date the break started must be in the past
               blank: Enter the date you started the break

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -137,7 +137,7 @@ en:
           You can find out whether you have the right to work in the UK on the
           <a href="https://www.gov.uk/" target="_blank" class="govuk-link">GOV.UK website (opens in new tab)</a>. You can apply for this role even if you do not have the
           right to work in the UK.
-      jobseekers_job_application_details_break_form:
+      jobseekers_break_form:
         reason_for_break: "For example, 'I was unemployed', 'I had health issues' or 'I was caring for a child'"
       jobseekers_job_application_details_employment_form:
         main_duties: Give a brief summary of your key responsibilities.
@@ -359,7 +359,7 @@ en:
         close_relationships_options:
           "no": "No"
           "yes": "Yes"
-      jobseekers_job_application_details_break_form:
+      jobseekers_break_form:
         reason_for_break: Enter reasons for break in work history
       jobseekers_job_application_details_employment_form:
         current_role_options:
@@ -851,7 +851,7 @@ en:
         gender: How would you describe your gender?
         orientation: How would you describe your sexual orientation?
         religion: What is your religion or belief?
-      jobseekers_job_application_details_break_form:
+      jobseekers_break_form:
         ended_on: End of break
         started_on: Start of break
       jobseekers_job_application_details_employment_form:
@@ -890,7 +890,6 @@ en:
         current_role: Are you still working in this role?
         ended_on: End date
         started_on: Start date
-
       jobseekers_subscription_form:
         frequency: When do you want to receive alerts?
       jobseekers_unsubscribe_feedback_form:

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -360,7 +360,7 @@ en:
           "no": "No"
           "yes": "Yes"
       jobseekers_break_form:
-        reason_for_break: Enter reasons for break in work history
+        reason_for_break: Enter reasons for gap in work history
       jobseekers_job_application_details_employment_form:
         current_role_options:
           "no": "No"
@@ -852,8 +852,8 @@ en:
         orientation: How would you describe your sexual orientation?
         religion: What is your religion or belief?
       jobseekers_break_form:
-        ended_on: End of break
-        started_on: Start of break
+        ended_on: End of gap
+        started_on: Start of gap
       jobseekers_job_application_details_employment_form:
         current_role: Is this your current role?
         ended_on: End date

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -2,7 +2,7 @@ en:
   buttons:
     accept_all_cookies: Accept all cookies
     accept_and_continue: Accept and continue
-    add_reason_for_break: add a reason for this break
+    add_reason_for_break: add a reason for this gap
     add_another_job: Add another job
     add_another_qualification: Add another qualification
     add_another_reference: Add another referee

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -48,6 +48,7 @@ en:
         confirm: Confirm
         title: Confirm your email address
     employments:
+      break: Break in work history
       current_role: Is this your current role?
       ended_on: End date
       main_duties: Main duties

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -55,7 +55,7 @@ en:
       started_on: Start date
       subjects: Subjects and key stages taught (optional)
       reason_for_leaving: Reason for leaving
-      gap_with_duration: You have a break in your work history (%{duration})
+      gap_with_duration: You have a gap in your work history (%{duration})
     forced_login:
       create_account: create an account
       job_application_html: You need to login or %{account_creation_link} with Teaching Vacancies to apply for this job.
@@ -562,15 +562,15 @@ en:
         confirm_destroy:
           caption: Current role and employment history
           heading: Are you sure you want to delete this entry?
-          title: Confirm deletion of a break — Application
+          title: Confirm deletion of a gap — Profile
         edit:
           caption: Current role and employment history
           heading: Please tell us what you were doing over this period
-          title: Change the reason of a break — Application
+          title: Change the reason of a gap — Profile
         new:
           caption: Current role and employment history
           heading: Please tell us what you were doing over this period
-          title: Add a reason for break — Application
+          title: Add a reason for gap — Profile
       hide_profile:
         add:
           cannot_find_school: I cannot find the school I'm looking for

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -55,6 +55,7 @@ en:
       started_on: Start date
       subjects: Subjects and key stages taught (optional)
       reason_for_leaving: Reason for leaving
+      gap_with_duration: You have a break in your work history (%{duration})
     forced_login:
       create_account: create an account
       job_application_html: You need to login or %{account_creation_link} with Teaching Vacancies to apply for this job.
@@ -557,6 +558,19 @@ en:
       success_html: >-
         You have saved this job. <a href="%{link}" class="govuk-link">View all your saved jobs</a> on your account.
     profiles:
+      breaks:
+        confirm_destroy:
+          caption: Current role and employment history
+          heading: Are you sure you want to delete this entry?
+          title: Confirm deletion of a break — Application
+        edit:
+          caption: Current role and employment history
+          heading: Please tell us what you were doing over this period
+          title: Change the reason of a break — Application
+        new:
+          caption: Current role and employment history
+          heading: Please tell us what you were doing over this period
+          title: Add a reason for break — Application
       hide_profile:
         add:
           cannot_find_school: I cannot find the school I'm looking for

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -48,7 +48,7 @@ en:
         confirm: Confirm
         title: Confirm your email address
     employments:
-      break: Break in work history
+      break: Gap in work history
       current_role: Is this your current role?
       ended_on: End date
       main_duties: Main duties
@@ -117,7 +117,7 @@ en:
             hint: "Give any relevant information"
             "no": "No"
         employment_history:
-          break: Break in work history
+          break: Gap in work history
           description:
             opening: >-
               Add details of all jobs you have had since you left full-time education. This should include:
@@ -127,7 +127,7 @@ en:
               - voluntary work, if it's relevant to your application
             closing: >-
               You will need to explain any gaps in your work history and the reason you left each role.
-          gap_with_duration: You have a break in your work history (%{duration})
+          gap_with_duration: You have a gap in your work history (%{duration})
           heading: Work history
           no_employments: No employment specified
           step_title: Employment history
@@ -218,15 +218,15 @@ en:
         confirm_destroy:
           caption: Current role and employment history
           heading: Are you sure you want to delete this entry?
-          title: Confirm deletion of a break — Application
+          title: Confirm deletion of a gap — Application
         edit:
           caption: Current role and employment history
           heading: Please tell us what you were doing over this period
-          title: Change the reason of a break — Application
+          title: Change the reason of a gap — Application
         new:
           caption: Current role and employment history
           heading: Please tell us what you were doing over this period
-          title: Add a reason for break — Application
+          title: Add a reason for gap — Application
       employments:
         current_role: This is my current role
         destroy:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,6 +98,10 @@ Rails.application.routes.draw do
         get :confirm_destroy
       end
 
+      resources :breaks, only: %i[new create edit update destroy], controller: "profiles/breaks" do
+        get :confirm_destroy
+      end
+
       resource :hide_profile, only: %i[show], controller: "profiles/hide_profile" do
         post :confirm_hide
         get :add

--- a/spec/support/jobseeker_helpers.rb
+++ b/spec/support/jobseeker_helpers.rb
@@ -67,11 +67,11 @@ module JobseekerHelpers
   end
 
   def fill_in_break_in_employment
-    fill_in "Enter reasons for break in work history", with: "Caring for a person"
-    fill_in "jobseekers_job_application_details_break_form[started_on(1i)]", with: "2020"
-    fill_in "jobseekers_job_application_details_break_form[started_on(2i)]", with: "08"
-    fill_in "jobseekers_job_application_details_break_form[ended_on(1i)]", with: "2020"
-    fill_in "jobseekers_job_application_details_break_form[ended_on(2i)]", with: "12"
+    fill_in "Enter reasons for gap in work history", with: "Caring for a person"
+    fill_in "jobseekers_break_form[started_on(1i)]", with: "2020"
+    fill_in "jobseekers_break_form[started_on(2i)]", with: "08"
+    fill_in "jobseekers_break_form[ended_on(1i)]", with: "2020"
+    fill_in "jobseekers_break_form[ended_on(2i)]", with: "12"
   end
 
   def fill_in_equal_opportunities

--- a/spec/system/jobseekers/jobseekers_can_add_employments_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_employments_to_their_job_application_spec.rb
@@ -82,16 +82,16 @@ RSpec.describe "Jobseekers can add employments and breaks to their job applicati
       expect(page).to have_content "You have a break in your work history (4 months)"
       click_on I18n.t("buttons.add_reason_for_break")
 
-      expect(page).to have_field("jobseekers_job_application_details_break_form_started_on_1i", with: "2021")
-      expect(page).to have_field("jobseekers_job_application_details_break_form_started_on_2i", with: "2")
-      expect(page).to have_field("jobseekers_job_application_details_break_form_ended_on_1i", with: "2021")
-      expect(page).to have_field("jobseekers_job_application_details_break_form_ended_on_2i", with: "6")
+      expect(page).to have_field("jobseekers_break_form_started_on_1i", with: "2021")
+      expect(page).to have_field("jobseekers_break_form_started_on_2i", with: "2")
+      expect(page).to have_field("jobseekers_break_form_ended_on_1i", with: "2021")
+      expect(page).to have_field("jobseekers_break_form_ended_on_2i", with: "6")
 
       click_on I18n.t("buttons.continue")
 
       expect(page).to have_content("There is a problem")
 
-      fill_in "Enter reasons for break in work history", with: "Travelling around the world"
+      fill_in "Enter reasons for gap in work history", with: "Travelling around the world"
       click_on I18n.t("buttons.continue")
 
       expect(page).to have_content("Travelling around the world")
@@ -99,12 +99,12 @@ RSpec.describe "Jobseekers can add employments and breaks to their job applicati
 
       click_on "Change Break in work history 2021-02-01 to 2021-06-01"
 
-      fill_in "Enter reasons for break in work history", with: ""
+      fill_in "Enter reasons for gap in work history", with: ""
       click_on I18n.t("buttons.continue")
 
       expect(page).to have_content("There is a problem")
 
-      fill_in "Enter reasons for break in work history", with: "Looking after my needy turtle"
+      fill_in "Enter reasons for gap in work history", with: "Looking after my needy turtle"
       click_on I18n.t("buttons.continue")
 
       expect(page).to have_content("Looking after my needy turtle")

--- a/spec/system/jobseekers/jobseekers_can_add_employments_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_employments_to_their_job_application_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "Jobseekers can add employments and breaks to their job applicati
 
     it "allows jobseekers to add, change and delete gaps in employment with prefilled start and end date" do
       visit jobseekers_job_application_build_path(job_application, :employment_history)
-      expect(page).to have_content "You have a break in your work history (4 months)"
+      expect(page).to have_content "You have a gap in your work history (4 months)"
       click_on I18n.t("buttons.add_reason_for_break")
 
       expect(page).to have_field("jobseekers_break_form_started_on_1i", with: "2021")
@@ -97,7 +97,7 @@ RSpec.describe "Jobseekers can add employments and breaks to their job applicati
       expect(page).to have_content("Travelling around the world")
       expect(page).to have_content("February 2021 to June 2021")
 
-      click_on "Change Break in work history 2021-02-01 to 2021-06-01"
+      click_on "Change Gap in work history 2021-02-01 to 2021-06-01"
 
       fill_in "Enter reasons for gap in work history", with: ""
       click_on I18n.t("buttons.continue")
@@ -109,7 +109,7 @@ RSpec.describe "Jobseekers can add employments and breaks to their job applicati
 
       expect(page).to have_content("Looking after my needy turtle")
 
-      click_on "Delete Break in work history 2021-02-01 to 2021-06-01"
+      click_on "Delete Gap in work history 2021-02-01 to 2021-06-01"
       click_on I18n.t("buttons.confirm_destroy")
 
       expect(page).not_to have_content("Looking after my needy turtle")

--- a/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
@@ -324,7 +324,6 @@ RSpec.describe "Jobseekers can manage their profile" do
     end
 
     context "if the jobseeker has a previous job application" do
-      include ActionView::Helpers::DateHelper
       let!(:previous_application) { create(:job_application, :status_submitted, jobseeker:, create_details: true) }
 
       it "prefills the form with the jobseeker's work history" do

--- a/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
@@ -278,12 +278,17 @@ RSpec.describe "Jobseekers can manage their profile" do
     end
 
     context "if the jobseeker has a previous job application" do
+      include ActionView::Helpers::DateHelper
       let!(:previous_application) { create(:job_application, :status_submitted, jobseeker:, create_details: true) }
 
       it "prefills the form with the jobseeker's work history" do
         visit jobseekers_profile_path
         previous_application.employments.each do |employment|
-          expect(page).to have_content(employment.organisation)
+          if employment.job?
+            expect(page).to have_content(employment.organisation)
+          elsif employment.break?
+            expect(page).to have_content("You have a gap in your work history")
+          end
         end
       end
     end

--- a/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
@@ -240,8 +240,8 @@ RSpec.describe "Jobseekers can manage their profile" do
           click_link "Return to profile"
 
           expect(page).to have_content "You have a gap in your work history (about 1 year)"
-          expect(page).to have_content "Add another job or add a reason for this break"
-          click_link "add a reason for this break"
+          expect(page).to have_content "Add another job or add a reason for this gap"
+          click_link "add a reason for this gap"
 
           click_button "Continue"
 
@@ -251,7 +251,7 @@ RSpec.describe "Jobseekers can manage their profile" do
 
           click_button "Continue"
 
-          expect(page).to have_css(".govuk-inset-text", text: "Break in work history")
+          expect(page).to have_css(".govuk-inset-text", text: "Gap in work history")
           within(".govuk-inset-text") do
             expect(page).to have_content("I was travelling")
             expect(page).to have_content("#{Date::MONTHNAMES[Date.today.month]} #{(Date.today - 1.year).year} to #{Date::MONTHNAMES[Date.today.month]} #{Date.today.year}")

--- a/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
@@ -245,15 +245,15 @@ RSpec.describe "Jobseekers can manage their profile" do
 
           click_button "Continue"
 
-          expect(page).to have_selector('.govuk-error-summary__list', text: 'Enter a reason for this gap')
+          expect(page).to have_selector(".govuk-error-summary__list", text: "Enter a reason for this gap")
 
           fill_in "jobseekers_break_form[reason_for_break]", with: "I was travelling"
 
           click_button "Continue"
 
-          expect(page).to have_css('.govuk-inset-text', text: 'Break in work history')
-          within('.govuk-inset-text') do
-            expect(page).to have_content('I was travelling')
+          expect(page).to have_css(".govuk-inset-text", text: "Break in work history")
+          within(".govuk-inset-text") do
+            expect(page).to have_content("I was travelling")
             expect(page).to have_content("#{Date::MONTHNAMES[Date.today.month]} #{(Date.today - 1.year).year} to #{Date::MONTHNAMES[Date.today.month]} #{Date.today.year}")
           end
         end

--- a/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
@@ -252,10 +252,32 @@ RSpec.describe "Jobseekers can manage their profile" do
           click_button "Continue"
 
           expect(page).to have_css(".govuk-inset-text", text: "Gap in work history")
+
+          gap = Employment.find_by(employment_type: "break")
+
           within(".govuk-inset-text") do
             expect(page).to have_content("I was travelling")
-            expect(page).to have_content("#{Date::MONTHNAMES[Date.today.month]} #{(Date.today - 1.year).year} to #{Date::MONTHNAMES[Date.today.month]} #{Date.today.year}")
+            expect(page).to have_content("#{Date::MONTHNAMES[gap.started_on.month]} #{gap.started_on.year} to #{Date::MONTHNAMES[gap.ended_on.month]} #{gap.ended_on.year}")
           end
+
+          click_on "Change Gap in work history #{gap.started_on} to #{gap.ended_on}"
+
+          fill_in "Enter reasons for gap in work history", with: ""
+          click_on I18n.t("buttons.continue")
+
+          expect(page).to have_content("There is a problem")
+
+          fill_in "Enter reasons for gap in work history", with: "I was ill"
+          click_on I18n.t("buttons.continue")
+
+          expect(page).to have_content("I was ill")
+
+          click_on "Delete Gap in work history #{gap.started_on} to #{gap.ended_on}"
+          click_on I18n.t("buttons.confirm_destroy")
+
+          expect(page).not_to have_content("I was ill")
+          expect(page).to have_content "You have a gap in your work history (about 1 year)"
+          expect(page).to have_content "Add another job or add a reason for this gap"
         end
       end
     end


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/jDtrhGbh/699-kcsie-gaps-in-employment-profile

## Changes in this PR:

- Adds gap highlighting to jobseeker profile work history.
- Allows users to add information about the gap in work history.
- Allows user to edit/destroy gap information.
- Refactors break form employment_gap_finder to work with both jobseeker profiles and jobseeker job applications.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
