### PR TITLE
Fix system tests with Cuprite on Devcontainers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,7 +13,7 @@ RUN apt update -yq \
    && curl -sL https://deb.nodesource.com/setup_$NODEJS_MAJOR_VERSION.x | bash
 
 # Set up dependencies
-RUN apt update && apt install -y nodejs postgresql-client redis-tools less vim sudo shared-mime-info man-db
+RUN apt update && apt install -y nodejs postgresql-client redis-tools less vim sudo shared-mime-info man-db chromium
 RUN npm install -g yarn
 
 # Install Terraform


### PR DESCRIPTION
## Changes in this PR:

After switching to Cuprit, there are a few things that weren't working out of the box when running the system tests inside devcontainers:
- Needed to install Chromium in the devcontainers.
- Needed to force headless runs (devcontainers don't have X11 to run a full browser) and tweak their settings.

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
