### PR TITLE
Update content on new feature reminder page.

### DIFF
--- a/app/views/publishers/new_features/reminder.html.slim
+++ b/app/views/publishers/new_features/reminder.html.slim
@@ -9,7 +9,8 @@
     p.govuk-body
       = t(".content")
     p.govuk-body
+      / govuk_link_to(t("app.opens_in_new_tab", link_text: text), href, target: "_blank", rel: "noreferrer noopener", **)
+      = govuk_link_to(t(".how_applications_work_link"), post_path(section: "get-help-hiring", subcategory: "how-to-create-job-listings-and-accept-applications", post_name: "accepting-job-applications-on-teaching-vacancies"), class: "govuk-body", target: "_blank", rel: "noreferrer noopener")
+    p.govuk-body
       = t(".find_a_job_service_info", link: open_in_new_tab_link_to(t(".link_text"), "https://www.gov.uk/find-a-job")).html_safe
-
-    = open_in_new_tab_link_to(t(".how_applications_work_link"), post_path(section: "get-help-hiring", subcategory: "how-to-create-job-listings-and-accept-applications", post_name: "accepting-job-applications-on-teaching-vacancies"), class: "govuk-body")
     = govuk_button_to t("buttons.reminder_continue"), organisation_jobs_path, class: "govuk-!-margin-top-8"

--- a/app/views/publishers/new_features/reminder.html.slim
+++ b/app/views/publishers/new_features/reminder.html.slim
@@ -8,5 +8,8 @@
       = t(".page_title")
     p.govuk-body
       = t(".content")
+    p.govuk-body
+      = t(".find_a_job_service_info", link: open_in_new_tab_link_to(t(".link_text"), "https://www.gov.uk/find-a-job")).html_safe
+
     = open_in_new_tab_link_to(t(".how_applications_work_link"), post_path(section: "get-help-hiring", subcategory: "how-to-create-job-listings-and-accept-applications", post_name: "accepting-job-applications-on-teaching-vacancies"), class: "govuk-body")
     = govuk_button_to t("buttons.reminder_continue"), organisation_jobs_path, class: "govuk-!-margin-top-8"

--- a/app/views/publishers/new_features/reminder.html.slim
+++ b/app/views/publishers/new_features/reminder.html.slim
@@ -9,7 +9,6 @@
     p.govuk-body
       = t(".content")
     p.govuk-body
-      / govuk_link_to(t("app.opens_in_new_tab", link_text: text), href, target: "_blank", rel: "noreferrer noopener", **)
       = govuk_link_to(t(".how_applications_work_link"), post_path(section: "get-help-hiring", subcategory: "how-to-create-job-listings-and-accept-applications", post_name: "accepting-job-applications-on-teaching-vacancies"), class: "govuk-body", target: "_blank", rel: "noreferrer noopener")
     p.govuk-body
       = t(".find_a_job_service_info", link: open_in_new_tab_link_to(t(".link_text"), "https://www.gov.uk/find-a-job")).html_safe

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -145,7 +145,7 @@ en:
       reminder:
         content: You can now receive and manage job applications for all roles on Teaching Vacancies, including education support roles.
         find_a_job_service_info: When you publish jobs on Teaching Vacancies, they can also be found on the %{link}.
-        how_applications_work_link: How applications work on Teaching Vacancies
+        how_applications_work_link: How applications work on Teaching Vacancies (opens in new tab).
         page_title: A reminder about applications
         link_text: GOV.UK Find a job service
     notifications:

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -144,9 +144,10 @@ en:
     new_features:
       reminder:
         content: You can now receive and manage job applications for all roles on Teaching Vacancies, including education support roles.
+        find_a_job_service_info: When you publish jobs on Teaching Vacancies, they can also be found on the %{link}.
         how_applications_work_link: How applications work on Teaching Vacancies
         page_title: A reminder about applications
-
+        link_text: GOV.UK Find a job service
     notifications:
       index:
         heading: Notifications


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/u75EIAso/1750-add-line-to-create-a-new-job-listing-reminder-screen-to-advise-jobs-are-pushed-to-find-a-job-service

## Changes in this PR:

Update content on new feature reminder page

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
