### PR TITLE
All School Roles: Jobseeker profiles changes

### DIFF
--- a/app/form_models/jobseekers/job_preferences_form.rb
+++ b/app/form_models/jobseekers/job_preferences_form.rb
@@ -49,8 +49,9 @@ module Jobseekers
 
       def options(phases: multistep.phases)
         school_types = School::READABLE_PHASE_MAPPINGS.select { |_, v| phases.include? v }.map(&:first)
-        School::PHASE_TO_KEY_STAGES_MAPPINGS.values_at(*school_types).flatten.uniq
-          .to_h { |opt| [opt.to_s, I18n.t("helpers.label.jobseekers_job_preferences_form.key_stages_options.#{opt}")] }
+        options = School::PHASE_TO_KEY_STAGES_MAPPINGS.values_at(*school_types).flatten.uniq
+                    .to_h { |opt| [opt.to_s, I18n.t("helpers.label.jobseekers_job_preferences_form.key_stages_options.#{opt}")] }
+        options.merge({"non_teaching" => "I'm not looking for a teaching job"})
       end
 
       def invalidate?

--- a/app/form_models/jobseekers/job_preferences_form.rb
+++ b/app/form_models/jobseekers/job_preferences_form.rb
@@ -51,7 +51,7 @@ module Jobseekers
         school_types = School::READABLE_PHASE_MAPPINGS.select { |_, v| phases.include? v }.map(&:first)
         options = School::PHASE_TO_KEY_STAGES_MAPPINGS.values_at(*school_types).flatten.uniq
                     .to_h { |opt| [opt.to_s, I18n.t("helpers.label.jobseekers_job_preferences_form.key_stages_options.#{opt}")] }
-        options.merge({"non_teaching" => "I'm not looking for a teaching job"})
+        options.merge({ "non_teaching" => "I'm not looking for a teaching job" })
       end
 
       def invalidate?

--- a/app/form_models/jobseekers/profile/qualified_teacher_status_form.rb
+++ b/app/form_models/jobseekers/profile/qualified_teacher_status_form.rb
@@ -1,5 +1,5 @@
 class Jobseekers::Profile::QualifiedTeacherStatusForm < BaseForm
-  validates :qualified_teacher_status, inclusion: { in: %w[yes no on_track] }
+  validates :qualified_teacher_status, inclusion: { in: %w[yes no on_track non_teacher] }
   validates :qualified_teacher_status_year, numericality: { less_than_or_equal_to: proc { Time.current.year } }, if: -> { qualified_teacher_status == "yes" }
 
   def self.fields

--- a/app/models/jobseeker_profile.rb
+++ b/app/models/jobseeker_profile.rb
@@ -31,7 +31,7 @@ class JobseekerProfile < ApplicationRecord
 
   delegate :first_name, :last_name, to: :personal_details, allow_nil: true
 
-  enum qualified_teacher_status: { yes: 0, no: 1, on_track: 2 }
+  enum qualified_teacher_status: { yes: 0, no: 1, on_track: 2, non_teacher: 3 }
 
   validates :jobseeker, uniqueness: true
 

--- a/app/views/jobseekers/profiles/about_you/edit.html.slim
+++ b/app/views/jobseekers/profiles/about_you/edit.html.slim
@@ -11,6 +11,7 @@
       = f.govuk_fieldset legend: { text: t(".page_title"), tag: "h1", size: "l" } do
 
         p = t(".page_description")
+        p = t(".items_explanation")
 
         ul.govuk-list.govuk-list--bullet
           - t(".page_description_items").each do |item|

--- a/app/views/jobseekers/profiles/job_preferences/key_stages.html.slim
+++ b/app/views/jobseekers/profiles/job_preferences/key_stages.html.slim
@@ -20,15 +20,15 @@
         = f.govuk_check_box :key_stages,
           :ks2,
           label: { text: "Key stage 2 (ages 7 to 11)" }
-        
+
         = f.govuk_check_box :key_stages,
           :ks3,
           label: { text: "Key stage 3 (ages 11 to 14)" }
-        
+
         = f.govuk_check_box :key_stages,
           :ks4,
           label: { text: "Key stage 4 (ages 14 to 16)" }
-        
+
         = f.govuk_check_box :key_stages,
           :ks5,
           label: { text: "Key stage 5 (ages 16 to 18)" }

