### PR TITLE
Remove references to flexible or term_time working patterns

### DIFF
--- a/app/form_models/jobseekers/job_preferences_form.rb
+++ b/app/form_models/jobseekers/job_preferences_form.rb
@@ -9,7 +9,7 @@ module Jobseekers
                sendco administration_hr_data_and_finance catering_cleaning_and_site_management it_support
                pastoral_health_and_welfare other_leadership other_support].freeze
     PHASES = %i[nursery primary middle secondary through].freeze
-    WORKING_PATTERNS = %i[full_time part_time flexible job_share term_time].freeze
+    WORKING_PATTERNS = %i[full_time part_time job_share].freeze
 
     def self.from_record(record)
       new(

--- a/app/form_models/publishers/jobseeker_profile_search_form.rb
+++ b/app/form_models/publishers/jobseeker_profile_search_form.rb
@@ -30,7 +30,7 @@ class Publishers::JobseekerProfileSearchForm
   end
 
   def working_pattern_options
-    %w[full_time part_time flexible job_share term_time].map do |working_pattern|
+    %w[full_time part_time job_share].map do |working_pattern|
       [working_pattern, I18n.t(working_pattern, scope: "publishers.jobseeker_profiles.filters.working_pattern_options")]
     end
   end

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -42,7 +42,7 @@ class Vacancy < ApplicationRecord
                          it_support pastoral_health_and_welfare other_support].freeze
 
   array_enum key_stages: { early_years: 0, ks1: 1, ks2: 2, ks3: 3, ks4: 4, ks5: 5 }
-  array_enum working_patterns: { full_time: 0, part_time: 100, flexible: 104, job_share: 101, term_time: 102 }
+  array_enum working_patterns: { full_time: 0, part_time: 100, job_share: 101 }
   array_enum phases: { nursery: 0, primary: 1, middle: 2, secondary: 3, sixth_form_or_college: 4, through: 5 }
   array_enum job_roles: JOB_ROLES
 

--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -49,7 +49,7 @@ class VacancyPresenter < BasePresenter
       ("FULL_TIME" if model.working_patterns.include? "full_time"),
       ("PART_TIME" if model.working_patterns.include? "part_time"),
       ("TEMPORARY" if model.fixed_term_contract_duration?),
-      ("OTHER" if model.working_patterns.any? { |working_pattern| working_pattern.in? %w[flexible job_share term_time] } && !model.fixed_term_contract_duration?),
+      ("OTHER" if model.working_patterns.any?("job_share") && !model.fixed_term_contract_duration?),
     ].compact
   end
 

--- a/app/views/home/_landing_page_links.html.slim
+++ b/app/views/home/_landing_page_links.html.slim
@@ -30,9 +30,7 @@
       = landing_page_link_group title: t(".working_patterns"), classes: "govuk-grid-column-one-third" do |group|
         = group.with_landing_page "full-time-school-jobs"
         = group.with_landing_page "part-time-school-jobs"
-        = group.with_landing_page "flexible-working-jobs-in-schools"
         = group.with_landing_page "school-job-shares"
-        = group.with_landing_page "school-term-time-jobs"
 
     - accordion.with_section(heading_text: t(".jobs_by_location")) do
       .govuk-grid-column-one-third

--- a/config/landing_pages.yml
+++ b/config/landing_pages.yml
@@ -203,10 +203,10 @@ shared:
       - job_share
   school-term-time-jobs:
     working_patterns:
-      - term_time
+      - part_time
   flexible-working-jobs-in-schools:
     working_patterns:
-      - flexible
+      - part_time
 
 ####################################################################################################
 # The data below is only used in automated tests, make sure you add your landing pages to the

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -854,11 +854,9 @@ en:
           academy: Academy
           local_authority: Local authority maintained schools
         working_patterns_options:
-          flexible: Flexible
           full_time: Full time
           job_share: Job share
           part_time: Part time
-          term_time: Term time
       publishers_vacancy_statistics_form:
         hired_status: Job filled on Teaching Vacancies?
         listed_elsewhere: Listed elsewhere?

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -131,11 +131,9 @@ en:
           sendco: SENDCo (special educational needs and disabilities coordinator)
         schools: Locations
         working_pattern_options:
