### PR TITLE
Status indicators

### DIFF
--- a/app/controllers/jobseekers/job_applications_controller.rb
+++ b/app/controllers/jobseekers/job_applications_controller.rb
@@ -233,9 +233,9 @@ class Jobseekers::JobApplicationsController < Jobseekers::JobApplications::BaseC
       application.in_progress_steps += [:professional_status]
     end
 
-    if application.qualifications.present?
-      application.in_progress_steps += [:qualifications]
-    end
+    return unless application.qualifications.present?
+
+    application.in_progress_steps += [:qualifications]
   end
 
   def profile

--- a/app/controllers/jobseekers/job_applications_controller.rb
+++ b/app/controllers/jobseekers/job_applications_controller.rb
@@ -202,9 +202,9 @@ class Jobseekers::JobApplicationsController < Jobseekers::JobApplications::BaseC
 
     application.assign_attributes(
       employments: profile.employments.map(&:duplicate),
-      first_name: profile.personal_details.try(:first_name),
-      last_name: profile.personal_details.try(:last_name),
-      phone_number: profile.personal_details.try(:phone_number),
+      first_name: profile.personal_details&.first_name,
+      last_name: profile.personal_details&.last_name,
+      phone_number: profile.personal_details&.phone_number,
       qualifications: profile.qualifications.map(&:duplicate),
       qualified_teacher_status_year: profile.qualified_teacher_status_year || "",
       qualified_teacher_status: profile.qualified_teacher_status || "",
@@ -215,7 +215,7 @@ class Jobseekers::JobApplicationsController < Jobseekers::JobApplications::BaseC
   end
 
   def profile_right_to_work
-    return "" if profile.personal_details.try(:right_to_work_in_uk).nil?
+    return "" if profile.personal_details&.right_to_work_in_uk.nil?
 
     profile.personal_details.right_to_work_in_uk? ? "yes" : "no"
   end

--- a/app/helpers/status_tag_helper.rb
+++ b/app/helpers/status_tag_helper.rb
@@ -38,7 +38,7 @@ module StatusTagHelper
   end
 
   def complete
-    govuk_tag(text: t("shared.status_tags.complete"))
+    govuk_tag(text: t("shared.status_tags.complete"), colour: "green")
   end
 
   def in_progress

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -21,6 +21,7 @@ class JobApplication < ApplicationRecord
     qualifications: 0,
     employment_history: 1,
     personal_details: 2,
+    professional_status: 3
   }
 
   # If you want to add a status, be sure to add a `status_at` column to the `job_applications` table

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -21,7 +21,7 @@ class JobApplication < ApplicationRecord
     qualifications: 0,
     employment_history: 1,
     personal_details: 2,
-    professional_status: 3
+    professional_status: 3,
   }
 
   # If you want to add a status, be sure to add a `status_at` column to the `job_applications` table

--- a/app/services/jobseekers/job_applications/quick_apply.rb
+++ b/app/services/jobseekers/job_applications/quick_apply.rb
@@ -47,7 +47,7 @@ class Jobseekers::JobApplications::QuickApply
   end
 
   def in_progress_steps
-    %w[qualifications employment_history]
+    %w[qualifications employment_history professional_status]
   end
 
   def copy_qualifications

--- a/spec/helpers/status_tag_helper_spec.rb
+++ b/spec/helpers/status_tag_helper_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe StatusTagHelper do
         let(:steps) { [:personal_details] }
 
         it "returns 'complete' tag" do
-          expect(subject).to eq(helper.govuk_tag(text: I18n.t("shared.status_tags.complete")))
+          expect(subject).to eq(helper.govuk_tag(text: I18n.t("shared.status_tags.complete"), colour: "green"))
         end
       end
 

--- a/spec/services/jobseekers/job_applications/quick_apply_spec.rb
+++ b/spec/services/jobseekers/job_applications/quick_apply_spec.rb
@@ -40,9 +40,9 @@ RSpec.describe Jobseekers::JobApplications::QuickApply do
           .to eq(%w[personal_details professional_status references ask_for_support])
       end
 
