### PR TITLE
Changed action-block to override_action-none

### DIFF
--- a/app/models/school_group.rb
+++ b/app/models/school_group.rb
@@ -23,7 +23,7 @@ class SchoolGroup < Organisation
   # Allows School Groups/MATs to use religious application forms for head office vacancies.
   # School Groups don’t store religious character information, so we treat a group with at least one faith school as a faith organisation.
   def faith_school?
-    schools.only_faith_schools.exists?
+    schools.faith_schools.exists?
   end
 
   def all_organisations

--- a/terraform/app/modules/cloudfront/main.tf
+++ b/terraform/app/modules/cloudfront/main.tf
@@ -182,8 +182,8 @@ resource "aws_wafv2_web_acl_rule" "sql-protection" {
   priority    = 2
   web_acl_arn = aws_wafv2_web_acl.cloudfront-waf[0].arn
 
-  action {
-    block {}
+  override_action {
+    none {}
   }
 
   statement {


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/chHAU4LZ/2846-add-rate-limiting-for-teaching-vacancies

## Changes in this PR:
Bugfix to update sql-protection rule. Despite the Terraform plan showing no issues, the aws_wafv2_web_acl_rule resource is showing as invalid during the apply stage. This change will attempt to resolve the issue by replacing the action block with override_action, which appears to be used instead when using AWS managed rule groups.

## To review:
Confirm that Terraform documentation uses the same structure when deploying AWS managed rule groups, as covered here: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_rule#managed-rule-group-statement:~:text=resource%20%22aws_wafv2_web_acl_rule%22%20%22aws_managed_rules,%3D%20true%0A%20%20%7D%0A%7D

Compare screenshots from AWS console when creating rate limit rules vs AWS managed rule groups - Note that action is only included in rate-limit and override is only included in managed rules:
<img width="605" height="710" alt="image" src="https://github.com/user-attachments/assets/d95dde86-8fe5-4b19-ab8f-c8843d96551d" />
<img width="594" height="820" alt="image" src="https://github.com/user-attachments/assets/5576f952-15ad-40e9-8071-3e9a43ae318e" />
