### PR TITLE
change aria-owns to aria-controls

### DIFF
--- a/app/assets/javascript/components/searchable_collection/searchable_collection.js
+++ b/app/assets/javascript/components/searchable_collection/searchable_collection.js
@@ -34,8 +34,10 @@ const SearchableCollectionComponent = class extends Controller {
 
     if (this.inputTarget.value.length) {
       this.element.querySelector('.collection-match').innerHTML = `${visibleItems.length} subjects match ${this.inputTarget.value}`;
+      this.inputTarget.setAttribute('aria-controls', 'subjects__listbox');
     } else {
       this.element.querySelector('.collection-match').innerHTML = '';
+      this.inputTarget.removeAttribute('aria-controls');
     }
   }
 

--- a/app/assets/javascript/components/searchable_collection/searchable_collection.js
+++ b/app/assets/javascript/components/searchable_collection/searchable_collection.js
@@ -34,10 +34,8 @@ const SearchableCollectionComponent = class extends Controller {
 
     if (this.inputTarget.value.length) {
       this.element.querySelector('.collection-match').innerHTML = `${visibleItems.length} subjects match ${this.inputTarget.value}`;
-      this.inputTarget.setAttribute('aria-controls', 'subjects__listbox');
     } else {
       this.element.querySelector('.collection-match').innerHTML = '';
-      this.inputTarget.removeAttribute('aria-controls');
     }
   }
 

--- a/app/components/searchable_collection_component/searchable_collection_component.html.slim
+++ b/app/components/searchable_collection_component/searchable_collection_component.html.slim
@@ -2,7 +2,7 @@
   div class="#{border_class} #{scrollable_class}"
     - if searchable?
       .searchable-collection-component__search
-        input.govuk-input.icon.icon--left.icon--search.js-action data-searchable-collection-target="input" data-action="input->searchable-collection#input" placeholder=@text[:placeholder] aria-label=@text[:aria_label] aria-expanded="true" aria-describedby=@text[:aria_describedby] role="combobox"
+        input.govuk-input.icon.icon--left.icon--search.js-action data-searchable-collection-target="input" data-action="input->searchable-collection#input" placeholder=@text[:placeholder] aria-label=@text[:aria_label] aria-expanded="true" aria-describedby=@text[:aria_describedby] aria-controls="subjects__listbox" role="combobox"
         .govuk-visually-hidden aria-live="assertive" role="status" class="collection-match"
 
     = collection

--- a/app/components/searchable_collection_component/searchable_collection_component.html.slim
+++ b/app/components/searchable_collection_component/searchable_collection_component.html.slim
@@ -2,7 +2,7 @@
   div class="#{border_class} #{scrollable_class}"
     - if searchable?
       .searchable-collection-component__search
-        input.govuk-input.icon.icon--left.icon--search.js-action data-searchable-collection-target="input" data-action="input->searchable-collection#input" placeholder=@text[:placeholder] aria-label=@text[:aria_label] aria-expanded="true" aria-describedby=@text[:aria_describedby] aria-owns="subjects__listbox" role="combobox"
+        input.govuk-input.icon.icon--left.icon--search.js-action data-searchable-collection-target="input" data-action="input->searchable-collection#input" placeholder=@text[:placeholder] aria-label=@text[:aria_label] aria-expanded="true" aria-describedby=@text[:aria_describedby] aria-controls="subjects__listbox" role="combobox"
         .govuk-visually-hidden aria-live="assertive" role="status" class="collection-match"
 
     = collection

--- a/app/components/searchable_collection_component/searchable_collection_component.html.slim
+++ b/app/components/searchable_collection_component/searchable_collection_component.html.slim
@@ -2,7 +2,7 @@
   div class="#{border_class} #{scrollable_class}"
     - if searchable?
       .searchable-collection-component__search
-        input.govuk-input.icon.icon--left.icon--search.js-action data-searchable-collection-target="input" data-action="input->searchable-collection#input" placeholder=@text[:placeholder] aria-label=@text[:aria_label] aria-expanded="true" aria-describedby=@text[:aria_describedby] aria-controls="subjects__listbox" role="combobox"
+        input.govuk-input.icon.icon--left.icon--search.js-action data-searchable-collection-target="input" data-action="input->searchable-collection#input" placeholder=@text[:placeholder] aria-label=@text[:aria_label] aria-expanded="true" aria-describedby=@text[:aria_describedby] role="combobox"
         .govuk-visually-hidden aria-live="assertive" role="status" class="collection-match"
 
     = collection


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/EPRpNbM5/923-a11y-412-name-role-value-required-aria-attributes-must-be-provided

## Changes in this PR:

This PR changes aria-owns "subjects__listbox" to aria-controls "subjects__listbox" to more accurately represent the relationship between the subjects search box and the checkboxes

## Screenshots of UI changes:

### Before

![Screenshot 2024-04-11 at 16 05 40](https://github.com/DFE-Digital/teaching-vacancies/assets/13124899/599f2303-7d9a-4e3e-b59c-c9313ee2f637)

### After
Note: I think the additional 2 issues are due to the review app banner.
![Screenshot 2024-04-11 at 16 05 49](https://github.com/DFE-Digital/teaching-vacancies/assets/13124899/1f9e8ea6-ee71-4f80-a7b3-cbf2d3a3e9b7)

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
