### PR TITLE
Modify delete review app

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -107,4 +107,4 @@ runs:
       id: deployment-conclusion
       shell: bash
       run: |
-        make ${{ env.DEPLOY_ENV }} ci tag=${{ inputs.tag }} terraform-app-apply
+        make ${{ env.DEPLOY_ENV }} ci tag=${{ inputs.tag }} terraform-apply

--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -1,4 +1,4 @@
-name: Delete review app
+name: Delete Review App
 
 on:
   pull_request:
@@ -14,32 +14,24 @@ on:
         description: 'Pull Request number to delete (EG: 1234 for review-pr-1234)'
         required: true
 
-# Wait until the Build And Deploy for the same PR is finished before starting this workflow.
-# If triggered by a manual workflow dispatch with a PR number, builds the corresponding 'ref' to match the Build and Deploy concurrency group for that PR.
-# For a closed or unlabeled PR, the 'ref' is available and matches the Build and deploy one.
-concurrency: workflow-Build-and-deploy-${{ (github.event_name == 'workflow_dispatch' && format('refs/pull/{0}/merge', github.event.inputs.pr_number)) || github.ref }}
-
-permissions:
-  id-token: write
-  pull-requests: write
-
 env:
   DOCKER_REPOSITORY: ghcr.io/dfe-digital/teaching-vacancies
 
 jobs:
   delete-review-app:
-    # Check if PR was closed with deploy label OR workflow was manually triggered OR deploy label was removed
-    # Define conditions for triggering the job
-    # 1. PR is closed and has the 'deploy' label
-    # 2. Workflow is manually triggered
-    # 3. 'deploy' label is removed from the PR
-    if: >
-      (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'deploy')) ||
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.action == 'unlabeled' && github.event.label.name == 'deploy')
     name: Delete review app
     runs-on: ubuntu-latest
+    concurrency: delete-review-app-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+    if: >
+      github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'deploy') ||
+      (github.event.action == 'unlabeled' && github.event.label.name == 'deploy') || (github.event_name ==
+      'workflow_dispatch')
+
     environment: review
+
+    permissions:
+      pull-requests: write
+      id-token: write
 
     steps:
     - name: Set environment variables
@@ -47,6 +39,7 @@ jobs:
         PR_NUMBER=${{ github.event.inputs.pr_number || github.event.number }}
         ENVIRONMENT=review-pr-${PR_NUMBER}
         echo "PR_NUMBER=${PR_NUMBER}" >> $GITHUB_ENV
+        echo "pr_id=${PR_NUMBER}" >> $GITHUB_ENV
         echo "ENVIRONMENT=${ENVIRONMENT}" >> $GITHUB_ENV
         echo "LINK_TO_RUN=https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" >> $GITHUB_ENV
         echo "LINK_TO_PR=https://github.com/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}" >> $GITHUB_ENV
@@ -70,53 +63,21 @@ jobs:
     - uses: actions/checkout@v4
       name: Checkout Code
 
-    - uses: google-github-actions/auth@v2
+    - name: Delete Review App
+      uses: DFE-Digital/github-actions/delete-review-app@master
       with:
-        project_id: teacher-vacancy-service
-        workload_identity_provider: projects/689616473831/locations/global/workloadIdentityPools/teaching-vacancies/providers/teaching-vacancies
-
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-
-    - name: Download fetch_config.rb
-      shell: bash
-      run: |
-        echo "::group:: Download fetch_config.rb script"
-        curl -s https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/master/scripts/fetch_config/fetch_config.rb -o bin/fetch_config.rb
-        chmod +x bin/fetch_config.rb
-        echo "::endgroup::"
-
-    - name: Validate secrets
-      shell: bash
-      run: |
-        gem install aws-sdk-ssm --no-document
-        bin/fetch_config.rb -s aws-ssm-parameter-path:/teaching-vacancies/dev/app -d quiet \
-          && echo Data in /teaching-vacancies/dev looks valid
-
-    - name: Terraform pin version
-      uses: hashicorp/setup-terraform@v3
-      with:
-        terraform_version: 1.5.1
-
-    - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
-      with:
+        pr-number: ${{ env.PR_NUMBER }}
+        resource-group-name: s189t01-tv-rv-rg
+        storage-account-name: s189t01tvtfstatervsa
+        tf-state-file: review-pr-${{ env.PR_NUMBER }}_kubernetes.tfstate
         azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-        azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-
-    - name: Terraform destroy (on PR closed)
-      run: |
-        make review ci terraform-app-destroy pr_id=${{env.PR_NUMBER}}
-
-    - name: Delete Terraform Statefile
-      run: ./bin/delete-state-file ${{env.PR_NUMBER}}
-
-    - name: Post sticky pull request comment
-      uses: marocchino/sticky-pull-request-comment@v2
-      with:
-        message: |
-          Review app <${{ env.LINK_TO_APP }}> was successfully deleted
-
+        azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        container-name: terraform-state
+        terraform-base: "terraform/app"
+        tf-file: "versions.tf"
+        gcp-project-id: teacher-vacancy-service
+        gcp-wip: projects/689616473831/locations/global/workloadIdentityPools/teaching-vacancies/providers/teaching-vacancies
     - name: Send failure message to twd_tv_dev channel
       if: failure()
       uses: rtCamp/action-slack-notify@v2.3.3

--- a/.github/workflows/recreate-qa-database.yml
+++ b/.github/workflows/recreate-qa-database.yml
@@ -65,4 +65,4 @@ jobs:
     - name: Deploy to environment
       if: ${{ github.event.inputs.environment }} != "production"
       run: |
-        make ${{ github.event.inputs.environment }} ci terraform-app-database-replace CONFIRM_REPLACE=yes
+        make ${{ github.event.inputs.environment }} ci terraform-database-replace CONFIRM_REPLACE=yes

--- a/Makefile
+++ b/Makefile
@@ -106,10 +106,10 @@ push-local-image: build-local-image ## make push-local-image # Requires active D
 		$(eval tag=$(LOCAL_TAG))
 
 .PHONY: plan-local-image
-plan-local-image: push-local-image terraform-app-plan## make passcode=MyPasscode <env> plan-local-image # Requires active Docker Hub session (`docker login`)
+plan-local-image: push-local-image terraform-plan## make passcode=MyPasscode <env> plan-local-image # Requires active Docker Hub session (`docker login`)
 
 .PHONY: deploy-local-image
-deploy-local-image: push-local-image terraform-app-plan## make passcode=MyPasscode <env> deploy-local-image # Requires active Docker Hub session (`docker login`)
+deploy-local-image: push-local-image terraform-plan## make passcode=MyPasscode <env> deploy-local-image # Requires active Docker Hub session (`docker login`)
 
 ##@ Plan or apply changes to, review, staging or production. Requires Terraform CLI
 
@@ -122,8 +122,8 @@ ci:	## Run in automation environment
 	$(eval export AUTO_APPROVE=-auto-approve)
 	$(eval export SKIP_AZURE_LOGIN=true)
 
-.PHONY: terraform-app-init
-terraform-app-init: set-azure-account
+.PHONY: terraform-init
+terraform-init: set-azure-account
 	rm -rf terraform/app/vendor/modules/aks
 	git -c advice.detachedHead=false clone --depth=1 --single-branch --branch ${TERRAFORM_MODULES_TAG} https://github.com/DFE-Digital/terraform-modules.git terraform/app/vendor/modules/aks
 
@@ -135,15 +135,15 @@ terraform-app-init: set-azure-account
 	$(eval export TF_VAR_service_short=${SERVICE_SHORT})
 
 
-.PHONY: terraform-app-plan
-terraform-app-plan: terraform-app-init check-terraform-variables ## make passcode=MyPasscode tag=dev-08406f04dd9eadb7df6fcda5213be880d7df37ed-20201022090714 <env> terraform-app-plan
+.PHONY: terraform-plan
+terraform-plan: terraform-init check-terraform-variables ## make passcode=MyPasscode tag=dev-08406f04dd9eadb7df6fcda5213be880d7df37ed-20201022090714 <env> terraform-plan
 		terraform -chdir=terraform/app plan -var-file ../workspace-variables/$(var_file).tfvars.json
 
-.PHONY: terraform-app-apply
-terraform-app-apply: terraform-app-init check-terraform-variables ## make passcode=MyPasscode tag=47fd1475376bbfa16a773693133569b794408995 <env> terraform-app-apply
+.PHONY: terraform-apply
+terraform-apply: terraform-init check-terraform-variables ## make passcode=MyPasscode tag=47fd1475376bbfa16a773693133569b794408995 <env> terraform-apply
 		terraform -chdir=terraform/app apply -input=false -var-file ../workspace-variables/$(var_file).tfvars.json -auto-approve
 
-terraform-app-destroy: terraform-app-init ## make qa destroy passcode=MyPasscode
+terraform-destroy: terraform-init ## make qa destroy passcode=MyPasscode
 	terraform -chdir=terraform/app destroy -var-file ../workspace-variables/${var_file}.tfvars.json ${AUTO_APPROVE}
 
 ##@ terraform/common code. Requires privileged IAM account to run

--- a/documentation/operations/deployment/deployments.md
+++ b/documentation/operations/deployment/deployments.md
@@ -74,7 +74,7 @@ Refresh the cached `ghcr.io/dfe-digital/teaching-vacancies:main` image on Github
 
 ### Default tag
 
-If no docker image tag is specified, the makefile defaults to using the `main` tag - as specified in the makfile's `terraform-app-init:` target
+If no docker image tag is specified, the makefile defaults to using the `main` tag - as specified in the makfile's `terraform-init:` target
 
 ### Deploy a specific tag to an environment - GitHub Actions
 

--- a/documentation/operations/infrastructure/hosting.md
+++ b/documentation/operations/infrastructure/hosting.md
@@ -224,7 +224,7 @@ kubectl scale --replicas=4 deployment teaching-vacancies-production-worker -n tv
 ```
 - Run:
   ```shell
-  make passcode=MyPasscode tag=47fd1475376bbfa16a773693133569b794408995 <env> terraform-app-apply
+  make passcode=MyPasscode tag=47fd1475376bbfa16a773693133569b794408995 <env> terraform-apply
   ```
 - If you want to have a deployment triggered by a push to a branch, add a trigger to [build_and_deploy.yml](../.github/workflows/build_and_deploy.yml)
 ```

--- a/documentation/operations/infrastructure/terraform.md
+++ b/documentation/operations/infrastructure/terraform.md
@@ -13,22 +13,22 @@ aws-vault exec Deployments -- [make invocation from below]
 
 Production
 ```
-make CONFIRM_PRODUCTION=true tag=47fd1475376bbfa16a773693133569b794408995 production terraform-app-plan
+make CONFIRM_PRODUCTION=true tag=47fd1475376bbfa16a773693133569b794408995 production terraform-plan
 ```
 
 QA
 ```
-make tag=dev-08406f04dd9eadb7df6fcda5213be880d7df37ed-20201022090714 qa terraform-app-plan
+make tag=dev-08406f04dd9eadb7df6fcda5213be880d7df37ed-20201022090714 qa terraform-plan
 ```
 
 Review app
 ```
-make pr_id=2086 tag=review-pr-2086-e4c2c4afd991161f88808c907b4c66a30e5f3ef4-20201002203641 review terraform-app-plan
+make pr_id=2086 tag=review-pr-2086-e4c2c4afd991161f88808c907b4c66a30e5f3ef4-20201002203641 review terraform-plan
 ```
 
 Staging
 ```
-make tag=47fd1475376bbfa16a773693133569b794408995 staging terraform-app-plan
+make tag=47fd1475376bbfa16a773693133569b794408995 staging terraform-plan
 ```
 
 To run the commands below, you will first need to assume the `Administrator` role with [aws-vault](/documentation/operations/infrastructure/aws-roles-and-cli-tools.md)
@@ -41,11 +41,11 @@ make terraform-common-plan
 ## Cleaning up after review apps that failed to destroy on PR close
 
 Occasionally, some issue will prevent a review app and its associated worker and services from
-getting destroyed. To clean up manually, use the `terraform-app-destroy` make target and set the
+getting destroyed. To clean up manually, use the `terraform-destroy` make target and set the
 `pr_id` variable to the PR ID from Github:
 
 ```
-make pr_id=1234 review terraform-app-destroy
+make pr_id=1234 review terraform-destroy
 ```
 
 ## Planning out to a file, and using `terraform show`


### PR DESCRIPTION
# Pull Request: Implement Centralized Delete-Review-App GitHub Action

## Context

We are standardizing our review app deletion process across services by migrating to a centralized GitHub Action (`DFE-Digital/github-actions/delete-review-app@master`). This reduces duplication, improves maintainability, and ensures consistent behavior across all services when cleaning up review app resources.

## Changes proposed in this pull request

- Replaced our custom delete-review-app workflow with the standardized version from `DFE-Digital/github-actions`
- Configured the workflow to maintain all existing functionality including:
  - PR-based and manual triggering
  - Proper authentication with Azure and GCP
  - Terraform state management
  - PR comment notifications
- Set up appropriate parameters to ensure the action works with our current infrastructure naming conventions
- All make targets have been changed from terraform-app-* to terraform-* to align with the naming convention across the rest of DFE-Digital service repos

The solution uses the existing make target for terraform destroy (`make ci review terraform-destroy`) which ensures compatibility with our current process without requiring changes to other workflows or infrastructure code.## Guidance to review

- Verify that all required parameters are correctly specified in the workflow file
- Test by creating a PR with the 'deploy' label to create a review app, then close the PR to verify it gets deleted
- Confirm in the Azure portal that all resources are properly cleaned up after the workflow runs
- Check that a comment is posted to the PR confirming deletion
- Working run - https://github.com/DFE-Digital/teaching-vacancies/actions/runs/14956257703

### Link to Trello card

https://trello.com/c/7M3ZvinR/2323-use-delete-review-app-github-action

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally

