### PR TITLE
Block unsupported establishment types from DfE Sign-in

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -4,15 +4,8 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   class OrganisationCategoryNotFound < StandardError; end
   rescue_from OrganisationCategoryNotFound, with: :unknown_organisation_category
 
-  # Organisation Category IDs
-  # Source: https://github.com/DFE-Digital/login.dfe.public-api#how-do-ids-map-to-categories-and-types
-  # DO NOT confuse these with the GIAS Download Organisation "Group Type (code)". They are not meant to match.
-  ORGANISATION_CATEGORIES = {
-    single_establishment: "001",
-    local_authority: "002",
-    multi_academy_trust: "010",
-    single_academy_trust: "013",
-  }.freeze
+  class EstablishmentTypeNotSupported < StandardError; end
+  rescue_from EstablishmentTypeNotSupported, with: :unsupported_establishment_type
 
   def dfe
     authorisation = Publishers::DfeSignIn::Authorisation.new(organisation_id: organisation_id, user_id: user_id)
@@ -36,21 +29,19 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def unknown_organisation_category(exception)
-    @org_name = auth_hash.dig("extra", "raw_info", "organisation", "name")
-    @org_type = auth_hash.dig("extra", "raw_info", "organisation", "category", "name")
+    render_unsupported_organisation(
+      exception,
+      template: "unknown_organisation_category",
+      org_type: auth_hash.dig("extra", "raw_info", "organisation", "category", "name"),
+    )
+  end
 
-    Sentry.with_scope do |scope|
-      scope.set_context(
-        "Authentication Organisation Context",
-        {
-          user_id: user_id,
-          auth_organisation: auth_hash.dig("extra", "raw_info", "organisation"),
-        },
-      )
-      Sentry.capture_exception(exception)
-    end
-
-    render "unknown_organisation_category", status: :forbidden
+  def unsupported_establishment_type(exception)
+    render_unsupported_organisation(
+      exception,
+      template: "unsupported_establishment_type",
+      org_type: auth_hash.dig("extra", "raw_info", "organisation", "type", "name"),
+    )
   end
 
   def not_found(error)
@@ -78,6 +69,31 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   private
 
+  def render_unsupported_organisation(exception, template:, org_type:)
+    @org_name = auth_hash.dig("extra", "raw_info", "organisation", "name")
+    @org_type = org_type
+
+    Sentry.with_scope do |scope|
+      scope.set_context(
+        "Authentication Organisation Context",
+        {
+          user_id: user_id,
+          auth_organisation: auth_hash.dig("extra", "raw_info", "organisation"),
+        },
+      )
+      Sentry.capture_exception(exception)
+    end
+
+    render template, status: :forbidden
+  end
+
+  def ensure_establishment_type_supported!
+    type_id = auth_hash.dig("extra", "raw_info", "organisation", "type", "id")
+    return unless Publishers::DfeSignIn::OrgIdMappings.out_of_scope_type?(type_id)
+
+    raise EstablishmentTypeNotSupported, "Organisation type ID `#{type_id}`"
+  end
+
   def auth_hash
     request.env["omniauth.auth"]
   end
@@ -97,13 +113,14 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def organisation_from_request
     # https://github.com/DFE-Digital/login.dfe.public-api#how-do-ids-map-to-categories-and-types
     case (cat_id = auth_hash.dig("extra", "raw_info", "organisation", "category", "id"))
-    when ORGANISATION_CATEGORIES[:single_establishment]
+    when Publishers::DfeSignIn::OrgIdMappings::CATEGORIES[:single_establishment]
+      ensure_establishment_type_supported!
       School.find_by!(urn: auth_hash.dig("extra", "raw_info", "organisation", "urn"))
-    when ORGANISATION_CATEGORIES[:local_authority]
+    when Publishers::DfeSignIn::OrgIdMappings::CATEGORIES[:local_authority]
       SchoolGroup.find_by!(local_authority_code: auth_hash.dig("extra", "raw_info", "organisation", "establishmentNumber"))
-    when ORGANISATION_CATEGORIES[:multi_academy_trust]
+    when Publishers::DfeSignIn::OrgIdMappings::CATEGORIES[:multi_academy_trust]
       SchoolGroup.find_by!(uid: auth_hash.dig("extra", "raw_info", "organisation", "uid"))
-    when ORGANISATION_CATEGORIES[:single_academy_trust]
+    when Publishers::DfeSignIn::OrgIdMappings::CATEGORIES[:single_academy_trust]
       # If the user is trying to sign in as a single-academy trust, try and find the school
       # contained within the trust and use that instead
       uid = auth_hash.dig("extra", "raw_info", "organisation", "uid")

