### PR TITLE
Fix translation errors

### DIFF
--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -777,6 +777,8 @@ en:
           pastoral_health_and_welfare: Pastoral, health and welfare
           other_leadership: Other leadership roles
           other_support: Other support roles
+          senior_leader: Senior leader
+          middle_leader: Middle leader
         teaching_job_role_options:
           teacher: Teacher
           head_of_year_or_phase: Head of year or phase

--- a/spec/system/publishers/publishers_can_view_a_jobseeker_profile_spec.rb
+++ b/spec/system/publishers/publishers_can_view_a_jobseeker_profile_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Jobseeker profiles", type: :system do
   before do
     jobseeker_profile.job_preferences.update(roles: %w[ teacher headteacher deputy_headteacher assistant_headteacher head_of_year_or_phase head_of_department_or_curriculum teaching_assistant
                                                         higher_level_teaching_assistant education_support sendco other_teaching_support administration_hr_data_and_finance
-                                                        catering_cleaning_and_site_management it_support pastoral_health_and_welfare other_leadership other_support ])
+                                                        catering_cleaning_and_site_management it_support pastoral_health_and_welfare other_leadership other_support senior_leader middle_leader])
   end
 
   scenario "A publisher can view a jobseeker's profile" do
@@ -28,7 +28,7 @@ RSpec.describe "Jobseeker profiles", type: :system do
       "Other teaching support, Administration, HR, data and finance, " \
       "Catering, cleaning and site management, IT support, " \
       "Pastoral, health and welfare, Other leadership roles, " \
-      "Other support roles",
+      "Other support roles", "Senior leader", "Middle leader"
     )
     expect(page).to have_content(jobseeker_profile.employments.first.subjects)
     expect(page).not_to have_content("Location")

--- a/spec/system/publishers/publishers_can_view_a_jobseeker_profile_spec.rb
+++ b/spec/system/publishers/publishers_can_view_a_jobseeker_profile_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Jobseeker profiles", type: :system do
       "Other teaching support, Administration, HR, data and finance, " \
       "Catering, cleaning and site management, IT support, " \
       "Pastoral, health and welfare, Other leadership roles, " \
-      "Other support roles", "Senior leader", "Middle leader"
+      "Other support roles, Senior leader, Middle leader",
     )
     expect(page).to have_content(jobseeker_profile.employments.first.subjects)
     expect(page).not_to have_content("Location")


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/kSByYkBc/913-old-job-roles-in-the-hiring-staff-view-of-candidate-profiles-formatting-weirdly

## Changes in this PR:

This PR will correct the translation errors, but will show the "Senior leader" and "Middle leader" legacy roles which perhaps we do not want? I propose that we deploy this PR to fix the translation error then decide what to do about the legacy roles displaying in another PR. 

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
