### PR TITLE
Add DFE Analytics events to GovUK OneLogin sign-in

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -70,4 +70,32 @@ class AuthenticationController < ApplicationController
 
     DfE::Analytics::SendEvents.do([event])
   end
+
+  def trigger_jobseeker_failed_govuk_one_login_sign_in_event(jobseeker = nil)
+    event = DfE::Analytics::Event.new
+      .with_type(:jobseeker_failed_govuk_one_login_sign_in)
+      .with_request_details(request)
+      .with_response_details(response)
+      .with_user(jobseeker)
+      .with_data(
+        hidden_data: { email_identifier: jobseeker&.email,
+                       govuk_one_login_id: jobseeker&.govuk_one_login_id },
+      )
+
+    DfE::Analytics::SendEvents.do([event])
+  end
+
+  def trigger_jobseeker_successful_govuk_one_login_sign_in_event(jobseeker)
+    event = DfE::Analytics::Event.new
+      .with_type(:jobseeker_successful_govuk_one_login_sign_in)
+      .with_request_details(request)
+      .with_response_details(response)
+      .with_user(jobseeker)
+      .with_data(
+        hidden_data: { email_identifier: jobseeker&.email,
+                       govuk_one_login_id: jobseeker&.govuk_one_login_id },
+      )
+
+    DfE::Analytics::SendEvents.do([event])
+  end
 end

--- a/app/controllers/jobseekers/govuk_one_login_callbacks_controller.rb
+++ b/app/controllers/jobseekers/govuk_one_login_callbacks_controller.rb
@@ -15,9 +15,11 @@ class Jobseekers::GovukOneLoginCallbacksController < Devise::OmniauthCallbacksCo
 
     if jobseeker
       sign_out_except(:jobseeker)
+      trigger_jobseeker_successful_govuk_one_login_sign_in_event(jobseeker)
       sign_in_and_redirect jobseeker
     end
   rescue GovukOneLoginError => e
+    trigger_jobseeker_failed_govuk_one_login_sign_in_event(jobseeker)
     Rails.logger.error(e.message)
     error_redirect
   end

--- a/config/analytics_custom_events.yml
+++ b/config/analytics_custom_events.yml
@@ -13,6 +13,7 @@ shared:
   - jobseeker_application_unsuccessful
   - jobseeker_confirmation_instructions
   - jobseeker_email_changed
+  - jobseeker_failed_govuk_one_login_sign_in
   - jobseeker_inactive_account
   - jobseeker_job_listing_ended_early
   - jobseeker_request_account_transfer
@@ -20,6 +21,7 @@ shared:
   - jobseeker_subscription_alert
   - jobseeker_subscription_confirmation
   - jobseeker_subscription_update
+  - jobseeker_successful_govuk_one_login_sign_in
   - jobseeker_draft_application_only
   - jobseeker_unapplied_saved_vacancy
   - publisher_applications_received


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/YSZzirDQ

## Changes in this PR:

For every successful/failed Jobseeker attempt to sign in with GovUK One Login into our service, we will send a corresponding event to DFE Analytics.
