### PR TITLE
Fix missing faith schools scope renaming

### DIFF
--- a/app/models/school_group.rb
+++ b/app/models/school_group.rb
@@ -23,7 +23,7 @@ class SchoolGroup < Organisation
   # Allows School Groups/MATs to use religious application forms for head office vacancies.
   # School Groups don’t store religious character information, so we treat a group with at least one faith school as a faith organisation.
   def faith_school?
-    schools.only_faith_schools.exists?
+    schools.faith_schools.exists?
   end
 
   def all_organisations


### PR DESCRIPTION
## Changes in this PR:

A [new use of the scope was added](https://github.com/DFE-Digital/teaching-vacancies/pull/9061), and it seems the [renaming of the scope branch ](https://github.com/DFE-Digital/teaching-vacancies/pull/9064)wasn't up to date when merged. So missed this bit!

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
