### PR TITLE
Schedule export service to DWP Find a Job

### DIFF
--- a/app/jobs/export_expired_vacancies_since_yesterday_to_dwp_find_a_job_service_job.rb
+++ b/app/jobs/export_expired_vacancies_since_yesterday_to_dwp_find_a_job_service_job.rb
@@ -1,0 +1,9 @@
+class ExportExpiredVacanciesSinceYesterdayToDwpFindAJobServiceJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    return if DisableExpensiveJobs.enabled?
+
+    Vacancies::Export::DwpFindAJob::ExpiredAndDeleted::Upload.new(25.hours.ago).call
+  end
+end

--- a/app/jobs/export_new_or_updated_vacancies_since_yesterday_to_dwp_find_a_job_service_job.rb
+++ b/app/jobs/export_new_or_updated_vacancies_since_yesterday_to_dwp_find_a_job_service_job.rb
@@ -1,0 +1,9 @@
+class ExportNewOrUpdatedVacanciesSinceYesterdayToDwpFindAJobServiceJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    return if DisableExpensiveJobs.enabled?
+
+    Vacancies::Export::DwpFindAJob::NewAndEdited::Upload.new(25.hours.ago).call
+  end
+end

--- a/app/services/vacancies/export/dwp_find_a_job/new_and_edited/upload.rb
+++ b/app/services/vacancies/export/dwp_find_a_job/new_and_edited/upload.rb
@@ -1,5 +1,3 @@
-require "net/sftp"
-
 module Vacancies::Export::DwpFindAJob::NewAndEdited
   class Upload < Vacancies::Export::DwpFindAJob::UploadBase
     FILENAME_PREFIX = "TeachingVacancies-upload".freeze

--- a/app/services/vacancies/export/dwp_find_a_job/upload_base.rb
+++ b/app/services/vacancies/export/dwp_find_a_job/upload_base.rb
@@ -1,3 +1,5 @@
+require "net/sftp"
+
 module Vacancies::Export::DwpFindAJob
   # Base class for uploading vacancies to DWP Find a Job service.
   # Subclasses must define the following constants:

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -18,6 +18,16 @@ export_users:
   class: 'ExportDSIUsersToBigQueryJob'
   queue: low
 
+export_new_or_updated_vacancies_to_dwp_find_a_job:
+  cron: '30 23 * * *'
+  class: 'ExportNewOrUpdatedVacanciesSinceYesterdayToDwpFindAJobServiceJob'
+  queue: low
+
+export_expired_vacancies_to_dwp_find_a_job:
+  cron: '30 21 * * *'
+  class: 'ExportExpiredVacanciesSinceYesterdayToDwpFindAJobServiceJob'
+  queue: low
+
 import_organisation_data:
   cron: '0 22 * * *'
   class: 'ImportOrganisationDataJob'

--- a/documentation/integrations/dwp-find-a-job.md
+++ b/documentation/integrations/dwp-find-a-job.md
@@ -10,10 +10,6 @@ There are 2 bulk upload types:
 1. Uploading new/edited vacancies.
 2. Uploading expired/deleted vacancies.
 
