### PR TITLE
Place additional documents page after choose application type page

### DIFF
--- a/app/services/publishers/vacancies/vacancy_step_process.rb
+++ b/app/services/publishers/vacancies/vacancy_step_process.rb
@@ -50,16 +50,19 @@ class Publishers::Vacancies::VacancyStepProcess < StepProcess
       end
     end
 
+    steps += additional_documents_steps
     steps + %i[contact_details confirm_contact_details]
   end
 
   def about_the_role_steps
-    first_steps = %i[about_the_role include_additional_documents]
-    last_steps = %i[school_visits visa_sponsorship]
+    %i[about_the_role school_visits visa_sponsorship]
+  end
+
+  def additional_documents_steps
     if vacancy.include_additional_documents
-      first_steps + [:documents] + last_steps
+      %i[include_additional_documents documents]
     else
-      first_steps + last_steps
+      %i[include_additional_documents]
     end
   end
 end

--- a/spec/services/publishers/vacancies/vacancy_step_process_spec.rb
+++ b/spec/services/publishers/vacancies/vacancy_step_process_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Publishers::Vacancies::VacancyStepProcess do
 
     context "application_process_steps" do
       it "has the required steps" do
-        expect(subject.steps).to include(:school_visits, :contact_details)
+        expect(subject.steps).to include(:school_visits, :include_additional_documents, :contact_details)
       end
 
       context "when the organisation is a school" do
@@ -143,6 +143,11 @@ RSpec.describe Publishers::Vacancies::VacancyStepProcess do
           expect(subject.steps).not_to include(:how_to_receive_applications)
           expect(subject.steps).not_to include(:application_link, :application_form)
         end
+
+        it "places additional documents after the application form type-specific steps" do
+          expect(subject.steps).to include(:applying_for_the_job, :anonymise_applications, :include_additional_documents, :contact_details)
+          expect(subject.steps.index(:include_additional_documents)).to be > subject.steps.index(:anonymise_applications)
+        end
       end
 
       context "when the vacancy does not allow job applications" do
@@ -158,13 +163,18 @@ RSpec.describe Publishers::Vacancies::VacancyStepProcess do
           it "has the expected steps" do
             expect(subject.steps).to include(:application_link)
           end
+
+          it "places additional documents after the application link step" do
+            expect(subject.steps).to include(:applying_for_the_job, :how_to_receive_applications, :application_link, :include_additional_documents, :contact_details)
+            expect(subject.steps.index(:include_additional_documents)).to be > subject.steps.index(:application_link)
+          end
         end
       end
     end
 
     context "about_the_role_steps" do
       it "has the required steps" do
-        expect(subject.steps).to include(:about_the_role, :include_additional_documents)
+        expect(subject.steps).to include(:about_the_role, :school_visits, :visa_sponsorship)
       end
 
       context "when include_additional_documents is true" do

--- a/spec/system/publishers/publishers_can_copy_a_vacancy_spec.rb
+++ b/spec/system/publishers/publishers_can_copy_a_vacancy_spec.rb
@@ -224,9 +224,9 @@ RSpec.describe "Copying a vacancy" do
         click_on I18n.t("buttons.save_and_continue")
         fill_in_start_date_form_fields
         click_on I18n.t("buttons.save_and_continue")
-        fill_in_include_additional_documents_form_fields(false)
-        click_on I18n.t("buttons.save_and_continue")
         fill_in_important_dates_form_fields(publish_on: Date.current, expires_at: 30.days.from_now)
+        click_on I18n.t("buttons.save_and_continue")
+        fill_in_include_additional_documents_form_fields(false)
         click_on I18n.t("buttons.save_and_continue")
         fill_in_contact_details_form_fields(contact_email: publisher.email)
         click_on I18n.t("buttons.save_and_continue")
@@ -259,11 +259,11 @@ RSpec.describe "Copying a vacancy" do
       fill_in_start_date_form_fields
       click_on I18n.t("buttons.save_and_continue")
 
-      expect(page).to have_content("Do you want to upload any additional documents?")
-      fill_in_include_additional_documents_form_fields(false)
+      fill_in_important_dates_form_fields(publish_on: Date.current, expires_at: 30.days.from_now)
       click_on I18n.t("buttons.save_and_continue")
 
