### PR TITLE
import religious character from GIAS and correct mapping 

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -9,7 +9,7 @@ class Organisation < ApplicationRecord
   has_rich_text :description
 
   SPECIAL_SCHOOL_TYPES = ["Community special school", "Foundation special school", "Non-maintained special school", "Academy special converter", "Academy special sponsor led", "Free schools special"].freeze
-  NON_FAITH_RELIGIOUS_CHARACTER_TYPES = ["", "None", "Does not apply", "null"].freeze
+  NON_FAITH_RELIGIOUS_CHARACTER_TYPES = ["None", "Does not apply"].freeze
   OUT_OF_SCOPE_DETAILED_SCHOOL_TYPES = ["Further education", "Other independent school", "Miscellaneous", "Special post 16 institution", "Other independent special school", "Higher education institutions", "Welsh establishment"].freeze
 
   friendly_id :slug_candidates, use: %i[slugged history]
@@ -53,7 +53,7 @@ class Organisation < ApplicationRecord
 
   scope :visible_to_jobseekers, -> { schools.not_closed.not_out_of_scope.or(Organisation.trusts).registered_for_service }
 
-  scope :only_faith_schools, -> { where.not("gias_data ->> 'ReligiousCharacter (name)' IN (?)", NON_FAITH_RELIGIOUS_CHARACTER_TYPES) }
+  scope :only_faith_schools, -> { where.not(religious_character: NON_FAITH_RELIGIOUS_CHARACTER_TYPES) }
 
   # This can safely ignore the 'extra' LA mappings as it is always called with a scope which excludes LAs in the first place
   scope :with_live_vacancies, lambda {

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -12,8 +12,63 @@ class School < Organisation
   INDEPENDENT_SCHOOL_TYPE = "Independent schools".freeze
   VALID_SCHOOL_TYPES = [LA_SCHOOL_TYPE, INDEPENDENT_SCHOOL_TYPE, "Special schools", "Universities", ACADEMY_TYPE, FREE_SCHOOL_TYPE, "Welsh schools", "Other types", "Colleges", "Online provider"].freeze
 
-  # This is direct from GIAS (with plurals removed via singularize)
+  # This is direct from GIAS
   validates :school_type, inclusion: { in: VALID_SCHOOL_TYPES }
+
+  CHRISTIAN_RELIGIOUS_TYPES = ["Anglican",
+                               "United Reformed Church",
+                               "Christian",
+                               "Greek Orthodox",
+                               "Anglican/Evangelical",
+                               "Anglican/Church of England",
+                               "Christian/Evangelical",
+                               "Christian/Methodist",
+                               "Christian/non-denominational",
+                               "Protestant/Evangelical",
+                               "Methodist/Church of England",
+                               "Protestant",
+                               "Reformed Baptist",
+                               "Christian Science",
+                               "Church of England",
+                               "Plymouth Brethren Christian Church",
+                               "Church of England/Methodist/United Reform Church/Baptist",
+                               "Moravian", # Protestant Christian church movement
+                               "Quaker",
+                               "Methodist",
+                               "Free Church",
+                               "Church of England/Free Church",
+                               "Church of England/Evangelical",
+                               "Church of England/United Reformed Church",
+                               "Anglican/Christian",
+                               "Inter- / non- denominational",
+                               "Seventh Day Adventist",
+                               "Church of England/Christian",
+                               "Church of England/Methodist",
+                               "Congregational Church"].freeze
+
+  CATHOLIC_RELIGIOUS_TYPES = ["Roman Catholic",
+                              "Catholic",
+                              "Roman Catholic/Anglican",
+                              "Roman Catholic/Church of England",
+                              "Church of England/Roman Catholic"].freeze
+
+  OTHER_RELIGIOUS_TYPES = [
+    "Jewish",
+    "Orthodox Jewish",
+    "Charadi Jewish",
+    "Islam",
+    "Muslim",
+    "Sunni Deobandi",
+    "Buddhist",
+    "Sikh",
+    "Hindu",
+    "Multi-faith",
+  ].freeze
+
+  validates :religious_character, inclusion: {
+    in: NON_FAITH_RELIGIOUS_CHARACTER_TYPES + CHRISTIAN_RELIGIOUS_TYPES + CATHOLIC_RELIGIOUS_TYPES + OTHER_RELIGIOUS_TYPES,
+    allow_nil: false,
+  }
 
   EXCLUDED_DETAILED_SCHOOL_TYPES = [
     "Further education",
@@ -51,13 +106,6 @@ class School < Organisation
     through: %i[early_years ks1 ks2 ks3 ks4 ks5],
   }.freeze
 
-  def religious_character
-    return if !respond_to?(:gias_data) || gias_data.nil?
-    return if ["None", "Does not apply"].include?(gias_data["ReligiousCharacter (name)"])
-
-    gias_data["ReligiousCharacter (name)"]
-  end
-
   def live_group_vacancies
     if part_of_a_trust?
       org_ids = [trust.id] + trust.schools.pluck(:id)
@@ -71,11 +119,11 @@ class School < Organisation
   end
 
   def faith_school?
-    religious_character.present?
+    NON_FAITH_RELIGIOUS_CHARACTER_TYPES.exclude? religious_character
   end
 
   def catholic_school?
-    religious_character&.include?("Catholic") || false
+    religious_character.in? CATHOLIC_RELIGIOUS_TYPES
   end
 
   def key_stages

--- a/app/services/search/school_search.rb
+++ b/app/services/search/school_search.rb
@@ -108,12 +108,12 @@ class Search::SchoolSearch
     return scope unless school_types.present?
 
     if school_types.include?("special_school") && school_types.include?("faith_school")
-      scope.where.not("gias_data ->> 'ReligiousCharacter (name)' IN (?)", Organisation::NON_FAITH_RELIGIOUS_CHARACTER_TYPES)
+      scope.where.not(religious_character: Organisation::NON_FAITH_RELIGIOUS_CHARACTER_TYPES)
            .or(scope.where(detailed_school_type: Organisation::SPECIAL_SCHOOL_TYPES))
     elsif school_types.include?("special_school")
       scope.where(detailed_school_type: Organisation::SPECIAL_SCHOOL_TYPES)
     elsif school_types.include?("faith_school")
-      scope.where.not("gias_data ->> 'ReligiousCharacter (name)' IN (?)", Organisation::NON_FAITH_RELIGIOUS_CHARACTER_TYPES)
+      scope.where.not(religious_character: Organisation::NON_FAITH_RELIGIOUS_CHARACTER_TYPES)
     else
       scope
     end

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -26,6 +26,7 @@ FactoryBot.define do
         "TypeOfEstablishment (code)": "02",
       }
     end
+    religious_character { "None" }
     detailed_school_type { "Voluntary aided school" }
     minimum_age { 11 }
     maximum_age { 18 }
@@ -74,22 +75,7 @@ FactoryBot.define do
     end
 
     trait :catholic do
-      gias_data do
-        {
-          CloseDate: nil,
-          HeadFirstName: Faker::Name.first_name,
-          HeadLastName: Faker::Name.last_name.delete("'"),
-          HeadPreferredJobTitle: Faker::Name.prefix.delete("."),
-          DateOfLastInspectionVisit: Faker::Date.between(from: 999.days.ago, to: 5.days.ago),
-          NumberOfPupils: Faker::Number.number(digits: 3),
-          "OfstedRating (name)": factory_sample(ofsted_ratings),
-          OpenDate: Faker::Date.between(from: 10_000.days.ago, to: 1000.days.ago),
-          "ReligiousCharacter (name)": "Roman Catholic",
-          SchoolCapacity: Faker::Number.number(digits: 4),
-          TelephoneNum: Faker::Number.number(digits: 11).to_s,
-          "Trusts (name)": "#{Faker::Company.name.delete("'")} Trust",
-        }
-      end
+      religious_character { "Roman Catholic" }
     end
 
     trait :no_geolocation do

--- a/spec/fixtures/basildon_schools.yml
+++ b/spec/fixtures/basildon_schools.yml
@@ -46,48 +46,8 @@
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: address3
   - !ruby/object:ActiveModel::Attribute::FromDatabase
