### PR TITLE
Show the professional status section for all vacancies

### DIFF
--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -82,11 +82,6 @@ class JobApplication < ApplicationRecord
     Jobseekers::JobApplicationMailer.application_submitted(self).deliver_later
   end
 
-  def ask_professional_status?
-    vacancy.job_roles.intersect?(%w[teacher headteacher deputy_headteacher assistant_headteacher
-                                    head_of_year_or_phase head_of_department_or_curriculum sendco])
-  end
-
   def deadline_passed?
     draft? && vacancy&.expired?
   end

--- a/app/services/jobseekers/job_applications/job_application_step_process.rb
+++ b/app/services/jobseekers/job_applications/job_application_step_process.rb
@@ -6,7 +6,7 @@ class Jobseekers::JobApplications::JobApplicationStepProcess < StepProcess
 
     super(current_step, {
       personal_details: %i[personal_details],
-      professional_status: professional_status_steps,
+      professional_status: %i[professional_status],
       qualifications: %i[qualifications],
       training_and_cpds: %i[training_and_cpds],
       employment_history: %i[employment_history],
@@ -17,11 +17,5 @@ class Jobseekers::JobApplications::JobApplicationStepProcess < StepProcess
       declarations: %i[declarations],
       review: %i[review],
     })
-  end
-
-  private
-
-  def professional_status_steps
-    job_application.ask_professional_status? ? %i[professional_status] : []
   end
 end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/lTX0Ydgp/1280-show-professional-status-section-to-all-jobseekers-applications

## Changes in this PR:

This PR changes our application form so that the jobseeker can fill out the professional status section of the form for both teaching and non teaching vacancies. Prior to this change only teaching vacancies would show this section.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
