### PR TITLE
Fix missing translations on important dates page

### DIFF
--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -772,6 +772,8 @@ en:
         expires_at: Closing date
         expiry_time: Closing time
       publishers_job_listing_important_dates_form:
+        expires_at: Closing date
+        expiry_time: Closing time
         publish_on: Another date
         publish_on_day: Publish date
       publishers_job_listing_relist_form:


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/4sI0Ar2b/3115-bug-missing-translations-on-dates-page-of-create-a-job-journey

## Changes in this PR:
This PR fixes a couple of issues on the important dates page of the job creation flow. The page was showing expires_at and expiry_time rather than the translations because these translations were missing

## Screenshots of UI changes:

### Before
<img width="1175" height="876" alt="Screenshot 2026-07-30 at 16 41 27" src="https://github.com/user-attachments/assets/d10d711c-ebcf-4243-b555-60141765c361" />

### After
<img width="926" height="855" alt="Screenshot 2026-07-31 at 11 19 51" src="https://github.com/user-attachments/assets/9339aafc-38ad-4787-891e-f62fd8e10867" />


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
