### PR TITLE
Amend the copy on job alert emails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
  # Alpine v3.19.
  # TODO: Regularly check in the alpine ruby "3.3.5-alpine3.19" images for its latest upgraded packages so we can remove
  # the hardcoded versions below when they have been updated in the alpine ruby image.
-ARG PROD_PACKAGES="imagemagick libpng libjpeg libxml2 libxslt libpq tzdata shared-mime-info postgresql15=15.8-r0 busybox=1.36.1-r19 openssl=3.1.7-r0"
+ARG PROD_PACKAGES="imagemagick libpng libjpeg libxml2 libxslt libpq tzdata shared-mime-info postgresql15 busybox=1.36.1-r19 openssl=3.1.7-r0"
 
 FROM ruby:3.3.5-alpine3.19 AS builder
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
  # Alpine v3.19.
  # TODO: Regularly check in the alpine ruby "3.3.5-alpine3.19" images for its latest upgraded packages so we can remove
  # the hardcoded versions below when they have been updated in the alpine ruby image.
-ARG PROD_PACKAGES="imagemagick libpng libjpeg libxml2 libxslt libpq tzdata shared-mime-info postgresql15 busybox=1.36.1-r19 openssl=3.1.7-r0"
+ARG PROD_PACKAGES="imagemagick libpng libjpeg libxml2 libxslt libpq tzdata shared-mime-info postgresql15=15.8-r0 busybox=1.36.1-r19 openssl=3.1.7-r0"
 
 FROM ruby:3.3.5-alpine3.19 AS builder
 

--- a/app/views/jobseekers/subscription_mailer/confirmation.text.erb
+++ b/app/views/jobseekers/subscription_mailer/confirmation.text.erb
@@ -7,7 +7,7 @@
 
 <%= t(".next_steps", frequency: t(".frequency.#{subscription.frequency}")) %>
 
-<%= t(".multiple_job_alerts", link: govuk_link_to(".multiple_job_alerts_link_text"), new_subscription_path) %>
+<%= t(".multiple_job_alerts", link: govuk_link_to(t(".multiple_job_alerts_link_text"), new_subscription_path)) %>
 
 ---
 

--- a/app/views/jobseekers/subscription_mailer/confirmation.text.erb
+++ b/app/views/jobseekers/subscription_mailer/confirmation.text.erb
@@ -7,7 +7,7 @@
 
 <%= t(".next_steps", frequency: t(".frequency.#{subscription.frequency}")) %>
 
-<%= t(".multiple_job_alerts", link: govuk_link_to(t(".multiple_job_alerts_link_text"), new_subscription_path)) %>
+<%= t(".multiple_job_alerts", link: govuk_link_to(t(".multiple_job_alerts_link_text"), new_subscription_url)) %>
 
 ---
 

--- a/app/views/jobseekers/subscription_mailer/confirmation.text.erb
+++ b/app/views/jobseekers/subscription_mailer/confirmation.text.erb
@@ -7,7 +7,7 @@
 
 <%= t(".next_steps", frequency: t(".frequency.#{subscription.frequency}")) %>
 
-<%= t(".multiple_job_alerts", link: govuk_link_to(t(".multiple_job_alerts_link_text"), new_subscription_url)) %>
+<%= t(".multiple_job_alerts", link: govuk_link_to(t(".multiple_job_alerts_link_text"), new_subscription_url)).html_safe %>
 
 ---
 

--- a/app/views/jobseekers/subscription_mailer/confirmation.text.erb
+++ b/app/views/jobseekers/subscription_mailer/confirmation.text.erb
@@ -7,6 +7,8 @@
 
 <%= t(".next_steps", frequency: t(".frequency.#{subscription.frequency}")) %>
 
+<%= t(".multiple_job_alerts", link: govuk_link_to(".multiple_job_alerts_link_text"), new_subscription_path) %>
+
 ---
 
 <%- unless jobseeker.present? %>
