### PR TITLE
Tweaking wording on savings figure

### DIFF
--- a/app/views/pages/savings-methodology.html.slim
+++ b/app/views/pages/savings-methodology.html.slim
@@ -6,7 +6,7 @@
     h1.govuk-heading-xl Savings methodology
 
     p.govuk-body
-      | We estimate that schools using Teaching Vacancies have all together saved between £47.3 and £60.8 million from September 2018 to August 2024.
+      | We estimate that, in total, schools using Teaching Vacancies have saved between £47.3 and £60.8 million from September 2018 to August 2024.
 
     h2.govuk-heading-l How we calculate the savings figure
 

--- a/app/views/pages/savings-methodology.html.slim
+++ b/app/views/pages/savings-methodology.html.slim
@@ -6,7 +6,7 @@
     h1.govuk-heading-xl Savings methodology
 
     p.govuk-body
-      | We estimate that Teaching Vacancies' current savings figure is between £47.3 and £60.8 million, from September 2018 to August 2024.
+      | We estimate that schools using Teaching Vacancies have all together saved between £47.3 and £60.8 million from September 2018 to August 2024.
 
     h2.govuk-heading-l How we calculate the savings figure
 


### PR DESCRIPTION
## Trello card URL

## Changes in this PR:

Nabil has requested a slight change to how we refer to the savings figure to make it clear it's a saving for schools and not the department directly.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
