### PR TITLE
Update profiles from job application submissions

### DIFF
--- a/app/controllers/jobseekers/job_applications_controller.rb
+++ b/app/controllers/jobseekers/job_applications_controller.rb
@@ -101,6 +101,8 @@ class Jobseekers::JobApplicationsController < Jobseekers::JobApplications::BaseC
 
   def update_jobseeker_profile!(job_application, form)
     profile = job_application.jobseeker.jobseeker_profile
+    return unless profile.present?
+
     profile.replace_qualifications!(job_application.qualifications.map(&:duplicate)) if form.update_profile_qualifications?
     profile.replace_employments!(job_application.employments.map(&:duplicate)) if form.update_profile_work_history?
   end

--- a/app/form_models/jobseekers/job_application/review_form.rb
+++ b/app/form_models/jobseekers/job_application/review_form.rb
@@ -1,7 +1,7 @@
 class Jobseekers::JobApplication::ReviewForm
   include ActiveModel::Model
 
-  attr_accessor :confirm_data_accurate, :confirm_data_usage, :completed_steps, :all_steps
+  attr_accessor :confirm_data_accurate, :confirm_data_usage, :update_profile, :completed_steps, :all_steps
 
   validates_acceptance_of :confirm_data_accurate, :confirm_data_usage,
                           acceptance: true,
@@ -17,5 +17,13 @@ class Jobseekers::JobApplication::ReviewForm
         I18n.t("activemodel.errors.models.jobseekers/job_application/review_form.attributes.#{step}.incomplete"),
       )
     end
+  end
+
+  def update_profile_qualifications?
+    update_profile&.include?("qualifications")
+  end
+
+  def update_profile_work_history?
+    update_profile&.include?("work_history")
   end
 end

--- a/app/models/jobseeker_profile.rb
+++ b/app/models/jobseeker_profile.rb
@@ -55,6 +55,20 @@ class JobseekerProfile < ApplicationRecord
     record.jobseeker
   end
 
+  def replace_qualifications!(new_qualifications)
+    transaction do
+      qualifications.destroy_all
+      update!(qualifications: new_qualifications)
+    end
+  end
+
+  def replace_employments!(new_employments)
+    transaction do
+      employments.destroy_all
+      update!(employments: new_employments)
+    end
+  end
+
   def deactivate!
     return unless active?
 

--- a/app/views/jobseekers/job_applications/review.html.slim
+++ b/app/views/jobseekers/job_applications/review.html.slim
@@ -25,6 +25,13 @@
       = form_for review_form, url: jobseekers_job_application_submit_path(job_application), method: :post do |f|
         = f.govuk_error_summary
 
+        = f.govuk_check_boxes_fieldset(:update_profile,
+                                       multiple: true,
+                                       legend: { text: t(".confirmation.update_your_profile.heading"), size: "m" },
+                                       hint: { text: t(".confirmation.update_your_profile.hint") }) do
+          = f.govuk_check_box :update_profile, "qualifications"
+          = f.govuk_check_box :update_profile, "work_history"
+
         h3.govuk-heading-m = t(".confirmation.heading")
 
         = f.govuk_check_boxes_fieldset :confirm_data_accurate, multiple: false, legend: nil do

--- a/app/views/jobseekers/job_applications/review.html.slim
+++ b/app/views/jobseekers/job_applications/review.html.slim
@@ -25,12 +25,13 @@
       = form_for review_form, url: jobseekers_job_application_submit_path(job_application), method: :post do |f|
         = f.govuk_error_summary
 
-        = f.govuk_check_boxes_fieldset(:update_profile,
-                                       multiple: true,
-                                       legend: { text: t(".confirmation.update_your_profile.heading"), size: "m" },
-                                       hint: { text: t(".confirmation.update_your_profile.hint") }) do
-          = f.govuk_check_box :update_profile, "qualifications"
-          = f.govuk_check_box :update_profile, "work_history"
+        - if current_jobseeker.jobseeker_profile.present?
+          = f.govuk_check_boxes_fieldset(:update_profile,
+                                         multiple: true,
+                                         legend: { text: t(".confirmation.update_your_profile.heading"), size: "m" },
+                                         hint: { text: t(".confirmation.update_your_profile.hint") }) do
+            = f.govuk_check_box :update_profile, "qualifications"
+            = f.govuk_check_box :update_profile, "work_history"
 
         h3.govuk-heading-m = t(".confirmation.heading")
 

