### PR TITLE
Requesting support page copy changes

### DIFF
--- a/app/views/jobseekers/job_applications/build/ask_for_support.html.slim
+++ b/app/views/jobseekers/job_applications/build/ask_for_support.html.slim
@@ -5,11 +5,18 @@
 h2.govuk-heading-l = t(".heading")
 
 p.govuk-body = t(".opening")
-p.govuk-body = t(".adjustments")
+p.govuk-body = t(".needs")
+p.govuk-body = t(".arranging_support")
+p.govuk-body = t(".adjustment_examples_intro")
 ul.govuk-list.govuk-list--bullet
-  - t(".adjustment_examples").each do |example|
-    li = example
-p.govuk-body = t(".closing")
+  li = t(".adjustment_examples.questions_in_writing")
+  li = t(".adjustment_examples.extra_time")
+  li = t(".adjustment_examples.short_break")
+  li = t(".adjustment_examples.quiet_room")
+  li = t(".adjustment_examples.captions_hearing_loop_bsl")
+  li = t(".adjustment_examples.step_free_access")
+  li = t(".adjustment_examples.contact_method")
+  li = t(".adjustment_examples.assistive_technology")
 
 = form_for @form, url: jobseekers_job_application_build_path(job_application, :ask_for_support), method: :patch do |f|
   = f.govuk_error_summary

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -136,20 +136,22 @@ en:
           title: Add training and continuing professional development (CPD)
           no_training: No training or CPD specified
         ask_for_support:
-          adjustments: "This could be:"
           adjustment_examples:
-            - organising equipment, like an adapted keyboard or a hearing loop
-            - putting you in touch with support staff before the day of your interview
-            - making sure classrooms are wheelchair accessible
-          closing: >-
-            It's against the law to discriminate against you if you have a disability.
-            You should not be asked questions about your health or your disability if they are not relevant to your teaching ability or practice.
-          heading: Ask for support if you have a disability or other needs
-          opening: >-
-            When you are attending an interview, you might benefit from extra support if you have a disability, a
-            mental health condition or educational needs. You can ask for the support that you need now. Adjustments will be made so you can attend an interview.
+            assistive_technology: using your own assistive technology
+            captions_hearing_loop_bsl: using captions, a hearing loop or a British Sign Language interpreter
+            contact_method: changing how we contact you, for example by email instead of phone
+            extra_time: extra time to read or answer questions
+            questions_in_writing: having interview questions in writing
+            quiet_room: using a quiet room
+            short_break: taking a short break
+            step_free_access: making sure the interview room has step-free access
+          adjustment_examples_intro: "This could include:"
+          arranging_support: You can tell us what would help now. We'll use this information to arrange support for your interview.
+          heading: Do you need support or adjustments for your interview?
+          needs: This can be for a disability, health condition, mental health condition, neurodivergence, temporary injury or another need.
+          opening: You can ask for support or an adjustment to help you take part in an interview.
           step_title: Ask for support
-          title: Ask for support if you have a disability — Application
+          title: Do you need support or adjustments for your interview? — Application
         declarations:
           heading: Declarations
           step_title: Declarations

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -570,7 +570,7 @@ en:
         application_sections: Application sections
         consent_text: In submitting this application, the candidate has consented to their data being shared and processed for recruitment purposes.
         ask_for_support:
-          heading: Ask for support if you have a disability or other needs
+          heading: Do you need support or adjustments for your interview?
           support_needed: Do you want to ask for support so that you can attend an interview?
         declarations:
           close_relationships: Do you have any family or close relationship with people within %{organisation}

--- a/config/locales/jobseekers/job_application/ask_for_support_form.yml
+++ b/config/locales/jobseekers/job_application/ask_for_support_form.yml
@@ -14,15 +14,14 @@ en:
   helpers:
     legend:
       jobseekers_job_application_ask_for_support_form:
-        is_support_needed: Do you want to ask for support so that you can attend an interview?
+        is_support_needed: Do you need support or adjustments for an interview?
         ask_for_support_section_completed: Have you completed this section?
     label:
       jobseekers_job_application_ask_for_support_form:
         support_needed_details: Tell us any information you think is relevant
         is_support_needed_options:
-          "false": No, I do not need support
-          "true": Yes, I would like to share some information about the support that I need
+          "false": No, I do not need support or adjustments
+          "true": Yes, I need support or adjustments
         ask_for_support_section_completed_options:
           false: No, I'll come back to it later
           true: Yes, I've completed this section
