### PR TITLE
One login sign in page tweaks

### DIFF
--- a/app/controllers/jobseekers/sessions_controller.rb
+++ b/app/controllers/jobseekers/sessions_controller.rb
@@ -2,9 +2,7 @@ class Jobseekers::SessionsController < Devise::SessionsController
   include ReturnPathTracking::Helpers
 
   def new
-    if (attempted_path = params[:attempted_path])
-      flash.now[:alert] = t("jobseekers.forced_login.#{forced_login_resource(attempted_path)}_html")
-    elsif (login_failure = params[:login_failure])
+    if (login_failure = params[:login_failure])
       alert_text = t("devise.failure.#{login_failure}")
       trigger_jobseeker_sign_in_event(:failure, alert_text)
       flash.now[:alert] = alert_text

--- a/app/views/jobseekers/sessions/new.html.slim
+++ b/app/views/jobseekers/sessions/new.html.slim
@@ -11,4 +11,6 @@
     p.govuk-body = t(".govuk_one_log_in.paragraph1")
     p.govuk-body = t(".govuk_one_log_in.paragraph2")
 
-    = jobseeker_login_button(class: "govuk-!-margin-bottom-2")
+    = jobseeker_login_button(class: "govuk-!-margin-bottom-6")
+
+    = govuk_details(summary_text: t(".govuk_one_log_in.how_to_find_registered_email.summary"), text: t(".govuk_one_log_in.how_to_find_registered_email.body"))

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -925,6 +925,9 @@ en:
         govuk_one_log_in:
           paragraph1: Create your GOV.UK One Login account using the same email address as your Teaching Vacancies account to automatically save your account details.
           paragraph2: If you use a different email address, you'll be able to transfer your account details after signing in.
+          how_to_find_registered_email:
+            summary: How to find your registered email address
+            body: We sent a message to the email address associated with your Teaching Vacancies account informing you about this change.
       locked:
         description: You have been locked out of your account because you have made too many attempts to log in.
         having_trouble_html: Still having trouble? %{request_support_link}.

--- a/spec/requests/jobseekers/job_applications_spec.rb
+++ b/spec/requests/jobseekers/job_applications_spec.rb
@@ -11,10 +11,8 @@ RSpec.describe "Job applications" do
     context "when the jobseeker is not signed in" do
       before { get(new_jobseekers_job_job_application_path(vacancy.id)) }
 
-      it "redirects to the sign in page with a flash message explaining why" do
-        follow_redirect!
-
-        expect(flash[:alert]).to be_present
+      it "redirects to the sign in page" do
+        expect(response.location).to match(a_string_matching(new_jobseeker_session_path))
       end
     end
 

--- a/spec/requests/jobseekers/saved_jobs_spec.rb
+++ b/spec/requests/jobseekers/saved_jobs_spec.rb
@@ -20,10 +20,8 @@ RSpec.describe "Saved jobs" do
     context "when a jobseeker is not signed in" do
       before { get(new_jobseekers_saved_job_path(vacancy.id)) }
 
-      it "redirects to the sign in page with a flash message explaining why" do
-        follow_redirect!
-
-        expect(flash[:alert]).to be_present
+      it "redirects to the sign in page" do
+        expect(response.location).to match(a_string_matching(new_jobseeker_session_path))
       end
     end
   end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/Cy6RpRhg/1302-content-updates-on-jobseeker-sign-in-page

## Changes in this PR:

- adds a govuk_details component to the jobseeker sign in page explaining how the jobseeker can find their registered email address
- removes the forced login banner which tells users that they need to sign in

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
