### PR TITLE
Show user a page explaining that they haven't been approved by their org on DfE sign in

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -14,6 +14,8 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   rescue_from EstablishmentNotRegistered, with: :establishment_not_registered
 
   def dfe
+    return render "pending_approval" unless org_data&.key?("id")
+
     authorisation = Publishers::DfeSignIn::Authorisation.new(organisation_id: organisation_id, user_id: user_id)
 
     if authorisation.authorised_support_user?

--- a/app/views/omniauth_callbacks/pending_approval.html.slim
+++ b/app/views/omniauth_callbacks/pending_approval.html.slim
@@ -1,0 +1,12 @@
+- content_for :page_title_prefix do
+  = t(".heading")
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    h1.govuk-heading-xl = t(".heading")
+
+    p.govuk-body = t(".paragraph_1")
+
+    p.govuk-body = t(".paragraph_2")
+
+    p.govuk-body = t(".paragraph_3")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -122,6 +122,11 @@ en:
   omniauth_callbacks:
     failure:
       message: Your session has expired so you have been logged out. Please sign in again to your account below.
+    pending_approval:
+      heading: Your account is waiting for approval
+      paragraph_1: Your request to access Teaching Vacancies has been sent to your organisation's DfE Sign-in approver.
+      paragraph_2: You'll be able to sign in after they approve your request.
+      paragraph_3: If you need help, contact your organisation's DfE Sign-in approver.
 
   nav:
     create_a_job_alert: Create a job alert

--- a/spec/requests/omniauth_callbacks_spec.rb
+++ b/spec/requests/omniauth_callbacks_spec.rb
@@ -47,6 +47,23 @@ RSpec.describe "DfE Sign In omniauth callbacks" do
       end
     end
 
+    context "when the auth hash has no organisation" do
+      before do
+        OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(
+          provider: "dfe",
+          uid: "161d1f6a-44f1-4a1a-940d-d1088c439da7",
+          info: { email: "an-email@example.com" },
+          extra: { raw_info: {} },
+        )
+      end
+
+      it "renders the pending approval page" do
+        get "/auth/dfe/callback"
+
+        expect(response.body).to include("Your account is waiting for approval")
+      end
+    end
+
     context "when the auth hash organisation has no id" do
       before do
         OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(

--- a/spec/requests/omniauth_callbacks_spec.rb
+++ b/spec/requests/omniauth_callbacks_spec.rb
@@ -61,9 +61,10 @@ RSpec.describe "DfE Sign In omniauth callbacks" do
         )
       end
 
-      it "raises a KeyError but still attaches the DSI auth data to the Sentry scope first" do
-        expect { get "/auth/dfe/callback" }.to raise_error(KeyError)
+      it "renders the pending approval page and attaches the DSI auth data to the Sentry scope" do
+        get "/auth/dfe/callback"
 
+        expect(response.body).to include("Your account is waiting for approval")
         expect(sentry_scope).to have_received(:set_context).with(
           "DSI auth data",
           hash_including(


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/4h4jIclR/3083-updated-dfe-sign-in-error-message

## Changes in this PR:

This change shows hiring staff users a view explaining the situation if they gain access to the service before their organisation approves them on DfE. Prior to this we raised an unhandled KeyError.

## Screenshots of UI changes:
<img width="940" height="622" alt="Screenshot 2026-07-23 at 11 00 30" src="https://github.com/user-attachments/assets/75d1ab38-5f9a-4a72-8e6a-7c992778accc" />


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
