### PR TITLE
Show account found banner on new quick apply page for existing users

### DIFF
--- a/app/controllers/jobseekers/job_applications_controller.rb
+++ b/app/controllers/jobseekers/job_applications_controller.rb
@@ -10,12 +10,12 @@ class Jobseekers::JobApplicationsController < Jobseekers::JobApplications::BaseC
   def new
     send_dfe_analytics_event
 
-    return unless quick_apply?
-
     if session[:user_exists_first_log_in]
       @user_exists_first_log_in = true
       session.delete(:user_exists_first_log_in)
     end
+
+    return unless quick_apply?
 
     redirect_to about_your_application_jobseekers_job_job_application_path(vacancy.id)
   end

--- a/app/controllers/jobseekers/job_applications_controller.rb
+++ b/app/controllers/jobseekers/job_applications_controller.rb
@@ -12,6 +12,11 @@ class Jobseekers::JobApplicationsController < Jobseekers::JobApplications::BaseC
 
     return unless quick_apply?
 
+    if session[:user_exists_first_log_in]
+      @user_exists_first_log_in = true
+      session.delete(:user_exists_first_log_in)
+    end
+
     redirect_to about_your_application_jobseekers_job_job_application_path(vacancy.id)
   end
 

--- a/app/views/jobseekers/job_applications/new.html.slim
+++ b/app/views/jobseekers/job_applications/new.html.slim
@@ -6,7 +6,6 @@
     p.govuk-body = "We have found a teaching vacancies account using this email address."
     p.govuk-body = "Your account information including past applications has been saved."
 
-
 span.govuk-caption-l = t("jobseekers.job_applications.caption", job_title: vacancy.job_title, organisation: vacancy.organisation_name)
 h2.govuk-heading-xl = t("jobseekers.job_applications.heading")
 

--- a/app/views/jobseekers/job_applications/new.html.slim
+++ b/app/views/jobseekers/job_applications/new.html.slim
@@ -2,9 +2,9 @@
 
 - if @user_exists_first_log_in
   = govuk_notification_banner title_text: t("banners.success"), classes: "govuk-notification-banner--success" do |notification_banner|
-    - notification_banner.with_heading(text: "Account found")
-    p.govuk-body = "We have found a teaching vacancies account using this email address."
-    p.govuk-body = "Your account information including past applications has been saved."
+    - notification_banner.with_heading(text:t(".one_login_banner.title"))
+    p.govuk-body = t(".one_login_banner.paragraph1")
+    p.govuk-body = t(".one_login_banner.paragraph2")
 
 span.govuk-caption-l = t("jobseekers.job_applications.caption", job_title: vacancy.job_title, organisation: vacancy.organisation_name)
 h2.govuk-heading-xl = t("jobseekers.job_applications.heading")

--- a/app/views/jobseekers/job_applications/new.html.slim
+++ b/app/views/jobseekers/job_applications/new.html.slim
@@ -1,10 +1,11 @@
 - content_for :page_title_prefix, t(".title")
 
-- if current_jobseeker.job_applications.blank?
-  = govuk_notification_banner title_text: t("banners.important") do
-    h3.govuk-heading-s = t(".cannot_see_past_applications.title")
-    p.govuk-body = t(".cannot_see_past_applications.paragraph1")
-    p.govuk-body = t(".cannot_see_past_applications.paragraph2", link: govuk_link_to(t(".cannot_see_past_applications.link_text"), new_jobseekers_request_account_transfer_email_path)).html_safe
+- if @user_exists_first_log_in
+  = govuk_notification_banner title_text: t("banners.success"), classes: "govuk-notification-banner--success" do |notification_banner|
+    - notification_banner.with_heading(text: "Account found")
+    p.govuk-body = "We have found a teaching vacancies account using this email address."
+    p.govuk-body = "Your account information including past applications has been saved."
+
 
 span.govuk-caption-l = t("jobseekers.job_applications.caption", job_title: vacancy.job_title, organisation: vacancy.organisation_name)
 h2.govuk-heading-xl = t("jobseekers.job_applications.heading")

