### PR TITLE
Avoid Publisher API V1 schema from automatically changing and add a drift guard

### DIFF
--- a/spec/swagger/v1/enum_consistency_spec.rb
+++ b/spec/swagger/v1/enum_consistency_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+require "swagger_helper"
+
+# This spec guards the V1 API contract against silent breakage caused by changes to Vacancy model constants.
+#
+# The ATS API V1 schema defines a fixed set of allowed enum values for fields like phases, key_stages, etc.
+# These are stored as frozen constants (V1_PHASES, V1_KEY_STAGES, ...) in swagger_helper.rb, deliberately
+# decoupled from the Vacancy model constants. This decoupling means a model change does NOT automatically
+# change the API contract — which is correct, because the API is a published, versioned interface.
+#
+# This spec detects when the model drifts from the V1 contract, forcing a conscious decision:
+#
+#   Scenario A — a new value is added to the model (e.g., Vacancy::PHASES gains :alternative_provision):
+#     - This is non-breaking: consumers only get back values they themselves submitted, so a new model
+#       value will never appear in their responses unless they explicitly use it.
+#     - Update the frozen V1 constant (e.g., V1_PHASES) to include the new value and regenerate swagger.yaml.
+#
+#   Scenario B — a value is removed or renamed in the model (e.g., :secondary split into :lower_secondary + :upper_secondary):
+#     - The V1 schema must keep accepting the old value ("secondary") from API consumers.
+#     - Add an inbound mapping in the service layer to translate "secondary" to the appropriate new model value(s).
+#     - Add an outbound mapping to translate new model values back to "secondary" in API responses.
+#
+#   Scenario C — mappings become untenable (too many, or semantics have fundamentally changed):
+#     - Create V2 of the API with a schema that reflects the new model.
+#     - Deprecate V1 with a communicated timeline.
+#     - Do NOT update V1 frozen constants.
+RSpec.describe "V1 API schema enum consistency" do
+  {
+    "job_roles" => { v1: V1_JOB_ROLES, model: -> { Vacancy.job_roles.keys } },
+    "contract_types" => { v1: V1_CONTRACT_TYPES, model: -> { Vacancy.contract_types.keys } },
+    "working_patterns" => { v1: V1_WORKING_PATTERNS, model: -> { Vacancy::WORKING_PATTERNS } },
+    "phases" => { v1: V1_PHASES, model: -> { Vacancy.phases.keys } },
+    "key_stages" => { v1: V1_KEY_STAGES, model: -> { Vacancy.key_stages.keys } },
+    "subjects" => { v1: V1_SUBJECTS, model: -> { SUBJECT_OPTIONS.map(&:first) } },
+  }.each do |field, sources|
+    describe field do
+      let(:v1_values) { sources[:v1].map(&:to_s).sort }
+      let(:model_values) { sources[:model].call.map(&:to_s).sort }
+
+      it "V1 schema matches current model values" do
+        added = model_values - v1_values
+        removed = v1_values - model_values
+
+        divergences = []
+        divergences << "Added in model but missing from V1 schema: #{added}" if added.any?
+        divergences << "Removed from model but still in V1 schema: #{removed}" if removed.any?
+
+        failure_message = "V1 API enum for '#{field}' has diverged from the model. Do NOT just update the frozen V1 constant.\n" \
+                          "Read the comment at the top of this spec file for the correct remediation steps.\n" \
+                          "#{divergences.join("\n")}"
+        expect(divergences).to be_empty, failure_message
+      end
+    end
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,9 +1,10 @@
 require "rails_helper"
 
 # V1 API contract — frozen enum values.
