### PR TITLE
Tighten vacancy duplication validation

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -335,7 +335,7 @@ class Vacancy < ApplicationRecord
 
   def no_duplicate_vacancy
     if find_duplicate_vacancy
-      errors.add(:base, "A vacancy with the same job title, expiry date, and organisation already exists.")
+      errors.add(:base, "A vacancy with the same job title, expiry date, contract type, working_patterns, phases and salary already exists for this organisation.")
     end
   end
 
@@ -348,11 +348,12 @@ class Vacancy < ApplicationRecord
 
   def find_duplicate_vacancy
     Vacancy.joins(:organisations)
-      .where(
-        job_title: job_title,
-        expires_at: expires_at,
-        organisations: { id: organisation_ids },
-      ).where.not(id: id).distinct.first
+           .where.not(id: id)
+           .where(job_title: job_title, expires_at: expires_at, organisations: { id: organisation_ids }, contract_type: contract_type, salary: salary)
+           .with_working_patterns(working_patterns)
+           .with_phases(phases)
+           .distinct
+           .first
   end
 
   # This method is used as a callback when either:

--- a/spec/services/publishers/ats_api/create_vacancy_service_spec.rb
+++ b/spec/services/publishers/ats_api/create_vacancy_service_spec.rb
@@ -370,13 +370,17 @@ RSpec.describe Publishers::AtsApi::CreateVacancyService do
       end
     end
 
-    context "when a vacancy with the same job_title, expired_at, and organisations exists" do
+    context "when a vacancy with the same information already exists for the organisation" do
       let!(:existing_vacancy) do
         create(
           :vacancy,
           job_title: job_title,
           expires_at: params[:expires_at],
           organisations: [school],
+          salary: params[:salary],
+          contract_type: params[:contract_type],
+          working_patterns: params[:working_patterns],
+          phases: params[:phases],
         )
       end
 
@@ -385,7 +389,7 @@ RSpec.describe Publishers::AtsApi::CreateVacancyService do
           {
             status: :conflict,
             json: {
-              errors: ["A vacancy with the same job title, expiry date, and organisation already exists."],
+              errors: ["A vacancy with the same job title, expiry date, contract type, working_patterns, phases and salary already exists for this organisation."],
               meta: { link: Rails.application.routes.url_helpers.vacancy_url(existing_vacancy.id) },
             },
           },

--- a/spec/services/publishers/ats_api/update_vacancy_service_spec.rb
+++ b/spec/services/publishers/ats_api/update_vacancy_service_spec.rb
@@ -243,13 +243,17 @@ RSpec.describe Publishers::AtsApi::UpdateVacancyService do
     end
   end
 
-  context "when a vacancy with the same job_title, expired_at, and organisations exists" do
+  context "when a vacancy with the same information already exists for the organisation" do
     let!(:existing_vacancy) do
       create(
         :vacancy,
         job_title: "Maths Teacher",
         expires_at: "2026-01-01",
         organisations: [school],
+        salary: vacancy.salary,
+        contract_type: vacancy.contract_type,
+        phases: vacancy.phases,
+        working_patterns: working_patterns,
       )
     end
 
@@ -276,7 +280,7 @@ RSpec.describe Publishers::AtsApi::UpdateVacancyService do
         {
           status: :conflict,
           json: {
-            errors: ["A vacancy with the same job title, expiry date, and organisation already exists."],
+            errors: ["A vacancy with the same job title, expiry date, contract type, working_patterns, phases and salary already exists for this organisation."],
             meta: { link: Rails.application.routes.url_helpers.vacancy_url(existing_vacancy.id) },
           },
         },


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/S6di5g4q/1831-resolve-issues-raised-by-eteach-on-the-publishers-ats-api

## Changes in this PR:

Make vacancy duplication validation less prone to false positives.

Some of our ATS clients are trying to publish different positions for the same schools but with slight differences (like different working patterns or salaries).

They should not be detected as a duplicate vacancy in our system.

Adding extra fields to check for during the duplication validation.


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [x] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [x] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
