### PR TITLE
Changes to the apply to jobs page

### DIFF
--- a/app/views/vacancies/listing/_job_details.html.slim
+++ b/app/views/vacancies/listing/_job_details.html.slim
@@ -90,44 +90,57 @@ section#job-details class="govuk-!-margin-bottom-5"
   - if vacancy.expires_at.future?
     h3.govuk-heading-m = t("jobseekers.job_applications.applying_for_the_job_heading")
 
-    .govuk-body = t("vacancies.international_teacher_advice.text_html", link: tracked_link_to(t("vacancies.international_teacher_advice.link"), "https://getintoteaching.education.gov.uk/non-uk-teachers", link_type: :international_teacher_advice_link_job_listing))
     - inset_text = t("vacancies.#{vacancy.visa_sponsorship_available ? 'sponsorship_available' : 'sponsorship_unavailable'}")
     - if vacancy.enable_job_applications?
       p.govuk-body = t("jobseekers.job_applications.applying_for_the_job_paragraph")
+      p.govuk-body = t("jobseekers.job_applications.no_cvs")
       = govuk_inset_text text: inset_text
       = govuk_button_link_to t("jobseekers.job_applications.apply"), new_jobseekers_job_job_application_path(vacancy.id)
+      .govuk-body = t("vacancies.international_teacher_advice.text_html", link: tracked_link_to(t("vacancies.international_teacher_advice.link"), "https://getintoteaching.education.gov.uk/non-uk-teachers", link_type: :international_teacher_advice_link_job_listing))
+
 
     - elsif vacancy.receive_applications == "website"
       p.govuk-body = t("jobs.apply_via_website")
+      p.govuk-body = t("jobseekers.job_applications.no_cvs")
       = govuk_inset_text text: inset_text
       = apply_link(vacancy, class: "govuk-!-margin-bottom-5")
+      .govuk-body = t("vacancies.international_teacher_advice.text_html", link: tracked_link_to(t("vacancies.international_teacher_advice.link"), "https://getintoteaching.education.gov.uk/non-uk-teachers", link_type: :international_teacher_advice_link_job_listing))
 
     - elsif vacancy.receive_applications == "email"
       p.govuk-body = t("jobs.apply_via_email_html", email: application_email_link(vacancy))
+      p.govuk-body = t("jobseekers.job_applications.no_cvs")
       = govuk_inset_text text: inset_text
       = govuk_button_link_to t("buttons.download_application_form", size: number_to_human_size(vacancy.application_form.byte_size)), job_document_path(vacancy, vacancy.application_form.id)
+      .govuk-body = t("vacancies.international_teacher_advice.text_html", link: tracked_link_to(t("vacancies.international_teacher_advice.link"), "https://getintoteaching.education.gov.uk/non-uk-teachers", link_type: :international_teacher_advice_link_job_listing))
 
     - else
       - if vacancy.how_to_apply.present?
         p.govuk-body = vacancy.how_to_apply
 
       - if vacancy.external?
-        h4.govuk-heading-m = t("publishers.vacancies.steps.applying_for_the_job")
         p = t("jobs.external.notice")
+        p.govuk-body = t("jobseekers.job_applications.no_cvs")
         = govuk_inset_text text: inset_text
         = external_advert_link vacancy, class: "govuk-!-margin-bottom-5"
+        .govuk-body = t("vacancies.international_teacher_advice.text_html", link: tracked_link_to(t("vacancies.international_teacher_advice.link"), "https://getintoteaching.education.gov.uk/non-uk-teachers", link_type: :international_teacher_advice_link_job_listing))
 
       - if vacancy.application_link.present? && vacancy.application_form.present?
+        p.govuk-body = t("jobseekers.job_applications.no_cvs")
         = govuk_inset_text text: inset_text
         = apply_link(vacancy, class: "govuk-button--secondary govuk-!-margin-bottom-5")
         br
         = govuk_button_link_to t("buttons.download_application_form", size: number_to_human_size(vacancy.application_form.byte_size)), job_document_path(vacancy, vacancy.application_form.id), class: "govuk-button--secondary"
+        .govuk-body = t("vacancies.international_teacher_advice.text_html", link: tracked_link_to(t("vacancies.international_teacher_advice.link"), "https://getintoteaching.education.gov.uk/non-uk-teachers", link_type: :international_teacher_advice_link_job_listing))
       - elsif vacancy.application_link.present?
