### PR TITLE
Rework update profile

### DIFF
--- a/app/controllers/jobseekers/job_applications/feedbacks_controller.rb
+++ b/app/controllers/jobseekers/job_applications/feedbacks_controller.rb
@@ -1,6 +1,8 @@
 class Jobseekers::JobApplications::FeedbacksController < Jobseekers::BaseController
   helper_method :vacancy
 
+  before_action :set_job_application
+
   def create
     @application_feedback_form = Jobseekers::JobApplication::FeedbackForm.new(feedback_form_params)
 
@@ -8,7 +10,7 @@ class Jobseekers::JobApplications::FeedbacksController < Jobseekers::BaseControl
       Feedback.create(feedback_attributes)
       redirect_to jobseekers_job_applications_path, success: t(".success")
     else
-      render "jobseekers/job_applications/submit"
+      render "jobseekers/job_applications/post_submit"
     end
   end
 
@@ -20,17 +22,17 @@ class Jobseekers::JobApplications::FeedbacksController < Jobseekers::BaseControl
 
   def feedback_attributes
     feedback_form_params.merge(
-      job_application_id: job_application.id,
+      job_application_id: @job_application.id,
       feedback_type: "application",
       jobseeker_id: current_jobseeker.id,
     )
   end
 
-  def job_application
-    @job_application ||= current_jobseeker.job_applications.find(params[:job_application_id])
+  def set_job_application
+    @job_application = current_jobseeker.job_applications.find(params[:job_application_id])
   end
 
   def vacancy
-    @vacancy ||= job_application.vacancy
+    @vacancy ||= @job_application.vacancy
   end
 end

--- a/app/controllers/jobseekers/job_applications_controller.rb
+++ b/app/controllers/jobseekers/job_applications_controller.rb
@@ -129,9 +129,11 @@ class Jobseekers::JobApplicationsController < Jobseekers::JobApplications::BaseC
     profile = job_application.jobseeker.jobseeker_profile
     return unless profile.present?
 
-    profile.replace_qualifications!(job_application.qualifications.map(&:duplicate)) if form.update_profile_qualifications?
-    profile.replace_employments!(job_application.employments.map(&:duplicate)) if form.update_profile_work_history?
-    profile.replace_training_and_cpds!(job_application.training_and_cpds.map(&:duplicate)) if form.update_profile_training_and_cpds?
+    if form.update_profile?
+      profile.replace_qualifications!(job_application.qualifications.map(&:duplicate))
+      profile.replace_employments!(job_application.employments.map(&:duplicate))
+      profile.replace_training_and_cpds!(job_application.training_and_cpds.map(&:duplicate))
+    end
   end
 
   def all_steps_valid?

--- a/app/form_models/jobseekers/job_application/review_form.rb
+++ b/app/form_models/jobseekers/job_application/review_form.rb
@@ -1,18 +1,15 @@
-class Jobseekers::JobApplication::ReviewForm < Jobseekers::JobApplication::PreSubmitForm
-  attr_accessor :confirm_data_accurate, :confirm_data_usage, :update_profile
+module Jobseekers
+  module JobApplication
+    class ReviewForm < PreSubmitForm
+      attr_accessor :confirm_data_accurate, :confirm_data_usage
 
-  validates_acceptance_of :confirm_data_accurate, :confirm_data_usage,
-                          acceptance: true,
-                          if: :all_steps_completed?
-  def update_profile_qualifications?
-    update_profile&.include?("qualifications")
-  end
+      validates_acceptance_of :confirm_data_accurate, :confirm_data_usage,
+                              acceptance: true,
+                              if: :all_steps_completed?
 
-  def update_profile_work_history?
-    update_profile&.include?("work_history")
-  end
+      include ActiveModel::Attributes
 
-  def update_profile_training_and_cpds?
-    update_profile&.include?("training_and_cpds")
+      attribute :update_profile, :boolean
+    end
   end
 end

