### PR TITLE
Update working patterns page

### DIFF
--- a/app/controllers/concerns/publishers/wizardable.rb
+++ b/app/controllers/concerns/publishers/wizardable.rb
@@ -58,7 +58,7 @@ module Publishers::Wizardable
 
   def working_patterns_params(params)
     params.require(:publishers_job_listing_working_patterns_form)
-          .permit(:working_patterns_details, working_patterns: [])
+          .permit(:working_patterns_details, :is_job_share, working_patterns: [])
           .merge(completed_steps: completed_steps)
   end
 

--- a/app/form_models/publishers/job_listing/working_patterns_form.rb
+++ b/app/form_models/publishers/job_listing/working_patterns_form.rb
@@ -1,9 +1,10 @@
 class Publishers::JobListing::WorkingPatternsForm < Publishers::JobListing::VacancyForm
-  validates :working_patterns, presence: true, inclusion: { in: Vacancy.working_patterns.keys }
+  validates :working_patterns, presence: true, inclusion: { in: Vacancy.working_patterns.keys - ["job_share"] }
+  validates :is_job_share, inclusion: { in: [true, false, "true", "false"] }
   validate :working_patterns_details_does_not_exceed_maximum_words
 
   def self.fields
-    %i[working_patterns working_patterns_details]
+    %i[working_patterns working_patterns_details is_job_share]
   end
   attr_accessor(*fields)
 
@@ -12,7 +13,7 @@ class Publishers::JobListing::WorkingPatternsForm < Publishers::JobListing::Vaca
   end
 
   def params_to_save
-    { working_patterns:, working_patterns_details: }
+    { working_patterns:, working_patterns_details:, is_job_share: }
   end
 
   private

--- a/app/form_models/publishers/job_listing/working_patterns_form.rb
+++ b/app/form_models/publishers/job_listing/working_patterns_form.rb
@@ -19,7 +19,7 @@ class Publishers::JobListing::WorkingPatternsForm < Publishers::JobListing::Vaca
   private
 
   def working_patterns_details_does_not_exceed_maximum_words
-    return unless working_patterns_details&.split&.length&.>(50)
+    return unless working_patterns_details&.split&.length&.>(75)
 
     errors.add(:working_patterns_details, :working_patterns_details_maximum_words, message: I18n.t("working_patterns_errors.working_patterns_details.maximum_words"))
   end

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -143,9 +143,13 @@ module VacanciesHelper
   end
 
   def vacancy_working_patterns_summary(vacancy)
-    vacancy.working_patterns.map { |working_pattern|
+    working_patterns = vacancy.working_patterns.map do |working_pattern|
       Vacancy.human_attribute_name("working_patterns.#{working_pattern}").downcase
-    }.join(", ").capitalize
+    end
+
+    working_patterns << "open to job share" if vacancy.is_job_share
+
+    working_patterns.join(", ").capitalize
   end
 
   def vacancy_working_patterns(vacancy)

--- a/app/presenters/vacancy_presenter.rb
+++ b/app/presenters/vacancy_presenter.rb
@@ -27,9 +27,13 @@ class VacancyPresenter < BasePresenter
   end
 
   def readable_working_patterns
