### PR TITLE
a11y: Make finished_studying a h2 rather than h3 for accessibility purposes

### DIFF
--- a/app/views/jobseekers/qualifications/fields/_degree.html.slim
+++ b/app/views/jobseekers/qualifications/fields/_degree.html.slim
@@ -2,7 +2,11 @@
 
 = f.govuk_text_field :subject, label: { size: "s" }, aria: { required: true }
 
-= f.govuk_radio_buttons_fieldset :finished_studying do
+- finished_studying_legend = capture do
+  legend.govuk-fieldset__legend.govuk-fieldset__legend--m
+    h2.govuk-fieldset__heading = t("helpers.legend.jobseekers_qualifications_shared_legends.finished_studying")
+
+= f.govuk_radio_buttons_fieldset :finished_studying, legend: -> { finished_studying_legend } do
   = f.govuk_radio_button :finished_studying, "true", link_errors: true do
     = f.govuk_text_field :grade, label: { size: "s" }, aria: { required: true }
     = f.govuk_number_field :year, label: { size: "s" }, aria: { required: true }, width: 4

--- a/app/views/jobseekers/qualifications/fields/_degree.html.slim
+++ b/app/views/jobseekers/qualifications/fields/_degree.html.slim
@@ -3,7 +3,7 @@
 = f.govuk_text_field :subject, label: { size: "s" }, aria: { required: true }
 
 - finished_studying_legend = capture do
-  legend.govuk-fieldset__legend.govuk-fieldset__legend--m
+  legend.govuk-fieldset__legend.govuk-fieldset__legend--s
     h2.govuk-fieldset__heading = t("helpers.legend.jobseekers_qualifications_shared_legends.finished_studying")
 
 = f.govuk_radio_buttons_fieldset :finished_studying, legend: -> { finished_studying_legend } do


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/B2ioDwKz/944-a11y-241-bypass-blocks-heading-structure-incorrect-postgrad-degree

## Changes in this PR:

Make the finished_studying legend on the jobseeker profile qualifications page a h2 rather than h3 for accessibility purposes

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
