### PR TITLE
Treat gracefully the Pagy::OverflowError exception

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -1,12 +1,14 @@
 class VacanciesController < ApplicationController
   before_action :set_landing_page, only: %i[index]
-  after_action :trigger_search_performed_event, only: %i[index]
 
   def index
     @vacancies_search = Search::VacancySearch.new(form.to_hash, sort: form.sort)
     @pagy, @vacancies = pagy_countless(@vacancies_search.vacancies)
 
     set_search_coordinates unless do_not_show_distance?
+    trigger_search_performed_event
+  rescue Pagy::OverflowError
+    redirect_to not_found_path
   end
 
   def show


### PR DESCRIPTION
When bots land into Vacancy Search Results URLs with pagination parameter over the maximum number of pages, Pagy triggers a Pagy::OverflowError.

Resolving it by capturing this particular exception and redirecting the request to the 404/Not Found page.

[Error in Sentry](https://teaching-vacancies.sentry.io/issues/4920406189/?environment=production&project=6212514&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=0)