### PR TITLE
References validation

### DIFF
--- a/app/form_models/jobseekers/job_application/references_form.rb
+++ b/app/form_models/jobseekers/job_application/references_form.rb
@@ -23,7 +23,7 @@ module Jobseekers
 
       def at_least_one_most_recent_employer
         return if references.any?(&:is_most_recent_employer)
-      
+
         errors.add(:references, :must_include_most_recent_employer)
       end
     end

--- a/app/form_models/jobseekers/job_application/references_form.rb
+++ b/app/form_models/jobseekers/job_application/references_form.rb
@@ -17,9 +17,15 @@ module Jobseekers
       end
 
       attribute :references
-      validates :references, length: { minimum: 2 }, if: -> { references_section_completed }
+      validate :at_least_one_most_recent_employer, if: -> { references_section_completed }
 
       completed_attribute(:references)
+
+      def at_least_one_most_recent_employer
+        return if references.any?(&:is_most_recent_employer)
+      
+        errors.add(:references, :must_include_most_recent_employer)
+      end
     end
   end
 end

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -250,7 +250,7 @@ en:
           step_title: Education and qualifications
           title: Education and qualifications — Application
         references:
-          description: You need 2 referees for this application but you may add more.
+          description: You must include your current or most recent employer as a referee. If you did not work with children in this role, you must also provide a referee from your last job where you worked with children.
           heading: References
           no_references: No referees specified
           step_title: References

--- a/config/locales/jobseekers/job_application/references_form.yml
+++ b/config/locales/jobseekers/job_application/references_form.yml
@@ -8,6 +8,7 @@ en:
               inclusion: Select yes if you have completed this section
             references:
               too_short: You must provide a minimum of %{count} references
+              must_include_most_recent_employer: At least one reference must be marked as the most recent employer.
   helpers:
     legend:
       jobseekers_job_application_references_form:

--- a/spec/factories/job_applications.rb
+++ b/spec/factories/job_applications.rb
@@ -62,7 +62,7 @@ FactoryBot.define do
       if options.create_details
         create_list :employment, 3, :job, job_application: job_application
         create_list :employment, 1, :break, job_application: job_application
-        create_list :reference, 2, job_application: job_application
+        create_list :reference, 1, job_application: job_application, is_most_recent_employer: true
         create_list :qualification, 3, job_application: job_application
         create_list :training_and_cpd, 2, job_application: job_application
       end

--- a/spec/factories/references.rb
+++ b/spec/factories/references.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     email { Faker::Internet.email(domain: "contoso.com") }
     phone_number { "01234 567890" }
     created_at { Faker::Date.in_date_period(year: 2016) }
+    is_most_recent_employer { [true, false].sample }
 
     job_application
   end

--- a/spec/form_models/jobseekers/job_application/references_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/references_form_spec.rb
@@ -3,16 +3,16 @@
 require "rails_helper"
 
 RSpec.describe Jobseekers::JobApplication::ReferencesForm do
-  let(:reference_with_current_employer) { create(:reference, is_most_recent_employer: true) }
-  let(:reference_without_current_employer) {  create(:reference, is_most_recent_employer: false) }
+  let(:form) { described_class.new(references: references, references_section_completed: true) }
 
-  subject { described_class.new(references: references, references_section_completed: true) }
+  let(:reference_with_current_employer) { create(:reference, is_most_recent_employer: true) }
+  let(:reference_without_current_employer) { create(:reference, is_most_recent_employer: false) }
 
   context "when at least one reference is from the most recent employer" do
     let(:references) { [reference_with_current_employer] }
 
     it "is valid" do
-      expect(subject).to be_valid
+      expect(form).to be_valid
     end
   end
 
@@ -20,8 +20,8 @@ RSpec.describe Jobseekers::JobApplication::ReferencesForm do
     let(:references) { [reference_without_current_employer] }
 
     it "is not valid" do
-      expect(subject).not_to be_valid
-      expect(subject.errors[:references]).to include("At least one reference must be marked as the most recent employer.")
+      expect(form).not_to be_valid
+      expect(form.errors[:references]).to include("At least one reference must be marked as the most recent employer.")
     end
   end
 
@@ -29,8 +29,8 @@ RSpec.describe Jobseekers::JobApplication::ReferencesForm do
     let(:references) { [] }
 
     it "is not valid" do
-      expect(subject).not_to be_valid
-      expect(subject.errors[:references]).to include("At least one reference must be marked as the most recent employer.")
+      expect(form).not_to be_valid
+      expect(form.errors[:references]).to include("At least one reference must be marked as the most recent employer.")
     end
   end
 end

--- a/spec/form_models/jobseekers/job_application/references_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/references_form_spec.rb
@@ -3,10 +3,34 @@
 require "rails_helper"
 
 RSpec.describe Jobseekers::JobApplication::ReferencesForm do
-  let(:form) { described_class.new(references_section_completed: true) }
+  let(:reference_with_current_employer) { create(:reference, is_most_recent_employer: true) }
+  let(:reference_without_current_employer) {  create(:reference, is_most_recent_employer: false) }
 
-  it "validates the references field" do
-    expect(form).not_to be_valid
-    expect(form.errors.messages).to eq(references: ["You must provide a minimum of 2 references"])
+  subject { described_class.new(references: references, references_section_completed: true) }
+
+  context "when at least one reference is from the most recent employer" do
+    let(:references) { [reference_with_current_employer] }
+
+    it "is valid" do
+      expect(subject).to be_valid
+    end
+  end
+
+  context "when no references are from the most recent employer" do
+    let(:references) { [reference_without_current_employer] }
+
+    it "is not valid" do
+      expect(subject).not_to be_valid
+      expect(subject.errors[:references]).to include("At least one reference must be marked as the most recent employer.")
+    end
+  end
+
+  context "when there are no references" do
+    let(:references) { [] }
+
+    it "is not valid" do
+      expect(subject).not_to be_valid
+      expect(subject.errors[:references]).to include("At least one reference must be marked as the most recent employer.")
+    end
   end
 end


### PR DESCRIPTION
## Trello card URL

https://trello.com/b/1QyLnb9W/teaching-vacancies-sprint-board

## Changes in this PR:

This PR changes our validations on references required for applying to jobs. Prior to this change an applicant needed 2 referees, this change ensures that at least one of their referees is from their current or most recent job and drops the need for 2 or more referees.

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
