### PR TITLE
Discard soft deletes phase 2

### DIFF
--- a/app/controllers/api/vacancies_controller.rb
+++ b/app/controllers/api/vacancies_controller.rb
@@ -11,14 +11,14 @@ class Api::VacanciesController < Api::ApplicationController
   end
 
   def show
-    vacancy = Vacancy.kept.listed.friendly.find(params[:id])
+    vacancy = Vacancy.listed.friendly.find(params[:id])
     @vacancy = VacancyPresenter.new(vacancy)
   end
 
   private
 
   def vacancies
-    Vacancy.includes(:organisations).kept.live.order(publish_on: :desc)
+    Vacancy.includes(:organisations).live.order(publish_on: :desc)
   end
 
   def trigger_api_queried_event(event_data = {})

--- a/app/controllers/publishers/ats_api/v1/vacancies_controller.rb
+++ b/app/controllers/publishers/ats_api/v1/vacancies_controller.rb
@@ -47,7 +47,7 @@ class Publishers::AtsApi::V1::VacanciesController < Api::ApplicationController
   private
 
   def set_vacancy
-    @vacancy = Vacancy.kept.published.find_by!(publisher_ats_api_client: client, id: params[:id])
+    @vacancy = Vacancy.non_draft.find_by!(publisher_ats_api_client: client, id: params[:id])
   end
 
   def required_vacancy_keys
@@ -101,10 +101,9 @@ class Publishers::AtsApi::V1::VacanciesController < Api::ApplicationController
   def vacancies
     Vacancy
       .includes(:organisations)
-      .kept
+      .non_draft
       .order(publish_on: :desc)
       .where(publisher_ats_api_client: client)
-      .where.not(status: Vacancy.statuses[:trashed])
   end
 
   def client

--- a/app/controllers/publishers/vacancies/extend_deadline_controller.rb
+++ b/app/controllers/publishers/vacancies/extend_deadline_controller.rb
@@ -31,6 +31,6 @@ class Publishers::Vacancies::ExtendDeadlineController < Publishers::Vacancies::B
   end
 
   def vacancy
-    @vacancy ||= current_organisation.all_vacancies.published.listed.find(params[:job_id])
+    @vacancy ||= current_organisation.all_vacancies.listed.find(params[:job_id])
   end
 end

--- a/app/controllers/publishers/vacancies/feedbacks_controller.rb
+++ b/app/controllers/publishers/vacancies/feedbacks_controller.rb
@@ -1,6 +1,6 @@
 class Publishers::Vacancies::FeedbacksController < Publishers::Vacancies::BaseController
   def create
-    @vacancy = VacancyPresenter.new(Vacancy.published.find(params[:job_id]))
+    @vacancy = VacancyPresenter.new(Vacancy.non_draft.find(params[:job_id]))
     @feedback_form = Publishers::JobListing::FeedbackForm.new(feedback_form_params)
 
     if @feedback_form.valid?

--- a/app/controllers/publishers/vacancies_controller.rb
+++ b/app/controllers/publishers/vacancies_controller.rb
@@ -99,7 +99,7 @@ class Publishers::VacanciesController < Publishers::Vacancies::BaseController
   def show_application_feature_reminder_page?
     return false if session[:visited_application_feature_reminder_page] || session[:visited_new_features_page]
 
-    Vacancy.published.where(
+    Vacancy.non_draft.where(
       publisher_id: current_publisher.id,
       enable_job_applications: true,
       created_at: Publishers::NewFeaturesController::NEW_FEATURES_PAGE_UPDATED_AT..,

--- a/app/jobs/index_newly_published_vacancies_job.rb
+++ b/app/jobs/index_newly_published_vacancies_job.rb
@@ -3,7 +3,7 @@ class IndexNewlyPublishedVacanciesJob < ApplicationJob
 
   # This job is to ensure vacancies that were created/updated before their published at date get indexed once they are published.
   def perform
-    Vacancy.published.where(publish_on: Time.zone.today).find_each do |vacancy|
+    Vacancy.non_draft.where(publish_on: Time.zone.today).find_each do |vacancy|
       UpdateGoogleIndexQueueJob.perform_later(Rails.application.routes.url_helpers.job_url(vacancy))
     end
   end

--- a/app/services/search/vacancy_search.rb
+++ b/app/services/search/vacancy_search.rb
@@ -11,8 +11,8 @@ class Search::VacancySearch
     @radius = search_criteria[:radius]
     @organisation_slug = search_criteria[:organisation_slug]
     @sort = sort || Search::VacancySort.new(keyword: keyword, location: location)
-    @original_scope = scope.kept.where(scope.where_values_hash)
-    @scope = scope.kept
+    @original_scope = scope.where(scope.where_values_hash)
+    @scope = scope
   end
 
   def active_criteria

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,13 +1,4 @@
 namespace :db do # rubocop:disable Metrics/BlockLength
-  desc "Set job role and ect_status from old job_roles field"
-  task set_new_job_role_and_ect_status: :environment do
-    main_job_roles = [0, 1, 4, 5, 6, 7]
-    Vacancy.published.find_each do |v|
-      v.update_columns job_role: v.job_roles&.find { |r| r.in? main_job_roles } || 0,
-                       ect_status: v.job_roles&.include?(3) ? :ect_suitable : :ect_unsuitable
-    end
-  end
-
   desc "Asynchronously import organisations from GIAS and seed the database"
   task async_seed: :environment do
     SeedDatabaseJob.perform_later
@@ -15,7 +6,7 @@ namespace :db do # rubocop:disable Metrics/BlockLength
 
   desc "Reset markers"
   task reset_markers: :environment do
-    Vacancy.published.applicable.find_each(&:reset_markers)
+    Vacancy.non_draft.applicable.find_each(&:reset_markers)
   end
 
   desc "Generates 1000 random vacancies for testing purposes"

--- a/spec/requests/publishers/ats_api/v1/vacancies_spec.rb
+++ b/spec/requests/publishers/ats_api/v1/vacancies_spec.rb
@@ -1098,7 +1098,7 @@ RSpec.describe "ats-api/v1/vacancies", openapi_spec: "v1/swagger.yaml" do
 
       response(204, "Indicates the vacancy was removed from the system.") do
         it "removes the vaancy" do |example|
-          expect { submit_request(example.metadata) }.to change(Vacancy.kept.live.where(publisher_ats_api_client: client), :count).from(1).to(0)
+          expect { submit_request(example.metadata) }.to change(Vacancy.live.where(publisher_ats_api_client: client), :count).from(1).to(0)
           assert_response_matches_metadata(example.metadata)
           expect(response.parsed_body).to be_empty
         end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/arZfP3fr/1803-draftvacancy-step-1-remove-the-soft-deletion-from-the-vacancy-status-list

## Changes in this PR:

Use the discard gem to allow consistent soft-deletes.