### PR TITLE
Fix campaign pages subjects

### DIFF
--- a/config/campaign_pages.yml
+++ b/config/campaign_pages.yml
@@ -193,6 +193,6 @@ test:
     working_patterns:
       - part_time
     subjects:
-      - Potions
-      - Sorcery
+      - Physics
+      - Science
     radius: 15

--- a/config/campaign_pages.yml
+++ b/config/campaign_pages.yml
@@ -38,115 +38,115 @@ shared:
     teaching_job_roles:
       - teacher
     subjects:
-      - maths
+      - Mathematics
     radius: 15
   geographybespoke:
     banner_image: "campaigns/subjects.jpg"
     teaching_job_roles:
       - teacher
     subjects:
-      - geography
+      - Geography
     radius: 15
   languagesbespoke:
     banner_image: "campaigns/subjects.jpg"
     teaching_job_roles:
       - teacher
     subjects:
-      - languages
+      - Languages
     radius: 15
   pebespoke:
     banner_image: "campaigns/subjects.jpg"
     teaching_job_roles:
       - teacher
     subjects:
-      - physical_education
+      - Physical education
     radius: 15
   physicsbespoke:
     banner_image: "campaigns/subjects.jpg"
     teaching_job_roles:
       - teacher
     subjects:
-      - physics
+      - Physics
     radius: 15
   historybespoke:
     banner_image: "campaigns/subjects.jpg"
     teaching_job_roles:
       - teacher
     subjects:
-      - history
+      - History
     radius: 15
   designandtechnologybespoke:
     banner_image: "campaigns/subjects.jpg"
     teaching_job_roles:
       - teacher
     subjects:
-      - design_and_technology
+      - Design and technology
     radius: 15
   sciencebespoke:
     banner_image: "campaigns/subjects.jpg"
     teaching_job_roles:
       - teacher
     subjects:
-      - science
+      - Science
     radius: 15
   dancedramamusicbespoke:
     banner_image: "campaigns/subjects.jpg"
     teaching_job_roles:
       - teacher
     subjects:
-      - dance
-      - drama
-      - music
+      - Dance
+      - Drama
+      - Music
     radius: 15
   computingbespoke:
     banner_image: "campaigns/subjects.jpg"
     teaching_job_roles:
       - teacher
     subjects:
-      - computing
+      - Computing
     radius: 15
   chemistrybespoke:
     banner_image: "campaigns/subjects.jpg"
     teaching_job_roles:
       - teacher
     subjects:
-      - chemistry
+      - Chemistry
     radius: 15
   businessandeconomicsbespoke:
     banner_image: "campaigns/subjects.jpg"
     teaching_job_roles:
       - teacher
     subjects:
-      - business_studies
-      - economics
+      - Business studies
+      - Economics
     radius: 15
   re:
     banner_image: "campaigns/subjects.jpg"
     teaching_job_roles:
       - teacher
     subjects:
-      - religious_education
+      - Religious education
     radius: 15
   biologybespoke:
     banner_image: "campaigns/subjects.jpg"
     teaching_job_roles:
       - teacher
     subjects:
-      - biology
+      - Biology
     radius: 15
   englishbespoke:
     banner_image: "campaigns/subjects.jpg"
     teaching_job_roles:
       - teacher
     subjects:
-      - english
+      - English
     radius: 15
   psychologybespoke:
     banner_image: "campaigns/subjects.jpg"
     teaching_job_roles:
       - teacher
     subjects:
-      - psychology
+      - Psychology
     radius: 15
   parttimebespoke+PRIMARY:
     banner_image: "campaigns/primary_part_time.jpg"

--- a/spec/configuration/campaign_pages_configuration_spec.rb
+++ b/spec/configuration/campaign_pages_configuration_spec.rb
@@ -10,4 +10,34 @@ RSpec.describe "Landing page configuration" do
       end
     end
   end
+
+  it "each campaign page configuration points to an existing banner image" do
+    Rails.application.config.campaign_pages.each do |campaign, config|
+      expect { ActionController::Base.helpers.image_path(config[:banner_image]) }
+        .not_to raise_error, "Image asset for campaign '#{campaign}' does not exist at 'app/assets/images/#{config[:banner_image]}'"
+    end
+  end
+
+  it "each campaign page configuration with teaching job roles filters by valid roles" do
+    Rails.application.config.campaign_pages.each do |campaign, config|
+      next if config[:teaching_job_roles].blank?
+
+      config[:teaching_job_roles].each do |job_role| # rubocop:disable Rspect/IteratedExpectation
+        expect(job_role).to be_in(Vacancy::TEACHING_JOB_ROLES),
+                            "Invalid teaching job role '#{job_role}' for campaign '#{campaign}'" # Needed iterated expectation for this descriptive error
+      end
+    end
+  end
+
+  it "each campaign page configuration with subjects filters by valid subjects" do
+    valid_subjects = SUBJECT_OPTIONS.map(&:first) # List of available subjects in the service (from subjects.yml)
+    Rails.application.config.campaign_pages.each do |campaign, config|
+      next if config[:subjects].blank?
+
+      config[:subjects].each do |subject| # rubocop:disable Rspect/IteratedExpectation
+        expect(subject).to be_in(valid_subjects),
+                           "Invalid subject '#{subject}' for campaign '#{campaign}'" # Needed iterated expectation for this descriptive error
+      end
+    end
+  end
 end

--- a/spec/services/campaign_page_spec.rb
+++ b/spec/services/campaign_page_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CampaignPage do
   before do
     allow(Search::VacancySearch)
       .to receive(:new)
-            .with(hash_including(working_patterns: %w[part_time], subjects: %w[Potions Sorcery]))
+            .with(hash_including(working_patterns: %w[part_time], subjects: %w[Physics Science]))
             .and_return(search)
   end
 
@@ -26,7 +26,7 @@ RSpec.describe CampaignPage do
       expect(described_class["FAKE1+CAMPAIGN"].banner_image)
         .to eq("campaigns/secondary_not_too_late.jpg")
       expect(described_class["FAKE1+CAMPAIGN"].criteria)
-        .to eq({ radius: 15, teaching_job_roles: %w[teacher], working_patterns: %w[part_time], subjects: %w[Potions Sorcery] })
+        .to eq({ radius: 15, teaching_job_roles: %w[teacher], working_patterns: %w[part_time], subjects: %w[Physics Science] })
     end
 
     it "raises an error if no landing page with the given slug has been configured" do


### PR DESCRIPTION
## Changes in this PR:
**Fix campaign pages subjects** 

The subjects listed in the campaign pages weren't matching our subjects list in the filters, what caused the desired subjects not being automatically applied per campaign.

**Add configuration tests for campaign filters**
Ensure each one of the values present in the campaigns configurations
matches an:
- Existing banner image.
- Existing teaching job role.
- Existing subject.

So, if the wrong value is entered when adding/updating a campaign, it will be caught by our tests.

## Screenshots of UI changes:

### Ensuring campaign banner image is valid
![Screenshot From 2025-03-06 13-03-04](https://github.com/user-attachments/assets/b328f95c-bee8-4e4a-9c3f-ec0d7e052795)

### Ensuring campaign teaching job role is valid
![Screenshot From 2025-03-06 13-24-13](https://github.com/user-attachments/assets/81c411e3-363f-4fc3-8dea-1d2e6b119424)

### Ensuring campaign subject is valid
![Screenshot From 2025-03-06 13-32-37](https://github.com/user-attachments/assets/dfa34b59-7a53-40be-9a2e-2423e4ad3c36)
