### PR TITLE
Revert "Enable Analytics federated auth"

### DIFF
--- a/terraform/workspace-variables/production.tfvars.json
+++ b/terraform/workspace-variables/production.tfvars.json
@@ -80,6 +80,6 @@
     "start_minute": 0
   },
   "enable_logit": true,
-  "enable_dfe_analytics_federated_auth": true,
+  "enable_dfe_analytics_federated_auth": false,
   "dataset_name": "production_dataset"
 }


### PR DESCRIPTION
Reverts DFE-Digital/teaching-vacancies#7420

Google API connections keep failing if we enable this flag.