### PR TITLE
Import group status field from gias into establishment_status

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -52,6 +52,7 @@ class Organisation < ApplicationRecord
   scope :schools, -> { where(type: "School") }
   scope :school_groups, -> { where(type: "SchoolGroup") }
   scope :trusts, -> { school_groups.where.not(uid: nil) }
+  scope :trusts_not_closed, -> { trusts.where.not("gias_data ->> 'Group Status' IN (?)", CLOSED_ESTABLISHMENT_STATUSES) }
   scope :local_authorities, -> { school_groups.where.not(local_authority_code: nil) }
   scope :in_vacancy_ids, ->(ids) { joins(:organisation_vacancies).where(organisation_vacancies: { vacancy_id: ids }).distinct }
 
@@ -63,7 +64,7 @@ class Organisation < ApplicationRecord
 
   scope :not_out_of_scope, -> { where.not(detailed_school_type: Organisation::OUT_OF_SCOPE_DETAILED_SCHOOL_TYPES).or(where(detailed_school_type: nil)) }
 
-  scope :visible_to_jobseekers, -> { schools.not_closed.not_out_of_scope.or(Organisation.trusts.not_closed) }
+  scope :visible_to_jobseekers, -> { schools.not_closed.not_out_of_scope.or(Organisation.trusts_not_closed) }
 
   scope :only_faith_schools, -> { where.not(religious_character: NON_FAITH_RELIGIOUS_CHARACTER_TYPES) }
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -52,7 +52,6 @@ class Organisation < ApplicationRecord
   scope :schools, -> { where(type: "School") }
   scope :school_groups, -> { where(type: "SchoolGroup") }
   scope :trusts, -> { school_groups.where.not(uid: nil) }
-  scope :trusts_not_closed, -> { trusts.where.not("gias_data ->> 'Group Status' IN (?)", CLOSED_ESTABLISHMENT_STATUSES) }
   scope :local_authorities, -> { school_groups.where.not(local_authority_code: nil) }
   scope :in_vacancy_ids, ->(ids) { joins(:organisation_vacancies).where(organisation_vacancies: { vacancy_id: ids }).distinct }
 
@@ -64,7 +63,7 @@ class Organisation < ApplicationRecord
 
   scope :not_out_of_scope, -> { where.not(detailed_school_type: Organisation::OUT_OF_SCOPE_DETAILED_SCHOOL_TYPES).or(where(detailed_school_type: nil)) }
 
-  scope :visible_to_jobseekers, -> { schools.not_closed.not_out_of_scope.or(Organisation.trusts_not_closed) }
+  scope :visible_to_jobseekers, -> { schools.not_closed.not_out_of_scope.or(Organisation.trusts.not_closed) }
 
   scope :only_faith_schools, -> { where.not(religious_character: NON_FAITH_RELIGIOUS_CHARACTER_TYPES) }
 

--- a/app/services/gias/import_trusts.rb
+++ b/app/services/gias/import_trusts.rb
@@ -130,6 +130,7 @@ class Gias::ImportTrusts
       group_type: row["Group Type"],
       town: row["Group Town"],
       postcode: row["Group Postcode"],
+      establishment_status: row["Group Status"],
       gias_data: row.to_h,
     }
   end

--- a/spec/factories/school_groups.rb
+++ b/spec/factories/school_groups.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     county { Faker::Address.state_abbr }
     description { Faker::Lorem.paragraph(sentence_count: 1) }
     email { Faker::Internet.email(domain: "contoso.com") }
