### PR TITLE
Add banner and hiring guide for ASR

### DIFF
--- a/app/components/dashboard_component/dashboard_component.html.slim
+++ b/app/components/dashboard_component/dashboard_component.html.slim
@@ -1,5 +1,11 @@
 = tag.div(**html_attributes) do
   .govuk-grid-row
+    .govuk-grid-column-full
+      = govuk_notification_banner title_text: "Important", classes: "govuk-notification-banner govuk-!-margin-top-0 govuk-!-margin-bottom-5" do |banner|
+        - banner.with_heading(text: t("jobs.dashboard.non-teaching-roles-banner.heading"))
+        p.govuk-body = govuk_link_to(t("jobs.dashboard.non-teaching-roles-banner.link_text"), "/get-help-hiring/how-to-list-non-teaching-roles")
+
+  .govuk-grid-row
     .govuk-grid-column-three-quarters
       .help-guide--mobile.help-guide--border-bottom
         h3.govuk-heading-m = t("jobs.dashboard.how_to_accept_job_applications_guide.title")

--- a/app/views/content/get-help-hiring/how-to-list-non-teaching-roles.md
+++ b/app/views/content/get-help-hiring/how-to-list-non-teaching-roles.md
@@ -1,0 +1,21 @@
+---
+order: 600
+title: How to list non-teaching roles
+meta_description: Find out how to list non-teaching roles for your school or trust on Teaching Vacancies. Recruit finance directors, business managers and more.
+date_posted: 19/03/2024
+category_tags: how-to
+---
+![3 teachers sat on sofas having an engaging and relaxed conversation in a canteen area of a school.](/content-assets/jobseeker-guides/write-a-great-teaching-job-application-800x300.jpg)
+
+You can use Teaching Vacancies to recruit for all roles in your school or trust.
+This includes roles such as a finance director, office support staff, site management and more.
+The job listing process is almost exactly the same for teaching and non-teaching roles.
+
+## Listing a non-teaching role
+  1. Select ‘create a job listing’ and choose whether your role is in teaching and leadership, teaching support, or non-teaching support.
+  2. Choose either a job title (for example, teaching assistant), or a job category (for example, administration, HR, data and finance). You can choose ‘other leadership roles’ or ‘other support roles’ if the categories don’t fit.
+
+## Leaving feedback
+You can leave feedback after you’ve created your job listing.
+We’ll also email you after the job listing has ended to ask how you filled your vacancy.
+We’re excited to support you with recruiting all roles in your school and look forward to welcoming new jobseekers to Teaching Vacancies.

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -23,6 +23,9 @@ en:
         description_mobile: Get guidance around how to accept vacancies
         link_text: View article
         title: How to accept job applications on Teaching Vacancies
+      non-teaching-roles-banner:
+        heading: You can now create job listings for all roles in your school or trust.
+        link_text: Find out how to list non-teaching roles.
       pending:
         tab_heading: Scheduled jobs
         with_count: Scheduled jobs (%{count})


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/QHLeTPVo

## Changes in this PR:
- Adds a new guide for non-teaching roles on hiring staff guides.
- Shows a banner on the publisher's job listings dashboard. The banner contains a link to the new guide.

## Screenshots of UI changes:
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/cd221133-553a-4011-a74b-348ead639453)
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/e24fab63-f25d-44cb-93ae-a90901caa9af)
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/732f48ed-3d52-40ab-aae5-965e828a1269)

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
