### PR TITLE
Update posting metadata

### DIFF
--- a/app/views/api/vacancies/_show.json.jbuilder
+++ b/app/views/api/vacancies/_show.json.jbuilder
@@ -2,13 +2,11 @@ json.set! "@context", "http://schema.org"
 json.set! "@type", "JobPosting"
 
 json.title vacancy.job_title
-# This doesn't appear in spec at https://developers.google.com/search/docs/appearance/structured-data/job-posting
-# not supported by Google
+# not supported by Google https://developers.google.com/search/docs/appearance/structured-data/job-posting
 json.jobBenefits vacancy.benefits_details
 json.datePosted vacancy.publish_on.iso8601
 json.description vacancy.skills_and_experience.present? ? vacancy.skills_and_experience : vacancy.job_advert
-# This doesn't appear in spec at https://developers.google.com/search/docs/appearance/structured-data/job-posting
-# not supported by Google
+# not supported by Google https://developers.google.com/search/docs/appearance/structured-data/job-posting
 json.occupationalCategory vacancy.job_roles.first
 json.directApply true
 
@@ -58,6 +56,7 @@ json.hiringOrganization do
   json.sameAs vacancy.organisation.url
   json.identifier vacancy.organisation&.urn || vacancy.organisation&.uid
   json.description vacancy.about_school
+  json.logo image_path("images/govuk-icon-180.png")
 end
 
 json.validThrough vacancy.expires_at.iso8601

--- a/app/views/api/vacancies/_show.json.jbuilder
+++ b/app/views/api/vacancies/_show.json.jbuilder
@@ -27,16 +27,27 @@ json.jobLocation do
   end
 end
 
-# Looks like we can't provide baseSalary as we're not the employer...?
-# json.baseSalary do
-#   json.set! "@type", "MonetaryAmount"
-#   json.currency "GBP"
-#   json.value do
-#     json.set! "@type", "QuantitativeValue"
-#     json.value vacancy.salary
-#     json.unitText "YEAR"
-#   end
-# end
+if vacancy.hourly_rate?
+  json.baseSalary do
+    json.set! "@type", "MonetaryAmount"
+    json.currency "GBP"
+    json.value do
+      json.set! "@type", "QuantitativeValue"
+      json.value vacancy.hourly_rate
+      json.unitText "HOUR"
+    end
+  end
+elsif vacancy.salary?
+  json.baseSalary do
+    json.set! "@type", "MonetaryAmount"
+    json.currency "GBP"
+    json.value do
+      json.set! "@type", "QuantitativeValue"
+      json.value vacancy.salary
+      json.unitText "YEAR"
+    end
+  end
+end
 
 json.url job_url(vacancy)
 

--- a/app/views/api/vacancies/_show.json.jbuilder
+++ b/app/views/api/vacancies/_show.json.jbuilder
@@ -2,11 +2,15 @@ json.set! "@context", "http://schema.org"
 json.set! "@type", "JobPosting"
 
 json.title vacancy.job_title
+# This doesn't appear in spec at https://developers.google.com/search/docs/appearance/structured-data/job-posting
+# not supported by Google
 json.jobBenefits vacancy.benefits_details
-json.datePosted vacancy.publish_on.to_time.iso8601
+json.datePosted vacancy.publish_on.iso8601
 json.description vacancy.skills_and_experience.present? ? vacancy.skills_and_experience : vacancy.job_advert
+# This doesn't appear in spec at https://developers.google.com/search/docs/appearance/structured-data/job-posting
+# not supported by Google
 json.occupationalCategory vacancy.job_roles.first
-json.directApply vacancy.enable_job_applications
+json.directApply true
 
 json.employmentType vacancy.working_patterns_for_job_schema
 
@@ -23,11 +27,24 @@ json.jobLocation do
   end
 end
 
+# Looks like we can't provide baseSalary as we're not the employer...?
+# json.baseSalary do
+#   json.set! "@type", "MonetaryAmount"
+#   json.currency "GBP"
+#   json.value do
+#     json.set! "@type", "QuantitativeValue"
+#     json.value vacancy.salary
+#     json.unitText "YEAR"
+#   end
+# end
+
 json.url job_url(vacancy)
 
 json.hiringOrganization do
   json.set! "@type", "Organization"
   json.name vacancy.organisation&.name
+  # This should at least put the school logo (from Google) next to the advert
+  json.sameAs vacancy.organisation.url
   json.identifier vacancy.organisation&.urn || vacancy.organisation&.uid
   json.description vacancy.about_school
 end

--- a/spec/requests/api/vacancies_spec.rb
+++ b/spec/requests/api/vacancies_spec.rb
@@ -145,31 +145,12 @@ RSpec.describe "Api::Vacancies" do
     context "format" do
       before { subject }
 
