### PR TITLE
[SPIKE] Job Application Tab nav

### DIFF
--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -91,6 +91,17 @@ class JobApplication < ApplicationRecord
 
   has_one_attached :baptism_certificate, service: :amazon_s3_documents
 
+  def self.group_by_status(scope = all)
+    result = statuses.each_with_object({}) do |(status_name, status_idx), hsh|
+      hsh[status_name.to_sym] = scope.where(status: status_idx)
+    end
+
+    result[:all] = scope
+    result[:new] = scope.where(status: %i[submitted reviewed])
+
+    result
+  end
+
   def name
     "#{first_name} #{last_name}"
   end

--- a/app/views/publishers/vacancies/job_applications/_candidates.html.slim
+++ b/app/views/publishers/vacancies/job_applications/_candidates.html.slim
@@ -1,10 +1,13 @@
 = form_with(model: form, url: tag_organisation_job_job_applications_path(vacancy.id), method: :get, scope: :publishers_job_application_tag_form) do |f|
 
   = f.govuk_error_summary
+  - if flash[origin]
+    = govuk_notification_banner title_text: "Error", success: false, classes: ["govuk-error-colour"] do |notification_banner|
+      - notification_banner.with_heading(text: flash[origin])
 
   = f.govuk_check_boxes_fieldset :job_applications, legend: { text: heading } do
+    = hidden_field_tag("publishers_job_application_tag_form[origin]", origin)
     = govuk_table(html_attributes: { data: { module: "moj-multi-select", multi_select_checkbox: "#multi_select_#{multi_select}", multi_select_idprefix: "id_all_#{multi_select}" } }) do |table|
-
       - table.with_head do |head|
         - head.with_row do |row|
           - row.with_cell(html_attributes: { id: "multi_select_#{multi_select}" })

--- a/app/views/publishers/vacancies/job_applications/index.html.slim
+++ b/app/views/publishers/vacancies/job_applications/index.html.slim
@@ -5,35 +5,30 @@
 .govuk-grid-row
   .govuk-grid-column-full
     - if vacancy.within_data_access_period?
-      - applications = job_applications.group_by(&:status)
-      - new_ones = applications.fetch("submitted", []) + applications.fetch("reviewed", [])
-      - rejected = applications.fetch("unsuccessful", [])
-      - shortlisted = applications.fetch("shortlisted", [])
-      - interviewing = applications.fetch("interviewing", [])
       = govuk_tabs do |tabs|
-        - tabs.with_tab(label: "All (#{job_applications.size})") do
+        - tabs.with_tab(label: "All (#{job_application_by_status[:all].count})") do
           - if job_applications.any?
-            = render "candidates", form: @form, vacancy: vacancy, candidates: job_applications, heading: "All Applications", multi_select: "all"
+            = render "candidates", form: @form, vacancy: vacancy, candidates: job_applications, heading: "All Applications", multi_select: "all", origin: :all
           - else
             = render EmptySectionComponent.new title: t(".no_applicants")
-        - tabs.with_tab(label: "New (#{new_ones.size})")
-          - if new_ones.any?
-            = render "candidates", form: @form, vacancy: vacancy, candidates: new_ones, heading: "New Applications", multi_select: "new"
+        - tabs.with_tab(label: "New (#{job_application_by_status[:new].count})")
+          - if job_application_by_status[:new].exists?
+            = render "candidates", form: @form, vacancy: vacancy, candidates: job_application_by_status[:new], heading: "New Applications", multi_select: "new", origin: :new
           - else
             = render EmptySectionComponent.new title: t(".no_new")
-        - tabs.with_tab(label: "Not Considering (#{rejected.size})")
-          - if rejected.any?
-            = render "candidates", form: @form, vacancy: vacancy, candidates: rejected, heading: "Not being considered", multi_select: "rej"
+        - tabs.with_tab(label: "Not Considering (#{job_application_by_status[:unsuccessful].count})")
+          - if job_application_by_status[:unsuccessful].exists?
+            = render "candidates", form: @form, vacancy: vacancy, candidates: job_application_by_status[:unsuccessful], heading: "Not being considered", multi_select: "rej", origin: :unsuccessful
           - else
             = render EmptySectionComponent.new title: t(".no_rejected")
-        - tabs.with_tab(label: "Shortlisted (#{shortlisted.size})")
-          - if shortlisted.any?
-            = render "candidates", form: @form, vacancy: vacancy, candidates: shortlisted, heading: "Shortlisted Applications", multi_select: "short"
+        - tabs.with_tab(label: "Shortlisted (#{job_application_by_status[:shortlisted].count})")
+          - if job_application_by_status[:shortlisted].exists?
+            = render "candidates", form: @form, vacancy: vacancy, candidates: job_application_by_status[:shortlisted], heading: "Shortlisted Applications", multi_select: "short", origin: :shortlisted
           - else
             = render EmptySectionComponent.new title: t(".no_shortlisted")
-        - tabs.with_tab(label: "Interviewing (#{interviewing.size})")
-          - if interviewing.any?
-            = render "candidates", form: @form, vacancy: vacancy, candidates: interviewing, heading: "Interviewing Applications", multi_select: "inter"
+        - tabs.with_tab(label: "Interviewing (#{job_application_by_status[:interviewing].count})")
+          - if job_application_by_status[:interviewing].exists?
+            = render "candidates", form: @form, vacancy: vacancy, candidates: job_application_by_status[:interviewing], heading: "Interviewing Applications", multi_select: "inter", origin: :interviewing
           - else
             = render EmptySectionComponent.new title: t(".no_interviewing")
     - else

--- a/app/views/publishers/vacancies/job_applications/tag.html.slim
+++ b/app/views/publishers/vacancies/job_applications/tag.html.slim
@@ -15,6 +15,7 @@
           li = ja.name
 
 = form_with(url: update_tag_organisation_job_job_applications_path(vacancy.id), scope: :publishers_job_application_status_form) do |f|
+  = hidden_field_tag("publishers_job_application_status_form[origin]", @origin)
   - @job_applications.each do |ja|
     = f.hidden_field :job_applications, multiple: true, value: ja.id
 


### PR DESCRIPTION
-------

## Trello card URL
[1755](https://trello.com/c/fZDkmt60)

## Description

### Issue
When performing an action and the selected job application is empty
Then the job application tab navigation would always display the `All` tab with an error message
even if we were on a different tab.

### Desired outcome
We would like to remain on the same tab after performing an action.

### Proposed solution
Pass on new parameter `origin` that would indicate the which tab triggered the action.
with this new parameter the controller is now able to redirect to the source tab.

### Technical approach
- Add a new scope `JobApplication.group_by_status`, returns a hash where the key is:
     * native status, shortlisted int 
     * a composite status used on the tab, aka new
     * all the records in scope, all
  and the value is an ActiveRecord::Relation for the selected statuses
     
- Add method `current_tab` in job_application_controller that returns the url anchor necessary to have the tab displayed after redirection.