### PR TITLE
Usecorrect image for secondary school campaign page

### DIFF
--- a/config/campaign_pages.yml
+++ b/config/campaign_pages.yml
@@ -14,7 +14,7 @@ shared:
       - primary
     radius: 15
   mostvacanciesbespoke+SECONDARY:
-    banner_image: "campaigns/primary_teacher.jpg"
+    banner_image: "campaigns/secondary_teacher.jpg"
     teaching_job_roles:
       - teacher
     phases:


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/o86Py4X5/1677-bespoke-url-landing-page-fix

## Changes in this PR:

This ticket changes the image that is displayed on the campaign page which filters by secondary school.

Note: the other issue on the ticket with regards to the secondary/primary filter being incorrect is due to other query string params overriding it. this doesn't need to be fixed in the codebase.

## Screenshots of UI changes:

### Before

### After
