### PR TITLE
Fix tempfile creation/upload to Find a Job service

### DIFF
--- a/app/services/vacancies/export/dwp_find_a_job/upload_base.rb
+++ b/app/services/vacancies/export/dwp_find_a_job/upload_base.rb
@@ -14,11 +14,14 @@ module Vacancies::Export::DwpFindAJob
     def call
       vacancies = self.class::QUERY_CLASS.new(from_date).vacancies
       xml = self.class::XML_CLASS.new(vacancies).xml
-      Tempfile.open(filename) do |file|
+      file = Tempfile.new(filename)
+      begin
         file.write(xml)
         upload_to_find_a_job_sftp(file.path)
-        log_upload(vacancies.size)
+      ensure
+        file.close!
       end
+      log_upload(vacancies.size)
     end
 
     private

--- a/spec/services/vacancies/export/dwp_find_a_job/expired_and_deleted/upload_spec.rb
+++ b/spec/services/vacancies/export/dwp_find_a_job/expired_and_deleted/upload_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe Vacancies::Export::DwpFindAJob::ExpiredAndDeleted::Upload do
     end
 
     it "generates an XML with the vacancies manually expired after the given date" do
-      tempfile = instance_double(Tempfile, path: "/tmp/#{file_name}")
-      expect(Tempfile).to receive(:open).with(file_name).and_yield(tempfile)
+      tempfile = instance_double(Tempfile, path: "/tmp/#{file_name}", close!: true)
+      expect(Tempfile).to receive(:new).with(file_name).and_return(tempfile)
       expect(tempfile).to receive(:write).with(
         <<~XML,
           <?xml version="1.0" encoding="UTF-8"?>

--- a/spec/services/vacancies/export/dwp_find_a_job/new_and_edited/upload_spec.rb
+++ b/spec/services/vacancies/export/dwp_find_a_job/new_and_edited/upload_spec.rb
@@ -103,8 +103,8 @@ RSpec.describe Vacancies::Export::DwpFindAJob::NewAndEdited::Upload do
     end
 
     it "generates an XML with the vacancies published/edited after the given date" do
-      tempfile = instance_double(Tempfile, path: "/tmp/#{file_name}")
-      expect(Tempfile).to receive(:open).with(file_name).and_yield(tempfile)
+      tempfile = instance_double(Tempfile, path: "/tmp/#{file_name}", close!: true)
+      expect(Tempfile).to receive(:new).with(file_name).and_return(tempfile)
       expect(tempfile).to receive(:write).with(expected_xml_content)
 
       subject.call


### PR DESCRIPTION
Trello ticket: https://trello.com/c/MGIXSJIZ

The self-contained block resulted in an empty file uploaded to DWP Find a Job service.

Manually creating and closing the tempfile fixes the issue.
