### PR TITLE
Current role

### DIFF
--- a/app/models/jobseeker_profile.rb
+++ b/app/models/jobseeker_profile.rb
@@ -135,6 +135,10 @@ class JobseekerProfile < ApplicationRecord
     @unexplained_employment_gaps ||= Jobseekers::JobApplications::EmploymentGapFinder.new(self).significant_gaps
   end
 
+  def current_or_most_recent_employment
+    @current_or_most_recent_employment ||= employments.job.order(started_on: :desc).first
+  end
+
   private
 
   def duplicate_and_save(records)

--- a/app/models/jobseeker_profile.rb
+++ b/app/models/jobseeker_profile.rb
@@ -136,7 +136,7 @@ class JobseekerProfile < ApplicationRecord
   end
 
   def current_or_most_recent_employment
-    @current_or_most_recent_employment ||= employments.job.order(started_on: :desc).first
+    employments.job.find_by(is_current_role: true) || employments.job.order(started_on: :desc).first
   end
 
   private

--- a/app/views/publishers/jobseeker_profiles/_layout.html.slim
+++ b/app/views/publishers/jobseeker_profiles/_layout.html.slim
@@ -7,6 +7,12 @@
 .govuk-grid-row
   .govuk-grid-column-full
     h1.govuk-heading-xl class="govuk-!-margin-bottom-4" = profile.full_name
