### PR TITLE
Use Geocoding Coordinates for "within UK validator"

### DIFF
--- a/app/validators/within_united_kingdom_validator.rb
+++ b/app/validators/within_united_kingdom_validator.rb
@@ -1,9 +1,33 @@
 class WithinUnitedKingdomValidator < ActiveModel::EachValidator
+  UK_NAMES = ["united kingdom", "uk", "gb", "great britain", "britain"].freeze
+
   def validate_each(record, attribute, value)
     return if value.blank?
 
-    return if Geocoder.search(value).map(&:country).include?("United Kingdom")
+    # Why not use: 'Geocoder.search(value).map(&:country).include?("United Kingdom")'?
+    # This would always trigger a new API call to Geocoder, which is not ideal.
+    #
+    # We are already caching all the search location coordinates to avoid unnecessary API calls and costs.
+    # This is done through the Geocoding class, a wrapper around the Geocoder gem that handles the API calls and caching.
+    # By reusing the Geocoding class interface, we can avoid triggering API calls when possible and reduce costs.
+    coordinates = Geocoding.new(value.strip).coordinates
+    return if uk_coordinates?(coordinates, value)
 
     record.errors.add(attribute, I18n.t("activemodel.errors.models.jobseekers/job_preferences_form/location_form.attributes.location.blank"))
+  end
+
+  private
+
+  def uk_coordinates?(coordinates, location_term)
+    return false if coordinates.blank? || coordinates == Geocoding::COORDINATES_NO_MATCH
+
+    if coordinates == Geocoding::COORDINATES_UK_CENTROID
+      # Google Geocode API returns the UK centroid coordinates when the search options restrict the results to within the UK
+      # and the location is outside the UK.
+      # Checks if the location term is one of the UK names that should return the centroid coordinates
+      location_term.strip.downcase.delete(".").in?(UK_NAMES)
+    else
+      true # Coordinates are valid and not the UK centroid, so it's in the UK.
+    end
   end
 end

--- a/app/validators/within_united_kingdom_validator.rb
+++ b/app/validators/within_united_kingdom_validator.rb
@@ -1,33 +1,9 @@
 class WithinUnitedKingdomValidator < ActiveModel::EachValidator
-  UK_NAMES = ["united kingdom", "uk", "gb", "great britain", "britain"].freeze
-
   def validate_each(record, attribute, value)
     return if value.blank?
 
-    # Why not use: 'Geocoder.search(value).map(&:country).include?("United Kingdom")'?
-    # This would always trigger a new API call to Geocoder, which is not ideal.
-    #
-    # We are already caching all the search location coordinates to avoid unnecessary API calls and costs.
-    # This is done through the Geocoding class, a wrapper around the Geocoder gem that handles the API calls and caching.
-    # By reusing the Geocoding class interface, we can avoid triggering API calls when possible and reduce costs.
-    coordinates = Geocoding.new(value.strip).coordinates
-    return if uk_coordinates?(coordinates, value)
-
-    record.errors.add(attribute, I18n.t("activemodel.errors.models.jobseekers/job_preferences_form/location_form.attributes.location.blank"))
-  end
-
-  private
-
-  def uk_coordinates?(coordinates, location_term)
-    return false if coordinates.blank? || coordinates == Geocoding::COORDINATES_NO_MATCH
-
-    if coordinates == Geocoding::COORDINATES_UK_CENTROID
-      # Google Geocode API returns the UK centroid coordinates when the search options restrict the results to within the UK
-      # and the location is outside the UK.
-      # Checks if the location term is one of the UK names that should return the centroid coordinates
-      location_term.strip.downcase.delete(".").in?(UK_NAMES)
-    else
-      true # Coordinates are valid and not the UK centroid, so it's in the UK.
+    unless Geocoding.new(value.strip).uk_coordinates?
+      record.errors.add(attribute, I18n.t("activemodel.errors.models.jobseekers/job_preferences_form/location_form.attributes.location.blank"))
     end
   end
 end

