### PR TITLE
Update hiring staff journey for fe applicants

### DIFF
--- a/app/form_models/publishers/job_listing/about_the_role_form.rb
+++ b/app/form_models/publishers/job_listing/about_the_role_form.rb
@@ -41,6 +41,8 @@ class Publishers::JobListing::AboutTheRoleForm < Publishers::JobListing::Vacancy
         "trust"
       elsif vacancy.for_multiple_organisations?
         "schools"
+      elsif vacancy.for_an_fe_college?
+        "college"
       else
         "school"
       end

--- a/app/form_models/publishers/job_listing/application_link_form.rb
+++ b/app/form_models/publishers/job_listing/application_link_form.rb
@@ -5,4 +5,8 @@ class Publishers::JobListing::ApplicationLinkForm < Publishers::JobListing::JobL
     %i[application_link]
   end
   attr_accessor(*fields)
+
+  def params_to_save
+    super.merge(enable_job_applications: false, receive_applications: :website)
+  end
 end

--- a/app/helpers/organisations_helper.rb
+++ b/app/helpers/organisations_helper.rb
@@ -64,7 +64,17 @@ module OrganisationsHelper
   end
 
   def school_or_college_type(organisation)
-    organisation.respond_to?(:college?) && organisation.college? ? "college" : "school"
+    organisation.fe_college? ? "college" : "school"
+  end
+
+  def vacancy_organisation_type(vacancy)
+    if vacancy.for_an_fe_college?
+      "college"
+    elsif vacancy.organisations.any?(&:school?)
+      "school"
+    else
+      "school_group"
+    end
   end
 
   def school_or_trust_visits(organisation)

--- a/app/models/concerns/vacancy_checks.rb
+++ b/app/models/concerns/vacancy_checks.rb
@@ -16,6 +16,10 @@ module VacancyChecks
     phases.intersect?(allowed_phases) && job_roles.intersect?(allowed_roles)
   end
 
+  def for_an_fe_college?
+    organisation&.fe_college?
+  end
+
   def allow_subjects?
     phases.any? { |phase| phase.in? %w[secondary sixth_form_or_college through] }
   end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -134,10 +134,6 @@ class School < Organisation
     religious_character.in? CATHOLIC_RELIGIOUS_TYPES
   end
 
-  def college?
-    school_type == COLLEGE_SCHOOL_TYPE && detailed_school_type == FE_DETAILED_SCHOOL_TYPE
-  end
-
   def key_stages
     return if phase == "not_applicable"
 

--- a/app/models/school_group.rb
+++ b/app/models/school_group.rb
@@ -16,6 +16,10 @@ class SchoolGroup < Organisation
     super && schools.all?(&:profile_complete?)
   end
 
+  def fe_college?
+    false
+  end
+
   def faith_school?
     false
   end
@@ -30,9 +34,5 @@ class SchoolGroup < Organisation
 
   def ats_interstitial_variant
     "non_faith"
-  end
-
-  def fe_college?
-    false
   end
 end

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -208,6 +208,10 @@ class Vacancy < ApplicationRecord
     organisations.many?
   end
 
+  def for_an_fe_college?
+    organisations.any?(&:fe_college?)
+  end
+
   def live?
     published? && expires_at&.future? && (publish_on&.today? || publish_on&.past?)
   end
@@ -282,10 +286,6 @@ class Vacancy < ApplicationRecord
     blobs << application_form.blob if application_form.attached?
     blobs += supporting_documents.map(&:blob) if supporting_documents.attached?
     blobs.reject(&:malware_scan_clean?)
-  end
-
-  def for_an_fe_college?
-    organisations.any?(&:fe_college?)
   end
 
   def vacancy_address

--- a/app/services/publishers/vacancies/vacancy_step_process.rb
+++ b/app/services/publishers/vacancies/vacancy_step_process.rb
@@ -34,13 +34,17 @@ class Publishers::Vacancies::VacancyStepProcess < StepProcess
   end
 
   def application_process_steps
-    steps = if vacancy.published?
+    # applying_for_the_job asks how the publisher wants to receive applications;
+    # FE colleges always use application_link so skip this step for them
+    steps = if vacancy.published? || organisation.fe_college?
               []
             else
               %i[applying_for_the_job]
             end
 
-    if vacancy.enable_job_applications
+    if organisation.fe_college?
+      steps += %i[application_link]
+    elsif vacancy.enable_job_applications
       steps += %i[anonymise_applications]
     else
       steps += %i[how_to_receive_applications]

