### PR TITLE
No longer use a tag for the "Completed" status, instead just show text

### DIFF
--- a/app/helpers/status_tag_helper.rb
+++ b/app/helpers/status_tag_helper.rb
@@ -12,7 +12,7 @@ module StatusTagHelper
   private
 
   def complete
-    govuk_tag(text: t("shared.status_tags.complete"), colour: "green")
+    { text: t("shared.status_tags.complete") }
   end
 
   def incomplete

--- a/spec/helpers/status_tag_helper_spec.rb
+++ b/spec/helpers/status_tag_helper_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe StatusTagHelper do
       context "when the step has been completed" do
         let(:step) { :personal_details }
 
-        it "returns 'complete' tag" do
-          expect(subject).to eq(helper.govuk_tag(text: I18n.t("shared.status_tags.complete"), colour: "green"))
+        it "returns 'complete' text with no tag" do
+          expect(subject).to eq({ text: I18n.t("shared.status_tags.complete") })
         end
       end
 

--- a/spec/system/jobseekers/prefilling_applications_spec.rb
+++ b/spec/system/jobseekers/prefilling_applications_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "Jobseekers can prefill applications" do
         expect(page).to have_content(previous_application.personal_statement)
         click_on "Save and continue"
         within("#personal_statement") do
-          expect(page).to have_css("strong.govuk-tag.govuk-tag--green", text: I18n.t("shared.status_tags.complete"))
+          expect(page).to have_css(".govuk-task-list__status", text: I18n.t("shared.status_tags.complete"))
         end
 
         # qualified teacher status


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/YIw0YjY5/1715-update-application-tag-colouring-on-task-list

## Changes in this PR:

This change removes the govuk-tag for sections with the status of completed so that no tag is shown, and users only see the black text on white background as requested in the ticket.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
