### PR TITLE
disable uploads

### DIFF
--- a/app/assets/javascript/application.js
+++ b/app/assets/javascript/application.js
@@ -39,6 +39,7 @@ import ShowHiddenContentController from './js_components/showHiddenContent/showH
 import TrackedLinkController from './js_components/trackedLink/trackedLink';
 import UtilsController from './js_components/utils';
 import WordCounterController from './js_components/wordCounter/wordCounter';
+import DisableUploadsController from './js_components/disableUploads';
 
 import './clarity_cookies';
 
@@ -80,6 +81,7 @@ application.register('show-hidden-content', ShowHiddenContentController);
 application.register('tracked-link', TrackedLinkController);
 application.register('utils', UtilsController);
 application.register('word-counter', WordCounterController);
+application.register('disable-uploads', DisableUploadsController);
 
 Rails.start();
 ActiveStorage.start();

--- a/app/assets/javascript/js_components/disableUploads.js
+++ b/app/assets/javascript/js_components/disableUploads.js
@@ -1,0 +1,25 @@
+import { Controller } from '@hotwired/stimulus';
+
+// https://www.donnfelker.com/disable-attachments-in-the-trix-editor/
+export default class extends Controller {
+  // eslint-disable-next-line class-methods-use-this
+  connect() {
+    // Disable trix uploads: https://github.com/basecamp/trix/issues/604#issuecomment-600974875
+    // Get rid of the upload button
+    document.addEventListener('trix-initialize', () => {
+      const fileTools = document.querySelector('.trix-button-group--file-tools');
+      // null check hack: trix-initialize gets called twice for some reason, sometimes it is null :shrug:
+      fileTools?.remove();
+    });
+    // Don't allow images/etc to be pasted
+    document.addEventListener('trix-attachment-add', (event) => {
+      if (!event.attachment.file) {
+        event.attachment.remove();
+      }
+    });
+    // No files, ever
+    document.addEventListener('trix-file-accept', (event) => {
+      event.preventDefault();
+    });
+  }
+}

--- a/app/assets/stylesheets/actiontext.scss
+++ b/app/assets/stylesheets/actiontext.scss
@@ -41,7 +41,6 @@ trix-toolbar .trix-button:focus {
 }
 
 /* Hide unwanted toolbar buttons - keep only bold, italic, link, bullet points, undo/redo */
-trix-toolbar .trix-button-group--file-tools,
 trix-toolbar .trix-button--icon-strike,
 trix-toolbar .trix-button--icon-heading-1,
 trix-toolbar .trix-button--icon-quote,

--- a/app/assets/stylesheets/actiontext.scss
+++ b/app/assets/stylesheets/actiontext.scss
@@ -100,11 +100,6 @@ trix-editor {
   min-height: 350px;
 }
 