-    name: gias_data
-    value_before_type_cast: '{"URN":"139917","LA (code)":"881","LA (name)":"Essex","EstablishmentNumber":"2091","EstablishmentName":"St
-      Teresa''s Catholic Primary School, Basildon","TypeOfEstablishment (code)":"28","TypeOfEstablishment
-      (name)":"Academy sponsor led","EstablishmentTypeGroup (code)":"10","EstablishmentTypeGroup
-      (name)":"Academies","EstablishmentStatus (code)":"1","EstablishmentStatus (name)":"Open","ReasonEstablishmentOpened
-      (code)":"06","ReasonEstablishmentOpened (name)":"New Provision","OpenDate":"01-12-2013","ReasonEstablishmentClosed
-      (code)":"99","ReasonEstablishmentClosed (name)":"","CloseDate":"","PhaseOfEducation
-      (code)":"2","PhaseOfEducation (name)":"Primary","StatutoryLowAge":"3","StatutoryHighAge":"11","Boarders
-      (code)":"1","Boarders (name)":"No boarders","NurseryProvision (name)":"Has Nursery
-      Classes","OfficialSixthForm (code)":"2","OfficialSixthForm (name)":"Does not
-      have a sixth form","Gender (code)":"3","Gender (name)":"Mixed","ReligiousCharacter
-      (code)":"03","ReligiousCharacter (name)":"Roman Catholic","ReligiousEthos (name)":"Roman
-      Catholic","Diocese (code)":"RC04","Diocese (name)":"Diocese of Brentwood","AdmissionsPolicy
-      (code)":"0","AdmissionsPolicy (name)":"Not applicable","SchoolCapacity":"236","SpecialClasses
-      (code)":"0","SpecialClasses (name)":"Not applicable","CensusDate":"18-01-2024","NumberOfPupils":"235","NumberOfBoys":"102","NumberOfGirls":"133","PercentageFSM":"12.30","TrustSchoolFlag
-      (code)":"3","TrustSchoolFlag (name)":"Supported by a multi-academy trust","Trusts
-      (code)":"2893","Trusts (name)":"CHRISTUS CATHOLIC TRUST","SchoolSponsorFlag
-      (name)":"Linked to a sponsor","SchoolSponsors (name)":"Catholic Diocese of Brentwood","FederationFlag
-      (name)":"Not applicable","Federations (code)":"","Federations (name)":"","UKPRN":"10042438","FEHEIdentifier":"","FurtherEducationType
-      (name)":"Not applicable","OfstedLastInsp":"21-10-2021","OfstedSpecialMeasures
-      (code)":"0","OfstedSpecialMeasures (name)":"Not applicable","LastChangedDate":"30-09-2024","Street":"Elsenham
-      Crescent","Locality":"","Address3":"","Town":"Basildon","County (name)":"Essex","Postcode":"SS14
-      1UE","SchoolWebsite":"www.st-teresasrc.essex.sch.uk","TelephoneNum":"01268553502","HeadTitle
-      (name)":"Mr","HeadFirstName":"Jacques","HeadLastName":"Bottjer","HeadPreferredJobTitle":"Headteacher","BSOInspectorateName
-      (name)":"Not applicable","InspectorateReport":"","DateOfLastInspectionVisit":"","NextInspectionVisit":"","TeenMoth
-      (name)":"Not applicable","TeenMothPlaces":"","CCF (name)":"","SENPRU (name)":"Not
-      applicable","EBD (name)":"Not applicable","PlacesPRU":"","FTProv (name)":"","EdByOther
-      (name)":"","Section41Approved (name)":"Not applicable","SEN1 (name)":"","SEN2
-      (name)":"","SEN3 (name)":"","SEN4 (name)":"","SEN5 (name)":"","SEN6 (name)":"","SEN7
-      (name)":"","SEN8 (name)":"","SEN9 (name)":"","SEN10 (name)":"","SEN11 (name)":"","SEN12
-      (name)":"","SEN13 (name)":"","TypeOfResourcedProvision (name)":"","ResourcedProvisionOnRoll":"","ResourcedProvisionCapacity":"","SenUnitOnRoll":"","SenUnitCapacity":"","GOR
-      (code)":"G","GOR (name)":"East of England","DistrictAdministrative (code)":"E07000066","DistrictAdministrative
-      (name)":"Basildon","AdministrativeWard (code)":"E05004033","AdministrativeWard
-      (name)":"Vange","ParliamentaryConstituency (code)":"E14001077","ParliamentaryConstituency
-      (name)":"Basildon and Billericay","UrbanRural (code)":"C1","UrbanRural (name)":"(England/Wales)
-      Urban city and town","GSSLACode (name)":"E10000012","Easting":"572949","Northing":"188608","MSOA
-      (name)":"Basildon 022","LSOA (name)":"Basildon 022D","InspectorateName (name)":"","SENStat":"","SENNoStat":"","BoardingEstablishment
-      (name)":"","PropsName":"","PreviousLA (code)":"999","PreviousLA (name)":"","PreviousEstablishmentNumber":"","OfstedRating
-      (name)":"Good","Country (name)":"","UPRN":"10090454349","SiteName":"","QABName
-      (code)":"0","QABName (name)":"Not applicable","EstablishmentAccredited (code)":"0","EstablishmentAccredited
-      (name)":"Not applicable","QABReport":"","CHNumber":"","MSOA (code)":"E02004445","LSOA
-      (code)":"E01021326","FSM":"29","AccreditationExpiryDate":""}'
+    name: religious_character
+    value_before_type_cast: 'None'
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: created_at
     value_before_type_cast: 2024-11-28 16:28:24.401152000 Z
@@ -118,9 +78,6 @@
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: geopoint
     value_before_type_cast: 0101000020E6100000EE69ECB108A0DF3F57A1B2BBEFC84940
-  - !ruby/object:ActiveModel::Attribute::FromDatabase
-    name: gias_data_hash
-    value_before_type_cast: 953da3c0acd2b024bbc2bde43a3b16b5afe5c0bf0880b56f9ac296d104368f66
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: slug
     value_before_type_cast: st-teresa-s-catholic-primary-school-basildon
@@ -197,49 +154,8 @@
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: address3
   - !ruby/object:ActiveModel::Attribute::FromDatabase
-    name: gias_data
-    value_before_type_cast: '{"URN":"114995","LA (code)":"881","LA (name)":"Essex","EstablishmentNumber":"2786","EstablishmentName":"Northlands
-      Primary School and Nursery","TypeOfEstablishment (code)":"01","TypeOfEstablishment
-      (name)":"Community school","EstablishmentTypeGroup (code)":"4","EstablishmentTypeGroup
-      (name)":"Local authority maintained schools","EstablishmentStatus (code)":"2","EstablishmentStatus
-      (name)":"Closed","ReasonEstablishmentOpened (code)":"00","ReasonEstablishmentOpened
-      (name)":"Not applicable","OpenDate":"","ReasonEstablishmentClosed (code)":"06","ReasonEstablishmentClosed
-      (name)":"For Academy","CloseDate":"31-08-2016","PhaseOfEducation (code)":"2","PhaseOfEducation
-      (name)":"Primary","StatutoryLowAge":"3","StatutoryHighAge":"11","Boarders (code)":"1","Boarders
-      (name)":"No boarders","NurseryProvision (name)":"Has Nursery Classes","OfficialSixthForm
-      (code)":"2","OfficialSixthForm (name)":"Does not have a sixth form","Gender
-      (code)":"3","Gender (name)":"Mixed","ReligiousCharacter (code)":"00","ReligiousCharacter
-      (name)":"Does not apply","ReligiousEthos (name)":"Does not apply","Diocese (code)":"0000","Diocese
-      (name)":"Not applicable","AdmissionsPolicy (code)":"0","AdmissionsPolicy (name)":"Not
-      applicable","SchoolCapacity":"525","SpecialClasses (code)":"2","SpecialClasses
-      (name)":"No Special Classes","CensusDate":"","NumberOfPupils":"","NumberOfBoys":"","NumberOfGirls":"","PercentageFSM":"","TrustSchoolFlag
-      (code)":"0","TrustSchoolFlag (name)":"Not applicable","Trusts (code)":"","Trusts
-      (name)":"","SchoolSponsorFlag (name)":"Not applicable","SchoolSponsors (name)":"","FederationFlag
-      (name)":"Not under a federation","Federations (code)":"","Federations (name)":"","UKPRN":"","FEHEIdentifier":"","FurtherEducationType
-      (name)":"Not applicable","OfstedLastInsp":"09-12-2011","OfstedSpecialMeasures
-      (code)":"0","OfstedSpecialMeasures (name)":"Not applicable","LastChangedDate":"15-10-2018","Street":"Winifred
-      Road","Locality":"Pitsea","Address3":"","Town":"Basildon","County (name)":"Essex","Postcode":"SS13
-      3JQ","SchoolWebsite":"","TelephoneNum":"","HeadTitle (name)":"Mrs","HeadFirstName":"Elizabeth","HeadLastName":"Young","HeadPreferredJobTitle":"Headteacher","BSOInspectorateName
-      (name)":"Not applicable","InspectorateReport":"","DateOfLastInspectionVisit":"","NextInspectionVisit":"","TeenMoth
-      (name)":"Not applicable","TeenMothPlaces":"","CCF (name)":"Not applicable","SENPRU
-      (name)":"Not applicable","EBD (name)":"Not applicable","PlacesPRU":"","FTProv
-      (name)":"","EdByOther (name)":"Not applicable","Section41Approved (name)":"Not
-      applicable","SEN1 (name)":"","SEN2 (name)":"","SEN3 (name)":"","SEN4 (name)":"","SEN5
-      (name)":"","SEN6 (name)":"","SEN7 (name)":"","SEN8 (name)":"","SEN9 (name)":"","SEN10
-      (name)":"","SEN11 (name)":"","SEN12 (name)":"","SEN13 (name)":"","TypeOfResourcedProvision
-      (name)":"","ResourcedProvisionOnRoll":"","ResourcedProvisionCapacity":"","SenUnitOnRoll":"","SenUnitCapacity":"","GOR
-      (code)":"G","GOR (name)":"East of England","DistrictAdministrative (code)":"E07000066","DistrictAdministrative
-      (name)":"Basildon","AdministrativeWard (code)":"E05004030","AdministrativeWard
-      (name)":"Pitsea North West","ParliamentaryConstituency (code)":"E14000933","ParliamentaryConstituency
-      (name)":"South Basildon and East Thurrock","UrbanRural (code)":"C1","UrbanRural
-      (name)":"(England/Wales) Urban city and town","GSSLACode (name)":"E10000012","Easting":"573767","Northing":"188755","MSOA
-      (name)":"Basildon 013","LSOA (name)":"Basildon 013D","InspectorateName (name)":"","SENStat":"","SENNoStat":"","BoardingEstablishment
-      (name)":"","PropsName":"","PreviousLA (code)":"915","PreviousLA (name)":"Pre
-      LGR (1998) Essex","PreviousEstablishmentNumber":"2786","OfstedRating (name)":"Good","Country
-      (name)":"","UPRN":"10090455041","SiteName":"","QABName (code)":"0","QABName
-      (name)":"Not applicable","EstablishmentAccredited (code)":"0","EstablishmentAccredited
-      (name)":"Not applicable","QABReport":"","CHNumber":"","MSOA (code)":"E02004436","LSOA
-      (code)":"E01021305","FSM":"","AccreditationExpiryDate":""}'
+    name: religious_character
+    value_before_type_cast: 'None'
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: created_at
     value_before_type_cast: 2024-11-28 16:26:00.104039000 Z
