### PR TITLE
Show all in scope schools even without registered publishers

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -68,7 +68,7 @@ class Organisation < ApplicationRecord
 
   scope :not_out_of_scope, -> { where.not(detailed_school_type: Organisation::OUT_OF_SCOPE_DETAILED_SCHOOL_TYPES).or(where(detailed_school_type: nil)) }
 
-  scope :visible_to_jobseekers, -> { schools.not_closed.not_out_of_scope.or(Organisation.trusts.registered_for_service) }
+  scope :visible_to_jobseekers, -> { schools.not_closed.not_out_of_scope.or(Organisation.trusts) }
 
   scope :only_faith_schools, -> { where.not(religious_character: NON_FAITH_RELIGIOUS_CHARACTER_TYPES) }
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -68,7 +68,7 @@ class Organisation < ApplicationRecord
 
   scope :not_out_of_scope, -> { where.not(detailed_school_type: Organisation::OUT_OF_SCOPE_DETAILED_SCHOOL_TYPES).or(where(detailed_school_type: nil)) }
 
-  scope :visible_to_jobseekers, -> { schools.not_closed.not_out_of_scope.or(Organisation.trusts).registered_for_service }
+  scope :visible_to_jobseekers, -> { schools.not_closed.not_out_of_scope.or(Organisation.trusts.registered_for_service) }
 
   scope :only_faith_schools, -> { where.not(religious_character: NON_FAITH_RELIGIOUS_CHARACTER_TYPES) }
 

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -192,32 +192,44 @@ RSpec.describe Organisation do
   end
 
   describe ".visible_to_jobseekers" do
+    let!(:open_school) { create(:school, establishment_status: "Open", detailed_school_type: "Primary school") }
+    let(:closed_school) { create(:school, establishment_status: "Closed", detailed_school_type: "Secondary school").tap(&:discard) }
+    let(:registered_trust) { create(:trust) }
+    let!(:unregistered_trust) { create(:trust) }
+    let(:fe_school) { create(:school, establishment_status: "Open", detailed_school_type: "Further education") }
+    let(:independent_school) { create(:school, establishment_status: "Open", detailed_school_type: "Other independent school") }
+    let(:misc_school) { create(:school, establishment_status: "Open", detailed_school_type: "Miscellaneous") }
+    let(:post_16_school) { create(:school, establishment_status: "Open", detailed_school_type: "Special post 16 institution") }
+    let(:independent_special_school) { create(:school, establishment_status: "Open", detailed_school_type: "Other independent special school") }
+    let(:higher_education_school) { create(:school, establishment_status: "Open", detailed_school_type: "Higher education institutions") }
+    let(:welsh_school) { create(:school, establishment_status: "Open", detailed_school_type: "Welsh establishment") }
+
     before do
