### PR TITLE
Remove vacancy status

### DIFF
--- a/app/controllers/api/vacancies_controller.rb
+++ b/app/controllers/api/vacancies_controller.rb
@@ -11,14 +11,14 @@ class Api::VacanciesController < Api::ApplicationController
   end
 
   def show
-    vacancy = Vacancy.listed.friendly.find(params[:id])
+    vacancy = PublishedVacancy.listed.friendly.find(params[:id])
     @vacancy = VacancyPresenter.new(vacancy)
   end
 
   private
 
   def vacancies
-    Vacancy.includes(:organisations).live.order(publish_on: :desc)
+    PublishedVacancy.includes(:organisations).live.order(publish_on: :desc)
   end
 
   def trigger_api_queried_event(event_data = {})

--- a/app/controllers/publishers/ats_api/v1/vacancies_controller.rb
+++ b/app/controllers/publishers/ats_api/v1/vacancies_controller.rb
@@ -47,7 +47,7 @@ class Publishers::AtsApi::V1::VacanciesController < Api::ApplicationController
   private
 
   def set_vacancy
-    @vacancy = Vacancy.non_draft.find_by!(publisher_ats_api_client: client, id: params[:id])
+    @vacancy = PublishedVacancy.kept.find_by!(publisher_ats_api_client: client, id: params[:id])
   end
 
   def required_vacancy_keys
@@ -99,9 +99,9 @@ class Publishers::AtsApi::V1::VacanciesController < Api::ApplicationController
   end
 
   def vacancies
-    Vacancy
+    PublishedVacancy
       .includes(:organisations)
-      .non_draft
+      .kept
       .order(publish_on: :desc)
       .where(publisher_ats_api_client: client)
   end

--- a/app/controllers/publishers/vacancies/base_controller.rb
+++ b/app/controllers/publishers/vacancies/base_controller.rb
@@ -26,7 +26,7 @@ class Publishers::Vacancies::BaseController < Publishers::BaseController
 
     # As the vacancy is not associated with an organisation upon creation, calling the vacancies method will return an empty array as an organisation is not associated
     # with it. To fix this, before the vacancy's status is set (and therefore before an organisation is associated), we find the job from the vacancies where status is nil.
-    @vacancy ||= vacancies.internal.find_by(id: params[:job_id].presence || params[:id]) || Vacancy.where(status: nil).find(params[:job_id].presence || params[:id])
+    @vacancy ||= vacancies.internal.find_by(id: params[:job_id].presence || params[:id]) || DraftVacancy.find(params[:job_id].presence || params[:id])
   end
 
   def form_sequence

--- a/app/controllers/publishers/vacancies/feedbacks_controller.rb
+++ b/app/controllers/publishers/vacancies/feedbacks_controller.rb
@@ -1,6 +1,6 @@
 class Publishers::Vacancies::FeedbacksController < Publishers::Vacancies::BaseController
   def create
-    @vacancy = VacancyPresenter.new(Vacancy.non_draft.find(params[:job_id]))
+    @vacancy = VacancyPresenter.new(PublishedVacancy.kept.find(params[:job_id]))
     @feedback_form = Publishers::JobListing::FeedbackForm.new(feedback_form_params)
 
     if @feedback_form.valid?

--- a/app/controllers/publishers/vacancies/publish_controller.rb
+++ b/app/controllers/publishers/vacancies/publish_controller.rb
@@ -3,7 +3,7 @@ class Publishers::Vacancies::PublishController < Publishers::Vacancies::BaseCont
     if vacancy.published?
       redirect_to organisation_job_path(vacancy.id), notice: t("messages.jobs.already_published")
     elsif all_steps_valid? && PublishVacancy.new(vacancy, current_publisher, current_organisation).call
-      update_google_index(vacancy) if vacancy.listed?
+      update_google_index(vacancy) if Vacancy.find(vacancy.id).listed?
       redirect_to organisation_job_summary_path(vacancy.id)
     else
       redirect_to organisation_job_path(vacancy.id)

--- a/app/controllers/publishers/vacancies/relist_controller.rb
+++ b/app/controllers/publishers/vacancies/relist_controller.rb
@@ -11,7 +11,7 @@ class Publishers::Vacancies::RelistController < Publishers::Vacancies::BaseContr
   def update
     @form = Publishers::JobListing::RelistForm.new(relist_params)
     if @form.valid?
-      vacancy.update(@form.attributes_to_save.merge(status: :published))
+      vacancy.update(@form.attributes_to_save.merge(type: "PublishedVacancy"))
       trigger_publisher_vacancy_relisted_event
       update_google_index(vacancy)
       redirect_to organisation_job_summary_path(vacancy.id), success: t(".success", job_title: vacancy.job_title)

--- a/app/controllers/publishers/vacancies_controller.rb
+++ b/app/controllers/publishers/vacancies_controller.rb
@@ -102,7 +102,7 @@ class Publishers::VacanciesController < Publishers::Vacancies::BaseController
   def show_application_feature_reminder_page?
     return false if session[:visited_application_feature_reminder_page] || session[:visited_new_features_page]
 
