### PR TITLE
Remove robots/crawlers exclusion of sign-in page

### DIFF
--- a/app/views/robots/show.text.erb
+++ b/app/views/robots/show.text.erb
@@ -7,7 +7,6 @@ Disallow: /subscriptions/
 Disallow: /documents/
 Disallow: /attachments/
 Disallow: /*-jobs*?*
-Disallow: /*/sign-in
 Disallow: /jobs*radius=*
 Disallow: /support-users
 <%- else %>


### PR DESCRIPTION
The sign-in page now just points to external Oauth integrations for both Jobseekers and Hiring Staff.

Some search engines are providing a preview box of this (and others) link when teaching vacancies is returned. The link context shows some unhelpful message: "We would love to show you a description here but the site won't allow us".

Given we don't find downsides on allowing crawlers to visit this page, we are removing the exclusion so the search engines can list it.

Bing
![image](https://github.com/user-attachments/assets/eb2c4d6f-f8fa-4e19-bc3b-4e5eea7b719f)

DuckDuckGo
![image](https://github.com/user-attachments/assets/bcb433c4-72ac-4a4d-a6e2-ecc49f985e84)
