### PR TITLE
Re-enable attachments on messages

### DIFF
--- a/app/assets/stylesheets/actiontext.scss
+++ b/app/assets/stylesheets/actiontext.scss
@@ -100,6 +100,11 @@ trix-editor {
   min-height: 350px;
 }
 
+/* Re-enable file tools toolbar for messages form */
+.message-form trix-toolbar .trix-button-group--file-tools {
+  display: block !important;
+}
+
 /* Hide link buttons on job application personal statement and profile about you (personal statement) forms */
 .personal-statement-form trix-toolbar .trix-button--icon-link,
 .about-you-form trix-toolbar .trix-button--icon-link {

--- a/app/views/shared/_message_form.html.slim
+++ b/app/views/shared/_message_form.html.slim
@@ -5,7 +5,7 @@ div class="govuk-!-margin-top-6"
   = form_for message_object, url: form_url, method: form_method do |f|
     = f.govuk_error_summary
 
-    .govuk-form-group
+    .govuk-form-group.message-form
       = f.rich_text_area :content, aria: { label: "Message" }
       noscript
         = f.govuk_text_area :content, label: { text: "Message" }, rows: 5


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/IdNp4YfN/2667-file-attachment-error-in-candidate-message-section-ats-evaluation-march-2026

## Changes in this PR:

Re-enables the file attachment button in the messages editor.

## Screenshots of UI changes:

### Before

### After

#### File attachment button present in the publisher-jobseeker messages:
<img width="900" height="658" alt="image" src="https://github.com/user-attachments/assets/d7e53652-fc3c-4415-b4b7-79a17db2e514" />

#### Attachment works without errors
<img width="1020" height="739" alt="image" src="https://github.com/user-attachments/assets/ff3ca11f-1e03-4972-be30-03529ee304cf" />


#### File attachment button not present in the Personal Statement
<img width="1000" height="698" alt="image" src="https://github.com/user-attachments/assets/14b642b4-c117-49d9-8685-bb29b44d3182" />

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
