### PR TITLE
Onelogin no account found page

### DIFF
--- a/app/controllers/jobseekers/accounts_controller.rb
+++ b/app/controllers/jobseekers/accounts_controller.rb
@@ -4,4 +4,6 @@ class Jobseekers::AccountsController < Jobseekers::BaseController
   def confirmation; end
 
   def account_found; end
+
+  def account_not_found; end
 end

--- a/app/controllers/jobseekers/govuk_one_login_callbacks_controller.rb
+++ b/app/controllers/jobseekers/govuk_one_login_callbacks_controller.rb
@@ -3,12 +3,13 @@ class Jobseekers::GovukOneLoginCallbacksController < Devise::OmniauthCallbacksCo
   # Devise redirects response from Govuk One Login to this method.
   # The request parameters contain the response from Govuk One Login from the user authentication through their portal.
 
-  
+  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize
   def openid_connect
     if (govuk_one_login_user = Jobseekers::GovukOneLogin::UserFromAuthResponse.call(params, session))
       session[:govuk_one_login_id_token] = govuk_one_login_user.id_token
-      
-      jobseeker = Jobseeker.find_by('lower(email) = ?', govuk_one_login_user.email.downcase)
+
+      jobseeker = Jobseeker.find_by("lower(email) = ?", govuk_one_login_user.email.downcase)
 
       if jobseeker.nil?
         session[:newly_created_user] = { value: "true", path: "/", expires: 1.hour.from_now }
@@ -29,6 +30,8 @@ class Jobseekers::GovukOneLoginCallbacksController < Devise::OmniauthCallbacksCo
     Rails.logger.error(e.message)
     error_redirect
   end
+  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/AbcSize
 
   private
 

--- a/app/models/jobseeker.rb
+++ b/app/models/jobseeker.rb
@@ -36,21 +36,16 @@ class Jobseeker < ApplicationRecord
     !confirmed? || unconfirmed_email.present?
   end
 
-  def self.find_or_create_from_govuk_one_login(email:, govuk_one_login_id:)
+  def self.create_from_govuk_one_login(email:, govuk_one_login_id:)
     return unless email.present? && govuk_one_login_id.present?
 
-    if (user = find_by("LOWER(email) = ?", email.downcase))
-      user.update(govuk_one_login_id: govuk_one_login_id) if user.govuk_one_login_id != govuk_one_login_id
-      user
-    else
-      # OneLogin users won't need/use this password. But is required by validations for in-house Devise users.
-      # Eventually when all the users become OneLogin users, we should be able to remove the password requirement.
-      random_password = Devise.friendly_token
-      create!(email: email.downcase,
-              govuk_one_login_id: govuk_one_login_id,
-              password: random_password,
-              confirmed_at: Time.zone.now)
-    end
+    # OneLogin users won't need/use this password. But is required by validations for in-house Devise users.
+    # Eventually when all the users become OneLogin users, we should be able to remove the password requirement.
+    random_password = Devise.friendly_token
+    create!(email: email.downcase,
+            govuk_one_login_id: govuk_one_login_id,
+            password: random_password,
+            confirmed_at: Time.zone.now)
   end
 
   def generate_merge_verification_code

--- a/app/views/jobseekers/accounts/account_found.html.slim
+++ b/app/views/jobseekers/accounts/account_found.html.slim
@@ -4,6 +4,5 @@
   .govuk-grid-column-two-thirds
     h1.govuk-heading-l = t(".page_title")
 
-    p.govuk-body = t(".could_not_find_account")
-    p.govuk-body = t(".continue_to_profile", link: govuk_link_to(t(".update_profile_link_text"), jobseekers_profile_path), search_and_apply_link: govuk_link_to(t(".search_and_apply_link_text"), jobs_path), create_alert_link: govuk_link_to(t(".create_alert_link_text"), new_subscription_path)).html_safe
+    p.govuk-body = t(".email_found")
     p.govuk-body = t(".helpful_links", update_profile_link: govuk_link_to(t(".update_profile_link_text"), jobseekers_profile_path), search_and_apply_link: govuk_link_to(t(".search_and_apply_link_text"), jobs_path), create_alert_link: govuk_link_to(t(".create_alert_link_text"), new_subscription_path)).html_safe

