### PR TITLE
Use separate forms for important date when vacancy has been published

### DIFF
--- a/app/controllers/concerns/publishers/wizardable.rb
+++ b/app/controllers/concerns/publishers/wizardable.rb
@@ -71,6 +71,11 @@ module Publishers::Wizardable # rubocop:disable Metrics/ModuleLength
           .permit(:actual_salary, :benefits, :benefits_details, :salary, :pay_scale, :hourly_rate, salary_types: [])
   end
 
+  def expiry_date_time_params(params)
+    params.require(:publishers_job_listing_expiry_date_time_form)
+          .permit(:expires_at, :expiry_time)
+  end
+
   def important_dates_params(params)
     params.require(:publishers_job_listing_important_dates_form)
           .permit(:publish_on, :publish_on_day, :expires_at, :expiry_time)

--- a/app/controllers/publishers/vacancies/build_controller.rb
+++ b/app/controllers/publishers/vacancies/build_controller.rb
@@ -41,8 +41,20 @@ class Publishers::Vacancies::BuildController < Publishers::Vacancies::WizardBase
 
   attr_reader :form
 
+  def form_params
+    if current_step == :important_dates && vacancy.disable_editing_publish_on?
+      expiry_date_time_params(params)
+    else
+      super
+    end
+  end
+
   def form_class
-    "publishers/job_listing/#{step}_form".camelize.constantize
+    if current_step == :important_dates && vacancy.disable_editing_publish_on?
+      Publishers::JobListing::ExpiryDateTimeForm
+    else
+      "publishers/job_listing/#{step}_form".camelize.constantize
+    end
   end
 
   def set_school_options # rubocop:disable Metrics/AbcSize
@@ -71,8 +83,8 @@ class Publishers::Vacancies::BuildController < Publishers::Vacancies::WizardBase
   end
 
   def update_vacancy
-    updated_completed_steps = completed_steps(steps_to_reset: form.steps_to_reset)
-    vacancy.assign_attributes(form.params_to_save.merge(completed_steps: updated_completed_steps))
+    updated_completed_steps = completed_steps(steps_to_reset: @form.steps_to_reset)
+    vacancy.assign_attributes(@form.params_to_save.merge(completed_steps: updated_completed_steps))
     vacancy.geocode_job_address if current_step == :confirm_job_address
     vacancy.refresh_slug
     update_google_index(vacancy) if vacancy.live?

--- a/app/form_models/publishers/job_listing/expiry_date_time_form.rb
+++ b/app/form_models/publishers/job_listing/expiry_date_time_form.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Publishers
+  module JobListing
+    class ExpiryDateTimeForm < JobListingForm
+      include ActiveRecord::AttributeAssignment
+      include DateAttributeAssignment
+
+      attr_writer :completed_steps, :current_organisation
+
+      attr_accessor :expiry_time, :publish_on
+      attr_reader :expires_at
+
+      validates :expires_at, date: { on_or_after: :now, on_or_before: :far_future, after: :publish_on }
+      validates :expiry_time, inclusion: { in: Vacancy::EXPIRY_TIME_OPTIONS }
+
+      class << self
+        def fields
+          %i[expires_at]
+        end
+
+        def load_from_params(form_params, vacancy, current_publisher:) # rubocop:disable Lint/UnusedMethodArgument
+          new(form_params.merge(publish_on: vacancy.publish_on))
+        end
+
+        def args_from_vacancy(vacancy)
+          { expires_at: vacancy.expires_at, expiry_time: vacancy.expires_at&.strftime("%k:%M")&.strip }
+        end
+
+        def load_from_model(vacancy, current_publisher:) # rubocop:disable Lint/UnusedMethodArgument
+          new(args_from_vacancy(vacancy))
+        end
+      end
+
+      # def initialize(params)
+      #   @expiry_time = params[:expiry_time] || params[:expires_at]&.strftime("%k:%M")&.strip
+      #
+      #   super
+      # end
+
+      def params_to_save
+        { expires_at: expires_at }
+      end
+
+      def expires_at=(value)
+        expires_on = date_from_multiparameter_hash(value)
+        @expires_at = datetime_from_date_and_time(expires_on, expiry_time)
+      end
+
+      def steps_to_reset
+        []
+      end
+    end
+  end
+end

--- a/app/form_models/publishers/job_listing/expiry_date_time_form.rb
+++ b/app/form_models/publishers/job_listing/expiry_date_time_form.rb
@@ -15,10 +15,6 @@ module Publishers
       validates :expiry_time, inclusion: { in: Vacancy::EXPIRY_TIME_OPTIONS }
 
       class << self
-        def fields
-          %i[expires_at]
-        end
-
         def load_from_params(form_params, vacancy, current_publisher:) # rubocop:disable Lint/UnusedMethodArgument
           new(form_params.merge(publish_on: vacancy.publish_on))
         end
@@ -31,12 +27,6 @@ module Publishers
           new(args_from_vacancy(vacancy))
         end
       end
