### PR TITLE
Remove back button from job alerts pages

### DIFF
--- a/app/views/subscriptions/edit.html.slim
+++ b/app/views/subscriptions/edit.html.slim
@@ -1,8 +1,5 @@
 - content_for :page_title_prefix, t("subscriptions.edit.title")
 
-- content_for :breadcrumbs do
-  = govuk_back_link text: t("app.back_to_homepage"), href: root_path, html_attributes: { "aria-label" => "Back navigation" }
-
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     = render "form", form_options: { url: subscription_path(@subscription.token), method: :patch }, i18n_prefix: "subscriptions.edit", button_text: t("buttons.update_alert") do |f|

--- a/app/views/subscriptions/new.html.slim
+++ b/app/views/subscriptions/new.html.slim
@@ -1,8 +1,5 @@
 - content_for :page_title_prefix, t("subscriptions.new.title")
 
-- content_for :breadcrumbs do
-  = govuk_back_link text: t("app.back_to_homepage"), href: root_path, html_attributes: { "aria-label" => "Back navigation" }
-
 .campaign-header.full-width-banner
   .govuk-width-container class="govuk-!-padding-left-6 govuk-!-padding-right-6"
     .govuk-grid-row class="govuk-!-padding-top-6 govuk-!-padding-bottom-2"


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/J1JuXMPd/2854-fe-review-job-alerts-page-remove-back-button

## Changes in this PR:

Remove the back link on the job alerts review page.

- Is there anything specific you want feedback on?

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
