### PR TITLE
Ensure flexi_working column is populated with nil if the flexi_working form value only includes html tags

### DIFF
--- a/app/form_models/publishers/job_listing/about_the_role_form.rb
+++ b/app/form_models/publishers/job_listing/about_the_role_form.rb
@@ -26,6 +26,21 @@ class Publishers::JobListing::AboutTheRoleForm < Publishers::JobListing::Vacancy
   end
   attr_accessor(*fields)
 
+  def params_to_save
+    {
+      job_advert:,
+      about_school:,
+      ect_status:,
+      skills_and_experience:,
+      school_offer:,
+      flexi_working: normalize_flexi_working,
+      safeguarding_information_provided:,
+      safeguarding_information:,
+      further_details_provided:,
+      further_details:,
+    }
+  end
+
   private
 
   def organisation_type
@@ -76,5 +91,11 @@ class Publishers::JobListing::AboutTheRoleForm < Publishers::JobListing::Vacancy
     return if remove_html_tags(job_advert).present?
 
     errors.add(:job_advert, :blank)
+  end
+
+  def normalize_flexi_working
+    stripped_value = remove_html_tags(flexi_working)&.strip
+
+    self.flexi_working = stripped_value.present? ? flexi_working : nil
   end
 end

--- a/spec/form_models/publishers/job_listing/about_the_role_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/about_the_role_form_spec.rb
@@ -216,4 +216,24 @@ RSpec.describe Publishers::JobListing::AboutTheRoleForm, type: :model do
       end
     end
   end
+
+  describe "flexi_working" do
+    let(:vacancy) { build_stubbed(:vacancy, :at_one_school, job_roles: ["teacher"], job_advert: "Test") }
+
+    context "when flexi working is blank except for html tags" do
+      let(:params) { { flexi_working: "<p><br></p>" } }
+
+      it "sets flexi_working as nil in params_to_save" do
+        expect(subject.params_to_save[:flexi_working]).to be_nil
+      end
+    end
+
+    context "when flexi working has text and html tags" do
+      let(:params) { { flexi_working: "<p>hello<br> world</p>" } }
+
+      it "params_to_save includes flexi_working value" do
+        expect(subject.params_to_save[:flexi_working]).to eq "<p>hello<br> world</p>"
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/27mBZozy/1474-flexi-working-box-stop-paras-ps-from-being-saved

## Changes in this PR:

Prior to this change the flexi_working column of vacancies could be populated with only html tags, even if no actual text was entered into this box. This change fixes that issue by adding a params_to_save method, following a pattern used in many other forms in our service, which ensures that the flexi_working column is only populated if the user enters text into the text box.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