--- a/app/services/publishers/dfe_sign_in/org_id_mappings.rb
+++ b/app/services/publishers/dfe_sign_in/org_id_mappings.rb
@@ -24,25 +24,23 @@ module Publishers::DfeSignIn
     # TV service access to their users.
     # We cannot manage these policies ourselves. It will need to be raised as a ServiceDesk ticket with DfE Sign-in team
     # to make any changes to the policies.
-    OUT_OF_SCOPE_TYPES = [
-      {
-        "10" => "Other independent special school",
-        "11" => "Other independent school",
-        "18" => "Further education",
-        "25" => "Offshore schools",
-        "26" => "Service children’s education",
-        "27" => "Miscellaneous",
-        "29" => "Higher education institutions",
-        "30" => "Welsh establishment",
-        "32" => "Special post 16 institution",
-        "37" => "British schools overseas",
-        "49" => "Online provider",
-        "56" => "Institution funded by other government department",
-      },
-    ].freeze
+    OUT_OF_SCOPE_TYPES = {
+      "10" => "Other independent special school",
+      "11" => "Other independent school",
+      "18" => "Further education",
+      "25" => "Offshore schools",
+      "26" => "Service children's education",
+      "27" => "Miscellaneous",
+      "29" => "Higher education institutions",
+      "30" => "Welsh establishment",
+      "32" => "Special post 16 institution",
+      "37" => "British schools overseas",
+      "49" => "Online provider",
+      "56" => "Institution funded by other government department",
+    }.freeze
 
     def self.out_of_scope_type?(type_id)
-      OUT_OF_SCOPE_TYPES.any? { |types| types.key?(type_id) }
+      OUT_OF_SCOPE_TYPES.key?(type_id)
     end
   end
 end

--- a/app/services/publishers/dfe_sign_in/org_id_mappings.rb
+++ b/app/services/publishers/dfe_sign_in/org_id_mappings.rb
@@ -29,7 +29,7 @@ module Publishers::DfeSignIn
       "11" => "Other independent school",
       "18" => "Further education",
       "25" => "Offshore schools",
-      "26" => "Service children's education",
+      "26" => "Service children’s education",
       "27" => "Miscellaneous",
       "29" => "Higher education institutions",
       "30" => "Welsh establishment",

--- a/app/services/publishers/dfe_sign_in/org_id_mappings.rb
+++ b/app/services/publishers/dfe_sign_in/org_id_mappings.rb
@@ -1,0 +1,48 @@
+module Publishers::DfeSignIn
+  # Maintains the relevant mappings between DfE Sign In organisation category/type IDs and the corresponding "concept" in our system.
+  # They are used to determine which organisations are supported for sign in, and which are not.
+  # Source of truth for these id mappings:
+  # https://github.com/DFE-Digital/login.dfe.public-api#how-do-ids-map-to-categories-and-types
+  module OrgIdMappings
+    # Organisation Category IDs
+    # DO NOT confuse these with the GIAS Download Organisation "Group Type (code)". They are not meant to match.
+    CATEGORIES = {
+      single_establishment: "001",
+      local_authority: "002",
+      multi_academy_trust: "010",
+      single_academy_trust: "013",
+    }.freeze
+
+    # These are the organisation types that we do not support signing in as.
+    # This list should be kept in sync with the list in Organisation::OUT_OF_SCOPE_DETAILED_SCHOOL_TYPES.
+    # The GIAS and DfE Sign In data use slightly different names for the same organisation types, but the idea is that if a
+    # type of organisation is out of scope for GIAS imports, it should also be out of scope for DfE Sign In.
+    #
+    # Note about allowing new types in the future:
+    # If we want to allow one of these types in the future, it won't be enough to just remove it from this list.
+    # We will also need to update the DfE Sign-in Policies rules/conditions to allow these types of organisations to grant
+    # TV service access to their users.
+    # We cannot manage these policies ourselves. It will need to be raised as a ServiceDesk ticket with DfE Sign-in team
+    # to make any changes to the policies.
+    OUT_OF_SCOPE_TYPES = [
+      {
+        "10" => "Other independent special school",
+        "11" => "Other independent school",
+        "18" => "Further education",
+        "25" => "Offshore schools",
+        "26" => "Service children’s education",
+        "27" => "Miscellaneous",
+        "29" => "Higher education institutions",
+        "30" => "Welsh establishment",
+        "32" => "Special post 16 institution",
+        "37" => "British schools overseas",
+        "49" => "Online provider",
+        "56" => "Institution funded by other government department",
+      },
+    ].freeze
+
+    def self.out_of_scope_type?(type_id)
+      OUT_OF_SCOPE_TYPES.any? { |types| types.key?(type_id) }
+    end
+  end
+end

--- a/app/services/publishers/dfe_sign_in/parsing.rb
+++ b/app/services/publishers/dfe_sign_in/parsing.rb
@@ -3,14 +3,13 @@ module Publishers::DfeSignIn
     def la_code(user)
       # The organisation in the user from the DSI response contains an establishment number, which
       # matches the LA code if the organisation is an LA.
