### PR TITLE
Add notification banner to profiles page letting users know they can …

### DIFF
--- a/app/views/jobseekers/profiles/show.html.slim
+++ b/app/views/jobseekers/profiles/show.html.slim
@@ -6,6 +6,11 @@
       = t(".page_title")
       = govuk_tag(text: t(".active"), colour: "green", classes: "vertical-align-middle govuk-!-margin-left-1") if profile.active?
 
+    = govuk_notification_banner title_text: "Important", classes: "govuk-notification-banner govuk-!-margin-top-0 govuk-!-margin-bottom-5" do |banner|
+        - banner.with_heading(text: t(".one_login_banner.header"))
+        p.govuk-body = t(".one_login_banner.paragraph1")
+        p.govuk-body = t(".one_login_banner.paragraph2", link: govuk_link_to(t(".one_login_banner.transfer_profile_link_text"), new_jobseekers_request_account_transfer_email_path)).html_safe
+
     p
       = govuk_link_to t(".turn_#{@off_on}_profile"), confirm_toggle_jobseekers_profile_path, class: "govuk-!-margin-right-2"
       = govuk_link_to t(".preview_profile"), jobseekers_profile_preview_path

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -779,6 +779,11 @@ en:
         turn_off_profile: Turn off profile
         turn_on_profile_text: When you turn on your profile it will be visible to hiring staff, and they can invite you to apply for roles.
         turn_on_profile: Turn on profile
+        one_login_banner:
+          header: Can't see your profile details?
+          paragraph1: If you had a Teaching Vacancies account using a different email address to your GOV.UK One Login account, your existing profile will not automatically be saved.
+          paragraph2: You can request to %{link}
+          transfer_profile_link_text: transfer your existing profile.
       confirm_toggle:
         confirm_turn_off: Confirm that you want to turn off your profile
         confirm_turn_on: Confirm that you want to turn on your profile


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/3MJuhGsS/1139-update-profile-tab-with-account-migration-notification

## Changes in this PR:

Add notification banner to profiles page letting users know they can transfer account information if they have not already

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
