### PR TITLE
Remove other secondary qualifications

### DIFF
--- a/app/controllers/jobseekers/job_applications/qualifications_controller.rb
+++ b/app/controllers/jobseekers/job_applications/qualifications_controller.rb
@@ -72,7 +72,7 @@ class Jobseekers::JobApplications::QualificationsController < Jobseekers::BaseCo
 
   def qualification_params
     params.require(qualification_form_param_key(@category))
-          .permit(:category, :finished_studying, :finished_studying_details, :grade, :institution, :name, :subject, :year, qualification_results_attributes: %i[id subject grade awarding_body])
+          .permit(:category, :finished_studying, :finished_studying_details, :grade, :institution, :name, :subject, :year, :awarding_body, qualification_results_attributes: %i[id subject grade awarding_body])
   end
 
   def category_param

--- a/app/controllers/jobseekers/profiles/qualifications_controller.rb
+++ b/app/controllers/jobseekers/profiles/qualifications_controller.rb
@@ -80,7 +80,7 @@ class Jobseekers::Profiles::QualificationsController < Jobseekers::ProfilesContr
       (params[qualification_form_param_key(@category)] || params).permit(:category)
     when "create", "edit", "update"
       params.require(qualification_form_param_key(@category))
-            .permit(:category, :finished_studying, :finished_studying_details, :grade, :institution, :name, :subject, :year, qualification_results_attributes: %i[id subject grade awarding_body])
+            .permit(:category, :finished_studying, :finished_studying_details, :grade, :institution, :name, :subject, :year, :awarding_body, qualification_results_attributes: %i[id subject grade awarding_body])
     end
   end
 

--- a/app/form_models/jobseekers/qualifications/other_form.rb
+++ b/app/form_models/jobseekers/qualifications/other_form.rb
@@ -2,4 +2,5 @@ class Jobseekers::Qualifications::OtherForm < Jobseekers::Qualifications::Qualif
   attr_accessor :subject, :grade
 
   validates :finished_studying, :institution, :name, presence: true
+  validates :grade, presence: true, if: -> { finished_studying == "true" }
 end

--- a/app/form_models/jobseekers/qualifications/qualification_form.rb
+++ b/app/form_models/jobseekers/qualifications/qualification_form.rb
@@ -1,7 +1,7 @@
 class Jobseekers::Qualifications::QualificationForm
   include ActiveModel::Model
 
-  attr_accessor :category, :finished_studying, :finished_studying_details, :name, :institution, :year
+  attr_accessor :category, :finished_studying, :finished_studying_details, :name, :institution, :year, :awarding_body
 
   validates :category, presence: true
   validates :finished_studying_details, presence: true, if: -> { finished_studying == "false" }

--- a/app/helpers/pdf_helper.rb
+++ b/app/helpers/pdf_helper.rb
@@ -122,6 +122,7 @@ module PdfHelper
       ["Institution:", qualification.institution],
       ["Grade:", qualification.grade],
       ["Date completed:", qualification.year],
+      ["Awarding body:", qualification.awarding_body],
     ].reject { |row| row[1].blank? }
 
     render_table(pdf, general_qualification_data)

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -52,7 +52,7 @@ class Qualification < ApplicationRecord
     elsif finished_studying?
       %w[subject institution grade year]
     else
-      %w[subject institution]
+      %w[subject institution grade awarding_body]
     end
   end
 

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -50,7 +50,7 @@ class Qualification < ApplicationRecord
     if secondary?
       %w[institution year]
     elsif finished_studying?
-      %w[subject institution grade year]
+      %w[subject institution grade year awarding_body]
     else
       %w[subject institution grade awarding_body]
     end

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -52,7 +52,7 @@ class Qualification < ApplicationRecord
     elsif finished_studying?
       %w[subject institution grade year awarding_body]
     else
-      %w[subject institution grade awarding_body]
+      %w[subject institution awarding_body]
     end
   end
 

--- a/app/services/qualifications_migration.rb
+++ b/app/services/qualifications_migration.rb
@@ -1,0 +1,32 @@
+class QualificationsMigration
+  def self.perform
+    ActiveRecord::Base.transaction do
+      qualifications = Qualification.where(category: 'other_secondary')
+
+      qualifications.find_each do |qualification|
+        # Get associated qualification results
+        results = qualification.qualification_results
+        results.each do |result|
+          # Create a new qualification with category 'other'
+          Qualification.create!(
+            category: 'other',
+            subject: result.subject,
+            grade: result.grade,
+            institution: qualification.institution,
+            name: qualification.name,
+            year: qualification.year,
+            job_application_id: qualification.job_application_id,
+            jobseeker_profile_id: qualification.jobseeker_profile_id,
+            finished_studying: qualification.finished_studying
+          )
+        end
+
+        # Delete the original qualification
+        qualification.destroy!
+      end
+    end
+  rescue => e
+    Rails.logger.error("Error migrating qualifications: #{e.message}")
+    raise
+  end
+end

