### PR TITLE
Prevent duplicate vacancies in API

### DIFF
--- a/app/services/publishers/ats_api/create_vacancy_service.rb
+++ b/app/services/publishers/ats_api/create_vacancy_service.rb
@@ -7,15 +7,11 @@ module Publishers
         def call(params)
           vacancy = Vacancy.new(sanitised_params(params))
 
-          if (conflict = conflict_vacancy(vacancy) || duplicate_vacancy(vacancy))
-            return conflict_response(conflict)
+          if (conflict = find_conflicting_vacancy(vacancy))
+            return conflict_response(conflict[:vacancy], conflict[:error_message])
           end
 
-          if vacancy.save
-            success_response(vacancy)
-          else
-            validation_error_response(vacancy)
-          end
+          vacancy.save ? success_response(vacancy) : validation_error_response(vacancy)
         end
 
         private
@@ -25,6 +21,14 @@ module Publishers
 
           params[:publish_on] ||= Time.zone.today.to_s
           params.except(:schools).merge(organisations: organisations)
+        end
+
+        def find_conflicting_vacancy(vacancy)
+          if (conflict = conflict_vacancy(vacancy))
+            { vacancy: conflict, error_message: "A vacancy with the provided ATS client ID and external reference already exists." }
+          elsif (duplicate = duplicate_vacancy(vacancy))
+            { vacancy: duplicate, error_message: "A vacancy with the same job title, expiry date, and organisation already exists." }
+          end
         end
 
         def conflict_vacancy(vacancy)
@@ -42,11 +46,11 @@ module Publishers
           ).distinct.first
         end
 
-        def conflict_response(conflict_vacancy)
+        def conflict_response(conflict_vacancy, error_message)
           {
             status: :conflict,
             json: {
-              error: "A vacancy with the provided data already exists",
+              error: error_message,
               link: Rails.application.routes.url_helpers.vacancy_url(conflict_vacancy),
             },
           }

--- a/spec/services/publishers/ats_api/create_vacancy_service_spec.rb
+++ b/spec/services/publishers/ats_api/create_vacancy_service_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Publishers::AtsApi::CreateVacancyService do
         {
           status: :conflict,
           json: {
-            error: "A vacancy with the provided data already exists",
+            error: "A vacancy with the provided ATS client ID and external reference already exists.",
             link: Rails.application.routes.url_helpers.vacancy_url(existing_vacancy),
           },
         }
@@ -185,7 +185,7 @@ RSpec.describe Publishers::AtsApi::CreateVacancyService do
         {
           status: :conflict,
           json: {
-            error: "A vacancy with the provided data already exists",
+            error: "A vacancy with the same job title, expiry date, and organisation already exists.",
             link: Rails.application.routes.url_helpers.vacancy_url(existing_vacancy),
           },
         }


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/tYTC3Qrw/1543-ats-api-do-not-allow-the-same-vacancy-for-the-same-org-to-be-posted-multiple-times-through-different-clients

## Changes in this PR:

Prevent duplicate vacancies to be posted from ATSs


