### PR TITLE
Add landing page for support job roles

### DIFF
--- a/config/landing_pages.yml
+++ b/config/landing_pages.yml
@@ -68,6 +68,16 @@ shared:
   other-support-roles-jobs:
     support_job_roles:
       - other_support
+  support-jobs:
+    support_job_roles:
+      - teaching_assistant
+      - higher_level_teaching_assistant
+      - education_support
+      - administration_hr_data_and_finance
+      - catering_cleaning_and_site_management
+      - it_support
+      - pastoral_health_and_welfare
+      - other_support
 
   ### Phases
   nursery-jobs:

--- a/config/locales/landing_pages.yml
+++ b/config/locales/landing_pages.yml
@@ -126,6 +126,11 @@ en:
       title: "Other Support Roles"
       heading: "%{count} other support roles"
       meta_description: "Find and apply for support roles in schools on Teaching Vacancies. Apply quickly and easily for full and part time jobs in schools."
+    support-jobs:
+      name: "Support roles"
+      title: "Support Roles"
+      heading: "%{count} support roles"
+      meta_description: "Find and apply for support roles in schools on Teaching Vacancies. Apply quickly and easily for full and part time jobs in schools."
 
     ### Education phases
     nursery-jobs:

--- a/spec/system/other/application_sitemap_spec.rb
+++ b/spec/system/other/application_sitemap_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Application sitemap" do
       document = Nokogiri::XML::Document.parse(body)
       nodes = document.search("url")
 
-      expect(nodes.count).to eq(301)
+      expect(nodes.count).to eq(302)
       expect(nodes.search("loc[text()='#{root_url(protocol: 'https')}']").text)
         .to eq(root_url(protocol: "https"))
 


### PR DESCRIPTION
## Trello card URL

## Changes in this PR:

Adds a landing page for support job roles

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
