### PR TITLE
Limit external vacancies to in scope orgs

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -71,6 +71,9 @@ class Organisation < ApplicationRecord
   scope :visible_to_jobseekers, -> { schools_visible_to_jobseekers.or(Organisation.kept.trusts_not_closed) }
 
   scope :colleges, -> { where(school_type: COLLEGE_SCHOOL_TYPE, detailed_school_type: FE_DETAILED_SCHOOL_TYPE) }
+  scope :not_fe_colleges, -> { where.not(id: colleges) }
+  # FE colleges may only publish vacancies manually during the private beta; discarded organisations must never match.
+  scope :eligible_for_external_publishing, -> { kept.not_fe_colleges }
 
   scope :in_scope_schools, -> { schools.kept.not_out_of_scope.where.not(school_type: COLLEGE_SCHOOL_TYPE).or(Organisation.trusts) }
 

--- a/app/services/publishers/ats_api/organisation_fetcher.rb
+++ b/app/services/publishers/ats_api/organisation_fetcher.rb
@@ -17,16 +17,16 @@ module Publishers
       private
 
       def find_trust(trust_uid)
-        SchoolGroup.trusts.find_by(uid: trust_uid) if trust_uid.present?
+        SchoolGroup.trusts.kept.find_by(uid: trust_uid) if trust_uid.present?
       end
 
       def find_schools(trust, school_urns)
         return if school_urns.blank?
 
         if trust
-          trust.schools.where(urn: school_urns)
+          trust.schools.eligible_for_external_publishing.where(urn: school_urns)
         else
-          ::Organisation.where(urn: school_urns)
+          ::Organisation.eligible_for_external_publishing.where(urn: school_urns)
         end
       end
 

--- a/app/services/vacancies/import/shared.rb
+++ b/app/services/vacancies/import/shared.rb
@@ -7,6 +7,13 @@ module Vacancies::Import
       (schools.map(&:detailed_school_type) & School::OUT_OF_SCOPE_DETAILED_SCHOOL_TYPES).present?
     end
 
+    # Soft-deleted organisations and FE colleges must not publish vacancies through feed integrations.
+    # Items whose URNs only match such organisations are skipped instead of falling back to their trust.
+    def no_importable_organisations?(trust, school_urns, schools)
+      (trust.blank? && schools.blank?) ||
+        (school_urns.present? && schools.blank? && Organisation.exists?(urn: school_urns))
+    end
+
     # Our system only imports MAT type trusts from GIAS DB.
     # If a feed provides a vacancy associated to a central trust that is not a MAT, no trust will be found in our DB
     # so no orgs/schools would be associated with the vacancy.

--- a/app/services/vacancies/import/sources/broadbean.rb
+++ b/app/services/vacancies/import/sources/broadbean.rb
@@ -161,17 +161,17 @@ class Vacancies::Import::Sources::Broadbean
   end
 
   def find_schools(item)
-    multi_academy_trust = SchoolGroup.trusts.find_by(uid: item["trustUID"]) if item["trustUID"].present?
+    multi_academy_trust = SchoolGroup.trusts.kept.find_by(uid: item["trustUID"]) if item["trustUID"].present?
 
     school_urns = item["schoolUrns"]&.split(",")
-    schools = Organisation.where(urn: school_urns) if school_urns.present?
+    schools = Organisation.eligible_for_external_publishing.where(urn: school_urns) if school_urns.present?
 
-    return [] if multi_academy_trust.blank? && schools.blank?
+    return [] if no_importable_organisations?(multi_academy_trust, school_urns, schools)
     return schools if multi_academy_trust.blank?
     return Array(multi_academy_trust) if schools.blank?
 
     # When having both trust and schools, only return the schools that are in the trust if any. Otherwise, return the trust itself.
-    multi_academy_trust.schools.where(urn: school_urns).order(:created_at).presence || Array(multi_academy_trust)
+    multi_academy_trust.schools.eligible_for_external_publishing.where(urn: school_urns).order(:created_at).presence || Array(multi_academy_trust)
   end
 
   def items

