### PR TITLE
remove aws-sdk-s3 from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,10 @@ updates:
       - dependency-name: "undercover"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
+      # TODO: Remove this ignore config once issue with aws-sdk-s3 has been resolved
+      - dependency-name: "aws-sdk-s3"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+
     groups:
       gem-dependencies:
         update-types:


### PR DESCRIPTION
## Changes in this PR:

aws-sdk-s3 1.189.1 seems to be having some major issues. Keep off the dependabot until issue is resolved

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
