### PR TITLE
Remove vacancy legacy fields

### DIFF
--- a/app/form_models/publishers/job_listing/about_the_role_form.rb
+++ b/app/form_models/publishers/job_listing/about_the_role_form.rb
@@ -4,9 +4,6 @@ class Publishers::JobListing::AboutTheRoleForm < Publishers::JobListing::Vacancy
   validates :ect_status, inclusion: { in: Vacancy.ect_statuses.keys }, if: -> { vacancy&.job_roles&.include?("teacher") }
   validate :skills_and_experience_presence
   validate :school_offer_presence
-  validates :safeguarding_information_provided, inclusion: { in: [true, false] }, if: -> { vacancy.safeguarding_information.present? }
-  validate :safeguarding_information_presence, if: -> { vacancy.safeguarding_information.present? && safeguarding_information_provided }
-  validate :safeguarding_information_does_not_exceed_maximum_words, if: -> { safeguarding_information_provided }
   validates :further_details_provided, inclusion: { in: [true, false] }
   validate :further_details_presence, if: -> { further_details_provided }
   validates :flexi_working_details_provided, inclusion: { in: [true, false] }
@@ -17,8 +14,6 @@ class Publishers::JobListing::AboutTheRoleForm < Publishers::JobListing::Vacancy
   attribute :skills_and_experience
   attribute :school_offer
   attribute :flexi_working
-  attribute :safeguarding_information_provided, :boolean
-  attribute :safeguarding_information
   attribute :further_details_provided, :boolean
   attribute :further_details
 
@@ -36,8 +31,6 @@ class Publishers::JobListing::AboutTheRoleForm < Publishers::JobListing::Vacancy
       skills_and_experience:,
       school_offer:,
       flexi_working: normalize_flexi_working,
-      safeguarding_information_provided:,
-      safeguarding_information:,
       further_details_provided:,
       further_details:,
       flexi_working_details_provided:,
@@ -66,16 +59,6 @@ class Publishers::JobListing::AboutTheRoleForm < Publishers::JobListing::Vacancy
     return if remove_html_tags(skills_and_experience).present?
 
     errors.add(:skills_and_experience, :blank)
-  end
-
-  def safeguarding_information_presence
-    return if remove_html_tags(safeguarding_information).present?
-
-    errors.add(:safeguarding_information, :blank)
-  end
-
-  def safeguarding_information_does_not_exceed_maximum_words
-    errors.add(:safeguarding_information, :length) if number_of_words_exceeds_permitted_length?(100, safeguarding_information)
   end
 
   def further_details_presence

--- a/app/models/concerns/resettable.rb
+++ b/app/models/concerns/resettable.rb
@@ -18,7 +18,6 @@ module Resettable
     reset_application_link
     reset_documents
     reset_contact_number
-    reset_safeguarding_information
     reset_further_details
     reset_benefits_details
   end
@@ -87,12 +86,6 @@ module Resettable
     return unless contact_number_provided_changed? && !contact_number_provided
 
     self.contact_number = nil
-  end
-
-  def reset_safeguarding_information
-    return unless safeguarding_information_provided_changed? && !safeguarding_information_provided
-
-    self.safeguarding_information = nil
   end
 
   def reset_further_details

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -2,6 +2,9 @@ require "geocoding"
 
 # rubocop:disable Metrics/ClassLength
 class Vacancy < ApplicationRecord
+  # needed to remove legacy columns
+  self.ignored_columns += %w[safeguarding_information_provided safeguarding_information]
+
   extend FriendlyId
   extend ArrayEnum
 

--- a/app/services/copy_vacancy_asa_template.rb
+++ b/app/services/copy_vacancy_asa_template.rb
@@ -27,7 +27,6 @@ class CopyVacancyAsaTemplate
         new_vacancy.completed_steps -= %w[start_date important_dates]
       end
 
