### PR TITLE
Remove back_link from personal details name page

### DIFF
--- a/app/models/concerns/profile_section.rb
+++ b/app/models/concerns/profile_section.rb
@@ -6,7 +6,7 @@ module ProfileSection
       find_or_initialize_by(**).tap do |record|
         if record.new_record?
           # do not populated from draft applications as they make be incomplete and invalid.
-          if (previously_submitted_application = jobseeker(record).job_applications.where.not(status: :draft).last)
+          if (previously_submitted_application = jobseeker(record).job_applications.after_submission.last)
             copy_attributes(record, previously_submitted_application)
 
             block&.call(record)

--- a/app/models/concerns/profile_section.rb
+++ b/app/models/concerns/profile_section.rb
@@ -5,8 +5,9 @@ module ProfileSection
     def prepare(**, &block)
       find_or_initialize_by(**).tap do |record|
         if record.new_record?
-          if (previous_application = jobseeker(record).job_applications.last)
-            copy_attributes(record, previous_application)
+          # do not populated from draft applications as they make be incomplete and invalid.
+          if (previously_submitted_application = jobseeker(record).job_applications.where.not(status: :draft).last)
+            copy_attributes(record, previously_submitted_application)
 
             block&.call(record)
             before_save_on_prepare(record)
@@ -24,9 +25,9 @@ module ProfileSection
       record.jobseeker_profile.jobseeker
     end
 
-    def copy_attributes(record, previous_application)
+    def copy_attributes(record, previously_submitted_application)
       attributes_to_copy.each do |attribute|
-        record.assign_attributes(attribute => previous_application.public_send(attribute))
+        record.assign_attributes(attribute => previously_submitted_application.public_send(attribute))
       end
     end
 

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -84,7 +84,7 @@ class JobApplication < ApplicationRecord
   has_noticed_notifications
 
   scope :submitted_yesterday, -> { submitted.where("DATE(submitted_at) = ?", Date.yesterday) }
-  scope :after_submission, -> { where(status: %w[submitted reviewed shortlisted unsuccessful withdrawn]) }
+  scope :after_submission, -> { where.not(status: :draft) }
   scope :draft, -> { where(status: "draft") }
 
   validates :email_address, email_address: true, if: -> { email_address_changed? } # Allows data created prior to validation to still be valid

--- a/app/views/jobseekers/profiles/personal_details/name.html.slim
+++ b/app/views/jobseekers/profiles/personal_details/name.html.slim
@@ -2,7 +2,6 @@
 
 - content_for :breadcrumbs do
   nav.govuk-breadcrumbs aria-label="Breadcrumbs"
-  = govuk_back_link text: t("buttons.back"), href: back_url, html_attributes: { "aria-label" => "Back navigation", role: "navigation" }
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/app/views/jobseekers/profiles/personal_details/name.html.slim
+++ b/app/views/jobseekers/profiles/personal_details/name.html.slim
@@ -2,6 +2,7 @@
 
 - content_for :breadcrumbs do
   nav.govuk-breadcrumbs aria-label="Breadcrumbs"
+  = govuk_back_link text: t("buttons.back"), href: escape_path, html_attributes: { "aria-label" => "Back navigation", role: "navigation" }
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds

--- a/spec/models/jobseeker_profile_spec.rb
+++ b/spec/models/jobseeker_profile_spec.rb
@@ -36,8 +36,8 @@ RSpec.describe JobseekerProfile, type: :model do
       end
 
       it "does not use the details from the draft application" do
-        expect(profile.employments.map(&:job_title).sort).to be_empty
-        expect(profile.qualifications.map(&:institution).sort).to be_empty
+        expect(profile.employments.map(&:job_title)).to be_empty
+        expect(profile.qualifications.map(&:institution)).to be_empty
         expect(profile.qualified_teacher_status_year).to be_nil
         expect(profile.qualified_teacher_status).to be_nil
         expect(profile.personal_details.first_name).to be_nil

--- a/spec/models/jobseeker_profile_spec.rb
+++ b/spec/models/jobseeker_profile_spec.rb
@@ -14,38 +14,43 @@ RSpec.describe JobseekerProfile, type: :model do
     end
 
     context "when the jobseeker has a previously submitted application" do
