### PR TITLE
Disable Attachment buton on Trix editor

### DIFF
--- a/app/assets/stylesheets/actiontext.scss
+++ b/app/assets/stylesheets/actiontext.scss
@@ -41,6 +41,7 @@ trix-toolbar .trix-button:focus {
 }
 
 /* Hide unwanted toolbar buttons - keep only bold, italic, link, bullet points, undo/redo */
+trix-toolbar .trix-button-group--file-tools,
 trix-toolbar .trix-button--icon-strike,
 trix-toolbar .trix-button--icon-heading-1,
 trix-toolbar .trix-button--icon-quote,
@@ -99,8 +100,7 @@ trix-editor {
   min-height: 350px;
 }
 
-/* Hide attachment and link buttons only on personal statement form */
-.personal-statement-form trix-toolbar .trix-button--icon-attach,
+/* Hide link buttons on personal statement form */
 .personal-statement-form trix-toolbar .trix-button--icon-link {
   display: none !important;
 }

--- a/app/assets/stylesheets/actiontext.scss
+++ b/app/assets/stylesheets/actiontext.scss
@@ -100,8 +100,9 @@ trix-editor {
   min-height: 350px;
 }
 
-/* Hide link buttons on personal statement form */
-.personal-statement-form trix-toolbar .trix-button--icon-link {
+/* Hide link buttons on job application personal statement and profile about you (personal statement) forms */
+.personal-statement-form trix-toolbar .trix-button--icon-link,
+.about-you-form trix-toolbar .trix-button--icon-link {
   display: none !important;
 }
 

--- a/app/views/jobseekers/profiles/about_you/edit.html.slim
+++ b/app/views/jobseekers/profiles/about_you/edit.html.slim
@@ -15,7 +15,7 @@
       - t(".page_description_items").each do |item|
         li.govuk-list-item = item
 
-    = tag.div data: { controller: "word-counter", word_counter_max_words_value: "1500" }
+    = tag.div class: "about-you-form", data: { controller: "word-counter", word_counter_max_words_value: "1500" }
       .govuk-form-group
         = f.rich_text_area :about_you, aria: { label: t("helpers.label.jobseekers_profile_about_you_form.about_you") }, data: { word_counter_target: "editor" }
         noscript


### PR DESCRIPTION


## Trello card URL

https://trello.com/c/i1yj8RsT

## Changes in this PR:

Temporarily, since the ActiveStorage Direct Uploads feature is blocked due to a lack of CORS configuration in Azure Storage accounts.

Edit: Also remove the link button from the Profile Personal Statement editor.

## Screenshots of UI changes:

### Before

#### Messages
<img width="853" height="374" alt="image" src="https://github.com/user-attachments/assets/6d584c77-a9ec-4d95-a456-17f809a7d971" />

#### Profile personal statement
<img width="858" height="666" alt="image" src="https://github.com/user-attachments/assets/2bbb26dd-9767-4e5f-bfb8-93e8fdb2c4ae" />


### After

#### Messages
<img width="852" height="362" alt="image" src="https://github.com/user-attachments/assets/3ac1790a-b1e0-48d0-ac8b-215758b1e73f" />

#### Profile Personal Statement
<img width="858" height="666" alt="image" src="https://github.com/user-attachments/assets/1f17ce03-a284-479c-804a-8a94fdf61851" />


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
