### PR TITLE
Remove email validation from Organisation  model

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -51,8 +51,6 @@ class Organisation < ApplicationRecord
 
   scope :visible_to_jobseekers, -> { schools.not_closed.not_out_of_scope.or(Organisation.trusts).registered_for_service }
 
-  validates :email, email_address: true
-
   alias_attribute :data, :gias_data
 
   enum phase: {


### PR DESCRIPTION
The validation causes existing Schools not to be able to publish vacancies because their stored email is invalid.

The form's validation should cover schools trying to introduce or change a wrong email address.

Related Sentry error blocking a publisher from creating vacancies: [Here](https://teaching-vacancies.sentry.io/issues/6009418670/tags/user/?environment=production&project=6212514&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=7d&stream_index=19)