### PR TITLE
Add processing of job alerts queue to Solid Queue

### DIFF
--- a/config/queue.yml
+++ b/config/queue.yml
@@ -3,7 +3,7 @@ default: &default
     - polling_interval: 1
       batch_size: 500
   workers:
-    - queues: [ low, default, notify, solid_queue_recurring ]
+    - queues: [ low, default, notify, solid_queue_recurring, jobalerts ]
       threads: 3
       processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
       polling_interval: 0.5


### PR DESCRIPTION
## Changes in this PR:

Need to process the 'jobalerts' queue in production for solid queue