### PR TITLE
Move first application banner to job application review page rather than new page

### DIFF
--- a/app/controllers/jobseekers/job_applications_controller.rb
+++ b/app/controllers/jobseekers/job_applications_controller.rb
@@ -42,7 +42,11 @@ class Jobseekers::JobApplicationsController < Jobseekers::JobApplications::BaseC
 
     new_job_application = prefill_job_application_with_available_data
 
-    redirect_to jobseekers_job_application_review_path(new_job_application), notice: t("jobseekers.job_applications.new_quick_apply.import_from_previous_application")
+    if jobseeker.job_applications.blank?
+      redirect_to jobseekers_job_application_review_path(new_job_application)
+    else
+      redirect_to jobseekers_job_application_review_path(new_job_application), notice: t("jobseekers.job_applications.new_quick_apply.import_from_previous_application")
+    end
   end
 
   def submit

--- a/app/views/jobseekers/job_applications/new.html.slim
+++ b/app/views/jobseekers/job_applications/new.html.slim
@@ -1,11 +1,5 @@
 - content_for :page_title_prefix, t(".title")
 
-- if current_jobseeker.job_applications.blank?
-  = govuk_notification_banner title_text: t("banners.important") do
-    h3.govuk-heading-s = t(".cannot_see_past_applications.title")
-    p.govuk-body = t(".cannot_see_past_applications.paragraph1")
-    p.govuk-body = t(".cannot_see_past_applications.paragraph2")
-
 span.govuk-caption-l = t("jobseekers.job_applications.caption", job_title: vacancy.job_title, organisation: vacancy.organisation_name)
 h2.govuk-heading-xl = t("jobseekers.job_applications.heading")
 

--- a/app/views/jobseekers/job_applications/review.html.slim
+++ b/app/views/jobseekers/job_applications/review.html.slim
@@ -1,5 +1,11 @@
 - content_for :page_title_prefix, job_application_page_title_prefix(review_form, t(".title"))
 
+- if current_jobseeker.job_applications.blank?
+  = govuk_notification_banner title_text: t("banners.important") do
+    h3.govuk-heading-s = t(".cannot_see_past_applications.title")
+    p.govuk-body = t(".cannot_see_past_applications.paragraph1")
+    p.govuk-body = t(".cannot_see_past_applications.paragraph2")
+
 = job_application_review(@job_application, step_process: step_process, show_tracks: current_jobseeker.job_applications.not_draft.none?) do |r|
   - r.with_header do
     = render "banner"

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -345,10 +345,6 @@ en:
           into a %{profile_link} so schools can contact you about relevant roles.
         profile_link_text: candidate profile
         title: Application
-        cannot_see_past_applications:
-          title: Can't see your information from past applications?
-          paragraph1: If you had a Teaching Vacancies account using a different email address to your GOV.UK One Login account, information from your past applications will not automatically be saved.
-          paragraph2: You can request to transfer information from your past applications.
       about_your_application:
         title: About your application
         warning:
@@ -429,6 +425,10 @@ en:
         phone_number: Phone number
         relationship: Relationship to applicant
       review:
+        cannot_see_past_applications:
+          title: Can't see your information from past applications?
+          paragraph1: If you had a Teaching Vacancies account using a different email address to your GOV.UK One Login account, information from your past applications will not automatically be saved.
+          paragraph2: You can request to transfer information from your past applications.
         confirmation:
           heading: Confirmation
           update_your_profile:


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/BdX6aAQq/1188-create-banner-on-first-quick-apply-job-application

## Changes in this PR:

This PR changes the location of the banner shown on first quick apply job application after logging in via onelogin to the job application review page rather than the new page

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
