### PR TITLE
2683 - New GitHub action validate infra workflow

### DIFF
--- a/.github/workflows/validate-infrastructure.yml
+++ b/.github/workflows/validate-infrastructure.yml
@@ -1,0 +1,36 @@
+name: Validate Infra
+
+on:
+  schedule:
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+jobs:
+  validate:
+    name: ${{ matrix.display }}
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - display: AKS infrastructure
+            validation_plan: aks-infra
+            terraform_base: terraform/app
+
+    steps:
+      - name: Validate ${{ matrix.display }}
+        uses: DFE-Digital/github-actions/validate-infra@master
+        with:
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          environment: production
+          terraform-base: ${{ matrix.terraform_base }}
+          validation-plan: ${{ matrix.validation_plan }}
+          service: ${{ vars.TEAMS_MSG_SERVICE_NAME }}
+          teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL_INFRA }}
+          image-prefix: main-

--- a/Makefile
+++ b/Makefile
@@ -134,10 +134,11 @@ terraform-app-init: set-azure-account
 	$(eval export TF_VAR_service_name=${SERVICE_NAME})
 	$(eval export TF_VAR_service_short=${SERVICE_SHORT})
 
+terraform-plan: terraform-app-plan terraform-common-plan
 
 .PHONY: terraform-app-plan
 terraform-app-plan: terraform-app-init check-terraform-variables ## make passcode=MyPasscode tag=dev-08406f04dd9eadb7df6fcda5213be880d7df37ed-20201022090714 <env> terraform-app-plan
-		terraform -chdir=terraform/app plan -var-file ../workspace-variables/$(var_file).tfvars.json
+		terraform -chdir=terraform/app plan ${DETAILED_EXITCODE} -var-file ../workspace-variables/$(var_file).tfvars.json
 
 .PHONY: terraform-app-apply
 terraform-app-apply: terraform-app-init check-terraform-variables ## make passcode=MyPasscode tag=47fd1475376bbfa16a773693133569b794408995 <env> terraform-app-apply


### PR DESCRIPTION
### Context

Adding a validate infra workflow to detect any changes in SD Infra Terraform 

### Changes proposed in this pull request

Add a new GitHub action workflow validate-infrastructure.yml.
${DETAILED_EXITCODE} added to Terraform plan in Makefile.
README.md updated.
TEAMS_WEBHOOK_URL_INFRA added as an Action repository secret.

### Guidance to review

Manually test changes by altering terraform/domains/environment_domains/config/production.tfvars.json **rate_limit_max** and running locally the following command.
`make production domains-plan  CONFIRM_PRODUCTION=yes`
This will produce a Terraform update in place.

To validate the workflow once available. Make a test branch with a change to terraform/domains/environment_domains/config/production.tfvars.json **rate_limit_max**. Run the workflow against that branch. It must produce a post in the SD Infra Alerts Teams channel with description **Domains environment infrastructure drift detected in production**

### Link to Trello card

https://trello.com/c/p76gfyrn/2683-schedule-validate-infra-workflow

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
