### PR TITLE
Fix wrong key for analytics hidden data

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -60,7 +60,7 @@ class VacanciesController < ApplicationController
           landing_page: params[:landing_page_slug],
           filters_set_from_keywords: form.filters_from_keyword.present?,
         },
-        event_hidden_data: {
+        hidden_data: {
           location_polygon_used: @vacancies_search&.polygon&.id,
         },
       }


### PR DESCRIPTION
The key/value is not being populated in DFE Analytics events due to the hash containing a misspelled key. It should be "hidden_data" (as named in other events).