@@ -270,9 +186,6 @@
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: geopoint
     value_before_type_cast: 0101000020E61000006C9F23333431E03F492F65C412C94940
-  - !ruby/object:ActiveModel::Attribute::FromDatabase
-    name: gias_data_hash
-    value_before_type_cast: 4d92dd2801d8dc556c4abf57d159e2035606210bad9a4e46090ae71a5b1122fc
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: slug
     value_before_type_cast: northlands-primary-school-and-nursery
@@ -348,48 +261,8 @@
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: address3
   - !ruby/object:ActiveModel::Attribute::FromDatabase
-    name: gias_data
-    value_before_type_cast: '{"URN":"114868","LA (code)":"881","LA (name)":"Essex","EstablishmentNumber":"2498","EstablishmentName":"Lincewood
-      Junior School","TypeOfEstablishment (code)":"01","TypeOfEstablishment (name)":"Community
-      school","EstablishmentTypeGroup (code)":"4","EstablishmentTypeGroup (name)":"Local
-      authority maintained schools","EstablishmentStatus (code)":"2","EstablishmentStatus
-      (name)":"Closed","ReasonEstablishmentOpened (code)":"00","ReasonEstablishmentOpened
-      (name)":"Not applicable","OpenDate":"","ReasonEstablishmentClosed (code)":"01","ReasonEstablishmentClosed
-      (name)":"Result of Amalgamation/Merger","CloseDate":"31-08-2003","PhaseOfEducation
-      (code)":"2","PhaseOfEducation (name)":"Primary","StatutoryLowAge":"7","StatutoryHighAge":"11","Boarders
-      (code)":"1","Boarders (name)":"No boarders","NurseryProvision (name)":"No Nursery
-      Classes","OfficialSixthForm (code)":"0","OfficialSixthForm (name)":"Not applicable","Gender
-      (code)":"3","Gender (name)":"Mixed","ReligiousCharacter (code)":"00","ReligiousCharacter
-      (name)":"Does not apply","ReligiousEthos (name)":"Does not apply","Diocese (code)":"0000","Diocese
-      (name)":"Not applicable","AdmissionsPolicy (code)":"0","AdmissionsPolicy (name)":"Not
-      applicable","SchoolCapacity":"","SpecialClasses (code)":"2","SpecialClasses
-      (name)":"No Special Classes","CensusDate":"","NumberOfPupils":"","NumberOfBoys":"","NumberOfGirls":"","PercentageFSM":"","TrustSchoolFlag
-      (code)":"0","TrustSchoolFlag (name)":"Not applicable","Trusts (code)":"","Trusts
-      (name)":"","SchoolSponsorFlag (name)":"Not applicable","SchoolSponsors (name)":"","FederationFlag
-      (name)":"Not under a federation","Federations (code)":"","Federations (name)":"","UKPRN":"","FEHEIdentifier":"","FurtherEducationType
-      (name)":"Not applicable","OfstedLastInsp":"","OfstedSpecialMeasures (code)":"0","OfstedSpecialMeasures
-      (name)":"Not applicable","LastChangedDate":"14-11-2018","Street":"Berry Lane","Locality":"Langdon
-      Hills","Address3":"","Town":"Basildon","County (name)":"Essex","Postcode":"SS16
-      6AZ","SchoolWebsite":"","TelephoneNum":"","HeadTitle (name)":"Mr","HeadFirstName":"T","HeadLastName":"Eastwell","HeadPreferredJobTitle":"Headteacher","BSOInspectorateName
-      (name)":"Not applicable","InspectorateReport":"","DateOfLastInspectionVisit":"","NextInspectionVisit":"","TeenMoth
-      (name)":"Not applicable","TeenMothPlaces":"","CCF (name)":"Not applicable","SENPRU
-      (name)":"Not applicable","EBD (name)":"Not applicable","PlacesPRU":"","FTProv
-      (name)":"","EdByOther (name)":"Not applicable","Section41Approved (name)":"Not
-      applicable","SEN1 (name)":"","SEN2 (name)":"","SEN3 (name)":"","SEN4 (name)":"","SEN5
-      (name)":"","SEN6 (name)":"","SEN7 (name)":"","SEN8 (name)":"","SEN9 (name)":"","SEN10
-      (name)":"","SEN11 (name)":"","SEN12 (name)":"","SEN13 (name)":"","TypeOfResourcedProvision
-      (name)":"","ResourcedProvisionOnRoll":"","ResourcedProvisionCapacity":"","SenUnitOnRoll":"","SenUnitCapacity":"","GOR
-      (code)":"G","GOR (name)":"East of England","DistrictAdministrative (code)":"E07000066","DistrictAdministrative
-      (name)":"Basildon","AdministrativeWard (code)":"E05004027","AdministrativeWard
-      (name)":"Langdon Hills","ParliamentaryConstituency (code)":"E14000933","ParliamentaryConstituency
-      (name)":"South Basildon and East Thurrock","UrbanRural (code)":"C1","UrbanRural
-      (name)":"(England/Wales) Urban city and town","GSSLACode (name)":"E10000012","Easting":"567772","Northing":"187477","MSOA
-      (name)":"Basildon 021","LSOA (name)":"Basildon 021C","InspectorateName (name)":"","SENStat":"","SENNoStat":"","BoardingEstablishment
-      (name)":"","PropsName":"","PreviousLA (code)":"915","PreviousLA (name)":"Pre
-      LGR (1998) Essex","PreviousEstablishmentNumber":"2498","OfstedRating (name)":"","Country
-      (name)":"","UPRN":"","SiteName":"","QABName (code)":"0","QABName (name)":"Not
-      applicable","EstablishmentAccredited (code)":"0","EstablishmentAccredited (name)":"Not
-      applicable","QABReport":"","CHNumber":"","MSOA (code)":"E02004444","LSOA (code)":"E01021282","FSM":"","AccreditationExpiryDate":""}'
+    name: religious_character
+    value_before_type_cast: 'None'
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: created_at
     value_before_type_cast: 2024-11-28 16:25:58.975507000 Z
@@ -420,9 +293,6 @@
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: geopoint
     value_before_type_cast: 0101000020E6100000F3A8E30080D0DA3F57420906D6C74940
-  - !ruby/object:ActiveModel::Attribute::FromDatabase
-    name: gias_data_hash
-    value_before_type_cast: 32e7571418abe718595b5bb84aa7bd301a4b8c17c7eaa3985789568959750d9d
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: slug
     value_before_type_cast: lincewood-junior-school

--- a/spec/fixtures/liverpool_schools.yml
+++ b/spec/fixtures/liverpool_schools.yml
@@ -16,6 +16,9 @@
     name: urn
     value_before_type_cast: '104921'
   - !ruby/object:ActiveModel::Attribute::FromDatabase
+    name: religious_character
+    value_before_type_cast: 'None'
+  - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: uid
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: phase
@@ -47,50 +50,6 @@
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: address3
   - !ruby/object:ActiveModel::Attribute::FromDatabase
-    name: gias_data
-    value_before_type_cast: '{"URN":"104921","LA (code)":"343","LA (name)":"Sefton","EstablishmentNumber":"3343","EstablishmentName":"St
-      Luke''s Halsall Church of England Primary School","TypeOfEstablishment (code)":"02","TypeOfEstablishment
-      (name)":"Voluntary aided school","EstablishmentTypeGroup (code)":"4","EstablishmentTypeGroup
-      (name)":"Local authority maintained schools","EstablishmentStatus (code)":"1","EstablishmentStatus
-      (name)":"Open","ReasonEstablishmentOpened (code)":"00","ReasonEstablishmentOpened
-      (name)":"Not applicable","OpenDate":"","ReasonEstablishmentClosed (code)":"00","ReasonEstablishmentClosed
-      (name)":"Not applicable","CloseDate":"","PhaseOfEducation (code)":"2","PhaseOfEducation
-      (name)":"Primary","StatutoryLowAge":"3","StatutoryHighAge":"11","Boarders (code)":"1","Boarders
-      (name)":"No boarders","NurseryProvision (name)":"Has Nursery Classes","OfficialSixthForm
-      (code)":"2","OfficialSixthForm (name)":"Does not have a sixth form","Gender
-      (code)":"3","Gender (name)":"Mixed","ReligiousCharacter (code)":"02","ReligiousCharacter
-      (name)":"Church of England","ReligiousEthos (name)":"Does not apply","Diocese
-      (code)":"CE22","Diocese (name)":"Diocese of Liverpool","AdmissionsPolicy (code)":"0","AdmissionsPolicy
-      (name)":"Not applicable","SchoolCapacity":"210","SpecialClasses (code)":"2","SpecialClasses
-      (name)":"No Special Classes","CensusDate":"18-01-2024","NumberOfPupils":"229","NumberOfBoys":"123","NumberOfGirls":"106","PercentageFSM":"14.60","TrustSchoolFlag
-      (code)":"0","TrustSchoolFlag (name)":"Not applicable","Trusts (code)":"","Trusts
-      (name)":"","SchoolSponsorFlag (name)":"Not applicable","SchoolSponsors (name)":"","FederationFlag
-      (name)":"Not under a federation","Federations (code)":"","Federations (name)":"","UKPRN":"10068597","FEHEIdentifier":"","FurtherEducationType
-      (name)":"Not applicable","OfstedLastInsp":"27-03-2024","OfstedSpecialMeasures
-      (code)":"0","OfstedSpecialMeasures (name)":"Not applicable","LastChangedDate":"24-09-2024","Street":"Cooks
-      Road","Locality":"Crosby","Address3":"","Town":"Liverpool","County (name)":"Merseyside","Postcode":"L23
-      2TB","SchoolWebsite":"http://www.stlukeshalsall.co.uk","TelephoneNum":"01519245142","HeadTitle
-      (name)":"Mr","HeadFirstName":"Richard J","HeadLastName":"Miller","HeadPreferredJobTitle":"Headteacher","BSOInspectorateName
-      (name)":"Not applicable","InspectorateReport":"","DateOfLastInspectionVisit":"","NextInspectionVisit":"","TeenMoth
-      (name)":"Not applicable","TeenMothPlaces":"","CCF (name)":"Not applicable","SENPRU
-      (name)":"Not applicable","EBD (name)":"Not applicable","PlacesPRU":"","FTProv
-      (name)":"","EdByOther (name)":"Not applicable","Section41Approved (name)":"Not
-      applicable","SEN1 (name)":"","SEN2 (name)":"","SEN3 (name)":"","SEN4 (name)":"","SEN5
-      (name)":"","SEN6 (name)":"","SEN7 (name)":"","SEN8 (name)":"","SEN9 (name)":"","SEN10
-      (name)":"","SEN11 (name)":"","SEN12 (name)":"","SEN13 (name)":"","TypeOfResourcedProvision
-      (name)":"","ResourcedProvisionOnRoll":"","ResourcedProvisionCapacity":"","SenUnitOnRoll":"","SenUnitCapacity":"","GOR
-      (code)":"B","GOR (name)":"North West","DistrictAdministrative (code)":"E08000014","DistrictAdministrative
-      (name)":"Sefton","AdministrativeWard (code)":"E05000934","AdministrativeWard
-      (name)":"Blundellsands","ParliamentaryConstituency (code)":"E14001463","ParliamentaryConstituency
-      (name)":"Sefton Central","UrbanRural (code)":"A1","UrbanRural (name)":"(England/Wales)
-      Urban major conurbation","GSSLACode (name)":"E08000014","Easting":"331909","Northing":"400144","MSOA
-      (name)":"Sefton 022","LSOA (name)":"Sefton 022D","InspectorateName (name)":"","SENStat":"","SENNoStat":"","BoardingEstablishment
-      (name)":"","PropsName":"","PreviousLA (code)":"999","PreviousLA (name)":"","PreviousEstablishmentNumber":"","OfstedRating
-      (name)":"Good","Country (name)":"","UPRN":"41020675","SiteName":"","QABName
-      (code)":"0","QABName (name)":"Not applicable","EstablishmentAccredited (code)":"0","EstablishmentAccredited
-      (name)":"Not applicable","QABReport":"","CHNumber":"","MSOA (code)":"E02001450","LSOA
-      (code)":"E01006939","FSM":"33","AccreditationExpiryDate":""}'
-  - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: created_at
     value_before_type_cast: 2024-11-28 16:23:38.159026000 Z
   - !ruby/object:ActiveModel::Attribute::FromDatabase
@@ -120,9 +79,6 @@
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: geopoint
     value_before_type_cast: 0101000020E610000099E2E18CEC3808C056B550A22DBF4A40
-  - !ruby/object:ActiveModel::Attribute::FromDatabase
-    name: gias_data_hash
-    value_before_type_cast: 44cb6eddddab6e3459fa8e7377dec703f435fe059ba246a028116bbcc1896b66
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: slug
     value_before_type_cast: st-luke-s-halsall-church-of-england-primary-school
@@ -164,6 +120,9 @@
     name: name
     value_before_type_cast: Abbot's Lea School
   - !ruby/object:ActiveModel::Attribute::FromDatabase
+    name: religious_character
+    value_before_type_cast: 'None'
+  - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: description
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: urn
@@ -200,53 +159,6 @@
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: address3
   - !ruby/object:ActiveModel::Attribute::FromDatabase
