### PR TITLE
Fix Sentry rule ignoring Safari parse JSON errors

### DIFF
--- a/app/assets/javascript/application.js
+++ b/app/assets/javascript/application.js
@@ -34,7 +34,7 @@ Sentry.init({
   release: window.sentryConfig.release,
   integrations: [],
   tracesSampleRate: 0, // Disable tracing (performance monitoring, doesn't impact errors)
-  ignoreErrors: [/'Object\.prototype\.hasOwnProperty\.call\(o,"telephone"\)'/],
+  ignoreErrors: [/'Object\.prototype\.hasOwnProperty\.call\([eo],"telephone"\)'/],
 });
 
 const application = Application.start();


### PR DESCRIPTION
There is a well-known issue with Safari browsers parsing JSON information. This triggers a JS browser error that doesn't affect the user navigation but causes tens of thousands of errors consuming our Sentry quota.

We had a rule to ignore these so our quota doesn't get hit, but the wording of the error slightly changed, causing the ignore rule to be bypassed.

![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/6165a209-2e74-4698-aaa6-df937e6818ec)

![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/4b25d0de-170a-4e1c-8940-2ba2bc170ad9)

![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/e418d00e-fa02-490a-93ee-0480393ed456)