--- a/app/views/jobseekers/job_applications/submit.html.slim
+++ b/app/views/jobseekers/job_applications/submit.html.slim
@@ -9,6 +9,8 @@
 
     p.govuk-body = t(".next_step.shortlisted", organisation: vacancy.organisation_name)
 
+    p.govuk-body = t(".next_step.profile_update")
+
     = govuk_button_link_to t(".next_step.view_applications"), jobseekers_job_applications_path, class: "govuk-button--secondary govuk-!-margin-bottom-3"
 
     hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -513,6 +513,9 @@ en:
           false: No, I'll come back to it later
           true: Yes, I've completed this section
       jobseekers_job_application_review_form:
+        update_profile_options:
+          qualifications: Update qualifications on profile
+          work_history: Update work history on profile
         confirm_data_accurate_options:
           "1": I confirm that the above information is accurate and complete
         confirm_data_usage_options:

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -385,6 +385,9 @@ en:
       review:
         confirmation:
           heading: Confirmation
+          update_your_profile:
+            heading: Do you want to update your profile?
+            hint: You can update your profile to match this application. This will replace the current information on your profile. Choose the sections you'd like to update.
           how_we_use_your_data:
             description: "When you submit your application, your data will be shared with:"
             heading: How your data is used
@@ -480,6 +483,8 @@ en:
           heading: What happens next
           shortlisted: >-
             If you are shortlisted for an interview %{organisation} will be in touch to let you know.
+          profile_update: >-
+            Your profile will match the information you supplied in your application if you chose to update it.
           view_applications: View your applications
         panel:
           body: We have sent an email confirmation to %{email}

--- a/spec/models/jobseeker_profile_spec.rb
+++ b/spec/models/jobseeker_profile_spec.rb
@@ -57,9 +57,15 @@ RSpec.describe JobseekerProfile, type: :model do
         .to change { profile.reload.qualifications }.from([old_qualification]).to(new_qualifications)
     end
 
