### PR TITLE
a11y: Move cookies banner to top of page

### DIFF
--- a/app/views/layouts/_skip_links.html.slim
+++ b/app/views/layouts/_skip_links.html.slim
@@ -1,4 +1,2 @@
-- if show_cookies_banner?
-  = govuk_skip_link(href: "#cookie-consent", text: t("app.skip_link.cookie"))
 = govuk_skip_link(href: "#main-content", text: t("app.skip_link.main"))
 = content_for :skip_links

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -10,6 +10,7 @@ html.govuk-template.app-html-class lang="en"
     = render "layouts/sentry_js_config"
 
   body class=body_class
+    = render "layouts/cookies_banner"
     = render "layouts/google_tag_manager_body" if include_google_tag_manager?
     = render "layouts/add_js_enabled_class_to_body"
     = render "layouts/skip_links"
@@ -29,5 +30,4 @@ html.govuk-template.app-html-class lang="en"
         = yield
       = content_for :after_main
     = render "layouts/footer"
-    = render "layouts/cookies_banner"
     = javascript_include_tag "application", defer: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,7 +17,6 @@ en:
       of <span class='govuk-!-font-weight-bold'>%{total}</span>
       %{type}
     skip_link:
-      cookie: Skip to cookie consent
       main: Skip to main content
     title: Teaching Vacancies
     support_title: Support for Teaching Vacancies

--- a/spec/system/publishers/publishers_can_view_a_job_application_spec.rb
+++ b/spec/system/publishers/publishers_can_view_a_job_application_spec.rb
@@ -66,10 +66,12 @@ RSpec.describe "Publishers can view a job application" do
     it "shows the correct calls to action" do
       visit organisation_job_job_application_path(vacancy.id, job_application)
 
-      expect(page).to have_css(".govuk-button-group") do |actions|
-        expect(actions).not_to have_css("a", class: "govuk-button", text: I18n.t("buttons.shortlist"))
-        expect(actions).not_to have_css("a", class: "govuk-button--warning", text: I18n.t("buttons.reject"))
-        expect(actions).to have_css("a", class: "govuk-button--secondary", text: I18n.t("buttons.download_application"))
+      within("#main-content") do
+        expect(page).to have_css(".govuk-button-group") do |actions|
+          expect(actions).not_to have_css("a", class: "govuk-button", text: I18n.t("buttons.shortlist"))
+          expect(actions).not_to have_css("a", class: "govuk-button--warning", text: I18n.t("buttons.reject"))
+          expect(actions).to have_css("a", class: "govuk-button--secondary", text: I18n.t("buttons.download_application"))
+        end
       end
     end
   end
@@ -80,10 +82,12 @@ RSpec.describe "Publishers can view a job application" do
     it "shows the correct calls to action and timeline" do
       visit organisation_job_job_application_path(vacancy.id, job_application)
 
-      expect(page).to have_css(".govuk-button-group") do |actions|
-        expect(actions).not_to have_css("a", class: "govuk-button", text: I18n.t("buttons.shortlist"))
-        expect(actions).to have_css("a", class: "govuk-button--warning", text: I18n.t("buttons.reject"))
-        expect(actions).to have_css("a", class: "govuk-button--secondary", text: I18n.t("buttons.download_application"))
+      within("#main-content") do
+        expect(page).to have_css(".govuk-button-group") do |actions|
+          expect(actions).not_to have_css("a", class: "govuk-button", text: I18n.t("buttons.shortlist"))
+          expect(actions).to have_css("a", class: "govuk-button--warning", text: I18n.t("buttons.reject"))
+          expect(actions).to have_css("a", class: "govuk-button--secondary", text: I18n.t("buttons.download_application"))
+        end
       end
     end
   end
@@ -94,10 +98,12 @@ RSpec.describe "Publishers can view a job application" do
     it "shows the correct calls to action and timeline" do
       visit organisation_job_job_application_path(vacancy.id, job_application)
 
-      expect(page).to have_css(".govuk-button-group") do |actions|
-        expect(actions).to have_css("a", class: "govuk-button", text: I18n.t("buttons.shortlist"))
-        expect(actions).to have_css("a", class: "govuk-button--warning", text: I18n.t("buttons.reject"))
-        expect(actions).to have_css("a", class: "govuk-button--secondary", text: I18n.t("buttons.download_application"))
+      within("#main-content") do
+        expect(page).to have_css(".govuk-button-group") do |actions|
+          expect(actions).to have_css("a", class: "govuk-button", text: I18n.t("buttons.shortlist"))
+          expect(actions).to have_css("a", class: "govuk-button--warning", text: I18n.t("buttons.reject"))
+          expect(actions).to have_css("a", class: "govuk-button--secondary", text: I18n.t("buttons.download_application"))
+        end
       end
     end
   end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/DdQozyE9/963-a11y-2411-focus-not-obscured-minimum-user-interface-components-are-obscured-when-receiving-keyboard-focus

## Changes in this PR:

During the accessibility audit it was observed that while the cookie banner is in show, the user can still tab to the background content meaning that user interface components are obscured by this banner. It would be expected that, even though the cookie banner is on screen, the user can still see all content on the page when tabbed to. Moving the cookie banner to the top of the page should fix this issue.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
