### PR TITLE
Remove invalid chars from DWP Find a Job export

### DIFF
--- a/app/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy.rb
+++ b/app/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy.rb
@@ -67,7 +67,10 @@ module Vacancies::Export::DwpFindAJob::PublishedAndUpdatedVacancies
     private
 
     def description_paragraph(title, text)
-      plain_text = ActionText::Fragment.from_html(text&.squish).to_plain_text
+      sanitized_text = text&.scrub("") # remove invalid byte sequences
+                           &.squish # remove leading/trailing whitespace and collapse multiple spaces
+                           &.gsub(/[\u0001-\u001A]/, "") # remove control chars, unicode codepoints from 0001 to 001A (Invalid under XML 1.0)
+      plain_text = ActionText::Fragment.from_html(sanitized_text).to_plain_text # convert HTML tags into plain text representation
       plain_text.present? ? "#{title}\n\n#{plain_text}\n\n" : ""
     end
   end

--- a/spec/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy_spec.rb
+++ b/spec/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy_spec.rb
@@ -147,6 +147,26 @@ RSpec.describe Vacancies::Export::DwpFindAJob::PublishedAndUpdated::ParsedVacanc
         )
       end
     end
+
+    context "when the vacancy job details contains an invalid byte sequence" do
+      before do
+        allow(vacancy).to receive(:skills_and_experience).and_return("Multi\x80\x80\x80Academy Trust")
+      end
+
+      it "removes them" do
+        expect(parsed.description).to eq("What skills and experience we're looking for\n\nMultiAcademy Trust")
+      end
+    end
+
+    context "when the vacancy job details contains unicode special characters" do
+      before do
+        allow(vacancy).to receive(:skills_and_experience).and_return("Multi\u0002'Academy' Trust. Any other info?")
+      end
+
+      it "removes them" do
+        expect(parsed.description).to eq("What skills and experience we're looking for\n\nMulti'Academy' Trust. Any other info?")
+      end
+    end
   end
 
   describe "#expiry" do


### PR DESCRIPTION
## Trello card URL

## Changes in this PR:

The export reading from DWP Find a Job is failing due to some of our vacancy descriptions containing Unicode control characters that are invalid with XML 1.0 specifications.

## Screenshots of UI changes:

![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/9ff1f5dd-7b77-49cd-97ae-0bef8103076c)


![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/c0264720-dbdc-430a-8525-e62783ee1090)

