### PR TITLE
Fix boolean selection validation errors

### DIFF
--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -12,7 +12,7 @@ en:
     category:
       inclusion: Select a qualification
     finished_studying:
-      blank: Select yes if you have finished studying for this qualification
+      inclusion: Select yes if you have finished studying for this qualification
     finished_studying_details:
       blank: Tell us why you are still studying for this qualification
     grade:
@@ -159,7 +159,7 @@ en:
       blank: Enter working patterns details
       maximum_words: Working patterns details must be 50 words or less
     is_job_share:
-      blank: Select yes if this role can be done as a job share
+      inclusion: Select yes if this role can be done as a job share
   pay_package_errors: &pay_package_errors
     actual_salary:
       blank: Enter actual salary
@@ -465,7 +465,7 @@ en:
         jobseekers/job_application/training_and_cpds_form:
           attributes:
             training_and_cpds_section_completed:
-              blank: Select yes if you have completed this section
+              inclusion: Select yes if you have completed this section
         jobseekers/job_application/religious_information_form:
           attributes:
             following_religion:

--- a/config/locales/jobseekers/job_application/professional_body_membership_form.yml
+++ b/config/locales/jobseekers/job_application/professional_body_membership_form.yml
@@ -1,4 +1,11 @@
 en:
+  activemodel:
+    errors:
+      models:
+        jobseekers/job_application/professional_body_memberships_form:
+          attributes:
+            professional_body_memberships_section_completed:
+              inclusion: Select yes if you have completed this section
   helpers:
     label:
       jobseekers_job_application_professional_body_memberships_form:

--- a/spec/form_models/jobseekers/job_application/professional_body_memberships_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/professional_body_memberships_form_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe Jobseekers::JobApplication::ProfessionalBodyMembershipsForm, type: :model do
+  let(:form) { described_class.new }
+
+  describe "section completion validation" do
+    it "errors when not answered" do
+      expect(form).not_to be_valid
+      expect(form.errors[:professional_body_memberships_section_completed])
+                 .to eq(["Select yes if you have completed this section"])
+    end
+
+    it "accepts 'true' as an answer" do
+      form.professional_body_memberships_section_completed = true
+      expect(form).to be_valid
+    end
+
+    it "accepts 'false' as an answer" do
+      form.professional_body_memberships_section_completed = false
+      expect(form).to be_valid
+    end
+  end
+end

--- a/spec/form_models/jobseekers/job_application/training_and_cpds_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/training_and_cpds_form_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe Jobseekers::JobApplication::TrainingAndCpdsForm, type: :model do
+  let(:form) { described_class.new }
+
+  describe "section completion validation" do
+    it "errors when not answered" do
+      expect(form).not_to be_valid
+      expect(form.errors[:training_and_cpds_section_completed])
+                 .to eq(["Select yes if you have completed this section"])
+    end
+
+    it "accepts 'true' as an answer" do
+      form.training_and_cpds_section_completed = true
+      expect(form).to be_valid
+    end
+
+    it "accepts 'false' as an answer" do
+      form.training_and_cpds_section_completed = false
+      expect(form).to be_valid
+    end
+  end
+end

--- a/spec/form_models/jobseekers/qualifications/other_form_spec.rb
+++ b/spec/form_models/jobseekers/qualifications/other_form_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe Jobseekers::Qualifications::OtherForm, type: :model do
   it { is_expected.to validate_presence_of(:institution) }
   it { is_expected.to validate_presence_of(:name) }
 
+  it "validates 'finished studying' presence" do
+    expect(form).not_to be_valid
+    expect(form.errors[:finished_studying]).to eq(["Select yes if you have finished studying for this qualification"])
+  end
+
   context "when finished studying is false" do
     let(:params) { { "finished_studying" => "false" } }
 

--- a/spec/form_models/publishers/job_listing/working_patterns_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/working_patterns_form_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Publishers::JobListing::WorkingPatternsForm, type: :model do
-  subject { described_class.new(params, vacancy) }
+  subject(:form) { described_class.new(params, vacancy) }
 
   let(:vacancy) { build(:vacancy) }
   let(:working_patterns) { nil }
@@ -12,6 +12,30 @@ RSpec.describe Publishers::JobListing::WorkingPatternsForm, type: :model do
 
   it { is_expected.to validate_presence_of(:working_patterns) }
   it { is_expected.to validate_inclusion_of(:working_patterns).in_array(Vacancy.working_patterns.keys - ["job_share"]) }
+
+  it "validates 'is_job_share' presence" do
+    expect(form).not_to be_valid
+    expect(form.errors[:is_job_share]).to eq(["Select yes if this role can be done as a job share"])
+  end
+
+  describe "'is_job_share' validation" do
+    it "errors when not answered" do
+      expect(form).not_to be_valid
+      expect(form.errors[:is_job_share]).to eq(["Select yes if this role can be done as a job share"])
+    end
+
+    it "accepts 'true' as an answer" do
+      form.is_job_share = true
+      form.validate
+      expect(form.errors[:is_job_share]).to be_empty
+    end
+
+    it "accepts 'false' as an answer" do
+      form.is_job_share = false
+      form.validate
+      expect(form.errors[:is_job_share]).to be_empty
+    end
+  end
 
   describe "#working_patterns_details" do
     context "when working_patterns_details does not exceed the maximum allowed length" do
@@ -24,7 +48,7 @@ RSpec.describe Publishers::JobListing::WorkingPatternsForm, type: :model do
       let(:working_patterns_details) { Faker::Lorem.sentence(word_count: 76) }
 
       it "ensures working_patterns_details cannot exceed 75 words" do
-        expect(subject.errors.of_kind?(:working_patterns_details, :working_patterns_details_maximum_words)).to be true
+        expect(form.errors.of_kind?(:working_patterns_details, :working_patterns_details_maximum_words)).to be true
       end
     end
   end


### PR DESCRIPTION
## Changes in this PR:

Some Yes/No radio selection had their error messages showing a rails default as they were moved from string to bool. Their error is no longer a "blank" but "inclusion".

## Screenshots of UI changes (same change in a few places):

### Before
![Screenshot From 2025-03-14 11-16-47](https://github.com/user-attachments/assets/78d34c99-71bb-4aae-a3c8-4caa2683bed9)

### After
![Screenshot From 2025-03-14 11-17-22](https://github.com/user-attachments/assets/eccf0926-442b-42f9-9e6f-4f7ff759a604)
