### PR TITLE
Creating service eligibility page

### DIFF
--- a/app/views/content/get-help-hiring/how-to-setup-your-account/check-your-eligibility-to-advertise-roles.md
+++ b/app/views/content/get-help-hiring/how-to-setup-your-account/check-your-eligibility-to-advertise-roles.md
@@ -1,0 +1,50 @@
+---
+order: 300
+title: Check your eligibility to advertise roles
+meta_description: Check if your school or trust is eligible to advertise roles on Teaching Vacancies.
+date_posted: 02/10/2024
+category_tags: how-to
+card-image: "/content-assets/get-help-hiring/how-to-setup-your-account/how-mat-can-use-TV.png"
+---
+
+
+To advertise your roles on Teaching Vacancies, you must be:
+
+* based in England
+
+* a state-funded school (or contain a state-funded school within your trust)
+
+
+You can [find out what type of school you work in](https://get-information-schools.service.gov.uk/). 
+
+## Eligible school types
+
+Table?
+
+## Establishments not eligible to list roles
+
+You cannot advertise roles on Teaching Vacancies if you are a:
+
+* British overseas school 
+
+* further education college 
+
+* higher education institution 
+
+* independent school 
+
+* independent special school 
+
+* institution funded by another government department 
+
+* offshore schools 
+
+* online provider 
+
+* service children’s education 
+
+* special post 16 institution 
+
+* Welsh establishment 
+
+For further support on if you are eligible to list your roles on Teaching Vacancies, [contact us](https://teaching-vacancies.service.gov.uk/support_request/new). 

--- a/app/views/content/get-help-hiring/how-to-setup-your-account/check-your-eligibility-to-advertise-roles.md
+++ b/app/views/content/get-help-hiring/how-to-setup-your-account/check-your-eligibility-to-advertise-roles.md
@@ -14,7 +14,7 @@ To advertise your roles on Teaching Vacancies, you must be:
 * a state-funded school (or contain a state-funded school within your trust)
 
 
-You can [find out what type of school you work in](https://get-information-schools.service.gov.uk/). 
+You can [find out what type of establishment you work in](https://get-information-schools.service.gov.uk/). 
 
 ## Eligible establishments
 

--- a/app/views/content/get-help-hiring/how-to-setup-your-account/check-your-eligibility-to-advertise-roles.md
+++ b/app/views/content/get-help-hiring/how-to-setup-your-account/check-your-eligibility-to-advertise-roles.md
@@ -18,7 +18,7 @@ You can [find out what type of establishment you work in](https://get-informatio
 
 ## Eligible establishments
 
-You can list roles on Teaching Vacancies if you are a:
+You can advertise roles on Teaching Vacancies if you are a:
 
 * academy 16 to 19 converter
 * academy 16 to 19 sponsor led
@@ -47,7 +47,7 @@ You can list roles on Teaching Vacancies if you are a:
 * voluntary aided school
 * voluntary controlled school
 
-## Establishments not eligible to list roles
+## Establishments not eligible to advertise roles
 
 You cannot advertise roles on Teaching Vacancies if you are a:
 
@@ -65,4 +65,4 @@ You cannot advertise roles on Teaching Vacancies if you are a:
 
 ## Get support
 
-For further support on if you are eligible to list your roles on Teaching Vacancies, [contact us](https://teaching-vacancies.service.gov.uk/support_request/new). 
+For further support on if you are eligible to advertise your roles on Teaching Vacancies, [contact us](https://teaching-vacancies.service.gov.uk/support_request/new). 

--- a/app/views/content/get-help-hiring/how-to-setup-your-account/check-your-eligibility-to-advertise-roles.md
+++ b/app/views/content/get-help-hiring/how-to-setup-your-account/check-your-eligibility-to-advertise-roles.md
@@ -52,26 +52,28 @@ You can list roles on Teaching Vacancies if you are a:
 
 You cannot advertise roles on Teaching Vacancies if you are a:
 
-* British overseas school 
+* British overseas school
 
-* further education college 
+* further education college
 
-* higher education institution 
+* higher education institution
 
-* independent school 
+* independent school
 
-* independent special school 
+* independent special school
 
-* institution funded by another government department 
+* institution funded by another government department
 
-* offshore schools 
+* offshore schools
 
-* online provider 
+* online provider
 
-* service children’s education 
+* service children’s education
 
-* special post 16 institution 
+* special post 16 institution
 
-* Welsh establishment 
+* Welsh establishment
+
+## Get support
 
 For further support on if you are eligible to list your roles on Teaching Vacancies, [contact us](https://teaching-vacancies.service.gov.uk/support_request/new). 

--- a/app/views/content/get-help-hiring/how-to-setup-your-account/check-your-eligibility-to-advertise-roles.md
+++ b/app/views/content/get-help-hiring/how-to-setup-your-account/check-your-eligibility-to-advertise-roles.md
@@ -4,7 +4,7 @@ title: Check your eligibility to advertise roles
 meta_description: Check if your school or trust is eligible to advertise roles on Teaching Vacancies.
 date_posted: 02/10/2024
 category_tags: how-to
-card-image: "/content-assets/get-help-hiring/how-to-setup-your-account/how-mat-can-use-TV.png"
+card-image: "/content-assets/get-help-hiring/how-to-setup-your-account/check-your-eligibility.png"
 ---
 
 

--- a/app/views/content/get-help-hiring/how-to-setup-your-account/check-your-eligibility-to-advertise-roles.md
+++ b/app/views/content/get-help-hiring/how-to-setup-your-account/check-your-eligibility-to-advertise-roles.md
@@ -16,7 +16,7 @@ To advertise your roles on Teaching Vacancies, you must be:
 
 You can [find out what type of school you work in](https://get-information-schools.service.gov.uk/). 
 
-## Eligible school types
+## Eligible establishments
 
 You can list roles on Teaching Vacancies if you are a:
 

--- a/app/views/content/get-help-hiring/how-to-setup-your-account/check-your-eligibility-to-advertise-roles.md
+++ b/app/views/content/get-help-hiring/how-to-setup-your-account/check-your-eligibility-to-advertise-roles.md
@@ -11,7 +11,6 @@ card-image: "/content-assets/get-help-hiring/how-to-setup-your-account/check-you
 To advertise your roles on Teaching Vacancies, you must be:
 
 * based in England
-
 * a state-funded school (or contain a state-funded school within your trust)
 
 

--- a/app/views/content/get-help-hiring/how-to-setup-your-account/check-your-eligibility-to-advertise-roles.md
+++ b/app/views/content/get-help-hiring/how-to-setup-your-account/check-your-eligibility-to-advertise-roles.md
@@ -19,7 +19,34 @@ You can [find out what type of school you work in](https://get-information-schoo
 
 ## Eligible school types
 
-Table?
+| Type of school |
+| --------------- |
+| Academy 16 to 19 converter |
+| Academy 16 to 19 sponsor led |
+| Academy alternative provision converter |
+| Academy alternative provision sponsor led |
+| Academy converter |
+| Academy special converter |
+| Academy special sponsor led |
+| Academy sponsor led |
+| City technology college |
+| Community school |
+| Community special school |
+| Foundation school |
+| Foundation special school |
+| Free schools 16 to 19 |
+| Free schools alternative provision |
+| Free schools special |
+| Free schools |
+| Local authority nursery school |
+| Non-maintained special school |
+| Pupil referral unit |
+| Secure units |
+| Sixth form centres |
+| Studio schools |
+| University technical college |
+| Voluntary aided school |
+| Voluntary controlled school |
 
 ## Establishments not eligible to list roles
 

--- a/app/views/content/get-help-hiring/how-to-setup-your-account/check-your-eligibility-to-advertise-roles.md
+++ b/app/views/content/get-help-hiring/how-to-setup-your-account/check-your-eligibility-to-advertise-roles.md
@@ -53,25 +53,15 @@ You can list roles on Teaching Vacancies if you are a:
 You cannot advertise roles on Teaching Vacancies if you are a:
 
 * British overseas school
-
 * further education college
-
 * higher education institution
-
 * independent school
-
 * independent special school
-
 * institution funded by another government department
-
 * offshore schools
-
 * online provider
-
 * service children’s education
-
 * special post 16 institution
-
 * Welsh establishment
 
 ## Get support

--- a/app/views/content/get-help-hiring/how-to-setup-your-account/check-your-eligibility-to-advertise-roles.md
+++ b/app/views/content/get-help-hiring/how-to-setup-your-account/check-your-eligibility-to-advertise-roles.md
@@ -19,34 +19,34 @@ You can [find out what type of school you work in](https://get-information-schoo
 
 ## Eligible school types
 
-| Type of school |
-| --------------- |
-| Academy 16 to 19 converter |
-| Academy 16 to 19 sponsor led |
-| Academy alternative provision converter |
-| Academy alternative provision sponsor led |
-| Academy converter |
-| Academy special converter |
-| Academy special sponsor led |
-| Academy sponsor led |
-| City technology college |
-| Community school |
-| Community special school |
-| Foundation school |
-| Foundation special school |
-| Free schools 16 to 19 |
-| Free schools alternative provision |
-| Free schools special |
-| Free schools |
-| Local authority nursery school |
-| Non-maintained special school |
-| Pupil referral unit |
-| Secure units |
-| Sixth form centres |
-| Studio schools |
-| University technical college |
-| Voluntary aided school |
-| Voluntary controlled school |
+You can list roles on Teaching Vacancies if you are a:
+
+* academy 16 to 19 converter
+* academy 16 to 19 sponsor led
+* academy alternative provision converter
+* academy alternative provision sponsor led
+* academy converter
+* academy special converter
+* academy special sponsor led
+* academy sponsor led
+* city technology college
+* community school
+* community special school
+* foundation school
+* foundation special school
+* free school 16 to 19
+* free school alternative provision
+* free school special
+* free school
+* local authority nursery school
+* non-maintained special school
+* pupil referral unit
+* secure unit
+* sixth form centre
+* studio school
+* university technical college
+* voluntary aided school
+* voluntary controlled school
 
 ## Establishments not eligible to list roles
 

--- a/app/views/content/get-help-hiring/how-to-setup-your-account/how-mats-can-use-teaching-vacancies.md
+++ b/app/views/content/get-help-hiring/how-to-setup-your-account/how-mats-can-use-teaching-vacancies.md
@@ -1,5 +1,5 @@
 ---
-order: 500
+order: 600
 title: How multi-academy trusts can use Teaching Vacancies
 meta_description: Multi-academy trusts can use Teaching Vacancies to manage roles across all of their locations. Find out how to manage applications and MAT information.
 date_posted: 05/07/2022

--- a/app/views/content/get-help-hiring/how-to-setup-your-account/how-to-approve-access-for-hiring-staff.md
+++ b/app/views/content/get-help-hiring/how-to-setup-your-account/how-to-approve-access-for-hiring-staff.md
@@ -1,5 +1,5 @@
 ---
-order: 300
+order: 400
 title: How to approve access for hiring staff
 meta_description: Organisation approvers are able to manage who has access to post jobs on the Teaching Vacancies service. Find out how to add, manage and remove users.
 date_posted: 20/04/2022

--- a/app/views/content/get-help-hiring/how-to-setup-your-account/how-to-request-organisation-access.md
+++ b/app/views/content/get-help-hiring/how-to-setup-your-account/how-to-request-organisation-access.md
@@ -1,5 +1,5 @@
 ---
-order: 400
+order: 500
 title: How to request organisation access
 meta_description: To post jobs on Teaching Vacancies, you need access to the right organisation. Find out how to make a request and get approved for one or multiple schools.
 date_posted: 20/04/2022

--- a/app/views/pages/dsi-account-request.html.slim
+++ b/app/views/pages/dsi-account-request.html.slim
@@ -18,6 +18,7 @@
     ul.govuk-list.govuk-list--bullet class="govuk-!-margin-bottom-8"
       li at a state-funded school or trust in England, or
       li if you work at a local authority and list job vacancies on behalf of schools
+    p.govuk-body #{govuk_link_to("Check you're eligible to list roles on Teaching Vacancies", "https://teaching-vacancies.service.gov.uk/get-help-hiring/how-to-setup-your-account/check-your-eligibility-to-advertise-roles")}.
 
     = dsi_account_request_link
 

--- a/app/views/pages/dsi-account-request.html.slim
+++ b/app/views/pages/dsi-account-request.html.slim
@@ -18,7 +18,7 @@
     ul.govuk-list.govuk-list--bullet class="govuk-!-margin-bottom-8"
       li at a state-funded school or trust in England, or
       li if you work at a local authority and list job vacancies on behalf of schools
-    p.govuk-body #{govuk_link_to("Check you're eligible to list roles on Teaching Vacancies", "https://teaching-vacancies.service.gov.uk/get-help-hiring/how-to-setup-your-account/check-your-eligibility-to-advertise-roles")}.
+    p.govuk-body #{govuk_link_to("Check you're eligible to list roles on Teaching Vacancies", "/get-help-hiring/how-to-setup-your-account/check-your-eligibility-to-advertise-roles")}.
 
     = dsi_account_request_link
 

--- a/app/views/pages/dsi-account-request.html.slim
+++ b/app/views/pages/dsi-account-request.html.slim
@@ -15,10 +15,10 @@
 
     p.govuk-body You can request an account if you work:
 
-    ul.govuk-list.govuk-list--bullet class="govuk-!-margin-bottom-8"
+    ul.govuk-list.govuk-list--bullet class="govuk-!-margin-bottom-4"
       li at a state-funded school or trust in England, or
       li if you work at a local authority and list job vacancies on behalf of schools
-    p.govuk-body #{govuk_link_to("Check you're eligible to list roles on Teaching Vacancies", "/get-help-hiring/how-to-setup-your-account/check-your-eligibility-to-advertise-roles")}.
+    p.govuk-body #{govuk_link_to("Check you're eligible to advertise roles on Teaching Vacancies", "/get-help-hiring/how-to-setup-your-account/check-your-eligibility-to-advertise-roles")}.
 
     = dsi_account_request_link
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -230,9 +230,9 @@ en:
     subcategory:
       get-help-hiring:
         how-to-create-job-listings-and-accept-applications: >-
-          Get support using your account
+          Get support using your account.
         how-to-setup-your-account: >-
-          Get support setting up your account
+          Get support setting up your account.
       jobseeker-guides:
         get-help-applying-for-your-teaching-role: >-
           Get advice from experienced teachers and school leaders on applying for your teaching role.

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -89,6 +89,7 @@ RSpec.describe PostsController do
             how-to-request-organisation-access
             how-mats-can-use-teaching-vacancies
             how-to-approve-access-for-hiring-staff
+            check-your-eligibility-to-advertise-roles
           ]
         end
 


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/K0ZTq1Us/1217-add-service-eligibility-to-site

## Changes in this PR:

Support desk often get asked by schools if they're eligible to advertise roles on TV.

This PR is to add the eligibility info onto the site.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
