### PR TITLE
Application data

### DIFF
--- a/app/controllers/jobseekers/job_applications_controller.rb
+++ b/app/controllers/jobseekers/job_applications_controller.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/ClassLength
 class Jobseekers::JobApplicationsController < Jobseekers::JobApplications::BaseController
   include Jobseekers::QualificationFormConcerns
 
@@ -42,7 +41,7 @@ class Jobseekers::JobApplicationsController < Jobseekers::JobApplications::BaseC
     raise ActionController::RoutingError, "Cannot quick apply if there's no profile or non-draft applications" unless quick_apply?
 
     new_job_application = prefill_job_application_with_available_data
-    
+
     redirect_to jobseekers_job_application_review_path(new_job_application)
   end
 
@@ -219,4 +218,3 @@ class Jobseekers::JobApplicationsController < Jobseekers::JobApplications::BaseC
     previous_application? || profile.present?
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/controllers/jobseekers/job_applications_controller.rb
+++ b/app/controllers/jobseekers/job_applications_controller.rb
@@ -34,16 +34,17 @@ class Jobseekers::JobApplicationsController < Jobseekers::JobApplications::BaseC
   # rubocop:enable Style/GuardClause
 
   def new_quick_apply
+    @has_previous_application = previous_application?
     raise ActionController::RoutingError, "Cannot quick apply if there's no profile or non-draft applications" unless quick_apply?
   end
 
   def quick_apply
     raise ActionController::RoutingError, "Cannot quick apply if there's no profile or non-draft applications" unless quick_apply?
 
-    new_job_application = if profile
-                            current_jobseeker.job_applications.build(vacancy:)
-                          else
+    new_job_application = if previous_application?
                             Jobseekers::JobApplications::QuickApply.new(current_jobseeker, vacancy).job_application
+                          else
+                            current_jobseeker.job_applications.build(vacancy:)
                           end
 
     prefill_application(new_job_application)
@@ -209,6 +210,7 @@ class Jobseekers::JobApplicationsController < Jobseekers::JobApplications::BaseC
   end
 
   def prefill_application(application)
+    return if previous_application?
     return unless profile.present?
 
     application.assign_attributes(
@@ -224,6 +226,7 @@ class Jobseekers::JobApplicationsController < Jobseekers::JobApplications::BaseC
     )
 
     mark_step_completion(application)
+    application
   end
 
   def profile_right_to_work

--- a/app/controllers/jobseekers/job_applications_controller.rb
+++ b/app/controllers/jobseekers/job_applications_controller.rb
@@ -42,7 +42,7 @@ class Jobseekers::JobApplicationsController < Jobseekers::JobApplications::BaseC
 
     new_job_application = prefill_job_application_with_available_data
 
-    redirect_to jobseekers_job_application_review_path(new_job_application)
+    redirect_to jobseekers_job_application_review_path(new_job_application), notice: t("jobseekers.job_applications.new_quick_apply.import_from_previous_application")
   end
 
   def submit

--- a/app/helpers/job_applications_helper.rb
+++ b/app/helpers/job_applications_helper.rb
@@ -120,6 +120,10 @@ module JobApplicationsHelper
     job_application.in_progress_steps.include?(step.to_s)
   end
 
+  def job_application_step_imported?(job_application, step)
+    job_application.imported_steps.include?(step.to_s)
+  end
+
   def visa_sponsorship_needed_answer(job_application)
     return unless job_application.right_to_work_in_uk.present?
 

--- a/app/helpers/status_tag_helper.rb
+++ b/app/helpers/status_tag_helper.rb
@@ -1,6 +1,8 @@
 module StatusTagHelper
   def review_section_tag(resource, steps, form_classes)
-    if form_classes.all?(&:optional?)
+    if resource.is_a?(JobApplication) && steps.all? { |step| job_application_step_imported?(resource, step) }
+      imported
+    elsif form_classes.all?(&:optional?)
       optional
     elsif resource.is_a?(JobApplication) && steps.all? { |step| job_application_step_in_progress?(resource, step) }
       in_progress
@@ -43,5 +45,9 @@ module StatusTagHelper
 
   def in_progress
     govuk_tag(text: t("shared.status_tags.in_progress"), colour: "yellow")
+  end
+
+  def imported
+    govuk_tag(text: t("shared.status_tags.imported"), colour: "blue")
   end
 end

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -18,6 +18,19 @@ class JobApplication < ApplicationRecord
     declarations: 8,
   }
 