-    model.working_patterns.map { |working_pattern|
+    working_patterns = model.working_patterns.map { |working_pattern|
       Vacancy.human_attribute_name("working_patterns.#{working_pattern}").downcase
     }.join(", ").capitalize
+
+    return working_patterns unless is_job_share
+
+    "#{working_patterns} (Can be done as a job share)"
   end
 
   def readable_working_patterns_with_details

--- a/app/queries/vacancy_filter_query.rb
+++ b/app/queries/vacancy_filter_query.rb
@@ -106,7 +106,7 @@ class VacancyFilterQuery < ApplicationQuery
 
   def add_working_patterns_filters(working_patterns, built_scope)
     return built_scope unless working_patterns.present?
-    
+
     if working_patterns.include?("job_share")
       working_patterns -= ["job_share"]
       built_scope = built_scope.where(is_job_share: true)

--- a/app/queries/vacancy_filter_query.rb
+++ b/app/queries/vacancy_filter_query.rb
@@ -28,7 +28,7 @@ class VacancyFilterQuery < ApplicationQuery
     built_scope = built_scope.quick_apply if filters[:quick_apply]
     built_scope = add_school_type_filters(filters, built_scope)
     working_patterns = fix_legacy_working_patterns(filters[:working_patterns])
-    built_scope = built_scope.with_any_of_working_patterns(working_patterns) if working_patterns.present?
+    built_scope = add_working_patterns_filters(working_patterns, built_scope)
 
     built_scope = built_scope.with_any_of_phases(phases(filters[:phases])) if phases(filters[:phases]).present?
 
@@ -102,6 +102,19 @@ class VacancyFilterQuery < ApplicationQuery
 
     # These are no longer relevant and have no current equivalent
     working_patterns - %w[compressed_hours staggered_hours]
+  end
+
+  def add_working_patterns_filters(working_patterns, built_scope)
+    return built_scope unless working_patterns.present?
+    
+    if working_patterns.include?("job_share")
+      working_patterns -= ["job_share"]
+      built_scope = built_scope.where(is_job_share: true)
+    end
+
+    built_scope.with_any_of_working_patterns(working_patterns) if working_patterns.present?
+
+    built_scope
   end
 
   def apply_job_roles(keys, built_scope, filters)

--- a/app/services/vacancies/import/sources/fusion.rb
+++ b/app/services/vacancies/import/sources/fusion.rb
@@ -41,6 +41,7 @@ class Vacancies::Import::Sources::Fusion
 
   private
 
+  # rubocop:disable Metrics/MethodLength
   def attributes_for(item, schools)
     {
       job_title: item["jobTitle"],
@@ -64,6 +65,7 @@ class Vacancies::Import::Sources::Fusion
     }.merge(organisation_fields(item, schools))
      .merge(start_date_fields(item))
   end
+  # rubocop:enable Metrics/MethodLength
 
   def organisation_fields(item, schools)
     {

--- a/app/services/vacancies/import/sources/fusion.rb
+++ b/app/services/vacancies/import/sources/fusion.rb
@@ -51,12 +51,13 @@ class Vacancies::Import::Sources::Fusion
       job_roles: job_roles_for(item),
       ect_status: ect_status_for(item),
       subjects: item["subjects"].presence&.split(",") || [],
-      working_patterns: item["workingPatterns"].presence&.split(","),
+      working_patterns: working_patterns_for(item),
       contract_type: contract_type_for(item),
       is_parental_leave_cover: parental_leave_cover_for?(item),
       phases: phase_for(item),
       key_stages: item["keyStages"].presence&.split(","),
       visa_sponsorship_available: visa_sponsorship_available_for(item),
+      is_job_share: job_share_for(item),
 
       # TODO: What about central office/multiple school vacancies?
       job_location: :at_one_school,
@@ -81,6 +82,25 @@ class Vacancies::Import::Sources::Fusion
     else
       { other_start_date_details: parsed_date.date, start_date_type: parsed_date.type }
     end
+  end
+
+  def working_patterns_for(item)
+    return unless item["workingPatterns"].present?
+
+    working_patterns = item["workingPatterns"].split(",")
+
+    if working_patterns.include?("job_share")
+      working_patterns -= ["job_share"]
+      working_patterns += ["part_time"]
+    end
+
+    working_patterns.uniq
+  end
+
+  def job_share_for(item)
+    return false unless item["workingPatterns"].split(",").include?("job_share")
+
+    true
   end
 
   def schools_for(item)

--- a/app/views/publishers/vacancies/build/working_patterns.html.slim
+++ b/app/views/publishers/vacancies/build/working_patterns.html.slim
@@ -17,6 +17,6 @@
       = f.govuk_text_area(:working_patterns_details,
                           label: -> { tag.label(t("helpers.label.publishers_job_listing_working_patterns_form.working_patterns_details"), class: ["govuk-label", "govuk-!-font-weight-bold"]) },
                           hint: -> { t("helpers.hint.publishers_job_listing_working_patterns_form.working_patterns_details") },
-                          max_words: 50)
+                          max_words: 75)
 
       = render "publishers/vacancies/vacancy_form_partials/submit", f: f

--- a/app/views/publishers/vacancies/build/working_patterns.html.slim
+++ b/app/views/publishers/vacancies/build/working_patterns.html.slim
@@ -6,11 +6,14 @@
       = f.govuk_error_summary
 
       = f.govuk_collection_check_boxes(:working_patterns,
-                                       Vacancy.working_patterns.keys,
+                                       Vacancy.working_patterns.keys - ["job_share"],
                                        :to_s,
                                        :to_s,
                                        legend: -> { tag.h2(t("publishers.vacancies.steps.working_patterns"), class: "govuk-heading-l") },
                                        hint: -> { t("helpers.hint.publishers_job_listing_working_patterns_form.working_patterns") })
+      = f.govuk_radio_buttons_fieldset :is_job_share, inline: true, legend: { text: "Can this role be done as a job share?" }, hint: { text: "For example, can this role be filled by two teacher who share responsibility for the class?" } do
+            = f.govuk_radio_button :is_job_share, true, label: { text: "Yes" }
+            = f.govuk_radio_button :is_job_share, false, label: { text: "No" }
       = f.govuk_text_area(:working_patterns_details,
                           label: -> { tag.label(t("helpers.label.publishers_job_listing_working_patterns_form.working_patterns_details"), class: ["govuk-label", "govuk-!-font-weight-bold"]) },
                           hint: -> { t("helpers.hint.publishers_job_listing_working_patterns_form.working_patterns_details") },

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -406,6 +406,7 @@ shared:
     - include_additional_documents
     - visa_sponsorship_available
     - is_parental_leave_cover
+    - is_job_share
   failed_imported_vacancies:
     - id
     - import_errors

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -160,7 +160,7 @@ en:
       inclusion: Select a working pattern
     working_patterns_details:
       blank: Enter working patterns details
-      maximum_words: Working patterns details must be 50 words or less
+      maximum_words: Working patterns details must be 75 words or less
     is_job_share:
       blank: Select yes if this role can be done as a job share
   pay_package_errors: &pay_package_errors

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -161,6 +161,8 @@ en:
     working_patterns_details:
       blank: Enter working patterns details
       maximum_words: Working patterns details must be 50 words or less
+    is_job_share:
+      blank: Select yes if this role can be done as a job share
   pay_package_errors: &pay_package_errors
     actual_salary:
       blank: Enter actual salary

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -287,7 +287,7 @@ en:
           teaching_assistant: For example ‘Teaching assistant’
       publishers_job_listing_working_patterns_form:
         working_patterns: Select all that apply.
-        working_patterns_details: For example, ‘32.5 hours a week‘ or ‘Monday and Wednesday‘.
+        working_patterns_details: For example, 16 hours a week, Monday to Wednesday.
         working_patterns_options:
           full_time_education_support: Usually at least 36.5 hours a week
           full_time_higher_level_teaching_assistant: Usually at least 36.5 hours a week

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -287,7 +287,7 @@ en:
           teaching_assistant: For example ‘Teaching assistant’
       publishers_job_listing_working_patterns_form:
         working_patterns: Select all that apply.
-        working_patterns_details: For example, 32.5 hours a week.
+        working_patterns_details: For example, ‘32.5 hours a week‘ or ‘Monday and Wednesday‘.
         working_patterns_options:
           full_time_education_support: Usually at least 36.5 hours a week
           full_time_higher_level_teaching_assistant: Usually at least 36.5 hours a week
@@ -846,7 +846,7 @@ en:
           false: "No"
           true: "Yes"
       publishers_job_listing_working_patterns_form:
-        working_patterns_details: Details of working hours (optional)
+        working_patterns_details: Details of working hours/days (optional)
         organisation_type_options:
           academy: Academy
           local_authority: Local authority maintained schools

--- a/db/migrate/20240718142645_add_is_job_share_to_vacancies.rb
+++ b/db/migrate/20240718142645_add_is_job_share_to_vacancies.rb
@@ -1,0 +1,5 @@
+class AddIsJobShareToVacancies < ActiveRecord::Migration[7.1]
+  def change
+    add_column :vacancies, :is_job_share, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_10_135644) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_18_142645) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -674,6 +674,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_10_135644) do
     t.boolean "include_additional_documents"
     t.boolean "visa_sponsorship_available"
     t.boolean "is_parental_leave_cover"
