### PR TITLE
Cleanup legacy working patterns and phases from search filter queries

### DIFF
--- a/app/queries/vacancy_filter_query.rb
+++ b/app/queries/vacancy_filter_query.rb
@@ -28,10 +28,7 @@ class VacancyFilterQuery < ApplicationQuery
     built_scope = built_scope.quick_apply if filters[:quick_apply]
     built_scope = add_school_type_filters(filters, built_scope)
     built_scope = add_working_patterns_filters(filters[:working_patterns], built_scope)
-
-    built_scope = built_scope.with_any_of_phases(filters[:phases]) if filters[:phases].present?
-
-    built_scope
+    add_phases_filters(filters[:phases], built_scope)
   end
 
   private
@@ -105,6 +102,19 @@ class VacancyFilterQuery < ApplicationQuery
       built_scope.where(is_job_share: true).or(built_scope.with_any_of_working_patterns(working_patterns - %w[job_share]))
     else
       built_scope.with_any_of_working_patterns(working_patterns)
+    end
+  end
+
+  def add_phases_filters(phases, built_scope)
+    return built_scope if phases.blank?
+
+    # Removes phases not defined in the model enumerable values (EG: legacy phases)
+    # Watch out: any legacy non-enum defined phases mapping must be done before this call.
+    phases &= Vacancy.phases.keys
+    if phases.any?
+      built_scope.with_any_of_phases(phases)
+    else
+      built_scope
     end
   end
 

--- a/spec/queries/vacancy_filter_query_spec.rb
+++ b/spec/queries/vacancy_filter_query_spec.rb
@@ -210,6 +210,22 @@ RSpec.describe VacancyFilterQuery do
           expect(subject.call(filters).map(&:slug)).to contain_exactly("vacancy-1", "pt1", "ft1")
         end
       end
+
+      context "with legacy filters" do
+        let(:filters) { { working_patterns: %w[compressed_hours staggered_hours] } }
+
+        it "ignores the legacy filters and returns many jobs" do
+          expect(subject.call(filters).count).to eq(31)
+        end
+      end
+
+      context "with no filters" do
+        let(:filters) { { working_patterns: [] } }
+
+        it "ignores the legacy filters and returns many jobs" do
+          expect(subject.call(filters).count).to eq(31)
+        end
+      end
     end
 
     describe "roles mapping" do

--- a/spec/queries/vacancy_filter_query_spec.rb
+++ b/spec/queries/vacancy_filter_query_spec.rb
@@ -228,6 +228,48 @@ RSpec.describe VacancyFilterQuery do
       end
     end
 
+    describe "phases search" do
+      context "with no filters" do
+        let(:filters) { { phases: [] } }
+
+        it "returns many jobs" do
+          expect(subject.call(filters).count).to eq(29)
+        end
+      end
+
+      context "with primary filter" do
+        let(:filters) { { phases: %w[primary] } }
+
+        it "returns primary jobs" do
+          expect(subject.call(filters).count).to eq(27)
+        end
+      end
+
+      context "with primary and secondary filter" do
+        let(:filters) { { phases: %w[primary secondary] } }
+
+        it "returns both primary and secondary jobs" do
+          expect(subject.call(filters).count).to eq(28)
+        end
+      end
+
+      context "with legacy no longer defined filters" do
+        let(:filters) { { phases: %w[middle] } }
+
+        it "ignores the legacy filters and returns many jobs" do
+          expect(subject.call(filters).count).to eq(29)
+        end
+      end
+
+      context "with both legacy and a valid filter" do
+        let(:filters) { { phases: %w[middle primary] } }
+
+        it "ignores the legacy filters and applies the filter for the valid value" do
+          expect(subject.call(filters).count).to eq(27)
+        end
+      end
+    end
+
     describe "roles mapping" do
       it "transforms legacy 'leadership' to all senior leadership roles" do
         filters = {


### PR DESCRIPTION
## Trello card URL
Fixes:
- https://teaching-vacancies.sentry.io/issues/6395338426/?environment=production&project=6212514&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=9
- https://teaching-vacancies.sentry.io/issues/6237942425/?environment=production&project=6212514&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=10

## Changes in this PR:

Removes any value in Woking Patterns and Phases filters that are not currently defined in their model-defined values. 
It avoids exceptions being raised to users landing with legacy filters.
