### PR TITLE
Store trn in job application

### DIFF
--- a/app/controllers/jobseekers/job_applications_controller.rb
+++ b/app/controllers/jobseekers/job_applications_controller.rb
@@ -152,7 +152,6 @@ class Jobseekers::JobApplicationsController < Jobseekers::JobApplications::BaseC
     form_class = "jobseekers/job_application/#{step}_form".camelize.constantize
 
     attributes = form_class.load_form(job_application)
-    attributes.merge!(trn_params) if step == :professional_status
 
     form = form_class.new(attributes)
 
@@ -256,13 +255,6 @@ class Jobseekers::JobApplicationsController < Jobseekers::JobApplications::BaseC
 
   def quick_apply?
     previous_application? || profile.present?
-  end
-
-  def trn_params
-    {
-      teacher_reference_number: current_jobseeker&.jobseeker_profile&.teacher_reference_number,
-      has_teacher_reference_number: current_jobseeker&.jobseeker_profile&.has_teacher_reference_number,
-    }
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/controllers/jobseekers/profiles/qualified_teacher_status_controller.rb
+++ b/app/controllers/jobseekers/profiles/qualified_teacher_status_controller.rb
@@ -2,13 +2,13 @@ module Jobseekers
   module Profiles
     class QualifiedTeacherStatusController < Jobseekers::ProfilesController
       def edit
-        @form = QualifiedTeacherStatusForm.new(profile.slice(*form_class.fields))
+        @form = QualifiedTeacherStatusForm.load_form_from_model(profile)
       end
 
       def update
         @form = QualifiedTeacherStatusForm.new(form_params)
         if @form.valid?
-          profile.update!(form_params)
+          profile.update!(@form.params_to_save)
           redirect_to jobseekers_profile_qualified_teacher_status_path
         else
           render :edit

--- a/app/form_models/jobseekers/profiles/qualified_teacher_status_form.rb
+++ b/app/form_models/jobseekers/profiles/qualified_teacher_status_form.rb
@@ -6,42 +6,57 @@ module Jobseekers
       validates :qualified_teacher_status, inclusion: { in: %w[yes no on_track non_teacher] }
       validates :qualified_teacher_status_year, numericality: { less_than_or_equal_to: proc { Time.current.year } }, if: -> { qualified_teacher_status == "yes" }
       validates :teacher_reference_number, presence: true, if: -> { qualified_teacher_status == "yes" }
-      validates_format_of :teacher_reference_number, with: /\A\d{7}\z/, allow_blank: false, if: -> { qualified_teacher_status == "yes" || has_teacher_reference_number == "yes" }
+      validates_format_of :teacher_reference_number, with: /\A\d{7}\z/, allow_blank: false, if: -> { qualified_teacher_status == "yes" || has_teacher_reference_number }
       validates_format_of :teacher_reference_number, with: /\A\d{7}\z/, allow_blank: true, if: -> { %w[no on_track].include?(qualified_teacher_status) }
       validates :is_statutory_induction_complete, inclusion: { in: [true, false] }, if: -> { qualified_teacher_status == "yes" }
 
-      validates :has_teacher_reference_number, inclusion: { in: %w[yes] }, if: -> { qualified_teacher_status == "yes" }
-      validates :has_teacher_reference_number, inclusion: { in: %w[yes no] }, if: -> { %w[no on_track].include?(qualified_teacher_status) }
-
-      def initialize(attributes = {})
-        super
-
-        if attributes[:is_statutory_induction_complete]
-          self.statutory_induction_complete_details = nil
-        end
-      end
+      validates :has_teacher_reference_number, inclusion: { in: [true] }, if: -> { qualified_teacher_status == "yes" }
+      validates :has_teacher_reference_number, inclusion: { in: [true, false] }, if: -> { %w[no on_track].include?(qualified_teacher_status) }
 
       FIELDS = %i[qualified_teacher_status
                   qualified_teacher_status_year
                   teacher_reference_number
-                  has_teacher_reference_number
                   statutory_induction_complete_details
                   qts_age_range_and_subject
                   qualified_teacher_status_details].freeze
 