-      reset_legacy_fields(new_vacancy)
       new_vacancy.tap do |v|
         v.organisations = vacancy.organisations
         v.send(:set_slug)
@@ -42,11 +41,6 @@ class CopyVacancyAsaTemplate
     def reset_date_fields(new_vacancy)
       new_vacancy.assign_attributes(expires_at: nil, start_date_type: nil, starts_on: nil,
                                     earliest_start_date: nil, latest_start_date: nil, other_start_date_details: nil, publish_on: nil)
-    end
-
-    def reset_legacy_fields(new_vacancy)
-      new_vacancy.assign_attributes(safeguarding_information_provided: nil,
-                                    safeguarding_information: nil)
     end
 
     def completed_steps(vacancy)

--- a/app/views/publishers/vacancies/build/about_the_role.html.slim
+++ b/app/views/publishers/vacancies/build/about_the_role.html.slim
@@ -15,14 +15,13 @@
         p.govuk-body = t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.no_description", organisation: vacancy.organisation.school? ? "school" : "organisation")
         p = govuk_link_to t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.no_description_link.#{vacancy.organisation.school? ? 'school' : 'organisation'}"), edit_publishers_organisation_description_path(vacancy.organisation, vacancy_id: vacancy.id)
 
-      - unless vacancy.safeguarding_information.present?
-        - if vacancy.organisation&.safeguarding_information.present?
-          p.govuk-body = t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.safeguarding_information", organisation: vacancy.organisation.school? ? "school" : "organisation")
-          = govuk_details(summary_text: t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.safeguarding_information_summary_text")) do
-            = simple_format(vacancy.organisation&.safeguarding_information)
-        - else
-          p.govuk-body = t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.no_safeguarding_information", organisation: vacancy.organisation.school? ? "school" : "organisation")
-          p = govuk_link_to t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.no_safeguarding_information_link"), edit_publishers_organisation_safeguarding_information_path(vacancy.organisation, vacancy_id: vacancy.id)
+      - if vacancy.organisation&.safeguarding_information.present?
+        p.govuk-body = t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.safeguarding_information", organisation: vacancy.organisation.school? ? "school" : "organisation")
+        = govuk_details(summary_text: t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.safeguarding_information_summary_text")) do
+          = simple_format(vacancy.organisation&.safeguarding_information)
+      - else
+        p.govuk-body = t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.no_safeguarding_information", organisation: vacancy.organisation.school? ? "school" : "organisation")
+        p = govuk_link_to t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.no_safeguarding_information_link"), edit_publishers_organisation_safeguarding_information_path(vacancy.organisation, vacancy_id: vacancy.id)
 
       - if vacancy.job_roles.include? "teacher"
         = f.govuk_collection_radio_buttons :ect_status,
@@ -45,15 +44,6 @@
             value: form.flexi_working, field_name: "publishers_job_listing_about_the_role_form[flexi_working]", hint: t("jobs.flexi_working.hint"),
             label: { text: t("jobs.flexi_working.publisher"), size: "s" })
         = f.govuk_radio_button :flexi_working_details_provided, "false"
-
-      - if vacancy.safeguarding_information.present?
-        = f.govuk_radio_buttons_fieldset :safeguarding_information_provided, legend: { size: "m", tag: nil }, class: ["safeguarding-information-provided-radios"] do
-          = f.govuk_radio_button :safeguarding_information_provided, "true", link_errors: true do
-            = editor(form_input: f.govuk_text_area(:safeguarding_information),
-                    value: form.safeguarding_information,
-                    field_name: "publishers_job_listing_about_the_role_form[safeguarding_information]",
-                    label: { text: t("helpers.label.publishers_job_listing_about_the_role_form.safeguarding_information"), classes: ["govuk-label", "govuk-label--s", "govuk-!-margin-bottom-2", "govuk-!-font-weight-bold"], id: "safeguarding-information-label" })
-          = f.govuk_radio_button :safeguarding_information_provided, "false"
 
       = f.govuk_radio_buttons_fieldset :further_details_provided, legend: { size: "m", tag: nil }, class: ["further-details-provided-radios"] do
         = f.govuk_radio_button :further_details_provided, "true", link_errors: true do

--- a/app/views/publishers/vacancies/vacancy_review_sections/_about_the_role.html.slim
+++ b/app/views/publishers/vacancies/vacancy_review_sections/_about_the_role.html.slim
@@ -43,27 +43,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
                   href: organisation_job_build_path(vacancy.id, :about_the_role, "back_to_#{action_name}": "true"),
                   visually_hidden_text: t("jobs.flexi_working.publisher", organisation: vacancy.organisation.type.downcase)
 
-  - if vacancy.safeguarding_information.present?
-    - unless vacancy.safeguarding_information_provided.nil?
-      - summary_list.with_row(html_attributes: { id: "safeguarding_information_provided" }) do |row|
-        - row.with_key
-          = t("jobs.safeguarding_information_provided")
-        - row.with_value
-          = vacancy.safeguarding_information_provided ? "Yes" : "No"
-        - row.with_action text: t("buttons.change"),
-                    href: organisation_job_build_path(vacancy.id, :about_the_role, "back_to_#{action_name}": "true"),
-                    visually_hidden_text: t("jobs.safeguarding_information_provided")
-
-    - summary_list.with_row(html_attributes: { id: "safeguarding_information" }) do |row|
-      - row.with_key
-        = t("jobs.safeguarding_information.publisher")
-      - row.with_value
-        .editor-rendered-content == vacancy.safeguarding_information
-      - row.with_action text: t("buttons.change"),
-                  href: organisation_job_build_path(vacancy.id, :about_the_role, "back_to_#{action_name}": "true"),
-                  visually_hidden_text: t("jobs.safeguarding_information.publisher")
-
-  - elsif vacancy.organisation&.safeguarding_information.present?
+  - if vacancy.organisation&.safeguarding_information.present?
     - summary_list.with_row(html_attributes: { id: "safeguarding_information" }) do |row|
       - row.with_key
         = t("jobs.safeguarding_information.publisher")

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -471,8 +471,6 @@ shared:
     - contact_number_provided
     - skills_and_experience
     - school_offer
-    - safeguarding_information_provided
-    - safeguarding_information
     - further_details_provided
     - further_details
     - include_additional_documents

--- a/db/migrate/20250919163525_remove_vacancies_legacy_fields.rb
+++ b/db/migrate/20250919163525_remove_vacancies_legacy_fields.rb
@@ -1,0 +1,8 @@
+class RemoveVacanciesLegacyFields < ActiveRecord::Migration[7.2]
+  def change
+    safety_assured do
+      remove_column :vacancies, :safeguarding_information_provided, :boolean
+      remove_column :vacancies, :safeguarding_information, :string
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_28_110645) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_19_163525) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -813,8 +813,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_28_110645) do
     t.boolean "contact_number_provided"
     t.string "skills_and_experience"
     t.string "school_offer"
