### PR TITLE
Temporally Disable Every ATS integration

### DIFF
--- a/app/jobs/import_from_vacancy_sources_job.rb
+++ b/app/jobs/import_from_vacancy_sources_job.rb
@@ -1,7 +1,7 @@
 class ImportFromVacancySourcesJob < ApplicationJob
   SOURCES = [
     Vacancies::Import::Sources::Broadbean,
-    Vacancies::Import::Sources::Every,
+    # Vacancies::Import::Sources::Every, Temporally disabled as their service is down
     Vacancies::Import::Sources::Fusion,
     Vacancies::Import::Sources::VacancyPoster,
     Vacancies::Import::Sources::Ventrus,


### PR DESCRIPTION
- Tackles this [sentry error](https://teaching-vacancies.sentry.io/issues/6881881337/?environment=production&project=6212514&query=is%3Aunresolved&referrer=issue-stream)

Every integration server endpoint has been failing for multiple days, and they are not responding.

Disabling the integration until they confirm they're back up or have finished their migration to the new API.

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
