### PR TITLE
a11y: Reorganising html elements for accessibility purposes

### DIFF
--- a/app/views/jobseekers/profiles/_summary.html.slim
+++ b/app/views/jobseekers/profiles/_summary.html.slim
@@ -47,11 +47,11 @@ dl.govuk-summary-list
   - profile.employments.order(:started_on).reverse_each do |employment|
     h3.govuk-heading-s class="govuk-!-padding-bottom-3"
       = employment.organisation
-      p class="govuk-!-margin-bottom-0" = employment.job_title
-      - if employment.subjects.present?
-        p class="govuk-!-margin-bottom-0" = employment.subjects
-      p.govuk-hint #{employment.started_on.to_formatted_s(:month_year)} to #{employment.ended_on&.to_formatted_s(:month_year) || "present"}
-      hr.govuk-section-break.govuk-section-break--s.govuk-section-break--visible
+    p class="govuk-!-margin-bottom-0" = employment.job_title
+    - if employment.subjects.present?
+      p class="govuk-!-margin-bottom-0" = employment.subjects
+    p.govuk-hint #{employment.started_on.to_formatted_s(:month_year)} to #{employment.ended_on&.to_formatted_s(:month_year) || "present"}
+    hr.govuk-section-break.govuk-section-break--s.govuk-section-break--visible
 
 - if profile.qualifications.any?
   h2.govuk-heading-m class="govuk-!-padding-bottom-3" = t(".qualifications")

--- a/app/views/jobseekers/profiles/_summary.html.slim
+++ b/app/views/jobseekers/profiles/_summary.html.slim
@@ -45,13 +45,14 @@ dl.govuk-summary-list
 - if profile.employments.any?
   h2.govuk-heading-m = t(".work_history")
   - profile.employments.order(:started_on).reverse_each do |employment|
-    h3.govuk-heading-s class="govuk-!-padding-bottom-3"
+    h3.govuk-heading-s class="govuk-!-padding-bottom-0 govuk-!-margin-bottom-0"
       = employment.organisation
     p class="govuk-!-margin-bottom-0" = employment.job_title
     - if employment.subjects.present?
       p class="govuk-!-margin-bottom-0" = employment.subjects
     p.govuk-hint #{employment.started_on.to_formatted_s(:month_year)} to #{employment.ended_on&.to_formatted_s(:month_year) || "present"}
-    hr.govuk-section-break.govuk-section-break--s.govuk-section-break--visible
+    - class_name = "govuk-!-margin-bottom-3"
+    hr.govuk-section-break.govuk-section-break--s.govuk-section-break--visible[class=class_name]
 
 - if profile.qualifications.any?
   h2.govuk-heading-m class="govuk-!-padding-bottom-3" = t(".qualifications")

--- a/app/views/jobseekers/qualifications/_preview_qualifications.html.slim
+++ b/app/views/jobseekers/qualifications/_preview_qualifications.html.slim
@@ -1,6 +1,6 @@
 - qualifications_sort_and_group(qualifications).each_value do |qualification_group|
   - qualification_group.each do |qualification|
-    h3.govuk-heading-s class="govuk-!-padding-bottom-0"
+    h3.govuk-heading-s class="govuk-!-padding-bottom-0 govuk-!-margin-bottom-0"
       = qualification.name
     - if qualification.finished_studying?
       p class="govuk-body govuk-!-margin-bottom-0"
@@ -10,8 +10,9 @@
           = qualification.subject.presence || qualification.grade
     - if qualification.secondary?
       - qualification.qualification_results.each do |res|
-        p class="govuk-!-padding-bottom-0" = tag.div("#{res.subject} (#{res.grade})", class: "govuk-body govuk-!-margin-bottom-0")
+        p class="govuk-!-margin-bottom-0" = tag.div("#{res.subject} (#{res.grade})", class: "govuk-body govuk-!-margin-bottom-0")
     - unless qualification.finished_studying.nil?
       p class="govuk-!-margin-top-0" = tag.div(qualification.finished_studying_details.presence, class: "govuk-body")
     p.govuk-hint = qualification.year
-    hr.govuk-section-break.govuk-section-break--s.govuk-section-break--visible
+    - class_name = "govuk-!-margin-bottom-3"
+    hr.govuk-section-break.govuk-section-break--s.govuk-section-break--visible[class=class_name]

--- a/app/views/jobseekers/qualifications/_preview_qualifications.html.slim
+++ b/app/views/jobseekers/qualifications/_preview_qualifications.html.slim
@@ -2,16 +2,16 @@
   - qualification_group.each do |qualification|
     h3.govuk-heading-s class="govuk-!-padding-bottom-0"
       = qualification.name
-      - if qualification.finished_studying?
-        p class="govuk-body govuk-!-margin-bottom-0"
-          - if qualification.subject.present? && qualification.grade.present?
-            = "#{qualification.subject} (#{qualification.grade})"
-          - else
-            = qualification.subject.presence || qualification.grade
-      - if qualification.secondary?
-        - qualification.qualification_results.each do |res|
-          p class="govuk-!-padding-bottom-0" = tag.div("#{res.subject} (#{res.grade})", class: "govuk-body govuk-!-margin-bottom-0")
-      - unless qualification.finished_studying.nil?
-        p class="govuk-!-margin-top-0" = tag.div(qualification.finished_studying_details.presence, class: "govuk-body")
-      p.govuk-hint = qualification.year
-      hr.govuk-section-break.govuk-section-break--s.govuk-section-break--visible
+    - if qualification.finished_studying?
+      p class="govuk-body govuk-!-margin-bottom-0"
+        - if qualification.subject.present? && qualification.grade.present?
+          = "#{qualification.subject} (#{qualification.grade})"
+        - else
+          = qualification.subject.presence || qualification.grade
+    - if qualification.secondary?
+      - qualification.qualification_results.each do |res|
+        p class="govuk-!-padding-bottom-0" = tag.div("#{res.subject} (#{res.grade})", class: "govuk-body govuk-!-margin-bottom-0")
+    - unless qualification.finished_studying.nil?
+      p class="govuk-!-margin-top-0" = tag.div(qualification.finished_studying_details.presence, class: "govuk-body")
+    p.govuk-hint = qualification.year
+    hr.govuk-section-break.govuk-section-break--s.govuk-section-break--visible


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/FNiiPNGK/973-a11y-412-name-role-value-incorrect-announcements-candidate-profile-page-hrs-in-the-heading-elements

## Changes in this PR:

Prior to this change, qualifications and work history entries on jobseeker profiles had all the details nested within an h2 tag which caused issues for users which need to use screen readers. This change reorganises these elements in a more accessible way.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
