### PR TITLE
Add confirm job address page to vacancy build flow

### DIFF
--- a/app/controllers/concerns/publishers/wizardable.rb
+++ b/app/controllers/concerns/publishers/wizardable.rb
@@ -48,7 +48,7 @@ module Publishers::Wizardable # rubocop:disable Metrics/ModuleLength
 
   def confirm_job_address_params(params)
     params.require(:publishers_job_listing_confirm_job_address_form)
-          .permit(:job_address)
+          .permit(:job_address_line1, :job_address_line2, :job_address_town, :job_address_county, :job_address_postcode)
   end
 
   def key_stages_params(params)

--- a/app/controllers/concerns/publishers/wizardable.rb
+++ b/app/controllers/concerns/publishers/wizardable.rb
@@ -46,6 +46,11 @@ module Publishers::Wizardable # rubocop:disable Metrics/ModuleLength
           .permit(:job_title)
   end
 
+  def confirm_job_address_params(params)
+    params.require(:publishers_job_listing_confirm_job_address_form)
+          .permit(:job_address)
+  end
+
   def key_stages_params(params)
     params.require(:publishers_job_listing_key_stages_form)
           .permit(key_stages: [])

--- a/app/controllers/publishers/vacancies/build_controller.rb
+++ b/app/controllers/publishers/vacancies/build_controller.rb
@@ -73,6 +73,7 @@ class Publishers::Vacancies::BuildController < Publishers::Vacancies::WizardBase
   def update_vacancy
     updated_completed_steps = completed_steps(steps_to_reset: form.steps_to_reset)
     vacancy.assign_attributes(form.params_to_save.merge(completed_steps: updated_completed_steps))
+    vacancy.geocode_job_address if current_step == :confirm_job_address
     vacancy.refresh_slug
     update_google_index(vacancy) if vacancy.live?
 

--- a/app/form_models/publishers/job_listing/confirm_job_address_form.rb
+++ b/app/form_models/publishers/job_listing/confirm_job_address_form.rb
@@ -1,7 +1,17 @@
 class Publishers::JobListing::ConfirmJobAddressForm < Publishers::JobListing::JobListingForm
   attr_accessor :job_address_line1, :job_address_line2, :job_address_town, :job_address_county, :job_address_postcode
 
+  validates :job_address_line1, presence: true, if: :any_address_field_present?
+  validates :job_address_town, presence: true, if: :any_address_field_present?
+  validates :job_address_postcode, presence: true, if: :any_address_field_present?
+
   def self.fields
     %i[job_address_line1 job_address_line2 job_address_town job_address_county job_address_postcode]
+  end
+
+  private
+
+  def any_address_field_present?
+    [job_address_line1, job_address_line2, job_address_town, job_address_county, job_address_postcode].any?(&:present?)
   end
 end

--- a/app/form_models/publishers/job_listing/confirm_job_address_form.rb
+++ b/app/form_models/publishers/job_listing/confirm_job_address_form.rb
@@ -1,0 +1,7 @@
+class Publishers::JobListing::ConfirmJobAddressForm < Publishers::JobListing::JobListingForm
+  attr_accessor :job_address
+
+  def self.fields
+    %i[job_address]
+  end
+end

--- a/app/form_models/publishers/job_listing/confirm_job_address_form.rb
+++ b/app/form_models/publishers/job_listing/confirm_job_address_form.rb
@@ -1,7 +1,7 @@
 class Publishers::JobListing::ConfirmJobAddressForm < Publishers::JobListing::JobListingForm
-  attr_accessor :job_address
+  attr_accessor :job_address_line1, :job_address_line2, :job_address_town, :job_address_county, :job_address_postcode
 
   def self.fields
-    %i[job_address]
+    %i[job_address_line1 job_address_line2 job_address_town job_address_county job_address_postcode]
   end
 end

--- a/app/form_models/publishers/vacancy_form_sequence.rb
+++ b/app/form_models/publishers/vacancy_form_sequence.rb
@@ -53,7 +53,7 @@ class Publishers::VacancyFormSequence
   end
 
   def next_incomplete_step_confirm_job_address?
-    return false unless @step_process.steps.include?(:confirm_job_address)
+    return false unless @step_names.include?(:confirm_job_address)
     return false if @vacancy.completed_steps.include?("confirm_job_address")
 
     @vacancy.completed_steps.last == "job_title"

--- a/app/form_models/publishers/vacancy_form_sequence.rb
+++ b/app/form_models/publishers/vacancy_form_sequence.rb
@@ -60,6 +60,6 @@ class Publishers::VacancyFormSequence
   end
 
   def not_validatable_steps
-    %i[subjects confirm_job_address review].freeze
+    %i[subjects review].freeze
   end
 end

--- a/app/form_models/publishers/vacancy_form_sequence.rb
+++ b/app/form_models/publishers/vacancy_form_sequence.rb
@@ -17,6 +17,7 @@ class Publishers::VacancyFormSequence
   def next_invalid_step
     # Due to subjects being an optional step (no validations) it needs to be handled differently
     return :subjects if next_incomplete_step_subjects?
+    return :confirm_job_address if next_incomplete_step_confirm_job_address?
 
     validate_all_steps.filter_map { |step, form| step if form.invalid? }.first
   end
@@ -51,7 +52,14 @@ class Publishers::VacancyFormSequence
                                      end
   end
 
+  def next_incomplete_step_confirm_job_address?
+    return false unless @step_process.steps.include?(:confirm_job_address)
+    return false if @vacancy.completed_steps.include?("confirm_job_address")
+
+    @vacancy.completed_steps.last == "job_title"
+  end
+
   def not_validatable_steps
-    %i[subjects review].freeze
+    %i[subjects confirm_job_address review].freeze
   end
 end

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -117,6 +117,7 @@ module VacanciesHelper
   def vacancy_job_location(vacancy)
     organisation = vacancy.organisation
     return "#{t('organisations.job_location_summary.at_multiple_locations')}, #{organisation.name}" if vacancy.organisations.many?
+    return address_join([organisation.name, vacancy.vacancy_address]) if vacancy.for_an_fe_college?
 
     address_join([organisation.name, organisation.town, organisation.county])
   end
@@ -131,6 +132,7 @@ module VacanciesHelper
   def vacancy_full_job_location(vacancy)
     organisation = vacancy.organisation
     return "#{t('organisations.job_location_summary.at_multiple_locations')}, #{organisation.name}" if vacancy.organisations.many?
+    return address_join([organisation.name, vacancy.vacancy_address]) if vacancy.for_an_fe_college?
 
     address_join([organisation.name, organisation.town, organisation.county, organisation.postcode])
   end

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -25,6 +25,10 @@ module VacanciesHelper
     end
   end
 
+  def fe_college_job_roles_options
+    [["teacher", I18n.t("helpers.label.publishers_job_listing_job_role_form.teaching_job_role_options.teacher")]]
+  end
+
   def teaching_job_roles_options
     Vacancy::TEACHING_JOB_ROLES.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_role_form.teaching_job_role_options.#{option}")] }
   end

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -305,6 +305,8 @@ class Vacancy < ApplicationRecord
   # In the former case, it gets an argument, which we don't need and thus ignore
   #
   def refresh_geolocation(_school_added_or_removed = nil)
+    return if job_address.present?
+
     self.geolocation = if organisations.one?
                          organisation.geopoint
                        else
@@ -317,6 +319,17 @@ class Vacancy < ApplicationRecord
                             uk_points = organisations.filter_map(&:uk_geopoint)
                             uk_points.presence && uk_points.first.factory.multi_point(uk_points)
                           end
+  end
+
+  def geocode_job_address
+    return unless job_address.present?
+
+    coordinates = Geocoding.new(job_address).coordinates
+    return if coordinates == Geocoding::COORDINATES_NO_MATCH
+
+    geopoint = GeoFactories::FACTORY_4326.point(coordinates.second, coordinates.first)
+    self.geolocation = geopoint
+    self.uk_geolocation = GeoFactories.convert_wgs84_to_sr27700(geopoint)
   end
 
   def resettable?

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -149,6 +149,11 @@ class Vacancy < ApplicationRecord
   validates :application_email, email_address: true, if: -> { application_email_changed? } # Allows data created prior to validation to still be valid
   validates :contact_email, email_address: true, if: -> { contact_email_changed? }
 
+  # An FE college may want to post a vacancy at a campus in a completely different location from the
+  # college's main address. These fields are exclusively reserved for storing that campus-specific
+  # address and are only applicable to FE college vacancies.
+  validate :job_address_only_for_fe_colleges, if: -> { organisations.any? && job_address_fields.any?(&:present?) }
+
   has_noticed_notifications
   has_paper_trail on: [:update],
                   only: ATTRIBUTES_TO_TRACK_IN_ACTIVITY_LOG,
