### PR TITLE
TRN form tweaks: Remove duplicated code, reorganise validations and reduce duplicated validation messages.

### DIFF
--- a/app/controllers/jobseekers/job_applications/build_controller.rb
+++ b/app/controllers/jobseekers/job_applications/build_controller.rb
@@ -142,10 +142,11 @@ class Jobseekers::JobApplications::BuildController < Jobseekers::JobApplications
   # In order for this to be implemented effectively, the JobseekerProfile would need to split out the its professional status fields.
   #
   def update_or_create_jobseeker_profile!
+    profile_params = form_params.slice(:teacher_reference_number, :has_teacher_reference_number, :qualified_teacher_status)
     if current_jobseeker.jobseeker_profile.nil?
-      current_jobseeker.create_jobseeker_profile!(form_params.slice(:teacher_reference_number, :has_teacher_reference_number, :qualified_teacher_status))
+      current_jobseeker.create_jobseeker_profile!(profile_params)
     else
-      current_jobseeker.jobseeker_profile.update!(form_params.slice(:teacher_reference_number, :has_teacher_reference_number, :qualified_teacher_status))
+      current_jobseeker.jobseeker_profile.update!(profile_params)
     end
   end
 

--- a/app/controllers/jobseekers/job_applications/build_controller.rb
+++ b/app/controllers/jobseekers/job_applications/build_controller.rb
@@ -51,6 +51,7 @@ class Jobseekers::JobApplications::BuildController < Jobseekers::JobApplications
     "jobseekers/job_application/#{step}_form".camelize.constantize
   end
 
+  # :nocov:
   def form_attributes
     attributes = case action_name
                  when "show"
@@ -61,13 +62,14 @@ class Jobseekers::JobApplications::BuildController < Jobseekers::JobApplications
 
     case step
     when :professional_status
-      attributes.merge(trn_params)
+      attributes.merge(jobseeker_profile: current_jobseeker&.jobseeker_profile)
     when :employment_history
       attributes.merge(unexplained_employment_gaps: job_application.unexplained_employment_gaps)
     else
       attributes
     end
   end
+  # :nocov:
 
   def form_params
     param_key = ActiveModel::Naming.param_key(form_class)
@@ -121,13 +123,6 @@ class Jobseekers::JobApplications::BuildController < Jobseekers::JobApplications
 
   def vacancy
     @vacancy ||= job_application.vacancy
-  end
-
-  def trn_params
-    {
-      teacher_reference_number: form_params[:teacher_reference_number] || current_jobseeker&.jobseeker_profile&.teacher_reference_number,
-      has_teacher_reference_number: form_params[:has_teacher_reference_number] || current_jobseeker&.jobseeker_profile&.has_teacher_reference_number,
-    }
   end
 
   # This set of fields needs to be a 'consistent' set rather than just a couple of fields.

--- a/app/form_models/jobseekers/job_application/professional_status_form.rb
+++ b/app/form_models/jobseekers/job_application/professional_status_form.rb
@@ -47,9 +47,21 @@ module Jobseekers
 
       # These validations are only applied when the professional status section is marked as completed.
       #
-      # Equivalent to if: -> { professional_status_section_completed == true }.
       # Nested validations using "if" calls would override the parent "with_options if:" call instead of combining the conditions.
       # By using "unless" we can keep using "if" for nested validations and the "if & unless" conditions will be combined.
+      #
+      # BAD: Output would be "validates ... if: -> { condition B }".
+      # with_options if: -> { condition A }
+      #   validates ... if: -> { condition B }
+      # end
+      #
+      # GOOD: Output would be "validates ... unless: -> { !condition A }, if: -> { condition B }".
+      #       That is the same as "validates ... if: -> { condition A && condition B }".
+      # with_options unless: -> { !condition A }
+      #   validates ... if: -> { condition B }
+      # end
+      #
+      # Equivalent to if: -> { professional_status_section_completed == true }.
       with_options unless: -> { professional_status_section_completed != true } do
         validates :qualified_teacher_status, inclusion: { in: %w[yes no on_track] }
         validates :statutory_induction_complete, inclusion: { in: %w[yes no] }
