### PR TITLE
add moment-js dependency after moj frontend upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   ],
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2",
+    "moment": "^2.30.1",
     "@ministryofjustice/frontend": "^3.7.0",
     "@sentry/browser": "9.2.0",
     "@stimulus/polyfills": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4692,6 +4692,11 @@ minimist@^1.2.0, minimist@^1.2.6:
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz"
   integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
 
+moment@^2.30.1:
+  version "2.30.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
+  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
+
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"


### PR DESCRIPTION
## Trello card URL

## Changes in this PR:

After the recent upgrade to MoJ frontend 3.7.0, it appears that moment-js is now a dependency for MoJ frontend