-    Vacancy.kept.where(
+    PublishedVacancy.kept.where(
       publisher_id: current_publisher.id,
       enable_job_applications: true,
       created_at: Publishers::NewFeaturesController::NEW_FEATURES_PAGE_UPDATED_AT..,

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -19,7 +19,7 @@ class VacanciesController < ApplicationController
       session.delete(:newly_created_user)
     end
 
-    vacancy = Vacancy.listed.friendly.find(params[:id])
+    vacancy = PublishedVacancy.listed.friendly.find(params[:id])
     TrackVacancyViewJob.perform_later(vacancy_id: vacancy.id, referrer_url: request.referer)
     @saved_job = current_jobseeker&.saved_jobs&.find_by(vacancy: vacancy)
     @job_application = current_jobseeker&.job_applications&.find_by(vacancy: vacancy)

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -193,7 +193,7 @@ module VacanciesHelper
     elsif vacancy.published?
       :live
     else
-      vacancy.status.to_sym
+      :draft
     end
   end
 

--- a/app/jobs/index_newly_published_vacancies_job.rb
+++ b/app/jobs/index_newly_published_vacancies_job.rb
@@ -3,7 +3,7 @@ class IndexNewlyPublishedVacanciesJob < ApplicationJob
 
   # This job is to ensure vacancies that were created/updated before their published at date get indexed once they are published.
   def perform
-    Vacancy.non_draft.where(publish_on: Time.zone.today).find_each do |vacancy|
+    PublishedVacancy.kept.where(publish_on: Time.zone.today).find_each do |vacancy|
       UpdateGoogleIndexQueueJob.perform_later(Rails.application.routes.url_helpers.job_url(vacancy))
     end
   end

--- a/app/models/draft_vacancy.rb
+++ b/app/models/draft_vacancy.rb
@@ -4,4 +4,16 @@ class DraftVacancy < Vacancy
   def trash!
     destroy!
   end
+
+  def draft?
+    true
+  end
+
+  def expired?
+    false
+  end
+
+  def published?
+    false
+  end
 end

--- a/app/models/published_vacancy.rb
+++ b/app/models/published_vacancy.rb
@@ -25,6 +25,18 @@ class PublishedVacancy < Vacancy
     remove_google_index
   end
 
+  def draft?
+    false
+  end
+
+  def expired?
+    expires_at.past?
+  end
+
+  def published?
+    true
+  end
+
   private
 
   def remove_google_index

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -112,12 +112,10 @@ class Vacancy < ApplicationRecord
   scope :expired_yesterday, -> { where("DATE(expires_at) = ?", 1.day.ago.to_date) }
   scope :expires_within_data_access_period, -> { where("expires_at >= ?", Time.current - DATA_ACCESS_PERIOD_FOR_PUBLISHERS) }
   scope :in_organisation_ids, ->(ids) { joins(:organisation_vacancies).where(organisation_vacancies: { organisation_id: ids }).distinct }
-  # scope :non_draft, -> { kept.published }
-  scope :listed, -> { kept.where("publish_on <= ?", Date.current) }
+  scope :listed, -> { kept.where.not(publish_on: nil).where("publish_on <= ?", Date.current) }
   scope :live, -> { listed.applicable }
-  scope :pending, -> { kept.where("publish_on > ?", Date.current) }
+  scope :pending, -> { kept.where.not(publish_on: nil).where("publish_on > ?", Date.current) }
   scope :quick_apply, -> { where(enable_job_applications: true) }
-  scope :published_on_count, ->(date) { kept.where(publish_on: date.all_day).count }
   scope :visa_sponsorship_available, -> { where(visa_sponsorship_available: true) }
 
   scope :internal, -> { where(external_source: nil, publisher_ats_api_client_id: nil) }

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -63,10 +63,7 @@ class Vacancy < ApplicationRecord
   enum :hired_status, { hired_tvs: 0, hired_other_free: 1, hired_paid: 2, hired_no_listing: 3, not_filled_ongoing: 4, not_filled_not_looking: 5, hired_dont_know: 6 }
   enum :listed_elsewhere, { listed_paid: 0, listed_free: 1, listed_mix: 2, not_listed: 3, listed_dont_know: 4 }
   enum :start_date_type, { specific_date: 0, date_range: 1, other: 2, undefined: 3, asap: 4 }
-  # trashed: 2 and removed_from_external_system: 3 removed in discard_soft_deletes 29/4/25
-  enum :status, { published: 0, draft: 1 }
 
-  validates :status, presence: true
   enum :receive_applications, { email: 0, website: 1, uploaded_form: 2 }
   enum :extension_reason, { no_applications: 0, didnt_find_right_candidate: 1, other_extension_reason: 2 }
 
@@ -111,16 +108,16 @@ class Vacancy < ApplicationRecord
 
   scope :applicable, -> { where("expires_at >= ?", Time.current) }
   scope :awaiting_feedback_recently_expired, -> { where(listed_elsewhere: nil, hired_status: nil).where("expires_at >= ?", 2.months.ago) }
-  scope :expired, -> { published.where("expires_at < ?", Time.current) }
+  scope :expired, -> { kept.where("expires_at < ?", Time.current) }
   scope :expired_yesterday, -> { where("DATE(expires_at) = ?", 1.day.ago.to_date) }
   scope :expires_within_data_access_period, -> { where("expires_at >= ?", Time.current - DATA_ACCESS_PERIOD_FOR_PUBLISHERS) }
   scope :in_organisation_ids, ->(ids) { joins(:organisation_vacancies).where(organisation_vacancies: { organisation_id: ids }).distinct }
-  scope :non_draft, -> { kept.published }
-  scope :listed, -> { non_draft.where("publish_on <= ?", Date.current) }
+  # scope :non_draft, -> { kept.published }
+  scope :listed, -> { kept.where("publish_on <= ?", Date.current) }
   scope :live, -> { listed.applicable }
-  scope :pending, -> { non_draft.where("publish_on > ?", Date.current) }
+  scope :pending, -> { kept.where("publish_on > ?", Date.current) }
   scope :quick_apply, -> { where(enable_job_applications: true) }
-  scope :published_on_count, ->(date) { non_draft.where(publish_on: date.all_day).count }
+  scope :published_on_count, ->(date) { kept.where(publish_on: date.all_day).count }
   scope :visa_sponsorship_available, -> { where(visa_sponsorship_available: true) }
 
   scope :internal, -> { where(external_source: nil, publisher_ats_api_client_id: nil) }
@@ -157,22 +154,13 @@ class Vacancy < ApplicationRecord
                   if: proc(&:listed?)
 
   # Publisher will need to set a new publish date if wanting to re-publish an scheduled vacancy turned back to a draft.
-  before_save -> { self.publish_on = nil if status_changed?(from: "published", to: "draft") }
+  before_save -> { self.publish_on = nil if type_changed?(from: "PublishedVacancy", to: "DraftVacancy") }
 
-  # temporary - keep 'type' column in sync with status, but only use Vacancy class in code
-  before_save do |vacancy|
-    if vacancy.status_changed?
-      vacancy.type = if vacancy.draft?
-                       "DraftVacancy"
-                     else
-                       "PublishedVacancy"
-                     end
-    end
-  end
+  self.ignored_columns += [:status]
 
   self.ignored_columns += %i[personal_statement_guidance how_to_apply school_visits_details]
 
-  after_save :reset_markers, if: -> { saved_change_to_status? && (listed? || pending?) }
+  after_save :reset_markers, if: -> { saved_change_to_type? && (listed? || pending?) }
 
   EQUAL_OPPORTUNITIES_PUBLICATION_THRESHOLD = 5
   EXPIRY_TIME_OPTIONS = %w[8:00 9:00 12:00 15:00 23:59].freeze
@@ -221,10 +209,6 @@ class Vacancy < ApplicationRecord
 
   def pending?
     published? && publish_on&.future?
-  end
-
-  def expired?
-    published? && expires_at&.past?
   end
 
   def can_receive_job_applications?

--- a/app/services/copy_vacancy_asa_template.rb
+++ b/app/services/copy_vacancy_asa_template.rb
@@ -4,7 +4,7 @@ class CopyVacancyAsaTemplate
   class << self
     def call(vacancy)
       new_vacancy = vacancy.dup
-      new_vacancy.status = :draft
+      new_vacancy.type = "DraftVacancy"
       new_vacancy.application_form.attach(vacancy.application_form.blob) if vacancy.application_form.attachments&.any?
 
       if vacancy.supporting_documents.attachments.any?

--- a/app/services/publish_vacancy.rb
+++ b/app/services/publish_vacancy.rb
@@ -10,7 +10,7 @@ class PublishVacancy
   def call
     vacancy.publisher_organisation = current_organisation
     vacancy.publisher = current_publisher
-    vacancy.status = :published
+    vacancy.type = "PublishedVacancy"
     vacancy.save
   end
 end

--- a/app/services/publishers/ats_api/create_vacancy_service.rb
+++ b/app/services/publishers/ats_api/create_vacancy_service.rb
@@ -28,7 +28,6 @@ module Publishers
           params[:ect_status] = params[:ect_suitable].in?([true, "true"]) ? "ect_suitable" : "ect_unsuitable"
           params.except(:schools, :ect_suitable)
                 .merge(organisations: organisations)
-                .merge(status: "published")
                 .merge(start_date_fields(params[:starts_on]))
         end
 

--- a/app/services/search/vacancy_search.rb
+++ b/app/services/search/vacancy_search.rb
@@ -4,8 +4,8 @@ class Search::VacancySearch
 
   attr_reader :search_criteria, :keyword, :location, :radius, :organisation_slug, :sort, :original_scope
 
-  def initialize(search_criteria, sort: nil, scope: Vacancy.live)
-    @search_criteria = search_criteria
+  def initialize(search_criteria, sort: nil, scope: PublishedVacancy.live)
+    @search_criteria = search_criteria.except(:keyword)
     @keyword = search_criteria[:keyword]
     @location = search_criteria[:location]
     @radius = search_criteria[:radius]
@@ -16,7 +16,7 @@ class Search::VacancySearch
   end
 
   def active_criteria
-    search_criteria
+    search_criteria.merge(keyword: @keyword)
       .reject { |k, v| v.blank? || (k == :radius && search_criteria[:location].blank?) }
   end
 

--- a/app/services/vacancies/import/sources/broadbean.rb
+++ b/app/services/vacancies/import/sources/broadbean.rb
@@ -28,13 +28,12 @@ class Vacancies::Import::Sources::Broadbean
       next if schools.blank?
       next if vacancy_listed_at_excluded_school_type?(schools)
 
+      # An external vacancy is by definition always published
       v = PublishedVacancy.find_or_initialize_by(
         external_source: SOURCE_NAME,
         external_reference: item["reference"],
       )
 
-      # An external vacancy is by definition always published
-      v.status = :published
       # Consider publish_on date to be the first time we saw this vacancy come through
       # (i.e. today, unless it already has a publish on date set)
       v.publish_on ||= Date.today

--- a/app/services/vacancies/import/sources/every.rb
+++ b/app/services/vacancies/import/sources/every.rb
@@ -19,13 +19,12 @@ class Vacancies::Import::Sources::Every
       next if schools.blank?
       next if vacancy_listed_at_excluded_school_type?(schools)
 
+      # An external vacancy is by definition always published
       v = PublishedVacancy.find_or_initialize_by(
         external_source: SOURCE_NAME,
         external_reference: result["reference"],
       )
 
-      # An external vacancy is by definition always published
-      v.status = :published
       # Consider publish_on date to be the first time we saw this vacancy come through
       # (i.e. today, unless it already has a publish on date set)
       v.publish_on ||= Date.today

--- a/app/services/vacancies/import/sources/fusion.rb
+++ b/app/services/vacancies/import/sources/fusion.rb
@@ -20,13 +20,12 @@ class Vacancies::Import::Sources::Fusion
       next if vacancy_listed_at_excluded_trust_type?(schools, result["trustUID"])
       next if vacancy_listed_at_excluded_school_type?(schools)
 
+      # An external vacancy is by definition always published
       v = PublishedVacancy.find_or_initialize_by(
         external_source: SOURCE_NAME,
         external_reference: result["reference"],
       )
 
-      # An external vacancy is by definition always published
-      v.status = :published
       # Consider publish_on date to be the first time we saw this vacancy come through
       # (i.e. today, unless it already has a publish on date set)
       v.publish_on ||= Date.today

--- a/app/services/vacancies/import/sources/my_new_term.rb
+++ b/app/services/vacancies/import/sources/my_new_term.rb
@@ -26,13 +26,12 @@ class Vacancies::Import::Sources::MyNewTerm
       next if vacancy_listed_at_excluded_trust_type?(schools, result["trustUID"])
       next if vacancy_listed_at_excluded_school_type?(schools)
 
+      # An external vacancy is by definition always published
       v = PublishedVacancy.find_or_initialize_by(
         external_source: SOURCE_NAME,
         external_reference: result["reference"],
       )
 
-      # An external vacancy is by definition always published
-      v.status = :published
       # Consider publish_on date to be the first time we saw this vacancy come through
       # (i.e. today, unless it already has a publish on date set)
       v.publish_on ||= Date.today

--- a/app/services/vacancies/import/sources/vacancy_poster.rb
+++ b/app/services/vacancies/import/sources/vacancy_poster.rb
@@ -27,13 +27,12 @@ class Vacancies::Import::Sources::VacancyPoster
       schools = find_schools(item)
       next if invalid_school?(schools, item["trustUID"])
 
+      # An external vacancy is by definition always published
       v = PublishedVacancy.find_or_initialize_by(
         external_source: SOURCE_NAME,
         external_reference: item["reference"]&.strip,
       )
 
-      # An external vacancy is by definition always published
-      v.status = :published
       # Consider publish_on date to be the first time we saw this vacancy come through
       # (i.e. today, unless it already has a publish on date set)
       v.publish_on ||= Date.today

--- a/app/services/vacancies/import/sources/ventrus.rb
+++ b/app/services/vacancies/import/sources/ventrus.rb
@@ -27,13 +27,12 @@ class Vacancies::Import::Sources::Ventrus
       next if schools.blank?
       next if vacancy_listed_at_excluded_school_type?(schools)
 
+      # An external vacancy is by definition always published
       v = PublishedVacancy.find_or_initialize_by(
         external_source: SOURCE_NAME,
         external_reference: item["VacancyID"],
       )
 
-      # An external vacancy is by definition always published
-      v.status = :published
       # Consider publish_on date to be the first time we saw this vacancy come through
       # (i.e. today, unless it already has a publish on date set)
       v.publish_on ||= Date.today

--- a/app/views/publishers/vacancies/vacancy_form_partials/_submit.html.slim
+++ b/app/views/publishers/vacancies/vacancy_form_partials/_submit.html.slim
@@ -5,7 +5,7 @@
     = f.govuk_submit t("buttons.continue"), class: "govuk-!-margin-bottom-5"
   - else
     = f.govuk_submit t("buttons.save_and_continue"), class: "govuk-!-margin-bottom-5", "data-upload-documents-target": "saveListingButton"
-  - if vacancy.draft? || (current_step == :job_title && vacancy.status.nil?)
+  - if vacancy.draft?
     = f.govuk_submit t("buttons.save_and_finish_later"), name: "save_and_finish_later", value: "true", secondary: true, class: "govuk-!-margin-bottom-5", "data-upload-documents-target": "saveListingButton"
 
 = govuk_link_to(t("buttons.cancel"), organisation_jobs_with_type_path(:draft), class: "govuk-link--no-visited-state govuk-body-m")

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -372,7 +372,6 @@ shared:
     - latest_start_date
     - other_start_date_details
     - contact_email
-    - status
     - publish_on
     - created_at
     - updated_at

--- a/db/migrate/20250609153726_re_allow_null_vacancy_status.rb
+++ b/db/migrate/20250609153726_re_allow_null_vacancy_status.rb
@@ -1,0 +1,6 @@
+class ReAllowNullVacancyStatus < ActiveRecord::Migration[7.2]
+  def change
+    # need to re-allow null in status column as it is now ignored
+    change_column_null :vacancies, :status, true
+  end
+end

--- a/db/migrate/20250609154252_remove_vacancy_status_indexes.rb
+++ b/db/migrate/20250609154252_remove_vacancy_status_indexes.rb
@@ -1,0 +1,7 @@
+class RemoveVacancyStatusIndexes < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    remove_index :vacancies, :status, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_06_06_150046) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_09_154252) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -644,7 +644,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_06_150046) do
     t.text "benefits_details"
     t.date "starts_on"
     t.string "contact_email"
-    t.integer "status", null: false
+    t.integer "status"
     t.date "publish_on"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
@@ -727,7 +727,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_06_150046) do
     t.index ["publisher_organisation_id"], name: "index_vacancies_on_publisher_organisation_id"
     t.index ["searchable_content"], name: "index_vacancies_on_searchable_content", using: :gin
     t.index ["slug"], name: "index_vacancies_on_slug"
-    t.index ["status"], name: "index_vacancies_on_status"
   end
 
   create_table "vacancy_analytics", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -6,7 +6,7 @@ namespace :db do
 
   desc "Reset markers"
   task reset_markers: :environment do
-    Vacancy.non_draft.applicable.find_each(&:reset_markers)
+    PublishedVacancy.applicable.find_each(&:reset_markers)
   end
 
   desc "Generates 1000 random vacancies for testing purposes"