--- a/app/services/vacancies/import/sources/broadbean.rb
+++ b/app/services/vacancies/import/sources/broadbean.rb
@@ -161,6 +161,7 @@ class Vacancies::Import::Sources::Broadbean
   end
 
   def find_schools(item)
+    multi_academy_trust = nil
     multi_academy_trust = SchoolGroup.trusts.kept.find_by(uid: item["trustUID"]) if item["trustUID"].present?
 
     school_urns = item["schoolUrns"]&.split(",")

--- a/app/services/vacancies/import/sources/fusion.rb
+++ b/app/services/vacancies/import/sources/fusion.rb
@@ -106,6 +106,7 @@ class Vacancies::Import::Sources::Fusion
   end
 
   def find_schools(item)
+    multi_academy_trust = nil
     multi_academy_trust = SchoolGroup.trusts.kept.find_by(uid: item["trustUID"]) if item["trustUID"].present?
 
     school_urns = item["schoolUrns"]&.split(",")

--- a/app/services/vacancies/import/sources/fusion.rb
+++ b/app/services/vacancies/import/sources/fusion.rb
@@ -106,17 +106,17 @@ class Vacancies::Import::Sources::Fusion
   end
 
   def find_schools(item)
-    multi_academy_trust = SchoolGroup.trusts.find_by(uid: item["trustUID"]) if item["trustUID"].present?
+    multi_academy_trust = SchoolGroup.trusts.kept.find_by(uid: item["trustUID"]) if item["trustUID"].present?
 
     school_urns = item["schoolUrns"]&.split(",")
-    schools = Organisation.where(urn: school_urns) if school_urns.present?
+    schools = Organisation.eligible_for_external_publishing.where(urn: school_urns) if school_urns.present?
 
-    return [] if multi_academy_trust.blank? && schools.blank?
+    return [] if no_importable_organisations?(multi_academy_trust, school_urns, schools)
     return schools if multi_academy_trust.blank?
     return Array(multi_academy_trust) if schools.blank?
 
     # When having both trust and schools, only return the schools that are in the trust if any. Otherwise, return the trust itself.
-    multi_academy_trust.schools.where(urn: school_urns).order(:created_at).presence || Array(multi_academy_trust)
+    multi_academy_trust.schools.eligible_for_external_publishing.where(urn: school_urns).order(:created_at).presence || Array(multi_academy_trust)
   end
 
   def job_roles_for(item)

--- a/app/services/vacancies/import/sources/vacancy_poster.rb
+++ b/app/services/vacancies/import/sources/vacancy_poster.rb
@@ -112,17 +112,17 @@ class Vacancies::Import::Sources::VacancyPoster
   end
 
   def find_schools(item)
-    multi_academy_trust = SchoolGroup.trusts.find_by(uid: item["trustUID"].strip) if item["trustUID"].present?
+    multi_academy_trust = SchoolGroup.trusts.kept.find_by(uid: item["trustUID"].strip) if item["trustUID"].present?
 
     school_urn = item["schoolUrns"]&.strip
-    schools = Organisation.where(urn: school_urn) if school_urn.present?
+    schools = Organisation.eligible_for_external_publishing.where(urn: school_urn) if school_urn.present?
 
-    return [] if multi_academy_trust.blank? && schools.blank?
+    return [] if no_importable_organisations?(multi_academy_trust, school_urn, schools)
     return schools if multi_academy_trust.blank?
     return Array(multi_academy_trust) if schools.blank?
 
     # When having both trust and schools, only return the schools that are in the trust if any. Otherwise, return the trust itself.
-    multi_academy_trust.schools.where(urn: school_urn).order(:created_at).presence || Array(multi_academy_trust)
+    multi_academy_trust.schools.eligible_for_external_publishing.where(urn: school_urn).order(:created_at).presence || Array(multi_academy_trust)
   end
 
   def job_roles_for(item)

