### PR TITLE
Add course length to training and CPD section of profile and job applciation

### DIFF
--- a/app/controllers/jobseekers/job_applications/training_and_cpds_controller.rb
+++ b/app/controllers/jobseekers/job_applications/training_and_cpds_controller.rb
@@ -41,13 +41,13 @@ class Jobseekers::JobApplications::TrainingAndCpdsController < Jobseekers::Profi
     when "create", "update"
       training_and_cpd_form_params
     when "edit"
-      training_and_cpd.slice(:name, :provider, :grade, :year_awarded)
+      training_and_cpd.slice(:name, :provider, :grade, :year_awarded, :course_length)
     end
   end
 
   def training_and_cpd_form_params
     params.require(:jobseekers_training_and_cpd_form)
-          .permit(:name, :provider, :grade, :year_awarded)
+          .permit(:name, :provider, :grade, :year_awarded, :course_length)
   end
 
   def training_and_cpd

--- a/app/controllers/jobseekers/profiles/training_and_cpds_controller.rb
+++ b/app/controllers/jobseekers/profiles/training_and_cpds_controller.rb
@@ -41,13 +41,13 @@ class Jobseekers::Profiles::TrainingAndCpdsController < Jobseekers::ProfilesCont
     when "create", "update"
       training_and_cpd_form_params
     when "edit"
-      training_and_cpd.slice(:name, :provider, :grade, :year_awarded)
+      training_and_cpd.slice(:name, :provider, :grade, :year_awarded, :course_length)
     end
   end
 
   def training_and_cpd_form_params
     params.require(:jobseekers_training_and_cpd_form)
-          .permit(:name, :provider, :grade, :year_awarded)
+          .permit(:name, :provider, :grade, :year_awarded, :course_length)
   end
 
   def training_and_cpd

--- a/app/form_models/jobseekers/training_and_cpd_form.rb
+++ b/app/form_models/jobseekers/training_and_cpd_form.rb
@@ -1,7 +1,7 @@
 class Jobseekers::TrainingAndCpdForm
   include ActiveModel::Model
 
-  attr_accessor :name, :provider, :grade, :year_awarded
+  attr_accessor :name, :provider, :grade, :year_awarded, :course_length
 
-  validates :name, :provider, :year_awarded, presence: true
+  validates :name, :provider, :year_awarded, :course_length, presence: true
 end

--- a/app/helpers/pdf_helper.rb
+++ b/app/helpers/pdf_helper.rb
@@ -106,7 +106,7 @@ module PdfHelper
     secondary_qualification_data = [
       ["Name:", qualification.name],
       ["Grade:", qualification.grade],
-      ["Year Awarded:", qualification.year],
+      ["Date completed:", qualification.year],
     ].reject { |row| row[1].blank? }
 
     render_table(pdf, secondary_qualification_data)

--- a/app/helpers/pdf_helper.rb
+++ b/app/helpers/pdf_helper.rb
@@ -119,7 +119,7 @@ module PdfHelper
       ["Qualification Name:", qualification.name],
       ["Institution:", qualification.institution],
       ["Grade:", qualification.grade],
-      ["Year Awarded:", qualification.year],
+      ["Date completed:", qualification.year],
     ].reject { |row| row[1].blank? }
 
     render_table(pdf, general_qualification_data)

--- a/app/views/jobseekers/job_applications/build/training_and_cpds.html.slim
+++ b/app/views/jobseekers/job_applications/build/training_and_cpds.html.slim
@@ -12,7 +12,7 @@
         = render DetailComponent.new title: training.name do |detail|
           - detail.with_body do
             = govuk_summary_list classes: "govuk-!-margin-bottom-0" do |summary_list|
-              - attributes = %w[name provider grade year_awarded]
+              - attributes = %w[name provider grade year_awarded course_length]
               - attributes.each do |attribute|
                 - if training[attribute].present?
                   - summary_list.with_row do |row|

--- a/app/views/jobseekers/job_applications/review/_training_and_cpds.html.slim
+++ b/app/views/jobseekers/job_applications/review/_training_and_cpds.html.slim
@@ -11,5 +11,6 @@
           - if training.grade.present?
             span class="govuk-!-display-inline-block govuk-!-margin-left-1"
               = "(#{training.grade})"
+        p class="govuk-!-margin-bottom-1" = training.course_length
         p.govuk-caption-m
           = "#{training.provider}, #{training.year_awarded}"

--- a/app/views/jobseekers/job_applications/training_and_cpds/edit.html.slim
+++ b/app/views/jobseekers/job_applications/training_and_cpds/edit.html.slim
@@ -6,12 +6,20 @@
     h1.govuk-heading-xl = t(".heading")
 
     = form_for form, url: jobseekers_job_application_training_and_cpd_path, method: :put do |f|
