### PR TITLE
Fix issue with leaving reason on work profile edit

### DIFF
--- a/app/controllers/jobseekers/profiles/employments_controller.rb
+++ b/app/controllers/jobseekers/profiles/employments_controller.rb
@@ -44,7 +44,7 @@ class Jobseekers::Profiles::EmploymentsController < Jobseekers::ProfilesControll
     when "new"
       {}
     when "edit"
-      employment.slice(:organisation, :job_title, :started_on, :current_role, :ended_on, :main_duties, :subjects)
+      employment.slice(*employment_attrs)
     when "create", "update"
       employment_form_params
     end
@@ -56,7 +56,11 @@ class Jobseekers::Profiles::EmploymentsController < Jobseekers::ProfilesControll
 
   def employment_form_params
     params.require(:jobseekers_profile_employment_form)
-          .permit(:organisation, :job_title, :started_on, :current_role, :ended_on, :main_duties, :subjects, :reason_for_leaving)
+          .permit(*employment_attrs)
           .merge("started_on(3i)" => "1", "ended_on(3i)" => "1")
+  end
+
+  def employment_attrs
+    %i[organisation job_title started_on current_role ended_on main_duties subjects reason_for_leaving].freeze
   end
 end

--- a/app/form_models/jobseekers/profile/employment_form.rb
+++ b/app/form_models/jobseekers/profile/employment_form.rb
@@ -9,7 +9,8 @@ class Jobseekers::Profile::EmploymentForm < BaseForm
 
   attr_reader :started_on, :ended_on
 
-  validates :organisation, :job_title, :main_duties, :reason_for_leaving, presence: true
+  validates :organisation, :job_title, :main_duties, presence: true
+  validates :reason_for_leaving, presence: true, if: -> { current_role == "no" }
   validates :started_on, date: { before: :today }
   validates :current_role, inclusion: { in: %w[yes no] }
   validates :ended_on, date: { before: :today, on_or_after: :started_on }, if: -> { current_role == "no" }


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/ilDxyapW/1393-profiles-reason-for-leaving-bug

## Changes in this PR:

- Is there anything specific you want feedback on?

Is is correct that leaving reason should not be mandatory when entering 'current' employment?

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
