### PR TITLE
Enable Analytics federated auth

### DIFF
--- a/terraform/workspace-variables/production.tfvars.json
+++ b/terraform/workspace-variables/production.tfvars.json
@@ -80,6 +80,6 @@
     "start_minute": 0
   },
   "enable_logit": true,
-  "enable_dfe_analytics_federated_auth": false,
+  "enable_dfe_analytics_federated_auth": true,
   "dataset_name": "production_dataset"
 }


### PR DESCRIPTION
Devops ticket:
- https://trello.com/c/yqj8hYRR

Related to:
- https://github.com/DFE-Digital/teaching-vacancies/pull/7403
- https://github.com/DFE-Digital/teaching-vacancies/pull/7406

The original attempt to enable it caused issues with our Google Api Client triggering ["PERMISSION_DENIED: Request had insufficient authentication scopes. (Google::Apis::ClientError)"](https://teaching-vacancies.sentry.io/issues/6202542283/?environment=production&project=6212514&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=7d&stream_index=18).
We have removed the "analytics" scope from Google Api client, as it was unnecessary for our current use of the API:
https://github.com/DFE-Digital/teaching-vacancies/pull/7407/files

After re-enabling it, we will monitor if the Indexing jobs fail again and revert if necessary (failed indexing jobs can be re-triggered in sidekiq, there is no risk to impact users here).