--- a/app/views/jobseekers/job_applications/new.html.slim
+++ b/app/views/jobseekers/job_applications/new.html.slim
@@ -2,7 +2,7 @@
 
 - if @user_exists_first_log_in
   = govuk_notification_banner title_text: t("banners.success"), classes: "govuk-notification-banner--success" do |notification_banner|
-    - notification_banner.with_heading(text:t(".one_login_banner.title"))
+    - notification_banner.with_heading(text: t(".one_login_banner.title"))
     p.govuk-body = t(".one_login_banner.paragraph1")
     p.govuk-body = t(".one_login_banner.paragraph2")
 

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -356,11 +356,10 @@ en:
           into a %{profile_link} so schools can contact you about relevant roles.
         profile_link_text: candidate profile
         title: Application
-        cannot_see_past_applications:
-          title: Can't see your information from past applications?
-          paragraph1: If you had a Teaching Vacancies account using a different email address to your GOV.UK One Login account, information from your past applications will not automatically be saved.
-          paragraph2: You can request to %{link}
-          link_text: transfer information from your past applications.
+        one_login_banner:
+          title: Account found
+          paragraph1: We have found a teaching vacancies account using this email address.
+          paragraph2: Your account information including past applications has been saved.
       about_your_application:
         title: About your application
         warning:

--- a/spec/system/jobseekers/jobseekers_can_sign_in_to_their_account_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_sign_in_to_their_account_spec.rb
@@ -29,12 +29,12 @@ RSpec.describe "Jobseekers can sign in to their account" do
       scenario "the user is sent to the quick application page" do
         visit new_jobseekers_job_job_application_path(vacancy.id)
         expect(current_path).to eq(new_jobseeker_session_path)
-  
+
         sign_in_jobseeker_govuk_one_login(jobseeker)
         expect(current_path).to eq(new_jobseekers_job_job_application_path(vacancy.id))
         expect(page).to have_css("h1", text: I18n.t("jobseekers.job_applications.new.heading"))
-        expect(page).to have_css('p.govuk-notification-banner__heading', text: 'Account found')
-        expect(page).to have_css('p.govuk-body', text: 'We have found a teaching vacancies account using this email address.')
+        expect(page).to have_css("p.govuk-notification-banner__heading", text: "Account found")
+        expect(page).to have_css("p.govuk-body", text: "We have found a teaching vacancies account using this email address.")
       end
     end
   end

--- a/spec/system/jobseekers/jobseekers_can_sign_in_to_their_account_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_sign_in_to_their_account_spec.rb
@@ -21,6 +21,22 @@ RSpec.describe "Jobseekers can sign in to their account" do
       expect(page).to have_css("h1", text: I18n.t("jobseekers.accounts.account_found.page_title"))
       expect(page).to have_link(text: I18n.t("nav.sign_out"))
     end
+
+    context "when the user sign-in following a vacancy quick apply link" do
+      let(:jobseeker) { create(:jobseeker, govuk_one_login_id: nil) }
+      let(:vacancy) { create(:vacancy, organisations: [build(:school)]) }
+
+      scenario "the user is sent to the quick application page" do
+        visit new_jobseekers_job_job_application_path(vacancy.id)
+        expect(current_path).to eq(new_jobseeker_session_path)
+  
+        sign_in_jobseeker_govuk_one_login(jobseeker)
+        expect(current_path).to eq(new_jobseekers_job_job_application_path(vacancy.id))
+        expect(page).to have_css("h1", text: I18n.t("jobseekers.job_applications.new.heading"))
+        expect(page).to have_css('p.govuk-notification-banner__heading', text: 'Account found')
+        expect(page).to have_css('p.govuk-body', text: 'We have found a teaching vacancies account using this email address.')
+      end
+    end
   end
 
   context "when signing in a jobseeker that hasn't an account in the service" do


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/aCYjPR9v/1301-quick-apply-journey-banner-update-for-account-found

## Changes in this PR:
This PR changes the banner shown on the new application page for users signing in on an existing account for the first time using one login.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
