### PR TITLE
Added provider alias for waf rules

### DIFF
--- a/terraform/app/modules/cloudfront/main.tf
+++ b/terraform/app/modules/cloudfront/main.tf
@@ -152,6 +152,7 @@ resource "aws_wafv2_web_acl" "cloudfront-waf" {
 
 resource "aws_wafv2_web_acl_rule" "rate-limit" {
   count       = var.enable_cloudfront_waf == true ? 1 : 0
+  provider    = aws.aws_us_east_1
   name        = "${var.service_name}-${var.environment}-rate-limit"
   priority    = 1
   web_acl_arn = aws_wafv2_web_acl.cloudfront-waf[0].arn
@@ -176,6 +177,7 @@ resource "aws_wafv2_web_acl_rule" "rate-limit" {
 
 resource "aws_wafv2_web_acl_rule" "sql-protection" {
   count       = var.enable_cloudfront_waf == true ? 1 : 0
+  provider    = aws.aws_us_east_1
   name        = "${var.service_name}-${var.environment}-sql-protection"
   priority    = 2
   web_acl_arn = aws_wafv2_web_acl.cloudfront-waf[0].arn


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/chHAU4LZ/2846-add-rate-limiting-for-teaching-vacancies

## Changes in this PR:
Add provider alias to aws_wafv2_web_acl_rule resources to use correct us-east-1 region

# To review:
Review code changes to confirm that aws_wafv2_web_acl_rule resources are now using the correct provider alias to match aws_wafv2_web_acl resource