### PR TITLE
Allow jobseekers with closed accounts to be automatically re-activated if they log in via the one login flow

### DIFF
--- a/app/controllers/jobseekers/govuk_one_login_callbacks_controller.rb
+++ b/app/controllers/jobseekers/govuk_one_login_callbacks_controller.rb
@@ -22,6 +22,7 @@ class Jobseekers::GovukOneLoginCallbacksController < Devise::OmniauthCallbacksCo
     if jobseeker
       sign_out_except(:jobseeker)
       trigger_jobseeker_successful_govuk_one_login_sign_in_event(jobseeker)
+      Jobseekers::ReactivateAccount.reactivate(jobseeker) if jobseeker.account_closed?
       sign_in_and_redirect jobseeker
     end
   rescue GovukOneLoginError => e

--- a/spec/system/jobseekers/jobseekers_can_sign_in_to_their_account_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_sign_in_to_their_account_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe "Jobseekers can sign in to their account" do
     end
   end
 
+  context "when signing in a user that has a closed account" do
+    let(:jobseeker) { create(:jobseeker, account_closed_on: Date.yesterday) }
+    it "allows them to sign in and reactivates their account" do
+      sign_in_jobseeker_govuk_one_login(jobseeker, navigate: true)
+      expect(page.current_path).to eq(jobseekers_job_applications_path)
+      expect(page).to have_css("h1", text: I18n.t("jobseekers.job_applications.index.page_title"))
+      expect(page).to have_link(text: I18n.t("nav.sign_out"))
+      expect(jobseeker.reload.account_closed_on).to eq nil
+    end
+  end
+
   context "when signing in a jobseeker that has not yet linked their account to a one login account" do
     let(:jobseeker) { create(:jobseeker, govuk_one_login_id: nil) }
 


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/KG2Vkd9P/1396-reactivate-closed-jobseeker-account-upon-new-login

## Changes in this PR:

This PR adds functionality that allows jobseekers to sign in, and if their account is currently closed, it automatically re-activates it upon sign in. This functionality was already in the service but not available during the new one login flow, this PR adds it to the one login sign in flow.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
