### PR TITLE
Remove job_title page inset text as it doesn't add much value

### DIFF
--- a/app/views/publishers/vacancies/build/job_title.html.slim
+++ b/app/views/publishers/vacancies/build/job_title.html.slim
@@ -19,10 +19,4 @@ end
         max_chars: 75,
         required: true
 
-      = govuk_inset_text do
-        - if vacancy.phases.many?
-          = t("publishers.vacancies.build.job_title.phase_inset_text.multiple_phases")
-        - else
-          = t("publishers.vacancies.build.job_title.phase_inset_text.phase", phase: vacancy.phases.first&.humanize&.downcase)
-
       = render "publishers/vacancies/vacancy_form_partials/submit", f: f


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/b7jSeDf1/1387-remove-inset-hint-text-from-job-title-page

## Changes in this PR:

This PR removes some inset text on the job title page of the job publishing journey.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
