### PR TITLE
disable within (as its the wrong one) within view specs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -120,6 +120,14 @@ ALLOWED_HOSTS = %w[selenium-chrome].freeze
 
 Rails.application.load_tasks
 
+#  confusingly there is a method in RSpec::Matchers called within
+# that doesn't yield and so silently breaks system specs converted into view specs
+module RSpec
+  module Matchers
+    undef within
+  end
+end
+
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
 

--- a/spec/views/jobseekers/job_applications/index.html.slim_spec.rb
+++ b/spec/views/jobseekers/job_applications/index.html.slim_spec.rb
@@ -13,9 +13,7 @@ RSpec.describe "jobseekers/job_applications/index" do
   end
 
   before do
-    without_partial_double_verification do
-      allow(view).to receive(:current_jobseeker).and_return(jobseeker.reload)
-    end
+    allow(view).to receive(:current_jobseeker).and_return(jobseeker.reload)
 
     assign(:job_applications, job_applications)
     assign(:count, job_applications.size)

--- a/spec/views/jobseekers/saved_jobs/index.html.slim_spec.rb
+++ b/spec/views/jobseekers/saved_jobs/index.html.slim_spec.rb
@@ -1,18 +1,19 @@
 require "rails_helper"
 
 RSpec.describe "jobseekers/saved_jobs/index" do
-  let(:jobseeker) { build_stubbed(:jobseeker) }
-  let(:organisation) { build_stubbed(:school) }
+  let(:jobseeker) { create(:jobseeker) }
+  let(:organisation) { build(:school) }
 
-  let(:vacancy_with_enabled_false) { build_stubbed(:vacancy, enable_job_applications: false, organisations: [organisation]) }
-  let(:vacancy_with_enabled_true) { build_stubbed(:vacancy, enable_job_applications: true, organisations: [organisation]) }
-  let(:expired_vacancy) { build_stubbed(:vacancy, :expired, organisations: [organisation]) }
-  let(:expired_external_vacancy) { build_stubbed(:vacancy, :external, :expired, :trashed, organisations: [organisation]) }
+  let(:vacancy_with_enabled_false) { create(:vacancy, enable_job_applications: false, organisations: [organisation]) }
+  let(:vacancy_with_enabled_true) { create(:vacancy, enable_job_applications: true, organisations: [organisation]) }
+  let(:expired_vacancy) { create(:vacancy, :expired, organisations: [organisation]) }
+  let(:expired_external_vacancy) { create(:vacancy, :external, :expired, :trashed, organisations: [organisation]) }
 
   let(:sort) { Jobseekers::SavedJobSort.new }
+  let(:page) { Capybara.string(rendered) }
 
   before do
-    allow(view).to receive(:sort).and_return(sort)
+    allow(view).to receive_messages(sort: sort, current_jobseeker: jobseeker)
 
     assign(:saved_jobs, saved_jobs)
     render
@@ -21,58 +22,38 @@ RSpec.describe "jobseekers/saved_jobs/index" do
   context "when there are saved jobs" do
     let(:saved_jobs) do
       [
-        build_stubbed(:saved_job, vacancy: expired_external_vacancy),
-        build_stubbed(:saved_job, vacancy: expired_vacancy),
-        build_stubbed(:saved_job, vacancy: vacancy_with_enabled_true),
-        build_stubbed(:saved_job, vacancy: vacancy_with_enabled_false),
+        create(:saved_job, vacancy: expired_external_vacancy, jobseeker: jobseeker),
+        create(:saved_job, vacancy: expired_vacancy, jobseeker: jobseeker),
+        create(:saved_job, vacancy: vacancy_with_enabled_true, jobseeker: jobseeker),
+        create(:saved_job, vacancy: vacancy_with_enabled_false, jobseeker: jobseeker),
       ]
     end
 
     context "when viewing saved jobs" do
+      let(:second_child) { page.find(".card-component:nth-child(2)") }
+      let(:third_child) { page.find(".card-component:nth-child(3)") }
+      let(:fourth_child) { page.find(".card-component:nth-child(4)") }
+
       it "shows saved jobs" do
         expect(rendered).to have_content(I18n.t("jobseekers.saved_jobs.index.page_title"))
         expect(rendered).to have_css("h1.govuk-heading-l", text: I18n.t("jobseekers.saved_jobs.index.page_title"))
         expect(rendered).to have_css(".card-component", count: 4)
 
