### PR TITLE
Awaiting feedback link

### DIFF
--- a/app/components/dashboard_component.rb
+++ b/app/components/dashboard_component.rb
@@ -63,7 +63,7 @@ class DashboardComponent < ApplicationComponent
   end
 
   def selected_scope
-    return "recently_awaiting_feedback" if @selected_type == "awaiting_feedback"
+    return "awaiting_feedback_recently_expired" if @selected_type == "awaiting_feedback"
 
     @selected_type == "published" ? "live" : selected_type
   end

--- a/app/components/dashboard_component.rb
+++ b/app/components/dashboard_component.rb
@@ -63,9 +63,11 @@ class DashboardComponent < ApplicationComponent
   end
 
   def selected_scope
-    return "awaiting_feedback_recently_expired" if @selected_type == "awaiting_feedback"
-
-    @selected_type == "published" ? "live" : selected_type
+    case @selected_type
+    when "awaiting_feedback" then "awaiting_feedback_recently_expired"
+    when "published" then "live"
+    else selected_type
+    end
   end
 
   def set_organisation_options

--- a/app/components/dashboard_component.rb
+++ b/app/components/dashboard_component.rb
@@ -63,6 +63,8 @@ class DashboardComponent < ApplicationComponent
   end
 
   def selected_scope
+    return "recently_awaiting_feedback" if @selected_type == "awaiting_feedback"
+
     @selected_type == "published" ? "live" : selected_type
   end
 

--- a/app/components/dashboard_component/dashboard_component.html.slim
+++ b/app/components/dashboard_component/dashboard_component.html.slim
@@ -108,6 +108,7 @@
                   dl
                     dt = "#{t('jobs.manage.expired.expired_on')}:"
                     dd = format_time_to_datetime_at(vacancy.expires_at)
+                  = govuk_link_to("Give feedback about this role", new_organisation_job_expired_feedback_path(job_id: vacancy.id))
                 - when "draft"
                   dl
                     dt = "#{t('jobs.manage.draft.time_created')}:"

--- a/app/components/dashboard_component/dashboard_component.html.slim
+++ b/app/components/dashboard_component/dashboard_component.html.slim
@@ -108,7 +108,7 @@
                   dl
                     dt = "#{t('jobs.manage.expired.expired_on')}:"
                     dd = format_time_to_datetime_at(vacancy.expires_at)
-                  = govuk_link_to("Give feedback about this role", new_organisation_job_expired_feedback_path(job_id: vacancy.id))
+                  = govuk_link_to(t("publishers.vacancies.show.heading_component.action.give_feedback"), new_organisation_job_expired_feedback_path(job_id: vacancy.id))
                 - when "draft"
                   dl
                     dt = "#{t('jobs.manage.draft.time_created')}:"

--- a/app/controllers/publishers/vacancies/expired_feedbacks_controller.rb
+++ b/app/controllers/publishers/vacancies/expired_feedbacks_controller.rb
@@ -26,6 +26,15 @@ class Publishers::Vacancies::ExpiredFeedbacksController < Publishers::Vacancies:
   end
 
   def vacancy
-    @vacancy ||= Vacancy.find_signed(params[:job_id])
+    return @vacancy if defined?(@vacancy)
+
+    signed_vacancy = Vacancy.find_signed(params[:job_id])
+
+    if signed_vacancy
+      @vacancy = signed_vacancy
+    else
+      authenticate_scope!
+      @vacancy = Vacancy.find(params[:job_id])
+    end
   end
 end

--- a/app/helpers/vacancy_forms_helper.rb
+++ b/app/helpers/vacancy_forms_helper.rb
@@ -70,7 +70,7 @@ module VacancyFormsHelper
     when "schedule_complete_draft"
       govuk_button_link_to(t("publishers.vacancies.show.heading_component.action.scheduled_complete_draft"), organisation_job_publish_path(vacancy.id), class: "govuk-!-margin-bottom-0")
     when "give_feedback"
