### PR TITLE
Format note timestamp

### DIFF
--- a/app/components/publisher_notes_on_job_application_component.html.slim
+++ b/app/components/publisher_notes_on_job_application_component.html.slim
@@ -5,7 +5,7 @@
   .govuk-summary-card__content
     - job_application.notes.each do |note|
       p.govuk-body-m = note.content
-      p.govuk-body-s By #{note.publisher.given_name} #{note.publisher.family_name}, #{note.created_at}
+      p.govuk-body-s By #{note.publisher.given_name} #{note.publisher.family_name}, #{note.created_at.to_fs}
       - delete_params = return_to_url ? { return_to: return_to_url } : {}
       = govuk_link_to(t("buttons.delete"), organisation_job_job_application_note_path(vacancy.id, job_application, note, delete_params), method: :delete)
       hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible

--- a/spec/components/publisher_notes_on_job_application_component_spec.rb
+++ b/spec/components/publisher_notes_on_job_application_component_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe PublisherNotesOnJobApplicationComponent, type: :component do
+  let(:notes_component) { Capybara.string(render_component) }
+  let(:component) { described_class.new(job_application:, vacancy:, notes_form:) }
+  let(:render_component) { render_inline(component) }
+  let(:notes_form) { Publishers::JobApplication::NotesForm.new }
+  let(:note) { build_stubbed(:note, created_at:) }
+  let(:job_application) { note.job_application }
+  let(:vacancy) { job_application.vacancy }
+  let(:created_at) { Time.zone.now }
+
+  before do
+    allow(job_application).to receive(:notes).and_return([note])
+    notes_component
+  end
+
+  it "renders formatted note timestamp" do
+    expect(notes_component.find("p.govuk-body-s").text).to include(created_at.to_fs)
+  end
+end


### PR DESCRIPTION
## Trello card URL
[2145](https://trello.com/c/Or6dhXLe)

## Changes in this PR:

- format note timestamp

## Screenshots of UI changes:

### Before
<img width="416" height="278" alt="Screenshot from 2025-09-09 17-16-02" src="https://github.com/user-attachments/assets/3d21efb1-0434-42a7-93ba-c79337d51d14" />

### After
<img width="416" height="278" alt="Screenshot from 2025-09-09 17-15-31" src="https://github.com/user-attachments/assets/39a9f242-a821-4fed-8edf-dade1741f61f" />


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>