### PR TITLE
ASR: Candidate Profiles Search

### DIFF
--- a/app/controllers/publishers/jobseeker_profiles_controller.rb
+++ b/app/controllers/publishers/jobseeker_profiles_controller.rb
@@ -12,7 +12,7 @@ class Publishers::JobseekerProfilesController < Publishers::BaseController
   private
 
   def jobseeker_profile_search_params
-    params.permit(locations: [], qualified_teacher_status: [], roles: [], working_patterns: [], education_phases: [], key_stages: [], subjects: [], right_to_work_in_uk: [])
+    params.permit(locations: [], qualified_teacher_status: [], teaching_job_roles: [], teaching_support_job_roles: [], non_teaching_support_job_roles: [], working_patterns: [], education_phases: [], key_stages: [], subjects: [], right_to_work_in_uk: [])
           .transform_values(&:compact_blank)
           .merge(current_organisation:)
   end

--- a/app/form_models/publishers/jobseeker_profile_search_form.rb
+++ b/app/form_models/publishers/jobseeker_profile_search_form.rb
@@ -28,7 +28,7 @@ class Publishers::JobseekerProfileSearchForm
 
   def non_teaching_support_job_role_options
     Vacancy::NON_TEACHING_SUPPORT_JOB_ROLES.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_role_form.non_teaching_support_job_role_options.#{option}")] }
-  end  
+  end
 
   def qts_options
     %w[yes on_track no].map { |i| [i, I18n.t(i, scope: "publishers.jobseeker_profiles.filters.qts_options")] }

--- a/app/form_models/publishers/jobseeker_profile_search_form.rb
+++ b/app/form_models/publishers/jobseeker_profile_search_form.rb
@@ -5,23 +5,30 @@ class Publishers::JobseekerProfileSearchForm
   attribute :current_organisation
   attribute :locations
   attribute :qualified_teacher_status
-  attribute :roles
+  attribute :teaching_job_roles
+  attribute :teaching_support_job_roles
+  attribute :non_teaching_support_job_roles
   attribute :working_patterns
   attribute :education_phases
   attribute :key_stages
   attribute :subjects
   attribute :right_to_work_in_uk
 
-  ROLES = %w[teacher head_of_year_or_phase head_of_department_or_curriculum assistant_headteacher deputy_headteacher
-             headteacher teaching_assistant higher_level_teaching_assistant education_support sendco].freeze
-
   def school_options
     current_organisation.schools.map { |school| [school.id, school.name] }
   end
 
-  def role_options
-    ROLES.map { |i| [i, I18n.t(i, scope: "publishers.jobseeker_profiles.filters.role_options")] }
+  def teaching_job_role_options
+    Vacancy::TEACHING_JOB_ROLES.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_role_form.teaching_job_role_options.#{option}")] }
   end
+
+  def teaching_support_job_role_options
+    Vacancy::TEACHING_SUPPORT_JOB_ROLES.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_role_form.teaching_support_job_role_options.#{option}")] }
+  end
+
+  def non_teaching_support_job_role_options
+    Vacancy::NON_TEACHING_SUPPORT_JOB_ROLES.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_role_form.non_teaching_support_job_role_options.#{option}")] }
+  end  
 
   def qts_options
     %w[yes on_track no].map { |i| [i, I18n.t(i, scope: "publishers.jobseeker_profiles.filters.qts_options")] }

--- a/app/services/search/jobseeker_profile_search.rb
+++ b/app/services/search/jobseeker_profile_search.rb
@@ -13,15 +13,23 @@ class Search::JobseekerProfileSearch
       .active.not_hidden_from(current_organisation)
       .where(job_preferences: { id: location_preferences_ids_matching_location_search })
 
+
     scope = scope.where(qualified_teacher_status: filters[:qualified_teacher_status]) if filters[:qualified_teacher_status].present?
-    scope = scope.where("job_preferences.roles && ARRAY[?]::varchar[]", filters[:roles]) if filters[:roles].present?
+    scope = scope.where("job_preferences.roles && ARRAY[?]::varchar[]", roles_filter) if roles_filter.present?
     scope = scope.where("job_preferences.working_patterns && ARRAY[?]::varchar[]", filters[:working_patterns]) if filters[:working_patterns].present?
     scope = scope.where("job_preferences.phases && ARRAY[?]::varchar[]", filters[:education_phases]) if filters[:education_phases].present?
     scope = scope.where("job_preferences.key_stages && ARRAY[?]::varchar[]", filters[:key_stages]) if filters[:key_stages].present?
     scope = scope.where("job_preferences.subjects && ARRAY[?]::varchar[]", filters[:subjects]) if filters[:subjects].present?
     scope = scope.where("personal_details.right_to_work_in_uk = ?", right_to_work_in_uk) if one_option_selected_for_right_to_work_in_uk?
-
     scope
+  end
+
+  def roles_filter
+    roles_filter = []
+    [:teaching_job_roles, :teaching_support_job_roles, :non_teaching_support_job_roles].each do |filter_type|
+      roles_filter += filters[filter_type] if filters[filter_type].present?
+    end
+    roles_filter
   end
 
   def total_count
@@ -29,12 +37,12 @@ class Search::JobseekerProfileSearch
   end
 
   def total_filters
-    filter_counts = %i[qualified_teacher_status roles working_patterns education_phases key_stages subjects right_to_work_in_uk].map { |filter| @filters[filter]&.count || 0 }
+    filter_counts = %i[qualified_teacher_status teaching_job_roles teaching_support_job_roles non_teaching_support_job_roles working_patterns education_phases key_stages subjects right_to_work_in_uk].map { |filter| @filters[filter]&.count || 0 }
     filter_counts.sum
   end
 
   def clear_filters_params
