### PR TITLE
Bugfix: Correctly query whether vacancy is for a religious school

### DIFF
--- a/app/models/job_application_pdf.rb
+++ b/app/models/job_application_pdf.rb
@@ -15,7 +15,7 @@ class JobApplicationPdf
   end
 
   def religious_application?
-    vacancy.religion_type.present?
+    vacancy.religion_type.present? && !vacancy.no_religion?
   end
 
   def header_text

--- a/spec/models/job_application_pdf_spec.rb
+++ b/spec/models/job_application_pdf_spec.rb
@@ -456,6 +456,36 @@ RSpec.describe JobApplicationPdf do
     end
   end
 
+  describe "#religious_application?" do
+    subject(:religious_application) { datasource.religious_application? }
+
+    let(:job_application) { build_stubbed(:job_application, vacancy: vacancy) }
+
+    context "when vacancy has no religion type" do
+      let(:vacancy) { build_stubbed(:vacancy, religion_type: nil) }
+
+      it { is_expected.to be false }
+    end
+
+    context "when vacancy religion type is no_religion" do
+      let(:vacancy) { build_stubbed(:vacancy, religion_type: "no_religion") }
+
+      it { is_expected.to be false }
+    end
+
+    context "when vacancy religion type is catholic" do
+      let(:vacancy) { build_stubbed(:vacancy, religion_type: "catholic") }
+
+      it { is_expected.to be true }
+    end
+
+    context "when vacancy religion type is other_religion" do
+      let(:vacancy) { build_stubbed(:vacancy, religion_type: "other_religion") }
+
+      it { is_expected.to be true }
+    end
+  end
+
   describe "religious applications" do
     context "with a baptism cerificate" do
       let(:job_application) do

--- a/spec/services/job_application_pdf_generator_spec.rb
+++ b/spec/services/job_application_pdf_generator_spec.rb
@@ -43,5 +43,15 @@ RSpec.describe JobApplicationPdfGenerator do
     it "includes page number" do
       expect(pdf).to include("1 of 4")
     end
+
+    context "when vacancy religion type is no_religion" do
+      let(:vacancy) { build_stubbed(:vacancy, :at_one_school, religion_type: "no_religion") }
+
+      it "generates PDF without religious information section" do
+        expect { document }.not_to raise_error
+        expect(document).to be_a(Prawn::Document)
+        expect(pdf).not_to include("Religious information")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Changes in this PR:

We were getting complaints about pdf downloads not working. It looks like the issue was that we were trying to render the religious information when we didn't have the appropriate fields. This was causing prawn to try to render this which was breaking:

`<data JobApplicationPdf::Table rows=[["How will you support the school's ethos and aims?", nil], ["Are you currently following a religion or faith?", {true: "Yes", false: "No"}]]>`

This PR fixes this issue by not rendering religious information for vacancies with religion_type: "no_religion"

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