--- a/app/services/vacancies/import/sources/vacancy_poster.rb
+++ b/app/services/vacancies/import/sources/vacancy_poster.rb
@@ -112,6 +112,7 @@ class Vacancies::Import::Sources::VacancyPoster
   end
 
   def find_schools(item)
+    multi_academy_trust = nil
     multi_academy_trust = SchoolGroup.trusts.kept.find_by(uid: item["trustUID"].strip) if item["trustUID"].present?
 
     school_urn = item["schoolUrns"]&.strip

--- a/app/services/vacancies/import/sources/ventrus.rb
+++ b/app/services/vacancies/import/sources/ventrus.rb
@@ -105,15 +105,16 @@ class Vacancies::Import::Sources::Ventrus
   def find_schools(item)
     return [] if item["TrustUID"] != VENTRUS_TRUST_UID
 
-    multi_academy_trust = SchoolGroup.trusts.find_by(uid: item["TrustUID"])
+    multi_academy_trust = SchoolGroup.trusts.kept.find_by(uid: item["TrustUID"])
     return [] if multi_academy_trust.blank?
 
     school_urns = item["URN"]&.split(",")
-    schools = Organisation.where(urn: school_urns) if school_urns.present?
+    schools = Organisation.eligible_for_external_publishing.where(urn: school_urns) if school_urns.present?
+    return [] if no_importable_organisations?(multi_academy_trust, school_urns, schools)
     return Array(multi_academy_trust) if schools.blank?
 
     # When having both trust and schools, only return the schools that are in the trust if any. Otherwise, return the trust itself.
-    multi_academy_trust.schools.where(urn: school_urns).order(:created_at).presence || Array(multi_academy_trust)
+    multi_academy_trust.schools.eligible_for_external_publishing.where(urn: school_urns).order(:created_at).presence || Array(multi_academy_trust)
   end
 
   def job_roles_for(item)

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -226,6 +226,29 @@ RSpec.describe Organisation do
     end
   end
 
+  describe ".not_fe_colleges" do
+    let!(:school) { create(:school) }
+    let!(:trust) { create(:trust) }
+    let!(:college) { create(:college) }
+
+    it "returns schools and trusts but excludes FE colleges" do
+      expect(Organisation.not_fe_colleges).to contain_exactly(school, trust)
+    end
+  end
+
+  describe ".eligible_for_external_publishing" do
+    let!(:school) { create(:school) }
+    let!(:trust) { create(:trust) }
+    let!(:discarded_school) { create(:school, :discarded) }
+    let!(:college) { create(:college) }
+    let!(:discarded_college) { create(:college, :discarded) }
+    let!(:discarded_trust) { create(:trust, discarded_at: Time.current) }
+
+    it "returns kept non-FE-college organisations only" do
+      expect(Organisation.eligible_for_external_publishing).to contain_exactly(school, trust)
+    end
+  end
+
   describe ".visible_to_jobseekers" do
     let!(:open_school) { create(:school, establishment_status: "Open", detailed_school_type: "Primary school") }
     let(:closed_school) { create(:school, establishment_status: "Closed", detailed_school_type: "Secondary school").tap(&:discard) }

--- a/spec/services/publishers/ats_api/create_vacancy_service_spec.rb
+++ b/spec/services/publishers/ats_api/create_vacancy_service_spec.rb
@@ -462,6 +462,66 @@ RSpec.describe Publishers::AtsApi::CreateVacancyService do
       end
     end
 
