### PR TITLE
Protect non production environments with password

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -31,6 +31,9 @@ runs:
 
     - name: Run deployment smoke test
       shell: bash
+      env:
+        HTTP_BASIC_USER: ${{ inputs.http_basic_user }}
+        HTTP_BASIC_PASSWORD: ${{ inputs.http_basic_password }}
       run:  bundle exec rspec spec/smoke_tests/jobseekers_can_view_homepage_spec.rb --tag smoke_test
 
     - name: print environment

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -261,6 +261,8 @@ jobs:
       with:
         aks_environment: ${{ env.ENVIRONMENT }}
         event_name: ${{ github.event_name }}
+        http_basic_user: ${{ secrets.HTTP_BASIC_USER }}
+        http_basic_password: ${{ secrets.HTTP_BASIC_PASSWORD }}
 
     - name: Exit whole workflow if ${{ env.ENVIRONMENT }} smoke test was not successful
       if: steps.smoke-test.conclusion != 'success'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,10 @@ class ApplicationController < ActionController::Base
   include Pagy::Backend
   include DfE::Analytics::Requests
 
+  http_basic_authenticate_with name: ENV.fetch("HTTP_BASIC_USER", ""),
+                               password: ENV.fetch("HTTP_BASIC_PASSWORD", ""),
+                               if: -> { ENV["HTTP_BASIC_PASSWORD"].present? && request.path != "/check" }
+
   add_flash_types :success, :warning
 
   protect_from_forgery with: :exception, except: :not_found

--- a/spec/smoke_tests/jobseekers_can_view_homepage_spec.rb
+++ b/spec/smoke_tests/jobseekers_can_view_homepage_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe "Page availability", js: true, smoke_test: true do
 
   context "Jobseeker visits vacancy page" do
     let(:smoke_test_auth) do
+      # User/Pass defined on Github Env secrets (https://github.com/DFE-Digital/teaching-vacancies/settings/environments/)
+      # They need to match the ones defined in AWS Parameter Store.
       http_basic_user = ENV.fetch("HTTP_BASIC_USER", "")
       http_basic_password = ENV.fetch("HTTP_BASIC_PASSWORD", "")
       return unless http_basic_password.present?
@@ -33,6 +35,7 @@ RSpec.describe "Page availability", js: true, smoke_test: true do
 
     it "ensures users can search and view a job vacancy page" do
       page.visit "#{base_url}/404" # you need to be on the domain to set the cookie
+      expect(page).to have_content("Page not found.")
 
       page.driver.browser.manage.add_cookie(name: "smoke_test", value: "1", domain: smoke_test_domain)
       page.driver.browser.manage.add_cookie(name: "consented-to-cookies", value: "no", domain: smoke_test_domain)

--- a/spec/smoke_tests/jobseekers_can_view_homepage_spec.rb
+++ b/spec/smoke_tests/jobseekers_can_view_homepage_spec.rb
@@ -1,3 +1,5 @@
+require "active_support"
+require "active_support/core_ext"
 require "capybara/rspec"
 require "i18n_helper"
 require "yaml"
@@ -11,6 +13,13 @@ RSpec.describe "Page availability", js: true, smoke_test: true do
   end
 
   context "Jobseeker visits vacancy page" do
+    let(:smoke_test_auth) do
+      http_basic_user = ENV.fetch("HTTP_BASIC_USER", "")
+      http_basic_password = ENV.fetch("HTTP_BASIC_PASSWORD", "")
+      return unless http_basic_password.present?
+
+      "#{http_basic_user}:#{http_basic_password}@"
+    end
     let(:smoke_test_domain) do
       aks_environment = ENV.fetch("AKS_ENVIRONMENT")
       begin
@@ -20,17 +29,18 @@ RSpec.describe "Page availability", js: true, smoke_test: true do
       end
     end
     let(:page) { Capybara::Session.new(:selenium_chrome_headless) }
+    let(:base_url) { "https://#{smoke_test_auth}#{smoke_test_domain}" }
 
     it "ensures users can search and view a job vacancy page" do
-      page.visit "https://#{smoke_test_domain}/404" # you need to be on the domain to set the cookie
+      page.visit "#{base_url}/404" # you need to be on the domain to set the cookie
 
       page.driver.browser.manage.add_cookie(name: "smoke_test", value: "1", domain: smoke_test_domain)
       page.driver.browser.manage.add_cookie(name: "consented-to-cookies", value: "no", domain: smoke_test_domain)
 
-      page.visit "https://#{smoke_test_domain}/"
+      page.visit "#{base_url}/"
       expect(page).to have_content(I18n.t("jobs.heading"))
 
-      page.visit "https://#{smoke_test_domain}/jobs?keyword=Maths"
+      page.visit "#{base_url}/jobs?keyword=Maths"
 
       expect(page).to have_css("h1", text: "Jobs")
       if page.has_css?(".search-results")
@@ -42,7 +52,7 @@ RSpec.describe "Page availability", js: true, smoke_test: true do
       if page.has_css?(".view-vacancy-link")
         page.first(".view-vacancy-link").click
         expect(page).to have_content(I18n.t("vacancies.show.job_details"))
-        expect(page.current_url).to include("https://#{smoke_test_domain}/jobs/")
+        expect(page.current_url).to include("#{base_url}/jobs/")
       end
     end
   end


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/JL4WCEtN

## Changes in this PR:

At the moment, Review Apps, QA and Staging environments are open to the internet.

This recently has become an issue since someone started applying for QA vacancies thinking they're real.

We are protecting them behind USER/PASSWORD HTTP basic authentication.

The protection will only be displayed if the `HTTP_BASIC_PASSWORD` env var is defined. We added it to `QA`, `Staging` and `Review` environments, not to `Production`.

### Screenshot

![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/a66d0c1f-83a5-47c7-873c-d4460a31a870)