-      it "sets in progress steps as qualifications and employment history" do
+      it "sets in progress steps as qualifications, employment history and professional status" do
         expect(subject.in_progress_steps)
-          .to eq(%w[qualifications employment_history])
+          .to eq(%w[qualifications employment_history professional_status])
       end
     end
 

--- a/spec/system/jobseekers/jobseeker_applications_statuses_spec.rb
+++ b/spec/system/jobseekers/jobseeker_applications_statuses_spec.rb
@@ -8,58 +8,58 @@ RSpec.describe "Jobseekers applications statuses" do
   context "when the jobseeker has a profile" do
     context "when the jobseeker has completed details in their profile" do
       let!(:jobseeker_profile) { create(:jobseeker_profile, :completed, jobseeker: jobseeker) }
-  
+
       it "shows all sections with the status tag 'in progress'" do
         login_as(jobseeker, scope: :jobseeker)
         visit job_path(vacancy)
         within ".banner-buttons" do
           click_on I18n.t("jobseekers.job_applications.banner_links.apply")
         end
-  
+
         click_button "Start application"
-  
-        expect(page).to have_css('#personal_details .review-component__section__heading__status', text: 'in progress')
-        expect(page).to have_css('#professional_status .review-component__section__heading__status', text: 'in progress')
-        expect(page).to have_css('#qualifications .review-component__section__heading__status', text: 'in progress')
-        expect(page).to have_css('#employment_history .review-component__section__heading__status', text: 'in progress')
+
+        expect(page).to have_css("#personal_details .review-component__section__heading__status", text: "in progress")
+        expect(page).to have_css("#professional_status .review-component__section__heading__status", text: "in progress")
+        expect(page).to have_css("#qualifications .review-component__section__heading__status", text: "in progress")
+        expect(page).to have_css("#employment_history .review-component__section__heading__status", text: "in progress")
       end
     end
 
     context "when the jobseeker has not completed any details in their profile" do
       let!(:jobseeker_profile) { create(:jobseeker_profile, jobseeker: jobseeker, qualified_teacher_status: nil) }
-  
+
       it "shows all sections with the status tag 'in progress'" do
         login_as(jobseeker, scope: :jobseeker)
         visit job_path(vacancy)
         within ".banner-buttons" do
           click_on I18n.t("jobseekers.job_applications.banner_links.apply")
         end
-  
+
         click_button "Start application"
-  
-        expect(page).to have_css('#personal_details .review-component__section__heading__status', text: 'not started')
-        expect(page).to have_css('#professional_status .review-component__section__heading__status', text: 'not started')
-        expect(page).to have_css('#qualifications .review-component__section__heading__status', text: 'not started')
-        expect(page).to have_css('#employment_history .review-component__section__heading__status', text: 'not started')
+
+        expect(page).to have_css("#personal_details .review-component__section__heading__status", text: "not started")
+        expect(page).to have_css("#professional_status .review-component__section__heading__status", text: "not started")
+        expect(page).to have_css("#qualifications .review-component__section__heading__status", text: "not started")
+        expect(page).to have_css("#employment_history .review-component__section__heading__status", text: "not started")
       end
     end
 
     context "when the jobseeker has completed some details in their profile but not all of them" do
       let!(:jobseeker_profile) { create(:jobseeker_profile, :with_qualifications, :with_employment_history, jobseeker: jobseeker, qualified_teacher_status: nil) }
-  
+
       it "shows all sections that have been filled in with the status tag 'in progress' and shows empty sections with the status tag 'not started'" do
         login_as(jobseeker, scope: :jobseeker)
         visit job_path(vacancy)
         within ".banner-buttons" do
           click_on I18n.t("jobseekers.job_applications.banner_links.apply")
         end
-  
+
         click_button "Start application"
