### PR TITLE
Change accessibility link

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,7 +30,7 @@ module ApplicationHelper
       { text: "Cookies", href: cookies_preferences_path },
       { text: "Privacy policy", href: "https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/privacy-information-education-providers-workforce-including-teachers", attr: { target: "_blank" } },
       { text: "Terms and conditions", href: page_path("terms-and-conditions") },
-      { text: "Accessibility", href: page_path("accessibility") },
+      { text: "Accessibility", href: "https://accessibility-statements.education.gov.uk/s/75" },
       { text: "Savings methodology", href: page_path("savings-methodology") },
       { text: "Vision statement", href: page_path("vision-statement") },
     ]

--- a/spec/system/other/support_links_spec.rb
+++ b/spec/system/other/support_links_spec.rb
@@ -17,9 +17,7 @@ RSpec.describe "A visitor to the website can access the support links" do
   end
 
   scenario "the accessibility statement" do
-    click_on "Accessibility"
-
-    expect(page).to have_content(/Accessibility statement/i)
+    expect(page).to have_link("Accessibility", href: "https://accessibility-statements.education.gov.uk/s/75")
   end
 
   scenario "the savings methodology" do


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/FMM0WOiI/2750-update-accessibility-statement-url-in-tvs-footer

## Changes in this PR:

This PR changes the accessibility link in the footer to link to https://accessibility-statements.education.gov.uk/s/75

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
