### PR TITLE
create template from legacy vacancy

### DIFF
--- a/app/controllers/publishers/vacancies/copy_controller.rb
+++ b/app/controllers/publishers/vacancies/copy_controller.rb
@@ -8,15 +8,7 @@ module Publishers
       end
 
       def create
-        @form = current_organisation.vacancy_templates.create(
-          vacancy.attributes
-                 .except(*(VacancyTemplate::IGNORED_ATTRIBUTES + %w[job_roles key_stages phases working_patterns]))
-                 .merge(copy_vacancy_params)
-                 .merge(job_roles: vacancy.job_roles,
-                        phases: vacancy.phases,
-                        working_patterns: vacancy.working_patterns,
-                        key_stages: vacancy.key_stages),
-        )
+        @form = create_template vacancy
         if @form.valid?
           redirect_to organisation_vacancy_templates_path, success: t("publishers.vacancies.show.copied.success")
         else
@@ -25,6 +17,26 @@ module Publishers
       end
 
       private
+
+      # rubocop can't seem to see that the caller check the return from this method
+      # rubocop:disable Rails/SaveBang
+      def create_template(vacancy)
+        receive_applications = if VacancyTemplate.receive_applications.key?(vacancy.receive_applications)
+                                 vacancy.receive_applications
+                               end
+
+        current_organisation.vacancy_templates.create(
+          vacancy.attributes
+                 .except(*(VacancyTemplate::IGNORED_ATTRIBUTES + %w[job_roles key_stages phases working_patterns receive_applications]))
+                 .merge(copy_vacancy_params)
+                 .merge(job_roles: vacancy.job_roles,
+                        phases: vacancy.phases,
+                        working_patterns: vacancy.working_patterns,
+                        key_stages: vacancy.key_stages,
+                        receive_applications: receive_applications),
+        )
+      end
+      # rubocop:enable Rails/SaveBang
 
       def copy_vacancy_params
         params.expect(vacancy_template: [:name])

--- a/spec/requests/publishers/vacancies/copy_spec.rb
+++ b/spec/requests/publishers/vacancies/copy_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "Publishers::Vacancies::CopyController" do
 
   describe "POST #create" do
     let(:name) { Faker::CryptoCoin.coin_name }
+    let(:new_template) { VacancyTemplate.last }
 
     context "with a simple vacancy" do
       let(:vacancy) { create(:vacancy, :no_tv_applications, organisations: [organisation]) }
@@ -25,6 +26,7 @@ RSpec.describe "Publishers::Vacancies::CopyController" do
         expect {
           post organisation_job_copy_path(vacancy.id, params: { vacancy_template: { name: name } })
         }.to change(VacancyTemplate, :count).by(1)
+        expect(new_template).to have_attributes(name: name, receive_applications: "website")
       end
     end
 
@@ -35,7 +37,7 @@ RSpec.describe "Publishers::Vacancies::CopyController" do
         expect {
           post organisation_job_copy_path(vacancy.id, params: { vacancy_template: { name: name } })
         }.to change(VacancyTemplate, :count).by(1)
-        expect(VacancyTemplate.last).to have_attributes(name: name, receive_applications: nil)
+        expect(new_template).to have_attributes(name: name, receive_applications: nil)
       end
     end
   end

--- a/spec/requests/publishers/vacancies/copy_spec.rb
+++ b/spec/requests/publishers/vacancies/copy_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Publishers::Vacancies::CopyController" do
+  let(:organisation) { create(:school) }
+  let(:publisher) { create(:publisher, accepted_terms_at: 1.day.ago) }
+
+  # rubocop:disable RSpec/AnyInstance
+  before do
+    allow_any_instance_of(ApplicationController).to receive(:current_organisation).and_return(organisation)
+    sign_in(publisher, scope: :publisher)
+  end
+  # rubocop:enable RSpec/AnyInstance
+
+  after { sign_out(publisher) }
+
+  describe "POST #create" do
+    let(:name) { Faker::CryptoCoin.coin_name }
+
+    context "with a simple vacancy" do
+      let(:vacancy) { create(:vacancy, organisations: [organisation]) }
+
+      it "copies a vacancy into a template" do
+        expect {
+          post organisation_job_copy_path(vacancy.id, params: { vacancy_template: { name: name } })
+        }.to change(VacancyTemplate, :count).by(1)
+      end
+    end
+
+    context "with a legacy email vacancy" do
+      let(:vacancy) { create(:vacancy, :legacy_email_application, organisations: [organisation]) }
+
+      it "copies a vacancy into a template" do
+        expect {
+          post organisation_job_copy_path(vacancy.id, params: { vacancy_template: { name: name } })
+        }.to change(VacancyTemplate, :count).by(1)
+        expect(VacancyTemplate.last).to have_attributes(name: name, receive_applications: nil)
+      end
+    end
+  end
+end

--- a/spec/requests/publishers/vacancies/copy_spec.rb
+++ b/spec/requests/publishers/vacancies/copy_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Publishers::Vacancies::CopyController" do
     let(:name) { Faker::CryptoCoin.coin_name }
 
     context "with a simple vacancy" do
-      let(:vacancy) { create(:vacancy, organisations: [organisation]) }
+      let(:vacancy) { create(:vacancy, :no_tv_applications, organisations: [organisation]) }
 
       it "copies a vacancy into a template" do
         expect {


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/Fqk1s3te/2835-copying-old-email-vacancy-into-template-is-not-valid

## Changes in this PR:

Allow vacancy template to be created from email vacancy