### PR TITLE
Hiring staff sign in journey

### DIFF
--- a/app/controllers/publishers/sessions_controller.rb
+++ b/app/controllers/publishers/sessions_controller.rb
@@ -2,7 +2,7 @@ class Publishers::SessionsController < Devise::SessionsController
   include ReturnPathTracking::Helpers
 
   def new
-    redirect_to new_publishers_login_key_path if AuthenticationFallback.enabled?
+    # redirect_to new_publishers_login_key_path if AuthenticationFallback.enabled?
 
     if (login_failure = params[:login_failure])
       flash.now[:alert] = t("devise.failure.#{login_failure}")

--- a/app/controllers/publishers/sessions_controller.rb
+++ b/app/controllers/publishers/sessions_controller.rb
@@ -2,7 +2,7 @@ class Publishers::SessionsController < Devise::SessionsController
   include ReturnPathTracking::Helpers
 
   def new
-    # redirect_to new_publishers_login_key_path if AuthenticationFallback.enabled?
+    redirect_to new_publishers_login_key_path if AuthenticationFallback.enabled?
 
     if (login_failure = params[:login_failure])
       flash.now[:alert] = t("devise.failure.#{login_failure}")

--- a/app/views/publishers/sessions/new.html.slim
+++ b/app/views/publishers/sessions/new.html.slim
@@ -1,15 +1,15 @@
 - content_for :page_title_prefix, t(".sign_in.title")
 
 .govuk-grid-row
-  .govuk-grid-column-two-thirds
+  .govuk-grid-column-full
     h1.govuk-heading-l = t(".sign_in.title")
 
     p = t(".sign_in.description")
+
+    h2.govuk-heading-m = t(".get_account.heading")
+    p.govuk-body = t(".get_account.body")
+
+    h2.govuk-heading-m = t(".list_role_for_trust_or_la.heading")
+    p.govuk-body = t(".list_role_for_trust_or_la.body")
+
     = govuk_button_to t("buttons.continue_to_dsi"), auth_dfe_path
-
-  .govuk-grid-column-one-third
-    h2.govuk-heading-m = t(".no_account.heading")
-
-    p.govuk-body = t(".no_account.content_html", link: govuk_link_to(t(".no_account.login_link_text"), auth_dfe_path, method: :post))
-
-    p.govuk-body = t(".no_account.account_request_html", link: govuk_link_to(t(".no_account.account_request_link_text"), page_path("dsi-account-request")))

--- a/app/views/publishers/vacancies/build/job_title.html.slim
+++ b/app/views/publishers/vacancies/build/job_title.html.slim
@@ -1,4 +1,11 @@
 - content_for :page_title_prefix, page_title_prefix(step_process, form)
+- unless current_organisation.trust_or_la?
+  .govuk-grid-row
+      .govuk-grid-column-full
+        = govuk_notification_banner title_text: "Important", classes: "govuk-notification-banner govuk-!-margin-top-0 govuk-!-margin-bottom-5" do |banner|
+          - banner.with_heading(text: t("publishers.vacancies.build.multiple_schools_advice_banner.heading"))
+          p.govuk-body = govuk_link_to(t("publishers.vacancies.build.multiple_schools_advice_banner.link_text"), "/get-help-hiring/how-to-setup-your-account/how-to-request-organisation-access")
+end
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -383,6 +383,9 @@ en:
           after: Deadline passed
           before: Application deadline
       build:
+        multiple_schools_advice_banner:
+          heading: Sign-in as your trust or local authority to advertise a job across multiple schools or at a trust or local authority level
+          link_text: Find out how to request organisational access
         about_the_role:
           step_title: About the role
         application_link:

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -332,7 +332,7 @@ en:
       new:
         get_account:
           heading: Get a Teaching Vacancies account
-          body: Create a DfE Sign-in account or log in to your existing one, the select 'Request access to a service' and choose Teaching Vacancies.
+          body: Create a DfE Sign-in account or log in to your existing one, then select 'Request access to a service' and choose Teaching Vacancies.
         list_role_for_trust_or_la:
           heading: List a role at trust or local authority level
           body: To list a role across multiple schools or at trust or local authority level, you need to make sure you have the right level of access. Continue to DfE Sign-in and select 'Request access to an organisation'.

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -330,6 +330,12 @@ en:
       create:
         not_authorised: You are not authorised to log in
       new:
+        get_account:
+          heading: Get a Teaching Vacancies account
+          body: Create a DfE Sign-in account or log in to your existing one, the select 'Request access to a service' and choose Teaching Vacancies.
+        list_role_for_trust_or_la:
+          heading: List a role at trust or local authority level
+          body: To list a role across multiple schools or at trust or local authority level, you need to make sure you have the right level of access. Continue to DfE Sign-in and select 'Request access to an organisation'.
         no_account:
           account_request_html: If you don't yet have access to Teaching Vacancies you can %{link}
           account_request_link_text: request an account


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/8SYsFTzj/1113-add-content-and-banner-re-hiring-staff-dfe-sign-in-journey

## Changes in this PR:

This PR changes some copy on the hiring staff sign in page and adds a notice banner when a hiring staff user is logged in as a non trust or LA giving them info on needing to log in as a trust or LA to post jobs at multiple locations.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
