### PR TITLE
fix import counties script URL, and improve test to indicate behaviour

### DIFF
--- a/app/services/ons_data_import/import_counties.rb
+++ b/app/services/ons_data_import/import_counties.rb
@@ -1,6 +1,6 @@
 class OnsDataImport::ImportCounties < OnsDataImport::Base
   def api_name
-    "Counties_and_Unitary_Authorities_April_2019_Boundaries_EW_BUC_2022"
+    "Counties_and_Unitary_Authorities_April_2019_Boundaries_EW_BFC_2022"
   end
 
   def name_field

--- a/spec/fixtures/files/ons_counties_geojson.json
+++ b/spec/fixtures/files/ons_counties_geojson.json
@@ -36,7 +36,7 @@
         ]
       },
       "properties" : {
-        "CTYUA19NM" : "Nowhereshire"
+        "CTYUA19NM" : "Conwy"
       }
     }
   ]

--- a/spec/services/ons_data_import/import_counties_spec.rb
+++ b/spec/services/ons_data_import/import_counties_spec.rb
@@ -6,24 +6,26 @@ RSpec.describe OnsDataImport::ImportCounties do
   let(:response1) { double(success?: true, to_s: file_fixture("ons_counties_geojson.json").read) }
   let(:response2) { double(success?: true, to_s: { features: [] }.to_json) }
 
+  # sadly this can't be a VCR test because the resultant download file is 118Mb
+  # which is impractical to even cut-down
   before do
     allow(HTTParty).to receive(:get)
-      .with(/Counties_and_Unitary_Authorities_April_2019_Boundaries_EW_BUC_2022/)
+      .with(/Counties_and_Unitary_Authorities_April_2019_Boundaries_EW_BFC_2022/)
       .and_return(response1, response2)
     subject.call
   end
 
   describe "#call" do
     let(:lincolnshire) { LocationPolygon.find_by(name: "lincolnshire") }
-    let(:nowhereshire) { LocationPolygon.find_by(name: "nowhereshire") }
+    let(:conwy) { LocationPolygon.find_by(name: "conwy") }
 
     it "creates a LocationPolygon for Lincolnshire" do
       expect(lincolnshire.area.to_s).to eq("POLYGON ((0.0 0.0, 1.0 1.0, 1.0 -1.0, 0.0 0.0))")
       expect(lincolnshire.location_type).to eq("counties")
     end
 
-    it "does not create a LocationPolygon for Nowhereshire" do
-      expect(nowhereshire).to be_nil
+    it "does not create a LocationPolygon for Conwy as it is welsh" do
+      expect(conwy).to be_nil
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR:

fix import counties script URL

- Is there anything specific you want feedback on?

I tried to convert the test to VCR, but the resultant 118 Mb file put me off. But this defect remained hidden for 2 years because of a developer typo in both script and test - over mocking. 

Having looked into the mechanism, it's possible that there are some errors of omission - everything is configured by hand (including the exclusion of Welsh data). It might be worth a re-look at some point

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
