### PR TITLE
Adapt subscription form for campaign emails

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -13,7 +13,7 @@ class SubscriptionsController < ApplicationController
     @form = Jobseekers::SubscriptionForm.new(new_form_attributes)
     @organisation = Organisation.friendly.find(search_criteria_params[:organisation_slug]) if organisation_job_alert?
 
-    render :new_campaign if campaign_link?
+    render "subscriptions/campaign/new" if campaign_link?
   end
 
   def create
@@ -22,7 +22,7 @@ class SubscriptionsController < ApplicationController
     @subscription = SubscriptionPresenter.new(subscription)
 
     if @form.invalid?
-      render :new
+      render @form.campaign.present? ? "subscriptions/campaign/new" : :new
     else
       recaptcha_protected(form: @form) do
         notify_new_subscription(subscription)
@@ -100,6 +100,7 @@ class SubscriptionsController < ApplicationController
       ect_statuses: (campaign[:email_ect].present? ? [campaign[:email_ect]] : ["ect_suitable"]),
       working_patterns: (campaign[:email_working_pattern].present? ? [campaign[:email_working_pattern]] : ["full_time"]),
       email: campaign[:email_contact].presence,
+      campaign: true,
     }.compact
   end
 
@@ -167,7 +168,9 @@ class SubscriptionsController < ApplicationController
 
   def subscription_params
     params.require(:jobseekers_subscription_form)
-          .permit(:email, :frequency, :keyword, :location, :organisation_slug, :radius, teaching_job_roles: [], teaching_support_job_roles: [], non_teaching_support_job_roles: [], visa_sponsorship_availability: [], ect_statuses: [], subjects: [], phases: [], working_patterns: [])
+          .permit(:email, :frequency, :keyword, :location, :organisation_slug, :radius, :campaign,
+                  teaching_job_roles: [], teaching_support_job_roles: [], non_teaching_support_job_roles: [],
+                  visa_sponsorship_availability: [], ect_statuses: [], subjects: [], phases: [], working_patterns: [])
   end
 
   def token

--- a/app/form_models/jobseekers/subscription_form.rb
+++ b/app/form_models/jobseekers/subscription_form.rb
@@ -19,7 +19,8 @@ class Jobseekers::SubscriptionForm < BaseForm
                 :ect_status_options,
                 :phase_options,
                 :working_pattern_options,
-                :organisation_slug
+                :organisation_slug,
+                :campaign
 
   validates :email, presence: true, email_address: true
   validates :frequency, presence: true
@@ -44,6 +45,7 @@ class Jobseekers::SubscriptionForm < BaseForm
     @phases = params[:phases]&.reject(&:blank?) || search_criteria[:phases]
     @working_patterns = params[:working_patterns]&.reject(&:blank?) || search_criteria[:working_patterns]
     @organisation_slug = params[:organisation_slug]
+    @campaign = params[:campaign].presence || false
 
     set_radius((params[:radius] || search_criteria[:radius]))
     set_facet_options

--- a/app/views/subscriptions/campaign/_fields.html.slim
+++ b/app/views/subscriptions/campaign/_fields.html.slim
@@ -1,0 +1,30 @@
+- unless @organisation
+  .autocomplete data-source="getLocationSuggestions" data-controller="autocomplete"
+    = f.govuk_text_field :location,
+      label: { text: t("subscriptions.new.campaign.location"), size: "s" },
+      form_group: { class: %w[location-finder__input govuk-!-margin-bottom-0] },
+      data: { coordinates: @vacancies_search&.point_coordinates || @point_coordinates }
+  = render "vacancies/search/current_location", target: "jobseekers-subscription-form-location-field"
+  = render "vacancies/search/radius", f: f, wide: false
+
+.divider-bottom class="govuk-!-margin-top-6"
+
+.plain-styling
+  = filters(submit_button: f.govuk_submit(t("buttons.apply_filters")), options: { remove_filter_links: false }) do |filters_component|
+      = render "/subscriptions/campaign/job_roles_fields", filters_component: filters_component, f: f, form: @form
+      - filters_component.with_group key: "education_phase", component: f.govuk_collection_check_boxes(:phases, @form.phase_options, :first, :last, small: false, legend: { text: t("jobs.filters.phases") }, hint: nil)
+      = render "shared/subjects_filter", filters_component: filters_component, f: f
+      - filters_component.with_group key: "ect_statuses", component: f.govuk_collection_check_boxes(:ect_statuses, @form.ect_status_options, :first, :last, small: false, legend: { text: t("jobs.filters.ect_suitable") }, hint: nil)
+      - filters_component.with_group key: "visa_sponsorship_availability", component: f.govuk_collection_check_boxes(:visa_sponsorship_availability, @form.visa_sponsorship_availability_options, :first, :last, small: false, legend: { text: t("jobs.filters.visa_sponsorship_availability.legend") }, hint: nil)
+      - filters_component.with_group key: "working_patterns", component: f.govuk_collection_check_boxes(:working_patterns, @form.working_pattern_options, :first, :last, small: false, legend: { text: t("jobs.filters.working_patterns") }, hint: nil)
+
+.divider-bottom class="govuk-!-margin-top-4"
+
+= f.hidden_field :campaign, value: true
+
+- if jobseeker_signed_in?
+  = f.hidden_field :email, value: current_jobseeker.email
+- else
+  = f.govuk_email_field :email, label: { size: "s" }, required: true
+
+= f.govuk_collection_radio_buttons :frequency, Subscription.frequencies.keys, :to_s

