### PR TITLE
content tweaks for accesibility

### DIFF
--- a/app/components/dashboard_component/dashboard_component.html.slim
+++ b/app/components/dashboard_component/dashboard_component.html.slim
@@ -9,10 +9,10 @@
     .govuk-grid-column-three-quarters
       .help-guide--mobile.help-guide--border-bottom
         h2.govuk-heading-m = t("jobs.dashboard.how_to_accept_job_applications_guide.title")
-        p.govuk-body = t("jobs.dashboard.how_to_accept_job_applications_guide.description_mobile")
         = govuk_link_to(t("jobs.dashboard.how_to_accept_job_applications_guide.link_text"),
                         post_path(section: "get-help-hiring", post_name: "accepting-job-applications-on-teaching-vacancies"),
                         class: "govuk-link--no-visited-state")
+        | .
       span.govuk-caption-l = @organisation.name
       h1.govuk-heading-l = t("jobs.dashboard.#{@selected_type}.with_count", count: @vacancies.count)
     .govuk-grid-column-one-quarter
@@ -52,10 +52,10 @@
 
         .help-guide--desktop class="govuk-!-margin-top-4"
           h2.govuk-heading-m = t("jobs.dashboard.how_to_accept_job_applications_guide.title")
-          p.govuk-body = t("jobs.dashboard.how_to_accept_job_applications_guide.description_desktop")
           = govuk_link_to(t("jobs.dashboard.how_to_accept_job_applications_guide.link_text"),
                           post_path(section: "get-help-hiring", post_name: "accepting-job-applications-on-teaching-vacancies"),
                           class: "govuk-link--no-visited-state")
+          | .
     #vacancy-results class=grid_column_class
       - if vacancies.none?
         = empty_section do
@@ -127,7 +127,7 @@
       .govuk-grid-column-one-quarter
         .help-guide--desktop
           h2.govuk-heading-m = t("jobs.dashboard.how_to_accept_job_applications_guide.title")
-          p.govuk-body = t("jobs.dashboard.how_to_accept_job_applications_guide.description_desktop")
           = govuk_link_to(t("jobs.dashboard.how_to_accept_job_applications_guide.link_text"),
                           post_path(section: "get-help-hiring", post_name: "accepting-job-applications-on-teaching-vacancies"),
                           class: "govuk-link--no-visited-state")
+          | .

