### PR TITLE
Make Google API Client authentication compatible with Analytics Federated Auth

### DIFF
--- a/config/initializers/google_api.rb
+++ b/config/initializers/google_api.rb
@@ -1,7 +1,6 @@
 require "google/apis/indexing_v3"
 
 GOOGLE_APIS_KEY = ENV.fetch("GOOGLE_APIS_KEY", "")
-GOOGLE_MAPS_API_KEY = ENV.fetch("GOOGLE_MAPS_API_KEY", "")
 GOOGLE_LOCATION_SEARCH_API_KEY = ENV.fetch("GOOGLE_LOCATION_SEARCH_API_KEY", "")
 
 if GOOGLE_APIS_KEY.empty?

--- a/config/initializers/google_api.rb
+++ b/config/initializers/google_api.rb
@@ -1,20 +1,13 @@
 require "google/apis/indexing_v3"
 
-GOOGLE_API_JSON_KEY = ENV.fetch("GOOGLE_API_JSON_KEY", "")
-
+GOOGLE_APIS_KEY = ENV.fetch("GOOGLE_APIS_KEY", "")
 GOOGLE_MAPS_API_KEY = ENV.fetch("GOOGLE_MAPS_API_KEY", "")
 GOOGLE_LOCATION_SEARCH_API_KEY = ENV.fetch("GOOGLE_LOCATION_SEARCH_API_KEY", "")
 
-if GOOGLE_API_JSON_KEY.empty? || JSON.parse(GOOGLE_API_JSON_KEY).empty?
-  Rails.logger.info("***No GOOGLE_API_JSON_KEY set")
+if GOOGLE_APIS_KEY.empty?
+  Rails.logger.info("***No GOOGLE_APIS_KEY set")
   return
 end
 
-scope = ["https://www.googleapis.com/auth/indexing",
-         "https://www.googleapis.com/auth/drive"]
-
-key = StringIO.new(GOOGLE_API_JSON_KEY)
-authorizer = Google::Auth::ServiceAccountCredentials.make_creds(json_key_io: key,
-                                                                scope: scope)
-authorizer.fetch_access_token!
-Google::Apis::RequestOptions.default.authorization = authorizer
+# Configure the Google API client to use the API key
+Google::Apis::RequestOptions.default.key = GOOGLE_APIS_KEY

