### PR TITLE
Stop blocking forms based on Recaptcha v3 score

### DIFF
--- a/app/controllers/concerns/recaptcha_checking.rb
+++ b/app/controllers/concerns/recaptcha_checking.rb
@@ -10,11 +10,15 @@ module RecaptchaChecking
   end
 
   def handle_invalid_recaptcha(form: nil, score: nil)
+    log_invalid_recaptcha(form: form, score: score)
+    redirect_to invalid_recaptcha_path
+  end
+
+  def log_invalid_recaptcha(form: nil, score: nil)
     form_name = form.class.name.gsub("::", "").underscore.humanize if form.present?
     Sentry.with_scope do |scope|
       scope.set_tags("form.name": form_name, "recaptcha.score": score)
       Sentry.capture_message("Invalid recaptcha", level: :warning)
     end
-    redirect_to invalid_recaptcha_path
   end
 end

--- a/app/controllers/general_feedbacks_controller.rb
+++ b/app/controllers/general_feedbacks_controller.rb
@@ -12,9 +12,8 @@ class GeneralFeedbacksController < ApplicationController
 
     if @general_feedback_form.invalid?
       render :new
-    elsif recaptcha_is_invalid?
-      handle_invalid_recaptcha(form: @general_feedback_form, score: recaptcha_reply["score"])
     else
+      log_invalid_recaptcha(form: @general_feedback_form, score: recaptcha_reply["score"]) if recaptcha_is_invalid?
       @feedback.recaptcha_score = recaptcha_reply&.dig("score")
       @feedback.save
       redirect_to root_path, success: t(".success")

--- a/app/controllers/jobseekers/subscriptions/feedbacks/further_feedbacks_controller.rb
+++ b/app/controllers/jobseekers/subscriptions/feedbacks/further_feedbacks_controller.rb
@@ -10,9 +10,8 @@ class Jobseekers::Subscriptions::Feedbacks::FurtherFeedbacksController < Applica
 
     if @feedback_form.invalid?
       render :new
-    elsif recaptcha_is_invalid?
-      handle_invalid_recaptcha(form: @feedback_form, score: recaptcha_reply["score"])
     else
+      log_invalid_recaptcha(form: @feedback_form, score: recaptcha_reply["score"]) if recaptcha_is_invalid?
       update_feedback
       redirect_to root_path, success: t(".success")
     end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -21,9 +21,8 @@ class SubscriptionsController < ApplicationController
 
     if @form.invalid?
       render :new
-    elsif recaptcha_is_invalid?
-      handle_invalid_recaptcha(form: @form, score: recaptcha_reply["score"])
     else
+      log_invalid_recaptcha(form: @form, score: recaptcha_reply["score"]) if recaptcha_is_invalid?
       notify_new_subscription(subscription)
 
       if jobseeker_signed_in?

--- a/app/controllers/support_requests_controller.rb
+++ b/app/controllers/support_requests_controller.rb
@@ -10,9 +10,8 @@ class SupportRequestsController < ApplicationController
 
     if @form.invalid?
       render :new
-    elsif recaptcha_is_invalid?
-      handle_invalid_recaptcha(form: @form, score: recaptcha_reply["score"])
     else
