### PR TITLE
don't link to religion information for non religious vacancy at religious school

### DIFF
--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -13,10 +13,9 @@ module VacanciesHelper
     return t("publishers.vacancies.application_form_type.uploaded_document") if vacancy.uploaded_form?
 
     if vacancy.enable_job_applications
-      case vacancy.religion_type
-      when "catholic"
+      if vacancy.catholic?
         t("publishers.vacancies.application_form_type.catholic")
-      when "other_religion"
+      elsif vacancy.other_religion?
         t("publishers.vacancies.application_form_type.other_religion")
       else
         t("publishers.vacancies.application_form_type.no_religion")

--- a/app/models/job_application_pdf.rb
+++ b/app/models/job_application_pdf.rb
@@ -15,7 +15,7 @@ class JobApplicationPdf
   end
 
   def religious_application?
-    vacancy.religion_type.present? && !vacancy.no_religion?
+    vacancy.catholic? || vacancy.other_religion?
   end
 
   def header_text
@@ -113,7 +113,7 @@ class JobApplicationPdf
   end
 
   def religious_information
-    religious_data = if vacancy.religion_type == "catholic"
+    religious_data = if vacancy.catholic?
                        catholic_religious_information
                      else
                        non_catholic_religious_information

--- a/app/services/jobseekers/job_applications/job_application_step_process.rb
+++ b/app/services/jobseekers/job_applications/job_application_step_process.rb
@@ -20,10 +20,9 @@ class Jobseekers::JobApplications::JobApplicationStepProcess
   def initialize(job_application:)
     @job_application = job_application
 
-    religious_steps = case job_application.vacancy.religion_type
-                      when "catholic"
+    religious_steps = if job_application.vacancy.catholic?
                         { catholic: [:catholic] }
-                      when "other_religion"
+                      elsif job_application.vacancy.other_religion?
                         { non_catholic: [:non_catholic] }
                       else
                         {}

--- a/app/views/jobseekers/job_applications/_job_application_review_sections.html.slim
+++ b/app/views/jobseekers/job_applications/_job_application_review_sections.html.slim
@@ -9,11 +9,10 @@
   = render "jobseekers/job_applications/review/professional_body_memberships", r: r, job_application: job_application
   = render "jobseekers/job_applications/review/employment_history", r: r, job_application: job_application
   = render "jobseekers/job_applications/review/personal_statement", r: r, job_application: job_application
-  - case job_application.vacancy.religion_type
-    - when "catholic"
-      = render "jobseekers/job_applications/review/catholic_religious_information", r: r, job_application: job_application
-    - when "other_religion"
-      = render "jobseekers/job_applications/review/non_catholic_religious_information", r: r, job_application: job_application
+  - if job_application.vacancy.catholic?
+    = render "jobseekers/job_applications/review/catholic_religious_information", r: r, job_application: job_application
+  - elsif job_application.vacancy.other_religion?
+    = render "jobseekers/job_applications/review/non_catholic_religious_information", r: r, job_application: job_application
   = render "jobseekers/job_applications/review/references", r: r, job_application: job_application
   - if jobseeker_signed_in?
     = render "jobseekers/job_applications/review/equal_opportunities", r: r

--- a/app/views/jobseekers/job_applications/_show.html.slim
+++ b/app/views/jobseekers/job_applications/_show.html.slim
@@ -13,7 +13,7 @@
           - navigation.with_anchor text: t(".professional_body_memberships.heading"), href: "#professional_body_memberships"
           - navigation.with_anchor text: t(".employment_history.heading"), href: "#employment_history"
           - navigation.with_anchor text: t(".personal_statement.heading"), href: "#personal_statement"
-          - if vacancy.religion_type.present?
+          - if vacancy.catholic? || vacancy.other_religion?
             - navigation.with_anchor text: t(".religious_information.heading"), href: "#following_religion"
           - navigation.with_anchor text: t(".referees.heading"), href: "#referees"
           - navigation.with_anchor text: t(".ask_for_support.heading"), href: "#ask_for_support"

