### PR TITLE
Remove Jobseeker legacy Devise fields from DB

### DIFF
--- a/app/models/jobseeker.rb
+++ b/app/models/jobseeker.rb
@@ -1,20 +1,6 @@
 class Jobseeker < ApplicationRecord
   has_encrypted :last_sign_in_ip, :current_sign_in_ip
 
-  # https://github.com/fatkodima/online_migrations?tab=readme-ov-file#removing-a-column
-  # Active Record caches database columns at runtime, so if you drop a column, it can cause exceptions until your app reboots.
-  # Ignoring the columns that are going to be dropped avoids this issue.
-  self.ignored_columns += %w[encrypted_password
-                             reset_password_token
-                             reset_password_sent_at
-                             confirmation_token
-                             confirmed_at
-                             confirmation_sent_at
-                             unconfirmed_email
-                             failed_attempts
-                             unlock_token
-                             locked_at]
-
   devise(*%I[
     timeoutable
     trackable

--- a/db/migrate/20241112153920_remove_devise_fields_from_jobseekers.rb
+++ b/db/migrate/20241112153920_remove_devise_fields_from_jobseekers.rb
@@ -1,0 +1,10 @@
+class RemoveDeviseFieldsFromJobseekers < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      remove_column(:jobseekers, :encrypted_password, type: :string, null: false, default: "")
+      remove_columns(:jobseekers, :reset_password_token, :confirmation_token, :unconfirmed_email, :unlock_token, type: :string)
+      remove_columns(:jobseekers, :reset_password_sent_at, :confirmed_at, :confirmation_sent_at, :locked_at, type: :datetime)
+      remove_column(:jobseekers, :failed_attempts, type: :integer, null: false, default: 0)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_29_111208) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_12_153920) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -301,19 +301,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_29_111208) do
 
   create_table "jobseekers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at", precision: nil
     t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at", precision: nil
     t.datetime "last_sign_in_at", precision: nil
-    t.string "confirmation_token"
-    t.datetime "confirmed_at", precision: nil
-    t.datetime "confirmation_sent_at", precision: nil
-    t.string "unconfirmed_email"
-    t.integer "failed_attempts", default: 0, null: false
-    t.string "unlock_token"
-    t.datetime "locked_at", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.date "account_closed_on"
@@ -322,11 +312,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_29_111208) do
     t.string "account_merge_confirmation_code"
     t.datetime "account_merge_confirmation_code_generated_at"
     t.string "govuk_one_login_id"
-    t.index ["confirmation_token"], name: "index_jobseekers_on_confirmation_token", unique: true
     t.index ["email"], name: "index_jobseekers_on_email", unique: true
     t.index ["govuk_one_login_id"], name: "index_jobseekers_on_govuk_one_login_id", unique: true
-    t.index ["reset_password_token"], name: "index_jobseekers_on_reset_password_token", unique: true
-    t.index ["unlock_token"], name: "index_jobseekers_on_unlock_token", unique: true
   end
 
   create_table "local_authority_publisher_schools", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION


## Trello card URL
 - https://trello.com/c/yEAtzluZ/1391-govuk-one-login-post-launch-removal-of-devise-unused-code-db-fields
## Changes in this PR:

All these fields are no longer set/read by the application code, as the related logic is managed now by the GovUK OneLogin external service.