### PR TITLE
Govuk one login jobseeker tweaks

### DIFF
--- a/app/controllers/jobseekers/govuk_one_login_callbacks_controller.rb
+++ b/app/controllers/jobseekers/govuk_one_login_callbacks_controller.rb
@@ -34,29 +34,34 @@ class Jobseekers::GovukOneLoginCallbacksController < Devise::OmniauthCallbacksCo
 
   private
 
+  # rubocop:disable Metrics/AbcSize
   def match_jobseeker_from_govuk_one_login(govuk_one_login_user)
-    id = govuk_one_login_user.id
-    email = govuk_one_login_user.email
-    jobseeker = Jobseeker.find_from_govuk_one_login(id:, email:)
+    jobseeker = Jobseeker.find_from_govuk_one_login(id: govuk_one_login_user.id, email: govuk_one_login_user.email)
 
     # Completely new user
     if jobseeker.nil?
       session[:newly_created_user] = { value: "true", path: "/", expires: 1.hour.from_now }
-      jobseeker = Jobseeker.create_from_govuk_one_login(id:, email:)
+      jobseeker = Jobseeker.create_from_govuk_one_login(id: govuk_one_login_user.id, email: govuk_one_login_user.email)
     # User exists but is their first time signing-in with OneLogin
     elsif jobseeker.govuk_one_login_id.nil?
       session[:user_exists_first_log_in] = { value: "true", path: "/", expires: 1.hour.from_now }
-      jobseeker.update!(govuk_one_login_id: id)
+      jobseeker.update!(govuk_one_login_id: govuk_one_login_user.id)
     # User deleted their OneLogin account and created a new one using the same email
-    elsif jobseeker.govuk_one_login_id != id
-      jobseeker.update!(govuk_one_login_id: id)
+    elsif jobseeker.govuk_one_login_id != govuk_one_login_user.id
+      previous_id = jobseeker.govuk_one_login_id
+      jobseeker.update!(govuk_one_login_id: govuk_one_login_user.id)
+      trigger_jobseeker_changed_govuk_one_login_id_event(jobseeker, previous_id)
     # User changed their email in OneLogin after having already signed in with us
-    elsif jobseeker.email != email
-      jobseeker.update_email_from_govuk_one_login!(email)
+    elsif jobseeker.email != govuk_one_login_user.email
+      previous_email = jobseeker.email
+      if jobseeker.update_email_from_govuk_one_login!(govuk_one_login_user.email)
+        trigger_jobseeker_changed_govuk_one_login_email_event(jobseeker, previous_email)
+      end
     end
 
     jobseeker
   end
+  # rubocop:enable Metrics/AbcSize
 
   def error_redirect
     flash[:alert] = I18n.t("jobseekers.govuk_one_login_callbacks.openid_connect.error")
@@ -89,4 +94,38 @@ class Jobseekers::GovukOneLoginCallbacksController < Devise::OmniauthCallbacksCo
       stored_location.include?("/jobseekers/subscriptions") || # Signed-in from a job alert email link.
       stored_location.include?("/jobseekers/account/email_preferences/edit") # Signed-in from a peak times email.
   end
+
+  # :nocov:
+  def trigger_jobseeker_changed_govuk_one_login_id_event(jobseeker, previous_id)
+    event = DfE::Analytics::Event.new
+      .with_type(:jobseeker_changed_govuk_one_login_id)
+      .with_request_details(request)
+      .with_response_details(response)
+      .with_user(jobseeker)
+      .with_data(
+        hidden_data: { email_identifier: jobseeker&.email,
+                       govuk_one_login_id: jobseeker&.govuk_one_login_id,
+                       previous_govuk_one_login_id: previous_id },
+      )
+
+    DfE::Analytics::SendEvents.do([event])
+  end
+  # :nocov:
+
+  # :nocov:
+  def trigger_jobseeker_changed_govuk_one_login_email_event(jobseeker, previous_email)
+    event = DfE::Analytics::Event.new
+      .with_type(:jobseeker_changed_govuk_one_login_email)
+      .with_request_details(request)
+      .with_response_details(response)
+      .with_user(jobseeker)
+      .with_data(
+        hidden_data: { email_identifier: jobseeker&.email,
+                       govuk_one_login_id: jobseeker&.govuk_one_login_id,
+                       previous_email_identifier: previous_email },
+      )
+
+    DfE::Analytics::SendEvents.do([event])
+  end
+  # :nocov:
 end

