### PR TITLE
Fe jobs page

### DIFF
--- a/app/helpers/links_helper.rb
+++ b/app/helpers/links_helper.rb
@@ -1,6 +1,4 @@
 module LinksHelper
-  include OrganisationsHelper
-
   def tracked_link_to(*, **)
     tracked_link_of_style(:govuk_link_to, *, **)
   end
@@ -82,7 +80,7 @@ module LinksHelper
 
   def apply_link(vacancy, **)
     tracked_open_in_new_tab_button_link_to(
-      t("jobs.view_advert.school.#{school_or_college_type(vacancy.organisation)}"),
+      t("jobs.view_advert.#{school_or_college_type(vacancy.organisation)}"),
       vacancy.application_link,
       "aria-label": t("jobs.aria_labels.apply_link"),
       link_type: :get_more_information,

--- a/app/helpers/links_helper.rb
+++ b/app/helpers/links_helper.rb
@@ -1,4 +1,6 @@
 module LinksHelper
+  include OrganisationsHelper
+
   def tracked_link_to(*, **)
     tracked_link_of_style(:govuk_link_to, *, **)
   end
@@ -80,7 +82,7 @@ module LinksHelper
 
   def apply_link(vacancy, **)
     tracked_open_in_new_tab_button_link_to(
-      t("jobs.view_advert.school"),
+      t("jobs.view_advert.school.#{school_or_college_type(vacancy.organisation)}"),
       vacancy.application_link,
       "aria-label": t("jobs.aria_labels.apply_link"),
       link_type: :get_more_information,

--- a/app/helpers/organisations_helper.rb
+++ b/app/helpers/organisations_helper.rb
@@ -51,6 +51,10 @@ module OrganisationsHelper
     end
   end
 
+  def school_or_college_type(organisation)
+    organisation.respond_to?(:college?) && organisation.college? ? "college" : "school"
+  end
+
   def school_or_trust_visits(organisation)
     if organisation.trust?
       "trust_visits_html"

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -131,6 +131,10 @@ class School < Organisation
     religious_character.in? CATHOLIC_RELIGIOUS_TYPES
   end
 
+  def college?
+    school_type == COLLEGE_SCHOOL_TYPE && detailed_school_type == FE_DETAILED_SCHOOL_TYPE
+  end
+
   def key_stages
     return if phase == "not_applicable"
 

--- a/app/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy.rb
+++ b/app/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy.rb
@@ -39,7 +39,7 @@ module Vacancies::Export::DwpFindAJob::PublishedAndUpdatedVacancies
     def description
       description = ""
       description += description_paragraph(I18n.t("jobs.skills_and_experience.jobseeker"), vacancy.skills_and_experience)
-      description += description_paragraph(I18n.t("jobs.school_offer.jobseeker"), vacancy.school_offer)
+      description += description_paragraph(I18n.t("jobs.school_offer.jobseeker.#{school_or_college_type}"), vacancy.school_offer)
       description += description_paragraph(I18n.t("jobs.further_details"), vacancy.further_details)
       description += description_paragraph(I18n.t("jobs.safeguarding_information.jobseeker"), vacancy.organisation.safeguarding_information)
       description.strip
@@ -74,6 +74,10 @@ module Vacancies::Export::DwpFindAJob::PublishedAndUpdatedVacancies
     end
 
     private
+
+    def school_or_college_type
+      vacancy.organisation.respond_to?(:college?) && vacancy.organisation.college? ? "college" : "school"
+    end
 
     # Every particular repost version of a vacancy will be live for a different 30 days period after the previous version.
     def date_from_publishing_version(offset_days)

--- a/app/views/vacancies/listing/_job_details.html.slim
+++ b/app/views/vacancies/listing/_job_details.html.slim
@@ -73,7 +73,7 @@ section#job-details class="govuk-!-margin-bottom-5"
     .govuk-body.editor-rendered-content == simple_format(vacancy.job_advert)
 
   - if vacancy.school_offer.present?
-    h2.govuk-heading-m = t("jobs.school_offer.jobseeker")
+    h2.govuk-heading-m = t("jobs.school_offer.jobseeker.#{school_or_college_type(vacancy.organisation)}")
     .govuk-body.editor-rendered-content == vacancy.school_offer
 
   - if vacancy.flexi_working.present?
@@ -115,7 +115,7 @@ section#job-details class="govuk-!-margin-bottom-5"
 
     - else
       - if vacancy.external?
-        p = t("jobs.external.notice")
+        p = t("jobs.external.notice.#{school_or_college_type(vacancy.organisation)}")
         p.govuk-body = t("jobseekers.job_applications.no_cvs")
         = external_advert_link vacancy, class: "govuk-!-margin-bottom-5"
 

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -195,7 +195,9 @@ en:
         description_html: Change your information about your commitment to safeguarding in your %{link}.
         link_text: profile
     school_offer:
-      jobseeker: What the school offers its staff
+      jobseeker:
+        school: What the school offers its staff
+        college: What the college offers its staff
       publisher: What does your school offer?
       hint: Provide details about what your school can offer staff, for example, employee benefits, wellbeing support or professional development.
     flexi_working:
@@ -313,12 +315,18 @@ en:
     share_on_twitter: Share to Twitter
     share_this_job: Share this job
     view_advert:
-      school: View advert on school website
+      school:
+        school: View advert on school website
+        college: View advert on college website
       external: View advert on external website
 
     external:
-      notice: This school accepts applications through their own website, where you may also find more information about this job.
-      link: View advert on school website
+      notice:
+        school: This school accepts applications through their own website, where you may also find more information about this job.
+        college: This college accepts applications through their own website, where you may also find more information about this job.
+      link:
+        school: View advert on school website
+        college: View advert on college website
 
     preview_listing:
       heading: Preview this job listing

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -315,9 +315,8 @@ en:
     share_on_twitter: Share to Twitter
     share_this_job: Share this job
     view_advert:
-      school:
-        school: View advert on school website
-        college: View advert on college website
+      school: View advert on school website
+      college: View advert on college website
       external: View advert on external website
 
     external:

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -32,6 +32,20 @@ RSpec.describe School do
     end
   end
 
+  describe "#college?" do
+    it "returns true when the school matches the colleges scope" do
+      expect(build(:college)).to be_college
+    end
+
+    it "returns false when the school type does not match the colleges scope" do
+      expect(build(:school, detailed_school_type: School::FE_DETAILED_SCHOOL_TYPE)).not_to be_college
+    end
+
+    it "returns false when the detailed school type does not match the colleges scope" do
+      expect(build(:school, school_type: School::COLLEGE_SCHOOL_TYPE)).not_to be_college
+    end
+  end
+
   describe "#ats_interstitial_variant" do
     subject { build(:school, religious_character: religious_character) }
 

--- a/spec/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy_spec.rb
+++ b/spec/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy_spec.rb
@@ -78,6 +78,14 @@ RSpec.describe Vacancies::Export::DwpFindAJob::PublishedAndUpdated::ParsedVacanc
       it "returns the vacancy school offer info" do
         expect(parsed.description).to eq("What the school offers its staff\n\nSchool offer info")
       end
+
+      context "when the vacancy organisation is a college" do
+        let(:school) { build_stubbed(:college, safeguarding_information: nil) }
+
+        it "uses college wording" do
+          expect(parsed.description).to eq("What the college offers its staff\n\nSchool offer info")
+        end
+      end
     end
 
     context "when the vacancy has further details information" do

--- a/spec/system/jobseekers/jobseekers_can_view_a_vacancy_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_view_a_vacancy_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "Viewing a single published vacancy" do
       let(:vacancy) { create(:vacancy, :apply_via_website, organisations: [school]) }
 
       scenario "a jobseeker can click on the application link" do
-        click_on I18n.t("jobs.view_advert.school")
+        click_on I18n.t("jobs.view_advert.school.school")
 
         expect(page.current_url).to eq vacancy.application_link
       end

--- a/spec/system/jobseekers/jobseekers_can_view_a_vacancy_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_view_a_vacancy_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "Viewing a single published vacancy" do
       let(:vacancy) { create(:vacancy, :apply_via_website, organisations: [school]) }
 
       scenario "a jobseeker can click on the application link" do
-        click_on I18n.t("jobs.view_advert.school.school")
+        click_on I18n.t("jobs.view_advert.school")
 
         expect(page.current_url).to eq vacancy.application_link
       end

--- a/spec/views/vacancies/show.html.slim_spec.rb
+++ b/spec/views/vacancies/show.html.slim_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "vacancies/show" do
 
   describe "Jobseekers can apply for a vacancy" do
     context "with a website vacancy" do
-      let(:expected_link) { I18n.t("jobs.view_advert.school", href: "http://www.google.com") }
+      let(:expected_link) { I18n.t("jobs.view_advert.school.school", href: "http://www.google.com") }
       let(:jobseeker) { nil }
 
       context "with a published vacancy" do
@@ -97,6 +97,18 @@ RSpec.describe "vacancies/show" do
         end
 
         it "has an application link" do
+          expect(rendered).to have_link(expected_link)
+        end
+      end
+
+      context "with a college vacancy" do
+        let(:expected_link) { I18n.t("jobs.view_advert.school.college", href: "http://www.google.com") }
+        let(:vacancy) do
+          build_stubbed(:vacancy, :apply_via_website,
+                        application_link: "www.google.com", organisations: [build(:college)])
+        end
+
+        it "uses college wording for the application link" do
           expect(rendered).to have_link(expected_link)
         end
       end
@@ -177,6 +189,14 @@ RSpec.describe "vacancies/show" do
       end
     end
 
+    describe "View advert on college website" do
+      let(:vacancy) { build_stubbed(:vacancy, :apply_via_website, organisations: [build(:college)]) }
+
+      it "has the correct text" do
+        expect(rendered).to have_content("View advert on college website (opens in new tab)")
+      end
+    end
+
     describe "Download an application form" do
       let(:vacancy) { create(:vacancy, :with_application_form) }
 
@@ -190,6 +210,14 @@ RSpec.describe "vacancies/show" do
 
       it "has the correct text" do
         expect(rendered).to have_content("View advert on external website (opens in new tab)")
+      end
+    end
+
+    describe "External college notice" do
+      let(:vacancy) { build_stubbed(:vacancy, :external, organisations: [build(:college)]) }
+
+      it "uses college wording" do
+        expect(rendered).to have_content("This college accepts applications through their own website")
       end
     end
   end

--- a/spec/views/vacancies/show.html.slim_spec.rb
+++ b/spec/views/vacancies/show.html.slim_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "vacancies/show" do
 
   describe "Jobseekers can apply for a vacancy" do
     context "with a website vacancy" do
-      let(:expected_link) { I18n.t("jobs.view_advert.school.school", href: "http://www.google.com") }
+      let(:expected_link) { I18n.t("jobs.view_advert.school", href: "http://www.google.com") }
       let(:jobseeker) { nil }
 
       context "with a published vacancy" do
@@ -102,7 +102,7 @@ RSpec.describe "vacancies/show" do
       end
 
       context "with a college vacancy" do
-        let(:expected_link) { I18n.t("jobs.view_advert.school.college", href: "http://www.google.com") }
+        let(:expected_link) { I18n.t("jobs.view_advert.college", href: "http://www.google.com") }
         let(:vacancy) do
           build_stubbed(:vacancy, :apply_via_website,
                         application_link: "www.google.com", organisations: [build(:college)])


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/wtLLV6yk/2875-fe-job-page-for-colleges-jobseeker-journey

## Changes in this PR:

On the vacancy advert we have some references to schools, this change changes these to use "colleges" when applicable

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
