### PR TITLE
Rack 3 upgrade (post Sidekiq removal)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -116,9 +116,6 @@ gem "pg_search"
 # PDF table support
 gem "prawn-table"
 gem "puma"
-# Removing sidekiq (which pinned rack ~> 2.0) unpins rack.
-# TODO: Unpin so we can upgrade to rack 3 in its own PR.
-gem "rack", "~> 2.2"
 gem "rack-attack"
 gem "rack-cors"
 gem "rails", RAILS_VERSION # Explicitly declare rails so we can do a "bundle update rails" when needed.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -595,7 +595,7 @@ GEM
       nio4r (~> 2.0)
     raabro (1.5.0)
     racc (1.8.1)
-    rack (2.2.23)
+    rack (3.2.6)
     rack-attack (6.8.0)
       rack (>= 1.0, < 4)
     rack-cors (2.0.2)
@@ -609,19 +609,20 @@ GEM
       faraday-follow_redirects
       json-jwt (>= 1.11.0)
       rack (>= 2.1.0)
-    rack-protection (3.2.0)
+    rack-protection (4.2.1)
       base64 (>= 0.1.0)
-      rack (~> 2.2, >= 2.2.4)
-    rack-session (1.0.2)
-      rack (< 3)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.2)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
     rack-test (2.2.0)
       rack (>= 1.3)
     rack_session_access (0.2.0)
       builder (>= 2.0.0)
       rack (>= 1.0.0)
-    rackup (1.0.1)
-      rack (< 3)
-      webrick
+    rackup (2.3.1)
+      rack (>= 3)
     rails (8.0.5.1)
       actioncable (= 8.0.5.1)
       actionmailbox (= 8.0.5.1)
@@ -1072,7 +1073,6 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   puma
-  rack (~> 2.2)
   rack-attack
   rack-cors
   rack-mini-profiler
@@ -1351,16 +1351,16 @@ CHECKSUMS
   puma (8.0.2) sha256=c8ed871dfbbe66448ea9ffd46692342d9804d4071522b52b5331b7b6e7b686fb
   raabro (1.5.0) sha256=3f998a7bc84f9c84df3ab580634d2e0a5bda4f0841168d56035f529c9877440a
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
-  rack (2.2.23) sha256=a8fe9d7e07064770b8ec123663fded8a59ef7e2b6db5cda7173d45a5718ab69c
+  rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
   rack-attack (6.8.0) sha256=f2499fdebf85bcc05573a22dff57d24305ac14ec2e4156cd3c28d47cafeeecf2
   rack-cors (2.0.2) sha256=415d4e1599891760c5dc9ef0349c7fecdf94f7c6a03e75b2e7c2b54b82adda1b
   rack-mini-profiler (4.0.1) sha256=485810c23211f908196c896ea10cad72ed68780ee2998bec1f1dfd7558263d78
   rack-oauth2 (2.2.1) sha256=c73aa87c508043e2258f02b4fb110cacba9b37d2ccf884e22487d014a120d1a5
-  rack-protection (3.2.0) sha256=3c74ba7fc59066453d61af9bcba5b6fe7a9b3dab6f445418d3b391d5ea8efbff
-  rack-session (1.0.2) sha256=a02115e5420b4de036839b9811e3f7967d73446a554b42aa45106af335851d76
+  rack-protection (4.2.1) sha256=cf6e2842df8c55f5e4d1a4be015e603e19e9bc3a7178bae58949ccbb58558bac
+  rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
   rack_session_access (0.2.0) sha256=03eb98f2027429ccbbeb18556006dfb6d928b0557ad3770783b8e2f368198d6b
-  rackup (1.0.1) sha256=ba86604a28989fe1043bff20d819b360944ca08156406812dca6742b24b3c249
+  rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
   rails (8.0.5.1) sha256=c91cefbf38881876ddbe67b5e0246eb985d27d60c6bb1cd7034b4261de0ba495
   rails-controller-testing (1.0.5) sha256=741448db59366073e86fc965ba403f881c636b79a2c39a48d0486f2607182e94
   rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -598,8 +598,9 @@ GEM
     rack (3.2.6)
     rack-attack (6.8.0)
       rack (>= 1.0, < 4)
-    rack-cors (2.0.2)
-      rack (>= 2.0.0)
+    rack-cors (3.0.0)
+      logger
+      rack (>= 3.0.14)
     rack-mini-profiler (4.0.1)
       rack (>= 1.2.0)
     rack-oauth2 (2.2.1)
@@ -1353,7 +1354,7 @@ CHECKSUMS
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
   rack-attack (6.8.0) sha256=f2499fdebf85bcc05573a22dff57d24305ac14ec2e4156cd3c28d47cafeeecf2
-  rack-cors (2.0.2) sha256=415d4e1599891760c5dc9ef0349c7fecdf94f7c6a03e75b2e7c2b54b82adda1b
+  rack-cors (3.0.0) sha256=7b95be61db39606906b61b83bd7203fa802b0ceaaad8fcb2fef39e097bf53f68
   rack-mini-profiler (4.0.1) sha256=485810c23211f908196c896ea10cad72ed68780ee2998bec1f1dfd7558263d78
   rack-oauth2 (2.2.1) sha256=c73aa87c508043e2258f02b4fb110cacba9b37d2ccf884e22487d014a120d1a5
   rack-protection (4.2.1) sha256=cf6e2842df8c55f5e4d1a4be015e603e19e9bc3a7178bae58949ccbb58558bac

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -20,8 +20,8 @@ class ErrorsController < ApplicationController
 
   def unprocessable_entity
     respond_to do |format|
-      format.html { render status: :unprocessable_entity }
-      format.json { render json: { error: "Unprocessable entity" }, status: :unprocessable_entity }
+      format.html { render status: :unprocessable_content }
+      format.json { render json: { error: "Unprocessable entity" }, status: :unprocessable_content }
     end
   end
 

--- a/app/controllers/jobseekers/job_applications/messages_controller.rb
+++ b/app/controllers/jobseekers/job_applications/messages_controller.rb
@@ -15,7 +15,7 @@ class Jobseekers::JobApplications::MessagesController < Jobseekers::JobApplicati
       conversation = @job_application.conversations.first
       @messages = conversation.messages.order(created_at: :desc)
 
-      render "jobseekers/job_applications/show", status: :unprocessable_entity
+      render "jobseekers/job_applications/show", status: :unprocessable_content
     end
   end
 

--- a/app/controllers/jobseekers/job_applications/qualifications_controller.rb
+++ b/app/controllers/jobseekers/job_applications/qualifications_controller.rb
@@ -16,7 +16,7 @@ class Jobseekers::JobApplications::QualificationsController < Jobseekers::BaseCo
     if @form.valid?
       redirect_to new_jobseekers_job_application_qualification_path(submit_category_params)
     else
-      render :select_category, status: :unprocessable_entity
+      render :select_category, status: :unprocessable_content
     end
   end
 
@@ -42,7 +42,7 @@ class Jobseekers::JobApplications::QualificationsController < Jobseekers::BaseCo
       job_application.qualifications.create(qualification_params)
       redirect_to back_path
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -54,7 +54,7 @@ class Jobseekers::JobApplications::QualificationsController < Jobseekers::BaseCo
       @qualification.update(qualification_params)
       redirect_to back_path
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/jobseekers/profiles/job_preferences_locations_controller.rb
+++ b/app/controllers/jobseekers/profiles/job_preferences_locations_controller.rb
@@ -32,7 +32,7 @@ module Jobseekers
         if @location.update(location_params)
           redirect_to jobseekers_job_preferences_locations_path
         else
-          render "edit", status: :unprocessable_entity
+          render "edit", status: :unprocessable_content
         end
       end
 

--- a/app/controllers/jobseekers/profiles/qualifications_controller.rb
+++ b/app/controllers/jobseekers/profiles/qualifications_controller.rb
@@ -16,7 +16,7 @@ class Jobseekers::Profiles::QualificationsController < Jobseekers::ProfilesContr
     if @form.valid?
       redirect_to new_jobseekers_profile_qualification_path(submit_category_params)
     else
-      render :select_category, status: :unprocessable_entity
+      render :select_category, status: :unprocessable_content
     end
   end
 
@@ -30,7 +30,7 @@ class Jobseekers::Profiles::QualificationsController < Jobseekers::ProfilesContr
       @profile.qualifications.create(qualification_params)
       redirect_to review_jobseekers_profile_qualifications_path
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -49,7 +49,7 @@ class Jobseekers::Profiles::QualificationsController < Jobseekers::ProfilesContr
       qualification.update(qualification_params)
       redirect_to review_jobseekers_profile_qualifications_path
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/publishers/ats_api/v1/vacancies_controller.rb
+++ b/app/controllers/publishers/ats_api/v1/vacancies_controller.rb
@@ -160,6 +160,6 @@ class Publishers::AtsApi::V1::VacanciesController < Api::ApplicationController
   end
 
   def render_unprocessable_entity(exception)
-    render json: { errors: [exception.message] }, status: :unprocessable_entity
+    render json: { errors: [exception.message] }, status: :unprocessable_content
   end
 end

--- a/app/controllers/publishers/ats_api/v1/vacancies_controller.rb
+++ b/app/controllers/publishers/ats_api/v1/vacancies_controller.rb
@@ -8,7 +8,7 @@ class Publishers::AtsApi::V1::VacanciesController < Api::ApplicationController
 
   rescue_from StandardError, with: :render_server_error
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
-  rescue_from Publishers::AtsApi::OrganisationFetcher::InvalidOrganisationError, with: :render_unprocessable_entity
+  rescue_from Publishers::AtsApi::OrganisationFetcher::InvalidOrganisationError, with: :render_unprocessable_content
   # If there is an issue with the parameter parsing we return a controlled 400 error with a messagge rather than a default 500 error.
   rescue_from ActionController::ParameterMissing, with: :render_bad_request
 
@@ -159,7 +159,7 @@ class Publishers::AtsApi::V1::VacanciesController < Api::ApplicationController
     render json: { errors: [exception.message] }, status: :bad_request
   end
 
-  def render_unprocessable_entity(exception)
+  def render_unprocessable_content(exception)
     render json: { errors: [exception.message] }, status: :unprocessable_content
   end
 end

--- a/app/controllers/publishers/ats_api/v1/vacancies_controller.rb
+++ b/app/controllers/publishers/ats_api/v1/vacancies_controller.rb
@@ -9,7 +9,7 @@ class Publishers::AtsApi::V1::VacanciesController < Api::ApplicationController
   rescue_from StandardError, with: :render_server_error
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
   rescue_from Publishers::AtsApi::OrganisationFetcher::InvalidOrganisationError, with: :render_unprocessable_content
-  # If there is an issue with the parameter parsing we return a controlled 400 error with a messagge rather than a default 500 error.
+  # If there is an issue with the parameter parsing we return a controlled 400 error with a message rather than a default 500 error.
   rescue_from ActionController::ParameterMissing, with: :render_bad_request
 
   def index

--- a/app/controllers/publishers/vacancies/job_applications/messages_controller.rb
+++ b/app/controllers/publishers/vacancies/job_applications/messages_controller.rb
@@ -18,7 +18,7 @@ class Publishers::Vacancies::JobApplications::MessagesController < Publishers::V
                     []
                   end
 
-      render "publishers/vacancies/job_applications/messages", status: :unprocessable_entity
+      render "publishers/vacancies/job_applications/messages", status: :unprocessable_content
     end
   end
 

--- a/app/services/publishers/ats_api/create_vacancy_service.rb
+++ b/app/services/publishers/ats_api/create_vacancy_service.rb
@@ -74,7 +74,7 @@ module Publishers
 
         def validation_error_response(vacancy)
           {
-            status: :unprocessable_entity,
+            status: :unprocessable_content,
             json: {
               errors: vacancy.errors.messages.flat_map do |attr, messages|
                 messages.map { |message| "#{attr}: #{message}" }

--- a/app/services/publishers/ats_api/update_vacancy_service.rb
+++ b/app/services/publishers/ats_api/update_vacancy_service.rb
@@ -76,7 +76,7 @@ module Publishers
 
         def validation_error_response(vacancy)
           {
-            status: :unprocessable_entity,
+            status: :unprocessable_content,
             json: {
               errors: vacancy.errors.messages.flat_map do |attr, messages|
                 messages.map { |message| "#{attr}: #{message}" }

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Errors" do
   describe "GET #unprocessable_entity" do
     it "returns unprocessable_entity" do
       get unprocessable_entity_path
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
     end
   end
 

--- a/spec/requests/jobseekers/job_applications/messages_spec.rb
+++ b/spec/requests/jobseekers/job_applications/messages_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Jobseekers::JobApplications::Messages" do
             post jobseekers_job_application_messages_path(job_application), params: message_params
           }.not_to change(Message, :count)
 
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(response).to render_template("jobseekers/job_applications/show")
           expect(assigns(:message).errors[:content]).to include("Please enter your message")
           expect(assigns(:messages)).to eq([])
@@ -59,7 +59,7 @@ RSpec.describe "Jobseekers::JobApplications::Messages" do
               post jobseekers_job_application_messages_path(job_application), params: message_params
             }.not_to change(Message, :count)
 
-            expect(response).to have_http_status(:unprocessable_entity)
+            expect(response).to have_http_status(:unprocessable_content)
             expect(response).to render_template("jobseekers/job_applications/show")
             expect(assigns(:message).errors[:content]).to include("Please enter your message")
             expect(assigns(:messages)).to include(existing_message)

--- a/spec/requests/jobseekers/profiles/qualifications_spec.rb
+++ b/spec/requests/jobseekers/profiles/qualifications_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.describe "Jobseeker profile qualifications" do
+  let(:jobseeker) { create(:jobseeker) }
+  let!(:profile) { create(:jobseeker_profile, jobseeker:) }
+
+  before { sign_in(jobseeker, scope: :jobseeker) }
+
+  after { sign_out(jobseeker) }
+
+  describe "POST #submit_category" do
+    context "when the form is valid" do
+      it "redirects to the new qualification page for the category" do
+        post submit_category_jobseekers_profile_qualifications_path,
+             params: { jobseekers_qualifications_category_form: { category: "undergraduate" } }
+
+        expect(response).to redirect_to(new_jobseekers_profile_qualification_path(category: "undergraduate"))
+      end
+    end
+
+    context "when the form is invalid" do
+      it "renders the category selection page with an unprocessable content status" do
+        post submit_category_jobseekers_profile_qualifications_path,
+             params: { jobseekers_qualifications_category_form: { category: "" } }
+
+        expect(response).to render_template(:select_category)
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+  end
+
+  describe "PATCH #update" do
+    let!(:qualification) do
+      create(:qualification,
+             category: "undergraduate",
+             institution: "Life University",
+             job_application: nil,
+             jobseeker_profile: profile)
+    end
+
+    let(:params) do
+      {
+        jobseekers_qualifications_degree_form: {
+          category: "undergraduate",
+          finished_studying: "true",
+          grade: "Honours",
+          institution: institution,
+          subject: "Biology",
+          year: "2020",
+        },
+      }
+    end
+
+    context "when the form is valid" do
+      let(:institution) { "University of Life" }
+
+      it "updates the qualification and redirects to the review page" do
+        expect { patch jobseekers_profile_qualification_path(qualification), params: params }
+          .to change { qualification.reload.institution }.from("Life University").to("University of Life")
+
+        expect(response).to redirect_to(review_jobseekers_profile_qualifications_path)
+      end
+    end
+
+    context "when the form is invalid" do
+      let(:institution) { "" }
+
+      it "does not update the qualification and renders the edit page with an unprocessable content status" do
+        expect { patch jobseekers_profile_qualification_path(qualification), params: params }
+          .to(not_change { qualification.reload.institution })
+
+        expect(response).to render_template(:edit)
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+  end
+end

--- a/spec/services/publishers/ats_api/create_vacancy_service_spec.rb
+++ b/spec/services/publishers/ats_api/create_vacancy_service_spec.rb
@@ -530,7 +530,7 @@ RSpec.describe Publishers::AtsApi::CreateVacancyService do
       let(:expires_at) { nil }
 
       it "returns a validation error response" do
-        expect(create_vacancy_service[:status]).to eq :unprocessable_entity
+        expect(create_vacancy_service[:status]).to eq :unprocessable_content
         expect(create_vacancy_service[:json][:errors]).to include(
           "job_title: can't be blank",
           "job_advert: Enter a job advert",
@@ -547,7 +547,7 @@ RSpec.describe Publishers::AtsApi::CreateVacancyService do
       it "returns a validation error" do
         expect(create_vacancy_service).to eq(
           {
-            status: :unprocessable_entity,
+            status: :unprocessable_content,
             json: {
               errors: ["job_title: must be 75 characters or fewer"],
             },
@@ -560,7 +560,7 @@ RSpec.describe Publishers::AtsApi::CreateVacancyService do
       let(:expires_at) { Date.current - 1.week }
 
       it "returns a validation error" do
-        expect(create_vacancy_service[:status]).to eq :unprocessable_entity
+        expect(create_vacancy_service[:status]).to eq :unprocessable_content
         expect(create_vacancy_service[:json][:errors]).to include(
           "expires_at: must be a future date",
           "expires_at: must be at least one day after the publish date",
@@ -572,7 +572,7 @@ RSpec.describe Publishers::AtsApi::CreateVacancyService do
       let(:expires_at) { Time.zone.today.end_of_day }
 
       it "returns a validation error" do
-        expect(create_vacancy_service[:status]).to eq :unprocessable_entity
+        expect(create_vacancy_service[:status]).to eq :unprocessable_content
         expect(create_vacancy_service[:json][:errors]).to include(
           "expires_at: must be a future date",
         )
@@ -586,7 +586,7 @@ RSpec.describe Publishers::AtsApi::CreateVacancyService do
       it "returns a validation error" do
         expect(create_vacancy_service).to eq(
           {
-            status: :unprocessable_entity,
+            status: :unprocessable_content,
             json: {
               errors: ["expires_at: must be at least one day after the publish date"],
             },
@@ -602,7 +602,7 @@ RSpec.describe Publishers::AtsApi::CreateVacancyService do
       it "returns a validation error" do
         expect(create_vacancy_service).to eq(
           {
-            status: :unprocessable_entity,
+            status: :unprocessable_content,
             json: {
               errors: ["expires_at: must be at least one day after the publish date"],
             },

--- a/spec/services/publishers/ats_api/update_vacancy_service_spec.rb
+++ b/spec/services/publishers/ats_api/update_vacancy_service_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe Publishers::AtsApi::UpdateVacancyService do
       let(:expires_at) { nil }
 
       it "returns a validation error response" do
-        expect(update_vacancy_service[:status]).to eq :unprocessable_entity
+        expect(update_vacancy_service[:status]).to eq :unprocessable_content
         expect(update_vacancy_service[:json][:errors]).to include(
           "job_title: can't be blank",
           "job_advert: Enter a job advert",
@@ -194,7 +194,7 @@ RSpec.describe Publishers::AtsApi::UpdateVacancyService do
     it "returns a validation error" do
       expect(update_vacancy_service).to eq(
         {
-          status: :unprocessable_entity,
+          status: :unprocessable_content,
           json: {
             errors: ["job_title: must be 75 characters or fewer"],
           },
@@ -209,7 +209,7 @@ RSpec.describe Publishers::AtsApi::UpdateVacancyService do
     it "returns a validation error" do
       expect(update_vacancy_service).to eq(
         {
-          status: :unprocessable_entity,
+          status: :unprocessable_content,
           json: {
             errors: [
               "expires_at: must be a future date",
@@ -226,7 +226,7 @@ RSpec.describe Publishers::AtsApi::UpdateVacancyService do
     it "returns a validation error" do
       expect(update_vacancy_service).to eq(
         {
-          status: :unprocessable_entity,
+          status: :unprocessable_content,
           json: {
             errors: [
               "expires_at: must be a future date",
@@ -244,7 +244,7 @@ RSpec.describe Publishers::AtsApi::UpdateVacancyService do
     it "returns a validation error" do
       expect(update_vacancy_service).to eq(
         {
-          status: :unprocessable_entity,
+          status: :unprocessable_content,
           json: {
             errors: ["expires_at: must be at least one day after the publish date"],
           },
@@ -260,7 +260,7 @@ RSpec.describe Publishers::AtsApi::UpdateVacancyService do
     it "returns a validation error" do
       expect(update_vacancy_service).to eq(
         {
-          status: :unprocessable_entity,
+          status: :unprocessable_content,
           json: {
             errors: ["expires_at: must be at least one day after the publish date"],
           },

--- a/spec/system/other/cookies_banner_spec.rb
+++ b/spec/system/other/cookies_banner_spec.rb
@@ -2,10 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Cookies banner" do
   def set_cookie(name, value)
-    headers = {}
-    Rack::Utils.set_cookie_header!(headers, name, value)
-    cookie_string = headers["Set-Cookie"]
-    Capybara.current_session.driver.browser.set_cookie cookie_string
+    Capybara.current_session.driver.browser.set_cookie Rack::Utils.set_cookie_header(name, value)
   end
 
   context "when the user has not set their cookies preferences" do


### PR DESCRIPTION
Follow up on Sidekiq removal, as the Sidekiq version we were using pinned the Rack gem version to v2.

## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
