### PR TITLE
a11y: Add skip link to publisher candidate profiles

### DIFF
--- a/app/views/publishers/jobseeker_profiles/index.html.slim
+++ b/app/views/publishers/jobseeker_profiles/index.html.slim
@@ -1,5 +1,8 @@
 - content_for :page_title_prefix, current_organisation.name
 
+- content_for :skip_links do
+  = govuk_skip_link(href: "#search-results", text: t("publishers.jobseeker_profiles.skip_link_list"))
+
 h1 class="govuk-heading-l" role="heading" aria-level="1"
   = t("publishers.jobseeker_profiles.search_result_heading", count: number_with_delimiter(@pagy.count))
 

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -63,6 +63,7 @@ en:
     job_listing_process_changed_draft_banner:
       heading_html: "You cannot make changes to this draft job listing. %{create_new_link} or %{contact_support_link}."
     jobseeker_profiles:
+      skip_link_list: Skip to candidate profiles
       trusts:
         available_to_travel_text:
           single_selected_location: "These candidates are willing to travel to your selected school location."


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/t1rqdwIH
## Changes in this PR:

On the publisher candidate profiles listing, accessibility software users had to tab through 60 elements before reaching the candidate listing results.

Adding a skip link on the heading allows them to quickly jump to the candidate profiles directly, without going through the filter elements.


## Screenshots of UI changes:
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/dbbaa7ae-9c78-4be7-a636-2dbde2394dcd)