### PR TITLE
a11y: Combine first name last name into a singular row on profile page

### DIFF
--- a/app/views/jobseekers/profiles/personal_details/_summary.html.slim
+++ b/app/views/jobseekers/profiles/personal_details/_summary.html.slim
@@ -2,16 +2,19 @@ ruby:
   form = Jobseekers::Profile::PersonalDetailsForm.from_record(profile.personal_details)
 
   attributes = {
-                 first_name: nil,
-                 last_name: nil,
                  phone_number_provided: { map_values: ->(value) { value.nil? ? "" : t("helpers.label.personal_details_form.phone_number_provided_options.#{value}") } },
                  phone_number: nil,
                  right_to_work_in_uk: { map_values: ->(value) { value.nil? ? "" : t("jobseekers.profiles.personal_details.work.options.#{value}") } },
                }
 
   summary = govuk_summary_list(html_attributes: { id: "personal_details" }) do |summary_list|
+    summary_list.with_row do |row|
+      row.with_key text: "Name"
+      row.with_value text: "#{form.first_name} #{form.last_name}"
+      row.with_action(text: t("buttons.change"), href: edit_personal_details_jobseekers_profile_path(step: "name"), visually_hidden_text: " name")
+    end
+
     attributes.each do |attribute, options|
-      next if attribute == :last_name
       step_name = form.class.delegated_attributes[attribute.to_s]
       value = form.public_send(attribute)
 
@@ -20,15 +23,9 @@ ruby:
       end
 
       summary_list.with_row do |row|
-        if attribute == :first_name
-          row.with_key text: "Name"
-          row.with_value text: "#{form.first_name} #{form.last_name}"
-          row.with_action(text: t("buttons.change"), href: edit_personal_details_jobseekers_profile_path(step: step_name), visually_hidden_text: " name")
-        else
-          row.with_key text: t(".#{attribute}")
-          row.with_value text: value
-          row.with_action(text: t("buttons.change"), href: edit_personal_details_jobseekers_profile_path(step: step_name), visually_hidden_text: attribute.to_s.humanize)
-        end
+        row.with_key text: t(".#{attribute}")
+        row.with_value text: value
+        row.with_action(text: t("buttons.change"), href: edit_personal_details_jobseekers_profile_path(step: step_name), visually_hidden_text: attribute.to_s.humanize)
       end
     end
 

--- a/app/views/jobseekers/profiles/personal_details/_summary.html.slim
+++ b/app/views/jobseekers/profiles/personal_details/_summary.html.slim
@@ -11,6 +11,7 @@ ruby:
 
   summary = govuk_summary_list(html_attributes: { id: "personal_details" }) do |summary_list|
     attributes.each do |attribute, options|
+      next if attribute == :last_name
       step_name = form.class.delegated_attributes[attribute.to_s]
       value = form.public_send(attribute)
 
@@ -19,9 +20,15 @@ ruby:
       end
 
       summary_list.with_row do |row|
-        row.with_key text: t(".#{attribute}")
-        row.with_value text: value
-        row.with_action(text: t("buttons.change"), href: edit_personal_details_jobseekers_profile_path(step: step_name), visually_hidden_text: attribute.to_s.humanize)
+        if attribute == :first_name
+          row.with_key text: "Name"
+          row.with_value text: "#{form.first_name} #{form.last_name}"
+          row.with_action(text: t("buttons.change"), href: edit_personal_details_jobseekers_profile_path(step: step_name), visually_hidden_text: " name")
+        else
+          row.with_key text: t(".#{attribute}")
+          row.with_value text: value
+          row.with_action(text: t("buttons.change"), href: edit_personal_details_jobseekers_profile_path(step: step_name), visually_hidden_text: attribute.to_s.humanize)
+        end
       end
     end
 

--- a/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
@@ -52,8 +52,7 @@ RSpec.describe "Jobseekers can manage their profile" do
 
         click_on I18n.t("buttons.return_to_profile")
 
-        expect(page).to have_content(first_name)
-        expect(page).to have_content(last_name)
+        expect(page).to have_content("#{first_name} #{last_name}")
         expect(page).to have_content(phone_number)
         expect(page).to have_content("Yes, I will need to apply for a visa giving me the right to work in the UK")
       end
@@ -81,7 +80,7 @@ RSpec.describe "Jobseekers can manage their profile" do
       end
 
       it "allows the jobseeker to edit their profile" do
-        row = page.find(".govuk-summary-list__key", text: "First name").find(:xpath, "..")
+        row = page.find(".govuk-summary-list__key", text: "Name").find(:xpath, "..")
 
         within(row) do
           click_link "Change"
@@ -97,8 +96,7 @@ RSpec.describe "Jobseekers can manage their profile" do
         choose "No"
         click_on I18n.t("buttons.save_and_continue")
 
-        expect(page).to have_content(new_first_name)
-        expect(page).to have_content(new_last_name)
+        expect(page).to have_content("#{new_first_name} #{new_last_name}")
         expect(page).to have_content("Do you want to provide a phone number?No")
         expect(page).not_to have_content(old_phone_number)
         expect(page).to have_content("No, I already have the right to work in the UK")
@@ -132,8 +130,7 @@ RSpec.describe "Jobseekers can manage their profile" do
     end
 
     it "still shows the summary rows for the blank attributes" do
-      expect(page).to have_content("First name")
-      expect(page).to have_content("Last name")
+      expect(page).to have_content("Name")
     end
   end
 


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/jvCZD72y/951-a11y-244-link-purpose-in-context-redundant-links-present-name-in-profiles

## Changes in this PR:

Prior to this change we had accessibility issues stemming from the "Change first name" and "Change last name" links going to the same page. This change addresses the issue by combining both names under a "Name" row so that there is only one link to change name for a user on the jobseeker profile.

Note: I didn't make any changes to the forms/fields in the database as I don't think this is necessary for a purely presentational issue but I am open to other opinions on that!

## Screenshots of UI changes:

### Before
![Screenshot 2024-04-19 at 12 20 20](https://github.com/DFE-Digital/teaching-vacancies/assets/13124899/4c6ce304-85e9-4884-907b-f389a00449b1)

### After
![Screenshot 2024-04-19 at 12 19 46](https://github.com/DFE-Digital/teaching-vacancies/assets/13124899/aacfa1b7-e098-4b07-9468-274b92da3770)

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