--- a/app/services/qualifications_migration.rb
+++ b/app/services/qualifications_migration.rb
@@ -1,13 +1,11 @@
 class QualificationsMigration
   def self.perform
     ActiveRecord::Base.transaction do
-      qualifications = Qualification.where(category: "other_secondary")
-
-      qualifications.find_each do |qualification|
-        results = qualification.qualification_results
-        results.each do |result|
-          Qualification.create!(category: "other", subject: result.subject, grade: result.grade, institution: qualification.institution, name: qualification.name,
-                                year: qualification.year, job_application_id: qualification.job_application_id, jobseeker_profile_id: qualification.jobseeker_profile_id,
+      Qualification.includes(:qualification_results).where(category: "other_secondary").find_each(batch_size: 500) do |qualification|
+        qualification.qualification_results.each do |result|
+          Qualification.create!(category: "other", subject: result.subject, grade: result.grade,
+                                institution: qualification.institution, name: qualification.name, year: qualification.year,
+                                job_application_id: qualification.job_application_id, jobseeker_profile_id: qualification.jobseeker_profile_id,
                                 finished_studying: qualification.finished_studying)
         end
 

--- a/app/services/qualifications_migration.rb
+++ b/app/services/qualifications_migration.rb
@@ -1,31 +1,20 @@
 class QualificationsMigration
   def self.perform
     ActiveRecord::Base.transaction do
-      qualifications = Qualification.where(category: 'other_secondary')
+      qualifications = Qualification.where(category: "other_secondary")
 
       qualifications.find_each do |qualification|
-        # Get associated qualification results
         results = qualification.qualification_results
         results.each do |result|
-          # Create a new qualification with category 'other'
-          Qualification.create!(
-            category: 'other',
-            subject: result.subject,
-            grade: result.grade,
-            institution: qualification.institution,
-            name: qualification.name,
-            year: qualification.year,
-            job_application_id: qualification.job_application_id,
-            jobseeker_profile_id: qualification.jobseeker_profile_id,
-            finished_studying: qualification.finished_studying
-          )
+          Qualification.create!(category: "other", subject: result.subject, grade: result.grade, institution: qualification.institution, name: qualification.name,
+                                year: qualification.year, job_application_id: qualification.job_application_id, jobseeker_profile_id: qualification.jobseeker_profile_id,
+                                finished_studying: qualification.finished_studying)
         end
 
-        # Delete the original qualification
         qualification.destroy!
       end
     end
-  rescue => e
+  rescue StandardError => e
     Rails.logger.error("Error migrating qualifications: #{e.message}")
     raise
   end

--- a/app/services/qualifications_migration.rb
+++ b/app/services/qualifications_migration.rb
@@ -3,7 +3,7 @@ class QualificationsMigration
     ActiveRecord::Base.transaction do
       Qualification.includes(:qualification_results).where(category: "other_secondary").find_each(batch_size: 500) do |qualification|
         qualification.qualification_results.each do |result|
-          Qualification.create!(category: "other", subject: result.subject, grade: result.grade,
+          Qualification.create!(category: "other", subject: result.subject, grade: result.grade, awarding_body: result.awarding_body,
                                 institution: qualification.institution, name: qualification.name, year: qualification.year,
                                 job_application_id: qualification.job_application_id, jobseeker_profile_id: qualification.jobseeker_profile_id,
                                 finished_studying: qualification.finished_studying)

--- a/app/views/jobseekers/job_applications/build/qualifications.html.slim
+++ b/app/views/jobseekers/job_applications/build/qualifications.html.slim
@@ -35,10 +35,10 @@
             - detail.with_action govuk_link_to t("buttons.change"), edit_jobseekers_job_application_qualification_path(job_application, qualification), class: "govuk-link--no-visited-state"
             - detail.with_action govuk_link_to t("buttons.delete"), jobseekers_job_application_qualification_path(job_application, qualification), method: :delete
 
-      = govuk_button_link_to t("buttons.add_another_qualification"), select_category_jobseekers_job_application_qualifications_path(job_application), class: "govuk-button--secondary"
+      = govuk_button_link_to t("buttons.add_another_qualification"), select_category_jobseekers_job_application_qualifications_path(job_application)
     - else
       = render EmptySectionComponent.new title: t(".no_qualifications") do
-        = govuk_button_link_to t("buttons.add_qualification"), select_category_jobseekers_job_application_qualifications_path(job_application), class: "govuk-button--secondary govuk-!-margin-bottom-0"
+        = govuk_button_link_to t("buttons.add_qualification"), select_category_jobseekers_job_application_qualifications_path(job_application), class: "govuk-!-margin-bottom-0"
 
     = form_for form, url: wizard_path, method: :patch do |f|
       = f.govuk_error_summary

--- a/app/views/jobseekers/job_applications/build/qualifications.html.slim
+++ b/app/views/jobseekers/job_applications/build/qualifications.html.slim
@@ -20,9 +20,10 @@
                     - row.with_value text: safe_join(qualification.qualification_results.map { |res| tag.div(display_secondary_qualification(res), class: "govuk-body govuk-!-margin-bottom-1") })
 
                 - qualification.display_attributes.each do |attribute|
-                  - summary_list.with_row do |row|
-                    - row.with_key text: t("helpers.label.#{qualification_form_param_key(qualification.category)}.#{attribute}")
-                    - row.with_value text: qualification[attribute]
+                  - if qualification[attribute].present?
+                    - summary_list.with_row do |row|
+                      - row.with_key text: t("helpers.label.#{qualification_form_param_key(qualification.category)}.#{attribute}")
+                      - row.with_value text: qualification[attribute]
 
                 - if qualification.finished_studying == false
                   - summary_list.with_row do |row|

--- a/app/views/jobseekers/job_applications/qualifications/new.html.slim
+++ b/app/views/jobseekers/job_applications/qualifications/new.html.slim
@@ -5,6 +5,8 @@
     span.govuk-caption-l = t(".caption")
     h1.govuk-heading-xl = t(".heading.#{@category}")
     p = t(".hint")
+    - if @category == "other"
+      p = t(".hint_for_other_qualifications")
 
     = form_for @form, url: jobseekers_job_application_qualifications_path(job_application, category: @category), method: :post do |f|
       = f.govuk_error_summary link_base_errors_to: :subject

--- a/app/views/jobseekers/job_applications/review/qualifications/_qualification.html.slim
+++ b/app/views/jobseekers/job_applications/review/qualifications/_qualification.html.slim
@@ -1,5 +1,5 @@
 p class="govuk-!-margin-bottom-1"
-  - if qualification.display_attributes.include?("subject")
+  - if qualification.display_attributes.include?("subject") && qualification[:subject].present?
     span class="govuk-!-display-inline-block"
       = qualification[:subject]
   - if qualification.display_attributes.include?("type")
@@ -7,7 +7,10 @@ p class="govuk-!-margin-bottom-1"
       = qualification[:type]
   - if qualification.display_attributes.include?("grade")
     span class="govuk-!-display-inline-block govuk-!-margin-left-1"
-      = "(#{qualification[:grade]})"
+      = "- #{qualification[:grade]}"
+  - if qualification.display_attributes.include?("awarding_body") && qualification[:awarding_body].present?
+    span class="govuk-!-display-inline-block govuk-!-margin-left-1"
+      = " (#{qualification[:awarding_body]})"
   - if qualification.finished_studying == false
     span class="govuk-!-display-inline-block govuk-!-margin-left-1"
       = "(#{t('helpers.label.jobseekers_qualifications_shared_labels.finished_studying_options.false').downcase} #{qualification.finished_studying_details&.downcase})"
@@ -15,6 +18,6 @@ p.govuk-caption-m
   - if qualification.display_attributes.include?("institution")
     span class="govuk-!-display-inline-block"
       = qualification[:institution]
-  - if qualification.display_attributes.include?("year")
+  - if qualification.display_attributes.include?("year") && qualification[:year].present?
     span class="govuk-!-display-inline-block"
       = ", #{qualification[:year]}"

--- a/app/views/jobseekers/profiles/qualifications/new.html.slim
+++ b/app/views/jobseekers/profiles/qualifications/new.html.slim
@@ -5,6 +5,8 @@
     span.govuk-caption-l = t(".caption")
     h1.govuk-heading-xl = t(".heading.#{@category}")
     p = t(".hint")
+    - if @category == "other"
+      p = t(".hint_for_other_qualifications")
 
     = form_for @form, url: jobseekers_profile_qualifications_path(profile, category: @category), method: :post do |f|
       = f.govuk_error_summary link_base_errors_to: :subject

--- a/app/views/jobseekers/qualifications/_qualifications.html.slim
+++ b/app/views/jobseekers/qualifications/_qualifications.html.slim
@@ -9,9 +9,10 @@
               - row.with_value text: safe_join(qualification.qualification_results.map { |res| tag.div(display_secondary_qualification(res), class: "govuk-body govuk-!-margin-bottom-1") })
 
           - qualification.display_attributes.each do |attribute|
-            - summary_list.with_row do |row|
-              - row.with_key text: t("helpers.label.#{qualification_form_param_key(qualification.category)}.#{attribute}")
-              - row.with_value text: qualification[attribute]
+            - if qualification[attribute].present?
+              - summary_list.with_row do |row|
+                - row.with_key text: t("helpers.label.#{qualification_form_param_key(qualification.category)}.#{attribute}")
+                - row.with_value text: qualification[attribute]
 
           - if qualification.finished_studying == false
             - summary_list.with_row do |row|

--- a/app/views/jobseekers/qualifications/fields/_other.html.slim
+++ b/app/views/jobseekers/qualifications/fields/_other.html.slim
@@ -2,6 +2,8 @@
 
 = f.govuk_text_field :name, label: { size: "s" }, aria: { required: true }
 
+= f.govuk_text_field :awarding_body, label: { size: "s" }
+
 = f.govuk_text_field :subject, label: { size: "s", text: t("helpers.optional_field_html", label: t("helpers.label.jobseekers_qualifications_shared_labels.subject")) }
 
 = f.govuk_radio_buttons_fieldset :finished_studying do

--- a/app/views/shared/_category_fieldset.html.slim
+++ b/app/views/shared/_category_fieldset.html.slim
@@ -2,7 +2,6 @@
   = form.govuk_radio_button :category, :gcse, link_errors: true
   = form.govuk_radio_button :category, :as_level
   = form.govuk_radio_button :category, :a_level
-  = form.govuk_radio_button :category, :other_secondary
   = form.govuk_radio_button :category, :undergraduate
   = form.govuk_radio_button :category, :postgraduate
   = form.govuk_radio_button :category, :other

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -298,6 +298,7 @@ shared:
     - year
     - job_application_id
     - jobseeker_profile_id
+    - awarding_body
   qualification_results:
     - id
     - qualification_id

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -585,6 +585,7 @@ en:
         institution: School, college, university or other organisation
         name: Qualification or course name
         year: Year qualification was awarded
+        awarding_body: Awarding body (optional)
       jobseekers_qualifications_secondary_common_form:
         <<: *jobseekers_qualifications_shared_labels
         institution: School, college, or other organisation

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -192,6 +192,8 @@ en:
       jobseekers_qualifications_degree_form:
         institution: For example, a university or college
         qualifications_section_completed: Ensure you've added all the education and qualifications you've done.
+      jobseekers_qualifications_other_form:
+        awarding_body: For example, a university or college
       jobseekers_job_alert_further_feedback_form:
         comment: This is optional, but the information will help us to make improvements.
         email: >-

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -224,6 +224,7 @@ en:
       jobseekers_qualifications_category_form:
         category_options:
           postgraduate: For example, A PGCE, master’s or PhD.
+          other: For example, BTECs, diplomas or qualifications from outside of the UK.
 
       publishers_organisation_form:
         description: Jobseekers will see this description of the %{organisation_type} in the job listing
@@ -430,7 +431,7 @@ en:
           other_secondary: Other secondary qualification
           undergraduate: Undergraduate degree
           postgraduate: Postgraduate qualification
-          other: Other qualification or course
+          other: Other qualification
         finished_studying_details: Please give details
         finished_studying_options:
           false: "Not finished yet"
@@ -573,7 +574,7 @@ en:
           other_secondary: Other secondary qualification
           undergraduate: Undergraduate degree
           postgraduate: Postgraduate qualification
-          other: Other qualification or course
+          other: Other qualification
       jobseekers_qualifications_degree_form:
         <<: *jobseekers_qualifications_shared_labels
         institution: Awarding body

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -406,7 +406,7 @@ en:
             other_secondary: Edit secondary qualifications
             undergraduate: Edit undergraduate degree
             postgraduate: Edit postgraduate qualification
-            other: Edit qualification or course
+            other: Edit qualification
           title: Edit qualification — Application
         new:
           <<: *qualifications_shared
@@ -417,9 +417,10 @@ en:
             other_secondary: Add secondary qualifications
             undergraduate: Add an undergraduate degree
             postgraduate: Add a postgraduate qualification
-            other: Add a qualification or course
+            other: Add a qualification
           title: Add a qualification — Application
           hint: You do not need to add qualified teacher status (QTS) here. You can add this to your application in the professional status section.
+          hint_for_other_qualifications: Add any formal qualifications. You can add details of any training or professional development in the continuing professional development part of the application.
         select_category:
           <<: *qualifications_shared
           heading: Add a qualification
@@ -806,9 +807,10 @@ en:
             other_secondary: Add secondary qualifications
             undergraduate: Add an undergraduate degree
             postgraduate: Add a postgraduate qualification
-            other: Add a qualification or course
+            other: Add a qualification
           title: Add a qualification — Profile
           hint: You do not need to add qualified teacher status (QTS) here. You can add this to your application in the professional status section.
+          hint_for_other_qualifications: Add any formal qualifications. You can add details of any training or professional development in the continuing professional development part of the application.
         edit:
           page_title: Qualifications
         review:

--- a/db/migrate/20250115153941_add_awarding_body_to_qualification.rb
+++ b/db/migrate/20250115153941_add_awarding_body_to_qualification.rb
@@ -1,0 +1,5 @@
+class AddAwardingBodyToQualification < ActiveRecord::Migration[7.2]
+  def change
+    add_column :qualifications, :awarding_body, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_13_144018) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_15_153941) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -531,6 +531,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_13_144018) do
     t.uuid "job_application_id"
     t.text "finished_studying_details_ciphertext"
     t.uuid "jobseeker_profile_id"