@@ -284,7 +289,7 @@ class Vacancy < ApplicationRecord
   end
 
   def vacancy_address
-    job_specific_address = [job_address_line1, job_address_line2, job_address_town, job_address_county, job_address_postcode].reject(&:blank?)
+    job_specific_address = job_address_fields.reject(&:blank?)
     return job_specific_address.join(", ") if job_specific_address.any?
 
     # :nocov:
@@ -312,6 +317,16 @@ class Vacancy < ApplicationRecord
 
   private
 
+  def job_address_fields
+    [job_address_line1, job_address_line2, job_address_town, job_address_county, job_address_postcode]
+  end
+
+  def job_address_only_for_fe_colleges
+    return if for_an_fe_college?
+
+    errors.add(:base, :job_address_only_for_fe_colleges)
+  end
+
   def update_conversation_searchable_content
     Conversation.joins(job_application: :vacancy)
                 .where(job_applications: { vacancy_id: id })
@@ -333,7 +348,7 @@ class Vacancy < ApplicationRecord
   #
   def refresh_geolocation(_school_added_or_removed = nil)
     # Don't override the vacancy-specific job location if one has been specified.
-    return if [job_address_line1, job_address_line2, job_address_town, job_address_county, job_address_postcode].any?(&:present?)
+    return if job_address_fields.any?(&:present?)
 
     # :nocov:
     self.geolocation = if organisations.one?

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -285,7 +285,9 @@ class Vacancy < ApplicationRecord
 
   def vacancy_address
     job_specific_address = [job_address_line1, job_address_line2, job_address_town, job_address_county, job_address_postcode].reject(&:blank?)
-    job_specific_address.any? ? job_specific_address.join(", ") : [organisation&.address, organisation&.town, organisation&.county, organisation&.postcode].reject(&:blank?).join(", ")
+    return job_specific_address.join(", ") if job_specific_address.any?
+
+    [organisation&.address, organisation&.town, organisation&.county, organisation&.postcode].reject(&:blank?).join(", ")
   end
 
   def geocode_job_address

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -283,6 +283,18 @@ class Vacancy < ApplicationRecord
     organisations.any?(&:fe_college?)
   end
 
+  def geocode_job_address
+    address = [job_address_line1, job_address_town, job_address_postcode].reject(&:blank?).join(", ")
+    return if address.blank?
+
+    coordinates = Geocoding.new(address).coordinates
+    return if coordinates == Geocoding::COORDINATES_NO_MATCH
+
+    geopoint = GeoFactories::FACTORY_4326.point(coordinates.second, coordinates.first)
+    self.geolocation = geopoint
+    self.uk_geolocation = GeoFactories.convert_wgs84_to_sr27700(geopoint)
+  end
+
   private
 
   def update_conversation_searchable_content
@@ -319,18 +331,6 @@ class Vacancy < ApplicationRecord
                             uk_points = organisations.filter_map(&:uk_geopoint)
                             uk_points.presence && uk_points.first.factory.multi_point(uk_points)
                           end
-  end
-
-  def geocode_job_address
-    address = [job_address_line1, job_address_town, job_address_postcode].reject(&:blank?).join(", ")
-    return if address.blank?
-
-    coordinates = Geocoding.new(address).coordinates
-    return if coordinates == Geocoding::COORDINATES_NO_MATCH
-
-    geopoint = GeoFactories::FACTORY_4326.point(coordinates.second, coordinates.first)
-    self.geolocation = geopoint
-    self.uk_geolocation = GeoFactories.convert_wgs84_to_sr27700(geopoint)
   end
 
   def resettable?

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -287,7 +287,9 @@ class Vacancy < ApplicationRecord
     job_specific_address = [job_address_line1, job_address_line2, job_address_town, job_address_county, job_address_postcode].reject(&:blank?)
     return job_specific_address.join(", ") if job_specific_address.any?
 
+    # :nocov:
     [organisation&.address, organisation&.town, organisation&.county, organisation&.postcode].reject(&:blank?).join(", ")
+    # :nocov:
   end
 
   def geocode_job_address

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -294,7 +294,13 @@ class Vacancy < ApplicationRecord
 
   def geocode_job_address
     address = [job_address_line1, job_address_town, job_address_postcode].reject(&:blank?).join(", ")
-    return if address.blank?
+
+    if address.blank?
+      self.geolocation = nil
+      self.uk_geolocation = nil
+      refresh_geolocation
+      return
+    end
 
     coordinates = Geocoding.new(address).coordinates
     return if coordinates == Geocoding::COORDINATES_NO_MATCH
@@ -326,8 +332,8 @@ class Vacancy < ApplicationRecord
   # In the former case, it gets an argument, which we don't need and thus ignore
   #
   def refresh_geolocation(_school_added_or_removed = nil)
-    # don't override the vacancy specific job location if one has been spcified.
-    return if job_address_line1.present?
+    # Don't override the vacancy-specific job location if one has been specified.
+    return if [job_address_line1, job_address_line2, job_address_town, job_address_county, job_address_postcode].any?(&:present?)
 
     # :nocov:
     self.geolocation = if organisations.one?

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -322,8 +322,10 @@ class Vacancy < ApplicationRecord
   # In the former case, it gets an argument, which we don't need and thus ignore
   #
   def refresh_geolocation(_school_added_or_removed = nil)
+    # don't override the vacancy specific job location if one has been spcified.
     return if job_address_line1.present?
 
+    # :nocov:
     self.geolocation = if organisations.one?
                          organisation.geopoint
                        else
@@ -336,6 +338,7 @@ class Vacancy < ApplicationRecord
                             uk_points = organisations.filter_map(&:uk_geopoint)
                             uk_points.presence && uk_points.first.factory.multi_point(uk_points)
                           end
+    # :nocov:
   end
 
   def resettable?

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -305,7 +305,7 @@ class Vacancy < ApplicationRecord
   # In the former case, it gets an argument, which we don't need and thus ignore
   #
   def refresh_geolocation(_school_added_or_removed = nil)
-    return if job_address.present?
+    return if job_address_line1.present?
 
     self.geolocation = if organisations.one?
                          organisation.geopoint
@@ -322,9 +322,10 @@ class Vacancy < ApplicationRecord
   end
 
   def geocode_job_address
-    return unless job_address.present?
+    address = [job_address_line1, job_address_town, job_address_postcode].reject(&:blank?).join(", ")
+    return if address.blank?
 
-    coordinates = Geocoding.new(job_address).coordinates
+    coordinates = Geocoding.new(address).coordinates
     return if coordinates == Geocoding::COORDINATES_NO_MATCH
 
     geopoint = GeoFactories::FACTORY_4326.point(coordinates.second, coordinates.first)

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -283,6 +283,11 @@ class Vacancy < ApplicationRecord
     organisations.any?(&:fe_college?)
   end
 
+  def vacancy_address
+    job_specific_address = [job_address_line1, job_address_line2, job_address_town, job_address_county, job_address_postcode].reject(&:blank?)
+    job_specific_address.any? ? job_specific_address.join(", ") : [organisation&.address, organisation&.town, organisation&.county, organisation&.postcode].reject(&:blank?).join(", ")
+  end
+
   def geocode_job_address
     address = [job_address_line1, job_address_town, job_address_postcode].reject(&:blank?).join(", ")
     return if address.blank?

--- a/app/services/publishers/vacancies/vacancy_step_process.rb
+++ b/app/services/publishers/vacancies/vacancy_step_process.rb
@@ -25,7 +25,7 @@ class Publishers::Vacancies::VacancyStepProcess < StepProcess
   def job_details_steps
     steps = %i[job_location job_title confirm_job_address job_role education_phases key_stages subjects contract_information start_date pay_package]
     steps.delete(:job_location) if organisation.school?
-    # steps.delete(:confirm_job_address) unless organisation.fe_college?
+    steps.delete(:confirm_job_address) unless organisation.fe_college?
     steps.delete(:education_phases) unless vacancy.allow_phase_to_be_set?
     steps.delete(:key_stages) unless vacancy.allow_key_stages?
     steps.delete(:subjects) unless vacancy.allow_subjects?

--- a/app/services/publishers/vacancies/vacancy_step_process.rb
+++ b/app/services/publishers/vacancies/vacancy_step_process.rb
@@ -23,8 +23,9 @@ class Publishers::Vacancies::VacancyStepProcess < StepProcess
   private
 
   def job_details_steps
