### PR TITLE
Right to work question

### DIFF
--- a/app/views/jobseekers/_visa_sponsorship_banner.html.slim
+++ b/app/views/jobseekers/_visa_sponsorship_banner.html.slim
@@ -2,4 +2,3 @@
   - notification_banner.with_heading(text: t("visa_sponsorship_banner.heading"))
 
   p.govuk-body = t("visa_sponsorship_banner.body", link: govuk_link_to(t("visa_sponsorship_banner.link_text"), edit_personal_details_jobseekers_profile_path(step: "work"))).html_safe
-  

--- a/app/views/jobseekers/_visa_sponsorship_banner.html.slim
+++ b/app/views/jobseekers/_visa_sponsorship_banner.html.slim
@@ -1,0 +1,5 @@
+= govuk_notification_banner title_text: "Important", classes: "govuk-notification-banner govuk-!-margin-top-0 govuk-!-margin-bottom-5" do |notification_banner|
+  - notification_banner.with_heading(text: t("visa_sponsorship_banner.heading"))
+
+  p.govuk-body = t("visa_sponsorship_banner.body", link: govuk_link_to(t("visa_sponsorship_banner.link_text"), edit_personal_details_jobseekers_profile_path(step: "work"))).html_safe
+  

--- a/app/views/jobseekers/job_applications/index.html.slim
+++ b/app/views/jobseekers/job_applications/index.html.slim
@@ -3,7 +3,7 @@
 - if current_jobseeker.job_applications.any?
   - content_for :skip_links do
     = govuk_skip_link(href: "#applications-results", text: t(".skip_link"))
-
+= render "jobseekers/visa_sponsorship_banner"
 h1.govuk-heading-l = t(".page_title_with_count", count: current_jobseeker.job_applications.count)
 
 .govuk-grid-row

--- a/app/views/jobseekers/job_applications/index.html.slim
+++ b/app/views/jobseekers/job_applications/index.html.slim
@@ -3,7 +3,8 @@
 - if current_jobseeker.job_applications.any?
   - content_for :skip_links do
     = govuk_skip_link(href: "#applications-results", text: t(".skip_link"))
-= render "jobseekers/visa_sponsorship_banner"
+- if Date.today <= Date.new(2024, 4, 2)
+  = render "jobseekers/visa_sponsorship_banner"
 h1.govuk-heading-l = t(".page_title_with_count", count: current_jobseeker.job_applications.count)
 
 .govuk-grid-row

--- a/app/views/jobseekers/profiles/personal_details/work.html.slim
+++ b/app/views/jobseekers/profiles/personal_details/work.html.slim
@@ -11,7 +11,7 @@
       = f.govuk_radio_buttons_fieldset :right_to_work_in_uk,
         legend: { text: t(".page_title"), tag: "h1", size: "l" },
         caption: { text: t(".caption"), size: "l" },
-        hint: { text: t(".hint.text", link: govuk_link_to(t(".hint.link"), "https://getintoteaching.education.gov.uk/non-uk-teachers/teach-in-england-if-you-trained-overseas#apply-for-your-visa", target: "_blank")).html_safe } do
+        hint: { text: t(".hint.text", link: govuk_link_to(t(".hint.link"), "https://getintoteaching.education.gov.uk/non-uk-teachers/visas-for-non-uk-teachers", target: "_blank")).html_safe } do
 
         = f.govuk_radio_button :right_to_work_in_uk, "true", label: { text: t(".options.true") }, link_errors: true
         = f.govuk_radio_button :right_to_work_in_uk, "false", label: { text: t(".options.false") }

--- a/app/views/jobseekers/saved_jobs/index.html.slim
+++ b/app/views/jobseekers/saved_jobs/index.html.slim
@@ -14,7 +14,8 @@ h1.govuk-heading-l = t(".page_title")
 .govuk-grid-row
   .govuk-grid-column-full
     = render "candidiate_profiles_banner" unless profile_complete?
-    = render "jobseekers/visa_sponsorship_banner"
+    - if Date.today <= Date.new(2024, 4, 2)
+      = render "jobseekers/visa_sponsorship_banner"
     - if saved_jobs.any?
       #vacancy-results
         - saved_jobs.each do |saved_job|

--- a/app/views/jobseekers/saved_jobs/index.html.slim
+++ b/app/views/jobseekers/saved_jobs/index.html.slim
@@ -14,6 +14,7 @@ h1.govuk-heading-l = t(".page_title")
 .govuk-grid-row
   .govuk-grid-column-full
     = render "candidiate_profiles_banner" unless profile_complete?
+    = render "jobseekers/visa_sponsorship_banner"
     - if saved_jobs.any?
       #vacancy-results
         - saved_jobs.each do |saved_job|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -451,6 +451,11 @@ en:
       - specify the types of teaching jobs you're looking for
       - apply for roles more quickly by pre-filling your information
     link_to_profile: Create a profile to simplify your job search.
+  
+  visa_sponsorship_banner:
+    heading: You can now specify if you need visa sponsorship on your profile
+    body: You can %{link} on your profile.
+    link_text: update your answer about needing a visa sponsorship
 
   terms_and_conditions:
     intro_html: >-

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -840,7 +840,7 @@ en:
         support_needed: Do you want to ask for support so that you can attend an interview?
       jobseekers_job_application_declarations_form:
         close_relationships: Do you have any family or close relationship with people within %{organisation}?
