### PR TITLE
GoogleAPIClient tests tweaks

### DIFF
--- a/spec/lib/google_api_client_spec.rb
+++ b/spec/lib/google_api_client_spec.rb
@@ -11,8 +11,11 @@ RSpec.describe GoogleApiClient, type: :singleton do
     allow(Google::Auth::ServiceAccountCredentials).to receive(:make_creds).and_return(authorizer)
   end
 
-  after do
-    described_class.instance_variable_set(:@singleton__instance__, nil) # Cleans the singleton after each test
+  around do |example|
+    # Ensures the singleton class instance is independent for each test.
+    described_class.instance_variable_set(:@singleton__instance__, nil)
+    example.run
+    described_class.instance_variable_set(:@singleton__instance__, nil)
   end
 
   describe "#initialize" do

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -586,7 +586,7 @@ RSpec.describe Vacancy do
       end
 
       it "returns an array with trust_uid and school_urns" do
-        expect(vacancy.organisation_urns.sort).to eq([{ trust_uid: "12345", school_urns: %w[100002 100003].sort }])
+        expect(vacancy.organisation_urns).to contain_exactly({ trust_uid: "12345", school_urns: %w[100002 100003].sort })
       end
     end
   end

--- a/spec/system/publishers/publishers_can_manage_a_profile_spec.rb
+++ b/spec/system/publishers/publishers_can_manage_a_profile_spec.rb
@@ -365,9 +365,10 @@ RSpec.describe "Publishers can manage an organisation or school profile" do
   describe "changing the organisation's logo" do
     let(:organisation) { create(:school) }
     let(:image_file_name) { "blank_image.png" }
+    let(:document_virus_check) { instance_double(Publishers::DocumentVirusCheck, safe?: true) }
 
     before do
-      allow_any_instance_of(Publishers::DocumentVirusCheck).to receive(:safe?).and_return(true)
+      allow(Publishers::DocumentVirusCheck).to receive(:new).and_return(document_virus_check)
       click_link I18n.t("nav.school_profile")
     end
 
@@ -391,9 +392,10 @@ RSpec.describe "Publishers can manage an organisation or school profile" do
   describe "deleting the organisation's logo" do
     let(:organisation) { create(:school, :with_image) }
     let(:image_file_name) { "blank_image.png" }
+    let(:document_virus_check) { instance_double(Publishers::DocumentVirusCheck, safe?: true) }
 
     before do
-      allow_any_instance_of(Publishers::DocumentVirusCheck).to receive(:safe?).and_return(true)
+      allow(Publishers::DocumentVirusCheck).to receive(:new).and_return(document_virus_check)
       click_link I18n.t("nav.school_profile")
     end
 
@@ -416,9 +418,10 @@ RSpec.describe "Publishers can manage an organisation or school profile" do
   describe "changing the organisation's photo" do
     let(:organisation) { create(:school) }
     let(:image_file_name) { "blank_image.png" }
+    let(:document_virus_check) { instance_double(Publishers::DocumentVirusCheck, safe?: true) }
 
     before do
-      allow_any_instance_of(Publishers::DocumentVirusCheck).to receive(:safe?).and_return(true)
+      allow(Publishers::DocumentVirusCheck).to receive(:new).and_return(document_virus_check)
       click_link I18n.t("nav.school_profile")
     end
 
@@ -442,9 +445,10 @@ RSpec.describe "Publishers can manage an organisation or school profile" do
   describe "deleting the organisation's photo" do
     let(:organisation) { create(:school, :with_image) }
     let(:image_file_name) { "blank_image.png" }
+    let(:document_virus_check) { instance_double(Publishers::DocumentVirusCheck, safe?: true) }
 
     before do
-      allow_any_instance_of(Publishers::DocumentVirusCheck).to receive(:safe?).and_return(true)
+      allow(Publishers::DocumentVirusCheck).to receive(:new).and_return(document_virus_check)
       click_link I18n.t("nav.school_profile")
     end
 

--- a/spec/validators/form_file_validator_spec.rb
+++ b/spec/validators/form_file_validator_spec.rb
@@ -15,13 +15,16 @@ end
 
 RSpec.describe FormFileValidator do
   describe "#validate_each" do
-    before { allow_any_instance_of(described_class).to receive(:validating_files_after_form_submission?).and_return(true) }
+    let(:document_virus_check) { instance_double(Publishers::DocumentVirusCheck, safe?: true) }
+
+    before do
+      allow(Publishers::DocumentVirusCheck).to receive(:new).and_return(document_virus_check)
+      allow_any_instance_of(described_class).to receive(:validating_files_after_form_submission?).and_return(true)
+    end
 
     context "when the form's file type is a document" do
       let(:form_with_documents) { DummyFormFileValidatorForm.new({ supporting_documents: [uploaded_document] }) }
       let(:uploaded_document) { fixture_file_upload("blank_job_spec.pdf", "application/pdf") }
-
-      before { allow_any_instance_of(Publishers::DocumentVirusCheck).to receive(:safe?).and_return(true) }
 
       context "when the document is valid" do
         before do
@@ -60,7 +63,7 @@ RSpec.describe FormFileValidator do
         let(:error_message) { I18n.t("jobs.file_virus_error_message", filename: uploaded_document.original_filename) }
 
         before do
-          allow_any_instance_of(Publishers::DocumentVirusCheck).to receive(:safe?).and_return(false)
+          allow(document_virus_check).to receive(:safe?).and_return(false)
           form_with_documents.valid?
         end
 


### PR DESCRIPTION
1. Ensure restart of the tested singleton class around each test.
Instead of only restarting the instance before or after each test, that causes flaky test issues when run in parallel.
2. Mock Document Virus check instances creation
Instead of `allow_any_instance_of...` we explicitly mock the `DocumentVirusCheck` instantiation to return a test double that is safe/unsafe.