### PR TITLE
Make fields optional for training and cpd

### DIFF
--- a/app/form_models/jobseekers/training_and_cpd_form.rb
+++ b/app/form_models/jobseekers/training_and_cpd_form.rb
@@ -3,5 +3,5 @@ class Jobseekers::TrainingAndCpdForm
 
   attr_accessor :name, :provider, :grade, :year_awarded, :course_length
 
-  validates :name, :provider, :year_awarded, :course_length, presence: true
+  validates :name, :year_awarded, presence: true
 end

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -421,11 +421,11 @@ en:
         institution: School, college, or other organisation
       jobseekers_training_and_cpd_form:
         name: Name of course or training
-        provider: Training provider
+        provider: Training provider (optional)
         grade: Grade (optional)
         year_awarded: Date completed
         year_completed_hint: For example, 1998
-        course_length: Course length
+        course_length: Course length (optional)
       jobseekers_sign_in_form:
         email: Email address
         password: Password

--- a/spec/form_models/jobseekers/training_and_cpd_form_spec.rb
+++ b/spec/form_models/jobseekers/training_and_cpd_form_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Jobseekers::TrainingAndCpdForm, type: :model do
   it { is_expected.to validate_presence_of(:name) }
-  it { is_expected.to validate_presence_of(:provider) }
+  it { is_expected.not_to validate_presence_of(:provider) }
   it { is_expected.to validate_presence_of(:year_awarded) }
-  it { is_expected.to validate_presence_of(:course_length) }
+  it { is_expected.not_to validate_presence_of(:course_length) }
 end

--- a/spec/system/jobseekers/jobseeker_can_add_training_and_cpds_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseeker_can_add_training_and_cpds_to_their_job_application_spec.rb
@@ -19,9 +19,7 @@ RSpec.describe "Jobseeker can add training and cpds to their job application" do
       expect(page).to have_css("h2.govuk-error-summary__title", text: "There is a problem")
       within(".govuk-error-summary__body") do
         expect(page).to have_link("Enter the name of the course or training", href: "#jobseekers-training-and-cpd-form-name-field-error")
-        expect(page).to have_link("Enter the name of the provider of the training", href: "#jobseekers-training-and-cpd-form-provider-field-error")
         expect(page).to have_link("Enter the year the course or training was awarded", href: "#jobseekers-training-and-cpd-form-year-awarded-field-error")
-        expect(page).to have_link("Enter the length of the course", href: "#jobseekers-training-and-cpd-form-course-length-field-error")
       end
 
       fill_in_and_submit_training_form("Rock climbing instructional course", "Training org", "A", "2024", "6 months")

--- a/spec/system/jobseekers/jobseekers_can_add_training_to_their_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_training_to_their_profile_spec.rb
@@ -21,9 +21,7 @@ RSpec.describe "Jobseekers can add training to their profile" do
         expect(page).to have_css("h2.govuk-error-summary__title", text: "There is a problem")
         within(".govuk-error-summary__body") do
           expect(page).to have_link("Enter the name of the course or training", href: "#jobseekers-training-and-cpd-form-name-field-error")
-          expect(page).to have_link("Enter the name of the provider of the training", href: "#jobseekers-training-and-cpd-form-provider-field-error")
           expect(page).to have_link("Enter the year the course or training was awarded", href: "#jobseekers-training-and-cpd-form-year-awarded-field-error")
-          expect(page).to have_link("Enter the length of the course", href: "#jobseekers-training-and-cpd-form-course-length-field-error")
         end
 
         fill_in_and_submit_training_form("Rock climbing instructional course", "TeachTrain ltd", "A", "2024", "6 months")


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/knHHUQP4/1795-make-training-provider-and-course-length-optional-on-cpd

## Changes in this PR:

Make training provider and course length optional for training and cpds on profile and applications

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
