### PR TITLE
Fe address bug

### DIFF
--- a/app/views/publishers/vacancies/build/confirm_job_address.html.slim
+++ b/app/views/publishers/vacancies/build/confirm_job_address.html.slim
@@ -7,11 +7,11 @@
 
   p.govuk-body = t(".hint")
 
-  - if vacancy.organisations.one?
-    = govuk_inset_text do
-      p.govuk-body
-        strong = t(".default_address_label")
-      p.govuk-body = full_address(vacancy.organisations.first)
+  = govuk_inset_text do
+    p.govuk-body
+      strong = t(".default_address_label")
+    - vacancy.organisations.each do |organisation|
+      p.govuk-body = full_address(organisation)
 
   = f.govuk_fieldset legend: { text: t(".change_address_label"), size: "m" } do
     = f.govuk_text_field :job_address_line1,

--- a/app/views/publishers/vacancies/build/confirm_job_address.html.slim
+++ b/app/views/publishers/vacancies/build/confirm_job_address.html.slim
@@ -7,10 +7,11 @@
 
   p.govuk-body = t(".hint")
 
-  = govuk_inset_text do
-    p.govuk-body
-      strong = t(".default_address_label")
-    p.govuk-body = full_address(current_organisation)
+  - if vacancy.organisations.one?
+    = govuk_inset_text do
+      p.govuk-body
+        strong = t(".default_address_label")
+      p.govuk-body = full_address(vacancy.organisations.first)
 
   = f.govuk_fieldset legend: { text: t(".change_address_label"), size: "m" } do
     = f.govuk_text_field :job_address_line1,


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/UYrkRDBj/2976-bug-selecting-college-job-filter-and-hitting-create-a-job-alert-results-in-an-error-page

## Changes in this PR:

This PR fixes the bug causing no default address to show up when the current organisation is a MAT/LA and can assign the vacancy to multiple locations.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
