### PR TITLE
Fix Capybara screenshots path on CI artifacts uploads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,8 +65,8 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: capybara-screenshots-${{ matrix.test_params.params }}
-          path: /tmp/capybara/*.png
+          name: capybara-screenshots-${{ matrix.test_params.name }}
+          path: /home/runner/work/teaching-vacancies/teaching-vacancies/tmp/capybara/*.png
           if-no-files-found: ignore # If only non-capybara tests fail there will be no screenshots
   frontend-tests:
     name: Run frontend JS unit tests


### PR DESCRIPTION
The path and name of the Capybara screenshots artefacts generated after CI errors were wrong.

I have forced a test failure to be able to test it pre-merging. 

Now it works correctly. 

### Screenshots showing the correct generation
![image](https://github.com/user-attachments/assets/c90c84b7-15fd-4542-b411-7dfbbdb9f8d2)

![image](https://github.com/user-attachments/assets/bde5a237-1c34-45d5-8b30-03b265b022ea)

![image](https://github.com/user-attachments/assets/55748207-0f46-43cb-a2e1-6b381990c98c)

![image](https://github.com/user-attachments/assets/396a987d-979b-4554-b3c6-a84f8851a9f5)