-    it "deletes the original qualifications" do
+    it "deletes the original profile qualifications" do
       profile.replace_qualifications!(new_qualifications)
       expect { old_qualification.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "does not delete qualifications unrelated to the profile" do
+      unrelated_qualification = create(:qualification)
+      profile.replace_qualifications!(new_qualifications)
+      expect { unrelated_qualification.reload }.not_to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 
@@ -73,9 +79,15 @@ RSpec.describe JobseekerProfile, type: :model do
         .to change { profile.reload.employments }.from([old_employment]).to(new_employments)
     end
 
-    it "deletes the original employments" do
+    it "deletes the original profile employments" do
       profile.replace_employments!(new_employments)
       expect { old_employment.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "does not delete employments unrelated to the profile" do
+      unrelated_employment = create(:employment)
+      profile.replace_employments!(new_employments)
+      expect { unrelated_employment.reload }.not_to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 end

--- a/spec/models/jobseeker_profile_spec.rb
+++ b/spec/models/jobseeker_profile_spec.rb
@@ -46,4 +46,36 @@ RSpec.describe JobseekerProfile, type: :model do
       end
     end
   end
+
+  describe "#replace_qualifications!" do
+    let(:old_qualification) { create(:qualification) }
+    let(:new_qualifications) { create_list(:qualification, 2) }
+    let(:profile) { create(:jobseeker_profile, qualifications: [old_qualification]) }
+
+    it "replaces the qualifications" do
+      expect { profile.replace_qualifications!(new_qualifications) }
+        .to change { profile.reload.qualifications }.from([old_qualification]).to(new_qualifications)
+    end
+
+    it "deletes the original qualifications" do
+      profile.replace_qualifications!(new_qualifications)
+      expect { old_qualification.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  describe "#replace_employments!" do
+    let(:old_employment) { create(:employment) }
+    let(:new_employments) { create_list(:employment, 2) }
+    let(:profile) { create(:jobseeker_profile, employments: [old_employment]) }
+
+    it "replaces the employments" do
+      expect { profile.replace_employments!(new_employments) }
+        .to change { profile.reload.employments }.from([old_employment]).to(new_employments)
+    end
+
+    it "deletes the original employments" do
+      profile.replace_employments!(new_employments)
+      expect { old_employment.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
 end

--- a/spec/system/jobseekers/jobseekers_can_update_their_profile_from_job_applications_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_update_their_profile_from_job_applications_spec.rb
@@ -3,48 +3,59 @@ require "rails_helper"
 RSpec.describe "Jobseekers can update their profile from job applications" do
   include ActiveJob::TestHelper
 
-  let(:jobseeker) { create(:jobseeker) }
   let(:vacancy) { create(:vacancy) }
-
-  let(:profile_qualification) { create(:qualification, name: "Original profile qualification") }
-  let(:profile_employment) { create(:employment, job_title: "Original profile employment") }
-  let!(:jobseeker_profile) { create(:jobseeker_profile, jobseeker: jobseeker, qualifications: [profile_qualification], employments: [profile_employment]) }
-
   let(:application_qualification) { create(:qualification, name: "Application qualification") }
   let(:application_employment) { create(:employment, job_title: "Application employment") }
   let(:job_application) { create(:job_application, jobseeker: jobseeker, vacancy: vacancy, qualifications: [application_qualification], employments: [application_employment]) }
 
-  before do
-    login_as(jobseeker, scope: :jobseeker)
-    visit jobseekers_job_application_review_path(job_application)
-    check I18n.t("helpers.label.jobseekers_job_application_review_form.confirm_data_accurate_options.1")
-    check I18n.t("helpers.label.jobseekers_job_application_review_form.confirm_data_usage_options.1")
+  context "when the jobseekers have a profile" do
+    let(:jobseeker) { create(:jobseeker) }
+    let(:profile_qualification) { create(:qualification, name: "Original profile qualification") }
+    let(:profile_employment) { create(:employment, job_title: "Original profile employment") }
+    let!(:jobseeker_profile) { create(:jobseeker_profile, jobseeker: jobseeker, qualifications: [profile_qualification], employments: [profile_employment]) }
+
+    before do
+      login_as(jobseeker, scope: :jobseeker)
+      visit jobseekers_job_application_review_path(job_application)
+      check I18n.t("helpers.label.jobseekers_job_application_review_form.confirm_data_accurate_options.1")
+      check I18n.t("helpers.label.jobseekers_job_application_review_form.confirm_data_usage_options.1")
+    end
+
+    scenario "jobseekers can update their profile qualifications using the job application information on submission" do
+      check I18n.t("helpers.label.jobseekers_job_application_review_form.update_profile_options.qualifications")
+      click_on I18n.t("buttons.submit_application")
+      expect(page).to have_content(I18n.t("jobseekers.job_applications.submit.panel.title"))
+
+      click_link "Your profile"
+      expect(page).to have_css("h3.govuk-summary-card__title", text: "Application qualification")
+      expect(page).not_to have_css("h3.govuk-summary-card__title", text: "Original profile qualification")
+
+      expect(page).to have_css("h3.govuk-summary-card__title", text: "Original profile employment")
+      expect(page).not_to have_css("h3.govuk-summary-card__title", text: "Application employment")
+    end
+
+    scenario "jobseekers can update their profile work history using the job application information on submission" do
+      check I18n.t("helpers.label.jobseekers_job_application_review_form.update_profile_options.work_history")
+      click_on I18n.t("buttons.submit_application")
+      expect(page).to have_content(I18n.t("jobseekers.job_applications.submit.panel.title"))
+
+      click_link "Your profile"
+
+      expect(page).to have_css("h3.govuk-summary-card__title", text: "Original profile qualification")
+      expect(page).not_to have_css("h3.govuk-summary-card__title", text: "Application qualification")
+
+      expect(page).to have_css("h3.govuk-summary-card__title", text: "Application employment")
+      expect(page).not_to have_css("h3.govuk-summary-card__title", text: "Original profile employment")
+    end
   end
 
-  scenario "jobseekers can update their profile qualifications using the job application information on submission" do
-    check I18n.t("helpers.label.jobseekers_job_application_review_form.update_profile_options.qualifications")
-    click_on I18n.t("buttons.submit_application")
-    expect(page).to have_content(I18n.t("jobseekers.job_applications.submit.panel.title"))
+  context "when the jobseekers do not have a profile" do
+    let(:jobseeker) { create(:jobseeker, jobseeker_profile: nil) }
 
-    click_link "Your profile"
-    expect(page).to have_css("h3.govuk-summary-card__title", text: "Application qualification")
-    expect(page).not_to have_css("h3.govuk-summary-card__title", text: "Original profile qualification")
-
-    expect(page).to have_css("h3.govuk-summary-card__title", text: "Original profile employment")
-    expect(page).not_to have_css("h3.govuk-summary-card__title", text: "Application employment")
-  end
-
-  scenario "jobseekers can update their profile work history using the job application information on submission" do
-    check I18n.t("helpers.label.jobseekers_job_application_review_form.update_profile_options.work_history")
-    click_on I18n.t("buttons.submit_application")
-    expect(page).to have_content(I18n.t("jobseekers.job_applications.submit.panel.title"))
-
-    click_link "Your profile"
-
-    expect(page).to have_css("h3.govuk-summary-card__title", text: "Original profile qualification")
-    expect(page).not_to have_css("h3.govuk-summary-card__title", text: "Application qualification")
-
-    expect(page).to have_css("h3.govuk-summary-card__title", text: "Application employment")
-    expect(page).not_to have_css("h3.govuk-summary-card__title", text: "Original profile employment")
+    scenario "they are not offered to update their qualifications or work history on submission" do
+      login_as(jobseeker, scope: :jobseeker)
+      visit jobseekers_job_application_review_path(job_application)
+      expect(page.body).not_to have_content(I18n.t(".jobseekers.job_applications.review.confirmation.update_your_profile.heading"))
+    end
   end
 end

--- a/spec/system/jobseekers/jobseekers_can_update_their_profile_from_job_applications_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_update_their_profile_from_job_applications_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe "Jobseekers can update their profile from job applications" do
+  include ActiveJob::TestHelper
+
+  let(:jobseeker) { create(:jobseeker) }
+  let(:vacancy) { create(:vacancy) }
+
+  let(:profile_qualification) { create(:qualification, name: "Original profile qualification") }
+  let(:profile_employment) { create(:employment, job_title: "Original profile employment") }
+  let!(:jobseeker_profile) { create(:jobseeker_profile, jobseeker: jobseeker, qualifications: [profile_qualification], employments: [profile_employment]) }
+
+  let(:application_qualification) { create(:qualification, name: "Application qualification") }
+  let(:application_employment) { create(:employment, job_title: "Application employment") }
+  let(:job_application) { create(:job_application, jobseeker: jobseeker, vacancy: vacancy, qualifications: [application_qualification], employments: [application_employment]) }
+
+  before do
+    login_as(jobseeker, scope: :jobseeker)
+    visit jobseekers_job_application_review_path(job_application)
+    check I18n.t("helpers.label.jobseekers_job_application_review_form.confirm_data_accurate_options.1")
+    check I18n.t("helpers.label.jobseekers_job_application_review_form.confirm_data_usage_options.1")
+  end
+
+  scenario "jobseekers can update their profile qualifications using the job application information on submission" do
+    check I18n.t("helpers.label.jobseekers_job_application_review_form.update_profile_options.qualifications")
+    click_on I18n.t("buttons.submit_application")
+    expect(page).to have_content(I18n.t("jobseekers.job_applications.submit.panel.title"))
+
+    click_link "Your profile"
+    expect(page).to have_css("h3.govuk-summary-card__title", text: "Application qualification")
+    expect(page).not_to have_css("h3.govuk-summary-card__title", text: "Original profile qualification")
+
+    expect(page).to have_css("h3.govuk-summary-card__title", text: "Original profile employment")
+    expect(page).not_to have_css("h3.govuk-summary-card__title", text: "Application employment")
+  end
+
+  scenario "jobseekers can update their profile work history using the job application information on submission" do
+    check I18n.t("helpers.label.jobseekers_job_application_review_form.update_profile_options.work_history")
+    click_on I18n.t("buttons.submit_application")
+    expect(page).to have_content(I18n.t("jobseekers.job_applications.submit.panel.title"))
+
+    click_link "Your profile"
+
+    expect(page).to have_css("h3.govuk-summary-card__title", text: "Original profile qualification")
+    expect(page).not_to have_css("h3.govuk-summary-card__title", text: "Application qualification")
+
+    expect(page).to have_css("h3.govuk-summary-card__title", text: "Application employment")
+    expect(page).not_to have_css("h3.govuk-summary-card__title", text: "Original profile employment")
+  end
+end


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/QupKHOe3

## Changes in this PR:
When jobseekers submit job applications, they're asked if they want to update their qualifications and/or work history in their profile using the job application data they've just provided.

If they choose so, it will replace their profile info with the job application one.

## Screenshots of UI changes:

### On the submission form
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/089e8a68-e59a-466f-be12-465af43cd586)

### After submission
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/786576d4-4eeb-486a-bba0-63b9bda12254)
