### PR TITLE
convert todays subscription alert run list to a set for performance

### DIFF
--- a/app/jobs/alert_email/base.rb
+++ b/app/jobs/alert_email/base.rb
@@ -8,7 +8,7 @@ class AlertEmail::Base < ApplicationJob
     # really fast (1 week's worth of vacancies is around 2000, so not worth leaving on disk for each of 100k daily subscriptions
     default_scope = Vacancy.includes(:organisations).live.order(publish_on: :desc).search_by_filter(from_date: from_date, to_date: Date.current)
 
-    already_run_ids = AlertRun.for_today.pluck(:subscription_id)
+    already_run_ids = Set.new AlertRun.for_today.pluck(:subscription_id)
 
     subscriptions.find_each.reject { |sub| already_run_ids.include?(sub.id) }.each do |subscription|
       vacancies = subscription.vacancies_matching(default_scope).first(MAXIMUM_RESULTS_PER_RUN)


### PR DESCRIPTION
## Trello card URL

## Changes in this PR:

convert todays subscription alert run list to a set for performance

The alert runs for today list could be large (>10_000 records) so convert to a set to improve lookup performance