-
-      # def initialize(params)
-      #   @expiry_time = params[:expiry_time] || params[:expires_at]&.strftime("%k:%M")&.strip
-      #
-      #   super
-      # end
 
       def params_to_save
         { expires_at: expires_at }

--- a/app/form_models/publishers/job_listing/important_dates_form.rb
+++ b/app/form_models/publishers/job_listing/important_dates_form.rb
@@ -1,66 +1,44 @@
-class Publishers::JobListing::ImportantDatesForm < Publishers::JobListing::VacancyForm
-  include ActiveRecord::AttributeAssignment
-  include DateAttributeAssignment
+class Publishers::JobListing::ImportantDatesForm < Publishers::JobListing::ExpiryDateTimeForm
+  attr_accessor :publish_on_day
+  attr_reader :publish_on
 
-  attr_accessor :expiry_time
-  attr_reader :expires_at, :publish_on
-  attr_writer :publish_on_day
-
-  validates(:publish_on, date: { on_or_after: :today, on_or_before: :far_future }, unless: lambda do
-    publish_on_day.blank? || disable_editing_publish_on? || (publish_on.is_a?(Date) && (publish_on.today? || publish_on.tomorrow?))
-  end)
-  validates :publish_on_day, inclusion: { in: %w[today tomorrow another_day] }, unless: :disable_editing_publish_on?
-  validates :expires_at, date: { on_or_after: :now, on_or_before: :far_future, after: :publish_on }
-  validates :expiry_time, inclusion: { in: Vacancy::EXPIRY_TIME_OPTIONS }
+  #  ;publish_on_day is a radio, so this validation is skipped if it hasn't been selected
+  validates :publish_on, date: { on_or_after: :today, on_or_before: :far_future }, unless: -> { publish_on_day.blank? }
+  validates :publish_on_day, inclusion: { in: %w[today tomorrow another_day] }
 
   def self.fields
     %i[publish_on expires_at]
   end
 
-  def initialize(params, vacancy)
-    @expiry_time = params[:expiry_time] || vacancy.expires_at&.strftime("%k:%M")&.strip
-
-    super
-  end
-
-  # We won't allow editing of publish_on if the vacancy is already published
-  def disable_editing_publish_on?
-    vacancy.published? && (vacancy.publish_on.past? || vacancy.publish_on.today?)
-  end
-
-  def params_to_save
-    { expires_at: expires_at }.tap do |params|
-      params[:publish_on] = publish_on if save_publish_on?
+  class << self
+    def load_from_model(vacancy, current_publisher:) # rubocop:disable Lint/UnusedMethodArgument
+      params = args_from_vacancy(vacancy)
+                 .merge(publish_on: vacancy.publish_on)
+                 .merge(publish_on_day: extract_publish_on_day(vacancy))
+      new(params)
     end
   end
 
-  def expires_at=(value)
-    expires_on = date_from_multiparameter_hash(value)
-    @expires_at = datetime_from_date_and_time(expires_on, expiry_time)
-  end
-
-  def publish_on_day
-    return "today" if params[:publish_on_day] == "today" || params[:publish_on] == Date.today
-    return "tomorrow" if params[:publish_on_day] == "tomorrow" || params[:publish_on] == Date.tomorrow
-
-    "another_day" if params[:publish_on_day] == "another_day" || params[:publish_on].is_a?(Date)
+  def params_to_save
+    { expires_at: expires_at,
+      publish_on: publish_on }
   end
 
   def publish_on=(value)
     @publish_on =
-      case params[:publish_on_day]
+      case @publish_on_day
       when "today" then Date.today
       when "tomorrow" then Date.tomorrow
       else date_from_multiparameter_hash(value)
       end
   end
 
-  private
+  class << self
+    def extract_publish_on_day(params)
+      return "today" if params[:publish_on_day] == "today" || params[:publish_on] == Date.today
+      return "tomorrow" if params[:publish_on_day] == "tomorrow" || params[:publish_on] == Date.tomorrow
 
-  # Determines if the publish_on date should be saved based on its presence and type.
-  # If publish_on is a Date and not disabled for editing (cannot change publishing date on already published vacancy),
-  # it will be saved.
-  def save_publish_on?
-    publish_on.present? && publish_on.is_a?(Date) && !disable_editing_publish_on?
+      "another_day" if params[:publish_on_day] == "another_day" || params[:publish_on].is_a?(Date)
+    end
   end
 end

--- a/app/form_models/publishers/job_listing/important_dates_form.rb
+++ b/app/form_models/publishers/job_listing/important_dates_form.rb
@@ -1,44 +1,48 @@
-class Publishers::JobListing::ImportantDatesForm < Publishers::JobListing::ExpiryDateTimeForm
-  attr_accessor :publish_on_day
-  attr_reader :publish_on
+module Publishers
+  module JobListing
+    class ImportantDatesForm < ExpiryDateTimeForm
+      attr_accessor :publish_on_day
+      attr_reader :publish_on
 
