### PR TITLE
Reinstate legacy job roles for subscriptions

### DIFF
--- a/lib/tasks/migrate_subscriptions.rake
+++ b/lib/tasks/migrate_subscriptions.rake
@@ -1,3 +1,5 @@
+# rubocop:disable Metrics/BlockLength
+
 namespace :subscriptions do
   desc "Migrate job_roles to new category fields"
   task migrate_roles: :environment do
@@ -6,11 +8,21 @@ namespace :subscriptions do
 
       next unless search_criteria["job_roles"] && search_criteria.values_at("teaching_job_roles", "teaching_support_job_roles", "non_teaching_support_job_roles").none?
 
+      mapped_roles = search_criteria["job_roles"].map { |role|
+        if role == "senior_leader"
+          Vacancy::SENIOR_LEADER_JOB_ROLES
+        elsif role == "middle_leader"
+          Vacancy::MIDDLE_LEADER_JOB_ROLES
+        else
+          role
+        end
+      }.flatten
+
       teaching_job_roles = []
       teaching_support_job_roles = []
       non_teaching_support_job_roles = []
 
-      search_criteria["job_roles"].each do |role|
+      mapped_roles.each do |role|
         if Vacancy::TEACHING_JOB_ROLES.include?(role)
           teaching_job_roles << role
         elsif Vacancy::TEACHING_SUPPORT_JOB_ROLES.include?(role)
@@ -32,3 +44,4 @@ namespace :subscriptions do
     puts "Migrated job_roles to new role fields in subscriptions"
   end
 end
+# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
## Trello card URL
No card

## Changes in this PR:

This scripts migrate search criteria for old subscriptions including job_roles to new search criteria using the new categories included by the ASR release. This has been tested locally.