+    t.string "awarding_body"
     t.index ["job_application_id"], name: "index_qualifications_on_job_application_id"
     t.index ["jobseeker_profile_id"], name: "index_qualifications_on_jobseeker_profile_id"
   end

--- a/lib/tasks/update_other_secondary_qualifications.rake
+++ b/lib/tasks/update_other_secondary_qualifications.rake
@@ -1,0 +1,9 @@
+namespace :qualifications do
+  desc "Migrate other_secondary qualifications to other category"
+  task migrate_to_other: :environment do
+    QualificationsMigration.perform
+    puts "Migration completed successfully."
+  rescue StandardError => e
+    puts "Migration failed: #{e.message}"
+  end
+end

--- a/spec/form_models/jobseekers/qualifications/other_form_spec.rb
+++ b/spec/form_models/jobseekers/qualifications/other_form_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Jobseekers::Qualifications::OtherForm, type: :model do
-  subject { described_class.new(params) }
+  subject(:form) { described_class.new(params) }
   let(:params) { {} }
 
   it { is_expected.to validate_presence_of(:category) }
@@ -13,11 +13,19 @@ RSpec.describe Jobseekers::Qualifications::OtherForm, type: :model do
     let(:params) { { "finished_studying" => "false" } }
 
     it { is_expected.to validate_presence_of(:finished_studying_details) }
