### PR TITLE
Add links to set job_application status date

### DIFF
--- a/app/components/tab_panel_component.rb
+++ b/app/components/tab_panel_component.rb
@@ -77,7 +77,7 @@ class TabPanelComponent < ApplicationComponent
     if application.offered_at
       application.offered_at.to_fs(:day_month_year)
     else
-      govuk_link_to(t("tabs.offered.add_job_offer_date"), tag_organisation_job_job_applications_path(application.vacancy.id, params: { publishers_job_application_tag_form: { origin: :offered, job_applications: [application.id] }, tag_action: "job_offer" }))
+      govuk_link_to(t("tabs.offered.add_job_offer_date"), tag_organisation_job_job_applications_path(application.vacancy.id, params: { publishers_job_application_tag_form: { origin: :offered, job_applications: [application.id] }, tag_action: "offered" }))
     end
   end
 

--- a/app/components/tab_panel_component.rb
+++ b/app/components/tab_panel_component.rb
@@ -74,11 +74,19 @@ class TabPanelComponent < ApplicationComponent
   end
 
   def candidate_offered_at(application)
-    application.offered_at&.to_fs(:day_month_year)
+    if application.offered_at
+      application.offered_at.to_fs(:day_month_year)
+    else
+      govuk_link_to(t("tabs.offered.add_job_offer_date"), tag_organisation_job_job_applications_path(application.vacancy.id, params: { publishers_job_application_tag_form: { origin: :offered, job_applications: [application.id] }, tag_action: "job_offer" }))
+    end
   end
 
   def candidate_declined_at(application)
-    application.declined_at&.to_fs(:day_month_year)
+    if application.declined_at
+      application.declined_at.to_fs(:day_month_year)
+    else
+      govuk_link_to(t("tabs.offered.add_decline_date"), tag_organisation_job_job_applications_path(application.vacancy.id, params: { publishers_job_application_tag_form: { origin: :offered, job_applications: [application.id] }, tag_action: "declined" }))
+    end
   end
 
   def candidate_interview_feedback_received_at(application)

--- a/app/components/tab_panel_component.rb
+++ b/app/components/tab_panel_component.rb
@@ -90,6 +90,10 @@ class TabPanelComponent < ApplicationComponent
   end
 
   def candidate_interview_feedback_received_at(application)
-    application.interview_feedback_received_at&.to_fs(:day_month_year)
+    if application.interview_feedback_received_at
+      application.interview_feedback_received_at.to_fs(:day_month_year)
+    else
+      govuk_link_to(t("tabs.offered.add_feedback_date"), tag_organisation_job_job_applications_path(application.vacancy.id, params: { publishers_job_application_tag_form: { origin: :interviewing, job_applications: [application.id] }, tag_action: "unsuccessful_interview" }))
+    end
   end
 end

--- a/app/controllers/publishers/vacancies/job_applications_controller.rb
+++ b/app/controllers/publishers/vacancies/job_applications_controller.rb
@@ -36,6 +36,8 @@ class Publishers::Vacancies::JobApplicationsController < Publishers::Vacancies::
       when "download" then download_selected(form.job_applications)
       when "export"   then export_selected(form.job_applications)
       when "declined" then render_declined_form(form.job_applications, form.origin)
+      when "offered"  then render_offered_form(form.job_applications, form.origin)
+      when "unsuccessful_interview" then render_unsuccessful_interview_form(form.job_applications, form.origin)
       else # when "update_status"
         render "tag"
       end

--- a/config/locales/publishers/job_application_status_form.yml
+++ b/config/locales/publishers/job_application_status_form.yml
@@ -103,7 +103,7 @@ en:
         status_options:
           submitted_html: New <span class="govuk-tag govuk-tag--blue">New</span>
           unsuccessful_html: Not progressing <span class="govuk-tag govuk-tag--red">Not progressing</span>
-          unsuccessful_interview_html: Interview unsuccessful <span class="govuk-tag govuk-tag--red">Not progressing</span>
+          unsuccessful_interview_html: Interview unsuccessful
           reviewed_html: Reviewed <span class="govuk-tag govuk-tag--purple">Reviewed</span>
           shortlisted_html: Shortlisted <span class="govuk-tag govuk-tag--yellow">Shortlisted</span>
           interviewing_html: Interviewing <span class="govuk-tag govuk-tag--green">Interviewing</span>

