### PR TITLE
Force Mission Control Adapter to SolidQueue

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -153,5 +153,7 @@ module TeachingVacancies
 
     # Mission control jobs defaults to HTTP basic auth, but we are securing it ourselves
     config.mission_control.jobs.http_basic_auth_enabled = false
+    # If Sidekiq is the default adapter, Mission Controll will default to attempt to use Sidekiq and fail.
+    config.mission_control.jobs.adapters = [:solid_queue]
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -153,7 +153,7 @@ module TeachingVacancies
 
     # Mission control jobs defaults to HTTP basic auth, but we are securing it ourselves
     config.mission_control.jobs.http_basic_auth_enabled = false
-    # If Sidekiq is the default adapter, Mission Controll will default to attempt to use Sidekiq and fail.
+    # If Sidekiq is the default ActiveJob adapter, Mission Control Jobs will attempt to use Sidekiq and fail.
     config.mission_control.jobs.adapters = [:solid_queue]
   end
 end


### PR DESCRIPTION


## Trello card URL

Follow up on https://trello.com/c/NcbSoHKZ

## Changes in this PR:

If not it defaults to the default activejob adapter. If set to Sidekiq, MissionControl will fail.

## Screenshots of UI changes:

### Before
<img width="1066" height="513" alt="image" src="https://github.com/user-attachments/assets/09940639-592b-41e6-8f9c-66fd48ef115b" />


### After
<img width="1477" height="317" alt="image" src="https://github.com/user-attachments/assets/b8c7a3a5-a0f1-4a2b-8a47-6bc7c5565eaf" />


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
