### PR TITLE
Add safe operator to ATS imports job_share_for? methods

### DIFF
--- a/app/services/vacancies/import/sources/broadbean.rb
+++ b/app/services/vacancies/import/sources/broadbean.rb
@@ -83,7 +83,7 @@ class Vacancies::Import::Sources::Broadbean
   end
 
   def job_share_for?(item)
-    item["workingPatterns"].include?("job_share")
+    item["workingPatterns"]&.include?("job_share")
   end
 
   def start_date_fields(item)

--- a/app/services/vacancies/import/sources/every.rb
+++ b/app/services/vacancies/import/sources/every.rb
@@ -76,7 +76,7 @@ class Vacancies::Import::Sources::Every
   end
 
   def job_share_for?(item)
-    item["workingPatterns"].include?("job_share")
+    item["workingPatterns"]&.include?("job_share")
   end
 
   def start_date_fields(item)

--- a/app/services/vacancies/import/sources/fusion.rb
+++ b/app/services/vacancies/import/sources/fusion.rb
@@ -99,7 +99,7 @@ class Vacancies::Import::Sources::Fusion
   end
 
   def job_share_for?(item)
-    return false unless item["workingPatterns"].split(",").include?("job_share")
+    return false unless item["workingPatterns"]&.split(",")&.include?("job_share")
 
     true
   end

--- a/app/services/vacancies/import/sources/my_new_term.rb
+++ b/app/services/vacancies/import/sources/my_new_term.rb
@@ -82,7 +82,7 @@ class Vacancies::Import::Sources::MyNewTerm
   end
 
   def job_share_for?(item)
-    item["workingPatterns"].include?("job_share")
+    item["workingPatterns"]&.include?("job_share")
   end
 
   def organisation_fields(schools)

--- a/app/services/vacancies/import/sources/united_learning.rb
+++ b/app/services/vacancies/import/sources/united_learning.rb
@@ -113,7 +113,7 @@ class Vacancies::Import::Sources::UnitedLearning
   end
 
   def job_share_for?(item)
-    item["Working_patterns"].include?("job_share")
+    item["Working_patterns"]&.include?("job_share")
   end
 
   def ect_status_for(item)

--- a/app/services/vacancies/import/sources/vacancy_poster.rb
+++ b/app/services/vacancies/import/sources/vacancy_poster.rb
@@ -78,7 +78,7 @@ class Vacancies::Import::Sources::VacancyPoster
   end
 
   def job_share_for?(item)
-    item["workingPatterns"].include?("job_share")
+    item["workingPatterns"]&.include?("job_share")
   end
 
   def job_advert_for(item)

--- a/app/services/vacancies/import/sources/ventrus.rb
+++ b/app/services/vacancies/import/sources/ventrus.rb
@@ -81,7 +81,7 @@ class Vacancies::Import::Sources::Ventrus
   end
 
   def job_share_for?(item)
-    item["Working_Patterns"].include?("job_share")
+    item["Working_Patterns"]&.include?("job_share")
   end
 
   def ect_status_for(item)


### PR DESCRIPTION
## Trello card URL

https://teaching-vacancies.sentry.io/issues/5830451706/?alert_rule_id=10370581&alert_type=issue&environment=production&notification_uuid=1fcacb0e-807c-4949-a406-4aa845eddeb7&project=6212514&referrer=slack

## Changes in this PR:

Fix a bug that occurs in the `job_share_for?` methods in our ATS import classes when the provided working_patterns is nil

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
