### PR TITLE
Exclude ats-api from basic auth

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
                                if: lambda {
                                  ENV["HTTP_BASIC_PASSWORD"].present? &&
                                    request.path != "/check" &&
-                                   !(request.host.include?("test.teacherservices.cloud") && request.path.start_with?("/ats-api", "/ats-api-docs"))
+                                   !(request.host.include?("test.teacherservices.cloud") && request.path.start_with?("/ats-api"))
                                }
 
   add_flash_types :success, :warning

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,11 @@ class ApplicationController < ActionController::Base
 
   http_basic_authenticate_with name: ENV.fetch("HTTP_BASIC_USER", ""),
                                password: ENV.fetch("HTTP_BASIC_PASSWORD", ""),
-                               if: -> { ENV["HTTP_BASIC_PASSWORD"].present? && request.path != "/check" }
+                               if: lambda {
+                                 ENV["HTTP_BASIC_PASSWORD"].present? &&
+                                   request.path != "/check" &&
+                                   !(Rails.env.review? && request.path.start_with?("/ats-api", "/ats-api-docs"))
+                               }
 
   add_flash_types :success, :warning
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
                                if: lambda {
                                  ENV["HTTP_BASIC_PASSWORD"].present? &&
                                    request.path != "/check" &&
-                                   !(Rails.env.review? && request.path.start_with?("/ats-api", "/ats-api-docs"))
+                                   !(request.host.include?("test.teacherservices.cloud") && request.path.start_with?("/ats-api", "/ats-api-docs"))
                                }
 
   add_flash_types :success, :warning

--- a/spec/requests/basic_auth_spec.rb
+++ b/spec/requests/basic_auth_spec.rb
@@ -3,6 +3,13 @@ require "rails_helper"
 RSpec.describe "HTTP Basic Auth exclusions" do
   let!(:api_client) { create(:publisher_ats_api_client) }
 
+  before do
+    # Stub ENV to simulate review app credentials being set
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("HTTP_BASIC_USER").and_return("user")
+    allow(ENV).to receive(:[]).with("HTTP_BASIC_PASSWORD").and_return("pass")
+  end
+
   context "when making a GET request to /ats-api on review app host" do
     it "does not require basic auth" do
       host! "teaching-vacancies-review-pr-1234.test.teacherservices.cloud"

--- a/spec/requests/basic_auth_spec.rb
+++ b/spec/requests/basic_auth_spec.rb
@@ -3,13 +3,6 @@ require "rails_helper"
 RSpec.describe "HTTP Basic Auth exclusions" do
   let!(:api_client) { create(:publisher_ats_api_client) }
 
-  context "when making a GET request to /check" do
-    it "does not require basic auth" do
-      get "/check"
-      expect(response).to have_http_status(:ok)
-    end
-  end
-
   context "when making a GET request to /ats-api on review app host" do
     it "does not require basic auth" do
       host! "teaching-vacancies-review-pr-1234.test.teacherservices.cloud"
@@ -21,22 +14,11 @@ RSpec.describe "HTTP Basic Auth exclusions" do
     end
   end
 
-  context "when making a GET request to homepage without auth" do
+  context "when making a GET request to homepage without auth on review app host" do
     it "requires basic auth" do
-      get "/", headers: { "HTTP_AUTHORIZATION" => nil }
+      host! "teaching-vacancies-review-pr-1234.test.teacherservices.cloud"
+      get "/"
       expect(response).to have_http_status(:unauthorized)
-    end
-  end
-
-  context "when making a GET request to homepage with valid credentials" do
-    it "allows access" do
-      get "/", headers: {
-        "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic.encode_credentials(
-          ENV["HTTP_BASIC_USER"],
-          ENV["HTTP_BASIC_PASSWORD"]
-        )
-      }
-      expect(response).to have_http_status(:ok)
     end
   end
 end

--- a/spec/requests/basic_auth_spec.rb
+++ b/spec/requests/basic_auth_spec.rb
@@ -3,10 +3,6 @@ require "rails_helper"
 RSpec.describe "HTTP Basic Auth exclusions" do
   let!(:api_client) { create(:publisher_ats_api_client) }
 
-  before do
-    stub_const("ENV", ENV.to_hash.merge("HTTP_BASIC_PASSWORD" => "secret", "HTTP_BASIC_USER" => "user"))
-  end
-
   context "when making a GET request to /check" do
     it "does not require basic auth" do
       get "/check"
@@ -27,7 +23,7 @@ RSpec.describe "HTTP Basic Auth exclusions" do
 
   context "when making a GET request to homepage without auth" do
     it "requires basic auth" do
-      get "/"
+      get "/", headers: { "HTTP_AUTHORIZATION" => nil }
       expect(response).to have_http_status(:unauthorized)
     end
   end
@@ -35,7 +31,10 @@ RSpec.describe "HTTP Basic Auth exclusions" do
   context "when making a GET request to homepage with valid credentials" do
     it "allows access" do
       get "/", headers: {
-        "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic.encode_credentials("user", "secret"),
+        "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic.encode_credentials(
+          ENV["HTTP_BASIC_USER"],
+          ENV["HTTP_BASIC_PASSWORD"]
+        )
       }
       expect(response).to have_http_status(:ok)
     end

--- a/spec/requests/basic_auth_spec.rb
+++ b/spec/requests/basic_auth_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe "HTTP Basic Auth exclusions", type: :request do
+  before do
+    stub_const("ENV", ENV.to_hash.merge("HTTP_BASIC_PASSWORD" => "secret", "HTTP_BASIC_USER" => "user"))
+
+    Rails.application.routes.draw do
+      get "/check" => "application#check"
+      get "/ats-api/v1/jobs" => "application#check" # simple action for testing
+      get "/ats-api-docs" => "application#check"
+      get "/protected" => "application#check"
+    end
+  end
+
+  context "GET /check" do
+    it "does not require basic auth" do
+      get "/check"
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context "GET /ats-api on review app host" do
+    it "does not require basic auth" do
+      host! "teaching-vacancies-review-pr-1234.test.teacherservices.cloud"
+      get "/ats-api/v1/jobs"
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context "GET /protected without auth" do
+    it "requires basic auth" do
+      get "/protected"
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  context "GET /protected with valid credentials" do
+    it "allows access" do
+      get "/protected", headers: {
+        "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic.encode_credentials("user", "secret")
+      }
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/Q7RaRAIq/1736-api-feedback-exclude-api-endpoint-path-from-httpbasic-auth

## Changes in this PR:

This PR ensures that requests to the ats api in the review app environment do not need to include basic auth credentials.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
