### PR TITLE
Fix bug that removed the publish date on already published vacancies

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -51,6 +51,6 @@ if ENV.fetch("COVERAGE", 0).to_i.positive?
     # .25% lower (branch) and .1% lower (line) than the test run for now
     #
     # possibly the tests are stable now?
-    minimum_coverage line: 96.31, branch: 81.94
+    minimum_coverage line: 96.31, branch: 81.93
   end
 end

--- a/app/form_models/publishers/job_listing/important_dates_form.rb
+++ b/app/form_models/publishers/job_listing/important_dates_form.rb
@@ -23,15 +23,15 @@ class Publishers::JobListing::ImportantDatesForm < Publishers::JobListing::Vacan
     super
   end
 
+  # We won't allow editing of publish_on if the vacancy is already published
   def disable_editing_publish_on?
     vacancy.published? && (vacancy.publish_on.past? || vacancy.publish_on.today?)
   end
 
   def params_to_save
-    {
-      publish_on: publish_on,
-      expires_at: expires_at,
-    }
+    { expires_at: expires_at }.tap do |params|
+      params[:publish_on] = publish_on if save_publish_on?
+    end
   end
 
   def expires_at=(value)
@@ -53,5 +53,14 @@ class Publishers::JobListing::ImportantDatesForm < Publishers::JobListing::Vacan
       when "tomorrow" then Date.tomorrow
       else date_from_multiparameter_hash(value)
       end
+  end
+
+  private
+
+  # Determines if the publish_on date should be saved based on its presence and type.
+  # If publish_on is a Date and not disabled for editing (cannot change publishing date on already published vacancy),
+  # it will be saved.
+  def save_publish_on?
+    publish_on.present? && publish_on.is_a?(Date) && !disable_editing_publish_on?
   end
 end

--- a/app/models/published_vacancy.rb
+++ b/app/models/published_vacancy.rb
@@ -8,6 +8,8 @@ class PublishedVacancy < Vacancy
 
   validate :enable_job_applications_cannot_be_changed_once_listed, if: -> { persisted? && listed? && enable_job_applications_changed? }
 
+  validates :publish_on, presence: true
+
   before_save :on_expired_vacancy_feedback_submitted_update_stats_updated_at, if: -> { listed_elsewhere_changed? && hired_status_changed? }
 
   def find_conflicting_vacancy

--- a/lib/tasks/backfill_vacancies_with_missing_publish_dates.rake
+++ b/lib/tasks/backfill_vacancies_with_missing_publish_dates.rake
@@ -1,0 +1,12 @@
+namespace :vacancies do
+  desc "Backfill vacancies with missing publish dates"
+  task backfill_vacancies_with_missing_publish_dates: :environment do
+    Vacancy.published.where(publish_on: nil).find_each do |v|
+      # Needed to make published vacancies that got affected by a bug valid again.
+      # We have no way to know when the vacancy was originally published.
+      # As is sometime in the past, it is not relevant anymore.
+      v.assign_attributes(publish_on: v.created_at.to_date)
+      v.save!(touch: false, validate: false)
+    end
+  end
+end

--- a/spec/form_models/publishers/job_listing/important_dates_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/important_dates_form_spec.rb
@@ -43,6 +43,10 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
       expect(subject).not_to be_valid
       expect(subject.errors.of_kind?(:publish_on_day, :inclusion)).to be true
     end
+
+    it "is not included in the parameters to save" do
+      expect(subject.params_to_save).not_to have_key(:publish_on)
+    end
   end
 
   describe "publish_on" do
@@ -59,6 +63,10 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
         it "is valid" do
           expect(subject).to be_valid
         end
+
+        it "is not included in the parameters to save" do
+          expect(subject.params_to_save).not_to have_key(:publish_on)
+        end
       end
 
       context "when vacancy is published and publish_on is in the future" do
@@ -68,6 +76,10 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
           expect(subject).to be_invalid
           expect(subject.errors.of_kind?(:publish_on, :blank)).to be true
         end
+
+        it "is not included in the parameters to save" do
+          expect(subject.params_to_save).not_to have_key(:publish_on)
+        end
       end
 
       context "when vacancy is not published" do
@@ -76,6 +88,10 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
         it "is invalid" do
           expect(subject).to be_invalid
           expect(subject.errors.of_kind?(:publish_on, :blank)).to be true