-    name: gias_data
-    value_before_type_cast: '{"URN":"104736","LA (code)":"341","LA (name)":"Liverpool","EstablishmentNumber":"7025","EstablishmentName":"Abbot''s
-      Lea School","TypeOfEstablishment (code)":"07","TypeOfEstablishment (name)":"Community
-      special school","EstablishmentTypeGroup (code)":"5","EstablishmentTypeGroup
-      (name)":"Special schools","EstablishmentStatus (code)":"1","EstablishmentStatus
-      (name)":"Open","ReasonEstablishmentOpened (code)":"00","ReasonEstablishmentOpened
-      (name)":"Not applicable","OpenDate":"","ReasonEstablishmentClosed (code)":"00","ReasonEstablishmentClosed
-      (name)":"Not applicable","CloseDate":"","PhaseOfEducation (code)":"0","PhaseOfEducation
-      (name)":"Not applicable","StatutoryLowAge":"3","StatutoryHighAge":"19","Boarders
-      (code)":"1","Boarders (name)":"No boarders","NurseryProvision (name)":"Has Nursery
-      Classes","OfficialSixthForm (code)":"1","OfficialSixthForm (name)":"Has a sixth
-      form","Gender (code)":"3","Gender (name)":"Mixed","ReligiousCharacter (code)":"00","ReligiousCharacter
-      (name)":"Does not apply","ReligiousEthos (name)":"Does not apply","Diocese (code)":"0000","Diocese
-      (name)":"Not applicable","AdmissionsPolicy (code)":"0","AdmissionsPolicy (name)":"Not
-      applicable","SchoolCapacity":"272","SpecialClasses (code)":"1","SpecialClasses
-      (name)":"Has Special Classes","CensusDate":"18-01-2024","NumberOfPupils":"271","NumberOfBoys":"229","NumberOfGirls":"42","PercentageFSM":"57.10","TrustSchoolFlag
-      (code)":"0","TrustSchoolFlag (name)":"Not applicable","Trusts (code)":"","Trusts
-      (name)":"","SchoolSponsorFlag (name)":"Not applicable","SchoolSponsors (name)":"","FederationFlag
-      (name)":"Not under a federation","Federations (code)":"","Federations (name)":"","UKPRN":"10017283","FEHEIdentifier":"","FurtherEducationType
-      (name)":"Not applicable","OfstedLastInsp":"10-07-2024","OfstedSpecialMeasures
-      (code)":"0","OfstedSpecialMeasures (name)":"Not applicable","LastChangedDate":"15-11-2024","Street":"Beaconsfield
-      Road","Locality":"Woolton","Address3":"","Town":"Liverpool","County (name)":"Merseyside","Postcode":"L25
-      6EE","SchoolWebsite":"www.abbotsleaschool.co.uk","TelephoneNum":"01514281161","HeadTitle
-      (name)":"Mrs","HeadFirstName":"Ania","HeadLastName":"Hildrey","HeadPreferredJobTitle":"Headteacher","BSOInspectorateName
-      (name)":"Not applicable","InspectorateReport":"","DateOfLastInspectionVisit":"","NextInspectionVisit":"","TeenMoth
-      (name)":"Not applicable","TeenMothPlaces":"","CCF (name)":"Not applicable","SENPRU
-      (name)":"Not applicable","EBD (name)":"Not applicable","PlacesPRU":"","FTProv
-      (name)":"","EdByOther (name)":"Not applicable","Section41Approved (name)":"Not
-      applicable","SEN1 (name)":"SpLD - Specific Learning Difficulty","SEN2 (name)":"OTH
-      - Other Difficulty/Disability","SEN3 (name)":"SLCN - Speech, language and Communication","SEN4
-      (name)":"ASD - Autistic Spectrum Disorder","SEN5 (name)":"SEMH - Social, Emotional
-      and Mental Health","SEN6 (name)":"MSI - Multi-Sensory Impairment","SEN7 (name)":"MLD
-      - Moderate Learning Difficulty","SEN8 (name)":"SLD - Severe Learning Difficulty","SEN9
-      (name)":"","SEN10 (name)":"","SEN11 (name)":"","SEN12 (name)":"","SEN13 (name)":"","TypeOfResourcedProvision
-      (name)":"Not applicable","ResourcedProvisionOnRoll":"","ResourcedProvisionCapacity":"","SenUnitOnRoll":"","SenUnitCapacity":"","GOR
-      (code)":"B","GOR (name)":"North West","DistrictAdministrative (code)":"E08000012","DistrictAdministrative
-      (name)":"Liverpool","AdministrativeWard (code)":"E05015339","AdministrativeWard
-      (name)":"Woolton Village","ParliamentaryConstituency (code)":"E14001337","ParliamentaryConstituency
-      (name)":"Liverpool Garston","UrbanRural (code)":"A1","UrbanRural (name)":"(England/Wales)
-      Urban major conurbation","GSSLACode (name)":"E08000012","Easting":"341418","Northing":"387532","MSOA
-      (name)":"Liverpool 047","LSOA (name)":"Liverpool 047E","InspectorateName (name)":"","SENStat":"","SENNoStat":"","BoardingEstablishment
-      (name)":"","PropsName":"","PreviousLA (code)":"999","PreviousLA (name)":"","PreviousEstablishmentNumber":"","OfstedRating
-      (name)":"Outstanding","Country (name)":"","UPRN":"38168369","SiteName":"","QABName
-      (code)":"0","QABName (name)":"Not applicable","EstablishmentAccredited (code)":"0","EstablishmentAccredited
-      (name)":"Not applicable","QABReport":"","CHNumber":"","MSOA (code)":"E02001393","LSOA
-      (code)":"E01006796","FSM":"129","AccreditationExpiryDate":""}'
-  - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: created_at
     value_before_type_cast: 2024-11-28 16:23:32.158796000 Z
   - !ruby/object:ActiveModel::Attribute::FromDatabase
@@ -276,9 +188,6 @@
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: geopoint
     value_before_type_cast: 0101000020E61000001FC70D2B9C0E07C0C6F7A6F7D0B04A40
-  - !ruby/object:ActiveModel::Attribute::FromDatabase
-    name: gias_data_hash
-    value_before_type_cast: b2542be41bd99b95f7a228c46682ba209d17d48946e058feceae0fa2aca90664
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: slug
     value_before_type_cast: abbot-s-lea-school

--- a/spec/fixtures/st_albans_schools.yml
+++ b/spec/fixtures/st_albans_schools.yml
@@ -47,51 +47,8 @@
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: address3
   - !ruby/object:ActiveModel::Attribute::FromDatabase
-    name: gias_data
-    value_before_type_cast: '{"URN":"117671","LA (code)":"919","LA (name)":"Hertfordshire","EstablishmentNumber":"7012","EstablishmentName":"St
-      Luke''s School","TypeOfEstablishment (code)":"12","TypeOfEstablishment (name)":"Foundation
-      special school","EstablishmentTypeGroup (code)":"5","EstablishmentTypeGroup
-      (name)":"Special schools","EstablishmentStatus (code)":"1","EstablishmentStatus
-      (name)":"Open","ReasonEstablishmentOpened (code)":"00","ReasonEstablishmentOpened
-      (name)":"Not applicable","OpenDate":"","ReasonEstablishmentClosed (code)":"00","ReasonEstablishmentClosed
-      (name)":"Not applicable","CloseDate":"","PhaseOfEducation (code)":"0","PhaseOfEducation
-      (name)":"Not applicable","StatutoryLowAge":"7","StatutoryHighAge":"16","Boarders
-      (code)":"1","Boarders (name)":"No boarders","NurseryProvision (name)":"Not applicable","OfficialSixthForm
-      (code)":"0","OfficialSixthForm (name)":"Not applicable","Gender (code)":"3","Gender
-      (name)":"Mixed","ReligiousCharacter (code)":"00","ReligiousCharacter (name)":"Does
-      not apply","ReligiousEthos (name)":"Does not apply","Diocese (code)":"0000","Diocese
-      (name)":"Not applicable","AdmissionsPolicy (code)":"0","AdmissionsPolicy (name)":"Not
-      applicable","SchoolCapacity":"175","SpecialClasses (code)":"1","SpecialClasses
-      (name)":"Has Special Classes","CensusDate":"18-01-2024","NumberOfPupils":"172","NumberOfBoys":"113","NumberOfGirls":"59","PercentageFSM":"41.90","TrustSchoolFlag
-      (code)":"2","TrustSchoolFlag (name)":"Not supported by a trust","Trusts (code)":"","Trusts
-      (name)":"","SchoolSponsorFlag (name)":"Not applicable","SchoolSponsors (name)":"","FederationFlag
-      (name)":"Not under a federation","Federations (code)":"","Federations (name)":"","UKPRN":"10008515","FEHEIdentifier":"","FurtherEducationType
-      (name)":"Not applicable","OfstedLastInsp":"07-06-2023","OfstedSpecialMeasures
-      (code)":"0","OfstedSpecialMeasures (name)":"Not applicable","LastChangedDate":"15-11-2024","Street":"Crouch
-      Hall Lane","Locality":"Redbourn","Address3":"","Town":"St Albans","County (name)":"Hertfordshire","Postcode":"AL3
-      7ET","SchoolWebsite":"http://www.stlukes.herts.sch.uk/","TelephoneNum":"01582626727","HeadTitle
-      (name)":"Mr","HeadFirstName":"Stephen","HeadLastName":"Hoult-Allen","HeadPreferredJobTitle":"Headteacher","BSOInspectorateName
-      (name)":"Not applicable","InspectorateReport":"","DateOfLastInspectionVisit":"","NextInspectionVisit":"","TeenMoth
-      (name)":"Not applicable","TeenMothPlaces":"","CCF (name)":"Not applicable","SENPRU
-      (name)":"Not applicable","EBD (name)":"Not applicable","PlacesPRU":"","FTProv
-      (name)":"","EdByOther (name)":"Not applicable","Section41Approved (name)":"Not
-      applicable","SEN1 (name)":"SpLD - Specific Learning Difficulty","SEN2 (name)":"VI
-      - Visual Impairment","SEN3 (name)":"OTH - Other Difficulty/Disability","SEN4
-      (name)":"SLCN - Speech, language and Communication","SEN5 (name)":"ASD - Autistic
-      Spectrum Disorder","SEN6 (name)":"MLD - Moderate Learning Difficulty","SEN7
-      (name)":"","SEN8 (name)":"","SEN9 (name)":"","SEN10 (name)":"","SEN11 (name)":"","SEN12
-      (name)":"","SEN13 (name)":"","TypeOfResourcedProvision (name)":"Not applicable","ResourcedProvisionOnRoll":"","ResourcedProvisionCapacity":"","SenUnitOnRoll":"","SenUnitCapacity":"","GOR
-      (code)":"G","GOR (name)":"East of England","DistrictAdministrative (code)":"E07000240","DistrictAdministrative
-      (name)":"St Albans","AdministrativeWard (code)":"E05013961","AdministrativeWard
-      (name)":"Redbourn","ParliamentaryConstituency (code)":"E14001268","ParliamentaryConstituency
-      (name)":"Harpenden and Berkhamsted","UrbanRural (code)":"D1","UrbanRural (name)":"(England/Wales)
-      Rural town and fringe","GSSLACode (name)":"E10000015","Easting":"510132","Northing":"212893","MSOA
-      (name)":"St Albans 006","LSOA (name)":"St Albans 006D","InspectorateName (name)":"","SENStat":"","SENNoStat":"","BoardingEstablishment
-      (name)":"","PropsName":"","PreviousLA (code)":"999","PreviousLA (name)":"","PreviousEstablishmentNumber":"","OfstedRating
-      (name)":"Good","Country (name)":"","UPRN":"100081153864","SiteName":"","QABName
-      (code)":"0","QABName (name)":"Not applicable","EstablishmentAccredited (code)":"0","EstablishmentAccredited
-      (name)":"Not applicable","QABReport":"","CHNumber":"","MSOA (code)":"E02004929","LSOA
-      (code)":"E01023725","FSM":"72","AccreditationExpiryDate":""}'
+    name: religious_character
+    value_before_type_cast: 'None'
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: created_at
     value_before_type_cast: 2024-11-28 16:26:34.298924000 Z