@@ -18,3 +20,5 @@
 <% end %>
 
 <%= t(".unsubscribe", unsubscribe_link: unsubscribe_link(subscription)) %>
+
+<%= t("shared.footer", home_page_link: home_page_link) %>

--- a/app/views/jobseekers/subscription_mailer/confirmation.text.erb
+++ b/app/views/jobseekers/subscription_mailer/confirmation.text.erb
@@ -7,7 +7,7 @@
 
 <%= t(".next_steps", frequency: t(".frequency.#{subscription.frequency}")) %>
 
-<%= t(".multiple_job_alerts", link: govuk_link_to(t(".multiple_job_alerts_link_text"), new_subscription_url)).html_safe %>
+<%= t(".multiple_job_alerts", link: notify_link(new_subscription_url, t(".multiple_job_alerts_link_text")))%>
 
 ---
 

--- a/app/views/jobseekers/subscription_mailer/update.text.erb
+++ b/app/views/jobseekers/subscription_mailer/update.text.erb
@@ -7,7 +7,7 @@
 
 <%= t(".next_steps", frequency: t(".frequency.#{subscription.frequency}")) %>
 
-<%= t(".multiple_job_alerts", link: govuk_link_to(".multiple_job_alerts_link_text"), new_subscription_path) %>
+<%= t(".multiple_job_alerts", link: govuk_link_to(t(".multiple_job_alerts_link_text"), new_subscription_path)) %>
 
 ---
 

--- a/app/views/jobseekers/subscription_mailer/update.text.erb
+++ b/app/views/jobseekers/subscription_mailer/update.text.erb
@@ -7,7 +7,7 @@
 
 <%= t(".next_steps", frequency: t(".frequency.#{subscription.frequency}")) %>
 
-<%= t(".multiple_job_alerts", link: govuk_link_to(t(".multiple_job_alerts_link_text"), new_subscription_path)) %>
+<%= t(".multiple_job_alerts", link: govuk_link_to(t(".multiple_job_alerts_link_text"), new_subscription_url)) %>
 
 ---
 

--- a/app/views/jobseekers/subscription_mailer/update.text.erb
+++ b/app/views/jobseekers/subscription_mailer/update.text.erb
@@ -7,7 +7,7 @@
 
 <%= t(".next_steps", frequency: t(".frequency.#{subscription.frequency}")) %>
 
-<%= t(".multiple_job_alerts", link: govuk_link_to(t(".multiple_job_alerts_link_text"), new_subscription_url)) %>
+<%= t(".multiple_job_alerts", link: govuk_link_to(t(".multiple_job_alerts_link_text"), new_subscription_url)).html_safe %>
 
 ---
 

--- a/app/views/jobseekers/subscription_mailer/update.text.erb
+++ b/app/views/jobseekers/subscription_mailer/update.text.erb
@@ -7,6 +7,8 @@
 
 <%= t(".next_steps", frequency: t(".frequency.#{subscription.frequency}")) %>
 
+<%= t(".multiple_job_alerts", link: govuk_link_to(".multiple_job_alerts_link_text"), new_subscription_path) %>
+
 ---
 
 <%- unless jobseeker.present? %>
@@ -18,3 +20,5 @@
 <% end %>
 
 <%= t(".unsubscribe", unsubscribe_link: unsubscribe_link(subscription)) %>
+
+<%= t("shared.footer", home_page_link: home_page_link) %>

--- a/app/views/jobseekers/subscription_mailer/update.text.erb
+++ b/app/views/jobseekers/subscription_mailer/update.text.erb
@@ -7,7 +7,7 @@
 
 <%= t(".next_steps", frequency: t(".frequency.#{subscription.frequency}")) %>
 
