### PR TITLE
Job offered tab

### DIFF
--- a/app/controllers/publishers/vacancies/job_applications_controller.rb
+++ b/app/controllers/publishers/vacancies/job_applications_controller.rb
@@ -1,9 +1,10 @@
+require "zip"
+
 class Publishers::Vacancies::JobApplicationsController < Publishers::Vacancies::JobApplications::BaseController
   include Jobseekers::QualificationFormConcerns
   include DatesHelper
 
   before_action :set_job_application, only: %i[show download_pdf pre_interview_checks collect_references]
-
   before_action :set_job_applications, only: %i[index tag_single tag]
 
   def index
@@ -32,36 +33,36 @@ class Publishers::Vacancies::JobApplicationsController < Publishers::Vacancies::
   end
 
   def tag_single
-    prepare_to_tag([params.fetch(:id)], "all")
+    form_key = ActiveModel::Naming.param_key(Publishers::JobApplication::TagForm)
+    params[form_key] = {
+      origin: JobApplicationsHelper::JOB_APPLICATION_DISPLAYED_STATUSES.first,
+      job_applications: [params.fetch(:id)],
+    }
+    with_valid_tag_form { render "tag" }
   end
 
   def tag
-    tag_params = params.require(:publishers_job_application_tag_form).permit(:origin, job_applications: [])
-    if params["download_selected"] == "true"
-      download_selected(tag_params)
-    else
-      origin = tag_params[:origin]
-      prepare_to_tag(tag_params.fetch(:job_applications).compact_blank, origin)
+    with_valid_tag_form do |form|
+      case params["target"]
+      when "download" then download_selected(form.job_applications)
+      when "export"   then export_selected(form.job_applications)
+      when "emails"   then copy_emails_selected(form.job_applications)
+      when "declined" then render_declined_form(form.job_applications, form.origin)
+      else # when "update_status"
+        render "tag"
+      end
     end
   end
 
   def update_tag
-    update_tag_params = params.require(:publishers_job_application_status_form).permit(:origin, :status, job_applications: [])
-
-    applications = update_tag_params.fetch(:job_applications)
-    new_status = update_tag_params.fetch(:status).to_sym
-
-    if new_status == :interviewing
-      batch = JobApplicationBatch.create!(vacancy: vacancy)
-      JobApplication.find(applications).each do |ja|
-        batch.batchable_job_applications.create!(job_application: ja)
+    with_valid_tag_form(context: :update_tag) do |form|
+      case form.status
+      when "interviewing" then redirect_to_references_and_declarations(form.job_applications)
+      when "offered" then render_offered_form(form.job_applications, form.origin)
+      else
+        form.job_applications.find_each { it.update!(form.attributes) }
+        redirect_to organisation_job_job_applications_path(vacancy.id, anchor: form.origin)
       end
-      redirect_to organisation_job_job_application_batch_references_and_declaration_path(vacancy.id, batch.id, Wicked::FIRST_STEP)
-    else
-      JobApplication.find(applications).each do |job_application|
-        job_application.update!(status: new_status)
-      end
-      redirect_to organisation_job_job_applications_path(vacancy.id, anchor: update_tag_params[:origin])
     end
   end
 
@@ -78,6 +79,19 @@ class Publishers::Vacancies::JobApplicationsController < Publishers::Vacancies::
     @reference_requests = @job_application.referees.filter_map(&:reference_request)
   end
 
+  def update_all
+    form_params = params.require(:publishers_job_application_offer_decline_date_form)
+                          .permit(:origin, :offered_at, :declined_at, :status, job_applications: [])
+    form_params[:job_applications] = vacancy.job_applications.where(id: Array(form_params[:job_applications]).compact_blank)
+    @form = Publishers::JobApplication::OfferDeclineDateForm.new(form_params)
+    if @form.valid?
+      vacancy.job_applications.where(id: @form.job_applications).find_each { it.update!(@form.attributes) }
+      redirect_to organisation_job_job_applications_path(vacancy.id, anchor: @form.origin)
+    else
+      render(@form.status == "offered" ? "offered_date" : "declined_date")
+    end
+  end
+
   private
 
   def set_job_applications
@@ -86,37 +100,64 @@ class Publishers::Vacancies::JobApplicationsController < Publishers::Vacancies::
     @job_applications = vacancy.job_applications.not_draft
   end
 
-  def prepare_to_tag(job_applications, origin)
-    @form = Publishers::JobApplication::TagForm.new(job_applications: job_applications)
-    if @form.valid?
-      @job_applications = vacancy.job_applications.where(id: @form.job_applications)
-      @origin = origin
+  def redirect_to_references_and_declarations(job_applications)
+    batch = JobApplicationBatch.create!(vacancy: vacancy)
+    job_applications.each do |ja|
+      batch.batchable_job_applications.create!(job_application: ja)
+    end
+    redirect_to organisation_job_job_application_batch_references_and_declaration_path(vacancy.id, batch.id, Wicked::FIRST_STEP)
+  end
+
+  def with_valid_tag_form(context: :all)
+    form_class = Publishers::JobApplication::TagForm
+    form_params = params.fetch(ActiveModel::Naming.param_key(form_class), {}).permit(form_class.fields)
+    form_params[:job_applications] = vacancy.job_applications.where(id: Array(form_params[:job_applications]).compact_blank)
+
+    @form = form_class.new(form_params)
+    if @form.valid?(context)
+      yield @form
+    elsif @form.errors.key?(:status)
       render "tag"
     else
-      flash[origin.to_sym] = @form.errors.full_messages
-      redirect_to organisation_job_job_applications_path(vacancy.id, anchor: origin)
+      flash[@form.origin.to_sym] = @form.errors.full_messages
+      redirect_to organisation_job_job_applications_path(vacancy.id, anchor: @form.origin)
     end
   end
 
-  require "zip"
+  def download_selected(selection)
+    downloads = selection
+                  .includes([:qualifications, :employments, :training_and_cpds, :referees, { jobseeker: :jobseeker_profile }, { vacancy: %i[organisations publisher_organisation] }])
 
-  def download_selected(tag_params)
-    @form = Publishers::JobApplication::DownloadForm.new(job_applications: tag_params.fetch(:job_applications).compact_blank)
-    if @form.valid?
-      downloads = JobApplication
-                    .includes([:qualifications, :employments, :training_and_cpds, :referees, { jobseeker: :jobseeker_profile }, { vacancy: %i[organisations publisher_organisation] }])
-                    .where(vacancy: vacancy.id, id: @form.job_applications)
-      stringio = Zip::OutputStream.write_buffer do |zio|
-        downloads.each do |job_application|
-          zio.put_next_entry "#{job_application.first_name}_#{job_application.last_name}.pdf"
-          zio.write JobApplicationPdfGenerator.new(job_application).generate.render
-        end
+    stringio = Zip::OutputStream.write_buffer do |zio|
+      downloads.each do |job_application|
+        zio.put_next_entry "#{job_application.first_name}_#{job_application.last_name}.pdf"
+        zio.write JobApplicationPdfGenerator.new(job_application).generate.render
       end
-      send_data(stringio.string,
-                filename: "applications_#{vacancy.job_title}.zip",
-                type: "application/zip")
-    else
-      render "index"
     end
+    send_data(stringio.string, filename: "applications_#{vacancy.job_title}.zip")
+  end
+
+  def export_selected(selection)
+    headers = %i[first_name last_name street_address city postcode phone_number email_address national_insurance_number teacher_reference_number]
+
+    data = CSV.generate do |csv|
+      csv << headers
+      selection.pluck(*headers).each { csv << it }
+    end
+    send_data(data, filename: "applications_offered_#{vacancy.job_title}.csv")
+  end
+
+  def copy_emails_selected(selection)
+    send_data(selection.pluck(:email_address).to_json, filename: "applications_emails_#{vacancy.job_title}.json")
+  end
+
+  def render_declined_form(job_applications, origin)
+    @form = Publishers::JobApplication::OfferDeclineDateForm.new(job_applications:, origin:, status: "declined")
+    render "declined_date"
+  end
+
+  def render_offered_form(job_applications, origin)
+    @form = Publishers::JobApplication::OfferDeclineDateForm.new(job_applications:, origin:, status: "offered")
+    render "offered_date"
   end
 end

