### PR TITLE
Map flexible term time working patterns ats

### DIFF
--- a/app/services/vacancies/import/shared.rb
+++ b/app/services/vacancies/import/shared.rb
@@ -1,5 +1,6 @@
 module Vacancies::Import
   module Shared
+    LEGACY_WORKING_PATTERNS = %w[flexible term_time job_share].freeze
     def vacancy_listed_at_excluded_school_type?(schools)
       return false if schools.none?
 

--- a/app/services/vacancies/import/sources/ark.rb
+++ b/app/services/vacancies/import/sources/ark.rb
@@ -77,6 +77,7 @@ class Vacancies::Import::Sources::Ark
       phases: phases_for(item),
       publish_on: publish_on_for(item),
       visa_sponsorship_available: visa_sponsorship_available_for(item),
+      is_job_share: is_job_share_for(item)
     }.merge(organisation_fields(schools))
     .merge(start_date_fields(item))
   end
@@ -147,7 +148,11 @@ class Vacancies::Import::Sources::Ark
   def working_patterns_for(item)
     item.fetch_by_attribute("category", "domain", "Working Pattern")
     .gsub("Full Time", "full_time")
-    .gsub(/Part Time|Casual|Flexible|Term Time/, "part_time")
+    .gsub(/Part Time|Casual|Flexible|Term Time|Job Share/, "part_time")
+  end
+
+  def is_job_share_for(item)
+    item.fetch_by_attribute("category", "domain", "Working Pattern") == "Job Share"
   end
 
   def contract_type_for(item)

--- a/app/services/vacancies/import/sources/ark.rb
+++ b/app/services/vacancies/import/sources/ark.rb
@@ -77,7 +77,7 @@ class Vacancies::Import::Sources::Ark
       phases: phases_for(item),
       publish_on: publish_on_for(item),
       visa_sponsorship_available: visa_sponsorship_available_for(item),
-      is_job_share: is_job_share_for(item)
+      is_job_share: job_share_for?(item),
     }.merge(organisation_fields(schools))
     .merge(start_date_fields(item))
   end
@@ -151,7 +151,7 @@ class Vacancies::Import::Sources::Ark
     .gsub(/Part Time|Casual|Flexible|Term Time|Job Share/, "part_time")
   end
 
-  def is_job_share_for(item)
+  def job_share_for?(item)
     item.fetch_by_attribute("category", "domain", "Working Pattern") == "Job Share"
   end
 

--- a/app/services/vacancies/import/sources/broadbean.rb
+++ b/app/services/vacancies/import/sources/broadbean.rb
@@ -74,7 +74,7 @@ class Vacancies::Import::Sources::Broadbean
     return [] if item["workingPatterns"].blank?
 
     item["workingPatterns"].delete(" ").split(",").map { |pattern|
-      if LEGACY_WORKING_PATTERNS.include?(pattern)
+      if Vacancies::Import::Shared::LEGACY_WORKING_PATTERNS.include?(pattern)
         "part_time"
       else
         pattern

--- a/app/services/vacancies/import/sources/broadbean.rb
+++ b/app/services/vacancies/import/sources/broadbean.rb
@@ -65,23 +65,24 @@ class Vacancies::Import::Sources::Broadbean
       is_parental_leave_cover: parental_leave_cover_for?(item),
       phases: phase_for(item),
       visa_sponsorship_available: visa_sponsorship_available_for(item),
-      is_job_share: is_job_share_for(item)
+      is_job_share: job_share_for?(item),
     }.merge(organisation_fields(schools))
      .merge(start_date_fields(item))
   end
 
   def working_patterns_for(item)
     return [] if item["workingPatterns"].blank?
-    item["workingPatterns"].delete(" ").split(",").map do |pattern|
-      if ["flexible", "term_time", "job_share"].include?(pattern)
+
+    item["workingPatterns"].delete(" ").split(",").map { |pattern|
+      if LEGACY_WORKING_PATTERNS.include?(pattern)
         "part_time"
       else
         pattern
       end
-    end.uniq
+    }.uniq
   end
 
-  def is_job_share_for(item)
+  def job_share_for?(item)
     item["workingPatterns"].include?("job_share")
   end
 

--- a/app/services/vacancies/import/sources/broadbean.rb
+++ b/app/services/vacancies/import/sources/broadbean.rb
@@ -60,13 +60,24 @@ class Vacancies::Import::Sources::Broadbean
       job_roles: job_roles_for(item),
       ect_status: ect_status_for(item),
       subjects: item["subjects"].presence&.split(",") || [],
-      working_patterns: item["workingPatterns"].presence&.split(","),
+      working_patterns: working_patterns_for(item),
       contract_type: contract_type_for(item),
       is_parental_leave_cover: parental_leave_cover_for?(item),
       phases: phase_for(item),
       visa_sponsorship_available: visa_sponsorship_available_for(item),
     }.merge(organisation_fields(schools))
      .merge(start_date_fields(item))
+  end
+
+  def working_patterns_for(item)
+    return [] if item["workingPatterns"].blank?
+    item["workingPatterns"].split(",").map do |pattern|
+      if pattern == "flexible" || pattern == "term_time"
+        "part_time"
+      else
+        pattern
+      end
+    end.uniq
   end
 
   def start_date_fields(item)

--- a/app/services/vacancies/import/sources/broadbean.rb
+++ b/app/services/vacancies/import/sources/broadbean.rb
@@ -65,19 +65,24 @@ class Vacancies::Import::Sources::Broadbean
       is_parental_leave_cover: parental_leave_cover_for?(item),
       phases: phase_for(item),
       visa_sponsorship_available: visa_sponsorship_available_for(item),
+      is_job_share: is_job_share_for(item)
     }.merge(organisation_fields(schools))
      .merge(start_date_fields(item))
   end
 
   def working_patterns_for(item)
     return [] if item["workingPatterns"].blank?
-    item["workingPatterns"].split(",").map do |pattern|
-      if pattern == "flexible" || pattern == "term_time"
+    item["workingPatterns"].delete(" ").split(",").map do |pattern|
+      if ["flexible", "term_time", "job_share"].include?(pattern)
         "part_time"
       else
         pattern
       end
     end.uniq
+  end
+
+  def is_job_share_for(item)
+    item["workingPatterns"].include?("job_share")
   end
 
   def start_date_fields(item)

--- a/app/services/vacancies/import/sources/every.rb
+++ b/app/services/vacancies/import/sources/every.rb
@@ -57,6 +57,7 @@ class Vacancies::Import::Sources::Every
       phases: phase_for(item),
       key_stages: item["keyStages"].presence&.split(","),
       visa_sponsorship_available: visa_sponsorship_available_for(item),
+      is_job_share: is_job_share_for(item),
 
       # TODO: What about central office/multiple school vacancies?
       job_location: :at_one_school,
@@ -67,13 +68,17 @@ class Vacancies::Import::Sources::Every
   def working_patterns_for(item)
     return [] if item["workingPatterns"].blank?
     
-    item["workingPatterns"].split(",").map do |pattern|
-      if pattern == "flexible" || pattern == "term_time"
+    item["workingPatterns"].delete(" ").split(",").map do |pattern|
+      if ["flexible", "term_time", "job_share"].include?(pattern)
         "part_time"
       else
         pattern
       end
     end.uniq
+  end
+
+  def is_job_share_for(item)
+    item["workingPatterns"].include?("job_share")
   end
 
   def start_date_fields(item)

