### PR TITLE
Import vacancies parsing fixes

### DIFF
--- a/app/vacancy_sources/vacancy_source/source/ark.rb
+++ b/app/vacancy_sources/vacancy_source/source/ark.rb
@@ -131,8 +131,6 @@ class VacancySource::Source::Ark
   end
 
   def ect_status_for(item)
-    return unless item["ectSuitable"].presence
-
     item["ectSuitable"] == "yes" ? "ect_suitable" : "ect_unsuitable"
   end
 

--- a/app/vacancy_sources/vacancy_source/source/ark.rb
+++ b/app/vacancy_sources/vacancy_source/source/ark.rb
@@ -71,7 +71,7 @@ class VacancySource::Source::Ark
       external_advert_url: item["advertUrl", "engAts"],
       job_roles: job_roles_for(item),
       ect_status: ect_status_for(item),
-      subjects: item["subjects"].presence&.split(","),
+      subjects: item["subjects"].presence&.split(",") || [],
       working_patterns: working_patterns_for(item),
       contract_type: contract_type_for(item),
       phases: phases_for(item),

--- a/app/vacancy_sources/vacancy_source/source/broadbean.rb
+++ b/app/vacancy_sources/vacancy_source/source/broadbean.rb
@@ -96,9 +96,7 @@ class VacancySource::Source::Broadbean
   end
 
   def ect_status_for(item)
-    return unless item["ectSuitable"].presence
-
-    item["ectSuitable"] == "yes" ? "ect_suitable" : "ect_unsuitable"
+    item["ectSuitable"] == "true" ? "ect_suitable" : "ect_unsuitable"
   end
 
   def phase_for(item)

--- a/app/vacancy_sources/vacancy_source/source/broadbean.rb
+++ b/app/vacancy_sources/vacancy_source/source/broadbean.rb
@@ -59,7 +59,7 @@ class VacancySource::Source::Broadbean
       # New structured fields
       job_roles: job_roles_for(item),
       ect_status: ect_status_for(item),
-      subjects: item["subjects"].presence&.split(","),
+      subjects: item["subjects"].presence&.split(",") || [],
       working_patterns: item["workingPatterns"].presence&.split(","),
       contract_type: item["contractType"].presence,
       phases: phase_for(item),

--- a/app/vacancy_sources/vacancy_source/source/every.rb
+++ b/app/vacancy_sources/vacancy_source/source/every.rb
@@ -50,7 +50,7 @@ class VacancySource::Source::Every
       external_advert_url: item["advertUrl"],
       job_roles: job_roles_for(item),
       ect_status: ect_status_for(item),
-      subjects: item["subjects"].presence&.split(","),
+      subjects: item["subjects"].presence&.split(",") || [],
       working_patterns: item["workingPatterns"].presence&.split(","),
       contract_type: item["contractType"].presence,
       phases: phase_for(item),

--- a/app/vacancy_sources/vacancy_source/source/every.rb
+++ b/app/vacancy_sources/vacancy_source/source/every.rb
@@ -119,9 +119,7 @@ class VacancySource::Source::Every
   end
 
   def ect_status_for(item)
-    return unless item["ectSuitable"].presence
-
-    item["ectSuitable"].to_s == "true" ? "ect_suitable" : "ect_unsuitable"
+    item["ectSuitable"] == true ? "ect_suitable" : "ect_unsuitable"
   end
 
   def phase_for(item)

--- a/app/vacancy_sources/vacancy_source/source/fusion.rb
+++ b/app/vacancy_sources/vacancy_source/source/fusion.rb
@@ -112,9 +112,7 @@ class VacancySource::Source::Fusion
   end
 
   def ect_status_for(item)
-    return unless item["ect_suitable"].presence
-
-    item["ectSuitable"] == "yes" ? "ect_suitable" : "ect_unsuitable"
+    item["ectSuitable"] == true ? "ect_suitable" : "ect_unsuitable"
   end
 
   def phase_for(item)

--- a/app/vacancy_sources/vacancy_source/source/fusion.rb
+++ b/app/vacancy_sources/vacancy_source/source/fusion.rb
@@ -50,7 +50,7 @@ class VacancySource::Source::Fusion
       external_advert_url: item["advertUrl"],
       job_roles: job_roles_for(item),
       ect_status: ect_status_for(item),
-      subjects: item["subjects"].presence&.split(","),
+      subjects: item["subjects"].presence&.split(",") || [],
       working_patterns: item["workingPatterns"].presence&.split(","),
       contract_type: item["contractType"].presence,
       phases: phase_for(item),

