### PR TITLE
Work history validation change

### DIFF
--- a/app/form_models/jobseekers/job_application/details/employment_form.rb
+++ b/app/form_models/jobseekers/job_application/details/employment_form.rb
@@ -9,7 +9,7 @@ class Jobseekers::JobApplication::Details::EmploymentForm
   validates :organisation, :job_title, :main_duties, :reason_for_leaving, presence: true
   validates :started_on, date: { before: :today }
   validates :current_role, inclusion: { in: %w[yes no] }
-  validates :ended_on, date: { before: :today, after: :started_on }, if: -> { current_role == "no" }
+  validates :ended_on, date: { before: :today, on_or_after: :started_on }, if: -> { current_role == "no" }
 
   def started_on=(value)
     @started_on = date_from_multiparameter_hash(value)

--- a/app/form_models/jobseekers/profile/employment_form.rb
+++ b/app/form_models/jobseekers/profile/employment_form.rb
@@ -12,7 +12,7 @@ class Jobseekers::Profile::EmploymentForm < BaseForm
   validates :organisation, :job_title, :main_duties, :reason_for_leaving, presence: true
   validates :started_on, date: { before: :today }
   validates :current_role, inclusion: { in: %w[yes no] }
-  validates :ended_on, date: { before: :today, after: :started_on }, if: -> { current_role == "no" }
+  validates :ended_on, date: { before: :today, on_or_after: :started_on }, if: -> { current_role == "no" }
 
   def started_on=(value)
     @started_on = date_from_multiparameter_hash(value)

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -620,7 +620,7 @@ en:
             current_role:
               inclusion: Select yes if this is your current role
             ended_on:
-              after: End date must be after the start date
+              on_or_after: End date must be on or after the start date
               before: The date the role ended must be in the past
               blank: Enter the date you left this school or organisation
               invalid: Enter a date in the correct format
@@ -706,7 +706,7 @@ en:
             current_role:
               inclusion: Select yes if this is your current role
             ended_on:
-              after: End date must be after the start date
+              on_or_after: End date must be on or after the start date
               before: The date the role ended must be in the past
               blank: Enter the date you left this school or organisation
               invalid: Enter a date in the correct format

--- a/spec/form_models/jobseekers/job_application/details/employment_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/details/employment_form_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Jobseekers::JobApplication::Details::EmploymentForm, type: :model
 
       it "is invalid" do
         expect(subject).not_to be_valid
-        expect(subject.errors.of_kind?(:ended_on, :after)).to be true
+        expect(subject.errors.of_kind?(:ended_on, :on_or_after)).to be true
       end
     end
   end
@@ -115,6 +115,18 @@ RSpec.describe Jobseekers::JobApplication::Details::EmploymentForm, type: :model
 
     it "is valid" do
       expect(subject).to be_valid
+    end
+
+    context "when ended_on is on the same date as started_on" do
+      let(:params) do
+        { organisation: "An organisation", job_title: "A job title", main_duties: "Some main duties",
+        current_role: "no", "started_on(1i)" => "2019", "started_on(2i)" => "09", "started_on(3i)" => "30",
+        "ended_on(1i)" => "2019", "ended_on(2i)" => "09", "ended_on(3i)" => "30", reason_for_leaving: "stress" }
+      end
+
+      it "is valid" do
+        expect(subject).to be_valid
+      end
     end
   end
 end

--- a/spec/form_models/jobseekers/job_application/details/employment_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/details/employment_form_spec.rb
@@ -120,8 +120,8 @@ RSpec.describe Jobseekers::JobApplication::Details::EmploymentForm, type: :model
     context "when ended_on is on the same date as started_on" do
       let(:params) do
         { organisation: "An organisation", job_title: "A job title", main_duties: "Some main duties",
-        current_role: "no", "started_on(1i)" => "2019", "started_on(2i)" => "09", "started_on(3i)" => "30",
-        "ended_on(1i)" => "2019", "ended_on(2i)" => "09", "ended_on(3i)" => "30", reason_for_leaving: "stress" }
+          current_role: "no", "started_on(1i)" => "2019", "started_on(2i)" => "09", "started_on(3i)" => "30",
+          "ended_on(1i)" => "2019", "ended_on(2i)" => "09", "ended_on(3i)" => "30", reason_for_leaving: "stress" }
       end
 
       it "is valid" do

--- a/spec/form_models/jobseekers/profiles/employment_form_spec.rb
+++ b/spec/form_models/jobseekers/profiles/employment_form_spec.rb
@@ -6,23 +6,33 @@ RSpec.describe Jobseekers::Profile::EmploymentForm, type: :model do
   it { is_expected.to validate_presence_of(:started_on) }
 
   context "when #ended_on is present" do
-    context "when #start_on is after #ended_on" do
-      subject { described_class.new(started_on: Date.today, ended_on: Date.yesterday) }
+    context "when it is not the current role" do
+      context "when #start_on is after #ended_on" do
+        subject { described_class.new(started_on: Date.yesterday, ended_on: Date.yesterday - 1.day, current_role: "no") }
 
-      it "adds an error to the form" do
-        subject.valid?
-
-        expect(subject.errors.added?(:started_on, :before)).to be true
+        it "adds an error to the form" do
+          subject.valid?
+          binding.pry
+          expect(subject.errors.added?(:ended_on, :on_or_after)).to be true
+        end
       end
-    end
 
-    context "when #start_on is after #ended_on" do
-      subject { described_class.new(started_on: Date.today, ended_on: Date.yesterday) }
+      context "when #start_on is before #ended_on" do
+        subject { described_class.new(started_on: Date.yesterday, ended_on: Date.today, current_role: "no") }
 
-      it "does not add an error to the form" do
-        subject.valid?
+        it "does not add an error to the form" do
+          subject.valid?
+          expect(subject.errors.added?(:ended_on, :on_or_after)).to be false
+        end
+      end
 
-        expect(subject.errors.added?(:started_on, :before)).to be true
+      context "when #ended_on is on the same day as #started_on" do
+        subject { described_class.new(started_on: Date.yesterday, ended_on: Date.yesterday, current_role: "no") }
+
+        it "does not add an error to the form" do
+          subject.valid?
+          expect(subject.errors.added?(:ended_on, :on_or_after)).to be false
+        end
       end
     end
   end

--- a/spec/form_models/jobseekers/profiles/employment_form_spec.rb
+++ b/spec/form_models/jobseekers/profiles/employment_form_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Jobseekers::Profile::EmploymentForm, type: :model do
 
         it "adds an error to the form" do
           subject.valid?
-          binding.pry
           expect(subject.errors.added?(:ended_on, :on_or_after)).to be true
         end
       end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/x2ubHlSi/1382-work-history-issue-adding-roles-that-start-end-in-the-same-month

## Changes in this PR:

This PR changes validation logic on our work history sections of both the job application and jobseeker profile to accept jobs that start and finish on the same day.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