+    it { is_expected.not_to validate_presence_of(:grade) }
   end
 
   context "when finished studying is true" do
     let(:params) { { "finished_studying" => "true" } }
 
     it { is_expected.to validate_numericality_of(:year).is_less_than_or_equal_to(Time.current.year) }
+    it { is_expected.to validate_presence_of(:grade) }
+
+    it "raises error without a grade" do
+      form.grade = nil
+      expect(form).not_to be_valid
+      expect(form.errors[:grade]).to include("Enter a grade")
+    end
   end
 end

--- a/spec/services/qualifications_migration_spec.rb
+++ b/spec/services/qualifications_migration_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe QualificationsMigration, type: :model do
+  let!(:qualification) { create(:qualification, category: 'other_secondary') }
+  
+  before do
+    qualification.qualification_results.destroy_all
+    QualificationResult.create(qualification: qualification, subject: 'Math', grade: 'A', awarding_body: "AXA")
+    QualificationResult.create(qualification: qualification, subject: 'English', grade: 'B', awarding_body: "Bee")
+  end
+
+  describe '.perform' do
+    it 'migrates qualifications with category other_secondary to other' do
+      expect {
+        QualificationsMigration.perform
+      }.to change { Qualification.where(category: 'other').count }.by(2)
+    end
+
+    it 'creates new qualifications with the correct attributes' do
+      QualificationsMigration.perform
+      new_qualifications = Qualification.where(category: 'other')
+
+      expect(new_qualifications.count).to eq(2)
+      expect(new_qualifications.pluck(:subject)).to contain_exactly('Math', 'English')
+      expect(new_qualifications.pluck(:grade)).to contain_exactly('A', 'B')
+    end
+
+    it 'deletes the original qualification with category other_secondary' do
+      expect {
+        QualificationsMigration.perform
+      }.to change { Qualification.where(category: 'other_secondary').count }.by(-1)
+    end
+
+    context 'when an error occurs during migration' do
+      before do
+        allow(Qualification).to receive(:create!).and_raise(StandardError, 'Test error')
+      end
+
+      it 'logs the error and does not delete original qualifications' do
+        expect(Rails.logger).to receive(:error).with(/Error migrating qualifications: Test error/)
+        expect {
+          QualificationsMigration.perform rescue nil
+        }.to_not change { Qualification.where(category: 'other_secondary').count }
+      end
+    end
+  end
+end

