### PR TITLE
Prevent invalid employment records from submission

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -51,6 +51,6 @@ if ENV.fetch("COVERAGE", 0).to_i.positive?
     # .25% lower (branch) and .1% lower (line) than the test run for now
     #
     # possibly the tests are stable now?
-    minimum_coverage line: 95.53, branch: 79.82
+    minimum_coverage line: 95.53, branch: 79.81
   end
 end

--- a/app/form_models/jobseekers/job_application/employment_history_form.rb
+++ b/app/form_models/jobseekers/job_application/employment_history_form.rb
@@ -12,29 +12,39 @@ module Jobseekers
         end
 
         def unstorable_fields
-          %i[unexplained_employment_gaps_present employment_history_section_completed]
+          %i[unexplained_employment_gaps_present employment_history_section_completed employments]
         end
 
         def load_form(model)
-          super.merge(unexplained_employment_gaps: model.unexplained_employment_gaps).merge(completed_attrs(model, :employment_history))
+          super.merge(employments: model.employments,
+                      unexplained_employment_gaps: model.unexplained_employment_gaps)
+               .merge(completed_attrs(model, :employment_history))
         end
       end
-      attr_accessor(:unexplained_employment_gaps)
+      attr_accessor(:unexplained_employment_gaps, :employments)
 
-      validate :employment_history_gaps_are_explained
+      validate :employment_history_gaps_are_explained, if: -> { unexplained_employment_gaps_present == "true" && employment_history_section_completed }
+
+      validate :employment_records_are_all_valid
+
+      completed_attribute(:employment_history)
+
+      private
 
       attribute :unexplained_employment_gaps_present, :boolean
 
       def employment_history_gaps_are_explained
-        return unless unexplained_employment_gaps_present && employment_history_section_completed
-
         unexplained_employment_gaps.each_value do |details|
           gap_duration = distance_of_time_in_words(details[:started_on], details[:ended_on] || Time.zone.today)
-          errors.add(:base, "You have a gap in your work history (#{gap_duration}).")
+          errors.add(:unexplained_employment_gaps, "You have a gap in your work history (#{gap_duration}).")
         end
       end
 
-      completed_attribute(:employment_history)
+      def employment_records_are_all_valid
+        employments.reject(&:valid?).each do |_employment|
+          errors.add(:base, :invalid_employment)
+        end
+      end
     end
   end
 end

--- a/app/form_models/jobseekers/job_application/employment_history_form.rb
+++ b/app/form_models/jobseekers/job_application/employment_history_form.rb
@@ -12,7 +12,7 @@ module Jobseekers
         end
 
         def unstorable_fields
-          %i[unexplained_employment_gaps_present employment_history_section_completed employments]
+          %i[unexplained_employment_gaps employment_history_section_completed employments]
         end
 
         def load_form(model)
@@ -23,7 +23,7 @@ module Jobseekers
       end
       attr_accessor(:unexplained_employment_gaps, :employments)
 
-      validate :employment_history_gaps_are_explained, if: -> { unexplained_employment_gaps_present == "true" && employment_history_section_completed }
+      validate :employment_history_gaps_are_explained, if: -> { employment_history_section_completed }
 
       validate :employment_records_are_all_valid
 

