### PR TITLE
Remove change link on job application after submission

### DIFF
--- a/app/components/job_application_review_component/section.rb
+++ b/app/components/job_application_review_component/section.rb
@@ -44,6 +44,6 @@ class JobApplicationReviewComponent::Section < ReviewComponent::Section
   def allow_edit?
     return @allow_edit unless @allow_edit.nil?
 
-    !@job_application.deadline_passed? && !@job_application.submitted?
+    !@job_application.deadline_passed? && @job_application.draft?
   end
 end


### PR DESCRIPTION
-------

## Trello card URL
[https://trello.com/c/I8Nm27zo](https://trello.com/c/I8Nm27zo)

## Changes in this PR:

Change linke only visible for job applications in `draft` status.

## Screenshots of UI changes:

### Before

### After