### PR TITLE
Foreground document purge to work around analytics issue

### DIFF
--- a/app/controllers/publishers/vacancies/documents_controller.rb
+++ b/app/controllers/publishers/vacancies/documents_controller.rb
@@ -20,7 +20,7 @@ class Publishers::Vacancies::DocumentsController < Publishers::Vacancies::BaseCo
 
   def destroy
     document = vacancy.supporting_documents.find(params[:id])
-    document.purge_later
+    document.purge
     send_dfe_analytics_event(:supporting_document_deleted, document.filename, document.byte_size, document.content_type)
 
     redirect_to after_document_delete_path, flash: { success: t("jobs.file_delete_success_message", filename: document.filename) }


### PR DESCRIPTION
## Changes in this PR:

DfeAnalytics appears to have a subtle bug (with a passing test to boot) that prevents the delete event from being streamed on an attachment when the attachment is removed in the background with purge_later. 

This converts this to a purge (which should have minimal impact as quite often the document is shared between vacancies, so the purge does nothing) 

It's possible that the scenario of 2 documents pointing to the same blob i(in combination with purge_later) is what causes the bug to appear



## Checklists:

### Integration Impact

Does this change affect any of these integrations?
- [x] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
