### PR TITLE
Remove unused step process method

### DIFF
--- a/app/services/jobseekers/job_applications/job_application_step_process.rb
+++ b/app/services/jobseekers/job_applications/job_application_step_process.rb
@@ -50,18 +50,6 @@ class Jobseekers::JobApplications::JobApplicationStepProcess
     step == group.last
   end
 
-  def all_possible_steps
-    steps = case job_application.vacancy.religion_type
-            when "catholic"
-              PRE_RELIGION_STEPS.merge(religious_information: [:religious_information]).merge(POST_RELIGION_STEPS)
-            when "other_religion"
-              PRE_RELIGION_STEPS.merge(non_catholic: [:non_catholic]).merge(POST_RELIGION_STEPS)
-            else
-              PRE_RELIGION_STEPS.merge(POST_RELIGION_STEPS)
-            end
-    steps.values.flatten
-  end
-
   def form_class_for(step)
     "jobseekers/job_application/#{step}_form".camelize.constantize
   end


### PR DESCRIPTION


## Trello card URL

- Discovered this code following a [Sentry Error](https://teaching-vacancies.sentry.io/issues/6736549779/?project=6212514)

## Changes in this PR:

Removing the method since seems a bit outdated, and nothing calls it.

Also doesn't seem covered/reached by our tests (what makes me think is not being used):
<img width="851" height="259" alt="image" src="https://github.com/user-attachments/assets/44ad5f70-8c4b-409f-aeb6-bcde3400b39b" />

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
