### PR TITLE
only update profile_id when profile tangled with job application

### DIFF
--- a/lib/tasks/remove_double_linked_associations.rake
+++ b/lib/tasks/remove_double_linked_associations.rake
@@ -9,13 +9,5 @@ namespace :db do
         ja.qualifications.reject { |t| t.jobseeker_profile_id.nil? }.each { |tr| tr.update_column(:jobseeker_profile_id, nil) }
       end
     end
-    JobseekerProfile.includes(:training_and_cpds, :employments, :professional_body_memberships, :qualifications).find_each do |ja|
-      JobseekerProfile.transaction do
-        ja.training_and_cpds.reject { |t| t.job_application_id.nil? }.each { |tr| tr.update_column(:job_application_id, nil) }
-        ja.employments.reject { |t| t.job_application_id.nil? }.each { |tr| tr.update_column(:job_application_id, nil) }
-        ja.professional_body_memberships.reject { |t| t.job_application_id.nil? }.each { |tr| tr.update_column(:job_application_id, nil) }
-        ja.qualifications.reject { |t| t.job_application_id.nil? }.each { |tr| tr.update_column(:job_application_id, nil) }
-      end
-    end
   end
 end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/uaWbekjF/1830-active-profiles-application-data-copy-bug

## Changes in this PR:

Improve safety of double linking script by only removing links to profiles from job_applications but not the reverse