### PR TITLE
schedule AggregateVacancyReferrerStatsJob to run every 15 mins

### DIFF
--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -171,6 +171,6 @@ import_from_vacancy_sources:
   queue: default
 
 aggregate_vacancy_referrer_stats:
-  cron: "15 * * * *"
+  cron: "*/15 * * * *" # Every 15 minutes
   class: AggregateVacancyReferrerStatsJob
   queue: low


### PR DESCRIPTION
## Changes in this PR:

This change fixes the AggregateVacancyReferrerStatsJob to run every 15 mins

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
