### PR TITLE
Allow colleges to upload application forms for their jobs

### DIFF
--- a/app/form_models/publishers/job_listing/application_link_form.rb
+++ b/app/form_models/publishers/job_listing/application_link_form.rb
@@ -5,8 +5,4 @@ class Publishers::JobListing::ApplicationLinkForm < Publishers::JobListing::JobL
     %i[application_link]
   end
   attr_accessor(*fields)
-
-  def params_to_save
-    super.merge(enable_job_applications: false, receive_applications: :website)
-  end
 end

--- a/app/form_models/publishers/job_listing/how_to_receive_applications_form.rb
+++ b/app/form_models/publishers/job_listing/how_to_receive_applications_form.rb
@@ -5,4 +5,8 @@ class Publishers::JobListing::HowToReceiveApplicationsForm < Publishers::JobList
     %i[receive_applications]
   end
   attr_accessor(*fields)
+
+  def params_to_save
+    super.merge(enable_job_applications: false)
+  end
 end

--- a/app/services/publishers/vacancies/vacancy_step_process.rb
+++ b/app/services/publishers/vacancies/vacancy_step_process.rb
@@ -34,17 +34,13 @@ class Publishers::Vacancies::VacancyStepProcess < StepProcess
   end
 
   def application_process_steps
-    # applying_for_the_job asks how the publisher wants to receive applications;
-    # FE colleges always use application_link so skip this step for them
     steps = if vacancy.published? || vacancy.for_an_fe_college?
               []
             else
               %i[applying_for_the_job]
             end
 
-    if vacancy.for_an_fe_college?
-      steps += %i[application_link]
-    elsif vacancy.enable_job_applications
+    if vacancy.enable_job_applications
       steps += %i[anonymise_applications]
     else
       steps += %i[how_to_receive_applications]

--- a/spec/form_models/publishers/job_listing/application_link_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/application_link_form_spec.rb
@@ -19,13 +19,5 @@ RSpec.describe Publishers::JobListing::ApplicationLinkForm, type: :model do
     it "includes the application_link" do
       expect(application_link_form.params_to_save).to include(application_link: "https://example.com/apply")
     end
-
-    it "sets enable_job_applications to false" do
-      expect(application_link_form.params_to_save).to include(enable_job_applications: false)
-    end
-
-    it "sets receive_applications to website" do
-      expect(application_link_form.params_to_save).to include(receive_applications: :website)
-    end
   end
 end

--- a/spec/form_models/publishers/job_listing/how_to_receive_applications_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/how_to_receive_applications_form_spec.rb
@@ -2,4 +2,12 @@ require "rails_helper"
 
 RSpec.describe Publishers::JobListing::HowToReceiveApplicationsForm, type: :model do
   it { is_expected.to validate_inclusion_of(:receive_applications).in_array(Vacancy.receive_applications.keys) }
+
+  describe "#params_to_save" do
+    let(:form) { described_class.new(receive_applications: "website") }
+
+    it "sets enable_job_applications to false" do
+      expect(form.params_to_save).to include(enable_job_applications: false)
+    end
+  end
 end

--- a/spec/services/publishers/vacancies/vacancy_step_process_spec.rb
+++ b/spec/services/publishers/vacancies/vacancy_step_process_spec.rb
@@ -114,16 +114,32 @@ RSpec.describe Publishers::Vacancies::VacancyStepProcess do
           expect(subject.steps).not_to include(:applying_for_the_job)
         end
 
-        it "does not include how_to_receive_applications" do
-          expect(subject.steps).not_to include(:how_to_receive_applications)
+        it "includes how_to_receive_applications" do
+          expect(subject.steps).to include(:how_to_receive_applications)
         end
 
-        it "includes application_link" do
-          expect(subject.steps).to include(:application_link)
+        context "when receive_applications is website" do
+          before { allow(vacancy).to receive(:receive_applications).and_return("website") }
+
+          it "includes application_link" do
+            expect(subject.steps).to include(:application_link)
+          end
+
+          it "places application_link before additional documents" do
+            expect(subject.steps.index(:application_link)).to be < subject.steps.index(:include_additional_documents)
+          end
         end
 
