### PR TITLE
Add different hints for each qualification type

### DIFF
--- a/app/views/jobseekers/job_applications/qualifications/new.html.slim
+++ b/app/views/jobseekers/job_applications/qualifications/new.html.slim
@@ -4,9 +4,7 @@
   .govuk-grid-column-two-thirds
     span.govuk-caption-l = t(".caption")
     h1.govuk-heading-xl = t(".heading.#{@category}")
-    p = t(".hint")
-    - if @category == "other"
-      p = t(".hint_for_other_qualifications")
+    p = t(".hint.#{@category}")
 
     = form_for @form, url: jobseekers_job_application_qualifications_path(job_application, category: @category), method: :post do |f|
       = f.govuk_error_summary link_base_errors_to: :subject

--- a/app/views/jobseekers/profiles/qualifications/new.html.slim
+++ b/app/views/jobseekers/profiles/qualifications/new.html.slim
@@ -4,9 +4,7 @@
   .govuk-grid-column-two-thirds
     span.govuk-caption-l = t(".caption")
     h1.govuk-heading-xl = t(".heading.#{@category}")
-    p = t(".hint")
-    - if @category == "other"
-      p = t(".hint_for_other_qualifications")
+    p = t(".hint.#{@category}")
 
     = form_for @form, url: jobseekers_profile_qualifications_path(profile, category: @category), method: :post do |f|
       = f.govuk_error_summary link_base_errors_to: :subject

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -434,6 +434,13 @@ en:
         qualifications_shared: &qualifications_shared
           caption: Education and qualifications
           subjects_and_grades: Subjects and grades
+          hint:
+            gcse: Add all your GCSEs.
+            as_level: Add all your AS levels.
+            a_level: Add all your A levels.
+            undergraduate: Add your undergraduate degree.
+            postgraduate: You do not need to add qualified teacher status (QTS) here. You can add this to your application in the professional status section.
+            other: Add any formal qualifications. You can add details of any training or professional development in the continuing professional development part of the application.
         edit:
           <<: *qualifications_shared
           heading:
@@ -454,13 +461,6 @@ en:
             postgraduate: Add a postgraduate qualification
             other: Add a qualification
           title: Add a qualification — Application
-          hint:
-            gcse: Add all your GCSEs.
-            as_level: Add all your AS levels.
-            a_level: Add all your A levels.
-            undergraduate: Add your undergraduate degree.
-            postgraduate: You do not need to add qualified teacher status (QTS) here. You can add this to your application in the professional status section.
-            other: Add any formal qualifications. You can add details of any training or professional development in the continuing professional development part of the application.
         select_category:
           <<: *qualifications_shared
           heading: Add a qualification
@@ -876,13 +876,6 @@ en:
             postgraduate: Add a postgraduate qualification
             other: Add a qualification
           title: Add a qualification — Profile
-          hint:
-            gcse: Add all your GCSEs.
-            as_level: Add all your AS levels.
-            a_level: Add all your A levels.
-            undergraduate: Add your undergraduate degree.
-            postgraduate: You do not need to add qualified teacher status (QTS) here. You can add this to your application in the professional status section.
-            other: Add any formal qualifications. You can add details of any training or professional development in the continuing professional development part of the application.
         edit:
           page_title: Qualifications
         review:

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -454,8 +454,13 @@ en:
             postgraduate: Add a postgraduate qualification
             other: Add a qualification
           title: Add a qualification — Application
-          hint: You do not need to add qualified teacher status (QTS) here. You can add this to your application in the professional status section.
-          hint_for_other_qualifications: Add any formal qualifications. You can add details of any training or professional development in the continuing professional development part of the application.
+          hint:
+            gcse: Add all your GCSEs.
+            as_level: Add all your AS levels.
+            a_level: Add all your A levels.
+            undergraduate: Add your undergraduate degree.
+            postgraduate: You do not need to add qualified teacher status (QTS) here. You can add this to your application in the professional status section.
+            other: Add any formal qualifications. You can add details of any training or professional development in the continuing professional development part of the application.
         select_category:
           <<: *qualifications_shared
           heading: Add a qualification
@@ -871,8 +876,13 @@ en:
             postgraduate: Add a postgraduate qualification
             other: Add a qualification
           title: Add a qualification — Profile
-          hint: You do not need to add qualified teacher status (QTS) here. You can add this to your application in the professional status section.
-          hint_for_other_qualifications: Add any formal qualifications. You can add details of any training or professional development in the continuing professional development part of the application.
+          hint:
+            gcse: Add all your GCSEs.
+            as_level: Add all your AS levels.
+            a_level: Add all your A levels.
+            undergraduate: Add your undergraduate degree.
+            postgraduate: You do not need to add qualified teacher status (QTS) here. You can add this to your application in the professional status section.
+            other: Add any formal qualifications. You can add details of any training or professional development in the continuing professional development part of the application.
         edit:
           page_title: Qualifications
         review:


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/08WqZbZm/1628-qualifications-hint-text-fix

## Changes in this PR:

This PR adds different hint text to help jobseekers enter values for each qualification type

## Screenshots of UI changes:

### Before

### After

## Next steps:

- [ ] Terraform deployment required?

- [ ] New development configuration to be shared?