-<%= t(".multiple_job_alerts", link: govuk_link_to(t(".multiple_job_alerts_link_text"), new_subscription_url)).html_safe %>
+<%= t(".multiple_job_alerts", link: notify_link(new_subscription_url, t(".multiple_job_alerts_link_text")))%>
 
 ---
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -378,7 +378,7 @@ en:
     errors:
       duplicate_alert: You must change the search criteria in order to update your job alert
       no_location_and_other_criterion_selected: Enter a location and one or more other filters, for example a keyword or job role.
-    intro: 'We’ll email you details of any new jobs that match the following criteria:'
+    intro: 'We’ll email you all new jobs that match the following criteria:'
     jobseeker_account_prompt:
       body:
         sign_in: Sign in to see all your job alerts in one place and save the jobs you are interested in.

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -174,11 +174,13 @@ en:
           daily: at the end of the day (at around 3 pm)
           weekly: weekly (at around 6 pm on Friday evening)
         next_steps: >-
-          You’ll receive a job alert %{frequency} when a job matching your criteria is listed.
+          You’ll receive job alerts %{frequency} when there is a job matching your criteria.
         subject: Teaching Vacancies job alert confirmation
         title: You have subscribed to a job alert from Teaching Vacancies
         unsubscribe: Don’t want to receive these email alerts? %{unsubscribe_link}
         unsubscribe_link_text: Unsubscribe here
+        multiple_job_alerts_link: To track more jobs with different criteria, you can %{link}
+        multiple_job_alerts_link_text: create multiple job alerts
       update:
         create_account:
           heading: Create a Teaching Vacancies account
@@ -188,11 +190,13 @@ en:
           daily: at the end of the day (at around 3 pm)
           weekly: weekly (at around 6 pm on Friday evening)
         next_steps: >-
-          You’ll receive a job alert %{frequency} when a job matching your criteria is listed.
+          You’ll receive job alerts %{frequency} when there is a job matching your criteria.
         subject: Teaching Vacancies job alert update
         title: You have updated a job alert from Teaching Vacancies
         unsubscribe: Don’t want to receive these email alerts? %{unsubscribe_link}
         unsubscribe_link_text: Unsubscribe here
+        multiple_job_alerts: To track more jobs with different criteria, you can %{link}
+        multiple_job_alerts_link_text: create multiple job alerts
 
   publishers:
     job_application_data_expiry_mailer:

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -179,7 +179,7 @@ en:
         title: You have subscribed to a job alert from Teaching Vacancies
         unsubscribe: Don’t want to receive these email alerts? %{unsubscribe_link}
         unsubscribe_link_text: Unsubscribe here
-        multiple_job_alerts_link: To track more jobs with different criteria, you can %{link}
+        multiple_job_alerts: To track more jobs with different criteria, you can %{link}
         multiple_job_alerts_link_text: create multiple job alerts
       update:
         create_account:

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -171,8 +171,8 @@ en:
           intro: "%{link_to} to see all your job alerts in one place, and save the jobs you are interested in"
           link: Create an account
         frequency:
-          daily: at the end of the day (at around 3 pm)
-          weekly: weekly (at around 6 pm on Friday evening)
+          daily: at the end of the day
+          weekly: weekly
         next_steps: >-
           You’ll receive job alerts %{frequency} when there is a job matching your criteria.
         subject: Teaching Vacancies job alert confirmation
@@ -187,8 +187,8 @@ en:
           intro: "%{link_to} to see all your job alerts in one place, and save the jobs you are interested in"
           link: Create an account
         frequency:
-          daily: at the end of the day (at around 3 pm)
-          weekly: weekly (at around 6 pm on Friday evening)
+          daily: at the end of the day
+          weekly: weekly
         next_steps: >-
           You’ll receive job alerts %{frequency} when there is a job matching your criteria.
         subject: Teaching Vacancies job alert update


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/T5pRSLbl/1226-content-updates-for-job-alert-subscription-email

## Changes in this PR:

This PR updates the content on the update and confirm job alert emails.

I have also upgraded the postgres package in our dockerfile to avoid a snyk issue.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