--- a/app/form_models/publishers/job_application/download_form.rb
+++ b/app/form_models/publishers/job_application/download_form.rb
@@ -1,8 +1,0 @@
-class Publishers::JobApplication::DownloadForm
-  include ActiveModel::Model
-  include ActiveModel::Validations
-
-  attr_accessor :job_applications
-
-  validates_length_of :job_applications, minimum: 1
-end

--- a/app/form_models/publishers/job_application/offer_decline_date_form.rb
+++ b/app/form_models/publishers/job_application/offer_decline_date_form.rb
@@ -1,0 +1,33 @@
+class Publishers::JobApplication::OfferDeclineDateForm
+  include ActiveModel::Model
+  include ActiveModel::Validations
+  include ActiveModel::Attributes
+  include ActiveRecord::AttributeAssignment
+
+  attribute :offered_at, :date_or_hash
+  attribute :declined_at, :date_or_hash
+  attribute :status, :string
+
+  attr_accessor :job_applications, :origin
+
+  validates :offered_at, date: {}, allow_nil: true
+  validates :declined_at, date: {}, allow_nil: true
+  validates_length_of :job_applications, minimum: 1
+
+  def job_application_ids
+    return [] if job_applications.blank?
+
+    job_applications.pluck(:id)
+  end
+
+  def attributes
+    hsh = super
+    ignore_field = status == "offered" ? "declined_at" : "offered_at"
+    hsh.delete(ignore_field)
+    hsh
+  end
+
+  def self.fields
+    [:origin, :status, { job_applications: [] }]
+  end
+end

--- a/app/form_models/publishers/job_application/tag_form.rb
+++ b/app/form_models/publishers/job_application/tag_form.rb
@@ -1,8 +1,30 @@
 class Publishers::JobApplication::TagForm
   include ActiveModel::Model
   include ActiveModel::Validations
+  include ActiveModel::Attributes
 
-  attr_accessor :job_applications
+  attribute :status, :string
+  attr_accessor :job_applications, :origin
 
   validates_length_of :job_applications, minimum: 1
+  validates_presence_of :status, on: :update_tag
+
+  def job_application_ids
+    return [] if job_applications.blank?
+
+    job_applications.pluck(:id)
+  end
+
+  def update_job_application_statuses
+    case origin
+    when "shortlisted" then %i[unsuccessful interviewing offered]
+    when "interviewing" then %i[unsuccessful offered]
+    else
+      %i[reviewed unsuccessful shortlisted interviewing offered]
+    end
+  end
+
+  def self.fields
+    [:origin, :status, { job_applications: [] }]
+  end
 end

--- a/app/helpers/job_applications_helper.rb
+++ b/app/helpers/job_applications_helper.rb
@@ -1,4 +1,6 @@
 module JobApplicationsHelper
+  JOB_APPLICATION_DISPLAYED_STATUSES = %i[submitted unsuccessful shortlisted interviewing offered].freeze
+
   PUBLISHER_STATUS_MAPPINGS = {
     submitted: "unread",
     reviewed: "reviewed",

--- a/app/helpers/job_applications_helper.rb
+++ b/app/helpers/job_applications_helper.rb
@@ -5,9 +5,10 @@ module JobApplicationsHelper
     submitted: "unread",
     reviewed: "reviewed",
     shortlisted: "shortlisted",
-    unsuccessful: "rejected",
+    unsuccessful: "not considering",
     withdrawn: "withdrawn",
     interviewing: "interviewing",
+    offered: "job offered",
   }.freeze
 
   JOBSEEKER_STATUS_MAPPINGS = {
@@ -20,6 +21,7 @@ module JobApplicationsHelper
     withdrawn: "withdrawn",
     interviewing: "interviewing",
     action_required: "action required",
+    offered: "offered",
   }.freeze
 
   JOB_APPLICATION_STATUS_TAG_COLOURS = {
@@ -27,11 +29,12 @@ module JobApplicationsHelper
     draft: "pink",
     submitted: "blue",
     reviewed: "purple",
-    shortlisted: "green",
+    shortlisted: "yellow",
     unsuccessful: "red",
     withdrawn: "yellow",
-    interviewing: "turquoise",
     action_required: "orange",
+    interviewing: "green",
+    offered: "pink",
   }.freeze
 
   def job_application_qualified_teacher_status_info(job_application)

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -54,7 +54,7 @@ class JobApplication < ApplicationRecord
   }
 
   # If you want to add a status, be sure to add a `status_at` column to the `job_applications` table
-  enum :status, { draft: 0, submitted: 1, reviewed: 2, shortlisted: 3, unsuccessful: 4, withdrawn: 5, interviewing: 6 }, default: 0
+  enum :status, { draft: 0, submitted: 1, reviewed: 2, shortlisted: 3, unsuccessful: 4, withdrawn: 5, interviewing: 6, offered: 7, declined: 8 }, default: 0
   array_enum working_patterns: { full_time: 0, part_time: 100, job_share: 101 }
 
   RELIGIOUS_REFERENCE_TYPES = { referee: 1, baptism_certificate: 2, baptism_date: 3, no_referee: 4 }.freeze
@@ -92,6 +92,16 @@ class JobApplication < ApplicationRecord
   validates :email_address, email_address: true, if: -> { email_address_changed? } # Allows data created prior to validation to still be valid
 
   has_one_attached :baptism_certificate, service: :amazon_s3_documents
+
+  def self.group_by_status(scope = all)
+    result = statuses.each_with_object({}) do |(status_name, status_idx), hsh|
+      hsh[status_name.to_sym] = scope.where(status: status_idx)
+    end
+
+    result[:submitted] = scope.where(status: %i[submitted reviewed])
+
+    result
+  end
 
   def name
     "#{first_name} #{last_name}"

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -1,5 +1,5 @@
 class JobApplication < ApplicationRecord
-  before_save :update_status_timestamp, if: :will_save_change_to_status?
+  before_save :update_status_timestamp, if: %i[will_save_change_to_status? ignore_for_offered_and_declined?]
   before_save :anonymise_report, if: :will_save_change_to_status?
   before_save :reset_support_needed_details
 
@@ -137,6 +137,10 @@ class JobApplication < ApplicationRecord
   end
 
   private
+
+  def ignore_for_offered_and_declined?
+    !status.in?(%w[offered declined])
+  end
 
   def update_status_timestamp
     self["#{status}_at"] = Time.current

--- a/app/views/publishers/vacancies/job_applications/_candidates.html.slim
+++ b/app/views/publishers/vacancies/job_applications/_candidates.html.slim
@@ -1,3 +1,7 @@
+- if origin == :offered
+  = govuk_inset_text do
+    p = t(".offered_inset")
+
 = form_with(model: form, url: tag_organisation_job_job_applications_path(vacancy.id), method: :get, scope: :publishers_job_application_tag_form) do |f|
 
   = f.govuk_error_summary
@@ -5,21 +9,33 @@
     = govuk_notification_banner title_text: "Error", success: false, classes: ["govuk-error-colour"] do |notification_banner|
       - notification_banner.with_heading(text: flash[origin])
 
-  = f.govuk_check_boxes_fieldset :job_applications, legend: { text: heading } do
+  = f.govuk_check_boxes_fieldset :job_applications, legend: { text: heading, size: "m" } do
     = f.hidden_field :origin, value: origin
     = govuk_table(html_attributes: { data: { module: "moj-multi-select", multi_select_checkbox: "#multi_select_#{multi_select}", multi_select_idprefix: "id_all_#{multi_select}" } }) do |table|
 
       - table.with_head do |head|
         - head.with_row do |row|
