### PR TITLE
Temporally disable job search pagination counting & sorting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
  # Alpine v3.18.
  # TODO: Regularly check in the alpine ruby "3.3.0-alpine3.18" images for its latest upgraded packages so we can remove
  # the hardcoded versions below when they have been updated in the alpine ruby image.
-ARG PROD_PACKAGES="imagemagick libxml2 libxslt libpq tzdata shared-mime-info openssl=3.1.4-r4"
+ARG PROD_PACKAGES="imagemagick libxml2 libxslt libpq tzdata shared-mime-info"
 
 FROM ruby:3.3.0-alpine3.18 AS builder
 

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -4,7 +4,7 @@ class VacanciesController < ApplicationController
 
   def index
     @vacancies_search = Search::VacancySearch.new(form.to_hash, sort: form.sort)
-    @pagy, @vacancies = pagy(@vacancies_search.vacancies, count: @vacancies_search.total_count)
+    @pagy, @vacancies = pagy_countless(@vacancies_search.vacancies)
 
     set_search_coordinates unless do_not_show_distance?
   end

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,4 +1,5 @@
 require "pagy/extras/overflow"
+require "pagy/extras/countless"
 
 Pagy::DEFAULT[:items] = 10
 Pagy::DEFAULT[:size] = [1, 1, 1, 1] # Design system recommendation

--- a/spec/system/jobseekers/jobseekers_can_search_for_jobs_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_search_for_jobs_spec.rb
@@ -8,13 +8,13 @@ RSpec.shared_examples "a successful search" do
       expect(page).to have_css("a", text: "Remove this filter Teacher")
     end
 
-    it "displays page 1 jobs" do
+    xit "displays page 1 jobs" do
       expect(page).to have_css(".search-results > .search-results__item", count: 2)
       expect(page).to have_content strip_tags(I18n.t("app.pagy_stats_html", from: 1, to: 2, total: 6, type: "results"))
     end
 
     context "when navigating between pages" do
-      it "displays page 3 jobs" do
+      xit "displays page 3 jobs" do
         within ".govuk-pagination" do
           click_on "3"
         end
@@ -33,7 +33,7 @@ RSpec.shared_examples "a successful search" do
       expect(page).to have_css("a", text: "Remove this filter Teacher")
     end
 
-    it "displays only the Maths jobs" do
+    xit "displays only the Maths jobs" do
       expect(page).to have_content strip_tags(I18n.t("app.pagy_stats_html", from: 1, to: 2, total: 2, type: "results"))
     end
 
@@ -116,7 +116,7 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
   end
 
   context "jobseekers can sort jobs by closing date" do
-    it "lists the jobs with the earliest closing date first" do
+    xit "lists the jobs with the earliest closing date first" do
       visit jobs_path
       select "Closing date", :from => "sort-by-field"
       click_button "Sort"
@@ -219,13 +219,13 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
         end
       end
 
-      it "orders by distance by default" do
+      xit "orders by distance by default" do
         expect(page).to have_select("sort_by", selected: "Distance")
         expect("Physics Teacher").to appear_before("Maths 1")
         expect("Maths 1").to appear_before("Maths Teacher 2")
       end
 
-      it "jobseekers can then choose to sort by different sort option", js: true do
+      xit "jobseekers can then choose to sort by different sort option", js: true do
         expect(page).to have_select("sort_by", selected: "Distance")
 
         select "Closing date", :from => "sort-by-field"

--- a/spec/system/jobseekers/jobseekers_can_view_all_the_jobs_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_view_all_the_jobs_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Jobseekers can view all the jobs" do
 
   describe "pagination" do
     shared_examples "jobseekers can view jobs and navigate between pages" do
-      scenario "jobseekers can view jobs and navigate between pages" do
+      xscenario "jobseekers can view jobs and navigate between pages" do
         expect(page).to have_css(".search-results > .search-results__item", count: 2)
         expect(page).to have_content "Showing 1 to 2 of 5 results"
 


### PR DESCRIPTION
There are severe performance issues on the COUNT queries used for the job search. Disabling the pagination counting for emergency purposes to monitor if this can help the DB server to survive until we identify the underlying issue causing the performance degradation int these queries.

- It disables the "Sort By" option on the search results.
- It shows only the current and next page on the pagination, then on the next page will show a further next page, etc
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/998dae1f-cb84-4151-bb00-ae06ad004404)
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/cbded36b-db0e-48eb-8ea7-7a993e59e86b)
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/a0d88d87-604c-4c1b-9c4b-670d19a22614)
