### PR TITLE
Temporally disable ImportFromVacancySources job

### DIFF
--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -28,10 +28,11 @@ import_polygon_data:
   class: 'ImportPolygonDataJob'
   queue: low
 
-import_from_vacancy_sources:
-  cron: '55 6-21 * * *'
-  class: 'ImportFromVacancySourcesJob'
-  queue: default
+# Temporally disabled due to server performance issues
+# import_from_vacancy_sources:
+#   cron: '55 6-21 * * *'
+#   class: 'ImportFromVacancySourcesJob'
+#   queue: default
 
 queue_applications_received:
   cron: '0 6 * * *'

--- a/spec/configuration/sidekiq_scheduled_jobs_spec.rb
+++ b/spec/configuration/sidekiq_scheduled_jobs_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe "Sidekiq configuration" do
       Sentry::SendEventJob
       SetOrganisationSlugsJob
       SetOrganisationSlugsOfBatchJob
+      ImportFromVacancySourcesJob
     ]
   end
 


### PR DESCRIPTION
The times this job runs correlate with our server outage downtime times. 
I'm temporarily disabling it to see if it resolves our outage issues.