-  #  ;publish_on_day is a radio, so this validation is skipped if it hasn't been selected
-  validates :publish_on, date: { on_or_after: :today, on_or_before: :far_future }, unless: -> { publish_on_day.blank? }
-  validates :publish_on_day, inclusion: { in: %w[today tomorrow another_day] }
+      #  ;publish_on_day is a radio, so this validation is skipped if it hasn't been selected
+      validates :publish_on, date: { on_or_after: :today, on_or_before: :far_future }, unless: -> { publish_on_day.blank? }
+      validates :publish_on_day, inclusion: { in: %w[today tomorrow another_day] }
 
-  def self.fields
-    %i[publish_on expires_at]
-  end
-
-  class << self
-    def load_from_model(vacancy, current_publisher:) # rubocop:disable Lint/UnusedMethodArgument
-      params = args_from_vacancy(vacancy)
-                 .merge(publish_on: vacancy.publish_on)
-                 .merge(publish_on_day: extract_publish_on_day(vacancy))
-      new(params)
-    end
-  end
-
-  def params_to_save
-    { expires_at: expires_at,
-      publish_on: publish_on }
-  end
-
-  def publish_on=(value)
-    @publish_on =
-      case @publish_on_day
-      when "today" then Date.today
-      when "tomorrow" then Date.tomorrow
-      else date_from_multiparameter_hash(value)
+      def self.fields
+        %i[publish_on expires_at]
       end
-  end
 
-  class << self
-    def extract_publish_on_day(params)
-      return "today" if params[:publish_on_day] == "today" || params[:publish_on] == Date.today
-      return "tomorrow" if params[:publish_on_day] == "tomorrow" || params[:publish_on] == Date.tomorrow
+      class << self
+        def load_from_model(vacancy, current_publisher:) # rubocop:disable Lint/UnusedMethodArgument
+          params = args_from_vacancy(vacancy)
+                     .merge(publish_on: vacancy.publish_on)
+                     .merge(publish_on_day: extract_publish_on_day(vacancy))
+          new(params)
+        end
+      end
 
-      "another_day" if params[:publish_on_day] == "another_day" || params[:publish_on].is_a?(Date)
+      def params_to_save
+        { expires_at: expires_at,
+          publish_on: publish_on }
+      end
+
+      def publish_on=(value)
+        @publish_on =
+          case @publish_on_day
+          when "today" then Date.today
+          when "tomorrow" then Date.tomorrow
+          else date_from_multiparameter_hash(value)
+          end
+      end
+
+      class << self
+        def extract_publish_on_day(params)
+          return "today" if params[:publish_on_day] == "today" || params[:publish_on] == Date.today
+          return "tomorrow" if params[:publish_on_day] == "tomorrow" || params[:publish_on] == Date.tomorrow
+
+          "another_day" if params[:publish_on_day] == "another_day" || params[:publish_on].is_a?(Date)
+        end
+      end
     end
   end
 end

--- a/app/form_models/publishers/job_listing/relist_form.rb
+++ b/app/form_models/publishers/job_listing/relist_form.rb
@@ -1,55 +1,18 @@
-class Publishers::JobListing::RelistForm < Publishers::JobListing::ImportantDatesForm
-  # include ActiveRecord::AttributeAssignment
-  # include DateAttributeAssignment
+module Publishers
+  module JobListing
+    class RelistForm < ImportantDatesForm
+      attr_accessor :extension_reason, :other_extension_reason_details
 
-  # attr_reader :publish_on, :expires_at
-  # attr_writer :publish_on_day
+      validates :extension_reason, inclusion: { in: Vacancy.extension_reasons.keys }
 
-  # validates(:publish_on, date: { on_or_after: :today, on_or_before: :far_future }, unless: lambda do
-  #   publish_on_day.blank? || (publish_on.is_a?(Date) && (publish_on.today? || publish_on.tomorrow?))
-  # end)
-  # validates :publish_on_day, inclusion: { in: %w[today tomorrow another_day] }
-
-  # attr_accessor :expiry_time, :extension_reason, :other_extension_reason_details
-  attr_accessor :extension_reason, :other_extension_reason_details
-
-  # validates :expires_at, date: { on_or_after: :now, on_or_before: :far_future }
-  # validates :expiry_time, inclusion: { in: Vacancy::EXPIRY_TIME_OPTIONS }
-
-  validates :extension_reason, inclusion: { in: Vacancy.extension_reasons.keys }
-
-  # def initialize(params = {})
-  #   @params = params
-  #   super
-  # end
-
-  def attributes_to_save
-    {
-      publish_on: publish_on,
-      expires_at: expires_at,
-      extension_reason: extension_reason,
-      other_extension_reason_details: other_extension_reason_details,
-    }
+      def attributes_to_save
+        {
+          publish_on: publish_on,
+          expires_at: expires_at,
+          extension_reason: extension_reason,
+          other_extension_reason_details: other_extension_reason_details,
+        }
+      end
+    end
   end
