### PR TITLE
Find a Job: Do not set explicit 30 days expiration

### DIFF
--- a/app/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy.rb
+++ b/app/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy.rb
@@ -39,7 +39,9 @@ module Vacancies::Export::DwpFindAJob::PublishedAndUpdatedVacancies
 
     def expiry
       expiry_date = vacancy.expires_at.to_date
-      return unless expiry_date.between?(Date.today + 1, Date.today + 30.days)
+      # Why max 29 days? Find a Job is rejecting vacancies where the expiry date 30 days from today is explicitly set.
+      # If left blank it will default to 30 days from today without rejection.
+      return unless expiry_date.between?(Date.today + 1, Date.today + 29.days)
 
       expiry_date.to_s
     end

--- a/spec/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy_spec.rb
+++ b/spec/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy_spec.rb
@@ -191,8 +191,8 @@ RSpec.describe Vacancies::Export::DwpFindAJob::PublishedAndUpdated::ParsedVacanc
       expect(parsed.expiry).to be_nil
     end
 
-    it "returns nil if the vacancy expiry date is more than 30 days in the future" do
-      allow(vacancy).to receive(:expires_at).and_return(Date.today + 31.days)
+    it "returns nil if the vacancy expiry date is more than 29 days in the future" do
+      allow(vacancy).to receive(:expires_at).and_return(Date.today + 30.days)
 
       expect(parsed.expiry).to be_nil
     end


### PR DESCRIPTION
Find a job service only allows an expiration date for the vacancies between 1 and 30 days from the publish/update date.

When we tried to push vacancies explicitly setting the expiration date to "30 days from now" it gets rejected and the update doesn't get published in the Find a Job service.

The rejection error is:
"Closing date must be between posting/editing date +1 day and posting date +30 days"

If we leave the field empty, it will set the "30 days from now" date when importing it on their side, as it is their default.

So we are reducing the maximum days to explicitly set to "29 days from now", and if it is later than that, it will be defaulted by the service to 30 days.

### Example: On June 30th was rejecting vacancies with expiry date set for July 30th (30 days after)
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/9e31218d-5eb0-4947-b486-f50f5666de76)
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/afbe139b-fd5a-4f31-8409-d07e19627dc9)
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/33e867b5-5aca-4591-8ef0-0ee97b8f3f7a)

### Meanwhile, on Find a Job service, when originally published leaving the field empty, automatically set it to 30 days from the publishing date:
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/5892f990-b310-4662-9425-7386e0b42dff)
