### PR TITLE
Replace editor bullet point button with hint text

### DIFF
--- a/app/components/editor_component/editor_component.html.slim
+++ b/app/components/editor_component/editor_component.html.slim
@@ -2,12 +2,9 @@
   .editor-component__controls
     label class="#{label_classes}" data-action="click->editor#focus" for="#{@field_name}-field" id=@label[:id]
       = @label[:text]
-    - if @hint.present?
-      .govuk-hint id="#{@field_name}-hint"
-        = @hint
+    .govuk-hint id="#{@field_name}-hint"
+      = @hint.presence || "You can copy and paste any information and keep bullet point formatting."
     .editor-component__toolbar data-editor-target="toolbar"
-      button.icon.icon--richtext-ul.govuk-button.govuk-button--secondary.editor-component__toolbar-button type="button" data-action="editor#performAction" data-editor-action="ul" aria-controls="editor-content-#{@field_name}"
-        = "Toggle bullet points"
 
   .editor-component__form-input data-editor-target="formInput"
     .editor-component__content-container

--- a/spec/components/editor_component_spec.rb
+++ b/spec/components/editor_component_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe EditorComponent, type: :component do
     subject! do
       render_inline(described_class.new(**kwargs))
     end
-    it "renders no hint text" do
-      expect(page).not_to have_css("div", class: "govuk-hint")
+    it "renders a default hint text" do
+      expect(page).to have_css("div", class: "govuk-hint", text: "You can copy and paste any information and keep bullet point formatting.")
     end
   end
 end


### PR DESCRIPTION


## Trello card URL
- https://trello.com/c/WsMIQ6N8

## Changes in this PR:

The text editor "toggle bullet point" button was highlighted as an accessibility issue in our recent accessibility assessment.

The team decided it was not worth keeping it and we can display a hint text instead.

## Screenshots of UI changes:

### Before
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/ff62417d-a8b7-42a3-894b-b41d272e9f8a)

### After
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/50f7abfd-ea0c-4874-9cf9-8e10daee0450)

