### PR TITLE
Hide 'finished qualification' flag if answer is Yes (because there is a date)

### DIFF
--- a/app/views/jobseekers/job_applications/build/qualifications.html.slim
+++ b/app/views/jobseekers/job_applications/build/qualifications.html.slim
@@ -28,7 +28,7 @@
                     - row.with_key text: t("helpers.label.#{qualification_form_param_key(qualification.category)}.#{attribute}")
                     - row.with_value text: qualification[attribute]
 
-                - unless qualification.finished_studying.nil?
+                - if qualification.finished_studying == false
                   - summary_list.with_row do |row|
                     - row.with_key text: t("helpers.legend.#{qualification_form_param_key(qualification.category)}.finished_studying")
                     - row.with_value text: safe_join([tag.div(t("helpers.label.jobseekers_qualifications_shared_labels.finished_studying_options.#{qualification.finished_studying}"), class: "govuk-body"), tag.div(qualification.finished_studying_details.presence, class: "govuk-body")])

--- a/app/views/jobseekers/qualifications/_preview_qualifications.html.slim
+++ b/app/views/jobseekers/qualifications/_preview_qualifications.html.slim
@@ -11,7 +11,7 @@
     - if qualification.secondary?
       - qualification.qualification_results.each do |res|
         p class="govuk-!-margin-bottom-0" = tag.div("#{res.subject} (#{res.grade})", class: "govuk-body govuk-!-margin-bottom-0")
-    - unless qualification.finished_studying.nil?
+    - if qualification.finished_studying == false
       p class="govuk-!-margin-top-0" = tag.div(qualification.finished_studying_details.presence, class: "govuk-body")
     p.govuk-hint = qualification.year
     - class_name = "govuk-!-margin-bottom-3"

--- a/app/views/jobseekers/qualifications/_qualifications.html.slim
+++ b/app/views/jobseekers/qualifications/_qualifications.html.slim
@@ -13,7 +13,7 @@
               - row.with_key text: t("helpers.label.#{qualification_form_param_key(qualification.category)}.#{attribute}")
               - row.with_value text: qualification[attribute]
 
-          - unless qualification.finished_studying.nil?
+          - if qualification.finished_studying == false
             - summary_list.with_row do |row|
               - row.with_key text: t("helpers.legend.#{qualification_form_param_key(qualification.category)}.finished_studying")
               - row.with_value text: safe_join([tag.div(t("helpers.label.jobseekers_qualifications_shared_labels.finished_studying_options.#{qualification.finished_studying}"), class: "govuk-body"), tag.div(qualification.finished_studying_details.presence, class: "govuk-body")])

--- a/spec/system/jobseekers/jobseekers_can_add_qualifications_to_their_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_qualifications_to_their_profile_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe "Jobseekers can add qualifications to their profile" do
         expect(page).to have_content("Superteacher Certificate")
         expect(page).to have_content("Teachers Academy")
         expect(page).to have_content("I expect to finish next year")
+        expect(page).to have_content("Not finished yet")
         expect(page).not_to have_content("Grade")
         expect(page).not_to have_content("Year")
       end
@@ -57,6 +58,8 @@ RSpec.describe "Jobseekers can add qualifications to their profile" do
         expect(page).to have_content("Maths – 110%")
         expect(page).to have_content("PE – 90%")
         expect(page).to have_content("2020")
+        expect(page).not_to have_content("Not finished yet")
+        expect(page).not_to have_content("Yes")
       end
 
       it "allows jobseekers to add a custom secondary qualification" do


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/U2vblnmg/1204-hide-the-have-you-finished-studying-field-from-the-your-profile-page-where-the-answer-is-yes

## Changes in this PR:

Consistent usage of finished_studying == false 

## Screenshots of UI changes:

### Before
![DegreeBefore](https://github.com/user-attachments/assets/76c6b925-840b-4034-89ae-b70bf13ac174)



### After
![DegreeAfter](https://github.com/user-attachments/assets/410e83b3-c14d-4c7a-8c61-443bed95d538)



## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
