### PR TITLE
Display vacancy pre-spike

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -5,7 +5,7 @@ class VacanciesController < ApplicationController
 
   before_action :store_jobseeker_location, only: %i[show], if: :storable_location?
 
-  # Looking for a non-existant job should return a 404
+  # Looking for a non-existent job should return a 404
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
 
   def index
@@ -24,8 +24,8 @@ class VacanciesController < ApplicationController
 
     vacancy = PublishedVacancy.kept.listed.friendly.find(params[:id])
     TrackVacancyViewJob.perform_later(vacancy_id: vacancy.id, referrer_url: request.referer, hostname: request.host, params: request.query_parameters)
-    @saved_job = current_jobseeker&.saved_jobs&.find_by(vacancy: vacancy)
-    @job_application = current_jobseeker&.job_applications&.find_by(vacancy: vacancy)
+    @saved_job = vacancy.saved_jobs.find_by(jobseeker: current_jobseeker)
+    @job_application = vacancy.job_applications.find_by(jobseeker: current_jobseeker)
     @invented_job_alert_search_criteria = Search::CriteriaInventor.new(vacancy).criteria
     @similar_jobs = Search::SimilarJobs.new(vacancy).similar_jobs
     @vacancy = vacancy.decorate

--- a/app/views/publishers/vacancies/preview.html.slim
+++ b/app/views/publishers/vacancies/preview.html.slim
@@ -1,5 +1,3 @@
 - content_for :page_title_prefix, t("jobs.preview_listing.page_title", organisation: current_organisation.name)
 
-.govuk-grid-row
-  .govuk-grid-column-full
-    = render "vacancies/show"
+= render "vacancies/show", vacancy: @vacancy, saved_job: nil, job_application: nil, similar_jobs: nil, invented_job_alert_search_criteria: nil

--- a/app/views/publishers/vacancies/preview.html.slim
+++ b/app/views/publishers/vacancies/preview.html.slim
@@ -1,3 +1,9 @@
 - content_for :page_title_prefix, t("jobs.preview_listing.page_title", organisation: current_organisation.name)
 
-= render "vacancies/show", vacancy: @vacancy, saved_job: nil, job_application: nil, similar_jobs: nil, invented_job_alert_search_criteria: nil
+= render "vacancies/vacancy_banner", vacancy: @vacancy
+= render "vacancies/listing/banner_buttons", vacancy: @vacancy,
+  saved_job: nil,
+  job_application: nil,
+  similar_jobs: nil,
+  invented_job_alert_search_criteria: nil
+= render "vacancies/show", vacancy: @vacancy, similar_jobs: nil, invented_job_alert_search_criteria: nil

--- a/app/views/vacancies/_show.html.slim
+++ b/app/views/vacancies/_show.html.slim
@@ -1,24 +1,3 @@
-- content_for :page_title_prefix, vacancy_listing_page_title_prefix(vacancy)
-
-- content_for :page_description, t(".page_description", job_title: vacancy.job_title,
-                                                        organisation: vacancy.organisation_name,
-                                                        deadline: format_date(vacancy.expires_at, :date_only_shorthand))
-
-- content_for :breadcrumbs do
-  = govuk_breadcrumbs breadcrumbs: vacancy_breadcrumbs(vacancy)
-
-- if vacancy.expired?
-  - content_for :meta_no_index do
-    meta name="robots" content="noindex"
-
-= render "vacancies/listing/banner", vacancy: vacancy
-
-= render "vacancies/listing/banner_buttons", vacancy: vacancy,
-                                             saved_job: saved_job,
-                                             job_application: job_application,
-                                             similar_jobs: similar_jobs,
-                                             invented_job_alert_search_criteria: invented_job_alert_search_criteria
-
 .govuk-grid-row class="govuk-!-margin-top-6"
   .govuk-grid-column-one-third
     = render "vacancies/listing/key_dates_sidebar", vacancy: vacancy, similar_jobs: similar_jobs

--- a/app/views/vacancies/_show.html.slim
+++ b/app/views/vacancies/_show.html.slim
@@ -1,44 +1,37 @@
-- content_for :page_title_prefix, vacancy_listing_page_title_prefix(@vacancy)
+- content_for :page_title_prefix, vacancy_listing_page_title_prefix(vacancy)
 
-- if @newly_created_user
-  = govuk_notification_banner title_text: t("banners.success"), classes: "govuk-notification-banner--success" do |notification_banner|
-    - notification_banner.with_heading(text: t(".one_login_banner.account_not_found.title"))
-    p.govuk-body = t(".one_login_banner.account_not_found.paragraph1")
-    p.govuk-body = t(".one_login_banner.account_not_found.paragraph2", link: govuk_link_to(t(".one_login_banner.account_not_found.transfer_account_link_text"), new_jobseekers_request_account_transfer_email_path)).html_safe
-
-- content_for :page_description, t(".page_description", job_title: @vacancy.job_title,
-                                                        organisation: @vacancy.organisation_name,
-                                                        deadline: format_date(@vacancy.expires_at, :date_only_shorthand))
+- content_for :page_description, t(".page_description", job_title: vacancy.job_title,
+                                                        organisation: vacancy.organisation_name,
+                                                        deadline: format_date(vacancy.expires_at, :date_only_shorthand))
 
 - content_for :breadcrumbs do
