### PR TITLE
Add optional month for non secondary qualification

### DIFF
--- a/app/controllers/jobseekers/job_applications/qualifications_controller.rb
+++ b/app/controllers/jobseekers/job_applications/qualifications_controller.rb
@@ -72,7 +72,7 @@ class Jobseekers::JobApplications::QualificationsController < Jobseekers::BaseCo
 
   def qualification_params
     params.require(qualification_form_param_key(@category))
-          .permit(:category, :finished_studying, :finished_studying_details, :grade, :institution, :name, :subject, :year, :awarding_body, qualification_results_attributes: %i[id subject grade awarding_body])
+          .permit(:category, :finished_studying, :finished_studying_details, :grade, :institution, :name, :subject, :year, :month, :awarding_body, qualification_results_attributes: %i[id subject grade awarding_body])
   end
 
   def category_param

--- a/app/form_models/jobseekers/qualifications/qualification_form.rb
+++ b/app/form_models/jobseekers/qualifications/qualification_form.rb
@@ -2,7 +2,7 @@ class Jobseekers::Qualifications::QualificationForm
   include ActiveModel::Model
   include ActiveModel::Attributes
 
-  attr_accessor :category, :finished_studying_details, :name, :institution, :year, :awarding_body
+  attr_accessor :category, :finished_studying_details, :name, :institution, :year, :month, :awarding_body
 
   attribute :finished_studying, :boolean
 
@@ -10,6 +10,9 @@ class Jobseekers::Qualifications::QualificationForm
   validates :finished_studying_details, presence: true, if: -> { finished_studying == false }
   validates :year, numericality: { less_than_or_equal_to: proc { Time.current.year } },
                    if: -> { finished_studying }
+  validates :month, numericality: { only_integer: true, greater_than: 0, less_than_or_equal_to: 12 },
+                    allow_blank: true,
+                    if: -> { finished_studying }
 
   def secondary?
     false

--- a/app/helpers/pdf_helper.rb
+++ b/app/helpers/pdf_helper.rb
@@ -129,7 +129,7 @@ module PdfHelper
       ["Qualification Name:", qualification.name],
       ["Institution:", qualification.institution],
       ["Grade:", qualification.grade],
-      ["Date completed:", qualification.year],
+      ["Date completed:", qualification.award_date],
       ["Awarding body:", qualification.awarding_body],
     ].reject { |row| row[1].blank? }
 

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -25,6 +25,7 @@ class Qualification < ApplicationRecord
       qualification_results: qualification_results.map(&:duplicate),
       subject:,
       year:,
+      month:,
     )
   end
 
@@ -43,14 +44,15 @@ class Qualification < ApplicationRecord
     else
       self.grade = ""
       self.year = nil
+      self.month = nil
     end
   end
 
   def display_attributes
     if secondary?
-      %w[institution year]
+      %w[institution award_date]
     elsif finished_studying?
-      %w[subject institution grade year awarding_body]
+      %w[subject institution grade award_date awarding_body]
     else
       %w[subject institution awarding_body]
     end
@@ -58,6 +60,10 @@ class Qualification < ApplicationRecord
 
   def secondary?
     category.in?(SECONDARY_QUALIFICATIONS)
+  end
+
+  def award_date
+    [Date::MONTHNAMES[month.to_i], year].join(" ").strip
   end
 
   private

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -49,12 +49,12 @@ class Qualification < ApplicationRecord
   end
 
   def display_attributes
-    if secondary?
-      %w[institution award_date]
-    elsif finished_studying?
-      %w[subject institution grade award_date awarding_body]
-    else
-      %w[subject institution awarding_body]
+    @display_attributes ||= Enumerator.new do |y|
+      display_attributes_list.each do
+        next if public_send(it).blank?
+
+        y << it
+      end
     end
   end
 
@@ -67,6 +67,15 @@ class Qualification < ApplicationRecord
   end
 
   private
+
+  def display_attributes_list
+    return %w[institution award_date] if secondary?
+
+    %w[subject institution].tap do
+      it.push(*%w[grade award_date]) if finished_studying?
+      it << "awarding_body"
+    end
+  end
 
   def mark_emptied_qualification_results_for_destruction
     # The "classic" Rails way of removing associated nested records is setting `_destroy` on the attributes in a form.

