### PR TITLE
Fix bug which means application update emails get sent to publisher email instead of vacancy contact_email

### DIFF
--- a/app/jobs/send_applications_received_yesterday_job.rb
+++ b/app/jobs/send_applications_received_yesterday_job.rb
@@ -2,19 +2,25 @@ class SendApplicationsReceivedYesterdayJob < ApplicationJob
   queue_as :low
 
   def perform
-    publishers_with_vacancies_with_applications_submitted_yesterday.each do |publisher|
-      next unless publisher.email?
-
-      Publishers::JobApplicationMailer.applications_received(publisher: publisher).deliver_later
-      Rails.logger.info("Sidekiq: Sending job applications received yesterday for publisher id: #{publisher.id}")
+    vacancies_grouped_by_recipient_email.each do |recipient_email, vacancies|
+      Publishers::JobApplicationMailer.applications_received(vacancies: vacancies, recipient_email: recipient_email).deliver_later
+      Rails.logger.info("Sidekiq: Sending job applications received yesterday for #{vacancies.count} vacancies to #{recipient_email}")
     end
   end
 
   private
 
-  def publishers_with_vacancies_with_applications_submitted_yesterday
-    Publisher.distinct
-             .joins(vacancies: :job_applications)
-             .where("DATE(job_applications.submitted_at) = ? AND job_applications.status = ?", Date.yesterday, 1)
+  def vacancies_grouped_by_recipient_email
+    vacancies_with_recipient_emails.group_by(&:recipient_email)
+  end
+
+  def vacancies_with_recipient_emails
+    Vacancy.distinct
+           .includes(:publisher)
+           .joins(:job_applications)
+           .where("DATE(job_applications.submitted_at) = ? AND job_applications.status = ?", Date.yesterday, 1)
+           .where("COALESCE(NULLIF(vacancies.contact_email, ''), publishers.email) IS NOT NULL")
+           .select("vacancies.*, COALESCE(NULLIF(vacancies.contact_email, ''), publishers.email) as recipient_email")
+           .joins(:publisher)
   end
 end

--- a/spec/jobs/send_applications_received_yesterday_job_spec.rb
+++ b/spec/jobs/send_applications_received_yesterday_job_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe SendApplicationsReceivedYesterdayJob do
         publisher = create(:publisher, email: "publisher@example.com")
         vacancy1 = create(:vacancy, contact_email: "hr@school.com", publisher: publisher)
         vacancy2 = create(:vacancy, contact_email: "hr@school.com", publisher: publisher)
-        
+
         create(:job_application, :submitted, vacancy: vacancy1, submitted_at: Date.yesterday)
         create(:job_application, :submitted, vacancy: vacancy2, submitted_at: Date.yesterday)
 
@@ -19,7 +19,7 @@ RSpec.describe SendApplicationsReceivedYesterdayJob do
           .to receive(:applications_received)
           .with(vacancies: [vacancy1, vacancy2], recipient_email: "hr@school.com")
           .and_return(message_delivery)
-        
+
         expect(message_delivery).to receive(:deliver_later)
 
         job.perform
@@ -30,14 +30,14 @@ RSpec.describe SendApplicationsReceivedYesterdayJob do
       it "falls back to publisher email" do
         publisher = create(:publisher, email: "publisher@example.com")
         vacancy = create(:vacancy, contact_email: nil, publisher: publisher)
-        
+
         create(:job_application, :submitted, vacancy: vacancy, submitted_at: Date.yesterday)
 
         expect(Publishers::JobApplicationMailer)
           .to receive(:applications_received)
           .with(vacancies: [vacancy], recipient_email: "publisher@example.com")
           .and_return(message_delivery)
-        
+
         expect(message_delivery).to receive(:deliver_later)
 
         job.perform
@@ -48,14 +48,14 @@ RSpec.describe SendApplicationsReceivedYesterdayJob do
       it "falls back to publisher email" do
         publisher = create(:publisher, email: "publisher@example.com")
         vacancy = create(:vacancy, contact_email: "", publisher: publisher)
-        
+
         create(:job_application, :submitted, vacancy: vacancy, submitted_at: Date.yesterday)
 
         expect(Publishers::JobApplicationMailer)
           .to receive(:applications_received)
           .with(vacancies: [vacancy], recipient_email: "publisher@example.com")
           .and_return(message_delivery)
-        
+
         expect(message_delivery).to receive(:deliver_later)
 
         job.perform
@@ -66,7 +66,7 @@ RSpec.describe SendApplicationsReceivedYesterdayJob do
       it "skips sending email" do
         publisher = create(:publisher, email: nil)
         vacancy = create(:vacancy, contact_email: nil, publisher: publisher)