--- a/app/views/jobseekers/accounts/account_found.html.slim
+++ b/app/views/jobseekers/accounts/account_found.html.slim
@@ -4,5 +4,6 @@
   .govuk-grid-column-two-thirds
     h1.govuk-heading-l = t(".page_title")
 
-    p.govuk-body = t(".email_found")
+    p.govuk-body = t(".could_not_find_account")
+    p.govuk-body = t(".continue_to_profile", link: govuk_link_to(t(".update_profile_link_text"), jobseekers_profile_path), search_and_apply_link: govuk_link_to(t(".search_and_apply_link_text"), jobs_path), create_alert_link: govuk_link_to(t(".create_alert_link_text"), new_subscription_path)).html_safe
     p.govuk-body = t(".helpful_links", update_profile_link: govuk_link_to(t(".update_profile_link_text"), jobseekers_profile_path), search_and_apply_link: govuk_link_to(t(".search_and_apply_link_text"), jobs_path), create_alert_link: govuk_link_to(t(".create_alert_link_text"), new_subscription_path)).html_safe

--- a/app/views/jobseekers/accounts/account_not_found.html.slim
+++ b/app/views/jobseekers/accounts/account_not_found.html.slim
@@ -1,0 +1,9 @@
+- content_for :page_title_prefix, t(".page_title")
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    h1.govuk-heading-l = t(".page_title")
+
+    p.govuk-body = t(".email_found")
+    p.govuk-body = t(".continue_to_profile", link: govuk_link_to(t(".profile_link_text"), jobseekers_profile_path)).html_safe
+    p.govuk-body = t(".transfer_account")

--- a/app/views/jobseekers/accounts/account_not_found.html.slim
+++ b/app/views/jobseekers/accounts/account_not_found.html.slim
@@ -6,4 +6,4 @@
 
     p.govuk-body = t(".could_not_find_account")
     p.govuk-body = t(".continue_to_profile", link: govuk_link_to(t(".profile_link_text"), jobseekers_profile_path)).html_safe
-    p.govuk-body = t(".transfer_account", link: govuk_link_to(t(".transfer_account_link_text"), account_not_found_jobseekers_account_path)).html_safe
+    p.govuk-body = t(".transfer_account", link: govuk_link_to(t(".transfer_account_link_text"), new_jobseekers_request_account_transfer_email_path)).html_safe

--- a/app/views/jobseekers/accounts/account_not_found.html.slim
+++ b/app/views/jobseekers/accounts/account_not_found.html.slim
@@ -4,6 +4,6 @@
   .govuk-grid-column-two-thirds
     h1.govuk-heading-l = t(".page_title")
 
-    p.govuk-body = t(".email_found")
+    p.govuk-body = t(".could_not_find_account")
     p.govuk-body = t(".continue_to_profile", link: govuk_link_to(t(".profile_link_text"), jobseekers_profile_path)).html_safe
     p.govuk-body = t(".transfer_account")

--- a/app/views/jobseekers/accounts/account_not_found.html.slim
+++ b/app/views/jobseekers/accounts/account_not_found.html.slim
@@ -6,4 +6,4 @@
 
     p.govuk-body = t(".could_not_find_account")
     p.govuk-body = t(".continue_to_profile", link: govuk_link_to(t(".profile_link_text"), jobseekers_profile_path)).html_safe
-    p.govuk-body = t(".transfer_account")
+    p.govuk-body = t(".transfer_account", link: govuk_link_to(t(".transfer_account_link_text"), account_not_found_jobseekers_account_path)).html_safe

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -47,6 +47,12 @@ en:
         update_profile_link_text: update your profile details
         search_and_apply_link_text: search and apply for jobs
         create_alert_link_text: create a job alert
+      account_not_found:
+        page_title: You have created a new Teaching Vacancies account
+        could_not_find_account: We could not find an existing Teaching Vacancies account using this email.
+        continue_to_profile: If this is correct, you can %{link}
+        profile_link_text: continue to your profile.
+        transfer_account: If you have a Teaching Vacancies account using a different email address, you can transfer your existing account information.
     account_feedbacks:
       create:
         success: Thank you for your feedback

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -52,7 +52,8 @@ en:
         could_not_find_account: We could not find an existing Teaching Vacancies account using this email.
         continue_to_profile: If this is correct, you can %{link}
         profile_link_text: continue to your profile.
