### PR TITLE
One login banners everywhere

### DIFF
--- a/app/views/jobseekers/job_applications/index.html.slim
+++ b/app/views/jobseekers/job_applications/index.html.slim
@@ -1,5 +1,11 @@
 - content_for :page_title_prefix, t(".page_title")
 
+= govuk_notification_banner title_text: "Important", classes: "govuk-notification-banner govuk-!-margin-top-0 govuk-!-margin-bottom-5" do |banner|
+  - banner.with_heading(text: t(".one_login_banner.header"))
+  p.govuk-body = t(".one_login_banner.paragraph1")
+  p.govuk-body = t(".one_login_banner.paragraph2", link: govuk_link_to(t(".one_login_banner.transfer_profile_link_text"), new_jobseekers_request_account_transfer_email_path)).html_safe
+
+
 - if current_jobseeker.job_applications.any?
   - content_for :skip_links do
     = govuk_skip_link(href: "#applications-results", text: t(".skip_link"))

--- a/app/views/jobseekers/job_applications/index.html.slim
+++ b/app/views/jobseekers/job_applications/index.html.slim
@@ -5,7 +5,6 @@
   p.govuk-body = t(".one_login_banner.paragraph1")
   p.govuk-body = t(".one_login_banner.paragraph2", link: govuk_link_to(t(".one_login_banner.transfer_profile_link_text"), new_jobseekers_request_account_transfer_email_path)).html_safe
 
-
 - if current_jobseeker.job_applications.any?
   - content_for :skip_links do
     = govuk_skip_link(href: "#applications-results", text: t(".skip_link"))

--- a/app/views/jobseekers/saved_jobs/_candidiate_profiles_banner.slim
+++ b/app/views/jobseekers/saved_jobs/_candidiate_profiles_banner.slim
@@ -1,9 +1,0 @@
-= govuk_notification_banner title_text: "Important", classes: "govuk-notification-banner govuk-!-margin-top-0 govuk-!-margin-bottom-5" do |notification_banner|
-  - notification_banner.with_heading(text: "Create a profile")
-
-  p.govuk-body = t("candidate_profiles_banner.intro")
-  ul.govuk-list.govuk-list--bullet
-    - t("candidate_profiles_banner.summary_list").each do |item|
-      li = item
-
-    = govuk_link_to t("candidate_profiles_banner.link_to_profile"), jobseekers_profile_path, class: "govuk-link--no-visited-state"

--- a/app/views/jobseekers/saved_jobs/index.html.slim
+++ b/app/views/jobseekers/saved_jobs/index.html.slim
@@ -6,6 +6,11 @@
 
 h1.govuk-heading-l = t(".page_title")
 
+= govuk_notification_banner title_text: "Important", classes: "govuk-notification-banner govuk-!-margin-top-0 govuk-!-margin-bottom-5" do |banner|
+  - banner.with_heading(text: t(".one_login_banner.header"))
+  p.govuk-body = t(".one_login_banner.paragraph1")
+  p.govuk-body = t(".one_login_banner.paragraph2", link: govuk_link_to(t(".one_login_banner.transfer_profile_link_text"), new_jobseekers_request_account_transfer_email_path)).html_safe
+
 - if saved_jobs.many?
   .govuk-grid-row
     .govuk-grid-column-full

--- a/app/views/jobseekers/saved_jobs/index.html.slim
+++ b/app/views/jobseekers/saved_jobs/index.html.slim
@@ -18,7 +18,6 @@ h1.govuk-heading-l = t(".page_title")
 
 .govuk-grid-row
   .govuk-grid-column-full
-    = render "candidiate_profiles_banner" unless profile_complete?
     - if Date.today <= Date.new(2024, 4, 2)
       = render "jobseekers/visa_sponsorship_banner"
     - if saved_jobs.any?

--- a/app/views/jobseekers/subscriptions/index.html.slim
+++ b/app/views/jobseekers/subscriptions/index.html.slim
@@ -6,6 +6,11 @@
 
 h1.govuk-heading-l = t(".page_title")
 
