### PR TITLE
Revert "Bump govuk-frontend from 6.1.0 to 6.2.0 (#8901)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "core-js": "^3.49.0",
     "dfe-frontend": "^2.0.1",
     "dompurify": "^3.4.8",
-    "govuk-frontend": "^6.2.0",
+    "govuk-frontend": "^6.1.0",
     "leaflet": "^1.9.4",
     "leaflet-gesture-handling": "^1.2.2",
     "leaflet.markercluster": "^1.5.3",

--- a/spec/services/search/school_search_spec.rb
+++ b/spec/services/search/school_search_spec.rb
@@ -47,21 +47,6 @@ RSpec.describe Search::SchoolSearch do
   end
 
   describe "#organisations" do
-    context "with the default scope" do
-      subject { described_class.new(form_hash) }
-
-      let!(:school_without_registered_publisher) { create(:school, name: "External only school") }
-
-      before do
-        create(:school, :closed, name: "Closed school")
-        create(:school, name: "Out of scope school", detailed_school_type: "Other independent school")
-      end
-
-      it "returns in-scope GIAS schools even when they do not have registered publishers" do
-        expect(subject.organisations).to contain_exactly(school_without_registered_publisher)
-      end
-    end
-
     context "when no filters (except for radius) are given" do
       subject { described_class.new(form_hash, scope: scope) }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5358,10 +5358,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"govuk-frontend@npm:^6.2.0":
-  version: 6.2.0
-  resolution: "govuk-frontend@npm:6.2.0"
-  checksum: 10c0/ab4a6b157b2785d14479bae4c78916dfe60ac9e00da7202b6c46b656078920a0b99627ec03e24482ab6a09962e200c477323e7229d75207c6ce24a3ac35dd30f
+"govuk-frontend@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "govuk-frontend@npm:6.1.0"
+  checksum: 10c0/543a8c6b1d709ec938e396fa3be923171637ab9b724f03618fa1bdc52023b6aa27fb42932b9e81df3fc134b0473442d42478dbf3e4b18e2bae00dbfe95363e96
   languageName: node
   linkType: hard
 
@@ -8495,7 +8495,7 @@ __metadata:
     eslint-config-airbnb-base: "npm:^15.0.0"
     eslint-plugin-import: "npm:^2.32.0"
     globals: "npm:^17.6.0"
-    govuk-frontend: "npm:^6.2.0"
+    govuk-frontend: "npm:^6.1.0"
     jest: "npm:^30.4.2"
     jest-environment-jsdom: "npm:30.4.1"
     jsdom: "npm:^29.1.0"


### PR DESCRIPTION
This reverts commit 0eb5f4eab7bc322188c52ae9ee7e5a1d23dcc54c.

## Changes in this PR:

Revert MoJ front end upgrade as it seems to break staging