### PR TITLE
fix college offer text

### DIFF
--- a/app/views/publishers/build_vacancy_templates/about_the_role.html.slim
+++ b/app/views/publishers/build_vacancy_templates/about_the_role.html.slim
@@ -18,7 +18,7 @@
     = editor(form_input: f.govuk_text_area(:school_offer,
       rows: 5, required: true, aria: { hidden: false }), value: @form.school_offer,
       field_name: "publishers_job_listing_about_the_role_form[school_offer]", hint: t("jobs.school_offer.hint"),
-      label: { text: t("jobs.school_offer.publisher"), size: "s", id: "school-offer-label" })
+      label: { text: t("jobs.school_offer.publisher", organisation_type: "school or college"), size: "s", id: "school-offer-label" })
 
     = f.govuk_radio_buttons_fieldset :flexi_working_details_provided, legend: { size: "m", tag: nil }, class: %w[flexi_working_details_provided] do
       = f.govuk_radio_button :flexi_working_details_provided, "true", link_errors: true do

--- a/app/views/publishers/vacancy_templates/_school_offer.html.slim
+++ b/app/views/publishers/vacancy_templates/_school_offer.html.slim
@@ -1,8 +1,8 @@
 - summary_list.with_row(html_attributes: { id: "school_offer" }) do |row|
   - row.with_key
-    = t("jobs.school_offer.publisher")
+    = t("jobs.school_offer.publisher", organisation_type: "school or college")
   - row.with_value
     .editor-rendered-content == template.school_offer
   - row.with_action text: t("buttons.change"),
     href: organisation_vacancy_template_build_path(template, :about_the_role, "back_to_#{action_name}": "true"),
-    visually_hidden_text: t("jobs.school_offer.publisher")
+    visually_hidden_text: t("jobs.school_offer.publisher", organisation_type: "school or college")

--- a/spec/views/publishers/vacancy_templates/show.html.slim_spec.rb
+++ b/spec/views/publishers/vacancy_templates/show.html.slim_spec.rb
@@ -16,5 +16,9 @@ RSpec.describe "publishers/vacancy_templates/show" do
     it "shows the school visits text" do
       expect(rendered).to have_content("Do you want to offer candidates a visit?")
     end
+
+    it "shows organisation type offer text" do
+      expect(rendered).to have_content("What does your school or college offer?")
+    end
   end
 end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/F9zdK2oe/2982-bug-vacancy-tetemplate-mplate

## Changes in this PR:

Fix organisation offer text display

## Screenshots of UI changes:

### Before
<img width="1029" height="463" alt="OrgOfferBefore" src="https://github.com/user-attachments/assets/65e9a791-ca68-4528-ba96-0b8ca0f83b13" />


### After

