### PR TITLE
Fe job search

### DIFF
--- a/app/form_models/jobseekers/search_form.rb
+++ b/app/form_models/jobseekers/search_form.rb
@@ -119,7 +119,7 @@ class Jobseekers::SearchForm
     end
     set_organisation_type_options
     @school_type_options = %w[faith_school special_school].map { |school_type| [school_type, I18n.t("organisations.filters.#{school_type}")] }
-    @subject_options = SUBJECT_OPTIONS
+    @subject_options = VACANCY_SEARCH_SUBJECT_OPTIONS
   end
 
   def set_filter_variables(params)

--- a/app/form_models/jobseekers/search_form.rb
+++ b/app/form_models/jobseekers/search_form.rb
@@ -157,6 +157,7 @@ class Jobseekers::SearchForm
     @organisation_type_options = [
       [I18n.t("helpers.label.publishers_job_listing_contract_information_form.organisation_type_options.academy"), "includes free schools"],
       [I18n.t("helpers.label.publishers_job_listing_contract_information_form.organisation_type_options.local_authority"), nil],
+      [I18n.t("helpers.label.publishers_job_listing_contract_information_form.organisation_type_options.colleges"), nil],
     ]
   end
 

--- a/app/queries/vacancy_filter_query.rb
+++ b/app/queries/vacancy_filter_query.rb
@@ -46,6 +46,10 @@ class VacancyFilterQuery < ApplicationQuery
       selected_school_types << School::LA_SCHOOL_TYPE
     end
 
+    if filters[:organisation_types].include?(School::COLLEGE_SCHOOL_TYPE)
+      selected_school_types << School::COLLEGE_SCHOOL_TYPE
+    end
+
     built_scope.joins(organisation_vacancies: :organisation).where(organisations: { school_type: selected_school_types }).distinct
   end
 

--- a/app/views/shared/_subjects_filter.html.slim
+++ b/app/views/shared/_subjects_filter.html.slim
@@ -1,11 +1,13 @@
+- subject_options = local_assigns.fetch(:subject_options, SUBJECT_OPTIONS)
+
 - filters_component.with_group key: "subjects", title: t("jobs.filters.subject"), component: searchable_collection(collection: f.govuk_collection_check_boxes(:subjects,
-    SUBJECT_OPTIONS,
+    subject_options,
     :first,
     :first,
     :last,
     small: true,
     legend: nil,
     hint: nil),
-    collection_count: SUBJECT_OPTIONS.count,
+    collection_count: subject_options.count,
     options: { scrollable: true },
     text: { aria_label: t("jobs.filters.subject"), placeholder: t("helpers.hint.publishers_job_listing_subjects_form.subjects_placeholder") })

--- a/app/views/vacancies/search/_filters.html.slim
+++ b/app/views/vacancies/search/_filters.html.slim
@@ -36,7 +36,7 @@ ruby:
       legend: t("jobs.filters.subject"),
       key: :subjects,
       selected: form.subjects,
-      options: SUBJECT_OPTIONS,
+      options: form.subject_options,
       value_method: :first,
       selected_method: :first,
       },
@@ -100,7 +100,7 @@ ruby:
     - filters_component.with_group key: "education_phase", component: f.govuk_collection_check_boxes(:phases, form.phase_options, :first, :last, small: true, legend: { text: t("jobs.filters.phases") }, hint: nil)
 
     - unless hidden_filters&.include?("subjects")
-      = render "shared/subjects_filter", filters_component: filters_component, f: f
+      = render "shared/subjects_filter", filters_component: filters_component, f: f, subject_options: form.subject_options
 
     - unless hidden_filters&.include?("ect_statuses")
       - filters_component.with_group key: "ect_statuses", component: f.govuk_collection_check_boxes(:ect_statuses, form.ect_status_options, :first, :last, small: true, legend: { text: t("jobs.filters.ect_suitable") }, hint: nil)

--- a/config/initializers/subjects.rb
+++ b/config/initializers/subjects.rb
@@ -1,3 +1,7 @@
 base_path = Rails.root.join("config/data")
 
 SUBJECT_OPTIONS = YAML.load_file(base_path.join("subjects.yml"))
+FURTHER_EDUCATION_SUBJECT_OPTIONS = YAML.load_file(base_path.join("further_education_subjects.yml"))
+VACANCY_SEARCH_SUBJECT_OPTIONS = (SUBJECT_OPTIONS + FURTHER_EDUCATION_SUBJECT_OPTIONS)
+  .uniq { |subject, _hint| subject.downcase }
+  .sort_by { |subject, _hint| subject.downcase }

