### PR TITLE
Add hint text to vacancy review page

### DIFF
--- a/app/views/publishers/vacancies/review.html.slim
+++ b/app/views/publishers/vacancies/review.html.slim
@@ -6,6 +6,8 @@
 span.govuk-caption-l = t(".caption")
 h1.govuk-heading-l = t(".heading", status: (vacancy.publish_on&.future? ? "schedule" : "publish"))
 
+p.govuk-body = t(".hint")
+
 = render "publishers/vacancies/sections"
 
 p

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -589,6 +589,7 @@ en:
         heading: Check details and %{status} job listing
         page_title: "%{heading} - Create job listing - Teaching Vacancies - GOV.UK"
         steps: Create a job listing steps
+        hint: Check the job listing before you publish it. Make sure the details are correct and there are no spelling mistakes.
       start:
         page_title: Create a job listing
         title: Create a job listing


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/EU19wXzA/2830-draft-hint-text-reminding-hiring-staff-to-check-for-errors-before-publishing-a-job-listing

## Changes in this PR:

Add hint text to the vacancy review page

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
