### PR TITLE
Fix expires_at validation for integrations

### DIFF
--- a/app/validators/external_vacancy_validator.rb
+++ b/app/validators/external_vacancy_validator.rb
@@ -44,12 +44,12 @@ class ExternalVacancyValidator < ActiveModel::Validator
   end
 
   def validate_expiry_date(record)
-    if record.expires_at <= Time.zone.today
+    if record.expires_at.to_date <= Time.zone.today
       record.errors.add(:expires_at, "must be a future date")
     end
 
-    if record.publish_on && record.expires_at <= record.publish_on
-      record.errors.add(:expires_at, "must be later than the publish date")
+    if record.publish_on && record.expires_at.to_date <= record.publish_on
+      record.errors.add(:expires_at, "must be at least one day after the publish date")
     end
   end
 end

--- a/spec/requests/publishers/ats_api/v1/vacancies_spec.rb
+++ b/spec/requests/publishers/ats_api/v1/vacancies_spec.rb
@@ -1073,8 +1073,38 @@ RSpec.describe "ats-api/v1/vacancies", openapi_spec: "v1/swagger.yaml" do
           submit_request(example.metadata)
           assert_response_matches_metadata(example.metadata)
           expect(response.parsed_body).to eq(
-            { "errors" => ["job_title: can't be blank", "external_reference: Enter an external reference", "expires_at: must be a future date", "expires_at: must be later than the publish date"] },
+            { "errors" => ["job_title: can't be blank", "external_reference: Enter an external reference", "expires_at: must be a future date", "expires_at: must be at least one day after the publish date"] },
           )
+        end
+
+        context "when expires_at is later today", document: false do
+          let(:vacancy) do
+            {
+              vacancy: {
+                external_advert_url: "https://www.example.com/ats-site/advertid",
+                expires_at: Time.zone.now.end_of_day.iso8601,
+                job_title: "Teacher of Geography",
+                job_advert: "We're looking for a dedicated Teacher of Geography",
+                salary: "£12,345 to £67,890",
+                external_reference: "REF1234HYZ",
+                job_roles: %w[teacher],
+                working_patterns: %w[full_time],
+                contract_type: "permanent",
+                phases: %w[secondary],
+                schools: {
+                  school_urns: [create(:school).urn],
+                },
+              },
+            }
+          end
+
+          it "rejects the vacancy as expires_at must be at least one day after today & publish date" do |example|
+            submit_request(example.metadata)
+            assert_response_matches_metadata(example.metadata)
+            expect(response.parsed_body).to eq(
+              { "errors" => ["expires_at: must be a future date", "expires_at: must be at least one day after the publish date"] },
+            )
+          end
         end
       end
 

--- a/spec/services/publishers/ats_api/create_vacancy_service_spec.rb
+++ b/spec/services/publishers/ats_api/create_vacancy_service_spec.rb
@@ -563,7 +563,18 @@ RSpec.describe Publishers::AtsApi::CreateVacancyService do
         expect(create_vacancy_service[:status]).to eq :unprocessable_entity
         expect(create_vacancy_service[:json][:errors]).to include(
           "expires_at: must be a future date",
-          "expires_at: must be later than the publish date",
+          "expires_at: must be at least one day after the publish date",
+        )
+      end
+    end
+
+    context "when expires_at is later today" do
+      let(:expires_at) { Time.zone.today.end_of_day }
+
+      it "returns a validation error" do
+        expect(create_vacancy_service[:status]).to eq :unprocessable_entity
+        expect(create_vacancy_service[:json][:errors]).to include(
+          "expires_at: must be a future date",
         )
       end
     end
@@ -577,7 +588,23 @@ RSpec.describe Publishers::AtsApi::CreateVacancyService do
           {
             status: :unprocessable_entity,
             json: {
-              errors: ["expires_at: must be later than the publish date"],
+              errors: ["expires_at: must be at least one day after the publish date"],
+            },
+          },
+        )
+      end
+    end
+
+    context "when expires_at is on the same date as publish_on but later in the day" do
+      let(:expires_at) { (Date.current + 2.weeks).end_of_day }
+      let(:publish_on) { Date.current + 2.weeks }
+
+      it "returns a validation error" do
+        expect(create_vacancy_service).to eq(
+          {
+            status: :unprocessable_entity,
+            json: {
+              errors: ["expires_at: must be at least one day after the publish date"],
             },
           },
         )

--- a/spec/services/publishers/ats_api/update_vacancy_service_spec.rb
+++ b/spec/services/publishers/ats_api/update_vacancy_service_spec.rb
@@ -220,6 +220,23 @@ RSpec.describe Publishers::AtsApi::UpdateVacancyService do
     end
   end
 
