### PR TITLE
Allow ATS API Client info on analytics

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -288,6 +288,12 @@ shared:
     - given_name
     - created_at
     - updated_at
+  publisher_ats_api_clients:
+    - id
+    - name
+    - last_rotated_at
+    - created_at
+    - updated_at
   publisher_preferences:
     - id
     - publisher_id
@@ -425,6 +431,7 @@ shared:
     - religion_type
     - flexi_working_details_provided
     - type
+    - publisher_ats_api_client_id
   failed_imported_vacancies:
     - id
     - import_errors

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -35,12 +35,7 @@
   - email_ciphertext
   - phone_number_ciphertext
   :publisher_ats_api_clients:
-  - id
-  - name
   - api_key
-  - last_rotated_at
-  - created_at
-  - updated_at
   :personal_details:
   - first_name_ciphertext
   - last_name_ciphertext
@@ -129,7 +124,6 @@
   - searchable_content
   - google_index_removed
   - expired_vacancy_feedback_email_sent_at
-  - publisher_ats_api_client_id
   :qualifications:
   - finished_studying_details_ciphertext
   :feedbacks:


### PR DESCRIPTION
The Publisher ATS API Clients belong to an organisation, not an individual.
And the organisations, being ATSs, are more generic than a particular school.

We only need to block the actual API key.

Pushing everything else to Analytics will allow us to, for example, get information on how many published vacancies each client has.

