### PR TITLE
Do not send Healthcheck requests to DFE Analytics

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -75,7 +75,7 @@ class ApplicationController < ActionController::Base
   end
 
   def request_is_healthcheck?
-    ["diego-healthcheck", "Amazon CloudFront"].include?(request.headers["User-Agent"])
+    request.path == "/check" || ["diego-healthcheck", "Amazon CloudFront"].include?(request.headers["User-Agent"])
   end
 
   # Default to Github Codespaces domain if set, otherwise use the standard domain.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,6 +17,8 @@ class ApplicationController < ActionController::Base
   before_action { EventContext.dfe_analytics_request_event = dfe_analytics_request_event }
   before_action :set_paper_trail_whodunnit
 
+  skip_after_action :trigger_request_event, only: :check
+
   helper GOVUKDesignSystemFormBuilder::BuilderHelper
 
   include AbTestable

--- a/spec/requests/redirect_to_canonical_domain_spec.rb
+++ b/spec/requests/redirect_to_canonical_domain_spec.rb
@@ -18,6 +18,24 @@ RSpec.describe "Redirect to canonical domain" do
       domain_minus_port = DOMAIN.split(":").first
       expect(response.location).to eq("http://#{domain_minus_port}/")
     end
+
+    it "does not redirect when the request is to the healthcheck path" do
+      get "/check", headers: headers
+
+      expect(response.status).to eq(200)
+    end
+
+    it "does not redirect when the request is from Diego Healthcheck" do
+      get "/", headers: headers.merge("User-Agent" => "diego-healthcheck")
+
+      expect(response.status).to eq(200)
+    end
+
+    it "does not redirect when the request is from Amazon CloudFront" do
+      get "/", headers: headers.merge("User-Agent" => "Amazon CloudFront")
+
+      expect(response.status).to eq(200)
+    end
   end
 
   context "when request.host_with_port is already the canonical DOMAIN" do

--- a/spec/system/other/dfe_analytics_spec.rb
+++ b/spec/system/other/dfe_analytics_spec.rb
@@ -28,5 +28,9 @@ RSpec.describe "dfe analytics integration" do
     it "sends a DFE Analytics web request event" do
       expect { get "/api/test" }.to have_sent_analytics_event_types(:web_request)
     end
+
+    it "does not send health check requests to DFE Analytics" do
+      expect { get "/check" }.not_to have_sent_analytics_event_types(:web_request)
+    end
   end
 end


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/CiumEq5G

## Changes in this PR:

#### Do not send Healthcheck requests to DFE Analytics

These requests are used for infra. purposes only and don't add any value to our Analytics platform.
As they're hit 1/s (3600/h) it is bloating our system resources with unnecessary requests/updates.

#### Do not redirect Healthchecks to the canonical domain

The healthcheck requests do not need redirections to the canonical domain. This is inefficient and bloats our logs given the frequency of those requests (1/s => 3600/h).