--- a/app/views/jobseekers/job_applications/post_submit.html.slim
+++ b/app/views/jobseekers/job_applications/post_submit.html.slim
@@ -11,11 +11,9 @@ div
 
     p.govuk-body = t(".next_step.profile_update")
 
-    p.govuk-grid-row
-      .govuk-grid-column-one-half
-        = govuk_button_link_to t(".next_step.show_application"), jobseekers_job_application_path(@job_application), class: "govuk-button--secondary"
-      .govuk-grid-column-one-half
-        = govuk_button_link_to t(".next_step.view_applications"), jobseekers_job_applications_path, class: "govuk-button--secondary"
+    .govuk-button-group
+      = govuk_button_link_to t(".next_step.show_application"), jobseekers_job_application_path(@job_application), class: "govuk-button--secondary"
+      = govuk_button_link_to t(".next_step.view_applications"), jobseekers_job_applications_path, class: "govuk-button--secondary"
 
     h2.govuk-heading-m = t(".candidate_profile.heading")
     p.govuk-body = t(".candidate_profile.text")

--- a/app/views/jobseekers/job_applications/post_submit.html.slim
+++ b/app/views/jobseekers/job_applications/post_submit.html.slim
@@ -1,7 +1,7 @@
 - content_for :page_title_prefix, job_application_page_title_prefix(@application_feedback_form, t(".title"))
 
-.govuk-grid-row
-  .govuk-grid-column-two-thirds
+div
+  div
     = govuk_panel title_text: t(".panel.title"), text: t(".panel.body", email: current_jobseeker.email)
 
     h2.govuk-heading-l class="govuk-!-margin-top-5"
@@ -11,7 +11,15 @@
 
     p.govuk-body = t(".next_step.profile_update")
 
-    = govuk_button_link_to t(".next_step.view_applications"), jobseekers_job_applications_path, class: "govuk-button--secondary govuk-!-margin-bottom-3"
+    p.govuk-grid-row
+      .govuk-grid-column-one-half
+        = govuk_button_link_to t(".next_step.show_application"), jobseekers_job_application_path(@job_application), class: "govuk-button--secondary"
+      .govuk-grid-column-one-half
+        = govuk_button_link_to t(".next_step.view_applications"), jobseekers_job_applications_path, class: "govuk-button--secondary"
+
+    h2.govuk-heading-m = t(".candidate_profile.heading")
+    p.govuk-body = t(".candidate_profile.text")
+    = govuk_button_link_to t(".next_step.show_profile"), jobseekers_profile_path, class: "govuk-button--secondary govuk-!-margin-bottom-0"
 
     hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
 

--- a/app/views/jobseekers/job_applications/post_submit.html.slim
+++ b/app/views/jobseekers/job_applications/post_submit.html.slim
@@ -1,40 +1,39 @@
 - content_for :page_title_prefix, job_application_page_title_prefix(@application_feedback_form, t(".title"))
 
-div
-  div
-    = govuk_panel title_text: t(".panel.title"), text: t(".panel.body", email: current_jobseeker.email)
+= govuk_panel title_text: t(".panel.title"), text: t(".panel.body", email: current_jobseeker.email)
 
-    h2.govuk-heading-l class="govuk-!-margin-top-5"
-      = t(".next_step.heading")
+h2.govuk-heading-l class="govuk-!-margin-top-5"
+  = t(".next_step.heading")
 
-    p.govuk-body = t(".next_step.shortlisted", organisation: vacancy.organisation_name)
+p.govuk-body = t(".next_step.shortlisted", organisation: vacancy.organisation_name)
 
-    p.govuk-body = t(".next_step.profile_update")
+p.govuk-body = t(".next_step.profile_update")
 