--- a/app/views/jobseekers/profiles/job_preferences/key_stages.html.slim
+++ b/app/views/jobseekers/profiles/job_preferences/key_stages.html.slim
@@ -9,34 +9,34 @@
     .govuk-grid-column-two-thirds
       = f.govuk_check_boxes_fieldset :key_stages, legend: { text: "Key stages", size: "l" }, caption: { text: "Job preferences", size: "l" } do
         = f.govuk_check_box :key_stages,
-          :early_years,
+          "early_years",
           label: { text: "Early years (ages 0 to 5)" },
           link_errors: true
 
         = f.govuk_check_box :key_stages,
-          :ks1,
+          "ks1",
           label: { text: "Key stage 1 (ages 5 to 7)" }
 
         = f.govuk_check_box :key_stages,
-          :ks2,
+          "ks2",
           label: { text: "Key stage 2 (ages 7 to 11)" }
 
         = f.govuk_check_box :key_stages,
-          :ks3,
+          "ks3",
           label: { text: "Key stage 3 (ages 11 to 14)" }
 
         = f.govuk_check_box :key_stages,
-          :ks4,
+          "ks4",
           label: { text: "Key stage 4 (ages 14 to 16)" }
 
         = f.govuk_check_box :key_stages,
-          :ks5,
+          "ks5",
           label: { text: "Key stage 5 (ages 16 to 18)" }
 
         = f.govuk_check_box_divider
 
         = f.govuk_check_box :key_stages,
-          :non_teaching,
+          "non_teaching",
           exclusive: true,
           label: { text: "I'm not looking for a teaching job" }
 

--- a/app/views/jobseekers/profiles/job_preferences/key_stages.html.slim
+++ b/app/views/jobseekers/profiles/job_preferences/key_stages.html.slim
@@ -7,6 +7,38 @@
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      = f.govuk_collection_check_boxes :key_stages, @step.options, :first, :last, legend: { size: "l", text: "Key stages" }, caption: { text: "Job preferences", size: "l" }
+      = f.govuk_check_boxes_fieldset :key_stages, legend: { text: "Key stages", size: "l" }, caption: { text: "Job preferences", size: "l" } do
+        = f.govuk_check_box :key_stages,
+          :early_years,
+          label: { text: "Early years (ages 0 to 5)" },
+          link_errors: true
+
+        = f.govuk_check_box :key_stages,
+          :ks1,
+          label: { text: "Key stage 1 (ages 5 to 7)" }
+
+        = f.govuk_check_box :key_stages,
+          :ks2,
+          label: { text: "Key stage 2 (ages 7 to 11)" }
+        
+        = f.govuk_check_box :key_stages,
+          :ks3,
+          label: { text: "Key stage 3 (ages 11 to 14)" }
+        
+        = f.govuk_check_box :key_stages,
+          :ks4,
+          label: { text: "Key stage 4 (ages 14 to 16)" }
+        
+        = f.govuk_check_box :key_stages,
+          :ks5,
+          label: { text: "Key stage 5 (ages 16 to 18)" }
+
+        = f.govuk_check_box_divider
+
+        = f.govuk_check_box :key_stages,
+          :non_teaching,
+          exclusive: true,
+          label: { text: "I'm not looking for a teaching job" }
+
       = f.govuk_submit "Save and continue"
       p = f.link_to "Cancel", escape_path

--- a/app/views/jobseekers/profiles/qualified_teacher_status/edit.html.slim
+++ b/app/views/jobseekers/profiles/qualified_teacher_status/edit.html.slim
@@ -14,6 +14,7 @@
 
         = f.govuk_radio_button :qualified_teacher_status, "no"
         = f.govuk_radio_button :qualified_teacher_status, "on_track"
+        = f.govuk_radio_button :qualified_teacher_status, "non_teacher"
 
       = f.govuk_submit t("buttons.save_and_continue")
 

--- a/app/views/jobseekers/profiles/qualified_teacher_status/edit.html.slim
+++ b/app/views/jobseekers/profiles/qualified_teacher_status/edit.html.slim
@@ -14,6 +14,7 @@
 
         = f.govuk_radio_button :qualified_teacher_status, "no"
         = f.govuk_radio_button :qualified_teacher_status, "on_track"
