### PR TITLE
Peak times may email

### DIFF
--- a/app/mailers/jobseekers/peak_times_mailer.rb
+++ b/app/mailers/jobseekers/peak_times_mailer.rb
@@ -7,7 +7,7 @@ class Jobseekers::PeakTimesMailer < Jobseekers::BaseMailer
   def reminder(jobseeker_id)
     @jobseeker = Jobseeker.includes(jobseeker_profile: :personal_details).find_by(id: jobseeker_id)
 
-    if current_month == "march" || current_month == "may"
+    if %w[march may].include?(current_month)
       send_notify_template_email
     else
       send_standard_email

--- a/app/mailers/jobseekers/peak_times_mailer.rb
+++ b/app/mailers/jobseekers/peak_times_mailer.rb
@@ -1,8 +1,19 @@
 class Jobseekers::PeakTimesMailer < Jobseekers::BaseMailer
   helper_method :jobseeker, :first_name, :campaign_url, :campaign_key
 
-  MARCH_PEAK_TIMES_TEMPLATE_ID = "ebad6edf-99a5-4072-951f-f01c1178cdae".freeze
-  MAY_PEAK_TIMES_TEMPLATE_ID = "084ff736-1802-4409-87b3-2826ee04eac3".freeze
+  PEAK_TIMES_CAMPAIGNS = {
+    "march" => {
+      template_id: "ebad6edf-99a5-4072-951f-f01c1178cdae",
+      url: "https://teaching-vacancies.service.gov.uk/jobs?utm_source=notify&utm_medium=email&utm_campaign=peak_email&utm_content=march_2026",
+    },
+    "may" => {
+      template_id: "084ff736-1802-4409-87b3-2826ee04eac3",
+      url: "https://teaching-vacancies.service.gov.uk/jobs?utm_source=notify&utm_medium=email&utm_campaign=peak_email&utm_content=may_2026",
+    },
+    "november" => {
+      url: "https://teaching-vacancies.service.gov.uk/jobs?utm_source=notify&utm_medium=email&utm_campaign=notify_november_2025&utm_content=tuesday_2025",
+    },
+  }.freeze
 
   def reminder(jobseeker_id)
     @jobseeker = Jobseeker.includes(jobseeker_profile: :personal_details).find_by(id: jobseeker_id)
@@ -17,9 +28,8 @@ class Jobseekers::PeakTimesMailer < Jobseekers::BaseMailer
   private
 
   def send_notify_template_email
