### PR TITLE
Add ASAP to the start date options

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -50,7 +50,7 @@ class Vacancy < ApplicationRecord
   enum ect_status: { ect_suitable: 0, ect_unsuitable: 1 }
   enum hired_status: { hired_tvs: 0, hired_other_free: 1, hired_paid: 2, hired_no_listing: 3, not_filled_ongoing: 4, not_filled_not_looking: 5, hired_dont_know: 6 }
   enum listed_elsewhere: { listed_paid: 0, listed_free: 1, listed_mix: 2, not_listed: 3, listed_dont_know: 4 }
-  enum start_date_type: { specific_date: 0, date_range: 1, other: 2, undefined: 3 }
+  enum start_date_type: { specific_date: 0, date_range: 1, other: 2, undefined: 3, asap: 4 }
   enum status: { published: 0, draft: 1, trashed: 2, removed_from_external_system: 3 }
   enum receive_applications: { email: 0, website: 1 }
 

--- a/app/views/publishers/vacancies/build/start_date.html.slim
+++ b/app/views/publishers/vacancies/build/start_date.html.slim
@@ -6,7 +6,8 @@
       = f.govuk_error_summary
 
       = f.govuk_radio_buttons_fieldset :start_date_type, legend: { text: vacancy_form_page_heading(vacancy, step_process, back_path: back_path), tag: "h1", size: "l" }, form_group: { data: { controller: "form" } } do
-        = f.govuk_radio_button :start_date_type, :specific_date, link_errors: true, label: { text: t("helpers.legend.publishers_job_listing_start_date_form.start_date_specific") }, data: { action: "click->form#clearListener" } do
+        = f.govuk_radio_button :start_date_type, :asap, link_errors: true, label: { text: t("helpers.legend.publishers_job_listing_start_date_form.asap") }
+        = f.govuk_radio_button :start_date_type, :specific_date, label: { text: t("helpers.legend.publishers_job_listing_start_date_form.start_date_specific") }, data: { action: "click->form#clearListener" } do
           = f.govuk_date_field :starts_on,
             legend: { text: "Date", tag: nil },
             hint: -> { t("helpers.hint.date", date: 2.months.from_now.strftime("%-d %-m %Y")) },

--- a/app/views/publishers/vacancies/extend_deadline/show.html.slim
+++ b/app/views/publishers/vacancies/extend_deadline/show.html.slim
@@ -24,7 +24,8 @@
         ->(option) { t("helpers.options.publishers_job_listing_extend_deadline_form.expiry_time.#{option}") }
 
       = f.govuk_radio_buttons_fieldset :start_date_type, legend: { text: t("helpers.legend.publishers_job_listing_extend_deadline_form.starts_on") }, form_group: { data: { controller: "form" } } do
-        = f.govuk_radio_button :start_date_type, :specific_date, link_errors: true, label: { text: t("helpers.legend.publishers_job_listing_extend_deadline_form.start_date_specific") }, data: { action: "click->form#clearListener" } do
+        = f.govuk_radio_button :start_date_type, :asap, link_errors: true, label: { text: t("helpers.legend.publishers_job_listing_start_date_form.asap") }
+        = f.govuk_radio_button :start_date_type, :specific_date, label: { text: t("helpers.legend.publishers_job_listing_extend_deadline_form.start_date_specific") }, data: { action: "click->form#clearListener" } do
           = f.govuk_date_field :starts_on,
             legend: { text: "Date" },
             hint: -> { t("helpers.hint.date", date: 2.months.from_now.strftime("%d %m %Y")) },

--- a/app/views/publishers/vacancies/vacancy_review_sections/_important_dates.html.slim
+++ b/app/views/publishers/vacancies/vacancy_review_sections/_important_dates.html.slim
@@ -36,6 +36,8 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
           = "#{format_date(vacancy.earliest_start_date)} to #{format_date(vacancy.latest_start_date)}"
         - when "other"
           = vacancy.other_start_date_details
+        - when "asap"
+          = t("helpers.legend.publishers_job_listing_start_date_form.asap")
         - else
           = t("jobs.not_defined")
       - unless vacancy.legacy_draft?

--- a/app/views/vacancies/listing/_key_dates_sidebar.html.slim
+++ b/app/views/vacancies/listing/_key_dates_sidebar.html.slim
@@ -15,5 +15,7 @@
       - timeline.with_item(key: t("jobs.latest_start_date"), value: format_date(vacancy.latest_start_date))
     - when "other"
       - timeline.with_item(key: t("jobs.other_start_date_details"), value: vacancy.other_start_date_details)
