### PR TITLE
Revert "copy notify_before_contact_referees field (#7907)"

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -51,7 +51,6 @@ if ENV.fetch("COVERAGE", 0).to_i.positive?
     # .25% lower (branch) and .1% lower (line) than the test run for now
     #
     # possibly the tests are stable now?
-    # SD 14/7/25 branch coverage still appears to be ~ .1% unstable
-    minimum_coverage line: 96.45, branch: 82.76
+    minimum_coverage line: 96.30, branch: 81.99
   end
 end

--- a/app/services/jobseekers/job_applications/prefill_job_application_from_previous_application.rb
+++ b/app/services/jobseekers/job_applications/prefill_job_application_from_previous_application.rb
@@ -42,8 +42,17 @@ class Jobseekers::JobApplications::PrefillJobApplicationFromPreviousApplication
   end
 
   def attributes_to_copy
-    (relevant_steps - %i[review declarations])
-      .flat_map { |step| form_fields_from_step(step) }
+    %i[personal_details
+       professional_status
+       ask_for_support
+       personal_statement
+       catholic_following_religion
+       non_catholic_following_religion
+       catholic_religion_details
+       school_ethos
+       non_catholic_religion_details]
+      .filter_map { |step| form_fields_from_step(step) if relevant_steps.include?(step) }
+      .flatten
   end
 
   def copy_associations(associations)

--- a/app/views/jobseekers/job_applications/review/_references.html.slim
+++ b/app/views/jobseekers/job_applications/review/_references.html.slim
@@ -41,8 +41,3 @@
           - summary_list.with_row do |row|
             - row.with_key text: t("helpers.legend.jobseekers_job_application_details_referee_form.is_most_recent_employer")
             - row.with_value text: t("helpers.label.jobseekers_job_application_details_referee_form.is_most_recent_employer_options.#{referee.is_most_recent_employer}")
-
-    = govuk_summary_list do |summary_list|
-      - summary_list.with_row do |row|
-        - row.with_key text: t("helpers.legend.jobseekers_job_application_referees_form.notify_before_contact_referers")
-        - row.with_value text: t("helpers.label.jobseekers_job_application_referees_form.notify_before_contact_referers_options.#{job_application.notify_before_contact_referers}")

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -39,8 +39,6 @@ users = [
   { email: "yvonne.ridley@education.gov.uk", family_name: "Ridley", given_name: "Yvonne" },
 ]
 
-user_emails = users.map { |u| u.fetch(:email) }
-
 users.each do |user|
   Publisher.create(organisations: [bexleyheath_school, weydon_trust, southampton_la, oakfield, avanti, abraham_moss], **user)
   SupportUser.create(user)
@@ -89,12 +87,10 @@ attrs = { organisations: southampton_la.schools.first(5), phases: %w[primary], p
 FactoryBot.create(:jobseeker, email: "jobseeker@contoso.com")
 JobApplication.statuses.count.times { |i| FactoryBot.create(:jobseeker, email: "jobseeker#{i}@contoso.com") }
 
-emails_without_applications = ["jobseeker@contoso.com"] + user_emails
 # Job Applications
 Vacancy.listed.each do |vacancy|
   statuses = JobApplication.statuses.keys
-  # only add fake job applications to non-DFE jobseekers
-  Jobseeker.where.not(email: emails_without_applications).each do |jobseeker|
+  Jobseeker.where.not(email: "jobseeker@contoso.com").each do |jobseeker|
     # Ensures each one of the statuses gets used. When no unused statuses are left, takes random ones from the list for further new applications.
     application_status = statuses.delete(statuses.sample) || JobApplication.statuses.keys.sample
     FactoryBot.create(:job_application, :for_seed_data, :"status_#{application_status}", jobseeker: jobseeker, vacancy: vacancy)

--- a/spec/services/jobseekers/job_applications/prefill_job_application_from_previous_application_spec.rb
+++ b/spec/services/jobseekers/job_applications/prefill_job_application_from_previous_application_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Jobseekers::JobApplications::PrefillJobApplicationFromPreviousApp
   describe "#job_application" do
     context "when jobseeker has a recent job application" do
       let(:old_vacancy) { create(:vacancy) }
-      let!(:recent_job_application) { create(:job_application, :status_submitted, submitted_at: 1.day.ago, jobseeker: jobseeker, vacancy: old_vacancy, notify_before_contact_referers: true) }
+      let!(:recent_job_application) { create(:job_application, :status_submitted, submitted_at: 1.day.ago, jobseeker: jobseeker, vacancy: old_vacancy) }
       let!(:older_job_application) { create(:job_application, :status_submitted, submitted_at: 1.week.ago, jobseeker: jobseeker, vacancy: old_vacancy) }
       let!(:draft_job_application) { create(:job_application, jobseeker: jobseeker, vacancy: old_vacancy) }
 
@@ -23,7 +23,7 @@ RSpec.describe Jobseekers::JobApplications::PrefillJobApplicationFromPreviousApp
         let(:attributes_to_copy) do
           %i[first_name last_name previous_names street_address city country postcode phone_number
              national_insurance_number qualified_teacher_status qualified_teacher_status_year qualified_teacher_status_details
-             is_statutory_induction_complete is_support_needed support_needed_details notify_before_contact_referers]
+             is_statutory_induction_complete is_support_needed support_needed_details]
         end
 
         it "copies personal info from the recent job application" do


### PR DESCRIPTION
This reverts commit 2860af6e53b5e129c271fb2325ead8f0fe992952.

## Trello card URL

## Changes in this PR:

- Is there anything specific you want feedback on?

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
