### PR TITLE
Publisher vacancy upload/download form change notification

### DIFF
--- a/app/jobs/send_vacancy_application_change_job.rb
+++ b/app/jobs/send_vacancy_application_change_job.rb
@@ -2,16 +2,17 @@ class SendVacancyApplicationChangeJob < ApplicationJob
   queue_as :default
 
   def perform
-    Vacancy
-      .includes(:publisher)
+    Publisher
+      .joins(:vacancies)
       .where(
-        receive_applications: :email,
-        created_at: 18.months.ago...,
+        vacancies: {
+          receive_applications: :email,
+          created_at: 18.months.ago...,
+        },
       )
-      .select(:contact_email).distinct
-      .select("*")
-      .find_each do |vacancy|
-        Publishers::VacancyChangeMailer.notify(vacancy:).deliver_later
-      end
+      .distinct
+      .find_each do |publisher|
+      Publishers::VacancyChangeMailer.notify(publisher:).deliver_later
+    end
   end
 end

--- a/app/jobs/send_vacancy_application_change_job.rb
+++ b/app/jobs/send_vacancy_application_change_job.rb
@@ -1,0 +1,17 @@
+class SendVacancyApplicationChangeJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Vacancy
+      .includes(:publisher)
+      .where(
+        receive_applications: :email,
+        created_at: 18.months.ago...,
+      )
+      .select(:contact_email).distinct
+      .select("*")
+      .find_each do |vacancy|
+        Publishers::VacancyChangeMailer.notify(vacancy:).deliver_later
+      end
+  end
+end

--- a/app/mailers/publishers/vacancy_change_mailer.rb
+++ b/app/mailers/publishers/vacancy_change_mailer.rb
@@ -1,0 +1,8 @@
+class Publishers::VacancyChangeMailer < Publishers::BaseMailer
+  def notify(publisher:)
+    @publisher = publisher
+    @subject = I18n.t("publishers.vacancy_change_mailer.notify.subject")
+
+    send_email(to: publisher.email, subject: @subject)
+  end
+end

--- a/app/views/publishers/vacancy_change_mailer/notify.text.erb
+++ b/app/views/publishers/vacancy_change_mailer/notify.text.erb
@@ -1,0 +1,5 @@
+<%= t(".dear", name: @publisher.given_name) %>
+
+<%= t(".content") %>
+
+<%= t(".footer", link: notify_mail_to("teaching.vacancies@education.gov.uk")) %>

--- a/config/analytics_custom_events.yml
+++ b/config/analytics_custom_events.yml
@@ -26,6 +26,7 @@ shared:
   - jobseeker_draft_application_only
   - jobseeker_unapplied_saved_vacancy
   - jobseeker_peak_times_reminder
+  - publisher_notify
   - publisher_applications_received
   - publisher_invite_to_apply
   - publisher_job_application_data_expiry

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -200,6 +200,20 @@ en:
         multiple_job_alerts_link_text: create multiple job alerts
 
   publishers:
+    vacancy_change_mailer:
+       notify:
+        subject: Changes to using your own application form on Teaching Vacancies
+        dear: "Dear %{name},"
+        content: |
+          We’re writing to let you know about a change to how using your own application form for hiring staff works on the Teaching Vacancies service. 
+          From now on, if you upload your own application form for a job listing, applicants will download, complete and then upload the finished form to Teaching Vacancies. This means you’ll need to sign in to Teaching Vacancies to review applications, rather than receiving them directly from applicants by email. 
+          You’ll get an email notification when an application has been submitted, so you’ll know when to check Teaching Vacancies to review new applications. 
+          Any live job listings you currently have on Teaching Vacancies will not be affected by this change. 
+        footer: |
+          If you have any questions about this process, please contact %{link}
+          Kind regards,
+          The Teaching Vacancies team
+
     job_application_data_expiry_mailer:
       job_application_data_expiry:
         expiry: From %{expiration_date}, you will no longer be able to access applications for %{job_title} listed in %{published_month}

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -6,6 +6,12 @@ send_peak_times_email_reminder:
   class: 'SendPeakTimesEmailReminderJob'
   queue: default
 
+# TODO: uncomment and set the date when ready to send notification
+# send_vacancy_change_notification:
+#   cron: '0 3 1 7 *' # "At 03:00 on 1 of July."
+#   class: 'SendVacancyApplicationChangeJob'
+#   queue: default
+
 #
 # MONTHLY CRON JOBS
 #

