### PR TITLE
Remove ignoring columns from Profile Employments

### DIFF
--- a/app/models/profile_employment.rb
+++ b/app/models/profile_employment.rb
@@ -4,4 +4,17 @@ class ProfileEmployment < EmploymentRecord
   has_encrypted :organisation, :job_title
 
   self.table_name = "employments"
+
+  # This model was originally ignoring the following columns from the employments table:
+  # - main_duties
+  # - subjects
+  # -reason_for_leaving
+  # These columns have no use in the profile employment model.
+  #
+  # Unfortunately, this results in the DfE Analytics entity updates not including those keys, causing an inconsistency in
+  # 'employments' entity schema in DfE Analytics. As 'Employment' and 'ProfileEmployment' models share the same table,
+  # but send different columns to DfE Analytics.
+  #
+  # TO DO: Check if we can ignore the unneeded columns again.After the Analytics entity feeding has been moved to
+  # Airbyte (DB -> Analytics direct updates).
 end

--- a/app/models/profile_employment.rb
+++ b/app/models/profile_employment.rb
@@ -4,7 +4,4 @@ class ProfileEmployment < EmploymentRecord
   has_encrypted :organisation, :job_title
 
   self.table_name = "employments"
-
-  # these fields are not used in the profile version
-  self.ignored_columns += %i[main_duties subjects reason_for_leaving]
 end


### PR DESCRIPTION
## Trello card URL
Resolving an issue raised by a Performance Analyst.

## Changes in this PR:

Having two models using the same DB table and one of the models ignoring a subset of the table attributes results in DfE Analytics entities missing the keys in some of the employment rows, but not in others. What is effectively an inconsistent schema for the employments table in BigQ.

The PA alerted us about the issue and how BigQ as it is configured in Analytics cannot deal with this, breaking the analytics pipelines.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
