### PR TITLE
Send emails for drafts to jobseeker account email

### DIFF
--- a/app/mailers/jobseekers/job_application_mailer.rb
+++ b/app/mailers/jobseekers/job_application_mailer.rb
@@ -9,8 +9,9 @@ class Jobseekers::JobApplicationMailer < Jobseekers::BaseMailer
 
   def job_listing_ended_early(job_application, vacancy)
     @job_application = job_application
+    @jobseeker = job_application.jobseeker
     @vacancy = vacancy
 
-    send_email(to: job_application.email_address, subject: t(".subject", job_title: @vacancy.job_title, organisation_name: @vacancy.organisation_name))
+    send_email(to: @jobseeker.email, subject: t(".subject", job_title: @vacancy.job_title, organisation_name: @vacancy.organisation_name))
   end
 end

--- a/app/mailers/jobseekers/vacancy_mailer.rb
+++ b/app/mailers/jobseekers/vacancy_mailer.rb
@@ -1,9 +1,10 @@
 class Jobseekers::VacancyMailer < Jobseekers::BaseMailer
   def draft_application_only(job_application)
     @job_application = job_application
+    @jobseeker = job_application.jobseeker
     @vacancy = job_application.vacancy
 
-    send_email(to: job_application.email_address,
+    send_email(to: @jobseeker.email,
                subject: I18n.t("jobseekers.vacancy_mailer.draft_application_only.subject", date: @vacancy.expires_at.to_date, job_title: job_application.vacancy.job_title))
   end
 

--- a/spec/mailers/jobseekers/job_application_mailer_spec.rb
+++ b/spec/mailers/jobseekers/job_application_mailer_spec.rb
@@ -36,12 +36,12 @@ RSpec.describe Jobseekers::JobApplicationMailer do
   end
 
   describe "#job_listing_ended_early" do
-    let(:job_application) { create(:job_application, :status_draft, jobseeker: jobseeker, vacancy: vacancy) }
+    let(:job_application) { create(:job_application, :status_draft, jobseeker: jobseeker, vacancy: vacancy, email_address: "other.email@contoso.com") }
     let(:mail) { described_class.job_listing_ended_early(job_application, vacancy) }
 
-    it "sends a `jobseeker_job_listing_ended_early` email" do
+    it "sends a `jobseeker_job_listing_ended_early` email to the jobseeker account's email address" do
       expect(mail.subject).to eq("Update on #{vacancy.job_title} at #{vacancy.organisation_name}")
-      expect(mail.to).to eq([job_application.email_address])
+      expect(mail.to).to eq([jobseeker.email])
       expect(mail.body.encoded).to include(I18n.t("jobseekers.job_application_mailer.job_listing_ended_early.heading",
                                                   job_title: vacancy.job_title, organisation_name: vacancy.organisation_name))
       expect(mail.body.encoded).to include(jobseekers_job_application_url(job_application))


### PR DESCRIPTION
Fixes both [this](https://teaching-vacancies.sentry.io/issues/6674552557/?environment=production&project=6212514&query=level%3Aerror&referrer=issue-stream&stream_index=1) and [this](https://teaching-vacancies.sentry.io/issues/6676724725/?environment=production&project=6212514&query=level%3Aerror&referrer=issue-stream&stream_index=0) Sentry errors.


We are getting errors on two mailers:
- The reminder emails about draft job applications. 
- The alerts to jobseekers with existing job application drafts for vacancies closed early by the publisher.


These errors are caused by the Job Application email address being missing on a subset of draft applications.

This happens when someone starts a job application draft, but the personal details sections haven't been imported from a prior application and haven't been filled out by the applicant.

There is a second issue using the personal details step email address: It may differ from the user account's email (EG: Users provide specific email addresses to receive job application communications from the school).

As a service, when communicating: "You may want to finish this draft before the vacancy closing date" or "You cannot longer appply to this vacancy", we are talking to the service user, not to the "applicant".

Switching to send this email to the jobseeker's email address, we achieve:
- Email will always be present, even when the job application hasn't filled the personal details section, avoiding errors/further filtering.
- The emails will be sent to the email associated to the user account, which seems more appropriate in this particular use case.

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
