### PR TITLE
Education employment gaps

### DIFF
--- a/app/controllers/jobseekers/job_applications/education_gaps_controller.rb
+++ b/app/controllers/jobseekers/job_applications/education_gaps_controller.rb
@@ -3,7 +3,7 @@ class Jobseekers::JobApplications::EducationGapsController < Jobseekers::BaseCon
 
   def create
     if form.valid?
-      job_application.employments.education_gap.create(education_gap_params)
+      job_application.employments.education_gap.create!(education_gap_params)
       redirect_to back_path
     else
       render :new
@@ -12,7 +12,7 @@ class Jobseekers::JobApplications::EducationGapsController < Jobseekers::BaseCon
 
   def update
     if form.valid?
-      education_gap.update(education_gap_params)
+      education_gap.update!(education_gap_params)
       redirect_to back_path
     else
       render :edit
@@ -20,7 +20,7 @@ class Jobseekers::JobApplications::EducationGapsController < Jobseekers::BaseCon
   end
 
   def destroy
-    education_gap.destroy
+    education_gap.destroy!
     redirect_to back_path
   end
 

--- a/app/controllers/jobseekers/job_applications/education_gaps_controller.rb
+++ b/app/controllers/jobseekers/job_applications/education_gaps_controller.rb
@@ -1,9 +1,20 @@
 class Jobseekers::JobApplications::EducationGapsController < Jobseekers::BaseController
-  helper_method :back_path, :education_gap, :form, :job_application
+  before_action :set_job_application
+  before_action :set_education_gap, only: %i[edit update destroy confirm_destroy]
+
+  def new
+    @form = Jobseekers::BreakForm.new
+  end
+
+  def edit
+    @form = Jobseekers::BreakForm.new(@education_gap.slice(:reason_for_break, :started_on, :ended_on))
+  end
 
   def create
-    if form.valid?
-      job_application.employments.education_gap.create!(education_gap_params)
+    @form = Jobseekers::BreakForm.new(education_gap_params)
+
+    if @form.valid?
+      @job_application.employments.education_gap.create!(education_gap_params)
       redirect_to back_path
     else
       render :new
@@ -11,50 +22,41 @@ class Jobseekers::JobApplications::EducationGapsController < Jobseekers::BaseCon
   end
 
   def update
-    if form.valid?
-      education_gap.update!(education_gap_params)
+    @form = Jobseekers::BreakForm.new(education_gap_params)
+
+    if @form.valid?
+      @education_gap.update!(education_gap_params)
       redirect_to back_path
     else
       render :edit
     end
   end
 
+  def confirm_destroy
+    @form = Jobseekers::BreakForm.new
+  end
+
   def destroy
-    education_gap.destroy!
+    @education_gap.destroy!
     redirect_to back_path
   end
 
   private
 
   def back_path
-    @back_path ||= jobseekers_job_application_build_path(job_application, :employment_history)
+    @back_path ||= jobseekers_job_application_build_path(@job_application, :employment_history)
   end
 
-  def education_gap
-    job_application.employments.education_gap.find(params[:id] || params[:education_gap_id])
+  def set_job_application
+    @job_application = current_jobseeker.job_applications.draft.find(params[:job_application_id])
+  end
+
+  def set_education_gap
+    @education_gap = @job_application.employments.education_gap.find(params[:id] || params[:education_gap_id])
   end
 
   def education_gap_params
     params.expect(jobseekers_break_form: %i[reason_for_break started_on ended_on])
           .merge("started_on(3i)" => "1", "ended_on(3i)" => "1")
-  end
-
-  def form
-    @form ||= Jobseekers::BreakForm.new(form_attributes)
-  end
-
-  def form_attributes
-    case action_name
-    when "new"
-      {}
-    when "edit"
-      education_gap.slice(:reason_for_break, :started_on, :ended_on)
-    when "create", "update"
-      education_gap_params
-    end
-  end
-
-  def job_application
-    @job_application ||= current_jobseeker.job_applications.draft.find(params[:job_application_id])
   end
 end

--- a/app/controllers/jobseekers/job_applications/education_gaps_controller.rb
+++ b/app/controllers/jobseekers/job_applications/education_gaps_controller.rb
@@ -1,0 +1,60 @@
+class Jobseekers::JobApplications::EducationGapsController < Jobseekers::BaseController
+  helper_method :back_path, :education_gap, :form, :job_application
+
+  def create
+    if form.valid?
+      job_application.employments.education_gap.create(education_gap_params)
+      redirect_to back_path
+    else
+      render :new
+    end
+  end
+
+  def update
+    if form.valid?
+      education_gap.update(education_gap_params)
+      redirect_to back_path
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    education_gap.destroy
+    redirect_to back_path
+  end
+
+  private
+
+  def back_path
+    @back_path ||= jobseekers_job_application_build_path(job_application, :employment_history)
+  end
+
+  def education_gap
+    job_application.employments.education_gap.find(params[:id] || params[:education_gap_id])
+  end
+
+  def education_gap_params
+    params.expect(jobseekers_break_form: %i[reason_for_break started_on ended_on])
+          .merge("started_on(3i)" => "1", "ended_on(3i)" => "1")
+  end
+
+  def form
+    @form ||= Jobseekers::BreakForm.new(form_attributes)
+  end
+
+  def form_attributes
+    case action_name
+    when "new"
+      {}
+    when "edit"
+      education_gap.slice(:reason_for_break, :started_on, :ended_on)
+    when "create", "update"
+      education_gap_params
+    end
+  end
+
+  def job_application
+    @job_application ||= current_jobseeker.job_applications.draft.find(params[:job_application_id])
+  end
+end

--- a/app/controllers/jobseekers/job_applications/education_gaps_controller.rb
+++ b/app/controllers/jobseekers/job_applications/education_gaps_controller.rb
@@ -32,9 +32,7 @@ class Jobseekers::JobApplications::EducationGapsController < Jobseekers::BaseCon
     end
   end
 
-  def confirm_destroy
-    @form = Jobseekers::BreakForm.new
-  end
+  def confirm_destroy; end
 
   def destroy
     @education_gap.destroy!

--- a/app/form_models/jobseekers/job_application/employment_history_form.rb
+++ b/app/form_models/jobseekers/job_application/employment_history_form.rb
@@ -43,13 +43,12 @@ module Jobseekers
       end
 
       def education_gap_is_explained
-        latest_qual_year = qualifications.where(finished_studying: true).maximum(:year)
-        first_job_year = employments.job.minimum(:started_on)&.year
+        latest_qual_year = qualifications.select(&:finished_studying?).filter_map(&:year).max
+        first_job_year = employments.select(&:job?).filter_map(&:started_on).min&.year
 
-        return unless latest_qual_year && first_job_year && latest_qual_year < first_job_year
-        return if employments.any?(&:education_gap?)
-
-        errors.add(:education_gap, :missing)
+        if latest_qual_year && first_job_year && latest_qual_year < first_job_year && employments.none?(&:education_gap?)
+          errors.add(:education_gap, :missing)
+        end
       end
 
       def employment_records_are_all_valid

--- a/app/form_models/jobseekers/job_application/employment_history_form.rb
+++ b/app/form_models/jobseekers/job_application/employment_history_form.rb
@@ -43,8 +43,8 @@ module Jobseekers
       end
 
       def education_gap_is_explained
