### PR TITLE
Do not merge: Vacancy analytics spike

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -20,7 +20,7 @@ class VacanciesController < ApplicationController
     end
 
     vacancy = Vacancy.listed.friendly.find(params[:id])
-    VacancyAnalytics.increment_view(vacancy.id, request.referrer)
+    UpdateVacancyAnalyticsJob.perform_later(vacancy.id, request.referrer)
     @saved_job = current_jobseeker&.saved_jobs&.find_by(vacancy: vacancy)
     @job_application = current_jobseeker&.job_applications&.find_by(vacancy: vacancy)
     @invented_job_alert_search_criteria = Search::CriteriaInventor.new(vacancy).criteria

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -20,6 +20,7 @@ class VacanciesController < ApplicationController
     end
 
     vacancy = Vacancy.listed.friendly.find(params[:id])
+    VacancyAnalytics.increment_view(vacancy_id, referrer)
     @saved_job = current_jobseeker&.saved_jobs&.find_by(vacancy: vacancy)
     @job_application = current_jobseeker&.job_applications&.find_by(vacancy: vacancy)
     @invented_job_alert_search_criteria = Search::CriteriaInventor.new(vacancy).criteria

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -20,7 +20,7 @@ class VacanciesController < ApplicationController
     end
 
     vacancy = Vacancy.listed.friendly.find(params[:id])
-    VacancyAnalytics.increment_view(vacancy_id, referrer)
+    VacancyAnalytics.increment_view(vacancy.id, request.referrer)
     @saved_job = current_jobseeker&.saved_jobs&.find_by(vacancy: vacancy)
     @job_application = current_jobseeker&.job_applications&.find_by(vacancy: vacancy)
     @invented_job_alert_search_criteria = Search::CriteriaInventor.new(vacancy).criteria

--- a/app/controllers/vacancy_analytics_controller.rb
+++ b/app/controllers/vacancy_analytics_controller.rb
@@ -1,0 +1,9 @@
+class VacancyAnalyticsController < ApplicationController
+  def show
+    analytics = VacancyAnalytics
+      .where(vacancy_id: params[:job_id])
+      .select("id, view_count, referrer_counts")
+
+    render json: analytics
+  end
+end

--- a/app/jobs/update_vacancy_analytics_job.rb
+++ b/app/jobs/update_vacancy_analytics_job.rb
@@ -1,0 +1,7 @@
+class UpdateVacancyAnalyticsJob < ApplicationJob
+  queue_as :default
+
+  def perform(vacancy_id, referrer)
+    VacancyAnalytics.increment_view(vacancy_id, referrer)
+  end
+end

--- a/app/models/vacancy_analytics.rb
+++ b/app/models/vacancy_analytics.rb
@@ -1,0 +1,15 @@
+class VacancyAnalytics < ApplicationRecord
+  belongs_to :vacancy
+
+  def self.increment_view(vacancy_id, referrer)
+    record = find_or_create_by!(vacancy_id: vacancy_id)
+
+    record.increment!(:view_count)
+
+    referrers = record.referrer_counts || {}
+    referrer_key = referrer.present? ? URI(referrer).host : "direct"
+    referrers[referrer_key] = referrers.fetch(referrer_key, 0) + 1
+
+    record.update!(referrer_counts: referrers)
+  end
+end

--- a/app/views/vacancies/_show.html.slim
+++ b/app/views/vacancies/_show.html.slim
@@ -31,6 +31,7 @@
     = render "vacancies/listing/key_dates_sidebar", vacancy: @vacancy, similar_jobs: @similar_jobs
 
   .govuk-grid-column-two-thirds
+    = govuk_link_to("View job analytics", job_analytics_path(@vacancy.id))
     = render "vacancies/listing/multi_school_banner", vacancy: @vacancy
 
     = render "vacancies/listing/job_details", vacancy: @vacancy

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -481,3 +481,10 @@ shared:
     - exam_taken
     - jobseeker_profile_id
     - job_application_id
