### PR TITLE
Add new support roles

### DIFF
--- a/app/helpers/landing_page_lists_helper.rb
+++ b/app/helpers/landing_page_lists_helper.rb
@@ -62,6 +62,11 @@ module LandingPageListsHelper
     "fe-catering-cleaning-site-management-jobs" => "catering_cleaning_and_site_management",
     "fe-it-support-jobs" => "it_support",
     "fe-pastoral-health-welfare-jobs" => "pastoral_health_and_welfare",
+    "fe-leadership-management-jobs" => "leadership_and_management",
+    "fe-business-support-administration-corporate-services-jobs" => "business_support_administration_and_corporate_services",
+    "fe-student-support-learning-progress-jobs" => "student_support_learning_and_progress",
+    "fe-marketing-communications-jobs" => "marketing_and_communications",
+    "fe-apprenticeships-commercial-services-jobs" => "apprenticeships_and_commercial_services",
     "fe-other-support-roles-jobs" => "other_support",
   }.freeze
 

--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -25,8 +25,12 @@ module VacanciesHelper
     end
   end
 
-  def fe_college_job_roles_options
+  def fe_college_teaching_job_roles_options
     [["teacher", I18n.t("helpers.label.publishers_job_listing_job_role_form.teaching_job_role_options.teacher")]]
+  end
+
+  def fe_college_support_job_roles_options
+    Vacancy::FE_SUPPORT_JOB_ROLES.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_role_form.fe_support_job_role_options.#{option}")] }
   end
 
   def teaching_job_roles_options

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -24,7 +24,9 @@ class Vacancy < ApplicationRecord
                 "head_of_year_or_phase" => 4, "head_of_department_or_curriculum" => 5, "teaching_assistant" => 6,
                 "higher_level_teaching_assistant" => 7, "education_support" => 8, "sendco" => 9, "administration_hr_data_and_finance" => 11,
                 "catering_cleaning_and_site_management" => 12, "it_support" => 13, "pastoral_health_and_welfare" => 14,
-                "other_leadership" => 15, "other_support" => 16 }.freeze
+                "other_leadership" => 15, "other_support" => 16, "leadership_and_management" => 17,
+                "business_support_administration_and_corporate_services" => 18, "student_support_learning_and_progress" => 19,
+                "marketing_and_communications" => 20, "apprenticeships_and_commercial_services" => 21 }.freeze
 
   MIDDLE_LEADER_JOB_ROLES = %w[head_of_year_or_phase head_of_department_or_curriculum].freeze
   SENIOR_LEADER_JOB_ROLES = %w[headteacher deputy_headteacher assistant_headteacher].freeze
@@ -34,6 +36,11 @@ class Vacancy < ApplicationRecord
   SUPPORT_JOB_ROLES = %w[teaching_assistant higher_level_teaching_assistant education_support
                          administration_hr_data_and_finance catering_cleaning_and_site_management
                          it_support pastoral_health_and_welfare other_support].freeze
+
+  # Only offered to publishers posting on behalf of an FE college - see Vacancy#for_an_fe_college?
+  FE_SUPPORT_JOB_ROLES = %w[leadership_and_management business_support_administration_and_corporate_services
+                            student_support_learning_and_progress marketing_and_communications
+                            apprenticeships_and_commercial_services].freeze
 
   SCHOOL_PHASES_MATCHING_VACANCY_PHASES = %w[nursery primary secondary sixth_form_or_college].freeze
 

--- a/app/validators/external_vacancy_validator.rb
+++ b/app/validators/external_vacancy_validator.rb
@@ -12,9 +12,18 @@ class ExternalVacancyValidator < ActiveModel::Validator
     validate_no_duplicate_vacancy(record)
     validate_job_title_length(record)
     validate_expiry_date(record) if record.expires_at.present?
+    validate_job_roles(record)
   end
 
   private