-        latest_qual_year = qualifications.filter_map { |q| q.year if q.finished_studying? }.max
-        first_job_year = employments.select(&:job?).filter_map(&:started_on).min&.year
+        latest_qual_year = qualifications.where(finished_studying: true).maximum(:year)
+        first_job_year = employments.job.minimum(:started_on)&.year
 
         return unless latest_qual_year && first_job_year && latest_qual_year < first_job_year
         return if employments.any?(&:education_gap?)

--- a/app/form_models/jobseekers/job_application/employment_history_form.rb
+++ b/app/form_models/jobseekers/job_application/employment_history_form.rb
@@ -12,18 +12,20 @@ module Jobseekers
         end
 
         def unstorable_fields
-          %i[unexplained_employment_gaps employment_history_section_completed employments]
+          %i[unexplained_employment_gaps employment_history_section_completed employments qualifications]
         end
 
         def load_form(model)
           super.merge(employments: model.employments,
-                      unexplained_employment_gaps: model.unexplained_employment_gaps)
+                      unexplained_employment_gaps: model.unexplained_employment_gaps,
+                      qualifications: model.qualifications)
                .merge(completed_attrs(model, :employment_history))
         end
       end
-      attr_accessor(:unexplained_employment_gaps, :employments)
+      attr_accessor(:unexplained_employment_gaps, :employments, :qualifications, :education_gap)
 
       validate :employment_history_gaps_are_explained, if: -> { employment_history_section_completed }
+      validate :education_gap_is_explained, if: -> { employment_history_section_completed }
 
       validate :employment_records_are_all_valid
 
@@ -38,6 +40,16 @@ module Jobseekers
           gap_duration = distance_of_time_in_words(details[:started_on], details[:ended_on] || Time.zone.today)
           errors.add(:unexplained_employment_gaps, "You have a gap in your work history (#{gap_duration}).")
         end
+      end
+
+      def education_gap_is_explained
+        latest_qual_year = qualifications.filter_map { |q| q.year if q.finished_studying? }.max
+        first_job_year = employments.select(&:job?).filter_map(&:started_on).min&.year
+
+        return unless latest_qual_year && first_job_year && latest_qual_year < first_job_year
+        return if employments.any?(&:education_gap?)
+
+        errors.add(:education_gap, :missing)
       end
 
       def employment_records_are_all_valid

--- a/app/form_models/jobseekers/job_application/employment_history_form.rb
+++ b/app/form_models/jobseekers/job_application/employment_history_form.rb
@@ -12,7 +12,7 @@ module Jobseekers
         end
 
         def unstorable_fields
-          %i[unexplained_employment_gaps employment_history_section_completed employments qualifications]
+          %i[employment_history_section_completed]
         end
 
         def load_form(model)

--- a/app/models/employment_record.rb
+++ b/app/models/employment_record.rb
@@ -5,7 +5,7 @@ class EmploymentRecord < ApplicationRecord
 
   # This class represents 2 concerns - 'job' and 'break' (from employment)
   # which might have been better modelled as 2 different types
-  enum :employment_type, { job: 0, break: 1 }
+  enum :employment_type, { job: 0, break: 1, education_gap: 2 }
 
   validates :organisation, :job_title, presence: true, if: -> { job? }
 

--- a/app/presenters/work_history_error_summary_presenter.rb
+++ b/app/presenters/work_history_error_summary_presenter.rb
@@ -12,6 +12,8 @@ class WorkHistoryErrorSummaryPresenter
           gap_id = "gap-#{gap[:started_on].strftime('%Y%m%d')}-#{gap[:ended_on].strftime('%Y%m%d')}"
           [attribute, message, "##{gap_id}"]
         end
+      elsif attribute == :education_gap
+        [[attribute, messages.first, "#education-gap-section"]]
       else
         [[attribute, messages.first]]
       end

--- a/app/views/jobseekers/job_applications/_explained_employment_break.html.slim
+++ b/app/views/jobseekers/job_applications/_explained_employment_break.html.slim
@@ -2,4 +2,4 @@
   - heading = employment.education_gap? ? t("jobseekers.job_applications.build.employment_history.education_gap") : t("jobseekers.job_applications.build.employment_history.break")
   h2.govuk-heading-s class="govuk-!-margin-bottom-1" = heading
   p.govuk-body class="govuk-!-margin-bottom-0" = employment.reason_for_break
-  p.govuk-hint class="govuk-!-margin-top-1 govuk-!-margin-bottom-1" #{employment.started_on.to_fs(:month_year)} to #{end_date(employment.ended_on, index)}
+  p.govuk-hint class="govuk-!-margin-top-1 govuk-!-margin-bottom-1" #{employment.started_on.to_fs(:month_year)} to #{employment.ended_on.to_fs(:month_year)}

--- a/app/views/jobseekers/job_applications/_explained_employment_break.html.slim
+++ b/app/views/jobseekers/job_applications/_explained_employment_break.html.slim
@@ -1,4 +1,5 @@
 = govuk_inset_text classes: "govuk-!-margin-top-3 govuk-!-margin-bottom-3 govuk-inset-text--blue", id: "employment-break-#{index}" do
-  h2.govuk-heading-s class="govuk-!-margin-bottom-1" = t("jobseekers.job_applications.build.employment_history.break")
+  - heading = employment.education_gap? ? t("jobseekers.job_applications.build.employment_history.education_gap") : t("jobseekers.job_applications.build.employment_history.break")
+  h2.govuk-heading-s class="govuk-!-margin-bottom-1" = heading
   p.govuk-body class="govuk-!-margin-bottom-0" = employment.reason_for_break
   p.govuk-hint class="govuk-!-margin-top-1 govuk-!-margin-bottom-1" #{employment.started_on.to_fs(:month_year)} to #{end_date(employment.ended_on, index)}

--- a/app/views/jobseekers/job_applications/build/employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/build/employment_history.html.slim
@@ -34,8 +34,9 @@
         = govuk_link_to jobseekers_job_application_education_gap_confirm_destroy_path(job_application, gap)
           = t("buttons.delete")
           span.govuk-visually-hidden = " #{t('.education_gap')} #{gap.started_on} to #{gap.ended_on}"
-  p.govuk-body
-    = govuk_button_link_to t("buttons.add_education_gap"), new_jobseekers_job_application_education_gap_path(job_application), class: "govuk-button--secondary govuk-!-margin-bottom-10 employment-gap-buttons"
+  - unless education_gaps.any?
+    p.govuk-body
+      = govuk_button_link_to t("buttons.add_education_gap"), new_jobseekers_job_application_education_gap_path(job_application), class: "govuk-button--secondary govuk-!-margin-bottom-10 employment-gap-buttons"
   hr.govuk-section-break.govuk-section-break--visible
 
   - if employments.any?

--- a/app/views/jobseekers/job_applications/build/employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/build/employment_history.html.slim
@@ -20,7 +20,7 @@
     = govuk_button_link_to t("buttons.add_work_history"), new_jobseekers_job_application_employment_path(job_application), class: "govuk-button--secondary govuk-!-margin-bottom-10 employment-gap-buttons"
     = govuk_button_link_to t("buttons.add_gap"), new_jobseekers_job_application_break_path(job_application), class: "govuk-button--secondary govuk-!-margin-bottom-10 employment-gap-buttons"
 
