### PR TITLE
Fix: Do not attempt to format null baptism date on review

### DIFF
--- a/app/views/jobseekers/job_applications/review/_catholic_religious_information.html.slim
+++ b/app/views/jobseekers/job_applications/review/_catholic_religious_information.html.slim
@@ -57,4 +57,4 @@
 
           - summary_list.with_row do |row|
             - row.with_key text: t("helpers.legend.jobseekers_job_application_catholic_form.baptism_date")
-            - row.with_value text: job_application.baptism_date.to_formatted_s(:day_month_year)
+            - row.with_value text: job_application.baptism_date&.to_formatted_s(:day_month_year)


### PR DESCRIPTION
- Sentry error: https://teaching-vacancies.sentry.io/issues/6486426833

This is triggering exceptions on the review page for one of our users who has a nil value on their baptism date.

Not sure if this should be possible. But better to have a validation error upon review than not being able to see the review page at all!

