### PR TITLE
Add CTA banner for self disclosure request

### DIFF
--- a/app/helpers/job_applications_helper.rb
+++ b/app/helpers/job_applications_helper.rb
@@ -17,7 +17,7 @@ module JobApplicationsHelper
     unsuccessful: "unsuccessful",
     withdrawn: "withdrawn",
     interviewing: "interviewing",
-    info_required: "info required",
+    action_required: "action required",
   }.freeze
 
   JOB_APPLICATION_STATUS_TAG_COLOURS = {
@@ -29,7 +29,7 @@ module JobApplicationsHelper
     unsuccessful: "red",
     withdrawn: "yellow",
     interviewing: "turquoise",
-    info_required: "orange",
+    action_required: "orange",
   }.freeze
 
   def job_application_qualified_teacher_status_info(job_application)

--- a/app/helpers/job_applications_helper.rb
+++ b/app/helpers/job_applications_helper.rb
@@ -17,6 +17,7 @@ module JobApplicationsHelper
     unsuccessful: "unsuccessful",
     withdrawn: "withdrawn",
     interviewing: "interviewing",
+    info_required: "info required",
   }.freeze
 
   JOB_APPLICATION_STATUS_TAG_COLOURS = {
@@ -28,6 +29,7 @@ module JobApplicationsHelper
     unsuccessful: "red",
     withdrawn: "yellow",
     interviewing: "turquoise",
+    info_required: "orange",
   }.freeze
 
   def job_application_qualified_teacher_status_info(job_application)

--- a/app/views/jobseekers/job_applications/_job_application.html.slim
+++ b/app/views/jobseekers/job_applications/_job_application.html.slim
@@ -20,5 +20,7 @@
 
   - if job_application.draft? && job_application.vacancy.expired?
     - card.with_action_item link: job_application_status_tag(:deadline_passed)
+  - elsif job_application.interviewing?
+    - card.with_action_item link: job_application_status_tag(:info_required)
   - else
     - card.with_action_item link: job_application_status_tag(job_application.status)

--- a/app/views/jobseekers/job_applications/_job_application.html.slim
+++ b/app/views/jobseekers/job_applications/_job_application.html.slim
@@ -21,6 +21,6 @@
   - if job_application.draft? && job_application.vacancy.expired?
     - card.with_action_item link: job_application_status_tag(:deadline_passed)
   - elsif job_application.interviewing?
-    - card.with_action_item link: job_application_status_tag(:info_required)
+    - card.with_action_item link: job_application_status_tag(:action_required)
   - else
     - card.with_action_item link: job_application_status_tag(job_application.status)

