### PR TITLE
Fix bug on "humanize_array" helper

### DIFF
--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -6,7 +6,7 @@ module VacanciesHelper
   WORD_EXCEPTIONS = %w[and the of upon].freeze
 
   def humanize_array(items)
-    items.map(&:humanize).join(", ")
+    items.reject(&:blank?).map(&:humanize).join(", ")
   end
 
   def page_title_prefix(step_process, form_object)

--- a/spec/helpers/vacancies_helper_spec.rb
+++ b/spec/helpers/vacancies_helper_spec.rb
@@ -1,6 +1,34 @@
 require "rails_helper"
 
 RSpec.describe VacanciesHelper do
+  describe "#humanize_array" do
+    subject { helper.humanize_array(items) }
+
+    context "when the array is empty" do
+      let(:items) { [] }
+
+      it "returns an empty string" do
+        expect(subject).to eq("")
+      end
+    end
+
+    context "when the array contains items" do
+      let(:items) { %w[maths science physics] }
+
+      it "returns a humanized list of items" do
+        expect(subject).to eq("Maths, Science, Physics")
+      end
+    end
+
+    context "when the array contains empty or null elements" do
+      let(:items) { ["", nil, "maths", "science", "physics"] }
+
+      it "returns a humanized list of items without the empty or null elements" do
+        expect(subject).to eq("Maths, Science, Physics")
+      end
+    end
+  end
+
   describe "#page_title_prefix" do
     subject { helper.page_title_prefix(step_process, form_object) }
 


### PR DESCRIPTION
## Trello card URL
- [Sentry error](https://teaching-vacancies.sentry.io/issues/5390164869/?environment=production&project=6212514&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&sort=freq&statsPeriod=24h&stream_index=15)

## Changes in this PR:

When the provided array contains nil elements, the helper throws an exception as it tries to call #humanize over the 'nil' value.

![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/e4ea0d52-d005-4271-903a-e371014843c0)
