### PR TITLE
Add hidden text to change links for accessibility purposes

### DIFF
--- a/app/views/jobseekers/profiles/about_you/_summary.html.slim
+++ b/app/views/jobseekers/profiles/about_you/_summary.html.slim
@@ -2,4 +2,4 @@
   - summary_list.with_row do |row|
     - row.with_key text: t(".about_you_title")
     - row.with_value text: simple_format(profile.about_you)
-    - row.with_action(text: t("buttons.change"), href: edit_jobseekers_profile_about_you_path)
+    - row.with_action(text: t("buttons.change"), href: edit_jobseekers_profile_about_you_path, visually_hidden_text: "about you")

--- a/app/views/jobseekers/profiles/job_preferences/_summary.html.slim
+++ b/app/views/jobseekers/profiles/job_preferences/_summary.html.slim
@@ -45,7 +45,7 @@ ruby:
       summary_list.with_row do |row|
         row.with_key text: t(".#{attribute}", count:)
         row.with_value text: value.presence || options[:blank]
-        row.with_action(text: t("buttons.change"), href: jobseekers_job_preferences_step_path(step: step_name))
+        row.with_action(text: t("buttons.change"), href: jobseekers_job_preferences_step_path(step: step_name), visually_hidden_text: attribute.to_s.humanize)
       end
     end
   end

--- a/app/views/jobseekers/profiles/personal_details/_summary.html.slim
+++ b/app/views/jobseekers/profiles/personal_details/_summary.html.slim
@@ -21,7 +21,7 @@ ruby:
       summary_list.with_row do |row|
         row.with_key text: t(".#{attribute}")
         row.with_value text: value
-        row.with_action(text: t("buttons.change"), href: edit_personal_details_jobseekers_profile_path(step: step_name))
+        row.with_action(text: t("buttons.change"), href: edit_personal_details_jobseekers_profile_path(step: step_name), visually_hidden_text: attribute.to_s.humanize)
       end
     end
 

--- a/app/views/jobseekers/profiles/qualified_teacher_status/_summary.html.slim
+++ b/app/views/jobseekers/profiles/qualified_teacher_status/_summary.html.slim
@@ -2,10 +2,10 @@
   - summary_list.with_row do |row|
     - row.with_key text: t(".status_title")
     - row.with_value text: t("helpers.label.jobseekers_profile_qualified_teacher_status_form.qualified_teacher_status_options.#{profile.qualified_teacher_status}")
-    - row.with_action(text: t("buttons.change"), href: edit_jobseekers_profile_qualified_teacher_status_path)
+    - row.with_action(text: t("buttons.change"), href: edit_jobseekers_profile_qualified_teacher_status_path, visually_hidden_text: "qualified teacher status")
 
   - if profile.qualified_teacher_status_year.present?
     - summary_list.with_row do |row|
       - row.with_key text: t(".year_title")
       - row.with_value text: profile.qualified_teacher_status_year
-      - row.with_action(text: t("buttons.change"), href: edit_jobseekers_profile_qualified_teacher_status_path)
+      - row.with_action(text: t("buttons.change"), href: edit_jobseekers_profile_qualified_teacher_status_path, visually_hidden_text: "year QTS awarded")

--- a/app/views/jobseekers/qualifications/_qualifications.html.slim
+++ b/app/views/jobseekers/qualifications/_qualifications.html.slim
@@ -20,5 +20,5 @@
 
       - if qualification.secondary?
         - detail.with_action govuk_link_to t("buttons.add_another_subject"), edit_jobseekers_profile_qualification_path(qualification, new_subject: true), class: "govuk-link--no-visited-state"
-      - detail.with_action govuk_link_to t("buttons.change"), edit_jobseekers_profile_qualification_path(qualification), class: "govuk-link--no-visited-state"
-      - detail.with_action govuk_link_to t("buttons.delete"), jobseekers_profile_qualification_confirm_destroy_path(qualification)
+      - detail.with_action govuk_link_to(safe_join([t("buttons.change"), tag.span(qualification.category.humanize, class: "govuk-visually-hidden")]), edit_jobseekers_profile_qualification_path(qualification), class: "govuk-link--no-visited-state")
+      - detail.with_action govuk_link_to(safe_join([t("buttons.delete"), tag.span(qualification.category.humanize, class: "govuk-visually-hidden")]), jobseekers_profile_qualification_confirm_destroy_path(qualification))


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/DyAl8m4O/931-a11y-244-link-purpose-in-context-multiple-instances-of-identical-link-text

## Changes in this PR:

This PR adds hidden text to links on jobseeker profile page to differentiate all the change links which previously had the same text in order to make it easier for users that use screen readers to understand the context of the links.

Note: The ticket seems to suggest the issue also existed on the school profile, but after investigating it it seems that all the different change links do in fact have hidden text adding to the context. See screenshot below for an example.

![Screenshot 2024-04-10 at 15 01 29](https://github.com/DFE-Digital/teaching-vacancies/assets/13124899/344174f0-d373-4bef-a8c5-e1472e116802)

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
