### PR TITLE
Fixing broken hiring guides links

### DIFF
--- a/app/components/dashboard_component/dashboard_component.html.slim
+++ b/app/components/dashboard_component/dashboard_component.html.slim
@@ -10,7 +10,7 @@
       .help-guide--mobile.help-guide--border-bottom
         h2.govuk-heading-m = t("jobs.dashboard.how_to_accept_job_applications_guide.title")
         = govuk_link_to(t("jobs.dashboard.how_to_accept_job_applications_guide.link_text"),
-                        post_path(section: "get-help-hiring", subcategory: "get-help-applying-for-your-teaching-role", post_name: "accepting-job-applications-on-teaching-vacancies"),
+                        post_path(section: "get-help-hiring", subcategory: "how-to-create-job-listings-and-accept-applications", post_name: "accepting-job-applications-on-teaching-vacancies"),
                         class: "govuk-link--no-visited-state")
         | .
       span.govuk-caption-l = @organisation.name
@@ -145,6 +145,6 @@
         .help-guide--desktop
           h2.govuk-heading-m = t("jobs.dashboard.how_to_accept_job_applications_guide.title")
           = govuk_link_to(t("jobs.dashboard.how_to_accept_job_applications_guide.link_text"),
-                          post_path(section: "get-help-hiring", subcategory: "get-help-applying-for-your-teaching-role", post_name: "accepting-job-applications-on-teaching-vacancies"),
+                          post_path(section: "get-help-hiring", subcategory: "how-to-create-job-listings-and-accept-applications", post_name: "accepting-job-applications-on-teaching-vacancies"),
                           class: "govuk-link--no-visited-state")
           | .

--- a/app/views/publishers/new_features/reminder.html.slim
+++ b/app/views/publishers/new_features/reminder.html.slim
@@ -8,5 +8,5 @@
       = t(".page_title")
     p.govuk-body
       = t(".content")
-    = open_in_new_tab_link_to(t(".how_applications_work_link"), post_path(section: "get-help-hiring", subcategory: "get-help-applying-for-your-teaching-role", post_name: "accepting-job-applications-on-teaching-vacancies"), class: "govuk-body")
+    = open_in_new_tab_link_to(t(".how_applications_work_link"), post_path(section: "get-help-hiring", subcategory: "how-to-create-job-listings-and-accept-applications", post_name: "accepting-job-applications-on-teaching-vacancies"), class: "govuk-body")
     = govuk_button_to t("buttons.reminder_continue"), organisation_jobs_path, class: "govuk-!-margin-top-8"

--- a/spec/system/publishers/publishers_are_reminded_of_application_functionality_spec.rb
+++ b/spec/system/publishers/publishers_are_reminded_of_application_functionality_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Application feature reminder" do
       click_on I18n.t("buttons.create_job")
 
       expect(page).to have_content(I18n.t("publishers.new_features.reminder.page_title"))
-      expect(page).to have_link(I18n.t("publishers.new_features.reminder.how_applications_work_link"), href: post_path(section: "get-help-hiring", subcategory: "get-help-applying-for-your-teaching-role", post_name: "accepting-job-applications-on-teaching-vacancies"))
+      expect(page).to have_link(I18n.t("publishers.new_features.reminder.how_applications_work_link"), href: post_path(section: "get-help-hiring", subcategory: "how-to-create-job-listings-and-accept-applications", post_name: "accepting-job-applications-on-teaching-vacancies"))
 
       click_on I18n.t("buttons.reminder_continue")
 


### PR DESCRIPTION
## Trello card URL

## Changes in this PR:

Noticed in Clarity that a hiring guide link was broken. Trying to fix that.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
