### PR TITLE
Add `date_updated` to post document metadata

### DIFF
--- a/app/services/markdown_document.rb
+++ b/app/services/markdown_document.rb
@@ -42,6 +42,10 @@ class MarkdownDocument
     Date.parse(@front_matter["date_posted"]) if @front_matter["date_posted"]
   end
 
+  def date_updated
+    Date.parse(@front_matter["date_updated"]) if @front_matter["date_updated"]
+  end
+
   def meta_description
     @front_matter["meta_description"]
   end

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -16,8 +16,15 @@
 
     == @post.content
 
+    - if @post.date_updated
+      span.govuk-body-s
+        = t(".updated_on")
+        time datetime=@post.date_updated.to_fs(:db)
+          =< @post.date_updated.to_fs
+      br
+
     - if @post.date_posted
       span.govuk-body-s
         = t(".published_on")
-        time datetime=@post.date_posted.to_formatted_s(:db)
-          =< @post.date_posted.to_formatted_s
+        time datetime=@post.date_posted.to_fs(:db)
+          =< @post.date_posted.to_fs

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -234,6 +234,7 @@ en:
     show:
       contents: Contents
       published_on: Published on
+      updated_on: Updated on
     subcategory:
       get-help-hiring:
         how-to-create-job-listings-and-accept-applications: >-

--- a/spec/fixtures/files/document.md
+++ b/spec/fixtures/files/document.md
@@ -3,6 +3,7 @@ order: 1
 title: Title
 meta_description: Meta description
 date_posted: 01/01/2022
+date_updated: 01/01/2022
 category_tags: category 1, category 2, category 3
 ---
 ## First heading

--- a/spec/services/markdown_document_spec.rb
+++ b/spec/services/markdown_document_spec.rb
@@ -74,6 +74,22 @@ RSpec.describe MarkdownDocument do
     end
   end
 
+  describe "#date_updated" do
+    context "when there is a date in the front matter" do
+      it "returns a Date" do
+        expect(subject.date_updated).to eq(Date.parse("01/01/2022"))
+      end
+    end
+
+    context "when there is no date in the front matter" do
+      let(:document_content) { file_fixture("document_no_front_matter.md").read }
+
+      it "returns nil" do
+        expect(subject.date_updated).to eq(nil)
+      end
+    end
+  end
+
   describe "#meta_description" do
     it "returns the meta description" do
       expect(subject.meta_description).to eq("Meta description")


### PR DESCRIPTION
## Trello card URL
[2092](https://trello.com/c/GIYELiwf)

## Changes in this PR:

* Markdown document now support an extra metadata field `date_updated`

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>