### PR TITLE
Increase SolidQueue workers polling intervals

### DIFF
--- a/config/queue.yml
+++ b/config/queue.yml
@@ -11,7 +11,7 @@ default: &default
     - queues: [ notify, default, low ]
       threads: 3
       processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
-      polling_interval: 0.5
+      polling_interval: 1
     # Second worker: handles throttled jobs, with a single thread and process
     # and less frequent polling. Queues are drained in priority order, left to right.
     # We throttle via worker concurrency and polling interval rather than #limit_concurrency
@@ -21,7 +21,7 @@ default: &default
     - queues: [ dbintensive, solid_queue_recurring, jobalerts ]
       threads: 1
       processes: 1
-      polling_interval: 1
+      polling_interval: 2
 
 development:
   <<: *default


### PR DESCRIPTION


## Trello card URL
- https://trello.com/c/WgknYrGz/2870-spike-could-we-move-from-sidekiq-to-solidqueue-dependency-of-trn-ab-test

## Changes in this PR:

The default Solidqueue worker polling interval value has been increased from 0.1 secs to 1 sec with the SolidQueue v1.5.0 release: https://github.com/rails/solid_queue/pull/721

It was noted as being way too agressive and even causing race conditions.

Given that change, we can set our standard worker to the default 1sec and increase the throttled worker to 2secs. It seems good enough and should reduce the DB load with less frequent polling.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
