### PR TITLE
Fix legacy integrations duplicating vacancies

### DIFF
--- a/app/services/vacancies/import/sources/broadbean.rb
+++ b/app/services/vacancies/import/sources/broadbean.rb
@@ -31,7 +31,7 @@ class Vacancies::Import::Sources::Broadbean
       # An external vacancy is by definition always published
       v = PublishedVacancy.find_or_initialize_by(
         external_source: SOURCE_NAME,
-        external_reference: item["reference"],
+        external_reference: item["reference"]&.strip,
       )
 
       # Consider publish_on date to be the first time we saw this vacancy come through

--- a/app/services/vacancies/import/sources/fusion.rb
+++ b/app/services/vacancies/import/sources/fusion.rb
@@ -23,7 +23,7 @@ class Vacancies::Import::Sources::Fusion
       # An external vacancy is by definition always published
       v = PublishedVacancy.find_or_initialize_by(
         external_source: SOURCE_NAME,
-        external_reference: result["reference"],
+        external_reference: result["reference"]&.strip,
       )
 
       # Consider publish_on date to be the first time we saw this vacancy come through

--- a/app/services/vacancies/import/sources/ventrus.rb
+++ b/app/services/vacancies/import/sources/ventrus.rb
@@ -30,7 +30,7 @@ class Vacancies::Import::Sources::Ventrus
       # An external vacancy is by definition always published
       v = PublishedVacancy.find_or_initialize_by(
         external_source: SOURCE_NAME,
-        external_reference: item["VacancyID"],
+        external_reference: item["VacancyID"]&.strip,
       )
 
       # Consider publish_on date to be the first time we saw this vacancy come through

--- a/spec/services/vacancies/import/sources/broadbean_spec.rb
+++ b/spec/services/vacancies/import/sources/broadbean_spec.rb
@@ -312,7 +312,7 @@ RSpec.describe Vacancies::Import::Sources::Broadbean do
       end
 
       context "when the source external reference has leading/trailing whitespace" do
-        let(:response_body) { super().gsub("0044", " 0044 ") }
+        let(:response_body) { super().gsub("<reference>0044</reference>", "<reference> 0044 </reference>") }
 
         it "still matches the existing vacancy and updates it" do
           expect(vacancy.id).to eq(existing_vacancy.id)
@@ -387,6 +387,14 @@ RSpec.describe Vacancies::Import::Sources::Broadbean do
 
       it "defaults visa_sponsorship_available to false" do
         expect(vacancy.visa_sponsorship_available).to eq false
+      end
+    end
+
+    context "when external reference is not provided" do
+      let(:response_body) { super().gsub("<reference>0044</reference>", "") }
+
+      it "sets it as nil" do
+        expect(vacancy.external_reference).to eq nil
       end
     end
 

--- a/spec/services/vacancies/import/sources/broadbean_spec.rb
+++ b/spec/services/vacancies/import/sources/broadbean_spec.rb
@@ -310,6 +310,18 @@ RSpec.describe Vacancies::Import::Sources::Broadbean do
 
         expect(vacancy.job_title).to eq("Class Teacher")
       end
+
+      context "when the source external reference has leading/trailing whitespace" do
+        let(:response_body) { super().gsub("0044", " 0044 ") }
+
+        it "still matches the existing vacancy and updates it" do
+          expect(vacancy.id).to eq(existing_vacancy.id)
+          expect(vacancy).to be_persisted
+          expect(vacancy).to be_changed
+
+          expect(vacancy.job_title).to eq("Class Teacher")
+        end
+      end
     end
 
     context "when the vacancy is associated with multiple schools from a trust" do

--- a/spec/services/vacancies/import/sources/fusion_spec.rb
+++ b/spec/services/vacancies/import/sources/fusion_spec.rb
@@ -360,6 +360,18 @@ RSpec.describe Vacancies::Import::Sources::Fusion do
 
         expect(vacancy.job_title).to eq("Class Teacher")
       end
