### PR TITLE
Exclude /ats-api from http basic authentication

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
                                if: lambda {
                                  ENV["HTTP_BASIC_PASSWORD"].present? &&
                                    request.path != "/check" &&
-                                   !(request.host.include?("test.teacherservices.cloud") && request.path.start_with?("/ats-api"))
+                                   !request.path.start_with?("/ats-api")
                                }
 
   add_flash_types :success, :warning

--- a/spec/requests/basic_auth_spec.rb
+++ b/spec/requests/basic_auth_spec.rb
@@ -10,9 +10,18 @@ RSpec.describe "HTTP Basic Auth exclusions" do
     allow(ENV).to receive(:[]).with("HTTP_BASIC_PASSWORD").and_return("pass")
   end
 
-  context "when making a GET request to /ats-api on review app host" do
-    it "does not require basic auth" do
+  context "when making a GET request to /ats-api" do
+    it "does not require basic auth on review app host" do
       host! "teaching-vacancies-review-pr-1234.test.teacherservices.cloud"
+      get "/ats-api/v1/vacancies", headers: {
+        "X-Api-Key" => api_client.api_key,
+        "Accept" => "application/json",
+      }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "does not require basic auth on staging host" do
+      host! "staging.teaching-vacancies.service.gov.uk"
       get "/ats-api/v1/vacancies", headers: {
         "X-Api-Key" => api_client.api_key,
         "Accept" => "application/json",


### PR DESCRIPTION
So the API requests do not require to have HTTP user/password. 
Any client would require a correct API KEY to be able to use it.

Raised since needing to bypass it for Staging made me realise there is no host/environment where the HTTP AUTH for the API endpoint would be needed.