### PR TITLE
Adding return to teaching adviser video transcript

### DIFF
--- a/app/views/content/jobseeker-guides/return-to-teaching-in-england/return-to-teaching.md
+++ b/app/views/content/jobseeker-guides/return-to-teaching-in-england/return-to-teaching.md
@@ -48,7 +48,7 @@ You can chat by phone, text or email, as little or as often as you need.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/2NrLm_XId4k" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
-[Read a transcript of the video](https://teaching-vacancies.campaign.gov.uk/what-does-a-return-to-teaching-adviser-do-video-transcript)
+[Read a transcript of the video](https://teaching-vacancies.service.gov.uk/jobseeker-guides/return-to-teaching-in-england/what-does-a-return-to-teaching-adviser-do-video-transcript)
 
 If you qualified as a teacher outside the UK, you must have qualified teacher status (QTS) to get an adviser and will be asked to provide your [Teacher Reference Number](https://www.gov.uk/guidance/teacher-reference-number-trn).
 

--- a/app/views/content/jobseeker-guides/return-to-teaching-in-england/what-does-a-return-to-teaching-adviser-do-video-transcript.md
+++ b/app/views/content/jobseeker-guides/return-to-teaching-in-england/what-does-a-return-to-teaching-adviser-do-video-transcript.md
@@ -11,7 +11,7 @@ My role as a return to teaching adviser is to offer one-to-one personal support 
 
 I’m effectively a mentor to the candidates that I support. I offer impartial advice on gaining classroom experience, keeping up to date with the national curriculum and also keeping up to speed with educational developments. 
 
-I can also offer you support with searching for job vacancies, writing your personal statement and completing your application form, preparing for your teaching interview and securing that all-important role.
+I can also offer you support with searching for job vacancies, writing your personal statement and completing your application form, preparing for your teaching interview and securing that all important role.
 
 ## What experience do return to teaching advisers have? 
 
@@ -29,7 +29,7 @@ You need knowledge of the teaching standards and how you can document this infor
 
 So you might be thinking that you don’t have the confidence to return to teaching, but I’m here to tell you that you definitely can. 
 
-Once you gain some valuable classroom experience and you get back into the swing of things, you’ll realise that this is something you can really do and there’s nothing better for me as a Return to Teaching Adviser when you secure a role. 
+Once you gain some valuable classroom experience and you get back into the swing of things, you’ll realise that this is something you can really do and there’s nothing better for me as a return to teaching adviser when you secure a role. 
 
 Teaching. Every Lesson Shapes a Life.
 

--- a/app/views/content/jobseeker-guides/return-to-teaching-in-england/what-does-a-return-to-teaching-adviser-do-video-transcript.md
+++ b/app/views/content/jobseeker-guides/return-to-teaching-in-england/what-does-a-return-to-teaching-adviser-do-video-transcript.md
@@ -1,0 +1,36 @@
+---
+title: Return to teaching adviser video transcript
+meta_description: A return to teaching adviser offers one to one support to teachers who are looking to return to the classroom.
+date_posted: 15/08/2024
+category_tags: apply
+---
+
+Billy Bone, return to teaching adviser: 
+
+My role as a return to teaching adviser is to offer one-to-one personal support for teachers who are looking to return to the classroom in certain subjects. 
+
+I’m effectively a mentor to the candidates that I support. I offer impartial advice on gaining classroom experience, keeping up to date with the national curriculum and also keeping up to speed with educational developments. 
+
+I can also offer you support with searching for job vacancies, writing your personal statement and completing your application form, preparing for your teaching interview and securing that all-important role.
+
+## What experience do return to teaching advisers have? 
+
+As a secondary school teacher for 10 years, I really enjoyed helping children with their learning and giving them confidence for the future. 
+
+This has now transferred to my career as an adviser and I now look to help returning teachers get back into the classroom so they can start inspiring children again. As a team we have experience teaching a wide range of subjects. 
+
+We’ve also taught in a variety of school settings. This means that we’re able to offer you bespoke support depending on your experience and your needs. 
+
+## Top tips for returning to teaching
+
+It’s really important to focus on gaining classroom experience and also getting up to speed with the national curriculum, along with educational developments. 
+
+You need knowledge of the teaching standards and how you can document this information. It’s important that you can showcase your qualities as a teacher and also demonstrate any transferable skills that you’ve developed that could be utilised within the classroom. 
+
+So you might be thinking that you don’t have the confidence to return to teaching, but I’m here to tell you that you definitely can. 
+
+Once you gain some valuable classroom experience and you get back into the swing of things, you’ll realise that this is something you can really do and there’s nothing better for me as a Return to Teaching Adviser when you secure a role. 
+
+Teaching. Every Lesson Shapes a Life.
+
+Search: return to teaching 

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe PostsController do
           %w[
             return-to-teaching
             return-to-england-after-teaching-overseas
+            what-does-a-return-to-teaching-adviser-do-video-transcript
           ]
         end
 


### PR DESCRIPTION
## Trello card URL

## Changes in this PR:

On our return to teaching page, we have a link to a video transcript currently still hosted on the campaign site.

This PR is to move this transcript across to the main TV site.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
