### PR TITLE
Upgrade Alpine Glib vulnerable version on Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
  # Alpine v3.19.
  # TODO: Regularly check in the alpine ruby "3.3.1-alpine3.19" images for its latest upgraded packages so we can remove
  # the hardcoded versions below when they have been updated in the alpine ruby image.
-ARG PROD_PACKAGES="imagemagick libpng libjpeg libxml2 libxslt libpq tzdata shared-mime-info postgresql15 gnutls=3.8.4-r0"
+ARG PROD_PACKAGES="imagemagick libpng libjpeg libxml2 libxslt libpq tzdata shared-mime-info postgresql15 gnutls=3.8.4-r0 glib=2.78.5-r0"
 
 FROM ruby:3.3.1-alpine3.19 AS builder
 


### PR DESCRIPTION
Vulnerability is blocking the deployment due to security risk.
