### PR TITLE
Fix publisher nav tab highlighting

### DIFF
--- a/app/helpers/navigations_helper.rb
+++ b/app/helpers/navigations_helper.rb
@@ -7,6 +7,22 @@ module NavigationsHelper
     current_page?(organisation_jobs_with_type_path) || request.original_fullpath =~ %r{^/organisation/jobs}
   end
 
+  def messages_active?
+    request.original_fullpath =~ %r{^/publishers/candidate_messages}
+  end
+
+  def candidate_profiles_active?
+    request.original_fullpath =~ %r{^/publishers/jobseeker_profiles}
+  end
+
+  def statistics_active?
+    request.original_fullpath =~ %r{^/publishers/current_year_statistics}
+  end
+
+  def notifications_active?
+    request.original_fullpath =~ %r{^/publishers/notifications}
+  end
+
   def schools_in_your_trust_active?
     request.original_fullpath =~ %r{^/publishers/schools}
   end

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -34,10 +34,10 @@
 = govuk_service_navigation(service_name: t("app.title"), navigation_id: "tv-service-navigation") do |navigation|
   - if publisher_signed_in?
     - navigation.with_navigation_item text: t("nav.manage_jobs"), href: organisation_jobs_with_type_path, active: manage_jobs_active?
-    - navigation.with_navigation_item text: t("nav.messages"), href: publishers_candidate_messages_path
-    - navigation.with_navigation_item text: t("nav.candidate_profiles"), href: publishers_jobseeker_profiles_path
-    - navigation.with_navigation_item text: "Statistics", href: publishers_current_year_statistics_path
-    - navigation.with_navigation_item text: t("nav.notifications_html", count: current_publisher.notifications.unread.count), href: publishers_notifications_path
+    - navigation.with_navigation_item text: t("nav.messages"), href: publishers_candidate_messages_path, active: messages_active?
+    - navigation.with_navigation_item text: t("nav.candidate_profiles"), href: publishers_jobseeker_profiles_path, active: candidate_profiles_active?
+    - navigation.with_navigation_item text: "Statistics", href: publishers_current_year_statistics_path, active: statistics_active?
+    - navigation.with_navigation_item text: t("nav.notifications_html", count: current_publisher.notifications.unread.count), href: publishers_notifications_path, active: notifications_active?
   - else
     - navigation.with_navigation_item text: t("sub_nav.jobs"), href: jobs_path
     - navigation.with_navigation_item text: t("sub_nav.schools"), href: organisations_path


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/xwKtjDH3/3058-bug-fix-tab-highlighting-for-hiring-staff

## Changes in this PR:

Prior to this change the primary tabs for hiring staff were not working properly. The Manage jobs tab would highlight properly but none of the others. This PR fixes the issue.

## Screenshots of UI changes:



### Before
<img width="1546" height="482" alt="Screenshot 2026-07-16 at 11 51 00" src="https://github.com/user-attachments/assets/894fd32a-676d-4131-a8f8-a8ac3e5c41de" />
<img width="1534" height="557" alt="Screenshot 2026-07-16 at 11 50 52" src="https://github.com/user-attachments/assets/3e1f7648-68cf-46e2-b41f-3d9252687152" />

### After
<img width="1463" height="547" alt="Screenshot 2026-07-17 at 11 19 03" src="https://github.com/user-attachments/assets/b36df66c-1e4f-43dd-a583-e3b647bb3872" />
<img width="1376" height="580" alt="Screenshot 2026-07-17 at 11 18 57" src="https://github.com/user-attachments/assets/6a13e401-335b-47f4-9430-e1f5f0f55b16" />


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
