### PR TITLE
Breadcrumb duplication

### DIFF
--- a/app/components/vacancy_form_page_heading_component/vacancy_form_page_heading_component.html.slim
+++ b/app/components/vacancy_form_page_heading_component/vacancy_form_page_heading_component.html.slim
@@ -1,5 +1,4 @@
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: back_path, html_attributes: { "aria-label" => "Back navigation" }
 
 - if @fieldset

--- a/app/views/jobseekers/job_applications/_banner.html.slim
+++ b/app/views/jobseekers/job_applications/_banner.html.slim
@@ -1,7 +1,6 @@
 - content_for :breadcrumbs do
-  nav aria-label="breadcrumb" role="navigation"
-    div class="govuk-!-display-none-print"
-      = govuk_breadcrumbs breadcrumbs: { "#{t('breadcrumbs.job_applications')}": jobseekers_job_applications_path, "#{vacancy.job_title}": "" }
+  div class="govuk-!-display-none-print"
+    = govuk_breadcrumbs breadcrumbs: { "#{t('breadcrumbs.job_applications')}": jobseekers_job_applications_path, "#{vacancy.job_title}": "" }
 
 .divider-bottom.review-banner class="govuk-!-margin-bottom-7"
   h1.govuk-heading-xl class="govuk-!-margin-bottom-4" = t("jobseekers.job_applications.caption", job_title: vacancy.job_title, organisation: vacancy.organisation_name)

--- a/app/views/jobseekers/job_applications/build/_banner.html.slim
+++ b/app/views/jobseekers/job_applications/build/_banner.html.slim
@@ -1,5 +1,4 @@
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: back_path, html_attributes: { "aria-label" => "Back navigation" }
 
 span.govuk-caption-l = t("jobseekers.job_applications.caption", job_title: vacancy.job_title, organisation: vacancy.organisation_name)

--- a/app/views/jobseekers/login_keys/new.html.slim
+++ b/app/views/jobseekers/login_keys/new.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t("jobseekers.sessions.new.title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: page_path("sign-in")
 
 .govuk-grid-row

--- a/app/views/jobseekers/profiles/about_you/edit.html.slim
+++ b/app/views/jobseekers/profiles/about_you/edit.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".page_title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: jobseekers_profile_path
 
 .govuk-grid-row

--- a/app/views/jobseekers/profiles/about_you/show.html.slim
+++ b/app/views/jobseekers/profiles/about_you/show.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".page_title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: jobseekers_profile_path
 
 .govuk-grid-row

--- a/app/views/jobseekers/profiles/confirm_toggle.html.slim
+++ b/app/views/jobseekers/profiles/confirm_toggle.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".confirm_turn_#{@off_on}")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: jobseekers_profile_path
 
 .govuk-grid-row

--- a/app/views/jobseekers/profiles/employments/edit.html.slim
+++ b/app/views/jobseekers/profiles/employments/edit.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".page_title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: review_jobseekers_profile_work_history_index_path, html_attributes: { "aria-label" => "Back navigation", role: "navigation" }
 
 .govuk-grid-row

--- a/app/views/jobseekers/profiles/employments/new.html.slim
+++ b/app/views/jobseekers/profiles/employments/new.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".page_title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: jobseekers_profile_path
 
 .govuk-grid-row

--- a/app/views/jobseekers/profiles/hide_profile/add.html.slim
+++ b/app/views/jobseekers/profiles/hide_profile/add.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".page_title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: jobseekers_profile_path
 
 .govuk-grid-row

--- a/app/views/jobseekers/profiles/hide_profile/cannot_find_school.html.slim
+++ b/app/views/jobseekers/profiles/hide_profile/cannot_find_school.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".page_title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: add_jobseekers_profile_hide_profile_path
 
 .govuk-grid-row

--- a/app/views/jobseekers/profiles/hide_profile/choose_school_or_trust.html.slim
+++ b/app/views/jobseekers/profiles/hide_profile/choose_school_or_trust.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".page_title", trust_name: @school.trust.name)
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: add_jobseekers_profile_hide_profile_path
 
 .govuk-grid-row

--- a/app/views/jobseekers/profiles/hide_profile/delete.html.slim
+++ b/app/views/jobseekers/profiles/hide_profile/delete.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".page_title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: schools_jobseekers_profile_hide_profile_path
 
 .govuk-grid-row

