### PR TITLE
Simplify DfE::Analytics behaviour on development

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,4 @@
+DFE_ANALYTICS_ASYNC=false
 DFE_ANALYTICS_LOG_ONLY=true
 DFE_SIGN_IN_REDIRECT_URL=http://localhost:3000/auth/dfe/callback
 DISABLE_EMAILS=false

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -5,7 +5,7 @@ DfE::Analytics.configure do |config|
 
   # Whether to use ActiveJob or dispatch events immediately.
   #
-  config.async = true
+  config.async = ActiveModel::Type::Boolean.new.cast(ENV.fetch("DFE_ANALYTICS_ASYNC", false))
 
   # Which ActiveJob queue to put events on
   #


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/V21umOln/1456-simplify-dfeanalytics-on-development-testing-environments

## Changes in this PR:

Configures DfE::Analytics on development so:
- Events stop being sent to background jobs to run asynchronously --> **This is bugged at the moment**. [Fix proposed](https://github.com/DFE-Digital/dfe-analytics/pull/181)
- Events are just logged, not sent to BigQ.

On testing, upon a closer look, it seems there is nothing to do.
`Sidekiq` in testing `fake!` mode is sending the jobs into an array, and the Analytics `fake!` testing mode [stubs BigQ client](https://github.com/DFE-Digital/dfe-analytics?tab=readme-ov-file#testing-modes).