### PR TITLE
Add casual contract type

### DIFF
--- a/app/controllers/concerns/publishers/wizardable.rb
+++ b/app/controllers/concerns/publishers/wizardable.rb
@@ -52,7 +52,7 @@ module Publishers::Wizardable
 
   def contract_type_params(params)
     params.require(:publishers_job_listing_contract_type_form)
-          .permit(:contract_type, :fixed_term_contract_duration, :parental_leave_cover_contract_duration)
+          .permit(:contract_type, :fixed_term_contract_duration, :is_parental_leave_cover)
           .merge(completed_steps: completed_steps)
   end
 

--- a/app/form_models/publishers/job_listing/contract_type_form.rb
+++ b/app/form_models/publishers/job_listing/contract_type_form.rb
@@ -1,11 +1,11 @@
 class Publishers::JobListing::ContractTypeForm < Publishers::JobListing::VacancyForm
-  attr_accessor :contract_type, :fixed_term_contract_duration, :parental_leave_cover_contract_duration
+  attr_accessor :contract_type, :fixed_term_contract_duration, :parental_leave_cover_contract_duration, :is_parental_leave_cover
 
   validates :contract_type, inclusion: { in: Vacancy.contract_types.keys }
   validates :fixed_term_contract_duration, presence: true, if: -> { contract_type == "fixed_term" }
-  validates :parental_leave_cover_contract_duration, presence: true, if: -> { contract_type == "parental_leave_cover" }
+  validates :is_parental_leave_cover, inclusion: { in: ["true", "false", true, false] }, if: -> { contract_type == "fixed_term" }
 
   def self.fields
-    %i[contract_type fixed_term_contract_duration parental_leave_cover_contract_duration]
+    %i[contract_type fixed_term_contract_duration parental_leave_cover_contract_duration is_parental_leave_cover]
   end
 end

--- a/app/form_models/publishers/job_listing/contract_type_form.rb
+++ b/app/form_models/publishers/job_listing/contract_type_form.rb
@@ -1,11 +1,11 @@
 class Publishers::JobListing::ContractTypeForm < Publishers::JobListing::VacancyForm
-  attr_accessor :contract_type, :fixed_term_contract_duration, :parental_leave_cover_contract_duration, :is_parental_leave_cover
+  attr_accessor :contract_type, :fixed_term_contract_duration, :is_parental_leave_cover
 
   validates :contract_type, inclusion: { in: Vacancy.contract_types.keys }
   validates :fixed_term_contract_duration, presence: true, if: -> { contract_type == "fixed_term" }
   validates :is_parental_leave_cover, inclusion: { in: ["true", "false", true, false] }, if: -> { contract_type == "fixed_term" }
 
   def self.fields
-    %i[contract_type fixed_term_contract_duration parental_leave_cover_contract_duration is_parental_leave_cover]
+    %i[contract_type fixed_term_contract_duration is_parental_leave_cover]
   end
 end

--- a/app/models/concerns/resettable.rb
+++ b/app/models/concerns/resettable.rb
@@ -8,7 +8,6 @@ module Resettable
   def reset_dependent_fields
     reset_actual_salary
     reset_fixed_term_contract_duration
-    reset_parental_leave_cover_contract_duration
     reset_keystages
     reset_subjects
     set_default_key_stage
@@ -36,12 +35,6 @@ module Resettable
     return unless contract_type_changed? && contract_type != "fixed_term"
 
     self.fixed_term_contract_duration = ""
-  end
-
-  def reset_parental_leave_cover_contract_duration
-    return unless contract_type_changed? && contract_type != "parental_leave_cover"
-
-    self.parental_leave_cover_contract_duration = ""
   end
 
   def reset_keystages

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -46,7 +46,7 @@ class Vacancy < ApplicationRecord
   array_enum phases: { nursery: 0, primary: 1, middle: 2, secondary: 3, sixth_form_or_college: 4, through: 5 }
   array_enum job_roles: JOB_ROLES
 
-  enum contract_type: { permanent: 0, fixed_term: 1, casual: 3 }
+  enum contract_type: { permanent: 0, fixed_term: 1, parental_leave_cover: 2, casual: 3 }
   enum ect_status: { ect_suitable: 0, ect_unsuitable: 1 }
   enum hired_status: { hired_tvs: 0, hired_other_free: 1, hired_paid: 2, hired_no_listing: 3, not_filled_ongoing: 4, not_filled_not_looking: 5, hired_dont_know: 6 }
   enum listed_elsewhere: { listed_paid: 0, listed_free: 1, listed_mix: 2, not_listed: 3, listed_dont_know: 4 }

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -46,7 +46,7 @@ class Vacancy < ApplicationRecord
   array_enum phases: { nursery: 0, primary: 1, middle: 2, secondary: 3, sixth_form_or_college: 4, through: 5 }
   array_enum job_roles: JOB_ROLES
 
-  enum contract_type: { permanent: 0, fixed_term: 1, parental_leave_cover: 2 }
+  enum contract_type: { permanent: 0, fixed_term: 1, casual: 3 }
   enum ect_status: { ect_suitable: 0, ect_unsuitable: 1 }
   enum hired_status: { hired_tvs: 0, hired_other_free: 1, hired_paid: 2, hired_no_listing: 3, not_filled_ongoing: 4, not_filled_not_looking: 5, hired_dont_know: 6 }
   enum listed_elsewhere: { listed_paid: 0, listed_free: 1, listed_mix: 2, not_listed: 3, listed_dont_know: 4 }

--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -78,11 +78,13 @@ class VacancyPresenter < BasePresenter
   def contract_type_with_duration
     return nil unless model.contract_type.present?
 
-    duration = model.fixed_term? ? model.fixed_term_contract_duration : model.parental_leave_cover_contract_duration
+    return I18n.t("publishers.vacancies.build.contract_type.#{model.contract_type}") if model.fixed_term_contract_duration.blank?
 
-    return I18n.t("helpers.label.publishers_job_listing_contract_type_form.contract_type_options.#{model.contract_type}") if duration.blank?
-
-    [I18n.t("helpers.label.publishers_job_listing_contract_type_form.contract_type_options.#{model.contract_type}"), duration].compact.join(" - ")
+    if is_parental_leave_cover
+      [I18n.t("publishers.vacancies.build.contract_type.#{model.contract_type}"),  model.fixed_term_contract_duration, I18n.t("publishers.vacancies.build.contract_type.parental_leave")].compact.join(" - ")
+    else
+      [I18n.t("publishers.vacancies.build.contract_type.#{model.contract_type}"),  model.fixed_term_contract_duration].compact.join(" - ")
+    end
   end
 
   def school_group_names

