### PR TITLE
Add quick link religion information

### DIFF
--- a/app/views/publishers/vacancies/job_applications/_application_details_and_notes.html.slim
+++ b/app/views/publishers/vacancies/job_applications/_application_details_and_notes.html.slim
@@ -11,8 +11,8 @@
         - navigation.with_anchor text: t("jobseekers.job_applications.build.professional_body_memberships.heading"), href: "#professional_body_memberships"
         - navigation.with_anchor text: t("jobseekers.job_applications.build.employment_history.heading"), href: "#employment_history"
         - navigation.with_anchor text: t("jobseekers.job_applications.build.personal_statement.heading"), href: "#personal_statement"
-        - if job_application.vacancy.religion_type.present?
-          - navigation.with_anchor text: t("jobseekers.job_applications.build.religious_information.heading"), href: "#religious_information"
+        - if vacancy.religion_type.present?
+          - navigation.with_anchor text: t("jobseekers.job_applications.build.religious_information.heading"), href: "#following_religion"
         - navigation.with_anchor text: t("jobseekers.job_applications.build.referees.heading"), href: "#referees"
         - navigation.with_anchor text: t("jobseekers.job_applications.build.ask_for_support.heading"), href: "#ask_for_support"
         - navigation.with_anchor text: t("jobseekers.job_applications.build.declarations.heading"), href: "#declarations"

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -199,6 +199,8 @@ en:
           preference_to_catholics: Schools, academies and colleges with a religious character can give preference to Catholic applicants when recruiting for teaching roles, and most senior leadership posts require the postholder to be a practising Catholic.
           preference_for_support_staff: Preference can also be given to Catholic applicants for support staff roles where there is a genuine occupational requirement. In requesting the information below it is not our intention to deter applicants.
           non_catholics_apply: Applicants from all faiths and none are welcome to apply.
+        religious_information:
+          heading: Religious information
         catholic_following_religion:
           heading: Religious information
         non_catholic_following_religion:

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -178,6 +178,10 @@ FactoryBot.define do
       end
     end
 
+    trait :catholic do
+      religion_type { :catholic }
+    end
+
     trait :external do
       enable_job_applications { false }
       about_school { Faker::Lorem.paragraph(sentence_count: factory_rand(5..10)) }

--- a/spec/views/publishers/vacancies/job_applications/show.html.slim_spec.rb
+++ b/spec/views/publishers/vacancies/job_applications/show.html.slim_spec.rb
@@ -1,12 +1,12 @@
 require "rails_helper"
 
 RSpec.describe "publishers/vacancies/job_applications/show" do
-  let(:vacancy) do
-    build_stubbed(:vacancy, :expired, organisations: build_stubbed_list(:school, 1),
-                                      job_applications:
-                                  build_stubbed_list(:job_application, 1, :status_submitted,
-                                                     training_and_cpds: build_stubbed_list(:training_and_cpd, 1),
-                                                     working_patterns: %w[full_time part_time]))
+  let(:vacancy) { build_stubbed(:vacancy, :expired, organisations:, job_applications:) }
+  let(:organisations) { build_stubbed_list(:school, 1) }
+  let(:job_applications) do
+    build_stubbed_list(:job_application, 1, :status_submitted,
+                       training_and_cpds: build_stubbed_list(:training_and_cpd, 1),
+                       working_patterns: %w[full_time part_time])
   end
   let(:job_application) do
     vacancy.job_applications.first
@@ -18,6 +18,32 @@ RSpec.describe "publishers/vacancies/job_applications/show" do
     assign :notes_form, Publishers::JobApplication::NotesForm.new
 
     render
+  end
+
+  describe "navigation quick links" do
+    context "when non religious vacancy" do
+      let(:vacancy) { build_stubbed(:vacancy, :expired, organisations:, job_applications:) }
+
+      it "renders no religious informaiton quick link" do
+        expect(rendered).to have_no_css(".navigation-list-component__anchors .govuk-link[href=\"#following_religion\"]", text: "Religious information")
+      end
+
+      it "renders no religious information section" do
+        expect(rendered).to have_no_css(".govuk-summary-card__title", text: "Religious information")
+      end
+    end
+
+    context "when religious vacancy" do
+      let(:vacancy) { build_stubbed(:vacancy, :catholic, :expired, organisations:, job_applications:) }
+
+      it "renders religious informaiton quick link" do
+        expect(rendered).to have_css(".navigation-list-component__anchors .govuk-link[href=\"#following_religion\"]", text: "Religious information")
+      end
+
+      it "renders a religious information section" do
+        expect(rendered).to have_css(".govuk-summary-card__title", text: "Religious information")
+      end
+    end
   end
 
   it "allows hiring staff to view the jobseekers personal details on the job application" do


### PR DESCRIPTION
-------

## Trello card URL
[1934](https://trello.com/c/xdytNJMq)

## Changes in this PR:

- add missing religion information quick link on publisher vacancy job application show page

## Screenshots of UI changes:

### Before

### After