### PR TITLE
Rescue InvalidGeometry error in location filtering for job alerts

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -119,7 +119,7 @@ class Subscription < ApplicationRecord
           return vacancies.select { |v| v.organisations.map(&:geopoint).any? { |point| polygon.area.contains?(point) } }
         end
       rescue RGeo::Error::InvalidGeometry => e
-        Rails.logger.error("Invalid geometry encountered for location #{polygon.name}: #{e.message}")
+        Sentry.capture_exception(e)
       end
 
       radius_in_metres = convert_miles_to_metres(radius_in_miles)

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -120,7 +120,7 @@ class Subscription < ApplicationRecord
         end
       rescue RGeo::Error::InvalidGeometry => e
         Sentry.with_scope do |scope|
-          scope.set_context("Polygon", { id: polygon.id, name: polygon.name } )
+          scope.set_context("Polygon", { id: polygon.id, name: polygon.name })
           Sentry.capture_exception(e)
         end
       end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -119,7 +119,10 @@ class Subscription < ApplicationRecord
           return vacancies.select { |v| v.organisations.map(&:geopoint).any? { |point| polygon.area.contains?(point) } }
         end
       rescue RGeo::Error::InvalidGeometry => e
-        Sentry.capture_exception(e)
+        Sentry.with_scope do |scope|
+          scope.set_context("Polygon", { id: polygon.id, name: polygon.name } )
+          Sentry.capture_exception(e)
+        end
       end
 
       radius_in_metres = convert_miles_to_metres(radius_in_miles)

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -111,6 +111,7 @@ class Subscription < ApplicationRecord
                       "derbyshire and derby"].freeze
 
   class << self
+    # rubocop:disable Metrics/AbcSize
     def limit_by_location(vacancies, location, radius_in_miles)
       polygon = LocationPolygon.buffered(radius_in_miles).with_name(location)
       begin
@@ -120,12 +121,13 @@ class Subscription < ApplicationRecord
       rescue RGeo::Error::InvalidGeometry => e
         Rails.logger.error("Invalid geometry encountered for location #{polygon.name}: #{e.message}")
       end
-    
+
       radius_in_metres = convert_miles_to_metres(radius_in_miles)
       coordinates = Geocoding.new(location).coordinates
       search_point = RGeo::Geographic.spherical_factory(srid: 4326).point(coordinates.second, coordinates.first)
       vacancies.select { |v| v.organisations.map(&:geopoint).any? { |point| search_point.distance(point) < radius_in_metres } }
     end
+    # rubocop:enable Metrics/AbcSize
 
     def handle_location(scope, criteria)
       if criteria.key?(:location)

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -229,11 +229,8 @@ RSpec.describe Subscription do
         end
 
         context "when polygon has invalid geometry", :geocode do
-          let(:vacancies) { subscription.vacancies_matching(Vacancy.all) }
           let(:subscription) { create(:daily_subscription, location: "basildon", radius: radius) }
           let(:radius) { 200 }
-          let(:basildon_polygon) { LocationPolygon.find_by(name: "basildon") }
-          let(:basildon_coordinates) { [51.5761, 0.4886] }
 
           before do
             # rubocop:disable RSpec/AnyInstance

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -241,7 +241,6 @@ RSpec.describe Subscription do
             # rubocop:enable RSpec/AnyInstance
 
             # Mock Geocoder to prevent real API call
-
             allow(Geocoder).to receive(:coordinates).with("basildon", hash_including(lookup: :google, components: "country:gb"))
                                                     .and_return([51.5761, 0.4886])
           end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -236,18 +236,13 @@ RSpec.describe Subscription do
           let(:basildon_coordinates) { [51.5761, 0.4886] }
 
           before do
-            # Create a double for the area with the invalid_reason method raising an error
-            polygon_area_double = instance_double(RGeo::Geos::Polygon)
-            allow(polygon_area_double).to receive(:invalid_reason).and_raise(RGeo::Error::InvalidGeometry)
-
-            # Stub the polygon to return the double for area
-            # rubocop:disable RSpec/AnyInstance
-            allow_any_instance_of(LocationPolygon).to receive(:area).and_return(polygon_area_double)
-            # rubocop:enable RSpec/AnyInstance
-
+            allow_any_instance_of(LocationPolygon).to receive(:area).and_raise(RGeo::Error::InvalidGeometry)
+          
             # Mock Geocoder to prevent real API call
