### PR TITLE
Guard against filter link params not containing key

### DIFF
--- a/app/components/filters_component.rb
+++ b/app/components/filters_component.rb
@@ -35,7 +35,7 @@ class FiltersComponent < ApplicationComponent
       filter_value = option.public_send(value_method)
       return unless selected.include?(filter_value)
 
-      if remove_filter_link[:params]
+      if remove_filter_link.dig(:params, key)
         filters = remove_filter_link[:params][key] - [filter_value]
         remove_filter_link_params = remove_filter_link[:params].merge(key => filters)
       else


### PR DESCRIPTION
Sometimes the key is not present on the filter link params and causes an exception when assuming the value was present and trying to operate with it.

[Associated production errors](https://teaching-vacancies.sentry.io/issues/4275572649/?environment=production&project=6212514&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=24h&stream_index=16)

```
NoMethodError
undefined method `-' for nil (NoMethodError)

        filters = remove_filter_link[:params][key] - [filter_value]
                                                   ^
```