--- a/app/services/vacancies/import/sources/broadbean.rb
+++ b/app/services/vacancies/import/sources/broadbean.rb
@@ -62,7 +62,7 @@ class Vacancies::Import::Sources::Broadbean
       subjects: item["subjects"].presence&.split(",") || [],
       working_patterns: item["workingPatterns"].presence&.split(","),
       contract_type: contract_type_for(item),
-      is_parental_leave_cover: is_parental_leave_cover_for(item),
+      is_parental_leave_cover: parental_leave_cover_for?(item),
       phases: phase_for(item),
       visa_sponsorship_available: visa_sponsorship_available_for(item),
     }.merge(organisation_fields(schools))
@@ -119,10 +119,11 @@ class Vacancies::Import::Sources::Broadbean
 
   def contract_type_for(item)
     return "fixed_term" if item["contractType"] == "parental_leave_cover"
+
     item["contractType"].presence
   end
-  
-  def is_parental_leave_cover_for(item)
+
+  def parental_leave_cover_for?(item)
     item["contractType"] == "parental_leave_cover"
   end
 

--- a/app/services/vacancies/import/sources/broadbean.rb
+++ b/app/services/vacancies/import/sources/broadbean.rb
@@ -61,7 +61,8 @@ class Vacancies::Import::Sources::Broadbean
       ect_status: ect_status_for(item),
       subjects: item["subjects"].presence&.split(",") || [],
       working_patterns: item["workingPatterns"].presence&.split(","),
-      contract_type: item["contractType"].presence,
+      contract_type: contract_type_for(item),
+      is_parental_leave_cover: is_parental_leave_cover_for(item),
       phases: phase_for(item),
       visa_sponsorship_available: visa_sponsorship_available_for(item),
     }.merge(organisation_fields(schools))
@@ -114,6 +115,15 @@ class Vacancies::Import::Sources::Broadbean
 
   def visa_sponsorship_available_for(item)
     item["visaSponsorshipAvailable"] == "true"
+  end
+
+  def contract_type_for(item)
+    return "fixed_term" if item["contractType"] == "parental_leave_cover"
+    item["contractType"].presence
+  end
+  
+  def is_parental_leave_cover_for(item)
+    item["contractType"] == "parental_leave_cover"
   end
 
   def organisation_fields(schools)

--- a/app/services/vacancies/import/sources/every.rb
+++ b/app/services/vacancies/import/sources/every.rb
@@ -52,7 +52,8 @@ class Vacancies::Import::Sources::Every
       ect_status: ect_status_for(item),
       subjects: item["subjects"].presence&.split(",") || [],
       working_patterns: item["workingPatterns"].presence&.split(","),
-      contract_type: item["contractType"].presence,
+      contract_type: contract_type_for(item),
+      is_parental_leave_cover: is_parental_leave_cover_for(item),
       phases: phase_for(item),
       key_stages: item["keyStages"].presence&.split(","),
       visa_sponsorship_available: visa_sponsorship_available_for(item),
@@ -135,6 +136,15 @@ class Vacancies::Import::Sources::Every
                  .parameterize(separator: "_")
                  .gsub("through_school", "through")
                  .gsub(/16-19|16_19/, "sixth_form_or_college")
+  end
+
+  def contract_type_for(item)
+    return "fixed_term" if item["contractType"] == "parental_leave_cover"
+    item["contractType"].presence
+  end
+  
+  def is_parental_leave_cover_for(item)
+    item["contractType"] == "parental_leave_cover"
   end
 
   def results

--- a/app/services/vacancies/import/sources/every.rb
+++ b/app/services/vacancies/import/sources/every.rb
@@ -53,7 +53,7 @@ class Vacancies::Import::Sources::Every
       subjects: item["subjects"].presence&.split(",") || [],
       working_patterns: item["workingPatterns"].presence&.split(","),
       contract_type: contract_type_for(item),
-      is_parental_leave_cover: is_parental_leave_cover_for(item),
+      is_parental_leave_cover: parental_leave_cover_for?(item),
       phases: phase_for(item),
       key_stages: item["keyStages"].presence&.split(","),
       visa_sponsorship_available: visa_sponsorship_available_for(item),
@@ -140,10 +140,11 @@ class Vacancies::Import::Sources::Every
 
   def contract_type_for(item)
     return "fixed_term" if item["contractType"] == "parental_leave_cover"
+
     item["contractType"].presence
   end
-  
-  def is_parental_leave_cover_for(item)
+
+  def parental_leave_cover_for?(item)
     item["contractType"] == "parental_leave_cover"
   end
 

--- a/app/services/vacancies/import/sources/fusion.rb
+++ b/app/services/vacancies/import/sources/fusion.rb
@@ -52,7 +52,8 @@ class Vacancies::Import::Sources::Fusion
       ect_status: ect_status_for(item),
       subjects: item["subjects"].presence&.split(",") || [],
       working_patterns: item["workingPatterns"].presence&.split(","),
-      contract_type: item["contractType"].presence,
+      contract_type: contract_type_for(item),
+      is_parental_leave_cover: is_parental_leave_cover_for(item),
       phases: phase_for(item),
       key_stages: item["keyStages"].presence&.split(","),
       visa_sponsorship_available: visa_sponsorship_available_for(item),
@@ -132,6 +133,15 @@ class Vacancies::Import::Sources::Fusion
 
   def visa_sponsorship_available_for(item)
     item["visaSponsorshipAvailable"] == true
+  end
+
+  def contract_type_for(item)
+    return "fixed_term" if item["contractType"] == "parental_leave_cover"
+    item["contractType"].presence
+  end
+  
+  def is_parental_leave_cover_for(item)
+    item["contractType"] == "parental_leave_cover"
   end
 
   def results

--- a/app/services/vacancies/import/sources/fusion.rb
+++ b/app/services/vacancies/import/sources/fusion.rb
@@ -53,7 +53,7 @@ class Vacancies::Import::Sources::Fusion
       subjects: item["subjects"].presence&.split(",") || [],
       working_patterns: item["workingPatterns"].presence&.split(","),
       contract_type: contract_type_for(item),
-      is_parental_leave_cover: is_parental_leave_cover_for(item),
+      is_parental_leave_cover: parental_leave_cover_for?(item),
       phases: phase_for(item),
       key_stages: item["keyStages"].presence&.split(","),
       visa_sponsorship_available: visa_sponsorship_available_for(item),
@@ -137,10 +137,11 @@ class Vacancies::Import::Sources::Fusion
 
   def contract_type_for(item)
     return "fixed_term" if item["contractType"] == "parental_leave_cover"
+
     item["contractType"].presence
   end
-  
-  def is_parental_leave_cover_for(item)
+
+  def parental_leave_cover_for?(item)
     item["contractType"] == "parental_leave_cover"
   end
 