--- a/spec/components/dashboard_component_spec.rb
+++ b/spec/components/dashboard_component_spec.rb
@@ -246,7 +246,7 @@ RSpec.describe DashboardComponent, type: :component do
     let(:organisation) { create(:school) }
     let(:vacancies) { [vacancy] }
     let(:vacancy) do
-      create(:vacancy, :published, organisations: [organisation])
+      create(:vacancy, organisations: [organisation])
     end
 
     before do

--- a/spec/components/dashboard_component_spec.rb
+++ b/spec/components/dashboard_component_spec.rb
@@ -34,9 +34,9 @@ RSpec.describe DashboardComponent, type: :component do
         let!(:inline_component) { render_inline(subject) }
 
         let(:vacancies) do
-          create_list(:vacancy, 1, :published, job_title: job_title,
-                                               job_applications: build_list(:job_application, 1, :status_submitted),
-                                               organisations: [organisation])
+          create_list(:vacancy, 1, job_title: job_title,
+                                   job_applications: build_list(:job_application, 1, :status_submitted),
+                                   organisations: [organisation])
           organisation.vacancies
         end
 
@@ -89,9 +89,9 @@ RSpec.describe DashboardComponent, type: :component do
         let(:open_school) { create(:school, name: "Open school") }
         let(:closed_school) { create(:school, :closed, name: "Closed school") }
         let(:vacancies) do
-          create_list(:vacancy, 1, :published, job_title: job_title,
-                                               job_applications: build_list(:job_application, 1, :status_submitted),
-                                               organisations: [organisation])
+          create_list(:vacancy, 1, job_title: job_title,
+                                   job_applications: build_list(:job_application, 1, :status_submitted),
+                                   organisations: [organisation])
           organisation.vacancies
         end
 
@@ -141,9 +141,9 @@ RSpec.describe DashboardComponent, type: :component do
         let(:closed_school) { create(:school, :closed, name: "Closed school") }
         let(:publisher_preference) { create(:publisher_preference, publisher: publisher, organisation: organisation, schools: [open_school]) }
         let(:vacancies) do
-          create_list(:vacancy, 1, :published, job_title: job_title,
-                                               job_applications: build_list(:job_application, 1, :status_submitted),
-                                               organisations: [open_school])
+          create_list(:vacancy, 1, job_title: job_title,
+                                   job_applications: build_list(:job_application, 1, :status_submitted),
+                                   organisations: [open_school])
           open_school.vacancies
         end
 
@@ -198,7 +198,7 @@ RSpec.describe DashboardComponent, type: :component do
 
     context "when job applications have not been received" do
       let(:organisation) { create(:school, name: "A school with jobs") }
-      let(:vacancies) { create_list(:vacancy, 1, :published, organisations: [organisation]) }
+      let(:vacancies) { create_list(:vacancy, 1, organisations: [organisation]) }
 
       before { render_inline(subject) }
 
@@ -213,13 +213,13 @@ RSpec.describe DashboardComponent, type: :component do
     let(:organisation) { create(:trust, schools: [school_oxford, school_cambridge]) }
     let(:school_oxford) { create(:school, name: "Oxford") }
     let(:school_cambridge) { create(:school, name: "Cambridge") }
-    let(:vacancy_cambridge) { create(:vacancy, :published, organisations: [school_cambridge], job_title: "Scientist") }
+    let(:vacancy_cambridge) { create(:vacancy, organisations: [school_cambridge], job_title: "Scientist") }
 
     before { publisher_preference.update organisations: [school_oxford] }
 
     context "when a relevant job exists" do
       let(:vacancies) { school_oxford.vacancies }
-      let!(:vacancy_oxford) { create(:vacancy, :published, organisations: [school_oxford], job_title: "Mathematician") }
+      let!(:vacancy_oxford) { create(:vacancy, organisations: [school_oxford], job_title: "Mathematician") }
 
       let!(:inline_component) { render_inline(subject) }
 

--- a/spec/components/vacancy_form_page_heading_component_spec.rb
+++ b/spec/components/vacancy_form_page_heading_component_spec.rb
@@ -2,8 +2,6 @@ require "rails_helper"
 
 RSpec.describe VacancyFormPageHeadingComponent, type: :component do
   let(:organisation) { create(:school, name: "Teaching Vacancies Academy") }
-  let(:vacancy) { create(:vacancy, status, organisations: [organisation], job_title: "Test job title", completed_steps: %w[job_location job_role review]) }
-  let(:status) { :published }
   let(:current_publisher_is_part_of_school_group?) { true }
   let(:previous_step) { :review }
   let(:back_path) { "/" }
@@ -30,7 +28,7 @@ RSpec.describe VacancyFormPageHeadingComponent, type: :component do
 
   describe "caption" do
     context "when vacancy is not published" do
-      let(:status) { :draft }
+      let(:vacancy) { build_stubbed(:draft_vacancy, organisations: [organisation], job_title: "Test job title", completed_steps: %w[job_location job_role review]) }
 
       it "shows the create caption with current step" do
         expect(page).to have_content(I18n.t("jobs.create_job_caption", step: 1, total: 2))
@@ -38,15 +36,17 @@ RSpec.describe VacancyFormPageHeadingComponent, type: :component do
     end
 
     context "when vacancy is published" do
+      let(:vacancy) { create(:vacancy, organisations: [organisation], job_title: "Test job title", completed_steps: %w[job_location job_role review]) }
+
       it "shows the edit caption with current step" do
         expect(page).to have_content(I18n.t("jobs.edit_job_caption", step: 1, total: 2))
       end
-    end
-  end
 
-  describe "#heading" do
-    it "returns edit job title" do
-      expect(page).to have_content(I18n.t("publishers.vacancies.steps.#{vacancy_step_process.current_step}"))
+      describe "#heading" do
+        it "returns edit job title" do
+          expect(page).to have_content(I18n.t("publishers.vacancies.steps.#{vacancy_step_process.current_step}"))
+        end
+      end
     end
   end
 end

--- a/spec/concerns/reset_vacancies_in_job_listings_spec.rb
+++ b/spec/concerns/reset_vacancies_in_job_listings_spec.rb
@@ -92,17 +92,12 @@ RSpec.describe Resettable do
   end
 
   context "when changing enable job applications" do
-    subject(:update_job_applications) { vacancy.update(enable_job_applications: true) }
-
-    let(:vacancy) { build(:vacancy, receive_applications: "website", enable_job_applications: false) }
-    let(:previous_receive_applications) { vacancy.receive_applications }
-
-    before { vacancy.update(status: :draft) }
+    let(:vacancy) { create(:draft_vacancy, receive_applications: "website", enable_job_applications: false) }
 
     it "resets receive application" do
-      expect { update_job_applications }
-        .to change { vacancy.receive_applications }
-        .from(previous_receive_applications).to(nil)
+      expect { vacancy.update!(enable_job_applications: true) }
+        .to change { vacancy.reload.receive_applications }
+        .from("website").to(nil)
     end
   end
 

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -60,7 +60,6 @@ FactoryBot.define do
     skills_and_experience { Faker::Lorem.sentence(word_count: factory_rand(50..150)) }
     start_date_type { "specific_date" }
     starts_on { 1.year.from_now.to_date }
-    status { :published }
     # Subjects are ignored when phases are primary-only
     subjects { factory_sample(SUBJECT_OPTIONS, 2).map(&:first).sort! }
     key_stages { %w[ks1] }
@@ -209,8 +208,6 @@ FactoryBot.define do
     end
 
     factory :draft_vacancy, class: "DraftVacancy" do
-      status { :draft }
-
       completed_steps do
         %w[job_location job_role education_phases job_title key_stages subjects contract_type working_patterns pay_package start_date
            applying_for_the_job school_visits contact_details about_the_role include_additional_documents]

--- a/spec/form_models/publishers/job_listing/important_dates_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/important_dates_form_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
       end
 
       context "when vacancy is published and publish_on is in the future" do
-        let(:vacancy) { build_stubbed(:vacancy, :published, publish_on: Date.current + 1.day) }
+        let(:vacancy) { build_stubbed(:vacancy, publish_on: Date.current + 1.day) }
 
         it "is invalid" do
           expect(subject).to be_invalid
@@ -112,7 +112,7 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
       end
 
       context "when vacancy is published and publish_on is in the future" do
-        let(:vacancy) { build_stubbed(:vacancy, :published, publish_on: Date.current + 1.day) }
+        let(:vacancy) { build_stubbed(:vacancy, publish_on: Date.current + 1.day) }
 
         it "is invalid" do
           expect(subject).to be_invalid
@@ -154,7 +154,7 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
       end
 
       context "when vacancy is published and publish_on is in the future" do
-        let(:vacancy) { build_stubbed(:vacancy, :published, publish_on: Date.current + 1.day) }
+        let(:vacancy) { build_stubbed(:vacancy, publish_on: Date.current + 1.day) }
 
         it "is invalid" do
           expect(subject).to be_invalid
@@ -184,7 +184,7 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
       let(:publish_on) { 1.year.ago.to_date }
 
       context "when vacancy is published" do
-        let(:vacancy) { build_stubbed(:vacancy, :published) }
+        let(:vacancy) { build_stubbed(:vacancy) }
 
         it "is valid" do
           expect(subject).to be_valid

--- a/spec/form_models/publishers/vacancy_form_sequence_spec.rb
+++ b/spec/form_models/publishers/vacancy_form_sequence_spec.rb
@@ -61,14 +61,14 @@ RSpec.describe Publishers::VacancyFormSequence do
     end
 
     context "when the vacancy has been published" do
-      let(:vacancy) { create(:vacancy, :published, phases: %w[secondary], organisations: [organisation]) }
+      let(:vacancy) { create(:vacancy, phases: %w[secondary], organisations: [organisation]) }
 
       context "when the current step has dependent steps" do
         let(:current_step) { :job_location }
         let(:validated_forms) { sequence.validate_all_steps }
 
         context "when the dependent steps are invalid" do
-          let(:vacancy) { create(:vacancy, :published, phases: nil, key_stages: nil, organisations: [organisation]) }
+          let(:vacancy) { create(:vacancy, phases: nil, key_stages: nil, organisations: [organisation]) }
 
           before { allow(vacancy).to receive(:allow_key_stages?).and_return(true) }
 
@@ -78,7 +78,7 @@ RSpec.describe Publishers::VacancyFormSequence do
         end
 
         context "when the dependent steps are valid" do
-          let(:vacancy) { create(:vacancy, :published, phases: %w[secondary], key_stages: %w[ks3], organisations: [organisation]) }
+          let(:vacancy) { create(:vacancy, phases: %w[secondary], key_stages: %w[ks3], organisations: [organisation]) }
 
           it "returns a hash containing valid forms for each dependent step" do
             validated_forms.each_value { |form| expect(form).to be_valid }
@@ -104,13 +104,13 @@ RSpec.describe Publishers::VacancyFormSequence do
     end
 
     context "when the vacancy has been published" do
-      let(:vacancy) { create(:vacancy, :published, phases: %w[secondary], organisations: [organisation]) }
+      let(:vacancy) { create(:vacancy, phases: %w[secondary], organisations: [organisation]) }
 
       context "when the current step has dependent steps" do
         let(:current_step) { :job_location }
 
         context "when the dependent steps are invalid" do
