### PR TITLE
Set a 30 min maintenance window on DFE Analytics

### DIFF
--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -28,6 +28,11 @@ DfE::Analytics.configure do |config|
   #
   config.bigquery_api_json_key = ENV.fetch("BIG_QUERY_API_JSON_KEY", nil)
 
+  # Period while DFE Analytics will be set in maintenance mode and the events won'tbe sent to BigQuery.
+  # Any event generated during this period will be re-enqueued to be sent later.
+  #
+  config.bigquery_maintenance_window = "01-08-2024 18:00..01-08-2024 18:30"
+
   # Passed directly to the retries: option on the BigQuery client
   #
   # config.bigquery_retries = 3


### PR DESCRIPTION
They need the service to stop pushing events to the BigQ tables during a period of time, so they can do some table encrypting work.