+        = f.govuk_radio_divider
         = f.govuk_radio_button :qualified_teacher_status, "non_teacher"
 
       = f.govuk_submit t("buttons.save_and_continue")

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -496,6 +496,7 @@ en:
         qualified_teacher_status_details_html: Please provide more detail (optional<span class='govuk-visually-hidden'> field</span>)</span>
         qualified_teacher_status_options:
           "no": "No"
+          on_track: I'm on track to receive my QTS
           non_teacher: I'm not looking for a teaching job
           "yes": "Yes"
         statutory_induction_complete_options:

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -496,7 +496,7 @@ en:
         qualified_teacher_status_details_html: Please provide more detail (optional<span class='govuk-visually-hidden'> field</span>)</span>
         qualified_teacher_status_options:
           "no": "No"
-          on_track: I'm on track to receive my QTS
+          non_teacher: I'm not looking for a teaching job
           "yes": "Yes"
         statutory_induction_complete_options:
           "no": "No"
@@ -555,6 +555,7 @@ en:
           "yes": "Yes"
           "no": "No"
           on_track: "I’m on track to receive QTS"
+          non_teacher: "I'm not looking for a teaching job"
         qualified_teacher_status_year: Year QTS was awarded
 
       personal_details_form:

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -799,7 +799,7 @@ en:
           caption: Work history
           page_title: Add a role — Profile
           title: Role
-          hint_text: If you've had more than 1 role at the same employer, add each role separately.
+          hint_text: "If you've had more than 1 role at the same employer, add each role separately."
         review:
           add_role_button_text: Add role
           return_to_profile: Return to profile

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -798,7 +798,7 @@ en:
           caption: Work history
           page_title: Add a role — Profile
           title: Role
-          hint_text: If you have had more than one role at the same school, add them all separately.
+          hint_text: If you've had more than 1 role at the same employer, add each role separately.
         review:
           add_role_button_text: Add role
           return_to_profile: Return to profile

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -731,7 +731,8 @@ en:
       about_you:
         edit:
           page_title: About You
-          page_description: "Write a statement about yourself. This will be visible on your profile. This may include information about:"
+          page_description: Describe your relevant skills, knowledge and experience. This will help schools see if you'd be a good fit for their role.
+          items_explanation: "If you're a teacher, this may include information about:"
           page_description_items:
             - "working with pupils"
             - "your teaching style and classroom management"

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -677,7 +677,7 @@ en:
         work:
           caption: Personal details
           hint:
-            text: If you're a non-UK citizen you will need a visa or immigration status which allows you to work as a teacher in England. Learn more about %{link}
+            text: If you're a non-UK citizen you will need a visa or immigration status which allows you to work in England. If you're looking for a teaching job, you can learn more about %{link}
             link: teaching in England as a non-UK citizen (opens in new tab).
             no_visa:
               text: There is %{link} if you qualified outside the UK.

--- a/spec/form_models/jobseekers/job_preferences_form_spec.rb
+++ b/spec/form_models/jobseekers/job_preferences_form_spec.rb
@@ -20,13 +20,13 @@ RSpec.describe Jobseekers::JobPreferencesForm, type: :model do
 
     describe "#options" do
       it "depend on the value of phases" do
-        expect(step.options).to be_empty
+        expect(step.options.keys).to eq %w[non_teaching]
 
         multistep.phases = %w[primary]
-        expect(step.options.keys).to eq %w[early_years ks1 ks2]
+        expect(step.options.keys).to eq %w[early_years ks1 ks2 non_teaching]
 
         multistep.phases = %w[nursery secondary]
-        expect(step.options.keys).to eq %w[early_years ks3 ks4 ks5]
+        expect(step.options.keys).to eq %w[early_years ks3 ks4 ks5 non_teaching]
       end
     end
 

--- a/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
@@ -840,63 +840,63 @@ RSpec.describe "Jobseekers can manage their profile" do
     end
 
     context "when a jobseeker enters non-teacher preferences" do
-    it "changes the journey" do
-      click_link("Add job preferences")
-      expect(current_path).to eq(jobseekers_job_preferences_step_path(:roles))
-      expect(page).to have_css("h3", text: "Job preferencesRoles")
+      it "changes the journey" do
+        click_link("Add job preferences")
+        expect(current_path).to eq(jobseekers_job_preferences_step_path(:roles))
+        expect(page).to have_css("h3", text: "Job preferencesRoles")
 