-# These MUST NOT change once V1 is published. If the Vacancy model values change,
-# add a mapping layer in the service rather than updating these constants.
-# When mapping becomes untenable, create V2 of the API.
+# Additive updates are allowed when new Vacancy model values need to be exposed in V1.
+# Existing published V1 values must not be removed, renamed, or repurposed without an
+# explicit compatibility decision: add a mapping layer in the service, or create V2 of
+# the API if mapping becomes untenable.
 V1_JOB_ROLES = %w[
   teacher
   headteacher

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,5 +1,99 @@
 require "rails_helper"
 
+# V1 API contract — frozen enum values.
+# These MUST NOT change once V1 is published. If the Vacancy model values change,
+# add a mapping layer in the service rather than updating these constants.
+# When mapping becomes untenable, create V2 of the API.
+V1_JOB_ROLES = %w[
+  teacher
+  headteacher
+  deputy_headteacher
+  assistant_headteacher
+  head_of_year_or_phase
+  head_of_department_or_curriculum
+  teaching_assistant
+  higher_level_teaching_assistant
+  education_support
+  sendco
+  administration_hr_data_and_finance
+  catering_cleaning_and_site_management
+  it_support
+  pastoral_health_and_welfare
+  other_leadership
+  other_support
+].freeze
+
+V1_CONTRACT_TYPES = %w[
+  permanent
+  fixed_term
+  casual
+].freeze
+
+V1_WORKING_PATTERNS = %w[
+  full_time
+  part_time
+].freeze
+
+V1_PHASES = %w[
+  nursery
+  primary
+  secondary
+  sixth_form_or_college
+  through
+].freeze
+
+V1_KEY_STAGES = %w[
+  early_years
+  ks1
+  ks2
+  ks3
+  ks4
+  ks5
+].freeze
+
+V1_SUBJECTS = [
+  "Accounting",
+  "Art and design",
+  "Biology",
+  "Business studies",
+  "Chemistry",
+  "Citizenship",
+  "Classics",
+  "Computing",
+  "Dance",
+  "Design and technology",
+  "Drama",
+  "Economics",
+  "Engineering",
+  "English",
+  "Food technology",
+  "French",
+  "Geography",
+  "German",
+  "Health and social care",
+  "History",
+  "Humanities",
+  "ICT",
+  "Languages",
+  "Law",
+  "Mandarin",
+  "Mathematics",
+  "Media studies",
+  "Music",
+  "Philosophy",
+  "Physical education",
+  "Physics",
+  "Politics",
+  "PSHE",
+  "Psychology",
+  "Religious education",
+  "Science",
+  "Social sciences",
+  "Sociology",
+  "Spanish",
+  "Statistics",
+].freeze
+
 RSpec.configure do |config|
   # Specify a root folder where Swagger JSON files are generated
   config.openapi_root = Rails.root.join("swagger").to_s
@@ -202,14 +296,14 @@ RSpec.configure do |config|
                     minItems: 1,
                     items: {
                       type: :string,
-                      enum: Vacancy.job_roles.keys,
+                      enum: V1_JOB_ROLES,
                       description: "A job role identifier representing a specific responsibility or position.",
                     },
                     description: "An array of one or more roles that best represent the nature and level of responsibility of the vacancy.",
                   },
                   contract_type: {
                     type: :string,
-                    enum: Vacancy.contract_types.keys,
+                    enum: V1_CONTRACT_TYPES,
                     example: "permanent",
                     description: "Specifies the type of employment contract associated with the vacancy.",
                   },
@@ -218,7 +312,7 @@ RSpec.configure do |config|
                     minItems: 1,
                     items: {
                       type: :string,
-                      enum: Vacancy::WORKING_PATTERNS,
+                      enum: V1_WORKING_PATTERNS,
                       description: "Indicates the expected working hours or schedule for the role.",
                     },
                     example: %w[full_time],
@@ -229,7 +323,7 @@ RSpec.configure do |config|
                     minItems: 1,
                     items: {
                       type: :string,
-                      enum: Vacancy.phases.keys,
+                      enum: V1_PHASES,
                       description: "Indicates the stage of education the vacancy relates to.",
                     },
                     example: %w[secondary],
@@ -276,7 +370,7 @@ RSpec.configure do |config|
                     minItems: 0,
                     items: {
                       type: :string,
-                      enum: Vacancy.key_stages.keys,
+                      enum: V1_KEY_STAGES,
                       description: "Indicates the key stage that the role is relevant to.",
                     },
                     example: %w[ks1 ks2],
