### PR TITLE
Message archiving

### DIFF
--- a/app/assets/stylesheets/components/messages.scss
+++ b/app/assets/stylesheets/components/messages.scss
@@ -10,3 +10,21 @@
   background-color: govuk-colour('light-grey');
   color: govuk-colour('black');
 }
+
+// Unread message styling - light grey background and bold text
+.message--unread {
+  background-color: govuk-colour('light-grey');
+  
+  // Make all text within unread messages bold
+  .govuk-summary-card__title,
+  .govuk-summary-card__content,
+  .govuk-summary-card__actions {
+    font-weight: bold;
+  }
+}
+
+// Unread conversation styling for table rows
+.conversation--unread {
+  background-color: govuk-colour('light-grey');
+  font-weight: bold;
+}

--- a/app/components/tabs_component.rb
+++ b/app/components/tabs_component.rb
@@ -1,7 +1,7 @@
 class TabsComponent < ApplicationComponent
   renders_many :navigation_items, lambda { |text:, link:, active: false|
     tag.li class: "tabs-component-navigation__item" do
-      active = true if current_page?(link)
+      active = true if current_page?(link, check_parameters: true)
       govuk_link_to text, link, class: "tabs-component-navigation__link", aria: { current: ("page" if active) }
     end
   }

--- a/app/controllers/jobseekers/job_applications_controller.rb
+++ b/app/controllers/jobseekers/job_applications_controller.rb
@@ -116,7 +116,7 @@ class Jobseekers::JobApplicationsController < Jobseekers::JobApplications::BaseC
       conversation = job_application.conversations.first
       @messages = (conversation && conversation.messages.order(created_at: :desc)) || []
       @message_form = Publishers::JobApplication::MessagesForm.new
-      
+
       # Mark publisher messages as read when jobseeker views them
       publisher_messages = @messages.select { |msg| msg.is_a?(PublisherMessage) && msg.unread? }
       publisher_messages.each(&:mark_as_read!)

--- a/app/controllers/jobseekers/job_applications_controller.rb
+++ b/app/controllers/jobseekers/job_applications_controller.rb
@@ -116,6 +116,10 @@ class Jobseekers::JobApplicationsController < Jobseekers::JobApplications::BaseC
       conversation = job_application.conversations.first
       @messages = (conversation && conversation.messages.order(created_at: :desc)) || []
       @message_form = Publishers::JobApplication::MessagesForm.new
+      
+      # Mark publisher messages as read when jobseeker views them
+      publisher_messages = @messages.select { |msg| msg.is_a?(PublisherMessage) && msg.unread? }
+      publisher_messages.each(&:mark_as_read!)
     end
   end
 

--- a/app/controllers/publishers/base_controller.rb
+++ b/app/controllers/publishers/base_controller.rb
@@ -7,6 +7,8 @@ class Publishers::BaseController < ApplicationController
   before_action :check_terms_and_conditions
   before_action :check_candidate_profiles_interstitial_acknowledged
 
+  helper_method :current_user
+
   def check_terms_and_conditions
     redirect_to publishers_terms_and_conditions_path unless current_publisher.accepted_terms_at?
   end

--- a/app/controllers/publishers/candidate_messages_controller.rb
+++ b/app/controllers/publishers/candidate_messages_controller.rb
@@ -5,7 +5,7 @@ class Publishers::CandidateMessagesController < Publishers::BaseController
     organisations_conversations = Conversation.for_organisation(current_organisation.id)
                                               .with_latest_message_date
                                               .includes(job_application: :vacancy, messages: :sender)
-                                              .order("latest_message_at DESC")
+                                              .order(latest_message_at: :desc)
 
     @conversations = @tab == "archive" ? organisations_conversations.archived : organisations_conversations.inbox
 
@@ -18,8 +18,7 @@ class Publishers::CandidateMessagesController < Publishers::BaseController
   def toggle_archive
     conversation_ids = params[:conversations] || []
 
-    Conversation.joins(job_application: :vacancy)
-                .merge(Vacancy.in_organisation_ids(current_organisation.id))
+    Conversation.for_organisation(current_organisation.id)
                 .where(id: conversation_ids)
                 .update_all(archived: params[:archive_action] == "archive")
 

--- a/app/controllers/publishers/candidate_messages_controller.rb
+++ b/app/controllers/publishers/candidate_messages_controller.rb
@@ -11,7 +11,7 @@ class Publishers::CandidateMessagesController < Publishers::BaseController
 
     @conversations = @tab == "archive" ? conversations_query.archived : conversations_query.inbox
 
-    @inbox_count = conversations_query.inbox.count { |conversation| conversation.has_unread_messages_for_publishers? }
+    @inbox_count = conversations_query.inbox.count(&:has_unread_messages_for_publishers?)
   end
 
   def toggle_archive