--- a/app/views/jobseekers/job_applications/build/qualifications.html.slim
+++ b/app/views/jobseekers/job_applications/build/qualifications.html.slim
@@ -18,10 +18,9 @@
                     - row.with_value text: safe_join(qualification.qualification_results.map { |res| tag.div(display_secondary_qualification(res), class: "govuk-body govuk-!-margin-bottom-1") })
 
                 - qualification.display_attributes.each do |attribute|
-                  - if qualification[attribute].present?
-                    - summary_list.with_row do |row|
-                      - row.with_key text: t("helpers.label.#{qualification_form_param_key(qualification.category)}.#{attribute}")
-                      - row.with_value text: qualification[attribute]
+                  - summary_list.with_row do |row|
+                    - row.with_key text: t("helpers.label.#{qualification_form_param_key(qualification.category)}.#{attribute}")
+                    - row.with_value text: qualification.public_send(attribute)
 
                 - if qualification.finished_studying == false
                   - summary_list.with_row do |row|

--- a/app/views/jobseekers/job_applications/review/qualifications/_qualification.html.slim
+++ b/app/views/jobseekers/job_applications/review/qualifications/_qualification.html.slim
@@ -20,4 +20,7 @@ p.govuk-caption-m
       = qualification[:institution]
   - if qualification.display_attributes.include?("year") && qualification[:year].present?
     span class="govuk-!-display-inline-block"
-      = ", #{qualification[:year]}"
+      - if qualification.display_attributes.include?("month") && qualification[:month].present?
+        = ", #{qualification.award_date}"
+      - else
+        = ", #{qualification[:year]}"

--- a/app/views/jobseekers/job_applications/review/qualifications/_qualification.html.slim
+++ b/app/views/jobseekers/job_applications/review/qualifications/_qualification.html.slim
@@ -1,26 +1,18 @@
 p class="govuk-!-margin-bottom-1"
-  - if qualification.display_attributes.include?("subject") && qualification[:subject].present?
-    span class="govuk-!-display-inline-block"
-      = qualification[:subject]
-  - if qualification.display_attributes.include?("type")
-    span class="govuk-!-display-inline-block govuk-!-margin-left-1"
-      = qualification[:type]
+  span class="govuk-!-display-inline-block"
+    = qualification[:subject]
   - if qualification.display_attributes.include?("grade")
     span class="govuk-!-display-inline-block govuk-!-margin-left-1"
       = "- #{qualification[:grade]}"
-  - if qualification.display_attributes.include?("awarding_body") && qualification[:awarding_body].present?
-    span class="govuk-!-display-inline-block govuk-!-margin-left-1"
-      = " (#{qualification[:awarding_body]})"
+  span class="govuk-!-display-inline-block govuk-!-margin-left-1"
+    = " (#{qualification[:awarding_body]})"
   - if qualification.finished_studying == false
     span class="govuk-!-display-inline-block govuk-!-margin-left-1"
       = "(#{t('helpers.label.jobseekers_qualifications_shared_labels.finished_studying_options.false').downcase} #{qualification.finished_studying_details&.downcase})"
+
 p.govuk-caption-m
-  - if qualification.display_attributes.include?("institution")
+  span class="govuk-!-display-inline-block"
+    = qualification[:institution]
+  - if qualification.display_attributes.include?("award_date")
     span class="govuk-!-display-inline-block"
-      = qualification[:institution]
-  - if qualification.display_attributes.include?("year") && qualification[:year].present?
-    span class="govuk-!-display-inline-block"
-      - if qualification.display_attributes.include?("month") && qualification[:month].present?
-        = ", #{qualification.award_date}"
-      - else
-        = ", #{qualification[:year]}"
+      = ", #{qualification.award_date}"

--- a/app/views/jobseekers/job_applications/review/qualifications/_secondary_qualification.html.slim
+++ b/app/views/jobseekers/job_applications/review/qualifications/_secondary_qualification.html.slim
@@ -2,9 +2,7 @@ p class="govuk-!-margin-bottom-1"
   = qualification.qualification_results.map { |result| display_secondary_qualification(result) }.join(", ")
 
 p.govuk-caption-m
-  - if qualification.display_attributes.include?("institution")
-    span class="govuk-!-display-inline-block"
-      = qualification[:institution]
-  - if qualification.display_attributes.include?("year")
-    span class="govuk-!-display-inline-block"
-      = ", #{qualification[:year]}"
+  span class="govuk-!-display-inline-block"
+    = qualification[:institution]
+  span class="govuk-!-display-inline-block"
+    = ", #{qualification.award_date}"