+      p.govuk-body = t(".description")
+      p.govuk-body = t(".example_intro")
+      ul.govuk-list.govuk-list--bullet
+        li = t(".example1")
+        li = t(".example2")
+        li = t(".example3")
+        li = t(".example4")
       = f.govuk_error_summary
 
       = f.govuk_text_field :name, label: { size: "s" }, aria: { required: true }
       = f.govuk_text_field :provider, label: { size: "s" }, aria: { required: true }
       = f.govuk_text_field :grade, label: { size: "s" }
       = f.govuk_text_field :year_awarded, label: { size: "s" }, type: "number", width: 4, hint: { text: t(".hint") }
+      = f.govuk_text_field :course_length, label: { size: "s" }, aria: { required: true }
       = f.govuk_submit t("buttons.save_and_continue")
 
     .govuk-button-group

--- a/app/views/jobseekers/job_applications/training_and_cpds/edit.html.slim
+++ b/app/views/jobseekers/job_applications/training_and_cpds/edit.html.slim
@@ -17,9 +17,9 @@
 
       = f.govuk_text_field :name, label: { size: "s" }, aria: { required: true }
       = f.govuk_text_field :provider, label: { size: "s" }, aria: { required: true }
-      = f.govuk_text_field :grade, label: { size: "s" }
       = f.govuk_text_field :year_awarded, label: { size: "s" }, type: "number", width: 4, hint: { text: t(".hint") }
       = f.govuk_text_field :course_length, label: { size: "s" }, aria: { required: true }
+      = f.govuk_text_field :grade, label: { size: "s" }
       = f.govuk_submit t("buttons.save_and_continue")
 
     .govuk-button-group

--- a/app/views/jobseekers/job_applications/training_and_cpds/new.html.slim
+++ b/app/views/jobseekers/job_applications/training_and_cpds/new.html.slim
@@ -19,8 +19,8 @@
       = f.govuk_text_field :name, label: { size: "s" }, aria: { required: true }
       = f.govuk_text_field :provider, label: { size: "s" }, aria: { required: true }
       = f.govuk_text_field :course_length, label: { size: "s" }, aria: { required: true }
-      = f.govuk_text_field :grade, label: { size: "s" }
       = f.govuk_text_field :year_awarded, label: { size: "s" }, type: "number", width: 4, hint: { text: t(".hint") }
+      = f.govuk_text_field :grade, label: { size: "s" }
       = f.govuk_submit t("buttons.save_and_continue")
 
     .govuk-button-group

--- a/app/views/jobseekers/job_applications/training_and_cpds/new.html.slim
+++ b/app/views/jobseekers/job_applications/training_and_cpds/new.html.slim
@@ -6,10 +6,19 @@
     h1.govuk-heading-xl = t(".heading")
 
     = form_for form, url: jobseekers_job_application_training_and_cpds_path(job_application), method: :post do |f|
+      p.govuk-body = t(".description")
+      p.govuk-body = t(".example_intro")
+      ul.govuk-list.govuk-list--bullet
+        li = t(".example1")
+        li = t(".example2")
+        li = t(".example3")
+        li = t(".example4")
+
       = f.govuk_error_summary
 
       = f.govuk_text_field :name, label: { size: "s" }, aria: { required: true }
       = f.govuk_text_field :provider, label: { size: "s" }, aria: { required: true }
+      = f.govuk_text_field :course_length, label: { size: "s" }, aria: { required: true }
       = f.govuk_text_field :grade, label: { size: "s" }
       = f.govuk_text_field :year_awarded, label: { size: "s" }, type: "number", width: 4, hint: { text: t(".hint") }
       = f.govuk_submit t("buttons.save_and_continue")

--- a/app/views/jobseekers/profiles/qualifications/confirm_destroy.html.slim
+++ b/app/views/jobseekers/profiles/qualifications/confirm_destroy.html.slim
@@ -24,7 +24,7 @@
             - row.with_key text: "Institution"
             - row.with_value text: qualification.institution
           - summary_list.with_row do |row|
-            - row.with_key text: "Year awarded"
+            - row.with_key text: "Date completed"
             - row.with_value text: qualification.year
           - summary_list.with_row do |row|
             - row.with_key text: t("jobseekers.qualifications.subjects_and_grades")

--- a/app/views/jobseekers/profiles/training_and_cpds/confirm_destroy.html.slim
+++ b/app/views/jobseekers/profiles/training_and_cpds/confirm_destroy.html.slim
@@ -22,12 +22,12 @@
           - row.with_value text: training_and_cpd.course_length
 
         - summary_list.with_row do |row|
-          - row.with_key text: t("helpers.label.jobseekers_training_and_cpd_form.grade")
-          - row.with_value text: training_and_cpd.grade
-
-        - summary_list.with_row do |row|
           - row.with_key text: t("helpers.label.jobseekers_training_and_cpd_form.year_awarded")
           - row.with_value text: training_and_cpd.year_awarded
+
+        - summary_list.with_row do |row|
+          - row.with_key text: t("helpers.label.jobseekers_training_and_cpd_form.grade")
+          - row.with_value text: training_and_cpd.grade
 
       = f.govuk_submit "Delete training"
 

