### PR TITLE
Remove content block from posts

### DIFF
--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -10,12 +10,7 @@
 .govuk-grid-row.post
   .govuk-grid-column-two-thirds
     h1 = @post.title
-    h2 = t(".contents")
-    ul
-      - @post.h2_headings.each do |heading|
-        - heading_id = heading.parameterize.sub(/^\d+-/, "") # Removes leading numbers from anchor links so they don't break
-        li = link_to(heading, "##{heading_id}")
-    hr.govuk-section-break.govuk-section-break--xl.govuk-section-break--visible
+
     == @post.content
 
     - if @post.date_posted


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/pP1T9EsI/992-remove-contents-block-from-hiring-and-jobseeker-guides

## Changes in this PR:

Prior to this change we had a contents block at the start of all our hiring and jobseeker guides, but the team have decided to remove the contents block to allow users to do less scrolling to access the important information and hopefully improve bounce rates on these pages

## Screenshots of UI changes:

### Before

![Screenshot 2024-05-07 at 15 13 22](https://github.com/DFE-Digital/teaching-vacancies/assets/13124899/fbaa9ed0-03ca-4228-ab2e-33a3efb54c4c)

### After

![Screenshot 2024-05-07 at 15 13 30](https://github.com/DFE-Digital/teaching-vacancies/assets/13124899/e2b7fa73-3422-460f-8f7a-9a4c85806719)

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
