### PR TITLE
Remove MoJ front end and replace the multi select component

### DIFF
--- a/app/assets/javascript/application.js
+++ b/app/assets/javascript/application.js
@@ -7,7 +7,6 @@ import '@stimulus/polyfills';
 import '@hotwired/turbo-rails';
 
 import * as govukFrontend from 'govuk-frontend';
-import * as mojFrontend from '@ministryofjustice/frontend';
 
 import { Application } from '@hotwired/stimulus';
 import Rails from 'rails-ujs';
@@ -34,6 +33,7 @@ import ClipboardController from './js_components/clipboard/clipboard';
 import FormController from './js_components/form/form';
 import LocationFinderController from './js_components/locationFinder/locationFinder';
 import ManageQualificationsController from './js_components/manageQualifications/manageQualifications';
+import MultiSelectController from './js_components/multiSelect/multiSelect';
 import PanelController from './js_components/panel/panel';
 import ShowHiddenContentController from './js_components/showHiddenContent/showHiddenContent';
 import TrackedLinkController from './js_components/trackedLink/trackedLink';
@@ -69,6 +69,7 @@ application.register('filters', FiltersController);
 application.register('form', FormController);
 application.register('location-finder', LocationFinderController);
 application.register('manage-qualifications', ManageQualificationsController);
+application.register('multi-select', MultiSelectController);
 application.register('map', MapController);
 application.register('map-sidebar', MapSidebarController);
 application.register('panel', PanelController);
@@ -84,7 +85,6 @@ Rails.start();
 ActiveStorage.start();
 
 govukFrontend.initAll();
-mojFrontend.initAll();
 initTrixURLNormalizer();
 
 // Make links in message content open in new tabs

