### PR TITLE
Feedback update

### DIFF
--- a/app/helpers/notify_views_helper.rb
+++ b/app/helpers/notify_views_helper.rb
@@ -19,7 +19,7 @@ module NotifyViewsHelper
 
   def expired_vacancy_feedback_link(vacancy)
     url = new_organisation_job_expired_feedback_url(vacancy.signed_id)
-    notify_link(url, vacancy.job_title)
+    notify_link(url, I18n.t("publishers.expired_vacancy_feedback_prompt_mailer.feedback_link_text"))
   end
 
   def expired_vacancy_unsubscribe_link(publisher)

--- a/app/jobs/send_expired_vacancy_feedback_prompt_job.rb
+++ b/app/jobs/send_expired_vacancy_feedback_prompt_job.rb
@@ -11,8 +11,6 @@ class SendExpiredVacancyFeedbackPromptJob < ApplicationJob
 
       Publishers::ExpiredVacancyFeedbackPromptMailer.prompt_for_feedback(expired_vacancy.publisher, expired_vacancy).deliver_later
 
-      Rails.logger.info("Sidekiq: Sending feedback prompt emails for vacancy id: #{expired_vacancy.id} vacancies to #{expired_vacancy.publisher.email}")
-
       expired_vacancy.update(expired_vacancy_feedback_email_sent_at: Time.zone.now)
     end
   end

--- a/app/mailers/publishers/expired_vacancy_feedback_prompt_mailer.rb
+++ b/app/mailers/publishers/expired_vacancy_feedback_prompt_mailer.rb
@@ -1,10 +1,10 @@
 class Publishers::ExpiredVacancyFeedbackPromptMailer < Publishers::BaseMailer
-  def prompt_for_feedback(publisher, vacancies)
+  def prompt_for_feedback(publisher, vacancy)
     @template = template
     @publisher = publisher
     @to = publisher.email
 
-    @vacancies = vacancies
+    @vacancy = vacancy
 
     view_mail(@template, to: @to, subject: "Teaching Vacancies needs your feedback on closed job listings")
   end

--- a/app/mailers/publishers/expired_vacancy_feedback_prompt_mailer.rb
+++ b/app/mailers/publishers/expired_vacancy_feedback_prompt_mailer.rb
@@ -6,6 +6,6 @@ class Publishers::ExpiredVacancyFeedbackPromptMailer < Publishers::BaseMailer
 
     @vacancy = vacancy
 
-    view_mail(@template, to: @to, subject: "Teaching Vacancies needs your feedback on closed job listings")
+    view_mail(@template, to: @to, subject: "Did you fill your vacancy?")
   end
 end

--- a/app/views/publishers/expired_vacancy_feedback_prompt_mailer/prompt_for_feedback.text.erb
+++ b/app/views/publishers/expired_vacancy_feedback_prompt_mailer/prompt_for_feedback.text.erb
@@ -1,6 +1,6 @@
 # <%= t('app.title') %>
 
-You recently recruited for <%= @vacancy.job_title %>
+You recently recruited for <%= @vacancy.job_title %>.
 
 <%= expired_vacancy_feedback_link(@vacancy) %>
 

--- a/app/views/publishers/expired_vacancy_feedback_prompt_mailer/prompt_for_feedback.text.erb
+++ b/app/views/publishers/expired_vacancy_feedback_prompt_mailer/prompt_for_feedback.text.erb
@@ -1,5 +1,3 @@
-# <%= t('app.title') %>
-
 You recently recruited for <%= @vacancy.job_title %>.
 
 <%= expired_vacancy_feedback_link(@vacancy) %>

--- a/app/views/publishers/expired_vacancy_feedback_prompt_mailer/prompt_for_feedback.text.erb
+++ b/app/views/publishers/expired_vacancy_feedback_prompt_mailer/prompt_for_feedback.text.erb
@@ -1,23 +1,12 @@
 # <%= t('app.title') %>
 
-Please let us know whether you filled these roles through Teaching Vacancies, or through another site or service.
+You recently recruited for <%= @vacancy.job_title %>
 
-It should only take a minute of your time.
+<%= expired_vacancy_feedback_link(@vacancy) %>
 