--- a/app/services/vacancies/import/sources/my_new_term.rb
+++ b/app/services/vacancies/import/sources/my_new_term.rb
@@ -59,7 +59,8 @@ class Vacancies::Import::Sources::MyNewTerm
       ect_status: ect_status_for(item),
       subjects: item["subjects"].presence || [],
       working_patterns: item["workingPatterns"].presence,
-      contract_type: item["contractType"]&.first,
+      contract_type: contract_type_for(item),
+      is_parental_leave_cover: is_parental_leave_cover_for(item),
       phases: phase_for(item),
       key_stages: key_stages_for(item),
       job_location: :at_one_school,
@@ -148,6 +149,15 @@ class Vacancies::Import::Sources::MyNewTerm
     item["phase"].strip
                  .gsub(/all_through|through_school/, "through")
                  .gsub(/16-19|16_19/, "sixth_form_or_college")
+  end
+
+  def contract_type_for(item)
+    return "fixed_term" if item["contractType"]&.first == "parental_leave_cover"
+    item["contractType"]&.first
+  end
+  
+  def is_parental_leave_cover_for(item)
+    item["contractType"]&.first == "parental_leave_cover"
   end
 
   def results

--- a/app/services/vacancies/import/sources/my_new_term.rb
+++ b/app/services/vacancies/import/sources/my_new_term.rb
@@ -60,7 +60,7 @@ class Vacancies::Import::Sources::MyNewTerm
       subjects: item["subjects"].presence || [],
       working_patterns: item["workingPatterns"].presence,
       contract_type: contract_type_for(item),
-      is_parental_leave_cover: is_parental_leave_cover_for(item),
+      is_parental_leave_cover: parental_leave_cover_for?(item),
       phases: phase_for(item),
       key_stages: key_stages_for(item),
       job_location: :at_one_school,
@@ -153,10 +153,11 @@ class Vacancies::Import::Sources::MyNewTerm
 
   def contract_type_for(item)
     return "fixed_term" if item["contractType"]&.first == "parental_leave_cover"
+
     item["contractType"]&.first
   end
-  
-  def is_parental_leave_cover_for(item)
+
+  def parental_leave_cover_for?(item)
     item["contractType"]&.first == "parental_leave_cover"
   end
 

--- a/app/services/vacancies/import/sources/united_learning.rb
+++ b/app/services/vacancies/import/sources/united_learning.rb
@@ -64,7 +64,8 @@ class Vacancies::Import::Sources::UnitedLearning
       ect_status: ect_status_for(item),
       subjects: item["Subjects"].presence&.split(",") || [],
       working_patterns: working_patterns_for(item),
-      contract_type: item["Contract_type"].presence,
+      contract_type: contract_type_for(item),
+      is_parental_leave_cover: is_parental_leave_cover_for(item),
       phases: phase_for(item),
       visa_sponsorship_available: visa_sponsorship_available_for(item),
     }.merge(organisation_fields(item))
@@ -119,6 +120,15 @@ class Vacancies::Import::Sources::UnitedLearning
                  .parameterize(separator: "_")
                  .gsub("through_school", "through")
                  .gsub(/16-19|16_19/, "sixth_form_or_college")
+  end
+
+  def contract_type_for(item)
+    return "fixed_term" if item["Contract_type"] == "parental_leave_cover"
+    item["Contract_type"].presence
+  end
+  
+  def is_parental_leave_cover_for(item)
+    item["Contract_type"] == "parental_leave_cover"
   end
 
   def visa_sponsorship_available_for(item)

--- a/app/services/vacancies/import/sources/united_learning.rb
+++ b/app/services/vacancies/import/sources/united_learning.rb
@@ -65,7 +65,7 @@ class Vacancies::Import::Sources::UnitedLearning
       subjects: item["Subjects"].presence&.split(",") || [],
       working_patterns: working_patterns_for(item),
       contract_type: contract_type_for(item),
-      is_parental_leave_cover: is_parental_leave_cover_for(item),
+      is_parental_leave_cover: parental_leave_cover_for?(item),
       phases: phase_for(item),
       visa_sponsorship_available: visa_sponsorship_available_for(item),
     }.merge(organisation_fields(item))
@@ -124,10 +124,11 @@ class Vacancies::Import::Sources::UnitedLearning
 
   def contract_type_for(item)
     return "fixed_term" if item["Contract_type"] == "parental_leave_cover"
+
     item["Contract_type"].presence
   end
-  
-  def is_parental_leave_cover_for(item)
+
+  def parental_leave_cover_for?(item)
     item["Contract_type"] == "parental_leave_cover"
   end
 

--- a/app/services/vacancies/import/sources/vacancy_poster.rb
+++ b/app/services/vacancies/import/sources/vacancy_poster.rb
@@ -58,7 +58,7 @@ class Vacancies::Import::Sources::VacancyPoster
       subjects: item["subjects"].presence&.split(","),
       working_patterns: item["workingPatterns"].presence&.split(","),
       contract_type: contract_type_for(item),
-      is_parental_leave_cover: is_parental_leave_cover_for(item),
+      is_parental_leave_cover: parental_leave_cover_for?(item),
       phases: phase_for(item),
       visa_sponsorship_available: false,
     }.merge(organisation_fields(item))
@@ -125,10 +125,11 @@ class Vacancies::Import::Sources::VacancyPoster
 
   def contract_type_for(item)
     return "fixed_term" if item["contractType"] == "parental_leave_cover"
+
     item["contractType"].presence
   end
-  
-  def is_parental_leave_cover_for(item)
+
+  def parental_leave_cover_for?(item)
     item["contractType"] == "parental_leave_cover"
   end
 

--- a/app/services/vacancies/import/sources/vacancy_poster.rb
+++ b/app/services/vacancies/import/sources/vacancy_poster.rb
@@ -57,7 +57,8 @@ class Vacancies::Import::Sources::VacancyPoster
       key_stages: item["keyStages"].presence&.split(","),
       subjects: item["subjects"].presence&.split(","),
       working_patterns: item["workingPatterns"].presence&.split(","),
-      contract_type: item["contractType"].presence,
+      contract_type: contract_type_for(item),
+      is_parental_leave_cover: is_parental_leave_cover_for(item),
       phases: phase_for(item),
       visa_sponsorship_available: false,
     }.merge(organisation_fields(item))
@@ -120,6 +121,15 @@ class Vacancies::Import::Sources::VacancyPoster
     .parameterize(separator: "_")
     .gsub("through_school", "through")
     .gsub(/16-19|16_19/, "sixth_form_or_college")
