### PR TITLE
use native job application type for job applications

### DIFF
--- a/spec/factories/job_applications.rb
+++ b/spec/factories/job_applications.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :job_application do
+  factory :job_application, class: "NativeJobApplication" do
     transient do
       draft_at { 2.weeks.ago }
       status { :draft }


### PR DESCRIPTION
## Changes in this PR:

Use correct class type in job_application factory, so that test setup reflects code