### PR TITLE
Correcting account creation guidance

### DIFF
--- a/app/views/omniauth_callbacks/not_authorised.html.slim
+++ b/app/views/omniauth_callbacks/not_authorised.html.slim
@@ -23,5 +23,6 @@
     p.govuk-body
       | If you don’t have an authorised Teaching Vacancies account, you can get one if you work at a state-funded
       |  school or trust providing primary or secondary education in England and have your headteacher or CEO’s approval.
-      |  Just ask them to send your full name and email address to #{govuk_mail_to(t("help.email"), t("help.email"))}.
-      |  Or email us your details directly, copying in your headteacher or CEO.
+      |  You can
+      |  #{govuk_link_to("get a Teaching Vacancies account through DfE Sign-in", "https://teaching-vacancies.service.gov.uk/pages/dsi-account-request/")}
+      |  .

--- a/app/views/omniauth_callbacks/not_authorised.html.slim
+++ b/app/views/omniauth_callbacks/not_authorised.html.slim
@@ -9,7 +9,7 @@
       | You've tried to sign in with #{email}, which is not authorised to list jobs for this school.
       |  If you have an authorised account associated with another email, you must sign #{email} out of DfE Sign-in,
       |  then sign into Teaching Vacancies with your authorised email. You can do this at
-      |  #{govuk_link_to("DfE Sign-in", "https://profile.signin.education.gov.uk/")}
+      |  #{govuk_link_to("DfE Sign-in", "https://profile.signin.education.gov.uk/")}.
 
     h2.govuk-heading-m If you are signing in with an authorised email
 
@@ -24,5 +24,4 @@
       | If you don’t have an authorised Teaching Vacancies account, you can get one if you work at a state-funded
       |  school or trust providing primary or secondary education in England and have your headteacher or CEO’s approval.
       |  You can
-      |  #{govuk_link_to("get a Teaching Vacancies account through DfE Sign-in", "https://teaching-vacancies.service.gov.uk/pages/dsi-account-request/")}
-      |  .
+      |  #{govuk_link_to("get a Teaching Vacancies account through DfE Sign-in", "https://teaching-vacancies.service.gov.uk/pages/dsi-account-request/")}.


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/f2Keg79R/247-confirm-if-account-creation-guidance-is-correct-on-this-issue-page

## Changes in this PR:

The current guidance on this page tells users to contact support desk when we should be telling them to request an account through DfE Sign-in.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
