### PR TITLE
Subject search

### DIFF
--- a/app/components/searchable_collection_component.rb
+++ b/app/components/searchable_collection_component.rb
@@ -10,6 +10,8 @@ class SearchableCollectionComponent < ApplicationComponent
     @border = options[:border] || false
     @collection_count = collection_count
     @scrollable = options[:scrollable] || searchable?
+    @search_name = options[:search_name]
+    @search_id = options[:search_id]
   end
 
   def searchable?
@@ -24,6 +26,14 @@ class SearchableCollectionComponent < ApplicationComponent
     return nil unless border
 
     "searchable-collection-component--border" if searchable?
+  end
+
+  def search_name
+    @search_name
+  end
+
+  def search_id
+    @search_id
   end
 
   private

--- a/app/components/searchable_collection_component.rb
+++ b/app/components/searchable_collection_component.rb
@@ -1,5 +1,6 @@
 class SearchableCollectionComponent < ApplicationComponent
   attr_accessor :collection, :collection_count, :threshold, :border, :label_text, :options, :scrollable
+  attr_reader :search_name, :search_id
 
   def initialize(collection:, collection_count:, options: {}, text: {}, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes.merge({ data: { controller: "searchable-collection" } }))
@@ -26,14 +27,6 @@ class SearchableCollectionComponent < ApplicationComponent
     return nil unless border
 
     "searchable-collection-component--border" if searchable?
-  end
-
-  def search_name
-    @search_name
-  end
-
-  def search_id
-    @search_id
   end
 
   private

--- a/app/components/searchable_collection_component/searchable_collection_component.html.slim
+++ b/app/components/searchable_collection_component/searchable_collection_component.html.slim
@@ -2,7 +2,7 @@
   div class="#{border_class} #{scrollable_class}"
     - if searchable?
       .searchable-collection-component__search
-        input.govuk-input.icon.icon--left.icon--search.js-action data-searchable-collection-target="input" data-action="input->searchable-collection#input" placeholder=@text[:placeholder] aria-label=@text[:aria_label] aria-expanded="true" aria-describedby=@text[:aria_describedby] aria-controls="subjects__listbox" role="combobox"
+        input.govuk-input.icon.icon--left.icon--search.js-action data-searchable-collection-target="input" data-action="input->searchable-collection#input" placeholder=@text[:placeholder] aria-label=@text[:aria_label] aria-expanded="true" aria-describedby=@text[:aria_describedby] aria-controls="subjects__listbox" role="combobox" name=search_name id=search_id
         .govuk-visually-hidden aria-live="assertive" role="status" class="collection-match"
 
     #subjects__listbox

--- a/app/controllers/concerns/publishers/wizardable.rb
+++ b/app/controllers/concerns/publishers/wizardable.rb
@@ -58,7 +58,7 @@ module Publishers::Wizardable # rubocop:disable Metrics/ModuleLength
 
   def subjects_params(params)
     params.require(:publishers_job_listing_subjects_form)
-          .permit(subjects: [])
+          .permit(:subject_search, subjects: [])
   end
 
   def contract_information_params(params)

--- a/app/controllers/publishers/build_vacancy_templates_controller.rb
+++ b/app/controllers/publishers/build_vacancy_templates_controller.rb
@@ -6,6 +6,7 @@ module Publishers
     include Publishers::Wizardable
 
     before_action :load_template
+    before_action :strip_checkbox_params, only: %i[update]
 
     steps(*VacancyTemplates::VacancyTemplateStepProcess.steps)
 
@@ -66,6 +67,12 @@ module Publishers
 
     def form_class
       VacancyTemplates::VacancyTemplateStepProcess.form_class(step)
+    end
+
+    def strip_checkbox_params
+      return unless STRIP_CHECKBOXES.key?(step)
+
+      strip_empty_checkboxes(STRIP_CHECKBOXES[step], :"publishers_job_listing_#{step}_form")
     end
 
     def load_template

--- a/app/form_models/publishers/job_listing/subjects_form.rb
+++ b/app/form_models/publishers/job_listing/subjects_form.rb
@@ -12,8 +12,7 @@ class Publishers::JobListing::SubjectsForm < Publishers::JobListing::JobListingF
       { subjects: [] }
     end
   end
-  attr_accessor(*FIELDS)
-  attr_accessor :subject_search
+  attr_accessor(*FIELDS, :subject_search)
 
   validate :subject_search_must_be_selected
 

