### PR TITLE
Email updates

### DIFF
--- a/app/helpers/notify_views_helper.rb
+++ b/app/helpers/notify_views_helper.rb
@@ -32,6 +32,11 @@ module NotifyViewsHelper
     notify_link(url, text)
   end
 
+  def writing_job_application_advice_link(text)
+    url = jobseeker_guides_write_a_great_teaching_job_application_in_five_steps_url
+    notify_link(url, text)
+  end
+
   def invitation_to_apply_vacancy_link(vacancy)
     url = job_url(vacancy)
     url_with_utm_params = job_url(vacancy, **utm_params)

--- a/app/helpers/notify_views_helper.rb
+++ b/app/helpers/notify_views_helper.rb
@@ -37,6 +37,16 @@ module NotifyViewsHelper
     notify_link(url, text)
   end
 
+  def teaching_job_interview_link(text)
+    url = jobseeker_guides_how_to_approach_a_teaching_job_interview_url
+    notify_link(url, text)
+  end
+
+  def teaching_job_interview_lesson_link(text)
+    url = jobseeker_guides_prepare_for_a_teaching_job_interview_lesson_url
+    notify_link(url, text)
+  end
+
   def invitation_to_apply_vacancy_link(vacancy)
     url = job_url(vacancy)
     url_with_utm_params = job_url(vacancy, **utm_params)

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -297,5 +297,9 @@ class Vacancy < ApplicationRecord
                        end
     reset_markers if persisted? && (listed? || pending?)
   end
+
+  def is_a_teaching_or_middle_leader_role?
+    (["teacher", "head_of_year_or_phase", "head_of_department_or_curriculum", "sendco", "other_leadership"] && (ja.vacancy.job_roles)).any?
+  end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -262,6 +262,10 @@ class Vacancy < ApplicationRecord
     end
   end
 
+  def is_a_teaching_or_middle_leader_role?
+    job_roles.intersect?(["teacher", "head_of_year_or_phase", "head_of_department_or_curriculum", "sendco", "other_leadership"])
+  end
+
   private
 
   def calculate_distance(search_coordinates, geolocation)
@@ -296,10 +300,6 @@ class Vacancy < ApplicationRecord
                          points.presence && points.first.factory.multi_point(points)
                        end
     reset_markers if persisted? && (listed? || pending?)
-  end
-
-  def is_a_teaching_or_middle_leader_role?
-    (["teacher", "head_of_year_or_phase", "head_of_department_or_curriculum", "sendco", "other_leadership"] && (ja.vacancy.job_roles)).any?
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -263,7 +263,7 @@ class Vacancy < ApplicationRecord
   end
 
   def is_a_teaching_or_middle_leader_role?
-    job_roles.intersect?(["teacher", "head_of_year_or_phase", "head_of_department_or_curriculum", "sendco", "other_leadership"])
+    job_roles.intersect?(%w[teacher head_of_year_or_phase head_of_department_or_curriculum sendco other_leadership])
   end
 
   private

--- a/app/views/jobseekers/job_application_mailer/application_shortlisted.text.erb
+++ b/app/views/jobseekers/job_application_mailer/application_shortlisted.text.erb
@@ -9,10 +9,10 @@
   <%= @job_application.further_instructions %>
 <% end %>
 
-<% if @vacancy.is_teaching_or_middle_leader_role? %>
-  <%= t(".read_advice_from")
-  <%= notify_link("/jobseeker-guides/get-help-applying-for-your-teaching-role/how-to-approach-a-teaching-job-interview", t(".teaching_job_interview"))
-  <%= notify_link("/jobseeker-guides/get-help-applying-for-your-teaching-role/prepare-for-a-teaching-job-interview-lesson", t(".teaching_interview_lession"))
+<% if @vacancy.is_a_teaching_or_middle_leader_role? %>
+  <%= t(".read_advice_from") %>
+  <%= notify_link("/jobseeker-guides/get-help-applying-for-your-teaching-role/how-to-approach-a-teaching-job-interview", t(".teaching_job_interview")) %>
+  <%= notify_link("/jobseeker-guides/get-help-applying-for-your-teaching-role/prepare-for-a-teaching-job-interview-lesson", t(".teaching_interview_lession")) %>
 <% end %>
 
 # <%= t(".more_info.heading") %>