--- a/app/services/vacancies/import/sources/every.rb
+++ b/app/services/vacancies/import/sources/every.rb
@@ -67,7 +67,7 @@ class Vacancies::Import::Sources::Every
     return [] if item["workingPatterns"].blank?
 
     item["workingPatterns"].delete(" ").split(",").map { |pattern|
-      if LEGACY_WORKING_PATTERNS.include?(pattern)
+      if Vacancies::Import::Shared::LEGACY_WORKING_PATTERNS.include?(pattern)
         "part_time"
       else
         pattern

--- a/app/services/vacancies/import/sources/every.rb
+++ b/app/services/vacancies/import/sources/every.rb
@@ -51,7 +51,7 @@ class Vacancies::Import::Sources::Every
       job_roles: job_roles_for(item),
       ect_status: ect_status_for(item),
       subjects: item["subjects"].presence&.split(",") || [],
-      working_patterns: item["workingPatterns"].presence&.split(","),
+      working_patterns: working_patterns_for(item),
       contract_type: contract_type_for(item),
       is_parental_leave_cover: parental_leave_cover_for?(item),
       phases: phase_for(item),
@@ -62,6 +62,18 @@ class Vacancies::Import::Sources::Every
       job_location: :at_one_school,
     }.merge(organisation_fields(item, schools))
      .merge(start_date_fields(item))
+  end
+
+  def working_patterns_for(item)
+    return [] if item["workingPatterns"].blank?
+    
+    item["workingPatterns"].split(",").map do |pattern|
+      if pattern == "flexible" || pattern == "term_time"
+        "part_time"
+      else
+        pattern
+      end
+    end.uniq
   end
 
   def start_date_fields(item)

--- a/app/services/vacancies/import/sources/every.rb
+++ b/app/services/vacancies/import/sources/every.rb
@@ -57,27 +57,25 @@ class Vacancies::Import::Sources::Every
       phases: phase_for(item),
       key_stages: item["keyStages"].presence&.split(","),
       visa_sponsorship_available: visa_sponsorship_available_for(item),
-      is_job_share: is_job_share_for(item),
-
+      is_job_share: job_share_for?(item),
       # TODO: What about central office/multiple school vacancies?
       job_location: :at_one_school,
-    }.merge(organisation_fields(item, schools))
-     .merge(start_date_fields(item))
+    }.merge(organisation_fields(item, schools)).merge(start_date_fields(item))
   end
 
   def working_patterns_for(item)
     return [] if item["workingPatterns"].blank?
-    
-    item["workingPatterns"].delete(" ").split(",").map do |pattern|
-      if ["flexible", "term_time", "job_share"].include?(pattern)
+
+    item["workingPatterns"].delete(" ").split(",").map { |pattern|
+      if LEGACY_WORKING_PATTERNS.include?(pattern)
         "part_time"
       else
         pattern
       end
-    end.uniq
+    }.uniq
   end
 
-  def is_job_share_for(item)
+  def job_share_for?(item)
     item["workingPatterns"].include?("job_share")
   end
 

--- a/app/services/vacancies/import/sources/fusion.rb
+++ b/app/services/vacancies/import/sources/fusion.rb
@@ -89,8 +89,8 @@ class Vacancies::Import::Sources::Fusion
   def working_patterns_for(item)
     return [] if item["workingPatterns"].blank?
     
-    item["workingPatterns"].split(",").map do |pattern|
-      if pattern == "flexible" || pattern == "term_time" || pattern == "job_share"
+    item["workingPatterns"].delete(" ").split(",").map do |pattern|
+      if ["flexible", "term_time", "job_share"].include?(pattern)
         "part_time"
       else
         pattern

--- a/app/services/vacancies/import/sources/fusion.rb
+++ b/app/services/vacancies/import/sources/fusion.rb
@@ -87,16 +87,15 @@ class Vacancies::Import::Sources::Fusion
   end
 
   def working_patterns_for(item)
-    return unless item["workingPatterns"].present?
-
-    working_patterns = item["workingPatterns"].split(",")
-
-    if working_patterns.include?("job_share")
-      working_patterns -= ["job_share"]
-      working_patterns += ["part_time"]
-    end
-
-    working_patterns.uniq
+    return [] if item["workingPatterns"].blank?
+    
+    item["workingPatterns"].split(",").map do |pattern|
+      if pattern == "flexible" || pattern == "term_time" || pattern == "job_share"
+        "part_time"
+      else
+        pattern
+      end
+    end.uniq
   end
 
   def job_share_for(item)

--- a/app/services/vacancies/import/sources/fusion.rb
+++ b/app/services/vacancies/import/sources/fusion.rb
@@ -58,7 +58,7 @@ class Vacancies::Import::Sources::Fusion
       phases: phase_for(item),
       key_stages: item["keyStages"].presence&.split(","),
       visa_sponsorship_available: visa_sponsorship_available_for(item),
-      is_job_share: job_share_for(item),
+      is_job_share: job_share_for?(item),
 
       # TODO: What about central office/multiple school vacancies?
       job_location: :at_one_school,
@@ -88,17 +88,17 @@ class Vacancies::Import::Sources::Fusion
 
   def working_patterns_for(item)
     return [] if item["workingPatterns"].blank?
-    
-    item["workingPatterns"].delete(" ").split(",").map do |pattern|
-      if ["flexible", "term_time", "job_share"].include?(pattern)
+
+    item["workingPatterns"].delete(" ").split(",").map { |pattern|
+      if LEGACY_WORKING_PATTERNS.include?(pattern)
         "part_time"
       else
         pattern
       end
-    end.uniq
+    }.uniq
   end
 
-  def job_share_for(item)
+  def job_share_for?(item)
     return false unless item["workingPatterns"].split(",").include?("job_share")
 
     true

--- a/app/services/vacancies/import/sources/fusion.rb
+++ b/app/services/vacancies/import/sources/fusion.rb
@@ -90,7 +90,7 @@ class Vacancies::Import::Sources::Fusion
     return [] if item["workingPatterns"].blank?
 
     item["workingPatterns"].delete(" ").split(",").map { |pattern|
-      if LEGACY_WORKING_PATTERNS.include?(pattern)
+      if Vacancies::Import::Shared::LEGACY_WORKING_PATTERNS.include?(pattern)
         "part_time"
       else
         pattern

--- a/app/services/vacancies/import/sources/my_new_term.rb
+++ b/app/services/vacancies/import/sources/my_new_term.rb
@@ -65,24 +65,23 @@ class Vacancies::Import::Sources::MyNewTerm
       key_stages: key_stages_for(item),
       job_location: :at_one_school,
       visa_sponsorship_available: visa_sponsorship_available_for(item),
-      is_job_share: is_job_share_for(item)
-    }.merge(organisation_fields(schools))
-     .merge(start_date_fields(item))
+      is_job_share: job_share_for?(item),
+    }.merge(organisation_fields(schools)).merge(start_date_fields(item))
   end
 
   def working_patterns_for(item)
     return if item["workingPatterns"].blank?
 
-    item["workingPatterns"].map do |pattern|
-      if ["flexible", "term_time", "job_share"].include?(pattern)
+    item["workingPatterns"].map { |pattern|
+      if LEGACY_WORKING_PATTERNS.include?(pattern)
         "part_time"
       else
         pattern
       end
-    end.uniq
+    }.uniq
   end
 
-  def is_job_share_for(item)
+  def job_share_for?(item)
     item["workingPatterns"].include?("job_share")
   end
 

--- a/app/services/vacancies/import/sources/my_new_term.rb
+++ b/app/services/vacancies/import/sources/my_new_term.rb
@@ -73,7 +73,7 @@ class Vacancies::Import::Sources::MyNewTerm
     return if item["workingPatterns"].blank?
 
     item["workingPatterns"].map { |pattern|
-      if LEGACY_WORKING_PATTERNS.include?(pattern)
+      if Vacancies::Import::Shared::LEGACY_WORKING_PATTERNS.include?(pattern)
         "part_time"
       else
         pattern

--- a/app/services/vacancies/import/sources/my_new_term.rb
+++ b/app/services/vacancies/import/sources/my_new_term.rb
@@ -65,21 +65,25 @@ class Vacancies::Import::Sources::MyNewTerm
       key_stages: key_stages_for(item),
       job_location: :at_one_school,
       visa_sponsorship_available: visa_sponsorship_available_for(item),
+      is_job_share: is_job_share_for(item)
     }.merge(organisation_fields(schools))
      .merge(start_date_fields(item))
   end
 
   def working_patterns_for(item)