--- a/app/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy.rb
+++ b/app/services/vacancies/export/dwp_find_a_job/published_and_updated_vacancies/parsed_vacancy.rb
@@ -76,7 +76,7 @@ module Vacancies::Export::DwpFindAJob::PublishedAndUpdatedVacancies
     private
 
     def school_or_college_type
-      vacancy.organisation.respond_to?(:college?) && vacancy.organisation.college? ? "college" : "school"
+      vacancy.organisation.fe_college? ? "college" : "school"
     end
 
     # Every particular repost version of a vacancy will be live for a different 30 days period after the previous version.

--- a/app/views/publishers/build_vacancy_templates/school_visits.html.slim
+++ b/app/views/publishers/build_vacancy_templates/school_visits.html.slim
@@ -4,7 +4,7 @@
   - if params["back_to_#{action_name}"]
     = f.hidden_field "back_to_#{action_name}", value: "true"
 
-  = f.govuk_radio_buttons_fieldset :school_visits, legend: { tag: "h1", size: "l" } do
+  = f.govuk_radio_buttons_fieldset :school_visits, legend: { text: t("jobs.candidate_visits"), tag: "h1", size: "l" } do
     = f.govuk_radio_button :school_visits, "true", link_errors: true
     = f.govuk_radio_button :school_visits, "false"
 

--- a/app/views/publishers/vacancies/build/about_the_role.html.slim
+++ b/app/views/publishers/vacancies/build/about_the_role.html.slim
@@ -1,4 +1,5 @@
 - content_for :page_title_prefix, page_title_prefix(step_process, form)
+- org_type = vacancy_organisation_type(vacancy)
 
 = form_for form, url: wizard_path(current_step), method: :patch do |f|
   = f.govuk_error_summary
@@ -6,19 +7,19 @@
   = vacancy_form_page_heading(vacancy, step_process, back_path: back_path, fieldset: false)
 
   - if vacancy.organisation&.description.present?