+  array_enum imported_steps: {
+    personal_details: 0,
+    professional_status: 1,
+    qualifications: 2,
+    training_and_cpds: 9,
+    employment_history: 3,
+    personal_statement: 4,
+    references: 5,
+    equal_opportunities: 6,
+    ask_for_support: 7,
+    declarations: 8,
+  }
+
   array_enum in_progress_steps: {
     qualifications: 0,
     employment_history: 1,

--- a/app/services/jobseekers/job_applications/prefill_job_application_from_jobseeker_profile.rb
+++ b/app/services/jobseekers/job_applications/prefill_job_application_from_jobseeker_profile.rb
@@ -1,0 +1,88 @@
+class Jobseekers::JobApplications::PrefillJobApplicationFromJobseekerProfile
+  attr_reader :jobseeker, :vacancy, :new_job_application
+
+  def initialize(jobseeker, vacancy, new_job_application)
+    @jobseeker = jobseeker
+    @vacancy = vacancy
+    @new_job_application = new_job_application
+  end
+
+  def call
+    copy_personal_info
+    copy_qualifications
+    copy_employments
+    copy_training_and_cpds
+    set_status_of_each_step
+    new_job_application.save
+    new_job_application
+  end
+
+  def copy_personal_info
+    new_job_application.assign_attributes(
+      first_name: jobseeker_profile.personal_details&.first_name,
+      last_name: jobseeker_profile.personal_details&.last_name,
+      phone_number: jobseeker_profile.personal_details&.phone_number,
+      qualified_teacher_status_year: jobseeker_profile.qualified_teacher_status_year || "",
+      qualified_teacher_status: jobseeker_profile.qualified_teacher_status || "",
+      right_to_work_in_uk: jobseeker_right_to_work,
+    )
+  end
+
+  def copy_qualifications
+    jobseeker_profile.qualifications.each do |qualification|
+      new_qualification = qualification.dup
+      new_qualification.update(job_application: new_job_application)
+
+      qualification.qualification_results.each do |result|
+        new_result = result.dup
+        new_result.update(qualification: new_qualification)
+      end
+    end
+
+    new_job_application.qualifications_section_completed = false
+  end
+
+  def copy_employments
+    jobseeker_profile.employments.each do |employment|
+      new_employment = employment.dup
+      new_employment.update(job_application: new_job_application, salary: "")
+    end
+
+    new_job_application.employment_history_section_completed = false
+  end
+
+  def copy_training_and_cpds
+    jobseeker_profile.training_and_cpds.each do |training|
+      new_training = training.dup
+      new_training.update(job_application: new_job_application)
+    end
+
+    new_job_application.training_and_cpds_section_completed = false
+  end
+
+  # rubocop:disable Metrics/AbcSize
+  def set_status_of_each_step
+    new_job_application.completed_steps = []
+    new_job_application.imported_steps = []
+
+    if new_job_application.first_name.present? || new_job_application.last_name.present? || new_job_application.phone_number.present? || new_job_application.right_to_work_in_uk.present?
+      new_job_application.in_progress_steps += [:personal_details]
+    end
+
+    new_job_application.in_progress_steps += [:employment_history] if new_job_application.employments.any?
+    new_job_application.in_progress_steps += [:professional_status] if new_job_application.qualified_teacher_status.present?
+    new_job_application.in_progress_steps += [:training_and_cpds] if new_job_application.training_and_cpds.any?
+    new_job_application.in_progress_steps += [:qualifications] if new_job_application.qualifications.present?
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  def jobseeker_right_to_work
+    return "" if jobseeker_profile.personal_details&.right_to_work_in_uk.nil?
+
+    jobseeker_profile.personal_details.right_to_work_in_uk? ? "yes" : "no"
+  end
+
+  def jobseeker_profile
+    @jobseeker_profile ||= jobseeker.jobseeker_profile
+  end
+end

--- a/app/services/jobseekers/job_applications/prefill_job_application_from_previous_application.rb
+++ b/app/services/jobseekers/job_applications/prefill_job_application_from_previous_application.rb
@@ -87,8 +87,9 @@ class Jobseekers::JobApplications::PrefillJobApplicationFromPreviousApplication
   end
 
   def completed_steps
-    completed_steps = %w[personal_details professional_status personal_statement references ask_for_support qualifications training_and_cpds].select { |step| relevant_steps.include?(step.to_sym) }
+    completed_steps = %w[personal_details personal_statement references ask_for_support qualifications training_and_cpds].select { |step| relevant_steps.include?(step.to_sym) }
     completed_steps << "employment_history" unless previous_application_was_submitted_before_we_began_validating_gaps_in_work_history?
+    completed_steps << "professional_status" if previous_application_has_professional_status_details?
     completed_steps
   end
 
@@ -106,5 +107,9 @@ class Jobseekers::JobApplications::PrefillJobApplicationFromPreviousApplication
 
   def previous_application_was_submitted_before_we_began_validating_gaps_in_work_history?
     recent_job_application.submitted_at < DateTime.strptime("Apr 3 10:34:11 2024 +0100", "%b %d %H:%M:%S %Y %z")
+  end
+
+  def previous_application_has_professional_status_details?
+    recent_job_application.ask_professional_status?
   end
 end

--- a/app/services/jobseekers/job_applications/prefill_job_application_from_previous_application.rb
+++ b/app/services/jobseekers/job_applications/prefill_job_application_from_previous_application.rb
@@ -1,0 +1,96 @@
+class Jobseekers::JobApplications::PrefillJobApplicationFromPreviousApplication
+  attr_reader :jobseeker, :vacancy, :new_job_application
+
+  def initialize(jobseeker, vacancy, new_job_application)
+    @jobseeker = jobseeker
+    @vacancy = vacancy
+    @new_job_application = new_job_application
+  end
+
+  def call
+    copy_personal_info
+    copy_qualifications
+    copy_employments
+    copy_references
+    copy_training_and_cpds
+    set_status_of_each_step
+    new_job_application.save
+    new_job_application
+  end
+
+  private
+
+  def copy_personal_info
+    new_job_application.assign_attributes(recent_job_application.slice(*attributes_to_copy))
+  end
+
+  def attributes_to_copy
+    %i[personal_details professional_status ask_for_support personal_statement].select { |step| relevant_steps.include?(step) }
+                                                                               .map { |step| form_fields_from_step(step) }
+                                                                               .flatten
+  end
+
+  def copy_qualifications
+    recent_job_application.qualifications.each do |qualification|
+      new_qualification = qualification.dup
+      new_qualification.update(job_application: new_job_application)
+
+      qualification.qualification_results.each do |result|
+        new_result = result.dup
+        new_result.update(qualification: new_qualification)
+      end
+    end
+
+    new_job_application.qualifications_section_completed = true
+  end
+
+  def copy_employments
+    recent_job_application.employments.each do |employment|
+      new_employment = employment.dup
+      new_employment.update(job_application: new_job_application, salary: "")
+    end
+
+    new_job_application.employment_history_section_completed = true
+  end
+
+  def copy_references
+    recent_job_application.references.each do |reference|
+      new_reference = reference.dup
+      new_reference.update(job_application: new_job_application)
+    end
+  end
+
+  def copy_training_and_cpds
+    recent_job_application.training_and_cpds.each do |training|
+      new_training = training.dup
+      new_training.update(job_application: new_job_application)
+    end
+
+    new_job_application.training_and_cpds_section_completed = true
+  end
+
+  def set_status_of_each_step
+    new_job_application.completed_steps = completed_steps
+    new_job_application.imported_steps = completed_steps
+    new_job_application.in_progress_steps = []
+  end
+
+  def recent_job_application
+    @recent_job_application ||= jobseeker.job_applications.not_draft.order(submitted_at: :desc).first
+  end
+
+  def relevant_steps
+    # The step process is needed in order to filter out the steps that are not relevant to the new job application,
+    # for eg. professional status - see https://github.com/DFE-Digital/teaching-vacancies/blob/75cec792d9e229fb866bdafc017f82501bd01001/app/services/jobseekers/job_applications/job_application_step_process.rb#L23
+    # The review step is used as a current step is required.
+    Jobseekers::JobApplications::JobApplicationStepProcess.new(:review, job_application: new_job_application).steps
+  end
+
+  def completed_steps
+    %w[personal_details professional_status personal_statement references ask_for_support qualifications employment_history training_and_cpds].select { |step| relevant_steps.include?(step.to_sym) }
+  end
+
+  def form_fields_from_step(step)
+    "jobseekers/job_application/#{step}_form".camelize.constantize.fields
+  end
+end

--- a/app/services/jobseekers/job_applications/quick_apply.rb
+++ b/app/services/jobseekers/job_applications/quick_apply.rb
@@ -7,22 +7,68 @@ class Jobseekers::JobApplications::QuickApply
   end
 
   def job_application
-    new_job_application.assign_attributes(recent_job_application.slice(*attributes_to_copy))
-    set_status_of_each_step
-    copy_qualifications
-    copy_employments
-    copy_references
-    copy_training_and_cpds
+    return new_job_application unless previously_submitted_application? || jobseeker_profile
+
+    source = previously_submitted_application? ? recent_job_application : jobseeker_profile
+    copy_personal_info(source)
+    copy_qualifications(source)
+    copy_employments(source)
+    copy_references(source)
+    copy_training_and_cpds(source)
+    set_status_of_each_step(source)
     new_job_application.save
     new_job_application
   end
 
   private
 
-  def set_status_of_each_step
+  def copy_personal_info(source)
+    if source.is_a? JobApplication
+      new_job_application.assign_attributes(recent_job_application.slice(*attributes_to_copy))
+    elsif source.is_a? JobseekerProfile
+      new_job_application.assign_attributes(
+        first_name: jobseeker_profile.personal_details&.first_name,
+        last_name: jobseeker_profile.personal_details&.last_name,
+        phone_number: jobseeker_profile.personal_details&.phone_number,
+        qualified_teacher_status_year: jobseeker_profile.qualified_teacher_status_year || "",
+        qualified_teacher_status: jobseeker_profile.qualified_teacher_status || "",
+        right_to_work_in_uk: jobseeker_right_to_work,
+      )
+    end
+  end
+
+  def jobseeker_right_to_work
+    return "" if jobseeker_profile.personal_details&.right_to_work_in_uk.nil?
+
+    jobseeker_profile.personal_details.right_to_work_in_uk? ? "yes" : "no"
+  end
+
+  def set_status_of_each_step(source)
+    if source.is_a? JobApplication
+      set_step_statuses_for_import_from_job_application
+    elsif source.is_a? JobseekerProfile
+      set_step_statuses_for_import_from_jobseeker_profile
+    end
+  end
+
+  def set_step_statuses_for_import_from_job_application
     new_job_application.completed_steps = completed_steps
     new_job_application.imported_steps = completed_steps
     new_job_application.in_progress_steps = []
+  end
+
+  def set_step_statuses_for_import_from_jobseeker_profile
+    new_job_application.completed_steps = []
+    new_job_application.imported_steps = []
+
+    if new_job_application.first_name.present? || new_job_application.last_name.present? || new_job_application.phone_number.present? || new_job_application.right_to_work_in_uk.present?
+      new_job_application.in_progress_steps += [:personal_details]
+    end
+
+    new_job_application.in_progress_steps += [:employment_history] if new_job_application.employments.any?
+    new_job_application.in_progress_steps += [:professional_status] if new_job_application.qualified_teacher_status.present?
+    new_job_application.in_progress_steps += [:training_and_cpds] if new_job_application.training_and_cpds.any?
+    new_job_application.in_progress_steps += [:qualifications] if new_job_application.qualifications.present?
   end
 
   def relevant_steps
@@ -58,8 +104,8 @@ class Jobseekers::JobApplications::QuickApply
     %w[]
   end
 
-  def copy_qualifications
-    recent_job_application.qualifications.each do |qualification|
+  def copy_qualifications(source)
+    source.qualifications.each do |qualification|
       new_qualification = qualification.dup
       new_qualification.update(job_application: new_job_application)
 
@@ -68,32 +114,51 @@ class Jobseekers::JobApplications::QuickApply
         new_result.update(qualification: new_qualification)
       end
     end
-    new_job_application.qualifications_section_completed = true
+    
+    qualifications_section_completed = true if source.is_a? JobApplication
+    qualifications_section_completed = false if source.is_a? JobseekerProfile
+
+    new_job_application.qualifications_section_completed = qualifications_section_completed
   end
 
-  def copy_employments
-    recent_job_application.employments.each do |employment|
+  def copy_employments(source)
+    source.employments.each do |employment|
       new_employment = employment.dup
       new_employment.update(job_application: new_job_application, salary: "")
     end
-    new_job_application.employment_history_section_completed = true
+
+    employment_section_completed = true if source.is_a? JobApplication
+    employment_section_completed = false if source.is_a? JobseekerProfile
+
+    new_job_application.employment_history_section_completed = employment_section_completed
   end
 
-  def copy_references
-    recent_job_application.references.each do |reference|
+  def copy_references(source)
+    return unless source.is_a? JobApplication
+
+    source.references.each do |reference|
       new_reference = reference.dup
       new_reference.update(job_application: new_job_application)
     end
   end
 
-  def copy_training_and_cpds
-    return if recent_job_application.training_and_cpds.empty?
-
-    recent_job_application.training_and_cpds.each do |training|
+  def copy_training_and_cpds(source)
+    source.training_and_cpds.each do |training|
       new_training = training.dup
       new_training.update(job_application: new_job_application)
     end
 
-    new_job_application.training_and_cpds_section_completed = true
+    training_section_completed = true if source.is_a? JobApplication
+    training_section_completed = false if source.is_a? JobseekerProfile
+
+    new_job_application.training_and_cpds_section_completed = training_section_completed
+  end
+
+  def previously_submitted_application?
+    jobseeker.job_applications.not_draft.any?
+  end
+  
+  def jobseeker_profile
+    @jobseeker_profile ||= jobseeker.jobseeker_profile
   end
 end

--- a/app/services/jobseekers/job_applications/quick_apply.rb
+++ b/app/services/jobseekers/job_applications/quick_apply.rb
@@ -7,7 +7,8 @@ class Jobseekers::JobApplications::QuickApply
   end
 
   def job_application
-    new_job_application.assign_attributes(recent_job_application.slice(*attributes_to_copy).merge(completed_steps: completed_steps, in_progress_steps: in_progress_steps))
+    new_job_application.assign_attributes(recent_job_application.slice(*attributes_to_copy))
+    set_status_of_each_step
     copy_qualifications
     copy_employments
     copy_references
@@ -17,6 +18,12 @@ class Jobseekers::JobApplications::QuickApply
   end
 
   private
+
+  def set_status_of_each_step
+    new_job_application.completed_steps = completed_steps
+    new_job_application.imported_steps = completed_steps
+    new_job_application.in_progress_steps = []
+  end
 
   def relevant_steps
     # The step process is needed in order to filter out the steps that are not relevant to the new job application,
@@ -44,11 +51,11 @@ class Jobseekers::JobApplications::QuickApply
   end
 
   def completed_steps
-    %w[personal_details professional_status references ask_for_support].select { |step| relevant_steps.include?(step.to_sym) }
+    %w[personal_details professional_status references ask_for_support qualifications employment_history training_and_cpds].select { |step| relevant_steps.include?(step.to_sym) }
   end
 
   def in_progress_steps
-    %w[qualifications employment_history professional_status]
+    %w[]
   end
 
   def copy_qualifications
@@ -61,7 +68,7 @@ class Jobseekers::JobApplications::QuickApply
         new_result.update(qualification: new_qualification)
       end
     end
-    new_job_application.qualifications_section_completed = false
+    new_job_application.qualifications_section_completed = true
   end
 
   def copy_employments
@@ -69,7 +76,7 @@ class Jobseekers::JobApplications::QuickApply
       new_employment = employment.dup
       new_employment.update(job_application: new_job_application, salary: "")
     end
-    new_job_application.employment_history_section_completed = false
+    new_job_application.employment_history_section_completed = true
   end
 
   def copy_references
@@ -87,8 +94,6 @@ class Jobseekers::JobApplications::QuickApply
       new_training.update(job_application: new_job_application)
     end
 
-    new_job_application.training_and_cpds_section_completed = false
-    in_progress_steps = new_job_application.in_progress_steps + ["training_and_cpds"]
-    new_job_application.in_progress_steps = in_progress_steps
+    new_job_application.training_and_cpds_section_completed = true
   end
 end

--- a/app/services/jobseekers/job_applications/quick_apply.rb
+++ b/app/services/jobseekers/job_applications/quick_apply.rb
@@ -57,6 +57,7 @@ class Jobseekers::JobApplications::QuickApply
     new_job_application.in_progress_steps = []
   end
 
+  # rubocop:disable Metrics/AbcSize
   def set_step_statuses_for_import_from_jobseeker_profile
     new_job_application.completed_steps = []
     new_job_application.imported_steps = []
@@ -70,6 +71,7 @@ class Jobseekers::JobApplications::QuickApply
     new_job_application.in_progress_steps += [:training_and_cpds] if new_job_application.training_and_cpds.any?
     new_job_application.in_progress_steps += [:qualifications] if new_job_application.qualifications.present?
   end
+  # rubocop:enable Metrics/AbcSize
 
   def relevant_steps
     # The step process is needed in order to filter out the steps that are not relevant to the new job application,
@@ -114,7 +116,7 @@ class Jobseekers::JobApplications::QuickApply
         new_result.update(qualification: new_qualification)
       end
     end
-    
+
     qualifications_section_completed = true if source.is_a? JobApplication
     qualifications_section_completed = false if source.is_a? JobseekerProfile
 
@@ -157,7 +159,7 @@ class Jobseekers::JobApplications::QuickApply
   def previously_submitted_application?
     jobseeker.job_applications.not_draft.any?
   end
-  
+
   def jobseeker_profile
     @jobseeker_profile ||= jobseeker.jobseeker_profile
   end

--- a/app/services/jobseekers/job_applications/quick_apply.rb
+++ b/app/services/jobseekers/job_applications/quick_apply.rb
@@ -34,9 +34,9 @@ class Jobseekers::JobApplications::QuickApply
   end
 
   def attributes_to_copy
-    %i[personal_details professional_status ask_for_support].select { |step| relevant_steps.include?(step) }
-                                                            .map { |step| form_fields_from_step(step) }
-                                                            .flatten
+    %i[personal_details professional_status ask_for_support personal_statement].select { |step| relevant_steps.include?(step) }
+                                                                               .map { |step| form_fields_from_step(step) }
+                                                                               .flatten
   end
 
   def form_fields_from_step(step)

--- a/app/services/jobseekers/job_applications/quick_apply.rb
+++ b/app/services/jobseekers/job_applications/quick_apply.rb
@@ -9,151 +9,17 @@ class Jobseekers::JobApplications::QuickApply
   def job_application
     return new_job_application unless previously_submitted_application? || jobseeker_profile
 
-    source = previously_submitted_application? ? recent_job_application : jobseeker_profile
-    copy_personal_info(source)
-    copy_qualifications(source)
-    copy_employments(source)
-    copy_references(source)
-    copy_training_and_cpds(source)
-    set_status_of_each_step(source)
-    new_job_application.save
-    new_job_application
+    if previously_submitted_application?
+      return Jobseekers::JobApplications::PrefillJobApplicationFromPreviousApplication.new(jobseeker, vacancy, new_job_application).call
+    end
+
+    Jobseekers::JobApplications::PrefillJobApplicationFromJobseekerProfile.new(jobseeker, vacancy, new_job_application).call
   end
 
   private
 
-  def copy_personal_info(source)
-    if source.is_a? JobApplication
-      new_job_application.assign_attributes(recent_job_application.slice(*attributes_to_copy))
-    elsif source.is_a? JobseekerProfile
-      new_job_application.assign_attributes(
-        first_name: jobseeker_profile.personal_details&.first_name,
-        last_name: jobseeker_profile.personal_details&.last_name,
-        phone_number: jobseeker_profile.personal_details&.phone_number,
-        qualified_teacher_status_year: jobseeker_profile.qualified_teacher_status_year || "",
-        qualified_teacher_status: jobseeker_profile.qualified_teacher_status || "",
-        right_to_work_in_uk: jobseeker_right_to_work,
-      )
-    end
-  end
-
-  def jobseeker_right_to_work
-    return "" if jobseeker_profile.personal_details&.right_to_work_in_uk.nil?
-
-    jobseeker_profile.personal_details.right_to_work_in_uk? ? "yes" : "no"
-  end
-
-  def set_status_of_each_step(source)
-    if source.is_a? JobApplication
-      set_step_statuses_for_import_from_job_application
-    elsif source.is_a? JobseekerProfile
-      set_step_statuses_for_import_from_jobseeker_profile
-    end
-  end
-
-  def set_step_statuses_for_import_from_job_application
-    new_job_application.completed_steps = completed_steps
-    new_job_application.imported_steps = completed_steps
-    new_job_application.in_progress_steps = []
-  end
-
-  # rubocop:disable Metrics/AbcSize
-  def set_step_statuses_for_import_from_jobseeker_profile
-    new_job_application.completed_steps = []
-    new_job_application.imported_steps = []
-
-    if new_job_application.first_name.present? || new_job_application.last_name.present? || new_job_application.phone_number.present? || new_job_application.right_to_work_in_uk.present?
-      new_job_application.in_progress_steps += [:personal_details]
-    end
-
-    new_job_application.in_progress_steps += [:employment_history] if new_job_application.employments.any?
-    new_job_application.in_progress_steps += [:professional_status] if new_job_application.qualified_teacher_status.present?
-    new_job_application.in_progress_steps += [:training_and_cpds] if new_job_application.training_and_cpds.any?
-    new_job_application.in_progress_steps += [:qualifications] if new_job_application.qualifications.present?
-  end
-  # rubocop:enable Metrics/AbcSize
-
-  def relevant_steps
-    # The step process is needed in order to filter out the steps that are not relevant to the new job application,
-    # for eg. professional status - see https://github.com/DFE-Digital/teaching-vacancies/blob/75cec792d9e229fb866bdafc017f82501bd01001/app/services/jobseekers/job_applications/job_application_step_process.rb#L23
-    # The review step is used as a current step is required.
-    Jobseekers::JobApplications::JobApplicationStepProcess.new(:review, job_application: new_job_application).steps
-  end
-
   def new_job_application
     @new_job_application ||= jobseeker.job_applications.create(vacancy: vacancy)
-  end
-
-  def recent_job_application
-    @recent_job_application ||= jobseeker.job_applications.not_draft.order(submitted_at: :desc).first
-  end
-
-  def attributes_to_copy
-    %i[personal_details professional_status ask_for_support personal_statement].select { |step| relevant_steps.include?(step) }
-                                                                               .map { |step| form_fields_from_step(step) }
-                                                                               .flatten
-  end
-
-  def form_fields_from_step(step)
-    "jobseekers/job_application/#{step}_form".camelize.constantize.fields
-  end
-
-  def completed_steps
-    %w[personal_details professional_status personal_statement references ask_for_support qualifications employment_history training_and_cpds].select { |step| relevant_steps.include?(step.to_sym) }
-  end
-
-  def in_progress_steps
-    %w[]
-  end
-
-  def copy_qualifications(source)
-    source.qualifications.each do |qualification|
-      new_qualification = qualification.dup
-      new_qualification.update(job_application: new_job_application)
-
-      qualification.qualification_results.each do |result|
-        new_result = result.dup
-        new_result.update(qualification: new_qualification)
-      end
-    end
-
-    qualifications_section_completed = true if source.is_a? JobApplication
-    qualifications_section_completed = false if source.is_a? JobseekerProfile
-
-    new_job_application.qualifications_section_completed = qualifications_section_completed
-  end
-
-  def copy_employments(source)
-    source.employments.each do |employment|
-      new_employment = employment.dup
-      new_employment.update(job_application: new_job_application, salary: "")
-    end
-
-    employment_section_completed = true if source.is_a? JobApplication
-    employment_section_completed = false if source.is_a? JobseekerProfile
-
-    new_job_application.employment_history_section_completed = employment_section_completed
-  end
-
-  def copy_references(source)
-    return unless source.is_a? JobApplication
-
-    source.references.each do |reference|
-      new_reference = reference.dup
-      new_reference.update(job_application: new_job_application)
-    end
-  end
-
-  def copy_training_and_cpds(source)
-    source.training_and_cpds.each do |training|
-      new_training = training.dup
-      new_training.update(job_application: new_job_application)
-    end
-
-    training_section_completed = true if source.is_a? JobApplication
-    training_section_completed = false if source.is_a? JobseekerProfile
-
-    new_job_application.training_and_cpds_section_completed = training_section_completed
   end
 
   def previously_submitted_application?

--- a/app/services/jobseekers/job_applications/quick_apply.rb
+++ b/app/services/jobseekers/job_applications/quick_apply.rb
@@ -51,7 +51,7 @@ class Jobseekers::JobApplications::QuickApply
   end
 
   def completed_steps
-    %w[personal_details professional_status references ask_for_support qualifications employment_history training_and_cpds].select { |step| relevant_steps.include?(step.to_sym) }
+    %w[personal_details professional_status personal_statement references ask_for_support qualifications employment_history training_and_cpds].select { |step| relevant_steps.include?(step.to_sym) }
   end
 
   def in_progress_steps

--- a/app/views/jobseekers/job_applications/new_quick_apply.html.slim
+++ b/app/views/jobseekers/job_applications/new_quick_apply.html.slim
@@ -6,7 +6,7 @@ h2.govuk-heading-xl = t("jobseekers.job_applications.heading")
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     h1.govuk-heading-l = t(".heading")
-    p.govuk-body = (profile ? t(".description1_profile") : t(".description1"))
+    p.govuk-body = (@has_previous_application ? t(".description1") : t(".description1_profile"))
     p.govuk-body = t(".description2")
     p.govuk-body = t(".description3")
     p.govuk-body = t(".save_and_return")

--- a/app/views/jobseekers/job_applications/review.html.slim
+++ b/app/views/jobseekers/job_applications/review.html.slim
@@ -55,6 +55,9 @@
         = f.govuk_check_boxes_fieldset :confirm_data_usage, multiple: false, legend: nil do
           = f.govuk_check_box :confirm_data_usage, "1", 0, multiple: false, link_errors: true
 
+        p.govuk-body
+          = t(".confirmation.resubmission_warning")
+
         - if vacancy.listed?
           = f.govuk_submit t("buttons.submit_application") do
             = govuk_link_to t("buttons.cancel_and_return_to_account"), jobseekers_job_applications_path, class: "govuk-link--no-visited-state"

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -143,6 +143,7 @@ shared:
     - safeguarding_issue
     - safeguarding_issue_details
     - training_and_cpds_section_completed
+    - imported_steps
   job_preferences_locations:
     - id
     - job_preferences_id

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -315,6 +315,7 @@ en:
       in_progress: in progress
       not_started: not started
       optional: optional
+      imported: imported
 
   stats:
     intro: >-

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -339,6 +339,7 @@ en:
           heading: Terms & Conditions
           privacy: privacy policy
           terms: terms and conditions
+        import_from_previous_application: Your details have been imported from your last job application. You should review each section to make sure the information is correct.
         description1: >-
           Your details have been imported from your last job application.
         description2: You should review this information before submitting.

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -339,7 +339,7 @@ en:
           heading: Terms & Conditions
           privacy: privacy policy
           terms: terms and conditions
-        import_from_previous_application: Your details have been imported from your last job application. You should review each section to make sure the information is correct.
+        import_from_previous_application: Your details have been imported from your last job application. You should review each section to make sure the information is still accurate.
         description1: >-
           Your details have been imported from your last job application.
         description2: You should review this information before submitting.

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -417,6 +417,7 @@ en:
             privacy_policy:
               description_html: Please read the Teaching Vacancies %{link_to} for more information on how your data is used.
               link_text: Privacy Policy
+          resubmission_warning: You cannot edit your application after submitting. If you withdraw your application, you will not be able to resubmit.
         deadline_passed: The deadline for this job listing has passed
         employment_history:
           none: You have not added any roles or employment history.

--- a/db/migrate/20240624110124_add_imported_steps_to_job_applications.rb
+++ b/db/migrate/20240624110124_add_imported_steps_to_job_applications.rb
@@ -1,0 +1,5 @@
+class AddImportedStepsToJobApplications < ActiveRecord::Migration[7.1]
+  def change
+    add_column :job_applications, :imported_steps, :integer, default: [], null: false, array: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_13_143058) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_24_110124) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -76,9 +76,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_13_143058) do
     t.uuid "job_application_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "organisation_ciphertext"
     t.integer "employment_type", default: 0
     t.text "reason_for_break", default: ""
