### PR TITLE
a11y: Fix Heading levels on Timeline component and job listing org details

### DIFF
--- a/app/components/timeline_component.rb
+++ b/app/components/timeline_component.rb
@@ -4,13 +4,13 @@ class TimelineComponent < ApplicationComponent
   end
 
   renders_one :heading, lambda { |title:|
-    tag.h3(class: "timeline-component__heading govuk-heading-s") { title }
+    tag.h2(class: "timeline-component__heading govuk-heading-s") { title }
   }
 
   renders_many :items, lambda { |key:, value:|
     tag.li(class: "timeline-component__item") do
       safe_join([
-        tag.h4(class: "timeline-component__key govuk-heading-s") { key },
+        tag.h3(class: "timeline-component__key govuk-heading-s") { key },
         tag.p(class: "timeline-component__value govuk-body") { value },
       ])
     end

--- a/app/views/vacancies/listing/_organisation_details.html.slim
+++ b/app/views/vacancies/listing/_organisation_details.html.slim
@@ -16,18 +16,18 @@ section#school-overview
     p.govuk-body = simple_format(vacancy_or_organisation_description(vacancy))
 
   - if vacancy.organisations.many?
-    h4.govuk-heading-m = t(".schools.school_details")
+    h3.govuk-heading-m = t(".schools.school_details")
     = govuk_accordion do |accordion|
       - vacancy.organisations.select(&:school?).each do |organisation|
         - accordion.with_section heading_text: organisation.name do
           = render "vacancies/listing/school", organisation: organisation, vacancy: vacancy, contact_details: false
 
   - if vacancy.school_visits?
-    h4.govuk-heading-m
+    h3.govuk-heading-m
       = t("jobs.arranging_a_visit.heading", organisation: vacancy.organisation_name)
     p.govuk-body = t("jobs.arranging_a_visit.description_html", email: contact_email_link(vacancy, class: "link-wrap"))
   - elsif vacancy.school_visits_details.present?
-    h4.govuk-heading-m
+    h3.govuk-heading-m
       = t("jobs.arranging_a_visit.heading", organisation: vacancy.organisation_name)
     p.govuk-body = vacancy.school_visits_details
 

--- a/spec/components/timeline_component_spec.rb
+++ b/spec/components/timeline_component_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe TimelineComponent, type: :component do
 
       it "renders heading" do
         expect(page).to have_css(".timeline-component") do |timeline|
-          expect(timeline).to have_css("h3", class: "timeline-component__heading", text: "A title")
+          expect(timeline).to have_css("h2", class: "timeline-component__heading", text: "A title")
         end
       end
     end
@@ -22,7 +22,7 @@ RSpec.describe TimelineComponent, type: :component do
     context "when heading slot is not defined" do
       it "does not render heading" do
         expect(page).to have_css(".timeline-component") do |timeline|
-          expect(timeline).not_to have_css("h4", class: "timeline-component__heading")
+          expect(timeline).not_to have_css("h3", class: "timeline-component__heading")
         end
       end
     end
@@ -45,11 +45,11 @@ RSpec.describe TimelineComponent, type: :component do
         end
 
         expect(page.all(".timeline-component__item")[0])
-          .to have_css("h4", text: "Item 1")
+          .to have_css("h3", text: "Item 1")
           .and have_css("p", text: "The first thing")
 
         expect(page.all(".timeline-component__item")[1])
-          .to have_css("h4", text: "Item 2")
+          .to have_css("h3", text: "Item 2")
           .and have_css("p", text: "The second thing")
       end
     end


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/iEzzSBtb

## Changes in this PR:

Fixes inconsistent heading level jumps in 2 places:
- Pages using the the timeline component for a vacancy/application.
- The job listing org details page.
