### PR TITLE
Ensure tests always run on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches:
       - '**'
-    paths-ignore:
-    - 'bigquery/**'
-    - 'documentation/**'
-    - 'terraform/common/**'
-    - '**.md'
 
 jobs:
   backend-tests:


### PR DESCRIPTION
All the test jobs are "required" in Github in order to allow merging the PR.

If a documentation change doesn't cause the tests to run, the required test checks are marked as expected/pending and the PR is unmergeable unless a repo admin overrides the missing checks.

The problem now is that, if we allow admins to override the check requirements to push into the main branch, this also allows admins to mistakenly push code directly into the main branch from their machines (been there, done that).

Given the pros & cons. It is way simpler to always run the tests/checks on github, regardless of code changes or not, and ensure the PRs are clean for a merge without having to change settings or override requirements.

Example:
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/53b50ae5-b06d-4dca-90bc-5a157e518dda)
