### PR TITLE
Fix MyNewTerm vacancies expires_at off by an hour due to BST

### DIFF
--- a/app/services/fix_my_new_term_expires_at.rb
+++ b/app/services/fix_my_new_term_expires_at.rb
@@ -1,10 +1,10 @@
 class FixMyNewTermExpiresAt
   # BST 2026: starts 2026-03-29 01:00 UTC, ends 2026-10-25 01:00 UTC
   # MyNewTerm sent expires_at as "local BST time stored as if it were UTC".
-  # The bug was fixed at 10:50 BST on 21 April 2026 (= 09:50 UTC).
+  # The bug was fixed at 10:56 BST on 21 April 2026 (= 09:56 UTC).
   # Vacancies created before that cutoff (regardless of when they were created)
   # may have a BST expiry that needs correcting.
-  VACANCY_CREATED_UNTIL = Time.utc(2026, 4, 21, 9, 50, 0).freeze
+  VACANCY_CREATED_UNTIL = Time.utc(2026, 4, 21, 9, 56, 0).freeze
 
   # Only fix vacancies whose expires_at falls inside the BST window.
   # Vacancies expiring after BST ends would be in GMT, where no offset error applies.

--- a/app/services/fix_my_new_term_expires_at.rb
+++ b/app/services/fix_my_new_term_expires_at.rb
@@ -13,10 +13,6 @@ class FixMyNewTermExpiresAt
   ATS_CLIENT_NAME = "MyNewTerm".freeze
 
   def self.call
-    new.call
-  end
-
-  def call
     client = PublisherAtsApiClient.find_by!(name: ATS_CLIENT_NAME)
 
     vacancies = client.vacancies

--- a/app/services/fix_my_new_term_expires_at.rb
+++ b/app/services/fix_my_new_term_expires_at.rb
@@ -1,0 +1,35 @@
+class FixMyNewTermExpiresAt
+  # BST 2026: starts 2026-03-29 01:00 UTC, ends 2026-10-25 01:00 UTC
+  # MyNewTerm sent expires_at as "local BST time stored as if it were UTC".
+  # The bug was fixed at 10:50 BST on 21 April 2026 (= 09:50 UTC).
+  # Vacancies created before that cutoff (regardless of when they were created)
+  # may have a BST expiry that needs correcting.
+  VACANCY_CREATED_UNTIL = Time.utc(2026, 4, 21, 9, 50, 0).freeze
+
+  # Only fix vacancies whose expires_at falls inside the BST window.
+  # Vacancies expiring after BST ends would be in GMT, where no offset error applies.
+  EXPIRES_AT_UNTIL = Time.utc(2026, 10, 25, 1, 0, 0).freeze
+
+  ATS_CLIENT_NAME = "MyNewTerm".freeze
+
+  def self.call
+    new.call
+  end
+
+  def call
+    client = PublisherAtsApiClient.find_by!(name: ATS_CLIENT_NAME)
+
+    vacancies = client.vacancies
+      .where(created_at: ...VACANCY_CREATED_UNTIL)
+      .where(expires_at: Time.current..EXPIRES_AT_UNTIL)
+
+    count = 0
+    vacancies.find_each do |vacancy|
+      vacancy.update_columns(expires_at: vacancy.expires_at - 1.hour)
+      count += 1
+    end
+
+    Rails.logger.info("FixMyNewTermExpiresAt: fixed #{count} vacancies")
+    count
+  end
+end

--- a/lib/tasks/fix_my_new_term_expires_at.rake
+++ b/lib/tasks/fix_my_new_term_expires_at.rake
@@ -1,0 +1,7 @@
+namespace :vacancies do
+  desc "Fix MyNewTerm ATS vacancies where expires_at was submitted as local BST time but stored as UTC (2026 BST period)"
+  task fix_my_new_term_expires_at: :environment do
+    count = FixMyNewTermExpiresAt.call
+    puts "Done. Fixed #{count} vacancies."
+  end
+end

