### PR TITLE
Fix login prompt after creating a subscription

### DIFF
--- a/app/views/subscriptions/_jobseeker_account_prompt.html.slim
+++ b/app/views/subscriptions/_jobseeker_account_prompt.html.slim
@@ -3,35 +3,11 @@
     h1.govuk-heading-l class="govuk-!-margin-bottom-5" = t(".heading.sign_in")
     p.govuk-body = t(".body.sign_in")
 
-    .govuk-grid-row
-      .govuk-grid-column-two-thirds
-        = form_for @jobseeker, url: jobseeker_session_path, method: :post do |f|
-          .govuk-heading-s class="govuk-!-margin-bottom-2"
-            = t(".form.email_address")
-          .govuk-body = @subscription.email
-
-          = f.hidden_field :email, value: @subscription.email
-          = f.govuk_password_field :password,
-                                   label: { text: t("helpers.label.jobseekers_sign_in_form.password"), size: "s" },
-                                   hint: nil,
-                                   autocomplete: "current-password"
-          = hidden_field_tag :redirected, true
-
-          = f.govuk_submit t("buttons.sign_in")
+    = govuk_button_link_to t("buttons.sign_in"), new_jobseeker_session_path(redirected: true)
 
 - else
   div data-account-prompt="sign-up"
     h1.govuk-heading-l class="govuk-!-margin-bottom-5" = t(".heading.sign_up")
     p.govuk-body = t(".body.sign_up")
 
-    .govuk-grid-row
-      .govuk-grid-column-two-thirds
-        = form_for Jobseeker.new, as: :jobseeker, url: jobseeker_registration_path, method: :post do |f|
-          .govuk-heading-s class="govuk-!-margin-bottom-2"
-            = t(".form.email_address")
-          .govuk-body = @subscription.email
-
-          = f.hidden_field :email, value: @subscription.email
-          = f.govuk_password_field :password, label: { size: "s" }, autocomplete: "new-password"
-
-          = f.govuk_submit t("buttons.create_account"), class: "govuk-!-margin-bottom-0"
+  = govuk_button_link_to t("buttons.create_account"), new_jobseeker_session_path(redirected: true)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -383,14 +383,9 @@ en:
       body:
         sign_in: Sign in to see all your job alerts in one place and save the jobs you are interested in.
         sign_up: Create an account to see all your job alerts in one place and save the jobs you are interested in.
-      form:
-        email_address: Email address
       heading:
         sign_in: Sign in to your Teaching Vacancies account
         sign_up: Create a Teaching Vacancies account
-      link:
-        sign_in: Sign in
-        sign_up: Create an account
     link:
       help_text_html: "%{link} whenever a job matching this search is listed."
       home_page: Visit %{home_page_link}

--- a/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
@@ -49,23 +49,10 @@ RSpec.describe "Jobseekers can create a job alert from a search", recaptcha: tru
       end
 
       context "when jobseeker is signed out" do
-        scenario "renders a sign in prompt form that redirects to job alerts dashboard" do
+        scenario "renders a sign in prompt that sends the user to GovUK One Login and redirects them back to the job alerts dashboard" do
           within "div[data-account-prompt='sign-in']" do
             expect(page).to have_content(I18n.t("subscriptions.jobseeker_account_prompt.heading.sign_in"))
-            fill_in "Password", with: jobseeker.password
-            within(".edit_jobseeker") do
-              click_on I18n.t("buttons.sign_in")
-            end
-          end
-          expect(current_path).to eq(jobseekers_subscriptions_path)
-        end
-
-        scenario "renders a sign in prompt form that redirects to sign in page on error then redirects to job alerts dashboard" do
-          within "div[data-account-prompt='sign-in']" do
-            expect(page).to have_content(I18n.t("subscriptions.jobseeker_account_prompt.heading.sign_in"))
-            within(".edit_jobseeker") do
-              click_on I18n.t("buttons.sign_in")
-            end
+            click_on I18n.t("buttons.sign_in")
           end
           sign_in_jobseeker_govuk_one_login(jobseeker)
           expect(current_path).to eq(jobseekers_subscriptions_path)

--- a/spec/system/jobseekers/jobseekers_can_manage_their_job_alerts_from_the_email_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_their_job_alerts_from_the_email_spec.rb
@@ -39,18 +39,7 @@ RSpec.describe "Jobseekers can manage their job alerts from the email" do
         end
 
         context "when jobseeker is signed out" do
-          it "renders a sign in prompt form that redirects to job alerts dashboard" do
-            within "div[data-account-prompt='sign-in']" do
-              expect(page).to have_content(I18n.t("subscriptions.jobseeker_account_prompt.heading.sign_in"))
-              fill_in "Password", with: jobseeker.password
-              within(".edit_jobseeker") do
-                click_on I18n.t("buttons.sign_in")
-              end
-            end
-            expect(current_path).to eq(jobseekers_subscriptions_path)
-          end
-
-          it "renders a sign in prompt form that redirects to sign in page on error then redirects to job alerts dashboard" do
+          it "renders a sign in prompt that sends the user to GovUK One Login and redirects them back to the job alerts dashboard" do
             within "div[data-account-prompt='sign-in']" do
               expect(page).to have_content(I18n.t("subscriptions.jobseeker_account_prompt.heading.sign_in"))
               click_on I18n.t("buttons.sign_in")


### PR DESCRIPTION
## Trello card URL
[Trello ticket](https://trello.com/c/kUNqmPbu)

## Changes in this PR:

The confirmation page after creating a job alert/subscription was showing an old sign-in flow, requesting the password.

Fixed it by switching it to a One Login button/link and ensuring that the users get redirected back to their job alerts dashboard (instead of the Job applications dashboard) after they sign in from this confirmation page.

## Screenshots of UI changes:

### Before 

#### It was displaying a password field.
#### Also it was redirecting back to job applications after signing in through OneLogin.
![image](https://github.com/user-attachments/assets/0fa7742b-f48e-417b-8520-41981a42f664)
----
### After

#### For existing users
![Screenshot From 2024-10-04 11-39-35](https://github.com/user-attachments/assets/000c6905-6567-4383-9b93-8c7953442b2b)
----
#### For email not matching any user
![image](https://github.com/user-attachments/assets/585294e1-adc4-4b30-9b09-4e3c5f09b404)
----
#### Both redirect back to this page
![Screenshot From 2024-10-04 11-39-50](https://github.com/user-attachments/assets/1920302d-54f3-461b-b1d2-6d0b0a312f56)