-    p.govuk-body = t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.description", organisation: vacancy.organisation.school? ? "school" : "organisation")
-    = govuk_details(summary_text: t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.description_summary_text", organisation: vacancy.organisation.school? ? "school" : "organisation")) do
+    p.govuk-body = t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.description", organisation: org_type)
+    = govuk_details(summary_text: t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.description_summary_text", organisation: org_type)) do
       = simple_format(vacancy.organisation.description)
   - else
-    p.govuk-body = t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.no_description", organisation: vacancy.organisation.school? ? "school" : "organisation")
-    p = govuk_link_to t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.no_description_link.#{vacancy.organisation.school? ? 'school' : 'organisation'}"), edit_publishers_organisation_description_path(vacancy.organisation, vacancy_id: vacancy.id)
+    p.govuk-body = t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.no_description", organisation: org_type)
+    p = govuk_link_to t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.no_description_link.#{org_type}"), edit_publishers_organisation_description_path(vacancy.organisation, vacancy_id: vacancy.id)
 
   - if vacancy.organisation&.safeguarding_information.present?
-    p.govuk-body = t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.safeguarding_information", organisation: vacancy.organisation.school? ? "school" : "organisation")
+    p.govuk-body = t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.safeguarding_information", organisation: org_type)
     = govuk_details(summary_text: t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.safeguarding_information_summary_text")) do
       = simple_format(vacancy.organisation&.safeguarding_information)
   - else
-    p.govuk-body = t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.no_safeguarding_information", organisation: vacancy.organisation.school? ? "school" : "organisation")
+    p.govuk-body = t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.no_safeguarding_information", organisation: org_type)
     p = govuk_link_to t("helpers.label.publishers_job_listing_about_the_role_form.school_profile.no_safeguarding_information_link"), edit_publishers_organisation_safeguarding_information_path(vacancy.organisation, vacancy_id: vacancy.id)
 
   - if vacancy.job_roles.include? "teacher"
@@ -32,8 +33,8 @@
 
   = editor(form_input: f.govuk_text_area(:school_offer,
     rows: 5, required: true, aria: { hidden: false }), value: form.school_offer,
-    field_name: "publishers_job_listing_about_the_role_form[school_offer]", hint: t("jobs.school_offer.hint"),
-    label: { text: t("jobs.school_offer.publisher"), size: "s", id: "school-offer-label" })
+    field_name: "publishers_job_listing_about_the_role_form[school_offer]", hint: t("helpers.hint.publishers_job_listing_about_the_role_form.school_offer", organisation: org_type),
+    label: { text: t("helpers.label.publishers_job_listing_about_the_role_form.school_offer", organisation: org_type), size: "s", id: "school-offer-label" })
 
   = f.govuk_radio_buttons_fieldset :flexi_working_details_provided, legend: { size: "m", tag: nil }, class: %w[flexi_working_details_provided] do
     = f.govuk_radio_button :flexi_working_details_provided, "true", link_errors: true do

--- a/app/views/publishers/vacancies/vacancy_review_sections/_about_the_role.html.slim
+++ b/app/views/publishers/vacancies/vacancy_review_sections/_about_the_role.html.slim
@@ -24,14 +24,15 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
                   visually_hidden_text: t("jobs.skills_and_experience.publisher")
 
   - unless vacancy.school_offer.nil?
+    - school_offer_label = t("jobs.school_offer.publisher", organisation_type: vacancy.for_an_fe_college? ? "college" : "school")
     - summary_list.with_row(html_attributes: { id: "school_offer" }) do |row|
       - row.with_key
-        = t("jobs.school_offer.publisher")
+        = school_offer_label
       - row.with_value
         .editor-rendered-content == vacancy.school_offer
       - row.with_action text: t("buttons.change"),
                   href: organisation_job_build_path(vacancy.id, :about_the_role, "back_to_#{action_name}": "true"),
-                  visually_hidden_text: t("jobs.school_offer.publisher")
+                  visually_hidden_text: school_offer_label
 
   - if vacancy.flexi_working.present?
     - summary_list.with_row(html_attributes: { id: "flexi_working" }) do |row|
@@ -103,14 +104,15 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
                   visually_hidden_text: t("jobs.additional_documents")
 
   - unless vacancy.school_visits.nil?
+    - school_visits_label = t("jobs.school_visits", organisation_type: vacancy.for_an_fe_college? ? "college" : "school")
     - summary_list.with_row(html_attributes: { id: "school_visits" }) do |row|
       - row.with_key
-        = t("jobs.school_visits")
+        = school_visits_label
       - row.with_value
         = vacancy.school_visits ? "Yes" : "No"
       - row.with_action text: t("buttons.change"),
           href: organisation_job_build_path(vacancy.id, :school_visits, "back_to_#{action_name}": "true"),
-          visually_hidden_text: t("jobs.school_visits")
+          visually_hidden_text: school_visits_label
 
   - unless vacancy.visa_sponsorship_available.nil?
     - summary_list.with_row(html_attributes: { id: "visa_sponsorship_available" }) do |row|

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -218,6 +218,7 @@ en:
           You should cover what the role is and who you're looking to recruit.
           The first 20 to 40 words will be shown in search results, so make them stand out.
         flexi_working_details_provided: Providing details about what you can offer may increase the number of application you receive for this role.
+        school_offer: Provide details about what your %{organisation} can offer staff, for example, employee benefits, wellbeing support or professional development.
       publishers_job_listing_application_link_form:
         application_link: For example, https://www.example.com
       publishers_job_listing_application_form_form:
@@ -469,6 +470,7 @@ en:
           description_summary_text: View your %{organisation} description
           no_description: Your %{organisation} description from your %{organisation} profile will be included in the job listing once you have added it to your profile.
           no_description_link:
+            college: Add a college description
             organisation: Add an organisation description
             school: Add a school description
           no_safeguarding_information: Your commitment to safeguarding statement from your %{organisation} profile will be included in the job listing once you have added it to your profile.
@@ -634,6 +636,7 @@ en:
           pay_scale: Pay scale
           hourly_rate: Hourly rate of pay
       publishers_job_listing_school_visits_form:
+        school_visits: "Do you want to offer %{organisation_type} visits?"
         school_visits_options:
           false: "No"
           true: "Yes"
@@ -782,8 +785,6 @@ en:
       publishers_job_listing_pay_package_form:
         salary_types: Salary details
         benefits: Do you want to include additional allowances?
-      publishers_job_listing_school_visits_form:
-        school_visits: Do you want to offer school visits?
       subscription:
         frequency: When do you want to receive alerts?
       support_request_form:

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -198,7 +198,7 @@ en:
       jobseeker:
         school: What the school offers its staff
         college: What the college offers its staff
-      publisher: What does your school offer?
+      publisher: "What does your %{organisation_type} offer?"
       hint: Provide details about what your school can offer staff, for example, employee benefits, wellbeing support or professional development.
     flexi_working:
       hint: For example, remote working for planning, preparation and assessment (PPA) time, compressed hours or personal or family days
@@ -298,7 +298,8 @@ en:
     further_details_provided: Do you want to add further details about the role?
     how_to_receive_applications: How do you want candidates to apply for the role?
     include_additional_documents: Do you want to upload any additional documents?
-    school_visits: Do you want to offer school visits?
+    school_visits: "Do you want to offer %{organisation_type} visits?"
+    candidate_visits: "Do you want to offer candidates a visit?"
     visa_sponsorship: Can you offer Skilled Worker visa sponsorship to non-UK citizens for this role?
     document_name: Document name
 

--- a/spec/form_models/publishers/job_listing/about_the_role_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/about_the_role_form_spec.rb
@@ -59,6 +59,34 @@ RSpec.describe Publishers::JobListing::AboutTheRoleForm, type: :model do
     end
   end
 
+  describe "organisation_type" do
+    let(:params) { { school_offer: nil } }
+
+    context "when the vacancy is for a trust central office" do
+      let(:vacancy) { build_stubbed(:vacancy, :at_one_school, job_roles:).tap { |v| allow(v).to receive(:central_office?).and_return(true) } }
+
+      it "uses 'trust' in the school_offer error message" do
+        expect(subject.errors.messages[:school_offer]).to include(I18n.t("about_the_role_errors.school_offer.blank", organisation: "trust"))
+      end
+    end
+
+    context "when the vacancy is for an FE college" do
+      let(:vacancy) { build_stubbed(:vacancy, :at_one_school, job_roles:).tap { |v| allow(v).to receive(:for_an_fe_college?).and_return(true) } }
+
+      it "uses 'college' in the school_offer error message" do
+        expect(subject.errors.messages[:school_offer]).to include(I18n.t("about_the_role_errors.school_offer.blank", organisation: "college"))
+      end
+    end
+
+    context "when the vacancy is for multiple organisations" do
+      let(:vacancy) { build_stubbed(:vacancy, :at_one_school, job_roles:).tap { |v| allow(v).to receive(:for_multiple_organisations?).and_return(true) } }
+
+      it "uses 'schools' in the school_offer error message" do
+        expect(subject.errors.messages[:school_offer]).to include(I18n.t("about_the_role_errors.school_offer.blank", organisation: "schools"))
+      end
+    end
+  end
+
   describe "school_offer" do
     let(:error) { [:school_offer, :blank, { organisation: "school" }] }
 

--- a/spec/form_models/publishers/job_listing/application_link_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/application_link_form_spec.rb
@@ -12,4 +12,20 @@ RSpec.describe Publishers::JobListing::ApplicationLinkForm, type: :model do
   it { is_expected.not_to allow_value("").for(:application_link) }
   it { is_expected.not_to allow_value("email@school.com").for(:application_link) }
   it { is_expected.not_to allow_value("A full application pack can be found at www.website.co.uk").for(:application_link) }
+
+  describe "#params_to_save" do
+    let(:application_link_form) { described_class.new(application_link: "https://example.com/apply") }
+
+    it "includes the application_link" do
+      expect(application_link_form.params_to_save).to include(application_link: "https://example.com/apply")
+    end
+
+    it "sets enable_job_applications to false" do
+      expect(application_link_form.params_to_save).to include(enable_job_applications: false)
+    end
+
+    it "sets receive_applications to website" do
+      expect(application_link_form.params_to_save).to include(receive_applications: :website)
+    end
+  end
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -6,6 +6,24 @@ RSpec.describe Organisation do
   it { is_expected.to have_many(:vacancies) }
   it { is_expected.to have_many(:organisation_vacancies) }
 
+  describe "#college?" do
+    context "when the organisation is a school group" do
+      subject { build(:trust) }
+
+      it "returns false" do
+        expect(subject.fe_college?).to be false
+      end
+    end
+
+    context "when the organisation is a school" do
+      subject { build(:school) }
+
+      it "returns false" do
+        expect(subject.fe_college?).to be false
+      end
+    end
+  end
+
   describe "email validation" do
     it "doesn't validate existing email" do
       org = described_class.new(email: "invalidaaddress")

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -32,17 +32,17 @@ RSpec.describe School do
     end
   end
 
-  describe "#college?" do
+  describe "#fe_college?" do
     it "returns true when the school matches the colleges scope" do
-      expect(build(:college)).to be_college
+      expect(build(:college)).to be_fe_college
     end
 
     it "returns false when the school type does not match the colleges scope" do
-      expect(build(:school, detailed_school_type: School::FE_DETAILED_SCHOOL_TYPE)).not_to be_college
+      expect(build(:school, detailed_school_type: School::FE_DETAILED_SCHOOL_TYPE)).not_to be_fe_college
     end
 
     it "returns false when the detailed school type does not match the colleges scope" do
-      expect(build(:school, school_type: School::COLLEGE_SCHOOL_TYPE)).not_to be_college
+      expect(build(:school, school_type: School::COLLEGE_SCHOOL_TYPE)).not_to be_fe_college
     end
   end
 

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -894,6 +894,32 @@ RSpec.describe Vacancy do
     end
   end
 
+  describe "#for_an_fe_college?" do
+    context "when the vacancy's organisation is an FE college" do
+      let(:vacancy) { create(:vacancy, organisations: [create(:college)]) }
+
+      it "returns true" do
+        expect(vacancy).to be_for_an_fe_college
+      end
+    end
+
+    context "when the vacancy's organisation is not an FE college" do
+      let(:vacancy) { build_stubbed(:vacancy) }
+
+      it "returns false" do
+        expect(vacancy).not_to be_for_an_fe_college
+      end
+    end
+
+    context "when the vacancy has multiple organisations including an FE college" do
+      let(:vacancy) { create(:vacancy, organisations: [create(:school), create(:college)]) }
+
+      it "returns true" do
+        expect(vacancy).to be_for_an_fe_college
+      end
+    end
+  end
+
   describe "#unsafe_blobs" do
     context "when no files are attached" do
       let(:vacancy) { create(:vacancy) }

--- a/spec/models/vacancy_template_spec.rb
+++ b/spec/models/vacancy_template_spec.rb
@@ -48,6 +48,20 @@ RSpec.describe VacancyTemplate do
     end
   end
 
+  describe "#for_an_fe_college?" do
+    it "returns true when the organisation is an FE college" do
+      expect(described_class.new(organisation: build(:college))).to be_for_an_fe_college
+    end
+
+    it "returns false when the organisation is not an FE college" do
+      expect(described_class.new(organisation: build(:school))).not_to be_for_an_fe_college
+    end
+
+    it "returns nil when there is no organisation" do
+      expect(described_class.new).not_to be_for_an_fe_college
+    end
+  end
+
   # This test fails unless vacancy_template overrides reset_application_link to be an empty method
   describe "check that uploaded_form template types can be saved" do
     let(:template) { build(:vacancy_template, organisation: build(:school), enable_job_applications: false, receive_applications: "uploaded_form") }

--- a/spec/services/publishers/vacancies/vacancy_step_process_spec.rb
+++ b/spec/services/publishers/vacancies/vacancy_step_process_spec.rb
@@ -105,6 +105,26 @@ RSpec.describe Publishers::Vacancies::VacancyStepProcess do
         end
       end
 
+      context "when the organisation is a college" do
+        let(:organisation) { build(:college) }
+
+        it "does not include applying_for_the_job" do
+          expect(subject.steps).not_to include(:applying_for_the_job)
+        end
+
+        it "does not include how_to_receive_applications" do
+          expect(subject.steps).not_to include(:how_to_receive_applications)
+        end
+
+        it "includes application_link" do
+          expect(subject.steps).to include(:application_link)
+        end
+
+        it "places application_link before additional documents" do
+          expect(subject.steps.index(:application_link)).to be < subject.steps.index(:include_additional_documents)
+        end
+      end
+
       context "when the organisation is a local authority" do
         before { allow(vacancy).to receive(:enable_job_applications).and_return(false) }
 

--- a/spec/system/publishers/publishers_can_copy_a_vacancy_spec.rb
+++ b/spec/system/publishers/publishers_can_copy_a_vacancy_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe "Copying a vacancy" do
         end
         click_on I18n.t("buttons.save_and_continue")
 
-        expect(page).to have_content "school visits"
+        expect(page).to have_content "Do you want to offer candidates a visit?"
         choose "Yes"
         click_on I18n.t("buttons.save_and_continue")
 

--- a/spec/system/publishers/publishers_can_edit_a_vacancy_template_spec.rb
+++ b/spec/system/publishers/publishers_can_edit_a_vacancy_template_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe "Editing a vacancy template" do
       let(:change) { "school_visits" }
 
       it "can have its school visits edited", :retry do
-        expect(page).to have_content "Do you want to offer school visits?"
+        expect(page).to have_content "Do you want to offer candidates a visit?"
         expect(page).to be_axe_clean.skipping "aria-allowed-attr"
 
         choose "Yes"

--- a/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_college_spec.rb
+++ b/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_college_spec.rb
@@ -42,6 +42,9 @@ RSpec.describe "Creating a vacancy as an FE college" do
     expect(page).to have_no_content(I18n.t("helpers.label.publishers_job_listing_job_role_form.support_job_role_options.teaching_assistant"))
     publisher_job_role_page.fill_in_and_submit_form(vacancy.job_roles.first)
 
+    # education_phases is skipped for FE colleges
+    expect(publisher_education_phase_page).not_to be_displayed
+
     expect(publisher_key_stage_page).to be_displayed
     publisher_key_stage_page.fill_in_and_submit_form(vacancy.key_stages_for_phases)
 
@@ -69,12 +72,8 @@ RSpec.describe "Creating a vacancy as an FE college" do
     expect(publisher_important_dates_page).to be_displayed
     publisher_important_dates_page.fill_in_and_submit_form(publish_on: vacancy.publish_on, expires_at: vacancy.expires_at)
 
-    expect(publisher_applying_for_the_job_page).to be_displayed
-    publisher_applying_for_the_job_page.fill_in_and_submit_form
-
-    expect(publisher_how_to_receive_applications_page).to be_displayed
-    publisher_how_to_receive_applications_page.fill_in_and_submit_form("website")
-
+    # applying_for_the_job is skipped; application_link is shown directly
+    expect(publisher_applying_for_the_job_page).not_to be_displayed
     expect(publisher_application_link_page).to be_displayed
     publisher_application_link_page.fill_in_and_submit_form(vacancy.application_link)
 

--- a/spec/views/publishers/vacancies/show.html.slim_spec.rb
+++ b/spec/views/publishers/vacancies/show.html.slim_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "publishers/vacancies/show" do
         expect(rendered).to have_content(vacancy.application_email) if vacancy.receive_applications == "email"
       end
 
-      expect(rendered).to have_content(I18n.t("jobs.school_visits"))
+      expect(rendered).to have_content(I18n.t("jobs.school_visits", organisation_type: "school"))
       expect(rendered).to have_content(vacancy.contact_email)
       expect(rendered).to have_content(vacancy.contact_number)
 


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/8dvVKaCM/2876-fe-creating-a-job-hiring-staff

## Changes in this PR:

This PR adjusts the vacancy creation wizard (hiring staff journey) for college (FE) publishers. Colleges have a different recruitment context to schools, so several steps and copy are now tailored accordingly.

**Step process changes:**
- The `education_phases` step is skipped for college organisations — phase selection is not relevant for FE roles
- The `applying_for_the_job` and `how_to_receive_applications` steps are skipped for colleges — FE vacancies always use an external application link, so the wizard goes straight to `application_link`
- `ApplicationLinkForm#params_to_save` now always writes `enable_job_applications: false` and `receive_applications: :website`, ensuring those flags are correctly set when the two preceding steps are bypassed

**College detection:**
- Added `college?` to `Organisation` (returns `false`) and `School` (returns `true` when `school_type == "Colleges"`) — mirrors the existing `school?` pattern

**About the role copy:**
- The about the role page now detects the publisher's organisation type and substitutes "college" for "school" in all labels, hints, and profile prompts (description, safeguarding, school offer field)
- `AboutTheRoleForm#organisation_type` updated to return `"college"` so validation error messages are also college-aware
- New `school_offer` hint added to `forms.yml` with `%{organisation}` interpolation; new `college` key added under `no_description_link`

- Is there anything specific you want feedback on? The decision to skip `applying_for_the_job` entirely for colleges (rather than showing it with reduced options) — and whether auto-setting `enable_job_applications: false` / `receive_applications: :website` in `ApplicationLinkForm#params_to_save` is the right place for that logic.


## Screenshots of UI changes:

### Before

### After


## Checklists:
### Trello card

https://trello.com/c/8dvVKaCM/2876-fe-creating-a-job-hiring-staff

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
