### PR TITLE
Update how-to-list-non-teaching-roles.md

### DIFF
--- a/app/views/content/get-help-hiring/how-to-create-job-listings-and-accept-applications/how-to-list-non-teaching-roles.md
+++ b/app/views/content/get-help-hiring/how-to-create-job-listings-and-accept-applications/how-to-list-non-teaching-roles.md
@@ -11,7 +11,7 @@ You can use Teaching Vacancies to recruit for all roles in your school or trust.
 
 This includes roles such as a finance director, office support staff, site management and more.
 
-The job listing process is almost exactly the same for teaching and non-teaching roles.
+The job listing process is almost exactly the same for teaching and non-teaching roles. When you advertise a role on Teaching Vacancies, it can also be found on the GOV.UK [Find a job service](https://www.gov.uk/find-a-job).
 
 ## Listing a non-teaching role
   1. Select ‘create a job listing’ and choose whether your role is in teaching and leadership, teaching support, or non-teaching support.

--- a/app/views/content/get-help-hiring/how-to-create-job-listings-and-accept-applications/how-to-list-non-teaching-roles.md
+++ b/app/views/content/get-help-hiring/how-to-create-job-listings-and-accept-applications/how-to-list-non-teaching-roles.md
@@ -11,7 +11,7 @@ You can use Teaching Vacancies to recruit for all roles in your school or trust.
 
 This includes roles such as a finance director, office support staff, site management and more.
 
-The job listing process is almost exactly the same for teaching and non-teaching roles. When you advertise a role on Teaching Vacancies, it can also be found on the GOV.UK [Find a job service](https://www.gov.uk/find-a-job).
+The job listing process is almost exactly the same for teaching and non-teaching roles. When you publish a role on Teaching Vacancies, it can also be found on the GOV.UK [Find a job service](https://www.gov.uk/find-a-job).
 
 ## Listing a non-teaching role
   1. Select ‘create a job listing’ and choose whether your role is in teaching and leadership, teaching support, or non-teaching support.


### PR DESCRIPTION
Added a line in the third paragraph - 'When you advertise a role on Teaching Vacancies, it can also be found on the GOV.UK [Find a job] service(https://www.gov.uk/find-a-job)'. 

This is to let users know jobs are being pushed to the Find a job service to pair with the same information on the 'Create the perfect teacher job advert' hiring guide.

## Trello card URL
https://trello.com/c/Oy1MDGvq/1607-add-content-to-advise-hiring-staff-that-jobs-are-pushed-to-dwp

## Changes in this PR:

- Is there anything specific you want feedback on?

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
