### PR TITLE
Fix legacy working patterns details being copied to new vacancies

### DIFF
--- a/app/services/copy_vacancy.rb
+++ b/app/services/copy_vacancy.rb
@@ -57,6 +57,7 @@ class CopyVacancy
     @new_vacancy.how_to_apply = nil
     @new_vacancy.safeguarding_information_provided = nil
     @new_vacancy.safeguarding_information = nil
+    @new_vacancy.working_patterns_details = nil
   end
 
   def current_steps

--- a/lib/tasks/remove_working_patterns.rake
+++ b/lib/tasks/remove_working_patterns.rake
@@ -14,4 +14,12 @@ namespace :vacancies do
       vacancy.update(working_patterns: new_working_patterns)
     end
   end
+
+  desc "Remove incorrectly copied legacy working patterns details from newer vacancies since legacy field was deprecated on 25th August 2022"
+  task remove_copied_legacy_working_patterns_details: :environment do
+    Vacancy.where("((full_time_details IS NOT NULL AND full_time_details != '') OR (part_time_details IS NOT NULL AND part_time_details != '')) " \
+                  "AND working_patterns_details IS NOT NULL " \
+                  "AND working_patterns_details != '' " \
+                  "AND created_at >= '2022-08-25'").update_all(working_patterns_details: nil)
+  end
 end

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -68,8 +68,8 @@ FactoryBot.define do
     visa_sponsorship_available { false }
 
     after(:build) do |v|
-      v.full_time_details = Faker::Lorem.sentence(word_count: factory_rand(1..50)) if v.working_patterns.include?("full_time")
-      v.part_time_details = Faker::Lorem.sentence(word_count: factory_rand(1..50)) if v.working_patterns.include?("part_time")
+      v.full_time_details = Faker::Lorem.sentence(word_count: factory_rand(1..50)) if v.working_patterns.include?("full_time") && v.full_time_details.blank?
+      v.part_time_details = Faker::Lorem.sentence(word_count: factory_rand(1..50)) if v.working_patterns.include?("part_time") && v.part_time_details.blank?
     end
 
     trait :legacy_vacancy do

--- a/spec/support/rake_tasks.rb
+++ b/spec/support/rake_tasks.rb
@@ -8,6 +8,13 @@ module TaskExampleGroup
     let(:tasks) { Rake::Task }
 
     subject(:task) { tasks[task_name] }
+
+    after(:each) do
+      # Calling a rake task sets their invoked state to "already invoked" and causes further tests for the task to be
+      # skipped and tests to fail.
+      # Following line allows the task to be called again in the next test.
+      task.reenable
+    end
   end
 end
 

--- a/spec/tasks/remove_copied_legacy_working_patterns_details_spec.rb
+++ b/spec/tasks/remove_copied_legacy_working_patterns_details_spec.rb
@@ -1,0 +1,94 @@
+require "rails_helper"
+
+RSpec.describe "vacancies:remove_copied_legacy_working_patterns_details" do
+  let(:migration_date) { Date.new(2022, 8, 25) }
+  let(:working_patterns_details) { "Legacy details" }
+
+  let!(:vacancy) do
+    create(:vacancy, created_at:, working_patterns:, full_time_details:, part_time_details:, working_patterns_details:)
+  end
+
+  RSpec.shared_examples "removes legacy working patterns details" do
+    it "removes the legacy working patterns details" do
+      expect { task.invoke }.to change { vacancy.reload.working_patterns_details }.from(working_patterns_details).to(nil)
+    end
+  end
+
+  RSpec.shared_examples "does not remove legacy working patterns details" do
+    it "does not remove the legacy working patterns details" do
+      expect { task.invoke }.not_to(change { vacancy.reload.working_patterns_details })
+    end
+  end
+
+  context "with a vacancy created post-migration date" do
+    let(:created_at) { migration_date + 1.day }
+
+    context "with full_time_details and part_time_details" do
+      let(:working_patterns) { %w[full_time part_time] }
+      let(:full_time_details) { "Full time details" }
+      let(:part_time_details) { "Part time details" }
+
+      include_examples "removes legacy working patterns details"
+    end
+
+    context "without full_time_details and part_time_details" do
+      let(:working_patterns) { [] }
+      let(:full_time_details) { "" }
+      let(:part_time_details) { "" }
+
+      include_examples "does not remove legacy working patterns details"
+    end
+
+    context "with only full_time_details" do
+      let(:working_patterns) { %w[full_time] }
+      let(:full_time_details) { "Full time details" }
+      let(:part_time_details) { "" }
+
+      include_examples "removes legacy working patterns details"
+    end
+
+    context "with only part_time_details" do
+      let(:working_patterns) { %w[part_time] }
+      let(:full_time_details) { "" }
+      let(:part_time_details) { "Part time details" }
+
+      include_examples "removes legacy working patterns details"
+    end
+  end
+
+  context "with a vacancy created pre-migration date" do
+    let(:created_at) { migration_date - 1.day }
+
+    context "with full_time_details and part_time_details" do
+      let(:working_patterns) { %w[full_time part_time] }
+      let(:full_time_details) { "Full time details" }
+      let(:part_time_details) { "Part time details" }
+
+      include_examples "does not remove legacy working patterns details"
+    end
+
+    context "without full_time_details and part_time_details" do
+      let(:working_patterns) { [] }
+      let(:full_time_details) { "" }
+      let(:part_time_details) { "" }
+
+      include_examples "does not remove legacy working patterns details"
+    end
+
+    context "with only full_time_details" do
+      let(:working_patterns) { %w[full_time] }
+      let(:full_time_details) { "Full time details" }
+      let(:part_time_details) { "" }
+
+      include_examples "does not remove legacy working patterns details"
+    end
+
+    context "with only part_time_details" do
+      let(:working_patterns) { %w[part_time] }
+      let(:full_time_details) { "" }
+      let(:part_time_details) { "Part time details" }
+
+      include_examples "does not remove legacy working patterns details"
+    end
+  end
+end


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/pxMTY1Gz

## Changes in this PR:


### Issue we are resolving:
While trying to re-instate the usage of the previously abandoned `working_patterns_details` field instead of the current individual `full/part_time_details` fields, I've noticed that even recent vacancies were still populating the abandoned  `working_patterns_details` field.

This is caused by the `CopyVacancy` service cloning this legacy value across vacancies when the publishers copy old vacancies to create a new one.

The field stopped being manually populated by publishers since August 25th 2022 when [this PR](https://github.com/DFE-Digital/teaching-vacancies/pull/5340) that replaced it for the new `full/part_time_details fields` was merged

### How we are resolving it:
1. Stop copying this field value when the publisher copies a vacancy.
2. Add a rake task to remove `working_patterns_details` values for any vacancy created during/after August 25th 2022 and containing either full or part-time details. As the information is irrelevant and conflicting. The `working_patterns_details` contained by these vacancies was always caused by copying the vacancy, not manual input (there was no way to introduce it manually).

## Related PRs
https://github.com/DFE-Digital/teaching-vacancies/pull/5340

