### PR TITLE
Tweak test that failed a production deploy

### DIFF
--- a/spec/system/jobseekers/jobseekers_can_give_application_feedback_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_give_application_feedback_spec.rb
@@ -28,12 +28,18 @@ RSpec.describe "Jobseekers can give job application feedback after submitting th
     fill_in "jobseekers_job_application_feedback_form[comment]", with: comment
     fill_in "jobseekers_job_application_feedback_form[occupation]", with: occupation
 
-    expect { click_on I18n.t("buttons.submit_feedback") }.to change {
+    expect { submit_feedback }.to change {
       jobseeker.feedbacks.where(comment: comment, email: jobseeker.email, feedback_type: "application", rating: "somewhat_satisfied", user_participation_response: "interested", occupation: occupation).count
     }.by(1)
 
     expect(current_path).to eq(jobseekers_job_applications_path)
 
     expect(page).to have_content(I18n.t("jobseekers.job_applications.feedbacks.create.success"))
+  end
+
+  def submit_feedback
+    click_on I18n.t("buttons.submit_feedback")
+    # wait for page load
+    find(".govuk-notification-banner--success")
   end
 end

--- a/spec/system/publishers/publishers_can_manage_job_applications_for_a_vacancy_spec.rb
+++ b/spec/system/publishers/publishers_can_manage_job_applications_for_a_vacancy_spec.rb
@@ -71,15 +71,12 @@ RSpec.describe "Publishers can manage job applications for a vacancy" do
     end
 
     scenario "Changing a single status", :js do
-      # ensure only 1 visible CTA button
-      click_on I18n.t("cookies_preferences.banner.buttons.reject")
-      find(".application-unsuccessful")
       within(".application-unsuccessful") do
         find(".govuk-checkboxes__item").click
       end
       click_on I18n.t("publishers.vacancies.job_applications.candidates.update_application_status")
       find(".govuk-tag--purple").click
-      find(".govuk-button").click
+      click_on "Save and continue"
       expect(page).to have_content("New (3)")
     end
 


### PR DESCRIPTION
## Changes in this PR:

A production deploy broke due to a race in this test scenario. Hopefully this change makes it more robust