-
-  # def expires_at=(value)
-  #   expires_on = date_from_multiparameter_hash(value)
-  #   @expires_at = datetime_from_date_and_time(expires_on, expiry_time)
-  # end
-
-  # def publish_on_day
-  #   return "today" if @publish_on_day == "today" || publish_on == Date.today
-  #   return "tomorrow" if @publish_on_day == "tomorrow" || publish_on == Date.tomorrow
-  #
-  #   "another_day" if @publish_on_day == "another_day" || publish_on.is_a?(Date)
-  # end
-
-  # def publish_on=(value)
-  #   @publish_on =
-  #     case @params[:publish_on_day]
-  #     when "today" then Date.today
-  #     when "tomorrow" then Date.tomorrow
-  #     else date_from_multiparameter_hash(value)
-  #     end
-  # end
 end

--- a/app/form_models/publishers/job_listing/relist_form.rb
+++ b/app/form_models/publishers/job_listing/relist_form.rb
@@ -1,26 +1,27 @@
-class Publishers::JobListing::RelistForm < BaseForm
-  include ActiveRecord::AttributeAssignment
-  include DateAttributeAssignment
+class Publishers::JobListing::RelistForm < Publishers::JobListing::ImportantDatesForm
+  # include ActiveRecord::AttributeAssignment
+  # include DateAttributeAssignment
 
-  attr_reader :publish_on, :expires_at
-  attr_writer :publish_on_day
+  # attr_reader :publish_on, :expires_at
+  # attr_writer :publish_on_day
 
-  validates(:publish_on, date: { on_or_after: :today, on_or_before: :far_future }, unless: lambda do
-    publish_on_day.blank? || (publish_on.is_a?(Date) && (publish_on.today? || publish_on.tomorrow?))
-  end)
-  validates :publish_on_day, inclusion: { in: %w[today tomorrow another_day] }
+  # validates(:publish_on, date: { on_or_after: :today, on_or_before: :far_future }, unless: lambda do
+  #   publish_on_day.blank? || (publish_on.is_a?(Date) && (publish_on.today? || publish_on.tomorrow?))
+  # end)
+  # validates :publish_on_day, inclusion: { in: %w[today tomorrow another_day] }
 
-  attr_accessor :expiry_time, :extension_reason, :other_extension_reason_details
+  # attr_accessor :expiry_time, :extension_reason, :other_extension_reason_details
+  attr_accessor :extension_reason, :other_extension_reason_details
 
-  validates :expires_at, date: { on_or_after: :now, on_or_before: :far_future }
-  validates :expiry_time, inclusion: { in: Vacancy::EXPIRY_TIME_OPTIONS }
+  # validates :expires_at, date: { on_or_after: :now, on_or_before: :far_future }
+  # validates :expiry_time, inclusion: { in: Vacancy::EXPIRY_TIME_OPTIONS }
 
   validates :extension_reason, inclusion: { in: Vacancy.extension_reasons.keys }
 
-  def initialize(params = {})
-    @params = params
-    super
-  end
+  # def initialize(params = {})
+  #   @params = params
+  #   super
+  # end
 
   def attributes_to_save
     {
@@ -31,24 +32,24 @@ class Publishers::JobListing::RelistForm < BaseForm
     }
   end
 
-  def expires_at=(value)
-    expires_on = date_from_multiparameter_hash(value)
-    @expires_at = datetime_from_date_and_time(expires_on, expiry_time)
-  end
+  # def expires_at=(value)
+  #   expires_on = date_from_multiparameter_hash(value)
+  #   @expires_at = datetime_from_date_and_time(expires_on, expiry_time)
+  # end
 
-  def publish_on_day
-    return "today" if @publish_on_day == "today" || publish_on == Date.today
-    return "tomorrow" if @publish_on_day == "tomorrow" || publish_on == Date.tomorrow
+  # def publish_on_day
+  #   return "today" if @publish_on_day == "today" || publish_on == Date.today
+  #   return "tomorrow" if @publish_on_day == "tomorrow" || publish_on == Date.tomorrow
+  #
+  #   "another_day" if @publish_on_day == "another_day" || publish_on.is_a?(Date)
+  # end
 
-    "another_day" if @publish_on_day == "another_day" || publish_on.is_a?(Date)
-  end
-
-  def publish_on=(value)
-    @publish_on =
-      case @params[:publish_on_day]
-      when "today" then Date.today
-      when "tomorrow" then Date.tomorrow
-      else date_from_multiparameter_hash(value)
-      end
-  end
+  # def publish_on=(value)
+  #   @publish_on =
+  #     case @params[:publish_on_day]
+  #     when "today" then Date.today
+  #     when "tomorrow" then Date.tomorrow
+  #     else date_from_multiparameter_hash(value)
+  #     end
+  # end
 end

--- a/app/form_models/publishers/job_listing/vacancy_form.rb
+++ b/app/form_models/publishers/job_listing/vacancy_form.rb
@@ -10,7 +10,7 @@ class Publishers::JobListing::VacancyForm < BaseForm
   end
 
   def params_to_save
-    params
+    @params
   end
 
   # Some forms may cause some previously completed steps in the Vacancy to be marked as incomplete again after updating

