### PR TITLE
Fix content on locations page of publisher create vacancy journey

### DIFF
--- a/app/views/publishers/vacancies/build/about_the_role.html.slim
+++ b/app/views/publishers/vacancies/build/about_the_role.html.slim
@@ -32,7 +32,7 @@
   = editor(form_input: f.govuk_text_area(:skills_and_experience, label: { size: "s", id: "skills-and-experience-label" }, rows: 5, required: true, aria: { hidden: false }), value: form.skills_and_experience, field_name: "publishers_job_listing_about_the_role_form[skills_and_experience]", label: { text: t("helpers.label.publishers_job_listing_about_the_role_form.skills_and_experience"), size: "s", id: "skills-and-experience-label" })
 
   = editor(form_input: f.govuk_text_area(:school_offer,
-    rows: 5, required: true, aria: { hidden: false }), value: form.school_offer,
+    rows: 5, required: true, aria: { hidden: false }, hint: nil), value: form.school_offer,
     field_name: "publishers_job_listing_about_the_role_form[school_offer]", hint: t("helpers.hint.publishers_job_listing_about_the_role_form.school_offer", organisation: org_type),
     label: { text: t("helpers.label.publishers_job_listing_about_the_role_form.school_offer", organisation: org_type), size: "s", id: "school-offer-label" })
 

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -256,8 +256,8 @@ en:
           full_time: This is what the annual salary would be for someone working full time
           part_time: This is the annual amount someone will take home
       publishers_job_listing_schools_form:
-        add_school: Add a school to your account
-        edit_schools_html: "Can't see the school you are looking for? %{link}"
+        add_school: Add a school or college to your account
+        edit_schools_html: "Can't see the school or college you are looking for? %{link}"
       publishers_job_listing_subjects_form:
         subjects_placeholder: Search
       publishers_vacancy_filter_form:


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/b3UHyGld/2991-bug-fest-la-locations-where-the-job-is-based
https://trello.com/c/DLysMKGa/2996-bug-fest-hiring-staff-what-does-your-college-offer

## Changes in this PR:

- some content on locations page to allow talk about "schools or colleges" rather than "schools"
- duplication in the hint text for "What does your college offer" on the about the role page

## Screenshots of UI changes:
<img width="1073" height="555" alt="Screenshot 2026-06-30 at 20 39 13" src="https://github.com/user-attachments/assets/78ca2a93-551e-43ac-8402-34951c2e3076" />
<img width="1024" height="238" alt="Screenshot 2026-06-30 at 20 40 12" src="https://github.com/user-attachments/assets/d7d95668-b680-4181-933f-c6af076de8ef" />



## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
