### PR TITLE
Do not apply simple formatting to HTML adverts

### DIFF
--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -45,6 +45,18 @@ module VacanciesHelper
     items.reject(&:blank?).map(&:humanize).join(", ")
   end
 
+  # Job adverts accept two formats (documented in the ATS API schema): HTML markup
+  # restricted to the tags allowed by `config.action_view.sanitized_allowed_tags`,
+  # or plain text where newlines map to br/p tags.
+  def formatted_job_advert(job_advert)
+    if job_advert&.match?(%r{</?(#{Regexp.union(ActionView::Base.sanitized_allowed_tags.to_a)})[\s/>]}i)
+      # The ApplicationHelper#sanitize override returns a plain String, so re-mark the sanitised output as safe.
+      sanitize(job_advert).html_safe
+    else
+      simple_format(job_advert)
+    end
+  end
+
   def vacancy_form_type(vacancy)
     return t("publishers.vacancies.application_form_type.uploaded_document") if vacancy.uploaded_form?
 

--- a/app/views/vacancies/listing/_job_details.html.slim
+++ b/app/views/vacancies/listing/_job_details.html.slim
@@ -70,7 +70,7 @@ section#job-details class="govuk-!-margin-bottom-5"
     .govuk-body.editor-rendered-content == vacancy.skills_and_experience
   - elsif vacancy.job_advert.present?
     h2.govuk-heading-m = t("jobs.job_summary", job_title: vacancy.job_title)
-    .govuk-body.editor-rendered-content == simple_format(vacancy.job_advert)
+    .govuk-body.editor-rendered-content == formatted_job_advert(vacancy.job_advert)
 
   - if vacancy.school_offer.present?
     h2.govuk-heading-m = t("jobs.school_offer.jobseeker.#{school_or_college_type(vacancy.organisation)}")

--- a/spec/helpers/vacancies_helper_spec.rb
+++ b/spec/helpers/vacancies_helper_spec.rb
@@ -29,6 +29,62 @@ RSpec.describe VacanciesHelper do
     end
   end
 
+  describe "#formatted_job_advert" do
+    subject { helper.formatted_job_advert(job_advert) }
+
+    context "when the job advert contains HTML markup" do
+      let(:job_advert) { "<p>We are hiring.</p>\n<ul>\n<li>Teach</li>\n<li>Mark</li>\n</ul>" }
+
+      it "renders the markup without inserting br tags for newlines between tags" do
+        expect(subject).to eq("<p>We are hiring.</p>\n<ul>\n<li>Teach</li>\n<li>Mark</li>\n</ul>")
+      end
+
+      it "is html safe" do
+        expect(subject).to be_html_safe
+      end
+    end
+
+    context "when the job advert contains HTML markup with disallowed tags or attributes" do
+      let(:job_advert) do
+        "<p style=\"color: red\"><span>Apply</span> <strong>now</strong></p>" \
+          "<script>alert('x')</script>" \
+          "<a href=\"https://example.com\" target=\"_blank\">school website</a>"
+      end
+
+      it "strips disallowed tags and attributes but keeps allowed ones" do
+        expect(subject).to eq("<p>Apply <strong>now</strong></p>alert('x')<a href=\"https://example.com\" target=\"_blank\">school website</a>")
+      end
+    end
+
+    context "when the job advert contains an ordered list" do
+      let(:job_advert) { "<ol><li>First</li><li>Second</li></ol>" }
+
+      it "strips the ol tag but keeps the list items" do
+        expect(subject).to eq("<li>First</li><li>Second</li>")
+      end
+    end
+
+    context "when the job advert is plain text" do
+      let(:job_advert) { "We are hiring.\nApply now.\n\nInterviews next week. 1 < 2" }
+
+      it "converts single newlines to br tags and double newlines to paragraphs" do
+        expect(subject).to eq("<p>We are hiring.\n<br />Apply now.</p>\n\n<p>Interviews next week. 1 &lt; 2</p>")
+      end
+
+      it "is html safe" do
+        expect(subject).to be_html_safe
+      end
+    end
+
+    context "when the job advert is nil" do
+      let(:job_advert) { nil }
+
+      it "returns an empty paragraph" do
+        expect(subject).to eq("<p></p>")
+      end
+    end
+  end
+
   describe "#tag_name" do
     subject { helper.tag_name(vacancy) }
 


### PR DESCRIPTION


## Trello card URL
- https://trello.com/c/lpzNsZNW

## Changes in this PR:

When an integration publishers (ATS or legacy) provides the job advert as HTML, we strip many of the tags. But we also apply the simple formatting (meant for formatting plain text) to it.

This causes extra line breaks and paragraphs into an advert that is providing their own formatting already.

We are checking if the advert contains html tags and the sanitize it and display it as it is.

The simple formatting will satay exclusively for plain text adverts.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