--- a/app/form_models/publishers/job_listing/subjects_form.rb
+++ b/app/form_models/publishers/job_listing/subjects_form.rb
@@ -1,18 +1,18 @@
 class Publishers::JobListing::SubjectsForm < Publishers::JobListing::JobListingForm
-  FIELDS = %i[subjects].freeze
+  FIELDS = %i[subjects subject_search].freeze
 
   class << self
     # rubocop:disable Lint/UnusedMethodArgument
     def load_from_model(vacancy, current_publisher:)
-      new(vacancy.slice(*FIELDS))
+      new(vacancy.slice(:subjects))
     end
     # rubocop:enable Lint/UnusedMethodArgument
 
     def fields
-      { subjects: [] }
+      [:subject_search, { subjects: [] }]
     end
   end
-  attr_accessor(*FIELDS, :subject_search)
+  attr_accessor(*FIELDS)
 
   validate :subject_search_must_be_selected
 

--- a/app/form_models/publishers/job_listing/subjects_form.rb
+++ b/app/form_models/publishers/job_listing/subjects_form.rb
@@ -26,6 +26,6 @@ class Publishers::JobListing::SubjectsForm < Publishers::JobListing::JobListingF
     return if subject_search.blank?
     return if subjects.present?
 
-    errors.add(:subject_search, I18n.t("publishers.vacancies.build.subjects.errors.subject_searched_for_but_not_selected"))
+    errors.add(:subjects, I18n.t("publishers.vacancies.build.subjects.errors.subject_searched_for_but_not_selected"))
   end
 end

--- a/app/form_models/publishers/job_listing/subjects_form.rb
+++ b/app/form_models/publishers/job_listing/subjects_form.rb
@@ -15,7 +15,6 @@ class Publishers::JobListing::SubjectsForm < Publishers::JobListing::JobListingF
   attr_accessor(*FIELDS)
   attr_accessor :subject_search
 
-  validate :subjects_must_be_from_list
   validate :subject_search_must_be_selected
 
   def params_to_save
@@ -24,20 +23,10 @@ class Publishers::JobListing::SubjectsForm < Publishers::JobListing::JobListingF
 
   private
 
-  def subjects_must_be_from_list
-    valid_subjects = (SUBJECT_OPTIONS + FURTHER_EDUCATION_SUBJECT_OPTIONS).map(&:first)
-    Array(subjects).compact_blank.each do |subject|
-      unless valid_subjects.include?(subject)
-        errors.add(:subjects, I18n.t("publishers.vacancies.build.subjects.errors.not_in_list"))
-        break
-      end
-    end
-  end
-
   def subject_search_must_be_selected
     return if subject_search.blank?
-    return if Array(subjects).compact_blank.any?
+    return if subjects.present?
 
-    errors.add(:subject_search, I18n.t("publishers.vacancies.build.subjects.errors.not_in_list"))
+    errors.add(:subject_search, I18n.t("publishers.vacancies.build.subjects.errors.subject_searched_for_but_not_selected"))
   end
 end

--- a/app/form_models/publishers/job_listing/subjects_form.rb
+++ b/app/form_models/publishers/job_listing/subjects_form.rb
@@ -13,8 +13,31 @@ class Publishers::JobListing::SubjectsForm < Publishers::JobListing::JobListingF
     end
   end
   attr_accessor(*FIELDS)
+  attr_accessor :subject_search
+
+  validate :subjects_must_be_from_list
+  validate :subject_search_must_be_selected
 
   def params_to_save
     { subjects: subjects.compact_blank }
+  end
+
+  private
+
+  def subjects_must_be_from_list
+    valid_subjects = (SUBJECT_OPTIONS + FURTHER_EDUCATION_SUBJECT_OPTIONS).map(&:first)
+    Array(subjects).compact_blank.each do |subject|
+      unless valid_subjects.include?(subject)
+        errors.add(:subjects, I18n.t("publishers.vacancies.build.subjects.errors.not_in_list"))
+        break
+      end
+    end
+  end
+
+  def subject_search_must_be_selected
+    return if subject_search.blank?
+    return if Array(subjects).compact_blank.any?
+
+    errors.add(:subject_search, I18n.t("publishers.vacancies.build.subjects.errors.not_in_list"))
   end
 end

--- a/app/views/publishers/build_vacancy_templates/subjects.html.slim
+++ b/app/views/publishers/build_vacancy_templates/subjects.html.slim
@@ -6,7 +6,7 @@
 
   = f.govuk_fieldset legend: { text: t("publishers.vacancies.steps.subjects"), tag: "h1", size: "l" } do
 
