### PR TITLE
Add extra libraries for Imagemagick logo conversion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
  # Alpine v3.19.
  # TODO: Regularly check in the alpine ruby "3.3.0-alpine3.19" images for its latest upgraded packages so we can remove
  # the hardcoded versions below when they have been updated in the alpine ruby image.
-ARG PROD_PACKAGES="imagemagick libxml2 libxslt libpq tzdata shared-mime-info postgresql15 gnutls=3.8.4-r0"
+ARG PROD_PACKAGES="imagemagick libpng libjpeg libxml2 libxslt libpq tzdata shared-mime-info postgresql15 gnutls=3.8.4-r0"
 
 FROM ruby:3.3.0-alpine3.19 AS builder
 


### PR DESCRIPTION
We upgraded to Alpine 3.19 and these errors started showing up:

```
MiniMagick::Invalid
`magick identify /tmp/mini_magick20240411-1-f8gk15.jpg` failed with status: 1 and error: (MiniMagick::Invalid)
identify: no decode delegate for this image format `JPEG' @ error/constitute.c/ReadImage/746.
```

https://teaching-vacancies.sentry.io/issues/4868795788/?environment=production&project=6212514&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=0