### PR TITLE
Fix bug in TRN section of job application

### DIFF
--- a/app/views/jobseekers/job_applications/build/professional_status.html.slim
+++ b/app/views/jobseekers/job_applications/build/professional_status.html.slim
@@ -19,9 +19,9 @@
         = f.govuk_radio_button :qualified_teacher_status, :on_track
 
       = f.govuk_radio_buttons_fieldset :has_teacher_reference_number, hint: -> { tag.p(t("helpers.label.jobseekers_profile_qualified_teacher_status_form.teacher_reference_number_hint", link: govuk_link_to(t("helpers.label.jobseekers_profile_qualified_teacher_status_form.trn_link_text"), "https://find-a-lost-trn.education.gov.uk/start", target: "_blank")).html_safe) } do
-        = f.govuk_radio_button :has_teacher_reference_number, "yes", link_errors: true, checked: current_jobseeker&.jobseeker_profile&.has_teacher_reference_number == "yes", label: { text: t("helpers.legend.jobseekers_job_application_professional_status_form.has_teacher_reference_number_options.yes") }
-          = f.govuk_text_field :teacher_reference_number, value: current_jobseeker&.jobseeker_profile&.teacher_reference_number, label: { text: t("helpers.legend.jobseekers_job_application_professional_status_form.teacher_reference_number") }
-        = f.govuk_radio_button :has_teacher_reference_number, "no", checked: current_jobseeker&.jobseeker_profile&.has_teacher_reference_number == "no", label: { text: t("helpers.legend.jobseekers_job_application_professional_status_form.has_teacher_reference_number_options.no") }
+        = f.govuk_radio_button :has_teacher_reference_number, "yes", link_errors: true, label: { text: t("helpers.legend.jobseekers_job_application_professional_status_form.has_teacher_reference_number_options.yes") }
+          = f.govuk_text_field :teacher_reference_number, label: { text: t("helpers.legend.jobseekers_job_application_professional_status_form.teacher_reference_number") }
+        = f.govuk_radio_button :has_teacher_reference_number, "no", label: { text: t("helpers.legend.jobseekers_job_application_professional_status_form.has_teacher_reference_number_options.no") }
 
       = f.govuk_collection_radio_buttons :statutory_induction_complete, f.object.statutory_induction_complete_options, :first, :last, hint: { text: t("helpers.label.jobseekers_job_application_professional_status_form.completed_period_hint") }
 


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/UPdoJtgA/1285-trn-bug-fix-application-radio-response

## Changes in this PR:
This PR fixes a bug in the TRN section of the job application process, which causes the value the user enters into the "Do you have a teacher reference number?" to be lost when there are errors on the page.

Note: I don't think we needed these values to be set from the jobseeker profile because we set these values in the form [here](https://github.com/DFE-Digital/teaching-vacancies/blob/398220e758d1d02809b4d9fffcb34e60e776f198/app/controllers/jobseekers/job_applications/build_controller.rb#L49)

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
