### PR TITLE
Fix broken accordions on the service

### DIFF
--- a/app/views/layouts/_add_js_enabled_class_to_body.html.slim
+++ b/app/views/layouts/_add_js_enabled_class_to_body.html.slim
@@ -1,2 +1,2 @@
 = javascript_tag(nonce: true) do
-  | document.body.className = ((document.body.className) ? document.body.className + " js-enabled" : "js-enabled");
+  | document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');


### PR DESCRIPTION

## Trello card URL
- https://trello.com/c/ZtDLk1xD

## Changes in this PR:
Since we migrated to GovUK Components v5 our accordions got broken on the main page.

We were missing a step on the gem upgrade to avoid this happening.

Fix from the step 4. on the gem upgrade instructions:
- https://github.com/x-govuk/govuk-components/releases/tag/v5.0.0

## Screenshots of UI changes:

### Before
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/9f990036-4662-47ae-b9cc-a787bc293824)

### After

![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/02b80902-6710-408c-a5d7-97da64ec5c5c)

## Next steps: