### PR TITLE
Application state changes

### DIFF
--- a/app/components/tab_panel_component.rb
+++ b/app/components/tab_panel_component.rb
@@ -111,6 +111,10 @@ class TabPanelComponent < ApplicationComponent
     end
   end
 
+  def candidate_rejected_at(application)
+    application.rejected_at&.to_fs(:day_month_year)
+  end
+
   def candidate_interviewing_at(application)
     if application.interviewing_at
       application.interviewing_at.to_fs

--- a/app/components/tab_panel_component.rb
+++ b/app/components/tab_panel_component.rb
@@ -75,7 +75,7 @@ class TabPanelComponent < ApplicationComponent
           + tag.br \
           + govuk_link_to(t("tabs.offered.pre_employment_checks"), pre_employment_checks_organisation_job_job_application_path(application.vacancy.id, application.id))
       end
-    elsif application.has_pre_interview_checks?
+    elsif application.in_or_past_interview_stage?
       tag.div do
         publisher_job_application_status_tag(application.status) \
         + tag.br \

--- a/app/controllers/publishers/vacancies/job_applications_controller.rb
+++ b/app/controllers/publishers/vacancies/job_applications_controller.rb
@@ -53,6 +53,7 @@ module Publishers
         end
       end
 
+      # rubocop:disable Metrics/AbcSize
       def update_tag
         with_valid_form(@job_applications, validate_all_attributes: true) do |form|
           case form.status
@@ -63,7 +64,7 @@ module Publishers
             else
               redirect_to_references_and_self_disclosure(form.job_applications)
             end
-          when "offered"      then render_offered_form(form.job_applications, form.origin)
+          when "offered" then render_offered_form(form.job_applications, form.origin)
           when "unsuccessful_interview" then render_unsuccessful_interview_form(form.job_applications, form.origin)
           else
             form.job_applications.each { it.update!(form.attributes) }
@@ -71,6 +72,7 @@ module Publishers
           end
         end
       end
+      # rubocop:enable Metrics/AbcSize
 
       def offer
         with_valid_form(@job_applications, validate_all_attributes: true) do |form|

--- a/app/controllers/publishers/vacancies/job_applications_controller.rb
+++ b/app/controllers/publishers/vacancies/job_applications_controller.rb
@@ -56,7 +56,13 @@ module Publishers
       def update_tag
         with_valid_form(@job_applications, validate_all_attributes: true) do |form|
           case form.status
-          when "interviewing" then redirect_to_references_and_self_disclosure(form.job_applications)
+          when "interviewing"
+            if form.job_applications.all?(&:unsuccessful_interview?)
+              form.job_applications.each { it.update!(status: :interviewing) }
+              redirect_to organisation_job_job_applications_path(@vacancy.id, anchor: form.origin)
+            else
+              redirect_to_references_and_self_disclosure(form.job_applications)
+            end
           when "offered"      then render_offered_form(form.job_applications, form.origin)
           when "unsuccessful_interview" then render_unsuccessful_interview_form(form.job_applications, form.origin)
           else

--- a/app/controllers/publishers/vacancies/references_and_self_disclosure_controller.rb
+++ b/app/controllers/publishers/vacancies/references_and_self_disclosure_controller.rb
@@ -54,7 +54,7 @@ module Publishers
             else
               ReferenceRequest.create_for_manual!(job_application)
             end
-            job_application.create_religious_reference_request!(status: :action_needed) if job_application.religious_referee?
+            job_application.create_religious_reference_request!(status: :action_needed) if job_application.religious_referee? && job_application.religious_reference_request.blank?
             if @form.collect_self_disclosure
               SelfDisclosureRequest.create_and_notify!(job_application)
             else

--- a/app/helpers/job_applications_helper.rb
+++ b/app/helpers/job_applications_helper.rb
@@ -69,7 +69,7 @@ module JobApplicationsHelper
 
   def tag_status_options(tab_origin)
     job_application_status = TABS_TO_CONTAINED_STATUSES.fetch(tab_origin, [tab_origin]).first
-    JobApplication.next_statuses(job_application_status) - %w[withdrawn]
+    JobApplication.next_statuses(job_application_status) - %w[withdrawn rejected]
   end
 
   def job_application_qualified_teacher_status_info(job_application)

--- a/app/helpers/job_applications_helper.rb
+++ b/app/helpers/job_applications_helper.rb
@@ -44,7 +44,7 @@ module JobApplicationsHelper
     declined: "grey",
   }.freeze
 
-  TABS_DEFINITION = {
+  TABS_TO_CONTAINED_STATUSES = {
     submitted: %w[submitted reviewed],
     unsuccessful: %w[unsuccessful withdrawn rejected],
     shortlisted: %w[shortlisted],
@@ -52,12 +52,12 @@ module JobApplicationsHelper
     offered: %w[offered declined],
   }.stringify_keys.freeze
 
-  REVERSE_TABS_LOOKUP = TABS_DEFINITION.invert
+  REVERSE_TABS_LOOKUP = TABS_TO_CONTAINED_STATUSES.invert
                                        .flat_map { |keys, v| keys.map { |k| [k, v] } }
                                        .to_h.freeze
 
   def job_applications_to_tabs(job_applications_hash)
-    TABS_DEFINITION.transform_values do |status_list|
+    TABS_TO_CONTAINED_STATUSES.transform_values do |status_list|
       # There might not be any applications with a particular status, so fill with empty list
       status_list.index_with { |status| job_applications_hash.fetch(status, []) }
     end
@@ -68,7 +68,7 @@ module JobApplicationsHelper
   end
 
   def tag_status_options(tab_origin)
-    job_application_status = TABS_DEFINITION.fetch(tab_origin, [tab_origin]).first
+    job_application_status = TABS_TO_CONTAINED_STATUSES.fetch(tab_origin, [tab_origin]).first
     JobApplication.next_statuses(job_application_status) - %w[withdrawn]
   end
 

--- a/app/helpers/job_applications_helper.rb
+++ b/app/helpers/job_applications_helper.rb
@@ -4,7 +4,7 @@ module JobApplicationsHelper
     reviewed: "reviewed",
     shortlisted: "shortlisted",
     unsuccessful: "not progressing",
-    rejected: "not progressing",
+    rejected: "rejection sent",
     withdrawn: "withdrawn",
     interviewing: "interviewing",
     unsuccessful_interview: "not progressing",
@@ -68,7 +68,7 @@ module JobApplicationsHelper
   end
 
   def tag_status_options(tab_origin)
-    job_application_status = TABS_DEFINITION[tab_origin].first
+    job_application_status = TABS_DEFINITION.fetch(tab_origin, [tab_origin]).first
     JobApplication.next_statuses(job_application_status) - %w[withdrawn]
   end
 

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -95,6 +95,7 @@ class JobApplication < ApplicationRecord
   # end of the road statuses for job application we cannot further update status at the point
   TERMINAL_STATUSES = (statuses.keys.map(&:to_s) - STATUS_TRANSITIONS.keys).freeze
   INACTIVE_STATUSES = (%w[draft] + TERMINAL_STATUSES).freeze
+  IN_OR_PAST_INTERVIEW_STAGE = %w[interviewing unsuccessful_interview offered declined].freeze
 
   PRE_SHORTLIST_STATUSES = %w[submitted reviewed].freeze
 
@@ -164,7 +165,7 @@ class JobApplication < ApplicationRecord
   end
 
   def in_or_past_interview_stage?
-    status.in?(%w[interviewing unsuccessful_interview offered declined])
+    status.in?(IN_OR_PAST_INTERVIEW_STAGE)
   end
 
   def name

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -97,7 +97,6 @@ class JobApplication < ApplicationRecord
   INACTIVE_STATUSES = (%w[draft] + TERMINAL_STATUSES).freeze
 
   PRE_SHORTLIST_STATUSES = %w[submitted reviewed].freeze
-  POST_INTERVIEW_STATUSES = (%w[interviewing] + INTERVIEWING_TARGETS + INTERVIEWING_TARGETS.flat_map { |st| STATUS_TRANSITIONS.fetch(st, []) }).uniq - %w[withdrawn]
 
   RELIGIOUS_REFERENCE_TYPES = { religious_referee: 1, baptism_certificate: 2, baptism_date: 3, no_religious_referee: 4 }.freeze
 
@@ -164,8 +163,8 @@ class JobApplication < ApplicationRecord
     INACTIVE_STATUSES.exclude?(status)
   end
 
-  def has_pre_interview_checks?
-    status.in?(POST_INTERVIEW_STATUSES)
+  def in_or_past_interview_stage?
+    status.in?(%w[interviewing unsuccessful_interview offered declined])
   end
 
   def name

--- a/app/models/job_application.rb
+++ b/app/models/job_application.rb
@@ -70,8 +70,10 @@ class JobApplication < ApplicationRecord
     "reviewed"     => %w[unsuccessful shortlisted interviewing offered withdrawn],
     "shortlisted"  => %w[unsuccessful interviewing offered withdrawn],
     "interviewing" => INTERVIEWING_TARGETS,
-    "offered"      => %w[declined withdrawn],
-    "unsuccessful" => %w[rejected],
+    "offered"                => %w[declined withdrawn],
+    "unsuccessful"           => %w[rejected shortlisted interviewing],
+    "rejected"               => %w[shortlisted interviewing],
+    "unsuccessful_interview" => %w[shortlisted interviewing],
   }.freeze
   # rubocop:enable Layout/HashAlignment
 

