### PR TITLE
Add `govuk-template--rebranded` to app layouts

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,5 +1,5 @@
 doctype html
-html.govuk-template.app-html-class lang="en"
+html.govuk-template.govuk-template--rebranded.app-html-class lang="en"
   head
     = render "layouts/vwo_head" if consented_to_extra_cookies?
     = render "layouts/clarity_head" if consented_to_extra_cookies?

--- a/app/views/layouts/application_supportal.html.slim
+++ b/app/views/layouts/application_supportal.html.slim
@@ -1,5 +1,5 @@
 doctype html
-html.govuk-template.app-html-class lang="en"
+html.govuk-template.govuk-template--rebranded.app-html-class lang="en"
   head
     title #{content_for :page_title_prefix} - #{t("app.support_title")}
     = stylesheet_link_tag "application", media: "all"

--- a/app/views/layouts/subscription_campaign.html.slim
+++ b/app/views/layouts/subscription_campaign.html.slim
@@ -1,5 +1,5 @@
 doctype html
-html.govuk-template.app-html-class lang="en"
+html.govuk-template.govuk-template--rebranded.app-html-class lang="en"
   head
     = render "layouts/google_tag_manager_head" if consented_to_extra_cookies?
     = render "layouts/head_meta"


### PR DESCRIPTION
The rebrand is currently half appplied because govuk-components was upgraded but the rebrand class wasn't added, so it's displaying a cyan dot on a black background instead of the blue one.

## Before 

![image](https://github.com/user-attachments/assets/25463f40-55e4-49e4-b59b-97281faffc63)

## After

![Screenshot From 2025-07-04 16-45-02](https://github.com/user-attachments/assets/5a2769f1-d785-47d8-a812-0f0c88cb856a)

