### PR TITLE
Export candidate date copy change

### DIFF
--- a/app/services/export_candidate_data_service.rb
+++ b/app/services/export_candidate_data_service.rb
@@ -62,7 +62,7 @@ class ExportCandidateDataService
 
   def references(job_application)
     requests = job_application.referees.filter_map(&:reference_request)
-    return Document["no_references.txt", "no request has been sent"] if requests.blank?
+    return Document["no_references_found.txt", "No references have been requested through Teaching Vacancies."] if requests.blank?
 
     requests.map do |request|
       referee_presenter = RefereePresenter.new(request.referee)
@@ -72,7 +72,7 @@ class ExportCandidateDataService
   end
 
   def self_disclosure(job_application)
-    return Document["no_self_disclosure.txt", "the candidate has no self-disclosure on record"] unless job_application.self_disclosure
+    return Document["no_declarations_found.txt", "No self-disclosure form has been submitted through Teaching Vacancies."] unless job_application.self_disclosure
 
     self_disclosure = SelfDisclosurePresenter.new(job_application)
     pdf = SelfDisclosurePdfGenerator.new(self_disclosure).generate

--- a/spec/services/export_candidate_data_service_spec.rb
+++ b/spec/services/export_candidate_data_service_spec.rb
@@ -153,8 +153,8 @@ RSpec.describe ExportCandidateDataService do
     context "when request has not been sent to referee" do
       let(:reference_requests) { [] }
 
-      it { expect(documents.filename).to eq("no_references.txt") }
-      it { expect(documents.data).to eq("no request has been sent") }
+      it { expect(documents.filename).to eq("no_references_found.txt") }
+      it { expect(documents.data).to eq("No references have been requested through Teaching Vacancies.") }
     end
   end
 
@@ -169,8 +169,8 @@ RSpec.describe ExportCandidateDataService do
     context "when job application has no self disclosure" do
       let(:self_disclosure) { nil }
 
-      it { expect(document.filename).to eq("no_self_disclosure.txt") }
-      it { expect(document.data).to eq("the candidate has no self-disclosure on record") }
+      it { expect(document.filename).to eq("no_declarations_found.txt") }
+      it { expect(document.data).to eq("No self-disclosure form has been submitted through Teaching Vacancies.") }
     end
   end
 end


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/1vRjlE2I/2027-update-data-download-button-on-job-offered-tab

## Changes in this PR:

Copy changes when TV does not manage self-disclosure and references