--- a/app/views/jobseekers/job_application_mailer/application_shortlisted.text.erb
+++ b/app/views/jobseekers/job_application_mailer/application_shortlisted.text.erb
@@ -9,7 +9,7 @@
   <%= @job_application.further_instructions %>
 <% end %>
 
-<% if (["teacher", "head_of_year_or_phase", "head_of_department_or_curriculum", "sendco", "other_leadership"] && (ja.vacancy.job_roles)).any? %>
+<% if @vacancy.is_teaching_or_middle_leader_role? %>
   <%= t(".read_advice_from")
   <%= notify_link("/jobseeker-guides/get-help-applying-for-your-teaching-role/how-to-approach-a-teaching-job-interview", t(".teaching_job_interview"))
   <%= notify_link("/jobseeker-guides/get-help-applying-for-your-teaching-role/prepare-for-a-teaching-job-interview-lesson", t(".teaching_interview_lession"))

--- a/app/views/jobseekers/job_application_mailer/application_shortlisted.text.erb
+++ b/app/views/jobseekers/job_application_mailer/application_shortlisted.text.erb
@@ -11,8 +11,8 @@
 
 <% if @vacancy.is_a_teaching_or_middle_leader_role? %>
   <%= t(".read_advice_from") %>
-  <%= notify_link(jobseeker_guides_how_to_approach_a_teaching_job_interview_url, t(".teaching_job_interview")) %>
-  <%= notify_link(jobseeker_guides_prepare_for_a_teaching_job_interview_lesson_url, t(".teaching_interview_lesson")) %>
+  <%= t(".guidance", link: teaching_job_interview_link(t(".teaching_job_interview"))) %>
+  <%= t(".guidance", link: teaching_job_interview_lesson_link(t(".teaching_interview_lesson"))) %>
 <% end %>
 
 # <%= t(".more_info.heading") %>

--- a/app/views/jobseekers/job_application_mailer/application_shortlisted.text.erb
+++ b/app/views/jobseekers/job_application_mailer/application_shortlisted.text.erb
@@ -9,6 +9,12 @@
   <%= @job_application.further_instructions %>
 <% end %>
 
+<% if (["teacher", "head_of_year_or_phase", "head_of_department_or_curriculum", "sendco", "other_leadership"] && (ja.vacancy.job_roles)).any? %>
+  <%= t(".read_advice_from")
+  <%= notify_link("/jobseeker-guides/get-help-applying-for-your-teaching-role/how-to-approach-a-teaching-job-interview", t(".teaching_job_interview"))
+  <%= notify_link("/jobseeker-guides/get-help-applying-for-your-teaching-role/prepare-for-a-teaching-job-interview-lesson", t(".teaching_interview_lession"))
+<% end %>
+
 # <%= t(".more_info.heading") %>
 
 <%= t(".more_info.description", email: notify_mail_to(@contact_email)) %>

--- a/app/views/jobseekers/job_application_mailer/application_shortlisted.text.erb
+++ b/app/views/jobseekers/job_application_mailer/application_shortlisted.text.erb
@@ -11,8 +11,8 @@
 
 <% if @vacancy.is_a_teaching_or_middle_leader_role? %>
   <%= t(".read_advice_from") %>
-  <%= notify_link("/jobseeker-guides/get-help-applying-for-your-teaching-role/how-to-approach-a-teaching-job-interview", t(".teaching_job_interview")) %>
-  <%= notify_link("/jobseeker-guides/get-help-applying-for-your-teaching-role/prepare-for-a-teaching-job-interview-lesson", t(".teaching_interview_lession")) %>
+  <%= notify_link(jobseeker_guides_how_to_approach_a_teaching_job_interview_url, t(".teaching_job_interview")) %>
+  <%= notify_link(jobseeker_guides_prepare_for_a_teaching_job_interview_lesson_url, t(".teaching_interview_lesson")) %>
 <% end %>
 
 # <%= t(".more_info.heading") %>

--- a/app/views/jobseekers/job_application_mailer/application_submitted.text.erb
+++ b/app/views/jobseekers/job_application_mailer/application_submitted.text.erb
@@ -8,8 +8,8 @@
 
 <% if @vacancy.is_a_teaching_or_middle_leader_role? %>
   <%= t(".read_advice_from") %>
