### PR TITLE
move examples.txt file so it doesn't show up in IDE searches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,9 +24,6 @@ yarn-debug.log*
 
 .byebug_history
 
-# Ignore examples persistence file
-/spec/examples.txt
-
 # Ignore generated test coverage folder
 /coverage
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ RSpec.configure do |config|
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
   config.filter_run_when_matching :focus
-  config.example_status_persistence_file_path = "spec/examples.txt"
+  config.example_status_persistence_file_path = "tmp/examples.txt"
   config.disable_monkey_patching!
   config.default_formatter = "doc" if config.files_to_run.one?
   config.profile_examples = nil


### PR DESCRIPTION
## Changes in this PR:

move examples.txt file so it doesn't show up in IDE searches

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
