### PR TITLE
Raise exception if vacancy cannot be created

### DIFF
--- a/app/controllers/publishers/vacancies_controller.rb
+++ b/app/controllers/publishers/vacancies_controller.rb
@@ -25,7 +25,7 @@ class Publishers::VacanciesController < Publishers::Vacancies::BaseController
   end
 
   def create
-    vacancy = Vacancy.create(publisher: current_publisher, publisher_organisation: current_organisation, organisations: [current_organisation])
+    vacancy = Vacancy.create!(publisher: current_publisher, publisher_organisation: current_organisation, organisations: [current_organisation])
 
     if current_organisation.school?
       vacancy.update(organisations: [current_organisation])


### PR DESCRIPTION
Trying to debug this [Sentry error](https://teaching-vacancies.sentry.io/issues/5998549447/events/d258d563044b47db9af2b4b7423ec22d/?project=6212514) noticed that the flow continued even when the vacancy failed to be created.

Instead of having an indirect exception down the flow due to a validation failure causing the vacancy not to be created and then a further call causing an error, we raise an exception directly if something fails during the creation of the vacancy.
