### PR TITLE
Fix account merge bug

### DIFF
--- a/app/controllers/jobseekers/account_transfers_controller.rb
+++ b/app/controllers/jobseekers/account_transfers_controller.rb
@@ -31,7 +31,7 @@ class Jobseekers::AccountTransfersController < Jobseekers::BaseController
   def successfully_transfer_account_data?
     Jobseekers::AccountTransfer.new(current_jobseeker, @account_transfer_form.email).call
     true
-  rescue Jobseekers::AccountTransfer::AccountNotFoundError, ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e
+  rescue Jobseekers::AccountTransfer::AccountNotFoundError, Jobseekers::AccountTransfer::CannotDeleteCurrentAccountError, ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e
     Rails.logger.error("Account transfer failed: #{e.message}")
     Rails.logger.error("Account transfer failed on #{e.record.class.name} with ID: #{e.record.id}")
     Rails.logger.error("Validation errors: #{e.record.errors.full_messages.join(', ')}")

--- a/app/services/jobseekers/account_transfer.rb
+++ b/app/services/jobseekers/account_transfer.rb
@@ -57,6 +57,7 @@ class Jobseekers::AccountTransfer
 
   def destroy_account_to_transfer
     raise CannotDeleteCurrentAccountError, "Cannot delete the currently logged in account" if @current_jobseeker == @account_to_transfer
+
     account_to_transfer.reload.destroy
   end
 end

--- a/app/services/jobseekers/account_transfer.rb
+++ b/app/services/jobseekers/account_transfer.rb
@@ -1,5 +1,6 @@
 class Jobseekers::AccountTransfer
   class AccountNotFoundError < StandardError; end
+  class CannotDeleteCurrentAccountError < StandardError; end
   attr_reader :current_jobseeker, :account_to_transfer
 
   def initialize(current_jobseeker, email)
@@ -16,7 +17,7 @@ class Jobseekers::AccountTransfer
       transfer_job_applications
       transfer_saved_jobs
       update_subscriptions
-      account_to_transfer.reload.destroy
+      destroy_account_to_transfer
     end
   end
 
@@ -52,5 +53,10 @@ class Jobseekers::AccountTransfer
     Subscription.where(email: account_to_transfer.email).each do |subscription|
       subscription.update!(email: current_jobseeker.email)
     end
+  end
+
+  def destroy_account_to_transfer
+    raise CannotDeleteCurrentAccountError, "Cannot delete the currently logged in account" if @current_jobseeker == @account_to_transfer
+    account_to_transfer.reload.destroy
   end
 end

--- a/spec/services/jobseekers/account_transfer_spec.rb
+++ b/spec/services/jobseekers/account_transfer_spec.rb
@@ -97,5 +97,13 @@ RSpec.describe Jobseekers::AccountTransfer do
         expect(Jobseeker.exists?(account_to_transfer.id)).to eq true
       end
     end
+
+    context "when jobseeker tries to import data from an account they are currently logged in as" do
+      it "raises an error and does not delete the current jobseeker" do
+        service = described_class.new(current_jobseeker, current_jobseeker.email)
+        expect { service.call }.to raise_error(Jobseekers::AccountTransfer::CannotDeleteCurrentAccountError)
+        expect(Jobseeker.exists?(current_jobseeker.id)).to eq true
+      end
+    end
   end
 end


### PR DESCRIPTION
## Trello card URL

## Changes in this PR:

There is currently an account merge bug which allows current jobseeker to delete their active, logged in account. This is happening because after merging data, the account from which the data was merged is then deleted. Prior to this change it was possible for a jobseeker to be logged in as "user@example.com" and request to merge data from "user@example.com" which then would delete their account, logging them out and losing all their data.

This PR fixes this issue by raising an error if the jobseeker tries to merge the account they are logged in as currently into itself.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