-      let!(:previous_application) { create(:job_application, :status_submitted, jobseeker:) }
+      let(:first_name) { "Bill" }
+      let(:last_name) { "Smith" }
+      let!(:previous_application) { create(:job_application, :status_submitted, jobseeker:, first_name:, last_name:) }
 
       it "uses the details from the previous application" do
         expect(profile.employments.map(&:job_title).sort).to eq(previous_application.employments.map(&:job_title).sort)
         expect(profile.qualifications.map(&:institution).sort).to eq(previous_application.qualifications.map(&:institution).sort)
         expect(profile.qualified_teacher_status_year).to eq(previous_application.qualified_teacher_status_year)
         expect(profile.qualified_teacher_status).to eq(previous_application.qualified_teacher_status)
-        expect(profile.personal_details.first_name).to eq(previous_application.first_name)
-        expect(profile.personal_details.last_name).to eq(previous_application.last_name)
+        expect(profile.personal_details.first_name).to eq(first_name)
+        expect(profile.personal_details.last_name).to eq(last_name)
       end
 
       it "creates a job preferences record" do
         expect(profile.job_preferences).to be_present
+        expect(profile.job_preferences).to be_persisted
       end
     end
 
     context "when the jobseeker has a previous draft application" do
       before do
-        create(:job_application, :status_draft, jobseeker:)
+        create(:job_application, :status_draft, jobseeker:, first_name: "karl", last_name: "karlssen", phone_number: "01234567899", right_to_work_in_uk: "yes")
       end
 
       it "does not use the details from the draft application" do
-        expect(profile.employments.map(&:job_title)).to be_empty
-        expect(profile.qualifications.map(&:institution)).to be_empty
+        expect(profile.employments).to be_empty
+        expect(profile.qualifications).to be_empty
         expect(profile.qualified_teacher_status_year).to be_nil
         expect(profile.qualified_teacher_status).to be_nil
         expect(profile.personal_details.first_name).to be_nil
         expect(profile.personal_details.last_name).to be_nil
+        expect(profile.personal_details.phone_number).to be_nil
       end
 
       it "creates a job preferences record" do
         expect(profile.job_preferences).to be_present
+        expect(profile.job_preferences).to be_persisted
       end
     end
 

--- a/spec/models/jobseeker_profile_spec.rb
+++ b/spec/models/jobseeker_profile_spec.rb
@@ -31,7 +31,9 @@ RSpec.describe JobseekerProfile, type: :model do
     end
 
     context "when the jobseeker has a previous draft application" do
-      let!(:previous_application) { create(:job_application, :status_draft, jobseeker:) }
+      before do
+        create(:job_application, :status_draft, jobseeker:)
+      end
 
       it "does not use the details from the draft application" do
         expect(profile.employments.map(&:job_title).sort).to be_empty

--- a/spec/models/jobseeker_profile_spec.rb
+++ b/spec/models/jobseeker_profile_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe JobseekerProfile, type: :model do
       end
     end
 
-    context "when the jobseeker has a previous application" do
+    context "when the jobseeker has a previously submitted application" do
       let!(:previous_application) { create(:job_application, :status_submitted, jobseeker:) }
 
       it "uses the details from the previous application" do
@@ -22,6 +22,24 @@ RSpec.describe JobseekerProfile, type: :model do
         expect(profile.qualified_teacher_status_year).to eq(previous_application.qualified_teacher_status_year)
         expect(profile.qualified_teacher_status).to eq(previous_application.qualified_teacher_status)
         expect(profile.personal_details.first_name).to eq(previous_application.first_name)
+        expect(profile.personal_details.last_name).to eq(previous_application.last_name)
+      end
+
+      it "creates a job preferences record" do
+        expect(profile.job_preferences).to be_present
+      end
+    end
+
+    context "when the jobseeker has a previous draft application" do
+      let!(:previous_application) { create(:job_application, :status_draft, jobseeker:) }
+
+      it "does not use the details from the draft application" do
+        expect(profile.employments.map(&:job_title).sort).to be_empty
+        expect(profile.qualifications.map(&:institution).sort).to be_empty
+        expect(profile.qualified_teacher_status_year).to be_nil
+        expect(profile.qualified_teacher_status).to be_nil
+        expect(profile.personal_details.first_name).to be_nil
+        expect(profile.personal_details.last_name).to be_nil
       end
 
       it "creates a job preferences record" do