--- a/app/models/jobseeker_profile.rb
+++ b/app/models/jobseeker_profile.rb
@@ -51,7 +51,7 @@ class JobseekerProfile < ApplicationRecord
 
   def self.copy_attributes(record, previous_application)
     record.assign_attributes(
-      employments: previous_application.employments.map(&:clone),
+      employments: previous_application.employments.map(&:duplicate),
       qualifications: previous_application.qualifications.map(&:duplicate),
       qualified_teacher_status_year: previous_application.qualified_teacher_status_year,
       qualified_teacher_status: previous_application.qualified_teacher_status,

--- a/app/models/jobseeker_profile.rb
+++ b/app/models/jobseeker_profile.rb
@@ -51,7 +51,7 @@ class JobseekerProfile < ApplicationRecord
 
   def self.copy_attributes(record, previous_application)
     record.assign_attributes(
-      employments: previous_application.employments.map(&:duplicate),
+      employments: previous_application.employments.map(&:clone),
       qualifications: previous_application.qualifications.map(&:duplicate),
       qualified_teacher_status_year: previous_application.qualified_teacher_status_year,
       qualified_teacher_status: previous_application.qualified_teacher_status,

--- a/app/presenters/work_history_error_summary_presenter.rb
+++ b/app/presenters/work_history_error_summary_presenter.rb
@@ -6,7 +6,7 @@ class WorkHistoryErrorSummaryPresenter
 
   def formatted_error_messages
     @error_messages.flat_map do |attribute, messages|
-      if attribute == :base
+      if attribute == :unexplained_employment_gaps
         messages.each_with_index.map do |message, index|
           gap = @unexplained_employment_gaps.values[index]
           gap_id = "gap-#{gap[:started_on].strftime('%Y%m%d')}-#{gap[:ended_on].strftime('%Y%m%d')}"

--- a/app/services/jobseekers/job_applications/prefill_job_application_from_previous_application.rb
+++ b/app/services/jobseekers/job_applications/prefill_job_application_from_previous_application.rb
@@ -19,6 +19,8 @@ class Jobseekers::JobApplications::PrefillJobApplicationFromPreviousApplication
     new_job_application
   end
 
+  PLAIN_STEPS = %w[personal_details personal_statement references ask_for_support qualifications training_and_cpds professional_body_memberships following_religion religion_details].freeze
+
   private
 
   def copy_personal_info
@@ -116,8 +118,8 @@ class Jobseekers::JobApplications::PrefillJobApplicationFromPreviousApplication
   end
 
   def completed_steps
-    completed_steps = %w[personal_details personal_statement references ask_for_support qualifications training_and_cpds professional_body_memberships following_religion religion_details].select { |step| relevant_steps.include?(step.to_sym) }
-    completed_steps << "employment_history" unless previous_application_was_submitted_before_we_began_validating_gaps_in_work_history?
+    completed_steps = PLAIN_STEPS.select { |step| relevant_steps.include?(step.to_sym) }
+    completed_steps << "employment_history" unless previous_application_was_submitted_before_we_began_validating_gaps_in_work_history? || recent_job_application.employments.reject(&:valid?).any?
     completed_steps << "professional_status" if previous_application_has_professional_status_details?
     completed_steps
   end

--- a/app/views/jobseekers/job_applications/build/_employment_summary_card.html.slim
+++ b/app/views/jobseekers/job_applications/build/_employment_summary_card.html.slim
@@ -9,6 +9,11 @@
       .govuk-summary-list__row
         dt.govuk-summary-list__key = t("jobseekers.job_applications.employments.organisation")
         dd.govuk-summary-list__value = employment.organisation.presence
+      - unless employment.valid?
+        - employment.errors.full_messages.each do |message|
+          .govuk-summary-list__row
+            dt.govuk-summary-list__key
+            dd.govuk-summary-list__value.govuk-error-message = message
       .govuk-summary-list__row
         dt.govuk-summary-list__key = t("jobseekers.job_applications.employments.started_on")
         dd.govuk-summary-list__value = employment.started_on.to_formatted_s(:month_year)

--- a/app/views/jobseekers/job_applications/build/employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/build/employment_history.html.slim
@@ -47,10 +47,8 @@
                 = " or "
                 = govuk_link_to t("buttons.add_reason_for_break"), new_jobseekers_job_application_break_path(job_application, started_on: gap[:started_on], ended_on: gap[:ended_on] || Date.current)
 
-      - unexplained_employment_gaps_present = job_application.unexplained_employment_gaps.present?
       = f.govuk_collection_radio_buttons :employment_history_section_completed, %w[true false], :to_s
 
-      = f.hidden_field :unexplained_employment_gaps_present, value: unexplained_employment_gaps_present
       = f.govuk_submit job_application_build_submit_button_text do
         = govuk_link_to t("buttons.cancel_and_return_to_account"), jobseekers_job_applications_path, class: "govuk-link--no-visited-state"
         span.govuk-caption-m

--- a/config/locales/jobseekers/employment_form.yml
+++ b/config/locales/jobseekers/employment_form.yml
@@ -23,7 +23,7 @@ en:
               blank: Enter the date you started at this school or organisation
               invalid: Enter a date in the correct format
             reason_for_leaving:
-              blank: Enter your reason for leaving the role
+              blank: Enter your reason for leaving this role
 
   helpers:
     hint:

--- a/config/locales/jobseekers/job_application/employment_history_form.yml
+++ b/config/locales/jobseekers/job_application/employment_history_form.yml
@@ -6,6 +6,7 @@ en:
           attributes:
             employment_history_section_completed:
               inclusion: Select yes if you have completed this section
+          invalid_employment: One or more of your employment records is invalid
   helpers:
     legend:
       jobseekers_job_application_employment_history_form:

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -108,10 +108,7 @@ Jobseeker.first(weydon_trust_schools.count).each do |jobseeker|
                                                             job_application: FactoryBot.build(:job_application,
                                                                                               vacancy: FactoryBot.build(:vacancy,
                                                                                                                         organisations: weydon_trust_schools))),
-                      employments: FactoryBot.build_list(:employment, 1,
-                                                         job_application: FactoryBot.build(:job_application,
-                                                                                           vacancy: FactoryBot.build(:vacancy,
-                                                                                                                     organisations: weydon_trust_schools))),
+                      employments: FactoryBot.build_list(:employment, 1, :jobseeker_profile_employment),
                       jobseeker: jobseeker) do |jobseeker_profile|
       FactoryBot.create(:job_preferences, jobseeker_profile: jobseeker_profile) do |job_preferences|
         FactoryBot.create(:job_preferences_location, job_preferences:, name: location_preference_names.pop)

