### PR TITLE
Tweak on self disclosure form

### DIFF
--- a/app/controllers/jobseekers/govuk_one_login_callbacks_controller.rb
+++ b/app/controllers/jobseekers/govuk_one_login_callbacks_controller.rb
@@ -92,6 +92,7 @@ class Jobseekers::GovukOneLoginCallbacksController < Devise::OmniauthCallbacksCo
       stored_location.include?("/saved_job/") || # Signed-in from a vacancy page save/unsave action.
       stored_location.include?("/jobs/") || # Signed-in from a job page (in order to download)
       stored_location.include?("/jobseekers/subscriptions") || # Signed-in from a job alert email link.
+      stored_location.include?("/self_disclosure/#{Wicked::FIRST_STEP}") || # Signed-in from self-disclosure email link.
       stored_location.include?("/jobseekers/account/email_preferences/edit") # Signed-in from a peak times email.
   end
 

--- a/app/views/jobseekers/job_applications/self_disclosure/barred_list.html.slim
+++ b/app/views/jobseekers/job_applications/self_disclosure/barred_list.html.slim
@@ -8,7 +8,8 @@
     span.govuk-caption-m = "Part 2 of 4"
     h1.govuk-heading-l = t(".heading")
     h2.govuk-heading-m = t(".barred_list_declaration")
-    = t(".description.html")
+    - t(".description").each do |text|
+      p.govuk-hint = text
 
   = form_with(model: @form, url: wizard_path(step), method: :patch) do |f|
     = f.govuk_error_summary

--- a/app/views/jobseekers/job_applications/self_disclosure/confirmation.html.slim
+++ b/app/views/jobseekers/job_applications/self_disclosure/confirmation.html.slim
@@ -8,7 +8,8 @@
     span.govuk-caption-m = "Part 4 of 4"
     h1.govuk-heading-l = t(".heading")
     h2.govuk-heading-m = t(".confirmation_declaration")
-    = t(".description.html")
+    - t(".description").each do |text|
+      p.govuk-hint = text
 
   = form_with(model: @form, url: wizard_path(step), method: :patch) do |f|
     = f.govuk_error_summary

--- a/app/views/jobseekers/job_applications/self_disclosure/personal_details.html.slim
+++ b/app/views/jobseekers/job_applications/self_disclosure/personal_details.html.slim
@@ -4,7 +4,9 @@
   div
     span.govuk-caption-m = "Part 1 of 4"
     h1.govuk-heading-l = t(".heading")
-    = t(".description.html")
+    - t(".description").each do |text|
+      p.govuk-hint = text
+
     h2.govuk-heading-m = t(".personal_details")
 
   = form_with(model: @form, url: wizard_path(step), method: :patch) do |f|

--- a/app/views/publishers/vacancies/job_applications/pre_interview_checks.html.slim
+++ b/app/views/publishers/vacancies/job_applications/pre_interview_checks.html.slim
@@ -20,6 +20,7 @@
         - row.with_cell(text: govuk_link_to(reference_request.referee.name, organisation_job_job_application_reference_request_path(vacancy.id, @job_application.id, reference_request)))
 
         - if reference_request.sent?
+
           - row.with_cell(text: t(".sent_at", date: reference_request.updated_at.to_date.to_formatted_s))
           - row.with_cell(text: govuk_tag(text: t(".pending_status"), colour: "blue"))
         - elsif reference_request.received?
@@ -41,10 +42,11 @@
         - row.with_cell do
           = govuk_link_to("Self-dislosure form", organisation_job_job_application_self_disclosure_path(vacancy.id, @job_application.id))
         - if @job_application.self_disclosure_request.completed?
-          - row.with_cell(text: "Completed on the #{@job_application.self_disclosure_request.updated_at.to_fs}")
+          - row.with_cell(text: t(".received_at", date: @job_application.self_disclosure_request.updated_at.to_fs(:day_month_year)))
           - row.with_cell do
-            = govuk_tag(text: "COMPLETED", colour: "green")
+            = govuk_tag(text: t(".completed_status"), colour: "green")
         - if @job_application.self_disclosure_request.pending?
-          - row.with_cell(text: "Request sent on the #{@job_application.self_disclosure_request.updated_at.to_fs}")
+          - time, date = %i[time_only day_month_year].map { @job_application.self_disclosure_request.updated_at.to_fs(it) }
+          - row.with_cell(text: t(".requested_at", time:, date:))
           - row.with_cell do