-      def self.fields
-        FIELDS + [:is_statutory_induction_complete]
+      class << self
+        def storable_fields
+          FIELDS + [:is_statutory_induction_complete]
+        end
+
+        def fields
+          storable_fields + [:has_teacher_reference_number]
+        end
+
+        def load_form_from_model(profile)
+          attributes = profile.slice(storable_fields)
+          has_trn = if attributes[:teacher_reference_number].present?
+                      "true"
+                    else
+                      (attributes[:teacher_reference_number].nil? ? nil : "false")
+                    end
+
+          new(attributes.merge(has_teacher_reference_number: has_trn))
+        end
+      end
+
+      def params_to_save
+        stored = attributes.symbolize_keys.slice(*self.class.storable_fields)
+        if has_teacher_reference_number
+          stored
+        else
+          # blank means we don't have one, nil means we don't know yet
+          stored.merge(teacher_reference_number: "")
+        end
       end
 
       attribute :is_statutory_induction_complete, :boolean
+      attribute :has_teacher_reference_number, :boolean
 
-      def updated_teacher_reference_number
-        return if has_teacher_reference_number == "no"
-
-        teacher_reference_number
+      FIELDS.each do |field|
+        attribute field
       end
-
-      attr_accessor(*FIELDS)
     end
   end
 end

--- a/app/helpers/job_applications_helper.rb
+++ b/app/helpers/job_applications_helper.rb
@@ -42,13 +42,8 @@ module JobApplicationsHelper
     end
   end
 
-  def job_application_jobseeker_profile_info(job_application)
-    profile = job_application.jobseeker&.jobseeker_profile
-    if profile&.has_teacher_reference_number == "yes"
-      profile.teacher_reference_number
-    else
-      "None"
-    end
+  def job_application_trn(job_application)
+    job_application.teacher_reference_number.presence || "None"
   end
 
   def job_application_support_needed_info(job_application)

--- a/app/helpers/pdf_helper.rb
+++ b/app/helpers/pdf_helper.rb
@@ -71,7 +71,7 @@ module PdfHelper
     # :nocov:
     professional_status = [
       [I18n.t("helpers.legend.jobseekers_job_application_professional_status_form.qualified_teacher_status"), pdf_job_application_qualified_teacher_status_info(job_application)],
-      [I18n.t("helpers.label.jobseekers_job_application_personal_details_form.teacher_reference_number_review"), job_application_jobseeker_profile_info(job_application)],
+      [I18n.t("helpers.label.jobseekers_job_application_personal_details_form.teacher_reference_number_review"), job_application_trn(job_application)],
       [I18n.t("helpers.legend.jobseekers_job_application_professional_status_form.is_statutory_induction_complete"), job_application.is_statutory_induction_complete? ? "Yes" : "No"],
     ]
     # :nocov:

--- a/app/models/jobseeker_profile.rb
+++ b/app/models/jobseeker_profile.rb
@@ -44,10 +44,13 @@ class JobseekerProfile < ApplicationRecord
       profile.qualified_teacher_status_year = nil
       profile.qts_age_range_and_subject = nil
     end
-    unless profile.has_teacher_reference_number == "yes"
-      profile.teacher_reference_number = nil
+
+    if profile.is_statutory_induction_complete
+      profile.statutory_induction_complete_details = nil
     end
   end
+
+  self.ignored_columns += %i[has_teacher_reference_number]
 
   def self.copy_attributes(record, previous_application)
     record.assign_attributes(

--- a/app/services/jobseekers/job_applications/prefill_job_application_from_previous_application.rb
+++ b/app/services/jobseekers/job_applications/prefill_job_application_from_previous_application.rb
@@ -53,11 +53,7 @@ class Jobseekers::JobApplications::PrefillJobApplicationFromPreviousApplication
        school_ethos
        non_catholic_religion_details]
       .filter_map { |step| form_fields_from_step(step) if relevant_steps.include?(step) }
-      .flatten - jobseeker_profile_fields
-  end
-
-  def jobseeker_profile_fields
-    %i[has_teacher_reference_number teacher_reference_number]
+      .flatten
   end
 
   def copy_qualifications