-      # TODO: change when we have non-teaching roles
-      check "Teacher"
-      click_on I18n.t("buttons.save_and_continue")
-      expect(current_path).to eq(jobseekers_job_preferences_step_path(:phases))
-      expect(page).to have_css("h3", text: "Job preferencesPhases")
+        # TODO: change when we have non-teaching roles
+        check "Teacher"
+        click_on I18n.t("buttons.save_and_continue")
+        expect(current_path).to eq(jobseekers_job_preferences_step_path(:phases))
+        expect(page).to have_css("h3", text: "Job preferencesPhases")
 
-      check "Secondary"
-      click_on I18n.t("buttons.save_and_continue")
-      expect(current_path).to eq(jobseekers_job_preferences_step_path(:key_stages))
-      expect(page).to have_css("h3", text: "Job preferencesKey stages")
+        check "Secondary"
+        click_on I18n.t("buttons.save_and_continue")
+        expect(current_path).to eq(jobseekers_job_preferences_step_path(:key_stages))
+        expect(page).to have_css("h3", text: "Job preferencesKey stages")
 
-      check "I'm not looking for a teaching job"
-      click_on I18n.t("buttons.save_and_continue")
+        check "I'm not looking for a teaching job"
+        click_on I18n.t("buttons.save_and_continue")
 
-      # Can move forward without selecting any subject
-      click_on I18n.t("buttons.save_and_continue")
-      expect(current_path).to eq(jobseekers_job_preferences_step_path(:working_patterns))
-      expect(page).to have_css("h3", text: "Job preferencesWorking patterns")
+        # Can move forward without selecting any subject
+        click_on I18n.t("buttons.save_and_continue")
+        expect(current_path).to eq(jobseekers_job_preferences_step_path(:working_patterns))
+        expect(page).to have_css("h3", text: "Job preferencesWorking patterns")
 
-      check "Full time"
-      click_on I18n.t("buttons.save_and_continue")
-      expect(current_path).to eq(jobseekers_job_preferences_step_path(:location))
-      expect(page).to have_css("h1", text: "Job preferencesLocation")
+        check "Full time"
+        click_on I18n.t("buttons.save_and_continue")
+        expect(current_path).to eq(jobseekers_job_preferences_step_path(:location))
+        expect(page).to have_css("h1", text: "Job preferencesLocation")
 
-      fill_in "Location", with: "Manchester"
-      choose "10 miles"
-      click_on I18n.t("buttons.save_and_continue")
-      expect(current_path).to eq(jobseekers_job_preferences_step_path(:locations))
-      expect(page).to have_css("h1", text: "Job preferencesLocations")
-      expect(page).to have_content("Manchester (10 miles)")
-      expect(page).to have_css("h3", text: "Do you want to add another location?")
+        fill_in "Location", with: "Manchester"
+        choose "10 miles"
+        click_on I18n.t("buttons.save_and_continue")
+        expect(current_path).to eq(jobseekers_job_preferences_step_path(:locations))
+        expect(page).to have_css("h1", text: "Job preferencesLocations")
+        expect(page).to have_content("Manchester (10 miles)")
+        expect(page).to have_css("h3", text: "Do you want to add another location?")
 
-      choose "No"
-      click_on I18n.t("buttons.save_and_continue")
-      expect(current_path).to eq(jobseekers_job_preferences_step_path(:review))
-      expect(page).to have_css("h1", text: "Job preferences")
-      expect(page).to have_css("dd", text: "Teacher")
-      expect(page).to have_css("dd", text: "Secondary")
-      expect(page).to have_css("dd", text: "I'm not looking for a teaching job")
-      expect(page).to have_css("dd", text: "Full time")
-      expect(page).to have_css("dd", text: "Manchester (10 miles)")
+        choose "No"
+        click_on I18n.t("buttons.save_and_continue")
+        expect(current_path).to eq(jobseekers_job_preferences_step_path(:review))
+        expect(page).to have_css("h1", text: "Job preferences")
+        expect(page).to have_css("dd", text: "Teacher")
+        expect(page).to have_css("dd", text: "Secondary")
+        expect(page).to have_css("dd", text: "I'm not looking for a teaching job")
+        expect(page).to have_css("dd", text: "Full time")
+        expect(page).to have_css("dd", text: "Manchester (10 miles)")
 
