### PR TITLE
Fix dependabot exclusion patterns for GovUK packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,7 @@ updates:
         patterns:
           - "*"
         exclude-patterns:
-          - "govuk"
+          - "govuk*"
           - "noticed"
 
   - package-ecosystem: "docker"
@@ -64,5 +64,4 @@ updates:
         patterns:
           - "*"
         exclude-patterns:
-          - "govuk"
-          - "jest"
+          - "govuk*"


### PR DESCRIPTION
Ensuring GovUK packages (gems and JS packages) don't get automatically upgraded by Dependabot.

Jest packages seem more stable nowadays (upgrade used to break our test spec), removing it from exclusions.