### PR TITLE
Onelogin fix links

### DIFF
--- a/app/views/jobseekers/accounts/show.html.slim
+++ b/app/views/jobseekers/accounts/show.html.slim
@@ -15,7 +15,8 @@ h1.govuk-heading-l = t(".page_title")
 
     h2.govuk-heading-m = t(".find_account_details.heading")
     p = t(".find_account_details.paragraph1")
-    p = t(".find_account_details.paragraph2")
+    p = t(".find_account_details.paragraph2", link: govuk_link_to(t(".find_account_details.link_text"), new_jobseekers_request_account_transfer_email_path)).html_safe
+
 
     h2.govuk-heading-m = t(".close_account")
     p = t(".close_account_explanation")

--- a/app/views/jobseekers/accounts/show.html.slim
+++ b/app/views/jobseekers/accounts/show.html.slim
@@ -17,7 +17,6 @@ h1.govuk-heading-l = t(".page_title")
     p = t(".find_account_details.paragraph1")
     p = t(".find_account_details.paragraph2", link: govuk_link_to(t(".find_account_details.link_text"), new_jobseekers_request_account_transfer_email_path)).html_safe
 
-
     h2.govuk-heading-m = t(".close_account")
     p = t(".close_account_explanation")
 

--- a/app/views/jobseekers/job_applications/new.html.slim
+++ b/app/views/jobseekers/job_applications/new.html.slim
@@ -4,7 +4,7 @@
   = govuk_notification_banner title_text: t("banners.important") do
     h3.govuk-heading-s = t(".cannot_see_past_applications.title")
     p.govuk-body = t(".cannot_see_past_applications.paragraph1")
-    p.govuk-body = t(".cannot_see_past_applications.paragraph2")
+    p.govuk-body = t(".cannot_see_past_applications.paragraph2", link: govuk_link_to(t(".cannot_see_past_applications.link_text"), new_jobseekers_request_account_transfer_email_path)).html_safe
 
 span.govuk-caption-l = t("jobseekers.job_applications.caption", job_title: vacancy.job_title, organisation: vacancy.organisation_name)
 h2.govuk-heading-xl = t("jobseekers.job_applications.heading")

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -25,7 +25,8 @@ en:
         find_account_details:
           heading: Can't find your old account details?
           paragraph1: If you had a Teaching Vacancies account using a different email address to your GOV.UK One Login account, your old account details will not automatically be saved.
-          paragraph2: You can request to transfer your existing account information.
+          paragraph2: You can request to %{link}
+          link_text: transfer your existing account information.
       confirmation:
         page_title: Account created
         apply_for_jobs_link_text: search and apply for teaching jobs

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -355,7 +355,8 @@ en:
         cannot_see_past_applications:
           title: Can't see your information from past applications?
           paragraph1: If you had a Teaching Vacancies account using a different email address to your GOV.UK One Login account, information from your past applications will not automatically be saved.
-          paragraph2: You can request to transfer information from your past applications.
+          paragraph2: You can request to %{link}
+          link_text: transfer information from your past applications.
       about_your_application:
         title: About your application
         warning:


### PR DESCRIPTION
## Trello card URL

## Changes in this PR:

This PR adds links to transfer account to the 'your account' page and the new job application page.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
