### PR TITLE
Fix "data" arg format for all analytics events

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -146,6 +146,11 @@ Style/HashSyntax:
 # This is incompatible with our other migration checks
 Rails/BulkChangeTable:
   Enabled: false
+
+# Incompatible with DfE-Analytics custom matcher we have extended (have_been_enqueued_as_analytics_event)
+RSpec/ExpectActual:
+  Enabled: false
+
 ##
 # Tech Debt
 # TODO: `rubocop-govuk` previously had all these metrics disabled as they are "just heuristics".

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -147,10 +147,6 @@ Style/HashSyntax:
 Rails/BulkChangeTable:
   Enabled: false
 
-# Incompatible with DfE-Analytics custom matcher we have extended (have_been_enqueued_as_analytics_event)
-RSpec/ExpectActual:
-  Enabled: false
-
 ##
 # Tech Debt
 # TODO: `rubocop-govuk` previously had all these metrics disabled as they are "just heuristics".

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -34,7 +34,7 @@ class Api::EventsController < Api::ApplicationController
         .with_request_details(request)
         .with_response_details(response)
         .with_user(current_user)
-        .with_data(data)
+        .with_data(data:)
 
       DfE::Analytics::SendEvents.do([event])
     end

--- a/app/controllers/api/vacancies_controller.rb
+++ b/app/controllers/api/vacancies_controller.rb
@@ -27,7 +27,7 @@ class Api::VacanciesController < Api::ApplicationController
       .with_request_details(request)
       .with_response_details(response)
       .with_user(current_user)
-      .with_data(event_data)
+      .with_data(data: event_data)
 
     DfE::Analytics::SendEvents.do([event])
   end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -30,12 +30,10 @@ class DocumentsController < ApplicationController
       .with_request_details(request)
       .with_response_details(response)
       .with_user(current_user)
-      .with_data(
-        vacancy_id: vacancy.id,
-        document_type: application_form? ? :application_form : :supporting_document,
-        document_id: file.id,
-        filename: file.filename,
-      )
+      .with_data(data: { vacancy_id: vacancy.id,
+                         document_type: application_form? ? :application_form : :supporting_document,
+                         document_id: file.id,
+                         filename: file.filename })
 
     DfE::Analytics::SendEvents.do([event])
   end

--- a/app/controllers/jobseekers/job_applications_controller.rb
+++ b/app/controllers/jobseekers/job_applications_controller.rb
@@ -214,7 +214,7 @@ class Jobseekers::JobApplicationsController < Jobseekers::JobApplications::BaseC
                                    .with_request_details(request)
                                    .with_response_details(response)
                                    .with_user(current_jobseeker)
-                                   .with_data(vacancy_id: vacancy.id)
+                                   .with_data(data: { vacancy_id: vacancy.id })
 
       DfE::Analytics::SendEvents.do([event])
     end

--- a/app/controllers/publishers/vacancies/application_forms_controller.rb
+++ b/app/controllers/publishers/vacancies/application_forms_controller.rb
@@ -57,7 +57,7 @@ class Publishers::Vacancies::ApplicationFormsController < Publishers::Vacancies:
         .with_request_details(request)
         .with_response_details(response)
         .with_user(current_publisher)
-        .with_data(event_data)
+        .with_data(data: event_data)
 
       DfE::Analytics::SendEvents.do([event])
     end

--- a/app/controllers/publishers/vacancies/documents_controller.rb
+++ b/app/controllers/publishers/vacancies/documents_controller.rb
@@ -82,13 +82,13 @@ class Publishers::Vacancies::DocumentsController < Publishers::Vacancies::BaseCo
         .with_request_details(request)
         .with_response_details(response)
         .with_user(current_publisher)
-        .with_data(
+        .with_data(data: {
           vacancy_id: vacancy.id,
           document_type: "supporting_document",
           name: name,
           size: size,
           content_type: content_type,
-        )
+        })
 
       DfE::Analytics::SendEvents.do([event])
     end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -137,7 +137,7 @@ class SubscriptionsController < ApplicationController
   end
 
   def trigger_create_job_alert_clicked_event
-    trigger_dfe_analytics_event(:vacancy_create_job_alert_clicked, { vacancy_id: vacancy_id })
+    trigger_dfe_analytics_event(:vacancy_create_job_alert_clicked, data: { vacancy_id: vacancy_id })
   end
 
   def trigger_dfe_analytics_event(type, data)

--- a/spec/mailers/jobseekers/account_mailer_spec.rb
+++ b/spec/mailers/jobseekers/account_mailer_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Jobseekers::AccountMailer do
 
     it "triggers a `jobseeker_account_closed` email event" do
       mail.deliver_now
-      expect(:jobseeker_account_closed).to have_been_enqueued_as_analytics_events
+      expect(:jobseeker_account_closed).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
     end
   end
 
@@ -47,7 +47,7 @@ RSpec.describe Jobseekers::AccountMailer do
 
     it "triggers a `jobseeker_inactive_account` email event" do
       mail.deliver_now
-      expect(:jobseeker_inactive_account).to have_been_enqueued_as_analytics_events
+      expect(:jobseeker_inactive_account).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
     end
   end
 end

--- a/spec/mailers/jobseekers/account_mailer_spec.rb
+++ b/spec/mailers/jobseekers/account_mailer_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Jobseekers::AccountMailer do
 
     it "triggers a `jobseeker_account_closed` email event" do
       mail.deliver_now
-      expect(:jobseeker_account_closed).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
+      expect(:jobseeker_account_closed).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template]) # rubocop:disable RSpec/ExpectActual
     end
   end
 
@@ -47,7 +47,7 @@ RSpec.describe Jobseekers::AccountMailer do
 
     it "triggers a `jobseeker_inactive_account` email event" do
       mail.deliver_now
-      expect(:jobseeker_inactive_account).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
+      expect(:jobseeker_inactive_account).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template]) # rubocop:disable RSpec/ExpectActual
     end
   end
 end

--- a/spec/mailers/jobseekers/alert_mailer_spec.rb
+++ b/spec/mailers/jobseekers/alert_mailer_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Jobseekers::AlertMailer do
 
       it "triggers a `jobseeker_subscription_alert` email event with the anonymised jobseeker id" do
         mail.deliver_now
-        expect(:jobseeker_subscription_alert).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
+        expect(:jobseeker_subscription_alert).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template]) # rubocop:disable RSpec/ExpectActual
       end
     end
 
@@ -102,7 +102,7 @@ RSpec.describe Jobseekers::AlertMailer do
 
       it "triggers a `jobseeker_subscription_alert` email event without the anonymised jobseeker id" do
         mail.deliver_now
-        expect(:jobseeker_subscription_alert).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
+        expect(:jobseeker_subscription_alert).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template]) # rubocop:disable RSpec/ExpectActual
       end
     end
   end