-  
-        expect(page).to have_css('#personal_details .review-component__section__heading__status', text: 'not started')
-        expect(page).to have_css('#professional_status .review-component__section__heading__status', text: 'not started')
-        expect(page).to have_css('#qualifications .review-component__section__heading__status', text: 'in progress')
-        expect(page).to have_css('#employment_history .review-component__section__heading__status', text: 'in progress')
+
+        expect(page).to have_css("#personal_details .review-component__section__heading__status", text: "not started")
+        expect(page).to have_css("#professional_status .review-component__section__heading__status", text: "not started")
+        expect(page).to have_css("#qualifications .review-component__section__heading__status", text: "in progress")
+        expect(page).to have_css("#employment_history .review-component__section__heading__status", text: "in progress")
       end
 
       context "when the jobseeker completes a section" do
@@ -72,41 +72,41 @@ RSpec.describe "Jobseekers applications statuses" do
 
           click_button "Start application"
 
-          within('#personal_details') do
-            click_link('Complete section')
+          within("#personal_details") do
+            click_link("Complete section")
           end
 
           fill_in_personal_details
           click_on "Save"
 
-          expect(page).to have_css('#personal_details .review-component__section__heading__status', text: 'complete')
+          expect(page).to have_css("#personal_details .review-component__section__heading__status", text: "complete")
 
-          within('#professional_status') do
-            click_link('Complete section')
+          within("#professional_status") do
+            click_link("Complete section")
           end
 
           fill_in_professional_status
           click_on "Save"
 
-          expect(page).to have_css('#professional_status .review-component__section__heading__status', text: 'complete')
+          expect(page).to have_css("#professional_status .review-component__section__heading__status", text: "complete")
 
-          within('#qualifications') do
-            click_link('Complete section')
+          within("#qualifications") do
+            click_link("Complete section")
           end
 
           choose "Yes, I've completed this section"
           click_on "Save"
 
-          expect(page).to have_css('#qualifications .review-component__section__heading__status', text: 'complete')
+          expect(page).to have_css("#qualifications .review-component__section__heading__status", text: "complete")
 
-          within('#employment_history') do
-            click_link('Complete section')
+          within("#employment_history") do
+            click_link("Complete section")
           end
 
           choose "Yes, I've completed this section"
           click_on "Save"
 
-          expect(page).to have_css('#employment_history .review-component__section__heading__status', text: 'complete')
+          expect(page).to have_css("#employment_history .review-component__section__heading__status", text: "complete")
         end
       end
     end

--- a/spec/system/jobseekers/jobseeker_applications_statuses_spec.rb
+++ b/spec/system/jobseekers/jobseeker_applications_statuses_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Jobseekers applications are prefilled with profile data" do
+RSpec.describe "Jobseekers applications statuses" do
   let!(:jobseeker) { create(:jobseeker) }
   let(:vacancy) { create(:vacancy, organisations: [school], visa_sponsorship_available: true) }
   let(:school) { create(:school) }
@@ -60,6 +60,54 @@ RSpec.describe "Jobseekers applications are prefilled with profile data" do
         expect(page).to have_css('#professional_status .review-component__section__heading__status', text: 'not started')
         expect(page).to have_css('#qualifications .review-component__section__heading__status', text: 'in progress')
         expect(page).to have_css('#employment_history .review-component__section__heading__status', text: 'in progress')
+      end
+
+      context "when the jobseeker completes a section" do
+        it "shows the section as complete" do
+          login_as(jobseeker, scope: :jobseeker)
+          visit job_path(vacancy)
+          within ".banner-buttons" do
+            click_on I18n.t("jobseekers.job_applications.banner_links.apply")
+          end
+
+          click_button "Start application"
+
+          within('#personal_details') do
+            click_link('Complete section')
+          end
+
+          fill_in_personal_details
+          click_on "Save"
+
+          expect(page).to have_css('#personal_details .review-component__section__heading__status', text: 'complete')
+
+          within('#professional_status') do
+            click_link('Complete section')
+          end
+
+          fill_in_professional_status
+          click_on "Save"
+
+          expect(page).to have_css('#professional_status .review-component__section__heading__status', text: 'complete')
+
+          within('#qualifications') do
+            click_link('Complete section')
+          end
+
+          choose "Yes, I've completed this section"
+          click_on "Save"
+
+          expect(page).to have_css('#qualifications .review-component__section__heading__status', text: 'complete')
+
+          within('#employment_history') do
+            click_link('Complete section')
+          end
+
+          choose "Yes, I've completed this section"
+          click_on "Save"
+
+          expect(page).to have_css('#employment_history .review-component__section__heading__status', text: 'complete')
+        end
       end
     end
   end

