### PR TITLE
Use Form abstraction instead of hardcoding on controllers

### DIFF
--- a/app/controllers/jobseekers/job_applications/build_controller.rb
+++ b/app/controllers/jobseekers/job_applications/build_controller.rb
@@ -48,11 +48,7 @@ class Jobseekers::JobApplications::BuildController < Jobseekers::JobApplications
   def form_attributes
     case action_name
     when "show"
-      if step.name == "employment_history"
-        job_application.slice(form_class.fields - [:unexplained_employment_gaps_present])
-      else
-        job_application.slice(form_class.fields)
-      end
+      job_application.slice(form_class.storable_fields)
     when "update"
       form_params
     end
@@ -95,11 +91,7 @@ class Jobseekers::JobApplications::BuildController < Jobseekers::JobApplications
   end
 
   def update_fields
-    if form.instance_of?(Jobseekers::JobApplication::EmploymentHistoryForm)
-      form_params.except(:unexplained_employment_gaps_present)
-    else
-      form_params
-    end
+    form_params.except(*form_class.unstorable_fields)
   end
 
   def step_incomplete?

--- a/app/form_models/jobseekers/job_application/base_form.rb
+++ b/app/form_models/jobseekers/job_application/base_form.rb
@@ -2,4 +2,12 @@ class Jobseekers::JobApplication::BaseForm < BaseForm
   def self.fields
     []
   end
+
+  def self.unstorable_fields
+    []
+  end
+
+  def self.storable_fields
+    fields - unstorable_fields
+  end
 end

--- a/app/form_models/jobseekers/job_application/employment_history_form.rb
+++ b/app/form_models/jobseekers/job_application/employment_history_form.rb
@@ -4,6 +4,11 @@ class Jobseekers::JobApplication::EmploymentHistoryForm < Jobseekers::JobApplica
   def self.fields
     %i[employment_history_section_completed unexplained_employment_gaps_present]
   end
+
+  def self.unstorable_fields
+    %i[unexplained_employment_gaps_present]
+  end
+
   attr_accessor(*fields)
 
   validates :employment_history_section_completed, presence: true


### PR DESCRIPTION
**Not meant to be merged**

Example of a different approach regarding dealing with a form field that cannot be stored in Job Applications.

It uses the form object inheritance to set a default behaviour that will apply to all the forms, while introducing the possibility of defining form fields not meant to be stored in the ob application object in DB.

This way, we do not need to do ad-hoc exclusions in the controllers and can keep a simpler decoupled controller, while specific form-needed behaviour is kept within the forms.
