### PR TITLE
Fix pagy error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,6 +40,12 @@ class ApplicationController < ActionController::Base
 
   private
 
+  # Clamp out-of-range/non-numeric page params (e.g. ?page=0 or ?page=-1) to page 1
+  # instead of letting Pagy raise Pagy::VariableError.
+  def pagy_get_page(vars)
+    [super.to_i, 1].max
+  end
+
   def show_cookies_banner?
     cookies["consented-to-additional-cookies-v3"].blank?
   end

--- a/spec/requests/vacancies_spec.rb
+++ b/spec/requests/vacancies_spec.rb
@@ -6,5 +6,15 @@ RSpec.describe "Vacancies" do
       get jobs_path
       expect(response.headers["X-Robots-Tag"]).to eq("noarchive")
     end
+
+    it "clamps to page 1 instead of raising when page is 0" do
+      get jobs_path(page: 0)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "clamps to page 1 instead of raising when page is negative" do
+      get jobs_path(page: -1)
+      expect(response).to have_http_status(:ok)
+    end
   end
 end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/Z1U0J8Va/3101-investigate-pagy-error

## Changes in this PR:

Fixes a `Pagy::VariableError` (~630 events / 90 days, `VacanciesController#index`) that was crashing with a 500 whenever a request arrived with an out-of-range or non-numeric `page` param (e.g. `?page=0`, `?page=-1`)

Pagy's `overflow: :last_page` config (in `config/initializers/pagy.rb`) only handles pages that are too *high* — it clamps back to the last page. It doesn't cover pages below the minimum, which raises `Pagy::VariableError` instead and was going unhandled anywhere in the app.

- Override `pagy_get_page` in `ApplicationController` to clamp the page param to a minimum of 1 before it ever reaches Pagy, rather than rescuing the exception after the fact. This fixes the bug for every controller that uses `pagy` (vacancies, organisations, colleges, notifications, etc.), not just `VacanciesController`.
- Add request spec coverage for `page=0` and `page=-1` returning `200` (served as page 1) instead of raising.
- Also includes an unrelated one-line contentving a local merge conflict: adds the missing`saved_jobs.index.deadline_passed` locale key (`"Job closed"`), which `app/views/jobseekers/saved_jobs/index.html.sa`job_application_status_tag(:deadline_passed)` but had no translation for.

- Is there anything specific you want feedback on?

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
