### PR TITLE
a11y: Visual changes to jobseeker profile layout as viewed by publisher

### DIFF
--- a/app/views/publishers/jobseeker_profiles/_layout.html.slim
+++ b/app/views/publishers/jobseeker_profiles/_layout.html.slim
@@ -4,7 +4,7 @@
   = govuk_back_link text: t("buttons.back"), href: publishers_jobseeker_profiles_path, html_attributes: { "aria-label" => "Back navigation", role: "navigation" }
 
 .govuk-grid-row
-  .govuk-grid-column-two-thirds
+  .govuk-grid-column-full
     h1.govuk-heading-xl class="govuk-!-margin-bottom-4" = profile.full_name
     .govuk-button-group data-controller="clipboard" data-clipboard-success-content-value="email address copied"
       = tracked_mail_to(profile.email,
@@ -21,4 +21,6 @@
             data-clipboard-target="button"
             class="js-action govuk-button govuk-button--secondary govuk-!-margin-bottom-2 clipboard-copy"]
         | Copy email
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
     = yield


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/V89fYh6H/962-a11y-144-resize-text-rendering-issue-observed-zooming-text-only

## Changes in this PR:

In the recent accessibility report it was flagged that when zooming in on the publishers jobseeker profile page the user loses some of the context of the buttons. This change aims to rectify this issue by putting the buttons in a full width column.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