-        it "places application_link before additional documents" do
-          expect(subject.steps.index(:application_link)).to be < subject.steps.index(:include_additional_documents)
+        context "when receive_applications is uploaded_form" do
+          before { allow(vacancy).to receive(:receive_applications).and_return("uploaded_form") }
+
+          it "includes application_form" do
+            expect(subject.steps).to include(:application_form)
+          end
+
+          it "places application_form before additional documents" do
+            expect(subject.steps.index(:application_form)).to be < subject.steps.index(:include_additional_documents)
+          end
         end
       end
 

--- a/spec/services/publishers/vacancies/vacancy_step_process_spec.rb
+++ b/spec/services/publishers/vacancies/vacancy_step_process_spec.rb
@@ -109,6 +109,7 @@ RSpec.describe Publishers::Vacancies::VacancyStepProcess do
 
       context "when the organisation is a college" do
         let(:vacancy_organisation) { build(:college) }
+        let(:vacancy) { build_stubbed(:draft_vacancy, job_roles: ["teacher"], enable_job_applications: nil, organisations: [vacancy_organisation]) }
 
         it "does not include applying_for_the_job" do
           expect(subject.steps).not_to include(:applying_for_the_job)

--- a/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_college_spec.rb
+++ b/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_college_spec.rb
@@ -5,15 +5,6 @@ RSpec.describe "Creating a vacancy as an FE college" do
   let(:publisher) { create(:publisher, organisations: [college]) }
   let(:created_vacancy) { Vacancy.order(:created_at).last }
 
-  let(:vacancy) do
-    build(:vacancy,
-          :ect_suitable,
-          :secondary,
-          :apply_via_website,
-          publish_on: Date.current,
-          organisations: [college])
-  end
-
   before do
     login_publisher(publisher: publisher, organisation: college)
     visit organisation_jobs_with_type_path
@@ -23,7 +14,7 @@ RSpec.describe "Creating a vacancy as an FE college" do
 
   after { logout }
 
-  it "shows the confirm job address step after job title, restricts job roles, and shows the address on the review page" do
+  def fill_in_job_details_through_important_dates(vacancy)
     expect(publisher_job_title_page).to be_displayed
     publisher_job_title_page.fill_in_and_submit_form(vacancy.job_title)
 
@@ -69,29 +60,105 @@ RSpec.describe "Creating a vacancy as an FE college" do
 
     expect(publisher_important_dates_page).to be_displayed
     publisher_important_dates_page.fill_in_and_submit_form(publish_on: vacancy.publish_on, expires_at: vacancy.expires_at)
+  end
 
-    # applying_for_the_job is skipped; application_link is shown directly
-    expect(publisher_applying_for_the_job_page).not_to be_displayed
-    expect(publisher_application_link_page).to be_displayed
-    publisher_application_link_page.fill_in_and_submit_form(vacancy.application_link)
+  context "when applying via website" do
+    let(:vacancy) do
+      build(:vacancy,
+            :ect_suitable,
+            :secondary,
+            :apply_via_website,
+            publish_on: Date.current,
+            organisations: [college])
+    end
 
-    expect(publisher_include_additional_documents_page).to be_displayed
-    publisher_include_additional_documents_page.fill_in_and_submit_form(vacancy.include_additional_documents)
+    it "shows the confirm job address step after job title, restricts job roles, and shows the address on the review page" do
+      fill_in_job_details_through_important_dates(vacancy)
 
-    expect(publisher_contact_details_page).to be_displayed
-    publisher_contact_details_page.fill_in_and_submit_form(vacancy.contact_email, vacancy.contact_number)
+      # applying_for_the_job is skipped; how_to_receive_applications is shown instead
+      expect(publisher_applying_for_the_job_page).not_to be_displayed
+      expect(publisher_how_to_receive_applications_page).to be_displayed
+      publisher_how_to_receive_applications_page.fill_in_and_submit_form(vacancy.receive_applications)
 
-    expect(publisher_confirm_contact_details_page).to be_displayed
-    publisher_confirm_contact_details_page.fill_in_and_submit_form
+      expect(publisher_application_link_page).to be_displayed
+      publisher_application_link_page.fill_in_and_submit_form(vacancy.application_link)
 
-    # Review page — campus address row shows the custom address entered above
-    expect(page).to have_current_path(organisation_job_review_path(created_vacancy.id), ignore_query: true)
-    expect(page).to have_css("#job_location")
-    expect(page).to have_content("10 Campus Road, Brighton, BN1 1AA")
+      expect(publisher_include_additional_documents_page).to be_displayed
+      publisher_include_additional_documents_page.fill_in_and_submit_form(vacancy.include_additional_documents)
 
