### PR TITLE
Use role names in yaml files to correctly render role names on hiring…

### DIFF
--- a/app/helpers/landing_pages_helper.rb
+++ b/app/helpers/landing_pages_helper.rb
@@ -21,14 +21,14 @@ module LandingPagesHelper
   def linked_job_roles_and_ect_status(vacancy)
     tag.ul class: "govuk-list" do
       safe_join(
-        vacancy.job_roles.map { |role| tag.li(linked_job_role(role)) }
+        vacancy.job_roles.map { |role| tag.li(linked_job_role(I18n.t("helpers.label.publishers_job_listing_job_role_form.job_role_options.#{role}"))) }
                          .push(tag.li(linked_ect_status(vacancy))),
       )
     end
   end
 
   def linked_job_role(role)
-    landing_page_link_or_text({ job_roles: [role] }, role&.humanize)
+    landing_page_link_or_text({ job_roles: [role] }, role)
   end
 
   def linked_ect_status(vacancy)

--- a/app/views/jobseekers/profiles/_summary.html.slim
+++ b/app/views/jobseekers/profiles/_summary.html.slim
@@ -8,7 +8,7 @@ p class="govuk-!-margin-bottom-3" = jobseeker_status(profile)
       - if (roles = job_preferences.roles).present?
         - summary_list.with_row do |row|
           - row.with_key text: t(".roles", count: roles.count)
-          - row.with_value text: humanize_array(roles)
+          - row.with_value text: job_preferences.roles.map { |role| I18n.t("helpers.label.publishers_job_listing_job_role_form.job_role_options.#{role}") }.join(", ")
       - if (phases = job_preferences.phases).present?
         - summary_list.with_row do |row|
           - row.with_key text: t(".education_phases", count: phases.count)

--- a/app/views/publishers/jobseeker_profiles/search/_results.html.slim
+++ b/app/views/publishers/jobseeker_profiles/search/_results.html.slim
@@ -12,7 +12,7 @@
         - if (preferences = jobseeker_profile.job_preferences).present?
           - summary_list.with_row do |row|
             - row.with_key text: t("publishers.jobseeker_profiles.preferred_roles", count: preferences.roles.count), classes: "govuk-body-s govuk-!-font-weight-bold govuk-!-padding-bottom-0"
-            - row.with_value text: jobseeker_profile.all_roles, classes: "govuk-body-s govuk-!-padding-bottom-0"
+            - row.with_value text: jobseeker_profile.job_preferences.roles.map {|role| I18n.t("helpers.label.publishers_job_listing_job_role_form.job_role_options.#{role}")}.join(", "), classes: "govuk-body-s govuk-!-padding-bottom-0"
 
           - summary_list.with_row do |row|
             - row.with_key text: t("publishers.jobseeker_profiles.preferred_key_stages", count: preferences.key_stages.count), classes: "govuk-body-s govuk-!-font-weight-bold govuk-!-padding-bottom-0"

--- a/app/views/publishers/jobseeker_profiles/search/_results.html.slim
+++ b/app/views/publishers/jobseeker_profiles/search/_results.html.slim
@@ -12,7 +12,7 @@
         - if (preferences = jobseeker_profile.job_preferences).present?
           - summary_list.with_row do |row|
             - row.with_key text: t("publishers.jobseeker_profiles.preferred_roles", count: preferences.roles.count), classes: "govuk-body-s govuk-!-font-weight-bold govuk-!-padding-bottom-0"
-            - row.with_value text: jobseeker_profile.job_preferences.roles.map {|role| I18n.t("helpers.label.publishers_job_listing_job_role_form.job_role_options.#{role}")}.join(", "), classes: "govuk-body-s govuk-!-padding-bottom-0"
+            - row.with_value text: jobseeker_profile.job_preferences.roles.map { |role| I18n.t("helpers.label.publishers_job_listing_job_role_form.job_role_options.#{role}") }.join(", "), classes: "govuk-body-s govuk-!-padding-bottom-0"
 
           - summary_list.with_row do |row|
             - row.with_key text: t("publishers.jobseeker_profiles.preferred_key_stages", count: preferences.key_stages.count), classes: "govuk-body-s govuk-!-font-weight-bold govuk-!-padding-bottom-0"

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -224,7 +224,10 @@ module VacancyHelpers
   def verify_vacancy_show_page_details(vacancy)
     vacancy = VacancyPresenter.new(vacancy)
     expect(page).to have_content(vacancy.job_title)
