### PR TITLE
Ensure personal statement section is not marked as complete when impo…

### DIFF
--- a/app/services/jobseekers/job_applications/prefill_job_application_from_previous_application.rb
+++ b/app/services/jobseekers/job_applications/prefill_job_application_from_previous_application.rb
@@ -16,7 +16,7 @@ class Jobseekers::JobApplications::PrefillJobApplicationFromPreviousApplication
     new_job_application
   end
 
-  PLAIN_STEPS = %w[personal_details personal_statement referees ask_for_support qualifications training_and_cpds professional_body_memberships following_religion religion_details].freeze
+  PLAIN_STEPS = %w[personal_details referees ask_for_support qualifications training_and_cpds professional_body_memberships following_religion religion_details].freeze
 
   private
 
@@ -78,13 +78,10 @@ class Jobseekers::JobApplications::PrefillJobApplicationFromPreviousApplication
   end
 
   def in_progress_steps
-    if previous_application_was_submitted_before_we_began_validating_gaps_in_work_history?
-      %w[employment_history]
-    elsif !previous_application_has_professional_status_details?
-      %w[professional_status]
-    else
-      []
-    end
+    steps = %w[personal_statement]
+    steps << "employment_history" if previous_application_was_submitted_before_we_began_validating_gaps_in_work_history?
+    steps << "professional_status" unless previous_application_has_professional_status_details?
+    steps
   end
 
   def form_fields_from_step(step)

--- a/spec/services/jobseekers/job_applications/prefill_job_application_from_previous_application_spec.rb
+++ b/spec/services/jobseekers/job_applications/prefill_job_application_from_previous_application_spec.rb
@@ -39,28 +39,28 @@ RSpec.describe Jobseekers::JobApplications::PrefillJobApplicationFromPreviousApp
 
           it "copies completed steps except for declarations and equal opportunities and employment_history and also adds them to imported steps" do
             expect(subject.completed_steps)
-              .to eq(%w[personal_details personal_statement referees ask_for_support qualifications training_and_cpds professional_body_memberships professional_status])
+              .to eq(%w[personal_details referees ask_for_support qualifications training_and_cpds professional_body_memberships professional_status])
             expect(subject.imported_steps)
-              .to eq(%w[personal_details personal_statement referees ask_for_support qualifications training_and_cpds professional_body_memberships professional_status])
+              .to eq(%w[personal_details referees ask_for_support qualifications training_and_cpds professional_body_memberships professional_status])
           end
 
           it "add employment_history to the in progress steps " do
             expect(subject.in_progress_steps)
-              .to eq(%w[employment_history])
+              .to eq(%w[personal_statement employment_history])
           end
         end
 
         context "when the application is from after we added gap validation for employment history section" do
           it "copies completed steps except for declarations and equal opportunities and also adds them to imported steps" do
             expect(subject.completed_steps)
-              .to eq(%w[personal_details personal_statement referees ask_for_support qualifications training_and_cpds professional_body_memberships employment_history professional_status])
+              .to eq(%w[personal_details referees ask_for_support qualifications training_and_cpds professional_body_memberships employment_history professional_status])
             expect(subject.imported_steps)
-              .to eq(%w[personal_details personal_statement referees ask_for_support qualifications training_and_cpds professional_body_memberships employment_history professional_status])
+              .to eq(%w[personal_details referees ask_for_support qualifications training_and_cpds professional_body_memberships employment_history professional_status])
           end
 
           it "sets in progress steps as empty" do
             expect(subject.in_progress_steps)
-              .to eq(%w[])
+              .to eq(%w[personal_statement])
           end
         end
 

--- a/spec/services/jobseekers/job_applications/prefill_job_application_from_previous_application_spec.rb
+++ b/spec/services/jobseekers/job_applications/prefill_job_application_from_previous_application_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Jobseekers::JobApplications::PrefillJobApplicationFromPreviousApp
               .to eq(%w[personal_details referees ask_for_support qualifications training_and_cpds professional_body_memberships employment_history professional_status])
           end
 
-          it "sets in progress steps as empty" do
+          it "does not add employment_history to the in progress steps" do
             expect(subject.in_progress_steps)
               .to eq(%w[personal_statement])
           end

--- a/spec/system/jobseekers/prefilling_applications_spec.rb
+++ b/spec/system/jobseekers/prefilling_applications_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "Jobseekers can prefill applications" do
         expect(page).to have_content(previous_application.personal_statement)
         click_on "Save and continue"
         within("#personal_statement") do
-          expect(page).to have_css(".govuk-task-list__status", text: I18n.t("shared.status_tags.complete"))
+          expect(page).to have_css(".govuk-task-list__status", text: I18n.t("shared.status_tags.incomplete"))
         end
 
         # qualified teacher status


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/ikkt7g6T/1982-personal-statement-is-copied-from-old-job-application-but-marked-as-complete-so-candidate-is-not-forced-to-check-it

## Changes in this PR:

Prior to this change when we imported a personal statement from a previous job application the personal statement was tagged as completed so jobseekers did not need to review it. This change ensures it is not tagged as complete so jobseekers have to review their personal statement for every new application.

## Screenshots of UI changes:

<img width="1108" height="695" alt="Screenshot 2025-07-28 at 15 19 07" src="https://github.com/user-attachments/assets/90f47bd7-4fcd-4fd4-b55f-6f72abeb0110" />

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
