### PR TITLE
Added provider alias to correct cloudfront region

### DIFF
--- a/terraform/app/modules/cloudfront/main.tf
+++ b/terraform/app/modules/cloudfront/main.tf
@@ -133,9 +133,10 @@ resource "aws_route53_record" "cloudfront-cnames" {
 }
 
 resource "aws_wafv2_web_acl" "cloudfront-waf" {
-  count = var.enable_cloudfront_waf == true ? 1 : 0
-  name  = "${var.service_name}-${var.environment}-waf"
-  scope = "CLOUDFRONT"
+  count    = var.enable_cloudfront_waf == true ? 1 : 0
+  provider = aws.aws_us_east_1
+  name     = "${var.service_name}-${var.environment}-waf"
+  scope    = "CLOUDFRONT"
 
   default_action {
     allow {}


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/chHAU4LZ/2846-add-rate-limiting-for-teaching-vacancies 

## Changes in this PR:
Added a provider alias to the aws_wafv2_web_acl resource so it uses the correct us-east-1 region instead of failing to deploy in eu-west-2.

The previous PR was approved since the plan was valid, however, the apply stage failed due to the aws_wafv2_web_acl resource being deployed in the eu-west-2 region, when the documentation states that it must be created in us-east-1: [Terraform Docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl#:~:text=scope%20%2D%20(Required%2C%20Forces%20new%20resource)%20Specifies%20whether%20this%20is%20for%20an%20AWS%20CloudFront%20distribution%20or%20for%20a%20regional%20application.%20Valid%20values%20are%20CLOUDFRONT%20or%20REGIONAL.%20To%20work%20with%20CloudFront%2C%20you%20must%20also%20specify%20the%20region%20us%2Deast%2D1%20(N.%20Virginia)%20on%20the%20AWS%20provider.)

Failed workflow: https://github.com/DFE-Digital/teaching-vacancies/actions/runs/29583631763

## To review
Clone the branch and run a terraform plan against qa:

Running a local plan will require authentication to Azure, AWS and GCP:

1. Run az login (with PIM elevation to test and prod)
2. Follow guidance in /documentation/operations/infrastructure/aws-roles-and-cli-tools.md to authenticate to AWS (Line 255 - Assuming an AWS role without AWS Vault) . Use Administrator role.
3. GCP should authenticate automatically when running the tf plan makefile command, however, you will need permissions to the teacher-vacancy-service project.

Once authentication is complete, run the following command to generate a plan for qa:
make qa terraform-app-plan

Confirm that plan shows that resource is now being deployed into us-east-1 region:
<img width="659" height="385" alt="image" src="https://github.com/user-attachments/assets/564404f1-f49b-479e-8686-ed4ff24c0498" />