+      log_invalid_recaptcha(form: @form, score: recaptcha_reply["score"]) if recaptcha_is_invalid?
       Zendesk.create_request!(
         attachments: [@form.screenshot],
         comment: @form.issue,

--- a/spec/controllers/jobseekers/subscriptions_controller_spec.rb
+++ b/spec/controllers/jobseekers/subscriptions_controller_spec.rb
@@ -73,40 +73,14 @@ RSpec.describe SubscriptionsController, recaptcha: true do
           allow_any_instance_of(ApplicationController).to receive(:verify_recaptcha).and_return(false)
         end
 
-        context "and subscription form is valid" do
-          it "redirects to invalid_recaptcha_path" do
-            subject
-            expect(response).to redirect_to(invalid_recaptcha_path)
-          end
-
-          it "does not save the Subscription record" do
-            expect(subscription).not_to receive(:save)
-            subject
-          end
-
-          it "sends the recaptcha error to Sentry" do
-            expect(Sentry).to receive(:capture_message).with("Invalid recaptcha", level: :warning)
-            subject
-          end
+        it "sets the recaptcha score on the Subscription record" do
+          expect(subscription).to receive(:update).with(recaptcha_score: recaptcha_score)
+          subject
         end
 
-        context "and subscription is not valid" do
-          let(:subscription_form_valid?) { false }
-
-          it "does not save the Subscription record" do
-            expect(subscription).not_to receive(:save)
-            subject
-          end
-
-          it "renders :new" do
-            subject
-            expect(response).to render_template(:new)
-          end
-
-          it "doesn't send a recaptcha error to Sentry" do
-            expect(Sentry).not_to receive(:capture_message).with("Invalid recaptcha", level: :warning)
-            subject
-          end
+        it "sends the recaptcha error to Sentry" do
+          expect(Sentry).to receive(:capture_message).with("Invalid recaptcha", level: :warning)
+          subject
         end
       end
     end

--- a/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe "Jobseekers can create a job alert from a search", recaptcha: tru
         allow_any_instance_of(ApplicationController).to receive(:verify_recaptcha).and_return(false)
       end
 
-      scenario "redirects to invalid_recaptcha path" do
+      it "registers the recaptcha failure while still creating the job alert" do
         visit new_subscription_path(search_criteria: { keyword: "test", location: "London" })
         fill_in_subscription_fields
-        click_on I18n.t("buttons.subscribe")
-        expect(page).to have_current_path(invalid_recaptcha_path)
+        expect(Sentry).to receive(:capture_message).with("Invalid recaptcha", level: :warning)
+        expect { click_on I18n.t("buttons.subscribe") }.to change { Subscription.count }.by(1)
       end
     end
   end

--- a/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_the_dashboard_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_the_dashboard_spec.rb
@@ -31,12 +31,13 @@ RSpec.describe "Jobseekers can create a job alert from the dashboard", recaptcha
         allow_any_instance_of(ApplicationController).to receive(:verify_recaptcha).and_return(false)
       end
 
-      it "redirects to invalid_recaptcha path" do
+      it "registers the recaptcha failure while still creating the job alert" do
         within ".empty-section-component" do
           click_on I18n.t("jobseekers.subscriptions.index.link_create")
         end
-        create_a_job_alert
-        expect(page).to have_current_path(invalid_recaptcha_path)
+        expect(Sentry).to receive(:capture_message).with("Invalid recaptcha", level: :warning)
+        expect { create_a_job_alert }.to change { Subscription.count }.by(1)
+        and_the_job_alert_is_on_the_index_page
       end
     end
   end

--- a/spec/system/jobseekers/jobseekers_can_give_job_alert_feedback_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_give_job_alert_feedback_spec.rb
@@ -86,20 +86,11 @@ RSpec.describe "A jobseeker can give feedback on a job alert", recaptcha: true d
       context "when recaptcha is invalid" do
         let(:verify_recaptcha) { false }
 
-        before { click_button I18n.t("buttons.submit") }
-
-        context "and the form is valid" do
-          scenario "redirects to invalid_recaptcha path" do
-            expect(page).to have_current_path(invalid_recaptcha_path)
-          end
-        end
-
-        context "and the form is invalid" do
-          let(:comment) { nil }
-
-          scenario "does not redirect to invalid_recaptcha path" do
-            expect(page).to have_content("There is a problem")
-          end
+        scenario "registers the recaptcha failure while still submitting the feedback" do
+          expect(Sentry).to receive(:capture_message).with("Invalid recaptcha", level: :warning)
+          click_button I18n.t("buttons.submit")
+          expect(current_path).to eq root_path
+          expect(page).to have_content(I18n.t("jobseekers.job_alert_feedbacks.update.success"))
         end
       end
     end


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/AoQdYmqs

## Changes in this PR:

The Google Recaptcha V3 tends to give low scores to many legitimate requests when there is a surge of submissions coming from our marketing campaigns.

This causes a lot of friction with users who get their form submissions blocked without any recourse/explanation.

Google Recaptcha V3 is meant to give the service more power to do further fine-tuning checks based on the Recaptcha score. Instead, we use it as a PASS/FAIL test that blocks the users.

We are moving to log the low scores into Sentry, but not block the form submission.
## Screenshots of UI changes:
