### PR TITLE
Bring full GovUk rebranding

### DIFF
--- a/app/views/layouts/_head_links.html.slim
+++ b/app/views/layouts/_head_links.html.slim
@@ -1,6 +1,6 @@
 / Unlike local assets, these require the `images/` path as it's the parent directory from the
 / NPM package that gets added to the asset path
-link href=image_path("images/favicon.ico") rel="shortcut icon" type=nil sizes="48x48"
-link href=image_path("images/favicon.svg") rel="icon" type="image/svg+xml" sizes="any"
-link href=image_path("images/govuk-icon-mask.svg") rel="mask-icon" color="#0b0c0c" type=nil
-link href=image_path("images/govuk-icon-180.png") rel="apple-touch-icon" type=nil
+link href=image_path("rebrand/images/favicon.ico") rel="shortcut icon" type=nil sizes="48x48"
+link href=image_path("rebrand/images/favicon.svg") rel="icon" type="image/svg+xml" sizes="any"
+link href=image_path("rebrand/images/govuk-icon-mask.svg") rel="mask-icon" color="#0b0c0c" type=nil
+link href=image_path("rebrand/images/govuk-icon-180.png") rel="apple-touch-icon" type=nil

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,5 +1,5 @@
 doctype html
-html.govuk-template.app-html-class lang="en"
+html.govuk-template.govuk-template--rebranded.app-html-class lang="en"
   head
     = render "layouts/vwo_head" if consented_to_extra_cookies?
     = render "layouts/clarity_head" if consented_to_extra_cookies?

--- a/app/views/layouts/application_supportal.html.slim
+++ b/app/views/layouts/application_supportal.html.slim
@@ -1,5 +1,5 @@
 doctype html
-html.govuk-template.app-html-class lang="en"
+html.govuk-template.govuk-template--rebranded.app-html-class lang="en"
   head
     title #{content_for :page_title_prefix} - #{t("app.support_title")}
     = stylesheet_link_tag "application", media: "all"

--- a/app/views/layouts/subscription_campaign.html.slim
+++ b/app/views/layouts/subscription_campaign.html.slim
@@ -1,5 +1,5 @@
 doctype html
-html.govuk-template.app-html-class lang="en"
+html.govuk-template.govuk-template--rebranded.app-html-class lang="en"
   head
     = render "layouts/google_tag_manager_head" if consented_to_extra_cookies?
     = render "layouts/head_meta"


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/BO4DbD3F/2051-govuk-rebrand-implementation
Related to https://github.com/DFE-Digital/teaching-vacancies/pull/7898 from @peteryates :bow: 

## Changes in this PR:

We upgraded the GovUK Components thinking we would need to explicitly set the rebrand on. 
But the blue dot from the rebrand was applied automatically in our service logo:
<img width="403" height="56" alt="image" src="https://github.com/user-attachments/assets/4c0755d5-4168-4c79-a49d-e21a93be7845" />

This PR brings up the whole rebrand style changes to be consisting with GovUK rebranding.

## Screenshots of UI changes:

### Before

**Header and navigation:**
<img width="995" height="188" alt="image" src="https://github.com/user-attachments/assets/1701bae9-abaa-4eef-b473-178783bb9c5f" />

**Favicon**
<img width="113" height="41" alt="image" src="https://github.com/user-attachments/assets/57eff9f7-0526-4cd4-82b2-c766dada0f00" />

**Footer**
<img width="1005" height="698" alt="image" src="https://github.com/user-attachments/assets/e8cb0ffc-a8af-4c22-98a5-0bd718ef8192" />

**Cookies banner**
<img width="659" height="221" alt="image" src="https://github.com/user-attachments/assets/42173f14-a177-4135-88c8-572219eff436" />


### After
**Header and navigation:**
<img width="995" height="188" alt="image" src="https://github.com/user-attachments/assets/d4e0055f-3261-4757-b74d-3fdf6e907f93" />

**Favicon**
<img width="113" height="41" alt="image" src="https://github.com/user-attachments/assets/27ed6f48-711c-41fd-bfc8-5813bf93d3ed" />

**Footer**
<img width="1005" height="698" alt="image" src="https://github.com/user-attachments/assets/2b87b9a3-893f-4556-a710-c3354d70a044" />

**Cookies banner**
<img width="659" height="221" alt="image" src="https://github.com/user-attachments/assets/504aafa1-9a8e-4909-8ec1-56b037788238" />


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