+  :vacancy_analytics:
+    - id
+    - vacancy_id
+    - view_count
+    - referrer_counts
+    - created_at
+    - updated_at

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -318,6 +318,7 @@ Rails.application.routes.draw do
 
   resources :jobs, only: %i[index show], controller: "vacancies" do
     resources :documents, only: %i[show]
+    resource :analytics, only: [:show], controller: 'vacancy_analytics'
   end
 
   resources :organisations, only: %i[index show], path: "schools" do

--- a/db/migrate/20250318105355_create_vacancy_analytics.rb
+++ b/db/migrate/20250318105355_create_vacancy_analytics.rb
@@ -1,0 +1,11 @@
+class CreateVacancyAnalytics < ActiveRecord::Migration[7.2]
+  def change
+    create_table :vacancy_analytics do |t|
+      t.uuid :vacancy_id, null: false
+      t.integer :view_count, default: 0
+      t.jsonb :referrer_counts, default: {}
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_28_143957) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_18_105355) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
-  enable_extension "citext"
   enable_extension "fuzzystrmatch"
-  enable_extension "pg_trgm"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
   enable_extension "postgis"
-  enable_extension "uuid-ossp"
 
   create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
@@ -333,9 +330,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_28_143957) do
     t.date "account_closed_on"
     t.text "current_sign_in_ip_ciphertext"
     t.text "last_sign_in_ip_ciphertext"
-    t.string "govuk_one_login_id"
     t.string "account_merge_confirmation_code"
     t.datetime "account_merge_confirmation_code_generated_at"
+    t.string "govuk_one_login_id"
     t.index ["email"], name: "index_jobseekers_on_email", unique: true
     t.index ["govuk_one_login_id"], name: "index_jobseekers_on_govuk_one_login_id", unique: true
   end
@@ -716,8 +713,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_28_143957) do
     t.string "flexi_working"
     t.integer "extension_reason"
     t.string "other_extension_reason_details"
-    t.uuid "publisher_ats_api_client_id"
     t.integer "religion_type"
+    t.uuid "publisher_ats_api_client_id"
     t.boolean "flexi_working_details_provided"
     t.index ["expires_at"], name: "index_vacancies_on_expires_at"
     t.index ["external_reference", "publisher_ats_api_client_id"], name: "index_vacancies_on_external_ref_and_publisher_ats_client_id", unique: true
@@ -730,6 +727,14 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_28_143957) do
     t.index ["searchable_content"], name: "index_vacancies_on_searchable_content", using: :gin
     t.index ["slug"], name: "index_vacancies_on_slug"
     t.index ["status"], name: "index_vacancies_on_status"
+  end
+
+  create_table "vacancy_analytics", force: :cascade do |t|
+    t.uuid "vacancy_id", null: false
+    t.integer "view_count", default: 0
+    t.jsonb "referrer_counts", default: {}
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "versions", force: :cascade do |t|
@@ -784,7 +789,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_28_143957) do
   add_foreign_key "references", "job_applications"
   add_foreign_key "saved_jobs", "jobseekers"
   add_foreign_key "saved_jobs", "vacancies"
-  add_foreign_key "school_group_memberships", "organisations", column: "school_group_id"
+  add_foreign_key "school_group_memberships", "organisations", column: "school_group_id", validate: false
   add_foreign_key "school_group_memberships", "organisations", column: "school_id"
   add_foreign_key "training_and_cpds", "job_applications"
   add_foreign_key "training_and_cpds", "jobseeker_profiles"


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/e0jSWvmS/1609-spike-share-vacancy-views-applicants-and-source-data-in-a-data-dashboard

## Changes in this PR:

Visiting https://teaching-vacancies-review-pr-7640.test.teacherservices.cloud/jobs/#{vacancy.id}/analytics shows the total number of views and referrer counts for a given vacancy.

for instance, https://teaching-vacancies-review-pr-7640.test.teacherservices.cloud/jobs/97ae63c7-d965-4cb5-bfce-d9c4886bb970/analytics shows this.

![Screenshot 2025-03-19 at 16 55 36](https://github.com/user-attachments/assets/ec589922-4dcd-4f53-8ae6-e0a788acbf74)

## Screenshots of UI changes:

### Before

### After