--- a/spec/services/qualifications_migration_spec.rb
+++ b/spec/services/qualifications_migration_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe QualificationsMigration, type: :model do
     profile_qualification.qualification_results.destroy_all
     application_qualification.qualification_results.destroy_all
 
-    QualificationResult.create!(qualification: profile_qualification, subject: "Science", grade: "A")
-    QualificationResult.create!(qualification: application_qualification, subject: "History", grade: "B")
+    QualificationResult.create!(qualification: profile_qualification, subject: "Science", grade: "A", awarding_body: "Oxford exam board")
+    QualificationResult.create!(qualification: application_qualification, subject: "History", grade: "B", awarding_body: "AXA")
   end
 
   describe ".perform" do
@@ -30,6 +30,7 @@ RSpec.describe QualificationsMigration, type: :model do
       expect(new_qualifications.count).to eq(2)
       expect(new_qualifications.pluck(:subject)).to contain_exactly("Science", "History")
       expect(new_qualifications.pluck(:grade)).to contain_exactly("A", "B")
+      expect(new_qualifications.pluck(:awarding_body)).to contain_exactly("Oxford exam board", "AXA")
     end
 
     it "ensures new qualifications maintain their associations" do

--- a/spec/services/qualifications_migration_spec.rb
+++ b/spec/services/qualifications_migration_spec.rb
@@ -1,46 +1,80 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe QualificationsMigration, type: :model do
-  let!(:qualification) { create(:qualification, category: 'other_secondary') }
-  
+  let!(:profile) { create(:jobseeker_profile) }
+  let!(:application) { create(:job_application) }
+
+  let!(:profile_qualification) { create(:qualification, category: "other_secondary", jobseeker_profile: profile, job_application: nil) }
+  let!(:application_qualification) { create(:qualification, category: "other_secondary", job_application: application, jobseeker_profile: nil) }
+  let!(:unrelated_qualification) { create(:qualification, category: "a_level") }
+
   before do