-          - row.with_cell(html_attributes: { id: "multi_select_#{multi_select}" })
+          - row.with_cell(html_attributes: { id: "multi_select_#{multi_select}" }) if origin != :declined
           - row.with_cell(text: t(".name"))
           - row.with_cell(text: t(".contact_details"))
-          - row.with_cell(text: t(".application_status"))
+          - row.with_cell(text: t(".offer_date")) if origin == :offered
+          - row.with_cell(text: t(".decline_date")) if origin == :declined
+          - row.with_cell(text: t(".application_status")) if origin != :declined
       - table.with_body do |body|
         - candidates.each_with_index do |application, index|
           - body.with_row(html_attributes: { class: "application-#{application.status}" }) do |row|
             = render "#{application.status}_row", row: row, application: application, index: index, vacancy: vacancy, f: f
 
-  .govuk-button-group
-    = f.govuk_submit t(".download_selected"), name: "download_selected", value: "true"
-    = f.govuk_submit t(".update_application_status"), name: "update_application_status", value: "true", secondary: true
+  - if origin == :offered
+    .govuk-button-group
+      = f.govuk_submit t(".download_selected"), name: "target", value: "download"
+      = f.govuk_submit t(".offer_declined"), name: "target", value: "declined", secondary: true
+      = f.govuk_submit t(".copy_applicant_email"), name: "target", value: "emails", secondary: true
+    .govuk-button-group
+      = f.govuk_submit t(".download_applicant_data"), name: "target", value: "export", secondary: true
+
+  - elsif origin != :declined
+    .govuk-button-group
+      = f.govuk_submit t(".download_selected"), name: "target", value: "download"
+      = f.govuk_submit t(".update_application_status"), name: "target", value: "update_status", secondary: true
+      = f.govuk_submit t(".copy_applicant_email"), name: "target", value: "emails", secondary: true

--- a/app/views/publishers/vacancies/job_applications/_declined_row.html.slim
+++ b/app/views/publishers/vacancies/job_applications/_declined_row.html.slim
@@ -1,0 +1,3 @@
+- row.with_cell(text: govuk_link_to(application.name, organisation_job_job_application_path(vacancy.id, application)))
+- row.with_cell(text: application.email_address)
+- row.with_cell(text: application.declined_at&.to_fs(:day_month_year))

--- a/app/views/publishers/vacancies/job_applications/_offered_row.html.slim
+++ b/app/views/publishers/vacancies/job_applications/_offered_row.html.slim
@@ -1,0 +1,5 @@
+- row.with_cell(text: tag.div(f.govuk_check_box(:job_applications, application.id, link_errors: index.zero?, label: { hidden: true, text: "Select #{application.name}" }), class: "govuk-checkboxes--small"))
+- row.with_cell(text: govuk_link_to(application.name, organisation_job_job_application_path(vacancy.id, application)))
+- row.with_cell(text: application.email_address)
+- row.with_cell(text: application.offered_at&.to_fs(:day_month_year))
+- row.with_cell(text: render("interviewing_status", application: application))

--- a/app/views/publishers/vacancies/job_applications/declined_date.html.slim
+++ b/app/views/publishers/vacancies/job_applications/declined_date.html.slim
@@ -1,0 +1,16 @@
+- content_for :breadcrumbs do
+  = govuk_back_link text: t("app.back_link"), href: organisation_job_job_applications_path(vacancy.id, anchor: @form.origin), html_attributes: { "aria-label" => "Back navigation", role: "navigation" }
+
+span.govuk-hint = t("publishers.vacancies.job_applications.update_application_status")
+= form_with(model: @form, url: update_all_organisation_job_job_applications_path(vacancy.id), method: :patch) do |f|
+  = f.govuk_error_summary
+  = f.hidden_field :origin
+  = f.hidden_field :status
+  - @form.job_application_ids.each do |value|
+    = f.hidden_field :job_applications, multiple: true, value:
+
+  = f.govuk_date_field :declined_at, label: { size: "s" }, legend: { size: "l" }
+
+  .govuk-button-group
+    = f.govuk_submit t("buttons.continue")
+    = govuk_button_link_to t("buttons.cancel"), organisation_job_job_applications_path(vacancy.id, anchor: @form.origin), secondary: true

--- a/app/views/publishers/vacancies/job_applications/index.html.slim
+++ b/app/views/publishers/vacancies/job_applications/index.html.slim
@@ -12,11 +12,6 @@
       - interviewing = applications.fetch("interviewing", [])
       = govuk_tabs do |tabs|
         / set id property so that anchors are '#shortlisted' rather than '#shortlisted-4'
-        - tabs.with_tab(label: "All (#{@job_applications.size})", id: "all") do
-          - if @job_applications.any?
-            = render "candidates", form: @form, vacancy: @vacancy, candidates: @job_applications, heading: "All Applications", multi_select: "all", origin: :all
-          - else
-            = render EmptySectionComponent.new title: t(".no_applicants")
         - tabs.with_tab(label: "New (#{new_ones.size})", id: "submitted")
           - if new_ones.any?
             = render "candidates", form: @form, vacancy: @vacancy, candidates: new_ones, heading: "New Applications", multi_select: "new", origin: :submitted

--- a/app/views/publishers/vacancies/job_applications/index.html.slim
+++ b/app/views/publishers/vacancies/job_applications/index.html.slim
@@ -9,11 +9,16 @@
       = govuk_tabs do |tabs|
         / set id property so that anchors are '#shortlisted' rather than '#shortlisted-4'
         - JobApplicationsHelper::JOB_APPLICATION_DISPLAYED_STATUSES.each do |status|
-          - tabs.with_tab(label: t(".tab.#{status}.label", count: categories[status].count), id: status.to_s)
+          - id = status.to_s
+          - count = (status == :offered ? categories[:offered].count + categories[:declined].count : categories[status].count)
+          - tabs.with_tab(label: t(".tab.#{status}.label", count:), id:)
             - if categories[status].exists?
               = render "candidates", form: @form, vacancy: @vacancy, candidates: categories[status], heading: t(".tab.#{status}.heading"), multi_select: status, origin: status
             - else
               = render EmptySectionComponent.new title: t(".tab.#{status}.none")
+            - if status == :offered && categories[:declined].exists?
+              = govuk_section_break(visible: true, size: "xl")
+              = render "candidates", form: @form, vacancy: @vacancy, candidates: categories[:declined], heading: t(".tab.declined.heading"), multi_select: :declined, origin: :declined
 
     - else
       = govuk_inset_text do

--- a/app/views/publishers/vacancies/job_applications/index.html.slim
+++ b/app/views/publishers/vacancies/job_applications/index.html.slim
@@ -5,33 +5,16 @@
 .govuk-grid-row
   .govuk-grid-column-full
     - if @vacancy.within_data_access_period?
-      - applications = @job_applications.group_by(&:status)
-      - new_ones = applications.fetch("submitted", []) + applications.fetch("reviewed", [])
-      - rejected = applications.fetch("unsuccessful", [])
-      - shortlisted = applications.fetch("shortlisted", [])
-      - interviewing = applications.fetch("interviewing", [])
+      - categories = @job_applications.group_by_status
       = govuk_tabs do |tabs|
         / set id property so that anchors are '#shortlisted' rather than '#shortlisted-4'
