### PR TITLE
Fix bug which causes job preferences page to crash if a JobPreference…

### DIFF
--- a/app/controllers/jobseekers/profiles/job_preferences_controller.rb
+++ b/app/controllers/jobseekers/profiles/job_preferences_controller.rb
@@ -96,7 +96,7 @@ module Jobseekers::Profiles
     end
 
     def job_preference_record
-      @job_preference_record ||= profile.job_preferences
+      @job_preference_record ||= profile.job_preferences || profile.build_job_preferences
     end
 
     def force_location_added

--- a/spec/system/jobseekers/jobseekers_can_add_job_preferences_to_their_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_job_preferences_to_their_profile_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe "Jobseekers can add job preferences to their profile" do
     context "when adding job preferences" do
       before do
         visit jobseekers_profile_path
-        create(:job_preferences, completed_steps: [], builder_completed: false, jobseeker_profile: jobseeker.jobseeker_profile)
       end
 
       it "allows jobseekers to add job preferences" do


### PR DESCRIPTION
## Changes in this PR:

This PR fixes [this bug](https://teaching-vacancies.sentry.io/issues/5991105845/?environment=production&project=6212514&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D%20NoMethodError&referrer=issue-stream&statsPeriod=30d&stream_index=0) which has been causing us issues since October.

We create an instance of JobseekerProfile when the user visits the jobseeker profile page. We do this using [JobseekerProfile#prepare](https://github.com/DFE-Digital/teaching-vacancies/blob/main/app/models/concerns/profile_section.rb) which should in turn create an associated instance of JobPreferences and PersonalDetails. It seems like this sometimes fails which causes the above error when users try to visit the job preferences page and job preferences do not exist. This change fixes the issue.

Note: I did not need to do the same for personal details as we already build an instance of PersonDetails if one does not exist (as can be seen [here](https://github.com/DFE-Digital/teaching-vacancies/blob/dfd4ba12798acd25adc46b9d2c13b5b82acf9824/app/controllers/jobseekers/profiles/personal_details_controller.rb#L22)), but for some reason we were not doing the same for job preferences.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
