### PR TITLE
Changing education phase labelling

### DIFF
--- a/app/views/jobseekers/profiles/job_preferences/phases.html.slim
+++ b/app/views/jobseekers/profiles/job_preferences/phases.html.slim
@@ -7,6 +7,6 @@
 
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      = f.govuk_collection_check_boxes :phases, @step.options, :first, :last, legend: { size: "l" }, caption: { text: "Job preferences", size: "l" }
+      = f.govuk_collection_check_boxes :phases, @step.options, :first, :last, legend: { text: "Education phase", size: "l" }, caption: { text: "Job preferences", size: "l" }
       = f.govuk_submit "Save and continue"
       p = f.link_to "Cancel", escape_path

--- a/app/views/jobseekers/profiles/job_preferences/phases.html.slim
+++ b/app/views/jobseekers/profiles/job_preferences/phases.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, "Job preferences: Education phase"
+- content_for :page_title_prefix, "Job preferences: education phase"
 - content_for :breadcrumbs do
   = govuk_back_link text: t("buttons.back"), href: back_url
 

--- a/app/views/jobseekers/profiles/job_preferences/phases.html.slim
+++ b/app/views/jobseekers/profiles/job_preferences/phases.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title_prefix, "Job preferences: phases"
+- content_for :page_title_prefix, "Job preferences: Education phase"
 - content_for :breadcrumbs do
   = govuk_back_link text: t("buttons.back"), href: back_url
 

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -54,10 +54,10 @@ en:
 
 
     education_phase_options:
-      middle: Middle
+      middle: Middle school
       nursery: Nursery
-      primary: Primary
-      secondary: Secondary
+      primary: Primary school
+      secondary: Secondary school
       sixth_form_or_college: Sixth form or college
       through: Through school
 

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -96,11 +96,11 @@ en:
       filters:
         education_phase_options:
           nursery: "Nursery"
-          primary: "Primary"
-          middle: "Middle"
-          secondary: "Secondary"
+          primary: "Primary school"
+          middle: "Middle school"
+          secondary: "Secondary school"
           sixth_form_or_college: "Sixth form or college"
-          through: "Through"
+          through: "Through school"
         key_stage_options:
           early_years: "Early years"
           ks1: "Key stage 1"

--- a/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
@@ -707,7 +707,7 @@ RSpec.describe "Jobseekers can manage their profile" do
       check "Assistant headteacher"
       click_on I18n.t("buttons.save_and_continue")
       expect(current_path).to eq(jobseekers_job_preferences_step_path(:phases))
-      expect(page).to have_css("h3", text: "Job preferencesPhases")
+      expect(page).to have_css("h3", text: "Job preferencesEducation phase")
 
       click_on I18n.t("buttons.save_and_continue")
       expect(current_path).to eq(jobseekers_job_preferences_step_path(:phases))
@@ -850,7 +850,7 @@ RSpec.describe "Jobseekers can manage their profile" do
         check "IT support"
         click_on I18n.t("buttons.save_and_continue")
         expect(current_path).to eq(jobseekers_job_preferences_step_path(:phases))
-        expect(page).to have_css("h3", text: "Job preferencesPhases")
+        expect(page).to have_css("h3", text: "Job preferencesEducation phase")
 
         check "Secondary"
         click_on I18n.t("buttons.save_and_continue")

--- a/spec/system/support_users/service_data_spec.rb
+++ b/spec/system/support_users/service_data_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "Service Data supportal section" do
     within(summary_card("Job Preferences")) do
       expect(page).to have_row("Id", preferences.id)
       expect(page).to have_row("Roles", preferences.roles)
-      expect(page).to have_row("Phases", preferences.phases)
+      expect(page).to have_row("Education phase", preferences.phases)
       expect(page).to have_row("Key stages", preferences.key_stages)
       expect(page).to have_row("Subjects", preferences.subjects)
       expect(page).to have_row("Working patterns", preferences.working_patterns)

--- a/spec/system/support_users/service_data_spec.rb
+++ b/spec/system/support_users/service_data_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "Service Data supportal section" do
     within(summary_card("Job Preferences")) do
       expect(page).to have_row("Id", preferences.id)
       expect(page).to have_row("Roles", preferences.roles)
-      expect(page).to have_row("Education phase", preferences.phases)
+      expect(page).to have_row("Phases", preferences.phases)
       expect(page).to have_row("Key stages", preferences.key_stages)
       expect(page).to have_row("Subjects", preferences.subjects)
       expect(page).to have_row("Working patterns", preferences.working_patterns)


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/qJqCbHF6/1166-content-tweak-on-job-preferences-education-phase-profiles

## Changes in this PR:

We want the phases section in a user's profile to match what we say on the main job search filters.

This means relabelling 'Phases' to 'Education phase' and adding 'school' to the end of the 'primary, secondary and middle' options.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
