### PR TITLE
Update job alerts email

### DIFF
--- a/app/helpers/notify_views_helper.rb
+++ b/app/helpers/notify_views_helper.rb
@@ -81,7 +81,11 @@ module NotifyViewsHelper
 
   def show_link(vacancy)
     url = job_url(vacancy, **utm_params)
-    notify_link(url, t("jobseekers.alert_mailer.alert.show_job_link"))
+    if vacancy.organisations.many?
+      notify_link(url, t("jobseekers.alert_mailer.alert.show_job_link", job_title: vacancy.job_title))
+    else
+      notify_link(url, t("jobseekers.alert_mailer.alert.show_job_link_with_organisation", job_title: vacancy.job_title, organisation_name: vacancy.organisations.first.name))
+    end
   end
 
   def sign_in_link

--- a/app/helpers/notify_views_helper.rb
+++ b/app/helpers/notify_views_helper.rb
@@ -81,7 +81,7 @@ module NotifyViewsHelper
 
   def show_link(vacancy)
     url = job_url(vacancy, **utm_params)
-    notify_link(url, vacancy.job_title)
+    notify_link(url, t("jobseekers.alert_mailer.alert.show_job_link"))
   end
 
   def sign_in_link
@@ -118,6 +118,20 @@ module NotifyViewsHelper
     else
       address_join([notify_link(url, organisation.name), organisation.town, organisation.county, organisation.postcode]).html_safe
     end
+  end
+
+  def vacancy_organisation_and_location(vacancy)
+    organisation = vacancy.organisation
+    if vacancy.organisations.many?
+      "#{t('organisations.job_location_summary.at_multiple_locations')}, #{organisation.name}".html_safe
+    else
+      address_join([organisation.town, organisation.county, organisation.postcode])
+    end
+  end
+
+  def edit_job_alert_link(subscription)
+    url = edit_subscription_url(subscription)
+    notify_link(url, t(".edit_link_text"))
   end
 
   def view_applications_for_link(vacancy)

--- a/app/helpers/notify_views_helper.rb
+++ b/app/helpers/notify_views_helper.rb
@@ -130,7 +130,7 @@ module NotifyViewsHelper
   end
 
   def edit_job_alert_link(subscription)
-    url = edit_subscription_url(subscription)
+    url = edit_subscription_url(subscription.token)
     notify_link(url, t(".edit_link_text"))
   end
 

--- a/app/views/jobseekers/alert_mailer/alert.text.erb
+++ b/app/views/jobseekers/alert_mailer/alert.text.erb
@@ -2,42 +2,24 @@
 
 ---
 <%- @vacancies.each do |vacancy| %>
-  <%= show_link(vacancy) %>
-  <%= vacancy_location_with_organisation_link(vacancy) %>
-
-  <%= t(".salary", salary: vacancy.salary) %>
+  <%= vacancy.job_title %>
+  <%= vacancy_organisation_and_location(vacancy) %>
   <%= t(".working_pattern", working_pattern: VacancyPresenter.new(vacancy).readable_working_patterns_with_details) %>
-  <%= t(".closing_date", closing_date: format_time_to_datetime_at(vacancy.expires_at)) %>
-
-  <%= '^ ' + t(".quick_apply") if vacancy.enable_job_applications? %>
-
+  <%= show_link(vacancy) %>
   ---
 <% end %>
 
 # <%= t(".title") %>
-<%= t("subscriptions.intro") %>
 
 <%- subscription.filtered_search_criteria.each_pair do |filter, value| %>
   <%= "- #{filter.humanize}: #{value}" %>
 <% end %>
 
-<%= t(".alert_frequency", frequency: subscription.frequency) %>
+<%- if jobseeker_has_profile? %>
+  
+<% end %>
 
 ---
-<%- unless jobseeker_has_profile? %>
-  # <%= t(".create_a_profile.heading") %>
-
-  <%= t(".create_a_profile.intro")%>
-
-  * <%= t(".create_a_profile.bullet_points.share_qualifications_and_experience")%>
-  * <%= t(".create_a_profile.bullet_points.specify_preferences")%>
-  * <%= t(".create_a_profile.bullet_points.apply_quickly")%>
-
-<%= t(".create_a_profile.further_information")%>
-
-<%= jobseeker_profile_link %>
-  ---
-<% end %>
 
 # <%= t(".relevance_feedback.heading") %>
 