-    = govuk_breadcrumbs breadcrumbs: vacancy_breadcrumbs(@vacancy)
+  = govuk_breadcrumbs breadcrumbs: vacancy_breadcrumbs(vacancy)
 
-- if @vacancy.expired?
+- if vacancy.expired?
   - content_for :meta_no_index do
     meta name="robots" content="noindex"
 
-= render "vacancies/listing/banner", vacancy: @vacancy
+= render "vacancies/listing/banner", vacancy: vacancy
 
-= render "vacancies/listing/banner_buttons", vacancy: @vacancy,
-                                             saved_job: @saved_job,
-                                             job_application: @job_application,
-                                             similar_jobs: @similar_jobs,
-                                             invented_job_alert_search_criteria: @invented_job_alert_search_criteria
+= render "vacancies/listing/banner_buttons", vacancy: vacancy,
+                                             saved_job: saved_job,
+                                             job_application: job_application,
+                                             similar_jobs: similar_jobs,
+                                             invented_job_alert_search_criteria: invented_job_alert_search_criteria
 
 .govuk-grid-row class="govuk-!-margin-top-6"
   .govuk-grid-column-one-third
-    = render "vacancies/listing/key_dates_sidebar", vacancy: @vacancy, similar_jobs: @similar_jobs
-    - if @vacancy.ect_suitable? || @vacancy.enable_job_applications?
-      = render "vacancies/listing/personal_statement_help", vacancy: @vacancy
+    = render "vacancies/listing/key_dates_sidebar", vacancy: vacancy, similar_jobs: similar_jobs
+    - if vacancy.ect_suitable? || vacancy.enable_job_applications?
+      = render "vacancies/listing/personal_statement_help", vacancy: vacancy
 
   .govuk-grid-column-two-thirds
-    = render "vacancies/listing/multi_school_banner", vacancy: @vacancy
+    = render "vacancies/listing/multi_school_banner", vacancy: vacancy
 
-    = render "vacancies/listing/job_details", vacancy: @vacancy
+    = render "vacancies/listing/job_details", vacancy: vacancy
 
-    = render "vacancies/listing/organisation_details", vacancy: @vacancy
+    = render "vacancies/listing/organisation_details", vacancy: vacancy
 
-    = render "vacancies/listing/similar_jobs", vacancy: @vacancy,
-                                               similar_jobs: @similar_jobs,
-                                               invented_job_alert_search_criteria: @invented_job_alert_search_criteria,
-                                               linked_locations: linked_locations(@vacancy)
+    = render "vacancies/listing/similar_jobs", vacancy: vacancy,
+                                               similar_jobs: similar_jobs,
+                                               invented_job_alert_search_criteria: invented_job_alert_search_criteria

--- a/app/views/vacancies/_vacancy_banner.html.slim
+++ b/app/views/vacancies/_vacancy_banner.html.slim
@@ -1,0 +1,14 @@
+- content_for :page_title_prefix, vacancy_listing_page_title_prefix(vacancy)
+
+- content_for :page_description, t(".page_description", job_title: vacancy.job_title,
+                                                        organisation: vacancy.organisation_name,
+                                                        deadline: format_date(vacancy.expires_at, :date_only_shorthand))
+
+- content_for :breadcrumbs do
+  = govuk_breadcrumbs breadcrumbs: vacancy_breadcrumbs(vacancy)
+
+- if vacancy.expired?
+  - content_for :meta_no_index do
+    meta name="robots" content="noindex"
+
+= render "vacancies/listing/banner", vacancy: vacancy

--- a/app/views/vacancies/listing/_similar_jobs.html.slim
+++ b/app/views/vacancies/listing/_similar_jobs.html.slim
@@ -18,6 +18,7 @@ section
     = govuk_link_to(t("jobs.alert.similar.verbose.link_text"), new_subscription_path(search_criteria: invented_job_alert_search_criteria, vacancy_id: vacancy.id))
     =< t("jobs.alert.similar.verbose.reminder")
 
+- linked_locations = linked_locations(vacancy)
 - if linked_locations.any?
   section
     p.icon.icon--left.icon--map-blue

--- a/app/views/vacancies/show.html.slim
+++ b/app/views/vacancies/show.html.slim
@@ -7,7 +7,13 @@
     p.govuk-body = t(".one_login_banner.account_not_found.paragraph1")
     p.govuk-body = t(".one_login_banner.account_not_found.paragraph2", link: govuk_link_to(t(".one_login_banner.account_not_found.transfer_account_link_text"), new_jobseekers_request_account_transfer_email_path)).html_safe
 
