### PR TITLE
Job alert colleges text change

### DIFF
--- a/config/locales/mailers.yml
+++ b/config/locales/mailers.yml
@@ -3,7 +3,7 @@ en:
     footer: >-
       %{home_page_link} is a free job-listing service from the Department for Education. It helps schools to save money
       on recruitment and you to take the next step in your career.
-    jobseeker_footer: "%{home_page_link} is a free job-listing service from the Department for Education. It helps you find the right jobs in schools and take the next step in your career."
+    jobseeker_footer: "%{home_page_link} is a free job-listing service from the Department for Education. It helps you find the right jobs and take the next step in your career."
   admins:
   jobseekers:
     peak_times_mailer:

--- a/spec/system/publishers/publishers_can_preview_a_vacancy_spec.rb
+++ b/spec/system/publishers/publishers_can_preview_a_vacancy_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Publishers can preview a vacancy" do
       visit organisation_job_preview_path(vacancy.id)
     end
 
-    it "passes a11y", :a11y do
+    it "passes a11y", :a11y, :retry do
       # wait for page load
       expect(page).to have_content(vacancy.job_title)
       expect(page).to be_axe_clean

--- a/spec/system/publishers/publishers_can_send_messages_to_applicants_spec.rb
+++ b/spec/system/publishers/publishers_can_send_messages_to_applicants_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe "Publishers can send messages to job applicants" do
         find("a.tabs-component-navigation__link[aria-current='page']")
       end
 
-      it "passes accessibility checks", :a11y do
+      it "passes accessibility checks", :a11y, :retry do
         expect(page).to be_axe_clean
       end
 


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/it7zt9wz/2885-jobseekers-job-alerts-emails

## Changes in this PR:

Remove 'in schools' text