-

--- a/spec/services/job_application_pdf_generator_spec.rb
+++ b/spec/services/job_application_pdf_generator_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe JobApplicationPdfGenerator do
       expect(pdf).to include("Work history")
       expect(pdf).to include("Personal statement")
       expect(pdf).to include("References")
-      expect(pdf).to include("Ask for support if you have a disability or other needs")
+      expect(pdf).to include("Do you need support or adjustments for your interview?")
       expect(pdf).to include("Declarations")
     end
 

--- a/spec/views/jobseekers/job_applications/apply.html.slim_spec.rb
+++ b/spec/views/jobseekers/job_applications/apply.html.slim_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe "jobseekers/job_applications/apply" do
           { name: "Work history", status: "Incomplete" },
           { name: "Personal statement", status: "Incomplete" },
           { name: "References", status: "Incomplete" },
-          { name: "Ask for support if you have a disability or other needs", status: "Incomplete" },
+          { name: "Do you need support or adjustments for your interview?", status: "Incomplete" },
           { name: "Declarations", status: "Incomplete" },
         ]
       end
@@ -109,7 +109,7 @@ RSpec.describe "jobseekers/job_applications/apply" do
           { name: "Personal statement", status: "Incomplete" },
           { name: "References", status: "Incomplete" },
           { name: "Equal opportunities and recruitment monitoring", status: "Incomplete" },
-          { name: "Ask for support if you have a disability or other needs", status: "Incomplete" },
+          { name: "Do you need support or adjustments for your interview?", status: "Incomplete" },
           { name: "Declarations", status: "Incomplete" },
         ]
       end
@@ -136,7 +136,7 @@ RSpec.describe "jobseekers/job_applications/apply" do
           { name: "Religious information", status: "Incomplete" },
           { name: "References", status: "Incomplete" },
           { name: "Equal opportunities and recruitment monitoring", status: "Incomplete" },
-          { name: "Ask for support if you have a disability or other needs", status: "Incomplete" },
+          { name: "Do you need support or adjustments for your interview?", status: "Incomplete" },
           { name: "Declarations", status: "Incomplete" },
         ]
       end
@@ -163,7 +163,7 @@ RSpec.describe "jobseekers/job_applications/apply" do
           { name: "Religious information", status: "Incomplete" },
           { name: "References", status: "Incomplete" },
           { name: "Equal opportunities and recruitment monitoring", status: "Incomplete" },
-          { name: "Ask for support if you have a disability or other needs", status: "Incomplete" },
+          { name: "Do you need support or adjustments for your interview?", status: "Incomplete" },
           { name: "Declarations", status: "Incomplete" },
         ]
       end

--- a/spec/views/jobseekers/job_applications/show.html.slim_spec.rb
+++ b/spec/views/jobseekers/job_applications/show.html.slim_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe "jobseekers/job_applications/show" do
           "Personal statement",
           "Religious information",
           "References",
-          "Ask for support if you have a disability or other needs",
+          "Do you need support or adjustments for your interview?",
           "Declarations",
         ]
       end
@@ -178,7 +178,7 @@ RSpec.describe "jobseekers/job_applications/show" do
             "Personal statement",
             "Religious information",
             "References",
-            "Ask for support if you have a disability or other needs",
+            "Do you need support or adjustments for your interview?",
             "Declarations",
           ]
         end
@@ -200,7 +200,7 @@ RSpec.describe "jobseekers/job_applications/show" do
           "Work history",
           "Personal statement",
           "References",
-          "Ask for support if you have a disability or other needs",
+          "Do you need support or adjustments for your interview?",
           "Declarations",
         ]
       end
@@ -222,7 +222,7 @@ RSpec.describe "jobseekers/job_applications/show" do
             "Work history",
             "Personal statement",
             "References",
-            "Ask for support if you have a disability or other needs",
+            "Do you need support or adjustments for your interview?",
             "Declarations",
           ]
         end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/C5OKdOud/2863-review-guidance-on-requesting-disability-support

## Changes in this PR:

This PR changes copy on the requesting support page for jobseekers

## Screenshots of UI changes:
<img width="1131" height="842" alt="Screenshot 2026-05-28 at 17 15 01" src="https://github.com/user-attachments/assets/a3cca4d7-a702-4e38-a5f0-86b879a560b6" />



## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
