### PR TITLE
tidy up landing pages lists, split and art and design from D&T

### DIFF
--- a/app/helpers/landing_page_lists_helper.rb
+++ b/app/helpers/landing_page_lists_helper.rb
@@ -61,29 +61,38 @@ module LandingPageListsHelper
     "fe-other-support-roles-jobs" => "other_support",
   }.freeze
 
-  SUBJECTS_COLUMNS = [
-    %w[maths-teacher-jobs english-media-studies-teacher-jobs physical-education-teacher-jobs dance-drama-music-teacher-jobs science-teacher-jobs],
-    %w[history-teacher-jobs geography-teacher-jobs mfl-teacher-jobs],
-    %w[ict-computer-science-teacher-jobs economics-business-studies-teacher-jobs art-design-technology-teacher-jobs food-technology-teacher-jobs politics-humanities-social-sciences-teacher-jobs psychology-philosophy-sociology-re-teacher-jobs health-relationships-social-care-teacher-jobs],
-  ].freeze
+  LEFT_SUBJECT_LIST = { "maths-teacher-jobs" => "Mathematics",
+                        "english-media-studies-teacher-jobs" => "English and Media Studies",
+                        "physical-education-teacher-jobs" => "Physical education",
+                        "dance-drama-music-teacher-jobs" => "Dance, Drama and Music",
+                        "science-teacher-jobs" => "Science" }.freeze
 
