### PR TITLE
Add professional body memberships to hiring staff view of jobseeker profiles

### DIFF
--- a/app/views/jobseekers/profiles/_summary.html.slim
+++ b/app/views/jobseekers/profiles/_summary.html.slim
@@ -72,3 +72,32 @@ dl.govuk-summary-list
           = training.grade
       p.govuk-hint = "#{training.provider}, #{training.year_awarded}"
       hr.govuk-section-break.govuk-section-break--s.govuk-section-break--visible
+
+- if profile.professional_body_memberships.any?
+  h2.govuk-heading-m class="govuk-!-padding-bottom-3" = t(".professional_body_memberships")
+  - profile.professional_body_memberships.each do |professional_body_membership|
+      = govuk_summary_list classes: "govuk-!-margin-bottom-0" do |summary_list|
+        - summary_list.with_row do |row|
+          - row.with_key text: t("helpers.label.jobseekers_professional_body_membership_form.name")
+          - row.with_value text: professional_body_membership.name
+
+        - if professional_body_membership.membership_type.present?
+          - summary_list.with_row do |row|
+            - row.with_key text: t("helpers.label.jobseekers_professional_body_membership_form.membership_type")
+            - row.with_value text: professional_body_membership.membership_type
+
+        - if professional_body_membership.membership_number.present?
+          - summary_list.with_row do |row|
+            - row.with_key text: t("helpers.label.jobseekers_professional_body_membership_form.membership_number")
+            - row.with_value text: professional_body_membership.membership_number
+
+        - if professional_body_membership.year_membership_obtained.present?
+          - summary_list.with_row do |row|
+            - row.with_key text: t("helpers.label.jobseekers_professional_body_membership_form.year_membership_obtained")
+            - row.with_value text: professional_body_membership.year_membership_obtained
+
+        - if professional_body_membership.exam_taken.present?
+          - summary_list.with_row do |row|
+            - row.with_key text: t("helpers.label.jobseekers_professional_body_membership_form.exam_taken")
+            - row.with_value text: t("helpers.label.jobseekers_professional_body_membership_form.exam_taken_options.#{professional_body_membership.exam_taken}")
+      br

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -936,6 +936,7 @@ en:
           one: Subject
           other: Subjects
         training_and_cpd: Training and continuing professional development (CPD)
+        professional_body_memberships: Professional body memberships
 
     sessions:
       new:

--- a/spec/system/publishers/publishers_can_view_a_jobseeker_profile_spec.rb
+++ b/spec/system/publishers/publishers_can_view_a_jobseeker_profile_spec.rb
@@ -6,9 +6,10 @@ RSpec.describe "Jobseeker profiles", type: :system do
   let(:jobseeker_profile) { create(:jobseeker_profile, :completed, :with_location_preferences) }
 
   before do
-    jobseeker_profile.job_preferences.update(roles: %w[ teacher headteacher deputy_headteacher assistant_headteacher head_of_year_or_phase head_of_department_or_curriculum teaching_assistant
-                                                        higher_level_teaching_assistant education_support sendco administration_hr_data_and_finance
-                                                        catering_cleaning_and_site_management it_support pastoral_health_and_welfare other_leadership other_support senior_leader middle_leader])
+    jobseeker_profile.job_preferences.update!(roles: %w[ teacher headteacher deputy_headteacher assistant_headteacher head_of_year_or_phase head_of_department_or_curriculum teaching_assistant
+                                                         higher_level_teaching_assistant education_support sendco administration_hr_data_and_finance
+                                                         catering_cleaning_and_site_management it_support pastoral_health_and_welfare other_leadership other_support senior_leader middle_leader])
+    create(:professional_body_membership, jobseeker_profile: jobseeker_profile)
   end
 
   scenario "A publisher can view a jobseeker's profile" do
@@ -37,5 +38,9 @@ RSpec.describe "Jobseeker profiles", type: :system do
     expect(page).to have_content(jobseeker_profile.training_and_cpds.first.grade)
     expect(page).to have_content(jobseeker_profile.training_and_cpds.first.year_awarded)
     expect(page).to have_content(jobseeker_profile.job_preferences.working_pattern_details)
+    expect(page).to have_content(jobseeker_profile.professional_body_memberships.first.name)
+    expect(page).to have_content(jobseeker_profile.professional_body_memberships.first.membership_type)
+    expect(page).to have_content(jobseeker_profile.professional_body_memberships.first.membership_number)
+    expect(page).to have_content(jobseeker_profile.professional_body_memberships.first.year_membership_obtained)
   end
 end


### PR DESCRIPTION
## Changes in this PR:

Prior to this PR, hiring staff could not see professional body membership information when viewing jobseeker profiles. This PR fixes this issue.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
