### PR TITLE
New job found feedback field

### DIFF
--- a/app/controllers/jobseekers/unsubscribe_feedbacks_controller.rb
+++ b/app/controllers/jobseekers/unsubscribe_feedbacks_controller.rb
@@ -36,6 +36,6 @@ class Jobseekers::UnsubscribeFeedbacksController < ApplicationController
 
   def unsubscribe_feedback_form_params
     params.require(:jobseekers_unsubscribe_feedback_form)
-          .permit(:comment, :email, :other_unsubscribe_reason_comment, :unsubscribe_reason, :user_participation_response, :occupation)
+          .permit(:comment, :email, :other_unsubscribe_reason_comment, :job_found_unsubscribe_reason_comment, :unsubscribe_reason, :user_participation_response, :occupation)
   end
 end

--- a/app/form_models/jobseekers/unsubscribe_feedback_form.rb
+++ b/app/form_models/jobseekers/unsubscribe_feedback_form.rb
@@ -1,11 +1,12 @@
 class Jobseekers::UnsubscribeFeedbackForm < BaseForm
-  attr_accessor :comment, :email, :other_unsubscribe_reason_comment, :unsubscribe_reason, :user_participation_response, :occupation
+  attr_accessor :comment, :email, :other_unsubscribe_reason_comment, :unsubscribe_reason, :user_participation_response, :occupation, :job_found_unsubscribe_reason_comment
 
   validates :comment, length: { maximum: 1200 }
   validates :email, presence: true, if: -> { user_participation_response == "interested" }
   validates :occupation, presence: true, if: -> { user_participation_response == "interested" }
   validates :email, email_address: true, if: -> { email.present? }
   validates :other_unsubscribe_reason_comment, presence: true, if: -> { unsubscribe_reason == "other_reason" }
+  validates :job_found_unsubscribe_reason_comment, presence: true, if: -> { unsubscribe_reason == "job_found" }
   validates :unsubscribe_reason, inclusion: { in: Feedback.unsubscribe_reasons.keys }
   validates :user_participation_response, inclusion: { in: Feedback.user_participation_responses.keys }
 end

--- a/app/views/jobseekers/unsubscribe_feedbacks/new.html.slim
+++ b/app/views/jobseekers/unsubscribe_feedbacks/new.html.slim
@@ -20,6 +20,9 @@
           - if reason == "other_reason"
             = f.govuk_radio_button :unsubscribe_reason, reason do
               = f.govuk_text_field :other_unsubscribe_reason_comment, label: { size: "s" }
+          - elsif reason == "job_found"
+            = f.govuk_radio_button :unsubscribe_reason, reason do
+              = f.govuk_text_field :job_found_unsubscribe_reason_comment, label: { size: "s" }
           - else
             = f.govuk_radio_button :unsubscribe_reason, reason
 

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -101,6 +101,7 @@ shared:
     - close_account_reason_comment
     - occupation
     - origin_path
+    - job_found_unsubscribe_reason_comment
   job_applications:
     - id
     - status

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -38,6 +38,8 @@ en:
       too_long: Occupation must not be more than 30 characters
     other_unsubscribe_reason_comment:
       blank: Tell us why you want to unsubscribe
+    job_found_unsubscribe_reason_comment:
+      blank: Enter where you found your job
     unsubscribe_reason:
       inclusion: Tell us why you want to unsubscribe
     user_participation_response:
@@ -532,7 +534,7 @@ en:
               blank: Enter your building and street
             teacher_reference_number:
               invalid: Enter a teacher reference number in the correct format
-            right_to_work_in_uk: 
+            right_to_work_in_uk:
               inclusion: Select no if you have the right to work in the UK
         jobseekers/job_application/personal_statement_form:
           attributes:

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -69,7 +69,6 @@ en:
     request_dsi_account: Request a DfE Sign-in account
     resend_email: Resend email
     return_to_profile: Return to profile
-    return_to_profile: Return to profile
     save: Save
     save_and_continue: Save and continue
     save_and_finish_later: Save and finish later
@@ -619,9 +618,10 @@ en:
         email: What is your email address?
         comment: Is there anything else you'd like to tell us?
         other_unsubscribe_reason_comment: Briefly, tell us more about that reason
+        job_found_unsubscribe_reason_comment: Where did you find your job?
         unsubscribe_reason_options:
           circumstances_change: My circumstances have changed
-          job_found: I have found a teaching job
+          job_found: I have found a job
           not_relevant: The alerts I am receiving are not relevant to me
           other_reason: Another reason
         user_participation_response_options:
@@ -955,7 +955,7 @@ en:
       jobseekers_unsubscribe_feedback_form:
         reason: Why do you want to unsubscribe from this alert?
         user_participation_response: Would you like to participate in our research?
-      jobseekers_profile_location_preferences: 
+      jobseekers_profile_location_preferences:
         another_location: Do you want to add another location?
 
       publishers_job_listing_about_the_role_form:

--- a/db/migrate/20240905135248_add_job_found_unsubscribe_reason_comment_to_feedback.rb
+++ b/db/migrate/20240905135248_add_job_found_unsubscribe_reason_comment_to_feedback.rb
@@ -1,0 +1,5 @@
+class AddJobFoundUnsubscribeReasonCommentToFeedback < ActiveRecord::Migration[7.1]
+  def change
+    add_column :feedbacks, :job_found_unsubscribe_reason_comment, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_18_142645) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_05_135248) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -168,6 +168,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_18_142645) do
     t.string "category"
     t.text "occupation"
     t.string "origin_path"
+    t.text "job_found_unsubscribe_reason_comment"
     t.index ["job_application_id"], name: "index_feedbacks_job_application_id"
     t.index ["jobseeker_id"], name: "index_feedbacks_jobseeker_id"
     t.index ["publisher_id"], name: "index_feedbacks_publisher_id"

