### PR TITLE
Use h2 rather than h3 for role selection checkbox legends on job preferences page for accessibility reasons

### DIFF
--- a/app/views/jobseekers/profiles/job_preferences/roles.html.slim
+++ b/app/views/jobseekers/profiles/job_preferences/roles.html.slim
@@ -13,8 +13,20 @@
       span.govuk-caption-m class="govuk-!-margin-bottom-8"
         | Select all that apply to set up your profile
 
-      = f.govuk_collection_check_boxes :roles, @step.teaching_job_roles_options, :first, :last, legend: { text: t("jobs.filters.teaching_job_roles"), size: "m" }
-      = f.govuk_collection_check_boxes :roles, @step.teaching_support_job_roles_options, :first, :last, legend: { text: t("jobs.filters.teaching_support_job_roles"), size: "m" }
-      = f.govuk_collection_check_boxes :roles, @step.non_teaching_support_job_roles_options, :first, :last, legend: { text: t("jobs.filters.non_teaching_support_job_roles"), size: "m" }
+      - teaching_legend = capture do
+        legend.govuk-fieldset__legend.govuk-fieldset__legend--m
+          h2.govuk-fieldset__heading = t("jobs.filters.teaching_job_roles")
+
+      - teaching_support_legend = capture do
+        legend.govuk-fieldset__legend.govuk-fieldset__legend--m
+          h2.govuk-fieldset__heading = t("jobs.filters.teaching_support_job_roles")
+
+      - non_teaching_support_legend = capture do
+        legend.govuk-fieldset__legend.govuk-fieldset__legend--m
+          h2.govuk-fieldset__heading = t("jobs.filters.non_teaching_support_job_roles")
+
+      = f.govuk_collection_check_boxes :roles, @step.teaching_job_roles_options, :first, :last, legend: -> { teaching_legend }
+      = f.govuk_collection_check_boxes :roles, @step.teaching_support_job_roles_options, :first, :last, legend: -> { teaching_support_legend }
+      = f.govuk_collection_check_boxes :roles, @step.non_teaching_support_job_roles_options, :first, :last, legend: -> { non_teaching_support_legend }
       = f.govuk_submit "Save and continue"
       p = f.link_to "Cancel", escape_path

--- a/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
@@ -698,9 +698,9 @@ RSpec.describe "Jobseekers can manage their profile" do
       click_link("Add job preferences")
       expect(current_path).to eq(jobseekers_job_preferences_step_path(:roles))
       expect(page).to have_css("h1", text: "What roles are you interested in?")
-      expect(page).to have_css("h3", text: "Teaching")
-      expect(page).to have_css("h3", text: "Teaching support")
-      expect(page).to have_css("h3", text: "Non-teaching support")
+      expect(page).to have_css("h2", text: "Teaching")
+      expect(page).to have_css("h2", text: "Teaching support")
+      expect(page).to have_css("h2", text: "Non-teaching support")
 
       click_on I18n.t("buttons.save_and_continue")
       expect(current_path).to eq(jobseekers_job_preferences_step_path(:roles))
@@ -847,9 +847,9 @@ RSpec.describe "Jobseekers can manage their profile" do
         click_link("Add job preferences")
         expect(current_path).to eq(jobseekers_job_preferences_step_path(:roles))
         expect(page).to have_css("h1", text: "What roles are you interested in?")
-        expect(page).to have_css("h3", text: "Teaching")
-        expect(page).to have_css("h3", text: "Teaching support")
-        expect(page).to have_css("h3", text: "Non-teaching support")
+        expect(page).to have_css("h2", text: "Teaching")
+        expect(page).to have_css("h2", text: "Teaching support")
+        expect(page).to have_css("h2", text: "Non-teaching support")
 
         # TODO: change when we have non-teaching roles
         check "Teacher"


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/NYv1YdgE/938-a11y-241-bypass-blocks-heading-structure-incorrect-roles

## Changes in this PR:

Use h2 rather than h3 for role selection checkbox legends on job preferences page for accessibility reasons

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
