### PR TITLE
Allow ats api to accept empty array for subjects and key stages

### DIFF
--- a/spec/requests/publishers/ats_api/v1/vacancies_spec.rb
+++ b/spec/requests/publishers/ats_api/v1/vacancies_spec.rb
@@ -200,11 +200,11 @@ RSpec.describe "ats-api/v1/vacancies", openapi_spec: "v1/swagger.yaml" do
             }
           end
           let(:vacancy) { { vacancy: vacancy_params } }
-        
+
           it "creates the vacancy with empty subjects" do |example|
             expect { submit_request(example.metadata) }.to change(Vacancy, :count).by(1)
             assert_response_matches_metadata(example.metadata)
-        
+
             created_vacancy = Vacancy.last
             expect(created_vacancy.subjects).to eq([])
             expect(created_vacancy.job_roles).to eq(%w[headteacher])

--- a/spec/requests/publishers/ats_api/v1/vacancies_spec.rb
+++ b/spec/requests/publishers/ats_api/v1/vacancies_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe "ats-api/v1/vacancies", openapi_spec: "v1/swagger.yaml" do
           )
         end
 
-        context "when subjects is an empty array", document: false do
+        context "when subjects and key_stages are empty arrays", document: false do
           let(:vacancy_params) do
             {
               external_advert_url: "https://www.example.com/ats-site/advertid",
@@ -195,7 +195,7 @@ RSpec.describe "ats-api/v1/vacancies", openapi_spec: "v1/swagger.yaml" do
                 school_urns: [school1.urn],
               },
               subjects: [],
-              key_stages: %w[ks1 ks2],
+              key_stages: [],
               starts_on: "Next September",
             }
           end

--- a/spec/requests/publishers/ats_api/v1/vacancies_spec.rb
+++ b/spec/requests/publishers/ats_api/v1/vacancies_spec.rb
@@ -174,6 +174,43 @@ RSpec.describe "ats-api/v1/vacancies", openapi_spec: "v1/swagger.yaml" do
           )
         end
 
+        context "when subjects is an empty array", document: false do
+          let(:vacancy_params) do
+            {
+              external_advert_url: "https://www.example.com/ats-site/advertid",
+              expires_at: "2026-01-01",
+              job_title: "Headteacher",
+              job_advert: "An exciting opportunity for a headteacher",
+              salary: "£70,000 to £90,000",
+              visa_sponsorship_available: false,
+              external_reference: "HEAD123",
+              ect_suitable: false,
+              job_roles: %w[headteacher],
+              is_job_share: false,
+              working_patterns: %w[full_time],
+              contract_type: "permanent",
+              phases: %w[primary],
+              publish_on: (Time.zone.today + 1).strftime("%Y-%m-%d"),
+              schools: {
+                school_urns: [school1.urn],
+              },
+              subjects: [],
+              key_stages: %w[ks1 ks2],
+              starts_on: "Next September",
+            }
+          end
+          let(:vacancy) { { vacancy: vacancy_params } }
+        
+          it "creates the vacancy with empty subjects" do |example|
+            expect { submit_request(example.metadata) }.to change(Vacancy, :count).by(1)
+            assert_response_matches_metadata(example.metadata)
+        
+            created_vacancy = Vacancy.last
+            expect(created_vacancy.subjects).to eq([])
+            expect(created_vacancy.job_roles).to eq(%w[headteacher])
+          end
+        end
+
         describe "organisation linking", document: false do
           let(:created_vacancy) { Vacancy.last }
 

--- a/spec/requests/publishers/ats_api/v1/vacancies_spec.rb
+++ b/spec/requests/publishers/ats_api/v1/vacancies_spec.rb
@@ -207,6 +207,7 @@ RSpec.describe "ats-api/v1/vacancies", openapi_spec: "v1/swagger.yaml" do
 
             created_vacancy = Vacancy.last
             expect(created_vacancy.subjects).to eq([])
+            expect(created_vacancy.key_stages).to eq([])
             expect(created_vacancy.job_roles).to eq(%w[headteacher])
           end
         end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -261,7 +261,7 @@ RSpec.configure do |config|
                   },
                   subjects: {
                     type: :array,
-                    minItems: 1,
+                    minItems: 0,
                     items: {
                       type: :string,
                       enum: SUBJECT_OPTIONS.map(&:first), # List of available subjects in the service (from subjects.yml)
@@ -451,7 +451,7 @@ RSpec.configure do |config|
               },
               subjects: {
                 type: :array,
-                minItems: 1,
+                minItems: 0,
                 items: {
                   type: :string,
                   enum: SUBJECT_OPTIONS.map(&:first), # List of available subjects in the service (from subjects.yml)

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -250,7 +250,7 @@ RSpec.configure do |config|
                   },
                   key_stages: {
                     type: :array,
-                    minItems: 1,
+                    minItems: 0,
                     items: {
                       type: :string,
                       enum: Vacancy.key_stages.keys,
@@ -440,7 +440,7 @@ RSpec.configure do |config|
               },
               key_stages: {
                 type: :array,
-                minItems: 1,
+                minItems: 0,
                 items: {
                   type: :string,
                   enum: Vacancy.key_stages.keys,


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/X5Lgz2IE/1828-eteach-api-production-issue-mandatory-subject

## Changes in this PR:

This PR allows us to accept vacancies with blank subjects field via our ats api.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