--- a/app/views/subscriptions/campaign/_form.html.slim
+++ b/app/views/subscriptions/campaign/_form.html.slim
@@ -1,0 +1,17 @@
+= form_for @form, **local_assigns.fetch(:form_options, {}) do |f|
+  = f.govuk_error_summary
+
+  h1.govuk-heading-xl class="govuk-!-margin-bottom-4" = t("#{i18n_prefix}.title")
+
+  - if @organisation
+    p.govuk-body-m = t("subscriptions.new.organisation_link_html", organisation_landing_page_link: govuk_link_to(@organisation.name, organisation_landing_page_path(@organisation)))
+    = f.hidden_field :organisation_slug, value: @organisation.slug
+
+  .subscription-criteria
+    = render "subscriptions/campaign/fields", f: f
+
+  = govuk_details summary_text: t("subscriptions.unsubscribe.guidance.heading"), text: t("subscriptions.unsubscribe.guidance.body")
+
+  = yield f
+
+  = f.govuk_submit button_text, class: "govuk-!-padding-left-8 govuk-!-padding-right-8"

--- a/app/views/subscriptions/campaign/_job_roles_fields.slim
+++ b/app/views/subscriptions/campaign/_job_roles_fields.slim
@@ -1,0 +1,13 @@
+- teaching_job_roles = capture do
+  = f.govuk_collection_check_boxes(:teaching_job_roles, form.teaching_job_role_options, :first, :last, small: false,
+                                   legend: { text: t("jobs.filters.campaign.teaching_job_roles") }, hint: nil)
+- teaching_support_job_roles = capture do
+  = f.govuk_collection_check_boxes(:teaching_support_job_roles, form.teaching_support_job_role_options, :first, :last, small: false,
+                                   legend: { text: t("jobs.filters.campaign.teaching_support_job_roles") }, hint: nil)
+- non_teaching_support_job_roles = capture do
+  = f.govuk_collection_check_boxes(:non_teaching_support_job_roles, form.non_teaching_support_job_role_options, :first, :last, small: false,
+                                   legend: { text: t("jobs.filters.campaign.non_teaching_support_job_roles") }, hint: nil)
+
+- filters_component.with_group key: "teaching_job_roles", component: teaching_job_roles
+- filters_component.with_group key: "teaching_support_job_roles", component: teaching_support_job_roles
+- filters_component.with_group key: "non_teaching_support_job_roles", component: non_teaching_support_job_roles

--- a/app/views/subscriptions/campaign/new.html.slim
+++ b/app/views/subscriptions/campaign/new.html.slim
@@ -5,5 +5,5 @@
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-     = render "form", form_options: { url: subscriptions_path }, i18n_prefix: "subscriptions.new", button_text: t("buttons.subscribe") do |f|
+     = render "subscriptions/campaign/form", form_options: { url: subscriptions_path }, i18n_prefix: "subscriptions.new", button_text: t("buttons.subscribe_campaign") do |f|
        = render "shared/recaptcha", form: f

--- a/app/views/subscriptions/new_campaign.html.slim
+++ b/app/views/subscriptions/new_campaign.html.slim
@@ -1,0 +1,9 @@
+- content_for :page_title_prefix, t("subscriptions.new.title")
+
+- content_for :breadcrumbs do
+  = govuk_back_link text: t("app.back_to_homepage"), href: root_path
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+     = render "form", form_options: { url: subscriptions_path }, i18n_prefix: "subscriptions.new", button_text: t("buttons.subscribe") do |f|
+       = render "shared/recaptcha", form: f

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -391,6 +391,8 @@ en:
       title: Create your job alert
       location:
         hint: Teaching Vacancies advertises school roles in England. Enter a UK city, county or postcode to look for roles near you.
