### PR TITLE
Replace deprecated Github action for AWS secrets

### DIFF
--- a/.github/workflows/backup_production_db.yml
+++ b/.github/workflows/backup_production_db.yml
@@ -35,11 +35,10 @@ jobs:
         role-duration-seconds: 3600
         role-skip-session-tagging: true
 
-    - name: Get SLACK_WEBHOOK From ParameterStore
-      uses: marvinpinto/action-inject-ssm-secrets@latest
+    - name: Get secrets from AWS ParameterStore
+      uses: dkershner6/aws-ssm-getparameters-action@v2
       with:
-        ssm_parameter: /teaching-vacancies/github_action/infra/slack_webhook
-        env_variable_name: SLACK_WEBHOOK
+        parameterPairs: "/teaching-vacancies/github_action/infra/slack_webhook = SLACK_WEBHOOK"
 
     - name: Install postgres client
       uses: DFE-Digital/github-actions/install-postgres-client@master

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -53,23 +53,12 @@ jobs:
           role-duration-seconds: 3600
           role-skip-session-tagging: true
 
-      - name: Get GIT_HUB_SERVICE_ACCOUNT_TOKEN From ParameterStore
-        uses: marvinpinto/action-inject-ssm-secrets@latest
+      - name: Get secrets from AWS ParameterStore
+        uses: dkershner6/aws-ssm-getparameters-action@v2
         with:
-          ssm_parameter: /teaching-vacancies/github_action/infra/git_hub_service_account_token
-          env_variable_name: GIT_HUB_SERVICE_ACCOUNT_TOKEN
-
-      - name: Get SLACK_WEBHOOK From ParameterStore
-        uses: marvinpinto/action-inject-ssm-secrets@latest
-        with:
-          ssm_parameter: /teaching-vacancies/github_action/infra/slack_webhook
-          env_variable_name: SLACK_WEBHOOK
-
-      - name: Get SNYK_TOKEN From ParameterStore
-        uses: marvinpinto/action-inject-ssm-secrets@latest
-        with:
-          ssm_parameter: /teaching-vacancies/github_action/infra/snyk
-          env_variable_name: SNYK_TOKEN
+          parameterPairs: "/teaching-vacancies/github_action/infra/slack_webhook = SLACK_WEBHOOK,
+            /teaching-vacancies/github_action/infra/git_hub_service_account_token = GIT_HUB_SERVICE_ACCOUNT_TOKEN,
+            /teaching-vacancies/github_action/infra/snyk = SNYK_TOKEN"
 
       - name: Set environment variables (Push)
         if: github.event_name == 'push'
@@ -200,17 +189,11 @@ jobs:
         role-duration-seconds: 3600
         role-skip-session-tagging: true
 
-    - name: Get SLACK_WEBHOOK From ParameterStore
-      uses: marvinpinto/action-inject-ssm-secrets@latest
+    - name: Get secrets from AWS ParameterStore
+      uses: dkershner6/aws-ssm-getparameters-action@v2
       with:
-        ssm_parameter: /teaching-vacancies/github_action/infra/slack_webhook
-        env_variable_name: SLACK_WEBHOOK
-
-    - name: Get GIT_HUB_SERVICE_ACCOUNT_TOKEN From ParameterStore
-      uses: marvinpinto/action-inject-ssm-secrets@latest
-      with:
-        ssm_parameter: /teaching-vacancies/github_action/infra/git_hub_service_account_token
-        env_variable_name: GIT_HUB_SERVICE_ACCOUNT_TOKEN
+        parameterPairs: "/teaching-vacancies/github_action/infra/slack_webhook = SLACK_WEBHOOK,
+          /teaching-vacancies/github_action/infra/git_hub_service_account_token = GIT_HUB_SERVICE_ACCOUNT_TOKEN"
 
     - name: Set environment variables from build output
       run: |
@@ -313,11 +296,10 @@ jobs:
           role-duration-seconds: 3600
           role-skip-session-tagging: true
 
-      - name: Get SLACK_WEBHOOK From ParameterStore
-        uses: marvinpinto/action-inject-ssm-secrets@latest
+      - name: Get secrets from AWS ParameterStore
+        uses: dkershner6/aws-ssm-getparameters-action@v2
         with:
-          ssm_parameter: /teaching-vacancies/github_action/infra/slack_webhook
-          env_variable_name: SLACK_WEBHOOK
+          parameterPairs: "/teaching-vacancies/github_action/infra/slack_webhook = SLACK_WEBHOOK"
 
       - name: Download and extract Gov.UK frontend archive
         run: bin/regenerate-offline

--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -47,17 +47,11 @@ jobs:
         role-duration-seconds: 3600
         role-skip-session-tagging: true
 
-    - name: Get SLACK_WEBHOOK From ParameterStore
-      uses: marvinpinto/action-inject-ssm-secrets@latest
+    - name: Get secrets from AWS ParameterStore
+      uses: dkershner6/aws-ssm-getparameters-action@v2
       with:
-        ssm_parameter: /teaching-vacancies/github_action/infra/slack_webhook
-        env_variable_name: SLACK_WEBHOOK
-
-    - name: Get GIT_HUB_SERVICE_ACCOUNT_TOKEN From ParameterStore
-      uses: marvinpinto/action-inject-ssm-secrets@latest
-      with:
-        ssm_parameter: /teaching-vacancies/github_action/infra/git_hub_service_account_token
-        env_variable_name: GIT_HUB_SERVICE_ACCOUNT_TOKEN
+        parameterPairs: "/teaching-vacancies/github_action/infra/slack_webhook = SLACK_WEBHOOK,
+          /teaching-vacancies/github_action/infra/git_hub_service_account_token = GIT_HUB_SERVICE_ACCOUNT_TOKEN"
 
     - uses: actions/checkout@v4
       name: Checkout Code

--- a/.github/workflows/rebuild_docker_cache.yml
+++ b/.github/workflows/rebuild_docker_cache.yml
@@ -31,17 +31,11 @@ jobs:
           role-duration-seconds: 3600
           role-skip-session-tagging: true
 
-      - name: Get SLACK_WEBHOOK From ParameterStore
-        uses: marvinpinto/action-inject-ssm-secrets@latest
+      - name: Get secrets from AWS ParameterStore
+        uses: dkershner6/aws-ssm-getparameters-action@v2
         with:
-          ssm_parameter: /teaching-vacancies/github_action/infra/slack_webhook
-          env_variable_name: SLACK_WEBHOOK
-
-      - name: Get SNYK_TOKEN From ParameterStore
-        uses: marvinpinto/action-inject-ssm-secrets@latest
-        with:
-          ssm_parameter: /teaching-vacancies/github_action/infra/snyk
-          env_variable_name: SNYK_TOKEN
+          parameterPairs: "/teaching-vacancies/github_action/infra/slack_webhook = SLACK_WEBHOOK,
+            /teaching-vacancies/github_action/infra/snyk = SNYK_TOKEN"
 
       - name: Set environment variables
         run: |


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/zPQqJAII

## Changes in this PR:

Teaching Vacancies uses an [archived project Github action](https://github.com/marvinpinto/action-inject-ssm-secrets) to retrieve secrets from AWS parameter store for our Github workflows.

Since it is unmaintained and triggers multiple warnings regarding deprecations.

We are replacing it with a newer active action: https://github.com/dkershner6/aws-ssm-getparameters-action
