### PR TITLE
Copy training and cpds from previous application into new application

### DIFF
--- a/app/services/jobseekers/job_applications/quick_apply.rb
+++ b/app/services/jobseekers/job_applications/quick_apply.rb
@@ -80,9 +80,15 @@ class Jobseekers::JobApplications::QuickApply
   end
 
   def copy_training_and_cpds
+    return if recent_job_application.training_and_cpds.empty?
+
     recent_job_application.training_and_cpds.each do |training|
       new_training = training.dup
       new_training.update(job_application: new_job_application)
     end
+
+    new_job_application.training_and_cpds_section_completed = false
+    in_progress_steps = new_job_application.in_progress_steps + ["training_and_cpds"]
+    new_job_application.in_progress_steps = in_progress_steps
   end
 end

--- a/app/services/jobseekers/job_applications/quick_apply.rb
+++ b/app/services/jobseekers/job_applications/quick_apply.rb
@@ -11,6 +11,7 @@ class Jobseekers::JobApplications::QuickApply
     copy_qualifications
     copy_employments
     copy_references
+    copy_training_and_cpds
     new_job_application.save
     new_job_application
   end
@@ -75,6 +76,13 @@ class Jobseekers::JobApplications::QuickApply
     recent_job_application.references.each do |reference|
       new_reference = reference.dup
       new_reference.update(job_application: new_job_application)
+    end
+  end
+
+  def copy_training_and_cpds
+    recent_job_application.training_and_cpds.each do |training|
+      new_training = training.dup
+      new_training.update(job_application: new_job_application)
     end
   end
 end

--- a/spec/factories/job_applications.rb
+++ b/spec/factories/job_applications.rb
@@ -70,6 +70,7 @@ FactoryBot.define do
         create_list :employment, 1, :break, job_application: job_application
         create_list :reference, 2, job_application: job_application
         create_list :qualification, 3, job_application: job_application
+        create_list :training_and_cpd, 2, job_application: job_application
       end
 
       job_application.update_columns(

--- a/spec/factories/training_and_cpds.rb
+++ b/spec/factories/training_and_cpds.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     grade { "Pass" }
     year_awarded { "2020" }
 
-    jobseeker_profile
-    job_application
+    jobseeker_profile { nil }
+    job_application { nil }
   end
 end

--- a/spec/services/jobseekers/job_applications/quick_apply_spec.rb
+++ b/spec/services/jobseekers/job_applications/quick_apply_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Jobseekers::JobApplications::QuickApply do
 
       it "sets in progress steps as qualifications, employment history and professional status" do
         expect(subject.in_progress_steps)
-          .to eq(%w[qualifications employment_history professional_status])
+          .to eq(%w[qualifications employment_history professional_status training_and_cpds])
       end
     end
 
@@ -97,6 +97,8 @@ RSpec.describe Jobseekers::JobApplications::QuickApply do
 
       expect(subject.training_and_cpds.map { |training| training.slice(*attributes_to_copy) })
         .to eq(recent_job_application.training_and_cpds.map { |training| training.slice(*attributes_to_copy) })
+
+      expect(subject.training_and_cpds_section_completed).to eq(false)
     end
 
     it "does not copy declarations attributes" do

--- a/spec/services/jobseekers/job_applications/quick_apply_spec.rb
+++ b/spec/services/jobseekers/job_applications/quick_apply_spec.rb
@@ -92,6 +92,13 @@ RSpec.describe Jobseekers::JobApplications::QuickApply do
         .to eq(recent_job_application.references.map { |reference| reference.slice(*attributes_to_copy) })
     end
 
+    it "copies training and cpds" do
+      attributes_to_copy = %i[name provider grade year_awarded]
+
+      expect(subject.training_and_cpds.map { |training| training.slice(*attributes_to_copy) })
+        .to eq(recent_job_application.training_and_cpds.map { |training| training.slice(*attributes_to_copy) })
+    end
+
     it "does not copy declarations attributes" do
       expect(subject.close_relationships).to be_blank
       expect(subject.close_relationships_details).to be_blank


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/lYlMS8dC/1018-import-training-and-cpd-from-previous-applications

## Changes in this PR:

Prior to this PR, a user without a profile who had entered training and CPD data in a previous application did not get this training data prefilled in a new application, causing them to have to enter it for every new application. This PR fixes this issue by populating the new application with training data from the previous application if the user does not have a profile.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
