### PR TITLE
Onelogin resend email banner

### DIFF
--- a/app/controllers/jobseekers/request_account_transfer_emails_controller.rb
+++ b/app/controllers/jobseekers/request_account_transfer_emails_controller.rb
@@ -13,8 +13,8 @@ class Jobseekers::RequestAccountTransferEmailsController < Jobseekers::BaseContr
         Jobseekers::AccountMailer.request_account_transfer(jobseeker).deliver_now
       end
 
-      notice_message = @request_account_transfer_email_form.email_resent ? "Email resent" : nil
-      redirect_to new_jobseekers_account_transfer_path(email: @request_account_transfer_email_form.email), notice: notice_message
+      success_message = @request_account_transfer_email_form.email_resent ? "Email resent" : nil
+      redirect_to new_jobseekers_account_transfer_path(email: @request_account_transfer_email_form.email), success: success_message
     else
       render :new
     end

--- a/app/controllers/jobseekers/request_account_transfer_emails_controller.rb
+++ b/app/controllers/jobseekers/request_account_transfer_emails_controller.rb
@@ -12,13 +12,15 @@ class Jobseekers::RequestAccountTransferEmailsController < Jobseekers::BaseContr
         jobseeker.generate_merge_verification_code
         Jobseekers::AccountMailer.request_account_transfer(jobseeker).deliver_now
       end
-      redirect_to new_jobseekers_account_transfer_path(email: @request_account_transfer_email_form.email)
+
+      notice_message = @request_account_transfer_email_form.email_resent ? "Email resent" : nil
+      redirect_to new_jobseekers_account_transfer_path(email: @request_account_transfer_email_form.email), notice: notice_message
     else
       render :new
     end
   end
 
   def request_account_transfer_email_form_params
-    params.require(:jobseekers_request_account_transfer_email_form).permit(:email)
+    params.require(:jobseekers_request_account_transfer_email_form).permit(:email, :email_resent)
   end
 end

--- a/app/controllers/jobseekers/request_account_transfer_emails_controller.rb
+++ b/app/controllers/jobseekers/request_account_transfer_emails_controller.rb
@@ -13,7 +13,7 @@ class Jobseekers::RequestAccountTransferEmailsController < Jobseekers::BaseContr
         Jobseekers::AccountMailer.request_account_transfer(jobseeker).deliver_now
       end
 
-      success_message = @request_account_transfer_email_form.email_resent ? "Email resent" : nil
+      success_message = @request_account_transfer_email_form.email_resent ? t(".success") : nil
       redirect_to new_jobseekers_account_transfer_path(email: @request_account_transfer_email_form.email), success: success_message
     else
       render :new

--- a/app/form_models/jobseekers/request_account_transfer_email_form.rb
+++ b/app/form_models/jobseekers/request_account_transfer_email_form.rb
@@ -1,5 +1,5 @@
 class Jobseekers::RequestAccountTransferEmailForm < BaseForm
-  attr_accessor :email
+  attr_accessor :email, :email_resent
 
   validates :email, presence: true
   validates :email, email_address: true

--- a/app/views/jobseekers/account_transfers/new.html.slim
+++ b/app/views/jobseekers/account_transfers/new.html.slim
@@ -20,4 +20,4 @@
     .govuk-button-group
       = govuk_link_to t("buttons.cancel"), jobseekers_profile_path
 
-    = govuk_details summary_text: t(".help_with_code"), text: t(".helpful_links", resend_code_link: govuk_link_to(t(".resend_code_link_text"), jobseekers_request_account_transfer_email_path(jobseekers_request_account_transfer_email_form: { email: @email }), method: :post), different_email_link: govuk_link_to(t(".different_email_link_text"), new_jobseekers_request_account_transfer_email_path)).html_safe
+    = govuk_details summary_text: t(".help_with_code"), text: t(".helpful_links", resend_code_link: govuk_link_to(t(".resend_code_link_text"), jobseekers_request_account_transfer_email_path(jobseekers_request_account_transfer_email_form: { email: @email, email_resent: true }), method: :post), different_email_link: govuk_link_to(t(".different_email_link_text"), new_jobseekers_request_account_transfer_email_path)).html_safe

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -971,6 +971,7 @@ en:
         hint: If you have an account associated with this email address, we'll send you an email to verify your details.
       errors:
         recent_code_request: Please wait 1 minute before requesting another code.
