### PR TITLE
Fix broken pipeline - CSS assets now built correctly in development mode

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -94,7 +94,6 @@ module TeachingVacancies
     config.maintenance_mode = ActiveModel::Type::Boolean.new.cast(ENV.fetch("MAINTENANCE_MODE", nil))
 
     config.assets.paths << Rails.root.join("node_modules/govuk-frontend/dist/govuk/assets")
-    config.assets.excluded_paths << Rails.root.join("app/assets/stylesheets")
 
     config.view_component.preview_paths << "#{Rails.root}/app/components/previews"
     config.view_component.preview_route = "/components"


### PR DESCRIPTION
… app/assets/build

## Trello card URL

https://trello.com/c/yCHKTHtt/1412-rails-pipeline-propshaft-appears-to-be-incorrectly-configured-for-development-can-only-run-with-pre-compiled-assets-css-fails-to

## Changes in this PR:

Remove CSS exclusion line so that application.css is built into app/assets/build by yarn build:css