+    t.text "organisation_ciphertext"
     t.text "job_title_ciphertext"
     t.text "main_duties_ciphertext"
     t.uuid "jobseeker_profile_id"
@@ -243,6 +243,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_13_143058) do
     t.string "safeguarding_issue"
     t.text "safeguarding_issue_details"
     t.boolean "training_and_cpds_section_completed"
+    t.integer "imported_steps", default: [], null: false, array: true
     t.index ["jobseeker_id"], name: "index_job_applications_jobseeker_id"
     t.index ["vacancy_id"], name: "index_job_applications_on_vacancy_id"
   end
@@ -651,11 +652,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_13_143058) do
     t.string "external_reference"
     t.string "external_advert_url"
     t.integer "ect_status"
+    t.string "pay_scale"
+    t.boolean "benefits"
     t.text "full_time_details"
     t.text "part_time_details"
     t.integer "phases", array: true
-    t.string "pay_scale"
-    t.boolean "benefits"
     t.integer "start_date_type"
     t.date "earliest_start_date"
     t.date "latest_start_date"

--- a/spec/factories/qualifications.rb
+++ b/spec/factories/qualifications.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
     finished_studying_details { finished_studying == false ? "Stopped due to illness" : "" }
     grade do
       if gcse? || a_level? || as_level?
-        factory_sample(["A", "B", "C"])
+        factory_sample(%w[A B C])
       elsif finished_studying?
         undergraduate? || postgraduate? ? factory_sample(["2.1", "2.2", "Honours"]) : factory_sample(%w[Pass Merit Distinction])
       else

--- a/spec/factories/qualifications.rb
+++ b/spec/factories/qualifications.rb
@@ -13,10 +13,12 @@ FactoryBot.define do
     end
 
     category { factory_sample(Qualification.categories.keys) }
-    finished_studying { undergraduate? || postgraduate? || other? ? Faker::Boolean.boolean : nil }
+    finished_studying { undergraduate? || postgraduate? || other? ? Faker::Boolean.boolean : true }
     finished_studying_details { finished_studying == false ? "Stopped due to illness" : "" }
     grade do
-      if finished_studying?
+      if gcse? || a_level? || as_level?
+        factory_sample(["A", "B", "C"])
+      elsif finished_studying?
         undergraduate? || postgraduate? ? factory_sample(["2.1", "2.2", "Honours"]) : factory_sample(%w[Pass Merit Distinction])
       else
         ""

--- a/spec/factories/qualifications.rb
+++ b/spec/factories/qualifications.rb
@@ -13,12 +13,10 @@ FactoryBot.define do
     end
 
     category { factory_sample(Qualification.categories.keys) }
-    finished_studying { undergraduate? || postgraduate? || other? ? Faker::Boolean.boolean : true }
+    finished_studying { undergraduate? || postgraduate? || other? ? Faker::Boolean.boolean : nil }
     finished_studying_details { finished_studying == false ? "Stopped due to illness" : "" }
     grade do
