### PR TITLE
Disable MyNewTerm legacy integration

### DIFF
--- a/app/jobs/import_from_vacancy_sources_job.rb
+++ b/app/jobs/import_from_vacancy_sources_job.rb
@@ -3,7 +3,6 @@ class ImportFromVacancySourcesJob < ApplicationJob
     Vacancies::Import::Sources::Broadbean,
     Vacancies::Import::Sources::Every,
     Vacancies::Import::Sources::Fusion,
-    Vacancies::Import::Sources::MyNewTerm,
     Vacancies::Import::Sources::VacancyPoster,
     Vacancies::Import::Sources::Ventrus,
   ].freeze


### PR DESCRIPTION
MyNewTerm is moving to the new Publisher ATS API integration.

We need to stop this integration from running automatically so there are no clashes in future vacancies posted by them, but we may still need to re-enable this.

I'm doing the minimum change to disable their legacy automated integration until we confirm is safe to completely remove the rest of the code.


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
