### PR TITLE
Remove results count from vacancy search results

### DIFF
--- a/app/views/vacancies/index.html.slim
+++ b/app/views/vacancies/index.html.slim
@@ -7,7 +7,7 @@
 = render "vacancies/search/page_title_and_description", landing_page: @landing_page
 
 h1 class="govuk-heading-l" role="heading" aria-level="1"
-  = t("jobs.search_result_heading", count: number_with_delimiter(@vacancies_search.total_count))
+  = "Jobs"
 
 - any_vacancies = @vacancies_search.total_count.positive?
 - if @vacancies_search.active_criteria? && any_vacancies

--- a/spec/system/jobseekers/jobseekers_can_view_landing_pages_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_view_landing_pages_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Jobseekers can view landing pages" do
 
     expect(page.title).to eq("Spiffy Part Time Potions and Sorcery Jobs - Teaching Vacancies - GOV.UK")
 
-    expect(page).to have_css("h1", text: "Jobs (1)")
+    expect(page).to have_css("h1", text: "Jobs")
     expect(page).to have_link("Head of Hogwarts")
   end
 end

--- a/spec/system/jobseekers/jobseekers_can_view_organisation_landing_pages_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_view_organisation_landing_pages_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Jobseekers can view organisation landing pages" do
       visit organisation_landing_page_path(school.slug)
 
       expect(page.title).to eq("School & Teaching Jobs at #{school.name} - Teaching Vacancies - GOV.UK")
-      expect(page).to have_css("h1", text: "Jobs (1)")
+      expect(page).to have_css("h1", text: "Jobs")
       expect(page).to have_link(vacancy.job_title.to_s)
       expect(page).to have_css("p", text: school.name)
     end
@@ -24,7 +24,7 @@ RSpec.describe "Jobseekers can view organisation landing pages" do
 
       expect(page.title).to eq("School & Teaching Jobs at #{school_group.name} - Teaching Vacancies - GOV.UK")
 
-      expect(page).to have_css("h1", text: "Jobs (2)")
+      expect(page).to have_css("h1", text: "Jobs")
       expect(page).to have_link(vacancy.job_title.to_s)
       expect(page).to have_link(vacancy2.job_title.to_s)
       expect(page).to have_css("p", text: school.name)


### PR DESCRIPTION
Temporal removal of the count due to DB performance issues. Meant to be reinstated after fixing the DB/query issues.
