### PR TITLE
a11y: Remove hidden text at start of link

### DIFF
--- a/config/locales/landing_pages.yml
+++ b/config/locales/landing_pages.yml
@@ -6,7 +6,7 @@ en:
     #   helps users relying on screenreaders to make sense of links to landing pages.
     #   Don't edit this unless you know what you are doing!
     accessible_link_text_html: '<span class="govuk-visually-hidden">View all </span>%{name}<span class="govuk-visually-hidden">jobs</span>'
-    accessible_link_text_with_count_html: '<span class="govuk-visually-hidden">View %{count} </span>%{name}<span class="govuk-visually-hidden">jobs</span>'
+    accessible_link_text_with_count_html: '%{name}<span class="govuk-visually-hidden">jobs</span>'
     ##
     # Content for location landing pages
     #   These are dynamic and will exist for any `LocationPolygon` in the database.


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/CNMDpvXI/959-a11y-253-label-in-name-labels-for-user-interface-components-do-not-match-the-visually-displayed-name-home-landing-page

## Changes in this PR:

Prior to this change, we had hidden text stating the number of jobs per link on the homepage, for example "View 2082 teacher jobs" where "View 2082" was visually hidden. The recently completed accessibility report found this to be an issue and advised that we should not have hidden text at the start of a link. This commit fixes this issue by removing the visually hidden text in question.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
