### PR TITLE
Add task to delete unconfirmed jobseekers

### DIFF
--- a/lib/tasks/delete_unconfirmed_jobseeker_accounts.rake
+++ b/lib/tasks/delete_unconfirmed_jobseeker_accounts.rake
@@ -1,0 +1,6 @@
+namespace :jobseekers do
+  desc "Delete all the unconfirmed jobseeker accounts not associated with any GovUK OneLogin account"
+  task delete_unconfirmed_accounts: :environment do
+    Jobseeker.where(confirmed_at: nil, govuk_one_login_id: nil).destroy_all
+  end
+end

--- a/spec/tasks/delete_unconfirmed_jobseeker_accounts_spec.rb
+++ b/spec/tasks/delete_unconfirmed_jobseeker_accounts_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe "jobseekers:delete_unconfirmed_accounts" do
+  it "deletes a Jobseeker account that is unconfirmed and not associated with a GovUK OneLogin account" do
+    create(:jobseeker, confirmed_at: nil, govuk_one_login_id: nil)
+    expect { task.invoke }.to change(Jobseeker, :count).by(-1)
+  end
+
+  it "does not delete a Jobseeker account that is unconfirmed and has been associated with a GovUK OneLogin account" do
+    create(:jobseeker, confirmed_at: nil, govuk_one_login_id: SecureRandom.alphanumeric(6))
+    expect { task.invoke }.not_to change(Jobseeker, :count)
+  end
+
+  it "does not delete a Jobseeker account that is confirmed" do
+    create(:jobseeker)
+    expect { task.invoke }.not_to change(Jobseeker, :count)
+  end
+end


### PR DESCRIPTION
## Trello card URL

- Part of the checklist in [this ticket](https://trello.com/c/iA0TDkHy/1174-govuk-one-login-release-ticket-final-checklist)

We will delete all the registered but unconfirmed accounts prior to gov UK one login creation/update.