### PR TITLE
Fix wordcount bug

### DIFF
--- a/app/assets/javascript/js_components/wordCounter/wordCounter.js
+++ b/app/assets/javascript/js_components/wordCounter/wordCounter.js
@@ -27,12 +27,7 @@ export default class extends Controller {
     const { editor } = this.editorTarget;
     if (!editor) return 0;
 
-    const text = editor.getDocument().toString().trim();
-    if (text.length === 0) return 0;
-
-    // '-' allows one-way street to be one word
-    const words = text.split(/(\w|-)+/);
-    return words.length;
+    return this.constructor.countWordsInText(editor.getDocument().toString());
   }
 
   displayCount(wordCount) {
@@ -46,5 +41,12 @@ export default class extends Controller {
 
   static formatNumber(num) {
     return num >= 1000 ? num.toLocaleString('en-GB') : num.toString();
+  }
+
+  static countWordsInText(text) {
+    const trimmedText = text.trim();
+    if (trimmedText.length === 0) return 0;
+
+    return trimmedText.split(/\s+/).length;
   }
 }

--- a/app/assets/javascript/js_components/wordCounter/wordCounter.test.js
+++ b/app/assets/javascript/js_components/wordCounter/wordCounter.test.js
@@ -1,0 +1,21 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import WordCounterController from './wordCounter';
+
+describe('word counter', () => {
+  describe('countWordsInText', () => {
+    it('counts words without counting spaces as words', () => {
+      expect(WordCounterController.countWordsInText('Education and Experience I have some text here')).toBe(8);
+    });
+
+    it('collapses repeated whitespace between words', () => {
+      expect(WordCounterController.countWordsInText('Education   and\nExperience\tI have some text here')).toBe(8);
+    });
+
+    it('returns zero for blank text', () => {
+      expect(WordCounterController.countWordsInText('   ')).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Trello card URL

## Changes in this PR:

This PR fixes an issue that double counts words in the word counter. This was caused by spaces being counted as well as words. This change fixes the issue.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
