### PR TITLE
Temporally disable Dfe Sign-in for publishers

### DIFF
--- a/terraform/workspace-variables/production_app_env.yml
+++ b/terraform/workspace-variables/production_app_env.yml
@@ -1,6 +1,6 @@
 ---
 APP_ROLE: production
-AUTHENTICATION_FALLBACK: false
+AUTHENTICATION_FALLBACK: true
 AUTHENTICATION_FALLBACK_FOR_JOBSEEKERS: false
 BIGQUERY_DATASET: production_dataset
 DFE_SIGN_IN_ISSUER: https://oidc.signin.education.gov.uk


### PR DESCRIPTION
## Changes in this PR:

Use email authentication fallback instead.

Reason: DSI is showing an error upon 2FA login attempt and blocking publishers from using our service.

## Screenshots of UI changes:

### Before
<img width="640" height="174" alt="image" src="https://github.com/user-attachments/assets/260997e0-09ce-40dd-8fa8-71745c21a172" />

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