-      it "maps vacancy to the JobPosting schema" do
-        expect(json.to_h).to eq(vacancy_json_ld(VacancyPresenter.new(vacancy)))
-      end
-
       describe "#employment_type" do
         let(:vacancy) { create(:vacancy, working_patterns: working_patterns) }
         let(:working_patterns) { %w[full_time part_time] }
 
         it "maps working patterns to the expected Google Jobs values" do
           expect(json.to_h).to include(employmentType: %w[FULL_TIME PART_TIME])
-        end
-      end
-
-      describe "#hiringOrganization" do
-        it "sets the school's details" do
-          hiring_organization = {
-            hiringOrganization: {
-              "@type": "Organization",
-              name: vacancy.organisation_name,
-              sameAs: vacancy.organisation.url,
-              identifier: vacancy.organisation.urn,
-              description: vacancy.about_school.present? ? "<p>#{vacancy.about_school}</p>" : nil,
-            },
-          }
-          expect(json.to_h).to include(hiring_organization)
         end
       end
     end

--- a/spec/requests/api/vacancies_spec.rb
+++ b/spec/requests/api/vacancies_spec.rb
@@ -174,6 +174,7 @@ RSpec.describe "Api::Vacancies" do
             hiringOrganization: {
               "@type": "Organization",
               name: vacancy.organisation_name,
+              sameAs: vacancy.organisation.url,
               identifier: vacancy.organisation.urn,
               description: vacancy.about_school.present? ? "<p>#{vacancy.about_school}</p>" : nil,
             },

--- a/spec/requests/api/vacancies_spec.rb
+++ b/spec/requests/api/vacancies_spec.rb
@@ -50,17 +50,6 @@ RSpec.describe "Api::Vacancies" do
       expect(json[:links].keys).to include(:self, :first, :last, :prev, :next)
     end
 
-    it "retrieves all live vacancies" do
-      published_vacancy = create(:vacancy, organisations: [school])
-      create(:vacancy, :expired, organisations: [school])
-
-      get api_jobs_path(api_version: 1), params: { format: :json }
-
-      expect(response.status).to eq(Rack::Utils.status_code(:ok))
-      expect(json[:data].count).to eq(1)
-      expect(json[:data]).to include(vacancy_json_ld(VacancyPresenter.new(published_vacancy)))
-    end
-
     context "when there are more vacancies than the per-page limit" do
       before do
         stub_const("Api::VacanciesController::MAX_API_RESULTS_PER_PAGE", per_page)
@@ -96,6 +85,7 @@ RSpec.describe "Api::Vacancies" do
     end
 
     it "does not retrieve incomplete or deleted vacancies" do
+      create(:vacancy, organisations: [school])
       create(:vacancy, :draft)
       create(:vacancy, :trashed)
       create(:vacancy, :future_publish)
@@ -103,7 +93,7 @@ RSpec.describe "Api::Vacancies" do
       get api_jobs_path(api_version: 1), params: { format: :json }
 
       expect(response.status).to eq(Rack::Utils.status_code(:ok))
