### PR TITLE
Stub OneLogin RSA key in specs

### DIFF
--- a/spec/services/jobseekers/govuk_one_login/client_spec.rb
+++ b/spec/services/jobseekers/govuk_one_login/client_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Jobseekers::GovukOneLogin::Client do
     let(:request_mock) { instance_double(Net::HTTP::Post, set_form_data: true) }
 
     before do
+      allow(Rails.application.config).to receive(:govuk_one_login_private_key).and_return("private_key")
+      allow(OpenSSL::PKey::RSA).to receive(:new).with("private_key").and_return(instance_double(OpenSSL::PKey::RSA))
       allow(JWT).to receive(:encode).and_return("jwt_assertion")
       allow(Net::HTTP::Post).to receive(:new).and_return(request_mock)
     end

--- a/spec/support/auth_helpers.rb
+++ b/spec/support/auth_helpers.rb
@@ -136,10 +136,17 @@ module AuthHelpers
   # That limits when this stub can be used, as it needs to be called after the user has navigated to the
   # 'new_jobseeker_session_path'.
   def stub_jobseeker_govuk_one_login_for(email:, one_login_id:, nonce:)
+    stub_jobseeker_govuk_one_login_rsa_key
     stub_jobseeker_govuk_one_login_authorisation
     stub_jobseeker_govuk_one_login_tokens
     stub_jobseeker_govuk_one_login_jwt(nonce:, one_login_id:)
     stub_jobseeker_govuk_one_login_user_info(email:, one_login_id:)
+  end
+
+  def stub_jobseeker_govuk_one_login_rsa_key
+    allow(Rails.application.config).to receive(:govuk_one_login_private_key).and_return("private_key")
+    rsa_stub = OpenSSL::PKey::RSA.new(1024)
+    allow(OpenSSL::PKey::RSA).to receive(:new).and_return(rsa_stub)
   end
 
   def stub_jobseeker_govuk_one_login_authorisation


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/VVBNCJAu/1398-investigate-fix-dependabot-ci-errors-due-to-lack-of-access-to-new-rails-credentials

## Changes in this PR:

Stubbing the RSA key, we isolate the test runs from the environment having access to a real RSA key.

This was problematic on Dependabot-created PRs, as they had no access to the Rails Credentials encrypted file.

We could set some dummy private key in the test environment values, but I suspect it would be raised by security tools as "exposing a secret" committed in git.

So I opted for stubbing the RSA key when needed..