### PR TITLE
References and self disclosures email content

### DIFF
--- a/app/controllers/jobseekers/job_applications/self_disclosure_controller.rb
+++ b/app/controllers/jobseekers/job_applications/self_disclosure_controller.rb
@@ -21,7 +21,7 @@ class Jobseekers::JobApplications::SelfDisclosureController < Jobseekers::BaseCo
     if @form.valid?
       @form.save_model!
       if next_step == Wicked::FINISH_STEP
-        self_disclosure.self_disclosure_request.received!
+        self_disclosure.mark_as_received
         redirect_to finish_wizard_path
       else
         redirect_to next_wizard_path

--- a/app/controllers/publishers/notifications_controller.rb
+++ b/app/controllers/publishers/notifications_controller.rb
@@ -1,22 +1,23 @@
 class Publishers::NotificationsController < Publishers::BaseController
   NOTIFICATIONS_PER_PAGE = 30
 
+  before_action :load_notifications
   after_action :mark_notifications_as_read
 
   def index
-    @unread_count = notifications.unread.count
-    @pagy, @notifications = pagy(notifications, items: NOTIFICATIONS_PER_PAGE)
+    @unread_count = @raw_notifications.unread.count
+    @pagy, @notifications = pagy(@raw_notifications, items: NOTIFICATIONS_PER_PAGE)
   end
 
   private
 
-  def notifications
-    @notifications ||= current_publisher.notifications
+  def load_notifications
+    @raw_notifications = current_publisher.notifications
                                         .where("created_at >= ?", Time.current - DATA_ACCESS_PERIOD_FOR_PUBLISHERS)
-                                        .order(created_at: :desc)
+                                        .newest_first
   end
 
   def mark_notifications_as_read
-    notifications.mark_as_read
+    @notifications.mark_as_read
   end
 end

--- a/app/controllers/referees/build_references_controller.rb
+++ b/app/controllers/referees/build_references_controller.rb
@@ -19,6 +19,7 @@ module Referees
     }.freeze
 
     steps(*FORMS.keys)
+
     def show
       if step != Wicked::FINISH_STEP
         if @reference.can_give_reference?
@@ -35,7 +36,7 @@ module Referees
                                    .permit(*(form_class.fields + [:token])))
       if @form.valid?
         @reference.update!(@form.params_to_save)
-        @reference_request.update!(status: :received) if step == steps.last
+        @reference.mark_as_received if step == steps.last
 
         redirect_to next_wizard_path(token: token)
       else

--- a/app/mailers/jobseekers/job_application_mailer.rb
+++ b/app/mailers/jobseekers/job_application_mailer.rb
@@ -20,6 +20,6 @@ class Jobseekers::JobApplicationMailer < Jobseekers::BaseMailer
     @vacancy = @job_application.vacancy
     @organisation_name = @vacancy.organisation_name
 
-    send_email(to: job_application.email_address, subject: t(".subject"))
+    send_email(to: job_application.email_address, subject: t(".subject", job_title: @vacancy.job_title))
   end
 end

--- a/app/mailers/publishers/collect_references_mailer.rb
+++ b/app/mailers/publishers/collect_references_mailer.rb
@@ -4,19 +4,38 @@ module Publishers
   class CollectReferencesMailer < BaseMailer
     def collect_references(reference_request)
       @reference_request = reference_request
-      job_application = reference_request.referee.job_application
-      send_email(to: reference_request.referee.email, subject: t(".subject", name: job_application.name,
-                                                                             job_title: job_application.vacancy.job_title,
-                                                                             organisation_name: job_application.vacancy.organisation_name))
+      @job_application = reference_request.referee.job_application
+      send_email(to: reference_request.referee.email, subject: t(".subject", name: @job_application.name,
+                                                                             job_title: @job_application.vacancy.job_title,
+                                                                             organisation_name: @job_application.vacancy.organisation_name))
     end
 
     def inform_applicant_about_references(job_application)
-      @name = job_application.name
+      @job_application = job_application
       @job_title = job_application.vacancy.job_title
       @organisation_name = job_application.vacancy.organisation_name
       send_email(to: job_application.email_address, subject: t(".subject",
                                                                job_title: @job_title,
                                                                organisation_name: @organisation_name))
