### PR TITLE
fix issue with incoming DSILogin records failing 

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,7 +1,7 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
-  before_save :strip_attributes
+  before_validation :strip_attributes
 
   private
 

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -14,7 +14,8 @@ class Publisher < ApplicationRecord
 
   has_encrypted :family_name, :given_name
 
-  validates :email, email_address: true, if: -> { email_changed? } # Allows data created prior to validation to still be valid
+  # don't use strict MX validation for publisher email - they come from DSILogin so can't really be fixed
+  validates :email, "valid_email_2/email": true, if: -> { email_changed? } # Allows data created prior to validation to still be valid
 
   devise :timeoutable
   self.timeout_in = 120.minutes # Overrides default Devise configuration

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -14,7 +14,7 @@ class Publisher < ApplicationRecord
 
   has_encrypted :family_name, :given_name
 
-  # don't use strict MX validation for publisher email - they come from DSILogin so can't really be fixed
+  # don't use strict MX validation for publisher email - they come from DSI Login so can't really be fixed
   validates :email, "valid_email_2/email": true, if: -> { email_changed? } # Allows data created prior to validation to still be valid
 
   devise :timeoutable

--- a/spec/models/publisher_spec.rb
+++ b/spec/models/publisher_spec.rb
@@ -150,4 +150,10 @@ RSpec.describe Publisher do
       end
     end
   end
+
+  context "when email has a trailing space" do
+    it "can be saved" do
+      expect(build(:publisher, email: "fred.bloggs@contoso.com ")).to be_valid
+    end
+  end
 end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/67sAt6O5/2873-bug-updateusersindb-crashing-and-possibly-preventing-future-updates

## Changes in this PR:

Some publisher records have trailing spaces in their emails, or their emails have missing MX records. Avoid strict validation for publishers coming in from sync with DSI as these errors can't be fixed easily

