### PR TITLE
Add overrides to ensure ccorrect location names + titalisation

### DIFF
--- a/app/models/location_landing_page.rb
+++ b/app/models/location_landing_page.rb
@@ -20,7 +20,9 @@ class LocationLandingPage < LandingPage
   end
 
   def name
-    (MAPPED_LOCATIONS[location.tr("-", " ")] || location).titleize.gsub(/\bAnd\b/, "and")
+    key = location.tr("-", " ")
+
+    (MAPPED_LOCATIONS[key] || location).titleize.gsub(/\b(And|Of|The|Upon)\b/, &:downcase)
   end
 
   private


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/R00ZieDO/3031-text-updates-main-page-schools-and-colleges-jobs-by-location

## Changes in this PR:

Add method to strip the upcase from certain link words (like upon and The). Add an exception for Yorkshire and the Humber.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
