### PR TITLE
tweaking hint text on hiring staff side

### DIFF
--- a/app/components/editor_component/editor_component.html.slim
+++ b/app/components/editor_component/editor_component.html.slim
@@ -3,7 +3,7 @@
     label class="#{label_classes}" data-action="click->editor#focus" for="#{@field_name}-field" id=@label[:id]
       = @label[:text]
     .govuk-hint id="#{@field_name}-hint"
-      = @hint.presence || "You can copy and paste any information and keep bullet point formatting."
+      = @hint.presence || "You can copy and paste bullet points into the text box."
     .editor-component__toolbar data-editor-target="toolbar"
 
   .editor-component__form-input data-editor-target="formInput"

--- a/app/views/jobseekers/job_applications/build/personal_statement.html.slim
+++ b/app/views/jobseekers/job_applications/build/personal_statement.html.slim
@@ -31,7 +31,7 @@
     = form_for form, url: wizard_path, method: :patch do |f|
       = f.govuk_error_summary
 
-      = f.govuk_text_area :personal_statement, label: { size: "s" }, rows: 15, required: true, aria: { required: true }
+      = f.govuk_text_area :personal_statement, label: { size: "s" }, rows: 15, required: true, aria: { required: true }, hint: { text: t(".hint") }
 
       = f.govuk_submit job_application_build_submit_button_text do
         = govuk_link_to t("buttons.cancel_and_return_to_account"), jobseekers_job_applications_path, class: "govuk-link--no-visited-state"

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -178,6 +178,7 @@ en:
             title: How to write a teacher personal statement
           step_title: Personal statement
           title: Personal statement — Application
+          hint: You can copy and paste bullet points into the text box.
         process_title: Application steps
         professional_status:
           heading: Professional status

--- a/spec/components/editor_component_spec.rb
+++ b/spec/components/editor_component_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe EditorComponent, type: :component do
       render_inline(described_class.new(**kwargs))
     end
     it "renders a default hint text" do
-      expect(page).to have_css("div", class: "govuk-hint", text: "You can copy and paste any information and keep bullet point formatting.")
+      expect(page).to have_css("div", class: "govuk-hint", text: "You can copy and paste bullet points into the text box.")
     end
   end
 end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/ryMGzBzp/994-adding-hint-text-to-textareas-with-formatting-on-hiring-staff-and-jobseeker-journeys

## Changes in this PR:

- tweaking hint text about bullet point formatting on hiring staff job description side
- adding hint text about bullet point formatting on jobseeker personal statement side

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
