### PR TITLE
Enable to skip the status check when manually deleting review apps

### DIFF
--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -13,6 +13,10 @@ on:
       pr_number:
         description: 'Pull Request number to delete (EG: 1234 for review-pr-1234)'
         required: true
+      skip_status_check:
+        description: 'Attempt deletion even if the review app status check fails'
+        required: false
+        type: boolean
 
 concurrency: workflow-Build-and-deploy-${{ github.ref }}
 
@@ -66,7 +70,7 @@ jobs:
         echo "HTTP_CODE=$HTTP_CODE" >> $GITHUB_ENV
 
     - name: Exit whole workflow if wait was not successful and review app is not up
-      if: steps.wait_for_deployment.outputs.conclusion != 'success' && env.HTTP_CODE != '200'
+      if: inputs.skip_status_check != true && steps.wait_for_deployment.outputs.conclusion != 'success' && env.HTTP_CODE != '200'
       run: exit 1
 
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/meN4h0BX

## Changes in this PR:
There are dangling review apps stuck for weeks that cannot be deleted because their status check fails.

Adding an option to skip the status check as a requirement to delete the review app allows us to manually delete those, while still checking the status by default.

## Screenshots of UI changes:
It adds an optional checkbox to skip the status check when required.
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/fa2cd385-34ce-4b4c-a50d-34918fc21c18)

Successfully deletes a stuck review app that previously failed to be deleted due to the status check failing
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/5c10e52b-987b-47ca-8863-2ae66183a535)

