### PR TITLE
Remove Analytics scope from Google Api Client

### DIFF
--- a/config/initializers/google_api.rb
+++ b/config/initializers/google_api.rb
@@ -11,7 +11,6 @@ if GOOGLE_API_JSON_KEY.empty? || JSON.parse(GOOGLE_API_JSON_KEY).empty?
 end
 
 scope = ["https://www.googleapis.com/auth/indexing",
-         "https://www.googleapis.com/auth/analytics",
          "https://www.googleapis.com/auth/drive"]
 
 key = StringIO.new(GOOGLE_API_JSON_KEY)


### PR DESCRIPTION
This scope was introduced to access/store the vacancies view counters data from Google Analytics. Was done with this PR:
- https://github.com/DFE-Digital/teaching-vacancies/pull/547

Since then, those counter db fields have been removed, the Google Analytics gem & client also have been removed.

Our current project only uses Google Api client for Google Drive and Indexing.

All the statistical data gets queried directly through Google Bigquery client. Called from the Publishers::VacancyStats service.
