### PR TITLE
Send email for saved jobs 10 days before expiry

### DIFF
--- a/app/jobs/send_email_for_unapplied_saved_vacancies_job.rb
+++ b/app/jobs/send_email_for_unapplied_saved_vacancies_job.rb
@@ -1,0 +1,16 @@
+class SendEmailForUnappliedSavedVacanciesJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    threshold = Date.today + 10.days
+
+    Vacancy.includes({ job_applications: :jobseeker }, { saved_jobs: :jobseeker })
+           .where("expires_at between ? and ?", threshold, threshold + 1.day)
+           .find_each do |vacancy|
+      applicants = vacancy.job_applications.map(&:jobseeker)
+      vacancy.saved_jobs.map(&:jobseeker).reject { |js| applicants.include?(js) }.each do |jobseeker|
+        Jobseekers::VacancyMailer.unapplied_saved_vacancy(vacancy, jobseeker).deliver_later
+      end
+    end
+  end
+end

--- a/app/mailers/jobseekers/vacancy_mailer.rb
+++ b/app/mailers/jobseekers/vacancy_mailer.rb
@@ -7,4 +7,13 @@ class Jobseekers::VacancyMailer < Jobseekers::BaseMailer
     view_mail(template, to: @to,
                         subject: I18n.t("jobseekers.vacancy_mailer.draft_application_only.subject", date: @vacancy.expires_at.to_date, job_title: job_application.vacancy.job_title))
   end
+
+  def unapplied_saved_vacancy(vacancy, jobseeker)
+    @to = jobseeker.email
+    @vacancy = vacancy
+    @jobseeker = jobseeker
+
+    view_mail(template, to: @to,
+                        subject: I18n.t("jobseekers.vacancy_mailer.unapplied_saved_vacancy.subject", days: 10, job_title: vacancy.job_title))
+  end
 end

--- a/app/views/jobseekers/vacancy_mailer/unapplied_saved_vacancy.text.erb
+++ b/app/views/jobseekers/vacancy_mailer/unapplied_saved_vacancy.text.erb
@@ -1,0 +1,11 @@
+<%= t(".salutation", name: @jobseeker.jobseeker_profile.first_name) %>
+
+# <%= t(".vacancy_closes", job_title: @vacancy.job_title, school: @vacancy.organisation.name, date: @vacancy.expires_at.to_date.to_formatted_s) %>
+
+<%= t(".saved_but_not_applied") %>
+
+<%= notify_link(job_url(@vacancy), t(".apply_for_link", job_title: @vacancy.job_title)) %>
+
+<%= t(".to_find_the_right_job") %>
+
+<%= t("shared.jobseeker_footer", home_page_link: home_page_link) %>

--- a/config/analytics_custom_events.yml
+++ b/config/analytics_custom_events.yml
@@ -23,6 +23,7 @@ shared:
   - jobseeker_subscription_update
   - jobseeker_unlock_instructions
   - jobseeker_draft_application_only
+  - jobseeker_unapplied_saved_vacancy
   - publisher_applications_received
   - publisher_invite_to_apply
   - publisher_job_application_data_expiry

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -175,6 +175,13 @@ en:
         outro: Or search on %{link_to}
         complete: complete your application
         apply_for_more_jobs: apply for more jobs on Teaching Vacancies
+      unapplied_saved_vacancy:
+        subject: "%{days} days left to apply for %{job_title}"
+        salutation: "Hi %{name}"
+        vacancy_closes: "%{job_title} at %{school} closes on %{date}"
+        saved_but_not_applied: You saved this job but have not applied to it yet
+        apply_for_link: "Apply for %{job_title} on Teaching Vacancies"
+        to_find_the_right_job: "To find the right job, remember to always check Teaching Vacancies"
 
     subscription_mailer:
       confirmation:

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -96,8 +96,13 @@ send_inactive_account_email:
   queue: low
 
 send_draft_applications_email:
-  cron: '20 11 * * *'
+  cron: '20 2 * * *'
   class: 'SendEmailForDraftJobApplicationsJob'
+  queue: default
+
+send_unapplied_saved_vacancies_email:
+  cron: '05 2 * * *'
+  class: 'SendEmailForUnappliedSavedVacanciesJob'
   queue: default
 
 send_account_confirmation_reminder_email:

--- a/spec/jobs/send_email_for_unapplied_saved_vacancies_job_spec.rb
+++ b/spec/jobs/send_email_for_unapplied_saved_vacancies_job_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe SendEmailForUnappliedSavedVacanciesJob, type: :job do
+  let(:jobseeker) { create(:jobseeker, :with_profile) }
+  let(:vacancy) { create(:vacancy, expires_at: expires_at) }
+
+  before do
+    create(:saved_job, vacancy: vacancy, jobseeker: jobseeker)
+  end
+
+  context "when vacancy has 10 days left" do
+    let(:expires_at) { Date.today + 10.days + 2.hours }
+
+    context "when an application hasnt been made" do
+      before do
+        expect(Jobseekers::VacancyMailer).to receive(:unapplied_saved_vacancy).with(vacancy, jobseeker).at_least(:once).and_call_original
+      end
+
+      it "sends an email" do
+        perform_enqueued_jobs { described_class.perform_later }
+      end
+    end
+
+    context "when an application has been made" do
+      before do
+        create(:job_application, jobseeker: jobseeker, vacancy: vacancy)
+        expect(Jobseekers::VacancyMailer).not_to receive(:unapplied_saved_vacancy)
+      end
+
+      it "doesnt send an email" do
+        perform_enqueued_jobs { described_class.perform_later }
+      end
+    end
+  end
+
+  context "when vacancy has 9 days left" do
+    let(:expires_at) { Date.today + 9.days + 2.hours }
+    before do
+      expect(Jobseekers::VacancyMailer).not_to receive(:unapplied_saved_vacancy)
+    end
+
+    it "doesnt send an email" do
+      perform_enqueued_jobs { described_class.perform_later }
+    end
+  end
+end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/0J0wBX1V/1227-new-email-for-jobseekers-with-saved-jobs

## Changes in this PR:

Email sent for saved jobs that haven't been applied for when job has 10 days before expiry

## Screenshots of UI changes:

### After
![SavedNotApplied](https://github.com/user-attachments/assets/8032c4eb-c4ab-43be-9720-35e9a3531a0e)


## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
