### PR TITLE
Introduce JobAlerts job concurrency limit of 2

### DIFF
--- a/app/jobs/send_job_alerts_job.rb
+++ b/app/jobs/send_job_alerts_job.rb
@@ -1,6 +1,20 @@
 class SendJobAlertsJob < SolidQueueJob
   queue_as :jobalerts
 
+  # Concurrency is limited per job here rather than via worker threads in config/queue.yml, because the
+  # jobalerts queue runs one thread per pod, so only a per-job limit caps concurrency across all pods.
+  #
+  # Alerts are enqueued in batches of 5000 subscriptions, so tens of these jobs land at once, and each
+  # runs heavy subscription/vacancy matching queries. Unthrottled they have driven DB CPU to 90-100%
+  # and crashed the service; at a limit of 2 the same run peaks at 20-30%. Alerts are not time critical,
+  # so the few minutes of delay this adds costs jobseekers nothing. Measure DB CPU over a full run
+  # before raising the limit.
+  #
+  # `duration` is not a job timeout: it is the expiry on the concurrency semaphore, a failsafe for a
+  # worker that dies without releasing it. Keep it well above the slowest single run, as an expired
+  # semaphore is deleted while jobs are still running and lets extra jobs through.
+  limits_concurrency to: 2, key: :send_job_alerts, duration: 10.minutes
+
   MAXIMUM_RESULTS_PER_RUN = 500
 
   def perform(name, subscriptions, from_date) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize


### PR DESCRIPTION

## Trello card URL
https://trello.com/c/HHnqTABG/3099-job-alerts-in-solidqueue-introduce-job-concurrency-limit-to-2

## Changes in this PR:

Introduce JobAlerts job concurrency limit of 2

To reduce DB CPU stress caused by multiple parallel jobs running vacancy/subscriptions matching queries at the same time.


## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