-    if item["workingPatterns"]
-      item["workingPatterns"] = item["workingPatterns"].map do |pattern|
-        if pattern == "flexible" || pattern == "term_time"
-          "part_time"
-        else
-          pattern
-        end
-      end.uniq
-    end
-    item["workingPatterns"]
+    return if item["workingPatterns"].blank?
+
+    item["workingPatterns"].map do |pattern|
+      if ["flexible", "term_time", "job_share"].include?(pattern)
+        "part_time"
+      else
+        pattern
+      end
+    end.uniq
+  end
+
+  def is_job_share_for(item)
+    item["workingPatterns"].include?("job_share")
   end
 
   def organisation_fields(schools)

--- a/app/services/vacancies/import/sources/my_new_term.rb
+++ b/app/services/vacancies/import/sources/my_new_term.rb
@@ -58,7 +58,7 @@ class Vacancies::Import::Sources::MyNewTerm
       job_roles: job_roles_for(item),
       ect_status: ect_status_for(item),
       subjects: item["subjects"].presence || [],
-      working_patterns: item["workingPatterns"].presence,
+      working_patterns: working_patterns_for(item),
       contract_type: contract_type_for(item),
       is_parental_leave_cover: parental_leave_cover_for?(item),
       phases: phase_for(item),
@@ -67,6 +67,19 @@ class Vacancies::Import::Sources::MyNewTerm
       visa_sponsorship_available: visa_sponsorship_available_for(item),
     }.merge(organisation_fields(schools))
      .merge(start_date_fields(item))
+  end
+
+  def working_patterns_for(item)
+    if item["workingPatterns"]
+      item["workingPatterns"] = item["workingPatterns"].map do |pattern|
+        if pattern == "flexible" || pattern == "term_time"
+          "part_time"
+        else
+          pattern
+        end
+      end.uniq
+    end
+    item["workingPatterns"]
   end
 
   def organisation_fields(schools)

--- a/app/services/vacancies/import/sources/united_learning.rb
+++ b/app/services/vacancies/import/sources/united_learning.rb
@@ -104,7 +104,7 @@ class Vacancies::Import::Sources::UnitedLearning
     return [] if item["Working_patterns"].blank?
 
     item["Working_patterns"].delete(" ").split(",").map { |pattern|
-      if LEGACY_WORKING_PATTERNS.include?(pattern)
+      if Vacancies::Import::Shared::LEGACY_WORKING_PATTERNS.include?(pattern)
         "part_time"
       else
         pattern

--- a/app/services/vacancies/import/sources/united_learning.rb
+++ b/app/services/vacancies/import/sources/united_learning.rb
@@ -68,6 +68,7 @@ class Vacancies::Import::Sources::UnitedLearning
       is_parental_leave_cover: parental_leave_cover_for?(item),
       phases: phase_for(item),
       visa_sponsorship_available: visa_sponsorship_available_for(item),
+      is_job_share: is_job_share_for(item)
     }.merge(organisation_fields(item))
   end
 
@@ -103,12 +104,16 @@ class Vacancies::Import::Sources::UnitedLearning
     return [] if item["Working_patterns"].blank?
 
     item["Working_patterns"].delete(" ").split(",").map do |pattern|
-      if pattern == "flexible" || pattern == "term_time"
+      if ["flexible", "term_time", "job_share"].include?(pattern)
         "part_time"
       else
         pattern
       end
     end.uniq
+  end
+
+  def is_job_share_for(item)
+    item["Working_patterns"].include?("job_share")
   end
 
   def ect_status_for(item)

--- a/app/services/vacancies/import/sources/united_learning.rb
+++ b/app/services/vacancies/import/sources/united_learning.rb
@@ -102,7 +102,13 @@ class Vacancies::Import::Sources::UnitedLearning
   def working_patterns_for(item)
     return [] if item["Working_patterns"].blank?
 
-    item["Working_patterns"].delete(" ").split(",").uniq
+    item["Working_patterns"].delete(" ").split(",").map do |pattern|
+      if pattern == "flexible" || pattern == "term_time"
+        "part_time"
+      else
+        pattern
+      end
+    end.uniq
   end
 
   def ect_status_for(item)

--- a/app/services/vacancies/import/sources/united_learning.rb
+++ b/app/services/vacancies/import/sources/united_learning.rb
@@ -68,7 +68,7 @@ class Vacancies::Import::Sources::UnitedLearning
       is_parental_leave_cover: parental_leave_cover_for?(item),
       phases: phase_for(item),
       visa_sponsorship_available: visa_sponsorship_available_for(item),
-      is_job_share: is_job_share_for(item)
+      is_job_share: job_share_for?(item),
     }.merge(organisation_fields(item))
   end
 
@@ -103,16 +103,16 @@ class Vacancies::Import::Sources::UnitedLearning
   def working_patterns_for(item)
     return [] if item["Working_patterns"].blank?
 
-    item["Working_patterns"].delete(" ").split(",").map do |pattern|
-      if ["flexible", "term_time", "job_share"].include?(pattern)
+    item["Working_patterns"].delete(" ").split(",").map { |pattern|
+      if LEGACY_WORKING_PATTERNS.include?(pattern)
         "part_time"
       else
         pattern
       end
-    end.uniq
+    }.uniq
   end
 
-  def is_job_share_for(item)
+  def job_share_for?(item)
     item["Working_patterns"].include?("job_share")
   end
 

--- a/app/services/vacancies/import/sources/vacancy_poster.rb
+++ b/app/services/vacancies/import/sources/vacancy_poster.rb
@@ -61,23 +61,23 @@ class Vacancies::Import::Sources::VacancyPoster
       is_parental_leave_cover: parental_leave_cover_for?(item),
       phases: phase_for(item),
       visa_sponsorship_available: false,
-      is_job_share: is_job_share_for(item)
+      is_job_share: job_share_for?(item),
     }.merge(organisation_fields(item))
   end
 
   def working_patterns_for(item)
     return [] if item["workingPatterns"].blank?
-    
-    item["workingPatterns"].delete(" ").split(",").map do |pattern|
-      if ["flexible", "term_time", "job_share"].include?(pattern)
+
+    item["workingPatterns"].delete(" ").split(",").map { |pattern|
+      if LEGACY_WORKING_PATTERNS.include?(pattern)
         "part_time"
       else
         pattern
       end
-    end.uniq
+    }.uniq
   end
 
-  def is_job_share_for(item)
+  def job_share_for?(item)
     item["workingPatterns"].include?("job_share")
   end
 

--- a/app/services/vacancies/import/sources/vacancy_poster.rb
+++ b/app/services/vacancies/import/sources/vacancy_poster.rb
@@ -69,7 +69,7 @@ class Vacancies::Import::Sources::VacancyPoster
     return [] if item["workingPatterns"].blank?
 
     item["workingPatterns"].delete(" ").split(",").map { |pattern|
-      if LEGACY_WORKING_PATTERNS.include?(pattern)
+      if Vacancies::Import::Shared::LEGACY_WORKING_PATTERNS.include?(pattern)
         "part_time"
       else
         pattern

--- a/app/services/vacancies/import/sources/vacancy_poster.rb
+++ b/app/services/vacancies/import/sources/vacancy_poster.rb
@@ -56,12 +56,24 @@ class Vacancies::Import::Sources::VacancyPoster
       ect_status: ect_status_for(item),
       key_stages: item["keyStages"].presence&.split(","),
       subjects: item["subjects"].presence&.split(","),
-      working_patterns: item["workingPatterns"].presence&.split(","),
+      working_patterns: working_patterns_for(item),
       contract_type: contract_type_for(item),
       is_parental_leave_cover: parental_leave_cover_for?(item),
       phases: phase_for(item),
       visa_sponsorship_available: false,
     }.merge(organisation_fields(item))