--- a/app/models/reference_request.rb
+++ b/app/models/reference_request.rb
@@ -64,7 +64,7 @@ class ReferenceRequest < ApplicationRecord
     end
 
     def create_for_external!(job_application)
-      job_application.referees.each do |referee|
+      job_application.referees.reject { |r| r.reference_request.present? }.each do |referee|
         create_external_for_referee!(referee)
       end
     end

--- a/app/models/reference_request.rb
+++ b/app/models/reference_request.rb
@@ -64,7 +64,7 @@ class ReferenceRequest < ApplicationRecord
     end
 
     def create_for_external!(job_application)
-      job_application.referees.reject { |r| r.reference_request.present? }.each do |referee|
+      job_application.referees.each do |referee|
         create_external_for_referee!(referee)
       end
     end

--- a/app/views/jobseekers/job_applications/_banner.html.slim
+++ b/app/views/jobseekers/job_applications/_banner.html.slim
@@ -22,7 +22,7 @@
       - if vacancy.application_form.present? && vacancy.application_form.blob.malware_scan_clean?
         = govuk_button_link_to t("buttons.download_application_form", size: number_to_human_size(vacancy.application_form.byte_size)), job_document_path(vacancy, vacancy.application_form.id), class: "vacancy-form"
 
-    - if job_application.active_status?
+    - if job_application.can_be_withdrawn?
       = govuk_button_link_to t("buttons.withdraw_application"), jobseekers_job_application_confirm_withdraw_path(job_application), class: "govuk-button--warning govuk-!-margin-bottom-4 withdraw-application"
 
     - unless job_application.draft?

--- a/app/views/publishers/vacancies/job_applications/_header.html.slim
+++ b/app/views/publishers/vacancies/job_applications/_header.html.slim
@@ -23,7 +23,7 @@ h1.govuk-heading-xl class="govuk-!-margin-bottom-5 govuk-!-margin-top-0"
 
 = tabs do |tabs|
   - tabs.with_navigation_item text: t(".tabs.application"), link: organisation_job_job_application_path(vacancy.id, job_application)
-  - if job_application.has_pre_interview_checks?
+  - if job_application.in_or_past_interview_stage?
     - tabs.with_navigation_item text: t(".tabs.pre_interview_checks"), link: pre_interview_checks_organisation_job_job_application_path(vacancy.id, job_application)
     - tabs.with_navigation_item text: t(".tabs.pre_employment_checks"), link: pre_employment_checks_organisation_job_job_application_path(vacancy.id, job_application.id)
   - tabs.with_navigation_item text: t(".tabs.messages"), active: current_page?(messages_organisation_job_job_application_path(vacancy.id, job_application.id)),