+    end
+
+    def declaration_received(job_application)
+      @job_application = job_application
+
+      send_email(to: job_application.vacancy.publisher.email,
+                 subject: t(".subject", organisation_name: job_application.vacancy.organisation.name,
+                                        job_title: job_application.vacancy.job_title))
+    end
+
+    def reference_received(reference_request)
+      @reference_request = reference_request
+      @job_application = reference_request.referee.job_application
+
+      send_email(to: @job_application.vacancy.publisher.email,
+                 subject: t(".subject",
+                            organisation_name: @job_application.vacancy.organisation.name,
+                            candidate_name: @job_application.name,
+                            job_title: @job_application.vacancy.job_title))
     end
   end
 end

--- a/app/mailers/publishers/collect_references_mailer.rb
+++ b/app/mailers/publishers/collect_references_mailer.rb
@@ -5,9 +5,10 @@ module Publishers
     def collect_references(reference_request)
       @reference_request = reference_request
       @job_application = reference_request.referee.job_application
-      send_email(to: reference_request.referee.email, subject: t(".subject", name: @job_application.name,
-                                                                             job_title: @job_application.vacancy.job_title,
-                                                                             organisation_name: @job_application.vacancy.organisation_name))
+      send_email(to: reference_request.referee.email,
+                 subject: t(".subject", name: @job_application.name,
+                                        job_title: @job_application.vacancy.job_title,
+                                        organisation_name: @job_application.vacancy.organisation_name))
     end
 
     def inform_applicant_about_references(job_application)

--- a/app/mailers/publishers/job_application_mailer.rb
+++ b/app/mailers/publishers/job_application_mailer.rb
@@ -2,15 +2,13 @@ class Publishers::JobApplicationMailer < Publishers::BaseMailer
   helper VacanciesHelper
 
   def applications_received(publisher:)
-    @template = template
     @publisher = publisher
     @vacancies = publisher.vacancies_with_job_applications_submitted_yesterday
-    @to = publisher.email
 
     @job_applications_count = @vacancies.sum { |vacancy| vacancy.job_applications.submitted_yesterday.count }
     @subject = I18n.t("publishers.job_application_mailer.applications_received.subject", count: @job_applications_count)
 
-    view_mail(@template, to: @to, subject: @subject)
+    send_email(to: publisher.email, subject: @subject)
   end
 
   private

--- a/app/models/job_reference.rb
+++ b/app/models/job_reference.rb
@@ -29,4 +29,9 @@ class JobReference < ApplicationRecord
   has_encrypted :reason_for_leaving
   has_encrypted :would_reemploy_current_reason
   has_encrypted :would_reemploy_any_reason
+
+  def mark_as_received
+    referee.reference_request.update!(status: :received)
+    Publishers::ReferenceReceivedNotifier.with(record: self).deliver
+  end
 end

--- a/app/models/self_disclosure.rb
+++ b/app/models/self_disclosure.rb
@@ -30,7 +30,7 @@ class SelfDisclosure < ApplicationRecord
 
   def mark_as_received
     self_disclosure_request.received!
-    Publishers::SelfDeclarationReceivedNotifier.with(record: self)
+    Publishers::SelfDisclosureReceivedNotifier.with(record: self)
                                                .deliver
   end
 end

--- a/app/models/self_disclosure.rb
+++ b/app/models/self_disclosure.rb
@@ -27,4 +27,10 @@ class SelfDisclosure < ApplicationRecord
     save!
     itself
   end
+
+  def mark_as_received
+    self_disclosure_request.received!
+    Publishers::SelfDeclarationReceivedNotifier.with(record: self)
+                                               .deliver
+  end
 end

--- a/app/notifiers/application_notifier.rb
+++ b/app/notifiers/application_notifier.rb
@@ -1,0 +1,2 @@
+class ApplicationNotifier < Noticed::Event
+end

--- a/app/notifiers/publishers/job_application_received_notifier.rb
+++ b/app/notifiers/publishers/job_application_received_notifier.rb
@@ -1,5 +1,4 @@
 class Publishers::JobApplicationReceivedNotifier < Noticed::Event
-  delegate :created_at, to: :record
   required_param :vacancy, :job_application
 
   notification_methods do

