### PR TITLE
Fix: Skip backfill task when criteria contains no phases

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -68,6 +68,7 @@ class Subscription < ApplicationRecord
         subs.each do |sub|
           criteria = sub.search_criteria
           phases = criteria["phases"]
+          next if phases.nil?
 
           normalized_phases = phases.flat_map { |phase|
             next if phase == "not_applicable"

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -549,5 +549,13 @@ RSpec.describe Subscription do
       }.to(change { sub.search_criteria["phases"] })
       expect(sub.search_criteria["phases"]).to match_array(%w[primary secondary])
     end
+
+    it "does not change the search criteria when phases key is missing" do
+      sub = described_class.create!(search_criteria: search_criteria)
+      expect {
+        described_class.normalize_phases!
+        sub.reload
+      }.not_to(change { sub.search_criteria }.from(search_criteria))
+    end
   end
 end


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/agdJHLTG/2231-subscription-alerts-profile-the-job-run-locally-with-real-volume-of-alerts
- Fixes https://github.com/DFE-Digital/teaching-vacancies/pull/8127

## Changes in this PR:

Skip the phases backfill process when the criteria contain no phases

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