--- a/app/views/jobseekers/profiles/hide_profile/review.html.slim
+++ b/app/views/jobseekers/profiles/hide_profile/review.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".page_title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: jobseekers_profile_path
 
 .govuk-grid-row

--- a/app/views/jobseekers/profiles/hide_profile/schools.html.slim
+++ b/app/views/jobseekers/profiles/hide_profile/schools.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".page_title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: jobseekers_profile_path
 
 .govuk-grid-row

--- a/app/views/jobseekers/profiles/hide_profile/show.html.slim
+++ b/app/views/jobseekers/profiles/hide_profile/show.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".page_title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: jobseekers_profile_path
 
 .govuk-grid-row

--- a/app/views/jobseekers/profiles/job_preferences/delete_location.html.slim
+++ b/app/views/jobseekers/profiles/job_preferences/delete_location.html.slim
@@ -1,6 +1,5 @@
 - content_for :page_title_prefix, "Job preferences: locations"
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: back_url
 
 .govuk-grid-row

--- a/app/views/jobseekers/profiles/job_preferences/key_stages.html.slim
+++ b/app/views/jobseekers/profiles/job_preferences/key_stages.html.slim
@@ -1,6 +1,5 @@
 - content_for :page_title_prefix, "Job preferences: phases"
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: back_url
 
 = form_for(@step, url: { action: :update }, as: :job_preferences) do |f|

--- a/app/views/jobseekers/profiles/job_preferences/location.html.slim
+++ b/app/views/jobseekers/profiles/job_preferences/location.html.slim
@@ -1,6 +1,5 @@
 - content_for :page_title_prefix, "Job preferences: locations"
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: back_url
 
 = form_for(location_form, url: { action: :update_location, id: params[:id] }, as: :job_preferences_location) do |f|

--- a/app/views/jobseekers/profiles/job_preferences/locations.html.slim
+++ b/app/views/jobseekers/profiles/job_preferences/locations.html.slim
@@ -1,6 +1,5 @@
 - content_for :page_title_prefix, "Job preferences: locations"
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: back_url, html_attributes: { "aria-label" => "Back navigation", role: "navigation" }
 
 = form_for @step, as: :job_preferences, url: { action: :update } do |f|

--- a/app/views/jobseekers/profiles/job_preferences/phases.html.slim
+++ b/app/views/jobseekers/profiles/job_preferences/phases.html.slim
@@ -1,6 +1,5 @@
 - content_for :page_title_prefix, "Job preferences: education phase"
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: back_url
 
 = form_for(@step, url: { action: :update }, as: :job_preferences) do |f|

--- a/app/views/jobseekers/profiles/job_preferences/review.html.slim
+++ b/app/views/jobseekers/profiles/job_preferences/review.html.slim
@@ -1,6 +1,5 @@
 - content_for :page_title_prefix, "Job preferences: review"
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: jobseekers_profile_path
 
 .govuk-grid-row

--- a/app/views/jobseekers/profiles/job_preferences/roles.html.slim
+++ b/app/views/jobseekers/profiles/job_preferences/roles.html.slim
@@ -1,6 +1,5 @@
 - content_for :page_title_prefix, "Job preferences: roles"
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: back_url, html_attributes: { "aria-label" => "Back navigation" }
 
 = form_for @step, url: { action: :update }, as: :job_preferences do |f|

--- a/app/views/jobseekers/profiles/job_preferences/subjects.html.slim
+++ b/app/views/jobseekers/profiles/job_preferences/subjects.html.slim
@@ -1,6 +1,5 @@
 - content_for :page_title_prefix, "Job preferences: roles"
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: back_url
 
 = form_for @step, url: { action: :update }, as: :job_preferences do |f|

--- a/app/views/jobseekers/profiles/job_preferences/working_patterns.html.slim
+++ b/app/views/jobseekers/profiles/job_preferences/working_patterns.html.slim
@@ -1,6 +1,5 @@
 - content_for :page_title_prefix, "Job preferences: phases"
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: back_url
 
 = form_for(@step, url: { action: :update }, as: :job_preferences) do |f|

--- a/app/views/jobseekers/profiles/personal_details/name.html.slim
+++ b/app/views/jobseekers/profiles/personal_details/name.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".page_title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: escape_path, html_attributes: { "aria-label" => "Back navigation" }
 
 .govuk-grid-row