-    # FE college should have a Change link on the Locations row linking to confirm_job_address
-    within("#job_location") do
-      expect(page).to have_link(I18n.t("buttons.change"), href: /confirm_job_address/)
+      expect(publisher_contact_details_page).to be_displayed
+      publisher_contact_details_page.fill_in_and_submit_form(vacancy.contact_email, vacancy.contact_number)
+
+      expect(publisher_confirm_contact_details_page).to be_displayed
+      publisher_confirm_contact_details_page.fill_in_and_submit_form
+
+      # Review page — campus address row shows the custom address entered above
+      expect(page).to have_current_path(organisation_job_review_path(created_vacancy.id), ignore_query: true)
+      expect(page).to have_css("#job_location")
+      expect(page).to have_content("10 Campus Road, Brighton, BN1 1AA")
+
+      # FE college should have a Change link on the Locations row linking to confirm_job_address
+      within("#job_location") do
+        expect(page).to have_link(I18n.t("buttons.change"), href: /confirm_job_address/)
+      end
+
+      within("#receive_applications") do
+        expect(page).to have_content(I18n.t("helpers.label.publishers_job_listing_how_to_receive_applications_form.receive_applications_options.website"))
+      end
+
+      within("#application_link") do
+        expect(page).to have_content(vacancy.application_link)
+      end
+    end
+  end
+
+  context "when uploading an application form" do
+    let(:vacancy) do
+      build(:vacancy,
+            :ect_suitable,
+            :secondary,
+            publish_on: Date.current,
+            organisations: [college])
+    end
+
+    it "routes through application_form and anonymise_applications steps" do
+      fill_in_job_details_through_important_dates(vacancy)
+
+      # applying_for_the_job is skipped; how_to_receive_applications is shown instead
+      expect(publisher_applying_for_the_job_page).not_to be_displayed
+      expect(publisher_how_to_receive_applications_page).to be_displayed
+      publisher_how_to_receive_applications_page.fill_in_and_submit_form("uploaded_form")
+
+      expect(publisher_application_form_page).to be_displayed
+      page.attach_file("publishers_job_listing_application_form_form[application_form]", Rails.root.join("spec/fixtures/files/blank_job_spec.pdf"))
+      click_on I18n.t("buttons.save_and_continue")
+
+      expect(publisher_anonymise_applications_page).to be_displayed
+      publisher_anonymise_applications_page.anonymous_option.click
+      click_on I18n.t("buttons.save_and_continue")
+
+      expect(publisher_include_additional_documents_page).to be_displayed
+      publisher_include_additional_documents_page.fill_in_and_submit_form(vacancy.include_additional_documents)
+
+      expect(publisher_contact_details_page).to be_displayed
+      publisher_contact_details_page.fill_in_and_submit_form(vacancy.contact_email, vacancy.contact_number)
+
+      expect(publisher_confirm_contact_details_page).to be_displayed
+      publisher_confirm_contact_details_page.fill_in_and_submit_form
+
+      expect(page).to have_current_path(organisation_job_review_path(created_vacancy.id), ignore_query: true)
+
+      within("#receive_applications") do
+        expect(page).to have_content(I18n.t("helpers.label.publishers_job_listing_how_to_receive_applications_form.receive_applications_options.uploaded_form"))
+      end
+
+      within("#uploaded_form") do
+        expect(page).to have_content("blank_job_spec.pdf")
+      end
+
+      within("#anonymise_applications") do
+        expect(page).to have_content("Yes")
+      end
     end
   end
 end

--- a/spec/views/publishers/vacancies/review.html.slim_spec.rb
+++ b/spec/views/publishers/vacancies/review.html.slim_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe "publishers/vacancies/review" do
         expect(rendered).not_to include(application_type)
       end
 
-      it "doesn't have an apply type line" do
-        expect(rendered).not_to include(apply_type)
+      it "has an apply type line" do
+        expect(rendered).to include(apply_type)
       end
     end
   end


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/b0NZjmn9/2940-fe-ability-to-upload-a-3rd-party-application-form-for-colleges

## Changes in this PR:
This PR allows colleges to upload an application form (like schools can) which a jobseeker can then download, fill in and upload to apply for the job. We removed the ability for colleges to do this as part of our FE college MVP release. That PR can be seen [here](https://github.com/DFE-Digital/teaching-vacancies/pull/8898) and may be useful for context!

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