-    template_id = current_month == "march" ? MARCH_PEAK_TIMES_TEMPLATE_ID : MAY_PEAK_TIMES_TEMPLATE_ID
     template_mail(
-      template_id,
+      PEAK_TIMES_CAMPAIGNS[current_month][:template_id],
       to: @jobseeker.email,
       personalisation: {
         campaign_url: campaign_url,
@@ -39,16 +49,7 @@ class Jobseekers::PeakTimesMailer < Jobseekers::BaseMailer
   end
 
   def campaign_url
-    case current_month
-    when "may"
-      "https://teaching-vacancies.service.gov.uk/jobs?utm_source=notify&utm_medium=email&utm_campaign=peak_email&utm_content=may_2026"
-    when "november"
-      "https://teaching-vacancies.service.gov.uk/jobs?utm_source=notify&utm_medium=email&utm_campaign=notify_november_2025&utm_content=tuesday_2025"
-    when "march"
-      "https://teaching-vacancies.service.gov.uk/jobs?utm_source=notify&utm_medium=email&utm_campaign=peak_email&utm_content=march_2026"
-    else
-      "https://teaching-vacancies.service.gov.uk/"
-    end
+    PEAK_TIMES_CAMPAIGNS.fetch(current_month, {}).fetch(:url, "https://teaching-vacancies.service.gov.uk/")
   end
 
   def campaign_key

--- a/app/mailers/jobseekers/peak_times_mailer.rb
+++ b/app/mailers/jobseekers/peak_times_mailer.rb
@@ -28,11 +28,15 @@ class Jobseekers::PeakTimesMailer < Jobseekers::BaseMailer
   end
 
   def send_standard_email
-    first_name = @jobseeker.jobseeker_profile&.personal_details&.first_name
-    subject = if first_name.present?
-                I18n.t("jobseekers.peak_times_mailer.#{campaign_key}.subject", first_name: first_name)
+    subject = if current_month == "may"
+                I18n.t("jobseekers.peak_times_mailer.#{campaign_key}.subject")
               else
-                I18n.t("jobseekers.peak_times_mailer.#{campaign_key}.nameless_subject")
+                first_name = @jobseeker.jobseeker_profile&.personal_details&.first_name
+                if first_name.present?
+                  I18n.t("jobseekers.peak_times_mailer.#{campaign_key}.subject", first_name: first_name)
+                else
+                  I18n.t("jobseekers.peak_times_mailer.#{campaign_key}.nameless_subject")
+                end
               end
     send_email(to: @jobseeker.email, subject:)
   end
@@ -40,7 +44,7 @@ class Jobseekers::PeakTimesMailer < Jobseekers::BaseMailer
   def campaign_url
     case current_month
     when "may"
-      "https://teaching-vacancies.service.gov.uk/?utm_source=Notify&utm_medium=email&utm_campaign=#{current_month}_peak_notify&utm_id=#{current_month}_peak_notify"
+      "https://teaching-vacancies.service.gov.uk/jobs?utm_source=notify&utm_medium=email&utm_campaign=peak_email&utm_content=may_2026"
     when "november"
       "https://teaching-vacancies.service.gov.uk/jobs?utm_source=notify&utm_medium=email&utm_campaign=notify_november_2025&utm_content=tuesday_2025"
     when "march"

--- a/app/mailers/jobseekers/peak_times_mailer.rb
+++ b/app/mailers/jobseekers/peak_times_mailer.rb
@@ -1,14 +1,14 @@
 class Jobseekers::PeakTimesMailer < Jobseekers::BaseMailer
   helper_method :jobseeker, :first_name, :campaign_url, :campaign_key
 
-  # Notify template ID for March peak times email
   MARCH_PEAK_TIMES_TEMPLATE_ID = "ebad6edf-99a5-4072-951f-f01c1178cdae".freeze
+  MAY_PEAK_TIMES_TEMPLATE_ID = "084ff736-1802-4409-87b3-2826ee04eac3".freeze
 
   def reminder(jobseeker_id)
     @jobseeker = Jobseeker.includes(jobseeker_profile: :personal_details).find_by(id: jobseeker_id)
 
-    if current_month == "march"
-      send_march_template_email
+    if current_month == "march" || current_month == "may"
+      send_notify_template_email
     else
       send_standard_email
     end
@@ -16,9 +16,10 @@ class Jobseekers::PeakTimesMailer < Jobseekers::BaseMailer
 
   private
 
-  def send_march_template_email
+  def send_notify_template_email
+    template_id = current_month == "march" ? MARCH_PEAK_TIMES_TEMPLATE_ID : MAY_PEAK_TIMES_TEMPLATE_ID
     template_mail(
-      MARCH_PEAK_TIMES_TEMPLATE_ID,
+      template_id,
       to: @jobseeker.email,
       personalisation: {
         campaign_url: campaign_url,
@@ -28,15 +29,11 @@ class Jobseekers::PeakTimesMailer < Jobseekers::BaseMailer
   end
 
   def send_standard_email
-    subject = if current_month == "may"
-                I18n.t("jobseekers.peak_times_mailer.#{campaign_key}.subject")
+    first_name = @jobseeker.jobseeker_profile&.personal_details&.first_name
+    subject = if first_name.present?
+                I18n.t("jobseekers.peak_times_mailer.#{campaign_key}.subject", first_name: first_name)
               else
-                first_name = @jobseeker.jobseeker_profile&.personal_details&.first_name
-                if first_name.present?
-                  I18n.t("jobseekers.peak_times_mailer.#{campaign_key}.subject", first_name: first_name)
-                else
-                  I18n.t("jobseekers.peak_times_mailer.#{campaign_key}.nameless_subject")
-                end
+                I18n.t("jobseekers.peak_times_mailer.#{campaign_key}.nameless_subject")
               end
     send_email(to: @jobseeker.email, subject:)
   end

--- a/app/views/jobseekers/peak_times_mailer/reminder.text.erb
+++ b/app/views/jobseekers/peak_times_mailer/reminder.text.erb
@@ -1,7 +1,17 @@
+<% if campaign_key == "may_reminder" %>
+## <%= t("jobseekers.peak_times_mailer.#{campaign_key}.heading") %>
+
+<%= t("jobseekers.peak_times_mailer.#{campaign_key}.line_1") %>
+
+<%= t("jobseekers.peak_times_mailer.#{campaign_key}.cta", campaign_url:) %>
+
+<%= t("jobseekers.peak_times_mailer.#{campaign_key}.line_3") %>
+<% else %>
 <%= t("jobseekers.peak_times_mailer.#{campaign_key}.line_1") %>
 
 <%= t("jobseekers.peak_times_mailer.#{campaign_key}.line_2", campaign_url:) %>
 
 <%= t("jobseekers.peak_times_mailer.#{campaign_key}.line_3") %>
+<% end %>
 
 <%= t("jobseekers.peak_times_mailer.#{campaign_key}.unsubscribe", link: edit_jobseekers_account_email_preferences_url) %>

--- a/app/views/jobseekers/peak_times_mailer/reminder.text.erb
+++ b/app/views/jobseekers/peak_times_mailer/reminder.text.erb
@@ -1,17 +1,10 @@
 <% if campaign_key == "may_reminder" %>
 ## <%= t("jobseekers.peak_times_mailer.#{campaign_key}.heading") %>
-
-<%= t("jobseekers.peak_times_mailer.#{campaign_key}.line_1") %>
-
-<%= t("jobseekers.peak_times_mailer.#{campaign_key}.cta", campaign_url:) %>
-
-<%= t("jobseekers.peak_times_mailer.#{campaign_key}.line_3") %>
-<% else %>
+<% end %>
 <%= t("jobseekers.peak_times_mailer.#{campaign_key}.line_1") %>
 
 <%= t("jobseekers.peak_times_mailer.#{campaign_key}.line_2", campaign_url:) %>
 
 <%= t("jobseekers.peak_times_mailer.#{campaign_key}.line_3") %>
-<% end %>
 
 <%= t("jobseekers.peak_times_mailer.#{campaign_key}.unsubscribe", link: edit_jobseekers_account_email_preferences_url) %>

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -11,7 +11,7 @@ en:
         subject: Searching for your next school role?
         heading: Did you know?
         line_1: "Schools typically advertise more jobs than usual at this time of year, making May a great time to search for your next role on Teaching Vacancies."
-        cta: "[Start your search now](%{campaign_url})"
+        line_2: "[Start your search now](%{campaign_url})"
         line_3: To find the right role, remember to always check Teaching Vacancies.
         unsubscribe: "If you no longer wish to be on this mailing list, you can [opt out of these emails](%{link})."
       november_reminder:

--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -8,10 +8,10 @@ en:
   jobseekers:
     peak_times_mailer:
       may_reminder:
-        subject: "%{first_name}, now is the best time to find school jobs"
-        nameless_subject: Now is the best time to find school jobs
-        line_1: Schools advertise more jobs than usual around this time of year.
-        line_2: "If you are looking for a school role, now is a great time to search for jobs on [Teaching Vacancies](%{campaign_url})."
+        subject: Searching for your next school role?
+        heading: Did you know?
+        line_1: "Schools typically advertise more jobs than usual at this time of year, making May a great time to search for your next role on Teaching Vacancies."
+        cta: "[Start your search now](%{campaign_url})"
         line_3: To find the right role, remember to always check Teaching Vacancies.
         unsubscribe: "If you no longer wish to be on this mailing list, you can [opt out of these emails](%{link})."
       november_reminder:

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -7,7 +7,7 @@ send_peak_times_email_reminder_march:
   queue: default
 
 send_peak_times_email_reminder_may:
-  cron: '0 3 14 5 *' # "At 03:00 on 14 of May."
+  cron: '0 11 11 5 *' # "At 11:00 on 11 of May."
   class: 'SendPeakTimesEmailReminderJob'
   queue: default
 

--- a/spec/mailers/jobseekers/peak_times_mailer_spec.rb
+++ b/spec/mailers/jobseekers/peak_times_mailer_spec.rb
@@ -20,37 +20,22 @@ RSpec.describe Jobseekers::PeakTimesMailer do
     end
 
     context "when it's May" do
-      before { travel_to Time.zone.local(2026, 5, 14, 3, 0, 0) }
+      before { travel_to Time.zone.local(2026, 5, 11, 11, 0, 0) }
 
+      let(:jobseeker) { create(:jobseeker) }
       let(:expected_url) { "https://teaching-vacancies.service.gov.uk/jobs?utm_source=notify&utm_medium=email&utm_campaign=peak_email&utm_content=may_2026" }
-      let(:expected_subject) { I18n.t("jobseekers.peak_times_mailer.may_reminder.subject") }
+      let(:unsubscribe_link) { Rails.application.routes.url_helpers.edit_jobseekers_account_email_preferences_url }
 
-      context "when jobseeker has personal details" do
-        let(:jobseeker) { create(:jobseeker, :with_personal_details) }
-
-        it_behaves_like "common email behaviors"
-
-        it "has May subject" do
-          expect(mail.subject).to eq(expected_subject)
-        end
-
-        it "includes May campaign URL" do
-          expect(mail.body).to include(expected_url)
-        end
+      it "sends to jobseeker's email" do
+        expect(mail.to).to contain_exactly(jobseeker.email)
       end
 
-      context "when jobseeker has no personal details" do
-        let(:jobseeker) { create(:jobseeker) }
+      it "includes campaign_url in personalisation" do
+        expect(mail.personalisation[:campaign_url]).to eq(expected_url)
+      end
 
-        it_behaves_like "common email behaviors"
-
-        it "has May subject" do
-          expect(mail.subject).to eq(expected_subject)
-        end
-
-        it "includes May campaign URL" do
-          expect(mail.body).to include(expected_url)
-        end
+      it "includes unsubscribe_link in personalisation" do
+        expect(mail.personalisation[:unsubscribe_link]).to eq(unsubscribe_link)
       end
     end
 

--- a/spec/mailers/jobseekers/peak_times_mailer_spec.rb
+++ b/spec/mailers/jobseekers/peak_times_mailer_spec.rb
@@ -20,18 +20,17 @@ RSpec.describe Jobseekers::PeakTimesMailer do
     end
 
     context "when it's May" do
-      before { travel_to Time.zone.local(2025, 5, 14, 3, 0, 0) }
+      before { travel_to Time.zone.local(2026, 5, 14, 3, 0, 0) }
 
-      let(:expected_url) { "https://teaching-vacancies.service.gov.uk/?utm_source=Notify&utm_medium=email&utm_campaign=may_peak_notify&utm_id=may_peak_notify" }
+      let(:expected_url) { "https://teaching-vacancies.service.gov.uk/jobs?utm_source=notify&utm_medium=email&utm_campaign=peak_email&utm_content=may_2026" }
+      let(:expected_subject) { I18n.t("jobseekers.peak_times_mailer.may_reminder.subject") }
 
       context "when jobseeker has personal details" do
         let(:jobseeker) { create(:jobseeker, :with_personal_details) }
-        let(:first_name) { jobseeker.jobseeker_profile.personal_details.first_name }
 
         it_behaves_like "common email behaviors"
 
-        it "has May subject with jobseeker firstname" do
-          expected_subject = I18n.t("jobseekers.peak_times_mailer.may_reminder.subject", first_name: first_name)
+        it "has May subject" do
           expect(mail.subject).to eq(expected_subject)
         end
 
@@ -45,8 +44,7 @@ RSpec.describe Jobseekers::PeakTimesMailer do
 
         it_behaves_like "common email behaviors"
 
-        it "has May generic subject without firstname" do
-          expected_subject = I18n.t("jobseekers.peak_times_mailer.may_reminder.nameless_subject")
+        it "has May subject" do
           expect(mail.subject).to eq(expected_subject)
         end
 
@@ -117,10 +115,9 @@ RSpec.describe Jobseekers::PeakTimesMailer do
       before { travel_to Time.zone.local(2025, 1, 15, 9, 0, 0) }
 
       let(:jobseeker) { create(:jobseeker, :with_personal_details) }
-      let(:first_name) { jobseeker.jobseeker_profile.personal_details.first_name }
 
       it "falls back to May campaign content" do
-        expected_subject = I18n.t("jobseekers.peak_times_mailer.may_reminder.subject", first_name: first_name)
+        expected_subject = I18n.t("jobseekers.peak_times_mailer.may_reminder.subject")
         expect(mail.subject).to eq(expected_subject)
       end
 


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/29sRLjf2/2760-peak-times-email-may-2026

## Changes in this PR:

This change adds new content for our peak time email in may and also swaps over to using a notify template for it.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