--- a/app/views/jobseekers/profiles/training_and_cpds/confirm_destroy.html.slim
+++ b/app/views/jobseekers/profiles/training_and_cpds/confirm_destroy.html.slim
@@ -16,6 +16,10 @@
         - summary_list.with_row do |row|
           - row.with_key text: t("helpers.label.jobseekers_training_and_cpd_form.provider")
           - row.with_value text: training_and_cpd.provider
+        
+        - summary_list.with_row do |row|
+          - row.with_key text: t("helpers.label.jobseekers_training_and_cpd_form.course_length")
+          - row.with_value text: training.course_length
 
         - summary_list.with_row do |row|
           - row.with_key text: t("helpers.label.jobseekers_training_and_cpd_form.grade")

--- a/app/views/jobseekers/profiles/training_and_cpds/confirm_destroy.html.slim
+++ b/app/views/jobseekers/profiles/training_and_cpds/confirm_destroy.html.slim
@@ -16,7 +16,7 @@
         - summary_list.with_row do |row|
           - row.with_key text: t("helpers.label.jobseekers_training_and_cpd_form.provider")
           - row.with_value text: training_and_cpd.provider
-        
+
         - summary_list.with_row do |row|
           - row.with_key text: t("helpers.label.jobseekers_training_and_cpd_form.course_length")
           - row.with_value text: training_and_cpd.course_length

--- a/app/views/jobseekers/profiles/training_and_cpds/confirm_destroy.html.slim
+++ b/app/views/jobseekers/profiles/training_and_cpds/confirm_destroy.html.slim
@@ -19,7 +19,7 @@
         
         - summary_list.with_row do |row|
           - row.with_key text: t("helpers.label.jobseekers_training_and_cpd_form.course_length")
-          - row.with_value text: training.course_length
+          - row.with_value text: training_and_cpd.course_length
 
         - summary_list.with_row do |row|
           - row.with_key text: t("helpers.label.jobseekers_training_and_cpd_form.grade")

--- a/app/views/jobseekers/profiles/training_and_cpds/edit.html.slim
+++ b/app/views/jobseekers/profiles/training_and_cpds/edit.html.slim
@@ -19,8 +19,8 @@
       = f.govuk_text_field :name, label: { size: "s" }, aria: { required: true }
       = f.govuk_text_field :provider, label: { size: "s" }, aria: { required: true }
       = f.govuk_text_field :course_length, label: { size: "s" }, aria: { required: true }
-      = f.govuk_text_field :grade, label: { size: "s" }
       = f.govuk_text_field :year_awarded, label: { size: "s" }, type: "number", width: 4, hint: { text: t(".hint") }
+      = f.govuk_text_field :grade, label: { size: "s" }
       = f.govuk_submit t("buttons.save_and_continue")
 
     .govuk-button-group

--- a/app/views/jobseekers/profiles/training_and_cpds/edit.html.slim
+++ b/app/views/jobseekers/profiles/training_and_cpds/edit.html.slim
@@ -13,11 +13,12 @@
         li = t(".example2")
         li = t(".example3")
         li = t(".example4")
-        
+
       = f.govuk_error_summary
 
       = f.govuk_text_field :name, label: { size: "s" }, aria: { required: true }
       = f.govuk_text_field :provider, label: { size: "s" }, aria: { required: true }
+      = f.govuk_text_field :course_length, label: { size: "s" }, aria: { required: true }
       = f.govuk_text_field :grade, label: { size: "s" }
       = f.govuk_text_field :year_awarded, label: { size: "s" }, type: "number", width: 4, hint: { text: t(".hint") }
       = f.govuk_submit t("buttons.save_and_continue")

--- a/app/views/jobseekers/profiles/training_and_cpds/edit.html.slim
+++ b/app/views/jobseekers/profiles/training_and_cpds/edit.html.slim
@@ -6,6 +6,14 @@
     h1.govuk-heading-xl = "Edit training and continuing professional development (CPD)"
 
     = form_for form, url: jobseekers_profile_training_and_cpd_path, method: :put do |f|
+      p.govuk-body = t(".description")
+      p.govuk-body = t(".example_intro")
+      ul.govuk-list.govuk-list--bullet
+        li = t(".example1")
+        li = t(".example2")
+        li = t(".example3")
+        li = t(".example4")
+        
       = f.govuk_error_summary
 
       = f.govuk_text_field :name, label: { size: "s" }, aria: { required: true }

--- a/app/views/jobseekers/profiles/training_and_cpds/new.html.slim
+++ b/app/views/jobseekers/profiles/training_and_cpds/new.html.slim
@@ -19,8 +19,8 @@
       = f.govuk_text_field :name, label: { size: "s" }, aria: { required: true }
       = f.govuk_text_field :provider, label: { size: "s" }, aria: { required: true }
       = f.govuk_text_field :course_length, label: { size: "s" }, aria: { required: true }
