### PR TITLE
Record Subscriptions Alerts stats into Sentry

### DIFF
--- a/app/jobs/alert_email/base.rb
+++ b/app/jobs/alert_email/base.rb
@@ -35,8 +35,8 @@ class AlertEmail::Base < ApplicationJob
     formatted_duration = format_duration(duration)
     Sentry.with_scope do |scope|
       scope.set_context("Alert run Statistics", { duration: formatted_duration,
-                                                  emails_sent: emails_count,
-                                                  new_vacancies: vacancies_count })
+                                                  alerts_sent: emails_count,
+                                                  vacancies_in_alerts: vacancies_count })
       Sentry.capture_message(
         "#{self.class.name} run successfully (duration: #{formatted_duration})",
         level: :info,

--- a/app/jobs/alert_email/base.rb
+++ b/app/jobs/alert_email/base.rb
@@ -1,8 +1,14 @@
 class AlertEmail::Base < ApplicationJob
   MAXIMUM_RESULTS_PER_RUN = 500
 
+  # rubocop:disable Metrics/AbcSize
   def perform
     return if DisableEmailNotifications.enabled?
+
+    # For stats tracking on each run
+    start_time = Time.current
+    emails_count = 0
+    vacancies_count = 0
 
     # The intent here is that if we don't have keyword or location searches, then this operation can all be done in memory
     # really fast (1 week's worth of vacancies is around 2000, so not worth leaving on disk for each of 100k daily subscriptions
@@ -12,11 +18,37 @@ class AlertEmail::Base < ApplicationJob
 
     subscriptions.find_each.reject { |sub| already_run_ids.include?(sub.id) }.each do |subscription|
       vacancies = subscription.vacancies_matching(default_scope).first(MAXIMUM_RESULTS_PER_RUN)
-
+      next unless vacancies.any?
       next if subscription.reload.email.blank?
 
-      Jobseekers::AlertMailer.alert(subscription.id, vacancies.pluck(:id)).deliver_later if vacancies.any?
+      emails_count += 1
+      vacancies_count += vacancies.size
+      Jobseekers::AlertMailer.alert(subscription.id, vacancies.pluck(:id)).deliver_later
     end
-    Sentry.capture_message("#{self.class.name} run successfully", level: :info)
+    log_to_sentry(duration: Time.current - start_time, vacancies_count:, emails_count:)
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  private
+
+  def log_to_sentry(duration:, vacancies_count:, emails_count:)
+    formatted_duration = format_duration(duration)
+    Sentry.with_scope do |scope|
+      scope.set_context("Alert run Statistics", { duration: formatted_duration,
+                                                  emails_sent: emails_count,
+                                                  new_vacancies: vacancies_count })
+      Sentry.capture_message(
+        "#{self.class.name} run successfully (duration: #{formatted_duration})",
+        level: :info,
+        fingerprint: ["{{ transaction }}"], # Groups Sentry messages by transaction. EG: Sidekiq/SendDailyAlertEmailJob
+      )
+    end
+  end
+
+  def format_duration(seconds)
+    total_seconds = seconds.to_i
+    minutes = total_seconds / 60
+    secs = total_seconds % 60
+    "#{minutes}m #{secs}s"
   end
 end

--- a/spec/jobs/send_daily_alert_email_job_spec.rb
+++ b/spec/jobs/send_daily_alert_email_job_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe SendDailyAlertEmailJob do
     end
 
     context "with no vacancies" do
-      let(:subscription) { create(:subscription, frequency: :daily) }
+      let!(:subscription) { create(:subscription, frequency: :daily) }
 
       it "does not send an email or create a run" do
         expect(Jobseekers::AlertMailer).to_not receive(:alert)

--- a/spec/jobs/send_daily_alert_email_job_spec.rb
+++ b/spec/jobs/send_daily_alert_email_job_spec.rb
@@ -23,9 +23,10 @@ RSpec.describe SendDailyAlertEmailJob do
         scope_mock = instance_double(Sentry::Scope).as_null_object
 
         allow(Time).to receive(:current).and_return(Time.current, Time.current + 65)
+        allow(Sentry).to receive(:capture_message)
         allow(Sentry).to receive(:with_scope).and_yield(scope_mock)
 
-        expect(scope_mock).to receive(:set_context).with("Alert run Statistics", { duration: "1m 5s", emails_sent: 1, new_vacancies: 1 })
+        expect(scope_mock).to receive(:set_context).with("Alert run Statistics", { duration: "1m 5s", alerts_sent: 1, vacancies_in_alerts: 1 })
         expect(Sentry).to receive(:capture_message).with(
           "SendDailyAlertEmailJob run successfully (duration: 1m 5s)",
           level: :info,


### PR DESCRIPTION

## Trello card URL
https://trello.com/c/CQjs31iq/2219-subscription-alert-runs-log-each-runtime-to-sentry

## Changes in this PR:

For each run of the Daily and Weekly alert email jobs, the job will send an info event to Sentry containing the runtime of the job, how many emails were sent and how many vacancies the subscribers were alerted about.

The new contextual info will be added to the `Context` Sentry block.
EG of how it will look in Sentry (field names have been changed so the email count is not filtered out):
<img width="252" height="116" alt="image" src="https://github.com/user-attachments/assets/e786af45-fd3c-4d29-be02-689530dc7ad6" />


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