-      fill_in_important_dates_form_fields(publish_on: Date.current, expires_at: 30.days.from_now)
+      expect(page).to have_content("Do you want to upload any additional documents?")
+      fill_in_include_additional_documents_form_fields(false)
       click_on I18n.t("buttons.save_and_continue")
 
       fill_in_contact_details_form_fields(contact_email: publisher.email)

--- a/spec/system/publishers/publishers_can_edit_a_draft_vacancy_spec.rb
+++ b/spec/system/publishers/publishers_can_edit_a_draft_vacancy_spec.rb
@@ -21,12 +21,12 @@ RSpec.describe "Publishers can edit a draft vacancy" do
           start_date: ["aria-allowed-attr"],
           pay_package: ["aria-allowed-attr"],
           about_the_role: ["aria-allowed-attr"],
-          include_additional_documents: [],
           school_visits: [],
           visa_sponsorship: ["aria-allowed-attr"],
           important_dates: ["aria-allowed-attr"],
           applying_for_the_job: [],
           anonymise_applications: [],
+          include_additional_documents: [],
           contact_details: ["aria-allowed-attr"],
         }
       end

--- a/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_local_authority_spec.rb
+++ b/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_local_authority_spec.rb
@@ -101,9 +101,6 @@ RSpec.describe "Creating a vacancy" do
     )
     publisher_about_the_role_page.fill_in_and_submit_form(vacancy)
 
-    expect(publisher_include_additional_documents_page).to be_displayed
-    publisher_include_additional_documents_page.fill_in_and_submit_form(vacancy.include_additional_documents)
-
     expect(publisher_school_visits_page).to be_displayed
     publisher_school_visits_page.fill_in_and_submit_form(vacancy.school_visits)
 
@@ -124,6 +121,9 @@ RSpec.describe "Creating a vacancy" do
     expect(publisher_application_link_page.errors.map(&:text)).to contain_exactly(I18n.t("application_link_errors.application_link.blank"))
     expect(publisher_application_link_page).to be_displayed
     publisher_application_link_page.fill_in_and_submit_form(vacancy.application_link)
+
+    expect(publisher_include_additional_documents_page).to be_displayed
+    publisher_include_additional_documents_page.fill_in_and_submit_form(vacancy.include_additional_documents)
 
     expect(publisher_contact_details_page).to be_displayed
     non_publisher_email = Faker::Internet.email(domain: "contoso.com")

--- a/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_school_spec.rb
@@ -104,11 +104,6 @@ RSpec.describe "Creating a vacancy" do
         )
         publisher_about_the_role_page.fill_in_and_submit_form(vacancy)
 
-        expect(publisher_include_additional_documents_page).to be_displayed
-        submit_empty_form
-        expect(publisher_include_additional_documents_page.errors.map(&:text)).to contain_exactly(I18n.t("include_additional_documents_errors.include_additional_documents.inclusion"))
-        publisher_include_additional_documents_page.fill_in_and_submit_form(vacancy.include_additional_documents)
-
         expect(publisher_school_visits_page).to be_displayed
         submit_empty_form
         expect(publisher_school_visits_page).to be_displayed
@@ -155,6 +150,11 @@ RSpec.describe "Creating a vacancy" do
         expect(publisher_anonymise_applications_page).to be_displayed
         publisher_anonymise_applications_page.anonymous_option.click
         click_on "Save and continue"
+
+        expect(publisher_include_additional_documents_page).to be_displayed
+        submit_empty_form
+        expect(publisher_include_additional_documents_page.errors.map(&:text)).to contain_exactly(I18n.t("include_additional_documents_errors.include_additional_documents.inclusion"))
+        publisher_include_additional_documents_page.fill_in_and_submit_form(vacancy.include_additional_documents)
 
         expect(publisher_contact_details_page).to be_displayed
         submit_empty_form
@@ -203,7 +203,6 @@ RSpec.describe "Creating a vacancy" do
           publisher_start_date_page.fill_in_and_submit_form(vacancy.starts_on)
           publisher_pay_package_page.fill_in_and_submit_form(vacancy)
           publisher_about_the_role_page.fill_in_and_submit_form(vacancy)
-          publisher_include_additional_documents_page.fill_in_and_submit_form(vacancy.include_additional_documents)
           publisher_school_visits_page.fill_in_and_submit_form(vacancy.school_visits)
           publisher_visa_sponsorship_page.fill_in_and_submit_form(vacancy.visa_sponsorship_available)
           publisher_important_dates_page.fill_in_and_submit_form(publish_on: vacancy.publish_on, expires_at: vacancy.expires_at)