+    t.boolean "is_job_share"
     t.index ["expires_at"], name: "index_vacancies_on_expires_at"
     t.index ["external_source", "external_reference"], name: "index_vacancies_on_external_source_and_external_reference"
     t.index ["geolocation", "expires_at", "publish_on"], name: "index_vacancies_on_geolocation_and_expires_at_and_publish_on", using: :gist

--- a/lib/tasks/backfill_is_job_share_for_vacancies.rake
+++ b/lib/tasks/backfill_is_job_share_for_vacancies.rake
@@ -1,0 +1,16 @@
+namespace :vacancies do
+  desc "Update working_patterns to replace 'job_share' with 'part_time' and set is_job_share to true"
+  task update_job_share: :environment do
+    vacancies_to_update = Vacancy.where("working_patterns @> ARRAY[?]::varchar[]", ['job_share'])
+
+    vacancies_to_update.find_each do |vacancy|
+      if vacancy.working_patterns.include?('job_share')
+        updated_patterns = vacancy.working_patterns.map { |pattern| pattern == 'job_share' ? 'part_time' : pattern }
+        
+        vacancy.update_columns(working_patterns: updated_patterns.uniq, is_job_share: true)
+        
+        puts "Updated vacancy with ID: #{vacancy.id}"
+      end
+    end
+  end
+end

