### PR TITLE
Production web app memory bumped

### DIFF
--- a/terraform/app/modules/paas/aks_application.tf
+++ b/terraform/app/modules/paas/aks_application.tf
@@ -51,6 +51,7 @@ module "web_application" {
   web_external_hostnames = var.web_external_hostnames_aks
   replicas               = var.aks_web_app_instances
   enable_logit           = var.enable_logit
+  max_memory             = var.aks_web_app_memory
 }
 
 module "worker_application" {

--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -94,6 +94,8 @@ variable "azure_maintenance_window" {}
 
 variable "enable_logit" {}
 
+variable "aks_web_app_memory" {}
+
 locals {
   postgres_ssl_mode = var.enable_postgres_ssl ? "require" : "disable"
 

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -89,6 +89,7 @@ module "paas" {
   web_external_hostnames_aks        = local.web_external_hostnames_aks
   azure_maintenance_window          = var.azure_maintenance_window
   enable_logit                      = var.enable_logit
+  aks_web_app_memory                = var.aks_web_app_memory
 }
 
 module "statuscake" {

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -147,6 +147,10 @@ variable "aks_worker_app_memory" {
   default = "1Gi"
 }
 
+variable "aks_web_app_memory" {
+  default = "1Gi"
+}
+
 variable "aks_route53_a_records" {
   default = []
 }

--- a/terraform/workspace-variables/production.tfvars.json
+++ b/terraform/workspace-variables/production.tfvars.json
@@ -35,6 +35,7 @@
   "aks_worker_app_instances": 4,
   "aks_web_app_instances": 8,
   "aks_worker_app_memory": "1.5Gi",
+  "aks_web_app_memory": "1.5Gi",
   "statuscake_alerts": {
     "500String": {
       "contact_group": [


### PR DESCRIPTION
## Trello card URL
  pods getting restarting with OOMKilled. 
  https://trello.com/c/op3vEqYt/1930-high-number-of-restarted-containers-for-teaching-vacancies-production
## Changes in this PR: 
 Increase web app memory.

##  Terraform plan.

   Run terraform plan  using command : aws-vault exec Deployments  make production terraform-app-plan CONFIRM_PRODUCTION=YES.

The output showed one change.

                      ~ resources {
                          ~ limits   = {
                              ~ "memory" = "1Gi" -> "1.5Gi"
                                # (1 unchanged element hidden)
                            }
                          ~ requests = {
                              ~ "memory" = "1Gi" -> "1.5Gi"
                                # (1 unchanged element hidden)
                            }
                        } 
### After

   After deployment need to check the  teaching-vacancies-production pods  status , it should not restart by OOMKilled
          kubectl -n tv-production get po
       

## Next steps:

- [x] Terraform deployment required?

- [ ] New development configuration to be shared?