-  <%= notify_link("/jobseeker-guides/get-help-applying-for-your-teaching-role/how-to-approach-a-teaching-job-interview", t(".teaching_job_interview")) %>
-  <%= notify_link("/jobseeker-guides/get-help-applying-for-your-teaching-role/prepare-for-a-teaching-job-interview-lesson", t(".teaching_interview_lession")) %>
+  <%= notify_link(jobseeker_guides_how_to_approach_a_teaching_job_interview_url, t(".teaching_job_interview")) %>
+  <%= notify_link(jobseeker_guides_prepare_for_a_teaching_job_interview_lesson_url, t(".teaching_interview_lesson")) %>
 <% end %>
 
 # <%= t(".more_info.heading") %>

--- a/app/views/jobseekers/job_application_mailer/application_submitted.text.erb
+++ b/app/views/jobseekers/job_application_mailer/application_submitted.text.erb
@@ -8,8 +8,8 @@
 
 <% if @vacancy.is_a_teaching_or_middle_leader_role? %>
   <%= t(".read_advice_from") %>
-  <%= notify_link(jobseeker_guides_how_to_approach_a_teaching_job_interview_url, t(".teaching_job_interview")) %>
-  <%= notify_link(jobseeker_guides_prepare_for_a_teaching_job_interview_lesson_url, t(".teaching_interview_lesson")) %>
+  <%= t(".guidance", link: teaching_job_interview_link(t(".teaching_job_interview"))) %>
+  <%= t(".guidance", link: teaching_job_interview_lesson_link(t(".teaching_interview_lesson"))) %>
 <% end %>
 
 # <%= t(".more_info.heading") %>

--- a/app/views/jobseekers/job_application_mailer/application_submitted.text.erb
+++ b/app/views/jobseekers/job_application_mailer/application_submitted.text.erb
@@ -6,7 +6,7 @@
 
 <%= t(".next_steps.description", organisation_name: @organisation_name, link: jobseeker_job_applications_link) %>
 
-<% if (["teacher", "head_of_year_or_phase", "head_of_department_or_curriculum", "sendco", "other_leadership"] && (ja.vacancy.job_roles)).any? %>
+<% if @vacancy.is_teaching_or_middle_leader_role? %>
   <%= t(".read_advice_from")
   <%= notify_link("/jobseeker-guides/get-help-applying-for-your-teaching-role/how-to-approach-a-teaching-job-interview", t(".teaching_job_interview"))
   <%= notify_link("/jobseeker-guides/get-help-applying-for-your-teaching-role/prepare-for-a-teaching-job-interview-lesson", t(".teaching_interview_lession"))

--- a/app/views/jobseekers/job_application_mailer/application_submitted.text.erb
+++ b/app/views/jobseekers/job_application_mailer/application_submitted.text.erb
@@ -6,10 +6,10 @@
 
 <%= t(".next_steps.description", organisation_name: @organisation_name, link: jobseeker_job_applications_link) %>
 
-<% if @vacancy.is_teaching_or_middle_leader_role? %>
-  <%= t(".read_advice_from")
-  <%= notify_link("/jobseeker-guides/get-help-applying-for-your-teaching-role/how-to-approach-a-teaching-job-interview", t(".teaching_job_interview"))
-  <%= notify_link("/jobseeker-guides/get-help-applying-for-your-teaching-role/prepare-for-a-teaching-job-interview-lesson", t(".teaching_interview_lession"))
+<% if @vacancy.is_a_teaching_or_middle_leader_role? %>
+  <%= t(".read_advice_from") %>
+  <%= notify_link("/jobseeker-guides/get-help-applying-for-your-teaching-role/how-to-approach-a-teaching-job-interview", t(".teaching_job_interview")) %>
+  <%= notify_link("/jobseeker-guides/get-help-applying-for-your-teaching-role/prepare-for-a-teaching-job-interview-lesson", t(".teaching_interview_lession")) %>
 <% end %>
 
 # <%= t(".more_info.heading") %>

--- a/app/views/jobseekers/job_application_mailer/application_submitted.text.erb
+++ b/app/views/jobseekers/job_application_mailer/application_submitted.text.erb
@@ -6,6 +6,12 @@
 
 <%= t(".next_steps.description", organisation_name: @organisation_name, link: jobseeker_job_applications_link) %>
 