--- a/spec/models/personal_details_spec.rb
+++ b/spec/models/personal_details_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe PersonalDetails do
       end
     end
 
-    context "when the profile has a previous application" do
+    context "when the profile has a previously submitted application" do
       let!(:previous_application) { create(:job_application, :status_submitted, jobseeker:) }
 
       it "uses the details from the previous application" do
@@ -30,6 +30,21 @@ RSpec.describe PersonalDetails do
 
       it "sets some steps to completed" do
         expect(personal_details.completed_steps).to include("name", "phone_number", "work")
+      end
+    end
+
+    context "when the jobseeker has a previous draft application" do
+      let!(:previous_application) { create(:job_application, :status_draft, jobseeker:) }
+
+      it "uses the details from the previous application" do
+        expect(personal_details.first_name).to be_nil
+        expect(personal_details.last_name).to be_nil
+        expect(personal_details.phone_number).to be_nil
+        expect(personal_details.right_to_work_in_uk).to be_nil
+      end
+
+      it "does not set steps to completed" do
+        expect(personal_details.completed_steps).to be_blank
       end
     end
 

--- a/spec/models/personal_details_spec.rb
+++ b/spec/models/personal_details_spec.rb
@@ -34,7 +34,9 @@ RSpec.describe PersonalDetails do
     end
 
     context "when the jobseeker has a previous draft application" do
-      let!(:previous_application) { create(:job_application, :status_draft, jobseeker:) }
+      before do
+        create(:job_application, :status_draft, jobseeker:)
+      end
 
       it "uses the details from the previous application" do
         expect(personal_details.first_name).to be_nil

--- a/spec/models/personal_details_spec.rb
+++ b/spec/models/personal_details_spec.rb
@@ -35,10 +35,10 @@ RSpec.describe PersonalDetails do
 
     context "when the jobseeker has a previous draft application" do
       before do
-        create(:job_application, :status_draft, jobseeker:)
+        create(:job_application, :status_draft, jobseeker:, first_name: "karl", last_name: "karlssen", phone_number: "01234567899", right_to_work_in_uk: "yes")
       end
 
-      it "uses the details from the previous application" do
+      it "does not use details from draft application" do
         expect(personal_details.first_name).to be_nil
         expect(personal_details.last_name).to be_nil
         expect(personal_details.phone_number).to be_nil

--- a/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
@@ -150,12 +150,8 @@ RSpec.describe "Jobseekers can manage their profile" do
         visit jobseekers_profile_path
       end
 
-      it "prefills the form with the jobseeker's provided personal details" do
+      it "does not prefill the form with the personal details from the draft application" do
         expect(page).not_to have_content(previous_application.phone_number)
-      end
-
-      it "still shows the summary rows for the blank attributes" do
-        expect(page).to have_content("Name")
       end
     end
 

--- a/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
@@ -127,8 +127,8 @@ RSpec.describe "Jobseekers can manage their profile" do
       end
     end
 
-    describe "personal details if the jobseeker has a blank previous job application" do
-      let!(:previous_application) { create(:job_application, :status_draft, jobseeker:, first_name: nil, last_name: nil, phone_number: "01234567890") }
+    describe "personal details if the jobseeker has a blank previously submitted job application" do
+      let!(:previous_application) { create(:job_application, :status_submitted, jobseeker:, first_name: nil, last_name: nil, phone_number: "01234567890") }
 
       before do
         visit jobseekers_profile_path
@@ -136,6 +136,22 @@ RSpec.describe "Jobseekers can manage their profile" do
 
       it "prefills the form with the jobseeker's provided personal details" do
         expect(page).to have_content(previous_application.phone_number)