-    .govuk-button-group
-      = govuk_button_link_to t(".next_step.show_application"), jobseekers_job_application_path(@job_application), class: "govuk-button--secondary"
-      = govuk_button_link_to t(".next_step.view_applications"), jobseekers_job_applications_path, class: "govuk-button--secondary"
+.govuk-button-group
+  = govuk_button_link_to t(".next_step.show_application"), jobseekers_job_application_path(@job_application), class: "govuk-button--secondary"
+  = govuk_button_link_to t(".next_step.view_applications"), jobseekers_job_applications_path, class: "govuk-button--secondary"
 
-    h2.govuk-heading-m = t(".candidate_profile.heading")
-    p.govuk-body = t(".candidate_profile.text")
-    = govuk_button_link_to t(".next_step.show_profile"), jobseekers_profile_path, class: "govuk-button--secondary govuk-!-margin-bottom-0"
+- if current_jobseeker.jobseeker_profile.present?
+  h2.govuk-heading-m = t(".candidate_profile.heading")
+  p.govuk-body = t(".candidate_profile.text")
+  = govuk_button_link_to t(".next_step.show_profile"), jobseekers_profile_path, class: "govuk-button--secondary govuk-!-margin-bottom-0"
 
-    hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
+hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
 
-    = form_for @application_feedback_form, url: jobseekers_job_application_feedback_path(anchor: "new_jobseekers_job_application_feedback_form") do |f|
-      = f.govuk_error_summary
+= form_for @application_feedback_form, url: jobseekers_job_application_feedback_path(anchor: "new_jobseekers_job_application_feedback_form") do |f|
+  = f.govuk_error_summary
 
-      h2.govuk-heading-m = t(".feedback.heading")
-      p.govuk-body = t(".feedback.description")
+  h2.govuk-heading-m = t(".feedback.heading")
+  p.govuk-body = t(".feedback.description")
 
-      = f.govuk_collection_radio_buttons :rating, Feedback.ratings.keys, :to_s
+  = f.govuk_collection_radio_buttons :rating, Feedback.ratings.keys, :to_s
 
-      = f.govuk_text_area :comment, label: { size: "s" }, rows: 10, max_chars: 1200
+  = f.govuk_text_area :comment, label: { size: "s" }, rows: 10, max_chars: 1200
 
-      = f.govuk_radio_buttons_fieldset(:user_participation_response, legend: { size: "s" }) do
-        = f.govuk_radio_button :user_participation_response, :interested, link_errors: true do
-          = f.govuk_email_field :email, value: @application_feedback_form.email.presence || current_jobseeker.email, required: true
-          = f.govuk_text_area :occupation, required: true, rows: 1
-        = f.govuk_radio_button :user_participation_response, :uninterested
+  = f.govuk_radio_buttons_fieldset(:user_participation_response, legend: { size: "s" }) do
+    = f.govuk_radio_button :user_participation_response, :interested, link_errors: true do
+      = f.govuk_email_field :email, value: @application_feedback_form.email.presence || current_jobseeker.email, required: true
+      = f.govuk_text_area :occupation, required: true, rows: 1
+    = f.govuk_radio_button :user_participation_response, :uninterested
 
-      = f.govuk_submit t("buttons.submit_feedback")
+  = f.govuk_submit t("buttons.submit_feedback")

--- a/app/views/jobseekers/job_applications/review.html.slim
+++ b/app/views/jobseekers/job_applications/review.html.slim
@@ -22,13 +22,9 @@
         = f.govuk_error_summary
 
         - if current_jobseeker.jobseeker_profile.present?
-          = f.govuk_check_boxes_fieldset(:update_profile,
-                                         multiple: true,
-                                         legend: { text: t(".confirmation.update_your_profile.heading"), size: "m" },
-                                         hint: { text: t(".confirmation.update_your_profile.hint") }) do
-            = f.govuk_check_box :update_profile, "qualifications"
-            = f.govuk_check_box :update_profile, "work_history"
-            = f.govuk_check_box :update_profile, "training_and_cpds"
+          = f.govuk_check_boxes_fieldset(:update_profile) do
+            p.govuk-body = open_in_new_tab_link_to t(".view_your_profile"), jobseekers_profile_path
+            = f.govuk_check_box :update_profile, "1"
 
         h3.govuk-heading-m = t(".confirmation.heading")
 

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -565,12 +565,6 @@ en:
             incomplete: Complete your religious information
           professional_body_memberships:
             incomplete: Complete your professional body memberships
