### PR TITLE
Pin action "slack-notify" to floating v2 version

### DIFF
--- a/.github/workflows/accessibility_tests.yml
+++ b/.github/workflows/accessibility_tests.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Notify twd_tv_dev channel on Pa11y test failures
         if: failure()
-        uses: rtCamp/action-slack-notify@v2.3.3
+        uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_CHANNEL: twd_tv_dev
           SLACK_USERNAME: CI Accessiblity Tests
@@ -137,7 +137,7 @@ jobs:
           echo "SCHOOLS_RESULT=$(echo '${{steps.LHCIAction.outputs.links}}' | jq 'nth(2; .[])' | tr -d '"')" >> $GITHUB_ENV
 
       - name: Notify twd_tv_dev channel on Lighthouse results
-        uses: rtCamp/action-slack-notify@v2.3.3
+        uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_CHANNEL: twd_tv_dev
           SLACK_USERNAME: CI Accessiblity Tests

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -224,7 +224,7 @@ jobs:
 
       - name: Notify twd_tv_dev channel on build workflow failure
         if: failure()
-        uses: rtCamp/action-slack-notify@v2.3.3
+        uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_CHANNEL: twd_tv_dev
           SLACK_USERNAME: CI Deployment
@@ -298,7 +298,7 @@ jobs:
 
     - name: Notify twd_tv_dev channel on ${{ env.ENVIRONMENT }} deployment failure
       if: steps.deploy_app_to_env.conclusion != 'success'
-      uses: rtCamp/action-slack-notify@v2.3.3
+      uses: rtCamp/action-slack-notify@v2
       env:
         SLACK_CHANNEL: twd_tv_dev
         SLACK_USERNAME: CI Deployment
@@ -332,7 +332,7 @@ jobs:
 
     - name: Send job status message to twd_tv_dev channel
       if: failure()
-      uses: rtCamp/action-slack-notify@v2.3.3
+      uses: rtCamp/action-slack-notify@v2
       env:
         SLACK_CHANNEL: twd_tv_dev
         SLACK_USERNAME: CI Deployment
@@ -381,7 +381,7 @@ jobs:
 
       - name: Send job status message to twd_tv_dev channel
         if: always()
-        uses: rtCamp/action-slack-notify@v2.3.3
+        uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_CHANNEL: twd_tv_dev
           SLACK_USERNAME: CI Deployment

--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -122,7 +122,7 @@ jobs:
 
     - name: Send failure message to twd_tv_dev channel
       if: failure()
-      uses: rtCamp/action-slack-notify@v2.3.3
+      uses: rtCamp/action-slack-notify@v2
       env:
         SLACK_CHANNEL: twd_tv_dev
         SLACK_USERNAME: CI Deployment

--- a/.github/workflows/rebuild_docker_cache.yml
+++ b/.github/workflows/rebuild_docker_cache.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Notify twd_tv_dev channel on build workflow failure
         if: failure()
-        uses: rtCamp/action-slack-notify@v2.3.3
+        uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_CHANNEL: twd_tv_dev
           SLACK_USERNAME: CI Deployment

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Slack notification
         if: steps.smoke-test.conclusion != 'success'
-        uses: rtCamp/action-slack-notify@v2.3.3
+        uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_CHANNEL: twd_tv_dev
           SLACK_COLOR: 'red'


### PR DESCRIPTION
## Changes in this PR:
The latest exact v2.3.3 version is failing to download on the workflows and [blocking deployments.](https://github.com/DFE-Digital/teaching-vacancies/actions/runs/24675065914/job/72159684376)

## Screenshots of UI changes:

### Before
<img width="1819" height="403" alt="image" src="https://github.com/user-attachments/assets/22a2b130-9b25-42cb-b1d4-6e4b059d65ea" />

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
