### PR TITLE
Reduce LocationPolygons DB queries per search

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -54,7 +54,7 @@ class VacanciesController < ApplicationController
   def trigger_search_performed_event
     fail_safe do
       vacancy_ids = @vacancies.pluck(:id)
-      polygon_id = DfE::Analytics.anonymise(@vacancies_search.location_search.polygon.id) if @vacancies_search.location_search.polygon
+      polygon_id = DfE::Analytics.anonymise(@vacancies_search.polygon.id) if @vacancies_search.polygon
 
       event_data = {
         search_criteria: form.to_hash,
@@ -91,6 +91,6 @@ class VacanciesController < ApplicationController
     # This is because the coordinates Google (or other providers) use for London (for example) could be miles away from the location of the school, even if the school is
     # actually in London which could potentially confuse jobseekers.
     normalised_query = form.to_hash[:location]&.strip&.downcase
-    normalised_query.nil? || LocationQuery::NATIONWIDE_LOCATIONS.include?(normalised_query) || LocationPolygon.contain?(normalised_query)
+    normalised_query.nil? || LocationQuery::NATIONWIDE_LOCATIONS.include?(normalised_query) || @vacancies_search.polygon.present?
   end
 end

--- a/app/services/search/location_builder.rb
+++ b/app/services/search/location_builder.rb
@@ -8,21 +8,18 @@ class Search::LocationBuilder
   attr_reader :location, :location_filter, :polygon, :radius
 
   def initialize(location, radius)
+    @radius_builder = Search::RadiusBuilder.new(location, radius)
     @location = location
-    @radius = Search::RadiusBuilder.new(location, radius).radius
+    @radius = @radius_builder.radius
     @location_filter = {}
 
     if NATIONWIDE_LOCATIONS.include?(@location&.downcase)
       @location = nil
-    elsif search_with_polygons?
+    elsif @radius_builder.polygon.present?
       @polygon = LocationPolygon.buffered(@radius).with_name(location)
     elsif @location.present?
       @location_filter = build_location_filter
     end
-  end
-
-  def search_with_polygons?
-    location.present? && LocationPolygon.contain?(location)
   end
 
   def point_coordinates

--- a/app/services/search/radius_builder.rb
+++ b/app/services/search/radius_builder.rb
@@ -2,10 +2,11 @@ class Search::RadiusBuilder
   DEFAULT_RADIUS_FOR_POINT_SEARCHES = 10
   DEFAULT_BUFFER_FOR_POLYGON_SEARCHES = 0
 
-  attr_reader :radius
+  attr_reader :radius, :polygon
 
   def initialize(location, radius)
     @location = location
+    @polygon = LocationPolygon.with_name(location) if location.present?
     @radius = get_radius(radius)
   end
 
@@ -14,9 +15,9 @@ class Search::RadiusBuilder
   attr_reader :location
 
   def get_radius(radius)
-    return DEFAULT_BUFFER_FOR_POLYGON_SEARCHES unless location.present?
-
-    if !search_with_polygons? && radius.to_s == DEFAULT_BUFFER_FOR_POLYGON_SEARCHES.to_s
+    if location.blank?
+      DEFAULT_BUFFER_FOR_POLYGON_SEARCHES
+    elsif polygon.blank? && radius.to_s == DEFAULT_BUFFER_FOR_POLYGON_SEARCHES.to_s
       DEFAULT_RADIUS_FOR_POINT_SEARCHES
     else
       Integer(radius || default_radius).abs
@@ -24,10 +25,6 @@ class Search::RadiusBuilder
   end
 
   def default_radius
-    search_with_polygons? ? DEFAULT_BUFFER_FOR_POLYGON_SEARCHES : DEFAULT_RADIUS_FOR_POINT_SEARCHES
-  end
-
-  def search_with_polygons?
-    location.present? && LocationPolygon.contain?(location)
+    polygon.present? ? DEFAULT_BUFFER_FOR_POLYGON_SEARCHES : DEFAULT_RADIUS_FOR_POINT_SEARCHES
   end
 end

--- a/app/services/search/vacancy_search.rb
+++ b/app/services/search/vacancy_search.rb
@@ -1,6 +1,6 @@
 class Search::VacancySearch
   extend Forwardable
-  def_delegators :location_search, :point_coordinates
+  def_delegators :location_search, :point_coordinates, :polygon
 
   attr_reader :search_criteria, :keyword, :location, :radius, :organisation_slug, :sort
 
@@ -58,7 +58,7 @@ class Search::VacancySearch
     sort_by_distance = sort.by == "distance"
     scope = Vacancy.live.includes(:organisations)
     scope = scope.where(id: organisation.all_vacancies.pluck(:id)) if organisation
-    scope = scope.search_by_location(location, radius, sort_by_distance: sort_by_distance) if location
+    scope = scope.search_by_location(location, radius, polygon:, sort_by_distance:) if location
     scope = scope.search_by_filter(search_criteria) if search_criteria.any?
     scope = scope.search_by_full_text(keyword) if keyword.present?
     order_scope(scope, sort_by_distance)

--- a/spec/services/search/location_builder_spec.rb
+++ b/spec/services/search/location_builder_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Search::LocationBuilder do
   let(:radius) { 10 }
   let(:expected_radius) { 1000 }
   let!(:location_polygon) { create(:location_polygon, name: "london") }
-  let(:radius_builder) { instance_double(Search::RadiusBuilder, radius: 1000) }
+  let(:radius_builder) { instance_double(Search::RadiusBuilder, radius: 1000, polygon: location_polygon) }
 
   before do
     allow(Search::RadiusBuilder).to receive(:new).with(location, radius).and_return(radius_builder)
@@ -42,6 +42,8 @@ RSpec.describe Search::LocationBuilder do
     context "when a non-polygonable location is specified" do
       let(:radius_in_metres) { expected_radius * 1_609 }
       let(:location) { point_location }
+
+      before { allow(radius_builder).to receive(:polygon).and_return(nil) }
 
       it "sets radius attribute, and location filter around the location" do
         expect(subject.polygon).to be_nil

--- a/spec/services/search/radius_builder_spec.rb
+++ b/spec/services/search/radius_builder_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe Search::RadiusBuilder do
 
   describe "#initialize" do
     context "when a non-polygonable location is specified" do
+      before { allow(LocationPolygon).to receive(:with_name).with(location).and_return(nil) }
+
       context "when no radius is specified" do
         let(:radius) { nil }
 
@@ -46,7 +48,9 @@ RSpec.describe Search::RadiusBuilder do
     end
 
     context "when a polygonable location is specified" do
-      before { allow(LocationPolygon).to receive(:contain?).with(location).and_return(true) }
+      let(:polygon) { instance_double(LocationPolygon) }
+
+      before { allow(LocationPolygon).to receive(:with_name).with(location).and_return(polygon) }
 
       context "when no radius is specified" do
         let(:radius) { nil }

--- a/spec/services/search/vacancy_search_spec.rb
+++ b/spec/services/search/vacancy_search_spec.rb
@@ -38,13 +38,16 @@ RSpec.describe Search::VacancySearch do
   let(:visa_sponsorship_availability) { nil }
   let(:school) { create(:school) }
   let(:scope) { double("scope", count: 870) }
+  let(:polygon) { instance_double(LocationPolygon) }
+  let(:location_builder) { instance_double(Search::LocationBuilder, polygon:) }
 
   before do
     allow(subject).to receive(:organisation).and_return(school)
     allow(school).to receive_message_chain(:all_vacancies, :pluck).and_return(vacancy_ids)
+    allow(Search::LocationBuilder).to receive(:new).with(location, radius).and_return(location_builder)
     allow(Vacancy).to receive(:live).and_return(scope)
     allow(scope).to receive(:includes).with(:organisations).and_return(scope)
-    allow(scope).to receive(:search_by_location).with("Louth", 10, { sort_by_distance: false }).and_return(scope)
+    allow(scope).to receive(:search_by_location).with("Louth", 10, { polygon:, sort_by_distance: false }).and_return(scope)
     allow(scope).to receive(:search_by_filter).and_return(scope)
     allow(scope).to receive(:search_by_full_text).with("maths teacher").and_return(scope)
     allow(scope).to receive(:where).with(id: vacancy_ids).and_return(scope)


### PR DESCRIPTION
Multiple bits that build up the vacancies search results call over and over the LocationPolygons DB search for the same location.

Reducing this to a minimum by:
- Memoizing the search for polygon from the first time it gets queried.
- Injecting this polygon into subsequent search bits, so it doesn't need to be queried from DB again.


## Screenshots of UI changes:

### Before: 7 DB calls
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/7e8a6e23-3f46-4fb6-832c-d66a90106ce1)

### After: 3 DB calls
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/240c8811-1dcb-4429-a46e-e44af337a588)