--- a/app/views/jobseekers/qualifications/_preview_qualifications.html.slim
+++ b/app/views/jobseekers/qualifications/_preview_qualifications.html.slim
@@ -13,6 +13,6 @@
         p class="govuk-!-margin-bottom-0" = tag.div("#{res.subject} (#{res.grade})", class: "govuk-body govuk-!-margin-bottom-0")
     - if qualification.finished_studying == false
       p class="govuk-!-margin-top-0" = tag.div(qualification.finished_studying_details.presence, class: "govuk-body")
-    p.govuk-hint = qualification.year
+    p.govuk-hint = qualification.award_date
     - class_name = "govuk-!-margin-bottom-3"
     hr.govuk-section-break.govuk-section-break--s.govuk-section-break--visible[class=class_name]

--- a/app/views/jobseekers/qualifications/_qualifications.html.slim
+++ b/app/views/jobseekers/qualifications/_qualifications.html.slim
@@ -9,10 +9,9 @@
               - row.with_value text: safe_join(qualification.qualification_results.map { |res| tag.div(display_secondary_qualification(res), class: "govuk-body govuk-!-margin-bottom-1") })
 
           - qualification.display_attributes.each do |attribute|
-            - if qualification[attribute].present?
-              - summary_list.with_row do |row|
-                - row.with_key text: t("helpers.label.#{qualification_form_param_key(qualification.category)}.#{attribute}")
-                - row.with_value text: qualification[attribute]
+            - summary_list.with_row do |row|
+              - row.with_key text: t("helpers.label.#{qualification_form_param_key(qualification.category)}.#{attribute}")
+              - row.with_value text: qualification.public_send(attribute)
 
           - if qualification.finished_studying == false
             - summary_list.with_row do |row|

--- a/app/views/jobseekers/qualifications/fields/_degree.html.slim
+++ b/app/views/jobseekers/qualifications/fields/_degree.html.slim
@@ -9,6 +9,10 @@
 = f.govuk_radio_buttons_fieldset :finished_studying, legend: -> { finished_studying_legend } do
   = f.govuk_radio_button :finished_studying, "true", link_errors: true do
     = f.govuk_text_field :grade, label: { size: "s" }, aria: { required: true }
-    = f.govuk_number_field :year, label: { size: "s" }, aria: { required: true }, width: 4
+    .govuk-grid-row
+      .govuk-grid-column-one-half
+        = f.govuk_number_field :year, label: { size: "s" }, aria: { required: true }, width: 4
+      .govuk-grid-column-one-half
+        = f.govuk_number_field :month, label: { size: "s", text: t("helpers.optional_field_html", label: t("helpers.label.jobseekers_qualifications_shared_labels.month")) }, width: 2
   = f.govuk_radio_button :finished_studying, "false"
     = f.govuk_text_field :finished_studying_details, label: { size: "s" }, aria: { required: true }

--- a/app/views/jobseekers/qualifications/fields/_other.html.slim
+++ b/app/views/jobseekers/qualifications/fields/_other.html.slim
@@ -9,6 +9,10 @@
 = f.govuk_radio_buttons_fieldset :finished_studying do
   = f.govuk_radio_button :finished_studying, "true", link_errors: true do
     = f.govuk_text_field :grade, label: { size: "s" }
-    = f.govuk_number_field :year, label: { size: "s" }, aria: { required: true }, width: 4
+    .govuk-grid-row
+      .govuk-grid-column-one-half
+        = f.govuk_number_field :year, label: { size: "s" }, aria: { required: true }, width: 4
+      .govuk-grid-column-one-half
+        = f.govuk_number_field :month, label: { size: "s", text: t("helpers.optional_field_html", label: t("helpers.label.jobseekers_qualifications_shared_labels.month")) }, width: 2
   = f.govuk_radio_button :finished_studying, "false"
     = f.govuk_text_field :finished_studying_details, label: { size: "s" }, aria: { required: true }

--- a/app/views/jobseekers/qualifications/fields/_secondary_school.html.slim
+++ b/app/views/jobseekers/qualifications/fields/_secondary_school.html.slim
@@ -1,6 +1,8 @@
 = f.govuk_text_field :institution, label: { size: "s" }, aria: { required: true }, width: "three-quarters"
 
