### PR TITLE
add back links to supportal

### DIFF
--- a/app/views/support_users/feedbacks/general.html.slim
+++ b/app/views/support_users/feedbacks/general.html.slim
@@ -1,5 +1,9 @@
 - content_for :page_title_prefix, t(".title")
 
+- content_for :breadcrumbs do
+  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
+  = govuk_back_link text: t("buttons.back"), href: support_user_root_path
+
 .govuk-grid-row
   .govuk-grid-column-full = render "tabs"
 

--- a/app/views/support_users/feedbacks/job_alerts.html.slim
+++ b/app/views/support_users/feedbacks/job_alerts.html.slim
@@ -1,5 +1,9 @@
 - content_for :page_title_prefix, t(".title")
 
+- content_for :breadcrumbs do
+  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
+  = govuk_back_link text: t("buttons.back"), href: support_user_root_path
+
 = render "tabs"
 = render "reporting_period_control"
 = render "tables", table_name: "job_alerts_feedback_table"

--- a/app/views/support_users/feedbacks/satisfaction_ratings.html.slim
+++ b/app/views/support_users/feedbacks/satisfaction_ratings.html.slim
@@ -1,5 +1,9 @@
 - content_for :page_title_prefix, t(".title")
 
+- content_for :breadcrumbs do
+  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
+  = govuk_back_link text: t("buttons.back"), href: support_user_root_path
+
 = render "tabs"
 
 = tabs do |tabs|

--- a/app/views/support_users/publisher_ats_api_clients/index.html.slim
+++ b/app/views/support_users/publisher_ats_api_clients/index.html.slim
@@ -1,5 +1,9 @@
 - content_for :page_title_prefix, t(".title")
 
+- content_for :breadcrumbs do
+  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
+  = govuk_back_link text: t("buttons.back"), href: support_user_root_path
+
 h1.govuk-heading-l = t(".title")
 = supportal_table(entries: @api_clients) do |t|
   - t.column "API client" do |api_client|

--- a/app/views/support_users/publisher_ats_api_clients/new.html.slim
+++ b/app/views/support_users/publisher_ats_api_clients/new.html.slim
@@ -1,5 +1,9 @@
 h1.govuk-heading-l New ATS API Client
 
+- content_for :breadcrumbs do
+  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
+  = govuk_back_link text: t("buttons.back"), href: support_users_publisher_ats_api_clients_path
+
 = form_with model: @api_client, url: support_users_publisher_ats_api_clients_path, local: true do |form|
   .govuk-form-group
     = form.label :name, class: "govuk-label"

--- a/app/views/support_users/publisher_ats_api_clients/show.html.slim
+++ b/app/views/support_users/publisher_ats_api_clients/show.html.slim
@@ -1,6 +1,10 @@
 - title = @api_client.name
 - content_for :page_title_prefix, title
 
+- content_for :breadcrumbs do
+  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
+  = govuk_back_link text: t("buttons.back"), href: support_users_service_data_path
+
 h1.govuk-heading-l = title
 
 = link_to "Rotate ATS API key", rotate_key_support_users_publisher_ats_api_client_path(@api_client), method: :post, class: "govuk-button govuk-button--secondary"

--- a/app/views/support_users/service_data/index.html.slim
+++ b/app/views/support_users/service_data/index.html.slim
@@ -1,5 +1,9 @@
 - content_for :page_title_prefix, t("support_users.service_data.index.title")
 
+- content_for :breadcrumbs do
+  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
+  = govuk_back_link text: t("buttons.back"), href: support_user_root_path
+
 h1.govuk-heading-l = t("support_users.service_data.index.heading")
 
 nav

--- a/app/views/support_users/service_data/jobseeker_profiles/index.html.slim
+++ b/app/views/support_users/service_data/jobseeker_profiles/index.html.slim
@@ -1,5 +1,9 @@
 - content_for :page_title_prefix, t(".title")
 
+- content_for :breadcrumbs do
+  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
+  = govuk_back_link text: t("buttons.back"), href: support_users_service_data_path
+
 h1.govuk-heading-l = t(".title")
 = supportal_table(entries: @jobseeker_profiles) do |t|
   - t.column "Jobseeker" do |jobseeker_profile|


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/AJ76uMPL/1924-add-back-links-on-support-dashboard-pages

## Changes in this PR:

Add back links to supportal pages

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
