### PR TITLE
Remove jobseeker_profile_id from training_and_cpds table

### DIFF
--- a/app/models/training_and_cpd.rb
+++ b/app/models/training_and_cpd.rb
@@ -1,6 +1,4 @@
 class TrainingAndCpd < ApplicationRecord
-  self.ignored_columns += %w[jobseeker_profile_id]
-
   belongs_to :job_application
 
   def duplicate

--- a/db/migrate/20260429095634_drop_jobseeker_profile_id_from_training_and_cpds.rb
+++ b/db/migrate/20260429095634_drop_jobseeker_profile_id_from_training_and_cpds.rb
@@ -1,0 +1,5 @@
+class DropJobseekerProfileIdFromTrainingAndCpds < ActiveRecord::Migration[8.0]
+  def change
+    safety_assured { remove_column :training_and_cpds, :jobseeker_profile_id, :uuid }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -826,7 +826,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_30_131102) do
     t.string "year_awarded"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "jobseeker_profile_id"
     t.uuid "job_application_id", null: false
     t.string "course_length"
     t.index ["job_application_id"], name: "index_training_and_cpds_on_job_application_id"

--- a/spec/factories/training_and_cpds.rb
+++ b/spec/factories/training_and_cpds.rb
@@ -6,6 +6,6 @@ FactoryBot.define do
     year_awarded { "2020" }
     course_length { "1 year" }
 
-    association :job_application
+    job_application
   end
 end

--- a/spec/factories/training_and_cpds.rb
+++ b/spec/factories/training_and_cpds.rb
@@ -6,6 +6,6 @@ FactoryBot.define do
     year_awarded { "2020" }
     course_length { "1 year" }
 
-    job_application { nil }
+    association :job_application
   end
 end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/fpnECSLC/2673-profile-training-and-cpd-journey

## Changes in this PR:

This PR removes jobseeker_profile_id from the training_and_cpds table and does some final tidying up

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
