### PR TITLE
Remove legacy 'phase' field from vacancy

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -68,6 +68,9 @@ class Organisation < ApplicationRecord
     through: 7,
   }
 
+  # This appears to be unused and confusing
+  self.ignored_columns += %i[readable_phases]
+
   def all_vacancies
     ids = school? ? [id] : [id] + schools.pluck(:id) + schools_outside_local_authority.pluck(:id)
     Vacancy.in_organisation_ids(ids)

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -120,6 +120,9 @@ class Vacancy < ApplicationRecord
   EQUAL_OPPORTUNITIES_PUBLICATION_THRESHOLD = 5
   EXPIRY_TIME_OPTIONS = %w[8:00 9:00 12:00 15:00 23:59].freeze
 
+  # This should have been ignored and removed in late 2022
+  self.ignored_columns += %i[phase]
+
   # Class method added to help with the mapping of array_enums for paper_trail, which stores the changes
   # as an array of integers in the version.
   def self.array_enums

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -404,7 +404,6 @@ shared:
     - job_location
     - job_roles
     - starts_asap
-    - phase
     - pay_scale
     - receive_applications
     - application_email

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -251,7 +251,6 @@ shared:
     - gias_data
     - created_at
     - updated_at
-    - readable_phases
     - url_override
     - region
     - detailed_school_type

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -8,20 +8,6 @@ namespace :db do # rubocop:disable Metrics/BlockLength
     end
   end
 