-    qualification.qualification_results.destroy_all
-    QualificationResult.create(qualification: qualification, subject: 'Math', grade: 'A', awarding_body: "AXA")
-    QualificationResult.create(qualification: qualification, subject: 'English', grade: 'B', awarding_body: "Bee")
+    profile_qualification.qualification_results.destroy_all
+    application_qualification.qualification_results.destroy_all
+
+    QualificationResult.create!(qualification: profile_qualification, subject: "Science", grade: "A")
+    QualificationResult.create!(qualification: application_qualification, subject: "History", grade: "B")
   end
 
-  describe '.perform' do
-    it 'migrates qualifications with category other_secondary to other' do
+  describe ".perform" do
+    it "migrates qualifications with category other_secondary to other" do
       expect {
-        QualificationsMigration.perform
-      }.to change { Qualification.where(category: 'other').count }.by(2)
+        described_class.perform
+      }.to change { Qualification.where(category: "other").count }.by(2)
     end
 
-    it 'creates new qualifications with the correct attributes' do
-      QualificationsMigration.perform
-      new_qualifications = Qualification.where(category: 'other')
+    it "creates new qualifications with the correct attributes" do
+      described_class.perform
+      new_qualifications = Qualification.where(category: "other")
 
       expect(new_qualifications.count).to eq(2)
