### PR TITLE
Fix libxml2 package version to avoid vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
  # Alpine v3.21.
  # TODO: Regularly check in the alpine ruby "3.4.3-alpine3.21" images for its latest upgraded packages so we can remove
  # the hardcoded versions below when they have been updated in the alpine ruby image.
-ARG PROD_PACKAGES="imagemagick libpng libjpeg libxml2 libxslt libpq tzdata shared-mime-info postgresql15 busybox yaml openssl=3.3.3-r0 musl=1.2.5-r9"
+ARG PROD_PACKAGES="imagemagick libpng libjpeg libxml2=2.13.4-r6 libxslt libpq tzdata shared-mime-info postgresql15 busybox yaml openssl=3.3.3-r0 musl=1.2.5-r9"
 
 FROM ruby:3.4.3-alpine3.21 AS builder
 


### PR DESCRIPTION
SNYK scan is blocking deploys due to a recent vulnerability on the default Alpine image libxml2 package.
