### PR TITLE
re-factor extended vacancy queries 

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -111,9 +111,14 @@ class Vacancy < ApplicationRecord
   # Not called from the code but frequently used for filtering during manual debugging sessions
   scope :external, -> { where.not(external_source: nil).or(where.not(publisher_ats_api_client_id: nil)) }
 
-  scope :search_by_filter, VacancyFilterQuery
-  scope :search_by_location, VacancyLocationQuery
-  scope :search_by_full_text, VacancyFullTextSearchQuery
+  # we need these 3 tiny modules to provide 'scoping glue' between the model and the queries
+  # so that if we can use PublishedVacancy and DraftVacancy safely
+  extend VacancyFilterQueryModule
+  scope :search_by_filter, ->(filters) { vacancy_filter_query(filters) }
+  extend VacancyLocationQueryModule
+  scope :search_by_location, ->(location_query, radius_in_miles, polygon:, sort_by_distance:) { vacancy_location_query(location_query, radius_in_miles, polygon: polygon, sort_by_distance: sort_by_distance) }
+  extend VacancyFulTextSearchQueryModule
+  scope :search_by_full_text, ->(query) { vacancy_full_text_search_query(query) }
 
   # effectively we have two different types of vacancy - external ones and internal ones
   # these require seperate validaqtion rules - internal ones are built up over time by a user,

--- a/app/queries/vacancy_filter_query_module.rb
+++ b/app/queries/vacancy_filter_query_module.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module VacancyFilterQueryModule
+  def vacancy_filter_query(filters)
+    VacancyFilterQuery.new(all).call(filters)
+  end
+end

--- a/app/queries/vacancy_ful_text_search_query_module.rb
+++ b/app/queries/vacancy_ful_text_search_query_module.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module VacancyFulTextSearchQueryModule
+  def vacancy_full_text_search_query(query)
+    VacancyFullTextSearchQuery.new(all).call(query)
+  end
+end

--- a/app/queries/vacancy_location_query_module.rb
+++ b/app/queries/vacancy_location_query_module.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module VacancyLocationQueryModule
+  def vacancy_location_query(location_query, radius_in_miles, polygon:, sort_by_distance:)
+    VacancyLocationQuery.new(all).call(location_query, radius_in_miles, polygon: polygon, sort_by_distance:sort_by_distance)
+  end
+end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/dPPBCYdN/1805-draftvacancy-step-3-change-service-logic-to-use-sti-classes

## Changes in this PR:
 
We have 3 extended queries on the Vacancy model, however they were implemented in a way that broke when we started using PublishedVacancy and DraftVacancy queries. 

This adds 3 tiny modules to hook into the existing queries in a more Rails compatible way

