### PR TITLE
Fix missing translation

### DIFF
--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -514,6 +514,10 @@ en:
             incomplete: Complete your references
           school_ethos:
             incomplete: Complete the question about how you meet the schools ethos and aims
+          catholic:
+            incomplete: Complete your religious information
+          non_catholic:
+            incomplete: Complete your religious information
           catholic_following_religion:
             incomplete: Complete your religious information
           non_catholic_following_religion:

--- a/spec/form_models/jobseekers/job_application/pre_submit_form_spec.rb
+++ b/spec/form_models/jobseekers/job_application/pre_submit_form_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Jobseekers
+  module JobApplication
+    RSpec.describe PreSubmitForm, type: :model do
+      subject(:form) { described_class.new(all_steps: all_steps, completed_steps: completed_steps) }
+
+      let(:all_steps) { %w[personal_details professional_status qualifications training_and_cpds professional_body_memberships employment_history personal_statement catholic non_catholic referees equal_opportunities ask_for_support declarations] }
+
+      context "when all steps are completed" do
+        let(:completed_steps) { all_steps }
+
+        it { is_expected.to be_valid }
+      end
+
+      context "when steps are incomplete" do
+        let(:completed_steps) { [] }
+
+        it "shows the correct error messages" do
+          expect(form).not_to be_valid
+          expect(form.errors.map(&:message)).to contain_exactly(
+            "Complete your personal details",
+            "Complete the questions about your professional status",
+            "Complete your qualifications",
+            "Complete your training and CPD",
+            "Complete your professional body memberships",
+            "Complete your employment history",
+            "Complete your personal statement",
+            "Complete your religious information",
+            "Complete your religious information",
+            "Complete your references",
+            "Complete the questions on equal opportunities",
+            "Complete the questions on interview support",
+            "Complete the declarations",
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/bcywAHFe/3103-bug-catholic-kcsie-application-error-message-is-not-valid

## Changes in this PR:

Prior to this change there was a couple of missing translations for error messages in the religious job creation flow. This PR adds those error messages and related tests.

## Screenshots of UI changes:
<img width="1249" height="878" alt="Screenshot 2026-07-31 at 14 14 29" src="https://github.com/user-attachments/assets/2f427ba6-ecf0-4e78-9405-90a5fffce956" />

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