-        within ".card-component:nth-child(2)" do
-          expect(rendered).to have_css(".card-component__header", text: expired_vacancy.job_title)
-        end
-
-        within ".card-component:nth-child(3)" do
-          expect(rendered).to have_css(".card-component__header", text: vacancy2.job_title)
-        end
-
-        within ".card-component:nth-child(4)" do
-          expect(rendered).to have_css(".card-component__header", text: vacancy1.job_title)
-        end
+        expect(second_child).to have_css(".card-component__header", text: expired_vacancy.job_title)
+        expect(third_child).to have_css(".card-component__header", text: vacancy_with_enabled_true.job_title)
+        expect(fourth_child).to have_css(".card-component__header", text: vacancy_with_enabled_false.job_title)
       end
 
       it "shows job closed label for expired jobs" do
-        within ".card-component:nth-child(2)" do
-          expect(rendered).to have_css(".card-component__body", text: I18n.t("jobseekers.saved_jobs.index.deadline_passed"))
-        end
-
-        within ".card-component:nth-child(3)" do
-          expect(rendered).to have_no_css(".card-component__body", text: I18n.t("jobseekers.saved_jobs.index.deadline_passed"))
-        end
-
-        within ".card-component:nth-child(4)" do
-          expect(rendered).to have_no_css(".card-component__body", text: I18n.t("jobseekers.saved_jobs.index.deadline_passed"))
-        end
+        expect(second_child).to have_css(".card-component__body", text: I18n.t("jobseekers.saved_jobs.index.deadline_passed"))
+        expect(third_child).to have_no_css(".card-component__body", text: I18n.t("jobseekers.saved_jobs.index.deadline_passed"))
+        expect(fourth_child).to have_no_css(".card-component__body", text: I18n.t("jobseekers.saved_jobs.index.deadline_passed"))
       end
 
       it "only allows jobseekers to apply for jobs that have not expired" do
-        within ".card-component:nth-child(2)" do
-          expect(rendered).to have_no_link(I18n.t("jobseekers.saved_jobs.index.apply"))
-        end
-
-        within ".card-component:nth-child(3)" do
-          expect(rendered).to have_link(I18n.t("jobseekers.saved_jobs.index.apply"))
-        end
-
-        within ".card-component:nth-child(4)" do
-          expect(rendered).to have_no_link(I18n.t("jobseekers.saved_jobs.index.apply"))
-        end
+        expect(second_child).to have_no_link(I18n.t("jobseekers.saved_jobs.index.apply"))
+        expect(third_child).to have_link(I18n.t("jobseekers.saved_jobs.index.apply"))
+        expect(fourth_child).to have_no_link(I18n.t("jobseekers.saved_jobs.index.apply"))
       end
     end
   end

--- a/spec/views/publishers/candidate_messages/index.html.slim_spec.rb
+++ b/spec/views/publishers/candidate_messages/index.html.slim_spec.rb
@@ -47,9 +47,7 @@ RSpec.describe "publishers/candidate_messages/index" do
         expect(rendered).to have_content("Archive")
         expect(rendered).to have_content("Inbox (1)")
 
-        # within("table tbody") do
         expect(table_body).to have_css("tr.conversation--unread")
-        # end
       end
     end
 
@@ -57,9 +55,7 @@ RSpec.describe "publishers/candidate_messages/index" do
       let(:messages) { build_stubbed_list(:jobseeker_message, 1, sender: jobseeker, read: true) }
 
       it "marks message as read" do
-        # within("table tbody") do
         expect(table_body).to have_no_css("tr.conversation--unread")
-        # end
       end
     end
   end

--- a/spec/views/publishers/candidate_messages/index.html.slim_spec.rb
+++ b/spec/views/publishers/candidate_messages/index.html.slim_spec.rb
@@ -37,6 +37,8 @@ RSpec.describe "publishers/candidate_messages/index" do
     let(:vacancy) { build_stubbed(:vacancy, :live, organisations: [organisation]) }
     let(:job_application) { build_stubbed(:job_application, :submitted, jobseeker: jobseeker, vacancy: vacancy, status: "interviewing") }
     let(:conversations) { build_stubbed_list(:conversation, 1, last_message_at: Time.current, job_application: job_application, messages: messages) }
+    let(:page) { Capybara.string(rendered) }
+    let(:table_body) { page.find("table tbody") }
 
     context "with unread messages" do
       let(:messages) { build_stubbed_list(:jobseeker_message, 1, sender: jobseeker) }