--- a/app/controllers/publishers/candidate_messages_controller.rb
+++ b/app/controllers/publishers/candidate_messages_controller.rb
@@ -1,0 +1,30 @@
+class Publishers::CandidateMessagesController < Publishers::BaseController
+  def index
+    @tab = params[:tab] || "inbox"
+
+    conversations_query = Conversation.joins(job_application: :vacancy)
+                                     .where(vacancies: { publisher_organisation_id: current_organisation.id })
+                                     .includes(job_application: :vacancy, messages: :sender)
+                                     .joins(:messages)
+                                     .group("conversations.id")
+                                     .order("MAX(messages.created_at) DESC")
+
+    @conversations = @tab == "archive" ? conversations_query.archived : conversations_query.inbox
+
+    @inbox_count = conversations_query.inbox.length
+  end
+
+  def toggle_archive
+    conversation_ids = params[:conversations] || []
+
+    Conversation.joins(job_application: :vacancy)
+                .where(id: conversation_ids, vacancies: { publisher_organisation_id: current_organisation.id })
+                .update_all(archived: params[:archive_action] == "archive")
+
+    if params[:archive_action] == "archive"
+      redirect_to publishers_candidate_messages_path(tab: "archive"), notice: t(".archived")
+    else
+      redirect_to publishers_candidate_messages_path, notice: t(".unarchived")
+    end
+  end
+end

--- a/app/controllers/publishers/candidate_messages_controller.rb
+++ b/app/controllers/publishers/candidate_messages_controller.rb
@@ -2,23 +2,25 @@ class Publishers::CandidateMessagesController < Publishers::BaseController
   def index
     @tab = params[:tab] || "inbox"
 
-    conversations_query = Conversation.joins(job_application: :vacancy)
-                                     .where(vacancies: { publisher_organisation_id: current_organisation.id })
-                                     .includes(job_application: :vacancy, messages: :sender)
-                                     .joins(:messages)
-                                     .group("conversations.id")
-                                     .order("MAX(messages.created_at) DESC")
+    organisations_conversations = Conversation.for_organisation(current_organisation.id)
+                                              .with_latest_message_date
+                                              .includes(job_application: :vacancy, messages: :sender)
+                                              .order("latest_message_at DESC")
 
-    @conversations = @tab == "archive" ? conversations_query.archived : conversations_query.inbox
+    @conversations = @tab == "archive" ? organisations_conversations.archived : organisations_conversations.inbox
 
-    @inbox_count = conversations_query.inbox.count(&:has_unread_messages_for_publishers?)
+    @inbox_count = Conversation.for_organisation(current_organisation.id)
+                               .inbox
+                               .with_unread_jobseeker_messages
+                               .count
   end
 
   def toggle_archive
     conversation_ids = params[:conversations] || []
 
     Conversation.joins(job_application: :vacancy)
-                .where(id: conversation_ids, vacancies: { publisher_organisation_id: current_organisation.id })
+                .merge(Vacancy.in_organisation_ids(current_organisation.id))
+                .where(id: conversation_ids)
                 .update_all(archived: params[:archive_action] == "archive")
 
     if params[:archive_action] == "archive"

--- a/app/controllers/publishers/candidate_messages_controller.rb
+++ b/app/controllers/publishers/candidate_messages_controller.rb
@@ -11,7 +11,7 @@ class Publishers::CandidateMessagesController < Publishers::BaseController
 
     @conversations = @tab == "archive" ? conversations_query.archived : conversations_query.inbox
 
-    @inbox_count = conversations_query.inbox.length
+    @inbox_count = conversations_query.inbox.count { |conversation| conversation.has_unread_messages_for_publishers? }
   end
 
   def toggle_archive

--- a/app/controllers/publishers/vacancies/job_applications/messages_controller.rb
+++ b/app/controllers/publishers/vacancies/job_applications/messages_controller.rb
@@ -7,7 +7,7 @@ class Publishers::Vacancies::JobApplications::MessagesController < Publishers::V
     if message_form.valid?
       conversation = find_or_create_conversation
       PublisherMessage.create!(content: message_form.content, sender: current_publisher, conversation: conversation)
-      redirect_to organisation_job_job_application_path(@vacancy.id, @job_application.id, tab: "messages"), success: t(".success")
+      redirect_to messages_organisation_job_job_application_path(@vacancy.id, @job_application.id), success: t(".success")
     else
       @tab = "messages"
       @show_form = "true"
@@ -21,7 +21,7 @@ class Publishers::Vacancies::JobApplications::MessagesController < Publishers::V
       @message_form = message_form
       @notes_form = Publishers::JobApplication::NotesForm.new
 
-      render "publishers/vacancies/job_applications/show", status: :unprocessable_entity
+      render "publishers/vacancies/job_applications/messages", status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/publishers/vacancies/job_applications_controller.rb
+++ b/app/controllers/publishers/vacancies/job_applications_controller.rb
@@ -71,7 +71,7 @@ class Publishers::Vacancies::JobApplicationsController < Publishers::Vacancies::
     @show_form = params["show_form"]
     @message_form = Publishers::JobApplication::MessagesForm.new
     @messages = @job_application.conversations.includes(:messages).flat_map(&:messages).sort_by(&:created_at).reverse
-    
+
     # Mark jobseeker messages as read when publisher views them
     jobseeker_messages = @messages.select { |msg| msg.is_a?(JobseekerMessage) && msg.unread? }
     jobseeker_messages.each(&:mark_as_read!)

