### PR TITLE
Add extra entries into INVALID_POLYGONS constant

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -112,8 +112,7 @@ class Subscription < ApplicationRecord
                       "county durham, darlington, hartlepool and stockton",
                       "cheshire",
                       "staffordshire and stoke",
-                      "lancashire, blackburn and blackpool"
-                    ].freeze
+                      "lancashire, blackburn and blackpool"].freeze
 
   class << self
     def limit_by_location(vacancies, location, radius_in_miles)

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -108,7 +108,12 @@ class Subscription < ApplicationRecord
                       "essex, southend and thurrock",
                       "leicestershire and rutland",
                       "lincolnshire and lincoln",
-                      "derbyshire and derby"].freeze
+                      "derbyshire and derby",
+                      "county durham, darlington, hartlepool and stockton",
+                      "cheshire",
+                      "staffordshire and stoke",
+                      "lancashire, blackburn and blackpool"
+                    ].freeze
 
   class << self
     def limit_by_location(vacancies, location, radius_in_miles)


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/MAlVPSX3/1638-bug-investigate-fix-error-on-daily-subscription-runs

## Changes in this PR:

Prior to this change, we were encountering [this error](https://teaching-vacancies.sentry.io/issues/6210036646/?environment=production&project=6212514&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=24h&stream_index=13). It looks like we have some new polygon locations which throw errors when we try to call methods on their area. By adding these invalid polygon locations to INVALID_POLYGONS I believe we can stop errors being thrown.

I experimented with changing the SIMPLIFICATION_TOLERANCE for the polygons in question and increasing it managed to fix most of their `Self-intersection` errors but some required quite high simplification tolerances, and one could not be fixed at any level that I tried.

Perhaps in a future PR we could experiment with increasing simplication tolerances after importing polygons for any of those that are invalid.