### PR TITLE
editing template subjects

### DIFF
--- a/app/controllers/publishers/build_vacancy_templates_controller.rb
+++ b/app/controllers/publishers/build_vacancy_templates_controller.rb
@@ -22,7 +22,7 @@ module Publishers
     end
 
     def update
-      @form = form_class.load_from_params(params.fetch(form_key, {}).permit(form_class.fields), @template, current_publisher: current_publisher)
+      @form = form_class.load_from_params(form_params.permit(form_class.fields), @template, current_publisher: current_publisher)
 
       if @form.valid?
         @template.update!(@form.params_to_save)
@@ -48,8 +48,12 @@ module Publishers
       params["save_and_finish_later"] == "true"
     end
 
+    def form_params
+      params.fetch(form_key, {})
+    end
+
     def back_to_show?
-      params[form_key]["back_to_show"] == "true"
+      form_params["back_to_show"] == "true"
     end
 
     def form_key

--- a/app/form_models/publishers/job_listing/subjects_form.rb
+++ b/app/form_models/publishers/job_listing/subjects_form.rb
@@ -15,6 +15,6 @@ class Publishers::JobListing::SubjectsForm < Publishers::JobListing::JobListingF
   attr_accessor(*FIELDS)
 
   def params_to_save
-    { subjects: subjects }
+    { subjects: subjects.compact_blank }
   end
 end

--- a/app/views/publishers/build_vacancy_templates/subjects.html.slim
+++ b/app/views/publishers/build_vacancy_templates/subjects.html.slim
@@ -16,7 +16,7 @@
         :first,
         :last,
         legend: nil,
-        include_hidden: false,
+        include_hidden: true,
         hint: nil,
         classes: "checkbox-label__bold"),
         collection_count: SUBJECT_OPTIONS.count,

--- a/spec/factories/vacancy_templates.rb
+++ b/spec/factories/vacancy_templates.rb
@@ -23,6 +23,8 @@ FactoryBot.define do
 
     trait :secondary do
       phases { %w[secondary] }
+      key_stages { %w[ks3] }
+      subjects { factory_sample(SUBJECT_OPTIONS, 2).map(&:first).sort }
     end
 
     trait :it_support do

--- a/spec/system/publishers/publishers_can_edit_a_vacancy_template_spec.rb
+++ b/spec/system/publishers/publishers_can_edit_a_vacancy_template_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Editing a vacancy template" do
   let(:publisher) { create(:publisher) }
-  let(:template) { create(:vacancy_template, organisation: organisation) }
+  let(:template) { create(:vacancy_template, :secondary, organisation: organisation, subjects: %w[Chemistry]) }
   let(:organisation) { create(:school) }
   let(:template_name) { Faker::Movie.title }
 
@@ -22,176 +22,169 @@ RSpec.describe "Editing a vacancy template" do
     }.to change(VacancyTemplate, :count).by(-1)
   end
 
-  describe "accessibility of change pages" do
-    it "can have its name edited from the template show page", :a11y do
-      expect(page).to have_content "Change"
-
-      within "#name" do
+  describe "accessibility of change pages", :a11y do
+    before do
+      within "##{change}" do
         click_on "Change"
       end
-
-      expect(page).to have_content "Template name"
-      expect(page).to be_axe_clean
-
-      fill_in "Template name", with: template_name
-      click_on I18n.t("publishers.vacancies.show.heading_component.action.copy")
-      expect(page).to have_content "Template details"
-      expect(page).to have_content template_name
-      expect(template.reload).to have_attributes(name: template_name)
     end
 
-    it "can have its role edited", :a11y do
-      expect(page).to have_content "Change"
+    context "with name" do
+      let(:change) { "name" }
 
-      within "#job_role" do
-        click_on "Change"
+      it "can have its name edited from the template show page" do
+        expect(page).to have_content "Template name"
+        expect(page).to be_axe_clean
+
+        fill_in "Template name", with: template_name
+        click_on I18n.t("publishers.vacancies.show.heading_component.action.copy")
+        expect(page).to have_content "Template details"
+        expect(page).to have_content template_name
+        expect(template.reload).to have_attributes(name: template_name)
       end
-
-      expect(page).to have_content "What type of job is this?"
-      expect(page).to be_axe_clean
-
-      check "Headteacher"
-      click_on I18n.t("buttons.save_and_continue")
-
-      expect(page).to have_content "Headteacher"
-      expect(template.reload).to have_attributes(job_roles: %w[teacher headteacher])
     end
 
-    it "can have its key_stages edited", :a11y do
-      expect(page).to have_content "Change"
+    context "with role" do
+      let(:change) { "job_role" }
 
