### PR TITLE
Fix peak reminder email when jobseeker has no name

### DIFF
--- a/app/mailers/jobseekers/peak_times_mailer.rb
+++ b/app/mailers/jobseekers/peak_times_mailer.rb
@@ -4,8 +4,12 @@ class Jobseekers::PeakTimesMailer < Jobseekers::BaseMailer
   def reminder(jobseeker_id)
     @jobseeker_id = jobseeker_id
 
-    send_email(to: jobseeker.email,
-               subject: I18n.t("jobseekers.peak_times_mailer.reminder.subject", first_name: first_name))
+    subject = if first_name.present?
+                I18n.t("jobseekers.peak_times_mailer.reminder.subject", first_name: first_name)
+              else
+                I18n.t("jobseekers.peak_times_mailer.reminder.nameless_subject")
+              end
+    send_email(to: jobseeker.email, subject:)
   end
 
   private
@@ -17,7 +21,7 @@ class Jobseekers::PeakTimesMailer < Jobseekers::BaseMailer
   end
 
   def first_name
-    @first_name ||= jobseeker.jobseeker_profile.personal_details.first_name
+    @first_name ||= jobseeker.jobseeker_profile&.personal_details&.first_name
   end
 
   def campaign_url

--- a/app/views/jobseekers/peak_times_mailer/reminder.text.erb
+++ b/app/views/jobseekers/peak_times_mailer/reminder.text.erb
@@ -1,4 +1,4 @@
-<%= t(".hello", first_name:) %>
+<%= first_name.present? ? t(".hello", first_name:) : t(".nameless_hello") %>
 
 <%= t(".line_1") %>
 

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -35,7 +35,9 @@ en:
     peak_times_mailer:
       reminder:
         subject: "%{first_name}, now is the best time to find school jobs"
+        nameless_subject: Now is the best time to find school jobs
         hello: "Hi %{first_name},"
+        nameless_hello: "Hi,"
         line_1: Schools advertise more jobs than usual around this time of year.
         line_2: "If you are looking for a school role, now is a great time to search for jobs on [Teaching Vacancies](%{campaign_url})."
         line_3: To find the right role, remember to always check Teaching Vacancies.

--- a/spec/mailers/jobseekers/peak_times_mailer_spec.rb
+++ b/spec/mailers/jobseekers/peak_times_mailer_spec.rb
@@ -5,19 +5,11 @@ RSpec.describe Jobseekers::PeakTimesMailer do
   describe ".reminder" do
     subject(:mail) { described_class.reminder(jobseeker.id) }
 
-    let(:jobseeker) { create(:jobseeker, :with_personal_details) }
+    shared_examples "common email behaviors" do
+      it "uses jobseekers' email" do
+        expect(mail.to).to contain_exactly(jobseeker.email)
+      end
 
-    it "has subject with jobseeker firstname" do
-      first_name = jobseeker.jobseeker_profile.personal_details.first_name
-      expected_subject = I18n.t("jobseekers.peak_times_mailer.reminder.subject", first_name: first_name)
-      expect(mail.subject).to eq(expected_subject)
-    end
-
-    it "uses jobseekers' email" do
-      expect(mail.to).to contain_exactly(jobseeker.email)
-    end
-
-    context "with template" do
       it "has an unsubcribe link" do
         unsubscribe_link = Rails.application
                              .routes
@@ -37,6 +29,38 @@ RSpec.describe Jobseekers::PeakTimesMailer do
 
           it { is_expected.to include(url) }
         end
+      end
+    end
+
+    context "when jobseeker has personal details" do
+      let(:jobseeker) { create(:jobseeker, :with_personal_details) }
+      let(:first_name) { jobseeker.jobseeker_profile.personal_details.first_name }
+
+      it_behaves_like "common email behaviors"
+
+      it "has subject with jobseeker firstname" do
+        expected_subject = I18n.t("jobseekers.peak_times_mailer.reminder.subject", first_name: first_name)
+        expect(mail.subject).to eq(expected_subject)
+      end
+
+      it "includes personalized greeting in the body" do
+        expect(mail.body).to include(first_name)
+      end
+    end
+
+    context "when jobseeker has no personal details" do
+      let(:jobseeker) { create(:jobseeker) }
+
+      it_behaves_like "common email behaviors"
+
+      it "has generic subject without firstname" do
+        expected_subject = I18n.t("jobseekers.peak_times_mailer.reminder.nameless_subject")
+        expect(mail.subject).to eq(expected_subject)
+      end
+
+      it "includes generic greeting in the body" do
+        nameless_greeting = I18n.t("jobseekers.peak_times_mailer.reminder.nameless_hello")
+        expect(mail.body).to include(nameless_greeting)
       end
     end
   end


### PR DESCRIPTION

## Trello card URL
- Fixes: https://teaching-vacancies.sentry.io/issues/6604185753

## Changes in this PR:

We got errors on the last run because hundreds of jobseekers had no profile/personal details, so their first name was not recorded.

Resolving it for future runs so it only uses the name when available.

## Screenshots of UI changes:

### Before

### After

#### With the name being present
![Screenshot From 2025-05-16 15-16-12](https://github.com/user-attachments/assets/abd1f732-f773-4292-9482-e9dd890125be)
![Screenshot From 2025-05-16 15-15-27](https://github.com/user-attachments/assets/6ba8d12b-389e-489c-a269-1479a04143c9)

#### Without the name
![Screenshot From 2025-05-16 15-16-51](https://github.com/user-attachments/assets/e78b28a5-a7d8-405b-8b12-dca16ba4f2a5)
![Screenshot From 2025-05-16 15-15-14](https://github.com/user-attachments/assets/98b0a38c-fa22-4943-891e-2ebc4cf27e07)


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
