### PR TITLE
2893 - Removes terraform-common-plan from plan stage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ terraform-app-init: set-azure-account
 	$(eval export TF_VAR_service_name=${SERVICE_NAME})
 	$(eval export TF_VAR_service_short=${SERVICE_SHORT})
 
-terraform-plan: terraform-app-plan terraform-common-plan
+terraform-plan: terraform-app-plan
 
 .PHONY: terraform-app-plan
 terraform-app-plan: terraform-app-init check-terraform-variables ## make passcode=MyPasscode tag=dev-08406f04dd9eadb7df6fcda5213be880d7df37ed-20201022090714 <env> terraform-app-plan


### PR DESCRIPTION
[## Trello card URL](https://trello.com/c/EUnRcz6f/2893-correct-iam-permissions-in-teaching-vacancies)

## Changes in this PR:
Removes terraform-common-plan from plan stage in Makefile. Line 137 is now:

`terraform-plan: terraform-app-plan`

This has been necessary to temporarily fix the failing Validate Infra workflow due to IAM permissions issues (terraform-common is not deployed by workflows hence the need to remove and consider). Further discussion around this may then be required.

## Checklist:

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the devops label
- [x] I have attached the pull request to the trello card
