### PR TITLE
add interviewing to list of statuses displayed to job seekers

### DIFF
--- a/app/helpers/job_applications_helper.rb
+++ b/app/helpers/job_applications_helper.rb
@@ -16,6 +16,7 @@ module JobApplicationsHelper
     shortlisted: "shortlisted",
     unsuccessful: "unsuccessful",
     withdrawn: "withdrawn",
+    interviewing: "interviewing",
   }.freeze
 
   JOB_APPLICATION_STATUS_TAG_COLOURS = {

--- a/app/views/jobseekers/job_applications/_job_application.html.slim
+++ b/app/views/jobseekers/job_applications/_job_application.html.slim
@@ -13,6 +13,8 @@
       = tag.div(card.labelled_item(t(".submitted"), format_time_to_datetime_at(job_application.submitted_at)))
     - when "shortlisted"
       = tag.div(card.labelled_item(t(".shortlisted"), format_time_to_datetime_at(job_application.shortlisted_at)))
+    - when "interviewing"
+      = tag.div(card.labelled_item(t(".interviewing"), format_time_to_datetime_at(job_application.interviewing_at)))
     - when "withdrawn"
       = tag.div(card.labelled_item(t(".withdrawn"), format_time_to_datetime_at(job_application.updated_at)))
 

--- a/app/views/jobseekers/job_applications/index.html.slim
+++ b/app/views/jobseekers/job_applications/index.html.slim
@@ -5,37 +5,25 @@
   p.govuk-body = t(".one_login_banner.paragraph1")
   p.govuk-body = t(".one_login_banner.paragraph2", link: govuk_link_to(t(".one_login_banner.transfer_profile_link_text"), new_jobseekers_request_account_transfer_email_path)).html_safe
 
-- if current_jobseeker.job_applications.any?
+- if @job_application_count.positive?
   - content_for :skip_links do
     = govuk_skip_link(href: "#applications-results", text: t(".skip_link"))
 - if Date.today <= Date.new(2024, 4, 2)
   = render "jobseekers/visa_sponsorship_banner"
-h1.govuk-heading-l = t(".page_title_with_count", count: current_jobseeker.job_applications.count)
+h1.govuk-heading-l = t(".page_title_with_count", count: @job_application_count)
 
 .govuk-grid-row
   .govuk-grid-column-full
-    - if current_jobseeker.job_applications.any?
+    - if @job_application_count.positive?
       #applications-results
-        - current_jobseeker.job_applications.includes(:vacancy).order(updated_at: :desc).draft.each do |job_application|
-          = render "job_application", job_application: job_application if job_application.vacancy.expires_at.future?
-
-        - current_jobseeker.job_applications.includes(:vacancy).order(submitted_at: :desc).submitted.each do |job_application|
+        - @active_drafts.each do |job_application|
           = render "job_application", job_application: job_application
 
-        - current_jobseeker.job_applications.includes(:vacancy).order(submitted_at: :desc).reviewed.each do |job_application|
+        - @active_job_applications.each do |job_application|
           = render "job_application", job_application: job_application
 
-        - current_jobseeker.job_applications.includes(:vacancy).order(submitted_at: :desc).shortlisted.each do |job_application|
+        - @expired_drafts.each do |job_application|
           = render "job_application", job_application: job_application
-
-        - current_jobseeker.job_applications.includes(:vacancy).order(submitted_at: :desc).unsuccessful.each do |job_application|
-          = render "job_application", job_application: job_application
-
-        - current_jobseeker.job_applications.includes(:vacancy).order(submitted_at: :desc).withdrawn.each do |job_application|
-          = render "job_application", job_application: job_application
-
-        - current_jobseeker.job_applications.includes(:vacancy).order(updated_at: :desc).draft.each do |job_application|
-          = render "job_application", job_application: job_application unless job_application.vacancy.expires_at.future?
 
     - else
       = render EmptySectionComponent.new title: t(".no_job_applications") do

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -366,6 +366,7 @@ en:
         closing_date: Closing date
         last_edited: Last edited
         shortlisted: Shortlisted
+        interviewing: Interviewing
         submitted: Submitted
         withdrawn: Withdrawn
       index:

--- a/spec/system/jobseekers/jobseekers_can_manage_their_job_applications_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_their_job_applications_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe "Jobseekers can manage their job applications" do
   let(:vacancy2) { create(:vacancy, :expired, job_title: "Teacher of History", organisations: [organisation]) }
   let(:vacancy3) { create(:vacancy, job_title: "Teacher of Design & Technology", organisations: [organisation]) }
   let(:vacancy4) { create(:vacancy, job_title: "Teacher of RE & PSHE", organisations: [organisation]) }
+  let(:vacancy5) { create(:vacancy, job_title: "Interviewing Job", organisations: [organisation]) }
+  let(:vacancy6) { create(:vacancy, job_title: "Withdrawn Job", organisations: [organisation]) }
+  let(:vacancy7) { create(:vacancy, job_title: "Unsuccessful Job", organisations: [organisation]) }
 
   context "when logged in" do
     before do
@@ -22,6 +25,9 @@ RSpec.describe "Jobseekers can manage their job applications" do
       let!(:deadline_passed_job_application) { create(:job_application, updated_at: 2.days.ago, jobseeker: jobseeker, vacancy: vacancy2) }
       let!(:submitted_job_application) { create(:job_application, :status_submitted, submitted_at: 1.day.ago, jobseeker: jobseeker, vacancy: vacancy3) }
       let!(:shortlisted_job_application) { create(:job_application, :status_shortlisted, submitted_at: 2.days.ago, jobseeker: jobseeker, vacancy: vacancy4) }
+      let!(:interviewing_job_application) { create(:job_application, :status_interviewing, jobseeker: jobseeker, vacancy: vacancy5) }
+      let!(:withdrawn_job_application) { create(:job_application, :status_withdrawn, jobseeker: jobseeker, vacancy: vacancy6) }
+      let!(:unsuccessful_job_application) { create(:job_application, :status_unsuccessful, jobseeker: jobseeker, vacancy: vacancy7) }
 
       before { visit jobseekers_job_applications_path }
 
@@ -49,6 +55,21 @@ RSpec.describe "Jobseekers can manage their job applications" do
           end
 
           within ".card-component:nth-child(4)" do
+            expect(page).to have_css(".card-component__header", text: interviewing_job_application.vacancy.job_title)
+            expect(page).to have_css(".card-component__actions", text: "interviewing")
+          end
+
+          within ".card-component:nth-child(5)" do
+            expect(page).to have_css(".card-component__header", text: unsuccessful_job_application.vacancy.job_title)
+            expect(page).to have_css(".card-component__actions", text: "unsuccessful")
+          end
+
+          within ".card-component:nth-child(6)" do
+            expect(page).to have_css(".card-component__header", text: withdrawn_job_application.vacancy.job_title)
+            expect(page).to have_css(".card-component__actions", text: "withdrawn")
+          end
+
+          within ".card-component:nth-child(7)" do
             expect(page).to have_css(".card-component__header", text: deadline_passed_job_application.vacancy.job_title)
             expect(page).to have_css(".card-component__actions", text: "deadline passed")
           end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/sTxKDJyX/1957-application-status-updates-jobseeker-view-to-match-hiring-staff-choices

## Changes in this PR:

Add 'interviewing' to job application statuses displayed to jobseekers. Actually make sure that all applications are displayed

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
