### PR TITLE
Fix Publisher accessible orgs when no preferences

### DIFF
--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -26,11 +26,16 @@ class Publisher < ApplicationRecord
   end
 
   def accessible_organisations(current_organisation)
-    publisher_preference = publisher_preferences.find_by(organisation: current_organisation)
-    if publisher_preference.organisations.any?
-      publisher_preference.organisations
-    elsif current_organisation.local_authority?
-      publisher_preference.schools
+    return [] unless current_organisation
+
+    if (publisher_preference = publisher_preferences.find_by(organisation: current_organisation))
+      if publisher_preference.organisations.any?
+        publisher_preference.organisations
+      elsif current_organisation.local_authority?
+        publisher_preference.schools
+      else
+        current_organisation.all_organisations
+      end
     else
       current_organisation.all_organisations
     end

--- a/spec/models/publisher_spec.rb
+++ b/spec/models/publisher_spec.rb
@@ -19,4 +19,157 @@ RSpec.describe Publisher do
       expect(publisher.vacancies_with_job_applications_submitted_yesterday).to eq [vacancy1]
     end
   end
+
+  describe "#accessible_organisations" do
+    subject(:accessible_organisations) { publisher.accessible_organisations(current_organisation) }
+
+    let(:publisher) { create(:publisher) }
+    let(:school) { create(:school) }
+
+    let(:current_organisation) { school }
+
+    context "when no current organisation is given" do
+      let(:current_organisation) { nil }
+
+      it "returns an empty collection" do
+        expect(accessible_organisations).to eq []
+      end
+    end
+
+    context "when the current organisation is a School" do
+      let(:current_organisation) { school }
+
+      context "when the publisher has preferences for the School" do
+        # School preferences if present are empty from orgs as they're created empty by Publishers::VacanciesController#index
+        let!(:publisher_preference) do
+          create(:publisher_preference, publisher: publisher, organisation: current_organisation, organisations: [])
+        end
+
+        it "returns the school" do
+          expect(accessible_organisations).to eq [school]
+        end
+      end
+
+      context "when the publisher has no preferences for the School" do
+        let(:different_organisation) { create(:school) }
+        let!(:publisher_preference) { create(:publisher_preference, publisher: publisher, organisation: different_organisation) }
+
+        it "returns the school" do
+          expect(accessible_organisations).to eq [school]
+        end
+      end
+    end
+
+    context "when the current organisation is a local authority" do
+      let(:la_first_school) { create(:school) }
+      let(:la_second_school) { create(:school) }
+      let(:local_authority) { create(:local_authority, schools: [la_first_school, la_second_school]) }
+      let(:current_organisation) { local_authority }
+
+      context "when the publisher has preferences with organisations for the local authority" do
+        let!(:publisher_preference) do
+          create(:publisher_preference, publisher: publisher, organisation: current_organisation, organisations: [la_first_school], schools: [])
+        end
+
+        it "returns the organisations from its preferences" do
+          expect(accessible_organisations).to eq [la_first_school]
+        end
+      end
+
+      context "when the publisher has preferences with schools for the local authority" do
+        let!(:publisher_preference) do
+          create(:publisher_preference, publisher: publisher, organisation: current_organisation, schools: [la_second_school], organisations: [])
+        end
+
+        it "returns the schools from its preferences" do
+          expect(accessible_organisations).to eq [la_second_school]
+        end
+      end
+
+      context "when the publisher has preferences with both organisations and schools for the local authority" do
+        let!(:publisher_preference) do
+          create(:publisher_preference, publisher: publisher, organisation: current_organisation, organisations: [la_first_school], schools: [la_second_school])
+        end
+
+        it "returns the organisations from its preferences" do
+          expect(accessible_organisations).to eq [la_first_school]
+        end
+      end
+
+      context "when the publisher has preferences without schools or organisations for the local authority" do
+        let!(:publisher_preference) do
+          create(:publisher_preference, publisher: publisher, organisation: current_organisation, organisations: [], schools: [])
+        end
+
+        it "returns an empty collection" do
+          expect(accessible_organisations).to eq []
+        end
+      end
+
+      context "when the publisher has no preferences for the local authority" do
+        let(:different_organisation) { create(:school) }
+        let!(:publisher_preference) { create(:publisher_preference, publisher: publisher, organisation: different_organisation) }
+
+        it "returns the local authority and all its schools" do
+          expect(accessible_organisations).to contain_exactly(local_authority, la_first_school, la_second_school)
+        end
+      end
+    end
+
+    context "when the current organisation is a trust" do
+      let(:trust_first_school) { create(:school) }
+      let(:trust_second_school) { create(:school) }
+      let(:trust) { create(:trust, schools: [trust_first_school, trust_second_school]) }
+      let(:current_organisation) { trust }
+
+      context "when the publisher has preferences with organisations for the trust" do
+        let!(:publisher_preference) do
+          create(:publisher_preference, publisher: publisher, organisation: current_organisation, organisations: [trust_first_school], schools: [])
+        end
+
+        it "returns the organisations from its preferences" do
+          expect(accessible_organisations).to eq [trust_first_school]
+        end
+      end
+
+      context "when the publisher has preferences with schools for the trust" do
+        let!(:publisher_preference) do
+          create(:publisher_preference, publisher: publisher, organisation: current_organisation, schools: [trust_second_school], organisations: [])
+        end
+
+        it "ignores the preferences and returns the trust and all its schools" do
+          expect(accessible_organisations).to contain_exactly(trust, trust_first_school, trust_second_school)
+        end
+      end
+
+      context "when the publisher has preferences with both organisations and schools for the trust" do
+        let!(:publisher_preference) do
+          create(:publisher_preference, publisher: publisher, organisation: current_organisation, organisations: [trust_first_school], schools: [trust_second_school])
+        end
+
+        it "returns the organisations from its preferences" do
+          expect(accessible_organisations).to eq [trust_first_school]
+        end
+      end
+
+      context "when the publisher has preferences without schools or organisations for the trust" do
+        let!(:publisher_preference) do
+          create(:publisher_preference, publisher: publisher, organisation: current_organisation, organisations: [], schools: [])
+        end
+
+        it "returns the trust and all its schools" do
+          expect(accessible_organisations).to contain_exactly(trust, trust_first_school, trust_second_school)
+        end
+      end
+
+      context "when the publisher has no preferences for the trust" do
+        let(:different_organisation) { create(:school) }
+        let!(:publisher_preference) { create(:publisher_preference, publisher: publisher, organisation: different_organisation) }
+
+        it "returns the trust and all its schools" do
+          expect(accessible_organisations).to contain_exactly(trust, trust_first_school, trust_second_school)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
If the Publisher#accessible_organisations method is called from a publisher without preferences created for the organisation, it would result in a no method error.

Guarded against it and covered the method with unit tests for each of the logic branches and their expected output.


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
