### PR TITLE
Fix bug causing school_group to show.

### DIFF
--- a/app/helpers/organisations_helper.rb
+++ b/app/helpers/organisations_helper.rb
@@ -73,7 +73,7 @@ module OrganisationsHelper
     elsif vacancy.organisations.any?(&:school?)
       "school"
     else
-      "school_group"
+      "organisation"
     end
   end
 


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/7RJvGBV5/3061-bug-school-group-showing-as-schoolgroup-to-publishers

## Changes in this PR:

This change fixes a bug with our translations causing school_group to show on about the role page rather than organisation.

## Screenshots of UI changes:

### Before
<img width="717" height="732" alt="Screenshot 2026-07-17 at 14 35 11" src="https://github.com/user-attachments/assets/79ebcf85-44fa-478b-83e5-25fb115b18ab" />

### After
<img width="920" height="827" alt="Screenshot 2026-07-17 at 14 34 45" src="https://github.com/user-attachments/assets/40f284b8-6580-42c3-b5e0-37b4b5559794" />

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
