### PR TITLE
upgrade alpine to 3.21 to avoid new CVEs from 11/3/2025

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
  # Some packages are defined here with a hardcoded version to resolve vulnerabilities in the packages coming with
  # Alpine v3.19.
- # TODO: Regularly check in the alpine ruby "3.3.6-alpine3.19" images for its latest upgraded packages so we can remove
+ # TODO: Regularly check in the alpine ruby "3.3.6-alpine3.21" images for its latest upgraded packages so we can remove
  # the hardcoded versions below when they have been updated in the alpine ruby image.
-ARG PROD_PACKAGES="imagemagick libpng libjpeg libxml2 libxslt libpq tzdata shared-mime-info postgresql15 busybox openssl=3.1.8-r0 musl=1.2.4_git20230717-r5"
+ARG PROD_PACKAGES="imagemagick libpng libjpeg libxml2 libxslt libpq tzdata shared-mime-info postgresql15 busybox"
 
-FROM ruby:3.3.6-alpine3.19 AS builder
+FROM ruby:3.3.6-alpine3.21 AS builder
 
 WORKDIR /app
 
@@ -50,7 +50,7 @@ RUN rm -rf node_modules log tmp yarn.lock && \
 
 
 # this stage reduces the image size.
-FROM ruby:3.3.6-alpine3.19 AS production
+FROM ruby:3.3.6-alpine3.21 AS production
 
 WORKDIR /app
 


### PR DESCRIPTION
## Changes in this PR:

upgrade base deployment image to alpine 3.21, remove old pins for previous CVEs