### PR TITLE
Do not assume credentials access on App setup

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -104,7 +104,7 @@ module TeachingVacancies
     # GovUK One Login
     config.govuk_one_login_base_url = ENV.fetch("GOVUK_ONE_LOGIN_BASE_URL", nil)
     config.govuk_one_login_client_id = ENV.fetch("GOVUK_ONE_LOGIN_CLIENT_ID", nil)
-    config.govuk_one_login_private_key = Rails.application.credentials.one_login.private_key
+    config.govuk_one_login_private_key = Rails.application.credentials.one_login&.private_key
 
     # TODO: We use Devise's `after_sign_out_path_for` to redirect users to DSI after signing out,
     # and have no way of disabling the foreign host redirect protection in that instance. Until


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/VVBNCJAu/1398-investigate-fix-dependabot-ci-errors-due-to-lack-of-access-to-new-rails-credentials

## Changes in this PR:

Avoid exceptions when running commands over Rails without the credentials being accessible.

This turned out to be an issue with Dependabot PRs CI runs, where the Github secrets are inaccessible and the CI runs fail.