-      if gcse? || a_level? || as_level?
-        factory_sample(%w[A B C])
-      elsif finished_studying?
+      if finished_studying?
         undergraduate? || postgraduate? ? factory_sample(["2.1", "2.2", "Honours"]) : factory_sample(%w[Pass Merit Distinction])
       else
         ""

--- a/spec/services/jobseekers/job_applications/prefill_job_application_from_jobseeker_profile_spec.rb
+++ b/spec/services/jobseekers/job_applications/prefill_job_application_from_jobseeker_profile_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe Jobseekers::JobApplications::PrefillJobApplicationFromJobseekerProfile do
+  let(:jobseeker) { create(:jobseeker) }
+  let(:new_vacancy) { create(:vacancy) }
+  let!(:jobseeker_profile) { create(:jobseeker_profile, :completed, jobseeker: jobseeker) }
+  let(:new_job_application) { jobseeker.job_applications.create(vacancy: new_vacancy) }
+
+  subject { described_class.new(jobseeker, new_vacancy, new_job_application).call }
+
+  it "creates a new draft job application for the new vacancy" do
+    expect { subject }.to change { jobseeker.job_applications.draft.count }.by(1)
+    expect(subject.vacancy).to eq(new_vacancy)
+  end
+
+  it "copies qualifications from jobseeker profile" do
+    attributes_to_copy = %i[category finished_studying finished_studying_details grade institution name subject year]
+
+    expect(subject.qualifications.map { |qualification| qualification.slice(*attributes_to_copy) })
+      .to eq(jobseeker_profile.qualifications.map { |qualification| qualification.slice(*attributes_to_copy) })
+  end
+
+  it "sets qualifications section completed to false" do
+    expect(subject.qualifications_section_completed).to eq(false)
+  end
+
+  it "adds qualifications to in progress steps" do
+    expect(subject.in_progress_steps).to include("qualifications")
+  end
+
+  it "copies employments from jobseeker profile" do
+    attributes_to_copy = %i[organisation job_title subjects current_role main_duties started_on ended_on]
+
+    expect(subject.employments.map { |employment| employment.slice(*attributes_to_copy) })
+      .to eq(jobseeker_profile.employments.map { |employment| employment.slice(*attributes_to_copy) })
+  end
+
+  it "sets employment history section completed to false" do
+    expect(subject.employment_history_section_completed).to eq(false)
+  end
+
+  it "adds employment history to in progress steps" do
+    expect(subject.in_progress_steps).to include("employment_history")
+  end
+
+  it "copies training and cpds from jobseeker profile" do
+    attributes_to_copy = %i[name provider grade year_awarded]
+
+    expect(subject.training_and_cpds.map { |training| training.slice(*attributes_to_copy) })
+      .to eq(jobseeker_profile.training_and_cpds.map { |training| training.slice(*attributes_to_copy) })
+  end
+
+  it "sets training and cpds section completed to false" do
+    expect(subject.training_and_cpds_section_completed).to eq(false)
+  end
+
+  it "adds training and cpds to in progress steps" do
+    expect(subject.in_progress_steps).to include("training_and_cpds")
+  end
+end

--- a/spec/services/jobseekers/job_applications/prefill_job_application_from_previous_application_spec.rb
+++ b/spec/services/jobseekers/job_applications/prefill_job_application_from_previous_application_spec.rb
@@ -39,9 +39,9 @@ RSpec.describe Jobseekers::JobApplications::PrefillJobApplicationFromPreviousApp
 
           it "copies completed steps except for declarations and equal opportunities and employment_history and also adds them to imported steps" do
             expect(subject.completed_steps)
-              .to eq(%w[personal_details professional_status personal_statement references ask_for_support qualifications training_and_cpds])
+              .to eq(%w[personal_details personal_statement references ask_for_support qualifications training_and_cpds professional_status])
             expect(subject.imported_steps)
-              .to eq(%w[personal_details professional_status personal_statement references ask_for_support qualifications training_and_cpds])
+              .to eq(%w[personal_details personal_statement references ask_for_support qualifications training_and_cpds professional_status])
           end
 
           it "add employment_history to the in progress steps " do
@@ -53,14 +53,24 @@ RSpec.describe Jobseekers::JobApplications::PrefillJobApplicationFromPreviousApp
         context "when the application is from after we added gap validation for employment history section" do
           it "copies completed steps except for declarations and equal opportunities and also adds them to imported steps" do
             expect(subject.completed_steps)
-              .to eq(%w[personal_details professional_status personal_statement references ask_for_support qualifications training_and_cpds employment_history])
+              .to eq(%w[personal_details personal_statement references ask_for_support qualifications training_and_cpds employment_history professional_status])
             expect(subject.imported_steps)
-              .to eq(%w[personal_details professional_status personal_statement references ask_for_support qualifications training_and_cpds employment_history])
+              .to eq(%w[personal_details personal_statement references ask_for_support qualifications training_and_cpds employment_history professional_status])
           end
 
           it "sets in progress steps as empty" do
             expect(subject.in_progress_steps)
               .to eq(%w[])
+          end
+        end
+
+        context "when the previous application did not ask about professional_status" do
+          let(:old_vacancy) { create(:vacancy, job_roles: ["it_support"]) }
+
+          it "does not include professional_status in completed, imported or in_progress steps" do
+            expect(subject.completed_steps.include?("professional_status")).to eq false
+            expect(subject.imported_steps.include?("professional_status")).to eq false
+            expect(subject.in_progress_steps.include?("professional_status")).to eq false
           end
         end
       end

--- a/spec/services/jobseekers/job_applications/prefill_job_application_from_previous_application_spec.rb
+++ b/spec/services/jobseekers/job_applications/prefill_job_application_from_previous_application_spec.rb
@@ -1,0 +1,119 @@
+require "rails_helper"
+
+RSpec.describe Jobseekers::JobApplications::PrefillJobApplicationFromPreviousApplication do
+  let(:jobseeker) { create(:jobseeker) }
+  let(:new_vacancy) { create(:vacancy) }
+  let(:new_job_application) { jobseeker.job_applications.create(vacancy: new_vacancy) }
+
+  subject { described_class.new(jobseeker, new_vacancy, new_job_application).call }
+
+  describe "#job_application" do
+    context "when jobseeker has a recent job application" do
+      let(:old_vacancy) { create(:vacancy) }
+      let!(:recent_job_application) { create(:job_application, :status_submitted, submitted_at: 1.day.ago, jobseeker: jobseeker, vacancy: old_vacancy) }
+      let!(:older_job_application) { create(:job_application, :status_submitted, submitted_at: 1.week.ago, jobseeker: jobseeker, vacancy: old_vacancy) }
+      let!(:draft_job_application) { create(:job_application, jobseeker: jobseeker, vacancy: old_vacancy) }
+
+      it "creates a new draft job application for the new vacancy" do
+        expect { subject }.to change { jobseeker.job_applications.draft.count }.by(1)
+        expect(subject.vacancy).to eq(new_vacancy)
+      end
+
+      context "when all steps from the most recent application are relevant to the new application" do
+        let(:attributes_to_copy) do
+          %i[ first_name last_name previous_names street_address city country postcode phone_number teacher_reference_number
+              national_insurance_number qualified_teacher_status qualified_teacher_status_year qualified_teacher_status_details
+              statutory_induction_complete support_needed support_needed_details]
+        end
+
+        it "copies personal info from the recent job application" do
+          expect(subject.slice(attributes_to_copy)).to eq(recent_job_application.slice(attributes_to_copy))
+        end
+
+        it "copies completed steps except for declarations and equal opportunities and also adds them to imported steps" do
+          expect(subject.completed_steps)
+            .to eq(%w[personal_details professional_status personal_statement references ask_for_support qualifications employment_history training_and_cpds])
+          expect(subject.imported_steps)
+            .to eq(%w[personal_details professional_status personal_statement references ask_for_support qualifications employment_history training_and_cpds])
+        end
+
+        it "sets in progress steps as empty" do
+          expect(subject.in_progress_steps)
+            .to eq(%w[])
+        end
+      end
+
+      context "when there are steps in the most recent application that are not relevant to the new application" do
+        let(:vacancy_for_teacher) { create(:vacancy, job_roles: ["teacher"]) }
+        let(:vacancy_for_teaching_assistant) { create(:vacancy, job_roles: ["teaching_assistant"]) }
+        let!(:most_recent_job_application) { create(:job_application, :status_submitted, submitted_at: 1.hour.ago, jobseeker: jobseeker, vacancy: vacancy_for_teacher) }
+        let(:attributes_to_not_copy) { %i[qualified_teacher_status qualified_teacher_status_year qualified_teacher_status_details statutory_induction_complete] }
+        let(:completed_step_to_not_copy) { %i[professional_status] }
+        let(:new_job_application) { jobseeker.job_applications.create(vacancy: vacancy_for_teaching_assistant) }
+
+        it "only copies the relevant personal info from the recent job application" do
+          expect(subject.slice(attributes_to_not_copy)).to_not eq(most_recent_job_application.slice(attributes_to_not_copy))
+        end
+
+        it "only copies the relevant completed steps" do
+          expect(subject.completed_steps).to_not include(completed_step_to_not_copy)
+        end
+      end
+
+      it "copies qualifications from the recent job application" do
+        attributes_to_copy = %i[category finished_studying finished_studying_details grade institution name subject year]
+
+        expect(subject.qualifications.map { |qualification| qualification.slice(*attributes_to_copy) })
+          .to eq(recent_job_application.qualifications.map { |qualification| qualification.slice(*attributes_to_copy) })
+      end
+
+      it "sets qualifications section completed to true" do
+        expect(subject.qualifications_section_completed).to eq(true)
+      end
+
+      it "copies employments from the recent job application" do
+        attributes_to_copy = %i[organisation job_title subjects current_role main_duties started_on ended_on]
+
+        expect(subject.employments.map { |employment| employment.slice(*attributes_to_copy) })
+          .to eq(recent_job_application.employments.map { |employment| employment.slice(*attributes_to_copy) })
+      end
+
+      it "sets employment history section completed to true" do
+        expect(subject.employment_history_section_completed).to eq(true)
+      end
+
+      it "copies references from the recent job application" do
+        attributes_to_copy = %i[name job_title organisation relationship email phone_number]
+
+        expect(subject.references.map { |reference| reference.slice(*attributes_to_copy) })
+          .to eq(recent_job_application.references.map { |reference| reference.slice(*attributes_to_copy) })
+      end
+
+      it "copies training and cpds from the recent job application" do
+        attributes_to_copy = %i[name provider grade year_awarded]
+
+        expect(subject.training_and_cpds.map { |training| training.slice(*attributes_to_copy) })
+          .to eq(recent_job_application.training_and_cpds.map { |training| training.slice(*attributes_to_copy) })
+
+        expect(subject.training_and_cpds_section_completed).to eq(true)
+      end
+
+      it "does not copy declarations attributes from the recent job application" do
+        expect(subject.close_relationships).to be_blank
+        expect(subject.close_relationships_details).to be_blank
+      end
+
+      it "does not copy equal opportunities attributes from the recent job application" do
+        expect(subject.disability).to be_blank
+        expect(subject.gender).to be_blank
+        expect(subject.gender_description).to be_blank
+        expect(subject.orientation).to be_blank
+        expect(subject.orientation_description).to be_blank
+        expect(subject.ethnicity).to be_blank
+        expect(subject.ethnicity_description).to be_blank
+        expect(subject.religion).to be_blank
+        expect(subject.religion_description).to be_blank
+      end
+    end
+  end
+end

--- a/spec/services/jobseekers/job_applications/quick_apply_spec.rb
+++ b/spec/services/jobseekers/job_applications/quick_apply_spec.rb
@@ -2,126 +2,190 @@ require "rails_helper"
 
 RSpec.describe Jobseekers::JobApplications::QuickApply do
   let(:jobseeker) { create(:jobseeker) }
-  let(:old_vacancy) { create(:vacancy) }
   let(:new_vacancy) { create(:vacancy) }
