### PR TITLE
Fix transcript bug on guidance pages

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,7 @@
 class PostsController < ApplicationController
   def index
     return not_found if params[:section] == "transcripts"
+    
     @subcategories = MarkdownDocument.all_subcategories(params[:section])
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,7 @@
 class PostsController < ApplicationController
   def index
+    return not_found if params[:section] == "transcripts"
     @subcategories = MarkdownDocument.all_subcategories(params[:section])
-    not_found if params[:section] == "transcripts"
   end
 
   def subcategory

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,7 @@
 class PostsController < ApplicationController
   def index
     @subcategories = MarkdownDocument.all_subcategories(params[:section])
+    not_found if params[:section] == "transcripts"
   end
 
   def subcategory

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -6,6 +6,8 @@ class PostsController < ApplicationController
   end
 
   def subcategory
+    return not_found if params[:section] == "transcripts"
+
     @posts = MarkdownDocument.all(params[:section], params[:subcategory])
     render :subcategory
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,7 @@
 class PostsController < ApplicationController
   def index
     return not_found if params[:section] == "transcripts"
-    
+
     @subcategories = MarkdownDocument.all_subcategories(params[:section])
   end
 

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -2,12 +2,13 @@
 - content_for :page_title_prefix, @post.title
 - content_for :page_description, @post.meta_description
 
-- content_for :breadcrumbs do
-  nav aria-label="breadcrumb" role="navigation"
-    = govuk_breadcrumbs breadcrumbs: { t("breadcrumbs.home") => root_path,
-                                       params[:section].titleize.capitalize => posts_path(section: params[:section]),
-                                       formatted_subcategory => subcategory_path(section: params[:section], subcategory: params[:subcategory]),
-                                       @post.title => "" }
+- unless params[:section] == "transcripts"
+  - content_for :breadcrumbs do
+    nav aria-label="breadcrumb" role="navigation"
+      = govuk_breadcrumbs breadcrumbs: { t("breadcrumbs.home") => root_path,
+                                        params[:section].titleize.capitalize => posts_path(section: params[:section]),
+                                        formatted_subcategory => subcategory_path(section: params[:section], subcategory: params[:subcategory]),
+                                        @post.title => "" }
 
 .govuk-grid-row.post
   .govuk-grid-column-two-thirds

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -107,6 +107,14 @@ RSpec.describe PostsController do
           expect(assigns(:posts).map(&:post_name).sort).to eq(post_names.sort)
         end
       end
+
+      context "when section is 'transcripts'" do
+        it "responds with a 404 not found" do
+          get :subcategory, params: { section: "transcripts", subcategory: "jobseekers" }
+  
+          expect(response).to have_http_status(:not_found)
+        end
+      end
     end
 
     it "renders the subcategory template" do

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe PostsController do
       context "when section is 'transcripts'" do
         it "responds with a 404 not found" do
           get :subcategory, params: { section: "transcripts", subcategory: "jobseekers" }
-  
+
           expect(response).to have_http_status(:not_found)
         end
       end

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe PostsController do
 
       expect(response).to render_template("index")
     end
+
+    context "when section is 'transcripts'" do
+      it "responds with a 404 not found" do
+        get :index, params: { section: "transcripts" }
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
   end
 
   describe "#subcategory" do


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/frDPPOcM/1417-do-not-show-breadcrumbs-for-transcript-pages-on-guides-posts

## Changes in this PR:

- Remove breadcrumbs from transcripts guides/posts
- Show not found page if someone navigates to the transcripts category of posts

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