--- a/app/models/jobseeker.rb
+++ b/app/models/jobseeker.rb
@@ -60,8 +60,9 @@ class Jobseeker < ApplicationRecord
       create!(email: email.downcase, govuk_one_login_id: id)
     end
 
-    # Either find the Jobseeker by their GovUK OneLogin id or uses the OneLogin email address to find possible Jobseekers
-    # created before introducing OneLogin and still non-linked with a OneLogin account.
+    # Either find the Jobseeker by their GovUK OneLogin id or uses the OneLogin email address to find:
+    # - Jobseekers created before introducing OneLogin and still non-linked with a OneLogin account.
+    # - Jobseekers that deleted their GovUK OneLogin account, created a new one with the same email but different id.
     def find_from_govuk_one_login(id:, email:)
       find_by(govuk_one_login_id: id) || find_by(email: email)
     end

--- a/app/models/jobseeker.rb
+++ b/app/models/jobseeker.rb
@@ -67,6 +67,15 @@ class Jobseeker < ApplicationRecord
     end
   end
 
+  # Unlinks the Jobseeker from GovUK OneLogin by removing the OneLogin id.
+  #
+  # This method is not currently called anywhere in the codebase, but is made available for developers to use in the
+  # console to resolve support requests.
+  #
+  def unlink_from_govuk_one_login!
+    update!(govuk_one_login_id: nil) if govuk_one_login_id.present?
+  end
+
   # Updates the Jobseeker's email address with the one provided by GovUK OneLogin.
   def update_email_from_govuk_one_login!(new_email)
     return false if new_email.blank? || new_email == email

--- a/app/models/jobseeker.rb
+++ b/app/models/jobseeker.rb
@@ -73,7 +73,7 @@ class Jobseeker < ApplicationRecord
 
     # Find any Jobseeker with the new email address that was created before OneLogin was introduced.
     if (legacy_user = self.class.find_by(email: new_email, govuk_one_login_id: nil))
-      return false if saved_data?
+      return false if saved_data_preventing_transfer? # Do not update email or transfer account if the current user has any saved data.
 
       Jobseekers::AccountTransfer.new(self, legacy_user.email).call
     end
@@ -100,8 +100,7 @@ class Jobseeker < ApplicationRecord
     )
   end
 
-  # Criteria used for determining if a Jobseeker has enough saved data to be considered for automatic account transfer.
-  def saved_data?
+  def saved_data_preventing_transfer?
     job_applications.any? || jobseeker_profile&.qualifications&.any? || jobseeker_profile&.employments&.any?
   end
 end

--- a/config/analytics_custom_events.yml
+++ b/config/analytics_custom_events.yml
@@ -12,6 +12,8 @@ shared:
   - jobseeker_application_shortlisted
   - jobseeker_application_submitted
   - jobseeker_application_unsuccessful
+  - jobseeker_changed_govuk_one_login_email
+  - jobseeker_changed_govuk_one_login_id
   - jobseeker_failed_govuk_one_login_sign_in
   - jobseeker_inactive_account
   - jobseeker_job_listing_ended_early

--- a/spec/models/jobseeker_spec.rb
+++ b/spec/models/jobseeker_spec.rb
@@ -123,6 +123,18 @@ RSpec.describe Jobseeker do
     end
   end
 