@@ -287,7 +381,7 @@ RSpec.configure do |config|
                     minItems: 0,
                     items: {
                       type: :string,
-                      enum: SUBJECT_OPTIONS.map(&:first), # List of available subjects in the service (from subjects.yml)
+                      enum: V1_SUBJECTS,
                       description: "Describes the subject or area of learning the role focuses on.",
                     },
                     example: %w[Mathematics Science],
@@ -423,7 +517,7 @@ RSpec.configure do |config|
                 minItems: 1,
                 items: {
                   type: :string,
-                  enum: Vacancy.job_roles.keys,
+                  enum: V1_JOB_ROLES,
                   description: "A job role identifier representing a specific responsibility or position.",
                 },
                 description: "An array of one or more roles that best represent the nature and level of responsibility of the vacancy.",
@@ -438,7 +532,7 @@ RSpec.configure do |config|
                 minItems: 1,
                 items: {
                   type: :string,
-                  enum: Vacancy::WORKING_PATTERNS,
+                  enum: V1_WORKING_PATTERNS,
                   description: "Indicates the expected working hours or schedule for the role.",
                 },
                 example: %w[full_time],
@@ -446,7 +540,7 @@ RSpec.configure do |config|
               },
               contract_type: {
                 type: :string,
-                enum: Vacancy.contract_types.keys,
+                enum: V1_CONTRACT_TYPES,
                 example: "permanent",
                 description: "Specifies the type of employment contract associated with the vacancy.",
               },
@@ -455,7 +549,7 @@ RSpec.configure do |config|
                 minItems: 1,
                 items: {
                   type: :string,
-                  enum: Vacancy.phases.keys,
+                  enum: V1_PHASES,
                   description: "Indicates the stage of education the vacancy relates to.",
                 },
                 example: %w[secondary],
@@ -466,7 +560,7 @@ RSpec.configure do |config|
                 minItems: 0,
                 items: {
                   type: :string,
-                  enum: Vacancy.key_stages.keys,
+                  enum: V1_KEY_STAGES,
                   description: "Indicates the key stage that the role is relevant to.",
                 },
                 example: %w[ks1 ks2],
@@ -477,7 +571,7 @@ RSpec.configure do |config|
                 minItems: 0,
                 items: {
                   type: :string,
-                  enum: SUBJECT_OPTIONS.map(&:first), # List of available subjects in the service (from subjects.yml)
+                  enum: V1_SUBJECTS,
                   description: "Describes the subject or area of learning the role focuses on.",
                 },
                 description: "An array of one or more subject areas that the vacancy involves.",


### PR DESCRIPTION


## Changes in this PR:
https://trello.com/c/eBZpVot1

### Context
We've raised in meetings that we need to be careful about changing values in the vacancy model enumerables, as that could break our existing Publisher ATS API contract with existing clients.

Upon a closer look into our API schemas/definition, I've noticed that they're dynamically generated from the Vacancy model values, which is convenient for refreshing the docs without needing developer explicit action, but is dangerous and doesn't respect the immutability that a published API versioned schema should adhere to.

EG: if someone changed a Vacancy model constant (e.g. splitting `:secondary` into two phases), the rswag schema would silently regenerate with the new values, breaking existing API consumers who could no longer submit the old value. 

### We want to:
- Do not automatically change the published schema clients are built against when our Vacancy model changes.
- Make the developer aware when changes to the Vacancy model would break our existing API schema.
- Force the developer to resolve this, providing some guidance.

### We achieve it by
- Replacing all dynamic model references in `spec/swagger_helper.rb` (e.g. `Vacancy.phases.keys`) with static frozen `V1_*` constants, decoupling the published V1 API contract from future Vacancy model changes
- Adding `spec/swagger/v1/enum_consistency_spec.rb` — a failing guard spec that detects when model constants diverge from the frozen V1 values, with inline instructions for the three remediation scenarios (add value, remove/rename value, create V2)


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
