### PR TITLE
 Add 'id' to checkbox list

### DIFF
--- a/app/assets/javascript/components/searchable_collection/searchable_collection.js
+++ b/app/assets/javascript/components/searchable_collection/searchable_collection.js
@@ -22,11 +22,6 @@ const SearchableCollectionComponent = class extends Controller {
 
     const visibleItems = this.collection.filter((item) => item.parentElement.style.display === 'block');
 
-    Array.from(this.element.getElementsByClassName('govuk-checkboxes')).forEach((el) => {
-      el.setAttribute('role', 'listbox');
-      el.id = 'subjects__listbox';
-    });
-
     visibleItems.forEach((item, i) => {
       item.setAttribute('aria-posinset', i + 1);
       item.setAttribute('aria-setsize', visibleItems.length);

--- a/app/components/searchable_collection_component/searchable_collection_component.html.slim
+++ b/app/components/searchable_collection_component/searchable_collection_component.html.slim
@@ -2,7 +2,7 @@
   div class="#{border_class} #{scrollable_class}"
     - if searchable?
       .searchable-collection-component__search
-        input.govuk-input.icon.icon--left.icon--search.js-action data-searchable-collection-target="input" data-action="input->searchable-collection#input" placeholder=@text[:placeholder] aria-label=@text[:aria_label] aria-expanded="true" aria-describedby=@text[:aria_describedby] aria-owns="subjects__listbox" role="combobox"
+        input.govuk-input.icon.icon--left.icon--search.js-action data-searchable-collection-target="input" data-action="input->searchable-collection#input" placeholder=@text[:placeholder] aria-label=@text[:aria_label] aria-expanded="true" aria-describedby=@text[:aria_describedby] aria-controls="subjects__listbox" role="combobox"
         .govuk-visually-hidden aria-live="assertive" role="status" class="collection-match"
 
     #subjects__listbox


### PR DESCRIPTION
The `aria-owns` attribute in the searchable collection's input referenced an `id` that didn't exist in the DOM structure. This resulted in an invalid association between the input field and the checkbox list, which was spotted in our accessibility audit and marked as an error.

This commit added an 'id' attribute to the `div` containing the checkboxes to resolve this.

These changes significantly improve the accessibility of the searchable collection. By creating a valid association between the containing input and the list of checkboxes, assistive technologies can now better understand the relationship. This results in a more seamless user experience for individuals relying on these technologies.