--- a/lib/tasks/backfill_is_job_share_for_vacancies.rake
+++ b/lib/tasks/backfill_is_job_share_for_vacancies.rake
@@ -1,14 +1,14 @@
 namespace :vacancies do
   desc "Update working_patterns to replace 'job_share' with 'part_time' and set is_job_share to true"
   task update_job_share: :environment do
-    vacancies_to_update = Vacancy.where("working_patterns @> ARRAY[?]::varchar[]", ['job_share'])
+    vacancies_to_update = Vacancy.where("working_patterns @> ARRAY[?]::varchar[]", ["job_share"])
 
     vacancies_to_update.find_each do |vacancy|
-      if vacancy.working_patterns.include?('job_share')
-        updated_patterns = vacancy.working_patterns.map { |pattern| pattern == 'job_share' ? 'part_time' : pattern }
-        
+      if vacancy.working_patterns.include?("job_share")
+        updated_patterns = vacancy.working_patterns.map { |pattern| pattern == "job_share" ? "part_time" : pattern }
+
         vacancy.update_columns(working_patterns: updated_patterns.uniq, is_job_share: true)
-        
+
         puts "Updated vacancy with ID: #{vacancy.id}"
       end
     end

--- a/lib/tasks/backfill_is_job_share_for_vacancies.rake
+++ b/lib/tasks/backfill_is_job_share_for_vacancies.rake
@@ -1,7 +1,7 @@
 namespace :vacancies do
   desc "Update working_patterns to replace 'job_share' with 'part_time' and set is_job_share to true"
   task update_job_share: :environment do
-    vacancies_to_update = Vacancy.where("working_patterns @> ARRAY[?]::varchar[]", ["job_share"])
+    vacancies_to_update = Vacancy.where("101 = ANY(working_patterns)")
 
     vacancies_to_update.find_each do |vacancy|
       if vacancy.working_patterns.include?("job_share")

