### PR TITLE
Add support for using gemsets with RVM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ dump.rdb
 
 # devops files
 bin/konduit.sh
+
+# RVM gemset support
+/.ruby-gemset


### PR DESCRIPTION
## Changes in this PR:

Add support for using gemsets with RVM by adding it to .gitignore