### PR TITLE
Tests and devcontainer fixes

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,7 +9,7 @@ ARG TERRAFORM_VERSION=1.5.1
 
 # Set up NodeSource repository for newer Node.JS
 RUN apt update -yq \
-   && apt install curl gnupg -yq \
+   && apt install curl gnupg cmake -yq \
    && curl -sL https://deb.nodesource.com/setup_$NODEJS_MAJOR_VERSION.x | bash
 
 # Set up dependencies

--- a/.env.test
+++ b/.env.test
@@ -6,6 +6,7 @@ DFE_SIGN_IN_SUPPORT_USER_ROLE_ID=test-support-user-role-id
 DFE_SIGN_IN_URL=https://test-url.local
 DISABLE_EMAILS=false
 DOMAIN=localhost:3000
+GOOGLE_API_JSON_KEY={}
 GOVUK_ONE_LOGIN_BASE_URL=https://test-onelogin-url.local
 GOVUK_ONE_LOGIN_CLIENT_ID=one_login_client_id
 VACANCY_SOURCE_UNITED_LEARNING_FEED_URL=http://example.com/feed.xml

--- a/spec/lib/google_api_client_spec.rb
+++ b/spec/lib/google_api_client_spec.rb
@@ -8,8 +8,11 @@ RSpec.describe GoogleApiClient, type: :singleton do
   end
 
   before do
-    described_class.instance_variable_set(:@singleton__instance__, nil) # Needed to setup the instance with different values in each test
     allow(Google::Auth::ServiceAccountCredentials).to receive(:make_creds).and_return(authorizer)
+  end
+
+  after do
+    described_class.instance_variable_set(:@singleton__instance__, nil) # Cleans the singleton after each test
   end
 
   describe "#initialize" do

--- a/spec/system/publishers/publishers_can_manage_a_profile_spec.rb
+++ b/spec/system/publishers/publishers_can_manage_a_profile_spec.rb
@@ -384,7 +384,7 @@ RSpec.describe "Publishers can manage an organisation or school profile" do
 
       expect(page).to have_content(I18n.t("publishers.organisations.update_success", organisation_type: "School"))
       expect(organisation.reload.logo.attachment.filename.to_s).to eq(image_file_name)
-      expect(page).to have_css("img[src*='#{url_for(organisation.logo)}']")
+      expect(page).to have_css("img[src*='#{Capybara.app_host}#{rails_blob_path(organisation.logo, only_path: true)}']")
     end
   end
 
@@ -435,7 +435,7 @@ RSpec.describe "Publishers can manage an organisation or school profile" do
 
       expect(page).to have_content(I18n.t("publishers.organisations.update_success", organisation_type: "School"))
       expect(organisation.reload.photo.attachment.filename.to_s).to eq(image_file_name)
-      expect(page).to have_css("img[src*='#{url_for(organisation.photo)}']")
+      expect(page).to have_css("img[src*='#{Capybara.app_host}#{rails_blob_path(organisation.photo, only_path: true)}']")
     end
   end
 


### PR DESCRIPTION
Fixes a few test issues:
- Tests failing due to `GOOGLE_API_JSON_KEY` being set in the local development environment.
- Capybara tests failures when run through devcontainer due to Capybara app host differing from `localhost`.
- Ensure that the Google API Client tests clean the singleton instance after each test, not before.

Also adds a dependency to the devcontainer image. As I had to add it to upgrade the gems.