+
+  # FE-exclusive job roles are only available to publishers posting on behalf of an FE college via the web
+  # app - they must not be accepted through external integrations (API or legacy), documented or not.
+  def validate_job_roles(record)
+    ArrayEnum::SubsetValidator
+      .new(attributes: [:job_roles], in: Vacancy.job_roles.keys - Vacancy::FE_SUPPORT_JOB_ROLES)
+      .validate(record)
+  end
 
   def validate_uniqueness_per_client(record)
     if record.find_external_reference_conflict_vacancy.present?

--- a/app/views/publishers/vacancies/build/job_role.html.slim
+++ b/app/views/publishers/vacancies/build/job_role.html.slim
@@ -6,7 +6,8 @@
   = f.govuk_error_summary
 
   - if vacancy.for_an_fe_college?
-    = f.govuk_collection_check_boxes :job_roles, fe_college_job_roles_options, :first, :last, legend: { text: t("jobs.filters.teaching_job_roles"), size: "s", tag: "h2" }, include_hidden: false
+    = f.govuk_collection_check_boxes :job_roles, fe_college_teaching_job_roles_options, :first, :last, legend: { text: t("jobs.filters.teaching_job_roles"), size: "s", tag: "h2" }, include_hidden: false
+    = f.govuk_collection_check_boxes :job_roles, fe_college_support_job_roles_options, :first, :last, legend: { text: t("jobs.filters.support_job_roles"), size: "s", tag: "h2" }, include_hidden: false
   - else
     = f.govuk_collection_check_boxes :job_roles, teaching_job_roles_options, :first, :last, legend: { text: t("jobs.filters.teaching_job_roles"), size: "s", tag: "h2" }, include_hidden: false
     = f.govuk_collection_check_boxes :job_roles, support_job_roles_options, :first, :last, legend: { text: t("jobs.filters.support_job_roles"), size: "s", tag: "h2" }, include_hidden: false

--- a/config/fe_landing_pages.yml
+++ b/config/fe_landing_pages.yml
@@ -53,6 +53,21 @@ shared:
   fe-pastoral-health-welfare-jobs:
     support_job_roles:
       - pastoral_health_and_welfare
+  fe-leadership-management-jobs:
+    support_job_roles:
+      - leadership_and_management
+  fe-business-support-administration-corporate-services-jobs:
+    support_job_roles:
+      - business_support_administration_and_corporate_services
+  fe-student-support-learning-progress-jobs:
+    support_job_roles:
+      - student_support_learning_and_progress
+  fe-marketing-communications-jobs:
+    support_job_roles:
+      - marketing_and_communications
+  fe-apprenticeships-commercial-services-jobs:
+    support_job_roles:
+      - apprenticeships_and_commercial_services
   fe-other-support-roles-jobs:
     support_job_roles:
       - other_support

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -596,6 +596,11 @@ en:
           catering_cleaning_and_site_management: Catering, cleaning and site management
           it_support: IT support
           pastoral_health_and_welfare: Pastoral, health and welfare
+          leadership_and_management: Leadership and management
+          business_support_administration_and_corporate_services: Business support, administration and corporate services
+          student_support_learning_and_progress: Student support, learning and progress
+          marketing_and_communications: Marketing and communications
+          apprenticeships_and_commercial_services: Apprenticeships and commercial services
           other_leadership: Other leadership role
           other_support: Other support role
           senior_leader: Senior leader
@@ -618,6 +623,12 @@ en:
           it_support: IT support
           pastoral_health_and_welfare: Pastoral, health and welfare
           other_support: Other support role
+        fe_support_job_role_options:
+          leadership_and_management: Leadership and management
+          business_support_administration_and_corporate_services: Business support, administration and corporate services
+          student_support_learning_and_progress: Student support, learning and progress
+          marketing_and_communications: Marketing and communications
+          apprenticeships_and_commercial_services: Apprenticeships and commercial services
         job_roles_options:
           <<: *job_role_options
       publishers_job_listing_key_stages_form:

--- a/config/locales/jobseekers/profile/job_preferences.yml
+++ b/config/locales/jobseekers/profile/job_preferences.yml
@@ -69,6 +69,11 @@ en:
           catering_cleaning_and_site_management: Catering, cleaning and site management
           it_support: IT support
           pastoral_health_and_welfare: Pastoral, health and welfare
+          leadership_and_management: Leadership and management
+          business_support_administration_and_corporate_services: Business support, administration and corporate services
+          student_support_learning_and_progress: Student support, learning and progress
+          marketing_and_communications: Marketing and communications
+          apprenticeships_and_commercial_services: Apprenticeships and commercial services
           other_leadership: Other leadership role
           other_support: Other support role
       jobseekers_job_preferences_form_key_stages_form:

--- a/config/locales/landing_pages.yml
+++ b/config/locales/landing_pages.yml
@@ -219,6 +219,31 @@ en:
       title: "Further Education Pastoral, Health and Welfare Jobs"
       heading: "%{count} further education pastoral, health and welfare jobs"
       meta_description: "Find pastoral, health and welfare jobs in further education colleges. Browse the latest FE support vacancies on Teaching Vacancies."
+    fe-leadership-management-jobs:
+      name: "Leadership and management (%{count})"
+      title: "Further Education Leadership and Management Jobs"
+      heading: "%{count} further education leadership and management jobs"
+      meta_description: "Find leadership and management jobs in further education colleges. Browse the latest FE support vacancies on Teaching Vacancies."
+    fe-business-support-administration-corporate-services-jobs:
+      name: "Business support, administration and corporate services (%{count})"
+      title: "Further Education Business Support, Administration and Corporate Services Jobs"
+      heading: "%{count} further education business support, administration and corporate services jobs"
+      meta_description: "Find business support, administration and corporate services jobs in further education colleges. Browse the latest FE support vacancies on Teaching Vacancies."
+    fe-student-support-learning-progress-jobs:
+      name: "Student support, learning and progress (%{count})"
+      title: "Further Education Student Support, Learning and Progress Jobs"
+      heading: "%{count} further education student support, learning and progress jobs"
+      meta_description: "Find student support, learning and progress jobs in further education colleges. Browse the latest FE support vacancies on Teaching Vacancies."
+    fe-marketing-communications-jobs:
+      name: "Marketing and communications (%{count})"
+      title: "Further Education Marketing and Communications Jobs"
+      heading: "%{count} further education marketing and communications jobs"
+      meta_description: "Find marketing and communications jobs in further education colleges. Browse the latest FE support vacancies on Teaching Vacancies."
+    fe-apprenticeships-commercial-services-jobs:
+      name: "Apprenticeships and commercial services (%{count})"
+      title: "Further Education Apprenticeships and Commercial Services Jobs"
+      heading: "%{count} further education apprenticeships and commercial services jobs"
+      meta_description: "Find apprenticeships and commercial services jobs in further education colleges. Browse the latest FE support vacancies on Teaching Vacancies."
     fe-other-support-roles-jobs:
       name: "Other support roles (%{count})"
       title: "Further Education Other Support Roles"

--- a/spec/swagger/v1/enum_consistency_spec.rb
+++ b/spec/swagger/v1/enum_consistency_spec.rb
@@ -26,7 +26,7 @@ require "swagger_helper"
 #     - Do NOT update V1 frozen constants.
 RSpec.describe "V1 API schema enum consistency" do
   {
-    "job_roles" => { v1: V1_JOB_ROLES, model: -> { Vacancy.job_roles.keys } },
+    "job_roles" => { v1: V1_JOB_ROLES, model: -> { Vacancy.job_roles.keys - Vacancy::FE_SUPPORT_JOB_ROLES } },
     "contract_types" => { v1: V1_CONTRACT_TYPES, model: -> { Vacancy.contract_types.keys } },
     "working_patterns" => { v1: V1_WORKING_PATTERNS, model: -> { Vacancy::WORKING_PATTERNS } },
     "phases" => { v1: V1_PHASES, model: -> { Vacancy.phases.keys } },

--- a/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_college_spec.rb
+++ b/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_college_spec.rb
@@ -26,9 +26,10 @@ RSpec.describe "Creating a vacancy as an FE college" do
       postcode: "BN1 1AA",
     )
 