--- a/config/locales/publishers/vacancies/tabs.yml
+++ b/config/locales/publishers/vacancies/tabs.yml
@@ -43,6 +43,7 @@ en:
       offered_inset: When you download this data, you will receive a ZIP file. This file contains all the selected candidate's personally identifiable information and application details.
       add_decline_date: Add decline date
       add_job_offer_date: Add job offer date
+      add_feedback_date: Add feedback date
     declined:
       heading: Offer declined
       none: No applications have been declined yet

--- a/config/locales/publishers/vacancies/tabs.yml
+++ b/config/locales/publishers/vacancies/tabs.yml
@@ -41,6 +41,8 @@ en:
       hint: ""
       none: No applications have been offered yet
       offered_inset: When you download this data, you will receive a ZIP file. This file contains all the selected candidate's personally identifiable information and application details.
+      add_decline_date: Add decline date
+      add_job_offer_date: Add job offer date
     declined:
       heading: Offer declined
       none: No applications have been declined yet

--- a/spec/components/tab_panel_component_spec.rb
+++ b/spec/components/tab_panel_component_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe TabPanelComponent, type: :component do
     context "when date nil" do
       let(:candidates) { build_stubbed_list(:job_application, 1, :status_declined, vacancy:, declined_at: nil) }
 
-      it { expect(component.candidate_declined_at(candidates.first)).to be_nil }
+      it { expect(tab_panel.find(".declined_at")).to have_link("Add decline date", href: Rails.application.routes.url_helpers.tag_organisation_job_job_applications_path(vacancy.id, params: { publishers_job_application_tag_form: { origin: :offered, job_applications: [candidates.first] }, tag_action: "declined" })) }
     end
   end
 

--- a/spec/components/tab_panel_component_spec.rb
+++ b/spec/components/tab_panel_component_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe TabPanelComponent, type: :component do
     context "when date nil" do
       let(:candidates) { build_stubbed_list(:job_application, 1, :status_unsuccessful_interview, vacancy:, interview_feedback_received_at: nil) }
 
-      it { expect(component.candidate_interview_feedback_received_at(candidates.first)).to be_nil }
+      it { expect(tab_panel.find(".interview_feedback_received_at")).to have_link("Add feedback date", href: Rails.application.routes.url_helpers.tag_organisation_job_job_applications_path(vacancy.id, params: { publishers_job_application_tag_form: { origin: :interviewing, job_applications: [candidates.first] }, tag_action: "unsuccessful_interview" })) }
     end
   end
 end

--- a/spec/components/tab_panel_component_spec.rb
+++ b/spec/components/tab_panel_component_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe TabPanelComponent, type: :component do
     context "when date nil" do
       let(:candidates) { build_stubbed_list(:job_application, 1, :status_offered, vacancy:, offered_at: nil) }
 
-      it { expect(component.candidate_offered_at(candidates.first)).to be_nil }
+      it { expect(tab_panel.find(".offered_at")).to have_link("Add job offer date", href: Rails.application.routes.url_helpers.tag_organisation_job_job_applications_path(vacancy.id, params: { publishers_job_application_tag_form: { origin: :offered, job_applications: [candidates.first] }, tag_action: "offered" })) }
     end
   end
 

--- a/spec/page_objects/pages/application.rb
+++ b/spec/page_objects/pages/application.rb
@@ -20,6 +20,7 @@ module PageObjects
         publisher_ats_satisfactory_reference: "Publisher::Ats::SatisfactoryReferencePage",
         publisher_ats_tag: "Publisher::Ats::TagPage",
         publisher_ats_job_decline_date: "Publisher::Ats::JobDeclineDatePage",
+        publisher_ats_job_offer_date: "Publisher::Ats::JobOfferDateTagPage",
         publisher_include_additional_documents: "Publisher::IncludeAdditionalDocumentsPage",
         publisher_job_title: "Publisher::JobTitlePage",
         publisher_pay_package: "Publisher::PayPackagePage",

--- a/spec/page_objects/pages/application.rb
+++ b/spec/page_objects/pages/application.rb
@@ -19,6 +19,7 @@ module PageObjects
         publisher_ats_reference_request: "Publisher::Ats::ReferenceRequestPage",
         publisher_ats_satisfactory_reference: "Publisher::Ats::SatisfactoryReferencePage",
         publisher_ats_tag: "Publisher::Ats::TagPage",
+        publisher_ats_job_decline_date: "Publisher::Ats::JobDeclineDatePage",
         publisher_include_additional_documents: "Publisher::IncludeAdditionalDocumentsPage",
         publisher_job_title: "Publisher::JobTitlePage",
         publisher_pay_package: "Publisher::PayPackagePage",