@@ -122,9 +79,6 @@
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: geopoint
     value_before_type_cast: 0101000020E6100000A323C00414DDD9BF17358951E4E64940
-  - !ruby/object:ActiveModel::Attribute::FromDatabase
-    name: gias_data_hash
-    value_before_type_cast: 0a84f86339ce7f69c5c9ff3cf11d60b0192d1334ead9bc835cdbdf5c38e265b1
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: slug
     value_before_type_cast: st-luke-s-school
@@ -200,47 +154,8 @@
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: address3
   - !ruby/object:ActiveModel::Attribute::FromDatabase
-    name: gias_data
-    value_before_type_cast: '{"URN":"139197","LA (code)":"919","LA (name)":"Hertfordshire","EstablishmentNumber":"1106","EstablishmentName":"Links
-      Academy","TypeOfEstablishment (code)":"42","TypeOfEstablishment (name)":"Academy
-      alternative provision converter","EstablishmentTypeGroup (code)":"10","EstablishmentTypeGroup
-      (name)":"Academies","EstablishmentStatus (code)":"1","EstablishmentStatus (name)":"Open","ReasonEstablishmentOpened
-      (code)":"10","ReasonEstablishmentOpened (name)":"Academy Converter","OpenDate":"01-02-2013","ReasonEstablishmentClosed
-      (code)":"99","ReasonEstablishmentClosed (name)":"","CloseDate":"","PhaseOfEducation
-      (code)":"0","PhaseOfEducation (name)":"Not applicable","StatutoryLowAge":"11","StatutoryHighAge":"16","Boarders
-      (code)":"1","Boarders (name)":"No boarders","NurseryProvision (name)":"Not applicable","OfficialSixthForm
-      (code)":"0","OfficialSixthForm (name)":"Not applicable","Gender (code)":"3","Gender
-      (name)":"Mixed","ReligiousCharacter (code)":"00","ReligiousCharacter (name)":"Does
-      not apply","ReligiousEthos (name)":"None","Diocese (code)":"0000","Diocese (name)":"Not
-      applicable","AdmissionsPolicy (code)":"0","AdmissionsPolicy (name)":"Not applicable","SchoolCapacity":"40","SpecialClasses
-      (code)":"0","SpecialClasses (name)":"Not applicable","CensusDate":"18-01-2024","NumberOfPupils":"5","NumberOfBoys":"4","NumberOfGirls":"1","PercentageFSM":"80.00","TrustSchoolFlag
-      (code)":"3","TrustSchoolFlag (name)":"Supported by a multi-academy trust","Trusts
-      (code)":"17357","Trusts (name)":"LINKS MULTI ACADEMY TRUST","SchoolSponsorFlag
-      (name)":"Linked to a sponsor","SchoolSponsors (name)":"Links Academy Trust","FederationFlag
-      (name)":"Not applicable","Federations (code)":"","Federations (name)":"","UKPRN":"10040055","FEHEIdentifier":"","FurtherEducationType
-      (name)":"Not applicable","OfstedLastInsp":"25-05-2023","OfstedSpecialMeasures
-      (code)":"0","OfstedSpecialMeasures (name)":"Not applicable","LastChangedDate":"09-10-2024","Street":"1
-      Hixberry Lane","Locality":"","Address3":"","Town":"St Albans","County (name)":"Hertfordshire","Postcode":"AL4
-      0TZ","SchoolWebsite":"https://linksacademystalbans.co.uk/","TelephoneNum":"01727836150","HeadTitle
-      (name)":"","HeadFirstName":"David","HeadLastName":"Allen","HeadPreferredJobTitle":"Headteacher","BSOInspectorateName
-      (name)":"Not applicable","InspectorateReport":"","DateOfLastInspectionVisit":"","NextInspectionVisit":"","TeenMoth
-      (name)":"Not applicable","TeenMothPlaces":"","CCF (name)":"","SENPRU (name)":"Not
-      applicable","EBD (name)":"Not applicable","PlacesPRU":"","FTProv (name)":"","EdByOther
-      (name)":"","Section41Approved (name)":"Not applicable","SEN1 (name)":"","SEN2
-      (name)":"","SEN3 (name)":"","SEN4 (name)":"","SEN5 (name)":"","SEN6 (name)":"","SEN7
-      (name)":"","SEN8 (name)":"","SEN9 (name)":"","SEN10 (name)":"","SEN11 (name)":"","SEN12
-      (name)":"","SEN13 (name)":"","TypeOfResourcedProvision (name)":"","ResourcedProvisionOnRoll":"","ResourcedProvisionCapacity":"","SenUnitOnRoll":"","SenUnitCapacity":"","GOR
-      (code)":"G","GOR (name)":"East of England","DistrictAdministrative (code)":"E07000240","DistrictAdministrative
-      (name)":"St Albans","AdministrativeWard (code)":"E05013956","AdministrativeWard
-      (name)":"Hill End","ParliamentaryConstituency (code)":"E14001507","ParliamentaryConstituency
-      (name)":"St Albans","UrbanRural (code)":"C1","UrbanRural (name)":"(England/Wales)
-      Urban city and town","GSSLACode (name)":"E10000015","Easting":"517883","Northing":"206960","MSOA
-      (name)":"St Albans 021","LSOA (name)":"St Albans 021B","InspectorateName (name)":"","SENStat":"","SENNoStat":"","BoardingEstablishment
-      (name)":"","PropsName":"","PreviousLA (code)":"999","PreviousLA (name)":"","PreviousEstablishmentNumber":"1111","OfstedRating
-      (name)":"Good","Country (name)":"","UPRN":"200003633791","SiteName":"","QABName
-      (code)":"0","QABName (name)":"Not applicable","EstablishmentAccredited (code)":"0","EstablishmentAccredited
-      (name)":"Not applicable","QABReport":"","CHNumber":"","MSOA (code)":"E02007090","LSOA
-      (code)":"E01023677","FSM":"4","AccreditationExpiryDate":""}'
+    name: religious_character
+    value_before_type_cast: 'None'
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: created_at
     value_before_type_cast: 2024-11-28 16:28:20.135037000 Z
@@ -271,9 +186,6 @@
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: geopoint
     value_before_type_cast: 0101000020E6100000320240E119CDD2BF870A3B63DDDF4940
-  - !ruby/object:ActiveModel::Attribute::FromDatabase
-    name: gias_data_hash
-    value_before_type_cast: 9c0ecb9a5bd95f44008cb35483cdbde037505059e5e070ce08ddf9a9f933dd36
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: slug
     value_before_type_cast: links-academy
@@ -349,49 +261,8 @@
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: address3
   - !ruby/object:ActiveModel::Attribute::FromDatabase
