### PR TITLE
Send peak times reminder email

### DIFF
--- a/app/controllers/jobseekers/govuk_one_login_callbacks_controller.rb
+++ b/app/controllers/jobseekers/govuk_one_login_callbacks_controller.rb
@@ -80,6 +80,7 @@ class Jobseekers::GovukOneLoginCallbacksController < Devise::OmniauthCallbacksCo
     stored_location.include?("/job_application/new") || # Signed-in from a quick apply link
       stored_location.include?("/saved_job/") || # Signed-in from a vacancy page save/unsave action.
       stored_location.include?("/jobs/") || # Signed-in from a job page (in order to download)
-      stored_location.include?("/jobseekers/subscriptions") # Signed-in from a job alert email link.
+      stored_location.include?("/jobseekers/subscriptions") || # Signed-in from a job alert email link.
+      stored_location.include?("/jobseekers/account/email_preferences/edit") # Signed-in from a peak times email.
   end
 end

--- a/app/jobs/send_peak_times_email_reminder_job.rb
+++ b/app/jobs/send_peak_times_email_reminder_job.rb
@@ -1,0 +1,9 @@
+class SendPeakTimesEmailReminderJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Jobseeker.email_opt_in.select(:id).find_each do |jobseeker|
+      Jobseekers::PeakTimesMailer.reminder(jobseeker.id).deliver_later
+    end
+  end
+end

--- a/app/mailers/jobseekers/peak_times_mailer.rb
+++ b/app/mailers/jobseekers/peak_times_mailer.rb
@@ -1,0 +1,37 @@
+class Jobseekers::PeakTimesMailer < Jobseekers::BaseMailer
+  helper_method :jobseeker, :first_name, :campaign_url
+
+  def reminder(jobseeker_id)
+    @jobseeker_id = jobseeker_id
+    @template = template
+    @to = jobseeker.email
+
+    view_mail(@template,
+              to: @to,
+              subject: I18n.t("jobseekers.peak_times_mailer.reminder.subject", first_name: first_name))
+  end
+
+  private
+
+  attr_reader :jobseeker_id
+
+  def jobseeker
+    @jobseeker ||= Jobseeker.includes(jobseeker_profile: :personal_details).find_by(id: jobseeker_id)
+  end
+
+  def first_name
+    @first_name ||= jobseeker.jobseeker_profile.personal_details.first_name
+  end
+
+  def campaign_url
+    "https://teaching-vacancies.service.gov.uk/?utm_source=Notify&utm_medium=email&utm_campaign=#{month}_peak_notify&utm_id=#{month}_peak_notify"
+  end
+
+  def month
+    @month ||= Date.current.strftime("%B").downcase
+  end
+
+  def email_event_prefix
+    "jobseeker_peak_times"
+  end
+end

--- a/app/models/jobseeker.rb
+++ b/app/models/jobseeker.rb
@@ -12,6 +12,9 @@ class Jobseeker < ApplicationRecord
   has_many :emergency_login_keys, as: :owner
   has_one :jobseeker_profile
 
+  scope :active, -> { where(account_closed_on: nil) }
+  scope :email_opt_in, -> { active.where(email_opt_out: false) }
+
   validates :email, presence: true, uniqueness: true
   validates :email, email_address: true, if: -> { email_changed? } # Allows data created prior to validation to still be valid
   validates :govuk_one_login_id, uniqueness: true, allow_nil: true

--- a/app/views/jobseekers/peak_times_mailer/reminder.text.erb
+++ b/app/views/jobseekers/peak_times_mailer/reminder.text.erb
@@ -1,0 +1,9 @@
+<%= t(".hello", first_name:) %>
+
+<%= t(".line_1") %>
+
+<%= t(".line_2", campaign_url:) %>
+
+<%= t(".line_3") %>
+
+<%= t(".unsubscribe", link: edit_jobseekers_account_email_preferences_url) %>

--- a/config/analytics_custom_events.yml
+++ b/config/analytics_custom_events.yml
@@ -23,6 +23,7 @@ shared:
   - jobseeker_successful_govuk_one_login_sign_in
   - jobseeker_draft_application_only
   - jobseeker_unapplied_saved_vacancy