@@ -67,6 +79,10 @@ module Jobseekers
       # Teacher reference number:
       # Its presence is required when the "has_teacher_reference_number" is "yes".
       # Its format is validated only when the number is provided.
+      # Having a qalified teacher status 'yes' will enforce the "has_teacher_reference_number" to be 'yes' what will force
+      # the "teacher_reference_number" to be present and formatted correctly.
+      # Codewise "has_teacher_reference_number" seems to be a redundant field as it can be inferred from the presence
+      # of the "teacher_reference_number".
       validates :teacher_reference_number, presence: true, if: -> { has_teacher_reference_number == "yes" }
       validates_format_of :teacher_reference_number, with: /\A\d{7}\z/, allow_blank: true
 

--- a/app/form_models/jobseekers/job_application/professional_status_form.rb
+++ b/app/form_models/jobseekers/job_application/professional_status_form.rb
@@ -57,7 +57,6 @@ module Jobseekers
         with_options if: -> { qualified_teacher_status == "yes" } do
           validates :qualified_teacher_status_year, numericality: { less_than_or_equal_to: proc { Time.current.year } }
           validates :has_teacher_reference_number, inclusion: { in: %w[yes] }
-          validates :teacher_reference_number, presence: true
         end
 
         with_options if: -> { qualified_teacher_status.in?(%w[no on_track]) } do
@@ -65,8 +64,11 @@ module Jobseekers
         end
       end
 
-      validates_format_of :teacher_reference_number, with: /\A\d{7}\z/, allow_blank: false, if: -> { qualified_teacher_status == "yes" || has_teacher_reference_number == "yes" }
-      validates_format_of :teacher_reference_number, with: /\A\d{7}\z/, allow_blank: true, if: -> { qualified_teacher_status.in?(%w[no on_track]) }
+      # Teacher reference number:
+      # Its presence is required when the "has_teacher_reference_number" is "yes".
+      # Its format is validated only when the number is provided.
+      validates :teacher_reference_number, presence: true, if: -> { has_teacher_reference_number == "yes" }
+      validates_format_of :teacher_reference_number, with: /\A\d{7}\z/, allow_blank: true
 
       completed_attribute(:professional_status)
     end

--- a/spec/form_models/jobseekers/job_application/professional_status_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/professional_status_form_spec.rb
@@ -14,6 +14,77 @@ RSpec.describe Jobseekers::JobApplication::ProfessionalStatusForm, type: :model 
     it { is_expected.to validate_numericality_of(:qualified_teacher_status_year).is_less_than_or_equal_to(Time.current.year) }
   end
 