+    context "when the given school is soft-deleted" do
+      let(:discarded_school) { create(:school, :discarded) }
+      let(:school_urns) { { school_urns: [discarded_school.urn] } }
+
+      it "raises InvalidOrganisationError" do
+        expect { create_vacancy_service }.to raise_error(
+          Publishers::AtsApi::OrganisationFetcher::InvalidOrganisationError,
+          "No valid organisations found",
+        )
+      end
+    end
+
+    context "when the given school is an FE college" do
+      let(:college) { create(:college) }
+      let(:school_urns) { { school_urns: [college.urn] } }
+
+      it "raises InvalidOrganisationError" do
+        expect { create_vacancy_service }.to raise_error(
+          Publishers::AtsApi::OrganisationFetcher::InvalidOrganisationError,
+          "No valid organisations found",
+        )
+      end
+    end
+
+    context "when the given trust is soft-deleted" do
+      let(:trust) { create(:trust, discarded_at: Time.current) }
+      let(:organisations) { { trust_uid: trust.uid } }
+
+      it "raises InvalidOrganisationError" do
+        expect { create_vacancy_service }.to raise_error(
+          Publishers::AtsApi::OrganisationFetcher::InvalidOrganisationError,
+          "No valid organisations found",
+        )
+      end
+    end
+
+    context "when the given school within the given trust is soft-deleted" do
+      let(:discarded_school) { create(:school, :discarded) }
+      let(:trust) { create(:trust, schools: [discarded_school]) }
+      let(:organisations) { { trust_uid: trust.uid, school_urns: [discarded_school.urn] } }
+
+      it "raises InvalidOrganisationError" do
+        expect { create_vacancy_service }.to raise_error(
+          Publishers::AtsApi::OrganisationFetcher::InvalidOrganisationError,
+          "No valid organisations found",
+        )
+      end
+    end
+
+    context "when an FE college and a valid school are both provided" do
+      let(:college) { create(:college) }
+      let(:school_urns) { { school_urns: [college.urn, school.urn] } }
+
+      it "only assigns the vacancy to the valid school" do
+        create_vacancy_service
+        vacancy = PublishedVacancy.last
+        expect(vacancy.organisations).to contain_exactly(school)
+      end
+    end
+
     context "when the vacancy is missing mandatory fields" do
       let(:job_title) { nil }
       let(:job_advert) { nil }

--- a/spec/services/publishers/ats_api/update_vacancy_service_spec.rb
+++ b/spec/services/publishers/ats_api/update_vacancy_service_spec.rb
@@ -156,6 +156,18 @@ RSpec.describe Publishers::AtsApi::UpdateVacancyService do
       end
     end
 
+    context "when the given school is an FE college" do
+      let(:college) { create(:college) }
+      let(:school_urns) { { school_urns: [college.urn] } }
+
+      it "raises Publishers::AtsApi::CreateVacancyService::InvalidOrganisationError" do
+        expect { update_vacancy_service }.to raise_error(
+          Publishers::AtsApi::OrganisationFetcher::InvalidOrganisationError,
+          "No valid organisations found",
+        )
+      end
+    end
+
     context "when the vacancy fails validation" do
       let(:job_title) { nil }
       let(:job_advert) { nil }

--- a/spec/services/publishers/ats_api/update_vacancy_service_spec.rb
+++ b/spec/services/publishers/ats_api/update_vacancy_service_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Publishers::AtsApi::UpdateVacancyService do
       let(:college) { create(:college) }
       let(:school_urns) { { school_urns: [college.urn] } }
 