--- a/app/views/jobseekers/base/_qts_fields.html.slim
+++ b/app/views/jobseekers/base/_qts_fields.html.slim
@@ -8,9 +8,9 @@
   = f.govuk_radio_button :qualified_teacher_status, "on_track"
 
 = f.govuk_radio_buttons_fieldset :has_teacher_reference_number, hint: -> { tag.p(t("helpers.label.jobseekers_profiles_qualified_teacher_status_form.teacher_reference_number_hint", link: govuk_link_to(t("helpers.label.jobseekers_profiles_qualified_teacher_status_form.trn_link_text"), "https://find-a-lost-trn.education.gov.uk/start", target: "_blank")).html_safe) } do
-  = f.govuk_radio_button :has_teacher_reference_number, "yes", link_errors: true, label: { text: t("helpers.legend.jobseekers_job_application_professional_status_form.has_teacher_reference_number_options.yes") }
-    = f.govuk_text_field :teacher_reference_number, label: { text: t("helpers.legend.jobseekers_job_application_professional_status_form.teacher_reference_number") }
-  = f.govuk_radio_button :has_teacher_reference_number, "no", label: { text: t("helpers.legend.jobseekers_job_application_professional_status_form.has_teacher_reference_number_options.no") }
+  = f.govuk_radio_button :has_teacher_reference_number, "true", link_errors: true
+    = f.govuk_text_field :teacher_reference_number
+  = f.govuk_radio_button :has_teacher_reference_number, "false"
 
 = f.govuk_radio_buttons_fieldset :is_statutory_induction_complete do
   = f.govuk_radio_button :is_statutory_induction_complete, "true", link_errors: true

--- a/app/views/jobseekers/job_applications/review/_professional_status.html.slim
+++ b/app/views/jobseekers/job_applications/review/_professional_status.html.slim
@@ -5,7 +5,7 @@
 
   - summary_list.with_row do |row|
     - row.with_key text: t("helpers.label.jobseekers_job_application_personal_details_form.teacher_reference_number_review")
-    - row.with_value text: job_application_jobseeker_profile_info(job_application)
+    - row.with_value text: job_application_trn(job_application)
 
   - summary_list.with_row do |row|
     - row.with_key text: t("helpers.label.jobseekers_job_application_professional_status_form.qts_age_range_and_subject")

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -180,7 +180,6 @@ shared:
     - requested_hidden_profile
     - is_statutory_induction_complete
     - teacher_reference_number
-    - has_teacher_reference_number
     - statutory_induction_complete_details
   jobseeker_profile_excluded_organisations:
     - id

--- a/config/locales/jobseekers/job_application/professional_status_form.yml
+++ b/config/locales/jobseekers/job_application/professional_status_form.yml
@@ -40,10 +40,6 @@ en:
         is_statutory_induction_complete: Have you completed your induction period?
       jobseekers_job_application_professional_status_form:
         has_teacher_reference_number: "Do you have a teacher reference number (TRN)?"
-        has_teacher_reference_number_options:
-          "yes": "Yes"
-          "no": "No"
-        teacher_reference_number: What is your teacher reference number (TRN)?
         is_statutory_induction_complete: Have you completed your induction period?
         qualified_teacher_status: Do you have qualified teacher status (QTS)?
         statutory_induction_complete_details: Additional induction details
@@ -60,8 +56,8 @@ en:
           "false": "No, I have not completed my induction period"
           "true": "Yes, I have completed my induction period"
         has_teacher_reference_number_options:
-          "yes": "Yes"
-          "no": "No"
+          "true": "Yes"
+          "false": "No"
         qualified_teacher_status_year: Year QTS was awarded
         qts_age_range_and_subject: Age range and subject you trained to teach
         teacher_reference_number: What is your teacher reference number (TRN)?
@@ -77,6 +73,10 @@ en:
           on_track: I'm on track to receive my QTS
           non_teacher: I'm not looking for a teaching job
           "yes": "Yes"
