### PR TITLE
[ATS API] Soft delete vacancies

### DIFF
--- a/app/controllers/publishers/vacancies/base_controller.rb
+++ b/app/controllers/publishers/vacancies/base_controller.rb
@@ -63,13 +63,6 @@ class Publishers::Vacancies::BaseController < Publishers::BaseController
     end
   end
 
-  def remove_google_index(job)
-    return if DisableExpensiveJobs.enabled?
-
-    url = job_url(job)
-    RemoveGoogleIndexQueueJob.perform_later(url)
-  end
-
   def update_google_index(job)
     return if DisableExpensiveJobs.enabled?
 

--- a/app/controllers/publishers/vacancies_controller.rb
+++ b/app/controllers/publishers/vacancies_controller.rb
@@ -39,9 +39,7 @@ class Publishers::VacanciesController < Publishers::Vacancies::BaseController
   end
 
   def destroy
-    vacancy.supporting_documents.purge_later
-    vacancy.update_attribute(:status, :trashed)
-    remove_google_index(vacancy)
+    vacancy.trash!
     redirect_to organisation_jobs_with_type_path, success: t(".success_html", job_title: vacancy.job_title)
   end
 

--- a/spec/controllers/publishers/vacancies/base_controller_spec.rb
+++ b/spec/controllers/publishers/vacancies/base_controller_spec.rb
@@ -18,24 +18,4 @@ RSpec.describe Publishers::Vacancies::BaseController do
       end
     end
   end
-
-  describe "#remove_google_index" do
-    let!(:vacancy) { create(:vacancy) }
-
-    context "when DisableExpensiveJobs is not enabled" do
-      before { allow(DisableExpensiveJobs).to receive(:enabled?).and_return(false) }
-
-      it "does perform the task" do
-        expect(RemoveGoogleIndexQueueJob).to receive(:perform_later)
-        controller.send(:remove_google_index, vacancy)
-      end
-    end
-
-    context "when DisableExpensiveJobs is enabled", :disable_expensive_jobs do
-      it "does NOT perform the task" do
-        expect(RemoveGoogleIndexQueueJob).not_to receive(:perform_later)
-        controller.send(:remove_google_index, vacancy)
-      end
-    end
-  end
 end

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -10,6 +10,53 @@ RSpec.describe Vacancy do
   it { is_expected.to have_many(:job_applications) }
   it { is_expected.to have_one(:equal_opportunities_report) }
 
+  describe "#trash!" do
+    subject { create(:vacancy) }
+
+    it "updates status" do
+      subject.trash!
+      expect(subject).to be_trashed
+    end
+
+    it "removes google index" do
+      url = Rails.application.routes.url_helpers.job_url(subject)
+      expect { subject.trash! }.to have_enqueued_job(RemoveGoogleIndexQueueJob).with(url)
+    end
+
+    it "removes attachements" do
+      subject.trash!
+      expect(subject.supporting_documents).to be_blank
+    end
+
+    context "when vacancy already trashed" do
+      subject { create(:vacancy, :trashed) }
+
+      it "does nothing" do
+        expect { subject.trash! }.not_to have_enqueued_job(RemoveGoogleIndexQueueJob)
+      end
+    end
+  end
+
+  describe "#remove_google_index" do
+    let(:vacancy) { create(:vacancy) }
+    subject(:remove_google_index) { vacancy.remove_google_index }
+
+    before { allow(DisableExpensiveJobs).to receive(:enabled?).and_return(enabled) }
+
+    context "when disable expensive jobs enabled is enabled" do
+      let(:enabled) { true }
+
+      it { expect { remove_google_index }.not_to have_enqueued_job(RemoveGoogleIndexQueueJob) }
+    end
+
+    context "when disable expensive jobs enabled is disabled" do
+      let(:enabled) { false }
+      let(:url) { Rails.application.routes.url_helpers.job_url(vacancy) }
+
+      it { expect { remove_google_index }.to have_enqueued_job(RemoveGoogleIndexQueueJob).with(url) }
+    end
+  end
+
   describe "#has_noticed_notifications" do
     subject { create(:vacancy) }
 

--- a/spec/requests/publishers/ats_api/v1/vacancies_spec.rb
+++ b/spec/requests/publishers/ats_api/v1/vacancies_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe "ats-api/v1/vacancies", openapi_spec: "v1/swagger.yaml" do
         end
 
         before do
+          create(:vacancy, :external, :trashed, publisher_ats_api_client: client, organisations: [school], external_reference: "REF_CLIENT_3")
           Array.new(3) do |index|
             create(
               :vacancy,
@@ -908,7 +909,7 @@ RSpec.describe "ats-api/v1/vacancies", openapi_spec: "v1/swagger.yaml" do
 
       response(204, "Indicates the vacancy was removed from the system.") do
         it "removes the vaancy" do |example|
-          expect { submit_request(example.metadata) }.to change(Vacancy, :count).from(1).to(0)
+          expect { submit_request(example.metadata) }.to change(Vacancy.active.where(publisher_ats_api_client: client), :count).from(1).to(0)
           assert_response_matches_metadata(example.metadata)
           expect(response.parsed_body).to be_empty
         end

--- a/spec/system/publishers/publishers_can_delete_vacancies_spec.rb
+++ b/spec/system/publishers/publishers_can_delete_vacancies_spec.rb
@@ -28,11 +28,4 @@ RSpec.describe "School deleting vacancies" do
 
     expect(vacancy.supporting_documents.count).to be_zero
   end
-
-  scenario "Notifies the Google index service" do
-    expect_any_instance_of(Publishers::Vacancies::BaseController).to receive(:remove_google_index).with(vacancy)
-
-    click_on I18n.t("publishers.vacancies.show.heading_component.action.delete")
-    click_on I18n.t("buttons.confirm_deletion")
-  end
 end


### PR DESCRIPTION
## Trello card URL
[1694](https://trello.com/c/gTuRa2Oy)

## Changes in this PR:

- Add `Vacancy#trash!` method
  Move the logic out of the controller down in the models
  This makes it simpler to keep a consistent behaviour across UI and API

- ATS API does not list trashed vacancies

- External reference constraints applies to trash vacancies