-The bulk upload file/s are imported once per day by Find a job service.
-
-Teaching Vacancies has no control on the frequency or timing of these imports, besides pushing info daily to be imported by Find a job.
-
 ```mermaid
 block-beta
 columns 3
@@ -263,6 +259,41 @@ We identify them by querying vacancies under all the following conditions:
 
 This criteria relies on, when the vacancies are manually closed, they get their closing datetime set to "right now", what also gets registered in the `updated_at` DB timestamp.
 There will be some difference on the exact timestamps, so we were generous and set 60 secs to be sure no closed vacancy stays posted in the Find a Job service.
+
+## How do we schedule the uploads
+The bulk upload file/s are imported once per day by Find a job service.
+
+Teaching Vacancies has no control on the frequency or timing of these imports, besides pushing info daily to be imported by Find a job.
+
+Every night we will push:
+- the vacancies that got published or edited over the last 25 hours.
+- the vacancies that got manually closed/expired by the publisher over the last 25 hours.
+
+Note: We use 25 hours to have 1h overlap between runs. Better to have some vacancies updated/deleted twice than missing from being exported
+due to its update in TV happening at the same time as the scheduled export run.
+
+## How to test-debug changes
+Find a Job service does not offer a testing environment, so all the testing needs to be done over production environment.
+
+The process for end-to-end manually testing goes through:
+1. Connect to a TV production console.
+2. Manually push the export to Find a Job service.
+  - Eg: `Vacancies::Export::DwpFindAJob::NewAndEdited::Upload.new(1.hour.ago).call`
+3. Using a FTP Client, connect to the DWP Find a Job SFTP Server.
+  - The connection details are defined in the env variables:
+    - `FIND_A_JOB_FTP_HOST`
+    - `FIND_A_JOB_FTP_PORT`
+    - `FIND_A_JOB_FTP_USER`
+    - `FIND_A_JOB_FTP_PASSWORD`
+4. On the FTP server, you will find:
+  - The files to be imported placed in the `Inbound` folder.
+  - The output of the recent upload/expiry exports placed in the `Outbund` folder.
+  - Already imported files placed in the `processed` folder.
+5. You can download/delete the files, editing them locally and re-upload them.
+6. Eventually, the files at the `Inbound` folder will be imported, moved to `processed` and a report generated at `Outbound`.
+5. You can see/manage the job adverts through the [Find a Job employer dashboard](https://findajob.dwp.gov.uk/employer/sign-in)
+  - An administrator has to invite you to Teaching Vacancies team. Our PM is the current admin.
+  - You will be able to manually Delete the adverts there.
 
 
 ## Technical specification

--- a/spec/jobs/export_expired_vacancies_since_yesterday_to_dwp_find_a_job_service_job_spec.rb
+++ b/spec/jobs/export_expired_vacancies_since_yesterday_to_dwp_find_a_job_service_job_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe ExportExpiredVacanciesSinceYesterdayToDwpFindAJobServiceJob do
+  subject(:job) { described_class.perform_later }
+
+  let(:upload) { instance_double(Vacancies::Export::DwpFindAJob::ExpiredAndDeleted::Upload, call: nil) }
+
+  before do
+    allow(Vacancies::Export::DwpFindAJob::ExpiredAndDeleted::Upload).to receive(:new).and_return(upload)
+  end
+
+  context "when DisableExpensiveJobs is enabled" do
+    before { allow(DisableExpensiveJobs).to receive(:enabled?).and_return(true) }
+
+    it "does not call the upload service" do
+      perform_enqueued_jobs { job }
+      expect(Vacancies::Export::DwpFindAJob::ExpiredAndDeleted::Upload).not_to have_received(:new)
+    end
+  end
+
+  context "when DisableExpensiveJobs is not enabled" do
+    before { allow(DisableExpensiveJobs).to receive(:enabled?).and_return(false) }
+
+    it "calls the upload service passing the time 25 hours before now" do
+      freeze_time do
+        perform_enqueued_jobs { job }
+        expect(Vacancies::Export::DwpFindAJob::ExpiredAndDeleted::Upload).to have_received(:new).with(25.hours.ago)
+        expect(upload).to have_received(:call)
+      end
+    end
+  end
+end

--- a/spec/jobs/export_new_or_updated_vacancies_since_yesterday_to_dwp_find_a_job_service_job_spec.rb
+++ b/spec/jobs/export_new_or_updated_vacancies_since_yesterday_to_dwp_find_a_job_service_job_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe ExportNewOrUpdatedVacanciesSinceYesterdayToDwpFindAJobServiceJob do
+  subject(:job) { described_class.perform_later }
+
+  let(:upload) { instance_double(Vacancies::Export::DwpFindAJob::NewAndEdited::Upload, call: nil) }
+
+  before do
+    allow(Vacancies::Export::DwpFindAJob::NewAndEdited::Upload).to receive(:new).and_return(upload)
+  end
+
+  context "when DisableExpensiveJobs is enabled" do
+    before { allow(DisableExpensiveJobs).to receive(:enabled?).and_return(true) }
+
+    it "does not call the upload service" do
+      perform_enqueued_jobs { job }
+      expect(Vacancies::Export::DwpFindAJob::NewAndEdited::Upload).not_to have_received(:new)
+    end
+  end
+
+  context "when DisableExpensiveJobs is not enabled" do
+    before { allow(DisableExpensiveJobs).to receive(:enabled?).and_return(false) }
+
+    it "calls the upload service passing the time 25 hours before now" do
+      freeze_time do
+        perform_enqueued_jobs { job }
+        expect(Vacancies::Export::DwpFindAJob::NewAndEdited::Upload).to have_received(:new).with(25.hours.ago)
+        expect(upload).to have_received(:call)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/MGIXSJIZ

## Changes in this PR:
- schedule daily export of vacancies to DWP Find a Job service.
- extend the documentation with information about the schedule and how to debug/test the integration.