--- a/lib/tasks/backfill_is_job_share_for_vacancies.rake
+++ b/lib/tasks/backfill_is_job_share_for_vacancies.rake
@@ -5,7 +5,7 @@ namespace :vacancies do
 
     vacancies_to_update.find_each do |vacancy|
       if vacancy.working_patterns.include?("job_share")
-        updated_patterns = vacancy.working_patterns.map { |pattern| pattern == "job_share" ? "part_time" : pattern }
+        updated_patterns = vacancy.working_patterns.map { |pattern| pattern == "job_share" ? Vacancy.working_patterns["part_time"] : Vacancy.working_patterns[pattern] }
 
         vacancy.update_columns(working_patterns: updated_patterns.uniq, is_job_share: true)
 

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -61,10 +61,11 @@ FactoryBot.define do
     starts_on { 1.year.from_now.to_date }
     status { :published }
     subjects { factory_sample(SUBJECT_OPTIONS, 2).map(&:first).sort! }
-    working_patterns { factory_rand_sample(Vacancy.working_patterns.keys, 1..2) }
+    working_patterns { factory_rand_sample(%w[full_time part_time], 1..2) }
     working_patterns_details { Faker::Lorem.sentence(word_count: factory_rand(1..50)) }
     visa_sponsorship_available { false }
     organisations { build_list(:school, 1) }
+    is_job_share { [true, false].sample }
 
     trait :legacy_vacancy do
       about_school { Faker::Lorem.paragraph(sentence_count: factory_rand(5..10)) }

--- a/spec/form_models/publishers/job_listing/working_patterns_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/working_patterns_form_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe Publishers::JobListing::WorkingPatternsForm, type: :model do
   it { is_expected.to validate_inclusion_of(:working_patterns).in_array(Vacancy.working_patterns.keys - ["job_share"]) }
 
   describe "#working_patterns_details" do
-    let(:working_patterns_details) { Faker::Lorem.sentence(word_count: 50) }
+    let(:working_patterns_details) { Faker::Lorem.sentence(word_count: 75) }
 
     context "when working_patterns_details exceeds the maximud allowed length" do
-      let(:working_patterns_details) { Faker::Lorem.sentence(word_count: 51) }
+      let(:working_patterns_details) { Faker::Lorem.sentence(word_count: 76) }
 
       it "ensures working_patterns_details cannot exceed 50 words" do
         expect(subject.errors.of_kind?(:working_patterns_details, :working_patterns_details_maximum_words)).to be true

--- a/spec/form_models/publishers/job_listing/working_patterns_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/working_patterns_form_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Publishers::JobListing::WorkingPatternsForm, type: :model do
   before { subject.valid? }
 
   it { is_expected.to validate_presence_of(:working_patterns) }
-  it { is_expected.to validate_inclusion_of(:working_patterns).in_array(Vacancy.working_patterns.keys) }
+  it { is_expected.to validate_inclusion_of(:working_patterns).in_array(Vacancy.working_patterns.keys - ["job_share"]) }
 
   describe "#working_patterns_details" do
     let(:working_patterns_details) { Faker::Lorem.sentence(word_count: 50) }

--- a/spec/helpers/vacancies_helper_spec.rb
+++ b/spec/helpers/vacancies_helper_spec.rb
@@ -284,20 +284,39 @@ RSpec.describe VacanciesHelper do
 
   describe "#vacancy_working_patterns" do
     subject { vacancy_working_patterns(vacancy) }
+    context "when vacancy does is not a job share" do
+      context "when the vacancy does not contain working patterns details" do
+        let(:vacancy) { build_stubbed(:vacancy, working_patterns: %w[full_time flexible], working_patterns_details: nil, is_job_share: false) }
 
