### PR TITLE
Resolve flaky tests

### DIFF
--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -27,7 +27,7 @@ FactoryBot.define do
     detailed_school_type { "Voluntary aided school" }
     minimum_age { 11 }
     maximum_age { 18 }
-    name { Faker::Educator.secondary_school.strip.delete("'") }
+    sequence(:name) { |n| "#{Faker::Educator.secondary_school.strip.delete("'")} #{n}" }
     phase { :secondary }
     readable_phases { %w[secondary] }
     region { "South-East England" }

--- a/spec/system/jobseekers/jobseekers_can_search_for_jobs_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_search_for_jobs_spec.rb
@@ -230,9 +230,9 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
 
         select "Closing date", :from => "sort-by-field"
 
+        expect(page).to have_select("sort_by", selected: "Closing date")
         expect("Maths 1").to appear_before("Physics Teacher")
         expect("Physics Teacher").to appear_before("Maths Teacher 2")
-        expect(page).to have_select("sort_by", selected: "Closing date")
 
         select "Newest job", :from => "sort-by-field"
 


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/kSImWKUs

## Changes in this PR:
### Avoid Schools with repeated names being generated
This is causing ambiguous matches over Capybara tests, when factory bot is creating schools. Sometimes they have repeated names and actions over clicking links fail due to the name being present twice.

### Reorder assertions to resolve flaky test
In case the error is happening for asserting over the result ordering before the order has been
applied & the results reloaded.

## Test results
Re-ran the tests about 10 times without any flaky test errors. 