### PR TITLE
send end listing job using background job

### DIFF
--- a/app/controllers/publishers/vacancies/end_listing_controller.rb
+++ b/app/controllers/publishers/vacancies/end_listing_controller.rb
@@ -1,12 +1,17 @@
 class Publishers::Vacancies::EndListingController < Publishers::Vacancies::BaseController
-  helper_method :form, :vacancy
+  before_action :set_vacancy
+
+  def show
+    @form = Publishers::JobListing::EndListingForm.new
+  end
 
   def update
-    if form.valid?
-      vacancy.update(form_params.merge(expires_at: Time.current))
-      update_google_index(vacancy)
-      SendJobListingEndedEarlyNotificationJob.new.perform(vacancy)
-      redirect_to organisation_job_path(vacancy.id), success: t(".success", job_title: vacancy.job_title)
+    @form = Publishers::JobListing::EndListingForm.new(form_params)
+    if @form.valid?
+      @vacancy.update!(form_params.merge(expires_at: Time.current))
+      update_google_index(@vacancy)
+      SendJobListingEndedEarlyNotificationJob.perform_later(@vacancy)
+      redirect_to organisation_job_path(@vacancy.id), success: t(".success", job_title: @vacancy.job_title)
     else
       render :show
     end
@@ -14,24 +19,11 @@ class Publishers::Vacancies::EndListingController < Publishers::Vacancies::BaseC
 
   private
 
-  def form
-    @form ||= Publishers::JobListing::EndListingForm.new(form_attributes)
-  end
-
-  def form_attributes
-    case action_name
-    when "show"
-      {}
-    when "update"
-      form_params
-    end
-  end
-
   def form_params
     (params[:publishers_job_listing_end_listing_form] || params).permit(:hired_status, :listed_elsewhere)
   end
 
-  def vacancy
-    @vacancy ||= current_organisation.all_vacancies.live.find(params[:job_id])
+  def set_vacancy
+    @vacancy = current_organisation.all_vacancies.live.find(params[:job_id])
   end
 end

--- a/app/views/publishers/vacancies/end_listing/show.html.slim
+++ b/app/views/publishers/vacancies/end_listing/show.html.slim
@@ -1,15 +1,15 @@
-- content_for :page_title_prefix, t(".title", job_title: vacancy.job_title)
+- content_for :page_title_prefix, t(".title", job_title: @vacancy.job_title)
 
 - content_for :breadcrumbs do
   nav.govuk-breadcrumbs aria-label="Breadcrumbs"
-  = govuk_back_link text: t("buttons.back"), href: organisation_job_path(vacancy.id)
+  = govuk_back_link text: t("buttons.back"), href: organisation_job_path(@vacancy.id)
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    span.govuk-caption-l = vacancy.job_title
+    span.govuk-caption-l = @vacancy.job_title
     h1.govuk-heading-xl = t(".heading")
 
-    = form_for form, url: organisation_job_end_listing_path(vacancy.id), method: :patch do |f|
+    = form_for @form, url: organisation_job_end_listing_path(@vacancy.id), method: :patch do |f|
       = f.govuk_error_summary
 
       = f.govuk_radio_buttons_fieldset(:hired_status, legend: { size: "m" }) do

--- a/spec/system/publishers/publishers_can_end_a_job_listing_early_spec.rb
+++ b/spec/system/publishers/publishers_can_end_a_job_listing_early_spec.rb
@@ -32,15 +32,13 @@ RSpec.describe "Publishers can end a job listing early" do
     let(:jobseeker) { create(:jobseeker) }
     let!(:job_application) { create(:job_application, :status_draft, jobseeker: jobseeker, vacancy: vacancy) }
 
-    before { allow(SendJobListingEndedEarlyNotificationJob).to receive(:new) { job } }
-
     it "sends an email to jobseekers with draft applications" do
       click_on vacancy.job_title
       click_on I18n.t("publishers.vacancies.show.heading_component.action.close_early")
       choose I18n.t("helpers.label.publishers_job_listing_end_listing_form.hired_status_options.hired_other_free")
       choose I18n.t("helpers.label.publishers_job_listing_end_listing_form.listed_elsewhere_options.listed_free")
 
-      expect(job).to receive(:perform).with(vacancy)
+      expect(SendJobListingEndedEarlyNotificationJob).to receive(:perform_later).with(vacancy)
 
       click_on I18n.t("buttons.end_listing")
     end


### PR DESCRIPTION
## Trello card URL

## Changes in this PR:

use background job to send job listing ended early mails

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