+= govuk_notification_banner title_text: "Important", classes: "govuk-notification-banner govuk-!-margin-top-0 govuk-!-margin-bottom-5" do |banner|
+  - banner.with_heading(text: t(".one_login_banner.header"))
+  p.govuk-body = t(".one_login_banner.paragraph1")
+  p.govuk-body = t(".one_login_banner.paragraph2", link: govuk_link_to(t(".one_login_banner.transfer_profile_link_text"), new_jobseekers_request_account_transfer_email_path)).html_safe
+
 .govuk-grid-row
   .govuk-grid-column-full
       - if subscriptions.any?

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -317,6 +317,12 @@ en:
         page_title_with_count: Applications (%{count})
         skip_link: Skip to my job applications
         view_application: View application
+        one_login_banner:
+          header: Can't see your applications?
+          paragraph1: If you had a Teaching Vacancies account using a different email address to your GOV.UK One Login account, your existing profile will not automatically be saved.
+          paragraph2: You can request to %{link}
+          transfer_profile_link_text: transfer your existing profile.
+
       new:
         assistance:
           content_html: You can find out more about our %{privacy_html} and our %{terms_html}.

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -926,6 +926,11 @@ en:
         skip_link: Skip to my job alerts
         zero_subscriptions_body_html: '%{link_to} to be made aware of future listings.'
         zero_subscriptions_title: You have no job alerts set up
+        one_login_banner:
+          header: Can't see your job alerts?
+          paragraph1: If you had a Teaching Vacancies account using a different email address to your GOV.UK One Login account, your existing profile will not automatically be saved.
+          paragraph2: You can request to %{link}
+          transfer_profile_link_text: transfer your existing profile.
       feedbacks:
         relevance_feedbacks:
           submit_feedback:

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -625,6 +625,12 @@ en:
         view: View application
         zero_saved_jobs_body_html: '%{link_to} and start saving jobs you may want to review and apply for later.'
         zero_saved_jobs_title: You have no saved jobs
+        one_login_banner:
+          header: Can't see your saved jobs?
+          paragraph1: If you had a Teaching Vacancies account using a different email address to your GOV.UK One Login account, your existing profile will not automatically be saved.
+          paragraph2: You can request to %{link}
+          transfer_profile_link_text: transfer your existing profile.
+
       save: Save this job for later
       saved: Job saved
       success_html: >-

--- a/spec/requests/jobseekers/saved_jobs_spec.rb
+++ b/spec/requests/jobseekers/saved_jobs_spec.rb
@@ -26,28 +26,6 @@ RSpec.describe "Saved jobs" do
     end
   end
 
-  describe "GET #index" do
-    before { sign_in(jobseeker, scope: :jobseeker) }
-
-    context "when a jobseeker has completed their profile" do
-      let!(:completed_profile) { create(:jobseeker_profile, :completed, jobseeker_id: jobseeker.id) }
-
-      before { get jobseekers_saved_jobs_path }
-
-      it "does not display a reminder to create a profile" do
-        expect(response).to_not render_template(partial: "_candidiate_profiles_banner")
-      end
-    end
-
-    context "when a jobseeker has not completed their profile" do
-      before { get jobseekers_saved_jobs_path }
-
-      it "displays a reminder to create a profile" do
-        expect(response).to render_template(partial: "_candidiate_profiles_banner")
-      end
-    end
-  end
-
   describe "DELETE #destroy" do
     let!(:saved_job) { create(:saved_job, jobseeker: jobseeker, vacancy: vacancy) }
 


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/qG89nSa8/1347-add-cant-find-your-details-banner-onto-applications-saved-jobs-and-job-alerts-tabs

## Changes in this PR:

This PR adds 'can`t find your details' banners to the job applications, saved jobs and job alerts page and deletes the old banner from the saved jobs page which told the users about the new feature called jobseeker profiles.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
