### PR TITLE
Remove change links

### DIFF
--- a/app/views/publishers/vacancies/vacancy_review_sections/_job_details.html.slim
+++ b/app/views/publishers/vacancies/vacancy_review_sections/_job_details.html.slim
@@ -8,7 +8,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
     - row.with_value
       ul.govuk-list.govuk-list--spaced
         = vacancy_job_locations(vacancy)
-    - unless current_organisation.school?
+    - unless current_organisation.school? || vacancy.live?
       - row.with_action text: t("buttons.change"),
                   href: organisation_job_build_path(vacancy.id, :job_location, "back_to_#{action_name}": "true"),
                   visually_hidden_text: t("publishers.vacancies.steps.job_location")
@@ -18,18 +18,20 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
       = t("jobs.job_title")
     - row.with_value
       = vacancy.job_title
-    - row.with_action text: t("buttons.change"),
-                href: organisation_job_build_path(vacancy.id, :job_title, "back_to_#{action_name}": "true"),
-                visually_hidden_text: t("jobs.job_title")
+    - unless vacancy.live?
+      - row.with_action text: t("buttons.change"),
+                  href: organisation_job_build_path(vacancy.id, :job_title, "back_to_#{action_name}": "true"),
+                  visually_hidden_text: t("jobs.job_title")
 
   - summary_list.with_row(html_attributes: { id: "job_role" }) do |row|
     - row.with_key
       = t("jobs.job_role")
     - row.with_value
       - vacancy_readable_job_roles(vacancy)
-    - row.with_action text: t("buttons.change"),
-                href: organisation_job_build_path(vacancy.id, :job_role, "back_to_#{action_name}": "true"),
-                visually_hidden_text: t("publishers.vacancies.steps.job_role")
+    - unless vacancy.live?
+      - row.with_action text: t("buttons.change"),
+                  href: organisation_job_build_path(vacancy.id, :job_role, "back_to_#{action_name}": "true"),
+                  visually_hidden_text: t("publishers.vacancies.steps.job_role")
 
   - if vacancy.allow_key_stages? && vacancy.key_stages.any?
     - summary_list.with_row(html_attributes: { id: "key_stages" }) do |row|
@@ -37,9 +39,10 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
         = t("jobs.key_stage", count: vacancy.key_stages.count)
       - row.with_value
         = vacancy_readable_key_stages(vacancy)
-      - row.with_action text: t("buttons.change"),
-                  href: organisation_job_build_path(vacancy.id, :key_stages, "back_to_#{action_name}": "true"),
-                  visually_hidden_text: t("jobs.key_stage", count: vacancy.key_stages.count)
+      - unless vacancy.live?
+        - row.with_action text: t("buttons.change"),
+                    href: organisation_job_build_path(vacancy.id, :key_stages, "back_to_#{action_name}": "true"),
+                    visually_hidden_text: t("jobs.key_stage", count: vacancy.key_stages.count)
 
   - if vacancy.allow_subjects? && (vacancy.completed_steps.include?("subjects") || vacancy.completed_steps.include?("job_details"))
     - summary_list.with_row(html_attributes: { id: "subjects" }) do |row|
@@ -47,9 +50,10 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
         = t("jobs.subjects", count: vacancy.subjects.count)
       - row.with_value
         = vacancy.subjects.any? ? vacancy_readable_subjects(vacancy) : t("jobs.not_defined")
-      - row.with_action text: t("buttons.change"),
-                  href: organisation_job_build_path(vacancy.id, :subjects, "back_to_#{action_name}": "true"),
-                  visually_hidden_text: t("jobs.subjects", count: vacancy.subjects.count)
+      - unless vacancy.live?
+        - row.with_action text: t("buttons.change"),
+                    href: organisation_job_build_path(vacancy.id, :subjects, "back_to_#{action_name}": "true"),
+                    visually_hidden_text: t("jobs.subjects", count: vacancy.subjects.count)
 
   - unless vacancy.contract_type.nil?
     - summary_list.with_row(html_attributes: { id: "contract_type" }) do |row|