+        end
+
+        it "is not included in the parameters to save" do
+          expect(subject.params_to_save).not_to have_key(:publish_on)
         end
       end
     end
@@ -89,6 +105,10 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
         it "is valid" do
           expect(subject).to be_valid
         end
+
+        it "is not included in the parameters to save" do
+          expect(subject.params_to_save).not_to have_key(:publish_on)
+        end
       end
 
       context "when vacancy is published and publish_on is in the future" do
@@ -98,6 +118,10 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
           expect(subject).to be_invalid
           expect(subject.errors.of_kind?(:publish_on, :invalid)).to be true
         end
+
+        it "is not included in the parameters to save" do
+          expect(subject.params_to_save).not_to have_key(:publish_on)
+        end
       end
 
       context "when vacancy is not published" do
@@ -106,6 +130,10 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
         it "is invalid" do
           expect(subject).to be_invalid
           expect(subject.errors.of_kind?(:publish_on, :invalid)).to be true
+        end
+
+        it "is not included in the parameters to save" do
+          expect(subject.params_to_save).not_to have_key(:publish_on)
         end
       end
     end
@@ -119,6 +147,10 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
         it "is valid" do
           expect(subject).to be_valid
         end
+
+        it "is not included in the parameters to save" do
+          expect(subject.params_to_save).not_to have_key(:publish_on)
+        end
       end
 
       context "when vacancy is published and publish_on is in the future" do
@@ -127,6 +159,10 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
         it "is invalid" do
           expect(subject).to be_invalid
           expect(subject.errors.of_kind?(:publish_on, :invalid)).to be true
+        end
+
+        it "is not included in the parameters to save" do
+          expect(subject.params_to_save).not_to have_key(:publish_on)
         end
       end
 
@@ -137,17 +173,25 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
           expect(subject).to be_invalid
           expect(subject.errors.of_kind?(:publish_on, :invalid)).to be true
         end
+
+        it "is not included in the parameters to save" do
+          expect(subject.params_to_save).not_to have_key(:publish_on)
+        end
       end
     end
 
     context "when date is not in the future" do
-      let(:publish_on) { 1.year.ago }
+      let(:publish_on) { 1.year.ago.to_date }
 
       context "when vacancy is published" do
         let(:vacancy) { build_stubbed(:vacancy, :published) }
 
         it "is valid" do
           expect(subject).to be_valid
+        end
+
+        it "is not included in the parameters to save" do
+          expect(subject.params_to_save).not_to have_key(:publish_on)
         end
       end
 
@@ -158,15 +202,25 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
           expect(subject).to be_invalid
           expect(subject.errors.of_kind?(:publish_on, :on_or_after)).to be true
         end
+
+        it "is included in the parameters to save" do
+          expect(subject.params_to_save).to have_key(:publish_on)
+          expect(subject.params_to_save[:publish_on]).to eq(publish_on)
+        end
       end
     end
 
     context "when date is too far in the future" do
-      let(:publish_on) { 25.months.from_now }
+      let(:publish_on) { 25.months.from_now.to_date }
 
       it "is invalid" do
         expect(subject).to be_invalid
         expect(subject.errors.of_kind?(:publish_on, :on_or_before)).to be true
+      end
+
+      it "is included in the parameters to save" do
+        expect(subject.params_to_save).to have_key(:publish_on)
+        expect(subject.params_to_save[:publish_on]).to eq(publish_on)
       end
     end
   end

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -10,6 +10,24 @@ RSpec.describe Vacancy do
   it { is_expected.to have_many(:job_applications) }
   it { is_expected.to have_one(:equal_opportunities_report) }
 
+  describe "publish_on removal callback" do
+    it "publish_on is not removed when creating a new draft" do
+      draft_vacancy = create(:draft_vacancy, publish_on: Date.current)
+      expect(draft_vacancy.publish_on).to be_present
+    end
+
+    it "publish_on is not removed when converting a draft to a published vacancy" do
+      vacancy = create(:draft_vacancy, publish_on: Date.current)
+      vacancy.update(status: :published)
+      expect(vacancy.publish_on).to be_present
+    end
+
+    it "publish_on is removed when converting a published vacancy back into a draft" do
+      vacancy = create(:vacancy, publish_on: Date.current)
+      expect { vacancy.update(status: :draft) }.to change { vacancy.publish_on }.from(Date.current).to(nil)
+    end
+  end
+
   describe "#trash!" do
     subject { create(:vacancy) }
 

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -28,6 +28,150 @@ RSpec.describe Vacancy do
     end
   end
 