--- a/documentation/application-secrets.md
+++ b/documentation/application-secrets.md
@@ -48,10 +48,10 @@ __Once you are inside:__
 1. Update `DFE_SIGN_IN_SECRET` and `DFE_SIGN_IN_PASSWORD` in [AWS Systems Manager Parameter Store](https://eu-west-2.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-2&tab=Table) `/teaching-vacancies/<env>/app/secrets` files
 
 ### Google API Keys
-There are several different API keys in use in different environments. There are keys for Google Maps, as well as service accounts for Google Analytics, BigQuery and Google Drive.
+There are several different API keys in use in different environments. There are keys for Google Location, Search Index and Drive, as well as service accounts for Google Analytics and BigQuery.
 - `GOOGLE_LOCATION_SEARCH_API_KEY` is used for both the Google Places API and the Google Geocoding API
 - `GOOGLE_MAPS_API_KEY` is used for Google Maps
-- `GOOGLE_API_JSON_KEY` is used for analytics, indexing and drive
+- `GOOGLE_APIS_KEY` is used for Google Web Search indexing and Drive APIs
 - `BIG_QUERY_API_JSON_KEY` is used for writing tables into BigQuery
 
 __NOTE: Keys with `JSON` in the name are `JSON` objects, not simple strings. They will need to be normalized in to `JSON` strings to be used in ENV variables.__
@@ -93,7 +93,7 @@ __NOTE: Keys with `JSON` in the name are `JSON` objects, not simple strings. The
     jq -c . teacher-vacancy-service-<some UID>.json | pbcopy
     ```
 1. Copy the full body of the new key as a json string (not necessary if you used `...| pbcopy` in the `jq` example, above)
-1. Paste the full string of the new key in [AWS Systems Manager Parameter Store](https://eu-west-2.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-2&tab=Table) `/teaching-vacancies/<env>/app/BIG_QUERY_API_JSON_KEY` or `/teaching-vacancies/<env>/app/GOOGLE_API_JSON_KEY` files
+1. Paste the full string of the new key in [AWS Systems Manager Parameter Store](https://eu-west-2.console.aws.amazon.com/systems-manager/parameters/?region=eu-west-2&tab=Table) `/teaching-vacancies/<env>/app/BIG_QUERY_API_JSON_KEY` file
 1. Do a rolling restart on the updated environment for the application
 1. Check that everything works as expected
 1. Delete the old key from the 'Keys' section in the Service Account window

--- a/documentation/application-secrets.md
+++ b/documentation/application-secrets.md
@@ -50,7 +50,6 @@ __Once you are inside:__
 ### Google API Keys
 There are several different API keys in use in different environments. There are keys for Google Location, Search Index and Drive, as well as service accounts for Google Analytics and BigQuery.
 - `GOOGLE_LOCATION_SEARCH_API_KEY` is used for both the Google Places API and the Google Geocoding API
-- `GOOGLE_MAPS_API_KEY` is used for Google Maps
 - `GOOGLE_APIS_KEY` is used for Google Web Search indexing and Drive APIs
 - `BIG_QUERY_API_JSON_KEY` is used for writing tables into BigQuery
 

--- a/documentation/hosting.md
+++ b/documentation/hosting.md
@@ -212,7 +212,6 @@ kubectl scale --replicas=4 deployment teaching-vacancies-production-worker -n tv
 - Create file `terraform/workspace-variables/<env>_app_env.yml`
 - Create SSM parameters of type `SecureString`:
   - `/teaching-vacancies/<env>/app/BIG_QUERY_API_JSON_KEY`
-  - `/teaching-vacancies/<env>/app/GOOGLE_API_JSON_KEY`
   - `/teaching-vacancies/<env>/app/secrets`
   - `/teaching-vacancies/<env>/infra/secrets`
 - Add a target to the Makefile

--- a/lib/google_indexing.rb
+++ b/lib/google_indexing.rb
@@ -31,6 +31,6 @@ class GoogleIndexing
   end
 
   def api_key_empty?
-    GOOGLE_API_JSON_KEY.empty? || JSON.parse(GOOGLE_API_JSON_KEY).empty?
+    GOOGLE_APIS_KEY.empty? || JSON.parse(GOOGLE_APIS_KEY).empty?
   end
 end

--- a/spec/jobs/remove_google_index_queue_job_spec.rb
+++ b/spec/jobs/remove_google_index_queue_job_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe RemoveGoogleIndexQueueJob do
   end
 
   it "aborts execution when no Google credentials are set" do
-    stub_const("GOOGLE_API_JSON_KEY", "")
+    stub_const("GOOGLE_APIS_KEY", "")
     Sidekiq::Testing.inline! do
       expect(GoogleIndexing).to receive(:new).and_raise(SystemExit, "No Google API")
 

--- a/spec/jobs/update_google_index_queue_job_spec.rb
+++ b/spec/jobs/update_google_index_queue_job_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe UpdateGoogleIndexQueueJob do
   end
 
   it "aborts execution when no Google credentials are set" do
-    stub_const("GOOGLE_API_JSON_KEY", "")
+    stub_const("GOOGLE_APIS_KEY", "")
     Sidekiq::Testing.inline! do
       expect(GoogleIndexing).to receive(:new).and_raise(SystemExit, "No Google API")
 

--- a/spec/lib/google_indexing_spec.rb
+++ b/spec/lib/google_indexing_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe GoogleIndexing do
 
   context "Successful requests" do
     before(:each) do
-      stub_const("GOOGLE_API_JSON_KEY", '{ "key": "value" }')
+      stub_const("GOOGLE_APIS_KEY", '{ "key": "value" }')
     end
 
     context "Requesting a url index update" do
@@ -43,7 +43,7 @@ RSpec.describe GoogleIndexing do
 
   context "When no GOOGLE_API key is set" do
     it "logs an error and aborts execution" do
-      stub_const("GOOGLE_API_JSON_KEY", "")
+      stub_const("GOOGLE_APIS_KEY", "")
       expect(GoogleIndexing::API::IndexingService).not_to receive(:new)
       GoogleIndexing.new(url)
     end

--- a/terraform/workspace-variables/production.tfvars.json
+++ b/terraform/workspace-variables/production.tfvars.json
@@ -80,6 +80,6 @@
     "start_minute": 0
   },
   "enable_logit": true,
-  "enable_dfe_analytics_federated_auth": false,
+  "enable_dfe_analytics_federated_auth": true,
   "dataset_name": "production_dataset"
 }


### PR DESCRIPTION

## Trello card URL
- https://trello.com/c/Axm4qiA1/1549-fix-issue-in-google-index-drive-apis-authentication-vs-analytics-wif-auth

## Changes in this PR:

For security reasons, we need to enable Analytics Federated Auth. And the changes come from DevOps team across multiple services.
Enabling this option made our existing `GOOGLE_API_JSON_KEY` (belonging to a Service Account) invalid on the GoogleApi Client calls (for web search index updates and google drive calls). It seems the service account permissions get somehow affected by enabling the analytics federated auth flag.
 
To isolate the analytics federated auth from the unrelated Google API Client calls, we are replacing Google Cloud Service Account JSON token & Scopes with a simple API KEY with exclusive access to Google Web Search Index and Google Drive APIs. We have created this new key ad-hoc for this purpose.

The API key works from the production console. But we won't be able to know if it is compatible with the new Analytics Federated auth option until we enable the federated auth (again) in the production config.
