### PR TITLE
Fix omniauth config for allowing both publishers and jobseekers

### DIFF
--- a/app/controllers/jobseekers/govuk_one_login_callbacks_controller.rb
+++ b/app/controllers/jobseekers/govuk_one_login_callbacks_controller.rb
@@ -38,8 +38,7 @@ class Jobseekers::GovukOneLoginCallbacksController < Devise::OmniauthCallbacksCo
   # We need to build our own logic to redirect the user to the correct pages.
   def after_sign_in_path_for(resource)
     stored_location = stored_location_for(resource)
-
-    if stored_location.include?("job_application/new")
+    if user_signed_in_from_quick_apply_link?(stored_location)
       stored_location
     elsif session[:user_exists_first_log_in]
       session.delete(:user_exists_first_log_in)
@@ -47,6 +46,10 @@ class Jobseekers::GovukOneLoginCallbacksController < Devise::OmniauthCallbacksCo
     else
       jobseekers_job_applications_path
     end
+  end
+
+  def user_signed_in_from_quick_apply_link?(stored_location)
+    stored_location&.include?("job_application/new")
   end
 
   def existing_jobseeker_first_sign_in_via_one_login(govuk_one_login_user)

--- a/app/controllers/jobseekers/govuk_one_login_callbacks_controller.rb
+++ b/app/controllers/jobseekers/govuk_one_login_callbacks_controller.rb
@@ -5,9 +5,9 @@ class Jobseekers::GovukOneLoginCallbacksController < Devise::OmniauthCallbacksCo
   def openid_connect
     if (govuk_one_login_user = Jobseekers::GovukOneLogin::UserFromAuthResponse.call(params, session))
       session[:govuk_one_login_id_token] = govuk_one_login_user.id_token
-      
+
       if existing_jobseeker_first_sign_in_via_one_login(govuk_one_login_user)