-      govuk_link_to("Give feedback about this role", new_organisation_job_expired_feedback_path(job_id: vacancy.id))
+      govuk_link_to(t("publishers.vacancies.show.heading_component.action.give_feedback"), new_organisation_job_expired_feedback_path(job_id: vacancy.id))
     end
   end
 

--- a/app/helpers/vacancy_forms_helper.rb
+++ b/app/helpers/vacancy_forms_helper.rb
@@ -69,6 +69,8 @@ module VacancyFormsHelper
       govuk_link_to(t("publishers.vacancies.show.heading_component.action.convert_to_draft"), organisation_job_convert_to_draft_path(vacancy.id), class: "govuk-!-margin-bottom-0")
     when "schedule_complete_draft"
       govuk_button_link_to(t("publishers.vacancies.show.heading_component.action.scheduled_complete_draft"), organisation_job_publish_path(vacancy.id), class: "govuk-!-margin-bottom-0")
+    when "give_feedback"
+      govuk_link_to("Give feedback about this role", new_organisation_job_expired_feedback_path(job_id: vacancy.id))
     end
   end
 

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -92,7 +92,7 @@ class Vacancy < ApplicationRecord
 
   scope :applicable, -> { where("expires_at >= ?", Time.current) }
   scope :awaiting_feedback, -> { expired.where(listed_elsewhere: nil, hired_status: nil) }
-  scope :recently_awaiting_feedback, -> { awaiting_feedback.where("expires_at >= ?", 2.months.ago) }
+  scope :awaiting_feedback_recently_expired, -> { awaiting_feedback.where("expires_at >= ?", 2.months.ago) }
   scope :expired, -> { published.where("expires_at < ?", Time.current) }
   scope :expired_yesterday, -> { where("DATE(expires_at) = ?", 1.day.ago.to_date) }
   scope :expires_within_data_access_period, -> { where("expires_at >= ?", Time.current - DATA_ACCESS_PERIOD_FOR_PUBLISHERS) }

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -92,6 +92,7 @@ class Vacancy < ApplicationRecord
 
   scope :applicable, -> { where("expires_at >= ?", Time.current) }
   scope :awaiting_feedback, -> { expired.where(listed_elsewhere: nil, hired_status: nil) }
+  scope :recently_awaiting_feedback, -> { awaiting_feedback.where("expires_at >= ?", 2.months.ago) }
   scope :expired, -> { published.where("expires_at < ?", Time.current) }
   scope :expired_yesterday, -> { where("DATE(expires_at) = ?", 1.day.ago.to_date) }
   scope :expires_within_data_access_period, -> { where("expires_at >= ?", Time.current - DATA_ACCESS_PERIOD_FOR_PUBLISHERS) }

--- a/app/views/publishers/vacancies/review_banners/_closed.html.slim
+++ b/app/views/publishers/vacancies/review_banners/_closed.html.slim
@@ -4,5 +4,5 @@ h1.govuk-heading-l class="govuk-!-display-inline"
 = govuk_inset_text do
   = vacancy_review_form_heading_inset_text(vacancy, "closed")
   .govuk-button-group class="govuk-!-margin-top-4"
-    - %w[view copy relist].each do |action|
+    - %w[view copy relist give_feedback].each do |action|
       = vacancy_review_form_heading_action_link(vacancy, action) unless vacancy.legacy? && action == "relist"

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -664,6 +664,7 @@ en:
             publish: Publish job listing
             scheduled_complete_draft: Schedule job listing
             view: View
+            give_feedback: Give feedback about this role
           inset_text:
             complete_draft: This job listing is complete and needs to be published.
             closed: This job listing was published on %{publish_date}. It closed on %{expiry_time}.

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -291,7 +291,7 @@ RSpec.describe Vacancy do
       it "includes only vacancies that expired within the last 2 months and are awaiting feedback" do
         recent_expired_and_awaiting_feedback = create(:vacancy, :expired, expires_at: 1.month.ago)
         old_expired_and_awaiting_feedback = create(:vacancy, :expired, expires_at: 3.months.ago)
