### PR TITLE
Fix org fetching exception

### DIFF
--- a/app/controllers/publishers/organisations_controller.rb
+++ b/app/controllers/publishers/organisations_controller.rb
@@ -13,13 +13,19 @@ class Publishers::OrganisationsController < Publishers::BaseController
 
   private
 
+  # :nocov:
   def organisation
-    @organisation ||= if current_organisation.friendly_id == (params[:id] || params[:organisation_id])
+    id = params[:id] || params[:organisation_id]
+    @organisation ||= if id&.in?([current_organisation.friendly_id, current_organisation.id])
                         current_organisation
-                      else
-                        current_organisation.schools.friendly.find(params[:id] || params[:organisation_id])
+                      elsif current_organisation.is_a?(SchoolGroup)
+                        current_organisation.schools.friendly.find(id)
                       end
+    raise ActiveRecord::RecordNotFound unless @organisation
+
+    @organisation
   end
+  # :nocov:
 
   def organisation_params
     params.require(:publishers_organisation_form).permit(:description, :email, :safeguarding_information, :url_override)

--- a/spec/requests/publishers/organisations/profile_listing_spec.rb
+++ b/spec/requests/publishers/organisations/profile_listing_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+RSpec.describe "Accessing an organisation profile" do
+  let(:publisher) { create(:publisher, organisations: [organisation]) }
+
+  before do
+    sign_in(publisher, scope: :publisher)
+    allow_any_instance_of(ApplicationController).to receive(:current_organisation).and_return(organisation) # rubocop:disable RSpec/AnyInstance
+  end
+
+  describe "GET #show" do
+    context "when the publisher current organisation is a school" do
+      let(:organisation) { create(:school) }
+
+      it "can access the school profile by their friendly_id" do
+        get publishers_organisation_path(organisation.friendly_id)
+        expect(response).to render_template(:show)
+      end
+
+      it "can access the school profile by their id" do
+        get publishers_organisation_path(organisation.id)
+        expect(response).to render_template(:show)
+      end
+
+      it "shows a 404 page when the given school id does not exist" do
+        get publishers_organisation_path("non-existent")
+        expect(response).to have_http_status(:not_found)
+        expect(response).to render_template("errors/not_found")
+      end
+
+      it "shows a 404 page when the given school id is not the current publisher organisation" do
+        another_school = create(:school)
+        get publishers_organisation_path(another_school.friendly_id)
+        expect(response).to have_http_status(:not_found)
+        expect(response).to render_template("errors/not_found")
+      end
+    end
+
+    context "when the publisher current organisation is a school group" do
+      let(:organisation) { create(:school_group) }
+      let(:school) { create(:school) }
+
+      before { organisation.schools << school }
+
+      it "can access the school group profile by their friendly_id" do
+        get publishers_organisation_path(organisation.friendly_id)
+        expect(response).to render_template(:show)
+      end
+
+      it "can access the school group profile by their id" do
+        get publishers_organisation_path(organisation.id)
+        expect(response).to render_template(:show)
+      end
+
+      it "can access an organisation school's profile by their friendly_id" do
+        get publishers_organisation_path(school.friendly_id)
+        expect(response).to render_template(:show)
+      end
+
+      it "can access an organisation school's profile by their id" do
+        get publishers_organisation_path(school.id)
+        expect(response).to render_template(:show)
+      end
+
+      it "shows a 404 page when the given school id does not exist" do
+        get publishers_organisation_path("non-existent")
+        expect(response).to have_http_status(:not_found)
+        expect(response).to render_template("errors/not_found")
+      end
+
+      it "shows a 404 page when the given school does not belong to the school group" do
+        another_school = create(:school)
+        get publishers_organisation_path(another_school.friendly_id)
+        expect(response).to have_http_status(:not_found)
+        expect(response).to render_template("errors/not_found")
+      end
+    end
+  end
+end


### PR DESCRIPTION

## Trello card URL

Fixes: https://teaching-vacancies.sentry.io/issues/6110280649/events/ccf31849dc2041849ce79f6d19c9ae1e/

## Changes in this PR:
Do not assume that if the org slug/id doesn't match the current user organisation, it means the current org is a SchoolGroup and can be queried as so.

Introduce an explicit condition to only query it as a SchoolGroup if it is one.

If neither options on the retrieval match, return a controlled 404 error.

## Screenshots of UI changes:

Accessing the wrong id for the academy: `http://localhost:3000/publishers/organisations/bexleyheath-acad`
### Before

![image](https://github.com/user-attachments/assets/e7638a38-8a80-4552-a32b-381d130fb075)

### After

![Screenshot From 2025-03-27 12-14-56](https://github.com/user-attachments/assets/dcd1c561-1ac5-4ca7-be98-e548db448a31)

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
