### PR TITLE
downgrade undercover

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,11 @@ updates:
       - dependency-name: "redis"
         update-types: ["version-update:semver-major"]
 
+      # TODO: Remove this ignore config once undercover issue has been resolved
+      # Undercover 0.6.x doesn't seeem to respect :nocov: directives properly
+      - dependency-name: "underciver"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+
     groups:
       gem-dependencies:
         update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,7 @@ updates:
 
       # TODO: Remove this ignore config once undercover issue has been resolved
       # Undercover 0.6.x doesn't seeem to respect :nocov: directives properly
-      - dependency-name: "underciver"
+      - dependency-name: "undercover"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
     groups:

--- a/.undercover
+++ b/.undercover
@@ -1,0 +1,1 @@
+-c origin/main

--- a/Gemfile
+++ b/Gemfile
@@ -117,7 +117,9 @@ group :development, :test do
   gem "rspec-rails"
   gem "rswag-specs"
   gem "slim_lint", require: false
-  gem "undercover", require: false
+  # https://github.com/grodowski/undercover/issues/220
+  # v 0.6 doesn't respect :nocov: tags properly
+  gem "undercover", "< 0.6", require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -322,8 +322,6 @@ GEM
     json-schema (5.0.1)
       addressable (~> 2.8)
     jwt (2.10.1)
-    jwt (2.9.3)
-      base64
     kramdown (2.5.1)
       rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)
@@ -741,9 +739,9 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
-    undercover (0.6.3)
+    undercover (0.5.0)
       bigdecimal
-      imagen (>= 0.2.0)
+      imagen (>= 0.1.8)
       rainbow (>= 2.1, < 4.0)
       rugged (>= 0.27, < 1.8)
     unicode (0.4.4.5)
@@ -919,7 +917,7 @@ DEPENDENCIES
   slim_lint
   solargraph
   tzinfo-data
-  undercover
+  undercover (< 0.6)
   uri-query_params
   valid_email2
   validate_url


### PR DESCRIPTION
## Changes in this PR:

Downgrade undercover to 0.5.x as version 6.x doesn't ignore :nocov: directives properly