-    context "when the vacancy does not contain working patterns details" do
-      let(:vacancy) { build_stubbed(:vacancy, working_patterns: %w[full_time flexible], working_patterns_details: nil) }
+        it "returns a summary of the working patterns" do
+          expect(subject).to eq("<li>Full time, flexible</li>")
+        end
+      end
 
-      it "returns a summary of the working patterns" do
-        expect(subject).to eq("<li>Full time, flexible</li>")
+      context "when the vacancy contains working patterns details" do
+        let(:vacancy) { build_stubbed(:vacancy, working_patterns: %w[full_time part_time], working_patterns_details: "Between 10 and 36 hours", is_job_share: false) }
+
+        it "returns the working patterns with details for each working pattern" do
+          expect(subject).to eq("<li>Full time, part time: Between 10 and 36 hours</li>")
+        end
       end
     end
 
-    context "when the vacancy contains working patterns details" do
-      let(:vacancy) { build_stubbed(:vacancy, working_patterns: %w[full_time part_time], working_patterns_details: "Between 10 and 36 hours") }
+    context "when vacancy does is a job share" do
+      context "when the vacancy does not contain working patterns details" do
+        let(:vacancy) { build_stubbed(:vacancy, working_patterns: %w[full_time flexible], working_patterns_details: nil, is_job_share: true) }
 
-      it "returns the working patterns with details for each working pattern" do
-        expect(subject).to eq("<li>Full time, part time: Between 10 and 36 hours</li>")
+        it "returns a summary of the working patterns" do
+          expect(subject).to eq("<li>Full time, flexible, open to job share</li>")
+        end
+      end
+
+      context "when the vacancy contains working patterns details" do
+        let(:vacancy) { build_stubbed(:vacancy, working_patterns: %w[full_time part_time], working_patterns_details: "Between 10 and 36 hours", is_job_share: true) }
+
+        it "returns the working patterns with details for each working pattern" do
+          expect(subject).to eq("<li>Full time, part time, open to job share: Between 10 and 36 hours</li>")
+        end
       end
     end
   end

--- a/spec/jobs/import_from_vacancy_source_job_spec.rb
+++ b/spec/jobs/import_from_vacancy_source_job_spec.rb
@@ -168,6 +168,7 @@ RSpec.describe ImportFromVacancySourceJob do
           "working_patterns_details" => nil,
           "visa_sponsorship_available" => false,
           "is_parental_leave_cover" => nil,
+          "is_job_share" => true,
         )
       end
 

--- a/spec/jobs/import_from_vacancy_source_job_spec.rb
+++ b/spec/jobs/import_from_vacancy_source_job_spec.rb
@@ -79,7 +79,8 @@ RSpec.describe ImportFromVacancySourceJob do
               further_details: "details",
               how_to_apply: "Click button",
               job_advert: "Aut repellat vel. Nesciunt exercitationem et. Numquam a corrupti. Et minus hic. Perspiciatis dolor neque. Sit est nemo. Ut ex officiis. Illum et mollitia. Quia qui qui. Debitis totam odio. Consequatur eum iste. Aut ex et. Quo explicabo quae. Aut id laborum. Occaecati quod sit. Laudantium ipsum placeat. Et sed nesciunt. Ut iste maxime. Ea repudiandae rem. Qui fugit adipisci. Vero fugiat dolor. Nesciunt eum et. Molestias nulla facere. Aliquid dolore assumenda. Aut repudiandae iusto. Quia aut maxime. Consequatur voluptates facere. Facere eius asperiores. Fugiat occaecati assumenda. Maiores consequatur architecto. Perferendis sint ut. Est odio dolorem. Aliquid fugiat iusto. Eaque fugiat voluptas. Eos velit assumenda. Nesciunt minus quia. Cupiditate vero dolor. Quos temporibus consequuntur. Vel cupiditate eos. Dolore dolores repellat. Ex ipsam consequuntur. Dolores harum voluptatem. Temporibus neque quis. Vero soluta sunt. Voluptas laboriosam modi. Quod ut nostrum. Veniam voluptatem et. Explicabo necessitatibus ex. Ut architecto placeat. Neque velit et.",
