### PR TITLE
Make emergency login keys polymorphic

### DIFF
--- a/app/controllers/publishers/login_keys_controller.rb
+++ b/app/controllers/publishers/login_keys_controller.rb
@@ -15,7 +15,7 @@ class Publishers::LoginKeysController < ApplicationController
   end
 
   def show
-    @publisher = Publisher.find(@login_key.publisher_id)
+    @publisher = @login_key.owner
 
     if @publisher.organisations.none?
       render(partial: "error", locals: { failure: "no_orgs" })
@@ -26,7 +26,7 @@ class Publishers::LoginKeysController < ApplicationController
   end
 
   def consume
-    @publisher = Publisher.find(@login_key.publisher_id)
+    @publisher = @login_key.owner
     @form = Publishers::LoginKeys::ChooseOrganisationForm.new(choose_organisation_form_params)
 
     if @form.valid?
@@ -76,6 +76,6 @@ class Publishers::LoginKeysController < ApplicationController
   end
 
   def generate_login_key(publisher:)
-    publisher.emergency_login_keys.create(not_valid_after: Time.current + EMERGENCY_LOGIN_KEY_DURATION)
+    EmergencyLoginKey.create(owner: publisher, not_valid_after: Time.current + EMERGENCY_LOGIN_KEY_DURATION)
   end
 end

--- a/app/models/emergency_login_key.rb
+++ b/app/models/emergency_login_key.rb
@@ -1,4 +1,5 @@
 class EmergencyLoginKey < ApplicationRecord
+  self.ignored_columns += %w[publisher_id]
   belongs_to :owner, polymorphic: true
   validates :not_valid_after, presence: true
 

--- a/app/models/emergency_login_key.rb
+++ b/app/models/emergency_login_key.rb
@@ -1,5 +1,5 @@
 class EmergencyLoginKey < ApplicationRecord
-  belongs_to :publisher
+  belongs_to :owner, polymorphic: true
   validates :not_valid_after, presence: true
 
   def expired?

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -1,5 +1,5 @@
 class Publisher < ApplicationRecord
-  has_many :emergency_login_keys
+  has_many :emergency_login_keys, as: :owner
   has_many :feedbacks, dependent: :destroy, inverse_of: :publisher
   has_many :notes, dependent: :destroy
   has_many :notifications, as: :recipient, dependent: :destroy, class_name: "Noticed::Notification"

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -96,6 +96,8 @@
   - publisher_id
   - created_at
   - updated_at
+  - owner_id
+  - owner_type
   :alert_runs:
   - id
   - subscription_id

--- a/db/migrate/20241028151455_add_owner_to_emergency_login_keys.rb
+++ b/db/migrate/20241028151455_add_owner_to_emergency_login_keys.rb
@@ -6,7 +6,9 @@ class AddOwnerToEmergencyLoginKeys < ActiveRecord::Migration[7.1]
     # Make publisher_id nullable to avoid NOT NULL constraint issues before deleting this column
     change_column_null :emergency_login_keys, :publisher_id, true
     # Add polymorphic owner reference
+    # rubocop:disable Rails/NotNullColumn
     add_reference :emergency_login_keys, :owner, polymorphic: true, type: :uuid, null: false
+    # rubocop:enable Rails/NotNullColumn
   end
 
   def down

--- a/db/migrate/20241028151455_add_owner_to_emergency_login_keys.rb
+++ b/db/migrate/20241028151455_add_owner_to_emergency_login_keys.rb
@@ -8,13 +8,13 @@ class AddOwnerToEmergencyLoginKeys < ActiveRecord::Migration[7.1]
     # Migrate existing records.
     EmergencyLoginKey.reset_column_information
     EmergencyLoginKey.find_each do |key|
-      key.update!(owner_id: key.publisher_id, owner_type: 'Publisher') if key.publisher_id.present?
+      key.update!(owner_id: key.publisher_id, owner_type: "Publisher") if key.publisher_id.present?
     end
   end
 
   def down
     # Migrate data back from owner columns
-    EmergencyLoginKey.where(owner_type: 'Publisher').find_each do |key|
+    EmergencyLoginKey.where(owner_type: "Publisher").find_each do |key|
       key.update!(publisher_id: key.owner_id)
     end
 

--- a/db/migrate/20241028151455_add_owner_to_emergency_login_keys.rb
+++ b/db/migrate/20241028151455_add_owner_to_emergency_login_keys.rb
@@ -1,0 +1,25 @@
+class AddOwnerToEmergencyLoginKeys < ActiveRecord::Migration[7.1]
+  def up
+    # Make publisher_id nullable to avoid NOT NULL constraint issues during data migration
+    change_column_null :emergency_login_keys, :publisher_id, true
+    # Add polymorphic owner reference
+    add_reference :emergency_login_keys, :owner, polymorphic: true, type: :uuid, null: true
+
+    # Migrate existing records.
+    EmergencyLoginKey.reset_column_information
+    EmergencyLoginKey.find_each do |key|
+      key.update!(owner_id: key.publisher_id, owner_type: 'Publisher') if key.publisher_id.present?
+    end
+  end
+
+  def down
+    # Migrate data back from owner columns
+    EmergencyLoginKey.where(owner_type: 'Publisher').find_each do |key|
+      key.update!(publisher_id: key.owner_id)
+    end
+
+    # Remove owner reference columns only if they exist
+    remove_column :emergency_login_keys, :owner_id if column_exists?(:emergency_login_keys, :owner_id)
+    remove_column :emergency_login_keys, :owner_type if column_exists?(:emergency_login_keys, :owner_type)
+  end
+end

