### PR TITLE
Fix Alert Email jobs memory load

### DIFF
--- a/app/jobs/alert_email/base.rb
+++ b/app/jobs/alert_email/base.rb
@@ -2,7 +2,7 @@ class AlertEmail::Base < ApplicationJob
   def perform
     return if DisableExpensiveJobs.enabled?
 
-    subscriptions.each do |subscription|
+    subscriptions.find_each do |subscription|
       next if subscription.alert_run_today?
 
       vacancies = vacancies_for_subscription(subscription)


### PR DESCRIPTION


## Trello card URL
- https://trello.com/c/w1KM928B/1414-refactor-daily-weeklyalerts-job-for-a-high-volume-of-alerts

## Changes in this PR:

We're experiencing serious performance issues and pods restarting during the Daily/Weekly alert email job runs.

We currently have over 100k subscriptions for daily alerts, and over 30k for weekly alerts.

The existing code loads all the subscriptions in memory before iterating over them.

We are changing this to fetch them in batches, aiming to improve the memory load and job performance.