+  describe "unlink_from_govuk_one_login!" do
+    it "unlinks the jobseeker from GovUK OneLogin by removing the OneLogin id" do
+      jobseeker = create(:jobseeker)
+      expect { jobseeker.unlink_from_govuk_one_login! }.to change { jobseeker.reload.govuk_one_login_id }.to(nil)
+    end
+
+    it "does not unlink the jobseeker if they do not have a OneLogin id" do
+      jobseeker = create(:jobseeker, govuk_one_login_id: nil)
+      expect { jobseeker.unlink_from_govuk_one_login! }.not_to change { jobseeker.reload.govuk_one_login_id }.from(nil)
+    end
+  end
+
   describe "update_email_from_govuk_one_login!" do
     let!(:jobseeker) { create(:jobseeker) }
 

--- a/spec/models/jobseeker_spec.rb
+++ b/spec/models/jobseeker_spec.rb
@@ -114,6 +114,14 @@ RSpec.describe Jobseeker do
       end
     end
 
+    context "when the jobseeker has a different govuk_one_login_id but the provided email matches" do
+      let!(:jobseeker) { create(:jobseeker, govuk_one_login_id: "id") }
+
+      it "finds the jobseeker by their email" do
+        expect(described_class.find_from_govuk_one_login(id: nil, email: jobseeker.email)).to eq(jobseeker)
+      end
+    end
+
     it "returns no user if neither the govuk_one_login_id or email match" do
       expect(described_class.find_from_govuk_one_login(id: "random", email: "random@contoso.com")).to be_nil
     end

--- a/spec/requests/jobseekers/govuk_one_login_spec.rb
+++ b/spec/requests/jobseekers/govuk_one_login_spec.rb
@@ -185,9 +185,10 @@ RSpec.describe "Govuk One Login authentication response" do
           allow(govuk_one_login_user).to receive(:id).and_return(new_one_login_id)
         end
 
-        it "updates the jobseeker's OneLogin ID in the existing teaching vacancies jobseeker" do
+        it "updates the jobseeker's OneLogin ID in the existing teaching vacancies jobseeker", :dfe_analytics do
           expect { get auth_govuk_one_login_callback_path }
             .to change { jobseeker.reload.govuk_one_login_id }.from(original_one_login_id).to(new_one_login_id)
+          expect(:jobseeker_changed_govuk_one_login_id).to have_been_enqueued_as_analytics_event # Rubocop:disable RSpec/ExpectActual
         end
 
         context "with no explicitly allowed url location to redirect to in devise session" do
@@ -207,9 +208,10 @@ RSpec.describe "Govuk One Login authentication response" do
         end
 
         context "when the updated email does not match any other jobseeker in teaching vacancies" do
-          it "updates the new email in the existing teaching vacancies jobseeker" do
+          it "updates the new email in the existing teaching vacancies jobseeker", :dfe_analytics do
             expect { get auth_govuk_one_login_callback_path }
               .to change { jobseeker.reload.email }.from("original_email@contoso.com").to(govuk_one_login_user.email)
+            expect(:jobseeker_changed_govuk_one_login_email).to have_been_enqueued_as_analytics_event # Rubocop:disable RSpec/ExpectActual
           end
 
           it "redirects the jobseeker to their applications page" do


### PR DESCRIPTION
## Trello card URL

- https://trello.com/c/LJQ6Tyxb/1827-investigate-govuk-onelogin-account-deletion-and-tv-govuk-unlinking-requests

## Changes in this PR:
- Fixes an edge case when GovUK One Login users have deleted and re-created their OneLogin account with the same email.
- Send analytics custom events when OneLogin information cause the Jobseeker to get their mapped OneLogin ID or their email updated.
- Adds a "helper" method to help us unlink Jobseekers from their GovUK OneLogin account if needed.
- Adds a couple of refactors, grouping and renaming GovUK OneLogin-related methods under the Jobseeker model.

### Regarding the edge case:
Recently, we started receiving requests to "unlink" existing Jobseekers from their current GovUK OneLogin id.

They have contacted GovUK OneLogin team, asked for their account to be completely deleted, and then created a new GovUK OneLogin account using the same email.

Once that happens, the user id is different and gets matched by their email. But we were keeping the original one login id, being left "unsync" between OneLogin and TV service.

Now we are automatically re-mapping users to their new GovUK One Login id when this happens.


### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