--- a/app/views/jobseekers/profiles/personal_details/phone_number.html.slim
+++ b/app/views/jobseekers/profiles/personal_details/phone_number.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".page_title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: back_url, html_attributes: { "aria-label" => "Back navigation" }
 
 .govuk-grid-row

--- a/app/views/jobseekers/profiles/personal_details/work.html.slim
+++ b/app/views/jobseekers/profiles/personal_details/work.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".page_title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: back_url, html_attributes: { "aria-label" => "Back navigation" }
 
 .govuk-grid-row

--- a/app/views/jobseekers/profiles/preview/show.html.slim
+++ b/app/views/jobseekers/profiles/preview/show.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".page_title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: jobseekers_profile_path
 
 .govuk-grid-row

--- a/app/views/jobseekers/profiles/professional_body_memberships/confirm_destroy.html.slim
+++ b/app/views/jobseekers/profiles/professional_body_memberships/confirm_destroy.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".caption")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: jobseekers_profile_path
 
 .govuk-grid-row

--- a/app/views/jobseekers/profiles/qualifications/confirm_destroy.html.slim
+++ b/app/views/jobseekers/profiles/qualifications/confirm_destroy.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, job_application_page_title_prefix(@form, t(".other.page_title"))
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: jobseekers_profile_path
 
 .govuk-grid-row

--- a/app/views/jobseekers/profiles/qualifications/edit.html.slim
+++ b/app/views/jobseekers/profiles/qualifications/edit.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".page_title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: jobseekers_profile_path
 
 .govuk-grid-row

--- a/app/views/jobseekers/profiles/qualifications/review.html.slim
+++ b/app/views/jobseekers/profiles/qualifications/review.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".page_title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: jobseekers_profile_path
 
 .govuk-grid-row

--- a/app/views/jobseekers/profiles/qualifications/select_category.html.slim
+++ b/app/views/jobseekers/profiles/qualifications/select_category.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, job_application_page_title_prefix(@form, t(".page_title"))
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: jobseekers_profile_path
 
 .govuk-grid-row

--- a/app/views/jobseekers/profiles/qualified_teacher_status/edit.html.slim
+++ b/app/views/jobseekers/profiles/qualified_teacher_status/edit.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".page_title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: jobseekers_profile_path
 
 = form_for @form, url: jobseekers_profile_qualified_teacher_status_path, method: "patch" do |f|

--- a/app/views/jobseekers/profiles/qualified_teacher_status/show.html.slim
+++ b/app/views/jobseekers/profiles/qualified_teacher_status/show.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".page_title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: jobseekers_profile_path
 
 .govuk-grid-row

--- a/app/views/jobseekers/profiles/training_and_cpds/confirm_destroy.html.slim
+++ b/app/views/jobseekers/profiles/training_and_cpds/confirm_destroy.html.slim
@@ -1,5 +1,4 @@
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: jobseekers_profile_path
 
 .govuk-grid-row

--- a/app/views/jobseekers/profiles/training_and_cpds/review.html.slim
+++ b/app/views/jobseekers/profiles/training_and_cpds/review.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, "Training and continuing professional development (CPD)"
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: jobseekers_profile_path
 
 .govuk-grid-row

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -34,7 +34,9 @@ html.govuk-template.govuk-template--rebranded.app-html-class lang="en"
     = render "layouts/sub_navigation"
 
     .govuk-width-container
-      = content_for :breadcrumbs
+      - if content_for? :breadcrumbs
+        nav.govuk-breadcrumbs aria-label="Breadcrumbs"
+          = content_for :breadcrumbs
       = render "layouts/flash_messages"
       main#main-content.govuk-main-wrapper.govuk-main-wrapper--auto-spacing role="main"
         = yield

--- a/app/views/pages/dsi-account-request.html.slim
+++ b/app/views/pages/dsi-account-request.html.slim
@@ -2,7 +2,6 @@
   | Request a Teaching Vacancies account
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: new_publisher_session_path
 
 .govuk-grid-row

--- a/app/views/posts/index.html.slim
+++ b/app/views/posts/index.html.slim
@@ -2,7 +2,6 @@
 - content_for :page_description, t(".#{params[:section]}.meta_description")
 
 - content_for :breadcrumbs do