-        session[:user_exists_first_log_in] = { value: 'true', path: '/', expires: 1.hour.from_now }
+        session[:user_exists_first_log_in] = { value: "true", path: "/", expires: 1.hour.from_now }
       end
 
       jobseeker = Jobseeker.find_or_create_from_govuk_one_login(email: govuk_one_login_user.email,

--- a/app/models/jobseeker.rb
+++ b/app/models/jobseeker.rb
@@ -1,16 +1,16 @@
 class Jobseeker < ApplicationRecord
   has_encrypted :last_sign_in_ip, :current_sign_in_ip
 
-  devise(*%I[confirmable
-             database_authenticatable
-             lockable
-             omniauthable
-             recoverable
-             registerable
-             timeoutable
-             trackable
-             validatable],
-         omniauth_providers: [:openid_connect])
+  devise(*%I[
+    confirmable
+    database_authenticatable
+    lockable
+    recoverable
+    registerable
+    timeoutable
+    trackable
+    validatable
+  ])
 
   has_many :feedbacks, dependent: :destroy, inverse_of: :jobseeker
   has_many :job_applications, dependent: :destroy

--- a/app/services/jobseekers/govuk_one_login.rb
+++ b/app/services/jobseekers/govuk_one_login.rb
@@ -3,7 +3,7 @@ module Jobseekers::GovukOneLogin
   CALLBACKS_BASE_URL = "#{ENV.fetch('DOMAIN').include?('localhost') ? 'http' : 'https'}://#{ENV.fetch('DOMAIN')}".freeze
 
   CALLBACKS = {
-    login: "#{CALLBACKS_BASE_URL}/jobseekers/auth/openid_connect/callback",
+    login: "#{CALLBACKS_BASE_URL}/jobseekers/auth/govuk_one_login/callback",
     logout: "#{CALLBACKS_BASE_URL}/jobseekers/sign_out",
   }.freeze
 

--- a/app/views/jobseekers/accounts/show.html.slim
+++ b/app/views/jobseekers/accounts/show.html.slim
@@ -12,7 +12,7 @@ h1.govuk-heading-l = t(".page_title")
       li = t(".data_to_change_in_govuk_one_login.password")
       li = t(".data_to_change_in_govuk_one_login.security_codes")
     p = govuk_link_to t(".change_details_link_text"), "https://home.account.gov.uk/settings"
-    
+
     h2.govuk-heading-m = t(".find_account_details.heading")
     p = t(".find_account_details.paragraph1")
     p = t(".find_account_details.paragraph2")

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -274,23 +274,7 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
-  config.omniauth :openid_connect, {
-    name: :gov_uk_one_login,
-    scope: %i[openid email],
-    response_type: :code,
-    client_options: {
-      port: 443,
-      scheme: "https",
-      host: Rails.application.config.govuk_one_login_base_url,
-      identifier: Rails.application.config.govuk_one_login_client_id,
-      redirect_uri: "jobseekers/auth/openid_connect/callback",
-    },
-    authorize_params: {
-      prompt: "login",
-    },
-  }
-
-  # NB: This has been extracted per
+  # NB: This has been extracted to /config/initializers/omniauth.rb per
   # https://github.com/heartcombo/devise/wiki/OmniAuth-with-multiple-models
 
   # ==> Warden configuration

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,4 +1,5 @@
 class OmniAuth::Strategies::Dfe < OmniAuth::Strategies::OpenIDConnect; end
+class OmniAuth::Strategies::GovukOneLogin < OmniAuth::Strategies::OpenIDConnect; end
 
 Rails.application.config.middleware.use OmniAuth::Builder do
   dfe_sign_in_issuer_uri    = URI(ENV.fetch("DFE_SIGN_IN_ISSUER", "example"))
@@ -25,6 +26,23 @@ Rails.application.config.middleware.use OmniAuth::Builder do
       authorization_endpoint: "/auth",
       jwks_uri: "/certs",
       userinfo_endpoint: "/me",
+    },
+  )
+
+  provider(
+    :govuk_one_login,
+    name: :govuk_one_login,
+    scope: %i[openid email],
+    response_type: :code,
+    client_options: {
+      port: 443,
+      scheme: "https",
+      host: Rails.application.config.govuk_one_login_base_url,
+      identifier: Rails.application.config.govuk_one_login_client_id,
+      redirect_uri: "jobseekers/auth/govuk_one_login/callback",
+    },
+    authorize_params: {
+      prompt: "login",
     },
   )
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,7 +62,6 @@ Rails.application.routes.draw do
     registrations: "jobseekers/registrations",
     sessions: "jobseekers/sessions",
     unlocks: "jobseekers/unlocks",
-    omniauth_callbacks: "jobseekers/govuk_one_login_callbacks",
   }, path_names: {
     sign_in: "sign-in",
   }
@@ -262,6 +261,12 @@ Rails.application.routes.draw do
   end
 
   devise_for :support_users
+
+  scope path: "jobseekers" do
+    devise_scope :jobseeker do
+      get "/auth/govuk_one_login/callback/", to: "jobseekers/govuk_one_login_callbacks#openid_connect"
+    end
+  end
 
   devise_scope :publisher do
     get "/auth/dfe", to: "omniauth_callbacks#passthru"

--- a/spec/requests/jobseekers/govuk_one_login_spec.rb
+++ b/spec/requests/jobseekers/govuk_one_login_spec.rb
@@ -2,13 +2,17 @@ require "rails_helper"
 
 RSpec.describe "Govuk One Login authentication response" do
   describe "GET #openid_connect" do
+    let(:devise_stored_location) { nil }
     let(:govuk_one_login_user) do
       instance_double(Jobseekers::GovukOneLogin::User,
                       id: "urn:fdc:gov.uk:2022:VtcZjnU4Sif2oyJZola3OkN0e3Jeku1cIMN38rFlhU4",
                       email: "user@example.com",
                       id_token: "eyJhbGciOiJSUzI1NiIsImtpZCI6IjFlOWdkazcifQ.ewogImlzcyI6I")
     end
+
     before do