--- a/app/form_models/publishers/vacancy_form_sequence.rb
+++ b/app/form_models/publishers/vacancy_form_sequence.rb
@@ -29,7 +29,11 @@ class Publishers::VacancyFormSequence
   end
 
   def validate_step(step_name)
-    step_form_class = File.join(@form_prefix, "#{step_name}_form").camelize.constantize
+    step_form_class = if step_name == :important_dates && @vacancy.disable_editing_publish_on?
+                        Publishers::JobListing::ExpiryDateTimeForm
+                      else
+                        File.join(@form_prefix, "#{step_name}_form").camelize.constantize
+                      end
 
     step_form_class.load_from_model(@vacancy, current_publisher: nil).tap do |form|
       form.valid?

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -281,6 +281,11 @@ class Vacancy < ApplicationRecord
     Publisher.find_by(email: contact_email).present?
   end
 
+  # We won't allow editing of publish_on if the vacancy is already published
+  def disable_editing_publish_on?
+    published? && (publish_on.past? || publish_on.today?)
+  end
+
   def unsafe_blobs
     blobs = []
     blobs << application_form.blob if application_form.attached?

--- a/app/views/publishers/vacancies/build/important_dates.html.slim
+++ b/app/views/publishers/vacancies/build/important_dates.html.slim
@@ -5,11 +5,13 @@
 
   = vacancy_form_page_heading(vacancy, step_process, back_path: back_path, fieldset: false)
 
-  - if form.disable_editing_publish_on?
+  - if vacancy.disable_editing_publish_on?
     #publish_on
       legend.govuk-fieldset__legend.govuk-fieldset__legend--m
         .govuk-fieldset__heading = t("helpers.legend.publishers_job_listing_important_dates_form.publish_on_day")
       p = format_date vacancy.publish_on
+      / = f.date_select :publish_on, use_hidden: true
+      / = f.hidden_field :publish_on_day, value: "another_day"
     br
   - else
     = render "publish_date", f: f

--- a/app/views/publishers/vacancies/build/important_dates.html.slim
+++ b/app/views/publishers/vacancies/build/important_dates.html.slim
@@ -10,8 +10,6 @@
       legend.govuk-fieldset__legend.govuk-fieldset__legend--m
         .govuk-fieldset__heading = t("helpers.legend.publishers_job_listing_important_dates_form.publish_on_day")
       p = format_date vacancy.publish_on
-      / = f.date_select :publish_on, use_hidden: true
-      / = f.hidden_field :publish_on_day, value: "another_day"
     br
   - else
     = render "publish_date", f: f

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -190,7 +190,7 @@ en:
       blank: Enter hourly rate
     salary_types:
       invalid: Select salary details
-  important_dates_errors: &important_dates_errors
+  expiry_date_time_errors: &expiry_date_time_errors
     expires_at:
       after: >-
         The closing date must be after the publish date entered above.
@@ -201,6 +201,7 @@ en:
       on_or_before: The closing date must be less than two years in the future
     expiry_time:
       inclusion: Select closing time
+  important_dates_errors: &important_dates_errors
     publish_on_day:
       inclusion: Select publish date
     publish_on:
@@ -396,6 +397,9 @@ en:
         publishers/job_listing/important_dates_form:
           attributes:
             <<: *important_dates_errors
+        publishers/job_listing/expiry_date_time_form:
+          attributes:
+            <<: *expiry_date_time_errors
         publishers/job_listing/start_date_form:
           attributes:
             <<: *start_date_errors
@@ -438,6 +442,7 @@ en:
         publishers/job_listing/copy_vacancy_form:
           attributes:
             <<: *important_dates_errors
+            <<: *expiry_date_time_errors
             <<: *start_date_errors
         publishers/job_listing/feedback_form:
           attributes:
@@ -451,10 +456,12 @@ en:
         publishers/job_listing/extend_deadline_form:
           attributes:
             <<: *important_dates_errors
+            <<: *expiry_date_time_errors
             <<: *start_date_errors
         publishers/job_listing/relist_form:
           attributes:
             <<: *important_dates_errors
+            <<: *expiry_date_time_errors
             extension_reason:
               inclusion: Select the reason why the vacancy is being relisted
         publishers/login_keys/choose_organisation_form:
@@ -688,6 +695,7 @@ en:
             <<: *contract_information_errors
             <<: *pay_package_errors
             <<: *important_dates_errors
+            <<: *expiry_date_time_errors
             <<: *start_date_errors
             <<: *applying_for_the_job_errors
             <<: *how_to_receive_applications_errors

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -768,9 +768,10 @@ en:
         user_participation_response: Would you like to participate in our research?
       publishers_job_listing_how_to_receive_applications_form:
         receive_applications: How do you want candidates to apply for the role?
-      publishers_job_listing_important_dates_form:
+      publishers_job_listing_expiry_date_time_form:
         expires_at: Closing date
         expiry_time: Closing time