--- a/lib/geocoding.rb
+++ b/lib/geocoding.rb
@@ -5,6 +5,7 @@ class Geocoding
   # the cache refresh period significantly impacts our Google Geocoding API usage and billing.
   CACHE_DURATION = 180.days
 
+  ACCEPTED_UK_CENTROID_LOCATIONS = ["united kingdom", "uk", "gb", "great britain", "britain"].freeze
   COORDINATES_UK_CENTROID = [55.378051, -3.435973].freeze
   COORDINATES_NO_MATCH = [0, 0].freeze
 
@@ -32,6 +33,28 @@ class Geocoding
       Rails.logger.error("Google Geocoding API responded with OVER_QUERY_LIMIT")
       Geocoder.coordinates(location, lookup: :uk_ordnance_survey_names)
     end || no_coordinates_match
+  end
+
+  # Why not use: 'Geocoder.search(value).map(&:country).include?("United Kingdom")'?
+  #
+  # This would always trigger a new API call to Geocoder, which is not ideal.
+  # We are already caching all the search location coordinates to avoid unnecessary API calls and costs.
+  # We want to avoid triggering API calls when possible and reduce costs.
+  #
+  # The search call also marks some legitimate UK location terms (suggested by Google Place Autocomplete) as outside the UK.
+  # We prefer to have a more relaxed check rather than to reject valid UK locations.
+  def uk_coordinates?
+    coordinates = self.coordinates
+    return false if coordinates.blank? || coordinates == Geocoding::COORDINATES_NO_MATCH
+
+    if coordinates == Geocoding::COORDINATES_UK_CENTROID
+      # Google Geocode API returns the UK centroid coordinates when the search options restrict the results to within the UK
+      # and the location is outside the UK.
+      # Checks if the location is one of the UK locations that should return the centroid coordinates
+      location.strip.downcase.delete(".").in?(ACCEPTED_UK_CENTROID_LOCATIONS)
+    else
+      true # Coordinates are valid and not the UK centroid, so it's in the UK.
+    end
   end
 
   def postcode_from_coordinates

--- a/spec/form_models/jobseekers/subscription_form_spec.rb
+++ b/spec/form_models/jobseekers/subscription_form_spec.rb
@@ -192,10 +192,10 @@ RSpec.describe Jobseekers::SubscriptionForm, type: :model do
 
     context "when location outside of the UK is entered" do
       let(:params) { { keyword: "Maths", location: "Ecuador" } }
+      let(:geocoding_stub) { instance_double(Geocoding, coordinates: Geocoding::COORDINATES_NO_MATCH) }
 
       before do
-        mock_response = [double(country: "Ecuador")]
-        allow(Geocoder).to receive(:search).and_return(mock_response)
+        allow(Geocoding).to receive(:new).with("Ecuador").and_return(geocoding_stub)
       end
 
       it "validates that the location is not within the uk" do

--- a/spec/form_models/jobseekers/subscription_form_spec.rb
+++ b/spec/form_models/jobseekers/subscription_form_spec.rb
@@ -192,10 +192,9 @@ RSpec.describe Jobseekers::SubscriptionForm, type: :model do
 
     context "when location outside of the UK is entered" do
       let(:params) { { keyword: "Maths", location: "Ecuador" } }
-      let(:geocoding_stub) { instance_double(Geocoding, coordinates: Geocoding::COORDINATES_NO_MATCH) }
 
       before do
-        allow(Geocoding).to receive(:new).with("Ecuador").and_return(geocoding_stub)
+        allow(Geocoding).to receive(:new).with("Ecuador").and_return(instance_double(Geocoding, uk_coordinates?: false))
       end
 
       it "validates that the location is not within the uk" do

--- a/spec/lib/geocoding_spec.rb
+++ b/spec/lib/geocoding_spec.rb
@@ -90,6 +90,48 @@ RSpec.describe Geocoding, :dfe_analytics, geocode: true do
     end
   end
 