+  end
+
+  def working_patterns_for(item)
+    return [] if item["workingPatterns"].blank?
+    
+    item["workingPatterns"].delete(" ").split(",").map do |pattern|
+      if pattern == "flexible" || pattern == "term_time" || pattern == "job_share"
+        "part_time"
+      else
+        pattern
+      end
+    end.uniq
   end
 
   def job_advert_for(item)

--- a/app/services/vacancies/import/sources/vacancy_poster.rb
+++ b/app/services/vacancies/import/sources/vacancy_poster.rb
@@ -61,6 +61,7 @@ class Vacancies::Import::Sources::VacancyPoster
       is_parental_leave_cover: parental_leave_cover_for?(item),
       phases: phase_for(item),
       visa_sponsorship_available: false,
+      is_job_share: is_job_share_for(item)
     }.merge(organisation_fields(item))
   end
 
@@ -68,12 +69,16 @@ class Vacancies::Import::Sources::VacancyPoster
     return [] if item["workingPatterns"].blank?
     
     item["workingPatterns"].delete(" ").split(",").map do |pattern|
-      if pattern == "flexible" || pattern == "term_time" || pattern == "job_share"
+      if ["flexible", "term_time", "job_share"].include?(pattern)
         "part_time"
       else
         pattern
       end
     end.uniq
+  end
+
+  def is_job_share_for(item)
+    item["workingPatterns"].include?("job_share")
   end
 
   def job_advert_for(item)

--- a/app/services/vacancies/import/sources/ventrus.rb
+++ b/app/services/vacancies/import/sources/ventrus.rb
@@ -59,12 +59,24 @@ class Vacancies::Import::Sources::Ventrus
       ect_status: ect_status_for(item),
       key_stages: item["Key_Stage"].presence&.split(","),
       # subjects: item["Subjects"].presence&.split(",") || [], # Ventrus don't have subjects in their feed
-      working_patterns: item["Working_Patterns"].presence&.split(","),
+      working_patterns: working_patterns_for(item),
       contract_type: contract_type_for(item),
       is_parental_leave_cover: parental_leave_cover_for?(item),
       phases: phase_for(item),
       visa_sponsorship_available: visa_sponsorship_available_for(item),
     }.merge(organisation_fields(schools))
+  end
+
+  def working_patterns_for(item)
+    return [] if item["Working_Patterns"].blank?
+    
+    item["Working_Patterns"].delete(" ").split(",").map do |pattern|
+      if pattern == "flexible" || pattern == "term_time" || pattern == "job_share"
+        "part_time"
+      else
+        pattern
+      end
+    end.uniq
   end
 
   def ect_status_for(item)

--- a/app/services/vacancies/import/sources/ventrus.rb
+++ b/app/services/vacancies/import/sources/ventrus.rb
@@ -64,23 +64,23 @@ class Vacancies::Import::Sources::Ventrus
       is_parental_leave_cover: parental_leave_cover_for?(item),
       phases: phase_for(item),
       visa_sponsorship_available: visa_sponsorship_available_for(item),
-      is_job_share: is_job_share_for(item)
+      is_job_share: job_share_for?(item),
     }.merge(organisation_fields(schools))
   end
 
   def working_patterns_for(item)
     return [] if item["Working_Patterns"].blank?
-    
-    item["Working_Patterns"].delete(" ").split(",").map do |pattern|
-      if ["flexible", "term_time", "job_share"].include?(pattern)
+
+    item["Working_Patterns"].delete(" ").split(",").map { |pattern|
+      if LEGACY_WORKING_PATTERNS.include?(pattern)
         "part_time"
       else
         pattern
       end
-    end.uniq
+    }.uniq
   end
 
-  def is_job_share_for(item)
+  def job_share_for?(item)
     item["Working_Patterns"].include?("job_share")
   end
 

--- a/app/services/vacancies/import/sources/ventrus.rb
+++ b/app/services/vacancies/import/sources/ventrus.rb
@@ -64,6 +64,7 @@ class Vacancies::Import::Sources::Ventrus
       is_parental_leave_cover: parental_leave_cover_for?(item),
       phases: phase_for(item),
       visa_sponsorship_available: visa_sponsorship_available_for(item),
+      is_job_share: is_job_share_for(item)
     }.merge(organisation_fields(schools))
   end
 
@@ -71,12 +72,16 @@ class Vacancies::Import::Sources::Ventrus
     return [] if item["Working_Patterns"].blank?
     
     item["Working_Patterns"].delete(" ").split(",").map do |pattern|
-      if pattern == "flexible" || pattern == "term_time" || pattern == "job_share"
+      if ["flexible", "term_time", "job_share"].include?(pattern)
         "part_time"
       else
         pattern
       end
     end.uniq
+  end
+
+  def is_job_share_for(item)
+    item["Working_Patterns"].include?("job_share")
   end
 
   def ect_status_for(item)

