### PR TITLE
Refactor: Improvements on "lib" folder

### DIFF
--- a/app/controllers/publishers/vacancies/base_controller.rb
+++ b/app/controllers/publishers/vacancies/base_controller.rb
@@ -1,4 +1,4 @@
-require "indexing"
+require "google_indexing"
 
 class Publishers::Vacancies::BaseController < Publishers::BaseController
   include Publishers::Wizardable

--- a/app/jobs/remove_google_index_queue_job.rb
+++ b/app/jobs/remove_google_index_queue_job.rb
@@ -1,9 +1,9 @@
-require "indexing"
+require "google_indexing"
 class RemoveGoogleIndexQueueJob < ApplicationJob
   queue_as :default
 
   def perform(url)
-    Indexing.new(url).remove
+    GoogleIndexing.new(url).remove
   rescue SystemExit => e
     Rails.logger.info("Sidekiq: Aborting Google remove index. Error: #{e.message}")
   rescue StandardError => e

--- a/app/jobs/remove_invalid_subscriptions_job.rb
+++ b/app/jobs/remove_invalid_subscriptions_job.rb
@@ -1,11 +1,9 @@
-require "remove_invalid_subscriptions"
-
 class RemoveInvalidSubscriptionsJob < ApplicationJob
   queue_as :low
 
   def perform
     return if DisableExpensiveJobs.enabled?
 
-    RemoveInvalidSubscriptions.new.run!
+    Jobseekers::RemoveInvalidSubscriptions.new.call
   end
 end

--- a/app/jobs/update_google_index_queue_job.rb
+++ b/app/jobs/update_google_index_queue_job.rb
@@ -1,9 +1,9 @@
-require "indexing"
+require "google_indexing"
 class UpdateGoogleIndexQueueJob < ApplicationJob
   queue_as :default
 
   def perform(url)
-    Indexing.new(url).update
+    GoogleIndexing.new(url).update
   rescue SystemExit => e
     Rails.logger.info("Sidekiq: Aborting Google update index. Error: #{e.message}")
   rescue StandardError => e

--- a/app/services/jobseekers/remove_invalid_subscriptions.rb
+++ b/app/services/jobseekers/remove_invalid_subscriptions.rb
@@ -1,9 +1,9 @@
 require "notifications/client"
 
-class RemoveInvalidSubscriptions
+class Jobseekers::RemoveInvalidSubscriptions
   # The GOV.UK Notify API retrieves a maximum of 250 messages that are 7 days old or newer
 
-  def run!
+  def call
     permanent_failures.each do |failed_message|
       Subscription.where(email: failed_message.email_address).destroy_all
     end

--- a/lib/google_indexing.rb
+++ b/lib/google_indexing.rb
@@ -1,6 +1,6 @@
 require "google/apis/indexing_v3"
 
-class Indexing
+class GoogleIndexing
   ACTIONS = { update: "URL_UPDATED",
               remove: "URL_DELETED" }.freeze
 

--- a/spec/jobs/remove_google_index_queue_job_spec.rb
+++ b/spec/jobs/remove_google_index_queue_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RemoveGoogleIndexQueueJob do
 
   it "executes perform" do
     indexing_service = double(:mock)
-    expect(Indexing).to receive(:new).with(url).and_return(indexing_service)
+    expect(GoogleIndexing).to receive(:new).with(url).and_return(indexing_service)
     expect(indexing_service).to receive(:remove)
 
     perform_enqueued_jobs { job }
@@ -15,7 +15,7 @@ RSpec.describe RemoveGoogleIndexQueueJob do
   it "aborts execution when no Google credentials are set" do
     stub_const("GOOGLE_API_JSON_KEY", "")
     Sidekiq::Testing.inline! do
-      expect(Indexing).to receive(:new).and_raise(SystemExit, "No Google API")
+      expect(GoogleIndexing).to receive(:new).and_raise(SystemExit, "No Google API")
 
       described_class.perform_now(url)
     end

--- a/spec/jobs/remove_invalid_subscriptions_job_spec.rb
+++ b/spec/jobs/remove_invalid_subscriptions_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe RemoveInvalidSubscriptionsJob do
     let(:disable_expensive_jobs_enabled?) { false }
 
     it "executes perform" do
-      expect(RemoveInvalidSubscriptions).to receive_message_chain(:new, :run!)
+      expect(Jobseekers::RemoveInvalidSubscriptions).to receive_message_chain(:new, :call)
       perform_enqueued_jobs { job }
     end
   end
@@ -18,7 +18,7 @@ RSpec.describe RemoveInvalidSubscriptionsJob do
     let(:disable_expensive_jobs_enabled?) { true }
 
     it "does not perform the job" do
-      expect(RemoveInvalidSubscriptions).not_to receive(:new)
+      expect(Jobseekers::RemoveInvalidSubscriptions).not_to receive(:new)
 
       perform_enqueued_jobs { job }
     end