-    # expect(page).to have_content(vacancy.readable_job_roles)
+    readable_job_roles = vacancy.job_roles.map { |role| I18n.t("helpers.label.publishers_job_listing_job_role_form.job_role_options.#{role}") }
+    readable_job_roles.each do |role|
+      expect(page).to have_content(role)
+    end
     sponsorship_text = vacancy.visa_sponsorship_available ? "Skilled Worker visas can be sponsored" : "Visas cannot be sponsored"
     expect(page).to have_content(sponsorship_text)
     vacancy.subjects.each { |subject| expect(page).to have_content subject }

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -224,7 +224,7 @@ module VacancyHelpers
   def verify_vacancy_show_page_details(vacancy)
     vacancy = VacancyPresenter.new(vacancy)
     expect(page).to have_content(vacancy.job_title)
-    expect(page).to have_content(vacancy.readable_job_roles)
+    # expect(page).to have_content(vacancy.readable_job_roles)
     sponsorship_text = vacancy.visa_sponsorship_available ? "Skilled Worker visas can be sponsored" : "Visas cannot be sponsored"
     expect(page).to have_content(sponsorship_text)
     vacancy.subjects.each { |subject| expect(page).to have_content subject }

--- a/spec/system/jobseekers/jobseekers_can_view_a_vacancy_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_view_a_vacancy_spec.rb
@@ -6,10 +6,29 @@ RSpec.describe "Viewing a single published vacancy" do
   before { visit job_path(vacancy) }
 
   context "when the vacancy status is published" do
-    let(:vacancy) { create(:vacancy, :published, organisations: [school]) }
+    let(:vacancy) { create(:vacancy, :published, organisations: [school], job_roles: %w[ teacher headteacher deputy_headteacher assistant_headteacher head_of_year_or_phase head_of_department_or_curriculum teaching_assistant
+    higher_level_teaching_assistant education_support sendco other_teaching_support administration_hr_data_and_finance
+    catering_cleaning_and_site_management it_support pastoral_health_and_welfare other_leadership other_support ]) }
 
     scenario "jobseekers can view the vacancy" do
       verify_vacancy_show_page_details(vacancy)
+
+      expected_texts = [
+        'Teacher', 'Headteacher', 'Deputy headteacher', 
+        'Assistant headteacher', 'Head of year or phase',
+        'Head of department or curriculum', 'Teaching assistant',
+        'HLTA (higher level teaching assistant)', 'Learning support or cover supervisor',
+        'SENDCo (special educational needs and disabilities coordinator)', 'Other teaching support', 
+        'Administration, HR, data and finance', 
+        'Catering, cleaning and site management',
+        'IT support', 'Pastoral, health and welfare',
+        'Other leadership', 'Other support',
+        'Suitable for early career teachers'
+      ]
+
+      expected_texts.each do |text|
+        expect(page).to have_content(text)
+      end  
     end
 
     context "when the publish_on date is in the future" do

--- a/spec/system/jobseekers/jobseekers_can_view_a_vacancy_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_view_a_vacancy_spec.rb
@@ -12,23 +12,6 @@ RSpec.describe "Viewing a single published vacancy" do
 
     scenario "jobseekers can view the vacancy" do
       verify_vacancy_show_page_details(vacancy)
-
-      expected_texts = [
-        'Teacher', 'Headteacher', 'Deputy headteacher', 
-        'Assistant headteacher', 'Head of year or phase',
-        'Head of department or curriculum', 'Teaching assistant',
-        'HLTA (higher level teaching assistant)', 'Learning support or cover supervisor',
-        'SENDCo (special educational needs and disabilities coordinator)', 'Other teaching support', 
-        'Administration, HR, data and finance', 
-        'Catering, cleaning and site management',
-        'IT support', 'Pastoral, health and welfare',
-        'Other leadership', 'Other support',
-        'Suitable for early career teachers'
-      ]
-
-      expected_texts.each do |text|
-        expect(page).to have_content(text)
-      end  
     end
 
     context "when the publish_on date is in the future" do

