### PR TITLE
Do not exclude 'id' from Sentry filtered params

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,5 @@
 Sentry.init do |config|
-  filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
+  filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters - %i[id])
   config.before_send = lambda do |event, _hint|
     filter.filter(event.to_hash)
   end


### PR DESCRIPTION
Filtering out 'id' from the parameters in Sentry caused Sentry error events not to be raised/displayed by Sentry.

This change reinstates it only for Sentry purposes while excluding it from the application logs.