----
-
-<%- @vacancies.each do |vacancy| %>
-  <%=expired_vacancy_feedback_link(vacancy)%>
-<% end %>
-
----
-
-Your feedback will help Teaching Vacancies to keep getting better, supporting us to save schools millions of pounds in recruitment costs each year.
-
-Thank you for your feedback.
+Your feedback will help us improve how we advertise roles for your school or trust.
 
 Kind regards,
-
-The <%= t('app.title') %> team
+Teaching Vacancies
 
 <%= expired_vacancy_unsubscribe_link(@publisher)%>

--- a/app/views/publishers/vacancies/summary.html.slim
+++ b/app/views/publishers/vacancies/summary.html.slim
@@ -31,7 +31,7 @@
 
       = f.govuk_collection_radio_buttons :rating, Feedback.ratings.keys, :to_s
 
-      = f.govuk_text_area :comment, label: { size: "s" }, rows: 10
+      = f.govuk_text_area :comment, rows: 4, label: { size: "s" }
 
       = f.govuk_radio_buttons_fieldset(:user_participation_response, legend: { size: "s" }) do
         = f.govuk_radio_button :user_participation_response, :interested, link_errors: true do
@@ -39,4 +39,5 @@
           = f.govuk_text_area :occupation, required: true, rows: 1
         = f.govuk_radio_button :user_participation_response, :uninterested
 
-      = f.govuk_submit t("buttons.submit_feedback")
+      = f.govuk_submit t("buttons.submit_feedback") do
+        = govuk_link_to t("buttons.skip_feedback"), organisation_jobs_path, class: "govuk-link--no-visited-state"

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -93,6 +93,7 @@ en:
     sign_in_jobseeker: Sign in as a jobseeker
     sign_in_publisher: Sign in as hiring staff
     skip_this_step: Skip this step
+    skip_feedback: Skip feedback
     start_application: Start application
     submit: Submit
     submit_application: Submit application

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -204,7 +204,7 @@ en:
           one: View %{count} new application
           other: View %{count} new applications
     expired_vacancy_feedback_prompt_mailer:
-      feedback_link_text: Tell us how you filled your vacancy
+      feedback_link_text: Tell us how you filled your vacancy.
 
   support_users:
     authentication_fallback_mailer:

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -203,6 +203,8 @@ en:
         view_applications:
           one: View %{count} new application
           other: View %{count} new applications
+    expired_vacancy_feedback_prompt_mailer:
+      feedback_link_text: Tell us how you filled your vacancy
 
   support_users:
     authentication_fallback_mailer:

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -636,13 +636,12 @@ en:
         date_posted: Your job listing will be published on %{date}.
         feedback:
           heading: Have time to share some feedback?
-          description: >-
-            Your feedback can help us improve the service to better support you as well as schools around England.
+          description: Your feedback can help us improve how you can list jobs.
         heading:
           published: Job listing published
           scheduled: Job listing scheduled
         make_changes: make changes to the job listing
-        manage_jobs: manage jobs
+        manage_jobs: manage your other job listings
         next_steps: Next steps
         page_title: Job listing published - Create job listing - Teaching Vacancies - GOV.UK
         preview_listing: preview the job listing

--- a/spec/jobs/send_expired_vacancy_feedback_email_prompt_job_spec.rb
+++ b/spec/jobs/send_expired_vacancy_feedback_email_prompt_job_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe SendExpiredVacancyFeedbackPromptJob do
   before { allow(Publishers::ExpiredVacancyFeedbackPromptMailer).to receive(:prompt_for_feedback).and_return(mail) }
 
   context "when the publisher has 5 or less vacancies to be prompted on" do
-    let!(:expired_vacancy_1) { create(:vacancy, :expired, publisher: publisher, expires_at: expiry_date) }
-    let!(:expired_vacancy_2) { create(:vacancy, :expired, publisher: publisher, expires_at: expiry_date) }
+    let!(:expired_vacancy1) { create(:vacancy, :expired, publisher: publisher, expires_at: expiry_date) }
+    let!(:expired_vacancy2) { create(:vacancy, :expired, publisher: publisher, expires_at: expiry_date) }
 
     before { create(:vacancy, :expired, publisher: publisher, expires_at: 1.day.ago) }
 
     it "sends an email with vacancies that expired between 2 weeks ago and the cutoff date" do
