### PR TITLE
Reduce logging from DfE::Analytics::SendEvent

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,7 +75,6 @@ Rails.application.configure do
   config.rails_semantic_logger.format = :json
   config.rails_semantic_logger.add_file_appender = false
   config.rails_semantic_logger.filter = proc do |log|
-    puts "FILTER CHECK: log.name=#{log.name.inspect}"
     !(log.name == "DfE::Analytics::SendEvents" || log.message.include?("DfE::Analytics::SendEvents"))
   end
 


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/ztsBOi77/1552-reduce-logging-from-worker-jobs

## Changes in this PR:

Previously, our filter was checking for:
```
config.rails_semantic_logger.filter = proc { |log| log.name != "DfE::Analytics::SendEvents" }
```

But it seems the message in Logit has `Rails` set for the `log.name`, and that's probably preventing the log from being silenced. This changes the filter so that we can silence for the correct parameter.

You can see part of the JSON of the event being sent here:

```
"app": {
      "message": "Performed DfE::Analytics::SendEvents (Job ID: acf104ad-a91a-409b-bdb6-f4463403d6a7) to Sidekiq(default) in 15.01ms",
      "payload": {
        "provider_job_id": "ef550c408046c6901c059441",
        "job_id": "acf104ad-a91a-409b-bdb6-f4463403d6a7",
        "params_json": "null",
        "queue": "default",
        "event_name": "perform.active_job",
        "duration": 15.01,
        "arguments": "",
        "adapter": "Sidekiq",
        "job_class": "DfE::Analytics::SendEvents"
      },
      "name": "Rails",
      "application": "",
      "environment": "production",
    },
  ```


After further investigation, these logs are being emitted under two different `log.name` values:

`log.name="DfE::Analytics::SendEvents"` – This was correctly filtered out.
`log.name="Rails"` – These logs were related to ActiveJob and contained DfE::Analytics::SendEvents in the message field, but were not being filtered.

So we needed to filter out two entries
