### PR TITLE
Allow school groups to post religious vacancies

### DIFF
--- a/app/models/school_group.rb
+++ b/app/models/school_group.rb
@@ -20,9 +20,8 @@ class SchoolGroup < Organisation
     false
   end
 
-  # Allows School Groups/MATs to post religious character vacancies for their head office.
-  # School Groups don't have religious character information, but some are religious.
-  # Only allowing this as this provides extra functionality that may be ignored if not needed.
+  # Allows School Groups/MATs to use religious application forms for head office vacancies.
+  # School Groups don’t store religious character information, so we treat a group with at least one faith school as a faith organisation.
   def faith_school?
     schools.only_faith_schools.exists?
   end

--- a/app/models/school_group.rb
+++ b/app/models/school_group.rb
@@ -20,8 +20,11 @@ class SchoolGroup < Organisation
     false
   end
 
+  # Allows School Groups/MATs to post religious character vacancies for their head office.
+  # School Groups don't have religious character information, but some are religious.
+  # Only allowing this as this provides extra functionality that may be ignored if not needed.
   def faith_school?
-    false
+    schools.only_faith_schools.exists?
   end
 
   def all_organisations

--- a/app/views/publishers/build_vacancy_templates/applying_for_the_job.html.slim
+++ b/app/views/publishers/build_vacancy_templates/applying_for_the_job.html.slim
@@ -14,7 +14,7 @@
       label: -> { t("helpers.label.publishers_job_listing_applying_for_the_job_form.application_form_type_options.no_religion_html", tag: govuk_tag(text: t("publishers.vacancies.build.applying_for_the_job.kcsie_compliant"), colour: "green")) },
       link_errors: true
 
-    - if @faith_school
+    - if current_organisation.faith_school?
       = f.govuk_radio_button :application_form_type, :catholic,
         label: -> { t("helpers.label.publishers_job_listing_applying_for_the_job_form.application_form_type_options.catholic_html", tag: govuk_tag(text: t("publishers.vacancies.build.applying_for_the_job.kcsie_compliant"), colour: "green")) }
 

--- a/spec/models/school_group_spec.rb
+++ b/spec/models/school_group_spec.rb
@@ -6,4 +6,26 @@ RSpec.describe SchoolGroup do
 
   it { expect(subject.attributes).to include("gias_data") }
   it { expect(described_class.columns_hash["gias_data"].type).to eq(:json) }
+
+  describe "#faith_school?" do
+    subject(:school_group) { create(:school_group, schools:) }
+
+    context "when any of the group schools is a faith school" do
+      let(:schools) { [create(:school, religious_character: "None"), create(:school, :catholic)] }
+
+      it { is_expected.to be_faith_school }
+    end
+
+    context "when none of the group schools is a faith school" do
+      let(:schools) { [create(:school, religious_character: "None"), create(:school, religious_character: "Does not apply")] }
+
+      it { is_expected.not_to be_faith_school }
+    end
+
+    context "when the group has no schools" do
+      let(:schools) { [] }
+
+      it { is_expected.not_to be_faith_school }
+    end
+  end
 end

--- a/spec/views/publishers/build_vacancy_templates/applying_for_the_job.html.slim_spec.rb
+++ b/spec/views/publishers/build_vacancy_templates/applying_for_the_job.html.slim_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe "publishers/build_vacancy_templates/applying_for_the_job" do
+  let(:publisher) { build_stubbed(:publisher) }
+  let(:form) { Publishers::JobListing::ApplyingForTheJobForm.new }
+
+  before do
+    assign(:form, form)
+    allow(view).to receive_messages(current_organisation: organisation, wizard_path: "")
+    sign_in(publisher, scope: :publisher)
+    render
+  end
+
+  after { sign_out publisher }
+
+  context "with a faith school" do
+    let(:organisation) { build_stubbed(:school, :catholic) }
+
+    it "offers the religious application forms" do
+      expect(rendered).to have_content("Catholic Education Service approved online application form")
+      expect(rendered).to have_content("Teaching Vacancies application form with questions about religion")
+    end
+  end
+
+  context "with a non-faith school" do
+    let(:organisation) { build_stubbed(:school, religious_character: "None") }
+
+    it "does not offer the religious application forms" do
+      expect(rendered).to have_no_content("Catholic Education Service approved online application form")
+      expect(rendered).to have_no_content("Teaching Vacancies application form with questions about religion")
+    end
+  end
+
+  context "with a school group containing a faith school" do
+    let(:organisation) { create(:school_group, schools: [create(:school, :catholic)]) }
+
+    it "offers the religious application forms" do
+      expect(rendered).to have_content("Catholic Education Service approved online application form")
+      expect(rendered).to have_content("Teaching Vacancies application form with questions about religion")
+    end
+  end
+
+  context "with a school group containing no faith schools" do
+    let(:organisation) { create(:school_group, schools: [create(:school, religious_character: "None")]) }
+
+    it "does not offer the religious application forms" do
+      expect(rendered).to have_no_content("Catholic Education Service approved online application form")
+      expect(rendered).to have_no_content("Teaching Vacancies application form with questions about religion")
+    end
+  end
+end


### PR DESCRIPTION
## Trello card URL

- https://trello.com/c/biT6Raji/3060-bug-catholic-mat-head-office-job-doesnt-allow-ces-form-to-be-selected

## Changes in this PR:

There was a Catholic MAT requesting to post a vacancy following the catholic application flow for their head office. This option wasn't offered to them.

It turned out that we only offer this to faith schools, and the School Groups/MATS don't have "religious character" info.

To resolve this, we are considering the school groups containing any faith school as faith schools themselves.
This will allow them to post religious vacancies for their head office positions.

This may be completely irrelevant for the majority of the SG/MATs, but they just to select the default non-religious application option when posting vacancies. This is an enhancement that they may or may not use.

Bonus: When trying to extend this to the vacancy templates, noticed that the religious flow for those was unreachable. Fixed it.

## Screenshots of UI changes:

Weydon MAT has 2 faith schools: 

### Before
<img width="1009" height="892" alt="image" src="https://github.com/user-attachments/assets/938e7923-8f76-4736-a6d4-b9d825688491" />

### After
<img width="1049" height="1078" alt="image" src="https://github.com/user-attachments/assets/ec5ff775-7b94-4d4b-b26f-1b6798692669" />


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
