### PR TITLE
Update content security policy

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -42,6 +42,8 @@ Rails.application.configure do
                        "https://www.clarity.ms"
 
     policy.style_src   :self
+
+    policy.worker_src  :self, :blob
   end
 
   # Generate session nonces for permitted importmap and inline scripts


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/ubh6Cciz/1397-investigate-recent-frontend-thousands-of-sentry-error-events

## Changes in this PR:

Enable blob sources for workers as needed to make VWO function properly in the attempt to solve this error.

```
SecurityError: Failed to construct 'Worker': Access to the script at 'blob:https://teaching-vacancies.service.gov.uk/17565d72-1b98-48ad-8da6-6b14ba86b5d4' is denied by the document's Content Security Policy.
```
