### PR TITLE
Remove DfE::Analytics::SendEvents from logs

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -74,9 +74,13 @@ Rails.application.configure do
   config.semantic_logger.application = "" # No need to send the application name as logstash reads it from Cloud Foundry log tags
   config.rails_semantic_logger.format = :json
   config.rails_semantic_logger.add_file_appender = false
+  config.rails_semantic_logger.filter = proc { |log| log.name != "DfE::Analytics::SendEvents" }
   config.active_record.logger = nil # Don't log SQL in production
   config.semantic_logger.backtrace_level = :error
-  config.semantic_logger.add_appender(io: $stdout, level: config.log_level, formatter: config.rails_semantic_logger.format)
+  config.semantic_logger.add_appender(io: $stdout,
+                                      level: config.log_level,
+                                      formatter: config.rails_semantic_logger.format,
+                                      filter: config.rails_semantic_logger.filter)
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false


### PR DESCRIPTION
These jobs are constantly run and clog our Logit.io instances due to the high volume of updates. 
We do not need them Logit as doesn't give us any valuable info/context.

We're filtering them out through Semantic logger.
