### PR TITLE
Rename only_faith_schools scope

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -77,7 +77,7 @@ class Organisation < ApplicationRecord
 
   scope :in_scope_schools, -> { schools.kept.not_out_of_scope.where.not(school_type: COLLEGE_SCHOOL_TYPE).or(Organisation.trusts) }
 
-  scope :only_faith_schools, -> { where.not(religious_character: NON_FAITH_RELIGIOUS_CHARACTER_TYPES) }
+  scope :faith_schools, -> { where.not(religious_character: NON_FAITH_RELIGIOUS_CHARACTER_TYPES) }
 
   # This can safely ignore the 'extra' LA mappings as it is always called with a scope which excludes LAs in the first place
   scope :with_live_vacancies, lambda {

--- a/app/queries/vacancy_filter_query.rb
+++ b/app/queries/vacancy_filter_query.rb
@@ -60,10 +60,10 @@ class VacancyFilterQuery
     built_scope = built_scope.joins(organisation_vacancies: :organisation)
 
     if school_types.include?("faith_school") && school_types.include?("special_school")
-      built_scope.merge(Organisation.only_faith_schools)
+      built_scope.merge(Organisation.faith_schools)
                  .or(built_scope.where("organisations.detailed_school_type IN (?)", Organisation::SPECIAL_SCHOOL_TYPES)).distinct
     elsif school_types.include?("faith_school")
-      built_scope.merge(Organisation.only_faith_schools).distinct
+      built_scope.merge(Organisation.faith_schools).distinct
     elsif school_types.include?("special_school")
       built_scope.where(organisations: { detailed_school_type: Organisation::SPECIAL_SCHOOL_TYPES }).distinct
     else


### PR DESCRIPTION
## Trello card URL

## Changes in this PR:

This change renames scope only_faith_schools to faith_schools. I think this scope name prior to this change was a bit surprising as it doesn't follow our scope naming conventions (i.e we use in_scope_schools rather than only_in_scope_schools etc). I thought it may have been used to determine if a MAT included only_faith_schools or something like that but that does not seem to be the intention.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
