### PR TITLE
Fix Publisher email code backup sign-in flow

### DIFF
--- a/app/controllers/publishers/login_keys_controller.rb
+++ b/app/controllers/publishers/login_keys_controller.rb
@@ -3,6 +3,7 @@ class Publishers::LoginKeysController < ApplicationController
 
   before_action :redirect_signed_in_publishers, only: %i[new create show]
   before_action :redirect_for_dsi_authentication, only: %i[new create show]
+  before_action :check_login_key, only: %i[show consume]
 
   def new
     flash.now[:notice] = t(".notice")
@@ -14,21 +15,46 @@ class Publishers::LoginKeysController < ApplicationController
   end
 
   def show
-    login_key = EmergencyLoginKey.find_by(id: params[:id])
-    return @reason_for_failing_sign_in = "no_key" unless login_key
-    return @reason_for_failing_sign_in = "expired" if login_key.expired?
+    @publisher = Publisher.find(@login_key.publisher_id)
 
-    @publisher = Publisher.find(login_key.publisher_id)
-    login_key.destroy
-    session.update(publisher_id: @publisher.id)
+    if @publisher.organisations.none?
+      render(partial: "error", locals: { failure: "no_orgs" })
+    else
+      @form = Publishers::LoginKeys::ChooseOrganisationForm.new
+      render(:show)
+    end
+  end
 
-    return @reason_for_failing_sign_in = "no_orgs" if @publisher.organisations.none?
-    return if @publisher.organisations.many?
+  def consume
+    @publisher = Publisher.find(@login_key.publisher_id)
+    @form = Publishers::LoginKeys::ChooseOrganisationForm.new(choose_organisation_form_params)
 
-    redirect_to create_publisher_session_path(organisation_id: @publisher.organisations.first.id)
+    if @form.valid?
+      org = Organisation.find(@form.organisation)
+      @login_key.destroy
+      session.update(publisher_id: @publisher.id)
+      redirect_to create_publisher_session_path(organisation_id: org.id)
+    else
+      render(:show)
+    end
   end
 
   private
+
+  def choose_organisation_form_params
+    (params[:publishers_login_keys_choose_organisation_form] || params).permit(:organisation)
+  end
+
+  def check_login_key
+    @login_key = EmergencyLoginKey.find_by(id: params[:id])
+    failure = if @login_key.nil?
+                "no_key"
+              elsif @login_key.expired?
+                "expired"
+              end
+
+    (render(:error, locals: { failure: }) and return) if failure.present?
+  end
 
   def redirect_signed_in_publishers
     return unless publisher_signed_in? && current_organisation.present?

--- a/app/form_models/publishers/login_keys/choose_organisation_form.rb
+++ b/app/form_models/publishers/login_keys/choose_organisation_form.rb
@@ -1,0 +1,7 @@
+class Publishers::LoginKeys::ChooseOrganisationForm < BaseForm
+  include ActiveModel::Model
+
+  attr_accessor :organisation
+
+  validates :organisation, presence: true
+end

--- a/app/views/publishers/login_keys/error.html.slim
+++ b/app/views/publishers/login_keys/error.html.slim
@@ -1,0 +1,7 @@
+- content_for :page_title_prefix, t("publishers.temp_login.choose_organisation.denial.title")
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    = govuk_notification_banner title_text: t("banners.important") do |banner|
+      - banner.with_heading text: t("publishers.temp_login.choose_organisation.denial.title")
+      = t("publishers.temp_login.choose_organisation.denial.#{failure}_html", try_again: govuk_link_to("try again", new_publisher_session_path))

--- a/app/views/publishers/login_keys/show.html.slim
+++ b/app/views/publishers/login_keys/show.html.slim
@@ -2,19 +2,12 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    - if @reason_for_failing_sign_in
-      = govuk_notification_banner title_text: t("banners.important") do |banner|
-        - banner.with_heading text: t("publishers.temp_login.choose_organisation.denial.title")
-        = t("publishers.temp_login.choose_organisation.denial.#{@reason_for_failing_sign_in}_html", try_again: govuk_link_to("try again", new_publisher_session_path))
-
-    - else
+    = form_for @form, url: consume_publishers_login_key_path(@login_key) do |f|
+      = f.govuk_error_summary
       h1.govuk-heading-l = t("publishers.temp_login.choose_organisation.heading")
 
