### PR TITLE
Vacancy filtering bug

### DIFF
--- a/app/queries/vacancy_filter_query.rb
+++ b/app/queries/vacancy_filter_query.rb
@@ -105,11 +105,14 @@ class VacancyFilterQuery < ApplicationQuery
   end
 
   def apply_job_roles(keys, built_scope, filters)
-    keys.each do |key|
-      if (filter_job_roles = job_roles(filters[key]).presence)
-        built_scope = built_scope.with_any_of_job_roles(filter_job_roles)
-      end
-    end
-    built_scope
+    string_roles = keys.flat_map { |key|
+      job_roles(filters[key])
+    }.compact
+
+    return built_scope if string_roles.blank?
+
+    roles = string_roles.map { |role| Vacancy::JOB_ROLES[role] }
+
+    built_scope.where("job_roles && ARRAY[?]::integer[]", roles)
   end
 end

--- a/app/queries/vacancy_filter_query.rb
+++ b/app/queries/vacancy_filter_query.rb
@@ -105,14 +105,14 @@ class VacancyFilterQuery < ApplicationQuery
   end
 
   def apply_job_roles(keys, built_scope, filters)
-    string_roles = keys.flat_map { |key|
+    filtered_roles_as_strings = keys.flat_map { |key|
       job_roles(filters[key])
     }.compact
 
-    return built_scope if string_roles.blank?
+    return built_scope if filtered_roles_as_strings.blank?
 
-    roles = string_roles.map { |role| Vacancy::JOB_ROLES[role] }
+    filtered_roles_as_integers = filtered_roles_as_strings.map { |role| Vacancy::JOB_ROLES[role] }
 
-    built_scope.where("job_roles && ARRAY[?]::integer[]", roles)
+    built_scope.where("job_roles && ARRAY[?]::integer[]", filtered_roles_as_integers)
   end
 end

--- a/spec/queries/vacancy_filter_query_spec.rb
+++ b/spec/queries/vacancy_filter_query_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe VacancyFilterQuery do
         expect(subject.call(filters)).to contain_exactly(teaching_assistant_vacancy, catering_cleaning_and_site_management_vacancy)
 
         filters = {
-          teaching_job_roles: %w[teacher],
+          teaching_job_roles: %w[teacher catering_cleaning_and_site_management],
         }
         expect(subject.call(filters).count).to eq(14)
         expect(subject.call(filters)).to contain_exactly(

--- a/spec/queries/vacancy_filter_query_spec.rb
+++ b/spec/queries/vacancy_filter_query_spec.rb
@@ -20,13 +20,25 @@ RSpec.describe VacancyFilterQuery do
 
   let!(:vacancy1) { create(:vacancy, job_title: "Vacancy 1", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[secondary], job_roles: ["teacher"], ect_status: "ect_suitable", organisations: [academy], enable_job_applications: true, visa_sponsorship_available: true) }
   let!(:vacancy2) { create(:vacancy, job_title: "Vacancy 2", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[sixth_form_or_college], job_roles: ["teacher"], ect_status: "ect_unsuitable", organisations: [free_school], enable_job_applications: true) }
-  let!(:vacancy3) { create(:vacancy, job_title: "Vacancy 3", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_role: "sendco", ect_status: nil, organisations: [local_authority_school], enable_job_applications: true) }
+  let!(:vacancy3) { create(:vacancy, job_title: "Vacancy 3", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["sendco"], ect_status: nil, organisations: [local_authority_school], enable_job_applications: true) }
   let!(:vacancy4) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 4", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["teacher"], ect_status: nil) }
   let!(:vacancy5) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 5", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["head_of_year_or_phase"], ect_status: nil, organisations: [academies]) }
   let!(:vacancy6) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 6", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["head_of_department_or_curriculum"], ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
   let!(:vacancy7) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 7", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["headteacher"], ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
   let!(:vacancy8) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 8", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["assistant_headteacher"], ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
   let!(:vacancy9) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 9", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["deputy_headteacher"], ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
+  let!(:teaching_assistant_vacancy) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 10", subjects: %w[], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["teaching_assistant"], ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
+  let!(:hlta_vacancy) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 11", subjects: %w[], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["higher_level_teaching_assistant"], ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
+  let!(:education_support_vacancy) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 12", subjects: %w[], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["education_support"], ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
+  let!(:sendco_vacancy) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 13", subjects: %w[], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["sendco"], ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
+  let!(:other_teaching_support_vacancy) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 14", subjects: %w[], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["other_teaching_support"], ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
+  let!(:administration_hr_data_and_finance_vacancy) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 15", subjects: %w[], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["administration_hr_data_and_finance"], ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
+  let!(:it_support_vacancy) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 16", subjects: %w[], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["it_support"], ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
+  let!(:pastoral_health_and_welfare_vacancy) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 17", subjects: %w[], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["pastoral_health_and_welfare"], ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
+  let!(:other_leadership_vacancy) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 18", subjects: %w[], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["other_leadership"], ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
+  let!(:other_support_vacancy) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 19", subjects: %w[], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["other_support"], ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
+  let!(:catering_cleaning_and_site_management_vacancy) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 19", subjects: %w[], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["catering_cleaning_and_site_management"], ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
+
   let!(:special_vacancy1) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 7", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["teacher"], ect_status: nil, organisations: [special_school1]) }
   let!(:special_vacancy2) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 8", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["teacher"], ect_status: nil, organisations: [special_school2]) }
   let!(:special_vacancy3) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 9", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["teacher"], ect_status: nil, organisations: [special_school3]) }
@@ -69,7 +81,10 @@ RSpec.describe VacancyFilterQuery do
             organisation_types: ["Academy"],
           }
           expect(subject.call(filters))
-            .to contain_exactly(vacancy1, vacancy2, vacancy5, vacancy6, vacancy7, vacancy8, vacancy9)
+            .to contain_exactly(vacancy1, vacancy2, vacancy5, vacancy6, vacancy7, vacancy8, vacancy9, teaching_assistant_vacancy,
+                                hlta_vacancy, education_support_vacancy, sendco_vacancy, other_teaching_support_vacancy,
+                                administration_hr_data_and_finance_vacancy, it_support_vacancy, pastoral_health_and_welfare_vacancy,
+                                other_leadership_vacancy, other_support_vacancy, catering_cleaning_and_site_management_vacancy)
         end
       end
 
@@ -88,7 +103,10 @@ RSpec.describe VacancyFilterQuery do
           expect(subject.call(filters)).to contain_exactly(
             vacancy1, vacancy2, vacancy3, vacancy4, vacancy5, vacancy6, vacancy7, vacancy8, vacancy9, special_vacancy1,
             special_vacancy2, special_vacancy3, special_vacancy4, special_vacancy5, special_vacancy6, faith_vacancy,
-            non_faith_vacancy1, non_faith_vacancy2, non_faith_vacancy3
+            non_faith_vacancy1, non_faith_vacancy2, non_faith_vacancy3, teaching_assistant_vacancy,
+            hlta_vacancy, education_support_vacancy, sendco_vacancy, other_teaching_support_vacancy,
+            administration_hr_data_and_finance_vacancy, it_support_vacancy, pastoral_health_and_welfare_vacancy,
+            other_leadership_vacancy, other_support_vacancy, catering_cleaning_and_site_management_vacancy
           )
         end
       end
@@ -99,7 +117,12 @@ RSpec.describe VacancyFilterQuery do
             organisation_types: ["Academy", "Local authority maintained schools"],
           }
           expect(subject.call(filters))
