### PR TITLE
Update DfE Analytics search_performed event

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -75,7 +75,7 @@ class VacanciesController < ApplicationController
       .with_request_details(request)
       .with_response_details(response)
       .with_user(current_jobseeker)
-      .with_data(data: event_data)
+      .with_data(event_data)
 
     DfE::Analytics::SendEvents.do([event])
   end


### PR DESCRIPTION
The serialisation of the search_performed DfE Analytics event has an issue: the data is nested one level too deep when sent to Big Query. This change addresses that issue. 