### PR TITLE
Add hint text to the school offer text area

### DIFF
--- a/app/components/editor_component/editor_component.html.slim
+++ b/app/components/editor_component/editor_component.html.slim
@@ -3,10 +3,9 @@
     label class="#{label_classes}" data-action="click->editor#focus" for="#{@field_name}-field" id=@label[:id]
       = @label[:text]
     .govuk-hint id="#{@field_name}-hint"
-      - if @hint
-        = @hint.presence
-        p
-      = "You can copy and paste bullet points into the text box."
+      - if @hint.present?
+        p.govuk-hint = @hint
+      p.govuk-hint = "You can copy and paste bullet points into the text box."
     .editor-component__toolbar data-editor-target="toolbar"
 
   .editor-component__form-input data-editor-target="formInput"

--- a/app/components/editor_component/editor_component.html.slim
+++ b/app/components/editor_component/editor_component.html.slim
@@ -3,7 +3,10 @@
     label class="#{label_classes}" data-action="click->editor#focus" for="#{@field_name}-field" id=@label[:id]
       = @label[:text]
     .govuk-hint id="#{@field_name}-hint"
-      = @hint.presence || "You can copy and paste bullet points into the text box."
+      - if @hint
+        = @hint.presence
+        p
+      = "You can copy and paste bullet points into the text box."
     .editor-component__toolbar data-editor-target="toolbar"
 
   .editor-component__form-input data-editor-target="formInput"

--- a/app/views/publishers/vacancies/build/about_the_role.html.slim
+++ b/app/views/publishers/vacancies/build/about_the_role.html.slim
@@ -46,7 +46,7 @@
                 required: true
 
       - else
-        = editor(form_input: f.govuk_text_area(:school_offer, label: { size: "s", id: "school-offer-label" }, rows: 5, required: true, aria: { hidden: false }), value: form.school_offer, field_name: "publishers_job_listing_about_the_role_form[school_offer]", label: { text: t("jobs.school_offer.publisher"), size: "s", id: "school-offer-label" })
+        = editor(form_input: f.govuk_text_area(:school_offer, label: { size: "s", id: "school-offer-label" }, rows: 5, required: true, aria: { hidden: false }), value: form.school_offer, field_name: "publishers_job_listing_about_the_role_form[school_offer]", hint: t("jobs.school_offer.hint"), label: { text: t("jobs.school_offer.publisher"), size: "s", id: "school-offer-label" })
 
       - unless vacancy.job_advert.present?
         - if vacancy.safeguarding_information.present?

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -187,6 +187,7 @@ en:
     school_offer:
       jobseeker: What the school offers its staff
       publisher: What does your school offer?
+      hint: Provide details about what your school can offer staff, for example, employee benefits, flexible working opportunities or professional development.
     skills_and_experience:
       jobseeker: What skills and experience we're looking for
       publisher: What skills and experience are you looking for?


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/ZnOFefl0/1127-add-hint-text-to-about-the-role-page-in-listing-journey

## Changes in this PR:

This PR adds hint text to the "What does your school offer?" question on the vacancy build form

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
