### PR TITLE
Fix rake task to allow us to properly migrate "other_teaching_support…

### DIFF
--- a/lib/tasks/update_vacancies_with_other_teaching_support_role.rake
+++ b/lib/tasks/update_vacancies_with_other_teaching_support_role.rake
@@ -1,5 +1,5 @@
 namespace :vacancy do
-  desc "Update job roles from legacy value 10 to new value 16"
+  desc "Update job roles from legacy value 10 (previously 'other_teaching_support') to new value 16 ('other_support')"
   task update_job_roles: :environment do
     vacancies = Vacancy.where("job_roles @> ARRAY[?]::integer[]", [10])
     puts "#{vacancies.count} vacancies with job roles including other_teaching_support"

--- a/lib/tasks/update_vacancies_with_other_teaching_support_role.rake
+++ b/lib/tasks/update_vacancies_with_other_teaching_support_role.rake
@@ -1,12 +1,17 @@
 namespace :vacancy do
-  desc "Update job roles from 'other_teaching_support' (10) to 'other_support' (16)"
+  desc "Update job roles from legacy value 10 to new value 16"
   task update_job_roles: :environment do
     vacancies = Vacancy.where("job_roles @> ARRAY[?]::integer[]", [10])
+    puts "#{vacancies.count} vacancies with job roles including other_teaching_support"
     updated_count = 0
 
     vacancies.find_each do |vacancy|
-      new_roles = vacancy.job_roles.map { |role| role == "other_teaching_support" ? "other_support" : role }.uniq
-      vacancy.update(job_roles: new_roles)
+      raw_roles = vacancy[:job_roles] || []
+      next unless raw_roles.include?(10)
+
+      new_roles = raw_roles.map { |role| role == 10 ? 16 : role }.uniq
+      vacancy.update_column(:job_roles, new_roles)
+      puts "Updated vacancy id #{vacancy.id}"
       updated_count += 1
     end
 

--- a/spec/tasks/update_job_roles_spec.rb
+++ b/spec/tasks/update_job_roles_spec.rb
@@ -2,34 +2,34 @@ require "rails_helper"
 require "rake"
 
 RSpec.describe "vacancy:update_job_roles" do
-  let!(:vacancy1) { create(:vacancy) }
-  let!(:vacancy2) { create(:vacancy) }
-  let!(:vacancy3) { create(:vacancy, job_roles: %w[it_support other_support]) }
+  let!(:vacancy_with_other_teaching_support_role) { create(:vacancy) }
+  let!(:vacancy_with_other_teaching_support_role_and_others) { create(:vacancy) }
+  let!(:vacancy) { create(:vacancy, job_roles: %w[it_support other_support]) }
 
   before do
     # Use `update_column` to manually insert the now-invalid job role `10` into the database.
     # This bypasses enum validation, which would otherwise raise an ArgumentError because `10`has been removed from the JOB_ROLES mapping and is no longer a valid value.
-    vacancy1.update_column(:job_roles, [10])
-    vacancy2.update_column(:job_roles, [0, 1, 10])
+    vacancy_with_other_teaching_support_role.update_column(:job_roles, [10])
+    vacancy_with_other_teaching_support_role_and_others.update_column(:job_roles, [0, 1, 10])
   end
 
   it "updates job_roles from 10 to 16" do
-    vacancy1.reload
+    vacancy_with_other_teaching_support_role.reload
     # ensure update_column worked successfully
-    expect(vacancy1[:job_roles]).to eq([10])
-    expect(vacancy1.job_roles).to eq([nil]) # because 10 is invalid
+    expect(vacancy_with_other_teaching_support_role[:job_roles]).to eq([10])
+    expect(vacancy_with_other_teaching_support_role.job_roles).to eq([nil]) # because 10 is invalid
 
     task.reenable
     task.invoke
 
-    vacancy1.reload
-    expect(vacancy1[:job_roles]).to eq([16])
-    expect(vacancy1.job_roles).to eq(%w[other_support])
-    vacancy2.reload
-    expect(vacancy2[:job_roles]).to eq([0, 1, 16])
-    expect(vacancy2.job_roles).to eq(%w[teacher headteacher other_support])
-    vacancy3.reload
-    expect(vacancy3[:job_roles]).to eq([13, 16])
-    expect(vacancy3.job_roles).to eq(%w[it_support other_support])
+    vacancy_with_other_teaching_support_role.reload
+    expect(vacancy_with_other_teaching_support_role[:job_roles]).to eq([16])
+    expect(vacancy_with_other_teaching_support_role.job_roles).to eq(%w[other_support])
+    vacancy_with_other_teaching_support_role_and_others.reload
+    expect(vacancy_with_other_teaching_support_role_and_others[:job_roles]).to eq([0, 1, 16])
+    expect(vacancy_with_other_teaching_support_role_and_others.job_roles).to eq(%w[teacher headteacher other_support])
+    vacancy.reload
+    expect(vacancy[:job_roles]).to eq([13, 16])
+    expect(vacancy.job_roles).to eq(%w[it_support other_support])
   end
 end

--- a/spec/tasks/update_job_roles_spec.rb
+++ b/spec/tasks/update_job_roles_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "vacancy:update_job_roles" do
+  let!(:vacancy1) { create(:vacancy) }
+  let!(:vacancy2) { create(:vacancy) }
+  let!(:vacancy3) { create(:vacancy, job_roles: %w[it_support other_support]) }
+
+  before do
+    # Use `update_column` to manually insert the now-invalid job role `10` into the database.
+    # This bypasses enum validation, which would otherwise raise an ArgumentError because `10`has been removed from the JOB_ROLES mapping and is no longer a valid value.
+    vacancy1.update_column(:job_roles, [10])
+    vacancy2.update_column(:job_roles, [0, 1, 10])
+  end
+
+  it "updates job_roles from 10 to 16" do
+    vacancy1.reload
+    # ensure update_column worked successfully
+    expect(vacancy1[:job_roles]).to eq([10])
+    expect(vacancy1.job_roles).to eq([nil]) # because 10 is invalid
+
+    task.reenable
+    task.invoke
+
+    vacancy1.reload
+    expect(vacancy1[:job_roles]).to eq([16])
+    expect(vacancy1.job_roles).to eq(%w[other_support])
+    vacancy2.reload
+    expect(vacancy2[:job_roles]).to eq([0, 1, 16])
+    expect(vacancy2.job_roles).to eq(%w[teacher headteacher other_support])
+    vacancy3.reload
+    expect(vacancy3[:job_roles]).to eq([13, 16])
+    expect(vacancy3.job_roles).to eq(%w[it_support other_support])
+  end
+end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/s8gf2is5/1773-translation-error-on-hiring-staff-view-of-candidate-profiles

## Changes in this PR:

Prior to this change we were seeing some translation errors on vacancy adverts that had "other_teaching_support" included in their job_roles. This was due to all references to other_teaching_support roles being deleted, including from the job_roles enum, in a prior PR. This PR had a rake task to migrate "other_teaching_support" role to "other_support" but it looks like it did not run successfully due to attempting to run it after removing "other_teaching_support" from the job_roles enum.

This change fixes this rake task to work even with the job_roles enum not allowing "other_teaching_support" as a job_role.

Note: after deploying and running this rake task we can delete the rake task and associated test as it will no longer be needed.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