+      success: Email resent
     account_transfers:
       new:
         page_title: Confirm account details transfer

--- a/spec/system/jobseekers/jobseekers_can_transfer_data_from_old_account_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_transfer_data_from_old_account_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe "Jobseekers can transfer data from an old account" do
       click_on "Save and continue"
       expect(delivered_emails.last.subject).to eq "Transfer your account data"
       expect(delivered_emails.last.body.raw_source).to include "Your verification code: #{old_jobseeker_account.reload.account_merge_confirmation_code}"
+      expect(page).not_to have_css('div.govuk-notification-banner__content p.govuk-notification-banner__heading', text: 'Email resent')
 
       fill_in "jobseekers_account_transfer_form[account_merge_confirmation_code]", with: "somethingincorrect"
       click_on "Confirm account transfer"
@@ -54,7 +55,13 @@ RSpec.describe "Jobseekers can transfer data from an old account" do
         expect(page).to have_link("Confirmation code does not match.", href: "#jobseekers-account-transfer-form-account-merge-confirmation-code-field-error")
       end
 
-      fill_in "jobseekers_account_transfer_form[account_merge_confirmation_code]", with: old_jobseeker_account.account_merge_confirmation_code
+      old_jobseeker_account.update(account_merge_confirmation_code_generated_at: DateTime.current - 2.minutes)
+      find('details.govuk-details').click
+      find('a.govuk-link', text: 'send the code again').click
+
+      expect(page).to have_css('div.govuk-notification-banner__content p.govuk-notification-banner__heading', text: 'Email resent')
+
+      fill_in "jobseekers_account_transfer_form[account_merge_confirmation_code]", with: old_jobseeker_account.reload.account_merge_confirmation_code
       click_on "Confirm account transfer"
       expect(page).to have_content "Your account details have been transferred successfully!"
 

--- a/spec/system/jobseekers/jobseekers_can_transfer_data_from_old_account_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_transfer_data_from_old_account_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Jobseekers can transfer data from an old account" do
       click_on "Save and continue"
       expect(delivered_emails.last.subject).to eq "Transfer your account data"
       expect(delivered_emails.last.body.raw_source).to include "Your verification code: #{old_jobseeker_account.reload.account_merge_confirmation_code}"
-      expect(page).not_to have_css('div.govuk-notification-banner__content p.govuk-notification-banner__heading', text: 'Email resent')
+      expect(page).not_to have_css("div.govuk-notification-banner__content p.govuk-notification-banner__heading", text: "Email resent")
 
       fill_in "jobseekers_account_transfer_form[account_merge_confirmation_code]", with: "somethingincorrect"
       click_on "Confirm account transfer"
@@ -56,10 +56,10 @@ RSpec.describe "Jobseekers can transfer data from an old account" do
       end
 
       old_jobseeker_account.update(account_merge_confirmation_code_generated_at: DateTime.current - 2.minutes)
-      find('details.govuk-details').click
-      find('a.govuk-link', text: 'send the code again').click
+      find("details.govuk-details").click
+      find("a.govuk-link", text: "send the code again").click
 
-      expect(page).to have_css('div.govuk-notification-banner__content p.govuk-notification-banner__heading', text: 'Email resent')
+      expect(page).to have_css("div.govuk-notification-banner__content p.govuk-notification-banner__heading", text: "Email resent")
 
       fill_in "jobseekers_account_transfer_form[account_merge_confirmation_code]", with: old_jobseeker_account.reload.account_merge_confirmation_code
       click_on "Confirm account transfer"


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/9KxtzGDA/1293-show-notification-when-user-successfully-requests-account-transfer-confirmation-code-to-be-resent

## Changes in this PR:
This PR adds a notification banner when a user successfully requests to have their confirmation code resent during the account transfer journey.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