+  describe "validations" do
+    describe "changing enable_job_applications" do
+      subject { vacancy }
+
+      before do
+        subject.enable_job_applications = false
+      end
+
+      context "when already listed" do
+        let(:vacancy) { build_stubbed(:vacancy, enable_job_applications: true) }
+
+        it "fails validation" do
+          expect(subject).not_to be_valid
+          expect(subject.errors).to include(:enable_job_applications)
+        end
+      end
+
+      context "when draft" do
+        let(:vacancy) { build_stubbed(:draft_vacancy, enable_job_applications: true) }
+
+        it { is_expected.to be_valid }
+      end
+
+      context "when scheduled" do
+        let(:vacancy) { build_stubbed(:draft_vacancy, enable_job_applications: true) }
+
+        it { is_expected.to be_valid }
+      end
+    end
+
+    describe "organisation association" do
+      it "is valid when an associated organisation has validation errors" do
+        publisher = build_stubbed(:publisher)
+        invalid_school = School.new(email: "invalid")
+        expect(invalid_school).not_to be_valid
+
+        expect(Vacancy.new(organisations: [invalid_school], publisher: publisher, status: "draft")).to be_valid
+      end
+    end
+
+    describe "conflict validation" do
+      let(:school) { create(:school) }
+      let(:publisher_ats_api_client) { create(:publisher_ats_api_client) }
+
+      subject(:new_vacancy) do
+        build(:vacancy, :external, external_reference: "REF123", publisher_ats_api_client:, organisations: [school])
+      end
+
+      context "when there a vacancy with the same ATS client ID but with different external reference" do
+        before do
+          create(:vacancy, :external, external_reference: "REF456", publisher_ats_api_client:, organisations: [school])
+        end
+
+        it "the new vacancy is valid" do
+          expect(new_vacancy).to be_valid
+        end
+      end
+
+      context "when there a vacancy with the same ATS client ID and external reference" do
+        before do
+          create(:vacancy, :external, external_reference: "REF123", publisher_ats_api_client:, organisations: [school])
+        end
+
+        it "the new vacancy is invalid" do
+          expect(new_vacancy).not_to be_valid
+          expect(new_vacancy.errors[:external_reference])
+            .to include("A vacancy with the provided ATS client ID and external reference already exists.")
+        end
+      end
+    end
+
+    describe "duplicate validation" do
+      let(:school) { create(:school) }
+      let(:publisher_ats_api_client) { create(:publisher_ats_api_client) }
+
+      subject(:new_vacancy) do
+        build(:vacancy, :external, external_reference: "REF123", publisher_ats_api_client:, organisations: [school])
+      end
+
+      context "when there is a vacancy with some shared info but not all required fields to be considered duplicated" do
+        before do
+          create(:vacancy,
+                 organisations: [school],
+                 job_title: new_vacancy.job_title,
+                 expires_at: new_vacancy.expires_at,
+                 working_patterns: new_vacancy.working_patterns)
+        end
+
+        it "the new vacancy is valid" do
+          expect(new_vacancy).to be_valid
+        end
+      end
+
+      context "when there is an existing vacancy sharing all required fields to be considered duplicated" do
+        before do
+          create(:vacancy,
+                 organisations: [school],
+                 job_title: new_vacancy.job_title,
+                 expires_at: new_vacancy.expires_at,
+                 working_patterns: new_vacancy.working_patterns,
+                 contract_type: new_vacancy.contract_type,
+                 phases: new_vacancy.phases,
+                 salary: new_vacancy.salary)
+        end
+
+        it "the new vacancy is invalid" do
+          expect(new_vacancy).not_to be_valid
+          expect(new_vacancy.errors[:base])
+            .to include("A vacancy with the same job title, expiry date, contract type, working_patterns, phases and salary already exists for this organisation.")
+        end
+      end
+
+      context "when there is an existing vacancy sharing all required fields to be considered duplicated but belongs to a different organisation" do
+        before do
+          create(:vacancy,
+                 organisations: [create(:school)],
+                 job_title: new_vacancy.job_title,
+                 expires_at: new_vacancy.expires_at,
+                 working_patterns: new_vacancy.working_patterns,
+                 contract_type: new_vacancy.contract_type,
+                 phases: new_vacancy.phases,
+                 salary: new_vacancy.salary)
+        end
+
+        it "the new vacancy is valid" do
+          expect(new_vacancy).to be_valid
+        end
+      end
+    end
+
+    describe "publish_on validation" do
+      it "enforces publish_on presence for published vacancies" do
+        vacancy = build_stubbed(:vacancy, publish_on: nil)
+        expect(vacancy).not_to be_valid
+        expect(vacancy.errors[:publish_on]).to include("Enter publish date")
+      end
+
+      it "allows publish_on to be nil for draft vacancies" do
+        vacancy = build_stubbed(:draft_vacancy, publish_on: nil)
+        expect(vacancy).to be_valid
+      end
+    end
+  end
+
   describe "#trash!" do
     subject { create(:vacancy) }
 