-      expect(Publishers::ExpiredVacancyFeedbackPromptMailer).to receive(:prompt_for_feedback).with(publisher, expired_vacancy_1)
+      expect(Publishers::ExpiredVacancyFeedbackPromptMailer).to receive(:prompt_for_feedback).with(publisher, expired_vacancy1)
       expect(mail).to receive(:deliver_later)
 
       perform_enqueued_jobs { job }
@@ -24,9 +24,9 @@ RSpec.describe SendExpiredVacancyFeedbackPromptJob do
 
     it "sets the timestamp" do
       perform_enqueued_jobs { job }
-      [expired_vacancy_1, expired_vacancy_2].each(&:reload)
+      [expired_vacancy1, expired_vacancy2].each(&:reload)
 
-      expect([expired_vacancy_1, expired_vacancy_2].map(&:expired_vacancy_feedback_email_sent_at)).to_not include(nil)
+      expect([expired_vacancy1, expired_vacancy2].map(&:expired_vacancy_feedback_email_sent_at)).to_not include(nil)
     end
 
     context "when the publisher has no email address" do

--- a/spec/jobs/send_expired_vacancy_feedback_email_prompt_job_spec.rb
+++ b/spec/jobs/send_expired_vacancy_feedback_email_prompt_job_spec.rb
@@ -10,12 +10,13 @@ RSpec.describe SendExpiredVacancyFeedbackPromptJob do
   before { allow(Publishers::ExpiredVacancyFeedbackPromptMailer).to receive(:prompt_for_feedback).and_return(mail) }
 
   context "when the publisher has 5 or less vacancies to be prompted on" do
-    let!(:expired_vacancies) { create_list(:vacancy, 4, :expired, publisher: publisher, expires_at: expiry_date) }
+    let!(:expired_vacancy_1) { create(:vacancy, :expired, publisher: publisher, expires_at: expiry_date) }
+    let!(:expired_vacancy_2) { create(:vacancy, :expired, publisher: publisher, expires_at: expiry_date) }
 
     before { create(:vacancy, :expired, publisher: publisher, expires_at: 1.day.ago) }
 
     it "sends an email with vacancies that expired between 2 weeks ago and the cutoff date" do
-      expect(Publishers::ExpiredVacancyFeedbackPromptMailer).to receive(:prompt_for_feedback).with(publisher, a_collection_containing_exactly(*expired_vacancies))
+      expect(Publishers::ExpiredVacancyFeedbackPromptMailer).to receive(:prompt_for_feedback).with(publisher, expired_vacancy_1)
       expect(mail).to receive(:deliver_later)
 
       perform_enqueued_jobs { job }
@@ -23,9 +24,9 @@ RSpec.describe SendExpiredVacancyFeedbackPromptJob do
 
     it "sets the timestamp" do
       perform_enqueued_jobs { job }
-      expired_vacancies.each(&:reload)
+      [expired_vacancy_1, expired_vacancy_2].each(&:reload)
 
-      expect(expired_vacancies.map(&:expired_vacancy_feedback_email_sent_at)).to_not include(nil)
+      expect([expired_vacancy_1, expired_vacancy_2].map(&:expired_vacancy_feedback_email_sent_at)).to_not include(nil)
     end
 
     context "when the publisher has no email address" do
@@ -46,25 +47,6 @@ RSpec.describe SendExpiredVacancyFeedbackPromptJob do
 
         perform_enqueued_jobs { job }
       end
-    end
-  end
-
-  context "with more than 5 vacancies matching the criteria" do
-    let!(:oldest_expired_vacancies) { create_list(:vacancy, 5, :expired, publisher: publisher, expires_at: expiry_date) }
-
-    before do
-      create(:vacancy, :expired, publisher: publisher, expires_at: expiry_date + 1.day)
-      create(:vacancy, :expired, publisher: publisher, expires_at: expiry_date + 2.days)
-      create(:vacancy, :expired, publisher: publisher, expires_at: 1.day.ago)
-    end
-
-    it "sends an email with the 5 oldest expired vacancies" do
-      expect(publisher.vacancies.count).to eq(8)
-
-      expect(Publishers::ExpiredVacancyFeedbackPromptMailer).to receive(:prompt_for_feedback).with(publisher, a_collection_containing_exactly(*oldest_expired_vacancies))
-      expect(mail).to receive(:deliver_later)
-
-      perform_enqueued_jobs { job }
     end
   end
 end

