### PR TITLE
pin to view_components 3.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,11 @@ updates:
       - dependency-name: "simplecov-lcov"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
+      # TODO: Remove this ignore config when we can upgrade to view components 4.x
+      # which is brought in by govuk-components 5.11.2
+      - dependency-name: "view-components"
+        update-types: ["version-update:semver-major"]
+
     groups:
       gem-dependencies:
         update-types:

--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,8 @@ gem "skylight"
 gem "slim-rails"
 gem "validate_url"
 gem "valid_email2"
+# this upgrade creates 848 test failures
+gem "view_component", "< 4"
 gem "wicked"
 gem "xml-sitemap"
 gem "zendesk_api"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1010,6 +1010,7 @@ DEPENDENCIES
   valid_email2
   validate_url
   vcr
+  view_component (< 4)
   web-console
   webmock
   wicked


### PR DESCRIPTION
## Changes in this PR:

govuk-components 5.11.2 brings in view_components 4.0.x which is completely incompatible with our current code base