### PR TITLE
Fix links in publisher job application email alerts

### DIFF
--- a/app/helpers/notify_views_helper.rb
+++ b/app/helpers/notify_views_helper.rb
@@ -70,7 +70,7 @@ module NotifyViewsHelper
   end
 
   def publisher_job_applications_link(vacancy)
-    url = organisation_job_job_applications_url(vacancy, **utm_params)
+    url = organisation_job_job_applications_url(vacancy.id, **utm_params)
     notify_link(url, t(".view_applications", count: vacancy.job_applications.submitted_yesterday.count))
   end
 

--- a/spec/mailers/publishers/job_application_mailer_spec.rb
+++ b/spec/mailers/publishers/job_application_mailer_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Publishers::JobApplicationMailer do
       expect(mail.subject).to eq(I18n.t("publishers.job_application_mailer.applications_received.subject", count: 2))
       expect(mail.to).to eq(["test@example.net"])
       expect(mail.body.encoded).to include(vacancy.job_title)
-                               .and include(organisation_job_job_applications_url(vacancy))
+                               .and include(organisation_job_job_applications_url(vacancy.id))
                                .and include(I18n.t("publishers.job_application_mailer.applications_received.view_applications", count: 2))
     end
 

--- a/spec/system/publishers/publishers_get_email_notifications_from_job_applications_spec.rb.rb
+++ b/spec/system/publishers/publishers_get_email_notifications_from_job_applications_spec.rb.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+RSpec.describe "Publishers get email notifications from job applications" do
+  include ActiveJob::TestHelper
+
+  let(:organisation) { create(:school) }
+  let(:publisher) { create(:publisher, email: "test@example.com", organisations: [organisation]) }
+  let(:vacancy) { create(:vacancy, :published, publisher: publisher, organisations: [organisation], publish_on: 2.days.ago) }
+  let!(:job_application) { create(:job_application, :status_submitted, vacancy: vacancy, submitted_at: 1.day.ago) }
+
+  before do
+    ActionMailer::Base.deliveries.clear
+    allow_any_instance_of(ApplicationController).to receive(:current_organisation).and_return(organisation)
+
+    login_publisher(publisher: publisher, organisation:)
+  end
+
+  scenario "publishers get an email linking to the job applications received the day before" do
+    perform_enqueued_jobs do
+      SendApplicationsReceivedYesterdayJob.new.perform
+    end
+    expect(ApplicationMailer.deliveries.count).to eq(1)
+    email = ApplicationMailer.deliveries.first
+    expect(email).to have_attributes(
+      to: ["test@example.com"],
+      subject: I18n.t("publishers.job_application_mailer.applications_received.subject", count: 1),
+    )
+    email_links = get_email_markdown_links(email.body.to_s)
+    expect(email_links.first[:text]).to eq("View 1 new application")
+    expect(email_links.first[:href]).to match(%r{organisation/jobs/#{vacancy.id}/job_applications})
+
+    visit email_links.first[:href]
+    expect(page).to have_css("h1", text: vacancy.job_title)
+  end
+
+  # Extracts the "[link text](link hreemf)" markdown links from an email body
+  def get_email_markdown_links(email_body)
+    email_body.scan(/\[([\w|\s]+)\]\((\S+)\)/).map { |match| { text: match[0], href: match[1] } }
+  end
+end


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/0gjqCFm9

## Changes in this PR:

The URL generated on the emails alerting publishers about job applications submitted to their vacancies were returning 404/Not Found pages for the publishers upon clicking on them.

The cause was the URLs were being generated using the friendly id/slug for the vacancies.

The publisher URLs do not use/accept the slug/friendly id, but require the real id for the vacancy.


## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