-        
+
         create(:job_application, :submitted, vacancy: vacancy, submitted_at: Date.yesterday)
 
         expect(Publishers::JobApplicationMailer).not_to receive(:applications_received)
@@ -79,7 +79,7 @@ RSpec.describe SendApplicationsReceivedYesterdayJob do
       it "only includes applications from yesterday" do
         publisher = create(:publisher, email: "publisher@example.com")
         vacancy = create(:vacancy, contact_email: nil, publisher: publisher)
-        
+
         create(:job_application, :submitted, vacancy: vacancy, submitted_at: Date.yesterday)
         create(:job_application, :submitted, vacancy: vacancy, submitted_at: Date.current)
         create(:job_application, :submitted, vacancy: vacancy, submitted_at: 2.days.ago)
@@ -88,7 +88,7 @@ RSpec.describe SendApplicationsReceivedYesterdayJob do
           .to receive(:applications_received)
           .with(vacancies: [vacancy], recipient_email: "publisher@example.com")
           .and_return(message_delivery)
-        
+
         expect(message_delivery).to receive(:deliver_later)
 
         job.perform
@@ -100,11 +100,11 @@ RSpec.describe SendApplicationsReceivedYesterdayJob do
         publisher1 = create(:publisher, email: "publisher1@example.com")
         publisher2 = create(:publisher, email: "publisher2@example.com")
         publisher3 = create(:publisher, email: "publisher3@example.com")
-        
+
         vacancy1 = create(:vacancy, contact_email: "hr@school1.com", publisher: publisher1)
         vacancy2 = create(:vacancy, contact_email: "hr@school1.com", publisher: publisher2) # Different publisher, same contact email
         vacancy3 = create(:vacancy, contact_email: nil, publisher: publisher3)
-        
+
         create(:job_application, :submitted, vacancy: vacancy1, submitted_at: Date.yesterday)
         create(:job_application, :submitted, vacancy: vacancy2, submitted_at: Date.yesterday)
         create(:job_application, :submitted, vacancy: vacancy3, submitted_at: Date.yesterday)
@@ -113,12 +113,12 @@ RSpec.describe SendApplicationsReceivedYesterdayJob do
           .to receive(:applications_received)
           .with(vacancies: [vacancy1, vacancy2], recipient_email: "hr@school1.com")
           .and_return(message_delivery)
-        
+
         expect(Publishers::JobApplicationMailer)
           .to receive(:applications_received)
           .with(vacancies: [vacancy3], recipient_email: "publisher3@example.com")
           .and_return(message_delivery)
-        
+
         expect(message_delivery).to receive(:deliver_later).twice
 
         job.perform

--- a/spec/jobs/send_applications_received_yesterday_job_spec.rb
+++ b/spec/jobs/send_applications_received_yesterday_job_spec.rb
@@ -1,21 +1,128 @@
 require "rails_helper"
 
 RSpec.describe SendApplicationsReceivedYesterdayJob do
-  subject(:job) { described_class.perform_later }
+  subject(:job) { described_class.new }
 
-  let(:publisher) { create(:publisher) }
   let(:message_delivery) { instance_double(ActionMailer::MessageDelivery) }
 
-  before { expect(Publisher).to receive_message_chain(:distinct, :joins, :where).and_return([publisher]) }
+  describe "#perform" do
+    context "when vacancies have contact emails" do
+      it "sends emails to contact emails and groups by recipient" do
+        publisher = create(:publisher, email: "publisher@example.com")
+        vacancy1 = create(:vacancy, contact_email: "hr@school.com", publisher: publisher)
+        vacancy2 = create(:vacancy, contact_email: "hr@school.com", publisher: publisher)
+        
+        create(:job_application, :submitted, vacancy: vacancy1, submitted_at: Date.yesterday)
+        create(:job_application, :submitted, vacancy: vacancy2, submitted_at: Date.yesterday)
 
-  it "sends applications received emails" do
-    expect(Publishers::JobApplicationMailer)
-      .to receive(:applications_received)
-      .with(publisher: publisher)
-      .and_return(message_delivery)
+        expect(Publishers::JobApplicationMailer)
+          .to receive(:applications_received)
+          .with(vacancies: [vacancy1, vacancy2], recipient_email: "hr@school.com")
+          .and_return(message_delivery)
+        
+        expect(message_delivery).to receive(:deliver_later)
 
-    expect(message_delivery).to receive(:deliver_later)
+        job.perform
+      end
+    end
 
