### PR TITLE
Add guard bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -115,6 +115,7 @@ group :development, :test do
   gem "database_consistency", require: false
   gem "debug", ">= 1.0.0", require: false
   gem "dotenv-rails"
+  gem "guard-bundler", "~> 3.0", require: false
   gem "guard-rspec", require: false
   gem "guard-rubocop", "~> 1.5", require: false
   gem "guard-slim_lint"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -337,6 +337,10 @@ GEM
       pry (>= 0.13.0)
       shellany (~> 0.0)
       thor (>= 0.18.1)
+    guard-bundler (3.0.1)
+      bundler (>= 2.1, < 3)
+      guard (~> 2.2)
+      guard-compat (~> 1.1)
     guard-compat (1.2.1)
     guard-rspec (4.7.3)
       guard (~> 2.1)
@@ -969,6 +973,7 @@ DEPENDENCIES
   google-cloud-bigquery
   govuk-components (~> 5.11.1)
   govuk_design_system_formbuilder (~> 5.11.0)
+  guard-bundler (~> 3.0)
   guard-rspec
   guard-rubocop (~> 1.5)
   guard-slim_lint

--- a/Guardfile
+++ b/Guardfile
@@ -98,3 +98,15 @@ guard :slim_lint, all_on_start: false do
   watch(%r{.+\.html.*\.slim$})
   watch(%r{(?:.+/)?\.slim-lint\.yml$}) { |m| File.dirname(m[0]) }
 end
+
+guard :bundler do
+  require "guard/bundler"
+  require "guard/bundler/verify"
+  helper = Guard::Bundler::Verify.new
+
+  files = %w[Gemfile]
+  files += Dir["*.gemspec"] if files.any? { |f| helper.uses_gemspec?(f) }
+
+  # Assume files are symlinked from somewhere
+  files.each { |file| watch(helper.real_path(file)) }
+end


### PR DESCRIPTION
## Changes in this PR:

Add guard-bundler which calls bundle:install to update any gems that are out of date with the Gemfile.lock

