### PR TITLE
Format main duties properly

### DIFF
--- a/app/views/jobseekers/employments/_employments.html.slim
+++ b/app/views/jobseekers/employments/_employments.html.slim
@@ -21,7 +21,8 @@
               - row.with_value text: employment.ended_on.to_formatted_s(:month_year)
           - summary_list.with_row(classes: "govuk-summary-list__row--no-actions") do |row|
             - row.with_key text: t("jobseekers.employments.main_duties")
-            - row.with_value text: employment.main_duties
+            - row.with_value do
+              = simple_format(employment.main_duties)
           - summary_list.with_row(classes: "govuk-summary-list__row--no-actions") do |row|
             - row.with_key text: t("jobseekers.employments.reason_for_leaving")
             - row.with_value text: employment.reason_for_leaving

--- a/app/views/jobseekers/job_applications/build/employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/build/employment_history.html.slim
@@ -53,7 +53,8 @@
 
                   - summary_list.with_row do |row|
                     - row.with_key text: t("jobseekers.job_applications.employments.main_duties")
-                    - row.with_value text: employment.main_duties
+                    - row.with_value do
+                      = simple_format(employment.main_duties)
 
                   - summary_list.with_row do |row|
                     - row.with_key text: t("jobseekers.job_applications.employments.reason_for_leaving")

--- a/app/views/jobseekers/job_applications/review/_employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/review/_employment_history.html.slim
@@ -22,7 +22,8 @@
 
           - summary_list.with_row do |row|
             - row.with_key text: t("helpers.label.jobseekers_job_application_details_employment_form.main_duties")
-            - row.with_value text: employment.main_duties
+            - row.with_value do
+              = simple_format(employment.main_duties)
 
           - summary_list.with_row do |row|
             - row.with_key text: t("helpers.legend.jobseekers_job_application_details_employment_form.started_on")


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/6VyXfCAb/1381-fix-formatting-on-application-main-duties-overview-work-history

## Changes in this PR:

This PR fixes the formatting of the "main duties" fields of jobseeker profiles and applications to allow things like bullet points to be used.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