@@ -140,7 +140,7 @@ RSpec.describe Jobseekers::AlertMailer do
 
       it "triggers a `jobseeker_subscription_alert` email event with the anonymised jobseeker id" do
         mail.deliver_now
-        expect(:jobseeker_subscription_alert).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
+        expect(:jobseeker_subscription_alert).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template]) # rubocop:disable RSpec/ExpectActual
       end
     end
 
@@ -149,7 +149,7 @@ RSpec.describe Jobseekers::AlertMailer do
 
       it "triggers a `jobseeker_subscription_alert` email event without the anonymised jobseeker id" do
         mail.deliver_now
-        expect(:jobseeker_subscription_alert).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
+        expect(:jobseeker_subscription_alert).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template]) # rubocop:disable RSpec/ExpectActual
       end
     end
 

--- a/spec/mailers/jobseekers/alert_mailer_spec.rb
+++ b/spec/mailers/jobseekers/alert_mailer_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Jobseekers::AlertMailer do
 
       it "triggers a `jobseeker_subscription_alert` email event with the anonymised jobseeker id" do
         mail.deliver_now
-        expect(:jobseeker_subscription_alert).to have_been_enqueued_as_analytics_events
+        expect(:jobseeker_subscription_alert).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
       end
     end
 
@@ -102,7 +102,7 @@ RSpec.describe Jobseekers::AlertMailer do
 
       it "triggers a `jobseeker_subscription_alert` email event without the anonymised jobseeker id" do
         mail.deliver_now
-        expect(:jobseeker_subscription_alert).to have_been_enqueued_as_analytics_events
+        expect(:jobseeker_subscription_alert).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
       end
     end
   end
@@ -140,7 +140,7 @@ RSpec.describe Jobseekers::AlertMailer do
 
       it "triggers a `jobseeker_subscription_alert` email event with the anonymised jobseeker id" do
         mail.deliver_now
-        expect(:jobseeker_subscription_alert).to have_been_enqueued_as_analytics_events
+        expect(:jobseeker_subscription_alert).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
       end
     end
 
@@ -149,7 +149,7 @@ RSpec.describe Jobseekers::AlertMailer do
 
       it "triggers a `jobseeker_subscription_alert` email event without the anonymised jobseeker id" do
         mail.deliver_now
-        expect(:jobseeker_subscription_alert).to have_been_enqueued_as_analytics_events
+        expect(:jobseeker_subscription_alert).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
       end
     end
 

--- a/spec/mailers/jobseekers/job_application_mailer_spec.rb
+++ b/spec/mailers/jobseekers/job_application_mailer_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Jobseekers::JobApplicationMailer do
 
     it "triggers a `jobseeker_application_shortlisted` email event" do
       mail.deliver_now
-      expect(:jobseeker_application_shortlisted).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
+      expect(:jobseeker_application_shortlisted).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template]) # rubocop:disable RSpec/ExpectActual
     end
   end
 
@@ -51,7 +51,7 @@ RSpec.describe Jobseekers::JobApplicationMailer do
 
     it "triggers a `jobseeker_application_submitted` email event" do
       mail.deliver_now
-      expect(:jobseeker_application_submitted).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
+      expect(:jobseeker_application_submitted).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template]) # rubocop:disable RSpec/ExpectActual
     end
   end
 
@@ -70,7 +70,7 @@ RSpec.describe Jobseekers::JobApplicationMailer do
 
     it "triggers a `jobseeker_application_unsuccessful` email event" do
       mail.deliver_now
-      expect(:jobseeker_application_unsuccessful).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
+      expect(:jobseeker_application_unsuccessful).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template]) # rubocop:disable RSpec/ExpectActual
     end
   end
 
@@ -89,7 +89,7 @@ RSpec.describe Jobseekers::JobApplicationMailer do
 
     it "triggers a `jobseeker_job_listing_ended_early` email event" do
       mail.deliver_now
-      expect(:jobseeker_job_listing_ended_early).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
+      expect(:jobseeker_job_listing_ended_early).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template]) # rubocop:disable RSpec/ExpectActual
     end
   end
 end

--- a/spec/mailers/jobseekers/job_application_mailer_spec.rb
+++ b/spec/mailers/jobseekers/job_application_mailer_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Jobseekers::JobApplicationMailer do
 
     it "triggers a `jobseeker_application_shortlisted` email event" do
       mail.deliver_now
-      expect(:jobseeker_application_shortlisted).to have_been_enqueued_as_analytics_events
+      expect(:jobseeker_application_shortlisted).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
     end
   end
 
@@ -51,7 +51,7 @@ RSpec.describe Jobseekers::JobApplicationMailer do
 
     it "triggers a `jobseeker_application_submitted` email event" do
       mail.deliver_now
-      expect(:jobseeker_application_submitted).to have_been_enqueued_as_analytics_events
+      expect(:jobseeker_application_submitted).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
     end
   end
 
@@ -70,7 +70,7 @@ RSpec.describe Jobseekers::JobApplicationMailer do
 
     it "triggers a `jobseeker_application_unsuccessful` email event" do
       mail.deliver_now
-      expect(:jobseeker_application_unsuccessful).to have_been_enqueued_as_analytics_events
+      expect(:jobseeker_application_unsuccessful).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
     end
   end
 
@@ -89,7 +89,7 @@ RSpec.describe Jobseekers::JobApplicationMailer do
 
     it "triggers a `jobseeker_job_listing_ended_early` email event" do
       mail.deliver_now
-      expect(:jobseeker_job_listing_ended_early).to have_been_enqueued_as_analytics_events
+      expect(:jobseeker_job_listing_ended_early).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
     end
   end
 end

--- a/spec/mailers/jobseekers/subscription_mailer_spec.rb
+++ b/spec/mailers/jobseekers/subscription_mailer_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Jobseekers::SubscriptionMailer do
 
       it "triggers a `jobseeker_subscription_confirmation` email event with the anonymised jobseeker id" do
         mail.deliver_now
-        expect(:jobseeker_subscription_confirmation).to have_been_enqueued_as_analytics_events
+        expect(:jobseeker_subscription_confirmation).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
       end
     end
 
@@ -64,7 +64,7 @@ RSpec.describe Jobseekers::SubscriptionMailer do
 
       it "triggers a `jobseeker_subscription_confirmation` email event without the anonymised jobseeker id" do
         mail.deliver_now
-        expect(:jobseeker_subscription_confirmation).to have_been_enqueued_as_analytics_events
+        expect(:jobseeker_subscription_confirmation).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
       end
     end
 
@@ -108,7 +108,7 @@ RSpec.describe Jobseekers::SubscriptionMailer do
 
       it "triggers a `jobseeker_subscription_update` email event with the anonymised jobseeker id" do
         mail.deliver_now
-        expect(:jobseeker_subscription_update).to have_been_enqueued_as_analytics_events
+        expect(:jobseeker_subscription_update).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
       end
     end
 
