### PR TITLE
Do not validate Org when creating a Vacancy

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -66,7 +66,12 @@ class Vacancy < ApplicationRecord
   has_many :job_applications, dependent: :destroy
   has_one :equal_opportunities_report, dependent: :destroy
   has_many :organisation_vacancies, dependent: :destroy
-  has_many :organisations, through: :organisation_vacancies, dependent: :destroy, after_add: :refresh_geolocation, after_remove: :refresh_geolocation
+  has_many :organisations,
+           through: :organisation_vacancies,
+           dependent: :destroy,
+           validate: false, # If an organisation has some validation error, we do not want to block users from creating a vacancy.
+           after_add: :refresh_geolocation,
+           after_remove: :refresh_geolocation
   has_many :markers, dependent: :destroy
   has_many :feedbacks, dependent: :destroy, inverse_of: :vacancy
 

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -489,6 +489,16 @@ RSpec.describe Vacancy do
         it { is_expected.to be_valid }
       end
     end
+
+    describe "organisation association" do
+      it "is valid when an associated organisation has validation errors" do
+        publisher = build_stubbed(:publisher)
+        invalid_school = build_stubbed(:school, email: "invalid")
+        expect(invalid_school).not_to be_valid
+
+        expect(Vacancy.new(organisations: [invalid_school], publisher: publisher)).to be_valid
+      end
+    end
   end
 
   describe "#geolocation" do


### PR DESCRIPTION
The `has_many` association validates the associated object by default.

This is causing issues with some existing Organisations that have a pre-existing invalid email since we added email validation to the Org. model. Now they cannot create new vacancies.

Disabling the check on Org validity when creating a Vacancy will allow the publishers to still publish new vacancies.

[Related issue on Sentry](https://teaching-vacancies.sentry.io/issues/6009418670/tags/user/?environment=production&project=6212514&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=7d&stream_index=19)