@@ -45,9 +47,9 @@ RSpec.describe "publishers/candidate_messages/index" do
         expect(rendered).to have_content("Archive")
         expect(rendered).to have_content("Inbox (1)")
 
-        within("table tbody") do
-          expect(rendered).to have_css("tr.conversation--unread")
-        end
+        # within("table tbody") do
+        expect(table_body).to have_css("tr.conversation--unread")
+        # end
       end
     end
 
@@ -55,9 +57,9 @@ RSpec.describe "publishers/candidate_messages/index" do
       let(:messages) { build_stubbed_list(:jobseeker_message, 1, sender: jobseeker, read: true) }
 
       it "marks message as read" do
-        within("table tbody") do
-          expect(rendered).to have_no_css("tr.conversation--unread")
-        end
+        # within("table tbody") do
+        expect(table_body).to have_no_css("tr.conversation--unread")
+        # end
       end
     end
   end

--- a/spec/views/publishers/vacancies/job_applications/index.html.slim_spec.rb
+++ b/spec/views/publishers/vacancies/job_applications/index.html.slim_spec.rb
@@ -169,7 +169,6 @@ RSpec.describe "publishers/vacancies/job_applications/index" do
         expect(rendered).to have_css(".application-#{status}")
 
         expect(application_status).to have_link("#{candidate.first_name} #{candidate.last_name}", href: organisation_job_job_application_path(vacancy.id, candidate.id))
-        # end
       end
     end
   end

--- a/spec/views/publishers/vacancies/job_applications/index.html.slim_spec.rb
+++ b/spec/views/publishers/vacancies/job_applications/index.html.slim_spec.rb
@@ -168,7 +168,6 @@ RSpec.describe "publishers/vacancies/job_applications/index" do
       it "shows applicant name that links to application" do
         expect(rendered).to have_css(".application-#{status}")
 
-        # within(".application-#{status}") do
         expect(application_status).to have_link("#{candidate.first_name} #{candidate.last_name}", href: organisation_job_job_application_path(vacancy.id, candidate.id))
         # end
       end

--- a/spec/views/publishers/vacancies/job_applications/index.html.slim_spec.rb
+++ b/spec/views/publishers/vacancies/job_applications/index.html.slim_spec.rb
@@ -17,25 +17,29 @@ RSpec.describe "publishers/vacancies/job_applications/index" do
     ]
   end
   let(:shortlisted) { build_stubbed_list(:job_application, 1, :status_shortlisted, vacancy:) }
+  let(:offered) { build_stubbed_list(:job_application, 1, :status_offered, vacancy:) }
+  let(:declined) { build_stubbed_list(:job_application, 1, :status_declined, vacancy:) }
   let(:interviewing) do
     [
       build_stubbed(:job_application, :status_interviewing, vacancy:),
       build_stubbed(:job_application, :status_interviewing, vacancy:, interviewing_at: nil),
     ]
   end
+  let(:page) { Capybara.string(rendered) }
+  let(:breadcrumbs) { page.first(".govuk-breadcrumbs") }
 
   before do
-    list_offered = build_stubbed_list(:job_application, 1, :status_offered, vacancy:)
-    list_declined = build_stubbed_list(:job_application, 1, :status_declined, vacancy:)
     list_unsuccessful_interview = build_stubbed_list(:job_application, 1, :status_unsuccessful_interview, vacancy:)
 
     assign :current_organisation, organisation
     assign :vacancy, vacancy
     assign :form, Publishers::JobApplication::TagForm.new
 
-    assign :job_applications, submitted + unsuccessful + shortlisted + list_offered + list_declined + interviewing + list_unsuccessful_interview
+    assign :job_applications, submitted + unsuccessful + shortlisted + offered + declined + interviewing + list_unsuccessful_interview
 
-    render
+    allow(view).to receive_messages("show_cookies_banner?" => false)
+
+    render template: "publishers/vacancies/job_applications/index", layout: "layouts/application"
   end
 
   it "shows a status 'tag' of 'unread'" do
@@ -49,25 +53,15 @@ RSpec.describe "publishers/vacancies/job_applications/index" do
 
   context "when a vacancy has expired and it has applications" do
     let(:vacancy) { build_stubbed(:vacancy, :expired, expires_at: 2.weeks.ago, organisations: [organisation]) }