-        jobseekers/job_application/review_form:
-          attributes:
-            confirm_data_accurate:
-              accepted:  You must confirm that your information is accurate and complete
-            confirm_data_usage:
-              accepted: You must consent to share your data in order to apply for this job
         jobseekers/job_application/withdraw_form:
           attributes:
             withdraw_reason:

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -432,15 +432,6 @@ en:
         training_and_cpds_section_completed_options:
           false: No, I'll come back to it later
           true: Yes, I've completed this section
-      jobseekers_job_application_review_form:
-        update_profile_options:
-          qualifications: Update qualifications on profile
-          work_history: Update work history on profile
-          training_and_cpds: Update training and CPD on profile
-        confirm_data_accurate_options:
-          "1": I confirm that the above information is accurate and complete
-        confirm_data_usage_options:
-          "1": I consent to my data being shared with these organisations
       jobseekers_job_application_withdraw_form:
         withdraw_reason_options:
           another_role: I have found another role

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -494,6 +494,7 @@ en:
         relationship: Relationship to applicant
         is_most_recent_employer: Current or most recent employer
       review:
+        view_your_profile: View your profile
         confirmation:
           heading: Confirmation
           update_your_profile:

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -599,7 +599,7 @@ en:
         submitted: Application submitted
         unsuccessful: Unsuccessful
         withdrawn: Withdrawn
-      submit:
+      post_submit:
         feedback:
           description: >-
             Your feedback can help us improve the service to better support you as well as schools around England.
@@ -609,8 +609,15 @@ en:
           shortlisted: >-
             If you are shortlisted for an interview %{organisation} will be in touch to let you know.
           profile_update: >-
-            Your profile will match the information you supplied in your application if you chose to update it.
-          view_applications: View your applications
+            Your application information will be saved so that you can use it when you next apply for a role.
+          view_applications: Return to all applications
+          show_application: Print or download your application
+          show_profile: View your profile
+        candidate_profile:
+          heading: Your candidate profile
+          text: >-
+            Your application information is also saved in your candidate profile. If you turn on your profile,
+            schools will be able to view it and contact you about roles.
         panel:
           body: We have sent an email confirmation to %{email}
           title: Your application has been submitted

--- a/config/locales/jobseekers/job_application/review_form.yml
+++ b/config/locales/jobseekers/job_application/review_form.yml
@@ -1,0 +1,27 @@
+en:
+  activemodel:
+    errors:
+      models:
+        jobseekers/job_application/review_form:
+          attributes:
+            confirm_data_accurate:
+              accepted:  You must confirm that your information is accurate and complete
+            confirm_data_usage:
+              accepted: You must consent to share your data in order to apply for this job
+  helpers:
+    legend:
+      jobseekers_job_application_review_form:
+        update_profile: Update your profile
+
+    hint:
+      jobseekers_job_application_review_form:
+        update_profile: If you turn on your profile, schools can use it to contact you about roles. You can update your existing profile to match this application.
+
+    label:
+      jobseekers_job_application_review_form:
+        update_profile_options:
+          "1": Update my profile
+        confirm_data_accurate_options:
+          "1": I confirm that the above information is accurate and complete
+        confirm_data_usage_options:
+          "1": I consent to my data being shared with these organisations

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,6 +105,7 @@ Rails.application.routes.draw do
       get :confirm_destroy
       get :confirm_withdraw
       post :submit
+      get :post_submit
       post :withdraw
       resource :feedback, only: %i[create], controller: "job_applications/feedbacks"
     end

