### PR TITLE
Review apps creation deletion concurrency tweaks

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -21,7 +21,7 @@ on:
       - synchronize
       - reopened
 
-concurrency: workflow-Build-and-deploy-${{ github.ref }}
+concurrency: workflow-Build-and-deploy-${{ github.event.pull_request.number }}
 
 env:
  DOCKER_REPOSITORY: ghcr.io/dfe-digital/teaching-vacancies

--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -18,7 +18,7 @@ on:
         required: false
         type: boolean
 
-concurrency: workflow-Build-and-deploy-${{ github.ref }}
+concurrency: workflow-Build-and-deploy-${{ github.event.pull_request.number }}
 
 env:
   DOCKER_REPOSITORY: ghcr.io/dfe-digital/teaching-vacancies

--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -13,10 +13,6 @@ on:
       pr_number:
         description: 'Pull Request number to delete (EG: 1234 for review-pr-1234)'
         required: true
-      skip_status_check:
-        description: 'Attempt deletion even if the review app status check fails'
-        required: false
-        type: boolean
 
 concurrency: workflow-Build-and-deploy-${{ github.event.pull_request.number }}
 
@@ -62,16 +58,6 @@ jobs:
       with:
         ssm_parameter: /teaching-vacancies/github_action/infra/git_hub_service_account_token
         env_variable_name: GIT_HUB_SERVICE_ACCOUNT_TOKEN
-
-
-    - name: check review status
-      run: |
-        HTTP_CODE=$(curl -o/dev/null -s -w "%{http_code}" https://${{secrets.HTTP_BASIC_USER}}:${{secrets.HTTP_BASIC_PASSWORD}}@teaching-vacancies-review-pr-${{env.PR_NUMBER}}.test.teacherservices.cloud)
-        echo "HTTP_CODE=$HTTP_CODE" >> $GITHUB_ENV
-
-    - name: Exit whole workflow if wait was not successful and review app is not up
-      if: inputs.skip_status_check != true && steps.wait_for_deployment.outputs.conclusion != 'success' && env.HTTP_CODE != '200'
-      run: exit 1
 
     - uses: actions/checkout@v4
       name: Checkout Code


### PR DESCRIPTION
## Changes in this PR:

- [Use PR number as ID for build/delete concurrency](https://github.com/DFE-Digital/teaching-vacancies/commit/d76b4a9d1a7dc226cb5eb25da84c9a8d722746a0)
Using the ref seems a little bit flaky sometimes. Moving to use the PR
number as criteria for ensuring build & deploy cannot run at the same
time.

- [Remove HTTP status check on review app deletion](https://github.com/DFE-Digital/teaching-vacancies/commit/cbf05d6f450c11ba143c1ef1b5919aa52cb48a78) 

This check was originally implemented to avoid review app deletion running in parallel with the review app build, as this is problematic.

This is resolved now by the concurrency value being shared between both workflows. The whole HTTP status check became redundant.