### PR TITLE
Reference email validation

### DIFF
--- a/config/locales/publishers/vacancies/job_applications/referee_form.en.yml
+++ b/config/locales/publishers/vacancies/job_applications/referee_form.en.yml
@@ -10,7 +10,7 @@ en:
               blank: Referee job title can't be blank
             email:
               blank: Referee email can't be blank
-              email: Referee email must be of the form example@example.com
+              invalid: Enter a valid email address in the correct format, like name@example.com
             organisation:
               blank: Referee organisation can't be blank
             relationship:

--- a/spec/form_models/publishers/vacancies/job_applications/referee_form_spec.rb
+++ b/spec/form_models/publishers/vacancies/job_applications/referee_form_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Publishers
+  module Vacancies
+    module JobApplications
+      RSpec.describe RefereeForm do
+        context "with invalid email" do
+          let(:form) { described_class.new(email: "invalid") }
+
+          it "has correct error message" do
+            expect(form).not_to be_valid
+            expect(form.errors[:email]).to include("Enter a valid email address in the correct format, like name@example.com")
+          end
+        end
+
+        context "with valid email" do
+          let(:form) do
+            described_class.new(
+              name: "Jane Smith",
+              uploaded_details: false,
+              job_title: "Head of Year",
+              organisation: "Test School",
+              relationship: "Manager",
+              email: Faker::Internet.email(domain: TEST_EMAIL_DOMAIN),
+            )
+          end
+
+          it "is valid" do
+            expect(form).to be_valid
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Trello card URL

## Changes in this PR:

Prior to this change the email validation on the referee form was not working properly because ValidEmail2::EmailValidator adds errors with :invalid (instead of :email) so the custom message was ignored and Rails fell back to the default "is invalid".

## Screenshots of UI changes:

### Before
<img width="849" height="827" alt="Screenshot 2026-04-13 at 10 34 33" src="https://github.com/user-attachments/assets/8fcced78-0ad0-4ea6-bc27-234d1fa21615" />

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
