### PR TITLE
fix religious change links to point to correct build step

### DIFF
--- a/app/views/jobseekers/job_applications/review/_catholic_religious_information.html.slim
+++ b/app/views/jobseekers/job_applications/review/_catholic_religious_information.html.slim
@@ -1,4 +1,4 @@
-- r.with_section :religious_information
+- r.with_section :catholic
   p.govuk-body = t("jobseekers.job_applications.review.religious_information.heading")
 
   = govuk_summary_list do |summary_list|

--- a/app/views/jobseekers/job_applications/review/_non_catholic_religious_information.html.slim
+++ b/app/views/jobseekers/job_applications/review/_non_catholic_religious_information.html.slim
@@ -1,4 +1,4 @@
-- r.with_section :religious_information
+- r.with_section :non_catholic
   p.govuk-body = t("jobseekers.job_applications.review.religious_information.heading")
 
   = govuk_summary_list do |summary_list|

--- a/spec/system/jobseekers/jobseekers_can_complete_a_religious_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_complete_a_religious_job_application_spec.rb
@@ -87,6 +87,10 @@ RSpec.describe "Jobseekers can complete a religious job application" do
               complete_from_references_page
             end
 
+            it "has a correct change link" do
+              expect(page).to have_link(href: jobseekers_job_application_build_path(job_application, :catholic))
+            end
+
             it "shows the referee details" do
               expect(page).to have_content(I18n.t("jobseekers.job_applications.build.referees.heading"))
 
@@ -220,12 +224,18 @@ RSpec.describe "Jobseekers can complete a religious job application" do
         context "when not following a religion" do
           let(:following_religion) { false }
 
-          it "completes the religious journey" do
+          before do
             click_on I18n.t("buttons.save_and_continue")
-            expect(page).to have_content(I18n.t("jobseekers.job_applications.build.referees.heading"))
             complete_from_references_page
+          end
+
+          it "completes the religious journey" do
             submit_application_from_review
             expect(page).to have_content(I18n.t("jobseekers.job_applications.post_submit.panel.title"))
+          end
+
+          it "has a correct change link" do
+            expect(page).to have_link(href: jobseekers_job_application_build_path(job_application, :non_catholic))
           end
         end
 


### PR DESCRIPTION
## Changes in this PR:

Use the specific religious type in the 'with_section' view helper - turns out this is used to build the 'Change' link on the review page, with the tag being the step required to perform the change.

## Screenshots of UI changes:

### Before

### After

