### PR TITLE
Reduce job alerts job memory usage

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -42,6 +42,7 @@ class Subscription < ApplicationRecord
 
   # One/off code. Remove after running the rake task to normalise all subscriptions
   LEGACY_PHASE_MAPPING = {
+    "middle" => %w[primary secondary].freeze,
     "middle_deemed_secondary" => %w[primary secondary].freeze,
     "middle_deemed_primary" => %w[primary secondary].freeze,
     "all_through" => %w[through].freeze,

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -27,7 +27,7 @@ class Subscription < ApplicationRecord
     subjects: ->(vacancy, value) { (vacancy.subjects || []).intersect?(value) },
     # legacy 'subject' criteria appears to be 1 single value
     subject: ->(vacancy, value) { (vacancy.subjects || []).include?(value) },
-    phases: ->(vacancy, value) { phases_match?(vacancy, value) },
+    phases: ->(vacancy, value) { (vacancy.phases || []).intersect?(value) },
     working_patterns: ->(vacancy, value) { working_pattern_match?(vacancy, value) },
     organisation_slug: ->(vacancy, value) { vacancy.organisations.map(&:slug).include?(value) },
     keyword: ->(vacancy, value) { value.downcase.strip.split.all? { |k| vacancy.searchable_content.include? k } },
@@ -51,16 +51,6 @@ class Subscription < ApplicationRecord
   }.freeze
 
   class << self
-    def phases_match?(vacancy, filter)
-      phases = filter.map { |phase| phase.in?(%w[middle_deemed_secondary middle_deemed_primary]) ? "primary secondary" : phase }
-          .map { |phase| phase == "all_through" ? "through" : phase }
-          .map { |phase| phase.in?(%w[sixteen_plus 16-19]) ? "sixth_form_or_college" : phase }
-          .reject { |phase| phase.in? %w[not_applicable] }
-          .map(&:split)
-          .flatten
-      vacancy.phases.intersect?(phases)
-    end
-
     def working_pattern_match?(vacancy, working_patterns)
       if working_patterns == %w[job_share]
         vacancy.is_job_share

--- a/lib/tasks/subscriptions_normalise_phases.rake
+++ b/lib/tasks/subscriptions_normalise_phases.rake
@@ -2,10 +2,8 @@
 
 namespace :subscriptions do
   desc "Normalize phases in search_criteria for all subscriptions"
-  # :nocov:
   task normalize_phases: :environment do
     Subscription.normalize_phases!
     puts "Normalized phases for subscriptions."
   end
-  # :nocov:
 end

--- a/lib/tasks/subscriptions_normalise_phases.rake
+++ b/lib/tasks/subscriptions_normalise_phases.rake
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+namespace :subscriptions do
+  desc "Normalize phases in search_criteria for all subscriptions"
+  # :nocov:
+  task normalize_phases: :environment do
+    Subscription.normalize_phases!
+    puts "Normalized phases for subscriptions."
+  end
+  # :nocov:
+end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -473,4 +473,91 @@ RSpec.describe Subscription do
       end
     end
   end
+
+  describe ".normalize_phases!" do
+    let(:search_criteria) do
+      { "radius" => "5",
+        "location" => "Barriedale, London SE14 6RF",
+        "working_patterns" => %w[full_time],
+        "teaching_job_roles" => %w[teacher assistant_headteacher] }
+    end
+
+    it "maps middle_deemed_primary legacy phase to new values" do
+      sub = described_class.create!(search_criteria: search_criteria.merge({ "phases" => %w[middle_deemed_primary nursery] }))
+      expect {
+        described_class.normalize_phases!
+        sub.reload
+      }.to(change { sub.search_criteria["phases"] })
+      expect(sub.search_criteria["phases"]).to match_array(%w[nursery primary secondary])
+    end
+
+    it "maps middle_deemed_secondary legacy phase to new values" do
+      sub = described_class.create!(search_criteria: search_criteria.merge({ "phases" => %w[nursery middle_deemed_secondary] }))
+      expect {
+        described_class.normalize_phases!
+        sub.reload
+      }.to(change { sub.search_criteria["phases"] })
+      expect(sub.search_criteria["phases"]).to match_array(%w[nursery primary secondary])
+    end
+
+    it "maps all_through legacy phase to new value" do
+      sub = described_class.create!(search_criteria: search_criteria.merge({ "phases" => %w[nursery all_through] }))
+      expect {
+        described_class.normalize_phases!
+        sub.reload
+      }.to(change { sub.search_criteria["phases"] })
+      expect(sub.search_criteria["phases"]).to match_array(%w[nursery through])
+    end
+
+    it "maps 16-19 legacy phase to new value" do
+      sub = described_class.create!(search_criteria: search_criteria.merge({ "phases" => %w[nursery 16-19] }))
+      expect {
+        described_class.normalize_phases!
+        sub.reload
+      }.to(change { sub.search_criteria["phases"] })
+      expect(sub.search_criteria["phases"]).to match_array(%w[nursery sixth_form_or_college])
+    end
+
+    it "maps sixteen_plus legacy phase to new value" do
+      sub = described_class.create!(search_criteria: search_criteria.merge({ "phases" => %w[nursery sixteen_plus] }))
+      expect {
+        described_class.normalize_phases!
+        sub.reload
+      }.to(change { sub.search_criteria["phases"] })
+      expect(sub.search_criteria["phases"]).to match_array(%w[nursery sixth_form_or_college])
+    end
+
+    it "removes phases if normalization results in empty array" do
+      sub = described_class.create!(search_criteria: { "phases" => %w[not_applicable] })
+      expect {
+        described_class.normalize_phases!
+        sub.reload
+      }.to change { sub.search_criteria.key?("phases") }.from(true).to(false)
+    end
+
+    it "does not update described_class if phases are already normalized" do
+      sub = described_class.create!(search_criteria: { "phases" => %w[primary secondary] })
+      expect {
+        described_class.normalize_phases!
+        sub.reload
+      }.not_to(change { sub.search_criteria })
+    end
+
+    it "removes phases if all are blank strings" do
+      sub = described_class.create!(search_criteria: { "phases" => ["", ""] })
+      expect {
+        described_class.normalize_phases!
+        sub.reload
+      }.to change { sub.search_criteria.key?("phases") }.from(true).to(false)
+    end
+
+    it "handles mixed legacy and blank phases" do
+      sub = described_class.create!(search_criteria: { "phases" => ["middle_deemed_primary", ""] })
+      expect {
+        described_class.normalize_phases!
+        sub.reload
+      }.to(change { sub.search_criteria["phases"] })
+      expect(sub.search_criteria["phases"]).to match_array(%w[primary secondary])
+    end
+  end
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -500,6 +500,24 @@ RSpec.describe Subscription do
       expect(sub.search_criteria["phases"]).to match_array(%w[nursery primary secondary])
     end
 
