### PR TITLE
Reduce empty lines between DWP find a Job paragraphs

### DIFF
--- a/app/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy.rb
+++ b/app/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy.rb
@@ -69,11 +69,25 @@ module Vacancies::Export::DwpFindAJob::PublishedAndUpdatedVacancies
     private
 
     def description_paragraph(title, text)
-      sanitized_text = text&.scrub("") # remove invalid byte sequences
-                           &.squish # remove leading/trailing whitespace and collapse multiple spaces
-                           &.gsub(/[\u0001-\u001A]/, "") # remove control chars, unicode codepoints from 0001 to 001A (Invalid under XML 1.0)
-      plain_text = ActionText::Fragment.from_html(sanitized_text).to_plain_text # convert HTML tags into plain text representation
-      plain_text.present? ? "#{title}\n\n#{plain_text}\n\n" : ""
+      plain_text = html_to_plain_text(text)
+      return "" if plain_text.blank?
+
+      "#{title}\n\n#{plain_text}\n\n"
+    end
+
+    def html_to_plain_text(html)
+      ActionText::Fragment.from_html(sanitize(html))
+                          .to_plain_text # convert HTML tags into plain text representation
+                          .strip
+                          .gsub(/(\s*\n\n\s*){2,}/, "\n\n") # reduce paragraph breaks to a single empty line between paragraphs
+    end
+
+    def sanitize(text)
+      return unless text
+
+      text.scrub("") # remove invalid byte sequences
+          .squish # remove leading/trailing whitespace and collapse multiple spaces
+          .gsub(/[\u0001-\u001A]/, "") # remove control chars, unicode codepoints from 0001 to 001A (Invalid under XML 1.0)
     end
   end
 end

--- a/documentation/integrations/dwp-find-a-job.md
+++ b/documentation/integrations/dwp-find-a-job.md
@@ -137,6 +137,8 @@ classDiagram
       +status_id()
       +type_id()
       -description_paragraph(title, text)
+      -html_to_plain_text(html)
+      -sanitize(text)
     }
 
   }

--- a/spec/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy_spec.rb
+++ b/spec/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy_spec.rb
@@ -148,6 +148,20 @@ RSpec.describe Vacancies::Export::DwpFindAJob::PublishedAndUpdated::ParsedVacanc
       end
     end
 
+    context "when the vacancy job details have more than 2 consecutive line breaks" do
+      before do
+        allow(vacancy).to receive(:skills_and_experience).and_return(
+          "<p>\r\n\r\n\r\n</p><p>The\r\nsuccessful candidate willwork as a 1:1 GTA, working alongside our teaching\r\nteam. </p><p>\r\n\r\n\r\n\r\n</p><p>Second\r\nparagraph.</p><p>\r\n\r\n</p><p>We are aspirational for every\r\nstudent within our Trust.</p><p>\r\n\r\n\r\n\r\n\r\n\r\n</p>",
+        )
+      end
+
+      it "normalises the empty lines between content to maximum 1 empty line" do
+        expect(parsed.description).to eq(
+          "What skills and experience we're looking for\n\nThe successful candidate willwork as a 1:1 GTA, working alongside our teaching team.\n\nSecond paragraph.\n\nWe are aspirational for every student within our Trust.",
+        )
+      end
+    end
+
     context "when the vacancy job details contains an invalid byte sequence" do
       before do
         allow(vacancy).to receive(:skills_and_experience).and_return("Multi\x80\x80\x80Academy Trust")


### PR DESCRIPTION
On DWP Find a Job description generation, when parsing multiple paragraphs, the resulting job description often has numerous empty lines between the paragraphs.

Reducing it to a single empty line is more readable on the output advert.
