### PR TITLE
Remove leading&trailing spaces from MyNewTerm texts

### DIFF
--- a/app/vacancy_sources/vacancy_source/source/my_new_term.rb
+++ b/app/vacancy_sources/vacancy_source/source/my_new_term.rb
@@ -49,11 +49,11 @@ class VacancySource::Source::MyNewTerm
 
   def attributes_for(item, schools)
     {
-      job_title: item["jobTitle"],
-      job_advert: item["jobAdvert"],
-      salary: item["salary"],
+      job_title: item["jobTitle"]&.strip,
+      job_advert: item["jobAdvert"]&.strip,
+      salary: item["salary"]&.strip,
       expires_at: Time.zone.parse(item["expiresAt"]),
-      external_advert_url: item["advertUrl"],
+      external_advert_url: item["advertUrl"]&.strip,
       job_roles: job_roles_for(item),
       ect_status: ect_status_for(item),
       subjects: item["subjects"].presence || [],


### PR DESCRIPTION
- https://trello.com/c/CnIP5aPf

These fields are stripped when stored in our DB, but the presence of leading/trailing spaces in the feed makes the imported vacancy be considered as changed from the information already stored in DB, causing a further DB save.

Striping the leading and trailing spaces when parsing the fields avoids this issue.
