### PR TITLE
upgrade libpq for CVE-2025-8713

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
  # Alpine v3.22.
  # TODO: Regularly check in the alpine ruby "3.4.5-alpine3.22" images for its latest upgraded packages so we can remove
  # the hardcoded versions below when they have been updated in the alpine ruby image.
-ARG PROD_PACKAGES="imagemagick libpng libjpeg libxml2 libxslt libpq tzdata shared-mime-info postgresql15"
+ARG PROD_PACKAGES="imagemagick libpng libjpeg libxml2 libxslt libpq tzdata shared-mime-info postgresql15 libpq=17.6-r0"
 
 FROM ruby:3.4.5-alpine3.22 AS builder
 


### PR DESCRIPTION
## Changes in this PR:

CVE for libpq 17 "https://www.postgresql.org/support/security/CVE-2025-8713/",

