### PR TITLE
Fix flaky unit test

### DIFF
--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe PostsController do
       it "finds the subcategories for jobseeker guides" do
         get :index, params: { section: "jobseeker-guides" }
 
-        expect(assigns(:subcategories).sort).to eq(subcategories.sort)
+        expect(assigns(:subcategories)).to match_array(subcategories)
       end
     end
 
@@ -18,7 +18,7 @@ RSpec.describe PostsController do
       it "finds the subcategories for jobseeker guides" do
         get :index, params: { section: "get-help-hiring" }
 
-        expect(assigns(:subcategories)).to eq(subcategories)
+        expect(assigns(:subcategories)).to match_array(subcategories)
       end
     end
 


### PR DESCRIPTION
Failing due to assertion checking the order of array elements when we only want to assert against the array contents.
