### PR TITLE
Fix Recaptcha reply score querying

### DIFF
--- a/app/controllers/jobseekers/subscriptions/feedbacks/further_feedbacks_controller.rb
+++ b/app/controllers/jobseekers/subscriptions/feedbacks/further_feedbacks_controller.rb
@@ -26,7 +26,7 @@ class Jobseekers::Subscriptions::Feedbacks::FurtherFeedbacksController < Applica
 
   def update_feedback
     feedback.update(further_feedback_form_params)
-    feedback.recaptcha_score = recaptcha_reply&.dig("score")
+    feedback.recaptcha_score = recaptcha_reply&.score
     feedback.save
   end
 

--- a/app/controllers/jobseekers/subscriptions/feedbacks/further_feedbacks_controller.rb
+++ b/app/controllers/jobseekers/subscriptions/feedbacks/further_feedbacks_controller.rb
@@ -26,7 +26,9 @@ class Jobseekers::Subscriptions::Feedbacks::FurtherFeedbacksController < Applica
 
   def update_feedback
     feedback.update(further_feedback_form_params)
+    # :nocov:
     feedback.recaptcha_score = recaptcha_reply&.score
+    # :nocov:
     feedback.save
   end
 

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -116,7 +116,7 @@ class SubscriptionsController < ApplicationController
   end
 
   def notify_new_subscription(subscription)
-    subscription.update(recaptcha_score: recaptcha_reply&.dig("score"))
+    subscription.update(recaptcha_score: recaptcha_reply&.score)
     Jobseekers::SubscriptionMailer.confirmation(subscription.id).deliver_later
     trigger_subscription_event(:job_alert_subscription_created, subscription)
   end

--- a/spec/controllers/jobseekers/subscriptions_controller_spec.rb
+++ b/spec/controllers/jobseekers/subscriptions_controller_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe SubscriptionsController, recaptcha: true do
       let(:errors) { instance_double(ActiveModel::Errors, add: nil) }
       let(:form) { instance_double(Jobseekers::SubscriptionForm, errors: errors) }
       let(:subscription_form_valid?) { true }
+      let(:recaptcha_reply) { instance_double(Recaptcha::Reply, score: recaptcha_score) }
 
       before do
         allow(Subscription).to receive(:new).and_return(subscription)
@@ -43,7 +44,7 @@ RSpec.describe SubscriptionsController, recaptcha: true do
         allow(form).to receive(:job_alert_params).and_return(job_alert_params)
         allow(form).to receive(:invalid?).and_return(!subscription_form_valid?)
         allow(form).to receive(:class).and_return(Jobseekers::SubscriptionForm)
-        allow(controller).to receive(:recaptcha_reply).and_return({ "score" => recaptcha_score })
+        allow(controller).to receive(:recaptcha_reply).and_return(recaptcha_reply)
         allow(controller).to receive(:verify_recaptcha).and_return(verify_recaptcha)
       end
 

--- a/spec/controllers/jobseekers/subscriptions_controller_spec.rb
+++ b/spec/controllers/jobseekers/subscriptions_controller_spec.rb
@@ -58,6 +58,20 @@ RSpec.describe SubscriptionsController, recaptcha: true do
           subject
         end
 
+        it "records the recaptcha score on the subscription" do
+          expect(subscription).to receive(:update).with(recaptcha_score: recaptcha_score)
+          subject
+        end
+
+        context "when the recaptcha reply as yet not been fetched" do
+          let(:recaptcha_reply) { nil }
+
+          it "records a nil recaptcha score" do
+            expect(subscription).to receive(:update).with(recaptcha_score: nil)
+            subject
+          end
+        end
+
         it "renders the subscription confirmation page" do
           expect(subject).to render_template("confirm")
         end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -89,9 +89,7 @@ RSpec.configure do |config|
   end
 
   config.before(:each, recaptcha: true) do
-    recaptcha_reply = double("recaptcha_reply")
-    allow(recaptcha_reply).to receive(:dig).with("score").and_return(0.9)
-    allow(recaptcha_reply).to receive(:[]).with("score").and_return(0.9)
+    recaptcha_reply = instance_double(Recaptcha::Reply, score: 0.9, success?: true)
     allow_any_instance_of(ApplicationController).to receive(:verify_recaptcha).and_return(true)
     allow_any_instance_of(ApplicationController).to receive(:recaptcha_reply).and_return(recaptcha_reply)
   end


### PR DESCRIPTION
Fixes [Sentry error](https://teaching-vacancies.sentry.io/issues/6781582794/?alert_rule_id=10370581&alert_type=issue&environment=production&notification_uuid=3bb17952-7ad4-4e38-a695-2f533c7d0ea8&project=6212514&referrer=slack)
Error introduced with:
- [Recaptcha minor version upgrade](https://github.com/DFE-Digital/teaching-vacancies/pull/7955)
- https://github.com/ambethia/recaptcha/blob/master/CHANGELOG.md#5200
- https://github.com/ambethia/recaptcha/commit/05847ea45a5608884c360d5896a9fa33f59866a0#diff-1cd3809b485866e2ff9f8d97014eeb48e9cd1fda2c9e31fa919cad70910ed0f7

The latest minor update of Recaptcha gem has changed the `recaptcha_reply` response from a `hash` to a `Reply` object.

This caused our current code using `dig` over the response to raise exceptions, as the `recaptcha_reply` no longer responds to `dig`.