-    t.boolean "safeguarding_information_provided"
-    t.string "safeguarding_information"
     t.boolean "further_details_provided"
     t.string "further_details"
     t.boolean "include_additional_documents"

--- a/spec/concerns/reset_vacancies_in_job_listings_spec.rb
+++ b/spec/concerns/reset_vacancies_in_job_listings_spec.rb
@@ -159,19 +159,6 @@ RSpec.describe Resettable do
     end
   end
 
-  context "when changing safeguarding information provided" do
-    subject(:update_safeguarding_information_provided) { vacancy.update(safeguarding_information_provided: false) }
-
-    let(:vacancy) { build(:vacancy, safeguarding_information_provided: true, safeguarding_information: "test") }
-    let(:previous_safeguarding_information) { vacancy.safeguarding_information }
-
-    it "resets safeguarding information" do
-      expect { update_safeguarding_information_provided }
-        .to change { vacancy.safeguarding_information }
-        .from(previous_safeguarding_information).to(nil)
-    end
-  end
-
   context "when changing further details provided" do
     subject(:update_further_details_provided) { vacancy.update(further_details_provided: false) }
 

--- a/spec/form_models/publishers/job_listing/about_the_role_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/about_the_role_form_spec.rb
@@ -96,69 +96,6 @@ RSpec.describe Publishers::JobListing::AboutTheRoleForm, type: :model do
     end
   end
 
