### PR TITLE
Correctly display safeguarding issues answer on application review page

### DIFF
--- a/app/helpers/job_applications_helper.rb
+++ b/app/helpers/job_applications_helper.rb
@@ -61,7 +61,7 @@ module JobApplicationsHelper
   end
 
   def job_application_safeguarding_issues_info(job_application)
-    case job_application.close_relationships
+    case job_application.safeguarding_issue
     when "yes"
       safe_join([tag.div("Yes", class: "govuk-body", id: "safeguarding_issue"),
                  tag.p(job_application.safeguarding_issue_details, class: "govuk-body", id: "safeguarding_issue_details")])


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/2siPCGy2/869-bug-fix-declarations-section

## Changes in this PR:

This PR fixes a bug which caused the declarations values on job applications form to show incorrectly if the two values were different.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
