### PR TITLE
a11y: Give publisher pages unique title

### DIFF
--- a/app/views/publishers/jobseeker_profiles/index.html.slim
+++ b/app/views/publishers/jobseeker_profiles/index.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, current_organisation.name
+- content_for :page_title_prefix, t(".title", organisation_name: current_organisation.name)
 
 - content_for :skip_links do
   = govuk_skip_link(href: "#search-results", text: t("publishers.jobseeker_profiles.skip_link_list"))

--- a/app/views/publishers/organisations/show.html.slim
+++ b/app/views/publishers/organisations/show.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, @organisation.name
+- content_for :page_title_prefix, t(".title", organisation_type: (@organisation.school? ? "School" : "Organisation"))
 
 - if current_organisation.school_group? && @organisation.school?
   - content_for :breadcrumbs do

--- a/app/views/publishers/vacancies/index.html.slim
+++ b/app/views/publishers/vacancies/index.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, current_organisation.name
+- content_for :page_title_prefix, t(".title.#{@selected_type}", organisation_name: current_organisation.name)
 
 - content_for :skip_links do
   = govuk_skip_link(href: "#vacancy-results", text: t(".skip_link", heading: t("jobs.dashboard.#{@selected_type}.tab_heading")))

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -72,6 +72,7 @@ en:
       non_trusts:
         available_to_travel_text: "These candidates are willing to travel to a location that’s near to your school."
       index:
+        title: "Candidate profiles - %{organisation_name}"
         no_results:
           heading: No candidates found
           lead_in: "This may be because:"
@@ -493,6 +494,12 @@ en:
         job_applications: When you create a job listing you can now choose for candidates to apply through Teaching Vacancies.
         job_applications_link_text: Preview the application form
         skip_link: Skip to %{heading}
+        title:
+          published: Active jobs - %{organisation_name}
+          expired: Closed jobs - %{organisation_name}
+          pending: Scheduled jobs - %{organisation_name}
+          draft: Draft jobs - %{organisation_name}
+          awaiting_feedback: Jobs awaiting feedbank - %{organisation_name}
       job_applications:
         header:
           status_heading: Applicant status


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/GR2GgjSf/968-a11y-242-page-titled-page-title-is-not-descriptive

## Changes in this PR:

The recent accessibility report found that the titles for all publisher pages were the same, this obviously causes accessibility issues. This change addresses this problem by giving different pages different titles which gives better context to users.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
