### PR TITLE
Export casual vacancies with VacancyType of temporary to DWP find a job

### DIFF
--- a/app/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy.rb
+++ b/app/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy.rb
@@ -17,7 +17,7 @@ module Vacancies::Export::DwpFindAJob::PublishedAndUpdatedVacancies
     CONTRACT_TYPE_MAPPING = {
       "permanent" => TYPE_PERMANENT_ID,
       "fixed_term" => TYPE_CONTRACT_ID,
-      "casual" => TYPE_TEMPORARY_ID
+      "casual" => TYPE_TEMPORARY_ID,
     }.freeze
 
     attr_reader :vacancy

--- a/app/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy.rb
+++ b/app/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy.rb
@@ -12,6 +12,7 @@ module Vacancies::Export::DwpFindAJob::PublishedAndUpdatedVacancies
     STATUS_PART_TIME_ID = 2
     TYPE_PERMANENT_ID = 1
     TYPE_CONTRACT_ID = 2
+    TYPE_TEMPORARY_ID = 3
 
     attr_reader :vacancy
 
@@ -67,6 +68,8 @@ module Vacancies::Export::DwpFindAJob::PublishedAndUpdatedVacancies
         TYPE_PERMANENT_ID
       when "fixed_term"
         TYPE_CONTRACT_ID
+      when "casual"
+        TYPE_TEMPORARY_ID
       end
     end
 

--- a/app/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy.rb
+++ b/app/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy.rb
@@ -14,6 +14,12 @@ module Vacancies::Export::DwpFindAJob::PublishedAndUpdatedVacancies
     TYPE_CONTRACT_ID = 2
     TYPE_TEMPORARY_ID = 3
 
+    CONTRACT_TYPE_MAPPING = {
+      "permanent" => TYPE_PERMANENT_ID,
+      "fixed_term" => TYPE_CONTRACT_ID,
+      "casual" => TYPE_TEMPORARY_ID
+    }.freeze
+
     attr_reader :vacancy
 
     delegate :job_title, :organisation, to: :vacancy
@@ -63,14 +69,8 @@ module Vacancies::Export::DwpFindAJob::PublishedAndUpdatedVacancies
     end
 
     def type_id
-      case vacancy.contract_type
-      when "permanent"
-        TYPE_PERMANENT_ID
-      when "fixed_term"
-        TYPE_CONTRACT_ID
-      when "casual"
-        TYPE_TEMPORARY_ID
-      end
+      # using fetch here so that an error is raised if a new contract_type is added to vacancies but not mapped to a DWP VacancyType here.
+      CONTRACT_TYPE_MAPPING.fetch(vacancy.contract_type)
     end
 
     private

--- a/spec/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy_spec.rb
+++ b/spec/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy_spec.rb
@@ -310,5 +310,11 @@ RSpec.describe Vacancies::Export::DwpFindAJob::PublishedAndUpdated::ParsedVacanc
 
       expect(parsed.type_id).to eq(described_class::TYPE_CONTRACT_ID)
     end
+
+    it "returns the contract type id if the vacancy contract type is casual" do
+      allow(vacancy).to receive(:contract_type).and_return("casual")
+
+      expect(parsed.type_id).to eq(described_class::TYPE_TEMPORARY_ID)
+    end
   end
 end

--- a/spec/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy_spec.rb
+++ b/spec/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy_spec.rb
@@ -316,5 +316,13 @@ RSpec.describe Vacancies::Export::DwpFindAJob::PublishedAndUpdated::ParsedVacanc
 
       expect(parsed.type_id).to eq(described_class::TYPE_TEMPORARY_ID)
     end
+
+    it "has a type_id mapping for all defined contract types" do
+      Vacancy.contract_types.keys.each do |contract_type|
+        allow(vacancy).to receive(:contract_type).and_return(contract_type)
+  
+        expect { parsed.type_id }.not_to raise_error
+      end
+    end
   end
 end

--- a/spec/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy_spec.rb
+++ b/spec/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy_spec.rb
@@ -318,9 +318,9 @@ RSpec.describe Vacancies::Export::DwpFindAJob::PublishedAndUpdated::ParsedVacanc
     end
 
     it "has a type_id mapping for all defined contract types" do
-      Vacancy.contract_types.keys.each do |contract_type|
+      Vacancy.contract_types.each_key do |contract_type|
         allow(vacancy).to receive(:contract_type).and_return(contract_type)
-  
+
         expect { parsed.type_id }.not_to raise_error
       end
     end


### PR DESCRIPTION
## Changes in this PR:

Prior to this change, we were not sending a value for the VacancyType column if the vacancy had a contract_type of "casual". This change means that we send populate VacancyType with 3 which maps to "temporary" on DWPs side. I am not sure if we are happy mapping "casual" -> "temporary" and am open to opinions.

See screenshot for DWP VacancyType mappings or see pages 20/21 [here](https://static.findajob.dwp.gov.uk/images/find_a_job_bulk_upload_spec_v3.0.pdf)

![Screenshot 2025-02-11 at 15 27 12](https://github.com/user-attachments/assets/384d335e-fcd7-4348-94f6-1b12503298b4)

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