-              visa_sponsorship_available: false)
+              visa_sponsorship_available: false,
+              is_job_share: true)
       end
 
       it "does not save the vacancy to the Vacancies table" do

--- a/spec/presenters/vacancy_presenter_spec.rb
+++ b/spec/presenters/vacancy_presenter_spec.rb
@@ -153,17 +153,26 @@ RSpec.describe VacancyPresenter do
   end
 
   describe "#readable_working_patterns" do
-    let(:vacancy) { build_stubbed(:vacancy, working_patterns: %w[full_time part_time]) }
+    context "when is_job_share" do
+      let(:vacancy) { build_stubbed(:vacancy, working_patterns: %w[full_time part_time], is_job_share: true) }
 
-    it "returns working patterns" do
-      expect(subject.readable_working_patterns).to eq("Full time, part time")
+      it "returns working patterns" do
+        expect(subject.readable_working_patterns).to eq("Full time, part time (Can be done as a job share)")
+      end
+    end
+
+    context "when is_job_share == false" do
+      let(:vacancy) { build_stubbed(:vacancy, working_patterns: %w[full_time part_time], is_job_share: false) }
+      it "returns working patterns" do
+        expect(subject.readable_working_patterns).to eq("Full time, part time")
+      end
     end
   end
 
   describe "#readable_working_patterns_with_details" do
     let(:working_patterns) { %w[full_time part_time] }
     let(:working_patterns_details) { "Some details" }
-    let(:vacancy) { build_stubbed(:vacancy, working_patterns:, working_patterns_details:) }
+    let(:vacancy) { build_stubbed(:vacancy, working_patterns:, working_patterns_details:, is_job_share: false) }
 
     it "returns the working with details" do
       expect(subject.readable_working_patterns_with_details).to eq("Full time, part time: Some details")

--- a/spec/queries/vacancy_filter_query_spec.rb
+++ b/spec/queries/vacancy_filter_query_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe VacancyFilterQuery do
 
   let!(:vacancy1) { create(:vacancy, job_title: "Vacancy 1", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[secondary], job_roles: ["teacher"], ect_status: "ect_suitable", organisations: [academy], enable_job_applications: true, visa_sponsorship_available: true) }
   let!(:vacancy2) { create(:vacancy, job_title: "Vacancy 2", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[sixth_form_or_college], job_roles: ["teacher"], ect_status: "ect_unsuitable", organisations: [free_school], enable_job_applications: true) }
-  let!(:vacancy3) { create(:vacancy, job_title: "Vacancy 3", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["sendco"], ect_status: nil, organisations: [local_authority_school], enable_job_applications: true) }
+  let!(:vacancy3) { create(:vacancy, job_title: "Vacancy 3", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["sendco"], ect_status: nil, organisations: [local_authority_school], enable_job_applications: true, ) }
   let!(:vacancy4) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 4", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["teacher"], ect_status: nil) }
   let!(:vacancy5) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 5", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["head_of_year_or_phase"], ect_status: nil, organisations: [academies]) }
   let!(:vacancy6) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 6", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["head_of_department_or_curriculum"], ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
@@ -160,6 +160,18 @@ RSpec.describe VacancyFilterQuery do
             school_types: %w[special_school faith_school],
           }
           expect(subject.call(filters)).to contain_exactly(special_vacancy1, special_vacancy2, special_vacancy3, special_vacancy4, special_vacancy5, special_vacancy6, faith_vacancy)
+        end
+      end
+    end
+
+    context "when working_patterns filter is selected" do
+      context "when job_share is selected" do
+        it "will return vacancies where is_job_share is true" do
+          filters = {
+            working_patterns: %w[job_share],
+          }
+          
+          expect(subject.call(filters).map(&:is_job_share).uniq).to contain_exactly(true)
         end
       end
     end