-    label.govuk-label.govuk-label--m for="publishers-job-listing-job-details-form-subject-search"
+    label.govuk-label.govuk-label--m for="#{f.object_name}_subject_search"
       = t("publishers.vacancies.build.subjects.search_label")
     p.govuk-hint = t("publishers.vacancies.build.subjects.search_hint")
 
@@ -21,7 +21,7 @@
         hint: nil,
         classes: "checkbox-label__bold"),
         collection_count: SUBJECT_OPTIONS.count,
-        options: { border: true, error: @form.errors[:subjects].first },
+        options: { border: true, search_name: "#{f.object_name}[subject_search]", search_id: "#{f.object_name}_subject_search" },
         text: { aria_label: "search subjects" })
 
   = render "button_group", f: f

--- a/app/views/publishers/build_vacancy_templates/subjects.html.slim
+++ b/app/views/publishers/build_vacancy_templates/subjects.html.slim
@@ -6,8 +6,9 @@
 
   = f.govuk_fieldset legend: { text: t("publishers.vacancies.steps.subjects"), tag: "h1", size: "l" } do
 
-    label for="publishers-job-listing-job-details-form-subject-search"
-      span.govuk-visually-hidden | Subject filter
+    label.govuk-label.govuk-label--m for="publishers-job-listing-job-details-form-subject-search"
+      = t("publishers.vacancies.build.subjects.search_label")
+    p.govuk-hint = t("publishers.vacancies.build.subjects.search_hint")
 
     div class="govuk-!-margin-bottom-6"
       = searchable_collection(collection: f.govuk_collection_check_boxes(:subjects,

--- a/app/views/publishers/build_vacancy_templates/subjects.html.slim
+++ b/app/views/publishers/build_vacancy_templates/subjects.html.slim
@@ -21,7 +21,7 @@
         hint: nil,
         classes: "checkbox-label__bold"),
         collection_count: SUBJECT_OPTIONS.count,
-        options: { border: true },
+        options: { border: true, error: @form.errors[:subjects].first },
         text: { aria_label: "search subjects" })
 
   = render "button_group", f: f

--- a/app/views/publishers/vacancies/build/subjects.html.slim
+++ b/app/views/publishers/vacancies/build/subjects.html.slim
@@ -5,19 +5,25 @@
 = form_for form, url: wizard_path(current_step), method: :patch do |f|
   = f.govuk_error_summary
 
-  - subject_options = vacancy.organisations.any?(&:fe_college?) ? FURTHER_EDUCATION_SUBJECT_OPTIONS : SUBJECT_OPTIONS
+  = f.govuk_fieldset legend: { hidden: true } do
 
-  div class="govuk-!-margin-bottom-6"
-    = searchable_collection(collection: f.govuk_collection_check_boxes(:subjects,
-      subject_options,
-      :first,
-      :first,
-      :last,
-      legend: { text: t("publishers.vacancies.build.subjects.search_label"), size: "m" },
-      hint: { text: t("publishers.vacancies.build.subjects.search_hint") },
-      classes: "checkbox-label__bold"),
-      collection_count: subject_options.count,
-      options: { border: true, search_name: "#{f.object_name}[subject_search]", search_id: "#{f.object_name}_subject_search" },
-      text: { aria_label: "search subjects" })
+    - subject_options = vacancy.organisations.any?(&:fe_college?) ? FURTHER_EDUCATION_SUBJECT_OPTIONS : SUBJECT_OPTIONS
+
+    label.govuk-label.govuk-label--m for="#{f.object_name}_subject_search"
+      = t("publishers.vacancies.build.subjects.search_label")
+    p.govuk-hint = t("publishers.vacancies.build.subjects.search_hint")
+
+    div class="govuk-!-margin-bottom-6"
+      = searchable_collection(collection: f.govuk_collection_check_boxes(:subjects,
+        subject_options,
+        :first,
+        :first,
+        :last,
+        legend: nil,
+        hint: nil,
+        classes: "checkbox-label__bold"),
+        collection_count: subject_options.count,
+        options: { border: true, search_name: "#{f.object_name}[subject_search]", search_id: "#{f.object_name}_subject_search" },
+        text: { aria_label: "search subjects" })
 
   = render "publishers/vacancies/vacancy_form_partials/submit", f: f

--- a/app/views/publishers/vacancies/build/subjects.html.slim
+++ b/app/views/publishers/vacancies/build/subjects.html.slim
@@ -7,7 +7,7 @@
 
   = f.govuk_fieldset legend: { hidden: true } do
 
