### PR TITLE
Add GetParameters permission to Deployments role

### DIFF
--- a/terraform/common/iam.tf
+++ b/terraform/common/iam.tf
@@ -46,7 +46,7 @@ data "aws_iam_policy_document" "deployments_role_policy" {
   # SSM
   statement {
     sid       = "ReadSSMParameters"
-    actions   = ["ssm:GetParameter", "ssm:GetParametersByPath"]
+    actions   = ["ssm:GetParameter", "ssm:GetParameters", "ssm:GetParametersByPath"]
     resources = ["*"]
   }
 


### PR DESCRIPTION
## Trello card URL
- Part of: https://trello.com/c/zPQqJAII/995-replace-abandoned-github-action-for-reading-aws-secrets

## Changes in this PR:
We are going to start using Github Actions that need the `ssm:GetParameters` permission during the Deployment workflows.

Note: This has already been applied to infra through Terraform console commands and tested with a Review App deployment.