+      campaign:
+        location: City, county or postcode (in England)
     unsubscribe:
       confirmation: Are you sure you want to unsubscribe?
       guidance:

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -98,6 +98,7 @@ en:
     submit_for_publication: Submit for publication
     submit_job_listing: Confirm and submit job
     subscribe: Subscribe
+    subscribe_campaign: Set up job alert
     unsubscribe: Unsubscribe
     update_alert: Update alert
     update_job: Update listing

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -34,6 +34,10 @@ en:
         with_count: Active jobs (%{count})
 
     filters:
+      campaign:
+        teaching_job_roles: Teaching roles
+        teaching_support_job_roles: Teaching support roles
+        non_teaching_support_job_roles: Non-teaching support roles
       job_filters: Job Filters
       job_type: Job type
       job_roles: Job role

--- a/spec/requests/subscriptions_spec.rb
+++ b/spec/requests/subscriptions_spec.rb
@@ -21,6 +21,18 @@ RSpec.describe "Subscriptions" do
       end
     end
 
+    context "when containing campaign parameters" do
+      let(:params) { { "email_contact" => "user@example.com", email_postcode: "SW12JP" } }
+
+      it "renders the template for the campaign users with pre-filled values" do
+        get(new_subscription_path, params:)
+
+        expect(response).to render_template(:new_campaign)
+        expect(response.body).to include("user@example.com")
+                             .and include("SW12JP")
+      end
+    end
+
     context "when hit via the nqt job alerts url" do
       before { get "/sign-up-for-NQT-job-alerts" }
 

--- a/spec/requests/subscriptions_spec.rb
+++ b/spec/requests/subscriptions_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Subscriptions" do
       it "renders the template for the campaign users with pre-filled values" do
         get(new_subscription_path, params:)
 
-        expect(response).to render_template(:new_campaign)
+        expect(response).to render_template("subscriptions/campaign/new")
         expect(response.body).to include("user@example.com")
                              .and include("SW12JP")
       end

--- a/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_a_mailing_campaign.rb
+++ b/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_a_mailing_campaign.rb
@@ -12,7 +12,7 @@ RSpec.describe "Jobseekers can create a job alert from a mailing campaign", reca
       visit new_subscription_path(params:)
       choose I18n.t("helpers.label.jobseekers_subscription_form.frequency_options.daily")
 
-      expect { click_on I18n.t("buttons.subscribe") }.not_to(change { Subscription.count })
+      expect { click_on I18n.t("buttons.subscribe_campaign") }.not_to(change { Subscription.count })
       expect(page).to have_content("There is a problem")
       expect(page).to have_content(I18n.t("recaptcha.error"))
       expect(page).to have_content(I18n.t("recaptcha.label"))
@@ -22,12 +22,14 @@ RSpec.describe "Jobseekers can create a job alert from a mailing campaign", reca
   scenario "the landing form has default values for radio, job role, ect suitability and working pattern" do
     visit new_subscription_path(params:)
 
-    expect(page).to have_field("Location", with: "SW24LP")
+    expect(page).to have_field("City, county or postcode (in England)", with: "SW24LP")
                 .and have_field("Email address", with: "user@example.com")
                 .and have_field("Search radius", with: "15")
                 .and have_checked_field("Teacher")
                 .and have_checked_field("Suitable for early career teachers")
                 .and have_checked_field("Full time")
+
+    validate_and_confirm
   end
 
   scenario "the subscription form values are set from the URL parameters" do
@@ -41,7 +43,7 @@ RSpec.describe "Jobseekers can create a job alert from a mailing campaign", reca
       email_working_pattern: "part_time",
     })
 
-    expect(page).to have_field("Location", with: "SW24LP")
+    expect(page).to have_field("City, county or postcode (in England)", with: "SW24LP")
                 .and have_field("Email address", with: "user@example.com")
                 .and have_field("Search radius", with: "10")
                 .and have_checked_field("Assistant headteacher")
@@ -52,5 +54,18 @@ RSpec.describe "Jobseekers can create a job alert from a mailing campaign", reca
 
     expect(page).not_to have_checked_field("Teacher")
     expect(page).not_to have_checked_field("Full time")
