### PR TITLE
Improve publisher ats api expires at documentation test timezones

### DIFF
--- a/spec/services/publishers/ats_api/create_vacancy_service_spec.rb
+++ b/spec/services/publishers/ats_api/create_vacancy_service_spec.rb
@@ -204,6 +204,133 @@ RSpec.describe Publishers::AtsApi::CreateVacancyService do
         end
       end
 
+      describe "'expires_at'" do
+        let(:raw_expires_at_query) { Arel.sql("to_char(expires_at, 'YYYY-MM-DD HH24:MI:SS')") }
+
+        context "when parsing equivalent representations during British Summer Time (BST)" do
+          # All inputs below represent the same instant: 9am UK local time (Thursday, 23 April 2026 during BST).
+          # They differ only in timezone notation; the app must parse each correctly and store the same instant.
+          before { travel_to(Time.zone.parse("2026-04-22T10:00:00")) }
+
+          let(:expected_local_iso8601) { "2026-04-23T09:00:00+01:00" }
+          let(:expected_utc_iso8601) { "2026-04-23T08:00:00Z" }
+          let(:expected_db_timestamp) { "2026-04-23 08:00:00" }
+
+          [
+            { input: "2026-04-23T08:00:00Z", desc: "UTC notation (Z suffix)" },
+            { input: "2026-04-23T08:00:00+00:00", desc: "explicit UTC offset" },
+            { input: "2026-04-23T09:00:00", desc: "naive local time (no timezone)" },
+            { input: "2026-04-23T09:00:00+01:00", desc: "explicit UK BST offset" },
+          ].each_with_index do |spec, index|
+            context "when expires_at is '#{spec[:input]}' (#{spec[:desc]})" do
+              let(:vacancy_params) do
+                params.merge(
+                  expires_at: spec[:input],
+                  external_reference: "new-ref-iso-#{index}",
+                  job_title: "A job title iso #{index}",
+                )
+              end
+
+              it "persists the same instant: 9am UK time (08:00 UTC) regardless of input format" do
+                response = described_class.call(vacancy_params)
+                vacancy = PublishedVacancy.find(response[:json][:id])
+                db_expires_at = Vacancy.where(id: vacancy.id).pick(raw_expires_at_query)
+
+                expect(db_expires_at).to eq(expected_db_timestamp)
+                expect(vacancy.expires_at.iso8601).to eq(expected_local_iso8601)
+                expect(vacancy.expires_at.utc.iso8601).to eq(expected_utc_iso8601)
+              end
+            end
+          end
+        end
+
+        context "when parsing equivalent representations during Greenwich Mean Time (GMT)" do
+          # All inputs below represent the same instant: 9am UK local time (Tuesday, 20 January 2026 during GMT).
+          # During GMT, local UK time is UTC+00:00, so local and UTC clock times match.
+          before { travel_to(Time.zone.parse("2026-01-15T10:00:00")) }
+
+          let(:expected_local_iso8601) { "2026-01-20T09:00:00+00:00" }
+          let(:expected_utc_iso8601) { "2026-01-20T09:00:00Z" }
+          let(:expected_db_timestamp) { "2026-01-20 09:00:00" }
+
+          [
+            { input: "2026-01-20T09:00:00Z", desc: "UTC notation (Z suffix)" },
+            { input: "2026-01-20T09:00:00+00:00", desc: "explicit UTC offset" },
+            { input: "2026-01-20T09:00:00", desc: "naive local time (no timezone)" },
+          ].each_with_index do |spec, index|
+            context "when expires_at is '#{spec[:input]}' (#{spec[:desc]})" do
+              let(:vacancy_params) do
+                params.merge(
+                  expires_at: spec[:input],
+                  external_reference: "new-ref-iso-gmt-#{index}",
+                  job_title: "A job title iso gmt #{index}",
+                )
+              end
+
+              it "persists the same instant: 9am UK time (09:00 UTC) regardless of input format" do
+                response = described_class.call(vacancy_params)
+                vacancy = PublishedVacancy.find(response[:json][:id])
+                db_expires_at = Vacancy.where(id: vacancy.id).pick(raw_expires_at_query)
+
+                expect(db_expires_at).to eq(expected_db_timestamp)
+                expect(vacancy.expires_at.iso8601).to eq(expected_local_iso8601)
+                expect(vacancy.expires_at.utc.iso8601).to eq(expected_utc_iso8601)
+              end
+            end
+          end
+        end
+
+        context "with Daylight Saving Time (DST) transitions" do
+          context "when created before BST with naive datetime expiring after BST starts" do
+            # This verifies cross-boundary parsing from a GMT date into a BST target date.
+            # For April 10, 09:00 local UK time is 08:00 UTC, and Rails stores that instant.
+            before { travel_to(Time.zone.parse("2026-03-15T10:00:00")) }
+
+            let(:vacancy_params) do
+              params.merge(
+                expires_at: "2026-04-10T09:00:00",
+                external_reference: "new-ref-dst-pre",
+                job_title: "A job title dst pre",
+              )
+            end
+
+            it "stores the April BST instant correctly even when submitted before BST begins" do
+              response = described_class.call(vacancy_params)
+              vacancy = PublishedVacancy.find(response[:json][:id])
+              db_expires_at = Vacancy.where(id: vacancy.id).pick(raw_expires_at_query)
+
+              expect(db_expires_at).to eq("2026-04-10 08:00:00")
+              expect(vacancy.expires_at.iso8601).to eq("2026-04-10T09:00:00+01:00")
+              expect(vacancy.expires_at.utc.iso8601).to eq("2026-04-10T08:00:00Z")
+            end
+          end
+
+          context "when created during BST expiring after clocks go back to Greenwich Mean Time (GMT) in autumn" do
+            # This verifies that a BST date expiring after the autumn DST transition is stored correctly.
+            # For November 15, 09:00 local UK time is 09:00 UTC, and Rails stores that instant.
+            before { travel_to(Time.zone.parse("2026-08-01T10:00:00")) }
+
+            let(:vacancy_params) do
+              params.merge(
+                expires_at: "2026-11-15T09:00:00",
+                external_reference: "new-ref-dst-post",
+                job_title: "A job title dst post",
+              )
+            end
+
+            it "stores the November date correctly even when submitted during BST" do
+              response = described_class.call(vacancy_params)
+              vacancy = PublishedVacancy.find(response[:json][:id])
+              db_expires_at = Vacancy.where(id: vacancy.id).pick(raw_expires_at_query)
+
+              expect(db_expires_at).to eq("2026-11-15 09:00:00")
+              expect(vacancy.expires_at.iso8601).to eq("2026-11-15T09:00:00+00:00")
+              expect(vacancy.expires_at.utc.iso8601).to eq("2026-11-15T09:00:00Z")
+            end
+          end
+        end
+      end
+
       context "when the vacancy belongs to a school" do
         it "creates a vacancy with the correct organisation" do
           create_vacancy_service

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -128,8 +128,16 @@ RSpec.configure do |config|
                   expires_at: {
                     type: :string,
                     format: :datetime,
-                    example: "2030-03-13T15:30:00Z",
-                    description: "The end datetime of the vacancy. Must be after the start date.",
+                    example: "2030-03-13T15:30:00",
+                    description: "The end datetime of the vacancy in <a href='https://en.wikipedia.org/wiki/ISO_8601'>ISO 8601</a> format." \
+                                 "<br>Must be after the start date." \
+                                 "<br>Main example without timezone designator (recommended):" \
+                                 "<ul><li>2030-03-13T15:30:00</li>" \
+                                 "<li>When using this format, the datetime is assumed to be in the local timezone for the given date.</li></ul>" \
+                                 "Examples with explicit timezone:" \
+                                 "<ul><li>UTC (Z): 2030-03-13T15:30:00Z</li>" \
+                                 "<li>Offset: 2030-03-13T15:30:00+01:00</li>" \
+                                 "<li>When providing a timezone, ensure your client sends the correct offset for the target UK date (GMT or BST)</li></ul>",
                   },
                   schools: {
                     oneOf: [
@@ -343,8 +351,8 @@ RSpec.configure do |config|
               expires_at: {
                 type: :string,
                 format: :datetime,
-                example: "2025-03-13T15:30:00Z",
-                description: "The end datetime of the vacancy. Must be after the start date.",
+                example: "2025-03-13T15:30:00",
+                description: 'The end datetime of the vacancy in <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO 8601</a> format',
               },
               job_title: {
                 type: :string,

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -128,16 +128,17 @@ RSpec.configure do |config|
                   expires_at: {
                     type: :string,
                     format: :datetime,
-                    example: "2030-03-13T15:30:00",
+                    example: "2026-04-13T15:30:00",
                     description: "The end datetime of the vacancy in <a href='https://en.wikipedia.org/wiki/ISO_8601'>ISO 8601</a> format." \
                                  "<br>Must be after the start date." \
                                  "<br>Main example without timezone designator (recommended):" \
-                                 "<ul><li>2030-03-13T15:30:00</li>" \
-                                 "<li>When using this format, the datetime is assumed to be in the local timezone for the given date.</li></ul>" \
-                                 "Examples with explicit timezone:" \
-                                 "<ul><li>UTC (Z): 2030-03-13T15:30:00Z</li>" \
-                                 "<li>Offset: 2030-03-13T15:30:00+01:00</li>" \
-                                 "<li>When providing a timezone, ensure your client sends the correct offset for the target UK date (GMT or BST)</li></ul>",
+                                 "<ul><li>2026-04-13T15:30:00</li>" \
+                                 "<li>When using this format, the datetime is interpreted in UK time (Europe/London) for the given date, with GMT/BST applied automatically as appropriate.</li></ul>" \
+                                 "Examples with explicit timezone resulting in the same point in time:" \
+                                 "<ul><li>UTC (Z): 2026-04-13T14:30:00Z</li>" \
+                                 "<ul><li>UTC: 2026-04-13T14:30:00+00:00</li>" \
+                                 "<li>Offset: 2026-04-13T15:30:00+01:00</li>" \
+                                 "<li>When providing a timezone, ensure to use the correct offset for the target UK date (GMT or BST)</li></ul>",
                   },
                   schools: {
                     oneOf: [
@@ -242,7 +243,7 @@ RSpec.configure do |config|
                   publish_on: {
                     type: :string,
                     format: :date,
-                    example: "2025-01-01",
+                    example: "2026-04-01",
                     description: "The date on which the vacancy should be published. Defaults to the current date.",
                   },
                   benefits_details: {
@@ -252,7 +253,7 @@ RSpec.configure do |config|
                   },
                   starts_on: {
                     type: :string,
-                    example: "12th May",
+                    example: "12th September",
                     description: "The start date (or approximate start timeframe) of the job.",
                   },
                   visa_sponsorship_available: {
@@ -345,14 +346,14 @@ RSpec.configure do |config|
               publish_on: {
                 type: :string,
                 format: :date,
-                example: "2025-01-01",
+                example: "2026-04-01",
                 description: "The date on which the vacancy should be published. Defaults to the current date.",
               },
               expires_at: {
                 type: :string,
                 format: :datetime,
-                example: "2025-03-13T15:30:00",
-                description: 'The end datetime of the vacancy in <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO 8601</a> format',
+                example: "2026-04-17T09:00:00.000+01:00",
+                description: 'The end datetime of the vacancy in <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO 8601</a> format, including a timezone offset',
               },
               job_title: {
                 type: :string,


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/aKuk0hEW

## Changes in this PR:

- Improve "expires_at" testing on API creation request
  I used these tests to understand and clarify what happens when the expires_at datetime is provided with different/no UTC offset specifications and the timezone changes between GMT and BST.

- Improve the API docs on the `expires_at` field 
  So the clients know what the specification for the input is, and what to expect when providing no time zone, or a specific timezone/offset in the input.

## Screenshots of UI changes:

### Before

#### Request
<img width="562" height="327" alt="image" src="https://github.com/user-attachments/assets/cae556d3-05da-40b2-a7ce-c5418e47b2e7" />
<img width="792" height="238" alt="image" src="https://github.com/user-attachments/assets/4ada0e95-fe0d-44a1-afee-d79b077ac0fa" />

#### Response
<img width="692" height="181" alt="image" src="https://github.com/user-attachments/assets/72cc3e26-6de9-4b38-b5ee-1b34b0a8dc25" />

### After

#### Request
<img width="611" height="409" alt="image" src="https://github.com/user-attachments/assets/20d15ef7-1885-4af2-bf5a-076c0af27ea6" />
<img width="1129" height="270" alt="image" src="https://github.com/user-attachments/assets/0bd6235a-a2ec-4d74-bfe4-bff193e07bd9" />

#### Response
<img width="814" height="187" alt="image" src="https://github.com/user-attachments/assets/d72eaa17-0993-4dbb-8c7b-f9cb0ec70b22" />


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
