### PR TITLE
Remove unnecessary hidden span

### DIFF
--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -428,7 +428,7 @@ en:
         name: Name
         organisation: Organisation
         relationship: Relationship to applicant
-        phone_number_html: Phone number (optional<span class='govuk-visually-hidden'> field</span>)</span>
+        phone_number_html: Phone number (optional)
       jobseekers_job_application_equal_opportunities_form:
         age_options:
           under_twenty_five: Under 25


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/acwtftKC/974-a11y-412-name-role-value-incorrect-announcements-we-have-some-hidden-text-on-the-phone-label-that-is-read-out-to-screen-readers

## Changes in this PR:
I believe there was a bug in this line of code, and the markup was plain wrong. This fixes the issue.
