### PR TITLE
Update DfE Analytics anonymised data API

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -31,9 +31,13 @@ class AuthenticationController < ApplicationController
       .with_response_details(response)
       .with_user(current_jobseeker)
       .with_data(
-        email_identifier: DfE::Analytics.anonymise(params.dig(:jobseeker, :email)),
-        success: success_or_failure == :success,
-        errors: errors,
+        data: {
+          success: success_or_failure == :success,
+          errors: errors,
+        },
+        hidden_data: {
+          email_identifier: params.dig(:jobseeker, :email),
+        },
       )
 
     DfE::Analytics::SendEvents.do([event])
@@ -45,7 +49,10 @@ class AuthenticationController < ApplicationController
       .with_request_details(request)
       .with_response_details(response)
       .with_user(current_publisher)
-      .with_data(user_anonymised_publisher_id: DfE::Analytics.anonymise(publisher_oid), sign_in_type: sign_in_type)
+      .with_data(
+        data: { sign_in_type: sign_in_type },
+        hidden_data: { user_anonymised_publisher_id: publisher_oid },
+      )
 
     DfE::Analytics::SendEvents.do([event])
   end
@@ -56,7 +63,10 @@ class AuthenticationController < ApplicationController
       .with_request_details(request)
       .with_response_details(response)
       .with_user(current_user)
-      .with_data(user_anonymised_id: DfE::Analytics.anonymise(oid), sign_in_type: sign_in_type)
+      .with_data(
+        data: { sign_in_type: sign_in_type },
+        hidden_data: { user_anonymised_id: oid },
+      )
 
     DfE::Analytics::SendEvents.do([event])
   end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -140,17 +140,20 @@ class SubscriptionsController < ApplicationController
 
   def trigger_subscription_event(type, subscription)
     event_data = {
-      autopopulated: session.delete(:subscription_autopopulated),
-      email_identifier: StringAnonymiser.new(subscription.email).to_s,
-      frequency: subscription.frequency,
-      recaptcha_score: subscription.recaptcha_score,
-      search_criteria: subscription.search_criteria,
-      subscription_identifier: subscription.id,
+      data: {
+        autopopulated: session.delete(:subscription_autopopulated),
+        frequency: subscription.frequency,
+        recaptcha_score: subscription.recaptcha_score,
+        search_criteria: subscription.search_criteria,
+        subscription_identifier: subscription.id,
+      },
+      hidden_data: {
+        email_identifier: subscription.email,
+      },
+
     }
 
-    dfe_analytics_event_data = event_data.merge(email_identifier: DfE::Analytics.anonymise(subscription.email))
-
-    trigger_dfe_analytics_event(type, dfe_analytics_event_data)
+    trigger_dfe_analytics_event(type, event_data)
   end
 
   def email

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -50,17 +50,19 @@ class VacanciesController < ApplicationController
 
   def trigger_search_performed_event
     fail_safe do
-      polygon_id = DfE::Analytics.anonymise(@vacancies_search.polygon.id) if @vacancies_search.polygon
-
       event_data = {
-        search_criteria: form.to_hash,
-        sort_by: form.sort.by,
-        page: params[:page] || 1,
-        total_count: @vacancies_search.total_count,
-        vacancies_on_page: @vacancies.map(&:id),
-        location_polygon_used: polygon_id,
-        landing_page: params[:landing_page_slug],
-        filters_set_from_keywords: form.filters_from_keyword.present?,
+        data: {
+          search_criteria: form.to_hash,
+          sort_by: form.sort.by,
+          page: params[:page] || 1,
+          total_count: @vacancies_search.total_count,
+          vacancies_on_page: @vacancies.map(&:id),
+          landing_page: params[:landing_page_slug],
+          filters_set_from_keywords: form.filters_from_keyword.present?,
+        },
+        event_hidden_data: {
+          location_polygon_used: @vacancies_search&.polygon&.id,
+        },
       }
 
       trigger_dfe_analytics_event(:search_performed, event_data)
@@ -73,7 +75,7 @@ class VacanciesController < ApplicationController
       .with_request_details(request)
       .with_response_details(response)
       .with_user(current_jobseeker)
-      .with_data(event_data)
+      .with_data(data: event_data)
 
     DfE::Analytics::SendEvents.do([event])
   end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -35,14 +35,20 @@ class ApplicationMailer < Mail::Notify::Mailer
   end
 
   def dfe_analytics_event_data
-    dfe_analytics_base_data.merge(dfe_analytics_custom_data)
+    base_data = dfe_analytics_base_data
+    base_data[:data].merge!(dfe_analytics_custom_data)
+    base_data
   end
 
   def dfe_analytics_base_data
     {
-      uid: uid,
-      notify_template: template,
-      email_identifier: DfE::Analytics.anonymise(to),
+      data: {
+        uid: uid,
+        notify_template: template,
+      },
+      hidden_data: {
+        email_identifier: to,
+      },
     }
   end
 end


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/b1qFprqI/1236-hidden-pii-dev-work-tuesday-24th

## Changes in this PR:

This change aligns bespoke analytics events with the latest gem version API, which uses slightly different syntax.