### PR TITLE
Jobseekers cant delete expired jobs

### DIFF
--- a/app/controllers/jobseekers/saved_jobs_controller.rb
+++ b/app/controllers/jobseekers/saved_jobs_controller.rb
@@ -1,5 +1,6 @@
 class Jobseekers::SavedJobsController < Jobseekers::BaseController
-  helper_method :saved_jobs, :sort
+  helper_method :sort
+  before_action :set_saved_jobs, only: %i[index]
 
   def index
     redirect_to jobseekers_job_applications_path if session.delete(:after_sign_in) && current_jobseeker.job_applications.any?
@@ -39,8 +40,8 @@ class Jobseekers::SavedJobsController < Jobseekers::BaseController
     @saved_job ||= current_jobseeker.saved_jobs.find_or_initialize_by(vacancy_id: vacancy.id)
   end
 
-  def saved_jobs
-    @saved_jobs ||= current_jobseeker.saved_jobs.includes(:vacancy).order("#{sort.by} #{sort.order}")
+  def set_saved_jobs
+    @saved_jobs = current_jobseeker.saved_jobs.includes(:vacancy).order("#{sort.by} #{sort.order}")
   end
 
   def saved_job_params

--- a/app/models/published_vacancy.rb
+++ b/app/models/published_vacancy.rb
@@ -22,8 +22,8 @@ class PublishedVacancy < Vacancy
   scope :expired, -> { kept.where(expires_at: ...Time.current) }
   scope :expired_yesterday, -> { where("DATE(expires_at) = ?", 1.day.ago.to_date) }
   scope :expires_within_data_access_period, -> { where(expires_at: (Time.current - DATA_ACCESS_PERIOD_FOR_PUBLISHERS)..) }
-  scope :listed, -> { kept.where(publish_on: ..Date.current) }
-  scope :live, -> { listed.applicable }
+  scope :listed, -> { where(publish_on: ..Date.current) }
+  scope :live, -> { kept.listed.applicable }
   scope :pending, -> { kept.where("publish_on > ?", Date.current) }
 
   def find_conflicting_vacancy

--- a/app/views/jobseekers/saved_jobs/index.html.slim
+++ b/app/views/jobseekers/saved_jobs/index.html.slim
@@ -1,12 +1,12 @@
 - content_for :page_title_prefix, t(".page_title")
 
-- if saved_jobs.any?
+- if @saved_jobs.any?
   - content_for :skip_links do
     = govuk_skip_link(href: "#vacancy-results", text: t(".skip_link"))
 
 h1.govuk-heading-l = t(".page_title")
 
-- if saved_jobs.many?
+- if @saved_jobs.many?
   .govuk-grid-row
     .govuk-grid-column-full
       = render SortComponent.new path: method(:jobseekers_saved_jobs_path), sort: sort
@@ -15,9 +15,9 @@ h1.govuk-heading-l = t(".page_title")
   .govuk-grid-column-one-quarter
     = render "jobseekers/shared/side_navigation"
   .govuk-grid-column-three-quarters
-    - if saved_jobs.any?
+    - if @saved_jobs.any?
       #vacancy-results
-        - saved_jobs.each do |saved_job|
+        - @saved_jobs.each do |saved_job|
           = render CardComponent.new do |card|
             - card.with_header do
               = tag.div(govuk_link_to(saved_job.vacancy.job_title, job_path(saved_job.vacancy), class: "govuk-link--no-visited-state"))

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -14,6 +14,9 @@ html.govuk-template.app-html-class lang="en"
     = stylesheet_link_tag "application", media: "all"
     = csrf_meta_tags
     = render "layouts/sentry_js_config"
+    / for chartkick gem to render using Google Charts
+    = javascript_include_tag "https://www.gstatic.com/charts/loader.js"
+    = javascript_include_tag "application", defer: true
 
   body class=body_class
     = render "layouts/skip_links"
