### PR TITLE
Do not show professional status for not teaching roles

### DIFF
--- a/app/views/jobseekers/job_applications/_show.html.slim
+++ b/app/views/jobseekers/job_applications/_show.html.slim
@@ -6,7 +6,8 @@
     .with_anchor-link-list class="govuk-!-display-none-print"
       = navigation_list(title: t(".application_sections")) do |navigation|
         - navigation.with_anchor text: t(".personal_details.heading"), href: "#personal_details"
-        - navigation.with_anchor text: t(".professional_status.heading"), href: "#professional_status"
+        - if (vacancy.job_roles & Vacancy::TEACHING_JOB_ROLES).present?
+          - navigation.with_anchor text: t(".professional_status.heading"), href: "#professional_status"
         - navigation.with_anchor text: t(".qualifications.heading"), href: "#qualifications"
         - navigation.with_anchor text: t(".employment_history.heading"), href: "#employment_history"
         - navigation.with_anchor text: t(".personal_statement.heading"), href: "#personal_statement"


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/LOMuqWdB/884-remove-professional-status-link-in-application-form-contents

## Changes in this PR:

This PR fixes an issue with a professional status link showing on job applications for non teaching roles despite there being no professional status data for non teaching roles.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
