### PR TITLE
Fix bug causing job alert page to crash

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -180,7 +180,7 @@ class SubscriptionsController < ApplicationController
                                     :location,
                                     :organisation_slug,
                                     :radius,
-                                    { teaching_job_roles: [], support_job_roles: [], ect_statuses: [], subjects: [], phases: [], working_patterns: [], visa_sponsorship_availability: [] }])
+                                    { teaching_job_roles: [], support_job_roles: [], ect_statuses: [], subjects: [], phases: [], working_patterns: [], visa_sponsorship_availability: [], organisation_types: [], school_types: [] }])
   end
 
   def subscription_params

--- a/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_create_a_job_alert_from_a_search_spec.rb
@@ -144,6 +144,23 @@ RSpec.describe "Jobseekers can create a job alert from a search", recaptcha: tru
     end
   end
 
+  describe "organisation type filter search" do
+    let!(:college) { create(:college) }
+
+    before do
+      create(:vacancy, organisations: [college])
+      visit jobs_path
+      check I18n.t("helpers.label.publishers_job_listing_contract_information_form.organisation_type_options.colleges")
+      first(:button, I18n.t("buttons.apply_filters")).click
+    end
+
+    scenario "successfully reaches the new job alert page after filtering by colleges" do
+      expect(page).to have_content(college.name)
+      click_on I18n.t("subscriptions.link.text")
+      expect(page).to have_content(I18n.t("subscriptions.new.title"))
+    end
+  end
+
   def click_job_alert_link
     if page.has_css?("#job-alert-link")
       click_on I18n.t("subscriptions.link.text")


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/UYrkRDBj

## Changes in this PR:

This PR fixes a bug which caused the job alert page to crash when we clicked the create job alert link from jobs page after filtering by college.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