--- a/spec/page_objects/pages/application.rb
+++ b/spec/page_objects/pages/application.rb
@@ -21,6 +21,7 @@ module PageObjects
         publisher_ats_tag: "Publisher::Ats::TagPage",
         publisher_ats_job_decline_date: "Publisher::Ats::JobDeclineDatePage",
         publisher_ats_job_offer_date: "Publisher::Ats::JobOfferDateTagPage",
+        publisher_ats_job_feedback_date: "Publisher::Ats::FeedbackTagPage",
         publisher_include_additional_documents: "Publisher::IncludeAdditionalDocumentsPage",
         publisher_job_title: "Publisher::JobTitlePage",
         publisher_pay_package: "Publisher::PayPackagePage",

--- a/spec/page_objects/pages/publisher/ats/feedback_page.rb
+++ b/spec/page_objects/pages/publisher/ats/feedback_page.rb
@@ -35,6 +35,10 @@ module PageObjects
             btn_continue.click
           end
         end
+
+        class FeedbackTagPage < FeedbackPage
+          set_url "/organisation/jobs/{vacancy_id}/job_applications/tag{?query*}"
+        end
       end
     end
   end

--- a/spec/page_objects/pages/publisher/ats/job_applications_page.rb
+++ b/spec/page_objects/pages/publisher/ats/job_applications_page.rb
@@ -14,6 +14,8 @@ module PageObjects
           element :name_link, ".name a"
           element :email, ".email_address"
           element :status, ".status"
