### PR TITLE
restore applications tab for Local authorities

### DIFF
--- a/app/views/publishers/vacancies/_tabs.html.slim
+++ b/app/views/publishers/vacancies/_tabs.html.slim
@@ -1,6 +1,6 @@
 = tabs(classes: %w[job-applications-nav]) do |tabs|
   - tabs.with_navigation_item text: t("buttons.job_listing"), link: organisation_job_path(vacancy.id), active: controller_name == "vacancies"
-  - if (vacancy.can_receive_job_applications? || vacancy.uploaded_form?) && !current_organisation.local_authority?
+  - if vacancy.can_receive_job_applications? || vacancy.uploaded_form?
     - tabs.with_navigation_item text: t("tabs.applications.hide_count"), link: organisation_job_job_applications_path(vacancy.id), active: controller_name == "job_applications"
   - if vacancy.published?
     - tabs.with_navigation_item text: t("tabs.statistics"), link: organisation_job_statistics_path(vacancy.id), active: controller_name == "statistics"


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/4Jg7sZzf/2134-show-application-tab-for-la-users

## Changes in this PR:

Current 'Applications' tab wasn't shown for LAs

## Screenshots of UI changes:

### Before
<img width="1107" height="402" alt="BeforeLATab" src="https://github.com/user-attachments/assets/c2b890cc-9ca3-4934-b5da-b76648d9a7ca" />


### After
<img width="1040" height="275" alt="AfterLAAppsTab" src="https://github.com/user-attachments/assets/60e5794c-9a4c-422c-911f-98e40e6a183f" />