-  let!(:recent_job_application) { create(:job_application, :status_submitted, submitted_at: 1.day.ago, jobseeker: jobseeker, vacancy: old_vacancy) }
-  let!(:older_job_application) { create(:job_application, :status_submitted, submitted_at: 1.week.ago, jobseeker: jobseeker, vacancy: old_vacancy) }
-  let!(:draft_job_application) { create(:job_application, jobseeker: jobseeker, vacancy: old_vacancy) }
 
-  describe "#recent_job_application" do
-    subject { described_class.new(jobseeker, new_vacancy).send(:recent_job_application) }
+  subject { described_class.new(jobseeker, new_vacancy).job_application }
 
-    it "returns the most recent non draft job application for the jobseeker" do
-      expect(subject).to eq(recent_job_application)
+  describe "#job_application" do
+    context "when jobseeker has a recent job application" do
+      let(:old_vacancy) { create(:vacancy) }
+      let!(:recent_job_application) { create(:job_application, :status_submitted, submitted_at: 1.day.ago, jobseeker: jobseeker, vacancy: old_vacancy) }
+      let!(:older_job_application) { create(:job_application, :status_submitted, submitted_at: 1.week.ago, jobseeker: jobseeker, vacancy: old_vacancy) }
+      let!(:draft_job_application) { create(:job_application, jobseeker: jobseeker, vacancy: old_vacancy) }
+
+      it "creates a new draft job application for the new vacancy" do
+        expect { subject }.to change { jobseeker.job_applications.draft.count }.by(1)
+        expect(subject.vacancy).to eq(new_vacancy)
+      end
+
+      context "when all steps from the most recent application are relevant to the new application" do
+        let(:attributes_to_copy) do
+          %i[ first_name last_name previous_names street_address city country postcode phone_number teacher_reference_number
+              national_insurance_number qualified_teacher_status qualified_teacher_status_year qualified_teacher_status_details
+              statutory_induction_complete support_needed support_needed_details]
+        end
+
+        it "copies personal info from the recent job application" do
+          expect(subject.slice(attributes_to_copy)).to eq(recent_job_application.slice(attributes_to_copy))
+        end
+
+        it "copies completed steps except for declarations and equal opportunities and also adds them to imported steps" do
+          expect(subject.completed_steps)
+            .to eq(%w[personal_details professional_status personal_statement references ask_for_support qualifications employment_history training_and_cpds])
+          expect(subject.imported_steps)
+            .to eq(%w[personal_details professional_status personal_statement references ask_for_support qualifications employment_history training_and_cpds])
+        end
+
+        it "sets in progress steps as empty" do
+          expect(subject.in_progress_steps)
+            .to eq(%w[])
+        end
+      end
+
+      context "when there are steps in the most recent application that are not relevant to the new application" do
+        subject { described_class.new(jobseeker, vacancy_for_teaching_assistant).job_application }
+        let(:vacancy_for_teacher) { create(:vacancy, job_roles: ["teacher"]) }
+        let(:vacancy_for_teaching_assistant) { create(:vacancy, job_roles: ["teaching_assistant"]) }
+        let!(:most_recent_job_application) { create(:job_application, :status_submitted, submitted_at: 1.hour.ago, jobseeker: jobseeker, vacancy: vacancy_for_teacher) }
+        let(:attributes_to_not_copy) { %i[qualified_teacher_status qualified_teacher_status_year qualified_teacher_status_details statutory_induction_complete] }
+        let(:completed_step_to_not_copy) { %i[professional_status] }
+
+        it "only copies the relevant personal info from the recent job application" do
+          expect(subject.slice(attributes_to_not_copy)).to_not eq(most_recent_job_application.slice(attributes_to_not_copy))
+        end
+
+        it "only copies the relevant completed steps" do
+          expect(subject.completed_steps).to_not include(completed_step_to_not_copy)
+        end
+      end
+
+      it "copies qualifications from the recent job application" do
+        attributes_to_copy = %i[category finished_studying finished_studying_details grade institution name subject year]
+
+        expect(subject.qualifications.map { |qualification| qualification.slice(*attributes_to_copy) })
+          .to eq(recent_job_application.qualifications.map { |qualification| qualification.slice(*attributes_to_copy) })
+      end
+
+      it "sets qualifications section completed to true" do
+        expect(subject.qualifications_section_completed).to eq(true)
+      end
+
+      it "copies employments from the recent job application" do
+        attributes_to_copy = %i[organisation job_title subjects current_role main_duties started_on ended_on]
+
+        expect(subject.employments.map { |employment| employment.slice(*attributes_to_copy) })
+          .to eq(recent_job_application.employments.map { |employment| employment.slice(*attributes_to_copy) })
+      end
+
+      it "sets employment history section completed to true" do
+        expect(subject.employment_history_section_completed).to eq(true)
+      end
+
+      it "copies references from the recent job application" do
+        attributes_to_copy = %i[name job_title organisation relationship email phone_number]
+
+        expect(subject.references.map { |reference| reference.slice(*attributes_to_copy) })
+          .to eq(recent_job_application.references.map { |reference| reference.slice(*attributes_to_copy) })
+      end
+
+      it "copies training and cpds from the recent job application" do
+        attributes_to_copy = %i[name provider grade year_awarded]
+
+        expect(subject.training_and_cpds.map { |training| training.slice(*attributes_to_copy) })
+          .to eq(recent_job_application.training_and_cpds.map { |training| training.slice(*attributes_to_copy) })
+
+        expect(subject.training_and_cpds_section_completed).to eq(true)
+      end
+
+      it "does not copy declarations attributes from the recent job application" do
+        expect(subject.close_relationships).to be_blank
+        expect(subject.close_relationships_details).to be_blank
+      end
+
+      it "does not copy equal opportunities attributes from the recent job application" do
+        expect(subject.disability).to be_blank
+        expect(subject.gender).to be_blank
+        expect(subject.gender_description).to be_blank
+        expect(subject.orientation).to be_blank
+        expect(subject.orientation_description).to be_blank
+        expect(subject.ethnicity).to be_blank
+        expect(subject.ethnicity_description).to be_blank
+        expect(subject.religion).to be_blank
+        expect(subject.religion_description).to be_blank
+      end
     end
   end
 
-  describe "#job_application" do
-    subject { described_class.new(jobseeker, new_vacancy).job_application }
+  context "when jobseeker does not have a recent job application but does have a jobseeker profile" do
+    let!(:jobseeker_profile) { create(:jobseeker_profile, :completed, jobseeker: jobseeker) }
 
     it "creates a new draft job application for the new vacancy" do
       expect { subject }.to change { jobseeker.job_applications.draft.count }.by(1)
       expect(subject.vacancy).to eq(new_vacancy)
     end
 
-    context "when all steps from the most recent application are relevant to the new application" do
-      let(:attributes_to_copy) do
-        %i[ first_name last_name previous_names street_address city country postcode phone_number teacher_reference_number
-            national_insurance_number qualified_teacher_status qualified_teacher_status_year qualified_teacher_status_details
-            statutory_induction_complete support_needed support_needed_details]
-      end
-
-      it "copies attributes" do
-        expect(subject.slice(attributes_to_copy)).to eq(recent_job_application.slice(attributes_to_copy))
-      end
-
-      it "copies completed steps except for declarations and equal opportunities and also adds them to imported steps" do
-        expect(subject.completed_steps)
-          .to eq(%w[personal_details professional_status references ask_for_support qualifications employment_history training_and_cpds])
-        expect(subject.imported_steps)
-          .to eq(%w[personal_details professional_status references ask_for_support qualifications employment_history training_and_cpds])
-      end
-
-      it "sets in progress steps as qualifications, employment history and professional status" do
-        expect(subject.in_progress_steps)
-          .to eq(%w[])
-      end
-    end
-
-    context "when there are steps in the most recent application that are not relevant to the new application" do
-      subject { described_class.new(jobseeker, vacancy_for_teaching_assistant).job_application }
-      let(:vacancy_for_teacher) { create(:vacancy, job_roles: ["teacher"]) }
-      let(:vacancy_for_teaching_assistant) { create(:vacancy, job_roles: ["teaching_assistant"]) }
-      let!(:most_recent_job_application) { create(:job_application, :status_submitted, submitted_at: 1.hour.ago, jobseeker: jobseeker, vacancy: vacancy_for_teacher) }
-      let(:attributes_to_not_copy) { %i[qualified_teacher_status qualified_teacher_status_year qualified_teacher_status_details statutory_induction_complete] }
-      let(:completed_step_to_not_copy) { %i[professional_status] }
-
-      it "only copies the relevant attributes" do
-        expect(subject.slice(attributes_to_not_copy)).to_not eq(most_recent_job_application.slice(attributes_to_not_copy))
-      end
-
-      it "only copies the relevant completed steps" do
-        expect(subject.completed_steps).to_not include(completed_step_to_not_copy)
-      end
-    end
-
-    it "copies qualifications" do
+    it "copies qualifications from jobseeker profile" do
       attributes_to_copy = %i[category finished_studying finished_studying_details grade institution name subject year]
 
       expect(subject.qualifications.map { |qualification| qualification.slice(*attributes_to_copy) })
-        .to eq(recent_job_application.qualifications.map { |qualification| qualification.slice(*attributes_to_copy) })
+        .to eq(jobseeker_profile.qualifications.map { |qualification| qualification.slice(*attributes_to_copy) })
     end
 
-    it "sets qualifications section completed to true" do
-      expect(subject.qualifications_section_completed).to eq(true)
+    it "sets qualifications section completed to false" do
+      expect(subject.qualifications_section_completed).to eq(false)
     end
 
-    it "copies employments" do
+    it "adds qualifications to in progress steps" do
+      expect(subject.in_progress_steps).to include("qualifications")
+    end
+
+    it "copies employments from jobseeker profile" do
       attributes_to_copy = %i[organisation job_title subjects current_role main_duties started_on ended_on]
 
       expect(subject.employments.map { |employment| employment.slice(*attributes_to_copy) })
-        .to eq(recent_job_application.employments.map { |employment| employment.slice(*attributes_to_copy) })
+        .to eq(jobseeker_profile.employments.map { |employment| employment.slice(*attributes_to_copy) })
     end
 
-    it "sets employment history section completed to true" do
-      expect(subject.employment_history_section_completed).to eq(true)
+    it "sets employment history section completed to false" do
+      expect(subject.employment_history_section_completed).to eq(false)
     end
 
-    it "copies references" do
-      attributes_to_copy = %i[name job_title organisation relationship email phone_number]
-
-      expect(subject.references.map { |reference| reference.slice(*attributes_to_copy) })
-        .to eq(recent_job_application.references.map { |reference| reference.slice(*attributes_to_copy) })
+    it "adds employment history to in progress steps" do
+      expect(subject.in_progress_steps).to include("employment_history")
     end
 
-    it "copies training and cpds" do
+    it "copies training and cpds from jobseeker profile" do
       attributes_to_copy = %i[name provider grade year_awarded]
 
       expect(subject.training_and_cpds.map { |training| training.slice(*attributes_to_copy) })
-        .to eq(recent_job_application.training_and_cpds.map { |training| training.slice(*attributes_to_copy) })
-
-      expect(subject.training_and_cpds_section_completed).to eq(true)
+        .to eq(jobseeker_profile.training_and_cpds.map { |training| training.slice(*attributes_to_copy) })
     end
 
-    it "does not copy declarations attributes" do
-      expect(subject.close_relationships).to be_blank
-      expect(subject.close_relationships_details).to be_blank
+    it "sets training and cpds section completed to false" do
+      expect(subject.training_and_cpds_section_completed).to eq(false)
     end
 
-    it "does not copy equal opportunities attributes" do
-      expect(subject.disability).to be_blank
-      expect(subject.gender).to be_blank
-      expect(subject.gender_description).to be_blank
-      expect(subject.orientation).to be_blank
-      expect(subject.orientation_description).to be_blank
-      expect(subject.ethnicity).to be_blank
-      expect(subject.ethnicity_description).to be_blank
-      expect(subject.religion).to be_blank
-      expect(subject.religion_description).to be_blank
+    it "adds training and cpds to in progress steps" do
+      expect(subject.in_progress_steps).to include("training_and_cpds")
+    end
+  end
+
+  context "when jobseeker has neither a recent job application nor a jobseeker profile" do
+    it "creates a new draft job application for the new vacancy" do
+      expect { subject }.to change { jobseeker.job_applications.draft.count }.by(1)
+      expect(subject.vacancy).to eq(new_vacancy)
     end
 
