### PR TITLE
remove form_attributes method (and form helper) from last 3 controllers

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -70,9 +70,9 @@ if ENV.fetch("COVERAGE", 0).to_i.positive?
     # However (possibly due to some residual random behaviour in test factories)
     # the line coverage needs to be set 0.02 below the reported value.
     # Nornmally this value needs to be 0.01 below the reported value due to rounding issues.
-    minimum_coverage line: 97.71, branch: 88.55
-    # Values from test run Tues 24th March 2026
-    # Line Coverage: 97.71% (12585 / 12880) -> 325 lines uncovered
-    # Branch Coverage: 87.68% (2783 / 3174) -> 217 + 174 = 391 branches uncovered
+    minimum_coverage line: 97.77, branch: 88.82
+    # Values from test run 30th June 2026
+    # Line Coverage: 97.78% (12707 / 12995) -> 287 lines uncovered
+    # Branch Coverage: 88.85% (2740 / 3084) -> 260 + 84 = 344 branches uncovered
   end
 end

--- a/app/controllers/jobseekers/job_applications/breaks_controller.rb
+++ b/app/controllers/jobseekers/job_applications/breaks_controller.rb
@@ -1,8 +1,24 @@
 class Jobseekers::JobApplications::BreaksController < Jobseekers::BaseController
-  helper_method :back_path, :employment_break, :form, :job_application
+  helper_method :back_path, :employment_break, :job_application
+
+  def new
+    form_attributes = if params[:started_on] && params[:ended_on]
+                        { started_on: Date.parse(params[:started_on]), ended_on: Date.parse(params[:ended_on]) }
+                      else
+                        # :nocov:
+                        {}
+                        # :nocov:
+                      end
+    @form = Jobseekers::BreakForm.new(form_attributes)
+  end
+
+  def edit
+    @form = Jobseekers::BreakForm.new(employment_break.slice(:reason_for_break, :started_on, :ended_on))
+  end
 
   def create
-    if form.valid?
+    @form = Jobseekers::BreakForm.new(employment_break_params)
+    if @form.valid?
       job_application.employments.break.create(employment_break_params)
       redirect_to back_path
     else
@@ -11,12 +27,17 @@ class Jobseekers::JobApplications::BreaksController < Jobseekers::BaseController
   end
 
   def update
-    if form.valid?
+    @form = Jobseekers::BreakForm.new(employment_break_params)
+    if @form.valid?
       employment_break.update(employment_break_params)
       redirect_to back_path
     else
       render :edit
     end
+  end
+
+  def confirm_destroy
+    @form = Jobseekers::BreakForm.new
   end
 
   def destroy
@@ -37,25 +58,6 @@ class Jobseekers::JobApplications::BreaksController < Jobseekers::BaseController
   def employment_break_params
     params.expect(jobseekers_break_form: %i[reason_for_break started_on ended_on])
           .merge("started_on(3i)" => "1", "ended_on(3i)" => "1")
-  end
-
-  def form
-    @form ||= Jobseekers::BreakForm.new(form_attributes)
-  end
-
-  def form_attributes
-    case action_name
-    when "new"
-      if params[:started_on] && params[:ended_on]
-        { started_on: Date.parse(params[:started_on]), ended_on: Date.parse(params[:ended_on]) }
-      else
-        {}
-      end
-    when "edit"
-      employment_break.slice(:reason_for_break, :started_on, :ended_on)
-    when "create", "update"
-      employment_break_params
-    end
   end
 
   def job_application

--- a/app/controllers/jobseekers/profiles/breaks_controller.rb
+++ b/app/controllers/jobseekers/profiles/breaks_controller.rb
@@ -1,8 +1,24 @@
 class Jobseekers::Profiles::BreaksController < Jobseekers::ProfilesController
-  helper_method :back_path, :employment_break, :form
+  helper_method :back_path, :employment_break
+
+  def new
+    form_attrubutes = if params[:started_on] && params[:ended_on]
+                        { started_on: Date.parse(params[:started_on]), ended_on: Date.parse(params[:ended_on]) }
+                      else
+                        # :nocov:
+                        {}
+                        # :nocov:
+                      end
+    @form = Jobseekers::BreakForm.new(form_attrubutes)
+  end
+
+  def edit
+    @form = Jobseekers::BreakForm.new(employment_break.slice(:reason_for_break, :started_on, :ended_on))
+  end
 
   def create
-    if form.valid?
+    @form = Jobseekers::BreakForm.new(employment_break_params)
+    if @form.valid?
       @profile.employments.break.create(employment_break_params)
       redirect_to back_path
     else
@@ -11,12 +27,17 @@ class Jobseekers::Profiles::BreaksController < Jobseekers::ProfilesController
   end
 
   def update
