### PR TITLE
Add flexi working section to Vacancy

### DIFF
--- a/app/controllers/concerns/publishers/wizardable.rb
+++ b/app/controllers/concerns/publishers/wizardable.rb
@@ -130,7 +130,8 @@ module Publishers::Wizardable
 
   def about_the_role_params(params)
     params.require(:publishers_job_listing_about_the_role_form)
-          .permit(:job_advert, :about_school, :ect_status, :skills_and_experience, :school_offer, :safeguarding_information_provided, :safeguarding_information, :further_details_provided, :further_details)
+          .permit(:job_advert, :about_school, :ect_status, :skills_and_experience, :school_offer, :flexi_working,
+                  :safeguarding_information_provided, :safeguarding_information, :further_details_provided, :further_details)
           .merge(completed_steps: completed_steps)
   end
 

--- a/app/form_models/publishers/job_listing/about_the_role_form.rb
+++ b/app/form_models/publishers/job_listing/about_the_role_form.rb
@@ -17,6 +17,7 @@ class Publishers::JobListing::AboutTheRoleForm < Publishers::JobListing::Vacancy
       ect_status
       skills_and_experience
       school_offer
+      flexi_working
       safeguarding_information_provided
       safeguarding_information
       further_details_provided

--- a/app/views/publishers/vacancies/build/about_the_role.html.slim
+++ b/app/views/publishers/vacancies/build/about_the_role.html.slim
@@ -46,7 +46,15 @@
                 required: true
 
       - else
-        = editor(form_input: f.govuk_text_area(:school_offer, label: { size: "s", id: "school-offer-label" }, rows: 5, required: true, aria: { hidden: false }), value: form.school_offer, field_name: "publishers_job_listing_about_the_role_form[school_offer]", hint: t("jobs.school_offer.hint"), label: { text: t("jobs.school_offer.publisher"), size: "s", id: "school-offer-label" })
+        = editor(form_input: f.govuk_text_area(:school_offer,
+          rows: 5, required: true, aria: { hidden: false }), value: form.school_offer,
+          field_name: "publishers_job_listing_about_the_role_form[school_offer]", hint: t("jobs.school_offer.hint"),
+          label: { text: t("jobs.school_offer.publisher"), size: "s", id: "school-offer-label" })
+
+      = editor(form_input: f.govuk_text_area(:flexi_working,
+        rows: 5, required: true, aria: { hidden: false }),
+        value: form.flexi_working, field_name: "publishers_job_listing_about_the_role_form[flexi_working]", hint: t("jobs.flexi_working.hint"),
+        label: { text: t("jobs.flexi_working.publisher"), size: "s" })
 
       - unless vacancy.job_advert.present?
         - if vacancy.safeguarding_information.present?

--- a/app/views/publishers/vacancies/vacancy_review_sections/_about_the_role.html.slim
+++ b/app/views/publishers/vacancies/vacancy_review_sections/_about_the_role.html.slim
@@ -58,6 +58,17 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
                     href: organisation_job_build_path(vacancy.id, :about_the_role, "back_to_#{action_name}": "true"),
                     visually_hidden_text: t("jobs.school_offer.publisher", organisation: vacancy.organisation.type.downcase)
 
+  - if vacancy.flexi_working.present?
+    - summary_list.with_row(html_attributes: { id: "flexi_working" }) do |row|
+      - row.with_key
+        = t("jobs.flexi_working.publisher")
+      - row.with_value
+        .editor-rendered-content == vacancy.flexi_working
+      - unless vacancy.legacy_draft?
+        - row.with_action text: t("buttons.change"),
+                    href: organisation_job_build_path(vacancy.id, :about_the_role, "back_to_#{action_name}": "true"),
+                    visually_hidden_text: t("jobs.flexi_working.publisher", organisation: vacancy.organisation.type.downcase)
+
   - if vacancy.safeguarding_information.present?
     - unless vacancy.safeguarding_information_provided.nil?
       - summary_list.with_row(html_attributes: { id: "safeguarding_information_provided" }) do |row|