--- a/app/views/publishers/vacancies/job_applications/_tab_interviewing.html.slim
+++ b/app/views/publishers/vacancies/job_applications/_tab_interviewing.html.slim
@@ -4,4 +4,4 @@
 - if candidates.fetch("unsuccessful_interview").any?
   = govuk_section_break(visible: true, size: "xl")
 
-  = render TabPanelComponent.new(vacancy:, candidates: candidates.fetch("unsuccessful_interview"), tab_name: "unsuccessful_interview", displayed_fields: %i[name email_address interview_feedback_received_at])
+  = render TabPanelComponent.new(vacancy:, candidates: candidates.fetch("unsuccessful_interview"), tab_name: "unsuccessful_interview", form:, button_group: %i[update_status], displayed_fields: %i[name email_address interview_feedback_received_at])

--- a/app/views/publishers/vacancies/job_applications/_tab_interviewing.html.slim
+++ b/app/views/publishers/vacancies/job_applications/_tab_interviewing.html.slim
@@ -4,4 +4,4 @@
 - if candidates.fetch("unsuccessful_interview").any?
   = govuk_section_break(visible: true, size: "xl")
 
-  = render TabPanelComponent.new(vacancy:, candidates: candidates.fetch("unsuccessful_interview"), tab_name: "unsuccessful_interview", form:, button_group: %i[update_status], displayed_fields: %i[name email_address interview_feedback_received_at])
+  = render TabPanelComponent.new(vacancy:, candidates: candidates.fetch("unsuccessful_interview"), tab_name: "unsuccessful_interview", form:, displayed_fields: %i[name email_address interview_feedback_received_at])

--- a/app/views/publishers/vacancies/job_applications/_tab_unsuccessful.html.slim
+++ b/app/views/publishers/vacancies/job_applications/_tab_unsuccessful.html.slim
@@ -4,19 +4,6 @@
 - rejected = candidates.fetch("rejected")
 
 - if rejected.any?
-  h3 = t(".have_been_sent")
+  = govuk_section_break(visible: true, size: "xl")
 
-  = govuk_table(id: "rejected_emails") do |table|
-    - table.with_head do |head|
-      - head.with_row do |row|
-        - row.with_cell(text: t("publishers.vacancies.job_applications.tab_unsuccessful.table.name"))
-        - row.with_cell(text: t("publishers.vacancies.job_applications.tab_unsuccessful.table.contact_details"))
-        - row.with_cell(text: t("publishers.vacancies.job_applications.tab_unsuccessful.table.status"))
-        - row.with_cell(text: t("publishers.vacancies.job_applications.tab_unsuccessful.table.date"))
-    - table.with_body do |body|
-      - rejected.each do |job_application|
-        - body.with_row do |row|
-          - row.with_cell(text: job_application.name)
-          - row.with_cell(text: job_application.email_address)
-          - row.with_cell(text: govuk_tag(text: "Rejection sent", colour: "red"))
-          - row.with_cell(text: job_application.rejected_at.to_fs(:day_month_year))
+  = render TabPanelComponent.new(vacancy:, candidates: rejected, tab_name: "rejected", form:, button_group: %i[update_status], displayed_fields: %i[name email_address status rejected_at])

--- a/app/views/publishers/vacancies/job_applications/_tab_unsuccessful.html.slim
+++ b/app/views/publishers/vacancies/job_applications/_tab_unsuccessful.html.slim
@@ -1,5 +1,5 @@
 = render TabPanelComponent.new(tab_name:, vacancy:, form:,
-  candidates: candidates.fetch("unsuccessful") + candidates.fetch("withdrawn"), button_group: %i[reject download])
+  candidates: candidates.fetch("unsuccessful") + candidates.fetch("withdrawn"), button_group: %i[update_status reject download])
 
 - rejected = candidates.fetch("rejected")
 

--- a/config/locales/publishers/vacancies/tabs.yml
+++ b/config/locales/publishers/vacancies/tabs.yml
@@ -8,6 +8,7 @@ en:
       declined_at: Decline date
       interview_feedback_received_at: Feedback date
       interviewing_at: Interview date
+      rejected_at: Date sent
     buttons:
       download: Download selected
       message_shortlisted: Send a message
