### PR TITLE
Fix bug by loading start date

### DIFF
--- a/app/form_models/publishers/job_listing/start_date_form.rb
+++ b/app/form_models/publishers/job_listing/start_date_form.rb
@@ -15,7 +15,7 @@ class Publishers::JobListing::StartDateForm < Publishers::JobListing::JobListing
     %i[start_date_type starts_on earliest_start_date latest_start_date other_start_date_details expires_at]
   end
 
-  def self.load_from_params(form_params, vacancy, current_publisher:)
+  def self.load_from_params(form_params, vacancy, _current_publisher:)
     new(form_params.merge(expires_at: vacancy.expires_at))
   end
 

--- a/app/form_models/publishers/job_listing/start_date_form.rb
+++ b/app/form_models/publishers/job_listing/start_date_form.rb
@@ -15,9 +15,11 @@ class Publishers::JobListing::StartDateForm < Publishers::JobListing::JobListing
     %i[start_date_type starts_on earliest_start_date latest_start_date other_start_date_details expires_at]
   end
 
-  def self.load_from_params(form_params, vacancy, _current_publisher:)
+  # rubocop:disable Lint/UnusedMethodArgument
+  def self.load_from_params(form_params, vacancy, current_publisher:)
     new(form_params.merge(expires_at: vacancy.expires_at))
   end
+  # rubocop:enable Lint/UnusedMethodArgument
 
   def params_to_save
     {

--- a/app/form_models/publishers/job_listing/start_date_form.rb
+++ b/app/form_models/publishers/job_listing/start_date_form.rb
@@ -15,6 +15,10 @@ class Publishers::JobListing::StartDateForm < Publishers::JobListing::JobListing
     %i[start_date_type starts_on earliest_start_date latest_start_date other_start_date_details expires_at]
   end
 
+  def self.load_from_params(form_params, vacancy, current_publisher:)
+    new(form_params.merge(expires_at: vacancy.expires_at))
+  end
+
   def params_to_save
     {
       start_date_type: start_date_type,

--- a/spec/form_models/publishers/job_listing/start_date_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/start_date_form_spec.rb
@@ -192,6 +192,31 @@ RSpec.describe Publishers::JobListing::StartDateForm, type: :model do
     end
   end
 
+  describe ".load_from_params" do
+    let(:form_params) do
+      {
+        start_date_type: "date_range",
+        "earliest_start_date(1i)" => earliest_start_date.year.to_s,
+        "earliest_start_date(2i)" => earliest_start_date.month.to_s,
+        "earliest_start_date(3i)" => earliest_start_date.day.to_s,
+        "latest_start_date(1i)" => latest_start_date.year.to_s,
+        "latest_start_date(2i)" => latest_start_date.month.to_s,
+        "latest_start_date(3i)" => latest_start_date.day.to_s,
+      }
+    end
+
+    context "when earliest_start_date is on or before the closing date" do
+      let(:earliest_start_date) { vacancy.expires_at.to_date }
+      let(:latest_start_date) { earliest_start_date + 1.month }
+
+      it "is invalid with a closing date error" do
+        form = described_class.load_from_params(form_params, vacancy, current_publisher: nil)
+        expect(form).to be_invalid
+        expect(form.errors.of_kind?(:earliest_start_date, :after)).to be true
+      end
+    end
+  end
+
   describe "other_start_date_details" do
     let(:start_date_type) { "other" }
 

--- a/spec/form_models/publishers/job_listing/start_date_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/start_date_form_spec.rb
@@ -215,6 +215,23 @@ RSpec.describe Publishers::JobListing::StartDateForm, type: :model do
         expect(form.errors.of_kind?(:earliest_start_date, :after)).to be true
       end
     end
+
+    context "when starts_on is on or before the closing date" do
+      let(:form_params) do
+        {
+          start_date_type: "specific_date",
+          "starts_on(1i)" => vacancy.expires_at.year.to_s,
+          "starts_on(2i)" => vacancy.expires_at.month.to_s,
+          "starts_on(3i)" => vacancy.expires_at.day.to_s,
+        }
+      end
+
+      it "is invalid with a closing date error" do
+        form = described_class.load_from_params(form_params, vacancy, current_publisher: nil)
+        expect(form).to be_invalid
+        expect(form.errors.of_kind?(:starts_on, :after)).to be true
+      end
+    end
   end
 
   describe "other_start_date_details" do


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/59arrUig/2997-bug-fest-job-start-date-silent-fail

## Changes in this PR:

This PR fixes a bug which was causing the start date step of the job creation flow to silently fail on the earliest_start_date validation when start date was not after the vacancy expires_at date. We would get brought back to the page by next_invalid_step which calls load_from_model which had access to expires_at.

## Screenshots of UI changes:
<img width="1187" height="747" alt="Screenshot 2026-07-02 at 10 58 33" src="https://github.com/user-attachments/assets/a15c608f-2da1-4b0a-90a1-728d206ea8b9" />
<img width="1133" height="816" alt="Screenshot 2026-07-02 at 10 59 07" src="https://github.com/user-attachments/assets/13824d2d-adf7-4f06-af62-962b79d59d33" />


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
