### PR TITLE
Re-enable Dfe Sign-in for Publishers sign-in

### DIFF
--- a/terraform/workspace-variables/production_app_env.yml
+++ b/terraform/workspace-variables/production_app_env.yml
@@ -1,6 +1,6 @@
 ---
 APP_ROLE: production
-AUTHENTICATION_FALLBACK: true
+AUTHENTICATION_FALLBACK: false
 AUTHENTICATION_FALLBACK_FOR_JOBSEEKERS: false
 BIGQUERY_DATASET: production_dataset
 DFE_SIGN_IN_ISSUER: https://oidc.signin.education.gov.uk


### PR DESCRIPTION
## Changes in this PR:

Re-enables Dfe Sign-in for our Publisher users, since their outage has been resolved.


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
