### PR TITLE
Fix link on subscription emails

### DIFF
--- a/app/helpers/notify_views_helper.rb
+++ b/app/helpers/notify_views_helper.rb
@@ -89,7 +89,7 @@ module NotifyViewsHelper
   end
 
   def sign_up_link
-    url = new_jobseeker_registration_url(**utm_params)
+    url = new_jobseeker_session_url(**utm_params)
     notify_link(url, t(".create_account.link"))
   end
 


### PR DESCRIPTION
The registration path should point to OneLogin bridge page, not to devise registration.
