### PR TITLE
Add banner to new quick apply page too so that if a user has a jobsee…

### DIFF
--- a/app/views/jobseekers/job_applications/new_quick_apply.html.slim
+++ b/app/views/jobseekers/job_applications/new_quick_apply.html.slim
@@ -1,5 +1,11 @@
 - content_for :page_title_prefix, t(".title")
 
+- if @user_exists_first_log_in
+  = govuk_notification_banner title_text: t("banners.success"), classes: "govuk-notification-banner--success" do |notification_banner|
+    - notification_banner.with_heading(text: t(".one_login_banner.title"))
+    p.govuk-body = t(".one_login_banner.paragraph1")
+    p.govuk-body = t(".one_login_banner.paragraph2")
+
 span.govuk-caption-l = t("jobseekers.job_applications.caption", job_title: vacancy.job_title, organisation: vacancy.organisation_name)
 h2.govuk-heading-xl = t("jobseekers.job_applications.heading")
 

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -371,6 +371,10 @@ en:
           search_for_jobs: Search for other jobs
           continue: Continue application
       new_quick_apply:
+        one_login_banner:
+          title: Account found
+          paragraph1: We have found a teaching vacancies account using this email address.
+          paragraph2: Your account information including past applications has been saved.
         assistance:
           content_html: You can find out more about our %{privacy_html} and our %{terms_html}.
           heading: Terms & Conditions


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/aCYjPR9v/1301-quick-apply-journey-banner-update-for-account-found

## Changes in this PR:

This PR also adds the new banner to the new quick apply page which users see if they have job_applications or jobseeker_profiles. The trello ticket above was to add it to the new application page which users see if they do not have job applications or jobseeker profiles but the product team decided it was best to show it on both pages.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