+    - if (employment = profile.current_or_most_recent_employment).present?
+      p.govuk-body class="govuk-!-margin-bottom-3"
+        - if employment.is_current_role?
+          = employment.job_title
+        - else
+          = t("publishers.jobseeker_profiles.previously_role", job_title: employment.job_title)
     .govuk-button-group data-controller="clipboard" data-clipboard-success-content-value="email address copied"
       = tracked_mail_to(profile.email,
                         target: "_blank",

--- a/app/views/publishers/jobseeker_profiles/_layout.html.slim
+++ b/app/views/publishers/jobseeker_profiles/_layout.html.slim
@@ -8,7 +8,7 @@
   .govuk-grid-column-full
     h1.govuk-heading-xl class="govuk-!-margin-bottom-4" = profile.full_name
     - if (employment = profile.current_or_most_recent_employment).present?
-      p.govuk-body class="govuk-!-margin-bottom-3"
+      span.govuk-caption-l class="govuk-!-margin-bottom-3"
         - if employment.is_current_role?
           = employment.job_title
         - else

--- a/app/views/publishers/jobseeker_profiles/search/_results.html.slim
+++ b/app/views/publishers/jobseeker_profiles/search/_results.html.slim
@@ -6,6 +6,11 @@
         = govuk_link_to jobseeker_profile.full_name, publishers_jobseeker_profile_path(jobseeker_profile)
 
       = govuk_summary_list(actions: false, classes: "govuk-summary-list--no-border search-results__summary-list--compact") do |summary_list|
+        - if (employment = jobseeker_profile.current_or_most_recent_employment).present?
+          - summary_list.with_row do |row|
+            - row.with_key text: employment.is_current_role? ? t("publishers.jobseeker_profiles.current_role") : t("publishers.jobseeker_profiles.latest_role"), classes: "govuk-body-s govuk-!-font-weight-bold govuk-!-padding-bottom-0"
+            - row.with_value text: employment.job_title, classes: "govuk-body-s govuk-!-padding-bottom-0"
+
         - summary_list.with_row do |row|
           - row.with_value text: jobseeker_profile.qts_status, classes: "govuk-body-s govuk-!-padding-bottom-0"
 

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -87,6 +87,9 @@ en:
       preferred_subjects:
         one: Preferred subject
         other: Preferred subjects
+      current_role: "Current role"
+      latest_role: "Latest role"
+      previously_role: "Previously %{job_title}"
       search_result_heading: "Candidate profiles (%{count})"
       sort_result_text: "Ordered by most recently updated."
       filters:

--- a/spec/models/jobseeker_profile_spec.rb
+++ b/spec/models/jobseeker_profile_spec.rb
@@ -151,4 +151,32 @@ RSpec.describe JobseekerProfile, type: :model do
       expect { unrelated_employment.reload }.not_to raise_error
     end
   end
+
+  describe "#current_or_most_recent_employment" do
+    let!(:profile) { create(:jobseeker_profile) }
+
+    context "when there are no employments" do
+      it "returns nil" do
+        expect(profile.current_or_most_recent_employment).to be_nil
+      end
+    end
+
+    context "when there are employments" do
+      let!(:older_employment) { create(:employment, jobseeker_profile: profile, started_on: 2.years.ago, ended_on: 1.year.ago) }
+      let!(:recent_employment) { create(:employment, jobseeker_profile: profile, started_on: 1.year.ago, ended_on: 6.months.ago) }
+
+      it "returns the most recent employment based on started_on date" do
+        expect(profile.current_or_most_recent_employment).to eq(recent_employment)
+      end
+    end
+
+    context "when there are employment breaks" do
+      let!(:employment) { create(:employment, jobseeker_profile: profile, started_on: 1.year.ago, ended_on: 6.months.ago) }
+      let!(:employment_break) { create(:employment, :break, jobseeker_profile: profile, started_on: 6.months.ago, ended_on: 3.months.ago) }
+
+      it "returns only job employments, not breaks" do
+        expect(profile.current_or_most_recent_employment).to eq(employment)
+      end
+    end
+  end
 end

--- a/spec/models/jobseeker_profile_spec.rb
+++ b/spec/models/jobseeker_profile_spec.rb
@@ -162,8 +162,11 @@ RSpec.describe JobseekerProfile, type: :model do
     end
 
     context "when there are employments" do
-      let!(:older_employment) { create(:employment, jobseeker_profile: profile, started_on: 2.years.ago, ended_on: 1.year.ago) }
-      let!(:recent_employment) { create(:employment, jobseeker_profile: profile, started_on: 1.year.ago, ended_on: 6.months.ago) }
+      let!(:recent_employment) { create(:employment, :jobseeker_profile_employment, jobseeker_profile: profile, started_on: 1.year.ago, ended_on: 6.months.ago) }
+
+      before do
+        create(:employment, :jobseeker_profile_employment, jobseeker_profile: profile, started_on: 2.years.ago, ended_on: 1.year.ago)
+      end
 
       it "returns the most recent employment based on started_on date" do
         expect(profile.current_or_most_recent_employment).to eq(recent_employment)
@@ -171,11 +174,26 @@ RSpec.describe JobseekerProfile, type: :model do
     end
 
     context "when there are employment breaks" do
-      let!(:employment) { create(:employment, jobseeker_profile: profile, started_on: 1.year.ago, ended_on: 6.months.ago) }
-      let!(:employment_break) { create(:employment, :break, jobseeker_profile: profile, started_on: 6.months.ago, ended_on: 3.months.ago) }
+      let!(:employment) { create(:employment, :jobseeker_profile_employment, jobseeker_profile: profile, started_on: 1.year.ago, ended_on: 6.months.ago) }
+
+      before do
+        create(:employment, :jobseeker_profile_employment, :break, jobseeker_profile: profile, started_on: 6.months.ago, ended_on: 3.months.ago)
+      end
 
       it "returns only job employments, not breaks" do
         expect(profile.current_or_most_recent_employment).to eq(employment)
+      end
+    end
+
+    context "when there is a current employment" do
+      let!(:current_employment) { create(:employment, :jobseeker_profile_employment, jobseeker_profile: profile, started_on: 6.months.ago, ended_on: nil, is_current_role: true) }
+
+      before do
+        create(:employment, :jobseeker_profile_employment, jobseeker_profile: profile, started_on: 1.month.ago, ended_on: 2.weeks.ago)
+      end
+
+      it "returns the current employment regardless of started_on date" do
+        expect(profile.current_or_most_recent_employment).to eq(current_employment)
       end
     end
   end

--- a/spec/system/publishers/publishers_can_search_for_jobseeker_profiles_spec.rb
+++ b/spec/system/publishers/publishers_can_search_for_jobseeker_profiles_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Publishers searching for Jobseeker profiles", type: :system do
   let!(:jobseeker_profile) { create(:jobseeker_profile, :with_personal_details, qualified_teacher_status: "yes", qualified_teacher_status_year: "2000", job_preferences: job_preferences, employments: [current_employment]) }
   let(:job_preferences) { create(:job_preferences, roles: roles, key_stages: %w[ks1], working_patterns: %w[full_time], locations: [location_preference_containing_school], subjects: ["English"]) }
   let(:location_preference_containing_school) { create(:job_preferences_location, name: "London", radius: 100) }
-  let(:current_employment) { create(:employment, job_title: "Senior Teacher", started_on: 1.year.ago, ended_on: nil, is_current_role: true) }
+  let(:current_employment) { create(:employment, :jobseeker_profile_employment, job_title: "Senior Teacher", started_on: 1.year.ago, ended_on: nil, is_current_role: true) }
 
   let!(:part_time_jobseeker_profile) { create(:jobseeker_profile, :with_personal_details, qualified_teacher_status: "yes", qualified_teacher_status_year: "2000", job_preferences: part_time_job_preferences) }
   let(:part_time_job_preferences) { create(:job_preferences, roles: %w[teacher], key_stages: %w[ks1], working_patterns: %w[part_time], locations: [part_time_preference_containing_school], subjects: ["Physics"]) }
@@ -63,8 +63,10 @@ RSpec.describe "Publishers searching for Jobseeker profiles", type: :system do
 
       # Check that current role is displayed for the jobseeker with employment
       within ".search-results__item", text: jobseeker_profile.full_name do
-        expect(page).to have_content("Current role")
-        expect(page).to have_content(current_employment.job_title)
+        within ".govuk-summary-list__row", text: "Current role" do
+          expect(page).to have_content("Current role")
+          expect(page).to have_content(current_employment.job_title)
+        end
       end
     end
 

--- a/spec/system/publishers/publishers_can_search_for_jobseeker_profiles_spec.rb
+++ b/spec/system/publishers/publishers_can_search_for_jobseeker_profiles_spec.rb
@@ -13,9 +13,10 @@ RSpec.describe "Publishers searching for Jobseeker profiles", type: :system do
         catering_cleaning_and_site_management it_support pastoral_health_and_welfare other_leadership other_support ]
   end
 
