### PR TITLE
Possible fix for null jobseeker build path

### DIFF
--- a/app/controllers/jobseekers/job_applications/build_controller.rb
+++ b/app/controllers/jobseekers/job_applications/build_controller.rb
@@ -17,10 +17,8 @@ class Jobseekers::JobApplications::BuildController < Jobseekers::JobApplications
 
       if redirect_to_review?
         redirect_to jobseekers_job_application_review_path(job_application), success: t("messages.jobseekers.job_applications.saved")
-      elsif steps_complete?
-        redirect_to jobseekers_job_application_apply_path job_application
       else
-        redirect_to jobseekers_job_application_build_path(job_application, step_process.next_step(step))
+        redirect_to jobseekers_job_application_apply_path job_application
       end
     else
       render step
@@ -28,10 +26,6 @@ class Jobseekers::JobApplications::BuildController < Jobseekers::JobApplications
   end
 
   private
-
-  def steps_complete?
-    step_process.last_of_group?(step)
-  end
 
   def back_path
     @back_path ||= if redirect_to_review?

--- a/app/services/jobseekers/job_applications/job_application_step_process.rb
+++ b/app/services/jobseekers/job_applications/job_application_step_process.rb
@@ -43,11 +43,6 @@ class Jobseekers::JobApplications::JobApplicationStepProcess
     steps[steps.index(step) + 1]
   end
 
-  def last_of_group?(step)
-    group = @step_groups.values.detect { |g| g.include?(step) }
-    step == group.last
-  end
-
   def form_class_for(step)
     "jobseekers/job_application/#{step}_form".camelize.constantize
   end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/y3rcPJKf/2842-sentry-null-next-step-for-job-seeker-filling-in-an-application

## Changes in this PR:

Remove unused code path