### PR TITLE
Fix: Remove flexible working pattern from profiles

### DIFF
--- a/lib/tasks/remove_flexible_working_pattern.rake
+++ b/lib/tasks/remove_flexible_working_pattern.rake
@@ -1,0 +1,24 @@
+# One-off task. Remove after running.
+namespace :job_preferences do
+  desc "Remove 'flexible' from job_preferences working_patterns"
+  task remove_flexible_working_pattern: :environment do
+    affected_count = 0
+
+    JobPreferences.where("working_patterns @> ARRAY['flexible']::varchar[]").find_each do |job_preference|
+      original_patterns = job_preference.working_patterns
+      updated_patterns = original_patterns - %w[flexible]
+
+      result = JobPreferences.where(id: job_preference.id)
+                             .update_all(working_patterns: updated_patterns)
+
+      if result == 1
+        affected_count += 1
+        puts "Updated JobPreference ID: #{job_preference.id}, removed 'flexible' from working patterns"
+      else
+        puts "Failed to update JobPreference ID: #{job_preference.id}"
+      end
+    end
+
+    puts "Task completed: updated #{affected_count} job_preferences records"
+  end
+end

--- a/spec/tasks/remove_flexible_working_pattern_spec.rb
+++ b/spec/tasks/remove_flexible_working_pattern_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "job_preferences:remove_flexible_working_pattern" do
+  before do
+    Rake.application.rake_require "tasks/remove_flexible_working_pattern"
+    Rake::Task.define_task(:environment)
+  end
+
+  let(:task) { Rake::Task["job_preferences:remove_flexible_working_pattern"] }
+  let(:profile) { create(:jobseeker_profile) }
+
+  it "removes 'flexible' from working_patterns array without changing timestamps" do
+    job_preferences = create(:job_preferences,
+                             jobseeker_profile: profile,
+                             working_patterns: %w[full_time flexible part_time])
+
+    original_created_at = job_preferences.created_at
+    original_updated_at = job_preferences.updated_at
+
+    travel 1.second
+
+    task.invoke
+
+    job_preferences.reload
+    expect(job_preferences.working_patterns).to match_array(%w[full_time part_time])
+    expect(job_preferences.created_at).to eq(original_created_at)
+    expect(job_preferences.updated_at).to eq(original_updated_at)
+  end
+
+  it "doesn't change job_preferences without 'flexible' in working_patterns" do
+    job_preferences = create(:job_preferences,
+                             jobseeker_profile: profile,
+                             working_patterns: %w[full_time part_time])
+
+    expect { task.invoke }.not_to(change { job_preferences.reload.working_patterns })
+  end
+
+  it "leaves empty working_patterns arrays unchanged" do
+    job_preferences = create(:job_preferences,
+                             jobseeker_profile: profile,
+                             working_patterns: [])
+
+    expect { task.invoke }.not_to(change { job_preferences.reload.working_patterns })
+  end
+
+  it "handles job_preferences with only 'flexible' in working_patterns" do
+    profile = create(:jobseeker_profile)
+    job_preferences = create(:job_preferences,
+                             jobseeker_profile: profile,
+                             working_patterns: %w[flexible])
+
+    expect { task.invoke }.to change { job_preferences.reload.working_patterns }.to([])
+  end
+end


### PR DESCRIPTION
## Trello card URL
- Fixes this Sentry error: https://teaching-vacancies.sentry.io/issues/6295531964

## Changes in this PR:

The flexible working pattern present in some jobseeker profile preferences is a non-valid value that breaks the prefilling of Job Application data from the profile.

When the "flexible" value attempts to write in the Job Application, is not a valid value for the Job Application enumerable and raises an exception.

As a consequence, it breaks the flow for these users when trying to apply for a vacancy.

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [x] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact
** Note **: This fixes an unintended impact over enumerable options change.

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
