### PR TITLE
2323 use delete review app GitHub action

### DIFF
--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -1,4 +1,4 @@
-name: Delete review app
+name: Delete Review App
 
 on:
   pull_request:
@@ -14,32 +14,27 @@ on:
         description: 'Pull Request number to delete (EG: 1234 for review-pr-1234)'
         required: true
 
-# Wait until the Build And Deploy for the same PR is finished before starting this workflow.
-# If triggered by a manual workflow dispatch with a PR number, builds the corresponding 'ref' to match the Build and Deploy concurrency group for that PR.
-# For a closed or unlabeled PR, the 'ref' is available and matches the Build and deploy one.
-concurrency: workflow-Build-and-deploy-${{ (github.event_name == 'workflow_dispatch' && format('refs/pull/{0}/merge', github.event.inputs.pr_number)) || github.ref }}
-
-permissions:
-  id-token: write
-  pull-requests: write
-
 env:
   DOCKER_REPOSITORY: ghcr.io/dfe-digital/teaching-vacancies
 
 jobs:
   delete-review-app:
-    # Check if PR was closed with deploy label OR workflow was manually triggered OR deploy label was removed
-    # Define conditions for triggering the job
-    # 1. PR is closed and has the 'deploy' label
-    # 2. Workflow is manually triggered
-    # 3. 'deploy' label is removed from the PR
-    if: >
-      (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'deploy')) ||
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.action == 'unlabeled' && github.event.label.name == 'deploy')
     name: Delete review app
     runs-on: ubuntu-latest
+    # Wait until the Build And Deploy for the same PR is finished before starting this workflow.
+    # If triggered by a manual workflow dispatch with a PR number, builds the corresponding 'ref' to match the Build and Deploy concurrency group for that PR.
+    # For a closed or unlabeled PR, the 'ref' is available and matches the Build and deploy one.
+    concurrency: workflow-Build-and-deploy-${{ (github.event_name == 'workflow_dispatch' && format('refs/pull/{0}/merge', github.event.inputs.pr_number)) || github.ref }}
+    if: >
+      github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'deploy') ||
+      (github.event.action == 'unlabeled' && github.event.label.name == 'deploy') || (github.event_name ==
+      'workflow_dispatch')
+
     environment: review
+
+    permissions:
+      pull-requests: write
+      id-token: write
 
     steps:
     - name: Set environment variables
@@ -47,6 +42,7 @@ jobs:
         PR_NUMBER=${{ github.event.inputs.pr_number || github.event.number }}
         ENVIRONMENT=review-pr-${PR_NUMBER}
         echo "PR_NUMBER=${PR_NUMBER}" >> $GITHUB_ENV
+        echo "pr_id=${PR_NUMBER}" >> $GITHUB_ENV
         echo "ENVIRONMENT=${ENVIRONMENT}" >> $GITHUB_ENV
         echo "LINK_TO_RUN=https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" >> $GITHUB_ENV
         echo "LINK_TO_PR=https://github.com/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}" >> $GITHUB_ENV
@@ -70,53 +66,21 @@ jobs:
     - uses: actions/checkout@v4
       name: Checkout Code
 
-    - uses: google-github-actions/auth@v2
+    - name: Delete Review App
+      uses: DFE-Digital/github-actions/delete-review-app@master
       with:
-        project_id: teacher-vacancy-service
-        workload_identity_provider: projects/689616473831/locations/global/workloadIdentityPools/teaching-vacancies/providers/teaching-vacancies
-
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-
-    - name: Download fetch_config.rb
-      shell: bash
-      run: |
-        echo "::group:: Download fetch_config.rb script"
-        curl -s https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/master/scripts/fetch_config/fetch_config.rb -o bin/fetch_config.rb
-        chmod +x bin/fetch_config.rb
-        echo "::endgroup::"
-
-    - name: Validate secrets
-      shell: bash
-      run: |
-        gem install aws-sdk-ssm --no-document
-        bin/fetch_config.rb -s aws-ssm-parameter-path:/teaching-vacancies/dev/app -d quiet \
-          && echo Data in /teaching-vacancies/dev looks valid
-
-    - name: Terraform pin version
-      uses: hashicorp/setup-terraform@v3
-      with:
-        terraform_version: 1.5.1
-
-    - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
-      with:
+        pr-number: ${{ env.PR_NUMBER }}
+        resource-group-name: s189t01-tv-rv-rg
+        storage-account-name: s189t01tvtfstatervsa
+        tf-state-file: review-pr-${{ env.PR_NUMBER }}_kubernetes.tfstate
         azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-        azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-
-    - name: Terraform destroy (on PR closed)
-      run: |
-        make review ci terraform-app-destroy pr_id=${{env.PR_NUMBER}}
-
-    - name: Delete Terraform Statefile
-      run: ./bin/delete-state-file ${{env.PR_NUMBER}}
-
-    - name: Post sticky pull request comment
-      uses: marocchino/sticky-pull-request-comment@v2
-      with:
-        message: |
-          Review app <${{ env.LINK_TO_APP }}> was successfully deleted
-
+        azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        container-name: terraform-state
+        terraform-base: "terraform/app"
+        tf-file: "versions.tf"
+        gcp-project-id: teacher-vacancy-service
+        gcp-wip: projects/689616473831/locations/global/workloadIdentityPools/teaching-vacancies/providers/teaching-vacancies
     - name: Send failure message to twd_tv_dev channel
       if: failure()
       uses: rtCamp/action-slack-notify@v2.3.3

--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,8 @@ terraform-app-apply: terraform-app-init check-terraform-variables ## make passco
 terraform-app-destroy: terraform-app-init ## make qa destroy passcode=MyPasscode
 	terraform -chdir=terraform/app destroy -var-file ../workspace-variables/${var_file}.tfvars.json ${AUTO_APPROVE}
 
+terraform-destroy: terraform-app-destroy ## Alias for terraform-app-destroy to support the delete-review-app action
+
 ##@ terraform/common code. Requires privileged IAM account to run
 
 .PHONY: terraform-common-init


### PR DESCRIPTION
# Pull Request: Implement Centralized Delete-Review-App GitHub Action

## Context

We are standardizing our review app deletion process across services by migrating to a centralized GitHub Action (`DFE-Digital/github-actions/delete-review-app@master`). This reduces duplication, improves maintainability, and ensures consistent behavior across all services when cleaning up review app resources.

## Changes proposed in this pull request

- Replaced our custom delete-review-app workflow with the standardized version from `DFE-Digital/github-actions`
- Configured the workflow to maintain all existing functionality including:
  - PR-based and manual triggering
  - Proper authentication with Azure and GCP
  - Terraform state management
  - PR comment notifications
- Set up appropriate parameters to ensure the action works with our current infrastructure naming conventions
- All make targets have been changed from terraform-app-* to terraform-* to align with the naming convention across the rest of DFE-Digital service repos

The solution uses the existing make target for terraform destroy (`make ci review terraform-destroy`) which ensures compatibility with our current process without requiring changes to other workflows or infrastructure code.## Guidance to review

- Verify that all required parameters are correctly specified in the workflow file
- Test by creating a PR with the 'deploy' label to create a review app, then close the PR to verify it gets deleted
- Confirm in the Azure portal that all resources are properly cleaned up after the workflow runs
- Check that a comment is posted to the PR confirming deletion
- Working run - https://github.com/DFE-Digital/teaching-vacancies/actions/runs/14999686671/job/42143008988

### Link to Trello card

https://trello.com/c/7M3ZvinR/2323-use-delete-review-app-github-action

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
