### PR TITLE
remove legacy draft vacancies

### DIFF
--- a/lib/tasks/remove_legacy_drafts.rake
+++ b/lib/tasks/remove_legacy_drafts.rake
@@ -1,8 +1,9 @@
 namespace :vacancies do
   desc "Remove legaqcy draft vacancies"
   task remove_legacy_drafts: :environment do
-    Vacancy.draft.find_each.select(&:legacy_draft?).each do |v|
-      v.destroy!
-    end
+    Vacancy.draft
+           .find_each
+           .select(&:legacy_draft?)
+           .each(&:destroy!)
   end
 end

--- a/lib/tasks/remove_legacy_drafts.rake
+++ b/lib/tasks/remove_legacy_drafts.rake
@@ -1,7 +1,7 @@
 namespace :vacancies do
   desc "Remove legaqcy draft vacancies"
   task remove_legacy_drafts: :environment do
-    Vacancy.draft.find_each.select { |v| v.legacy_draft? }.each do |v|
+    Vacancy.draft.find_each.select(&:legacy_draft?).each do |v|
       v.destroy!
     end
   end

--- a/lib/tasks/remove_legacy_drafts.rake
+++ b/lib/tasks/remove_legacy_drafts.rake
@@ -1,0 +1,8 @@
+namespace :vacancies do
+  desc "Remove legaqcy draft vacancies"
+  task remove_legacy_drafts: :environment do
+    Vacancy.draft.find_each.select { |v| v.legacy_draft? }.each do |v|
+      v.destroy!
+    end
+  end
+end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/uWPB5rKq/1893-spike-vacancy-legacy-drafts-can-we-remove-them

## Changes in this PR:

Create task to remove legacy draft vacancies 

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
