### PR TITLE
Add legacy support role filter name

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -11,6 +11,8 @@ class Subscription < ApplicationRecord
   FILTERS = {
     teaching_job_roles: ->(vacancy, value) { vacancy.job_roles.intersect?(value) },
     support_job_roles: ->(vacancy, value) { vacancy.job_roles.intersect?(value) },
+    # support_job_roles used to be called this, and there are still actuve subscriptions with this name
+    teaching_support_job_roles: ->(vacancy, value) { vacancy.job_roles.intersect?(value) },
     visa_sponsorship_availability: ->(vacancy, value) { value.include? vacancy.visa_sponsorship_available.to_s },
     ect_statuses: ->(vacancy, value) { value.include?(vacancy.ect_status) },
     subjects: ->(vacancy, value) { (vacancy.subjects || []).intersect?(value) },


### PR DESCRIPTION
## Changes in this PR:

Fix crash on production due to legacy active filter name