### PR TITLE
Job alert location error

### DIFF
--- a/app/assets/javascript/js_components/autocomplete/autocomplete.js
+++ b/app/assets/javascript/js_components/autocomplete/autocomplete.js
@@ -20,15 +20,16 @@ export default class extends Controller {
     const formInput = this.element.querySelector('input');
     const dataSource = api[this.element.dataset.source];
     const position = this.element.dataset.autocompletePosition;
+    const inputParent = formInput.parentNode;
 
-    this.element.insertAdjacentHTML('beforeend', suggestionsContainerHTML);
+    inputParent.insertAdjacentHTML('beforeend', suggestionsContainerHTML);
 
     if (formInput && dataSource) {
       let currentInputValue = formInput.value;
-      formInput.parentNode.removeChild(formInput);
+      inputParent.removeChild(formInput);
 
       accessibleAutocomplete({
-        element: this.element.getElementsByClassName(SUGGESTIONS_CLASSNAME).item(0),
+        element: inputParent.getElementsByClassName(SUGGESTIONS_CLASSNAME).item(0),
         id: formInput.id,
         name: formInput.name,
         defaultValue: currentInputValue,

--- a/app/views/subscriptions/_fields.html.slim
+++ b/app/views/subscriptions/_fields.html.slim
@@ -1,12 +1,11 @@
 = render "vacancies/search/keyword", f: f, wide: false
 - unless @organisation
-  .autocomplete data-source="getLocationSuggestions" data-controller="autocomplete"
-    = f.govuk_text_field :location,
-      label: { text: t("jobs.location"), size: "s" },
-      autocomplete: "off",
-      hint: { text: t("subscriptions.new.location.hint") },
-      form_group: { class: %w[location-finder__input govuk-!-margin-bottom-0] },
-      data: { coordinates: @vacancies_search&.point_coordinates || @point_coordinates }
+  = f.govuk_text_field :location,
+    label: { text: t("jobs.location"), size: "s" },
+    autocomplete: "off",
+    hint: { text: t("subscriptions.new.location.hint") },
+    form_group: { class: %w[location-finder__input govuk-!-margin-bottom-0 autocomplete], data: { source: "getLocationSuggestions", controller: "autocomplete" } },
+    data: { coordinates: @vacancies_search&.point_coordinates || @point_coordinates }
   = render "vacancies/search/current_location", target: "jobseekers-subscription-form-location-field"
   = render "vacancies/search/radius", f: f, wide: false
 

--- a/app/views/vacancies/search/_current_location.html.slim
+++ b/app/views/vacancies/search/_current_location.html.slim
@@ -1,4 +1,4 @@
-.location-finder class="govuk-!-margin-top-1 govuk-!-margin-bottom-2" data-controller="location-finder" data-location-finder-source-value="getPostcodeFromCoordinates" data-location-finder-input-value=target
+.location-finder class="govuk-!-margin-top-3 govuk-!-margin-bottom-2" data-controller="location-finder" data-location-finder-source-value="getPostcodeFromCoordinates" data-location-finder-input-value=target
   button.location-finder__button data-action="click->location-finder#findLocation" data-location-finder-target="button" type="button"
     span.location-finder__link-prefix = "or "
     = t("jobs.search.use_current_location_html")


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/U6YYTAvQ/1191-job-alerts-location-error-messaging-bug

## Changes in this PR:

Tweak form handling to include input field in scope of error bar. Error class has resisted a fix - it appears that accessible autocomplete seems to overwrite the input classes, and adding the inputClasses property (conditionally on a an appropriate error) appeared to have no effect.

## Screenshots of UI changes:

### Before
![Screenshot from 2024-09-05 12-38-00](https://github.com/user-attachments/assets/32fd5652-07a8-4d5c-8a37-feb5fcb73bc9)


### After
![Screenshot from 2024-09-05 12-38-39](https://github.com/user-attachments/assets/fdd4db5d-d937-4e38-bcb1-e5ec1db2e2d9)



## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