-    name: gias_data
-    value_before_type_cast: '{"URN":"139159","LA (code)":"919","LA (name)":"Hertfordshire","EstablishmentNumber":"2099","EstablishmentName":"Mandeville
-      Primary School","TypeOfEstablishment (code)":"34","TypeOfEstablishment (name)":"Academy
-      converter","EstablishmentTypeGroup (code)":"10","EstablishmentTypeGroup (name)":"Academies","EstablishmentStatus
-      (code)":"1","EstablishmentStatus (name)":"Open","ReasonEstablishmentOpened (code)":"10","ReasonEstablishmentOpened
-      (name)":"Academy Converter","OpenDate":"01-01-2013","ReasonEstablishmentClosed
-      (code)":"99","ReasonEstablishmentClosed (name)":"","CloseDate":"","PhaseOfEducation
-      (code)":"2","PhaseOfEducation (name)":"Primary","StatutoryLowAge":"3","StatutoryHighAge":"11","Boarders
-      (code)":"1","Boarders (name)":"No boarders","NurseryProvision (name)":"Has Nursery
-      Classes","OfficialSixthForm (code)":"2","OfficialSixthForm (name)":"Does not
-      have a sixth form","Gender (code)":"3","Gender (name)":"Mixed","ReligiousCharacter
-      (code)":"00","ReligiousCharacter (name)":"Does not apply","ReligiousEthos (name)":"Does
-      not apply","Diocese (code)":"0000","Diocese (name)":"Not applicable","AdmissionsPolicy
-      (code)":"0","AdmissionsPolicy (name)":"Not applicable","SchoolCapacity":"446","SpecialClasses
-      (code)":"2","SpecialClasses (name)":"No Special Classes","CensusDate":"18-01-2024","NumberOfPupils":"394","NumberOfBoys":"182","NumberOfGirls":"212","PercentageFSM":"25.90","TrustSchoolFlag
-      (code)":"3","TrustSchoolFlag (name)":"Supported by a multi-academy trust","Trusts
-      (code)":"3107","Trusts (name)":"SPIRAL PARTNERSHIP TRUST","SchoolSponsorFlag
-      (name)":"Linked to a sponsor","SchoolSponsors (name)":"Spiral Partnership Trust","FederationFlag
-      (name)":"Not applicable","Federations (code)":"","Federations (name)":"","UKPRN":"10039766","FEHEIdentifier":"","FurtherEducationType
-      (name)":"Not applicable","OfstedLastInsp":"14-10-2021","OfstedSpecialMeasures
-      (code)":"0","OfstedSpecialMeasures (name)":"Not applicable","LastChangedDate":"08-11-2024","Street":"Mandeville
-      Drive","Locality":"","Address3":"","Town":"St Albans","County (name)":"Hertfordshire","Postcode":"AL1
-      2LE","SchoolWebsite":"www.mandeville.herts.sch.uk","TelephoneNum":"01727519220","HeadTitle
-      (name)":"Mrs","HeadFirstName":"Cathy","HeadLastName":"Longhurst","HeadPreferredJobTitle":"Head
-      Teacher","BSOInspectorateName (name)":"Not applicable","InspectorateReport":"","DateOfLastInspectionVisit":"","NextInspectionVisit":"","TeenMoth
-      (name)":"Not applicable","TeenMothPlaces":"","CCF (name)":"Not applicable","SENPRU
-      (name)":"Not applicable","EBD (name)":"Not applicable","PlacesPRU":"","FTProv
-      (name)":"Not applicable","EdByOther (name)":"Not applicable","Section41Approved
-      (name)":"Not applicable","SEN1 (name)":"","SEN2 (name)":"","SEN3 (name)":"","SEN4
-      (name)":"","SEN5 (name)":"","SEN6 (name)":"","SEN7 (name)":"","SEN8 (name)":"","SEN9
-      (name)":"","SEN10 (name)":"","SEN11 (name)":"","SEN12 (name)":"","SEN13 (name)":"","TypeOfResourcedProvision
-      (name)":"","ResourcedProvisionOnRoll":"","ResourcedProvisionCapacity":"","SenUnitOnRoll":"","SenUnitCapacity":"","GOR
-      (code)":"G","GOR (name)":"East of England","DistrictAdministrative (code)":"E07000240","DistrictAdministrative
-      (name)":"St Albans","AdministrativeWard (code)":"E05013963","AdministrativeWard
-      (name)":"Sopwell","ParliamentaryConstituency (code)":"E14001507","ParliamentaryConstituency
-      (name)":"St Albans","UrbanRural (code)":"C1","UrbanRural (name)":"(England/Wales)
-      Urban city and town","GSSLACode (name)":"E10000015","Easting":"514697","Northing":"205557","MSOA
-      (name)":"St Albans 017","LSOA (name)":"St Albans 017C","InspectorateName (name)":"","SENStat":"","SENNoStat":"","BoardingEstablishment
-      (name)":"","PropsName":"","PreviousLA (code)":"999","PreviousLA (name)":"","PreviousEstablishmentNumber":"","OfstedRating
-      (name)":"Good","Country (name)":"","UPRN":"100081149771","SiteName":"","QABName
-      (code)":"0","QABName (name)":"Not applicable","EstablishmentAccredited (code)":"0","EstablishmentAccredited
-      (name)":"Not applicable","QABReport":"","CHNumber":"","MSOA (code)":"E02004940","LSOA
-      (code)":"E01023739","FSM":"96","AccreditationExpiryDate":""}'
+    name: religious_character
+    value_before_type_cast: 'None'
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: created_at
     value_before_type_cast: 2024-11-28 16:28:20.135037000 Z
@@ -422,9 +293,6 @@
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: geopoint
     value_before_type_cast: 0101000020E6100000DB49E29078C8D5BFC11022DC55DE4940
-  - !ruby/object:ActiveModel::Attribute::FromDatabase
-    name: gias_data_hash
-    value_before_type_cast: 53ddf0fd9e5bb33ade12784f2b321f95d338947b35ac7f2ab83ee558c1454801
   - !ruby/object:ActiveModel::Attribute::FromDatabase
     name: slug
     value_before_type_cast: mandeville-primary-school

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -4,38 +4,11 @@ RSpec.describe School do
   it { is_expected.to have_many(:school_group_memberships) }
   it { is_expected.to have_many(:school_groups) }
 
-  describe "#religious_character" do
-    let(:religious_character) { "Roman Catholic" }
-    let(:gias_data) { { "ReligiousCharacter (name)" => religious_character } }
-
-    subject { build(:school, gias_data: gias_data) }
-
-    it "returns religious character" do
-      expect(subject.religious_character).to eq "Roman Catholic"
-    end
-
-    context "when the school has no religious character" do
-      let(:religious_character) { "Does not apply" }
-
-      it "returns nil" do
-        expect(subject.religious_character).to eq nil
-      end
-    end
-
-    context "when the school has no gias_data" do
-      let(:gias_data) { nil }
-
-      it "returns nil" do
-        expect(subject.religious_character).to eq nil
-      end
-    end
-  end
-
   describe "#catholic_school?" do
-    subject { build(:school, gias_data: gias_data) }
+    subject { build(:school, religious_character: religious_character) }
 
     context "when the religious character is Catholic" do
-      let(:gias_data) { { "ReligiousCharacter (name)" => "Catholic" } }
+      let(:religious_character) { "Catholic" }
 
       it "returns true" do
         expect(subject.catholic_school?).to be true
@@ -43,7 +16,7 @@ RSpec.describe School do
     end
 
     context "when the religious character is Roman Catholic" do
-      let(:gias_data) { { "ReligiousCharacter (name)" => "Roman Catholic" } }
+      let(:religious_character) { "Roman Catholic" }
 
       it "returns true" do
         expect(subject.catholic_school?).to be true
@@ -51,15 +24,7 @@ RSpec.describe School do
     end
 
     context "when the school has no religious character" do
-      let(:gias_data) { { "ReligiousCharacter (name)" => "Does not apply" } }
-
-      it "returns false" do
-        expect(subject.catholic_school?).to be false
-      end
-    end
-
-    context "when the school has no gias_data" do
-      let(:gias_data) { nil }
+      let(:religious_character) { "Does not apply" }
 
       it "returns false" do
         expect(subject.catholic_school?).to be false
@@ -68,10 +33,10 @@ RSpec.describe School do
   end
 
   describe "#ats_interstitial_variant" do
-    subject { build(:school, gias_data: gias_data) }
+    subject { build(:school, religious_character: religious_character) }
 
     context "when catholic_school? is true" do
-      let(:gias_data) { { "ReligiousCharacter (name)" => "Catholic" } }
+      let(:religious_character) { "Catholic" }
 
       it "returns catholic" do
         expect(subject.ats_interstitial_variant).to eq("catholic")
@@ -79,7 +44,7 @@ RSpec.describe School do
     end
 
     context "when faith_school? is true but not catholic" do
-      let(:gias_data) { { "ReligiousCharacter (name)" => "Church of England" } }
+      let(:religious_character) { "Church of England" }
 
       it "returns other_faith" do
         expect(subject.ats_interstitial_variant).to eq("other_faith")
@@ -87,7 +52,7 @@ RSpec.describe School do
     end
 
     context "when the school has no faith" do
-      let(:gias_data) { { "ReligiousCharacter (name)" => "Does not apply" } }
+      let(:religious_character) { "Does not apply" }
 
       it "returns non_faith" do
         expect(subject.ats_interstitial_variant).to eq("non_faith")

--- a/spec/presenters/vacancy_decorator_spec.rb
+++ b/spec/presenters/vacancy_decorator_spec.rb
@@ -290,7 +290,7 @@ RSpec.describe VacancyDecorator do
                     publisher_organisation: publisher_organisation,
                     publisher: publisher)
     end
