### PR TITLE
Remove vacancy legacy fields db

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -2,9 +2,6 @@ require "geocoding"
 
 # rubocop:disable Metrics/ClassLength
 class Vacancy < ApplicationRecord
-  # needed to remove legacy columns
-  self.ignored_columns += %w[safeguarding_information_provided safeguarding_information]
-
   extend FriendlyId
   extend ArrayEnum
 

--- a/db/migrate/20250919163525_remove_vacancies_legacy_fields.rb
+++ b/db/migrate/20250919163525_remove_vacancies_legacy_fields.rb
@@ -1,0 +1,8 @@
+class RemoveVacanciesLegacyFields < ActiveRecord::Migration[7.2]
+  def change
+    safety_assured do
+      remove_column :vacancies, :safeguarding_information_provided, :boolean
+      remove_column :vacancies, :safeguarding_information, :string
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -854,8 +854,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_24_133259) do
     t.boolean "contact_number_provided"
     t.string "skills_and_experience"
     t.string "school_offer"
-    t.boolean "safeguarding_information_provided"
-    t.string "safeguarding_information"
     t.boolean "further_details_provided"
     t.string "further_details"
     t.boolean "include_additional_documents"


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/giXMS3L4/2190-forgotten-legacy-fields

## Changes in this PR:

Delete the vacancies table columns:
-     "safeguarding_information"
-     "safeguarding_information_provided" 

## Depends on PR
#8117 

Updates 
## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [X] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
