### PR TITLE
 Hide equal opportunities details on submitted application

### DIFF
--- a/app/views/jobseekers/job_applications/review/_equal_opportunities.html.slim
+++ b/app/views/jobseekers/job_applications/review/_equal_opportunities.html.slim
@@ -1,24 +1,27 @@
 - r.with_section :equal_opportunities do |s|
-  - s.with_row do |row|
-    - row.with_key text: t("helpers.legend.jobseekers_job_application_equal_opportunities_form.disability")
-    - row.with_value text: job_application.disability.humanize
+ - if r.job_application.submitted?
+   p.govuk-body = t("jobseekers.job_applications.build.equal_opportunities.anonymity")
+ - else
+   - s.with_row do |row|
+     - row.with_key text: t("helpers.legend.jobseekers_job_application_equal_opportunities_form.disability")
+     - row.with_value text: job_application.disability.humanize
 
-  - s.with_row do |row|
-    - row.with_key text: t("helpers.legend.jobseekers_job_application_equal_opportunities_form.age")
-    - row.with_value text: job_application.age.humanize
+   - s.with_row do |row|
+     - row.with_key text: t("helpers.legend.jobseekers_job_application_equal_opportunities_form.age")
+     - row.with_value text: job_application.age.humanize
 
-  - s.with_row do |row|
-    - row.with_key text: t("helpers.legend.jobseekers_job_application_equal_opportunities_form.gender")
-    - row.with_value text: safe_join([tag.div(job_application.gender.humanize, class: "govuk-body"), tag.div(job_application.gender_description, class: "govuk-body")])
+   - s.with_row do |row|
+     - row.with_key text: t("helpers.legend.jobseekers_job_application_equal_opportunities_form.gender")
+     - row.with_value text: safe_join([tag.div(job_application.gender.humanize, class: "govuk-body"), tag.div(job_application.gender_description, class: "govuk-body")])
 
-  - s.with_row do |row|
-    - row.with_key text: t("helpers.legend.jobseekers_job_application_equal_opportunities_form.orientation")
-    - row.with_value text: safe_join([tag.div(job_application.orientation.humanize, class: "govuk-body"), tag.div(job_application.orientation_description, class: "govuk-body")])
+   - s.with_row do |row|
+     - row.with_key text: t("helpers.legend.jobseekers_job_application_equal_opportunities_form.orientation")
+     - row.with_value text: safe_join([tag.div(job_application.orientation.humanize, class: "govuk-body"), tag.div(job_application.orientation_description, class: "govuk-body")])
 
-  - s.with_row do |row|
-    - row.with_key text: t("helpers.legend.jobseekers_job_application_equal_opportunities_form.ethnicity")
-    - row.with_value text: safe_join([tag.div(job_application.ethnicity.humanize, class: "govuk-body"), tag.div(job_application.ethnicity_description, class: "govuk-body")])
+   - s.with_row do |row|
+     - row.with_key text: t("helpers.legend.jobseekers_job_application_equal_opportunities_form.ethnicity")
+     - row.with_value text: safe_join([tag.div(job_application.ethnicity.humanize, class: "govuk-body"), tag.div(job_application.ethnicity_description, class: "govuk-body")])
 
-  - s.with_row do |row|
-    - row.with_key text: t("helpers.legend.jobseekers_job_application_equal_opportunities_form.religion")
-    - row.with_value text: safe_join([tag.div(job_application.religion.humanize, class: "govuk-body"), tag.div(job_application.religion_description, class: "govuk-body")])
+   - s.with_row do |row|
+     - row.with_key text: t("helpers.legend.jobseekers_job_application_equal_opportunities_form.religion")
+     - row.with_value text: safe_join([tag.div(job_application.religion.humanize, class: "govuk-body"), tag.div(job_application.religion_description, class: "govuk-body")])

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -175,8 +175,8 @@ en:
           title: Current role and employment history — Application
         equal_opportunities:
           anonymity: >-
-            This will not be used as part of your application. It will only be used anonymously to monitor the
-            inclusivity of the shortlisting process.
+            Your information will be held anonymously by the Department for Education to monitor the inclusivity of applicants.
+            It will not be used as part of your application.
           explanation: >-
             School staff from a range of backgrounds and experiences in society provide students with a better all-round education.
             Please provide some basic information about your identity to help achieve this.

--- a/spec/system/jobseekers/job_applications_submitted_spec.rb
+++ b/spec/system/jobseekers/job_applications_submitted_spec.rb
@@ -56,6 +56,12 @@ RSpec.describe "Submitted job applications for jobseekers" do
       it "removes the 'submit application' section" do
         expect(page).not_to have_css(".new_jobseekers_job_application_review_form")
       end
+
+      it "does not show equal opportunities section details" do
+        within ".review-component__section", text: I18n.t("jobseekers.job_applications.build.equal_opportunities.heading") do
+          expect(page).to have_content(I18n.t("jobseekers.job_applications.build.equal_opportunities.anonymity"))
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/15eCJLFO)

## Changes in this PR:

### Hide equal opportunities details on submitted application
- Hide equal opportunities section details for submitted applications

- Updated copy for equal opportunities anonymity

## Screenshots of UI changes:

### Before
![image](https://github.com/user-attachments/assets/b64a26a9-5296-482e-99b5-45da61ef9b08)


### After
![image](https://github.com/user-attachments/assets/08072172-771d-487d-8f1c-c6d5f97c96a8)
