### PR TITLE
Run DfE Analytics jobs through Solidqueue adapter

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -68,7 +68,6 @@ module TeachingVacancies
     # Use custom error pages
     config.exceptions_app = routes
 
-    # DfeAnalytics is hooked into Sidekiq as its the biggest generator of job traffic
     config.active_job.queue_adapter = :solid_queue
 
     # we have multiple mailers (Notify and Smtp) so can't configure here

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -63,18 +63,3 @@ DfE::Analytics.configure do |config|
 
   config.azure_federated_auth = ENV.include? "GOOGLE_CLOUD_CREDENTIALS"
 end
-
-# Temporary: run DfE Analytics jobs on Sidekiq (the gem doesn't allow overriding the ActiveJob adapter).
-module DfE
-  module Analytics
-    module Jobs
-      # rubocop:disable Rails/ApplicationJob
-      class AnalyticsJob < ActiveJob::Base
-        # simplecov:disable
-        self.queue_adapter = :sidekiq unless Rails.env.test?
-        # simplecov:enable
-      end
-      # rubocop:enable Rails/ApplicationJob
-    end
-  end
-end


### PR DESCRIPTION


## Trello card URL
- https://trello.com/c/KpifscrN/3120-solidqueue-migration-move-dfe-analytics-events-back-to-solidqueue


## Changes in this PR:

We kept DfE Analytics jobs in Sidekiq after originally moving them to SolidQueue, because the high volume of jobs clogged the PostgreSQL SolidQueue jobs table, causing the DB to run out of space and a service outage.

Since then, we have set up hourly cleanup jobs to regularly clear any job run over 24 hours ago, and we have run this for any other job without issues.

Given the progress on the maintenance, we are moving the analytics jobs back to the Solidqueue adapter, as we are attempting to remove Sidekiq from our system completely.


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
