### PR TITLE
Add banner on the new job application page for newly created users

### DIFF
--- a/app/controllers/jobseekers/job_applications_controller.rb
+++ b/app/controllers/jobseekers/job_applications_controller.rb
@@ -15,6 +15,11 @@ class Jobseekers::JobApplicationsController < Jobseekers::JobApplications::BaseC
       session.delete(:user_exists_first_log_in)
     end
 
+    if session[:newly_created_user]
+      @newly_created_user = true
+      session.delete(:newly_created_user)
+    end
+
     return unless quick_apply?
 
     redirect_to about_your_application_jobseekers_job_job_application_path(vacancy.id)

--- a/app/views/jobseekers/job_applications/new.html.slim
+++ b/app/views/jobseekers/job_applications/new.html.slim
@@ -2,9 +2,15 @@
 
 - if @user_exists_first_log_in
   = govuk_notification_banner title_text: t("banners.success"), classes: "govuk-notification-banner--success" do |notification_banner|
-    - notification_banner.with_heading(text: t(".one_login_banner.title"))
-    p.govuk-body = t(".one_login_banner.paragraph1")
-    p.govuk-body = t(".one_login_banner.paragraph2")
+    - notification_banner.with_heading(text: t(".one_login_banner.account_found.title"))
+    p.govuk-body = t(".one_login_banner.account_found.paragraph1")
+    p.govuk-body = t(".one_login_banner.account_found.paragraph2")
+
+- if @newly_created_user
+  = govuk_notification_banner title_text: t("banners.success"), classes: "govuk-notification-banner--success" do |notification_banner|
+    - notification_banner.with_heading(text: t(".one_login_banner.account_not_found.title"))
+    p.govuk-body = t(".one_login_banner.account_not_found.paragraph1")
+    p.govuk-body = t(".one_login_banner.account_not_found.paragraph2", link: govuk_link_to(t(".one_login_banner.account_not_found.transfer_account_link_text"), new_jobseekers_request_account_transfer_email_path)).html_safe
 
 span.govuk-caption-l = t("jobseekers.job_applications.caption", job_title: vacancy.job_title, organisation: vacancy.organisation_name)
 h2.govuk-heading-xl = t("jobseekers.job_applications.heading")

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -357,9 +357,15 @@ en:
         profile_link_text: candidate profile
         title: Application
         one_login_banner:
-          title: Account found
-          paragraph1: We have found a teaching vacancies account using this email address.
-          paragraph2: Your account information including past applications has been saved.
+          account_found:
+            title: Account found
+            paragraph1: We have found a teaching vacancies account using this email address.
+            paragraph2: Your account information including past applications has been saved.
+          account_not_found:
+            title: New account created
+            paragraph1: You've made a new Teaching Vacancies account.
+            paragraph2: If you already have an account using a different email address, you can %{link}
+            transfer_account_link_text: transfer your account information.
       about_your_application:
         title: About your application
         warning:


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/OswyuEqv/1307-quick-apply-journey-banner-update-for-account-not-found

## Changes in this PR:

This change introduces a new banner if a jobseeker gets taken to login after applying for a quick apply job and creates a brand new account.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