--- a/app/notifiers/publishers/reference_received_notifier.rb
+++ b/app/notifiers/publishers/reference_received_notifier.rb
@@ -1,0 +1,43 @@
+class Publishers::ReferenceReceivedNotifier < ApplicationNotifier
+  recipients do
+    record.referee.job_application.vacancy.publisher
+  end
+
+  deliver_by :email do |config|
+    config.mailer = "Publishers::CollectReferencesMailer"
+    config.method = "reference_received"
+    config.args = :reference_request
+  end
+
+  notification_methods do
+    def message
+      t("notifications.publishers/reference_received_notification.message_html", link: reference_link)
+    end
+
+    include DatesHelper
+    include ActionView::Helpers::UrlHelper
+    include GovukLinkHelper
+    include GovukVisuallyHiddenHelper
+
+    def timestamp
+      "#{day(created_at)} at #{format_time(created_at)}"
+    end
+
+    private
+
+    def reference_link
+      govuk_link_to t("notifications.publishers/reference_received_notification.reference_received"),
+                    organisation_job_job_application_reference_request_path(job_application.vacancy.id, job_application.id, event.record.referee.reference_request),
+                    class: "govuk-link--no-visited-state"
+    end
+
+    def job_application
+      record.referee.job_application
+    end
+  end
+
+  # this gets passed the notification as a a parameter 'just in case'
+  def reference_request(*)
+    record.referee.reference_request
+  end
+end

--- a/app/notifiers/publishers/self_declaration_received_notifier.rb
+++ b/app/notifiers/publishers/self_declaration_received_notifier.rb
@@ -1,0 +1,42 @@
+class Publishers::SelfDeclarationReceivedNotifier < ApplicationNotifier
+  recipients do
+    record.self_disclosure_request.job_application.vacancy.publisher
+  end
+
+  deliver_by :email do |config|
+    config.mailer = "Publishers::CollectReferencesMailer"
+    config.method = "declaration_received"
+    config.args = :job_application
+  end
+
+  notification_methods do
+    def message
+      t("notifications.publishers/self_declaration_received_notification.message_html", link: disclosure_link)
+    end
+    include DatesHelper
+    include ActionView::Helpers::UrlHelper
+    include GovukLinkHelper
+    include GovukVisuallyHiddenHelper
+
+    def timestamp
+      "#{day(created_at)} at #{format_time(created_at)}"
+    end
+
+    private
+
+    def disclosure_link
+      govuk_link_to t("notifications.publishers/self_declaration_received_notification.disclosure_received"),
+                    organisation_job_job_application_self_disclosure_path(job_application.vacancy.id, job_application.id),
+                    class: "govuk-link--no-visited-state"
+    end
+
+    def job_application
+      record.self_disclosure_request.job_application
+    end
+  end
+
+  # this gets passed the notification as a a parameter 'just in case'
+  def job_application(*)
+    record.self_disclosure_request.job_application
+  end
+end

--- a/app/notifiers/publishers/self_disclosure_received_notifier.rb
+++ b/app/notifiers/publishers/self_disclosure_received_notifier.rb
@@ -1,4 +1,4 @@
-class Publishers::SelfDeclarationReceivedNotifier < ApplicationNotifier
+class Publishers::SelfDisclosureReceivedNotifier < ApplicationNotifier
   recipients do
     record.self_disclosure_request.job_application.vacancy.publisher
   end