@@ -117,7 +117,7 @@ RSpec.describe Jobseekers::SubscriptionMailer do
 
       it "triggers a `jobseeker_subscription_update` email event without the anonymised jobseeker id" do
         mail.deliver_now
-        expect(:jobseeker_subscription_update).to have_been_enqueued_as_analytics_events
+        expect(:jobseeker_subscription_update).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
       end
     end
   end

--- a/spec/mailers/jobseekers/subscription_mailer_spec.rb
+++ b/spec/mailers/jobseekers/subscription_mailer_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Jobseekers::SubscriptionMailer do
 
       it "triggers a `jobseeker_subscription_confirmation` email event with the anonymised jobseeker id" do
         mail.deliver_now
-        expect(:jobseeker_subscription_confirmation).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
+        expect(:jobseeker_subscription_confirmation).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template]) # rubocop:disable RSpec/ExpectActual
       end
     end
 
@@ -64,7 +64,7 @@ RSpec.describe Jobseekers::SubscriptionMailer do
 
       it "triggers a `jobseeker_subscription_confirmation` email event without the anonymised jobseeker id" do
         mail.deliver_now
-        expect(:jobseeker_subscription_confirmation).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
+        expect(:jobseeker_subscription_confirmation).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template]) # rubocop:disable RSpec/ExpectActual
       end
     end
 
@@ -108,7 +108,7 @@ RSpec.describe Jobseekers::SubscriptionMailer do
 
       it "triggers a `jobseeker_subscription_update` email event with the anonymised jobseeker id" do
         mail.deliver_now
-        expect(:jobseeker_subscription_update).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
+        expect(:jobseeker_subscription_update).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template]) # rubocop:disable RSpec/ExpectActual
       end
     end
 
@@ -117,7 +117,7 @@ RSpec.describe Jobseekers::SubscriptionMailer do
 
       it "triggers a `jobseeker_subscription_update` email event without the anonymised jobseeker id" do
         mail.deliver_now
-        expect(:jobseeker_subscription_update).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
+        expect(:jobseeker_subscription_update).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template]) # rubocop:disable RSpec/ExpectActual
       end
     end
   end

--- a/spec/mailers/publishers/authentication_fallback_mailer_spec.rb
+++ b/spec/mailers/publishers/authentication_fallback_mailer_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Publishers::AuthenticationFallbackMailer do
 
     it "triggers a `publisher_sign_in_fallback` email event" do
       mail.deliver_now
-      expect(:publisher_sign_in_fallback).to have_been_enqueued_as_analytics_events
+      expect(:publisher_sign_in_fallback).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
     end
   end
 end

--- a/spec/mailers/publishers/authentication_fallback_mailer_spec.rb
+++ b/spec/mailers/publishers/authentication_fallback_mailer_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Publishers::AuthenticationFallbackMailer do
 
     it "triggers a `publisher_sign_in_fallback` email event" do
       mail.deliver_now
-      expect(:publisher_sign_in_fallback).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
+      expect(:publisher_sign_in_fallback).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template]) # rubocop:disable RSpec/ExpectActual
     end
   end
 end

--- a/spec/mailers/publishers/expired_vacancy_feedback_prompt_mailer_spec.rb
+++ b/spec/mailers/publishers/expired_vacancy_feedback_prompt_mailer_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Publishers::ExpiredVacancyFeedbackPromptMailer do
 
     it "triggers a `publisher_prompt_for_feedback` email event" do
       mail.deliver_now
-      expect(:publisher_prompt_for_feedback).to have_been_enqueued_as_analytics_events
+      expect(:publisher_prompt_for_feedback).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
     end
   end
 end

--- a/spec/mailers/publishers/expired_vacancy_feedback_prompt_mailer_spec.rb
+++ b/spec/mailers/publishers/expired_vacancy_feedback_prompt_mailer_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Publishers::ExpiredVacancyFeedbackPromptMailer do
 
     it "triggers a `publisher_prompt_for_feedback` email event" do
       mail.deliver_now
-      expect(:publisher_prompt_for_feedback).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
+      expect(:publisher_prompt_for_feedback).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template]) # rubocop:disable RSpec/ExpectActual
     end
   end
 end

--- a/spec/mailers/publishers/job_application_data_expiry_mailer_spec.rb
+++ b/spec/mailers/publishers/job_application_data_expiry_mailer_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Publishers::JobApplicationDataExpiryMailer do
 
     it "triggers a `publisher_job_application_data_expiry` email event" do
       mail.deliver_now
-      expect(:publisher_job_application_data_expiry).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
+      expect(:publisher_job_application_data_expiry).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template]) # rubocop:disable RSpec/ExpectActual
     end
   end
 end

--- a/spec/mailers/publishers/job_application_data_expiry_mailer_spec.rb
+++ b/spec/mailers/publishers/job_application_data_expiry_mailer_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Publishers::JobApplicationDataExpiryMailer do
 
     it "triggers a `publisher_job_application_data_expiry` email event" do
       mail.deliver_now
-      expect(:publisher_job_application_data_expiry).to have_been_enqueued_as_analytics_events
+      expect(:publisher_job_application_data_expiry).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
     end
   end
 end

--- a/spec/mailers/publishers/job_application_mailer_spec.rb
+++ b/spec/mailers/publishers/job_application_mailer_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Publishers::JobApplicationMailer do
 
     it "triggers a `publisher_applications_received` email event" do
       mail.deliver_now
-      expect(:publisher_applications_received).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
+      expect(:publisher_applications_received).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template]) # rubocop:disable RSpec/ExpectActual
     end
   end
 end

--- a/spec/mailers/publishers/job_application_mailer_spec.rb
+++ b/spec/mailers/publishers/job_application_mailer_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Publishers::JobApplicationMailer do
 
     it "triggers a `publisher_applications_received` email event" do
       mail.deliver_now
-      expect(:publisher_applications_received).to have_been_enqueued_as_analytics_events
+      expect(:publisher_applications_received).to have_been_enqueued_as_analytics_event(with_data: %i[uid notify_template])
     end
   end
 end

--- a/spec/models/equal_opportunities_report_spec.rb
+++ b/spec/models/equal_opportunities_report_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe EqualOpportunitiesReport do
 
     it "triggers an event with the correct data" do
       subject.trigger_event
-      expect(:equal_opportunities_report_published).to have_been_enqueued_as_analytics_events
+      expect(:equal_opportunities_report_published).to have_been_enqueued_as_analytics_event
     end
   end
 end

--- a/spec/requests/api/events_spec.rb
+++ b/spec/requests/api/events_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Events API" do
     end
 
     it "triggers an event" do