-    @filters.merge({ qualified_teacher_status: [], roles: [], working_patterns: [], education_phases: [], key_stages: [], subjects: [], right_to_work_in_uk: [] })
+    @filters.merge({ qualified_teacher_status: [], teaching_job_roles: [], teaching_support_job_roles: [], non_teaching_support_job_roles: [], working_patterns: [], education_phases: [], key_stages: [], subjects: [], right_to_work_in_uk: [] })
   end
 
   private

--- a/app/services/search/jobseeker_profile_search.rb
+++ b/app/services/search/jobseeker_profile_search.rb
@@ -13,7 +13,6 @@ class Search::JobseekerProfileSearch
       .active.not_hidden_from(current_organisation)
       .where(job_preferences: { id: location_preferences_ids_matching_location_search })
 
-
     scope = scope.where(qualified_teacher_status: filters[:qualified_teacher_status]) if filters[:qualified_teacher_status].present?
     scope = scope.where("job_preferences.roles && ARRAY[?]::varchar[]", roles_filter) if roles_filter.present?
     scope = scope.where("job_preferences.working_patterns && ARRAY[?]::varchar[]", filters[:working_patterns]) if filters[:working_patterns].present?
@@ -26,7 +25,7 @@ class Search::JobseekerProfileSearch
 
   def roles_filter
     roles_filter = []
-    [:teaching_job_roles, :teaching_support_job_roles, :non_teaching_support_job_roles].each do |filter_type|
+    %i[teaching_job_roles teaching_support_job_roles non_teaching_support_job_roles].each do |filter_type|
       roles_filter += filters[filter_type] if filters[filter_type].present?
     end
     roles_filter

--- a/app/services/search/jobseeker_profile_search.rb
+++ b/app/services/search/jobseeker_profile_search.rb
@@ -13,7 +13,7 @@ class Search::JobseekerProfileSearch
       .active.not_hidden_from(current_organisation)
       .where(job_preferences: { id: location_preferences_ids_matching_location_search })
 
-    scope = scope.where(qualified_teacher_status: filters[:qualified_teacher_status]) if filters[:qualified_teacher_status].present?
+    scope = filter_by_qts(scope) if filters[:qualified_teacher_status].present?
     scope = scope.where("job_preferences.roles && ARRAY[?]::varchar[]", roles_filter) if roles_filter.present?
     scope = scope.where("job_preferences.working_patterns && ARRAY[?]::varchar[]", filters[:working_patterns]) if filters[:working_patterns].present?
     scope = scope.where("job_preferences.phases && ARRAY[?]::varchar[]", filters[:education_phases]) if filters[:education_phases].present?
@@ -40,6 +40,15 @@ class Search::JobseekerProfileSearch
 
   def clear_filters_params
     @filters.merge({ qualified_teacher_status: [], teaching_job_roles: [], teaching_support_job_roles: [], non_teaching_support_job_roles: [], working_patterns: [], education_phases: [], key_stages: [], subjects: [], right_to_work_in_uk: [] })
+  end
+
+  def filter_by_qts(scope)
+    if filters[:qualified_teacher_status].include?("no")
+      selected_statuses = filters[:qualified_teacher_status] << "non_teacher"
+      return scope.where(qualified_teacher_status: selected_statuses).or(scope.where(qualified_teacher_status: nil))
+    end
+
+    scope.where(qualified_teacher_status: filters[:qualified_teacher_status])
   end
 
   private

--- a/app/services/search/jobseeker_profile_search.rb
+++ b/app/services/search/jobseeker_profile_search.rb
@@ -24,11 +24,9 @@ class Search::JobseekerProfileSearch
   end
 
   def roles_filter
-    roles_filter = []
-    %i[teaching_job_roles teaching_support_job_roles non_teaching_support_job_roles].each do |filter_type|
-      roles_filter += filters[filter_type] if filters[filter_type].present?
-    end
-    roles_filter
+    role_filters = %i[teaching_job_roles teaching_support_job_roles non_teaching_support_job_roles]
+
+    role_filters.flat_map { |filter_type| filters[filter_type] }.compact
   end
 
   def total_count