-    label.govuk-label.govuk-label--m for="publishers-job-listing-job-details-form-subject-search"
+    label.govuk-label.govuk-label--m for="publishers_job_listing_subjects_form_subject_search"
       = t("publishers.vacancies.build.subjects.search_label")
     p.govuk-hint = t("publishers.vacancies.build.subjects.search_hint")
 
@@ -23,7 +23,7 @@
         hint: nil,
         classes: "checkbox-label__bold"),
         collection_count: subject_options.count,
-        options: { border: true },
+        options: { border: true, search_name: "#{f.object_name}[subject_search]", search_id: "#{f.object_name}_subject_search" },
         text: { aria_label: "search subjects" })
 
   = render "publishers/vacancies/vacancy_form_partials/submit", f: f

--- a/app/views/publishers/vacancies/build/subjects.html.slim
+++ b/app/views/publishers/vacancies/build/subjects.html.slim
@@ -5,25 +5,19 @@
 = form_for form, url: wizard_path(current_step), method: :patch do |f|
   = f.govuk_error_summary
 
-  = f.govuk_fieldset legend: { hidden: true } do
+  - subject_options = vacancy.organisations.any?(&:fe_college?) ? FURTHER_EDUCATION_SUBJECT_OPTIONS : SUBJECT_OPTIONS
 
-    label.govuk-label.govuk-label--m for="publishers_job_listing_subjects_form_subject_search"
-      = t("publishers.vacancies.build.subjects.search_label")
-    p.govuk-hint = t("publishers.vacancies.build.subjects.search_hint")
-
-    - subject_options = vacancy.organisations.any?(&:fe_college?) ? FURTHER_EDUCATION_SUBJECT_OPTIONS : SUBJECT_OPTIONS
-
-    div class="govuk-!-margin-bottom-6"
-      = searchable_collection(collection: f.govuk_collection_check_boxes(:subjects,
-        subject_options,
-        :first,
-        :first,
-        :last,
-        legend: nil,
-        hint: nil,
-        classes: "checkbox-label__bold"),
-        collection_count: subject_options.count,
-        options: { border: true, search_name: "#{f.object_name}[subject_search]", search_id: "#{f.object_name}_subject_search" },
-        text: { aria_label: "search subjects" })
+  div class="govuk-!-margin-bottom-6"
+    = searchable_collection(collection: f.govuk_collection_check_boxes(:subjects,
+      subject_options,
+      :first,
+      :first,
+      :last,
+      legend: { text: t("publishers.vacancies.build.subjects.search_label"), size: "m" },
+      hint: { text: t("publishers.vacancies.build.subjects.search_hint") },
+      classes: "checkbox-label__bold"),
+      collection_count: subject_options.count,
+      options: { border: true, search_name: "#{f.object_name}[subject_search]", search_id: "#{f.object_name}_subject_search" },
+      text: { aria_label: "search subjects" })
 
   = render "publishers/vacancies/vacancy_form_partials/submit", f: f

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -501,7 +501,7 @@ en:
           search_label: Search subjects
           search_hint: "Start typing a subject, then select it from the list. Leave this blank if the subject is not listed."
           errors:
-            not_in_list: Select a subject from the list, or leave this blank
+            subject_searched_for_but_not_selected: Select a subject from the list, or leave this blank
         contract_type:
           step_title: Contract type
           fixed_term: Fixed term

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -501,7 +501,7 @@ en:
           search_label: Search subjects
           search_hint: "Start typing a subject, then select it from the list. Leave this blank if the subject is not listed."
           errors:
-            subject_searched_for_but_not_selected: Select a subject from the list, or leave this blank
+            subject_searched_for_but_not_selected: Select a subject from the list, or leave the search bar blank
         contract_type:
           step_title: Contract type
           fixed_term: Fixed term

--- a/config/locales/publishers.yml
+++ b/config/locales/publishers.yml
@@ -499,7 +499,9 @@ en:
         subjects:
           step_title: Subjects
           search_label: Search subjects
-          search_hint: Start typing to filter the list of subjects.
+          search_hint: "Start typing a subject, then select it from the list. Leave this blank if the subject is not listed."
+          errors:
+            not_in_list: Select a subject from the list, or leave this blank
         contract_type:
           step_title: Contract type
           fixed_term: Fixed term

