### PR TITLE
Send messages to job application email

### DIFF
--- a/app/mailers/jobseekers/job_application_mailer.rb
+++ b/app/mailers/jobseekers/job_application_mailer.rb
@@ -3,16 +3,14 @@ class Jobseekers::JobApplicationMailer < Jobseekers::BaseMailer
     @vacancy = job_application.vacancy
     @organisation_name = @vacancy.organisation_name
     @contact_email = @vacancy.contact_email
-    @jobseeker = job_application.jobseeker
 
-    send_email(to: @jobseeker.email, subject: I18n.t("jobseekers.job_application_mailer.application_submitted.subject"))
+    send_email(to: job_application.email, subject: I18n.t("jobseekers.job_application_mailer.application_submitted.subject"))
   end
 
   def job_listing_ended_early(job_application, vacancy)
     @job_application = job_application
-    @jobseeker = job_application.jobseeker
     @vacancy = vacancy
 
-    send_email(to: job_application.jobseeker.email, subject: t(".subject", job_title: @vacancy.job_title, organisation_name: @vacancy.organisation_name))
+    send_email(to: job_application.email, subject: t(".subject", job_title: @vacancy.job_title, organisation_name: @vacancy.organisation_name))
   end
 end

--- a/app/mailers/jobseekers/job_application_mailer.rb
+++ b/app/mailers/jobseekers/job_application_mailer.rb
@@ -4,13 +4,13 @@ class Jobseekers::JobApplicationMailer < Jobseekers::BaseMailer
     @organisation_name = @vacancy.organisation_name
     @contact_email = @vacancy.contact_email
 
-    send_email(to: job_application.email, subject: I18n.t("jobseekers.job_application_mailer.application_submitted.subject"))
+    send_email(to: job_application.email_address, subject: I18n.t("jobseekers.job_application_mailer.application_submitted.subject"))
   end
 
   def job_listing_ended_early(job_application, vacancy)
     @job_application = job_application
     @vacancy = vacancy
 
-    send_email(to: job_application.email, subject: t(".subject", job_title: @vacancy.job_title, organisation_name: @vacancy.organisation_name))
+    send_email(to: job_application.email_address, subject: t(".subject", job_title: @vacancy.job_title, organisation_name: @vacancy.organisation_name))
   end
 end

--- a/app/mailers/jobseekers/vacancy_mailer.rb
+++ b/app/mailers/jobseekers/vacancy_mailer.rb
@@ -3,7 +3,7 @@ class Jobseekers::VacancyMailer < Jobseekers::BaseMailer
     @job_application = job_application
     @vacancy = job_application.vacancy
 
-    send_email(to: job_application.email,
+    send_email(to: job_application.email_address,
                subject: I18n.t("jobseekers.vacancy_mailer.draft_application_only.subject", date: @vacancy.expires_at.to_date, job_title: job_application.vacancy.job_title))
   end
 

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -95,12 +95,6 @@ class JobApplication < ApplicationRecord
     "#{first_name} #{last_name}"
   end
 
-  def email
-    # This method and its test can be removed once there are no job applications remaining which were submitted before
-    # we asked jobseekers for their emails as part of the application.
-    email_address.presence || jobseeker.email
-  end
-
   def submit!
     submitted!
     Publishers::JobApplicationReceivedNotifier.with(vacancy: vacancy, job_application: self).deliver(vacancy.publisher)

--- a/app/models/job_application_pdf.rb
+++ b/app/models/job_application_pdf.rb
@@ -233,7 +233,7 @@ class JobApplicationPdf
       [I18n.t("last_name", scope:), job_application.last_name],
       [I18n.t("your_address", scope: address_scope), your_address],
       [I18n.t("phone_number", scope:), job_application.phone_number],
-      [I18n.t("email_address", scope:), job_application.email],
+      [I18n.t("email_address", scope:), job_application.email_address],
       [I18n.t("has_right_to_work_in_uk", scope: declaration_scope), visa_sponsorship_needed_answer(job_application)],
       [I18n.t("working_patterns", scope:), readable_working_patterns(job_application)],
     ]

--- a/app/views/jobseekers/job_applications/build/personal_details.html.slim
+++ b/app/views/jobseekers/job_applications/build/personal_details.html.slim
@@ -19,7 +19,7 @@
         = f.govuk_text_field :postcode, width: "one-third"
         = f.govuk_text_field :country, width: "one-third"
       = f.govuk_phone_field :phone_number, label: { size: "s" }, width: "one-half", aria: { required: true }
-      = f.govuk_email_field :email_address, value: @form.email_address.presence || job_application.email, label: { size: "s" }, width: "one-half", aria: { required: true }
+      = f.govuk_email_field :email_address, value: @form.email_address.presence || job_application.email_address, label: { size: "s" }, width: "one-half", aria: { required: true }
       = f.govuk_radio_buttons_fieldset :has_right_to_work_in_uk,
         legend: { text: t("jobseekers.profiles.personal_details.work.page_title"), size: "s" },
         hint: { text: t(radio_button_legend_hint[:text], link: govuk_link_to(t(radio_button_legend_hint[:link]), "https://getintoteaching.education.gov.uk/non-uk-teachers/teach-in-england-if-you-trained-overseas#apply-for-your-visa", target: "_blank")).html_safe } do

--- a/app/views/jobseekers/job_applications/review/_personal_details.html.slim
+++ b/app/views/jobseekers/job_applications/review/_personal_details.html.slim
@@ -22,7 +22,7 @@
 
   - s.with_row do |row|
     - row.with_key text: t("helpers.label.jobseekers_job_application_personal_details_form.email_address")
-    - row.with_value text: job_application.email
+    - row.with_value text: job_application.email_address
 
   - s.with_row do |row|
     - row.with_key text: t("helpers.legend.jobseekers_job_application_declarations_form.has_right_to_work_in_uk")

--- a/spec/factories/job_applications.rb
+++ b/spec/factories/job_applications.rb
@@ -95,7 +95,6 @@ FactoryBot.define do
     city { "" }
     postcode { "" }
     country { "" }
-    email_address { "" }
     phone_number { "" }
     teacher_reference_number { "" }
     national_insurance_number { "" }

--- a/spec/mailers/jobseekers/job_application_mailer_spec.rb
+++ b/spec/mailers/jobseekers/job_application_mailer_spec.rb
@@ -19,11 +19,10 @@ RSpec.describe Jobseekers::JobApplicationMailer do
   describe "#application_submitted" do
     let(:job_application) { build(:job_application, :status_submitted, jobseeker: jobseeker, vacancy: vacancy) }
     let(:mail) { described_class.application_submitted(job_application) }
-    let(:notify_template) { NOTIFY_PRODUCTION_TEMPLATE }
 
     it "sends a `jobseeker_application_submitted` email" do
       expect(mail.subject).to eq(I18n.t("jobseekers.job_application_mailer.application_submitted.subject"))
