### PR TITLE
Fix ECT status filter from Campaign config criteria

### DIFF
--- a/app/services/campaign_search_params_merger.rb
+++ b/app/services/campaign_search_params_merger.rb
@@ -58,7 +58,9 @@ class CampaignSearchParamsMerger
 
   def extract_ect_status(params)
     ect_value = params.delete(:email_ECT)
-    params[:ect_statuses] = if ect_value.present? && ActiveModel::Type::Boolean.new.cast(ect_value)
+    return if ect_value.blank?
+
+    params[:ect_statuses] = if ActiveModel::Type::Boolean.new.cast(ect_value)
                               %w[ect_suitable]
                             else
                               %w[ect_unsuitable]

--- a/config/campaign_pages.yml
+++ b/config/campaign_pages.yml
@@ -29,7 +29,8 @@ shared:
     radius: 15
   ectrolesbespoke:
     banner_image: "campaigns/ect_teacher.jpg"
-    ect_suitable: true
+    ect_statuses:
+      - ect_suitable
     teaching_job_roles:
       - teacher
     radius: 15
@@ -216,4 +217,6 @@ test:
     subjects:
       - Physics
       - Science
+    ect_statuses:
+      - ect_suitable
     radius: 15

--- a/spec/services/campaign_page_spec.rb
+++ b/spec/services/campaign_page_spec.rb
@@ -25,8 +25,11 @@ RSpec.describe CampaignPage do
     it "returns a configured landing page instance if a landing page with the given slug exists" do
       expect(described_class["FAKE1+CAMPAIGN"].banner_image)
         .to eq("campaigns/secondary_not_too_late.jpg")
-      expect(described_class["FAKE1+CAMPAIGN"].criteria)
-        .to eq({ radius: 15, teaching_job_roles: %w[teacher], working_patterns: %w[part_time], subjects: %w[Physics Science] })
+      expect(described_class["FAKE1+CAMPAIGN"].criteria).to eq({ radius: 15,
+                                                                 teaching_job_roles: %w[teacher],
+                                                                 working_patterns: %w[part_time],
+                                                                 subjects: %w[Physics Science],
+                                                                 ect_statuses: %w[ect_suitable] })
     end
 
     it "raises an error if no landing page with the given slug has been configured" do

--- a/spec/services/campaign_search_params_merger_spec.rb
+++ b/spec/services/campaign_search_params_merger_spec.rb
@@ -39,11 +39,27 @@ RSpec.describe CampaignSearchParamsMerger do
       end
     end
 
-    context "when ECT status is present in URL params" do
-      let(:url_params) { { email_ECT: "true" } }
+    describe "ECT status" do
+      context "when ECT status is not present in URL params" do
+        it "includes ect_statuses from campaign criteria" do
+          expect(merger.merged_params[:ect_statuses]).to eq(%w[ect_suitable])
+        end
+      end
 
-      it "maps email_ECT to ect_statuses" do
-        expect(merger.merged_params[:ect_statuses]).to eq(%w[ect_suitable])
+      context "when ECT status is present in URL params" do
+        let(:url_params) { { email_ECT: "true" } }
+
+        it "maps email_ECT to ect_statuses" do
+          expect(merger.merged_params[:ect_statuses]).to eq(%w[ect_suitable])
+        end
+      end
+
+      context "when ECT status is present in URL params and contradicts the campaign default criteria" do
+        let(:url_params) { { email_ECT: "false" } }
+
+        it "the URL param takes precedence" do
+          expect(merger.merged_params[:ect_statuses]).to eq(%w[ect_unsuitable])
+        end
       end
     end
 


### PR DESCRIPTION

## Trello card URL
- https://trello.com/c/BsqmPfhD/1844-check-ect-bespoke-landing-page

## Changes in this PR:

The ECT Status option defined in the campaign page configuration wasn't mapping to the ECT status search filter.

Fixed the configuration and mapping to match the expected behaviour.

## Screenshots of UI changes:

### Before

![image](https://github.com/user-attachments/assets/068945a7-1f24-4da2-bb73-d682fea2a1f6)

### After

![image](https://github.com/user-attachments/assets/78173098-cdfc-43ab-9205-a260305e8e6c)

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