-      p = t("publishers.temp_login.choose_organisation.please_select")
-
-      - @publisher.organisations.each do |organisation|
-        p
-          - if organisation.school?
-            = govuk_link_to(location(organisation), create_publisher_session_path(organisation_id: organisation.id))
-          - else
-            = govuk_link_to(organisation.name, create_publisher_session_path(organisation_id: organisation.id))
+      = f.govuk_radio_buttons_fieldset :organisation, legend: { text: t("publishers.temp_login.choose_organisation.please_select"), size: "m" } do
+        - @publisher.organisations.each_with_index do |organisation, index|
+          - text = organisation.school? ? location(organisation) : organisation.name
+          = f.govuk_radio_button(:organisation, organisation.id, label: { text: }, link_errors: index.zero?)
+      = f.govuk_submit t("buttons.sign_in")

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -7,7 +7,7 @@
       "check_name": "CrossSiteScripting",
       "message": "Unescaped parameter value",
       "file": "app/views/posts/show.html.slim",
-      "line": 17,
+      "line": 18,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "MarkdownDocument.new(params[:section], params[:post_name]).content",
       "render_path": [
@@ -37,25 +37,25 @@
     {
       "warning_type": "Unscoped Find",
       "warning_code": 82,
-      "fingerprint": "2958a42de474fe8d86f893d3f6735d7f6d05d0755845d75f54bf69290577cb5c",
+      "fingerprint": "4555c296b942cffb89636f6e393403f7c6a8918d34ce290871cd44ee9a0a6ab1",
       "check_name": "UnscopedFind",
-      "message": "Unscoped call to `JobseekerProfile#find`",
-      "file": "app/controllers/publishers/invitations_controller.rb",
-      "line": 10,
+      "message": "Unscoped call to `EmergencyLoginKey#find_by`",
+      "file": "app/controllers/publishers/login_keys_controller.rb",
+      "line": 49,
       "link": "https://brakemanscanner.org/docs/warning_types/unscoped_find/",
-      "code": "JobseekerProfile.find(params[:id])",
+      "code": "EmergencyLoginKey.find_by(:id => params[:id])",
       "render_path": null,
       "location": {
         "type": "method",
-        "class": "Publishers::InvitationsController",
-        "method": "index"
+        "class": "Publishers::LoginKeysController",
+        "method": "check_login_key"
       },
       "user_input": "params[:id]",
       "confidence": "Weak",
       "cwe_id": [
         285
       ],
-      "note": ""
+      "note": "Emergency login key cannot be scoped to already signed-in users"
     },
     {
       "warning_type": "SQL Injection",
@@ -110,7 +110,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/queries/location_query.rb",
-      "line": 70,
+      "line": 65,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "Arel.sql(\"ST_Distance(#{field_name}, '#{point}')\")",
       "render_path": null,
@@ -156,7 +156,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/queries/location_query.rb",
-      "line": 40,
+      "line": 35,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "scope.joins(\"\\n      INNER JOIN location_polygons\\n      ON ST_DWithin(#{field_name}, location_polygons.area, #{radius})\\n    \")",
       "render_path": null,
@@ -171,29 +171,6 @@
         89
       ],
       "note": "Neither field_name or radius come directly from user input. field_name is hardcoded in the child classes of LocationQuery and radius comes from Search::RadiusBuilder#get_radius which sanitises the input."
-    },
-    {
-      "warning_type": "Unscoped Find",
-      "warning_code": 82,
-      "fingerprint": "9c93c9f5d08bf27281c1583b673b5915f80943fcb8f0b89e90c84c497242a7fe",
-      "check_name": "UnscopedFind",
-      "message": "Unscoped call to `EmergencyLoginKey#find_by`",
-      "file": "app/controllers/publishers/login_keys_controller.rb",
-      "line": 17,
-      "link": "https://brakemanscanner.org/docs/warning_types/unscoped_find/",
-      "code": "EmergencyLoginKey.find_by(:id => params[:id])",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Publishers::LoginKeysController",
-        "method": "show"
-      },
-      "user_input": "params[:id]",
-      "confidence": "Weak",
-      "cwe_id": [
-        285
-      ],
-      "note": ""
     },
     {
       "warning_type": "SQL Injection",
@@ -225,7 +202,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/queries/location_query.rb",
-      "line": 65,
+      "line": 60,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "Arel.sql(\"ST_Distance(#{field_name}, ST_Centroid(location_polygons.area))\")",
       "render_path": null,
@@ -248,7 +225,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/queries/location_query.rb",
-      "line": 56,
+      "line": 51,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "scope.where(\"ST_DWithin(#{field_name}, ?, ?)\", \"POINT(#{Geocoding.new(query).coordinates.second} #{Geocoding.new(query).coordinates.first})\", radius)",
       "render_path": null,
@@ -265,6 +242,6 @@
       "note": "Neither field_name or the coordinates come directly from user input. field_name is hardcoded in the child classes of LocationQuery and the coordinates come from Geocoding#coordinates which returns an array with coordinates returned by our cache or third party geocoding APIs. It defaults to [0,0] if relevant coordinates are not found."
     }
   ],