+      end
+
+      it "still shows the summary rows for the blank attributes" do
+        expect(page).to have_content("Name")
+      end
+    end
+
+    describe "personal details if the jobseeker has a blank previous draft job application" do
+      let!(:previous_application) { create(:job_application, :status_draft, jobseeker:, first_name: nil, last_name: nil, phone_number: "01234567890") }
+
+      before do
+        visit jobseekers_profile_path
+      end
+
+      it "prefills the form with the jobseeker's provided personal details" do
+        expect(page).not_to have_content(previous_application.phone_number)
       end
 
       it "still shows the summary rows for the blank attributes" do

--- a/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
@@ -128,16 +128,19 @@ RSpec.describe "Jobseekers can manage their profile" do
     end
 
     describe "personal details if the jobseeker has a previously submitted job application" do
-      let!(:previous_application) { create(:job_application, :status_submitted, jobseeker:, first_name: "Alfred", last_name: "Accelsior", phone_number: "01234567890") }
+      let(:first_name) { "Alfred" }
+      let(:last_name) { "Accelsior" }
+      let(:phone_number) { "01234567890" }
+      let!(:previous_application) { create(:job_application, :status_submitted, jobseeker:, first_name:, last_name:, phone_number:) }
 
       before do
         visit jobseekers_profile_path
       end
 
       it "prefills the form with the jobseeker's provided personal details" do
-        expect(page).to have_content(previous_application.phone_number)
-        expect(page).to have_content(previous_application.first_name)
-        expect(page).to have_content(previous_application.last_name)
+        expect(page).to have_content(first_name)
+        expect(page).to have_content(last_name)
+        expect(page).to have_content(phone_number)
       end
     end
 

--- a/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
@@ -127,8 +127,8 @@ RSpec.describe "Jobseekers can manage their profile" do
       end
     end
 
-    describe "personal details if the jobseeker has a blank previously submitted job application" do
-      let!(:previous_application) { create(:job_application, :status_submitted, jobseeker:, first_name: nil, last_name: nil, phone_number: "01234567890") }
+    describe "personal details if the jobseeker has a previously submitted job application" do
+      let!(:previous_application) { create(:job_application, :status_submitted, jobseeker:, first_name: "Alfred", last_name: "Accelsior", phone_number: "01234567890") }
 
       before do
         visit jobseekers_profile_path
@@ -136,10 +136,8 @@ RSpec.describe "Jobseekers can manage their profile" do
 
       it "prefills the form with the jobseeker's provided personal details" do
         expect(page).to have_content(previous_application.phone_number)
-      end
-
-      it "still shows the summary rows for the blank attributes" do
-        expect(page).to have_content("Name")
+        expect(page).to have_content(previous_application.first_name)
+        expect(page).to have_content(previous_application.last_name)
       end
     end
 


### PR DESCRIPTION
## Changes in this PR:

We recently had a user report a bug. The user could not turn on their profile because they had not completed their personal details. The name page crashed when they tried to enter their name in the jobseeker profile.

### Why did this happen?

The user's jobseeker profile had some personal details filled in but the name section was blank. In completed_steps it had work and phone_number sections marked as complete but not the name section. The name is the first step in the personal details flow.

The "Step not completed" error was raised by the `previous_step` defined in lib/multistep/form.rb. This error seems to be raised to ensure that multistep forms cannot be filled in out of order. As name was not completed but later steps in the personal details flow were completed it raised this error.

The `previous_step` method was called because of the back link on the name page of the personal details form.

### How did this happen?

I think the user's jobseeker profile got into this state due to the way that we populate a new jobseeker profile for a user. If the user has a job application, when they first visit the jobseeker profile page, we populate their profile with information from their previous application regardless of whether that application has been submitted or not.

In this case the user had both a draft and a submitted job application, I think that the user's jobseeker profile got populated based on the draft application which was missing some information.

### How to fix this?

I have tried to fix this both for other jobseekers who may already have their data in a similar state and to ensure other jobseekers do not get their data into a similar state.

1. Removing the back link from the name page of the personal details flow. This back link is not needed as it's the first page of the flow and the user can use the cancel button, or the browsers back button to return to the profile summary page. Removing this back link stops the error being raised for users who find themselves in a similar position to the user who raised the issue.

2. Only populate new jobseeker profiles with data from job applications if they are not in a draft state. This hopefully should ensure that the data from the job application is completed and valid and will not create a jobseeker profile that is missing important data.

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
