### PR TITLE
Reduce the sample rate for Sentry FE error replays

### DIFF
--- a/app/assets/javascript/application.js
+++ b/app/assets/javascript/application.js
@@ -37,7 +37,7 @@ Sentry.init({
   dsn: window.sentryConfig.dsn,
   integrations: [Sentry.replayIntegration()],
   replaysSessionSampleRate: 0,
-  replaysOnErrorSampleRate: 1.0,
+  replaysOnErrorSampleRate: 0.1,
   environment: window.sentryConfig.environment,
   release: window.sentryConfig.release,
   tracesSampleRate: 0, // Disable tracing (performance monitoring, doesn't impact errors)


### PR DESCRIPTION
We don't need to get the replay for 100% of the errors. It is costing us extra billing.