-      within "#key_stages" do
-        click_on "Change"
+      it "can have its role edited" do
+        expect(page).to have_content "What type of job is this?"
+        expect(page).to be_axe_clean
+
+        check "Headteacher"
+        click_on I18n.t("buttons.save_and_continue")
+
+        expect(page).to have_content "Headteacher"
+        expect(template.reload).to have_attributes(job_roles: %w[teacher headteacher])
       end
-
-      expect(page).to have_content "Key stages"
-      expect(page).to be_axe_clean
-
-      check "Key stage 2"
-      click_on I18n.t("buttons.save_and_continue")
-
-      expect(page).to have_content "Key stage 2"
-      expect(template.reload).to have_attributes(key_stages: %w[ks1 ks2])
     end
 
-    it "can have its contract type edited", :a11y do
-      expect(page).to have_content "Change"
+    context "with subjects" do
+      let(:change) { "subjects" }
 
-      within "#contract_type" do
-        click_on "Change"
+      it "can have its subjects edited to nothing" do
+        expect(page).to have_content "Subjects (optional)"
+        expect(page).to be_axe_clean
+
+        uncheck "Chemistry"
+        click_on I18n.t("buttons.save_and_continue")
+
+        expect(page).to have_no_content "Chemistry"
+        expect(template.reload).to have_attributes(subjects: [])
       end
-
-      expect(page).to have_content "Contract information"
-      #  https://github.com/alphagov/govuk-frontend/issues/979
-      expect(page).to be_axe_clean.skipping "aria-allowed-attr"
-
-      choose "Permanent"
-      click_on I18n.t("buttons.save_and_continue")
-
-      expect(page).to have_content "Permanent"
-      expect(template.reload).to have_attributes(contract_type: "permanent")
     end
 
-    it "can have its salary edited", :a11y do
-      expect(page).to have_content "Change"
+    context "with key_stages" do
+      let(:change) { "key_stages" }
 
-      within "#salary" do
-        click_on "Change"
+      it "can have its key_stages edited" do
+        expect(page).to have_content "Key stages"
+        expect(page).to be_axe_clean
+
+        check "Key stage 4"
+        click_on I18n.t("buttons.save_and_continue")
+
+        expect(page).to have_content "Key stage 4"
+        expect(template.reload).to have_attributes(key_stages: %w[ks3 ks4])
       end
-
-      expect(page).to have_content "Salary details"
-      #  https://github.com/alphagov/govuk-frontend/issues/979
-      expect(page).to be_axe_clean.skipping "aria-allowed-attr"
-
-      uncheck "Full-time equivalent salary"
-
-      check "Pay scale"
-      fill_in "Pay scale", with: "M1 to M2"
-      click_on I18n.t("buttons.save_and_continue")
-
-      expect(page).to have_content "M1 to M2"
-      expect(template.reload).to have_attributes(pay_scale: "M1 to M2")
     end
 
-    it "has an accessible ECT page", :a11y do
-      expect(page).to have_content "Change"
+    context "with contract_type" do
+      let(:change) { "contract_type" }
 
-      within "#ect_status" do
-        click_on "Change"
+      it "can have its contract type edited" do
+        expect(page).to have_content "Contract information"
+        #  https://github.com/alphagov/govuk-frontend/issues/979
+        expect(page).to be_axe_clean.skipping "aria-allowed-attr"
+
+        choose "Permanent"
+        click_on I18n.t("buttons.save_and_continue")
+
+        expect(page).to have_content "Permanent"
+        expect(template.reload).to have_attributes(contract_type: "permanent")
       end
-
-      expect(page).to have_content "Is this role suitable for an early career teacher"
-      #  https://github.com/alphagov/govuk-frontend/issues/979
-      expect(page).to be_axe_clean.skipping "aria-allowed-attr"
     end
 
-    it "can have its ect status edited" do
-      expect(page).to have_content "Change"
+    context "with salary" do
+      let(:change) { "salary" }
 
-      within "#ect_status" do
-        click_on "Change"
+      it "can have its salary edited" do
+        expect(page).to have_content "Salary details"
+        #  https://github.com/alphagov/govuk-frontend/issues/979
+        expect(page).to be_axe_clean.skipping "aria-allowed-attr"
+
+        uncheck "Full-time equivalent salary"
+
+        check "Pay scale"
+        fill_in "Pay scale", with: "M1 to M2"
+        click_on I18n.t("buttons.save_and_continue")
+
+        expect(page).to have_content "M1 to M2"
+        expect(template.reload).to have_attributes(pay_scale: "M1 to M2")
       end
