### PR TITLE
Move homepage create job link

### DIFF
--- a/app/views/home/_landing_page_links.html.slim
+++ b/app/views/home/_landing_page_links.html.slim
@@ -1,4 +1,4 @@
-  .landing-page-links
+.landing-page-links
   = govuk_accordion do |accordion|
     - accordion.with_section(heading_text: t(".jobs_by_school_type_and_role")) do
       = landing_page_link_group title: t(".teaching_roles"), classes: "govuk-grid-column-one-third" do |group|

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -3,24 +3,21 @@
 = render "search"
 
 .govuk-grid-row class="govuk-!-margin-top-6"
-  .govuk-grid-column-one-half
-    h2.govuk-heading-m = t(".title_h2")
-    p.govuk-body = t(".description")
-    p.govuk-body = t(".personal_statement_section.description_html",
-                     personal_statement_guide_link: govuk_link_to(t(".personal_statement_section.link_text"),
-                                                    posts_path(section: "jobseeker-guides"),
-                                                    class: "govuk-link--no-visited-state"))
-  .govuk-grid-column-one-quarter
+  .govuk-grid-column-one-third
+    h2.govuk-heading-m = t("nav.create_a_job_alert")
+    p.govuk-body = t(".alerts_description")
+    = govuk_button_link_to(t("buttons.setup_alerts"), new_subscription_path, class: "govuk-!-margin-bottom-2 govuk-button--secondary")
+  .govuk-grid-column-one-third
     h2.govuk-heading-m = t(".jobseeker_section.title")
     - if jobseeker_signed_in?
       p.govuk-body = t(".jobseeker_section.signed_in.description")
       .govuk-body class="govuk-!-margin-bottom-3" = govuk_link_to t("buttons.view_account"), jobseeker_root_path, class: "govuk-link--no-visited-state"
     - else
       p.govuk-body = t(".jobseeker_section.signed_out.description_html")
-      = govuk_button_link_to(t("buttons.sign_in"), new_jobseeker_session_path, class: "govuk-!-margin-bottom-2")
+      = govuk_button_link_to(t("buttons.sign_in"), new_jobseeker_session_path, class: "govuk-!-margin-bottom-2 govuk-button--secondary")
       p.govuk-body = t(".jobseeker_section.signed_out.create_account_html", create_account_link: govuk_link_to(t(".jobseeker_section.signed_out.link_text.create_account"), new_jobseeker_session_path, class: "govuk-link--no-visited-state"))
 
-  .govuk-grid-column-one-quarter
+  .govuk-grid-column-one-third
     h2.govuk-heading-m = t(".publisher_section.title")
     - if publisher_signed_in?
       p.govuk-body = t(".publisher_section.signed_in.description_html",
@@ -28,7 +25,7 @@
         manage_jobs_link: govuk_link_to(t(".publisher_section.signed_in.link_text.manage_jobs"), organisation_jobs_with_type_path, class: "govuk-link--no-visited-state"))
     - else
       p.govuk-body = t(".publisher_section.signed_out.description_html")
-      = govuk_button_link_to(t(".publisher_section.signed_out.link_text.sign_in"), publishers_sign_in_path, class: "govuk-!-margin-bottom-2")
+      = govuk_button_link_to(t(".publisher_section.signed_out.link_text.sign_in"), publishers_sign_in_path, class: "govuk-!-margin-bottom-2 govuk-button--secondary")
       p.govuk-body = t(".publisher_section.signed_out.create_account_html", create_account_link: govuk_link_to(t(".publisher_section.signed_out.link_text.create_account"), page_path("dsi-account-request"), class: "govuk-link--no-visited-state"))
 
 = render "landing_page_links"

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -17,5 +17,4 @@
     = header.with_navigation_item text: t("nav.support_user_dashboard"), href: support_user_root_path, active: current_page?(support_user_root_path)
     = header.with_navigation_item text: t("nav.sign_out"), href: destroy_support_user_session_path, options: { method: :delete }
   - else
-    = header.with_navigation_item text: t("nav.create_a_job_alert"), href: new_subscription_path
     = header.with_navigation_item text: t("nav.sign_in"), href: page_path("sign-in")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -157,6 +157,7 @@ en:
             create_account: create a jobseeker account
             sign_in: Jobseeker sign in
         title: For jobseekers
+      alerts_description: Receive email alerts with the latest jobs for this search
       personal_statement_section:
         description_html: You can apply for jobs, set up job alerts and %{personal_statement_guide_link}.
         link_text: read advice for jobseekers

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -96,6 +96,7 @@ en:
       one: Open filters (%{count} applied)
       other: Open filters (%{count} applied)
     sign_in: Sign in
+    setup_alerts: Set up alerts
     sign_in_to_download: Sign in to download application form
     sign_in_jobseeker: Sign in as a jobseeker
     sign_in_publisher: Sign in as hiring staff

--- a/spec/smoke_tests/jobseekers_can_view_homepage_spec.rb
+++ b/spec/smoke_tests/jobseekers_can_view_homepage_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Page availability", js: true, smoke_test: true do
       page.driver.browser.manage.add_cookie(name: "consented-to-cookies", value: "no", domain: smoke_test_domain)
 
       page.visit "#{base_url}/"
-      expect(page).to have_content(I18n.t("jobs.heading"))
+      expect(page).to have_content(I18n.t("nav.create_a_job_alert"))
 
       page.visit "#{base_url}/jobs?keyword=Maths"
 

--- a/spec/system/other/users_can_view_the_main_navigation_spec.rb
+++ b/spec/system/other/users_can_view_the_main_navigation_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe "Main navigation for users to sign in and out" do
 
     it "renders the correct links" do
       within ".govuk-header__navigation" do
-        expect(page).to have_content(I18n.t("nav.create_a_job_alert"))
         expect(page).to have_content(I18n.t("buttons.sign_in"))
       end
     end

--- a/spec/system/publishers/publishers_can_visit_the_public_listings_spec.rb
+++ b/spec/system/publishers/publishers_can_visit_the_public_listings_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe "School viewing public listings" do
     within(".govuk-header__navigation") { expect(page).to have_content(I18n.t("nav.manage_jobs")) }
 
     within(".govuk-header") { click_on(I18n.t("app.title")) }
-    expect(page).to have_content(I18n.t("jobs.heading"))
 
     within(".govuk-header__navigation") { click_on(I18n.t("nav.manage_jobs")) }
     expect(page).to have_content(school.name)


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/11cXL3o5/1565-move-create-a-job-alert-link-on-the-home-page

## Changes in this PR:

- Is there anything specific you want feedback on?

## Screenshots of UI changes:

### Before
![HomePageBefore2](https://github.com/user-attachments/assets/2928ba9f-8df0-4ac2-a8fd-793830af5e23)


### After
![HomePageAfter2](https://github.com/user-attachments/assets/d3eea016-cf88-4e9e-aea0-595bf40ab1e4)


## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