--- a/app/services/vacancies/import/sources/ventrus.rb
+++ b/app/services/vacancies/import/sources/ventrus.rb
@@ -72,7 +72,7 @@ class Vacancies::Import::Sources::Ventrus
     return [] if item["Working_Patterns"].blank?
 
     item["Working_Patterns"].delete(" ").split(",").map { |pattern|
-      if LEGACY_WORKING_PATTERNS.include?(pattern)
+      if Vacancies::Import::Shared::LEGACY_WORKING_PATTERNS.include?(pattern)
         "part_time"
       else
         pattern

--- a/spec/services/vacancies/import/sources/ark_spec.rb
+++ b/spec/services/vacancies/import/sources/ark_spec.rb
@@ -281,6 +281,17 @@ RSpec.describe Vacancies::Import::Sources::Ark do
           end
         end
       end
+
+      context "when the working pattern is Job Share" do
+        let(:working_pattern) { "Job Share" }
+        it "maps the source working pattern to '[part_time]' in the vacancy" do
+          expect(vacancy.working_patterns).to eq(["part_time"])
+        end
+
+        it "sets is_job_share to true" do
+          expect(vacancy.is_job_share).to eq(true)
+        end
+      end
     end
 
     describe "contract type mapping" do

--- a/spec/services/vacancies/import/sources/broadbean_spec.rb
+++ b/spec/services/vacancies/import/sources/broadbean_spec.rb
@@ -118,6 +118,40 @@ RSpec.describe Vacancies::Import::Sources::Broadbean do
       end
     end
 
+    describe "working_patterns mapping" do
+      context "when working_patterns includes `flexible`" do
+        let(:response_body) { super().gsub("part_time", "full_time,flexible") }
+  
+        it "maps flexible to part time" do
+          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+        end
+      end
+  
+      context "when working_patterns includes `flexible` and `part_time`" do
+        let(:response_body) { super().gsub("part_time", "full_time,part_time,flexible") }
+  
+        it "maps flexible to part time" do
+          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+        end
+      end
+  
+      context "when working_patterns includes `term_time`" do
+        let(:response_body) { super().gsub("part_time", "full_time,term_time") }
+  
+        it "maps term_time to part time" do
+          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+        end
+      end
+  
+      context "when working_patterns includes `term_time` and `part_time`" do
+        let(:response_body) { super().gsub("part_time", "full_time,part_time,term_time") }
+    
+        it "maps term_time to part time" do
+          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+        end
+      end
+    end
+
     describe "job roles mapping" do
       let(:response_body) { super().gsub("head_of_year_or_phase", job_roles.join(",")) }
 

--- a/spec/services/vacancies/import/sources/broadbean_spec.rb
+++ b/spec/services/vacancies/import/sources/broadbean_spec.rb
@@ -121,39 +121,39 @@ RSpec.describe Vacancies::Import::Sources::Broadbean do
     describe "working_patterns mapping" do
       context "when working_patterns includes `flexible`" do
         let(:response_body) { super().gsub("part_time", "full_time,flexible") }
-  
+
         it "maps flexible to part time" do
-          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+          expect(vacancy.working_patterns).to eq %w[full_time part_time]
         end
       end
-  
+
       context "when working_patterns includes `flexible` and `part_time`" do
         let(:response_body) { super().gsub("part_time", "full_time,part_time,flexible") }
-  
+
         it "maps flexible to part time" do
-          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+          expect(vacancy.working_patterns).to eq %w[full_time part_time]
         end
       end
-  
+
       context "when working_patterns includes `term_time`" do
         let(:response_body) { super().gsub("part_time", "full_time,term_time") }
-  
+
         it "maps term_time to part time" do
-          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+          expect(vacancy.working_patterns).to eq %w[full_time part_time]
         end
       end
-  
+
       context "when working_patterns includes `term_time` and `part_time`" do
         let(:response_body) { super().gsub("part_time", "full_time,part_time,term_time") }
-    
+
         it "maps term_time to part time" do
-          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+          expect(vacancy.working_patterns).to eq %w[full_time part_time]
         end
       end
 
       context "when working pattern includes `job_share`" do
         let(:response_body) { super().gsub("part_time", "job_share") }
-    
+
         it "maps job_share to part time" do
           expect(vacancy.working_patterns).to eq ["part_time"]
         end

--- a/spec/services/vacancies/import/sources/broadbean_spec.rb
+++ b/spec/services/vacancies/import/sources/broadbean_spec.rb
@@ -150,6 +150,26 @@ RSpec.describe Vacancies::Import::Sources::Broadbean do
           expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
         end
       end
+
+      context "when working pattern includes `job_share`" do
+        let(:response_body) { super().gsub("part_time", "job_share") }
+    
+        it "maps job_share to part time" do
+          expect(vacancy.working_patterns).to eq ["part_time"]
+        end
+
+        it "sets is_job_share to true" do
+          expect(vacancy.is_job_share).to eq true
+        end
+      end
+
+      context "when the working patterns list contains spaces" do
+        let(:response_body) { super().gsub("part_time", "full_time, part_time") }
+
+        it "records both working patterns in the vacancy" do
+          expect(vacancy.working_patterns).to contain_exactly("part_time", "full_time")
+        end
+      end
     end
 
     describe "job roles mapping" do

--- a/spec/services/vacancies/import/sources/every_spec.rb
+++ b/spec/services/vacancies/import/sources/every_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Vacancies::Import::Sources::Every do
       end
 
       it "maps flexible to part time" do
-        expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+        expect(vacancy.working_patterns).to eq %w[full_time part_time]
       end
     end
 
@@ -137,7 +137,7 @@ RSpec.describe Vacancies::Import::Sources::Every do
       end
 
       it "maps flexible to part time" do
-        expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+        expect(vacancy.working_patterns).to eq %w[full_time part_time]
       end
     end
 
@@ -149,7 +149,7 @@ RSpec.describe Vacancies::Import::Sources::Every do
       end
 
       it "maps term_time to part time" do
-        expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+        expect(vacancy.working_patterns).to eq %w[full_time part_time]
       end
     end
 
@@ -159,9 +159,9 @@ RSpec.describe Vacancies::Import::Sources::Every do
         hash["result"].first["workingPatterns"] = "full_time,part_time,term_time"
         hash.to_json
       end
-  
+
       it "maps term_time to part time" do
-        expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+        expect(vacancy.working_patterns).to eq %w[full_time part_time]
       end
     end
 
@@ -171,7 +171,7 @@ RSpec.describe Vacancies::Import::Sources::Every do
         hash["result"].first["workingPatterns"] = "job_share"
         hash.to_json
       end
-  
+
       it "maps job_share to part time" do
         expect(vacancy.working_patterns).to eq ["part_time"]
       end

--- a/spec/services/vacancies/import/sources/every_spec.rb
+++ b/spec/services/vacancies/import/sources/every_spec.rb
@@ -116,6 +116,56 @@ RSpec.describe Vacancies::Import::Sources::Every do
     end
   end
 
+  describe "working_patterns mapping" do
+    context "when working_patterns includes `flexible`" do
+      let(:response_body) do
+        hash = JSON.parse(super())
+        hash["result"].first["workingPatterns"] = "full_time,flexible"
+        hash.to_json
+      end
+
+      it "maps flexible to part time" do
+        expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+      end
+    end
+
+    context "when working_patterns includes `flexible` and `part_time`" do
+      let(:response_body) do
+        hash = JSON.parse(super())
+        hash["result"].first["workingPatterns"] = "full_time,part_time,flexible"
+        hash.to_json
+      end
+
+      it "maps flexible to part time" do
+        expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+      end
+    end
+
+    context "when working_patterns includes `term_time`" do
+      let(:response_body) do
+        hash = JSON.parse(super())
+        hash["result"].first["workingPatterns"] = "full_time,term_time"
+        hash.to_json
+      end
+
+      it "maps term_time to part time" do
+        expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+      end
+    end
+
+    context "when working_patterns includes `term_time` and `part_time`" do
+      let(:response_body) do
+        hash = JSON.parse(super())
+        hash["result"].first["workingPatterns"] = "full_time,part_time,term_time"
+        hash.to_json
+      end
+  
+      it "maps term_time to part time" do
+        expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+      end
+    end
+  end
+
   describe "job roles mapping" do
     let(:response_body) { super().gsub("teacher", job_roles.join(",")) }
 

--- a/spec/services/vacancies/import/sources/every_spec.rb
+++ b/spec/services/vacancies/import/sources/every_spec.rb
@@ -164,6 +164,34 @@ RSpec.describe Vacancies::Import::Sources::Every do
         expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
       end
     end
+
+    context "when working pattern includes `job_share`" do
+      let(:response_body) do
+        hash = JSON.parse(super())
+        hash["result"].first["workingPatterns"] = "job_share"
+        hash.to_json
+      end
+  
+      it "maps job_share to part time" do
+        expect(vacancy.working_patterns).to eq ["part_time"]
+      end
+
+      it "sets is_job_share to true" do
+        expect(vacancy.is_job_share).to eq true
+      end
+    end
+
+    context "when the working patterns list contains spaces" do
+      let(:response_body) do
+        hash = JSON.parse(super())
+        hash["result"].first["workingPatterns"] = "full_time, part_time, term_time"
+        hash.to_json
+      end
+
+      it "records both working patterns in the vacancy" do
+        expect(vacancy.working_patterns).to contain_exactly("part_time", "full_time")
+      end
+    end
   end
 
   describe "job roles mapping" do

--- a/spec/services/vacancies/import/sources/fusion_spec.rb
+++ b/spec/services/vacancies/import/sources/fusion_spec.rb
@@ -113,6 +113,56 @@ RSpec.describe Vacancies::Import::Sources::Fusion do
       end
     end
 
+    describe "working_patterns mapping" do
+      context "when working_patterns includes `flexible`" do
+        let(:response_body) do
+          hash = JSON.parse(super())
+          hash["result"].first["workingPatterns"] = "full_time,flexible"
+          hash.to_json
+        end
+  
+        it "maps flexible to part time" do
+          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+        end
+      end
+  
+      context "when working_patterns includes `flexible` and `part_time`" do
+        let(:response_body) do
+          hash = JSON.parse(super())
+          hash["result"].first["workingPatterns"] = "full_time,part_time,flexible"
+          hash.to_json
+        end
+  
+        it "maps flexible to part time" do
+          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+        end
+      end
+  
+      context "when working_patterns includes `term_time`" do
+        let(:response_body) do
+          hash = JSON.parse(super())
+          hash["result"].first["workingPatterns"] = "full_time,term_time"
+          hash.to_json
+        end
+  
+        it "maps term_time to part time" do
+          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+        end
+      end
+  
+      context "when working_patterns includes `term_time` and `part_time`" do
+        let(:response_body) do
+          hash = JSON.parse(super())
+          hash["result"].first["workingPatterns"] = "full_time,part_time,term_time"
+          hash.to_json
+        end
+    
+        it "maps term_time to part time" do
+          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+        end
+      end
+    end
+
     describe "start date mapping" do
       let(:fixture_date) { "2022-11-21T00:00:00" }
 

--- a/spec/services/vacancies/import/sources/fusion_spec.rb
+++ b/spec/services/vacancies/import/sources/fusion_spec.rb
@@ -120,45 +120,45 @@ RSpec.describe Vacancies::Import::Sources::Fusion do
           hash["result"].first["workingPatterns"] = "full_time,flexible"
           hash.to_json
         end
-  
+
         it "maps flexible to part time" do
-          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+          expect(vacancy.working_patterns).to eq %w[full_time part_time]
         end
       end
-  
+
       context "when working_patterns includes `flexible` and `part_time`" do
         let(:response_body) do
           hash = JSON.parse(super())
           hash["result"].first["workingPatterns"] = "full_time,part_time,flexible"
           hash.to_json
         end
-  
+
         it "maps flexible to part time" do
-          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+          expect(vacancy.working_patterns).to eq %w[full_time part_time]
         end
       end
-  
+
       context "when working_patterns includes `term_time`" do
         let(:response_body) do
           hash = JSON.parse(super())
           hash["result"].first["workingPatterns"] = "full_time,term_time"
           hash.to_json
         end
-  
+
         it "maps term_time to part time" do
-          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+          expect(vacancy.working_patterns).to eq %w[full_time part_time]
         end
       end
-  
+
       context "when working_patterns includes `term_time` and `part_time`" do
         let(:response_body) do
           hash = JSON.parse(super())
           hash["result"].first["workingPatterns"] = "full_time,part_time,term_time"
           hash.to_json
         end
-    
+
         it "maps term_time to part time" do
-          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+          expect(vacancy.working_patterns).to eq %w[full_time part_time]
         end
       end
 
@@ -168,23 +168,23 @@ RSpec.describe Vacancies::Import::Sources::Fusion do
           hash["result"].first["workingPatterns"] = "job_share"
           hash.to_json
         end
-    
+
         it "maps job_share to part time" do
           expect(vacancy.working_patterns).to eq ["part_time"]
         end
-  
+
         it "sets is_job_share to true" do
           expect(vacancy.is_job_share).to eq true
         end
       end
-  
+
       context "when the working patterns list contains spaces" do
         let(:response_body) do
           hash = JSON.parse(super())
           hash["result"].first["workingPatterns"] = "full_time, part_time, term_time"
           hash.to_json
         end
-  
+
         it "records both working patterns in the vacancy" do
           expect(vacancy.working_patterns).to contain_exactly("part_time", "full_time")
         end

--- a/spec/services/vacancies/import/sources/fusion_spec.rb
+++ b/spec/services/vacancies/import/sources/fusion_spec.rb
@@ -161,6 +161,34 @@ RSpec.describe Vacancies::Import::Sources::Fusion do
           expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
         end
       end
+
+      context "when working pattern includes `job_share`" do
+        let(:response_body) do
+          hash = JSON.parse(super())
+          hash["result"].first["workingPatterns"] = "job_share"
+          hash.to_json
+        end
+    
+        it "maps job_share to part time" do
+          expect(vacancy.working_patterns).to eq ["part_time"]
+        end
+  
+        it "sets is_job_share to true" do
+          expect(vacancy.is_job_share).to eq true
+        end
+      end
+  
+      context "when the working patterns list contains spaces" do
+        let(:response_body) do
+          hash = JSON.parse(super())
+          hash["result"].first["workingPatterns"] = "full_time, part_time, term_time"
+          hash.to_json
+        end
+  
+        it "records both working patterns in the vacancy" do
+          expect(vacancy.working_patterns).to contain_exactly("part_time", "full_time")
+        end
+      end
     end
 
     describe "start date mapping" do

--- a/spec/services/vacancies/import/sources/my_new_term_spec.rb
+++ b/spec/services/vacancies/import/sources/my_new_term_spec.rb
@@ -119,6 +119,22 @@ RSpec.describe Vacancies::Import::Sources::MyNewTerm do
         expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
       end
     end
+
+    context "when working pattern includes `job_share`" do
+      let(:job_listings_response_body) do
+        hash = JSON.parse(super())
+        hash["data"]["jobs"].first["workingPatterns"] = ["job_share"]
+        hash.to_json
+      end
+  
+      it "maps job_share to part time" do
+        expect(vacancy.working_patterns).to eq ["part_time"]
+      end
+
+      it "sets is_job_share to true" do
+        expect(vacancy.is_job_share).to eq true
+      end
+    end
   end
 
   context "when contract_type is parental_leave_cover" do

--- a/spec/services/vacancies/import/sources/my_new_term_spec.rb
+++ b/spec/services/vacancies/import/sources/my_new_term_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Vacancies::Import::Sources::MyNewTerm do
     end
   end
 
-  describe "working_patterns" do
+  describe "working_patterns mapping" do
     context "when working_patterns includes `flexible`" do
       let(:job_listings_response_body) do
         hash = JSON.parse(super())

--- a/spec/services/vacancies/import/sources/my_new_term_spec.rb
+++ b/spec/services/vacancies/import/sources/my_new_term_spec.rb
@@ -75,48 +75,48 @@ RSpec.describe Vacancies::Import::Sources::MyNewTerm do
     context "when working_patterns includes `flexible`" do
       let(:job_listings_response_body) do
         hash = JSON.parse(super())
-        hash["data"]["jobs"].first["workingPatterns"] = ["full_time", "flexible"]
+        hash["data"]["jobs"].first["workingPatterns"] = %w[full_time flexible]
         hash.to_json
       end
 
       it "maps flexible to part time" do
-        expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+        expect(vacancy.working_patterns).to eq %w[full_time part_time]
       end
     end
 
     context "when working_patterns includes `flexible` and `part_time`" do
       let(:job_listings_response_body) do
         hash = JSON.parse(super())
-        hash["data"]["jobs"].first["workingPatterns"] = ["full_time", "part_time", "flexible"]
+        hash["data"]["jobs"].first["workingPatterns"] = %w[full_time part_time flexible]
         hash.to_json
       end
 
       it "maps flexible to part time" do
-        expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+        expect(vacancy.working_patterns).to eq %w[full_time part_time]
       end
     end
 
     context "when working_patterns includes `term_time`" do
       let(:job_listings_response_body) do
         hash = JSON.parse(super())
-        hash["data"]["jobs"].first["workingPatterns"] = ["full_time", "term_time"]
+        hash["data"]["jobs"].first["workingPatterns"] = %w[full_time term_time]
         hash.to_json
       end
 
       it "maps term_time to part time" do
-        expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+        expect(vacancy.working_patterns).to eq %w[full_time part_time]
       end
     end
 
     context "when working_patterns includes `term_time` and `part_time`" do
       let(:job_listings_response_body) do
         hash = JSON.parse(super())
-        hash["data"]["jobs"].first["workingPatterns"] = ["full_time", "part_time", "term_time"]
+        hash["data"]["jobs"].first["workingPatterns"] = %w[full_time part_time term_time]
         hash.to_json
       end
-  
+
       it "maps term_time to part time" do
-        expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+        expect(vacancy.working_patterns).to eq %w[full_time part_time]
       end
     end
 
@@ -126,7 +126,7 @@ RSpec.describe Vacancies::Import::Sources::MyNewTerm do
         hash["data"]["jobs"].first["workingPatterns"] = ["job_share"]
         hash.to_json
       end
-  
+
       it "maps job_share to part time" do
         expect(vacancy.working_patterns).to eq ["part_time"]
       end

--- a/spec/services/vacancies/import/sources/my_new_term_spec.rb
+++ b/spec/services/vacancies/import/sources/my_new_term_spec.rb
@@ -71,6 +71,56 @@ RSpec.describe Vacancies::Import::Sources::MyNewTerm do
     end
   end
 
+  describe "working_patterns" do
+    context "when working_patterns includes `flexible`" do
+      let(:job_listings_response_body) do
+        hash = JSON.parse(super())
+        hash["data"]["jobs"].first["workingPatterns"] = ["full_time", "flexible"]
+        hash.to_json
+      end
+
+      it "maps flexible to part time" do
+        expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+      end
+    end
+
+    context "when working_patterns includes `flexible` and `part_time`" do
+      let(:job_listings_response_body) do
+        hash = JSON.parse(super())
+        hash["data"]["jobs"].first["workingPatterns"] = ["full_time", "part_time", "flexible"]
+        hash.to_json
+      end
+
+      it "maps flexible to part time" do
+        expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+      end
+    end
+
+    context "when working_patterns includes `term_time`" do
+      let(:job_listings_response_body) do
+        hash = JSON.parse(super())
+        hash["data"]["jobs"].first["workingPatterns"] = ["full_time", "term_time"]
+        hash.to_json
+      end
+
+      it "maps term_time to part time" do
+        expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+      end
+    end
+
+    context "when working_patterns includes `term_time` and `part_time`" do
+      let(:job_listings_response_body) do
+        hash = JSON.parse(super())
+        hash["data"]["jobs"].first["workingPatterns"] = ["full_time", "part_time", "term_time"]
+        hash.to_json
+      end
+  
+      it "maps term_time to part time" do
+        expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+      end
+    end
+  end
+
   context "when contract_type is parental_leave_cover" do
     let(:job_listings_response_body) { super().gsub("permanent", "parental_leave_cover") }
 

--- a/spec/services/vacancies/import/sources/united_learning_spec.rb
+++ b/spec/services/vacancies/import/sources/united_learning_spec.rb
@@ -155,16 +155,40 @@ RSpec.describe Vacancies::Import::Sources::UnitedLearning do
         end
       end
 
-      describe "working patterns mapping" do
+      describe "working_patterns mapping" do
         before do
           allow(item_stub).to receive(:[]).with("Working_patterns").and_return(working_patterns)
         end
 
-        context "when the working patterns contain multiple valid values" do
-          let(:working_patterns) { "part_time,full_time,job_share" }
-
-          it "records them all in the vacancy" do
-            expect(vacancy.working_patterns).to contain_exactly("part_time", "full_time", "job_share")
+        context "when working_patterns includes `flexible`" do
+          let(:working_patterns) { "full_time,flexible" }
+    
+          it "maps flexible to part time" do
+            expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+          end
+        end
+    
+        context "when working_patterns includes `flexible` and `part_time`" do
+          let(:working_patterns) { "full_time,part_time,flexible" }
+    
+          it "maps flexible to part time" do
+            expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+          end
+        end
+    
+        context "when working_patterns includes `term_time`" do
+          let(:working_patterns) { "full_time,term_time" }
+    
+          it "maps term_time to part time" do
+            expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+          end
+        end
+    
+        context "when working_patterns includes `term_time` and `part_time`" do
+          let(:working_patterns) { "full_time,part_time,term_time" }
+      
+          it "maps term_time to part time" do
+            expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
           end
         end
 

--- a/spec/services/vacancies/import/sources/united_learning_spec.rb
+++ b/spec/services/vacancies/import/sources/united_learning_spec.rb
@@ -192,6 +192,18 @@ RSpec.describe Vacancies::Import::Sources::UnitedLearning do
           end
         end
 
+        context "when working_patterns includes `job_share`" do
+          let(:working_patterns) { "job_share" }
+      
+          it "maps job_share to part time" do
+            expect(vacancy.working_patterns).to eq ["part_time"]
+          end
+    
+          it "sets is_job_share to true" do
+            expect(vacancy.is_job_share).to eq true
+          end
+        end
+
         context "when the working patterns list contains spaces" do
           let(:working_patterns) { "part_time , full_time" }
 

--- a/spec/services/vacancies/import/sources/united_learning_spec.rb
+++ b/spec/services/vacancies/import/sources/united_learning_spec.rb
@@ -162,43 +162,43 @@ RSpec.describe Vacancies::Import::Sources::UnitedLearning do
 
         context "when working_patterns includes `flexible`" do
           let(:working_patterns) { "full_time,flexible" }
-    
+
           it "maps flexible to part time" do
-            expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+            expect(vacancy.working_patterns).to eq %w[full_time part_time]
           end
         end
-    
+
         context "when working_patterns includes `flexible` and `part_time`" do
           let(:working_patterns) { "full_time,part_time,flexible" }
-    
+
           it "maps flexible to part time" do
-            expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+            expect(vacancy.working_patterns).to eq %w[full_time part_time]
           end
         end
-    
+
         context "when working_patterns includes `term_time`" do
           let(:working_patterns) { "full_time,term_time" }
-    
+
           it "maps term_time to part time" do
-            expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+            expect(vacancy.working_patterns).to eq %w[full_time part_time]
           end
         end
-    
+
         context "when working_patterns includes `term_time` and `part_time`" do
           let(:working_patterns) { "full_time,part_time,term_time" }
-      
+
           it "maps term_time to part time" do
-            expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+            expect(vacancy.working_patterns).to eq %w[full_time part_time]
           end
         end
 
         context "when working_patterns includes `job_share`" do
           let(:working_patterns) { "job_share" }
-      
+
           it "maps job_share to part time" do
             expect(vacancy.working_patterns).to eq ["part_time"]
           end
-    
+
           it "sets is_job_share to true" do
             expect(vacancy.is_job_share).to eq true
           end

--- a/spec/services/vacancies/import/sources/vancancy_poster_spec.rb
+++ b/spec/services/vacancies/import/sources/vancancy_poster_spec.rb
@@ -89,6 +89,18 @@ RSpec.describe Vacancies::Import::Sources::VacancyPoster do
         end
       end
 
+      context "when working pattern includes `job_share`" do
+        let(:response_body) { super().gsub("full_time", "job_share") }
+    
+        it "maps job_share to part time" do
+          expect(vacancy.working_patterns).to eq ["part_time"]
+        end
+
+        it "sets is_job_share to true" do
+          expect(vacancy.is_job_share).to eq true
+        end
+      end
+
       context "when the working patterns list contains spaces" do
         let(:response_body) { super().gsub("full_time", "full_time, part_time") }
 

--- a/spec/services/vacancies/import/sources/vancancy_poster_spec.rb
+++ b/spec/services/vacancies/import/sources/vancancy_poster_spec.rb
@@ -59,39 +59,39 @@ RSpec.describe Vacancies::Import::Sources::VacancyPoster do
     describe "working_patterns mapping" do
       context "when working_patterns includes `flexible`" do
         let(:response_body) { super().gsub("full_time", "full_time,flexible") }
-  
+
         it "maps flexible to part time" do
-          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+          expect(vacancy.working_patterns).to eq %w[full_time part_time]
         end
       end
-  
+
       context "when working_patterns includes `flexible` and `part_time`" do
         let(:response_body) { super().gsub("full_time", "full_time,part_time,flexible") }
-  
+
         it "maps flexible to part time" do
-          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+          expect(vacancy.working_patterns).to eq %w[full_time part_time]
         end
       end
-  
+
       context "when working_patterns includes `term_time`" do
         let(:response_body) { super().gsub("full_time", "full_time,term_time") }
-  
+
         it "maps term_time to part time" do
-          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+          expect(vacancy.working_patterns).to eq %w[full_time part_time]
         end
       end
-  
+
       context "when working_patterns includes `term_time` and `part_time`" do
         let(:response_body) { super().gsub("full_time", "full_time,part_time,term_time") }
-    
+
         it "maps term_time to part time" do
-          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+          expect(vacancy.working_patterns).to eq %w[full_time part_time]
         end
       end
 
       context "when working pattern includes `job_share`" do
         let(:response_body) { super().gsub("full_time", "job_share") }
-    
+
         it "maps job_share to part time" do
           expect(vacancy.working_patterns).to eq ["part_time"]
         end

--- a/spec/services/vacancies/import/sources/vancancy_poster_spec.rb
+++ b/spec/services/vacancies/import/sources/vancancy_poster_spec.rb
@@ -56,6 +56,48 @@ RSpec.describe Vacancies::Import::Sources::VacancyPoster do
       expect(vacancy.organisations).to eq(schools)
     end
 
+    describe "working_patterns mapping" do
+      context "when working_patterns includes `flexible`" do
+        let(:response_body) { super().gsub("full_time", "full_time,flexible") }
+  
+        it "maps flexible to part time" do
+          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+        end
+      end
+  
+      context "when working_patterns includes `flexible` and `part_time`" do
+        let(:response_body) { super().gsub("full_time", "full_time,part_time,flexible") }
+  
+        it "maps flexible to part time" do
+          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+        end
+      end
+  
+      context "when working_patterns includes `term_time`" do
+        let(:response_body) { super().gsub("full_time", "full_time,term_time") }
+  
+        it "maps term_time to part time" do
+          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+        end
+      end
+  
+      context "when working_patterns includes `term_time` and `part_time`" do
+        let(:response_body) { super().gsub("full_time", "full_time,part_time,term_time") }
+    
+        it "maps term_time to part time" do
+          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+        end
+      end
+
+      context "when the working patterns list contains spaces" do
+        let(:response_body) { super().gsub("full_time", "full_time, part_time") }
+
+        it "records both working patterns in the vacancy" do
+          expect(vacancy.working_patterns).to contain_exactly("part_time", "full_time")
+        end
+      end
+    end
+
     describe "job roles mapping" do
       let(:response_body) { super().gsub("deputy_headteacher", job_role) }
 

--- a/spec/services/vacancies/import/sources/ventrus_spec.rb
+++ b/spec/services/vacancies/import/sources/ventrus_spec.rb
@@ -61,39 +61,39 @@ RSpec.describe Vacancies::Import::Sources::Ventrus do
     describe "working_patterns mapping" do
       context "when working_patterns includes `flexible`" do
         let(:response_body) { super().gsub("part_time", "full_time,flexible") }
-  
+
         it "maps flexible to part time" do
-          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+          expect(vacancy.working_patterns).to eq %w[full_time part_time]
         end
       end
-  
+
       context "when working_patterns includes `flexible` and `part_time`" do
         let(:response_body) { super().gsub("part_time", "full_time,part_time,flexible") }
-  
+
         it "maps flexible to part time" do
-          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+          expect(vacancy.working_patterns).to eq %w[full_time part_time]
         end
       end
-  
+
       context "when working_patterns includes `term_time`" do
         let(:response_body) { super().gsub("part_time", "full_time,term_time") }
-  
+
         it "maps term_time to part time" do
-          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+          expect(vacancy.working_patterns).to eq %w[full_time part_time]
         end
       end
-  
+
       context "when working_patterns includes `term_time` and `part_time`" do
         let(:response_body) { super().gsub("part_time", "full_time,part_time,term_time") }
-    
+
         it "maps term_time to part time" do
-          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+          expect(vacancy.working_patterns).to eq %w[full_time part_time]
         end
       end
 
       context "when working pattern includes `job_share`" do
         let(:response_body) { super().gsub("part_time", "job_share") }
-    
+
         it "maps job_share to part time" do
           expect(vacancy.working_patterns).to eq ["part_time"]
         end

--- a/spec/services/vacancies/import/sources/ventrus_spec.rb
+++ b/spec/services/vacancies/import/sources/ventrus_spec.rb
@@ -91,6 +91,18 @@ RSpec.describe Vacancies::Import::Sources::Ventrus do
         end
       end
 
+      context "when working pattern includes `job_share`" do
+        let(:response_body) { super().gsub("part_time", "job_share") }
+    
+        it "maps job_share to part time" do
+          expect(vacancy.working_patterns).to eq ["part_time"]
+        end
+
+        it "sets is_job_share to true" do
+          expect(vacancy.is_job_share).to eq true
+        end
+      end
+
       context "when the working patterns list contains spaces" do
         let(:response_body) { super().gsub("part_time", "full_time, part_time") }
 

--- a/spec/services/vacancies/import/sources/ventrus_spec.rb
+++ b/spec/services/vacancies/import/sources/ventrus_spec.rb
@@ -58,6 +58,48 @@ RSpec.describe Vacancies::Import::Sources::Ventrus do
       expect(vacancy.organisations).to eq(schools)
     end
 
+    describe "working_patterns mapping" do
+      context "when working_patterns includes `flexible`" do
+        let(:response_body) { super().gsub("part_time", "full_time,flexible") }
+  
+        it "maps flexible to part time" do
+          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+        end
+      end
+  
+      context "when working_patterns includes `flexible` and `part_time`" do
+        let(:response_body) { super().gsub("part_time", "full_time,part_time,flexible") }
+  
+        it "maps flexible to part time" do
+          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+        end
+      end
+  
+      context "when working_patterns includes `term_time`" do
+        let(:response_body) { super().gsub("part_time", "full_time,term_time") }
+  
+        it "maps term_time to part time" do
+          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+        end
+      end
+  
+      context "when working_patterns includes `term_time` and `part_time`" do
+        let(:response_body) { super().gsub("part_time", "full_time,part_time,term_time") }
+    
+        it "maps term_time to part time" do
+          expect(vacancy.working_patterns).to eq ["full_time", "part_time"]
+        end
+      end
+
+      context "when the working patterns list contains spaces" do
+        let(:response_body) { super().gsub("part_time", "full_time, part_time") }
+
+        it "records both working patterns in the vacancy" do
+          expect(vacancy.working_patterns).to contain_exactly("part_time", "full_time")
+        end
+      end
+    end
+
     describe "job roles mapping" do
       let(:response_body) { super().gsub("teaching_assistant", job_roles.join(",")) }
 


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/QSLdej8d/1206-map-deleted-workingpatterns-to-parttime-on-ats-imports

## Changes in this PR:

- maps flexible and term_time working patterns to part_time for all ATS providers
- maps job_share to part_time and sets is_job_share to true for all ATS providers when working_pattern is provided as job_share
- handles spaces in the working_patterns strings
- adds tests for above scenarios

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