-      create(:publisher, organisations: [trust,
-                                         open_school,
+      create(:publisher, organisations: [registered_trust,
                                          closed_school,
                                          fe_school,
-                                         independant_school,
+                                         independent_school,
                                          misc_school,
                                          post_16_school,
-                                         independant_special_school,
+                                         independent_special_school,
                                          higher_education_school,
                                          welsh_school])
     end
 
-    let(:open_school) { create(:school, establishment_status: "Open", detailed_school_type: "Primary school") }
-    let(:closed_school) { create(:school, establishment_status: "Closed", detailed_school_type: "Secondary school").tap(&:discard) }
-    let(:trust) { Organisation.create(type: "SchoolGroup", name: "Trust", uid: "1") }
-    let(:fe_school) { create(:school, establishment_status: "Open", detailed_school_type: "Further education") }
-    let(:independant_school) { create(:school, establishment_status: "Open", detailed_school_type: "Other independent school") }
-    let(:misc_school) { create(:school, establishment_status: "Open", detailed_school_type: "Miscellaneous") }
-    let(:post_16_school) { create(:school, establishment_status: "Open", detailed_school_type: "Special post 16 institution") }
-    let(:independant_special_school) { create(:school, establishment_status: "Open", detailed_school_type: "Other independent special school") }
-    let(:higher_education_school) { create(:school, establishment_status: "Open", detailed_school_type: "Higher education institutions") }
-    let(:welsh_school) { create(:school, establishment_status: "Open", detailed_school_type: "Welsh establishment") }
+    it "returns unregistered open in-scope schools" do
+      expect(Organisation.visible_to_jobseekers).to include(open_school)
+    end
 
-    it "returns open schools that are not out of scope" do
-      expect(Organisation.visible_to_jobseekers).to contain_exactly(open_school, trust)
+    it "does not return unregistered trusts" do
+      expect(Organisation.visible_to_jobseekers).not_to include(unregistered_trust)
+    end
+
+    it "returns registered trusts" do
+      expect(Organisation.visible_to_jobseekers).to include(registered_trust)
+    end
+
+    it "does not return closed or out-of-scope schools" do
+      expect(Organisation.visible_to_jobseekers).to contain_exactly(open_school, registered_trust)
     end
   end
 

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -194,8 +194,6 @@ RSpec.describe Organisation do
   describe ".visible_to_jobseekers" do
     let!(:open_school) { create(:school, establishment_status: "Open", detailed_school_type: "Primary school") }
     let(:closed_school) { create(:school, establishment_status: "Closed", detailed_school_type: "Secondary school").tap(&:discard) }
-    let(:registered_trust) { create(:trust) }
-    let!(:unregistered_trust) { create(:trust) }
     let(:fe_school) { create(:school, establishment_status: "Open", detailed_school_type: "Further education") }
     let(:independent_school) { create(:school, establishment_status: "Open", detailed_school_type: "Other independent school") }
     let(:misc_school) { create(:school, establishment_status: "Open", detailed_school_type: "Miscellaneous") }
@@ -203,6 +201,8 @@ RSpec.describe Organisation do
     let(:independent_special_school) { create(:school, establishment_status: "Open", detailed_school_type: "Other independent special school") }
     let(:higher_education_school) { create(:school, establishment_status: "Open", detailed_school_type: "Higher education institutions") }
     let(:welsh_school) { create(:school, establishment_status: "Open", detailed_school_type: "Welsh establishment") }
+    let(:registered_trust) { create(:trust) }
+    let!(:unregistered_trust) { create(:trust) }
 
     before do
       create(:publisher, organisations: [registered_trust,
@@ -220,16 +220,12 @@ RSpec.describe Organisation do
       expect(Organisation.visible_to_jobseekers).to include(open_school)
     end
 
-    it "does not return unregistered trusts" do
-      expect(Organisation.visible_to_jobseekers).not_to include(unregistered_trust)
-    end
-
-    it "returns registered trusts" do
-      expect(Organisation.visible_to_jobseekers).to include(registered_trust)
+    it "returns registered and unregistered trusts" do
+      expect(Organisation.visible_to_jobseekers).to include(registered_trust, unregistered_trust)
     end
 
     it "does not return closed or out-of-scope schools" do
-      expect(Organisation.visible_to_jobseekers).to contain_exactly(open_school, registered_trust)
+      expect(Organisation.visible_to_jobseekers).to contain_exactly(open_school, registered_trust, unregistered_trust)
     end
   end
 

--- a/spec/services/search/school_search_spec.rb
+++ b/spec/services/search/school_search_spec.rb
@@ -47,6 +47,21 @@ RSpec.describe Search::SchoolSearch do
   end
 
   describe "#organisations" do
+    context "with the default scope" do
+      subject { described_class.new(form_hash) }
+
+      let!(:school_without_registered_publisher) { create(:school, name: "External only school") }
+
+      before do
+        create(:school, :closed, name: "Closed school")
+        create(:school, name: "Out of scope school", detailed_school_type: "Other independent school")
+      end
+
+      it "returns in-scope GIAS schools even when they do not have registered publishers" do
+        expect(subject.organisations).to contain_exactly(school_without_registered_publisher)
+      end
+    end
+
     context "when no filters (except for radius) are given" do
       subject { described_class.new(form_hash, scope: scope) }
 


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/D1SPHXwe/2871-bug-schools-and-colleges-page-by-association-doesnt-list-all-schools-in-scope

## Changes in this PR:

This PR changes our visible_to_jobseekers scope to show all schools that are open and in scope even if they have not registered for our service.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
