### PR TITLE
use secret rather than ENV/ARG for RAILS_MASTER_KEY

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -148,16 +148,18 @@ jobs:
 
       - name: Build and push docker image from builder target
         uses: docker/build-push-action@v6
+        env:
+          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+          BUILDKIT_INLINE_CACHE: 1
         with:
           build-args: |
-            BUILDKIT_INLINE_CACHE=1
-            RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_KEY }}
+            --secret id=RAILS_MASTER_KEY
           # Cache from builder target tagged with branch name, may be empty first time branch is pushed
           # Cache from builder target tagged with main branch name, always present, maybe less recent
           cache-from: |
             ${{ env.DOCKER_REPOSITORY }}:builder-${{ env.GIT_BRANCH }}
             ${{ env.DOCKER_REPOSITORY }}:builder-main
-          # Need to tell buildx to use current rather than git
+          # Need to tell buildx to use current rather than git so that it picks up the swagger files we have just built
           context: "."
           push: true
           # Tag with branch name for reuse
@@ -166,11 +168,12 @@ jobs:
 
       - name: Build and push docker image from production target
         uses: docker/build-push-action@v6
+        env:
+          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+          BUILDKIT_INLINE_CACHE: 1
         with:
           build-args: |
-            BUILDKIT_INLINE_CACHE=1
-            COMMIT_SHA=${{ env.COMMIT_SHA }}
-            RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_KEY }}
+            --secret id=RAILS_MASTER_KEY
           # Cache from builder target built above, always present
           # Cache from production target tagged with branch name, may be empty first time branch is pushed
           # Cache from production target tagged with main branch name, always present, maybe less recent

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -173,6 +173,7 @@ jobs:
         with:
           build-args: |
             BUILDKIT_INLINE_CACHE=1
+            COMMIT_SHA=${{ env.COMMIT_SHA }}
             --secret id=master_key,env=RAILS_MASTER_KEY
           # Cache from builder target built above, always present
           # Cache from production target tagged with branch name, may be empty first time branch is pushed

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -170,9 +170,9 @@ jobs:
         uses: docker/build-push-action@v6
         env:
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
-          BUILDKIT_INLINE_CACHE: 1
         with:
           build-args: |
+            BUILDKIT_INLINE_CACHE=1
             --secret id=master_key,env=RAILS_MASTER_KEY
           # Cache from builder target built above, always present
           # Cache from production target tagged with branch name, may be empty first time branch is pushed

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -150,9 +150,9 @@ jobs:
         uses: docker/build-push-action@v6
         env:
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
-          BUILDKIT_INLINE_CACHE: 1
         with:
           build-args: |
+            BUILDKIT_INLINE_CACHE=1
             --secret id=master_key,env=RAILS_MASTER_KEY
           # Cache from builder target tagged with branch name, may be empty first time branch is pushed
           # Cache from builder target tagged with main branch name, always present, maybe less recent

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -153,7 +153,7 @@ jobs:
           BUILDKIT_INLINE_CACHE: 1
         with:
           build-args: |
-            --secret id=RAILS_MASTER_KEY
+            --secret id=master_key,env=RAILS_MASTER_KEY
           # Cache from builder target tagged with branch name, may be empty first time branch is pushed
           # Cache from builder target tagged with main branch name, always present, maybe less recent
           cache-from: |
@@ -173,7 +173,7 @@ jobs:
           BUILDKIT_INLINE_CACHE: 1
         with:
           build-args: |
-            --secret id=RAILS_MASTER_KEY
+            --secret id=master_key,env=RAILS_MASTER_KEY
           # Cache from builder target built above, always present
           # Cache from production target tagged with branch name, may be empty first time branch is pushed
           # Cache from production target tagged with main branch name, always present, maybe less recent

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,13 +32,13 @@ COPY . .
 # configuring it using the ENV variables we provide in storage.yml. However, at this point, these ENV vars have not been loaded,
 # causing the error. Below we define two throaway ENV vars to prevent the error from being thrown. These are then later overwritten,
 # when all of the ENV vars are loaded.
-ARG RAILS_MASTER_KEY
+#ARG RAILS_MASTER_KEY
 
 ENV DOCUMENTS_S3_BUCKET=throwaway_value
 ENV SCHOOLS_IMAGES_LOGOS_S3_BUCKET=throwaway_value
