### PR TITLE
One login page not found issue

### DIFF
--- a/app/controllers/jobseekers/govuk_one_login_callbacks_controller.rb
+++ b/app/controllers/jobseekers/govuk_one_login_callbacks_controller.rb
@@ -45,9 +45,11 @@ class Jobseekers::GovukOneLoginCallbacksController < Devise::OmniauthCallbacksCo
   end
 
   def error_redirect
-    return if jobseeker_signed_in?
-
-    flash[:alert] = I18n.t("jobseekers.govuk_one_login_callbacks.openid_connect.error")
+    flash[:alert] = if jobseeker_signed_in?
+                      "You are already successfully signed in"
+                    else
+                      I18n.t("jobseekers.govuk_one_login_callbacks.openid_connect.error")
+                    end
     redirect_to root_path
   end
 

--- a/app/controllers/jobseekers/govuk_one_login_callbacks_controller.rb
+++ b/app/controllers/jobseekers/govuk_one_login_callbacks_controller.rb
@@ -3,6 +3,11 @@ class Jobseekers::GovukOneLoginCallbacksController < Devise::OmniauthCallbacksCo
   # Devise redirects response from Govuk One Login to this method.
   # The request parameters contain the response from Govuk One Login from the user authentication through their portal.
   def openid_connect
+    if jobseeker_signed_in?
+      flash[:alert] = I18n.t("jobseekers.govuk_one_login_callbacks.openid_connect.already_signed_in")
+      redirect_to root_path and return
+    end
+
     govuk_one_login_user = Jobseekers::GovukOneLogin::UserFromAuthResponse.call(params, session)
     return error_redirect unless govuk_one_login_user
 
@@ -45,11 +50,7 @@ class Jobseekers::GovukOneLoginCallbacksController < Devise::OmniauthCallbacksCo
   end
 
   def error_redirect
-    flash[:alert] = if jobseeker_signed_in?
-                      "You are already successfully signed in"
-                    else
-                      I18n.t("jobseekers.govuk_one_login_callbacks.openid_connect.error")
-                    end
+    flash[:alert] = I18n.t("jobseekers.govuk_one_login_callbacks.openid_connect.error")
     redirect_to root_path
   end
 

--- a/app/controllers/jobseekers/govuk_one_login_callbacks_controller.rb
+++ b/app/controllers/jobseekers/govuk_one_login_callbacks_controller.rb
@@ -2,6 +2,7 @@ class Jobseekers::GovukOneLoginCallbacksController < Devise::OmniauthCallbacksCo
   include Jobseekers::GovukOneLogin::Errors
   # Devise redirects response from Govuk One Login to this method.
   # The request parameters contain the response from Govuk One Login from the user authentication through their portal.
+  # rubocop:disable Metrics/MethodLength
   def openid_connect
     if jobseeker_signed_in?
       flash[:alert] = I18n.t("jobseekers.govuk_one_login_callbacks.openid_connect.already_signed_in")
@@ -28,6 +29,7 @@ class Jobseekers::GovukOneLoginCallbacksController < Devise::OmniauthCallbacksCo
     Rails.logger.error(e.message)
     error_redirect
   end
+  # rubocop:enable Metrics/MethodLength
 
   private
 


### PR DESCRIPTION
## Trello card URL

## Changes in this PR:

We are seeing quite a few of[ these "Page not found" issues ](https://clarity.microsoft.com/projects/view/obwl2wv90g/impressions?date=Last%202%20days&heatmapDeviceType=0&heatmapType=0&URL=2%3B6%3B%5Ehttps%3A%2F%2Fteaching-vacancies%5C.service%5C.gov%5C.uk%2Fjobseekers%2Fauth%2Fgovuk_one_login%2Fcallback(%5C%3F.*)%3F%24) when users are logging in via one login. I'm not totally sure what user behaviour is leading to this, but one example was a user having logged in and then clicking the back button repeatedly. Currently the GovukOneLoginCallbacksController catches GovukOneLoginError but if the user is already logged in then it doesn't redirect them anywhere and we don't have a view for `openid_connect` so I think this might be causing these errors.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
