### PR TITLE
2864: Adds terraform-version-file, AWS & GCP auth, and confirm-production to validate-infrastructure.yml

### DIFF
--- a/.github/workflows/validate-infrastructure.yml
+++ b/.github/workflows/validate-infrastructure.yml
@@ -20,19 +20,24 @@ jobs:
           - display: AKS infrastructure
             validation_plan: aks-infra
             terraform_base: terraform/app
+            terraform_version_file: versions.tf
 
     steps:
       - name: Validate ${{ matrix.display }}
         uses: DFE-Digital/github-actions/validate-infra@master
-        env:
-          SKIP_CONFIRM_PRODUCTION: true
         with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          gcp-wip: projects/689616473831/locations/global/workloadIdentityPools/teaching-vacancies/providers/teaching-vacancies
+          gcp-project-id: teacher-vacancy-service
           environment: production
           terraform-base: ${{ matrix.terraform_base }}
           validation-plan: ${{ matrix.validation_plan }}
           service: ${{ vars.TEAMS_MSG_SERVICE_NAME }}
           teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL_INFRA }}
           image-prefix: main-
+          confirm-production: YES
+          terraform-version-file: ${{ matrix.terraform_version_file }}


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/lr3FXIjQ/2864-validate-infra-tv

## Context
Validate Infra action failing for teaching-vacancies.

## Changes in this PR:
Added _confirm-production_ flag as required - sent through to github-actions Validate Infra workflow.
Configured _AWS and GCP authentication_ to resolve failures caused by these not being present.
Directly specified the _terraform_version_file_ location.

Changes relate directly to the Validate Infra workflow in github-actions service, but there is no dependency between merges apart from those mentioned during testing in **Guidance to review**, below.

## Guidance to review
Ensure both PRs are merged before testing.
Run Validate Infra workflow in teaching-vacancies against main branch, as follows:

- Take a branch off this branch
- Set target-branch: 2864-validate-infra-fix
- Change `uses: DFE-Digital/github-actions/validate-infra@main` to `uses: DFE-Digital/github-actions/validate-infra@2864-validate-infra-fix`
- Run the workflow against this branch

**Please note:** the workflow will still report drift, but this is either:

- expected due to console changes (secrets added/changed/removed or Postgres server storage manually changed), or
- due to a known issue with the Postgres module in terraform-modules that is to be raised in a separate trello card.

## Checklists:

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the Devops label
- [x] I have attached the pull request to the trello card

### Integration Impact

None
