### PR TITLE
Little sanity refactor on PublisherPreference creation

### DIFF
--- a/spec/system/publishers/authentication/oauth_spec.rb
+++ b/spec/system/publishers/authentication/oauth_spec.rb
@@ -160,10 +160,10 @@ RSpec.describe "Publisher authentication" do
 
     context "with valid credentials that match a Local Authority" do
       let(:organisation) { create(:local_authority, local_authority_code: "100") }
+      let!(:publisher) { Publisher.find_by(oid: user_oid) }
 
       before do
         allow(Rails.configuration).to receive(:enforce_local_authority_allowlist).and_return(true)
-        allow(PublisherPreference).to receive(:find_by).and_return(publisher_preference)
 
         stub_publisher_authentication_step(school_urn: nil, la_code: organisation.local_authority_code, email: dsi_email_address)
         stub_publisher_authorisation_step
@@ -171,7 +171,9 @@ RSpec.describe "Publisher authentication" do
       end
 
       context "when user preferences have been set" do
-        let(:publisher_preference) { instance_double(PublisherPreference) }
+        before do
+          create(:publisher_preference, publisher: publisher, organisation: organisation)
+        end
 
         it_behaves_like "a successful Publisher sign in"
 
@@ -185,8 +187,6 @@ RSpec.describe "Publisher authentication" do
       end
 
       context "when user preferences have not been set" do
-        let(:publisher_preference) { nil }
-
         it "redirects the sign in page to the publisher preference page" do
           visit new_publisher_session_path
           sign_in_publisher


### PR DESCRIPTION


## Trello card URL

## Changes in this PR:

This is not meant to fully resolve how the PublisherPreferences are designed and implemented.

It just refactors the code in the publisher vacancies controller that is currently retrieving/setting the publisher preference.

The code was hard to read as the related logic was split. Grouping it into a single method/block of code with explicit branching conditions, I aim to help devs to be able to quickly read and understand what is happening in the controller, and allow further improvements on the preferences setup.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
