### PR TITLE
Add commented flag for Dis Recov to app terraform

### DIFF
--- a/terraform/app/modules/paas/aks_application.tf
+++ b/terraform/app/modules/paas/aks_application.tf
@@ -56,6 +56,11 @@ module "web_application" {
   replicas               = var.aks_web_app_instances
   enable_logit           = var.enable_logit
   max_memory             = var.aks_web_app_memory
+
+  # Uncomment this when we want traffic to be redirected to the maintenance
+  # page during disaster recovery (i.e., while waiting for a database to be
+  # recreated)
+  # send_traffic_to_maintenance_page = true
 }
 
 module "worker_application" {


### PR DESCRIPTION
This flag needs to be uncommented/used when, during a disaster recovery process, we need to re-deploy an environment but still point the site to the maintenance page.


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
