### PR TITLE
Enforce jobseeker login to download job form

### DIFF
--- a/app/controllers/jobseekers/govuk_one_login_callbacks_controller.rb
+++ b/app/controllers/jobseekers/govuk_one_login_callbacks_controller.rb
@@ -79,6 +79,7 @@ class Jobseekers::GovukOneLoginCallbacksController < Devise::OmniauthCallbacksCo
 
     stored_location.include?("/job_application/new") || # Signed-in from a quick apply link
       stored_location.include?("/saved_job/") || # Signed-in from a vacancy page save/unsave action.
+      stored_location.include?("/jobs/") || # Signed-in from a job page (in order to download)
       stored_location.include?("/jobseekers/subscriptions") # Signed-in from a job alert email link.
   end
 end

--- a/app/controllers/jobseekers/sessions_controller.rb
+++ b/app/controllers/jobseekers/sessions_controller.rb
@@ -14,7 +14,7 @@ class Jobseekers::SessionsController < Devise::SessionsController
 
     super do
       unless redirected?
-        store_return_location(request.referrer, scope: :jobseeker)
+        store_return_location(request.referer, scope: :jobseeker)
         session[:after_sign_in] = true
       end
     end

--- a/app/controllers/jobseekers/sessions_controller.rb
+++ b/app/controllers/jobseekers/sessions_controller.rb
@@ -14,7 +14,7 @@ class Jobseekers::SessionsController < Devise::SessionsController
 
     super do
       unless redirected?
-        store_return_location(request.referer, scope: :jobseeker)
+        store_return_location(jobseeker_root_path, scope: :jobseeker)
         session[:after_sign_in] = true
       end
     end

--- a/app/controllers/jobseekers/sessions_controller.rb
+++ b/app/controllers/jobseekers/sessions_controller.rb
@@ -14,7 +14,7 @@ class Jobseekers::SessionsController < Devise::SessionsController
 
     super do
       unless redirected?
-        store_return_location(jobseeker_root_path, scope: :jobseeker)
+        store_return_location(request.referrer, scope: :jobseeker)
         session[:after_sign_in] = true
       end
     end

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -1,5 +1,9 @@
 class VacanciesController < ApplicationController
+  include ReturnPathTracking::Helpers
+
   before_action :set_landing_page, only: %i[index]
+
+  before_action :store_jobseeker_location, only: %i[show], if: :storable_location?
 
   def index
     @vacancies_search = Search::VacancySearch.new(form.to_hash, sort: form.sort)
@@ -118,5 +122,9 @@ class VacanciesController < ApplicationController
     # actually in London which could potentially confuse jobseekers.
     normalised_query = form.to_hash[:location]&.strip&.downcase
     normalised_query.nil? || LocationQuery::NATIONWIDE_LOCATIONS.include?(normalised_query) || @vacancies_search.polygon.present?
+  end
+
+  def store_jobseeker_location
+    store_return_location(scope: :jobseeker)
   end
 end

--- a/app/views/vacancies/listing/_job_details.html.slim
+++ b/app/views/vacancies/listing/_job_details.html.slim
@@ -116,7 +116,7 @@ section#job-details class="govuk-!-margin-bottom-5"
       - if current_jobseeker.present?
         = govuk_button_link_to t("buttons.download_application_form", size: number_to_human_size(vacancy.application_form.byte_size)), job_document_path(vacancy, vacancy.application_form.id)
       - else
-        = govuk_button_link_to t("buttons.sign_in_to_download"), new_jobseeker_session_path
+        = govuk_button_link_to t("buttons.sign_in_to_download"), new_jobseeker_session_path(redirected: true)
 
       .govuk-body = t("vacancies.international_teacher_advice.text_html", link: tracked_link_to(t("vacancies.international_teacher_advice.link"), "https://getintoteaching.education.gov.uk/non-uk-teachers", link_type: :international_teacher_advice_link_job_listing))
 

--- a/app/views/vacancies/listing/_job_details.html.slim
+++ b/app/views/vacancies/listing/_job_details.html.slim
@@ -113,7 +113,11 @@ section#job-details class="govuk-!-margin-bottom-5"
       p.govuk-body = t("jobs.apply_via_email_html", email: application_email_link(vacancy))
       p.govuk-body = t("jobseekers.job_applications.no_cvs")
       = govuk_inset_text text: inset_text
