### PR TITLE
Tweaks from draft vacancy spike

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -90,7 +90,6 @@ class Vacancy < ApplicationRecord
 
   delegate :name, to: :organisation, prefix: true, allow_nil: true
 
-  scope :active, -> { where(status: %i[published draft]) }
   scope :applicable, -> { where("expires_at >= ?", Time.current) }
   scope :awaiting_feedback, -> { expired.where(listed_elsewhere: nil, hired_status: nil) }
   scope :expired, -> { published.where("expires_at < ?", Time.current) }

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Vacancy do
 
     before do
       Publishers::JobApplicationReceivedNotifier.with(vacancy: subject, job_application: job_application)
-                                                    .deliver(subject.publisher)
+                                                .deliver(subject.publisher)
       expect(Noticed::Notification.count).to eq 1
       subject.destroy
     end
@@ -683,6 +683,20 @@ RSpec.describe Vacancy do
       it "returns the distance to given location" do
         expect(subject.distance_in_miles_to(test_coordinates).floor).to eq 161
       end
+    end
+  end
+
+  describe "#draft!" do
+    subject { create(:vacancy, :future_publish) }
+
+    before { subject.draft! }
+
+    it "converts the job to a draft" do
+      expect(subject.status).to eq("draft")
+    end
+
+    it "resets the publish_on date" do
+      expect(subject.publish_on).to eq(nil)
     end
   end
 

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -188,16 +188,6 @@ RSpec.describe Vacancy do
     let(:expired_earlier_today) { create(:vacancy, expires_at: 5.hour.ago) }
     let(:expires_later_today) { create(:vacancy, status: :published, expires_at: 1.hour.from_now) }
 
-    describe "#active" do
-      it "retrieves active vacancies that have a status of :draft or :published" do
-        draft = create_list(:vacancy, 2, :draft)
-        published = create_list(:vacancy, 5, :published)
-        create_list(:vacancy, 4, :trashed)
-
-        expect(Vacancy.active.count).to eq(draft.count + published.count)
-      end
-    end
-
     describe "#applicable" do
       it "finds current vacancies" do
         expired_earlier_today.send :set_slug
@@ -693,20 +683,6 @@ RSpec.describe Vacancy do
       it "returns the distance to given location" do
         expect(subject.distance_in_miles_to(test_coordinates).floor).to eq 161
       end
-    end
-  end
-
-  describe "#draft!" do
-    subject { create(:vacancy, :future_publish) }
-
-    before { subject.draft! }
-
-    it "converts the job to a draft" do
-      expect(subject.status).to eq("draft")
-    end
-
-    it "resets the publish_on date" do
-      expect(subject.publish_on).to eq(nil)
     end
   end
 

--- a/spec/requests/publishers/ats_api/v1/vacancies_spec.rb
+++ b/spec/requests/publishers/ats_api/v1/vacancies_spec.rb
@@ -909,7 +909,7 @@ RSpec.describe "ats-api/v1/vacancies", openapi_spec: "v1/swagger.yaml" do
 
       response(204, "Indicates the vacancy was removed from the system.") do
         it "removes the vaancy" do |example|
-          expect { submit_request(example.metadata) }.to change(Vacancy.active.where(publisher_ats_api_client: client), :count).from(1).to(0)
+          expect { submit_request(example.metadata) }.to change(Vacancy.live.where(publisher_ats_api_client: client), :count).from(1).to(0)
           assert_response_matches_metadata(example.metadata)
           expect(response.parsed_body).to be_empty
         end

--- a/spec/support/vacancy_helpers.rb
+++ b/spec/support/vacancy_helpers.rb
@@ -42,7 +42,9 @@ module VacancyHelpers
     if vacancy.contract_type == "fixed_term"
       choose I18n.t("helpers.label.publishers_job_listing_contract_information_form.contract_type_options.fixed_term")
       # Choose "Yes" for parental leave coverage
-      find_by_id("publishers-job-listing-contract-information-form-is-parental-leave-cover-true-field").choose
+      within "#publishers-job-listing-contract-information-form-contract-type-fixed-term-conditional" do
+        choose "Yes"
+      end
       fill_in "Length of contract", with: "1 month"
     else
       choose I18n.t("helpers.label.publishers_job_listing_contract_information_form.contract_type_options.#{vacancy.contract_type}")
@@ -53,8 +55,8 @@ module VacancyHelpers
     end
 
     # Choose "Yes" or "No" for job share option
-    job_share_field_id = vacancy.is_job_share ? "publishers-job-listing-contract-information-form-is-job-share-true-field" : "publishers-job-listing-contract-information-form-is-job-share-false-field"
-    find("##{job_share_field_id}").choose
+    job_share_label = "publishers-job-listing-contract-information-form-is-job-share-#{vacancy.is_job_share}-field"
+    find("label[for=#{job_share_label}]").click
 
     fill_in "publishers_job_listing_contract_information_form[working_patterns_details]", with: vacancy.working_patterns_details
   end

