### PR TITLE
Fix failing test due to date change

### DIFF
--- a/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
@@ -927,7 +927,7 @@ RSpec.describe "Jobseekers can manage their profile" do
     fill_in "jobseekers_profile_employment_form[started_on(2i)]", with: "09"
     choose "No", name: "jobseekers_profile_employment_form[current_role]"
     fill_in "jobseekers_profile_employment_form[ended_on(1i)]", with: (Date.today - 1.year).year
-    fill_in "jobseekers_profile_employment_form[ended_on(2i)]", with: Date.today.month
+    fill_in "jobseekers_profile_employment_form[ended_on(2i)]", with: 1.month.ago.month
     fill_in I18n.t("helpers.label.jobseekers_profile_employment_form.main_duties"), with: "Goals and that"
     fill_in I18n.t("helpers.label.jobseekers_profile_employment_form.reason_for_leaving"), with: "I hate it there"
 


### PR DESCRIPTION
With the change of date, a Rails date helper used during the system tests stopped returning the expected wording value.

To ensure we get the "about 1 year" in the wording. The date difference must be (according to the helper docs): "1 yr <-> 1 yr, 3 months"

Setting the time gap between jobs as 1yr + 1 month, we ensure that the date falls well within the range, instead of being on the edge between two different wording outputs.

## Failing runs with the date change & this branch fixing it
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/c4037fde-5f0d-40c6-b172-c9a494ae035f)