@@ -39,6 +42,3 @@ html.govuk-template.app-html-class lang="en"
         = yield
       = content_for :after_main
     = render "layouts/footer"
-    / for chartkick gem to render using Google Charts
-    = javascript_include_tag "https://www.gstatic.com/charts/loader.js"
-    = javascript_include_tag "application", defer: true

--- a/spec/system/jobseekers/jobseekers_can_manage_their_saved_jobs_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_their_saved_jobs_spec.rb
@@ -82,14 +82,11 @@ RSpec.describe "Jobseekers can manage their saved jobs" do
         end
       end
 
-      context "when deleting a saved job" do
-        before { click_on I18n.t("jobseekers.saved_jobs.index.delete"), match: :first }
-
-        it "deletes the saved job and redirects to the dashboard" do
-          expect(page).to have_content(I18n.t("jobseekers.saved_jobs.index.page_title"))
-          expect(page).to have_content(I18n.t("jobseekers.saved_jobs.destroy.success"))
-          expect(page).to have_css(".card-component", count: 2)
-        end
+      scenario "deleting an expired saved job redirects to the dashboard" do
+        click_on I18n.t("jobseekers.saved_jobs.index.delete"), match: :first
+        expect(page).to have_content(I18n.t("jobseekers.saved_jobs.index.page_title"))
+        expect(page).to have_content(I18n.t("jobseekers.saved_jobs.destroy.success"))
+        expect(page).to have_css(".card-component", count: 2)
       end
     end
 

--- a/spec/system/jobseekers/jobseekers_can_manage_their_saved_jobs_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_their_saved_jobs_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe "Jobseekers can manage their saved jobs" do
   let(:jobseeker) { create(:jobseeker) }
   let(:organisation) { create(:school) }
 
-  let(:vacancy1) { create(:vacancy, enable_job_applications: false, organisations: [organisation]) }
   let(:vacancy2) { create(:vacancy, enable_job_applications: true, organisations: [organisation]) }
   let(:expired_vacancy) { create(:vacancy, :expired, organisations: [organisation]) }
   let(:expired_external_vacancy) { create(:vacancy, :external, :expired, organisations: [organisation]).tap(&:discard!) }
@@ -16,7 +15,6 @@ RSpec.describe "Jobseekers can manage their saved jobs" do
 
     context "when there are saved jobs" do
       before do
-        jobseeker.saved_jobs.create(vacancy: vacancy1)
         jobseeker.saved_jobs.create(vacancy: vacancy2)
         jobseeker.saved_jobs.create(vacancy: expired_vacancy)
         jobseeker.saved_jobs.create(vacancy: expired_external_vacancy)
@@ -28,84 +26,25 @@ RSpec.describe "Jobseekers can manage their saved jobs" do
         expect(page).to be_axe_clean
       end
 
