### PR TITLE
Email sub multiple job types

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -90,7 +90,7 @@ class Subscription < ApplicationRecord
     # and convert them into an array matcher using any?
     if JOB_ROLE_ALIASES.any? { |job_role_alias| criteria.key?(job_role_alias) }
       job_roles = criteria.slice(*JOB_ROLE_ALIASES).values
-      criteria.merge!(job_roles: job_roles)
+      criteria[:job_roles] = job_roles
     end
 
     vacancies = scope.select do |vacancy|

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -224,13 +224,26 @@ RSpec.describe Subscription do
       context "with teaching job roles" do
         before do
           create(:vacancy, :published_slugged, contact_number: "teach1", job_roles: %w[teacher], subjects: %w[English], phases: %w[secondary], working_patterns: %w[full_time])
+          create(:vacancy, :published_slugged, contact_number: "itsupp1", job_roles: %w[it_support], subjects: %w[English], phases: %w[secondary], working_patterns: %w[full_time])
         end
 
         let(:teacher_vacancy) { Vacancy.find_by!(contact_number: "teach1") }
-        let(:subscription) { create(:subscription, teaching_job_roles: %w[teacher], frequency: :daily) }
+        let(:it_vacancy) { Vacancy.find_by!(contact_number: "itsupp1") }
 
-        it "only finds the teaching job" do
-          expect(vacancies).to eq([teacher_vacancy])
+        context "with single filter" do
+          let(:subscription) { create(:subscription, teaching_job_roles: %w[teacher], frequency: :daily) }
+
+          it "only finds the teaching job" do
+            expect(vacancies).to eq([teacher_vacancy])
+          end
+        end
+
+        context "with multiple filters" do
+          let(:subscription) { create(:subscription, teaching_job_roles: %w[teacher], support_job_roles: %w[it_support], frequency: :daily) }
+
+          it "finds both jobs" do
+            expect(vacancies).to contain_exactly(teacher_vacancy, it_vacancy)
+          end
         end
       end
 


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/bk6LFLyh/1566-bug-job-alerts-email-subscription-roles-need-to-stack-results

## Changes in this PR:

Convert all job_roles filters to a single 'or' filter
