### PR TITLE
Extend project documentation

### DIFF
--- a/documentation/development/tooling/testing.md
+++ b/documentation/development/tooling/testing.md
@@ -64,6 +64,34 @@ or using Spring binstub:
 parallel_rspec
 ```
 
+## RSpec test coverage reports
+We use [Simplecov](https://github.com/simplecov-ruby/simplecov) and [Undercover](https://github.com/grodowski/undercover) gems for measuring and enforcing our test coverage.
+
+The configuration and minimum coverage requirements are set on the [.simplecov file](/.simplecov)
+
+### How to generate coverage reports locally?
+
+Set `COVERAGE=1` in your environment or as a prefix the full rspec run.
+
+EG: `COVERAGE=1 rspec`
+
+After running the full test suite, the coverage report should be available at the project's `/coverage/index.html` path.
+
+### Finding code coverage on the PR runs
+
+The code coverage is generated as an artifact on the projects Github PR check `test -> Run RSpec Tests in parallel -> Upload coverage report`
+
+When the step is expanded, there is a link to download it as:
+`Artifact download URL: https://github.com/DFE-Digital/teaching-vacancies/actions/runs/111111111/artifacts/22222222`
+
+The link will download a `ZIP` file containing the coverage report for the PR tests run.
+
+### Undercover alerts
+
+Once having a coverage report generated, undercover can be used to alert us about code that we added or changed without test coverage.
+
+This happens automatically in the PRs `test -> Run RSpec Tests in parallel` workflow. But can also be run locally invoking the `undercover` command.
+
 ## Visual regression testing
 
 The visual layout and appearance of defined scenarios (pages and common content) can be tested using [BackstopJS](https://github.com/garris/BackstopJS)

--- a/documentation/operations/deployment/deployments.md
+++ b/documentation/operations/deployment/deployments.md
@@ -11,7 +11,8 @@ Once the PR has been merged to main or a `deploy` tag applied to Review app, the
 - Builds and tags a Docker image from code in the `main` (staging, prod and qa) or `review app` branch
 - Tags the Docker image with the commit SHA as the tag
 - Logs in to Github's container registry as the service account `twd-tv-ci`
-- Pushes the image to GitHub packages, after it has been scanned by `Snyk` for vulnerabilities
+- Pushes the image to GitHub packages, after it has been scanned by `Snyk` for vulnerabilities.
+    - See [this guide](/documentation/operations/infrastructure/docker.md#docker-image-scan) on how to fix vulnerability errors that may arise at this stage.
 - Calls the [deploy_app.yml](../.github/workflows/deploy_app.yml) workflow to use Terraform to update the `web` and `worker` apps to use the new Docker image, and apply any changes to the appropriate environment.
 - Runs a smoke test against the deployed environment
 - If deployment (push) is to the main branch, performs `Post Deployment`

--- a/documentation/operations/deployment/deployments.md
+++ b/documentation/operations/deployment/deployments.md
@@ -53,7 +53,9 @@ To identify possible exceptions you can:
 
 - Check the logs for the review app pod:
   - `kubectl -n tv-development get pods` To identify the review app pod we want to check.
-  - `kubectl -n tv-development logs -f teaching-vacancies-review-pr-7546-c7476575b-gfbd4`
+  - `kubectl -n tv-development logs -f POD_NAME` To view logs.
+
+     For example: `kubectl -n tv-development logs -f teaching-vacancies-review-pr-7546-c7476575b-gfbd4`
 
 ### Merge and concurrency deployment management
 When there are multiple merges, this could lead to race conditions. To mitigate this, the `turnstyle` action prevents two or more instances of the same workflow from running concurrently.

--- a/documentation/operations/deployment/deployments.md
+++ b/documentation/operations/deployment/deployments.md
@@ -45,7 +45,7 @@ Sometimes, a review apps seem to timeout with a message like:
 >
 > │ Error: Waiting for rollout to finish: 1 replicas wanted; 0 replicas Ready
 
-This may men that the Review App startup process was terminated with an exception.
+This may mean that the Review App startup process was terminated with an exception.
 
 To identify possible exceptions you can:
 

--- a/documentation/operations/deployment/deployments.md
+++ b/documentation/operations/deployment/deployments.md
@@ -26,7 +26,7 @@ Perform the following to trigger a deployment a review app
 - attach a `deploy` label
 - Docker image and tag used to deploy the `review app` is based on the review app's `branch` and `sha` e.g teva-1234:commit_sha
 
-### Review app databases
+#### Review app databases
 By default, review apps use a simple postgis container deployed to AKS, as opposed to real Azure database flexible servers as it's cheaper and much faster to deploy.
 
 To use the Azure database temporarily in a review app, you can change the following parameters to `true` in `terraform/workspace-variables/review.tfvars.json` on the branch (do not commit this hange to main, remove it before merging):
@@ -36,6 +36,23 @@ To use the Azure database temporarily in a review app, you can change the follow
 "enable_postgres_ssl": true,
 "add_database_name_suffix": true,
 ```
+#### Review app deployment failures
+
+Sometimes, a review apps seem to timeout with a message like:
+
+> module.paas.module.web_application.kubernetes_deployment.main: Still creating... [9m50s elapsed]
+>
+> │ Error: Waiting for rollout to finish: 1 replicas wanted; 0 replicas Ready
+
+This may men that the Review App startup process was terminated with an exception.
+
+To identify possible exceptions you can:
+
+- Check the Sentry errors for `review` environment.
+
+- Check the logs for the review app pod:
+  - `kubectl -n tv-development get pods` To identify the review app pod we want to check.
+  - `kubectl -n tv-development logs -f teaching-vacancies-review-pr-7546-c7476575b-gfbd4`
 
 ### Merge and concurrency deployment management
 When there are multiple merges, this could lead to race conditions. To mitigate this, the `turnstyle` action prevents two or more instances of the same workflow from running concurrently.
@@ -81,7 +98,7 @@ This workflow can be triggered manually, passing the PR number corresponding to 
 ### Deleting review apps manually
 
 Sometimes, the [delete_review_app.yml](../.github/workflows/delete_review_app.yml) workflow errors as the review app
-wasn't  healthy/accesible and failed the initial "is this review app running?" check.
+wasn't healthy/accesible and failed the initial "is this review app running?" check.
 
 The kubernetes pods and other AKS resources (DB, Redis instances...) may still be running but orphaned once the PR is
 closed and the deletion job fails.

--- a/documentation/operations/infrastructure/docker.md
+++ b/documentation/operations/infrastructure/docker.md
@@ -256,3 +256,10 @@ To view the docker images stored on GitHub's container registry, you need to go 
 ### Docker image scan
 
 As part of the CI/CD, we conduct a Docker security scan using `snyk`, by invoking Snyk's docker image: `snyk/snyk-cli:docker`. This allows us a deep image inspection and vulnerability scan. When a vulnerability is detected while scanning, this breaks breaks CI/CD build. The vulnerability detected by `snyk`would need to be fixed before a successfully build can be completed.
+
+To fix it:
+1. Identify the offending package in the CI error message.
+2. Search for a patched non-vulnerable version.
+3. Set the explicit non-vulnerable version dependency (EG: `openssl=3.1.8-r0`) in the [Dockerfile's](/Dockerfile) `PROD_PACKAGES` list.
+4. Test the fix by pushing the Dockerfile change into a review app, an check the build output.
+5. Review & merge if it fixed the build.

--- a/documentation/operations/maintenance/bau-tasks.md
+++ b/documentation/operations/maintenance/bau-tasks.md
@@ -26,3 +26,32 @@ For backfilling the whole DB into analytics (**very resource/time intensive**), 
 ```
 bundle exec rails dfe:analytics:import_all_entities
 ```
+
+### Copying files from a kubernetes pod to the developer machine
+
+[Article](https://spacelift.io/blog/kubectl-cp) with detailed instructions and examples.
+
+`kubectl cp -n <namespace> <pod-name>:<path> <destination-on-local-system>`
+
+Example:
+`kubectl cp -n tv-development  teaching-vacancies-review-pr-7433-744c5c9b4b-ckxxd:jobseeker_emails.txt ./file.txt`
+
+### Exporting SQL query outputs from service DB to the developer machine as CSV file
+
+You will need kounduit
+If not already setup, you can install it using the project Maefile. From the project's root:
+```
+ make bin/konduit.sh
+```
+Connect to the DB PSQL console:
+```
+bin/konduit.sh teaching-vacancies-production -- psql
+```
+From the PSQL console, execute a query:
+```
+COPY (
+  SELECT column/s
+  FROM table
+  WHERE condition
+) TO '/local/path/filename.csv' WITH CSV HEADER;
+```

--- a/documentation/operations/maintenance/bau-tasks.md
+++ b/documentation/operations/maintenance/bau-tasks.md
@@ -38,7 +38,7 @@ Example:
 
 ### Exporting SQL query outputs from service DB to the developer machine as CSV file
 
-You will need kounduit
+You will need konduit
 If not already setup, you can install it using the project Maefile. From the project's root:
 ```
  make bin/konduit.sh
@@ -60,7 +60,7 @@ COPY (
 
 We now and then want to execute a [scheduled rake task](/config/schedule.yml) on demand.
 
-Unles for particular debugging reasons, there is no need to do this from a production rails console.
+Unless for particular debugging reasons, there is no need to do this from a production rails console.
 
 They can be triggered from the Sidekiq dashboard, accessible with your work email through DfE Sign-in.
 [Link to Sidekiq dashboard in production](https://teaching-vacancies.service.gov.uk/sidekiq)

--- a/documentation/operations/maintenance/bau-tasks.md
+++ b/documentation/operations/maintenance/bau-tasks.md
@@ -55,3 +55,15 @@ COPY (
   WHERE condition
 ) TO '/local/path/filename.csv' WITH CSV HEADER;
 ```
+
+### Running schedule tasks on demand
+
+We now and then want to execute a [scheduled rake task](/config/schedule.yml) on demand.
+
+Unles for particular debugging reasons, there is no need to do this from a production rails console.
+
+They can be triggered from the Sidekiq dashboard, accessible with your work email through DfE Sign-in.
+[Link to Sidekiq dashboard in production](https://teaching-vacancies.service.gov.uk/sidekiq)
+
+Once in the dashboard, the [Cron tab](https://teaching-vacancies.service.gov.uk/sidekiq/cron) lists all the schedule jobs,
+where they can be inmediately enqued or enabled/disabled on demand. .

--- a/documentation/team/onboarding.md
+++ b/documentation/team/onboarding.md
@@ -46,7 +46,7 @@ Onboarding a new team member to TV project codespaces:
 
 2. The team member must have individual write access (not only by a team membership) in the [project access settings](https://github.com/DFE-Digital/teaching-vacancies/settings/access).
 
-3. Request codespace access for the team member thorugh the [DFE Service Portal](https://dfe.service-now.com.mcas.ms/serviceportal?id=sc_cat_item&sys_id=0aacf3a81ba52110b192ec69b04bcb14) under `GitHub (dfe-digital) -> Other`.
+3. Request codespace access for the team member through the [DFE Service Portal](https://dfe.service-now.com.mcas.ms/serviceportal?id=sc_cat_item&sys_id=0aacf3a81ba52110b192ec69b04bcb14) under `GitHub (dfe-digital) -> Other`.
 
 
     **Request content template**

--- a/documentation/team/onboarding.md
+++ b/documentation/team/onboarding.md
@@ -35,6 +35,33 @@ Plus
 
 One of TV developers needs to add the new developer to [teaching-vacancies-developers](https://github.com/orgs/DFE-Digital/teams/teaching-vacancies-developers) as `maintainer` role.
 
+### Github Codespaces access for content team members
+
+We provide content team members a cloud development environment through [Github Codespaces](https://docs.github.com/en/codespaces).
+The codespaces are built using our [Devcontainer setup](/documentation/development/tooling/devcontainer.md)
+
+Onboarding a new team member to TV project codespaces:
+
+1. Ensure the team member has a Github user and is a member of [DFE-Digital organisation](https://github.com/orgs/DFE-Digital/teams).
+
+2. The team member must have individual write access (not only by a team membership) in the [project access settings](https://github.com/DFE-Digital/teaching-vacancies/settings/access).
+
+3. Request codespace access for the team member thorugh the [DFE Service Portal](https://dfe.service-now.com.mcas.ms/serviceportal?id=sc_cat_item&sys_id=0aacf3a81ba52110b192ec69b04bcb14) under `GitHub (dfe-digital) -> Other`.
+
+
+    **Request content template**
+    > Add a new user to organisation-owned Codespaces for Teaching Vacancies service.
+    >
+    > A new Teaching Vacancies content team member needs access to the DFE Digital-paid codespaces.
+    >
+    > Our project: https://github.com/DFE-Digital/teaching-vacancies
+    >
+    > The user: @user_github_handle
+    >
+    > Thank you.
+
+4. Once the ticket gets actioned, the user should be able to create codespaces from the `Code -> Codespaces` green button in our Github project landing page.
+
 ## DFE Azure Platform Identity
 
 Follow the [developer onboarding docs](https://github.com/DFE-Digital/teacher-services-cloud/blob/main/documentation/developer-onboarding.md#developer-onboarding) to setup your account in DFE Azure Platform Identity.


### PR DESCRIPTION
- Add onboarding instructions for Github Codespaces 
- Extend BAU docs with export file & queries info
- Add info to debug Review App deployment failures
- Add instructions on how to resolve Snyk errors
- Add info about code coverage tools on testing docs
- Add info on running schedule tasks on demand 