+      allow(Jobseekers::GovukOneLogin::UserFromAuthResponse).to receive(:call).and_return(govuk_one_login_user)
+      allow_any_instance_of(ApplicationController).to receive(:stored_location_for).and_return(devise_stored_location)
       get root_path # Loads OneLogin Sign-in button and sets session values for user.
     end
 
@@ -21,43 +25,87 @@ RSpec.describe "Govuk One Login authentication response" do
       expect(response.request.flash[:alert]).to include("There was a problem signing in. Please try again.")
     end
 
-    context "when the OneLogin response is successful" do
-      before do
-        allow(Jobseekers::GovukOneLogin::UserFromAuthResponse).to receive(:call).and_return(govuk_one_login_user)
+    it "sets the OneLogin ID token in the user session" do
+      get jobseeker_openid_connect_omniauth_callback_path
+
+      expect(session[:govuk_one_login_id_token]).to eq(govuk_one_login_user.id_token)
+    end
+
+    it " deletes the OneLogin state and nonce used for authentication from the user session" do
+      get jobseeker_openid_connect_omniauth_callback_path
+
+      expect(session[:govuk_one_login_state]).to be_nil
+      expect(session[:govuk_one_login_nonce]).to be_nil
+    end
+
+    context "when the OneLogin user matches a TV jobseeker" do
+      let!(:jobseeker) { create(:jobseeker, email: "user@example.com") }
+
+      it "signs in the user as the existing jobseeker" do
+        expect { get jobseeker_openid_connect_omniauth_callback_path }.not_to change(Jobseeker, :count)
+        expect(controller.current_jobseeker).to eq(jobseeker)
+        expect(controller.current_jobseeker).to have_attributes(email: govuk_one_login_user.email,
+                                                                govuk_one_login_id: govuk_one_login_user.id)
       end
 
-      it "redirects the signed in user to their applications page" do
-        get jobseeker_openid_connect_omniauth_callback_path
+      context "with a quick apply url location to redirect to in devise session" do
+        let(:devise_stored_location) { "/job_application/new" }
 
-        expect(controller.current_jobseeker).to be_present
-        expect(response).to redirect_to(jobseekers_job_applications_path)
-      end
+        it "redirects the jobseeker to the quick apply url" do
+          get jobseeker_openid_connect_omniauth_callback_path
 
-      it "sets the OneLogin ID token in the session and deletes the OneLogin state and nonce used for authentication" do
-        get jobseeker_openid_connect_omniauth_callback_path
-
-        expect(session[:govuk_one_login_id_token]).to eq(govuk_one_login_user.id_token)
-        expect(session[:govuk_one_login_state]).to be_nil
-        expect(session[:govuk_one_login_nonce]).to be_nil
-      end
-
-      context "when the OneLogin user matches a TV jobseeker" do
-        let!(:jobseeker) { create(:jobseeker, email: "user@example.com") }
-
-        it "signs in the user as the existing jobseeker" do
-          expect { get jobseeker_openid_connect_omniauth_callback_path }.not_to change(Jobseeker, :count)
-          expect(controller.current_jobseeker).to eq(jobseeker)
-          expect(controller.current_jobseeker).to have_attributes(email: govuk_one_login_user.email,
-                                                                  govuk_one_login_id: govuk_one_login_user.id)
+          expect(response).to redirect_to(devise_stored_location)
         end
       end
 
