### PR TITLE
Fix: Create profile if not present

### DIFF
--- a/app/controllers/jobseekers/job_applications/build_controller.rb
+++ b/app/controllers/jobseekers/job_applications/build_controller.rb
@@ -135,9 +135,17 @@ class Jobseekers::JobApplications::BuildController < Jobseekers::JobApplications
   end
 
   def update_jobseeker_profile
-    current_jobseeker.jobseeker_profile.update(
-      teacher_reference_number: form_params[:teacher_reference_number],
-      has_teacher_reference_number: form_params[:has_teacher_reference_number],
-    )
+    profile = current_jobseeker.jobseeker_profile
+    if profile.present?
+      profile.update!(
+        teacher_reference_number: form_params[:teacher_reference_number],
+        has_teacher_reference_number: form_params[:has_teacher_reference_number],
+      )
+    else
+      current_jobseeker.create_jobseeker_profile(
+        teacher_reference_number: form_params[:teacher_reference_number],
+        has_teacher_reference_number: form_params[:has_teacher_reference_number],
+      )
+    end
   end
 end

--- a/spec/system/jobseekers/jobseekers_can_add_professional_status_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_professional_status_to_their_job_application_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe "Jobseekers can add details about their qualified teacher status to a job application" do
   let(:jobseeker) { create(:jobseeker) }
-  let!(:jobseeker_profile) { create(:jobseeker_profile, jobseeker: jobseeker) }
   let(:vacancy) { create(:vacancy, organisations: [build(:school)]) }
   let!(:job_application) { create(:job_application, :status_draft, jobseeker: jobseeker, vacancy: vacancy) }
 


### PR DESCRIPTION
The code blows in production, as it is sometimes reached by current job seekers without a profile.

Do an "upsert" instead. Update the info in the profile or create a new profile for the user if it wasn't already created.
