### PR TITLE
Reduce image creation on orgs

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -71,6 +71,8 @@ Rails.application.configure do
   ENV["DFE_SIGN_IN_ISSUER"] = "http://fake.dsi.example.com"
   config.middleware.insert_before 0, DfeSignIn::FakeSignOutEndpoint
 
+  # we don't really need logs in test mode, certainly not every request
+  config.log_level = :warn
   config.log_file_size = 100.megabytes
 
   # Raise error when a before_action's only/except options reference missing actions

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -71,8 +71,6 @@ Rails.application.configure do
   ENV["DFE_SIGN_IN_ISSUER"] = "http://fake.dsi.example.com"
   config.middleware.insert_before 0, DfeSignIn::FakeSignOutEndpoint
 
-  # we don't really need logs in test mode, certainly not every request
-  config.log_level = :warn
   config.log_file_size = 100.megabytes
 
   # Raise error when a before_action's only/except options reference missing actions

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -40,12 +40,14 @@ FactoryBot.define do
     sequence(:urn) { |n| n + 100_000 }
     url { Faker::Internet.url(host: "example.com") }
 
-    after(:build) do |school|
-      blank_image = File.open(Rails.root.join("spec/fixtures/files/blank_image.png"))
-      normalised_logo = ImageManipulator.new(image_file_path: blank_image.path).alter_dimensions_and_preserve_aspect_ratio("100", "100")
+    trait :with_image do
+      after(:build) do |school|
+        blank_image = File.open(Rails.root.join("spec/fixtures/files/blank_image.png"))
+        normalised_logo = ImageManipulator.new(image_file_path: blank_image.path).alter_dimensions_and_preserve_aspect_ratio("100", "100")
 
-      school.logo.attach(io: StringIO.open(normalised_logo.to_blob), filename: "logo.png", content_type: "image/png")
-      school.photo.attach(io: blank_image, filename: "photo.png", content_type: "image/png")
+        school.logo.attach(io: StringIO.open(normalised_logo.to_blob), filename: "logo.png", content_type: "image/png")
+        school.photo.attach(io: blank_image, filename: "photo.png", content_type: "image/png")
+      end
     end
 
     trait :closed do

--- a/spec/system/other/users_can_only_be_signed_in_to_one_type_of_account_spec.rb
+++ b/spec/system/other/users_can_only_be_signed_in_to_one_type_of_account_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Users can only be signed in to one type of account" do
-  let(:school) { create(:school, urn: "110627") }
+  let(:school) { create(:school, :with_image, urn: "110627") }
 
   let(:jobseeker) { create(:jobseeker) }
   let!(:publisher) { create(:publisher, organisations: [school]) }

--- a/spec/system/publishers/publishers_are_redirected_after_sign_in_spec.rb
+++ b/spec/system/publishers/publishers_are_redirected_after_sign_in_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Publishers are redirected after sign in" do
-  let!(:organisation) { create(:school) }
+  let!(:organisation) { create(:school, :with_image) }
   let(:publisher) { create(:publisher) }
   let(:vacancy) { create(:vacancy, publisher: publisher, organisations: [organisation]) }
 

--- a/spec/system/publishers/publishers_can_manage_a_profile_spec.rb
+++ b/spec/system/publishers/publishers_can_manage_a_profile_spec.rb
@@ -389,7 +389,7 @@ RSpec.describe "Publishers can manage an organisation or school profile" do
   end
 
   describe "deleting the organisation's logo" do
-    let(:organisation) { create(:school) }
+    let(:organisation) { create(:school, :with_image) }
     let(:image_file_name) { "blank_image.png" }
 
     before do
@@ -440,7 +440,7 @@ RSpec.describe "Publishers can manage an organisation or school profile" do
   end
 
   describe "deleting the organisation's photo" do
-    let(:organisation) { create(:school) }
+    let(:organisation) { create(:school, :with_image) }
     let(:image_file_name) { "blank_image.png" }
 
     before do

--- a/spec/system/publishers/publishers_can_sign_in_by_email_spec.rb
+++ b/spec/system/publishers/publishers_can_sign_in_by_email_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe "Publishers can sign in with fallback email authentication" do
   end
 
   context "publisher flow" do
-    let(:school) { create(:school, name: "Some school") }
-    let(:other_school) { create(:school, name: "Some other school") }
-    let(:trust) { create(:trust) }
-    let(:local_authority) { create(:local_authority, local_authority_code: "100") }
+    let(:school) { create(:school, :with_image, name: "Some school") }
+    let(:other_school) { create(:school, :with_image, name: "Some other school") }
+    let(:trust) { create(:trust, :with_image) }
+    let(:local_authority) { create(:local_authority, :with_image, local_authority_code: "100") }
     let(:publisher) { create(:publisher, organisations: organisations, accepted_terms_at: 1.day.ago) }
 
     let(:login_key) do

--- a/spec/system/publishers/publishers_can_sign_in_by_email_spec.rb
+++ b/spec/system/publishers/publishers_can_sign_in_by_email_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe "Publishers can sign in with fallback email authentication" do
   context "publisher flow" do
     let(:school) { create(:school, :with_image, name: "Some school") }
     let(:other_school) { create(:school, :with_image, name: "Some other school") }
-    let(:trust) { create(:trust, :with_image) }
-    let(:local_authority) { create(:local_authority, :with_image, local_authority_code: "100") }
+    let(:trust) { create(:trust) }
+    let(:local_authority) { create(:local_authority, local_authority_code: "100") }
     let(:publisher) { create(:publisher, organisations: organisations, accepted_terms_at: 1.day.ago) }
 
     let(:login_key) do

--- a/spec/system/publishers/publishers_can_sign_in_with_dfe_spec.rb
+++ b/spec/system/publishers/publishers_can_sign_in_with_dfe_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Publishers can sign in with DfE Sign In" do
   end
 
   context "with valid credentials that match a school" do
-    let!(:organisation) { create(:school, urn: "110627") }
+    let!(:organisation) { create(:school, :with_image, urn: "110627") }
 
     before do
       stub_publisher_authentication_step email: dsi_email_address

--- a/spec/system/publishers/publishers_can_visit_the_public_listings_spec.rb
+++ b/spec/system/publishers/publishers_can_visit_the_public_listings_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "School viewing public listings" do
     set_up_omniauth_config
   end
 
-  let!(:school) { create(:school, urn: "110627") }
+  let!(:school) { create(:school, :with_image, urn: "110627") }
 
   context "when signed in with DfE Sign In" do
     before do


### PR DESCRIPTION
## Changes in this PR:

Stop creating images for all organisations - just when they are needed. Appears to speed up tests by around 40% - my i5 desktop goes from 10 minutes to 7mins 21 secs with this change