### PR TITLE
Adjust tab contrast colour for footer links and vacancy map

### DIFF
--- a/app/assets/stylesheets/components/map.scss
+++ b/app/assets/stylesheets/components/map.scss
@@ -18,7 +18,7 @@
 
         &__marker {
           &:focus {
-            outline: $govuk-focus-width solid $govuk-focus-colour !important;
+            outline: $govuk-focus-width solid govuk-colour('red') !important;
           }
 
           &--show {

--- a/app/assets/stylesheets/layouts/_footer.scss
+++ b/app/assets/stylesheets/layouts/_footer.scss
@@ -5,7 +5,6 @@
 
   &__navigation {
     .govuk-footer__link {
-      background: 0;
       border: 0;
       margin-bottom: 0;
       padding: 0;


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/YbZ4qgAn/969-a11y-247-focus-visible-visible-tab-focus-indicator

## Changes in this PR:
Adjust tab colour for footer links and vacancy map.

**Note:**
It's interesting to note how the CSS code is already prepared to deal with accessibility requirements and colours, but for some reason, it still was reported during the audit:

`node_modules/govuk-frontend/dist/govuk/settings/_colours-applied.scss`

```
/// Focus colour
///
/// Used for outline (and background, where appropriate) when interactive
/// elements (links, form controls) have keyboard focus.
///
/// @type Colour
/// @access public

$govuk-focus-colour: govuk-colour("yellow") !default;
```


- Is there anything specific you want feedback on?

## Screenshots of UI changes:

### Before
<img width="673" alt="Screenshot 2024-04-24 at 09 42 09" src="https://github.com/DFE-Digital/teaching-vacancies/assets/1470166/c3025afc-d456-4f5c-a1ee-d520c781e921">

<img width="468" alt="Screenshot 2024-04-24 at 09 42 15" src="https://github.com/DFE-Digital/teaching-vacancies/assets/1470166/c76d9b3e-efac-49a1-af11-b71f115fb811">

### After
<img width="711" alt="Screenshot 2024-04-24 at 09 42 29" src="https://github.com/DFE-Digital/teaching-vacancies/assets/1470166/185f6176-4244-49c1-b871-6e2c396007f4">
<img width="799" alt="Screenshot 2024-04-24 at 09 42 41" src="https://github.com/DFE-Digital/teaching-vacancies/assets/1470166/d3b39d2c-2c52-4a3c-9b6d-c1c4f7ed4306">

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
