### PR TITLE
Delete unconfirmed accounts on all bounces

### DIFF
--- a/app/jobs/delete_jobseekers_with_incorrect_emails_job.rb
+++ b/app/jobs/delete_jobseekers_with_incorrect_emails_job.rb
@@ -3,7 +3,9 @@ class DeleteJobseekersWithIncorrectEmailsJob < ApplicationJob
 
   def perform
     client = GovUkNotifyStatusClient.new
-    responses = client.get_email_notifications(status: "permanent-failure")
+    # This isn't particularily well-documented, but this picks up
+    # all failures temporary-failure, permanent-failure and technical-failure
+    responses = client.get_email_notifications(status: "failure")
 
     failed_email_addresses = responses.map(&:email_address)
 

--- a/app/services/gov_uk_notify_status_client.rb
+++ b/app/services/gov_uk_notify_status_client.rb
@@ -3,7 +3,7 @@ class GovUkNotifyStatusClient
     @client = Notifications::Client.new(ENV.fetch("NOTIFY_KEY", nil))
   end
 
-  def get_email_notifications(options)
+  def get_email_notifications(options = {})
     opts = options.merge(template_type: "email")
     notifications = @client.get_notifications(opts).collection
 

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -116,7 +116,7 @@ update_dsi_users_in_db:
   queue: low
 
 delete_jobseekers_with_incorrect_emails:
-  cron: '30 2 * * 1'
+  cron: '30 2 * * Mon,Thu'
   class: 'DeleteJobseekersWithIncorrectEmailsJob'
   queue: low
 

--- a/spec/jobs/delete_jobseekers_with_incorrect_emails_job_spec.rb
+++ b/spec/jobs/delete_jobseekers_with_incorrect_emails_job_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe DeleteJobseekersWithIncorrectEmailsJob, type: :job do
   before do
     allow(Notifications::Client).to receive(:new).and_return(notify_client_mock)
     allow(notify_client_mock)
-      .to receive(:get_notifications).with({ template_type: "email", status: "permanent-failure" })
+      .to receive(:get_notifications).with({ template_type: "email", status: "failure" })
                                      .and_return(notify_notifications_mock)
     allow(notify_notifications_mock).to receive(:collection).and_return(notify_api_response)
     allow(notify_client_mock)
-      .to receive(:get_notifications).with({ template_type: "email", status: "permanent-failure", older_than: "last-email" })
+      .to receive(:get_notifications).with({ template_type: "email", status: "failure", older_than: "last-email" })
                                      .and_return(double("no notifications", collection: []))
   end
 


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/cybo2kgi/1205-bounced-job-alerts-auto-deletion

## Changes in this PR:

Is there anything I might have missed with this plan? If a user confirm email bounces for any reason, presumably it's ok to delete the account as it's probably not a real person. We re-send the confirm email every 5 days, does that need altering too in some way? Should we delete unconfirmed accounts if they don't respond after a certain time period?

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
