### PR TITLE
Fixup seeds unique OId (and in production non null)

### DIFF
--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -12,7 +12,7 @@ class Publisher < ApplicationRecord
   has_many :publisher_messages, foreign_key: :sender_id, dependent: :destroy
   has_many :message_templates, dependent: :destroy
 
-  validates :oid, uniqueness: true
+  validates :oid, uniqueness: true, presence: true
 
   has_encrypted :family_name, :given_name
 

--- a/db/migrate/20260622154520_publisher_oid_not_null.rb
+++ b/db/migrate/20260622154520_publisher_oid_not_null.rb
@@ -1,0 +1,13 @@
+class PublisherOidNotNull < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_not_null_constraint :publishers, :oid, name: "publishers_oid_null", validate: false
+    # You can use `validate_constraint_in_background` if you have a very large table
+    # and want to validate the constraint using background schema migrations.
+    validate_not_null_constraint :publishers, :oid, name: "publishers_oid_null"
+
+    change_column_null :publishers, :oid, false
+    remove_check_constraint :publishers, name: "publishers_oid_null"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_11_120102) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_22_154520) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -643,7 +643,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_11_120102) do
   end
 
   create_table "publishers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "oid"
+    t.string "oid", null: false
     t.datetime "accepted_terms_at", precision: nil
     t.string "email"
     t.datetime "last_activity_at", precision: nil


### PR DESCRIPTION
## Changes in this PR:

Seeds are currently broken in review apps from main due to the lack of an OID on test publishers. This restores that and adds not-null to the OID (there are no nulls in production) along with a presence check 