-
-      expect(page).to have_content "Is this role suitable for an early career teacher"
-
-      within ".ect-status-radios" do
-        choose "No"
-      end
-      click_on I18n.t("buttons.save_and_continue")
-
-      expect(page).to have_current_path organisation_vacancy_template_path(template)
-      expect(template.reload).to have_attributes(ect_status: "ect_unsuitable")
     end
 
-    it "can have its school visits edited", :a11y do
-      expect(page).to have_content "Change"
+    context "with ect status" do
+      let(:change) { "ect_status" }
 
-      within "#school_visits" do
-        click_on "Change"
+      it "can have its ect status edited" do
+        expect(page).to have_content "Is this role suitable for an early career teacher"
+        #  https://github.com/alphagov/govuk-frontend/issues/979
+        expect(page).to be_axe_clean.skipping "aria-allowed-attr"
+
+        within ".ect-status-radios" do
+          choose "No"
+        end
+        click_on I18n.t("buttons.save_and_continue")
+
+        expect(page).to have_current_path organisation_vacancy_template_path(template)
+        expect(template.reload).to have_attributes(ect_status: "ect_unsuitable")
       end
-
-      expect(page).to have_content "Do you want to offer school visits?"
-      expect(page).to be_axe_clean.skipping "aria-allowed-attr"
-
-      choose "Yes"
-      click_on I18n.t("buttons.save_and_continue")
-
-      expect(page).to have_current_path organisation_vacancy_template_path(template)
-      expect(template.reload).to have_attributes(school_visits: true)
     end
 
-    it "can have its visa_sponsorship_available edited", :a11y do
-      expect(page).to have_content "Change"
+    context "with school visits" do
+      let(:change) { "school_visits" }
 
-      within "#visa_sponsorship_available" do
-        click_on "Change"
+      it "can have its school visits edited" do
+        expect(page).to have_content "Do you want to offer school visits?"
+        expect(page).to be_axe_clean.skipping "aria-allowed-attr"
+
+        choose "Yes"
+        click_on I18n.t("buttons.save_and_continue")
+
+        expect(page).to have_current_path organisation_vacancy_template_path(template)
+        expect(template.reload).to have_attributes(school_visits: true)
       end
-
-      expect(page).to have_content "Visa sponsorship"
-      expect(page).to be_axe_clean.skipping "aria-allowed-attr"
-
-      choose "Yes"
-      click_on I18n.t("buttons.save_and_continue")
-
-      expect(page).to have_current_path organisation_vacancy_template_path(template)
-      expect(template.reload).to have_attributes(visa_sponsorship_available: true)
     end
 
-    it "can have its application type edited", :a11y, :retry do
-      expect(page).to have_content "Change"
+    context "with visa_sponsorship_available" do
+      let(:change) { "visa_sponsorship_available" }
 
-      within "#enable_job_applications" do
-        click_on "Change"
+      it "can have its visa_sponsorship_available edited", :a11y do
+        expect(page).to have_content "Visa sponsorship"
+        expect(page).to be_axe_clean.skipping "aria-allowed-attr"
+
+        choose "Yes"
+        click_on I18n.t("buttons.save_and_continue")
+
+        expect(page).to have_current_path organisation_vacancy_template_path(template)
+        expect(template.reload).to have_attributes(visa_sponsorship_available: true)
       end
+    end
 
-      expect(page).to have_content "Choose your application form"
-      expect(page).to be_axe_clean.skipping "aria-allowed-attr"
+    context "with application type" do
+      let(:change) { "enable_job_applications" }
 
-      choose "Use other application form"
-      click_on I18n.t("buttons.save_and_continue")
+      it "can have its application type edited", :retry do
+        expect(page).to have_content "Choose your application form"
+        expect(page).to be_axe_clean.skipping "aria-allowed-attr"
 
-      expect(page).to have_current_path organisation_vacancy_template_path(template)
-      expect(template.reload).to have_attributes(enable_job_applications: false)
+        choose "Use other application form"
+        click_on I18n.t("buttons.save_and_continue")
+
+        expect(page).to have_current_path organisation_vacancy_template_path(template)
+        expect(template.reload).to have_attributes(enable_job_applications: false)
+      end
     end
   end
 

--- a/spec/system/publishers/publishers_can_send_messages_to_applicants_spec.rb
+++ b/spec/system/publishers/publishers_can_send_messages_to_applicants_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe "Publishers can send messages to job applicants" do
 
       after { logout }
 
-      it "passes accessibility checks", :a11y do
+      it "passes accessibility checks", :a11y, :retry do
         # wait for page load
         expect(page).to have_text("Hello from publisher")
         expect(page).to be_axe_clean


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/BLzV51Ee/2834-sentry-allow-vacancy-template-subjects-to-be-editable

## Changes in this PR:

Fix up editing of template subjects, and allow the list of subjects to be empty