### PR TITLE
Fix school visits text for vacancy template

### DIFF
--- a/app/views/publishers/vacancy_templates/_school_visits.html.slim
+++ b/app/views/publishers/vacancy_templates/_school_visits.html.slim
@@ -1,8 +1,8 @@
 - summary_list.with_row(html_attributes: { id: "school_visits" }) do |row|
   - row.with_key
-    = t("jobs.school_visits")
+    = t("jobs.candidate_visits")
   - row.with_value
     = template.school_visits ? "Yes" : "No"
   - row.with_action text: t("buttons.change"),
     href: organisation_vacancy_template_build_path(template, :school_visits, "back_to_#{action_name}": "true"),
-    visually_hidden_text: t("jobs.school_visits")
+    visually_hidden_text: t("jobs.candidate_visits")

--- a/spec/views/publishers/vacancy_templates/show.html.slim_spec.rb
+++ b/spec/views/publishers/vacancy_templates/show.html.slim_spec.rb
@@ -12,5 +12,9 @@ RSpec.describe "publishers/vacancy_templates/show" do
     it "shows the 'other' type" do
       expect(rendered).to have_content("Other")
     end
+
+    it "shows the school visits text" do
+      expect(rendered).to have_content("Do you want to offer candidates a visit?")
+    end
   end
 end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/Vr7PB146/2981-bug-school-visits-for-job-template-page-displayed-incorrectly

## Changes in this PR:

fix up school visits display for job template

## Screenshots of UI changes:

### Before
<img width="1033" height="140" alt="SchoolVisitsTemplateBefore" src="https://github.com/user-attachments/assets/d3b5fb38-b5fe-4a04-8546-770896fd026f" />


### After