-      context "when the OneLogin user does not match a TV jobseeker" do
-        it "creates a new jobseeker and signs them in" do
-          expect { get jobseeker_openid_connect_omniauth_callback_path }.to change(Jobseeker, :count).by(1)
-          expect(controller.current_jobseeker).to eq(Jobseeker.last)
-          expect(controller.current_jobseeker).to have_attributes(email: govuk_one_login_user.email,
-                                                                  govuk_one_login_id: govuk_one_login_user.id)
+      context "with no quick apply url location to redirect to in devise session" do
+        let(:devise_stored_location) { jobseekers_subscriptions_path }
+
+        context "when the jobseeker is signing in for the first time via OneLogin" do
+          it "redirects the new jobseeker to the account found page" do
+            get jobseeker_openid_connect_omniauth_callback_path
+
+            expect(response).to redirect_to(account_found_jobseekers_account_path)
+          end
+        end
+
+        context "when is not the first time the jobseeker is signing in via OneLogin" do
+          let!(:jobseeker) { create(:jobseeker, email: "user@example.com", govuk_one_login_id: govuk_one_login_user.id) }
+
+          it "redirects the jobseeker to their applications page" do
+            get jobseeker_openid_connect_omniauth_callback_path
+
+            expect(response).to redirect_to(jobseekers_job_applications_path)
+          end
+        end
+      end
+    end
+
+    context "when the OneLogin user does not match a TV jobseeker" do
+      it "creates a new jobseeker and signs them in" do
+        expect { get jobseeker_openid_connect_omniauth_callback_path }.to change(Jobseeker, :count).by(1)
+        expect(controller.current_jobseeker).to eq(Jobseeker.last)
+        expect(controller.current_jobseeker).to have_attributes(email: govuk_one_login_user.email,
+                                                                govuk_one_login_id: govuk_one_login_user.id)
+      end
+
+      context "with a quick apply url location to redirect to in devise session" do
+        let(:devise_stored_location) { "/job_application/new" }
+
+        it "redirects the jobseeker to the stored location" do
+          get jobseeker_openid_connect_omniauth_callback_path
+
+          expect(response).to redirect_to(devise_stored_location)
+        end
+      end
+
+      context "with no quick apply url location to redirect to in devise session" do
+        let(:devise_stored_location) { jobseekers_subscriptions_path }
+
+        it "redirects the jobseeker to their applications page" do
+          get jobseeker_openid_connect_omniauth_callback_path
+
+          expect(response).to redirect_to(jobseekers_job_applications_path)
         end
       end
     end

--- a/spec/services/jobseekers/govuk_one_login/client_spec.rb
+++ b/spec/services/jobseekers/govuk_one_login/client_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Jobseekers::GovukOneLogin::Client do
       expect(request_mock).to have_received(:set_form_data).with(
         grant_type: "authorization_code",
         code: code,
-        redirect_uri: "http://localhost:3000/jobseekers/auth/openid_connect/callback",
+        redirect_uri: "http://localhost:3000/jobseekers/auth/govuk_one_login/callback",
         client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
         client_assertion: "jwt_assertion",
       )

--- a/spec/services/jobseekers/govuk_one_login/helper_spec.rb
+++ b/spec/services/jobseekers/govuk_one_login/helper_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Jobseekers::GovukOneLogin::Helper, type: :helper do
     it "generates the params for the GovUk OneLogin authorize endpoint" do
       login_params = helper.generate_login_params
       expect(login_params).to include(
-        redirect_uri: "http://localhost:3000/jobseekers/auth/openid_connect/callback",
+        redirect_uri: "http://localhost:3000/jobseekers/auth/govuk_one_login/callback",
         client_id: "one_login_client_id",
         response_type: "code",
         scope: "email openid",


### PR DESCRIPTION
## What this PR does:
- Fixes and extends Govuk One Login request spec to cover new business logic about where to redirect jobseekers after login.
- Fixes linting errors.
- Changes the Omniauth Jobseekers Onelogin configuration approach to be compatible with Publishers Omniauth (DFE Sign-in)

## What this PR does not do:
- Fixing existing tests based in Jobseekers Devise user/password approach. This will be tackled in a separate PR.

## Long explanation

Originally we were using Devise "omniauthable" module on the jobseekers.

This was breaking the system tests for the Publisher users (based on
Omniauth DFE Sign-in service).

We have found that "omniauthable" is not compatible with multiple models
using Omniauth. So we have to remove the "omniauthable" wrapper/config
over plain Omniauth for the Jobseeker, and configure it directly through
the Omniauth configuration, as done with DFE Sign-in Publisher users.

Devise documentation and instructions:
https://github.com/heartcombo/devise/wiki/OmniAuth-with-multiple-models
