### PR TITLE
Adding (opens in new tab) in link text

### DIFF
--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -702,8 +702,8 @@ en:
         the_below_url_will_change: If you edit the job title in your listing, the below URL will change and you may need to reshare the link
         share_page_url: Share page URL
         button_copy: Copy URL
-        facebook_share: Share on Facebook
-        x_share: Share on X (formerly known as Twitter)
+        facebook_share: Share on Facebook (opens in new tab)
+        x_share: Share on X, formerly known as Twitter (opens in new tab)
         job_url_copied: URL Copied
       statistics:
         show:

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -401,7 +401,7 @@ en:
               content_with_no_link: You can choose for candidates to apply for the job through Teaching Vacancies.
               link: Preview the application form
           using_application_form_html: Use Teaching Vacancies' application form for an online form compliant with %{link}.
-          kcsie_guidance: keeping children safe in education (KCSIE) guidance
+          kcsie_guidance: keeping children safe in education (KCSIE) guidance (opens in new tab)
           kcsie_url: "https://www.gov.uk/government/publications/keeping-children-safe-in-education--2"
           kcsie_compliant: KCSIE compliant
           reason_for_our_form: Online application forms make it quicker and easier for candidates to apply and may lead to more applicants for your role.


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/WRkBdSBV/1514-add-opens-in-new-tab-content-onto-links-in-the-job-listing-journey

## Changes in this PR:

We have analysed where and when we open links in the same tab vs opening in a new tab for user accessibility. We need to make sure that, where links open in new tabs, we add text so that the user is aware of that.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