-          let(:vacancy) { create(:vacancy, :published, phases: nil, key_stages: nil, organisations: [organisation]) }
+          let(:vacancy) { create(:vacancy, phases: nil, key_stages: nil, organisations: [organisation]) }
 
           it "returns false" do
             expect(sequence.all_steps_valid?).to be false
@@ -118,7 +118,7 @@ RSpec.describe Publishers::VacancyFormSequence do
         end
 
         context "when the dependent steps are valid" do
-          let(:vacancy) { create(:vacancy, :published, phases: %w[secondary], key_stages: %w[ks3], organisations: [organisation]) }
+          let(:vacancy) { create(:vacancy, phases: %w[secondary], key_stages: %w[ks3], organisations: [organisation]) }
 
           it "returns true" do
             expect(sequence.all_steps_valid?).to be true
@@ -153,7 +153,7 @@ RSpec.describe Publishers::VacancyFormSequence do
 
     context "when the vacancy has been published" do
       let(:current_step) { :job_location }
-      let(:vacancy) { create(:vacancy, :published, phases: nil, organisations: [organisation]) }
+      let(:vacancy) { create(:vacancy, phases: nil, organisations: [organisation]) }
 
       context "when a dependent step is invalid" do
         it "returns the first invalid dependent step" do

--- a/spec/helpers/vacancies_helper_spec.rb
+++ b/spec/helpers/vacancies_helper_spec.rb
@@ -410,7 +410,7 @@ RSpec.describe VacanciesHelper do
     subject { helper.vacancy_review_form_heading_inset_text(vacancy, status) }
 
     context "when the job has been published" do
-      let(:vacancy) { create(:vacancy, :published) }
+      let(:vacancy) { create(:vacancy) }
       let(:status) { "published" }
 
       it "returns the correct text" do
@@ -438,7 +438,7 @@ RSpec.describe VacanciesHelper do
       end
 
       context "when the draft is incomplete" do
-        let(:vacancy) { create(:vacancy, :published) }
+        let(:vacancy) { create(:vacancy) }
         let(:status) { "incomplete_draft" }
 
         it "returns the correct text" do

--- a/spec/jobs/import_from_vacancy_source_job_spec.rb
+++ b/spec/jobs/import_from_vacancy_source_job_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ImportFromVacancySourceJob do
     context "when a new valid vacancy comes through" do
       let(:vacancies_from_source) { [vacancy] }
       let(:vacancy) do
-        build(:vacancy, :published, :external, phases: %w[secondary], job_roles: ["teaching_assistant"], organisations: [school])
+        build(:vacancy, :external, phases: %w[secondary], job_roles: ["teaching_assistant"], organisations: [school])
       end
 
       it "saves the vacancy" do
@@ -43,7 +43,7 @@ RSpec.describe ImportFromVacancySourceJob do
     context "when the vacancy has already been imported" do
       let(:vacancies_from_source) { [vacancy] }
       let(:vacancy) do
-        build(:vacancy, :published, :external, phases: %w[secondary], job_roles: ["teaching_assistant"], organisations: [school], external_source: "fake_source")
+        build(:vacancy, :external, phases: %w[secondary], job_roles: ["teaching_assistant"], organisations: [school], external_source: "fake_source")
       end
 
       before { described_class.perform_now(FakeVacancySource) }
@@ -52,10 +52,6 @@ RSpec.describe ImportFromVacancySourceJob do
         expect(vacancy).not_to receive(:save)
         described_class.perform_now(FakeVacancySource)
       end
-
-      it "the originally imported vacancy keeps its original status" do
-        expect { described_class.perform_now(FakeVacancySource) }.not_to(change { vacancy.reload.status })
-      end
     end
 
     context "when a new vacancy comes through but isn't valid" do
