### PR TITLE
a11y: Changes to improve accessibility on the references page

### DIFF
--- a/app/views/jobseekers/job_applications/build/_banner.html.slim
+++ b/app/views/jobseekers/job_applications/build/_banner.html.slim
@@ -2,4 +2,4 @@
   = govuk_back_link text: t("buttons.back"), href: back_path
 
 span.govuk-caption-l = t("jobseekers.job_applications.caption", job_title: vacancy.job_title, organisation: vacancy.organisation_name)
-h2.govuk-heading-xl = t("jobseekers.job_applications.heading")
+h1.govuk-heading-xl = t("jobseekers.job_applications.heading")

--- a/app/views/jobseekers/job_applications/build/references.html.slim
+++ b/app/views/jobseekers/job_applications/build/references.html.slim
@@ -5,7 +5,7 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     = render "caption"
-    h1.govuk-heading-l = t(".heading")
+    h2.govuk-heading-l = t(".heading")
 
     p.govuk-body = t(".description1_html")
     p.govuk-body = t(".description2")

--- a/app/views/jobseekers/job_applications/build/references.html.slim
+++ b/app/views/jobseekers/job_applications/build/references.html.slim
@@ -5,7 +5,7 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     = render "caption"
-    h2.govuk-heading-l = t(".heading")
+    h1.govuk-heading-l = t(".heading")
 
     p.govuk-body = t(".description1_html")
     p.govuk-body = t(".description2")

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -190,7 +190,7 @@ en:
           title: Education and qualifications — Application
         references:
           description1_html: >-
-            <strong>Two referees are required  for this application.</strong> One of these must be your
+            <strong>Two referees are required for this application.</strong> One of these must be your
             current or most recent employer. If you are shortlisted, your referees may be contacted before your interview.
           description2: >-
             If you do not currently work with children, but have done so in the past, you must include a referee from

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -190,7 +190,7 @@ en:
           title: Education and qualifications — Application
         references:
           description1_html: >-
-            <span class='text-red'>Two referees are required</span> for this application. One of these must be your
+            <strong>Two referees are required  for this application.</strong> One of these must be your
             current or most recent employer. If you are shortlisted, your referees may be contacted before your interview.
           description2: >-
             If you do not currently work with children, but have done so in the past, you must include a referee from


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/0cyYB8tG/939-a11y-241-bypass-blocks-heading-structure-incorrect-and-131-info-and-relationships-variations-in-text-convey-information-referenc

## Changes in this PR:

This ticket changes:

- the title of the references page to a h1 (instead of the existing h2)
- emphasises important text on the page by using strong tag rather than red text, and changes some of the emphasised text.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
