### PR TITLE
Enable Review Apps pointing to feature branches

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -16,8 +16,6 @@ on:
     - '.github/pull_request_template.md'
 
   pull_request:
-    branches:
-    - main
     types:
       - labeled
       - synchronize

--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -2,7 +2,6 @@ name: Delete review app
 
 on:
   pull_request:
-    branches: [ main ]
     types: [closed]
     paths-ignore:
       - 'bigquery/**'


### PR DESCRIPTION
Review Apps were only being triggered if the Pull Request was opened against the "main" branch.

This blocked us from individually review changes against a long lived feature branch.

Now every PR will trigger a review app as long as is labeled as "deploy".

## Testing it does work
I opened this PR against ASR Feature branch so we can test that the deploy of the review app gets triggered.
Will re-point it against `main` before merging.

