### PR TITLE
remove stray unpaired :nocov: tag

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -51,6 +51,6 @@ if ENV.fetch("COVERAGE", 0).to_i.positive?
     # .25% lower (branch) and .1% lower (line) than the test run for now
     #
     # possibly the tests are stable now?
-    minimum_coverage line: 96.26, branch: 81.83
+    minimum_coverage line: 96.27, branch: 81.98
   end
 end

--- a/app/helpers/job_applications_helper.rb
+++ b/app/helpers/job_applications_helper.rb
@@ -42,7 +42,6 @@ module JobApplicationsHelper
     end
   end
 
-  # :nocov:
   def end_date(date, index = 1)
     return "present" if index.zero?
 


### PR DESCRIPTION
## Changes in this PR:

Remove stray unpaired :nocov: tag, which lasted until the end of the file and reduced our coverage numbers