+          element :interview_feedback_received_at, ".interview_feedback_received_at"
+          element :declined_at, ".declined_at"
 
           STATUS_MAPPING = {
             "unread" => "submitted",

--- a/spec/page_objects/pages/publisher/ats/job_applications_page.rb
+++ b/spec/page_objects/pages/publisher/ats/job_applications_page.rb
@@ -16,6 +16,7 @@ module PageObjects
           element :status, ".status"
           element :interview_feedback_received_at, ".interview_feedback_received_at"
           element :declined_at, ".declined_at"
+          element :offered_at, ".offered_at"
 
           STATUS_MAPPING = {
             "unread" => "submitted",

--- a/spec/page_objects/pages/publisher/ats/job_offer_date_page.rb
+++ b/spec/page_objects/pages/publisher/ats/job_offer_date_page.rb
@@ -32,6 +32,10 @@ module PageObjects
             btn_continue.click
           end
         end
+
+        class JobOfferDateTagPage < JobOfferDatePage
+          set_url "/organisation/jobs/{vacancy_id}/job_applications/tag{?query*}"
+        end
       end
     end
   end

--- a/spec/system/publishers/publishers_can_set_feedback_and_declined_date_spec.rb
+++ b/spec/system/publishers/publishers_can_set_feedback_and_declined_date_spec.rb
@@ -67,15 +67,16 @@ RSpec.describe "Publisher can set feedback and declined dates" do
         publisher_ats_applications_page.load(vacancy_id: vacancy.id)
         expect(publisher_ats_applications_page.job_title).to have_text(vacancy.job_title)
 
-        publisher_ats_applications_page.select_tab(:tab_offered)
+        publisher_ats_applications_page.select_tab(:tab_interviewing)
 
-        expect(publisher_ats_applications_page.tab_panel.job_applications.first.interview_feedback_received_at).to have_link("Add feedback date", href: tag_organisation_job_job_applications_path(vacancy.id, params: { publishers_job_application_tag_form: { origin: :interviewing, job_applications: [job_application.id] }, tag_action: "feedback" }))
+        expect(publisher_ats_applications_page.tab_panel.job_applications.first.interview_feedback_received_at).to have_link("Add feedback date", href: tag_organisation_job_job_applications_path(vacancy.id, params: { publishers_job_application_tag_form: { origin: :interviewing, job_applications: [job_application.id] }, tag_action: "unsuccessful_interview" }))
 
         publisher_ats_applications_page.tab_panel.job_applications.first.interview_feedback_received_at.click_on("Add feedback date")
 
         # Form page
         expect(publisher_ats_job_feedback_date_page).to be_displayed(vacancy_id: vacancy.id)
         feedback_date = 2.days.ago
+        publisher_ats_job_feedback_date_page.interview_feedback_received_yes.click
         publisher_ats_job_feedback_date_page.set_date(feedback_date)
         publisher_ats_job_feedback_date_page.btn_continue.click
 

--- a/spec/system/publishers/publishers_can_set_feedback_and_declined_date_spec.rb
+++ b/spec/system/publishers/publishers_can_set_feedback_and_declined_date_spec.rb
@@ -19,15 +19,16 @@ RSpec.describe "Publisher can set feedback and declined dates" do
 
         expect(publisher_ats_applications_page.tab_panel.job_applications.first.declined_at).to have_link("Add decline date", href: tag_organisation_job_job_applications_path(vacancy.id, params: { publishers_job_application_tag_form: { origin: :offered, job_applications: [job_application.id] }, tag_action: "declined" }))
 
-        publisher_ats_applications_page.tab_panel.job_applications.first.declined_at.click_on("Add declined date")
+        publisher_ats_applications_page.tab_panel.job_applications.first.declined_at.click_on("Add decline date")
 
         # Form page
         expect(publisher_ats_job_decline_date_page).to be_displayed(vacancy_id: vacancy.id)
         decline_date = 2.days.ago
         publisher_ats_job_decline_date_page.set_date(decline_date)
+        publisher_ats_job_decline_date_page.btn_continue.click
 
         expect(publisher_ats_applications_page).to be_displayed(vacancy_id: vacancy.id)
-        expect(publisher_ats_applications_page.tab_panel.job_applications.first.declined_at).to have_text(decline_date.to_fs)
+        expect(publisher_ats_applications_page.tab_panel.job_applications.first.declined_at).to have_text(decline_date.to_fs(:day_month_year))
       end
     end
   end
@@ -50,9 +51,10 @@ RSpec.describe "Publisher can set feedback and declined dates" do
         expect(publisher_ats_job_offer_date_page).to be_displayed(vacancy_id: vacancy.id)
         offer_date = 2.days.ago
         publisher_ats_job_offer_date_page.set_date(offer_date)
+        publisher_ats_job_offer_date_page.btn_continue.click
 
         expect(publisher_ats_applications_page).to be_displayed(vacancy_id: vacancy.id)
-        expect(publisher_ats_applications_page.tab_panel.job_applications.first.offered_at).to have_text(offer_date.to_fs)
+        expect(publisher_ats_applications_page.tab_panel.job_applications.first.offered_at).to have_text(offer_date.to_fs(:day_month_year))
       end
     end
   end
@@ -75,9 +77,10 @@ RSpec.describe "Publisher can set feedback and declined dates" do
         expect(publisher_ats_job_feedback_date_page).to be_displayed(vacancy_id: vacancy.id)
         feedback_date = 2.days.ago
         publisher_ats_job_feedback_date_page.set_date(feedback_date)
+        publisher_ats_job_feedback_date_page.btn_continue.click
 
         expect(publisher_ats_applications_page).to be_displayed(vacancy_id: vacancy.id)
-        expect(publisher_ats_applications_page.tab_panel.job_applications.first.interview_feedback_received_at).to have_text(feedback_date.to_fs)
+        expect(publisher_ats_applications_page.tab_panel.job_applications.first.interview_feedback_received_at).to have_text(feedback_date.to_fs(:day_month_year))
       end
     end
   end

--- a/spec/system/publishers/publishers_can_set_feedback_and_declined_date_spec.rb
+++ b/spec/system/publishers/publishers_can_set_feedback_and_declined_date_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Publisher can set feedback and declined dates" do
 
         expect(publisher_ats_applications_page.tab_panel.job_applications.first.offered_at).to have_link("Add job offer date", href: tag_organisation_job_job_applications_path(vacancy.id, params: { publishers_job_application_tag_form: { origin: :offered, job_applications: [job_application.id] }, tag_action: "offered" }))
 
-        publisher_ats_applications_page.tab_panel.job_applications.first.declined_at.click_on("Add job offer date")
+        publisher_ats_applications_page.tab_panel.job_applications.first.offered_at.click_on("Add job offer date")
 
         # Form page
         expect(publisher_ats_job_offer_date_page).to be_displayed(vacancy_id: vacancy.id)

--- a/spec/system/publishers/publishers_can_set_feedback_and_declined_date_spec.rb
+++ b/spec/system/publishers/publishers_can_set_feedback_and_declined_date_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+RSpec.describe "Publisher can set feedback and declined dates" do
+  let(:publisher) { create(:publisher, :with_organisation, accepted_terms_at: 1.day.ago) }
+  let(:organisations) { publisher.organisations }
+  let(:vacancy) { create(:vacancy, organisations:) }
+
+  before { job_application }
+
+  context "when candidate declines offer", :js do
+    let(:job_application) { create(:job_application, :status_declined, vacancy:, declined_at: nil) }
+
+    scenario "add declined date from tab offered" do
+      run_with_publisher(publisher) do
+        publisher_ats_applications_page.load(vacancy_id: vacancy.id)
+        expect(publisher_ats_applications_page.job_title).to have_text(vacancy.job_title)
+
+        publisher_ats_applications_page.select_tab(:tab_offered)
+
+        expect(publisher_ats_applications_page.tab_panel.job_applications.first.declined_at).to have_link("Add decline date", href: tag_organisation_job_job_applications_path(vacancy.id, params: { publishers_job_application_tag_form: { origin: :offered, job_applications: [job_application.id] }, tag_action: "declined" }))
+
+        publisher_ats_applications_page.tab_panel.job_applications.first.declined_at.click_on("Add declined date")
+
+        # Form page
+        expect(publisher_ats_job_decline_date_page).to be_displayed(vacancy_id: vacancy.id)
+        decline_date = 2.days.ago
+        publisher_ats_job_decline_date_page.set_date(decline_date)
+
+        expect(publisher_ats_applications_page).to be_displayed(vacancy_id: vacancy.id)
+        expect(publisher_ats_applications_page.tab_panel.job_applications.first.declined_at).to have_text(decline_date.to_fs)
+      end
+    end
+  end
+
+  context "when candidate has an offer", :js do
+    let(:job_application) { create(:job_application, :status_offered, vacancy:, offered_at: nil) }
+
+    scenario "add offer date from tab offered" do
+      run_with_publisher(publisher) do
+        publisher_ats_applications_page.load(vacancy_id: vacancy.id)
+        expect(publisher_ats_applications_page.job_title).to have_text(vacancy.job_title)
+
+        publisher_ats_applications_page.select_tab(:tab_offered)
+
+        expect(publisher_ats_applications_page.tab_panel.job_applications.first.offered_at).to have_link("Add job offer date", href: tag_organisation_job_job_applications_path(vacancy.id, params: { publishers_job_application_tag_form: { origin: :offered, job_applications: [job_application.id] }, tag_action: "offered" }))
+
+        publisher_ats_applications_page.tab_panel.job_applications.first.declined_at.click_on("Add job offer date")
+
+        # Form page
+        expect(publisher_ats_job_offer_date_page).to be_displayed(vacancy_id: vacancy.id)
+        offer_date = 2.days.ago
+        publisher_ats_job_offer_date_page.set_date(offer_date)
+
+        expect(publisher_ats_applications_page).to be_displayed(vacancy_id: vacancy.id)
+        expect(publisher_ats_applications_page.tab_panel.job_applications.first.offered_at).to have_text(offer_date.to_fs)
+      end
+    end
+  end
+
+  context "when candidate interview is unsuccessful", :js do
+    let(:job_application) { create(:job_application, :status_unsuccessful_interview, vacancy:, interview_feedback_received_at: nil) }
+
+    scenario "add declined date from tab offered" do
+      run_with_publisher(publisher) do
+        publisher_ats_applications_page.load(vacancy_id: vacancy.id)
+        expect(publisher_ats_applications_page.job_title).to have_text(vacancy.job_title)
+
+        publisher_ats_applications_page.select_tab(:tab_offered)
+
+        expect(publisher_ats_applications_page.tab_panel.job_applications.first.interview_feedback_received_at).to have_link("Add feedback date", href: tag_organisation_job_job_applications_path(vacancy.id, params: { publishers_job_application_tag_form: { origin: :interviewing, job_applications: [job_application.id] }, tag_action: "feedback" }))
+
+        publisher_ats_applications_page.tab_panel.job_applications.first.interview_feedback_received_at.click_on("Add feedback date")
+
+        # Form page
+        expect(publisher_ats_job_feedback_date_page).to be_displayed(vacancy_id: vacancy.id)
+        feedback_date = 2.days.ago
+        publisher_ats_job_feedback_date_page.set_date(feedback_date)
+
+        expect(publisher_ats_applications_page).to be_displayed(vacancy_id: vacancy.id)
+        expect(publisher_ats_applications_page.tab_panel.job_applications.first.interview_feedback_received_at).to have_text(feedback_date.to_fs)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Trello card URL
[2135](https://trello.com/c/PsTRIO1z/2135-provide-links-to-add-offer-declined-and-interview-feedback-dates-from-the-apps-management-table)
## Changes in this PR:

- Is there anything specific you want feedback on?

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>

<!-- Message of single commit: -->

Add links for set job application status date

setup system spec