### PR TITLE
Override foreman's environment handling 

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -6,4 +6,6 @@ then
   gem install foreman
 fi
 
+# override foreman environment handling so that our dotenv params load properly
+# https://github.com/ddollar/foreman/issues/561
 foreman start -e /dev/null -f Procfile.dev "$@"

--- a/bin/dev
+++ b/bin/dev
@@ -6,4 +6,4 @@ then
   gem install foreman
 fi
 
-foreman start -f Procfile.dev "$@"
+foreman start -e /dev/null -f Procfile.dev "$@"


### PR DESCRIPTION
## Changes in this PR:

Allow our dotenv variables to be processed correctly (including LOCKBOX_MASTER_KEY) which was the source of the encryption failed errors