+        has_teacher_reference_number_options:
+          "true": "Yes"
+          "false": "No"
+        teacher_reference_number: What is your teacher reference number (TRN)?
         is_statutory_induction_complete_options:
           "false": "No, I have not completed my induction period"
           "true": "Yes, I have completed my induction period"

--- a/spec/factories/jobseeker_profiles.rb
+++ b/spec/factories/jobseeker_profiles.rb
@@ -8,12 +8,10 @@ FactoryBot.define do
     association :jobseeker
 
     trait :with_trn do
-      has_teacher_reference_number { "yes" }
       teacher_reference_number { Faker::Number.number(digits: 7).to_s }
     end
 
     trait :without_trn do
-      has_teacher_reference_number { "no" }
       teacher_reference_number { nil }
     end
 

--- a/spec/form_models/jobseekers/job_application/professional_status_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/professional_status_form_spec.rb
@@ -47,15 +47,15 @@ RSpec.describe Jobseekers::JobApplication::ProfessionalStatusForm, type: :model 
 
         it { is_expected.to validate_numericality_of(:qualified_teacher_status_year).is_less_than_or_equal_to(Time.current.year) }
 
-        it { is_expected.to validate_inclusion_of(:has_teacher_reference_number).in_array(%w[yes]) }
+        it { is_expected.to validate_inclusion_of(:has_teacher_reference_number).in_array([true]) }
 
         it { is_expected.not_to validate_presence_of(:teacher_reference_number) }
 
         context "when has_teacher_reference_number is 'no'" do
-          let(:attributes) { super().merge(has_teacher_reference_number: "no") }
+          let(:attributes) { super().merge(has_teacher_reference_number: "false") }
 
           it "contains an error for the has_teacher_reference_number field" do
-            form.valid?
+            expect(form).not_to be_valid
             expect(form.errors[:has_teacher_reference_number])
               .to eq(["Select yes and enter your teacher reference number (TRN). All teachers with QTS have a 7 digit TRN."])
           end
@@ -80,8 +80,6 @@ RSpec.describe Jobseekers::JobApplication::ProfessionalStatusForm, type: :model 
       %w[no on_track].each do |status|
         context "when qualified_teacher_status is '#{status}'" do
           let(:attributes) { super().merge(qualified_teacher_status: status) }
-
-          it { is_expected.to validate_inclusion_of(:has_teacher_reference_number).in_array(%w[yes no]) }
 
           it { is_expected.not_to validate_numericality_of(:qualified_teacher_status_year).is_less_than_or_equal_to(Time.current.year) }
           it { is_expected.not_to validate_presence_of(:teacher_reference_number) }

--- a/spec/form_models/jobseekers/profiles/qualified_teacher_status_form_spec.rb
+++ b/spec/form_models/jobseekers/profiles/qualified_teacher_status_form_spec.rb
@@ -3,18 +3,17 @@ require "rails_helper"
 module Jobseekers
   module Profiles
     RSpec.describe QualifiedTeacherStatusForm, type: :model do
-      subject(:form) { described_class.new(attributes) }
-
-      let(:current_year) { Time.current.year }
-      let(:attributes) { {} }
-
       describe "validations" do
+        subject(:form) { described_class.new(attributes) }
+
+        let(:current_year) { Time.current.year }
+        let(:attributes) { {} }
+
         context "when is_qualified_teacher_status is true" do
           let(:attributes) do
             { qualified_teacher_status: "yes",
               qualified_teacher_status_year: current_year,
               teacher_reference_number: "1234567",
-              has_teacher_reference_number: "yes",
               is_statutory_induction_complete: true }
           end
 
@@ -23,64 +22,41 @@ module Jobseekers
           it { is_expected.to validate_presence_of(:teacher_reference_number) }
           it { is_expected.to allow_value("1234567").for(:teacher_reference_number) }
           it { is_expected.not_to allow_value("12345").for(:teacher_reference_number) }
-          it { is_expected.to validate_inclusion_of(:has_teacher_reference_number).in_array(%w[yes]) }
+          it { is_expected.to validate_inclusion_of(:has_teacher_reference_number).in_array([true]) }
         end
 
         context "when qualified_teacher_status is 'no'" do
