### PR TITLE
Report to Sentry ATS imports without errors

### DIFF
--- a/app/jobs/import_from_vacancy_source_job.rb
+++ b/app/jobs/import_from_vacancy_source_job.rb
@@ -71,9 +71,8 @@ class ImportFromVacancySourceJob < ApplicationJob
   end
 
   def report_validation_errors
-    return if @errors.none?
+    failed_percentage = @errors.any? ? ((@errors.count.to_f / @vacancies_count) * 100).round(1) : 0
 
-    failed_percentage = ((@errors.count.to_f / @vacancies_count) * 100).round(1)
     Sentry.with_scope do |scope|
       scope.set_tags(source: @source_name)
       scope.set_context("Import failure rate", { vacancies_in_feed: @vacancies_count,


### PR DESCRIPTION
As we use Sentry warnings as a portal to register runs for each source import, we have no data at all when a source has 0 errors on import.

This prevents us from seeing when it ran, how long it took, if it ran correctly...
