### PR TITLE
Show banners on either the job_application/new path or the job_application/new_quick_apply path

### DIFF
--- a/app/controllers/jobseekers/job_applications_controller.rb
+++ b/app/controllers/jobseekers/job_applications_controller.rb
@@ -10,19 +10,19 @@ class Jobseekers::JobApplicationsController < Jobseekers::JobApplications::BaseC
   def new
     send_dfe_analytics_event
 
-    if session[:user_exists_first_log_in]
-      @user_exists_first_log_in = true
-      session.delete(:user_exists_first_log_in)
-    end
-
     if session[:newly_created_user]
       @newly_created_user = true
       session.delete(:newly_created_user)
     end
 
-    return unless quick_apply?
-
-    redirect_to about_your_application_jobseekers_job_job_application_path(vacancy.id)
+    if quick_apply?
+      redirect_to about_your_application_jobseekers_job_job_application_path(vacancy.id)
+    else
+      if session[:user_exists_first_log_in]
+        @user_exists_first_log_in = true
+        session.delete(:user_exists_first_log_in)
+      end
+    end
   end
 
   def create
@@ -43,6 +43,11 @@ class Jobseekers::JobApplicationsController < Jobseekers::JobApplications::BaseC
   # rubocop:enable Style/GuardClause
 
   def new_quick_apply
+    if session[:user_exists_first_log_in]
+      @user_exists_first_log_in = true
+      session.delete(:user_exists_first_log_in)
+    end
+
     @has_previous_application = previous_application?
     raise ActionController::RoutingError, "Cannot quick apply if there's no profile or non-draft applications" unless quick_apply?
   end

--- a/app/controllers/jobseekers/job_applications_controller.rb
+++ b/app/controllers/jobseekers/job_applications_controller.rb
@@ -17,11 +17,9 @@ class Jobseekers::JobApplicationsController < Jobseekers::JobApplications::BaseC
 
     if quick_apply?
       redirect_to about_your_application_jobseekers_job_job_application_path(vacancy.id)
-    else
-      if session[:user_exists_first_log_in]
-        @user_exists_first_log_in = true
-        session.delete(:user_exists_first_log_in)
-      end
+    elsif session[:user_exists_first_log_in]
+      @user_exists_first_log_in = true
+      session.delete(:user_exists_first_log_in)
     end
   end
 


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/dMNZUBnq/1341-quick-apply-journey-banner-for-account-found-if-jobseeker-has-a-profile-or-previous-applications

## Changes in this PR:

When a user tries to apply for a quick apply job and is forced to log in for the first time via one login, and has an existing account on TVs they get sent to one of two pages. They are sent to the job_application/new page if they do not have a jobseeker_profile or any previous job applications and they get sent to the job_application/new_quick_apply path if they do have a jobseeker profile or previous applications.

We want to show the account found banner in both cases.

Prior to this change the banner was not showing when the jobseeker had previous profile/applications and was directed to the  job_application/new_quick_apply because the @user_exists_first_log_in variable was set to true and     session.delete(:user_exists_first_log_in) happened in the new action, but the jobseeker in question was redirected to the about_your_application action which in turn directed the user to the new_quick_apply action but user_exists_first_log_in was already deleted from the session.

This PR fixes this issue by only deleting user_exists_first_log_in from the session in the new action if the does not have an existing profile or job applications.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
