### PR TITLE
Fix document virus check tempfile download path

### DIFF
--- a/app/services/publishers/document_virus_check.rb
+++ b/app/services/publishers/document_virus_check.rb
@@ -21,7 +21,7 @@ class Publishers::DocumentVirusCheck
     drive_service.get_file(
       uploaded_file.id,
       acknowledge_abuse: false,
-      download_dest: uploaded_file.id.to_s,
+      download_dest: Rails.root.join("tmp", uploaded_file.id.to_s).to_s,
     )
 
     true
@@ -31,7 +31,7 @@ class Publishers::DocumentVirusCheck
     raise e
   ensure
     if drive_service
-      FileUtils.rm_rf(uploaded_file.id.to_s)
+      FileUtils.rm_rf(Rails.root.join("tmp", uploaded_file.id.to_s).to_s)
       drive_service.delete_file(uploaded_file.id)
     end
   end

--- a/spec/services/publishers/document_virus_check_spec.rb
+++ b/spec/services/publishers/document_virus_check_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Publishers::DocumentVirusCheck do
     context "when the file downloads fine" do
       before do
         expect(drive_service).to receive(:get_file)
-          .with("0xDECAFBAD", acknowledge_abuse: false, download_dest: "0xDECAFBAD")
+          .with("0xDECAFBAD", acknowledge_abuse: false, download_dest: Rails.root.join("tmp/0xDECAFBAD").to_s)
           .and_return(true)
       end
 
@@ -46,7 +46,7 @@ RSpec.describe Publishers::DocumentVirusCheck do
 
       it "deletes the temporary downloaded file and the file on Google Drive" do
         expect(drive_service).to receive(:delete_file).with("0xDECAFBAD")
-        expect(FileUtils).to receive(:rm_rf).with("0xDECAFBAD").and_return(true)
+        expect(FileUtils).to receive(:rm_rf).with(Rails.root.join("tmp/0xDECAFBAD").to_s).and_return(true)
 
         subject.safe?
       end
@@ -55,7 +55,7 @@ RSpec.describe Publishers::DocumentVirusCheck do
     context "when the file does not download due to a virus" do
       before do
         expect(drive_service).to receive(:get_file)
-          .with("0xDECAFBAD", acknowledge_abuse: false, download_dest: "0xDECAFBAD")
+          .with("0xDECAFBAD", acknowledge_abuse: false, download_dest: Rails.root.join("tmp/0xDECAFBAD").to_s)
           .and_raise(Google::Apis::ClientError.new("Whoops", status_code: 403))
       end
 
@@ -90,7 +90,7 @@ RSpec.describe Publishers::DocumentVirusCheck do
       before do
         expect(drive_service)
           .to receive(:get_file)
-                .with("0xDECAFBAD", acknowledge_abuse: false, download_dest: "0xDECAFBAD")
+                .with("0xDECAFBAD", acknowledge_abuse: false, download_dest: Rails.root.join("tmp/0xDECAFBAD").to_s)
                 .and_raise(error)
       end
 


### PR DESCRIPTION


## Trello card URL
- Related to: 
  - https://github.com/DFE-Digital/teaching-vacancies/pull/8069
  - https://github.com/DFE-Digital/teaching-vacancies/pull/8059
  -  
## Changes in this PR:

The document virus check process was using the project root as destination for the scanned file to be downloaded prior to be checked for safety and deleted.

This was innocuous until our infra team tried to change the permissions for our Docker images, and the file uploads started failing during the antivirus check.

Resolving it by downloading the files where they belong: The project "tmp" folder.
This folder has explicit permissions with the new Docker user permissions approach.

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
