### PR TITLE
Add Recaptcha to Jobseekers registration form

### DIFF
--- a/app/views/jobseekers/registrations/new.html.slim
+++ b/app/views/jobseekers/registrations/new.html.slim
@@ -23,6 +23,8 @@
         = f.govuk_radio_button :account_type, :non_teaching, label: { text: t(".labels.non_teaching") }, hint: { text: t(".hints.non_teaching") }
       end
 
+      = render "shared/recaptcha", form: f
+
       = f.govuk_submit t("buttons.create_account")
 
   .govuk-grid-column-one-third

--- a/spec/system/jobseekers/jobseekers_can_sign_up_to_an_account_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_sign_up_to_an_account_spec.rb
@@ -6,6 +6,20 @@ RSpec.describe "Jobseekers can sign up to an account" do
   let(:created_jobseeker) { Jobseeker.first }
 
   describe "creating an account" do
+    context "when recaptcha V3 check fails" do
+      before do
+        allow_any_instance_of(ApplicationController).to receive(:verify_recaptcha).and_return(false)
+      end
+
+      scenario "requests the user to pass a recaptcha V2 check" do
+        visit new_jobseeker_registration_path
+        expect { sign_up_jobseeker }.not_to change(Jobseeker, :count)
+        expect(page).to have_content("There is a problem")
+        expect(page).to have_content(I18n.t("recaptcha.error"))
+        expect(page).to have_content(I18n.t("recaptcha.label"))
+      end
+    end
+
     it "validates and submits the form, triggers account created event, sends confirmation email and redirects to check your email page" do
       visit new_jobseeker_registration_path
       click_on I18n.t("buttons.create_account")


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/IBsQVlb7

## Changes in this PR:
Some bots are spamming users with registration confirmation emails.
Adding recaptcha to this form to attempt to reduce the number of these
bot submissions.

Following instructions on Devise with Recaptcha:
https://github.com/heartcombo/devise/wiki/How-To:-Use-Recaptcha-with-Devise



## Screenshots of UI changes:
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/b4f55b9f-60d8-42f9-8d4f-5abaa8e4e3fd)