### PR TITLE
Change popular search heading from h3 to h2 and update necessary css

### DIFF
--- a/app/assets/stylesheets/layouts/home/_search.scss
+++ b/app/assets/stylesheets/layouts/home/_search.scss
@@ -34,7 +34,7 @@
   .govuk-hint,
   .govuk-link,
   h1,
-  h3 {
+  h2 {
     color: govuk-colour('white');
   }
 
@@ -42,7 +42,7 @@
     display: none;
   }
 
-  h3 {
+  h2 {
     margin-bottom: govuk-spacing(2);
     margin-top: govuk-spacing(2);
   }

--- a/app/views/home/_search.html.slim
+++ b/app/views/home/_search.html.slim
@@ -7,7 +7,7 @@
       = render "vacancies/search/location", f: f, label_text: t(".location_label"), show_hint: false, desktop: true
       = f.govuk_submit t("buttons.search"), class: "govuk-button--start"
 
-  h3.govuk-heading-s = t("jobs.search.popular_searches.title")
+  h2.govuk-heading-s = t("jobs.search.popular_searches.title")
 
   .search__popular
     = search_keyword_quick_link("primary", page: "primary-school-jobs")


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/IRrDeqbY/936-a11y-241-bypass-blocks-heading-structure-incorrect-landing-page

## Changes in this PR:

Change popular search heading from h3 to h2 to correct the heading hierarchy for accessibility purposes and update necessary css

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