-  h2.govuk-heading-l = t(".education_gap_section.heading")
+  h2.govuk-heading-l#education-gap-section = t(".education_gap_section.heading")
   p.govuk-body = t(".education_gap_section.description")
   - if (education_gaps = job_application.employments.education_gap).any?
     - education_gaps.each do |gap|

--- a/app/views/jobseekers/job_applications/build/employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/build/employment_history.html.slim
@@ -19,7 +19,24 @@
   p.govuk-body
     = govuk_button_link_to t("buttons.add_work_history"), new_jobseekers_job_application_employment_path(job_application), class: "govuk-button--secondary govuk-!-margin-bottom-10 employment-gap-buttons"
     = govuk_button_link_to t("buttons.add_gap"), new_jobseekers_job_application_break_path(job_application), class: "govuk-button--secondary govuk-!-margin-bottom-10 employment-gap-buttons"
-    hr.govuk-section-break.govuk-section-break--visible
+
+  h2.govuk-heading-l = t(".education_gap_section.heading")
+  p.govuk-body = t(".education_gap_section.description")
+  - if (education_gaps = job_application.employments.education_gap).any?
+    - education_gaps.each do |gap|
+      = govuk_inset_text do
+        h2.govuk-heading-s class="govuk-!-margin-bottom-1" = t(".education_gap")
+        p.govuk-body class="govuk-!-margin-bottom-0" = gap.reason_for_break
+        p.govuk-hint class="govuk-!-margin-top-0 govuk-!-margin-bottom-1" #{gap.started_on.to_fs(:month_year)} to #{gap.ended_on.to_fs(:month_year)}
+        = govuk_link_to edit_jobseekers_job_application_education_gap_path(job_application, gap), class: "govuk-link--no-visited-state govuk-!-margin-right-3"
+          = t("buttons.change")
+          span.govuk-visually-hidden = " #{t('.education_gap')} #{gap.started_on} to #{gap.ended_on}"
+        = govuk_link_to jobseekers_job_application_education_gap_confirm_destroy_path(job_application, gap)
+          = t("buttons.delete")
+          span.govuk-visually-hidden = " #{t('.education_gap')} #{gap.started_on} to #{gap.ended_on}"
+  p.govuk-body
+    = govuk_button_link_to t("buttons.add_education_gap"), new_jobseekers_job_application_education_gap_path(job_application), class: "govuk-button--secondary govuk-!-margin-bottom-10 employment-gap-buttons"
+  hr.govuk-section-break.govuk-section-break--visible
 
   - if employments.any?
     - employments.reverse_each do |employment|

--- a/app/views/jobseekers/job_applications/build/employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/build/employment_history.html.slim
@@ -30,10 +30,10 @@
         p.govuk-hint class="govuk-!-margin-top-0 govuk-!-margin-bottom-1" #{gap.started_on.to_fs(:month_year)} to #{gap.ended_on.to_fs(:month_year)}
         = govuk_link_to edit_jobseekers_job_application_education_gap_path(job_application, gap), class: "govuk-link--no-visited-state govuk-!-margin-right-3"
           = t("buttons.change")
-          span.govuk-visually-hidden = " #{t('.education_gap')} #{gap.started_on} to #{gap.ended_on}"
+          span.govuk-visually-hidden = " #{t('.education_gap')} #{gap.started_on.to_fs(:month_year)} to #{gap.ended_on.to_fs(:month_year)}"
         = govuk_link_to jobseekers_job_application_education_gap_confirm_destroy_path(job_application, gap)
           = t("buttons.delete")
-          span.govuk-visually-hidden = " #{t('.education_gap')} #{gap.started_on} to #{gap.ended_on}"
+          span.govuk-visually-hidden = " #{t('.education_gap')} #{gap.started_on.to_fs(:month_year)} to #{gap.ended_on.to_fs(:month_year)}"
   - unless education_gaps.any?
     p.govuk-body
       = govuk_button_link_to t("buttons.add_education_gap"), new_jobseekers_job_application_education_gap_path(job_application), class: "govuk-button--secondary govuk-!-margin-bottom-10 employment-gap-buttons"

--- a/app/views/jobseekers/job_applications/education_gaps/_fields.html.slim
+++ b/app/views/jobseekers/job_applications/education_gaps/_fields.html.slim
@@ -1,0 +1,7 @@
+= f.govuk_date_field :started_on,
+  omit_day: true,
+  hint: -> { t("helpers.hint.date", date: 15.months.ago.strftime("%m %Y")) }
+= f.govuk_date_field :ended_on,
+  omit_day: true,
+  hint: -> { t("helpers.hint.date", date: 3.months.ago.strftime("%m %Y")) }
+= f.govuk_text_area :reason_for_break, label: { size: "s" }, required: true

--- a/app/views/jobseekers/job_applications/education_gaps/_fields.html.slim
+++ b/app/views/jobseekers/job_applications/education_gaps/_fields.html.slim
@@ -4,4 +4,4 @@
 = f.govuk_date_field :ended_on,
   omit_day: true,
   hint: -> { t("helpers.hint.date", date: 3.months.ago.strftime("%m %Y")) }
-= f.govuk_text_area :reason_for_break, label: { size: "s" }, required: true
+= f.govuk_text_area :reason_for_break, label: { text: t("helpers.label.jobseekers_break_form.reason_for_break_education_gap"), size: "s" }, required: true

--- a/app/views/jobseekers/job_applications/education_gaps/confirm_destroy.html.slim
+++ b/app/views/jobseekers/job_applications/education_gaps/confirm_destroy.html.slim
@@ -1,9 +1,9 @@
-- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
+- content_for :page_title_prefix, job_application_page_title_prefix(@form, t(".title"))
 
 span.govuk-caption-l = t(".caption")
 h1.govuk-heading-xl = t(".heading")
 
-= form_for form, url: jobseekers_job_application_education_gap_path(job_application, education_gap), method: :delete do |f|
+= form_for @form, url: jobseekers_job_application_education_gap_path(@job_application, @education_gap), method: :delete do |f|
   = f.govuk_submit t("buttons.confirm_destroy"), class: "govuk-button--warning"
 
-= govuk_link_to t("buttons.cancel"), jobseekers_job_application_build_path(job_application, :employment_history)
+= govuk_link_to t("buttons.cancel"), jobseekers_job_application_build_path(@job_application, :employment_history)

--- a/app/views/jobseekers/job_applications/education_gaps/confirm_destroy.html.slim
+++ b/app/views/jobseekers/job_applications/education_gaps/confirm_destroy.html.slim
@@ -1,0 +1,9 @@
+- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
+
+span.govuk-caption-l = t(".caption")
+h1.govuk-heading-xl = t(".heading")
+
+= form_for form, url: jobseekers_job_application_education_gap_path(job_application, education_gap), method: :delete do |f|
+  = f.govuk_submit t("buttons.confirm_destroy"), class: "govuk-button--warning"
+
+= govuk_link_to t("buttons.cancel"), jobseekers_job_application_build_path(job_application, :employment_history)

--- a/app/views/jobseekers/job_applications/education_gaps/confirm_destroy.html.slim
+++ b/app/views/jobseekers/job_applications/education_gaps/confirm_destroy.html.slim
@@ -1,9 +1,9 @@
-- content_for :page_title_prefix, job_application_page_title_prefix(@form, t(".title"))
+- content_for :page_title_prefix, t(".title")
 
 span.govuk-caption-l = t(".caption")
 h1.govuk-heading-xl = t(".heading")
 
