### PR TITLE
Fix healthcheck for Review App deletion action

### DIFF
--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -62,8 +62,8 @@ jobs:
 
     - name: check review status
       run: |
-        HTTP_CODE=$(curl -o/dev/null -s -w "%{http_code}" https://teaching-vacancies-review-pr-${{env.PR_NUMBER}}.test.teacherservices.cloud)
-        echo "HTTP_CODE=$HTTP_CODE"  >> $GITHUB_ENV
+        HTTP_CODE=$(curl -o/dev/null -s -w "%{http_code}" https://${{secrets.HTTP_BASIC_USER}}:${{secrets.HTTP_BASIC_PASSWORD}}@teaching-vacancies-review-pr-${{env.PR_NUMBER}}.test.teacherservices.cloud)
+        echo "HTTP_CODE=$HTTP_CODE" >> $GITHUB_ENV
 
     - name: Exit whole workflow if wait was not successful and review app is not up
       if: steps.wait_for_deployment.outputs.conclusion != 'success' && env.HTTP_CODE != '200'


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/meN4h0BX

## Changes in this PR:
The review apps are now behind a HTTP user/password protection. The healthcheck wasn't able to access the URL and the workflow for deleting the review apps were being cancelled each time due to the failed healthcheck step.
