### PR TITLE
Setup CORS rules on Azure Storage for Direct Uploads

### DIFF
--- a/terraform/app/modules/paas/main.tf
+++ b/terraform/app/modules/paas/main.tf
@@ -27,6 +27,17 @@ module "documents_azure_storage" {
   ]
 
   create_encryption_scope = false
+
+  # CORS rules for Rails Direct Uploads (browser to storage)
+  cors_rules = [
+    {
+      allowed_headers    = ["Content-Type", "Content-MD5", "Content-Disposition", "x-ms-blob-content-disposition", "x-ms-blob-type"]
+      allowed_methods    = ["PUT"]
+      allowed_origins    = var.azure_storage_cors_allowed_origins
+      exposed_headers    = []
+      max_age_in_seconds = 3600
+    }
+  ]
 }
 
 # Azure Storage Account for School Images/Logos

--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -122,6 +122,11 @@ variable "azure_storage_blob_delete_after_days" {
   description = "Auto-delete blobs after X days (0 to disable)"
 }
 
+variable "azure_storage_cors_allowed_origins" {
+  default     = []
+  description = "Allowed origins (URLs) for Cross Origin Resource Sharing (CORS) rule"
+}
+
 locals {
   postgres_ssl_mode = var.enable_postgres_ssl ? "require" : "disable"
 

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -95,6 +95,7 @@ module "paas" {
   azure_storage_blob_delete_retention_days  = var.azure_storage_blob_delete_retention_days
   azure_storage_blob_versioning_enabled     = var.azure_storage_blob_versioning_enabled
   azure_storage_blob_delete_after_days      = var.azure_storage_blob_delete_after_days
+  azure_storage_cors_allowed_origins        = var.azure_storage_cors_allowed_origins
 }
 
 module "statuscake" {

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -186,6 +186,11 @@ variable "azure_storage_blob_delete_after_days" {
   description = "Auto-delete blobs after X days (0 to disable)"
 }
 
+variable "azure_storage_cors_allowed_origins" {
+  default     = []
+  description = "Allowed origins (URLs) for Cross Origin Resource Sharing (CORS) rule"
+}
+
 locals {
   app_env_values             = yamldecode(file("${path.module}/../workspace-variables/${var.app_environment}_app_env.yml"))
   infra_secrets              = yamldecode(data.aws_ssm_parameter.infra_secrets.value)

--- a/terraform/workspace-variables/production.tfvars.json
+++ b/terraform/workspace-variables/production.tfvars.json
@@ -89,5 +89,6 @@
   "azure_storage_production_replication_type": "ZRS",
   "azure_storage_blob_delete_retention_days": 7,
   "azure_storage_blob_versioning_enabled": true,
-  "azure_storage_blob_delete_after_days": 0
+  "azure_storage_blob_delete_after_days": 0,
+  "azure_storage_cors_allowed_origins": ["https://teaching-vacancies.service.gov.uk"]
 }

--- a/terraform/workspace-variables/qa.tfvars.json
+++ b/terraform/workspace-variables/qa.tfvars.json
@@ -21,5 +21,6 @@
   "enable_logit": true,
   "azure_storage_blob_delete_retention_days": 7,
   "azure_storage_blob_versioning_enabled": false,
-  "azure_storage_blob_delete_after_days": 0
+  "azure_storage_blob_delete_after_days": 0,
+  "azure_storage_cors_allowed_origins": ["https://qa.teaching-vacancies.service.gov.uk"]
 }

--- a/terraform/workspace-variables/review.tfvars.json
+++ b/terraform/workspace-variables/review.tfvars.json
@@ -21,5 +21,6 @@
   "dataset_name": "staging_dataset",
   "azure_storage_blob_delete_retention_days": null,
   "azure_storage_blob_versioning_enabled": false,
-  "azure_storage_blob_delete_after_days": 7
+  "azure_storage_blob_delete_after_days": 7,
+  "azure_storage_cors_allowed_origins": ["https://*.test.teacherservices.cloud"]
 }

--- a/terraform/workspace-variables/staging.tfvars.json
+++ b/terraform/workspace-variables/staging.tfvars.json
@@ -27,5 +27,6 @@
   "dataset_name": "staging_dataset",
   "azure_storage_blob_delete_retention_days": 7,
   "azure_storage_blob_versioning_enabled": false,
-  "azure_storage_blob_delete_after_days": 0
+  "azure_storage_blob_delete_after_days": 0,
+  "azure_storage_cors_allowed_origins": ["https://staging.teaching-vacancies.service.gov.uk"]
 }


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/HlgDC5Gp/2825-message-file-attachments-failing-in-review-qa-production
- https://trello.com/c/IdNp4YfN/2667-file-attachment-error-in-candidate-message-section-ats-evaluation-march-2026

## Changes in this PR:

Set up CORS rules in Terraform that will persist across deployments.

They will allow Direct Uploads (Browser -> Storage server) in all our environments.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