@@ -58,4 +59,8 @@ en:
     unsuccessful_interview:
       heading: Interview unsuccessful
       none: No applications have had a unsuccessful interview yet
+      hint: ""
+    rejected:
+      heading: Rejected applications
+      none: No applications have been rejected yet
       hint: ""

--- a/spec/components/tab_panel_component_spec.rb
+++ b/spec/components/tab_panel_component_spec.rb
@@ -120,6 +120,21 @@ RSpec.describe TabPanelComponent, type: :component do
     end
   end
 
+  context "when rendering candidate's rejected_at date" do
+    let(:candidates) { build_stubbed_list(:job_application, 1, :status_rejected, vacancy:, rejected_at: Time.zone.now) }
+    let(:displayed_fields) { %i[name email_address rejected_at] }
+    let(:expected_date) { candidates.first.rejected_at.to_fs(:day_month_year) }
+
+    it { expect(tab_panel.find(".rejected_at")).to have_text(expected_date) }
+    it { expect(component.candidate_rejected_at(candidates.first)).to eq(expected_date) }
+
+    context "when date nil" do
+      let(:candidates) { build_stubbed_list(:job_application, 1, :status_rejected, vacancy:, rejected_at: nil) }
+
+      it { expect(component.candidate_rejected_at(candidates.first)).to be_nil }
+    end
+  end
+
   context "when rendering candidate's feedback date" do
     let(:candidates) { build_stubbed_list(:job_application, 1, :status_unsuccessful_interview, vacancy:, interview_feedback_received_at: Time.zone.now) }
     let(:displayed_fields) { %i[name email_address interview_feedback_received_at] }

--- a/spec/helpers/job_applications_helper_spec.rb
+++ b/spec/helpers/job_applications_helper_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe JobApplicationsHelper do
     context "when tab_origin unsuccessful" do
       let(:tab_origin) { "unsuccessful" }
 
-      it { is_expected.to match_array(%w[rejected]) }
+      it { is_expected.to match_array(%w[rejected shortlisted interviewing]) }
     end
 
     context "when tab_origin shortlisted" do

--- a/spec/helpers/job_applications_helper_spec.rb
+++ b/spec/helpers/job_applications_helper_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe JobApplicationsHelper do
   describe "all job application statuses except draft are listed" do
-    subject { JobApplicationsHelper::TABS_DEFINITION.values.flatten }
+    subject { JobApplicationsHelper::TABS_TO_CONTAINED_STATUSES.values.flatten }
 
     it { is_expected.to match_array(JobApplication.statuses.except(:draft).keys) }
   end

--- a/spec/helpers/job_applications_helper_spec.rb
+++ b/spec/helpers/job_applications_helper_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe JobApplicationsHelper do
     context "when tab_origin unsuccessful" do
       let(:tab_origin) { "unsuccessful" }
 
-      it { is_expected.to match_array(%w[rejected shortlisted interviewing]) }
+      it { is_expected.to match_array(%w[shortlisted interviewing]) }
     end
 
     context "when tab_origin shortlisted" do

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe JobApplication do
     context "when from status is unsuccessful" do
       let(:from_status) { "unsuccessful" }
 
-      it { is_expected.to match_array(%w[rejected]) }
+      it { is_expected.to match_array(%w[rejected shortlisted interviewing]) }
     end
 
     context "when from status is rejected" do

--- a/spec/models/job_application_spec.rb
+++ b/spec/models/job_application_spec.rb
@@ -196,6 +196,18 @@ RSpec.describe JobApplication do
 
       it { is_expected.to match_array(%w[rejected]) }
     end
+
+    context "when from status is rejected" do
+      let(:from_status) { "rejected" }
+
+      it { is_expected.to match_array(%w[shortlisted interviewing]) }
+    end
+
+    context "when from status is unsuccessful_interview" do
+      let(:from_status) { "unsuccessful_interview" }
+
+      it { is_expected.to match_array(%w[shortlisted interviewing]) }
+    end
   end
 
   describe "#active_status?" do
@@ -243,12 +255,12 @@ RSpec.describe JobApplication do
         reviewed: false,
         shortlisted: false,
         unsuccessful: false,
