### PR TITLE
Fix ECT display error in Vacancy listing display

### DIFF
--- a/app/models/landing_page.rb
+++ b/app/models/landing_page.rb
@@ -50,7 +50,7 @@ class LandingPage
   end
 
   def name
-    I18n.t(:name, **translation_args)
+    I18n.t(:name, **translation_args).html_safe
   end
 
   def heading

--- a/config/locales/landing_pages.yml
+++ b/config/locales/landing_pages.yml
@@ -758,7 +758,7 @@ en:
     # sure to add all real landing pages above.
     ################################################################################################
     part-time-potions-and-sorcery-teacher-jobs:
-      name: "Potions and Sorcery"
+      name: "Potions and Sorcery (%{count})"
       banner_title: "Spiffy Part Time Potions and Sorcery Jobs"
       title: "Spiffy Part Time Potions and Sorcery Jobs"
       heading: "%{count} amazing jobs APPLY NOW"

--- a/spec/models/landing_page_spec.rb
+++ b/spec/models/landing_page_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe LandingPage do
   describe "i18n methods" do
     specify { expect(landing_page.heading).to eq("<span class=\"govuk-!-font-weight-bold\">42</span> amazing jobs APPLY NOW") }
     specify { expect(landing_page.meta_description).to eq("Lorem ipsum dolor sit jobs, vacancies adipiscing elit.") }
-    specify { expect(landing_page.name).to eq("Potions and Sorcery") }
+    specify { expect(landing_page.name).to eq("Potions and Sorcery (<span class=\"govuk-!-font-weight-bold\">42</span>)") }
     specify { expect(landing_page.title).to eq("Spiffy Part Time Potions and Sorcery Jobs") }
     specify { expect(landing_page.banner_title).to eq("Spiffy Part Time Potions and Sorcery Jobs") }
   end


### PR DESCRIPTION
## Trello card URL

- https://trello.com/c/lkrbI6Ok

## Changes in this PR:

The new counters included in the landing page name are HTML formatted,
causing the Landing Page name used for the link to be escaped.

Setting it as safe, as this is not user sourced.

## Screenshots of UI changes:

### Before
<img width="1135" height="1195" alt="image" src="https://github.com/user-attachments/assets/02f8fe44-53fa-4e9c-9cbf-f33701bd85c4" />

### After
<img width="1337" height="663" alt="image" src="https://github.com/user-attachments/assets/6a26f7a4-6aca-4bb4-84a8-e5fa49d39d94" />


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
