### PR TITLE
Revert "Enable federated auth for big query in production"

### DIFF
--- a/terraform/workspace-variables/production.tfvars.json
+++ b/terraform/workspace-variables/production.tfvars.json
@@ -80,6 +80,6 @@
     "start_minute": 0
   },
   "enable_logit": true,
-  "enable_dfe_analytics_federated_auth": true,
+  "enable_dfe_analytics_federated_auth": false,
   "dataset_name": "production_dataset"
 }


### PR DESCRIPTION

## Trello card URL
https://trello.com/c/yqj8hYRR

## Changes in this PR:
This reverts commit b4646a19e65d6107d0bf9487037109b66c0ca483. Disable federated auth. 
Google Indexing job seems to be broken.