@@ -57,9 +61,10 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
         = t("jobs.contract_type")
       - row.with_value
         = vacancy_contract_type_with_duration(vacancy)
-      - row.with_action text: t("buttons.change"),
-                  href: organisation_job_build_path(vacancy.id, :contract_information, "back_to_#{action_name}": "true"),
-                  visually_hidden_text: t("jobs.contract_type")
+      - unless vacancy.live?
+        - row.with_action text: t("buttons.change"),
+                    href: organisation_job_build_path(vacancy.id, :contract_information, "back_to_#{action_name}": "true"),
+                    visually_hidden_text: t("jobs.contract_type")
 
   - if vacancy.working_patterns.any?
     - summary_list.with_row(html_attributes: { id: "working_patterns" }) do |row|
@@ -67,18 +72,20 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
         = t("jobs.working_patterns")
       - row.with_value
         = vacancy_readable_working_patterns(vacancy)
-      - row.with_action text: t("buttons.change"),
-                  href: organisation_job_build_path(vacancy.id, :contract_information, "back_to_#{action_name}": "true"),
-                  visually_hidden_text: t("jobs.working_patterns")
+      - unless vacancy.live?
+        - row.with_action text: t("buttons.change"),
+                    href: organisation_job_build_path(vacancy.id, :contract_information, "back_to_#{action_name}": "true"),
+                    visually_hidden_text: t("jobs.working_patterns")
 
     - summary_list.with_row(html_attributes: { id: "working_patterns_details" }) do |row|
       - row.with_key
         = t("jobs.working_patterns_details")
       - row.with_value
         = vacancy.working_patterns_details? ? vacancy.working_patterns_details : t("jobs.not_defined")
-      - row.with_action text: t("buttons.change"),
-                  href: organisation_job_build_path(vacancy.id, :contract_information, "back_to_#{action_name}": "true"),
-                  visually_hidden_text: t("jobs.working_patterns")
+      - unless vacancy.live?
+        - row.with_action text: t("buttons.change"),
+                    href: organisation_job_build_path(vacancy.id, :contract_information, "back_to_#{action_name}": "true"),
+                    visually_hidden_text: t("jobs.working_patterns")
 
     - unless vacancy.start_date_type.nil?
       - summary_list.with_row(html_attributes: { id: "start_date" }) do |row|

--- a/spec/system/publishers/publishers_are_reminded_of_application_functionality_spec.rb
+++ b/spec/system/publishers/publishers_are_reminded_of_application_functionality_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "Application feature reminder" do
 
         click_on "Change", match: :first
 
-        expect(current_path).to eq(organisation_job_build_path(last_vacancy.id, :job_title))
+        expect(current_path).to eq(organisation_job_build_path(last_vacancy.id, :start_date))
       end
     end
   end

--- a/spec/system/publishers/publishers_can_edit_a_published_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers/publishers_can_edit_a_published_vacancy_as_a_school_spec.rb
@@ -16,34 +16,9 @@ RSpec.describe "Publishers can edit a vacancy" do
     end
 
     describe "#job_title" do
-      before do
-        publisher_vacancy_page.change_job_title_link.click
-      end
-
-      it "can not be edited when validation fails" do
-        expect(publisher_job_title_page).to be_displayed
-
-        fill_in "publishers_job_listing_job_title_form[job_title]", with: ""
-        click_on I18n.t("buttons.save_and_continue")
-
-        expect(publisher_job_title_page.errors.map(&:text)).to eq(["Enter a job title"])
-      end
-
-      it "notifies the Google index service" do
-        expect(publisher_job_title_page).to be_displayed
-
-        expect_any_instance_of(Publishers::Vacancies::BaseController)
-          .to receive(:update_google_index).with(vacancy)
-
-        fill_in "publishers_job_listing_job_title_form[job_title]", with: "Assistant Head Teacher"
-        click_on I18n.t("buttons.save_and_continue")
-
-        expect(publisher_vacancy_page).to be_displayed
-        expect(page).to have_content("Assistant Head Teacher")
-
-        visit job_path(vacancy.reload)
-        # ensures the vacancy slug is updated when the title is saved
-        expect(page.current_path).to eq("/jobs/assistant-head-teacher")
+      it "does not show a change link for live vacancies" do
+        expect(page).to have_css("#job_title")
+        expect(page).not_to have_css("#job_title a")
       end
     end
 