+  describe "#uk_coordinates?" do
+    let(:geocoding_instance) { described_class.new(location) }
+
+    before do
+      allow(geocoding_instance).to receive(:coordinates).and_return(coordinates)
+    end
+
+    subject { geocoding_instance.uk_coordinates? }
+
+    context "when location is within the United Kingdom" do
+      let(:location) { "London" }
+      let(:coordinates) { [51.5074, -0.1278] }
+
+      it { is_expected.to be true }
+    end
+
+    context "when location returns no coordinates" do
+      let(:location) { "Madrid" }
+      let(:coordinates) { Geocoding::COORDINATES_NO_MATCH }
+
+      it { is_expected.to be false }
+    end
+
+    context "when the location returns the default GB centroid coordinates" do
+      let(:coordinates) { Geocoding::COORDINATES_UK_CENTROID }
+
+      context "when the provided location is outside the UK" do
+        let(:location) { "Madrid" }
+
+        it { is_expected.to be false }
+      end
+
+      (described_class::ACCEPTED_UK_CENTROID_LOCATIONS + ["U.K.", "G.B.", "U.K", "G.B"]).each do |uk_name|
+        context "when the location is '#{uk_name}'" do
+          let(:location) { uk_name }
+
+          it { is_expected.to be true }
+        end
+      end
+    end
+  end
+
   describe "#postcode_from_coordinates" do
     let(:coordinates) { google_coordinates }
     let(:postcode) { "TS14 6RE" }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,8 +71,6 @@ RSpec.configure do |config|
       double("BigQuery", dataset: double("BigQuery dataset", table: double.as_null_object)),
     )
 
-    mock_response = [double(country: "United Kingdom")]
-    allow(Geocoder).to receive(:search).and_return(mock_response)
     stub_request(:get, %r{maps.googleapis.com/maps/api/place/autocomplete}).to_return(status: 200, body: '{"predictions": []}', headers: {})
   end
 

--- a/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
@@ -122,10 +122,9 @@ RSpec.describe "Jobseekers can create a job alert from a search", recaptcha: tru
     context "when a point location outside the UK search is carried out" do
       let(:search_with_polygons?) { false }
       let(:location) { "Dublin" }
-      let(:geocoding_stub) { instance_double(Geocoding, coordinates: Geocoding::COORDINATES_NO_MATCH) }
 
       before do
-        allow(Geocoding).to receive(:new).with("Dublin").and_return(geocoding_stub)
+        allow(Geocoding).to receive(:new).with(location).and_return(instance_double(Geocoding, uk_coordinates?: false))
       end
 
       scenario "does not creates a job alert" do

--- a/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
@@ -122,10 +122,10 @@ RSpec.describe "Jobseekers can create a job alert from a search", recaptcha: tru
     context "when a point location outside the UK search is carried out" do
       let(:search_with_polygons?) { false }
       let(:location) { "Dublin" }
+      let(:geocoding_stub) { instance_double(Geocoding, coordinates: Geocoding::COORDINATES_NO_MATCH) }
 
       before do
-        mock_response = [double(country: "Ireland")]
-        allow(Geocoder).to receive(:search).and_return(mock_response)
+        allow(Geocoding).to receive(:new).with("Dublin").and_return(geocoding_stub)
       end
 
       scenario "does not creates a job alert" do

--- a/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe "Jobseekers can manage their profile" do
 
   before do
     allow(Geocoding).to receive(:new).with(anything).and_call_original
-    allow(Geocoding).to receive(:new).with("San Francisco")
-      .and_return(instance_double(Geocoding, coordinates: Geocoding::COORDINATES_NO_MATCH))
+    allow(Geocoding).to receive(:new).with("San Francisco").and_return(instance_double(Geocoding, uk_coordinates?: false))
   end
 
   context "with a jobseeker" do

--- a/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
@@ -4,13 +4,9 @@ RSpec.describe "Jobseekers can manage their profile" do
   let(:jobseeker) { create(:jobseeker) }
 
   before do
