### PR TITLE
Migrate now defunct job preferences role "other_teaching_support" to "other_support"

### DIFF
--- a/lib/tasks/update_job_preferences_roles.rake
+++ b/lib/tasks/update_job_preferences_roles.rake
@@ -11,7 +11,8 @@ namespace :job_preferences do
         role == "other_teaching_support" ? "other_support" : role
       }.uniq
 
-      pref.update!(roles: new_roles)
+      pref.assign_attributes(roles: new_roles)
+      pref.save!(touch: false)
       puts "Updated JobPreferences id: #{pref.id}"
       updated_count += 1
     end

--- a/lib/tasks/update_job_preferences_roles.rake
+++ b/lib/tasks/update_job_preferences_roles.rake
@@ -7,8 +7,6 @@ namespace :job_preferences do
     puts "#{job_prefs.count} JobPreferences to update"
 
     job_prefs.find_each do |pref|
-      next unless pref.roles.include?("other_teaching_support")
-
       new_roles = pref.roles.map { |role|
         role == "other_teaching_support" ? "other_support" : role
       }.uniq

--- a/lib/tasks/update_job_preferences_roles.rake
+++ b/lib/tasks/update_job_preferences_roles.rake
@@ -1,0 +1,23 @@
+namespace :job_preferences do
+  desc "Replace 'other_teaching_support' with 'other_support' in job_preferences.roles"
+  task update_roles: :environment do
+    job_prefs = JobPreferences.where("'other_teaching_support' = ANY(roles)")
+    updated_count = 0
+
+    puts "#{job_prefs.count} JobPreferences to update"
+
+    job_prefs.find_each do |pref|
+      next unless pref.roles.include?("other_teaching_support")
+
+      new_roles = pref.roles.map { |role|
+        role == "other_teaching_support" ? "other_support" : role
+      }.uniq
+
+      pref.update!(roles: new_roles)
+      puts "Updated JobPreferences id: #{pref.id}"
+      updated_count += 1
+    end
+
+    puts "#{updated_count} JobPreferences records updated."
+  end
+end

--- a/spec/tasks/update_job_preferences_roles_spec.rb
+++ b/spec/tasks/update_job_preferences_roles_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "job_preferences:update_roles" do
+  let!(:with_only_legacy_role) do
+    create(:job_preferences, roles: %w[other_teaching_support])
+  end
+
+  let!(:with_mixed_roles) do
+    create(:job_preferences, roles: %w[teacher other_teaching_support])
+  end
+
+  let!(:already_correct) do
+    create(:job_preferences, roles: %w[other_support it_support])
+  end
+
+  it "replaces 'other_teaching_support' with 'other_support' in roles" do
+    task.reenable
+    task.invoke
+
+    with_only_legacy_role.reload
+    expect(with_only_legacy_role.roles).to eq(%w[other_support])
+
+    with_mixed_roles.reload
+    expect(with_mixed_roles.roles).to match_array(%w[teacher other_support])
+    expect(with_mixed_roles.roles).not_to include("other_teaching_support")
+
+    already_correct.reload
+    expect(already_correct.roles).to match_array(%w[other_support it_support])
+  end
+end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/s8gf2is5/1773-translation-error-on-hiring-staff-view-of-candidate-profiles

## Changes in this PR:

This PR adds a rake task to migrate the "other_teaching_support" role in existing jobseeker job preferences to "other_support" as we no longer support the "other_teaching_support" role.

Note: we removed the ability for jobseeker to add this role to their job preferences a while ago but missed migrating the 792 existing job preferences that contain this role.

## Screenshots of UI changes:

### Before running rake task
![Screenshot 2025-04-25 at 09 56 39](https://github.com/user-attachments/assets/e05ad8b9-c292-44da-a2d3-0b9af4e13a1b)

### After running rake task
![Screenshot 2025-04-25 at 09 58 25](https://github.com/user-attachments/assets/3457a12f-4f6f-4150-8baf-1d9350563ad4)


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