-        - tabs.with_tab(label: "New (#{new_ones.size})", id: "submitted")
-          - if new_ones.any?
-            = render "candidates", form: @form, vacancy: @vacancy, candidates: new_ones, heading: "New Applications", multi_select: "new", origin: :submitted
-          - else
-            = render EmptySectionComponent.new title: t(".no_new")
-        - tabs.with_tab(label: "Not Considering (#{rejected.size})", id: "not_considering")
-          - if rejected.any?
-            = render "candidates", form: @form, vacancy: @vacancy, candidates: rejected, heading: "Not being considered", multi_select: "rej", origin: :not_considering
-          - else
-            = render EmptySectionComponent.new title: t(".no_rejected")
-        - tabs.with_tab(label: "Shortlisted (#{shortlisted.size})", id: "shortlisted")
-          - if shortlisted.any?
-            = render "candidates", form: @form, vacancy: @vacancy, candidates: shortlisted, heading: "Shortlisted Applications", multi_select: "short", origin: :shortlisted
-          - else
-            = render EmptySectionComponent.new title: t(".no_shortlisted")
-        - tabs.with_tab(label: "Interviewing (#{interviewing.size})", id: "interviewing")
-          - if interviewing.any?
-            = render "candidates", form: @form, vacancy: @vacancy, candidates: interviewing, heading: "Interviewing Applications", multi_select: "inter", origin: :interviewing
-          - else
-            = render EmptySectionComponent.new title: t(".no_interviewing")
+        - JobApplicationsHelper::JOB_APPLICATION_DISPLAYED_STATUSES.each do |status|
+          - tabs.with_tab(label: t(".tab.#{status}.label", count: categories[status].count), id: status.to_s)
+            - if categories[status].exists?
+              = render "candidates", form: @form, vacancy: @vacancy, candidates: categories[status], heading: t(".tab.#{status}.heading"), multi_select: status, origin: status
+            - else
+              = render EmptySectionComponent.new title: t(".tab.#{status}.none")
+
     - else
       = govuk_inset_text do
         p = t(".expired_more_than_year")

--- a/app/views/publishers/vacancies/job_applications/offered_date.html.slim
+++ b/app/views/publishers/vacancies/job_applications/offered_date.html.slim
@@ -1,0 +1,16 @@
+- content_for :breadcrumbs do
+  = govuk_back_link text: t("app.back_link"), href: organisation_job_job_applications_path(vacancy.id, anchor: @form.origin), html_attributes: { "aria-label" => "Back navigation", role: "navigation" }
+
+span.govuk-hint = t("publishers.vacancies.job_applications.update_application_status")
+= form_with(model: @form, url: update_all_organisation_job_job_applications_path(vacancy.id), method: :patch) do |f|
+  = f.govuk_error_summary
+  = f.hidden_field :origin
+  = f.hidden_field :status
+  - @form.job_application_ids.each do |value|
+    = f.hidden_field :job_applications, multiple: true, value:
+
+  = f.govuk_date_field :offered_at, label: { size: "s" }, legend: { size: "l" }
+
+  .govuk-button-group
+    = f.govuk_submit t("buttons.continue")
+    = govuk_button_link_to t("buttons.cancel"), organisation_job_job_applications_path(vacancy.id, anchor: @form.origin), secondary: true

--- a/app/views/publishers/vacancies/job_applications/tag.html.slim
+++ b/app/views/publishers/vacancies/job_applications/tag.html.slim
@@ -1,30 +1,28 @@
 - content_for :page_title_prefix, t(".page_title")
 
-- if @job_applications.size == 1
-  h1.govuk-heading-l class="govuk-!-display-inline"
-    = t(".what_application_status_single", name: @job_applications.first.name)
-- else
-  h1.govuk-heading-l class="govuk-!-display-inline"
-    = t(".what_application_status_multiple")
-  = govuk_inset_text do
-    = t(".applicants")
+p.govuk-hint = t("publishers.vacancies.job_applications.update_application_status")
+h1.govuk-heading-l class="govuk-!-display-inline"
+  = t(".what_application_status", count: @form.job_applications.count)
 
-    p.govuk-body
-      ul
-        - @job_applications.each do |ja|
-          li = ja.name
+= govuk_inset_text do
+  = t(".applicants")
+  p.govuk-body
+    ul
+      - @form.job_applications.each do |ja|
+        li = ja.name
 
-= form_with(url: update_tag_organisation_job_job_applications_path(vacancy.id), scope: :publishers_job_application_status_form) do |f|
-  =  f.hidden_field :origin, value: @origin
-  - @job_applications.each do |ja|
-    = f.hidden_field :job_applications, multiple: true, value: ja.id
+= form_with(model: @form, url: update_tag_organisation_job_job_applications_path(vacancy.id)) do |f|
+  = f.govuk_error_summary
+  = f.hidden_field :origin
+  - @form.job_application_ids.each do |value|
+    = f.hidden_field :job_applications, multiple: true, value:
 
-  = f.govuk_radio_buttons_fieldset :status do
-    = f.govuk_radio_button :status, :submitted
-    = f.govuk_radio_button :status, :unsuccessful
-    = f.govuk_radio_button :status, :reviewed
-    = f.govuk_radio_button :status, :shortlisted
+  = f.govuk_radio_buttons_fieldset :status, legend: nil do
+    - @form.update_job_application_statuses[..-2].each do |status|
+      = f.govuk_radio_button :status, status
     = f.govuk_radio_divider
-    = f.govuk_radio_button :status, :interviewing
+    = f.govuk_radio_button :status, @form.update_job_application_statuses.last
 
-  = f.govuk_submit t("buttons.save_and_continue")
+  .govuk-button-group
+    = f.govuk_submit t("buttons.save_and_continue")
+    = govuk_button_link_to t("buttons.cancel"), organisation_job_job_applications_path(vacancy.id, anchor: @form.origin), secondary: true

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -115,6 +115,8 @@ shared:
     - unsuccessful_at
     - interviewing_at
     - withdrawn_at
+    - offered_at
+    - declined_at
     - first_name
     - last_name
     - previous_names

--- a/config/initializers/date_time_formats.rb
+++ b/config/initializers/date_time_formats.rb
@@ -5,6 +5,7 @@ Date::DATE_FORMATS[:day_month] = "%-d %B"
 Date::DATE_FORMATS[:day_month_year] = "%d %B %Y"
 
 # Format times globally into these formats:
+Time::DATE_FORMATS[:day_month_year] = "%d %B %Y"
 Time::DATE_FORMATS[:default] = "%e %B %Y %-l:%M%P"
 Time::DATE_FORMATS[:date_only] = "%e %B %Y"
 Time::DATE_FORMATS[:date_only_shorthand] = "%e %b %Y"

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -2,3 +2,4 @@
 
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
+Mime::Type.register "application/zip", :zip, [], %w[zip]

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -543,15 +543,32 @@ en:
             pre_interview_checks: Pre-interview checks
             notes: Notes
         index:
+          tab:
+            submitted:
+              label: "New %{count}"
+              heading: New applications
+              none: There are no pending applications
+            unsuccessful:
+              label: "Not Considering %{count}"
+              heading: Not being considered
+              none: No applications have been marked for rejection
+            shortlisted:
+              label: "Shortlisted %{count}"
+              heading: Shortlisted applications
+              none: No applications have been shortlisted yet
+            interviewing:
+              label: "Interviewing %{count}"
+              heading: Interviewing applications
+              none: No applications have been marked for interview yet
+            offered:
+              label: "Offered %{count}"
+              heading:
+              none: No applications have been offered yet
           deadline:
             after: Deadline passed
             before: Application deadline
           expired_more_than_year: In line with our data retention policy you are no longer able to view applications for this job.
           no_applicants: Nobody has applied for this job yet
-          no_new: There are no pending applications
-          no_rejected: No applications have been marked for rejection
-          no_interviewing: No applications have been marked for interview yet
-          no_shortlisted: No applications have been shortlisted yet
           received: Received on
           rejected:
             one: Rejected application

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -534,6 +534,9 @@ en:
           draft: Draft jobs - %{organisation_name}
           awaiting_feedback: Jobs awaiting feedbank - %{organisation_name}
       job_applications:
+        update_application_status: Update application status
+        update_tag:
+          blank: You must select one option
         interviewing_status:
           pre_interview_checks: Pre-interview checks
         header:
@@ -545,25 +548,29 @@ en:
         index:
           tab:
             submitted:
-              label: "New %{count}"
+              label: "New (%{count})"
               heading: New applications
               none: There are no pending applications
             unsuccessful:
-              label: "Not Considering %{count}"
+              label: "Not considering (%{count})"
               heading: Not being considered
               none: No applications have been marked for rejection
             shortlisted:
-              label: "Shortlisted %{count}"
+              label: "Shortlisted (%{count})"
               heading: Shortlisted applications
               none: No applications have been shortlisted yet
             interviewing:
-              label: "Interviewing %{count}"
+              label: "Interviewing (%{count})"
               heading: Interviewing applications
               none: No applications have been marked for interview yet
             offered:
-              label: "Offered %{count}"
-              heading:
+              label: "Job offered (%{count})"
+              heading: Applicants offered a job
               none: No applications have been offered yet
+            declined:
+              label: "Declined (%{count})"
+              heading: Offer declined
+              none: No applications have been declined yet
           deadline:
             after: Deadline passed
             before: Application deadline
@@ -588,6 +595,12 @@ en:
           application_status: Application status
           update_application_status: Update application status
           download_selected: Download selected
+          copy_applicant_email: Copy selected emails
+          offer_declined: Mark offer as declined
+          download_applicant_data: Download applicants data
+          decline_date: Decline date
+          offer_date: Ofer date
+          offered_inset: Downloading applicant data will generate a CSV file that includes each applicant’s name, address, phone number, National Insurance number, and TRN.
         interviewing:
           name: Name
           contact_details: Contact details
@@ -682,8 +695,9 @@ en:
             how_long: How long have you known the candidate and in what capacity?
         tag:
           page_title: Update application status
-          what_application_status_single: What application status do you want to assign to %{name}?
-          what_application_status_multiple: What application status do you want to assign to these applicants?
+          what_application_status:
+            one: What application status do you want to assign to this applicant?
+            other: What application status do you want to assign to these applicants?
           applicants: Applicants
         update_status:
           unsuccessful: "%{name} has been sent an email telling them their application has not been successful"

--- a/config/locales/publishers/job_application_status_form.yml
+++ b/config/locales/publishers/job_application_status_form.yml
@@ -2,6 +2,10 @@ en:
   activemodel:
     errors:
       models:
+        publishers/job_application/tag_form:
+          attributes:
+            status:
+              blank: You must select one status
         publishers/job_application/collect_references_form:
           attributes:
             collect_references_and_declarations:
@@ -23,18 +27,27 @@ en:
               blank: Enter a valid email address
               invalid: Enter a valid email address
 
+        publishers/job_application/offer_decline_date_form:
+          attributes:
+            offered_at:
+              invalid: Enter a valid date, for example, 27 3 2007
+            declined_at:
+              invalid: Enter a valid date, for example, 27 3 2007
+            job_applications:
+              too_short: You must select at least one job application
+
   helpers:
     hint:
-      publishers_job_application_status_form:
+      publishers_job_application_tag_form:
         status_options:
           submitted: Applications that have not been reviewed
-          unsuccessful: Applications that you arw not taking forward to interview. You can create an email to send to the applicant to let them know
-          reviewed: Applications that have been reviewed
+          reviewed: Applications that have been reviewed. Reviewed applications will remain in the 'New' tab until shortlisted or not considering.
+          unsuccessful: Applications that you are not taking forward to interview. You can create an email to send to the applicant to let them know
           shortlisted: Applications that have been shortlisted
           interviewing: >-
-            Applications that you plan to interview. You can create an email to send to the applicant to let them know,
-            alternatively you can reach out to the applicant. You will also be able to trigger pre-interview checks
-            through the Teaching Vacancies service.
+            Candidates you plan to interview. You can create an email to send to the applicant to let them know.
+            You will also be able to trigger pre-interview checks through the Teaching Vacancies service.
+          offered: Candidates that have been offered a job. Should they decline the offer you will have the option to update the status later.
 
       publishers_job_application_collect_references_form:
         collect_references_and_declarations_options:
@@ -56,14 +69,20 @@ en:
           true: "This reference will be marked as complete"
           false: "This reference will remain as received"
 
+      publishers_job_application_offer_decline_date_form:
+        offered_at: For example 24 2 2025
+        declined_at: For example 24 2 2025
+
+
     label:
-      publishers_job_application_status_form:
+      publishers_job_application_tag_form:
         status_options:
           submitted_html: New <span class="govuk-tag govuk-tag--blue">New</span>
-          unsuccessful_html: Not Considering <span class="govuk-tag govuk-tag--red">Not Considering</span>
+          unsuccessful_html: Not considering <span class="govuk-tag govuk-tag--red">Not considering</span>
           reviewed_html: Reviewed <span class="govuk-tag govuk-tag--purple">Reviewed</span>
-          shortlisted_html: Shortlisted <span class="govuk-tag govuk-tag--green">Shortlisted</span>
-          interviewing_html: Interviewing <span class="govuk-tag govuk-tag--turquoise">Interviewing</span>
+          shortlisted_html: Shortlisted <span class="govuk-tag govuk-tag--yellow">Shortlisted</span>
+          interviewing_html: Interviewing <span class="govuk-tag govuk-tag--green">Interviewing</span>
+          offered_html: Job offered <span class="govuk-tag govuk-tag--pink">Job offered</span>
 
       publishers_job_application_collect_references_form:
         collect_references_and_declarations_options:
@@ -89,3 +108,9 @@ en:
         contact_applicants: >-
           The applicant needs to be notified when you are collecting references.
           Would you like Teaching Vacancies to contact the applicant?
+
+      publishers_job_application_offer_decline_date_form:
+        offered_at: >-
+          When was the job offered to the candidate? (Optional)
+        declined_at: >-
+          When did the candidate decline the offer? (Optional)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -407,6 +407,7 @@ Rails.application.routes.draw do
         get :tag, on: :collection
         get :tag_single, on: :member
         post :update_tag, on: :collection
+        patch :update_all, on: :collection
         member do
           get :pre_interview_checks
           get :collect_references

--- a/db/migrate/20250617110705_add_offered_at_to_job_application.rb
+++ b/db/migrate/20250617110705_add_offered_at_to_job_application.rb
@@ -1,0 +1,6 @@
+class AddOfferedAtToJobApplication < ActiveRecord::Migration[7.2]
+  def change
+    add_column :job_applications, :offered_at, :datetime
+    add_column :job_applications, :declined_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_27_101345) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_17_110705) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -275,6 +275,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_27_101345) do
     t.boolean "has_close_relationships"
     t.boolean "has_right_to_work_in_uk"
     t.boolean "has_safeguarding_issue"
+    t.datetime "offered_at"
+    t.datetime "declined_at"
     t.index ["jobseeker_id"], name: "index_job_applications_jobseeker_id"
     t.index ["vacancy_id"], name: "index_job_applications_on_vacancy_id"
   end

--- a/spec/factories/job_applications.rb
+++ b/spec/factories/job_applications.rb
@@ -189,4 +189,22 @@ FactoryBot.define do
 
     status { :interviewing }
   end
+
+  trait :status_offered do
+    transient do
+      submitted_at { 4.days.ago }
+      offered_at { 2.days.ago }
+    end
+
+    status { :offered }
+  end
+
+  trait :status_declined do
+    transient do
+      submitted_at { 4.days.ago }
+      declined_at { 2.days.ago }
+    end
+
+    status { :declined }
+  end
 end