--- a/app/views/publishers/jobseeker_profiles/search/_filters.html.slim
+++ b/app/views/publishers/jobseeker_profiles/search/_filters.html.slim
@@ -17,7 +17,7 @@ ruby:
       selected_method: :last,
     },
     {
-      legend: "Teaching",
+      legend: t("jobs.filters.teaching_job_roles"),
       key: :teaching_job_roles,
       selected: @form.teaching_job_roles,
       options: @form.teaching_job_role_options,
@@ -25,7 +25,7 @@ ruby:
       selected_method: :last,
     },
     {
-      legend: "Teaching support",
+      legend: t("jobs.filters.teaching_support_job_roles"),
       key: :teaching_support_job_roles,
       selected: @form.teaching_support_job_roles,
       options: @form.teaching_support_job_role_options,
@@ -33,7 +33,7 @@ ruby:
       selected_method: :last,
     },
     {
-      legend: "Non teaching",
+      legend: t("jobs.filters.non_teaching_support_job_roles"),
       key: :non_teaching_support_job_roles,
       selected: @form.non_teaching_support_job_roles,
       options: @form.non_teaching_support_job_role_options,

--- a/app/views/publishers/jobseeker_profiles/search/_filters.html.slim
+++ b/app/views/publishers/jobseeker_profiles/search/_filters.html.slim
@@ -17,13 +17,29 @@ ruby:
       selected_method: :last,
     },
     {
-      legend: t("publishers.jobseeker_profiles.filters.preferred_roles"),
-      key: :roles,
-      selected: @form.roles,
-      options: @form.role_options,
+      legend: "Teaching",
+      key: :teaching_job_roles,
+      selected: @form.teaching_job_roles,
+      options: @form.teaching_job_role_options,
       value_method: :first,
       selected_method: :last,
-      },
+    },
+    {
+      legend: "Teaching support",
+      key: :teaching_support_job_roles,
+      selected: @form.teaching_support_job_roles,
+      options: @form.teaching_support_job_role_options,
+      value_method: :first,
+      selected_method: :last,
+    },
+    {
+      legend: "Non teaching",
+      key: :non_teaching_support_job_roles,
+      selected: @form.non_teaching_support_job_roles,
+      options: @form.non_teaching_support_job_role_options,
+      value_method: :first,
+      selected_method: :last,
+    },
     {
       legend: t("publishers.jobseeker_profiles.filters.preferred_working_patterns"),
       key: :working_patterns,
@@ -67,7 +83,7 @@ ruby:
             - rb.with_group(**filter_type.merge(remove_filter_link: { url_helper: :publishers_jobseeker_profiles_path, params: @jobseeker_profile_search.filters }))
         - filters_component.with_group key: "right_to_work_in_uk", component: f.govuk_collection_check_boxes(:right_to_work_in_uk, f.object.right_to_work_in_uk_options, :first, :last, small: true, legend: { text: t("publishers.jobseeker_profiles.filters.right_to_work_in_uk") }, hint: nil)
         - filters_component.with_group key: "qualified_teacher_status", component: f.govuk_collection_check_boxes(:qualified_teacher_status, f.object.qts_options, :first, :last, small: true, legend: { text: t("publishers.jobseeker_profiles.filters.qualified_teacher_status") }, hint: nil)
-        - filters_component.with_group key: "roles", component: f.govuk_collection_check_boxes(:roles, f.object.role_options, :first, :last, small: true, legend: { text: t("publishers.jobseeker_profiles.filters.preferred_roles") }, hint: nil)
+        = render "/vacancies/search/job_roles_filters", filters_component: filters_component, f: f, form: @form
         - filters_component.with_group key: "working_patterns", component: f.govuk_collection_check_boxes(:working_patterns, f.object.working_pattern_options, :first, :last, small: true, legend: { text: t("publishers.jobseeker_profiles.filters.preferred_working_patterns") }, hint: nil)
         - filters_component.with_group key: "education_phases", component: f.govuk_collection_check_boxes(:education_phases, f.object.education_phase_options, :first, :last, small: true, legend: { text: t("publishers.jobseeker_profiles.filters.preferred_education_phases") }, hint: nil)
         - filters_component.with_group key: "key_stages", component: f.govuk_collection_check_boxes(:key_stages, f.object.key_stage_options, :first, :last, small: true, legend: { text: t("publishers.jobseeker_profiles.filters.preferred_key_stages") }, hint: nil)

--- a/app/views/publishers/jobseeker_profiles/search/_filters.html.slim
+++ b/app/views/publishers/jobseeker_profiles/search/_filters.html.slim
@@ -1,22 +1,6 @@
 ruby:
   filter_types = [
     {
-      legend: t("publishers.jobseeker_profiles.filters.right_to_work_in_uk"),
-      key: :right_to_work_in_uk,
-      selected: @form.right_to_work_in_uk,
-      options: @form.right_to_work_in_uk_options,
-      value_method: :first,
-      selected_method: :last,
-    },
-    {
-      legend: t("publishers.jobseeker_profiles.filters.qualified_teacher_status"),
-      key: :qualified_teacher_status,
-      selected: @form.qualified_teacher_status,
-      options: @form.qts_options,
-      value_method: :first,
-      selected_method: :last,
-    },
-    {
       legend: t("jobs.filters.teaching_job_roles"),
       key: :teaching_job_roles,
       selected: @form.teaching_job_roles,
@@ -37,6 +21,22 @@ ruby:
       key: :non_teaching_support_job_roles,
       selected: @form.non_teaching_support_job_roles,
       options: @form.non_teaching_support_job_role_options,
+      value_method: :first,
+      selected_method: :last,
+    },
+    {
+      legend: t("publishers.jobseeker_profiles.filters.right_to_work_in_uk"),
+      key: :right_to_work_in_uk,
+      selected: @form.right_to_work_in_uk,
+      options: @form.right_to_work_in_uk_options,
+      value_method: :first,
+      selected_method: :last,
+    },
+    {
+      legend: t("publishers.jobseeker_profiles.filters.qualified_teacher_status"),
+      key: :qualified_teacher_status,
+      selected: @form.qualified_teacher_status,
+      options: @form.qts_options,
       value_method: :first,
       selected_method: :last,
     },
@@ -81,9 +81,9 @@ ruby:
         - filters_component.with_remove_filter_links do |rb|
           - filter_types.each do |filter_type|
             - rb.with_group(**filter_type.merge(remove_filter_link: { url_helper: :publishers_jobseeker_profiles_path, params: @jobseeker_profile_search.filters }))
+        = render "publishers/jobseeker_profiles/search/job_roles_filters", filters_component: filters_component, f: f, form: @form
         - filters_component.with_group key: "right_to_work_in_uk", component: f.govuk_collection_check_boxes(:right_to_work_in_uk, f.object.right_to_work_in_uk_options, :first, :last, small: true, legend: { text: t("publishers.jobseeker_profiles.filters.right_to_work_in_uk") }, hint: nil)
         - filters_component.with_group key: "qualified_teacher_status", component: f.govuk_collection_check_boxes(:qualified_teacher_status, f.object.qts_options, :first, :last, small: true, legend: { text: t("publishers.jobseeker_profiles.filters.qualified_teacher_status") }, hint: nil)
-        = render "/vacancies/search/job_roles_filters", filters_component: filters_component, f: f, form: @form
         - filters_component.with_group key: "working_patterns", component: f.govuk_collection_check_boxes(:working_patterns, f.object.working_pattern_options, :first, :last, small: true, legend: { text: t("publishers.jobseeker_profiles.filters.preferred_working_patterns") }, hint: nil)
         - filters_component.with_group key: "education_phases", component: f.govuk_collection_check_boxes(:education_phases, f.object.education_phase_options, :first, :last, small: true, legend: { text: t("publishers.jobseeker_profiles.filters.preferred_education_phases") }, hint: nil)
         - filters_component.with_group key: "key_stages", component: f.govuk_collection_check_boxes(:key_stages, f.object.key_stage_options, :first, :last, small: true, legend: { text: t("publishers.jobseeker_profiles.filters.preferred_key_stages") }, hint: nil)

--- a/app/views/publishers/jobseeker_profiles/search/_job_roles_filters.html.slim
+++ b/app/views/publishers/jobseeker_profiles/search/_job_roles_filters.html.slim
@@ -1,0 +1,13 @@
+- teaching_job_roles = capture do
+  = govuk_details(summary_text: safe_join([tag.span(t("jobs.filters.teaching_job_roles"), "aria-label": t("jobs.aria_labels.filters.teaching_job_roles"), title: t("jobs.filters.teaching_job_roles"))]), open: form.teaching_job_roles&.any?) do
+    = f.govuk_collection_check_boxes(:teaching_job_roles, form.teaching_job_role_options, :first, :last, small: true, legend: nil, hint: nil)
+- teaching_support_job_roles = capture do
+  = govuk_details(summary_text: safe_join([tag.span(t("jobs.filters.teaching_support_job_roles"), "aria-label": t("jobs.aria_labels.filters.teaching_support_job_roles"), title: t("jobs.filters.teaching_support_job_roles"))]), open: form.teaching_support_job_roles&.any?) do
+    = f.govuk_collection_check_boxes(:teaching_support_job_roles, form.teaching_support_job_role_options, :first, :last, small: true, legend: nil, hint: nil)
+- non_teaching_support_job_roles = capture do
+  = govuk_details(summary_text: safe_join([tag.span(t("jobs.filters.non_teaching_support_job_roles"), "aria-label": t("jobs.aria_labels.filters.non_teaching_support_job_roles"), title: t("jobs.filters.non_teaching_support_job_roles"))]), open: form.non_teaching_support_job_roles&.any?) do
+    = f.govuk_collection_check_boxes(:non_teaching_support_job_roles, form.non_teaching_support_job_role_options, :first, :last, small: true, legend: nil, hint: nil)
+
+- filters_component.with_group key: "teaching_job_roles", component: teaching_job_roles, title: t("publishers.jobseeker_profiles.filters.preferred_roles")
+- filters_component.with_group key: "teaching_support_job_roles", component: teaching_support_job_roles
+- filters_component.with_group key: "non_teaching_support_job_roles", component: non_teaching_support_job_roles

--- a/app/views/vacancies/search/_job_roles_filters.html.slim
+++ b/app/views/vacancies/search/_job_roles_filters.html.slim
@@ -1,11 +1,11 @@
 - teaching_job_roles = capture do
-  = govuk_details(summary_text: safe_join([tag.span(t("jobs.filters.teaching_job_roles"), "aria-label": t("jobs.aria_labels.filters.teaching_job_roles"), title: t("jobs.filters.teaching_job_roles"))]), open: form.teaching_job_roles&.any?) do
+  = govuk_details(summary_text: safe_join([tag.span(t("jobs.filters.teaching_job_roles"), "aria-label": t("jobs.aria_labels.filters.teaching_job_roles"), title: t("jobs.filters.teaching_job_roles"))]), open: form.teaching_job_roles.any?) do
     = f.govuk_collection_check_boxes(:teaching_job_roles, form.teaching_job_role_options, :first, :last, small: true, legend: nil, hint: nil)
 - teaching_support_job_roles = capture do
-  = govuk_details(summary_text: safe_join([tag.span(t("jobs.filters.teaching_support_job_roles"), "aria-label": t("jobs.aria_labels.filters.teaching_support_job_roles"), title: t("jobs.filters.teaching_support_job_roles"))]), open: form.teaching_support_job_roles&.any?) do
+  = govuk_details(summary_text: safe_join([tag.span(t("jobs.filters.teaching_support_job_roles"), "aria-label": t("jobs.aria_labels.filters.teaching_support_job_roles"), title: t("jobs.filters.teaching_support_job_roles"))]), open: form.teaching_support_job_roles.any?) do
     = f.govuk_collection_check_boxes(:teaching_support_job_roles, form.teaching_support_job_role_options, :first, :last, small: true, legend: nil, hint: nil)
 - non_teaching_support_job_roles = capture do
-  = govuk_details(summary_text: safe_join([tag.span(t("jobs.filters.non_teaching_support_job_roles"), "aria-label": t("jobs.aria_labels.filters.non_teaching_support_job_roles"), title: t("jobs.filters.non_teaching_support_job_roles"))]), open: form.non_teaching_support_job_roles&.any?) do
+  = govuk_details(summary_text: safe_join([tag.span(t("jobs.filters.non_teaching_support_job_roles"), "aria-label": t("jobs.aria_labels.filters.non_teaching_support_job_roles"), title: t("jobs.filters.non_teaching_support_job_roles"))]), open: form.non_teaching_support_job_roles.any?) do
     = f.govuk_collection_check_boxes(:non_teaching_support_job_roles, form.non_teaching_support_job_role_options, :first, :last, small: true, legend: nil, hint: nil)
 
 - filters_component.with_group key: "teaching_job_roles", component: teaching_job_roles, title: t("jobs.filters.job_type")

--- a/app/views/vacancies/search/_job_roles_filters.html.slim
+++ b/app/views/vacancies/search/_job_roles_filters.html.slim
@@ -1,11 +1,12 @@
+- byebug
 - teaching_job_roles = capture do
-  = govuk_details(summary_text: safe_join([tag.span(t("jobs.filters.teaching_job_roles"), "aria-label": t("jobs.aria_labels.filters.teaching_job_roles"), title: t("jobs.filters.teaching_job_roles"))]), open: form.teaching_job_roles.any?) do
+  = govuk_details(summary_text: safe_join([tag.span(t("jobs.filters.teaching_job_roles"), "aria-label": t("jobs.aria_labels.filters.teaching_job_roles"), title: t("jobs.filters.teaching_job_roles"))]), open: form.teaching_job_roles&.any?) do
     = f.govuk_collection_check_boxes(:teaching_job_roles, form.teaching_job_role_options, :first, :last, small: true, legend: nil, hint: nil)
 - teaching_support_job_roles = capture do
-  = govuk_details(summary_text: safe_join([tag.span(t("jobs.filters.teaching_support_job_roles"), "aria-label": t("jobs.aria_labels.filters.teaching_support_job_roles"), title: t("jobs.filters.teaching_support_job_roles"))]), open: form.teaching_support_job_roles.any?) do
+  = govuk_details(summary_text: safe_join([tag.span(t("jobs.filters.teaching_support_job_roles"), "aria-label": t("jobs.aria_labels.filters.teaching_support_job_roles"), title: t("jobs.filters.teaching_support_job_roles"))]), open: form.teaching_support_job_roles&.any?) do
     = f.govuk_collection_check_boxes(:teaching_support_job_roles, form.teaching_support_job_role_options, :first, :last, small: true, legend: nil, hint: nil)
 - non_teaching_support_job_roles = capture do
-  = govuk_details(summary_text: safe_join([tag.span(t("jobs.filters.non_teaching_support_job_roles"), "aria-label": t("jobs.aria_labels.filters.non_teaching_support_job_roles"), title: t("jobs.filters.non_teaching_support_job_roles"))]), open: form.non_teaching_support_job_roles.any?) do
+  = govuk_details(summary_text: safe_join([tag.span(t("jobs.filters.non_teaching_support_job_roles"), "aria-label": t("jobs.aria_labels.filters.non_teaching_support_job_roles"), title: t("jobs.filters.non_teaching_support_job_roles"))]), open: form.non_teaching_support_job_roles&.any?) do
     = f.govuk_collection_check_boxes(:non_teaching_support_job_roles, form.non_teaching_support_job_role_options, :first, :last, small: true, legend: nil, hint: nil)
 
 - filters_component.with_group key: "teaching_job_roles", component: teaching_job_roles, title: t("jobs.filters.job_type")

--- a/app/views/vacancies/search/_job_roles_filters.html.slim
+++ b/app/views/vacancies/search/_job_roles_filters.html.slim
@@ -1,4 +1,3 @@
-- byebug
 - teaching_job_roles = capture do
   = govuk_details(summary_text: safe_join([tag.span(t("jobs.filters.teaching_job_roles"), "aria-label": t("jobs.aria_labels.filters.teaching_job_roles"), title: t("jobs.filters.teaching_job_roles"))]), open: form.teaching_job_roles&.any?) do
     = f.govuk_collection_check_boxes(:teaching_job_roles, form.teaching_job_role_options, :first, :last, small: true, legend: nil, hint: nil)

--- a/spec/services/search/jobseeker_profile_search_spec.rb
+++ b/spec/services/search/jobseeker_profile_search_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Search::JobseekerProfileSearch do
     end
 
     context "job_preferences roles" do
-      let(:filters) { { current_organisation: organisation, qualified_teacher_status: [], teaching_job_roles: [], non_teaching_support_job_roles: [], non_teaching_support_job_roles: %w[other_support], working_patterns: [], phases: [], key_stages: [], subjects: [] } }
+      let(:filters) { { current_organisation: organisation, qualified_teacher_status: [], teaching_job_roles: [], teaching_support_job_roles: [], non_teaching_support_job_roles: %w[other_support], working_patterns: [], phases: [], key_stages: [], subjects: [] } }
       let(:control_job_preferences_attrs) { { roles: %w[leader] } }
       let(:control_profile_attrs) { {} }
 
@@ -128,17 +128,17 @@ RSpec.describe Search::JobseekerProfileSearch do
       let!(:cleaning_staff_jobseeker_profile) { create(:jobseeker_profile, :with_personal_details, qualified_teacher_status: "no", job_preferences: cleaning_staff_job_preferences) }
       let(:cleaning_staff_job_preferences) { create(:job_preferences, roles: %w[catering_cleaning_and_site_management other_support], working_patterns: %w[full_time], locations: [cleaning_staff_location_preference_containing_school]) }
       let(:cleaning_staff_location_preference_containing_school) { create(:job_preferences_location, name: "London", radius: 100) }
-    
+
       let!(:teaching_assistant_jobseeker_profile) { create(:jobseeker_profile, :with_personal_details, qualified_teacher_status: "no", job_preferences: teaching_assistant_job_preferences) }
       let(:teaching_assistant_job_preferences) { create(:job_preferences, roles: %w[teaching_assistant higher_level_teaching_assistant], working_patterns: %w[full_time], locations: [teaching_assistant_preference_containing_school]) }
-      let(:teaching_assistant_preference_containing_school) { create(:job_preferences_location, name: "London", radius: 100) }    
+      let(:teaching_assistant_preference_containing_school) { create(:job_preferences_location, name: "London", radius: 100) }
 
       it "should only return the jobseeker profiles with the roles specified in the filters" do
         expect(search.jobseeker_profiles).to eq([cleaning_staff_jobseeker_profile])
       end
 
       context "searching using multiple roles" do
-        let(:filters) { { current_organisation: organisation, qualified_teacher_status: [], teaching_job_roles: %w[teacher headteacher], non_teaching_support_job_roles: [], non_teaching_support_job_roles: [], working_patterns: [], phases: [], key_stages: [], subjects: [] } }
+        let(:filters) { { current_organisation: organisation, qualified_teacher_status: [], teaching_job_roles: %w[teacher headteacher], teaching_support_job_roles: [], non_teaching_support_job_roles: [], working_patterns: [], phases: [], key_stages: [], subjects: [] } }
 
         let(:headteacher_jobseeker_profile) { create(:jobseeker_profile) }
         let(:headteacher_job_preferences) { create(:job_preferences, roles: %w[headteacher], jobseeker_profile: headteacher_jobseeker_profile) }

--- a/spec/services/search/jobseeker_profile_search_spec.rb
+++ b/spec/services/search/jobseeker_profile_search_spec.rb
@@ -99,16 +99,36 @@ RSpec.describe Search::JobseekerProfileSearch do
       let(:qts_job_preferences) { create(:job_preferences, jobseeker_profile: qts_jobseeker_profile) }
       let!(:qts_job_preference_location) { create(:job_preferences_location, **location_preference, job_preferences: qts_job_preferences) }
 
+      let(:no_qts_jobseeker_profile) { create(:jobseeker_profile, qualified_teacher_status: "no") }
+      let(:no_qts_job_preferences) { create(:job_preferences, jobseeker_profile: no_qts_jobseeker_profile) }
+      let!(:no_qts_job_preference_location) { create(:job_preferences_location, **location_preference, job_preferences: no_qts_job_preferences) }
+
+      let(:nil_qts_jobseeker_profile) { create(:jobseeker_profile, qualified_teacher_status: nil) }
+      let(:nil_qts_job_preferences) { create(:job_preferences, jobseeker_profile: nil_qts_jobseeker_profile) }
+      let!(:nil_qts_job_preference_location) { create(:job_preferences_location, **location_preference, job_preferences: nil_qts_job_preferences) }
+
+      let(:non_teacher_qts_jobseeker_profile) { create(:jobseeker_profile, qualified_teacher_status: "non_teacher") }
+      let(:non_teacher_qts_job_preferences) { create(:job_preferences, jobseeker_profile: non_teacher_qts_jobseeker_profile) }
+      let!(:non_teacher_qts_job_preference_location) { create(:job_preferences_location, **location_preference, job_preferences: non_teacher_qts_job_preferences) }
+
+      let(:on_track_qts_jobseeker_profile) { create(:jobseeker_profile, qualified_teacher_status: "on_track") }
+      let(:on_track_qts_job_preferences) { create(:job_preferences, jobseeker_profile: on_track_qts_jobseeker_profile) }
+      let!(:on_track_qts_job_preference_location) { create(:job_preferences_location, **location_preference, job_preferences: on_track_qts_job_preferences) }
+
       it "should return the jobseeker profiles with the qualified_teacher_status specified in the filters" do
         expect(search.jobseeker_profiles).to eq([qts_jobseeker_profile])
+      end
+      
+      context "when hiring staff selects 'Does not have QTS'" do
+        let(:filters) { { current_organisation: organisation, qualified_teacher_status: %w[no], roles: [], working_patterns: [], phases: [], key_stages: [], subjects: [] } }
+
+        it "returns jobseekers with who answered 'No', 'I'm not looking for a teaching role' or didn't answer the QTS question" do
+          expect(search.jobseeker_profiles).to match_array([no_qts_jobseeker_profile, nil_qts_jobseeker_profile, non_teacher_qts_jobseeker_profile])
+        end
       end
 
       context "searching using multiple QTS statuses" do
         let(:filters) { { current_organisation: organisation, qualified_teacher_status: %w[yes on_track], roles: [], working_patterns: [], phases: [], key_stages: [], subjects: [] } }
-
-        let(:on_track_qts_jobseeker_profile) { create(:jobseeker_profile, qualified_teacher_status: "on_track") }
-        let(:on_track_qts_job_preferences) { create(:job_preferences, jobseeker_profile: on_track_qts_jobseeker_profile) }
-        let!(:on_track_qts_job_preference_location) { create(:job_preferences_location, **location_preference, job_preferences: on_track_qts_job_preferences) }
 
         it "should return the jobseeker profiles with the qualified_teacher_status specified in the filters" do
           expect(search.jobseeker_profiles).to match_array([qts_jobseeker_profile, on_track_qts_jobseeker_profile])

--- a/spec/services/search/jobseeker_profile_search_spec.rb
+++ b/spec/services/search/jobseeker_profile_search_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Search::JobseekerProfileSearch do
       it "should return the jobseeker profiles with the qualified_teacher_status specified in the filters" do
         expect(search.jobseeker_profiles).to eq([qts_jobseeker_profile])
       end
-      
+
       context "when hiring staff selects 'Does not have QTS'" do
         let(:filters) { { current_organisation: organisation, qualified_teacher_status: %w[no], roles: [], working_patterns: [], phases: [], key_stages: [], subjects: [] } }
 

--- a/spec/services/search/jobseeker_profile_search_spec.rb
+++ b/spec/services/search/jobseeker_profile_search_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Search::JobseekerProfileSearch do
     end
 
     context "job_preferences roles" do
-      let(:filters) { { current_organisation: organisation, qualified_teacher_status: [], roles: %w[teacher], working_patterns: [], phases: [], key_stages: [], subjects: [] } }
+      let(:filters) { { current_organisation: organisation, qualified_teacher_status: [], teaching_job_roles: [], non_teaching_support_job_roles: [], non_teaching_support_job_roles: %w[other_support], working_patterns: [], phases: [], key_stages: [], subjects: [] } }
       let(:control_job_preferences_attrs) { { roles: %w[leader] } }
       let(:control_profile_attrs) { {} }
 
@@ -125,12 +125,20 @@ RSpec.describe Search::JobseekerProfileSearch do
       let(:teacher_job_preferences) { create(:job_preferences, roles: %w[teacher], jobseeker_profile: teacher_jobseeker_profile) }
       let!(:teacher_job_preference_location) { create(:job_preferences_location, **location_preference, job_preferences: teacher_job_preferences) }
 
+      let!(:cleaning_staff_jobseeker_profile) { create(:jobseeker_profile, :with_personal_details, qualified_teacher_status: "no", job_preferences: cleaning_staff_job_preferences) }
+      let(:cleaning_staff_job_preferences) { create(:job_preferences, roles: %w[catering_cleaning_and_site_management other_support], working_patterns: %w[full_time], locations: [cleaning_staff_location_preference_containing_school]) }
+      let(:cleaning_staff_location_preference_containing_school) { create(:job_preferences_location, name: "London", radius: 100) }
+    
+      let!(:teaching_assistant_jobseeker_profile) { create(:jobseeker_profile, :with_personal_details, qualified_teacher_status: "no", job_preferences: teaching_assistant_job_preferences) }
+      let(:teaching_assistant_job_preferences) { create(:job_preferences, roles: %w[teaching_assistant higher_level_teaching_assistant], working_patterns: %w[full_time], locations: [teaching_assistant_preference_containing_school]) }
+      let(:teaching_assistant_preference_containing_school) { create(:job_preferences_location, name: "London", radius: 100) }    
+
       it "should only return the jobseeker profiles with the roles specified in the filters" do
-        expect(search.jobseeker_profiles).to eq([teacher_jobseeker_profile])
+        expect(search.jobseeker_profiles).to eq([cleaning_staff_jobseeker_profile])
       end
 
       context "searching using multiple roles" do
-        let(:filters) { { current_organisation: organisation, qualified_teacher_status: [], roles: %w[teacher headteacher], working_patterns: [], phases: [], key_stages: [], subjects: [] } }
+        let(:filters) { { current_organisation: organisation, qualified_teacher_status: [], teaching_job_roles: %w[teacher headteacher], non_teaching_support_job_roles: [], non_teaching_support_job_roles: [], working_patterns: [], phases: [], key_stages: [], subjects: [] } }
 
         let(:headteacher_jobseeker_profile) { create(:jobseeker_profile) }
         let(:headteacher_job_preferences) { create(:job_preferences, roles: %w[headteacher], jobseeker_profile: headteacher_jobseeker_profile) }

--- a/spec/system/publishers/publishers_can_search_for_jobseeker_profiles_spec.rb
+++ b/spec/system/publishers/publishers_can_search_for_jobseeker_profiles_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe "Publishers searching for Jobseeker profiles", type: :system do
   let(:teaching_assistant_job_preferences) { create(:job_preferences, roles: %w[teaching_assistant higher_level_teaching_assistant], working_patterns: %w[full_time], locations: [teaching_assistant_preference_containing_school]) }
   let(:teaching_assistant_preference_containing_school) { create(:job_preferences_location, name: "London", radius: 100) }
 
-
   describe "Visiting the publisher's jobseeker profiles start page" do
     before { login_publisher(publisher:, organisation:) }
 

--- a/spec/system/publishers/publishers_can_search_for_jobseeker_profiles_spec.rb
+++ b/spec/system/publishers/publishers_can_search_for_jobseeker_profiles_spec.rb
@@ -21,6 +21,15 @@ RSpec.describe "Publishers searching for Jobseeker profiles", type: :system do
   let(:no_right_to_work_in_uk_preferences) { create(:job_preferences, roles: %w[teacher], key_stages: %w[ks1], working_patterns: %w[part_time], locations: [no_right_to_work_in_uk_containing_school], subjects: ["Geography"]) }
   let(:no_right_to_work_in_uk_containing_school) { create(:job_preferences_location, name: "London", radius: 100) }
 
+  let!(:cleaning_staff_jobseeker_profile) { create(:jobseeker_profile, :with_personal_details, qualified_teacher_status: "no", job_preferences: cleaning_staff_job_preferences) }
+  let(:cleaning_staff_job_preferences) { create(:job_preferences, roles: %w[catering_cleaning_and_site_management other_support], working_patterns: %w[full_time], locations: [cleaning_staff_location_preference_containing_school]) }
+  let(:cleaning_staff_location_preference_containing_school) { create(:job_preferences_location, name: "London", radius: 100) }
+
+  let!(:teaching_assistant_jobseeker_profile) { create(:jobseeker_profile, :with_personal_details, qualified_teacher_status: "no", job_preferences: teaching_assistant_job_preferences) }
+  let(:teaching_assistant_job_preferences) { create(:job_preferences, roles: %w[teaching_assistant higher_level_teaching_assistant], working_patterns: %w[full_time], locations: [teaching_assistant_preference_containing_school]) }
+  let(:teaching_assistant_preference_containing_school) { create(:job_preferences_location, name: "London", radius: 100) }
+
+
   describe "Visiting the publisher's jobseeker profiles start page" do
     before { login_publisher(publisher:, organisation:) }
 
@@ -69,6 +78,8 @@ RSpec.describe "Publishers searching for Jobseeker profiles", type: :system do
         expect(page).to_not have_link(href: publishers_jobseeker_profile_path(part_time_jobseeker_profile))
         expect(page).to_not have_link(href: publishers_jobseeker_profile_path(jobseeker_profile))
         expect(page).to_not have_link(href: publishers_jobseeker_profile_path(no_right_to_work_in_uk_profile))
+        expect(page).to_not have_link(href: publishers_jobseeker_profile_path(cleaning_staff_jobseeker_profile))
+        expect(page).to_not have_link(href: publishers_jobseeker_profile_path(teaching_assistant_jobseeker_profile))
         expect(page).to have_link(I18n.t("publishers.jobseeker_profiles.filters.working_pattern_options.part_time"))
         expect(page).to have_link(I18n.t("publishers.jobseeker_profiles.filters.key_stage_options.ks5"))
         expect(page).to have_link(I18n.t("publishers.jobseeker_profiles.filters.right_to_work_in_uk_options.true"))
@@ -81,6 +92,8 @@ RSpec.describe "Publishers searching for Jobseeker profiles", type: :system do
         expect(page).to have_link(href: publishers_jobseeker_profile_path(part_time_jobseeker_profile))
         expect(page).to_not have_link(href: publishers_jobseeker_profile_path(jobseeker_profile))
         expect(page).to have_link(href: publishers_jobseeker_profile_path(no_right_to_work_in_uk_profile))
+        expect(page).to_not have_link(href: publishers_jobseeker_profile_path(cleaning_staff_jobseeker_profile))
+        expect(page).to_not have_link(href: publishers_jobseeker_profile_path(teaching_assistant_jobseeker_profile))
         expect(page).to have_link(I18n.t("publishers.jobseeker_profiles.filters.working_pattern_options.part_time"))
         expect(page).not_to have_link(I18n.t("publishers.jobseeker_profiles.filters.key_stage_options.ks5"))
         expect(page).not_to have_link(I18n.t("publishers.jobseeker_profiles.filters.right_to_work_in_uk_options.true"))
@@ -92,9 +105,59 @@ RSpec.describe "Publishers searching for Jobseeker profiles", type: :system do
         expect(page).to have_link(href: publishers_jobseeker_profile_path(part_time_jobseeker_profile))
         expect(page).to have_link(href: publishers_jobseeker_profile_path(jobseeker_profile))
         expect(page).to have_link(href: publishers_jobseeker_profile_path(no_right_to_work_in_uk_profile))
+        expect(page).to have_link(href: publishers_jobseeker_profile_path(cleaning_staff_jobseeker_profile))
+        expect(page).to have_link(href: publishers_jobseeker_profile_path(teaching_assistant_jobseeker_profile))
         expect(page).not_to have_link(I18n.t("publishers.jobseeker_profiles.filters.working_pattern_options.part_time"))
         expect(page).not_to have_link(I18n.t("publishers.jobseeker_profiles.filters.key_stage_options.ks5"))
         expect(page).not_to have_link(I18n.t("publishers.jobseeker_profiles.filters.right_to_work_in_uk_options.true"))
+      end
+    end
+
+    context "when role filters are selected" do
+      before do
+        visit publishers_jobseeker_profiles_path
+      end
+
+      it "will allow hiring staff to filter by jobseekers' preferred roles" do
+        within ".filters-component" do
+          find('span[title="Teaching support"]').click
+          check "HLTA (higher level teaching assistant)"
+          find('span[title="Non-teaching support"]').click
+          check "Catering, cleaning and site management"
+          click_on I18n.t("buttons.apply_filters")
+        end
+
+        expect(page).not_to have_link(href: publishers_jobseeker_profile_path(part_time_jobseeker_profile))
+        expect(page).not_to have_link(href: publishers_jobseeker_profile_path(jobseeker_profile))
+        expect(page).not_to have_link(href: publishers_jobseeker_profile_path(no_right_to_work_in_uk_profile))
+        expect(page).to have_link(href: publishers_jobseeker_profile_path(cleaning_staff_jobseeker_profile))
+        expect(page).to have_link(href: publishers_jobseeker_profile_path(teaching_assistant_jobseeker_profile))
+        expect(page).to have_link("Catering, cleaning and site management")
+        expect(page).to have_link("HLTA (higher level teaching assistant)")
+
+        click_link "HLTA (higher level teaching assistant)"
+
+        within ".filters-component" do
+          find('span[title="Teaching"]').click
+          check "Teacher"
+          click_on I18n.t("buttons.apply_filters")
+        end
+
+        expect(page).to have_link(href: publishers_jobseeker_profile_path(part_time_jobseeker_profile))
+        expect(page).to have_link(href: publishers_jobseeker_profile_path(jobseeker_profile))
+        expect(page).to have_link(href: publishers_jobseeker_profile_path(no_right_to_work_in_uk_profile))
+        expect(page).to have_link(href: publishers_jobseeker_profile_path(cleaning_staff_jobseeker_profile))
+        expect(page).not_to have_link(href: publishers_jobseeker_profile_path(teaching_assistant_jobseeker_profile))
+        expect(page).to have_link("Catering, cleaning and site management")
+        expect(page).to have_link("Teacher")
+
+        click_link "Clear filters"
+
+        expect(page).to have_link(href: publishers_jobseeker_profile_path(part_time_jobseeker_profile))
+        expect(page).to have_link(href: publishers_jobseeker_profile_path(jobseeker_profile))
+        expect(page).to have_link(href: publishers_jobseeker_profile_path(no_right_to_work_in_uk_profile))
+        expect(page).to have_link(href: publishers_jobseeker_profile_path(cleaning_staff_jobseeker_profile))
+        expect(page).to have_link(href: publishers_jobseeker_profile_path(teaching_assistant_jobseeker_profile))
       end
     end
   end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/ncEycij5/759-asr-hiring-staff-candidate-profiles

## Changes in this PR:

- Add new roles to the candidate profile search page filters.
- Re order search page filters
- Allow searching of candidates by the new roles.
- Change to QTS filter logic to return users with the following values in the qts column if the hiring staff filter by "does not have QTS": nil, no, non_teacher.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
