### PR TITLE
Track analytics on google geocoding api hits

### DIFF
--- a/app/controllers/api/location_suggestion_controller.rb
+++ b/app/controllers/api/location_suggestion_controller.rb
@@ -2,7 +2,7 @@ class Api::LocationSuggestionController < Api::ApplicationController
   before_action :verify_json_request, only: %i[show]
   before_action :check_valid_params, only: %i[show]
 
-  # Try to reduce our Google Places API bill
+  # By caching this action, we considerably reduce our Google Places API bill
   caches_action :show
 
   def show

--- a/config/analytics_custom_events.yml
+++ b/config/analytics_custom_events.yml
@@ -4,6 +4,7 @@ shared:
   - equal_opportunities_report_published
   - failed_dsi_sign_in_attempt
   - form_validation_failed
+  - google_geocoding_api_hit
   - job_alert_subscription_created
   - job_alert_subscription_unsubscribed
   - job_alert_subscription_updated

--- a/lib/geocoding.rb
+++ b/lib/geocoding.rb
@@ -16,7 +16,7 @@ class Geocoding
 
     Rails.cache.fetch([:geocoding, location], expires_in: CACHE_DURATION, skip_nil: true) do
       Geocoder.coordinates(location, lookup: :google, components: "country:gb").tap do |coords|
-         trigger_google_geocoding_api_hit_event(type: :coordinates, location:, result: coords)
+        trigger_google_geocoding_api_hit_event(type: :coordinates, location:, result: coords)
       end
     rescue Geocoder::OverQueryLimitError
       trigger_google_geocoding_api_hit_event(type: :coordinates, location:, result: "OVER_QUERY_LIMIT")

--- a/lib/geocoding.rb
+++ b/lib/geocoding.rb
@@ -15,9 +15,9 @@ class Geocoding
     return self.class.test_coordinates if Rails.application.config.geocoder_lookup == :test
 
     Rails.cache.fetch([:geocoding, location], expires_in: CACHE_DURATION, skip_nil: true) do
-      coords = Geocoder.coordinates(location, lookup: :google, components: "country:gb")
-      trigger_google_geocoding_api_hit_event(type: :coordinates, location:, result: coords)
-      coords
+      Geocoder.coordinates(location, lookup: :google, components: "country:gb").tap do |coords|
+         trigger_google_geocoding_api_hit_event(type: :coordinates, location:, result: coords)
+      end
     rescue Geocoder::OverQueryLimitError
       trigger_google_geocoding_api_hit_event(type: :coordinates, location:, result: "OVER_QUERY_LIMIT")
       Rails.logger.error("Google Geocoding API responded with OVER_QUERY_LIMIT")

--- a/lib/geocoding.rb
+++ b/lib/geocoding.rb
@@ -15,8 +15,11 @@ class Geocoding
     return self.class.test_coordinates if Rails.application.config.geocoder_lookup == :test
 
     Rails.cache.fetch([:geocoding, location], expires_in: CACHE_DURATION, skip_nil: true) do
-      Geocoder.coordinates(location, lookup: :google, components: "country:gb")
+      coords = Geocoder.coordinates(location, lookup: :google, components: "country:gb")
+      trigger_google_geocoding_api_hit_event(type: :coordinates, location:, result: coords)
+      coords
     rescue Geocoder::OverQueryLimitError
+      trigger_google_geocoding_api_hit_event(type: :coordinates, location:, result: "OVER_QUERY_LIMIT")
       Rails.logger.error("Google Geocoding API responded with OVER_QUERY_LIMIT")
       Geocoder.coordinates(location, lookup: :uk_ordnance_survey_names)
     end || no_coordinates_match
@@ -27,14 +30,30 @@ class Geocoding
 
     Rails.cache.fetch([:postcode_from_coords, location], expires_in: CACHE_DURATION, skip_nil: true) do
       result = Geocoder.search(location, lookup: :google).first
-      result.data["address_components"].find { |line| "postal_code".in?(line["types"]) }&.dig("short_name") unless result.nil?
+      if result.present?
+        postcode = result.data["address_components"].find { |line| "postal_code".in?(line["types"]) }&.dig("short_name")
+        trigger_google_geocoding_api_hit_event(type: :postcode, location:, result: postcode)
+        postcode
+      else
+        trigger_google_geocoding_api_hit_event(type: :postcode, location:, result: nil)
+        nil
+      end
     rescue Geocoder::OverQueryLimitError
+      trigger_google_geocoding_api_hit_event(type: :postcode, location:, result: "OVER_QUERY_LIMIT")
       Rails.logger.error("Google Geocoding API responded with OVER_QUERY_LIMIT")
       fallback_postcode_from_coords
     end || no_postcode_match
   end
 
   private
