### PR TITLE
Schedule export service to DWP find a job

### DIFF
--- a/app/jobs/export_vacancies_closed_early_since_yesterday_to_dwp_find_a_job_service_job.rb
+++ b/app/jobs/export_vacancies_closed_early_since_yesterday_to_dwp_find_a_job_service_job.rb
@@ -1,0 +1,9 @@
+class ExportVacanciesClosedEarlySinceYesterdayToDwpFindAJobServiceJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    return if DisableExpensiveJobs.enabled?
+
+    Vacancies::Export::DwpFindAJob::ClosedEarly.new(25.hours.ago).call
+  end
+end

--- a/app/jobs/export_vacancies_published_and_updated_since_yesterday_to_dwp_find_a_job_service_job.rb
+++ b/app/jobs/export_vacancies_published_and_updated_since_yesterday_to_dwp_find_a_job_service_job.rb
@@ -1,0 +1,9 @@
+class ExportVacanciesPublishedAndUpdatedSinceYesterdayToDwpFindAJobServiceJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    return if DisableExpensiveJobs.enabled?
+
+    Vacancies::Export::DwpFindAJob::PublishedAndUpdated.new(25.hours.ago).call
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -18,6 +18,16 @@ export_users:
   class: 'ExportDSIUsersToBigQueryJob'
   queue: low
 
+export_vacancies_published_and_updated_to_dwp_find_a_job_service:
+  cron: '30 23 * * *'
+  class: 'ExportVacanciesPublishedAndUpdatedSinceYesterdayToDwpFindAJobServiceJob'
+  queue: low
+
+export_vacancies_closed_early_to_dwp_find_a_job_service:
+  cron: '30 21 * * *'
+  class: 'ExportVacanciesClosedEarlySinceYesterdayToDwpFindAJobServiceJob'
+  queue: low
+
 import_organisation_data:
   cron: '0 22 * * *'
   class: 'ImportOrganisationDataJob'

--- a/spec/jobs/export_vacancies_closed_early_since_yesterday_to_dwp_find_a_job_service_job_spec.rb
+++ b/spec/jobs/export_vacancies_closed_early_since_yesterday_to_dwp_find_a_job_service_job_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe ExportVacanciesClosedEarlySinceYesterdayToDwpFindAJobServiceJob do
+  subject(:job) { described_class.perform_later }
+
+  let(:service) { instance_double(Vacancies::Export::DwpFindAJob::ClosedEarly, call: nil) }
+
+  before do
+    allow(Vacancies::Export::DwpFindAJob::ClosedEarly).to receive(:new).and_return(service)
+  end
+
+  context "when DisableExpensiveJobs is enabled" do
+    before { allow(DisableExpensiveJobs).to receive(:enabled?).and_return(true) }
+
+    it "does not call the service" do
+      perform_enqueued_jobs { job }
+      expect(Vacancies::Export::DwpFindAJob::ClosedEarly).not_to have_received(:new)
+    end
+  end
+
+  context "when DisableExpensiveJobs is not enabled" do
+    before { allow(DisableExpensiveJobs).to receive(:enabled?).and_return(false) }
+
+    it "calls the service passing the time 25 hours before now" do
+      freeze_time do
+        perform_enqueued_jobs { job }
+        expect(Vacancies::Export::DwpFindAJob::ClosedEarly).to have_received(:new).with(25.hours.ago)
+        expect(service).to have_received(:call)
+      end
+    end
+  end
+end

--- a/spec/jobs/export_vacancies_published_and_updated_since_yesterday_to_dwp_find_a_job_service_job_spec.rb
+++ b/spec/jobs/export_vacancies_published_and_updated_since_yesterday_to_dwp_find_a_job_service_job_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe ExportVacanciesPublishedAndUpdatedSinceYesterdayToDwpFindAJobServiceJob do
+  subject(:job) { described_class.perform_later }
+
+  let(:service) { instance_double(Vacancies::Export::DwpFindAJob::PublishedAndUpdated, call: nil) }
+
+  before do
+    allow(Vacancies::Export::DwpFindAJob::PublishedAndUpdated).to receive(:new).and_return(service)
+  end
+
+  context "when DisableExpensiveJobs is enabled" do
+    before { allow(DisableExpensiveJobs).to receive(:enabled?).and_return(true) }
+
+    it "does not call the service" do
+      perform_enqueued_jobs { job }
+      expect(Vacancies::Export::DwpFindAJob::PublishedAndUpdated).not_to have_received(:new)
+    end
+  end
+
+  context "when DisableExpensiveJobs is not enabled" do
+    before { allow(DisableExpensiveJobs).to receive(:enabled?).and_return(false) }
+
+    it "calls the service passing the time 25 hours before now" do
+      freeze_time do
+        perform_enqueued_jobs { job }
+        expect(Vacancies::Export::DwpFindAJob::PublishedAndUpdated).to have_received(:new).with(25.hours.ago)
+        expect(service).to have_received(:call)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/MGIXSJIZ

## Changes in this PR:

- schedule daily export of vacancies to DWP Find a Job service.
- extend the documentation with information about the schedule and how to debug/test the integration.