@@ -499,47 +643,6 @@ RSpec.describe Vacancy do
     end
   end
 
-  describe "validations" do
-    describe "changing enable_job_applications" do
-      subject { vacancy }
-
-      before do
-        subject.enable_job_applications = false
-      end
-
-      context "when already listed" do
-        let(:vacancy) { build_stubbed(:vacancy, enable_job_applications: true) }
-
-        it "fails validation" do
-          expect(subject).not_to be_valid
-          expect(subject.errors).to include(:enable_job_applications)
-        end
-      end
-
-      context "when draft" do
-        let(:vacancy) { build_stubbed(:draft_vacancy, enable_job_applications: true) }
-
-        it { is_expected.to be_valid }
-      end
-
-      context "when scheduled" do
-        let(:vacancy) { build_stubbed(:draft_vacancy, enable_job_applications: true) }
-
-        it { is_expected.to be_valid }
-      end
-    end
-
-    describe "organisation association" do
-      it "is valid when an associated organisation has validation errors" do
-        publisher = build_stubbed(:publisher)
-        invalid_school = School.new(email: "invalid")
-        expect(invalid_school).not_to be_valid
-
-        expect(Vacancy.new(organisations: [invalid_school], publisher: publisher, status: "draft")).to be_valid
-      end
-    end
-  end
-
   describe "#geolocation" do
     subject { create(:vacancy, organisations: organisations) }
 
@@ -822,96 +925,6 @@ RSpec.describe Vacancy do
 
       it "returns the conflicting vacancy with the same reference" do
         expect(vacancy.find_conflicting_vacancy).to eq(conflicting_vacancy_with_same_reference)