-ENV RAILS_MASTER_KEY=$RAILS_MASTER_KEY
+#ENV RAILS_MASTER_KEY=$RAILS_MASTER_KEY
 
-RUN RAILS_ENV=production SECRET_KEY_BASE=required-to-run-but-not-used RAILS_SERVE_STATIC_FILES=1 bundle exec rake assets:precompile
+RUN RAILS_ENV=production SECRET_KEY_BASE=required-to-run-but-not-used RAILS_SERVE_STATIC_FILES=1 RAILS_MASTER_KEY=/run/secrets/RAILS_MASTER_KEY bundle exec rake assets:precompile
 
 RUN rm -rf node_modules log tmp yarn.lock && \
       rm -rf /usr/local/bundle/cache && \
@@ -69,4 +69,4 @@ ARG COMMIT_SHA
 ENV COMMIT_SHA=$COMMIT_SHA
 
 EXPOSE 3000
-CMD bundle exec rails db:migrate:ignore_concurrent_migration_exceptions && bundle exec rails s
+CMD RAILS_MASTER_KEY=/run/secrets/RAILS_MASTER_KEY bundle exec rails db:migrate:ignore_concurrent_migration_exceptions && bundle exec rails s

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,7 @@ COPY . .
 ENV DOCUMENTS_S3_BUCKET=throwaway_value
 ENV SCHOOLS_IMAGES_LOGOS_S3_BUCKET=throwaway_value
 
-# RAILS_MASTER_KEY here is a throwaway value, not used in this step but needs to be 16 hex coded bytes
-RUN RAILS_ENV=production RAILS_MASTER_KEY=01010101010101010101010101010101 SECRET_KEY_BASE=required-to-run-but-not-used RAILS_SERVE_STATIC_FILES=1 bundle exec rake assets:precompile
+RUN --mount=type=secret,id=master_key,env=RAILS_MASTER_KEY RAILS_ENV=production SECRET_KEY_BASE=required-to-run-but-not-used RAILS_SERVE_STATIC_FILES=1 bundle exec rake assets:precompile
 
 RUN rm -rf node_modules log tmp yarn.lock && \
       rm -rf /usr/local/bundle/cache && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,9 @@ COPY . .
 
 ENV DOCUMENTS_S3_BUCKET=throwaway_value
 ENV SCHOOLS_IMAGES_LOGOS_S3_BUCKET=throwaway_value
-#ENV RAILS_MASTER_KEY=$RAILS_MASTER_KEY
 
-RUN RAILS_ENV=production SECRET_KEY_BASE=required-to-run-but-not-used RAILS_SERVE_STATIC_FILES=1 RAILS_MASTER_KEY=/run/secrets/RAILS_MASTER_KEY bundle exec rake assets:precompile
+# RAILS_MASTER_KEY here is a throwaway value, not used in this step but needs to be 16 hex coded bytes
+RUN RAILS_ENV=production RAILS_MASTER_KEY=01010101010101010101010101010101 SECRET_KEY_BASE=required-to-run-but-not-used RAILS_SERVE_STATIC_FILES=1 bundle exec rake assets:precompile
 
 RUN rm -rf node_modules log tmp yarn.lock && \
       rm -rf /usr/local/bundle/cache && \
@@ -69,4 +69,4 @@ ARG COMMIT_SHA
 ENV COMMIT_SHA=$COMMIT_SHA
 
 EXPOSE 3000
-CMD RAILS_MASTER_KEY=/run/secrets/RAILS_MASTER_KEY bundle exec rails db:migrate:ignore_concurrent_migration_exceptions && bundle exec rails s
+CMD bundle exec rails db:migrate:ignore_concurrent_migration_exceptions && bundle exec rails s

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ COPY . .
 # configuring it using the ENV variables we provide in storage.yml. However, at this point, these ENV vars have not been loaded,
 # causing the error. Below we define two throaway ENV vars to prevent the error from being thrown. These are then later overwritten,
 # when all of the ENV vars are loaded.
-#ARG RAILS_MASTER_KEY
 
 ENV DOCUMENTS_S3_BUCKET=throwaway_value
 ENV SCHOOLS_IMAGES_LOGOS_S3_BUCKET=throwaway_value


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/WqgZtiOj/1923-do-not-pass-secrets-to-dockerfile-builds-in-arg-or-env-values

## Changes in this PR:

Use secrets for RAILS_MASTER_KEY

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