+
+    validate_and_confirm
+  end
+
+  def validate_and_confirm
+    click_button I18n.t("buttons.subscribe_campaign")
+    expect(page).to have_content("There is a problem")
+                .and have_content("Select when you want to receive job alert emails")
+
+    choose I18n.t("helpers.label.jobseekers_subscription_form.frequency_options.daily")
+    click_button I18n.t("buttons.subscribe_campaign")
+    expect(current_path).to eq(subscriptions_path)
+    expect(page).to have_content(I18n.t("subscriptions.confirm.header.create"))
   end
 end

--- a/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_a_mailing_campaign.rb
+++ b/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_a_mailing_campaign.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe "Jobseekers can create a job alert from a mailing campaign", recaptcha: true do
+  let(:params) { { email_contact: "user@example.com", email_postcode: "SW24LP" } }
+
+  describe "when recaptcha V3 check fails" do
+    before do
+      allow_any_instance_of(ApplicationController).to receive(:verify_recaptcha).and_return(false)
+    end
+
+    it "requests the user to pass a recaptcha V2 check" do
+      visit new_subscription_path(params:)
+      choose I18n.t("helpers.label.jobseekers_subscription_form.frequency_options.daily")
+
+      expect { click_on I18n.t("buttons.subscribe") }.not_to(change { Subscription.count })
+      expect(page).to have_content("There is a problem")
+      expect(page).to have_content(I18n.t("recaptcha.error"))
+      expect(page).to have_content(I18n.t("recaptcha.label"))
+    end
+  end
+
+  scenario "the landing form has default values for radio, job role, ect suitability and working pattern" do
+    visit new_subscription_path(params:)
+
+    expect(page).to have_field("Location", with: "SW24LP")
+                .and have_field("Email address", with: "user@example.com")
+                .and have_field("Search radius", with: "15")
+                .and have_checked_field("Teacher")
+                .and have_checked_field("Suitable for early career teachers")
+                .and have_checked_field("Full time")
+  end
+
+  scenario "the subscription form values are set from the URL parameters" do
+    visit new_subscription_path(params: {
+      email_contact: "user@example.com",
+      email_postcode: "SW24LP",
+      email_subject: "mathematics",
+      email_phase: "primary",
+      email_radius: "10",
+      email_jobrole: "assistant_headteacher",
+      email_working_pattern: "part_time",
+    })
+
+    expect(page).to have_field("Location", with: "SW24LP")
+                .and have_field("Email address", with: "user@example.com")
+                .and have_field("Search radius", with: "10")
+                .and have_checked_field("Assistant headteacher")
+                .and have_checked_field("Mathematics")
+                .and have_checked_field("Suitable for early career teachers")
+                .and have_checked_field("Primary school")
+                .and have_checked_field("Part time")
+
+    expect(page).not_to have_checked_field("Teacher")
+    expect(page).not_to have_checked_field("Full time")
+  end
+end


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/ThN1CkQS

## Changes in this PR:
Some groups of users are going to receive marketing campaign emails targeted to them. These emails will include a link to create subscriptions in our service to receive job alerts.

We allow to prefill the subscription form, based on parameter values added to the email links.

Some of these values will default unless specified, some will only be set if specified as parameters.

The interface of the subscription forms for campaign links will be slightly different than the default subscription form.

Some changes: 
- No field for the keyword search.
- Reordering fields.
- Different field legend/names.
- Button reworded.

## Examples

### Link sent in the campaign:
https://teaching-vacancies-review-pr-6779.test.teacherservices.cloud/subscriptions/new?email_contact=user@example.com&email_postcode=SW23PJ

It will prefill the subscription form with:
- Email address as `user@example.com`
- Location as  `SW23PJ`
- Search radius as `15 miles`
- Job role as `Teacher`
- Suitable for early career teachers checked.
- Working Pattern as `Full time`

### Link sent in the campaign:
https://teaching-vacancies-review-pr-6779.test.teacherservices.cloud/subscriptions/new?email_contact=user@example.com&email_postcode=SW23PJ&email_radius=100&email_jobrole=headteacher&email_phase=primary&email_subject=biology&email_working_pattern=part_time

It will prefill the subscription form with:
- Email address as `user@example.com`
- Location as  `SW23PJ`
- Search radius as `100 miles`
- Education phase as `Primary school`
- Job role as `Headteacher`
- Suitable for early career teachers checked.
- Subjects with `Biology` checked.
- Working Pattern as `Part time`

## Screenshots

#### Some of the changes
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/c2859a35-4ab9-406a-a34b-ab71a4740da1)
----
#### New wording on the button
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/7342ba0c-e299-40e0-8737-33633250cebb)


