### PR TITLE
Review app deletion improvements

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -20,7 +20,7 @@ on:
       - synchronize
       - reopened
 
-concurrency: workflow-Build-and-deploy-${{ github.event.pull_request.number }}
+concurrency: workflow-Build-and-deploy-${{ github.ref }}
 permissions:
   id-token: write
   packages: write

--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -14,7 +14,10 @@ on:
         description: 'Pull Request number to delete (EG: 1234 for review-pr-1234)'
         required: true
 
-concurrency: workflow-Build-and-deploy-${{ github.event.pull_request.number }}
+# Wait until the Build And Deploy for the same PR is finished before starting this workflow.
+# If triggered by a manual workflow dispatch with a PR number, builds the corresponding 'ref' to match the Build and Deploy concurrency group for that PR.
+# For a closed or unlabeled PR, the 'ref' is available and matches the Build and deploy one.
+concurrency: workflow-Build-and-deploy-${{ github.event_name == 'workflow_dispatch' && format('refs/pull/{0}/merge', github.event.inputs.pr_number) || github.ref }}
 
 permissions:
   id-token: write

--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -17,7 +17,7 @@ on:
 # Wait until the Build And Deploy for the same PR is finished before starting this workflow.
 # If triggered by a manual workflow dispatch with a PR number, builds the corresponding 'ref' to match the Build and Deploy concurrency group for that PR.
 # For a closed or unlabeled PR, the 'ref' is available and matches the Build and deploy one.
-concurrency: workflow-Build-and-deploy-${{ github.event_name == 'workflow_dispatch' && format('refs/pull/{0}/merge', github.event.inputs.pr_number) || github.ref }}
+concurrency: workflow-Build-and-deploy-${{ (github.event_name == 'workflow_dispatch' && format('refs/pull/{0}/merge', github.event.inputs.pr_number)) || github.ref }}
 
 permissions:
   id-token: write

--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -29,7 +29,14 @@ env:
 jobs:
   delete-review-app:
     # Check if PR was closed with deploy label OR workflow was manually triggered OR deploy label was removed
-    if: (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'deploy')) || github.event_name == 'workflow_dispatch' || (github.event.action == 'unlabeled' && github.event.label.name == 'deploy')
+    # Define conditions for triggering the job
+    # 1. PR is closed and has the 'deploy' label
+    # 2. Workflow is manually triggered
+    # 3. 'deploy' label is removed from the PR
+    if: >
+      (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'deploy')) ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.action == 'unlabeled' && github.event.label.name == 'deploy')
     name: Delete review app
     runs-on: ubuntu-latest
     environment: review

--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -2,7 +2,7 @@ name: Delete review app
 
 on:
   pull_request:
-    types: [closed]
+    types: [closed, unlabeled]
     paths-ignore:
       - 'bigquery/**'
       - 'documentation/**'
@@ -25,7 +25,8 @@ env:
 
 jobs:
   delete-review-app:
-    if: contains(github.event.pull_request.labels.*.name, 'deploy') || github.event_name == 'workflow_dispatch'
+    # Check if PR was closed with deploy label OR workflow was manually triggered OR deploy label was removed
+    if: (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'deploy')) || github.event_name == 'workflow_dispatch' || (github.event.action == 'unlabeled' && github.event.label.name == 'deploy')
     name: Delete review app
     runs-on: ubuntu-latest
     environment: review


### PR DESCRIPTION
**Delete review app when removing "deploy" label**

At the moment review apps only get deleted when their PR gets closed while containing the "deploy" label.

This change allows the deletion workflow to run over open PRs when the "deploy" label gets manually removed from the PR.

Trying to reduce the amount of review apps being left over and requiring manual (workflow) deletion.


**Revert to use "ref" instead of pr number for concurrency**

Revert changes introduced on https://github.com/DFE-Digital/teaching-vacancies/pull/6812 as they had the unintended output of the review apps deletion being blocked by production deploys.