+  end
+
+  def contract_type_for(item)
+    return "fixed_term" if item["contractType"] == "parental_leave_cover"
+    item["contractType"].presence
+  end
+  
+  def is_parental_leave_cover_for(item)
+    item["contractType"] == "parental_leave_cover"
   end
 
   def items

--- a/app/services/vacancies/import/sources/ventrus.rb
+++ b/app/services/vacancies/import/sources/ventrus.rb
@@ -60,7 +60,8 @@ class Vacancies::Import::Sources::Ventrus
       key_stages: item["Key_Stage"].presence&.split(","),
       # subjects: item["Subjects"].presence&.split(",") || [], # Ventrus don't have subjects in their feed
       working_patterns: item["Working_Patterns"].presence&.split(","),
-      contract_type: item["Contract_Type"].presence,
+      contract_type: contract_type_for(item),
+      is_parental_leave_cover: is_parental_leave_cover_for(item),
       phases: phase_for(item),
       visa_sponsorship_available: visa_sponsorship_available_for(item),
     }.merge(organisation_fields(schools))
@@ -119,6 +120,15 @@ class Vacancies::Import::Sources::Ventrus
                  .parameterize(separator: "_")
                  .gsub("through_school", "through")
                  .gsub(/16-19|16_19/, "sixth_form_or_college")
+  end
+
+  def contract_type_for(item)
+    return "fixed_term" if item["Contract_Type"] == "parental_leave_cover"
+    item["Contract_Type"].presence
+  end
+  
+  def is_parental_leave_cover_for(item)
+    item["Contract_Type"] == "parental_leave_cover"
   end
 
   def visa_sponsorship_available_for(item)

--- a/app/services/vacancies/import/sources/ventrus.rb
+++ b/app/services/vacancies/import/sources/ventrus.rb
@@ -61,7 +61,7 @@ class Vacancies::Import::Sources::Ventrus
       # subjects: item["Subjects"].presence&.split(",") || [], # Ventrus don't have subjects in their feed
       working_patterns: item["Working_Patterns"].presence&.split(","),
       contract_type: contract_type_for(item),
-      is_parental_leave_cover: is_parental_leave_cover_for(item),
+      is_parental_leave_cover: parental_leave_cover_for?(item),
       phases: phase_for(item),
       visa_sponsorship_available: visa_sponsorship_available_for(item),
     }.merge(organisation_fields(schools))
@@ -124,10 +124,11 @@ class Vacancies::Import::Sources::Ventrus
 
   def contract_type_for(item)
     return "fixed_term" if item["Contract_Type"] == "parental_leave_cover"
+
     item["Contract_Type"].presence
   end
-  
-  def is_parental_leave_cover_for(item)
+
+  def parental_leave_cover_for?(item)
     item["Contract_Type"] == "parental_leave_cover"
   end
 

--- a/app/views/publishers/vacancies/build/contract_type.html.slim
+++ b/app/views/publishers/vacancies/build/contract_type.html.slim
@@ -10,9 +10,9 @@
 
         = f.govuk_radio_button :contract_type, :fixed_term do
           = f.govuk_radio_buttons_fieldset :is_parental_leave_cover, inline: true, legend: { text: "Is this covering maternity or paternity leave?" } do
-            = f.govuk_radio_button :is_parental_leave_cover, :true, label: { text: "Yes" }
-            = f.govuk_radio_button :is_parental_leave_cover, :false, label: { text: "No" }
+            = f.govuk_radio_button :is_parental_leave_cover, true, label: { text: "Yes" }
+            = f.govuk_radio_button :is_parental_leave_cover, false, label: { text: "No" }
           = f.govuk_text_field :fixed_term_contract_duration, label: { size: "s" }
-        
+
         = f.govuk_radio_button :contract_type, :casual
       = render "publishers/vacancies/vacancy_form_partials/submit", f: f

--- a/app/views/publishers/vacancies/build/contract_type.html.slim
+++ b/app/views/publishers/vacancies/build/contract_type.html.slim
@@ -9,9 +9,10 @@
         = f.govuk_radio_button :contract_type, :permanent, link_errors: true
 
         = f.govuk_radio_button :contract_type, :fixed_term do
+          = f.govuk_radio_buttons_fieldset :is_parental_leave_cover, inline: true, legend: { text: "Is this covering maternity or paternity leave?" } do
+            = f.govuk_radio_button :is_parental_leave_cover, :true, label: { text: "Yes" }
+            = f.govuk_radio_button :is_parental_leave_cover, :false, label: { text: "No" }
           = f.govuk_text_field :fixed_term_contract_duration, label: { size: "s" }
-
-        = f.govuk_radio_button :contract_type, :parental_leave_cover do
-          = f.govuk_text_field :parental_leave_cover_contract_duration, label: { size: "s" }
-
+        
+        = f.govuk_radio_button :contract_type, :casual
       = render "publishers/vacancies/vacancy_form_partials/submit", f: f

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -405,6 +405,7 @@ shared:
     - further_details
     - include_additional_documents
     - visa_sponsorship_available
+    - is_parental_leave_cover
   failed_imported_vacancies:
     - id
     - import_errors

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -154,8 +154,6 @@ en:
       inclusion: Select contract type
     fixed_term_contract_duration:
       blank: Enter the length of the fixed term contract
-    parental_leave_cover_contract_duration:
-      blank: Enter the length of the maternity or parental leave cover contract
   working_patterns_errors: &working_patterns_errors
     working_patterns:
       blank: Select a working pattern

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -687,11 +687,13 @@ en:
           true: "Yes"
       publishers_job_listing_contract_type_form:
         contract_type_options:
-          fixed_term: Fixed term
+          fixed_term: Fixed term (including maternity or parental leave cover)
           parental_leave_cover: Maternity or parental leave cover
           permanent: Permanent
+          casual: Casual
         fixed_term_contract_duration: Length of contract
         parental_leave_cover_contract_duration: Length of contract
+        is_parental_leave_cover: Is this covering maternity or paternal leave?
       publishers_job_listing_contact_details_form:
         contact_email_options:
           other: Another email address

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -692,7 +692,6 @@ en:
           permanent: Permanent
           casual: Casual
         fixed_term_contract_duration: Length of contract
-        parental_leave_cover_contract_duration: Length of contract
         is_parental_leave_cover: Is this covering maternity or paternal leave?
       publishers_job_listing_contact_details_form:
         contact_email_options:

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -431,6 +431,10 @@ en:
           step_title: Subjects
         contract_type:
           step_title: Contract type
+          fixed_term: Fixed term
+          parental_leave: Maternity or parental leave cover
+          permanent: Permanent
+          casual: Casual
         page_title:
           create: Create job listing - [Section %{section_number} of 4] - Teaching Vacancies - GOV.UK
           edit: Change job listing - [Section %{section_number} of 4] - Teaching Vacancies - GOV.UK

