### PR TITLE
Set default safe guarding information for organisations

### DIFF
--- a/db/migrate/20240308173633_add_default_safe_guarding_information_to_organisations.rb
+++ b/db/migrate/20240308173633_add_default_safe_guarding_information_to_organisations.rb
@@ -1,0 +1,18 @@
+class AddDefaultSafeGuardingInformationToOrganisations < ActiveRecord::Migration[7.1]
+  def change
+    default = "Our organisation is committed to safeguarding and promoting the welfare of children, young people and vulnerable adults. " \
+              "We expect all staff, volunteers and trustees to share this commitment.\n\n" \
+              "Our recruitment process follows the keeping children safe in education guidance.\n\n" \
+              "Offers of employment may be subject to the following checks (where relevant):\n" \
+              "childcare disqualification\n" \
+              "Disclosure and Barring Service (DBS)\n" \
+              "medical\n" \
+              "online and social media\n" \
+              "prohibition from teaching\n" \
+              "right to work\n" \
+              "satisfactory references\n" \
+              "suitability to work with children\n\n" \
+              "You must tell us about any unspent conviction, cautions, reprimands or warnings under the Rehabilitation of Offenders Act 1974 (Exceptions) Order 1975."
+    change_column_default :organisations, :safeguarding_information, from: nil, to: default
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_09_180737) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_08_173633) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -427,7 +427,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_09_180737) do
     t.text "gias_data_hash"
     t.string "slug"
     t.string "email"
-    t.string "safeguarding_information"
+    t.string "safeguarding_information", default: "Our organisation is committed to safeguarding and promoting the welfare of children, young people and vulnerable adults. We expect all staff, volunteers and trustees to share this commitment.\n\nOur recruitment process follows the keeping children safe in education guidance.\n\nOffers of employment may be subject to the following checks (where relevant):\nchildcare disqualification\nDisclosure and Barring Service (DBS)\nmedical\nonline and social media\nprohibition from teaching\nright to work\nsatisfactory references\nsuitability to work with children\n\nYou must tell us about any unspent conviction, cautions, reprimands or warnings under the Rehabilitation of Offenders Act 1974 (Exceptions) Order 1975."
     t.tsvector "searchable_content"
     t.index ["geopoint"], name: "index_organisations_on_geopoint", using: :gist
     t.index ["local_authority_code"], name: "index_organisations_on_local_authority_code", unique: true

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -45,6 +45,26 @@ namespace :db do # rubocop:disable Metrics/BlockLength
     SetOrganisationSlugsJob.perform_now
   end
 
+  desc "Backfill default safeguarding information for organisations without it"
+  task backfill_default_organisation_safeguarding_information: :environment do
+    default = "Our organisation is committed to safeguarding and promoting the welfare of children, young people and vulnerable adults. " \
+              "We expect all staff, volunteers and trustees to share this commitment.\n\n" \
+              "Our recruitment process follows the keeping children safe in education guidance.\n\n" \
+              "Offers of employment may be subject to the following checks (where relevant):\n" \
+              "childcare disqualification\n" \
+              "Disclosure and Barring Service (DBS)\n" \
+              "medical\n" \
+              "online and social media\n" \
+              "prohibition from teaching\n" \
+              "right to work\n" \
+              "satisfactory references\n" \
+              "suitability to work with children\n\n" \
+              "You must tell us about any unspent conviction, cautions, reprimands or warnings under the Rehabilitation of Offenders Act 1974 (Exceptions) Order 1975."
+    Organisation.where(safeguarding_information: nil)
+      .or(Organisation.where(safeguarding_information: ""))
+      .update_all(safeguarding_information: default)
+  end
+
   desc "Set other_start_date_details and start_date_type for vacancies"
   task set_start_date_fields: :environment do
     Vacancy.find_each do |v|


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/fAnLWbgy

## Changes in this PR:
- Sets a default value for organisations safeguarding information.
- Adds a task to backfill any organisation without existing safeguarding info with the default value.

## Screenshots of UI changes:

### Before

### After
On the seeded created Review App info, now it populates it wit the default value.

![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/24e0cb82-9297-4b00-9210-80dc5790bd6f)

![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/96e5dfd3-aee2-47a2-b2ff-200556907497)
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/628806b8-e885-4637-b8ba-9c19e46ccc91)


It can be updated by the schools if needed.

![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/d75b50ea-7ee3-4e76-b57b-fa2eea61f7e4)