+
+  def trigger_google_geocoding_api_hit_event(type:, location:, result:)
+    event = DfE::Analytics::Event.new
+      .with_type(:google_geocoding_api_hit)
+      .with_data(data: { type:, location: location.to_s, result: result&.to_s })
+
+    DfE::Analytics::SendEvents.do([event])
+  end
 
   def fallback_postcode_from_coords(service: :nominatim)
     result = Geocoder.search(location, lookup: service).first.data

--- a/spec/lib/geocoding_spec.rb
+++ b/spec/lib/geocoding_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "geocoding"
 
 # rubocop:disable RSpec/ExpectActual
-RSpec.describe Geocoding, geocode: true do
+RSpec.describe Geocoding, :dfe_analytics, geocode: true do
   subject { described_class.new(location) }
 
   let(:google_coordinates) { [54.5399146, -1.0435559] }
@@ -29,7 +29,7 @@ RSpec.describe Geocoding, geocode: true do
         subject.coordinates
       end
 
-      it "does not trigger a Google Geocoding API hit event", :dfe_analytics do
+      it "does not trigger a Google Geocoding API hit event" do
         subject.coordinates
         expect(:google_geocoding_api_hit).not_to have_been_enqueued_as_analytics_event
       end
@@ -41,7 +41,7 @@ RSpec.describe Geocoding, geocode: true do
           expect(subject.coordinates).to eq(google_coordinates)
         end
 
-        it "triggers a Google Geocoding API hit event", :dfe_analytics do
+        it "triggers a Google Geocoding API hit event" do
           subject.coordinates
           expect(:google_geocoding_api_hit).to have_been_enqueued_as_analytics_event(
             with_data: { type: "coordinates", location: location, result: google_coordinates.to_s },
@@ -54,7 +54,7 @@ RSpec.describe Geocoding, geocode: true do
           expect(subject.coordinates).to eq(no_match)
         end
 
-        it "triggers a Google Geocoding API hit event", :dfe_analytics do
+        it "triggers a Google Geocoding API hit event" do
           subject.coordinates
           expect(:google_geocoding_api_hit).to have_been_enqueued_as_analytics_event(
             with_data: { type: "coordinates", location: location, result: nil },
@@ -68,7 +68,7 @@ RSpec.describe Geocoding, geocode: true do
           subject.coordinates
         end
 
-        it "triggers a Google Geocoding API hit event", :dfe_analytics do
+        it "triggers a Google Geocoding API hit event" do
           subject.coordinates
           expect(:google_geocoding_api_hit).to have_been_enqueued_as_analytics_event(
             with_data: { type: "coordinates", location: location, result: "OVER_QUERY_LIMIT" },
@@ -113,7 +113,7 @@ RSpec.describe Geocoding, geocode: true do
         subject.postcode_from_coordinates
       end
 
-      it "does not trigger a Google Geocoding API hit event", :dfe_analytics do
+      it "does not trigger a Google Geocoding API hit event" do
         subject.postcode_from_coordinates
         expect(:google_geocoding_api_hit).not_to have_been_enqueued_as_analytics_event
       end
@@ -125,7 +125,7 @@ RSpec.describe Geocoding, geocode: true do
           expect(subject.postcode_from_coordinates).to eq(postcode)
         end
 
-        it "triggers a Google Geocoding API hit event", :dfe_analytics do
+        it "triggers a Google Geocoding API hit event" do
           subject.postcode_from_coordinates
           expect(:google_geocoding_api_hit).to have_been_enqueued_as_analytics_event(
             with_data: { type: "postcode", location: google_coordinates.to_s, result: postcode },
@@ -138,7 +138,7 @@ RSpec.describe Geocoding, geocode: true do
           expect(subject.postcode_from_coordinates).to be_nil
         end
 
-        it "triggers a Google Geocoding API hit event", :dfe_analytics do
+        it "triggers a Google Geocoding API hit event" do
           subject.postcode_from_coordinates
           expect(:google_geocoding_api_hit).to have_been_enqueued_as_analytics_event(
             with_data: { type: "postcode", location: google_coordinates.to_s, result: nil },
@@ -153,7 +153,7 @@ RSpec.describe Geocoding, geocode: true do
         subject.postcode_from_coordinates
       end
 
-      it "triggers a Google Geocoding API hit event", :dfe_analytics do
+      it "triggers a Google Geocoding API hit event" do
         subject.postcode_from_coordinates
         expect(:google_geocoding_api_hit).to have_been_enqueued_as_analytics_event(
           with_data: { type: "postcode", location: google_coordinates.to_s, result: "OVER_QUERY_LIMIT" },


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/D974czyQ/1553-add-analytics-info-on-google-geocoding-api-hits

## Changes in this PR:

Sends a new custom event to DFE Analytics: `google_geocoding_api_hit`

This event and the contextual type, location, and result will help us track what queries hit the Google Geocoding API and how frequently they hit it. 

## Next steps:
Study possible patterns/issues regarding our caching approach.
EG: We're not caching queries that return `nil`. Are there many of those?