-          let(:attributes) { { qualified_teacher_status: "no", has_teacher_reference_number: "no" } }
+          let(:attributes) { { qualified_teacher_status: "no" } }
 
           it { is_expected.to allow_value("1234567").for(:teacher_reference_number) }
-          it { is_expected.to validate_inclusion_of(:has_teacher_reference_number).in_array(%w[yes no]) }
         end
 
         context "when qualified_teacher_status is 'on_track'" do
-          let(:attributes) { { qualified_teacher_status: "on_track", has_teacher_reference_number: "yes" } }
+          let(:attributes) { { qualified_teacher_status: "on_track" } }
 
-          it { is_expected.to validate_inclusion_of(:has_teacher_reference_number).in_array(%w[yes no]) }
           it { is_expected.to allow_value("1234567").for(:teacher_reference_number) }
         end
       end
 
-      describe "#updated_teacher_reference_number" do
-        context "when has_teacher_reference_number is 'yes'" do
-          let(:attributes) { { has_teacher_reference_number: "yes", teacher_reference_number: "1234567" } }
+      describe "#load_form_from_model" do
+        subject(:form) { described_class.load_form_from_model(profile).has_teacher_reference_number }
 
-          it "returns the teacher reference number" do
-            expect(form.updated_teacher_reference_number).to eq("1234567")
-          end
+        context "when TRN is unknown" do
+          let(:profile) { build(:jobseeker_profile, teacher_reference_number: nil) }
+
+          it { is_expected.to be_nil }
         end
 
-        context "when has_teacher_reference_number is 'no'" do
-          let(:attributes) { { has_teacher_reference_number: "no" } }
+        context "when TRN is blank" do
+          let(:profile) { build(:jobseeker_profile, teacher_reference_number: "") }
 
-          it "returns nil" do
-            expect(form.updated_teacher_reference_number).to be_nil
-          end
-        end
-      end
-
-      context "when statutory_induction_complete is yes" do
-        let(:valid_attributes) do
-          {
-            qualified_teacher_status: "yes",
-            qualified_teacher_status_year: "2020",
-            has_teacher_reference_number: "yes",
-            teacher_reference_number: "1234567",
-          }
+          it { is_expected.to be(false) }
         end
 
-        context "when statutory_induction_complete is yes" do
-          it "sets statutory_induction_complete_details to nil" do
-            subject = described_class.new(valid_attributes.merge(is_statutory_induction_complete: true, statutory_induction_complete_details: "some info"))
-            expect(subject.statutory_induction_complete_details).to be_nil
-          end
-        end
+        context "when TRN is set" do
+          let(:profile) { build(:jobseeker_profile, :with_trn) }
 
-        context "when statutory_induction_complete is no" do
-          it "does not modify statutory_induction_complete_details" do
-            subject = described_class.new(valid_attributes.merge(is_statutory_induction_complete: false, statutory_induction_complete_details: "some info"))
-            expect(subject.statutory_induction_complete_details).to eq "some info"
-          end
+          it { is_expected.to be(true) }
         end
       end
     end

--- a/spec/models/jobseeker_profile_spec.rb
+++ b/spec/models/jobseeker_profile_spec.rb
@@ -72,30 +72,6 @@ RSpec.describe JobseekerProfile, type: :model do
     end
   end
 
-  describe "#save" do
-    let(:profile) { create(:jobseeker_profile) }
-
-    before do
-      profile.update!(has_teacher_reference_number: has_teacher_reference_number, teacher_reference_number: "1234567")
-    end
-
-    context "without a TRN" do
-      let(:has_teacher_reference_number) { "no" }
-
-      it "blanks TRN" do
-        expect(profile.teacher_reference_number).to be_nil
-      end
-    end
-
-    context "with a TRN" do
-      let(:has_teacher_reference_number) { "yes" }
-
-      it "keeps the TRN" do
-        expect(profile.teacher_reference_number).to eq("1234567")
-      end
-    end
-  end
-
   describe "#replace_qualifications!" do
     let(:old_qualification) { create(:qualification) }
     let(:new_qualifications) { create_list(:qualification, 2) }
