### PR TITLE
Add hint text to publisher working patterns step

### DIFF
--- a/app/views/publishers/vacancies/build/working_patterns.html.slim
+++ b/app/views/publishers/vacancies/build/working_patterns.html.slim
@@ -9,7 +9,8 @@
                                        Vacancy.working_patterns.keys,
                                        :to_s,
                                        :to_s,
-                                       legend: -> { tag.h2(t("publishers.vacancies.steps.working_patterns"), class: "govuk-heading-l") })
+                                       legend: -> { tag.h2(t("publishers.vacancies.steps.working_patterns"), class: "govuk-heading-l") },
+                                       hint: -> { t("helpers.hint.publishers_job_listing_working_patterns_form.working_patterns") })
       = f.govuk_text_area(:working_patterns_details,
                           label: -> { tag.label(t("helpers.label.publishers_job_listing_working_patterns_form.working_patterns_details"), class: ["govuk-label", "govuk-!-font-weight-bold"]) },
                           hint: -> { t("helpers.hint.publishers_job_listing_working_patterns_form.working_patterns_details") },

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -282,6 +282,7 @@ en:
             through: For example ‘Teacher of KS1’ or ‘Teacher of Maths’
           teaching_assistant: For example ‘Teaching assistant’
       publishers_job_listing_working_patterns_form:
+        working_patterns: Select all that apply.
         working_patterns_details: For example, 32.5 hours a week.
         working_patterns_options:
           full_time_education_support: Usually at least 36.5 hours a week


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/sePo4ADe

## Changes in this PR:
Add a hint text for the working patterns selection form on the publishers flows.


## Screenshots of UI changes:

### Before
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/0d25ea98-da70-42f2-8f8b-6c205a1cea01)

### After
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/81031650-ba5e-426b-bc55-23c456260dd5)