--- a/spec/factories/job_applications.rb
+++ b/spec/factories/job_applications.rb
@@ -60,8 +60,6 @@ FactoryBot.define do
 
     after :create do |job_application, options|
       if options.create_details
-        create_list :employment, 3, :job, job_application: job_application
-        create_list :employment, 1, :break, job_application: job_application
         create_list :reference, 1, job_application: job_application, is_most_recent_employer: true
         create_list :qualification, 3, job_application: job_application
         create_list :training_and_cpd, 2, job_application: job_application

--- a/spec/form_models/jobseekers/job_application/employment_history_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/employment_history_form_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Jobseekers::JobApplication::EmploymentHistoryForm, type: :model d
       employment_history_section_completed: employment_history_section_completed,
       unexplained_employment_gaps_present: unexplained_employment_gaps_present,
       unexplained_employment_gaps: unexplained_employment_gaps,
+      employments: [],
     }
   end
 
@@ -25,7 +26,7 @@ RSpec.describe Jobseekers::JobApplication::EmploymentHistoryForm, type: :model d
       it "adds errors for each unexplained gap" do
         expect(form).not_to be_valid
 
-        expect(form.errors[:base]).to include(
+        expect(form.errors[:unexplained_employment_gaps]).to include(
           "You have a gap in your work history (about 1 year).",
           "You have a gap in your work history (7 months).",
         )

--- a/spec/form_models/jobseekers/job_application/employment_history_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/employment_history_form_spec.rb
@@ -6,14 +6,12 @@ RSpec.describe Jobseekers::JobApplication::EmploymentHistoryForm, type: :model d
   let(:attributes) do
     {
       employment_history_section_completed: employment_history_section_completed,
-      unexplained_employment_gaps_present: unexplained_employment_gaps_present,
       unexplained_employment_gaps: unexplained_employment_gaps,
       employments: [],
     }
   end
 
   let(:employment_history_section_completed) { "true" }
-  let(:unexplained_employment_gaps_present) { "true" }
   let(:unexplained_employment_gaps) do
     {
       gap1: { started_on: Date.new(2023, 12, 1), ended_on: Date.new(2024, 12, 1) },
@@ -22,7 +20,7 @@ RSpec.describe Jobseekers::JobApplication::EmploymentHistoryForm, type: :model d
   end
 
   describe "validations" do
-    context "when employment history gaps are present" do
+    context "with employment history gaps" do
       it "adds errors for each unexplained gap" do
         expect(form).not_to be_valid
 
@@ -33,13 +31,11 @@ RSpec.describe Jobseekers::JobApplication::EmploymentHistoryForm, type: :model d
       end
     end
 
-    context "when unexplained_employment_gaps_present is false" do
-      let(:unexplained_employment_gaps_present) { "false" }
+    context "without unexplained_employment_gaps" do
+      let(:unexplained_employment_gaps) { {} }
 
       it "does not add errors for gaps" do
         expect(form).to be_valid
-
-        expect(form.errors[:base]).to be_empty
       end
     end
 
@@ -47,19 +43,7 @@ RSpec.describe Jobseekers::JobApplication::EmploymentHistoryForm, type: :model d
       let(:employment_history_section_completed) { "false" }
 
       it "does not add errors for gaps" do
-        form.valid?
-
-        expect(form.errors[:base]).to be_empty
-      end
-    end
-
-    context "when no unexplained employment gaps exist" do
-      let(:unexplained_employment_gaps) { {} }
-
-      it "does not add errors for gaps" do
-        form.valid?
-
-        expect(form.errors[:base]).to be_empty
+        expect(form).to be_valid
       end
     end
   end

--- a/spec/helpers/pdf_helper_spec.rb
+++ b/spec/helpers/pdf_helper_spec.rb
@@ -4,7 +4,7 @@ require "pdf/inspector"
 
 RSpec.describe JobApplicationPdfGenerator, type: :service do
   let(:job_application) do
-    create(:job_application, create_details: false, vacancy: vacancy,
+    create(:job_application, vacancy: vacancy,
                              statutory_induction_complete_details: "something", working_patterns: %w[full_time part_time])
   end
   let!(:professional_body_membership) { create(:professional_body_membership, job_application: job_application, membership_number: nil, year_membership_obtained: nil) }

--- a/spec/models/jobseeker_profile_spec.rb
+++ b/spec/models/jobseeker_profile_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe JobseekerProfile, type: :model do
     let(:excluded_attrs) { %i[job_application_id jobseeker_profile_id created_at id updated_at] }
 
     before do
-      create(:job_application, create_details: false, employments: new_employments)
+      create(:job_application, employments: new_employments)
     end
 
     it "replaces the employments" do

--- a/spec/presenters/work_history_error_summary_presenter_spec.rb
+++ b/spec/presenters/work_history_error_summary_presenter_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe WorkHistoryErrorSummaryPresenter do
   end
   let(:errors) do
     {
-      base: [
+      unexplained_employment_gaps: [
         "You have a gap in your work history (1 year).",
         "You have a gap in your work history (6 months).",
       ],
@@ -22,8 +22,8 @@ RSpec.describe WorkHistoryErrorSummaryPresenter do
     it "provides links to the correct gap IDs" do
       expect(presenter.formatted_error_messages).to eq(
         [
-          [:base, "You have a gap in your work history (1 year).", "#gap-20231201-20241201"],
-          [:base, "You have a gap in your work history (6 months).", "#gap-20201101-20210531"],
+          [:unexplained_employment_gaps, "You have a gap in your work history (1 year).", "#gap-20231201-20241201"],
+          [:unexplained_employment_gaps, "You have a gap in your work history (6 months).", "#gap-20201101-20210531"],
         ],
       )
     end

--- a/spec/requests/jobseekers/job_applications_spec.rb
+++ b/spec/requests/jobseekers/job_applications_spec.rb
@@ -293,7 +293,7 @@ RSpec.describe "Job applications" do
       end
 
       context "when the review form is valid" do
-        let!(:jobseeker_profile) { create(:jobseeker_profile, jobseeker: jobseeker, has_teacher_reference_number: "yes", teacher_reference_number: "1234567") }
+        let!(:jobseeker_profile) { create(:jobseeker_profile, :with_trn, jobseeker: jobseeker) }
 
         it "submits the job application and sends email" do
           assert_emails 1 do

--- a/spec/services/jobseekers/job_applications/prefill_job_application_from_previous_application_spec.rb
+++ b/spec/services/jobseekers/job_applications/prefill_job_application_from_previous_application_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe Jobseekers::JobApplications::PrefillJobApplicationFromPreviousApp
 
       context "when all steps from the most recent application are relevant to the new application" do
         let(:attributes_to_copy) do
-          %i[ first_name last_name previous_names street_address city country postcode phone_number
-              national_insurance_number qualified_teacher_status qualified_teacher_status_year qualified_teacher_status_details
-              is_statutory_induction_complete is_support_needed support_needed_details]
+          %i[first_name last_name previous_names street_address city country postcode phone_number
+             national_insurance_number qualified_teacher_status qualified_teacher_status_year qualified_teacher_status_details
+             is_statutory_induction_complete is_support_needed support_needed_details]
         end
 
         it "copies personal info from the recent job application" do

--- a/spec/system/jobseekers/jobseekers_can_add_employments_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_employments_to_their_job_application_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "Jobseekers can add employments and breaks to their job applicati
     end
 
     it "shows the record with an error, and prevents saving until fixed" do
-      expect(all(".govuk-summary-card__content").last).to have_content "Enter your reason for leaving the role"
+      expect(all(".govuk-summary-card__content").last).to have_content "Enter your reason for leaving this role"
 
       choose "Yes, I've completed this section"
       validates_step_complete(button: "Save and continue")

--- a/spec/system/jobseekers/jobseekers_can_add_employments_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_employments_to_their_job_application_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Jobseekers can add employments and breaks to their job application" do
   let(:jobseeker) { create(:jobseeker) }
   let(:vacancy) { create(:vacancy, organisations: [build(:school)]) }
-  let!(:job_application) { create(:job_application, :status_draft, jobseeker: jobseeker, vacancy: vacancy) }
+  let!(:job_application) { create(:job_application, :status_draft, create_details: false, jobseeker: jobseeker, vacancy: vacancy) }
 
   before { login_as(jobseeker, scope: :jobseeker) }
 
@@ -40,35 +40,35 @@ RSpec.describe "Jobseekers can add employments and breaks to their job applicati
     expect(page).to have_content(Date.new(2020, 7, 1).to_formatted_s(:month_year))
   end
 
-  it "displays employment history from newest to oldest job" do
-    visit jobseekers_job_application_build_path(job_application, :employment_history)
+  context "with an employmeent history" do
+    before do
+      build(:employment, reason_for_leaving: nil, job_application: job_application, job_title: "Oldest job",
+                         started_on: Date.new(2015, 7, 1), ended_on: Date.new(2019, 7, 1)).save!(validate: false)
+      create(:employment, job_application: job_application, job_title: "Old job", started_on: Date.new(2019, 7, 1), ended_on: Date.new(2020, 7, 1))
+      create(:employment, :current_role, job_application: job_application, job_title: "The Best Teacher", started_on: Date.new(2020, 7, 1))
 
-    click_on I18n.t("buttons.add_work_history")
-    validates_step_complete(button: I18n.t("buttons.save_employment"))
+      visit jobseekers_job_application_build_path(job_application, :employment_history)
+    end
 
-    fill_in_employment_history(job_title: "Old job")
+    it "displays employment history from newest to oldest job" do
+      expect(all(".govuk-summary-card__title").map(&:text)).to eq ["The Best Teacher", "Old job", "Oldest job"]
+    end
 
-    click_on I18n.t("buttons.save_employment")
+    it "shows the record with an error, and prevents saving until fixed" do
+      expect(all(".govuk-summary-card__content").last).to have_content "Enter your reason for leaving the role"
 
-    first(:link, "Add another job").click
+      choose "Yes, I've completed this section"
+      validates_step_complete(button: "Save and continue")
 
-    fill_in_employment_history(job_title: "Oldest job", start_month: "09", start_year: "2015", end_month: "06", end_year: "2019")
-
-    click_on I18n.t("buttons.save_employment")
-
-    first(:link, "Add another job").click
-
-    fill_in_current_role(form: "jobseekers_job_application_details_employment_form")
-
-    click_on I18n.t("buttons.save_employment")
-
-    oldest_job = find("h3", text: "Oldest job").path
-    middle_job = find("h3", text: "Old job").path
-    newest_job = find("h3", text: "The Best Teacher").path
-
-    expect(newest_job).to be < middle_job
-    expect(newest_job).to be < oldest_job
-    expect(middle_job).to be < oldest_job
+      within all(".govuk-summary-card").last do
+        click_on "Change"
+      end
+      fill_in "Reason for leaving role", with: "Needed for KSCIE compliance"
+      click_on I18n.t("buttons.save_employment")
+      choose "Yes, I've completed this section"
+      click_on "Save and continue"
+      expect(page).to have_current_path(jobseekers_job_application_apply_path(job_application))
+    end
   end
 
   context "managing employment history gaps" do

--- a/spec/system/jobseekers/jobseekers_can_add_employments_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_employments_to_their_job_application_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Jobseekers can add employments and breaks to their job application" do
   let(:jobseeker) { create(:jobseeker) }
   let(:vacancy) { create(:vacancy, organisations: [build(:school)]) }
-  let!(:job_application) { create(:job_application, :status_draft, create_details: false, jobseeker: jobseeker, vacancy: vacancy) }
+  let!(:job_application) { create(:job_application, :status_draft, jobseeker: jobseeker, vacancy: vacancy) }
 
   before { login_as(jobseeker, scope: :jobseeker) }
 

--- a/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
@@ -251,7 +251,7 @@ RSpec.describe "Jobseekers can manage their profile" do
                 .to contain_exactly(["Enter a school or other organisation", "#jobseekers-profile-employment-form-organisation-field-error"],
                                     ["Enter your job title", "#jobseekers-profile-employment-form-job-title-field-error"],
                                     ["Enter your main duties for this role", "#jobseekers-profile-employment-form-main-duties-field-error"],
-                                    ["Enter your reason for leaving the role", "#jobseekers-profile-employment-form-reason-for-leaving-field-error"],
+                                    ["Enter your reason for leaving this role", "#jobseekers-profile-employment-form-reason-for-leaving-field-error"],
                                     ["Enter the date you started at this school or organisation", "#jobseekers-profile-employment-form-started-on-field-error"])
             end
           end
@@ -262,7 +262,7 @@ RSpec.describe "Jobseekers can manage their profile" do
             expect(page).to have_css("ul.govuk-list.govuk-error-summary__list")
 
             within "ul.govuk-list.govuk-error-summary__list" do
-              expect(page).to have_link("Enter your reason for leaving the role", href: "#jobseekers-profile-employment-form-reason-for-leaving-field-error")
+              expect(page).to have_link("Enter your reason for leaving this role", href: "#jobseekers-profile-employment-form-reason-for-leaving-field-error")
             end
           end
         end

--- a/spec/system/jobseekers/jobseekers_can_update_their_profile_from_job_applications_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_update_their_profile_from_job_applications_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Jobseekers can update their profile from job applications" do
 
   let(:vacancy) { create(:vacancy) }
   let(:application_qualification) { create(:qualification, name: "Application qualification") }
-  let(:application_employment) { create(:employment, job_title: "Application employment") }
+  let(:application_employment) { create(:employment, :current_role, job_title: "Application employment") }
   let(:application_training) { create(:training_and_cpd, name: "Application training") }
   let(:job_application) do
     create(:job_application, create_details: true, jobseeker: jobseeker, vacancy: vacancy,


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/avSRIbAT/1655-bug-old-employment-records-can-be-invalid-mainly-due-a-lack-of-leaving-reason-insist-that-they-are-validated-before-application

## Changes in this PR:

Create a workflow so that invalid employment records copied from an old job application or profile have to be fixed up before job application can be submitted

### After
![InvalidEmployment](https://github.com/user-attachments/assets/63c5aaff-5d3b-4e10-a1ae-49244397104a)
