### PR TITLE
Fix rackup to v1.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ gem "prawn-table"
 gem "puma"
 gem "rack-attack"
 gem "rack-cors"
+gem "rackup", "= 1.0.0" # Temporal dependency until puma resolves a bug with a version > v6.4.3. Remove this line after that
 gem "rails_semantic_logger"
 gem "recaptcha"
 gem "redis"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -849,6 +849,7 @@ DEPENDENCIES
   rack-cors
   rack-mini-profiler
   rack_session_access
+  rackup (= 1.0.0)
   rails-controller-testing
   rails_semantic_logger
   railties (~> 7.1.2)


### PR DESCRIPTION
To avoid Puma errors during Capybara runs.
We will be able to remove this once Puma launches a patch > 6.4.3