--- a/db/migrate/20241028151455_add_owner_to_emergency_login_keys.rb
+++ b/db/migrate/20241028151455_add_owner_to_emergency_login_keys.rb
@@ -1,25 +1,22 @@
 class AddOwnerToEmergencyLoginKeys < ActiveRecord::Migration[7.1]
   def up
-    # Make publisher_id nullable to avoid NOT NULL constraint issues during data migration
+    # Emergency login keys are useless after 10 mins so no need to backfill them
+    EmergencyLoginKey.destroy_all
+
+    # Make publisher_id nullable to avoid NOT NULL constraint issues before deleting this column
     change_column_null :emergency_login_keys, :publisher_id, true
     # Add polymorphic owner reference
-    add_reference :emergency_login_keys, :owner, polymorphic: true, type: :uuid, null: true
-
-    # Migrate existing records.
-    EmergencyLoginKey.reset_column_information
-    EmergencyLoginKey.find_each do |key|
-      key.update!(owner_id: key.publisher_id, owner_type: "Publisher") if key.publisher_id.present?
-    end
+    add_reference :emergency_login_keys, :owner, polymorphic: true, type: :uuid, null: false
   end
 
   def down
-    # Migrate data back from owner columns
-    EmergencyLoginKey.where(owner_type: "Publisher").find_each do |key|
-      key.update!(publisher_id: key.owner_id)
-    end
+    # Emergency login keys are useless after 10 mins so no need to backfill them
+    EmergencyLoginKey.destroy_all
 
     # Remove owner reference columns only if they exist
-    remove_column :emergency_login_keys, :owner_id if column_exists?(:emergency_login_keys, :owner_id)
-    remove_column :emergency_login_keys, :owner_type if column_exists?(:emergency_login_keys, :owner_type)
+    remove_column :emergency_login_keys, :owner_id
+    remove_column :emergency_login_keys, :owner_type
+
+    change_column_null :emergency_login_keys, :publisher_id, false
   end
 end

--- a/db/migrate/20241029111208_remove_publisher_id_from_emergency_login_keys.rb
+++ b/db/migrate/20241029111208_remove_publisher_id_from_emergency_login_keys.rb
@@ -1,0 +1,5 @@
+class RemovePublisherIdFromEmergencyLoginKeys < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured { remove_column :emergency_login_keys, :publisher_id, :uuid }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_02_105609) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_28_151455) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -61,9 +61,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_02_105609) do
 
   create_table "emergency_login_keys", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "not_valid_after", precision: nil, null: false
-    t.uuid "publisher_id", null: false
+    t.uuid "publisher_id"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.string "owner_type"
+    t.uuid "owner_id"
+    t.index ["owner_type", "owner_id"], name: "index_emergency_login_keys_on_owner"
     t.index ["publisher_id"], name: "index_emergency_login_keys_on_publisher_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -64,8 +64,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_28_151455) do
     t.uuid "publisher_id"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.string "owner_type"
-    t.uuid "owner_id"
+    t.string "owner_type", null: false
+    t.uuid "owner_id", null: false
     t.index ["owner_type", "owner_id"], name: "index_emergency_login_keys_on_owner"
     t.index ["publisher_id"], name: "index_emergency_login_keys_on_publisher_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_28_151455) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_29_111208) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -61,13 +61,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_28_151455) do
 
   create_table "emergency_login_keys", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "not_valid_after", precision: nil, null: false
-    t.uuid "publisher_id"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "owner_type", null: false
     t.uuid "owner_id", null: false
     t.index ["owner_type", "owner_id"], name: "index_emergency_login_keys_on_owner"
-    t.index ["publisher_id"], name: "index_emergency_login_keys_on_publisher_id"
   end
 
   create_table "employments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -713,7 +711,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_28_151455) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "alert_runs", "subscriptions"
-  add_foreign_key "emergency_login_keys", "publishers"
   add_foreign_key "employments", "job_applications"
   add_foreign_key "employments", "jobseeker_profiles"
   add_foreign_key "equal_opportunities_reports", "vacancies"

--- a/spec/factories/emergency_login_keys.rb
+++ b/spec/factories/emergency_login_keys.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :emergency_login_key do
     not_valid_after { Date.current - 5.months }
-    publisher
+    owner
   end
 end

