### PR TITLE
allow local authorities to view applicants

### DIFF
--- a/app/components/dashboard_component.rb
+++ b/app/components/dashboard_component.rb
@@ -59,7 +59,7 @@ class DashboardComponent < ApplicationComponent
   end
 
   def include_job_applications?
-    organisation.group_type != "local_authority" && @selected_type.in?(%w[published expired])
+    @selected_type.in?(%w[published expired])
   end
 
   def selected_scope

--- a/spec/components/dashboard_component_spec.rb
+++ b/spec/components/dashboard_component_spec.rb
@@ -140,8 +140,8 @@ RSpec.describe DashboardComponent, type: :component do
           expect(inline_component.css(".govuk-summary-list").to_html).to include(vacancy.job_title)
         end
 
-        it "does not render the link to view applicants" do
-          expect(page).not_to have_content(I18n.t("jobs.manage.view_applicants", count: 1))
+        it "renders the link to view applicants" do
+          expect(page).to have_content(I18n.t("jobs.manage.view_applicants", count: 1))
         end
 
         it "renders the local authority's name in the table" do


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/7CKCcd80/1572-bug-local-authorities-cant-view-applicants-for-a-vacancy

## Changes in this PR:

Remove LA restriction on viewing applicant listings