### PR TITLE
Change legend heading from h3 to h2

### DIFF
--- a/app/views/jobseekers/registrations/new.html.slim
+++ b/app/views/jobseekers/registrations/new.html.slim
@@ -12,9 +12,13 @@
 
       p.govuk-body = t(".description")
 
+      - legend_html = capture do
+        legend.govuk-fieldset__legend.govuk-fieldset__legend--m
+          h2.govuk-fieldset__heading = t(".labels.account_type")
+
       = f.govuk_email_field :email, label: { size: "s" }, width: "two-thirds"
       = f.govuk_password_field :password, label: { size: "s" }, width: "two-thirds"
-      = f.govuk_radio_buttons_fieldset(:account_type, legend: { text: t(".labels.account_type"), size: "m" }) do
+      = f.govuk_radio_buttons_fieldset(:account_type, legend: -> { legend_html }) do
         = f.govuk_radio_button :account_type, :teaching, label: { text: t(".labels.teaching") }, hint: { text: t(".hints.teaching") }, link_errors: true
         = f.govuk_radio_button :account_type, :non_teaching, label: { text: t(".labels.non_teaching") }, hint: { text: t(".hints.non_teaching") }
       end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/6g5tNExB/937-a11y-241-bypass-blocks-heading-structure-incorrect-create-js-account

## Changes in this PR:

Change "What type of job are you looking for?" legend in the create jobseeker account page from a h3 to an h2 for accessibility purposes

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
