### PR TITLE
Only validate models email if email changed

### DIFF
--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -49,7 +49,7 @@ class Feedback < ApplicationRecord
   scope :contactable, -> { except_job_alerts.where(user_participation_response: :interested) }
   scope :with_comments_or_contactable, -> { with_comments.or(contactable) }
 
-  validates :email, email_address: true
+  validates :email, email_address: true, if: -> { email_changed? } # Allows data created prior to validation to still be valid
 
   belongs_to :job_application, optional: true, inverse_of: :feedbacks
   belongs_to :jobseeker, optional: true

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -64,7 +64,7 @@ class JobApplication < ApplicationRecord
   scope :after_submission, -> { where(status: %w[submitted reviewed shortlisted unsuccessful withdrawn]) }
   scope :draft, -> { where(status: "draft") }
 
-  validates :email_address, email_address: true
+  validates :email_address, email_address: true, if: -> { email_address_changed? } # Allows data created prior to validation to still be valid
 
   def name
     "#{first_name} #{last_name}"

--- a/app/models/jobseeker.rb
+++ b/app/models/jobseeker.rb
@@ -17,7 +17,8 @@ class Jobseeker < ApplicationRecord
   has_many :saved_jobs, dependent: :destroy
   has_one :jobseeker_profile
 
-  validates :email, presence: true, email_address: true
+  validates :email, presence: true
+  validates :email, email_address: true, if: -> { email_changed? } # Allows data created prior to validation to still be valid
 
   after_update :update_subscription_emails
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -51,7 +51,7 @@ class Organisation < ApplicationRecord
 
   scope :visible_to_jobseekers, -> { schools.not_closed.not_out_of_scope.or(Organisation.trusts).registered_for_service }
 
-  validates :email, email_address: true
+  validates :email, email_address: true, if: -> { email_changed? } # Allows data created prior to validation to still be valid
 
   alias_attribute :data, :gias_data
 

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -10,7 +10,7 @@ class Publisher < ApplicationRecord
 
   has_encrypted :family_name, :given_name
 
-  validates :email, email_address: true
+  validates :email, email_address: true, if: -> { email_changed? } # Allows data created prior to validation to still be valid
 
   devise :timeoutable
   self.timeout_in = 120.minutes # Overrides default Devise configuration

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -3,5 +3,5 @@ class Reference < ApplicationRecord
 
   has_encrypted :name, :job_title, :organisation, :email, :phone_number
 
-  validates :email, email_address: true
+  validates :email, email_address: true, if: -> { email_changed? } # Allows data created prior to validation to still be valid
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -8,7 +8,7 @@ class Subscription < ApplicationRecord
 
   scope :active, -> { where(active: true) }
 
-  validates :email, email_address: true
+  validates :email, email_address: true, if: -> { email_changed? } # Allows data created prior to validation to still be valid
 
   def self.encryptor
     key_generator_secret = SUBSCRIPTION_KEY_GENERATOR_SECRET

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -103,8 +103,8 @@ class Vacancy < ApplicationRecord
   validates_with ExternalVacancyValidator, if: :external?
   validates :organisations, :presence => true
 
-  validates :application_email, email_address: true
-  validates :contact_email, email_address: true
+  validates :application_email, email_address: true, if: -> { application_email_changed? } # Allows data created prior to validation to still be valid
+  validates :contact_email, email_address: true, if: -> { contact_email_changed? }
 
   has_noticed_notifications
   has_paper_trail on: [:update],

--- a/app/services/email_address_audit.rb
+++ b/app/services/email_address_audit.rb
@@ -13,7 +13,7 @@ class EmailAddressAudit
       EMAIL_CLASSES.each_with_object({}) do |(klass, method), hash|
         invalid_records = klass.find_each.with_object([]) do |record, array|
           address = record.public_send(method)
-          if address.present? && !record.valid?
+          if address.present? && !ValidEmail2::Address.new(address).valid_strict_mx?
             array << record
           end
         end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -6,6 +6,22 @@ RSpec.describe Organisation do
   it { is_expected.to have_many(:vacancies) }
   it { is_expected.to have_many(:organisation_vacancies) }
 
+  describe "email validation" do
+    it "doesn't validate existing email" do
+      org = described_class.new(email: "invalidaaddress")
+      org.save(validate: false)
+
+      expect(org).to be_valid
+    end
+
+    it "validates new email" do
+      org = create(:school)
+      org.email = "invalidaaddress"
+
+      expect(org).not_to be_valid
+    end
+  end
+
   describe "#all_vacancies" do
     context "when the organisation is a school" do
       let!(:school1) { create(:school) }

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -493,7 +493,7 @@ RSpec.describe Vacancy do
     describe "organisation association" do
       it "is valid when an associated organisation has validation errors" do
         publisher = build_stubbed(:publisher)
-        invalid_school = build_stubbed(:school, email: "invalid")
+        invalid_school = School.new(email: "invalid")
         expect(invalid_school).not_to be_valid
 
         expect(Vacancy.new(organisations: [invalid_school], publisher: publisher)).to be_valid


### PR DESCRIPTION
Since we introduced the new email validation, existing objects for multiple models became invalid due to not passing the email validation.

This becomes an issue as affected users get unexpected errors when trying to update those objects in different flows unrelated to introducing/updating the email.

We are trying to mitigate this by only validating the models' email if the email field has been updated (new/changed value).

This would allow the object to still be valid when containing a legacy email, while not allowing to create/edit the email with an invalid value.