-= f.govuk_number_field :year, label: { size: "s" }, aria: { required: true }, width: 4
+.govuk-grid-row
+  .govuk-grid-column-one-half
+    = f.govuk_number_field :year, label: { size: "s" }, aria: { required: true }, width: 4
 
 = f.govuk_fieldset legend: { text: t("helpers.legend.jobseekers_qualifications_shared_legends.subjects") }, class: "subjects-and-grades", data: { controller: "manage-qualifications" } do
   - f.object.qualification_results.each_with_index do |result, idx|

--- a/app/views/jobseekers/qualifications/review/_qualification.html.slim
+++ b/app/views/jobseekers/qualifications/review/_qualification.html.slim
@@ -1,10 +1,6 @@
 p class="govuk-!-margin-bottom-1"
-  - if qualification.display_attributes.include?("subject")
-    span class="govuk-!-display-inline-block"
-      = qualification[:subject]
-  - if qualification.display_attributes.include?("type")
-    span class="govuk-!-display-inline-block govuk-!-margin-left-1"
-      = qualification[:type]
+  span class="govuk-!-display-inline-block"
+    = qualification[:subject]
   - if qualification.display_attributes.include?("grade")
     span class="govuk-!-display-inline-block govuk-!-margin-left-1"
       = "(#{qualification[:grade]})"
@@ -12,12 +8,8 @@ p class="govuk-!-margin-bottom-1"
     span class="govuk-!-display-inline-block govuk-!-margin-left-1"
       = "(#{t('helpers.label.jobseekers_qualifications_shared_labels.finished_studying_options.false').downcase} #{qualification.finished_studying_details&.downcase})"
 p.govuk-caption-m
-  - if qualification.display_attributes.include?("institution")
+  span class="govuk-!-display-inline-block"
+    = qualification[:institution]
+  - if qualification.display_attributes.include?("award_date")
     span class="govuk-!-display-inline-block"
-      = qualification[:institution]
-  - if qualification.display_attributes.include?("year")
-    span class="govuk-!-display-inline-block"
-      - if qualification.display_attributes.include?("month") && qualification[:month].present?
-        = ", #{qualification.award_date}"
-      - else
-        = ", #{qualification[:year]}"
+      = ", #{qualification.award_date}"

--- a/app/views/jobseekers/qualifications/review/_qualification.html.slim
+++ b/app/views/jobseekers/qualifications/review/_qualification.html.slim
@@ -17,4 +17,7 @@ p.govuk-caption-m
       = qualification[:institution]
   - if qualification.display_attributes.include?("year")
     span class="govuk-!-display-inline-block"
-      = ", #{qualification[:year]}"
+      - if qualification.display_attributes.include?("month") && qualification[:month].present?
+        = ", #{qualification.award_date}"
+      - else
+        = ", #{qualification[:year]}"

--- a/app/views/jobseekers/qualifications/review/_secondary_qualification.html.slim
+++ b/app/views/jobseekers/qualifications/review/_secondary_qualification.html.slim
@@ -2,9 +2,7 @@ p class="govuk-!-margin-bottom-1"
   = qualification.qualification_results.map { |result| display_secondary_qualification(result) }.join(", ")
 
 p.govuk-caption-m
-  - if qualification.display_attributes.include?("institution")
-    span class="govuk-!-display-inline-block"
-      = qualification[:institution]
-  - if qualification.display_attributes.include?("year")
-    span class="govuk-!-display-inline-block"
-      = ", #{qualification[:year]}"
+  span class="govuk-!-display-inline-block"
+    = qualification[:institution]
+  span class="govuk-!-display-inline-block"
+    = ", #{qualification.award_date}"

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -306,6 +306,7 @@ shared:
     - name
     - subject
     - year
+    - month
     - job_application_id
     - jobseeker_profile_id
     - awarding_body

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -359,6 +359,7 @@ en:
         grade: Grade
         subject: Subject
         year: Year awarded
+        month: Month awarded
       jobseekers_job_application_details_reference_form:
         email: Email address
         job_title: Job title

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -407,16 +407,17 @@ en:
         <<: *jobseekers_qualifications_shared_labels
         institution: Awarding body
         qualifications: Qualifications
-        year: Year qualification was awarded
+        award_date: Year qualification was awarded
       jobseekers_qualifications_other_form:
         <<: *jobseekers_qualifications_shared_labels
         institution: School, college, university or other organisation
         name: Qualification or course name
-        year: Year qualification was awarded
+        award_date: Year qualification was awarded
         awarding_body: Awarding body (optional)
       jobseekers_qualifications_secondary_common_form:
         <<: *jobseekers_qualifications_shared_labels
         institution: School, college, or other organisation