-      expect(json[:data].count).to eq(0)
+      expect(json[:data].count).to eq(1)
     end
   end
 

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -297,6 +297,11 @@ module VacancyHelpers
     {
       "@context": "http://schema.org",
       "@type": "JobPosting",
+      baseSalary: {
+        :@type=>"MonetaryAmount",
+        :currency=>"GBP",
+        :value=>{:@type=>"QuantitativeValue", :unitText=>"HOUR", :value=>"£25 per hour"}
+      },
       title: vacancy.job_title,
       jobBenefits: vacancy.benefits_details,
       datePosted: vacancy.publish_on.iso8601,

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -299,7 +299,7 @@ module VacancyHelpers
       "@type": "JobPosting",
       title: vacancy.job_title,
       jobBenefits: vacancy.benefits_details,
-      datePosted: vacancy.publish_on.to_time.iso8601,
+      datePosted: vacancy.publish_on.iso8601,
       description: vacancy.skills_and_experience.present? ? vacancy.skills_and_experience : vacancy.job_advert,
       occupationalCategory: vacancy.job_roles.first,
       directApply: vacancy.enable_job_applications,
@@ -320,6 +320,7 @@ module VacancyHelpers
       hiringOrganization: {
         "@type": "Organization",
         name: vacancy.organisation_name,
+        sameAs: vacancy.organisation.url,
         identifier: vacancy.organisation.urn,
         description: vacancy.about_school,
       },

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -293,46 +293,6 @@ module VacancyHelpers
     expect(page).to have_selector("meta[itemprop='#{key}'][content='#{value}']")
   end
 
-  def vacancy_json_ld(vacancy)
-    {
-      "@context": "http://schema.org",
-      "@type": "JobPosting",
-      baseSalary: {
-        :@type=>"MonetaryAmount",
-        :currency=>"GBP",
-        :value=>{:@type=>"QuantitativeValue", :unitText=>"HOUR", :value=>"£25 per hour"}
-      },
-      title: vacancy.job_title,
-      jobBenefits: vacancy.benefits_details,
-      datePosted: vacancy.publish_on.iso8601,
-      description: vacancy.skills_and_experience.present? ? vacancy.skills_and_experience : vacancy.job_advert,
-      occupationalCategory: vacancy.job_roles.first,
-      directApply: vacancy.enable_job_applications,
-      employmentType: vacancy.working_patterns_for_job_schema,
-      industry: "Education",
-      jobLocation: {
-        "@type": "Place",
-        address: {
-          "@type": "PostalAddress",
-          addressLocality: vacancy.organisation.town,
-          addressRegion: vacancy.organisation.region,
-          streetAddress: vacancy.organisation.address,
-          postalCode: vacancy.organisation.postcode,
-          addressCountry: "GB",
-        },
-      },
-      url: job_url(vacancy),
-      hiringOrganization: {
-        "@type": "Organization",
-        name: vacancy.organisation_name,
-        sameAs: vacancy.organisation.url,
-        identifier: vacancy.organisation.urn,
-        description: vacancy.about_school,
-      },
-      validThrough: vacancy.expires_at.to_time.iso8601,
-    }
-  end
-
   def create_published_vacancy(*, **)
     build(:vacancy, :past_publish, *, **).tap do |vacancy|
       yield vacancy if block_given?

--- a/spec/system/jobseekers/jobseekers_can_view_a_vacancy_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_view_a_vacancy_spec.rb
@@ -41,17 +41,6 @@ RSpec.describe "Viewing a single published vacancy" do
       end
     end
 
-    context "with multiple working patterns" do
-      let(:vacancy) { create(:vacancy, organisations: [school], working_patterns: %w[full_time part_time]) }
-
-      it "contains correct JobPosting schema.org mark up" do
-        expect(page).to have_content "Full time"
-        expect(page).to have_content "part time"
-        expect(script_tag_content(wrapper_class: ".jobref"))
-          .to eq(vacancy_json_ld(VacancyPresenter.new(vacancy)).to_json)
-      end
-    end
-
     context "with supporting documents attached" do
       let(:vacancy) { create(:vacancy, :published, :with_supporting_documents, organisations: [school]) }
 

--- a/spec/system/jobseekers/jobseekers_can_view_a_vacancy_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_view_a_vacancy_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Viewing a single published vacancy" do
     context "with multiple working patterns" do
       let(:vacancy) { create(:vacancy, organisations: [school], working_patterns: %w[full_time part_time]) }
 
-      scenario "the page contains correct JobPosting schema.org mark up" do
+      it "contains correct JobPosting schema.org mark up" do
         expect(page).to have_content "Full time"
         expect(page).to have_content "part time"
         expect(script_tag_content(wrapper_class: ".jobref"))

--- a/spec/views/vacancies/show.html.slim_spec.rb
+++ b/spec/views/vacancies/show.html.slim_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe "vacancies/show" do
+  before do
+    assign :vacancy, VacancyPresenter.new(create(:vacancy, hourly_rate: hourly_rate, salary: salary))
+    render
+  end
+
+  describe "job posting metadata" do
+    let(:json_ld) { JSON.parse(rendered.html.css("script.jobref").inner_text, symbolize_names: true) }
+
+    context "with hourly rate" do
+      let(:hourly_rate) { 25 }
+      let(:salary) { "27000" }
+
+      it "has hourly rate as salary" do
+        expect(json_ld.fetch(:baseSalary)).to eq({ :@type => "MonetaryAmount", :currency => "GBP", :value => { :@type => "QuantitativeValue", :unitText => "HOUR", :value => "25" } })
+      end
+    end
+
+    context "without hourly rate" do
+      let(:hourly_rate) { nil }
+      let(:salary) { "27000" }
+
+      it "has salary instead" do
+        expect(json_ld.fetch(:baseSalary)).to eq({ :@type => "MonetaryAmount", :currency => "GBP", :value => { :@type => "QuantitativeValue", :unitText => "YEAR", :value => "27000" } })
+      end
+    end
+
+    context "without money" do
+      let(:hourly_rate) { nil }
+      let(:salary) { nil }
+
+      it "has no salary" do
+        expect(json_ld.key?(:baseSalary)).to be(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/7LryjALd/1597-update-metadata-to-match-current-google-guidelines

## Changes in this PR:

Update job posting metadata to show gov icon 