### PR TITLE
straighten out pre interview table

### DIFF
--- a/app/views/publishers/vacancies/job_applications/pre_interview_checks.html.slim
+++ b/app/views/publishers/vacancies/job_applications/pre_interview_checks.html.slim
@@ -10,28 +10,24 @@
 = govuk_table html_attributes: { id: "references" } do |table|
   - table.with_head do |head|
     - head.with_row do |row|
-      - row.with_cell(text: t(".references"))
+      - row.with_cell(text: t(".request_type"))
+      - row.with_cell(text: t(".form_requests"))
       - row.with_cell(text: t(".last_action"))
       - row.with_cell(text: t(".status"))
 
   - table.with_body do |body|
     - @reference_requests.each do |reference_request|
       - body.with_row do |row|
+        - row.with_cell(text: t(".reference"))
         - row.with_cell(text: govuk_link_to(reference_request.referee.name, organisation_job_job_application_reference_request_path(vacancy.id, @job_application.id, reference_request)))
         - status = reference_request_status(reference_request, reference_request.referee.job_reference)
 
         - row.with_cell(text: t(".#{status}_at", date: reference_request.updated_at.to_fs(:time_on_date)))
         - row.with_cell(text: govuk_tag(text: t("reference_requests.#{status}.status"), colour: t("reference_requests.#{status}.colour")))
 
-= govuk_table do |table|
-  - table.with_head do |head|
-    - head.with_row do |row|
-      - row.with_cell(text: t(".self_disclosure"))
-      - row.with_cell(text: t(".last_action"))
-      - row.with_cell(text: t(".status"))
-  - table.with_body do |body|
     - if @job_application.self_disclosure_request
       - body.with_row do |row|
+        - row.with_cell(text: t(".self_disclosure"))
         - row.with_cell do
           = govuk_link_to("Self-disclosure form", organisation_job_job_application_self_disclosure_path(vacancy.id, @job_application.id))
         - if @job_application.self_disclosure_request.completed?

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -606,7 +606,9 @@ en:
           received_at: Received %{date}
           declined_at: Declined %{date}
           created_at: Created %{date}
-          references: References
+          form_requests: Form requests
+          reference: Reference
+          request_type: Request type
           last_action: Last action
           self_disclosure: Self-disclosure
           status: Status

--- a/spec/system/publishers/publishers_can_select_a_job_application_for_interview_spec.rb
+++ b/spec/system/publishers/publishers_can_select_a_job_application_for_interview_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Publishers can select a job application for interview", :perform
         click_on "Save and continue"
       end
 
-      scenario "contacting applicant sends emails to referees and applicant", :js do
+      scenario "contacting applicant sends emails to referees and applicant" do
         choose "Yes"
         click_on "Save and continue"
         choose self_disclosure_answer
@@ -146,7 +146,7 @@ RSpec.describe "Publishers can select a job application for interview", :perform
           context "with a simple reference" do
             let(:reference_data) { attributes_for(:job_reference, :reference_given) }
 
-            it "can progress to the page where the reference is shown", :js do
+            it "can progress to the page where the reference is shown" do
               expect(publisher_ats_pre_interview_checks_page).to be_displayed
 
               publisher_ats_pre_interview_checks_page.reference_links.first.click
@@ -206,7 +206,7 @@ RSpec.describe "Publishers can select a job application for interview", :perform
                              unable_to_undertake_reason: undertake_reason)
             end
 
-            it "can progress to the page where the reference is shown", :js do
+            it "can progress to the page where the reference is shown" do
               expect(publisher_ats_pre_interview_checks_page).to be_displayed
 
               publisher_ats_pre_interview_checks_page.reference_links.first.click
@@ -286,7 +286,8 @@ RSpec.describe "Publishers can select a job application for interview", :perform
                 .to contain_exactly("employer@contoso.com", "previous@contoso.com")
 
               expect(publisher_ats_pre_interview_checks_page).to be_displayed
-              expect(publisher_ats_pre_interview_checks_page.reference_links.count).to eq(2)
+              # This now includes the self disclosure
+              expect(publisher_ats_pre_interview_checks_page.reference_links.count).to eq(3)
               publisher_ats_pre_interview_checks_page.reference_links.first.click
 
               expect(publisher_ats_reference_request_page).to be_displayed
@@ -301,7 +302,7 @@ RSpec.describe "Publishers can select a job application for interview", :perform
                 .to contain_exactly("employer@contoso.com", "previous@contoso.com", "jobseeker@contoso.com")
 
               expect(publisher_ats_pre_interview_checks_page).to be_displayed
-              publisher_ats_pre_interview_checks_page.reference_links.last.click
+              publisher_ats_pre_interview_checks_page.reference_links.first.click
 
               expect(publisher_ats_reference_request_page).to be_displayed
               expect(publisher_ats_reference_request_page.timeline_titles.map(&:text))


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/1dfEjRuj/2113-alter-layout-of-pre-interview-checks-table-to-fix-misalignment

## Changes in this PR:

Tidy display layout

## Screenshots of UI changes:

### Before
<img width="1071" height="249" alt="BeforeTidy" src="https://github.com/user-attachments/assets/d4040438-1a21-47b8-ab37-fd1bed5618dd" />


### After
<img width="1046" height="194" alt="AfterTidy" src="https://github.com/user-attachments/assets/2d526ef6-9a93-4e59-a7c5-526b0656e2b8" />