-    let(:school) { build(:school, gias_data: { "ReligiousCharacter (name)" => "Church of England" }) }
+    let(:school) { build(:school, religious_character: "Church of England") }
     let(:organisations) { [school] }
     let(:publisher_organisation) { school }
     let(:publisher) { build_stubbed(:publisher) }

--- a/spec/queries/vacancy_filter_query_spec.rb
+++ b/spec/queries/vacancy_filter_query_spec.rb
@@ -47,9 +47,9 @@ RSpec.describe VacancyFilterQuery do
       local_authority_school = create(:school, name: "local authority", school_type: "Local authority maintained schools")
       create(:vacancy, job_title: "Vacancy 3", phases: %w[primary], job_roles: ["sendco"], organisations: [local_authority_school], enable_job_applications: true)
 
-      non_faith_school1 = create(:school, name: "nonfaith1", gias_data: { "ReligiousCharacter (name)" => "" })
-      non_faith_school2 = create(:school, name: "nonfaith2", gias_data: { "ReligiousCharacter (name)" => "Does not apply" })
-      non_faith_school3 = create(:school, name: "nonfaith3", gias_data: { "ReligiousCharacter (name)" => "None" })
+      non_faith_school1 = create(:school, name: "nonfaith1", religious_character: "None")
+      non_faith_school2 = create(:school, name: "nonfaith2", religious_character: "Does not apply")
+      non_faith_school3 = create(:school, name: "nonfaith3", religious_character: "None")
 
       create(:vacancy, :apply_via_website, job_title: "Vacancy 14", phases: %w[primary], organisations: [non_faith_school1])
       create(:vacancy, :apply_via_website, job_title: "Vacancy 15-NFV2", phases: %w[primary], organisations: [non_faith_school2])
@@ -72,8 +72,8 @@ RSpec.describe VacancyFilterQuery do
       academies = create(:academy, name: "Academy1")
       create(:vacancy, :apply_via_website, job_title: "Vacancy 5", phases: %w[primary], job_roles: ["head_of_year_or_phase"], organisations: [academies])
 
-      faith_school = create(:school, name: "Religious", gias_data: { "ReligiousCharacter (name)" => "anything" })
-      faith_school2 = create(:school, name: "Religious", gias_data: { "ReligiousCharacter (name)" => "somethingelse" })
+      faith_school = create(:school, name: "Religious", religious_character: "Christian")
+      faith_school2 = create(:school, name: "Religious2", religious_character: "Christian")
       create(:vacancy, :apply_via_website, job_title: "Vacancy 13F", phases: %w[primary], publisher_organisation: faith_school, organisations: [faith_school, faith_school2])
 
       free_school = create(:school, :free_school, name: "Freeschool1")

--- a/spec/services/search/school_search_spec.rb
+++ b/spec/services/search/school_search_spec.rb
@@ -154,10 +154,10 @@ RSpec.describe Search::SchoolSearch do
       let(:special_school4) { create(:school, name: "Academy special converter", detailed_school_type: "Academy special converter") }
       let(:special_school5) { create(:school, name: "Academy special sponsor led", detailed_school_type: "Academy special sponsor led") }
       let(:special_school6) { create(:school, name: "Non-maintained special school", detailed_school_type: "Free schools special") }
-      let(:faith_school) { create(:school, name: "Religious", gias_data: { "ReligiousCharacter (name)" => "anything" }) }
-      let(:non_faith_school1) { create(:school, name: "nonfaith1", gias_data: { "ReligiousCharacter (name)" => "" }) }
-      let(:non_faith_school2) { create(:school, name: "nonfaith2", gias_data: { "ReligiousCharacter (name)" => "Does not apply" }) }
-      let(:non_faith_school3) { create(:school, name: "nonfaith3", gias_data: { "ReligiousCharacter (name)" => "None" }) }
+      let(:faith_school) { create(:school, name: "Religious", religious_character: "Christian") }
+      let(:non_faith_school1) { create(:school, name: "nonfaith1", religious_character: "None") }
+      let(:non_faith_school2) { create(:school, name: "nonfaith2", religious_character: "Does not apply") }
+      let(:non_faith_school3) { create(:school, name: "nonfaith3", religious_character: "None") }
       let(:other_school) { create(:school, name: "other", detailed_school_type: "Something else") }
 
       context "when school_types == ['faith_school']" do

--- a/spec/system/jobseekers/jobseekers_can_search_for_jobs_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_search_for_jobs_spec.rb
@@ -327,11 +327,11 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
     let(:special_school4) { create(:school, name: "Academy special converter", detailed_school_type: "Academy special converter", geopoint: "POINT(-0.019501 51.504949)") }
     let(:special_school5) { create(:school, name: "Academy special sponsor led", detailed_school_type: "Academy special sponsor led", geopoint: "POINT(-0.019501 51.504949)") }
     let(:special_school6) { create(:school, name: "Non-maintained special school", detailed_school_type: "Free schools special", geopoint: "POINT(-0.019501 51.504949)") }
-    let(:faith_school) { create(:school, name: "Religious", gias_data: { "ReligiousCharacter (name)" => "anything" }, geopoint: "POINT(-0.019501 51.504949)") }
-    let(:faith_school2) { create(:school, name: "ABCDEF", gias_data: { "ReligiousCharacter (name)" => "somethingelse" }, geopoint: "POINT(-0.019501 51.504949)") }
-    let(:non_faith_school1) { create(:school, name: "nonfaith1", gias_data: { "ReligiousCharacter (name)" => "" }, geopoint: "POINT(-0.019501 51.504949)") }
-    let(:non_faith_school2) { create(:school, name: "nonfaith2", gias_data: { "ReligiousCharacter (name)" => "Does not apply" }, geopoint: "POINT(-0.019501 51.504949)") }
-    let(:non_faith_school3) { create(:school, name: "nonfaith3", gias_data: { "ReligiousCharacter (name)" => "None" }, geopoint: "POINT(-0.019501 51.504949)") }
+    let(:faith_school) { create(:school, name: "Religious", religious_character: "Christian", geopoint: "POINT(-0.019501 51.504949)") }
+    let(:faith_school2) { create(:school, name: "ABCDEF", religious_character: "Christian", geopoint: "POINT(-0.019501 51.504949)") }
+    let(:non_faith_school1) { create(:school, name: "nonfaith1", religious_character: "None", geopoint: "POINT(-0.019501 51.504949)") }
+    let(:non_faith_school2) { create(:school, name: "nonfaith2", religious_character: "Does not apply", geopoint: "POINT(-0.019501 51.504949)") }
+    let(:non_faith_school3) { create(:school, name: "nonfaith3", religious_character: "None", geopoint: "POINT(-0.019501 51.504949)") }
 
     let!(:special_job1) { create(:vacancy, :past_publish, job_roles: ["teacher"], job_title: "AAAA", subjects: [], organisations: [special_school1]) }
     let!(:special_job2) { create(:vacancy, :past_publish, job_roles: ["teacher"], job_title: "BBBB", subjects: [], organisations: [special_school2]) }

--- a/spec/system/jobseekers/jobseekers_can_search_for_schools_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_search_for_schools_spec.rb
@@ -112,10 +112,10 @@ RSpec.describe "Searching on the schools page" do
   end
 
   context "when filtering by school type" do
-    let(:faith_school) { create(:school, name: "Religious", gias_data: { "ReligiousCharacter (name)" => "anything" }) }
-    let(:non_faith_school1) { create(:school, name: "nonfaith1", gias_data: { "ReligiousCharacter (name)" => "" }) }
-    let(:non_faith_school2) { create(:school, name: "nonfaith2", gias_data: { "ReligiousCharacter (name)" => "Does not apply" }) }
-    let(:non_faith_school3) { create(:school, name: "nonfaith3", gias_data: { "ReligiousCharacter (name)" => "None" }) }
+    let(:faith_school) { create(:school, name: "Religious", religious_character: "Christian") }
+    let(:non_faith_school1) { create(:school, name: "nonfaith1", religious_character: "None") }
+    let(:non_faith_school2) { create(:school, name: "nonfaith2", religious_character: "Does not apply") }
+    let(:non_faith_school3) { create(:school, name: "nonfaith3", religious_character: "None") }
     let(:special_school2) { create(:school, name: "Foundation special school", detailed_school_type: "Foundation special school") }
     let(:special_school3) { create(:school, name: "Non-maintained special school", detailed_school_type: "Non-maintained special school") }
     let(:special_school4) { create(:school, name: "Academy special converter", detailed_school_type: "Academy special converter") }


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/wzqdp28P/2820-incorrect-mapping-of-religious-character-schools-for-both-cofe-and-roman-catholic-schools

## Changes in this PR:

Map religious character from GIAS, and then filter correctly by the field in the DB.

Remove gias_data and gias_data_hash from database 