### PR TITLE
Remove dfe-frontend dependency

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,7 +3,6 @@ $govuk-assets-path: '/';
 
 // External dependencies
 @import 'accessible-autocomplete/dist/accessible-autocomplete.min';
-@import 'dfe-frontend/packages/dfefrontend';
 @import 'govuk-frontend/dist/govuk/index';
 @import 'leaflet/dist/leaflet';
 @import 'leaflet.markercluster/dist/MarkerCluster';

--- a/app/assets/stylesheets/components/card.scss
+++ b/app/assets/stylesheets/components/card.scss
@@ -1,5 +1,97 @@
 @import 'base';
 
+.dfe-grid-container {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+  margin-bottom: 30px;
+
+  @include govuk-media-query($from: tablet) {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 30px;
+  }
+}
+
+.dfe-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  background-color: #ffffff;
+  border: 1px solid #b1b4b6;
+  max-width: 400px;
+
+  @include govuk-media-query($until: tablet) {
+    max-width: 100%;
+  }
+
+  > picture,
+  > picture > img {
+    max-width: 100%;
+  }
+
+  &:hover,
+  &:focus-within {
+    background-color: #003a69;
+  }
+
+  &:hover a,
+  &:focus-within a,
+  &:hover p,
+  &:focus-within p,
+  &:hover .govuk-heading-m,
+  &:focus-within .govuk-heading-m {
+    color: #ffffff;
+  }
+
+  &:focus-within {
+    outline: 3px solid #ffdd00;
+  }
+}
+
+.dfe-card-container {
+  padding: govuk-spacing(4);
+  display: flex;
+  flex-grow: 1;
+  flex-direction: column;
+
+  :last-child {
+    margin-top: auto;
+  }
+
+  h2 + p:last-child,
+  h3 + p:last-child {
+    margin-top: 0;
+  }
+}
+
+.dfe-card-link--header {
+  text-decoration: none;
+  color: #347ca9;
+
+  &::after {
+    position: absolute;
+    content: "";
+    left: 0;
+    top: 0;
+    right: 0;
+    bottom: 0;
+  }
+
+  &:focus {
+    color: #0b0c0c;
+  }
+}
+
+.dfe-card-link--retake {
+  position: relative;
+  z-index: 2;
+
+  &:focus {
+    color: #0b0c0c;
+  }
+}
+
 .card-component {
   @include govuk-font(16);
   border-bottom: 1px solid govuk-functional-colour(border);

--- a/app/assets/stylesheets/components/card.scss
+++ b/app/assets/stylesheets/components/card.scss
@@ -17,7 +17,7 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  background-color: #ffffff;
+  background-color: #fff;
   border: 1px solid #b1b4b6;
   max-width: 400px;
 
@@ -41,11 +41,11 @@
   &:focus-within p,
   &:hover .govuk-heading-m,
   &:focus-within .govuk-heading-m {
-    color: #ffffff;
+    color: #fff;
   }
 
   &:focus-within {
-    outline: 3px solid #ffdd00;
+    outline: 3px solid #fd0;
   }
 }
 
@@ -71,7 +71,7 @@
 
   &::after {
     position: absolute;
-    content: "";
+    content: '';
     left: 0;
     top: 0;
     right: 0;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "chartkick": "^5.0.1",
     "classlist-polyfill": "^1.2.0",
     "core-js": "^3.49.0",
-    "dfe-frontend": "^2.0.1",
     "dompurify": "^3.4.11",
     "govuk-frontend": "^6.3.0",
     "leaflet": "^1.9.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4303,15 +4303,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dfe-frontend@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "dfe-frontend@npm:2.0.1"
-  dependencies:
-    govuk-frontend: "npm:^5.3.1"
-  checksum: 10c0/29558d897fe03d011d0ae0c8f729c3b2740b22659961179a9282f6af57a6e94dac950d4273de1c717ded352fb474bfbdbd9cc2e8ec681fc48426c703a81095f9
-  languageName: node
-  linkType: hard
-
 "doctrine@npm:^2.1.0":
   version: 2.1.0
   resolution: "doctrine@npm:2.1.0"
@@ -5409,13 +5400,6 @@ __metadata:
   version: 1.2.0
   resolution: "gopd@npm:1.2.0"
   checksum: 10c0/50fff1e04ba2b7737c097358534eacadad1e68d24cccee3272e04e007bed008e68d2614f3987788428fd192a5ae3889d08fb2331417e4fc4a9ab366b2043cead
-  languageName: node
-  linkType: hard
-
-"govuk-frontend@npm:^5.3.1":
-  version: 5.14.0
-  resolution: "govuk-frontend@npm:5.14.0"
-  checksum: 10c0/dcb1116003bb4a8ff167434bb30a779d6deafecb10687d044d5c560c0a7ff2053b8666000831c18ad3bcf4aa310678bf3c0cc40d734570b2b81c44853ddd388a
   languageName: node
   linkType: hard
 
@@ -8590,7 +8574,6 @@ __metadata:
     classlist-polyfill: "npm:^1.2.0"
     concurrently: "npm:^10.0.3"
     core-js: "npm:^3.49.0"
-    dfe-frontend: "npm:^2.0.1"
     dompurify: "npm:^3.4.11"
     esbuild: "npm:^0.28.1"
     esbuild-plugin-babel: "npm:^0.2.3"


### PR DESCRIPTION
## Trello card URL

Part of https://trello.com/c/5KUMh1tS/2915-frontend-upgrade-deprecated-sass-import-rules

## Changes in this PR:

dfe-frontend is not maintained and blocks our sass migration. this change removes it and adds styles we use from it to our own card.scss file

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
