### PR TITLE
Add extra info on Job alerts logging stats

### DIFF
--- a/app/jobs/alert_email/base.rb
+++ b/app/jobs/alert_email/base.rb
@@ -2,17 +2,22 @@ class AlertEmail::Base < ApplicationJob
   MAXIMUM_RESULTS_PER_RUN = 500
 
   # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/MethodLength
   def perform
     return if DisableEmailNotifications.enabled?
 
     # For stats tracking on each run
     start_time = Time.current
-    emails_count = 0
-    vacancies_count = 0
+    sent_alerts_count = 0
+    vacancies_in_alerts_count = 0
+    subscriptions_count = subscriptions.count
 
     # The intent here is that if we don't have keyword or location searches, then this operation can all be done in memory
     # really fast (1 week's worth of vacancies is around 2000, so not worth leaving on disk for each of 100k daily subscriptions
     default_scope = PublishedVacancy.includes(:organisations).live.order(publish_on: :desc).search_by_filter(from_date: from_date, to_date: Date.yesterday).to_a
+
+    # for stats tracking on each run
+    new_vacancies_count = default_scope.size
 
     already_run_ids = Set.new AlertRun.for_today.pluck(:subscription_id)
 
@@ -21,22 +26,29 @@ class AlertEmail::Base < ApplicationJob
       next unless vacancies.any?
       next if subscription.email.blank?
 
-      emails_count += 1
-      vacancies_count += vacancies.size
+      sent_alerts_count += 1
+      vacancies_in_alerts_count += vacancies.size
       Jobseekers::AlertMailer.alert(subscription.id, vacancies.pluck(:id)).deliver_later
     end
-    log_to_sentry(duration: Time.current - start_time, vacancies_count:, emails_count:)
+    log_to_sentry(duration: Time.current - start_time,
+                  new_vacancies_count:,
+                  subscriptions_count:,
+                  vacancies_in_alerts_count:,
+                  sent_alerts_count:)
   end
   # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/MethodLength
 
   private
 
-  def log_to_sentry(duration:, vacancies_count:, emails_count:)
+  def log_to_sentry(duration:, new_vacancies_count:, subscriptions_count:, vacancies_in_alerts_count:, sent_alerts_count:)
     formatted_duration = format_duration(duration)
     Sentry.with_scope do |scope|
       scope.set_context("Alert run Statistics", { duration: formatted_duration,
-                                                  alerts_sent: emails_count,
-                                                  vacancies_in_alerts: vacancies_count })
+                                                  new_vacancies_count:,
+                                                  subscriptions_count:,
+                                                  sent_alerts_count:,
+                                                  vacancies_in_alerts_count: })
       Sentry.capture_message(
         "#{self.class.name} run successfully (duration: #{formatted_duration})",
         level: :info,

--- a/spec/jobs/send_daily_alert_email_job_spec.rb
+++ b/spec/jobs/send_daily_alert_email_job_spec.rb
@@ -26,7 +26,11 @@ RSpec.describe SendDailyAlertEmailJob do
         allow(Sentry).to receive(:capture_message)
         allow(Sentry).to receive(:with_scope).and_yield(scope_mock)
 
-        expect(scope_mock).to receive(:set_context).with("Alert run Statistics", { duration: "1m 5s", alerts_sent: 1, vacancies_in_alerts: 1 })
+        expect(scope_mock).to receive(:set_context).with("Alert run Statistics", { duration: "1m 5s",
+                                                                                   new_vacancies_count: 1,
+                                                                                   subscriptions_count: 1,
+                                                                                   sent_alerts_count: 1,
+                                                                                   vacancies_in_alerts_count: 1 })
         expect(Sentry).to receive(:capture_message).with(
           "SendDailyAlertEmailJob run successfully (duration: 1m 5s)",
           level: :info,


### PR DESCRIPTION


## Trello card URL
Follow-up on first run after: https://trello.com/c/CQjs31iq/2219-subscription-alert-runs-log-each-runtime-to-sentry

## Changes in this PR:

- Add stats on the total number of new vacancies to check and the total number of subscriptions per run.
- Rename stats so it is clear what is what.

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
