### PR TITLE
Fix review app migration issue

### DIFF
--- a/lib/tasks/migrate_swallowing_concurrent_migration_exceptions.rake
+++ b/lib/tasks/migrate_swallowing_concurrent_migration_exceptions.rake
@@ -15,5 +15,15 @@ namespace :db do
     rescue ActiveRecord::ConcurrentMigrationError
       # Do nothing
     end
+
+    desc "Run db:prepare for review apps, loading schema if app tables are missing"
+    task review: :environment do
+      unless ActiveRecord::Base.connection.table_exists?(:vacancies)
+        Rake::Task["db:schema:load"].invoke
+      end
+      Rake::Task["db:migrate"].invoke
+    rescue ActiveRecord::ConcurrentMigrationError
+      # Do nothing
+    end
   end
 end

--- a/terraform/workspace-variables/review.tfvars.json
+++ b/terraform/workspace-variables/review.tfvars.json
@@ -4,7 +4,7 @@
   "aks_web_app_start_command": [
     "/bin/sh",
     "-c",
-    "bundle exec rails db:prepare:ignore_concurrent_migration_exceptions db:async_seed && rails s"
+    "bundle exec rails db:prepare:review db:async_seed && rails s"
   ],
   "parameter_store_environment": "dev",
   "region": "eu-west-2",


### PR DESCRIPTION
## Trello card URL

## Changes in this PR:

This PR is an attempt to fix the issue we have with review app deploys failing due to the migrations running before the schema has loaded. 

I have added a manual check to review apps to ensure we only load from schema if one of our custom tables exists to try to avoid the situation in which the migrations are being run on top of tables that have not yet been created.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
