### PR TITLE
Mandatory vacancy status

### DIFF
--- a/app/controllers/concerns/publishers/wizardable.rb
+++ b/app/controllers/concerns/publishers/wizardable.rb
@@ -32,7 +32,6 @@ module Publishers::Wizardable # rubocop:disable Metrics/ModuleLength
   def job_title_params(params)
     params.require(:publishers_job_listing_job_title_form)
           .permit(:job_title)
-          .merge(status: vacancy.status || "draft")
   end
 
   def key_stages_params(params)

--- a/app/controllers/publishers/vacancies_controller.rb
+++ b/app/controllers/publishers/vacancies_controller.rb
@@ -50,7 +50,7 @@ class Publishers::VacanciesController < Publishers::Vacancies::BaseController
   end
 
   def create
-    vacancy = Vacancy.create!(publisher: current_publisher, publisher_organisation: current_organisation, organisations: [current_organisation])
+    vacancy = Vacancy.create!(publisher: current_publisher, publisher_organisation: current_organisation, organisations: [current_organisation], status: "draft")
 
     if current_organisation.school? && current_organisation.phase.in?(Vacancy::SCHOOL_PHASES_MATCHING_VACANCY_PHASES)
       vacancy.update!(phases: [current_organisation.phase])

--- a/app/views/publishers/vacancies/vacancy_form_partials/_submit.html.slim
+++ b/app/views/publishers/vacancies/vacancy_form_partials/_submit.html.slim
@@ -1,5 +1,7 @@
 .govuk-button-group
-  - if vacancy.status.nil? && current_step != :job_title
+  / on create with location, we want a continue button until the job title is filled in as drafts without job_titles
+  / can't be accessed sensibly (as they don't have titles so can't be referenced)
+  - if vacancy.job_title.nil? && current_step != :job_title
     = f.govuk_submit t("buttons.continue"), class: "govuk-!-margin-bottom-5"
   - else
     = f.govuk_submit t("buttons.save_and_continue"), class: "govuk-!-margin-bottom-5", "data-upload-documents-target": "saveListingButton"

--- a/lib/tasks/make_null_status_vacancies_draft.rake
+++ b/lib/tasks/make_null_status_vacancies_draft.rake
@@ -1,0 +1,10 @@
+namespace :vacancy do
+  desc "Update qualified_teacher_status from 'non_teacher' to 'no'"
+  task update_null_statuses: :environment do
+    Vacancy.where(status: nil).find_each do |v|
+      # use this rather than update_column so that type gets set automatically
+      v.update_attributes(status: :draft)
+      v.save!(validate: false, touch: false)
+    end
+  end
+end

--- a/lib/tasks/make_null_status_vacancies_draft.rake
+++ b/lib/tasks/make_null_status_vacancies_draft.rake
@@ -1,5 +1,5 @@
 namespace :vacancy do
-  desc "Update qualified_teacher_status from 'non_teacher' to 'no'"
+  desc "Convert vacancies with null statuses to drafts"
   task update_null_statuses: :environment do
     Vacancy.where(status: nil).find_each do |v|
       # use this rather than update_column so that type gets set automatically

--- a/lib/tasks/make_null_status_vacancies_draft.rake
+++ b/lib/tasks/make_null_status_vacancies_draft.rake
@@ -3,7 +3,7 @@ namespace :vacancy do
   task update_null_statuses: :environment do
     Vacancy.where(status: nil).find_each do |v|
       # use this rather than update_column so that type gets set automatically
-      v.update_attributes(status: :draft)
+      v.assign_attributes(status: :draft)
       v.save!(validate: false, touch: false)
     end
   end

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -517,7 +517,7 @@ RSpec.describe Vacancy do
         invalid_school = School.new(email: "invalid")
         expect(invalid_school).not_to be_valid
 
-        expect(Vacancy.new(organisations: [invalid_school], publisher: publisher)).to be_valid
+        expect(Vacancy.new(organisations: [invalid_school], publisher: publisher, status: "draft")).to be_valid
       end
     end
   end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/dPPBCYdN/1805-draftvacancy-step-3-change-service-logic-to-use-sti-classes

## Changes in this PR:

Make vacancy status mandatory. Set on create