-  let!(:jobseeker_profile) { create(:jobseeker_profile, :with_personal_details, qualified_teacher_status: "yes", qualified_teacher_status_year: "2000", job_preferences: job_preferences) }
+  let!(:jobseeker_profile) { create(:jobseeker_profile, :with_personal_details, qualified_teacher_status: "yes", qualified_teacher_status_year: "2000", job_preferences: job_preferences, employments: [current_employment]) }
   let(:job_preferences) { create(:job_preferences, roles: roles, key_stages: %w[ks1], working_patterns: %w[full_time], locations: [location_preference_containing_school], subjects: ["English"]) }
   let(:location_preference_containing_school) { create(:job_preferences_location, name: "London", radius: 100) }
+  let(:current_employment) { create(:employment, job_title: "Senior Teacher", started_on: 1.year.ago, ended_on: nil, is_current_role: true) }
 
   let!(:part_time_jobseeker_profile) { create(:jobseeker_profile, :with_personal_details, qualified_teacher_status: "yes", qualified_teacher_status_year: "2000", job_preferences: part_time_job_preferences) }
   let(:part_time_job_preferences) { create(:job_preferences, roles: %w[teacher], key_stages: %w[ks1], working_patterns: %w[part_time], locations: [part_time_preference_containing_school], subjects: ["Physics"]) }
@@ -58,6 +59,12 @@ RSpec.describe "Publishers searching for Jobseeker profiles", type: :system do
         expect(page).to have_content(jobseeker_profile.job_preferences.key_stages.first.humanize)
         expect(page).to have_content(jobseeker_profile.job_preferences.working_patterns.first.humanize)
         expect(page).to have_content(jobseeker_profile.job_preferences.subjects.first.humanize)
+      end
+
+      # Check that current role is displayed for the jobseeker with employment
+      within ".search-results__item", text: jobseeker_profile.full_name do
+        expect(page).to have_content("Current role")
+        expect(page).to have_content(current_employment.job_title)
       end
     end
 

--- a/spec/views/publishers/jobseeker_profiles/show.html.slim_spec.rb
+++ b/spec/views/publishers/jobseeker_profiles/show.html.slim_spec.rb
@@ -70,8 +70,8 @@ RSpec.describe "publishers/jobseeker_profiles/show" do
   end
 
   context "when jobseeker has a current role" do
