### PR TITLE
Restore required imagemagick package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
  # the hardcoded versions below when they have been updated in the alpine ruby image.
  # To find the current version of each package in the alpine image, search here:
  # https://pkgs.alpinelinux.org/packages?name=&branch=v3.23
-ARG PROD_PACKAGES="zlib=1.3.2-r0 expat=2.7.5-r0 curl=8.19.0-r0 libcurl=8.19.0-r0 curl-dev=8.19.0-r0 libpng libjpeg libxml2 libxslt libpq=18.4-r0 tzdata shared-mime-info postgresql18=18.4-r0 vips-poppler vips-magick proj-dev lcms2=2.19-r0"
+ARG PROD_PACKAGES="imagemagick zlib=1.3.2-r0 expat=2.7.5-r0 curl=8.19.0-r0 libcurl=8.19.0-r0 curl-dev=8.19.0-r0 libpng libjpeg libxml2 libxslt libpq=18.4-r0 tzdata shared-mime-info postgresql18=18.4-r0 vips-poppler vips-magick proj-dev lcms2=2.19-r0"
 
 FROM ruby:4.0.1-alpine3.23 AS builder
 


### PR DESCRIPTION
It is needed by our system for image transformations.

## Trello card URL
Resolving these errors https://teaching-vacancies.sentry.io/issues/7473529221/?environment=production&project=6212514&query=is%3Aunresolved&referrer=issue-stream that appear to have started happening since https://github.com/DFE-Digital/teaching-vacancies/pull/8865

## Changes in this PR:

Reintroduces imagemagick into our docker image so minimagick can resize images.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