-        rejected: true,
+        rejected: false,
         withdrawn: true,
         interviewing: false,
         offered: false,
         declined: true,
-        unsuccessful_interview: true,
+        unsuccessful_interview: false,
       }.each do |status_value, terminal|
         context "when status is set to #{status_value}" do
           let(:status) { status_value }

--- a/spec/requests/publishers/vacancies/references_and_self_disclosure_spec.rb
+++ b/spec/requests/publishers/vacancies/references_and_self_disclosure_spec.rb
@@ -14,13 +14,24 @@ RSpec.describe "Publishers::Vacancies::ReferencesAndSelfDisclosure" do
   end
 
   before do
+    # rubocop:disable RSpec/AnyInstance
     allow_any_instance_of(ApplicationController).to receive(:current_organisation).and_return(organisation)
+    # rubocop:enable RSpec/AnyInstance
     sign_in(publisher, scope: :publisher)
   end
 
   after { sign_out(publisher) }
 
   describe "PATCH #update on collect_self_disclosure step" do
+    subject(:request) do
+      patch(
+        organisation_job_job_application_batch_references_and_self_disclosure_path(
+          vacancy.id, batch.id, :collect_self_disclosure
+        ),
+        params: params,
+      )
+    end
+
     let(:params) do
       {
         publishers_job_application_collect_self_disclosure_form: {
@@ -29,15 +40,6 @@ RSpec.describe "Publishers::Vacancies::ReferencesAndSelfDisclosure" do
           contact_applicants: false,
         },
       }
-    end
-
-    subject(:request) do
-      patch(
-        organisation_job_job_application_batch_references_and_self_disclosure_path(
-          vacancy.id, batch.id, :collect_self_disclosure
-        ),
-        params: params,
-      )
     end
 
     context "when job application has a religious referee and no existing religious reference request" do

--- a/spec/requests/publishers/vacancies/references_and_self_disclosure_spec.rb
+++ b/spec/requests/publishers/vacancies/references_and_self_disclosure_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Publishers::Vacancies::ReferencesAndSelfDisclosure" do
+  let(:organisation) { create(:school) }
+  let(:vacancy) { create(:vacancy, organisations: [organisation]) }
+  let(:publisher) { create(:publisher, accepted_terms_at: 1.day.ago) }
+  let(:job_application) { create(:job_application, :status_submitted, vacancy: vacancy) }
+  let(:batch) do
+    batch = JobApplicationBatch.create!(vacancy: vacancy)
+    batch.batchable_job_applications.create!(job_application: job_application)
+    batch
+  end
+
+  before do
+    allow_any_instance_of(ApplicationController).to receive(:current_organisation).and_return(organisation)
+    sign_in(publisher, scope: :publisher)
+  end
+
+  after { sign_out(publisher) }
+
+  describe "PATCH #update on collect_self_disclosure step" do
+    let(:params) do
+      {
+        publishers_job_application_collect_self_disclosure_form: {
+          collect_self_disclosure: false,
+          collect_references: false,
+          contact_applicants: false,
+        },
+      }
+    end
+
+    subject(:request) do
+      patch(
+        organisation_job_job_application_batch_references_and_self_disclosure_path(
+          vacancy.id, batch.id, :collect_self_disclosure
+        ),
+        params: params,
+      )
+    end
+
+    context "when job application has a religious referee and no existing religious reference request" do
+      let(:job_application) { create(:job_application, :status_submitted, :with_religious_referee, vacancy: vacancy) }
+
+      it "creates a religious reference request" do
+        expect { request }.to change(ReligiousReferenceRequest, :count).by(1)
+      end
+
+      it "updates the job application status to interviewing" do
+        expect { request }.to change { job_application.reload.status }.to("interviewing")
+      end
+    end
+  end
+end

--- a/spec/system/publishers/publishers_can_change_status_of_applications_spec.rb
+++ b/spec/system/publishers/publishers_can_change_status_of_applications_spec.rb
@@ -415,7 +415,7 @@ RSpec.describe "check job application after status transition" do
     let(:status) { "unsuccessful_interview" }
 
     # JS needed so that all tabs are not visible
