### PR TITLE
Use h2 instead of h3 for subtitle on location preferences page

### DIFF
--- a/app/views/jobseekers/profiles/job_preferences/location.html.slim
+++ b/app/views/jobseekers/profiles/job_preferences/location.html.slim
@@ -12,11 +12,11 @@
         | Location
       .govuk-form-group.autocomplete data-source="getLocationSuggestions" data-controller="autocomplete" data-debouncems="400"
         = f.govuk_text_field :location,
-          label: { text: "Location", size: "m" },
+          label: -> { tag.h2("Location") },
           hint: { text: t("activemodel.location.hint") },
           form_group: { classes: %w[location-finder__input govuk-!-margin-bottom-0] }
 
-      = f.govuk_collection_radio_buttons :radius, f.object.radius_options, :first, :last, legend: { text: "Search radius", size: "m" }
+      = f.govuk_collection_radio_buttons :radius, f.object.radius_options, :first, :last, legend: -> { tag.h2("Search radius") }
 
       = f.govuk_submit "Save and continue"
       p = f.link_to "Cancel", escape_path


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/FA574QHl/1374-accessibility-heading-structure-incorrect-profile-job-preferences-locations-add-a-new-location

## Changes in this PR:

Changing the h3 subtitles on location preferences page to h2s for accessibility purposes

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