-        recent_expired_and_not_awaiting_feedback  = create(:vacancy, :expired, expires_at: 1.month.ago, listed_elsewhere: :listed_paid)
+        recent_expired_and_not_awaiting_feedback = create(:vacancy, :expired, expires_at: 1.month.ago, listed_elsewhere: :listed_paid)
 
         results = Vacancy.awaiting_feedback_recently_expired
 

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -286,6 +286,20 @@ RSpec.describe Vacancy do
         expect(Vacancy.published_on_count(1.month.ago)).to eq(published_some_other_day.count)
       end
     end
+
+    describe "#awaiting_feedback_recently_expired" do
+      it "includes only vacancies that expired within the last 2 months and are awaiting feedback" do
+        recent_expired_and_awaiting_feedback = create(:vacancy, :expired, expires_at: 1.month.ago)
+        old_expired_and_awaiting_feedback = create(:vacancy, :expired, expires_at: 3.months.ago)
+        recent_expired_and_not_awaiting_feedback  = create(:vacancy, :expired, expires_at: 1.month.ago, listed_elsewhere: :listed_paid)
+
+        results = Vacancy.awaiting_feedback_recently_expired
+
+        expect(results).to include(recent_expired_and_awaiting_feedback)
+        expect(results).not_to include(old_expired_and_awaiting_feedback)
+        expect(results).not_to include(recent_expired_and_not_awaiting_feedback)
+      end
+    end
   end
 
   describe "#organisation_name" do

--- a/spec/requests/publishers/vacancies/expired_feedbacks_spec.rb
+++ b/spec/requests/publishers/vacancies/expired_feedbacks_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe "Publishers::Vacancies::ExpiredFeedbacksController" do
+  describe "POST /organisation/jobs/:job_id/expired-feedback" do
+    let(:valid_publisher) { create(:publisher, :with_organisation) }
+    let(:invalid_publisher) { create(:publisher, :with_organisation) }
+    let(:vacancy) { create(:vacancy, publisher: valid_publisher) }
+    let(:valid_params) do
+      {
+        publishers_job_listing_expired_feedback_form: {
+          hired_status: "hired_other_free",
+          listed_elsewhere: "listed_dont_know",
+        },
+      }
+    end
+
+    context "when making a request without a signed id" do
+      let(:job_id) { vacancy.id.to_s } # use unsigned ID to force fallback
+
+      context  "when a hiring staff user is logged in" do
+        # rubocop:disable RSpec/AnyInstance
+        before do
+          # Stub authenticate_scope! to simulate a logged-in user
+          allow_any_instance_of(Publishers::Vacancies::ExpiredFeedbacksController).to receive(:authenticate_scope!) { vacancy.publisher }
+        end
+        # rubocop:enable RSpec/AnyInstance
+
+        it "finds the vacancy via fallback and updates it" do
+          expect {
+            post "/organisation/jobs/#{job_id}/expired-feedback", params: valid_params
+          }.to change { vacancy.reload.attributes.slice("hired_status", "listed_elsewhere") }
+           .from({ "hired_status" => nil, "listed_elsewhere" => nil })
+           .to({ "hired_status" => "hired_other_free", "listed_elsewhere" => "listed_dont_know" })
+
+          expect(response).to redirect_to(submitted_organisation_job_expired_feedback_path)
+        end
+      end
+
+      context "when a hiring staff user is not logged in" do
+        # Do not stub authenticate_scope! so that Devise authentication is enforced
+        it "does not update vacancy and redirects to the login page" do
+          expect {
+            post "/organisation/jobs/#{job_id}/expired-feedback", params: valid_params
+          }.not_to(change { vacancy.reload.attributes.slice("hired_status", "listed_elsewhere") })
+
+          expect(response).to redirect_to(new_publisher_session_path(redirected: true))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/Q8P4aJkO/1720-making-jobs-awaiting-feedback-more-prominent-trying-to-increase-attribution

## Changes in this PR:

This change adds links to the job listing feedback page from the closed jobs tab.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
