### PR TITLE
Upgrade Hosting/Onboarding docs with latest PIM groups

### DIFF
--- a/documentation/hosting.md
+++ b/documentation/hosting.md
@@ -31,11 +31,11 @@ Each of the Kubernetes clusters is divided into [namespaces](https://learn.micro
 
 Each namespace hosts one/multiple different environments for Teaching Vacancies service.
 
-| Cluster     | Name                                    | PIM role group                                | Access                                                  |
-|-------------|-----------------------------------------|-----------------------------------------------|---------------------------------------------------------|
-| Development | s189-teacher-services-cloud-development | s189-teacher-services-cloud-Delivery Team USR | Permanently granted                                     |
-| Test        | s189-teacher-services-cloud-test        | s189 AKS admin test PIM                       | Up to 8 hours. Self approved on Azure PIM               |
-| Production  | s189-teacher-services-cloud-production  | s189 AKS admin production PIM                 | Up to 8 hours. Subject to manager approval on Azure PIM |
+| Cluster     | Name                                    | DfE Platform Identity Group | Access                                                  |
+|-------------|-----------------------------------------|-----------------------------|---------------------------------------------------------|
+| Development | s189-teacher-services-cloud-development | s189 TV delivery team       | Permanently granted                                     |
+| Test        | s189-teacher-services-cloud-test        | s189 AKS admin test PIM     | Permanently granted                                     |
+| Production  | s189-teacher-services-cloud-production  | s189 TV production PIM      | Up to 8 hours. Needs [team member approval](https://portal.azure.com/#view/Microsoft_Azure_PIMCommon/ResourceMenuBlade/~/MyActions/resourceId/73b976f6-fd4c-461f-bacb-95c6fae6f9d0/resourceType/Security/provider/aadgroup/resourceDisplayName/s189%20TV%20production%20PIM/resourceExternalId/73b976f6-fd4c-461f-bacb-95c6fae6f9d0) |
 
 Teaching Vacancies application environments are hosted in the following clusters/namespaces:
 
@@ -47,24 +47,19 @@ Teaching Vacancies application environments are hosted in the following clusters
 | Production      | s189-teacher-services-cloud-production | tv-production        |
 
 
-During [onboarding](./onboarding.md) you will have been granted access to selected Azure resources and roles:
+During [onboarding](./onboarding.md) you will have been granted access to selected Azure resources and roles.
 
-By default, you will have the `Reader` role in the:
-- `s189-teacher-services-cloud-test` subscription.
-- `s189-teacher-services-cloud-production` subscription.
+By default, you will have access to TV Kubernetes namespaces/envs/apps hosted in the `s189-teacher-services-cloud-test` cluster.
 
-You will have to request temporal (up to 8 hours per request) "Member" role on test (`s189 AKS admin test PIM`) and production (`s189 AKS admin production PIM`) to access/manage their hosted environments running Teaching Vacancies apps:
+For the `tv-production` namespace containing the Production environment running the Teaching Vacancies live app, you will have to [request the temporal activation](https://portal.azure.com/#view/Microsoft_Azure_PIMCommon/ResourceMenuBlade/~/MyActions/resourceId/73b976f6-fd4c-461f-bacb-95c6fae6f9d0/resourceType/Security/provider/aadgroup/resourceDisplayName/s189%20TV%20production%20PIM/resourceExternalId/73b976f6-fd4c-461f-bacb-95c6fae6f9d0) (up to 8 hours per request) for the `Member` role on the (`s189 TV production PIM`).
 
-- For `test` subscription the role will me automatically self-granted on request.
-- For `production` subscription the role requires a manager approval,
+Senior developers/tech lead on the team and DevOps have the will be able to [approve each others requests](https://portal.azure.com/#view/Microsoft_Azure_PIMCommon/ResourceMenuBlade/~/ApproveRequests/resourceId/73b976f6-fd4c-461f-bacb-95c6fae6f9d0/resourceType/Security/provider/aadgroup/resourceDisplayName/s189%20TV%20production%20PIM/resourceExternalId/73b976f6-fd4c-461f-bacb-95c6fae6f9d0).
 
-Senior developers, Tech Leads, and DevOps have the `Manager` role in all required subscriptions.
+Users aren´t able to self-approve their own role requests.
 
-Managers are able to approve other users role requests, but aren´t able to self-approve their own role requests.
-
-## Logging on Azure Platform and changing role
-1. Request your access for the `s189 AKS admin PIM` role on the desired subscription through a [Azure Privileged Identity Management (PIM) request](https://technical-guidance.education.gov.uk/infrastructure/hosting/azure-cip/#privileged-identity-management-pim-requests) under `Groups` tab in the [Azure Portal](https://portal.azure.com.mcas.ms/).
-2. The request will be self approved for the test subscription, or will need to be approved by a manager for the production subscription.
+## Getting Production access on Azure Platform
+1. Request your access for the `s189 TV production PIM` role on the [Azure Privileged Identity Management (PIM) request](https://technical-guidance.education.gov.uk/infrastructure/hosting/azure-cip/#privileged-identity-management-pim-requests) under `Groups` tab in the [Azure Portal](https://portal.azure.com.mcas.ms/).
+2. The request will need to be approved.
 
 ## Installing the Azure Client and Kubectl
 1. Install the [Azure Client](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
@@ -74,8 +69,8 @@ Managers are able to approve other users role requests, but aren´t able to self
     ```
 
 ## Login from Azure Console
-- You will need [access](#logging-on-azure-platform-and-changing-role) to the `s189 AKS admin PIM` role in the desired subscription hosting the environment you want access to.
-- Login into the tenant using the Azure Cli. This will launch your browser for the login.
+- You will need [production access](#getting-production-access-on-azure-platform) first if you want to run commands on the production environment.
+- Log into the tenant using the Azure Cli. This will launch your browser for the login.
     ```
     az login --tenant 9c7d9dd3-840c-4b3f-818e-552865082e16
     ```

--- a/documentation/onboarding.md
+++ b/documentation/onboarding.md
@@ -37,6 +37,8 @@ The new developer will be added to [teaching-vacancies-developers](https://githu
 
 You will need to request a Azure CID through the [Service Portal](https://dfe.service-now.com.mcas.ms/serviceportal?id=sc_cat_item&sys_id=51b0b9c5db1ff7809402e1aa4b96197d&referrer=recent_items) following [these instructions](https://technical-guidance.education.gov.uk/infrastructure/hosting/azure-cip/#onboarding-users).
 
+Request your Lead Developer/Team Lead to add you to the [s189 TV delivery team members list](https://portal.azure.com/#view/Microsoft_AAD_IAM/GroupDetailsMenuBlade/~/Members/groupId/30d11bf0-ab94-477a-bef4-82793788a7b7/menuId/).
+
 Once having access, contact the Teacher Services Infrastructure team and request access to the following s189 subscriptions:
 
 * s189-teacher-services-cloud-development


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/g9ppxCmf

## Changes in this PR:

Since the way we can access non-prod and prod environments has changed, we are updating it in our documentation.