-      = f.govuk_text_field :grade, label: { size: "s" }
       = f.govuk_text_field :year_awarded, label: { size: "s" }, type: "number", width: 4, hint: { text: t(".hint") }
+      = f.govuk_text_field :grade, label: { size: "s" }
       = f.govuk_submit t("buttons.save_and_continue")
 
     .govuk-button-group

--- a/app/views/jobseekers/profiles/training_and_cpds/new.html.slim
+++ b/app/views/jobseekers/profiles/training_and_cpds/new.html.slim
@@ -6,6 +6,14 @@
     h1.govuk-heading-xl = "Add training and continuing professional development (CPD)"
 
     = form_for form, url: jobseekers_profile_training_and_cpds_path(profile), method: :post do |f|
+      p.govuk-body = t(".description")
+      p.govuk-body = t(".example_intro")
+      ul.govuk-list.govuk-list--bullet
+        li = t(".example1")
+        li = t(".example2")
+        li = t(".example3")
+        li = t(".example4")
+
       = f.govuk_error_summary
 
       = f.govuk_text_field :name, label: { size: "s" }, aria: { required: true }

--- a/app/views/jobseekers/profiles/training_and_cpds/new.html.slim
+++ b/app/views/jobseekers/profiles/training_and_cpds/new.html.slim
@@ -18,6 +18,7 @@
 
       = f.govuk_text_field :name, label: { size: "s" }, aria: { required: true }
       = f.govuk_text_field :provider, label: { size: "s" }, aria: { required: true }
+      = f.govuk_text_field :course_length, label: { size: "s" }, aria: { required: true }
       = f.govuk_text_field :grade, label: { size: "s" }
       = f.govuk_text_field :year_awarded, label: { size: "s" }, type: "number", width: 4, hint: { text: t(".hint") }
       = f.govuk_submit t("buttons.save_and_continue")

--- a/app/views/jobseekers/training_and_cpds/_training_and_cpds.html.slim
+++ b/app/views/jobseekers/training_and_cpds/_training_and_cpds.html.slim
@@ -16,12 +16,12 @@
             - row.with_value text: training.course_length
 
         - summary_list.with_row do |row|
-          - row.with_key text: t("helpers.label.jobseekers_training_and_cpd_form.grade")
-          - row.with_value text: training.grade
-
-        - summary_list.with_row do |row|
           - row.with_key text: t("helpers.label.jobseekers_training_and_cpd_form.year_awarded")
           - row.with_value text: training.year_awarded
+
+        - summary_list.with_row do |row|
+          - row.with_key text: t("helpers.label.jobseekers_training_and_cpd_form.grade")
+          - row.with_value text: training.grade
 
     - detail.with_action govuk_link_to(safe_join([t("buttons.change"), tag.span(training.name, class: "govuk-visually-hidden")]), edit_jobseekers_profile_training_and_cpd_path(training), class: "govuk-link--no-visited-state")
     - detail.with_action govuk_link_to(safe_join([t("buttons.delete"), tag.span(training.name, class: "govuk-visually-hidden")]), jobseekers_profile_training_and_cpd_confirm_destroy_path(training))

--- a/app/views/jobseekers/training_and_cpds/_training_and_cpds.html.slim
+++ b/app/views/jobseekers/training_and_cpds/_training_and_cpds.html.slim
@@ -10,6 +10,11 @@
           - row.with_key text: t("helpers.label.jobseekers_training_and_cpd_form.provider")
           - row.with_value text: training.provider
 
+        - if training.course_length.present?
+          - summary_list.with_row do |row|
+            - row.with_key text: t("helpers.label.jobseekers_training_and_cpd_form.course_length")
+            - row.with_value text: training.course_length
+
         - summary_list.with_row do |row|
           - row.with_key text: t("helpers.label.jobseekers_training_and_cpd_form.grade")
           - row.with_value text: training.grade

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -439,6 +439,7 @@ shared:
     - updated_at
     - jobseeker_profile_id
     - job_application_id
+    - course_length
   :noticed_notifications:
     - id
     - type

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -734,6 +734,8 @@ en:
               blank: Enter the name of the provider of the training
             year_awarded:
               blank: Enter the year the course or training was awarded
+            course_length:
+              blank: Enter the length of the course
         jobseekers/account_transfer_form:
           attributes:
             email:

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -618,6 +618,7 @@ en:
         grade: Grade (optional)
         year_awarded: Year awarded
         year_completed_hint: For example, 1998
+        course_length: Course length
 
 
       personal_details_form:

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -616,7 +616,7 @@ en:
         name: Name of course or training
         provider: Training provider
         grade: Grade (optional)
-        year_awarded: Year awarded
+        year_awarded: Date completed
         year_completed_hint: For example, 1998
         course_length: Course length
 

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -780,11 +780,11 @@ en:
         new:
           <<: *training_shared
           hint: For example, 2024.
-          description: Include any training you've completed within the last 3 years relevant to the role.
+          description: Include any training you've completed within the last 3 years.
         edit:
           <<: *training_shared
           hint: For example, 2024.