@@ -243,9 +242,6 @@ RSpec.describe "Creating a vacancy" do
         expect(publisher_about_the_role_page).to be_displayed
         publisher_about_the_role_page.fill_in_and_submit_form(vacancy)
 
-        expect(publisher_include_additional_documents_page).to be_displayed
-        publisher_include_additional_documents_page.fill_in_and_submit_form(vacancy.include_additional_documents)
-
         expect(publisher_school_visits_page).to be_displayed
         publisher_school_visits_page.fill_in_and_submit_form(vacancy.school_visits)
 
@@ -262,6 +258,9 @@ RSpec.describe "Creating a vacancy" do
         expect(publisher_anonymise_applications_page).to be_displayed
         publisher_anonymise_applications_page.anonymous_option.click
         click_on "Save and continue"
+
+        expect(publisher_include_additional_documents_page).to be_displayed
+        publisher_include_additional_documents_page.fill_in_and_submit_form(vacancy.include_additional_documents)
 
         expect(publisher_contact_details_page).to be_displayed
         non_publisher_email = Faker::Internet.email(domain: "contoso.com")
@@ -429,6 +428,9 @@ RSpec.describe "Creating a vacancy" do
     publisher_anonymise_applications_page.standard_option.click
     click_on "Save and continue"
 
+    fill_in_include_additional_documents_form_fields(vacancy.include_additional_documents)
+    click_on I18n.t("buttons.save_and_continue")
+
     fill_in_contact_details_form_fields(contact_email: vacancy.contact_email, contact_number: vacancy.contact_number)
     click_on I18n.t("buttons.save_and_continue")
     publisher_confirm_contact_details_page.fill_in_and_submit_form
@@ -477,10 +479,6 @@ RSpec.describe "Creating a vacancy" do
 
     expect(page).to have_current_path(organisation_job_build_path(created_vacancy_id, :about_the_role), ignore_query: true)
     fill_in_about_the_role_form_fields(vacancy)
-    click_on I18n.t("buttons.save_and_continue")
-
-    expect(page).to have_current_path(organisation_job_build_path(created_vacancy_id, :include_additional_documents), ignore_query: true)
-    fill_in_include_additional_documents_form_fields(vacancy.include_additional_documents)
     click_on I18n.t("buttons.save_and_continue")
 
     expect(page).to have_current_path(organisation_job_build_path(created_vacancy_id, :school_visits), ignore_query: true)

--- a/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_trust_spec.rb
+++ b/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_trust_spec.rb
@@ -90,11 +90,6 @@ RSpec.describe "Creating a vacancy" do
     )
     publisher_about_the_role_page.fill_in_and_submit_form(vacancy)
 
-    expect(publisher_include_additional_documents_page).to be_displayed
-    submit_empty_form
-    expect(publisher_include_additional_documents_page.errors.map(&:text)).to contain_exactly(I18n.t("include_additional_documents_errors.include_additional_documents.inclusion"))
-    publisher_include_additional_documents_page.fill_in_and_submit_form(vacancy.include_additional_documents)
-
     expect(publisher_school_visits_page).to be_displayed
     submit_empty_form
     expect(publisher_school_visits_page).to be_displayed
@@ -134,6 +129,11 @@ RSpec.describe "Creating a vacancy" do
     expect(publisher_application_link_page.errors.map(&:text)).to contain_exactly(I18n.t("application_link_errors.application_link.blank"))
     expect(publisher_application_link_page).to be_displayed
     publisher_application_link_page.fill_in_and_submit_form(vacancy.application_link)
+
+    expect(publisher_include_additional_documents_page).to be_displayed
+    submit_empty_form
+    expect(publisher_include_additional_documents_page.errors.map(&:text)).to contain_exactly(I18n.t("include_additional_documents_errors.include_additional_documents.inclusion"))
+    publisher_include_additional_documents_page.fill_in_and_submit_form(vacancy.include_additional_documents)
 
     expect(publisher_contact_details_page).to be_displayed
     submit_empty_form


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/lFNnJYZY/2857-job-listing-document-uploads-process

## Changes in this PR:

This PR moves the upload additional documents page to after the publisher chooses which type of application form they wish to use.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
