### PR TITLE
Remove nav for accessibility purposes

### DIFF
--- a/app/components/dashboard_component/dashboard_component.html.slim
+++ b/app/components/dashboard_component/dashboard_component.html.slim
@@ -25,7 +25,14 @@
   .govuk-grid-row class="govuk-!-margin-bottom-7"
     - if @vacancies.many?
       .govuk-grid-column-full
-        = render SortComponent.new sort: @sort, url_params: { type: @selected_type }, path: method(:organisation_jobs_with_type_path)
+        ul.sort-component__list
+          - @sort.each do |option|
+            li.sort-component__list-item
+              - if option.by == @sort.by
+                = option.display_name.humanize
+              - else
+                = govuk_link_to(safe_join([tag.span("#{t('jobs.sort_by.label')} ", class: "govuk-visually-hidden"), option.display_name.humanize]), organisation_jobs_with_type_path({sort_by: option.by, type: @selected_type}))
+
     - if @organisation.school_group?
       .govuk-grid-column-one-third-at-desktop class="govuk-!-margin-bottom-4"
         - if @organisation.local_authority?

--- a/app/components/dashboard_component/dashboard_component.html.slim
+++ b/app/components/dashboard_component/dashboard_component.html.slim
@@ -31,7 +31,7 @@
               - if option.by == @sort.by
                 = option.display_name.humanize
               - else
-                = govuk_link_to(safe_join([tag.span("#{t('jobs.sort_by.label')} ", class: "govuk-visually-hidden"), option.display_name.humanize]), organisation_jobs_with_type_path({sort_by: option.by, type: @selected_type}))
+                = govuk_link_to(safe_join([tag.span("#{t('jobs.sort_by.label')} ", class: "govuk-visually-hidden"), option.display_name.humanize]), organisation_jobs_with_type_path({ sort_by: option.by, type: @selected_type }))
 
     - if @organisation.school_group?
       .govuk-grid-column-one-third-at-desktop class="govuk-!-margin-bottom-4"


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/WfHBvyAy/1375-accessibility-hiring-staff-active-jobs-page-duplicate-navigation-elements

## Changes in this PR:

During an accessibility audit this page was found to have issues due to have two nav elements in close proximity. To fix this i have taken the code from the sort component and hard coded it onto the page with the nav that wraps it removed. I did not remove the nav from the actual component because this component is used in multiple other places, none of which (as far as I know) are causing accessibility issues.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