-          description: Include any training you've completed within the last 3 years relevant to the role.
+          description: Include any training you've completed within the last 3 years.
         destroy:
           success: Training deleted
       qualifications:

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -88,6 +88,14 @@ en:
         success: Thank you for your feedback on your job alert
       update:
         success: Thank you for providing additional feedback on your job alert
+    shared:
+      training_shared: &training_shared
+        description: Include any training you've completed within the last 3 years relevant to the role you're applying for.
+        example_intro: "For example you could include:"
+        example1: safeguarding training
+        example2: Prevent duty training
+        example3: first aid courses
+        example4: Team Teach
     job_applications:
       apply: Apply for this job
       applying_for_the_job_heading: Applying for the job
@@ -251,10 +259,12 @@ en:
         step_title: Training and continuing professional development (CPD)
         title: Add training and continuing professional development (CPD)
         new:
+          <<: *training_shared
           hint: For example, 1998
           caption: Training and continuing professional development (CPD)
           heading: Add training and continuing professional development (CPD)
         edit:
+          <<: *training_shared
           hint: For example, 1998
           caption: Training and continuing professional development (CPD)
           heading: Edit training and continuing professional development (CPD)
@@ -766,13 +776,6 @@ en:
         summary:
           about_you_title: About You
       training_and_cpds:
-        training_shared: &training_shared
-          description: Include any training you've completed within the last 3 years relevant to the role you're applying for.
-          example_intro: "For example you could include:"
-          example1: safeguarding training
-          example2: Prevent duty training
-          example3: first aid courses
-          example4: Team Teach
         new:
           <<: *training_shared
           hint: For example, 1998

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -766,9 +766,18 @@ en:
         summary:
           about_you_title: About You
       training_and_cpds:
+        training_shared: &training_shared
+          description: Include any training you've completed within the last 3 years relevant to the role you're applying for.
+          example_intro: "For example you could include:"
+          example1: safeguarding training
+          example2: Prevent duty training
+          example3: first aid courses
+          example4: Team Teach
         new:
+          <<: *training_shared
           hint: For example, 1998
         edit:
+          <<: *training_shared
           hint: For example, 1998
         destroy:
           success: Training deleted

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -260,12 +260,12 @@ en:
         title: Add training and continuing professional development (CPD)
         new:
           <<: *training_shared
-          hint: For example, 1998
+          hint: For example, 2024.
           caption: Training and continuing professional development (CPD)
           heading: Add training and continuing professional development (CPD)
         edit:
           <<: *training_shared
-          hint: For example, 1998
+          hint: For example, 2024.
           caption: Training and continuing professional development (CPD)
           heading: Edit training and continuing professional development (CPD)
         destroy:
@@ -778,10 +778,10 @@ en:
       training_and_cpds:
         new:
           <<: *training_shared
-          hint: For example, 1998
+          hint: For example, 2024.
         edit:
           <<: *training_shared
-          hint: For example, 1998
+          hint: For example, 2024.
         destroy:
           success: Training deleted
       qualifications:

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -90,7 +90,6 @@ en:
         success: Thank you for providing additional feedback on your job alert
     shared:
       training_shared: &training_shared
-        description: Include any training you've completed within the last 3 years relevant to the role you're applying for.
         example_intro: "For example you could include:"
         example1: safeguarding training
         example2: Prevent duty training
@@ -263,11 +262,13 @@ en:
           hint: For example, 2024.
           caption: Training and continuing professional development (CPD)
           heading: Add training and continuing professional development (CPD)
+          description: Include any training you've completed within the last 3 years relevant to the role you're applying for.
         edit:
           <<: *training_shared
           hint: For example, 2024.
           caption: Training and continuing professional development (CPD)
           heading: Edit training and continuing professional development (CPD)
+          description: Include any training you've completed within the last 3 years relevant to the role you're applying for.
         destroy:
           success: Training deleted
         review:
@@ -779,9 +780,11 @@ en:
         new:
           <<: *training_shared
           hint: For example, 2024.
+          description: Include any training you've completed within the last 3 years relevant to the role.
         edit:
           <<: *training_shared
           hint: For example, 2024.
+          description: Include any training you've completed within the last 3 years relevant to the role.
         destroy:
           success: Training deleted
       qualifications:

--- a/db/migrate/20250108105814_add_course_length_to_training_and_cpds.rb
+++ b/db/migrate/20250108105814_add_course_length_to_training_and_cpds.rb
@@ -1,0 +1,5 @@
+class AddCourseLengthToTrainingAndCpds < ActiveRecord::Migration[7.2]
+  def change
+    add_column :training_and_cpds, :course_length, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -607,6 +607,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_13_131902) do
     t.datetime "updated_at", null: false
     t.uuid "jobseeker_profile_id"
     t.uuid "job_application_id"