-      context "when viewing saved jobs" do
-        it "shows saved jobs" do
-          expect(page).to have_content(I18n.t("jobseekers.saved_jobs.index.page_title"))
-          expect(page).to have_css("h1.govuk-heading-l", text: I18n.t("jobseekers.saved_jobs.index.page_title"))
-          expect(page).to have_css(".card-component", count: 4)
-
-          within ".card-component:nth-child(2)" do
-            expect(page).to have_css(".card-component__header", text: expired_vacancy.job_title)
-          end
-
-          within ".card-component:nth-child(3)" do
-            expect(page).to have_css(".card-component__header", text: vacancy2.job_title)
-          end
-
-          within ".card-component:nth-child(4)" do
-            expect(page).to have_css(".card-component__header", text: vacancy1.job_title)
-          end
-        end
-
-        it "shows job closed label for expired jobs" do
-          within ".card-component:nth-child(2)" do
-            expect(page).to have_css(".card-component__body", text: I18n.t("jobseekers.saved_jobs.index.deadline_passed"))
-          end
-
-          within ".card-component:nth-child(3)" do
-            expect(page).not_to have_css(".card-component__body", text: I18n.t("jobseekers.saved_jobs.index.deadline_passed"))
-          end
-
-          within ".card-component:nth-child(4)" do
-            expect(page).not_to have_css(".card-component__body", text: I18n.t("jobseekers.saved_jobs.index.deadline_passed"))
-          end
-        end
-
-        it "only allows jobseekers to apply for jobs that have not expired" do
-          within ".card-component:nth-child(2)" do
-            expect(page).not_to have_link(I18n.t("jobseekers.saved_jobs.index.apply"))
-          end
-
-          within ".card-component:nth-child(3)" do
-            expect(page).to have_link(I18n.t("jobseekers.saved_jobs.index.apply"))
-          end
-
-          within ".card-component:nth-child(4)" do
-            expect(page).not_to have_link(I18n.t("jobseekers.saved_jobs.index.apply"))
-          end
-        end
-
-        context "when applying to a saved job" do
-          before { click_on I18n.t("jobseekers.saved_jobs.index.apply") }
-
-          it "redirects to the new job application page" do
-            expect(current_path).to eq(new_jobseekers_job_job_application_path(vacancy2.id))
-          end
-        end
+      scenario "when applying to a saved job redirects to the new job application page" do
+        click_on I18n.t("jobseekers.saved_jobs.index.apply")
+        expect(current_path).to eq(new_jobseekers_job_job_application_path(vacancy2.id))
       end
 
       scenario "deleting an expired saved job redirects to the dashboard" do
         click_on I18n.t("jobseekers.saved_jobs.index.delete"), match: :first
         expect(page).to have_content(I18n.t("jobseekers.saved_jobs.index.page_title"))
         expect(page).to have_content(I18n.t("jobseekers.saved_jobs.destroy.success"))
-        expect(page).to have_css(".card-component", count: 3)
+        expect(page).to have_css(".card-component", count: 2)
       end
 
       scenario "deleting an expired soft-deleted saved job redirects to the dashboard" do
-        within ".card-component:nth-child(4)" do
+        within ".card-component:nth-child(3)" do
           click_on I18n.t("jobseekers.saved_jobs.index.delete")
         end
         expect(page).to have_content(I18n.t("jobseekers.saved_jobs.index.page_title"))
         expect(page).to have_content(I18n.t("jobseekers.saved_jobs.destroy.success"))
-        expect(page).to have_css(".card-component", count: 3)
-      end
-    end
-
-    context "when there are no saved jobs" do
-      before { visit jobseekers_saved_jobs_path }
-
-      it "shows zero saved jobs" do
-        expect(page).to have_content(I18n.t("jobseekers.saved_jobs.index.zero_saved_jobs_title"))
+        expect(page).to have_css(".card-component", count: 2)
       end
     end
   end

--- a/spec/system/jobseekers/jobseekers_can_manage_their_saved_jobs_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_their_saved_jobs_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "Jobseekers can manage their saved jobs" do
   let(:vacancy1) { create(:vacancy, enable_job_applications: false, organisations: [organisation]) }
   let(:vacancy2) { create(:vacancy, enable_job_applications: true, organisations: [organisation]) }
   let(:expired_vacancy) { create(:vacancy, :expired, organisations: [organisation]) }
+  let(:expired_external_vacancy) { create(:vacancy, :external, :expired, organisations: [organisation]).tap(&:discard!) }
 
   context "when logged in" do
     before { login_as(jobseeker, scope: :jobseeker) }
@@ -18,6 +19,7 @@ RSpec.describe "Jobseekers can manage their saved jobs" do
         jobseeker.saved_jobs.create(vacancy: vacancy1)
         jobseeker.saved_jobs.create(vacancy: vacancy2)
         jobseeker.saved_jobs.create(vacancy: expired_vacancy)
+        jobseeker.saved_jobs.create(vacancy: expired_external_vacancy)
 
         visit jobseekers_saved_jobs_path
       end
