### PR TITLE
Find a job: Ensure file content is written to disk

### DIFF
--- a/app/services/vacancies/export/dwp_find_a_job/upload_base.rb
+++ b/app/services/vacancies/export/dwp_find_a_job/upload_base.rb
@@ -17,6 +17,7 @@ module Vacancies::Export::DwpFindAJob
       file = Tempfile.new(filename)
       begin
         file.write(xml)
+        file.flush # Ensure all data is written to disk before uploading
         upload_to_find_a_job_sftp(file.path)
       ensure
         file.close!

--- a/spec/services/vacancies/export/dwp_find_a_job/expired_and_deleted/upload_spec.rb
+++ b/spec/services/vacancies/export/dwp_find_a_job/expired_and_deleted/upload_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Vacancies::Export::DwpFindAJob::ExpiredAndDeleted::Upload do
     end
 
     it "generates an XML with the vacancies manually expired after the given date" do
-      tempfile = instance_double(Tempfile, path: "/tmp/#{file_name}", close!: true)
+      tempfile = instance_double(Tempfile, path: "/tmp/#{file_name}", flush: true, close!: true)
       expect(Tempfile).to receive(:new).with(file_name).and_return(tempfile)
       expect(tempfile).to receive(:write).with(
         <<~XML,

--- a/spec/services/vacancies/export/dwp_find_a_job/new_and_edited/upload_spec.rb
+++ b/spec/services/vacancies/export/dwp_find_a_job/new_and_edited/upload_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe Vacancies::Export::DwpFindAJob::NewAndEdited::Upload do
     end
 
     it "generates an XML with the vacancies published/edited after the given date" do
-      tempfile = instance_double(Tempfile, path: "/tmp/#{file_name}", close!: true)
+      tempfile = instance_double(Tempfile, path: "/tmp/#{file_name}", flush: true, close!: true)
       expect(Tempfile).to receive(:new).with(file_name).and_return(tempfile)
       expect(tempfile).to receive(:write).with(expected_xml_content)
 


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/MGIXSJIZ

## Changes in this PR:

We need to ensure that the xml content of the tempfile has been written to disk before pushing the file to DWP Find a Job service.

Otherwise, the uploaded file is empty on some of the runs.
