### PR TITLE
All School Roles: job listing journey

### DIFF
--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -64,7 +64,7 @@ class JobApplication < ApplicationRecord
 
   def ask_professional_status?
     vacancy.job_roles.intersect?(%w[teacher headteacher deputy_headteacher assistant_headteacher
-                                    head_of_year_or_phase head_of_department_or_curriculum])
+                                    head_of_year_or_phase head_of_department_or_curriculum sendco])
   end
 
   def deadline_passed?


### PR DESCRIPTION
## Trello card URL

https://trello.com/b/1QyLnb9W/teaching-vacancies-sprint-board

## Changes in this PR:

The only change in this PR is to add sendco to the list of roles for which the jobseeker is asked to add their professional status when applying for a vacancy.

I don't think the other requirements of the ticket require any additional code.

**1. add another radio option to key stage for “I’m not looking for a teaching role” as per screenshot 1**

This already should work as expected. We do not show the key stages page for non-teaching jobs (which is the preferred behaviour). This is handled in Publishers::Vacancies::VacancyStepProcess. In the job_details_step method we delete the key_stages step unless vacancy.allow_key_stages? The logic can be seen below:

```
# app/services/publishers/vacancies/vacancy_step_process.rb line 19
  def job_details_steps
    steps = %i[job_location job_role education_phases job_title key_stages subjects contract_type working_patterns pay_package]
    steps.delete(:job_location) if organisation.school?
    steps.delete(:education_phases) unless vacancy.allow_phase_to_be_set?
    steps.delete(:key_stages) unless vacancy.allow_key_stages?
    steps.delete(:subjects) unless vacancy.allow_subjects?

    steps
  end

```
```
# app/models/vacancy.rb line 178
  def allow_key_stages?
    allowed_phases = %w[primary middle secondary through]
    allowed_roles = %w[teacher headteacher deputy_headteacher assistant_headteacher
                       head_of_year_or_phase head_of_department_or_curriculum teaching_assistant]

    phases.intersect?(allowed_phases) && job_roles.intersect?(allowed_roles)
  end
```

**2. on the about a role page, hide the ECT question**

We only show the ect question if vacancy.job_roles.include? "teacher" (about_the_role.html.slim line 27) so this will work by default. We also only validate the presence of this field if the role is teacher (see below)
```
# app/views/publishers/vacancies/build/about_the_role.html.slim line 27
      - if vacancy.job_roles.include? "teacher"
        = f.govuk_collection_radio_buttons :ect_status,
          Vacancy.ect_statuses.keys,
          :to_s,
          class: ["ect-status-radios"],
          legend: { size: "m", tag: nil }
```
```
# app/form_models/publishers/job_listing/about_the_role_form.rb line 2
`validates :ect_status, inclusion: { in: Vacancy.ect_statuses.keys }, if: -> { vacancy&.job_roles&.include?("teacher") }`
```

**3. Hide the professional status section (QTS and stat induction year) within the jobseeker application form**

The professional status page is only shown if job_application.ask_professional_status? (see Jobseekers::JobApplications::JobApplicationStepProcess). This method is only true if the vacancy is for a teaching role.

```
# app/models/job_application.rb line 65
  def ask_professional_status?
    vacancy.job_roles.intersect?(%w[teacher headteacher deputy_headteacher assistant_headteacher
                                    head_of_year_or_phase head_of_department_or_curriculum sendco])
  end
```

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
