### PR TITLE
Pass extra `origin` params

### DIFF
--- a/app/views/publishers/vacancies/job_applications/_candidates.html.slim
+++ b/app/views/publishers/vacancies/job_applications/_candidates.html.slim
@@ -1,8 +1,12 @@
 = form_with(model: form, url: tag_organisation_job_job_applications_path(vacancy.id), method: :get, scope: :publishers_job_application_tag_form) do |f|
 
   = f.govuk_error_summary
+  - if flash[origin]
+    = govuk_notification_banner title_text: "Error", success: false, classes: ["govuk-error-colour"] do |notification_banner|
+      - notification_banner.with_heading(text: flash[origin])
 
   = f.govuk_check_boxes_fieldset :job_applications, legend: { text: heading } do
+    = f.hidden_field :origin, value: origin
     = govuk_table(html_attributes: { data: { module: "moj-multi-select", multi_select_checkbox: "#multi_select_#{multi_select}", multi_select_idprefix: "id_all_#{multi_select}" } }) do |table|
 
       - table.with_head do |head|

--- a/app/views/publishers/vacancies/job_applications/index.html.slim
+++ b/app/views/publishers/vacancies/job_applications/index.html.slim
@@ -12,29 +12,29 @@
       - interviewing = applications.fetch("interviewing", [])
       = govuk_tabs do |tabs|
         / set id property so that anchors are '#shortlisted' rather than '#shortlisted-4'
-        - tabs.with_tab(label: "All (#{job_applications.size})") do
+        - tabs.with_tab(label: "All (#{job_applications.size})", id: "all") do
           - if job_applications.any?
-            = render "candidates", form: @form, vacancy: vacancy, candidates: job_applications, heading: "All Applications", multi_select: "all"
+            = render "candidates", form: @form, vacancy: vacancy, candidates: job_applications, heading: "All Applications", multi_select: "all", origin: :all
           - else
             = render EmptySectionComponent.new title: t(".no_applicants")
         - tabs.with_tab(label: "New (#{new_ones.size})", id: "submitted")
           - if new_ones.any?
-            = render "candidates", form: @form, vacancy: vacancy, candidates: new_ones, heading: "New Applications", multi_select: "new"
+            = render "candidates", form: @form, vacancy: vacancy, candidates: new_ones, heading: "New Applications", multi_select: "new", origin: :submitted
           - else
             = render EmptySectionComponent.new title: t(".no_new")
         - tabs.with_tab(label: "Not Considering (#{rejected.size})", id: "not_considering")
           - if rejected.any?
-            = render "candidates", form: @form, vacancy: vacancy, candidates: rejected, heading: "Not being considered", multi_select: "rej"
+            = render "candidates", form: @form, vacancy: vacancy, candidates: rejected, heading: "Not being considered", multi_select: "rej", origin: :not_considering
           - else
             = render EmptySectionComponent.new title: t(".no_rejected")
         - tabs.with_tab(label: "Shortlisted (#{shortlisted.size})", id: "shortlisted")
           - if shortlisted.any?
-            = render "candidates", form: @form, vacancy: vacancy, candidates: shortlisted, heading: "Shortlisted Applications", multi_select: "short"
+            = render "candidates", form: @form, vacancy: vacancy, candidates: shortlisted, heading: "Shortlisted Applications", multi_select: "short", origin: :shortlisted
           - else
             = render EmptySectionComponent.new title: t(".no_shortlisted")
         - tabs.with_tab(label: "Interviewing (#{interviewing.size})", id: "interviewing")
           - if interviewing.any?
-            = render "candidates", form: @form, vacancy: vacancy, candidates: interviewing, heading: "Interviewing Applications", multi_select: "inter"
+            = render "candidates", form: @form, vacancy: vacancy, candidates: interviewing, heading: "Interviewing Applications", multi_select: "inter", origin: :interviewing
           - else
             = render EmptySectionComponent.new title: t(".no_interviewing")
     - else

--- a/app/views/publishers/vacancies/job_applications/tag.html.slim
+++ b/app/views/publishers/vacancies/job_applications/tag.html.slim
@@ -15,6 +15,7 @@
           li = ja.name
 
 = form_with(url: update_tag_organisation_job_job_applications_path(vacancy.id), scope: :publishers_job_application_status_form) do |f|
+  =  f.hidden_field :origin, value: @origin
   - @job_applications.each do |ja|
     = f.hidden_field :job_applications, multiple: true, value: ja.id
 

--- a/spec/requests/publishers/vacancies/job_applications_spec.rb
+++ b/spec/requests/publishers/vacancies/job_applications_spec.rb
@@ -100,6 +100,14 @@ RSpec.describe "Job applications" do
     end
   end
 
+  describe "GET #tag_single" do
+    it "tags a single application" do
+      get tag_single_organisation_job_job_application_path(vacancy.id, job_application.id)
+
+      expect(response).to render_template(:tag)
+    end
+  end
+
   describe "GET #tag" do
     let(:vacancy) { create(:vacancy, job_title: "teacher-job") }
     let(:job_application_2) { create(:job_application, :status_submitted, vacancy: vacancy) }
@@ -112,8 +120,8 @@ RSpec.describe "Job applications" do
       end
 
       it "renders index when form is invalid" do
-        get tag_organisation_job_job_applications_path(vacancy.id), params: { publishers_job_application_tag_form: { job_applications: [] } }
-        expect(response).to render_template(:index)
+        get tag_organisation_job_job_applications_path(vacancy.id), params: { publishers_job_application_tag_form: { job_applications: [], origin: "all" } }
+        expect(response).to redirect_to(organisation_job_job_applications_path(vacancy.id, anchor: "all"))
       end
     end
 

--- a/spec/system/publishers/publishers_can_manage_job_applications_for_a_vacancy_spec.rb
+++ b/spec/system/publishers/publishers_can_manage_job_applications_for_a_vacancy_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "Publishers can manage job applications for a vacancy" do
 
     scenario "Changing multiple statuses at once", :js do
       # Wait for page to fully load
-      find_by_id("tab_all-6")
+      find_by_id("tab_all")
 
       within(".application-reviewed") do
         expect(page).to have_css(".govuk-checkboxes__item", wait: 5)


### PR DESCRIPTION
retains the id of the original tab

-------

## Trello card URL
[1755](https://trello.com/c/fZDkmt60)

## Changes in this PR:

Implements change suggested is #7736

### Solution
Pass on new parameter `origin` that would indicate the which tab
triggered the action.  with this new parameter the controller is now
able to redirect to the source tab.