### PR TITLE
Remove last_activity_at

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -295,7 +295,6 @@ shared:
     - accepted_terms_at
     - email
     - email_opt_out
-    - last_activity_at
     - family_name
     - given_name
     - created_at

--- a/db/migrate/20260723204840_remove_last_activity_at_from_publishers.rb
+++ b/db/migrate/20260723204840_remove_last_activity_at_from_publishers.rb
@@ -1,0 +1,7 @@
+class RemoveLastActivityAtFromPublishers < ActiveRecord::Migration[8.0]
+  def change
+    safety_assured do
+      remove_column :publishers, :last_activity_at, :datetime
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_08_151811) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_23_204840) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -646,7 +646,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_08_151811) do
     t.string "oid", null: false
     t.datetime "accepted_terms_at", precision: nil
     t.string "email"
-    t.datetime "last_activity_at", precision: nil
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text "family_name_ciphertext"


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/W3hgbwAR/3093-remove-last-activity-timestamp-from-publishers-table

## Changes in this PR:

Remove last_activity_at column from publishers table

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
