### PR TITLE
Extend cached period of Google Geocoding results

### DIFF
--- a/lib/geocoding.rb
+++ b/lib/geocoding.rb
@@ -1,5 +1,9 @@
 class Geocoding
-  CACHE_DURATION = 30.days
+  # The geographical coordinates of the UK are stable and unlikely to change, allowing us to cache the results for an
+  # extended period.
+  # Due to the high volume of location searches we receive daily (over 70k/day at the time of writing),
+  # the cache refresh period significantly impacts our Google Geocoding API usage and billing.
+  CACHE_DURATION = 180.days
 
   attr_reader :location
 


### PR DESCRIPTION
We're attempting to cut costs on the Google Geocoding bill.

Currently, we query the API around 4.26k times per day on average. The volume of location searches received by the server exceeds 70k searches per day.

As the geocoding information within the UK is very stable data, keeping the results cached for only 30 days seems quite a conservative approach.

By increasing it to 180 days we aim to reduce the amount of times the same location searches get re-queried to the API.

