### PR TITLE
Content changes to the jobseekers flow

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -989,6 +989,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  arm64-darwin-25
   x86_64-darwin-23
   x86_64-darwin-24
   x86_64-linux

--- a/app/assets/javascript/js_components/wordCounter/wordCounter.js
+++ b/app/assets/javascript/js_components/wordCounter/wordCounter.js
@@ -33,9 +33,9 @@ export default class extends Controller {
   displayCount(wordCount) {
     const formattedCount = this.constructor.formatNumber(wordCount);
     const formattedMax = this.constructor.formatNumber(this.maxWordsValue);
-    const message = `You have written ${formattedCount} words in this section. `
-      + `The word limit for this section is ${formattedMax} words. `
-      + 'Schools typically expect personal statements to be between 500 and 1,000 words long.';
+    const message = `You have written ${formattedCount} words. `
+      + `The word limit is ${formattedMax} words. `
+      + 'Schools typically expect personal statements to be 500 to 1,000 words.';
     this.counterTarget.textContent = message;
   }
 

--- a/app/controllers/jobseekers/profiles_controller.rb
+++ b/app/controllers/jobseekers/profiles_controller.rb
@@ -40,7 +40,7 @@ class Jobseekers::ProfilesController < Jobseekers::BaseController
       title: "Work history",
       display_summary: ->(profile) { profile.employments.any? },
       key: "employments",
-      link_text: "Add roles",
+      link_text: "Add a job or voluntary role",
       page_path: -> { new_jobseekers_profile_work_history_path },
     },
     {

--- a/app/helpers/job_applications_helper.rb
+++ b/app/helpers/job_applications_helper.rb
@@ -13,19 +13,19 @@ module JobApplicationsHelper
   }.freeze
 
   JOBSEEKER_STATUS_MAPPINGS = {
-    deadline_passed: "job closed",
-    draft: "draft",
-    submitted: "submitted",
-    reviewed: "submitted",
-    shortlisted: "shortlisted",
-    unsuccessful: "unsuccessful",
-    rejected: "unsuccessful",
-    withdrawn: "withdrawn",
-    interviewing: "interviewing",
-    unsuccessful_interview: "unsuccessful",
-    action_required: "needs action",
-    offered: "offered",
-    declined: "declined",
+    deadline_passed: "Job closed",
+    draft: "Draft",
+    submitted: "Submitted",
+    reviewed: "Submitted",
+    shortlisted: "Shortlisted",
+    unsuccessful: "Unsuccessful",
+    rejected: "Unsuccessful",
+    withdrawn: "Withdrawn",
+    interviewing: "Interviewing",
+    unsuccessful_interview: "Unsuccessful",
+    action_required: "Needs action",
+    offered: "Offered",
+    declined: "Declined",
   }.freeze
 
   JOB_APPLICATION_STATUS_TAG_COLOURS = {

--- a/app/views/jobseekers/base/_employment_fields.html.slim
+++ b/app/views/jobseekers/base/_employment_fields.html.slim
@@ -4,11 +4,11 @@
 
 = f.govuk_date_field :started_on,
   omit_day: true,
-  hint: -> { t("helpers.hint.date", date: 15.months.ago.strftime("%m %Y")) }
+  hint: -> { t("helpers.hint.date", date: 15.months.ago.strftime("%-m %Y")) }
 = f.govuk_date_field :ended_on,
   omit_day: true,
-  hint: -> { t("helpers.hint.date", date: 3.months.ago.strftime("%m %Y")) }
-= f.govuk_radio_divider
+  hint: -> { t("helpers.hint.date", date: 3.months.ago.strftime("%-m %Y")) }
+= f.govuk_radio_divider "Or"
 = f.govuk_check_box :is_current_role, "true", "false", multiple: false
 
 = f.govuk_text_area :main_duties, label: { size: "s" }, required: true, max_words: Employment::MAIN_DUTIES_MAX_WORDS

--- a/app/views/jobseekers/base/_qts_fields.html.slim
+++ b/app/views/jobseekers/base/_qts_fields.html.slim
@@ -15,4 +15,4 @@
   = f.govuk_radio_button :is_statutory_induction_complete, "true", link_errors: true
   = f.govuk_radio_button :is_statutory_induction_complete, "false" do
     = f.govuk_text_area :statutory_induction_complete_details,
-      label: -> { tag.p(t("helpers.label.jobseekers_profiles_qualified_teacher_status_form.statutory_induction_complete_details", link: govuk_link_to(t("helpers.label.jobseekers_profiles_qualified_teacher_status_form.statutory_induction_complete_details_hint_text"), "https://www.gov.uk/government/publications/induction-for-early-career-teachers-england", target: "_blank")).html_safe) }
+      label: { text: t("helpers.label.jobseekers_profiles_qualified_teacher_status_form.statutory_induction_complete_details") }

--- a/app/views/jobseekers/job_applications/_banner.html.slim
+++ b/app/views/jobseekers/job_applications/_banner.html.slim
@@ -31,4 +31,4 @@
     - if job_application.withdrawn?
       = govuk_button_link_to t("buttons.download_blank_application"), jobseekers_job_application_form_preview_path(job_application, :blank), class: "govuk-button--secondary blank-application"
 
-    = open_in_new_tab_link_to "View this listing", job_path(job_application.vacancy), class: "govuk-!-margin-bottom-0 view-listing-link"
+    = open_in_new_tab_link_to "View job listing", job_path(job_application.vacancy), class: "govuk-!-margin-bottom-0 view-listing-link"

--- a/app/views/jobseekers/job_applications/build/declarations.html.slim
+++ b/app/views/jobseekers/job_applications/build/declarations.html.slim
@@ -8,7 +8,7 @@ p.govuk-body = t(".description1", link_text: open_in_new_tab_link_to(t(".dbs_lin
 p.govuk-body = t(".description2")
 p.govuk-body = t(".description3")
 p.govuk-body = open_in_new_tab_link_to(t(".description4"), "https://www.gov.uk/tell-employer-or-college-about-criminal-record")
-p.govuk-body = t(".description5", link_text: open_in_new_tab_link_to(t(".keep_children_safe_link_text"), kcsie_link)).html_safe
+p.govuk-body = t(".description5")
 
 = form_for @form, url: jobseekers_job_application_build_path(job_application, :declarations), method: :patch do |f|
   = f.govuk_error_summary

--- a/app/views/jobseekers/profiles/employments/_summary.html.slim
+++ b/app/views/jobseekers/profiles/employments/_summary.html.slim
@@ -1,4 +1,4 @@
 p class="govuk-!-margin-bottom-6"
-  = govuk_link_to "Add roles", new_jobseekers_profile_work_history_path
+  = govuk_link_to "Add a job or voluntary role", new_jobseekers_profile_work_history_path
 
 = render "jobseekers/employments/employments", employments: profile.employments

--- a/app/views/jobseekers/profiles/personal_details/_summary.html.slim
+++ b/app/views/jobseekers/profiles/personal_details/_summary.html.slim
@@ -29,9 +29,7 @@ ruby:
     summary_list.with_row do |row|
       row.with_key text: t("jobseekers.profiles.personal_details.summary.email")
       row.with_value text: (current_jobseeker.email +
-                       govuk_inset_text(text: t("helpers.label.personal_details.change_email_html",
-                                              link: govuk_link_to(t("helpers.label.personal_details.change_email_link_text"),
-                                                    jobseekers_account_path)),
+                       govuk_inset_text(text: govuk_link_to(t("helpers.label.personal_details.change_email_link_text"), jobseekers_account_path),
                                         classes: "govuk-!-margin-top-3")).html_safe
     end
   end

--- a/app/views/jobseekers/qualifications/_fields.html.slim
+++ b/app/views/jobseekers/qualifications/_fields.html.slim
@@ -4,6 +4,6 @@
 - when "gcse", "as_level", "a_level"
   = render "jobseekers/qualifications/fields/secondary_school", f: f, category: category
 - when "undergraduate", "postgraduate", "degree"
-  = render "jobseekers/qualifications/fields/degree", f: f
+  = render "jobseekers/qualifications/fields/degree", f: f, category: category
 - when "other"
   = render "jobseekers/qualifications/fields/other", f: f

--- a/app/views/jobseekers/qualifications/fields/_degree.html.slim
+++ b/app/views/jobseekers/qualifications/fields/_degree.html.slim
@@ -1,6 +1,10 @@
-= f.govuk_text_field :institution, label: { size: "s" }, aria: { required: true }
+- institution_label = t("helpers.label.jobseekers_qualifications_degree_form.institution_options.#{category}", default: t("helpers.label.jobseekers_qualifications_degree_form.institution_options.undergraduate"))
+- institution_hint = t("helpers.hint.jobseekers_qualifications_degree_form.institution_options.#{category}", default: nil)
+- subject_label = t("helpers.label.jobseekers_qualifications_degree_form.subject_options.#{category}", default: t("helpers.label.jobseekers_qualifications_degree_form.subject_options.undergraduate"))
 
-= f.govuk_text_field :subject, label: { size: "s" }, aria: { required: true }
+= f.govuk_text_field :institution, label: { size: "s", text: institution_label }, hint: (institution_hint ? { text: institution_hint } : {}), aria: { required: true }
+
+= f.govuk_text_field :subject, label: { size: "s", text: subject_label }, aria: { required: true }
 
 - finished_studying_legend = capture do
   legend.govuk-fieldset__legend.govuk-fieldset__legend--s

--- a/app/views/jobseekers/qualifications/fields/_secondary_school.html.slim
+++ b/app/views/jobseekers/qualifications/fields/_secondary_school.html.slim
@@ -10,7 +10,7 @@
       .inline-fields-container.subject-row class="#{idx > f.object.highest_present_result_index ? "js-hidden" : ""}" data-manage-qualifications-target="row"
         = result_form.govuk_text_field :subject, label: { text: "Subject #{idx + 1}" }, aria: { required: idx.zero? }, form_group: { classes: "govuk-!-width-two-thirds" }
         = result_form.govuk_text_field :grade, aria: { required: idx.zero? }, form_group: { classes: "govuk-!-width-one-third" }, label: { text: "Grade" }
-        = result_form.govuk_text_field :awarding_body, aria: { required: false }, form_group: { classes: "govuk-!-width-one-third" }, label: { text: "Awarding Body (optional)" }
+        = result_form.govuk_text_field :awarding_body, aria: { required: false }, form_group: { classes: "govuk-!-width-one-third" }, label: { text: "Awarding body (optional)" }
         .govuk-form-group.button_to
           button.govuk-button.js-action.govuk-button--secondary class="govuk-!-margin-bottom-0" data-action="manage-qualifications#deleteRow" type="button"
             = "#{t('buttons.delete_subject')} #{idx + 1}"

--- a/app/views/jobseekers/request_account_transfer_emails/new.html.slim
+++ b/app/views/jobseekers/request_account_transfer_emails/new.html.slim
@@ -7,7 +7,7 @@
 
       = f.govuk_email_field :email, label: { text: t(".heading"), tag: "h1", size: "l" }, caption: { text: t(".page_title"), size: "l" }, width: "two-thirds", hint: { text: t(".hint") }, required: true
 
-      = f.govuk_submit t("buttons.save_and_continue"), class: "govuk-!-margin-bottom-5"
+      = f.govuk_submit t(".submit"), class: "govuk-!-margin-bottom-5"
 
     .govuk-button-group
       = govuk_link_to t("buttons.cancel"), jobseekers_profile_path

--- a/app/views/subscriptions/_fields.html.slim
+++ b/app/views/subscriptions/_fields.html.slim
@@ -1,10 +1,10 @@
 = f.govuk_text_field :keyword,
-  label: { text: t("jobs.search.keyword"), size: "s" },
-  hint: { text: t("jobs.search.keyword_hint") },
+  label: { text: t("subscriptions.new.keyword"), size: "s" },
+  hint: { text: t("subscriptions.new.keyword_hint") },
   autocomplete: "off"
 - unless @organisation
   = f.govuk_text_field :location,
-    label: { text: t("jobs.search.location"), size: "s" },
+    label: { text: t("subscriptions.new.location.label"), size: "s" },
     autocomplete: "off",
     form_group: { class: %w[location-finder__input govuk-!-margin-bottom-0 autocomplete], data: { source: "getLocationSuggestions", controller: "autocomplete" } },
     data: { coordinates: @vacancies_search&.point_coordinates || @point_coordinates }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -353,7 +353,10 @@ en:
       description: You can change the search criteria you have used by amending the keywords, location or filters before you create your alert.
       organisation_link_html: This alert will only send you emails about %{organisation_landing_page_link}.
       title: Create your job alert
+      keyword: Job title or keyword
+      keyword_hint: Enter a job title, subject or keyword
       location:
+        label: City, county or postcode in England
         hint: Teaching Vacancies advertises school roles in England. Enter a UK city, county or postcode to look for roles near you.
       campaign:
         title:

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -2,30 +2,30 @@ en:
   buttons:
     accept_all_cookies: Accept all cookies
     accept_and_continue: Accept and continue
-    add_reason_for_break: add a reason for this gap
+    add_reason_for_break: explain this gap
     add_another_job: Add another job
     add_another_qualification: Add another qualification
     add_another_reference: Add another referee
     add_another_subject: Add another subject
     add_education_gap: Add gap between education and work history
-    add_gap: Add gap in work history
+    add_gap: Add a gap in work history
     add_job: Add a job
     add_note: Add note
     add_qualification: Add a qualification
     add_training: Add training
-    add_another_training: Add another training
+    add_another_training: Add another training or CPD activity
     add_another_professional_body_membership: Add another membership
-    add_professional_body_membership: Add membership
+    add_professional_body_membership: Add a membership
     add_referee: Add a referee
     add_reference: Add a reference
-    add_work_history: Add work history
+    add_work_history: Add a job or voluntary role
     apply_filters: Apply filters
     back: Back
     back_to_manage_jobs: Back to manage jobs
     back_to_teaching_vacancies: Back to Teaching Vacancies
     cancel: Cancel
     cancel_and_return: Cancel and return
-    cancel_and_return_to_account: Cancel and return to account
+    cancel_and_return_to_account: Cancel and return to your account
     cancel_copy: Cancel job listing copy
     change: Change
     change_hidden_text_html: Change <span class='govuk-visually-hidden'>%{hidden_text}</span>
@@ -93,7 +93,7 @@ en:
     save_template: Save template
     save_and_finish_later: Save and come back later
     save_changes: Save changes
-    save_employment: Save role
+    save_employment: Save job or voluntary role
     save_note: Save note
     save_qualification:
       one: Save qualification
@@ -170,7 +170,8 @@ en:
         occupation: >-
           We'll only use this to tell you about opportunities to take part in user research that is relevant to you.
       jobseekers_qualifications_degree_form:
-        institution: For example, a university or college
+        institution_options:
+          postgraduate: For example, a university or college
         qualifications_section_completed: Ensure you've added all the education and qualifications you've done.
       jobseekers_qualifications_other_form:
         awarding_body: For example, a university or college
@@ -345,14 +346,14 @@ en:
       jobseekers_qualifications_shared_labels: &jobseekers_qualifications_shared_labels
         category_options:
           gcse: GCSEs
-          as_level: AS Levels
-          a_level: A Levels
+          as_level: AS levels
+          a_level: A levels
           undergraduate: Undergraduate degree
           postgraduate: Postgraduate qualification
           other: Other qualification
-        finished_studying_details: Please give details
+        finished_studying_details: Provide details about your qualification (optional)
         finished_studying_options:
-          false: "Not finished yet"
+          false: "No, I have not completed it yet"
           true: "Yes"
         grade: Grade
         subject: Subject
@@ -386,14 +387,20 @@ en:
         <<: *jobseekers_qualifications_shared_labels
         category_options:
           gcse: GCSEs
-          as_level: AS Levels
-          a_level: A Levels
+          as_level: AS levels
+          a_level: A levels
           undergraduate: Undergraduate degree
           postgraduate: Postgraduate qualification
           other: Other qualification
       jobseekers_qualifications_degree_form:
         <<: *jobseekers_qualifications_shared_labels
         institution: Awarding body
+        institution_options:
+          undergraduate: University or college
+          postgraduate: University, college or awarding body
+        subject_options:
+          undergraduate: Degree subject
+          postgraduate: Qualification subject
         qualifications: Qualifications
         award_date: Year qualification was awarded
       jobseekers_qualifications_other_form:
@@ -404,11 +411,11 @@ en:
         awarding_body: Awarding body (optional)
       jobseekers_qualifications_secondary_common_form:
         <<: *jobseekers_qualifications_shared_labels
-        institution: School, college, or other organisation
+        institution: School, college or other organisation
         award_date: Year qualification was awarded
       jobseekers_training_and_cpd_form:
-        name: Name of course or training
-        provider: Training provider (optional)
+        name: Name of training or course
+        provider: Training provider
         grade: Grade (optional)
         year_awarded: Date completed
         year_completed_hint: For example, 1998
@@ -419,8 +426,8 @@ en:
       jobseekers_subscription_form:
         email: Email address
         frequency_options:
-          daily: Daily, around 3 pm
-          weekly: Weekly (Friday, around 6 pm)
+          daily: Daily, around 3pm
+          weekly: Weekly, on Friday around 6pm
       jobseekers_unsubscribe_feedback_form:
         email: What is your email address?
         comment: Is there anything else you'd like to tell us?
@@ -685,7 +692,7 @@ en:
         employment_history_section_completed: Have you completed this section?
       jobseekers_job_application_equal_opportunities_form:
         age: How old are you?
-        disability: Do you consider yourself to have a disability as defined by the Equality Act 2010?
+        disability: Do you consider yourself to be disabled under the Equality Act 2010?
         ethnicity: What is your ethnic group?
         gender: How would you describe your gender?
         orientation: How would you describe your sexual orientation?
@@ -696,7 +703,7 @@ en:
       jobseekers_job_application_details_qualifications_category_form:
         category: What qualification would you like to add?
       jobseekers_qualifications_shared_legends: &jobseekers_qualifications_shared_legends
-        finished_studying: Have you finished studying for this qualification?
+        finished_studying: Have you completed this qualification?
         subjects: Subjects
       jobseekers_job_application_details_qualifications_degree_form:
         <<: *jobseekers_qualifications_shared_legends
@@ -714,12 +721,12 @@ en:
       jobseekers_qualifications_other_form:
         <<: *jobseekers_qualifications_shared_legends
       jobseekers_subscription_form:
-        frequency: When do you want to receive alerts?
+        frequency: How often do you want to receive alerts?
       jobseekers_unsubscribe_feedback_form:
         reason: Why do you want to unsubscribe from this alert?
         user_participation_response: Would you like to participate in our research?
       jobseekers_qualifications_category_form:
-        category: Enter your highest level of qualification.
+        category: What is your highest level of qualification?
 
       publishers_job_listing_about_the_role_form:
         ect_status: Is this role suitable for an early career teacher (ECT)?

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -56,7 +56,7 @@ en:
       visa_sponsorship_availability:
         legend: Visa sponsorship
         option: Only show jobs with visa sponsorship
-        subscriptions: Only send alerts for jobs with visa sponsorship
+        subscriptions: Only send alerts for jobs that offer visa sponsorship
 
 
     education_phase_options:

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -78,11 +78,11 @@ en:
       is_current_role: Is this your current role?
       ended_on: End date
       main_duties: Main duties
-      organisation: School or employer
+      organisation: School, college or employer
       started_on: Start date
       subjects: Subjects and key stages taught (optional)
       reason_for_leaving: Reason for leaving
-      gap_with_duration: You have a gap in your work history (%{duration})
+      gap_with_duration: You have a gap in your work history of %{duration}
     forced_login:
       job_application_html: You need to login or create an account with Teaching Vacancies to apply for this job.
       saved_job_html: You need to login or create an account with Teaching Vacancies to save this job.
@@ -100,7 +100,7 @@ en:
         success: Thank you for providing additional feedback on your job alert
     shared:
       training_shared: &training_shared
-        example_intro: "For example you could include:"
+        example_intro: "For example, you could include:"
         example1: safeguarding training
         example2: Prevent duty training
         example3: first aid courses
@@ -114,9 +114,9 @@ en:
       apply:
         apply: Apply for this job
         heading: Your application
-        review_application: Review application
+        review_application: Review and submit application
         review_and_submit: Review and submit your application
-        you_will_have: You will have the opportunity to review your application in full before you submit it.
+        you_will_have: You can review your application before you submit it.
         title: Review your application — Application
         download_application_form: To apply for this job, you'll need to download the application form. Complete the sections below to provide your personal details and upload your completed application form.
       applying_for_the_job_heading: Applying for the job
@@ -133,23 +133,23 @@ en:
         training_and_cpds:
           heading: Training and continuing professional development (CPD)
           step_title: Training and continuing professional development (CPD)
-          title: Add training and continuing professional development (CPD)
+          title: Add training or continuing professional development (CPD)
           no_training: No training or CPD specified
         ask_for_support:
           adjustment_examples:
             assistive_technology: using your own assistive technology
-            captions_hearing_loop_bsl: using captions, a hearing loop or a British Sign Language interpreter
+            captions_hearing_loop_bsl: using captions, a hearing loop or a British Sign Language (BSL) interpreter
             contact_method: changing how we contact you, for example by email instead of phone
             extra_time: extra time to read or answer questions
             questions_in_writing: having interview questions in writing
             quiet_room: using a quiet room
             short_break: taking a short break
             step_free_access: making sure the interview room has step-free access
-          adjustment_examples_intro: "This could include:"
-          arranging_support: You can tell us what would help now. We'll use this information to arrange support for your interview.
+          adjustment_examples_intro: "Examples of support or adjustments include:"
+          arranging_support: Tell us what would help. We’ll use this information to arrange support for your interview.
           heading: Do you need support or adjustments for your interview?
-          needs: This can be for a disability, health condition, mental health condition, neurodivergence, temporary injury or another need.
-          opening: You can ask for support or an adjustment to help you take part in an interview.
+          needs: This could be because of a disability, health condition, neurodivergence, temporary injury or another need.
+          opening: You can ask for support or adjustments to help you take part in an interview.
           step_title: Ask for support
           title: Do you need support or adjustments for your interview? — Application
         declarations:
@@ -158,16 +158,15 @@ en:
           title: Declarations — Application
           dbs_link_text: Disclosure and Barring Service (DBS) check
           description1: >-
-            You'll need to complete an enhanced %{link_text} if you're successful in this role. If you're outside the UK, you'll need to get a
-            criminal record check from your home country.
-          description2: It's a criminal offence if you're barred by the DBS or court orders to apply for a role working with children.
-          description3: Not all convictions or police cautions on a criminal record will stop you from working in a school. But you will have to declare any convictions.
-          description4: Learn more about when you need to tell someone about your criminal record.
-          keep_children_safe_link_text: keeping children safe in education obligations.
-          description5: Schools may also conduct their own online checks as part of their %{link_text}
+            If you are successful, you will need to complete an enhanced %{link_text}. If you have lived or worked outside the UK, you may need to
+            provide a criminal record check from another country.
+          description2: It's a criminal offence to apply for a role working with children or young people if you are barred from doing so by the DBS or a court order.
+          description3: Not all convictions or cautions will stop you from working in a school or college. You must declare any convictions or cautions you are required to disclose.
+          description4: Check when you need to tell someone about your criminal record
+          description5: Schools and colleges may also carry out online searches as part of their safeguarding checks.
           safeguarding_issue:
-            "yes": "Yes, I want to share something"
-            hint: "Give any relevant information"
+            "yes": "Yes, I need to declare something"
+            hint: "Give details of the safeguarding issue"
             "no": "No"
         employment_history:
           break: Gap in work history
@@ -178,12 +177,12 @@ en:
               - all paid roles
               - voluntary work, if relevant to your application
             work_experience_advice: If you’re applying for a teaching job, you should include teaching and other experience, if you have it.
-            gaps_advice: "You’ll also need to explain any gaps in your work history. This includes any gaps between:"
+            gaps_advice: "You’ll also need to explain any gaps in your work history. This includes gaps between:"
             gaps_bullets:
               - school and university
               - university and employment
-              - different forms of employment
-            reasons: You’ll need to provide the reason you left each role.
+              - different jobs
+            reasons: You will need to give the reason you left each role.
             gaps: >-
               If you had a gap between finishing full-time education and starting work that you have not explained then please %{link} to give details about it
             gaps_link_text: click here
@@ -198,13 +197,13 @@ en:
           title: Current role and employment history — Application
         equal_opportunities:
           anonymity: >-
-            Your information will be held anonymously by the Department for Education to monitor the inclusivity of applicants.
-            It will not be used as part of your application.
+            Your answers will be anonymised and used by the Department for Education to monitor the diversity of applicants.
+            They will not be used as part of your application.
           explanation: >-
-            School staff from a range of backgrounds and experiences in society provide students with a better all-round education.
-            Please provide some basic information about your identity to help achieve this.
+            Staff from a range of backgrounds and experiences help provide children and young people with a better education.
+            We ask these questions to help monitor the diversity of applicants.
           heading: Equal opportunities and recruitment monitoring
-          optional: You can select ‘prefer not to say’ if you would rather not answer any question.
+          optional: Select ‘Prefer not to say’ if you do not want to answer a question.
           step_title: Equal opportunities
           title: Equal opportunities — Application
         catholic:
@@ -249,18 +248,18 @@ en:
           banner_documents_html: >-
             Documents supplied with %{job_link} listing that may be of some help with your personal statement.
           banner_no_documents_html: >-
-            It may be helpful to refer to %{job_link}. You should include any skills, qualities and experience that are relevant to this role.
+            You may find it helpful to refer to %{job_link}. You should include any skills, qualities and experience that are relevant to this role.
           description: >-
-            Your personal statement is your opportunity to explain why you are suitable for this role. Schools typically expect personal statements to be about 2 pages long, which is approximately 500 to 1,000 words.
+            Your personal statement is your opportunity to explain why you are suitable for this role. Schools typically expect personal statements to be about 500 to 1,000 words.
           job_description: job description
           heading: Personal statement
           applying_for_a_teaching_role: If you're applying for a teaching role
-          you_could_provide: "You could include information about:"
+          you_could_provide: "You could include:"
           personal_statement_preamble: "Get advice from experienced teachers and school leaders on "
           personal_statement_preamble_continued_html: . You can can also use the %{tool_link} for prompts and tips to help you get started.
           tool_link_text: personal statement builder
           bullets:
-            - your teaching and classroom management style
+            - your teaching style and approach to classroom management
             - your knowledge of the curriculum
             - your understanding of safeguarding and pupil wellbeing
             - additional responsibilities you’ve taken on in school
@@ -274,22 +273,22 @@ en:
           heading: Professional status
           step_title: Professional status
           title: Professional status — Application
-          introduction: If you have no teaching experience and are applying for a support role, you should answer no to these questions.
+          introduction: If you're applying for a support role and do not have teaching experience, answer ‘No’ to these questions.
         qualifications:
           heading: Qualifications
           no_qualifications: No qualifications specified
           step_title: Education and qualifications
           title: Education and qualifications — Application
         referees:
-          description_html: You must include details for a referee from your current or most recent employer. If you did not work with children in this role, you must include at least one referee from the last job where you worked with children. Schools must contact your referees in compliance with %{link}.
-          kcsie: Keeping children safe in education statutory guidance
+          description_html: You must include details for a referee from your current or most recent employer. If you did not work with children in this role, you must include at least one referee from the last job where you worked with children. Schools or colleges must contact referees in line with %{link}.
+          kcsie: keeping children safe in education (KCSIE) statutory guidance
           heading: References
-          no_references: No referees specified
+          no_references: No referees added
           step_title: References
           title: References — Application
         review:
           step_title: Review your application
-      cancel_caption: If you select cancel you will lose any unsaved information from this step. Completed details from previous steps will be saved in your draft applications.
+      cancel_caption: If you select ‘Cancel and return to your account’, you will lose any unsaved information from this step. Information from previous steps will be saved in your draft application.
       caption: "%{job_title} at %{organisation}"
       closing_date: Closing date
       confirm_destroy:
@@ -338,19 +337,19 @@ en:
       training_and_cpds:
         heading: Training and continuing professional development (CPD)
         step_title: Training and continuing professional development (CPD)
-        title: Add training and continuing professional development (CPD)
+        title: Add training or continuing professional development (CPD)
         fields:
           hint: For example, 2024.
         new:
           <<: *training_shared
           caption: Training and continuing professional development (CPD)
-          heading: Add training and continuing professional development (CPD)
-          description: Include any training you've completed within the last 3 years relevant to the role you're applying for.
+          heading: Add training or continuing professional development (CPD)
+          description: Include any training you've completed in the last 3 years that is relevant to the role.
         edit:
           <<: *training_shared
           caption: Training and continuing professional development (CPD)
-          heading: Edit training and continuing professional development (CPD)
-          description: Include any training you've completed within the last 3 years relevant to the role you're applying for.
+          heading: Edit training or continuing professional development (CPD)
+          description: Include any training you've completed in the last 3 years that is relevant to the role.
         destroy:
           success: Training deleted
         review:
@@ -369,7 +368,7 @@ en:
         reason_for_leaving: Reason for leaving
         new:
           caption: Current role and employment history
-          heading: Add a role
+          heading: Add a job or voluntary role
           title: Add a role — Application
         organisation: Organisation
         salary: Salary
@@ -474,12 +473,12 @@ en:
           caption: Education and qualifications
           subjects_and_grades: Subjects and grades
           hint:
-            gcse: Add all your GCSEs.
+            gcse: Add all your GCSEs
             as_level: Add all your AS levels.
             a_level: Add all your A levels.
             undergraduate: Add your undergraduate degree.
-            postgraduate: You do not need to add qualified teacher status (QTS) here. You can add this to your application in the professional status section.
-            other: Add any formal qualifications. You can add details of any training or professional development in the continuing professional development part of the application.
+            postgraduate: Do not add qualified teacher status (QTS) here. You can add it in the professional status section.
+            other: Add any formal qualifications. You can add training or professional development in the training and professional development section.
         edit:
           <<: *qualifications_shared
           heading:
@@ -494,8 +493,8 @@ en:
           <<: *qualifications_shared
           heading:
             gcse: Add GCSEs
-            as_level: Add AS Levels
-            a_level: Add A Levels
+            as_level: Add AS levels
+            a_level: Add A levels
             undergraduate: Add an undergraduate degree
             postgraduate: Add a postgraduate qualification
             other: Add a qualification
@@ -511,37 +510,37 @@ en:
         edit:
           caption: References
           description:
-            html: If you are shortlisted, your referees may be contacted before your interview. Schools must contact your referees in compliance with %{link}. You can ask to be told before a school contacts your referees, but we cannot guarantee the school will do so.
-          kcsie: Keeping children safe in education statutory guidance
+            html: If you are shortlisted, your referees may be contacted before your interview. Schools or colleges must contact referees in line with %{link}. You can ask to be told before a school contacts your referees, but we cannot guarantee the school will do so.
+          kcsie: keeping children safe in education (KCSIE) statutory guidance
           heading: Edit a referee
           title: Edit a referee — Application
-          work_in_school_heading: If you work in a school
-          work_in_school_guidance: Your reference must be confirmed by your headteacher but does not have to be provided by them.
+          work_in_school_heading: If you work in a school or college now
+          work_in_school_guidance: Your reference must be confirmed by your headteacher, but they do not have to provide it.
           trainee_teacher_heading: If you are a trainee teacher
-          trainee_teacher_guidance: You should provide a reference where you can show your experience working with children. You can include references from school placements or from your course provider.
-          work_with_children_heading: If you used to work with children
-          work_with_children_guidance: If you do not currently work with children but have in the past, you should provide one reference from your current or most recent employer and one from the last time you worked with children.
-          consent_confirmation: By adding this referee, you are confirming that they have consented to providing their contact information for the purpose of providing a reference.
+          trainee_teacher_guidance: You should provide a reference from someone who can confirm your experience working with children or young people. You can include references from school placements or from your course provider.
+          work_with_children_heading: If you have worked with children or young people before
+          work_with_children_guidance: If you do not work with children or young people now but have in the past, you should provide one reference from your current or most recent employer and one from the last time you worked with children or young people.
+          consent_confirmation: By adding this referee, you confirm they have agreed to provide their contact information for a reference.
         email: Email address
         job_title: Job title
         name: Name
         new:
           caption: References
           description:
-            html: If you are shortlisted, your referees may be contacted before your interview. Schools must contact your referees in compliance with %{link}. You can ask to be told before a school contacts your referees, but we cannot guarantee the school will do so.
-          kcsie: Keeping children safe in education statutory guidance
+            html: If you are shortlisted, your referees may be contacted before your interview. Schools or colleges must contact referees in line with %{link}. You can ask to be told before a school contacts your referees, but we cannot guarantee the school will do so.
+          kcsie: keeping children safe in education (KCSIE) statutory guidance
           heading: Add a referee
           title: Add a referee — Application
-          work_in_school_heading: If you work in a school
-          work_in_school_guidance: Your reference must be confirmed by your headteacher but does not have to be provided by them.
+          work_in_school_heading: If you work in a school or college now
+          work_in_school_guidance: Your reference must be confirmed by your headteacher, but they do not have to provide it.
           trainee_teacher_heading: If you are a trainee teacher
-          trainee_teacher_guidance: You should provide a reference where you can show your experience working with children. You can include references from school placements or from your course provider.
-          work_with_children_heading: If you used to work with children
-          work_with_children_guidance: If you do not currently work with children but have in the past, you should provide one reference from your current or most recent employer and one from the last time you worked with children.
-          consent_confirmation: By adding this referee, you are confirming that they have consented to providing their contact information for the purpose of providing a reference.
+          trainee_teacher_guidance: You should provide a reference from someone who can confirm your experience working with children or young people. You can include references from school placements or from your course provider.
+          work_with_children_heading: If you have worked with children or young people before
+          work_with_children_guidance: If you do not work with children or young people now but have in the past, you should provide one reference from your current or most recent employer and one from the last time you worked with children or young people.
+          consent_confirmation: By adding this referee, you confirm they have agreed to provide their contact information for a reference.
         organisation: Organisation
         phone_number: Phone number
-        relationship: Relationship to applicant
+        relationship: Relationship to you
         is_most_recent_employer: Current or most recent employer
       review:
         contact_referer:
@@ -549,7 +548,7 @@ en:
           publisher: This applicant wants to be contacted before you collect their references.
         view_your_profile: View your profile
         confirmation:
-          heading: Confirmation
+          heading: Confirm and submit your application
           update_your_profile:
             heading: Do you want to update your profile?
             hint: You can update your profile to match this application. This will replace the current information on your profile. Choose the sections you'd like to update.
@@ -558,12 +557,12 @@ en:
             heading: How your data is used
             list:
               dfe: the Department for Education
-              employer: the school or schools the job is at
-              listing_organisation: the school, trust or local authority which posted the job listing
+              employer: the school or college, or group of schools or colleges, where the job is based
+              listing_organisation: the school, trust, college or local authority that posted the job listing
             privacy_policy:
-              description_html: Please read the Teaching Vacancies %{link_to} for more information on how your data is used.
-              link_text: Privacy Policy
-          resubmission_warning: You cannot edit your application after submitting. If you withdraw your application, you will not be able to resubmit.
+              description_html: Read the Teaching Vacancies %{link_to} for more information about how your data is used.
+              link_text: privacy policy
+          resubmission_warning: You cannot edit your application after you submit it. If you withdraw your application, you will not be able to submit it again.
         deadline_passed: The deadline for this job listing has passed
         employment_history:
           none: You have not added any roles or employment history.
@@ -706,17 +705,17 @@ en:
         continue: Continue application
         deadline_passed: job closed
         delete: Delete
-        link_find: Find a job
+        link_find: Find jobs
         page_title: Saved jobs
         skip_link: Skip to my saved jobs
         view: View application
-        zero_saved_jobs_body_html: '%{link_to} and start saving jobs you may want to review and apply for later.'
+        zero_saved_jobs_body_html: '%{link_to} and save the ones you want to review or apply for later.'
         zero_saved_jobs_title: You have no saved jobs
         one_login_banner:
           header: Can't see your saved jobs?
-          paragraph1: If you had a Teaching Vacancies account using a different email address to your GOV.UK One Login account, your saved jobs will not automatically be saved.
-          paragraph2_html: You can request to %{link}
-          transfer_profile_link_text: transfer your existing profile.
+          paragraph1: If your Teaching Vacancies account used a different email address from your GOV.UK One Login account, your saved jobs will not automatically appear here.
+          paragraph2_html: You can request %{link}
+          transfer_profile_link_text: a transfer of your existing profile.
 
       save: Save this job for later
       saved: Job saved
@@ -780,7 +779,7 @@ en:
           caption: Personal details
           heading: Name and visa sponsorship
           page_title: Name and visa sponsorship
-          visa: Do you need Skilled Worker visa sponsorship?
+          visa: Do you need Skilled Worker visa sponsorship to work in the UK?
           learn_more:
             other_routes_to_qts: other routes to QTS
             qualifications_and_experience: the qualifications and experience you’ll need
@@ -790,14 +789,14 @@ en:
             link: check your eligibility (link opens in new tab)
           work:
             options:
-              false: "Yes, I will need to apply for a visa giving me the right to work in the UK"
+              false: "Yes, I need Skilled Worker visa sponsorship"
               true: "No, I already have the right to work in the UK"
             hint:
               text: If you're a non-UK citizen you will need a visa or immigration status which allows you to work in England. If you're looking for a teaching job, you can learn more about %{link}
               link: teaching in England as a non-UK citizen (opens in new tab).
               no_visa:
-                text: You can %{link}
-                link: find out what visa you need if you're a non-UK citizen (link opens in new tab).
+                text: "%{link}"
+                link: Find out what visa you need if you’re a non-UK citizen (opens in new tab)
             warning:
               text: This role cannot offer visa sponsorship.
               paragraph_1: It is unlikely you will be considered for this job as it is not offering Skilled Worker visa sponsorship to non-UK citizens.
@@ -828,24 +827,24 @@ en:
         activate_profile_text: >-
           When you turn on your profile it will only be visible to hiring staff in schools and trusts.
           They can get in touch by email to invite you apply for roles.
-        hide_profile: Hide profile from schools or trusts
+        hide_profile: Hide profile from schools, trusts or colleges
         imported: You have recently submitted a job application, so some of your details have been imported into your profile.
-        page_description: Your profile allows schools to contact you, based on the details in your profile.
+        page_description: Your profile allows schools, trusts and colleges to contact you, based on your profile details.
         inactive_profile: >-
-          Your profile is inactive. You can reactivate it by selecting 'Turn on profile'.
-          When your profile is active, schools and trust hiring staff can view your details and contact you about jobs by email.
+          Your profile is inactive. To make it active, select ‘Turn on your profile’.
+          When your profile is active, school, trust, and college hiring staff can view your details and contact you about jobs by email.
         page_title: Your profile
         preview_and_turn_off_profile: Preview and turn off profile
-        preview_and_turn_on_profile: Preview and turn on profile
+        preview_and_turn_on_profile: Preview and turn on your profile
         preview_profile: Preview profile
         profile_turned_off: Profile turned off
         profile_turned_on: Profile turned on
-        set_up_profile_visibility: Set up who cannot view your profile
+        set_up_profile_visibility: Choose who cannot view your profile
         turn_off_profile_text: When you turn off your profile it will not be visible to hiring staff in schools and trusts.
         turn_off_profile: Turn off profile
-        turn_on_profile_text: When you turn on your profile, school and trust hiring staff will be able to view your details and contact you by email. You can %{link_text}
-        turn_on_profile_link_text: hide your profile from specific schools or trusts.
-        turn_on_profile: Turn on profile
+        turn_on_profile_text: When you turn on your profile, hiring staff can view your details and contact you by email. You can %{link_text}
+        turn_on_profile_link_text: hide your profile from specific schools, colleges or trusts.
+        turn_on_profile: Turn on your profile
         one_login_banner:
           header: Can't see your profile details?
           paragraph1: If you had a Teaching Vacancies account using a different email address to your GOV.UK One Login account, your existing profile will not automatically be saved.
@@ -1041,8 +1040,9 @@ en:
     request_account_transfer_emails:
       new:
         page_title: Transfer account details
-        heading: What was the email address on your Teaching Vacancies account?
-        hint: If you have an account associated with this email address, we'll send you an email to verify your details.
+        heading: What email address did you use for your Teaching Vacancies account?
+        hint: If there’s a Teaching Vacancies account for this email address, we’ll send you an email to verify your details.
+        submit: Send verification email
       errors:
         recent_code_request: Please wait 1 minute before requesting another code.
         cannot_transfer_logged_in_account: You entered the email of the account you are currently logged in to. The data in this account is already available to you and cannot be transferred.

--- a/config/locales/jobseekers.yml
+++ b/config/locales/jobseekers.yml
@@ -703,7 +703,6 @@ en:
         application_deadline: Application deadline
         apply: Apply for this job
         continue: Continue application
-        deadline_passed: job closed
         delete: Delete
         link_find: Find jobs
         page_title: Saved jobs

--- a/config/locales/jobseekers/employment_form.yml
+++ b/config/locales/jobseekers/employment_form.yml
@@ -48,9 +48,9 @@ en:
   helpers:
     hint:
       jobseekers_job_application_details_employment_form:
-        main_duties: Give a brief summary of your key responsibilities.
-        organisation: For a non-teaching job, tell us the name of the organisation you worked at
-        reason_for_leaving: If you’re still in the role, give a brief summary of your reasons for wanting to leave.
+        main_duties: Give a brief summary of your main responsibilities
+        organisation: For example, the name of the school, company or organisation
+        reason_for_leaving: If you are still in this role, give a brief summary of your reasons for wanting to leave
       jobseekers_profile_employment_form:
         main_duties: Give a brief summary of your key responsibilities.
         organisation_name: If you worked for yourself, enter ‘self-employed’
@@ -60,13 +60,13 @@ en:
     label:
       jobseekers_job_application_details_employment_form:
         is_current_role_options:
-          "true": I currently work here
+          "true": I currently work in this role
         job_title: Job title
         main_duties: Main duties
-        organisation: School or other organisation
+        organisation: Organisation name
         subjects_review: Subjects and key stages taught
-        subjects_html: Subjects and key stages taught (optional<span class='govuk-visually-hidden'> field</span>)</span>
-        reason_for_leaving: Reason for leaving role
+        subjects_html: Subjects and key stages you taught (optional<span class='govuk-visually-hidden'> field</span>)</span>
+        reason_for_leaving: Reason for leaving this role
       jobseekers_profile_employment_form:
         is_current_role_options:
           "true": I currently work here

--- a/config/locales/jobseekers/job_application/ask_for_support_form.yml
+++ b/config/locales/jobseekers/job_application/ask_for_support_form.yml
@@ -14,11 +14,11 @@ en:
   helpers:
     legend:
       jobseekers_job_application_ask_for_support_form:
-        is_support_needed: Do you need support or adjustments for an interview?
+        is_support_needed: Do you need support or adjustments for your interview?
         ask_for_support_section_completed: Have you completed this section?
     label:
       jobseekers_job_application_ask_for_support_form:
-        support_needed_details: Tell us any information you think is relevant
+        support_needed_details: Tell us what support or adjustments you need
         is_support_needed_options:
           "false": No, I do not need support or adjustments
           "true": Yes, I need support or adjustments

--- a/config/locales/jobseekers/job_application/declarations_form.yml
+++ b/config/locales/jobseekers/job_application/declarations_form.yml
@@ -18,14 +18,14 @@ en:
     legend:
       jobseekers_job_application_declarations_form:
         has_close_relationships:
-          other: Do you have any family or close relationship(s) with people within the school or any governors or trustees at %{organisation}?
-          trust: Do you have any family or close relationship(s) with people within the school, MAT or any governors or trustees at %{organisation}?
-        has_right_to_work_in_uk: Do you need Skilled Worker visa sponsorship?
-        has_safeguarding_issue: Do you want to declare any substantiated safeguarding issues, such as a criminal record or professional misconduct?
+          other: Do you have a family or close relationship with anyone who works at %{organisation}, or with any of its governors or trustees?
+          trust: Do you have a family or close relationship with anyone who works at %{organisation}, or with any of its governors or trustees?
+        has_right_to_work_in_uk: Do you need Skilled Worker visa sponsorship to work in the UK?
+        has_safeguarding_issue: Do you need to declare any safeguarding issues, such as a criminal record or professional misconduct?
         declarations_section_completed: Have you completed this section?
     label:
       jobseekers_job_application_declarations_form:
-        close_relationships_details: Please give details
+        close_relationships_details: Give details of the relationship
         has_close_relationships_options:
           "false": "No"
           "true": "Yes"

--- a/config/locales/jobseekers/job_application/employment_history_form.yml
+++ b/config/locales/jobseekers/job_application/employment_history_form.yml
@@ -20,5 +20,5 @@ en:
           true: Yes, I've completed this section
     hint:
       jobseekers_job_application_employment_history_form:
-        employment_history_section_completed: Ensure you've added all your employment history.
+        employment_history_section_completed: Make sure you have added all jobs and any gaps in your work history.
 

--- a/config/locales/jobseekers/job_application/equal_opportunites_form.yml
+++ b/config/locales/jobseekers/job_application/equal_opportunites_form.yml
@@ -54,7 +54,7 @@ en:
     orientation_options:
       bisexual: Bisexual
       gay_or_lesbian: Gay or lesbian
-      heterosexual: Heterosexual
+      heterosexual: Heterosexual or straight
       other: Other sexual orientation
       prefer_not_to_say: Prefer not to say
     religion_options:
@@ -83,13 +83,13 @@ en:
           true: Yes, I've completed this section
     hint:
       jobseekers_job_application_equal_opportunities_form:
-        gender: If the options below do not reflect how you identify, please select ‘Other gender identity’.
-        ethnicity: If the options below do not reflect how you identify, please select ‘Other ethnic group’.
+        gender: If none of the options reflect how you identify, select ‘Other gender identity’.
+        ethnicity: If none of the options reflect how you identify, select ‘Other ethnic group’.
         ethnicity_options:
           asian: Includes Indian, Pakistani, Bangladeshi or Chinese
           mixed: Includes White and Black Caribbean, White and Black African or White and Asian
-          white: Includes English, Welsh, Scottish, Northern Irish, British, Irish Gypsy or Irish Traveller
-        orientation: If the options below do not reflect how you identify, please select ‘Other sexual orientation’.
+          white: Includes English, Welsh, Scottish, Northern Irish, British, Irish, Gypsy or Irish Traveller
+        orientation: If none of the options reflect how you identify, select ‘Other sexual orientation’.
         religion: >-
-          You can select ‘Other religion or belief’ if your beliefs are not represented by one of the given options.
+          If none of the options reflect your religion or belief, select ‘Other religion or belief’.
 

--- a/config/locales/jobseekers/job_application/personal_details_form.yml
+++ b/config/locales/jobseekers/job_application/personal_details_form.yml
@@ -84,10 +84,10 @@ en:
     legend:
       jobseekers_job_application_personal_details_form:
         your_address: Your address
-        has_ni_number: Do you have a national insurance number?
+        has_ni_number: Do you have a National Insurance number?
         personal_details_section_completed: Have you completed this section?
         working_pattern_details: Working pattern preference details
-        working_patterns: Working pattern preference
+        working_patterns: Working pattern preferences
       jobseekers_uploaded_job_application_personal_details_form:
         personal_details_section_completed: Have you completed this section?
       jobseekers_uploaded_job_application_upload_application_form_form:
@@ -95,8 +95,7 @@ en:
     label:
       personal_details:
         email: Email
-        change_email_html: Select to %{link}
-        change_email_link_text: change your email address
+        change_email_link_text: Change your email address
         first_name: First name
         last_name: Last name
 
@@ -117,11 +116,11 @@ en:
         teacher_reference_number_html: Teacher reference number (TRN) (optional<span class='govuk-visually-hidden'> field</span>)</span>
         has_ni_number_options:
           "yes": "Yes"
-          "no": No, I do not have one or do not want to provide it yet
+          "no": No, I do not have one or I do not want to provide it yet
         personal_details_section_completed_options:
-          false: No, I'll come back to it later
+          false: No, I’ll come back to it later
           true: Yes, I've completed this section
-        working_pattern_details: Provide more details about your working patterns preference (optional)
+        working_pattern_details: Provide more details about your working pattern preferences (optional)
         working_patterns: Full, part time or job share
       jobseekers_uploaded_job_application_personal_details_form:
         email_address: Email address
@@ -149,12 +148,7 @@ en:
         has_ni_number: >-
           You can find this on your National Insurance card,
           benefit letter, payslip or P60. It's made up of 2 letters, 6 numbers and a final letter.
-        phone_number: Enter a phone number you are happy to be contacted on. For example, 01632 960 001, 07700 900 982 or +44 0808 157 0192.
-        previous_names: For example maiden name or name at birth, if different from the name you have now.
-        working_patterns: >-
-          Some schools may be open to part-time applicants even if a position is advertised as full time.
-
-          Provide your preference so that you can discuss your options with the school.
-
-          Select all that apply.
-        working_pattern_details: For example, if you're looking for a role that's 2 days a week, or Monday to Wednesday.
+        phone_number: Enter a phone number we can use to contact you, for example 01632 960 001, 07700 900 982 or +44 0808 157 0192
+        previous_names: For example, a maiden name or name at birth, if it is different from the name you use now
+        working_patterns: Some schools may consider part-time applicants, even if a role is advertised as full time. Select all that apply
+        working_pattern_details: For example, 2 days a week or Monday to Wednesday

--- a/config/locales/jobseekers/job_application/professional_status_form.yml
+++ b/config/locales/jobseekers/job_application/professional_status_form.yml
@@ -52,32 +52,32 @@ en:
           "true": "Yes, I have completed my induction period"
         qualified_teacher_status_year: Year QTS was gained
         qts_age_range_and_subject: Age range and subject you trained to teach
-        teacher_reference_number: What is your teacher reference number (TRN)?
+        teacher_reference_number: What is your teacher reference number?
         is_statutory_induction_complete: Have you completed your induction period?
-        statutory_induction_complete_details: Provide more detail, for example, if you have started but not completed your induction, or you are %{link} (optional)
-        statutory_induction_complete_details_hint_text: exempt from completing an induction
+        statutory_induction_complete_details: Provide more details about your induction period (optional)
         trn_link_text: find your TRN
       jobseekers_job_application_professional_status_form:
-        qualified_teacher_status_details_html: Please provide more detail (optional<span class='govuk-visually-hidden'> field</span>)</span>
+        qualified_teacher_status_details_html: Why do you not have QTS? (optional<span class='govuk-visually-hidden'> field</span>)</span>
         qualified_teacher_status_options:
           "no": "No"
-          on_track: I'm on track to receive my QTS
+          on_track: I’m on track to get QTS
           non_teacher: I'm not looking for a teaching job
           "yes": "Yes"
-        teacher_reference_number: What is your teacher reference number (TRN)?
+        teacher_reference_number: What is your teacher reference number?
         is_statutory_induction_complete_options:
           "false": "No, I have not completed my induction period"
           "true": "Yes, I have completed my induction period"
-        qualified_teacher_status_year: Year QTS was gained
+        qualified_teacher_status_year: Year you gained QTS
         qts_age_range_and_subject: Age range and subject you trained to teach
-        hint: You're unlikely to get a teaching job in England unless you have QTS. Find out %{link}. If you answer yes to this question, we’ll ask you to provide your teacher reference number (TRN).
+        hint: You are unlikely to get a teaching job in England unless you have qualified teacher status (QTS). If you answer ‘Yes’, we’ll ask for your teacher reference number (TRN).
         link_text: how to get QTS
         professional_status_section_completed_options:
           false: No, I'll come back to it later
           true: Yes, I've completed this section
     hint:
       jobseekers_job_application_professional_status_form:
-        is_statutory_induction_complete: Early career teachers (ECTs) have to complete a 2 year induction period. This used to be 1 year for newly qualified teachers (NQTs).
-        teacher_reference_number: You can %{link} if you do not know it (for example, if you're a trainee teacher) or have forgotten it. Your TRN is 7 digits long.
+        is_statutory_induction_complete: Early career teachers (ECTs) have to complete a 2-year induction period. This used to be 1 year for newly qualified teachers (NQTs).
+        teacher_reference_number: Your teacher reference number (TRN) is 7 digits long. You can %{link} if you do not know it or have forgotten it.
+        statutory_induction_complete_details: For example, whether you have started but not completed your induction, or are exempt from completing it
       jobseekers_profiles_qualified_teacher_status_form:
         is_statutory_induction_complete: Early career teachers (ECTs) have to complete a 2 year induction period. This used to be 1 year for newly qualified teachers (NQTs).

--- a/config/locales/jobseekers/job_application/references_form.yml
+++ b/config/locales/jobseekers/job_application/references_form.yml
@@ -14,11 +14,11 @@ en:
   helpers:
     legend:
       jobseekers_job_application_referees_form:
-        notify_before_contact_referers: Do you want the school to tell you before they contact your referees?
+        notify_before_contact_referers: Do you want the school or college to contact you before they contact your referees?
         referees_section_completed: Have you completed this section?
       jobseekers_job_application_details_referee_form:
         phone_number: Phone number
-        is_most_recent_employer: Is this your current or most recent employer?
+        is_most_recent_employer: Is this referee from your current or most recent employer?
     label:
       jobseekers_job_application_referees_form:
         referees_section_completed_options:
@@ -32,7 +32,7 @@ en:
         job_title: Job title
         name: Name
         organisation: Organisation
-        relationship: Relationship to applicant
+        relationship: Relationship to you
         phone_number: Phone number (optional)
         is_most_recent_employer_options:
           "true": "Yes"
@@ -40,12 +40,11 @@ en:
 
     hint:
       jobseekers_job_application_referees_form:
-        notify_before_contact_referers: We will ask the school to tell you before contacting your referees, but we cannot guarantee they will do so.
+        notify_before_contact_referers: We’ll ask the school or college to contact you before they contact your referees, but we cannot guarantee they will do this.
         notify_before_contact_referers_options:
-          text: We will ask the school to tell you before contacting your referees.
+          text: We’ll ask the school or college to contact you before they contact your referees.
       jobseekers_job_application_details_referee_form:
-        phone_number: >-
-          Provide a phone number that your referee is happy to be contacted on.
+        phone_number: Provide a phone number we can use to contact your referee
         is_most_recent_employer_hints:
           hint1: One of your referees should be your current or most recent employer.
           hint2: If you do not have an employer referee, you can provide a personal referee.

--- a/config/locales/jobseekers/job_application/review_form.yml
+++ b/config/locales/jobseekers/job_application/review_form.yml
@@ -20,7 +20,7 @@ en:
     label:
       jobseekers_job_application_review_form:
         confirm_data_accurate_options:
-          "1": I confirm that the above information is accurate and complete
+          "1": I confirm that the information in my application is accurate and complete
         confirm_data_usage_options:
-          "1": I consent to my data being shared with and processed by these organisations for recruitment purposes (for example, background and qualification checks)
+          "1": I consent to my data being shared with and processed by these organisations for recruitment purposes, including background and qualification checks
 

--- a/config/locales/jobseekers/professional_body_membership_form.yml
+++ b/config/locales/jobseekers/professional_body_membership_form.yml
@@ -24,14 +24,14 @@ en:
         name: Name of professional body
         membership_type: Membership type or level (optional)
         membership_number: Membership or registration number (optional)
-        year_membership_obtained: Date obtained (optional)
-        exam_taken: Did you take an exam for this membership?
+        year_membership_obtained: Date you joined (optional)
+        exam_taken: Did you take an exam to get this membership?
         exam_taken_options:
           "true": "Yes"
           "false": "No"
     legend:
       jobseekers_professional_body_membership_form:
-        exam_taken: Did you take an exam for this membership?
+        exam_taken: Did you take an exam to get this membership?
   jobseekers:
     job_applications:
       show:
@@ -44,12 +44,12 @@ en:
         professional_body_memberships:
           list_heading: Professional body memberships
           heading: Professional body memberships (optional)
-          hint: You can include professional memberships here, such as the Chartered College of Teaching or the General Teaching Council.
-          no_training: No memberships specified
-          no_professional_body_memberships: No memberships specified
+          hint: You can add professional body memberships, such as the Chartered College of Teaching or the General Teaching Council.
+          no_training: No memberships added
+          no_professional_body_memberships: No memberships added
       professional_body_memberships:
         new:
-          heading: Add professional body memberships
+          heading: Add a professional body membership
           page_title: Professional body memberships
         edit:
           heading: Edit professional body memberships

--- a/config/locales/jobseekers/profile/job_preferences.yml
+++ b/config/locales/jobseekers/profile/job_preferences.yml
@@ -62,7 +62,7 @@ en:
           assistant_headteacher: Assistant headteacher
           deputy_headteacher: Deputy headteacher
           higher_level_teaching_assistant: HLTA (higher level teaching assistant)
-          sendco: SENCO (special educational needs coordinator)
+          sendco: SENCo (special educational needs coordinator)
           teacher: Teacher or lecturer
           teaching_assistant: Teaching assistant
           administration_hr_data_and_finance: Administration, HR, data and finance

--- a/spec/helpers/job_applications_helper_spec.rb
+++ b/spec/helpers/job_applications_helper_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe JobApplicationsHelper do
 
       it "has good translations" do
         expect(radio_button_legend_hint(vacancy).transform_values { |t| I18n.t(t) })
-          .to eq(text: "You can %{link}",
-                 link: "find out what visa you need if you're a non-UK citizen (link opens in new tab).")
+          .to eq(text: "%{link}",
+                 link: "Find out what visa you need if you’re a non-UK citizen (opens in new tab)")
       end
     end
   end

--- a/spec/support/jobseeker_helpers.rb
+++ b/spec/support/jobseeker_helpers.rb
@@ -13,7 +13,7 @@ module JobseekerHelpers
 
   def fill_in_ask_for_support
     choose "Yes", name: "jobseekers_job_application_ask_for_support_form[is_support_needed]"
-    fill_in "Tell us any information you think is relevant", with: "Some details about support"
+    fill_in "Tell us what support or adjustments you need", with: "Some details about support"
     choose I18n.t("helpers.label.jobseekers_job_application_ask_for_support_form.ask_for_support_section_completed_options.true")
   end
 
@@ -24,27 +24,27 @@ module JobseekerHelpers
     fill_in I18n.t("helpers.label.#{form}.reason_for_leaving"), with: reason_for_leaving if reason_for_leaving.present?
 
     if I18n.exists?("helpers.label.#{form}.subjects_html")
-      fill_in "Subjects and key stages taught (optional field)", with: "English KS1"
+      fill_in "Subjects and key stages you taught (optional field)", with: "English KS1"
     end
 
     fill_in "#{form}[started_on(1i)]", with: start_year
     fill_in "#{form}[started_on(2i)]", with: start_month
-    check "I currently work here"
+    check I18n.t("helpers.label.#{form}.is_current_role_options.true")
   end
 
   def fill_in_declarations
     choose "Yes", name: "jobseekers_job_application_declarations_form[has_close_relationships]"
-    fill_in "Please give details", with: "Some details of the relationship"
-    choose "Yes, I want to share something"
-    fill_in "Give any relevant information", with: "Criminal record"
+    fill_in "Give details of the relationship", with: "Some details of the relationship"
+    choose "Yes, I need to declare something"
+    fill_in "Give details of the safeguarding issue", with: "Criminal record"
     choose I18n.t("helpers.label.jobseekers_job_application_declarations_form.declarations_section_completed_options.true")
   end
 
   def fill_in_employment_history(job_title: "The Best Teacher", start_month: "09", start_year: "2019", end_month: "07", end_year: "2020")
-    fill_in "School or other organisation", with: "The Best School"
+    fill_in "Organisation name", with: "The Best School"
     fill_in "Job title", with: job_title
     fill_in "Main duties", with: "Some details about what the main duties were"
-    fill_in "Reason for leaving role", with: "Just couldn't take it any longer"
+    fill_in "Reason for leaving this role", with: "Just couldn't take it any longer"
     fill_in "jobseekers_job_application_details_employment_form[started_on(1i)]", with: start_year
     fill_in "jobseekers_job_application_details_employment_form[started_on(2i)]", with: start_month
     fill_in "jobseekers_job_application_details_employment_form[ended_on(1i)]", with: end_year
@@ -52,7 +52,7 @@ module JobseekerHelpers
   end
 
   def fill_in_training_and_cpds(name: "Fire safety", provider: "TrainingProvider ltd", grade: "Pass", year_awarded: "2020", course_length: "1 year")
-    fill_in "Name of course or training", with: name
+    fill_in "Name of training or course", with: name
     fill_in "Training provider", with: provider
     fill_in "Grade", with: grade
     fill_in "Date completed", with: year_awarded
@@ -113,8 +113,8 @@ module JobseekerHelpers
 
   def fill_in_professional_status
     choose "Yes", name: "jobseekers_job_application_professional_status_form[qualified_teacher_status]"
-    fill_in "Year QTS was gained", with: Time.current.year
-    fill_in "What is your teacher reference number (TRN)?", with: "1234567"
+    fill_in "Year you gained QTS", with: Time.current.year
+    fill_in "What is your teacher reference number?", with: "1234567"
     choose "Yes", name: "jobseekers_job_application_professional_status_form[is_statutory_induction_complete]"
 
     choose I18n.t("helpers.label.jobseekers_job_application_professional_status_form.professional_status_section_completed_options.true")
@@ -124,7 +124,7 @@ module JobseekerHelpers
     fill_in "Name", with: "Jim Referee"
     fill_in "Job title", with: "Important job"
     fill_in "Organisation", with: "Important organisation"
-    fill_in "Relationship to applicant", with: "Colleague"
+    fill_in "Relationship to you", with: "Colleague"
     fill_in "Email address", with: Faker::Internet.email(domain: TEST_EMAIL_DOMAIN)
     fill_in "Phone number", with: "09999 123456"
     choose("Yes")
@@ -142,8 +142,8 @@ module JobseekerHelpers
   end
 
   def fill_in_undergraduate_degree
-    fill_in "Subject", with: "Linguistics"
-    fill_in "Awarding body", with: "University of Life"
+    fill_in "Degree subject", with: "Linguistics"
+    fill_in "University or college", with: "University of Life"
     choose "Yes", name: "jobseekers_qualifications_degree_form[finished_studying]"
     fill_in "Grade", with: "2:1"
     fill_in "Year", with: "2019"
@@ -155,14 +155,14 @@ module JobseekerHelpers
     fill_in "Awarding body (optional)", with: "AXA"
     fill_in "Subject", with: "Superteaching"
     choose "No", name: "jobseekers_qualifications_other_form[finished_studying]"
-    fill_in "Please give details", with: "I expect to finish next year"
+    fill_in "Provide details about your qualification (optional)", with: "I expect to finish next year"
   end
 
   def fill_in_professional_body_membership
     fill_in "Name of professional body", with: "Teachers Union"
     fill_in "Membership type or level (optional)", with: "Gold"
     fill_in "Membership or registration number (optional)", with: "42"
-    fill_in "Date obtained (optional)", with: "2020"
+    fill_in "Date you joined (optional)", with: "2020"
     choose "Yes"
   end
 

--- a/spec/system/jobseekers/jobseekers_can_add_declarations_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_declarations_to_their_job_application_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Jobseekers can disclose close relationships or safeguarding issu
     end
 
     choose("Yes")
-    choose("Yes, I want to share something")
+    choose("Yes, I need to declare something")
 
     click_on "Save and continue"
 

--- a/spec/system/jobseekers/jobseekers_can_add_employments_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_employments_to_their_job_application_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "Jobseekers can add employments and breaks to their job applicati
       within all(".govuk-summary-card").last do
         click_on "Change"
       end
-      fill_in "Reason for leaving role", with: "Needed for KSCIE compliance"
+      fill_in "Reason for leaving this role", with: "Needed for KSCIE compliance"
       click_on I18n.t("buttons.save_employment")
       choose "Yes, I've completed this section"
       click_on "Save and continue"
@@ -196,10 +196,10 @@ RSpec.describe "Jobseekers can add employments and breaks to their job applicati
     it "allows jobseekers to edit employment history" do
       click_on "Change Teacher"
 
-      fill_in "School or other organisation", with: ""
+      fill_in "Organisation name", with: ""
       validates_step_complete(button: I18n.t("buttons.save_employment"))
 
-      fill_in "School or other organisation", with: "A different school"
+      fill_in "Organisation name", with: "A different school"
       click_on I18n.t("buttons.save_employment")
 
       expect(page).to have_current_path(jobseekers_job_application_build_path(job_application, :employment_history), ignore_query: true)

--- a/spec/system/jobseekers/jobseekers_can_add_professional_body_membership_to_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_professional_body_membership_to_job_application_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe "Jobseekers can add professional body memberships to their job ap
           { key: "Name of professional body", value: "Teachers Union" },
           { key: "Membership type or level (optional)", value: "Gold" },
           { key: "Membership or registration number (optional)", value: "42" },
-          { key: "Date obtained (optional)", value: "2020" },
-          { key: "Did you take an exam for this membership?", value: "Yes" },
+          { key: "Date you joined (optional)", value: "2020" },
+          { key: "Did you take an exam to get this membership?", value: "Yes" },
         ]
 
         rows.each do |row|

--- a/spec/system/jobseekers/jobseekers_can_add_professional_status_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_professional_status_to_their_job_application_spec.rb
@@ -36,13 +36,13 @@ RSpec.describe "Jobseekers can add details about their qualified teacher status 
       expect(page).to have_link("Enter the year your QTS was gained", href: "#jobseekers-job-application-professional-status-form-qualified-teacher-status-year-field-error")
     end
 
-    fill_in "Year QTS was gained", with: "2022"
+    fill_in "Year you gained QTS", with: "2022"
     fill_in I18n.t("helpers.label.jobseekers_job_application_professional_status_form.qts_age_range_and_subject"), with: "Adding up for little ones"
     choose("Yes, I have completed my induction period")
 
     click_on "Save and continue"
 
-    fill_in "What is your teacher reference number (TRN)?", with: "1234567"
+    fill_in "What is your teacher reference number?", with: "1234567"
 
     click_on "Save and continue"
 

--- a/spec/system/jobseekers/jobseekers_can_add_professional_status_to_their_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_professional_status_to_their_profile_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Jobseekers can add professional status to their profile" do
             expect(page).to have_link("Select yes if you have completed your statutory induction year", href: "#jobseekers-profiles-qualified-teacher-status-form-is-statutory-induction-complete-field-error")
           end
           fill_in "Year QTS was gained", with: "2032"
-          fill_in "What is your teacher reference number (TRN)?", with: "ABC"
+          fill_in "What is your teacher reference number?", with: "ABC"
           choose "Yes, I have completed my induction period"
           click_on "Save and continue"
           within "ul.govuk-list.govuk-error-summary__list" do
@@ -53,7 +53,7 @@ RSpec.describe "Jobseekers can add professional status to their profile" do
             expect(page).to have_link("Enter a teacher reference number (TRN) that is 7 digits long", href: "#jobseekers-profiles-qualified-teacher-status-form-teacher-reference-number-field-error")
           end
           fill_in "Year QTS was gained", with: "2022"
-          fill_in "What is your teacher reference number (TRN)?", with: "1234567"
+          fill_in "What is your teacher reference number?", with: "1234567"
           choose "No, I have not completed my induction period"
           fill_in "jobseekers-profiles-qualified-teacher-status-form-statutory-induction-complete-details-field", with: "Don't have time to explain"
           click_on "Save and continue"
@@ -96,7 +96,7 @@ RSpec.describe "Jobseekers can add professional status to their profile" do
       expect(find("#jobseekers-profiles-qualified-teacher-status-form-teacher-reference-number-field", visible: false).value).to eq("7777777")
 
       fill_in "Year QTS was gained", with: "2000"
-      fill_in "What is your teacher reference number (TRN)?", with: "1234567"
+      fill_in "What is your teacher reference number?", with: "1234567"
       choose "No, I have not completed my induction period"
       fill_in "jobseekers-profiles-qualified-teacher-status-form-statutory-induction-complete-details-field", with: "I am working on it."
 

--- a/spec/system/jobseekers/jobseekers_can_add_qualifications_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_qualifications_to_their_job_application_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "Jobseekers can add qualifications to their job application" do
 
       it "allows jobseekers to edit the qualification" do
         expect(page).to have_link(I18n.t("buttons.cancel"), href: jobseekers_job_application_build_path(job_application, :qualifications))
-        fill_in "Awarding body", with: "University of Life"
+        fill_in "University or college", with: "University of Life"
         click_on I18n.t("buttons.save_qualification.one")
         expect(page).not_to have_content("Life University")
         expect(page).to have_content("University of Life")

--- a/spec/system/jobseekers/jobseekers_can_add_qualifications_to_their_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_qualifications_to_their_profile_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Jobseekers can add qualifications to their profile" do
         expect(page).to have_content("Superteacher Certificate")
         expect(page).to have_content("Teachers Academy")
         expect(page).to have_content("I expect to finish next year")
-        expect(page).to have_content("Not finished yet")
+        expect(page).to have_content("No, I have not completed it yet")
         expect(page).to have_content("Superteaching")
         expect(page).to have_content("AXA")
         expect(page).not_to have_content("Grade")
@@ -64,7 +64,7 @@ RSpec.describe "Jobseekers can add qualifications to their profile" do
         expect(page).to have_content("Maths – 110%")
         expect(page).to have_content("PE – 90%")
         expect(page).to have_content("2020")
-        expect(page).not_to have_content("Not finished yet")
+        expect(page).not_to have_content("No, I have not completed it yet")
         expect(page).not_to have_content("Yes")
       end
     end
@@ -85,7 +85,7 @@ RSpec.describe "Jobseekers can add qualifications to their profile" do
       it "allows jobseekers to edit the qualification" do
         visit review_jobseekers_profile_qualifications_path
         click_on "Change"
-        fill_in "Awarding body", with: "University of Life"
+        fill_in "University or college", with: "University of Life"
         click_on I18n.t("buttons.save_and_continue")
         expect(page).not_to have_content("Life University")
         expect(page).to have_content("University of Life")

--- a/spec/system/jobseekers/jobseekers_can_add_references_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_references_to_their_job_application_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Jobseekers can add references to their job application" do
     end
 
     it "shows no referees" do
-      expect(page).to have_content("No referees specified")
+      expect(page).to have_content("No referees added")
     end
 
     context "when adding a referee" do

--- a/spec/system/jobseekers/jobseekers_can_add_training_and_cpds_to_their_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_add_training_and_cpds_to_their_job_application_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "Jobseeker can add training and cpds to their job application" do
   end
 
   def expect_page_to_have_values(name, provider, grade, year, course_length)
-    expect(page).to have_css(".govuk-summary-list__key", text: "Name of course or training")
+    expect(page).to have_css(".govuk-summary-list__key", text: "Name of training or course")
     expect(page).to have_css(".govuk-summary-list__value", text: name)
 
     expect(page).to have_css(".govuk-summary-list__key", text: "Training provider")

--- a/spec/system/jobseekers/jobseekers_can_complete_a_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_complete_a_job_application_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "Jobseekers can complete a job application" do
       fill_in_declarations
       click_on I18n.t("buttons.save_and_continue")
       expect(page).to have_css("#declarations", text: I18n.t("shared.status_tags.complete"))
-      click_on "Review application"
+      click_on "Review and submit application"
 
       # wait for page load
       find(".govuk-list.review-component__sections")
@@ -154,7 +154,7 @@ RSpec.describe "Jobseekers can complete a job application" do
     click_on(I18n.t("jobseekers.job_applications.build.professional_body_memberships.list_heading"))
     expect(page).to have_content("No memberships")
     validates_step_complete
-    click_on "Add membership"
+    click_on "Add a membership"
     fill_in_professional_body_membership
     click_on "Save and continue"
     choose "Yes, I've completed this section"
@@ -178,7 +178,7 @@ RSpec.describe "Jobseekers can complete a job application" do
     let(:vacancy) { create(:vacancy, :with_uploaded_application_form, job_roles: ["teacher"], organisations: [organisation]) }
 
     it "errors on the review button" do
-      click_button "Review application"
+      click_button "Review and submit application"
       within(".govuk-error-summary__body") do
         expect(page).to have_link("Complete your personal details")
       end
@@ -187,7 +187,7 @@ RSpec.describe "Jobseekers can complete a job application" do
     it "allows jobseekers to complete an application and go to review page" do
       click_link(I18n.t("jobseekers.job_applications.build.personal_details.heading"))
       validates_step_complete
-      choose I18n.t("helpers.label.jobseekers_job_application_personal_details_form.personal_details_section_completed_options.false")
+      choose I18n.t("helpers.label.jobseekers_uploaded_job_application_personal_details_form.personal_details_section_completed_options.false")
       click_on I18n.t("buttons.save_and_continue")
       expect(page).not_to have_content("There is a problem")
       expect(page).to have_css("#personal_details .govuk-task-list__status .govuk-tag", text: "Incomplete")
@@ -228,7 +228,7 @@ RSpec.describe "Jobseekers can complete a job application" do
       choose I18n.t("helpers.label.jobseekers_uploaded_job_application_upload_application_form_form.upload_application_form_section_completed_options.true")
       click_on I18n.t("buttons.save_and_continue")
 
-      click_button "Review application"
+      click_button "Review and submit application"
       expect(page).to have_current_path(jobseekers_job_application_review_path(vacancy.job_applications.first), ignore_query: true)
     end
   end

--- a/spec/system/jobseekers/jobseekers_can_complete_a_religious_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_complete_a_religious_job_application_spec.rb
@@ -383,7 +383,7 @@ RSpec.describe "Jobseekers can complete a religious job application" do
     click_on "Save and continue"
 
     click_on(I18n.t("jobseekers.job_applications.build.professional_body_memberships.list_heading"))
-    click_on "Add membership"
+    click_on "Add a membership"
     fill_in_professional_body_membership
     click_on "Save and continue"
     choose "Yes, I've completed this section"
@@ -426,7 +426,7 @@ RSpec.describe "Jobseekers can complete a religious job application" do
     click_on(I18n.t("jobseekers.job_applications.build.declarations.heading"))
     fill_in_declarations
     click_on I18n.t("buttons.save_and_continue")
-    click_on "Review application"
+    click_on "Review and submit application"
   end
 
   def submit_application_from_review

--- a/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_a_profile_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Jobseekers can manage their profile", :geocode do
           choose "Yes"
         end
         fill_in "jobseekers_profiles_qualified_teacher_status_form[qualified_teacher_status_year]", with: "2019"
-        fill_in "What is your teacher reference number (TRN)?", with: "1234567"
+        fill_in "What is your teacher reference number?", with: "1234567"
         fill_in "Age range and subject you trained to teach", with: subject_ages
         choose "No, I have not completed my induction period"
         fill_in "jobseekers-profiles-qualified-teacher-status-form-statutory-induction-complete-details-field", with: "I am working on it."
@@ -61,7 +61,7 @@ RSpec.describe "Jobseekers can manage their profile", :geocode do
 
         describe "errors" do
           before do
-            click_link("Add roles")
+            click_link("Add a job or voluntary role")
           end
 
           it "raises errors for missing fields" do
@@ -105,9 +105,9 @@ RSpec.describe "Jobseekers can manage their profile", :geocode do
             add_jobseeker_profile_employment_with_a_gap
             click_link "Return to profile"
 
-            expect(page).to have_content "You have a gap in your work history (almost 1 year)"
-            expect(page).to have_content "Add another job or add a reason for this gap"
-            click_link "add a reason for this gap"
+            expect(page).to have_content "You have a gap in your work history of almost 1 year"
+            expect(page).to have_content "Add another job or explain this gap"
+            click_link "explain this gap"
 
             click_button "Continue"
 
@@ -142,8 +142,8 @@ RSpec.describe "Jobseekers can manage their profile", :geocode do
             click_on I18n.t("buttons.confirm_destroy")
 
             expect(page).not_to have_content("I was ill")
-            expect(page).to have_content "You have a gap in your work history (almost 1 year)"
-            expect(page).to have_content "Add another job or add a reason for this gap"
+            expect(page).to have_content "You have a gap in your work history of almost 1 year"
+            expect(page).to have_content "Add another job or explain this gap"
           end
         end
       end
@@ -498,7 +498,7 @@ RSpec.describe "Jobseekers can manage their profile", :geocode do
   private
 
   def add_jobseeker_profile_employment
-    click_link("Add roles")
+    click_link("Add a job or voluntary role")
 
     fill_in_current_role(form: "jobseekers_profile_employment_form")
 
@@ -509,7 +509,7 @@ RSpec.describe "Jobseekers can manage their profile", :geocode do
   end
 
   def add_jobseeker_profile_employment_with_a_gap
-    click_link("Add roles")
+    click_link("Add a job or voluntary role")
 
     fill_in I18n.t("helpers.label.jobseekers_profile_employment_form.organisation"), with: "Arsenal"
     fill_in I18n.t("helpers.label.jobseekers_profile_employment_form.job_title"), with: "Number 9"

--- a/spec/system/jobseekers/jobseekers_can_manage_personal_details_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_personal_details_spec.rb
@@ -25,26 +25,26 @@ RSpec.describe "Jobseekers can manage their personal details" do
 
       context "with an error" do
         it "displays an error" do
-          expect(page).to have_content("Do you need Skilled Worker visa sponsorship?")
+          expect(page).to have_content("Do you need Skilled Worker visa sponsorship to work in the UK?")
           click_on I18n.t("buttons.save_and_continue")
           expect(page).to have_content("There is a problem")
         end
       end
 
       it "passes a11y", :a11y do
-        expect(page).to have_content("Do you need Skilled Worker visa sponsorship?")
+        expect(page).to have_content("Do you need Skilled Worker visa sponsorship to work in the UK?")
         expect(page).to be_axe_clean
       end
 
       it "allows the jobseeker to fill in their personal details" do
-        expect(page).to have_content("Do you need Skilled Worker visa sponsorship?")
+        expect(page).to have_content("Do you need Skilled Worker visa sponsorship to work in the UK?")
         fill_in "personal_details[first_name]", with: first_name
         fill_in "personal_details[last_name]", with: last_name
         choose "Yes"
         click_on I18n.t("buttons.save_and_continue")
 
         expect(page).to have_content("#{first_name} #{last_name}")
-        expect(page).to have_content("Yes, I will need to apply for a visa giving me the right to work in the UK")
+        expect(page).to have_content("Yes, I need Skilled Worker visa sponsorship")
       end
     end
 

--- a/spec/system/jobseekers/jobseekers_can_manage_their_job_applications_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_manage_their_job_applications_spec.rb
@@ -59,22 +59,22 @@ RSpec.describe "Jobseekers can manage their job applications" do
 
           within ".card-component:nth-child(1)" do
             expect(page).to have_css(".card-component__header", text: draft_job_application.vacancy.job_title)
-            expect(page).to have_css(".card-component__actions", text: "draft")
+            expect(page).to have_css(".card-component__actions", text: "Draft")
           end
 
           within ".card-component:nth-child(2)" do
             expect(page).to have_css(".card-component__header", text: application_with_action.vacancy.job_title)
-            expect(page).to have_css(".card-component__actions", text: "needs action")
+            expect(page).to have_css(".card-component__actions", text: "Needs action")
           end
 
           within ".card-component:nth-child(3)" do
             expect(page).to have_css(".card-component__header", text: interviewing_job_application.vacancy.job_title)
-            expect(page).to have_css(".card-component__actions", text: "interviewing")
+            expect(page).to have_css(".card-component__actions", text: "Interviewing")
           end
 
           within ".card-component:nth-child(4)" do
             expect(page).to have_css(".card-component__header", text: shortlisted_job_application.vacancy.job_title)
-            expect(page).to have_css(".card-component__actions", text: "shortlisted")
+            expect(page).to have_css(".card-component__actions", text: "Shortlisted")
           end
 
           within ".card-component:nth-child(5)" do
@@ -83,22 +83,22 @@ RSpec.describe "Jobseekers can manage their job applications" do
               dt = find("dt", text: "Submitted")
               expect(dt.sibling("dd").text).to eq("1 March 2025 at 12:31pm")
             end
-            expect(page).to have_css(".card-component__actions", text: "submitted")
+            expect(page).to have_css(".card-component__actions", text: "Submitted")
           end
 
           within ".card-component:nth-child(6)" do
             expect(page).to have_css(".card-component__header", text: unsuccessful_job_application.vacancy.job_title)
-            expect(page).to have_css(".card-component__actions", text: "unsuccessful")
+            expect(page).to have_css(".card-component__actions", text: "Unsuccessful")
           end
 
           within ".card-component:nth-child(7)" do
             expect(page).to have_css(".card-component__header", text: withdrawn_job_application.vacancy.job_title)
-            expect(page).to have_css(".card-component__actions", text: "withdrawn")
+            expect(page).to have_css(".card-component__actions", text: "Withdrawn")
           end
 
           within ".card-component:nth-child(8)" do
             expect(page).to have_css(".card-component__header", text: deadline_passed_job_application.vacancy.job_title)
-            expect(page).to have_css(".card-component__actions", text: "job closed")
+            expect(page).to have_css(".card-component__actions", text: "Job closed")
           end
         end
 

--- a/spec/system/jobseekers/jobseekers_can_transfer_data_from_old_account_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_transfer_data_from_old_account_spec.rb
@@ -28,21 +28,21 @@ RSpec.describe "Jobseekers can transfer data from an old account" do
       expect_account_to_have_no_data
 
       visit new_jobseekers_request_account_transfer_email_path
-      click_on "Save and continue"
+      click_on "Send verification email"
       expect(page).to have_css("ul.govuk-list.govuk-error-summary__list")
       within "ul.govuk-list.govuk-error-summary__list" do
         expect(page).to have_link("Enter your email address", href: "#jobseekers-request-account-transfer-email-form-email-field-error")
       end
 
       fill_in "jobseekers_request_account_transfer_email_form[email]", with: "xxxxx"
-      click_on "Save and continue"
+      click_on "Send verification email"
       expect(page).to have_css("ul.govuk-list.govuk-error-summary__list")
       within "ul.govuk-list.govuk-error-summary__list" do
         expect(page).to have_link("Enter a valid email address in the correct format, like name@example.com", href: "#jobseekers-request-account-transfer-email-form-email-field-error")
       end
 
       fill_in "jobseekers_request_account_transfer_email_form[email]", with: old_jobseeker_account.email
-      click_on "Save and continue"
+      click_on "Send verification email"
       expect(delivered_emails.last.personalisation.fetch(:token)).to eq(old_jobseeker_account.reload.account_merge_confirmation_code)
       expect(page).not_to have_css("div.govuk-notification-banner__content p.govuk-notification-banner__heading", text: "Email resent")
 
@@ -72,7 +72,7 @@ RSpec.describe "Jobseekers can transfer data from an old account" do
     it "allows user to request an account transfer but does not send an email" do
       visit new_jobseekers_request_account_transfer_email_path
       fill_in "jobseekers_request_account_transfer_email_form[email]", with: "nonexistant-user-email@gmail.com"
-      click_on "Save and continue"
+      click_on "Send verification email"
       expect(delivered_emails).to eq []
       expect(page).to have_content "Check your email"
     end
@@ -87,7 +87,7 @@ RSpec.describe "Jobseekers can transfer data from an old account" do
       visit new_jobseekers_request_account_transfer_email_path
 
       fill_in "jobseekers_request_account_transfer_email_form[email]", with: jobseeker.email
-      click_on "Save and continue"
+      click_on "Send verification email"
 
       within "ul.govuk-list.govuk-error-summary__list" do
         expect(page).to have_link("You entered the email of the account you are currently logged in to. The data in this account is already available to you and cannot be transferred.", href: "#jobseekers-request-account-transfer-email-form-email-field-error")
@@ -99,7 +99,7 @@ RSpec.describe "Jobseekers can transfer data from an old account" do
     before do
       visit new_jobseekers_request_account_transfer_email_path
       fill_in "jobseekers_request_account_transfer_email_form[email]", with: old_jobseeker_account.email
-      click_on "Save and continue"
+      click_on "Send verification email"
       travel_to(Time.current + 61.minutes)
     end
 
@@ -119,13 +119,13 @@ RSpec.describe "Jobseekers can transfer data from an old account" do
     it "only sends the first email" do
       visit new_jobseekers_request_account_transfer_email_path
       fill_in "jobseekers_request_account_transfer_email_form[email]", with: old_jobseeker_account.email
-      click_on "Save and continue"
+      click_on "Send verification email"
 
       expect(page).to have_content "Email sent to: #{old_jobseeker_account.email}"
 
       visit new_jobseekers_request_account_transfer_email_path
       fill_in "jobseekers_request_account_transfer_email_form[email]", with: old_jobseeker_account.email
-      click_on "Save and continue"
+      click_on "Send verification email"
 
       expect(page).to have_css("ul.govuk-list.govuk-error-summary__list")
       within "ul.govuk-list.govuk-error-summary__list" do

--- a/spec/system/publishers/publishers_can_change_status_of_applications_spec.rb
+++ b/spec/system/publishers/publishers_can_change_status_of_applications_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "check job application after status transition" do
         # view draft application
         jobseeker_applications_page.click_on_job_application(job_application.id)
         expect(jobseeker_application_apply_page).to be_displayed(id: job_application.id)
-        expect(jobseeker_application_apply_page.tag).to have_text("draft")
+        expect(jobseeker_application_apply_page.tag).to have_text("Draft")
       end
 
       run_with_publisher(publisher) do
@@ -94,7 +94,7 @@ RSpec.describe "check job application after status transition" do
         #
         jobseeker_applications_page.click_on_job_application(job_application.id)
         expect(jobseeker_application_page).to be_displayed(id: job_application.id)
-        expect(jobseeker_application_page.tag).to have_text("submitted")
+        expect(jobseeker_application_page.tag).to have_text("Submitted")
       end
 
       run_with_publisher(publisher) do
@@ -129,7 +129,7 @@ RSpec.describe "check job application after status transition" do
         #
         jobseeker_applications_page.click_on_job_application(job_application.id)
         expect(jobseeker_application_page).to be_displayed(id: job_application.id)
-        expect(jobseeker_application_page.tag).to have_text("unsuccessful")
+        expect(jobseeker_application_page.tag).to have_text("Unsuccessful")
       end
     end
   end
@@ -171,7 +171,7 @@ RSpec.describe "check job application after status transition" do
         #
         jobseeker_applications_page.click_on_job_application(job_application.id)
         expect(jobseeker_application_page).to be_displayed(id: job_application.id)
-        expect(jobseeker_application_page.tag).to have_text("shortlisted")
+        expect(jobseeker_application_page.tag).to have_text("Shortlisted")
       end
     end
   end
@@ -193,7 +193,7 @@ RSpec.describe "check job application after status transition" do
         #
         jobseeker_applications_page.click_on_job_application(job_application.id)
         expect(jobseeker_application_page).to be_displayed(id: job_application.id)
-        expect(jobseeker_application_page.tag).to have_text("shortlisted")
+        expect(jobseeker_application_page.tag).to have_text("Shortlisted")
       end
 
       run_with_publisher(publisher) do
@@ -243,7 +243,7 @@ RSpec.describe "check job application after status transition" do
 
         jobseeker_applications_page.click_on_job_application(job_application.id)
         expect(jobseeker_application_page).to be_displayed(id: job_application.id)
-        expect(jobseeker_application_page.tag).to have_text("interviewing")
+        expect(jobseeker_application_page.tag).to have_text("Interviewing")
       end
     end
   end
@@ -265,7 +265,7 @@ RSpec.describe "check job application after status transition" do
         #
         jobseeker_applications_page.click_on_job_application(job_application.id)
         expect(jobseeker_application_page).to be_displayed(id: job_application.id)
-        expect(jobseeker_application_page.tag).to have_text("interviewing")
+        expect(jobseeker_application_page.tag).to have_text("Interviewing")
       end
 
       run_with_publisher(publisher) do
@@ -308,7 +308,7 @@ RSpec.describe "check job application after status transition" do
 
         jobseeker_applications_page.click_on_job_application(job_application.id)
         expect(jobseeker_application_page).to be_displayed(id: job_application.id)
-        expect(jobseeker_application_page.tag).to have_text("offered")
+        expect(jobseeker_application_page.tag).to have_text("Offered")
       end
     end
   end
@@ -330,7 +330,7 @@ RSpec.describe "check job application after status transition" do
         #
         jobseeker_applications_page.click_on_job_application(job_application.id)
         expect(jobseeker_application_page).to be_displayed(id: job_application.id)
-        expect(jobseeker_application_page.tag).to have_text("interviewing")
+        expect(jobseeker_application_page.tag).to have_text("Interviewing")
       end
 
       run_with_publisher(publisher) do
@@ -362,7 +362,7 @@ RSpec.describe "check job application after status transition" do
         #
         jobseeker_applications_page.click_on_job_application(job_application.id)
         expect(jobseeker_application_page).to be_displayed(id: job_application.id)
-        expect(jobseeker_application_page.tag).to have_text("unsuccessful")
+        expect(jobseeker_application_page.tag).to have_text("Unsuccessful")
       end
     end
   end
@@ -382,7 +382,7 @@ RSpec.describe "check job application after status transition" do
 
         jobseeker_applications_page.click_on_job_application(job_application.id)
         expect(jobseeker_application_page).to be_displayed(id: job_application.id)
-        expect(jobseeker_application_page.tag).to have_text("offered")
+        expect(jobseeker_application_page.tag).to have_text("Offered")
       end
 
       run_with_publisher(publisher) do
@@ -411,7 +411,7 @@ RSpec.describe "check job application after status transition" do
         #
         jobseeker_applications_page.click_on_job_application(job_application.id)
         expect(jobseeker_application_page).to be_displayed(id: job_application.id)
-        expect(jobseeker_application_page.tag).to have_text("declined")
+        expect(jobseeker_application_page.tag).to have_text("Declined")
       end
     end
   end

--- a/spec/views/jobseekers/job_applications/apply.html.slim_spec.rb
+++ b/spec/views/jobseekers/job_applications/apply.html.slim_spec.rb
@@ -35,9 +35,9 @@ RSpec.describe "jobseekers/job_applications/apply" do
 
     it "displays common elements" do
       expect(banner).to have_css(selectors[:header], text: "#{vacancy.job_title} at #{vacancy.organisation.name}")
-      expect(banner).to have_css(selectors[:view_link], text: "View this listing (opens in new tab)")
-      expect(banner).to have_link("View this listing (opens in new tab)", href: job_path(vacancy))
-      expect(banner).to have_css(selectors[:tag], text: "draft")
+      expect(banner).to have_css(selectors[:view_link], text: "View job listing (opens in new tab)")
+      expect(banner).to have_link("View job listing (opens in new tab)", href: job_path(vacancy))
+      expect(banner).to have_css(selectors[:tag], text: "Draft")
     end
 
     context "with draft application" do

--- a/spec/views/jobseekers/job_applications/index.html.slim_spec.rb
+++ b/spec/views/jobseekers/job_applications/index.html.slim_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "jobseekers/job_applications/index" do
         it "renders draft applications group first" do
           expect(groups[0]).to have_css(selectors[:job_application_header], text: active_draft_job.job_title)
           expect(groups[0].find(selectors[:job_application_header])["href"]).to eq(jobseekers_job_application_apply_path(active_draft))
-          expect(groups[0]).to have_css(selectors[:job_application_tag], text: "draft")
+          expect(groups[0]).to have_css(selectors[:job_application_tag], text: "Draft")
         end
 
         it "renders active applications group" do
@@ -65,9 +65,9 @@ RSpec.describe "jobseekers/job_applications/index" do
             expect(groups[idx + 1]).to have_css(selectors[:job_application_header], text: application.vacancy.job_title)
             expect(groups[idx + 1].find(selectors[:job_application_header])["href"]).to eq(jobseekers_job_application_path(application))
             if application.status == "reviewed"
-              expect(groups[idx + 1]).to have_css(selectors[:job_application_tag], text: "submitted")
+              expect(groups[idx + 1]).to have_css(selectors[:job_application_tag], text: "Submitted")
             else
-              expect(groups[idx + 1]).to have_css(selectors[:job_application_tag], text: application.status)
+              expect(groups[idx + 1]).to have_css(selectors[:job_application_tag], text: JobApplicationsHelper::JOBSEEKER_STATUS_MAPPINGS[application.status.to_sym])
             end
           end
         end
@@ -75,14 +75,14 @@ RSpec.describe "jobseekers/job_applications/index" do
         it "renders expired applications group last" do
           expect(groups.last).to have_css(selectors[:job_application_header], text: vacancy_expired.job_title)
           expect(groups.last.find(selectors[:job_application_header])["href"]).to eq(jobseekers_job_application_apply_path(expired_draft))
-          expect(groups.last).to have_css(selectors[:job_application_tag], text: "job closed")
+          expect(groups.last).to have_css(selectors[:job_application_tag], text: "Job closed")
         end
       end
     end
   end
 
   describe "self disclosure request tag" do
-    let(:tag_text) { "needs action" }
+    let(:tag_text) { "Needs action" }
     let(:job_applications) { [job_application] }
 
     context "when self_disclosure_request sent" do

--- a/spec/views/jobseekers/job_applications/review.html.slim_spec.rb
+++ b/spec/views/jobseekers/job_applications/review.html.slim_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "jobseekers/job_applications/review" do
     let(:vacancy) { build_stubbed(:vacancy, organisations: build_stubbed_list(:trust, 1, name: trust_name)) }
 
     it "has MAT-specific content" do
-      expect(rendered).to have_content("Do you have any family or close relationship(s) with people within the school, MAT or any governors or trustees at #{trust_name}?")
+      expect(rendered).to have_content("Do you have a family or close relationship with anyone who works at #{trust_name}, or with any of its governors or trustees?")
     end
   end
 
@@ -26,7 +26,7 @@ RSpec.describe "jobseekers/job_applications/review" do
     let(:vacancy) { build_stubbed(:vacancy, organisations: build_stubbed_list(:school, 1, name: school_name)) }
 
     it "has content which doesnt mention a MAT" do
-      expect(rendered).to have_content("Do you have any family or close relationship(s) with people within the school or any governors or trustees at #{school_name}?")
+      expect(rendered).to have_content("Do you have a family or close relationship with anyone who works at #{school_name}, or with any of its governors or trustees?")
     end
   end
 end

--- a/spec/views/jobseekers/job_applications/show.html.slim_spec.rb
+++ b/spec/views/jobseekers/job_applications/show.html.slim_spec.rb
@@ -98,15 +98,15 @@ RSpec.describe "jobseekers/job_applications/show" do
 
     it "displays common elements" do
       expect(banner).to have_css(selectors[:header], text: "#{vacancy.job_title} at #{vacancy.organisation.name}")
-      expect(banner).to have_css(selectors[:view_link], text: "View this listing (opens in new tab)")
-      expect(banner).to have_link("View this listing (opens in new tab)", href: job_path(vacancy))
+      expect(banner).to have_css(selectors[:view_link], text: "View job listing (opens in new tab)")
+      expect(banner).to have_link("View job listing (opens in new tab)", href: job_path(vacancy))
     end
 
     context "with active application" do
       let(:job_application) { build_stubbed(:job_application, :status_shortlisted, jobseeker:, vacancy:) }
 
       it "renders section" do
-        expect(banner).to have_css(selectors[:tag], text: "shortlisted")
+        expect(banner).to have_css(selectors[:tag], text: "Shortlisted")
 
         expect(banner).to have_css(selectors[:withdraw_btn])
         expect(banner).to have_link("Withdraw", href: jobseekers_job_application_confirm_withdraw_path(job_application))
@@ -123,7 +123,7 @@ RSpec.describe "jobseekers/job_applications/show" do
       let(:self_disclosure_request) { create(:self_disclosure_request, :sent) }
 
       it "renders section" do
-        expect(banner).to have_css(selectors[:tag], text: "unsuccessful")
+        expect(banner).to have_css(selectors[:tag], text: "Unsuccessful")
 
         expect(banner).to have_css(selectors[:download_btn])
         expect(banner).to have_link("Download your completed application", href: jobseekers_job_application_download_path(job_application))

--- a/spec/views/jobseekers/saved_jobs/index.html.slim_spec.rb
+++ b/spec/views/jobseekers/saved_jobs/index.html.slim_spec.rb
@@ -45,9 +45,9 @@ RSpec.describe "jobseekers/saved_jobs/index" do
       end
 
       it "shows job closed label for expired jobs" do
-        expect(second_child).to have_css(".card-component__body", text: I18n.t("jobseekers.saved_jobs.index.deadline_passed"))
-        expect(third_child).to have_no_css(".card-component__body", text: I18n.t("jobseekers.saved_jobs.index.deadline_passed"))
-        expect(fourth_child).to have_no_css(".card-component__body", text: I18n.t("jobseekers.saved_jobs.index.deadline_passed"))
+        expect(second_child).to have_css(".card-component__body", text: "Job closed")
+        expect(third_child).to have_no_css(".card-component__body", text: "Job closed")
+        expect(fourth_child).to have_no_css(".card-component__body", text: "Job closed")
       end
 
       it "only allows jobseekers to apply for jobs that have not expired" do

--- a/spec/views/publishers/vacancies/job_applications/show.html.slim_spec.rb
+++ b/spec/views/publishers/vacancies/job_applications/show.html.slim_spec.rb
@@ -64,10 +64,10 @@ RSpec.describe "publishers/vacancies/job_applications/show" do
     expect(rendered).to have_css(".govuk-summary-list__key", text: "Email address")
     expect(rendered).to have_css(".govuk-summary-list__value", text: job_application.email_address)
 
-    expect(rendered).to have_css(".govuk-summary-list__key", text: "Do you need Skilled Worker visa sponsorship?")
+    expect(rendered).to have_css(".govuk-summary-list__key", text: "Do you need Skilled Worker visa sponsorship to work in the UK?")
     expect(rendered).to have_css(".govuk-summary-list__value", text: I18n.t("jobseekers.profiles.personal_details.edit.work.options.true"))
 
-    expect(rendered).to have_css(".govuk-summary-list__key", text: "Do you have a national insurance number?")
+    expect(rendered).to have_css(".govuk-summary-list__key", text: "Do you have a National Insurance number?")
     expect(rendered).to have_css(".govuk-summary-list__value", text: I18n.t("helpers.label.jobseekers_job_application_personal_details_form.has_ni_number_options.yes"))
 
     expect(rendered).to have_css(".govuk-summary-list__key", text: "National Insurance number")
@@ -103,10 +103,10 @@ RSpec.describe "publishers/vacancies/job_applications/show" do
       expect(rendered).to have_css(".govuk-summary-list__key", text: "Email address")
       expect(rendered).to have_no_css(".govuk-summary-list__value", text: job_application.email_address)
 
-      expect(rendered).to have_css(".govuk-summary-list__key", text: "Do you need Skilled Worker visa sponsorship?")
+      expect(rendered).to have_css(".govuk-summary-list__key", text: "Do you need Skilled Worker visa sponsorship to work in the UK?")
       expect(rendered).to have_css(".govuk-summary-list__value", text: I18n.t("jobseekers.profiles.personal_details.edit.work.options.true"))
 
-      expect(rendered).to have_css(".govuk-summary-list__key", text: "Do you have a national insurance number?")
+      expect(rendered).to have_css(".govuk-summary-list__key", text: "Do you have a National Insurance number?")
       expect(rendered).to have_css(".govuk-summary-list__value", text: I18n.t("helpers.label.jobseekers_job_application_personal_details_form.has_ni_number_options.yes"))
 
       expect(rendered).to have_css(".govuk-summary-list__key", text: "National Insurance number")
@@ -164,7 +164,7 @@ RSpec.describe "publishers/vacancies/job_applications/show" do
       expect(rendered).to have_css(".govuk-summary-list__key", text: "Email address")
       expect(rendered).to have_css(".govuk-summary-list__value", text: uploaded_job_application.email_address)
 
-      expect(rendered).to have_css(".govuk-summary-list__key", text: "Do you need Skilled Worker visa sponsorship?")
+      expect(rendered).to have_css(".govuk-summary-list__key", text: "Do you need Skilled Worker visa sponsorship to work in the UK?")
       expect(rendered).to have_css(".govuk-summary-list__value", text: I18n.t("jobseekers.profiles.personal_details.edit.work.options.true"))
 
       expect(rendered).to have_css(".govuk-summary-list__key", text: "Teacher reference number (TRN)")


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/FEwfuNvx/3043-text-update-jobseeker-journey

## Changes in this PR:

- Locale files (config/locales/jobseekers.yml, forms.yml, jobs.yml, en.yml, and several config/locales/jobseekers/**/*.yml) — the bulk of the copy updates across saved jobs, account transfer, applications list, apply, and all 12 application wizard steps, plus profile and job alert pages.
- A few small supporting code changes, since some copy couldn't be achieved via text alone:
  - job_applications_helper.rb: capitalized the draft/shortlisted/interviewing/offered status tag values.
  - Qualifications: added category-aware labels so the "institution"/"subject" field text can differ between undergraduate ("University or college", "Degree subject") and postgraduate ("University, college or awarding body", "Qualification subject") — previously these shared one label.
  - request_account_transfer_emails/new.html.slim: button changed to "Send verification email" (kept separate from the global "Save and continue" button used elsewhere).
  - subscriptions/new: gave the keyword/location fields their own locale keys so the wording change didn't leak into the main job search page (it originally shared keys with it).
  - Small tweaks: date hint format (03 2025 → 3 2025), "Or" divider capitalization on the employment form, and removed a now-redundant link in the declarations step.
- Updated spec/support/jobseeker_helpers.rb and ~15 spec files whose assertions/fill-ins referenced the old copy, so the suite stays green.

## Screenshots of UI changes:

### Before

### After

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
