### PR TITLE
Exclude the one login id from Rails param logging

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -50,6 +50,7 @@ Rails.application.config.filter_parameters += %i[
   contact_email
   contact_number
   qualification_results_attributes
+  govuk_one_login_id
 ] + [
   /^age$/i,
 ]


### PR DESCRIPTION
As it is listed in Analytics PII, we need to also exclude it from the Rails parameter logging.


This resolves a new test introduced in `main`. Failing since we refreshed the branch.