-  nav aria-label="Breadcrumbs"
   = govuk_breadcrumbs breadcrumbs: { t("breadcrumbs.home") => root_path,
                                      params[:section].titleize.capitalize => "" }
 

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -4,8 +4,7 @@
 
 - unless params[:section] == "transcripts"
   - content_for :breadcrumbs do
-    nav aria-label="breadcrumb" role="navigation"
-      = govuk_breadcrumbs breadcrumbs: { t("breadcrumbs.home") => root_path,
+    = govuk_breadcrumbs breadcrumbs: { t("breadcrumbs.home") => root_path,
                                         params[:section].titleize.capitalize => posts_path(section: params[:section]),
                                         formatted_subcategory => subcategory_path(section: params[:section], subcategory: params[:subcategory]),
                                         @post.title => "" }

--- a/app/views/posts/subcategory.html.slim
+++ b/app/views/posts/subcategory.html.slim
@@ -3,7 +3,6 @@
 - content_for :page_description, "All posts under the subcategory: #{formatted_subcategory}"
 
 - content_for :breadcrumbs do
-  nav aria-label="Breadcrumbs"
   = govuk_breadcrumbs breadcrumbs: { t("breadcrumbs.home") => root_path,
     params[:section].titleize.capitalize => posts_path(section: params[:section]),
     formatted_subcategory => "" }

--- a/app/views/publishers/jobseeker_profiles/_layout.html.slim
+++ b/app/views/publishers/jobseeker_profiles/_layout.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, profile.full_name
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: publishers_jobseeker_profiles_path, html_attributes: { "aria-label" => "Back navigation", role: "navigation" }
 
 .govuk-grid-row

--- a/app/views/publishers/login_keys/new.html.slim
+++ b/app/views/publishers/login_keys/new.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t("publishers.sessions.new.sign_in.title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: page_path("sign-in")
 
 .govuk-grid-row

--- a/app/views/publishers/organisations/photo/confirm_destroy.html.slim
+++ b/app/views/publishers/organisations/photo/confirm_destroy.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, @organisation.name.titlecase
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: edit_publishers_organisation_photo_path(@organisation)
 
 .govuk-grid-row

--- a/app/views/publishers/organisations/safeguarding_information/edit.html.slim
+++ b/app/views/publishers/organisations/safeguarding_information/edit.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, @organisation.name.titlecase
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: back_link_destination
 
 .govuk-grid-row

--- a/app/views/publishers/organisations/schools/preview.html.slim
+++ b/app/views/publishers/organisations/schools/preview.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".page_title", school_group_name: @organisation.name)
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t(".exit_preview_link_text"), href: publishers_organisation_path(@organisation)
 
 .govuk-grid-row

--- a/app/views/publishers/organisations/show.html.slim
+++ b/app/views/publishers/organisations/show.html.slim
@@ -2,8 +2,7 @@
 
 - if current_organisation.school_group? && @organisation.school?
   - content_for :breadcrumbs do
-    nav aria-label="breadcrumb" role="navigation"
-      = govuk_breadcrumbs breadcrumbs: { t("nav.organisation_profile") => publishers_organisation_path(current_organisation), t("nav.school_profile") => nil }
+    = govuk_breadcrumbs breadcrumbs: { t("nav.organisation_profile") => publishers_organisation_path(current_organisation), t("nav.school_profile") => nil }
 
 - unless @organisation.profile_complete?
   = govuk_notification_banner title_text: t("banners.important"), classes: "govuk-!-margin-bottom-5" do |banner|

--- a/app/views/publishers/organisations/url_override/edit.html.slim
+++ b/app/views/publishers/organisations/url_override/edit.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, @organisation.name.titlecase
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: publishers_organisation_path(@organisation)
 
 .govuk-grid-row

--- a/app/views/publishers/vacancies/_review_breadcrumbs.html.slim
+++ b/app/views/publishers/vacancies/_review_breadcrumbs.html.slim
@@ -1,4 +1,3 @@
 - content_for :breadcrumbs do
-  nav aria-label="Breadcrumbs"
   = govuk_breadcrumbs breadcrumbs: { "#{t("jobs.dashboard.#{vacancy_publication_status(vacancy)}.tab_heading")}": organisation_jobs_with_type_path(vacancy_publication_status(vacancy)),
     "#{vacancy.job_title}": "" }

--- a/app/views/publishers/vacancies/confirm_destroy.html.slim
+++ b/app/views/publishers/vacancies/confirm_destroy.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".page_title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: organisation_job_path(vacancy.id)
 
 .govuk-grid-row

--- a/app/views/publishers/vacancies/end_listing/show.html.slim
+++ b/app/views/publishers/vacancies/end_listing/show.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".title", job_title: @vacancy.job_title)
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: organisation_job_path(@vacancy.id)
 
 .govuk-grid-row