--- a/app/views/jobseekers/job_application_mailer/declarations.text.erb
+++ b/app/views/jobseekers/job_application_mailer/declarations.text.erb
@@ -1,4 +1,4 @@
-<%= t(".dear", name: @job_application.first_name) %>
+<%= t(".dear", name: @job_application.name) %>
 
 <%= t(".body",
       school_name: @organisation_name,

--- a/app/views/jobseekers/job_application_mailer/declarations.text.erb
+++ b/app/views/jobseekers/job_application_mailer/declarations.text.erb
@@ -1,3 +1,6 @@
 <%= t(".dear", name: @job_application.first_name) %>
 
-<%= t(".self_disclosure_info", link: notify_link(jobseekers_job_application_self_disclosure_url(@job_application, Wicked::FIRST_STEP), t(".self_disclosure_form"))) %>
+<%= t(".body",
+      school_name: @organisation_name,
+      job_title: @vacancy.job_title,
+      link: notify_link(jobseekers_job_application_self_disclosure_url(@job_application, Wicked::FIRST_STEP), t(".self_disclosure_form"))) %>

--- a/app/views/publishers/collect_references_mailer/collect_references.text.erb
+++ b/app/views/publishers/collect_references_mailer/collect_references.text.erb
@@ -1,8 +1,11 @@
-# <%= t(".title", name: @reference_request.referee.job_application.name) %>
+# <%= t(".title", name: @reference_request.referee.name) %>
 
 <%=
   # Wicked::Wizard redirects to first step w/o any parameters so we have to mention first step here explcitly
-  notify_link(reference_build_url(@reference_request.id, 'can_give', token: @reference_request.token), t(".submit_reference"))
+  t(".body", job_title: @job_application.vacancy.job_title, organisation_name: @job_application.vacancy.organisation.name,
+    candidate_name: @job_application.name, school_email: @job_application.vacancy.application_email,
+      link: notify_link(reference_build_url(@reference_request.id, 'can_give', token: @reference_request.token), t(".submit_reference")) )
 %>
+
 
 <%= t("shared.footer", home_page_link: home_page_link) %>

--- a/app/views/publishers/collect_references_mailer/collect_references.text.erb
+++ b/app/views/publishers/collect_references_mailer/collect_references.text.erb
@@ -3,7 +3,7 @@
 <%=
   # Wicked::Wizard redirects to first step w/o any parameters so we have to mention first step here explcitly
   t(".body", job_title: @job_application.vacancy.job_title, organisation_name: @job_application.vacancy.organisation.name,
-    candidate_name: @job_application.name, school_email: @job_application.vacancy.application_email,
+    candidate_name: @job_application.name, school_email: @job_application.vacancy.contact_email,
       link: notify_link(reference_build_url(@reference_request.id, 'can_give', token: @reference_request.token), t(".submit_reference")) )
 %>
 

--- a/app/views/publishers/collect_references_mailer/declaration_received.text.erb
+++ b/app/views/publishers/collect_references_mailer/declaration_received.text.erb
@@ -1,0 +1,7 @@
+# <%= t(".title", name: @job_application.vacancy.publisher.papertrail_display_name) %>
+
+<%= t(".body", job_title: @job_application.vacancy.job_title, organisation_name: @job_application.vacancy.organisation.name,
+      candidate_name: @job_application.name,
+      link: notify_link(organisation_job_job_application_self_disclosure_url(@job_application.vacancy.id, @job_application), t(".sign_in")) ) %>
+
+<%= t("shared.footer", home_page_link: home_page_link) %>

--- a/app/views/publishers/collect_references_mailer/inform_applicant_about_references.text.erb
+++ b/app/views/publishers/collect_references_mailer/inform_applicant_about_references.text.erb
@@ -1,5 +1,6 @@
-# <%= t(".title", name: @name) %>
+# <%= t(".title", name: @job_application.name) %>
 
-<%= t(".collection", job_title: @job_title, organisation_name: @organisation_name) %>
+<%= t(".body", job_title: @job_title, organisation_name: @organisation_name,
+      link: notify_link(jobseekers_job_application_url(@job_application, anchor: 'referees'), t(".sign_in")) ) %>
 
 <%= t("shared.footer", home_page_link: home_page_link) %>

--- a/app/views/publishers/collect_references_mailer/reference_received.text.erb
+++ b/app/views/publishers/collect_references_mailer/reference_received.text.erb
@@ -1,0 +1,8 @@
+# <%= t(".title", name: @job_application.vacancy.publisher.papertrail_display_name) %>
+
+<%= t(".body", job_title: @job_application.vacancy.job_title,
+      organisation_name: @job_application.vacancy.organisation.name,
+      candidate_name: @job_application.name,
+      link: notify_link(organisation_job_job_application_reference_request_url(@job_application.vacancy.id, @job_application, @reference_request), t(".sign_in")) ) %>
+
+<%= t("shared.footer", home_page_link: home_page_link) %>

--- a/config/analytics_custom_events.yml
+++ b/config/analytics_custom_events.yml
@@ -30,9 +30,11 @@ shared:
   - publisher_notify
   - publisher_applications_received
   - publisher_collect_references
+  - publisher_declaration_received
   - publisher_inform_applicant_about_references
   - publisher_invite_to_apply
   - publisher_job_application_data_expiry
+  - publisher_reference_received
   - publisher_prompt_for_feedback
   - publisher_sign_in_fallback
   - publisher_vacancy_relisted

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -99,15 +99,6 @@ en:
         search:
           intro: Search and apply for more teaching jobs on Teaching Vacancies
           link_text: Go to Teaching Vacancies
-      application_shortlisted:
-        <<: *job_application_mailer_shared
-        heading: You have been shortlisted for %{job_title} at %{organisation_name}
-        instructions: What happens next
-        subject: Your job application has been shortlisted
-        read_advice_from: "Read advice from experienced teachers and school leaders on preparing for your:"
-        teaching_job_interview: "teaching job interview"
-        teaching_interview_lesson: "teaching interview lesson"
-        guidance: "- %{link}"
       application_submitted:
         <<: *job_application_mailer_shared
         heading: Your application has been sent to %{organisation_name}
@@ -122,18 +113,20 @@ en:
         teaching_job_interview: "teaching job interview"
         teaching_interview_lesson: "teaching interview lesson"
         guidance: "- %{link}"
-      application_unsuccessful:
-        <<: *job_application_mailer_shared
-        feedback: Feedback from the school
-        heading: Unfortunately your application was not successful this time
-        advice: To improve your application for next time, read advice from experienced teachers and school leaders on %{link}.
-        application_advice_link_text: writing a great application
-        subject: Your job application has been unsuccessful
       declarations:
-        subject: Declarations
+        subject: Complete your self-disclosure form for %{job_title}
         dear: Dear %{name}
-        self_disclosure_form: self-disclosure form
-        self_disclosure_info: "Your are required to complete your %{link} before attending your interview."
+        self_disclosure_form: Teaching Vacancies account
+        body: |
+          %{school_name} has requested that you complete your self-disclosure form as part of your application for %{job_title}.
+
+          Sign in to your %{link} to complete your self-disclosure form.
+
+          If you are having issues completing the form, email [teaching.vacancies@education.gov.uk](mailto:teaching.vacancies@education.gov.uk).
+
+          Kind regards,
+
+          Teaching Vacancies team
       job_listing_ended_early:
         body: |
           Unfortunately, %{organisation_name} has ended the job listing early and you can no longer apply for the role.
@@ -242,13 +235,51 @@ en:
       feedback_link_text: Tell us how you filled your vacancy.
     collect_references_mailer:
       collect_references:
-        subject: Supply a reference for %{name} for role %{job_title} at %{organisation_name}
-        title: Supply a reference for %{name}
-        submit_reference: Submit reference
+        subject: Provide a reference for %{name} for role %{job_title} at %{organisation_name}
+        title: Dear %{name}
+        submit_reference: reference request form
+        body: |
+          You have been provided as a referee by %{candidate_name} for the %{job_title} at %{organisation_name}.
+
+          Complete this %{link} to provide a reference. You can decline to provide a reference.
+
+          If you cannot complete the above reference form using the link provided, contact %{school_email}.
+
+          Kind regards,
+          Teaching Vacancies team
       inform_applicant_about_references:
         subject: References are being collected for role %{job_title} at %{organisation_name}
+        sign_in: sign in to your Teaching vacancies account
         title: Dear %{name}
-        collection: References are being collected for role %{job_title} at %{organisation_name}
+        body: |
+          %{organisation_name} will be collecting your references for %{job_title} at %{organisation_name}.
+
+          If you need to review what referees you provided for this application, %{link}.
+
+          Kind regards,
+          Teaching Vacancies team
+      declaration_received:
+        subject: You have received a declaration form for %{job_title} at %{organisation_name}
+        title: Dear %{name}
+        sign_in: Teaching Vacancies account
+        body: |
+          You have received a declaration form from %{candidate_name} for %{job_title} at %{organisation_name}.
+
+          You can review the declaration form by signing in to your %{link}.
+
+          Kind regards,
+          Teaching Vacancies team
+      reference_received:
+        subject: You have received a reference from %{candidate_name} for %{job_title} at %{organisation_name}
+        title: Dear %{name}
+        sign_in: Teaching Vacancies account
+        body: |
+          You have received a reference for %{candidate_name} for %{job_title} at %{organisation_name}.
+
+          Sign in to your %{link} to view the reference provided.
+
+          Kind regards,
+          Teaching Vacancies team
   support_users:
     authentication_fallback_mailer:
       sign_in_fallback:

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -118,7 +118,7 @@ en:
         dear: Dear %{name}
         self_disclosure_form: Teaching Vacancies account
         body: |
-          %{school_name} has requested that you complete your self-disclosure form as part of your application for %{job_title}.
+          %{school_name} has requested that you complete your self-disclosure form as part of your application for %{job_title} at %{school_name}.
 
           Sign in to your %{link} to complete your self-disclosure form.
 
@@ -203,10 +203,10 @@ en:
         subject: Changes to using your own application form on Teaching Vacancies
         dear: "Dear %{name},"
         content: |
-          We’re writing to let you know about a change to how using your own application form for hiring staff works on the Teaching Vacancies service. 
-          From now on, if you upload your own application form for a job listing, applicants will download, complete and then upload the finished form to Teaching Vacancies. This means you’ll need to sign in to Teaching Vacancies to review applications, rather than receiving them directly from applicants by email. 
-          You will receive one email daily from Teaching Vacancies which includes a summary of any applications submitted in the last 24 hours. 
-          Any live job listings you currently have on Teaching Vacancies will not be affected by this change. 
+          We’re writing to let you know about a change to how using your own application form for hiring staff works on the Teaching Vacancies service.
+          From now on, if you upload your own application form for a job listing, applicants will download, complete and then upload the finished form to Teaching Vacancies. This means you’ll need to sign in to Teaching Vacancies to review applications, rather than receiving them directly from applicants by email.
+          You will receive one email daily from Teaching Vacancies which includes a summary of any applications submitted in the last 24 hours.
+          Any live job listings you currently have on Teaching Vacancies will not be affected by this change.
         footer: |
           If you have any questions about this process, please contact %{link}
           Kind regards,

--- a/config/locales/notifications.yml
+++ b/config/locales/notifications.yml
@@ -39,6 +39,12 @@ en:
       message_html: You have received %{link} for %{job_title} at %{organisation}
     publishers/job_application_data_expiry_notification:
       message_html: You will have access to candidates' applications for %{link} until %{date}
+    publishers/self_declaration_received_notification:
+      message_html: You have received a %{link}
+      disclosure_received: self disclosure form
+    publishers/reference_received_notification:
+      message_html: You have received a %{link}
+      reference_received: reference for a candidate
 
   errors:
     jobs:

--- a/spec/mailers/jobseekers/job_application_mailer_spec.rb
+++ b/spec/mailers/jobseekers/job_application_mailer_spec.rb
@@ -2,9 +2,10 @@ require "rails_helper"
 require "dfe/analytics/rspec/matchers"
 
 RSpec.describe Jobseekers::JobApplicationMailer do
+  let(:job_title) { Faker::Job.title }
   let(:jobseeker) { create(:jobseeker) }
   let(:organisation) { build(:school) }
-  let(:vacancy) { build(:vacancy, organisations: [organisation]) }
+  let(:vacancy) { build(:vacancy, organisations: [organisation], job_title: job_title) }
   let(:contact_email) { vacancy.contact_email }
 
   let(:expected_data) do
@@ -59,7 +60,7 @@ RSpec.describe Jobseekers::JobApplicationMailer do
     let(:self_disclosure_link) { jobseekers_job_application_self_disclosure_url(job_application, Wicked::FIRST_STEP) }
 
     it "sends a `declarations` email" do
-      expect(mail.subject).to eq("Declarations")
+      expect(mail.subject).to eq("Complete your self-disclosure form for #{job_title}")
       expect(mail.to).to eq([job_application.email_address])
       expect(mail.body).to include(self_disclosure_link)
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -57,8 +57,6 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
 
   config.before do
-    ActiveJob::Base.queue_adapter = :test
-
     allow(Google::Cloud::Bigquery).to receive(:new).and_return(
       double("BigQuery", dataset: double("BigQuery dataset", table: double.as_null_object)),
     )
@@ -75,6 +73,12 @@ RSpec.configure do |config|
     ENV["ENABLE_DFE_ANALYTICS"] = "true"
     example.run
     ENV.delete "ENABLE_DFE_ANALYTICS"
+  end
+
+  config.around(:each, :perform_enqueued) do |example|
+    perform_enqueued_jobs do
+      example.run
+    end
   end
 
   config.before(:each, type: :system) do

--- a/spec/system/publishers/publishers_can_manage_self_disclosure_spec.rb
+++ b/spec/system/publishers/publishers_can_manage_self_disclosure_spec.rb
@@ -3,9 +3,9 @@ require "rails_helper"
 RSpec.describe "Publishers manage self disclosure" do
   include ActiveJob::TestHelper
 
-  let(:publisher) { create(:publisher) }
+  let(:publisher) { create(:publisher, email: "publisher@contoso.com") }
   let(:organisation) { create(:school) }
-  let(:vacancy) { create(:vacancy, :expired, organisations: [organisation]) }
+  let(:vacancy) { create(:vacancy, :expired, organisations: [organisation], publisher: publisher) }
   let(:jobseeker) { create(:jobseeker) }
   let(:job_application) { create(:job_application, :status_submitted, vacancy: vacancy, jobseeker: jobseeker) }
 
@@ -42,42 +42,43 @@ RSpec.describe "Publishers manage self disclosure" do
     end
 
     describe "visit self disclosure form" do
-      let(:request) { create(:self_disclosure_request, job_application_id: job_application.id) }
-      let(:form) { create(:self_disclosure, self_disclosure_request_id: request.id) }
+      let(:request) { create(:self_disclosure_request, job_application: job_application) }
 
       before do
+        create(:self_disclosure, self_disclosure_request: request)
         request.sent!
-        form
       end
 
-      context "when completed by publisher" do
-        it "to manuanlly complete form" do
-          publisher_ats_self_disclosure_page.load(
-            vacancy_id: vacancy.id,
-            job_application_id: job_application.id,
-          )
+      it "can be manually marked as complete by publisher" do
+        publisher_ats_self_disclosure_page.load(
+          vacancy_id: vacancy.id,
+          job_application_id: job_application.id,
+        )
 
-          expect(publisher_ats_self_disclosure_page.status.text).to eq("Pending")
-          expect(publisher_ats_self_disclosure_page.button.text).to eq("Manually mark as complete")
-          expect(publisher_ats_self_disclosure_page).not_to have_goto_references_and_declaration_form
+        expect(publisher_ats_self_disclosure_page.status.text).to eq("Pending")
+        expect(publisher_ats_self_disclosure_page.button.text).to eq("Manually mark as complete")
+        expect(publisher_ats_self_disclosure_page).not_to have_goto_references_and_declaration_form
 
-          publisher_ats_self_disclosure_page.button.click
+        publisher_ats_self_disclosure_page.button.click
 
-          expect(publisher_ats_self_disclosure_page.banner_title.text).to eq("Success")
-          expect(publisher_ats_self_disclosure_page.status.text).to eq("Completed")
-        end
+        expect(publisher_ats_self_disclosure_page.banner_title.text).to eq("Success")
+        expect(publisher_ats_self_disclosure_page.status.text).to eq("Completed")
       end
 
       context "when completed by jobseeker" do
-        let(:request) { create(:self_disclosure_request, job_application_id: job_application.id) }
-
         before do
-          request.sent!
-          request.received!
-          form
+          request.self_disclosure.mark_as_received
+          # trigger notifications
+          perform_enqueued_jobs
+          perform_enqueued_jobs
         end
 
-        it "show form" do
+        it "send an email notification to the publisher that the disclosure had been received" do
+          expect(ActionMailer::Base.deliveries.map(&:to).flatten)
+            .to contain_exactly("publisher@contoso.com")
+        end
+
+        it "shows the form" do
           publisher_ats_self_disclosure_page.load(
             vacancy_id: vacancy.id,
             job_application_id: job_application.id,

--- a/spec/system/publishers/publishers_can_manage_self_disclosure_spec.rb
+++ b/spec/system/publishers/publishers_can_manage_self_disclosure_spec.rb
@@ -26,11 +26,8 @@ RSpec.describe "Publishers manage self disclosure" do
       choose "Yes"
     end
 
-    it "sends the notification email" do
+    it "sends the notification email", :perform_enqueued do
       click_on("Save and continue")
-      expect {
-        perform_enqueued_jobs
-      }.to change(ActionMailer::Base.deliveries, :count).by(2)
       expect(ActionMailer::Base.deliveries.map(&:to).flatten).to contain_exactly(job_application.email_address, job_application.email_address)
     end
 
@@ -65,12 +62,9 @@ RSpec.describe "Publishers manage self disclosure" do
         expect(publisher_ats_self_disclosure_page.status.text).to eq("Completed")
       end
 
-      context "when completed by jobseeker" do
+      context "when completed by jobseeker", :perform_enqueued do
         before do
           request.self_disclosure.mark_as_received
-          # trigger notifications
-          perform_enqueued_jobs
-          perform_enqueued_jobs
         end
 
         it "send an email notification to the publisher that the disclosure had been received" do

--- a/spec/system/publishers/publishers_can_view_their_notifications_spec.rb
+++ b/spec/system/publishers/publishers_can_view_their_notifications_spec.rb
@@ -47,8 +47,7 @@ RSpec.describe "Publishers can view their notifications" do
 
           disc_ref = create(:self_disclosure_request, job_application: application)
           self_disc = create(:self_disclosure, self_disclosure_request: disc_ref)
-          Publishers::SelfDeclarationReceivedNotifier.with(record: self_disc,
-                                                           job_application: application)
+          Publishers::SelfDisclosureReceivedNotifier.with(record: self_disc)
                                                      .deliver
         end
       end

--- a/spec/system/publishers/publishers_can_view_their_notifications_spec.rb
+++ b/spec/system/publishers/publishers_can_view_their_notifications_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "Publishers can view their notifications" do
+  include ActiveJob::TestHelper
+
   let(:publisher) { create(:publisher) }
   let(:organisation) { create(:school) }
   let(:vacancy) { create(:vacancy, :published, organisations: [organisation], publisher: publisher) }
@@ -10,10 +12,12 @@ RSpec.describe "Publishers can view their notifications" do
 
   after { logout }
 
-  context "when the notification was created outside the data access period" do
+  context "when the notification was created outside the data access period", :js do
     before do
-      Publishers::JobApplicationReceivedNotifier.with(vacancy: vacancy, job_application: job_application).deliver(vacancy.publisher)
-      publisher.notifications.first.update(created_at: Time.now - 2.years)
+      travel_to 2.years.ago do
+        Publishers::JobApplicationReceivedNotifier.with(vacancy: vacancy, job_application: job_application).deliver(vacancy.publisher)
+      end
+      publisher.notifications.each { |n| n.update!(created_at: n.event.created_at) }
       visit publishers_notifications_path
     end
 
@@ -22,37 +26,58 @@ RSpec.describe "Publishers can view their notifications" do
     end
   end
 
-  context "when paginating" do
-    let(:job_application2) { create(:job_application, :status_submitted, vacancy: vacancy, created_at: 1.minute.ago) }
-
+  context "when paginating", :versioning do
     before do
-      stub_const("Publishers::NotificationsController::NOTIFICATIONS_PER_PAGE", 1)
-      Publishers::JobApplicationReceivedNotifier.with(vacancy: vacancy, job_application: job_application).deliver(vacancy.publisher)
-      Publishers::JobApplicationReceivedNotifier.with(vacancy: vacancy, job_application: job_application2).deliver(vacancy.publisher)
+      stub_const("Publishers::NotificationsController::NOTIFICATIONS_PER_PAGE", 2)
+
+      [3, 2, 1].each do |delay|
+        travel_to delay.days.ago do
+          v = create(:vacancy, :published, organisations: [organisation], publisher: publisher, job_title: "#{delay} ago")
+          application = create(:job_application, :status_submitted, vacancy: v, create_details: true)
+
+          create(:reference_request, referee: application.referees.first)
+          job_reference = create(:job_reference, :reference_given, referee: application.referees.first)
+
+          Publishers::ReferenceReceivedNotifier.with(record: job_reference)
+                                               .deliver
+        end
+        travel_to (delay.days + 1.hour).ago do
+          v = create(:vacancy, :published, organisations: [organisation], publisher: publisher, job_title: "#{delay} ago")
+          application = create(:job_application, :status_submitted, vacancy: v, create_details: true)
+
+          disc_ref = create(:self_disclosure_request, job_application: application)
+          self_disc = create(:self_disclosure, self_disclosure_request: disc_ref)
+          Publishers::SelfDeclarationReceivedNotifier.with(record: self_disc,
+                                                           job_application: application)
+                                                     .deliver
+        end
+      end
+
+      # notifications are created with insert_all, which uses the DB timestamp
+      # and hence isn't changed by the travel_to block
+      publisher.notifications.each { |n| n.update!(created_at: n.event.created_at) }
+
       visit root_path
+      click_on strip_tags(I18n.t("nav.notifications_html", count: 6))
     end
 
     it "clicks notifications link, renders the notifications, paginates, and marks as read" do
-      click_on strip_tags(I18n.t("nav.notifications_html", count: 2))
-
-      within ".notification" do
-        expect(page).to have_css("div", class: "notification__tag", text: "new", count: 1)
+      within "#notifications-results" do
+        expect(page).to have_css("div", class: "notification__tag", text: "new", count: 2)
       end
 
       click_on "Next"
       # wait for page load
       find(".govuk-pagination__prev", wait: 10)
 
-      within ".notification" do
-        expect(page).to have_css("div", class: "notification__tag", text: "new", count: 1)
+      within "#notifications-results" do
+        expect(page).to have_css("div", class: "notification__tag", text: "new", count: 2)
       end
 
       click_on "Previous"
-      # wait for page load
-      find(".govuk-pagination__next")
 
-      within ".notification" do
-        expect(page).not_to have_css("div", class: "notification__tag", text: "new", count: 1)
+      within "#notifications-results" do
+        expect(page).not_to have_css("div", class: "notification__tag", text: "new", count: 2)
       end
     end
   end


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/QJNdkOy4/1949-update-emails-for-references-and-self-disclosure-flows-branch

## Changes in this PR:

Email content for self disclosure and reference notifications

- Is there anything specific you want feedback on?

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
