### PR TITLE
Add multicolumn index for vacancies search with distance

### DIFF
--- a/db/migrate/20240209180737_add_geolocation_and_timestamps_index_to_vacancy.rb
+++ b/db/migrate/20240209180737_add_geolocation_and_timestamps_index_to_vacancy.rb
@@ -2,6 +2,8 @@ class AddGeolocationAndTimestampsIndexToVacancy < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 
   def change
+    enable_extension "btree_gist"
+
     add_index :vacancies, [:geolocation, :expires_at, :publish_on], using: :gist, algorithm: :concurrently
     remove_index :vacancies, column: :geolocation, name: "index_vacancies_on_geolocation", algorithm: :concurrently
   end

--- a/db/migrate/20240209180737_add_geolocation_and_timestamps_index_to_vacancy.rb
+++ b/db/migrate/20240209180737_add_geolocation_and_timestamps_index_to_vacancy.rb
@@ -1,0 +1,8 @@
+class AddGeolocationAndTimestampsIndexToVacancy < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :vacancies, [:geolocation, :expires_at, :publish_on], using: :gist, algorithm: :concurrently
+    remove_index :vacancies, column: :geolocation, name: "index_vacancies_on_geolocation", algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_31_115602) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_09_180737) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "btree_gist"
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -636,7 +637,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_31_115602) do
     t.boolean "visa_sponsorship_available"
     t.index ["expires_at"], name: "index_vacancies_on_expires_at"
     t.index ["external_source", "external_reference"], name: "index_vacancies_on_external_source_and_external_reference"
-    t.index ["geolocation"], name: "index_vacancies_on_geolocation", using: :gist
+    t.index ["geolocation", "expires_at", "publish_on"], name: "index_vacancies_on_geolocation_and_expires_at_and_publish_on", using: :gist
     t.index ["publish_on"], name: "index_vacancies_on_publish_on"
     t.index ["publisher_id"], name: "index_vacancies_on_publisher_id"
     t.index ["publisher_organisation_id"], name: "index_vacancies_on_publisher_organisation_id"

--- a/terraform/app/modules/paas/aks_database.tf
+++ b/terraform/app/modules/paas/aks_database.tf
@@ -12,7 +12,7 @@ module "postgres" {
   use_azure                      = var.deploy_azure_backing_services
   azure_enable_backup_storage    = var.azure_enable_backup_storage
   azure_enable_monitoring        = var.enable_monitoring
-  azure_extensions               = ["pgcrypto", "fuzzystrmatch", "plpgsql", "pg_trgm", "postgis"]
+  azure_extensions               = ["btree_gist", "pgcrypto", "fuzzystrmatch", "plpgsql", "pg_trgm", "postgis"]
   azure_sku_name                 = var.postgres_flexible_server_sku
   azure_enable_high_availability = var.postgres_enable_high_availability
   server_version                 = 14

--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -127,7 +127,7 @@ locals {
   worker_app_start_command            = "bundle exec sidekiq -C config/sidekiq.yml"
   worker_app_name                     = "${var.service_name}-worker-${var.environment}"
 
-  postgres_extensions = { enable_extensions = ["pgcrypto", "fuzzystrmatch", "plpgsql", "pg_trgm", "postgis"] }
+  postgres_extensions = { enable_extensions = ["btree_gist", "pgcrypto", "fuzzystrmatch", "plpgsql", "pg_trgm", "postgis"] }
 
   # AKS
   # Use the AKS ingress domain by default. Override with the DOMAIN variable is present


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/rUep7Tw1/809-performance-issues-analyze-and-improve-vacancy-search-results-counting-query

## Changes in this PR:
When searching vacancies filtering by distance to a location, there is a noticeable performance difference between the current approach taken by the db optimizer:
- scanning multiple vacancies table indexes and then combining the results.
versus the approach proposed by this work:
- scan a unique index combining both the geolocation data and the timestamps used to filter all the searches.

Making the index search as restrictive as possible, while using criteria used by all the vacancy searches that use distance filtering, removes a lot of overhead from the query planner to combine results and filter them afterwards.

Comparing both approaches locally with the same Polygon Search query, the multicolumn index search is consistently **between 2x and 3x times faster in its execution time**.

### Note
Removing the original geolocation index as any possible usage has been covered by the new combined one:
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/3d649fac-2080-4079-a04e-c6c4ac2126d2)

### Why choose those fields for the index?

Every single search that involves geolocation in the service will also filter for live vacancies (published state, published on the date, not expired on the date).

The published state is irrelevant here as if the results passed the date filters, will be published almost for sure.

Other conditions (job role, phases, etc) may be present or not on the search, so are better left outside the index. This will ensure this index is used by any search that calculates the distance of the results.

## Screenshots of changes:

### Before:
#### Using independent indices on the `geolocation` and `expires_at` field for the vacancy
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/ab5fdac1-5968-419a-bb1f-3c871849c849)
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/ea284f53-43d5-4c6b-9eba-1bbbe7d8c5f0)


### After
#### Using the new combined index for `geolocation`, `expires_at` and `publish_on`
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/efb65599-3fc2-4f34-9994-e1dace70ea32)
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/733cd146-5c72-4466-950d-fe0ea21fdc65)

## Next steps:

I have already enabled the `btree_gist` extension on Azure DBs. This is needed to allow non-supported by default attributes (EG: the timestamp without timezone) to be added to a gist index.

**We need to confirm with infra team that plugins enabled through the web interface will stay enabled between deployments. Do not merge until we know so.**