### PR TITLE
Change link address

### DIFF
--- a/app/views/layouts/_footer.html.slim
+++ b/app/views/layouts/_footer.html.slim
@@ -16,7 +16,7 @@
               li.govuk-footer__list-item
                 = link_to t("footer.jobseeker_guides"), posts_path(section: "jobseeker-guides"), class: "govuk-footer__link"
               li.govuk-footer__list-item
-                = link_to t("footer.return_to_teaching"), post_path(section: "jobseeker-guides", subcategory: "return-to-teaching-in-england", post_name: "return-to-teaching-step-by-step"), class: "govuk-footer__link"
+                = link_to t("footer.return_to_teaching"), post_path(section: "jobseeker-guides", subcategory: "return-to-teaching-in-england", post_name: "return-to-teaching"), class: "govuk-footer__link"
               li.govuk-footer__list-item
                 = tracked_link_to(t("footer.international_teacher_advice_link_text"), "https://getintoteaching.education.gov.uk/non-uk-teachers", class: "govuk-footer__link", link_type: :international_teacher_advice_link_footer)
       .govuk-grid-column-one-half

--- a/app/views/layouts/_footer.html.slim
+++ b/app/views/layouts/_footer.html.slim
@@ -16,7 +16,7 @@
               li.govuk-footer__list-item
                 = link_to t("footer.jobseeker_guides"), posts_path(section: "jobseeker-guides"), class: "govuk-footer__link"
               li.govuk-footer__list-item
-                = link_to t("footer.return_to_teaching"), post_path(section: "jobseeker-guides", subcategory: "return-to-teaching-in-england", post_name: "return-to-teaching-in-england"), class: "govuk-footer__link"
+                = link_to t("footer.return_to_teaching"), subcategory_path(section: "jobseeker-guides", subcategory: "return-to-teaching-in-england"), class: "govuk-footer__link"
               li.govuk-footer__list-item
                 = tracked_link_to(t("footer.international_teacher_advice_link_text"), "https://getintoteaching.education.gov.uk/non-uk-teachers", class: "govuk-footer__link", link_type: :international_teacher_advice_link_footer)
       .govuk-grid-column-one-half

--- a/app/views/layouts/_footer.html.slim
+++ b/app/views/layouts/_footer.html.slim
@@ -16,7 +16,7 @@
               li.govuk-footer__list-item
                 = link_to t("footer.jobseeker_guides"), posts_path(section: "jobseeker-guides"), class: "govuk-footer__link"
               li.govuk-footer__list-item
-                = link_to t("footer.return_to_teaching"), post_path(section: "jobseeker-guides", subcategory: "return-to-teaching-in-england", post_name: "return-to-teaching"), class: "govuk-footer__link"
+                = link_to t("footer.return_to_teaching"), post_path(section: "jobseeker-guides", subcategory: "return-to-teaching-in-england", post_name: "return-to-teaching-in-england"), class: "govuk-footer__link"
               li.govuk-footer__list-item
                 = tracked_link_to(t("footer.international_teacher_advice_link_text"), "https://getintoteaching.education.gov.uk/non-uk-teachers", class: "govuk-footer__link", link_type: :international_teacher_advice_link_footer)
       .govuk-grid-column-one-half


### PR DESCRIPTION
## Changes in this PR:

This PR changes the return to teaching link in the footer so that it links to a different content page, as requested by content team.

## Screenshots of UI changes:

### Before

### After