-        transfer_account: If you have a Teaching Vacancies account using a different email address, you can transfer your existing account information.
+        transfer_account: If you have a Teaching Vacancies account using a different email address, you can %{link}
+        transfer_account_link_text: transfer your existing account information.
     account_feedbacks:
       create:
         success: Thank you for your feedback

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -184,6 +184,7 @@ Rails.application.routes.draw do
       member do
         get :confirmation
         get :account_found
+        get :account_not_found
       end
     end
     resource :account_feedback, only: %i[new create]

--- a/spec/models/jobseeker_spec.rb
+++ b/spec/models/jobseeker_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Jobseeker do
   end
 
   describe ".create_from_govuk_one_login" do
-    let(:email) { "user@example.com" }
+    let(:email) { "notarealuser121342@gmail.com" }
     let(:govuk_one_login_id) { "urn:fdc:gov.uk:2022:VtcZjnU4Sif2oyJZola3OkN0e3Jeku1cIMN38rFlhU4" }
 
     subject(:create_from_govuk_one_login) do

--- a/spec/models/jobseeker_spec.rb
+++ b/spec/models/jobseeker_spec.rb
@@ -49,51 +49,21 @@ RSpec.describe Jobseeker do
     end
   end
 
-  describe ".find_or_create_from_govuk_one_login" do
+  describe ".create_from_govuk_one_login" do
     let(:email) { "user@example.com" }
     let(:govuk_one_login_id) { "urn:fdc:gov.uk:2022:VtcZjnU4Sif2oyJZola3OkN0e3Jeku1cIMN38rFlhU4" }
 
-    subject(:find_or_create) do
-      described_class.find_or_create_from_govuk_one_login(email: email, govuk_one_login_id: govuk_one_login_id)
+    subject(:create_from_govuk_one_login) do
+      described_class.create_from_govuk_one_login(email: email, govuk_one_login_id: govuk_one_login_id)
     end
 
     RSpec.shared_examples "invalid input" do
       it "returns nil" do
-        expect(find_or_create).to be_nil
+        expect(create_from_govuk_one_login).to be_nil
       end
 
       it "does not create a new jobseeker" do
-        expect { find_or_create }.not_to change(described_class, :count)
-      end
-    end
-
-    RSpec.shared_examples "existing jobseeker" do
-      let!(:jobseeker) { create(:jobseeker, email: existing_jobseeker_email, govuk_one_login_id:) }
-
-      it "returns the existing jobseeker" do
-        expect(find_or_create).to eq jobseeker
-      end
-
-      it "does not create a new jobseeker" do
-        expect { find_or_create }.not_to change(described_class, :count)
-      end
-
-      context "when the existing jobseeker has no govuk one login id" do
-        let!(:jobseeker) { create(:jobseeker, email:, govuk_one_login_id: nil) }
-
-        it "updates the existing jobseeker with the govuk one login id" do
-          expect { find_or_create }.to change { jobseeker.reload.govuk_one_login_id }.from(nil).to(govuk_one_login_id)
-        end
-      end
-
-      context "when the existing jobseeker had a different govuk one login id" do
-        let!(:jobseeker) { create(:jobseeker, email:, govuk_one_login_id: "old_govuk_one_login_id") }
-
-        it "updates the existing jobseeker govuk one login id" do
-          expect { find_or_create }.to change { jobseeker.reload.govuk_one_login_id }
-                                   .from("old_govuk_one_login_id")
-                                   .to(govuk_one_login_id)
-        end
+        expect { create_from_govuk_one_login }.not_to change(described_class, :count)
       end
     end
 
@@ -109,25 +79,13 @@ RSpec.describe Jobseeker do
       include_examples "invalid input"
     end
 
-    context "when a jobseeker with the exact email address already exists" do
-      include_examples "existing jobseeker" do
-        let(:existing_jobseeker_email) { email }
-      end
-    end
-
-    context "when a jobseeker with the same email address with different capitalisation exist" do
-      include_examples "existing jobseeker" do
-        let(:existing_jobseeker_email) { email.upcase }
-      end
-    end
-
-    context "without an existing jobseeker with the same email address" do
+    context "when an email and govuk_on_login_id is provided" do
       it "creates a new jobseeker" do
-        expect { find_or_create }.to change(described_class, :count).by(1)
+        expect { create_from_govuk_one_login }.to change(described_class, :count).by(1)
       end
 
       it "returns the new jobseeker with the one login id and email" do