--- a/spec/lib/tasks/fix_my_new_term_expires_at_task_spec.rb
+++ b/spec/lib/tasks/fix_my_new_term_expires_at_task_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe "vacancies:fix_my_new_term_expires_at" do
+  include_context "rake"
+
+  let(:task_path) { "lib/tasks/fix_my_new_term_expires_at" }
+
+  # rubocop:disable RSpec/NamedSubject
+  it "calls the service" do
+    allow(FixMyNewTermExpiresAt).to receive(:call).and_return(1)
+
+    subject.execute
+
+    expect(FixMyNewTermExpiresAt).to have_received(:call)
+  end
+
+  it "prints the number of fixed vacancies" do
+    allow(FixMyNewTermExpiresAt).to receive(:call).and_return(2)
+
+    expect { subject.execute }.to output("Done. Fixed 2 vacancies.\n").to_stdout
+  end
+  # rubocop:enable RSpec/NamedSubject
+end

--- a/spec/services/fix_my_new_term_expires_at_spec.rb
+++ b/spec/services/fix_my_new_term_expires_at_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+
+RSpec.describe FixMyNewTermExpiresAt do
+  subject(:service) { described_class.call }
+
+  let!(:ats_client) { create(:publisher_ats_api_client, name: "MyNewTerm") }
+  let!(:other_client) { create(:publisher_ats_api_client, name: "OtherClient") }
+
+  # Convenience helpers
+  let(:bst_start_utc) { Time.utc(2026, 3, 29, 1, 0, 0) }
+  let(:cutoff_utc) { Time.utc(2026, 4, 21, 9, 50, 0) }
+  let(:bst_end_utc) { Time.utc(2026, 10, 25, 1, 0, 0) }
+
+  # Within the created_at window
+  let(:created_in_window) { bst_start_utc + 1.day }
+  # Expires within BST window
+  let(:expires_in_bst) { Time.utc(2026, 6, 1, 9, 0, 0) }
+
+  def vacancy_for(client, created_at:, expires_at:)
+    create(
+      :vacancy,
+      :external,
+      publisher_ats_api_client: client,
+      created_at: created_at,
+      expires_at: expires_at,
+    )
+  end
+
+  describe "#call" do
+    context "with a vacancy in the full window with expires_at inside BST" do
+      it "reduces expires_at by 1 hour" do
+        vacancy = vacancy_for(ats_client, created_at: created_in_window, expires_at: expires_in_bst)
+        expect { service }.to change { vacancy.reload.expires_at }.by(-1.hour)
+      end
+
+      it "returns the count of fixed vacancies" do
+        vacancy_for(ats_client, created_at: created_in_window, expires_at: expires_in_bst)
+        vacancy_for(ats_client, created_at: created_in_window, expires_at: expires_in_bst + 1.day)
+        expect(service).to eq(2)
+      end
+    end
+
+    context "with a vacancy created before BST started but expiring within BST" do
+      it "reduces expires_at by 1 hour" do
+        vacancy = vacancy_for(ats_client, created_at: bst_start_utc - 1.day, expires_at: expires_in_bst)
+        expect { service }.to change { vacancy.reload.expires_at }.by(-1.hour)
+      end
+    end
+
+    context "with a vacancy that is already expired" do
+      it "does not change expires_at" do
+        vacancy = create(:vacancy, :external, :expired, publisher_ats_api_client: ats_client)
+        # Force expires_at into the BST window (past) to confirm the filter excludes it
+        past_bst_expiry = Time.utc(2026, 4, 10, 9, 0, 0)
+        vacancy.update_columns(created_at: created_in_window, expires_at: past_bst_expiry)
+        expect { service }.not_to(change { vacancy.reload.expires_at })
+      end
+    end
+
+    context "with a vacancy created at or after the cutoff (10:50 BST / 09:50 UTC on 21 Apr)" do
+      it "does not change expires_at when created exactly at cutoff" do
+        # The cutoff_utc is the exclusive upper bound, so vacancies created at that exact second are excluded
+        vacancy = vacancy_for(ats_client, created_at: cutoff_utc, expires_at: expires_in_bst)
+        expect { service }.not_to(change { vacancy.reload.expires_at })
+      end
+
+      it "does not change expires_at when created after cutoff" do
+        vacancy = vacancy_for(ats_client, created_at: cutoff_utc + 1.hour, expires_at: expires_in_bst)
+        expect { service }.not_to(change { vacancy.reload.expires_at })
+      end
+    end
+
+    context "with a vacancy whose expires_at is outside the BST window" do
+      it "does not change expires_at when expiry is after BST ends (winter/GMT)" do
+        vacancy = vacancy_for(ats_client, created_at: created_in_window, expires_at: bst_end_utc + 1.day)
+        expect { service }.not_to(change { vacancy.reload.expires_at })
+      end
+    end
+
+    context "with a vacancy belonging to a different ATS client" do
+      it "does not change expires_at" do
+        vacancy = vacancy_for(other_client, created_at: created_in_window, expires_at: expires_in_bst)
+        expect { service }.not_to(change { vacancy.reload.expires_at })
+      end
+    end
+
+    context "when the MyNewTerm client does not exist" do
+      before { ats_client.destroy }
+
+      it "raises ActiveRecord::RecordNotFound" do
+        expect { service }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/spec/services/fix_my_new_term_expires_at_spec.rb
+++ b/spec/services/fix_my_new_term_expires_at_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe FixMyNewTermExpiresAt do
 
   # Convenience helpers
   let(:bst_start_utc) { Time.utc(2026, 3, 29, 1, 0, 0) }