-  describe "safeguarding_information" do
-    context "when safeguarding_information is already present on the vacancy" do
-      let(:vacancy) { build_stubbed(:vacancy, :at_one_school, job_roles: ["teacher"], safeguarding_information: "safeguarding") }
-
-      context "when safeguarding_information_provided is false" do
-        let(:error) { %i[safeguarding_information blank] }
-
-        let(:params) { { safeguarding_information_provided: "false" } }
-
-        it "passes validation" do
-          expect(subject.errors.added?(*error)).to be false
-        end
-      end
-
-      context "when safeguarding_information_provided is true" do
-        let(:error) { %i[safeguarding_information blank] }
-        let(:params) { { safeguarding_information: safeguarding_information, safeguarding_information_provided: "true" } }
-
-        context "when safeguarding_information has been provided" do
-          let(:error) { %i[safeguarding_information blank] }
-          let(:safeguarding_information) { Faker::Lorem.sentence(word_count: 99) }
-
-          it "passes validation" do
-            expect(subject.errors.added?(*error)).to be false
-          end
-        end
-
-        context "when safeguarding_information has not been provided" do
-          let(:error) { %i[safeguarding_information blank] }
-          let(:safeguarding_information) { nil }
-
-          it "fails validation" do
-            expect(subject.errors.added?(*error)).to be true
-          end
-        end
-
-        context "when safeguarding_information is over 100 words" do
-          let(:error) { %i[safeguarding_information length] }
-          let(:params) { { safeguarding_information: Faker::Lorem.sentence(word_count: 101), safeguarding_information_provided: "true" } }
-
-          it "fails validation" do
-            expect(subject.errors.added?(*error)).to be true
-          end
-
-          it "has the correct error message" do
-            expect(subject.errors.messages[:safeguarding_information]).to include(I18n.t("about_the_role_errors.safeguarding_information.length"))
-          end
-        end
-      end
-    end
-
-    context "when safeguarding_information is not already present on the vacancy" do
-      let(:params) { { safeguarding_information: nil, safeguarding_information_provided: nil } }
-      let(:presence_error) { %i[safeguarding_information blank] }
-      let(:length_error) { %i[safeguarding_information length] }
-
-      it "passes validation" do
-        expect(subject.errors.added?(*presence_error)).to be false
-        expect(subject.errors.added?(*length_error)).to be false
-      end
-    end
-  end
-
   describe "further_details" do
     context "when further_details_provided is false" do
       let(:params) { { further_details_provided: "false" } }

--- a/spec/jobs/import_from_vacancy_source_job_spec.rb
+++ b/spec/jobs/import_from_vacancy_source_job_spec.rb
@@ -156,8 +156,6 @@ RSpec.describe ImportFromVacancySourceJob do
           "readable_phases" => [],
           "receive_applications" => nil,
           "religion_type" => nil,
-          "safeguarding_information" => nil,
-          "safeguarding_information_provided" => nil,
           "salary" => "Main pay range 1 to Upper pay range 3, £23,719 to £39,406 per year (full time equivalent)",
           "school_offer" => "School Offer",
           "school_visits" => true,


### PR DESCRIPTION
## Trello card URL
[2190](https://trello.com/c/giXMS3L4/2190-forgotten-legacy-fields)

## Changes in this PR:

-  Remove vacancy legacy fields `safeguarding_information` and `safeguarding_information_provided`

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [X] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