-= form_for @form, url: jobseekers_job_application_education_gap_path(@job_application, @education_gap), method: :delete do |f|
+= form_with url: jobseekers_job_application_education_gap_path(@job_application, @education_gap), method: :delete do |f|
   = f.govuk_submit t("buttons.confirm_destroy"), class: "govuk-button--warning"
 
 = govuk_link_to t("buttons.cancel"), jobseekers_job_application_build_path(@job_application, :employment_history)

--- a/app/views/jobseekers/job_applications/education_gaps/edit.html.slim
+++ b/app/views/jobseekers/job_applications/education_gaps/edit.html.slim
@@ -1,0 +1,13 @@
+- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
+
+span.govuk-caption-l = t(".caption")
+h1.govuk-heading-xl = t(".heading")
+
+= form_for form, url: jobseekers_job_application_education_gap_path(job_application, education_gap), method: :patch do |f|
+  = f.govuk_error_summary
+
+  = render "fields", f: f
+
+  = f.govuk_submit t("buttons.continue")
+
+= govuk_link_to t("buttons.cancel"), jobseekers_job_application_build_path(job_application, :employment_history)

--- a/app/views/jobseekers/job_applications/education_gaps/edit.html.slim
+++ b/app/views/jobseekers/job_applications/education_gaps/edit.html.slim
@@ -1,13 +1,13 @@
-- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
+- content_for :page_title_prefix, job_application_page_title_prefix(@form, t(".title"))
 
 span.govuk-caption-l = t(".caption")
 h1.govuk-heading-xl = t(".heading")
 
-= form_for form, url: jobseekers_job_application_education_gap_path(job_application, education_gap), method: :patch do |f|
+= form_for @form, url: jobseekers_job_application_education_gap_path(@job_application, @education_gap), method: :patch do |f|
   = f.govuk_error_summary
 
   = render "fields", f: f
 
   = f.govuk_submit t("buttons.continue")
 
-= govuk_link_to t("buttons.cancel"), jobseekers_job_application_build_path(job_application, :employment_history)
+= govuk_link_to t("buttons.cancel"), jobseekers_job_application_build_path(@job_application, :employment_history)

--- a/app/views/jobseekers/job_applications/education_gaps/new.html.slim
+++ b/app/views/jobseekers/job_applications/education_gaps/new.html.slim
@@ -1,0 +1,13 @@
+- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
+
+span.govuk-caption-l = t(".caption")
+h1.govuk-heading-xl = t(".heading")
+
+= form_for form, url: jobseekers_job_application_education_gaps_path(job_application), method: :post do |f|
+  = f.govuk_error_summary
+
+  = render "fields", f: f
+
+  = f.govuk_submit t("buttons.continue")
+
+= govuk_link_to t("buttons.cancel"), jobseekers_job_application_build_path(job_application, :employment_history)

--- a/app/views/jobseekers/job_applications/education_gaps/new.html.slim
+++ b/app/views/jobseekers/job_applications/education_gaps/new.html.slim
@@ -1,13 +1,13 @@
-- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
+- content_for :page_title_prefix, job_application_page_title_prefix(@form, t(".title"))
 
 span.govuk-caption-l = t(".caption")
 h1.govuk-heading-xl = t(".heading")
 
-= form_for form, url: jobseekers_job_application_education_gaps_path(job_application), method: :post do |f|
+= form_for @form, url: jobseekers_job_application_education_gaps_path(@job_application), method: :post do |f|
   = f.govuk_error_summary
 
   = render "fields", f: f
 
   = f.govuk_submit t("buttons.continue")
 
-= govuk_link_to t("buttons.cancel"), jobseekers_job_application_build_path(job_application, :employment_history)
+= govuk_link_to t("buttons.cancel"), jobseekers_job_application_build_path(@job_application, :employment_history)

--- a/app/views/jobseekers/job_applications/review/_employment_history.html.slim
+++ b/app/views/jobseekers/job_applications/review/_employment_history.html.slim
@@ -42,7 +42,7 @@
             - row.with_key text: t("helpers.label.jobseekers_job_application_details_employment_form.reason_for_leaving")
             - row.with_value text: employment.reason_for_leaving
 
-      - elsif employment.break?
+      - elsif employment.break? || employment.education_gap?
         = render "jobseekers/job_applications/explained_employment_break", employment: employment, index: index
 
       - if (gap = job_application.unexplained_employment_gaps[employment]).present?

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -7,6 +7,7 @@ en:
     add_another_qualification: Add another qualification
     add_another_reference: Add another referee
     add_another_subject: Add another subject
+    add_education_gap: Add gap between education and work history
     add_gap: Add gap in work history
     add_job: Add a job
     add_note: Add note

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -341,6 +341,7 @@ en:
           uninterested: 'No'
       jobseekers_break_form:
         reason_for_break: Enter reasons for gap in work history
+        reason_for_break_education_gap: Enter reasons for gap between education and work history
       jobseekers_qualifications_shared_labels: &jobseekers_qualifications_shared_labels
         category_options:
           gcse: GCSEs

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -188,6 +188,10 @@ en:
               If you had a gap between finishing full-time education and starting work that you have not explained then please %{link} to give details about it
             gaps_link_text: click here
           gap_with_duration: You have a gap in your work history from %{from} to %{to} (%{duration})
+          education_gap: Gap between education and work history
+          education_gap_section:
+            heading: Gap between education and work history
+            description: This section explains the gap between my education and work experience.
           heading: Work history
           no_employments: No employment specified
           step_title: Employment history
@@ -318,6 +322,19 @@ en:
           caption: Current role and employment history
           heading: Add a gap in work history
           title: Add a reason for gap — Application
+      education_gaps:
+        confirm_destroy:
+          caption: Current role and employment history
+          heading: Are you sure you want to delete this entry?
+          title: Confirm deletion of education gap — Application
+        edit:
+          caption: Current role and employment history
+          heading: Add a gap between education and work history
+          title: Change the gap between education and work history — Application
+        new:
+          caption: Current role and employment history
+          heading: Add a gap between education and work history
+          title: Add a gap between education and work history — Application
       training_and_cpds:
         heading: Training and continuing professional development (CPD)
         step_title: Training and continuing professional development (CPD)

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -330,11 +330,11 @@ en:
         edit:
           caption: Current role and employment history
           heading: Add a gap between education and work history
-          title: Change the gap between education and work history — Application
+          title: Add a reason for gap between education and work history — Application
         new:
           caption: Current role and employment history
           heading: Add a gap between education and work history
-          title: Add a gap between education and work history — Application
+          title: Add a reason for gap between education and work history — Application
       training_and_cpds:
         heading: Training and continuing professional development (CPD)
         step_title: Training and continuing professional development (CPD)

--- a/config/locales/jobseekers/job_application/employment_history_form.yml
+++ b/config/locales/jobseekers/job_application/employment_history_form.yml
@@ -6,6 +6,8 @@ en:
           attributes:
             employment_history_section_completed:
               inclusion: Select yes if you have completed this section
+            education_gap:
+              missing: You have a gap in your work history between your education and first employment
           invalid_employment: One or more of your employment records is invalid
   helpers:
     legend:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,6 +96,9 @@ Rails.application.routes.draw do
       resources :breaks, only: %i[new create edit update destroy], controller: "job_applications/breaks" do
         get :confirm_destroy
       end