--- a/app/views/content/get-help-hiring/accepting-job-applications-on-teaching-vacancies.md
+++ b/app/views/content/get-help-hiring/accepting-job-applications-on-teaching-vacancies.md
@@ -116,4 +116,4 @@ To comply with data protection regulations, you will have access to applications
 
 If you have questions about using Teaching Vacancies to receive and manage job applications, please [contact us](https://teaching-vacancies.service.gov.uk/support_request/new).
 
-* Read our advice on [how to write teacher job adverts](/get-help-hiring/creating-the-perfect-teacher-job-advert)
+ Read our advice on [how to write teacher job adverts](/get-help-hiring/creating-the-perfect-teacher-job-advert)

--- a/app/views/content/get-help-hiring/accepting-job-applications-on-teaching-vacancies.md
+++ b/app/views/content/get-help-hiring/accepting-job-applications-on-teaching-vacancies.md
@@ -98,11 +98,11 @@ When you view your list of [active](https://teaching-vacancies.service.gov.uk/or
 
 Click on a candidate’s name to see details of their application. Each applicant is given one of the following labels:
 
-* **Unread** - new applications you have not yet clicked on
-* **Reviewed** - applications you have clicked on, but not yet rejected or shortlisted
-* **Withdrawn** - applications that have been withdrawn by the jobseeker
-* **Rejected** - applications which you have declined
-* **Shortlisted** - applications which you have taken on to the next stage
+* **unread** - new applications you have not yet clicked on
+* **reviewed** - applications you have clicked on, but not yet rejected or shortlisted
+* **withdrawn** - applications that have been withdrawn by the jobseeker
+* **rejected** - applications which you have declined
+* **shortlisted** - applications which you have taken on to the next stage
 
 You can shortlist or reject applications either from the main list (once they have been reviewed) or from within the application details page. When you choose to shortlist or reject a candidate, you’re given the option to provide more information to be included within the notification email.
 

--- a/app/views/content/get-help-hiring/accepting-job-applications-on-teaching-vacancies.md
+++ b/app/views/content/get-help-hiring/accepting-job-applications-on-teaching-vacancies.md
@@ -116,4 +116,4 @@ To comply with data protection regulations, you will have access to applications
 
 If you have questions about using Teaching Vacancies to receive and manage job applications, please [contact us](https://teaching-vacancies.service.gov.uk/support_request/new).
 
- Read our advice on [how to write teacher job adverts](/get-help-hiring/creating-the-perfect-teacher-job-advert)
+ Read our advice on [how to write teacher job adverts](/get-help-hiring/creating-the-perfect-teacher-job-advert).

--- a/app/views/content/get-help-hiring/creating-the-perfect-teacher-job-advert.md
+++ b/app/views/content/get-help-hiring/creating-the-perfect-teacher-job-advert.md
@@ -24,18 +24,26 @@ Your job title will not only be displayed on Teaching Vacancies but also on sear
 
 Naturally, a jobseeker’s eyes are often drawn to the salary field. They want to know whether the compensation being offered meets their expectations, and many will move on at this stage if it’s not what they’re looking for.
 
-Teacher salaries can be complicated compared to some other industries, so when listing a job there are three separate fields to give you space to be transparent and explain the exact remuneration related to the role:
+Teacher salaries can be complicated compared to some other industries, so when listing a job there are three separate fields to give you space to be transparent and explain the exact remuneration related to the role.
 
-* **Annual or full time equivalent (FTE) salary** - this is simply what the role would pay per year, regardless of any particular working patterns. If it’s a [full time](/full-time-school-jobs) role, enter the full basic salary (or a salary band) here. If it’s not, calculate this from the number of days or weeks per year the role covers.
-* **Actual salary** - for [part time](/part-time-school-jobs), [flexible](/flexible-working-jobs-in-schools), [job share](/school-job-shares) or [term time](/school-term-time-jobs) roles, provide the candidate with specific information on the money they will receive. You may decide to state this per year or per month, depending on the nature of the role.
-* **Additional allowances** - many schools offer teachers benefits beyond their monthly wages. This is your opportunity to list salary sacrifice schemes, cycle to work vouchers, tax-free childcare, and any other bonuses related to working at your school. You may also want to detail the training and career development opportunities you offer.
+ **Annual or full time equivalent (FTE) salary** 
+
+ This is simply what the role would pay per year, regardless of any particular working patterns. If it’s a [full time](/full-time-school-jobs) role, enter the full basic salary (or a salary band) here. If it’s not, calculate this from the number of days or weeks per year the role covers.
+ 
+ **Actual salary** 
+ 
+ For [part time](/part-time-school-jobs), [flexible](/flexible-working-jobs-in-schools), [job share](/school-job-shares) or [term time](/school-term-time-jobs) roles, provide the candidate with specific information on the money they will receive. You may decide to state this per year or per month, depending on the nature of the role.
+ 
+ **Additional allowances** 
+ 
+ Many schools offer teachers benefits beyond their monthly wages. This is your opportunity to list salary sacrifice schemes, cycle to work vouchers, tax-free childcare, and any other bonuses related to working at your school. You may also want to detail the training and career development opportunities you offer.
 
 However you decide to best describe the salary on offer using these fields, avoid referring to pay in a way that doesn’t make sense to people outside your organisation. Those you work with may have an understanding of the grades or bands you use, or acronyms such as MPS or UPS, but don’t assume your candidates will. Make it easy for them by providing a straightforward numerical value.
 
 ### Application method
 On Teaching Vacancies we offer two ways for you to receive applications, either through our built-in application form, or through your own method.
 
-* Read our guidance on [how to accept job applications on Teaching Vacancies](/get-help-hiring/accepting-job-applications-on-teaching-vacancies)
+Read our guidance on [how to accept job applications on Teaching Vacancies](/get-help-hiring/accepting-job-applications-on-teaching-vacancies).
 
 If you choose the former you’ll have the benefit of managing candidates in one place from the start of the process all the way through to offering someone the job. If you choose the latter, you can point applicants to a form on your website, or ask them to submit attachments via an email address.
 
@@ -95,10 +103,18 @@ You don’t want to put anyone off applying by making the criteria too strict, b
 
 The final step of posting a job on Teaching Vacancies offers you a chance to preview how it will look from the jobseeker’s perspective. Remember that job ads should be written for them, not you.
 
-We highly recommend taking off your hiring staff hat and looking at your job advert with an objective eye and asking yourself these questions:
+We highly recommend taking off your hiring staff hat and looking at your job advert with an objective eye and asking yourself the following questions.
 
-* **How does it look on a mobile?** The majority of candidates search for jobs on smartphones, so look at the preview link on a small screen to ensure it flows as you’d like it to and it’s pleasing to the eye.
-* **Is there any duplicate information?** Some schools post job ads including salaries or working patterns within the job description, despite these already being summarised at the top of the job advert template. Remove anything that’s already included elsewhere.
-* **Does it comply with employment legislation?** While you’re perfectly within your rights to ask that candidates meet certain criteria, it’s illegal to refer to age, gender, and various other personal characteristics. This also applies to phrases such as 'recent graduate' or 'highly experienced', so focus more on what you want candidates to be able to do, rather than how long they’ve been doing it.
+ **How does it look on a mobile?**
+ 
+  The majority of candidates search for jobs on smartphones, so look at the preview link on a small screen to ensure it flows as you’d like it to and it’s pleasing to the eye.
+ 
+ **Is there any duplicate information?** 
+ 
+ Some schools post job ads including salaries or working patterns within the job description, despite these already being summarised at the top of the job advert template. Remove anything that’s already included elsewhere.
+
+**Does it comply with employment legislation?** 
+
+While you’re perfectly within your rights to ask that candidates meet certain criteria, it’s illegal to refer to age, gender, and various other personal characteristics. This also applies to phrases such as 'recent graduate' or 'highly experienced', so focus more on what you want candidates to be able to do, rather than how long they’ve been doing it.
 
 And finally, edit your text thoroughly. Like any piece of writing, your first draft should look very different from your final version. Don’t rely on your computer’s spell checker, and make use of the many online tools that help you write in a simpler, clearer and more persuasive way.

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -17,7 +17,7 @@
       .govuk-body class="govuk-!-margin-bottom-3" = govuk_link_to t("buttons.view_account"), jobseeker_root_path, class: "govuk-link--no-visited-state"
     - else
       p.govuk-body = t(".jobseeker_section.signed_out.description_html")
-      = govuk_button_link_to(t("buttons.sign_in"), new_jobseeker_session_path, class: "govuk-!-margin-bottom-2")
+      = govuk_button_link_to(t(".jobseeker_section.signed_out.link_text.sign_in"), new_jobseeker_session_path, class: "govuk-!-margin-bottom-2")
       p.govuk-body = t(".jobseeker_section.signed_out.create_account_html", create_account_link: govuk_link_to(t(".jobseeker_section.signed_out.link_text.create_account"), new_jobseeker_registration_path, class: "govuk-link--no-visited-state"))
 
   .govuk-grid-column-one-quarter

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -8,7 +8,7 @@
     p.govuk-body = t(".description")
     p.govuk-body = t(".personal_statement_section.description_html",
                      personal_statement_guide_link: govuk_link_to(t(".personal_statement_section.link_text"),
-                                                    post_path(section: "jobseeker-guides", post_name: "how-to-write-teacher-personal-statement"),
+                                                    posts_path(section: "jobseeker-guides"),
                                                     class: "govuk-link--no-visited-state"))
   .govuk-grid-column-one-quarter
     h2.govuk-heading-m = t(".jobseeker_section.title")

--- a/app/views/layouts/_footer.html.slim
+++ b/app/views/layouts/_footer.html.slim
@@ -23,7 +23,7 @@
                 - if jobseeker_signed_in?
                   = link_to t("nav.create_a_job_alert"), jobseekers_account_path, class: "govuk-footer__link"
                 - else
-                  = link_to t("nav.sign_in"), new_jobseeker_session_path, class: "govuk-footer__link"
+                  = link_to t("nav.jobseeker_sign_in"), new_jobseeker_session_path, class: "govuk-footer__link"
               li.govuk-footer__list-item
                 = link_to t("nav.personal_statement"),
                           post_path(section: "jobseeker-guides", post_name: "how-to-write-teacher-personal-statement"),
@@ -49,6 +49,6 @@
                   = link_to t("footer.manage_job_listings"), organisation_jobs_with_type_path, class: "govuk-footer__link"
               - else
                 li.govuk-footer__list-item
-                  = link_to t("nav.sign_in"), new_publisher_session_path, class: "govuk-footer__link"
+                  = link_to t("nav.publisher_sign_in"), new_publisher_session_path, class: "govuk-footer__link"
               li.govuk-footer__list-item
                 = link_to t("footer.hiring_guides"), posts_path(section: "get-help-hiring"), class: "govuk-footer__link"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -151,7 +151,7 @@ en:
             create_account: create a jobseeker account
         title: For jobseekers
       personal_statement_section:
-        description_html: You can also apply for jobs, set up job alerts and %{personal_statement_guide_link}.
+        description_html: You can apply for jobs, set up job alerts and %{personal_statement_guide_link}.
         link_text: read advice for jobseekers
       publisher_section:
         signed_in:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,7 +148,7 @@ en:
           create_account_html: or %{create_account_link}.
           description_html: Save and apply for jobs in schools.
           link_text:
-            create_account: create an account
+            create_account: create a jobseeker account
         title: For jobseekers
       personal_statement_section:
         description_html: You can also apply for jobs, set up job alerts and %{personal_statement_guide_link}.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -162,7 +162,7 @@ en:
           create_account_html: or %{create_account_link}.
           description_html: Post jobs and manage applications.
           link_text:
-            create_account: create an account
+            create_account: create a hiring staff account
             sign_in: Sign in
             sign_up: sign up
         title: For hiring staff

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -124,6 +124,8 @@ en:
     personal_statement: Writing a personal statement
     hiring_guides: Hiring guides
     sign_in: Sign in
+    jobseeker_sign_in: Jobseeker sign in
+    publisher_sign_in: Hiring staff sign in
     sign_out: Sign out
     support_user_dashboard: Support dashboard
     support_user_return_to_service: Return to Teaching Vacancies
@@ -149,6 +151,7 @@ en:
           description_html: Save and apply for jobs in schools.
           link_text:
             create_account: create a jobseeker account
+            sign_in: Jobseeker sign in
         title: For jobseekers
       personal_statement_section:
         description_html: You can apply for jobs, set up job alerts and %{personal_statement_guide_link}.
@@ -390,10 +393,10 @@ en:
       location:
         hint: Teaching Vacancies advertises school roles in England. Enter a UK city, county or postcode to look for roles near you.
       campaign:
-        title: 
+        title:
           with_name: Hey %{name}, welcome to Teaching Vacancies!
           without_name: Welcome to Teaching Vacancies!
-        description: 
+        description:
           with_subject: Get %{subject} teacher jobs sent straight to your inbox.
           without_subject: Get teaching jobs sent straight to your inbox.
         location: City, county or postcode (in England)
@@ -457,7 +460,7 @@ en:
       - specify the types of teaching jobs you're looking for
       - apply for roles more quickly by pre-filling your information
     link_to_profile: Create a profile to simplify your job search.
-  
+
   visa_sponsorship_banner:
     heading: You can now specify if you need visa sponsorship on your profile
     body: You can %{link} on your profile.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,7 +66,7 @@ en:
   footer:
     headings:
       feedback: Feedback
-      for_job_seekers: Job seekers
+      for_job_seekers: Jobseekers
       for_schools: Hiring staff
       support: Support
     international_teacher_advice_link_text: Teach in England if you trained overseas

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -163,7 +163,7 @@ en:
           description_html: Post jobs and manage applications.
           link_text:
             create_account: create a hiring staff account
-            sign_in: Sign in
+            sign_in: Hiring staff sign in
             sign_up: sign up
         title: For hiring staff
       title: Teaching, leadership and support jobs

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -588,8 +588,8 @@ en:
 
       personal_details_form:
         email: Email
-        change_email_html: Change your email address from within your %{link}
-        change_email_link_text: account
+        change_email_html: Select to %{link}
+        change_email_link_text: change your email address
         first_name: First name
         last_name: Last name
         phone_number: Phone number

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -19,9 +19,7 @@ en:
         tab_heading: Closed jobs
         with_count: Closed jobs (%{count})
       how_to_accept_job_applications_guide:
-        description_desktop: Find out the simplest way to get candidates to apply for your jobs.
-        description_mobile: Get guidance around how to accept vacancies
-        link_text: Find out how to use the Teaching Vacancies application form 
+        link_text: Find out how to use the Teaching Vacancies application form
         title: Accept job applications using our online form
       non-teaching-roles-banner:
         heading: You can now create job listings for all roles in your school or trust.

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -21,8 +21,8 @@ en:
       how_to_accept_job_applications_guide:
         description_desktop: Find out the simplest way to get candidates to apply for your jobs.
         description_mobile: Get guidance around how to accept vacancies
-        link_text: How to accept job applications on Teaching Vacancies article 
-        title: How to accept job applications on Teaching Vacancies
+        link_text: Find out how to use the Teaching Vacancies application form 
+        title: Accept job applications using our online form
       non-teaching-roles-banner:
         heading: You can now create job listings for all roles in your school or trust.
         link_text: Find out how to list non-teaching roles.

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -21,7 +21,7 @@ en:
       how_to_accept_job_applications_guide:
         description_desktop: Find out the simplest way to get candidates to apply for your jobs.
         description_mobile: Get guidance around how to accept vacancies
-        link_text: View article
+        link_text: How to accept job applications on Teaching Vacancies article 
         title: How to accept job applications on Teaching Vacancies
       non-teaching-roles-banner:
         heading: You can now create job listings for all roles in your school or trust.

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -192,7 +192,7 @@ en:
           title: Education and qualifications — Application
         references:
           description1_html: >-
-            <strong>Two referees are required for this application.</strong> One of these must be your
+            <strong>2 referees are required for this application.</strong> One of these must be your
             current or most recent employer. If you are shortlisted, your referees may be contacted before your interview.
           description2: >-
             If you do not currently work with children, but have done so in the past, you must include a referee from

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -170,7 +170,7 @@ en:
           personal_statement_guide:
             description_desktop: Find out how to sell your skills and experience to school recruiters.
             description_mobile: Get guidance around creating the perfect personal statement.
-            link_text: View article
+            link_text: How to write a teacher personal statement article
             title: How to write a teacher personal statement
           step_title: Personal statement
           title: Personal statement — Application

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -170,7 +170,7 @@ en:
           personal_statement_guide:
             description_desktop: Find out how to sell your skills and experience to school recruiters.
             description_mobile: Get guidance around creating the perfect personal statement.
-            link_text: How to write a teacher personal statement article
+            link_text: How to write a teacher personal statement
             title: How to write a teacher personal statement
           step_title: Personal statement
           title: Personal statement — Application
@@ -874,7 +874,7 @@ en:
           content_html: "%{link_to} to save and apply for jobs you are interested in."
           heading: Don't have an account yet?
           link: Create an account
-        title: Jobseeker sign in
+        title: Sign in
       locked:
         description: You have been locked out of your account because you have made too many attempts to log in.
         having_trouble_html: Still having trouble? %{request_support_link}.

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -143,14 +143,14 @@ en:
 
           We appreciate the time you have invested in your draft application and understand that this might be disappointing news.
 
-          You can view your draft application %{link}.
+          You can %{link}.
 
           Thank you for using Teaching Vacancies.
         heading: "%{job_title} at %{organisation_name}"
         home_page:
           link_text: Find another job
         job_application:
-          link_text: here
+          link_text: view your draft application
         subject: Update on %{job_title} at %{organisation_name}
 
     subscription_mailer:

--- a/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
@@ -393,7 +393,7 @@ RSpec.describe "Jobseekers can manage their profile" do
     end
 
     context "if the profile is inactive" do
-      let!(:profile) { create(:jobseeker_profile, jobseeker:, job_preferences:, active: false) }
+      let!(:profile) { create(:jobseeker_profile, :with_personal_details, jobseeker:, job_preferences:, active: false) }
 
       it "does not appear in search results" do
         visit publishers_jobseeker_profiles_path
@@ -495,7 +495,7 @@ RSpec.describe "Jobseekers can manage their profile" do
     let(:permitted_publisher) { create(:publisher) }
     let(:forbidden_publisher) { create(:publisher) }
 
-    let!(:profile) { create(:jobseeker_profile, jobseeker:, job_preferences:, active: true) }
+    let!(:profile) { create(:jobseeker_profile, :with_personal_details, jobseeker:, job_preferences:, active: true) }
 
     let(:job_preferences) do
       build(:job_preferences,


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/tDOWmWvA/1052-fix-content-accessibility-issues

## Changes in this PR:

This PR is to make some small content tweaks around the site, mainly rewriting link text and updating link destinations.

One of the main changes is updating the sign in buttons on the home screen - having 2 buttons that say the same thing but go to different places isn't very good for accessibility, and could also be potentially confusing for users skimming the homepage and looking to quickly sign in.

We've tried to preface the sign in buttons so that they say either 'jobseeker sign in' or 'hiring staff sign in' (and doing the same for the 'create an account' links) but I think by doing this we've broken something in the code (sorry!! 😬).

There's also a few other changes we'd like to make but couldn't manage ourselves, which I've commented on in the PR.

This PR was mainly to show Joe around GitHub/Codespaces, so if we've made it overly complicated by trying to change things ourselves, feel free to ditch the PR!!

No rush on these at all - just small tweaks it'd be good to make when we can.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