-= render "vacancies/show", vacancy: @vacancy, saved_job: @saved_job, job_application: @job_application, similar_jobs: @similar_jobs, invented_job_alert_search_criteria: @invented_job_alert_search_criteria
+= render "vacancies/vacancy_banner", vacancy: @vacancy
+= render "vacancies/listing/banner_buttons", vacancy: @vacancy,
+  saved_job: @saved_job,
+  job_application: @job_application,
+  similar_jobs: @similar_jobs,
+  invented_job_alert_search_criteria: @invented_job_alert_search_criteria
+= render "vacancies/show", vacancy: @vacancy, similar_jobs: @similar_jobs, invented_job_alert_search_criteria: @invented_job_alert_search_criteria
 
 script.jobref type="application/ld+json"
   == render(partial: "api/vacancies/show", formats: [:json], locals: { vacancy: @vacancy })

--- a/app/views/vacancies/show.html.slim
+++ b/app/views/vacancies/show.html.slim
@@ -1,7 +1,13 @@
 - if malware_scan_clean?(@vacancy.organisation.logo)
   - content_for :social_image, polymorphic_url(@vacancy.organisation.logo)
 
-= render "vacancies/show"
+- if @newly_created_user
+  = govuk_notification_banner title_text: t("banners.success"), classes: "govuk-notification-banner--success" do |notification_banner|
+    - notification_banner.with_heading(text: t(".one_login_banner.account_not_found.title"))
+    p.govuk-body = t(".one_login_banner.account_not_found.paragraph1")
+    p.govuk-body = t(".one_login_banner.account_not_found.paragraph2", link: govuk_link_to(t(".one_login_banner.account_not_found.transfer_account_link_text"), new_jobseekers_request_account_transfer_email_path)).html_safe
+
+= render "vacancies/show", vacancy: @vacancy, saved_job: @saved_job, job_application: @job_application, similar_jobs: @similar_jobs, invented_job_alert_search_criteria: @invented_job_alert_search_criteria
 
 script.jobref type="application/ld+json"
   == render(partial: "api/vacancies/show", formats: [:json], locals: { vacancy: @vacancy })

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -502,8 +502,9 @@ en:
           zero: "%{heading} - Teaching, leadership and support jobs"
           one: "%{heading} - Teaching, leadership and support jobs"
           other: "%{heading} page %{count} - Teaching, leadership and support jobs"
-    show:
+    vacancy_banner:
       page_description: '%{job_title} job from %{organisation}. Apply by %{deadline}.'
+    show:
       job_details: Job details
       one_login_banner:
         account_found:

--- a/spec/system/jobseekers/jobseekers_can_view_a_vacancy_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_view_a_vacancy_spec.rb
@@ -92,15 +92,15 @@ RSpec.describe "Viewing a single published vacancy" do
       scenario "the vacancy's meta data are rendered correctly" do
         expect(page.find('meta[name="description"]', visible: false)["content"])
           .to eq(I18n.t("vacancies.vacancy_banner.page_description", job_title: vacancy.job_title,
-                                                           organisation: vacancy.organisation_name,
-                                                           deadline: format_date(vacancy.expires_at, :date_only_shorthand)))
+                                                                     organisation: vacancy.organisation_name,
+                                                                     deadline: format_date(vacancy.expires_at, :date_only_shorthand)))
       end
 
       scenario "the vacancy's open graph meta data are rendered correctly" do
         expect(page.find('meta[property="og:description"]', visible: false)["content"])
           .to eq(I18n.t("vacancies.vacancy_banner.page_description", job_title: vacancy.job_title,
-                                                           organisation: vacancy.organisation_name,
-                                                           deadline: format_date(vacancy.expires_at, :date_only_shorthand)))
+                                                                     organisation: vacancy.organisation_name,
+                                                                     deadline: format_date(vacancy.expires_at, :date_only_shorthand)))
       end
     end
 

--- a/spec/system/jobseekers/jobseekers_can_view_a_vacancy_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_view_a_vacancy_spec.rb
@@ -91,14 +91,14 @@ RSpec.describe "Viewing a single published vacancy" do
 
       scenario "the vacancy's meta data are rendered correctly" do
         expect(page.find('meta[name="description"]', visible: false)["content"])
-          .to eq(I18n.t("vacancies.show.page_description", job_title: vacancy.job_title,
+          .to eq(I18n.t("vacancies.vacancy_banner.page_description", job_title: vacancy.job_title,
                                                            organisation: vacancy.organisation_name,
                                                            deadline: format_date(vacancy.expires_at, :date_only_shorthand)))
       end
 
       scenario "the vacancy's open graph meta data are rendered correctly" do
         expect(page.find('meta[property="og:description"]', visible: false)["content"])
-          .to eq(I18n.t("vacancies.show.page_description", job_title: vacancy.job_title,
+          .to eq(I18n.t("vacancies.vacancy_banner.page_description", job_title: vacancy.job_title,
                                                            organisation: vacancy.organisation_name,
                                                            deadline: format_date(vacancy.expires_at, :date_only_shorthand)))
       end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/3AIlLRdg/3023-vacancy-show-template-tidy-up

## Changes in this PR:

Moved variable access from partials into the main template, passing parameters to partials as per rails idioms. Turns out that preview re-uses the 'show' partial but with all apart from 'vacancy' not set - this now shows that these variables are explicitly set to nil
