### PR TITLE
Add new headteacher job role mapping to MyNewTerm

### DIFF
--- a/app/services/vacancies/import/sources/my_new_term.rb
+++ b/app/services/vacancies/import/sources/my_new_term.rb
@@ -135,7 +135,7 @@ class Vacancies::Import::Sources::MyNewTerm
       else
         Array.wrap(role.gsub("deputy_headteacher_principal", "deputy_headteacher")
                        .gsub("assistant_headteacher_principal", "assistant_headteacher")
-                       .gsub("headteacher_principal", "headteacher")
+                       .gsub(/headteacher_principal|executive_headteacher/, "headteacher")
                        .gsub(/head_of_year_or_phase|head_of_year/, "head_of_year_or_phase")
                        .gsub(/learning_support|other_support|science_technician/, "other_support")
                        .gsub(/\s+/, ""))

--- a/spec/services/vacancies/import/sources/my_new_term_spec.rb
+++ b/spec/services/vacancies/import/sources/my_new_term_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe Vacancies::Import::Sources::MyNewTerm do
       end
     end
 
-    %w[headteacher_principal headteacher].each do |role|
+    %w[headteacher_principal executive_headteacher headteacher].each do |role|
       context "when the source role is '#{role}'" do
         let(:source_roles) { [role] }
 


### PR DESCRIPTION
Map incoming "executive_headteacher" job role as "headteacher"

Agreed with MyNewTerm team through email communications as they had some vacancies not showing up in our system due to the `executive_headteacher` job role not matching any of ours.