### PR TITLE
Typo on link causing missing template error

### DIFF
--- a/app/views/jobseekers/job_applications/professional_body_memberships/new.html.slim
+++ b/app/views/jobseekers/job_applications/professional_body_memberships/new.html.slim
@@ -18,4 +18,4 @@
       = f.govuk_submit t("buttons.save_and_continue")
 
     .govuk-button-group
-      = govuk_link_to t("buttons.cancel"), jobseekers_job_application_build_path(job_application, :professional_body_membership)
+      = govuk_link_to t("buttons.cancel"), jobseekers_job_application_build_path(job_application, :professional_body_memberships)

--- a/spec/system/jobseekers/jobseekers_can_add_professional_body_membership_to_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_professional_body_membership_to_job_application_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "Jobseekers can add professional body memberships to their job ap
     end
 
     it "allows jobseekers to add a professional body membership" do
+      expect(page).to have_link(I18n.t("buttons.cancel"), href: jobseekers_job_application_build_path(job_application, :professional_body_memberships))
       validates_step_complete(button: I18n.t("buttons.save_and_continue"))
       fill_in_professional_body_membership
       click_on I18n.t("buttons.save_and_continue")


### PR DESCRIPTION
## Changes in this PR:

This PR fixes [this bug](https://teaching-vacancies.sentry.io/issues/6273462218/?environment=production&referrer=alerts-related-issues-issue-stream) which caused the cancel link on the professional_body_memberships/new page to raise a missing template error.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
