### PR TITLE
Migrate all workflows to Ubuntu v24

### DIFF
--- a/.github/workflows/accessibility_tests.yml
+++ b/.github/workflows/accessibility_tests.yml
@@ -13,7 +13,7 @@ jobs:
       RAILS_ENV: test
       HTTP_BASIC_USER: ${{ secrets.HTTP_BASIC_USER }}
       HTTP_BASIC_PASSWORD: ${{ secrets.HTTP_BASIC_PASSWORD }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -82,7 +82,7 @@ jobs:
       RAILS_ENV: test
       HTTP_BASIC_USER: ${{ secrets.HTTP_BASIC_USER }}
       HTTP_BASIC_PASSWORD: ${{ secrets.HTTP_BASIC_PASSWORD }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/backup_production_db.yml
+++ b/.github/workflows/backup_production_db.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   sync:
     name: Backup production database
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     environment: production
     services:
       postgres:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -33,7 +33,7 @@ jobs:
   swagger-gen:
     name: Generate and Cache swagger docs
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     env:
       RAILS_ENV: test
@@ -84,7 +84,7 @@ jobs:
       docker_image_tag: ${{ env.DOCKER_IMAGE_TAG }}
       commit_sha: ${{ env.COMMIT_SHA }}
       LINK_TO_RUN: ${{ env.LINK_TO_RUN }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
 
@@ -234,7 +234,7 @@ jobs:
       # Its value is the list of environments. The matrix iterates once per environment and the value is accessed via ${{ matrix.environment }}
       matrix: ${{fromJSON(needs.build.outputs.matrix_environments)}}
     needs: [build]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
@@ -337,7 +337,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     name: Post deployment steps
     needs: [build, deploy]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -27,7 +27,7 @@ jobs:
   delete-review-app:
     if: contains(github.event.pull_request.labels.*.name, 'deploy') || github.event_name == 'workflow_dispatch'
     name: Delete review app
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     environment: review
 
     steps:

--- a/.github/workflows/deploy_app_via_workflow_dispatch.yml
+++ b/.github/workflows/deploy_app_via_workflow_dispatch.yml
@@ -21,7 +21,7 @@ jobs:
 
   deploy-app:
     name: Deploy ${{ github.event.inputs.tag }} to ${{ github.event.inputs.environment }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
 
     - name: Deploy App to ${{ env.ENVIRONMENT }} environment

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
   backend-lint:
     name: Run backend linting checks
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code
@@ -33,7 +33,7 @@ jobs:
   frontend-lint:
     name: Run frontend JS and SASS linting checks
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code
@@ -50,7 +50,7 @@ jobs:
   terraform-lint:
     name: Run Terraform check
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code
@@ -69,7 +69,7 @@ jobs:
   db-lint:
     name: Run Database consistency checks
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     env:
       DATABASE_URL: postgis://postgres:postgres@localhost:5432/tvs_test

--- a/.github/workflows/rebuild_docker_cache.yml
+++ b/.github/workflows/rebuild_docker_cache.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   build:
     name: Build docker image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/recreate-qa-database.yml
+++ b/.github/workflows/recreate-qa-database.yml
@@ -17,7 +17,7 @@ jobs:
 
   replace-postgres-DB-and-apps:
     name: Replace PostgresDB and apps in ${{ github.event.inputs.environment }} environment
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
 
     - uses: actions/checkout@v4

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -9,7 +9,7 @@ jobs:
     name: Smoke Test Production
     env:
       RAILS_ENV: test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
 
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   backend-tests:
     name: Run RSpec Tests in parallel
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   backend-tests:
     name: Run RSpec Tests in parallel
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false
@@ -88,7 +88,7 @@ jobs:
   frontend-tests:
     name: Run frontend JS unit tests
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Changes in this PR:
Ubuntu 20.04 runner has become unsupported.
Migrating to the latest stable version before we start getting errors in our action runs.

For context: https://github.com/actions/runner-images/issues/11101