-  "updated": "2024-01-15 11:25:34 +0000",
-  "brakeman_version": "6.1.1"
+  "updated": "2024-03-07 14:26:16 +0000",
+  "brakeman_version": "6.1.2"
 }

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -438,6 +438,10 @@ en:
               invalid: Enter a date in the correct format
               on_or_after: The closing date must be in the future
               on_or_before: The closing date must be less than two years in the future
+        publishers/login_keys/choose_organisation_form:
+          attributes:
+            organisation:
+              blank: Select the organisation you wish to sign with
         publishers/organisation/email_form:
           attributes:
             <<: *email_errors

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -360,7 +360,7 @@ en:
         heading: Choose your organisation
         page_title: Choose your organisation
         please_select: >-
-          You are associated with more than one organisation. Please select the one you wish to sign in with.
+          Please select the organisation you wish to sign in with.
       email:
         body: Click the link below to sign in to the Teaching Vacancies service. This link can only be used once.
         heading: Sign in to Teaching Vacancies

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -158,7 +158,9 @@ Rails.application.routes.draw do
       get "confirm-unsubscribe", to: "accounts#confirm_unsubscribe"
       patch "unsubscribe", to: "accounts#unsubscribe"
     end
-    resources :login_keys, only: %i[show new create]
+    resources :login_keys, only: %i[show new create] do
+      post :consume, on: :member
+    end
     resources :jobseeker_profiles, only: %i[index show]
     resource :new_features, only: %i[show update] do
       get :reminder

--- a/spec/system/other/users_can_only_be_signed_in_to_one_type_of_account_spec.rb
+++ b/spec/system/other/users_can_only_be_signed_in_to_one_type_of_account_spec.rb
@@ -56,6 +56,8 @@ RSpec.describe "Users can only be signed in to one type of account" do
         expect(page).to have_content(I18n.t("jobseekers.accounts.show.page_title"))
 
         visit publishers_login_key_path(login_key)
+        choose school.name
+        click_button I18n.t("buttons.sign_in")
         expect(page).to have_current_path(publisher_root_path)
 
         visit jobseekers_account_path

--- a/spec/system/publishers/publishers_can_sign_in_by_email_spec.rb
+++ b/spec/system/publishers/publishers_can_sign_in_by_email_spec.rb
@@ -70,7 +70,9 @@ RSpec.describe "Publishers can sign in with fallback email authentication" do
           expect(page).to have_content(trust.name)
           expect(page).to have_content(local_authority.name)
 
-          click_on school.name
+          choose school.name
+          click_button I18n.t("buttons.sign_in")
+
           expect(:successful_publisher_sign_in_attempt).to have_been_enqueued_as_analytics_events
 
           expect(page).to have_content(school.name)
@@ -105,7 +107,7 @@ RSpec.describe "Publishers can sign in with fallback email authentication" do
       context "organisation is a School" do
         let(:organisations) { [school] }
 
-        it "can sign in and bypass choice of org" do
+        it "can sign in" do
           freeze_time do
             visit root_path
             within(".govuk-header__navigation") { click_on I18n.t("buttons.sign_in") }
@@ -118,10 +120,16 @@ RSpec.describe "Publishers can sign in with fallback email authentication" do
             click_on I18n.t("buttons.submit")
             expect(page).to have_content(I18n.t("publishers.temp_login.check_your_email.sent"))
 
-            # Expect that the link in the email goes to the landing page
             visit publishers_login_key_path(login_key)
-            expect(:successful_publisher_sign_in_attempt).to have_been_enqueued_as_analytics_events
 
