### PR TITLE
compact phases for discarded vacancies

### DIFF
--- a/lib/tasks/dicard_trashed_vacancies.rake
+++ b/lib/tasks/dicard_trashed_vacancies.rake
@@ -2,7 +2,9 @@ namespace :vacancies do
   desc "Discard trashed vacancies"
   task discard_trashed: :environment do
     Vacancy.trashed.or(Vacancy.removed_from_external_system).find_each do |v|
-      v.assign_attributes(status: :published, discarded_at: v.updated_at)
+      # when the 'middle school' phase was removed, some deleted vacancies didn't get updated
+      # so they have phases with 'nil' in their arrays - this tidies them up so that they can be handled.
+      v.assign_attributes(status: :published, discarded_at: v.updated_at, phases: v.phases.compact)
       v.save!(touch: false, validate: false)
     end
   end


### PR DESCRIPTION
## Trello card URL

## Changes in this PR:

Need to compact phases in discarded vacancies as they might have had 'middle' as a phase.