-    it "does not copy personal statement" do
-      expect(subject.personal_statement).to eq recent_job_application.personal_statement
+    it "returns blank job application" do
+      expect(subject.first_name).to be_blank
+      expect(subject.last_name).to be_blank
+      expect(subject.phone_number).to be_blank
+      expect(subject.qualified_teacher_status_year).to be_blank
+      expect(subject.qualified_teacher_status).to be_blank
+      expect(subject.right_to_work_in_uk).to be_blank
+      expect(subject.qualifications).to be_blank
+      expect(subject.employments).to be_blank
+      expect(subject.training_and_cpds).to be_blank
     end
   end
 end

--- a/spec/services/jobseekers/job_applications/quick_apply_spec.rb
+++ b/spec/services/jobseekers/job_applications/quick_apply_spec.rb
@@ -1,191 +1,69 @@
 require "rails_helper"
 
 RSpec.describe Jobseekers::JobApplications::QuickApply do
-  let(:jobseeker) { create(:jobseeker) }
-  let(:new_vacancy) { create(:vacancy) }
-
-  subject { described_class.new(jobseeker, new_vacancy).job_application }
+  subject { described_class.new(jobseeker, vacancy) }
 
   describe "#job_application" do
     context "when jobseeker has a recent job application" do
-      let(:old_vacancy) { create(:vacancy) }
-      let!(:recent_job_application) { create(:job_application, :status_submitted, submitted_at: 1.day.ago, jobseeker: jobseeker, vacancy: old_vacancy) }
-      let!(:older_job_application) { create(:job_application, :status_submitted, submitted_at: 1.week.ago, jobseeker: jobseeker, vacancy: old_vacancy) }
-      let!(:draft_job_application) { create(:job_application, jobseeker: jobseeker, vacancy: old_vacancy) }
+      let(:jobseeker) { double("Jobseeker") }
+      let(:vacancy) { double("Vacancy") }
+      let(:new_job_application) { double("JobApplication") }
+      let(:prefill_service) { double("Jobseekers::JobApplications::PrefillJobApplicationFromPreviousApplication") }
 
-      it "creates a new draft job application for the new vacancy" do
-        expect { subject }.to change { jobseeker.job_applications.draft.count }.by(1)
-        expect(subject.vacancy).to eq(new_vacancy)
+      before do
+        allow(jobseeker).to receive_message_chain(:job_applications, :create).and_return(new_job_application)
+        allow(jobseeker).to receive_message_chain(:job_applications, :not_draft, :any?).and_return(true)
+        allow(jobseeker).to receive(:jobseeker_profile).and_return(nil)
       end
 
-      context "when all steps from the most recent application are relevant to the new application" do
-        let(:attributes_to_copy) do
-          %i[ first_name last_name previous_names street_address city country postcode phone_number teacher_reference_number
-              national_insurance_number qualified_teacher_status qualified_teacher_status_year qualified_teacher_status_details
-              statutory_induction_complete support_needed support_needed_details]
-        end
+      it "prefills the new job application from the previous job application" do
+        expect(Jobseekers::JobApplications::PrefillJobApplicationFromPreviousApplication).to receive(:new).with(jobseeker, vacancy, new_job_application).and_return(prefill_service)
+        expect(prefill_service).to receive(:call)
 
-        it "copies personal info from the recent job application" do
-          expect(subject.slice(attributes_to_copy)).to eq(recent_job_application.slice(attributes_to_copy))
-        end
-
-        it "copies completed steps except for declarations and equal opportunities and also adds them to imported steps" do
-          expect(subject.completed_steps)
-            .to eq(%w[personal_details professional_status personal_statement references ask_for_support qualifications employment_history training_and_cpds])
-          expect(subject.imported_steps)
-            .to eq(%w[personal_details professional_status personal_statement references ask_for_support qualifications employment_history training_and_cpds])
-        end
-
-        it "sets in progress steps as empty" do
-          expect(subject.in_progress_steps)
-            .to eq(%w[])
-        end
-      end
-
-      context "when there are steps in the most recent application that are not relevant to the new application" do
-        subject { described_class.new(jobseeker, vacancy_for_teaching_assistant).job_application }
-        let(:vacancy_for_teacher) { create(:vacancy, job_roles: ["teacher"]) }
-        let(:vacancy_for_teaching_assistant) { create(:vacancy, job_roles: ["teaching_assistant"]) }
-        let!(:most_recent_job_application) { create(:job_application, :status_submitted, submitted_at: 1.hour.ago, jobseeker: jobseeker, vacancy: vacancy_for_teacher) }
-        let(:attributes_to_not_copy) { %i[qualified_teacher_status qualified_teacher_status_year qualified_teacher_status_details statutory_induction_complete] }
-        let(:completed_step_to_not_copy) { %i[professional_status] }
-
-        it "only copies the relevant personal info from the recent job application" do
-          expect(subject.slice(attributes_to_not_copy)).to_not eq(most_recent_job_application.slice(attributes_to_not_copy))
-        end
-
-        it "only copies the relevant completed steps" do
-          expect(subject.completed_steps).to_not include(completed_step_to_not_copy)
-        end
-      end
-
-      it "copies qualifications from the recent job application" do
-        attributes_to_copy = %i[category finished_studying finished_studying_details grade institution name subject year]
-
-        expect(subject.qualifications.map { |qualification| qualification.slice(*attributes_to_copy) })
-          .to eq(recent_job_application.qualifications.map { |qualification| qualification.slice(*attributes_to_copy) })
-      end
-
-      it "sets qualifications section completed to true" do
-        expect(subject.qualifications_section_completed).to eq(true)
-      end
-
-      it "copies employments from the recent job application" do
-        attributes_to_copy = %i[organisation job_title subjects current_role main_duties started_on ended_on]
-
-        expect(subject.employments.map { |employment| employment.slice(*attributes_to_copy) })
-          .to eq(recent_job_application.employments.map { |employment| employment.slice(*attributes_to_copy) })
-      end
-
-      it "sets employment history section completed to true" do
-        expect(subject.employment_history_section_completed).to eq(true)
-      end
-
-      it "copies references from the recent job application" do
-        attributes_to_copy = %i[name job_title organisation relationship email phone_number]
-
-        expect(subject.references.map { |reference| reference.slice(*attributes_to_copy) })
-          .to eq(recent_job_application.references.map { |reference| reference.slice(*attributes_to_copy) })
-      end
-
-      it "copies training and cpds from the recent job application" do
-        attributes_to_copy = %i[name provider grade year_awarded]
-
-        expect(subject.training_and_cpds.map { |training| training.slice(*attributes_to_copy) })
-          .to eq(recent_job_application.training_and_cpds.map { |training| training.slice(*attributes_to_copy) })
-
-        expect(subject.training_and_cpds_section_completed).to eq(true)
-      end
-
-      it "does not copy declarations attributes from the recent job application" do
-        expect(subject.close_relationships).to be_blank
-        expect(subject.close_relationships_details).to be_blank
-      end
-
-      it "does not copy equal opportunities attributes from the recent job application" do
-        expect(subject.disability).to be_blank
-        expect(subject.gender).to be_blank
-        expect(subject.gender_description).to be_blank
-        expect(subject.orientation).to be_blank
-        expect(subject.orientation_description).to be_blank
-        expect(subject.ethnicity).to be_blank
-        expect(subject.ethnicity_description).to be_blank
-        expect(subject.religion).to be_blank
-        expect(subject.religion_description).to be_blank
+        subject.job_application
       end
     end
   end
 
   context "when jobseeker does not have a recent job application but does have a jobseeker profile" do
-    let!(:jobseeker_profile) { create(:jobseeker_profile, :completed, jobseeker: jobseeker) }
+    let(:jobseeker) { double("Jobseeker") }
+    let(:vacancy) { double("Vacancy") }
+    let(:new_job_application) { double("JobApplication") }
+    let(:prefill_service) { double("Jobseekers::JobApplications::PrefillJobApplicationFromJobseekerProfile") }
 
-    it "creates a new draft job application for the new vacancy" do
-      expect { subject }.to change { jobseeker.job_applications.draft.count }.by(1)
-      expect(subject.vacancy).to eq(new_vacancy)
+    before do
+      allow(jobseeker).to receive_message_chain(:job_applications, :create).and_return(new_job_application)
+      allow(jobseeker).to receive_message_chain(:job_applications, :not_draft, :any?).and_return(false)
+      allow(jobseeker).to receive(:jobseeker_profile).and_return(double("JobseekerProfile"))
     end
 
-    it "copies qualifications from jobseeker profile" do
-      attributes_to_copy = %i[category finished_studying finished_studying_details grade institution name subject year]
+    it "prefills the new job application from the jobseeker profile" do
+      expect(Jobseekers::JobApplications::PrefillJobApplicationFromJobseekerProfile).to receive(:new).with(jobseeker, vacancy, new_job_application).and_return(prefill_service)
+      expect(prefill_service).to receive(:call)
 
-      expect(subject.qualifications.map { |qualification| qualification.slice(*attributes_to_copy) })
-        .to eq(jobseeker_profile.qualifications.map { |qualification| qualification.slice(*attributes_to_copy) })
-    end
-
-    it "sets qualifications section completed to false" do
-      expect(subject.qualifications_section_completed).to eq(false)
-    end
-
-    it "adds qualifications to in progress steps" do
-      expect(subject.in_progress_steps).to include("qualifications")
-    end
-
-    it "copies employments from jobseeker profile" do
-      attributes_to_copy = %i[organisation job_title subjects current_role main_duties started_on ended_on]
-
-      expect(subject.employments.map { |employment| employment.slice(*attributes_to_copy) })
-        .to eq(jobseeker_profile.employments.map { |employment| employment.slice(*attributes_to_copy) })
-    end
-
-    it "sets employment history section completed to false" do
-      expect(subject.employment_history_section_completed).to eq(false)
-    end
-
-    it "adds employment history to in progress steps" do
-      expect(subject.in_progress_steps).to include("employment_history")
-    end
-
-    it "copies training and cpds from jobseeker profile" do
-      attributes_to_copy = %i[name provider grade year_awarded]
-
-      expect(subject.training_and_cpds.map { |training| training.slice(*attributes_to_copy) })
-        .to eq(jobseeker_profile.training_and_cpds.map { |training| training.slice(*attributes_to_copy) })
-    end
-
-    it "sets training and cpds section completed to false" do
-      expect(subject.training_and_cpds_section_completed).to eq(false)
-    end
-
-    it "adds training and cpds to in progress steps" do
-      expect(subject.in_progress_steps).to include("training_and_cpds")
+      subject.job_application
     end
   end
 
   context "when jobseeker has neither a recent job application nor a jobseeker profile" do
+    let(:jobseeker) { create(:jobseeker) }
+    let(:vacancy) { create(:vacancy) }
+
     it "creates a new draft job application for the new vacancy" do
-      expect { subject }.to change { jobseeker.job_applications.draft.count }.by(1)
-      expect(subject.vacancy).to eq(new_vacancy)
+      expect { subject.job_application }.to change { jobseeker.job_applications.draft.count }.by(1)
     end
 
     it "returns blank job application" do
-      expect(subject.first_name).to be_blank
-      expect(subject.last_name).to be_blank
-      expect(subject.phone_number).to be_blank
-      expect(subject.qualified_teacher_status_year).to be_blank
-      expect(subject.qualified_teacher_status).to be_blank
-      expect(subject.right_to_work_in_uk).to be_blank
-      expect(subject.qualifications).to be_blank
-      expect(subject.employments).to be_blank
-      expect(subject.training_and_cpds).to be_blank
+      job_application = subject.job_application
+      expect(job_application.first_name).to be_blank
+      expect(job_application.last_name).to be_blank
+      expect(job_application.phone_number).to be_blank
+      expect(job_application.qualified_teacher_status_year).to be_blank
+      expect(job_application.qualified_teacher_status).to be_blank
+      expect(job_application.right_to_work_in_uk).to be_blank
+      expect(job_application.qualifications).to be_blank
+      expect(job_application.employments).to be_blank
+      expect(job_application.training_and_cpds).to be_blank
     end
   end
 end

