### PR TITLE
Fix: Add empty model class to allow old data migration

### DIFF
--- a/db/migrate/20210409094259_change_vacancy_apply_through_field.rb
+++ b/db/migrate/20210409094259_change_vacancy_apply_through_field.rb
@@ -1,4 +1,8 @@
 class ChangeVacancyApplyThroughField < ActiveRecord::Migration[6.1]
+  # Minimal version of Vacancy model class to avoid old data migration update calls to fail due to missing field/methods
+  # on the current real model class.
+  class Vacancy < ActiveRecord::Base; end
+
   def up
     add_column :vacancies, :enable_job_applications, :boolean, null: true
     Vacancy.where("apply_through_teaching_vacancies = 'yes'").update_all("enable_job_applications = TRUE")


### PR DESCRIPTION
If the data migration runs against the up to date todays model class, the attributes/methods may differ from the ones existing/needed when the old migration was created.

This causes issues when running old migrations as exceptions arise due to the missing method/attribute.

By creating a minimal empty model class we remove the dependency on the real model.