-  SUBJECTS_LIST = {
-    "art-design-technology-teacher-jobs" => "Art and Design Technology",
-    "dance-drama-music-teacher-jobs" => "Dance, Drama and Music",
-    "economics-business-studies-teacher-jobs" => "Economics and Business Studies",
-    "english-media-studies-teacher-jobs" => "English and Media Studies",
-    "food-technology-teacher-jobs" => "Food technology",
-    "geography-teacher-jobs" => "Geography",
-    "health-relationships-social-care-teacher-jobs" => "Health and Social Care",
+  MIDDLE_SUBJECT_LIST = {
     "history-teacher-jobs" => "History",
-    "ict-computer-science-teacher-jobs" => "ICT and Computer Science",
-    "maths-teacher-jobs" => "Mathematics",
+    "geography-teacher-jobs" => "Geography",
     "mfl-teacher-jobs" => "Foreign Languages",
-    "physical-education-teacher-jobs" => "Physical education",
+  }.freeze
+
+  RIGHT_SUBJECT_LIST = {
+    "ict-computer-science-teacher-jobs" => "ICT and Computer Science",
+    "economics-business-studies-teacher-jobs" => "Economics and Business Studies",
+    "art-design-teacher-jobs" => "Art and design",
+    "design-technology-teacher-jobs" => "Design and technology",
+    "food-technology-teacher-jobs" => "Food technology",
     "politics-humanities-social-sciences-teacher-jobs" => "Politics, Humanities and Social Sciences",
     "psychology-philosophy-sociology-re-teacher-jobs" => "Psychology, Sociology and RE",
-    "science-teacher-jobs" => "Science",
+    "health-relationships-social-care-teacher-jobs" => "Health and Social Care",
   }.freeze
+
+  SUBJECTS_COLUMNS = [
+    LEFT_SUBJECT_LIST.keys,
+    MIDDLE_SUBJECT_LIST.keys,
+    RIGHT_SUBJECT_LIST.keys,
+  ].freeze
+
+  SUBJECTS_LIST = LEFT_SUBJECT_LIST.merge(MIDDLE_SUBJECT_LIST)
+                                   .merge(RIGHT_SUBJECT_LIST)
+                                   .freeze
 
   CHILD_SUBJECTS_LIST = {
     Spanish: "spanish-teacher-jobs",

--- a/app/services/vacancy_counter.rb
+++ b/app/services/vacancy_counter.rb
@@ -1,6 +1,5 @@
 class VacancyCounter
   GROUPED_SUBJECTS = {
-    "Art and Design Technology": [:"Art and design", :"Design and technology"],
     "Dance, Drama and Music": %i[Dance Drama Music],
     "Economics and Business Studies": [:Economics, :"Business studies"],
     "English and Media Studies": [:English, :"Media studies"],
@@ -17,7 +16,7 @@ class VacancyCounter
       scope.joins("CROSS JOIN LATERAL unnest(job_roles) AS r(role)")
            .group("r.role")
            .count
-           .transform_keys { |k| Vacancy::JOB_ROLES.invert[k].to_sym }
+           .transform_keys { |k| Vacancy::JOB_ROLES.invert.fetch(k).to_sym }
     end
 
     def phase_counts(scope:)
@@ -31,7 +30,7 @@ class VacancyCounter
       scope.joins("CROSS JOIN LATERAL unnest(working_patterns) AS w(pattern)")
            .group("w.pattern")
            .count
-           .transform_keys { |k| Vacancy::WORKING_PATTERNS_ENUM.invert[k] }
+           .transform_keys { |k| Vacancy::WORKING_PATTERNS_ENUM.invert.fetch(k) }
     end
 
     def job_share_counts(scope:)

--- a/app/views/home/_jobs_by_type_section.html.slim
+++ b/app/views/home/_jobs_by_type_section.html.slim
@@ -29,7 +29,7 @@ div class="govuk-!-margin-top-6"
       .govuk-grid-column-one-third
         ul.govuk-list
           - column_slugs.each do |landing_page|
-            - tuple = tallied_subjects[landing_page]
+            - tuple = tallied_subjects.fetch(landing_page)
             - count = tuple.first
             - child_subjects = tuple.second
             li = govuk_link_to t("landing_pages.#{landing_page}.name", count: count), landing_page_path(landing_page), class: "govuk-link--no-visited-state"

--- a/config/locales/landing_pages.yml
+++ b/config/locales/landing_pages.yml
@@ -264,12 +264,12 @@ en:
       heading: "%{count} art and design technology teacher jobs"
       meta_description: "Search for the latest art and design teacher jobs in England. Apply for design technology (DT) teaching roles and set up alerts for new jobs near you."
     art-design-teacher-jobs:
-      name: "Art and design"
+      name: "Art and design (%{count})"
       title: "Art and design Teacher Jobs"
       heading: "%{count} art and design teacher jobs"
       meta_description: "Search for the latest art and design teacher jobs in England. Apply for art and design teaching roles and set up alerts for new jobs near you."
     design-technology-teacher-jobs:
-      name: "Design and technology"
+      name: "Design and technology (%{count})"
       title: "Design and technology Teacher Jobs"
       heading: "%{count} design and technology teacher jobs"
       meta_description: "Search for the latest design and technology teacher jobs in England. Apply for design and technology roles and set up alerts for new jobs near you."

--- a/spec/services/vacancy_counter_spec.rb
+++ b/spec/services/vacancy_counter_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe VacancyCounter do
 
       it "successfully groups modern foreign languages together" do
         expect(described_class.subject_counts(scope: school_scope))
-            .to include(French: 1, Spanish: 1, Mandarin: 1, Classics: 1, German: 1, "Foreign Languages": 6)
+          .to include(French: 1, Spanish: 1, Mandarin: 1, Classics: 1, German: 1, "Foreign Languages": 6)
       end
     end
 
@@ -155,6 +155,29 @@ RSpec.describe VacancyCounter do
       end
     end
 
+    context "with art and design technology subjects" do
+      before do
+        create(:vacancy, :secondary, subjects: ["Art and design"])
+        create(:vacancy, :secondary, subjects: ["Design and technology"])
+        create(:vacancy, :secondary, subjects: ["Art and design", "Design and technology"])
+      end
+
+      it "groups art and design technology subjects together" do
+        expect(described_class.subject_counts(scope: school_scope))
+          .to eq("Art and design": 2,
+                 "Dance, Drama and Music": 0,
+                 "English and Media Studies": 0,
+                 "Foreign Languages": 0,
+                 "Health and Social Care": 0,
+                 "ICT and Computer Science": 0,
+                 "Design and technology": 2,
+                 "Economics and Business Studies": 0,
+                 "Politics, Humanities and Social Sciences": 0,
+                 "Psychology, Sociology and RE": 0,
+                 Science: 0)
+      end
+    end
+
     context "with dance, drama and music subjects" do
       before do
         create(:vacancy, :secondary, subjects: %w[Dance])
@@ -164,7 +187,7 @@ RSpec.describe VacancyCounter do
 
       it "groups dance, drama and music subjects together" do
         expect(described_class.subject_counts(scope: school_scope))
-            .to include("Dance, Drama and Music": 3, Dance: 1, Drama: 1, Music: 1)
+          .to include("Dance, Drama and Music": 3, Dance: 1, Drama: 1, Music: 1)
       end
     end
 
@@ -176,7 +199,7 @@ RSpec.describe VacancyCounter do
 
       it "groups economics and business studies subjects together" do
         expect(described_class.subject_counts(scope: school_scope))
-            .to include("Economics and Business Studies": 2, Economics: 1, "Business studies": 1)
+          .to include("Economics and Business Studies": 2, Economics: 1, "Business studies": 1)
       end
     end
 
@@ -188,7 +211,7 @@ RSpec.describe VacancyCounter do
 
       it "groups english and media studies subjects together" do
         expect(described_class.subject_counts(scope: school_scope))
-            .to include("English and Media Studies": 2, English: 1, "Media studies": 1)
+          .to include("English and Media Studies": 2, English: 1, "Media studies": 1)
       end
     end
 
@@ -200,7 +223,7 @@ RSpec.describe VacancyCounter do
 
       it "groups health and social care subjects together" do
         expect(described_class.subject_counts(scope: school_scope))
-            .to include("Health and Social Care": 2, "Health and social care": 1, "Relationships and sex education": 1)
+          .to include("Health and Social Care": 2, "Health and social care": 1, "Relationships and sex education": 1)
       end
     end
 
@@ -212,7 +235,7 @@ RSpec.describe VacancyCounter do
 
       it "groups ICT and computer science subjects together" do
         expect(described_class.subject_counts(scope: school_scope))
-            .to include("ICT and Computer Science": 2, ICT: 1, Computing: 1)
+          .to include("ICT and Computer Science": 2, ICT: 1, Computing: 1)
       end
     end
 
@@ -225,7 +248,7 @@ RSpec.describe VacancyCounter do
 
       it "groups politics, humanities and social sciences subjects together" do
         expect(described_class.subject_counts(scope: school_scope))
-            .to include("Politics, Humanities and Social Sciences": 3, Politics: 1, Humanities: 1, "Social sciences": 1)
+          .to include("Politics, Humanities and Social Sciences": 3, Politics: 1, Humanities: 1, "Social sciences": 1)
       end
     end
 
@@ -239,7 +262,7 @@ RSpec.describe VacancyCounter do
 
       it "groups psychology, sociology and RE subjects together" do
         expect(described_class.subject_counts(scope: school_scope))
-            .to include("Psychology, Sociology and RE": 4, Psychology: 1, Philosophy: 1, Sociology: 1, "Religious education": 1)
+          .to include("Psychology, Sociology and RE": 4, Psychology: 1, Philosophy: 1, Sociology: 1, "Religious education": 1)
       end
     end
   end

--- a/spec/services/vacancy_counter_spec.rb
+++ b/spec/services/vacancy_counter_spec.rb
@@ -155,19 +155,6 @@ RSpec.describe VacancyCounter do
       end
     end
 
-    context "with art and design technology subjects" do
-      before do
-        create(:vacancy, :secondary, subjects: ["Art and design"])
-        create(:vacancy, :secondary, subjects: ["Design and technology"])
-        create(:vacancy, :secondary, subjects: ["Art and design", "Design and technology"])
-      end
-
-      it "groups art and design technology subjects together" do
-        expect(described_class.subject_counts(scope: school_scope))
-            .to include("Art and Design Technology": 4, "Art and design": 2, "Design and technology": 2)
-      end
-    end
-
     context "with dance, drama and music subjects" do
       before do
         create(:vacancy, :secondary, subjects: %w[Dance])


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/3IopUrNi/2954-bug-art-and-design-subjects-should-be-seperate-fe-only

## Changes in this PR:

fix up Art and Design split

## Screenshots of UI changes:

### Before
<img width="1102" height="353" alt="BeforeDandT" src="https://github.com/user-attachments/assets/82335495-3085-451a-84c8-235a1c973654" />


### After
<img width="1170" height="354" alt="AfterArtDandT" src="https://github.com/user-attachments/assets/2ab66a64-327e-4a89-a0a6-27f372c13e83" />