-/* Re-enable file tools toolbar for messages form */
-.message-form trix-toolbar .trix-button-group--file-tools {
-  display: block !important;
-}
-
 /* Hide link buttons on job application personal statement and profile about you (personal statement) forms */
 .personal-statement-form trix-toolbar .trix-button--icon-link,
 .about-you-form trix-toolbar .trix-button--icon-link {

--- a/app/views/jobseekers/job_applications/build/personal_statement.html.slim
+++ b/app/views/jobseekers/job_applications/build/personal_statement.html.slim
@@ -33,7 +33,7 @@
 
   div class="personal-statement-form" data-controller="word-counter" data-word-counter-max-words-value="1500"
     - error_class = @form.errors[:personal_statement_richtext].any? ? "govuk-form-group--error" : ""
-    div class="govuk-form-group #{error_class}" id=(@form.errors[:personal_statement_richtext].any? ? "jobseekers-job-application-personal-statement-form-personal-statement-richtext-field-error" : "jobseekers-job-application-personal-statement-form-personal-statement-richtext-field")
+    div data-controller="disable-uploads" class="govuk-form-group #{error_class}" id=(@form.errors[:personal_statement_richtext].any? ? "jobseekers-job-application-personal-statement-form-personal-statement-richtext-field-error" : "jobseekers-job-application-personal-statement-form-personal-statement-richtext-field")
       - if @form.errors[:personal_statement_richtext].any?
         span id="personal-statement-error" class="govuk-error-message"
           span class="govuk-visually-hidden" = "Error:"

--- a/app/views/jobseekers/profiles/about_you/edit.html.slim
+++ b/app/views/jobseekers/profiles/about_you/edit.html.slim
@@ -16,7 +16,7 @@
         li.govuk-list-item = item
 
     = tag.div class: "about-you-form", data: { controller: "word-counter", word_counter_max_words_value: "1500" }
-      .govuk-form-group
+      .govuk-form-group data-controller="disable-uploads"
         = f.rich_text_area :about_you, aria: { label: t("helpers.label.jobseekers_profile_about_you_form.about_you") }, data: { word_counter_target: "editor" }
         noscript
           = f.govuk_text_area :about_you, label: { size: "s" }, max_words: 1500, rows: 11

--- a/app/views/publishers/message_templates/edit.html.slim
+++ b/app/views/publishers/message_templates/edit.html.slim
@@ -8,8 +8,9 @@ h1.govuk-heading-xl = t(".heading")
 
   = f.govuk_text_field :name
 
-  = f.govuk_label :content
-  = f.rich_text_area :content
+  div data-controller="disable-uploads"
+    = f.govuk_label :content
+    = f.rich_text_area :content
 
   .govuk-button-group
     = f.govuk_submit t("buttons.save_template"), class: "govuk-!-margin-top-6"

--- a/app/views/publishers/message_templates/new.html.slim
+++ b/app/views/publishers/message_templates/new.html.slim
@@ -8,8 +8,9 @@ h1.govuk-heading-xl = t(".heading")
 
   = f.govuk_text_field :name
 
-  = f.govuk_label :content
-  = f.rich_text_area :content
+  div data-controller="disable-uploads"
+    = f.govuk_label :content
+    = f.rich_text_area :content
 
   .govuk-button-group
     = f.govuk_submit t("buttons.save_template"), class: "govuk-!-margin-top-6"

--- a/app/views/publishers/organisations/description/edit.html.slim
+++ b/app/views/publishers/organisations/description/edit.html.slim
@@ -18,7 +18,7 @@
     .govuk-hint
       = t("helpers.hint.publishers_organisation_form.description", organisation_type: organisation_type_basic(@organisation))
 
-    div class="school-description-form"
+    div class="school-description-form" data-controller="disable-uploads"
       = f.rich_text_area :description, aria: { label: t("helpers.label.publishers_organisation_form.description"), required: true }, class: "govuk-!-margin-bottom-6"
 
       noscript

--- a/app/views/shared/_message_form.html.slim
+++ b/app/views/shared/_message_form.html.slim
@@ -5,7 +5,7 @@ div class="govuk-!-margin-top-6"
   = form_for message_object, url: form_url, method: form_method do |f|
     = f.govuk_error_summary
 
-    .govuk-form-group.message-form
+    .govuk-form-group.message-form data-controller="disable-uploads"
       = f.rich_text_area :content, aria: { label: "Message" }
       noscript
         = f.govuk_text_area :content, label: { text: "Message" }, rows: 5

--- a/app/views/shared/_message_form.html.slim
+++ b/app/views/shared/_message_form.html.slim
@@ -5,7 +5,8 @@ div class="govuk-!-margin-top-6"
   = form_for message_object, url: form_url, method: form_method do |f|
     = f.govuk_error_summary
 
-    .govuk-form-group.message-form data-controller="disable-uploads"
+    / This is the one place where we allow trix uploads
+    .govuk-form-group.message-form
       = f.rich_text_area :content, aria: { label: "Message" }
       noscript
         = f.govuk_text_area :content, label: { text: "Message" }, rows: 5

--- a/spec/factories/personal_details.rb
+++ b/spec/factories/personal_details.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :personal_details do
-    first_name { FFaker::Name.first_name }
+    first_name { Faker::Name.unique.first_name }
     last_name { FFaker::Name.html_safe_last_name }
     has_right_to_work_in_uk { true }
     jobseeker_profile


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/6rTpgNdp/2917-granular-proper-disabling-of-trix-attachments

## Changes in this PR:

Disable trix uploads

## Screenshots of UI changes:

### Before

### After
<img width="1020" height="415" alt="SendMessageUpload" src="https://github.com/user-attachments/assets/af5bcaa0-1dd3-43e0-b72d-284d4d00eb3f" />

<img width="1032" height="408" alt="image" src="https://github.com/user-attachments/assets/61277357-60d0-4192-baf8-a42c9aec92c3" />