+  - jobseeker_peak_times_reminder
   - publisher_applications_received
   - publisher_invite_to_apply
   - publisher_job_application_data_expiry

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -32,6 +32,14 @@ en:
         valid_for: The code is only valid for one hour.
         not_requested: If you did not request this, you can ignore this email.
         need_help: If you need help using the verification code, you can %{mail_to}.
+    peak_times_mailer:
+      reminder:
+        subject: "%{first_name}, now is the best time to find school jobs"
+        hello: "Hi %{first_name},"
+        line_1: Schools advertise more jobs than usual around this time of year.
+        line_2: "If you are looking for a school role, now is a great time to search for jobs on [Teaching Vacancies](%{campaign_url})."
+        line_3: To find the right role, remember to always check Teaching Vacancies.
+        unsubscribe: "If you no longer wish to be on this mailing list, you can [opt out of these emails](%{link})."
     alert_mailer:
       alert:
         alert_frequency: >-

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,4 +1,12 @@
 #
+# SET DATE CRON JOBS
+#
+send_peak_times_email_reminder:
+  cron: '0 3 14 5 *' # "At 03:00 on 14 of May."
+  class: 'SendPeakTimesEmailReminderJob'
+  queue: default
+
+#
 # MONTHLY CRON JOBS
 #
 clear_emergency_login_keys:

--- a/spec/factories/jobseekers.rb
+++ b/spec/factories/jobseekers.rb
@@ -13,5 +13,11 @@ FactoryBot.define do
       email_opt_out { true }
       email_opt_out_reason { 0 }
     end
+
+    trait :with_personal_details do
+      after(:create) do |jobseeker|
+        create(:jobseeker_profile, :with_personal_details, jobseeker: jobseeker)
+      end
+    end
   end
 end

--- a/spec/factories/jobseekers.rb
+++ b/spec/factories/jobseekers.rb
@@ -8,5 +8,10 @@ FactoryBot.define do
         create(:jobseeker_profile, jobseeker: jobseeker)
       end
     end
+
+    trait :email_opted_out do
+      email_opt_out { true }
+      email_opt_out_reason { 0 }
+    end
   end
 end

--- a/spec/jobs/send_peak_times_email_reminder_job_spec.rb
+++ b/spec/jobs/send_peak_times_email_reminder_job_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe SendPeakTimesEmailReminderJob do
+  subject(:job) { described_class.perform_later }
+
+  let(:jobseeker) { create(:jobseeker, :with_personal_details) }
+
+  describe "#perform" do
+    let(:mail) { instance_double(ActionMailer::MessageDelivery) }
+
+    before do
+      allow(Jobseekers::PeakTimesMailer).to receive(:reminder).with(jobseeker.id) { mail }
+    end
+
+    it "enqueues mail sending job" do
+      expect(Jobseekers::PeakTimesMailer).to receive(:reminder).with(jobseeker.id)
+      expect(mail).to receive(:deliver_later)
+      perform_enqueued_jobs { job }
+    end
+  end
+end

--- a/spec/mailers/jobseekers/peak_times_mailer_spec.rb
+++ b/spec/mailers/jobseekers/peak_times_mailer_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+require "dfe/analytics/rspec/matchers"
+
+RSpec.describe Jobseekers::PeakTimesMailer do
+  describe ".reminder" do
+    subject(:mail) { described_class.reminder(jobseeker.id) }
+
+    let(:jobseeker) { create(:jobseeker, :with_personal_details) }
+
+    it "has subject with jobseeker firstname" do
+      first_name = jobseeker.jobseeker_profile.personal_details.first_name
+      expected_subject = I18n.t("jobseekers.peak_times_mailer.reminder.subject", first_name: first_name)
+      expect(mail.subject).to eq(expected_subject)
+    end
+
+    it "uses jobseekers' email" do
+      expect(mail.to).to contain_exactly(jobseeker.email)
+    end
+
+    context "with template" do
+      it "has an unsubcribe link" do
+        unsubscribe_link = Rails.application
+                             .routes
+                             .url_helpers
+                             .edit_jobseekers_account_email_preferences_url
+        expect(mail.body).to include(unsubscribe_link)
+      end
+
+      %w[march may].each do |month|
+        context "when it's month #{month}" do
+          subject(:body) { mail.body }
+
+          before { travel_to Time.zone.local(2025, month_num, 13, 9, 0, 0) }
+
+          let(:month_num) { month == "march" ? 3 : 5 }
+          let(:url) { "https://teaching-vacancies.service.gov.uk/?utm_source=Notify&utm_medium=email&utm_campaign=#{month}_peak_notify&utm_id=#{month}_peak_notify" }
+
+          it { is_expected.to include(url) }
+        end
+      end
+    end
+  end
+end