-        jobseeker = find_or_create
+        jobseeker = create_from_govuk_one_login
         expect(jobseeker).to be_a(described_class)
         expect(jobseeker).to have_attributes(email:, govuk_one_login_id:)
       end

--- a/spec/requests/jobseekers/govuk_one_login_spec.rb
+++ b/spec/requests/jobseekers/govuk_one_login_spec.rb
@@ -20,19 +20,19 @@ RSpec.describe "Govuk One Login authentication response" do
       allow(Jobseekers::GovukOneLogin::UserFromAuthResponse).to receive(:call)
         .and_raise(Jobseekers::GovukOneLogin::Errors::GovukOneLoginError)
 
-      get jobseeker_openid_connect_omniauth_callback_path
+      get auth_govuk_one_login_callback_path
       expect(response).to redirect_to(root_path)
       expect(response.request.flash[:alert]).to include("There was a problem signing in. Please try again.")
     end
 
     it "sets the OneLogin ID token in the user session" do
-      get jobseeker_openid_connect_omniauth_callback_path
+      get auth_govuk_one_login_callback_path
 
       expect(session[:govuk_one_login_id_token]).to eq(govuk_one_login_user.id_token)
     end
 
     it " deletes the OneLogin state and nonce used for authentication from the user session" do
-      get jobseeker_openid_connect_omniauth_callback_path
+      get auth_govuk_one_login_callback_path
 
       expect(session[:govuk_one_login_state]).to be_nil
       expect(session[:govuk_one_login_nonce]).to be_nil
@@ -42,7 +42,7 @@ RSpec.describe "Govuk One Login authentication response" do
       let!(:jobseeker) { create(:jobseeker, email: "user@example.com") }
 
       it "signs in the user as the existing jobseeker" do
-        expect { get jobseeker_openid_connect_omniauth_callback_path }.not_to change(Jobseeker, :count)
+        expect { get auth_govuk_one_login_callback_path }.not_to change(Jobseeker, :count)
         expect(controller.current_jobseeker).to eq(jobseeker)
         expect(controller.current_jobseeker).to have_attributes(email: govuk_one_login_user.email,
                                                                 govuk_one_login_id: govuk_one_login_user.id)
@@ -52,7 +52,7 @@ RSpec.describe "Govuk One Login authentication response" do
         let(:devise_stored_location) { "/job_application/new" }
 
         it "redirects the jobseeker to the quick apply url" do
-          get jobseeker_openid_connect_omniauth_callback_path
+          get auth_govuk_one_login_callback_path
 
           expect(response).to redirect_to(devise_stored_location)
         end
@@ -63,7 +63,7 @@ RSpec.describe "Govuk One Login authentication response" do
 
         context "when the jobseeker is signing in for the first time via OneLogin" do
           it "redirects the new jobseeker to the account found page" do
-            get jobseeker_openid_connect_omniauth_callback_path
+            get auth_govuk_one_login_callback_path
 
             expect(response).to redirect_to(account_found_jobseekers_account_path)
           end
@@ -73,7 +73,7 @@ RSpec.describe "Govuk One Login authentication response" do
           let!(:jobseeker) { create(:jobseeker, email: "user@example.com", govuk_one_login_id: govuk_one_login_user.id) }
 
           it "redirects the jobseeker to their applications page" do
-            get jobseeker_openid_connect_omniauth_callback_path
+            get auth_govuk_one_login_callback_path
 
             expect(response).to redirect_to(jobseekers_job_applications_path)
           end
@@ -83,7 +83,7 @@ RSpec.describe "Govuk One Login authentication response" do
 
     context "when the OneLogin user does not match a TV jobseeker" do
       it "creates a new jobseeker and signs them in" do
-        expect { get jobseeker_openid_connect_omniauth_callback_path }.to change(Jobseeker, :count).by(1)
+        expect { get auth_govuk_one_login_callback_path }.to change(Jobseeker, :count).by(1)
         expect(controller.current_jobseeker).to eq(Jobseeker.last)
         expect(controller.current_jobseeker).to have_attributes(email: govuk_one_login_user.email,
                                                                 govuk_one_login_id: govuk_one_login_user.id)
@@ -93,7 +93,7 @@ RSpec.describe "Govuk One Login authentication response" do
         let(:devise_stored_location) { "/job_application/new" }
 
         it "redirects the jobseeker to the stored location" do
