### PR TITLE
Fix jobseeker profile bug

### DIFF
--- a/app/views/jobseekers/profiles/job_preferences/_job_preferences.html.slim
+++ b/app/views/jobseekers/profiles/job_preferences/_job_preferences.html.slim
@@ -28,7 +28,7 @@ ruby:
     locations: {
       if: ->(model) { model.locations.any? },
       map_values: ->(value) { "#{value.name} (#{t('jobs.search.number_of_miles', count: value.radius.to_i)})" },
-      join_with: "</br>",
+      join_with: tag.br,
     },
   }
 
@@ -41,7 +41,7 @@ ruby:
     - count = value.is_a?(Array) ? value.count : 1
     - if options[:map_values] || options[:join_with]
       - value = value.map { |elem| options[:map_values].call(elem) } if options[:map_values]
-      - value = value.join(options[:join_with].html_safe).html_safe
+      - value = safe_join(Array(value), options[:join_with])
 
     - summary_list.with_row do |row|
       - row.with_key text: t("jobseekers.profiles.job_preferences.summary.#{attribute}", count:)

--- a/spec/views/jobseekers/profiles/job_preferences/_job_preferences.html.slim_spec.rb
+++ b/spec/views/jobseekers/profiles/job_preferences/_job_preferences.html.slim_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe "jobseekers/profiles/job_preferences/_job_preferences" do
+  let(:profile) { build_stubbed(:jobseeker_profile, job_preferences:) }
+
+  before { render partial: "jobseekers/profiles/job_preferences/job_preferences", locals: { profile: } }
+
+  context "when subjects is nil but the step is marked as completed" do
+    let(:job_preferences) do
+      build_stubbed(:job_preferences,
+                    subjects: nil,
+                    completed_steps: { "subjects" => "completed" })
+    end
+
+    it "renders without error" do
+      expect(rendered).to have_content("Subjects")
+    end
+  end
+
+  context "when subjects is an empty array but the step is marked as completed" do
+    let(:job_preferences) do
+      build_stubbed(:job_preferences,
+                    subjects: [],
+                    completed_steps: { "subjects" => "completed" })
+    end
+
+    it "renders without error and shows blank text" do
+      expect(rendered).to have_content("No subject preference chosen")
+    end
+  end
+
+  context "when there are multiple locations" do
+    let(:job_preferences) do
+      prefs = create(:job_preferences)
+      create(:job_preferences_location, name: "London", radius: 10, job_preferences: prefs)
+      create(:job_preferences_location, name: "Bristol", radius: 25, job_preferences: prefs)
+      prefs.reload
+    end
+    let(:profile) { build_stubbed(:jobseeker_profile, job_preferences:) }
+
+    it "renders each location separated by a line break" do
+      expect(rendered).to match(/London.*<br>.*Bristol/m)
+    end
+  end
+end


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/AUkAlDT5/2852-jobseeker-profile-job-preferences-bug

## Changes in this PR:

This PR fixes a `NoMethodError: undefined method 'join' for nil `crash for jobseekers who have subjects set to nil but have the subjects step marked as completed. Also fixes invalid `</br>` used to join locations, replacing it with tag.br, which was needed to allow us to use safe_join to safely handle nil values.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