+        p.govuk-body = t("jobseekers.job_applications.no_cvs")
         = govuk_inset_text text: inset_text
         = apply_link(vacancy, class: "govuk-!-margin-bottom-5")
+        .govuk-body = t("vacancies.international_teacher_advice.text_html", link: tracked_link_to(t("vacancies.international_teacher_advice.link"), "https://getintoteaching.education.gov.uk/non-uk-teachers", link_type: :international_teacher_advice_link_job_listing))
       - elsif vacancy.application_form.present?
+        p.govuk-body = t("jobseekers.job_applications.no_cvs")
         = govuk_inset_text text: inset_text
         = govuk_button_link_to t("buttons.download_application_form", size: number_to_human_size(vacancy.application_form.byte_size)), job_document_path(vacancy, vacancy.application_form.id)
+        .govuk-body = t("vacancies.international_teacher_advice.text_html", link: tracked_link_to(t("vacancies.international_teacher_advice.link"), "https://getintoteaching.education.gov.uk/non-uk-teachers", link_type: :international_teacher_advice_link_job_listing))
   - else
     = govuk_inset_text text: t("jobs.expired_listing.notification"), classes: "govuk-!-font-weight-bold"
 

--- a/app/views/vacancies/listing/_job_details.html.slim
+++ b/app/views/vacancies/listing/_job_details.html.slim
@@ -98,7 +98,6 @@ section#job-details class="govuk-!-margin-bottom-5"
       = govuk_button_link_to t("jobseekers.job_applications.apply"), new_jobseekers_job_job_application_path(vacancy.id)
       .govuk-body = t("vacancies.international_teacher_advice.text_html", link: tracked_link_to(t("vacancies.international_teacher_advice.link"), "https://getintoteaching.education.gov.uk/non-uk-teachers", link_type: :international_teacher_advice_link_job_listing))
 
-
     - elsif vacancy.receive_applications == "website"
       p.govuk-body = t("jobs.apply_via_website")
       p.govuk-body = t("jobseekers.job_applications.no_cvs")

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -261,14 +261,14 @@ en:
         delete: Delete
 
     additional_documents: Additional documents
-    apply: More on how to apply
+    apply: How to apply
     application_link: Link to website
     application_email: Email address to receive applications
     application_email_subject: '%{job} job application'
     application_email_body: Regarding the job at %{url}
     application_form: Application form
     apply_via_email_html: Please download the application form using the link below, and once completed send to %{email}
-    apply_via_website: Apply for the job by following the link below
+    apply_via_website: Apply for the job by following the link below.
     contact_email: Email address
     contact_email_subject: '%{job} job enquiry'
     contact_email_body: Regarding the job at %{url}

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -77,6 +77,7 @@ en:
       apply: Apply for this job
       applying_for_the_job_heading: Applying for the job
       applying_for_the_job_paragraph: Please complete the online application.
+      no_cvs: CVs are not accepted.
       banner_links:
         apply: Apply for this job
         draft: Started - continue application


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/HD3ULXP7/1112-content-update-on-job-advert-applying-for-the-job-section

## Changes in this PR:

This PR makes changes to the vacancy apply pages.

Quick apply vacancy:
https://teaching-vacancies-review-pr-6991.test.teacherservices.cloud/jobs/team-leader-of-maths-bluemeadow-high-1
![Screenshot 2024-08-06 at 09 09 02](https://github.com/user-attachments/assets/3625bab6-f7ac-40c5-ac0d-a5aa36be0a04)

Download application form job:
https://teaching-vacancies-review-pr-6991.test.teacherservices.cloud/jobs/download-application-form-job
![Screenshot 2024-08-06 at 09 31 01](https://github.com/user-attachments/assets/7883c2a3-3212-4b8c-a329-c4037f94fea9)

School website job:
https://teaching-vacancies-review-pr-6991.test.teacherservices.cloud/jobs/school-website-job
![Screenshot 2024-08-06 at 09 27 22](https://github.com/user-attachments/assets/fcf516a1-33b3-4e88-a666-1968116986b4)

ATS vacancy:
https://teaching-vacancies-review-pr-6991.test.teacherservices.cloud/jobs/director-of-learning-science-glenfield-infant-school-southampton-hampshire
![Screenshot 2024-08-05 at 17 08 27](https://github.com/user-attachments/assets/7ee1bfb5-39eb-4391-8479-c7bbdc9c5fe3)


## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
