### PR TITLE
Notify before references are sought

### DIFF
--- a/app/form_models/jobseekers/job_application/referees_form.rb
+++ b/app/form_models/jobseekers/job_application/referees_form.rb
@@ -6,6 +6,10 @@ module Jobseekers
       include CompletedFormAttribute
 
       class << self
+        def storable_fields
+          %i[notify_before_contact_referers]
+        end
+
         def unstorable_fields
           %i[referees_section_completed referees]
         end
@@ -17,7 +21,10 @@ module Jobseekers
       end
 
       attribute :referees
+      attribute :notify_before_contact_referers, :boolean
       validate :at_least_one_most_recent_employer, if: -> { referees_section_completed }
+
+      validates :notify_before_contact_referers, inclusion: { in: [true, false] }
 
       completed_attribute(:referees)
 

--- a/app/models/job_application_pdf.rb
+++ b/app/models/job_application_pdf.rb
@@ -125,7 +125,10 @@ class JobApplicationPdf
   def referees
     return no_data_available(I18n.t("jobseekers.job_applications.show.employment_history.none")) if job_application.referees.none?
 
-    make_nested_section do
+    contact_referers = nil
+    contact_referers = I18n.t("jobseekers.job_applications.review.contact_referer.publisher") if job_application.notify_before_contact_referers
+
+    make_nested_section(contact_referers) do
       job_application.referees.sort_by(&:created_at).map do |referee|
         reference_data = [
           ["Name:", referee.name],
@@ -201,9 +204,9 @@ class JobApplicationPdf
     [[text, nil]]
   end
 
-  def make_nested_section
+  def make_nested_section(sub_title = nil)
     # make a nested section data structure rendered by `JobApplicationPdfGenerator.render_nested_section`
-    [[nil, yield]]
+    [[sub_title, yield]]
   end
 
   def month_year(date)

--- a/app/views/jobseekers/job_applications/build/referees.html.slim
+++ b/app/views/jobseekers/job_applications/build/referees.html.slim
@@ -6,7 +6,7 @@
   div
     h2.govuk-heading-l = t(".heading")
 
-    p.govuk-body = t(".description")
+    p.govuk-body = t(".description_html", link: govuk_link_to(t(".kcsie"), "https://www.gov.uk/government/publications/keeping-children-safe-in-education--2"))
 
     - if job_application.referees.any?
       - job_application.referees.each do |referee|
@@ -35,6 +35,11 @@
 
     = form_for @form, url: jobseekers_job_application_build_path(job_application, :referees), method: :patch do |f|
       = f.govuk_error_summary
+
+      = f.govuk_radio_buttons_fieldset(:notify_before_contact_referers) do
+        = f.govuk_radio_button :notify_before_contact_referers, "true", link_errors: true do
+          span.govuk-hint = t("helpers.hint.jobseekers_job_application_referees_form.notify_before_contact_referers_options.text")
+        = f.govuk_radio_button :notify_before_contact_referers, "false"
 
       = f.govuk_collection_radio_buttons :referees_section_completed, %w[true false], :to_s
 

--- a/app/views/jobseekers/job_applications/referees/edit.html.slim
+++ b/app/views/jobseekers/job_applications/referees/edit.html.slim
@@ -5,7 +5,7 @@
     span.govuk-caption-l = t(".caption")
     h1.govuk-heading-xl = t(".heading")
 
-    p.govuk-body = t(".description")
+    p.govuk-body = t(".description.html", link: govuk_link_to(t(".kcsie"), "https://www.gov.uk/government/publications/keeping-children-safe-in-education--2"))
     h2.govuk-heading-m = t(".work_in_school_heading")
     p.govuk-body = t(".work_in_school_guidance")
     h2.govuk-heading-m = t(".trainee_teacher_heading")
@@ -18,4 +18,5 @@
 
       = render "fields", f: f
 
+      p.govuk-body = t(".consent_confirmation")
       = f.govuk_submit t("buttons.save_reference")

--- a/app/views/jobseekers/job_applications/referees/new.html.slim
+++ b/app/views/jobseekers/job_applications/referees/new.html.slim
@@ -5,7 +5,7 @@
     span.govuk-caption-l = t(".caption")
     h1.govuk-heading-xl = t(".heading")
 
-    p.govuk-body = t(".description")
+    p.govuk-body = t(".description.html", link: govuk_link_to(t(".kcsie"), "https://www.gov.uk/government/publications/keeping-children-safe-in-education--2"))
     h2.govuk-heading-m = t(".work_in_school_heading")
     p.govuk-body = t(".work_in_school_guidance")
     h2.govuk-heading-m = t(".trainee_teacher_heading")
@@ -17,6 +17,8 @@
       = f.govuk_error_summary
 
       = render "fields", f: f
+
+      p.govuk-body = t(".consent_confirmation")
 
       = f.govuk_submit t("buttons.save_reference")
       = govuk_button_link_to t("buttons.cancel"), jobseekers_job_application_build_path(job_application, :referees), class: "govuk-button--secondary govuk-!-margin-left-3"

--- a/app/views/jobseekers/job_applications/review/_references.html.slim
+++ b/app/views/jobseekers/job_applications/review/_references.html.slim
@@ -8,6 +8,12 @@
     - job_application.referees.sort_by(&:created_at).each do |referee|
       = govuk_summary_list html_attributes: { id: referee.name } do |summary_list|
         - summary_list.with_row do |row|
+          - if jobseeker_signed_in? && job_application.notify_before_contact_referers
+            - row.with_key text: t("jobseekers.job_applications.review.contact_referer.jobseeker")
+          - elsif publisher_signed_in? && job_application.notify_before_contact_referers
+            - row.with_key text: t("jobseekers.job_applications.review.contact_referer.publisher")
+
+        - summary_list.with_row do |row|
           - row.with_key text: referee.name
 
         - summary_list.with_row do |row|

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -159,6 +159,7 @@ shared:
     - ethos_and_aims
     - working_patterns
     - working_pattern_details
+    - notify_before_contact_referers
   job_preferences_locations:
     - id
     - job_preferences_id

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -257,7 +257,8 @@ en:
           step_title: Education and qualifications
           title: Education and qualifications — Application
         referees:
-          description: You must include your current or most recent employer as a referee. If you did not work with children in this role, you must also provide a referee from your last job where you worked with children.
+          description_html: You must include details for a referee from your current or most recent employer. If you did not work with children in this role, you must include at least one referee from the last job where you worked with children. Schools must contact your referees in compliance with %{link}.
+          kcsie: Keeping children safe in education statutory guidance
           heading: References
           no_references: No referees specified
           step_title: References
@@ -478,7 +479,9 @@ en:
           success: Your referee was deleted
         edit:
           caption: References
-          description: If you are shortlisted, your referees may be contacted before your interview.
+          description:
+            html: If you are shortlisted, your referees may be contacted before your interview. Schools must contact your referees in compliance with %{link}. You can ask to be told before a school contacts your referees, but we cannot guarantee the school will do so.
+          kcsie: Keeping children safe in education statutory guidance
           heading: Edit a referee
           title: Edit a referee — Application
           work_in_school_heading: If you work in a school
@@ -486,13 +489,16 @@ en:
           trainee_teacher_heading: If you are a trainee teacher
           trainee_teacher_guidance: You should provide a reference where you can show your experience working with children. You can include references from school placements or from your course provider.
           work_with_children_heading: If you used to work with children
-          work_with_children_guidance: If you do not currently work with children but have in the past, you should provide one referee from your current or most recent employer and one from the last time you worked with children.
+          work_with_children_guidance: If you do not currently work with children but have in the past, you should provide one reference from your current or most recent employer and one from the last time you worked with children.
+          consent_confirmation: By adding this referee, you are confirming that they have consented to providing their contact information for the purpose of providing a reference.
         email: Email address
         job_title: Job title
         name: Name
         new:
           caption: References
-          description: If you are shortlisted, your referees may be contacted before your interview.
+          description:
+            html: If you are shortlisted, your referees may be contacted before your interview. Schools must contact your referees in compliance with %{link}. You can ask to be told before a school contacts your referees, but we cannot guarantee the school will do so.
+          kcsie: Keeping children safe in education statutory guidance
           heading: Add a referee
           title: Add a referee — Application
           work_in_school_heading: If you work in a school
@@ -500,12 +506,16 @@ en:
           trainee_teacher_heading: If you are a trainee teacher
           trainee_teacher_guidance: You should provide a reference where you can show your experience working with children. You can include references from school placements or from your course provider.
           work_with_children_heading: If you used to work with children
-          work_with_children_guidance: If you do not currently work with children but have in the past, you should provide one referee from your current or most recent employer and one from the last time you worked with children.
+          work_with_children_guidance: If you do not currently work with children but have in the past, you should provide one reference from your current or most recent employer and one from the last time you worked with children.
+          consent_confirmation: By adding this referee, you are confirming that they have consented to providing their contact information for the purpose of providing a reference.
         organisation: Organisation
         phone_number: Phone number
         relationship: Relationship to applicant
         is_most_recent_employer: Current or most recent employer
       review:
+        contact_referer:
+          jobseeker: You have requested that the school contact you before collecting references.
+          publisher: This applicant wants to be contacted before you collect their references.
         view_your_profile: View your profile
         confirmation:
           heading: Confirmation

--- a/config/locales/jobseekers/job_application/references_form.yml
+++ b/config/locales/jobseekers/job_application/references_form.yml
@@ -6,15 +6,28 @@ en:
           attributes:
             referees_section_completed:
               inclusion: Select yes if you have completed this section
+            notify_before_contact_referers:
+              inclusion: Select yes if you want to be notified before the school contacts your referer
             referees:
               too_short: You must provide a minimum of %{count} references
               must_include_most_recent_employer: At least one reference must be marked as the most recent employer.
   helpers:
     legend:
       jobseekers_job_application_referees_form:
+        notify_before_contact_referers: Do you want the school to tell you before they contact your referees?
         referees_section_completed: Have you completed this section?
     label:
       jobseekers_job_application_referees_form:
         referees_section_completed_options:
           false: No, I'll come back to it later
           true: Yes, I've completed this section
+        notify_before_contact_referers_options:
+          true: "Yes"
+          false: "No"
+
+    hint:
+      jobseekers_job_application_referees_form:
+        notify_before_contact_referers: We will ask the school to tell you before contacting your referees, but we cannot guarantee they will do so.
+        notify_before_contact_referers_options:
+          text: We will ask the school to tell you before contacting your referees.
+      

--- a/db/migrate/20250602150519_add_notify_before_contact_referers_to_job_application.rb
+++ b/db/migrate/20250602150519_add_notify_before_contact_referers_to_job_application.rb
@@ -1,0 +1,7 @@
+class AddNotifyBeforeContactReferersToJobApplication < ActiveRecord::Migration[7.2]
+  # rubocop:disable Rails/ThreeStateBooleanColumn
+  def change
+    add_column :job_applications, :notify_before_contact_referers, :boolean
+  end
+  # rubocop:enable Rails/ThreeStateBooleanColumn
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -259,6 +259,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_06_150046) do
     t.boolean "has_close_relationships"
     t.boolean "has_right_to_work_in_uk"
     t.boolean "has_safeguarding_issue"
