### PR TITLE
Rake task to change "other_teaching_support" job roles to "other_support" job roles

### DIFF
--- a/lib/tasks/update_vacancies_with_other_teaching_support_role.rake
+++ b/lib/tasks/update_vacancies_with_other_teaching_support_role.rake
@@ -1,0 +1,15 @@
+namespace :vacancy do
+  desc "Update job roles from 'other_teaching_support' (10) to 'other_support' (16)"
+  task update_job_roles: :environment do
+    vacancies = Vacancy.where("job_roles @> ARRAY[?]::integer[]", [10])
+    updated_count = 0
+
+    vacancies.find_each do |vacancy|
+      new_roles = vacancy.job_roles.map { |role| role == "other_teaching_support" ? "other_support" : role }.uniq
+      vacancy.update(job_roles: new_roles)
+      updated_count += 1
+    end
+
+    puts "#{updated_count} vacancies updated."
+  end
+end


### PR DESCRIPTION
## Trello card URL

Part of this ticket: https://trello.com/c/SWQWOjLs/977-update-job-role-categories-to-be-teaching-leadership-then-support-merge-teaching-support-and-non-teaching-support

## Changes in this PR:

Add rake task to change "other_teaching_support" job roles to "other_support" job roles. There are currently 4 vacancies that will be changed.

We will be removing "other_teaching_support" as a potential job role in the future, this change is to update our existing vacancies before this role removal happens.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
