### PR TITLE
Redirect existing users to account found page if it's their first log…

### DIFF
--- a/app/controllers/jobseekers/accounts_controller.rb
+++ b/app/controllers/jobseekers/accounts_controller.rb
@@ -2,4 +2,6 @@ class Jobseekers::AccountsController < Jobseekers::BaseController
   def show; end
 
   def confirmation; end
+
+  def account_found; end
 end

--- a/app/controllers/jobseekers/govuk_one_login_callbacks_controller.rb
+++ b/app/controllers/jobseekers/govuk_one_login_callbacks_controller.rb
@@ -5,6 +5,10 @@ class Jobseekers::GovukOneLoginCallbacksController < Devise::OmniauthCallbacksCo
   def openid_connect
     if (govuk_one_login_user = Jobseekers::GovukOneLogin::UserFromAuthResponse.call(params, session))
       session[:govuk_one_login_id_token] = govuk_one_login_user.id_token
+      
+      if existing_jobseeker_first_sign_in_via_one_login(govuk_one_login_user)
+        session[:user_exists_first_log_in] = { value: 'true', path: '/', expires: 1.hour.from_now }
+      end
 
       jobseeker = Jobseeker.find_or_create_from_govuk_one_login(email: govuk_one_login_user.email,
                                                                 govuk_one_login_id: govuk_one_login_user.id)
@@ -32,6 +36,15 @@ class Jobseekers::GovukOneLoginCallbacksController < Devise::OmniauthCallbacksCo
   # Devise method to redirect the user after sign in.
   # We need to build our own logic to redirect the user to the correct pages.
   def after_sign_in_path_for(_resource)
-    jobseekers_job_applications_path
+    if session[:user_exists_first_log_in]
+      session.delete(:user_exists_first_log_in)
+      account_found_jobseekers_account_path
+    else
+      jobseekers_job_applications_path
+    end
+  end
+
+  def existing_jobseeker_first_sign_in_via_one_login(govuk_one_login_user)
+    Jobseeker.find_by(email: govuk_one_login_user.email, govuk_one_login_id: nil)
   end
 end

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -26,6 +26,13 @@ en:
           prefill: apply for roles more quickly by pre-filling your information
           share_your_qualifications: share your qualifications and experience with schools
           specify_jobs: specify the types of teaching jobs you’re looking for
+      account_found:
+        page_title: Account found
+        email_found: We've found a Teaching Vacancies account using the same email address as your GOV.UK One Login account and have saved your information.
+        helpful_links: You can %{update_profile_link}, continue to %{search_and_apply_link} or %{create_alert_link}.
+        update_profile_link_text: update your profile details
+        search_and_apply_link_text: search and apply for jobs
+        create_alert_link_text: create a job alert
     account_feedbacks:
       create:
         success: Thank you for your feedback

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -184,6 +184,7 @@ Rails.application.routes.draw do
     resource :account, only: %i[show] do
       member do
         get :confirmation
+        get :account_found
       end
     end
     resource :account_feedback, only: %i[new create]


### PR DESCRIPTION
…in via gov.uk one login

## Trello card URL

https://trello.com/c/68f2WcbW/1147-send-users-to-account-found-landing-page-for-after-onelogin-success

## Changes in this PR:

This PR redirects users to an account found page after their first log in via GOV.UK One Login if there is an account with a matching email address in the TV database.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