--- a/app/views/jobseekers/job_applications/apply.html.slim
+++ b/app/views/jobseekers/job_applications/apply.html.slim
@@ -55,15 +55,14 @@
         html_attributes: { id: :personal_statement },
         status: review_section_tag(@job_application, :personal_statement))
 
-      - case @job_application.vacancy.religion_type
-        - when "catholic"
-          - task_list.with_item(title: t("jobseekers.job_applications.build.catholic.step_title"), href: jobseekers_job_application_build_path(@job_application, :catholic),
-            html_attributes: { id: :religious_information },
-            status: review_section_tag(@job_application, :catholic))
-        - when "other_religion"
-          - task_list.with_item(title: t("jobseekers.job_applications.build.catholic.step_title"), href: jobseekers_job_application_build_path(@job_application, :non_catholic),
-            html_attributes: { id: :religious_information },
-            status: review_section_tag(@job_application, :non_catholic))
+      - if @job_application.vacancy.catholic?
+        - task_list.with_item(title: t("jobseekers.job_applications.build.catholic.step_title"), href: jobseekers_job_application_build_path(@job_application, :catholic),
+          html_attributes: { id: :religious_information },
+          status: review_section_tag(@job_application, :catholic))
+      - elsif @job_application.vacancy.other_religion?
+        - task_list.with_item(title: t("jobseekers.job_applications.build.catholic.step_title"), href: jobseekers_job_application_build_path(@job_application, :non_catholic),
+          html_attributes: { id: :religious_information },
+          status: review_section_tag(@job_application, :non_catholic))
 
       - task_list.with_item(title: t("jobseekers.job_applications.build.referees.heading"), href: jobseekers_job_application_build_path(@job_application, :referees),
         html_attributes: { id: :referees },

--- a/app/views/publishers/vacancies/job_applications/_application_details_and_notes.html.slim
+++ b/app/views/publishers/vacancies/job_applications/_application_details_and_notes.html.slim
@@ -13,7 +13,7 @@
           - navigation.with_anchor text: t("jobseekers.job_applications.build.professional_body_memberships.heading"), href: "#professional_body_memberships"
           - navigation.with_anchor text: t("jobseekers.job_applications.build.employment_history.heading"), href: "#employment_history"
           - navigation.with_anchor text: t("jobseekers.job_applications.build.personal_statement.heading"), href: "#personal_statement"
-          - if vacancy.religion_type.present?
+          - if vacancy.catholic? || vacancy.other_religion?
             - navigation.with_anchor text: t("jobseekers.job_applications.build.religious_information.heading"), href: "#following_religion"
           - navigation.with_anchor text: t("jobseekers.job_applications.build.referees.heading"), href: "#referees"
           - navigation.with_anchor text: t("jobseekers.job_applications.build.ask_for_support.heading"), href: "#ask_for_support"

--- a/spec/helpers/vacancies_helper_spec.rb
+++ b/spec/helpers/vacancies_helper_spec.rb
@@ -133,66 +133,66 @@ RSpec.describe VacanciesHelper do
   end
 
   describe "#vacancy_form_type" do
-    let(:vacancy) { instance_double(Vacancy) }
-
     context "when vacancy uses uploaded form" do
-      it "returns uploaded_document translation" do
-        allow(vacancy).to receive(:uploaded_form?).and_return(true)
+      let(:vacancy) { build_stubbed(:vacancy, :with_uploaded_application_form) }
 
+      it {
         expect(helper.vacancy_form_type(vacancy)).to eq(
           t("publishers.vacancies.application_form_type.uploaded_document"),
         )
-      end
+      }
     end
 
     context "when job applications are enabled" do
-      before do
-        allow(vacancy).to receive_messages(uploaded_form?: false, enable_job_applications: true)
+      context "when religion_type is catholic" do
+        let(:vacancy) { build_stubbed(:vacancy, religion_type: :catholic) }
+
+        it {
+          expect(helper.vacancy_form_type(vacancy)).to eq(
+            t("publishers.vacancies.application_form_type.catholic"),
+          )
+        }
       end
 
-      it "returns catholic translation if religion_type is catholic" do
-        allow(vacancy).to receive(:religion_type).and_return("catholic")
+      context "when religion_type is other_religion" do
+        let(:vacancy) { build_stubbed(:vacancy, religion_type: :other_religion) }
 
-        expect(helper.vacancy_form_type(vacancy)).to eq(
-          t("publishers.vacancies.application_form_type.catholic"),
-        )
+        it {
+          expect(helper.vacancy_form_type(vacancy)).to eq(
+            t("publishers.vacancies.application_form_type.other_religion"),
+          )
+        }
       end
 
-      it "returns other_religion translation if religion_type is other_religion" do
-        allow(vacancy).to receive(:religion_type).and_return("other_religion")
+      context "when religion_type is no_religion" do
+        let(:vacancy) { build_stubbed(:vacancy, religion_type: :no_religion) }
 
-        expect(helper.vacancy_form_type(vacancy)).to eq(
-          t("publishers.vacancies.application_form_type.other_religion"),
-        )
+        it {
+          expect(helper.vacancy_form_type(vacancy)).to eq(
+            t("publishers.vacancies.application_form_type.no_religion"),
+          )
+        }
       end
 
-      it "returns no_religion translation for any other religion_type" do
-        allow(vacancy).to receive(:religion_type).and_return("non_religious")
+      context "when religion_type is nil" do
+        let(:vacancy) { build_stubbed(:vacancy, religion_type: nil) }
 
-        expect(helper.vacancy_form_type(vacancy)).to eq(
-          t("publishers.vacancies.application_form_type.no_religion"),
-        )
-      end
-
-      it "returns no_religion translation when religion_type is nil" do
-        allow(vacancy).to receive(:religion_type).and_return(nil)
-
-        expect(helper.vacancy_form_type(vacancy)).to eq(
-          t("publishers.vacancies.application_form_type.no_religion"),
-        )
+        it {
+          expect(helper.vacancy_form_type(vacancy)).to eq(
+            t("publishers.vacancies.application_form_type.no_religion"),
+          )
+        }
       end
     end
 
     context "when job applications are not enabled" do
-      before do
-        allow(vacancy).to receive_messages(uploaded_form?: false, enable_job_applications: false)
-      end
+      let(:vacancy) { build_stubbed(:vacancy, :no_tv_applications) }
 
-      it "returns other translation" do
+      it {
         expect(helper.vacancy_form_type(vacancy)).to eq(
           t("publishers.vacancies.application_form_type.other"),
         )
-      end
+      }
     end
   end
 

--- a/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_school_spec.rb
@@ -253,7 +253,7 @@ RSpec.describe "Creating a vacancy" do
 
         fill_from_visits_to_review(vacancy)
         expect(current_path).to eq(organisation_job_review_path(created_vacancy.id))
-        expect(Vacancy.find(created_vacancy.id).religion_type.to_sym).to eq(:catholic)
+        expect(Vacancy.find(created_vacancy.id)).to be_catholic
       end
 
       scenario "Church of England" do
@@ -262,7 +262,7 @@ RSpec.describe "Creating a vacancy" do
 
         fill_from_visits_to_review(vacancy)
         expect(current_path).to eq(organisation_job_review_path(created_vacancy.id))
-        expect(Vacancy.find(created_vacancy.id).religion_type.to_sym).to eq(:other_religion)
+        expect(Vacancy.find(created_vacancy.id)).to be_other_religion
       end
 
       scenario "No religion questions" do
@@ -271,7 +271,7 @@ RSpec.describe "Creating a vacancy" do
 
         fill_from_visits_to_review(vacancy)
         expect(current_path).to eq(organisation_job_review_path(created_vacancy.id))
-        expect(Vacancy.find(created_vacancy.id).religion_type.to_sym).to eq(:no_religion)
+        expect(Vacancy.find(created_vacancy.id)).to be_no_religion
       end
     end
 


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/v6SKk1tT/1988-religious-information-link-present-on-review-of-non-religious-applications

## Changes in this PR:

Don't show religious link for non-religious vacancy. 

- Is there anything specific you want feedback on?

Change to use vacancy.catholic? rather than vacancy.religion_type as feels more robust e.g. don't need a nil check

## Screenshots of UI changes:

### Before

### After