-          get jobseeker_openid_connect_omniauth_callback_path
+          get auth_govuk_one_login_callback_path
 
           expect(response).to redirect_to(devise_stored_location)
         end
@@ -103,7 +103,7 @@ RSpec.describe "Govuk One Login authentication response" do
         let(:devise_stored_location) { jobseekers_subscriptions_path }
 
         it "redirects the jobseeker to an account not found page page" do
-          get jobseeker_openid_connect_omniauth_callback_path
+          get auth_govuk_one_login_callback_path
 
           expect(response).to redirect_to(account_not_found_jobseekers_account_path)
         end

--- a/spec/requests/jobseekers/govuk_one_login_spec.rb
+++ b/spec/requests/jobseekers/govuk_one_login_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Govuk One Login authentication response" do
     let(:govuk_one_login_user) do
       instance_double(Jobseekers::GovukOneLogin::User,
                       id: "urn:fdc:gov.uk:2022:VtcZjnU4Sif2oyJZola3OkN0e3Jeku1cIMN38rFlhU4",
-                      email: "user@example.com",
+                      email: "user@someemail.com",
                       id_token: "eyJhbGciOiJSUzI1NiIsImtpZCI6IjFlOWdkazcifQ.ewogImlzcyI6I")
     end
 
@@ -39,7 +39,7 @@ RSpec.describe "Govuk One Login authentication response" do
     end
 
     context "when the OneLogin user matches a TV jobseeker" do
-      let!(:jobseeker) { create(:jobseeker, email: "user@example.com") }
+      let!(:jobseeker) { create(:jobseeker, email: "user@someemail.com") }
 
       it "signs in the user as the existing jobseeker" do
         expect { get auth_govuk_one_login_callback_path }.not_to change(Jobseeker, :count)
@@ -70,7 +70,7 @@ RSpec.describe "Govuk One Login authentication response" do
         end
 
         context "when is not the first time the jobseeker is signing in via OneLogin" do
-          let!(:jobseeker) { create(:jobseeker, email: "user@example.com", govuk_one_login_id: govuk_one_login_user.id) }
+          let!(:jobseeker) { create(:jobseeker, email: "user@someemail.com", govuk_one_login_id: govuk_one_login_user.id) }
 
           it "redirects the jobseeker to their applications page" do
             get auth_govuk_one_login_callback_path

--- a/spec/requests/jobseekers/govuk_one_login_spec.rb
+++ b/spec/requests/jobseekers/govuk_one_login_spec.rb
@@ -102,10 +102,10 @@ RSpec.describe "Govuk One Login authentication response" do
       context "with no quick apply url location to redirect to in devise session" do
         let(:devise_stored_location) { jobseekers_subscriptions_path }
 
-        it "redirects the jobseeker to their applications page" do
+        it "redirects the jobseeker to an account not found page page" do
           get jobseeker_openid_connect_omniauth_callback_path
 
-          expect(response).to redirect_to(jobseekers_job_applications_path)
+          expect(response).to redirect_to(account_not_found_jobseekers_account_path)
         end
       end
     end

--- a/spec/services/jobseekers/govuk_one_login/helper_spec.rb
+++ b/spec/services/jobseekers/govuk_one_login/helper_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Jobseekers::GovukOneLogin::Helper, type: :helper do
       login_uri = helper.govuk_one_login_uri(:login, helper.generate_login_params)
       expect(login_uri.host).to eq "oidc.test.account.gov.uk"
       expect(login_uri.path).to eq "/authorize"
-      expect(login_uri.query).to include "redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fjobseekers%2Fauth%2Fopenid_connect%2Fcallback"
+      expect(login_uri.query).to include "redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fjobseekers%2Fauth%2Fgovuk_one_login%2Fcallback"
       expect(login_uri.query).to include "client_id=one_login_client_id"
       expect(login_uri.query).to include "response_type=code"
       expect(login_uri.query).to include "scope=email+openid"


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/QITtyko2/1146-gol-to-tv-journey-2-new-sign-in-with-no-email-match-account-found

## Changes in this PR:

This page creates a page for jobseekers to explain that an account was not found matching their gov.uk one login details and explains some helpful information. It also redirects users to this page after they log in unless they were applying for a quick apply job.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
