### PR TITLE
upgrade to action-cache 4.2.0

### DIFF
--- a/.github/actions/prepare-app-env/action.yml
+++ b/.github/actions/prepare-app-env/action.yml
@@ -42,7 +42,7 @@ runs:
 
     - name: Set up yarn cache
       if: ${{ inputs.skip-node == 'false' }}
-      uses: actions/cache@v4.1.2
+      uses: actions/cache@v4.2.0
       with:
         path: ${{ steps.yarn-cache.outputs.dir }}
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
## Changes in this PR:

Upgrade to action-cache 4.2.0 before Feb 1st 2025 to avoid issues