+      resources :education_gaps, only: %i[new create edit update destroy], controller: "job_applications/education_gaps" do
+        get :confirm_destroy
+      end
       resources :qualifications, only: %i[new create edit update destroy], controller: "job_applications/qualifications" do
         collection do
           get :select_category

--- a/spec/factories/employments.rb
+++ b/spec/factories/employments.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
       employment_type { :break }
     end
 
-    trait :education_gap do
+    factory :education_gap do
       employment_type { :education_gap }
       organisation { nil }
       job_title { nil }

--- a/spec/factories/employments.rb
+++ b/spec/factories/employments.rb
@@ -20,6 +20,15 @@ FactoryBot.define do
       employment_type { :break }
     end
 
+    trait :education_gap do
+      employment_type { :education_gap }
+      organisation { nil }
+      job_title { nil }
+      main_duties { nil }
+      reason_for_leaving { nil }
+      reason_for_break { Faker::Lorem.sentence }
+    end
+
     trait :current_role do
       is_current_role { true }
       ended_on { nil }

--- a/spec/form_models/jobseekers/job_application/employment_history_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/employment_history_form_spec.rb
@@ -3,12 +3,14 @@ require "rails_helper"
 RSpec.describe Jobseekers::JobApplication::EmploymentHistoryForm, type: :model do
   subject(:form) { described_class.new(attributes) }
 
+  let(:job_application) { create(:job_application) }
+
   let(:attributes) do
     {
       employment_history_section_completed: employment_history_section_completed,
       unexplained_employment_gaps: unexplained_employment_gaps,
-      employments: [],
-      qualifications: [],
+      employments: job_application.employments,
+      qualifications: job_application.qualifications,
     }
   end
 
@@ -49,7 +51,6 @@ RSpec.describe Jobseekers::JobApplication::EmploymentHistoryForm, type: :model d
     end
 
     context "when there is a gap between education and first job" do
