### PR TITLE
Fix race condition in Vacancy analytics source updates

### DIFF
--- a/app/services/vacancy_analytics_service.rb
+++ b/app/services/vacancy_analytics_service.rb
@@ -36,6 +36,9 @@ class VacancyAnalyticsService
 
   def self.update_stats_in_database(vacancy_updates)
     vacancy_updates.each do |vacancy_id, new_referrer_counts|
+      # Skip if the associated vacancy does not exist. This may happen if the vacancy was deleted after the visit was tracked.
+      next unless Vacancy.exists?(id: vacancy_id)
+
       VacancyAnalytics.transaction do
         analytics = VacancyAnalytics.where(vacancy_id: vacancy_id).lock(true).first_or_initialize
 

--- a/spec/services/vacancy_analytics_service_spec.rb
+++ b/spec/services/vacancy_analytics_service_spec.rb
@@ -92,5 +92,17 @@ RSpec.describe VacancyAnalyticsService do
 
       expect(existing.reload.referrer_counts["google.com"]).to eq(5)
     end
+
+    it "ignores the update if the vacancy trying no longer exists" do
+      deleted_vacancy_id = SecureRandom.uuid
+      original_count = VacancyAnalytics.count
+
+      expect {
+        described_class.update_stats_in_database({
+          deleted_vacancy_id => { "google.com" => 3 },
+        })
+      }.not_to raise_error
+      expect(VacancyAnalytics.count).to eq(original_count)
+    end
   end
 end


### PR DESCRIPTION
## Trello card URL
[Sentry error for review app](https://teaching-vacancies.sentry.io/issues/6752259792/events/recommended/?environment=review&groupId=6752259792&pageEnd=2025-08-07T22%3A02%3A14.292&pageStart=2025-08-06T22%3A02%3A14.292&project=6212514&query=server_name%3A%22%5BFILTERED%5D%22&referrer=issue-stream&source=issue_details)

## Changes in this PR:

When a vacancy visit is tracked in Redis, and later the Redis updates written in DB, the vacancy associated with the tracked visit may have been removed from our system in between.

So far this has only happened in Review Apps (where the chances of destroying Vacancies while testing and setting vacancies are higher), but it could still happen in production.

Resolving it by ensuring the vacancy we're trying to register analytics about still exists before trying to record the analytics in DB.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
