### PR TITLE
Add custom logger to filter email recipients in Action Mailer logs

### DIFF
--- a/config/initializers/sanitised_mailer_logger.rb
+++ b/config/initializers/sanitised_mailer_logger.rb
@@ -1,3 +1,5 @@
+require "json"
+
 class SanitisedMailerLogger < Logger
   def initialize(*args)
     super
@@ -7,6 +9,8 @@ class SanitisedMailerLogger < Logger
   end
 
   def format_message(severity, timestamp, progname, msg)
+    msg = msg.to_json if msg.is_a?(Hash)
+
     sanitized_message = msg.gsub(/"to":\[\s*"[^\"]+"\s*\]/, '"to":["[FILTERED]"]')
     "#{timestamp} #{severity} #{progname}: #{sanitized_message}\n"
   end


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/NeANEInB/1040-remove-pii-emails-from-production-workers-logs

## Changes in this PR:
Tthe custom logger extends ActiveSupport::Logger and overrides the format_message method. It replace the email addresses with the string "[FILTERED]", before calling super to maintain the rest of the original logging behaviour.

