### PR TITLE
Add vacancy relisted event

### DIFF
--- a/app/controllers/publishers/vacancies/relist_controller.rb
+++ b/app/controllers/publishers/vacancies/relist_controller.rb
@@ -12,6 +12,7 @@ class Publishers::Vacancies::RelistController < Publishers::Vacancies::BaseContr
     @form = Publishers::JobListing::RelistForm.new(relist_params)
     if @form.valid?
       vacancy.update(@form.attributes_to_save.merge(status: :published))
+      trigger_publisher_vacancy_relisted_event
       update_google_index(vacancy)
       redirect_to organisation_job_summary_path(vacancy.id), success: t(".success", job_title: vacancy.job_title)
     else
@@ -25,5 +26,24 @@ class Publishers::Vacancies::RelistController < Publishers::Vacancies::BaseContr
   def relist_params
     params.require(:publishers_job_listing_relist_form)
           .permit(:expires_at, :expiry_time, :publish_on, :publish_on_day, :extension_reason, :other_extension_reason_details)
+  end
+
+  def trigger_publisher_vacancy_relisted_event
+    fail_safe do
+      event_data = {
+        data: {
+          relist_form: @form.attributes_to_save,
+        },
+      }
+
+      event = DfE::Analytics::Event.new
+                                   .with_type(:publisher_vacancy_relisted)
+                                   .with_request_details(request)
+                                   .with_response_details(response)
+                                   .with_user(current_publisher)
+                                   .with_data(event_data)
+
+      DfE::Analytics::SendEvents.do([event])
+    end
   end
 end

--- a/config/analytics_custom_events.yml
+++ b/config/analytics_custom_events.yml
@@ -29,6 +29,7 @@ shared:
   - publisher_job_application_data_expiry
   - publisher_prompt_for_feedback
   - publisher_sign_in_fallback
+  - publisher_vacancy_relisted
   - search_performed
   - successful_publisher_sign_in_attempt
   - support_user_sign_in_fallback

--- a/spec/system/publishers/publishers_can_extend_a_deadline_spec.rb
+++ b/spec/system/publishers/publishers_can_extend_a_deadline_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "dfe/analytics/rspec/matchers"
 
 RSpec.describe "Publishers can extend a deadline" do
   let(:organisation) { create(:school) }
@@ -86,6 +87,10 @@ RSpec.describe "Publishers can extend a deadline" do
         expect(new_vacancy).to have_attributes(extension_reason: "didnt_find_right_candidate",
                                                publish_on: Date.today,
                                                expires_at: expires_at)
+      end
+
+      it "sends an event to analytics" do
+        expect(:publisher_vacancy_relisted).to have_been_enqueued_as_analytics_events
       end
 
       context "when looking at tabs" do


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/Ha7c4eKN/1342-check-add-a-separate-analytics-event-for-the-new-relisting-job-journey

## Changes in this PR:
We are adding a new event for relisting vacancies
