### PR TITLE
Remove unused account_type column from jobseekers

### DIFF
--- a/app/models/jobseeker.rb
+++ b/app/models/jobseeker.rb
@@ -1,5 +1,4 @@
 class Jobseeker < ApplicationRecord
-  self.ignored_columns += ["account_type"]
   has_encrypted :last_sign_in_ip, :current_sign_in_ip
 
   devise(*%I[

--- a/db/migrate/20240528084036_remove_account_type_from_jobseekers.rb
+++ b/db/migrate/20240528084036_remove_account_type_from_jobseekers.rb
@@ -1,0 +1,5 @@
+class RemoveAccountTypeFromJobseekers < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured { remove_column :jobseekers, :account_type, :string }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_29_155152) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_28_084036) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -313,7 +313,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_29_155152) do
     t.date "account_closed_on"
     t.text "current_sign_in_ip_ciphertext"
     t.text "last_sign_in_ip_ciphertext"
-    t.string "account_type"
     t.index ["confirmation_token"], name: "index_jobseekers_on_confirmation_token", unique: true
     t.index ["email"], name: "index_jobseekers_on_email", unique: true
     t.index ["reset_password_token"], name: "index_jobseekers_on_reset_password_token", unique: true


### PR DESCRIPTION
## Trello card URL

## Changes in this PR:

This PR removes the column 'account_type' from the jobseekers table. This column was ignored, and code associated to it delete, in [a previous PR](https://github.com/DFE-Digital/teaching-vacancies/pull/6873).

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
