### PR TITLE
Move job alert text under job count section

### DIFF
--- a/app/views/vacancies/index.html.slim
+++ b/app/views/vacancies/index.html.slim
@@ -7,14 +7,14 @@
 
 = render "vacancies/search/page_title_and_description", landing_page: @landing_page
 
-- any_vacancies = @vacancies_search.total_count.positive?
-- if @vacancies_search.active_criteria? && any_vacancies
-  p = t("subscriptions.link.help_text_html", link: govuk_link_to(t("subscriptions.link.text"), new_subscription_path(search_criteria: @vacancies_search.active_criteria, coordinates_present: @vacancies_search.point_coordinates.present?)))
-
 = form_for @form, as: "", url: jobs_path, method: :get, html: { data: { controller: "form" }, role: "search" } do |f|
 
   h1 class="govuk-heading-l" role="heading" aria-level="1"
     = t("jobs.search_result_heading", count: number_with_delimiter(@vacancies_search.total_count))
+
+  - any_vacancies = @vacancies_search.total_count.positive?
+  - if @vacancies_search.active_criteria? && any_vacancies
+    p = t("subscriptions.link.help_text_html", link: govuk_link_to(t("subscriptions.link.text"), new_subscription_path(search_criteria: @vacancies_search.active_criteria, coordinates_present: @vacancies_search.point_coordinates.present?)))
 
   - if @landing_page&.has_banner_image?
     = render "vacancies/search/banner", f: f, form: @form, vacancies_search: @vacancies_search


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/C1ArMerE/1587-move-create-a-job-alert-text-on-the-job-search-page

## Changes in this PR:
Move job alert header under job count section