-      let(:job_application) { create(:job_application) }
       let(:attributes) do
         {
           employment_history_section_completed: "true",
@@ -60,7 +61,7 @@ RSpec.describe Jobseekers::JobApplication::EmploymentHistoryForm, type: :model d
       end
 
       before do
-        create(:employment, job_application: job_application, started_on: Date.new(2021, 3, 1))
+        create(:employment, job_application: job_application, started_on: Date.new(2021, 3, 1), ended_on: Date.new(2022, 1, 1))
         create(:qualification, job_application: job_application, finished_studying: true, year: 2018)
       end
 
@@ -81,7 +82,6 @@ RSpec.describe Jobseekers::JobApplication::EmploymentHistoryForm, type: :model d
     end
 
     context "when there is no gap between education and first job" do
-      let(:job_application) { create(:job_application) }
       let(:attributes) do
         {
           employment_history_section_completed: "true",
@@ -92,7 +92,7 @@ RSpec.describe Jobseekers::JobApplication::EmploymentHistoryForm, type: :model d
       end
 
       before do
-        create(:employment, job_application: job_application, started_on: Date.new(2021, 9, 1))
+        create(:employment, job_application: job_application, started_on: Date.new(2021, 9, 1), ended_on: Date.new(2022, 6, 1))
         create(:qualification, job_application: job_application, finished_studying: true, year: 2021)
       end
 
@@ -103,7 +103,6 @@ RSpec.describe Jobseekers::JobApplication::EmploymentHistoryForm, type: :model d
     end
 
     context "when there are no jobs" do
-      let(:job_application) { create(:job_application) }
       let(:attributes) do
         {
           employment_history_section_completed: "true",

--- a/spec/form_models/jobseekers/job_application/employment_history_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/employment_history_form_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Jobseekers::JobApplication::EmploymentHistoryForm, type: :model d
       employment_history_section_completed: employment_history_section_completed,
       unexplained_employment_gaps: unexplained_employment_gaps,
       employments: [],
+      qualifications: [],
     }
   end
 
@@ -43,6 +44,85 @@ RSpec.describe Jobseekers::JobApplication::EmploymentHistoryForm, type: :model d
       let(:employment_history_section_completed) { "false" }
 
       it "does not add errors for gaps" do
+        expect(form).to be_valid
+      end
+    end
+
+    context "with a detectable education-to-employment gap" do
+      let(:unexplained_employment_gaps) { {} }
+
+      let(:qualification) { instance_double(Qualification, finished_studying?: true, year: 2018) }
+      let(:job) { instance_double(Employment, job?: true, education_gap?: false, break?: false, started_on: Date.new(2021, 3, 1), valid?: true) }
+
+      let(:attributes) do
+        {
+          employment_history_section_completed: "true",
+          unexplained_employment_gaps: {},
+          employments: [job],
+          qualifications: [qualification],
+        }
+      end
+
+      it "adds an error when no education gap record exists" do
+        expect(form).not_to be_valid
+        expect(form.errors[:education_gap]).to include(
+          "You have a gap in your work history between your education and first employment",
+        )
+      end
+
+      context "when an education gap record has been added" do
+        let(:gap_record) { instance_double(Employment, job?: false, education_gap?: true, break?: false, started_on: nil, valid?: true) }
+
+        let(:attributes) do
+          {
+            employment_history_section_completed: "true",
+            unexplained_employment_gaps: {},
+            employments: [job, gap_record],
+            qualifications: [qualification],
+          }
+        end
+
+        it "does not add an error" do
+          expect(form.errors[:education_gap]).to be_empty
+        end
+      end
+    end
+
+    context "when qualification year equals first job year (no provable gap)" do
+      let(:unexplained_employment_gaps) { {} }
+
+      let(:qualification) { instance_double(Qualification, finished_studying?: true, year: 2021) }
+      let(:job) { instance_double(Employment, job?: true, education_gap?: false, break?: false, started_on: Date.new(2021, 9, 1), valid?: true) }
+
+      let(:attributes) do
+        {
+          employment_history_section_completed: "true",
+          unexplained_employment_gaps: {},
+          employments: [job],
+          qualifications: [qualification],
+        }
+      end
+
+      it "does not add an error" do
+        expect(form).to be_valid
+        expect(form.errors[:education_gap]).to be_empty
+      end
+    end
+
+    context "when there are no jobs" do
+      let(:unexplained_employment_gaps) { {} }
+      let(:qualification) { instance_double(Qualification, finished_studying?: true, year: 2018) }
+
+      let(:attributes) do
+        {
+          employment_history_section_completed: "true",
+          unexplained_employment_gaps: {},
+          employments: [],
+          qualifications: [qualification],
+        }
+      end
+
+      it "does not add an education gap error" do
         expect(form).to be_valid
       end
     end

--- a/spec/form_models/jobseekers/job_application/employment_history_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/employment_history_form_spec.rb
@@ -48,39 +48,29 @@ RSpec.describe Jobseekers::JobApplication::EmploymentHistoryForm, type: :model d
       end
     end
 
-    context "with a detectable education-to-employment gap" do
-      let(:unexplained_employment_gaps) { {} }
-
-      let(:qualification) { instance_double(Qualification, finished_studying?: true, year: 2018) }
-      let(:job) { instance_double(Employment, job?: true, education_gap?: false, break?: false, started_on: Date.new(2021, 3, 1), valid?: true) }
+    context "when there is a gap between education and first job" do
+      let(:job_application) { create(:job_application) }
+      let!(:job) { create(:employment, job_application: job_application, started_on: Date.new(2021, 3, 1)) }
+      let!(:qualification) { create(:qualification, job_application: job_application, finished_studying: true, year: 2018) }
 
       let(:attributes) do
         {
           employment_history_section_completed: "true",
           unexplained_employment_gaps: {},
-          employments: [job],
-          qualifications: [qualification],
+          employments: job_application.employments,
+          qualifications: job_application.qualifications,
         }
       end
 
-      it "adds an error when no education gap record exists" do
+      it "adds an error when there is an unexplained gap between education and first job" do
         expect(form).not_to be_valid
         expect(form.errors[:education_gap]).to include(
           "You have a gap in your work history between your education and first employment",
         )
       end
 
-      context "when an education gap record has been added" do
-        let(:gap_record) { instance_double(Employment, job?: false, education_gap?: true, break?: false, started_on: nil, valid?: true) }
-
-        let(:attributes) do
-          {
-            employment_history_section_completed: "true",
-            unexplained_employment_gaps: {},
-            employments: [job, gap_record],
-            qualifications: [qualification],
-          }
-        end
+      context "when the gap between education and first job is explained" do
+        let!(:education_gap) { create(:employment, :education_gap, job_application: job_application) }
 
         it "does not add an error" do
           expect(form.errors[:education_gap]).to be_empty
@@ -88,18 +78,17 @@ RSpec.describe Jobseekers::JobApplication::EmploymentHistoryForm, type: :model d
       end
     end
 
-    context "when qualification year equals first job year (no provable gap)" do
-      let(:unexplained_employment_gaps) { {} }
-
-      let(:qualification) { instance_double(Qualification, finished_studying?: true, year: 2021) }
-      let(:job) { instance_double(Employment, job?: true, education_gap?: false, break?: false, started_on: Date.new(2021, 9, 1), valid?: true) }
+    context "when there is no gap between education and first job" do
+      let(:job_application) { create(:job_application) }
+      let!(:job) { create(:employment, job_application: job_application, started_on: Date.new(2021, 9, 1)) }
+      let!(:qualification) { create(:qualification, job_application: job_application, finished_studying: true, year: 2021) }
 
       let(:attributes) do
         {
           employment_history_section_completed: "true",
           unexplained_employment_gaps: {},
-          employments: [job],
-          qualifications: [qualification],
+          employments: job_application.employments,
+          qualifications: job_application.qualifications,
         }
       end
 
@@ -110,15 +99,15 @@ RSpec.describe Jobseekers::JobApplication::EmploymentHistoryForm, type: :model d
     end
 
     context "when there are no jobs" do
-      let(:unexplained_employment_gaps) { {} }
-      let(:qualification) { instance_double(Qualification, finished_studying?: true, year: 2018) }
+      let(:job_application) { create(:job_application) }
+      let!(:qualification) { create(:qualification, job_application: job_application, finished_studying: true, year: 2018) }
 
       let(:attributes) do
         {
           employment_history_section_completed: "true",
           unexplained_employment_gaps: {},
-          employments: [],
-          qualifications: [qualification],
+          employments: job_application.employments,
+          qualifications: job_application.qualifications,
         }
       end
 

--- a/spec/form_models/jobseekers/job_application/employment_history_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/employment_history_form_spec.rb
@@ -50,9 +50,6 @@ RSpec.describe Jobseekers::JobApplication::EmploymentHistoryForm, type: :model d
 
     context "when there is a gap between education and first job" do
       let(:job_application) { create(:job_application) }
-      let!(:job) { create(:employment, job_application: job_application, started_on: Date.new(2021, 3, 1)) }
-      let!(:qualification) { create(:qualification, job_application: job_application, finished_studying: true, year: 2018) }
-
       let(:attributes) do
         {
           employment_history_section_completed: "true",
@@ -60,6 +57,11 @@ RSpec.describe Jobseekers::JobApplication::EmploymentHistoryForm, type: :model d
           employments: job_application.employments,
           qualifications: job_application.qualifications,
         }
+      end
+
+      before do
+        create(:employment, job_application: job_application, started_on: Date.new(2021, 3, 1))
+        create(:qualification, job_application: job_application, finished_studying: true, year: 2018)
       end
 
       it "adds an error when there is an unexplained gap between education and first job" do
@@ -70,7 +72,7 @@ RSpec.describe Jobseekers::JobApplication::EmploymentHistoryForm, type: :model d
       end
 
       context "when the gap between education and first job is explained" do
-        let!(:education_gap) { create(:employment, :education_gap, job_application: job_application) }
+        before { create(:employment, :education_gap, job_application: job_application) }
 
         it "does not add an error" do
           expect(form.errors[:education_gap]).to be_empty
@@ -80,9 +82,6 @@ RSpec.describe Jobseekers::JobApplication::EmploymentHistoryForm, type: :model d
 
     context "when there is no gap between education and first job" do
       let(:job_application) { create(:job_application) }
-      let!(:job) { create(:employment, job_application: job_application, started_on: Date.new(2021, 9, 1)) }
-      let!(:qualification) { create(:qualification, job_application: job_application, finished_studying: true, year: 2021) }
-
       let(:attributes) do
         {
           employment_history_section_completed: "true",
@@ -90,6 +89,11 @@ RSpec.describe Jobseekers::JobApplication::EmploymentHistoryForm, type: :model d
           employments: job_application.employments,
           qualifications: job_application.qualifications,
         }
+      end
+
+      before do
+        create(:employment, job_application: job_application, started_on: Date.new(2021, 9, 1))
+        create(:qualification, job_application: job_application, finished_studying: true, year: 2021)
       end
 
       it "does not add an error" do
@@ -100,8 +104,6 @@ RSpec.describe Jobseekers::JobApplication::EmploymentHistoryForm, type: :model d
 
     context "when there are no jobs" do
       let(:job_application) { create(:job_application) }
-      let!(:qualification) { create(:qualification, job_application: job_application, finished_studying: true, year: 2018) }
-
       let(:attributes) do
         {
           employment_history_section_completed: "true",
@@ -110,6 +112,8 @@ RSpec.describe Jobseekers::JobApplication::EmploymentHistoryForm, type: :model d
           qualifications: job_application.qualifications,
         }
       end
+
+      before { create(:qualification, job_application: job_application, finished_studying: true, year: 2018) }
 
       it "does not add an education gap error" do
         expect(form).to be_valid

--- a/spec/form_models/jobseekers/job_application/employment_history_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/employment_history_form_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe Jobseekers::JobApplication::EmploymentHistoryForm, type: :model d
         before { create(:employment, :education_gap, job_application: job_application) }
 
         it "does not add an error" do
+          expect(form).to be_valid
           expect(form.errors[:education_gap]).to be_empty
         end
       end

--- a/spec/form_models/jobseekers/job_application/employment_history_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/employment_history_form_spec.rb
@@ -3,18 +3,18 @@ require "rails_helper"
 RSpec.describe Jobseekers::JobApplication::EmploymentHistoryForm, type: :model do
   subject(:form) { described_class.new(attributes) }
 
-  let(:job_application) { create(:job_application) }
-
   let(:attributes) do
     {
       employment_history_section_completed: employment_history_section_completed,
       unexplained_employment_gaps: unexplained_employment_gaps,
-      employments: job_application.employments,
-      qualifications: job_application.qualifications,
+      employments: employments,
+      qualifications: qualifications,
     }
   end
 
   let(:employment_history_section_completed) { "true" }
+  let(:employments) { [] }
+  let(:qualifications) { [] }
   let(:unexplained_employment_gaps) do
     {
       gap1: { started_on: Date.new(2023, 12, 1), ended_on: Date.new(2024, 12, 1) },
@@ -51,19 +51,9 @@ RSpec.describe Jobseekers::JobApplication::EmploymentHistoryForm, type: :model d
     end
 
     context "when there is a gap between education and first job" do
-      let(:attributes) do
-        {
-          employment_history_section_completed: "true",
-          unexplained_employment_gaps: {},
-          employments: job_application.employments,
-          qualifications: job_application.qualifications,
-        }
-      end
-
-      before do
-        create(:employment, job_application: job_application, started_on: Date.new(2021, 3, 1), ended_on: Date.new(2022, 1, 1))
-        create(:qualification, job_application: job_application, finished_studying: true, year: 2018)
-      end
+      let(:unexplained_employment_gaps) { {} }
+      let(:employments) { [build_stubbed(:employment, started_on: Date.new(2021, 3, 1), ended_on: Date.new(2022, 1, 1))] }
+      let(:qualifications) { [build_stubbed(:qualification, finished_studying: true, year: 2018)] }
 
       it "adds an error when there is an unexplained gap between education and first job" do
         expect(form).not_to be_valid
@@ -73,47 +63,53 @@ RSpec.describe Jobseekers::JobApplication::EmploymentHistoryForm, type: :model d
       end
 
       context "when the gap between education and first job is explained" do
-        before { create(:employment, :education_gap, job_application: job_application) }
+        let(:employments) do
+          [
+            build_stubbed(:employment, started_on: Date.new(2021, 3, 1), ended_on: Date.new(2022, 1, 1)),
+            build_stubbed(:education_gap, started_on: Date.new(2018, 7, 1), ended_on: Date.new(2021, 2, 28)),
+          ]
+        end
 
         it "does not add an error" do
           expect(form).to be_valid
-          expect(form.errors[:education_gap]).to be_empty
+        end
+      end
+
+      context "when a current role is the first job" do
+        let(:employments) { [build_stubbed(:employment, :current_role, started_on: Date.new(2021, 3, 1))] }
+
+        it "adds an error" do
+          expect(form).not_to be_valid
+          expect(form.errors[:education_gap]).to include(
+            "You have a gap in your work history between your education and first employment",
+          )
         end
       end
     end
 
     context "when there is no gap between education and first job" do
-      let(:attributes) do
-        {
-          employment_history_section_completed: "true",
-          unexplained_employment_gaps: {},
-          employments: job_application.employments,
-          qualifications: job_application.qualifications,
-        }
-      end
-
-      before do
-        create(:employment, job_application: job_application, started_on: Date.new(2021, 9, 1), ended_on: Date.new(2022, 6, 1))
-        create(:qualification, job_application: job_application, finished_studying: true, year: 2021)
-      end
+      let(:unexplained_employment_gaps) { {} }
+      let(:employments) { [build_stubbed(:employment, started_on: Date.new(2021, 9, 1), ended_on: Date.new(2022, 6, 1))] }
+      let(:qualifications) { [build_stubbed(:qualification, finished_studying: true, year: 2021)] }
 
       it "does not add an error" do
         expect(form).to be_valid
-        expect(form.errors[:education_gap]).to be_empty
       end
     end
 
     context "when there are no jobs" do
-      let(:attributes) do
-        {
-          employment_history_section_completed: "true",
-          unexplained_employment_gaps: {},
-          employments: job_application.employments,
-          qualifications: job_application.qualifications,
-        }
-      end
+      let(:unexplained_employment_gaps) { {} }
+      let(:qualifications) { [build_stubbed(:qualification, finished_studying: true, year: 2018)] }
 
-      before { create(:qualification, job_application: job_application, finished_studying: true, year: 2018) }
+      it "does not add an education gap error" do
+        expect(form).to be_valid
+      end
+    end
+
+    context "when qualifications are unfinished" do
+      let(:unexplained_employment_gaps) { {} }
+      let(:employments) { [build_stubbed(:employment, started_on: Date.new(2021, 3, 1), ended_on: Date.new(2022, 1, 1))] }
+      let(:qualifications) { [build_stubbed(:qualification, finished_studying: false, year: nil)] }
 
       it "does not add an education gap error" do
         expect(form).to be_valid

--- a/spec/presenters/work_history_error_summary_presenter_spec.rb
+++ b/spec/presenters/work_history_error_summary_presenter_spec.rb
@@ -27,5 +27,17 @@ RSpec.describe WorkHistoryErrorSummaryPresenter do
         ],
       )
     end
+
+    context "with an education gap error" do
+      let(:errors) { { education_gap: ["You have a gap in your work history between your education and first employment"] } }
+
+      it "provides a link to the education gap section" do
+        expect(presenter.formatted_error_messages).to eq(
+          [
+            [:education_gap, "You have a gap in your work history between your education and first employment", "#education-gap-section"],
+          ],
+        )
+      end
+    end
   end
 end

--- a/spec/support/jobseeker_helpers.rb
+++ b/spec/support/jobseeker_helpers.rb
@@ -146,7 +146,7 @@ module JobseekerHelpers
     fill_in "Awarding body", with: "University of Life"
     choose "Yes", name: "jobseekers_qualifications_degree_form[finished_studying]"
     fill_in "Grade", with: "2:1"
-    fill_in "Year", with: "1960"
+    fill_in "Year", with: "2019"
   end
 
   def fill_in_other_qualification

--- a/spec/system/jobseekers/jobseekers_can_add_employments_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_employments_to_their_job_application_spec.rb
@@ -129,6 +129,40 @@ RSpec.describe "Jobseekers can add employments and breaks to their job applicati
     end
   end
 
+  context "managing gap between education and work history" do
+    let(:employments) { [] }
+
+    it "allows jobseekers to add, change and delete a gap between education and work history" do
+      click_on I18n.t("buttons.add_education_gap")
+
+      expect(page).to have_current_path(new_jobseekers_job_application_education_gap_path(job_application), ignore_query: true)
+      expect(page).to have_content(I18n.t("jobseekers.job_applications.education_gaps.new.heading"))
+
+      click_on I18n.t("buttons.continue")
+
+      expect(page).to have_content("There is a problem")
+
+      fill_in "Enter reasons for gap between education and work history", with: "Finishing some stuff up"
+      click_on I18n.t("buttons.continue")
+
+      expect(page).to have_current_path(jobseekers_job_application_build_path(job_application, :employment_history), ignore_query: true)
+      expect(page).to have_content("Finishing some stuff up")
+
+      click_on "Change Gap between education and work history"
+
+      fill_in "Enter reasons for gap between education and work history", with: "Preparing to being work"
+      click_on I18n.t("buttons.continue")
+
+      expect(page).to have_content("Preparing to being work")
+      expect(page).not_to have_content("Finishing some stuff up")
+
+      click_on "Delete Gap between education and work history"
+      click_on I18n.t("buttons.confirm_destroy")
+
+      expect(page).not_to have_content("Preparing to being work")
+    end
+  end
+
   context "when there is at least one role" do
     let(:employments) do
       [

--- a/spec/system/jobseekers/jobseekers_can_add_employments_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_employments_to_their_job_application_spec.rb
@@ -143,6 +143,10 @@ RSpec.describe "Jobseekers can add employments and breaks to their job applicati
       expect(page).to have_content("There is a problem")
 
       fill_in "Enter reasons for gap between education and work history", with: "Finishing some stuff up"
+      fill_in "jobseekers_break_form[started_on(1i)]", with: "2018"
+      fill_in "jobseekers_break_form[started_on(2i)]", with: "09"
+      fill_in "jobseekers_break_form[ended_on(1i)]", with: "2019"
+      fill_in "jobseekers_break_form[ended_on(2i)]", with: "06"
       click_on I18n.t("buttons.continue")
 
       expect(page).to have_current_path(jobseekers_job_application_build_path(job_application, :employment_history), ignore_query: true)
@@ -151,6 +155,10 @@ RSpec.describe "Jobseekers can add employments and breaks to their job applicati
       click_on "Change Gap between education and work history"
 
       fill_in "Enter reasons for gap between education and work history", with: "Preparing to being work"
+      fill_in "jobseekers_break_form[started_on(1i)]", with: "2018"
+      fill_in "jobseekers_break_form[started_on(2i)]", with: "09"
+      fill_in "jobseekers_break_form[ended_on(1i)]", with: "2019"
+      fill_in "jobseekers_break_form[ended_on(2i)]", with: "06"
       click_on I18n.t("buttons.continue")
 
       expect(page).to have_content("Preparing to being work")

--- a/spec/system/jobseekers/jobseekers_can_add_employments_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_employments_to_their_job_application_spec.rb
@@ -159,20 +159,20 @@ RSpec.describe "Jobseekers can add employments and breaks to their job applicati
 
       expect(page).to have_content("There is a problem")
 
-      fill_in "Enter reasons for gap between education and work history", with: "Preparing to being work"
+      fill_in "Enter reasons for gap between education and work history", with: "Preparing to work (ugh)"
       fill_in "jobseekers_break_form[started_on(1i)]", with: "2018"
       fill_in "jobseekers_break_form[started_on(2i)]", with: "09"
       fill_in "jobseekers_break_form[ended_on(1i)]", with: "2019"
       fill_in "jobseekers_break_form[ended_on(2i)]", with: "06"
       click_on I18n.t("buttons.continue")
 
-      expect(page).to have_content("Preparing to being work")
+      expect(page).to have_content("Preparing to work (ugh)")
       expect(page).not_to have_content("Finishing some stuff up")
 
       click_on "Delete Gap between education and work history"
       click_on I18n.t("buttons.confirm_destroy")
 
-      expect(page).not_to have_content("Preparing to being work")
+      expect(page).not_to have_content("Preparing to work (ugh)")
     end
   end
 

--- a/spec/system/jobseekers/jobseekers_can_add_employments_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_employments_to_their_job_application_spec.rb
@@ -154,6 +154,11 @@ RSpec.describe "Jobseekers can add employments and breaks to their job applicati
 
       click_on "Change Gap between education and work history"
 
+      fill_in "Enter reasons for gap between education and work history", with: ""
+      click_on I18n.t("buttons.continue")
+
+      expect(page).to have_content("There is a problem")
+
       fill_in "Enter reasons for gap between education and work history", with: "Preparing to being work"
       fill_in "jobseekers_break_form[started_on(1i)]", with: "2018"
       fill_in "jobseekers_break_form[started_on(2i)]", with: "09"

--- a/spec/system/jobseekers/jobseekers_can_review_a_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_review_a_job_application_spec.rb
@@ -59,6 +59,13 @@ RSpec.describe "Jobseekers can review a job application" do
         expect(page).to have_content(employment.started_on.to_fs(:month_year))
         expect(page).to have_content(employment.ended_on.to_fs(:month_year))
       end
+
+      job_application.employments.education_gap.each do |employment|
+        expect(page).to have_content(I18n.t("jobseekers.job_applications.build.employment_history.education_gap"))
+        expect(page).to have_content(employment.reason_for_break)
+        expect(page).to have_content(employment.started_on.to_fs(:month_year))
+        expect(page).to have_content(employment.ended_on.to_fs(:month_year))
+      end
     end
 
     within ".review-component__section", text: I18n.t("jobseekers.job_applications.build.personal_statement.heading") do

--- a/spec/system/publishers/publishers_can_manage_job_applications_for_a_vacancy_spec.rb
+++ b/spec/system/publishers/publishers_can_manage_job_applications_for_a_vacancy_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Publishers can manage job applications for a vacancy" do
 
   describe "viewing a job application with an education gap" do
     let(:job_application) { create(:job_application, :status_submitted, vacancy:) }
-    let!(:education_gap) { create(:employment, :education_gap, job_application: job_application) }
+    let!(:education_gap) { create(:education_gap, job_application: job_application) }
 
     it "displays the education gap in the work history section" do
       visit organisation_job_job_application_path(vacancy.id, job_application.id)

--- a/spec/system/publishers/publishers_can_manage_job_applications_for_a_vacancy_spec.rb
+++ b/spec/system/publishers/publishers_can_manage_job_applications_for_a_vacancy_spec.rb
@@ -9,6 +9,22 @@ RSpec.describe "Publishers can manage job applications for a vacancy" do
 
   after { logout }
 
+  describe "viewing a job application with an education gap" do
+    let(:job_application) { create(:job_application, :status_submitted, vacancy:) }
+    let!(:education_gap) { create(:employment, :education_gap, job_application: job_application) }
+
+    it "displays the education gap in the work history section" do
+      visit organisation_job_job_application_path(vacancy.id, job_application.id)
+
+      within ".review-component__section", text: I18n.t("jobseekers.job_applications.show.employment_history.heading") do
+        expect(page).to have_content(I18n.t("jobseekers.job_applications.build.employment_history.education_gap"))
+        expect(page).to have_content(education_gap.reason_for_break)
+        expect(page).to have_content(education_gap.started_on.to_fs(:month_year))
+        expect(page).to have_content(education_gap.ended_on.to_fs(:month_year))
+      end
+    end
+  end
+
   describe "through job application page actions" do
     let(:job_application) { create(:job_application, :status_submitted, vacancy:) }
 


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/Gw3GqZUL/2745-gaps-between-qualifications-and-work-history

## Changes in this PR:

This change adds th ability for jobseekers to account for gaps between leaving education and starting their first job. It forces users to account for these kind of gaps, raising error message if they don't.

## Screenshots of UI changes:

<img width="1157" height="768" alt="Screenshot 2026-06-09 at 09 22 48" src="https://github.com/user-attachments/assets/74247600-50df-4b80-aa71-8b2896f0a613" />

<img width="1134" height="722" alt="Screenshot 2026-06-09 at 09 21 49" src="https://github.com/user-attachments/assets/49581452-5804-4c84-af5e-6f04b596433d" />

<img width="1135" height="693" alt="Screenshot 2026-06-09 at 09 21 27" src="https://github.com/user-attachments/assets/5b349ef0-9d95-4270-a9a4-7b82fa52c9de" />

<img width="765" height="781" alt="Screenshot 2026-06-09 at 09 29 31" src="https://github.com/user-attachments/assets/5e3d0cda-8d09-4506-ba4f-073bd0398752" />

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