@@ -30,45 +32,45 @@ RSpec.describe "Jobseekers can manage their saved jobs" do
         it "shows saved jobs" do
           expect(page).to have_content(I18n.t("jobseekers.saved_jobs.index.page_title"))
           expect(page).to have_css("h1.govuk-heading-l", text: I18n.t("jobseekers.saved_jobs.index.page_title"))
-          expect(page).to have_css(".card-component", count: 3)
+          expect(page).to have_css(".card-component", count: 4)
 
-          within ".card-component:nth-child(1)" do
+          within ".card-component:nth-child(2)" do
             expect(page).to have_css(".card-component__header", text: expired_vacancy.job_title)
           end
 
-          within ".card-component:nth-child(2)" do
+          within ".card-component:nth-child(3)" do
             expect(page).to have_css(".card-component__header", text: vacancy2.job_title)
           end
 
-          within ".card-component:nth-child(3)" do
+          within ".card-component:nth-child(4)" do
             expect(page).to have_css(".card-component__header", text: vacancy1.job_title)
           end
         end
 
         it "shows job closed label for expired jobs" do
-          within ".card-component:nth-child(1)" do
+          within ".card-component:nth-child(2)" do
             expect(page).to have_css(".card-component__body", text: I18n.t("jobseekers.saved_jobs.index.deadline_passed"))
           end
 
-          within ".card-component:nth-child(2)" do
+          within ".card-component:nth-child(3)" do
             expect(page).not_to have_css(".card-component__body", text: I18n.t("jobseekers.saved_jobs.index.deadline_passed"))
           end
 
-          within ".card-component:nth-child(3)" do
+          within ".card-component:nth-child(4)" do
             expect(page).not_to have_css(".card-component__body", text: I18n.t("jobseekers.saved_jobs.index.deadline_passed"))
           end
         end
 
         it "only allows jobseekers to apply for jobs that have not expired" do
-          within ".card-component:nth-child(1)" do
+          within ".card-component:nth-child(2)" do
             expect(page).not_to have_link(I18n.t("jobseekers.saved_jobs.index.apply"))
           end
 
-          within ".card-component:nth-child(2)" do
+          within ".card-component:nth-child(3)" do
             expect(page).to have_link(I18n.t("jobseekers.saved_jobs.index.apply"))
           end
 
-          within ".card-component:nth-child(3)" do
+          within ".card-component:nth-child(4)" do
             expect(page).not_to have_link(I18n.t("jobseekers.saved_jobs.index.apply"))
           end
         end
@@ -86,7 +88,16 @@ RSpec.describe "Jobseekers can manage their saved jobs" do
         click_on I18n.t("jobseekers.saved_jobs.index.delete"), match: :first
         expect(page).to have_content(I18n.t("jobseekers.saved_jobs.index.page_title"))
         expect(page).to have_content(I18n.t("jobseekers.saved_jobs.destroy.success"))
-        expect(page).to have_css(".card-component", count: 2)
+        expect(page).to have_css(".card-component", count: 3)
+      end
+
+      scenario "deleting an expired soft-deleted saved job redirects to the dashboard" do
+        within ".card-component:nth-child(4)" do
+          click_on I18n.t("jobseekers.saved_jobs.index.delete")
+        end
+        expect(page).to have_content(I18n.t("jobseekers.saved_jobs.index.page_title"))
+        expect(page).to have_content(I18n.t("jobseekers.saved_jobs.destroy.success"))
+        expect(page).to have_css(".card-component", count: 3)
       end
     end
 