--- a/spec/system/jobseekers/jobseekers_can_view_a_vacancy_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_view_a_vacancy_spec.rb
@@ -6,9 +6,11 @@ RSpec.describe "Viewing a single published vacancy" do
   before { visit job_path(vacancy) }
 
   context "when the vacancy status is published" do
-    let(:vacancy) { create(:vacancy, :published, organisations: [school], job_roles: %w[ teacher headteacher deputy_headteacher assistant_headteacher head_of_year_or_phase head_of_department_or_curriculum teaching_assistant
-    higher_level_teaching_assistant education_support sendco other_teaching_support administration_hr_data_and_finance
-    catering_cleaning_and_site_management it_support pastoral_health_and_welfare other_leadership other_support ]) }
+    let(:vacancy) do
+      create(:vacancy, :published, organisations: [school], job_roles: %w[ teacher headteacher deputy_headteacher assistant_headteacher head_of_year_or_phase head_of_department_or_curriculum teaching_assistant
+                                                                           higher_level_teaching_assistant education_support sendco other_teaching_support administration_hr_data_and_finance
+                                                                           catering_cleaning_and_site_management it_support pastoral_health_and_welfare other_leadership other_support ])
+    end
 
     scenario "jobseekers can view the vacancy" do
       verify_vacancy_show_page_details(vacancy)

--- a/spec/system/publishers/publishers_can_preview_a_vacancy_spec.rb
+++ b/spec/system/publishers/publishers_can_preview_a_vacancy_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Publishers can preview a vacancy" do
     before { visit organisation_job_path(vacancy.id) }
 
     context "when the job has been scheduled" do
-      let(:vacancy) { create(:vacancy, :future_publish, :teacher, :ect_suitable, organisations: [school], phases: %w[secondary], key_stages: %w[ks3]) }
+      let(:vacancy) { create(:vacancy, :future_publish, :teacher, :ect_suitable, job_roles: %w[teacher other_support], organisations: [school], phases: %w[secondary], key_stages: %w[ks3]) }
 
       scenario "users can preview the listing" do
         click_on I18n.t("publishers.vacancies.show.heading_component.action.preview")
@@ -22,7 +22,7 @@ RSpec.describe "Publishers can preview a vacancy" do
     end
 
     context "when the job in draft and all steps are valid" do
-      let(:vacancy) { create(:vacancy, :future_publish, :teacher, :ect_suitable, organisations: [school], phases: %w[secondary], key_stages: %w[ks3]) }
+      let(:vacancy) { create(:vacancy, :future_publish, :teacher, :ect_suitable, job_roles: %w[teacher other_support], organisations: [school], phases: %w[secondary], key_stages: %w[ks3]) }
 
       scenario "users can preview the listing" do
         click_on I18n.t("publishers.vacancies.show.heading_component.action.preview")

--- a/spec/system/publishers/publishers_can_search_for_jobseeker_profiles_spec.rb
+++ b/spec/system/publishers/publishers_can_search_for_jobseeker_profiles_spec.rb
@@ -7,9 +7,11 @@ RSpec.describe "Publishers searching for Jobseeker profiles", type: :system do
   let(:school_cambridge) { create(:school, name: "Cambridge", geopoint: "POINT (-0.108267 51.506438)") }
   let(:trust_publisher) { create(:publisher, organisations: [trust]) }
   let(:trust) { create(:trust, schools: [school_oxford, school_cambridge], geopoint: "POINT (-0.108267 51.506438)") }
