### PR TITLE
Fix Baptism cet. filename in PDF generation

### DIFF
--- a/app/models/job_application_pdf.rb
+++ b/app/models/job_application_pdf.rb
@@ -253,7 +253,7 @@ class JobApplicationPdf
       ]
     when "baptism_certificate"
       [
-        [I18n.t("jobseekers.job_applications.review.religious_information.baptism_certificate"), job_application.baptism_certificate.filename],
+        [I18n.t("jobseekers.job_applications.review.religious_information.baptism_certificate"), job_application.baptism_certificate.filename.to_s],
       ]
 
     when "baptism_date"

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -556,7 +556,7 @@ en:
           none: You have not added any training.
         religious_information:
           heading: This school has a religious character and has asked applicants to provide religious information as part of the application, where possible.
-          baptism_certificate: Baptism certficate
+          baptism_certificate: Baptism certificate
       show:
         application_sections: Application sections
         ask_for_support:

--- a/spec/services/job_application_pdf_generator_spec.rb
+++ b/spec/services/job_application_pdf_generator_spec.rb
@@ -53,5 +53,18 @@ RSpec.describe JobApplicationPdfGenerator do
         expect(pdf).not_to include("Religious information")
       end
     end
+
+    context "when the religion reference data is a baptism certificate" do
+      let(:vacancy) { build_stubbed(:vacancy, :catholic) }
+      let(:job_application) do
+        build_stubbed(:job_application, :status_submitted, :with_baptism_certificate, vacancy:)
+      end
+
+      it "generates PDF with the baptism certificate file name" do
+        expect { document }.not_to raise_error
+        expect(document).to be_a(Prawn::Document)
+        expect(pdf).to include("blank_job_spec.pdf")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Trello card URL
- [Sentry error 1](https://teaching-vacancies.sentry.io/issues/6793572530/?environment=qa&project=6212514&query=is%3Aunresolved%20level%3Aerror&referrer=issue-stream)
- [Sentry error 2](https://teaching-vacancies.sentry.io/issues/6793572251/?environment=qa&project=6212514&query=is%3Aunresolved%20level%3Aerror&referrer=issue-stream)

## Changes in this PR:

Prawn requires the given tables to be formed by rows of strings when rendering them.

The Baptism certificate "filename" was an instance of ActiveStorage::Filename, causing Prawn to blow up when trying to generate the PDF.

Casting the filename into its string output resolves it.

### Bonus: 
Fixes a typo in `Baptism certificate`

### Before
`["Baptism certficate", #<ActiveStorage::Filename:0x00007fece5e95410 @filename="Test Doc.docx">]` :x: 

### After
`["Baptism certificate", "Test Doc.docx"]`  :heavy_check_mark: 

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
