### PR TITLE
Do not attempt to send alerts to subscriptions which do not have email addresses

### DIFF
--- a/app/jobs/alert_email/base.rb
+++ b/app/jobs/alert_email/base.rb
@@ -12,7 +12,7 @@ class AlertEmail::Base < ApplicationJob
 
     subscriptions.find_each.reject { |sub| already_run_ids.include?(sub.id) }.each do |subscription|
       vacancies = subscription.vacancies_matching(default_scope).first(MAXIMUM_RESULTS_PER_RUN)
-
+      next if subscription.reload.email.blank?
       Jobseekers::AlertMailer.alert(subscription.id, vacancies.pluck(:id)).deliver_later if vacancies.any?
     end
     Sentry.capture_message("#{self.class.name} run successfully", level: :info)

--- a/spec/jobs/send_daily_alert_email_job_spec.rb
+++ b/spec/jobs/send_daily_alert_email_job_spec.rb
@@ -19,6 +19,16 @@ RSpec.describe SendDailyAlertEmailJob do
         perform_enqueued_jobs { job }
       end
 
+      context "when subscription does not have an email address" do
+        before do
+          subscription.update!(email: nil)
+        end
+        
+        it "does not send an email" do
+          expect(Jobseekers::AlertMailer).to_not receive(:alert).with(subscription.id, Vacancy.pluck(:id)) { mail }
+        end
+      end
+
       context "when a run exists" do
         before do
           create(:alert_run, subscription: subscription, run_on: Date.current)


### PR DESCRIPTION
## Changes in this PR:

This change is an attempt to fix[ this sentry error](https://teaching-vacancies.sentry.io/issues/6537134720/?environment=production&project=6212514&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=8) which seems to occur when we try to send job alert emails to subscriptions that do have email_address set to nil. Subscriptions can have email_address: nil when a user unsubscribes. I think we see this error when a user unsubscribes after the SendDailyAlertEmailJob has started, but before the job alert has been sent. This change reloads the subscription and checks that it has an email address before attempting to send the email.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