-    steps = %i[job_location job_title job_role education_phases key_stages subjects contract_information start_date pay_package]
+    steps = %i[job_location job_title confirm_job_address job_role education_phases key_stages subjects contract_information start_date pay_package]
     steps.delete(:job_location) if organisation.school?
+    # steps.delete(:confirm_job_address) unless organisation.fe_college?
     steps.delete(:education_phases) unless vacancy.allow_phase_to_be_set?
     steps.delete(:key_stages) unless vacancy.allow_key_stages?
     steps.delete(:subjects) unless vacancy.allow_subjects?

--- a/app/views/publishers/vacancies/build/confirm_job_address.html.slim
+++ b/app/views/publishers/vacancies/build/confirm_job_address.html.slim
@@ -12,19 +12,29 @@
       strong = t(".default_address_label")
     p.govuk-body = full_address(current_organisation)
 
-  div data-controller="show-hidden-content"
-    = f.govuk_text_field :job_address,
-      label: { text: t(".change_address_label"), size: "m" },
-      hint: { text: t(".change_address_hint") },
-      autocomplete: "off",
-      form_group: { class: %w[autocomplete], data: { source: "getLocationSuggestions", controller: "autocomplete", debouncems: "400" } }
+  = f.govuk_fieldset legend: { text: t(".change_address_label"), size: "m" } do
+    = f.govuk_text_field :job_address_line1,
+      label: { text: t(".address_line1") },
+      autocomplete: "address-line1",
+      width: "two-thirds"
 
-    a.govuk-link href="#" data-action="click->show-hidden-content#show"
-      = t(".enter_address_manually")
+    = f.govuk_text_field :job_address_line2,
+      label: { text: t(".address_line2") },
+      autocomplete: "address-line2",
+      width: "two-thirds"
 
-    div data-show-hidden-content-target="content"
-      = f.govuk_text_area :job_address,
-        label: { text: t(".manual_address_label"), size: "m" },
-        rows: 4
+    = f.govuk_text_field :job_address_town,
+      label: { text: t(".town") },
+      autocomplete: "address-level2",
+      width: "two-thirds"
+
+    = f.govuk_text_field :job_address_county,
+      label: { text: t(".county") },
+      width: "two-thirds"
+
+    = f.govuk_text_field :job_address_postcode,
+      label: { text: t(".postcode") },
+      autocomplete: "postal-code",
+      width: "one-quarter"
 
   = render "publishers/vacancies/vacancy_form_partials/submit", f: f

--- a/app/views/publishers/vacancies/build/confirm_job_address.html.slim
+++ b/app/views/publishers/vacancies/build/confirm_job_address.html.slim
@@ -1,0 +1,21 @@
+- content_for :page_title_prefix, page_title_prefix(step_process, form)
+
+= form_for form, url: wizard_path(current_step), method: :patch do |f|
+  = f.govuk_error_summary
+
+  = vacancy_form_page_heading(vacancy, step_process, back_path: back_path, fieldset: false)
+
+  p.govuk-body = t(".hint")
+
+  = govuk_inset_text do
+    p.govuk-body
+      strong = t(".default_address_label")
+    p.govuk-body = full_address(current_organisation)
+
+  = f.govuk_text_field :job_address,
+    label: { text: t(".change_address_label"), size: "m" },
+    hint: { text: t(".change_address_hint") },
+    autocomplete: "off",
+    form_group: { class: %w[autocomplete], data: { source: "getLocationSuggestions", controller: "autocomplete", debouncems: "400" } }
+
+  = render "publishers/vacancies/vacancy_form_partials/submit", f: f

--- a/app/views/publishers/vacancies/build/confirm_job_address.html.slim
+++ b/app/views/publishers/vacancies/build/confirm_job_address.html.slim
@@ -12,10 +12,19 @@
       strong = t(".default_address_label")
     p.govuk-body = full_address(current_organisation)
 
-  = f.govuk_text_field :job_address,
-    label: { text: t(".change_address_label"), size: "m" },
-    hint: { text: t(".change_address_hint") },
-    autocomplete: "off",
-    form_group: { class: %w[autocomplete], data: { source: "getLocationSuggestions", controller: "autocomplete", debouncems: "400" } }
+  div data-controller="show-hidden-content"
+    = f.govuk_text_field :job_address,
+      label: { text: t(".change_address_label"), size: "m" },
+      hint: { text: t(".change_address_hint") },
+      autocomplete: "off",
+      form_group: { class: %w[autocomplete], data: { source: "getLocationSuggestions", controller: "autocomplete", debouncems: "400" } }
+
+    a.govuk-link href="#" data-action="click->show-hidden-content#show"
+      = t(".enter_address_manually")
+
+    div data-show-hidden-content-target="content"
+      = f.govuk_text_area :job_address,
+        label: { text: t(".manual_address_label"), size: "m" },
+        rows: 4
 
   = render "publishers/vacancies/vacancy_form_partials/submit", f: f

--- a/app/views/publishers/vacancies/build/job_role.html.slim
+++ b/app/views/publishers/vacancies/build/job_role.html.slim
@@ -5,7 +5,10 @@
 = form_for form, url: wizard_path(current_step), method: :patch do |f|
   = f.govuk_error_summary
 
-  = f.govuk_collection_check_boxes :job_roles, teaching_job_roles_options, :first, :last, legend: { text: t("jobs.filters.teaching_job_roles"), size: "s", tag: "h2" }, include_hidden: false
-  = f.govuk_collection_check_boxes :job_roles, support_job_roles_options, :first, :last, legend: { text: t("jobs.filters.support_job_roles"), size: "s", tag: "h2" }, include_hidden: false
+  - if vacancy.for_an_fe_college?
+    = f.govuk_collection_check_boxes :job_roles, fe_college_job_roles_options, :first, :last, legend: { text: t("jobs.filters.teaching_job_roles"), size: "s", tag: "h2" }, include_hidden: false
+  - else
+    = f.govuk_collection_check_boxes :job_roles, teaching_job_roles_options, :first, :last, legend: { text: t("jobs.filters.teaching_job_roles"), size: "s", tag: "h2" }, include_hidden: false
+    = f.govuk_collection_check_boxes :job_roles, support_job_roles_options, :first, :last, legend: { text: t("jobs.filters.support_job_roles"), size: "s", tag: "h2" }, include_hidden: false
 
   = render "publishers/vacancies/vacancy_form_partials/submit", f: f

--- a/app/views/publishers/vacancies/vacancy_review_sections/_job_details.html.slim
+++ b/app/views/publishers/vacancies/vacancy_review_sections/_job_details.html.slim
@@ -8,7 +8,11 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
     - row.with_value
       ul.govuk-list.govuk-list--spaced
         = vacancy_job_locations(vacancy)
-    - unless current_organisation.school? || vacancy.live?
+    - if vacancy.for_an_fe_college? && !vacancy.live?
+      - row.with_action text: t("buttons.change"),
+                  href: organisation_job_build_path(vacancy.id, :confirm_job_address, "back_to_#{action_name}": "true"),
+                  visually_hidden_text: t("publishers.vacancies.steps.job_location")
+    - elsif !current_organisation.school? && !vacancy.live?
       - row.with_action text: t("buttons.change"),
                   href: organisation_job_build_path(vacancy.id, :job_location, "back_to_#{action_name}": "true"),
                   visually_hidden_text: t("publishers.vacancies.steps.job_location")
@@ -22,17 +26,6 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
       - row.with_action text: t("buttons.change"),
                   href: organisation_job_build_path(vacancy.id, :job_title, "back_to_#{action_name}": "true"),
                   visually_hidden_text: t("jobs.job_title")
-
-  - if vacancy.for_an_fe_college?
-    - summary_list.with_row(html_attributes: { id: "job_address" }) do |row|
-      - row.with_key
-        = t("publishers.vacancies.build.confirm_job_address.step_title")
-      - row.with_value
-        = vacancy.vacancy_address
-      - unless vacancy.live?
-        - row.with_action text: t("buttons.change"),
-                    href: organisation_job_build_path(vacancy.id, :confirm_job_address, "back_to_#{action_name}": "true"),
-                    visually_hidden_text: t("publishers.vacancies.build.confirm_job_address.step_title")
 
   - summary_list.with_row(html_attributes: { id: "job_role" }) do |row|
     - row.with_key

--- a/app/views/publishers/vacancies/vacancy_review_sections/_job_details.html.slim
+++ b/app/views/publishers/vacancies/vacancy_review_sections/_job_details.html.slim
@@ -6,8 +6,11 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
     - row.with_key
       = t("jobs.job_location")
     - row.with_value