--- a/spec/services/jobseekers/job_applications/quick_apply_spec.rb
+++ b/spec/services/jobseekers/job_applications/quick_apply_spec.rb
@@ -35,14 +35,16 @@ RSpec.describe Jobseekers::JobApplications::QuickApply do
         expect(subject.slice(attributes_to_copy)).to eq(recent_job_application.slice(attributes_to_copy))
       end
 
-      it "copies completed steps except qualifications and employment history" do
+      it "copies completed steps except for declarations and equal opportunities and also adds them to imported steps" do
         expect(subject.completed_steps)
-          .to eq(%w[personal_details professional_status references ask_for_support])
+          .to eq(%w[personal_details professional_status references ask_for_support qualifications employment_history training_and_cpds])
+        expect(subject.imported_steps)
+          .to eq(%w[personal_details professional_status references ask_for_support qualifications employment_history training_and_cpds])
       end
 
       it "sets in progress steps as qualifications, employment history and professional status" do
         expect(subject.in_progress_steps)
-          .to eq(%w[qualifications employment_history professional_status training_and_cpds])
+          .to eq(%w[])
       end
     end
 
@@ -70,8 +72,8 @@ RSpec.describe Jobseekers::JobApplications::QuickApply do
         .to eq(recent_job_application.qualifications.map { |qualification| qualification.slice(*attributes_to_copy) })
     end
 
-    it "sets qualifications section completed to false" do
-      expect(subject.qualifications_section_completed).to eq(false)
+    it "sets qualifications section completed to true" do
+      expect(subject.qualifications_section_completed).to eq(true)
     end
 
     it "copies employments" do
@@ -81,8 +83,8 @@ RSpec.describe Jobseekers::JobApplications::QuickApply do
         .to eq(recent_job_application.employments.map { |employment| employment.slice(*attributes_to_copy) })
     end
 
-    it "sets employment history section completed to false" do
-      expect(subject.employment_history_section_completed).to eq(false)
+    it "sets employment history section completed to true" do
+      expect(subject.employment_history_section_completed).to eq(true)
     end
 
     it "copies references" do
@@ -98,7 +100,7 @@ RSpec.describe Jobseekers::JobApplications::QuickApply do
       expect(subject.training_and_cpds.map { |training| training.slice(*attributes_to_copy) })
         .to eq(recent_job_application.training_and_cpds.map { |training| training.slice(*attributes_to_copy) })
 
-      expect(subject.training_and_cpds_section_completed).to eq(false)
+      expect(subject.training_and_cpds_section_completed).to eq(true)
     end
 
     it "does not copy declarations attributes" do
@@ -119,7 +121,7 @@ RSpec.describe Jobseekers::JobApplications::QuickApply do
     end
 
     it "does not copy personal statement" do
-      expect(subject.personal_statement).to be_blank
+      expect(subject.personal_statement).to eq recent_job_application.personal_statement
     end
   end
 end

--- a/spec/system/jobseekers/prefilling_applications_spec.rb
+++ b/spec/system/jobseekers/prefilling_applications_spec.rb
@@ -23,32 +23,38 @@ RSpec.describe "Jobseekers can prefill applications" do
       let!(:previous_application) { create(:job_application, :status_submitted, jobseeker:, qualified_teacher_status: "yes", qualified_teacher_status_year: "2020", 
                                                              references: [reference], employments: [employment1, employment2], qualifications: [qualification1, qualification2]) }
 
-      it "prefills the new application with the previous application details, not the profile details" do
+      it "prefills the new application with the previous application details, not the profile details and marks steps as `imported`" do
         visit job_path(vacancy.id)
 
-      expect(page).to have_content("Your details have been imported from your last job application or profile")
+        expect(page).to have_content("Your details have been imported from your last job application or profile")
       
-      within ".banner-buttons" do
-        click_on I18n.t("jobseekers.saved_jobs.index.apply")
-      end
+        within ".banner-buttons" do
+          click_on I18n.t("jobseekers.saved_jobs.index.apply")
+        end
 
-      expect(page).to have_content("We saved your information from the last job you applied for")
+        expect(page).to have_content("We saved your information from the last job you applied for")
 
-      click_on I18n.t("buttons.start_application")
+        click_on I18n.t("buttons.start_application")
 
-<<<<<<< HEAD
-      expect(page).to have_content(previous_application.first_name)
-      expect(page).to have_content(previous_application.last_name)
-      expect(page).to have_content(previous_application.phone_number)
-=======
         expect(page).to have_content(previous_application.first_name)
         expect(page).to have_content(previous_application.last_name)
         expect(page).to have_content(previous_application.phone_number)
+        within('#personal_details') do
+          expect(page).to have_css('strong.govuk-tag.govuk-tag--blue', text: 'imported')
+        end
+
         expect(page).to have_content(previous_application.personal_statement)
+        within('#personal_statement.review-component__section') do
+          expect(page).to have_css('strong.govuk-tag.govuk-tag--blue', text: 'imported')
+        end
+
         # qualified teacher status
         expect(page).to have_content("Yes, awarded in 2020")
         # skilled worker visa sponsorship
         expect(page).to have_content("No, I already have the right to work in the UK")
+        within('#professional_status') do
+          expect(page).to have_css('strong.govuk-tag.govuk-tag--blue', text: 'imported')
+        end
         # references
         expect(page).to have_content(reference.job_title)
         expect(page).to have_content(reference.organisation)
@@ -58,17 +64,32 @@ RSpec.describe "Jobseekers can prefill applications" do
         expect(page).to have_content(employment1.organisation)
         expect(page).to have_content(employment2.main_duties)
         expect(page).to have_content(employment2.organisation)
+        within('#employment_history') do
+          expect(page).to have_css('strong.govuk-tag.govuk-tag--blue', text: 'imported')
+        end
 
         expect(page).to have_content(I18n.t("helpers.label.jobseekers_qualifications_category_form.category_options.#{qualification1.category}"))
         expect(page).to have_content(qualification1.institution)
         expect(page).to have_content(I18n.t("helpers.label.jobseekers_qualifications_category_form.category_options.#{qualification1.category}"))
         expect(page).to have_content(qualification2.institution)
+        within('#qualifications') do
+          expect(page).to have_css('strong.govuk-tag.govuk-tag--blue', text: 'imported')
+        end
 
         expect(page).to have_content(training.name)
         expect(page).to have_content(training.provider)
         expect(page).to have_content(training.grade)
         expect(page).to have_content(training.year_awarded)
->>>>>>> e685dce7a (Add specs)
+
+        within('#training_and_cpds') do
+          expect(page).to have_css('strong.govuk-tag.govuk-tag--blue', text: 'imported')
+        end
+
+        expect(page).to have_content(previous_application.support_needed.capitalize)
+        expect(page).to have_content(previous_application.support_needed_details)
+        within('#ask_for_support') do
+          expect(page).to have_css('strong.govuk-tag.govuk-tag--blue', text: 'imported')
+        end
       end
     end
 

--- a/spec/system/jobseekers/prefilling_applications_spec.rb
+++ b/spec/system/jobseekers/prefilling_applications_spec.rb
@@ -20,14 +20,16 @@ RSpec.describe "Jobseekers can prefill applications" do
       let(:qualification1) { create(:qualification) }
       let(:qualification2) { create(:qualification) }
       let(:training) { create(:training_and_cpd) }
-      let!(:previous_application) { create(:job_application, :status_submitted, jobseeker:, qualified_teacher_status: "yes", qualified_teacher_status_year: "2020", 
-                                                             references: [reference], employments: [employment1, employment2], qualifications: [qualification1, qualification2]) }
+      let!(:previous_application) do
+        create(:job_application, :status_submitted, jobseeker:, qualified_teacher_status: "yes", qualified_teacher_status_year: "2020",
+                                                    references: [reference], employments: [employment1, employment2], qualifications: [qualification1, qualification2])
+      end
 
       it "prefills the new application with the previous application details, not the profile details and marks steps as `imported`" do
         visit job_path(vacancy.id)
 
         expect(page).to have_content("Your details have been imported from your last job application or profile")
-      
+
         within ".banner-buttons" do
           click_on I18n.t("jobseekers.saved_jobs.index.apply")
         end
@@ -39,21 +41,21 @@ RSpec.describe "Jobseekers can prefill applications" do
         expect(page).to have_content(previous_application.first_name)
         expect(page).to have_content(previous_application.last_name)
         expect(page).to have_content(previous_application.phone_number)
-        within('#personal_details') do
-          expect(page).to have_css('strong.govuk-tag.govuk-tag--blue', text: 'imported')
+        within("#personal_details") do
+          expect(page).to have_css("strong.govuk-tag.govuk-tag--blue", text: "imported")
         end
 
         expect(page).to have_content(previous_application.personal_statement)
-        within('#personal_statement.review-component__section') do
-          expect(page).to have_css('strong.govuk-tag.govuk-tag--blue', text: 'imported')
+        within("#personal_statement.review-component__section") do
+          expect(page).to have_css("strong.govuk-tag.govuk-tag--blue", text: "imported")
         end
 
         # qualified teacher status
         expect(page).to have_content("Yes, awarded in 2020")
         # skilled worker visa sponsorship
         expect(page).to have_content("No, I already have the right to work in the UK")
-        within('#professional_status') do
-          expect(page).to have_css('strong.govuk-tag.govuk-tag--blue', text: 'imported')
+        within("#professional_status") do
+          expect(page).to have_css("strong.govuk-tag.govuk-tag--blue", text: "imported")
         end
         # references
         expect(page).to have_content(reference.job_title)
@@ -64,8 +66,8 @@ RSpec.describe "Jobseekers can prefill applications" do
         expect(page).to have_content(employment1.organisation)
         expect(page).to have_content(employment2.main_duties)
         expect(page).to have_content(employment2.organisation)
-        within('#employment_history') do
-          expect(page).to have_css('strong.govuk-tag.govuk-tag--blue', text: 'imported')
+        within("#employment_history") do
+          expect(page).to have_css("strong.govuk-tag.govuk-tag--blue", text: "imported")
         end
 
         previous_application.qualifications.each do |qualification|
@@ -76,8 +78,8 @@ RSpec.describe "Jobseekers can prefill applications" do
           end
         end
 
-        within('#qualifications') do
-          expect(page).to have_css('strong.govuk-tag.govuk-tag--blue', text: 'imported')
+        within("#qualifications") do
+          expect(page).to have_css("strong.govuk-tag.govuk-tag--blue", text: "imported")
         end
 
         expect(page).to have_content(training.name)
@@ -85,14 +87,14 @@ RSpec.describe "Jobseekers can prefill applications" do
         expect(page).to have_content(training.grade)
         expect(page).to have_content(training.year_awarded)
 
-        within('#training_and_cpds') do
-          expect(page).to have_css('strong.govuk-tag.govuk-tag--blue', text: 'imported')
+        within("#training_and_cpds") do
+          expect(page).to have_css("strong.govuk-tag.govuk-tag--blue", text: "imported")
         end
 
         expect(page).to have_content(previous_application.support_needed.capitalize)
         expect(page).to have_content(previous_application.support_needed_details)
-        within('#ask_for_support') do
-          expect(page).to have_css('strong.govuk-tag.govuk-tag--blue', text: 'imported')
+        within("#ask_for_support") do
+          expect(page).to have_css("strong.govuk-tag.govuk-tag--blue", text: "imported")
         end
       end
     end
@@ -100,16 +102,15 @@ RSpec.describe "Jobseekers can prefill applications" do
     context "when the jobseeeker does not have a previous application" do
       it "prefills the application form with the jobseeker's profile details" do
         visit job_path(vacancy.id)
-  
+
         within ".banner-buttons" do
           click_on I18n.t("jobseekers.saved_jobs.index.apply")
         end
-  
+
         expect(page).to have_content("You have recently made a candidate profile")
-  
+
         click_on I18n.t("buttons.start_application")
 