-    # Job role page only shows Teacher or Lecturer for FE colleges
+    # Job role page shows Teacher or Lecturer plus the FE-specific support roles, but not the school-only roles
     expect(publisher_job_role_page).to be_displayed
     expect(page).to have_content(I18n.t("helpers.label.publishers_job_listing_job_role_form.teaching_job_role_options.teacher"))
+    expect(page).to have_content(I18n.t("helpers.label.publishers_job_listing_job_role_form.fe_support_job_role_options.leadership_and_management"))
     expect(page).to have_no_content(I18n.t("helpers.label.publishers_job_listing_job_role_form.teaching_job_role_options.headteacher"))
     expect(page).to have_no_content(I18n.t("helpers.label.publishers_job_listing_job_role_form.support_job_role_options.teaching_assistant"))
     publisher_job_role_page.fill_in_and_submit_form(vacancy.job_roles.first)

--- a/spec/validators/external_vacancy_validator_spec.rb
+++ b/spec/validators/external_vacancy_validator_spec.rb
@@ -122,6 +122,45 @@ RSpec.describe ExternalVacancyValidator, type: :model do
     end
   end
 
+  describe "job roles validation" do
+    context "when job_roles only contains roles available outside FE colleges" do
+      before do
+        vacancy.job_roles = %w[teacher teaching_assistant]
+        vacancy.validate
+      end
+
+      it "does not add a job roles error" do
+        expect(vacancy.errors[:job_roles]).to be_empty
+      end
+    end
+
+    context "when job_roles contains an FE-exclusive support role" do
+      before do
+        vacancy.job_roles = %w[teacher leadership_and_management]
+        vacancy.validate
+      end
+
+      it "adds a job roles error" do
+        expect(vacancy.errors[:job_roles]).to include("Select a job role")
+      end
+
+      it "adds an inclusion error" do
+        expect(vacancy.errors.of_kind?(:job_roles, :inclusion)).to be true
+      end
+    end
+
+    context "when job_roles only contains FE-exclusive support roles" do
+      before do
+        vacancy.job_roles = Vacancy::FE_SUPPORT_JOB_ROLES
+        vacancy.validate
+      end
+
+      it "adds a job roles error" do
+        expect(vacancy.errors[:job_roles]).to include("Select a job role")
+      end
+    end
+  end
+
   describe "external reference conflict validation" do
     subject(:vacancy) { build(:vacancy, :external, external_reference: "REF123", publisher_ats_api_client:) }
 


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/BHm9tbIW/3102-support-roles-to-be-added-for-fe-hiring-staff-to-fill-vacancies-in-non-teaching-roles

## Changes in this PR:

Adds 5 new roles to the support job-role group, positioned between "Pastoral, health and welfare" and "Other support role":

- Leadership and management
- Business support, administration and corporate services
- Student support, learning and progress
- Marketing and communications
- Apprenticeships and commercial services

Model (app/models/vacancy.rb): new entries added to Vacancy::JOB_ROLES (fresh IDs 17–21) and inserted in order into Vacancy::SUPPORT_JOB_ROLES — this array drives display order everywhere roles are listed (publisher job forms, jobseeker profile/search, subscriptions, dashboard filters).

Labels: added to config/locales/forms.yml (job listing form options) and config/locales/jobseekers/profile/job_preferences.yml (jobseeker profile summary).

Public API contract (spec/swagger_helper.rb): added to V1_JOB_ROLES, per that file's documented process for additive/non-breaking enum changes.

SEO landing pages (main + FE site): new page config in config/landing_pages.yml/config/fe_landing_pages.yml, translated title/heading/meta description in config/locales/landing_pages.yml, and slug mappings in app/helpers/landing_page_lists_helper.rb. Also added the 5 roles to the existing support-jobs aggregate landing page.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
