### PR TITLE
Add missing salary fields to organisation display

### DIFF
--- a/app/views/organisations/_organisation.html.slim
+++ b/app/views/organisations/_organisation.html.slim
@@ -100,13 +100,17 @@
             - row.with_key text: t("organisations.show.vacancy.job_role"), classes: "govuk-body-s govuk-!-font-weight-bold govuk-!-padding-bottom-0"
             - row.with_value text: humanize_array(vacancy.job_roles), classes: "govuk-body-s govuk-!-padding-bottom-0"
 
-          - summary_list.with_row do |row|
-            - row.with_key text: t("organisations.show.vacancy.full_time_equivalent_salary"), classes: "govuk-body-s govuk-!-font-weight-bold govuk-!-padding-bottom-0"
-            - row.with_value text: vacancy.salary, classes: "govuk-body-s govuk-!-padding-bottom-0"
+          - if vacancy.salary?
+            = render "organisations/vacancy_field", summary_list: summary_list, field_desc: t("organisations.show.vacancy.full_time_equivalent_salary"), field_value: vacancy.salary
 
-          - summary_list.with_row do |row|
-            - row.with_key text: t("organisations.show.vacancy.actual_salary"), classes: "govuk-body-s govuk-!-font-weight-bold govuk-!-padding-bottom-0"
-            - row.with_value text: vacancy.actual_salary, classes: "govuk-body-s govuk-!-padding-bottom-0"
+          - if vacancy.actual_salary?
+            = render "organisations/vacancy_field", summary_list: summary_list, field_desc: t("organisations.show.vacancy.actual_salary"), field_value: vacancy.actual_salary
+
+          - if vacancy.pay_scale?
+            = render "organisations/vacancy_field", summary_list: summary_list, field_desc: t("jobs.pay_scale"), field_value: vacancy.pay_scale
+
+          - if vacancy.hourly_rate?
+            = render "organisations/vacancy_field", summary_list: summary_list, field_desc: t("jobs.hourly_rate"), field_value: vacancy.hourly_rate
 
           - summary_list.with_row do |row|
             - row.with_key text: t("organisations.show.vacancy.working_pattern"), classes: "govuk-body-s govuk-!-font-weight-bold govuk-!-padding-bottom-0"

--- a/app/views/organisations/_vacancy_field.html.slim
+++ b/app/views/organisations/_vacancy_field.html.slim
@@ -1,0 +1,3 @@
+- summary_list.with_row do |row|
+  - row.with_key text: field_desc, classes: "govuk-body-s govuk-!-font-weight-bold govuk-!-padding-bottom-0"
+  - row.with_value text: field_value, classes: "govuk-body-s govuk-!-padding-bottom-0"

--- a/app/views/vacancies/search/_results.html.slim
+++ b/app/views/vacancies/search/_results.html.slim
@@ -28,6 +28,11 @@
             - row.with_key text: t("jobs.pay_scale"), classes: "govuk-body-s govuk-!-font-weight-bold govuk-!-padding-bottom-0"
             - row.with_value text: vacancy.pay_scale, classes: "govuk-body-s govuk-!-padding-bottom-0"
 
+        - if vacancy.hourly_rate?
+          - summary_list.with_row do |row|
+            - row.with_key text: t("jobs.hourly_rate"), classes: "govuk-body-s govuk-!-font-weight-bold govuk-!-padding-bottom-0"
+            - row.with_value text: vacancy.hourly_rate, classes: "govuk-body-s govuk-!-padding-bottom-0"
+
         - summary_list.with_row do |row|
           - row.with_key text: organisation_type_label(vacancy), classes: "govuk-body-s govuk-!-font-weight-bold govuk-!-padding-bottom-0"
           - row.with_value text: organisation_type_value(vacancy), classes: "govuk-body-s govuk-!-padding-bottom-0"

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -83,6 +83,13 @@ FactoryBot.define do
       skills_and_experience { nil }
     end
 
+    trait :without_any_money do
+      salary { nil }
+      hourly_rate { nil }
+      pay_scale { nil }
+      actual_salary { nil }
+    end
+
     trait :no_tv_applications do
       receive_applications { "website" }
       application_link { Faker::Internet.url(host: "example.com") }

--- a/spec/views/organisations/show.html.slim_spec.rb
+++ b/spec/views/organisations/show.html.slim_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe "organisations/show", type: :view do
+  before do
+    assign :organisation, create(:school, vacancies: [vacancy])
+    render
+  end
+
+  context "with salary" do
+    let(:vacancy) { build(:vacancy, :without_any_money, salary: Faker::Alphanumeric.alpha(number: 7)) }
+
+    it "shows salary" do
+      expect(rendered).to have_content(vacancy.salary)
+    end
+  end
+
+  context "with actual salary" do
+    let(:vacancy) { build(:vacancy, :without_any_money, actual_salary: Faker::Number.number(digits: 5)) }
+
+    it "shows actual salary" do
+      expect(rendered).to have_content(vacancy.actual_salary)
+    end
+  end
+
+  context "with hourly rate" do
+    let(:vacancy) { build(:vacancy, :without_any_money, hourly_rate: Faker::Alphanumeric.alpha(number: 7)) }
+
+    it "shows hourly rate" do
+      expect(rendered).to have_content(vacancy.hourly_rate)
+    end
+  end
+
+  context "with pay scale" do
+    let(:vacancy) { build(:vacancy, :without_any_money, pay_scale: Faker::Alphanumeric.alpha(number: 7)) }
+
+    it "shows pay scale" do
+      expect(rendered).to have_content(vacancy.pay_scale)
+    end
+  end
+
+  context "with all" do
+    let(:vacancy) { build(:vacancy) }
+
+    it "shows salary" do
+      expect(rendered).to have_content(vacancy.salary)
+    end
+
+    it "shows actual salary" do
+      expect(rendered).to have_content(vacancy.actual_salary)
+    end
+
+    it "shows hourly rate" do
+      expect(rendered).to have_content(vacancy.hourly_rate)
+    end
+
+    it "shows pay scale" do
+      expect(rendered).to have_content(vacancy.pay_scale)
+    end
+  end
+end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/rzdK1f2W/1187-only-show-completed-salary-fields-on-school-profiles-and-show-hourly-rate-in-job-listing-overview

## Changes in this PR:

Only show salary fields for vacancies if they have been filled in during the journey. Also add hourly rate to vacancy in search results 

## Screenshots of UI changes:

### Before
![SearchBefore](https://github.com/user-attachments/assets/b93f0504-e598-433b-8ae7-100ccdfa586d)
![SchoolBefore](https://github.com/user-attachments/assets/71570556-dbe0-4e8d-8e47-2c7859966a6e)


### After
![SearchAfter](https://github.com/user-attachments/assets/5d289a68-fd1a-427f-9225-a8c0a7b59142)
![SchoolAfter](https://github.com/user-attachments/assets/3dd1deb0-9e4a-40f9-bdb9-0dea8ea5a1e3)


## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
