### PR TITLE
Cache result of hitting Google places API 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby "3.3.5"
 RAILS_VERSION = "~> 7.1.2".freeze
 gem "actionmailer", RAILS_VERSION
 gem "actionpack", RAILS_VERSION
+gem "actionpack-action_caching"
 gem "actiontext", RAILS_VERSION
 gem "activejob", RAILS_VERSION
 gem "activemodel", RAILS_VERSION

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,8 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    actionpack-action_caching (1.2.2)
+      actionpack (>= 4.0.0)
     actiontext (7.1.4)
       actionpack (= 7.1.4)
       activerecord (= 7.1.4)
@@ -745,6 +747,7 @@ PLATFORMS
 DEPENDENCIES
   actionmailer (~> 7.1.2)
   actionpack (~> 7.1.2)
+  actionpack-action_caching
   actiontext (~> 7.1.2)
   activejob (~> 7.1.2)
   activemodel (~> 7.1.2)

--- a/app/controllers/api/location_suggestion_controller.rb
+++ b/app/controllers/api/location_suggestion_controller.rb
@@ -2,6 +2,9 @@ class Api::LocationSuggestionController < Api::ApplicationController
   before_action :verify_json_request, only: %i[show]
   before_action :check_valid_params, only: %i[show]
 
+  # Try to reduce our Google Places API bill
+  caches_action :show
+
   def show
     begin
       suggestions, matched_terms = LocationSuggestion.new(location).suggest_locations


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/3azRNTRs/1260-google-places-api-can-we-cache-the-queries

## Changes in this PR:

Cache result of hitting Google places API 

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