-      ul.govuk-list.govuk-list--spaced
-        = vacancy_job_locations(vacancy)
+      - if vacancy.for_an_fe_college?
+        = vacancy.vacancy_address
+      - else
+        ul.govuk-list.govuk-list--spaced
+          = vacancy_job_locations(vacancy)
     - if vacancy.for_an_fe_college? && !vacancy.live?
       - row.with_action text: t("buttons.change"),
                   href: organisation_job_build_path(vacancy.id, :confirm_job_address, "back_to_#{action_name}": "true"),

--- a/app/views/publishers/vacancies/vacancy_review_sections/_job_details.html.slim
+++ b/app/views/publishers/vacancies/vacancy_review_sections/_job_details.html.slim
@@ -14,7 +14,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
     - if vacancy.for_an_fe_college? && !vacancy.live?
       - row.with_action text: t("buttons.change"),
                   href: organisation_job_build_path(vacancy.id, :confirm_job_address, "back_to_#{action_name}": "true"),
-                  visually_hidden_text: t("publishers.vacancies.steps.job_location")
+                  visually_hidden_text: t("publishers.vacancies.steps.confirm_job_address")
     - elsif !current_organisation.school? && !vacancy.live?
       - row.with_action text: t("buttons.change"),
                   href: organisation_job_build_path(vacancy.id, :job_location, "back_to_#{action_name}": "true"),

--- a/app/views/publishers/vacancies/vacancy_review_sections/_job_details.html.slim
+++ b/app/views/publishers/vacancies/vacancy_review_sections/_job_details.html.slim
@@ -23,6 +23,17 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
                   href: organisation_job_build_path(vacancy.id, :job_title, "back_to_#{action_name}": "true"),
                   visually_hidden_text: t("jobs.job_title")
 
+  - if vacancy.for_an_fe_college?
+    - summary_list.with_row(html_attributes: { id: "job_address" }) do |row|
+      - row.with_key
+        = t("publishers.vacancies.build.confirm_job_address.step_title")
+      - row.with_value
+        = vacancy.vacancy_address
+      - unless vacancy.live?
+        - row.with_action text: t("buttons.change"),
+                    href: organisation_job_build_path(vacancy.id, :confirm_job_address, "back_to_#{action_name}": "true"),
+                    visually_hidden_text: t("publishers.vacancies.build.confirm_job_address.step_title")
+
   - summary_list.with_row(html_attributes: { id: "job_role" }) do |row|
     - row.with_key
       = t("jobs.job_role")

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -537,6 +537,11 @@ shared:
     - type
     - publisher_ats_api_client_id
     - anonymise_applications
+    - job_address_line1
+    - job_address_line2
+    - job_address_town
+    - job_address_county
+    - job_address_postcode
   failed_imported_vacancies:
     - id
     - import_errors

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -464,6 +464,11 @@ shared:
     - religion_type
     - flexi_working_details_provided
     - anonymise_applications
+    - job_address_line1
+    - job_address_line2
+    - job_address_town
+    - job_address_county
+    - job_address_postcode
   vacancies:
     - id
     - job_title

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -133,6 +133,11 @@
   - searchable_content
   - google_index_removed
   - expired_vacancy_feedback_email_sent_at
+  - job_address_line1
+  - job_address_line2
+  - job_address_town
+  - job_address_county
+  - job_address_postcode
   :qualifications:
   - finished_studying_details_ciphertext
   :feedbacks:

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -133,11 +133,6 @@
   - searchable_content
   - google_index_removed
   - expired_vacancy_feedback_email_sent_at
-  - job_address_line1
-  - job_address_line2
-  - job_address_town
-  - job_address_county
-  - job_address_postcode
   :qualifications:
   - finished_studying_details_ciphertext
   :feedbacks:

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -689,6 +689,7 @@ en:
               same_as_old: Your new email can't be the same as your old email
               taken: This email seems to already have an account with Teaching Vacancies
         vacancy:
+          job_address_only_for_fe_colleges: Campus address fields are only applicable to FE college vacancies
           attributes:
             job_advert:
               blank: Enter a job advert

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -136,6 +136,13 @@ en:
     phases:
       blank: Select education phase
       inclusion: Select education phase
+  confirm_job_address_errors: &confirm_job_address_errors
+    job_address_line1:
+      blank: Enter address line 1
+    job_address_town:
+      blank: Enter a town or city
+    job_address_postcode:
+      blank: Enter a postcode
   job_title_errors: &job_title_errors
     job_title:
       blank: Enter a job title
@@ -371,6 +378,9 @@ en:
         publishers/job_listing/education_phases_form:
           attributes:
             <<: *education_phases_errors
+        publishers/job_listing/confirm_job_address_form:
+          attributes:
+            <<: *confirm_job_address_errors
         publishers/job_listing/job_title_form:
           attributes:
             <<: *job_title_errors

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -464,9 +464,11 @@ en:
           hint: Use this page to change the address for this job. Leave these fields blank to use the default address.
           default_address_label: Default address
           change_address_label: Change the address for this job listing
-          change_address_hint: Start typing the address or postcode, then select the correct address from the list.
-          enter_address_manually: I can't find the address
-          manual_address_label: Enter address manually
+          address_line1: Address line 1
+          address_line2: Address line 2 (optional)
+          town: Town or city
+          county: County (optional)
+          postcode: Postcode
         contact_details:
           step_title: Contact details
         documents:

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -465,6 +465,8 @@ en:
           default_address_label: Default address
           change_address_label: Change the address for this job listing
           change_address_hint: Start typing the address or postcode, then select the correct address from the list.
+          enter_address_manually: I can't find the address
+          manual_address_label: Enter address manually
         contact_details:
           step_title: Contact details
         documents:

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -459,6 +459,12 @@ en:
           step_title: Receiving applications
         application_process:
           step_title: Application process
+        confirm_job_address:
+          step_title: Confirm job address
+          hint: Use this page to change the address for this job. Leave these fields blank to use the default address.
+          default_address_label: Default address
+          change_address_label: Change the address for this job listing
+          change_address_hint: Start typing the address or postcode, then select the correct address from the list.
         contact_details:
           step_title: Contact details
         documents:
@@ -693,6 +699,7 @@ en:
         school_visits: Do you want to offer school visits?
         college_visits: Do you want to offer college visits?
         contact_details: Contact details
+        confirm_job_address: Confirm job address
         confirm_contact_details: Check this email address
         about_the_role: About the role
         include_additional_documents: Do you want to upload any additional documents?

--- a/db/migrate/20260617154709_add_job_address_to_vacancies.rb
+++ b/db/migrate/20260617154709_add_job_address_to_vacancies.rb
@@ -1,5 +1,0 @@
-class AddJobAddressToVacancies < ActiveRecord::Migration[8.0]
-  def change
-    add_column :vacancies, :job_address, :string
-  end
-end

--- a/db/migrate/20260617154709_add_job_address_to_vacancies.rb
+++ b/db/migrate/20260617154709_add_job_address_to_vacancies.rb
@@ -1,0 +1,5 @@
+class AddJobAddressToVacancies < ActiveRecord::Migration[8.0]
+  def change
+    add_column :vacancies, :job_address, :string
+  end
+end

--- a/db/migrate/20260618125907_add_job_address_to_vacancies.rb
+++ b/db/migrate/20260618125907_add_job_address_to_vacancies.rb
@@ -1,0 +1,9 @@
+class AddJobAddressToVacancies < ActiveRecord::Migration[8.0]
+  def change
+    add_column :vacancies, :job_address_line1, :string
+    add_column :vacancies, :job_address_line2, :string
+    add_column :vacancies, :job_address_town, :string
+    add_column :vacancies, :job_address_county, :string
+    add_column :vacancies, :job_address_postcode, :string
+  end
+end

--- a/db/migrate/20260619113400_add_job_address_to_vacancy_templates.rb
+++ b/db/migrate/20260619113400_add_job_address_to_vacancy_templates.rb
@@ -1,0 +1,9 @@
+class AddJobAddressToVacancyTemplates < ActiveRecord::Migration[8.0]
+  def change
+    add_column :vacancy_templates, :job_address_line1, :string
+    add_column :vacancy_templates, :job_address_line2, :string
+    add_column :vacancy_templates, :job_address_town, :string
+    add_column :vacancy_templates, :job_address_county, :string
+    add_column :vacancy_templates, :job_address_postcode, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_18_125907) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_19_113400) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -979,6 +979,11 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_18_125907) do
     t.integer "receive_applications"
     t.integer "religion_type"
     t.boolean "anonymise_applications"