-  
         expect(page).to have_content(profile.personal_details.first_name)
         expect(page).to have_content(profile.personal_details.last_name)
         expect(page).to have_content(profile.personal_details.phone_number)

--- a/spec/system/jobseekers/prefilling_applications_spec.rb
+++ b/spec/system/jobseekers/prefilling_applications_spec.rb
@@ -13,43 +13,47 @@ RSpec.describe "Jobseekers can prefill applications" do
     let(:profile) { create(:jobseeker_profile, :completed, qualified_teacher_status: "yes") }
     let(:jobseeker) { profile.jobseeker }
 
-    it "prefills the application form with the jobseeker's details" do
-      visit job_path(vacancy.id)
+    context "and when the jobseeker also has a previous application" do
+      let!(:previous_application) { create(:job_application, :status_submitted, jobseeker:) }
 
+      it "prefills the new application with the previous application details, not the profile details" do
+        visit job_path(vacancy.id)
+
+      expect(page).to have_content("Your details have been imported from your last job application or profile")
+      
       within ".banner-buttons" do
         click_on I18n.t("jobseekers.saved_jobs.index.apply")
       end
 
-      expect(page).to have_content("Your details have been imported from your last job application or profile")
+      expect(page).to have_content("We saved your information from the last job you applied for")
 
       click_on I18n.t("buttons.start_application")
 
-      expect(page).to have_content(profile.personal_details.first_name)
-      expect(page).to have_content(profile.personal_details.last_name)
-      expect(page).to have_content(profile.personal_details.phone_number)
-      expect(page).to have_content(profile.qualified_teacher_status_year)
-      expect(page).to have_content(profile.qualifications.first.institution)
-      expect(page).to have_content(profile.employments.first.job_title)
-      expect(page).to have_content(profile.employments.first.subjects)
+      expect(page).to have_content(previous_application.first_name)
+      expect(page).to have_content(previous_application.last_name)
+      expect(page).to have_content(previous_application.phone_number)
+      end
     end
 
-    context "and the jobseeker has a previous application" do
-      before do
-        create(:job_application, :status_submitted, jobseeker:)
-      end
-
-      it "prefers the jobseeker's profile details over the previous application" do
+    context "when the jobseeeker does not have a previous application" do
+      it "prefills the application form with the jobseeker's details" do
         visit job_path(vacancy.id)
-
+  
         within ".banner-buttons" do
           click_on I18n.t("jobseekers.saved_jobs.index.apply")
         end
-
+  
+        expect(page).to have_content("You have recently made a candidate profile")
+  
         click_on I18n.t("buttons.start_application")
-
+  
         expect(page).to have_content(profile.personal_details.first_name)
         expect(page).to have_content(profile.personal_details.last_name)
         expect(page).to have_content(profile.personal_details.phone_number)
+        expect(page).to have_content(profile.qualified_teacher_status_year)
+        expect(page).to have_content(profile.qualifications.first.institution)
+        expect(page).to have_content(profile.employments.first.job_title)
+        expect(page).to have_content(profile.employments.first.subjects)
       end
     end
   end

--- a/spec/system/jobseekers/prefilling_applications_spec.rb
+++ b/spec/system/jobseekers/prefilling_applications_spec.rb
@@ -28,13 +28,11 @@ RSpec.describe "Jobseekers can prefill applications" do
       it "prefills the new application with the previous application details, not the profile details and marks steps as `imported`" do
         visit job_path(vacancy.id)
 
-        expect(page).to have_content("Your details have been imported from your last job application or profile")
+        expect(page).to have_content("Your details have been imported from your last job application.")
 
         within ".banner-buttons" do
           click_on I18n.t("jobseekers.saved_jobs.index.apply")
         end
-
-        expect(page).to have_content("We saved your information from the last job you applied for")
 
         click_on I18n.t("buttons.start_application")
 
@@ -106,8 +104,6 @@ RSpec.describe "Jobseekers can prefill applications" do
         within ".banner-buttons" do
           click_on I18n.t("jobseekers.saved_jobs.index.apply")
         end
-
-        expect(page).to have_content("You have recently made a candidate profile")
 
         click_on I18n.t("buttons.start_application")
 

--- a/spec/system/jobseekers/prefilling_applications_spec.rb
+++ b/spec/system/jobseekers/prefilling_applications_spec.rb
@@ -10,11 +10,18 @@ RSpec.describe "Jobseekers can prefill applications" do
   end
 
   context "when the jobseeker has a completed profile" do
-    let(:profile) { create(:jobseeker_profile, :completed, qualified_teacher_status: "yes") }
+    let(:profile) { create(:jobseeker_profile, :completed, qualified_teacher_status: "yes", qualified_teacher_status_year: "2020") }
     let(:jobseeker) { profile.jobseeker }
 
     context "and when the jobseeker also has a previous application" do
-      let!(:previous_application) { create(:job_application, :status_submitted, jobseeker:) }
+      let(:reference) { create(:reference, job_title: "Reference4Testing") }
+      let(:employment1) { create(:employment) }
+      let(:employment2) { create(:employment) }
+      let(:qualification1) { create(:qualification) }
+      let(:qualification2) { create(:qualification) }
+      let(:training) { create(:training_and_cpd) }
+      let!(:previous_application) { create(:job_application, :status_submitted, jobseeker:, qualified_teacher_status: "yes", qualified_teacher_status_year: "2020", 
+                                                             references: [reference], employments: [employment1, employment2], qualifications: [qualification1, qualification2]) }
 
       it "prefills the new application with the previous application details, not the profile details" do
         visit job_path(vacancy.id)
@@ -29,14 +36,44 @@ RSpec.describe "Jobseekers can prefill applications" do
 
       click_on I18n.t("buttons.start_application")
 
+<<<<<<< HEAD
       expect(page).to have_content(previous_application.first_name)
       expect(page).to have_content(previous_application.last_name)
       expect(page).to have_content(previous_application.phone_number)
+=======
+        expect(page).to have_content(previous_application.first_name)
+        expect(page).to have_content(previous_application.last_name)
+        expect(page).to have_content(previous_application.phone_number)
+        expect(page).to have_content(previous_application.personal_statement)
+        # qualified teacher status
+        expect(page).to have_content("Yes, awarded in 2020")
+        # skilled worker visa sponsorship
+        expect(page).to have_content("No, I already have the right to work in the UK")
+        # references
+        expect(page).to have_content(reference.job_title)
+        expect(page).to have_content(reference.organisation)
+        expect(page).to have_content(reference.relationship)
+        # work history
+        expect(page).to have_content(employment1.main_duties)
+        expect(page).to have_content(employment1.organisation)
+        expect(page).to have_content(employment2.main_duties)
+        expect(page).to have_content(employment2.organisation)
+
+        expect(page).to have_content(I18n.t("helpers.label.jobseekers_qualifications_category_form.category_options.#{qualification1.category}"))
+        expect(page).to have_content(qualification1.institution)
+        expect(page).to have_content(I18n.t("helpers.label.jobseekers_qualifications_category_form.category_options.#{qualification1.category}"))
+        expect(page).to have_content(qualification2.institution)
+
+        expect(page).to have_content(training.name)
+        expect(page).to have_content(training.provider)
+        expect(page).to have_content(training.grade)
+        expect(page).to have_content(training.year_awarded)
+>>>>>>> e685dce7a (Add specs)
       end
     end
 
     context "when the jobseeeker does not have a previous application" do
-      it "prefills the application form with the jobseeker's details" do
+      it "prefills the application form with the jobseeker's profile details" do
         visit job_path(vacancy.id)
   
         within ".banner-buttons" do

--- a/spec/system/jobseekers/prefilling_applications_spec.rb
+++ b/spec/system/jobseekers/prefilling_applications_spec.rb
@@ -68,10 +68,14 @@ RSpec.describe "Jobseekers can prefill applications" do
           expect(page).to have_css('strong.govuk-tag.govuk-tag--blue', text: 'imported')
         end
 
-        expect(page).to have_content(I18n.t("helpers.label.jobseekers_qualifications_category_form.category_options.#{qualification1.category}"))
-        expect(page).to have_content(qualification1.institution)
-        expect(page).to have_content(I18n.t("helpers.label.jobseekers_qualifications_category_form.category_options.#{qualification1.category}"))
-        expect(page).to have_content(qualification2.institution)
+        previous_application.qualifications.each do |qualification|
+          expect(page).to have_content(I18n.t("helpers.label.jobseekers_qualifications_category_form.category_options.#{qualification.category}"))
+          expect(page).to have_content(qualification.institution)
+          if qualification.display_attributes.include?("grade")
+            expect(page).to have_content("(#{qualification.grade})")
+          end
+        end
+
         within('#qualifications') do
           expect(page).to have_css('strong.govuk-tag.govuk-tag--blue', text: 'imported')
         end
@@ -104,12 +108,20 @@ RSpec.describe "Jobseekers can prefill applications" do
         expect(page).to have_content("You have recently made a candidate profile")
   
         click_on I18n.t("buttons.start_application")
+
   
         expect(page).to have_content(profile.personal_details.first_name)
         expect(page).to have_content(profile.personal_details.last_name)
         expect(page).to have_content(profile.personal_details.phone_number)
         expect(page).to have_content(profile.qualified_teacher_status_year)
         expect(page).to have_content(profile.qualifications.first.institution)
+        profile.qualifications.each do |qualification|
+          expect(page).to have_content(I18n.t("helpers.label.jobseekers_qualifications_category_form.category_options.#{qualification.category}"))
+          expect(page).to have_content(qualification.institution)
+          if qualification.display_attributes.include?("grade")
+            expect(page).to have_content("(#{qualification.grade})")
+          end
+        end
         expect(page).to have_content(profile.employments.first.job_title)
         expect(page).to have_content(profile.employments.first.subjects)
       end

--- a/spec/system/jobseekers/prefilling_applications_spec.rb
+++ b/spec/system/jobseekers/prefilling_applications_spec.rb
@@ -28,13 +28,13 @@ RSpec.describe "Jobseekers can prefill applications" do
       it "prefills the new application with the previous application details, not the profile details and marks steps as `imported`" do
         visit job_path(vacancy.id)
 
-        expect(page).to have_content("Your details have been imported from your last job application.")
-
         within ".banner-buttons" do
           click_on I18n.t("jobseekers.saved_jobs.index.apply")
         end
 
         click_on I18n.t("buttons.start_application")
+
+        expect(page).to have_content("Your details have been imported from your last job application.")
 
         expect(page).to have_content(previous_application.first_name)
         expect(page).to have_content(previous_application.last_name)
@@ -122,26 +122,6 @@ RSpec.describe "Jobseekers can prefill applications" do
         expect(page).to have_content(profile.employments.first.job_title)
         expect(page).to have_content(profile.employments.first.subjects)
       end
-    end
-  end
-
-  context "when the jobseeker has a previous application" do
-    let!(:previous_application) { create(:job_application, :status_submitted, jobseeker:) }
-
-    it "uses the details from the previous application" do
-      visit job_path(vacancy.id)
-
-      within ".banner-buttons" do
-        click_on I18n.t("jobseekers.saved_jobs.index.apply")
-      end
-
-      expect(page).to have_content("Your details have been imported from your last job application")
-
-      click_on I18n.t("buttons.start_application")
-
-      expect(page).to have_content(previous_application.first_name)
-      expect(page).to have_content(previous_application.last_name)
-      expect(page).to have_content(previous_application.phone_number)
     end
   end
 


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/9mSB17Pd/1048-application-data-saving

## Changes in this PR:

This PR changes the logic of how we pre-populate quick apply job applications. Prior to this change, if a profile existed we used that to populate the application, and only used a previous application if no profile existed. This PR switches that logic around to pre-populate using a previous application where possible, and only use a jobseeker profile as back up.

It also adds in some additional changes:
- we now pre-populate personal statements
- we now use an imported tag to display data that has been imported from a previous application (but not a jobseeker profile)
- adds in some warning data to let users know that they cannot re-submit a withdrawn application.
- refactors the code in the quick apply controller and the quick apply class to switch the logic out of the controller and simplify the logic.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