@@ -63,7 +59,6 @@ RSpec.describe ImportFromVacancySourceJob do
       let(:contact_email) { Faker::Internet.email(domain: TEST_EMAIL_DOMAIN) }
       let(:vacancy) do
         build(:vacancy,
-              :published,
               :external,
               phases: [],
               enable_job_applications: true,
@@ -165,7 +160,6 @@ RSpec.describe ImportFromVacancySourceJob do
           "starts_asap" => nil,
           "starts_on" => (Date.today + 1.year).strftime("%Y-%m-%d"),
           "stats_updated_at" => nil,
-          "status" => "published",
           "subjects" => [],
           "updated_at" => nil,
           "working_patterns" => ["full_time"],
@@ -191,8 +185,8 @@ RSpec.describe ImportFromVacancySourceJob do
 
     context "when there is already a duplicate vacancy in the FailedImportedVacancy table" do
       let(:vacancies_from_source) { [vacancy1, vacancy2] }
-      let(:vacancy1) { build(:vacancy, :published, :external, external_reference: "123", phases: [], organisations: [school], job_title: "") }
-      let(:vacancy2) { build(:vacancy, :published, :external, external_reference: "123", phases: [], organisations: [school], job_title: "") }
+      let(:vacancy1) { build(:vacancy, :external, external_reference: "123", phases: [], organisations: [school], job_title: "") }
+      let(:vacancy2) { build(:vacancy, :external, external_reference: "123", phases: [], organisations: [school], job_title: "") }
 
       it "does not save the second vacancy" do
         import_from_vacancy_source_job
@@ -202,7 +196,7 @@ RSpec.describe ImportFromVacancySourceJob do
     end
 
     context "when a live vacancy no longer comes through" do
-      before { create(:vacancy, :published, :external, phases: %w[secondary], organisations: [school], external_source: "fake_source", external_reference: "123", updated_at: 1.hour.ago) }
+      before { create(:vacancy, :external, phases: %w[secondary], organisations: [school], external_source: "fake_source", external_reference: "123", updated_at: 1.hour.ago) }
 
       let(:vacancies_from_source) { [] }
 

--- a/spec/jobs/index_newly_published_vacancies_job_spec.rb
+++ b/spec/jobs/index_newly_published_vacancies_job_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe IndexNewlyPublishedVacanciesJob do
   end
 
   it "enqueues UpdateGoogleIndexQueueJob for each vacancy published today" do
-    published_today_vacancy = create(:vacancy, :published, publish_on: Time.zone.today)
+    published_today_vacancy = create(:vacancy, publish_on: Time.zone.today)
     create(:draft_vacancy, publish_on: Time.zone.today)
-    create(:vacancy, :published, publish_on: Time.zone.today - 1.day)
+    create(:vacancy, publish_on: Time.zone.today - 1.day)
 
     described_class.perform_now
 

--- a/spec/jobs/remove_vacancies_that_expired_yesterday_from_google_index_job_spec.rb
+++ b/spec/jobs/remove_vacancies_that_expired_yesterday_from_google_index_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe RemoveVacanciesThatExpiredYesterdayFromGoogleIndexJob do
   before do
     create_list(:vacancy, 5, expires_at: 1.day.ago)
     create_list(:vacancy, 1, expires_at: 2.days.ago)
-    create_list(:vacancy, 1, :published)
+    create_list(:vacancy, 1)
   end
 
   it "removes the url for each expired vacancy" do

--- a/spec/jobs/send_job_listing_ended_early_notification_job_spec.rb
+++ b/spec/jobs/send_job_listing_ended_early_notification_job_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe SendJobListingEndedEarlyNotificationJob do
   subject(:job) { described_class.perform_later(vacancy) }
   let(:mail) { double("Mail::Message", deliver_later: true) }
-  let(:vacancy) { create(:vacancy, :published) }
+  let(:vacancy) { create(:vacancy) }
 
   before do
     allow(Jobseekers::JobApplicationMailer).to receive(:job_listing_ended_early) { mail }

--- a/spec/mailers/jobseekers/alert_mailer_spec.rb
+++ b/spec/mailers/jobseekers/alert_mailer_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Jobseekers::AlertMailer do
   let(:school) { create(:school) }
   let(:mail) { described_class.alert(subscription.id, vacancies.pluck(:id)) }
   # The array of vacancies is set to length 1 because the order varies, making it hard to test url parameters.
-  let(:vacancies) { create_list(:vacancy, 1, :published, organisations: [school]).map { |vacancy| VacancyPresenter.new(vacancy) } }
+  let(:vacancies) { create_list(:vacancy, 1, organisations: [school]).map { |vacancy| VacancyPresenter.new(vacancy) } }
   let(:utm_params) { { utm_source: "a_unique_identifier", utm_medium: "email", utm_campaign: "#{frequency}_alert" } }
   let(:relevant_job_alert_feedback_url) do
     subscription_submit_feedback_url(

--- a/spec/models/job_preferences/job_scope_spec.rb
+++ b/spec/models/job_preferences/job_scope_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe JobPreferences::JobScope do
 
   let!(:vacancy1) do
     create(:vacancy,
-           :published,
            job_roles: ["teacher"],
            phases: %w[primary secondary],
            key_stages: nil,
@@ -15,7 +14,6 @@ RSpec.describe JobPreferences::JobScope do
 
   let!(:vacancy2) do
     create(:vacancy,
-           :published,
            job_roles: ["teaching_assistant"],
            phases: %w[primary secondary],
            key_stages: %w[ks1],
@@ -25,7 +23,6 @@ RSpec.describe JobPreferences::JobScope do
 
   let!(:vacancy3) do
     create(:vacancy,
-           :published,
            job_roles: ["headteacher"],
            phases: %w[primary],
            key_stages: %w[ks2],
@@ -35,7 +32,6 @@ RSpec.describe JobPreferences::JobScope do
 
   let!(:vacancy4) do
     create(:vacancy,
-           :published,
            job_roles: ["head_of_year_or_phase"],
            phases: %w[secondary],
            key_stages: %w[ks1 ks2],

--- a/spec/models/vacancy_organisation_association_spec.rb
+++ b/spec/models/vacancy_organisation_association_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Vacancy do
     let(:school_group) { create(:trust, schools: [school_one, school_two]) }
     let(:school_one) { create(:school, name: "First school", phase: "primary") }
     let(:school_two) { create(:school, name: "Second school", phase: "primary") }
-    let(:vacancy) { create(:vacancy, :published, :ect_suitable, job_roles: %w[teacher], organisations: [school_group], phases: %w[primary], key_stages: %w[ks1]) }
+    let(:vacancy) { create(:vacancy, :ect_suitable, job_roles: %w[teacher], organisations: [school_group], phases: %w[primary], key_stages: %w[ks1]) }
 
     describe "#refresh_geolocation" do
       context "when associated with a school group (trust)" do

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -18,13 +18,13 @@ RSpec.describe Vacancy do
 
     it "publish_on is not removed when converting a draft to a published vacancy" do
       vacancy = create(:draft_vacancy, publish_on: Date.current)
-      vacancy.update(status: :published)
+      vacancy.update!(type: "PublishedVacancy")
       expect(vacancy.publish_on).to be_present
     end
 
     it "publish_on is removed when converting a published vacancy back into a draft" do
       vacancy = create(:vacancy, publish_on: Date.current)
-      expect { vacancy.update(status: :draft) }.to change { vacancy.publish_on }.from(Date.current).to(nil)
+      expect { vacancy.update(type: "DraftVacancy") }.to change { vacancy.publish_on }.from(Date.current).to(nil)
     end
   end
 
@@ -64,7 +64,7 @@ RSpec.describe Vacancy do
         invalid_school = School.new(email: "invalid")
         expect(invalid_school).not_to be_valid
 
-        expect(Vacancy.new(organisations: [invalid_school], publisher: publisher, status: "draft")).to be_valid
+        expect(DraftVacancy.new(organisations: [invalid_school], publisher: publisher)).to be_valid
       end
     end
 
@@ -783,14 +783,10 @@ RSpec.describe Vacancy do
     end
   end
 
-  describe "#draft!" do
+  describe "draft!" do
     subject { create(:vacancy, :future_publish) }
 
-    before { subject.draft! }
-
-    it "converts the job to a draft" do
-      expect(subject.status).to eq("draft")
-    end
+    before { subject.update!(type: "DraftVacancy") }
 
     it "resets the publish_on date" do
       expect(subject.publish_on).to eq(nil)

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -402,23 +402,6 @@ RSpec.describe Vacancy do
       end
     end
 
-    describe "#published_on_count(date)" do
-      it "retrieves vacancies listed on the specified date" do
-        published_today = create_list(:vacancy, 3, :published_slugged)
-        published_yesterday = build_list(:vacancy, 2, :published_slugged, publish_on: 1.day.ago)
-        published_yesterday.each { |v| v.save(validate: false) }
-        published_the_other_day = build_list(:vacancy, 1, :published_slugged, publish_on: 2.days.ago)
-        published_the_other_day.each { |v| v.save(validate: false) }
-        published_some_other_day = build_list(:vacancy, 6, :published_slugged, publish_on: 1.month.ago)
-        published_some_other_day.each { |v| v.save(validate: false) }
-
-        expect(Vacancy.published_on_count(Date.current)).to eq(published_today.count)
-        expect(Vacancy.published_on_count(1.day.ago)).to eq(published_yesterday.count)
-        expect(Vacancy.published_on_count(2.days.ago)).to eq(published_the_other_day.count)
-        expect(Vacancy.published_on_count(1.month.ago)).to eq(published_some_other_day.count)
-      end
-    end
-
     describe "#awaiting_feedback_recently_expired" do
       it "includes only vacancies that expired within the last 2 months and are awaiting feedback" do
         recent_expired_and_awaiting_feedback = create(:vacancy, :expired, expires_at: 1.month.ago)

--- a/spec/notifications/publishers/job_application_received_notifier_spec.rb
+++ b/spec/notifications/publishers/job_application_received_notifier_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Publishers::JobApplicationReceivedNotifier do
-  let(:vacancy) { create(:vacancy, :published, organisations: [build(:school)]) }
+  let(:vacancy) { create(:vacancy, organisations: [build(:school)]) }
   let(:publisher) { vacancy.publisher }
   let(:job_application) { create(:job_application, :status_submitted, vacancy: vacancy) }
 

--- a/spec/requests/api/vacancies_spec.rb
+++ b/spec/requests/api/vacancies_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe "Api::Vacancies" do
     end
 
     it "never redirects to latest url" do
-      vacancy = create(:vacancy, :published)
+      vacancy = create(:vacancy)
       vacancy.job_title = "A new job title"
       vacancy.refresh_slug
       vacancy.save

--- a/spec/requests/publishers/ats_api/v1/vacancies_spec.rb
+++ b/spec/requests/publishers/ats_api/v1/vacancies_spec.rb
@@ -57,9 +57,9 @@ RSpec.describe "ats-api/v1/vacancies", openapi_spec: "v1/swagger.yaml" do
           body = response.parsed_body
           expect(body.keys).to match_array(%w[vacancies meta])
           # Contain all the client vacancies
-          expect(body["vacancies"].map { |v| v["id"] }).to contain_exactly(vacancy_published.id,
-                                                                           vacancy_unpublished.id,
-                                                                           vacancy_expired.id)
+          expect(body["vacancies"].map { |v| v["external_reference"] }).to contain_exactly(vacancy_published.external_reference,
+                                                                                           vacancy_unpublished.external_reference,
+                                                                                           vacancy_expired.external_reference)
           expect(body["meta"]["totalPages"]).to eq(1)
         end
       end
@@ -151,7 +151,6 @@ RSpec.describe "ats-api/v1/vacancies", openapi_spec: "v1/swagger.yaml" do
           created_vacancy = Vacancy.last
           expect(response.parsed_body).to eq("id" => created_vacancy.id)
           expect(created_vacancy).to have_attributes(
-            status: "published",
             external_advert_url: "https://www.example.com/ats-site/advertid",
             expires_at: Date.new(2026, 1, 1),
             job_title: "Teacher of Geography",
@@ -288,7 +287,6 @@ RSpec.describe "ats-api/v1/vacancies", openapi_spec: "v1/swagger.yaml" do
             created_vacancy = Vacancy.last
             expect(response.parsed_body).to eq("id" => created_vacancy.id)
             expect(created_vacancy).to have_attributes(
-              status: "published",
               publish_on: Time.zone.today,
               benefits_details: nil,
               starts_on: nil,

--- a/spec/requests/publishers/vacancies/application_forms_spec.rb
+++ b/spec/requests/publishers/vacancies/application_forms_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "Documents" do
         end
 
         context "when the vacancy has not been published" do
-          before { vacancy.update(status: "draft") }
+          let(:vacancy) { create(:draft_vacancy, enable_job_applications: false, receive_applications: "email", organisations: [organisation]) }
 
           it "redirects to the review page" do
             expect(request).to redirect_to(organisation_job_review_path(vacancy.id))

--- a/spec/requests/publishers/vacancies/build_spec.rb
+++ b/spec/requests/publishers/vacancies/build_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Job applications build" do
     context "when the vacancy has been published" do
       context "when dependent steps have been made invalid" do
         context "when changing the job location" do
-          let(:vacancy) { create(:vacancy, :published, phases: ["nursery"], organisations: [school_one]) }
+          let(:vacancy) { create(:vacancy, phases: ["nursery"], organisations: [school_one]) }
 
           before do
             allow(vacancy).to receive(:allow_key_stages?).and_return(true)
@@ -58,7 +58,7 @@ RSpec.describe "Job applications build" do
           before { patch(organisation_job_build_path(vacancy.id, :job_role, params)) }
 
           context "when the new job_role can be ect_suitable" do
-            let(:vacancy) { create(:vacancy, :published, job_roles: ["headteacher"], organisations: [school_one]) }
+            let(:vacancy) { create(:vacancy, job_roles: ["headteacher"], organisations: [school_one]) }
             let(:params) { { publishers_job_listing_job_role_form: { job_roles: ["teacher"] } } }
 
             it "redirects to the about_the_role step" do
@@ -67,7 +67,7 @@ RSpec.describe "Job applications build" do
           end
 
           context "when the the education_phase and the new job_role allows key_stages to be set" do
-            let(:vacancy) { create(:vacancy, :published, phases: %w[primary], job_roles: ["sendco"], organisations: [school_one]) }
+            let(:vacancy) { create(:vacancy, phases: %w[primary], job_roles: ["sendco"], organisations: [school_one]) }
             let(:params) { { publishers_job_listing_job_role_form: { job_roles: ["teacher"] } } }
 
             it "redirects to the key_stages step" do
@@ -77,7 +77,7 @@ RSpec.describe "Job applications build" do
         end
 
         context "when changing the education_phase" do
-          let(:vacancy) { create(:vacancy, :published, phases: ["nursery"], organisations: [school_without_phase]) }
+          let(:vacancy) { create(:vacancy, phases: ["nursery"], organisations: [school_without_phase]) }
 
           before { patch(organisation_job_build_path(vacancy.id, :education_phases, params)) }
 
@@ -94,7 +94,7 @@ RSpec.describe "Job applications build" do
           before { patch(organisation_job_build_path(vacancy.id, :how_to_receive_applications, params)) }
 
           context "when changing to uploaded_form" do
-            let(:vacancy) { create(:vacancy, :published, enable_job_applications: false, receive_applications: "website", organisations: [school_one]) }
+            let(:vacancy) { create(:vacancy, enable_job_applications: false, receive_applications: "website", organisations: [school_one]) }
             let(:params) { { publishers_job_listing_how_to_receive_applications_form: { receive_applications: "uploaded_form" } } }
 
             it "redirects to the application_form step" do
@@ -103,7 +103,7 @@ RSpec.describe "Job applications build" do
           end
 
           context "when changing to website" do
-            let(:vacancy) { create(:vacancy, :published, enable_job_applications: false, receive_applications: "email", organisations: [school_one]) }
+            let(:vacancy) { create(:vacancy, enable_job_applications: false, receive_applications: "email", organisations: [school_one]) }
             let(:params) { { publishers_job_listing_how_to_receive_applications_form: { receive_applications: "website" } } }
 
             it "redirects to the application_link step" do
@@ -115,7 +115,7 @@ RSpec.describe "Job applications build" do
         context "when changing include_additional_documents to true" do
           before { patch(organisation_job_build_path(vacancy.id, :include_additional_documents, params)) }
 
-          let(:vacancy) { create(:vacancy, :published, include_additional_documents: false, organisations: [school_one]) }
+          let(:vacancy) { create(:vacancy, include_additional_documents: false, organisations: [school_one]) }
           let(:params) { { publishers_job_listing_include_additional_documents_form: { include_additional_documents: true } } }
 
           it "redirects to the documents step" do

--- a/spec/requests/publishers/vacancies/end_listing_spec.rb
+++ b/spec/requests/publishers/vacancies/end_listing_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "End job listing early" do
   let(:organisation) { create(:school) }
-  let(:vacancy) { create(:vacancy, :published, expires_at: 1.week.from_now, organisations: [organisation]) }
+  let(:vacancy) { create(:vacancy, expires_at: 1.week.from_now, organisations: [organisation]) }
   let(:publisher) { create(:publisher) }
 
   before do
@@ -15,7 +15,7 @@ RSpec.describe "End job listing early" do
 
   describe "GET #show" do
     context "when the vacancy does not belong to the current organisation" do
-      let(:vacancy) { create(:vacancy, :published, organisations: [build(:school)]) }
+      let(:vacancy) { create(:vacancy, organisations: [build(:school)]) }
 
       it "returns not_found" do
         get organisation_job_end_listing_path(vacancy.id)

--- a/spec/requests/publishers/vacancies/extend_deadline_spec.rb
+++ b/spec/requests/publishers/vacancies/extend_deadline_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Extend deadline" do
   let(:organisation) { create(:school) }
-  let(:vacancy) { create(:vacancy, :published, publish_on: publish_on, expires_at: 1.month.from_now, organisations: [organisation]) }
+  let(:vacancy) { create(:vacancy, publish_on: publish_on, expires_at: 1.month.from_now, organisations: [organisation]) }
   let(:publisher) { create(:publisher) }
   let(:publish_on) { 1.month.ago }
 
@@ -15,7 +15,7 @@ RSpec.describe "Extend deadline" do
 
   describe "GET #show" do
     context "when the vacancy does not belong to the current organisation" do
-      let(:vacancy) { create(:vacancy, :published, organisations: [create(:school)]) }
+      let(:vacancy) { create(:vacancy, organisations: [create(:school)]) }
 
       it "returns not_found" do
         get organisation_job_extend_deadline_path(vacancy.id)
@@ -59,7 +59,7 @@ RSpec.describe "Extend deadline" do
     let(:params) { { publishers_job_listing_extend_deadline_form: form_params } }
 
     context "when the vacancy does not belong to the current organisation" do
-      let(:vacancy) { create(:vacancy, :published, organisations: [create(:school)]) }
+      let(:vacancy) { create(:vacancy, organisations: [create(:school)]) }
 
       it "returns not_found" do
         patch organisation_job_extend_deadline_path(vacancy.id), params: params

--- a/spec/requests/publishers/vacancies/job_applications_spec.rb
+++ b/spec/requests/publishers/vacancies/job_applications_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "Job applications" do
   describe "GET #index" do
     context "when the vacancy does not belong to the current organisation" do
       let(:other_organisation) { create(:school) }
-      let(:vacancy) { create(:vacancy, :published) }
+      let(:vacancy) { create(:vacancy) }
 
       before do
         allow_any_instance_of(ApplicationController)

--- a/spec/services/copy_vacancy_asa_template_spec.rb
+++ b/spec/services/copy_vacancy_asa_template_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe CopyVacancyAsaTemplate do
     it "creates a new vacancy as draft" do
       expect(result).to be_a(Vacancy)
       expect(Vacancy.count).to eq(2)
-      expect(result.status).to eq("draft")
+      expect(result.type).to eq("DraftVacancy")
       expect(result.organisations).to eq [school]
     end
 

--- a/spec/services/job_application_pdf_generator_spec.rb
+++ b/spec/services/job_application_pdf_generator_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "pdf/inspector"
 
 RSpec.describe JobApplicationPdfGenerator do
-  let(:vacancy) { build_stubbed(:vacancy, :published, :at_one_school) }
+  let(:vacancy) { build_stubbed(:vacancy, :at_one_school) }
   let(:job_application) do
     build_stubbed(:job_application, :status_submitted,
                   vacancy: vacancy,

--- a/spec/services/publish_vacancy_spec.rb
+++ b/spec/services/publish_vacancy_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PublishVacancy do
     it "updates the vacancy's status to published" do
       PublishVacancy.new(vacancy, user, organisation).call
 
-      expect(vacancy.status).to eq("published")
+      expect(vacancy.type).to eq("PublishedVacancy")
     end
 
     it "updates the id of the user who confirmed the publishing of a vacancy" do

--- a/spec/services/publishers/ats_api/create_vacancy_service_spec.rb
+++ b/spec/services/publishers/ats_api/create_vacancy_service_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe Publishers::AtsApi::CreateVacancyService do
         expect { create_vacancy_service }.to change(Vacancy, :count).by(1)
         vacancy = Vacancy.last
         expect(vacancy.external_reference).to eq("new-ref")
-        expect(vacancy.status).to eq("published")
       end
 
       describe "'publish_on'" do

--- a/spec/services/publishers/vacancies/vacancy_step_process_spec.rb
+++ b/spec/services/publishers/vacancies/vacancy_step_process_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Publishers::Vacancies::VacancyStepProcess do
       end
 
       context "when the vacancy is published" do
-        let(:vacancy) { build_stubbed(:vacancy, :published, job_roles: ["teacher"]) }
+        let(:vacancy) { build_stubbed(:vacancy, job_roles: ["teacher"]) }
 
         context "when the vacancy allows job applications" do
           before { allow(vacancy).to receive(:enable_job_applications).and_return(true) }

--- a/spec/services/vacancies/export/dwp_find_a_job/closed_early_spec.rb
+++ b/spec/services/vacancies/export/dwp_find_a_job/closed_early_spec.rb
@@ -4,10 +4,9 @@ RSpec.describe Vacancies::Export::DwpFindAJob::ClosedEarly do
   describe "#call" do
     subject { described_class.new("2024-05-01") }
 
-    let(:vacancy_expired_old) { create(:vacancy, :published, publish_on: 4.days.ago, expires_at: 2.days.ago) }
+    let(:vacancy_expired_old) { create(:vacancy, publish_on: 4.days.ago, expires_at: 2.days.ago) }
     let(:vacancy_manually_expired) do
       create(:vacancy,
-             :published,
              id: "ff7af59b-558b-4c55-9941-fe1942d84984",
              publish_on: 1.week.ago,
              updated_at: 10.minutes.ago,
@@ -16,7 +15,6 @@ RSpec.describe Vacancies::Export::DwpFindAJob::ClosedEarly do
     end
     let(:vacancy_manually_expired2) do
       create(:vacancy,
-             :published,
              id: "ac54642c-1679-4a86-9d00-7ed7e54c751e",
              publish_on: 1.week.ago,
              updated_at: 45.seconds.ago,
@@ -25,7 +23,6 @@ RSpec.describe Vacancies::Export::DwpFindAJob::ClosedEarly do
     end
     let(:vacancy_naturally_expired) do
       create(:vacancy,
-             :published,
              id: "0ee558c1-3587-4f7a-a0c2-d40a2289c7fe",
              publish_on: 1.week.ago,
              updated_at: 1.week.ago,

--- a/spec/services/vacancies/export/dwp_find_a_job/closed_early_vacancies/query_spec.rb
+++ b/spec/services/vacancies/export/dwp_find_a_job/closed_early_vacancies/query_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Vacancies::Export::DwpFindAJob::ClosedEarlyVacancies::Query do
     let(:early_ended_internal_before_date_vacancy) { create(:vacancy, expires_at: "2024-04-30T10:00:00", updated_at: "2024-04-30T10:00:01", created_at: 1.week.ago) }
     let(:expired_not_early_ended_internal_vacancy) { create(:vacancy, expires_at: "2024-05-2T10:00:00", created_at: 1.week.ago, updated_at: 6.days.ago) }
     let(:early_ended_external_vacancy) do
-      build(:vacancy, :published, :external, publish_on: "2024-05-01", expires_at: "2024-05-2T10:00:00", updated_at: "2024-05-2T10:00:00", organisations: [school], created_at: 1.week.ago).tap do |v|
+      build(:vacancy, :external, publish_on: "2024-05-01", expires_at: "2024-05-2T10:00:00", updated_at: "2024-05-2T10:00:00", organisations: [school], created_at: 1.week.ago).tap do |v|
         v.save(validate: false)
       end
     end

--- a/spec/services/vacancies/export/dwp_find_a_job/published_and_updated_spec.rb
+++ b/spec/services/vacancies/export/dwp_find_a_job/published_and_updated_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe Vacancies::Export::DwpFindAJob::PublishedAndUpdated do
     end
     let(:vacancy_published_old) do
       create(:vacancy,
-             :published,
              publish_on: 2.days.ago,
              created_at: 2.days.ago,
              updated_at: 2.days.ago,
@@ -22,7 +21,6 @@ RSpec.describe Vacancies::Export::DwpFindAJob::PublishedAndUpdated do
     end
     let(:vacancy_published) do
       create(:vacancy,
-             :published,
              id: "ff7af59b-558b-4c55-9941-fe1942d84984",
              publish_on: 1.hour.ago,
              updated_at: 2.weeks.ago,
@@ -40,7 +38,6 @@ RSpec.describe Vacancies::Export::DwpFindAJob::PublishedAndUpdated do
     end
     let(:vacancy_updated) do
       create(:vacancy,
-             :published,
              id: "0ee558c1-3587-4f7a-a0c2-d40a2289c7fe",
              publish_on: 2.days.ago,
              updated_at: 1.hour.ago,
@@ -58,7 +55,6 @@ RSpec.describe Vacancies::Export::DwpFindAJob::PublishedAndUpdated do
     end
     let(:vacancy_to_be_reposted) do
       create(:vacancy,
-             :published,
              id: "51d379eb-78f8-47ab-be8e-307887d4c807",
              publish_on: 62.days.ago,
              updated_at: 62.days.ago,

--- a/spec/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy_spec.rb
+++ b/spec/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Vacancies::Export::DwpFindAJob::PublishedAndUpdated::ParsedVacancy do
-  let(:vacancy) { build_stubbed(:vacancy, :published) }
+  let(:vacancy) { build_stubbed(:vacancy) }
 
   subject(:parsed) { described_class.new(vacancy) }
 

--- a/spec/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/query_spec.rb
+++ b/spec/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/query_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Vacancies::Export::DwpFindAJob::PublishedAndUpdated::Query do
-  let(:vacancy) { build_stubbed(:vacancy, :published) }
+  let(:vacancy) { build_stubbed(:vacancy) }
 
   subject { described_class.new("2024-05-01") }
 
@@ -15,12 +15,12 @@ RSpec.describe Vacancies::Export::DwpFindAJob::PublishedAndUpdated::Query do
 
   describe "#vacancies" do
     let(:school) { create(:school) }
-    let(:published_internal_vacancy) { create(:vacancy, :published, publish_on: "2024-05-02", expires_at: "2024-05-12", created_at: 1.week.ago, updated_at: 1.week.ago) }
-    let(:published_internal_before_date_vacancy) { create(:vacancy, :published, publish_on: "2024-04-30", expires_at: "2024-05-12", created_at: 1.week.ago, updated_at: 1.week.ago) }
-    let(:published_internal_updated_vacancy) { create(:vacancy, :published, publish_on: "2024-04-30", expires_at: "2024-05-12", created_at: 1.week.ago, updated_at: Time.zone.now) }
-    let(:unpublished_internal_vacancy) { create(:vacancy, :published, publish_on: "2024-05-03", expires_at: "2024-05-12", created_at: 1.week.ago, updated_at: 1.week.ago) }
+    let(:published_internal_vacancy) { create(:vacancy, publish_on: "2024-05-02", expires_at: "2024-05-12", created_at: 1.week.ago, updated_at: 1.week.ago) }
+    let(:published_internal_before_date_vacancy) { create(:vacancy, publish_on: "2024-04-30", expires_at: "2024-05-12", created_at: 1.week.ago, updated_at: 1.week.ago) }
+    let(:published_internal_updated_vacancy) { create(:vacancy, publish_on: "2024-04-30", expires_at: "2024-05-12", created_at: 1.week.ago, updated_at: Time.zone.now) }
+    let(:unpublished_internal_vacancy) { create(:vacancy, publish_on: "2024-05-03", expires_at: "2024-05-12", created_at: 1.week.ago, updated_at: 1.week.ago) }
     let(:publised_external_vacancy) do
-      build(:vacancy, :published, :external, publish_on: "2024-05-02", expires_at: "2024-05-12", organisations: [school], created_at: 1.week.ago, updated_at: 1.week.ago).tap do |v|
+      build(:vacancy, :external, publish_on: "2024-05-02", expires_at: "2024-05-12", organisations: [school], created_at: 1.week.ago, updated_at: 1.week.ago).tap do |v|
         v.save(validate: false)
       end
     end
@@ -53,26 +53,26 @@ RSpec.describe Vacancies::Export::DwpFindAJob::PublishedAndUpdated::Query do
     describe "vacancies that need to be reposted" do
       [31, 62, 93, 124, 155, 186].each do |days|
         it "includes internal vacancies published exactly #{days} days ago" do
-          vacancy = create(:vacancy, :published, publish_on: days.days.ago, expires_at: Time.zone.now + 12.days,
-                                                 created_at: days.days.ago, updated_at: days.days.ago)
+          vacancy = create(:vacancy, publish_on: days.days.ago, expires_at: Time.zone.now + 12.days,
+                                     created_at: days.days.ago, updated_at: days.days.ago)
           expect(subject.vacancies).to contain_exactly(vacancy)
         end
       end
 
       [15, 30, 60, 61, 63].each do |days|
         it "does not include internal vacancies published exactly #{days} days ago" do
-          create(:vacancy, :published, publish_on: days.days.ago, expires_at: Time.zone.now + 12.days,
-                                       created_at: days.days.ago, updated_at: days.days.ago)
+          create(:vacancy, publish_on: days.days.ago, expires_at: Time.zone.now + 12.days,
+                           created_at: days.days.ago, updated_at: days.days.ago)
           expect(subject.vacancies).to be_empty
         end
       end
     end
 
     it "combines all the vacancy selection criterias" do
-      create(:vacancy, :published, publish_on: 30.days.ago, expires_at: Time.zone.now + 56.days, created_at: 50.days.ago, updated_at: 50.days.ago)
+      create(:vacancy, publish_on: 30.days.ago, expires_at: Time.zone.now + 56.days, created_at: 50.days.ago, updated_at: 50.days.ago)
 
-      published_internal_31_days_ago_vacancy = create(:vacancy, :published, publish_on: 31.days.ago, expires_at: Time.zone.now + 56.days, created_at: 50.days.ago, updated_at: 50.days.ago)
-      published_internal_62_days_ago_vacancy = create(:vacancy, :published, publish_on: 62.days.ago, expires_at: Time.zone.now + 56.days, created_at: 70.days.ago, updated_at: 70.days.ago)
+      published_internal_31_days_ago_vacancy = create(:vacancy, publish_on: 31.days.ago, expires_at: Time.zone.now + 56.days, created_at: 50.days.ago, updated_at: 50.days.ago)
+      published_internal_62_days_ago_vacancy = create(:vacancy, publish_on: 62.days.ago, expires_at: Time.zone.now + 56.days, created_at: 70.days.ago, updated_at: 70.days.ago)
       published_internal_vacancy
       published_internal_before_date_vacancy
       published_internal_updated_vacancy

--- a/spec/system/jobseekers/job_applications_deadline_passed_spec.rb
+++ b/spec/system/jobseekers/job_applications_deadline_passed_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Deadline-passed job applications for jobseekers" do
   context "when an application is in 'draft' status and the deadline for application has passed" do
     let(:deadline) { 1.week.ago }
 
-    let(:vacancy) { create(:vacancy, :at_one_school, :published, expires_at: deadline) }
+    let(:vacancy) { create(:vacancy, :at_one_school, expires_at: deadline) }
 
     let(:jobseeker) { create(:jobseeker) }
     let!(:job_application) do

--- a/spec/system/jobseekers/job_applications_submitted_spec.rb
+++ b/spec/system/jobseekers/job_applications_submitted_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Submitted job applications for jobseekers" do
   context "when an application is in submitted status" do
-    let(:vacancy) { create(:vacancy, :at_one_school, :published) }
+    let(:vacancy) { create(:vacancy, :at_one_school) }
 
     let(:jobseeker) { create(:jobseeker) }
     let!(:job_application) do

--- a/spec/system/jobseekers/jobseekers_can_apply_for_a_vacancy_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_apply_for_a_vacancy_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Jobseekers can apply for a vacancy" do
 
     context "with a published vacancy" do
       let(:vacancy) do
-        create(:vacancy, :published, :no_tv_applications,
+        create(:vacancy, :no_tv_applications,
                application_link: "www.google.com", organisations: [build(:school)])
       end
 
@@ -31,7 +31,7 @@ RSpec.describe "Jobseekers can apply for a vacancy" do
 
   context "with a download form vacancy" do
     let(:vacancy) do
-      create(:vacancy, :published, :with_application_form,
+      create(:vacancy, :with_application_form,
              organisations: [build(:school)])
     end
     let(:jobseeker) { create(:jobseeker) }

--- a/spec/system/jobseekers/jobseekers_can_give_job_alert_feedback_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_give_job_alert_feedback_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "A jobseeker can give feedback on a job alert", recaptcha: true d
   let(:search_criteria) { { keyword: "Math", location: "London" } }
   let(:subscription) { create(:subscription, frequency: :daily, search_criteria: search_criteria) }
   let(:relevant_to_user) { true }
-  let(:vacancies) { create_list(:vacancy, 2, :published) }
+  let(:vacancies) { create_list(:vacancy, 2) }
   let(:job_alert_vacancy_ids) { vacancies.pluck(:id) }
   let(:verify_recaptcha) { true }
 

--- a/spec/system/jobseekers/jobseekers_can_save_a_job_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_save_a_job_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Jobseekers can save a job" do
   let(:school) { create(:school) }
-  let(:vacancy) { create(:vacancy, :published, organisations: [school]) }
+  let(:vacancy) { create(:vacancy, organisations: [school]) }
   let(:created_jobseeker) { Jobseeker.first }
 
   context "when a jobseeker has an account" do

--- a/spec/system/jobseekers/jobseekers_can_search_for_jobs_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_search_for_jobs_spec.rb
@@ -15,9 +15,11 @@ RSpec.shared_examples "a successful search" do
 
     context "when navigating between pages" do
       it "displays page 3 jobs" do
+        sleep 30
         within ".govuk-pagination" do
           click_on "3"
         end
+        sleep 20
 
         expect(page).to have_css(".search-results > .search-results__item", count: 2)
         expect(page).to have_content strip_tags(I18n.t("app.pagy_stats_html", from: 5, to: 6, total: 6, type: "results"))

--- a/spec/system/jobseekers/jobseekers_can_view_a_vacancy_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_view_a_vacancy_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe "Viewing a single published vacancy" do
 
   context "when the vacancy status is published" do
     let(:vacancy) do
-      create(:vacancy, :published, start_date_type: "asap", organisations: [school], job_roles: %w[ teacher headteacher deputy_headteacher assistant_headteacher head_of_year_or_phase head_of_department_or_curriculum teaching_assistant
-                                                                                                    higher_level_teaching_assistant education_support sendco administration_hr_data_and_finance
-                                                                                                    catering_cleaning_and_site_management it_support pastoral_health_and_welfare other_leadership other_support ])
+      create(:vacancy, start_date_type: "asap", organisations: [school], job_roles: %w[ teacher headteacher deputy_headteacher assistant_headteacher head_of_year_or_phase head_of_department_or_curriculum teaching_assistant
+                                                                                        higher_level_teaching_assistant education_support sendco administration_hr_data_and_finance
+                                                                                        catering_cleaning_and_site_management it_support pastoral_health_and_welfare other_leadership other_support ])
     end
 
     scenario "jobseekers can view the vacancy" do
@@ -59,7 +59,7 @@ RSpec.describe "Viewing a single published vacancy" do
     end
 
     context "with supporting documents attached" do
-      let(:vacancy) { create(:vacancy, :published, :with_supporting_documents, organisations: [school]) }
+      let(:vacancy) { create(:vacancy, :with_supporting_documents, organisations: [school]) }
 
       scenario "can see the supporting documents section" do
         visit job_path(vacancy)
@@ -107,15 +107,15 @@ RSpec.describe "Viewing a single published vacancy" do
     end
 
     scenario "jobseeker does not see a tag on jobs that don't allow to apply through Teaching Vacancies" do
-      vacancy_without_apply = create(:vacancy, :published, :no_tv_applications, organisations: [school])
+      vacancy_without_apply = create(:vacancy, :no_tv_applications, organisations: [school])
 
       visit job_path(vacancy_without_apply)
       expect(page).not_to have_css("strong.govuk-tag--green", text: I18n.t("vacancies.listing.enable_job_applications_tag"))
     end
 
     context "with similar jobs listed" do
-      let(:similar_job_tv_application) { create(:vacancy, :published, organisations: [school]) }
-      let(:similar_job_no_tv_application) { create(:vacancy, :published, :no_tv_applications, organisations: [school]) }
+      let(:similar_job_tv_application) { create(:vacancy, organisations: [school]) }
+      let(:similar_job_no_tv_application) { create(:vacancy, :no_tv_applications, organisations: [school]) }
       let(:similar_jobs_stub) do
         instance_double(Search::SimilarJobs, similar_jobs: [similar_job_tv_application, similar_job_no_tv_application])
       end

--- a/spec/system/jobseekers/prefilling_applications_spec.rb
+++ b/spec/system/jobseekers/prefilling_applications_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Jobseekers can prefill applications" do
   let(:jobseeker) { create(:jobseeker) }
-  let(:vacancy) { create(:vacancy, :published, :at_one_school) }
+  let(:vacancy) { create(:vacancy, :at_one_school) }
   let(:school) { vacancy.organisation_vacancies.first.organisation }
 
   before do

--- a/spec/system/publishers/publishers_are_reminded_of_application_functionality_spec.rb
+++ b/spec/system/publishers/publishers_are_reminded_of_application_functionality_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Application feature reminder" do
   after { logout }
 
   context "when at least one vacancy has been published that accepts applications through TV" do
-    let!(:vacancy) { create(:vacancy, :published, enable_job_applications: true, publisher:, organisations: [organisation]) }
+    let!(:vacancy) { create(:vacancy, enable_job_applications: true, publisher:, organisations: [organisation]) }
 
     it "does not show reminder page when creating a job" do
       visit organisation_jobs_with_type_path
@@ -24,7 +24,7 @@ RSpec.describe "Application feature reminder" do
   context "when no vacancy that accepts applications through TV has been published since the last update to the new features page" do
     before { stub_const("Publishers::NewFeaturesController::NEW_FEATURES_PAGE_UPDATED_AT", DateTime.new(2020, 1, 1).freeze) }
 
-    let!(:vacancy) { create(:vacancy, :published, enable_job_applications: false, publisher:, organisations: [organisation]) }
+    let!(:vacancy) { create(:vacancy, enable_job_applications: false, publisher:, organisations: [organisation]) }
 
     it "shows reminder page before first step of create job and does not show it twice in the same session" do
       visit organisation_jobs_with_type_path

--- a/spec/system/publishers/publishers_can_edit_a_published_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers/publishers_can_edit_a_published_vacancy_as_a_school_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe "Publishers can edit a vacancy" do
 
       describe "publish_on" do
         context "when the publication date is in the past" do
-          let(:vacancy) { create(:vacancy, :published, organisations: [school], slug: "test-slug", publish_on: 1.day.ago) }
+          let(:vacancy) { create(:vacancy, organisations: [school], slug: "test-slug", publish_on: 1.day.ago) }
           let(:expiry_time) { vacancy.expires_at + 1.year }
 
           before do
@@ -170,7 +170,7 @@ RSpec.describe "Publishers can edit a vacancy" do
 
     describe "#documents" do
       let(:filename) { "blank_job_spec.pdf" }
-      let(:vacancy) { create(:vacancy, :published, :with_supporting_documents, include_additional_documents: true, organisations: [school], phases: %w[secondary], key_stages: %w[ks3]) }
+      let(:vacancy) { create(:vacancy, :with_supporting_documents, include_additional_documents: true, organisations: [school], phases: %w[secondary], key_stages: %w[ks3]) }
 
       scenario "can edit documents" do
         publisher_vacancy_page.change_supporting_documents_link.click
@@ -260,7 +260,7 @@ RSpec.describe "Publishers can edit a vacancy" do
   context "when a vacancy is external" do
     let!(:vacancy) do
       create(
-        :vacancy, :external, :published, :expires_tomorrow,
+        :vacancy, :external, :expires_tomorrow,
         phases: %w[secondary],
         job_title: "Imported vacancy",
         organisations: [school]

--- a/spec/system/publishers/publishers_can_end_a_job_listing_early_spec.rb
+++ b/spec/system/publishers/publishers_can_end_a_job_listing_early_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Publishers can end a job listing early" do
   let(:organisation) { create(:school) }
-  let!(:vacancy) { create(:vacancy, :published, organisations: [organisation]) }
+  let!(:vacancy) { create(:vacancy, organisations: [organisation]) }
   let(:publisher) { create(:publisher) }
 
   before do

--- a/spec/system/publishers/publishers_can_filter_vacancies_in_their_dashboard_spec.rb
+++ b/spec/system/publishers/publishers_can_filter_vacancies_in_their_dashboard_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe "Publishers can filter vacancies in their dashboard" do
   let(:local_authority2) { create(:local_authority) }
   let(:school1) { create(:school, name: "Happy Rainbows School") }
   let(:school2) { create(:school, name: "Dreary Grey School") }
-  let!(:school_group_vacancy) { create(:vacancy, :published, organisations: [trust], job_title: "Maths Teacher") }
-  let!(:school1_vacancy) { create(:vacancy, :published, organisations: [school1], job_title: "English Teacher") }
+  let!(:school_group_vacancy) { create(:vacancy, organisations: [trust], job_title: "Maths Teacher") }
+  let!(:school1_vacancy) { create(:vacancy, organisations: [school1], job_title: "English Teacher") }
   let!(:school1_draft_vacancy) { create(:draft_vacancy, organisations: [school1], job_title: "Science Teacher") }
   let!(:school2_draft_vacancy) { create(:draft_vacancy, organisations: [school2], job_title: "History Teacher") }
 

--- a/spec/system/publishers/publishers_can_give_job_listing_feedback_spec.rb
+++ b/spec/system/publishers/publishers_can_give_job_listing_feedback_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Publishers can give job listing feedback" do
   end
 
   context "when the vacancy is published" do
-    let(:vacancy) { create(:vacancy, :published, organisations: [organisation], publisher: publisher) }
+    let(:vacancy) { create(:vacancy, organisations: [organisation], publisher: publisher) }
 
     it "submits blank feedback, renders error and then submits feedback successfully" do
       click_on I18n.t("buttons.submit_feedback")

--- a/spec/system/publishers/publishers_can_provide_feedback_on_expired_vacancies_via_prompt_email_spec.rb
+++ b/spec/system/publishers/publishers_can_provide_feedback_on_expired_vacancies_via_prompt_email_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Publishers can provide feedback on expired vacancies via the pro
 
   context "when no publishers have vacancies that expired between 2 and 6 weeks ago" do
     before do
-      create(:vacancy, :published, publisher: publisher, expires_at: 1.week.ago)
+      create(:vacancy, publisher: publisher, expires_at: 1.week.ago)
       perform_enqueued_jobs do
         SendExpiredVacancyFeedbackPromptJob.new.perform
       end
@@ -22,7 +22,7 @@ RSpec.describe "Publishers can provide feedback on expired vacancies via the pro
   end
 
   context "when a publisher has vacancies that expired between 2 and 6 weeks ago" do
-    let!(:first_vacancy_in_email) { create(:vacancy, :published, publisher: publisher, expires_at: 5.weeks.ago) }
+    let!(:first_vacancy_in_email) { create(:vacancy, publisher: publisher, expires_at: 5.weeks.ago) }
 
     before do
       perform_enqueued_jobs do
@@ -60,8 +60,8 @@ RSpec.describe "Publishers can provide feedback on expired vacancies via the pro
     let(:second_publisher) { create(:publisher, email: second_email) }
 
     before do
-      create_list(:vacancy, 2, :published, publisher: publisher, expires_at: 4.weeks.ago)
-      create_list(:vacancy, 2, :published, publisher: second_publisher, expires_at: 4.weeks.ago)
+      create_list(:vacancy, 2, publisher: publisher, expires_at: 4.weeks.ago)
+      create_list(:vacancy, 2, publisher: second_publisher, expires_at: 4.weeks.ago)
       perform_enqueued_jobs do
         SendExpiredVacancyFeedbackPromptJob.new.perform
       end

--- a/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_school_spec.rb
@@ -177,8 +177,8 @@ RSpec.describe "Creating a vacancy" do
 
           click_on I18n.t("publishers.vacancies.show.heading_component.action.publish")
 
-          expect(Vacancy.find(vacancy.id).publisher).to eq(publisher_that_publishes_vacancy)
-          expect(Vacancy.find(vacancy.id).publisher_organisation).to eq(school)
+          expect(PublishedVacancy.find(vacancy.id).publisher).to eq(publisher_that_publishes_vacancy)
+          expect(PublishedVacancy.find(vacancy.id).publisher_organisation).to eq(school)
         end
       end
 

--- a/spec/system/publishers/publishers_can_see_the_vacancies_dashboard_spec.rb
+++ b/spec/system/publishers/publishers_can_see_the_vacancies_dashboard_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Publishers can see the vacancies dashboard" do
   after { logout }
 
   scenario "school" do
-    vacancy = create(:vacancy, status: "published", organisations: [school])
+    vacancy = create(:vacancy, organisations: [school])
 
     visit organisation_jobs_with_type_path
 
@@ -20,7 +20,7 @@ RSpec.describe "Publishers can see the vacancies dashboard" do
   end
 
   context "viewing the lists of jobs on the school page" do
-    let!(:published_vacancy) { create(:vacancy, :published, organisations: [school]) }
+    let!(:published_vacancy) { create(:vacancy, organisations: [school]) }
     let!(:draft_vacancy) { create(:draft_vacancy, organisations: [school]) }
     let!(:pending_vacancy) { create(:vacancy, :future_publish, organisations: [school]) }
     let!(:expired_vacancy) do
@@ -28,7 +28,7 @@ RSpec.describe "Publishers can see the vacancies dashboard" do
     end
 
     scenario "jobs are split into sections" do
-      create_list(:vacancy, 5, :published, organisations: [school])
+      create_list(:vacancy, 5, organisations: [school])
 
       visit organisation_jobs_with_type_path
 

--- a/spec/system/publishers/publishers_can_unsubscribe_from_expired_vacancy_feedback_prompt_emails_spec.rb
+++ b/spec/system/publishers/publishers_can_unsubscribe_from_expired_vacancy_feedback_prompt_emails_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Publishers can unsubscribe from expired vacancy feedback prompt 
 
   before do
     ActionMailer::Base.deliveries.clear
-    create(:vacancy, :published, publisher: publisher, expires_at: 3.weeks.ago)
+    create(:vacancy, publisher: publisher, expires_at: 3.weeks.ago)
     perform_enqueued_jobs do
       SendExpiredVacancyFeedbackPromptJob.new.perform
     end

--- a/spec/system/publishers/publishers_can_view_their_notifications_spec.rb
+++ b/spec/system/publishers/publishers_can_view_their_notifications_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Publishers can view their notifications" do
   let(:publisher) { create(:publisher) }
   let(:organisation) { create(:school) }
-  let(:vacancy) { create(:vacancy, :published, organisations: [organisation], publisher: publisher) }
+  let(:vacancy) { create(:vacancy, organisations: [organisation], publisher: publisher) }
   let(:job_application) { create(:job_application, :status_submitted, vacancy: vacancy) }
 
   before { login_publisher(publisher: publisher, organisation: organisation) }

--- a/spec/system/publishers/publishers_can_view_vacancy_activity_log_spec.rb
+++ b/spec/system/publishers/publishers_can_view_vacancy_activity_log_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Publishers can view a vacancy's activity log", versioning: true do
   let(:publisher) { create(:publisher, organisations: [organisation]) }
   let(:organisation) { create(:school) }
-  let(:vacancy) { create(:vacancy, :published, contract_type: "permanent", subjects: old_subjects, phases: %w[secondary], organisations: [organisation], key_stages: %w[ks3]) }
+  let(:vacancy) { create(:vacancy, contract_type: "permanent", subjects: old_subjects, phases: %w[secondary], organisations: [organisation], key_stages: %w[ks3]) }
   let(:new_job_title) { "Demon headmaster wanted" }
   let(:new_contract_type) { "fixed_term" }
   let(:old_subjects) { %w[Mathematics Science] }

--- a/spec/system/publishers/publishers_get_email_notifications_from_job_applications_spec.rb
+++ b/spec/system/publishers/publishers_get_email_notifications_from_job_applications_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Publishers get email notifications from job applications" do
   let(:organisation) { create(:school) }
   let(:publisher) { create(:publisher, organisations: [organisation]) }
   let(:job_title) { Faker::Adjective.positive }
-  let(:vacancy) { create(:vacancy, :published, publisher: publisher, organisations: [organisation], publish_on: 2.days.ago, job_title: job_title ) }
+  let(:vacancy) { create(:vacancy, publisher: publisher, organisations: [organisation], publish_on: 2.days.ago, job_title: job_title ) }
   let!(:job_application) { create(:job_application, :status_submitted, vacancy: vacancy, submitted_at: 1.day.ago) }
 
   before do

--- a/spec/views/publishers/vacancies/job_applications/index.html.slim_spec.rb
+++ b/spec/views/publishers/vacancies/job_applications/index.html.slim_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe "publishers/vacancies/job_applications/index" do
   let(:publisher) { build_stubbed(:publisher, organisations: [organisation]) }
 
   let(:vacancy) do
-    build_stubbed(:vacancy, :published, publisher: publisher, organisations: [organisation],
-                                        job_applications: [build_stubbed(:job_application, :submitted)])
+    build_stubbed(:vacancy, publisher: publisher, organisations: [organisation],
+                            job_applications: [build_stubbed(:job_application, :submitted)])
   end
   let(:job_application) { vacancy.job_applications.first }
 
@@ -134,7 +134,7 @@ RSpec.describe "publishers/vacancies/job_applications/index" do
   end
 
   context "when a vacancy is active and it has no applications" do
-    let(:vacancy) { build_stubbed(:vacancy, :published, expires_at: 1.month.from_now, organisations: [organisation], job_applications: []) }
+    let(:vacancy) { build_stubbed(:vacancy, expires_at: 1.month.from_now, organisations: [organisation], job_applications: []) }
 
     describe "the summary section" do
       it "shows breadcrumb with link to active jobs in dashboard" do


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/dPPBCYdN/1805-draftvacancy-step-3-change-service-logic-to-use-sti-classes

## Changes in this PR:

- Is there anything specific you want feedback on?

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