--- a/app/views/publishers/vacancies/extend_deadline/show.html.slim
+++ b/app/views/publishers/vacancies/extend_deadline/show.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".title", job_title: vacancy.job_title)
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: organisation_job_path(vacancy.id)
 
 .govuk-grid-row

--- a/app/views/publishers/vacancies/job_applications/_header.html.slim
+++ b/app/views/publishers/vacancies/job_applications/_header.html.slim
@@ -1,5 +1,4 @@
 - content_for :breadcrumbs do
-  nav aria-label="Breadcrumbs"
   = govuk_breadcrumbs breadcrumbs: { "#{t('jobs.dashboard.published.tab_heading')}": organisation_jobs_with_type_path(:live),
                                      "#{vacancy.job_title}": organisation_job_job_applications_path(vacancy.id),
                                      "#{job_application.name}": "" }

--- a/app/views/publishers/vacancies/relist/edit.html.slim
+++ b/app/views/publishers/vacancies/relist/edit.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".title", job_title: vacancy.job_title)
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: organisation_job_path(@vacancy.id)
 
 .govuk-grid-row

--- a/app/views/publishers/vacancies/review.html.slim
+++ b/app/views/publishers/vacancies/review.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, review_page_title_prefix(vacancy)
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: organisation_job_build_path(vacancy.id, step_process.previous_step)
 
 .govuk-grid-row

--- a/app/views/publishers/vacancies/start.html.slim
+++ b/app/views/publishers/vacancies/start.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".page_title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: organisation_jobs_path
 
 .govuk-grid-row

--- a/app/views/referees/build_references/employment_reference.html.slim
+++ b/app/views/referees/build_references/employment_reference.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".page_title", name: @referee.job_application.name)
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: previous_wizard_path(token: @form.token)
 
 span.govuk-caption-m = t(".caption")

--- a/app/views/referees/build_references/how_would_you_rate_part_1.html.slim
+++ b/app/views/referees/build_references/how_would_you_rate_part_1.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".page_title", name: @referee.job_application.name)
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: previous_wizard_path(token: @form.token)
 
 span.govuk-caption-m = t(".caption")

--- a/app/views/referees/build_references/how_would_you_rate_part_2.html.slim
+++ b/app/views/referees/build_references/how_would_you_rate_part_2.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".page_title", name: @referee.job_application.name)
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: previous_wizard_path(token: @form.token)
 
 span.govuk-caption-m = t(".caption")

--- a/app/views/referees/build_references/how_would_you_rate_part_3.html.slim
+++ b/app/views/referees/build_references/how_would_you_rate_part_3.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".page_title", name: @referee.job_application.name)
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: previous_wizard_path(token: @form.token)
 
 span.govuk-caption-m = t(".caption")

--- a/app/views/referees/build_references/referee_details.html.slim
+++ b/app/views/referees/build_references/referee_details.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".page_title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: previous_wizard_path(token: @form.token)
 
 span.govuk-caption-m = t(".caption")

--- a/app/views/referees/build_references/reference_information.html.slim
+++ b/app/views/referees/build_references/reference_information.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".page_title", name: @referee.job_application.name)
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: previous_wizard_path(token: @form.token)
 
 span.govuk-caption-m = t(".caption")