@@ -49,6 +31,6 @@
 
 ---
 
-<%= t("shared.footer", home_page_link: home_page_link) %>
+<%= t("shared.jobseeker_footer", home_page_link: home_page_link) %>
 
 <%= t(".unsubscribe", unsubscribe_link: unsubscribe_link(subscription)) %>

--- a/app/views/jobseekers/alert_mailer/alert.text.erb
+++ b/app/views/jobseekers/alert_mailer/alert.text.erb
@@ -15,8 +15,8 @@
   <%= "- #{filter.humanize}: #{value}" %>
 <% end %>
 
-<%- if jobseeker_has_profile? %>
-  
+<%- if jobseeker %>
+  <%= edit_job_alert_link(subscription) %>
 <% end %>
 
 ---

--- a/app/views/jobseekers/alert_mailer/alert.text.erb
+++ b/app/views/jobseekers/alert_mailer/alert.text.erb
@@ -12,7 +12,7 @@
 # <%= t(".title") %>
 
 <%- subscription.filtered_search_criteria.each_pair do |filter, value| %>
-  <%= "- #{filter.humanize}: #{value}" %>
+  <%= "#{filter.humanize}: #{value}" %>
 <% end %>
 
 <%- if jobseeker %>

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -3,6 +3,7 @@ en:
     footer: >-
       %{home_page_link} is a free job-listing service from the Department for Education. It helps schools to save money
       on recruitment and you to take the next step in your career.
+    jobseeker_footer: "%{home_page_link} is a free job-listing service from the Department for Education. It helps you find the right jobs in schools and take the next step in your career."
 
   admins:
   jobseekers:
@@ -97,17 +98,18 @@ en:
           other: "%{school_name} is hiring for a %{job_title} - and %{count_minus_one} other new job(s)"
         summary:
           daily:
-            one: A new job matching your search criteria was listed in the last day
-            other: "%{count} new jobs matching your search criteria were listed in the last day"
+            one: You have a new job alert
+            other: "You have %{count} new job alerts"
           weekly:
-            one: A new job matching your search criteria was listed in the last week
-            other: "%{count} new jobs matching your search criteria were listed in the last week"
-        title: This job alert
+            one: You have a new job alert
+            other: "You have %{count} new job alerts"
+        title: Your job alert search
         quick_apply: You can use quick apply for this job which allows you to apply simply and quickly using your profile.
         unsubscribe: Don’t want to receive these email alerts? %{unsubscribe_link}
         unsubscribe_link_text: Unsubscribe here
         working_pattern: "Working pattern: %{working_pattern}"
-
+        show_job_link: Look at the full job advert on Teaching Vacancies
+        edit_link_text: Change your job alert search on Teaching Vacancies
     job_application_mailer:
       shared: &job_application_mailer_shared
         intro: Your application for %{job_title} at %{organisation_name}

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -108,7 +108,8 @@ en:
         unsubscribe: Don’t want to receive these email alerts? %{unsubscribe_link}
         unsubscribe_link_text: Unsubscribe here
         working_pattern: "Working pattern: %{working_pattern}"
-        show_job_link: Look at the full job advert on Teaching Vacancies
+        show_job_link: "View %{job_title} job"
+        show_job_link_with_organisation: "View %{job_title} at %{organisation_name} job"
         edit_link_text: Change your job alert search on Teaching Vacancies
     job_application_mailer:
       shared: &job_application_mailer_shared

--- a/spec/mailers/jobseekers/alert_mailer_spec.rb
+++ b/spec/mailers/jobseekers/alert_mailer_spec.rb
@@ -75,14 +75,9 @@ RSpec.describe Jobseekers::AlertMailer do
       expect(body).to include(I18n.t("jobseekers.alert_mailer.alert.summary.daily", count: 1))
                   .and include(vacancies.first.job_title)
                   .and include(job_url(vacancies.first, **utm_params))