+      publishers_job_listing_important_dates_form:
         publish_on: Another date
         publish_on_day: Publish date
       publishers_job_listing_relist_form:
@@ -815,7 +816,7 @@ en:
           "12:00": 12pm (midday)
           "15:00": 3pm
           "23:59": 11:59pm
-      publishers_job_listing_important_dates_form:
+      publishers_job_listing_expiry_date_time_form:
         expiry_time:
           "8:00": 8am
           "9:00": 9am

--- a/spec/form_models/publishers/job_listing/important_dates_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/important_dates_form_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
-  subject { described_class.new(params, vacancy) }
+  subject { described_class.new(params) }
 
   let(:vacancy) { build_stubbed(:vacancy, publish_on: publish_on) }
 
@@ -44,8 +44,8 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
       expect(subject.errors.of_kind?(:publish_on_day, :inclusion)).to be true
     end
 
-    it "is not included in the parameters to save" do
-      expect(subject.params_to_save).not_to have_key(:publish_on)
+    it "is included in the parameters to save" do
+      expect(subject.params_to_save).to have_key(:publish_on)
     end
   end
 
@@ -61,10 +61,12 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
         let(:vacancy) { build_stubbed(:vacancy, :past_publish) }
 
         it "is valid" do
+          pending("This doesnt make sense, as the field doesnt render for a past publish vacancy")
           expect(subject).to be_valid
         end
 
         it "is not included in the parameters to save" do
+          pending("This doesnt make sense, as the field doesnt render for a past publish vacancy")
           expect(subject.params_to_save).not_to have_key(:publish_on)
         end
       end
@@ -78,6 +80,7 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
         end
 
         it "is not included in the parameters to save" do
+          pending("This doesnt make sense, params_to_save is not called for an invalid form")
           expect(subject.params_to_save).not_to have_key(:publish_on)
         end
       end
@@ -91,6 +94,7 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
         end
 
         it "is not included in the parameters to save" do
+          pending("This doesnt make sense, params_to_save is not called for an invalid form")
           expect(subject.params_to_save).not_to have_key(:publish_on)
         end
       end
@@ -103,10 +107,12 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
         let(:vacancy) { build_stubbed(:vacancy, :past_publish) }
 
         it "is valid" do
+          pending("This doesnt make sense, as the field doesnt render for a past publish vacancy")
           expect(subject).to be_valid
         end
 
         it "is not included in the parameters to save" do
+          pending("This doesnt make sense, as the field doesnt render for a past publish vacancy")
           expect(subject.params_to_save).not_to have_key(:publish_on)
         end
       end
@@ -120,6 +126,7 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
         end
 
         it "is not included in the parameters to save" do
+          pending("This doesnt make sense, params_to_save is not called for an invalid form")
           expect(subject.params_to_save).not_to have_key(:publish_on)
         end
       end
@@ -133,6 +140,7 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
         end
 
         it "is not included in the parameters to save" do
+          pending("This doesnt make sense, params_to_save is not called for an invalid form")
           expect(subject.params_to_save).not_to have_key(:publish_on)
         end
       end
@@ -145,10 +153,12 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
         let(:vacancy) { build_stubbed(:vacancy, :past_publish) }
 
         it "is valid" do
+          pending("This doesnt make sense, as the field doesnt render for a past publish vacancy")
           expect(subject).to be_valid
         end
 
         it "is not included in the parameters to save" do
+          pending("This doesnt make sense, as the field doesnt render for a past publish vacancy")
           expect(subject.params_to_save).not_to have_key(:publish_on)
         end
       end
@@ -162,6 +172,7 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
         end
 
         it "is not included in the parameters to save" do
+          pending("This doesnt make sense, params_to_save is not called for an invalid form")
           expect(subject.params_to_save).not_to have_key(:publish_on)
         end
       end
@@ -175,6 +186,7 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
         end
 
         it "is not included in the parameters to save" do
+          pending("This doesnt make sense, params_to_save is not called for an invalid form")
           expect(subject.params_to_save).not_to have_key(:publish_on)
         end
       end
@@ -187,10 +199,12 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
         let(:vacancy) { build_stubbed(:vacancy) }
 
         it "is valid" do
+          pending("This doesnt make sense, as the field doesnt render for a published vacancy")
           expect(subject).to be_valid
         end
 
         it "is not included in the parameters to save" do
+          pending("This doesnt make sense, as the field doesnt render for a published vacancy")
           expect(subject.params_to_save).not_to have_key(:publish_on)
         end
       end

--- a/spec/form_models/publishers/job_listing/important_dates_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/important_dates_form_spec.rb
@@ -57,31 +57,12 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
         params["publish_on(3i)"] = ""
       end
 