--- a/spec/system/jobseekers/jobseekers_applications_get_prefilled_with_profile_data_spec.rb
+++ b/spec/system/jobseekers/jobseekers_applications_get_prefilled_with_profile_data_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe "Jobseekers applications are prefilled with profile data" do
+  let!(:jobseeker) { create(:jobseeker) }
+  let(:vacancy) { create(:vacancy, organisations: [school], visa_sponsorship_available: true) }
+  let(:school) { create(:school) }
+
+  context "when the jobseeker has a profile" do
+    context "when the jobseeker has completed details in their profile" do
+      let!(:jobseeker_profile) { create(:jobseeker_profile, :completed, jobseeker: jobseeker) }
+  
+      it "shows all sections with the status tag 'in progress'" do
+        login_as(jobseeker, scope: :jobseeker)
+        visit job_path(vacancy)
+        within ".banner-buttons" do
+          click_on I18n.t("jobseekers.job_applications.banner_links.apply")
+        end
+  
+        click_button "Start application"
+  
+        expect(page).to have_css('#personal_details .review-component__section__heading__status', text: 'in progress')
+        expect(page).to have_css('#professional_status .review-component__section__heading__status', text: 'in progress')
+        expect(page).to have_css('#qualifications .review-component__section__heading__status', text: 'in progress')
+        expect(page).to have_css('#employment_history .review-component__section__heading__status', text: 'in progress')
+      end
+    end
+
+    context "when the jobseeker has not completed any details in their profile" do
+      let!(:jobseeker_profile) { create(:jobseeker_profile, jobseeker: jobseeker, qualified_teacher_status: nil) }
+  
+      it "shows all sections with the status tag 'in progress'" do
+        login_as(jobseeker, scope: :jobseeker)
+        visit job_path(vacancy)
+        within ".banner-buttons" do
+          click_on I18n.t("jobseekers.job_applications.banner_links.apply")
+        end
+  
+        click_button "Start application"
+  
+        expect(page).to have_css('#personal_details .review-component__section__heading__status', text: 'not started')
+        expect(page).to have_css('#professional_status .review-component__section__heading__status', text: 'not started')
+        expect(page).to have_css('#qualifications .review-component__section__heading__status', text: 'not started')
+        expect(page).to have_css('#employment_history .review-component__section__heading__status', text: 'not started')
+      end
+    end
+
+    context "when the jobseeker has completed some details in their profile but not all of them" do
+      let!(:jobseeker_profile) { create(:jobseeker_profile, :with_qualifications, :with_employment_history, jobseeker: jobseeker, qualified_teacher_status: nil) }
+  
+      it "shows all sections that have been filled in with the status tag 'in progress' and shows empty sections with the status tag 'not started'" do
+        login_as(jobseeker, scope: :jobseeker)
+        visit job_path(vacancy)
+        within ".banner-buttons" do
+          click_on I18n.t("jobseekers.job_applications.banner_links.apply")
+        end
+  
+        click_button "Start application"
+  
+        expect(page).to have_css('#personal_details .review-component__section__heading__status', text: 'not started')
+        expect(page).to have_css('#professional_status .review-component__section__heading__status', text: 'not started')
+        expect(page).to have_css('#qualifications .review-component__section__heading__status', text: 'in progress')
+        expect(page).to have_css('#employment_history .review-component__section__heading__status', text: 'in progress')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Trello card URL

https://trello.com/b/1QyLnb9W/teaching-vacancies-sprint-board

## Changes in this PR:

- Change colour of completed tag to green.
- Set professional status, employments and qualifications status tags to 'in progress', rather than 'completed', when data is imported from jobseeker profile.
- Add tests for the application status tag behaviour when data is imported from jobseeker profile.
- Set personal details data to nil, rather than '', if no personal details data exists in jobseeker profile so that the personal details status tag reads 'not started' rather than 'in progress' when no data is available.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
