### PR TITLE
Bugfix: Losing contact_references value when no candidate needed to be contacted

### DIFF
--- a/app/controllers/publishers/vacancies/references_and_self_disclosure_controller.rb
+++ b/app/controllers/publishers/vacancies/references_and_self_disclosure_controller.rb
@@ -19,7 +19,7 @@ module Publishers
                                  contact_applicants: params[:contact_applicants]
                 end
         if (step == :ask_references_email) && (!@form.collect_references || @job_applications.none?(&:notify_before_contact_referers?))
-          skip_step
+          skip_step collect_references: params[:collect_references]
         end
         render_wizard
       end

--- a/app/controllers/publishers/vacancies/references_and_self_disclosure_controller.rb
+++ b/app/controllers/publishers/vacancies/references_and_self_disclosure_controller.rb
@@ -19,6 +19,7 @@ module Publishers
                                  contact_applicants: params[:contact_applicants]
                 end
         if (step == :ask_references_email) && (!@form.collect_references || @job_applications.none?(&:notify_before_contact_referers?))
+          # this causes render_wizard to re-direct, so need to pass the field so that we don't lose it
           skip_step collect_references: params[:collect_references]
         end
         render_wizard

--- a/app/views/publishers/vacancies/job_applications/base/ask_references_email.html.slim
+++ b/app/views/publishers/vacancies/job_applications/base/ask_references_email.html.slim
@@ -3,6 +3,7 @@
 = form_with(model: @form, url: wizard_path, method: :patch) do |f|
   = f.govuk_error_summary
 
+  / need to accumulate user answers to previous questions
   = f.hidden_field :collect_references, value: f.object.collect_references
 
   - legend_text = t(contact_referees_message(@job_applications), scope: "helpers.legend.publishers_job_application_references_contact_applicant_form.contact_applicants")

--- a/app/views/publishers/vacancies/job_applications/base/collect_self_disclosure.html.slim
+++ b/app/views/publishers/vacancies/job_applications/base/collect_self_disclosure.html.slim
@@ -3,6 +3,7 @@
 = form_with(model: @form, url: wizard_path, method: :patch) do |f|
   = f.govuk_error_summary
 
+  / need to accumulate user answers to previous questions
   = f.hidden_field :collect_references, value: f.object.collect_references
   = f.hidden_field :contact_applicants, value: f.object.contact_applicants
 


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/mfXHEKEC/2228-bug-pre-interview-checks-are-not-being-automatically-triggered-despite-saying-yes

## Changes in this PR:

- Is there anything specific you want feedback on?

## Screenshots of UI changes:

### Before

### After