-  let(:roles) { %w[ teacher headteacher deputy_headteacher assistant_headteacher head_of_year_or_phase head_of_department_or_curriculum teaching_assistant 
-                    higher_level_teaching_assistant education_support sendco other_teaching_support administration_hr_data_and_finance
-                    catering_cleaning_and_site_management it_support pastoral_health_and_welfare other_leadership other_support ] }
+  let(:roles) do
+    %w[ teacher headteacher deputy_headteacher assistant_headteacher head_of_year_or_phase head_of_department_or_curriculum teaching_assistant
+        higher_level_teaching_assistant education_support sendco other_teaching_support administration_hr_data_and_finance
+        catering_cleaning_and_site_management it_support pastoral_health_and_welfare other_leadership other_support ]
+  end
 
   let!(:jobseeker_profile) { create(:jobseeker_profile, :with_personal_details, qualified_teacher_status: "yes", qualified_teacher_status_year: "2000", job_preferences: job_preferences) }
   let(:job_preferences) { create(:job_preferences, roles: roles, key_stages: %w[ks1], working_patterns: %w[full_time], locations: [location_preference_containing_school], subjects: ["English"]) }
@@ -49,7 +51,7 @@ RSpec.describe "Publishers searching for Jobseeker profiles", type: :system do
           "Other teaching support, Administration, HR, data and finance, " \
           "Catering, cleaning and site management, IT support, " \
           "Pastoral, health and welfare, Other leadership roles, " \
-          "Other support roles"
+          "Other support roles",
         )
         expect(page).to have_content(jobseeker_profile.job_preferences.key_stages.first.humanize)
         expect(page).to have_content(jobseeker_profile.job_preferences.working_patterns.first.humanize)

--- a/spec/system/publishers/publishers_can_search_for_jobseeker_profiles_spec.rb
+++ b/spec/system/publishers/publishers_can_search_for_jobseeker_profiles_spec.rb
@@ -7,9 +7,12 @@ RSpec.describe "Publishers searching for Jobseeker profiles", type: :system do
   let(:school_cambridge) { create(:school, name: "Cambridge", geopoint: "POINT (-0.108267 51.506438)") }
   let(:trust_publisher) { create(:publisher, organisations: [trust]) }
   let(:trust) { create(:trust, schools: [school_oxford, school_cambridge], geopoint: "POINT (-0.108267 51.506438)") }
+  let(:roles) { %w[ teacher headteacher deputy_headteacher assistant_headteacher head_of_year_or_phase head_of_department_or_curriculum teaching_assistant 
+                    higher_level_teaching_assistant education_support sendco other_teaching_support administration_hr_data_and_finance
+                    catering_cleaning_and_site_management it_support pastoral_health_and_welfare other_leadership other_support ] }
 
   let!(:jobseeker_profile) { create(:jobseeker_profile, :with_personal_details, qualified_teacher_status: "yes", qualified_teacher_status_year: "2000", job_preferences: job_preferences) }
-  let(:job_preferences) { create(:job_preferences, roles: %w[teacher], key_stages: %w[ks1], working_patterns: %w[full_time], locations: [location_preference_containing_school], subjects: ["English"]) }
+  let(:job_preferences) { create(:job_preferences, roles: roles, key_stages: %w[ks1], working_patterns: %w[full_time], locations: [location_preference_containing_school], subjects: ["English"]) }
   let(:location_preference_containing_school) { create(:job_preferences_location, name: "London", radius: 100) }
 
   let!(:part_time_jobseeker_profile) { create(:jobseeker_profile, :with_personal_details, qualified_teacher_status: "yes", qualified_teacher_status_year: "2000", job_preferences: part_time_job_preferences) }
@@ -38,7 +41,16 @@ RSpec.describe "Publishers searching for Jobseeker profiles", type: :system do
       [jobseeker_profile, part_time_jobseeker_profile].each do |jobseeker_profile|
         expect(page).to have_link(href: publishers_jobseeker_profile_path(jobseeker_profile))
         expect(page).to have_content(jobseeker_profile.full_name)