-            allow(Geocoder).to receive(:coordinates).with("basildon", hash_including(lookup: :google, components: "country:gb")).and_return(basildon_coordinates)
+            allow(Geocoder).to receive(:coordinates).with("basildon", hash_including(lookup: :google, components: "country:gb"))
+                                                    .and_return([51.5761, 0.4886])
           end
+          
 
           it "rescues RGeo::Error::InvalidGeometry and falls back to distance-based filtering" do
             expect(Rails.logger).to receive(:error).with(/Invalid geometry encountered for location/)

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -237,15 +237,14 @@ RSpec.describe Subscription do
 
           before do
             allow_any_instance_of(LocationPolygon).to receive(:area).and_raise(RGeo::Error::InvalidGeometry)
-          
+
             # Mock Geocoder to prevent real API call
             allow(Geocoder).to receive(:coordinates).with("basildon", hash_including(lookup: :google, components: "country:gb"))
                                                     .and_return([51.5761, 0.4886])
           end
-          
 
           it "rescues RGeo::Error::InvalidGeometry and falls back to distance-based filtering" do
-            expect(Rails.logger).to receive(:error).with(/Invalid geometry encountered for location/)
+            expect(Sentry).to receive(:capture_exception).with(instance_of(RGeo::Error::InvalidGeometry))
             # same result as entering basildon postcode with radius of 200.
             expect(vacancies).to contain_exactly(liverpool_vacancy, st_albans_vacancy, basildon_vacancy)
           end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -228,25 +228,26 @@ RSpec.describe Subscription do
           end
         end
 
-        context "when polygon has invalid geometry", :geocode, :vcr do
+        context "when polygon has invalid geometry", :geocode do
           let(:vacancies) { subscription.vacancies_matching(Vacancy.all) }
           let(:subscription) { create(:daily_subscription, location: "basildon", radius: radius) }
           let(:radius) { 200 }
           let(:basildon_polygon) { LocationPolygon.find_by(name: "basildon") }
           let(:basildon_coordinates) { [51.5761, 0.4886] }
-          
+
           before do
             # Create a double for the area with the invalid_reason method raising an error
-            polygon_area_double = instance_double("RGeo::Geos::Polygon")
+            polygon_area_double = instance_double(RGeo::Geos::Polygon)
             allow(polygon_area_double).to receive(:invalid_reason).and_raise(RGeo::Error::InvalidGeometry)
-          
+
             # Stub the polygon to return the double for area
+            # rubocop:disable RSpec/AnyInstance
             allow_any_instance_of(LocationPolygon).to receive(:area).and_return(polygon_area_double)
-          
+            # rubocop:enable RSpec/AnyInstance
+
             # Mock Geocoder to prevent real API call
             allow(Geocoder).to receive(:coordinates).with("basildon", hash_including(lookup: :google, components: "country:gb")).and_return(basildon_coordinates)
           end
-          
 
           it "rescues RGeo::Error::InvalidGeometry and falls back to distance-based filtering" do
             expect(Rails.logger).to receive(:error).with(/Invalid geometry encountered for location/)

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -236,9 +236,12 @@ RSpec.describe Subscription do
           let(:basildon_coordinates) { [51.5761, 0.4886] }
 
           before do
+            # rubocop:disable RSpec/AnyInstance
             allow_any_instance_of(LocationPolygon).to receive(:area).and_raise(RGeo::Error::InvalidGeometry)
+            # rubocop:enable RSpec/AnyInstance
 
             # Mock Geocoder to prevent real API call
+
             allow(Geocoder).to receive(:coordinates).with("basildon", hash_including(lookup: :google, components: "country:gb"))
                                                     .and_return([51.5761, 0.4886])
           end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/MAlVPSX3/1638-bug-investigate-fix-error-on-daily-subscription-runs

## Changes in this PR:

We have been experiencing some RGeo::Error::InvalidGeometry errors when processing job alerts. I raised [a PR](https://github.com/DFE-Digital/teaching-vacancies/pull/7573) to add the invalid polygons (which were causing these errors) to the INVALID_POLYGONS to stop these errors occuring.

This PR ensures we handle any RGeo::Error::InvalidGeometry errors which could thrown in the future by invalid polygons that we have not yet added to INVALID_POLYGONS. This change rescues these errors and falls back to using co-ordinates rather than the polygon if the polygon is raising errors.

## Screenshots of UI changes:

### Before

### After