-      expect(new_qualifications.pluck(:subject)).to contain_exactly('Math', 'English')
-      expect(new_qualifications.pluck(:grade)).to contain_exactly('A', 'B')
+      expect(new_qualifications.pluck(:subject)).to contain_exactly("Science", "History")
+      expect(new_qualifications.pluck(:grade)).to contain_exactly("A", "B")
     end
 
-    it 'deletes the original qualification with category other_secondary' do
+    it "ensures new qualifications maintain their associations" do
+      described_class.perform
+
+      profile_other_qualification = Qualification.find_by(subject: "Science", category: "other")
+      application_other_qualification = Qualification.find_by(subject: "History", category: "other")
+
+      expect(profile_other_qualification.jobseeker_profile).to eq(profile)
+      expect(profile_other_qualification.job_application).to be_nil
+
+      expect(application_other_qualification.job_application).to eq(application)
+      expect(application_other_qualification.jobseeker_profile).to be_nil
+    end
+
+    it "deletes the original qualifications with category other_secondary" do
       expect {
-        QualificationsMigration.perform
-      }.to change { Qualification.where(category: 'other_secondary').count }.by(-1)
+        described_class.perform
+      }.to change { Qualification.where(category: "other_secondary").count }.by(-2)
     end
 
-    context 'when an error occurs during migration' do
+    it "does not change other qualification types" do
+      expect {
+        described_class.perform
+      }.not_to(change { Qualification.where(category: "a_level").count })
+
+      unaffected_qualification = Qualification.find_by(id: unrelated_qualification.id)
+      expect(unaffected_qualification).to be_present
+      expect(unaffected_qualification.category).to eq("a_level")
+    end
+
+    context "when an error occurs during migration" do
       before do
-        allow(Qualification).to receive(:create!).and_raise(StandardError, 'Test error')
+        allow(Qualification).to receive(:create!).and_raise(StandardError, "Test error")
       end
 
-      it 'logs the error and does not delete original qualifications' do
+      it "logs the error and does not delete original qualifications" do
         expect(Rails.logger).to receive(:error).with(/Error migrating qualifications: Test error/)
         expect {
-          QualificationsMigration.perform rescue nil
-        }.to_not change { Qualification.where(category: 'other_secondary').count }
+          begin
+            described_class.perform
+          rescue StandardError
+            nil
+          end
+        }.not_to(change { Qualification.where(category: "other_secondary").count })
       end
     end
   end

--- a/spec/support/jobseeker_helpers.rb
+++ b/spec/support/jobseeker_helpers.rb
@@ -138,6 +138,8 @@ module JobseekerHelpers
   def fill_in_other_qualification
     fill_in "Qualification or course name", with: "Superteacher Certificate"
     fill_in "School, college, university or other organisation", with: "Teachers Academy"
+    fill_in "Awarding body (optional)", with: "AXA"
+    fill_in "Subject", with: "Superteaching"
     choose "No", name: "jobseekers_qualifications_other_form[finished_studying]"
     fill_in "Please give details", with: "I expect to finish next year"
   end

--- a/spec/system/jobseekers/jobseekers_can_add_qualifications_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_qualifications_to_their_job_application_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Jobseekers can add qualifications to their job application" do
     end
 
     it "allows jobseekers to add a custom qualification or course (category 'other')" do
-      select_qualification_category("Other qualification or course")
+      select_qualification_category("Other qualification")
       expect(page).to have_content(I18n.t("jobseekers.job_applications.qualifications.new.heading.other"))
       validates_step_complete(button: I18n.t("buttons.save_qualification.one"))
       fill_in_other_qualification

--- a/spec/system/jobseekers/jobseekers_can_add_qualifications_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_qualifications_to_their_job_application_spec.rb
@@ -40,38 +40,11 @@ RSpec.describe "Jobseekers can add qualifications to their job application" do
       expect(current_path).to eq(jobseekers_job_application_build_path(job_application, :qualifications))
       expect(page).to have_content("Superteacher Certificate")
       expect(page).to have_content("Teachers Academy")
+      expect(page).to have_content("Superteaching")
+      expect(page).to have_content("AXA")
       expect(page).to have_content("I expect to finish next year")
       expect(page).not_to have_content("Grade")
       expect(page).not_to have_content("Year")
