### PR TITLE
Deduplicate scopes on vacancy search query

### DIFF
--- a/app/queries/vacancy_filter_query.rb
+++ b/app/queries/vacancy_filter_query.rb
@@ -1,7 +1,7 @@
 class VacancyFilterQuery < ApplicationQuery
   attr_reader :scope
 
-  def initialize(scope = Vacancy.live)
+  def initialize(scope = Vacancy.all)
     @scope = scope
   end
 

--- a/app/queries/vacancy_full_text_search_query.rb
+++ b/app/queries/vacancy_full_text_search_query.rb
@@ -1,7 +1,7 @@
 class VacancyFullTextSearchQuery < ApplicationQuery
   attr_reader :scope
 
-  def initialize(scope = Vacancy.live)
+  def initialize(scope = Vacancy.all)
     @scope = scope
   end
 

--- a/app/queries/vacancy_location_query.rb
+++ b/app/queries/vacancy_location_query.rb
@@ -1,5 +1,5 @@
 class VacancyLocationQuery < LocationQuery
-  def initialize(scope = Vacancy.live)
+  def initialize(scope = Vacancy.all)
     @scope = scope
   end
 


### PR DESCRIPTION
The ActiveRecord chained scopes built by the VacancySearch service resulted in a SQL query that contained repeated conditions:
- The "published" state is checked multiple times.
- The "publish_on" and "expires_at" values are checked multiple times.

It is caused by combining multiple scopes initialized as `Vacancy.live`

This makes the logs and debugging harder to read, and even if the performance difference is negligible (I'm pretty sure PostgreSQL optimises this), it is better to tidy this up to avoid repeated conditions in the queries.

Also, having a scope definition (meant to be chained) relying on the "live" scope is unnecessary and may induce mistakes (I wouldn't assume a Location/Filter scope also chains the "live" scope to the query).

## Examples of the same search

### Before
```
"SELECT COUNT(DISTINCT \"vacancies\".\"id\") 
FROM \"vacancies\" 
LEFT OUTER JOIN \"organisation_vacancies\"  ON \"organisation_vacancies\".\"vacancy_id\" = \"vacancies\".\"id\" 
LEFT OUTER JOIN \"organisations\" ON \"organisations\".\"id\" = \"organisation_vacancies\".\"organisation_id\" 
INNER JOIN location_polygons\n      ON ST_DWithin(vacancies.geolocation, location_polygons.area, 16090) 
WHERE \"vacancies\".\"status\" = $1 
AND (publish_on <= '2024-02-06') 
AND (expires_at >= '2024-02-06 20:43:18.124890') 
AND \"vacancies\".\"status\" = $2 
AND (publish_on <= '2024-02-06') 
AND (expires_at >= '2024-02-06 20:43:18.125089') 
AND (location_polygons.id = '43dd7de1-54ce-430d-852e-c1b8724a2b04') AND \"vacancies\".\"status\" = $3 
AND (publish_on <= '2024-02-06') 
AND (expires_at >= '2024-02-06 20:43:18.126414') 
AND (job_roles && ARRAY[6])", :binds => { :status => [ 0, 0, 0 ] }
```

### After
```
"SELECT COUNT(DISTINCT \"vacancies\".\"id\") 
FROM \"vacancies\" 
LEFT OUTER JOIN \"organisation_vacancies\" ON \"organisation_vacancies\".\"vacancy_id\" = \"vacancies\".\"id\" 
LEFT OUTER JOIN \"organisations\" ON \"organisations\".\"id\" = \"organisation_vacancies\".\"organisation_id\" 
INNER JOIN location_polygons\n      ON ST_DWithin(vacancies.geolocation, location_polygons.area, 16090) WHERE \"vacancies\".\"status\" = $1 
AND (publish_on <= '2024-02-07') 
AND (expires_at >= '2024-02-07 00:11:10.776547') 
AND (location_polygons.id = '43dd7de1-54ce-430d-852e-c1b8724a2b04') 
AND (job_roles && ARRAY[6])", :binds => { :status => 0 }
```