### PR TITLE
Removed WAF resources

### DIFF
--- a/terraform/app/modules/cloudfront/main.tf
+++ b/terraform/app/modules/cloudfront/main.tf
@@ -182,8 +182,8 @@ resource "aws_wafv2_web_acl_rule" "sql-protection" {
   priority    = 2
   web_acl_arn = aws_wafv2_web_acl.cloudfront-waf[0].arn
 
-  action {
-    block {}
+  override_action {
+    none {}
   }
 
   statement {

--- a/terraform/workspace-variables/qa.tfvars.json
+++ b/terraform/workspace-variables/qa.tfvars.json
@@ -7,7 +7,7 @@
       "cloudfront_origin_domain_name": "teaching-vacancies-qa.test.teacherservices.cloud",
       "offline_bucket_domain_name": "530003481352-offline-site.s3.amazonaws.com",
       "offline_bucket_origin_path": "/teaching-vacancies-offline",
-      "enable_cloudfront_waf": true,
+      "enable_cloudfront_waf": false,
       "waf_ip_rate_limit": 900
     }
   },


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/chHAU4LZ/2846-add-rate-limiting-for-teaching-vacancies

## Changes in this PR:
Remove WAF resources temporarily to unblock deployments to QA, will be reapplied once other changes have been implemented.

## To review:
Run local terraform plan using make qa terraform-plan and/or review the following screenshots to confirm removal of WAF and rate limit rule:
<img width="1017" height="768" alt="image" src="https://github.com/user-attachments/assets/b57ca903-42bb-45f6-9c39-34f55d63de71" />
<img width="1006" height="415" alt="image" src="https://github.com/user-attachments/assets/5fb1cd34-0445-46ae-b5dc-8db01003964f" />
