### PR TITLE
Clean Alerts with "delete_all"

### DIFF
--- a/app/jobs/delete_old_alert_runs_job.rb
+++ b/app/jobs/delete_old_alert_runs_job.rb
@@ -2,6 +2,6 @@ class DeleteOldAlertRunsJob < ApplicationJob
   queue_as :low
 
   def perform
-    AlertRun.where(run_on: ...1.week.ago).destroy_all
+    AlertRun.where(run_on: ...1.week.ago).delete_all
   end
 end


### PR DESCRIPTION
The destroy_all call was not adequate for the high volume of data, as instantiates each record in memory.

Delete all executes everything with a single SQL query (what I originally intended and missed).
