### PR TITLE
a11y: create job alert headings

### DIFF
--- a/app/views/subscriptions/_job_roles_fields.slim
+++ b/app/views/subscriptions/_job_roles_fields.slim
@@ -1,13 +1,13 @@
 - teaching_legend = capture do
-  legend.govuk-fieldset__legend.govuk-fieldset__legend--m
+  legend.govuk-fieldset__legend.govuk-fieldset__legend--s
     h2.govuk-fieldset__heading = t("jobs.filters.teaching_job_roles")
 
 - teaching_support_legend = capture do
-  legend.govuk-fieldset__legend.govuk-fieldset__legend--m
+  legend.govuk-fieldset__legend.govuk-fieldset__legend--s
     h2.govuk-fieldset__heading = t("jobs.filters.teaching_support_job_roles")
 
 - non_teaching_support_legend = capture do
-  legend.govuk-fieldset__legend.govuk-fieldset__legend--m
+  legend.govuk-fieldset__legend.govuk-fieldset__legend--s
     h2.govuk-fieldset__heading = t("jobs.filters.non_teaching_support_job_roles")
 
 - teaching_job_roles = capture do

--- a/app/views/subscriptions/_job_roles_fields.slim
+++ b/app/views/subscriptions/_job_roles_fields.slim
@@ -1,9 +1,21 @@
+- teaching_legend = capture do
+  legend.govuk-fieldset__legend.govuk-fieldset__legend--m
+    h2.govuk-fieldset__heading = t("jobs.filters.teaching_job_roles")
+
+- teaching_support_legend = capture do
+  legend.govuk-fieldset__legend.govuk-fieldset__legend--m
+    h2.govuk-fieldset__heading = t("jobs.filters.teaching_support_job_roles")
+
+- non_teaching_support_legend = capture do
+  legend.govuk-fieldset__legend.govuk-fieldset__legend--m
+    h2.govuk-fieldset__heading = t("jobs.filters.non_teaching_support_job_roles")
+
 - teaching_job_roles = capture do
-  = f.govuk_collection_check_boxes(:teaching_job_roles, form.teaching_job_role_options, :first, :last, small: false, legend: { text: t("jobs.filters.teaching_job_roles") }, hint: nil)
+  = f.govuk_collection_check_boxes(:teaching_job_roles, form.teaching_job_role_options, :first, :last, small: false, legend: -> { teaching_legend }, hint: nil)
 - teaching_support_job_roles = capture do
-  = f.govuk_collection_check_boxes(:teaching_support_job_roles, form.teaching_support_job_role_options, :first, :last, small: false, legend: { text: t("jobs.filters.teaching_support_job_roles") }, hint: nil)
+  = f.govuk_collection_check_boxes(:teaching_support_job_roles, form.teaching_support_job_role_options, :first, :last, small: false, legend: -> { teaching_support_legend }, hint: nil)
 - non_teaching_support_job_roles = capture do
-  = f.govuk_collection_check_boxes(:non_teaching_support_job_roles, form.non_teaching_support_job_role_options, :first, :last, small: false, legend: { text: t("jobs.filters.non_teaching_support_job_roles") }, hint: nil)
+  = f.govuk_collection_check_boxes(:non_teaching_support_job_roles, form.non_teaching_support_job_role_options, :first, :last, small: false, legend: -> { non_teaching_support_legend }, hint: nil)
 
 - filters_component.with_group key: "teaching_job_roles", component: teaching_job_roles
 - filters_component.with_group key: "teaching_support_job_roles", component: teaching_support_job_roles


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/AOi3Krfl/941-a11y-241-bypass-blocks-heading-structure-incorrect-create-job-alert

## Changes in this PR:

Prior to this change the headings for the different job types sections (i.e teaching/teaching support/non teaching support) on the create job alerts page had h3 tags, when they should have had h2 tags as found in the accessibility investigation and explained in the ticket. This change corrects the issue.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
