### PR TITLE
a11y: location heading

### DIFF
--- a/app/views/jobseekers/profiles/job_preferences/locations.html.slim
+++ b/app/views/jobseekers/profiles/job_preferences/locations.html.slim
@@ -13,7 +13,7 @@
 
       - another_location_legend = capture do
         legend.govuk-fieldset__legend.govuk-fieldset__legend--m
-          h2.govuk-fieldset__heading = "Do you want to add another location?"
+          h2.govuk-fieldset__heading = t("helpers.legend.jobseekers_profile_location_preferences.another_location")
 
       = govuk_summary_list(classes: "locations-summary-list") do |summary_list|
         = @form.locations.each.with_index do |(id, location), index|

--- a/app/views/jobseekers/profiles/job_preferences/locations.html.slim
+++ b/app/views/jobseekers/profiles/job_preferences/locations.html.slim
@@ -11,6 +11,10 @@
         span.govuk-caption-l Job preferences
         | Locations
 
+      - another_location_legend = capture do
+        legend.govuk-fieldset__legend.govuk-fieldset__legend--m
+          h2.govuk-fieldset__heading = "Do you want to add another location?"
+
       = govuk_summary_list(classes: "locations-summary-list") do |summary_list|
         = @form.locations.each.with_index do |(id, location), index|
           - summary_list.with_row do |row|
@@ -20,7 +24,7 @@
             - row.with_action(text: t("buttons.delete"), href: { action: :delete_location, id: id })
 
       = f.hidden_field :add_location, value: ""
-      = f.govuk_radio_buttons_fieldset(:add_location, legend: { size: "m", text: "Do you want to add another location?" }) do
+      = f.govuk_radio_buttons_fieldset(:add_location, legend: -> { another_location_legend }) do
         = f.govuk_radio_button :add_location, "true", label: { text: "Yes" }
         = f.govuk_radio_button :add_location, "false", label: { text: "No" }
 

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -940,6 +940,8 @@ en:
       jobseekers_unsubscribe_feedback_form:
         reason: Why do you want to unsubscribe from this alert?
         user_participation_response: Would you like to participate in our research?
+      jobseekers_profile_location_preferences: 
+        another_location: Do you want to add another location?
 
       publishers_job_listing_about_the_role_form:
         ect_status: Is this role suitable for an early career teacher (ECT)?

--- a/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
@@ -801,7 +801,7 @@ RSpec.describe "Jobseekers can manage their profile" do
       expect(current_path).to eq(jobseekers_job_preferences_step_path(:locations))
       expect(page).to have_css("h1", text: "Job preferencesLocations")
       expect(page).to have_content("London (1 mile)")
-      expect(page).to have_css("h3", text: "Do you want to add another location?")
+      expect(page).to have_css("h2", text: "Do you want to add another location?")
 
       click_on I18n.t("buttons.save_and_continue")
       expect(page).to have_css("h2", text: "There is a problem")
@@ -818,7 +818,7 @@ RSpec.describe "Jobseekers can manage their profile" do
       expect(page).to have_css("h1", text: "Job preferencesLocations")
       expect(page).to have_content("London (1 mile)")
       expect(page).to have_content("Manchester (10 miles)")
-      expect(page).to have_css("h3", text: "Do you want to add another location?")
+      expect(page).to have_css("h2", text: "Do you want to add another location?")
 
       choose "No"
       click_on I18n.t("buttons.save_and_continue")
@@ -881,7 +881,7 @@ RSpec.describe "Jobseekers can manage their profile" do
         expect(current_path).to eq(jobseekers_job_preferences_step_path(:locations))
         expect(page).to have_css("h1", text: "Job preferencesLocations")
         expect(page).to have_content("Manchester (10 miles)")
-        expect(page).to have_css("h3", text: "Do you want to add another location?")
+        expect(page).to have_css("h2", text: "Do you want to add another location?")
 
         choose "No"
         click_on I18n.t("buttons.save_and_continue")


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/3kTalbwD/943-a11y-241-bypass-blocks-heading-structure-incorrect-location

## Changes in this PR:

Update "Do you want to add another location" from h3 to h2 for accessibility purposes

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
