### PR TITLE
tighenten VCR config

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -116,6 +116,8 @@ Rails.root.glob("spec/page_objects/**/*.rb").each { |f| require f }
 
 ActiveRecord::Migration.maintain_test_schema!
 
+ALLOWED_HOSTS = %w[selenium-chrome].freeze
+
 Rails.application.load_tasks
 
 RSpec.configure do |config|
@@ -127,6 +129,13 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
 
   config.use_transactional_fixtures = true
+
+  WebMock.disable_net_connect!(allow_localhost: true, allow: ALLOWED_HOSTS)
+  config.around(:each, :vcr) do |example|
+    WebMock.allow_net_connect!
+    example.run
+    WebMock.disable_net_connect!(allow_localhost: true, allow: ALLOWED_HOSTS)
+  end
 
   config.before do
     allow(Google::Cloud::Bigquery).to receive(:new).and_return(
@@ -301,7 +310,6 @@ VCR.configure do |config|
   config.hook_into :webmock
   config.configure_rspec_metadata!
   config.ignore_localhost = true
-  config.ignore_hosts "ea-edubase-api-prod.azurewebsites.net", "selenium-chrome"
   config.ignore_hosts IPSocket.getaddress(Socket.gethostname) if ENV.fetch("DEVCONTAINER", nil) == "true"
 
   # defaults to method and URI


### PR DESCRIPTION
## Changes in this PR:

Tighten up VCR config so that tests are not allowed to call out to the internet unless tagged :vcr