### PR TITLE
Add new disaster recovery docs

### DIFF
--- a/documentation/operations/deployment/deployments.md
+++ b/documentation/operations/deployment/deployments.md
@@ -117,31 +117,24 @@ In those cases, we will need to manually delete the review app by:
   kubectl -n tv-development get deployments
   ```
   In this example, we identify `teaching-vacancies-review-pr-6488` as the review app that needs to be removed.
+  Delete each of the review app deployment resources with `kubectl`:
 - Delete the web app deployment with `kubectl`:
   ```bash
    kubectl -n tv-development delete deployment teaching-vacancies-review-pr-6488
   ```
-- Delete the worker deployment with `kubectl`:
+- Delete the worker:
   ```bash
    kubectl -n tv-development delete deployment teaching-vacancies-review-pr-6488-worker
   ```
-
-#### Deleting the review app resources in the Azure Portal
-- On the Azure Portal, go to the `Resource Groups` section.
-- Click on the the `s189t01-tv-rv-rg` resource group (review resource group), under the `s189-teacher-services-cloud-test` subscription
-- In the filter field, introduce the number of the review app you're deleting, to find all its associated resources. In our example it will be `6488`.
-  - Example of the filtered resources we will find:
-    | Name                                      | Type                                                            |
-    |-------------------------------------------|-----------------------------------------------------------------|
-    | s189t01-tv-review-pr-6488-redis-cache     | Azure Cache for Redis                                           |
-    | s189t01-tv-review-pr-6488-redis-cache-pe  | Private endpoint                                                |
-    | s189t01-tv-review-pr-6488-redis-cache-pe.nic.ae0700e4-b326-43cd-aab5-b65da2c4ebfe  | Network Interface      |
-    | s189t01-tv-review-pr-6488-redis-queue     | Azure Cache for Redis                                           |
-    | s189t01-tv-review-pr-6488-redis-queue-pe  | Private endpoint                                                |
-    | s189t01-tv-review-pr-6488-redis-queue-pe.nic.fb886c94-78c0-42d1-8132-4f82d59bfaa3  | Network Interface      |
-    | s189t01-tv-rv-pg-review-pr-6488           | Azure Database for PostgreSQL flexible server                   |
-- Select all the resources associated with the Review App you are deleting.
-- On the top menu, click on the bin icon with the **Delete** action.
-  - Do **not** click on the `Delete resource group`, as this would delete all the resources for all the running review apps.
-- Review the resources that are going to be deleted and confirm the deletion.
-- You will see the resources progressively dissapearing from the list as the deletion gets processed.
+- Delete the database:
+  ```bash
+   kubectl -n tv-development delete deployment teaching-vacancies-review-pr-6488-postgres
+  ```
+- Delete the Redis cache:
+  ```bash
+   kubectl -n tv-development delete deployment teaching-vacancies-review-pr-6488-redis-cache
+  ```
+- Dekete the Redis queue:
+  ```bash
+   kubectl -n tv-development delete deployment teaching-vacancies-review-pr-6488-redis-queue
+  ```

--- a/documentation/operations/maintenance/disaster-recovery.md
+++ b/documentation/operations/maintenance/disaster-recovery.md
@@ -1,2 +1,6 @@
 # Disaster recovery
-**[OUTDATED] This document is outdated  since we moved to AKS and needs to be completely re-written
+
+In the event of full loss of database or partial loss of data, follow the instructions fom the Teacher Services Cloud project:
+- [Disaster recovery instructions](https://github.com/DFE-Digital/teacher-services-cloud/blob/main/documentation/disaster-recovery.md)
+- [Disaster recovery testing instructions](https://github.com/DFE-Digital/teacher-services-cloud/blob/main/documentation/disaster-recovery-testing.md)
+


### PR DESCRIPTION
## Trello card URL

- https://trello.com/c/VgRQR1lZ/1659-research-and-understand-the-disaster-recovery-plan

## Changes in this PR:

Update the documentation with the new Disaster Recovery docs from the infra. team. 

Also updates the docs regarding the Review App manual deletion to reflect the current hosting for the different services. 


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
