### PR TITLE
Change Contents heading on "get help hiring" pages to an h2 rather than h3 for accessibility purposes

### DIFF
--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -9,7 +9,7 @@
 .govuk-grid-row.post
   .govuk-grid-column-two-thirds
     h1 = @post.title
-    h3 = t(".contents")
+    h2 = t(".contents")
     ul
       - @post.h2_headings.each do |heading|
         - heading_id = heading.parameterize.sub(/^\d+-/, "") # Removes leading numbers from anchor links so they don't break


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/xhOrIg0h/946-a11y-241-bypass-blocks-heading-structure-incorrect-accept-job-apps

## Changes in this PR:

Change Contents heading on "get help hiring" pages to an h2 rather than h3 for accessibility purposes

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
