### PR TITLE
Spike: move TRN input  to different QTS options

### DIFF
--- a/app/views/jobseekers/base/_qts_fields.html.slim
+++ b/app/views/jobseekers/base/_qts_fields.html.slim
@@ -2,15 +2,13 @@
   = f.govuk_radio_button :qualified_teacher_status, "yes", link_errors: true
     = f.govuk_text_field :qualified_teacher_status_year
     = f.govuk_text_field :qts_age_range_and_subject
+    = f.govuk_text_field :teacher_reference_number, label: { text: t("helpers.legend.jobseekers_job_application_professional_status_form.teacher_reference_number") }
 
   = f.govuk_radio_button :qualified_teacher_status, "no"
+    = f.govuk_text_field :teacher_reference_number, label: { text: t("helpers.legend.jobseekers_job_application_professional_status_form.teacher_reference_number_optional") }
     = f.govuk_text_area :qualified_teacher_status_details
   = f.govuk_radio_button :qualified_teacher_status, "on_track"
-
-= f.govuk_radio_buttons_fieldset :has_teacher_reference_number, hint: -> { tag.p(t("helpers.label.jobseekers_profiles_qualified_teacher_status_form.teacher_reference_number_hint", link: govuk_link_to(t("helpers.label.jobseekers_profiles_qualified_teacher_status_form.trn_link_text"), "https://find-a-lost-trn.education.gov.uk/start", target: "_blank")).html_safe) } do
-  = f.govuk_radio_button :has_teacher_reference_number, "yes", link_errors: true, label: { text: t("helpers.legend.jobseekers_job_application_professional_status_form.has_teacher_reference_number_options.yes") }
-    = f.govuk_text_field :teacher_reference_number, label: { text: t("helpers.legend.jobseekers_job_application_professional_status_form.teacher_reference_number") }
-  = f.govuk_radio_button :has_teacher_reference_number, "no", label: { text: t("helpers.legend.jobseekers_job_application_professional_status_form.has_teacher_reference_number_options.no") }
+    = f.govuk_text_field :teacher_reference_number, label: { text: t("helpers.legend.jobseekers_job_application_professional_status_form.teacher_reference_number_optional") }
 
 = f.govuk_radio_buttons_fieldset :statutory_induction_complete,
   legend: { text: t("helpers.label.jobseekers_profiles_qualified_teacher_status_form.statutory_induction_complete") } do

--- a/config/locales/jobseekers/job_application/professional_status_form.yml
+++ b/config/locales/jobseekers/job_application/professional_status_form.yml
@@ -43,6 +43,7 @@ en:
           "yes": "Yes"
           "no": "No"
         teacher_reference_number: What is your teacher reference number (TRN)?
+        teacher_reference_number_optional: What is your teacher reference number (TRN)? (optional)
         statutory_induction_complete: Have you completed your induction period?
         qualified_teacher_status: Do you have qualified teacher status (QTS)?
         statutory_induction_complete_details: Additional induction details


### PR DESCRIPTION
Aiming to simplify validations and logic over the TRN requirement on the job application professional status step.

Instead of explicitly asking if the user has a TRN independently from the QTS, we embed the TRN field in each of the possible radio button options on the QTS question.

Then it is only required if the QTS answer is "Yes".


![Screenshot From 2025-03-04 11-50-28](https://github.com/user-attachments/assets/ddc4e025-e957-4ba1-9c69-195b405e4b80)

----

![Screenshot From 2025-03-04 11-51-51](https://github.com/user-attachments/assets/bb10a815-5033-46e7-b9a4-b069f2e78fb8)

----

![Screenshot From 2025-03-04 11-55-01](https://github.com/user-attachments/assets/00f9705f-fe0e-4038-80fe-60092904295e)

----

![Screenshot From 2025-03-04 11-56-24](https://github.com/user-attachments/assets/149c20fe-b595-4421-832d-cf1b9f23dc10)

----

![Screenshot From 2025-03-04 11-56-43](https://github.com/user-attachments/assets/daf40905-6b2c-4af6-94cb-74b0d49db345)
