### PR TITLE
Code coverage tools

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
       RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
       PARALLEL_TEST_PROCESSORS: 4
       PARALLEL_TEST_FIRST_IS_1: true
+      COVERAGE: 1
 
     services:
       postgres:
@@ -32,8 +33,11 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
+      # need depth 0 for undercover to work properly
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Prepare application environment
         uses: ./.github/actions/prepare-app-env
@@ -58,13 +62,27 @@ jobs:
       - name: Run tests in parallel
         run: bundle exec rake parallel:spec
 
+      # Tests may fail due to lack of coverage, so always run coverage upload and checks
+      # to help diagnose issues
+      - name: Upload Coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage report
+          path: coverage
+
+      - name: Check coverage
+        if: always()
+        run: bundle exec undercover -c origin/main
+
       - name: Upload Capybara failures screenshots
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: capybara-screenshots
+          name: capybara-screenshots-${{ matrix.test_params.name }}
           path: /home/runner/work/teaching-vacancies/teaching-vacancies/tmp/capybara/*.png
           if-no-files-found: ignore # If only non-capybara tests fail there will be no screenshots
+
 
   frontend-tests:
     name: Run frontend JS unit tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: capybara-screenshots-${{ matrix.test_params.name }}
+          name: capybara-screenshots
           path: /home/runner/work/teaching-vacancies/teaching-vacancies/tmp/capybara/*.png
           if-no-files-found: ignore # If only non-capybara tests fail there will be no screenshots
 

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,53 @@
+# default to coverage 'off' as it makes no sense
+# unless most of the tests are being run
+# however setting merge_timeout super-large is a possible option
+# e.g. COVERAGE=1 MERGE_TIMEOUT=86400
+# merge_timeout just keeps coverage data around a long time
+# as it doesn't change very often - would probably need guard support
+# for this to be valuable so that only changed files have tests run
+if ENV.fetch("COVERAGE", 0).to_i.positive?
+  require "simplecov"
+  require "simplecov-lcov"
+
+  # This allows both LCOV and HTML formatting -
+  # lcov for undercover gem, HTML for humans
+  class SimpleCov::Formatter::MergedFormatter
+    def format(result)
+      SimpleCov::Formatter::HTMLFormatter.new.format(result)
+      SimpleCov::Formatter::LcovFormatter.new.format(result)
+    end
+  end
+
+  SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
+  SimpleCov.formatter = SimpleCov::Formatter::MergedFormatter
+
+  SimpleCov.start :rails do
+    enable_coverage :branch
+    primary_coverage :branch
+
+    # This line would enable template coverage,
+    # but slim templates don't seem to work very well
+    # enable_coverage_for_eval
+    merge_timeout ENV["MERGE_TIMEOUT"].to_i if ENV.key? "MERGE_TIMEOUT"
+
+    add_filter %r{.rake$}
+    add_filter "app/services/custom_log_formatter.rb"
+    add_filter "app/controllers/robots_controller.rb"
+    add_filter "app/controllers/sha_controller.rb"
+    add_filter "app/jobs/set_organisation_slugs_job.rb"
+    add_filter "app/mailers/jobseekers/authentication_fallback_mailer.rb"
+
+    add_filter "lib/dfe_sign_in/fake_sign_out_endpoint.rb"
+    add_filter "lib/modules/aws_ip_ranges.rb"
+
+    add_group "Components", "app/components"
+    add_group "Queries", "app/queries"
+    add_group "Services", "app/services"
+    add_group "Forms", "app/form_models"
+    add_group "Validators", "app/validators"
+    add_group "Presenters", "app/presenters"
+    add_group "Notifiers", "app/notifiers"
+
+    minimum_coverage line: 94.94, branch: 79.15 unless ENV.key? "CI"
+  end
+end

--- a/Gemfile
+++ b/Gemfile
@@ -117,6 +117,7 @@ group :development, :test do
   gem "rspec-rails"
   gem "rswag-specs"
   gem "slim_lint", require: false
+  gem "undercover", require: false
 end
 
 group :test do
@@ -126,6 +127,8 @@ group :test do
   gem "rack_session_access"
   gem "selenium-webdriver"
   gem "shoulda-matchers"
+  gem "simplecov", require: false
+  gem "simplecov-lcov", require: false
   gem "uri-query_params"
   gem "vcr"
   gem "webmock"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,6 +192,7 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.5.1)
+    docile (1.4.1)
     dotenv (3.1.7)
     dotenv-rails (3.1.7)
       dotenv (= 3.1.7)
@@ -294,6 +295,8 @@ GEM
     httpclient (2.8.3)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    imagen (0.2.0)
+      parser (>= 2.5, != 2.5.1.1)
     inflection (1.0.0)
     io-console (0.8.0)
     ipaddr (1.2.7)
@@ -646,6 +649,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
     rubyzip (2.4.1)
+    rugged (1.7.2)
     sanitize (7.0.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.16.8)
@@ -683,6 +687,13 @@ GEM
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov-lcov (0.8.0)
+    simplecov_json_formatter (0.1.4)
     skylight (6.0.4)
       activesupport (>= 5.2.0)
     slim (5.2.1)
@@ -730,6 +741,11 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
+    undercover (0.6.3)
+      bigdecimal
+      imagen (>= 0.2.0)
+      rainbow (>= 2.1, < 4.0)
+      rugged (>= 0.27, < 1.8)
     unicode (0.4.4.5)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
@@ -896,11 +912,14 @@ DEPENDENCIES
   shoulda-matchers
   sidekiq (< 7)
   sidekiq-cron
+  simplecov
+  simplecov-lcov
   skylight
   slim-rails
   slim_lint
   solargraph
   tzinfo-data
+  undercover
   uri-query_params
   valid_email2
   validate_url

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require "simplecov"
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/CUdxmu4H/1538-implement-coverage-checks-with-simplecov-lcov-simplecov-html-and-undercover-gems

## Changes in this PR:

This introduces a suite of code coverage tools:

* simplecov - the foundation
* simplecov-html - a reporting tool showing human-readable coverage data 
* simplecov-lcov - a reporting tool in 'lcov' format, readable by machines

* undercover
      This is integrated with git, and compares the coverage data with the 'current' branch against main. It will detect any 'changed' code and make sure that it has complete branch coverage. This can be overridden with the :nocov: annotation if really required

Coverage is off locally by default (it adds about 20% overhead with our current setup) but can be enabled with COVERAGE=1. It's switched on for CI (so that undercover can detect it)


## Screenshots of UI changes:

### Before

### After
![Coveraqge](https://github.com/user-attachments/assets/d5fc4040-efcc-4b7a-8c25-344120061519)