--- a/spec/configuration/sidekiq_scheduled_jobs_spec.rb
+++ b/spec/configuration/sidekiq_scheduled_jobs_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe "Sidekiq configuration" do
       SetOrganisationSlugsOfBatchJob
       ImportFromVacancySourceJob
       TrackVacancyViewJob
+      SendVacancyApplicationChangeJob
     ]
   end
 

--- a/spec/jobs/send_vacancy_application_change_job_spec.rb
+++ b/spec/jobs/send_vacancy_application_change_job_spec.rb
@@ -3,18 +3,20 @@ require "rails_helper"
 RSpec.describe SendVacancyApplicationChangeJob do
   subject(:job) { described_class.perform_later }
 
+  let(:publisher) { vacancy.publisher }
+
   describe "#perform" do
     let(:mail) { instance_double(ActionMailer::MessageDelivery) }
 
     before do
-      allow(Publishers::VacancyChangeMailer).to receive(:notify).with(vacancy:) { mail }
+      allow(Publishers::VacancyChangeMailer).to receive(:notify).with(publisher:) { mail }
     end
 
     context "when vacancy created within the last 18 months" do
       let(:vacancy) { create(:vacancy, :with_application_form, created_at: 17.months.ago) }
 
       it "enqueues mail sending job" do
-        expect(Publishers::VacancyChangeMailer).to receive(:notify).with(vacancy:)
+        expect(Publishers::VacancyChangeMailer).to receive(:notify).with(publisher:)
         expect(mail).to receive(:deliver_later)
         perform_enqueued_jobs { job }
       end
@@ -24,7 +26,7 @@ RSpec.describe SendVacancyApplicationChangeJob do
       let(:vacancy) { create(:vacancy, :with_application_form, created_at: 19.months.ago) }
 
       it "does nothing" do
-        expect(Publishers::VacancyChangeMailer).not_to receive(:notify).with(vacancy:)
+        expect(Publishers::VacancyChangeMailer).not_to receive(:notify).with(publisher:)
         perform_enqueued_jobs { job }
       end
     end

--- a/spec/jobs/send_vacancy_application_change_job_spec.rb
+++ b/spec/jobs/send_vacancy_application_change_job_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe SendVacancyApplicationChangeJob do
+  subject(:job) { described_class.perform_later }
+
+  describe "#perform" do
+    let(:mail) { instance_double(ActionMailer::MessageDelivery) }
+
+    before do
+      allow(Publishers::VacancyChangeMailer).to receive(:notify).with(vacancy:) { mail }
+    end
+
+    context "when vacancy created within the last 18 months" do
+      let(:vacancy) { create(:vacancy, :with_application_form, created_at: 17.months.ago) }
+
+      it "enqueues mail sending job" do
+        expect(Publishers::VacancyChangeMailer).to receive(:notify).with(vacancy:)
+        expect(mail).to receive(:deliver_later)
+        perform_enqueued_jobs { job }
+      end
+    end
+
+    context "when vacancy older than 18 months" do
+      let(:vacancy) { create(:vacancy, :with_application_form, created_at: 19.months.ago) }
+
+      it "does nothing" do
+        expect(Publishers::VacancyChangeMailer).not_to receive(:notify).with(vacancy:)
+        perform_enqueued_jobs { job }
+      end
+    end
+  end
+end

--- a/spec/mailers/publishers/vacancy_change_mailer_spec.rb
+++ b/spec/mailers/publishers/vacancy_change_mailer_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+require "dfe/analytics/rspec/matchers"
+
+RSpec.describe Publishers::VacancyChangeMailer do
+  let(:publisher) { create(:publisher) }
+
+  describe "#notify" do
+    let(:mail) { described_class.notify(publisher:) }
+    let(:some_content) { I18n.t("publishers.vacancy_change_mailer.notify.content").split("\n") }
+    let(:footer) { I18n.t("publishers.vacancy_change_mailer.notify.footer", link: "").split("\n") }
+
+    it "sends a `notification` email" do
+      expect(mail.subject).to eq(I18n.t("publishers.vacancy_change_mailer.notify.subject"))
+      expect(mail.to).to eq([publisher.email])
+      expect(mail.body).to include(publisher.given_name)
+                      .and include(*some_content)
+                      .and include(*footer)
+    end
+  end
+end


### PR DESCRIPTION
## Trello card URL
[1881](https://trello.com/c/I8EuLcdj)

## Changes in this PR:

add `Publishers::VacancyChangeMailer` with `SendVacancyApplicationChangeJob`

prepared an schedule.yml entry for when the upload/download PR is ready