### PR TITLE
Update apply button

### DIFF
--- a/app/helpers/links_helper.rb
+++ b/app/helpers/links_helper.rb
@@ -70,7 +70,7 @@ module LinksHelper
 
   def external_advert_link(vacancy, **)
     tracked_open_in_new_tab_button_link_to(
-      t("jobs.external.link"),
+      t("jobs.view_advert.external"),
       vacancy.external_advert_url,
       link_type: :external_advert_link,
       link_subject: vacancy.id,
@@ -79,8 +79,8 @@ module LinksHelper
   end
 
   def apply_link(vacancy, **)
-    tracked_button_link_to(
-      t("jobs.apply"),
+    tracked_open_in_new_tab_button_link_to(
+      t("jobs.view_advert.school"),
       vacancy.application_link,
       "aria-label": t("jobs.aria_labels.apply_link"),
       link_type: :get_more_information,

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -301,6 +301,9 @@ en:
     share_on_facebook: Share to Facebook
     share_on_twitter: Share to Twitter
     share_this_job: Share this job
+    view_advert:
+      school: View advert on school website
+      external: View advert on external website
 
     external:
       notice: This school accepts applications through their own website, where you may also find more information about this job.

--- a/spec/controllers/jobseekers/flood_light_tags_spec.rb
+++ b/spec/controllers/jobseekers/flood_light_tags_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe VacanciesController do
     end
   end
 
-  describe "How to Apply Button" do
+  describe "View advert on school website" do
     let(:vacancy) { create(:vacancy, :no_tv_applications) }
 
     it "has the correct text" do
-      expect(response.body).to have_content("How to apply")
+      expect(response.body).to have_content("View advert on school website (opens in new tab)")
     end
   end
 
@@ -38,11 +38,11 @@ RSpec.describe VacanciesController do
     end
   end
 
-  describe "View advert on school website" do
+  describe "View advert on external website" do
     let(:vacancy) { create(:vacancy, :external) }
 
     it "has the correct text" do
-      expect(response.body).to have_content("View advert on school website (opens in new tab)")
+      expect(response.body).to have_content("View advert on external website (opens in new tab)")
     end
   end
 end

--- a/spec/system/jobseekers/jobseekers_can_apply_for_a_vacancy_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_apply_for_a_vacancy_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Jobseekers can apply for a vacancy" do
   before { visit job_path(vacancy) }
 
   context "with a website vacancy" do
-    let(:expected_link) { I18n.t("jobs.apply", href: "http://www.google.com") }
+    let(:expected_link) { I18n.t("jobs.view_advert.school", href: "http://www.google.com") }
 
     context "with a published vacancy" do
       let(:vacancy) do

--- a/spec/system/jobseekers/jobseekers_can_view_a_vacancy_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_view_a_vacancy_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "Viewing a single published vacancy" do
 
       scenario "a jobseeker can click on the application link" do
         visit job_path(vacancy)
-        click_on I18n.t("jobs.apply")
+        click_on I18n.t("jobs.view_advert.school")
 
         expect(page.current_url).to eq vacancy.application_link
       end


### PR DESCRIPTION
-------

## Trello card URL
[1889](https://trello.com/c/03zwYji6)

## Changes in this PR:

for school website
"How to apply" => "View advert on school website (opens in new tab)"
Opens a new tracked tab for this case

for external sources
"View advert on school website (opens in new tab)" => "View advert on external website (opens in new tab)")


## Screenshots of UI changes:

### Before

### After