### PR TITLE
Fix flaky test due to inner array elems order

### DIFF
--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -586,7 +586,8 @@ RSpec.describe Vacancy do
       end
 
       it "returns an array with trust_uid and school_urns" do
-        expect(vacancy.organisation_urns).to contain_exactly({ trust_uid: "12345", school_urns: %w[100002 100003].sort })
+        expect(vacancy.organisation_urns)
+          .to contain_exactly(trust_uid: "12345", school_urns: contain_exactly("100002", "100003"))
       end
     end
   end


### PR DESCRIPTION
The order of the urns was causing test failures.
