### PR TITLE
Fix missing filter bug

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -164,7 +164,7 @@ class SubscriptionsController < ApplicationController
 
   def search_criteria_params
     params.require(:search_criteria)
-          .permit(:keyword, :location, :organisation_slug, :radius, teaching_job_roles: [], support_job_roles: [], ect_statuses: [], subjects: [], phases: [], working_patterns: [])
+          .permit(:keyword, :location, :organisation_slug, :radius, teaching_job_roles: [], support_job_roles: [], ect_statuses: [], subjects: [], phases: [], working_patterns: [], visa_sponsorship_availability: [])
   end
 
   def subscription_params

--- a/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
@@ -171,6 +171,7 @@ RSpec.describe "Jobseekers can create a job alert from a search", recaptcha: tru
     check I18n.t("jobs.filters.ect_suitable")
     check I18n.t("helpers.label.publishers_job_listing_education_phases_form.phases_options.primary")
     check I18n.t("helpers.label.publishers_job_listing_working_patterns_form.working_patterns_options.full_time")
+    check I18n.t("jobs.filters.visa_sponsorship_availability.option")
     click_on I18n.t("buttons.search")
   end
 
@@ -185,6 +186,7 @@ RSpec.describe "Jobseekers can create a job alert from a search", recaptcha: tru
     expect(page.find_field("jobseekers-subscription-form-ect-statuses-ect-suitable-field")).to be_checked
     expect(page.find_field("jobseekers-subscription-form-phases-primary-field")).to be_checked
     expect(page.find_field("jobseekers-subscription-form-working-patterns-full-time-field")).to be_checked
+    expect(page.find_field("jobseekers-subscription-form-visa-sponsorship-availability-true-field")).to be_checked
   end
 
   def fill_in_subscription_fields


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/rHYFUHiE/1095-visa-sponsorship-job-search-to-job-alert-bug

## Changes in this PR:

Prior to this change, when a user filtered jobs by visa sponsorship availability, and then tried to set up a job alert using the existing filters, the visa sponsorship filter was not preselected on the job alert page. This was due to the visa_sponsorship_availability param not being permitted on the subscriptions controller. This change fixes this issue and adds this filter to the assertions on the job alert spec.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