-      # Category '002' denotes an LA.
       # To be consistent with trusts and schools, we only send the LA code to BigQuery if the organisation
       # is of the right type (i.e. it's an LA).
 
       # There is a different schema for the approvers and users API responses:
-      if user.dig("organisation", "Category") == "002"
+      if user.dig("organisation", "Category") == OrgIdMappings::CATEGORIES[:local_authority]
         user.dig("organisation", "EstablishmentNumber")
-      elsif user.dig("organisation", "category", "id") == "002"
+      elsif user.dig("organisation", "category", "id") == OrgIdMappings::CATEGORIES[:local_authority]
         user.dig("organisation", "establishmentNumber")
       end
     end

--- a/app/views/omniauth_callbacks/unsupported_establishment_type.html.slim
+++ b/app/views/omniauth_callbacks/unsupported_establishment_type.html.slim
@@ -1,0 +1,8 @@
+- content_for(:page_title_prefix) { "Sign In error" }
+
+h1.govuk-heading-xl Sorry, we cannot sign you in
+
+p.govuk-body You are trying to sign in to Teaching Vacancies on behalf of #{@org_name}, which is an establishment of type "#{@org_type}". This type of establishment is not supported by Teaching Vacancies.
+
+p.govuk-body
+  | If you are not sure why you are seeing this error, you can #{link_to("report a problem", new_support_request_path)}.

