### PR TITLE
convert rate limits into active job delays

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -120,8 +120,6 @@ gem "rgeo-proj4"
 # open API docs for external client integrations
 gem "rswag-api"
 gem "rswag-ui"
-# more limiting of Govuk Notify API requests
-gem "ruby-limiter"
 # needed to make zipfiles - often in sidekiq jobs
 gem "rubyzip"
 gem "sentry-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -779,7 +779,6 @@ GEM
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
       rubocop-rspec (~> 3.5)
-    ruby-limiter (2.3.0)
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
@@ -1088,7 +1087,6 @@ DEPENDENCIES
   rubocop-govuk (> 5.2.0)
   rubocop-performance
   rubocop-rspec_rails
-  ruby-limiter
   rubyzip
   selenium-webdriver
   sentry-rails
@@ -1405,7 +1403,6 @@ CHECKSUMS
   rubocop-rake (0.7.1) sha256=3797f2b6810c3e9df7376c26d5f44f3475eda59eb1adc38e6f62ecf027cbae4d
   rubocop-rspec (3.9.0) sha256=8fa70a3619408237d789aeecfb9beef40576acc855173e60939d63332fdb55e2
   rubocop-rspec_rails (2.32.0) sha256=4a0d641c72f6ebb957534f539d9d0a62c47abd8ce0d0aeee1ef4701e892a9100
-  ruby-limiter (2.3.0) sha256=a8c247e14bc092c749d67bcd2a2def052580447da02b04612a2baa88cb154464
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   ruby-rc4 (0.1.5) sha256=00cc40a39d20b53f5459e7ea006a92cf584e9bc275e2a6f7aa1515510e896c03
   ruby2_keywords (0.0.5) sha256=ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef

--- a/app/jobs/send_peak_times_email_reminder_job.rb
+++ b/app/jobs/send_peak_times_email_reminder_job.rb
@@ -2,8 +2,9 @@ class SendPeakTimesEmailReminderJob < ApplicationJob
   queue_as :default
 
   def perform
-    Jobseeker.email_opt_in.select(:id).find_each do |jobseeker|
-      Jobseekers::PeakTimesMailer.reminder(jobseeker.id).deliver_later
+    Jobseeker.email_opt_in.select(:id).find_each.with_index do |jobseeker, index|
+      delay = index * GovukNotifyMailer::SIDEKIQ_WORKER_COUNT / GovukNotifyMailer::GOVUK_NOTIFY_SEND_LIMIT_PER_MINUTE
+      Jobseekers::PeakTimesMailer.reminder(jobseeker.id).deliver_later(wait: delay.minutes)
     end
   end
 end

--- a/app/jobs/send_subscription_governance_emails_job.rb
+++ b/app/jobs/send_subscription_governance_emails_job.rb
@@ -4,8 +4,11 @@ class SendSubscriptionGovernanceEmailsJob < ApplicationJob
   def perform
     return if DisableEmailNotifications.enabled?
 
-    subscriptions_needing_governance_email.find_each do |subscription|
-      send_appropriate_governance_email(subscription)
+    subscriptions_needing_governance_email.find_each.with_index do |subscription, index|
+      delay = index * GovukNotifyMailer::SIDEKIQ_WORKER_COUNT / GovukNotifyMailer::GOVUK_NOTIFY_SEND_LIMIT_PER_MINUTE
+
+      mailer_method = appropriate_governance_email(subscription)
+      Jobseekers::SubscriptionMailer.public_send(mailer_method, subscription).deliver_later(wait: delay.minutes)
       subscription.update_column(:deletion_warning_email_sent_at, Time.current)
     end
   end
@@ -19,20 +22,18 @@ class SendSubscriptionGovernanceEmailsJob < ApplicationJob
       .where(deletion_warning_email_sent_at: nil)
   end
 
-  def send_appropriate_governance_email(subscription)
+  def appropriate_governance_email(subscription)
     registered = Jobseeker.exists?(email: subscription.email.downcase)
     never_updated = subscription.created_at.to_i == subscription.updated_at.to_i
 
-    mailer_method = if registered && never_updated
-                      :governance_email_registered_never_updated
-                    elsif registered && !never_updated
-                      :governance_email_registered_was_updated
-                    elsif !registered && never_updated
-                      :governance_email_unregistered_never_updated
-                    else # !registered && !never_updated
-                      :governance_email_unregistered_was_updated
-                    end
-
-    Jobseekers::SubscriptionMailer.public_send(mailer_method, subscription).deliver_later
+    if registered && never_updated
+      :governance_email_registered_never_updated
+    elsif registered && !never_updated
+      :governance_email_registered_was_updated
+    elsif !registered && never_updated
+      :governance_email_unregistered_never_updated
+    else # !registered && !never_updated
+      :governance_email_unregistered_was_updated
+    end
   end
 end

--- a/app/mailers/govuk_notify_mailer.rb
+++ b/app/mailers/govuk_notify_mailer.rb
@@ -1,7 +1,7 @@
 class GovukNotifyMailer < Mail::Notify::Mailer
   SIDEKIQ_WORKER_COUNT = 4
-  # This is the maximum rate we can send through production Govuk Notify
-  GOVUK_NOTIFY_SEND_LIMIT_PER_MINUTE = 3000
+  # Maximum rate we can send through production Govuk Notify is 3000 - reduce it a bit so we don't hit the limit
+  GOVUK_NOTIFY_SEND_LIMIT_PER_MINUTE = 2800
 
   helper NotifyViewsHelper
   include MailerAnalyticsEvents
@@ -13,14 +13,6 @@ class GovukNotifyMailer < Mail::Notify::Mailer
   # This line clearly cannot be auto-tested
   # :nocov:
   self.delivery_method = :notify unless Rails.env.test?
-
-  # inspired by https://mattbrictson.com/blog/applying-a-rate-limit-in-sidekiq
-  extend Limiter::Mixin
-
-  # limit sending emails to 3000 per minute - but send in a burst, don't balance across the minute
-  # calculate as 3000 / worker_count to make it clear what's going on
-  limit_method :send_email, rate: GOVUK_NOTIFY_SEND_LIMIT_PER_MINUTE / SIDEKIQ_WORKER_COUNT, balanced: false
-  limit_method :template_mail, rate: GOVUK_NOTIFY_SEND_LIMIT_PER_MINUTE / SIDEKIQ_WORKER_COUNT, balanced: false
 
   def send_email(to:, subject:)
     @to = to

--- a/app/mailers/jobseekers/subscription_mailer.rb
+++ b/app/mailers/jobseekers/subscription_mailer.rb
@@ -1,10 +1,5 @@
 module Jobseekers
   class SubscriptionMailer < BaseMailer
-    # Rate limit governance emails to comply with GOV.UK Notify sending limits
-    limit_method :governance_email,
-                 rate: GOVUK_NOTIFY_SEND_LIMIT_PER_MINUTE / SIDEKIQ_WORKER_COUNT,
-                 balanced: false
-
     def confirmation(subscription)
       subscription_email(subscription, "subscribed", "subscribed to")
     end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/wHyWpMK0/2920-peak-times-mailer-not-being-rate-limitted

## Changes in this PR:

Convert rate limits into active job delays