### PR TITLE
SPIKE: Edit and resubmit withdrawn applications

### DIFF
--- a/app/controllers/jobseekers/job_applications_controller.rb
+++ b/app/controllers/jobseekers/job_applications_controller.rb
@@ -102,6 +102,13 @@ class Jobseekers::JobApplicationsController < Jobseekers::JobApplications::BaseC
     end
   end
 
+  def edit_withdrawn
+    raise ActionController::RoutingError, "Cannot withdraw non-reviewed/shortlisted/submitted application" unless job_application.withdrawn?
+
+    job_application.draft!
+    redirect_to jobseekers_job_application_review_path(job_application)
+  end
+
   private
 
   def prefill_job_application_with_available_data

--- a/app/views/jobseekers/job_applications/_banner.html.slim
+++ b/app/views/jobseekers/job_applications/_banner.html.slim
@@ -16,8 +16,10 @@
   .govuk-button-group class="govuk-!-margin-bottom-3 govuk-!-margin-top-3 govuk-!-display-none-print"
     - if job_application.draft?
       = govuk_button_link_to t("buttons.delete_application"), jobseekers_job_application_confirm_destroy_path(job_application), class: "govuk-button--warning govuk-!-margin-bottom-4"
-    - if job_application.status.in?(%w[reviewed shortlisted submitted])
+    - elsif job_application.status.in?(%w[reviewed shortlisted submitted])
       = govuk_button_link_to t("buttons.withdraw_application"), jobseekers_job_application_confirm_withdraw_path(job_application), class: "govuk-button--warning govuk-!-margin-bottom-4"
+    - elsif job_application.withdrawn?
+      = govuk_button_link_to t("buttons.edit_withdrawn"), jobseekers_job_application_edit_withdrawn_path(job_application), method: :post, class: "govuk-button--secondary govuk-!-margin-bottom-4"
     - unless job_application.draft?
       = govuk_button_link_to t("buttons.download_application"), "#", class: "govuk-button--secondary js-action print-application", "data-controller": "utils", "data-action": "click->utils#print"
     = open_in_new_tab_link_to "View this listing", job_path(job_application.vacancy), class: "govuk-!-margin-bottom-0 view-listing-link"

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -53,6 +53,7 @@ en:
     download_application_form: Download an application form - %{size}
     download_stats: Download statistics (csv, 0.2KB)
     edit: Edit
+    edit_withdrawn: Edit to resubmit
     end_listing: Close job listing
     end_listing_early: End job listing early
     extend_closing_date: Extend closing date

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,6 +99,7 @@ Rails.application.routes.draw do
       get :confirm_destroy
       get :confirm_withdraw
       post :submit
+      post :edit_withdrawn
       post :withdraw
       resource :feedback, only: %i[create], controller: "job_applications/feedbacks"
     end


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/U5VSf3J9/1464-spike-resubmitting-a-withdrawn-job-application

## Changes in this PR:

Minimum code to enable jobseekers to edit and re-submit a withdrawn job application.

This is not enough to go live, as there are pending questions and unwanted consequences. EG: The current job application timeline model is not fit for purpose.

## Screenshots of UI changes:

This "edit to resubmit" button converts the withdrawn application into a draft and redirects the user to the draft review page: 
![image](https://github.com/user-attachments/assets/37e06272-7676-477e-9036-4429e4868d4e)