-          flexible: Flexible
           full_time: Full time
           job_share: Job share
           part_time: Part time
-          term_time: Term time
         right_to_work_in_uk_options:
           "true": "Does not need visa sponsorship"
           "false": "Needs visa sponsorship"

--- a/config/search/keyword_filter_mappings.yml
+++ b/config/search/keyword_filter_mappings.yml
@@ -131,7 +131,7 @@
     - Media studies
 "flexible":
   working_patterns:
-    - flexible
+    - part_time
 "finance teacher":
   phases:
     - secondary

--- a/spec/helpers/vacancies_helper_spec.rb
+++ b/spec/helpers/vacancies_helper_spec.rb
@@ -286,10 +286,10 @@ RSpec.describe VacanciesHelper do
     subject { vacancy_working_patterns(vacancy) }
     context "when vacancy does is not a job share" do
       context "when the vacancy does not contain working patterns details" do
-        let(:vacancy) { build_stubbed(:vacancy, working_patterns: %w[full_time flexible], working_patterns_details: nil, is_job_share: false) }
+        let(:vacancy) { build_stubbed(:vacancy, working_patterns: %w[full_time part_time], working_patterns_details: nil) }
 
         it "returns a summary of the working patterns" do
-          expect(subject).to eq("<li>Full time, flexible</li>")
+          expect(subject).to eq("<li>Full time, part time</li>")
         end
       end
 

--- a/spec/helpers/vacancies_helper_spec.rb
+++ b/spec/helpers/vacancies_helper_spec.rb
@@ -286,7 +286,7 @@ RSpec.describe VacanciesHelper do
     subject { vacancy_working_patterns(vacancy) }
     context "when vacancy does is not a job share" do
       context "when the vacancy does not contain working patterns details" do
-        let(:vacancy) { build_stubbed(:vacancy, working_patterns: %w[full_time part_time], working_patterns_details: nil) }
+        let(:vacancy) { build_stubbed(:vacancy, working_patterns: %w[full_time part_time], working_patterns_details: nil, is_job_share: false) }
 
         it "returns a summary of the working patterns" do
           expect(subject).to eq("<li>Full time, part time</li>")
@@ -304,10 +304,10 @@ RSpec.describe VacanciesHelper do
 
     context "when vacancy does is a job share" do
       context "when the vacancy does not contain working patterns details" do
-        let(:vacancy) { build_stubbed(:vacancy, working_patterns: %w[full_time flexible], working_patterns_details: nil, is_job_share: true) }
+        let(:vacancy) { build_stubbed(:vacancy, working_patterns: %w[full_time part_time], working_patterns_details: nil, is_job_share: true) }
 
         it "returns a summary of the working patterns" do
-          expect(subject).to eq("<li>Full time, flexible, open to job share</li>")
+          expect(subject).to eq("<li>Full time, part time, open to job share</li>")
         end
       end
 

--- a/spec/services/vacancies/import/sources/united_learning_spec.rb
+++ b/spec/services/vacancies/import/sources/united_learning_spec.rb
@@ -161,10 +161,10 @@ RSpec.describe Vacancies::Import::Sources::UnitedLearning do
         end
 
         context "when the working patterns contain multiple valid values" do
-          let(:working_patterns) { "part_time,full_time,job_share,flexible" }
+          let(:working_patterns) { "part_time,full_time,job_share" }
 
           it "records them all in the vacancy" do
-            expect(vacancy.working_patterns).to contain_exactly("part_time", "full_time", "job_share", "flexible")
+            expect(vacancy.working_patterns).to contain_exactly("part_time", "full_time", "job_share")
           end
         end
 


### PR DESCRIPTION
## NOTE: run this rake task before merging this PR https://github.com/DFE-Digital/teaching-vacancies/pull/6952

## Trello card URL

https://trello.com/c/sBZZrORD/1064-remove-flexible-and-term-time-working-patterns

## Changes in this PR:

This PR removes flexible and term time working patterns and updates the landing pages for these working patterns to show part time jobs.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
