### PR TITLE
reset_application_link for vacancy templates

### DIFF
--- a/app/models/vacancy_template.rb
+++ b/app/models/vacancy_template.rb
@@ -84,6 +84,7 @@ class VacancyTemplate < ApplicationRecord
   def reset_documents; end
   def reset_contact_number; end
   def reset_application_email; end
+  def reset_application_link; end
 
   def vacancy_attributes
     attributes.symbolize_keys.except(:id, :name, :job_roles, :organisation_id,

--- a/spec/models/vacancy_template_spec.rb
+++ b/spec/models/vacancy_template_spec.rb
@@ -47,4 +47,14 @@ RSpec.describe VacancyTemplate do
                            other_extension_reason_details])
     end
   end
+
+  describe "resetting before save" do
+    let(:template) { build(:vacancy_template, organisation: build(:school), enable_job_applications: false, receive_applications: "uploaded_form") }
+
+    it "can be saved" do
+      expect(template).to be_valid
+      expect(template.errors.messages).to be_empty
+      expect(template.save).to be(true)
+    end
+  end
 end

--- a/spec/models/vacancy_template_spec.rb
+++ b/spec/models/vacancy_template_spec.rb
@@ -48,7 +48,8 @@ RSpec.describe VacancyTemplate do
     end
   end
 
-  describe "resetting before save" do
+  # This test fails unless vacancy_template overrides reset_application_link to be an empty method
+  describe "check that uploaded_form template types can be saved" do
     let(:template) { build(:vacancy_template, organisation: build(:school), enable_job_applications: false, receive_applications: "uploaded_form") }
 
     it "can be saved" do


### PR DESCRIPTION
## Changes in this PR:

Override reset_application_link for templates as they don't have the application_link prperty