--- a/spec/form_models/publishers/job_application/offer_decline_date_form_spec.rb
+++ b/spec/form_models/publishers/job_application/offer_decline_date_form_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+module Publishers
+  module JobApplication
+    RSpec.describe OfferDeclineDateForm, type: :model do
+      it { is_expected.to validate_length_of(:job_applications) }
+
+      describe ".job_application_ids" do
+        subject { described_class.new(job_applications:).job_application_ids }
+
+        let(:job_application) { create(:job_application) }
+
+        context "with a selection" do
+          let(:job_applications) { ::JobApplication.where(id: job_application.id) }
+
+          it { is_expected.to eq([job_application.id]) }
+        end
+
+        context "with no selection" do
+          let(:job_applications) { ::JobApplication.where(id: "no-id") }
+
+          it { is_expected.to eq([]) }
+        end
+      end
+
+      describe "#.fields" do
+        subject { described_class.fields }
+
+        it { is_expected.to eq([:origin, :status, { job_applications: [] }]) }
+      end
+
+      describe ".attributes" do
+        subject { described_class.new(status:, offered_at:, declined_at:).attributes }
+
+        context "when status offered" do
+          let(:status) { "offered" }
+          let(:offered_at) { Date.new(2025, 2, 1) }
+          let(:declined_at) { nil }
+
+          it { is_expected.to match({ offered_at:, status: }.stringify_keys) }
+        end
+
+        context "when status declined" do
+          let(:status) { "declined" }
+          let(:offered_at) { nil }
+          let(:declined_at) { Date.new(2025, 2, 1) }
+
+          it { is_expected.to match({ declined_at:, status: }.stringify_keys) }
+        end
+      end
+    end
+  end
+end

--- a/spec/form_models/publishers/job_application/tag_form_spec.rb
+++ b/spec/form_models/publishers/job_application/tag_form_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+module Publishers
+  module JobApplication
+    RSpec.describe TagForm, type: :model do
+      subject(:tag_form) { described_class.new(job_applications:, status:, origin:) }
+
+      let(:job_applications) { build_list(:job_application, 2) }
+      let(:status) { "shortlisted" }
+      let(:origin) { "shortlisted" }
+
+      it { is_expected.to validate_length_of(:job_applications) }
+
+      describe ".job_application_ids" do
+        subject { described_class.new(job_applications:).job_application_ids }
+
+        let(:job_application) { create(:job_application) }
+
+        context "with a selection" do
+          let(:job_applications) { ::JobApplication.where(id: job_application.id) }
+
+          it { is_expected.to eq([job_application.id]) }
+        end
+
+        context "with no selection" do
+          let(:job_applications) { ::JobApplication.where(id: "no-id") }
+
+          it { is_expected.to eq([]) }
+        end
+      end
+
+      context "when context is update_tag" do
+        it "when status missing invalid" do
+          tag_form.status = nil
+          tag_form.valid?(:update_tag)
+          expect(tag_form.errors[:status]).to be_present
+        end
+
+        it "when status present valid" do
+          tag_form.valid?(:update_tag)
+          expect(tag_form.errors[:status]).to be_empty
+        end
+      end
+
+      describe ".update_job_application_statuses" do
+        subject { described_class.new(job_applications:, status:, origin:).update_job_application_statuses }
+
+        context "when origin is shortlisted" do
+          let(:origin) { "shortlisted" }
+
+          it { is_expected.to eq(%i[unsuccessful interviewing offered]) }
+        end
+
+        context "when origin is interviewing" do
+          let(:origin) { "interviewing" }
+
+          it { is_expected.to eq(%i[unsuccessful offered]) }
+        end
+
+        context "when origin is any other" do
+          let(:origin) { "reviewed" }
+
+          it { is_expected.to eq(%i[reviewed unsuccessful shortlisted interviewing offered]) }
+        end
+      end
+    end
+  end
+end

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -6,6 +6,12 @@ RSpec.describe JobApplication do
   it { is_expected.to have_many(:employments) }
   it { is_expected.to have_many(:referees) }
 
+  describe ".group_by_status" do
+    subject(:hash) { described_class.group_by_status }
+
+    it { expect(hash.keys).to eq(%i[draft submitted reviewed shortlisted unsuccessful withdrawn interviewing offered declined]) }
+  end
+
   describe "#has_noticed_notifications" do
     subject { create(:job_application) }
 

--- a/spec/requests/publishers/vacancies/job_applications_spec.rb
+++ b/spec/requests/publishers/vacancies/job_applications_spec.rb
@@ -109,39 +109,222 @@ RSpec.describe "Job applications" do
   end
 
   describe "GET #tag" do
+    subject { response }
+
     let(:vacancy) { create(:vacancy, job_title: "teacher-job") }
     let(:job_application_2) { create(:job_application, :status_submitted, vacancy: vacancy) }
-    let(:tag_params) { { publishers_job_application_tag_form: { job_applications: [job_application.id, job_application_2.id] } } }
+    let(:params) do
+      {
+        publishers_job_application_tag_form: {
+          job_applications:,
+          origin:,
+        },
+        target:,
+      }
+    end
+    let(:job_applications) { [job_application.id, job_application_2.id] }
+    let(:origin) { "new" }
+    let(:target) { nil }
+
+    before do
+      get(tag_organisation_job_job_applications_path(vacancy.id), params:)
+    end
 
     context "when preparing to tag job applications" do
-      it "renders the tag template" do
-        get tag_organisation_job_job_applications_path(vacancy.id), params: tag_params
-        expect(response).to render_template(:tag)
-      end
+      it { is_expected.to render_template(:tag) }
 
-      it "renders index when form is invalid" do
-        get tag_organisation_job_job_applications_path(vacancy.id), params: { publishers_job_application_tag_form: { job_applications: [], origin: "all" } }
-        expect(response).to redirect_to(organisation_job_job_applications_path(vacancy.id, anchor: "all"))
+      context "when no job application selected" do
+        let(:job_applications) { [] }
+
+        it { is_expected.to redirect_to(organisation_job_job_applications_path(vacancy.id, anchor: origin)) }
       end
     end
 
     context "when downloading selected job applications" do
-      let(:download_params) { tag_params.merge(download_selected: "true") }
+      let(:target) { "download" }
 
       it "sends zip file with PDFs" do
-        get tag_organisation_job_job_applications_path(vacancy.id), params: download_params
-
         expect(response).to have_http_status(:ok)
         expect(response.content_type).to eq("application/zip")
         expect(response.headers["Content-Disposition"]).to include("applications_#{vacancy.job_title}.zip")
       end
 
