### PR TITLE
Fix seed file issue

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -1,5 +1,5 @@
 require "geocoding"
-# testing seeds
+
 # rubocop:disable Metrics/ClassLength
 class Vacancy < ApplicationRecord
   extend FriendlyId

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -1,5 +1,5 @@
 require "geocoding"
-
+# testing seeds
 # rubocop:disable Metrics/ClassLength
 class Vacancy < ApplicationRecord
   extend FriendlyId

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -97,10 +97,7 @@ Jobseeker.first(weydon_trust_schools.count).each do |jobseeker|
     FactoryBot.create(:job_preferences, jobseeker_profile: jobseeker_profile) do |job_preferences|
       FactoryBot.create(:job_preferences_location, job_preferences:, name: location_preference_names.pop)
     end
-    # :with_employment_history trait creates a job_application through the factory, which in turn creates a vacancy that has no associated organisation and causes review app builds to break.
-    jobseeker_profile.employments.each do |employment|
-      vacancy_without_org_id = employment.job_application.vacancy_id
-      OrganisationVacancy.create(vacancy_id: vacancy_without_org_id, organisation_id: weydon_trust_schools.first.id)
-    end
   end
 end
+
+Vacancy.all.select { |v| v.organisation.nil? }.each(&:destroy)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -97,5 +97,10 @@ Jobseeker.first(weydon_trust_schools.count).each do |jobseeker|
     FactoryBot.create(:job_preferences, jobseeker_profile: jobseeker_profile) do |job_preferences|
       FactoryBot.create(:job_preferences_location, job_preferences:, name: location_preference_names.pop)
     end
+    # :with_employment_history trait creates a job_application through the factory, which in turn creates a vacancy that has no associated organisation and causes review app builds to break.
+    jobseeker_profile.employments.each do |employment|
+      vacancy_without_org_id = employment.job_application.vacancy_id
+      OrganisationVacancy.create(vacancy_id: vacancy_without_org_id, organisation_id: weydon_trust_schools.first.id)
+    end
   end
 end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/j0NL483t/846-seeds-creating-vacancies-without-organisations

## Changes in this PR:

We have an issue in our seed file which causes 14 vacancies to be created but not assigned to an organisation. This seems to be caused by our job application factory creating vacancies without organisations. This PR is a quick win as stops our smoke test from failing, and allows the jobs page to load correctly by deleting these organisation free vacancies add the end of the seed file, but to fully fix the issue more work needs to be done to properly correct the issue.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
