### PR TITLE
Use stored centroids to calculate distances

### DIFF
--- a/app/queries/location_query.rb
+++ b/app/queries/location_query.rb
@@ -56,9 +56,9 @@ class LocationQuery < ApplicationQuery
   end
 
   def sort_by_polygon_distance(field_name)
-    @scope = scope.select("vacancies.*, ST_Distance(#{field_name}, ST_Centroid(location_polygons.area), false) AS distance")
+    @scope = scope.select("vacancies.*, ST_Distance(#{field_name}, location_polygons.centroid, false) AS distance")
                   # why not using 'distance' alias? is not defined when calling this query with a 'pluck'
-                  .order(Arel.sql("ST_Distance(#{field_name}, ST_Centroid(location_polygons.area), false)"))
+                  .order(Arel.sql("ST_Distance(#{field_name}, location_polygons.centroid, false)"))
   end
 
   def sort_by_coordinates_distance(field_name, point)

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -26,13 +26,13 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "247ffca0a9eb003f3adee0fc7c76367a73fedf3282be496fa76f54a99d496c50",
+      "fingerprint": "15db60bfa4ee24da38dd0c72ed69b7287f3130bde4f784ab8279d2f288ba24e6",
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/queries/location_query.rb",
       "line": 61,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "Arel.sql(\"ST_Distance(#{field_name}, ST_Centroid(location_polygons.area), false)\")",
+      "code": "Arel.sql(\"ST_Distance(#{field_name}, location_polygons.centroid, false)\")",
       "render_path": null,
       "location": {
         "type": "method",


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/cf3f17rU/1528-use-precomputed-centroid-of-locationpolygons-areas

## Changes in this PR:

Use the stored centroid instead of calculating the centroid for the polygon area with each distance calculation.

This will save computation time when ordering all the search results by distance.

## Screenshots
Test on the Review App showing London got its centroid populated:
```
> LocationPolygon.where(name: "london").first.centroid
=> #<RGeo::Geographic::SphericalPointImpl:0x2b50c "POINT (-0.11039731810647747 51.501006516791904)">
```
### Using the precomputed centroid to order by distance
![image](https://github.com/user-attachments/assets/d6161895-187e-4033-bb16-f39798cfda9a)