+    t.boolean "notify_before_contact_referers"
     t.index ["jobseeker_id"], name: "index_job_applications_jobseeker_id"
     t.index ["vacancy_id"], name: "index_job_applications_on_vacancy_id"
   end

--- a/lib/tasks/backfil_job_application_notify_before_contact_referers.rake
+++ b/lib/tasks/backfil_job_application_notify_before_contact_referers.rake
@@ -1,0 +1,9 @@
+#
+# Ensure existing job_applications get set to false to stay valid
+#
+namespace :job_application do
+  desc "Backfill job_application.notify_before_contact_referers"
+  task notify_before_contact_referers: :environment do
+    JobApplication.where(notify_before_contact_referers: nil).update_all(notify_before_contact_referers: false)
+  end
+end

--- a/spec/factories/job_applications.rb
+++ b/spec/factories/job_applications.rb
@@ -55,6 +55,9 @@ FactoryBot.define do
     safeguarding_issue_details { Faker::Lorem.paragraph(sentence_count: 1) }
     has_right_to_work_in_uk { true }
 
+    # Referees
+    notify_before_contact_referers { false }
+
     completed_steps { JobApplication.completed_steps.keys }
     in_progress_steps { [] }
 

--- a/spec/form_models/jobseekers/job_application/referees_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/referees_form_spec.rb
@@ -2,11 +2,15 @@
 
 require "rails_helper"
 