--- a/spec/views/jobseekers/saved_jobs/index.html.slim_spec.rb
+++ b/spec/views/jobseekers/saved_jobs/index.html.slim_spec.rb
@@ -1,0 +1,87 @@
+require "rails_helper"
+
+RSpec.describe "jobseekers/saved_jobs/index" do
+  let(:jobseeker) { build_stubbed(:jobseeker) }
+  let(:organisation) { build_stubbed(:school) }
+
+  let(:vacancy_with_enabled_false) { build_stubbed(:vacancy, enable_job_applications: false, organisations: [organisation]) }
+  let(:vacancy_with_enabled_true) { build_stubbed(:vacancy, enable_job_applications: true, organisations: [organisation]) }
+  let(:expired_vacancy) { build_stubbed(:vacancy, :expired, organisations: [organisation]) }
+  let(:expired_external_vacancy) { build_stubbed(:vacancy, :external, :expired, :trashed, organisations: [organisation]) }
+
+  let(:sort) { Jobseekers::SavedJobSort.new }
+
+  before do
+    allow(view).to receive(:sort).and_return(sort)
+
+    assign(:saved_jobs, saved_jobs)
+    render
+  end
+
+  context "when there are saved jobs" do
+    let(:saved_jobs) do
+      [
+        build_stubbed(:saved_job, vacancy: expired_external_vacancy),
+        build_stubbed(:saved_job, vacancy: expired_vacancy),
+        build_stubbed(:saved_job, vacancy: vacancy_with_enabled_true),
+        build_stubbed(:saved_job, vacancy: vacancy_with_enabled_false),
+      ]
+    end
+
+    context "when viewing saved jobs" do
+      it "shows saved jobs" do
+        expect(rendered).to have_content(I18n.t("jobseekers.saved_jobs.index.page_title"))
+        expect(rendered).to have_css("h1.govuk-heading-l", text: I18n.t("jobseekers.saved_jobs.index.page_title"))
+        expect(rendered).to have_css(".card-component", count: 4)
+
+        within ".card-component:nth-child(2)" do
+          expect(rendered).to have_css(".card-component__header", text: expired_vacancy.job_title)
+        end
+
+        within ".card-component:nth-child(3)" do
+          expect(rendered).to have_css(".card-component__header", text: vacancy2.job_title)
+        end
+
+        within ".card-component:nth-child(4)" do
+          expect(rendered).to have_css(".card-component__header", text: vacancy1.job_title)
+        end
+      end
+
+      it "shows job closed label for expired jobs" do
+        within ".card-component:nth-child(2)" do
+          expect(rendered).to have_css(".card-component__body", text: I18n.t("jobseekers.saved_jobs.index.deadline_passed"))
+        end
+
+        within ".card-component:nth-child(3)" do
+          expect(rendered).to have_no_css(".card-component__body", text: I18n.t("jobseekers.saved_jobs.index.deadline_passed"))
+        end
+
+        within ".card-component:nth-child(4)" do
+          expect(rendered).to have_no_css(".card-component__body", text: I18n.t("jobseekers.saved_jobs.index.deadline_passed"))
+        end
+      end
+
+      it "only allows jobseekers to apply for jobs that have not expired" do
+        within ".card-component:nth-child(2)" do
+          expect(rendered).to have_no_link(I18n.t("jobseekers.saved_jobs.index.apply"))
+        end
+
+        within ".card-component:nth-child(3)" do
+          expect(rendered).to have_link(I18n.t("jobseekers.saved_jobs.index.apply"))
+        end
+
+        within ".card-component:nth-child(4)" do
+          expect(rendered).to have_no_link(I18n.t("jobseekers.saved_jobs.index.apply"))
+        end
+      end
+    end
+  end
+
+  context "when there are no saved jobs" do
+    let(:saved_jobs) { [] }
+
+    it "shows zero saved jobs" do
+      expect(rendered).to have_content(I18n.t("jobseekers.saved_jobs.index.zero_saved_jobs_title"))
+    end
+  end
+end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/wv8udenw/2918-bug-jobseekers-cannot-delete-expired-jobs-from-the-saved-jobs-list

## Changes in this PR:

Deleting a saved job pointing to an external vacancy could fail if that vacancy had been soft-deleted as a result of being so old that the external site had removed it from our system. 

Fix was to move the 'kept' scope from 'listed' (which holds all vacancies that have been published) to 'live' (which lists all active vacancies. The saved jobs controller uses the 'listed' scope which needs to have jobs in scope even if they expired many years ago