### PR TITLE
multiple keywords in email searches

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -25,7 +25,7 @@ class Subscription < ApplicationRecord
     phases: ->(vacancy, value) { vacancy.phases.intersect?(value) },
     working_patterns: ->(vacancy, value) { working_pattern_match?(vacancy, value) },
     organisation_slug: ->(vacancy, value) { vacancy.organisations.map(&:slug).include?(value) },
-    keyword: ->(vacancy, value) { vacancy.searchable_content.include? value.downcase.strip },
+    keyword: ->(vacancy, value) { value.downcase.strip.split.all? { |k| vacancy.searchable_content.include? k } },
   }.freeze
 
   class << self

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -136,6 +136,14 @@ RSpec.describe Subscription do
           end
         end
 
+        context "with multiple keywords" do
+          let(:keyword) { "really nice" }
+
+          it "finds the nice job" do
+            expect(vacancies).to eq([nice_job])
+          end
+        end
+
         context "with keyword caps and trailing space" do
           let(:keyword) { "Nice " }
 


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/vGSBn3W4/1606-bug-multiple-keywords-not-handled-properly-during-email-subscription

## Changes in this PR:

Deal with multiple keywords searches. People search for 'Teaching assistant' keywords and teaching assistant filter, and at the moment that produces zero results as the searchable content is organised by word

- Is there anything specific you want feedback on?

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
