### PR TITLE
Update vision-statement.html.slim

### DIFF
--- a/app/views/pages/vision-statement.html.slim
+++ b/app/views/pages/vision-statement.html.slim
@@ -11,7 +11,7 @@
       | Read our #{govuk_link_to("guidance on eligibility", "/get-help-hiring/how-to-setup-your-account/check-your-eligibility-to-advertise-roles")} to make sure your school can advertise roles using our service.
 
     p.govuk-body
-      | Since launching the Teaching Vacancies service in April 2019, our mission has been to help schools save time and money on recruitment advertising. We estimate that, in total, schools using Teaching Vacancies have saved between £47.3 and £60.8 million from September 2018 to August 2024.
+      | Since launching the Teaching Vacancies service in April 2019, our mission has been to help schools save time and money on recruitment advertising. We estimate that, in total, schools using Teaching Vacancies have saved between £63.7 and £84.2 million from September 2018 to August 2025.
 
     p.govuk-body
       | To achieve our mission, we accept integrations through our application programming interface (API) from applicant tracking systems or other publicly funded services if they meet our service scope, and their business aims and values align with ours.


### PR DESCRIPTION
I've updated line 14 to match the figures in the latest version of our savings methodology and '2024' is now '2025'.

## Trello card URL
https://trello.com/c/ive6o17T/2149-update-vision-statement

## Changes in this PR:
I've updated the figures to match our savings methodology (republished last Monday) and '2024' has become '2025'.

- Is there anything specific you want feedback on?

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