-      expect(:tracked_link_clicked).to have_been_enqueued_as_analytics_event(with_data: event_data)
+      expect(:tracked_link_clicked).to have_been_enqueued_as_analytics_event(with_data: event_data) # rubocop:disable RSpec/ExpectActual
     end
 
     it "requires a CSRF token", with_csrf_protection: true do

--- a/spec/requests/api/events_spec.rb
+++ b/spec/requests/api/events_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Events API" do
     end
 
     it "triggers an event" do
-      expect(:tracked_link_clicked).to have_been_enqueued_as_analytics_events
+      expect(:tracked_link_clicked).to have_been_enqueued_as_analytics_event(with_data: event_data)
     end
 
     it "requires a CSRF token", with_csrf_protection: true do

--- a/spec/requests/api/vacancies_spec.rb
+++ b/spec/requests/api/vacancies_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe "Api::Vacancies" do
 
     it "still monitors API usage if the request is for an entity that is not found" do
       get api_job_path("slug-that-does-not-exist", api_version: 1), params: { format: :json }
-      expect(:api_queried).to have_been_enqueued_as_analytics_events
+      expect(:api_queried).to have_been_enqueued_as_analytics_event
     end
 
     context "sets headers" do
@@ -139,7 +139,7 @@ RSpec.describe "Api::Vacancies" do
 
     it "triggers an api_queried event" do
       subject
-      expect(:api_queried).to have_been_enqueued_as_analytics_events
+      expect(:api_queried).to have_been_enqueued_as_analytics_event
     end
 
     it "never redirects to latest url" do

--- a/spec/requests/documents_spec.rb
+++ b/spec/requests/documents_spec.rb
@@ -17,7 +17,12 @@ RSpec.describe "Documents" do
       it "triggers a `vacancy_document_downloaded` event" do
         get job_document_path(vacancy, document.id)
 
-        expect(:vacancy_document_downloaded).to have_been_enqueued_as_analytics_events
+        expect(:vacancy_document_downloaded).to have_been_enqueued_as_analytics_event(
+          with_data: { vacancy_id: vacancy.id,
+                       document_type: "supporting_document",
+                       document_id: document.id,
+                       filename: document.filename },
+        )
       end
     end
   end
@@ -37,7 +42,12 @@ RSpec.describe "Documents" do
       it "triggers a `vacancy_document_downloaded` event" do
         get job_document_path(vacancy, document.id)
 
-        expect(:vacancy_document_downloaded).to have_been_enqueued_as_analytics_events
+        expect(:vacancy_document_downloaded).to have_been_enqueued_as_analytics_event(
+          with_data: { vacancy_id: vacancy.id,
+                       document_type: "application_form",
+                       document_id: document.id,
+                       filename: document.filename },
+        )
       end
     end
   end

--- a/spec/requests/documents_spec.rb
+++ b/spec/requests/documents_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Documents" do
       it "triggers a `vacancy_document_downloaded` event" do
         get job_document_path(vacancy, document.id)
 