-            .to contain_exactly(vacancy1, vacancy2, vacancy3, vacancy5, vacancy6, vacancy7, vacancy8, vacancy9)
+            .to contain_exactly(
+              vacancy1, vacancy2, vacancy3, vacancy5, vacancy6, vacancy7, vacancy8, vacancy9, teaching_assistant_vacancy,
+              hlta_vacancy, education_support_vacancy, sendco_vacancy, other_teaching_support_vacancy,
+              administration_hr_data_and_finance_vacancy, it_support_vacancy, pastoral_health_and_welfare_vacancy,
+              other_leadership_vacancy, other_support_vacancy, catering_cleaning_and_site_management_vacancy
+            )
         end
       end
     end
@@ -177,6 +200,41 @@ RSpec.describe VacancyFilterQuery do
         }
         expect(subject.call(filters)).to contain_exactly(
           vacancy1, vacancy2, vacancy3, vacancy4, vacancy5, vacancy6, vacancy7, vacancy8, vacancy9, special_vacancy1,
+          special_vacancy2, special_vacancy3, special_vacancy4, special_vacancy5, special_vacancy6, faith_vacancy,
+          non_faith_vacancy1, non_faith_vacancy2, non_faith_vacancy3, teaching_assistant_vacancy,
+          hlta_vacancy, education_support_vacancy, sendco_vacancy, other_teaching_support_vacancy,
+          administration_hr_data_and_finance_vacancy, it_support_vacancy, pastoral_health_and_welfare_vacancy,
+          other_leadership_vacancy, other_support_vacancy, catering_cleaning_and_site_management_vacancy
+        )
+      end
+
+      it "correctly filters by multiple roles, including all roles selected" do
+        filters = {
+          teaching_job_roles: %w[headteacher],
+          non_teaching_support_job_roles: %w[other_support],
+          teaching_support_job_roles: %w[higher_level_teaching_assistant],
+        }
+        expect(subject.call(filters).count).to eq(3)
+        expect(subject.call(filters)).to contain_exactly(vacancy7, other_support_vacancy, hlta_vacancy)
+
+        filters = {
+          teaching_job_roles: %w[pastoral_health_and_welfare sendco],
+        }
+        expect(subject.call(filters).count).to eq(3)
+        expect(subject.call(filters)).to contain_exactly(pastoral_health_and_welfare_vacancy, sendco_vacancy, vacancy3)
+
+        filters = {
+          teaching_job_roles: %w[teaching_assistant catering_cleaning_and_site_management],
+        }
+        expect(subject.call(filters).count).to eq(2)
+        expect(subject.call(filters)).to contain_exactly(teaching_assistant_vacancy, catering_cleaning_and_site_management_vacancy)
+
+        filters = {
+          teaching_job_roles: %w[teacher],
+        }
+        expect(subject.call(filters).count).to eq(14)
+        expect(subject.call(filters)).to contain_exactly(
+          vacancy1, vacancy2, vacancy4, catering_cleaning_and_site_management_vacancy, special_vacancy1,
           special_vacancy2, special_vacancy3, special_vacancy4, special_vacancy5, special_vacancy6, faith_vacancy,
           non_faith_vacancy1, non_faith_vacancy2, non_faith_vacancy3
         )


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/jde67aXq/890-filters-on-the-jobs-page-are-looking-for-exact-matches-on-the-job-roles-ie-roles-that-are-both-teaching-assistant-and-catering-r

## Changes in this PR:

This PR fixes a bug which caused the job roles filtering to return 0 jobs if multiple roles were selected.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