-    perform_enqueued_jobs { job }
+    context "when vacancies have no contact email but publisher has email" do
+      it "falls back to publisher email" do
+        publisher = create(:publisher, email: "publisher@example.com")
+        vacancy = create(:vacancy, contact_email: nil, publisher: publisher)
+        
+        create(:job_application, :submitted, vacancy: vacancy, submitted_at: Date.yesterday)
+
+        expect(Publishers::JobApplicationMailer)
+          .to receive(:applications_received)
+          .with(vacancies: [vacancy], recipient_email: "publisher@example.com")
+          .and_return(message_delivery)
+        
+        expect(message_delivery).to receive(:deliver_later)
+
+        job.perform
+      end
+    end
+
+    context "when vacancy has empty contact email" do
+      it "falls back to publisher email" do
+        publisher = create(:publisher, email: "publisher@example.com")
+        vacancy = create(:vacancy, contact_email: "", publisher: publisher)
+        
+        create(:job_application, :submitted, vacancy: vacancy, submitted_at: Date.yesterday)
+
+        expect(Publishers::JobApplicationMailer)
+          .to receive(:applications_received)
+          .with(vacancies: [vacancy], recipient_email: "publisher@example.com")
+          .and_return(message_delivery)
+        
+        expect(message_delivery).to receive(:deliver_later)
+
+        job.perform
+      end
+    end
+
+    context "when neither vacancy nor publisher has email" do
+      it "skips sending email" do
+        publisher = create(:publisher, email: nil)
+        vacancy = create(:vacancy, contact_email: nil, publisher: publisher)
+        
+        create(:job_application, :submitted, vacancy: vacancy, submitted_at: Date.yesterday)
+
+        expect(Publishers::JobApplicationMailer).not_to receive(:applications_received)
+
+        job.perform
+      end
+    end
+
+    context "when applications were submitted on different days" do
+      it "only includes applications from yesterday" do
+        publisher = create(:publisher, email: "publisher@example.com")
+        vacancy = create(:vacancy, contact_email: nil, publisher: publisher)
+        
+        create(:job_application, :submitted, vacancy: vacancy, submitted_at: Date.yesterday)
+        create(:job_application, :submitted, vacancy: vacancy, submitted_at: Date.current)
+        create(:job_application, :submitted, vacancy: vacancy, submitted_at: 2.days.ago)
+
+        expect(Publishers::JobApplicationMailer)
+          .to receive(:applications_received)
+          .with(vacancies: [vacancy], recipient_email: "publisher@example.com")
+          .and_return(message_delivery)
+        
+        expect(message_delivery).to receive(:deliver_later)
+
+        job.perform
+      end
+    end
+
+    context "when multiple recipients exist" do
+      it "sends separate emails to each recipient and groups vacancies by recipient" do
+        publisher1 = create(:publisher, email: "publisher1@example.com")
+        publisher2 = create(:publisher, email: "publisher2@example.com")
+        publisher3 = create(:publisher, email: "publisher3@example.com")
+        
+        vacancy1 = create(:vacancy, contact_email: "hr@school1.com", publisher: publisher1)
+        vacancy2 = create(:vacancy, contact_email: "hr@school1.com", publisher: publisher2) # Different publisher, same contact email
+        vacancy3 = create(:vacancy, contact_email: nil, publisher: publisher3)
+        
+        create(:job_application, :submitted, vacancy: vacancy1, submitted_at: Date.yesterday)
+        create(:job_application, :submitted, vacancy: vacancy2, submitted_at: Date.yesterday)
+        create(:job_application, :submitted, vacancy: vacancy3, submitted_at: Date.yesterday)
+
+        expect(Publishers::JobApplicationMailer)
+          .to receive(:applications_received)
+          .with(vacancies: [vacancy1, vacancy2], recipient_email: "hr@school1.com")
+          .and_return(message_delivery)
+        
+        expect(Publishers::JobApplicationMailer)
+          .to receive(:applications_received)
+          .with(vacancies: [vacancy3], recipient_email: "publisher3@example.com")
+          .and_return(message_delivery)
+        
+        expect(message_delivery).to receive(:deliver_later).twice
+
+        job.perform
+      end
+    end
   end
 end


### PR DESCRIPTION
## Changes in this PR:

We had a support request related to us sending job application updates to the "wrong" hiring staff email. A hiring staff user from an LA was getting the emails rather than the school because we send these emails to the publisher's email. Fisal and I spoke about it and think defaulting to send it the vacancy.contact_email makes more sense, and using publisher.email as a fallback so that is the change I made in this PR.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
