### PR TITLE
Fix Ark trust uid

### DIFF
--- a/app/vacancy_sources/vacancy_source/source/ark.rb
+++ b/app/vacancy_sources/vacancy_source/source/ark.rb
@@ -4,7 +4,7 @@ class VacancySource::Source::Ark
 
   FEED_URL = ENV.fetch("VACANCY_SOURCE_ARK_FEED_URL").freeze
   SOURCE_NAME = "ark".freeze
-  TRUST_UID = "4243".freeze
+  TRUST_UID = "2157".freeze
 
   # Helper class for less verbose handling of items in the feed
   class FeedItem


### PR DESCRIPTION
The constant containing Ark trust uid was containing Ventrus trust uid instead.

This caused the vacancies for Ark being wrongly associated with Ventrus trust instead.
