### PR TITLE
Exclude ":name" from Sentry param filtering

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,5 @@
 Sentry.init do |config|
-  filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters - %i[id])
+  filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters - %i[id name])
   config.before_send = lambda do |event, _hint|
     filter.filter(event.to_hash)
   end


### PR DESCRIPTION
## Trello card URL
Follows on:
- Attempt 1: https://github.com/DFE-Digital/teaching-vacancies/pull/7698
- Revert: https://github.com/DFE-Digital/teaching-vacancies/pull/7905

## Changes in this PR:

Rails parameter filtering does partial matching.
So filtering `:name` causes every parameter in Sentry including `name` to be filtered out:
- `server_name`
- `filename` ...

This makes debugging Sentry errors more difficult, as the file info and server name (what is an issue to identify particular review apps raising errors) are filtered out.

The filtering configuration also lists "given_name" and "family_name", so if they are present in the error they will be explicitly filtered anyways.

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