-      it "raises Publishers::AtsApi::CreateVacancyService::InvalidOrganisationError" do
+      it "raises Publishers::AtsApi::OrganisationFetcher::InvalidOrganisationError" do
         expect { update_vacancy_service }.to raise_error(
           Publishers::AtsApi::OrganisationFetcher::InvalidOrganisationError,
           "No valid organisations found",

--- a/spec/services/vacancies/import/sources/broadbean_spec.rb
+++ b/spec/services/vacancies/import/sources/broadbean_spec.rb
@@ -380,6 +380,26 @@ RSpec.describe Vacancies::Import::Sources::Broadbean do
           expect(subject.count).to eq(0)
         end
       end
+
+      context "when the school is soft-deleted" do
+        before do
+          school2.discard
+        end
+
+        it "does not import vacancy" do
+          expect(subject.count).to eq(0)
+        end
+      end
+
+      context "when the school is an FE college" do
+        before do
+          school2.update(school_type: School::COLLEGE_SCHOOL_TYPE, detailed_school_type: School::FE_DETAILED_SCHOOL_TYPE)
+        end
+
+        it "does not import vacancy" do
+          expect(subject.count).to eq(0)
+        end
+      end
     end
 
     context "when visa_sponsorship_available field is not supplied" do

--- a/spec/services/vacancies/import/sources/fusion_spec.rb
+++ b/spec/services/vacancies/import/sources/fusion_spec.rb
@@ -440,6 +440,45 @@ RSpec.describe Vacancies::Import::Sources::Fusion do
         end
       end
 
+      context "when the school is soft-deleted" do
+        let(:discarded_school) { create(:school, :discarded, urn: "333333") }
+        let(:school_urns) { [discarded_school.urn] }
+        let(:trust_uid) { nil }
+
+        it "does not import vacancy" do
+          expect(subject.count).to eq(0)
+        end
+      end
+
+      context "when the school is an FE college" do
+        let(:college) { create(:college, urn: "444444") }
+        let(:school_urns) { [college.urn] }
+        let(:trust_uid) { nil }
+
+        it "does not import vacancy" do
+          expect(subject.count).to eq(0)
+        end
+      end
+
+      context "when a soft-deleted school belongs to the given trust" do
+        let(:discarded_school) { create(:school, :discarded, urn: "333333") }
+        let(:trust_schools) { [discarded_school] }
+        let(:school_urns) { [discarded_school.urn] }
+
+        it "does not import vacancy" do
+          expect(subject.count).to eq(0)
+        end
+      end
+
+      context "when the trust is soft-deleted" do
+        let!(:school_group) { create(:school_group, name: "E-ACT", uid: "12345", schools: trust_schools, discarded_at: Time.current) }
+        let(:school_urns) { [] }
+
+        it "does not import vacancy" do
+          expect(subject.count).to eq(0)
+        end
+      end
+
       context "when the vacancy is associated with multiple schools from a trust" do
         let!(:school2) { create(:school, name: "Test School 2", urn: "222222", phase: :primary) }
         let(:trust_schools) { [school1, school2].sort_by(&:created_at) }

--- a/spec/services/vacancies/import/sources/fusion_spec.rb
+++ b/spec/services/vacancies/import/sources/fusion_spec.rb
@@ -521,6 +521,25 @@ RSpec.describe Vacancies::Import::Sources::Fusion do
         end
       end
 
+      context "when no school URNs are provided" do
+        let(:response_body) do
+          JSON.parse(super()).tap { |h| h[0].delete("schoolUrns") }.to_json
+        end
+
+        it "assigns the vacancy to the trust" do
+          expect(vacancy.organisations).to contain_exactly(school_group)
+        end
+      end
+
+      context "when the school URN does not belong to the given trust" do
+        let!(:other_school) { create(:school, name: "Outside School", urn: "999999", phase: :primary) }
+        let(:school_urns) { [other_school.urn] }
+
+        it "assigns the vacancy to the trust" do
+          expect(vacancy.organisations).to contain_exactly(school_group)
+        end
+      end
+
       context "when the school doesn't belong to a school group" do
         let(:school2) { create(:school, name: "Test School 2", urn: "222222", phase: :primary) }
         let(:school_urns) { [school2.urn] }

--- a/spec/services/vacancies/import/sources/vacancy_poster_spec.rb
+++ b/spec/services/vacancies/import/sources/vacancy_poster_spec.rb
@@ -271,6 +271,42 @@ RSpec.describe Vacancies::Import::Sources::VacancyPoster do
       end
     end
 
+    describe "vacancy organisation parsing" do
+      let!(:school_group) { create(:school_group, name: "E-ACT", uid: "TRUST01", schools: trust_schools) }
+      let(:trust_schools) { [school1] }
+      let(:response_body) do
+        super().gsub("<trustUID><![CDATA[ ]]></trustUID>", "<trustUID><![CDATA[TRUST01]]></trustUID>")
+      end
+
+      context "when the vacancy belongs to a school within the trust" do
+        it "assigns the vacancy to the school" do
+          expect(vacancy.organisations).to contain_exactly(school1)
+        end
+      end
+
+      context "when the vacancy belongs to the central trust office" do
+        let(:response_body) do
+          super().gsub("<schoolUrns><![CDATA[123456]]></schoolUrns>", "<schoolUrns><![CDATA[]]></schoolUrns>")
+        end
+
+        it "assigns the vacancy to the trust" do
+          expect(vacancy.organisations).to contain_exactly(school_group)
+        end
+      end
+
+      context "when the school URN does not belong to the given trust" do
+        let(:trust_schools) { [] }
+        let!(:other_school) { create(:school, name: "Outside School", urn: "999999", phase: :primary) }
+        let(:response_body) do
+          super().gsub("<schoolUrns><![CDATA[123456]]></schoolUrns>", "<schoolUrns><![CDATA[#{other_school.urn}]]></schoolUrns>")
+        end
+
+        it "assigns the vacancy to the trust" do
+          expect(vacancy.organisations).to contain_exactly(school_group)
+        end
+      end
+    end
+
     context "when the same vacancy has been imported previously" do
       let!(:existing_vacancy) do
         create(

--- a/spec/services/vacancies/import/sources/vacancy_poster_spec.rb
+++ b/spec/services/vacancies/import/sources/vacancy_poster_spec.rb
@@ -64,6 +64,26 @@ RSpec.describe Vacancies::Import::Sources::VacancyPoster do
       end
     end
 
+    context "when the school is soft-deleted" do
+      before do
+        school1.discard
+      end
+
+      it "does not import vacancy" do
+        expect(subject.count).to eq(0)
+      end
+    end
+
+    context "when the school is an FE college" do
+      before do
+        school1.update(school_type: School::COLLEGE_SCHOOL_TYPE, detailed_school_type: School::FE_DETAILED_SCHOOL_TYPE)
+      end
+
+      it "does not import vacancy" do
+        expect(subject.count).to eq(0)
+      end
+    end
+
     describe "working_patterns mapping" do
       context "when working_patterns includes `flexible`" do
         let(:response_body) { super().gsub("full_time", "full_time,flexible") }

--- a/spec/services/vacancies/import/sources/ventrus_spec.rb
+++ b/spec/services/vacancies/import/sources/ventrus_spec.rb
@@ -350,6 +350,35 @@ RSpec.describe Vacancies::Import::Sources::Ventrus do
       end
     end
 
+    context "when the school is soft-deleted" do
+      before do
+        school1.discard
+      end
+
+      it "does not import vacancy" do
+        expect(subject.count).to eq(0)
+      end
+    end
+
+    context "when the school is an FE college" do
+      before do
+        school1.update(school_type: School::COLLEGE_SCHOOL_TYPE, detailed_school_type: School::FE_DETAILED_SCHOOL_TYPE)
+      end
+
+      it "does not import vacancy" do
+        expect(subject.count).to eq(0)
+      end
+    end
+
+    context "when the school group is soft-deleted" do
+      let!(:school_group) { create(:school_group, name: "Ventrus", uid: "4243", schools: schools, discarded_at: Time.current) }
+      let(:response_body) { super().gsub("111111", "") }
+
+      it "does not import vacancy" do
+        expect(subject.count).to eq(0)
+      end
+    end
+
     context "when visa_sponsorship_available field is not supplied" do
       let(:response_body) { file_fixture("vacancy_sources/ventrus_without_visa_sponsorship_available.xml").read }
 


### PR DESCRIPTION


## Trello card URL
https://trello.com/c/kgDF2GGi

## Changes in this PR:

Do not allow external vacancies (either from the legacy integrations or from the ATS API) for organisations that are either deleted in our system or FE colleges.

As they're out of scope for our current stage of the FE expansion and "deleted" orgs shouldn't be matchable in our system.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