--- a/app/controllers/publishers/vacancies/job_applications_controller.rb
+++ b/app/controllers/publishers/vacancies/job_applications_controller.rb
@@ -9,7 +9,7 @@ class Publishers::Vacancies::JobApplicationsController < Publishers::Vacancies::
     "FeedbackForm" => Publishers::JobApplication::FeedbackForm,
   }.freeze
 
-  before_action :set_job_application, only: %i[show download pre_interview_checks]
+  before_action :set_job_application, only: %i[show download pre_interview_checks messages]
   before_action :set_job_applications, only: %i[index tag]
 
   def index
@@ -19,11 +19,7 @@ class Publishers::Vacancies::JobApplicationsController < Publishers::Vacancies::
 
   def show
     redirect_to organisation_job_job_application_terminal_path(vacancy.id, @job_application) if @job_application.withdrawn?
-    @tab = params["tab"]
-    @show_form = params["show_form"]
     @notes_form = Publishers::JobApplication::NotesForm.new
-    @message_form = Publishers::JobApplication::MessagesForm.new
-    @messages = @job_application.conversations.includes(:messages).flat_map(&:messages).sort_by(&:created_at).reverse
 
     raise ActionController::RoutingError, "Cannot view a draft application" if @job_application.draft?
   end
@@ -69,6 +65,12 @@ class Publishers::Vacancies::JobApplicationsController < Publishers::Vacancies::
 
   def pre_interview_checks
     @reference_requests = @job_application.referees.filter_map(&:reference_request)
+  end
+
+  def messages
+    @show_form = params["show_form"]
+    @message_form = Publishers::JobApplication::MessagesForm.new
+    @messages = @job_application.conversations.includes(:messages).flat_map(&:messages).sort_by(&:created_at).reverse
   end
 
   private

--- a/app/controllers/publishers/vacancies/job_applications_controller.rb
+++ b/app/controllers/publishers/vacancies/job_applications_controller.rb
@@ -71,6 +71,10 @@ class Publishers::Vacancies::JobApplicationsController < Publishers::Vacancies::
     @show_form = params["show_form"]
     @message_form = Publishers::JobApplication::MessagesForm.new
     @messages = @job_application.conversations.includes(:messages).flat_map(&:messages).sort_by(&:created_at).reverse
+    
+    # Mark jobseeker messages as read when publisher views them
+    jobseeker_messages = @messages.select { |msg| msg.is_a?(JobseekerMessage) && msg.unread? }
+    jobseeker_messages.each(&:mark_as_read!)
   end
 
   private

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -4,18 +4,18 @@ class Conversation < ApplicationRecord
 
   scope :inbox, -> { where(archived: false) }
   scope :archived, -> { where(archived: true) }
