### PR TITLE
can't didplay form detail on vacancy template

### DIFF
--- a/app/views/publishers/vacancy_templates/show.html.slim
+++ b/app/views/publishers/vacancy_templates/show.html.slim
@@ -43,11 +43,5 @@ h1.govuk-heading-xl = @template.name
 
   = render "application_form_type", summary_list: summary_list, template: @template
 
-  / we ask these questions separately, so its possible to have an empty link here
-  - if @template.website? && @template.application_link.present?
-    = render "website", summary_list: summary_list, template: @template
-  - elsif @template.uploaded_form?
-    = render "uploaded_form", summary_list: summary_list, template: @template
-
   - if @template.allow_job_applications?
     = render "anonymise_applications", summary_list: summary_list, template: @template

--- a/spec/factories/vacancy_templates.rb
+++ b/spec/factories/vacancy_templates.rb
@@ -28,5 +28,10 @@ FactoryBot.define do
     trait :it_support do
       job_roles { %w[it_support] }
     end
+
+    trait :website do
+      enable_job_applications { false }
+      receive_applications { :website }
+    end
   end
 end

--- a/spec/views/publishers/vacancy_templates/show.html.slim_spec.rb
+++ b/spec/views/publishers/vacancy_templates/show.html.slim_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe "publishers/vacancy_templates/show" do
+  before do
+    assign :template, vacancy_template
+    render
+  end
+
+  context "with a website type" do
+    let(:vacancy_template) { build_stubbed(:vacancy_template, :website) }
+
+    it "shows the 'other' type" do
+      expect(rendered).to have_content("Other")
+    end
+  end
+end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/EGOl9gJt/2832-undefined-method-applicationlink-for-an-instance-of-vacancytemplate

## Changes in this PR:

Remove detail rendering for external application templates