+    let(:application_status) { page.find(".application-#{status}") }
 
     describe "the summary section" do
       it "shows breadcrumb with link to passed deadline in dashboard" do
-        within(".govuk-breadcrumbs") do
-          expect(rendered).to have_link(I18n.t("jobs.dashboard.expired.tab_heading"), href: organisation_jobs_with_type_path(:expired))
-        end
+        expect(breadcrumbs).to have_link(I18n.t("jobs.dashboard.expired.tab_heading"), href: organisation_jobs_with_type_path(:expired))
       end
 
       it "shows breadcrumbs with vacancy title" do
-        within(".govuk-breadcrumbs") do
-          expect(rendered).to have_content(vacancy.job_title)
-        end
-      end
-
-      it "shows a card for each application that has been submitted" do
-        # this is the 'all' tab
-        within ".govuk-table__body" do
-          expect(rendered).to have_css(".govuk-table__row", count: 6)
-        end
+        expect(breadcrumbs).to have_content(vacancy.job_title)
       end
     end
 
@@ -76,15 +70,11 @@ RSpec.describe "publishers/vacancies/job_applications/index" do
       let(:candidate) { submitted.first }
 
       it "shows applicant name that links to application" do
-        within(".application-#{status}") do
-          expect(rendered).to have_link("#{candidate.first_name} #{candidate.last_name}", href: organisation_job_job_application_path(vacancy.id, candidate.id))
-        end
+        expect(application_status).to have_link("#{candidate.first_name} #{candidate.last_name}", href: organisation_job_job_application_path(vacancy.id, candidate.id))
       end
 
       it "shows blue submitted tag" do
-        within(".application-#{status}") do
-          expect(rendered).to have_css(".govuk-tag--blue", text: "unread")
-        end
+        expect(application_status).to have_css(".govuk-tag--light-blue", text: "unread")
       end
     end
 
@@ -119,28 +109,23 @@ RSpec.describe "publishers/vacancies/job_applications/index" do
       let(:candidate) { submitted.last }
 
       it "shows applicant name that links to application" do
-        within(".application-#{status}") do
-          expect(rendered).to have_link("#{candidate.first_name} #{candidate.last_name}", href: organisation_job_job_application_path(vacancy.id, candidate.id))
-        end
+        expect(application_status).to have_link("#{candidate.first_name} #{candidate.last_name}", href: organisation_job_job_application_path(vacancy.id, candidate.id))
       end
 
       it "shows purple reviewed tag" do
-        within(".application-#{status}") do
-          expect(rendered).to have_css(".govuk-tag--purple", text: "reviewed")
-        end
+        expect(application_status).to have_css(".govuk-tag--purple", text: "reviewed")
       end
     end
 
     describe "shortlisted application" do
       let(:candidate) { shortlisted.first }
+      let(:status) { "shortlisted" }
 
       it "shows applicant name that links to application and green shortlisted tag" do
         expect(rendered).to have_css(".application-shortlisted")
 
-        within(".application-shortlisted") do
-          expect(rendered).to have_css(".govuk-tag--green", text: "shortlisted")
-          expect(rendered).to have_link("#{candidate.first_name} #{candidate.last_name}", href: organisation_job_job_application_path(vacancy.id, candidate.id))
-        end
+        expect(application_status).to have_css(".govuk-tag--orange", text: "shortlisted")
+        expect(application_status).to have_link("#{candidate.first_name} #{candidate.last_name}", href: organisation_job_job_application_path(vacancy.id, candidate.id))
       end
     end
 
@@ -149,19 +134,13 @@ RSpec.describe "publishers/vacancies/job_applications/index" do
       let(:candidate) { unsuccessful.first }
 
       it "shows applicant name that links to application" do
-        expect(rendered).to have_css(".application-#{status}")
-
-        within(".application-#{status}") do
-          expect(rendered).to have_link("#{candidate.first_name} #{candidate.last_name}", href: organisation_job_job_application_path(vacancy.id, candidate.id))
-        end
+        expect(application_status).to have_link("#{candidate.first_name} #{candidate.last_name}", href: organisation_job_job_application_path(vacancy.id, candidate.id))
       end
 
       it "shows red rejected tag" do
         expect(rendered).to have_css(".application-#{status}")
 
-        within(".application-#{status}") do
-          expect(rendered).to have_css(".govuk-tag--red", text: "rejected")
-        end
+        expect(application_status).to have_css(".govuk-tag--red", text: "not progressing")
       end
     end
 
