### PR TITLE
show pre-interview tab on statuses after interviewing

### DIFF
--- a/app/components/tab_panel_component.rb
+++ b/app/components/tab_panel_component.rb
@@ -62,8 +62,7 @@ class TabPanelComponent < ApplicationComponent
   end
 
   def candidate_status(application)
-    # we want to show this tab if the application has ever been in the 'interviewing' state
-    if application.interviewing_at.present?
+    if application.has_pre_interview_checks?
       tag.div do
         publisher_job_application_status_tag(application.status) \
         + tag.br \

--- a/app/views/publishers/vacancies/job_applications/_header.html.slim
+++ b/app/views/publishers/vacancies/job_applications/_header.html.slim
@@ -15,5 +15,5 @@ h1.govuk-heading-xl class="govuk-!-margin-bottom-5 govuk-!-margin-top-0"
 
 = tabs do |tabs|
   - tabs.with_navigation_item text: t(".tabs.application"), link: organisation_job_job_application_path(vacancy.id, job_application)
-  - if job_application.interviewing?
+  - if job_application.has_pre_interview_checks?
     - tabs.with_navigation_item text: t(".tabs.pre_interview_checks"), link: pre_interview_checks_organisation_job_job_application_path(vacancy.id, job_application)


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/YPfF6i8g/2112-show-pre-interview-checks-tab-from-interviewing-status-onwards

## Changes in this PR:

Show pre-interview tab when there is something to display