--- a/spec/form_models/publishers/job_listing/subjects_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/subjects_form_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe Publishers::JobListing::SubjectsForm, type: :model do
+  subject(:form) { described_class.new(subjects:) }
+
+  context "when subjects is blank" do
+    let(:subjects) { [] }
+
+    it { is_expected.to be_valid }
+  end
+
+  context "when subject_search is present but no subject is selected" do
+    subject(:form) { described_class.new(subjects: [], subject_search: "magic") }
+
+    it { is_expected.not_to be_valid }
+
+    it "adds the correct error message" do
+      form.valid?
+      expect(form.errors[:subject_search]).to include(I18n.t("publishers.vacancies.build.subjects.errors.subject_searched_for_but_not_selected"))
+    end
+  end
+
+  context "when subject_search is present and a subject is selected" do
+    subject(:form) { described_class.new(subjects: [SUBJECT_OPTIONS.first.first], subject_search: "magic") }
+
+    it { is_expected.to be_valid }
+  end
+
+  context "when subject_search is blank and no subject is selected" do
+    subject(:form) { described_class.new(subjects: [], subject_search: "") }
+
+    it { is_expected.to be_valid }
+  end
+end

--- a/spec/form_models/publishers/job_listing/subjects_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/subjects_form_spec.rb
@@ -31,4 +31,10 @@ RSpec.describe Publishers::JobListing::SubjectsForm, type: :model do
 
     it { is_expected.to be_valid }
   end
+
+  context "when subject_search is blank and subjects are selected" do
+    subject(:form) { described_class.new(subjects: [SUBJECT_OPTIONS.first.first], subject_search: "") }
+
+    it { is_expected.to be_valid }
+  end
 end

--- a/spec/form_models/publishers/job_listing/subjects_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/subjects_form_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Publishers::JobListing::SubjectsForm, type: :model do
 
     it "adds the correct error message" do
       form.valid?
-      expect(form.errors[:subject_search]).to include(I18n.t("publishers.vacancies.build.subjects.errors.subject_searched_for_but_not_selected"))
+      expect(form.errors[:subjects]).to include(I18n.t("publishers.vacancies.build.subjects.errors.subject_searched_for_but_not_selected"))
     end
   end
 

--- a/spec/system/publishers/publishers_can_edit_a_vacancy_template_spec.rb
+++ b/spec/system/publishers/publishers_can_edit_a_vacancy_template_spec.rb
@@ -72,6 +72,14 @@ RSpec.describe "Editing a vacancy template" do
         expect(page).to have_no_content "Chemistry"
         expect(template.reload).to have_attributes(subjects: [])
       end
+
+      it "shows an error when typing in the search bar without selecting a subject", :retry do
+        uncheck "Chemistry"
+        fill_in "publishers_job_listing_subjects_form[subject_search]", with: "magic"
+        click_on I18n.t("buttons.save_and_continue")
+
+        expect(page).to have_content I18n.t("publishers.vacancies.build.subjects.errors.subject_searched_for_but_not_selected")
+      end
     end
 
     context "with key_stages" do

--- a/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_school_spec.rb
+++ b/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_school_spec.rb
@@ -64,6 +64,10 @@ RSpec.describe "Creating a vacancy" do
         # tick every key stage for the relevant phase
         publisher_key_stage_page.fill_in_and_submit_form(vacancy.key_stages_for_phases)
         expect(publisher_subjects_page).to be_displayed
+        fill_in "publishers_job_listing_subjects_form[subject_search]", with: "magic"
+        click_on I18n.t("buttons.save_and_continue")
+        expect(publisher_subjects_page).to be_displayed
+        expect(publisher_subjects_page.errors.map(&:text)).to contain_exactly(I18n.t("publishers.vacancies.build.subjects.errors.subject_searched_for_but_not_selected"))
         publisher_subjects_page.fill_in_and_submit_form(vacancy.subjects)
 
         expect(publisher_contract_information_page).to be_displayed


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/gUVK1M0o/3057-bug-fest-ticket-hiring-staff-enters-text-to-add-a-subject-when-creating-a-new-vacancy

## Changes in this PR:

This PR adds an error message to the search bar on subjects page for hiring staff if the user enters something in the search bar but does not select a subject (for both vacancy and vacancy template flow). Note: I have changed the error message from the one outlined in the ticket as I don't think it was fit for purpose.

## Screenshots of UI changes:
Template:
<img width="1327" height="740" alt="Screenshot 2026-07-23 at 09 33 28" src="https://github.com/user-attachments/assets/bd51b3a5-5d6b-41ac-b205-c8b034e213fa" />

Vacancy:
<img width="1258" height="847" alt="Screenshot 2026-07-23 at 09 34 29" src="https://github.com/user-attachments/assets/93dcb972-0208-4a96-95ee-e6450bc8b451" />



## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