-        right_to_work_in_uk: Do you currently have the right to work in the UK?
+        right_to_work_in_uk: Do you need Skilled worker visa sponsorship?
         safeguarding_issue: Do you want to declare any safeguarding issues, such as a criminal record or professional misconduct?
       jobseekers_job_application_details_reference_form:
         phone_number: Phone number

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -417,7 +417,7 @@ en:
         declarations:
           close_relationships: Do you have any family or close relationship with people within %{organisation}
           heading: Declarations
-          right_to_work_in_uk: Do you currently have the right to work in the UK?
+          right_to_work_in_uk: Do you currently have the right to work in the UK?2
         employment_history:
           current_role: Is this your current role?
           ended_on: End date
@@ -653,15 +653,15 @@ en:
           last_name: Last name
           phone_number: Phone number
           phone_number_provided: Do you want to provide a phone number?
-          right_to_work_in_uk: Do you currently have the right to work in the UK?
+          right_to_work_in_uk: Do you need a Skilled worker visa sponsorship?
         work:
           caption: Personal details
           hint:
-            text: If you're a non-UK citizen you will need a visa or immigration status which allows you to work as a teacher in England. Learn more about %{link}
-            link: teaching in England as a non-UK citizen (opens in new tab).
+            text: You can %{link}
+            link: find out what visa you need if you're a non-UK citizen (link opens in new tab).
             no_visa:
-              text: There is %{link} if you qualified outside the UK.
-              link: guidance for working as a teacher in England (link opens in new tab)
+              text: You can %{link}
+              link: find out what visa you need if you're a non-UK citizen (link opens in new tab).
           warning:
             text: This role cannot offer visa sponsorship.
             paragraph_1: It is unlikely you will be considered for this job as it is not offering skilled worker visa sponsorship to non-UK citizens.
@@ -677,9 +677,9 @@ en:
             text: You may be able to apply for QTS – %{link}.
             link: check your eligibility (link opens in new tab)
           options:
-            false: "No"
-            true: "Yes"
-          page_title: Do you currently have the right to work in the UK?
+            false: "Yes, I will need to apply for a visa giving me the right to work in the UK"
+            true: "No, I already have the right to work in the UK"
+          page_title: Do you need Skilled work visa sponsorship?
           schools_cannot_give_advice:
             text: "Schools cannot give you advice about becoming a teacher in England. However, you can visit %{link} to learn more about:"
             link: Teach in England if you trained overseas (link opens in new tab)

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -417,7 +417,7 @@ en:
         declarations:
           close_relationships: Do you have any family or close relationship with people within %{organisation}
           heading: Declarations
-          right_to_work_in_uk: Do you currently have the right to work in the UK?2
+          right_to_work_in_uk: Do you currently have the right to work in the UK?
         employment_history:
           current_role: Is this your current role?
           ended_on: End date

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -111,7 +111,7 @@ en:
         preferred_roles: "Preferred roles"
         preferred_working_patterns: "Preferred working patterns"
         qualified_teacher_status: "Qualified teaching status (QTS)"
-        right_to_work_in_uk: "Right to work in the UK"
+        right_to_work_in_uk: "Visa sponsorship"
         qts_options:
           "no": Does not have QTS
           on_track: On track to receive QTS

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -132,8 +132,8 @@ en:
           full_time: "Full time"
           part_time: "Part time"
         right_to_work_in_uk_options:
-          "true": "Does have the right to work in the UK"
-          "false": "Does not have the right to work in the UK"
+          "true": "Does not need visa sponsorship"
+          "false": "Needs visa sponsorship"
     login_keys:
       new:
         notice: >-

--- a/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Jobseekers can manage their profile" do
         fill_in "personal_details_form[phone_number]", with: phone_number
         click_on I18n.t("buttons.save_and_continue")
 
-        expect(page).to have_content("Do you currently have the right to work in the UK?")
+        expect(page).to have_content("Do you need Skilled work visa sponsorship?")
         choose "Yes"
         click_on I18n.t("buttons.save_and_continue")
 
@@ -55,7 +55,7 @@ RSpec.describe "Jobseekers can manage their profile" do
         expect(page).to have_content(first_name)
         expect(page).to have_content(last_name)
         expect(page).to have_content(phone_number)
-        expect(page).to have_content("Do you currently have the right to work in the UK?Yes")
+        expect(page).to have_content("Yes, I will need to apply for a visa giving me the right to work in the UK")
       end
 
       it "does not display a notice to inform the user about prefilling" do
@@ -101,7 +101,7 @@ RSpec.describe "Jobseekers can manage their profile" do
         expect(page).to have_content(new_last_name)
         expect(page).to have_content("Do you want to provide a phone number?No")
         expect(page).not_to have_content(old_phone_number)
-        expect(page).to have_content("Do you currently have the right to work in the UK?No")
+        expect(page).to have_content("No, I already have the right to work in the UK")
       end
     end
   end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/fGZQieAJ/851-replace-right-to-work-question-content

## Changes in this PR:

This PR changes the content on the right to work page in the application form and in the jobseeker profile. It also adds a banner to let the user know about the changes on the saved jobs and applications index pages.

Note: I have just added an if statement to ensure the banners are not shown for more than 4 weeks. We will need to remove this banner after 4 weeks anyway so I added this if statement just in case for some reason we do not manage to remove it in time (I have put a note in my calendar to remove it though!).

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