--- a/db/migrate/20240710135644_add_is_parental_leave_cover_to_vacancies.rb
+++ b/db/migrate/20240710135644_add_is_parental_leave_cover_to_vacancies.rb
@@ -1,0 +1,5 @@
+class AddIsParentalLeaveCoverToVacancies < ActiveRecord::Migration[7.1]
+  def change
+    add_column :vacancies, :is_parental_leave_cover, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_24_110124) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_10_135644) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -673,6 +673,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_24_110124) do
     t.string "further_details"
     t.boolean "include_additional_documents"
     t.boolean "visa_sponsorship_available"
+    t.boolean "is_parental_leave_cover"
     t.index ["expires_at"], name: "index_vacancies_on_expires_at"
     t.index ["external_source", "external_reference"], name: "index_vacancies_on_external_source_and_external_reference"
     t.index ["geolocation", "expires_at", "publish_on"], name: "index_vacancies_on_geolocation_and_expires_at_and_publish_on", using: :gist

--- a/lib/tasks/update_vacancy_contract_type.rake
+++ b/lib/tasks/update_vacancy_contract_type.rake
@@ -1,0 +1,16 @@
+namespace :vacancies do
+  desc "Update vacancies with contract_type == parental_leave_cover to contract_type == fixed_term and set is_parental_leave_cover to true"
+  task update_parental_leave_cover: :environment do
+    vacancies_to_update = Vacancy.where(contract_type: Vacancy.contract_types[:parental_leave_cover])
+    
+    vacancies_to_update.find_each do |vacancy|
+      vacancy.update(
+        contract_type: Vacancy.contract_types[:fixed_term],
+        is_parental_leave_cover: true,
+        fixed_term_contract_duration: vacancy.parental_leave_cover_contract_duration
+      )
+    end
+
+    puts "#{vacancies_to_update.count} vacancies updated successfully."
+  end
+end

--- a/lib/tasks/update_vacancy_contract_type.rake
+++ b/lib/tasks/update_vacancy_contract_type.rake
@@ -2,12 +2,12 @@ namespace :vacancies do
   desc "Update vacancies with contract_type == parental_leave_cover to contract_type == fixed_term and set is_parental_leave_cover to true"
   task update_parental_leave_cover: :environment do
     vacancies_to_update = Vacancy.where(contract_type: Vacancy.contract_types[:parental_leave_cover])
-    
+
     vacancies_to_update.find_each do |vacancy|
       vacancy.update(
         contract_type: Vacancy.contract_types[:fixed_term],
         is_parental_leave_cover: true,
-        fixed_term_contract_duration: vacancy.parental_leave_cover_contract_duration
+        fixed_term_contract_duration: vacancy.parental_leave_cover_contract_duration,
       )
     end
 

--- a/spec/concerns/reset_vacancies_in_job_listings_spec.rb
+++ b/spec/concerns/reset_vacancies_in_job_listings_spec.rb
@@ -36,16 +36,6 @@ RSpec.describe Resettable do
           .from(previous_fixed_term_contract_duration).to("")
       end
     end
-
-    context "from parental leave cover" do
-      let(:contract_type) { "parental_leave_cover" }
-
-      it "resets parental leave cover contract duration" do
-        expect { update_contract_type }
-          .to change { vacancy.parental_leave_cover_contract_duration }
-          .from(previous_parental_leave_cover_contract_duration).to("")
-      end
-    end
   end
 
   context "when changing education support" do

--- a/spec/concerns/reset_vacancies_in_job_listings_spec.rb
+++ b/spec/concerns/reset_vacancies_in_job_listings_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe Resettable do
 
     let(:vacancy) { build(:vacancy, contract_type: contract_type) }
     let(:previous_fixed_term_contract_duration) { vacancy.fixed_term_contract_duration }
-    let(:previous_parental_leave_cover_contract_duration) { vacancy.parental_leave_cover_contract_duration }
 
     context "from fixed term" do
       let(:contract_type) { "fixed_term" }

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -44,7 +44,6 @@ FactoryBot.define do
     fixed_term_contract_duration { "6 months" }
     further_details_provided { true }
     further_details { Faker::Lorem.sentence(word_count: factory_rand(50..300)) }
-    parental_leave_cover_contract_duration { "6 months" }
     expires_at { 6.months.from_now.change(hour: 9, minute: 0, second: 0) }
     hired_status { nil }
     include_additional_documents { false }

--- a/spec/fixtures/files/vacancy_sources/broadband_not_parental_leave_cover.xml
+++ b/spec/fixtures/files/vacancy_sources/broadband_not_parental_leave_cover.xml
@@ -1,0 +1,21 @@
+<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<items>
+  <item>
+    <reference>0044</reference>
+    <advertUrl>http://testurl.com</advertUrl>
+    <publishOn>2023-08-02</publishOn>
+    <expiresAt>2023-08-23T01:40:35+0100</expiresAt>
+    <jobTitle>Class Teacher</jobTitle>
+    <jobAdvert>Non-random descriptive text</jobAdvert>
+    <salary>£50879 - £85262 per week</salary>
+    <startDate>20-5-2023</startDate>
+    <jobRole>head_of_year_or_phase</jobRole>
+    <ectSuitable>true</ectSuitable>
+    <workingPatterns>part_time</workingPatterns>
+    <contractType>fixed_term</contractType>
+    <phase>primary</phase>
+    <schoolUrns>111111,222222</schoolUrns>
+    <trustUID>12345</trustUID>
+    <visaSponsorshipAvailable>true</visaSponsorshipAvailable>
+  </item>
+</items>

