### PR TITLE
Add notification banner to new job application page

### DIFF
--- a/app/views/jobseekers/job_applications/new.html.slim
+++ b/app/views/jobseekers/job_applications/new.html.slim
@@ -1,5 +1,11 @@
 - content_for :page_title_prefix, t(".title")
 
+- if current_jobseeker.job_applications.blank?
+  = govuk_notification_banner title_text: t("banners.important") do
+    h3.govuk-heading-s = t(".cannot_see_past_applications.title")
+    p.govuk-body = t(".cannot_see_past_applications.paragraph1")
+    p.govuk-body = t(".cannot_see_past_applications.paragraph2")
+
 span.govuk-caption-l = t("jobseekers.job_applications.caption", job_title: vacancy.job_title, organisation: vacancy.organisation_name)
 h2.govuk-heading-xl = t("jobseekers.job_applications.heading")
 

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -345,6 +345,10 @@ en:
           into a %{profile_link} so schools can contact you about relevant roles.
         profile_link_text: candidate profile
         title: Application
+        cannot_see_past_applications:
+          title: Can't see your information from past applications?
+          paragraph1: If you had a Teaching Vacancies account using a different email address to your GOV.UK One Login account, information from your past applications will not automatically be saved.
+          paragraph2: You can request to transfer information from your past applications.
       about_your_application:
         title: About your application
         warning:


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/BdX6aAQq/1188-create-banner-on-first-quick-apply-job-application

## Changes in this PR:

This PR adds a notification banner if a jobseeker does not have any past job applications, that informs them that they may be able to transfer account information from their past account if they have one.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
