### PR TITLE
Bugfix: Colleges page scoping

### DIFF
--- a/app/controllers/colleges_controller.rb
+++ b/app/controllers/colleges_controller.rb
@@ -1,7 +1,7 @@
 class CollegesController < ApplicationController
   def index
     @search_form = CollegeSearchForm.new(search_params)
-    @college_search = Search::CollegeSearch.new(@search_form.to_h, scope: School.kept.colleges.visible_to_jobseekers)
+    @college_search = Search::CollegeSearch.new(@search_form.to_h, scope: School.colleges.schools_visible_to_jobseekers)
     @pagy, @colleges = pagy(@college_search.organisations.order(:name))
   end
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -63,7 +63,8 @@ class Organisation < ApplicationRecord
 
   scope :not_out_of_scope, -> { where.not(detailed_school_type: Organisation::OUT_OF_SCOPE_DETAILED_SCHOOL_TYPES).or(where(detailed_school_type: nil)) }
 
-  scope :visible_to_jobseekers, -> { schools.kept.not_closed.not_out_of_scope.or(Organisation.kept.trusts_not_closed) }
+  scope :schools_visible_to_jobseekers, -> { schools.kept.not_closed.not_out_of_scope }
+  scope :visible_to_jobseekers, -> { schools_visible_to_jobseekers.or(Organisation.kept.trusts_not_closed) }
 
   scope :only_faith_schools, -> { where.not(religious_character: NON_FAITH_RELIGIOUS_CHARACTER_TYPES) }
 

--- a/spec/requests/colleges_spec.rb
+++ b/spec/requests/colleges_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe "Colleges" do
+  describe "GET /colleges" do
+    it "renders successfully and excludes trust organisations" do
+      college = create(:college, name: "Test College")
+      trust = create(:trust, name: "Test Trust")
+
+      get colleges_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(college.name)
+      expect(response.body).not_to include(trust.name)
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR:

When combining recent refactors in `main` with the new colleges page feature in FE, an invalid scope was used for the School colleges during conflict resolution.

This was causing a School to try to chain scope school groups and throw an exception.

The resolution is to use a school-specific scope for this case.

## Screenshots of UI changes when visiting /colleges page:

### Before
<img width="709" height="646" alt="image" src="https://github.com/user-attachments/assets/76dc27fb-eb08-4e3a-9da8-80a6dd1fec84" />


### After
<img width="1018" height="1167" alt="image" src="https://github.com/user-attachments/assets/53cc284c-f939-49db-8256-e1abe34eea27" />


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