--- a/spec/system/publishers/publishers_can_copy_a_vacancy_spec.rb
+++ b/spec/system/publishers/publishers_can_copy_a_vacancy_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Copying a vacancy", :js do
+RSpec.describe "Copying a vacancy" do
   let(:publisher) { create(:publisher) }
   let(:school) { create(:school, safeguarding_information: nil) }
 

--- a/spec/system/publishers/publishers_can_copy_a_vacancy_spec.rb
+++ b/spec/system/publishers/publishers_can_copy_a_vacancy_spec.rb
@@ -1,12 +1,14 @@
 require "rails_helper"
 
-RSpec.describe "Copying a vacancy" do
+RSpec.describe "Copying a vacancy", :js do
   let(:publisher) { create(:publisher) }
   let(:school) { create(:school, safeguarding_information: nil) }
 
   let!(:original_vacancy) { create_published_vacancy(organisations: [school], phases: %w[secondary], key_stages: %w[ks3]) }
 
   before { login_publisher(publisher: publisher, organisation: school) }
+
+  after { logout }
 
   RSpec.shared_examples "publishing a copied vacancy" do |options|
     before { visit organisation_jobs_with_type_path(type: options[:type]) }

--- a/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_school_spec.rb
@@ -265,6 +265,8 @@ RSpec.describe "Creating a vacancy" do
 
         before { login_publisher(publisher: publisher_that_publishes_vacancy, organisation: school) }
 
+        after { logout }
+
         scenario "the publisher and organisation_publisher are reset" do
           visit organisation_job_path(vacancy.id)
 
@@ -284,10 +286,12 @@ RSpec.describe "Creating a vacancy" do
 
         visit organisation_job_path(vacancy.id)
         click_on I18n.t("publishers.vacancies.show.heading_component.action.scheduled_complete_draft")
+        #  wait for page to load
+        find(".govuk-panel.govuk-panel--confirmation")
 
         expect(page).to have_content(I18n.t("publishers.vacancies.summary.date_posted", date: format_date(vacancy.publish_on)))
 
-        visit organisation_job_path(vacancy.id)
+        click_on "make changes to the job listing"
 
         has_scheduled_vacancy_review_heading?(vacancy)
         expect(page).to have_content(format_date(vacancy.publish_on).to_s)
@@ -301,7 +305,7 @@ RSpec.describe "Creating a vacancy" do
 
         expect(page).to have_content(I18n.t("publishers.vacancies.summary.date_posted", date: format_date(vacancy.publish_on)))
 
-        visit organisation_job_path(vacancy.id)
+        click_on "make changes to the job listing"
 
         has_scheduled_vacancy_review_heading?(vacancy)
 

--- a/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_trust_spec.rb
+++ b/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_trust_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe "Creating a vacancy" do
   let(:school3) { create(:school, :closed, name: "Closed school") }
   let(:vacancy) { build(:vacancy, :central_office, :ect_suitable, job_roles: ["teacher"], organisations: [school_group], phases: %w[secondary], key_stages: %w[ks3]) }
   let(:created_vacancy) { Vacancy.last }
-  let(:published) { Vacancy.order(:created_at).last }
 
   before do
     login_publisher(publisher: publisher, organisation: school_group)
@@ -177,6 +176,6 @@ RSpec.describe "Creating a vacancy" do
     verify_all_vacancy_details(created_vacancy)
 
     click_on I18n.t("publishers.vacancies.show.heading_component.action.publish")
-    expect(current_path).to eq(organisation_job_summary_path(published.id))
+    expect(current_path).to eq(organisation_job_summary_path(created_vacancy.id))
   end
 end

--- a/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_trust_spec.rb
+++ b/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_trust_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "Creating a vacancy" do
   let(:school3) { create(:school, :closed, name: "Closed school") }
   let(:vacancy) { build(:vacancy, :central_office, :ect_suitable, job_roles: ["teacher"], organisations: [school_group], phases: %w[secondary], key_stages: %w[ks3]) }
   let(:created_vacancy) { Vacancy.last }
+  let(:published) { Vacancy.order(:created_at).last }
 
   before do
     login_publisher(publisher: publisher, organisation: school_group)
@@ -176,6 +177,6 @@ RSpec.describe "Creating a vacancy" do
     verify_all_vacancy_details(created_vacancy)
 
     click_on I18n.t("publishers.vacancies.show.heading_component.action.publish")
-    expect(current_path).to eq(organisation_job_summary_path(created_vacancy.id))
+    expect(current_path).to eq(organisation_job_summary_path(published.id))
   end
 end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/gwQ9t4fo/1706-spike-dfe-wizard-and-vacancydraft

## Changes in this PR:

Include some tidy-ups from the draft vacancy PR. 

1. Remove unused and confusing 'active' scope from Vacancy
2. Improve a couple of test helpers so they work in both js and non-js contexts
3. Tweak a couple of tests to continue the flow rather than navigating in the middle of a test