### PR TITLE
Validate data transfer request

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
  # Alpine v3.19.
  # TODO: Regularly check in the alpine ruby "3.3.5-alpine3.19" images for its latest upgraded packages so we can remove
  # the hardcoded versions below when they have been updated in the alpine ruby image.
-ARG PROD_PACKAGES="imagemagick libpng libjpeg libxml2 libxslt libpq tzdata shared-mime-info postgresql15 busybox=1.36.1-r19 openssl=3.1.7-r1"
+ARG PROD_PACKAGES="imagemagick libpng libjpeg libxml2 libxslt libpq tzdata shared-mime-info postgresql15 busybox=1.36.1-r19 openssl=3.1.7-r1 expat=2.6.4-r0"
 
 FROM ruby:3.3.5-alpine3.19 AS builder
 

--- a/app/controllers/jobseekers/request_account_transfer_emails_controller.rb
+++ b/app/controllers/jobseekers/request_account_transfer_emails_controller.rb
@@ -4,7 +4,7 @@ class Jobseekers::RequestAccountTransferEmailsController < Jobseekers::BaseContr
   end
 
   def create
-    @request_account_transfer_email_form = Jobseekers::RequestAccountTransferEmailForm.new(request_account_transfer_email_form_params)
+    @request_account_transfer_email_form = Jobseekers::RequestAccountTransferEmailForm.new(request_account_transfer_email_form_params.merge({current_jobseeker_email: current_jobseeker.email}))
 
     if @request_account_transfer_email_form.valid?
       jobseeker = Jobseeker.find_by(email: @request_account_transfer_email_form.email.downcase)

--- a/app/controllers/jobseekers/request_account_transfer_emails_controller.rb
+++ b/app/controllers/jobseekers/request_account_transfer_emails_controller.rb
@@ -4,7 +4,7 @@ class Jobseekers::RequestAccountTransferEmailsController < Jobseekers::BaseContr
   end
 
   def create
-    @request_account_transfer_email_form = Jobseekers::RequestAccountTransferEmailForm.new(request_account_transfer_email_form_params.merge({current_jobseeker_email: current_jobseeker.email}))
+    @request_account_transfer_email_form = Jobseekers::RequestAccountTransferEmailForm.new(request_account_transfer_email_form_params.merge({ current_jobseeker_email: current_jobseeker.email }))
 
     if @request_account_transfer_email_form.valid?
       jobseeker = Jobseeker.find_by(email: @request_account_transfer_email_form.email.downcase)

--- a/app/form_models/jobseekers/request_account_transfer_email_form.rb
+++ b/app/form_models/jobseekers/request_account_transfer_email_form.rb
@@ -1,9 +1,10 @@
 class Jobseekers::RequestAccountTransferEmailForm < BaseForm
-  attr_accessor :email, :email_resent
+  attr_accessor :email, :email_resent, :current_jobseeker_email
 
   validates :email, presence: true
   validates :email, email_address: true
   validate :validate_recent_code_request, if: -> { email.present? }
+  validate :validate_account_to_transfer_is_not_the_currently_logged_in_user, if: -> { email.present? }
 
   def validate_recent_code_request
     jobseeker = Jobseeker.find_by(email: email.downcase)
@@ -15,8 +16,8 @@ class Jobseekers::RequestAccountTransferEmailForm < BaseForm
   end
 
   def validate_account_to_transfer_is_not_the_currently_logged_in_user
-    return unless email.downcase == current_jobseeker.email.downcase
+    return unless email.downcase == current_jobseeker_email.downcase
 
-    errors.add(:email, :recent_code_request, message: I18n.t("jobseekers.request_account_transfer_emails.errors.recent_code_request"))
+    errors.add(:email, :cannot_transfer_to_same_account, message: I18n.t("jobseekers.request_account_transfer_emails.errors.cannot_transfer_logged_in_account"))
   end
 end

--- a/app/form_models/jobseekers/request_account_transfer_email_form.rb
+++ b/app/form_models/jobseekers/request_account_transfer_email_form.rb
@@ -13,4 +13,10 @@ class Jobseekers::RequestAccountTransferEmailForm < BaseForm
 
     errors.add(:email, :recent_code_request, message: I18n.t("jobseekers.request_account_transfer_emails.errors.recent_code_request"))
   end
+
+  def validate_account_to_transfer_is_not_the_currently_logged_in_user
+    return unless email.downcase == current_jobseeker.email.downcase
+
+    errors.add(:email, :recent_code_request, message: I18n.t("jobseekers.request_account_transfer_emails.errors.recent_code_request"))
+  end
 end

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -972,7 +972,7 @@ en:
         hint: If you have an account associated with this email address, we'll send you an email to verify your details.
       errors:
         recent_code_request: Please wait 1 minute before requesting another code.
-        cannot_transfer_logged_in_account: You cannot request to transfer data from the account you are currently logged in as.
+        cannot_transfer_logged_in_account: You entered the email of the account you are currently logged in to. The data in this account is already available to you and cannot be transferred.
       success: Email resent
     account_transfers:
       new:

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -972,6 +972,7 @@ en:
         hint: If you have an account associated with this email address, we'll send you an email to verify your details.
       errors:
         recent_code_request: Please wait 1 minute before requesting another code.
+        cannot_transfer_logged_in_account: You cannot request to transfer data from the account you are currently logged in as.
       success: Email resent
     account_transfers:
       new:

--- a/spec/system/jobseekers/jobseekers_can_transfer_data_from_old_account_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_transfer_data_from_old_account_spec.rb
@@ -89,32 +89,10 @@ RSpec.describe "Jobseekers can transfer data from an old account" do
 
       fill_in "jobseekers_request_account_transfer_email_form[email]", with: jobseeker.email
       click_on "Save and continue"
-      expect(delivered_emails.last.subject).to eq "Transfer your account data"
-      expect(delivered_emails.last.body.raw_source).to include "Your verification code: #{jobseeker.reload.account_merge_confirmation_code}"
 
-      # Before transfer, create some data in the jobseeker account
-      jobseeker.jobseeker_profile.destroy!
-      profile = create(:jobseeker_profile, :completed, jobseeker: jobseeker)
-      submitted_application = create(:job_application, :status_submitted, jobseeker: jobseeker)
-
-      # Attempt to transfer data to the same account
-      fill_in "jobseekers_account_transfer_form[account_merge_confirmation_code]", with: jobseeker.account_merge_confirmation_code
-      click_on "Confirm account transfer"
-      expect(page).to have_content I18n.t("jobseekers.account_transfers.create.failure")
-
-      # Jobseeker hasn't lost any data
-      click_on "Your profile"
-
-      expect(page).to have_content profile.first_name
-      expect(page).to have_content profile.last_name
-      expect(page).to have_content profile.qualifications.first.name
-      expect(page).to have_content profile.employments.first.organisation
-      expect(page).to have_content profile.training_and_cpds.first.name
-
-      click_on "Applications"
-
-      expect(page).to have_content "Applications (1)"
-      expect(page).to have_content submitted_application.vacancy.job_title
+      within "ul.govuk-list.govuk-error-summary__list" do
+        expect(page).to have_link("You entered the email of the account you are currently logged in to. The data in this account is already available to you and cannot be transferred.", href: "#jobseekers-request-account-transfer-email-form-email-field-error")
+      end
     end
   end
 


### PR DESCRIPTION
## Changes in this PR:

This PR stops users being able to request to transfer data from the same account that they're currently logged into.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