-  # TODO: remove phase field from vacancies table once this is done
-  desc "Set phases from schools or old readable_phases field and benefits"
-  task set_new_phases_and_benefits: :environment do
-    Vacancy.find_each do |v|
-      phases =
-        if v.school_phases.any?
-          v.school_phases.map { |p| Vacancy.phases[p] }
-        else
-          v.readable_phases.map { |p| p.in?(["16-19", "16 to 19"]) ? 4 : Vacancy.phases[p] }
-        end
-      v.update_columns phases: phases, benefits: v.benefits_details.present?
-    end
-  end
-
   desc "Asynchronously import organisations from GIAS and seed the database"
   task async_seed: :environment do
     SeedDatabaseJob.perform_later

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -29,7 +29,6 @@ FactoryBot.define do
     maximum_age { 18 }
     sequence(:name) { |n| "#{Faker::Educator.secondary_school.strip.delete("'")} #{n}" }
     phase { :secondary }
-    readable_phases { %w[secondary] }
     region { "South-East England" }
     safeguarding_information { Faker::Lorem.paragraph(sentence_count: 1) }
     sequence(:slug) { |n| "#{name.parameterize}-#{n}" }

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -107,7 +107,6 @@ FactoryBot.define do
     end
 
     trait :central_office do
-      phase { "multiple_phases" }
       organisations { build_list(:trust, 1) }
     end
 

--- a/spec/fixtures/basildon_schools.yml
+++ b/spec/fixtures/basildon_schools.yml
@@ -95,8 +95,6 @@
     name: updated_at
     value_before_type_cast: 2024-11-28 23:00:46.134741000 Z
   - !ruby/object:ActiveModel::Attribute::FromDatabase
-    name: readable_phases
-  - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: url_override
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: region
@@ -249,8 +247,6 @@
     name: updated_at
     value_before_type_cast: 2024-11-28 23:01:00.378077000 Z
   - !ruby/object:ActiveModel::Attribute::FromDatabase
-    name: readable_phases
-  - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: url_override
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: region
@@ -400,8 +396,6 @@
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: updated_at
     value_before_type_cast: 2024-11-28 23:01:01.282103000 Z
-  - !ruby/object:ActiveModel::Attribute::FromDatabase
-    name: readable_phases
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: url_override
   - !ruby/object:ActiveModel::Attribute::FromDatabase

--- a/spec/fixtures/liverpool_schools.yml
+++ b/spec/fixtures/liverpool_schools.yml
@@ -97,8 +97,6 @@
     name: updated_at
     value_before_type_cast: 2024-11-28 23:00:39.433225000 Z
   - !ruby/object:ActiveModel::Attribute::FromDatabase
-    name: readable_phases
-  - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: url_override
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: region
@@ -254,8 +252,6 @@
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: updated_at
     value_before_type_cast: 2024-11-28 23:00:40.696169000 Z
-  - !ruby/object:ActiveModel::Attribute::FromDatabase
-    name: readable_phases
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: url_override
   - !ruby/object:ActiveModel::Attribute::FromDatabase

--- a/spec/fixtures/st_albans_schools.yml
+++ b/spec/fixtures/st_albans_schools.yml
@@ -99,8 +99,6 @@
     name: updated_at
     value_before_type_cast: 2024-11-28 23:00:43.233243000 Z
   - !ruby/object:ActiveModel::Attribute::FromDatabase
-    name: readable_phases
-  - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: url_override
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: region
@@ -249,8 +247,6 @@
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: updated_at
     value_before_type_cast: 2024-11-28 23:00:53.290075000 Z
-  - !ruby/object:ActiveModel::Attribute::FromDatabase
-    name: readable_phases
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: url_override
   - !ruby/object:ActiveModel::Attribute::FromDatabase
@@ -402,8 +398,6 @@
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: updated_at
     value_before_type_cast: 2024-11-28 23:00:56.309950000 Z
-  - !ruby/object:ActiveModel::Attribute::FromDatabase
-    name: readable_phases
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: url_override
   - !ruby/object:ActiveModel::Attribute::FromDatabase

--- a/spec/jobs/import_from_vacancy_source_job_spec.rb
+++ b/spec/jobs/import_from_vacancy_source_job_spec.rb
@@ -147,7 +147,6 @@ RSpec.describe ImportFromVacancySourceJob do
           "part_time_details" => nil,
           "pay_scale" => "Main pay range 1 to Upper pay range 3, £23,719 to £39,406 per year (full time equivalent)",
           "personal_statement_guidance" => "Maxime blanditiis quos. Cum officia facilis. Et et quod. Dolore id ut. Id aut quia.",
-          "phase" => nil,
           "phases" => [],
           "publish_on" => Date.today.strftime("%Y-%m-%d"),
           "publisher_id" => nil,

--- a/spec/requests/publishers/vacancies/build_spec.rb
+++ b/spec/requests/publishers/vacancies/build_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Job applications build" do
     context "when the vacancy has been published" do
       context "when dependent steps have been made invalid" do
         context "when changing the job location" do
-          let(:vacancy) { create(:vacancy, :published, phase: "nursery", organisations: [school_one]) }
+          let(:vacancy) { create(:vacancy, :published, phases: ["nursery"], organisations: [school_one]) }
 
           before do
             allow(vacancy).to receive(:allow_key_stages?).and_return(true)
@@ -75,7 +75,7 @@ RSpec.describe "Job applications build" do
         end
 
         context "when changing the education_phase" do
-          let(:vacancy) { create(:vacancy, :published, phase: "nursery", organisations: [school_without_phase]) }
+          let(:vacancy) { create(:vacancy, :published, phases: ["nursery"], organisations: [school_without_phase]) }
 
           before { patch(organisation_job_build_path(vacancy.id, :education_phases, params)) }
 

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -188,7 +188,6 @@ module VacancyHelpers
     verify_job_locations(vacancy)
 
     expect(page).to have_content(vacancy.readable_job_roles)
-    expect(page).to have_content(vacancy.phase&.humanize) if vacancy.phase.present?
     expect(page).to have_content(vacancy.job_title)
     expect(page).to have_content(vacancy.readable_key_stages) if vacancy.key_stages.present?
     expect(page).to have_content(vacancy.readable_subjects) if vacancy.subjects.any?


### PR DESCRIPTION
## Trello card URL

## Changes in this PR:

Remove legacy 'phase' field from vacancy

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