+    it "maps middle legacy phase to new values" do
+      sub = described_class.create!(search_criteria: search_criteria.merge({ "phases" => %w[nursery middle] }))
+      expect {
+        described_class.normalize_phases!
+        sub.reload
+      }.to(change { sub.search_criteria["phases"] })
+      expect(sub.search_criteria["phases"]).to match_array(%w[nursery primary secondary])
+    end
+
+    it "does not return repeated values if multiple legacy phases map into the same new phase" do
+      sub = described_class.create!(search_criteria: search_criteria.merge({ "phases" => %w[middle_deemed_primary middle_deemed_secondary middle] }))
+      expect {
+        described_class.normalize_phases!
+        sub.reload
+      }.to(change { sub.search_criteria["phases"] })
+      expect(sub.search_criteria["phases"]).to match_array(%w[primary secondary])
+    end
+
     it "maps all_through legacy phase to new value" do
       sub = described_class.create!(search_criteria: search_criteria.merge({ "phases" => %w[nursery all_through] }))
       expect {


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/agdJHLTG/2231-subscription-alerts-profile-the-job-run-locally-with-real-volume-of-alerts

## Changes in this PR:

Reduces the memory used by the job alert jobs by:
- Backfilling the legacy phases mapping into the subscription search criteria values instead of doing real-time mapping over the loop (what caused a lot of memory allocations). Now we will just "match" the phase without needing a mapping anymore. **Note: Found a missing mapping here. Added it**.
- Slightly tweak how we define and apply the filters, to reduce memory allocations inside the vacancies loop.
- Fewer intermediate objects and strings.

## Screenshots of UI changes:
### Test for Daily Alerts with 2000 subscriptions over 390 new vacancies

| Metric | Original | After changes | Change | % |
| --- | --- | --- | --- | --- |
| Memory Used |	7,236,692 KB |	3,360,852 KB	 |-3,875,840 KB | -53% |
| Runtime |	~52 sec	| ~42 sec | -10 sec | -19% |

#### Also did a proper memory profiling of the job run before and after:

| Metric | Original | After changes | Change | % |
| --- | --- | --- | --- | --- |
| Allocated Memory (subscription.rb) | 911,620,848 bytes | 105,254,314 bytes | -806 MB | -90% |
| Allocated Objects (subscription.rb) | 15,628,903 objects | 2,098,999 objects | - 13.5 million objects | -87%|

##### These metrics only apply to the `subscriptions.rb` memory allocation.
There are also lots of allocations by the `rgeo` gem for geospatial calculations/checks by the location search. And those have not been affected. I plan to tackle those separately by reshaping how we do the subscription location filtering.


### For the backfill of the phases in the subscriptions:
#### Before

All the phases (and how many times they appear in the search criteria) in our prod DB subscriptions:
```
{"nursery" => 20232,
 "primary" => 91073,
 "middle" => 28329,
 "secondary" => 69828,
 "16-19" => 7878,
 "sixth_form_or_college" => 21700,
 "through" => 13839,
 "middle_deemed_secondary" => 323,
 "sixteen_plus" => 410,
 "middle_deemed_primary" => 246,
 "all_through" => 177,
 "not_applicable" => 15,
 "" => 1}
```


#### After
Ran the backfill mapping tasks over a copy of prod DB:
Now all the values match our current `phases` possible values.
```
{"nursery" => 20232, 
 "primary" => 99627, 
 "secondary" => 78688, 
 "sixth_form_or_college" => 29988, 
 "through" => 14016}
```

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