+            expect(page).to have_content("Choose your organisation")
+            expect(page).not_to have_content(I18n.t("publishers.temp_login.choose_organisation.denial.title"))
+            expect(page).to have_content(school.name)
+
+            choose school.name
+            click_button I18n.t("buttons.sign_in")
+
+            expect(:successful_publisher_sign_in_attempt).to have_been_enqueued_as_analytics_events
             expect(page).not_to have_content("Choose your organisation")
             expect(page).to have_content(school.name)
             expect { login_key.reload }.to raise_error ActiveRecord::RecordNotFound
@@ -134,7 +142,7 @@ RSpec.describe "Publishers can sign in with fallback email authentication" do
 
         before { allow(PublisherPreference).to receive(:find_by).and_return(instance_double(PublisherPreference)) }
 
-        it "can sign in and bypass choice of org" do
+        it "can sign in" do
           freeze_time do
             visit root_path
             within(".govuk-header__navigation") { click_on I18n.t("buttons.sign_in") }
@@ -147,8 +155,15 @@ RSpec.describe "Publishers can sign in with fallback email authentication" do
             click_on I18n.t("buttons.submit")
             expect(page).to have_content(I18n.t("publishers.temp_login.check_your_email.sent"))
 
-            # Expect that the link in the email goes to the landing page
             visit publishers_login_key_path(login_key)
+
+            expect(page).to have_content("Choose your organisation")
+            expect(page).not_to have_content(I18n.t("publishers.temp_login.choose_organisation.denial.title"))
+            expect(page).to have_content(trust.name)
+
+            choose trust.name
+            click_button I18n.t("buttons.sign_in")
+
             expect(:successful_publisher_sign_in_attempt).to have_been_enqueued_as_analytics_events
 
             expect(page).not_to have_content("Choose your organisation")
@@ -166,7 +181,7 @@ RSpec.describe "Publishers can sign in with fallback email authentication" do
           allow(PublisherPreference).to receive(:find_by).and_return(instance_double(PublisherPreference))
         end
 
-        it "can sign in and bypass choice of org" do
+        it "can sign in" do
           freeze_time do
             visit root_path
             within(".govuk-header__navigation") { click_on I18n.t("buttons.sign_in") }
@@ -179,8 +194,15 @@ RSpec.describe "Publishers can sign in with fallback email authentication" do
             click_on I18n.t("buttons.submit")
             expect(page).to have_content(I18n.t("publishers.temp_login.check_your_email.sent"))
 
-            # Expect that the link in the email goes to the landing page
             visit publishers_login_key_path(login_key)
+
+            expect(page).to have_content("Choose your organisation")
+            expect(page).not_to have_content(I18n.t("publishers.temp_login.choose_organisation.denial.title"))
+            expect(page).to have_content(local_authority.name)
+
+            choose local_authority.name
+            click_button I18n.t("buttons.sign_in")
+
             expect(:successful_publisher_sign_in_attempt).to have_been_enqueued_as_analytics_events
 
             expect(page).not_to have_content("Choose your organisation")


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/SDl8FvRH

## Changes in this PR:
When DFE Sign-in service is not enabled, our service uses login keys sent by email as a backup authentication method for Publishers.

This is widely used in local development and review apps.

Since the Microsoft Outlook security check pre-visits any HTTPS link received by email, and our service was consuming the login token when the publisher followed the log-in email, the token was being consumed by the Outlook security check before the Publisher landed on the page. Consequently, the publisher found an invalid page and could not sign in.

To resolve this, we redesigned how the publisher sign-in process works:
- When following the link, the token will be checked but not consumed (so the https security can be checked by Microsoft Outlook).
- If the token is valid, the publisher will be shown a page to choose the organisation to sign in for.
- Upon selecting the organisation and submitting the choice, the login token will be consumed/deleted and the publisher will sign in for the chosen org.
- Is there anything specific you want feedback on?

## Screenshots of UI changes:
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/25e2570b-b78b-4d97-beb9-306e7f6496cf)

### Before

The login key would already be consumed when landing on this page. If the above link checking by Outlook visits the page, consumes it, and redirects the user afterwards, it ends up being an "invalid link" for the user.

![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/9d25e3cf-df03-43a0-a114-2ff8d12cc793)

### After
The login key is not consumer until the user submits this form choosing the organisation they want to sign-in for.
This way even if this page is originally visited by the Outlook security check, it doesn't consume/invalidate the login key.
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/85987e94-aff0-4601-8689-b6ad1b0ae907)
