### PR TITLE
Fix Ventrus school mapping

### DIFF
--- a/spec/fixtures/files/vacancy_sources/ventrus.xml
+++ b/spec/fixtures/files/vacancy_sources/ventrus.xml
@@ -28,7 +28,7 @@
                     <URN>111111</URN>
                     <Working_Patterns>part_time</Working_Patterns>
                     <Contract_Type>permanent</Contract_Type>
-                    <TrustUID></TrustUID>
+                    <TrustUID>4243</TrustUID>
                     <Documents>
                         <document>
                             <name><![CDATA[JD Grade C Generalist TA Secondary (App 2) Updated 15.12.2020.pdf]]></name>

--- a/spec/fixtures/files/vacancy_sources/ventrus_with_parental_leave_cover.xml
+++ b/spec/fixtures/files/vacancy_sources/ventrus_with_parental_leave_cover.xml
@@ -28,7 +28,7 @@
                     <URN>111111</URN>
                     <Working_Patterns>part_time</Working_Patterns>
                     <Contract_Type>parental_leave_cover</Contract_Type>
-                    <TrustUID></TrustUID>
+                    <TrustUID>4243</TrustUID>
                     <Documents>
                         <document>
                             <name><![CDATA[JD Grade C Generalist TA Secondary (App 2) Updated 15.12.2020.pdf]]></name>

--- a/spec/fixtures/files/vacancy_sources/ventrus_without_visa_sponsorship_available.xml
+++ b/spec/fixtures/files/vacancy_sources/ventrus_without_visa_sponsorship_available.xml
@@ -28,7 +28,7 @@
                     <URN>111111</URN>
                     <Working_Patterns>part_time</Working_Patterns>
                     <Contract_Type>permanent</Contract_Type>
-                    <TrustUID></TrustUID>
+                    <TrustUID>4243</TrustUID>
                     <Documents>
                         <document>
                             <name><![CDATA[JD Grade C Generalist TA Secondary (App 2) Updated 15.12.2020.pdf]]></name>


### PR DESCRIPTION
There is a bug in the existing code when no school URN comes from Ventrus feed. Our system assigns the vacancy to the first Organisation found with "nil" urn value.

So the Ventrus vacancy ends assigned to a random MAT/SchoolGroup (that has no URN value).

To fix it, we are:
- Ensuring that the correct trust ID must be provided by Ventrus feed.
- Only assigning the vacancy to a particular school if the URN is provided and belongs to a school that is part of Ventrus.
- When no/incorrect school urn is provided, it assigns it to Ventrust trust itself, not to a particular school.