+  context "when expires_at is later today" do
+    let(:expires_at) { Time.zone.today.end_of_day }
+
+    it "returns a validation error" do
+      expect(update_vacancy_service).to eq(
+        {
+          status: :unprocessable_entity,
+          json: {
+            errors: [
+              "expires_at: must be a future date",
+            ],
+          },
+        },
+      )
+    end
+  end
+
   context "when expires at is before publish_on" do
     let(:expires_at) { Date.current + 1.week }
     let(:publish_on) { Date.current + 2.weeks }
@@ -229,7 +246,23 @@ RSpec.describe Publishers::AtsApi::UpdateVacancyService do
         {
           status: :unprocessable_entity,
           json: {
-            errors: ["expires_at: must be later than the publish date"],
+            errors: ["expires_at: must be at least one day after the publish date"],
+          },
+        },
+      )
+    end
+  end
+
+  context "when expires_at is on the same date as publish_on but later in the day" do
+    let(:expires_at) { (Date.current + 2.weeks).end_of_day }
+    let(:publish_on) { Date.current + 2.weeks }
+
+    it "returns a validation error" do
+      expect(update_vacancy_service).to eq(
+        {
+          status: :unprocessable_entity,
+          json: {
+            errors: ["expires_at: must be at least one day after the publish date"],
           },
         },
       )

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -225,7 +225,7 @@ RSpec.configure do |config|
                     format: :datetime,
                     example: "2026-04-13T15:30:00",
                     description: "The end datetime of the vacancy in <a href='https://en.wikipedia.org/wiki/ISO_8601'>ISO 8601</a> format." \
-                                 "<br>Must be after the publish date." \
+                                 "<br>Must be at least the day after the publish date (and at least the day after the current date)." \
                                  "<br>Main example without timezone designator (recommended):" \
                                  "<ul><li>2026-04-13T15:30:00</li>" \
                                  "<li>When using this format, the datetime is interpreted in UK time (Europe/London) for the given date, with GMT/BST applied automatically as appropriate.</li></ul>" \

--- a/spec/validators/external_vacancy_validator_spec.rb
+++ b/spec/validators/external_vacancy_validator_spec.rb
@@ -64,6 +64,28 @@ RSpec.describe ExternalVacancyValidator, type: :model do
     end
   end
 
+  context "when expiry date is later today" do
+    before do
+      vacancy.expires_at = Time.zone.today.end_of_day
+      vacancy.validate
+    end
+
+    it "adds an expiry date error" do
+      expect(vacancy.errors[:expires_at]).to include("must be a future date")
+    end
+  end
+
+  context "when expiry date is tomorrow" do
+    before do
+      vacancy.expires_at = Time.zone.tomorrow.beginning_of_day
+      vacancy.validate
+    end
+
+    it "does not add an expiry date error" do
+      expect(vacancy.errors[:expires_at]).to be_empty
+    end
+  end
+
   context "when expiry date is before publish date" do
     before do
       vacancy.publish_on = Date.current + 5.days
@@ -72,7 +94,31 @@ RSpec.describe ExternalVacancyValidator, type: :model do
     end
 
     it "adds an expiry date vs publish date error" do
-      expect(vacancy.errors[:expires_at]).to include("must be later than the publish date")
+      expect(vacancy.errors[:expires_at]).to include("must be at least one day after the publish date")
+    end
+  end
+
+  context "when expiry date is on the same date as the publish date but later in the day" do
+    before do
+      vacancy.publish_on = Date.current + 5.days
+      vacancy.expires_at = (Date.current + 5.days).end_of_day
+      vacancy.validate
+    end
+
+    it "adds an expiry date vs publish date error" do
+      expect(vacancy.errors[:expires_at]).to include("must be at least one day after the publish date")
+    end
+  end
+
+  context "when expiry date is the day after the publish date" do
+    before do
+      vacancy.publish_on = Date.current + 5.days
+      vacancy.expires_at = (Date.current + 6.days).beginning_of_day
+      vacancy.validate
+    end
+
+    it "does not add an expiry date error" do
+      expect(vacancy.errors[:expires_at]).to be_empty
     end
   end
 


### PR DESCRIPTION
## Trello card URL
Another one from ARK dev:

- https://trello.com/c/lpzNsZNW

## Changes in this PR:

Fix the validation on expires_at for external vacancies so:
- The expires_at value must be at least one day after the vacancy gets created.
- Does not allow creating expired vacancies, as it was allowing it (expires_at set as today but before now -> This was accepted).
- Expires_at must be a day after the publish_on (if publish_on is provided).


## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