+    - when "asap"
+      - timeline.with_item(key: t("jobs.other_start_date_details"), value: t("helpers.legend.publishers_job_listing_start_date_form.asap") )
   - timeline.with_item(key: t("jobs.application_deadline"), value: format_time_to_datetime_at(vacancy.expires_at))
   - timeline.with_item(key: t("jobs.date_listed"), value: format_date(vacancy.publish_on))

--- a/app/views/vacancies/listing/_key_dates_sidebar.html.slim
+++ b/app/views/vacancies/listing/_key_dates_sidebar.html.slim
@@ -16,6 +16,6 @@
     - when "other"
       - timeline.with_item(key: t("jobs.other_start_date_details"), value: vacancy.other_start_date_details)
     - when "asap"
-      - timeline.with_item(key: t("jobs.other_start_date_details"), value: t("helpers.legend.publishers_job_listing_start_date_form.asap") )
+      - timeline.with_item(key: t("jobs.other_start_date_details"), value: t("helpers.legend.publishers_job_listing_start_date_form.asap"))
   - timeline.with_item(key: t("jobs.application_deadline"), value: format_time_to_datetime_at(vacancy.expires_at))
   - timeline.with_item(key: t("jobs.date_listed"), value: format_date(vacancy.publish_on))

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -1010,6 +1010,7 @@ en:
         start_date_specific: Specific date
         starts_on: Job start date
         starts_on_html: Date job starts (optional<span class='govuk-visually-hidden'> field</span>)</span>
+        asap: As soon as possible
       publishers_job_listing_key_stages_form:
         key_stages: Key stages
       publishers_job_listing_schools_form:

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -191,6 +191,8 @@ module VacancyHelpers
     expect(page).to have_content(vacancy.expires_at.to_date.to_formatted_s.strip)
     if vacancy.start_date_type == "specific_date"
       expect(page).to have_content(vacancy.starts_on.to_formatted_s.strip)
+    elsif vacancy.start_date_type == "asap"
+      expect(page).to have_content("As soon as possible")
     end
 
     unless vacancy.enable_job_applications?
@@ -240,8 +242,10 @@ module VacancyHelpers
 
     expect(page).to have_content(vacancy.publish_on.to_formatted_s.strip)
     expect(page).to have_content(vacancy.expires_at.to_date.to_formatted_s.strip)
-    if vacancy.starts_on?
+    if vacancy.start_date_type == "specific_date"
       expect(page).to have_content(vacancy.starts_on.to_formatted_s.strip)
+    elsif vacancy.start_date_type == "asap"
+      expect(page).to have_content("As soon as possible")
     end
 
     expect(page.html).to include(vacancy.skills_and_experience)

--- a/spec/system/jobseekers/jobseekers_can_view_a_vacancy_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_view_a_vacancy_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe "Viewing a single published vacancy" do
 
   context "when the vacancy status is published" do
     let(:vacancy) do
-      create(:vacancy, :published, organisations: [school], job_roles: %w[ teacher headteacher deputy_headteacher assistant_headteacher head_of_year_or_phase head_of_department_or_curriculum teaching_assistant
-                                                                           higher_level_teaching_assistant education_support sendco administration_hr_data_and_finance
-                                                                           catering_cleaning_and_site_management it_support pastoral_health_and_welfare other_leadership other_support ])
+      create(:vacancy, :published, start_date_type: "asap", organisations: [school], job_roles: %w[ teacher headteacher deputy_headteacher assistant_headteacher head_of_year_or_phase head_of_department_or_curriculum teaching_assistant
+                                                                                                    higher_level_teaching_assistant education_support sendco administration_hr_data_and_finance
+                                                                                                    catering_cleaning_and_site_management it_support pastoral_health_and_welfare other_leadership other_support ])
     end
 
     scenario "jobseekers can view the vacancy" do

--- a/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_trust_spec.rb
+++ b/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_trust_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe "Creating a vacancy" do
     click_on I18n.t("buttons.save_and_continue")
     expect(current_path).to eq(organisation_job_build_path(created_vacancy.id, :start_date))
 
-    fill_in_start_date_form_fields(vacancy)
+    choose I18n.t("helpers.legend.publishers_job_listing_start_date_form.asap")
     click_on I18n.t("buttons.save_and_continue")
     expect(current_path).to eq(organisation_job_build_path(created_vacancy.id, :applying_for_the_job))
 


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/yXG83Kng/1033-add-an-as-soon-as-possible-option-on-the-start-date-in-the-job-listing-journey

## Changes in this PR:

This PR adds a new ASAP option to the start date options on the job listing journey.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