-      click_on I18n.t("buttons.return_to_profile")
-      expect(current_path).to eq(jobseekers_profile_path)
-      expect(page).to have_css("h1", text: "Your profile")
-      expect(page).to have_css("dd", text: "Teacher")
-      expect(page).to have_css("dd", text: "Secondary")
-      expect(page).to have_css("dd", text: "I'm not looking for a teaching job")
-      expect(page).to have_css("dd", text: "Full time")
-      expect(page).to have_css("dd", text: "Manchester (10 miles)")
+        click_on I18n.t("buttons.return_to_profile")
+        expect(current_path).to eq(jobseekers_profile_path)
+        expect(page).to have_css("h1", text: "Your profile")
+        expect(page).to have_css("dd", text: "Teacher")
+        expect(page).to have_css("dd", text: "Secondary")
+        expect(page).to have_css("dd", text: "I'm not looking for a teaching job")
+        expect(page).to have_css("dd", text: "Full time")
+        expect(page).to have_css("dd", text: "Manchester (10 miles)")
+      end
     end
-  end
   end
 
   private

--- a/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
@@ -177,6 +177,16 @@ RSpec.describe "Jobseekers can manage their profile" do
       expect(page).to have_content("I’m on track to receive QTS")
       expect(page).not_to have_content("2019")
     end
+
+    it "allows the jobseeker to edit their QTS status to non-teacher" do
+      click_link("Add qualified teacher status")
+
+      choose "I'm not looking for a teaching job"
+      click_on I18n.t("buttons.save_and_continue")
+
+      expect(page).to have_content("I'm not looking for a teaching job")
+      expect(page).not_to have_content("2019")
+    end
   end
 
   describe "QTS if the jobseeker has a previous job application" do
@@ -828,6 +838,146 @@ RSpec.describe "Jobseekers can manage their profile" do
       expect(page).to have_css("dd", text: "Full time")
       expect(page).to have_css("dd", text: "London (1 mile)Manchester (10 miles)")
     end
