### PR TITLE
a11y: Rearrange footer elements

### DIFF
--- a/app/views/layouts/_footer.html.slim
+++ b/app/views/layouts/_footer.html.slim
@@ -1,50 +1,54 @@
 = govuk_footer(meta_items: footer_links) do |footer|
   - footer.with_navigation
       .govuk-grid-column-one-half
-        span.govuk-footer__heading.govuk-heading-m
-          = t("footer.headings.support")
-        ul.govuk-footer__list
-          li.govuk-footer__list-item
-            = link_to t("footer.request_support"), new_support_request_path, class: "govuk-footer__link"
+        .govuk-grid-row
+          .govuk-grid-column-full
+            span.govuk-footer__heading.govuk-heading-m
+              = t("footer.headings.support")
+            ul.govuk-footer__list
+              li.govuk-footer__list-item
+                = link_to t("footer.request_support"), new_support_request_path, class: "govuk-footer__link"
+        .govuk-grid-row
+          .govuk-grid-column-full
+            span.govuk-footer__heading.govuk-heading-m
+              = t("footer.headings.for_job_seekers")
+            ul.govuk-footer__list
+              li.govuk-footer__list-item
+                = link_to t("footer.search_teaching_vacancies"), root_url, class: "govuk-footer__link"
+              li.govuk-footer__list-item
+                = link_to t("footer.return_to_teaching"), "https://teaching-vacancies.campaign.gov.uk/return-to-teaching/", class: "govuk-footer__link"
+              li.govuk-footer__list-item
+                = tracked_link_to(t("footer.international_teacher_advice_link_text"), "https://getintoteaching.education.gov.uk/non-uk-teachers", class: "govuk-footer__link", link_type: :international_teacher_advice_link_footer)
+              li.govuk-footer__list-item
+                - if jobseeker_signed_in?
+                  = link_to t("nav.create_a_job_alert"), jobseekers_account_path, class: "govuk-footer__link"
+                - else
+                  = link_to t("nav.sign_in"), new_jobseeker_session_path, class: "govuk-footer__link"
+              li.govuk-footer__list-item
+                = link_to t("nav.personal_statement"),
+                          post_path(section: "jobseeker-guides", post_name: "how-to-write-teacher-personal-statement"),
+                          class: "govuk-footer__link"
 
       .govuk-grid-column-one-half
-        span.govuk-footer__heading.govuk-heading-m
-          = t("footer.headings.feedback")
-        ul.govuk-footer__list
-          li.govuk-footer__list-item
-            = footer_feedback_link_text
-
-      .govuk-grid-column-one-half
-        span.govuk-footer__heading.govuk-heading-m
-          = t("footer.headings.for_job_seekers")
-        ul.govuk-footer__list
-          li.govuk-footer__list-item
-            = link_to t("footer.search_teaching_vacancies"), root_url, class: "govuk-footer__link"
-          li.govuk-footer__list-item
-            = link_to t("footer.return_to_teaching"), "https://teaching-vacancies.campaign.gov.uk/return-to-teaching/", class: "govuk-footer__link"
-          li.govuk-footer__list-item
-            = tracked_link_to(t("footer.international_teacher_advice_link_text"), "https://getintoteaching.education.gov.uk/non-uk-teachers", class: "govuk-footer__link", link_type: :international_teacher_advice_link_footer)
-          li.govuk-footer__list-item
-            - if jobseeker_signed_in?
-              = link_to t("nav.create_a_job_alert"), jobseekers_account_path, class: "govuk-footer__link"
-            - else
-              = link_to t("nav.sign_in"), new_jobseeker_session_path, class: "govuk-footer__link"
-          li.govuk-footer__list-item
-            = link_to t("nav.personal_statement"),
-                      post_path(section: "jobseeker-guides", post_name: "how-to-write-teacher-personal-statement"),
-                      class: "govuk-footer__link"
-
-      .govuk-grid-column-one-half
-        span.govuk-footer__heading.govuk-heading-m
-          = t("footer.headings.for_schools")
-        ul.govuk-footer__list
-          - if publisher_signed_in?
-            li.govuk-footer__list-item
-              = button_to(t("footer.list_a_teaching_job"), organisation_jobs_path, class: "govuk-footer__link govuk-body-s")
-            li.govuk-footer__list-item
-              = link_to t("footer.manage_job_listings"), organisation_jobs_with_type_path, class: "govuk-footer__link"
-          - else
-            li.govuk-footer__list-item
-              = link_to t("nav.sign_in"), new_publisher_session_path, class: "govuk-footer__link"
-          li.govuk-footer__list-item
-            = link_to t("footer.hiring_guides"), posts_path(section: "get-help-hiring"), class: "govuk-footer__link"
+        .govuk-grid-row
+          .govuk-grid-column-full
+            span.govuk-footer__heading.govuk-heading-m
+              = t("footer.headings.feedback")
+            ul.govuk-footer__list
+              li.govuk-footer__list-item
+                = footer_feedback_link_text
+        .govuk-grid-row
+          .govuk-grid-column-full
+            span.govuk-footer__heading.govuk-heading-m
+              = t("footer.headings.for_schools")
+            ul.govuk-footer__list
+              - if publisher_signed_in?
+                li.govuk-footer__list-item
+                  = button_to(t("footer.list_a_teaching_job"), organisation_jobs_path, class: "govuk-footer__link govuk-body-s")
+                li.govuk-footer__list-item
+                  = link_to t("footer.manage_job_listings"), organisation_jobs_with_type_path, class: "govuk-footer__link"
+              - else
+                li.govuk-footer__list-item
+                  = link_to t("nav.sign_in"), new_publisher_session_path, class: "govuk-footer__link"
+              li.govuk-footer__list-item
+                = link_to t("footer.hiring_guides"), posts_path(section: "get-help-hiring"), class: "govuk-footer__link"


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/kqmxjTrR

## Changes in this PR:

The accessibility assessment found an issue when navigating tabbing through the footer elements.

The order in which elements are selected on the tabbing was going left to right between sections instead of following the expected visual arrangement from the top to the bottom.

Reorganising the footer sections using govuk grid elements allows us to properly partition the footer elements to keep the same presentation while achieving the tabbing expected behaviour.
