### PR TITLE
update privacy policy link throughout site

### DIFF
--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -17,7 +17,6 @@ class SitemapController < ApplicationController
       end
 
       # Static pages
-      m.add page_path("privacy-policy"), period: "weekly"
       m.add page_path("terms-and-conditions"), period: "weekly"
       m.add page_path("cookies"), period: "weekly"
       m.add page_path("accessibility"), period: "weekly"

--- a/app/helpers/notify_views_helper.rb
+++ b/app/helpers/notify_views_helper.rb
@@ -65,7 +65,7 @@ module NotifyViewsHelper
   end
 
   def privacy_policy_link
-    url = page_url("privacy-policy", **utm_params)
+    url = "https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/privacy-information-education-providers-workforce-including-teachers"
     notify_link(url, t(".privacy_policy_link"))
   end
 

--- a/app/views/jobseekers/job_applications/new.html.slim
+++ b/app/views/jobseekers/job_applications/new.html.slim
@@ -21,4 +21,4 @@ h2.govuk-heading-xl = t("jobseekers.job_applications.heading")
 
   .govuk-grid-column-one-third
     h2.govuk-heading-m = t(".assistance.heading")
-    p.govuk-body-s = t(".assistance.content_html", privacy_html: govuk_link_to(t(".assistance.privacy"), page_path("privacy-policy")), terms_html: govuk_link_to(t(".assistance.terms"), page_path("terms-and-conditions")))
+    p.govuk-body-s = t(".assistance.content_html", privacy_html: govuk_link_to(t(".assistance.privacy"), "https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/privacy-information-education-providers-workforce-including-teachers"), terms_html: govuk_link_to(t(".assistance.terms"), page_path("terms-and-conditions")))

--- a/app/views/jobseekers/job_applications/new_quick_apply.html.slim
+++ b/app/views/jobseekers/job_applications/new_quick_apply.html.slim
@@ -14,4 +14,4 @@ h2.govuk-heading-xl = t("jobseekers.job_applications.heading")
 
   .govuk-grid-column-one-third
     h2.govuk-heading-m = t(".assistance.heading")
-    p.govuk-body-s = t(".assistance.content_html", privacy_html: govuk_link_to(t(".assistance.privacy"), page_path("privacy-policy")), terms_html: govuk_link_to(t(".assistance.terms"), page_path("terms-and-conditions")))
+    p.govuk-body-s = t(".assistance.content_html", privacy_html: govuk_link_to(t(".assistance.privacy"), "https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/privacy-information-education-providers-workforce-including-teachers"), terms_html: govuk_link_to(t(".assistance.terms"), page_path("terms-and-conditions")))

--- a/app/views/jobseekers/job_applications/review.html.slim
+++ b/app/views/jobseekers/job_applications/review.html.slim
@@ -41,7 +41,7 @@
 
         p.govuk-body
           = t(".confirmation.how_we_use_your_data.privacy_policy.description_html",
-              link_to: govuk_link_to(t(".confirmation.how_we_use_your_data.privacy_policy.link_text"), page_path("privacy-policy")))
+              link_to: govuk_link_to(t(".confirmation.how_we_use_your_data.privacy_policy.link_text"), "https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/privacy-information-education-providers-workforce-including-teachers"))
 
         = f.govuk_check_boxes_fieldset :confirm_data_usage, multiple: false, legend: nil do
           = f.govuk_check_box :confirm_data_usage, "1", 0, multiple: false, link_errors: true

--- a/spec/mailers/publishers/job_application_data_expiry_mailer_spec.rb
+++ b/spec/mailers/publishers/job_application_data_expiry_mailer_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Publishers::JobApplicationDataExpiryMailer do
                                                                                                                                       expiration_date: vacancy_data_expiration_date))
                                .and include(I18n.t("publishers.job_application_data_expiry_mailer.job_application_data_expiry.expiry", job_title: vacancy.job_title,
                                                                                                                                        expiration_date: vacancy_data_expiration_date))
-      expect(mail.body.to_s).to include(page_url("privacy-policy"))
+      expect(mail.body.to_s).to include("https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/privacy-information-education-providers-workforce-including-teachers")
                             .and include(organisation_job_job_applications_url(vacancy.id))
     end
 

--- a/spec/system/other/application_sitemap_spec.rb
+++ b/spec/system/other/application_sitemap_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Application sitemap" do
       document = Nokogiri::XML::Document.parse(body)
       nodes = document.search("url")
 
-      expect(nodes.count).to eq(294)
+      expect(nodes.count).to eq(293)
       expect(nodes.search("loc[text()='#{root_url(protocol: 'https')}']").text)
         .to eq(root_url(protocol: "https"))
 
@@ -36,8 +36,6 @@ RSpec.describe "Application sitemap" do
         .to eq(page_url("terms-and-conditions", protocol: "https"))
       expect(nodes.search("loc:contains('#{page_url('cookies', protocol: 'https')}')").text)
         .to eq(page_url("cookies", protocol: "https"))
-      expect(nodes.search("loc:contains('#{page_url('privacy-policy', protocol: 'https')}')").text)
-        .to eq(page_url("privacy-policy", protocol: "https"))
       expect(nodes.search("loc:contains('#{page_url('accessibility', protocol: 'https')}')").text)
         .to eq(page_url("accessibility", protocol: "https"))
     end


### PR DESCRIPTION
## Changes in this PR:

In [this PR](https://github.com/DFE-Digital/teaching-vacancies/pull/6665) as per [this ticket](https://trello.com/c/Ikr2JoWG/830-update-privacy-notice) I changed the link to the privacy policy in the footer and removed the old privacy-policy page. However, it turns out we are sending an email with a link to the old privacy policy page which is broken as it no longer exists, and while looking into this I found we also link to the old privacy policy in some other areas of the service. This PR aims to correct this issue.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
