### PR TITLE
feat(2438): tv - AKS containers run as non root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ ENV ENV="/root/.ashrc"
 ARG COMMIT_SHA
 ENV COMMIT_SHA=$COMMIT_SHA
 
-RUN mkdir /app/tmp
+RUN mkdir -p /app/tmp /app/log
 RUN chown -hR appuser:appgroup /app/tmp /app/log
 USER 10001
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ RUN rm -rf node_modules log tmp yarn.lock && \
 # this stage reduces the image size.
 FROM ruby:3.4.3-alpine3.21 AS production
 
+RUN addgroup -S appgroup -g 20001 && adduser -S appuser -G appgroup -u 10001
 WORKDIR /app
 
 ARG PROD_PACKAGES
@@ -68,5 +69,8 @@ ENV ENV="/root/.ashrc"
 ARG COMMIT_SHA
 ENV COMMIT_SHA=$COMMIT_SHA
 
+RUN mkdir /app/tmp
+RUN chown -hR appuser:appgroup /app/tmp
+USER 10001
 EXPOSE 3000
 CMD bundle exec rails db:migrate:ignore_concurrent_migration_exceptions && bundle exec rails s

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ ARG COMMIT_SHA
 ENV COMMIT_SHA=$COMMIT_SHA
 
 RUN mkdir /app/tmp
-RUN chown -hR appuser:appgroup /app/tmp
+RUN chown -hR appuser:appgroup /app/tmp /app/log
 USER 10001
 EXPOSE 3000
 CMD bundle exec rails db:migrate:ignore_concurrent_migration_exceptions && bundle exec rails s

--- a/terraform/app/modules/paas/aks_application.tf
+++ b/terraform/app/modules/paas/aks_application.tf
@@ -48,6 +48,7 @@ module "web_application" {
   cluster_configuration_map  = module.cluster_data.configuration_map
   kubernetes_config_map_name = module.application_configuration.kubernetes_config_map_name
   kubernetes_secret_name     = module.application_configuration.kubernetes_secret_name
+  run_as_non_root            = var.run_as_non_root
 
   docker_image           = var.app_docker_image
   command                = var.aks_web_app_start_command
@@ -71,6 +72,7 @@ module "worker_application" {
   cluster_configuration_map  = module.cluster_data.configuration_map
   kubernetes_config_map_name = module.application_configuration.kubernetes_config_map_name
   kubernetes_secret_name     = module.application_configuration.kubernetes_secret_name
+  run_as_non_root            = var.run_as_non_root
 
   docker_image   = var.app_docker_image
   command        = ["/bin/sh", "-c", "bundle exec sidekiq -C config/sidekiq.yml"]

--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -103,6 +103,12 @@ variable "dataset_name" {
   description = "dfe analytics dataset name in Google Bigquery"
 }
 
+variable "run_as_non_root" {
+  type        = bool
+  default     = true
+  description = "Whether to enforce that containers must run as non-root user"
+}
+
 locals {
   postgres_ssl_mode = var.enable_postgres_ssl ? "require" : "disable"
 


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/K3lSRfxS/2438-security-aks-containers-run-as-non-root-user-tv

## Changes in this PR:
- ensuring both that the docker container is configured to run as non-root-user and terraform enforces a non-root user

## Screenshots of UI changes:

### Before
- container runs as root
<img width="1418" height="195" alt="Screenshot from 2025-09-10 14-58-57" src="https://github.com/user-attachments/assets/8420ded2-94d3-4c9f-b0cf-567d94a2b47e" />


### After
- container runs as non-root
<img width="1434" height="158" alt="Screenshot from 2025-09-10 14-57-12" src="https://github.com/user-attachments/assets/cdef8ee5-ac6a-421d-bd02-08d8e42c7263" />



## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
