### PR TITLE
fix referee typo

### DIFF
--- a/config/locales/jobseekers/job_application/references_form.yml
+++ b/config/locales/jobseekers/job_application/references_form.yml
@@ -7,7 +7,7 @@ en:
             referees_section_completed:
               inclusion: Select yes if you have completed this section
             notify_before_contact_referers:
-              inclusion: Select 'Yes' if you want to be notified before the school contacts your referee
+              inclusion: Select 'Yes' if you want to be notified before the school contacts your referee(s)
             referees:
               too_short: You must provide a minimum of %{count} references
               must_include_most_recent_employer: At least one reference must be marked as the most recent employer.

--- a/config/locales/jobseekers/job_application/references_form.yml
+++ b/config/locales/jobseekers/job_application/references_form.yml
@@ -7,7 +7,7 @@ en:
             referees_section_completed:
               inclusion: Select yes if you have completed this section
             notify_before_contact_referers:
-              inclusion: Select yes if you want to be notified before the school contacts your referer
+              inclusion: Select 'Yes' if you want to be notified before the school contacts your referee
             referees:
               too_short: You must provide a minimum of %{count} references
               must_include_most_recent_employer: At least one reference must be marked as the most recent employer.
@@ -30,4 +30,4 @@ en:
         notify_before_contact_referers: We will ask the school to tell you before contacting your referees, but we cannot guarantee they will do so.
         notify_before_contact_referers_options:
           text: We will ask the school to tell you before contacting your referees.
-      
+


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/YrLCZQRZ/1981-fix-typo-in-error-message

## Changes in this PR:

Fix error message to specify referee rather than referer

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
