### PR TITLE
Email draft applications before deadline

### DIFF
--- a/app/jobs/send_email_for_draft_job_applications_job.rb
+++ b/app/jobs/send_email_for_draft_job_applications_job.rb
@@ -1,0 +1,15 @@
+class SendEmailForDraftJobApplicationsJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    threshold = Date.today + 10.days
+
+    Vacancy.includes({ job_applications: :jobseeker })
+           .where("expires_at between ? and ?", threshold, threshold + 1.day)
+           .find_each do |vacancy|
+      vacancy.job_applications.draft.each do |job_application|
+        Jobseekers::VacancyMailer.draft_application_only(job_application).deliver_later
+      end
+    end
+  end
+end

--- a/app/mailers/jobseekers/vacancy_mailer.rb
+++ b/app/mailers/jobseekers/vacancy_mailer.rb
@@ -1,0 +1,10 @@
+class Jobseekers::VacancyMailer < Jobseekers::BaseMailer
+  def draft_application_only(job_application)
+    @job_application = job_application
+    @vacancy = job_application.vacancy
+    @to = job_application.email
+
+    view_mail(template, to: @to,
+                        subject: I18n.t("jobseekers.vacancy_mailer.draft_application_only.subject", date: @vacancy.expires_at.to_date, job_title: job_application.vacancy.job_title))
+  end
+end

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -62,6 +62,7 @@ class JobApplication < ApplicationRecord
 
   scope :submitted_yesterday, -> { submitted.where("DATE(submitted_at) = ?", Date.yesterday) }
   scope :after_submission, -> { where(status: %w[submitted reviewed shortlisted unsuccessful withdrawn]) }
+  scope :draft, -> { where(status: "draft") }
 
   validates :email_address, email_address: true
 

--- a/app/views/jobseekers/vacancy_mailer/draft_application_only.text.erb
+++ b/app/views/jobseekers/vacancy_mailer/draft_application_only.text.erb
@@ -1,0 +1,7 @@
+# <%= t(".intro", job_title: @vacancy.job_title, school: @vacancy.organisation.name, date: @vacancy.expires_at.to_date.to_formatted_s) %>
+
+<%= t(".body", link_to: notify_link(jobseekers_job_application_review_url(@job_application), t(".complete"))) %>
+
+<%= t(".outro", link_to: home_page_link) %>
+
+<%= t("shared.jobseeker_footer", home_page_link: home_page_link) %>

--- a/config/analytics_custom_events.yml
+++ b/config/analytics_custom_events.yml
@@ -22,6 +22,7 @@ shared:
   - jobseeker_subscription_confirmation
   - jobseeker_subscription_update
   - jobseeker_unlock_instructions
+  - jobseeker_draft_application_only
   - publisher_applications_received
   - publisher_invite_to_apply
   - publisher_job_application_data_expiry

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -167,6 +167,15 @@ en:
           link_text: view your draft application
         subject: Update on %{job_title} at %{organisation_name}
 
+    vacancy_mailer:
+      draft_application_only:
+        subject: Apply for %{job_title} before %{date}
+        intro: The deadline to apply for %{job_title} at %{school} is %{date}
+        body: You started an application for this role, but have not submitted it yet. If you want to apply, there is still time to %{link_to}.
+        outro: Or search on %{link_to}
+        complete: complete your application
+        apply_for_more_jobs: apply for more jobs on Teaching Vacancies
+
     subscription_mailer:
       confirmation:
         create_account:

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -95,6 +95,11 @@ send_inactive_account_email:
   class: 'SendInactiveAccountEmailJob'
   queue: low
 
+send_draft_applications_email:
+  cron: '20 11 * * *'
+  class: 'SendEmailForDraftJobApplicationsJob'
+  queue: default
+
 send_account_confirmation_reminder_email:
   cron: '0 9 * * *'
   class: 'SendAccountConfirmationReminderEmailJob'

--- a/spec/jobs/send_email_for_draft_job_applications_job_spec.rb
+++ b/spec/jobs/send_email_for_draft_job_applications_job_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe SendEmailForDraftJobApplicationsJob, type: :job do
   let(:vacancy) { create(:vacancy, expires_at: Date.today + time_left + 2.hours) }
   let(:job_application) { JobApplication.last }
 
+  include Rails.application.routes.url_helpers
+
   before do
     create(:job_application, :status_draft, vacancy: vacancy, jobseeker: jobseeker)
   end
@@ -16,8 +18,11 @@ RSpec.describe SendEmailForDraftJobApplicationsJob, type: :job do
       expect(Jobseekers::VacancyMailer).to receive(:draft_application_only).with(job_application).at_least(:once).and_call_original
     end
 
-    it "sends an email" do
-      perform_enqueued_jobs { described_class.perform_later }
+    it "sends an email containing a link to review the job application" do
+      expect {
+        perform_enqueued_jobs { described_class.perform_later }
+      }.to change(ActionMailer::Base.deliveries, :count).by(1)
+      expect(ActionMailer::Base.deliveries.last.body).to include(jobseekers_job_application_review_url(job_application))
     end
   end
 

--- a/spec/jobs/send_email_for_draft_job_applications_job_spec.rb
+++ b/spec/jobs/send_email_for_draft_job_applications_job_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe SendEmailForDraftJobApplicationsJob, type: :job do
+  let(:jobseeker) { create(:jobseeker) }
+  let(:vacancy) { create(:vacancy, expires_at: Date.today + time_left + 2.hours) }
+  let(:job_application) { JobApplication.last }
+
+  before do
+    create(:job_application, :status_draft, vacancy: vacancy, jobseeker: jobseeker)
+  end
+
+  context "when vacancy has 10 days left" do
+    let(:time_left) { 10.days }
+
+    before do
+      expect(Jobseekers::VacancyMailer).to receive(:draft_application_only).with(job_application).at_least(:once).and_call_original
+    end
+
+    it "sends an email" do
+      perform_enqueued_jobs { described_class.perform_later }
+    end
+  end
+
+  context "when vacancy has 9 days left" do
+    let(:time_left) { 9.days }
+    before do
+      expect(Jobseekers::VacancyMailer).not_to receive(:draft_application_only)
+    end
+
+    it "doesnt send an email" do
+      perform_enqueued_jobs { described_class.perform_later }
+    end
+  end
+
+  context "when vacancy has 11 days left" do
+    let(:time_left) { 11.days }
+    before do
+      expect(Jobseekers::VacancyMailer).not_to receive(:draft_application_only)
+    end
+
+    it "doesnt send an email" do
+      perform_enqueued_jobs { described_class.perform_later }
+    end
+  end
+end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/pdIHz5MT/1225-new-email-for-unsubmitted-applications

## Changes in this PR:

New email for impending deadline draft applications 

![StartedLate](https://github.com/user-attachments/assets/cf5c1b01-3577-485a-9efa-cc38e26b0bb3)



## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