--- a/app/views/subscriptions/edit.html.slim
+++ b/app/views/subscriptions/edit.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t("subscriptions.edit.title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("app.back_to_homepage"), href: root_path, html_attributes: { "aria-label" => "Back navigation" }
 
 .govuk-grid-row

--- a/app/views/subscriptions/new.html.slim
+++ b/app/views/subscriptions/new.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t("subscriptions.new.title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("app.back_to_homepage"), href: root_path, html_attributes: { "aria-label" => "Back navigation" }
 
 .campaign-header.full-width-banner

--- a/app/views/support_users/feedbacks/general.html.slim
+++ b/app/views/support_users/feedbacks/general.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: support_user_root_path
 
 .govuk-grid-row

--- a/app/views/support_users/feedbacks/job_alerts.html.slim
+++ b/app/views/support_users/feedbacks/job_alerts.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: support_user_root_path
 
 = render "tabs"

--- a/app/views/support_users/feedbacks/satisfaction_ratings.html.slim
+++ b/app/views/support_users/feedbacks/satisfaction_ratings.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: support_user_root_path
 
 = render "tabs"

--- a/app/views/support_users/publisher_ats_api_clients/index.html.slim
+++ b/app/views/support_users/publisher_ats_api_clients/index.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: support_user_root_path
 
 h1.govuk-heading-l = t(".title")

--- a/app/views/support_users/publisher_ats_api_clients/new.html.slim
+++ b/app/views/support_users/publisher_ats_api_clients/new.html.slim
@@ -1,7 +1,6 @@
 h1.govuk-heading-l New ATS API Client
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: support_users_publisher_ats_api_clients_path
 
 = form_with model: @api_client, url: support_users_publisher_ats_api_clients_path, local: true do |form|

--- a/app/views/support_users/publisher_ats_api_clients/show.html.slim
+++ b/app/views/support_users/publisher_ats_api_clients/show.html.slim
@@ -2,7 +2,6 @@
 - content_for :page_title_prefix, title
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: support_users_publisher_ats_api_clients_path
 
 h1.govuk-heading-l = title

--- a/app/views/support_users/service_data/index.html.slim
+++ b/app/views/support_users/service_data/index.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t("support_users.service_data.index.title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: support_user_root_path
 
 h1.govuk-heading-l = t("support_users.service_data.index.heading")

--- a/app/views/support_users/service_data/jobseeker_profiles/index.html.slim
+++ b/app/views/support_users/service_data/jobseeker_profiles/index.html.slim
@@ -1,7 +1,6 @@
 - content_for :page_title_prefix, t(".title")
 
 - content_for :breadcrumbs do
-  nav.govuk-breadcrumbs aria-label="Breadcrumbs"
   = govuk_back_link text: t("buttons.back"), href: support_users_service_data_path
 
 h1.govuk-heading-l = t(".title")

--- a/app/views/vacancies/_show.html.slim
+++ b/app/views/vacancies/_show.html.slim
@@ -11,7 +11,6 @@
                                                         deadline: format_date(@vacancy.expires_at, :date_only_shorthand))
 
 - content_for :breadcrumbs do
-  nav aria-label="breadcrumb" role="navigation"
     = govuk_breadcrumbs breadcrumbs: vacancy_breadcrumbs(@vacancy)
 
 - if @vacancy.expired?

--- a/app/views/vacancies/campaign_landing_page.html.slim
+++ b/app/views/vacancies/campaign_landing_page.html.slim
@@ -2,7 +2,6 @@
   = govuk_skip_link(href: "#search-results", text: t("jobs.skip_link_list"))
 
 - content_for :breadcrumbs do
-  nav aria-label="Breadcrumbs"
   = govuk_breadcrumbs breadcrumbs: organisation_landing_page_breadcrumbs(@vacancies_search.organisation_slug) if @vacancies_search.organisation_slug.present?
 
 = render "vacancies/search/page_title_and_description", landing_page: @landing_page

--- a/app/views/vacancies/index.html.slim
+++ b/app/views/vacancies/index.html.slim
@@ -2,7 +2,6 @@
   = govuk_skip_link(href: "#search-results", text: t("jobs.skip_link_list"))
 
 - content_for :breadcrumbs do
-  nav aria-label="Breadcrumbs"
   = govuk_breadcrumbs breadcrumbs: organisation_landing_page_breadcrumbs(@vacancies_search.organisation_slug) if @vacancies_search.organisation_slug.present?
 
 = render "vacancies/search/page_title_and_description", landing_page: @landing_page


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/fDqxXxH8/2068-replace-deprecated-service-name-and-navigation-links

## Changes in this PR:

Refactoring breadcrumb handling to reduce noise in main pull request