### PR TITLE
Use full ARN with account id for AWS Deployment role

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -17,6 +17,9 @@ inputs:
   aws-secret-access-key:
     description: AWS-KEY
     required: true
+  aws-account-id:
+    description: AWS Account ID for role assumption
+    required: true
   azure-client-id:
     description: Azure service principal or managed identity client ID when using OIDC
     required: true
@@ -36,12 +39,12 @@ runs:
       name: Checkout Code
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
         aws-region: eu-west-2
-        role-to-assume: Deployments
+        role-to-assume: arn:aws:iam::${{ inputs.AWS_ACCOUNT_ID }}:role/Deployments
         role-duration-seconds: 3600
         role-skip-session-tagging: true
 

--- a/.github/workflows/accessibility_tests.yml
+++ b/.github/workflows/accessibility_tests.yml
@@ -47,7 +47,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
-          role-to-assume: Deployments
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/Deployments
           role-duration-seconds: 3600
           role-skip-session-tagging: true
 
@@ -98,7 +98,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
-          role-to-assume: Deployments
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/Deployments
           role-duration-seconds: 3600
           role-skip-session-tagging: true
 

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -97,7 +97,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
-          role-to-assume: Deployments
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/Deployments
           role-duration-seconds: 3600
           role-skip-session-tagging: true
 
@@ -256,7 +256,7 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: eu-west-2
-        role-to-assume: Deployments
+        role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/Deployments
         role-duration-seconds: 3600
         role-skip-session-tagging: true
 
@@ -292,6 +292,7 @@ jobs:
         pr_id: ${{ github.event.number }}
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
         azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
         azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -364,7 +365,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
-          role-to-assume: Deployments
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/Deployments
           role-duration-seconds: 3600
           role-skip-session-tagging: true
 

--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -61,7 +61,7 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: eu-west-2
-        role-to-assume: Deployments
+        role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/Deployments
         role-duration-seconds: 3600
         role-skip-session-tagging: true
 

--- a/.github/workflows/deploy_app_via_workflow_dispatch.yml
+++ b/.github/workflows/deploy_app_via_workflow_dispatch.yml
@@ -37,6 +37,7 @@ jobs:
         pr_id: ${{ inputs.pr_id }}
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
         azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
         azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/rebuild_docker_cache.yml
+++ b/.github/workflows/rebuild_docker_cache.yml
@@ -27,7 +27,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
-          role-to-assume: Deployments
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/Deployments
           role-duration-seconds: 3600
           role-skip-session-tagging: true
 

--- a/.github/workflows/recreate-qa-database.yml
+++ b/.github/workflows/recreate-qa-database.yml
@@ -29,7 +29,7 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: eu-west-2
-        role-to-assume: Deployments
+        role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/Deployments
         role-duration-seconds: 3600
         role-skip-session-tagging: true
 

--- a/documentation/operations/deployment/github-actions.md
+++ b/documentation/operations/deployment/github-actions.md
@@ -8,7 +8,7 @@
 
 ### Secret lifecycle
 
-All scerets are stored on AWS parameterstore, with the exception of `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, which are needed to bootstrap Github Action's workflow. With sufficient privileges, these are available under [Settings/Secrets](https://github.com/DFE-Digital/teaching-vacancies/settings/secrets)
+All scerets are stored on AWS parameterstore, with the exception of `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_ACCOUNT_ID`, which are needed to bootstrap Github Action's workflow. With sufficient privileges, these are available under [Settings/Secrets](https://github.com/DFE-Digital/teaching-vacancies/settings/secrets)
 
 Secrets may be:
 - Added


### PR DESCRIPTION
## Changes in this PR:

Resolves [recent deploy workflow errors](https://github.com/DFE-Digital/teaching-vacancies/actions/runs/24334843648/job/71056556135?pr=8712) by using a full ARN with the account ID for the AWS Deployment role.

The action requires this since v6.1
Added the secret on GitHub.


## Screenshots of UI changes:

### Before
<img width="696" height="262" alt="image" src="https://github.com/user-attachments/assets/a076ee53-f6db-41a6-84ea-07e83699ef03" />

### After
<img width="566" height="316" alt="image" src="https://github.com/user-attachments/assets/23aeb72a-4a63-4008-b6c3-f1e4fa47190b" />


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