--- a/spec/fixtures/files/vacancy_sources/united_learning_with_parental_leave_cover.xml
+++ b/spec/fixtures/files/vacancy_sources/united_learning_with_parental_leave_cover.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss xmlns:a10="http://www.w3.org/2005/Atom" version="2.0">
+   <channel>
+       <title>United Learning RSS Feed</title>
+       <link>https://unitedlearning.current-vacancies.com/RSSFeeds/Vacancies/UNITEDLEAR?feedID=C8E62F84748A4306A68C06C1C583F242</link>
+       <description>United Learning RSS Feed</description>
+       <item>
+           <link>https://unitedlearning.current-vacancies.com/Jobs/FeedLink/2648837</link>
+           <title>Head of Geography</title>
+           <a10:updated>2022-04-29T10:29:57Z</a10:updated>
+           <a10:content type="text/xml">
+               <Vacancy>
+                   <VacancyID>751190</VacancyID>
+                   <vTitle>Head of Geography</vTitle>
+                   <VacancyPublishInfoID>2648837</VacancyPublishInfoID>
+                   <Vacancy_title>Head of Geography</Vacancy_title>
+                   <Salary>PT/EPT + TLR 2B</Salary>
+                   <Advert_text>Lorem ipsum dolor sit amet</Advert_text>
+                   <Vacancy_ID>NTXTP751190</Vacancy_ID>
+                   <Expiry_date>15/05/2022 12:00:00</Expiry_date>
+                   <Job_roles>teacher</Job_roles>
+                   <ect_suitable>yes</ect_suitable>
+                   <send_responsible>yes</send_responsible>
+                   <Working_patterns>full_time</Working_patterns>
+                   <Subjects>Geography</Subjects>
+                   <Contract_type>parental_leave_cover</Contract_type>
+                   <Phase>Secondary</Phase>
+                   <URN>136636</URN>
+                   <Key_stages>ks2</Key_stages>
+                   <Documents>
+                      <document>
+                          <name><![CDATA[Job Description - Head of Department Final April 21 TCC (6) (3) (1).pdf]]></name>
+                          <extension>pdf</extension>
+                          <size>225131</size>
+                          <url><![CDATA[https://unitedlearning.current-vacancies.com/Jobs/DownloadDocument/934437?cid=1567&pubid=2648837]]></url>
+                      </document>
+                   </Documents>
+                   <Visa_sponsorship_available>true</Visa_sponsorship_available>
+               </Vacancy>
+           </a10:content>
+       </item>
+   </channel>
+</rss>

--- a/spec/fixtures/files/vacancy_sources/ventrus_with_parental_leave_cover.xml
+++ b/spec/fixtures/files/vacancy_sources/ventrus_with_parental_leave_cover.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss xmlns:a10="http://www.w3.org/2005/Atom" version="2.0">
+    <channel>
+        <title>Ventrus Multi Academy Trust RSS Feed</title>
+        <link>https://ventrus.current-vacancies.com/RSSFeeds/Vacancies/VENTRUSMUL?feedID=BF7A3AA9DA7C4B3E90C3FE8664CB6EFB</link>
+        <description>Ventrus Multi Academy Trust RSS Feed</description>
+        <item>
+            <link>http://testurl.com</link>
+            <title>Teaching Assistant</title>
+            <a10:updated>2023-08-04T10:16:07Z</a10:updated>
+            <a10:content type="text/xml">
+                <Vacancy>
+                    <VacancyID>915213</VacancyID>
+                    <vTitle>Teaching Assistant</vTitle>
+                    <VacancyPublishInfoID>3191462</VacancyPublishInfoID>
+                    <Vacancy_title>Teaching Assistant</Vacancy_title>
+                    <Salary>£21,575 - £22,369</Salary>
+                    <Advert_text><![CDATA[<p><strong>This is a random advert text </strong><br> with HTML</p>]]></Advert_text>
+                    <Vacancy_ID>PIL915213</Vacancy_ID>
+                    <Expiry_date>01/09/2023 12:00:00</Expiry_date>
+                    <vContractType>Permanent</vContractType>
+                    <Job_Location>Barnstaple,_Devon</Job_Location>
+                    <ECT_Suitable>True</ECT_Suitable>
+                    <Job_Roles>teaching_assistant</Job_Roles>
+                    <Key_Stage>ks2</Key_Stage>
+                    <Phase_>secondary</Phase_>
+                    <SEND_Responsible>no</SEND_Responsible>
+                    <URN>111111</URN>
+                    <Working_Patterns>part_time</Working_Patterns>
+                    <Contract_Type>parental_leave_cover</Contract_Type>
+                    <TrustUID></TrustUID>
+                    <Documents>
+                        <document>
+                            <name><![CDATA[JD Grade C Generalist TA Secondary (App 2) Updated 15.12.2020.pdf]]></name>
+                            <extension>12</extension>
+                            <size>760447</size>
+                            <url><![CDATA[https://ventrus.current-vacancies.com/Jobs/DownloadDocument/1115402?cid=1711&pubid=3191462]]></url>
+                        </document>
+                    </Documents>
+                    <Visa_Sponsorship_Available>true</Visa_sponsorship_available>
+                </Vacancy>
+            </a10:content>
+        </item>
+    </channel>
+</rss>

--- a/spec/jobs/import_from_vacancy_source_job_spec.rb
+++ b/spec/jobs/import_from_vacancy_source_job_spec.rb
@@ -167,6 +167,7 @@ RSpec.describe ImportFromVacancySourceJob do
           "working_patterns" => ["full_time"],
           "working_patterns_details" => nil,
           "visa_sponsorship_available" => false,
+          "is_parental_leave_cover" => nil,
         )
       end
 

--- a/spec/jobs/import_from_vacancy_source_job_spec.rb
+++ b/spec/jobs/import_from_vacancy_source_job_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe ImportFromVacancySourceJob do
           "latest_start_date" => nil,
           "listed_elsewhere" => nil,
           "other_start_date_details" => nil,
-          "parental_leave_cover_contract_duration" => "",
+          "parental_leave_cover_contract_duration" => nil,
           "part_time_details" => nil,
           "pay_scale" => "Main pay range 1 to Upper pay range 3, £23,719 to £39,406 per year (full time equivalent)",
           "personal_statement_guidance" => "Maxime blanditiis quos. Cum officia facilis. Et et quod. Dolore id ut. Id aut quia.",

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -437,26 +437,6 @@ RSpec.describe Vacancy do
       end
     end
 
-    context "when changing contract type from fixed_term to parental_leave_cover" do
-      subject { create(:vacancy, contract_type: "fixed_term", fixed_term_contract_duration: "8 months") }
-
-      before { subject.update contract_type: "parental_leave_cover" }
-
-      it "resets fixed_term_contract_duration field" do
-        expect(subject.fixed_term_contract_duration).to be_blank
-      end
-    end
-
-    context "when changing contract type from parental_leave_cover to fixed_term" do
-      subject { create(:vacancy, contract_type: "parental_leave_cover", parental_leave_cover_contract_duration: "8 months") }
-
-      before { subject.update contract_type: "fixed_term" }
-
-      it "resets parental_leave_cover_contract_duration field" do
-        expect(subject.parental_leave_cover_contract_duration).to be_blank
-      end
-    end
-
     context "when phase is changed from primary to secondary" do
       subject { create(:vacancy, phases: ["primary"], subjects: %w[English]) }
 

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -424,16 +424,12 @@ RSpec.describe Vacancy do
     end
 
     context "when changing contract type to permanent" do
-      subject { create(:vacancy, contract_type: "fixed_term", fixed_term_contract_duration: "8 months", parental_leave_cover_contract_duration: "8 months") }
+      subject { create(:vacancy, contract_type: "fixed_term", fixed_term_contract_duration: "8 months") }
 
       before { subject.update contract_type: "permanent" }
 
       it "resets fixed_term_contract_duration field" do
         expect(subject.fixed_term_contract_duration).to be_blank
-      end
-
-      it "resets parental_leave_cover_contract_duration field" do
-        expect(subject.parental_leave_cover_contract_duration).to be_blank
       end
     end
 

--- a/spec/presenters/vacancy_presenter_spec.rb
+++ b/spec/presenters/vacancy_presenter_spec.rb
@@ -200,10 +200,8 @@ RSpec.describe VacancyPresenter do
     let(:vacancy) do
       build_stubbed(:vacancy, contract_type: contract_type,
                               fixed_term_contract_duration: fixed_term_contract_duration,
-                              parental_leave_cover_contract_duration: parental_leave_cover_contract_duration,
                               is_parental_leave_cover: is_parental_leave_cover)
     end
-    let(:parental_leave_cover_contract_duration) { "" }
 
     context "when permanent" do
       let(:contract_type) { :permanent }

--- a/spec/presenters/vacancy_presenter_spec.rb
+++ b/spec/presenters/vacancy_presenter_spec.rb
@@ -200,13 +200,15 @@ RSpec.describe VacancyPresenter do
     let(:vacancy) do
       build_stubbed(:vacancy, contract_type: contract_type,
                               fixed_term_contract_duration: fixed_term_contract_duration,
-                              parental_leave_cover_contract_duration: parental_leave_cover_contract_duration)
+                              parental_leave_cover_contract_duration: parental_leave_cover_contract_duration,
+                              is_parental_leave_cover: is_parental_leave_cover)
     end
     let(:parental_leave_cover_contract_duration) { "" }
 
     context "when permanent" do
       let(:contract_type) { :permanent }
       let(:fixed_term_contract_duration) { "" }
+      let(:is_parental_leave_cover) { nil }
 
       it "returns Permanent" do
         expect(subject.contract_type_with_duration).to eq "Permanent"
@@ -217,35 +219,20 @@ RSpec.describe VacancyPresenter do
       let(:contract_type) { :fixed_term }
       let(:fixed_term_contract_duration) { "6 months" }
 
-      it "returns Fixed term (duration)" do
-        expect(subject.contract_type_with_duration).to eq "Fixed term - 6 months"
+      context "when is_parental_leave_cover is false" do
+        let(:is_parental_leave_cover) { false }
+
+        it "returns Fixed term (duration)" do
+          expect(subject.contract_type_with_duration).to eq "Fixed term - 6 months"
+        end
       end
-    end
-  end
 
-  describe "#parental_leave_cover_contract_duration" do
-    let(:vacancy) do
-      build_stubbed(:vacancy, contract_type: contract_type,
-                              parental_leave_cover_contract_duration: parental_leave_cover_contract_duration,
-                              fixed_term_contract_duration: fixed_term_contract_duration)
-    end
-    let(:fixed_term_contract_duration) { "" }
+      context "when is_parental_leave_cover is true" do
+        let(:is_parental_leave_cover) { true }
 
-    context "when permanent" do
-      let(:contract_type) { :permanent }
-      let(:parental_leave_cover_contract_duration) { "" }
-
-      it "returns Permanent" do
-        expect(subject.contract_type_with_duration).to eq "Permanent"
-      end
-    end
-
-    context "when parental_leave cover" do
-      let(:contract_type) { :parental_leave_cover }
-      let(:parental_leave_cover_contract_duration) { "6 months" }
-
-      it "returns Maternity or parental leave cover (duration)" do
-        expect(subject.contract_type_with_duration).to eq "Maternity or parental leave cover - 6 months"
+        it "returns Fixed term (duration)" do
+          expect(subject.contract_type_with_duration).to eq "Fixed term - 6 months - Maternity or parental leave cover"
+        end
       end
     end
   end

--- a/spec/services/vacancies/import/sources/broadbean_spec.rb
+++ b/spec/services/vacancies/import/sources/broadbean_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe Vacancies::Import::Sources::Broadbean do
         job_roles: job_roles,
         key_stages: [],
         working_patterns: %w[part_time],
-        contract_type: "parental_leave_cover",
+        contract_type: "fixed_term",
+        is_parental_leave_cover: true,
         phases: %w[primary],
         visa_sponsorship_available: true,
         ect_status: "ect_suitable",
@@ -314,6 +315,15 @@ RSpec.describe Vacancies::Import::Sources::Broadbean do
 
       it "does not import vacancy" do
         expect(subject.count).to eq(0)
+      end
+    end
+
+    context "when the vacancy is not parental leave cover" do
+      let(:response_body) { file_fixture("vacancy_sources/broadband_not_parental_leave_cover.xml").read }
+
+      it "sets is_parental_leave_cover to false" do
+        expect(vacancy.is_parental_leave_cover).to eq false
+        expect(vacancy.contract_type).to eq "fixed_term"
       end
     end
   end

--- a/spec/services/vacancies/import/sources/every_spec.rb
+++ b/spec/services/vacancies/import/sources/every_spec.rb
@@ -318,4 +318,13 @@ RSpec.describe Vacancies::Import::Sources::Every do
       expect(subject.count).to eq(0)
     end
   end
+
+  context "when contract_type is parental_leave_cover" do
+    let(:response_body) { super().gsub("fixed_term", "parental_leave_cover") }
+
+    it "sets contract_type to fixed_term and is_parental_leave_cover to true" do
+      expect(vacancy.contract_type).to eq("fixed_term")
+      expect(vacancy.is_parental_leave_cover).to eq(true)
+    end
+  end
 end

--- a/spec/services/vacancies/import/sources/fusion_spec.rb
+++ b/spec/services/vacancies/import/sources/fusion_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe Vacancies::Import::Sources::Fusion do
 
     context "when contract_type is parental_leave_cover" do
       let(:response_body) { super().gsub("fixed_term", "parental_leave_cover") }
-  
+
       it "sets contract_type to fixed_term and is_parental_leave_cover to true" do
         expect(vacancy.contract_type).to eq("fixed_term")
         expect(vacancy.is_parental_leave_cover).to eq(true)

--- a/spec/services/vacancies/import/sources/fusion_spec.rb
+++ b/spec/services/vacancies/import/sources/fusion_spec.rb
@@ -178,6 +178,15 @@ RSpec.describe Vacancies::Import::Sources::Fusion do
       end
     end
 
+    context "when contract_type is parental_leave_cover" do
+      let(:response_body) { super().gsub("fixed_term", "parental_leave_cover") }
+  
+      it "sets contract_type to fixed_term and is_parental_leave_cover to true" do
+        expect(vacancy.contract_type).to eq("fixed_term")
+        expect(vacancy.is_parental_leave_cover).to eq(true)
+      end
+    end
+
     describe "phase mapping" do
       let(:response_body) { super().gsub("primary", phase) }
 

--- a/spec/services/vacancies/import/sources/my_new_term_spec.rb
+++ b/spec/services/vacancies/import/sources/my_new_term_spec.rb
@@ -71,6 +71,15 @@ RSpec.describe Vacancies::Import::Sources::MyNewTerm do
     end
   end
 
+  context "when contract_type is parental_leave_cover" do
+    let(:job_listings_response_body) { super().gsub("permanent", "parental_leave_cover") }
+
+    it "sets contract_type to fixed_term and is_parental_leave_cover to true" do
+      expect(vacancy.contract_type).to eq("fixed_term")
+      expect(vacancy.is_parental_leave_cover).to eq(true)
+    end
+  end
+
   describe "job roles mapping" do
     let(:job_listings_response_body) { super().gsub("teacher", source_roles.join(",")) }
 

--- a/spec/services/vacancies/import/sources/united_learning_spec.rb
+++ b/spec/services/vacancies/import/sources/united_learning_spec.rb
@@ -213,6 +213,19 @@ RSpec.describe Vacancies::Import::Sources::UnitedLearning do
     end
   end
 
+  context "when contract_type is parental_leave_cover" do
+    before do
+      expect(HTTParty).to receive(:get).with("http://example.com/feed.xml").and_return(file_fixture("vacancy_sources/united_learning_with_parental_leave_cover.xml").read)
+    end
+
+    let(:vacancy) { subject.first }
+
+    it "sets contract_type to fixed_term and is_parental_leave_cover to true" do
+      expect(vacancy.contract_type).to eq("fixed_term")
+      expect(vacancy.is_parental_leave_cover).to eq(true)
+    end
+  end
+
   describe "enumeration error" do
     before do
       # FIXME: Manually stubbing HTTParty because of weird interactions between VCR and Webmock

--- a/spec/services/vacancies/import/sources/vancancy_poster_spec.rb
+++ b/spec/services/vacancies/import/sources/vancancy_poster_spec.rb
@@ -156,6 +156,15 @@ RSpec.describe Vacancies::Import::Sources::VacancyPoster do
       end
     end
 
+    context "when contract_type is parental_leave_cover" do
+      let(:response_body) { super().gsub("permanent", "parental_leave_cover") }
+
+      it "sets contract_type to fixed_term and is_parental_leave_cover to true" do
+        expect(vacancy.contract_type).to eq("fixed_term")
+        expect(vacancy.is_parental_leave_cover).to eq(true)
+      end
+    end
+
     context "when the same vacancy has been imported previously" do
       let!(:existing_vacancy) do
         create(

--- a/spec/services/vacancies/import/sources/ventrus_spec.rb
+++ b/spec/services/vacancies/import/sources/ventrus_spec.rb
@@ -205,6 +205,15 @@ RSpec.describe Vacancies::Import::Sources::Ventrus do
       end
     end
 
+    context "when contract_type is parental_leave_cover" do
+      let(:response_body) { file_fixture("vacancy_sources/ventrus_with_parental_leave_cover.xml").read }
+  
+      it "sets contract_type to fixed_term and is_parental_leave_cover to true" do
+        expect(vacancy.contract_type).to eq("fixed_term")
+        expect(vacancy.is_parental_leave_cover).to eq(true)
+      end
+    end
+
     context "when school associated with vacancy is of excluded type" do
       before do
         school1.update(detailed_school_type: "Other independent school")

--- a/spec/services/vacancies/import/sources/ventrus_spec.rb
+++ b/spec/services/vacancies/import/sources/ventrus_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe Vacancies::Import::Sources::Ventrus do
 
     context "when contract_type is parental_leave_cover" do
       let(:response_body) { file_fixture("vacancy_sources/ventrus_with_parental_leave_cover.xml").read }
-  
+
       it "sets contract_type to fixed_term and is_parental_leave_cover to true" do
         expect(vacancy.contract_type).to eq("fixed_term")
         expect(vacancy.is_parental_leave_cover).to eq(true)

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -39,7 +39,13 @@ module VacancyHelpers
   end
 
   def fill_in_contract_type_form_fields(vacancy)
-    choose I18n.t("helpers.label.publishers_job_listing_contract_type_form.contract_type_options.#{vacancy.contract_type}")
+    if vacancy.contract_type == "fixed_term"
+      choose I18n.t("helpers.label.publishers_job_listing_contract_type_form.contract_type_options.fixed_term")
+      choose "Yes"
+      fill_in "Length of contract", with: "1 month"
+    else
+      choose I18n.t("helpers.label.publishers_job_listing_contract_type_form.contract_type_options.#{vacancy.contract_type}")
+    end
   end
 
   def fill_in_working_patterns_form_fields(vacancy)

--- a/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_local_authority_spec.rb
+++ b/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_local_authority_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Creating a vacancy" do
   let(:school_group) { create(:local_authority, schools: [school1, school2], safeguarding_information: nil) }
   let(:school1) { create(:school, :not_applicable, name: "First school") }
   let(:school2) { create(:school, :not_applicable, name: "Second school") }
-  let(:vacancy) { build(:vacancy, :no_tv_applications, :ect_suitable, job_roles: ["teacher"], phases: %w[secondary], organisations: [school1, school2]) }
+  let(:vacancy) { build(:vacancy, :no_tv_applications, :ect_suitable, job_roles: ["teacher"], phases: %w[secondary], organisations: [school1, school2], contract_type: "fixed_term", is_parental_leave_cover: true) }
   let(:created_vacancy) { Vacancy.last }
 
   before do

--- a/spec/system/publishers/publishers_can_view_vacancy_activity_log_spec.rb
+++ b/spec/system/publishers/publishers_can_view_vacancy_activity_log_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe "Publishers can view a vacancy's activity log", versioning: true 
 
     choose I18n.t("helpers.label.publishers_job_listing_contract_type_form.contract_type_options.#{new_contract_type}")
     within("#publishers-job-listing-contract-type-form-contract-type-fixed-term-conditional") do
+      choose "Yes"
       fill_in I18n.t("helpers.label.publishers_job_listing_contract_type_form.fixed_term_contract_duration"), with: "6 months"
     end
 


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/rYAJiPw3/1065-add-casual-contract-type

## Changes in this PR:

This ticket:
- Adds casual contract type and a new column on vacancy called is_parental_leave_cover
- Removes parental_leave_cover contract type
- Adds rake task to migrate all parental leave cover vacancies to be fixed term with is_parental_leave_cover set to true
- Changes all ATS providers to handle the new logic apart from ark which does not seem to support parental_leave_cover

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