+    t.string "course_length"
     t.index ["job_application_id"], name: "index_training_and_cpds_on_job_application_id"
     t.index ["jobseeker_profile_id"], name: "index_training_and_cpds_on_jobseeker_profile_id"
   end

--- a/spec/factories/training_and_cpds.rb
+++ b/spec/factories/training_and_cpds.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     provider { "TeachTrainLtd" }
     grade { "Pass" }
     year_awarded { "2020" }
+    course_length { "1 year" }
 
     jobseeker_profile { nil }
     job_application { nil }

--- a/spec/form_models/jobseekers/training_and_cpd_form_spec.rb
+++ b/spec/form_models/jobseekers/training_and_cpd_form_spec.rb
@@ -4,4 +4,5 @@ RSpec.describe Jobseekers::TrainingAndCpdForm, type: :model do
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_presence_of(:provider) }
   it { is_expected.to validate_presence_of(:year_awarded) }
+  it { is_expected.to validate_presence_of(:course_length) }
 end

--- a/spec/support/jobseeker_helpers.rb
+++ b/spec/support/jobseeker_helpers.rb
@@ -48,7 +48,7 @@ module JobseekerHelpers
     fill_in "Name of course or training", with: name
     fill_in "Training provider", with: provider
     fill_in "Grade", with: grade
-    fill_in "Year awarded", with: year_awarded
+    fill_in "Date completed", with: year_awarded
     fill_in "Course length", with: course_length
   end
 

--- a/spec/support/jobseeker_helpers.rb
+++ b/spec/support/jobseeker_helpers.rb
@@ -44,11 +44,12 @@ module JobseekerHelpers
     fill_in "jobseekers_job_application_details_employment_form[ended_on(2i)]", with: end_month
   end
 
-  def fill_in_training_and_cpds(name: "Fire safety", provider: "TrainingProvider ltd", grade: "Pass", year_awarded: "2020")
+  def fill_in_training_and_cpds(name: "Fire safety", provider: "TrainingProvider ltd", grade: "Pass", year_awarded: "2020", course_length: "1 year")
     fill_in "Name of course or training", with: name
     fill_in "Training provider", with: provider
     fill_in "Grade", with: grade
     fill_in "Year awarded", with: year_awarded
+    fill_in "Course length", with: course_length
   end
 
   def fill_in_break_in_employment(start_year: "2020", start_month: "08", end_year: "2020", end_month: "12")

--- a/spec/system/jobseekers/jobseeker_can_add_training_and_cpds_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseeker_can_add_training_and_cpds_to_their_job_application_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "Jobseeker can add training and cpds to their job application" do
     fill_in "Name", with: name
     fill_in "Training provider", with: provider
     fill_in "Grade", with: grade
-    fill_in "Year awarded", with: year
+    fill_in "Date completed", with: year
     fill_in "Course length", with: course_length
     click_on "Save and continue"
   end
@@ -86,7 +86,7 @@ RSpec.describe "Jobseeker can add training and cpds to their job application" do
     expect(page).to have_css(".govuk-summary-list__key", text: "Grade (optional)")
     expect(page).to have_css(".govuk-summary-list__value", text: grade)
 
-    expect(page).to have_css(".govuk-summary-list__key", text: "Year awarded")
+    expect(page).to have_css(".govuk-summary-list__key", text: "Date completed")
     expect(page).to have_css(".govuk-summary-list__value", text: year)
 
     expect(page).to have_css(".govuk-summary-list__key", text: "Course length")

--- a/spec/system/jobseekers/jobseeker_can_add_training_and_cpds_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseeker_can_add_training_and_cpds_to_their_job_application_spec.rb
@@ -21,13 +21,14 @@ RSpec.describe "Jobseeker can add training and cpds to their job application" do
         expect(page).to have_link("Enter the name of the course or training", href: "#jobseekers-training-and-cpd-form-name-field-error")
         expect(page).to have_link("Enter the name of the provider of the training", href: "#jobseekers-training-and-cpd-form-provider-field-error")
         expect(page).to have_link("Enter the year the course or training was awarded", href: "#jobseekers-training-and-cpd-form-year-awarded-field-error")
+        expect(page).to have_link("Enter the length of the course", href: "#jobseekers-training-and-cpd-form-course-length-field-error")
       end
 
-      fill_in_and_submit_training_form("Rock climbing instructional course", "Training org", "A", "2024")
+      fill_in_and_submit_training_form("Rock climbing instructional course", "Training org", "A", "2024", "6 months")
 
       expect(current_path).to eq("/jobseekers/job_applications/#{job_application.id}/build/training_and_cpds")
 
-      expect_page_to_have_values("Rock climbing instructional course", "Training org", "A", "2024")
+      expect_page_to_have_values("Rock climbing instructional course", "Training org", "A", "2024", "6 months")
     end
   end
 
@@ -36,16 +37,16 @@ RSpec.describe "Jobseeker can add training and cpds to their job application" do
 
     it "allows jobseeker to edit existing training" do
       visit jobseekers_job_application_build_path(job_application, :training_and_cpds)
