### PR TITLE
Vacancy search db queries improvements

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -53,7 +53,6 @@ class VacanciesController < ApplicationController
 
   def trigger_search_performed_event
     fail_safe do
-      vacancy_ids = @vacancies.pluck(:id)
       polygon_id = DfE::Analytics.anonymise(@vacancies_search.polygon.id) if @vacancies_search.polygon
 
       event_data = {
@@ -61,7 +60,7 @@ class VacanciesController < ApplicationController
         sort_by: form.sort.by,
         page: params[:page] || 1,
         total_count: @vacancies_search.total_count,
-        vacancies_on_page: vacancy_ids,
+        vacancies_on_page: @vacancies.map(&:id),
         location_polygon_used: polygon_id,
         landing_page: params[:landing_page_slug],
         filters_set_from_keywords: form.filters_from_keyword.present?,

--- a/app/services/search/vacancy_search.rb
+++ b/app/services/search/vacancy_search.rb
@@ -49,7 +49,7 @@ class Search::VacancySearch
   end
 
   def total_count
-    @total_count ||= vacancies.count(:id)
+    @total_count ||= vacancies.size
   end
 
   private

--- a/app/views/vacancies/search/_sort.html.slim
+++ b/app/views/vacancies/search/_sort.html.slim
@@ -1,2 +1,2 @@
-  - if vacancies_search.sort.many? && vacancies.count(:id) > 1
+  - if vacancies_search.sort.many? && vacancies.many?
     = render SortComponent.new path: method(:jobs_path), sort: vacancies_search.sort, url_params: form.to_hash, display_type: "inline-select"

--- a/spec/services/search/vacancy_search_spec.rb
+++ b/spec/services/search/vacancy_search_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Search::VacancySearch do
   let(:school_types) { nil }
   let(:visa_sponsorship_availability) { nil }
   let(:school) { create(:school) }
-  let(:scope) { double("scope", count: 870) }
+  let(:scope) { double("scope", size: 870) }
   let(:polygon) { instance_double(LocationPolygon) }
   let(:location_builder) { instance_double(Search::LocationBuilder, polygon:) }
 
@@ -63,7 +63,7 @@ RSpec.describe Search::VacancySearch do
 
   describe "wider suggestions" do
     context "when results are returned" do
-      let(:scope) { double("scope", count: 870) }
+      let(:scope) { double("scope", size: 870) }
 
       it "does not offer suggestions" do
         expect(subject.wider_search_suggestions).to be_nil
@@ -71,7 +71,7 @@ RSpec.describe Search::VacancySearch do
     end
 
     context "when no results are returned" do
-      let(:scope) { double("scope", count: 0) }
+      let(:scope) { double("scope", size: 0) }
       let(:suggestions_builder) { double(suggestions: [1, 2, 3]) }
 
       before do


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/rUep7Tw1/809-performance-issues-analyze-and-improve-vacancy-search-results-counting-query

## Changes in this PR:

There are 2 improvements:
1. Remove 2 DB queries per search.
2. Simplify queries by removing 2 `LEFT OUTER JOIN` statements from every search.

### [Remove unnecessary DB calls on vacancy search results](https://github.com/DFE-Digital/teaching-vacancies/commit/2a5129697c963eff684e8254de676e13ea702bb0)
1 - Remove `pluck` call for Analytics Event

We have the vacancies already loaded in memory. Plucking the id's triggers
an unnecessary extra DB query.

2 - Remove DB query from results sorting partial.

The `count` triggers a DB query. Rely on the vacancies collection to check
if has more than one element instead.

The behaviour is the same, we save 2 extra DB queries per search/results
page.

### [Avoid unnecessary table joins from count queries](https://github.com/DFE-Digital/teaching-vacancies/pull/6657/commits/9da641c3f71e51d058743884ac77ed7c48f452ae)

For the Vacancy count method, relying on "size" instead of
`count(:id)` transforms the query into a simpler one, saving two `LEFT
OUTER JOIN` calls.

This is a weird one.

If we count methods as used to do originally before the sorting by
distance:
- `vacancies.count`
Then the formed query would raise a malformed SQL syntax error with the
sort by distance.

With the current implementation to make it compatible with the sort by
distance:
- `vacancies.count(:id)`
Then the count query weirdly forces LEFT OUTER JOIN relationships with
both "organisations" and "organisation_vacancies". This is odd as these
joins are triggered even when we are not filtering by any organisation
value. Those overcomplicate the query, when it doesn't seem to be any
need for it.

If, instead, we rely on the "size" method:
- `vacancies.size`
Then the count query doesn't do any join with the organisation or
organisation_vacancies tables if we don't filter by org fields.
And if we filter by org fields, it does simple inner joins.

## Before

```
def total_count
  @total_count ||= vacancies.count(:id)
end

(11.5ms) ActiveRecord -- Vacancy Count -- { :sql => "SELECT COUNT(DISTINCT \"vacancies\".\"id\") 
                                                      FROM \"vacancies\" 
                                                      LEFT OUTER JOIN \"organisation_vacancies\" ON \"organisation_vacancies\".\"vacancy_id\" = \"vacancies\".\"id\" 
                                                      LEFT OUTER JOIN \"organisations\" ON \"organisations\".\"id\" = \"organisation_vacancies\".\"organisation_id\" 
                                                      INNER JOIN location_polygons\n      ON ST_DWithin(vacancies.geolocation, location_polygons.area, 16090) 
                                                      WHERE \"vacancies\".\"status\" = $1 
                                                      AND (publish_on <= '2024-02-08') 
                                                      AND (expires_at >= '2024-02-08 23:19:28.224577') 
                                                      AND (location_polygons.id = '43dd7de1-54ce-430d-852e-c1b8724a2b04') 
                                                      AND (job_roles && ARRAY[6])", 
                                             :binds => { :status => 0 }, :allocations => 347, :cached => nil }
```
## After
```
def total_count
  @total_count ||= vacancies.size
end

(11.3ms) ActiveRecord -- Vacancy Count -- { :sql => "SELECT COUNT(*) 
                                                     FROM \"vacancies\" 
                                                     INNER JOIN location_polygons ON ST_DWithin(vacancies.geolocation, location_polygons.area, 16090) 
                                                     WHERE \"vacancies\".\"status\" = $1 
                                                     AND (publish_on <= '2024-02-08') 
                                                     AND (expires_at >= '2024-02-08 23:34:17.899635') 
                                                     AND (location_polygons.id = '43dd7de1-54ce-430d-852e-c1b8724a2b04') 
                                                     AND (job_roles && ARRAY[6])", 
                                            :binds => { :status => 0 }, :allocations => 347, :cached => nil }
```
