### PR TITLE
Remove unused GIT_HUB_SERVICE_ACCOUNT_TOKEN

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -57,7 +57,6 @@ jobs:
         uses: dkershner6/aws-ssm-getparameters-action@v2
         with:
           parameterPairs: "/teaching-vacancies/github_action/infra/slack_webhook = SLACK_WEBHOOK,
-            /teaching-vacancies/github_action/infra/git_hub_service_account_token = GIT_HUB_SERVICE_ACCOUNT_TOKEN,
             /teaching-vacancies/github_action/infra/snyk = SNYK_TOKEN"
 
       - name: Set environment variables (Push)
@@ -192,8 +191,7 @@ jobs:
     - name: Get secrets from AWS ParameterStore
       uses: dkershner6/aws-ssm-getparameters-action@v2
       with:
-        parameterPairs: "/teaching-vacancies/github_action/infra/slack_webhook = SLACK_WEBHOOK,
-          /teaching-vacancies/github_action/infra/git_hub_service_account_token = GIT_HUB_SERVICE_ACCOUNT_TOKEN"
+        parameterPairs: "/teaching-vacancies/github_action/infra/slack_webhook = SLACK_WEBHOOK"
 
     - name: Set environment variables from build output
       run: |

--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -50,8 +50,7 @@ jobs:
     - name: Get secrets from AWS ParameterStore
       uses: dkershner6/aws-ssm-getparameters-action@v2
       with:
-        parameterPairs: "/teaching-vacancies/github_action/infra/slack_webhook = SLACK_WEBHOOK,
-          /teaching-vacancies/github_action/infra/git_hub_service_account_token = GIT_HUB_SERVICE_ACCOUNT_TOKEN"
+        parameterPairs: "/teaching-vacancies/github_action/infra/slack_webhook = SLACK_WEBHOOK"
 
     - uses: actions/checkout@v4
       name: Checkout Code


### PR DESCRIPTION
## Changes in this PR:
Removed reference to unused secret GIT_HUB_SERVICE_ACCOUNT_TOKEN

Check the review app was [deployed](https://github.com/DFE-Digital/teaching-vacancies/actions/runs/10724976443/job/29741950160) and [deleted](https://github.com/DFE-Digital/teaching-vacancies/actions/runs/10725086367/job/29742160082?pr=7045) successfully