-      end
-    end
-  end
-
-  describe "conflict validation" do
-    let(:school) { create(:school) }
-    let(:publisher_ats_api_client) { create(:publisher_ats_api_client) }
-
-    subject(:new_vacancy) do
-      build(:vacancy, :external, external_reference: "REF123", publisher_ats_api_client:, organisations: [school])
-    end
-
-    context "when there a vacancy with the same ATS client ID but with different external reference" do
-      before do
-        create(:vacancy, :external, external_reference: "REF456", publisher_ats_api_client:, organisations: [school])
-      end
-
-      it "the new vacancy is valid" do
-        expect(new_vacancy).to be_valid
-      end
-    end
-
-    context "when there a vacancy with the same ATS client ID and external reference" do
-      before do
-        create(:vacancy, :external, external_reference: "REF123", publisher_ats_api_client:, organisations: [school])
-      end
-
-      it "the new vacancy is invalid" do
-        expect(new_vacancy).not_to be_valid
-        expect(new_vacancy.errors[:external_reference])
-          .to include("A vacancy with the provided ATS client ID and external reference already exists.")
-      end
-    end
-  end
-
-  describe "duplicate validation" do
-    let(:school) { create(:school) }
-    let(:publisher_ats_api_client) { create(:publisher_ats_api_client) }
-
-    subject(:new_vacancy) do
-      build(:vacancy, :external, external_reference: "REF123", publisher_ats_api_client:, organisations: [school])
-    end
-
-    context "when there is a vacancy with some shared info but not all required fields to be considered duplicated" do
-      before do
-        create(:vacancy,
-               organisations: [school],
-               job_title: new_vacancy.job_title,
-               expires_at: new_vacancy.expires_at,
-               working_patterns: new_vacancy.working_patterns)
-      end
-
-      it "the new vacancy is valid" do
-        expect(new_vacancy).to be_valid
-      end
-    end
-
-    context "when there is an existing vacancy sharing all required fields to be considered duplicated" do
-      before do
-        create(:vacancy,
-               organisations: [school],
-               job_title: new_vacancy.job_title,
-               expires_at: new_vacancy.expires_at,
-               working_patterns: new_vacancy.working_patterns,
-               contract_type: new_vacancy.contract_type,
-               phases: new_vacancy.phases,
-               salary: new_vacancy.salary)
-      end
-
-      it "the new vacancy is invalid" do
-        expect(new_vacancy).not_to be_valid
-        expect(new_vacancy.errors[:base])
-          .to include("A vacancy with the same job title, expiry date, contract type, working_patterns, phases and salary already exists for this organisation.")
-      end
-    end
-
-    context "when there is an existing vacancy sharing all required fields to be considered duplicated but belongs to a different organisation" do
-      before do
-        create(:vacancy,
-               organisations: [create(:school)],
-               job_title: new_vacancy.job_title,
-               expires_at: new_vacancy.expires_at,
-               working_patterns: new_vacancy.working_patterns,
-               contract_type: new_vacancy.contract_type,
-               phases: new_vacancy.phases,
-               salary: new_vacancy.salary)
-      end
-
-      it "the new vacancy is valid" do
-        expect(new_vacancy).to be_valid
       end
     end
   end

--- a/spec/services/publishers/ats_api/update_vacancy_service_spec.rb
+++ b/spec/services/publishers/ats_api/update_vacancy_service_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Publishers::AtsApi::UpdateVacancyService do
       working_patterns: %w[part_time],
       other_start_date_details: "September 2022",
       start_date_type: "other",
+      publish_on: publish_on,
       starts_on: nil,
     )
   end
@@ -29,7 +30,7 @@ RSpec.describe Publishers::AtsApi::UpdateVacancyService do
   let(:job_roles) { vacancy.job_roles }
   let(:working_patterns) { %w[full_time] }
   let(:expires_at) { Time.zone.today + 30.days }
-  let(:publish_on) { nil }
+  let(:publish_on) { 1.week.ago }
   let(:params) do
     {
       external_reference: "new-ref",
@@ -45,7 +46,6 @@ RSpec.describe Publishers::AtsApi::UpdateVacancyService do
       salary: vacancy.salary,
       schools: school_urns,
       publisher_ats_api_client_id: publisher_ats_api_client_id,
-      publish_on: publish_on,
     }
   end
 
@@ -188,7 +188,7 @@ RSpec.describe Publishers::AtsApi::UpdateVacancyService do
   end
 
   context "when expires_at date is in the past" do
-    let(:expires_at) { Date.current - 1.week }
+    let(:expires_at) { Date.current - 1.day }
 
     it "returns a validation error" do
       expect(update_vacancy_service).to eq(


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/LQnXrxjT/1878-bug-some-non-discarded-published-vacancies-have-no-publishon-timestamp

## Changes in this PR:

### Fix bug removing `publish_on` from already published vacancies.
The implementation of the important dates form was causing the publish_on date to be removed when publishers updated the vacancy expiration date and time, even though the `publish_on` field is not editable at that stage.

The parameter was still being set (to `nil`) and updated into the Vacancy in DB upon form save.

We're adding a rake task to backfill any vacancy historically affected by this bug (has been like this for multiple years, since it was built :/ ). Fortunately, only 70 or so vacancies seemed to be affected by this (many of those already expired).

### Use a model callback instead of a method override

When converting a published vacancy back into a draft, instead of overriding the status change method, we will use a more controlled callback method to reset the publish_on value only after the status change and before saving the updated value.

### Add validation to ensure the publish date is present

Only enforced on published vacancies. A Vacancy shouldn't be able to be published unless they have a publish_on date.

## Screenshot of form page with bug:
![Screenshot From 2025-06-10 15-33-38](https://github.com/user-attachments/assets/049bc709-d3ad-41dc-9f3f-d24fd42c3f8e)


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [x] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [x] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