--- a/spec/mailers/publishers/expired_vacancy_feedback_prompt_mailer_spec.rb
+++ b/spec/mailers/publishers/expired_vacancy_feedback_prompt_mailer_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Publishers::ExpiredVacancyFeedbackPromptMailer do
     end
 
     it "lists all vacancies" do
-      expect(mail.subject).to eq("Teaching Vacancies needs your feedback on closed job listings")
+      expect(mail.subject).to eq("Did you fill your vacancy?")
       expect(mail.to).to eq([email])
 
       expect(body).to include(content_extract1)

--- a/spec/mailers/publishers/expired_vacancy_feedback_prompt_mailer_spec.rb
+++ b/spec/mailers/publishers/expired_vacancy_feedback_prompt_mailer_spec.rb
@@ -7,12 +7,17 @@ RSpec.describe Publishers::ExpiredVacancyFeedbackPromptMailer do
   let(:body) { mail.body.raw_source }
 
   describe "prompt_for_feedback" do
-    let(:content_extract) { "Please let us know whether you filled these roles through Teaching Vacancies, or through another site or service." }
+    let(:content_extract1) do
+      "You recently recruited for #{vacancy.job_title}"
+    end
+    let(:content_extract2) do
+      "Tell us how you filled your vacancy"
+    end
     let(:email) { "test@example.com" }
     let(:publisher) { create(:publisher, email: email) }
-    let(:mail) { described_class.prompt_for_feedback(publisher, vacancies) }
+    let(:mail) { described_class.prompt_for_feedback(publisher, vacancy) }
     let(:notify_template) { NOTIFY_PRODUCTION_TEMPLATE }
-    let(:vacancies) { create_list(:vacancy, 5, :expired) }
+    let(:vacancy) { create(:vacancy, :expired) }
     let(:expected_data) do
       {
         notify_template: notify_template,
@@ -26,12 +31,9 @@ RSpec.describe Publishers::ExpiredVacancyFeedbackPromptMailer do
       expect(mail.subject).to eq("Teaching Vacancies needs your feedback on closed job listings")
       expect(mail.to).to eq([email])
 
-      expect(body).to include(content_extract)
-                  .and include(vacancies.first.job_title)
-                  .and include(vacancies.second.job_title)
-                  .and include(vacancies.third.job_title)
-                  .and include(vacancies.fourth.job_title)
-                  .and include(vacancies.fifth.job_title)
+      expect(body).to include(content_extract1)
+                  .and include(content_extract2)
+                  .and include(vacancy.job_title)
     end
 
     it "triggers a `publisher_prompt_for_feedback` email event" do

--- a/spec/system/publishers/publishers_can_provide_feedback_on_expired_vacancies_via_prompt_email_spec.rb
+++ b/spec/system/publishers/publishers_can_provide_feedback_on_expired_vacancies_via_prompt_email_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe "Publishers can provide feedback on expired vacancies via the pro
     let!(:first_vacancy_in_email) { create(:vacancy, :published, publisher: publisher, expires_at: 5.weeks.ago) }
 
     before do
-      create(:vacancy, :published, publisher: publisher, expires_at: 4.weeks.ago)
       perform_enqueued_jobs do
         SendExpiredVacancyFeedbackPromptJob.new.perform
       end
@@ -65,9 +64,9 @@ RSpec.describe "Publishers can provide feedback on expired vacancies via the pro
       end
     end
 
-    scenario "they all receive a feedback prompt email" do
-      expect(ApplicationMailer.deliveries.map(&:to)).to match a_collection_containing_exactly(["test@example.com"], ["test2@example.com"])
-      expect(ApplicationMailer.deliveries.count).to eq(2)
+    scenario "they receive a feedback prompt email for each qualifying vacanct" do
+      expect(ApplicationMailer.deliveries.map(&:to)).to match a_collection_containing_exactly(["test@example.com"], ["test@example.com"], ["test2@example.com"], ["test2@example.com"])
+      expect(ApplicationMailer.deliveries.count).to eq(4)
     end
   end
 end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/G8VlH6co/1034-improve-hiring-staff-feedback-within-email-and-job-listings

## Changes in this PR:

This PR changes content on the feedback page and the expired vacancy feedback email, but it also makes changes to the worker so that we send one expired vacancy feedback email per vacancy, rather than sending multiple in one email per publisher.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