-      expect_page_to_have_values("Rock climbing", "TeachTrainLtd", "Pass", "2020")
+      expect_page_to_have_values("Rock climbing", "TeachTrainLtd", "Pass", "2020", "1 year")
 
       click_link "Change"
 
-      fill_in_and_submit_training_form("Choir singing instructional course", "Training org", "A", "2024")
+      fill_in_and_submit_training_form("Choir singing instructional course", "Training org", "A", "2024", "6 months")
 
       expect(current_path).to eq("/jobseekers/job_applications/#{job_application.id}/build/training_and_cpds")
 
-      expect_page_to_have_values("Choir singing instructional course", "Training org", "A", "2024")
-      expect_page_not_to_have_values("Rock climbing", "TeachTrainLtd", "Pass", "2020")
+      expect_page_to_have_values("Choir singing instructional course", "Training org", "A", "2024", "6 months")
+      expect_page_not_to_have_values("Rock climbing", "TeachTrainLtd", "Pass", "2020", "1 year")
     end
   end
 
@@ -54,7 +55,7 @@ RSpec.describe "Jobseeker can add training and cpds to their job application" do
 
     it "allows jobseeker to edit existing training" do
       visit jobseekers_job_application_build_path(job_application, :training_and_cpds)
-      expect_page_to_have_values("Rock climbing", "TeachTrainLtd", "Pass", "2020")
+      expect_page_to_have_values("Rock climbing", "TeachTrainLtd", "Pass", "2020", "1 year")
 
       click_link "Delete"
 
@@ -62,19 +63,20 @@ RSpec.describe "Jobseeker can add training and cpds to their job application" do
 
       expect(current_path).to eq("/jobseekers/job_applications/#{job_application.id}/build/training_and_cpds")
 
-      expect_page_not_to_have_values("Rock climbing", "TeachTrainLtd", "Pass", "2020")
+      expect_page_not_to_have_values("Rock climbing", "TeachTrainLtd", "Pass", "2020", "1 year")
     end
   end
 
-  def fill_in_and_submit_training_form(name, provider, grade, year)
+  def fill_in_and_submit_training_form(name, provider, grade, year, course_length)
     fill_in "Name", with: name
     fill_in "Training provider", with: provider
     fill_in "Grade", with: grade
     fill_in "Year awarded", with: year
+    fill_in "Course length", with: course_length
     click_on "Save and continue"
   end
 
-  def expect_page_to_have_values(name, provider, grade, year)
+  def expect_page_to_have_values(name, provider, grade, year, course_length)
     expect(page).to have_css(".govuk-summary-list__key", text: "Name of course or training")
     expect(page).to have_css(".govuk-summary-list__value", text: name)
 
@@ -86,12 +88,16 @@ RSpec.describe "Jobseeker can add training and cpds to their job application" do
 
     expect(page).to have_css(".govuk-summary-list__key", text: "Year awarded")
     expect(page).to have_css(".govuk-summary-list__value", text: year)
+
+    expect(page).to have_css(".govuk-summary-list__key", text: "Course length")
+    expect(page).to have_css(".govuk-summary-list__value", text: course_length)
   end
 
-  def expect_page_not_to_have_values(name, provider, grade, year)
+  def expect_page_not_to_have_values(name, provider, grade, year, course_length)
     expect(page).not_to have_css(".govuk-summary-list__value", text: name)
     expect(page).not_to have_css(".govuk-summary-list__value", text: provider)
     expect(page).not_to have_css(".govuk-summary-list__value", text: grade)
     expect(page).not_to have_css(".govuk-summary-list__value", text: year)
+    expect(page).not_to have_css(".govuk-summary-list__value", text: course_length)
   end
 end

--- a/spec/system/jobseekers/jobseekers_can_add_training_to_their_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_training_to_their_profile_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe "Jobseekers can add training to their profile" do
     fill_in "Name", with: name
     fill_in "Training provider", with: provider
     fill_in "Grade", with: grade
-    fill_in "Year awarded", with: year
+    fill_in "Date completed", with: year
     fill_in "Course length", with: course_length
     click_on "Save and continue"
   end
@@ -113,7 +113,7 @@ RSpec.describe "Jobseekers can add training to their profile" do
     expect(page).to have_css(".govuk-summary-list__key", text: "Grade (optional)")
     expect(page).to have_css(".govuk-summary-list__value", text: grade)
 
-    expect(page).to have_css(".govuk-summary-list__key", text: "Year awarded")
+    expect(page).to have_css(".govuk-summary-list__key", text: "Date completed")
     expect(page).to have_css(".govuk-summary-list__value", text: year)
 
     expect(page).to have_css(".govuk-summary-list__key", text: "Course length")

