### PR TITLE
fix job alert overlap

### DIFF
--- a/app/jobs/alert_email/base.rb
+++ b/app/jobs/alert_email/base.rb
@@ -14,6 +14,6 @@ class AlertEmail::Base < ApplicationJob
   end
 
   def vacancies_for_subscription(subscription)
-    subscription.vacancies_for_range(from_date, Date.current)
+    subscription.vacancies_for_range(from_date, Date.yesterday)
   end
 end

--- a/app/jobs/send_daily_alert_email_job.rb
+++ b/app/jobs/send_daily_alert_email_job.rb
@@ -6,6 +6,6 @@ class SendDailyAlertEmailJob < AlertEmail::Base
   end
 
   def from_date
-    Time.zone.yesterday
+    2.days.ago.to_date
   end
 end

--- a/app/jobs/send_weekly_alert_email_job.rb
+++ b/app/jobs/send_weekly_alert_email_job.rb
@@ -6,6 +6,6 @@ class SendWeeklyAlertEmailJob < AlertEmail::Base
   end
 
   def from_date
-    1.week.ago.to_date
+    8.days.ago.to_date
   end
 end

--- a/spec/jobs/send_daily_alert_email_job_spec.rb
+++ b/spec/jobs/send_daily_alert_email_job_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe SendDailyAlertEmailJob do
     let(:job) { described_class.new }
 
     it "gets vacancies in the last day" do
-      expect(subscription).to receive(:vacancies_for_range).with(Time.zone.yesterday, Date.current) { Vacancy.none }
+      expect(subscription).to receive(:vacancies_for_range).with(2.days.ago.to_date, Date.yesterday) { Vacancy.none }
       job.vacancies_for_subscription(subscription)
     end
   end

--- a/spec/jobs/send_weekly_alert_email_job_spec.rb
+++ b/spec/jobs/send_weekly_alert_email_job_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe SendWeeklyAlertEmailJob do
     let(:job) { described_class.new }
 
     it "gets vacancies in the last week" do
-      expect(subscription).to receive(:vacancies_for_range).with(1.week.ago.to_date, Date.current) { Vacancy.none }
+      expect(subscription).to receive(:vacancies_for_range).with(8.days.ago.to_date, Date.yesterday) { Vacancy.none }
       job.vacancies_for_subscription(subscription)
     end
   end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/kvlE0HnA/1444-job-subscriptions-overlap-the-daily-run-includes-yesterdays-and-todays-jobs-up-until-3pm-which-are-them-repeated-tomorrow

## Changes in this PR:

- Is there anything specific you want feedback on?

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
