### PR TITLE
2846 - Update IAM permissions to deploy WAF resources

### DIFF
--- a/terraform/common/iam.tf
+++ b/terraform/common/iam.tf
@@ -96,6 +96,13 @@ data "aws_iam_policy_document" "deployments_role_policy" {
     resources = ["*"]
   }
 
+  # WAF
+  statement {
+    sid       = "ManageWAF"
+    actions   = ["wafv2:*"]
+    resources = ["*"]
+  }
+
   # Offline site in S3
   statement {
     sid       = "ManageOfflineSiteS3Files"

--- a/terraform/workspace-variables/qa.tfvars.json
+++ b/terraform/workspace-variables/qa.tfvars.json
@@ -6,9 +6,7 @@
     "tvsqaaks": {
       "cloudfront_origin_domain_name": "teaching-vacancies-qa.test.teacherservices.cloud",
       "offline_bucket_domain_name": "530003481352-offline-site.s3.amazonaws.com",
-      "offline_bucket_origin_path": "/teaching-vacancies-offline",
-      "enable_cloudfront_waf": true,
-      "waf_ip_rate_limit": 900
+      "offline_bucket_origin_path": "/teaching-vacancies-offline"
     }
   },
   "environment": "qa",

--- a/terraform/workspace-variables/qa.tfvars.json
+++ b/terraform/workspace-variables/qa.tfvars.json
@@ -6,7 +6,9 @@
     "tvsqaaks": {
       "cloudfront_origin_domain_name": "teaching-vacancies-qa.test.teacherservices.cloud",
       "offline_bucket_domain_name": "530003481352-offline-site.s3.amazonaws.com",
-      "offline_bucket_origin_path": "/teaching-vacancies-offline"
+      "offline_bucket_origin_path": "/teaching-vacancies-offline",
+      "enable_cloudfront_waf": true,
+      "waf_ip_rate_limit": 900
     }
   },
   "environment": "qa",


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/chHAU4LZ/2846-add-rate-limiting-for-teaching-vacancies

## Changes in this PR:
This is a bugfix for a failing WAF deployment, which is caused by insufficient IAM permissions. This PR will add permissions to deployments_role_policy to allow the creation and management of WAF resources.

Once the PR is approved, the IAM changes will be applied locally before being merged. The merge will then trigger the build workflow, which should succeed in deploying the WAF resources since the required permissions will now be in place.

## To review:
Check the code changes to confirm that the IAM changes will add the ability to deploy WAF resources
Run a local plan using "make qa terraform-common-plan" and/or review the plan changes below:
<img width="747" height="616" alt="image" src="https://github.com/user-attachments/assets/95e50052-5fe8-4360-8dff-46a1a7bb4d7b" />
