### PR TITLE
Ensure users cannot navigated to delete school pages

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -21,9 +21,7 @@ class OrganisationsController < ApplicationController
   end
 
   def set_organisation
-    @organisation = Organisation.visible_to_jobseekers
-                                .where.not(detailed_school_type: Organisation::FE_DETAILED_SCHOOL_TYPE)
-                                .friendly.find(params[:id] || params[:organisation_id])
+    @organisation = Organisation.kept.friendly.find(params[:id] || params[:organisation_id])
   end
 
   # :nocov:

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -21,7 +21,9 @@ class OrganisationsController < ApplicationController
   end
 
   def set_organisation
-    @organisation = Organisation.friendly.find(params[:id] || params[:organisation_id])
+    @organisation = Organisation.visible_to_jobseekers
+                                .where.not(detailed_school_type: Organisation::FE_DETAILED_SCHOOL_TYPE)
+                                .friendly.find(params[:id] || params[:organisation_id])
   end
 
   # :nocov:

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -1,4 +1,6 @@
 class OrganisationsController < ApplicationController
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found
+
   before_action :strip_empty_filter_checkboxes, only: %i[index]
 
   before_action :set_organisation, only: %i[show]

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -21,7 +21,7 @@ class OrganisationsController < ApplicationController
   end
 
   def set_organisation
-    @organisation = Organisation.kept.friendly.find(params[:id] || params[:organisation_id])
+    @organisation = Organisation.visible_to_jobseekers.friendly.find(params[:id] || params[:organisation_id])
   end
 
   # :nocov:

--- a/spec/requests/organisations_spec.rb
+++ b/spec/requests/organisations_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe "Organisations" do
+  describe "GET /schools/:id" do
+    it "renders successfully for a school" do
+      school = create(:school)
+      get organisation_path(school)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders successfully for a college" do
+      college = create(:college)
+      get organisation_path(college)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns not found for a soft-deleted organisation" do
+      school = create(:school)
+      school.discard
+      get organisation_path(school)
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/requests/organisations_spec.rb
+++ b/spec/requests/organisations_spec.rb
@@ -14,9 +14,21 @@ RSpec.describe "Organisations" do
       expect(response).to have_http_status(:ok)
     end
 
+    it "renders successfully for a trust" do
+      trust = create(:trust)
+      get organisation_path(trust)
+      expect(response).to have_http_status(:ok)
+    end
+
     it "returns not found for a soft-deleted organisation" do
       school = create(:school)
       school.discard
+      get organisation_path(school)
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns not found for a closed organisation" do
+      school = create(:school, establishment_status: "Closed")
       get organisation_path(school)
       expect(response).to have_http_status(:not_found)
     end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/S47xzDYV/3026-exclude-deleted-orgs-from-org-listing-pages

## Changes in this PR:

This ticket ensures users cannot view the organisation page for a soft deleted organisation, or any organisation that does not show on our schools/colleges index page.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
