### PR TITLE
Change hint text on visa sponsorship page

### DIFF
--- a/app/views/publishers/vacancies/build/visa_sponsorship.html.slim
+++ b/app/views/publishers/vacancies/build/visa_sponsorship.html.slim
@@ -5,7 +5,18 @@
     = form_for form, url: wizard_path(current_step), method: :patch do |f|
       = f.govuk_error_summary
 
-      = f.govuk_radio_buttons_fieldset :visa_sponsorship_available, hint: -> { tag.p(t("publishers.vacancies.job_applications.visa_sponsorship.hint", link: govuk_link_to(t("publishers.vacancies.job_applications.visa_sponsorship.link_text"), "https://www.gov.uk/guidance/recruit-teachers-from-overseas#apply-to-become-a-licensed-worker-sponsor", target: "_blank")).html_safe) }, legend: { text: vacancy_form_page_heading(vacancy, step_process, back_path: back_path), tag: "h1", size: "l" } do
+      - hint = capture do
+        p = t("publishers.vacancies.job_applications.visa_sponsorship.hint_intro")
+        ul
+          li = t("publishers.vacancies.job_applications.visa_sponsorship.hint_bullet_1")
+          li = t("publishers.vacancies.job_applications.visa_sponsorship.hint_bullet_2")
+        p
+          a href="https://www.gov.uk/skilled-worker-visa/if-you-work-in-healthcare-or-education" target="_blank" = t("publishers.vacancies.job_applications.visa_sponsorship.learn_more_link_text")
+        p
+          = t("publishers.vacancies.job_applications.visa_sponsorship.hint_salary_text")
+          a href="https://www.gov.uk/government/publications/skilled-worker-visa-eligible-occupations/skilled-worker-visa-eligible-occupations-and-codes" target="_blank" = t("publishers.vacancies.job_applications.visa_sponsorship.eligibility_link_text")
+
+      = f.govuk_radio_buttons_fieldset :visa_sponsorship_available, hint: -> { hint }, legend: { text: vacancy_form_page_heading(vacancy, step_process, back_path: back_path), tag: "h1", size: "l" } do
 
         = f.govuk_radio_button :visa_sponsorship_available, "true", link_errors: true
           p = t("publishers.vacancies.job_applications.visa_sponsorship.yes_hint")

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -558,7 +558,7 @@ en:
         visa_sponsorship:
           yes_hint: This will help jobseekers who are looking for sponsorship to find your job more easily.
           no_hint: This will tell jobseekers on your job listing that you cannot offer sponsorship for this role.
-          hint_intro: "To offer Skill Worker visa sponsorship, this role must:"
+          hint_intro: "To offer Skilled Worker visa sponsorship, this role must:"
           hint_bullet_1: meet the minimum salary requirements
           hint_bullet_2: be included on the list of eligible roles
           hint_salary_text: Different salary rules apply for support roles in schools. 

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -558,8 +558,12 @@ en:
         visa_sponsorship:
           yes_hint: This will help jobseekers who are looking for sponsorship to find your job more easily.
           no_hint: This will tell jobseekers on your job listing that you cannot offer sponsorship for this role.
-          hint: If you're not already a sponsor you can %{link}
-          link_text: apply to become a licensed worker sponsor (opens in new tab).
+          hint_intro: "To offer Skill Worker visa sponsorship, this role must:"
+          hint_bullet_1: meet the minimum salary requirements
+          hint_bullet_2: be included on the list of eligible roles
+          hint_salary_text: Different salary rules apply for support roles in schools. 
+          learn_more_link_text: Learn more about Skilled Worker visa requirements for teaching jobs (opens in new tab).
+          eligibility_link_text: Find out about eligible support roles and salary requirements (opens in new tab).
       live:
         notice: You can only view active jobs
       review:


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/mk19NtZk/1016-visa-sponsorship-content-updates-hiring-staff-job-listing-journey

## Changes in this PR:

This PR updates the hint text on the visa sponsorship page of the job listing journey as per the trello card.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