--- a/app/views/jobseekers/job_applications/index.html.slim
+++ b/app/views/jobseekers/job_applications/index.html.slim
@@ -16,6 +16,10 @@ h1.govuk-heading-l = t(".page_title_with_count", count: current_jobseeker.job_ap
   .govuk-grid-column-full
     - if current_jobseeker.job_applications.any?
       #applications-results
+        - current_jobseeker.job_applications.includes(:vacancy).order(submitted_at: :desc).interviewing.each do |job_application|
+          - if job_application.self_disclosure_request&.sent?
+            = render "job_application", job_application: job_application
+
         - current_jobseeker.job_applications.includes(:vacancy).order(updated_at: :desc).draft.each do |job_application|
           = render "job_application", job_application: job_application if job_application.vacancy.expires_at.future?
 

--- a/app/views/jobseekers/job_applications/show.html.slim
+++ b/app/views/jobseekers/job_applications/show.html.slim
@@ -1,5 +1,11 @@
 - content_for :page_title_prefix, t(".page_title")
 
+- if job_application.self_disclosure_request&.sent?
+  = govuk_notification_banner title_text: t("banners.important") do |notification_banner|
+    - organisation = job_application.vacancy.organisation.name
+    - link = govuk_link_to(t(".self_disclosure.form"), jobseekers_job_application_self_disclosure_path(job_application, Wicked::FIRST_STEP))
+    - notification_banner.with_heading(text: t(".self_disclosure.cta_html", organisation:, link:))
+
 = render "banner"
 
 = render "jobseekers/job_applications/show" do

--- a/config/locales/jobseekers/job_applications/self_disclosure.yml
+++ b/config/locales/jobseekers/job_applications/self_disclosure.yml
@@ -1,4 +1,10 @@
 en:
+  jobseekers:
+    job_applications:
+      show:
+        self_disclosure:
+          form: self-disclosure declaration
+          cta_html: "%{organisation} has asked you to complete a %{link} as soon as possible."
   activemodel:
     errors:
       models:

--- a/spec/factories/self_disclosure_requests.rb
+++ b/spec/factories/self_disclosure_requests.rb
@@ -1,6 +1,14 @@
 FactoryBot.define do
   factory :self_disclosure_request do
     job_application
-    status { 2 }
+    status { "sent" }
+  end
+
+  trait :sent do
+    status { "sent" }
+  end
+
+  trait :manual do
+    status { "manual" }
   end
 end

--- a/spec/views/jobseekers/job_applications/index.html.slim_spec.rb
+++ b/spec/views/jobseekers/job_applications/index.html.slim_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe "jobseekers/job_applications/index" do
+  let(:jobseeker) { create(:jobseeker) }
+  let(:other_job_application) { create(:job_application, jobseeker:) }
+  let(:self_disclosure_request) { nil }
+
+  before do
+    jobseeker.job_applications << self_disclosure_request.job_application if self_disclosure_request
+    allow(view).to receive(:current_jobseeker).and_return(jobseeker)
+    render
+  end
+
+  describe "self disclosure request tag" do
+    context "when self_disclosure_request sent" do
+      let(:job_application) { create(:job_application, :status_interviewing) }
+      let(:self_disclosure_request) { create(:self_disclosure_request, :sent, job_application:) }
+
+      it { expect(rendered).to have_content("info required") }
+    end
+
+    context "when self_disclosure_request manual" do
+      let(:self_disclosure_request) { create(:self_disclosure_request, :manual) }
+
+      it { expect(rendered).to have_no_content("info required") }
+    end
+
+    context "when self_disclosure_request missing" do
+      it { expect(rendered).to have_no_content("info required") }
+    end
+  end
+end

--- a/spec/views/jobseekers/job_applications/index.html.slim_spec.rb
+++ b/spec/views/jobseekers/job_applications/index.html.slim_spec.rb
@@ -12,21 +12,23 @@ RSpec.describe "jobseekers/job_applications/index" do
   end
 
   describe "self disclosure request tag" do
+    let(:tag_text) { "action required" }
+
     context "when self_disclosure_request sent" do
       let(:job_application) { create(:job_application, :status_interviewing) }
       let(:self_disclosure_request) { create(:self_disclosure_request, :sent, job_application:) }
 
-      it { expect(rendered).to have_content("info required") }
+      it { expect(rendered).to have_content(tag_text) }
     end
 
     context "when self_disclosure_request manual" do
       let(:self_disclosure_request) { create(:self_disclosure_request, :manual) }
 
-      it { expect(rendered).to have_no_content("info required") }
+      it { expect(rendered).to have_no_content(tag_text) }
     end
 
     context "when self_disclosure_request missing" do
-      it { expect(rendered).to have_no_content("info required") }
+      it { expect(rendered).to have_no_content(tag_text) }
     end
   end
 end

--- a/spec/views/jobseekers/job_applications/show.html.slim_spec.rb
+++ b/spec/views/jobseekers/job_applications/show.html.slim_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe "jobseekers/job_applications/show" do
+  let(:jobseeker) { create(:jobseeker) }
+  let(:other_job_application) { create(:job_application, jobseeker:) }
+  let(:self_disclosure_request) { nil }
+  let(:job_application) { create(:job_application) }
+
+  before do
+    job_application.self_disclosure_request = self_disclosure_request
+    without_partial_double_verification do
+      allow(view).to receive_messages(job_application:, vacancy: job_application.vacancy)
+    end
+    render
+  end
+
+  describe "self disclosure request banner" do
+    let(:scope) { "jobseekers.job_applications.show.self_disclosure" }
+    let(:call_to_action) do
+      I18n.t(
+        ".cta_html",
+        scope:,
+        organisation: job_application.vacancy.organisation.name,
+        link: "self-disclosure declaration",
+      )
+    end
+    let(:form_path) do
+      jobseekers_job_application_self_disclosure_path(job_application, Wicked::FIRST_STEP)
+    end
+
+    context "when self_disclosure_request sent" do
+      let(:job_application) { create(:job_application, :status_interviewing) }
+      let(:self_disclosure_request) { create(:self_disclosure_request, :sent, job_application:) }
+
+      it { expect(rendered).to have_content(call_to_action) }
+      it { expect(rendered).to have_link(I18n.t(".form", scope:), href: form_path) }
+    end
+
+    context "when self_disclosure_request manual" do
+      let(:job_application) { create(:job_application, :status_interviewing) }
+      let(:self_disclosure_request) { create(:self_disclosure_request, :manual) }
+
+      it { expect(rendered).to have_no_content(call_to_action) }
+      it { expect(rendered).to have_no_link(I18n.t(".form", scope:), href: form_path) }
+    end
+
+    context "when job application not status interviewing" do
+      it { expect(rendered).to have_no_content(call_to_action) }
+      it { expect(rendered).to have_no_link(I18n.t(".form", scope:), href: form_path) }
+    end
+  end
+end


### PR DESCRIPTION
# Add self-disclosure request banner

## Trello card URL
[1916](https://trello.com/c/aBz8Ylya)

## Changes in this PR:

- Add banner on jobseekers/job_applications/show for self disclosure request

- Add tag on jobseekers/job_applications/index for self disclosure request

## Screenshots of UI changes:

### Before

### After
![image](https://github.com/user-attachments/assets/201b347a-c5ef-4c28-a797-81bb67a18163)


![image](https://github.com/user-attachments/assets/7054e386-95bc-4b15-9132-fe6b16ee5547)
