### PR TITLE
remove change apply type rows when step process doesn't allow it

### DIFF
--- a/app/controllers/publishers/vacancies_controller.rb
+++ b/app/controllers/publishers/vacancies_controller.rb
@@ -63,6 +63,7 @@ class Publishers::VacanciesController < Publishers::Vacancies::WizardBaseControl
 
   def review
     @vacancy = vacancy.decorate
+    @step_process = step_process
   end
 
   def use_template

--- a/app/views/publishers/vacancies/_sections.html.slim
+++ b/app/views/publishers/vacancies/_sections.html.slim
@@ -7,4 +7,4 @@
   = render "publishers/vacancies/vacancy_review_sections/important_dates", vacancy: vacancy
 
 - if section_begun?(vacancy, :application_process, step_process)
-  = render "publishers/vacancies/vacancy_review_sections/application_process", vacancy: vacancy, current_organisation: current_organisation
+  = render "publishers/vacancies/vacancy_review_sections/application_process", vacancy: vacancy, current_organisation: current_organisation, step_process: step_process

--- a/app/views/publishers/vacancies/review.html.slim
+++ b/app/views/publishers/vacancies/review.html.slim
@@ -1,14 +1,14 @@
 - content_for :page_title_prefix, review_page_title_prefix(vacancy)
 
 - content_for :breadcrumbs do
-  = govuk_back_link text: t("buttons.back"), href: organisation_job_build_path(vacancy.id, step_process.previous_step)
+  = govuk_back_link text: t("buttons.back"), href: organisation_job_build_path(vacancy.id, @step_process.previous_step)
 
 span.govuk-caption-l = t(".caption")
 h1.govuk-heading-l = t(".heading", status: (vacancy.publish_on&.future? ? "schedule" : "publish"))
 
 p.govuk-body = t(".hint")
 
-= render "publishers/vacancies/sections"
+= render "sections", step_process: @step_process
 
 p
   = open_in_new_tab_link_to(t("buttons.preview_job_listing"), organisation_job_preview_path(vacancy.id), class: "govuk-!-margin-bottom-0")

--- a/app/views/publishers/vacancies/vacancy_review_sections/_application_process.html.slim
+++ b/app/views/publishers/vacancies/vacancy_review_sections/_application_process.html.slim
@@ -2,7 +2,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
   = t("publishers.vacancies.build.application_process.step_title")
 
 = govuk_summary_list(html_attributes: { id: "application_process" }) do |summary_list|
-  - unless current_organisation.group_type == "local_authority" && vacancy.enable_job_applications.nil?
+  - if [true, false].include?(vacancy.enable_job_applications) && step_process.steps.include?(:applying_for_the_job)
     - summary_list.with_row(html_attributes: { id: "enable_job_applications" }) do |row|
       - row.with_key
         = t("jobs.enable_job_applications")
@@ -14,14 +14,15 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
                     visually_hidden_text: t("jobs.enable_job_applications")
 
   - if vacancy.enable_job_applications == false && vacancy.receive_applications.present?
-    - summary_list.with_row(html_attributes: { id: "receive_applications" }) do |row|
-      - row.with_key
-        = t("jobs.how_to_receive_applications")
-      - row.with_value
-        = t("helpers.label.publishers_job_listing_how_to_receive_applications_form.receive_applications_options.#{vacancy.receive_applications}")
-      - row.with_action text: t("buttons.change"),
-                  href: organisation_job_build_path(vacancy.id, :how_to_receive_applications, "back_to_#{action_name}": "true"),
-                  visually_hidden_text: t("jobs.how_to_receive_applications")
+    - if step_process.steps.include? :how_to_receive_applications
+      - summary_list.with_row(html_attributes: { id: "receive_applications" }) do |row|
+        - row.with_key
+          = t("jobs.how_to_receive_applications")
+        - row.with_value
+          = t("helpers.label.publishers_job_listing_how_to_receive_applications_form.receive_applications_options.#{vacancy.receive_applications}")
+        - row.with_action text: t("buttons.change"),
+                    href: organisation_job_build_path(vacancy.id, :how_to_receive_applications, "back_to_#{action_name}": "true"),
+                    visually_hidden_text: t("jobs.how_to_receive_applications")
     / legacy type - no longer supported on creation
     - if vacancy.email?
       - if vacancy.application_form.attachments&.any?

--- a/spec/views/publishers/vacancies/review.html.slim_spec.rb
+++ b/spec/views/publishers/vacancies/review.html.slim_spec.rb
@@ -2,21 +2,47 @@ require "rails_helper"
 
 RSpec.describe "publishers/vacancies/review" do
   let(:school) { build_stubbed(:school) }
-  let(:vacancy) { build_stubbed(:vacancy, publish_on: publish_date) }
   let(:vacancy_presenter) { vacancy.decorate }
   let(:step_process) { Publishers::Vacancies::VacancyStepProcess.new(:review, vacancy: vacancy, organisation: school) }
 
   before do
-    allow(view).to receive_messages(vacancy: vacancy_presenter, current_organisation: school, step_process: step_process)
+    assign :step_process, step_process
+    allow(view).to receive_messages(vacancy: vacancy_presenter, current_organisation: school)
 
     render
   end
 
   context "with website applications" do
-    let(:vacancy) { build_stubbed(:vacancy, :apply_via_website) }
+    let(:vacancy) { build_stubbed(:draft_vacancy, :apply_via_website, organisations: [organisation]) }
+    let(:application_type) { "Other" }
+    let(:apply_type) { "How do you want candidates to apply for the role?" }
 
-    it "doesnt show the document link" do
-      expect(rendered).not_to include("Document name")
+    context "with a school" do
+      let(:organisation) { build_stubbed(:school) }
+
+      it "doesnt show the document link" do
+        expect(rendered).not_to include("Document name")
+      end
+
+      it "has a change application type line" do
+        expect(rendered).to include(application_type)
+      end
+
+      it "has an apply type line" do
+        expect(rendered).to include(apply_type)
+      end
+    end
+
+    context "with a college" do
+      let(:organisation) { build_stubbed(:college) }
+
+      it "doesn't include a change application type line" do
+        expect(rendered).not_to include(application_type)
+      end
+
+      it "doesn't have an apply type line" do
+        expect(rendered).not_to include(apply_type)
+      end
     end
   end
 
@@ -39,6 +65,7 @@ RSpec.describe "publishers/vacancies/review" do
 
   context "when the vacancy is published today" do
     let(:publish_date) { Date.current }
+    let(:vacancy) { build_stubbed(:vacancy, publish_on: publish_date) }
 
     it "shows the immediate publish button" do
       expect(rendered).to include(I18n.t("publishers.vacancies.show.heading_component.action.publish"))
@@ -47,6 +74,7 @@ RSpec.describe "publishers/vacancies/review" do
 
   context "when the vacancy is scheduled for future" do
     let(:publish_date) { Date.current + 2.days }
+    let(:vacancy) { build_stubbed(:vacancy, publish_on: publish_date) }
 
     it "shows the scheduled publish button" do
       expect(rendered).to include(I18n.t("publishers.vacancies.show.heading_component.action.scheduled_complete_draft"))


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/EkUvDjvi/2989-bug-fest-hiring-staff-job-listing-screen

## Changes in this PR:

Don't display change rows when journey hasn't included the steps we're going back to

## Screenshots of UI changes:

### Before

### After
<img width="1101" height="295" alt="CollegeAfter" src="https://github.com/user-attachments/assets/da9c29fb-599d-45fc-9d4d-567723f9d522" />