--- a/app/vacancy_sources/vacancy_source/source/my_new_term.rb
+++ b/app/vacancy_sources/vacancy_source/source/my_new_term.rb
@@ -56,7 +56,7 @@ class VacancySource::Source::MyNewTerm
       external_advert_url: item["advertUrl"],
       job_roles: job_roles_for(item),
       ect_status: ect_status_for(item),
-      subjects: item["subjects"].presence,
+      subjects: item["subjects"].presence || [],
       working_patterns: item["workingPatterns"].presence,
       contract_type: item["contractType"]&.first,
       phases: phase_for(item),

--- a/app/vacancy_sources/vacancy_source/source/my_new_term.rb
+++ b/app/vacancy_sources/vacancy_source/source/my_new_term.rb
@@ -117,8 +117,6 @@ class VacancySource::Source::MyNewTerm
   end
 
   def ect_status_for(item)
-    return unless item["ectSuitable"].presence
-
     item["ectSuitable"] == true ? "ect_suitable" : "ect_unsuitable"
   end
 

--- a/app/vacancy_sources/vacancy_source/source/united_learning.rb
+++ b/app/vacancy_sources/vacancy_source/source/united_learning.rb
@@ -104,8 +104,6 @@ class VacancySource::Source::UnitedLearning
   end
 
   def ect_status_for(item)
-    return unless item["ect_suitable"].presence
-
     item["ect_suitable"] == "yes" ? "ect_suitable" : "ect_unsuitable"
   end
 

--- a/app/vacancy_sources/vacancy_source/source/united_learning.rb
+++ b/app/vacancy_sources/vacancy_source/source/united_learning.rb
@@ -62,7 +62,7 @@ class VacancySource::Source::UnitedLearning
       # New structured fields
       job_roles: job_roles_for(item),
       ect_status: ect_status_for(item),
-      subjects: item["Subjects"].presence&.split(","),
+      subjects: item["Subjects"].presence&.split(",") || [],
       working_patterns: working_patterns_for(item),
       contract_type: item["Contract_type"].presence,
       phases: phase_for(item),

--- a/app/vacancy_sources/vacancy_source/source/ventrus.rb
+++ b/app/vacancy_sources/vacancy_source/source/ventrus.rb
@@ -58,7 +58,7 @@ class VacancySource::Source::Ventrus
       job_roles: job_roles_for(item),
       ect_status: ect_status_for(item),
       key_stages: item["Key_Stage"].presence&.split(","),
-      # subjects: item["Subjects"].presence&.split(","),
+      # subjects: item["Subjects"].presence&.split(",") || [], # Ventrus don't have subjects in their feed
       working_patterns: item["Working_Patterns"].presence&.split(","),
       contract_type: item["Contract_Type"].presence,
       phases: phase_for(item),

--- a/app/vacancy_sources/vacancy_source/source/ventrus.rb
+++ b/app/vacancy_sources/vacancy_source/source/ventrus.rb
@@ -67,9 +67,10 @@ class VacancySource::Source::Ventrus
   end
 
   def ect_status_for(item)
-    return unless item["ECT_Suitable"].presence
-
-    item["ECT_Suitable"] == "yes" ? "ect_suitable" : "ect_unsuitable"
+    case item["ECT_Suitable"]
+    when "True", "true" then "ect_suitable"
+    else "ect_unsuitable"
+    end
   end
 
   def organisation_fields(schools)

--- a/spec/vacancy_sources/vacancy_source/source/broadbean_spec.rb
+++ b/spec/vacancy_sources/vacancy_source/source/broadbean_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe VacancySource::Source::Broadbean do
         contract_type: "parental_leave_cover",
         phases: %w[primary],
         visa_sponsorship_available: true,
+        ect_status: "ect_suitable",
       }
     end
 

--- a/spec/vacancy_sources/vacancy_source/source/every_spec.rb
+++ b/spec/vacancy_sources/vacancy_source/source/every_spec.rb
@@ -269,6 +269,38 @@ RSpec.describe VacancySource::Source::Every do
     end
   end
 
