### PR TITLE
Relax Sentry parameter filtering

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,7 +1,13 @@
 Sentry.init do |config|
   filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters - %i[id])
   config.before_send = lambda do |event, _hint|
-    filter.filter(event.to_hash)
+    # Only filter user-provided data, not system metadata
+    if event.request
+      event.request.data = filter.filter(event.request.data)
+    end
+
+    # Don't filter server_name and other metadata
+    event
   end
 
   config.breadcrumbs_logger = %i[active_support_logger http_logger]


### PR DESCRIPTION
Currently a good part of the metadata information in Sentry is being "filtered". This makes difficult to trace and debug the info on the sentry exceptions. 

It is especially hard to identify particular review apps triggering errors. 


We are relaxing this filtering by only applying it to the actual request data sent by the user.

## Before

![image](https://github.com/user-attachments/assets/6b47c08b-0774-4636-8116-a4529b6e3f16)
![image](https://github.com/user-attachments/assets/4d015c6e-7a3b-4ee5-a474-97c3cb35b84f)

## After
![image](https://github.com/user-attachments/assets/15acd825-7817-4250-a367-151ae5aaa5a7)
![image](https://github.com/user-attachments/assets/e763b5fc-3cc3-41bf-9f00-dbf7c0bc7b81)


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