--- a/spec/system/publishers/publishers_can_view_vacancy_activity_log_spec.rb
+++ b/spec/system/publishers/publishers_can_view_vacancy_activity_log_spec.rb
@@ -3,11 +3,8 @@ require "rails_helper"
 RSpec.describe "Publishers can view a vacancy's activity log", versioning: true do
   let(:publisher) { create(:publisher, organisations: [organisation]) }
   let(:organisation) { create(:school) }
-  let(:vacancy) { create(:vacancy, :secondary, contract_type: "permanent", subjects: old_subjects, organisations: [organisation]) }
-  let(:new_job_title) { "Demon headmaster wanted" }
-  let(:new_contract_type) { "fixed_term" }
-  let(:old_subjects) { %w[Mathematics Science] }
-  let(:new_subjects) { %w[Computing Dance] }
+  let(:vacancy) { create(:vacancy, :secondary, :live, organisations: [organisation]) }
+  let(:new_salary) { "£50,000 per year" }
 
   before do
     login_publisher(publisher: publisher, organisation: organisation)
@@ -17,28 +14,15 @@ RSpec.describe "Publishers can view a vacancy's activity log", versioning: true 
   after { logout }
 
   it "updates the activity log" do
-    click_review_page_change_link(section: "job_details", row: "subjects")
-    expect(current_path).to eq(organisation_job_build_path(vacancy.id, :subjects))
+    click_review_page_change_link(section: "job_details", row: "salary")
+    expect(current_path).to eq(organisation_job_build_path(vacancy.id, :pay_package))
 
-    old_subjects.each { |subject| uncheck subject }
-    new_subjects.each { |subject| check subject }
-
-    click_on I18n.t("buttons.save_and_continue")
-    click_review_page_change_link(section: "job_details", row: "working_patterns")
-    expect(current_path).to eq(organisation_job_build_path(vacancy.id, :contract_information))
-
-    choose I18n.t("helpers.label.publishers_job_listing_contract_information_form.contract_type_options.#{new_contract_type}")
-    within("#publishers-job-listing-contract-information-form-contract-type-fixed-term-conditional") do
-      choose "Yes"
-      fill_in I18n.t("helpers.label.publishers_job_listing_contract_information_form.fixed_term_contract_duration"), with: "6 months"
-    end
-
+    fill_in "publishers_job_listing_pay_package_form[salary]", with: new_salary
     click_on I18n.t("buttons.save_and_continue")
 
     click_on I18n.t("tabs.activity_log")
 
-    expect(page).to have_content(I18n.t("publishers.activity_log.subjects", new_value: new_subjects.to_sentence, count: new_subjects.count))
-    expect(page).to have_content(I18n.t("publishers.activity_log.contract_type", new_value: new_contract_type.humanize))
+    expect(page).to have_content(I18n.t("publishers.activity_log.salary", new_value: new_salary))
     expect(page).to have_content(publisher.papertrail_display_name)
     expect(page).to have_content(vacancy.versions.first.created_at)
   end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/aOe4w39T/2851-remove-unnecessary-change-buttons-after-a-job-listing-has-been-posted-devs

## Changes in this PR:

Remove change links on the first 7 items in the Job details section of the vacacncy review page.

- Is there anything specific you want feedback on?

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