-    it "allows the publisher to move an interview-unsuccessful application back to interviewing to correct human error", :js do
+    it "allows the publisher to move an interview-unsuccessful application back to interviewing without going through the references/self-disclosure journey again", :js do
       run_with_publisher(publisher) do
         publisher_ats_applications_page.load(vacancy_id: vacancy.id, anchor: :interviewing)
 
@@ -425,11 +425,7 @@ RSpec.describe "check job application after status transition" do
           tag_page.select_and_submit("interviewing")
         end
 
-        expect(publisher_ats_collect_references_page).to be_displayed(vacancy_id: vacancy.id)
-        publisher_ats_collect_references_page.answer_no
-        find("label[for='publishers-job-application-collect-self-disclosure-form-collect-self-disclosure-false-field']").click
-        click_on "Save and continue"
-
+        expect(publisher_ats_collect_references_page).not_to be_displayed(vacancy_id: vacancy.id)
         expect(publisher_ats_applications_page).to be_displayed
         expect(publisher_ats_applications_page.selected_tab).to have_text("Interviewing")
         display_status = publisher_ats_applications_page.tab_panel.job_applications.first.status

--- a/spec/system/publishers/publishers_can_change_status_of_applications_spec.rb
+++ b/spec/system/publishers/publishers_can_change_status_of_applications_spec.rb
@@ -367,6 +367,77 @@ RSpec.describe "check job application after status transition" do
     end
   end
 
+  describe "transition: unsuccessful to shortlisted" do
+    let(:status) { "unsuccessful" }
+
+    # JS needed so that all tabs are not visible
+    it "allows the publisher to move a not-considering application back to shortlisted to correct human error", :js do
+      run_with_publisher(publisher) do
+        publisher_ats_applications_page.load(vacancy_id: vacancy.id, anchor: :unsuccessful)
+
+        expect(publisher_ats_applications_page.tab_panel.job_applications.count).to eq(1)
+
+        publisher_ats_applications_page.update_status(job_application) do |tag_page|
+          tag_page.select_and_submit("shortlisted")
+        end
+
+        publisher_ats_applications_page.load(vacancy_id: vacancy.id, anchor: :shortlisted)
+
+        display_status = publisher_ats_applications_page.tab_panel.job_applications.first.status
+        expect(display_status).to have_text("shortlisted")
+      end
+    end
+  end
+
+  describe "transition: rejected to shortlisted" do
+    let(:status) { "rejected" }
+
+    # JS needed so that all tabs are not visible
+    it "allows the publisher to move a rejected application back to shortlisted to correct human error", :js do
+      run_with_publisher(publisher) do
+        publisher_ats_applications_page.load(vacancy_id: vacancy.id, anchor: :unsuccessful)
+
+        expect(publisher_ats_applications_page.tab_panel.job_applications.count).to eq(1)
+
+        publisher_ats_applications_page.update_status(job_application) do |tag_page|
+          tag_page.select_and_submit("shortlisted")
+        end
+
+        publisher_ats_applications_page.load(vacancy_id: vacancy.id, anchor: :shortlisted)
+
+        display_status = publisher_ats_applications_page.tab_panel.job_applications.first.status
+        expect(display_status).to have_text("shortlisted")
+      end
+    end
+  end
+
+  describe "transition: unsuccessful_interview to interviewing" do
+    let(:status) { "unsuccessful_interview" }
+
+    # JS needed so that all tabs are not visible
+    it "allows the publisher to move an interview-unsuccessful application back to interviewing to correct human error", :js do
+      run_with_publisher(publisher) do
+        publisher_ats_applications_page.load(vacancy_id: vacancy.id, anchor: :interviewing)
+
+        expect(publisher_ats_applications_page.tab_panel.job_applications.count).to eq(1)
+
+        publisher_ats_applications_page.update_status(job_application) do |tag_page|
+          tag_page.select_and_submit("interviewing")
+        end
+
+        expect(publisher_ats_collect_references_page).to be_displayed(vacancy_id: vacancy.id)
+        publisher_ats_collect_references_page.answer_no
+        find("label[for='publishers-job-application-collect-self-disclosure-form-collect-self-disclosure-false-field']").click
+        click_on "Save and continue"
+
+        expect(publisher_ats_applications_page).to be_displayed
+        expect(publisher_ats_applications_page.selected_tab).to have_text("Interviewing")
+        display_status = publisher_ats_applications_page.tab_panel.job_applications.first.status
+        expect(display_status).to have_text("interviewing")
+      end
+    end
+  end
+
   describe "transition: offered to declined", :versioning do
     let(:status) { "offered" }
 

