### PR TITLE
All school roles content updates

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -112,7 +112,7 @@ en:
 
   nav:
     create_a_job_alert: Create a job alert
-    find_job: Find a teaching job
+    find_job: Find a job
     manage_jobs: Manage jobs
     manage_settings: Manage settings
     school_profile: School profile
@@ -145,7 +145,7 @@ en:
 
   home:
     index:
-      browse_all: Browse all teaching jobs in England
+      browse_all: Browse all teaching, leadership and school-based support jobs in England
       description: Search for teaching, leadership and school-based support jobs in England.
       jobseeker_section:
         signed_in:
@@ -481,7 +481,7 @@ en:
     intro: 'Candidate profiles are a new feature that allows schools to contact you about relevant jobs. With a profile you can:'
     summary_list:
       - share your qualifications with schools
-      - specify the types of teaching jobs you're looking for
+      - specify the types of jobs you're looking for
       - apply for roles more quickly by pre-filling your information
     link_to_profile: Create a profile to simplify your job search.
 
@@ -519,7 +519,7 @@ en:
   vacancies:
     index:
       page_description: >-
-        Search for teaching jobs near you and other school jobs including headteacher and teaching assistant. Visit the official place to find teaching jobs.
+        Search for teaching, leadership and school-based support jobs near you. Visit the official place to find teaching and education support roles.
       no_polygons: This search didn't use any polygons.
     international_teacher_advice:
         link: help you understand your next steps

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -14,7 +14,7 @@ en:
           password_placeholder: "**************"
       confirmation:
         page_title: Account created
-        apply_for_jobs_link_text: search and apply for teaching jobs
+        apply_for_jobs_link_text: search and apply for jobs
         apply_for_jobs: You can now %{apply_for_jobs_link_text} or %{create_a_profile_link_text}.
         create_a_profile_link_text: create a profile
         create_profile:
@@ -25,7 +25,7 @@ en:
           lead_in: "A profile will let you:"
           prefill: apply for roles more quickly by pre-filling your information
           share_your_qualifications: share your qualifications and experience with schools
-          specify_jobs: specify the types of teaching jobs you’re looking for
+          specify_jobs: specify the types of jobs you’re looking for
     account_feedbacks:
       create:
         success: Thank you for your feedback
@@ -296,8 +296,8 @@ en:
       index:
         continue_application: Continue application
         find_and_apply: Find and apply
-        no_job_applications: You have not applied for any teaching jobs
-        no_job_applications_body_html: "%{link_to} for a teaching job."
+        no_job_applications: You have not applied for any jobs
+        no_job_applications_body_html: "%{link_to} for a job."
         page_title: Applications
         page_title_with_count: Applications (%{count})
         skip_link: Skip to my job applications
@@ -601,12 +601,12 @@ en:
         continue: Continue application
         deadline_passed: Deadline passed
         delete: Delete
-        link_find: Find a teaching job
+        link_find: Find a job
         page_title: Saved jobs
         skip_link: Skip to my saved jobs
         view: View application
         zero_saved_jobs_body_html: '%{link_to} and start saving jobs you may want to review and apply for later.'
-        zero_saved_jobs_title: You have no saved teaching jobs
+        zero_saved_jobs_title: You have no saved jobs
       save: Save this job for later
       saved: Job saved
       success_html: >-

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -84,7 +84,7 @@ en:
           bullet_points:
             apply_quickly: apply for roles more quickly by pre-filling your information
             share_qualifications_and_experience: share your qualifications and experience with schools
-            specify_preferences: specify the types of teaching jobs you’re looking for
+            specify_preferences: specify the types of jobs you’re looking for
           further_information: >-
             When you turn on your profile, it will be visible to hiring staff in schools and trusts. They can
             get in touch by email to invite you to apply for roles where they think you’d be a great fit.

--- a/spec/system/jobseekers/jobseekers_can_transfer_data_from_old_account_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_transfer_data_from_old_account_spec.rb
@@ -121,11 +121,11 @@ RSpec.describe "Jobseekers can transfer data from an old account" do
     visit jobseekers_job_applications_path
 
     expect(page).to have_content "Applications (0)"
-    expect(page).to have_content "You have not applied for any teaching jobs"
+    expect(page).to have_content "You have not applied for any jobs"
 
     visit jobseekers_saved_jobs_path
 
-    expect(page).to have_content "You have no saved teaching jobs"
+    expect(page).to have_content "You have no saved jobs"
 
     visit jobseekers_subscriptions_path
 
@@ -147,7 +147,7 @@ RSpec.describe "Jobseekers can transfer data from an old account" do
 
     visit jobseekers_saved_jobs_path
 
-    expect(page).not_to have_content "You have no saved teaching jobs"
+    expect(page).not_to have_content "You have no saved jobs"
     expect(page).to have_content saved_job.vacancy.job_title
 
     visit jobseekers_subscriptions_path


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/w5BRFB81/1061-tweak-content-on-saved-jobs-and-applications-pages

## Changes in this PR:

We have a few instances on the site where we're still referring to 'teaching jobs'. This is no longer accurate now we've launched all school roles.

This PR is to remove some of the references to 'teaching jobs'.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
