### PR TITLE
move logo to right hand side on schools page to match jobs page

### DIFF
--- a/app/views/organisations/search/_results.html.slim
+++ b/app/views/organisations/search/_results.html.slim
@@ -1,13 +1,13 @@
 - schools.each do |school|
   .header-with-logo
-    - if school.logo.attached?
-      .header-with-logo-logo--search-result
-        = image_tag(school.logo, alt: t("publishers.organisations.organisation.logo.alt_text", organisation_name: school.name))
     .header-with-logo-title
       h2.govuk-heading-m class="govuk-!-margin-bottom-0"
         = govuk_link_to(school.name, organisation_path(school))
       p.govuk-body class="govuk-!-margin-bottom-0"
         = full_address(school)
+    - if school.logo.attached?
+      .header-with-logo-logo--search-result
+        = image_tag(school.logo, alt: t("publishers.organisations.organisation.logo.alt_text", organisation_name: school.name))
 
   = govuk_summary_list(classes: "govuk-summary-list--no-border") do |summary_list|
     - if school.key_stages.present?


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/yLTqozMG/1959-schools-page-logos-are-weird-move-them-to-the-right-side-to-mirror-jobs-page

## Changes in this PR:

Move school logo to right hand side of page

## Screenshots of UI changes:

### Before
<img width="667" height="411" alt="BeforeChangeLogoi" src="https://github.com/user-attachments/assets/6d0a7c70-a657-4a6f-880e-0462d17a7453" />


### After
<img width="660" height="418" alt="AfterChangeLogo" src="https://github.com/user-attachments/assets/fc446e1a-7fb5-489f-addc-42e9b8b69f68" />



## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