--- a/spec/mailers/previews/jobseekers/peak_times_preview.rb
+++ b/spec/mailers/previews/jobseekers/peak_times_preview.rb
@@ -1,0 +1,7 @@
+# Preview url
+# http://localhost:3000/rails/mailers/jobseekers/peak_times/reminder
+class Jobseekers::PeakTimesPreview < ActionMailer::Preview
+  def reminder
+    Jobseekers::PeakTimesMailer.reminder(Jobseeker.email_opt_in.limit(1).pick(:id))
+  end
+end

--- a/spec/models/jobseeker_spec.rb
+++ b/spec/models/jobseeker_spec.rb
@@ -4,6 +4,32 @@ RSpec.describe Jobseeker do
   it { is_expected.to have_many(:saved_jobs) }
   it { is_expected.to have_many(:job_applications) }
 
+  describe "scopes" do
+    describe ".active" do
+      subject(:active_jobseekers) { described_class.active }
+
+      let(:jobseeker_active) { create(:jobseeker) }
+      let(:jobseeker_inactive) { create(:jobseeker, account_closed_on: 1.day.ago) }
+
+      it { is_expected.not_to include(jobseeker_inactive) }
+      it { is_expected.to include(jobseeker_active) }
+    end
+
+    describe ".email_opt_in" do
+      subject(:active_jobseekers) { described_class.email_opt_in }
+
+      let(:jobseeker_active_opted_out) { create(:jobseeker, :email_opted_out) }
+      let(:jobseeker_active_opted_in) { create(:jobseeker) }
+      let(:jobseeker_inactive_opted_out) { create(:jobseeker, :email_opted_out, account_closed_on: 1.day.ago) }
+      let(:jobseeker_inactive_opted_in) { create(:jobseeker, account_closed_on: 1.day.ago) }
+
+      it { is_expected.not_to include(jobseeker_inactive_opted_out) }
+      it { is_expected.not_to include(jobseeker_inactive_opted_in) }
+      it { is_expected.not_to include(jobseeker_active_opted_out) }
+      it { is_expected.to include(jobseeker_active_opted_in) }
+    end
+  end
+
   describe "validations" do
     describe "email_opt_out_reason" do
       let(:jobseeker) { build(:jobseeker, email_opt_out: true) }

--- a/spec/requests/jobseekers/govuk_one_login_spec.rb
+++ b/spec/requests/jobseekers/govuk_one_login_spec.rb
@@ -22,6 +22,16 @@ RSpec.describe "Govuk One Login authentication response" do
         end
       end
 
+      context "with a peak times unsubscribe url location to redirect to in devise session" do
+        let(:devise_stored_location) { edit_jobseekers_account_email_preferences_path }
+
+        it "redirects the jobseeker to the email preferences page" do
+          get auth_govuk_one_login_callback_path
+
+          expect(response).to redirect_to(devise_stored_location)
+        end
+      end
+
       context "with the job alerts subscriptions page to redirect to in devise session" do
         let(:devise_stored_location) { jobseekers_subscriptions_path }
 


### PR DESCRIPTION
## Trello card URL
[1680](https://trello.com/c/Hcdpq4Eh)

## Changes in this PR:

- Add `SendPeakTimesEmailReminderJob`
- Add `PeakTimesMailer`
- Add scopes to Jobseeker model

## Screenshots of UI changes

### EMail preview
![email-preview](https://github.com/user-attachments/assets/33204746-7c36-4297-a9d0-89d46d079bd8)



## Checklists:

### Integration Impact

Does this change affect any of these integrations?
- [X] DfE Analytics platform, a new custom event has been added `jobseeker_peak_times_reminder`