--- a/spec/jobs/update_google_index_queue_job_spec.rb
+++ b/spec/jobs/update_google_index_queue_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe UpdateGoogleIndexQueueJob do
 
   it "executes perform" do
     indexing_service = double(:mock)
-    expect(Indexing).to receive(:new).with(url).and_return(indexing_service)
+    expect(GoogleIndexing).to receive(:new).with(url).and_return(indexing_service)
     expect(indexing_service).to receive(:update)
 
     perform_enqueued_jobs { job }
@@ -15,7 +15,7 @@ RSpec.describe UpdateGoogleIndexQueueJob do
   it "aborts execution when no Google credentials are set" do
     stub_const("GOOGLE_API_JSON_KEY", "")
     Sidekiq::Testing.inline! do
-      expect(Indexing).to receive(:new).and_raise(SystemExit, "No Google API")
+      expect(GoogleIndexing).to receive(:new).and_raise(SystemExit, "No Google API")
 
       described_class.perform_now(url)
     end

--- a/spec/lib/google_indexing_spec.rb
+++ b/spec/lib/google_indexing_spec.rb
@@ -1,11 +1,11 @@
 require "rails_helper"
-require "indexing"
+require "google_indexing"
 
-RSpec.describe Indexing do
+RSpec.describe GoogleIndexing do
   let(:url) { "https://google.com" }
   let(:mock_request) { double(:mock_request) }
   let(:google_service) { double(:google_service) }
-  let(:service) { Indexing.new(url) }
+  let(:service) { GoogleIndexing.new(url) }
 
   context "Successful requests" do
     before(:each) do
@@ -18,7 +18,7 @@ RSpec.describe Indexing do
           .to receive(:new).and_return(google_service)
         expect(Google::Apis::IndexingV3::UrlNotification)
           .to receive(:new)
-          .with(url: url, type: Indexing::ACTIONS[:update])
+          .with(url: url, type: GoogleIndexing::ACTIONS[:update])
           .and_return(mock_request)
         expect(google_service).to receive(:publish_url_notification).with(mock_request)
 
@@ -32,7 +32,7 @@ RSpec.describe Indexing do
           .to receive(:new).and_return(google_service)
         expect(Google::Apis::IndexingV3::UrlNotification)
           .to receive(:new)
-          .with(url: url, type: Indexing::ACTIONS[:remove])
+          .with(url: url, type: GoogleIndexing::ACTIONS[:remove])
           .and_return(mock_request)
         expect(google_service).to receive(:publish_url_notification).with(mock_request)
 
@@ -44,8 +44,8 @@ RSpec.describe Indexing do
   context "When no GOOGLE_API key is set" do
     it "logs an error and aborts execution" do
       stub_const("GOOGLE_API_JSON_KEY", "")
-      expect(Indexing::API::IndexingService).not_to receive(:new)
-      Indexing.new(url)
+      expect(GoogleIndexing::API::IndexingService).not_to receive(:new)
+      GoogleIndexing.new(url)
     end
   end
 end

--- a/spec/services/jobseekers/remove_invalid_subscriptions_spec.rb
+++ b/spec/services/jobseekers/remove_invalid_subscriptions_spec.rb
@@ -1,10 +1,9 @@
 require "rails_helper"
-require "remove_invalid_subscriptions"
 
-RSpec.describe RemoveInvalidSubscriptions do
+RSpec.describe Jobseekers::RemoveInvalidSubscriptions do
   subject { described_class.new }
 
-  describe "#run!" do
+  describe "#call" do
     let(:notify_api_response) do
       [double("response", status: "permanent-failure", email_address: "first@failed.com"),
        double("response", status: "permanent-failure", email_address: "second@failed.com"),
@@ -27,7 +26,7 @@ RSpec.describe RemoveInvalidSubscriptions do
     end
 
     it "destroys subscriptions with permanently failed email addresses" do
-      expect { subject.run! }.to change { Subscription.count }.from(3).to(1)
+      expect { subject.call }.to change { Subscription.count }.from(3).to(1)
     end
   end
 end


### PR DESCRIPTION
## Trello card URL

## Changes in this PR:

- Rename 'Indexing' lib to 'GoogleIndexing'

Found 'Indexing' to be too generic and prone to confusion (Google indexing? DB indexing? vacancies indexing?)

By being explicit in the name, the calls on it become clearer about their intention.

- [Move RemoveInvalidSubscriptions: lib to service](https://github.com/DFE-Digital/teaching-vacancies/pull/6848/commits/5c89c5fb7bc5b792693360756e74d7191b256ce5) 

The RemoveInvalidSubscriptions code is domain-dependent on our jobseeker subscriptions. Library code should be domain/independent (eg: could be extracted into a gem).

We are moving it from the library folder into the app/services one, turning it into a service object namespaced under the jobseekers domain.