+
+    context "when a jobseeker enters non-teacher preferences" do
+    it "changes the journey" do
+      click_link("Add job preferences")
+      expect(current_path).to eq(jobseekers_job_preferences_step_path(:roles))
+      expect(page).to have_css("h3", text: "Job preferencesRoles")
+
+      click_on I18n.t("buttons.save_and_continue")
+      expect(current_path).to eq(jobseekers_job_preferences_step_path(:roles))
+      expect(page).to have_css("h2", text: "There is a problem")
+
+      # TODO: change when we have non-teaching roles
+      check "Teacher"
+      click_on I18n.t("buttons.save_and_continue")
+      expect(current_path).to eq(jobseekers_job_preferences_step_path(:phases))
+      expect(page).to have_css("h3", text: "Job preferencesPhases")
+
+      click_on I18n.t("buttons.save_and_continue")
+      expect(current_path).to eq(jobseekers_job_preferences_step_path(:phases))
+      expect(page).to have_css("h2", text: "There is a problem")
+
+      check "Secondary"
+      click_on I18n.t("buttons.save_and_continue")
+      expect(current_path).to eq(jobseekers_job_preferences_step_path(:key_stages))
+      expect(page).to have_css("h3", text: "Job preferencesKey stages")
+
+      click_on I18n.t("buttons.save_and_continue")
+      expect(current_path).to eq(jobseekers_job_preferences_step_path(:key_stages))
+      expect(page).to have_css("h2", text: "There is a problem")
+
+      check "I'm not looking for a teaching job"
+      click_on I18n.t("buttons.save_and_continue")
+      expect(current_path).to eq(jobseekers_job_preferences_step_path(:working_patterns))
+      expect(page).to have_css("h3", text: "Job preferencesWorking patterns")
+
+      # Fill in the Subjects
+      click_link "Back"
+      expect(current_path).to eq(jobseekers_job_preferences_step_path(:subjects))
+      expect(page).to have_css("h3", text: "Job preferencesSubjects (optional)")
+
+      check "Mathematics"
+      click_on I18n.t("buttons.save_and_continue")
+      expect(current_path).to eq(jobseekers_job_preferences_step_path(:working_patterns))
+      expect(page).to have_css("h3", text: "Job preferencesWorking patterns")
+
+      click_on I18n.t("buttons.save_and_continue")
+      expect(current_path).to eq(jobseekers_job_preferences_step_path(:working_patterns))
+
+      check "Full time"
+      click_on I18n.t("buttons.save_and_continue")
+      expect(current_path).to eq(jobseekers_job_preferences_step_path(:location))
+      expect(page).to have_css("h1", text: "Job preferencesLocation")
+
+      click_on I18n.t("buttons.save_and_continue")
+      expect(current_path).to eq(jobseekers_job_preferences_step_path(:location))
+      expect(page).to have_css("h2", text: "There is a problem")
+
+      fill_in "Location", with: "London"
+      click_on I18n.t("buttons.save_and_continue")
+      expect(current_path).to eq(jobseekers_job_preferences_step_path(:location))
+      expect(page).to have_css("h2", text: "There is a problem")
+
+      choose "1 mile"
+      click_on I18n.t("buttons.save_and_continue")
+      expect(current_path).to eq(jobseekers_job_preferences_step_path(:locations))
+      expect(page).to have_css("h1", text: "Job preferencesLocations")
+      expect(page).to have_content("London (1 mile)")
+
+      click_link "Change"
+      expect(page).to have_css("h1", text: "Job preferencesLocation")
+      expect(page).to have_field("Location", with: "London")
+      expect(page).to have_checked_field("1 mile")
+
+      choose "5 miles"
+      click_on I18n.t("buttons.save_and_continue")
+      expect(current_path).to eq(jobseekers_job_preferences_step_path(:locations))
+      expect(page).to have_css("h1", text: "Job preferencesLocations")
+      expect(page).to have_content("London (5 miles)")
+
+      click_link "Delete"
+      expect(page).to have_css("h1", text: "Delete locationConfirm that you want to delete London (5 miles)")
+      click_on "Delete this location"
+
+      expect(current_path).to eq(jobseekers_job_preferences_step_path(:location))
+      expect(page).to have_content("Location deleted")
+      expect(page).to have_css("h1", text: "Job preferencesLocation")
+
+      fill_in "Location", with: "San Francisco"
+      choose "1 mile"
+      click_on I18n.t("buttons.save_and_continue")
+      expect(page).to have_css("h2", text: "There is a problem")
+      expect(page).to have_content("Enter a city, county or postcode in the UK")
+
+      fill_in "Location", with: "London"
+      choose "1 mile"
+      click_on I18n.t("buttons.save_and_continue")
+      expect(current_path).to eq(jobseekers_job_preferences_step_path(:locations))
+      expect(page).to have_css("h1", text: "Job preferencesLocations")
+      expect(page).to have_content("London (1 mile)")
+      expect(page).to have_css("h3", text: "Do you want to add another location?")
+
+      click_on I18n.t("buttons.save_and_continue")
+      expect(page).to have_css("h2", text: "There is a problem")
+
+      choose "Yes"
+      click_on I18n.t("buttons.save_and_continue")
+      expect(current_path).to eq(jobseekers_job_preferences_step_path(:location))
+      expect(page).to have_css("h1", text: "Job preferencesLocation")
+
+      fill_in "Location", with: "Manchester"
+      choose "10 miles"
+      click_on I18n.t("buttons.save_and_continue")
+      expect(current_path).to eq(jobseekers_job_preferences_step_path(:locations))
+      expect(page).to have_css("h1", text: "Job preferencesLocations")
+      expect(page).to have_content("London (1 mile)")
+      expect(page).to have_content("Manchester (10 miles)")
+      expect(page).to have_css("h3", text: "Do you want to add another location?")
+
+      choose "No"
+      click_on I18n.t("buttons.save_and_continue")
+      expect(current_path).to eq(jobseekers_job_preferences_step_path(:review))
+      expect(page).to have_css("h1", text: "Job preferences")
+      expect(page).to have_css("dd", text: "TeacherHead of year or phaseAssistant headteacher")
+      expect(page).to have_css("dd", text: "Secondary")
+      expect(page).to have_css("dd", text: "Key stage 3 (ages 11 to 14), Key stage 4 (ages 14 to 16)")
+      expect(page).to have_css("dd", text: "Mathematics")
+      expect(page).to have_css("dd", text: "Full time")
+      expect(page).to have_css("dd", text: "London (1 mile)Manchester (10 miles)")
+
+      click_on I18n.t("buttons.return_to_profile")
+      expect(current_path).to eq(jobseekers_profile_path)
+      expect(page).to have_css("h1", text: "Your profile")
+      expect(page).to have_css("dd", text: "TeacherHead of year or phaseAssistant headteacher")
+      expect(page).to have_css("dd", text: "Secondary")
+      expect(page).to have_css("dd", text: "Key stage 3 (ages 11 to 14), Key stage 4 (ages 14 to 16)")
+      expect(page).to have_css("dd", text: "Mathematics")
+      expect(page).to have_css("dd", text: "Full time")
+      expect(page).to have_css("dd", text: "London (1 mile)Manchester (10 miles)")
+    end
+  end
   end
 
   private

