### PR TITLE
Update rake task for TRN migration

### DIFF
--- a/lib/tasks/migrate_trn_to_profiles.rake
+++ b/lib/tasks/migrate_trn_to_profiles.rake
@@ -3,42 +3,32 @@ namespace :jobseeker_profile do
   desc "Migrate Teacher Reference Number (TRN) from job_applications to jobseeker_profiles, creating profiles if necessary"
   task migrate_teacher_reference_number_to_profiles: :environment do
     batch_size = 500
+    failed_log = File.open("failed_migrations.log", "w")
 
-    namespace :jobseeker_profile do
-      desc "Migrate Teacher Reference Number (TRN) from job_applications to jobseeker_profiles, creating profiles if necessary"
-      task migrate_teacher_reference_number_to_profiles: :environment do
-        batch_size = 500
+    latest_application_ids = JobApplication
+                               .where.not(teacher_reference_number_ciphertext: [nil, ""])
+                               .select("DISTINCT ON (jobseeker_id) id")
+                               .order(:jobseeker_id, created_at: :desc)
+                               .pluck(:id)
 
-        latest_application_ids = JobApplication
-                                   .where.not(teacher_reference_number_ciphertext: [nil, ""])
-                                   .select("DISTINCT ON (jobseeker_id) id")
-                                   .order(:jobseeker_id, created_at: :desc)
-                                   .pluck(:id)
+    JobApplication
+      .where(id: latest_application_ids)
+      .find_each(batch_size: batch_size) do |application|
+      profile = JobseekerProfile.find_or_initialize_by(jobseeker_id: application.jobseeker_id)
 
-        JobApplication
-          .where(id: latest_application_ids)
-          .find_each(batch_size: batch_size) do |application|
-            puts "Jobseeker ID: #{application.jobseeker_id}"
-            puts "Teacher Reference Number (encrypted): #{application.teacher_reference_number_ciphertext}"
-
-            profile = JobseekerProfile.find_or_initialize_by(jobseeker_id: application.jobseeker_id)
-
-            if profile.teacher_reference_number.blank?
-              profile.update(teacher_reference_number: application.teacher_reference_number, has_teacher_reference_number: "yes")
-
-              if profile.persisted?
-                puts "Migrated TRN for profile ID: #{profile.id} (jobseeker ID: #{application.jobseeker_id})"
-              else
-                puts "Failed to save profile for jobseeker ID: #{application.jobseeker_id}. Errors: #{profile.errors.full_messages.join(', ')}"
-              end
-            else
-              puts "Profile already has TRN for jobseeker ID: #{application.jobseeker_id}"
-            end
-          end
-
-        puts "Teacher Reference Number migration completed."
+      if profile.teacher_reference_number.blank?
+        if profile.update(teacher_reference_number: application.teacher_reference_number, has_teacher_reference_number: "yes")
+          puts "Migrated TRN for profile ID: #{profile.id} (jobseeker ID: #{application.jobseeker_id})"
+        else
+          failed_log.puts("Failed to save profile for Jobseeker ID: #{application.jobseeker_id}, Application ID: #{application.id}. Errors: #{profile.errors.full_messages.join(', ')}")
+        end
+      else
+        puts "Profile already has TRN for jobseeker ID: #{application.jobseeker_id}"
       end
     end
+
+    failed_log.close
+    puts "Teacher Reference Number migration completed. Check 'failed_migrations.log' for any failures."
   end
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/rYYbUnVN/1345-delete-job-application-trns-from-the-database-and-migrate-missing-trns-to-jobseeker-profiles

## Changes in this PR:

Currently, we’re saving TRNs on job applications (that’s how it has always been done historically) and jobseeker profiles. The correct place is jobseeker profiles semantically and from a tech perspective because we ask TRNs to jobseekers when they complete their profiles. When they apply for new jobs, we pull the TRN from the profiles table in the database.

Before deleting the field from the job applications table, we first need to create a new profile for all the job seekers who submitted a job application providing a trn and migrate it to this newly created profile.


