### PR TITLE
Revert "feat(2438): tv - AKS containers run as non root user"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,6 @@ RUN rm -rf node_modules log tmp yarn.lock && \
 # this stage reduces the image size.
 FROM ruby:3.4.5-alpine3.22 AS production
 
-RUN addgroup -S appgroup -g 20001 && adduser -S appuser -G appgroup -u 10001
 WORKDIR /app
 
 ARG PROD_PACKAGES
@@ -67,8 +66,5 @@ ENV ENV="/root/.ashrc"
 ARG COMMIT_SHA
 ENV COMMIT_SHA=$COMMIT_SHA
 
-RUN mkdir -p /app/tmp /app/log
-RUN chown -hR appuser:appgroup /app/tmp /app/log
-USER 10001
 EXPOSE 3000
 CMD bundle exec rails db:migrate:ignore_concurrent_migration_exceptions && bundle exec rails s

--- a/terraform/app/modules/paas/aks_application.tf
+++ b/terraform/app/modules/paas/aks_application.tf
@@ -48,7 +48,6 @@ module "web_application" {
   cluster_configuration_map  = module.cluster_data.configuration_map
   kubernetes_config_map_name = module.application_configuration.kubernetes_config_map_name
   kubernetes_secret_name     = module.application_configuration.kubernetes_secret_name
-  run_as_non_root            = var.run_as_non_root
 
   docker_image           = var.app_docker_image
   command                = var.aks_web_app_start_command
@@ -77,7 +76,6 @@ module "worker_application" {
   cluster_configuration_map  = module.cluster_data.configuration_map
   kubernetes_config_map_name = module.application_configuration.kubernetes_config_map_name
   kubernetes_secret_name     = module.application_configuration.kubernetes_secret_name
-  run_as_non_root            = var.run_as_non_root
 
   docker_image   = var.app_docker_image
   command        = ["/bin/sh", "-c", "bundle exec sidekiq -C config/sidekiq.yml"]

--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -103,12 +103,6 @@ variable "dataset_name" {
   description = "dfe analytics dataset name in Google Bigquery"
 }
 
-variable "run_as_non_root" {
-  type        = bool
-  default     = true
-  description = "Whether to enforce that containers must run as non-root user"
-}
-
 locals {
   postgres_ssl_mode = var.enable_postgres_ssl ? "require" : "disable"
 


### PR DESCRIPTION
Reverts DFE-Digital/teaching-vacancies#8059

Seems to be related with the permission issue when trying to read files for antivirus check: https://teaching-vacancies.sentry.io/issues/6880431324/?environment=production&project=6212514&query=is%3Aunresolved&referrer=issue-stream