### PR TITLE
Reinstate application config bigquery dataset

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -124,6 +124,8 @@ module TeachingVacancies
     config.analytics = config_for(:analytics)
     config.analytics_pii = config_for(:analytics_pii)
 
+    config.bigquery_dataset = ENV.fetch("BIGQUERY_DATASET", nil)
+
     config.enforce_local_authority_allowlist = ActiveModel::Type::Boolean.new.cast(ENV.fetch("ENFORCE_LOCAL_AUTHORITY_ALLOWLIST", nil))
 
     config.geocoder_lookup = :default


### PR DESCRIPTION
This makes available at the application level the Big Query Dataset that was removed in a previous PR (https://github.com/DFE-Digital/teaching-vacancies/pull/7356). 

This PR fixes the issue momentarily and allows the infra team to remove an unnecessary environment variable unblocking them. After this we need to investigate if we can remove this config and use this instead:
https://github.com/DFE-Digital/teaching-vacancies/blob/main/config/initializers/dfe_analytics.rb#L24