### PR TITLE
Skip MyNewTerm non-valid central trust jobs

### DIFF
--- a/app/services/vacancies/import/shared.rb
+++ b/app/services/vacancies/import/shared.rb
@@ -5,5 +5,12 @@ module Vacancies::Import
 
       (schools.map(&:detailed_school_type) & School::EXCLUDED_DETAILED_SCHOOL_TYPES).present?
     end
+
+    # Our system only imports MAT type trusts from GIAS DB.
+    # If a feed provides a vacancy associated to a central trust that is not a MAT, no trust will be found in our DB
+    # so no orgs/schools would be associated with the vacancy.
+    def vacancy_listed_at_excluded_trust_type?(schools, trust_uid)
+      schools.none? && trust_uid.present?
+    end
   end
 end

--- a/app/services/vacancies/import/sources/my_new_term.rb
+++ b/app/services/vacancies/import/sources/my_new_term.rb
@@ -22,6 +22,7 @@ class Vacancies::Import::Sources::MyNewTerm
   def each
     results.each do |result|
       schools = find_schools(result)
+      next if vacancy_listed_at_excluded_trust_type?(schools, result["trustUID"])
       next if vacancy_listed_at_excluded_school_type?(schools)
 
       v = Vacancy.find_or_initialize_by(

--- a/spec/services/vacancies/import/sources/my_new_term_spec.rb
+++ b/spec/services/vacancies/import/sources/my_new_term_spec.rb
@@ -357,6 +357,14 @@ RSpec.describe Vacancies::Import::Sources::MyNewTerm do
       it "assigns the vacancy job location to the school group" do
         expect(vacancy.readable_job_location).to eq(school_group.name)
       end
+
+      context "when the provided central trust does not exist in our system" do
+        let(:trust_uid) { "invalid_trust_id" }
+
+        it "skips the vacancy" do
+          expect(vacancy).to be_nil
+        end
+      end
     end
 
     context "when the school doesn't belong to a school group" do


### PR DESCRIPTION
When the central trust the vacancy is associated to is not a MAT, it won't be listed in our system and no school will be found.

We are having issues with dozens of MyNewTerm vacancies being created while not having any org associated to the due to this, causing exceptions when listed/displayed in our system.

We are going to explicitly exclude those from being created.