-RSpec.describe Jobseekers::JobApplication::RefereesForm do
-  let(:form) { described_class.new(referees: referees, referees_section_completed: true) }
+RSpec.describe Jobseekers::JobApplication::RefereesForm, type: :model do
+  let(:form) { described_class.new(referees: referees, referees_section_completed: true, notify_before_contact_referers: true) }
 
   let(:reference_with_current_employer) { create(:referee, is_most_recent_employer: true) }
   let(:reference_without_current_employer) { create(:referee, is_most_recent_employer: false) }
+
+  before { allow(Shoulda::Matchers).to receive(:warn) }
+
+  it { is_expected.to validate_inclusion_of(:notify_before_contact_referers).in_array([true, false]) }
 
   context "when at least one reference is from the most recent employer" do
     let(:referees) { [reference_with_current_employer] }

--- a/spec/models/job_application_pdf_spec.rb
+++ b/spec/models/job_application_pdf_spec.rb
@@ -339,6 +339,16 @@ RSpec.describe JobApplicationPdf do
       end
     end
 
+    context "when jobseeker want to be notified before contacting the referer" do
+      let(:referee) { build(:referee) }
+
+      before { job_application.notify_before_contact_referers = true }
+
+      it "adds a notification request statement" do
+        expect(referees.first.first).to eq(I18n.t("jobseekers.job_applications.review.contact_referer.publisher"))
+      end
+    end
+
     context "when reference has phone number" do
       let(:referee) { build(:referee, phone_number: "01234567890") }
 


### PR DESCRIPTION
* add column job_application.notify_before_contact_referers
* Update views
* add `rake job_application:notify_before_contact_referers` to backfill existing job applications

-------

## Trello card URL
[1836](https://trello.com/c/A0R1kErI)

## Changes in this PR:


## Screenshots of UI changes:

### Before

### After
![Screenshot from 2025-06-03 11-40-47](https://github.com/user-attachments/assets/2fa93ab9-3ce0-471c-90e9-fbe8251b17ed)

![Screenshot from 2025-06-03 11-40-04](https://github.com/user-attachments/assets/455fcbff-731a-446b-8afa-c5f9d953d7fd)

view

![Screenshot from 2025-06-03 11-35-21](https://github.com/user-attachments/assets/468367ea-87fd-4b39-80ac-41ea0b2966cb)


pdf
![Screenshot from 2025-06-03 11-35-00](https://github.com/user-attachments/assets/27d43d8d-6071-4bea-9563-77288e126694)

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [X] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)