### PR TITLE
Automatically retry mailer transient SSL errors

### DIFF
--- a/app/jobs/alert_mailer_job.rb
+++ b/app/jobs/alert_mailer_job.rb
@@ -1,4 +1,4 @@
-class AlertMailerJob < ActionMailer::MailDeliveryJob
+class AlertMailerJob < ApplicationMailDeliveryJob
   EXPIRES_IN = 4.hours
 
   before_enqueue do

--- a/app/jobs/application_mail_delivery_job.rb
+++ b/app/jobs/application_mail_delivery_job.rb
@@ -1,0 +1,8 @@
+require "openssl"
+
+class ApplicationMailDeliveryJob < ActionMailer::MailDeliveryJob
+  # Transient TLS/SSL failures (e.g. "SSL_read: (null) (tls_retry_write_records
+  # failure)") happen intermittently when talking to the SMTP/Notify endpoints.
+  # Retry rather than dumping the email into the failed jobs dashboard.
+  retry_on OpenSSL::SSL::SSLError, wait: :polynomially_longer, attempts: 5
+end

--- a/config/initializers/mail_delivery_retries.rb
+++ b/config/initializers/mail_delivery_retries.rb
@@ -1,0 +1,18 @@
+# Retry transient SSL/TLS errors when delivering email instead of letting the
+# job land in the Solid Queue failed jobs dashboard for manual retry.
+
+# All mailers deliver via ApplicationMailDeliveryJob, which retries OpenSSL errors.
+# Set in a to_prepare block so the (autoloaded, reloadable) job constant is only
+# referenced once autoloading is available — referencing it directly from an
+# initializer autoloads too early and raises on boot.
+require "openssl"
+
+Rails.application.config.to_prepare do
+  ActionMailer::Base.delivery_job = ApplicationMailDeliveryJob
+end
+
+# Noticed delivers email through its own job (Noticed::DeliveryMethods::Email),
+# so give it the same retry behaviour.
+ActiveSupport.on_load(:noticed_delivery_methods_email) do
+  retry_on OpenSSL::SSL::SSLError, wait: :polynomially_longer, attempts: 5
+end

--- a/spec/jobs/application_mail_delivery_job_spec.rb
+++ b/spec/jobs/application_mail_delivery_job_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe ApplicationMailDeliveryJob do
+  let(:email) { Faker::Internet.email(domain: TEST_EMAIL_DOMAIN) }
+  let(:subscription) { create(:daily_subscription, email:, keyword: "English") }
+
+  describe "wiring" do
+    it "is the default delivery job for all mailers" do
+      expect(ActionMailer::Base.delivery_job).to eq(described_class)
+    end
+
+    it "is the parent of the custom AlertMailerJob so it inherits the retry behaviour" do
+      expect(AlertMailerJob.ancestors).to include(described_class)
+    end
+  end
+
+  describe "retrying transient SSL errors" do
+    it "registers OpenSSL::SSL::SSLError as a retry handler" do
+      expect(described_class.rescue_handlers.map(&:first)).to include(OpenSSL::SSL::SSLError.name)
+    end
+
+    it "registers the same retry handler on the Noticed email delivery job" do
+      expect(Noticed::DeliveryMethods::Email.rescue_handlers.map(&:first)).to include("OpenSSL::SSL::SSLError")
+    end
+
+    it "re-enqueues instead of failing when a transient SSL error is raised, then succeeds on retry" do
+      attempts = 0
+      delivery = Jobseekers::SubscriptionMailer.confirmation(subscription)
+      allow(Jobseekers::SubscriptionMailer).to receive(:confirmation).and_return(delivery)
+      allow(delivery).to receive(:deliver_now) do
+        attempts += 1
+        raise OpenSSL::SSL::SSLError, "SSL_read: (null) (tls_retry_write_records failure)" if attempts == 1
+      end
+
+      expect {
+        perform_enqueued_jobs(at: 1.minute.from_now) do
+          Jobseekers::SubscriptionMailer.confirmation(subscription).deliver_later
+        end
+      }.not_to raise_error
+
+      expect(attempts).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/hxyEZ3WS/3097-automatically-retry-on-mailer-ssl-errors

## Changes in this PR:

SolidQueue doesn't automatically retry jobs after they fail with an exception.

We want all the mailers having punctual transient SSL failures to retry the job automatically.

The "polynomially_longer" wait will be similar to the Sidekiq wait increases after each failure for the same job:
first wait ~3s, then ~18s, then ~83s, etc

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
