### PR TITLE
Fix usage of "PublishedVacancy.listed" scope

### DIFF
--- a/app/controllers/api/vacancies_controller.rb
+++ b/app/controllers/api/vacancies_controller.rb
@@ -12,7 +12,7 @@ class Api::VacanciesController < Api::ApplicationController
   end
 
   def show
-    vacancy = PublishedVacancy.listed.friendly.find(params[:id])
+    vacancy = PublishedVacancy.kept.listed.friendly.find(params[:id])
     @vacancy = vacancy.decorate
   end
 

--- a/app/controllers/jobseekers/saved_jobs_controller.rb
+++ b/app/controllers/jobseekers/saved_jobs_controller.rb
@@ -53,6 +53,8 @@ class Jobseekers::SavedJobsController < Jobseekers::BaseController
   end
 
   def vacancy
+    # We want to allow jobseekers to delete saved jobs even when the vacancy was soft deleted.
+    # That is why we don't use 'kept' scope here.
     @vacancy ||= PublishedVacancy.listed.find(saved_job_params[:job_id])
   end
 end

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -19,7 +19,7 @@ class VacanciesController < ApplicationController
       session.delete(:newly_created_user)
     end
 
-    vacancy = PublishedVacancy.listed.friendly.find(params[:id])
+    vacancy = PublishedVacancy.kept.listed.friendly.find(params[:id])
     TrackVacancyViewJob.perform_later(vacancy_id: vacancy.id, referrer_url: request.referer, hostname: request.host, params: request.query_parameters)
     @saved_job = current_jobseeker&.saved_jobs&.find_by(vacancy: vacancy)
     @job_application = current_jobseeker&.job_applications&.find_by(vacancy: vacancy)

--- a/app/jobs/send_expired_vacancy_feedback_prompt_job.rb
+++ b/app/jobs/send_expired_vacancy_feedback_prompt_job.rb
@@ -20,9 +20,11 @@ class SendExpiredVacancyFeedbackPromptJob < ApplicationJob
   private
 
   def vacancies_requiring_expiry_email_prompt
-    PublishedVacancy.listed.where(expires_at: CUTOFF_DATE..2.weeks.ago.beginning_of_day,
-                                  hired_status: nil,
-                                  expired_vacancy_feedback_email_sent_at: nil)
-      .where.not(publisher: nil)
+    PublishedVacancy.kept
+                    .listed
+                    .where(expires_at: CUTOFF_DATE..2.weeks.ago.beginning_of_day,
+                           hired_status: nil,
+                           expired_vacancy_feedback_email_sent_at: nil)
+                    .where.not(publisher: nil)
   end
 end

--- a/app/views/vacancies/search/_no_results.html.slim
+++ b/app/views/vacancies/search/_no_results.html.slim
@@ -1,3 +1,3 @@
 .empty
-  - t("jobs.none_listed", count: PublishedVacancy.listed.count).each do |sentence|
+  - t("jobs.none_listed", count: PublishedVacancy.kept.listed.count).each do |sentence|
     p = sentence

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -105,7 +105,7 @@ FactoryBot.create(:jobseeker, email: "jobseeker@contoso.com")
 emails_with_fewer_applications = ["jobseeker@contoso.com"] + user_emails
 # Job Applications
 statuses = JobApplication.statuses.keys
-PublishedVacancy.listed.first(50).each do |vacancy|
+PublishedVacancy.kept.listed.first(50).each do |vacancy|
   Jobseeker.where.not(email: emails_with_fewer_applications).each do |jobseeker|
     application_status = JobApplication.statuses.keys.sample
     FactoryBot.create(:job_application, :for_seed_data, :"status_#{application_status}",

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -345,8 +345,9 @@ RSpec.describe Vacancy do
     end
 
     describe "#listed" do
-      it "retrieves vacancies that have a status of :published and a past publish_on date" do
+      it "retrieves vacancies that have a status of :published and a past publish_on date, including discarded vacancies" do
         published = create_list(:vacancy, 5)
+        published.first.discard
         create_list(:vacancy, 3, :future_publish)
 
         expect(PublishedVacancy.listed.count).to eq(published.count)


### PR DESCRIPTION
This scope previously included the ".kept" scope. It was removed so that Jobseekers could delete saved vacancies, even if they had been soft-deleted.

But altering the "listed" scope affects other areas of the service where we really don't want to include "deleted" vacancies.

Explicitly calling ".kept" in those cases.

Recent change: https://github.com/DFE-Digital/teaching-vacancies/pull/8899
Alert raised by Copilot: https://github.com/DFE-Digital/teaching-vacancies/pull/8932#discussion_r3428432315
<img width="733" height="524" alt="image" src="https://github.com/user-attachments/assets/e6a22a2c-3f46-4756-acb6-24ab8da045fd" />


## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
