### PR TITLE
Fix wrong timestamp displayed for jobseekers

### DIFF
--- a/app/views/jobseekers/job_applications/_job_application.html.slim
+++ b/app/views/jobseekers/job_applications/_job_application.html.slim
@@ -10,7 +10,7 @@
     - when "draft"
       = tag.div(card.labelled_item(t(".last_edited"), format_time_to_datetime_at(job_application.updated_at)))
     - when "submitted", "reviewed", "unsuccessful"
-      = tag.div(card.labelled_item(t(".submitted"), format_time_to_datetime_at(job_application.updated_at)))
+      = tag.div(card.labelled_item(t(".submitted"), format_time_to_datetime_at(job_application.submitted_at)))
     - when "shortlisted"
       = tag.div(card.labelled_item(t(".shortlisted"), format_time_to_datetime_at(job_application.shortlisted_at)))
     - when "withdrawn"

--- a/spec/system/jobseekers/jobseekers_can_manage_their_job_applications_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_their_job_applications_spec.rb
@@ -10,7 +10,10 @@ RSpec.describe "Jobseekers can manage their job applications" do
   let(:vacancy4) { create(:vacancy, job_title: "Teacher of RE & PSHE", organisations: [organisation]) }
 
   context "when logged in" do
-    before { login_as(jobseeker, scope: :jobseeker) }
+    before do
+      travel_to Time.zone.local(2025, 3, 2, 12, 31, 23)
+      login_as(jobseeker, scope: :jobseeker)
+    end
 
     after { logout }
 
@@ -33,6 +36,10 @@ RSpec.describe "Jobseekers can manage their job applications" do
 
           within ".card-component:nth-child(2)" do
             expect(page).to have_css(".card-component__header", text: submitted_job_application.vacancy.job_title)
+            within ".card-component__body" do
+              dt = find("dt", text: "Submitted")
+              expect(dt.sibling("dd").text).to eq("1 March 2025 at 12:31pm")
+            end
             expect(page).to have_css(".card-component__actions", text: "submitted")
           end
 


### PR DESCRIPTION
## Changes in this PR:

When the jobseekers see their list of Job Applications in their account, the wrong timestamp is being displayed near the "Submitted" applications.

It should be displaying the submitted_at, not the updated_at.

This caused confusion for jobseekers that reported it thinking there is a bug that made them miss the vacancy application timeline even when it was submitted in time.

## Screenshots of UI changes:

### Fixes the wrong source of data being used in the highlighted line:
![image](https://github.com/user-attachments/assets/0a201ca4-f1be-4ccc-bd3c-795a8385a06c)


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