--- a/documentation/operations/maintenance/support-requests.md
+++ b/documentation/operations/maintenance/support-requests.md
@@ -60,6 +60,6 @@ Sometimes Publishers report seeing [this error page](/workspace/app/views/omniau
 
 The most common cause for this is the Organisation having multiple entities with similar/same name in DfE Sign-in, and the publisher belonging/signing-in with an organisation that is not between our accepted list of org types.
 
-The allowed org categories are listed in the `OmniauthCallbacksController::ORGANISATION_CATEGORIES`.
+The allowed org categories are listed in the `Publishers::DfeSignIn::OrgIdMappings::CATEGORIES`.
 
 We usually confirm this by visiting the [Get Information About Schools (GIAS)](https://get-information-schools.service.gov.uk/) Service to retrieve the valid organisation UKPRN and request the Support Team to confirm with them they're signing-in with an Org with that UKPRN.

--- a/spec/services/publishers/dfe_sign_in/org_id_mappings_spec.rb
+++ b/spec/services/publishers/dfe_sign_in/org_id_mappings_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe Publishers::DfeSignIn::OrgIdMappings do
+  describe "OUT_OF_SCOPE_TYPES" do
+    it "contains exactly the same organisation types as Organisation::OUT_OF_SCOPE_DETAILED_SCHOOL_TYPES" do
+      dsi_out_of_scope_names = described_class::OUT_OF_SCOPE_TYPES.flat_map(&:values)
+
+      expect(dsi_out_of_scope_names).to match_array(Organisation::OUT_OF_SCOPE_DETAILED_SCHOOL_TYPES)
+    end
+  end
+
+  describe ".out_of_scope_type?" do
+    it "returns true for an out-of-scope type id" do
+      expect(described_class.out_of_scope_type?("18")).to be true # Further education
+    end
+
+    it "returns false for an in-scope type id" do
+      expect(described_class.out_of_scope_type?("01")).to be false
+    end
+
+    it "returns false for nil" do
+      expect(described_class.out_of_scope_type?(nil)).to be false
+    end
+  end
+end

--- a/spec/services/publishers/dfe_sign_in/org_id_mappings_spec.rb
+++ b/spec/services/publishers/dfe_sign_in/org_id_mappings_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Publishers::DfeSignIn::OrgIdMappings do
   describe "OUT_OF_SCOPE_TYPES" do
     it "contains exactly the same organisation types as Organisation::OUT_OF_SCOPE_DETAILED_SCHOOL_TYPES" do
-      dsi_out_of_scope_names = described_class::OUT_OF_SCOPE_TYPES.flat_map(&:values)
+      dsi_out_of_scope_names = described_class::OUT_OF_SCOPE_TYPES.values
 
       expect(dsi_out_of_scope_names).to match_array(Organisation::OUT_OF_SCOPE_DETAILED_SCHOOL_TYPES)
     end

--- a/spec/services/publishers/dfe_sign_in/parsing_spec.rb
+++ b/spec/services/publishers/dfe_sign_in/parsing_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe Publishers::DfeSignIn::Parsing do
+  subject(:parser) { Class.new { include Publishers::DfeSignIn::Parsing }.new }
+
+  let(:la_category_id) { Publishers::DfeSignIn::OrgIdMappings::CATEGORIES[:local_authority] }
+
+  describe "#la_code" do
+    context "when using the approvers API schema (capitalised keys)" do
+      context "when the organisation is a local authority" do
+        let(:user) do
+          { "organisation" => { "Category" => la_category_id, "EstablishmentNumber" => "123" } }
+        end
+
+        it "returns the establishment number" do
+          expect(parser.la_code(user)).to eq("123")
+        end
+      end
+
+      context "when the organisation is not a local authority" do
+        let(:user) do
+          { "organisation" => { "Category" => "001", "EstablishmentNumber" => "123" } }
+        end
+
+        it "returns nil" do
+          expect(parser.la_code(user)).to be_nil
+        end
+      end
+    end
+
+    context "when using the users API schema (lowercase keys)" do
+      context "when the organisation is a local authority" do
+        let(:user) do
+          { "organisation" => { "category" => { "id" => la_category_id }, "establishmentNumber" => "456" } }
+        end
+
+        it "returns the establishment number" do
+          expect(parser.la_code(user)).to eq("456")
+        end
+      end
+
+      context "when the organisation is not a local authority" do
+        let(:user) do
+          { "organisation" => { "category" => { "id" => "001" }, "establishmentNumber" => "456" } }
+        end
+
+        it "returns nil" do
+          expect(parser.la_code(user)).to be_nil
+        end
+      end
+    end
+
+    context "when the organisation key is missing" do
+      let(:user) { {} }
+
+      it "returns nil" do
+        expect(parser.la_code(user)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/support/auth_helpers.rb
+++ b/spec/support/auth_helpers.rb
@@ -27,7 +27,7 @@ module AuthHelpers
 
   def stub_publisher_authentication_step(organisation_id: "939eac36-0777-48c2-9c2c-b87c948a9ee0",
                                          school_urn: "110627", trust_uid: nil, la_code: nil,
-                                         category: nil,
+                                         category: nil, establishment_type: nil,
                                          email: "an-email@example.com")
     if category.blank?
       category = "001" if school_urn.present?
@@ -64,6 +64,7 @@ module AuthHelpers
             uid: trust_uid,
             name: "FooBar organisation",
             category: { id: category, name: category_name },
+            type: establishment_type,
             establishmentNumber: la_code,
           },
         },

--- a/spec/system/publishers/authentication/oauth_spec.rb
+++ b/spec/system/publishers/authentication/oauth_spec.rb
@@ -222,6 +222,25 @@ RSpec.describe "Publisher authentication" do
       end
     end
 
+    context "with valid credentials but an out-of-scope establishment type" do
+      before do
+        stub_publisher_authentication_step(
+          email: dsi_email_address,
+          establishment_type: { id: "18", name: "Further education" },
+        )
+        stub_publisher_authorisation_step
+      end
+
+      it "records an error in sentry and shows the unsupported establishment type page" do
+        expect(Sentry).to receive(:capture_exception).with(an_instance_of(OmniauthCallbacksController::EstablishmentTypeNotSupported))
+
+        visit new_publisher_session_path
+        sign_in_publisher
+        expect(page.status_code).to eq(403) # Forbidden
+        expect(page).to have_content("You are trying to sign in to Teaching Vacancies on behalf of FooBar organisation, which is an establishment of type \"Further education\". This type of establishment is not supported by Teaching Vacancies.")
+      end
+    end
+
     context "when there is was an error with DfE Sign-in" do
       before do
         stub_publisher_authentication_step


### PR DESCRIPTION
## Trello card URL
Tangentially part of this: https://trello.com/c/kcKSuAPm/2964-ensure-publishers-signing-in-for-fe-colleges-can-access-the-service-through-dfe-sign-in


## Changes in this PR:

When we tested the changes on DfE Sign-in testing environments for them enabling the FE Colleges to use our service through policy changes, we found out that the college publisher could sign in immediately in our service even before we have added any FE code.

As long as the org category is accepted by us and our service has the organisation in our DB, they're in.

This is a problem in some situations, like enabling Further Education orgs at DfE Sign-in policy level in preparation for our integration with FE colleges, being done before we actually want to enable them in our service.

To mitigate these issues, we're adding a new level of filtering the incoming publishers from DfE Sign in.

Upon signing-in for an establishment, we will check that the establishment type is not one of the out of scope/excluded by our service. And if it is one of those, we will send them to a tailored error page, following the same format as done with the orgs with an unsupported category.

## Screenshots of UI changes:
<img width="721" height="455" alt="image" src="https://github.com/user-attachments/assets/d7e8b0bb-cf1b-4646-a3e0-14b992276386" />

### Before
<img width="1165" height="539" alt="image" src="https://github.com/user-attachments/assets/34870890-9820-43f1-977b-0f235c04e938" />

### After
<img width="1233" height="561" alt="image" src="https://github.com/user-attachments/assets/fd818f77-aa70-4ec7-90e9-da7c719c282a" />


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