-    if form.valid?
+    @form = Jobseekers::BreakForm.new(employment_break_params)
+    if @form.valid?
       employment_break.update(employment_break_params)
       redirect_to back_path
     else
       render :edit
     end
+  end
+
+  def confirm_destroy
+    @form = Jobseekers::BreakForm.new
   end
 
   def destroy
@@ -37,24 +58,5 @@ class Jobseekers::Profiles::BreaksController < Jobseekers::ProfilesController
   def employment_break_params
     params.expect(jobseekers_break_form: %i[reason_for_break started_on ended_on])
           .merge("started_on(3i)" => "1", "ended_on(3i)" => "1")
-  end
-
-  def form
-    @form ||= Jobseekers::BreakForm.new(form_attributes)
-  end
-
-  def form_attributes
-    case action_name
-    when "new"
-      if params[:started_on] && params[:ended_on]
-        { started_on: Date.parse(params[:started_on]), ended_on: Date.parse(params[:ended_on]) }
-      else
-        {}
-      end
-    when "edit"
-      employment_break.slice(:reason_for_break, :started_on, :ended_on)
-    when "create", "update"
-      employment_break_params
-    end
   end
 end

--- a/app/controllers/jobseekers/profiles/qualifications_controller.rb
+++ b/app/controllers/jobseekers/profiles/qualifications_controller.rb
@@ -3,7 +3,7 @@ class Jobseekers::Profiles::QualificationsController < Jobseekers::ProfilesContr
 
   helper_method :jobseeker_profile, :qualification, :qualification_form_param_key
 
-  before_action :set_form_and_category, only: %i[new create edit update]
+  before_action :set_category, only: %i[new create edit update]
 
   def select_category
     @form = Jobseekers::Qualifications::CategoryForm.new
@@ -20,9 +20,12 @@ class Jobseekers::Profiles::QualificationsController < Jobseekers::ProfilesContr
     end
   end
 
-  def new; end
+  def new
+    @form = category_form_class(@category).new(category: @category)
+  end
 
   def create
+    @form = category_form_class(@category).new(qualification_params)
     if @form.valid?
       @profile.qualifications.create(qualification_params)
       redirect_to review_jobseekers_profile_qualifications_path
@@ -31,11 +34,17 @@ class Jobseekers::Profiles::QualificationsController < Jobseekers::ProfilesContr
     end
   end
 
-  def edit; end
+  def edit
+    form_attributes = qualification
+            .slice(:category, :finished_studying, :finished_studying_details, :grade, :institution, :name, :subject, :year, :qualification_results)
+            .reject { |_, v| v.blank? && v != false }
+    @form = category_form_class(@category).new(form_attributes)
+  end
 
   def review; end
 
   def update
+    @form = category_form_class(@category).new(qualification_params)
     if @form.valid?
       qualification.update(qualification_params)
       redirect_to review_jobseekers_profile_qualifications_path
@@ -56,45 +65,26 @@ class Jobseekers::Profiles::QualificationsController < Jobseekers::ProfilesContr
 
   private
 
-  def form_attributes
-    case action_name
-    when "new"
-      { category: @category }
-    when "edit"
-      qualification
-        .slice(:category, :finished_studying, :finished_studying_details, :grade, :institution, :name, :subject, :year, :qualification_results)
-        .reject { |_, v| v.blank? && v != false }
-    when "create", "update"
-      qualification_params
-    end
-  end
-
   def submit_category_params
     key = ActiveModel::Naming.param_key(Jobseekers::Qualifications::CategoryForm)
     (params[key] || params).permit(:category)
   end
 
   def qualification_params
-    case action_name
-    when "new", "confirm_destroy"
-      (params[qualification_form_param_key(@category)] || params).permit(:category)
-    when "create", "edit", "update"
-      params.expect(qualification_form_param_key(@category) => [:category,
-                                                                :finished_studying,
-                                                                :finished_studying_details,
-                                                                :grade,
-                                                                :institution,
-                                                                :name,
-                                                                :subject,
-                                                                :year,
-                                                                :awarding_body,
-                                                                { qualification_results_attributes: [%i[id subject grade awarding_body]] }])
-    end
+    params.expect(qualification_form_param_key(@category) => [:category,
+                                                              :finished_studying,
+                                                              :finished_studying_details,
+                                                              :grade,
+                                                              :institution,
+                                                              :name,
+                                                              :subject,
+                                                              :year,
+                                                              :awarding_body,
+                                                              { qualification_results_attributes: [%i[id subject grade awarding_body]] }])
   end
 
-  def set_form_and_category
+  def set_category
     @category = action_name.in?(%w[edit update]) ? qualification.category : category_param
-    @form = category_form_class(@category).new(form_attributes)
   end
 
   def category_param