+<% if (["teacher", "head_of_year_or_phase", "head_of_department_or_curriculum", "sendco", "other_leadership"] && (ja.vacancy.job_roles)).any? %>
+  <%= t(".read_advice_from")
+  <%= notify_link("/jobseeker-guides/get-help-applying-for-your-teaching-role/how-to-approach-a-teaching-job-interview", t(".teaching_job_interview"))
+  <%= notify_link("/jobseeker-guides/get-help-applying-for-your-teaching-role/prepare-for-a-teaching-job-interview-lesson", t(".teaching_interview_lession"))
+<% end %>
+
 # <%= t(".more_info.heading") %>
 
 <%= t(".more_info.description", email: notify_mail_to(@contact_email)) %>

--- a/app/views/jobseekers/job_application_mailer/application_unsuccessful.text.erb
+++ b/app/views/jobseekers/job_application_mailer/application_unsuccessful.text.erb
@@ -7,7 +7,7 @@
   <%= @job_application.rejection_reasons %>
 <% end %>
 
-<% if (["teacher", "head_of_year_or_phase", "head_of_department_or_curriculum", "sendco", "other_leadership"] && (ja.vacancy.job_roles)).any? %>
+<% if @vacancy.is_teaching_or_middle_leader_role? %>
   <%= t(".advice", link: notify_link("jobseeker-guides/get-help-applying-for-your-teaching-role/write-a-great-teaching-job-application-in-five-steps", t(".application_advice_link_text"))
 <% end %>
 

--- a/app/views/jobseekers/job_application_mailer/application_unsuccessful.text.erb
+++ b/app/views/jobseekers/job_application_mailer/application_unsuccessful.text.erb
@@ -7,8 +7,8 @@
   <%= @job_application.rejection_reasons %>
 <% end %>
 
-<% if @vacancy.is_teaching_or_middle_leader_role? %>
-  <%= t(".advice", link: notify_link("jobseeker-guides/get-help-applying-for-your-teaching-role/write-a-great-teaching-job-application-in-five-steps", t(".application_advice_link_text"))
+<% if @vacancy.is_a_teaching_or_middle_leader_role? %>
+  <%= t(".advice", link: notify_link("jobseeker-guides/get-help-applying-for-your-teaching-role/write-a-great-teaching-job-application-in-five-steps", t(".application_advice_link_text"))) %>
 <% end %>
 
 # <%= t(".more_info.heading") %>

--- a/app/views/jobseekers/job_application_mailer/application_unsuccessful.text.erb
+++ b/app/views/jobseekers/job_application_mailer/application_unsuccessful.text.erb
@@ -8,7 +8,7 @@
 <% end %>
 
 <% if @vacancy.is_a_teaching_or_middle_leader_role? %>
-  <%= t(".advice", link: notify_link("jobseeker-guides/get-help-applying-for-your-teaching-role/write-a-great-teaching-job-application-in-five-steps", t(".application_advice_link_text"))) %>
+  <%= t(".advice", link: writing_job_application_advice_link(t(".application_advice_link_text"))) %>
 <% end %>
 
 # <%= t(".more_info.heading") %>

--- a/app/views/jobseekers/job_application_mailer/application_unsuccessful.text.erb
+++ b/app/views/jobseekers/job_application_mailer/application_unsuccessful.text.erb
@@ -7,6 +7,10 @@
   <%= @job_application.rejection_reasons %>
 <% end %>
 
+<% if (["teacher", "head_of_year_or_phase", "head_of_department_or_curriculum", "sendco", "other_leadership"] && (ja.vacancy.job_roles)).any? %>
+  <%= t(".advice", link: notify_link("jobseeker-guides/get-help-applying-for-your-teaching-role/write-a-great-teaching-job-application-in-five-steps", t(".application_advice_link_text"))
+<% end %>
+
 # <%= t(".more_info.heading") %>
 
 <%= t(".more_info.description", email: notify_mail_to(@contact_email)) %>

--- a/app/views/jobseekers/vacancy_mailer/draft_application_only.text.erb
+++ b/app/views/jobseekers/vacancy_mailer/draft_application_only.text.erb
@@ -3,7 +3,7 @@
 <%= t(".body", link_to: notify_link(jobseekers_job_application_review_url(@job_application), t(".complete"))) %>
 
 <% if @vacancy.is_a_teaching_or_middle_leader_role? %>
-  <%= t(".advice", link: notify_link("/jobseeker-guides/get-help-applying-for-your-teaching-role/write-a-great-teaching-job-application-in-five-steps", t(".writing_a_great_application"))) %>
+  <%= t(".advice", link: writing_job_application_advice_link(t(".application_advice_link_text"))) %>
 <% end %>
 
 <%= t(".outro", link_to: home_page_link) %>

--- a/app/views/jobseekers/vacancy_mailer/draft_application_only.text.erb
+++ b/app/views/jobseekers/vacancy_mailer/draft_application_only.text.erb
@@ -1,7 +1,8 @@
 # <%= t(".intro", job_title: @vacancy.job_title, school: @vacancy.organisation.name, date: @vacancy.expires_at.to_date.to_formatted_s) %>
 
 <%= t(".body", link_to: notify_link(jobseekers_job_application_review_url(@job_application), t(".complete"))) %>
-<% if (["teacher", "head_of_year_or_phase", "head_of_department_or_curriculum", "sendco", "other_leadership"] && (ja.vacancy.job_roles)).any? %>
+
+<% if @vacancy.is_teaching_or_middle_leader_role? %>
   <%= t(".advice", link_to: notify_link("/jobseeker-guides/get-help-applying-for-your-teaching-role/write-a-great-teaching-job-application-in-five-steps", t(".writing_a_great_application"))
 <% end %>
 

--- a/app/views/jobseekers/vacancy_mailer/draft_application_only.text.erb
+++ b/app/views/jobseekers/vacancy_mailer/draft_application_only.text.erb
@@ -2,8 +2,8 @@
 
 <%= t(".body", link_to: notify_link(jobseekers_job_application_review_url(@job_application), t(".complete"))) %>
 
-<% if @vacancy.is_teaching_or_middle_leader_role? %>
-  <%= t(".advice", link_to: notify_link("/jobseeker-guides/get-help-applying-for-your-teaching-role/write-a-great-teaching-job-application-in-five-steps", t(".writing_a_great_application"))
+<% if @vacancy.is_a_teaching_or_middle_leader_role? %>
+  <%= t(".advice", link: notify_link("/jobseeker-guides/get-help-applying-for-your-teaching-role/write-a-great-teaching-job-application-in-five-steps", t(".writing_a_great_application"))) %>
 <% end %>
 
 <%= t(".outro", link_to: home_page_link) %>

--- a/app/views/jobseekers/vacancy_mailer/draft_application_only.text.erb
+++ b/app/views/jobseekers/vacancy_mailer/draft_application_only.text.erb
@@ -1,6 +1,9 @@
 # <%= t(".intro", job_title: @vacancy.job_title, school: @vacancy.organisation.name, date: @vacancy.expires_at.to_date.to_formatted_s) %>
 
 <%= t(".body", link_to: notify_link(jobseekers_job_application_review_url(@job_application), t(".complete"))) %>
+<% if (["teacher", "head_of_year_or_phase", "head_of_department_or_curriculum", "sendco", "other_leadership"] && (ja.vacancy.job_roles)).any? %>
+  <%= t(".advice", link_to: notify_link("/jobseeker-guides/get-help-applying-for-your-teaching-role/write-a-great-teaching-job-application-in-five-steps", t(".writing_a_great_application"))
+<% end %>
 
 <%= t(".outro", link_to: home_page_link) %>
 

--- a/app/views/jobseekers/vacancy_mailer/unapplied_saved_vacancy.text.erb
+++ b/app/views/jobseekers/vacancy_mailer/unapplied_saved_vacancy.text.erb
@@ -6,8 +6,8 @@
 
 <%= notify_link(job_url(@vacancy), t(".apply_for_link", job_title: @vacancy.job_title)) %>
 
-<% if @vacancy.is_teaching_or_middle_leader_role? %>
-  <%= t(".advice", link: notify_link("jobseeker-guides/get-help-applying-for-your-teaching-role/write-a-great-teaching-job-application-in-five-steps", t(".application_advice_link_text"))
+<% if @vacancy.is_a_teaching_or_middle_leader_role? %>
+  <%= t(".advice", link: notify_link("jobseeker-guides/get-help-applying-for-your-teaching-role/write-a-great-teaching-job-application-in-five-steps", t(".application_advice_link_text"))) %>
 <% end %>
 
 <%= t(".to_find_the_right_job") %>

--- a/app/views/jobseekers/vacancy_mailer/unapplied_saved_vacancy.text.erb
+++ b/app/views/jobseekers/vacancy_mailer/unapplied_saved_vacancy.text.erb
@@ -7,7 +7,7 @@
 <%= notify_link(job_url(@vacancy), t(".apply_for_link", job_title: @vacancy.job_title)) %>
 
 <% if @vacancy.is_a_teaching_or_middle_leader_role? %>
-  <%= t(".advice", link: notify_link("jobseeker-guides/get-help-applying-for-your-teaching-role/write-a-great-teaching-job-application-in-five-steps", t(".application_advice_link_text"))) %>
+  <%= t(".advice", link: writing_job_application_advice_link(t(".application_advice_link_text"))) %>
 <% end %>
 
 <%= t(".to_find_the_right_job") %>

--- a/app/views/jobseekers/vacancy_mailer/unapplied_saved_vacancy.text.erb
+++ b/app/views/jobseekers/vacancy_mailer/unapplied_saved_vacancy.text.erb
@@ -6,6 +6,10 @@
 
 <%= notify_link(job_url(@vacancy), t(".apply_for_link", job_title: @vacancy.job_title)) %>
 
+<% if (["teacher", "head_of_year_or_phase", "head_of_department_or_curriculum", "sendco", "other_leadership"] && (ja.vacancy.job_roles)).any? %>
+  <%= t(".advice", link: notify_link("jobseeker-guides/get-help-applying-for-your-teaching-role/write-a-great-teaching-job-application-in-five-steps", t(".application_advice_link_text"))
+<% end %>
+
 <%= t(".to_find_the_right_job") %>
 
 <%= t("shared.jobseeker_footer", home_page_link: home_page_link) %>

--- a/app/views/jobseekers/vacancy_mailer/unapplied_saved_vacancy.text.erb
+++ b/app/views/jobseekers/vacancy_mailer/unapplied_saved_vacancy.text.erb
@@ -6,7 +6,7 @@
 
 <%= notify_link(job_url(@vacancy), t(".apply_for_link", job_title: @vacancy.job_title)) %>
 
-<% if (["teacher", "head_of_year_or_phase", "head_of_department_or_curriculum", "sendco", "other_leadership"] && (ja.vacancy.job_roles)).any? %>
+<% if @vacancy.is_teaching_or_middle_leader_role? %>
   <%= t(".advice", link: notify_link("jobseeker-guides/get-help-applying-for-your-teaching-role/write-a-great-teaching-job-application-in-five-steps", t(".application_advice_link_text"))
 <% end %>
 

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -114,7 +114,7 @@ en:
         <<: *job_application_mailer_shared
         feedback: Feedback from the school
         heading: Unfortunately your application was not successful this time
-        advice: To improve your application for next time, read advice from experienced teachers and school leaders on 
+        advice: To improve your application for next time, read advice from experienced teachers and school leaders on %{link}
         application_advice_link_text: writing a great application.
         subject: Your job application has been unsuccessful
       job_listing_ended_early:
@@ -139,7 +139,7 @@ en:
         intro: The deadline to apply for %{job_title} at %{school} is %{date}
         body: You started an application for this role, but have not submitted it yet. If you want to apply, there is still time to %{link_to}.
         advice: Read advice from experienced teachers and school leaders on %{link}
-        writing_a_great_application: writing a great application.
+        application_advice_link_text: writing a great application.
         outro: Or search on %{link_to}
         complete: complete your application
         apply_for_more_jobs: apply for more jobs on Teaching Vacancies

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -96,7 +96,7 @@ en:
         subject: Your job application has been shortlisted
         read_advice_from: "Read advice from experienced teachers and schools leaders on preparing for your:"
         teaching_job_interview: "- teaching job interview"
-        teaching_interview_lession: "- teaching interview lesson"
+        teaching_interview_lesson: "- teaching interview lesson"
       application_submitted:
         <<: *job_application_mailer_shared
         heading: Your application has been sent to %{organisation_name}
@@ -109,7 +109,7 @@ en:
         subject: Your job application has been submitted
         read_advice_from: "Read advice from experienced teachers and schools leaders on preparing for your:"
         teaching_job_interview: "- teaching job interview"
-        teaching_interview_lession: "- teaching interview lesson"
+        teaching_interview_lesson: "- teaching interview lesson"
       application_unsuccessful:
         <<: *job_application_mailer_shared
         feedback: Feedback from the school

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -111,6 +111,8 @@ en:
         <<: *job_application_mailer_shared
         feedback: Feedback from the school
         heading: Unfortunately your application was not successful this time
+        advice: To improve your application for next time, read advice from experienced teachers and school leaders on 
+        application_advice_link_text: writing a great application.
         subject: Your job application has been unsuccessful
       job_listing_ended_early:
         body: |

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -94,9 +94,10 @@ en:
         heading: You have been shortlisted for %{job_title} at %{organisation_name}
         instructions: What happens next
         subject: Your job application has been shortlisted
-        read_advice_from: "Read advice from experienced teachers and schools leaders on preparing for your:"
-        teaching_job_interview: "- teaching job interview"
-        teaching_interview_lesson: "- teaching interview lesson"
+        read_advice_from: "Read advice from experienced teachers and school leaders on preparing for your:"
+        teaching_job_interview: "teaching job interview"
+        teaching_interview_lesson: "teaching interview lesson"
+        guidance: "- %{link}"
       application_submitted:
         <<: *job_application_mailer_shared
         heading: Your application has been sent to %{organisation_name}
@@ -107,9 +108,10 @@ en:
             touch to let you know.
           link_text: view your application
         subject: Your job application has been submitted
-        read_advice_from: "Read advice from experienced teachers and schools leaders on preparing for your:"
-        teaching_job_interview: "- teaching job interview"
-        teaching_interview_lesson: "- teaching interview lesson"
+        read_advice_from: "Read advice from experienced teachers and school leaders on preparing for your:"
+        teaching_job_interview: "teaching job interview"
+        teaching_interview_lesson: "teaching interview lesson"
+        guidance: "- %{link}"
       application_unsuccessful:
         <<: *job_application_mailer_shared
         feedback: Feedback from the school

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -145,6 +145,8 @@ en:
         saved_but_not_applied: You saved this job but have not applied to it yet
         apply_for_link: "Apply for %{job_title} on Teaching Vacancies"
         to_find_the_right_job: "To find the right job, remember to always check Teaching Vacancies"
+        advice: Read advice from experienced teachers and school leaders on %{link}
+        application_advice_link_text: writing a great application.
 
     subscription_mailer:
       confirmation:

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -94,6 +94,9 @@ en:
         heading: You have been shortlisted for %{job_title} at %{organisation_name}
         instructions: What happens next
         subject: Your job application has been shortlisted
+        read_advice_from: "Read advice from experienced teachers and schools leaders on preparing for your:"
+        teaching_job_interview: "- teaching job interview"
+        teaching_interview_lession: "- teaching interview lesson"
       application_submitted:
         <<: *job_application_mailer_shared
         heading: Your application has been sent to %{organisation_name}

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -107,6 +107,9 @@ en:
             touch to let you know.
           link_text: view your application
         subject: Your job application has been submitted
+        read_advice_from: "Read advice from experienced teachers and schools leaders on preparing for your:"
+        teaching_job_interview: "- teaching job interview"
+        teaching_interview_lession: "- teaching interview lesson"
       application_unsuccessful:
         <<: *job_application_mailer_shared
         feedback: Feedback from the school

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -81,8 +81,8 @@ en:
       shared: &job_application_mailer_shared
         intro: Your application for %{job_title} at %{organisation_name}
         paragraph1: The school will be in touch to let you know what the next steps are. If you have any further questions, you can contact them at %{email}.
-        paragraph2: Search and %{link}
-        apply_link_text: apply for more jobs on Teaching Vacancies.
+        paragraph2: Search and %{link}.
+        apply_link_text: apply for more jobs on Teaching Vacancies
         more_info:
           heading: Still have questions?
           description: If you would like more information you can contact the school at %{email}.
@@ -116,8 +116,8 @@ en:
         <<: *job_application_mailer_shared
         feedback: Feedback from the school
         heading: Unfortunately your application was not successful this time
-        advice: To improve your application for next time, read advice from experienced teachers and school leaders on %{link}
-        application_advice_link_text: writing a great application.
+        advice: To improve your application for next time, read advice from experienced teachers and school leaders on %{link}.
+        application_advice_link_text: writing a great application
         subject: Your job application has been unsuccessful
       job_listing_ended_early:
         body: |
@@ -140,8 +140,8 @@ en:
         subject: Apply for %{job_title} before %{date}
         intro: The deadline to apply for %{job_title} at %{school} is %{date}
         body: You started an application for this role, but have not submitted it yet. If you want to apply, there is still time to %{link_to}.
-        advice: Read advice from experienced teachers and school leaders on %{link}
-        application_advice_link_text: writing a great application.
+        advice: Read advice from experienced teachers and school leaders on %{link}.
+        application_advice_link_text: writing a great application
         outro: Or search on %{link_to}
         complete: complete your application
         apply_for_more_jobs: apply for more jobs on Teaching Vacancies
@@ -149,11 +149,11 @@ en:
         subject: "%{days} days left to apply for %{job_title}"
         salutation: "Hi %{name}"
         vacancy_closes: "%{job_title} at %{school} closes on %{date}"
-        saved_but_not_applied: You saved this job but have not applied to it yet
+        saved_but_not_applied: You saved this job but have not applied to it yet.
         apply_for_link: "Apply for %{job_title} on Teaching Vacancies"
-        to_find_the_right_job: "To find the right job, remember to always check Teaching Vacancies"
-        advice: Read advice from experienced teachers and school leaders on %{link}
-        application_advice_link_text: writing a great application.
+        to_find_the_right_job: "To find the right job, remember to always check Teaching Vacancies."
+        advice: Read advice from experienced teachers and school leaders on %{link}.
+        application_advice_link_text: writing a great application
 
     subscription_mailer:
       confirmation:

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -130,6 +130,8 @@ en:
         subject: Apply for %{job_title} before %{date}
         intro: The deadline to apply for %{job_title} at %{school} is %{date}
         body: You started an application for this role, but have not submitted it yet. If you want to apply, there is still time to %{link_to}.
+        advice: Read advice from experienced teachers and school leaders on %{link}
+        writing_a_great_application: writing a great application.
         outro: Or search on %{link_to}
         complete: complete your application
         apply_for_more_jobs: apply for more jobs on Teaching Vacancies

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -577,4 +577,48 @@ RSpec.describe Vacancy do
       expect(subject.publish_on).to eq(nil)
     end
   end
+
+  describe "#is_a_teaching_or_middle_leader_role?" do
+    let(:vacancy) { create(:vacancy, job_roles: job_roles) }
+
+    context "when job_roles includes a teaching role" do
+      let(:job_roles) { ["teacher"] }
+
+      it "returns true" do
+        expect(vacancy.is_a_teaching_or_middle_leader_role?).to be true
+      end
+    end
+
+    context "when job_roles includes a middle leader role" do
+      let(:job_roles) { ["head_of_year_or_phase"] }
+
+      it "returns true" do
+        expect(vacancy.is_a_teaching_or_middle_leader_role?).to be true
+      end
+    end
+
+    context "when job_roles includes multiple valid roles" do
+      let(:job_roles) { ["teacher", "head_of_department_or_curriculum"] }
+
+      it "returns true" do
+        expect(vacancy.is_a_teaching_or_middle_leader_role?).to be true
+      end
+    end
+
+    context "when job_roles does not include any teaching or middle leader role" do
+      let(:job_roles) { ["administration_hr_data_and_finance"] }
+
+      it "returns false" do
+        expect(vacancy.is_a_teaching_or_middle_leader_role?).to be false
+      end
+    end
+
+    context "when job_roles is empty" do
+      let(:job_roles) { [] }
+
+      it "returns false" do
+        expect(vacancy.is_a_teaching_or_middle_leader_role?).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/Xsjm3WIi/1355-send-emails-to-users-applying-for-teaching-roles

## Changes in this PR:
This PR conditionally adds some content to some emails we send out, adding guidance for jobseekers if they're applying to a teaching or middle leadership job.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
