### PR TITLE
Add uniqueness constraint to publisher to convert crashes into failures

### DIFF
--- a/app/jobs/update_single_dsi_user_in_db_job.rb
+++ b/app/jobs/update_single_dsi_user_in_db_job.rb
@@ -3,7 +3,7 @@
 class UpdateSingleDSIUserInDbJob < ApplicationJob
   queue_as :low
 
-  # Race conditions mat result in validation failures due to duplicates
+  # Race conditions may result in validation failures due to duplicates
   retry_on ActiveModel::ValidationError
 
   def perform(dsi_user)

--- a/app/jobs/update_single_dsi_user_in_db_job.rb
+++ b/app/jobs/update_single_dsi_user_in_db_job.rb
@@ -3,6 +3,9 @@
 class UpdateSingleDSIUserInDbJob < ApplicationJob
   queue_as :low
 
+  # Race conditions mat result in validation failures due to duplicates
+  retry_on ActiveModel::ValidationError
+
   def perform(dsi_user)
     Publishers::DfeSignIn::UpdateUsersInDb.convert_to_user(dsi_user)
   end

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -12,6 +12,8 @@ class Publisher < ApplicationRecord
   has_many :publisher_messages, foreign_key: :sender_id, dependent: :destroy
   has_many :message_templates, dependent: :destroy
 
+  validates :oid, uniqueness: true
+
   has_encrypted :family_name, :given_name
 
   # don't use strict MX validation for publisher email - they come from DSI Login so can't really be fixed


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/ecY6N0mt/2903-review-and-triage-sentry-206

## Changes in this PR:

Currently oid collisions are causing db crashes rather than save failures. this should push these back into save failures