### PR TITLE
Do not show closed trusts in visible_to_jobseekers scope

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -52,6 +52,7 @@ class Organisation < ApplicationRecord
   scope :schools, -> { where(type: "School") }
   scope :school_groups, -> { where(type: "SchoolGroup") }
   scope :trusts, -> { school_groups.where.not(uid: nil) }
+  scope :trusts_not_closed, -> { trusts.where.not("gias_data ->> 'Group Status' IN (?)", CLOSED_ESTABLISHMENT_STATUSES) }
   scope :local_authorities, -> { school_groups.where.not(local_authority_code: nil) }
   scope :in_vacancy_ids, ->(ids) { joins(:organisation_vacancies).where(organisation_vacancies: { vacancy_id: ids }).distinct }
 
@@ -63,7 +64,7 @@ class Organisation < ApplicationRecord
 
   scope :not_out_of_scope, -> { where.not(detailed_school_type: Organisation::OUT_OF_SCOPE_DETAILED_SCHOOL_TYPES).or(where(detailed_school_type: nil)) }
 
-  scope :visible_to_jobseekers, -> { schools.not_closed.not_out_of_scope.or(Organisation.trusts) }
+  scope :visible_to_jobseekers, -> { schools.not_closed.not_out_of_scope.or(Organisation.trusts_not_closed) }
 
   scope :only_faith_schools, -> { where.not(religious_character: NON_FAITH_RELIGIOUS_CHARACTER_TYPES) }
 

--- a/spec/factories/school_groups.rb
+++ b/spec/factories/school_groups.rb
@@ -18,6 +18,7 @@ FactoryBot.define do
         "Group Locality": address,
         "Group Town": town,
         "Group County": county,
+        "Group Status": "Open",
       }
     end
     group_type { "Multi-academy trust" }

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -190,6 +190,15 @@ RSpec.describe Organisation do
     end
   end
 
+  describe ".trusts_not_closed" do
+    let!(:open_trust) { create(:trust, gias_data: { "Group Status" => "Open" }) }
+    let!(:closed_trust) { create(:trust, gias_data: { "Group Status" => "Closed" }) }
+
+    it "returns trusts whose group status is not closed" do
+      expect(Organisation.trusts_not_closed).to contain_exactly(open_trust)
+    end
+  end
+
   describe ".visible_to_jobseekers" do
     let!(:open_school) { create(:school, establishment_status: "Open", detailed_school_type: "Primary school") }
     let(:closed_school) { create(:school, establishment_status: "Closed", detailed_school_type: "Secondary school").tap(&:discard) }
@@ -200,12 +209,14 @@ RSpec.describe Organisation do
     let(:independent_special_school) { create(:school, establishment_status: "Open", detailed_school_type: "Other independent special school") }
     let(:higher_education_school) { create(:school, establishment_status: "Open", detailed_school_type: "Higher education institutions") }
     let(:welsh_school) { create(:school, establishment_status: "Open", detailed_school_type: "Welsh establishment") }
-    let(:registered_trust) { create(:trust) }
-    let!(:unregistered_trust) { create(:trust) }
+    let(:registered_trust) { create(:trust, gias_data: { "Group Status" => "Open" }) }
+    let!(:unregistered_trust) { create(:trust, gias_data: { "Group Status" => "Open" }) }
+    let!(:closed_trust) { create(:trust, gias_data: { "Group Status" => "Closed" }) }
 
     before do
       create(:publisher, organisations: [registered_trust,
                                          closed_school,
+                                         closed_trust,
                                          fe_school,
                                          independent_school,
                                          misc_school,
@@ -223,7 +234,7 @@ RSpec.describe Organisation do
       expect(Organisation.visible_to_jobseekers).to include(registered_trust, unregistered_trust)
     end
 
-    it "does not return closed or out-of-scope schools" do
+    it "does not return closed trusts or closed or out-of-scope schools" do
       expect(Organisation.visible_to_jobseekers).to contain_exactly(open_school, registered_trust, unregistered_trust)
     end
   end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/YiLOUNyw/2924-remove-closed-trusts-from-schools-page

## Changes in this PR:

Prior to this change we were showing closed trusts, this change ensures we only show currently open trusts (according to GIAS data).

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
