### PR TITLE
Precompute Centroid for polygon areas

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -208,6 +208,7 @@ shared:
     - name
     - location_type
     - area
+    - centroid
     - created_at
     - updated_at
   notifications:

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -116,29 +116,6 @@
       "note": ""
     },
     {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "549d2779be79702f98156c6ec1a388b35ff19d87b0978910d4fad9d59a424cb9",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/services/ons_data_import/create_composites.rb",
-      "line": 14,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "ActiveRecord::Base.connection.exec_update(\"\\n        UPDATE location_polygons\\n        SET area=(\\n              SELECT ST_Union(area::geometry)::geography\\n              FROM location_polygons\\n              WHERE name IN (#{constituents.map do\n ActiveRecord::Base.connection.quote(c.downcase)\n end.join(\", \")})\\n            ),\\n            location_type='composite'\\n        WHERE id='#{LocationPolygon.find_or_create_by(:name => name).id}'\\n      \")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "OnsDataImport::CreateComposites",
-        "method": "call"
-      },
-      "user_input": "constituents.map do\n ActiveRecord::Base.connection.quote(c.downcase)\n end.join(\", \")",
-      "confidence": "Medium",
-      "cwe_id": [
-        89
-      ],
-      "note": "This is our own static data with no user input provided in the query"
-    },
-    {
       "warning_type": "Unscoped Find",
       "warning_code": 82,
       "fingerprint": "58f3df7253d0dfa30ca15dd14b17c6e3c5f8f5760b5363c3df49a692a1c74195",
@@ -215,6 +192,29 @@
       "confidence": "Weak",
       "cwe_id": [
         285
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "b2035069089eae3a5d8ec3a3a615aee253ec3cf2cd68c5535af152b8de779f46",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/services/ons_data_import/create_composites.rb",
+      "line": 13,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "ActiveRecord::Base.connection.exec_update(\"\\n        WITH composite_area AS (\\n          SELECT ST_Union(area::geometry)::geography AS geo\\n          FROM location_polygons\\n          WHERE name IN (#{constituents.map do\n ActiveRecord::Base.connection.quote(c.downcase)\n end.join(\", \")})\\n        )\\n        UPDATE location_polygons\\n        SET area=composite_area.geo,\\n            location_type='composite',\\n            centroid=ST_Centroid(composite_area.geo)\\n        FROM composite_area\\n        WHERE id='#{LocationPolygon.find_or_create_by(:name => name).id}'\\n      \")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "OnsDataImport::CreateComposites",
+        "method": "call"
+      },
+      "user_input": "constituents.map do\n ActiveRecord::Base.connection.quote(c.downcase)\n end.join(\", \")",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
       ],
       "note": ""
     },

--- a/db/migrate/20250114180542_add_centroid_to_location_polygons.rb
+++ b/db/migrate/20250114180542_add_centroid_to_location_polygons.rb
@@ -1,0 +1,8 @@
+class AddCentroidToLocationPolygons < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_column :location_polygons, :centroid, :st_point, geographic: true
+    add_index :location_polygons, :centroid, using: :gist, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -77,11 +77,11 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_17_112840) do
     t.uuid "job_application_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "employment_type", default: 0
-    t.text "reason_for_break", default: ""
     t.text "organisation_ciphertext"
     t.text "job_title_ciphertext"
     t.text "main_duties_ciphertext"
+    t.integer "employment_type", default: 0
+    t.text "reason_for_break", default: ""
     t.uuid "jobseeker_profile_id"
     t.text "reason_for_leaving"
     t.index ["job_application_id"], name: "index_employments_on_job_application_id"
@@ -312,9 +312,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_17_112840) do
     t.date "account_closed_on"
     t.text "current_sign_in_ip_ciphertext"
     t.text "last_sign_in_ip_ciphertext"
+    t.string "govuk_one_login_id"
     t.string "account_merge_confirmation_code"
     t.datetime "account_merge_confirmation_code_generated_at"
-    t.string "govuk_one_login_id"
     t.index ["email"], name: "index_jobseekers_on_email", unique: true
     t.index ["govuk_one_login_id"], name: "index_jobseekers_on_govuk_one_login_id", unique: true
   end
@@ -333,7 +333,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_17_112840) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.geography "area", limit: {:srid=>4326, :type=>"geometry", :geographic=>true}
+    t.geography "centroid", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}
     t.index ["area"], name: "index_location_polygons_on_area", using: :gist
+    t.index ["centroid"], name: "index_location_polygons_on_centroid", using: :gist
     t.index ["name"], name: "index_location_polygons_on_name"
   end
 
@@ -697,8 +699,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_17_112840) do
     t.boolean "include_additional_documents"
     t.boolean "visa_sponsorship_available"
     t.boolean "is_parental_leave_cover"
-    t.boolean "is_job_share"
     t.string "hourly_rate"
+    t.boolean "is_job_share"
     t.string "flexi_working"
     t.integer "extension_reason"
     t.string "other_extension_reason_details"

--- a/lib/tasks/backfill_location_polygons_centroid.rake
+++ b/lib/tasks/backfill_location_polygons_centroid.rake
@@ -1,0 +1,6 @@
+namespace :location_polygons do
+  desc "Computes and set centroid on location polygons containing an area but no centroid"
+  task backfill_centroid: :environment do
+    LocationPolygon.where.not(area: nil).where(centroid: nil).update_all("centroid = ST_Centroid(area)")
+  end
+end

--- a/spec/factories/location_polygons.rb
+++ b/spec/factories/location_polygons.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     name { "London" }
     location_type { "cities" }
     area { "POLYGON((0 0, 1 1, 0 1, 0 0))" }
+    centroid { "POINT(0.33331264776372055 0.6666929898148579)" }
   end
 end

--- a/spec/tasks/backfill_location_polygons_centroid_spec.rb
+++ b/spec/tasks/backfill_location_polygons_centroid_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe "location_polygons:backfill_centroid" do
+  let(:area) { "POLYGON((0 0, 1 1, 0 1, 0 0))" }
+  let(:centroid) { "POINT(0.33331264776372055 0.6666929898148579)" }
+
+  it "computes and sets the centroid on location polygons containing an area but no centroid" do
+    location_polygon = create(:location_polygon, area: area, centroid: nil)
+
+    expect { task.invoke }.to change { location_polygon.reload.centroid }.from(nil).to(
+      RGeo::Geographic.spherical_factory(srid: 4326).parse_wkt(centroid),
+    )
+  end
+
+  it "does not update the centroid if it is already set" do
+    location_polygon = create(:location_polygon, area: area, centroid: centroid)
+
+    expect { task.invoke }.not_to(change { location_polygon.reload.centroid })
+  end
+
+  it "does not update the centroid if the area is nil" do
+    location_polygon = create(:location_polygon, area: nil, centroid: nil)
+
+    expect { task.invoke }.not_to(change { location_polygon.reload.centroid })
+  end
+end


### PR DESCRIPTION
## Trello ticket
https://trello.com/c/cf3f17rU/1528-use-precomputed-centroid-of-locationpolygons-areas

## Description

The centroid is used to calculate the distances on the vacancy searches.

The centroid for a polygon area doesn't change unless the area changes too.

As we dynamically calculate it for every location polygon area against every vacancy during the searches, if we pre-compute it we save the DB to execute again the centroid calculation on every search.

**This is the first step in pre-computing and storing it in DB.**
Further work will follow:
- Use the pre-computed values on the location searches.
- Fix possible issues when searching over polygons without area/centroid.
- Legacy Polygons maintenance.