-      context "when vacancy is published and publish_on is on or before today" do
-        let(:vacancy) { build_stubbed(:vacancy, :past_publish) }
-
-        it "is valid" do
-          pending("This doesnt make sense, as the field doesnt render for a past publish vacancy")
-          expect(subject).to be_valid
-        end
-
-        it "is not included in the parameters to save" do
-          pending("This doesnt make sense, as the field doesnt render for a past publish vacancy")
-          expect(subject.params_to_save).not_to have_key(:publish_on)
-        end
-      end
-
       context "when vacancy is published and publish_on is in the future" do
         let(:vacancy) { build_stubbed(:vacancy, publish_on: Date.current + 1.day) }
 
         it "is invalid" do
           expect(subject).to be_invalid
           expect(subject.errors.of_kind?(:publish_on, :blank)).to be true
-        end
-
-        it "is not included in the parameters to save" do
-          pending("This doesnt make sense, params_to_save is not called for an invalid form")
-          expect(subject.params_to_save).not_to have_key(:publish_on)
         end
       end
 
@@ -91,11 +72,6 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
         it "is invalid" do
           expect(subject).to be_invalid
           expect(subject.errors.of_kind?(:publish_on, :blank)).to be true
-        end
-
-        it "is not included in the parameters to save" do
-          pending("This doesnt make sense, params_to_save is not called for an invalid form")
-          expect(subject.params_to_save).not_to have_key(:publish_on)
         end
       end
     end
@@ -103,31 +79,12 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
     context "when date is incomplete" do
       before { params["publish_on(2i)"] = "" }
 
-      context "when vacancy is published and publish_on is on or before today" do
-        let(:vacancy) { build_stubbed(:vacancy, :past_publish) }
-
-        it "is valid" do
-          pending("This doesnt make sense, as the field doesnt render for a past publish vacancy")
-          expect(subject).to be_valid
-        end
-
-        it "is not included in the parameters to save" do
-          pending("This doesnt make sense, as the field doesnt render for a past publish vacancy")
-          expect(subject.params_to_save).not_to have_key(:publish_on)
-        end
-      end
-
       context "when vacancy is published and publish_on is in the future" do
         let(:vacancy) { build_stubbed(:vacancy, publish_on: Date.current + 1.day) }
 
         it "is invalid" do
           expect(subject).to be_invalid
           expect(subject.errors.of_kind?(:publish_on, :invalid)).to be true
-        end
-
-        it "is not included in the parameters to save" do
-          pending("This doesnt make sense, params_to_save is not called for an invalid form")
-          expect(subject.params_to_save).not_to have_key(:publish_on)
         end
       end
 
@@ -137,11 +94,6 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
         it "is invalid" do
           expect(subject).to be_invalid
           expect(subject.errors.of_kind?(:publish_on, :invalid)).to be true
-        end
-
-        it "is not included in the parameters to save" do
-          pending("This doesnt make sense, params_to_save is not called for an invalid form")
-          expect(subject.params_to_save).not_to have_key(:publish_on)
         end
       end
     end
@@ -149,31 +101,12 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
     context "when date is invalid" do
       before { params["publish_on(2i)"] = "100" }
 
-      context "when vacancy is published and publish_on is on or before today" do
-        let(:vacancy) { build_stubbed(:vacancy, :past_publish) }
-
-        it "is valid" do
-          pending("This doesnt make sense, as the field doesnt render for a past publish vacancy")
-          expect(subject).to be_valid
-        end
-
-        it "is not included in the parameters to save" do
-          pending("This doesnt make sense, as the field doesnt render for a past publish vacancy")
-          expect(subject.params_to_save).not_to have_key(:publish_on)
-        end
-      end
-
       context "when vacancy is published and publish_on is in the future" do
         let(:vacancy) { build_stubbed(:vacancy, publish_on: Date.current + 1.day) }
 
         it "is invalid" do
           expect(subject).to be_invalid
           expect(subject.errors.of_kind?(:publish_on, :invalid)).to be true
-        end
-
-        it "is not included in the parameters to save" do
-          pending("This doesnt make sense, params_to_save is not called for an invalid form")
-          expect(subject.params_to_save).not_to have_key(:publish_on)
         end
       end
 
@@ -184,30 +117,11 @@ RSpec.describe Publishers::JobListing::ImportantDatesForm, type: :model do
           expect(subject).to be_invalid
           expect(subject.errors.of_kind?(:publish_on, :invalid)).to be true
         end
-
-        it "is not included in the parameters to save" do
-          pending("This doesnt make sense, params_to_save is not called for an invalid form")
-          expect(subject.params_to_save).not_to have_key(:publish_on)
-        end
       end
     end
 
     context "when date is not in the future" do
       let(:publish_on) { 1.year.ago.to_date }
-
-      context "when vacancy is published" do
-        let(:vacancy) { build_stubbed(:vacancy) }
-
-        it "is valid" do
-          pending("This doesnt make sense, as the field doesnt render for a published vacancy")
-          expect(subject).to be_valid
-        end
-
-        it "is not included in the parameters to save" do
-          pending("This doesnt make sense, as the field doesnt render for a published vacancy")
-          expect(subject.params_to_save).not_to have_key(:publish_on)
-        end
-      end
 
       context "when vacancy is not published" do
         let(:vacancy) { build_stubbed(:draft_vacancy) }

