### PR TITLE
Bump Openssl version in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
  # Alpine v3.19.
  # TODO: Regularly check in the alpine ruby "3.3.5-alpine3.19" images for its latest upgraded packages so we can remove
  # the hardcoded versions below when they have been updated in the alpine ruby image.
-ARG PROD_PACKAGES="imagemagick libpng libjpeg libxml2 libxslt libpq tzdata shared-mime-info postgresql15 busybox=1.36.1-r19 openssl=3.1.7-r0"
+ARG PROD_PACKAGES="imagemagick libpng libjpeg libxml2 libxslt libpq tzdata shared-mime-info postgresql15 busybox=1.36.1-r19 openssl=3.1.7-r1"
 
 FROM ruby:3.3.5-alpine3.19 AS builder
 


### PR DESCRIPTION
It fixes a vulnerability alert on the current version.
