### PR TITLE
Add missing index to AlertRuns

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_07_110428) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_13_131902) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -56,6 +56,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_07_110428) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.integer "status", default: 0
+    t.index ["run_on"], name: "index_alert_runs_on_run_on"
     t.index ["subscription_id"], name: "index_alert_runs_on_subscription_id"
   end
 


### PR DESCRIPTION
There is a query counting on the AlertRuns for today and, given the size of the table, it takes a long time due to the lack of an index for the date field.
![image](https://github.com/user-attachments/assets/e80584e8-81e3-4cde-9ce6-5af5ae8315dc)
![image](https://github.com/user-attachments/assets/79f1ba66-6bf6-4f41-b0c9-d87c6f1bf376)
