### PR TITLE
Delete old non-draft job applications apart from most recent

### DIFF
--- a/app/jobs/delete_old_non_draft_job_applications_job.rb
+++ b/app/jobs/delete_old_non_draft_job_applications_job.rb
@@ -1,0 +1,18 @@
+class DeleteOldNonDraftJobApplicationsJob < ApplicationJob
+  queue_as :low
+
+  OLD_THRESHOLD = 5.years.ago.freeze
+
+  def perform
+    JobApplication.after_submission
+                  .where("submitted_at < ?", OLD_THRESHOLD)
+                  .order("submitted_at desc")
+                  .group_by(&:jobseeker_id).each_value do |ja_group|
+      if JobApplication.where("submitted_at >= ?", OLD_THRESHOLD).where(jobseeker: ja_group.first.jobseeker).exists?
+        ja_group.each(&:destroy)
+      else
+        ja_group[1..].each(&:destroy)
+      end
+    end
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -80,6 +80,11 @@ remove_stale_vacancies:
   class: 'RemoveStaleVacanciesJob'
   queue: low
 
+delete_old_applications:
+  cron: '0 05 * * *'
+  class: 'DeleteOldNonDraftJobApplicationsJob'
+  queue: low
+
 remove_vacancies_that_expired_yesterday_from_google_index:
   cron: '0 04 * * *'
   class: 'RemoveVacanciesThatExpiredYesterdayFromGoogleIndexJob'

--- a/spec/jobs/delete_old_non_draft_job_applications_job_spec.rb
+++ b/spec/jobs/delete_old_non_draft_job_applications_job_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe DeleteOldNonDraftJobApplicationsJob, type: :job do
+  let(:jobseeker) { create(:jobseeker) }
+  let(:over_5_years_ago) { 5.years.ago - 1.day }
+
+  before do
+    job_applications.each(&:save!)
+    described_class.perform_now
+  end
+
+  context "with some but not all old applications" do
+    let(:job_applications) do
+      [
+        create(:job_application, :status_submitted, jobseeker: jobseeker, submitted_at: over_5_years_ago),
+        create(:job_application, :status_submitted, jobseeker: jobseeker, submitted_at: over_5_years_ago),
+        create(:job_application, :status_draft, jobseeker: jobseeker, submitted_at: over_5_years_ago),
+        create(:job_application, :status_submitted, jobseeker: jobseeker),
+      ]
+    end
+
+    it "deletes all old submitted applications" do
+      expect(JobApplication.count).to eq(2)
+    end
+  end
+
+  context "with all old job applications" do
+    let(:job_applications) do
+      [
+        create(:job_application, :status_submitted, jobseeker: jobseeker, submitted_at: over_5_years_ago),
+        create(:job_application, :status_submitted, jobseeker: jobseeker, submitted_at: over_5_years_ago - 1.day),
+      ]
+    end
+
+    it "retains the last application for a user" do
+      expect(JobApplication.all).to eq([job_applications.first])
+    end
+  end
+end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/F0vm90SL/1193-job-application-auto-deletion

## Changes in this PR:

Deleting old (post-submission) job applications - but leave the last one for the user to submit a new application later

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