--- a/spec/system/jobseekers/jobseekers_can_complete_a_religious_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_complete_a_religious_job_application_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe "Jobseekers can complete a religious job application" do
               check I18n.t("helpers.label.jobseekers_job_application_review_form.confirm_data_accurate_options.1")
               check I18n.t("helpers.label.jobseekers_job_application_review_form.confirm_data_usage_options.1")
               click_on I18n.t("buttons.submit_application")
-              click_on "View your applications"
+              click_on I18n.t("jobseekers.job_applications.post_submit.next_step.view_applications")
               expect(page).to have_content(vacancy.job_title)
             end
           end
@@ -140,7 +140,7 @@ RSpec.describe "Jobseekers can complete a religious job application" do
               check I18n.t("helpers.label.jobseekers_job_application_review_form.confirm_data_accurate_options.1")
               check I18n.t("helpers.label.jobseekers_job_application_review_form.confirm_data_usage_options.1")
               click_on I18n.t("buttons.submit_application")
-              click_on "View your applications"
+              click_on I18n.t("jobseekers.job_applications.post_submit.next_step.view_applications")
               expect(page).to have_content(vacancy.job_title)
             end
           end
@@ -226,7 +226,7 @@ RSpec.describe "Jobseekers can complete a religious job application" do
             expect(page).to have_content(I18n.t("jobseekers.job_applications.build.references.heading"))
             complete_from_references_page
             submit_application_from_review
-            expect(page).to have_content(I18n.t("jobseekers.job_applications.submit.panel.title"))
+            expect(page).to have_content(I18n.t("jobseekers.job_applications.post_submit.panel.title"))
           end
         end
 
@@ -260,7 +260,7 @@ RSpec.describe "Jobseekers can complete a religious job application" do
                 expect(page).to have_content(I18n.t("jobseekers.job_applications.build.references.heading"))
                 complete_from_references_page
                 submit_application_from_review
-                expect(page).to have_content(I18n.t("jobseekers.job_applications.submit.panel.title"))
+                expect(page).to have_content(I18n.t("jobseekers.job_applications.post_submit.panel.title"))
               end
             end
 
@@ -282,7 +282,7 @@ RSpec.describe "Jobseekers can complete a religious job application" do
                 click_on I18n.t("buttons.save_and_continue")
                 complete_from_references_page
                 submit_application_from_review
-                expect(page).to have_content(I18n.t("jobseekers.job_applications.submit.panel.title"))
+                expect(page).to have_content(I18n.t("jobseekers.job_applications.post_submit.panel.title"))
               end
             end
           end

--- a/spec/system/jobseekers/jobseekers_can_submit_a_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_submit_a_job_application_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Jobseekers can submit a job application" do
         .to change { JobApplication.first.status }.from("draft").to("submitted")
         .and change { delivered_emails.count }.by(1)
 
-      expect(page).to have_content(I18n.t("jobseekers.job_applications.submit.panel.title"))
+      expect(page).to have_content(I18n.t("jobseekers.job_applications.post_submit.panel.title"))
 
       visit first_link_from_last_mail
       expect(current_path).to eq(jobseekers_job_applications_path)

--- a/spec/system/jobseekers/jobseekers_can_update_their_profile_from_job_applications_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_update_their_profile_from_job_applications_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Jobseekers can update their profile from job applications" do
     scenario "jobseekers can update their profile qualifications using the job application information on submission" do
       check I18n.t("helpers.label.jobseekers_job_application_review_form.update_profile_options.1")
       click_on I18n.t("buttons.submit_application")
-      expect(page).to have_content(I18n.t("jobseekers.job_applications.submit.panel.title"))
+      expect(page).to have_content(I18n.t("jobseekers.job_applications.post_submit.panel.title"))
 
       click_link "Your profile"
       expect(page).to have_css("h3.govuk-summary-card__title", text: "Application qualification")