-                  .and include(organisation_landing_page_url(vacancies.first.organisation.slug, **utm_params))
-                  .and include(I18n.t("jobseekers.alert_mailer.alert.salary", salary: vacancies.first.salary))
                   .and include(I18n.t("jobseekers.alert_mailer.alert.working_pattern", working_pattern: vacancies.first.readable_working_patterns_with_details))
-                  .and include(I18n.t("jobseekers.alert_mailer.alert.closing_date", closing_date: format_time_to_datetime_at(vacancies.first.expires_at)))
                   .and include(I18n.t("jobseekers.alert_mailer.alert.title"))
-                  .and include(I18n.t("subscriptions.intro"))
                   .and include("Keyword: English")
-                  .and include(I18n.t("jobseekers.alert_mailer.alert.alert_frequency", frequency: subscription.frequency))
                   .and include(I18n.t("jobseekers.alert_mailer.alert.relevance_feedback.heading"))
                   .and match(/(\[#{I18n.t('jobseekers.alert_mailer.alert.relevance_feedback.relevant_link_text')}\]\(.+true)/)
                   .and include(relevant_job_alert_feedback_url)
@@ -125,18 +120,11 @@ RSpec.describe Jobseekers::AlertMailer do
       expect(mail.to).to eq([subscription.email])
       expect(body).to include(I18n.t("jobseekers.alert_mailer.alert.summary.weekly", count: 1))
                   .and include(vacancies.first.job_title)
-                  .and include(vacancies.first.job_title)
                   .and include(job_url(vacancies.first, **utm_params))
-                  .and include(organisation_landing_page_url(vacancies.first.organisation.slug, **utm_params))
-                  .and include(I18n.t("jobseekers.alert_mailer.alert.salary", salary: vacancies.first.salary))
                   .and include(I18n.t("jobseekers.alert_mailer.alert.working_pattern",
                                       working_pattern: vacancies.first.readable_working_patterns_with_details))
-                  .and include(I18n.t("jobseekers.alert_mailer.alert.closing_date",
-                                      closing_date: format_time_to_datetime_at(vacancies.first.expires_at)))
                   .and include(I18n.t("jobseekers.alert_mailer.alert.title"))
-                  .and include(I18n.t("subscriptions.intro"))
                   .and include("Keyword: English")
-                  .and include(I18n.t("jobseekers.alert_mailer.alert.alert_frequency", frequency: subscription.frequency))
                   .and include(I18n.t("jobseekers.alert_mailer.alert.relevance_feedback.heading"))
                   .and match(/(\[#{I18n.t('jobseekers.alert_mailer.alert.relevance_feedback.relevant_link_text')}\]\(.+true)/)
                   .and include(relevant_job_alert_feedback_url)
@@ -173,24 +161,6 @@ RSpec.describe Jobseekers::AlertMailer do
         expect(body).to_not include(jobseekers_profile_url(**utm_params))
         expect(body).to_not include(I18n.t("jobseekers.alert_mailer.alert.create_a_profile.heading"))
         expect(body).to_not include(I18n.t("jobseekers.alert_mailer.alert.create_a_profile.link_text"))
-      end
-    end
-
-    context "when the subscriber does not have a jobseeker account" do
-      it "does not display the section encouraging them to create a profile" do
-        expect(body).to include(jobseekers_profile_url(**utm_params))
-                    .and include(I18n.t("jobseekers.alert_mailer.alert.create_a_profile.heading"))
-                    .and include(I18n.t("jobseekers.alert_mailer.alert.create_a_profile.link_text"))
-      end
-    end
-
-    context "when the subscriber has a jobseeker account but no profile" do
-      let(:jobseeker) { create(:jobseeker, email: email) }
-
-      it "does not display the section encouraging them to create a profile" do
-        expect(body).to include(jobseekers_profile_url(**utm_params))
-                    .and include(I18n.t("jobseekers.alert_mailer.alert.create_a_profile.heading"))
-                    .and include(I18n.t("jobseekers.alert_mailer.alert.create_a_profile.link_text"))
       end
     end
   end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/qM80JvL7/1111-update-job-alert-email-content

## Changes in this PR:

This PR changes the copy on the job alerts emails.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
