### PR TITLE
Minor ats api doc and test changes

### DIFF
--- a/spec/requests/publishers/ats_api/v1/vacancies_spec.rb
+++ b/spec/requests/publishers/ats_api/v1/vacancies_spec.rb
@@ -440,7 +440,7 @@ RSpec.describe "ats-api/v1/vacancies", openapi_spec: "v1/swagger.yaml" do
         end
       end
 
-      response(409, "A conflicting vacancy exists.<br>The conflicting vacancy contains the same values for either:<ul><li>The external reference.</li><li>All these fields:</li><ul><li>job title</li><li>expiry date</li><li>contract type</li><li>working patterns</li><li>phases</li><li>salary</li></ul></ul>") do
+      response(409, "A conflicting vacancy exists.<br>The conflicting vacancy contains the same values for either:<ul><li>The external reference (must be unique per API Client).</li><li>All these fields (must be unique per school):</li><ul><li>job title</li><li>expiry date</li><li>contract type</li><li>working patterns</li><li>phases</li><li>salary</li></ul></ul>") do
         schema "$ref" => "#/components/schemas/conflict_error"
 
         let(:school) { create(:school) }
@@ -1011,7 +1011,7 @@ RSpec.describe "ats-api/v1/vacancies", openapi_spec: "v1/swagger.yaml" do
         end
       end
 
-      response(409, "A conflicting vacancy exists.<br>The conflicting vacancy contains the same values for either:<ul><li>The external reference.</li><li>All these fields:</li><ul><li>job title</li><li>expiry date</li><li>contract type</li><li>working patterns</li><li>phases</li><li>salary</li></ul></ul>") do
+      response(409, "A conflicting vacancy exists.<br>The conflicting vacancy contains the same values for either:<ul><li>The external reference (must be unique per API Client).</li><li>All these fields (must be unique per school):</li><ul><li>job title</li><li>expiry date</li><li>contract type</li><li>working patterns</li><li>phases</li><li>salary</li></ul></ul>") do
         schema "$ref" => "#/components/schemas/conflict_error"
 
         let!(:other_vacancy) { create(:vacancy, :external, publisher_ats_api_client: client, external_reference: "EXISTING-REF") }

--- a/spec/services/publishers/ats_api/create_vacancy_service_spec.rb
+++ b/spec/services/publishers/ats_api/create_vacancy_service_spec.rb
@@ -568,5 +568,36 @@ RSpec.describe Publishers::AtsApi::CreateVacancyService do
         expect(conflict_attempt.attempts_count).to eq(2)
       end
     end
+
+    context "when a deleted vacancy with the same information already exists for the organisation" do
+      before do
+        create(:vacancy,
+               :trashed,
+               job_title: job_title,
+               expires_at: params[:expires_at],
+               organisations: [school],
+               salary: params[:salary],
+               contract_type: params[:contract_type],
+               working_patterns: params[:working_patterns],
+               phases: params[:phases])
+      end
+
+      it "creates a new published vacancy" do
+        expect { create_vacancy_service }.to change { PublishedVacancy.kept.count }.by(1)
+        vacancy = PublishedVacancy.kept.last
+        expect(vacancy).to have_attributes(
+          job_title: job_title,
+          organisations: [school],
+          salary: params[:salary],
+          contract_type: params[:contract_type],
+          working_patterns: params[:working_patterns],
+          phases: params[:phases],
+        )
+      end
+
+      it "returns a success response" do
+        expect(create_vacancy_service).to eq(status: :created, json: { id: PublishedVacancy.kept.last.id })
+      end
+    end
   end
 end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -225,7 +225,7 @@ RSpec.configure do |config|
                     format: :datetime,
                     example: "2026-04-13T15:30:00",
                     description: "The end datetime of the vacancy in <a href='https://en.wikipedia.org/wiki/ISO_8601'>ISO 8601</a> format." \
-                                 "<br>Must be after the start date." \
+                                 "<br>Must be after the publish date." \
                                  "<br>Main example without timezone designator (recommended):" \
                                  "<ul><li>2026-04-13T15:30:00</li>" \
                                  "<li>When using this format, the datetime is interpreted in UK time (Europe/London) for the given date, with GMT/BST applied automatically as appropriate.</li></ul>" \

--- a/spec/validators/external_vacancy_validator_spec.rb
+++ b/spec/validators/external_vacancy_validator_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe ExternalVacancyValidator, type: :model do
       end
     end
 
-    context "when there a vacancy with the same ATS client ID and external reference" do
+    context "when there is a vacancy with the same ATS client ID and external reference" do
       before do
         create(:vacancy, :external, external_reference: "REF123", publisher_ats_api_client:)
       end
@@ -100,6 +100,16 @@ RSpec.describe ExternalVacancyValidator, type: :model do
         expect(vacancy).not_to be_valid
         expect(vacancy.errors[:external_reference])
           .to include("A vacancy with the provided ATS client ID and external reference already exists.")
+      end
+    end
+
+    context "when there is a deleted vacancy with the same ATS client ID and external reference" do
+      before do
+        create(:vacancy, :external, :trashed, external_reference: "REF123", publisher_ats_api_client:)
+      end
+
+      it "the new vacancy is valid" do
+        expect(vacancy).to be_valid
       end
     end
   end


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/lpzNsZNW

## Changes in this PR:

Based on ARK dev questions we noticed:
- Wrong wording in one of the ATS API field descriptions.
- Lack of explicit testing for some validations if the existing vacancy was deleted.

Covered both with this PR.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