--- a/app/views/vacancies/listing/_job_details.html.slim
+++ b/app/views/vacancies/listing/_job_details.html.slim
@@ -76,6 +76,10 @@ section#job-details class="govuk-!-margin-bottom-5"
     h2.govuk-heading-m = t("jobs.school_offer.jobseeker")
     .govuk-body.editor-rendered-content == vacancy.school_offer
 
+  - if vacancy.flexi_working.present?
+    h2.govuk-heading-m = t("jobs.flexi_working.jobseeker")
+    .govuk-body.editor-rendered-content == vacancy.flexi_working
+
   - if vacancy.further_details_provided?
     h2.govuk-heading-m = t("jobs.further_details")
     .govuk-body == vacancy.further_details

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -413,6 +413,7 @@ shared:
     - is_parental_leave_cover
     - is_job_share
     - hourly_rate
+    - flexi_working
   failed_imported_vacancies:
     - id
     - import_errors

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -188,6 +188,10 @@ en:
       jobseeker: What the school offers its staff
       publisher: What does your school offer?
       hint: Provide details about what your school can offer staff, for example, employee benefits, flexible working opportunities or professional development.
+    flexi_working:
+      hint: For example, remote working for planning, preparation and assessment (PPA) time, compressed hours or personal or family days
+      publisher: What flexible working opportunities can you offer?
+      jobseeker: What the school offers its staff around flexible working
     skills_and_experience:
       jobseeker: What skills and experience we're looking for
       publisher: What skills and experience are you looking for?

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -187,11 +187,11 @@ en:
     school_offer:
       jobseeker: What the school offers its staff
       publisher: What does your school offer?
-      hint: Provide details about what your school can offer staff, for example, employee benefits, flexible working opportunities or professional development.
+      hint: Provide details about what your school can offer staff, for example, employee benefits, wellbeing support or professional development.
     flexi_working:
       hint: For example, remote working for planning, preparation and assessment (PPA) time, compressed hours or personal or family days
       publisher: What flexible working opportunities can you offer?
-      jobseeker: What the school offers its staff around flexible working
+      jobseeker: Flexible working opportunities
     skills_and_experience:
       jobseeker: What skills and experience we're looking for
       publisher: What skills and experience are you looking for?

--- a/db/migrate/20240924144355_add_flexi_working_to_vacancy.rb
+++ b/db/migrate/20240924144355_add_flexi_working_to_vacancy.rb
@@ -1,0 +1,5 @@
+class AddFlexiWorkingToVacancy < ActiveRecord::Migration[7.1]
+  def change
+    add_column :vacancies, :flexi_working, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_05_135248) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_24_144355) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -680,8 +680,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_05_135248) do
     t.boolean "include_additional_documents"
     t.boolean "visa_sponsorship_available"
     t.boolean "is_parental_leave_cover"
-    t.string "hourly_rate"
     t.boolean "is_job_share"
+    t.string "hourly_rate"
+    t.string "flexi_working"
     t.index ["expires_at"], name: "index_vacancies_on_expires_at"
     t.index ["external_source", "external_reference"], name: "index_vacancies_on_external_source_and_external_reference"
     t.index ["geolocation", "expires_at", "publish_on"], name: "index_vacancies_on_geolocation_and_expires_at_and_publish_on", using: :gist

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -67,6 +67,7 @@ FactoryBot.define do
     visa_sponsorship_available { false }
     organisations { build_list(:school, 1) }
     is_job_share { [true, false].sample }
+    flexi_working { Faker::Lorem.sentence(word_count: factory_rand(50..150)) }
 
     trait :legacy_vacancy do
       about_school { Faker::Lorem.paragraph(sentence_count: factory_rand(5..10)) }

