### PR TITLE
ensure SolidQueueJob uses solid queue adapter

### DIFF
--- a/app/jobs/solid_queue_job.rb
+++ b/app/jobs/solid_queue_job.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
 class SolidQueueJob < ApplicationJob
+  # :nocov:
+  # Set the adapter explicitly, otherwise this uses the default one (which might be sidekiq)
+  self.queue_adapter = :sidekiq unless Rails.env.test?
+  # :nocov:
+
   retry_on StandardError, attempts: 10
 end


### PR DESCRIPTION
## Changes in this PR:

While testing solid queue for Alert emails, the time was changed for testing (because this line was forgotten). When merging the change was dropped (safer than merging change + revert) but this line was dropped too, hence AlertEmails still ran in sidekiq