### PR TITLE
[1912] Ship production logs to Logit.io

### DIFF
--- a/terraform/workspace-variables/production.tfvars.json
+++ b/terraform/workspace-variables/production.tfvars.json
@@ -77,5 +77,6 @@
     "day_of_week": 0,
     "start_hour": 2,
     "start_minute": 0
-  }
+  },
+  "enable_logit": true
 }


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/bjfo0jo9

## Changes in this PR:
Switch enable_logit to true for the production environment
The other environments are already in Logit