### PR TITLE
Sign-out Jobseekers through Govuk OneLogin

### DIFF
--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -12,7 +12,7 @@
     = header.with_navigation_item text: t("nav.create_a_job_alert"), href: new_subscription_path
     = header.with_navigation_item text: t("nav.your_profile"), href: jobseekers_profile_path
     = header.with_navigation_item text: t("nav.your_account"), href: jobseekers_account_path, active: your_account_active?
-    = header.with_navigation_item text: t("nav.sign_out"), href: destroy_jobseeker_session_path, options: { method: :delete }
+    = header.with_navigation_item text: t("nav.sign_out"), href: jobseeker_logout_uri.to_s
   - elsif support_user_signed_in?
     = header.with_navigation_item text: t("nav.support_user_dashboard"), href: support_user_root_path, active: current_page?(support_user_root_path)
     = header.with_navigation_item text: t("nav.sign_out"), href: destroy_support_user_session_path, options: { method: :delete }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -268,6 +268,7 @@ Rails.application.routes.draw do
   scope path: "jobseekers" do
     devise_scope :jobseeker do
       get "/auth/govuk_one_login/callback/", to: "jobseekers/govuk_one_login_callbacks#openid_connect"
+      get "/sign_out", to: "jobseekers/sessions#destroy", as: :jobseekers_sign_out # Handle GovukOneLogin sign out 'post_logout_redirect_uri'
     end
   end
 

--- a/spec/system/jobseekers/jobseekers_can_sign_out_from_their_account_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_sign_out_from_their_account_spec.rb
@@ -10,8 +10,24 @@ RSpec.describe "Jobseekers can sign out from their account" do
   scenario "signing out takes them to sign in page with banner" do
     visit root_path
     within(".govuk-header__navigation") do
-      click_on I18n.t("nav.sign_out")
+      expect(page).to have_link(I18n.t("nav.sign_out"),
+                                href: /^#{Jobseekers::GovukOneLogin::ENDPOINTS[:logout]}.*post_logout_redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fjobseekers%2Fsign_out/)
     end
+
+    one_login_logout_url = find("a", text: I18n.t("nav.sign_out"))[:href]
+
+    stub_request(:get, Jobseekers::GovukOneLogin::ENDPOINTS[:logout])
+      .with(query: hash_including({}))
+      .to_return(status: 301, headers: { "Location" => "http://localhost:3000/jobseekers/sign_out&state=e333acc9-652d-4cc1-9893-7841e31cb7a5" })
+
+    # The rack_test driver doesn't support requests to external urls (the domain info is just ignored and all paths are
+    # routed directly to the AUT)
+    # https://stackoverflow.com/questions/49171142/rspec-capybara-redirect-to-external-page-sends-me-back-to-root-path
+    # Simulates the external request directly
+    Net::HTTP.get(URI(one_login_logout_url))
+    expect(a_request(:get, Jobseekers::GovukOneLogin::ENDPOINTS[:logout]).with(query: hash_including({}))).to have_been_made.once
+    # Simulate the callback response from GovUK One Login
+    visit jobseekers_sign_out_path
 
     expect(current_path).to eq(new_jobseeker_session_path)
     expect(page).to have_content(I18n.t("devise.sessions.signed_out"))


### PR DESCRIPTION
We had already built the endpoint and uri helpers to use the GovUK OneLogin /logout endpoint, but the "Sign Out" link in our navigation bar was still directly destroying the session through Devise.

The behaviour caused the jobseeker to be signed out from our service, but still signed-in in GovUK OneLogin. This caused the next sign-in attempt to directly redirect back the jobseeker signed in our service without having been prompted to any security user/password check by OneLogin service.

We have fixed this by:
- Replacing the navigation Sign Out button to send the user to the /logout endpoint in GovUK One Login. This signs them out from OneLogin.
- Ensuring OneLogin redirects the user back to our internal session destroy endpoint. So the user session in our service is also signed out.

To achieve this, we had to enable a new route, to accept GET requests to the session-destroying endpoint (defaults to DESTROY).

## Screenshots

### The navigation "Sign Out" link now points to GovUK OneLogin URL
![Screenshot From 2024-09-30 17-56-37](https://github.com/user-attachments/assets/11a1da13-f3fb-4f74-a71f-98ebfa844c20)

![Screenshot From 2024-09-30 17-56-55](https://github.com/user-attachments/assets/d80f4a5b-f230-4870-9ee5-fa54fee023e9)

### After following the link the user gets sent back and signed out from our service

![Screenshot From 2024-09-30 17-57-12](https://github.com/user-attachments/assets/1f0a72c3-dd15-4e1a-968a-cb0ea6812bee)