--- a/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
@@ -845,104 +845,26 @@ RSpec.describe "Jobseekers can manage their profile" do
       expect(current_path).to eq(jobseekers_job_preferences_step_path(:roles))
       expect(page).to have_css("h3", text: "Job preferencesRoles")
 
-      click_on I18n.t("buttons.save_and_continue")
-      expect(current_path).to eq(jobseekers_job_preferences_step_path(:roles))
-      expect(page).to have_css("h2", text: "There is a problem")
-
       # TODO: change when we have non-teaching roles
       check "Teacher"
       click_on I18n.t("buttons.save_and_continue")
       expect(current_path).to eq(jobseekers_job_preferences_step_path(:phases))
       expect(page).to have_css("h3", text: "Job preferencesPhases")
 
-      click_on I18n.t("buttons.save_and_continue")
-      expect(current_path).to eq(jobseekers_job_preferences_step_path(:phases))
-      expect(page).to have_css("h2", text: "There is a problem")
-
       check "Secondary"
       click_on I18n.t("buttons.save_and_continue")
       expect(current_path).to eq(jobseekers_job_preferences_step_path(:key_stages))
       expect(page).to have_css("h3", text: "Job preferencesKey stages")
 
-      click_on I18n.t("buttons.save_and_continue")
-      expect(current_path).to eq(jobseekers_job_preferences_step_path(:key_stages))
-      expect(page).to have_css("h2", text: "There is a problem")
-
       check "I'm not looking for a teaching job"
       click_on I18n.t("buttons.save_and_continue")
-      expect(current_path).to eq(jobseekers_job_preferences_step_path(:working_patterns))
-      expect(page).to have_css("h3", text: "Job preferencesWorking patterns")
 
-      # Fill in the Subjects
-      click_link "Back"
-      expect(current_path).to eq(jobseekers_job_preferences_step_path(:subjects))
-      expect(page).to have_css("h3", text: "Job preferencesSubjects (optional)")
-
-      check "Mathematics"
+      # Can move forward without selecting any subject
       click_on I18n.t("buttons.save_and_continue")
       expect(current_path).to eq(jobseekers_job_preferences_step_path(:working_patterns))
       expect(page).to have_css("h3", text: "Job preferencesWorking patterns")
-
-      click_on I18n.t("buttons.save_and_continue")
-      expect(current_path).to eq(jobseekers_job_preferences_step_path(:working_patterns))
 
       check "Full time"