--- a/spec/system/jobseekers/jobseekers_can_add_training_to_their_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_training_to_their_profile_spec.rb
@@ -23,17 +23,18 @@ RSpec.describe "Jobseekers can add training to their profile" do
           expect(page).to have_link("Enter the name of the course or training", href: "#jobseekers-training-and-cpd-form-name-field-error")
           expect(page).to have_link("Enter the name of the provider of the training", href: "#jobseekers-training-and-cpd-form-provider-field-error")
           expect(page).to have_link("Enter the year the course or training was awarded", href: "#jobseekers-training-and-cpd-form-year-awarded-field-error")
+          expect(page).to have_link("Enter the length of the course", href: "#jobseekers-training-and-cpd-form-course-length-field-error")
         end
 
-        fill_in_and_submit_training_form("Rock climbing instructional course", "TeachTrain ltd", "A", "2024")
+        fill_in_and_submit_training_form("Rock climbing instructional course", "TeachTrain ltd", "A", "2024", "6 months")
 
-        expect_page_to_have_values("Rock climbing instructional course", "TeachTrain ltd", "A", "2024")
+        expect_page_to_have_values("Rock climbing instructional course", "TeachTrain ltd", "A", "2024", "6 months")
 
         click_link "Return to profile"
 
         expect(page).to have_current_path(jobseekers_profile_path)
 
-        expect_page_to_have_values("Rock climbing instructional course", "TeachTrain ltd", "A", "2024")
+        expect_page_to_have_values("Rock climbing instructional course", "TeachTrain ltd", "A", "2024", "6 months")
       end
     end
 
@@ -44,21 +45,21 @@ RSpec.describe "Jobseekers can add training to their profile" do
       end
 
       it "allows jobseeker to edit training" do
-        expect_page_to_have_values("Rock climbing", "TeachTrainLtd", "Pass", "2020")
+        expect_page_to_have_values("Rock climbing", "TeachTrainLtd", "Pass", "2020", "1 year")
 
         within(".govuk-summary-card__title-wrapper", text: "Rock climbing") do
           click_link("Change")
         end
 
-        fill_in_and_submit_training_form("Teaching piano to young adults", "PianoWorx", "A", "2021")
+        fill_in_and_submit_training_form("Teaching piano to young adults", "PianoWorx", "A", "2021", "1 year")
 
-        expect_page_to_have_values("Teaching piano to young adults", "PianoWorx", "A", "2021")
+        expect_page_to_have_values("Teaching piano to young adults", "PianoWorx", "A", "2021", "1 year")
 
         click_link "Return to profile"
 
         expect(page).to have_current_path(jobseekers_profile_path)
 
-        expect_page_to_have_values("Teaching piano to young adults", "PianoWorx", "A", "2021")
+        expect_page_to_have_values("Teaching piano to young adults", "PianoWorx", "A", "2021", "1 year")
       end
     end
 
@@ -69,7 +70,7 @@ RSpec.describe "Jobseekers can add training to their profile" do
       end
 
       it "allows users to delete training" do
-        expect_page_to_have_values("Rock climbing", "TeachTrainLtd", "Pass", "2020")
+        expect_page_to_have_values("Rock climbing", "TeachTrainLtd", "Pass", "2020", "1 year")
 
         within(".govuk-summary-card__title-wrapper", text: "Rock climbing") do
           click_link("Delete")
@@ -88,19 +89,21 @@ RSpec.describe "Jobseekers can add training to their profile" do
         expect(page).to_not have_css(".govuk-summary-list__value", text: "TeachTrainLtd")
         expect(page).to_not have_css(".govuk-summary-list__value", text: "Pass")
         expect(page).to_not have_css(".govuk-summary-list__value", text: "2020")
+        expect(page).to_not have_css(".govuk-summary-list__value", text: "1 year")
       end
     end
   end
 
-  def fill_in_and_submit_training_form(name, provider, grade, year)
+  def fill_in_and_submit_training_form(name, provider, grade, year, course_length)
     fill_in "Name", with: name
     fill_in "Training provider", with: provider
     fill_in "Grade", with: grade
     fill_in "Year awarded", with: year
+    fill_in "Course length", with: course_length
     click_on "Save and continue"
   end
 
-  def expect_page_to_have_values(name, provider, grade, year)
+  def expect_page_to_have_values(name, provider, grade, year, course_length)
     expect(page).to have_css(".govuk-summary-list__key", text: "Name of course or training")
     expect(page).to have_css(".govuk-summary-list__value", text: name)
 
@@ -112,5 +115,8 @@ RSpec.describe "Jobseekers can add training to their profile" do
 
     expect(page).to have_css(".govuk-summary-list__key", text: "Year awarded")
     expect(page).to have_css(".govuk-summary-list__value", text: year)
+
+    expect(page).to have_css(".govuk-summary-list__key", text: "Course length")
+    expect(page).to have_css(".govuk-summary-list__value", text: course_length)
   end
 end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/zYg69szQ/1475-content-changes-to-cpd-section-application-and-profiles

## Changes in this PR:

This change adds course length question to training and cpd section of both jobseeker profile and job applications, and also makes some changes to the content on the training form.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