-      it "renders index when download form is invalid" do
-        get tag_organisation_job_job_applications_path(vacancy.id), params: {
-          publishers_job_application_tag_form: { job_applications: [] },
-          download_selected: "true",
-        }
-        expect(response).to render_template(:index)
+      context "when no job application selected" do
+        let(:job_applications) { [] }
+
+        it { is_expected.to redirect_to(organisation_job_job_applications_path(vacancy.id, anchor: origin)) }
+      end
+    end
+
+    context "when exporting selected job applications" do
+      let(:target) { "export" }
+
+      it "sends csv file" do
+        expect(response).to have_http_status(:ok)
+        expect(response.content_type).to eq("text/csv")
+        expect(response.headers["Content-Disposition"]).to include("applications_offered_#{vacancy.job_title}.csv")
+      end
+
+      context "when no job application selected" do
+        let(:job_applications) { [] }
+
+        it { is_expected.to redirect_to(organisation_job_job_applications_path(vacancy.id, anchor: origin)) }
+      end
+    end
+
+    context "when copying emails" do
+      let(:target) { "emails" }
+
+      it "sends json files with emails" do
+        expect(response).to have_http_status(:ok)
+        expect(response.content_type).to eq("application/json")
+        expect(response.headers["Content-Disposition"]).to include("applications_emails_#{vacancy.job_title}.json")
+      end
+
+      context "when no job application selected" do
+        let(:job_applications) { [] }
+
+        it { is_expected.to redirect_to(organisation_job_job_applications_path(vacancy.id, anchor: origin)) }
+      end
+    end
+
+    context "when declining job offer" do
+      let(:target) { "declined" }
+
+      it { is_expected.to render_template(:declined_date) }
+    end
+  end
+
+  describe "POST #update_tag" do
+    subject { response }
+
+    let(:params) do
+      {
+        publishers_job_application_tag_form: { origin:, status:, job_applications: },
+      }
+    end
+    let(:vacancy) { create(:vacancy, job_title: "teacher-job") }
+    let(:job_application_2) { create(:job_application, :status_submitted, vacancy: vacancy) }
+    let(:job_applications) { [job_application.id, job_application_2.id] }
+    let(:origin) { "new" }
+    let(:status) { nil }
+    let(:request) do
+      post(update_tag_organisation_job_job_applications_path(vacancy.id), params:)
+    end
+
+    before { request }
+
+    context "when no status selected" do
+      it { is_expected.to render_template(:tag) }
+    end
+
+    context "when progressing to interviewing" do
+      let(:request) { nil }
+      let(:status) { "interviewing" }
+      let(:batch) { JobApplicationBatch.last }
+
+      it "creates a batch and redirect" do
+        expect { post(update_tag_organisation_job_job_applications_path(vacancy.id), params:) }
+          .to change(JobApplicationBatch, :count).by(1)
+
+        expect(response).to redirect_to organisation_job_job_application_batch_references_and_declaration_path(vacancy.id, batch.id, Wicked::FIRST_STEP)
+      end
+    end
+
+    context "when progressing to offered" do
+      let(:status) { "offered" }
+
+      it { is_expected.to render_template(:offered_date) }
+    end
+
+    context "when progressing to other status" do
+      let(:request) { nil }
+      let(:status) { "shortlisted" }
+
+      it "update status and redirects" do
+        expect { post(update_tag_organisation_job_job_applications_path(vacancy.id), params:) }
+          .to change { job_application.reload.status }.from("submitted").to(status)
+
+        expect(response).to redirect_to organisation_job_job_applications_path(vacancy.id, anchor: origin)
+      end
+    end
+  end
+
+  describe "PATCH #update_all" do
+    subject { response }
+
+    let(:params) do
+      { publishers_job_application_offer_decline_date_form: form_params }
+    end
+    let(:vacancy) { create(:vacancy, job_title: "teacher-job") }
+    let(:job_application_2) { create(:job_application, :status_submitted, vacancy: vacancy) }
+    let(:job_applications) { [job_application.id, job_application_2.id] }
+    let(:origin) { "new" }
+    let(:status) { nil }
+    let(:form_params) do
+      { origin:, status:, job_applications: }
+    end
+
+    %w[offered declined].each do |new_status|
+      context "when #{new_status}_at invalid" do
+        let(:status) { new_status }
+        let(:field) { :"#{new_status}_at" }
+
+        context "when job applications ommitted" do
+          let(:job_applications) { nil }
+
+          before do
+            patch(update_all_organisation_job_job_applications_path(vacancy.id), params:)
+          end
+
+          it { is_expected.to render_template("#{new_status}_date") }
+        end
+
+        context "when date ommitted" do
+          it "update job application" do
+            expect { patch(update_all_organisation_job_job_applications_path(vacancy.id), params:) }
+              .to change { job_application.reload.status }.from("submitted").to(status)
+            expect(response).to redirect_to organisation_job_job_applications_path(vacancy.id, anchor: origin)
+          end
+
+          it "does not update date" do
+            expect { patch(update_all_organisation_job_job_applications_path(vacancy.id), params:) }
+              .to not_change { job_application.reload.public_send(field) }.from(nil)
+          end
+        end
+
+        context "when date is invalid" do
+          let(:form_params) do
+            { origin:, status:, job_applications: }.merge("#{new_status}_at(1i)" => 111)
+          end
+
+          before do
+            patch(update_all_organisation_job_job_applications_path(vacancy.id), params:)
+          end
+
+          it { is_expected.to render_template("#{new_status}_date") }
+        end
+
+        context "when date is valid" do
+          let(:form_params) do
+            { origin:, status:, job_applications: }.merge(
+              "#{new_status}_at(1i)" => 2025,
+              "#{new_status}_at(2i)" => 12,
+              "#{new_status}_at(3i)" => 11,
+            )
+          end
+
+          it "update job application" do
+            expect { patch(update_all_organisation_job_job_applications_path(vacancy.id), params:) }
+              .to change { job_application.reload.status }.from("submitted").to(status)
+            expect(response).to redirect_to organisation_job_job_applications_path(vacancy.id, anchor: origin)
+          end
+
+          it "update date" do
+            expect { patch(update_all_organisation_job_job_applications_path(vacancy.id), params:) }
+              .to change { job_application.reload.public_send(field) }.from(nil).to(Date.new(2025, 12, 11))
+          end
+        end
       end
     end
   end

--- a/spec/support/matchers/validate_date_or_hash_of.rb
+++ b/spec/support/matchers/validate_date_or_hash_of.rb
@@ -28,11 +28,11 @@ RSpec::Matchers.define :validate_date_or_hash_of do |attribute|
     test_cases_results.all?
   end
 
-  failure_message do
+  failure_message do |record|
     "expected #{record.class} to validate date of #{attribute}"
   end
 
-  failure_message_when_negated do
+  failure_message_when_negated do |record|
     "expected #{record.class} not to validate date of #{attribute}"
   end
 

--- a/spec/system/publishers/publishers_can_manage_job_applications_for_a_vacancy_spec.rb
+++ b/spec/system/publishers/publishers_can_manage_job_applications_for_a_vacancy_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Publishers can manage job applications for a vacancy" do
 
     scenario "Changing multiple statuses at once" do
       # Wait for page to fully load
-      find_by_id("tab_all")
+      find_by_id("tab_submitted")
 
       within(".application-reviewed") do
         expect(page).to have_css(".govuk-checkboxes__item", wait: 5)
@@ -67,6 +67,7 @@ RSpec.describe "Publishers can manage job applications for a vacancy" do
 
     scenario "Changing a single status" do
       expect(page).to have_button(I18n.t("publishers.vacancies.job_applications.candidates.update_application_status"), wait: 10)
+      find_by_id("tab_not_considering", wait: 5).click
       within(".application-unsuccessful") do
         find(".govuk-checkboxes__input", visible: false).set(true)
       end

--- a/spec/system/publishers/publishers_can_manage_job_applications_for_a_vacancy_spec.rb
+++ b/spec/system/publishers/publishers_can_manage_job_applications_for_a_vacancy_spec.rb
@@ -62,12 +62,12 @@ RSpec.describe "Publishers can manage job applications for a vacancy" do
       expect(page).to have_css(".govuk-tag--red", wait: 10)
       find(".govuk-tag--red").click
       click_on I18n.t("buttons.save_and_continue")
-      expect(page).to have_content("Not Considering (3)")
+      expect(page).to have_content("Not considering (3)")
     end
 
     scenario "Changing a single status" do
       expect(page).to have_button(I18n.t("publishers.vacancies.job_applications.candidates.update_application_status"), wait: 10)
-      find_by_id("tab_not_considering", wait: 5).click
+      find_by_id("tab_unsuccessful", wait: 5).click
       within(".application-unsuccessful") do
         find(".govuk-checkboxes__input", visible: false).set(true)
       end
@@ -77,7 +77,7 @@ RSpec.describe "Publishers can manage job applications for a vacancy" do
       choose("Reviewed ")
       # wait for complete render
       within "#main-content" do
-        find ".govuk-button"
+        find "h1"
       end
       click_on "Save and continue"
       expect(page).to have_content("New (3)")

--- a/spec/views/publishers/vacancies/job_applications/index.html.slim_spec.rb
+++ b/spec/views/publishers/vacancies/job_applications/index.html.slim_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe "publishers/vacancies/job_applications/index" do
       end
 
       it "shows that there are no applicants" do
