### PR TITLE
Change error message for invalid email addresses

### DIFF
--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -4,8 +4,8 @@ en:
       inclusion: Please select an option for the additional cookies
   email_errors: &email_errors
     email:
-      blank: Enter an email address in the correct format, like name@example.com
-      invalid: Enter an email address in the correct format, like name@example.com
+      blank: Enter a valid email address in the correct format, like name@example.com
+      invalid: Enter a valid email address in the correct format, like name@example.com
   qualification_errors: &qualification_errors
     qualification_results_attributes_0_subject:
       at_least_one_result_required: Enter at least one subject and grade for this qualification
@@ -29,13 +29,13 @@ en:
   subscription_errors: &subscription_errors
     email:
       blank: Enter your email address
-      invalid: Enter an email address in the correct format, like name@example.com
+      invalid: Enter a valid email address in the correct format, like name@example.com
     frequency:
       blank: Select when you want to receive job alert emails
   unsubscribe_feedback_errors: &unsubscribe_feedback_errors
     email:
       blank: Enter your email address
-      invalid: Enter an email address in the correct format, like name@example.com
+      invalid: Enter a valid email address in the correct format, like name@example.com
     occupation:
       blank: Enter your occupation
       too_long: Occupation must not be more than 30 characters
@@ -54,7 +54,7 @@ en:
       too_long: Feedback must not be more than 1,200 characters
     email:
       blank: Enter your email address
-      invalid: Enter an email address in the correct format, like name@example.com
+      invalid: Enter a valid email address in the correct format, like name@example.com
     rating:
       inclusion: Select how satisfied or dissatisfied you are
     report_a_problem:
@@ -69,7 +69,7 @@ en:
       inclusion: Please indicate if you'd like to participate in user research
     email:
       blank: Enter your email address
-      invalid: Enter an email address in the correct format, like name@example.com
+      invalid: Enter a valid email address in the correct format, like name@example.com
     occupation:
       blank: Enter your occupation
       too_long: Occupation must not be more than 30 characters
@@ -93,7 +93,7 @@ en:
   jobseekers_job_application_feedback_form: &jobseekers_job_application_feedback_form_errors
     email:
       blank: Enter your email address
-      invalid: Enter an email address in the correct format, like name@example.com
+      invalid: Enter a valid email address in the correct format, like name@example.com
     occupation:
       blank: Enter your occupation
       too_long: Occupation must not be more than 30 characters
@@ -106,7 +106,7 @@ en:
   publisher_job_listing_feedback_form: &publisher_job_listing_feedback_form_errors
     email:
       blank: Enter your email address
-      invalid: Enter an email address in the correct format, like name@example.com
+      invalid: Enter a valid email address in the correct format, like name@example.com
     occupation:
       blank: Enter your occupation
       too_long: Occupation must not be more than 30 characters
@@ -245,12 +245,12 @@ en:
   application_form_errors: &application_form_errors
     application_email:
       blank: Select the email address to receive applications
-      invalid: Enter an email address in the correct format, like name@example.com
+      invalid: Enter a valid email address in the correct format, like name@example.com
     application_form:
       blank: Select application form
     other_application_email:
       blank: Enter an email address
-      invalid: Enter an email address in the correct format, like name@example.com
+      invalid: Enter a valid email address in the correct format, like name@example.com
   application_link_errors: &application_link_errors
     application_link:
       blank: Enter the link to the application website
@@ -261,7 +261,7 @@ en:
   contact_details_errors: &contact_details_errors
     contact_email:
       blank: Enter an email address
-      invalid: Enter an email address in the correct format, like name@example.com
+      invalid: Enter a valid email address in the correct format, like name@example.com
     contact_number:
       blank: Enter a phone number
       invalid: Enter a phone number in the correct format
@@ -269,7 +269,7 @@ en:
       inclusion: Select yes if you want to give a contact phone number
     other_contact_email:
       blank: Enter an email address
-      invalid: Enter an email address in the correct format, like name@example.com
+      invalid: Enter a valid email address in the correct format, like name@example.com
   about_the_role_errors: &about_the_role_errors
     about_school:
       blank: Enter a description of the %{organisation}
@@ -527,7 +527,7 @@ en:
               blank: Enter your country
             email_address:
               blank: Enter your email address
-              invalid: Enter an email address in the correct format, like name@example.com
+              invalid: Enter a valid email address in the correct format, like name@example.com
             first_name:
               blank: Enter your first name
             last_name:
@@ -669,7 +669,7 @@ en:
           attributes:
             email:
               blank: Enter your referee's email address
-              invalid: Enter an email address in the correct format, like name@example.com
+              invalid: Enter a valid email address in the correct format, like name@example.com
             job_title:
               blank: Enter your referee's job title
             name:
@@ -733,12 +733,12 @@ en:
           attributes:
             email: 
               blank: Enter your email address
-              invalid: Enter an email address in the correct format, like name@example.com
+              invalid: Enter a valid email address in the correct format, like name@example.com
         jobseekers/request_account_transfer_email_form:
           attributes:
             email:
               blank: Enter your email address
-              invalid: Enter an email address in the correct format, like name@example.com
+              invalid: Enter a valid email address in the correct format, like name@example.com
             recent_code_request: XYZ
 
 
@@ -752,7 +752,7 @@ en:
           attributes:
             email_address:
               blank: Enter your email address
-              invalid: Enter an email address in the correct format, like name@example.com
+              invalid: Enter a valid email address in the correct format, like name@example.com
             is_for_whole_site:
               inclusion: Choose whether this issue is for the whole site or a specific page
             issue:
@@ -772,7 +772,7 @@ en:
           attributes:
             email:
               blank: Enter your email address
-              invalid: Enter an email address in the correct format, like name@example.com
+              invalid: Enter a valid email address in the correct format, like name@example.com
               not_found: Email address is not valid or the account was not created
               same_as_old: Your new email can't be the same as your old email
               taken: This email seems to already have an account with Teaching Vacancies

--- a/spec/system/jobseekers/jobseekers_can_transfer_data_from_old_account_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_transfer_data_from_old_account_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Jobseekers can transfer data from an old account" do
       click_on "Save and continue"
       expect(page).to have_css("ul.govuk-list.govuk-error-summary__list")
       within "ul.govuk-list.govuk-error-summary__list" do
-        expect(page).to have_link("Enter an email address in the correct format, like name@example.com", href: "#jobseekers-request-account-transfer-email-form-email-field-error")
+        expect(page).to have_link("Enter a valid email address in the correct format, like name@example.com", href: "#jobseekers-request-account-transfer-email-form-email-field-error")
       end
 
       fill_in "jobseekers_request_account_transfer_email_form[email]", with: old_jobseeker_account.email


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/XzUDl2V7/1252-update-email-field-error-message-on-job-alerts-form

## Changes in this PR:

This PR slightly changes the wording on the invalid email address errors.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