-    allow(Geocoder).to receive(:search) do |location|
-      if %w[London Manchester].include?(location)
-        [double(country: "United Kingdom")]
-      else
-        [double(country: "United States")]
-      end
-    end
+    allow(Geocoding).to receive(:new).with(anything).and_call_original
+    allow(Geocoding).to receive(:new).with("San Francisco")
+      .and_return(instance_double(Geocoding, coordinates: Geocoding::COORDINATES_NO_MATCH))
   end
 
   context "with a jobseeker" do

--- a/spec/validators/within_united_kingdom_validator_spec.rb
+++ b/spec/validators/within_united_kingdom_validator_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+class DummyWithinUnitedKingdomModel
+  include ActiveModel::Model
+
+  validates :location, within_united_kingdom: true
+
+  attr_accessor :location
+end
+
+RSpec.describe WithinUnitedKingdomValidator do
+  subject(:dummy) { DummyWithinUnitedKingdomModel.new(location: location) }
+
+  before do
+    allow(Geocoding).to receive(:new).with(location).and_return(geocoding)
+  end
+
+  context "when location is within the United Kingdom" do
+    let(:location) { "London" }
+    let(:geocoding) { instance_double(Geocoding, coordinates: [51.5074, -0.1278]) }
+
+    it "is valid" do
+      expect(dummy).to be_valid
+    end
+  end
+
+  context "when location returns no coordinates" do
+    let(:location) { "Madrid" }
+    let(:geocoding) { instance_double(Geocoding, coordinates: Geocoding::COORDINATES_NO_MATCH) }
+
+    it "is not valid" do
+      expect(dummy).not_to be_valid
+    end
+
+    it "adds an error message" do
+      dummy.valid?
+      expect(dummy.errors[:location])
+        .to include(I18n.t("activemodel.errors.models.jobseekers/job_preferences_form/location_form.attributes.location.blank"))
+    end
+  end
+
+  context "when the location returns the default GB centroid coordinates" do
+    context "when the provided location is outside the UK" do
+      let(:location) { "Madrid" }
+      let(:geocoding) { instance_double(Geocoding, coordinates: Geocoding::COORDINATES_UK_CENTROID) }
+
+      it "is not valid" do
+        expect(dummy).not_to be_valid
+      end
+
+      it "adds an error message" do
+        dummy.valid?
+        expect(dummy.errors[:location])
+          .to include(I18n.t("activemodel.errors.models.jobseekers/job_preferences_form/location_form.attributes.location.blank"))
+      end
+    end
+
+    (described_class::UK_NAMES + ["U.K.", "G.B.", "U.K", "G.B"]).each do |uk_name|
+      context "when the location is '#{uk_name}'" do
+        let(:location) { uk_name }
+        let(:geocoding) { instance_double(Geocoding, coordinates: Geocoding::COORDINATES_UK_CENTROID) }
+
+        it "is valid" do
+          expect(dummy).to be_valid
+        end
+      end
+    end
+  end
+end

--- a/spec/validators/within_united_kingdom_validator_spec.rb
+++ b/spec/validators/within_united_kingdom_validator_spec.rb
@@ -9,24 +9,22 @@ class DummyWithinUnitedKingdomModel
 end
 
 RSpec.describe WithinUnitedKingdomValidator do
-  subject(:dummy) { DummyWithinUnitedKingdomModel.new(location: location) }
+  subject(:dummy) { DummyWithinUnitedKingdomModel.new(location: "Location") }
 
   before do
-    allow(Geocoding).to receive(:new).with(location).and_return(geocoding)
+    allow(Geocoding).to receive(:new).with("Location").and_return(geocoding)
   end
 
   context "when location is within the United Kingdom" do
-    let(:location) { "London" }
-    let(:geocoding) { instance_double(Geocoding, coordinates: [51.5074, -0.1278]) }
+    let(:geocoding) { instance_double(Geocoding, uk_coordinates?: true) }
 
     it "is valid" do
       expect(dummy).to be_valid
     end
   end
 
