### PR TITLE
Remove the Job Title from the filtered out params

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -15,7 +15,6 @@ Rails.application.config.filter_parameters += %i[
   orientation
   religion
   id
-  job_title
   jobseeker_id
   jobseeker_profile_id
   support_needed_details


### PR DESCRIPTION
The job title is not particular PII and is very useful to identify vacancies when searching api request logs in Kibana or listing vacancies in the console.

Opening this PR after having searched the logs for a particular creation event in our Publisher ATS API and having found it filtered out (when contained needed/key information to look for).

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
