### PR TITLE
Add masked policy tags to BigQ PII fields

### DIFF
--- a/lib/base_dsi_exporter.rb
+++ b/lib/base_dsi_exporter.rb
@@ -4,6 +4,8 @@ require "google/cloud/bigquery"
 class BaseDSIBigQueryExporter
   include DFESignIn
 
+  POLICY_TAG_MASKED = "projects/teacher-vacancy-service/locations/europe-west2/taxonomies/3297834668207407318/policyTags/6333608070544109307".freeze
+
   attr_reader :dataset
 
   def initialize(bigquery: Google::Cloud::Bigquery.new)

--- a/lib/export_dsi_approvers_to_big_query.rb
+++ b/lib/export_dsi_approvers_to_big_query.rb
@@ -31,9 +31,9 @@ class ExportDSIApproversToBigQuery < BaseDSIBigQueryExporter
 
   def insert_table_data(batch)
     dataset.insert TABLE_NAME, present_for_big_query(batch), autocreate: true do |schema|
-      schema.string "email", mode: :required
-      schema.string "family_name", mode: :required
-      schema.string "given_name", mode: :required
+      schema.string "email", mode: :required, policy_tags: [POLICY_TAG_MASKED]
+      schema.string "family_name", mode: :required, policy_tags: [POLICY_TAG_MASKED]
+      schema.string "given_name", mode: :required, policy_tags: [POLICY_TAG_MASKED]
       schema.integer "la_code", mode: :nullable
       schema.string "role_id", mode: :required
       schema.string "role_name", mode: :required

--- a/lib/export_dsi_users_to_big_query.rb
+++ b/lib/export_dsi_users_to_big_query.rb
@@ -33,9 +33,9 @@ class ExportDSIUsersToBigQuery < BaseDSIBigQueryExporter
   def insert_table_data(batch)
     dataset.insert TABLE_NAME, present_for_big_query(batch), autocreate: true do |schema|
       schema.timestamp "approval_datetime", mode: :nullable
-      schema.string "email", mode: :nullable
-      schema.string "family_name", mode: :nullable
-      schema.string "given_name", mode: :nullable
+      schema.string "email", mode: :nullable, policy_tags: [POLICY_TAG_MASKED]
+      schema.string "family_name", mode: :nullable, policy_tags: [POLICY_TAG_MASKED]
+      schema.string "given_name", mode: :nullable, policy_tags: [POLICY_TAG_MASKED]
       schema.integer "la_code", mode: :nullable
       schema.string "role", mode: :nullable
       schema.integer "school_urn", mode: :nullable


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/nPHRjKlN

## Changes in this PR:

When pushing the DSI users data to Google BigQ, a policy tag for masking data is applied to users PII columns.

Only accounts with masking privileges will be able to view this info in plain when using Google BigQ.