-  context "when location returns no coordinates" do
-    let(:location) { "Madrid" }
-    let(:geocoding) { instance_double(Geocoding, coordinates: Geocoding::COORDINATES_NO_MATCH) }
+  context "when location is not within the United Kingdom" do
+    let(:geocoding) { instance_double(Geocoding, uk_coordinates?: false) }
 
     it "is not valid" do
       expect(dummy).not_to be_valid
@@ -36,34 +34,6 @@ RSpec.describe WithinUnitedKingdomValidator do
       dummy.valid?
       expect(dummy.errors[:location])
         .to include(I18n.t("activemodel.errors.models.jobseekers/job_preferences_form/location_form.attributes.location.blank"))
-    end
-  end
-
-  context "when the location returns the default GB centroid coordinates" do
-    context "when the provided location is outside the UK" do
-      let(:location) { "Madrid" }
-      let(:geocoding) { instance_double(Geocoding, coordinates: Geocoding::COORDINATES_UK_CENTROID) }
-
-      it "is not valid" do
-        expect(dummy).not_to be_valid
-      end
-
-      it "adds an error message" do
-        dummy.valid?
-        expect(dummy.errors[:location])
-          .to include(I18n.t("activemodel.errors.models.jobseekers/job_preferences_form/location_form.attributes.location.blank"))
-      end
-    end
-
-    (described_class::UK_NAMES + ["U.K.", "G.B.", "U.K", "G.B"]).each do |uk_name|
-      context "when the location is '#{uk_name}'" do
-        let(:location) { uk_name }
-        let(:geocoding) { instance_double(Geocoding, coordinates: Geocoding::COORDINATES_UK_CENTROID) }
-
-        it "is valid" do
-          expect(dummy).to be_valid
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/KLCEMGAG/1860-support-query-bug-autocomplete-locations-not-passing-uk-validation

## Changes in this PR:

### TLDR: 
Moves away from doing explicit country API queries for every profile or job alert location input, and checks for locations and uses the existing cached coordinates instead.

This also resolves an issue with the location validation failing when providing valid auto-suggested values.

### Description

Doing separate calls to `Geocoder.search` to check the result country for validating location inputs, while being the "proper" way to check a location term country, has some issues in our usage context:

1. Some users reported that the validation failed when searching for a term suggested by the location autocomplete. The location should be valid.
2. Each search hits the Google Geocode API, increasing the service costs.

The changes propose a simplification: Reusing the location coordinates queried and cached by our service for job searches.

Since our Google API coordinate queries are restricted to "within the uk", we can use the lack of coordinates or the lack of the "default" response for a missing location returned by the API as an indication to classify a location as within/outside of the UK.

This brings some advantages:
- Aligning results between the location search and the validation. To avoid inconsistencies, as the search case reported by some users.
- Rely on cached values. Reducing our API usage costs.

But also some downsides:
- The validation gets more "relaxed". Since relying on coordinates is more prone to allow non-UK locations to return some UK coordinate value, and pass the validation.

Overall, I think that is a good tradeoff to have. Since this validation is not critical and we would rather have some people passing it and not getting results/alerts than some legit location searches failing on the form validation, plus the cost reduction.

## Screenshots of UI changes:

### Before
#### This shouldn't fail the location validation
<img src="https://github.com/user-attachments/assets/0a1a84ae-fdd5-483d-b20f-3519777ed5bd" width=50% height=50%>

-----

#### Correct validation failure
<img src="https://github.com/user-attachments/assets/76f39cdf-1a13-42fd-bfb0-489de377a62f" width=50% height=50%>

### After

#### Correct location doesn't fail anymore
<img src="https://github.com/user-attachments/assets/9fb3a765-68a5-443c-8610-0692098fbbad" width=50% height=50%>

----

#### Validation error still raised for non UK locations
<img src="https://github.com/user-attachments/assets/3ec13490-8dac-45df-8ef1-994e822bf3ef" width=50% height=50%>

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
