### PR TITLE
a11y: Add red highlighting to zoom buttons on vacancy maps for accessibility purposes

### DIFF
--- a/app/assets/stylesheets/components/map.scss
+++ b/app/assets/stylesheets/components/map.scss
@@ -4,6 +4,10 @@
   display: none;
 }
 
+.leaflet-bar a:focus {
+  outline: 6px solid #d4351c; 
+}
+
 .js-enabled {
   .map-component {
     display: block;


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/z8VfYsKW/984-a11y-247-focus-visible-visible-tab-focus-indicator-zoom-in-out-map-buttons

## Changes in this PR:

Add red highlighting to zoom buttons on vacancy maps for accessibility purposes

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
