### PR TITLE
Feature/rbac db backup

### DIFF
--- a/.github/workflows/backup_production_db.yml
+++ b/.github/workflows/backup_production_db.yml
@@ -55,9 +55,13 @@ jobs:
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
 
+    - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
+      with:
+        azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+
     - name: K8 setup for staging
       run: |
-        make get-cluster-credentials CLUSTER_RESOURCE_GROUP_NAME=s189p01-tsc-pd-rg CLUSTER_NAME=s189p01-tsc-production-aks
+        make production get-cluster-credentials CONFIRM_PRODUCTION=YES
         make bin/konduit.sh
 
     - name: Backup production DB


### PR DESCRIPTION
Trello card
https://trello.com/c/3m8PNLG6/937-enable-azure-rbac-deployment-on-all-services

Context
After adding RBAC, the production db backup was failing. this is the fix by adding the missing env to make and also putting kubelogin before get cluster credentials 

Changes proposed in this pull request
Update workflow 

Guidance to review
by running the production db backup job