### PR TITLE
Devcontainer improvements

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,7 +36,8 @@
         "Shopify.ruby-extensions-pack",
         "GitHub.copilot",
         "donjayamanne.git-extension-pack",
-        "bierner.markdown-mermaid"
+        "bierner.markdown-mermaid",
+        "KoichiSasada.vscode-rdbg"
       ],
       "settings": {
         // Get highlighting for local env files

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       - "6379:6379"
 
   selenium-chrome:
-    image: selenium/standalone-chrome:119.0
+    image: selenium/standalone-chrome:latest
     shm_size: 2G
     ports:
       - "7900:7900"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,15 +5,25 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Rails Server",
-      "type": "Ruby",
+      //Start Rails server
+      "name": "Debug Rails",
+      "type": "rdbg",
       "request": "launch",
-      "program": "${workspaceRoot}/bin/rails",
-      "args": [
-        "server",
-        "-b",
-        "0.0.0.0"
-      ]
+      // "command": "bundle exec rails", #bundle exec rails won't stop in the debugger
+      "command": "bin/rails",
+      "script": "s",
+      "args": ["-b","0.0.0.0"],
+    },
+    {
+      // Run tests on the active rspec file
+      "name": "Debug Rspec with current file",
+      "type": "rdbg",
+      "request": "launch",
+      "command": "bundle exec rspec",
+      "script": "${file}",
+      "args": [],
+      // Confirm the executed command in the window. Make it easy to specify options such as execution of
+      "askParameters": true
     }
   ]
 }

--- a/Gemfile
+++ b/Gemfile
@@ -105,6 +105,7 @@ group :development, :test do
   gem "brakeman"
   gem "byebug", platforms: %i[mri mingw x64_mingw]
   gem "database_consistency", require: false
+  gem "debug", ">= 1.0.0", require: false
   gem "dotenv-rails"
   gem "launchy", "~> 3.0"
   gem "parallel_tests"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,6 +185,9 @@ GEM
     database_consistency (1.7.26)
       activerecord (>= 3.2)
     date (3.4.0)
+    debug (1.9.2)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     debug_inspector (1.2.0)
     declarative (0.0.20)
     devise (4.9.4)
@@ -793,6 +796,7 @@ DEPENDENCIES
   climate_control
   cssbundling-rails
   database_consistency
+  debug (>= 1.0.0)
   devise
   dfe-analytics!
   dotenv-rails


### PR DESCRIPTION
1. Setup Rails debugging into the VSCode devcontainers. Now VSCode debugging tools work seamlessly with the rails application.
2. Upgrade Selenium Chrome to `latest` on Devcontainers.