+
+      context "when the source external reference has leading/trailing whitespace" do
+        let(:response_body) { super().gsub("0044", " 0044 ") }
+
+        it "still matches the existing vacancy and updates it" do
+          expect(vacancy.id).to eq(existing_vacancy.id)
+          expect(vacancy).to be_persisted
+          expect(vacancy).to be_changed
+
+          expect(vacancy.job_title).to eq("Class Teacher")
+        end
+      end
     end
 
     context "when visa_sponsorship_available is not provided" do

--- a/spec/services/vacancies/import/sources/fusion_spec.rb
+++ b/spec/services/vacancies/import/sources/fusion_spec.rb
@@ -386,6 +386,18 @@ RSpec.describe Vacancies::Import::Sources::Fusion do
       end
     end
 
+    describe "when external reference is not provided" do
+      let(:response_body) do
+        hash = JSON.parse(super())
+        hash["result"].first.delete("reference")
+        hash.to_json
+      end
+
+      it "sets it as nil" do
+        expect(vacancy.external_reference).to eq nil
+      end
+    end
+
     describe "vacancy organisation parsing" do
       let(:trust_uid) { school_group.uid }
       let(:school_urns) { [school1.urn] }

--- a/spec/services/vacancies/import/sources/ventrus_spec.rb
+++ b/spec/services/vacancies/import/sources/ventrus_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe Vacancies::Import::Sources::Ventrus do
       end
 
       context "when the source external reference has leading/trailing whitespace" do
-        let(:response_body) { super().gsub("915213", " 915213 ") }
+        let(:response_body) { super().gsub("<VacancyID>915213</VacancyID>", "<VacancyID> 915213 </VacancyID>") }
 
         it "still matches the existing vacancy and updates it" do
           expect(vacancy.id).to eq(existing_vacancy.id)
@@ -355,6 +355,14 @@ RSpec.describe Vacancies::Import::Sources::Ventrus do
 
       it "defaults visa_sponsorship_available to false" do
         expect(vacancy.visa_sponsorship_available).to eq false
+      end
+    end
+
+    context "when external reference is not provided" do
+      let(:response_body) { super().gsub("<VacancyID>915213</VacancyID>", "") }
+
+      it "sets it as nil" do
+        expect(vacancy.external_reference).to eq nil
       end
     end
 

--- a/spec/services/vacancies/import/sources/ventrus_spec.rb
+++ b/spec/services/vacancies/import/sources/ventrus_spec.rb
@@ -248,6 +248,18 @@ RSpec.describe Vacancies::Import::Sources::Ventrus do
 
         expect(vacancy.job_title).to eq("Teaching Assistant")
       end
+
+      context "when the source external reference has leading/trailing whitespace" do
+        let(:response_body) { super().gsub("915213", " 915213 ") }
+
+        it "still matches the existing vacancy and updates it" do
+          expect(vacancy.id).to eq(existing_vacancy.id)
+          expect(vacancy).to be_persisted
+          expect(vacancy).to be_changed
+
+          expect(vacancy.job_title).to eq("Teaching Assistant")
+        end
+      end
     end
 
     context "when the vacancy is associated with multiple schools from the trust" do


### PR DESCRIPTION

## Trello card URL

Reported from a school getting hundreds of duplicated adverts: https://trello.com/c/SKD4W2Si/2881-bug-hundreds-of-duplicated-instances-for-a-school-vacancy



## Changes in this PR:

When the legacy integrations source/feed has leading or trailing spaces in the external reference value (EG: external_reference: " CODE_01") it resulted with the same vacancy being re-created as a new vacancy in each import attempt (once per hour!).

This happened because the external_reference gets normalised by Rails ActiveRecord when creating the new vacancy (EG: "CODE_01"), and further pulls calling "find_or_create_by" does not match "CODE_01" with " CODE_01", resulting in a new record instead of matching the existing one.

Resolution: We are stripping possible spaces from the external reference when matching against existing data in our service.

### The offending value in the source:
<img width="390" height="38" alt="image" src="https://github.com/user-attachments/assets/7997873f-6a7e-488f-b2aa-336c04713345" />

### The consequence:
<img width="607" height="847" alt="image" src="https://github.com/user-attachments/assets/bb159cf6-fb5d-40fe-9b06-930ee1057483" />

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