-  scope :for_organisation, ->(org_id) {
+  scope :for_organisation, lambda { |org_id|
     joins(job_application: :vacancy)
       .merge(Vacancy.in_organisation_ids(org_id))
   }
-  scope :with_latest_message_date, -> {
+  scope :with_latest_message_date, lambda {
     joins(:messages)
       .select("conversations.*, MAX(messages.created_at) as latest_message_at")
       .group("conversations.id")
   }
-  scope :with_unread_jobseeker_messages, -> {
+  scope :with_unread_jobseeker_messages, lambda {
     joins(:messages)
-      .where(messages: { type: 'JobseekerMessage', read: false })
+      .where(messages: { type: "JobseekerMessage", read: false })
       .distinct
   }
 

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -2,6 +2,9 @@ class Conversation < ApplicationRecord
   belongs_to :job_application
   has_many :messages, dependent: :destroy
 
+  scope :inbox, -> { where(archived: false) }
+  scope :archived, -> { where(archived: true) }
+
   def self.default_title_for(job_application)
     "Regarding application: #{job_application.vacancy.job_title}"
   end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -4,6 +4,20 @@ class Conversation < ApplicationRecord
 
   scope :inbox, -> { where(archived: false) }
   scope :archived, -> { where(archived: true) }
+  scope :for_organisation, ->(org_id) {
+    joins(job_application: :vacancy)
+      .merge(Vacancy.in_organisation_ids(org_id))
+  }
+  scope :with_latest_message_date, -> {
+    joins(:messages)
+      .select("conversations.*, MAX(messages.created_at) as latest_message_at")
+      .group("conversations.id")
+  }
+  scope :with_unread_jobseeker_messages, -> {
+    joins(:messages)
+      .where(messages: { type: 'JobseekerMessage', read: false })
+      .distinct
+  }
 
   def self.default_title_for(job_application)
     "Regarding application: #{job_application.vacancy.job_title}"

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -8,4 +8,8 @@ class Conversation < ApplicationRecord
   def self.default_title_for(job_application)
     "Regarding application: #{job_application.vacancy.job_title}"
   end
+
+  def has_unread_messages_for_publishers?
+    messages.any? { |msg| msg.is_a?(JobseekerMessage) && msg.unread? }
+  end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -5,4 +5,15 @@ class Message < ApplicationRecord
   validates :sender_id, presence: true
 
   has_rich_text :content
+
+  scope :unread, -> { where(read: false) }
+  scope :read, -> { where(read: true) }
+
+  def mark_as_read!
+    update!(read: true)
+  end
+
+  def unread?
+    !read?
+  end
 end

--- a/app/views/layouts/_publisher_secondary_nav.html.slim
+++ b/app/views/layouts/_publisher_secondary_nav.html.slim
@@ -4,3 +4,4 @@
       = tabs html_attributes: { "aria-label": "publisher nav", id: "publisher-nav" } do |tabs|
         - tabs.with_navigation_item text: "Job listings", link: organisation_jobs_with_type_path
         - tabs.with_navigation_item text: "Candidate profiles", link: publishers_jobseeker_profiles_path
+        - tabs.with_navigation_item text: "Candidate messages", link: publishers_candidate_messages_path

--- a/app/views/publishers/candidate_messages/index.html.slim
+++ b/app/views/publishers/candidate_messages/index.html.slim
@@ -1,0 +1,44 @@
+- content_for :page_title_prefix, current_organisation.name
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    h1.govuk-heading-xl Candidate messages
+
+    = tabs do |t|
+      - t.with_navigation_item text: "Inbox (#{@inbox_count})", link: publishers_candidate_messages_path, active: @tab == "inbox"
+      - t.with_navigation_item text: "Archive", link: publishers_candidate_messages_path(tab: "archive"), active: @tab == "archive"
+
+    - if @conversations.any?
+      = form_with url: toggle_archive_publishers_candidate_messages_path, method: :patch, local: true do |f|
+        = f.hidden_field :archive_action, value: (@tab == "archive" ? "unarchive" : "archive")
+        .govuk-button-group style="margin-bottom: 20px;"
+          - if @tab == "archive"
+            = f.govuk_submit t(".buttons.unarchive"), class: "govuk-button--secondary"
+          - else
+            = f.govuk_submit t(".buttons.archive"), class: "govuk-button--secondary"
+        = govuk_table html_attributes: { data: { module: "moj-multi-select", multi_select_checkbox: "#multi_select_conversations", multi_select_idprefix: "id_all_conversations" } } do |table|
+          - table.with_head do |head|
+            - head.with_row do |row|
+              - row.with_cell html_attributes: { id: "multi_select_conversations" }
+              - row.with_cell text: t(".table_headers.name")
+              - row.with_cell text: t(".table_headers.application")
+              - row.with_cell text: t(".table_headers.date_and_time")
+          - table.with_body do |body|
+            - @conversations.each do |conversation|
+              - job_application = conversation.job_application
+              - latest_message = conversation.messages.order(created_at: :desc).first
+              - body.with_row do |row|
+                - row.with_cell do
+                  .govuk-checkboxes--small
+                    = f.govuk_check_box :conversations, conversation.id, multiple: true, label: { hidden: true, text: "Select #{job_application.name}" }
+                - row.with_cell do
+                  = govuk_link_to job_application.name, organisation_job_job_application_path(job_application.vacancy.id, job_application.id, tab: "messages")
+                - row.with_cell text: "#{job_application.vacancy.job_title} - #{job_application.status.humanize}"
+                - row.with_cell text: latest_message.created_at.to_fs(:default)
+    - else
+      = govuk_inset_text do
+        p
+          - if @tab == "archive"
+            = t(".empty_state.no_archived_messages")
+          - else
+            = t(".empty_state.no_messages")

--- a/app/views/publishers/candidate_messages/index.html.slim
+++ b/app/views/publishers/candidate_messages/index.html.slim
@@ -5,8 +5,8 @@
     h1.govuk-heading-xl Candidate messages
 
     = tabs do |t|
-      - t.with_navigation_item text: "Inbox (#{@inbox_count})", link: publishers_candidate_messages_path, active: @tab == "inbox"
-      - t.with_navigation_item text: "Archive", link: publishers_candidate_messages_path(tab: "archive"), active: @tab == "archive"
+      - t.with_navigation_item text: "Inbox (#{@inbox_count})", link: publishers_candidate_messages_path
+      - t.with_navigation_item text: "Archive", link: publishers_candidate_messages_path(tab: "archive")
 
     - if @conversations.any?
       = form_with url: toggle_archive_publishers_candidate_messages_path, method: :patch, local: true do |f|
@@ -33,7 +33,7 @@
                     = f.govuk_check_box :conversations, conversation.id, multiple: true, label: { hidden: true, text: "Select #{job_application.name}" }
                 - row.with_cell do
                   = govuk_link_to job_application.name, organisation_job_job_application_path(job_application.vacancy.id, job_application.id, tab: "messages")
-                - row.with_cell text: "#{job_application.vacancy.job_title}"
+                - row.with_cell text: job_application.vacancy.job_title
                 - row.with_cell text: latest_message.created_at.to_fs(:default)
     - else
       = govuk_inset_text do

--- a/app/views/publishers/candidate_messages/index.html.slim
+++ b/app/views/publishers/candidate_messages/index.html.slim
@@ -27,7 +27,7 @@
             - @conversations.each do |conversation|
               - job_application = conversation.job_application
               - latest_message = conversation.messages.order(created_at: :desc).first
-              - body.with_row do |row|
+              - body.with_row html_attributes: { class: ("conversation--unread" if conversation.has_unread_messages_for_publishers?) } do |row|
                 - row.with_cell do
                   .govuk-checkboxes--small
                     = f.govuk_check_box :conversations, conversation.id, multiple: true, label: { hidden: true, text: "Select #{job_application.name}" }

--- a/app/views/publishers/candidate_messages/index.html.slim
+++ b/app/views/publishers/candidate_messages/index.html.slim
@@ -33,7 +33,7 @@
                     = f.govuk_check_box :conversations, conversation.id, multiple: true, label: { hidden: true, text: "Select #{job_application.name}" }
                 - row.with_cell do
                   = govuk_link_to job_application.name, organisation_job_job_application_path(job_application.vacancy.id, job_application.id, tab: "messages")
-                - row.with_cell text: "#{job_application.vacancy.job_title} - #{job_application.status.humanize}"
+                - row.with_cell text: "#{job_application.vacancy.job_title}"
                 - row.with_cell text: latest_message.created_at.to_fs(:default)
     - else
       = govuk_inset_text do

--- a/app/views/publishers/vacancies/job_applications/_header.html.slim
+++ b/app/views/publishers/vacancies/job_applications/_header.html.slim
@@ -17,3 +17,4 @@ h1.govuk-heading-xl class="govuk-!-margin-bottom-5 govuk-!-margin-top-0"
   - tabs.with_navigation_item text: t(".tabs.application"), link: organisation_job_job_application_path(vacancy.id, job_application)
   - if job_application.interviewing?
     - tabs.with_navigation_item text: t(".tabs.pre_interview_checks"), link: pre_interview_checks_organisation_job_job_application_path(vacancy.id, job_application)
+  - tabs.with_navigation_item text: "Messages", link: messages_organisation_job_job_application_path(vacancy.id, job_application.id)

--- a/app/views/publishers/vacancies/job_applications/messages.html.slim
+++ b/app/views/publishers/vacancies/job_applications/messages.html.slim
@@ -14,10 +14,5 @@
               form_help_text: t(".how_will_message_be_sent"),
               form_help_content: t(".message_sent_description")
 
-    - unless @show_form == "true"
-      / Inset text (only show when form is not visible)
-      = govuk_inset_text do
-        = t(".pre_interview_documentation_note")
-
     #messages-list
       = render partial: @messages, locals: { current_user: current_user, job_application: @job_application }

--- a/app/views/publishers/vacancies/job_applications/messages.html.slim
+++ b/app/views/publishers/vacancies/job_applications/messages.html.slim
@@ -1,3 +1,7 @@
+- content_for :page_title_prefix, t(".page_title")
+
+= render "publishers/vacancies/job_applications/header", vacancy: @vacancy, job_application: @job_application
+
 .govuk-grid-row
   .govuk-grid-column-full
     div class="govuk-!-margin-bottom-6"
@@ -6,7 +10,7 @@
     - if @show_form
       = render "shared/message_form",
               message_object: @message_form,
-              form_url: organisation_job_job_application_messages_path(vacancy.id, job_application.id),
+              form_url: organisation_job_job_application_messages_path(vacancy.id, @job_application.id),
               form_help_text: t(".how_will_message_be_sent"),
               form_help_content: t(".message_sent_description")
 
@@ -16,4 +20,4 @@
         = t(".pre_interview_documentation_note")
 
     #messages-list
-      = render partial: messages, locals: { current_user: current_user, job_application: job_application }
+      = render partial: @messages, locals: { current_user: current_user, job_application: @job_application }

--- a/app/views/publishers/vacancies/job_applications/show.html.slim
+++ b/app/views/publishers/vacancies/job_applications/show.html.slim
@@ -11,11 +11,4 @@
       - elsif !@job_application.terminal_status?
         = govuk_button_link_to t("buttons.update_application_status"), tag_organisation_job_job_applications_path(@vacancy.id, params: { publishers_job_application_tag_form: { origin: tab_name(@job_application.status), job_applications: [@job_application.id] } }), class: "govuk-button--secondary"
 
-= tabs do |t|
-  - t.with_navigation_item text: "Application Details & Notes", link: organisation_job_job_application_path(@vacancy.id, @job_application.id, tab: "details"), active: @tab.blank? || @tab == "details"
-  - t.with_navigation_item text: "Messages", link: organisation_job_job_application_path(@vacancy.id, @job_application.id, tab: "messages"), active: (@tab == "messages")
-
-- if @tab == "messages"
-  = render "/publishers/vacancies/job_applications/messages", job_application: @job_application, vacancy: @vacancy, message: @message, messages: @messages, current_user: current_publisher
-- else
-  = render "application_details_and_notes", allow_edit: false, job_application: @job_application, vacancy: @vacancy
+= render "application_details_and_notes", allow_edit: false, job_application: @job_application, vacancy: @vacancy

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -593,3 +593,4 @@ shared:
     - title
     - created_at
     - updated_at
+    - archived

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -587,6 +587,7 @@ shared:
     - created_at
     - updated_at
     - type
+    - read
   :conversations:
     - id
     - job_application_id

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -60,6 +60,21 @@ en:
         one: Working pattern changed to %{new_value}
         other: Working patterns changed to %{new_value}
       show_value_changed: "%{attribute} changed to %{new_value}"
+    candidate_messages:
+      toggle_archive:
+        archived: "You have moved messages to archived"
+        unarchived: "You have moved messages to inbox"
+      index:
+        table_headers:
+          name: "Name"
+          application: "Application" 
+          date_and_time: "Date and time"
+        buttons:
+          archive: "Archive"
+          unarchive: "Unarchive"
+        empty_state:
+          no_messages: "No messages yet."
+          no_archived_messages: "No archived messages yet."
     incomplete_profile:
       complete_link_text: Complete your %{organisation_type} profile
       heading: Complete your %{organisation_type} profile

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -70,8 +70,8 @@ en:
           application: "Application" 
           date_and_time: "Date and time"
         buttons:
-          archive: "Archive"
-          unarchive: "Unarchive"
+          archive: "Archive message"
+          unarchive: "Unarchive message"
         empty_state:
           no_messages: "No messages yet."
           no_archived_messages: "No archived messages yet."
@@ -576,7 +576,6 @@ en:
           message_sent_description: "Candidates will receive a copy of this message to their email and can also view the message when signed in to their Teaching Vacancies account."
           send_message: "Send message"
           cancel: "Cancel"
-          pre_interview_documentation_note: "If a candidate responds with their pre-interview documentation as an attachment, you can mark this as received and completed within the 'Pre-interview checks' section."
           date_prefix: "Date:"
         header:
           status_heading: Applicant status

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -566,6 +566,7 @@ en:
         interviewing_status:
           pre_interview_checks: Pre-interview checks
         messages:
+          page_title: "Messages"
           create:
             success: Message sent successfully
             failure: Message could not be sent

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -218,6 +218,11 @@ Rails.application.routes.draw do
       post :consume, on: :member
     end
     resources :jobseeker_profiles, only: %i[index show]
+    resources :candidate_messages, only: %i[index] do
+      collection do
+        patch :toggle_archive
+      end
+    end
     resource :new_features, only: %i[] do
       get :reminder
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -419,6 +419,9 @@ Rails.application.routes.draw do
         member do
           get :pre_interview_checks
         end
+        member do
+          get :messages
+        end
         resource :self_disclosure, only: %i[show update], controller: "publishers/vacancies/job_applications/self_disclosure"
         resources :collect_reference_flags, only: %i[show update], controller: "publishers/vacancies/collect_reference_flags"
         resources :collect_self_disclosure_flags, only: %i[show update], controller: "publishers/vacancies/collect_self_disclosure_flags"

--- a/db/migrate/20250822000000_add_archived_to_conversations.rb
+++ b/db/migrate/20250822000000_add_archived_to_conversations.rb
@@ -1,0 +1,8 @@
+class AddArchivedToConversations < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_column :conversations, :archived, :boolean, default: false, null: false
+    add_index :conversations, :archived, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20250905144201_add_read_to_messages.rb
+++ b/db/migrate/20250905144201_add_read_to_messages.rb
@@ -1,0 +1,5 @@
+class AddReadToMessages < ActiveRecord::Migration[7.2]
+  def change
+    add_column :messages, :read, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -84,6 +84,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_28_110645) do
     t.string "title"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "archived", default: false, null: false
+    t.index ["archived"], name: "index_conversations_on_archived"
     t.index ["job_application_id"], name: "index_conversations_on_job_application_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_28_110645) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_05_144201) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -460,6 +460,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_28_110645) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "type", null: false
+    t.boolean "read", default: false, null: false
     t.index ["conversation_id"], name: "index_messages_on_conversation_id"
     t.index ["sender_id"], name: "index_messages_on_sender_id"
   end

--- a/spec/system/publishers/publishers_can_archive_candidate_messages_spec.rb
+++ b/spec/system/publishers/publishers_can_archive_candidate_messages_spec.rb
@@ -1,0 +1,135 @@
+require "rails_helper"
+
+RSpec.describe "Publishers can archive and unarchive candidate messages", :js do
+  let(:organisation) { create(:school) }
+  let(:publisher) { create(:publisher) }
+  let(:jobseeker) { create(:jobseeker) }
+
+  let(:health_vacancy) { create(:vacancy, :live, publisher_organisation: organisation) }
+  let(:music_vacancy) { create(:vacancy, :live, publisher_organisation: organisation) }
+
+  let(:health_job_application) { create(:job_application, :status_submitted, vacancy: health_vacancy, jobseeker: jobseeker) }
+  let(:music_job_application) { create(:job_application, :status_submitted, vacancy: music_vacancy, jobseeker: jobseeker) }
+
+  before { login_publisher(publisher: publisher, organisation: organisation) }
+  after { logout }
+
+  context "when conversations exist" do
+    let!(:health_conversation) { create(:conversation, job_application: health_job_application, archived: false) }
+    let!(:music_conversation) { create(:conversation, job_application: music_job_application, archived: false) }
+
+    before do
+      create(:jobseeker_message, conversation: health_conversation, sender: jobseeker)
+      create(:jobseeker_message, conversation: music_conversation, sender: jobseeker)
+    end
+
+    describe "viewing candidate messages" do
+      context "when on the inbox tab" do
+        before do
+          visit publishers_candidate_messages_path
+        end
+
+        it "shows inbox tab with correct count and allows publishers to archive messages" do
+          expect(page).to have_content("Inbox (2)")
+          expect(page).to have_content("Archive")
+
+          within("tbody") do
+            expect(page).to have_content(health_job_application.name)
+            expect(page).to have_content(music_job_application.name)
+            expect(page).to have_no_content("No messages yet")
+          end
+
+          check("Select #{health_job_application.name}", match: :first)
+          click_button "Archive"
+
+          expect(page).to have_content("You have moved messages to archived")
+          expect(page).to have_content("Inbox (1)")
+          expect(health_conversation.reload).to be_archived
+          expect(music_conversation.reload).not_to be_archived
+        end
+
+        context "with multiple conversations selected" do
+          it "archives all selected conversations" do
+            check("Select #{health_job_application.name}", match: :first)
+            check("Select #{music_job_application.name}", match: :first)
+            click_button "Archive"
+
+            expect(page).to have_content("You have moved messages to archived")
+            expect(page).to have_content("Inbox (0)")
+            expect(health_conversation.reload).to be_archived
+            expect(music_conversation.reload).to be_archived
+          end
+        end
+
+        context "with no conversations selected" do
+          it "archives no conversations, with no errors" do
+            click_button "Archive"
+
+            expect(page).to have_content("You have moved messages to archived")
+
+            expect(health_conversation.reload).not_to be_archived
+            expect(music_conversation.reload).not_to be_archived
+          end
+        end
+      end
+    end
+
+    describe "unarchiving conversations" do
+      before do
+        health_conversation.update!(archived: true)
+        music_conversation.update!(archived: true)
+        visit publishers_candidate_messages_path(tab: "archive")
+      end
+
+      context "with single conversation selected" do
+        it "unarchives the selected conversation" do
+          expect(page).to have_content("Inbox (0)")
+          check("Select #{music_job_application.name}", match: :first)
+          click_button "Unarchive"
+
+          expect(page).to have_content("You have moved messages to inbox")
+          expect(music_conversation.reload).not_to be_archived
+          expect(health_conversation.reload).to be_archived
+
+          expect(page).to have_content("Inbox (1)")
+        end
+      end
+
+      context "with multiple conversations selected" do
+        it "unarchives all selected conversations" do
+          check("Select #{health_job_application.name}", match: :first)
+          check("Select #{music_job_application.name}", match: :first)
+          click_button "Unarchive"
+
+          expect(page).to have_content("You have moved messages to inbox")
+          expect(health_conversation.reload).not_to be_archived
+          expect(music_conversation.reload).not_to be_archived
+
+          expect(page).to have_content("Inbox (2)")
+        end
+      end
+
+      context "with no conversations selected" do
+        it "unarchives no conversations, with no errors" do
+          click_button "Unarchive"
+
+          expect(health_conversation.reload).to be_archived
+          expect(music_conversation.reload).to be_archived
+        end
+      end
+    end
+  end
+
+  context "when no conversations exist" do
+    it "tells users no messages exist yet" do
+      visit publishers_candidate_messages_path
+
+      expect(page).to have_content("Inbox (0)")
+      expect(page).to have_content("No messages yet.")
+
+      visit publishers_candidate_messages_path(tab: "archive")
+
+      expect(page).to have_content("No archived messages yet.")
+    end
+  end
+end

--- a/spec/system/publishers/publishers_can_send_messages_to_applicants_spec.rb
+++ b/spec/system/publishers/publishers_can_send_messages_to_applicants_spec.rb
@@ -127,7 +127,6 @@ RSpec.describe "Publishers can send messages to job applicants" do
 
       expect(page).to have_link("Send message to hiring staff")
       expect(page).to have_no_link("Print this page")
-      expect(page).to have_no_text("If a candidate responds with their pre-interview documentation")
 
       click_link "Send message to hiring staff"
 

--- a/spec/system/publishers/publishers_can_send_messages_to_applicants_spec.rb
+++ b/spec/system/publishers/publishers_can_send_messages_to_applicants_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Publishers can send messages to job applicants" do
         create(:publisher_message, conversation: conversation, sender: publisher)
         create(:publisher_message, conversation: conversation, sender: another_publisher)
         create(:jobseeker_message, conversation: conversation, sender: jobseeker)
-        visit organisation_job_job_application_path(vacancy.id, job_application.id, tab: "messages")
+        visit messages_organisation_job_job_application_path(vacancy.id, job_application.id)
       end
 
       # This should be a view test, but it resisted all efforts to make it so.
@@ -37,7 +37,7 @@ RSpec.describe "Publishers can send messages to job applicants" do
 
     context "when viewing a job application messages tab" do
       it "allows publisher to send a message to the job applicant", :js do
-        visit organisation_job_job_application_path(vacancy.id, job_application.id, tab: "messages")
+        visit messages_organisation_job_job_application_path(vacancy.id, job_application.id)
 
         expect(page).to have_link("Print this page")
         expect(page).to have_link("Send message to candidate")
@@ -71,7 +71,7 @@ RSpec.describe "Publishers can send messages to job applicants" do
       let!(:message) { create(:publisher_message, conversation: conversation, sender: publisher, content: "Previous message content") }
 
       it "displays existing messages and allows sending additional messages" do
-        visit organisation_job_job_application_path(vacancy.id, job_application.id, tab: "messages")
+        visit messages_organisation_job_job_application_path(vacancy.id, job_application.id)
 
         expect(page).to have_text("#{publisher.given_name} #{publisher.family_name}")
         expect(page).to have_text("Previous message content")
@@ -93,7 +93,7 @@ RSpec.describe "Publishers can send messages to job applicants" do
       end
 
       it "shows validation errors with existing messages when sending blank message" do
-        visit organisation_job_job_application_path(vacancy.id, job_application.id, tab: "messages")
+        visit messages_organisation_job_job_application_path(vacancy.id, job_application.id)
 
         expect(page).to have_text("Previous message content")
 
@@ -162,7 +162,7 @@ RSpec.describe "Publishers can send messages to job applicants" do
 
       login_publisher(publisher: publisher, organisation: organisation)
 
-      visit organisation_job_job_application_path(vacancy.id, job_application.id, tab: "messages")
+      visit messages_organisation_job_job_application_path(vacancy.id, job_application.id)
 
       expect(page).to have_text("Hello from publisher")
       expect(page).to have_text("Jobseeker reply content")

--- a/spec/system/publishers/publishers_can_view_candidate_messages_spec.rb
+++ b/spec/system/publishers/publishers_can_view_candidate_messages_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe "Publishers can view candidate messages", :js do
 
       visit publishers_candidate_messages_path
       expect(page).to have_content("Inbox (1)")
-      
+
       within("table tbody") do
         expect(page).to have_css("tr.conversation--unread")
       end
@@ -156,7 +156,7 @@ RSpec.describe "Publishers can view candidate messages", :js do
       expect(page).to have_content("Inbox (0)")
 
       within("table tbody") do
-        expect(page).not_to have_css("tr.conversation--unread")
+        expect(page).to have_no_css("tr.conversation--unread")
       end
     end
   end

--- a/spec/system/publishers/publishers_can_view_candidate_messages_spec.rb
+++ b/spec/system/publishers/publishers_can_view_candidate_messages_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Publishers can archive and unarchive candidate messages", :js do
+RSpec.describe "Publishers can view candidate messages", :js do
   let(:organisation) { create(:school) }
   let(:publisher) { create(:publisher) }
   let(:jobseeker) { create(:jobseeker) }
@@ -130,6 +130,34 @@ RSpec.describe "Publishers can archive and unarchive candidate messages", :js do
       visit publishers_candidate_messages_path(tab: "archive")
 
       expect(page).to have_content("No archived messages yet.")
+    end
+  end
+
+  describe "reading messages" do
+    let(:vacancy) { create(:vacancy, :live, organisations: [organisation]) }
+    let(:job_application) { create(:job_application, :submitted, vacancy: vacancy) }
+    let(:jobseeker) { job_application.jobseeker }
+    let!(:conversation) { create(:conversation, job_application: job_application) }
+
+    it "updates inbox total and marks message as read" do
+      create(:jobseeker_message, conversation: conversation, sender: jobseeker, read: false)
+
+      visit publishers_candidate_messages_path
+      expect(page).to have_content("Inbox (1)")
+      
+      within("table tbody") do
+        expect(page).to have_css("tr.conversation--unread")
+      end
+
+      visit messages_organisation_job_job_application_path(vacancy.id, job_application.id)
+
+      visit publishers_candidate_messages_path
+
+      expect(page).to have_content("Inbox (0)")
+
+      within("table tbody") do
+        expect(page).not_to have_css("tr.conversation--unread")
+      end
     end
   end
 end

--- a/spec/system/publishers/publishers_can_view_candidate_messages_spec.rb
+++ b/spec/system/publishers/publishers_can_view_candidate_messages_spec.rb
@@ -2,11 +2,11 @@ require "rails_helper"
 
 RSpec.describe "Publishers can view candidate messages", :js do
   let(:organisation) { create(:school) }
-  let(:publisher) { create(:publisher) }
+  let(:publisher) { create(:publisher, organisations: [organisation]) }
   let(:jobseeker) { create(:jobseeker) }
 
-  let(:health_vacancy) { create(:vacancy, :live, publisher_organisation: organisation) }
-  let(:music_vacancy) { create(:vacancy, :live, publisher_organisation: organisation) }
+  let(:health_vacancy) { create(:vacancy, :live, organisations: [organisation]) }
+  let(:music_vacancy) { create(:vacancy, :live, organisations: [organisation]) }
 
   let(:health_job_application) { create(:job_application, :status_submitted, vacancy: health_vacancy, jobseeker: jobseeker) }
   let(:music_job_application) { create(:job_application, :status_submitted, vacancy: music_vacancy, jobseeker: jobseeker) }


### PR DESCRIPTION
## Trello card URL

- https://trello.com/c/EaN3qvC8/2040-comms-build-ats-message-dashboard
- https://trello.com/c/MDSWL2pL/2041-comms-build-ats-archive-functionality-part-of-message-dashboard

## Changes in this PR:

This PR introduces the MVP of the messages dashboard and allows publishers to archive messages. This does not include any searching or filtering features.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
