### PR TITLE
Remove line breaks from jobs sent to find a job service

### DIFF
--- a/app/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy.rb
+++ b/app/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy.rb
@@ -67,7 +67,7 @@ module Vacancies::Export::DwpFindAJob::PublishedAndUpdatedVacancies
     private
 
     def description_paragraph(title, text)
-      plain_text = ActionText::Fragment.from_html(text).to_plain_text
+      plain_text = ActionText::Fragment.from_html(text&.squish).to_plain_text
       plain_text.present? ? "#{title}\n\n#{plain_text}\n\n" : ""
     end
   end

--- a/spec/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy_spec.rb
+++ b/spec/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy_spec.rb
@@ -123,13 +123,27 @@ RSpec.describe Vacancies::Export::DwpFindAJob::PublishedAndUpdated::ParsedVacanc
     context "when the vacancy job details have html tags" do
       before do
         allow(vacancy).to receive(:skills_and_experience).and_return(
-          "<p>First paragraph</p><ul><li>Item 0</li><li>Item 1<ul><li>Item A<ol><li>Item i</li><li>Item ii</li></ol></li><li>Item B<ul><li>Item i</li></ul></li></ul></li><li>Item 2</li></ul><p><a href='url'>link text</a>",
+          "<p>First paragraph</p><ul><li>Item 0</li><li>Item 1<ul><li>Item A<ol><li>Item i</li><li>Item ii</li></ol></li><li>Item B<ul><li>Item i</li></ul></li></ul></li><li>Item 2</li></ul><p><a href='url'>link text</a></p>",
         )
       end
 
       it "return the html content parsed into plain text" do
         expect(parsed.description).to eq(
           "What skills and experience we're looking for\n\nFirst paragraph\n\n• Item 0\n• Item 1\n  • Item A\n    1. Item i\n    2. Item ii\n  • Item B\n    • Item i\n• Item 2\n\nlink text",
+        )
+      end
+    end
+
+    context "when the vacancy job details have html tags mixed with carriage return symbols" do
+      before do
+        allow(vacancy).to receive(:skills_and_experience).and_return(
+          "<p>First\r\nparagraph</p><ul><li>Item 0</li><li>Item\r\n1</li></ul><p>Last paragraph</p>",
+        )
+      end
+
+      it "return the html content parsed into plain text with the carriage symbols turned into spaces" do
+        expect(parsed.description).to eq(
+          "What skills and experience we're looking for\n\nFirst paragraph\n\n• Item 0\n• Item 1\n\nLast paragraph",
         )
       end
     end


### PR DESCRIPTION
The stored HTML in DB used for the job descriptions contains carriage returns that we do not want to display in the DWP Find a Job advert, as they break sentences instead of respecting the HTML parsing structure into plain text.

We now remove them before parsing the HTML context into plain text for the export.


## Screenshots of UI changes:
### Issue on our service vs DWP Find a Job output display
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/89b06ae6-6c33-45aa-8f84-721dd3a3e53c)

### Cause of the issue (`\r\n`)
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/6a72d160-34eb-4857-918f-97b5fbf4e30a)
