### PR TITLE
a11y alt text

### DIFF
--- a/app/views/vacancies/listing/_banner.html.slim
+++ b/app/views/vacancies/listing/_banner.html.slim
@@ -4,7 +4,7 @@
 .header-with-logo class="govuk-!-margin-bottom-5"
   - if vacancy.organisation.logo.attached?
     .header-with-logo-logo
-      = image_tag(vacancy.organisation.logo, alt: t("publishers.organisations.organisation.logo.alt_text", organisation_name: vacancy.organisation.name))
+      = image_tag(vacancy.organisation.logo, alt: "")
   .header-with-logo-title
     - if vacancy.enable_job_applications?
       div class="govuk-!-margin-bottom-2" = govuk_tag(text: t("vacancies.listing.enable_job_applications_tag"), colour: "green")

--- a/app/views/vacancies/search/_results.html.slim
+++ b/app/views/vacancies/search/_results.html.slim
@@ -4,7 +4,7 @@
       .header-with-logo
         - if vacancy.organisation.logo.attached?
           .header-with-logo-logo--search-result
-            = image_tag(vacancy.organisation.logo, alt: t("publishers.organisations.organisation.logo.alt_text", organisation_name: vacancy.organisation.name))
+            = image_tag(vacancy.organisation.logo, alt: "")
         .header-with-logo-title
           h2.govuk-heading-m class="govuk-!-margin-bottom-0"
             span class="govuk-!-margin-right-2" = results_link(vacancy, class: "view-vacancy-link")


### PR DESCRIPTION
…e text for images, decorative imagery contains alternative text. Images that are not informative and do not convey content, or with content that is already conveyed in text are decorative, should be given null alternative text (alt="") or implemented as CSS backgrounds. This commit addresses this issue by setting alt text to empty string.

## Trello card URL

## Changes in this PR:

- Is there anything specific you want feedback on?

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