-            = govuk_tag(text: "PENDING", colour: "blue")
+            = govuk_tag(text: t(".pending_status"), colour: "blue")

--- a/config/locales/jobseekers/job_applications/self_disclosure/barred_list.yml
+++ b/config/locales/jobseekers/job_applications/self_disclosure/barred_list.yml
@@ -7,9 +7,8 @@ en:
           heading: Self-disclosure form
           barred_list_declaration: Barred list declaration
           description:
-            html: >-
-              <p class="govuk-hint">If this role has been defined as regulated activity or work it will also be subject to an enhanced with barred list check in England, Northern Ireland and Wales or checks under the Protecting Vulnerable Groups scheme in Scotland.</p>
-              <p class="govuk-hint"><It is a criminal offence to apply for or accept a position working with children if you have been barred from/listed as unsuitable to engage in regulated activity/work with children.</p>
+            - "It is a criminal offence to apply for or accept a position working with children if you have been barred from/listed as unsuitable to engage in regulated activity/work with children."
+            - "If this role has been defined as regulated activity or work it will also be subject to an enhanced with barred list check in England, Northern Ireland and Wales or checks under the Protecting Vulnerable Groups scheme in Scotland." 
 
   helpers:
     legend:

--- a/config/locales/jobseekers/job_applications/self_disclosure/confirmation.yml
+++ b/config/locales/jobseekers/job_applications/self_disclosure/confirmation.yml
@@ -7,8 +7,7 @@ en:
           heading: Self-disclosure form
           confirmation_declaration: Confirmation declaration
           description:
-            html: >-
-              <p class="govuk-hint">Select all options in order to complete the declaration. You may be asked for a wet signature at your interview.</p>
+            - "Select all options in order to complete the declaration. You may be asked for a wet signature at your interview."
           agreed_for_processing: I agree that the information provided here may be processed in connection with recruitment purposes and I understand that an offer of employment may be withdrawn or disciplinary action may be taken if information is not disclosed by me and subsequently come to the organisation’s attention.
           agreed_for_criminal_record: In accordance with the organisation’s procedures if required I agree to provide a valid criminal record certificate and consent to the organisation clarifying any information provided on the disclosure with the agencies providing it.
           agreed_for_organisation_update: I agree to inform the organisation within 24 hours if I am subsequently investigated by any agency or organisation in relation to concerns about my behaviour towards children or young people.

--- a/config/locales/jobseekers/job_applications/self_disclosure/personal_details.yml
+++ b/config/locales/jobseekers/job_applications/self_disclosure/personal_details.yml
@@ -6,10 +6,9 @@ en:
           page_title: Self-disclosure form
           heading: Self-disclosure form
           description:
-            html: >-
-              <p class="govuk-hint">You are being asked to complete this form because the role you are applying for is exempt from the Rehabilitation of Offenders Act 1974 in England, Scotland and Wales, or the Rehabilitation of Offenders (Northern Ireland) Order 1978 and involves contact with children or young people.</p>
-              <p class="govuk-hint">As the role you have applied for involves work with children, you will also be required to undergo the relevant vetting and barring checks.</p>
-              <p class="govuk-hint">All information you provide will be treated as confidential and managed in accordance with relevant data protection legislation and guidance. You have a legal right to access any information held about you.</p>
+            - "You are being asked to complete this form because the role you are applying for is exempt from the Rehabilitation of Offenders Act 1974 in England, Scotland and Wales, or the Rehabilitation of Offenders (Northern Ireland) Order 1978 and involves contact with children or young people."
+            - "As the role you have applied for involves work with children, you will also be required to undergo the relevant vetting and barring checks."
+            - "All information you provide will be treated as confidential and managed in accordance with relevant data protection legislation and guidance. You have a legal right to access any information held about you."
           personal_details: Personal details
           criminal_record:
             heading: Criminal record declaration

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -605,9 +605,11 @@ en:
         pre_interview_checks:
           page_title: Pre Interview Checks
           sent_at: Request sent %{date}
+          requested_at: Request sent at %{time} on %{date}
           received_at: Received %{date}
           created_at: Created %{date}
           pending_status: Pending
+          completed_status: Completed
           received_status: Received
           created_status: Created
           references: References


### PR DESCRIPTION
## Trello card URL
[1933](https://trello.com/c/4wRXnjqV)

## Changes in this PR:

- barred list page copy

- email link to form

- pre interview checks page

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>