### PR TITLE
Limit Dev and Test env log files size

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -78,4 +78,6 @@ Rails.application.configure do
   config.action_view.annotate_rendered_view_with_filenames = true
 
   config.i18n.raise
+
+  config.log_file_size = 100.megabytes
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -67,6 +67,8 @@ Rails.application.configure do
   require "fake_dsi_sign_out_endpoint"
   ENV["DFE_SIGN_IN_ISSUER"] = "http://fake.dsi.example.com"
   config.middleware.insert_before 0, FakeDSISignOutEndpoint
+
+  config.log_file_size = 100.megabytes
 end
 
 # Avoid OmniAuth output in tests:


### PR DESCRIPTION
New Rails 7.1 feature allows us to limit the size of the log files for development and test environments.

Setting them to max 100MB to avoid them growing out of control.
