### PR TITLE
Repost vacancies on Find a Job every 31 days

### DIFF
--- a/app/services/vacancies/export/dwp_find_a_job/closed_early_vacancies/xml.rb
+++ b/app/services/vacancies/export/dwp_find_a_job/closed_early_vacancies/xml.rb
@@ -2,6 +2,8 @@ require "nokogiri"
 
 module Vacancies::Export::DwpFindAJob::ClosedEarlyVacancies
   class Xml
+    include Vacancies::Export::DwpFindAJob::Versioning
+
     attr_reader :vacancies
 
     def initialize(vacancies)
@@ -14,7 +16,7 @@ module Vacancies::Export::DwpFindAJob::ClosedEarlyVacancies
       Nokogiri::XML::Builder.new(encoding: "UTF-8") { |xml|
         xml.ExpireVacancies do
           vacancies.each do |vacancy|
-            xml.ExpireVacancy(vacancyRefCode: vacancy.id)
+            xml.ExpireVacancy(vacancyRefCode: versioned_reference(vacancy))
           end
         end
       }.to_xml

--- a/app/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/xml.rb
+++ b/app/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/xml.rb
@@ -29,7 +29,7 @@ module Vacancies::Export::DwpFindAJob::PublishedAndUpdatedVacancies
 
       vacancy = ParsedVacancy.new(vacancy)
 
-      xml.Vacancy(vacancyRefCode: vacancy.id) do
+      xml.Vacancy(vacancyRefCode: vacancy.reference) do
         xml.Title vacancy.job_title
         xml.Description vacancy.description
         xml.Location do

--- a/app/services/vacancies/export/dwp_find_a_job/versioning.rb
+++ b/app/services/vacancies/export/dwp_find_a_job/versioning.rb
@@ -1,0 +1,29 @@
+module Vacancies::Export::DwpFindAJob::Versioning
+  # Find a Job vacancies can only be live to 30 days from the original posted date.
+  # They need to ve reposted as a different job advert every 31 days.
+  DAYS_BETWEEN_REPOSTS = 31
+  MIN_LIVE_DAYS = 1
+  MAX_LIVE_DAYS = 30
+
+  # It generates a versioned reference for a vacancy.
+  # The original reference for a vacancy on its first publishing period in Find a Job service is the vacancy id.
+  # Each repost period will version the reference as "id-1", "id-2", "id-3", etc.
+  def versioned_reference(vacancy)
+    version = version(vacancy)
+    return unless version
+
+    version.zero? ? vacancy.id : vacancy.id + "-#{version}"
+  end
+
+  # Each repost of a vacancy will have an incremental version number.
+  def version(vacancy)
+    return if vacancy.publish_on.blank? || vacancy.publish_on.to_date > Date.today
+
+    published_days = (Date.today - vacancy.publish_on.to_date).to_i
+    if published_days < DAYS_BETWEEN_REPOSTS
+      0
+    else
+      published_days / DAYS_BETWEEN_REPOSTS
+    end
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -18,6 +18,8 @@ export_users:
   class: 'ExportDSIUsersToBigQueryJob'
   queue: low
 
+# Internal querying & parsing of Find a Job export data depends on this running time.
+# Be careful if changing this time as you will need to adapt the code.
 export_vacancies_published_and_updated_to_dwp_find_a_job_service:
   cron: '30 23 * * *'
   class: 'ExportVacanciesPublishedAndUpdatedSinceYesterdayToDwpFindAJobServiceJob'

--- a/spec/services/vacancies/export/dwp_find_a_job/closed_early_vacancies/xml_spec.rb
+++ b/spec/services/vacancies/export/dwp_find_a_job/closed_early_vacancies/xml_spec.rb
@@ -2,21 +2,43 @@ require "rails_helper"
 
 RSpec.describe Vacancies::Export::DwpFindAJob::ClosedEarlyVacancies::Xml do
   describe "#xml" do
-    let(:vacancy1) { instance_double(Vacancy, id: 1) }
-    let(:vacancy2) { instance_double(Vacancy, id: 2) }
-
     subject { described_class.new([vacancy1, vacancy2]) }