-      expect(mail.to).to eq([jobseeker.email])
+      expect(mail.to).to eq([job_application.email_address])
       expect(mail.body.encoded).to include(I18n.t("jobseekers.job_application_mailer.application_submitted.heading",
                                                   organisation_name: organisation.name))
                                .and include(I18n.t("jobseekers.job_application_mailer.shared.more_info.description",
@@ -39,11 +38,10 @@ RSpec.describe Jobseekers::JobApplicationMailer do
   describe "#job_listing_ended_early" do
     let(:job_application) { create(:job_application, :status_draft, jobseeker: jobseeker, vacancy: vacancy) }
     let(:mail) { described_class.job_listing_ended_early(job_application, vacancy) }
-    let(:notify_template) { NOTIFY_PRODUCTION_TEMPLATE }
 
     it "sends a `jobseeker_job_listing_ended_early` email" do
       expect(mail.subject).to eq("Update on #{vacancy.job_title} at #{vacancy.organisation_name}")
-      expect(mail.to).to eq([jobseeker.email])
+      expect(mail.to).to eq([job_application.email_address])
       expect(mail.body.encoded).to include(I18n.t("jobseekers.job_application_mailer.job_listing_ended_early.heading",
                                                   job_title: vacancy.job_title, organisation_name: vacancy.organisation_name))
       expect(mail.body.encoded).to include(jobseekers_job_application_url(job_application))

--- a/spec/models/job_application_pdf_spec.rb
+++ b/spec/models/job_application_pdf_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe JobApplicationPdf do
         [I18n.t("last_name", scope:), job_application.last_name],
         [I18n.t("helpers.legend.jobseekers_job_application_personal_details_form.your_address"), address],
         [I18n.t("phone_number", scope:), job_application.phone_number],
-        [I18n.t("email_address", scope:), job_application.email],
+        [I18n.t("email_address", scope:), job_application.email_address],
         [I18n.t("helpers.legend.jobseekers_job_application_declarations_form.has_right_to_work_in_uk"), "No, I already have the right to work in the UK"],
         [I18n.t("working_patterns", scope:), "Part time"],
       ]

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -53,28 +53,6 @@ RSpec.describe JobApplication do
     end
   end
 
-  describe "#email" do
-    let(:jobseeker) { build_stubbed(:jobseeker, email: "backup-email@example.com") }
-    subject { build_stubbed(:job_application, email_address: email_address, jobseeker: jobseeker) }
-    let(:email_address) { "something@example.com" }
-
-    context "when the application has an email address" do
-      let(:email_address) { "something@example.com" }
-
-      it "uses the application email address" do
-        expect(subject.email).to eq("something@example.com")
-      end
-    end
-
-    context "when the application does not have an email address" do
-      let(:email_address) { "" }
-
-      it "uses the jobseeker email address" do
-        expect(subject.email).to eq("backup-email@example.com")
-      end
-    end
-  end
-
   context "when saving change to status" do
     subject { create(:job_application) }
 

--- a/spec/system/jobseekers/jobseekers_can_complete_a_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_complete_a_job_application_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Jobseekers can complete a job application" do
   it "allows jobseekers to complete an application and go to review page" do
     visit jobseekers_job_application_build_path(job_application, :personal_details)
     expect(page).to have_content(I18n.t("jobseekers.job_applications.build.personal_details.heading"))
-    expect(page).to have_field("Email address", with: jobseeker.email)
+    expect(page).to have_field("Email address", with: job_application.email_address)
     validates_step_complete
     fill_in_personal_details
     click_on I18n.t("buttons.save_and_continue")

--- a/spec/views/publishers/vacancies/job_applications/show.html.slim_spec.rb
+++ b/spec/views/publishers/vacancies/job_applications/show.html.slim_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "publishers/vacancies/job_applications/show" do
     expect(rendered).to have_css(".govuk-summary-list__value", text: job_application.phone_number)
 
     expect(rendered).to have_css(".govuk-summary-list__key", text: "Email address")
-    expect(rendered).to have_css(".govuk-summary-list__value", text: job_application.email)
+    expect(rendered).to have_css(".govuk-summary-list__value", text: job_application.email_address)
 
     expect(rendered).to have_css(".govuk-summary-list__key", text: "Do you need Skilled Worker visa sponsorship?")
     expect(rendered).to have_css(".govuk-summary-list__value", text: I18n.t("jobseekers.profiles.personal_details.work.options.true"))


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/brOdxbPw/1798-self-disclosure-part-1-triggering-self-disclosure-collection-flow-sent-to-jobseeker-applicant-ats-branch

## Changes in this PR:

This PR has 2 distinct commits:

1. Use JobApplication#email to send job application email messages (rather than jobseeker.email)

3. Remove JobApplication#email as it is a hangover from 2021, before job applications had email addresses. Use JobApplication#email_address instead