--- a/spec/queries/vacancy_filter_query_spec.rb
+++ b/spec/queries/vacancy_filter_query_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe VacancyFilterQuery do
 
   let!(:vacancy1) { create(:vacancy, job_title: "Vacancy 1", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[secondary], job_roles: ["teacher"], ect_status: "ect_suitable", organisations: [academy], enable_job_applications: true, visa_sponsorship_available: true) }
   let!(:vacancy2) { create(:vacancy, job_title: "Vacancy 2", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[sixth_form_or_college], job_roles: ["teacher"], ect_status: "ect_unsuitable", organisations: [free_school], enable_job_applications: true) }
-  let!(:vacancy3) { create(:vacancy, job_title: "Vacancy 3", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["sendco"], ect_status: nil, organisations: [local_authority_school], enable_job_applications: true, ) }
+  let!(:vacancy3) { create(:vacancy, job_title: "Vacancy 3", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["sendco"], ect_status: nil, organisations: [local_authority_school], enable_job_applications: true) }
   let!(:vacancy4) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 4", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["teacher"], ect_status: nil) }
   let!(:vacancy5) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 5", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["head_of_year_or_phase"], ect_status: nil, organisations: [academies]) }
   let!(:vacancy6) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 6", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["head_of_department_or_curriculum"], ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
@@ -170,7 +170,7 @@ RSpec.describe VacancyFilterQuery do
           filters = {
             working_patterns: %w[job_share],
           }
-          
+
           expect(subject.call(filters).map(&:is_job_share).uniq).to contain_exactly(true)
         end
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,6 +13,7 @@ require "rack_session_access/capybara"
 require "sidekiq/testing"
 require "view_component/test_helpers"
 require "webmock/rspec"
+require "capybara-screenshot/rspec"
 
 Sidekiq::Testing.fake!
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,7 +13,6 @@ require "rack_session_access/capybara"
 require "sidekiq/testing"
 require "view_component/test_helpers"
 require "webmock/rspec"
-require "capybara-screenshot/rspec"
 
 Sidekiq::Testing.fake!
 

--- a/spec/services/vacancies/import/sources/fusion_spec.rb
+++ b/spec/services/vacancies/import/sources/fusion_spec.rb
@@ -209,6 +209,17 @@ RSpec.describe Vacancies::Import::Sources::Fusion do
       end
     end
 
+    describe "working_patterns" do
+      let(:response_body) { super().gsub("full_time", "job_share") }
+
+      context "when vacancy is a job share" do
+        it "sets vacancy to part time and is_job_share to true" do
+          expect(vacancy.working_patterns).to eq(["part_time"])
+          expect(vacancy.is_job_share).to eq(true)
+        end
+      end
+    end
+
     describe "ect suitability mapping" do
       let(:response_body) do
         JSON.parse(super()).tap { |h|

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -53,6 +53,8 @@ module VacancyHelpers
       check Vacancy.human_attribute_name(working_pattern.to_s), name: "publishers_job_listing_working_patterns_form[working_patterns][]"
     end
 
+    choose(vacancy.is_job_share ? "Yes" : "No")
+
     fill_in "publishers_job_listing_working_patterns_form[working_patterns_details]", with: vacancy.working_patterns_details
   end
 


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/UTrUqP0Z/1066-update-working-patterns-page

## Changes in this PR:

This PR removes job_share as an option in the working patterns checkbox question and instead adds a new radio button in which the user answers whether the job can be done as a job share or not.

Due to this change in the structure of the question, and the related logic, I have introduced a new field in the vacancies table called is_job_share.

Other changes in this PR are:

- changes to working_patterns filtering to account for the way that job share vacancies are now handled.
- updates to fusion logic (the only ATS that has ever introduced a job share vacancy, it has only introduced 1)
- updates to tests.
- rake task to backfill is_job_share for existing job share vacancies

Note: I will create another PR to remove the "job_share" working_pattern after this has been merged but I believe this should be done after we have run the rake task to backfill existing job_share vacancies

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