+        award_date: Year qualification was awarded
       jobseekers_training_and_cpd_form:
         name: Name of course or training
         provider: Training provider (optional)

--- a/db/migrate/20250430141711_add_month_to_qualifications.rb
+++ b/db/migrate/20250430141711_add_month_to_qualifications.rb
@@ -1,0 +1,5 @@
+class AddMonthToQualifications < ActiveRecord::Migration[7.2]
+  def change
+    add_column :qualifications, :month, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_02_154655) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_30_141711) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -552,6 +552,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_02_154655) do
     t.text "finished_studying_details_ciphertext"
     t.uuid "jobseeker_profile_id"
     t.string "awarding_body"
+    t.integer "month"
     t.index ["job_application_id"], name: "index_qualifications_on_job_application_id"
     t.index ["jobseeker_profile_id"], name: "index_qualifications_on_jobseeker_profile_id"
   end

--- a/spec/factories/qualifications.rb
+++ b/spec/factories/qualifications.rb
@@ -26,6 +26,7 @@ FactoryBot.define do
     name { other? ? Faker::Educator.degree : "" }
     subject { undergraduate? || postgraduate? || other? ? Faker::Educator.subject : "" }
     year { finished_studying == false ? nil : factory_rand(1970..2020) }
+    month { finished_studying == false ? nil : factory_rand(1..12) }
 
     job_application
   end

--- a/spec/form_models/jobseekers/qualifications/qualification_form_spec.rb
+++ b/spec/form_models/jobseekers/qualifications/qualification_form_spec.rb
@@ -1,0 +1,168 @@
+require "rails_helper"
+
+RSpec.describe Jobseekers::Qualifications::QualificationForm do
+  describe "validations" do
+    let(:form) do
+      described_class.new(
+        category: "undergraduate",
+        finished_studying: finished_studying,
+        finished_studying_details: finished_studying_details,
+        year: year,
+        month: month,
+      )
+    end
+
+    describe "#category" do
+      let(:finished_studying) { true }
+      let(:finished_studying_details) { nil }
+      let(:year) { 2020 }
+      let(:month) { 6 }
+
+      context "when category is blank" do
+        let(:form) { described_class.new(category: "") }
+
+        it "is invalid" do
+          expect(form).not_to be_valid
+          expect(form.errors[:category]).to be_present
+        end
+      end
+    end
+
+    describe "#finished_studying_details" do
+      let(:year) { nil }
+      let(:month) { nil }
+
+      context "when finished_studying is false" do
+        let(:finished_studying) { false }
+
+        context "when finished_studying_details is present" do
+          let(:finished_studying_details) { "Current student" }
+
+          it "is valid" do
+            expect(form).to be_valid
+          end
+        end
+
+        context "when finished_studying_details is blank" do
+          let(:finished_studying_details) { "" }
+
+          it "is invalid" do
+            expect(form).not_to be_valid
+            expect(form.errors[:finished_studying_details]).to be_present
+          end
+        end
+      end
+
+      context "when finished_studying is true" do
+        let(:finished_studying) { true }
+        let(:finished_studying_details) { "" }
+        let(:year) { 2020 }
+
+        it "is valid even if finished_studying_details is blank" do
+          expect(form).to be_valid
+        end
+      end
+    end
+
+    describe "#year" do
+      let(:finished_studying_details) { nil }
+      let(:month) { nil }
+
+      context "when finished_studying is true" do
+        let(:finished_studying) { true }
+
+        context "when year is in the future" do
+          let(:year) { Time.current.year + 1 }
+
+          it "is invalid" do
+            expect(form).not_to be_valid
+            expect(form.errors[:year]).to be_present
+          end
+        end
+
+        context "when year is in the past" do
+          let(:year) { Time.current.year - 1 }
+
+          it "is valid" do
+            expect(form).to be_valid
+          end
+        end
+      end
+
+      context "when finished_studying is false" do
+        let(:finished_studying) { false }
+        let(:finished_studying_details) { "Current student" }
+        let(:year) { nil }
+
+        it "does not validate year" do
+          expect(form).to be_valid
+        end
+      end
+    end
+
+    describe "#month" do
+      let(:finished_studying_details) { nil }
+      let(:year) { 2020 }
+
+      context "when finished_studying is true" do
+        let(:finished_studying) { true }
+
+        context "when month is nil" do
+          let(:month) { nil }
+
+          it "is valid" do
+            expect(form).to be_valid
+          end
+        end
+
+        context "when month is a valid month number" do
+          let(:month) { 6 }
+
+          it "is valid" do
+            expect(form).to be_valid
+          end
+        end
+
+        context "when month is less than 1" do
+          let(:month) { 0 }
+
+          it "is invalid" do
+            expect(form).not_to be_valid
+            expect(form.errors[:month]).to be_present
+          end
+        end
+
+        context "when month is greater than 12" do
+          let(:month) { 13 }
+
+          it "is invalid" do
+            expect(form).not_to be_valid
+            expect(form.errors[:month]).to be_present
+          end
+        end
+
+        context "when month is not an integer" do
+          let(:month) { "June" }
+
+          it "is invalid" do
+            expect(form).not_to be_valid
+            expect(form.errors[:month]).to be_present
+          end
+        end
+      end
+
+      context "when finished_studying is false" do
+        let(:finished_studying) { false }
+        let(:finished_studying_details) { "Current student" }
+
+        context "when month is provided" do
+          let(:month) { 6 }
+
+          it "does not validate month" do
+            expect(form).to be_valid
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/qualification_spec.rb
+++ b/spec/models/qualification_spec.rb
@@ -4,6 +4,46 @@ RSpec.describe Qualification do
   it { is_expected.to belong_to(:job_application).optional }
   it { is_expected.to belong_to(:jobseeker_profile).optional }
 
