### PR TITLE
Increase production DB resources

### DIFF
--- a/documentation/alert-runbook.md
+++ b/documentation/alert-runbook.md
@@ -35,7 +35,7 @@ make production logs CONFIRM_PRODUCTION=YES
 Most AKS settings are in [production.tfvars.json](../terraform/workspace-variables/production.tfvars.json)
 
 ```
-postgres_flexible_server_sku      = "GP_Standard_D2ds_v4"
+postgres_flexible_server_sku      = "GP_Standard_D4ds_v5"
 postgres_enable_high_availability = true
 redis_queue_sku_name              = "Premium"
 aks_web_app_instances             = 8

--- a/terraform/workspace-variables/production.tfvars.json
+++ b/terraform/workspace-variables/production.tfvars.json
@@ -24,7 +24,7 @@
   "cluster": "production",
   "namespace": "tv-production",
   "enable_monitoring": true,
-  "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
+  "postgres_flexible_server_sku": "GP_Standard_D4ds_v5",
   "postgres_enable_high_availability": true,
   "redis_cache_capacity": 1,
   "redis_cache_family": "P",


### PR DESCRIPTION
The DB CPU struggles with some spatial queries, causing punctual AKS Pod restarts and Service downtime.

Since we keep all our searching withing the DB, and we have PostGIS extension, doing extensive location searching and ordering, having the basic DB tier with 2CPUs is proving insufficient for CPU-heavy polygon distances calculations against thousands of vacancies.

Prior to this change, we have explored that the queries are not missing any indices and attempted other tweaks.