-  let(:cutoff_utc) { Time.utc(2026, 4, 21, 9, 50, 0) }
+  let(:cutoff_utc) { Time.utc(2026, 4, 21, 9, 56, 0) }
   let(:bst_end_utc) { Time.utc(2026, 10, 25, 1, 0, 0) }
 
   # Within the created_at window

--- a/spec/services/fix_my_new_term_expires_at_spec.rb
+++ b/spec/services/fix_my_new_term_expires_at_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe FixMyNewTermExpiresAt do
       end
     end
 
-    context "with a vacancy created at or after the cutoff (10:50 BST / 09:50 UTC on 21 Apr)" do
+    context "with a vacancy created at or after the cutoff (10:56 BST / 09:56 UTC on 21 Apr)" do
       it "does not change expires_at when created exactly at cutoff" do
         # The cutoff_utc is the exclusive upper bound, so vacancies created at that exact second are excluded
         vacancy = vacancy_for(ats_client, created_at: cutoff_utc, expires_at: expires_in_bst)

--- a/spec/services/fix_my_new_term_expires_at_spec.rb
+++ b/spec/services/fix_my_new_term_expires_at_spec.rb
@@ -27,9 +27,7 @@ RSpec.describe FixMyNewTermExpiresAt do
   end
 
   describe "#call" do
-    around do |example|
-      travel_to(Time.utc(2026, 4, 22, 9, 0, 0)) { example.run }
-    end
+    before { travel_to(Time.utc(2026, 4, 22, 9, 0, 0)) }
 
     context "with a vacancy in the full window with expires_at inside BST" do
       it "reduces expires_at by 1 hour" do

--- a/spec/services/fix_my_new_term_expires_at_spec.rb
+++ b/spec/services/fix_my_new_term_expires_at_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe FixMyNewTermExpiresAt do
   end
 
   describe "#call" do
+    around do |example|
+      travel_to(Time.utc(2026, 4, 22, 9, 0, 0)) { example.run }
+    end
+
     context "with a vacancy in the full window with expires_at inside BST" do
       it "reduces expires_at by 1 hour" do
         vacancy = vacancy_for(ats_client, created_at: created_in_window, expires_at: expires_in_bst)


### PR DESCRIPTION


## Trello card URL
- Related to https://trello.com/c/aKuk0hEW

## Changes in this PR:

MyNewTerm were submitting expires_at values as if local BST time were UTC, meaning every vacancy created during the affected window has an expiry stored one hour too late.

This adds a one-off rake task (vacancies:fix_my_new_term_expires_at) that finds all their not-yet-expired vacancies with an expiry inside the 2026 BST window and subtracts one hour.

They have confirmed the date & time where they fixed the datetime format on their incoming vacancies. So used that as a limiter on which vacancies to fix.

It is a one-off task. So I will remove this once it's run.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