+    t.string "job_address_line1"
+    t.string "job_address_line2"
+    t.string "job_address_town"
+    t.string "job_address_county"
+    t.string "job_address_postcode"
     t.index ["organisation_id"], name: "index_vacancy_templates_on_organisation_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_17_154709) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_18_125907) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -902,7 +902,11 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_17_154709) do
     t.string "type", null: false
     t.boolean "anonymise_applications", default: false
     t.geometry "uk_geolocation", limit: {srid: 27700, type: "geometry"}
-    t.string "job_address"
+    t.string "job_address_line1"
+    t.string "job_address_line2"
+    t.string "job_address_town"
+    t.string "job_address_county"
+    t.string "job_address_postcode"
     t.index ["contact_email"], name: "index_vacancies_on_contact_email"
     t.index ["discarded_at"], name: "index_vacancies_on_discarded_at"
     t.index ["expires_at"], name: "index_vacancies_on_expires_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_30_131102) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_17_154709) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -902,6 +902,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_30_131102) do
     t.string "type", null: false
     t.boolean "anonymise_applications", default: false
     t.geometry "uk_geolocation", limit: {srid: 27700, type: "geometry"}
+    t.string "job_address"
     t.index ["contact_email"], name: "index_vacancies_on_contact_email"
     t.index ["discarded_at"], name: "index_vacancies_on_discarded_at"
     t.index ["expires_at"], name: "index_vacancies_on_expires_at"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -71,7 +71,7 @@ schools = [bexleyheath_school,
 user_emails = users.map { |u| u.fetch(:email) }
 
 users.each.with_index do |user, index|
-  organisations = [bexleyheath_school, weydon_trust, southampton_la, abraham_moss, aston_maths, st_anthony, osmaston_cofe]
+  organisations = [bexleyheath_school, weydon_trust, southampton_la, abraham_moss, aston_maths, st_anthony, osmaston_cofe, oaklands_college]
   publisher = Publisher.create!(oid: index.to_s, organisations: organisations, **user)
 
   organisations.each do |organisation|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -71,7 +71,7 @@ schools = [bexleyheath_school,
 user_emails = users.map { |u| u.fetch(:email) }
 
 users.each.with_index do |user, index|
-  organisations = [bexleyheath_school, weydon_trust, southampton_la, abraham_moss, aston_maths, st_anthony, osmaston_cofe, oaklands_college]
+  organisations = [bexleyheath_school, weydon_trust, southampton_la, abraham_moss, aston_maths, st_anthony, osmaston_cofe, oaklands_college, loreto_college]
   publisher = Publisher.create!(oid: index.to_s, organisations: organisations, **user)
 
   organisations.each do |organisation|

--- a/spec/form_models/publishers/job_listing/confirm_job_address_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/confirm_job_address_form_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe Publishers::JobListing::ConfirmJobAddressForm, type: :model do
+  context "when all fields are blank" do
+    subject { described_class.new }
+
+    it { is_expected.to be_valid }
+  end
+
+  context "when any address field is present" do
+    subject { described_class.new(job_address_line1: "10 Main Street", job_address_town: "Brighton", job_address_postcode: "BN1 1AA") }
+
+    it { is_expected.to be_valid }
+
+    context "when job_address_line1 is missing" do
+      subject { described_class.new(job_address_town: "Brighton", job_address_postcode: "BN1 1AA") }
+
+      it { is_expected.to validate_presence_of(:job_address_line1) }
+    end
+
+    context "when job_address_town is missing" do
+      subject { described_class.new(job_address_line1: "10 Main Street", job_address_postcode: "BN1 1AA") }
+
+      it { is_expected.to validate_presence_of(:job_address_town) }
+    end
+
+    context "when job_address_postcode is missing" do
+      subject { described_class.new(job_address_line1: "10 Main Street", job_address_town: "Brighton") }
+
+      it { is_expected.to validate_presence_of(:job_address_postcode) }
+    end
+  end
+end

--- a/spec/form_models/publishers/vacancy_form_sequence_spec.rb
+++ b/spec/form_models/publishers/vacancy_form_sequence_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Publishers::VacancyFormSequence do
       job_role
       education_phases
       job_title
+      confirm_job_address
       key_stages
       subjects
       contract_information
@@ -90,6 +91,23 @@ RSpec.describe Publishers::VacancyFormSequence do
         it "returns the first invalid dependent step" do
           expect(sequence.next_invalid_step).to eq(:education_phases)
         end
+      end
+    end
+
+    context "when confirm_job_address step is included and has missing fields" do
+      let(:organisation) { create(:college) }
+      let(:vacancy) do
+        create(:draft_vacancy, :secondary, :apply_via_website,
+               school_visits: true,
+               organisations: [organisation],
+               completed_steps: all_steps.map(&:to_s) - ["review"],
+               job_address_town: "Brighton",
+               job_address_postcode: "BN1 1AA",
+               job_address_line1: nil)
+      end
+
+      it "returns confirm_job_address as the next invalid step" do
+        expect(sequence.next_invalid_step).to eq(:confirm_job_address)
       end
     end
   end

--- a/spec/form_models/publishers/vacancy_form_sequence_spec.rb
+++ b/spec/form_models/publishers/vacancy_form_sequence_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Publishers::VacancyFormSequence do
         create(:draft_vacancy, :secondary, :apply_via_website,
                school_visits: true,
                organisations: [organisation],
-               completed_steps: all_steps.map(&:to_s) - ["review"],
+               completed_steps: all_steps.map(&:to_s) - %w[review],
                job_address_town: "Brighton",
                job_address_postcode: "BN1 1AA",
                job_address_line1: nil)

--- a/spec/helpers/vacancies_helper_spec.rb
+++ b/spec/helpers/vacancies_helper_spec.rb
@@ -158,6 +158,66 @@ RSpec.describe VacanciesHelper do
         expect(subject).to eq("#{vacancy.organisation.name}, Cool Town, Orange County, SW1A")
       end
     end
+
+    context "when the vacancy is at an FE college with a custom job address" do
+      let(:college) { build(:college, name: "City College") }
+      let(:vacancy) { build(:vacancy, organisations: [college], job_address_line1: "10 Campus Road", job_address_town: "Brighton", job_address_postcode: "BN1 1AA") }
+
+      it "returns the college name with the custom address" do
+        expect(subject).to eq("City College, 10 Campus Road, Brighton, BN1 1AA")
+      end
+    end
+
+    context "when the vacancy is at an FE college without a custom job address" do
+      let(:college) { build(:college, name: "City College", town: "Brighton", county: "East Sussex", postcode: "BN1 1AA") }
+      let(:vacancy) { build(:vacancy, organisations: [college]) }
+
+      it "returns the college name with the organisation address" do
+        expect(subject).to eq("City College, Brighton, East Sussex, BN1 1AA")
+      end
+    end
+  end
+
+  describe "#vacancy_job_location" do
+    subject { helper.vacancy_job_location(vacancy) }
+
+    context "when the vacancy is at multiple schools" do
+      let(:school_group) { create(:school_group) }
+      let(:school) { create(:school, school_groups: [school_group]) }
+      let(:school2) { create(:school, school_groups: [school_group]) }
+      let(:vacancy) { build(:vacancy, organisations: [school, school2]) }
+
+      it "returns the multiple schools location" do
+        expect(subject).to eq("More than one location, #{vacancy.organisation.name}")
+      end
+    end
+
+    context "when the vacancy is not at multiple schools" do
+      let(:school) { build(:school, name: "Magic School", town: "Cool Town", county: "Orange County") }
+      let(:vacancy) { build(:vacancy, organisations: [school]) }
+
+      it "returns the location without postcode" do
+        expect(subject).to eq("Magic School, Cool Town, Orange County")
+      end
+    end
+
+    context "when the vacancy is at an FE college with a custom job address" do
+      let(:college) { build(:college, name: "City College") }
+      let(:vacancy) { build(:vacancy, organisations: [college], job_address_line1: "10 Campus Road", job_address_town: "Brighton", job_address_postcode: "BN1 1AA") }
+
+      it "returns the college name with the custom address" do
+        expect(subject).to eq("City College, 10 Campus Road, Brighton, BN1 1AA")
+      end
+    end
+
+    context "when the vacancy is at an FE college without a custom job address" do
+      let(:college) { build(:college, name: "City College", town: "Brighton", county: "East Sussex") }
+      let(:vacancy) { build(:vacancy, organisations: [college]) }
+
+      it "returns the college name with the organisation address" do
+        expect(subject).to eq("City College, Brighton, East Sussex")
+      end
+    end
   end
 
   describe "#vacancy_form_type" do

--- a/spec/helpers/vacancies_helper_spec.rb
+++ b/spec/helpers/vacancies_helper_spec.rb
@@ -169,11 +169,11 @@ RSpec.describe VacanciesHelper do
     end
 
     context "when the vacancy is at an FE college without a custom job address" do
-      let(:college) { build(:college, name: "City College", town: "Brighton", county: "East Sussex", postcode: "BN1 1AA") }
+      let(:college) { build(:college, name: "City College", address: "1 High Street", town: "Brighton", county: "East Sussex", postcode: "BN1 1AA") }
       let(:vacancy) { build(:vacancy, organisations: [college]) }
 
       it "returns the college name with the organisation address" do
-        expect(subject).to eq("City College, Brighton, East Sussex, BN1 1AA")
+        expect(subject).to eq("City College, 1 High Street, Brighton, East Sussex, BN1 1AA")
       end
     end
   end
@@ -211,11 +211,11 @@ RSpec.describe VacanciesHelper do
     end
 
     context "when the vacancy is at an FE college without a custom job address" do
-      let(:college) { build(:college, name: "City College", town: "Brighton", county: "East Sussex") }
+      let(:college) { build(:college, name: "City College", address: "1 High Street", town: "Brighton", county: "East Sussex", postcode: "BN1 1AA") }
       let(:vacancy) { build(:vacancy, organisations: [college]) }
 
       it "returns the college name with the organisation address" do
-        expect(subject).to eq("City College, Brighton, East Sussex")
+        expect(subject).to eq("City College, 1 High Street, Brighton, East Sussex, BN1 1AA")
       end
     end
   end

--- a/spec/jobs/import_from_vacancy_source_job_spec.rb
+++ b/spec/jobs/import_from_vacancy_source_job_spec.rb
@@ -174,6 +174,11 @@ RSpec.describe ImportFromVacancySourceJob do
           "is_job_share" => true,
           "hourly_rate" => "£25 per hour",
           "flexi_working_details_provided" => true,
+          "job_address_line1" => nil,
+          "job_address_line2" => nil,
+          "job_address_town" => nil,
+          "job_address_county" => nil,
+          "job_address_postcode" => nil,
         )
       end
 

--- a/spec/models/vacancy_organisation_association_spec.rb
+++ b/spec/models/vacancy_organisation_association_spec.rb
@@ -60,6 +60,16 @@ RSpec.describe Vacancy do
           expect(vacancy.geolocation).to eq(original_geolocation)
         end
       end
+
+      context "when the vacancy has partial job address fields set with missing fields" do
+        let(:vacancy) { create(:vacancy, :ect_suitable, job_roles: %w[teacher], organisations: [school_one], phases: %w[primary], key_stages: %w[ks1], job_address_town: "Brighton", job_address_postcode: "BN1 1AA") }
+
+        it "does not update the geolocation from the organisation" do
+          original_geolocation = vacancy.geolocation
+          vacancy.organisations = [school_two]
+          expect(vacancy.geolocation).to eq(original_geolocation)
+        end
+      end
     end
 
     describe "#organisation" do

--- a/spec/models/vacancy_organisation_association_spec.rb
+++ b/spec/models/vacancy_organisation_association_spec.rb
@@ -50,6 +50,16 @@ RSpec.describe Vacancy do
           expect(vacancy.geolocation).to eq(school_group.geopoint)
         end
       end
+
+      context "when the vacancy has a custom job address" do
+        let(:vacancy) { create(:vacancy, :ect_suitable, job_roles: %w[teacher], organisations: [school_one], phases: %w[primary], key_stages: %w[ks1], job_address_line1: "10 Campus Road") }
+
+        it "does not update the geolocation from the organisation" do
+          original_geolocation = vacancy.geolocation
+          vacancy.organisations = [school_two]
+          expect(vacancy.geolocation).to eq(original_geolocation)
+        end
+      end
     end
 
     describe "#organisation" do

--- a/spec/models/vacancy_organisation_association_spec.rb
+++ b/spec/models/vacancy_organisation_association_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Vacancy do
     let(:school_group) { create(:trust, :with_geopoint, schools: [school_one, school_two]) }
     let(:school_one) { create(:school, name: "First school", phase: "primary") }
     let(:school_two) { create(:school, name: "Second school", phase: "primary") }
+    let(:college) { create(:college) }
     let(:vacancy) { create(:vacancy, :ect_suitable, job_roles: %w[teacher], organisations: [school_group], phases: %w[primary], key_stages: %w[ks1]) }
 
     describe "#refresh_geolocation" do
@@ -52,7 +53,7 @@ RSpec.describe Vacancy do
       end
 
       context "when the vacancy has a custom job address" do
-        let(:vacancy) { create(:vacancy, :ect_suitable, job_roles: %w[teacher], organisations: [school_one], phases: %w[primary], key_stages: %w[ks1], job_address_line1: "10 Campus Road") }
+        let(:vacancy) { create(:vacancy, :ect_suitable, job_roles: %w[teacher], organisations: [college], phases: %w[primary], key_stages: %w[ks1], job_address_line1: "10 Campus Road") }
 
         it "does not update the geolocation from the organisation" do
           original_geolocation = vacancy.geolocation
@@ -62,7 +63,7 @@ RSpec.describe Vacancy do
       end
 
       context "when the vacancy has partial job address fields set with missing fields" do
-        let(:vacancy) { create(:vacancy, :ect_suitable, job_roles: %w[teacher], organisations: [school_one], phases: %w[primary], key_stages: %w[ks1], job_address_town: "Brighton", job_address_postcode: "BN1 1AA") }
+        let(:vacancy) { create(:vacancy, :ect_suitable, job_roles: %w[teacher], organisations: [college], phases: %w[primary], key_stages: %w[ks1], job_address_town: "Brighton", job_address_postcode: "BN1 1AA") }
 
         it "does not update the geolocation from the organisation" do
           original_geolocation = vacancy.geolocation

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -941,4 +941,49 @@ RSpec.describe Vacancy do
       end
     end
   end
+
+  describe "#vacancy_address" do
+    let(:college) { create(:college) }
+
+    context "when a custom job address has been entered" do
+      subject { build(:vacancy, organisations: [college], job_address_line1: "10 Campus Road", job_address_town: "Brighton", job_address_postcode: "BN1 1AA") }
+
+      it "returns the custom address" do
+        expect(subject.vacancy_address).to eq("10 Campus Road, Brighton, BN1 1AA")
+      end
+    end
+
+    context "when no custom job address has been entered" do
+      subject { build(:vacancy, organisations: [college]) }
+
+      it "falls back to the organisation address" do
+        expect(subject.vacancy_address).to eq([college.address, college.town, college.county, college.postcode].reject(&:blank?).join(", "))
+      end
+    end
+  end
+
+  describe "#geocode_job_address" do
+    let(:school) { create(:school) }
+    subject { build(:vacancy, organisations: [school]) }
+
+    context "when all address fields are blank" do
+      it "does not call Geocoding" do
+        expect(Geocoding).not_to receive(:new)
+        subject.geocode_job_address
+      end
+    end
+
+    context "when the address does not geocode" do
+      before do
+        subject.job_address_line1 = "Nowhere"
+        subject.job_address_town = "Nowhereville"
+        subject.job_address_postcode = "XX1 1XX"
+        allow(Geocoding).to receive(:new).and_return(instance_double(Geocoding, coordinates: Geocoding::COORDINATES_NO_MATCH))
+      end
+
+      it "does not update the geolocation" do
+        expect { subject.geocode_job_address }.not_to change { subject.geolocation }
+      end
+    end
+  end
 end

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -942,6 +942,47 @@ RSpec.describe Vacancy do
     end
   end
 
+  describe "job address validations" do
+    let(:college) { create(:college) }
+    let(:school) { create(:school) }
+    let(:job_address_attrs) { { job_address_line1: "10 Campus Road", job_address_town: "Brighton", job_address_postcode: "BN1 1AA" } }
+
+    context "when the vacancy belongs to an FE college" do
+      it "is valid with job address fields present" do
+        vacancy = build(:vacancy, organisations: [college], **job_address_attrs)
+        expect(vacancy).to be_valid
+      end
+
+      it "is valid without job address fields present" do
+        vacancy = build(:vacancy, organisations: [college])
+        vacancy.valid?
+        expect(vacancy.errors[:base]).not_to include(I18n.t("activerecord.errors.models.vacancy.job_address_only_for_fe_colleges"))
+      end
+    end
+
+    context "when the vacancy does not belong to an FE college" do
+      it "is invalid with job address fields present" do
+        vacancy = build(:vacancy, organisations: [school], **job_address_attrs)
+        expect(vacancy).not_to be_valid
+        expect(vacancy.errors[:base]).to include(I18n.t("activerecord.errors.models.vacancy.job_address_only_for_fe_colleges"))
+      end
+
+      it "is valid when no job address fields are present" do
+        vacancy = build(:vacancy, organisations: [school])
+        vacancy.valid?
+        expect(vacancy.errors[:base]).not_to include(I18n.t("activerecord.errors.models.vacancy.job_address_only_for_fe_colleges"))
+      end
+    end
+
+    context "when no organisations are associated yet" do
+      it "does not raise a validation error for job address fields" do
+        vacancy = build(:vacancy, organisations: [], **job_address_attrs)
+        vacancy.valid?
+        expect(vacancy.errors[:base]).not_to include(I18n.t("activerecord.errors.models.vacancy.job_address_only_for_fe_colleges"))
+      end
+    end
+  end
+
   describe "#vacancy_address" do
     let(:college) { create(:college) }
 

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -1046,7 +1046,7 @@ RSpec.describe Vacancy do
     let(:school_two) { create(:school, name: "Second school") }
 
     context "when only partial job address is given" do
-      let(:vacancy) { create(:vacancy, :ect_suitable, job_roles: %w[teacher], organisations: [school_one], phases: %w[primary], key_stages: %w[ks1], job_address_line2: "Floor 2") }
+      let(:vacancy) { create(:vacancy, :ect_suitable, job_roles: %w[teacher], organisations: [create(:college)], phases: %w[primary], key_stages: %w[ks1], job_address_line2: "Floor 2") }
 
       it "does not overwrite geolocation with the organisation geopoint" do
         original_geolocation = vacancy.geolocation

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -957,7 +957,7 @@ RSpec.describe Vacancy do
       subject { build(:vacancy, organisations: [college]) }
 
       it "falls back to the organisation address" do
-        expect(subject.vacancy_address).to eq([college.address, college.town, college.county, college.postcode].reject(&:blank?).join(", "))
+        expect(subject.vacancy_address).to eq([college.address, college.town, college.county, college.postcode].compact_blank.join(", "))
       end
     end
   end
@@ -982,7 +982,7 @@ RSpec.describe Vacancy do
       end
 
       it "does not update the geolocation" do
-        expect { subject.geocode_job_address }.not_to change { subject.geolocation }
+        expect { subject.geocode_job_address }.not_to(change(subject, :geolocation))
       end
     end
   end

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -971,6 +971,19 @@ RSpec.describe Vacancy do
         expect(Geocoding).not_to receive(:new)
         subject.geocode_job_address
       end
+
+      context "when the vacancy previously had custom geolocation set" do
+        before do
+          geopoint = GeoFactories::FACTORY_4326.point(-0.1, 51.5)
+          subject.geolocation = geopoint
+          subject.uk_geolocation = GeoFactories.convert_wgs84_to_sr27700(geopoint)
+        end
+
+        it "clears geolocation and resets it from the organisation" do
+          subject.geocode_job_address
+          expect(subject.geolocation).to eq(school.geopoint)
+        end
+      end
     end
 
     context "when the address does not geocode" do
@@ -983,6 +996,21 @@ RSpec.describe Vacancy do
 
       it "does not update the geolocation" do
         expect { subject.geocode_job_address }.not_to(change(subject, :geolocation))
+      end
+    end
+  end
+
+  describe "#refresh_geolocation" do
+    let(:school_one) { create(:school, name: "First school") }
+    let(:school_two) { create(:school, name: "Second school") }
+
+    context "when only partial job address is given" do
+      let(:vacancy) { create(:vacancy, :ect_suitable, job_roles: %w[teacher], organisations: [school_one], phases: %w[primary], key_stages: %w[ks1], job_address_line2: "Floor 2") }
+
+      it "does not overwrite geolocation with the organisation geopoint" do
+        original_geolocation = vacancy.geolocation
+        vacancy.organisations = [school_two]
+        expect(vacancy.geolocation).to eq(original_geolocation)
       end
     end
   end

--- a/spec/page_objects/pages/application.rb
+++ b/spec/page_objects/pages/application.rb
@@ -24,6 +24,7 @@ module PageObjects
         publisher_ats_job_feedback_date: "Publisher::Ats::FeedbackTagPage",
         publisher_include_additional_documents: "Publisher::IncludeAdditionalDocumentsPage",
         publisher_job_title: "Publisher::JobTitlePage",
+        publisher_confirm_job_address: "Publisher::ConfirmJobAddressPage",
         publisher_pay_package: "Publisher::PayPackagePage",
         publisher_application_form: "Publisher::ApplicationFormPage",
         publisher_important_dates: "Publisher::ImportantDatesPage",

--- a/spec/page_objects/pages/publisher/confirm_job_address_page.rb
+++ b/spec/page_objects/pages/publisher/confirm_job_address_page.rb
@@ -1,0 +1,18 @@
+module PageObjects
+  module Pages
+    module Publisher
+      class ConfirmJobAddressPage < CommonPage
+        set_url "/organisation/jobs/{vacancy_id}/build/confirm_job_address"
+
+        def fill_in_and_submit_form(line1: "", line2: "", town: "", county: "", postcode: "")
+          fill_in "publishers_job_listing_confirm_job_address_form[job_address_line1]", with: line1
+          fill_in "publishers_job_listing_confirm_job_address_form[job_address_line2]", with: line2
+          fill_in "publishers_job_listing_confirm_job_address_form[job_address_town]", with: town
+          fill_in "publishers_job_listing_confirm_job_address_form[job_address_county]", with: county
+          fill_in "publishers_job_listing_confirm_job_address_form[job_address_postcode]", with: postcode
+          click_on I18n.t("buttons.save_and_continue")
+        end
+      end
+    end
+  end
+end

--- a/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_college_spec.rb
+++ b/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_college_spec.rb
@@ -91,5 +91,10 @@ RSpec.describe "Creating a vacancy as an FE college" do
     expect(page).to have_current_path(organisation_job_review_path(created_vacancy.id), ignore_query: true)
     expect(page).to have_css("#job_location")
     expect(page).to have_content("10 Campus Road, Brighton, BN1 1AA")
+
+    # FE college should have a Change link on the Locations row linking to confirm_job_address
+    within("#job_location") do
+      expect(page).to have_link(I18n.t("buttons.change"), href: /confirm_job_address/)
+    end
   end
 end

--- a/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_college_spec.rb
+++ b/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_college_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "Creating a vacancy as an FE college" do
   let(:vacancy) do
     build(:vacancy,
           :ect_suitable,
+          :secondary,
           :apply_via_website,
           publish_on: Date.current,
           organisations: [college])
@@ -22,24 +23,29 @@ RSpec.describe "Creating a vacancy as an FE college" do
 
   after { logout }
 
-  it "follows the FE college journey, skipping education phases and applying_for_the_job" do
+  it "shows the confirm job address step after job title, restricts job roles, and shows the address on the review page" do
     expect(publisher_job_title_page).to be_displayed
     publisher_job_title_page.fill_in_and_submit_form(vacancy.job_title)
 
+    # Confirm job address is shown for FE colleges only
     expect(publisher_confirm_job_address_page).to be_displayed
-    publisher_confirm_job_address_page.fill_in_and_submit_form
+    publisher_confirm_job_address_page.fill_in_and_submit_form(
+      line1: "10 Campus Road",
+      town: "Brighton",
+      postcode: "BN1 1AA",
+    )
 
+    # Job role page only shows Teacher or Lecturer for FE colleges
     expect(publisher_job_role_page).to be_displayed
     expect(page).to have_content(I18n.t("helpers.label.publishers_job_listing_job_role_form.teaching_job_role_options.teacher"))
     expect(page).to have_no_content(I18n.t("helpers.label.publishers_job_listing_job_role_form.teaching_job_role_options.headteacher"))
     expect(page).to have_no_content(I18n.t("helpers.label.publishers_job_listing_job_role_form.support_job_role_options.teaching_assistant"))
     publisher_job_role_page.fill_in_and_submit_form(vacancy.job_roles.first)
 
-    # education_phases is skipped for FE colleges; subjects uses FE-specific options
-    expect(publisher_education_phase_page).not_to be_displayed
+    expect(publisher_key_stage_page).to be_displayed
+    publisher_key_stage_page.fill_in_and_submit_form(vacancy.key_stages_for_phases)
+
     expect(publisher_subjects_page).to be_displayed
-    expect(page).to have_content("Accountancy and finance")
-    expect(page).to have_no_content("Accounting")
     publisher_subjects_page.fill_in_and_submit_form(vacancy.subjects)
 
     expect(publisher_contract_information_page).to be_displayed
@@ -52,7 +58,6 @@ RSpec.describe "Creating a vacancy as an FE college" do
     publisher_pay_package_page.fill_in_and_submit_form(vacancy)
 
     expect(publisher_about_the_role_page).to be_displayed
-    expect(page).to have_content(I18n.t("helpers.label.publishers_job_listing_about_the_role_form.school_offer", organisation: "college"))
     publisher_about_the_role_page.fill_in_and_submit_form(vacancy)
 
     expect(publisher_school_visits_page).to be_displayed
@@ -64,11 +69,13 @@ RSpec.describe "Creating a vacancy as an FE college" do
     expect(publisher_important_dates_page).to be_displayed
     publisher_important_dates_page.fill_in_and_submit_form(publish_on: vacancy.publish_on, expires_at: vacancy.expires_at)
 
-    # applying_for_the_job is skipped; application_link is shown directly
-    expect(publisher_applying_for_the_job_page).not_to be_displayed
+    expect(publisher_applying_for_the_job_page).to be_displayed
+    publisher_applying_for_the_job_page.fill_in_and_submit_form
+
+    expect(publisher_how_to_receive_applications_page).to be_displayed
+    publisher_how_to_receive_applications_page.fill_in_and_submit_form("website")
+
     expect(publisher_application_link_page).to be_displayed
-    submit_empty_form
-    expect(publisher_application_link_page.errors.map(&:text)).to contain_exactly(I18n.t("application_link_errors.application_link.blank"))
     publisher_application_link_page.fill_in_and_submit_form(vacancy.application_link)
 
     expect(publisher_include_additional_documents_page).to be_displayed
@@ -80,14 +87,9 @@ RSpec.describe "Creating a vacancy as an FE college" do
     expect(publisher_confirm_contact_details_page).to be_displayed
     publisher_confirm_contact_details_page.fill_in_and_submit_form
 
+    # Review page — campus address row shows the custom address entered above
     expect(page).to have_current_path(organisation_job_review_path(created_vacancy.id), ignore_query: true)
-
-    click_on I18n.t("publishers.vacancies.show.heading_component.action.publish")
-    expect(page).to have_current_path(organisation_job_summary_path(created_vacancy.id), ignore_query: true)
-    expect(PublishedVacancy.find(created_vacancy.id).application_link).to eq(vacancy.application_link)
-  end
-
-  def submit_empty_form
-    click_on I18n.t("buttons.save_and_continue")
+    expect(page).to have_css("#job_address")
+    expect(page).to have_content("10 Campus Road, Brighton, BN1 1AA")
   end
 end

--- a/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_college_spec.rb
+++ b/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_college_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "Creating a vacancy as an FE college" do
 
     # Review page — campus address row shows the custom address entered above
     expect(page).to have_current_path(organisation_job_review_path(created_vacancy.id), ignore_query: true)
-    expect(page).to have_css("#job_address")
+    expect(page).to have_css("#job_location")
     expect(page).to have_content("10 Campus Road, Brighton, BN1 1AA")
   end
 end

--- a/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_college_spec.rb
+++ b/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_college_spec.rb
@@ -1,0 +1,93 @@
+require "rails_helper"
+
+RSpec.describe "Creating a vacancy as an FE college" do
+  let(:college) { create(:college) }
+  let(:publisher) { create(:publisher, organisations: [college]) }
+  let(:created_vacancy) { Vacancy.order(:created_at).last }
+
+  let(:vacancy) do
+    build(:vacancy,
+          :ect_suitable,
+          :apply_via_website,
+          publish_on: Date.current,
+          organisations: [college])
+  end
+
+  before do
+    login_publisher(publisher: publisher, organisation: college)
+    visit organisation_jobs_with_type_path
+    click_on I18n.t("buttons.create_job")
+    click_on I18n.t("buttons.create_job")
+  end
+
+  after { logout }
+
+  it "follows the FE college journey, skipping education phases and applying_for_the_job" do
+    expect(publisher_job_title_page).to be_displayed
+    publisher_job_title_page.fill_in_and_submit_form(vacancy.job_title)
+
+    expect(publisher_confirm_job_address_page).to be_displayed
+    publisher_confirm_job_address_page.fill_in_and_submit_form
+
+    expect(publisher_job_role_page).to be_displayed
+    expect(page).to have_content(I18n.t("helpers.label.publishers_job_listing_job_role_form.teaching_job_role_options.teacher"))
+    expect(page).to have_no_content(I18n.t("helpers.label.publishers_job_listing_job_role_form.teaching_job_role_options.headteacher"))
+    expect(page).to have_no_content(I18n.t("helpers.label.publishers_job_listing_job_role_form.support_job_role_options.teaching_assistant"))
+    publisher_job_role_page.fill_in_and_submit_form(vacancy.job_roles.first)
+
+    # education_phases is skipped for FE colleges; subjects uses FE-specific options
+    expect(publisher_education_phase_page).not_to be_displayed
+    expect(publisher_subjects_page).to be_displayed
+    expect(page).to have_content("Accountancy and finance")
+    expect(page).to have_no_content("Accounting")
+    publisher_subjects_page.fill_in_and_submit_form(vacancy.subjects)
+
+    expect(publisher_contract_information_page).to be_displayed
+    publisher_contract_information_page.fill_in_and_submit_form(vacancy)
+
+    expect(publisher_start_date_page).to be_displayed
+    publisher_start_date_page.fill_in_and_submit_form(vacancy.starts_on)
+
+    expect(publisher_pay_package_page).to be_displayed
+    publisher_pay_package_page.fill_in_and_submit_form(vacancy)
+
+    expect(publisher_about_the_role_page).to be_displayed
+    expect(page).to have_content(I18n.t("helpers.label.publishers_job_listing_about_the_role_form.school_offer", organisation: "college"))
+    publisher_about_the_role_page.fill_in_and_submit_form(vacancy)
+
+    expect(publisher_school_visits_page).to be_displayed
+    publisher_school_visits_page.fill_in_and_submit_form(vacancy.school_visits)
+
+    expect(publisher_visa_sponsorship_page).to be_displayed
+    publisher_visa_sponsorship_page.fill_in_and_submit_form(vacancy.visa_sponsorship_available)
+
+    expect(publisher_important_dates_page).to be_displayed
+    publisher_important_dates_page.fill_in_and_submit_form(publish_on: vacancy.publish_on, expires_at: vacancy.expires_at)
+
+    # applying_for_the_job is skipped; application_link is shown directly
+    expect(publisher_applying_for_the_job_page).not_to be_displayed
+    expect(publisher_application_link_page).to be_displayed
+    submit_empty_form
+    expect(publisher_application_link_page.errors.map(&:text)).to contain_exactly(I18n.t("application_link_errors.application_link.blank"))
+    publisher_application_link_page.fill_in_and_submit_form(vacancy.application_link)
+
+    expect(publisher_include_additional_documents_page).to be_displayed
+    publisher_include_additional_documents_page.fill_in_and_submit_form(vacancy.include_additional_documents)
+
+    expect(publisher_contact_details_page).to be_displayed
+    publisher_contact_details_page.fill_in_and_submit_form(vacancy.contact_email, vacancy.contact_number)
+
+    expect(publisher_confirm_contact_details_page).to be_displayed
+    publisher_confirm_contact_details_page.fill_in_and_submit_form
+
+    expect(page).to have_current_path(organisation_job_review_path(created_vacancy.id), ignore_query: true)
+
+    click_on I18n.t("publishers.vacancies.show.heading_component.action.publish")
+    expect(page).to have_current_path(organisation_job_summary_path(created_vacancy.id), ignore_query: true)
+    expect(PublishedVacancy.find(created_vacancy.id).application_link).to eq(vacancy.application_link)
+  end
+
+  def submit_empty_form
+    click_on I18n.t("buttons.save_and_continue")
+  end
+end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/8dvVKaCM/2876-fe-creating-a-job-hiring-staff

## Changes in this PR:

This PR adds a step to the job build flow for FE hiring staff, the confirm job address page. It also reduces the number of options in the job role step to 1 for fe hiring staff.

## Screenshots of UI changes:

<img width="1093" height="369" alt="Screenshot 2026-06-22 at 15 36 23" src="https://github.com/user-attachments/assets/1ffb07cf-6839-4586-9f8a-2e4cdf93a028" />
<img width="1100" height="570" alt="Screenshot 2026-06-22 at 15 32 30" src="https://github.com/user-attachments/assets/d13a6d84-5bf7-4393-bec7-96e6648065ae" />
<img width="898" height="534" alt="Screenshot 2026-06-22 at 15 24 07" src="https://github.com/user-attachments/assets/e108b5e7-8cc4-48a4-9fd7-f964f5e96bba" />


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