@@ -115,6 +91,26 @@ RSpec.describe JobseekerProfile, type: :model do
       unrelated_qualification = create(:qualification)
       profile.replace_qualifications!(new_qualifications)
       expect { unrelated_qualification.reload }.not_to raise_error
+    end
+  end
+
+  describe "#save" do
+    let(:profile) { create(:jobseeker_profile, is_statutory_induction_complete: is_statutory_induction_complete, statutory_induction_complete_details: "some info") }
+
+    context "when statutory_induction_complete is true" do
+      let(:is_statutory_induction_complete) { true }
+
+      it "sets statutory_induction_complete_details to nil" do
+        expect(profile.statutory_induction_complete_details).to be_nil
+      end
+    end
+
+    context "when statutory_induction_complete is false" do
+      let(:is_statutory_induction_complete) { false }
+
+      it "does not modify statutory_induction_complete_details" do
+        expect(profile.statutory_induction_complete_details).to eq "some info"
+      end
     end
   end
 

--- a/spec/system/jobseekers/jobseekers_can_add_professional_status_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_professional_status_to_their_job_application_spec.rb
@@ -49,24 +49,6 @@ RSpec.describe "Jobseekers can add details about their qualified teacher status 
 
     expect(page).not_to have_css("h2", text: "There is a problem")
 
-    expect(job_application.reload.qts_age_range_and_subject).to eq("Adding up for little ones")
-  end
-
-  it "creates a jobseeker profile if the jobseeker does not have one" do
-    choose "Yes", name: "jobseekers_job_application_professional_status_form[qualified_teacher_status]"
-
-    fill_in "Year QTS was awarded", with: "2022"
-    fill_in "Please provide more detail (optional field)", with: "It was hard work but I made it"
-
-    choose("Yes, I have completed my induction period")
-    choose "Yes", name: "jobseekers_job_application_professional_status_form[has_teacher_reference_number]"
-    fill_in "What is your teacher reference number (TRN)?", with: "1234567"
-
-    click_on "Save and continue"
-
-    expect(page).to have_current_path(jobseekers_job_application_apply_path(job_application))
-
-    jobseeker.reload
-    expect(jobseeker.jobseeker_profile).to have_attributes(teacher_reference_number: "1234567", has_teacher_reference_number: "yes")
+    expect(job_application.reload).to have_attributes(qts_age_range_and_subject: "Adding up for little ones", teacher_reference_number: "1234567")
   end
 end

--- a/spec/system/jobseekers/jobseekers_can_add_professional_status_to_their_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_professional_status_to_their_profile_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "Jobseekers can add professional status to their profile" do
   describe "editing professional status" do
     let!(:profile) do
       create(:jobseeker_profile, jobseeker:, qualified_teacher_status: "yes", qualified_teacher_status_year: "2020", teacher_reference_number: "7777777",
-                                 is_statutory_induction_complete: true, has_teacher_reference_number: "yes")
+                                 is_statutory_induction_complete: true)
     end
 
     before { visit jobseekers_profile_path }
@@ -92,7 +92,7 @@ RSpec.describe "Jobseekers can add professional status to their profile" do
         expect(find("#jobseekers-profiles-qualified-teacher-status-form-qualified-teacher-status-yes-field", visible: false)).to be_checked
       end
       within(find("fieldset", text: "Do you have a teacher reference number (TRN)?")) do
-        expect(find("#jobseekers-profiles-qualified-teacher-status-form-has-teacher-reference-number-yes-field", visible: false)).to be_checked
+        expect(find("#jobseekers-profiles-qualified-teacher-status-form-has-teacher-reference-number-true-field", visible: false)).to be_checked
       end
       expect(find("#jobseekers-profiles-qualified-teacher-status-form-qualified-teacher-status-year-field", visible: false).value).to eq("2020")
       within(find("fieldset", text: "Have you completed your induction period?")) do


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/a7XdO59B/1663-trn-go-back-to-record-it-per-job-application

## Changes in this PR:

Revert storing TRN only in profile - store it on every job application