### PR TITLE
Add DeleteOldFeedbackJob to remove feedbacks older than 5 years

### DIFF
--- a/app/jobs/delete_old_feedback_job.rb
+++ b/app/jobs/delete_old_feedback_job.rb
@@ -1,0 +1,7 @@
+class DeleteOldFeedbackJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Feedback.where("created_at <= ?", 5.years.ago).destroy_all
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -107,3 +107,8 @@ delete_jobseekers_with_incorrect_emails:
   cron: '30 2 * * 1'
   class: 'DeleteJobseekersWithIncorrectEmailsJob'
   queue: low
+
+delete_old_feedback:
+  cron: '0 3 * * *'
+  class: 'DeleteOldFeedbackJob'
+  queue: default

--- a/spec/jobs/delete_old_feedback_job_spec.rb
+++ b/spec/jobs/delete_old_feedback_job_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe DeleteOldFeedbackJob do
+  let!(:relevant_feedback) { create(:feedback, created_at: 4.years.ago) }
+  let!(:old_feedback) { create(:feedback, created_at: 6.years.ago) }
+
+  before do
+    allow(DisableExpensiveJobs).to receive(:enabled?).and_return(false)
+
+    described_class.perform_now
+  end
+
+  it "destroys old feedbacks" do
+    expect(Feedback.exists?(old_feedback.id)).to be false
+  end
+
+  it "does not destroy relevant feedbacks" do
+    expect(Feedback.exists?(relevant_feedback.id)).to be true
+  end
+end


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/EdjXktBI/753-supportal-feedback-auto-deletion

## Changes in this PR:

A new ActiveJob `DeleteOldFeedbackJob` has been added that finds all feedback older than 5 years and destroys them.
The job is scheduled to be run everyday at 3:00 AM


