### PR TITLE
Add chevrons to dropdowns

### DIFF
--- a/app/assets/stylesheets/components/filters.scss
+++ b/app/assets/stylesheets/components/filters.scss
@@ -137,26 +137,6 @@
           font-weight: bold;
           text-decoration: none;
         }
-
-        &__summary::before {
-          content: url('/svg/icon-filter-details-closed.svg');
-          width: 30px;
-          height: 30px;
-          border-style: none;
-          clip-path: unset;
-          left: -5px;
-        }
-      }
-
-      details[open] {
-        .govuk-details__summary::before {
-          content: url('/svg/icon-filter-details-expanded.svg');
-          width: 30px;
-          height: 30px;
-          border-style: none;
-          clip-path: unset;
-          left: -5px;
-        }
       }
 
       &:last-of-type {

--- a/app/views/publishers/jobseeker_profiles/search/_filters.html.slim
+++ b/app/views/publishers/jobseeker_profiles/search/_filters.html.slim
@@ -78,13 +78,36 @@ ruby:
             small: true, legend: { text: t("publishers.jobseeker_profiles.filters.schools") }),
             collection_count: f.object.school_options.count,
             options: { scrollable: true })
+
         - filters_component.with_remove_filter_links do |rb|
           - filter_types.each do |filter_type|
             - rb.with_group(**filter_type, remove_filter_link: { url_helper: :publishers_jobseeker_profiles_path, params: @jobseeker_profile_search.filters })
+
         = render "publishers/jobseeker_profiles/search/job_roles_filters", filters_component: filters_component, f: f, form: @form
-        - filters_component.with_group key: "right_to_work_in_uk", component: f.govuk_collection_check_boxes(:right_to_work_in_uk, f.object.right_to_work_in_uk_options, :first, :last, small: true, legend: { text: t("publishers.jobseeker_profiles.filters.right_to_work_in_uk") }, hint: nil)
-        - filters_component.with_group key: "qualified_teacher_status", component: f.govuk_collection_check_boxes(:qualified_teacher_status, f.object.qts_options, :first, :last, small: true, legend: { text: t("publishers.jobseeker_profiles.filters.qualified_teacher_status") }, hint: nil)
-        - filters_component.with_group key: "working_patterns", component: f.govuk_collection_check_boxes(:working_patterns, f.object.working_pattern_options, :first, :last, small: true, legend: { text: t("publishers.jobseeker_profiles.filters.preferred_working_patterns") }, hint: nil)
-        - filters_component.with_group key: "education_phases", component: f.govuk_collection_check_boxes(:education_phases, f.object.education_phase_options, :first, :last, small: true, legend: { text: t("publishers.jobseeker_profiles.filters.preferred_education_phases") }, hint: nil)
-        - filters_component.with_group key: "key_stages", component: f.govuk_collection_check_boxes(:key_stages, f.object.key_stage_options, :first, :last, small: true, legend: { text: t("publishers.jobseeker_profiles.filters.preferred_key_stages") }, hint: nil)
+
+        - right_to_work_in_uk = capture do
+          = govuk_details(summary_text: t("publishers.jobseeker_profiles.filters.right_to_work_in_uk"), open: @form.right_to_work_in_uk.present?) do
+            = f.govuk_collection_check_boxes(:right_to_work_in_uk, f.object.right_to_work_in_uk_options, :first, :last, small: true, legend: nil, hint: nil)
+        - filters_component.with_group key: "right_to_work_in_uk", component: right_to_work_in_uk
+
+        - qualified_teacher_status = capture do
+          = govuk_details(summary_text: t("publishers.jobseeker_profiles.filters.qualified_teacher_status"), open: @form.qualified_teacher_status.present?) do
+            = f.govuk_collection_check_boxes(:qualified_teacher_status, f.object.qts_options, :first, :last, small: true, legend: nil, hint: nil)
+        - filters_component.with_group key: "qualified_teacher_status", component: qualified_teacher_status
+
+        - working_patterns = capture do
+          = govuk_details(summary_text: t("publishers.jobseeker_profiles.filters.preferred_working_patterns"), open: @form.working_patterns.present?) do
+            = f.govuk_collection_check_boxes(:working_patterns, f.object.working_pattern_options, :first, :last, small: true, legend: nil, hint: nil)
+        - filters_component.with_group key: "working_patterns", component: working_patterns
+
+        - education_phases = capture do
+          = govuk_details(summary_text: t("publishers.jobseeker_profiles.filters.preferred_education_phases"), open: @form.education_phases.present?) do
+            = f.govuk_collection_check_boxes(:education_phases, f.object.education_phase_options, :first, :last, small: true, legend: nil, hint: nil)
+        - filters_component.with_group key: "education_phases", component: education_phases
+
+        - key_stages = capture do
+          = govuk_details(summary_text: t("publishers.jobseeker_profiles.filters.preferred_key_stages"), open: @form.key_stages.present?) do
+            = f.govuk_collection_check_boxes(:key_stages, f.object.key_stage_options, :first, :last, small: true, legend: nil, hint: nil)
+        - filters_component.with_group key: "key_stages", component: key_stages
+
         = render "shared/subjects_filter", filters_component: filters_component, f: f

--- a/app/views/vacancies/search/_filters.html.slim
+++ b/app/views/vacancies/search/_filters.html.slim
@@ -39,7 +39,7 @@ ruby:
       options: SUBJECT_OPTIONS,
       value_method: :first,
       selected_method: :first,
-      },
+    },
     {
       legend: t("jobs.filters.ect_suitable"),
       key: :ect_statuses,

--- a/spec/system/publishers/publishers_can_search_for_jobseeker_profiles_spec.rb
+++ b/spec/system/publishers/publishers_can_search_for_jobseeker_profiles_spec.rb
@@ -89,6 +89,7 @@ RSpec.describe "Publishers searching for Jobseeker profiles", type: :system do
 
     it "will allow a publisher to filter the jobseeker profiles" do
       within ".filters-component" do
+        first("summary", text: I18n.t("publishers.jobseeker_profiles.filters.preferred_working_patterns")).click
         check I18n.t("publishers.jobseeker_profiles.filters.working_pattern_options.part_time")
       end
 
@@ -104,8 +105,13 @@ RSpec.describe "Publishers searching for Jobseeker profiles", type: :system do
     context "when filters are selected" do
       before do
         within ".filters-component" do
+          first("summary", text: I18n.t("publishers.jobseeker_profiles.filters.preferred_working_patterns")).click
           check I18n.t("publishers.jobseeker_profiles.filters.working_pattern_options.part_time")
+
+          first("summary", text: I18n.t("publishers.jobseeker_profiles.filters.preferred_key_stages")).click
           check I18n.t("publishers.jobseeker_profiles.filters.key_stage_options.ks5")
+
+          first("summary", text: I18n.t("publishers.jobseeker_profiles.filters.right_to_work_in_uk")).click
           check I18n.t("publishers.jobseeker_profiles.filters.right_to_work_in_uk_options.true")
         end
 


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/OXRRkIG1/2855-fe-changes-to-the-job-alerts-dropdown-screen

## Changes in this PR:

Add Chevrons to the categories on the job alerts page to alert users that the link is a dropdown menu.

## Screenshots of UI changes:

### Before

### After
<img width="743" height="586" alt="Screenshot 2026-05-20 at 12 40 46" src="https://github.com/user-attachments/assets/67c0d8c0-f027-4fb7-8a92-16362a015383" />


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