-      = govuk_button_link_to t("buttons.download_application_form", size: number_to_human_size(vacancy.application_form.byte_size)), job_document_path(vacancy, vacancy.application_form.id)
+      - if current_jobseeker.present?
+        = govuk_button_link_to t("buttons.download_application_form", size: number_to_human_size(vacancy.application_form.byte_size)), job_document_path(vacancy, vacancy.application_form.id)
+      - else
+        = govuk_button_link_to t("buttons.sign_in_to_download"), new_jobseeker_session_path
+
       .govuk-body = t("vacancies.international_teacher_advice.text_html", link: tracked_link_to(t("vacancies.international_teacher_advice.link"), "https://getintoteaching.education.gov.uk/non-uk-teachers", link_type: :international_teacher_advice_link_job_listing))
 
     - else

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -92,6 +92,7 @@ en:
       one: Open filters (%{count} applied)
       other: Open filters (%{count} applied)
     sign_in: Sign in
+    sign_in_to_download: Sign in to download application form
     sign_in_jobseeker: Sign in as a jobseeker
     sign_in_publisher: Sign in as hiring staff
     skip_this_step: Skip this step

--- a/spec/controllers/jobseekers/flood_light_tags_spec.rb
+++ b/spec/controllers/jobseekers/flood_light_tags_spec.rb
@@ -6,8 +6,13 @@ RSpec.describe VacanciesController do
   render_views
 
   before do
+    # The application form is behind a login now
+    sign_in create(:jobseeker), scope: :jobseeker
+
     get :show, params: { id: vacancy }
   end
+
+  after { sign_out }
 
   describe "Apply Button" do
     let(:vacancy) { create(:vacancy) }

--- a/spec/controllers/jobseekers/flood_light_tags_spec.rb
+++ b/spec/controllers/jobseekers/flood_light_tags_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-# Please notify performance analyst if you change this test
+# Please notify performance analyst (currently Brandon) if you change this test
 # as it reflects the binding between the application and the Floodlight tags in GA
 RSpec.describe VacanciesController do
   render_views
@@ -12,7 +12,7 @@ RSpec.describe VacanciesController do
     get :show, params: { id: vacancy }
   end
 
-  after { sign_out }
+  after { sign_out :jobseeker }
 
   describe "Apply Button" do
     let(:vacancy) { create(:vacancy) }

--- a/spec/system/jobseekers/jobseekers_can_apply_for_a_vacancy_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_apply_for_a_vacancy_spec.rb
@@ -1,26 +1,47 @@
 require "rails_helper"
 
 RSpec.describe "Jobseekers can apply for a vacancy" do
-  let(:vacancy) do
-    create(:vacancy, :published, :no_tv_applications,
-           application_link: "www.google.com", organisations: [build(:school)])
-  end
-
   before { visit job_path(vacancy) }
 
-  after { logout }
+  context "with a website vacancy" do
+    let(:expected_link) { I18n.t("jobs.apply", href: "http://www.google.com") }
 
-  scenario "the application link is without protocol" do
-    expect(page).to have_link(I18n.t("jobs.apply", href: "http://www.google.com"))
+    context "with a published vacancy" do
+      let(:vacancy) do
+        create(:vacancy, :published, :no_tv_applications,
+               application_link: "www.google.com", organisations: [build(:school)])
+      end
+
+      it "has an application link" do
+        expect(page).to have_link(expected_link)
+      end
+    end
+
+    context "with an expired vacancy" do
+      let(:vacancy) do
+        create(:vacancy, :expired, :no_tv_applications,
+               application_link: "www.google.com", organisations: [build(:school)])
+      end
+
+      it "does not have an application link" do
+        expect(page).not_to have_link(expected_link)
+      end
+    end
   end
 
-  let(:expired_vacancy) do
-    create(:vacancy, :expired, :no_tv_applications,
-           application_link: "www.google.com", organisations: [build(:school)])
-  end
+  context "with a download form vacancy" do
+    let(:vacancy) do
+      create(:vacancy, :published, :with_application_form,
+             organisations: [build(:school)])
+    end
+    let(:jobseeker) { create(:jobseeker) }
+    let(:expected_content) { "Download an application form" }
 
-  scenario "the application links are not present for expired vacancy" do
-    visit job_path(expired_vacancy)
-    expect(page).not_to have_link(I18n.t("jobs.apply", href: "http://www.google.com"))
+    it "apply link can only be found after login" do
+      expect(page).not_to have_content(expected_content)
+      all(".govuk-button").last.click
+      sign_in_jobseeker_govuk_one_login(jobseeker)
+      expect(page).to have_content(expected_content)
+    end
   end
 end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/GPZDLsAv/1399-putting-word-doc-apps-forms-behind-a-login-release-after-gov-one-login

## Changes in this PR:

- Is there anything specific you want feedback on?

## Screenshots of UI changes:

### Before

### After
![SigninForDownload](https://github.com/user-attachments/assets/1887d469-9c26-46aa-be1b-2a7cbec668b3)


## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