--- a/config/locales/jobseekers/job_application/contract_information_form.yml
+++ b/config/locales/jobseekers/job_application/contract_information_form.yml
@@ -10,6 +10,7 @@ en:
         working_patterns_details: Details of working hours/days (optional)
         organisation_type_options:
           academy: Academy
+          colleges: Colleges
           local_authority: Local authority maintained schools
         working_patterns_options:
           full_time: Full time

--- a/spec/form_models/jobseekers/search_form_spec.rb
+++ b/spec/form_models/jobseekers/search_form_spec.rb
@@ -95,6 +95,20 @@ RSpec.describe Jobseekers::SearchForm, type: :model do
     end
   end
 
+  describe "#subject_options" do
+    let(:params) { {} }
+
+    it "includes further education subjects" do
+      expect(subject.subject_options).to include(["Animal care", ""])
+    end
+
+    it "does not include duplicate subject labels" do
+      subject_names = subject.subject_options.map(&:first)
+
+      expect(subject_names.map(&:downcase)).to eq(subject_names.map(&:downcase).uniq)
+    end
+  end
+
   describe "#set_filters_from_keyword" do
     let(:params) { { keyword: keyword, previous_keyword: previous_keyword, landing_page: landing_page, phases: phases } }
 

--- a/spec/form_models/jobseekers/search_form_spec.rb
+++ b/spec/form_models/jobseekers/search_form_spec.rb
@@ -109,6 +109,14 @@ RSpec.describe Jobseekers::SearchForm, type: :model do
     end
   end
 
+  describe "#organisation_type_options" do
+    let(:params) { {} }
+
+    it "includes colleges" do
+      expect(subject.organisation_type_options).to include([School::COLLEGE_SCHOOL_TYPE, nil])
+    end
+  end
+
   describe "#set_filters_from_keyword" do
     let(:params) { { keyword: keyword, previous_keyword: previous_keyword, landing_page: landing_page, phases: phases } }
 

--- a/spec/queries/vacancy_filter_query_spec.rb
+++ b/spec/queries/vacancy_filter_query_spec.rb
@@ -124,6 +124,16 @@ RSpec.describe VacancyFilterQuery do
       end
     end
 
+    context "when filtering by a further education subject" do
+      let(:filters) { { subjects: ["Animal care"] } }
+      let!(:animal_care_vacancy) { create(:vacancy, :secondary, job_title: "Animal care teacher", subjects: ["Animal care"]) }
+      let!(:functional_skills_vacancy) { create(:vacancy, :secondary, job_title: "Functional skills teacher", subjects: ["Functional skills"]) }
+
+      it "returns vacancies with that further education subject" do
+        expect(subject).to contain_exactly(animal_care_vacancy)
+      end
+    end
+
     context "when visa_sponsorship_available is selected" do
       let(:filters) { { visa_sponsorship_availability: ["true"] } }
 

--- a/spec/queries/vacancy_filter_query_spec.rb
+++ b/spec/queries/vacancy_filter_query_spec.rb
@@ -131,6 +131,7 @@ RSpec.describe VacancyFilterQuery do
 
       it "returns vacancies with that further education subject" do
         expect(subject).to contain_exactly(animal_care_vacancy)
+        expect(subject).not_to include(functional_skills_vacancy)
       end
     end
 

--- a/spec/queries/vacancy_filter_query_spec.rb
+++ b/spec/queries/vacancy_filter_query_spec.rb
@@ -163,6 +163,16 @@ RSpec.describe VacancyFilterQuery do
         end
       end
 
+      context "when organisation_types == ['Colleges']" do
+        let(:filters) { { organisation_types: [School::COLLEGE_SCHOOL_TYPE] } }
+        let(:college) { create(:school, name: "College", school_type: School::COLLEGE_SCHOOL_TYPE) }
+        let!(:college_vacancy) { create(:vacancy, :apply_via_website, job_title: "College vacancy", organisations: [college]) }
+
+        it "will return vacancies associated with colleges" do
+          expect(subject).to contain_exactly(college_vacancy)
+        end
+      end
+
       context "when organisation_types is empty" do
         let(:filters) { {} }
 


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/7OnELa52/2779-fe-jobseeker-job-search-page

## Changes in this PR:

This PR adds a college option to organisation filter on the jobs search page and adds in further education subkects to the subjects filter. It doesn't change the subjects options for other places currently, namely on the subjects drop down for job alerts and in the publisher's jobseeker profile search page (but maybe it should?)

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
