### PR TITLE
Fix catholic form page when validations fail with attachment.

### DIFF
--- a/app/views/jobseekers/job_applications/build/catholic.html.slim
+++ b/app/views/jobseekers/job_applications/build/catholic.html.slim
@@ -31,7 +31,7 @@
               = f.govuk_text_field :religious_referee_email
               = f.govuk_text_field :religious_referee_phone
             = f.govuk_radio_button :religious_reference_type, :baptism_certificate do
-              - if f.object.baptism_certificate.attached?
+              - if f.object.baptism_certificate.respond_to?(:attached?) && f.object.baptism_certificate.attached? # If form validations fail, the file is a tempfile that doesn't respond to ActiveStorage methods.
                 p.govuk-body
                   = govuk_link_to("#{f.object.baptism_certificate.filename}  (#{number_to_human_size(f.object.baptism_certificate.byte_size)})", f.object.baptism_certificate, download: "true")
               = f.govuk_file_field :baptism_certificate,


### PR DESCRIPTION


## Trello card URL

- https://teaching-vacancies.sentry.io/issues/6437668574

## Changes in this PR:

When a jobseeker attaches a baptism certificate and submits the form without filling other required fields, the baptism certificate exists as a temp file but is not attached.

Once the page renders to display the validation errors, it triggers an exception when trying to call attachment methods over the certificate to generate a link to it.

Resolving it by only calling these methods when the file is attached.
