### PR TITLE
personal statement content tweaks

### DIFF
--- a/app/views/jobseekers/job_applications/build/personal_statement.html.slim
+++ b/app/views/jobseekers/job_applications/build/personal_statement.html.slim
@@ -13,7 +13,7 @@
         div class="govuk-!-margin-top-3"
           = render SupportingDocumentComponent.with_collection(job_application.vacancy.supporting_documents)
       - else
-        = t(".banner_no_documents_html", job_link: open_in_new_tab_link_to("‘#{job_application.vacancy.job_title}’ #{t(".job_description")}", job_path(job_application.vacancy)))
+        = t(".banner_no_documents_html", job_link: open_in_new_tab_link_to("‘#{job_application.vacancy.job_title}’ #{t('.job_description')}", job_path(job_application.vacancy)))
 
     h2.govuk-heading-l = t(".applying_for_a_teaching_role")
 

--- a/app/views/jobseekers/job_applications/build/personal_statement.html.slim
+++ b/app/views/jobseekers/job_applications/build/personal_statement.html.slim
@@ -3,11 +3,11 @@
 = render "banner", vacancy: vacancy, back_path: back_path
 
 .govuk-grid-row
-  .govuk-grid-column-two-thirds
+  div
     h2.govuk-heading-l = t(".heading")
     p.govuk-body = t(".description")
 
-    = govuk_notification_banner title_text: t(".banner_title") do
+    p.govuk-body
       - if job_application.vacancy.supporting_documents.any?
         = t(".banner_documents_html", job_link: open_in_new_tab_link_to("‘#{job_application.vacancy.job_title}’", job_path(job_application.vacancy)))
         div class="govuk-!-margin-top-3"
@@ -15,12 +15,19 @@
       - else
         = t(".banner_no_documents_html", job_link: open_in_new_tab_link_to("‘#{job_application.vacancy.job_title}’", job_path(job_application.vacancy)))
 
-    .help-guide--mobile
-      h3.govuk-heading-m = t(".personal_statement_guide.title")
-      p.govuk-body = t(".personal_statement_guide.description_mobile")
-      = govuk_link_to(t(".personal_statement_guide.link_text"),
-                      post_path(section: "jobseeker-guides", subcategory: "get-help-applying-for-your-teaching-role", post_name: "how-to-write-teacher-personal-statement"),
-                      class: "govuk-link--no-visited-state")
+    h2.govuk-heading-l = t(".applying_for_a_teaching_role")
+
+    p.govuk-body = t(".you_could_provide")
+
+    ul
+      - t(".bullets").each do |b|
+        li = b
+
+    p.govuk-body
+      = t(".personal_statement_preamble")
+      = govuk_link_to(t(".personal_statement_link_text"),
+        post_path(section: "jobseeker-guides", subcategory: "get-help-applying-for-your-teaching-role", post_name: "how-to-write-teacher-personal-statement"),
+        class: "govuk-link--no-visited-state")
 
     - if job_application.vacancy.personal_statement_guidance.present?
       h3.govuk-heading-s = t(".additional_instructions")
@@ -29,7 +36,7 @@
     = form_for form, url: jobseekers_job_application_build_path(job_application, :personal_statement), method: :patch do |f|
       = f.govuk_error_summary
 
-      = f.govuk_text_area :personal_statement, label: { size: "s" }, rows: 15, required: true, aria: { required: true }, hint: { text: t(".hint") }
+      = f.govuk_text_area :personal_statement, label: { size: "s" }, rows: 15, required: true, aria: { required: true }
 
       = f.govuk_collection_radio_buttons :personal_statement_section_completed, %w[true false], :to_s
 
@@ -37,11 +44,3 @@
         = govuk_link_to t("buttons.cancel_and_return_to_account"), jobseekers_job_applications_path, class: "govuk-link--no-visited-state"
         span.govuk-caption-m
           = t("jobseekers.job_applications.cancel_caption")
