### PR TITLE
Fix filter bug

### DIFF
--- a/app/queries/vacancy_filter_query.rb
+++ b/app/queries/vacancy_filter_query.rb
@@ -112,7 +112,7 @@ class VacancyFilterQuery < ApplicationQuery
       built_scope = built_scope.where(is_job_share: true)
     end
 
-    built_scope.with_any_of_working_patterns(working_patterns) if working_patterns.present?
+    built_scope = built_scope.with_any_of_working_patterns(working_patterns) if working_patterns.present?
 
     built_scope
   end

--- a/spec/queries/vacancy_filter_query_spec.rb
+++ b/spec/queries/vacancy_filter_query_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe VacancyFilterQuery do
   let(:non_faith_school2) { create(:school, name: "nonfaith2", gias_data: { "ReligiousCharacter (name)" => "Does not apply" }) }
   let(:non_faith_school3) { create(:school, name: "nonfaith3", gias_data: { "ReligiousCharacter (name)" => "None" }) }
 
-  let!(:vacancy1) { create(:vacancy, job_title: "Vacancy 1", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[secondary], job_roles: ["teacher"], ect_status: "ect_suitable", organisations: [academy], enable_job_applications: true, visa_sponsorship_available: true) }
-  let!(:vacancy2) { create(:vacancy, job_title: "Vacancy 2", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[sixth_form_or_college], job_roles: ["teacher"], ect_status: "ect_unsuitable", organisations: [free_school], enable_job_applications: true) }
-  let!(:vacancy3) { create(:vacancy, job_title: "Vacancy 3", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["sendco"], ect_status: nil, organisations: [local_authority_school], enable_job_applications: true) }
+  let!(:vacancy1) { create(:vacancy, job_title: "Vacancy 1", subjects: %w[English Spanish], working_patterns: %w[part_time full_time], phases: %w[secondary], job_roles: ["teacher"], ect_status: "ect_suitable", organisations: [academy], enable_job_applications: true, visa_sponsorship_available: true) }
+  let!(:vacancy2) { create(:vacancy, job_title: "Vacancy 2", subjects: %w[English Spanish], working_patterns: %w[part_time], phases: %w[sixth_form_or_college], job_roles: ["teacher"], ect_status: "ect_unsuitable", organisations: [free_school], enable_job_applications: true) }
+  let!(:vacancy3) { create(:vacancy, job_title: "Vacancy 3", subjects: %w[English Spanish], working_patterns: %w[part_time], phases: %w[primary], job_roles: ["sendco"], ect_status: nil, organisations: [local_authority_school], enable_job_applications: true) }
   let!(:vacancy4) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 4", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["teacher"], ect_status: nil) }
   let!(:vacancy5) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 5", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["head_of_year_or_phase"], ect_status: nil, organisations: [academies]) }
   let!(:vacancy6) { create(:vacancy, :no_tv_applications, job_title: "Vacancy 6", subjects: %w[English Spanish], working_patterns: %w[full_time], phases: %w[primary], job_roles: ["head_of_department_or_curriculum"], ect_status: nil, publisher_organisation: free_school, organisations: [free_school, free_schools]) }
@@ -172,6 +172,27 @@ RSpec.describe VacancyFilterQuery do
           }
 
           expect(subject.call(filters).map(&:is_job_share).uniq).to contain_exactly(true)
+        end
+      end
+
+      context "when part time is selected" do
+        it "will return vacancies where working patterns include part_time" do
+          filters = {
+            working_patterns: %w[part_time],
+          }
+
+          expect(subject.call(filters)).to contain_exactly(vacancy1, vacancy2, vacancy3)
+        end
+      end
+
+      context "when full time is selected" do
+        it "will return vacancies where working patterns include full_time" do
+          filters = {
+            working_patterns: %w[full_time],
+          }
+
+          expect(subject.call(filters)).not_to include(vacancy2, vacancy3)
+          expect(subject.call(filters).count).to eq 27
         end
       end
     end


### PR DESCRIPTION
## Changes in this PR:

This change fixes a bug that originated in [this pr](https://github.com/DFE-Digital/teaching-vacancies/pull/6966) which was causing the working patterns filter to not work (apart from job share). This managed to get into production because we had no tests for the working pattern filter (apart from the one added for job share in the above PR) so I have added some working pattern filter tests to ensure this will not happen again.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