-      click_on I18n.t("buttons.save_and_continue")
-      expect(current_path).to eq(jobseekers_job_preferences_step_path(:location))
-      expect(page).to have_css("h1", text: "Job preferencesLocation")
-
-      click_on I18n.t("buttons.save_and_continue")
-      expect(current_path).to eq(jobseekers_job_preferences_step_path(:location))
-      expect(page).to have_css("h2", text: "There is a problem")
-
-      fill_in "Location", with: "London"
-      click_on I18n.t("buttons.save_and_continue")
-      expect(current_path).to eq(jobseekers_job_preferences_step_path(:location))
-      expect(page).to have_css("h2", text: "There is a problem")
-
-      choose "1 mile"
-      click_on I18n.t("buttons.save_and_continue")
-      expect(current_path).to eq(jobseekers_job_preferences_step_path(:locations))
-      expect(page).to have_css("h1", text: "Job preferencesLocations")
-      expect(page).to have_content("London (1 mile)")
-
-      click_link "Change"
-      expect(page).to have_css("h1", text: "Job preferencesLocation")
-      expect(page).to have_field("Location", with: "London")
-      expect(page).to have_checked_field("1 mile")
-
-      choose "5 miles"
-      click_on I18n.t("buttons.save_and_continue")
-      expect(current_path).to eq(jobseekers_job_preferences_step_path(:locations))
-      expect(page).to have_css("h1", text: "Job preferencesLocations")
-      expect(page).to have_content("London (5 miles)")
-
-      click_link "Delete"
-      expect(page).to have_css("h1", text: "Delete locationConfirm that you want to delete London (5 miles)")
-      click_on "Delete this location"
-
-      expect(current_path).to eq(jobseekers_job_preferences_step_path(:location))
-      expect(page).to have_content("Location deleted")
-      expect(page).to have_css("h1", text: "Job preferencesLocation")
-
-      fill_in "Location", with: "San Francisco"
-      choose "1 mile"
-      click_on I18n.t("buttons.save_and_continue")
-      expect(page).to have_css("h2", text: "There is a problem")
-      expect(page).to have_content("Enter a city, county or postcode in the UK")
-
-      fill_in "Location", with: "London"
-      choose "1 mile"
-      click_on I18n.t("buttons.save_and_continue")
-      expect(current_path).to eq(jobseekers_job_preferences_step_path(:locations))
-      expect(page).to have_css("h1", text: "Job preferencesLocations")
-      expect(page).to have_content("London (1 mile)")
-      expect(page).to have_css("h3", text: "Do you want to add another location?")
-
-      click_on I18n.t("buttons.save_and_continue")
-      expect(page).to have_css("h2", text: "There is a problem")
-
-      choose "Yes"
       click_on I18n.t("buttons.save_and_continue")
       expect(current_path).to eq(jobseekers_job_preferences_step_path(:location))
       expect(page).to have_css("h1", text: "Job preferencesLocation")
@@ -952,7 +874,6 @@ RSpec.describe "Jobseekers can manage their profile" do
       click_on I18n.t("buttons.save_and_continue")
       expect(current_path).to eq(jobseekers_job_preferences_step_path(:locations))
       expect(page).to have_css("h1", text: "Job preferencesLocations")
-      expect(page).to have_content("London (1 mile)")
       expect(page).to have_content("Manchester (10 miles)")
       expect(page).to have_css("h3", text: "Do you want to add another location?")
 
@@ -960,22 +881,20 @@ RSpec.describe "Jobseekers can manage their profile" do
       click_on I18n.t("buttons.save_and_continue")
       expect(current_path).to eq(jobseekers_job_preferences_step_path(:review))
       expect(page).to have_css("h1", text: "Job preferences")
-      expect(page).to have_css("dd", text: "TeacherHead of year or phaseAssistant headteacher")
+      expect(page).to have_css("dd", text: "Teacher")
       expect(page).to have_css("dd", text: "Secondary")
-      expect(page).to have_css("dd", text: "Key stage 3 (ages 11 to 14), Key stage 4 (ages 14 to 16)")
-      expect(page).to have_css("dd", text: "Mathematics")
+      expect(page).to have_css("dd", text: "I'm not looking for a teaching job")
       expect(page).to have_css("dd", text: "Full time")
-      expect(page).to have_css("dd", text: "London (1 mile)Manchester (10 miles)")
+      expect(page).to have_css("dd", text: "Manchester (10 miles)")
 
       click_on I18n.t("buttons.return_to_profile")
       expect(current_path).to eq(jobseekers_profile_path)
       expect(page).to have_css("h1", text: "Your profile")
-      expect(page).to have_css("dd", text: "TeacherHead of year or phaseAssistant headteacher")
+      expect(page).to have_css("dd", text: "Teacher")
       expect(page).to have_css("dd", text: "Secondary")
-      expect(page).to have_css("dd", text: "Key stage 3 (ages 11 to 14), Key stage 4 (ages 14 to 16)")
-      expect(page).to have_css("dd", text: "Mathematics")
+      expect(page).to have_css("dd", text: "I'm not looking for a teaching job")
       expect(page).to have_css("dd", text: "Full time")
-      expect(page).to have_css("dd", text: "London (1 mile)Manchester (10 miles)")
+      expect(page).to have_css("dd", text: "Manchester (10 miles)")
     end
   end
   end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/HLP4fqKU/829-asr-jobseeker-profiles

## Changes in this PR:

This PR contains a variety of changes to the jobseeker profiles pages as outlined on the trello card. Notably adding "I'm not interested in teaching jobs" to the QTS and Key Stages portions of the jobseeker profiles as well as various copy changes through the jobseeker profiles journey.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