--- a/app/assets/javascript/js_components/multiSelect/multiSelect.js
+++ b/app/assets/javascript/js_components/multiSelect/multiSelect.js
@@ -9,7 +9,7 @@ class MultiSelectController extends Controller {
     if (!$container || !$checkboxes.length) return;
 
     this.$checkboxes = $checkboxes;
-    this.$toggle = this.buildToggle(`${idPrefix}checkboxes-all`);
+    this.$toggle = MultiSelectController.buildToggle(`${idPrefix}checkboxes-all`);
     this.$toggleInput = this.$toggle.querySelector('input');
 
     $container.append(this.$toggle);
@@ -18,7 +18,7 @@ class MultiSelectController extends Controller {
     this.$checkboxes.forEach(($input) => $input.addEventListener('click', this.onCheckboxClick.bind(this)));
   }
 
-  buildToggle(id) {
+  static buildToggle(id) {
     const $toggle = document.createElement('div');
     const $input = document.createElement('input');
     const $label = document.createElement('label');
@@ -43,7 +43,7 @@ class MultiSelectController extends Controller {
   }
 
   onToggleClick() {
-    const checked = this.$toggleInput.checked;
+    const { checked } = this.$toggleInput;
     this.$checkboxes.forEach(($input) => { $input.checked = checked; });
   }
 

--- a/app/assets/javascript/js_components/multiSelect/multiSelect.js
+++ b/app/assets/javascript/js_components/multiSelect/multiSelect.js
@@ -1,0 +1,56 @@
+import { Controller } from '@hotwired/stimulus';
+
+class MultiSelectController extends Controller {
+  connect() {
+    const idPrefix = this.element.dataset.idPrefix || '';
+    const $container = this.element.querySelector(`#${idPrefix}select-all`);
+    const $checkboxes = Array.from(this.element.querySelectorAll('tbody input.govuk-checkboxes__input'));
+
+    if (!$container || !$checkboxes.length) return;
+
+    this.$checkboxes = $checkboxes;
+    this.$toggle = this.buildToggle(`${idPrefix}checkboxes-all`);
+    this.$toggleInput = this.$toggle.querySelector('input');
+
+    $container.append(this.$toggle);
+
+    this.$toggleInput.addEventListener('click', this.onToggleClick.bind(this));
+    this.$checkboxes.forEach(($input) => $input.addEventListener('click', this.onCheckboxClick.bind(this)));
+  }
+
+  buildToggle(id) {
+    const $toggle = document.createElement('div');
+    const $input = document.createElement('input');
+    const $label = document.createElement('label');
+    const $span = document.createElement('span');
+
+    $toggle.classList.add('govuk-checkboxes__item', 'govuk-checkboxes--small', 'multi-select__checkbox');
+
+    $input.id = id;
+    $input.type = 'checkbox';
+    $input.classList.add('govuk-checkboxes__input');
+
+    $label.setAttribute('for', id);
+    $label.classList.add('govuk-label', 'govuk-checkboxes__label', 'multi-select__toggle-label');
+
+    $span.classList.add('govuk-visually-hidden');
+    $span.textContent = 'Select all';
+
+    $label.append($span);
+    $toggle.append($input, $label);
+
+    return $toggle;
+  }
+
+  onToggleClick() {
+    const checked = this.$toggleInput.checked;
+    this.$checkboxes.forEach(($input) => { $input.checked = checked; });
+  }
+
+  onCheckboxClick() {
+    const allChecked = this.$checkboxes.every(($input) => $input.checked);
+    this.$toggleInput.checked = allChecked;
+  }
+}
+
+export default MultiSelectController;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,10 +1,7 @@
 $govuk-global-styles: true;
-$govuk-new-link-styles: true;
 $govuk-assets-path: '/';
 
-@forward '@ministryofjustice/frontend/moj/all';
-
-// External dependencioes
+// External dependencies
 @import 'accessible-autocomplete/dist/accessible-autocomplete.min';
 @import 'dfe-frontend/packages/dfefrontend';
 @import 'govuk-frontend/dist/govuk/index';
@@ -79,6 +76,7 @@ $govuk-assets-path: '/';
 @import 'js_components/loadingIndicator';
 @import 'js_components/locationFinder';
 @import 'js_components/manageQualifications';
+@import 'js_components/multiSelect';
 @import 'js_components/panel';
 @import 'js_components/uploadDocuments';
 

--- a/app/assets/stylesheets/js_components/multiSelect.scss
+++ b/app/assets/stylesheets/js_components/multiSelect.scss
@@ -1,0 +1,9 @@
+.multi-select__checkbox {
+  display: inline-block;
+  padding-left: 0;
+}
+
+.multi-select__toggle-label {
+  margin: 0 !important;
+  padding: 0 !important;
+}

--- a/app/components/tab_panel_component.rb
+++ b/app/components/tab_panel_component.rb
@@ -26,7 +26,7 @@ class TabPanelComponent < ApplicationComponent
 
   def govuk_table_args
     if @form.present?
-      { html_attributes: { data: { module: "moj-multi-select", id_prefix: "id_all_#{@tab_name}-" } } }
+      { html_attributes: { data: { controller: "multi-select", id_prefix: "id_all_#{@tab_name}-" } } }
     else
       {}
     end

--- a/app/views/publishers/candidate_messages/index.html.slim
+++ b/app/views/publishers/candidate_messages/index.html.slim
@@ -37,7 +37,7 @@ h1.govuk-heading-l Candidate messages
         = f.govuk_submit t(".buttons.unarchive"), class: "govuk-button--secondary"
       - else
         = f.govuk_submit t(".buttons.archive"), class: "govuk-button--secondary"
-    = govuk_table html_attributes: { data: { module: "moj-multi-select", id_prefix: "conversations-" } } do |table|
+    = govuk_table html_attributes: { data: { controller: "multi-select", id_prefix: "conversations-" } } do |table|
       - table.with_head do |head|
         - head.with_row do |row|
           - row.with_cell html_attributes: { id: "conversations-select-all" }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.23",
-    "@ministryofjustice/frontend": "^9.0.0",
     "@rails/actiontext": "^8.1.300",
     "@rails/activestorage": "^8.1.300",
     "@sentry/browser": "10.60.0",

--- a/spec/components/tab_panel_component_spec.rb
+++ b/spec/components/tab_panel_component_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe TabPanelComponent, type: :component do
       expect(tab_panel.find("form")["method"]).to eq("get")
     end
 
-    it "table has moj multi select attributes" do
-      expect(tab_panel.find("table")["data-module"]).to eq("moj-multi-select")
+    it "table has multi select attributes" do
+      expect(tab_panel.find("table")["data-controller"]).to eq("multi-select")
     end
 
     it "has buttons" do

--- a/yarn.lock
+++ b/yarn.lock
@@ -2598,16 +2598,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ministryofjustice/frontend@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "@ministryofjustice/frontend@npm:9.0.0"
-  peerDependencies:
-    govuk-frontend: ^6.0.0
-    moment: 2.30.1
-  checksum: 10c0/6b08112f34a564c516692ae14de2422decefdc6b26963b3922c47442a3a3ee18b8e034c3f3bedc15b881e017b0a3e8465ace50aa7526a5a90d4d56adf1e623f5
-  languageName: node
-  linkType: hard
-
 "@napi-rs/wasm-runtime@npm:^0.2.11":
   version: 0.2.12
   resolution: "@napi-rs/wasm-runtime@npm:0.2.12"
@@ -8590,7 +8580,6 @@ __metadata:
     "@eslint/js": "npm:^10.0.1"
     "@hotwired/stimulus": "npm:^3.2.2"
     "@hotwired/turbo-rails": "npm:^8.0.23"
-    "@ministryofjustice/frontend": "npm:^9.0.0"
     "@rails/actiontext": "npm:^8.1.300"
     "@rails/activestorage": "npm:^8.1.300"
     "@sentry/browser": "npm:10.60.0"


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/0hgC98B6/2923-moj-frontend-can-we-remove-it

## Changes in this PR:

This PR removes MoJ frontend and replaces the multi select component on the ATS page and the publisher's messages page.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
