### PR TITLE
Fix subscriptions email address capitalisation

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -29,7 +29,7 @@ class SubscriptionsController < ApplicationController
         if jobseeker_signed_in?
           redirect_to jobseekers_subscriptions_path, success: t(".success")
         else
-          @jobseeker = Jobseeker.find_by(email: subscription.email)
+          @jobseeker = Jobseeker.find_by(email: subscription.email.downcase)
           store_return_location(jobseekers_subscriptions_path)
           render :confirm
         end
@@ -196,7 +196,7 @@ class SubscriptionsController < ApplicationController
     if jobseeker_signed_in?
       redirect_to jobseekers_subscriptions_path, success: t(".success")
     else
-      @jobseeker = Jobseeker.find_by(email: subscription.email)
+      @jobseeker = Jobseeker.find_by(email: subscription.email.downcase)
       store_return_location(jobseekers_subscriptions_path)
       render :confirm
     end

--- a/app/form_models/jobseekers/subscription_form.rb
+++ b/app/form_models/jobseekers/subscription_form.rb
@@ -52,7 +52,7 @@ class Jobseekers::SubscriptionForm < BaseForm
 
   def job_alert_params
     {
-      email: email,
+      email: email&.downcase,
       frequency: frequency,
       search_criteria: search_criteria_hash,
     }

--- a/app/mailers/jobseekers/subscription_mailer.rb
+++ b/app/mailers/jobseekers/subscription_mailer.rb
@@ -30,7 +30,7 @@ class Jobseekers::SubscriptionMailer < Jobseekers::BaseMailer
   end
 
   def jobseeker
-    @jobseeker ||= Jobseeker.find_by(email: subscription.email)
+    @jobseeker ||= Jobseeker.find_by(email: subscription.email.downcase)
   end
 
   def subscription

--- a/spec/controllers/jobseekers/subscriptions_controller_spec.rb
+++ b/spec/controllers/jobseekers/subscriptions_controller_spec.rb
@@ -2,10 +2,11 @@ require "rails_helper"
 
 RSpec.describe SubscriptionsController, recaptcha: true do
   describe "#create" do
+    let(:email) { "foo@example.net" }
     let(:params) do
       {
         jobseekers_subscription_form: {
-          email: "foo@example.net",
+          email: email,
           frequency: "daily",
           keyword: "english",
         }.symbolize_keys,
@@ -22,7 +23,7 @@ RSpec.describe SubscriptionsController, recaptcha: true do
       let(:recaptcha_score) { 0.9 }
       let(:job_alert_params) do
         {
-          email: "foo@example.net",
+          email: email,
           frequency: "daily",
           search_criteria: { keyword: "english" },
         }
@@ -37,6 +38,7 @@ RSpec.describe SubscriptionsController, recaptcha: true do
         allow(Subscription).to receive(:new).and_return(subscription)
         allow(subscription).to receive(:id).and_return("abc123")
         allow(subscription).to receive(:class).and_return(Subscription)
+        allow(subscription).to receive(:email).and_return(email)
         allow(Jobseekers::SubscriptionForm).to receive(:new).and_return(form)
         allow(form).to receive(:job_alert_params).and_return(job_alert_params)
         allow(form).to receive(:invalid?).and_return(!subscription_form_valid?)

--- a/spec/mailers/jobseekers/alert_mailer_spec.rb
+++ b/spec/mailers/jobseekers/alert_mailer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Jobseekers::AlertMailer do
   let(:frequency) { :daily }
   let(:search_criteria) { { keyword: "English" } }
   let(:subscription) do
-    subscription = Subscription.create(email: email, frequency: frequency, search_criteria: search_criteria)
+    subscription = Subscription.create(email: email.upcase, frequency: frequency, search_criteria: search_criteria)
     # The hashing algorithm uses a random initialization vector to encrypt the token,
     # so is different every time, so we stub the token to be the same every time, so
     # it's clearer what we're testing when we test the unsubscribe link

--- a/spec/mailers/jobseekers/subscription_mailer_spec.rb
+++ b/spec/mailers/jobseekers/subscription_mailer_spec.rb
@@ -4,7 +4,7 @@ require "dfe/analytics/rspec/matchers"
 RSpec.describe Jobseekers::SubscriptionMailer do
   include ERB::Util
 
-  let(:email) { Faker::Internet.email(domain: TEST_EMAIL_DOMAIN) }
+  let(:email) { Faker::Internet.email(domain: TEST_EMAIL_DOMAIN).upcase }
   let(:search_criteria) { { keyword: "English" } }
   let(:subscription) do
     subscription = Subscription.create(email: email, frequency: "daily", search_criteria: search_criteria)


### PR DESCRIPTION
The subscription email addresses are stored with the capitalisation as provided in the subscription form.

This causes:
- Subscriptions could be duplicated with different capitalisation.
- Alert emails to registered jobseekers containing wrong content (offering to register/create an account) due to the user email not being found even when the email is the same address.

Resolving it by ensuring the email used to register the subscriptions is downcased, and by downcasing the queries searching Jobseekers by email for the subscription alerts.