-
-  .govuk-grid-column-one-third
-    .help-guide--desktop class="govuk-!-margin-top-6"
-      h3.govuk-heading-m = t(".personal_statement_guide.title")
-      p.govuk-body = t(".personal_statement_guide.description_desktop")
-      = govuk_link_to(t(".personal_statement_guide.link_text"),
-                      post_path(section: "jobseeker-guides", subcategory: "get-help-applying-for-your-teaching-role", post_name: "how-to-write-teacher-personal-statement"),
-                      class: "govuk-link--no-visited-state")

--- a/app/views/jobseekers/job_applications/build/personal_statement.html.slim
+++ b/app/views/jobseekers/job_applications/build/personal_statement.html.slim
@@ -13,7 +13,7 @@
         div class="govuk-!-margin-top-3"
           = render SupportingDocumentComponent.with_collection(job_application.vacancy.supporting_documents)
       - else
-        = t(".banner_no_documents_html", job_link: open_in_new_tab_link_to("‘#{job_application.vacancy.job_title}’", job_path(job_application.vacancy)))
+        = t(".banner_no_documents_html", job_link: open_in_new_tab_link_to("‘#{job_application.vacancy.job_title}’ #{t(".job_description")}", job_path(job_application.vacancy)))
 
     h2.govuk-heading-l = t(".applying_for_a_teaching_role")
 
@@ -25,7 +25,7 @@
 
     p.govuk-body
       = t(".personal_statement_preamble")
-      = govuk_link_to(t(".personal_statement_link_text"),
+      = open_in_new_tab_link_to(t(".personal_statement_link_text"),
         post_path(section: "jobseeker-guides", subcategory: "get-help-applying-for-your-teaching-role", post_name: "how-to-write-teacher-personal-statement"),
         class: "govuk-link--no-visited-state")
 

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -195,9 +195,10 @@ en:
           banner_documents_html: >-
             Documents supplied with %{job_link} listing that may be of some help with your personal statement.
           banner_no_documents_html: >-
-            It may be helpful to refer back to %{job_link} when writing your personal statement.
+            It may be helpful to refer back to %{job_link} and include any relevant personal qualities and experiences.
           description: >-
             Explain why you are suitable for this role.
+          job_description: job description
           heading: Personal statement
           applying_for_a_teaching_role: If you're applying for a teaching role
           you_could_provide: "You could include information about:"

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -197,17 +197,21 @@ en:
           banner_no_documents_html: >-
             It may be helpful to refer back to %{job_link} when writing your personal statement.
           description: >-
-            Please explain why you are suitable for this role. You should refer to the person specification in the job
-            description, and include any relevant personal qualities and experiences.
+            Explain why you are suitable for this role.
           heading: Personal statement
-          personal_statement_guide:
-            description_desktop: Find out how to sell your skills and experience to school recruiters.
-            description_mobile: Get guidance around creating the perfect personal statement.
-            link_text: How to write a teacher personal statement
-            title: How to write a teacher personal statement
+          applying_for_a_teaching_role: If you're applying for a teaching role
+          you_could_provide: "You could include information about:"
+          personal_statement_preamble: "Get advice from experienced teachers and school leaders on "
+          bullets:
+            - your teaching and classroom management style
+            - your knowledge of the curriculum
+            - your understanding of safeguarding and student wellbeing
+            - additional responsibilities you’ve taken on in school
+            - experience in special educational needs and disability (SEND)
+            - any relevant interests or extra-curricular activities
+          personal_statement_link_text: writing your personal statement
           step_title: Personal statement
           title: Personal statement — Application
-          hint: You can copy and paste bullet points into the text box.
         process_title: Application steps
         professional_status:
           heading: Professional status


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/fZgNC7OW/1494-content-tweaks-on-personal-statement-section-of-application

## Changes in this PR:

New content for personal statement page

## Screenshots of UI changes:

### Before
![Persnalstatementybefore](https://github.com/user-attachments/assets/02152d2d-47e4-47d2-aabe-b18aac579149)


### After
![PersonalStatementAfter](https://github.com/user-attachments/assets/6be6b614-b517-4643-a6cc-bddc941e1101)


## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