--- a/spec/system/publishers/publishers_can_edit_a_published_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers/publishers_can_edit_a_published_vacancy_as_a_school_spec.rb
@@ -51,10 +51,10 @@ RSpec.describe "Publishers can edit a vacancy" do
     end
 
     describe "#important_dates" do
-      def edit_date(date_type, date)
-        fill_in "publishers_job_listing_important_dates_form[#{date_type}(3i)]", with: date&.day.presence || ""
-        fill_in "publishers_job_listing_important_dates_form[#{date_type}(2i)]", with: date&.month.presence || ""
-        fill_in "publishers_job_listing_important_dates_form[#{date_type}(1i)]", with: date&.year.presence || ""
+      def edit_date(form_name, date_type, date)
+        fill_in "publishers_job_listing_#{form_name}_form[#{date_type}(3i)]", with: date&.day.presence || ""
+        fill_in "publishers_job_listing_#{form_name}_form[#{date_type}(2i)]", with: date&.month.presence || ""
+        fill_in "publishers_job_listing_#{form_name}_form[#{date_type}(1i)]", with: date&.year.presence || ""
         click_on I18n.t("buttons.save_and_continue")
       end
 
@@ -66,16 +66,16 @@ RSpec.describe "Publishers can edit a vacancy" do
         scenario "can not be edited when validation fails" do
           expect(publisher_important_dates_page).to be_displayed
 
-          edit_date("expires_at", nil)
+          edit_date("expiry_date_time", "expires_at", nil)
 
-          expect(publisher_important_dates_page.errors.map(&:text)).to eq([I18n.t("important_dates_errors.expires_at.blank")])
+          expect(publisher_important_dates_page.errors.map(&:text)).to eq([I18n.t("expiry_date_time_errors.expires_at.blank")])
         end
 
         scenario "can be successfully edited" do
           expect(publisher_important_dates_page).to be_displayed
 
           expiry_date = Date.current + 1.week
-          edit_date("expires_at", expiry_date)
+          edit_date("expiry_date_time", "expires_at", expiry_date)
 
           expect(publisher_vacancy_page).to be_displayed
           expect(vacancy.reload.expires_at.to_date).to eq(expiry_date)
@@ -109,7 +109,7 @@ RSpec.describe "Publishers can edit a vacancy" do
             expect(publisher_important_dates_page).to be_displayed
             expect(publisher_important_dates_page).to have_change_publish_day_field
 
-            edit_date("publish_on", publish_on)
+            edit_date("important_dates", "publish_on", publish_on)
 
             expect(publisher_vacancy_page).to be_displayed
             expect(vacancy.reload.publish_on).to eq(publish_on)

--- a/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_school_spec.rb
@@ -125,11 +125,11 @@ RSpec.describe "Creating a vacancy" do
         expect(publisher_important_dates_page).to be_displayed
         expect(publisher_important_dates_page.errors.map(&:text)).to contain_exactly(
           I18n.t("important_dates_errors.publish_on_day.inclusion"),
-          I18n.t("important_dates_errors.expires_at.blank"),
-          I18n.t("important_dates_errors.expiry_time.inclusion"),
+          I18n.t("expiry_date_time_errors.expires_at.blank"),
+          I18n.t("expiry_date_time_errors.expiry_time.inclusion"),
         )
         publisher_important_dates_page.fill_in_and_submit_form(publish_on: vacancy.publish_on, expires_at: Time.zone.yesterday)
-        expect(publisher_important_dates_page.errors.map(&:text)).to contain_exactly(I18n.t("important_dates_errors.expires_at.after"))
+        expect(publisher_important_dates_page.errors.map(&:text)).to contain_exactly(I18n.t("expiry_date_time_errors.expires_at.after"))
         publisher_important_dates_page.fill_in_and_submit_form(publish_on: vacancy.publish_on, expires_at: vacancy.expires_at)
 
         expect(publisher_applying_for_the_job_page).to be_displayed

--- a/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_trust_spec.rb
+++ b/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_trust_spec.rb
@@ -107,8 +107,8 @@ RSpec.describe "Creating a vacancy" do
     expect(publisher_important_dates_page).to be_displayed
     expect(publisher_important_dates_page.errors.map(&:text)).to contain_exactly(
       I18n.t("important_dates_errors.publish_on_day.inclusion"),
-      I18n.t("important_dates_errors.expires_at.blank"),
-      I18n.t("important_dates_errors.expiry_time.inclusion"),
+      I18n.t("expiry_date_time_errors.expires_at.blank"),
+      I18n.t("expiry_date_time_errors.expiry_time.inclusion"),
     )
     publisher_important_dates_page.fill_in_and_submit_form(publish_on: vacancy.publish_on, expires_at: vacancy.expires_at)
 


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/5YLpAiOU/3017-could-the-stepprocess-decide-to-load-different-forms-on-published-vacancy

## Changes in this PR:

Load a different date-time form when vacancy is published to remove complexity around publish_at . Had to keep the step the same, as the steps are persisted on the model