-    let(:current_employment) { create(:employment, job_title: "Mathematics Teacher", is_current_role: true, started_on: 1.year.ago, ended_on: nil) }
-    let(:previous_employment) { create(:employment, job_title: "Science Teacher", is_current_role: false, started_on: 3.years.ago, ended_on: 2.years.ago) }
+    let(:current_employment) { create(:employment, :jobseeker_profile_employment, job_title: "Mathematics Teacher", is_current_role: true, started_on: 1.year.ago, ended_on: nil) }
+    let(:previous_employment) { create(:employment, :jobseeker_profile_employment, job_title: "Science Teacher", is_current_role: false, started_on: 3.years.ago, ended_on: 2.years.ago) }
     let(:jobseeker_profile) do
       create(:jobseeker_profile, :with_personal_details,
              employments: [current_employment, previous_employment],
@@ -80,13 +80,13 @@ RSpec.describe "publishers/jobseeker_profiles/show" do
 
     scenario "displays the current job title even when previous roles exist" do
       expect(rendered).to have_content("Mathematics Teacher")
-      expect(rendered).not_to have_content("Previously Mathematics Teacher")
-      expect(rendered).not_to have_content("Previously Science Teacher")
+      expect(rendered).to have_no_content("Previously Mathematics Teacher")
+      expect(rendered).to have_no_content("Previously Science Teacher")
     end
   end
 
   context "when jobseeker has a previous role but no current role" do
-    let(:previous_employment) { create(:employment, job_title: "Science Teacher", is_current_role: false, started_on: 2.years.ago, ended_on: 1.year.ago) }
+    let(:previous_employment) { create(:employment, :jobseeker_profile_employment, job_title: "Science Teacher", is_current_role: false, started_on: 2.years.ago, ended_on: 1.year.ago) }
     let(:jobseeker_profile) do
       create(:jobseeker_profile, :with_personal_details,
              employments: [previous_employment],
@@ -106,8 +106,8 @@ RSpec.describe "publishers/jobseeker_profiles/show" do
     end
 
     scenario "does not display any job title" do
-      expect(rendered).not_to have_content("Previously")
-      expect(rendered).not_to have_content("Current role")
+      expect(rendered).to have_no_content("Previously")
+      expect(rendered).to have_no_content("Current role")
     end
   end
 end

--- a/spec/views/publishers/jobseeker_profiles/show.html.slim_spec.rb
+++ b/spec/views/publishers/jobseeker_profiles/show.html.slim_spec.rb
@@ -68,4 +68,46 @@ RSpec.describe "publishers/jobseeker_profiles/show" do
   scenario "A publisher can contact the jobseeker from their profile" do
     expect(rendered).to have_link(jobseeker_profile.email, href: "mailto:#{jobseeker_profile.email}")
   end
+
+  context "when jobseeker has a current role" do
+    let(:current_employment) { create(:employment, job_title: "Mathematics Teacher", is_current_role: true, started_on: 1.year.ago, ended_on: nil) }
+    let(:previous_employment) { create(:employment, job_title: "Science Teacher", is_current_role: false, started_on: 3.years.ago, ended_on: 2.years.ago) }
+    let(:jobseeker_profile) do
+      create(:jobseeker_profile, :with_personal_details,
+             employments: [current_employment, previous_employment],
+             job_preferences: create(:job_preferences))
+    end
+
+    scenario "displays the current job title even when previous roles exist" do
+      expect(rendered).to have_content("Mathematics Teacher")
+      expect(rendered).not_to have_content("Previously Mathematics Teacher")
+      expect(rendered).not_to have_content("Previously Science Teacher")
+    end
+  end
+
+  context "when jobseeker has a previous role but no current role" do
+    let(:previous_employment) { create(:employment, job_title: "Science Teacher", is_current_role: false, started_on: 2.years.ago, ended_on: 1.year.ago) }
+    let(:jobseeker_profile) do
+      create(:jobseeker_profile, :with_personal_details,
+             employments: [previous_employment],
+             job_preferences: create(:job_preferences))
+    end
+
+    scenario "displays the previous job title with 'Previously' prefix" do
+      expect(rendered).to have_content("Previously Science Teacher")
+    end
+  end
+
+  context "when jobseeker has no employment history" do
+    let(:jobseeker_profile) do
+      create(:jobseeker_profile, :with_personal_details,
+             employments: [],
+             job_preferences: create(:job_preferences))
+    end
+
+    scenario "does not display any job title" do
+      expect(rendered).not_to have_content("Previously")
+      expect(rendered).not_to have_content("Current role")
+    end
+  end
 end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/NK37OyvG/1931-highlight-current-or-latest-role-within-candidate-profiles

## Changes in this PR:

This PR adds previous or current roles to jobseeker profile in prominent positions both on the jobseeker profile card on the search page and also on the show page.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
