### PR TITLE
Make solid queue the default queue, override DfeAnaytics config

### DIFF
--- a/app/jobs/solid_queue_job.rb
+++ b/app/jobs/solid_queue_job.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
 class SolidQueueJob < ApplicationJob
-  # :nocov:
-  # Set the adapter explicitly, otherwise this uses the default one (which might be sidekiq)
-  self.queue_adapter = :solid_queue unless Rails.env.test?
-  # :nocov:
-
   retry_on StandardError, attempts: 10
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -68,7 +68,8 @@ module TeachingVacancies
     # Use custom error pages
     config.exceptions_app = routes
 
-    config.active_job.queue_adapter = :sidekiq
+    # DfeAnalytics is hooked into Sidekiq as its the biggest generator of job traffic
+    config.active_job.queue_adapter = :solid_queue
 
     # we have multiple mailers (Notify and Smtp) so can't configure here
     # config.action_mailer.delivery_method = :notify

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -64,8 +64,7 @@ DfE::Analytics.configure do |config|
   config.azure_federated_auth = ENV.include? "GOOGLE_CLOUD_CREDENTIALS"
 end
 
-#  Temp - run DfEAnalytics Jobs on sidekiq.
-# Config doesn't allow override of queue adapter
+# Temporary: run DfE Analytics jobs on Sidekiq (the gem doesn't allow overriding the ActiveJob adapter).
 module DfE
   module Analytics
     module Jobs

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -69,9 +69,11 @@ end
 module DfE
   module Analytics
     module Jobs
-      class AnalyticsJob < ApplicationJob
+      # rubocop:disable Rails/ApplicationJob
+      class AnalyticsJob < ActiveJob::Base
         self.queue_adapter = :sidekiq
       end
+      # rubocop:enable Rails/ApplicationJob
     end
   end
 end

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -63,3 +63,14 @@ DfE::Analytics.configure do |config|
 
   config.azure_federated_auth = ENV.include? "GOOGLE_CLOUD_CREDENTIALS"
 end
+
+#  Temp - run DfEAnalytics Jobs on sidekiq
+module DfE
+  module Analytics
+    module Jobs
+      class AnalyticsJob < ApplicationJob
+        self.queue_adapter = :sidekiq
+      end
+    end
+  end
+end

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -64,7 +64,8 @@ DfE::Analytics.configure do |config|
   config.azure_federated_auth = ENV.include? "GOOGLE_CLOUD_CREDENTIALS"
 end
 
-#  Temp - run DfEAnalytics Jobs on sidekiq
+#  Temp - run DfEAnalytics Jobs on sidekiq.
+# Config doesn't allow override of queue adapter
 module DfE
   module Analytics
     module Jobs

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -71,7 +71,9 @@ module DfE
     module Jobs
       # rubocop:disable Rails/ApplicationJob
       class AnalyticsJob < ActiveJob::Base
-        self.queue_adapter = :sidekiq
+        # :nocov:
+        self.queue_adapter = :sidekiq unless Rails.env.test?
+        # :nocov:
       end
       # rubocop:enable Rails/ApplicationJob
     end


### PR DESCRIPTION
## Changes in this PR:

Make solid queue the default queue backend, ovrerride the DfeAnaltics version