+
+    let(:vacancy1) { instance_double(Vacancy, id: "ff7af59b-558b-4c55-9941-fe1942d84984", publish_on: 3.days.ago) }
+    let(:vacancy2) { instance_double(Vacancy, id: "0ee558c1-3587-4f7a-a0c2-d40a2289c7fe", publish_on: 30.days.ago) }
+
+    before { travel_to(Time.zone.local(2024, 5, 2, 1, 4, 44)) }
+    after { travel_back }
 
     it "generates an XML document with the given vacancy references to be deleted" do
       expect(subject.xml).to eq(
         <<~XML,
           <?xml version="1.0" encoding="UTF-8"?>
           <ExpireVacancies>
-            <ExpireVacancy vacancyRefCode="1"/>
-            <ExpireVacancy vacancyRefCode="2"/>
+            <ExpireVacancy vacancyRefCode="ff7af59b-558b-4c55-9941-fe1942d84984"/>
+            <ExpireVacancy vacancyRefCode="0ee558c1-3587-4f7a-a0c2-d40a2289c7fe"/>
           </ExpireVacancies>
         XML
       )
+    end
+
+    context "when the vacancy that was closed early was published longer than 30 days ago" do
+      before do
+        allow(vacancy1).to receive(:publish_on).and_return(31.days.ago)
+        allow(vacancy2).to receive(:publish_on).and_return(62.days.ago)
+      end
+
+      it "uses the appropriate version in of the advert reference" do
+        expect(subject.xml).to eq(
+          <<~XML,
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ExpireVacancies>
+              <ExpireVacancy vacancyRefCode="ff7af59b-558b-4c55-9941-fe1942d84984-1"/>
+              <ExpireVacancy vacancyRefCode="0ee558c1-3587-4f7a-a0c2-d40a2289c7fe-2"/>
+            </ExpireVacancies>
+          XML
+        )
+      end
     end
 
     context "when there are no vacancies to be deleted" do

--- a/spec/services/vacancies/export/dwp_find_a_job/published_and_updated_spec.rb
+++ b/spec/services/vacancies/export/dwp_find_a_job/published_and_updated_spec.rb
@@ -56,6 +56,24 @@ RSpec.describe Vacancies::Export::DwpFindAJob::PublishedAndUpdated do
              slug: "it-technician",
              organisations: [org])
     end
+    let(:vacancy_to_be_reposted) do
+      create(:vacancy,
+             :published,
+             id: "51d379eb-78f8-47ab-be8e-307887d4c807",
+             publish_on: 62.days.ago,
+             updated_at: 62.days.ago,
+             created_at: 62.days.ago,
+             job_title: "Maths teacher",
+             skills_and_experience: "We need a maths teacher",
+             school_offer: "We offer a great school for a maths teacher",
+             further_details: "More details",
+             expires_at: Time.zone.local(2024, 5, 17, 9, 0, 0),
+             working_patterns: ["full_time"],
+             job_roles: ["teacher"],
+             contract_type: "permanent",
+             slug: "maths-teacher",
+             organisations: [org])
+    end
 
     let(:expected_xml_content) do
       <<~XML
@@ -102,6 +120,36 @@ RSpec.describe Vacancies::Export::DwpFindAJob::PublishedAndUpdated do
             <ApplyMethod id="2"/>
             <ApplyUrl>http://#{DOMAIN}/jobs/great-teacher</ApplyUrl>
           </Vacancy>
+          <Vacancy vacancyRefCode="#{vacancy_to_be_reposted.id}-2">
+            <Title>Maths teacher</Title>
+            <Description>What skills and experience we're looking for
+
+        We need a maths teacher
+
+        What the school offers its staff
+
+        We offer a great school for a maths teacher
+
+        Further details about the role
+
+        More details
+
+        Commitment to safeguarding
+
+        Safeguarding text</Description>
+            <Location>
+              <StreetAddress>1 School Lane</StreetAddress>
+              <City>School Town</City>
+              <State>School County</State>
+              <PostalCode>AB12 3CD</PostalCode>
+            </Location>
+            <VacancyExpiry>2024-05-17</VacancyExpiry>
+            <VacancyType id="1"/>
+            <VacancyStatus id="1"/>
+            <VacancyCategory id="27"/>
+            <ApplyMethod id="2"/>
+            <ApplyUrl>http://#{DOMAIN}/jobs/maths-teacher</ApplyUrl>
+          </Vacancy>
           <Vacancy vacancyRefCode="#{vacancy_updated.id}">
             <Title>IT technician</Title>
             <Description>What skills and experience we're looking for