-        expect(rendered).to have_css(".empty-section-component h3", text: I18n.t("publishers.vacancies.job_applications.index.no_applicants"))
+        expect(rendered).to have_css(".empty-section-component h3", text: I18n.t("publishers.vacancies.job_applications.index.no_new"))
       end
     end
   end

--- a/spec/views/publishers/vacancies/job_applications/index.html.slim_spec.rb
+++ b/spec/views/publishers/vacancies/job_applications/index.html.slim_spec.rb
@@ -1,12 +1,12 @@
 require "rails_helper"
 
 RSpec.describe "publishers/vacancies/job_applications/index" do
-  let(:organisation) { build_stubbed(:school) }
-  let(:publisher) { build_stubbed(:publisher, organisations: [organisation]) }
+  let(:organisation) { create(:school) }
+  let(:publisher) { create(:publisher, organisations: [organisation]) }
 
   let(:vacancy) do
-    build_stubbed(:vacancy, :published, publisher: publisher, organisations: [organisation],
-                                        job_applications: [build_stubbed(:job_application, :submitted)])
+    create(:vacancy, :published, publisher: publisher, organisations: [organisation],
+                                 job_applications: [create(:job_application, :submitted)])
   end
   let(:job_application) { vacancy.job_applications.first }
 
@@ -29,23 +29,27 @@ RSpec.describe "publishers/vacancies/job_applications/index" do
 
   context "when a vacancy has expired and it has applications" do
     let(:vacancy) do
-      build_stubbed(:vacancy, :expired, expires_at: 2.weeks.ago, organisations: [organisation],
-                                        job_applications: [
-                                          job_application_submitted,
-                                          job_application_reviewed,
-                                          job_application_shortlisted,
-                                          job_application_unsuccessful,
-                                          job_application_withdrawn,
-                                          job_application_interviewing,
-                                        ])
+      create(:vacancy, :expired,
+             expires_at: 2.weeks.ago,
+             organisations: [organisation],
+             job_applications: [
+               job_application_submitted,
+               job_application_reviewed,
+               job_application_shortlisted,
+               job_application_unsuccessful,
+               job_application_withdrawn,
+               job_application_interviewing,
+             ])
     end
 
-    let(:job_application_submitted) { build_stubbed(:job_application, :status_submitted, last_name: "Alan") }
-    let(:job_application_reviewed) { build_stubbed(:job_application, :status_reviewed, last_name: "Charlie") }
-    let(:job_application_shortlisted) { build_stubbed(:job_application, :status_shortlisted, last_name: "Billy") }
-    let(:job_application_unsuccessful) { build_stubbed(:job_application, :status_unsuccessful, last_name: "Dave") }
-    let(:job_application_withdrawn) {  build_stubbed(:job_application, :status_withdrawn, last_name: "Ethan") }
-    let(:job_application_interviewing) { build_stubbed(:job_application, :status_interviewing, last_name: "Freddy") }
+    let(:job_application_submitted) { create(:job_application, :status_submitted, last_name: "Alan") }
+    let(:job_application_reviewed) { create(:job_application, :status_reviewed, last_name: "Charlie") }
+    let(:job_application_shortlisted) { create(:job_application, :status_shortlisted, last_name: "Billy") }
+    let(:job_application_unsuccessful) { create(:job_application, :status_unsuccessful, last_name: "Dave") }
+    let(:job_application_withdrawn) {  create(:job_application, :status_withdrawn, last_name: "Ethan") }
+    let(:job_application_interviewing) { create(:job_application, :status_interviewing, last_name: "Freddy") }
+    let(:job_application_offered) { create(:job_application, :status_offered, last_name: "Etha") }
+    let(:job_application_declined) { create(:job_application, :status_declined, last_name: "Monique") }
 
     describe "the summary section" do
       it "shows breadcrumb with link to passed deadline in dashboard" do
@@ -131,10 +135,42 @@ RSpec.describe "publishers/vacancies/job_applications/index" do
         end
       end
     end
+
+    describe "offered application" do
+      let(:status) { "offered" }
+
+      it "shows applicant name that links to application" do
+        within(".application-#{status}") do
+          expect(rendered).to have_link("#{job_application_offered.first_name} #{job_application_offered.last_name}", href: organisation_job_job_application_path(vacancy.id, job_application_offered.id))
+        end
+      end
+
+      it "shows purple offered tag" do
+        within(".application-#{status}") do
+          expect(rendered).to have_css(".govuk-tag--purple", text: "job offered")
+        end
+      end
+    end
+
+    describe "declined application" do
+      let(:status) { "declined" }
+
+      it "shows applicant name that links to application" do
+        within(".application-#{status}") do
+          expect(rendered).to have_link("#{job_application_declined.first_name} #{job_application_declined.last_name}", href: organisation_job_job_application_path(vacancy.id, job_application_declined.id))
+        end
+      end
+
+      it "shows purple declined tag" do
+        within(".application-#{status}") do
+          expect(rendered).to have_css(".govuk-tag--purple", text: "job declined")
+        end
+      end
+    end
   end
 
   context "when a vacancy is active and it has no applications" do
-    let(:vacancy) { build_stubbed(:vacancy, :published, expires_at: 1.month.from_now, organisations: [organisation], job_applications: []) }
+    let(:vacancy) { create(:vacancy, :published, expires_at: 1.month.from_now, organisations: [organisation], job_applications: []) }
 
     describe "the summary section" do
       it "shows breadcrumb with link to active jobs in dashboard" do
@@ -150,13 +186,13 @@ RSpec.describe "publishers/vacancies/job_applications/index" do
       end
 
       it "shows that there are no applicants" do
-        expect(rendered).to have_css(".empty-section-component h3", text: I18n.t("publishers.vacancies.job_applications.index.no_new"))
+        expect(rendered).to have_css(".empty-section-component h3", text: I18n.t("publishers.vacancies.job_applications.index.tab.submitted.none"))
       end
     end
   end
 
   context "when a vacancy has expired more than 1 year ago and it has applications" do
-    let(:vacancy) { build_stubbed(:vacancy, :expired, expires_at: 1.year.ago, organisations: [organisation], job_applications: build_stubbed_list(:job_application, 1, :status_submitted)) }
+    let(:vacancy) { create(:vacancy, :expired, expires_at: 1.year.ago, organisations: [organisation], job_applications: create_list(:job_application, 1, :status_submitted)) }
 
     describe "the summary section" do
       it "shows no application cards" do

--- a/spec/views/publishers/vacancies/job_applications/tag.html.slim_spec.rb
+++ b/spec/views/publishers/vacancies/job_applications/tag.html.slim_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe "publishers/vacancies/job_applications/tag" do
+  let(:vacancy) do
+    create(:vacancy, :published, job_applications: [create(:job_application, :submitted)])
+  end
+  let(:form) { Publishers::JobApplication::TagForm.new(job_applications:, status:, origin:) }
+  let(:job_applications) { vacancy.job_applications }
+  let(:status) { "shortlisted" }
+  let(:origin) { "submitted" }
+
+  before do
+    assign :form, form
+    without_partial_double_verification do
+      allow(view).to receive(:vacancy).and_return(vacancy)
+    end
+    render
+  end
+
+  describe "form options" do
+    context "when origin is new tab" do
+      let(:origin) { "submitted" }
+
+      %i[reviewed unsuccessful shortlisted interviewing offered].each do |status|
+        it "shows a radio button for status '#{status}'" do
+          expect(rendered).to have_css("#publishers-job-application-tag-form-status-#{status}-field")
+        end
+      end
+    end
+
+    context "when origin is shortlisted tab" do
+      let(:origin) { "shortlisted" }
+
+      %i[unsuccessful interviewing offered].each do |status|
+        it "shows a radio button for status '#{status}'" do
+          expect(rendered).to have_css("#publishers-job-application-tag-form-status-#{status}-field")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Trello card URL
[1866](https://trello.com/c/ViQIH92Z)

## Changes in this PR:

Add Job offered tab to publisher job application page


## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>