--- a/spec/jobs/clear_emergency_keys_job_spec.rb
+++ b/spec/jobs/clear_emergency_keys_job_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe ClearEmergencyLoginKeysJob do
   subject(:job) { described_class.perform_later }
+
   let(:publisher) { create(:publisher) }
 
   it "deletes all EmergencyLoginKeys" do

--- a/spec/jobs/clear_emergency_keys_job_spec.rb
+++ b/spec/jobs/clear_emergency_keys_job_spec.rb
@@ -2,9 +2,10 @@ require "rails_helper"
 
 RSpec.describe ClearEmergencyLoginKeysJob do
   subject(:job) { described_class.perform_later }
+  let(:publisher) { create(:publisher) }
 
   it "deletes all EmergencyLoginKeys" do
-    2.times { create(:emergency_login_key) }
+    2.times { EmergencyLoginKey.create(owner: publisher, not_valid_after: Date.current - 1.day) }
     expect { perform_enqueued_jobs { job } }
         .to change { EmergencyLoginKey.all.size }.from(2).to(0)
   end

--- a/spec/mailers/publishers/authentication_fallback_mailer_spec.rb
+++ b/spec/mailers/publishers/authentication_fallback_mailer_spec.rb
@@ -4,7 +4,7 @@ require "dfe/analytics/rspec/matchers"
 RSpec.describe Publishers::AuthenticationFallbackMailer do
   describe "the user receives the sign in email containing the magic link" do
     let(:publisher) { create(:publisher) }
-    let(:login_key) { publisher.emergency_login_keys.create(not_valid_after: Time.current + 10.minutes) }
+    let(:login_key) { EmergencyLoginKey.create(not_valid_after: Time.current + 10.minutes, owner: publisher) }
     let(:mail) { described_class.sign_in_fallback(login_key_id: login_key.id, publisher: publisher) }
     let(:notify_template) { NOTIFY_PRODUCTION_TEMPLATE }
     let(:expected_data) do

--- a/spec/models/emergency_login_key_spec.rb
+++ b/spec/models/emergency_login_key_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe EmergencyLoginKey do
-  it { is_expected.to belong_to(:publisher) }
+  it { is_expected.to belong_to(:owner) }
 
   describe "validations" do
     context "a new key" do

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Organisation do
   describe "email validation" do
     it "doesn't validate existing email" do
       org = described_class.new(email: "invalidaaddress")
-      org.save(validate: false)
+      org.save!(validate: false)
 
       expect(org).to be_valid
     end

--- a/spec/system/other/users_can_only_be_signed_in_to_one_type_of_account_spec.rb
+++ b/spec/system/other/users_can_only_be_signed_in_to_one_type_of_account_spec.rb
@@ -46,9 +46,7 @@ RSpec.describe "Users can only be signed in to one type of account" do
     context "when email fallback is enabled" do
       let(:authentication_fallback_enabled?) { true }
       let(:login_key) do
-        publisher.emergency_login_keys.create(
-          not_valid_after: Time.current + Publishers::LoginKeysController::EMERGENCY_LOGIN_KEY_DURATION,
-        )
+        EmergencyLoginKey.create(owner: publisher, not_valid_after: Time.current + Publishers::LoginKeysController::EMERGENCY_LOGIN_KEY_DURATION)
       end
 
       it "signs out from the jobseeker account when signing in as a publisher using DSI" do

--- a/spec/system/publishers/publishers_can_sign_in_by_email_spec.rb
+++ b/spec/system/publishers/publishers_can_sign_in_by_email_spec.rb
@@ -20,9 +20,7 @@ RSpec.describe "Publishers can sign in with fallback email authentication" do
     let(:publisher) { create(:publisher, organisations: organisations, accepted_terms_at: 1.day.ago) }
 
     let(:login_key) do
-      publisher.emergency_login_keys.create(
-        not_valid_after: Time.current + Publishers::LoginKeysController::EMERGENCY_LOGIN_KEY_DURATION,
-      )
+      EmergencyLoginKey.create(owner: publisher, not_valid_after: Time.current + Publishers::LoginKeysController::EMERGENCY_LOGIN_KEY_DURATION)
     end
 
     let(:message_delivery) { instance_double(ActionMailer::MessageDelivery) }


### PR DESCRIPTION
## Trello card URL

Work leading up to being able to complete this card: https://trello.com/c/EDeonNSy/1351-onelogin-set-fallback-sign-in-by-email-option-for-jobseekers

## Changes in this PR:

This PR makes the emergency_login_key model polymorphic. Emergency login keys are used for the fallback login method we use for hiring staff currently when we don't have access to DfE sign in (mainly used for testing on review apps).

I am making the emergency log in keys polymorphic so that we can introduce a similar fallback login flow for jobseekers. I think it makes sense for jobseekers also to be able to own emergency login keys in this scenario.

Note: I am destroying all existing emergency log in keys in the migration as they are currently only used by team members to sign in on review apps, are useless after 10 mins and are destroyed after use. Happy to change this to backfill the new column for existing emergency log in keys if the reviewer prefers, but I prefer this approach.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