@@ -144,6 +192,7 @@ RSpec.describe Vacancies::Export::DwpFindAJob::PublishedAndUpdated do
       travel_to(Time.zone.local(2024, 5, 2, 1, 4, 44))
       vacancy_published_old
       vacancy_published
+      vacancy_to_be_reposted
       vacancy_updated
 
       allow(Tempfile).to receive(:new).with(filename).and_return(tempfile)
@@ -169,7 +218,7 @@ RSpec.describe Vacancies::Export::DwpFindAJob::PublishedAndUpdated do
 
       subject.call
       expect(Rails.logger).to have_received(:info)
-        .with("[DWP Find a Job] Uploaded '#{filename}.xml': Containing 2 vacancies to publish.")
+        .with("[DWP Find a Job] Uploaded '#{filename}.xml': Containing 3 vacancies to publish.")
     end
   end
 end

--- a/spec/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/xml_spec.rb
+++ b/spec/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/xml_spec.rb
@@ -14,7 +14,7 @@ module Vacancies::Export::DwpFindAJob::PublishedAndUpdatedVacancies
       let(:parsed_vacancy) do
         instance_double(
           ParsedVacancy,
-          id: "10",
+          reference: "10",
           organisation: org,
           job_title: "Awesome teacher",
           description: "Job description",
@@ -139,7 +139,7 @@ module Vacancies::Export::DwpFindAJob::PublishedAndUpdatedVacancies
         let(:parsed_vacancy2) do
           instance_double(
             ParsedVacancy,
-            id: "11",
+            reference: "11",
             organisation: org,
             job_title: "Another teacher",
             description: "Another job description",

--- a/spec/services/vacancies/export/dwp_find_a_job/versioning_spec.rb
+++ b/spec/services/vacancies/export/dwp_find_a_job/versioning_spec.rb
@@ -1,0 +1,196 @@
+require "rails_helper"
+
+class DummyExport
+  include Vacancies::Export::DwpFindAJob::Versioning
+end
+
+RSpec.describe Vacancies::Export::DwpFindAJob::Versioning do
+  let(:vacancy) { build_stubbed(:vacancy, publish_on: publish_date) }
+
+  before { travel_to(Time.zone.local(2024, 5, 2, 1, 4, 44)) }
+  after { travel_back }
+
+  describe "#version" do
+    subject(:version) { DummyExport.new.version(vacancy) }
+
+    context "when the vacancy does not have publishing date set" do
+      let(:publish_date) { nil }
+
+      it "returns nil" do
+        expect(version).to be_nil
+      end
+    end
+
+    context "when the vacancy publishing date is empty" do
+      let(:publish_date) { "" }
+
+      it "returns nil" do
+        expect(version).to be_nil
+      end
+    end
+
+    context "when the vacancy publishing date is in the future" do
+      let(:publish_date) { 1.day.from_now }
+
+      it "returns nil" do
+        expect(version).to be_nil
+      end
+    end
+
+    context "when the vacancy publishing date is today" do
+      let(:publish_date) { Date.current }
+
+      it "returns 0" do
+        expect(version).to eq(0)
+      end
+    end
+
+    context "when the vacancy was published less than 31 days ago" do
+      let(:publish_date) { 30.days.ago }
+
+      it "returns 0" do
+        expect(version).to eq(0)
+      end
+    end
+
+    context "when the vacancy was published 31 days ago" do
+      let(:publish_date) { 31.days.ago }
+
+      it "returns 1" do
+        expect(version).to eq(1)
+      end
+    end
+
+    context "when the vacancy was published 61 days ago" do
+      let(:publish_date) { 61.days.ago }
+
+      it "returns 1" do
+        expect(version).to eq(1)
+      end
+    end
+
+    context "when the vacancy was published 62 days ago" do
+      let(:publish_date) { 62.days.ago }
+
+      it "returns 2" do
+        expect(version).to eq(2)
+      end
+    end
+
+    context "when the vacancy was published 92 days ago" do
+      let(:publish_date) { 92.days.ago }
+
+      it "returns 2" do
+        expect(version).to eq(2)
+      end
+    end
+
+    context "when the vacancy was published 93 days ago" do
+      let(:publish_date) { 93.days.ago }
+
+      it "returns 3" do
+        expect(version).to eq(3)
+      end
+    end
+
+    context "when the vacancy was published 372 days ago" do
+      let(:publish_date) { 372.days.ago }
+
+      it "returns 12" do
+        expect(version).to eq(12)
+      end
+    end
+  end
+
+  describe "#versioned_reference" do
+    subject(:versioned_reference) { DummyExport.new.versioned_reference(vacancy) }
+
+    context "when the vacancy does not have publishing date set" do
+      let(:publish_date) { nil }
+
+      it "returns nil" do
+        expect(versioned_reference).to be_nil
+      end
+    end
+
+    context "when the vacancy publishing date is empty" do
+      let(:publish_date) { "" }
+
+      it "returns nil" do
+        expect(versioned_reference).to be_nil
+      end
+    end
+
+    context "when the vacancy publishing date is in the future" do
+      let(:publish_date) { 1.day.from_now }
+
+      it "returns nil" do
+        expect(versioned_reference).to be_nil
+      end
+    end
+
+    context "when the vacancy publishing date is today" do
+      let(:publish_date) { Date.current }
+
+      it "returns the vacancy id" do
+        expect(versioned_reference).to eq(vacancy.id)
+      end
+    end
+
+    context "when the vacancy was published less than 31 days ago" do
+      let(:publish_date) { 30.days.ago }
+
+      it "returns the vacancy id" do
+        expect(versioned_reference).to eq(vacancy.id)
+      end
+    end
+
+    context "when the vacancy was published 31 days ago" do
+      let(:publish_date) { 31.days.ago }
+
+      it "returns the vacancy id with a suffix version: '-1'" do
+        expect(versioned_reference).to eq("#{vacancy.id}-1")
+      end
+    end
+
+    context "when the vacancy was published 61 days ago" do
+      let(:publish_date) { 61.days.ago }
+
+      it "returns the vacancy id with a suffix version: '-1'" do
+        expect(versioned_reference).to eq("#{vacancy.id}-1")
+      end
+    end
+
+    context "when the vacancy was published 62 days ago" do
+      let(:publish_date) { 62.days.ago }
+
+      it "returns the vacancy id with a suffix version: '-2'" do
+        expect(versioned_reference).to eq("#{vacancy.id}-2")
+      end
+    end
+
+    context "when the vacancy was published 92 days ago" do
+      let(:publish_date) { 92.days.ago }
+
+      it "returns the vacancy id with a suffix version: '-2'" do
+        expect(versioned_reference).to eq("#{vacancy.id}-2")
+      end
+    end
+
+    context "when the vacancy was published 93 days ago" do
+      let(:publish_date) { 93.days.ago }
+
+      it "returns the vacancy id with a suffix version: '-3'" do
+        expect(versioned_reference).to eq("#{vacancy.id}-3")
+      end
+    end
+
+    context "when the vacancy was published 372 days ago" do
+      let(:publish_date) { 372.days.ago }
+
+      it "returns the vacancy id with a suffix version: '-12'" do
+        expect(versioned_reference).to eq("#{vacancy.id}-12")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/JkJr98UZ/1068-fix-find-a-job-doesnt-allow-to-push-back-expiry-dates

## Changes in this PR:

The original attempt to keep our vacancies published for longer than 30 days in Find a Job service failed, as they don't allow adverts to live for longer than 30 days after they originally got posted.

The only way to keep our vacancies posted on Find a Job for the whole lifespan of the vacancy in our service is to keep reposting them every 31 days, just when the original/previous version of the advert reaches its day limit and is no longer posted.

The key concept in the new approach is "Vacancy versioning".

Vacancy versioning is based on how many days have passed since the vacancy was published on TV.
- The original version of the vacancy will be published on Find a Job for 30 days after published on TV (and exported to Find a Job).
- 31 days after TV vacancy was published, it will be reposted under a new version.
- 62 days after TV vacancy was published, a further new version will be used to repost the vacancy.
- etc until the repost covers the period where the vacancy expires in our service.

To post different versioned adverts for the same vacancy, we will use the vacancy uuid as a reference for the first advert.

After that, we will suffix the vacancy uuid with a "-1", "-2", "-3",... Each corresponds with the particular "days since" version for the current date.

## Screenshots:
![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/346ffbde-a81b-4aa8-8c9b-f73859f887ad)

![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/6f7a3180-0996-4de4-a3d8-886eb8b8222a)

![image](https://github.com/DFE-Digital/teaching-vacancies/assets/1227578/e935a369-f530-4546-8cf4-7a12bda87101)



## Next steps:

- [ ] Merge after all the bulk uploaded vacancies are expired on DWP Find a Job (July 26th)
