### PR TITLE
ignore legacy jobs_sort criteria in job alert subscription

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -67,7 +67,8 @@ class Subscription < ApplicationRecord
 
   def vacancies_matching(default_scope)
     scope = default_scope
-    criteria = search_criteria.symbolize_keys
+    # ignore legacy sorting criteria
+    criteria = search_criteria.symbolize_keys.except(:jobs_sort)
     scope, criteria = handle_location(scope, criteria)
 
     scope.select do |vacancy|


### PR DESCRIPTION
## Changes in this PR:

Ignore legacy jobs_sort search criteria in job alerts