### PR TITLE
Adapt well-known password change route to OneLogin

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -409,7 +409,7 @@ Rails.application.routes.draw do
   end
 
   # Well known URLs
-  get ".well-known/change-password", to: redirect(status: 302) { Rails.application.routes.url_helpers.edit_jobseeker_registration_path(password_update: true) }
+  get ".well-known/change-password", to: redirect(status: 302) { "https://home.account.gov.uk/security" }
 
   match "/401", as: :unauthorised, to: "errors#unauthorised", via: :all
   match "/404", as: :not_found, to: "errors#not_found", via: :all


### PR DESCRIPTION
Fixes [Sentry error](https://teaching-vacancies.sentry.io/issues/6736317562/?environment=production&project=6212514&query=level%3Aerror&referrer=issue-stream&stream_index=2)

The previous URL no longer exist since we do not manage the user account security within the service.

Pointing to the appropriate GovUK OneLogin page so browsers and password managers know where to direct the users to update their passwords.

## Before

<img width="1457" height="533" alt="image" src="https://github.com/user-attachments/assets/2479c155-4637-4481-866e-c8f7f7a664ec" />


## After

<img width="1080" height="654" alt="image" src="https://github.com/user-attachments/assets/144b7553-26f7-463a-b749-7c76c2f26d18" />



## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
