### PR TITLE
Updating education phase filter for schools

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -270,11 +270,11 @@ en:
         key_stage: Key stage
         key_stages:
           early_years: Early years
-          ks1: KS1
-          ks2: KS2
-          ks3: KS3
-          ks4: KS4
-          ks5: KS5
+          ks1: Key stage 1
+          ks2: Key stage 2
+          ks3: Key stage 3
+          ks4: Key stage 4
+          ks5: Key stage 5
         phase: Education phase
         phases:
           nursery: Nursery

--- a/config/locales/organisations.yml
+++ b/config/locales/organisations.yml
@@ -4,7 +4,7 @@ en:
     other_type: Type
 
     filters:
-      education_phase: Phase of education
+      education_phase: Education phase
       key_stage: Key stage
       special_school: Special school
       faith_school: Faith school


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/eM2MdAKw/1020-content-tweaks-on-schools-page-filters

## Changes in this PR:

- updating the header from ‘Phase of education’ to ‘Education phase’

- amending the options shown under the key stage filter to be the full names (key stage 1) rather than 'KS1'.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
