### PR TITLE
Delete referenced to contract_type parental_leave_cover

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
  # Alpine v3.19.
  # TODO: Regularly check in the alpine ruby "3.3.6-alpine3.19" images for its latest upgraded packages so we can remove
  # the hardcoded versions below when they have been updated in the alpine ruby image.
-ARG PROD_PACKAGES="imagemagick libpng libjpeg libxml2 libxslt libpq tzdata shared-mime-info postgresql15 busybox openssl"
+ARG PROD_PACKAGES="imagemagick libpng libjpeg libxml2 libxslt libpq tzdata shared-mime-info postgresql15 busybox openssl=3.1.8-r0"
 
 FROM ruby:3.3.6-alpine3.19 AS builder
 

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -45,7 +45,7 @@ class Vacancy < ApplicationRecord
   array_enum working_patterns: { full_time: 0, part_time: 100, job_share: 101 }
   array_enum phases: { nursery: 0, primary: 1, middle: 2, secondary: 3, sixth_form_or_college: 4, through: 5 }
   array_enum job_roles: JOB_ROLES
-
+  # removed parental_leave_cover: 2 from contract types. No instances in DB.
   enum :contract_type, { permanent: 0, fixed_term: 1, casual: 3 }
   enum :ect_status, { ect_suitable: 0, ect_unsuitable: 1 }
   enum :hired_status, { hired_tvs: 0, hired_other_free: 1, hired_paid: 2, hired_no_listing: 3, not_filled_ongoing: 4, not_filled_not_looking: 5, hired_dont_know: 6 }

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -46,7 +46,7 @@ class Vacancy < ApplicationRecord
   array_enum phases: { nursery: 0, primary: 1, middle: 2, secondary: 3, sixth_form_or_college: 4, through: 5 }
   array_enum job_roles: JOB_ROLES
 
-  enum :contract_type, { permanent: 0, fixed_term: 1, parental_leave_cover: 2, casual: 3 }
+  enum :contract_type, { permanent: 0, fixed_term: 1, casual: 3 }
   enum :ect_status, { ect_suitable: 0, ect_unsuitable: 1 }
   enum :hired_status, { hired_tvs: 0, hired_other_free: 1, hired_paid: 2, hired_no_listing: 3, not_filled_ongoing: 4, not_filled_not_looking: 5, hired_dont_know: 6 }
   enum :listed_elsewhere, { listed_paid: 0, listed_free: 1, listed_mix: 2, not_listed: 3, listed_dont_know: 4 }

--- a/app/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy.rb
+++ b/app/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy.rb
@@ -65,7 +65,7 @@ module Vacancies::Export::DwpFindAJob::PublishedAndUpdatedVacancies
       case vacancy.contract_type
       when "permanent"
         TYPE_PERMANENT_ID
-      when "fixed_term", "parental_leave_cover"
+      when "fixed_term"
         TYPE_CONTRACT_ID
       end
     end

--- a/spec/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy_spec.rb
+++ b/spec/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy_spec.rb
@@ -310,11 +310,5 @@ RSpec.describe Vacancies::Export::DwpFindAJob::PublishedAndUpdated::ParsedVacanc
 
       expect(parsed.type_id).to eq(described_class::TYPE_CONTRACT_ID)
     end
-
-    it "returns the contract type id if the vacancy contract type is parental_leave_cover" do
-      allow(vacancy).to receive(:contract_type).and_return("parental_leave_cover")
-
-      expect(parsed.type_id).to eq(described_class::TYPE_CONTRACT_ID)
-    end
   end
 end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/lYuVXjVD/1561-bug-parental-leave-cover-translation-error

## Changes in this PR:

The issue on the ticket, as illustrated by the screenshot, is that translations are missing for vacancies which have `contract_type` set to `parental_leave_cover.` We no longer allow hiring staff to create vacancies with `contract_type `set to `parental_leave_cover` as we now populate the `is_parental_leave_cover` column. 

The missing translation was showing up because our seed file creates vacancies from the vacancy factory which randomly assigns a `contract_type` to each vacancy, and we had not removed `parental_leave_cover` from vacancy contract types. This PR fixes this issue.

Note: We do not have any vacancies in our prod database with `contract_type` set to `parental_leave_cover`

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