--- a/app/views/jobseekers/job_applications/breaks/confirm_destroy.html.slim
+++ b/app/views/jobseekers/job_applications/breaks/confirm_destroy.html.slim
@@ -1,9 +1,9 @@
-- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
+- content_for :page_title_prefix, job_application_page_title_prefix(@form, t(".title"))
 
 span.govuk-caption-l = t(".caption")
 h1.govuk-heading-xl = t(".heading")
 
-= form_for form, url: jobseekers_job_application_break_path(job_application, employment_break), method: :delete do |f|
+= form_for @form, url: jobseekers_job_application_break_path(job_application, employment_break), method: :delete do |f|
   = f.govuk_submit t("buttons.confirm_destroy"), class: "govuk-button--warning"
 
 = govuk_link_to t("buttons.cancel"), jobseekers_job_application_build_path(job_application, :employment_history)

--- a/app/views/jobseekers/job_applications/breaks/edit.html.slim
+++ b/app/views/jobseekers/job_applications/breaks/edit.html.slim
@@ -1,9 +1,9 @@
-- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
+- content_for :page_title_prefix, job_application_page_title_prefix(@form, t(".title"))
 
 span.govuk-caption-l = t(".caption")
 h1.govuk-heading-xl = t(".heading")
 
-= form_for form, url: jobseekers_job_application_break_path(job_application, employment_break), method: :patch do |f|
+= form_for @form, url: jobseekers_job_application_break_path(job_application, employment_break), method: :patch do |f|
   = f.govuk_error_summary
 
   = render "fields", f: f

--- a/app/views/jobseekers/job_applications/breaks/new.html.slim
+++ b/app/views/jobseekers/job_applications/breaks/new.html.slim
@@ -1,9 +1,9 @@
-- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
+- content_for :page_title_prefix, job_application_page_title_prefix(@form, t(".title"))
 
 span.govuk-caption-l = t(".caption")
 h1.govuk-heading-xl = t(".heading")
 
-= form_for form, url: jobseekers_job_application_breaks_path(job_application), method: :post do |f|
+= form_for @form, url: jobseekers_job_application_breaks_path(job_application), method: :post do |f|
   = f.govuk_error_summary
 
   = render "fields", f: f

--- a/app/views/jobseekers/profiles/breaks/confirm_destroy.html.slim
+++ b/app/views/jobseekers/profiles/breaks/confirm_destroy.html.slim
@@ -1,11 +1,11 @@
-- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
+- content_for :page_title_prefix, job_application_page_title_prefix(@form, t(".title"))
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     span.govuk-caption-l = t(".caption")
     h1.govuk-heading-xl = t(".heading")
 
-    = form_for form, url: jobseekers_profile_break_path(employment_break), method: :delete do |f|
+    = form_for @form, url: jobseekers_profile_break_path(employment_break), method: :delete do |f|
       = f.govuk_submit t("buttons.confirm_destroy"), class: "govuk-button--warning"
 
     = govuk_link_to t("buttons.cancel"), jobseekers_profile_path

--- a/app/views/jobseekers/profiles/breaks/edit.html.slim
+++ b/app/views/jobseekers/profiles/breaks/edit.html.slim
@@ -1,11 +1,11 @@
-- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
+- content_for :page_title_prefix, job_application_page_title_prefix(@form, t(".title"))
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     span.govuk-caption-l = t(".caption")
     h1.govuk-heading-xl = t(".heading")
 
-    = form_for form, url: jobseekers_profile_break_path(employment_break), method: :patch do |f|
+    = form_for @form, url: jobseekers_profile_break_path(employment_break), method: :patch do |f|
       = f.govuk_error_summary
 
       = render "fields", f: f

--- a/app/views/jobseekers/profiles/breaks/new.html.slim
+++ b/app/views/jobseekers/profiles/breaks/new.html.slim
@@ -1,11 +1,11 @@
-- content_for :page_title_prefix, job_application_page_title_prefix(form, t(".title"))
+- content_for :page_title_prefix, job_application_page_title_prefix(@form, t(".title"))
 
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     span.govuk-caption-l = t(".caption")
     h1.govuk-heading-xl = t(".heading")
 
-    = form_for form, url: jobseekers_profile_breaks_path, method: :post do |f|
+    = form_for @form, url: jobseekers_profile_breaks_path, method: :post do |f|
       = f.govuk_error_summary
 
       = render "fields", f: f


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/aXCGiAjy/2987-remove-the-formattributes-anti-pattern-from-controllers

## Changes in this PR:

Remove the 'form_attributes' anti-pattern from the last 3 controllers. This anti-pattern results in more code lines, confusing code and also violates the basic tenet of code not having to understand its calling context. (switching behaviour on action)

This PR reduces the code-base size by 11 lines (from 14985 to 14974)