-        expect(:vacancy_document_downloaded).to have_been_enqueued_as_analytics_event(
+        expect(:vacancy_document_downloaded).to have_been_enqueued_as_analytics_event( # rubocop:disable RSpec/ExpectActual
           with_data: { vacancy_id: vacancy.id,
                        document_type: "supporting_document",
                        document_id: document.id,
@@ -42,7 +42,7 @@ RSpec.describe "Documents" do
       it "triggers a `vacancy_document_downloaded` event" do
         get job_document_path(vacancy, document.id)
 
-        expect(:vacancy_document_downloaded).to have_been_enqueued_as_analytics_event(
+        expect(:vacancy_document_downloaded).to have_been_enqueued_as_analytics_event( # rubocop:disable RSpec/ExpectActual
           with_data: { vacancy_id: vacancy.id,
                        document_type: "application_form",
                        document_id: document.id,

--- a/spec/requests/jobseekers/govuk_one_login_spec.rb
+++ b/spec/requests/jobseekers/govuk_one_login_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "Govuk One Login authentication response" do
       it "sends an analytics event for a failed OneLogin sign-in attempt" do
         get auth_govuk_one_login_callback_path
 
-        expect(:jobseeker_failed_govuk_one_login_sign_in).to have_been_enqueued_as_analytics_events
+        expect(:jobseeker_failed_govuk_one_login_sign_in).to have_been_enqueued_as_analytics_event
       end
     end
 
@@ -87,7 +87,7 @@ RSpec.describe "Govuk One Login authentication response" do
     it "sends an analytics event for a successful OneLogin sign-in attempt" do
       get auth_govuk_one_login_callback_path
 
-      expect(:jobseeker_successful_govuk_one_login_sign_in).to have_been_enqueued_as_analytics_events
+      expect(:jobseeker_successful_govuk_one_login_sign_in).to have_been_enqueued_as_analytics_event
     end
 
     context "when the OneLogin user does not match a TV jobseeker" do

--- a/spec/requests/jobseekers/job_applications_spec.rb
+++ b/spec/requests/jobseekers/job_applications_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Job applications" do
         it "triggers a `vacancy_apply_clicked` event" do
           get new_jobseekers_job_job_application_path(vacancy.id)
 
-          expect(:vacancy_apply_clicked).to have_been_enqueued_as_analytics_event(with_data: { vacancy_id: vacancy.id })
+          expect(:vacancy_apply_clicked).to have_been_enqueued_as_analytics_event(with_data: { vacancy_id: vacancy.id }) # rubocop:disable RSpec/ExpectActual
         end
 
         context "when a job application for the job already exists" do

--- a/spec/requests/jobseekers/job_applications_spec.rb
+++ b/spec/requests/jobseekers/job_applications_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Job applications" do
         it "triggers a `vacancy_apply_clicked` event" do
           get new_jobseekers_job_job_application_path(vacancy.id)
 
-          expect(:vacancy_apply_clicked).to have_been_enqueued_as_analytics_events
+          expect(:vacancy_apply_clicked).to have_been_enqueued_as_analytics_event(with_data: { vacancy_id: vacancy.id })
         end
 
         context "when a job application for the job already exists" do

--- a/spec/requests/publishers/vacancies/application_forms_spec.rb
+++ b/spec/requests/publishers/vacancies/application_forms_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Documents" do
     context "when the form is valid" do
       it "triggers an event" do
         request
-        expect(:supporting_document_created).to have_been_enqueued_as_analytics_event(
+        expect(:supporting_document_created).to have_been_enqueued_as_analytics_event( # rubocop:disable RSpec/ExpectActual
           with_data: { vacancy_id: vacancy.id,
                        document_type: "application_form",
                        name: "blank_job_spec.pdf",
@@ -162,7 +162,7 @@ RSpec.describe "Documents" do
         it "sends a supporting_document_replaced event" do
           request
 
-          expect(:supporting_document_replaced).to have_been_enqueued_as_analytics_event(
+          expect(:supporting_document_replaced).to have_been_enqueued_as_analytics_event( # rubocop:disable RSpec/ExpectActual
             with_data: { vacancy_id: vacancy.id,
                          document_type: "application_form",
                          name: "blank_job_spec.pdf",

--- a/spec/requests/publishers/vacancies/application_forms_spec.rb
+++ b/spec/requests/publishers/vacancies/application_forms_spec.rb
@@ -32,7 +32,13 @@ RSpec.describe "Documents" do
     context "when the form is valid" do
       it "triggers an event" do
         request
-        expect(:supporting_document_created).to have_been_enqueued_as_analytics_events
+        expect(:supporting_document_created).to have_been_enqueued_as_analytics_event(
+          with_data: { vacancy_id: vacancy.id,
+                       document_type: "application_form",
+                       name: "blank_job_spec.pdf",
+                       size: vacancy.application_form.byte_size,
+                       content_type: "application/pdf" },
+        )
       end
 
       it "attaches the application form to the vacancy" do
@@ -156,7 +162,13 @@ RSpec.describe "Documents" do
         it "sends a supporting_document_replaced event" do
           request
 
-          expect(:supporting_document_replaced).to have_been_enqueued_as_analytics_events
+          expect(:supporting_document_replaced).to have_been_enqueued_as_analytics_event(
+            with_data: { vacancy_id: vacancy.id,
+                         document_type: "application_form",
+                         name: "blank_job_spec.pdf",
+                         size: vacancy.application_form.byte_size,
+                         content_type: "application/pdf" },
+          )
         end
 
         it "redirects to the next step" do

--- a/spec/requests/publishers/vacancies/documents_spec.rb
+++ b/spec/requests/publishers/vacancies/documents_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Documents" do
 
       it "triggers an event" do
         request
-        expect(:supporting_document_created).to have_been_enqueued_as_analytics_event(
+        expect(:supporting_document_created).to have_been_enqueued_as_analytics_event( # rubocop:disable RSpec/ExpectActual
           with_data: { vacancy_id: vacancy.id,
                        document_type: "supporting_document",
                        name: "blank_job_spec.pdf",
@@ -111,7 +111,7 @@ RSpec.describe "Documents" do
 
     it "triggers an event" do
       request
-      expect(:supporting_document_deleted).to have_been_enqueued_as_analytics_event(
+      expect(:supporting_document_deleted).to have_been_enqueued_as_analytics_event( # rubocop:disable RSpec/ExpectActual
         with_data: { vacancy_id: vacancy.id,
                      document_type: "supporting_document",
                      name: "blank_job_spec.pdf",

--- a/spec/requests/publishers/vacancies/documents_spec.rb
+++ b/spec/requests/publishers/vacancies/documents_spec.rb
@@ -27,7 +27,13 @@ RSpec.describe "Documents" do
 
       it "triggers an event" do
         request
-        expect(:supporting_document_created).to have_been_enqueued_as_analytics_events
+        expect(:supporting_document_created).to have_been_enqueued_as_analytics_event(
+          with_data: { vacancy_id: vacancy.id,
+                       document_type: "supporting_document",
+                       name: "blank_job_spec.pdf",
+                       size: vacancy.supporting_documents.first.byte_size,
+                       content_type: "application/pdf" },
+        )
       end
 
       it "renders the index page" do
@@ -105,7 +111,13 @@ RSpec.describe "Documents" do
 
     it "triggers an event" do
       request
-      expect(:supporting_document_deleted).to have_been_enqueued_as_analytics_events
+      expect(:supporting_document_deleted).to have_been_enqueued_as_analytics_event(
+        with_data: { vacancy_id: vacancy.id,
+                     document_type: "supporting_document",
+                     name: "blank_job_spec.pdf",
+                     size: vacancy.supporting_documents.first.byte_size,
+                     content_type: "application/pdf" },
+      )
     end
 
     it "removes the document" do

--- a/spec/requests/subscriptions_spec.rb
+++ b/spec/requests/subscriptions_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "Subscriptions" do
     it "triggers a `job_alert_subscription_created` event" do
       subject
 
-      expect(:job_alert_subscription_created).to have_been_enqueued_as_analytics_event(
+      expect(:job_alert_subscription_created).to have_been_enqueued_as_analytics_event( # rubocop:disable RSpec/ExpectActual
         with_data: %i[autopopulated frequency recaptcha_score search_criteria subscription_identifier],
       )
     end
@@ -139,7 +139,7 @@ RSpec.describe "Subscriptions" do
     it "triggers a `job_alert_subscription_updated` event" do
       subject
 
-      expect(:job_alert_subscription_updated).to have_been_enqueued_as_analytics_event(
+      expect(:job_alert_subscription_updated).to have_been_enqueued_as_analytics_event( # rubocop:disable RSpec/ExpectActual
         with_data: %i[autopopulated frequency recaptcha_score search_criteria subscription_identifier],
       )
     end
@@ -167,7 +167,7 @@ RSpec.describe "Subscriptions" do
     it "triggers a `job_alert_subscription_unsubscribed` event" do
       subject
 
-      expect(:job_alert_subscription_unsubscribed).to have_been_enqueued_as_analytics_event(
+      expect(:job_alert_subscription_unsubscribed).to have_been_enqueued_as_analytics_event( # rubocop:disable RSpec/ExpectActual
         with_data: %i[autopopulated frequency recaptcha_score search_criteria subscription_identifier],
       )
     end

--- a/spec/requests/subscriptions_spec.rb
+++ b/spec/requests/subscriptions_spec.rb
@@ -89,7 +89,9 @@ RSpec.describe "Subscriptions" do
     it "triggers a `job_alert_subscription_created` event" do
       subject
 
-      expect(:job_alert_subscription_created).to have_been_enqueued_as_analytics_events
+      expect(:job_alert_subscription_created).to have_been_enqueued_as_analytics_event(
+        with_data: %i[autopopulated frequency recaptcha_score search_criteria subscription_identifier],
+      )
     end
 
     context "with unsafe params" do
@@ -137,7 +139,9 @@ RSpec.describe "Subscriptions" do
     it "triggers a `job_alert_subscription_updated` event" do
       subject
 
-      expect(:job_alert_subscription_updated).to have_been_enqueued_as_analytics_events
+      expect(:job_alert_subscription_updated).to have_been_enqueued_as_analytics_event(
+        with_data: %i[autopopulated frequency recaptcha_score search_criteria subscription_identifier],
+      )
     end
 
     context "with unsafe params" do
@@ -163,7 +167,9 @@ RSpec.describe "Subscriptions" do
     it "triggers a `job_alert_subscription_unsubscribed` event" do
       subject
 
-      expect(:job_alert_subscription_unsubscribed).to have_been_enqueued_as_analytics_events
+      expect(:job_alert_subscription_unsubscribed).to have_been_enqueued_as_analytics_event(
+        with_data: %i[autopopulated frequency recaptcha_score search_criteria subscription_identifier],
+      )
     end
   end
 end

--- a/spec/support/matchers/have_been_enqueued_as_analytics_event.rb
+++ b/spec/support/matchers/have_been_enqueued_as_analytics_event.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+# Allows to assert against the enqueued DFE Analytics events.
+# The matcher can be used in the following way:
+# - First option. Assert that the event type was enqueued:
+#     expect(:event_type).to have_been_enqueued_as_analytics_event
+# - Second option. Assert that the event type was enqueued with specific data:
+#     expect(:event_type).to have_been_enqueued_as_analytics_event(with_data: { key: "value" })
+# - Third option. Assert that the event type was enqueued with specific data keys (without asserting against the values):
+#     expect(:event_type).to have_been_enqueued_as_analytics_event(with_data: [:key1, :key2])
+#
+# Copied and extended from dfe-analytics matcher:
+# https://github.com/DFE-Digital/dfe-analytics/blob/main/lib/dfe/analytics/rspec/matchers/have_been_enqueued_as_analytics_events.rb
+RSpec::Matchers.define :have_been_enqueued_as_analytics_event do |args|
+  match do |event_type|
+    data = args&.fetch(:with_data, {})
+    if data.present?
+      jobs = jobs_to_event_types_with_data(queue_adapter.enqueued_jobs)
+      expect(jobs).to include(
+        hash_including(
+          event_type: event_type.to_s,
+          data: data.is_a?(Array) ? hash_including(*data) : hash_including(data),
+        ),
+      )
+    else
+      expect(enqueued_event_types).to include(event_type.to_s)
+    end
+  end
+
+  failure_message do |event_type|
+    if enqueued_event_types.blank?
+      "expected #{event_type} to have been sent as an analytics event type, but no analytics events were sent"
+    elsif enqueued_event_types.include?(event_type.to_s)
+      wanted_data = args&.fetch(:with_data, {})
+      if wanted_data.any?
+        jobs = jobs_to_event_types_with_data(queue_adapter.enqueued_jobs)
+        if wanted_data.is_a?(Array)
+          data_keys = jobs.filter_map { |job| job[:data].keys if job[:event_type] == event_type.to_s }.first
+          "expected #{event_type} to have been sent with data keys: #{wanted_data}, but was was sent with: #{data_keys}"
+        else
+          data = jobs.filter_map { |job| job[:data] if job[:event_type] == event_type.to_s }.first
+          "expected #{event_type} to have been sent with data: #{wanted_data}, but was was sent with: #{data}}"
+        end
+      end
+    else
+      "expected #{event_type} to have been sent as an analytics event type, but found event types: #{enqueued_event_types.uniq}"
+    end
+  end
+
+  def queue_adapter
+    ActiveJob::Base.queue_adapter
+  end
+
+  def jobs_to_event_types(jobs)
+    jobs.map { |job|
+      next unless job["job_class"] == "DfE::Analytics::SendEvents"
+
+      job[:args].first.map do |e|
+        e.fetch("event_type")
+      end
+    }.flatten
+  end
+
+  def jobs_to_event_types_with_data(jobs)
+    jobs.map { |job|
+      next unless job["job_class"] == "DfE::Analytics::SendEvents"
+
+      job[:args].first.map do |e|
+        {
+          event_type: e.fetch("event_type"),
+          data: parse_data(e.fetch("data", {})),
+        }
+      end
+    }.flatten.compact
+  end
+
+  def parse_data(data)
+    return {} if data.none?
+
+    data.each_with_object({}) do |kv, h|
+      h[kv.fetch("key").to_sym] = kv.fetch("value")&.first
+    end
+  end
+
+  def enqueued_event_types
+    @enqueued_event_types ||= jobs_to_event_types(queue_adapter.enqueued_jobs)
+  end
+end

--- a/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_a_listing_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_a_listing_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Jobseekers can create a job alert from a listing", recaptcha: tr
 
   scenario "can click on the first link to create a job alert using data from the vacancy" do
     click_on I18n.t("jobs.alert.similar.terse")
-    expect(:vacancy_create_job_alert_clicked).to have_been_enqueued_as_analytics_event(with_data: { vacancy_id: vacancy.id })
+    expect(:vacancy_create_job_alert_clicked).to have_been_enqueued_as_analytics_event(with_data: { vacancy_id: vacancy.id }) # rubocop:disable RSpec/ExpectActual
 
     expect(page).to have_content(I18n.t("subscriptions.new.title"))
     and_the_search_criteria_are_populated
@@ -38,7 +38,7 @@ RSpec.describe "Jobseekers can create a job alert from a listing", recaptcha: tr
   scenario "can click on the second link to create a job alert using data from the vacancy" do
     click_on I18n.t("jobs.alert.similar.verbose.link_text")
 
-    expect(:vacancy_create_job_alert_clicked).to have_been_enqueued_as_analytics_event(with_data: { vacancy_id: vacancy.id })
+    expect(:vacancy_create_job_alert_clicked).to have_been_enqueued_as_analytics_event(with_data: { vacancy_id: vacancy.id }) # rubocop:disable RSpec/ExpectActual
     and_the_search_criteria_are_populated
   end
 

--- a/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_a_listing_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_a_listing_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Jobseekers can create a job alert from a listing", recaptcha: tr
 
   scenario "can click on the first link to create a job alert using data from the vacancy" do
     click_on I18n.t("jobs.alert.similar.terse")
-    expect(:vacancy_create_job_alert_clicked).to have_been_enqueued_as_analytics_events
+    expect(:vacancy_create_job_alert_clicked).to have_been_enqueued_as_analytics_event(with_data: { vacancy_id: vacancy.id })
 
     expect(page).to have_content(I18n.t("subscriptions.new.title"))
     and_the_search_criteria_are_populated
@@ -38,7 +38,7 @@ RSpec.describe "Jobseekers can create a job alert from a listing", recaptcha: tr
   scenario "can click on the second link to create a job alert using data from the vacancy" do
     click_on I18n.t("jobs.alert.similar.verbose.link_text")
 
-    expect(:vacancy_create_job_alert_clicked).to have_been_enqueued_as_analytics_events
+    expect(:vacancy_create_job_alert_clicked).to have_been_enqueued_as_analytics_event(with_data: { vacancy_id: vacancy.id })
     and_the_search_criteria_are_populated
   end
 

--- a/spec/system/jobseekers/jobseekers_can_sign_in_by_email_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_sign_in_by_email_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Jobseekers can sign in with fallback email authentication" do
           expect(page).to have_content("Saved jobs")
           expect(page).to have_current_path(jobseeker_root_path)
 
-          expect(:jobseeker_sign_in_attempt).to have_been_enqueued_as_analytics_events
+          expect(:jobseeker_sign_in_attempt).to have_been_enqueued_as_analytics_event(with_data: { success: "true", errors: nil })
 
           # Can sign out
           click_on(I18n.t("nav.sign_out"))

--- a/spec/system/jobseekers/jobseekers_can_sign_in_by_email_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_sign_in_by_email_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Jobseekers can sign in with fallback email authentication" do
           expect(page).to have_content("Saved jobs")
           expect(page).to have_current_path(jobseeker_root_path)
 
-          expect(:jobseeker_sign_in_attempt).to have_been_enqueued_as_analytics_event(with_data: { success: "true", errors: nil })
+          expect(:jobseeker_sign_in_attempt).to have_been_enqueued_as_analytics_event(with_data: { success: "true", errors: nil }) # rubocop:disable RSpec/ExpectActual
 
           # Can sign out
           click_on(I18n.t("nav.sign_out"))

--- a/spec/system/publishers/publishers_can_extend_a_deadline_spec.rb
+++ b/spec/system/publishers/publishers_can_extend_a_deadline_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe "Publishers can extend a deadline" do
       end
 
       it "sends an event to analytics" do
-        expect(:publisher_vacancy_relisted).to have_been_enqueued_as_analytics_event(
+        expect(:publisher_vacancy_relisted).to have_been_enqueued_as_analytics_event( # rubocop:disable RSpec/ExpectActual
           with_data: {
             relist_form: "{\"publish_on\":\"#{Date.today}\",\"expires_at\":\"#{expires_at.strftime('%FT%T.%L%:z')}\",\"extension_reason\":\"didnt_find_right_candidate\",\"other_extension_reason_details\":\"\"}",
           },

--- a/spec/system/publishers/publishers_can_extend_a_deadline_spec.rb
+++ b/spec/system/publishers/publishers_can_extend_a_deadline_spec.rb
@@ -90,7 +90,11 @@ RSpec.describe "Publishers can extend a deadline" do
       end
 
       it "sends an event to analytics" do
-        expect(:publisher_vacancy_relisted).to have_been_enqueued_as_analytics_events
+        expect(:publisher_vacancy_relisted).to have_been_enqueued_as_analytics_event(
+          with_data: {
+            relist_form: "{\"publish_on\":\"#{Date.today}\",\"expires_at\":\"#{expires_at.strftime('%FT%T.%L%:z')}\",\"extension_reason\":\"didnt_find_right_candidate\",\"other_extension_reason_details\":\"\"}",
+          },
+        )
       end
 
       context "when looking at tabs" do

--- a/spec/system/publishers/publishers_can_sign_in_by_email_spec.rb
+++ b/spec/system/publishers/publishers_can_sign_in_by_email_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "Publishers can sign in with fallback email authentication" do
           choose school.name
           click_button I18n.t("buttons.sign_in")
 
-          expect(:successful_publisher_sign_in_attempt).to have_been_enqueued_as_analytics_event(with_data: { sign_in_type: "email" })
+          expect(:successful_publisher_sign_in_attempt).to have_been_enqueued_as_analytics_event(with_data: { sign_in_type: "email" }) # rubocop:disable RSpec/ExpectActual
 
           expect(page).to have_content(school.name)
           expect { login_key.reload }.to raise_error ActiveRecord::RecordNotFound
@@ -127,7 +127,7 @@ RSpec.describe "Publishers can sign in with fallback email authentication" do
             choose school.name
             click_button I18n.t("buttons.sign_in")
 
-            expect(:successful_publisher_sign_in_attempt).to have_been_enqueued_as_analytics_event(with_data: { sign_in_type: "email" })
+            expect(:successful_publisher_sign_in_attempt).to have_been_enqueued_as_analytics_event(with_data: { sign_in_type: "email" }) # rubocop:disable RSpec/ExpectActual
             expect(page).not_to have_content("Choose your organisation")
             expect(page).to have_content(school.name)
             expect { login_key.reload }.to raise_error ActiveRecord::RecordNotFound
@@ -162,7 +162,7 @@ RSpec.describe "Publishers can sign in with fallback email authentication" do
             choose trust.name
             click_button I18n.t("buttons.sign_in")
 
-            expect(:successful_publisher_sign_in_attempt).to have_been_enqueued_as_analytics_event(with_data: { sign_in_type: "email" })
+            expect(:successful_publisher_sign_in_attempt).to have_been_enqueued_as_analytics_event(with_data: { sign_in_type: "email" }) # rubocop:disable RSpec/ExpectActual
 
             expect(page).not_to have_content("Choose your organisation")
             expect(page).to have_content(trust.name)
@@ -201,7 +201,7 @@ RSpec.describe "Publishers can sign in with fallback email authentication" do
             choose local_authority.name
             click_button I18n.t("buttons.sign_in")
 
-            expect(:successful_publisher_sign_in_attempt).to have_been_enqueued_as_analytics_event(with_data: { sign_in_type: "email" })
+            expect(:successful_publisher_sign_in_attempt).to have_been_enqueued_as_analytics_event(with_data: { sign_in_type: "email" }) # rubocop:disable RSpec/ExpectActual
 
             expect(page).not_to have_content("Choose your organisation")
             expect(page).to have_content(local_authority.name)

--- a/spec/system/publishers/publishers_can_sign_in_by_email_spec.rb
+++ b/spec/system/publishers/publishers_can_sign_in_by_email_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "Publishers can sign in with fallback email authentication" do
           choose school.name
           click_button I18n.t("buttons.sign_in")
 
-          expect(:successful_publisher_sign_in_attempt).to have_been_enqueued_as_analytics_events
+          expect(:successful_publisher_sign_in_attempt).to have_been_enqueued_as_analytics_event(with_data: { sign_in_type: "email" })
 
           expect(page).to have_content(school.name)
           expect { login_key.reload }.to raise_error ActiveRecord::RecordNotFound
@@ -127,7 +127,7 @@ RSpec.describe "Publishers can sign in with fallback email authentication" do
             choose school.name
             click_button I18n.t("buttons.sign_in")
 
-            expect(:successful_publisher_sign_in_attempt).to have_been_enqueued_as_analytics_events
+            expect(:successful_publisher_sign_in_attempt).to have_been_enqueued_as_analytics_event(with_data: { sign_in_type: "email" })
             expect(page).not_to have_content("Choose your organisation")
             expect(page).to have_content(school.name)
             expect { login_key.reload }.to raise_error ActiveRecord::RecordNotFound
@@ -162,7 +162,7 @@ RSpec.describe "Publishers can sign in with fallback email authentication" do
             choose trust.name
             click_button I18n.t("buttons.sign_in")
 
-            expect(:successful_publisher_sign_in_attempt).to have_been_enqueued_as_analytics_events
+            expect(:successful_publisher_sign_in_attempt).to have_been_enqueued_as_analytics_event(with_data: { sign_in_type: "email" })
 
             expect(page).not_to have_content("Choose your organisation")
             expect(page).to have_content(trust.name)
@@ -201,7 +201,7 @@ RSpec.describe "Publishers can sign in with fallback email authentication" do
             choose local_authority.name
             click_button I18n.t("buttons.sign_in")
 
-            expect(:successful_publisher_sign_in_attempt).to have_been_enqueued_as_analytics_events
+            expect(:successful_publisher_sign_in_attempt).to have_been_enqueued_as_analytics_event(with_data: { sign_in_type: "email" })
 
             expect(page).not_to have_content("Choose your organisation")
             expect(page).to have_content(local_authority.name)

--- a/spec/system/publishers/publishers_can_sign_in_with_dfe_spec.rb
+++ b/spec/system/publishers/publishers_can_sign_in_with_dfe_spec.rb
@@ -8,7 +8,7 @@ RSpec.shared_examples "a successful Publisher sign in" do
 
   scenario "it signs in the user successfully" do
     sign_in_publisher
-    expect(:successful_publisher_sign_in_attempt).to have_been_enqueued_as_analytics_event(with_data: { sign_in_type: "dsi" })
+    expect(:successful_publisher_sign_in_attempt).to have_been_enqueued_as_analytics_event(with_data: { sign_in_type: "dsi" }) # rubocop:disable RSpec/ExpectActual
 
     within(".govuk-header__navigation") { expect(page).to have_selector(:link_or_button, I18n.t("nav.sign_out")) }
     within(".govuk-header__navigation") { expect(page).to have_selector(:link_or_button, I18n.t("nav.manage_jobs")) }
@@ -20,7 +20,7 @@ RSpec.shared_examples "a failed Publisher sign in" do |options|
     visit new_publisher_session_path
     sign_in_publisher
 
-    expect(:failed_dsi_sign_in_attempt).to have_been_enqueued_as_analytics_event(with_data: { sign_in_type: "dsi" })
+    expect(:failed_dsi_sign_in_attempt).to have_been_enqueued_as_analytics_event(with_data: { sign_in_type: "dsi" }) # rubocop:disable RSpec/ExpectActual
 
     expect(page).to have_content(/The email you're signed in with isn't authorised to list jobs for this school/i)
     expect(page).to have_content(options[:email])

--- a/spec/system/publishers/publishers_can_sign_in_with_dfe_spec.rb
+++ b/spec/system/publishers/publishers_can_sign_in_with_dfe_spec.rb
@@ -8,7 +8,7 @@ RSpec.shared_examples "a successful Publisher sign in" do
 
   scenario "it signs in the user successfully" do
     sign_in_publisher
-    expect(:successful_publisher_sign_in_attempt).to have_been_enqueued_as_analytics_events
+    expect(:successful_publisher_sign_in_attempt).to have_been_enqueued_as_analytics_event(with_data: { sign_in_type: "dsi" })
 
     within(".govuk-header__navigation") { expect(page).to have_selector(:link_or_button, I18n.t("nav.sign_out")) }
     within(".govuk-header__navigation") { expect(page).to have_selector(:link_or_button, I18n.t("nav.manage_jobs")) }
@@ -20,7 +20,7 @@ RSpec.shared_examples "a failed Publisher sign in" do |options|
     visit new_publisher_session_path
     sign_in_publisher
 
-    expect(:failed_dsi_sign_in_attempt).to have_been_enqueued_as_analytics_events
+    expect(:failed_dsi_sign_in_attempt).to have_been_enqueued_as_analytics_event(with_data: { sign_in_type: "dsi" })
 
     expect(page).to have_content(/The email you're signed in with isn't authorised to list jobs for this school/i)
     expect(page).to have_content(options[:email])

--- a/spec/system/support_users/dfe_sign_in_spec.rb
+++ b/spec/system/support_users/dfe_sign_in_spec.rb
@@ -19,7 +19,7 @@ RSpec.shared_examples "a failed Support User sign in" do |options|
     visit new_support_user_session_path
 
     sign_in_support_user
-    expect(:failed_dsi_sign_in_attempt).to have_been_enqueued_as_analytics_events
+    expect(:failed_dsi_sign_in_attempt).to have_been_enqueued_as_analytics_event(with_data: { sign_in_type: "dsi" })
 
     expect(page).to have_content(/The email you're signed in with isn't authorised to list jobs for this school/i)
     expect(page).to have_content(options[:email])

--- a/spec/system/support_users/dfe_sign_in_spec.rb
+++ b/spec/system/support_users/dfe_sign_in_spec.rb
@@ -19,7 +19,7 @@ RSpec.shared_examples "a failed Support User sign in" do |options|
     visit new_support_user_session_path
 
     sign_in_support_user
-    expect(:failed_dsi_sign_in_attempt).to have_been_enqueued_as_analytics_event(with_data: { sign_in_type: "dsi" })
+    expect(:failed_dsi_sign_in_attempt).to have_been_enqueued_as_analytics_event(with_data: { sign_in_type: "dsi" }) # rubocop:disable RSpec/ExpectActual
 
     expect(page).to have_content(/The email you're signed in with isn't authorised to list jobs for this school/i)
     expect(page).to have_content(options[:email])


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/6BDuNhsQ/1460-investigate-analytics-trackedlinkclicked-not-reaching-bigq
## Changes in this PR:

dfe-analytics v1.13 introduced a unannounced (and seems unexpected) breaking change on how the "data" argument must be formatted for the events.

Since then, we adapted our calls in some instances when we wanted/needed to use the new 'hidden_data' option.

The problem is, as much as in their documentation state that you can call a custom event with `.with_data(some: "info")`, in reality all the events instantiated like that get their data dropped unless are wrapped within a `data:` key: `.with_data(data: { some: "info" })`

- Ref: https://github.com/DFE-Digital/dfe-analytics/issues/182

### New custom test matcher

As part of these changes, I've copied and extended the `DfE::Analytics` `have_enqued_as_analytics_events` rspec matcher.

Our `have_enqued_as_analytics_event` matcher will be able to assert against the data contained in the event created by the gem, as
- First option. Assert that the event type was enqueued:
  `expect(:event_type).to have_been_enqueued_as_analytics_event`

- Second option. Assert that the event type was enqueued with specific data:
  `expect(:event_type).to have_been_enqueued_as_analytics_event(with_data: { key: "value" })`

- Third option. Assert that the event type was enqueued with specific data keys (without asserting against the values):
  `expect(:event_type).to have_been_enqueued_as_analytics_event(with_data: [:key1, :key2])`

## Screenshots of UI changes:

![Screenshot From 2024-12-09 18-11-22](https://github.com/user-attachments/assets/59d6e7d3-33dd-4d6f-a7b3-988a813c8af3)
![Screenshot From 2024-12-09 19-36-13](https://github.com/user-attachments/assets/50e73aad-9940-4ead-be8f-e827f5b4e661)