-    end
-
-    it "allows jobseekers to add a common secondary qualification" do
-      select_qualification_category("GCSE")
-      expect(page).to have_link(I18n.t("buttons.cancel"), href: select_category_jobseekers_job_application_qualifications_path(job_application))
-      expect(page).to have_content(I18n.t("jobseekers.job_applications.qualifications.new.heading.gcse"))
-      validates_step_complete(button: I18n.t("buttons.save_qualification.other"))
-      fill_in_gcses
-      click_on I18n.t("buttons.save_qualification.other")
-      expect(current_path).to eq(jobseekers_job_application_build_path(job_application, :qualifications))
-      expect(page).to have_content("GCSEs")
-      expect(page).to have_content("Churchill School for Gifted Macaques")
-      expect(page).to have_content("Maths – 110% (Cambridge Board)")
-      expect(page).to have_content("PE – 90%")
-      expect(page).to have_content("2020")
-    end
-
-    it "allows jobseekers to add a custom secondary qualification" do
-      select_qualification_category("Other secondary qualification")
-      expect(page).to have_content(I18n.t("jobseekers.job_applications.qualifications.new.heading.other_secondary"))
-      validates_step_complete(button: I18n.t("buttons.save_qualification.other"))
-      fill_in_custom_secondary_qualifications
-      click_on I18n.t("buttons.save_qualification.other")
-      expect(current_path).to eq(jobseekers_job_application_build_path(job_application, :qualifications))
-      expect(page).to have_content("Welsh Baccalaureate")
-      expect(page).to have_content("Happy Rainbows School for High Achievers")
-      expect(page).to have_content("Science – 5")
-      expect(page).to have_content("German – 4")
-      expect(page).to have_content("2020")
     end
   end
 

--- a/spec/system/jobseekers/jobseekers_can_add_qualifications_to_their_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_qualifications_to_their_profile_spec.rb
@@ -40,6 +40,8 @@ RSpec.describe "Jobseekers can add qualifications to their profile" do
         expect(page).to have_content("Teachers Academy")
         expect(page).to have_content("I expect to finish next year")
         expect(page).to have_content("Not finished yet")
+        expect(page).to have_content("Superteaching")
+        expect(page).to have_content("AXA")
         expect(page).not_to have_content("Grade")
         expect(page).not_to have_content("Year")
       end
@@ -60,21 +62,6 @@ RSpec.describe "Jobseekers can add qualifications to their profile" do
         expect(page).to have_content("2020")
         expect(page).not_to have_content("Not finished yet")
         expect(page).not_to have_content("Yes")
-      end
-
-      it "allows jobseekers to add a custom secondary qualification" do
-        click_on "Add qualifications"
-        select_qualification_category("Other secondary qualification")
-        expect(page).to have_content(I18n.t("jobseekers.job_applications.qualifications.new.heading.other_secondary"))
-        validates_step_complete(button: I18n.t("buttons.save_qualification.other"))
-        fill_in_custom_secondary_qualifications
-        click_on I18n.t("buttons.save_qualification.other")
-        expect(current_path).to eq(review_jobseekers_profile_qualifications_path)
-        expect(page).to have_content("Welsh Baccalaureate")
-        expect(page).to have_content("Happy Rainbows School for High Achievers")
-        expect(page).to have_content("Science – 5")
-        expect(page).to have_content("German – 4")
-        expect(page).to have_content("2020")
       end
     end
   end

--- a/spec/system/jobseekers/jobseekers_can_add_qualifications_to_their_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_qualifications_to_their_profile_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Jobseekers can add qualifications to their profile" do
 
       it "allows jobseekers to add a custom qualification or course (category 'other')" do
         click_on "Add qualifications"
-        select_qualification_category("Other qualification or course")
+        select_qualification_category("Other qualification")
         expect(page).to have_content(I18n.t("jobseekers.profiles.qualifications.new.heading.other"))
         validates_step_complete(button: I18n.t("buttons.save_qualification.one"))
         fill_in_other_qualification


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/W6CAivdA/1442-updates-to-other-qualifications-journey-application-profiles

## Changes in this PR:

This PR:

- adds a migration to delete qualifications with category "other_secondary" and replace them with qualifications with category "other" for each of the results.
- adds a new field to "other" qualifications to allow users to enter the awarding body.
- removes "other_secondary" qualifications option from qualifications form.
- changes some content on the other qualifications page.

Notes: 

I have written the logic in a service class just so I could easily test the migration logic for peace of mind. We can delete all these files once the changes to qualifications (removing the 'other_secondary' qualification category for example) have been made and the migration is run.

I cannot remove all the references to "other_secondary" qualifications until after the migration is run so I will need to create a follow up PR to remove these and delete the migration class/spec/rake task.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