+  describe "teacher reference information" do
+    subject(:form) { described_class.new(attributes) }
+
+    context "with TRI attributes explicitly provided during the initialisation" do
+      let(:attributes) { { teacher_reference_number: "1234567", has_teacher_reference_number: "yes" } }
+
+      it "sets the TRI attributes" do
+        expect(form).to have_attributes(teacher_reference_number: "1234567",
+                                        has_teacher_reference_number: "yes")
+      end
+
+      context "when a profile with different TRI attributes is also provided" do
+        let(:profile) do
+          instance_double(JobseekerProfile, teacher_reference_number: "7654321", has_teacher_reference_number: "yes")
+        end
+        let(:attributes) { super().merge(jobseeker_profile: profile) }
+
+        it "sets the explicitly provided TRI attributes over the profile attributes" do
+          expect(form).to have_attributes(teacher_reference_number: "1234567",
+                                          has_teacher_reference_number: "yes")
+        end
+      end
+    end
+
+    context "when no TRI attributes are provided" do
+      let(:attributes) { {} }
+
+      it "does not set the TRI attributes" do
+        expect(form).to have_attributes(teacher_reference_number: nil,
+                                        has_teacher_reference_number: nil)
+      end
+
+      context "with a jobseeker profile" do
+        let(:attributes) { { jobseeker_profile: profile } }
+
+        context "with TRI values" do
+          let(:profile) do
+            instance_double(JobseekerProfile, teacher_reference_number: "7654321", has_teacher_reference_number: "yes")
+          end
+
+          it "sets the teacher reference number and has_teacher_reference_number from the profile" do
+            expect(form).to have_attributes(teacher_reference_number: "7654321",
+                                            has_teacher_reference_number: "yes")
+          end
+        end
+
+        context "without TRI values" do
+          let(:profile) do
+            instance_double(JobseekerProfile, teacher_reference_number: nil, has_teacher_reference_number: nil)
+          end
+
+          it "does not set the TRI attributes" do
+            expect(form).to have_attributes(teacher_reference_number: nil,
+                                            has_teacher_reference_number: nil)
+          end
+        end
+
+        context "when explicitly stating no teacher reference number is provided" do
+          let(:profile) do
+            instance_double(JobseekerProfile, teacher_reference_number: nil, has_teacher_reference_number: "no")
+          end
+
+          it "sets the has_teacher_reference_number from the profile" do
+            expect(form).to have_attributes(teacher_reference_number: nil,
+                                            has_teacher_reference_number: "no")
+          end
+        end
+      end
+    end
+  end
+
   describe "statutory_induction_complete_details" do
     let(:valid_attributes) do
       {

--- a/spec/form_models/jobseekers/job_application/professional_status_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/professional_status_form_spec.rb
@@ -28,31 +28,13 @@ RSpec.describe Jobseekers::JobApplication::ProfessionalStatusForm, type: :model 
       it { is_expected.not_to validate_presence_of(:qts_age_range_and_subject) }
       it { is_expected.not_to validate_presence_of(:qualified_teacher_status_details) }
 
-      context "when qualified_teacher_status is 'yes'" do
-        let(:attributes) { super().merge(qualified_teacher_status: "yes") }
-
-        it { is_expected.to validate_presence_of(:teacher_reference_number) }
-
-        include_examples "validates teacher reference number format"
-      end
-
-      %w[no on_track].each do |status|
-        context "when qualified_teacher_status is '#{status}'" do
-          let(:attributes) { super().merge(qualified_teacher_status: status) }
-
-          it { is_expected.not_to validate_presence_of(:teacher_reference_number) }
-
-          include_examples "validates teacher reference number format"
-          include_examples "allows teacher reference number to be blank"
-        end
-      end
+      include_examples "validates teacher reference number format"
+      include_examples "allows teacher reference number to be blank"
 
       context "when has_teacher_reference_number is 'yes'" do
         let(:attributes) { super().merge(has_teacher_reference_number: "yes") }
 
         it { is_expected.to validate_presence_of(:teacher_reference_number) }
-
-        include_examples "validates teacher reference number format"
       end
     end
 
@@ -69,9 +51,32 @@ RSpec.describe Jobseekers::JobApplication::ProfessionalStatusForm, type: :model 
 
         it { is_expected.to validate_inclusion_of(:has_teacher_reference_number).in_array(%w[yes]) }
 
-        it { is_expected.to validate_presence_of(:teacher_reference_number) }
+        it { is_expected.not_to validate_presence_of(:teacher_reference_number) }
 
-        include_examples "validates teacher reference number format"
+        context "when has_teacher_reference_number is 'no'" do
+          let(:attributes) { super().merge(has_teacher_reference_number: "no") }
+
+          it "contains an error for the has_teacher_reference_number field" do
+            form.valid?
+            expect(form.errors[:has_teacher_reference_number])
+              .to eq(["Select yes and enter your teacher reference number (TRN). All teachers with QTS have a 7 digit TRN."])
+          end
+
+          it "does not contain any errors for the teacher reference number field" do
+            form.valid?
+            expect(form.errors[:teacher_reference_number]).to be_empty
+          end
+
+          it { is_expected.not_to validate_presence_of(:teacher_reference_number) }
+        end
+
+        context "when has_teacher_reference_number is 'yes'" do
+          let(:attributes) { super().merge(has_teacher_reference_number: "yes") }
+
+          it { is_expected.to validate_presence_of(:teacher_reference_number) }
+
+          include_examples "validates teacher reference number format"
+        end
       end
 
       %w[no on_track].each do |status|

--- a/spec/form_models/jobseekers/job_application/professional_status_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/professional_status_form_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe Jobseekers::JobApplication::ProfessionalStatusForm, type: :model 
       context "with a jobseeker profile" do
         let(:attributes) { { jobseeker_profile: profile } }
 
-        context "with TRI values" do
+        context "when the jobseeker profile has TRI values" do
           let(:profile) do
             instance_double(JobseekerProfile, teacher_reference_number: "7654321", has_teacher_reference_number: "yes")
           end
@@ -141,7 +141,7 @@ RSpec.describe Jobseekers::JobApplication::ProfessionalStatusForm, type: :model 
           end
         end
 
-        context "without TRI values" do
+        context "when the jobseeker profile doesn't have TRI values" do
           let(:profile) do
             instance_double(JobseekerProfile, teacher_reference_number: nil, has_teacher_reference_number: nil)
           end
@@ -152,7 +152,7 @@ RSpec.describe Jobseekers::JobApplication::ProfessionalStatusForm, type: :model 
           end
         end
 
-        context "when explicitly stating no teacher reference number is provided" do
+        context "when the jobseeker profile has_teacher_reference_number set to 'no'" do
           let(:profile) do
             instance_double(JobseekerProfile, teacher_reference_number: nil, has_teacher_reference_number: "no")
           end

--- a/spec/system/jobseekers/jobseekers_can_add_professional_status_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_professional_status_to_their_job_application_spec.rb
@@ -39,7 +39,6 @@ RSpec.describe "Jobseekers can add details about their qualified teacher status 
     click_on "Save and continue"
 
     within "ul.govuk-list.govuk-error-summary__list" do
-      expect(page).to have_link("Enter a teacher reference number (TRN) that is 7 digits long", href: "#jobseekers-job-application-professional-status-form-teacher-reference-number-field-error")
       expect(page).to have_link("Select yes and enter your teacher reference number (TRN). All teachers with QTS have a 7 digit TRN.", href: "#jobseekers-job-application-professional-status-form-has-teacher-reference-number-field-error")
     end
 


### PR DESCRIPTION
## Trello card URL

- https://trello.com/c/2LLFZmsR/1632-remove-repeated-validation-errors-on-professional-status-form-teacher-reference-number-attributes

## Changes in this PR:

There are 3 main changes on the job application professional status form submission:

1. Code to assign the TRN attributes from the jobseeker profile was defined in 2 different places: The form itself and the controller.
    Only the controller code was reachable. 
    This PR removes the but from controller logic and moves it to the form, as it aims to keep as much of the particular form logic within the form itself (especially when the controller is shared across the whole job application flow) and it allows deeper unit testing at form object model level.

2. Refactor validations grouping them by shared conditions, and add extensive validation testing.
    This was mainly done to be able to identify and fix any redundancy (next point), but also made the form validations easier to glance through and more manageable. 

2. Remove duplications on professional status form error messages.
    The combination of attribute validations, presence, format, inclusion... caused situations where the same error message was displayed for 2 different fields, or the same field has the same error message listed twice.
    We have simplified the validations over TRN fields so they don't step on each other.

## Screenshots of UI changes:

### Before

![Screenshot_20250226_204224](https://github.com/user-attachments/assets/5ee819a5-7994-4612-aca7-682af6348c68)

![Screenshot_20250226_222455](https://github.com/user-attachments/assets/f025c687-f3b3-4a49-89f4-f37d5cea91a1)

### After

![image](https://github.com/user-attachments/assets/496eb42e-7b3d-441b-a04c-771e3372002a)

![image](https://github.com/user-attachments/assets/359d3643-3b18-47d1-a25a-63b50ebccb7b)

#### Only if selecting "Yes" on "Do you have a teacher reference number (TRN)?" but not entering the number
![image](https://github.com/user-attachments/assets/f8f5b9b7-c054-4968-9fba-2481521610a1)

