### PR TITLE
Replace govuk_link_to method's no_visited_state argument

### DIFF
--- a/app/views/vacancies/listing/_key_dates_sidebar.html.slim
+++ b/app/views/vacancies/listing/_key_dates_sidebar.html.slim
@@ -2,7 +2,7 @@
   - if vacancy.expired? && similar_jobs.present?
     - timeline.with_heading(title: t("jobs.expired_listing.timeline_heading_with_similar_jobs_link_html",
                        date: format_date(vacancy.expires_at, :date_only),
-                       similar_jobs_link: govuk_link_to(t("jobs.similar_jobs.anchor_link_text"), "#similar-jobs", { no_visited_state: true })))
+                       similar_jobs_link: govuk_link_to(t("jobs.similar_jobs.anchor_link_text"), "#similar-jobs")))
   - elsif vacancy.expired?
     - timeline.with_heading(title: t("jobs.expired_listing.timeline_heading_html", date: format_date(vacancy.expires_at, :date_only)))
   - else


### PR DESCRIPTION
This PR addresses a breaking change that occurred when we upgraded our version of Gov UK Components, which impacted the govuk_link_to helper method. Previously, we were using the no_visited_state: true argument with this method to control the styling of visited links.

In the upgraded version, govuk_link_to method's signature has changed and it no longer accepts no_visited_state as a parameter. To resolve this issue, we have removed the no_visited_state argument from all govuk_link_to method calls