+    establishment_status { "Open" }
     gias_data do
       {
         "Group UID": uid,

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -190,15 +190,6 @@ RSpec.describe Organisation do
     end
   end
 
-  describe ".trusts_not_closed" do
-    let!(:open_trust) { create(:trust, gias_data: { "Group Status" => "Open" }) }
-    let!(:closed_trust) { create(:trust, gias_data: { "Group Status" => "Closed" }) }
-
-    it "returns trusts whose group status is not closed" do
-      expect(Organisation.trusts_not_closed).to contain_exactly(open_trust)
-    end
-  end
-
   describe ".visible_to_jobseekers" do
     let!(:open_school) { create(:school, establishment_status: "Open", detailed_school_type: "Primary school") }
     let(:closed_school) { create(:school, establishment_status: "Closed", detailed_school_type: "Secondary school").tap(&:discard) }
@@ -209,9 +200,9 @@ RSpec.describe Organisation do
     let(:independent_special_school) { create(:school, establishment_status: "Open", detailed_school_type: "Other independent special school") }
     let(:higher_education_school) { create(:school, establishment_status: "Open", detailed_school_type: "Higher education institutions") }
     let(:welsh_school) { create(:school, establishment_status: "Open", detailed_school_type: "Welsh establishment") }
-    let(:registered_trust) { create(:trust, gias_data: { "Group Status" => "Open" }) }
-    let!(:unregistered_trust) { create(:trust, gias_data: { "Group Status" => "Open" }) }
-    let!(:closed_trust) { create(:trust, gias_data: { "Group Status" => "Closed" }) }
+    let(:registered_trust) { create(:trust) }
+    let!(:unregistered_trust) { create(:trust) }
+    let!(:closed_trust) { create(:trust, establishment_status: "Closed") }
 
     before do
       create(:publisher, organisations: [registered_trust,

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -190,6 +190,15 @@ RSpec.describe Organisation do
     end
   end
 
+  describe ".not_closed" do
+    let!(:open_trust) { create(:trust, establishment_status: "Open") }
+    let!(:closed_trust) { create(:trust, establishment_status: "Closed") }
+
+    it "returns open trusts and excludes closed trusts" do
+      expect(Organisation.trusts.not_closed).to contain_exactly(open_trust)
+    end
+  end
+
   describe ".trusts_not_closed" do
     let!(:open_trust) { create(:trust, gias_data: { "Group Status" => "Open" }) }
     let!(:closed_trust) { create(:trust, gias_data: { "Group Status" => "Closed" }) }

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -190,6 +190,15 @@ RSpec.describe Organisation do
     end
   end
 
+  describe ".trusts_not_closed" do
+    let!(:open_trust) { create(:trust, gias_data: { "Group Status" => "Open" }) }
+    let!(:closed_trust) { create(:trust, gias_data: { "Group Status" => "Closed" }) }
+
+    it "returns trusts whose group status is not closed" do
+      expect(Organisation.trusts_not_closed).to contain_exactly(open_trust)
+    end
+  end
+
   describe ".visible_to_jobseekers" do
     let!(:open_school) { create(:school, establishment_status: "Open", detailed_school_type: "Primary school") }
     let(:closed_school) { create(:school, establishment_status: "Closed", detailed_school_type: "Secondary school").tap(&:discard) }
@@ -202,7 +211,7 @@ RSpec.describe Organisation do
     let(:welsh_school) { create(:school, establishment_status: "Open", detailed_school_type: "Welsh establishment") }
     let(:registered_trust) { create(:trust) }
     let!(:unregistered_trust) { create(:trust) }
-    let!(:closed_trust) { create(:trust, establishment_status: "Closed") }
+    let!(:closed_trust) { create(:trust, establishment_status: "Closed", gias_data: { "Group Status" => "Closed" }) }
 
     before do
       create(:publisher, organisations: [registered_trust,

--- a/spec/services/gias/import_trusts_spec.rb
+++ b/spec/services/gias/import_trusts_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe Gias::ImportTrusts do
       expect(trust1.gias_data).not_to be_blank
       expect(trust1.name).to eq("Abbey Academies Trust")
       expect(trust1.group_type).to eq("Multi-academy trust")
+      expect(trust1.establishment_status).to eq("Open")
       expect(trust1.address).to eq("Abbey Road")
       expect(trust1.county).to eq("Not recorded")
       expect(trust1.postcode).to eq("PE10 9EP")


### PR DESCRIPTION
## Trello card URL

## Changes in this PR:

This PR changes the import trust functionality to populate the establishment_status column with the group status field from GIAS. This means we can use the not_closed scope for trusts in the same way we use it for schools, simplifying the model.

Note: I have not deleted the `trusts_not_closed` scope yet. We will need it until the import is run and the establishment_status is populated for trusts. Once that is done we will be able to delete the trusts_not_closed scope and related tests.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