+  describe "ect suitability mapping" do
+    let(:response_body) do
+      JSON.parse(super()).tap { |h|
+        h["result"].first["ectSuitable"] = ect_suitability
+      }.to_json
+    end
+
+    context "when the vacancy is suitable for an ECT" do
+      let(:ect_suitability) { true }
+
+      it "sets the vacancy as suitable for an ECT" do
+        expect(vacancy.ect_status).to eq("ect_suitable")
+      end
+    end
+
+    context "when the vacancy is not suitable for an ECT" do
+      let(:ect_suitability) { false }
+
+      it "sets the vacancy as not suitable for an ECT" do
+        expect(vacancy.ect_status).to eq("ect_unsuitable")
+      end
+    end
+
+    context "when the vacancy suitability for an ECT is not provided" do
+      let(:ect_suitability) { nil }
+
+      it "sets the vacancy as not suitable for an ECT" do
+        expect(vacancy.ect_status).to eq("ect_unsuitable")
+      end
+    end
+  end
+
   context "when school associated with vacancy is of excluded type" do
     before do
       school1.update(detailed_school_type: "Other independent school")

--- a/spec/vacancy_sources/vacancy_source/source/fusion_spec.rb
+++ b/spec/vacancy_sources/vacancy_source/source/fusion_spec.rb
@@ -192,6 +192,38 @@ RSpec.describe VacancySource::Source::Fusion do
       end
     end
 
+    describe "ect suitability mapping" do
+      let(:response_body) do
+        JSON.parse(super()).tap { |h|
+          h["result"].first["ectSuitable"] = ect_suitability
+        }.to_json
+      end
+
+      context "when the vacancy is suitable for an ECT" do
+        let(:ect_suitability) { true }
+
+        it "sets the vacancy as suitable for an ECT" do
+          expect(vacancy.ect_status).to eq("ect_suitable")
+        end
+      end
+
+      context "when the vacancy is not suitable for an ECT" do
+        let(:ect_suitability) { false }
+
+        it "sets the vacancy as not suitable for an ECT" do
+          expect(vacancy.ect_status).to eq("ect_unsuitable")
+        end
+      end
+
+      context "when the vacancy suitability for an ECT is not provided" do
+        let(:ect_suitability) { nil }
+
+        it "sets the vacancy as not suitable for an ECT" do
+          expect(vacancy.ect_status).to eq("ect_unsuitable")
+        end
+      end
+    end
+
     context "when the same vacancy has been imported previously" do
       let!(:existing_vacancy) do
         create(

--- a/spec/vacancy_sources/vacancy_source/source/my_new_term_spec.rb
+++ b/spec/vacancy_sources/vacancy_source/source/my_new_term_spec.rb
@@ -252,6 +252,38 @@ RSpec.describe VacancySource::Source::MyNewTerm do
     end
   end
 
+  describe "ect suitability mapping" do
+    let(:job_listings_response_body) do
+      JSON.parse(super()).tap { |h|
+        h["data"]["jobs"].first["ectSuitable"] = ect_suitability
+      }.to_json
+    end
+
+    context "when the vacancy is suitable for an ECT" do
+      let(:ect_suitability) { true }
+
+      it "sets the vacancy as suitable for an ECT" do
+        expect(vacancy.ect_status).to eq("ect_suitable")
+      end
+    end
+
+    context "when the vacancy is not suitable for an ECT" do
+      let(:ect_suitability) { false }
+
+      it "sets the vacancy as not suitable for an ECT" do
+        expect(vacancy.ect_status).to eq("ect_unsuitable")
+      end
+    end
+
+    context "when the vacancy suitability for an ECT is not provided" do
+      let(:ect_suitability) { nil }
+
+      it "sets the vacancy as not suitable for an ECT" do
+        expect(vacancy.ect_status).to eq("ect_unsuitable")
+      end
+    end
+  end
+
   describe "vacancy organisation parsing" do
     let(:trust_uid) { school_group.uid }
     let(:school_urns) { [in_scope_school.urn] }

--- a/spec/vacancy_sources/vacancy_source/source/ventrus_spec.rb
+++ b/spec/vacancy_sources/vacancy_source/source/ventrus_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe VacancySource::Source::Ventrus do
         contract_type: "permanent",
         phases: %w[secondary],
         visa_sponsorship_available: true,
+        ect_status: "ect_suitable",
       }
     end
 


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/CnIP5aPf

## Changes in this PR:

Two main fixes:
- Ect Suitable values were incorrectly parsed across all the vacancies.
- When comparing already stored vacancies with the same vacancy coming from the feed, if the vacancy has no subjects, trying to store it as `nil` caused Rails to take it as a different value from the stored `[]` for the subjects and ends re-saving the vacancy (that had no changes). This happens for hundreds of vacancies in some feeds like MyNewTerm.
Avoid this by assigning `[]` to the field in the parsing instead of `nil`.


