### PR TITLE
Change jobseekers email type in DB to Citext: Part 1.

### DIFF
--- a/db/migrate/20241011112641_initialize_change_jobseekers_email_type.rb
+++ b/db/migrate/20241011112641_initialize_change_jobseekers_email_type.rb
@@ -1,0 +1,7 @@
+class InitializeChangeJobseekersEmailType < ActiveRecord::Migration[7.1]
+  def change
+    enable_extension("citext")
+
+    initialize_column_type_change :jobseekers, :email, :citext
+  end
+end

--- a/db/migrate/20241011114125_backfill_change_jobseekers_email_type.rb
+++ b/db/migrate/20241011114125_backfill_change_jobseekers_email_type.rb
@@ -1,0 +1,11 @@
+class BackfillChangeJobseekersEmailType < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    backfill_column_for_type_change :jobseekers, :email
+  end
+
+  def down
+    # no op
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_24_144355) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_11_114125) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -320,6 +320,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_24_144355) do
     t.text "last_sign_in_ip_ciphertext"
     t.string "account_merge_confirmation_code"
     t.datetime "account_merge_confirmation_code_generated_at"
+    t.citext "email_for_type_change", default: "", null: false
     t.index ["confirmation_token"], name: "index_jobseekers_on_confirmation_token", unique: true
     t.index ["email"], name: "index_jobseekers_on_email", unique: true
     t.index ["reset_password_token"], name: "index_jobseekers_on_reset_password_token", unique: true


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/RuwbQ6Az/1308-move-jobseekers-email-field-in-db-to-citext-non-case-sensitive-searches-type

## Changes in this PR:

To achieve a smooth non-case sensitive "search user by email", while keeping the indexed search instead of table scanning, the ideal solution seems to be using citext as the DB type, allowing postgresql to do the non-case sensitive matches.

Changing the column type directly would lock the Jobseekers table. So, following "Online Migrations" guidance (and its useful helpers), we're doing the change in stages to avoid causing service downtime.

The first stages to be deployed are:

1 - Create a new email column of citext type that is kept in sync with email column using DB triggers.

2 - Backfill this column for all the existing data.

Reference:

https://github.com/fatkodima/online_migrations?tab=readme-ov-file#bullettrain_side-concrete-steps-for-active-record

## Screenshots of UI changes:

### Before
```ruby
Jobseeker.find_by(email: "MARC.SarDon@education.GOV.uk")
=> nil
```
### After
Testing that new users get a trigger to copy the email into the citext column:
```ruby
Jobseeker.create(email: "pringaohowto@gmail.com", password: "password")
js = Jobseeker.find_by(email: "pringaohowto@gmail.com")
js.email_for_type_change
=> "pringaohowto@gmail.com"
```

Testing the citext column provides non-case sensitive matches on `find_by` searches.
```ruby
Jobseeker.find_by(email_for_type_change: "MARC.SarDon@education.GOV.uk")
=> #<Jobseeker id: "e15a25f1-4886-42d0-ac3a-ada7451c3bdd", email: "marc.sardon@education.gov.uk"...
```

On the Review app:
![image](https://github.com/user-attachments/assets/eeeb9ddd-6c57-434c-80a4-3ab05f303c08)

## Next steps:


After deploying and testing this, we will follow up by copying the constraints, indexes, foreign keys, etc and swapping the columns.

Once that is deployed we will remove the copy trigger and the old column.