--- a/spec/system/jobseekers/jobseekers_can_manage_their_job_alerts_from_the_dashboard_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_their_job_alerts_from_the_dashboard_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Jobseekers can manage their job alerts from the dashboard" do
 
         it "unsubscribes from the job alert and redirects to the dashboard" do
           click_on I18n.t("buttons.unsubscribe")
-          choose I18n.t("helpers.label.jobseekers_unsubscribe_feedback_form.unsubscribe_reason_options.job_found")
+          choose I18n.t("helpers.label.jobseekers_unsubscribe_feedback_form.unsubscribe_reason_options.circumstances_change")
           choose name: "jobseekers_unsubscribe_feedback_form[user_participation_response]", option: "interested"
           fill_in "jobseekers_unsubscribe_feedback_form[occupation]", with: "teacher"
           click_button I18n.t("buttons.submit_feedback")

--- a/spec/system/jobseekers/jobseekers_can_unsubscribe_from_subscriptions_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_unsubscribe_from_subscriptions_spec.rb
@@ -26,31 +26,68 @@ RSpec.describe "A jobseeker can unsubscribe from subscriptions" do
     end
 
     context "when jobseeker is not signed in" do
-      it "allows the user to provide feedback and redirects to the jobs path" do
-        click_on I18n.t("buttons.submit_feedback")
+      context "with a blank form" do
+        it "generates an error" do
+          click_on I18n.t("buttons.submit_feedback")
 
-        expect(page).to have_content("There is a problem")
+          expect(page).to have_content("There is a problem")
+        end
+      end
 
-        choose "jobseekers-unsubscribe-feedback-form-unsubscribe-reason-other-reason-field"
-        fill_in "jobseekers_unsubscribe_feedback_form[other_unsubscribe_reason_comment]", with: "Spam"
-        fill_in "jobseekers_unsubscribe_feedback_form[comment]", with: "Eggs"
-        choose name: "jobseekers_unsubscribe_feedback_form[user_participation_response]", option: "interested"
-        fill_in "jobseekers_unsubscribe_feedback_form[email]", with: email
-        fill_in "jobseekers_unsubscribe_feedback_form[occupation]", with: occupation
+      context "with valid data" do
+        before do
+          fill_in "jobseekers_unsubscribe_feedback_form[comment]", with: "Eggs"
+          choose name: "jobseekers_unsubscribe_feedback_form[user_participation_response]", option: "interested"
+          fill_in "jobseekers_unsubscribe_feedback_form[email]", with: email
+          fill_in "jobseekers_unsubscribe_feedback_form[occupation]", with: occupation
+        end
 
-        expect { click_on I18n.t("buttons.submit_feedback") }.to change {
-          subscription.feedbacks.where(comment: "Eggs",
-                                       email: email,
-                                       feedback_type: "unsubscribe",
-                                       other_unsubscribe_reason_comment: "Spam",
-                                       search_criteria: subscription.search_criteria,
-                                       unsubscribe_reason: "other_reason",
-                                       occupation: occupation).count
-        }.by(1)
+        context "with other reason" do
+          it "allows the user to provide feedback and redirects to the jobs path" do
+            choose "jobseekers-unsubscribe-feedback-form-unsubscribe-reason-other-reason-field"
+            fill_in "jobseekers_unsubscribe_feedback_form[other_unsubscribe_reason_comment]", with: "Spam"
 
-        click_on I18n.t("jobseekers.unsubscribe_feedbacks.confirmation.new_search_link")
+            expect { click_on I18n.t("buttons.submit_feedback") }.to change {
+              subscription.feedbacks.where(comment: "Eggs",
+                                           email: email,
+                                           feedback_type: "unsubscribe",
+                                           other_unsubscribe_reason_comment: "Spam",
+                                           search_criteria: subscription.search_criteria,
+                                           unsubscribe_reason: "other_reason",
+                                           occupation: occupation).count
+            }.by(1)
 
-        expect(current_path).to eq jobs_path
+            click_on I18n.t("jobseekers.unsubscribe_feedbacks.confirmation.new_search_link")
+
+            expect(current_path).to eq jobs_path
+          end
+        end
+
+        context "with new job reason" do
+          before do
+            choose "jobseekers-unsubscribe-feedback-form-unsubscribe-reason-job-found-field"
+          end
+
+          it "errors without a comment" do
+            click_on I18n.t("buttons.submit_feedback")
+
+            expect(page).to have_content("There is a problem")
+          end
+
+          it "allows the user to provide feedback" do
+            fill_in "jobseekers_unsubscribe_feedback_form[job_found_unsubscribe_reason_comment]", with: "NewJob"
+
+            expect { click_on I18n.t("buttons.submit_feedback") }.to change {
+              subscription.feedbacks.where(comment: "Eggs",
+                                           email: email,
+                                           feedback_type: "unsubscribe",
+                                           job_found_unsubscribe_reason_comment: "NewJob",
+                                           search_criteria: subscription.search_criteria,
+                                           unsubscribe_reason: "job_found",
+                                           occupation: occupation).count
+            }.by(1)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/rfU8UepO/1186-add-a-field-to-job-alert-unsubscribe-where-did-you-find-your-job

## Changes in this PR:

New feedback field - mandatory feedback comment when unsubscribing from an alert due to a new job

## Screenshots of UI changes:

### Before
![FoundATEachingJob](https://github.com/user-attachments/assets/6f45b674-c417-4007-916d-b8b02e722331)

### After
![AfterJobGot](https://github.com/user-attachments/assets/9fcfba68-60e9-4cb5-8a44-eddb4181eb8e)



## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