@@ -172,30 +151,26 @@ RSpec.describe "publishers/vacancies/job_applications/index" do
       it "shows applicant name that links to application" do
         expect(rendered).to have_css(".application-#{status}")
 
-        within(".application-#{status}") do
-          expect(rendered).to have_link("#{candidate.first_name} #{candidate.last_name}", href: organisation_job_job_application_path(vacancy.id, candidate.id))
-        end
+        expect(application_status).to have_link("#{candidate.first_name} #{candidate.last_name}", href: organisation_job_job_application_path(vacancy.id, candidate.id))
       end
 
-      it "shows pink job offered tag" do
+      it "shows job offered tag" do
         expect(rendered).to have_css(".application-#{status}")
 
-        within(".application-#{status}") do
-          expect(rendered).to have_css(".govuk-tag--pink", text: "job offered")
-        end
+        expect(application_status).to have_css(".govuk-tag--purple", text: "job offered")
       end
     end
 
     describe "declined application" do
       let(:status) { "declined" }
-      let(:candidate) { offered.last }
+      let(:candidate) { declined.first }
 
       it "shows applicant name that links to application" do
         expect(rendered).to have_css(".application-#{status}")
 
-        within(".application-#{status}") do
-          expect(rendered).to have_link("#{candidate.first_name} #{candidate.last_name}", href: organisation_job_job_application_path(vacancy.id, candidate.id))
-        end
+        # within(".application-#{status}") do
+        expect(application_status).to have_link("#{candidate.first_name} #{candidate.last_name}", href: organisation_job_job_application_path(vacancy.id, candidate.id))
+        # end
       end
     end
   end
@@ -207,15 +182,11 @@ RSpec.describe "publishers/vacancies/job_applications/index" do
 
     describe "the summary section" do
       it "shows breadcrumb with link to active jobs in dashboard" do
-        within(".govuk-breadcrumbs") do
-          expect(rendered).to have_link(I18n.t("jobs.dashboard.published.tab_heading"), href: organisation_jobs_with_type_path(:live))
-        end
+        expect(breadcrumbs).to have_link(I18n.t("jobs.dashboard.published.tab_heading"), href: organisation_jobs_with_type_path(:live))
       end
 
       it "shows breadcrumbs with vacancy title" do
-        within(".govuk-breadcrumbs") do
-          expect(rendered).to have_content(vacancy.job_title)
-        end
+        expect(breadcrumbs).to have_content(vacancy.job_title)
       end
 
       it "shows that there are no applicants" do

--- a/spec/views/vacancies/campaign_landing_page.html.slim_spec.rb
+++ b/spec/views/vacancies/campaign_landing_page.html.slim_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe "vacancies/campaign_landing_page" do
   let(:form) { Jobseekers::SearchForm.new(campaign_params.merge(landing_page: campaign_page)) }
   let(:vacancies_search) { Search::VacancySearch.new(form.to_hash, sort: form.sort) }
   let(:pagy) { pagy_array(vacancies).first }
+  let(:search_results) { campaign_landing_view.find_by_id("search-results") }
 
   before do
     allow(vacancies_search).to receive(:vacancies) { vacancies }
@@ -63,10 +64,8 @@ RSpec.describe "vacancies/campaign_landing_page" do
     expect(campaign_landing_view).to have_css("h1", text: "John, find the right mathematics fake job for you")
 
     expect(campaign_landing_view).to have_css("#search-results")
-    within "#search-results" do
-      expect(campaign_landing_view).to have_link(recent_part_time_maths_job.job_title, href: job_path(recent_part_time_maths_job))
-      expect(campaign_landing_view).to have_link(older_part_time_maths_job.job_title, href: job_path(older_part_time_maths_job))
-    end
+    expect(search_results).to have_link(recent_part_time_maths_job.job_title, href: job_path(recent_part_time_maths_job))
+    expect(search_results).to have_link(older_part_time_maths_job.job_title, href: job_path(older_part_time_maths_job))
     expect(campaign_landing_view).to have_css(".sort-container")
     expect(campaign_landing_view).to have_select("Sort by", selected: "Newest job")
   end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/rJmCdw6Z/2946-fix-view-test-assertions-ignored-in-within-blocks

## Changes in this PR:

Disable the confusing 'within' matcher in Rspec, so that all 'within'; calls in view specs fail. 