--- a/spec/jobs/import_from_vacancy_source_job_spec.rb
+++ b/spec/jobs/import_from_vacancy_source_job_spec.rb
@@ -81,6 +81,7 @@ RSpec.describe ImportFromVacancySourceJob do
               how_to_apply: "Click button",
               job_advert: "Aut repellat vel. Nesciunt exercitationem et. Numquam a corrupti. Et minus hic. Perspiciatis dolor neque. Sit est nemo. Ut ex officiis. Illum et mollitia. Quia qui qui. Debitis totam odio. Consequatur eum iste. Aut ex et. Quo explicabo quae. Aut id laborum. Occaecati quod sit. Laudantium ipsum placeat. Et sed nesciunt. Ut iste maxime. Ea repudiandae rem. Qui fugit adipisci. Vero fugiat dolor. Nesciunt eum et. Molestias nulla facere. Aliquid dolore assumenda. Aut repudiandae iusto. Quia aut maxime. Consequatur voluptates facere. Facere eius asperiores. Fugiat occaecati assumenda. Maiores consequatur architecto. Perferendis sint ut. Est odio dolorem. Aliquid fugiat iusto. Eaque fugiat voluptas. Eos velit assumenda. Nesciunt minus quia. Cupiditate vero dolor. Quos temporibus consequuntur. Vel cupiditate eos. Dolore dolores repellat. Ex ipsam consequuntur. Dolores harum voluptatem. Temporibus neque quis. Vero soluta sunt. Voluptas laboriosam modi. Quod ut nostrum. Veniam voluptatem et. Explicabo necessitatibus ex. Ut architecto placeat. Neque velit et.",
               visa_sponsorship_available: false,
+              flexi_working: "Debitis id voluptate cumque iusto quod ut libero facere repellendus est perspiciatis rem labore voluptatibus",
               is_job_share: true)
       end
 
@@ -121,6 +122,7 @@ RSpec.describe ImportFromVacancySourceJob do
           "external_reference" => "J3D1",
           "external_source" => "may_the_feed_be_with_you",
           "fixed_term_contract_duration" => "",
+          "flexi_working" => "Debitis id voluptate cumque iusto quod ut libero facere repellendus est perspiciatis rem labore voluptatibus",
           "full_time_details" => nil,
           "further_details" => "details",
           "further_details_provided" => true,

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -138,6 +138,7 @@ module VacancyHelpers
 
     fill_in "publishers_job_listing_about_the_role_form[skills_and_experience]", with: vacancy.skills_and_experience
     fill_in "publishers_job_listing_about_the_role_form[school_offer]", with: vacancy.school_offer
+    fill_in "publishers_job_listing_about_the_role_form[flexi_working]", with: vacancy.flexi_working
 
     # within ".safeguarding-information-provided-radios" do
     #   choose I18n.t("helpers.label.publishers_job_listing_about_the_role_form.safeguarding_information_provided_options.#{vacancy.safeguarding_information_provided}")
@@ -221,6 +222,7 @@ module VacancyHelpers
     expect(page).to have_content(strip_tags(vacancy.readable_ect_status)) if vacancy.ect_status.present?
     expect(page).to have_content(vacancy.skills_and_experience)
     expect(page).to have_content(vacancy.school_offer)
+    expect(page).to have_content(vacancy.flexi_working)
 
     if vacancy.organisation&.safeguarding_information.present?
       expect(page).to have_content(vacancy.organisation.safeguarding_information)


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/guCjce57/1241-add-flexi-working-box-on-about-the-role-page

## Changes in this PR:

- Is there anything specific you want feedback on?

## Screenshots of UI changes:

### Before
![BeforeFlexi](https://github.com/user-attachments/assets/57e36bd9-4bf3-4898-811f-8c1ae36ad67c)

### After
![AfterFlexiForm](https://github.com/user-attachments/assets/8c9b4d76-d1d8-4c62-be82-58a45f1d6839)
![AfterFlexi2](https://github.com/user-attachments/assets/c952e711-66b1-4d65-b729-03c0945edfe7)
![AfterFlexi3](https://github.com/user-attachments/assets/b70518be-036f-4195-919b-f32d5d2fd4f2)


## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
