### PR TITLE
Fix DWP Find a Job vacancy description field

### DIFF
--- a/app/services/vacancies/export/dwp_find_a_job/new_and_edited/parsed_vacancy.rb
+++ b/app/services/vacancies/export/dwp_find_a_job/new_and_edited/parsed_vacancy.rb
@@ -27,7 +27,16 @@ module Vacancies::Export::DwpFindAJob::NewAndEdited
     end
 
     def description
-      strip_tags(vacancy.job_advert)
+      skills_and_experience = strip_tags(vacancy.skills_and_experience)
+      school_offer = strip_tags(vacancy.school_offer)
+      further_details = strip_tags(vacancy.further_details)
+      safeguarding = strip_tags(vacancy.organisation.safeguarding_information)
+      description = ""
+      description += "#{I18n.t('jobs.skills_and_experience.jobseeker')}\n\n#{skills_and_experience}\n\n" if skills_and_experience.present?
+      description += "#{I18n.t('jobs.school_offer.jobseeker')}\n\n#{school_offer}\n\n" if school_offer.present?
+      description += "#{I18n.t('jobs.further_details')}\n\n#{further_details}\n\n" if further_details.present?
+      description += "#{I18n.t('jobs.safeguarding_information.jobseeker')}\n\n#{safeguarding}" if safeguarding.present?
+      description.strip
     end
 
     def expiry

--- a/spec/services/vacancies/export/dwp_find_a_job/new_and_edited/upload_spec.rb
+++ b/spec/services/vacancies/export/dwp_find_a_job/new_and_edited/upload_spec.rb
@@ -2,7 +2,14 @@ require "rails_helper"
 
 RSpec.describe Vacancies::Export::DwpFindAJob::NewAndEdited::Upload do
   describe "#call" do
-    let(:org) { create(:school, address: "1 School Lane", town: "School Town", county: "School County", postcode: "AB12 3CD") }
+    let(:org) do
+      create(:school,
+             address: "1 School Lane",
+             town: "School Town",
+             county: "School County",
+             postcode: "AB12 3CD",
+             safeguarding_information: "Safeguarding text")
+    end
     let(:vacancy_published_old) do
       create(:vacancy,
              :published,
@@ -19,7 +26,9 @@ RSpec.describe Vacancies::Export::DwpFindAJob::NewAndEdited::Upload do
              updated_at: 2.weeks.ago,
              created_at: 2.weeks.ago,
              job_title: "Great teacher",
-             job_advert: "We need a great teacher",
+             skills_and_experience: "We need a great teacher",
+             school_offer: "We offer a great school",
+             further_details: "More details",
              expires_at: Time.zone.local(2024, 5, 17, 9, 0, 0),
              working_patterns: ["full_time"],
              job_roles: ["teacher"],
@@ -35,7 +44,9 @@ RSpec.describe Vacancies::Export::DwpFindAJob::NewAndEdited::Upload do
              updated_at: 1.hour.ago,
              created_at: 1.hour.ago,
              job_title: "IT technician",
-             job_advert: "IT technician for school",
+             skills_and_experience: "We need a IT technician",
+             school_offer: "We offer a great school",
+             further_details: "More details",
              expires_at: Time.zone.local(2024, 5, 20, 9, 0, 0),
              working_patterns: ["part_time"],
              job_roles: ["it_support"],
@@ -50,7 +61,21 @@ RSpec.describe Vacancies::Export::DwpFindAJob::NewAndEdited::Upload do
         <Vacancies>
           <Vacancy vacancyRefCode="#{vacancy_published.id}">
             <Title>Great teacher</Title>
-            <Description>We need a great teacher</Description>
+            <Description>What skills and experience we're looking for
+
+        We need a great teacher
+
+        What the school offers its staff
+
+        We offer a great school
+
+        Further details about the role
+
+        More details
+
+        Commitment to safeguarding
+
+        Safeguarding text</Description>
             <Location>
               <StreetAddress>1 School Lane</StreetAddress>
               <City>School Town</City>
@@ -66,7 +91,21 @@ RSpec.describe Vacancies::Export::DwpFindAJob::NewAndEdited::Upload do
           </Vacancy>
           <Vacancy vacancyRefCode="#{vacancy_updated.id}">
             <Title>IT technician</Title>
-            <Description>IT technician for school</Description>
+            <Description>What skills and experience we're looking for
+
+        We need a IT technician
+
+        What the school offers its staff
+
+        We offer a great school
+
+        Further details about the role
+
+        More details
+
+        Commitment to safeguarding
+
+        Safeguarding text</Description>
             <Location>
               <StreetAddress>1 School Lane</StreetAddress>
               <City>School Town</City>


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/MGIXSJIZ

## Changes in this PR:

The `job_advert` field we were trying to parse is only present on external vacancies.

For the internal vacancies, we use a combination of fields requested during the job creation.

We need to reproduce the job description from TV combining those fields in the parsed information we push to DWP Find a job description field.
