### PR TITLE
bug: fix link on active jobs to be 'live' rather than 'published'

### DIFF
--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -194,6 +194,8 @@ module VacanciesHelper
       :expired
     elsif vacancy.pending?
       :pending
+    elsif vacancy.published?
+      :live
     else
       vacancy.status.to_sym
     end

--- a/spec/system/publishers/publishers_can_manage_job_applications_for_a_vacancy_spec.rb
+++ b/spec/system/publishers/publishers_can_manage_job_applications_for_a_vacancy_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe "Publishers can manage job applications for a vacancy" do
     describe "the summary section" do
       it "shows breadcrumb with link to active jobs in dashboard" do
         within(".govuk-breadcrumbs") do
-          expect(page).to have_link(I18n.t("jobs.dashboard.published.tab_heading"), href: organisation_jobs_with_type_path(:published))
+          expect(page).to have_link(I18n.t("jobs.dashboard.published.tab_heading"), href: organisation_jobs_with_type_path(:live))
         end
       end
 


### PR DESCRIPTION
## Changes in this PR:

'Active' link should point to 'live' rather than defunct 'published' type grouping