--- a/spec/system/jobseekers/jobseekers_can_update_their_profile_from_job_applications_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_update_their_profile_from_job_applications_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Jobseekers can update their profile from job applications" do
     after { logout }
 
     scenario "jobseekers can update their profile qualifications using the job application information on submission" do
-      check I18n.t("helpers.label.jobseekers_job_application_review_form.update_profile_options.qualifications")
+      check I18n.t("helpers.label.jobseekers_job_application_review_form.update_profile_options.1")
       click_on I18n.t("buttons.submit_application")
       expect(page).to have_content(I18n.t("jobseekers.job_applications.submit.panel.title"))
 
@@ -33,42 +33,8 @@ RSpec.describe "Jobseekers can update their profile from job applications" do
       expect(page).to have_css("h3.govuk-summary-card__title", text: "Application qualification")
       expect(page).not_to have_css("h3.govuk-summary-card__title", text: "Original profile qualification")
 
-      expect(page).to have_css("h3.govuk-summary-card__title", text: "Original profile employment")
-      expect(page).not_to have_css("h3.govuk-summary-card__title", text: "Application employment")
-
-      expect(page).to have_css("h3.govuk-summary-card__title", text: "Original profile training")
-      expect(page).not_to have_css("h3.govuk-summary-card__title", text: "Application training")
-    end
-
-    scenario "jobseekers can update their profile work history using the job application information on submission" do
-      check I18n.t("helpers.label.jobseekers_job_application_review_form.update_profile_options.work_history")
-      click_on I18n.t("buttons.submit_application")
-      expect(page).to have_content(I18n.t("jobseekers.job_applications.submit.panel.title"))
-
-      click_link "Your profile"
-
-      expect(page).to have_css("h3.govuk-summary-card__title", text: "Original profile qualification")
-      expect(page).not_to have_css("h3.govuk-summary-card__title", text: "Application qualification")
-
       expect(page).to have_css("h3.govuk-summary-card__title", text: "Application employment")
       expect(page).not_to have_css("h3.govuk-summary-card__title", text: "Original profile employment")
-
-      expect(page).to have_css("h3.govuk-summary-card__title", text: "Original profile training")
-      expect(page).not_to have_css("h3.govuk-summary-card__title", text: "Application training")
-    end
-
-    scenario "jobseekers can update their profile training and cpd using the job application information on submission" do
-      check I18n.t("helpers.label.jobseekers_job_application_review_form.update_profile_options.training_and_cpds")
-      click_on I18n.t("buttons.submit_application")
-      expect(page).to have_content(I18n.t("jobseekers.job_applications.submit.panel.title"))
-
-      click_link "Your profile"
-
-      expect(page).to have_css("h3.govuk-summary-card__title", text: "Original profile qualification")
-      expect(page).not_to have_css("h3.govuk-summary-card__title", text: "Application qualification")
-
-      expect(page).to have_css("h3.govuk-summary-card__title", text: "Original profile employment")
-      expect(page).not_to have_css("h3.govuk-summary-card__title", text: "Application employment")
 
       expect(page).not_to have_css("h3.govuk-summary-card__title", text: "Original profile training")
       expect(page).to have_css("h3.govuk-summary-card__title", text: "Application training")


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/r52X72QF/1530-application-submission-confirmation-page-save-data-to-profile-feature-updates

## Changes in this PR:

Rework profile filling and final page shown on application submit

## Screenshots of UI changes:

### Before
![ReviewBefore](https://github.com/user-attachments/assets/0f9b9db6-2c78-4015-a73d-f0fde61af84e)
![SubmitBefore](https://github.com/user-attachments/assets/0d18e1ed-f381-46f0-8d61-fe16c9569936)



### After
![ReviewAfter](https://github.com/user-attachments/assets/cd213202-5c41-423f-b4f4-edd937abd01d)
![SubmittedAfter](https://github.com/user-attachments/assets/e31bf522-838e-4ff5-9aa4-750a6b4a5182)


## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
