### PR TITLE
Remove all school roles banner

### DIFF
--- a/app/components/dashboard_component/dashboard_component.html.slim
+++ b/app/components/dashboard_component/dashboard_component.html.slim
@@ -1,11 +1,5 @@
 = tag.div(**html_attributes) do
   .govuk-grid-row
-    .govuk-grid-column-full
-      = govuk_notification_banner title_text: "Important", classes: "govuk-notification-banner govuk-!-margin-top-0 govuk-!-margin-bottom-5" do |banner|
-        - banner.with_heading(text: t("jobs.dashboard.non-teaching-roles-banner.heading"))
-        p.govuk-body = govuk_link_to(t("jobs.dashboard.non-teaching-roles-banner.link_text"), "/get-help-hiring/how-to-create-job-listings-and-accept-applications/how-to-list-non-teaching-roles")
-
-  .govuk-grid-row
     .govuk-grid-column-three-quarters
       .help-guide--mobile.help-guide--border-bottom
         h2.govuk-heading-m = t("jobs.dashboard.how_to_accept_job_applications_guide.title")

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -21,9 +21,6 @@ en:
       how_to_accept_job_applications_guide:
         link_text: Find out how to use the Teaching Vacancies application form
         title: Accept job applications using our online form
-      non-teaching-roles-banner:
-        heading: You can now create job listings for all roles in your school or trust.
-        link_text: Find out how to list non-teaching roles.
       pending:
         tab_heading: Scheduled jobs
         with_count: Scheduled jobs (%{count})


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/NlzP4s2G/1492-remove-all-school-roles-banner

## Changes in this PR:

Prior to this change, when hiring staff sign in, they get this all school roles banner. Now that we’ve launched all school roles for a significant period of time and have sent a lot of comms about it, we can remove it. This PR removes the banner.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