+  describe "#remove_inapplicable_data" do
+    subject(:qualification) do
+      build(:qualification,
+            finished_studying: finished_studying,
+            grade: "Merit",
+            year: 2020,
+            month: 6,
+            finished_studying_details: "Current student")
+    end
+
+    before { qualification.remove_inapplicable_data }
+
+    context "when finished_studying is true clears finished_studying_details" do
+      let(:finished_studying) { true }
+
+      it { expect(qualification.finished_studying_details).to be_blank }
+      it { expect(qualification.grade).to eq("Merit") }
+      it { expect(qualification.year).to eq(2020) }
+      it { expect(qualification.month).to eq(6) }
+    end
+
+    context "when finished_studying is false clears grade, year and month" do
+      let(:finished_studying) { false }
+
+      it { expect(qualification.finished_studying_details).to eq("Current student") }
+      it { expect(qualification.grade).to be_blank }
+      it { expect(qualification.year).to be_blank }
+      it { expect(qualification.month).to be_blank }
+    end
+
+    context "when finished_studying is nil does not modify any fields" do
+      let(:finished_studying) { nil }
+
+      it { expect(qualification.finished_studying_details).to eq("Current student") }
+      it { expect(qualification.grade).to eq("Merit") }
+      it { expect(qualification.year).to eq(2020) }
+      it { expect(qualification.month).to eq(6) }
+    end
+  end
+
   describe "#name" do
     let(:qualification) { build_stubbed(:qualification, name: name, category: category) }
 
@@ -50,6 +90,7 @@ RSpec.describe Qualification do
         name
         subject
         year
+        month
       ].each do |attribute|
         expect(duplicate.public_send(attribute)).to eq(qualification.public_send(attribute))
       end
@@ -70,6 +111,50 @@ RSpec.describe Qualification do
 
     it "does not copy jobseeker profile associations" do
       expect(duplicate.jobseeker_profile).to be_nil
+    end
+  end
+
+  describe "#display_attributes" do
+    subject(:display_attributes) { qualification.display_attributes }
+
+    context "when qualification is secondary" do
+      let(:qualification) { build_stubbed(:qualification, category: "gcse") }
+
+      it { is_expected.to match_array(%w[institution award_date]) }
+    end
+
+    context "when qualification is not secondary and finished_studying is true" do
+      let(:qualification) { build_stubbed(:qualification, category: "undergraduate", finished_studying: true) }
+
+      it { is_expected.to match_array(%w[subject institution grade award_date awarding_body]) }
+    end
+
+    context "when qualification is not secondary and finished_studying is false" do
+      let(:qualification) { build_stubbed(:qualification, category: "undergraduate", finished_studying: false) }
+
+      it { is_expected.to match_array(%w[subject institution awarding_body]) }
+    end
+  end
+
+  describe "#award_date" do
+    subject(:award_date) { qualification.award_date }
+
+    context "when month and year are present" do
+      let(:qualification) { build_stubbed(:qualification, year: 2020, month: 6) }
+
+      it { is_expected.to eq("June 2020") }
+    end
+
+    context "when only year is present" do
+      let(:qualification) { build_stubbed(:qualification, year: 2020, month: nil) }
+
+      it { is_expected.to eq("2020") }
+    end
+
+    context "when neither month nor year is present" do
+      let(:qualification) { build_stubbed(:qualification, year: nil, month: nil) }
+
+      it { is_expected.to be_blank }
     end
   end
 end

