### PR TITLE
Change copy on employment history section of job application

### DIFF
--- a/app/views/jobseekers/job_applications/build/employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/build/employment_history.html.slim
@@ -16,6 +16,9 @@
           li = job_bullet
       p.govuk-body = t(".description.work_experience_advice")
       p.govuk-body = t(".description.gaps_advice")
+      ul.govuk-list.govuk-list--bullet
+        - t(".description.gaps_bullets").each do |gap_bullet|
+          li = gap_bullet
       p.govuk-body = t(".description.reasons")
       p.govuk-body
         = govuk_button_link_to t("buttons.add_work_history"), new_jobseekers_job_application_employment_path(job_application), class: "govuk-button--secondary govuk-!-margin-bottom-10 employment-gap-buttons"

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -131,7 +131,11 @@ en:
               - all paid roles
               - voluntary work, if relevant to your application
             work_experience_advice: If you’re applying for a teaching job, you should include teaching and other experience, if you have it. 
-            gaps_advice: You’ll also need to explain any gaps in your work history, including between finishing full-time education and starting work.
+            gaps_advice: "You’ll also need to explain any gaps in your work history. This includes any gaps between:"
+            gaps_bullets:
+              - school and university
+              - university and employment
+              - different forms of employment
             reasons: You’ll need to provide the reason you left each role.
             gaps: >-
               If you had a gap between finishing full-time education and starting work that you have not explained then please %{link} to give details about it


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/sWczsVCi/1245-content-tweak-on-work-history-gaps

## Changes in this PR:

Change content on work history section of job applications

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
