### PR TITLE
FE subjects for job alerts

### DIFF
--- a/app/views/publishers/vacancies/build/subjects.html.slim
+++ b/app/views/publishers/vacancies/build/subjects.html.slim
@@ -8,16 +8,18 @@
     label for="publishers-job-listing-job-details-form-subject-search"
       span.govuk-visually-hidden | Subject filter
 
+    - subject_options = vacancy.organisations.any?(&:college?) ? FURTHER_EDUCATION_SUBJECT_OPTIONS : SUBJECT_OPTIONS
+
     div class="govuk-!-margin-bottom-6"
       = searchable_collection(collection: f.govuk_collection_check_boxes(:subjects,
-        SUBJECT_OPTIONS,
+        subject_options,
         :first,
         :first,
         :last,
         legend: nil,
         hint: nil,
         classes: "checkbox-label__bold"),
-        collection_count: SUBJECT_OPTIONS.count,
+        collection_count: subject_options.count,
         options: { border: true },
         text: { aria_label: "search subjects" })
 

--- a/app/views/publishers/vacancies/build/subjects.html.slim
+++ b/app/views/publishers/vacancies/build/subjects.html.slim
@@ -8,7 +8,7 @@
     label for="publishers-job-listing-job-details-form-subject-search"
       span.govuk-visually-hidden | Subject filter
 
-    - subject_options = vacancy.organisations.any?(&:college?) ? FURTHER_EDUCATION_SUBJECT_OPTIONS : SUBJECT_OPTIONS
+    - subject_options = vacancy.organisations.any?(&:fe_college?) ? FURTHER_EDUCATION_SUBJECT_OPTIONS : SUBJECT_OPTIONS
 
     div class="govuk-!-margin-bottom-6"
       = searchable_collection(collection: f.govuk_collection_check_boxes(:subjects,

--- a/app/views/subscriptions/_fields.html.slim
+++ b/app/views/subscriptions/_fields.html.slim
@@ -36,14 +36,14 @@
       - subjects = capture do
         = govuk_details(summary_text: safe_join([tag.span(t("jobs.filters.subjects"), "aria-label": t("jobs.aria_labels.filters.subjects"), title: t("jobs.filters.subjects"))]), open: @form.subjects) do
           = f.govuk_collection_check_boxes(:subjects,
-            FURTHER_EDUCATION_SUBJECT_OPTIONS,
+            VACANCY_SEARCH_SUBJECT_OPTIONS,
               :first,
               :first,
               :last,
               small: true,
               legend: nil,
               hint: nil,
-              collection_count: FURTHER_EDUCATION_SUBJECT_OPTIONS.count,
+              collection_count: VACANCY_SEARCH_SUBJECT_OPTIONS.count,
               options: { scrollable: true },
               text: { aria_label: t("jobs.filters.subject"), placeholder: t("helpers.hint.publishers_job_listing_subjects_form.subjects_placeholder") })
 

--- a/app/views/subscriptions/_fields.html.slim
+++ b/app/views/subscriptions/_fields.html.slim
@@ -36,14 +36,14 @@
       - subjects = capture do
         = govuk_details(summary_text: safe_join([tag.span(t("jobs.filters.subjects"), "aria-label": t("jobs.aria_labels.filters.subjects"), title: t("jobs.filters.subjects"))]), open: @form.subjects) do
           = f.govuk_collection_check_boxes(:subjects,
-              SUBJECT_OPTIONS,
+            FURTHER_EDUCATION_SUBJECT_OPTIONS,
               :first,
               :first,
               :last,
               small: true,
               legend: nil,
               hint: nil,
-              collection_count: SUBJECT_OPTIONS.count,
+              collection_count: FURTHER_EDUCATION_SUBJECT_OPTIONS.count,
               options: { scrollable: true },
               text: { aria_label: t("jobs.filters.subject"), placeholder: t("helpers.hint.publishers_job_listing_subjects_form.subjects_placeholder") })
 

--- a/config/initializers/subjects.rb
+++ b/config/initializers/subjects.rb
@@ -2,6 +2,9 @@ base_path = Rails.root.join("config/data")
 
 SUBJECT_OPTIONS = YAML.load_file(base_path.join("subjects.yml"))
 FURTHER_EDUCATION_SUBJECT_OPTIONS = YAML.load_file(base_path.join("further_education_subjects.yml"))
+
+# de-duplicated list - use this for JebSeeker side when we don't know FE/School,
+# other lists Hiring staff side when we do (vacancy organisations contains an FE college)
 VACANCY_SEARCH_SUBJECT_OPTIONS = (SUBJECT_OPTIONS + FURTHER_EDUCATION_SUBJECT_OPTIONS)
   .uniq { |subject, _hint| subject.downcase }
   .sort_by { |subject, _hint| subject.downcase }

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -113,7 +113,7 @@ FactoryBot.define do
 
       # Subjects are ignored when phases don't include secondary
       # SUBJECT_OPTIONS is a list of pairs (to go directly into an HTML select)
-      subjects { factory_sample(SUBJECT_OPTIONS.map(&:first), 2).sort }
+      subjects { factory_sample(FURTHER_EDUCATION_SUBJECT_OPTIONS.map(&:first), 3).sort }
 
       key_stages { factory_rand_sample(key_stages_for_phases, 2..3) }
       rand_contract_type = Vacancy.contract_types.keys.sample

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -113,7 +113,7 @@ FactoryBot.define do
 
       # Subjects are ignored when phases don't include secondary
       # SUBJECT_OPTIONS is a list of pairs (to go directly into an HTML select)
-      subjects { factory_sample(FURTHER_EDUCATION_SUBJECT_OPTIONS.map(&:first), 3).sort }
+      subjects { factory_sample(VACANCY_SEARCH_SUBJECT_OPTIONS.map(&:first), 3).sort }
 
       key_stages { factory_rand_sample(key_stages_for_phases, 2..3) }
       rand_contract_type = Vacancy.contract_types.keys.sample

--- a/spec/lib/tasks/db_migrate_ignore_concurrent_migration_exceptions_rake_task_spec.rb
+++ b/spec/lib/tasks/db_migrate_ignore_concurrent_migration_exceptions_rake_task_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "db:migrate:ignore_concurrent_migration_exceptions" do
 
     subject.execute
 
-    expect(Rake::Task["db:migrate"]).to have_received(:invoke)
+    expect(Rake::Task["db:migrate"]).to have_received(:invoke).at_least(:once)
   end
 
   it "swallows ActiveRecord::ConcurrentMigrationError" do

--- a/spec/system/publishers/publishers_can_edit_a_vacancy_template_spec.rb
+++ b/spec/system/publishers/publishers_can_edit_a_vacancy_template_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "Editing a vacancy template" do
     context "with role" do
       let(:change) { "job_role" }
 
-      it "can have its role edited" do
+      it "can have its role edited", :retry do
         expect(page).to have_content "What type of job is this?"
         expect(page).to be_axe_clean
 


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/89g99dNH/2896-update-the-college-list-of-subjects

## Changes in this PR:

Job alerts subjects list