--- a/spec/system/publishers/publishers_can_change_status_of_applications_spec.rb
+++ b/spec/system/publishers/publishers_can_change_status_of_applications_spec.rb
@@ -427,6 +427,8 @@ RSpec.describe "check job application after status transition" do
 
         expect(publisher_ats_collect_references_page).not_to be_displayed(vacancy_id: vacancy.id)
         expect(publisher_ats_applications_page).to be_displayed
+
+        publisher_ats_applications_page.load(vacancy_id: vacancy.id, anchor: :interviewing)
         expect(publisher_ats_applications_page.selected_tab).to have_text("Interviewing")
         display_status = publisher_ats_applications_page.tab_panel.job_applications.first.status
         expect(display_status).to have_text("interviewing")

--- a/spec/system/publishers/publishers_can_reject_a_job_application_spec.rb
+++ b/spec/system/publishers/publishers_can_reject_a_job_application_spec.rb
@@ -111,11 +111,7 @@ RSpec.describe "Publishers can reject a job application" do
           # check that the rejected applications have moved from the top row to the table below
           expect(all("tr.govuk-table__row.application-unsuccessful").size).to eq(1)
 
-          within("#rejected_emails") do
-            within(".govuk-table__body") do
-              expect(all("tr").count).to eq(2)
-            end
-          end
+          expect(all("tr.govuk-table__row.application-rejected").size).to eq(2)
         end
       end
     end

--- a/spec/system/publishers/publishers_can_select_a_job_application_for_interview_spec.rb
+++ b/spec/system/publishers/publishers_can_select_a_job_application_for_interview_spec.rb
@@ -238,4 +238,27 @@ RSpec.describe "Publishers can select a job application for interview", :perform
       end
     end
   end
+
+  context "when the job application already has a religious reference request" do
+    let(:notify_candidate) { false }
+    let(:job_application) do
+      create(:job_application, :status_submitted, :with_religious_referee,
+             notify_before_contact_referers: notify_candidate,
+             email_address: jobseeker.email,
+             religious_reference_request: build(:religious_reference_request),
+             vacancy: vacancy, jobseeker: jobseeker)
+    end
+
+    it "does not create a duplicate religious reference request" do
+      expect(ReligiousReferenceRequest.count).to eq(1)
+      choose "Yes"
+      click_on "Save and continue"
+      # 2nd question not asked when candidate doesn't need contacting
+      choose "Yes"
+      click_on "Save and continue"
+      # wait for page load
+      find_by_id("interviewing")
+      expect(ReligiousReferenceRequest.count).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/I45eAhN5/3091-application-change-flexibility-application-status

## Changes in this PR:
Prior to this change, hiring staff could not move job applications from the "Rejected" or "Not considering" statuses. This change allows hiring staff to change the status from "Rejected" or "Not considering" to "Shortlisted" or "Interviewing" statuses

## Screenshots of UI changes:

### Before
<img width="616" height="905" alt="Screenshot 2026-08-05 at 19 06 22" src="https://github.com/user-attachments/assets/894dfa13-418e-4f4f-950b-cc7e52849e8f" />
<img width="569" height="893" alt="Screenshot 2026-08-05 at 19 06 32" src="https://github.com/user-attachments/assets/428f3428-087a-480a-b8cf-b5650933fdd0" />

### After
<img width="557" height="900" alt="Screenshot 2026-08-05 at 19 03 54" src="https://github.com/user-attachments/assets/a3816471-e4a2-4776-b946-93d02bbc15bb" />
<img width="626" height="901" alt="Screenshot 2026-08-05 at 19 03 44" src="https://github.com/user-attachments/assets/1948cca1-ca32-4671-b720-552eb1e2894a" />


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
