### PR TITLE
Add organisation validation to vacancy

### DIFF
--- a/app/controllers/publishers/vacancies_controller.rb
+++ b/app/controllers/publishers/vacancies_controller.rb
@@ -25,7 +25,7 @@ class Publishers::VacanciesController < Publishers::Vacancies::BaseController
   end
 
   def create
-    vacancy = Vacancy.create(publisher: current_publisher, publisher_organisation: current_organisation)
+    vacancy = Vacancy.create(publisher: current_publisher, publisher_organisation: current_organisation, organisations: [current_organisation])
 
     if current_organisation.school?
       vacancy.update(organisations: [current_organisation])

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -95,6 +95,7 @@ class Vacancy < ApplicationRecord
   validates :slug, presence: true
   validate :enable_job_applications_cannot_be_changed_once_listed
   validates_with ExternalVacancyValidator, if: :external?
+  validates :organisations, :presence => true
 
   has_noticed_notifications
   has_paper_trail on: [:update],

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -65,6 +65,7 @@ FactoryBot.define do
     working_patterns { factory_rand_sample(Vacancy.working_patterns.keys, 1..2) }
     working_patterns_details { Faker::Lorem.sentence(word_count: factory_rand(1..50)) }
     visa_sponsorship_available { false }
+    organisations { build_list(:school, 1) }
 
     trait :legacy_vacancy do
       about_school { Faker::Lorem.paragraph(sentence_count: factory_rand(5..10)) }

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Vacancy do
     let(:generator) { instance_double(Search::Postgres::TsvectorGenerator, tsvector: "'Hello'") }
 
     it "updates the searchable_content column on save" do
-      expect(Search::Postgres::TsvectorGenerator).to receive(:new).with(Hash).and_return(generator)
+      allow(Search::Postgres::TsvectorGenerator).to receive(:new).with(Hash).and_return(generator)
       expect(subject.searchable_content).to be_nil
       subject.save
       expect(subject.searchable_content).to eq("'Hello'")
@@ -542,14 +542,6 @@ RSpec.describe Vacancy do
       it "is set to a multipoint" do
         expect(subject.geolocation.map(&:lat)).to contain_exactly(2, 4)
         expect(subject.geolocation.map(&:lon)).to contain_exactly(1, 3)
-      end
-    end
-
-    context "if there is no organisation" do
-      let(:organisations) { [] }
-
-      it "is set to nil" do
-        expect(subject.geolocation).to be_nil
       end
     end
 

--- a/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_trust_spec.rb
+++ b/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_trust_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe "Creating a vacancy" do
         expect(page).to have_content(I18n.t("publishers.vacancies.steps.job_location"))
       end
 
+      uncheck I18n.t("organisations.job_location_heading.central_office")
+
       click_on I18n.t("buttons.continue")
 
       within(".govuk-error-summary") do
@@ -53,8 +55,9 @@ RSpec.describe "Creating a vacancy" do
   scenario "publishes a vacancy" do
     visit organisation_jobs_with_type_path
     click_on I18n.t("buttons.create_job")
-
+    uncheck I18n.t("organisations.job_location_heading.central_office")
     click_on I18n.t("buttons.continue")
+
     expect(page).to have_content("There is a problem")
 
     fill_in_job_location_form_fields(vacancy)


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/59Kv4maU/1005-to-explore-introduce-validation-and-db-constraints-to-enforce-organisation-presence-on-vacancy-creation

## Changes in this PR:

This PR adds validation to vacancies to ensure that a vacancy cannot be created without an associated organisation.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