-        expect(page).to have_content(jobseeker_profile.job_preferences.roles.first.humanize)
+        expect(page).to have_content(
+          "Teacher, Headteacher, Deputy headteacher, Assistant headteacher, " \
+          "Head of year or phase, Head of department or curriculum, " \
+          "Teaching assistant, HLTA (higher level teaching assistant), " \
+          "Learning support or cover supervisor, SENDCo (special educational needs and disabilities coordinator), " \
+          "Other teaching support, Administration, HR, data and finance, " \
+          "Catering, cleaning and site management, IT support, " \
+          "Pastoral, health and welfare, Other leadership roles, " \
+          "Other support roles"
+        )
         expect(page).to have_content(jobseeker_profile.job_preferences.key_stages.first.humanize)
         expect(page).to have_content(jobseeker_profile.job_preferences.working_patterns.first.humanize)
         expect(page).to have_content(jobseeker_profile.job_preferences.subjects.first.humanize)
@@ -127,7 +139,7 @@ RSpec.describe "Publishers searching for Jobseeker profiles", type: :system do
         end
 
         expect(page).not_to have_link(href: publishers_jobseeker_profile_path(part_time_jobseeker_profile))
-        expect(page).not_to have_link(href: publishers_jobseeker_profile_path(jobseeker_profile))
+        expect(page).to have_link(href: publishers_jobseeker_profile_path(jobseeker_profile))
         expect(page).not_to have_link(href: publishers_jobseeker_profile_path(no_right_to_work_in_uk_profile))
         expect(page).to have_link(href: publishers_jobseeker_profile_path(cleaning_staff_jobseeker_profile))
         expect(page).to have_link(href: publishers_jobseeker_profile_path(teaching_assistant_jobseeker_profile))

--- a/spec/system/publishers/publishers_can_view_a_jobseeker_profile_spec.rb
+++ b/spec/system/publishers/publishers_can_view_a_jobseeker_profile_spec.rb
@@ -5,6 +5,12 @@ RSpec.describe "Jobseeker profiles", type: :system do
   let(:organisation) { create(:school) }
   let(:jobseeker_profile) { create(:jobseeker_profile, :completed, :with_location_preferences) }
 
+  before do
+    jobseeker_profile.job_preferences.update(roles: %w[ teacher headteacher deputy_headteacher assistant_headteacher head_of_year_or_phase head_of_department_or_curriculum teaching_assistant
+                                                        higher_level_teaching_assistant education_support sendco other_teaching_support administration_hr_data_and_finance
+                                                        catering_cleaning_and_site_management it_support pastoral_health_and_welfare other_leadership other_support ])
+  end
+
   scenario "A publisher can view a jobseeker's profile" do
     login_publisher(publisher:, organisation:)
     visit publishers_jobseeker_profile_path(jobseeker_profile)
@@ -14,6 +20,16 @@ RSpec.describe "Jobseeker profiles", type: :system do
     expect(page).to have_content(jobseeker_profile.qualified_teacher_status_year)
     expect(page).to have_content(jobseeker_profile.about_you)
     expect(page).to have_content(jobseeker_profile.job_preferences.subjects.map(&:humanize).join(", "))
+    expect(page).to have_content(
+      "Teacher, Headteacher, Deputy headteacher, Assistant headteacher, " \
+      "Head of year or phase, Head of department or curriculum, " \
+      "Teaching assistant, HLTA (higher level teaching assistant), " \
+      "Learning support or cover supervisor, SENDCo (special educational needs and disabilities coordinator), " \
+      "Other teaching support, Administration, HR, data and finance, " \
+      "Catering, cleaning and site management, IT support, " \
+      "Pastoral, health and welfare, Other leadership roles, " \
+      "Other support roles",
+    )
     expect(page).to have_content(jobseeker_profile.employments.first.subjects)
     expect(page).not_to have_content("Location")
   end


### PR DESCRIPTION
… staff side when viewing candidate profiles

## Trello card URL

https://trello.com/c/Xv6u9y53/900-learning-support-or-cover-supervisor-on-js-profile-showing-up-as-education-support-on-hiring-staff-side

## Changes in this PR:
Prior to this change, the "Learning support or cover supervisor" role was showing up as "Education support" when the hiring staff viewed jobseeker profiles. This change fixes the issue.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
