### PR TITLE
Fix campaign pages error

### DIFF
--- a/app/services/campaign_page.rb
+++ b/app/services/campaign_page.rb
@@ -5,6 +5,8 @@ class CampaignPage
   LANGUAGE_SUBJECTS = %w[English Spanish German French].freeze
 
   def self.exists?(utm_content)
+    return false if utm_content.blank?
+
     Rails.application.config.campaign_pages.key?(utm_content.to_sym)
   end
 

--- a/config/campaign_pages.yml
+++ b/config/campaign_pages.yml
@@ -6,14 +6,14 @@ shared:
     phases:
       - primary
     radius: 15
-  mostvacanciesbespoke%2BPRIMARY:
+  mostvacanciesbespoke+PRIMARY:
     banner_image: "campaigns/primary_teacher.jpg"
     teaching_job_roles:
       - teacher
     phases:
       - primary
     radius: 15
-  mostvacanciesbespoke%2BSECONDARY:
+  mostvacanciesbespoke+SECONDARY:
     banner_image: "campaigns/primary_teacher.jpg"
     teaching_job_roles:
       - teacher

--- a/config/locales/campaign_pages.yml
+++ b/config/locales/campaign_pages.yml
@@ -2,9 +2,9 @@ en:
   campaign_pages:
     whentoapplybespoke+PRIMARY:
       banner_title: "%{name}, find your primary teacher job"
-    mostvacanciesbespoke%2BPRIMARY:
+    mostvacanciesbespoke+PRIMARY:
       banner_title: "%{name}, find your primary teacher job"
-    mostvacanciesbespoke%2BSECONDARY:
+    mostvacanciesbespoke+SECONDARY:
       banner_title: "%{name}, find your secondary teacher job"
     whentoapplybespoke+SECONDARY:
       banner_title: "%{name}, find your secondary teacher job"

--- a/config/locales/campaign_pages.yml
+++ b/config/locales/campaign_pages.yml
@@ -28,8 +28,6 @@ en:
       banner_title: "%{name}, find the right %{subject} teacher job for you"
     dancedramamusicbespoke:
       banner_title: "%{name}, find the right %{subject} teacher job for you"
-    dancedramamusicbespoke:
-      banner_title: "%{name}, find the right %{subject} teacher job for you"
     computingbespoke:
       banner_title: "%{name}, find the right %{subject} teacher job for you"
     chemistrybespoke:

--- a/spec/services/campaign_page_spec.rb
+++ b/spec/services/campaign_page_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe CampaignPage do
     it "returns whether a landing page has been set up" do
       expect(described_class.exists?("FAKE1+CAMPAIGN")).to be(true)
       expect(described_class.exists?("i-do-not-exist")).to be(false)
+      expect(described_class.exists?("")).to be(false)
+      expect(described_class.exists?(nil)).to be(false)
     end
   end
 


### PR DESCRIPTION
Fixing a couple issues with the campaigns:

- The name of the campaign was using URL codified symbol `%2B` for `+`, causing mismatches when retrieving it.
- The `exists?` method was throwing an uncontrolled exception.
- One campaign config was duplicated.
