### PR TITLE
fix up old dependabot config 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,13 +22,9 @@ updates:
       - dependency-name: "redis"
         update-types: ["version-update:semver-major"]
 
-      # TODO: Remove this ignore config once undercover issue has been resolved
-      # Undercover 0.6.x doesn't seeem to respect :nocov: directives properly
-      - dependency-name: "undercover"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
-
-      # TODO: Remove this ignore config once issue with aws-sdk-s3 has been resolved
-      - dependency-name: "aws-sdk-s3"
+      # TODO: Remove this ignore config once undercover is able to parse output
+#     # from simplecov-lcov 0.9
+      - dependency-name: "simplecov-lcov"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
     groups:

--- a/Gemfile
+++ b/Gemfile
@@ -23,8 +23,7 @@ gem "activerecord-session_store"
 gem "active_storage_validations"
 gem "addressable"
 gem "array_enum"
-# something strange with 1.189.1 - it hangs for 6 hours on install
-gem "aws-sdk-s3", "< 1.189.1", require: false
+gem "aws-sdk-s3"
 gem "breasal"
 gem "devise"
 gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.15.7"
@@ -123,9 +122,7 @@ group :development, :test do
   gem "rspec-rails"
   gem "rswag-specs"
   gem "slim_lint", require: false
-  # https://github.com/grodowski/undercover/issues/220
-  # v 0.6 doesn't respect :nocov: tags properly
-  gem "undercover", "< 0.6", require: false
+  gem "undercover", require: false
 end
 
 group :test do
@@ -139,7 +136,8 @@ group :test do
   gem "selenium-webdriver"
   gem "shoulda-matchers"
   gem "simplecov", require: false
-  gem "simplecov-lcov", require: false
+  # Lcov 0.9 breaks undercover's LCov parser
+  gem "simplecov-lcov", "< 0.9", require: false
   gem "site_prism"
   gem "uri-query_params"
   gem "vcr"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,8 +120,8 @@ GEM
     ast (2.4.3)
     attr_required (1.0.2)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1144.0)
-    aws-sdk-core (3.229.0)
+    aws-partitions (1.1151.0)
+    aws-sdk-core (3.230.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
@@ -129,11 +129,11 @@ GEM
       bigdecimal
       jmespath (~> 1, >= 1.6.1)
       logger
-    aws-sdk-kms (1.104.0)
-      aws-sdk-core (~> 3, >= 3.225.0)
+    aws-sdk-kms (1.110.0)
+      aws-sdk-core (~> 3, >= 3.228.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.189.0)
-      aws-sdk-core (~> 3, >= 3.225.0)
+    aws-sdk-s3 (1.197.0)
+      aws-sdk-core (~> 3, >= 3.228.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
     aws-sdk-ssm (1.201.0)
@@ -713,7 +713,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
     rubyzip (3.0.1)
-    rugged (1.7.2)
+    rugged (1.9.0)
     sanitize (7.0.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.16.8)
@@ -813,11 +813,14 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
-    undercover (0.5.0)
+    undercover (0.7.4)
+      base64
       bigdecimal
-      imagen (>= 0.1.8)
+      imagen (>= 0.2.0)
       rainbow (>= 2.1, < 4.0)
-      rugged (>= 0.27, < 1.8)
+      rugged (>= 0.27, < 1.10)
+      simplecov
+      simplecov_json_formatter
     unicode (0.4.4.5)
     unicode-display_width (3.1.5)
       unicode-emoji (~> 4.0, >= 4.0.4)
@@ -899,7 +902,7 @@ DEPENDENCIES
   addressable
   amazing_print
   array_enum
-  aws-sdk-s3 (< 1.189.1)
+  aws-sdk-s3
   aws-sdk-ssm
   better_errors
   binding_of_caller
@@ -995,14 +998,14 @@ DEPENDENCIES
   sidekiq (< 7)
   sidekiq-cron
   simplecov
-  simplecov-lcov
+  simplecov-lcov (< 0.9)
   site_prism
   skylight
   slim-rails
   slim_lint
   solargraph
   tzinfo-data
-  undercover (< 0.6)
+  undercover
   uri-query_params
   valid_email2
   validate_url


### PR DESCRIPTION
## Changes in this PR:

Remove 2 old dependabot configurations.

Add a new one as undercover appears to have its own LCov parser that can't parse the updated LCov format