--- a/spec/models/qualification_spec.rb
+++ b/spec/models/qualification_spec.rb
@@ -124,13 +124,13 @@ RSpec.describe Qualification do
     end
 
     context "when qualification is not secondary and finished_studying is true" do
-      let(:qualification) { build_stubbed(:qualification, category: "undergraduate", finished_studying: true) }
+      let(:qualification) { build_stubbed(:qualification, category: "undergraduate", finished_studying: true, awarding_body: "uni") }
 
       it { is_expected.to match_array(%w[subject institution grade award_date awarding_body]) }
     end
 
     context "when qualification is not secondary and finished_studying is false" do
-      let(:qualification) { build_stubbed(:qualification, category: "undergraduate", finished_studying: false) }
+      let(:qualification) { build_stubbed(:qualification, category: "undergraduate", finished_studying: false, awarding_body: "uni") }
 
       it { is_expected.to match_array(%w[subject institution awarding_body]) }
     end

--- a/spec/requests/jobseekers/job_applications/qualifications_spec.rb
+++ b/spec/requests/jobseekers/job_applications/qualifications_spec.rb
@@ -190,7 +190,8 @@ RSpec.describe "Job applications qualifications" do
                                finished_studying_details: "Taking my time",
                                grade: "1",
                                subject: "Haunting",
-                               year: 1990)
+                               year: 1990,
+                               month: 6)
       end
       let(:original_finished_studying) { "true" }
       let(:params) do
@@ -215,6 +216,7 @@ RSpec.describe "Job applications qualifications" do
             expect { patch jobseekers_job_application_qualification_path(job_application, qualification), params: params }
               .to change { qualification.reload.grade }.from("1").to("")
               .and change { qualification.reload.year }.from(1990).to(nil)
+              .and change { qualification.reload.month }.from(6).to(nil)
           end
         end
 

--- a/spec/support/jobseeker_helpers.rb
+++ b/spec/support/jobseeker_helpers.rb
@@ -126,8 +126,8 @@ module JobseekerHelpers
     find_by_id("add_subject").click
     fill_in "jobseekers_qualifications_secondary_common_form[qualification_results_attributes][1][subject]", with: "PE"
     fill_in "jobseekers_qualifications_secondary_common_form[qualification_results_attributes][1][grade]", with: "90%"
-    fill_in "School, college, or other organisation", with: "Churchill School for Gifted Macaques"
-    fill_in I18n.t("helpers.label.jobseekers_qualifications_shared_labels.year"), with: "2020"
+    fill_in "jobseekers_qualifications_secondary_common_form[institution]", with: "Churchill School for Gifted Macaques"
+    fill_in "jobseekers_qualifications_secondary_common_form[year]", with: "2020"
   end
 
   def fill_in_undergraduate_degree

--- a/spec/system/publishers/publishers_can_manage_job_applications_for_a_vacancy_spec.rb
+++ b/spec/system/publishers/publishers_can_manage_job_applications_for_a_vacancy_spec.rb
@@ -88,6 +88,7 @@ RSpec.describe "Publishers can manage job applications for a vacancy" do
     end
 
     scenario "Changing a single status", :js do
+      expect(page).to have_button(I18n.t("publishers.vacancies.job_applications.candidates.update_application_status"), wait: 10)
       within(".application-unsuccessful") do
         find(".govuk-checkboxes__input", visible: false).set(true)
       end


### PR DESCRIPTION
## Trello card URL
[1810](https://trello.com/c/pUCH2lZJ)

## Changes in this PR:
* Add `qualification.month`
  - integer column to stay consistent with year column
  - new method `qualification.award_date` will be used when rendering

* Add `qualification.month` to dfe analytics

* Render non secondary qualification optional award month

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [X] Adds/removes model validations
- [X] Adds/removes database fields

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [X] DfE Analytics platform
-
### User Experience & Data Integrity

-
</details>