### PR TITLE
Order supporting documents in order at which they were created at

### DIFF
--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -88,6 +88,11 @@ class Vacancy < ApplicationRecord
   }.freeze
 
   has_many_attached :supporting_documents, service: :azure_storage_documents
+  has_many :supporting_documents_in_order,
+           -> { where(name: "supporting_documents").order(created_at: :asc) },
+           class_name: "ActiveStorage::Attachment",
+           as: :record,
+           inverse_of: :record
 
   validates :supporting_documents, content_type: DOCUMENT_CONTENT_TYPES,
                                    size: { less_than: DOCUMENT_FILE_SIZE_LIMIT }, if: -> { include_additional_documents }

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -87,7 +87,9 @@ class Vacancy < ApplicationRecord
     valid_file_types: %i[PDF DOC DOCX],
   }.freeze
 
-  has_many_attached :supporting_documents, service: :azure_storage_documents
+  has_many_attached :supporting_documents, service: :azure_storage_documents do |attachable|
+    attachable.order("active_storage_attachments.created_at ASC")
+  end
 
   validates :supporting_documents, content_type: DOCUMENT_CONTENT_TYPES,
                                    size: { less_than: DOCUMENT_FILE_SIZE_LIMIT }, if: -> { include_additional_documents }

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -87,9 +87,7 @@ class Vacancy < ApplicationRecord
     valid_file_types: %i[PDF DOC DOCX],
   }.freeze
 
-  has_many_attached :supporting_documents, service: :azure_storage_documents do |attachable|
-    attachable.order("active_storage_attachments.created_at ASC")
-  end
+  has_many_attached :supporting_documents, service: :azure_storage_documents
 
   validates :supporting_documents, content_type: DOCUMENT_CONTENT_TYPES,
                                    size: { less_than: DOCUMENT_FILE_SIZE_LIMIT }, if: -> { include_additional_documents }

--- a/app/views/jobseekers/job_applications/build/personal_statement.html.slim
+++ b/app/views/jobseekers/job_applications/build/personal_statement.html.slim
@@ -12,7 +12,7 @@
     - if job_application.vacancy.supporting_documents.any?
       = t(".banner_documents_html", job_link: open_in_new_tab_link_to("‘#{job_application.vacancy.job_title}’", job_path(job_application.vacancy)))
       div class="govuk-!-margin-top-3"
-        = render SupportingDocumentComponent.with_collection(job_application.vacancy.supporting_documents)
+        = render SupportingDocumentComponent.with_collection(job_application.vacancy.supporting_documents.order("active_storage_attachments.created_at ASC"))
     - else
       = t(".banner_no_documents_html", job_link: open_in_new_tab_link_to("'#{job_application.vacancy.job_title}' #{t('.job_description')}", job_path(job_application.vacancy)))
 

--- a/app/views/jobseekers/job_applications/build/personal_statement.html.slim
+++ b/app/views/jobseekers/job_applications/build/personal_statement.html.slim
@@ -12,7 +12,7 @@
     - if job_application.vacancy.supporting_documents.any?
       = t(".banner_documents_html", job_link: open_in_new_tab_link_to("‘#{job_application.vacancy.job_title}’", job_path(job_application.vacancy)))
       div class="govuk-!-margin-top-3"
-        = render SupportingDocumentComponent.with_collection(job_application.vacancy.supporting_documents.order("active_storage_attachments.created_at ASC"))
+        = render SupportingDocumentComponent.with_collection(job_application.vacancy.supporting_documents_in_order)
     - else
       = t(".banner_no_documents_html", job_link: open_in_new_tab_link_to("'#{job_application.vacancy.job_title}' #{t('.job_description')}", job_path(job_application.vacancy)))
 

--- a/app/views/publishers/vacancies/documents/_documents.html.slim
+++ b/app/views/publishers/vacancies/documents/_documents.html.slim
@@ -1,5 +1,5 @@
 dl.govuk-summary-list
-  - vacancy.supporting_documents.order("active_storage_attachments.created_at ASC").each_with_index do |document, index|
+  - vacancy.supporting_documents_in_order.each_with_index do |document, index|
     .govuk-summary-list__row
       dt.govuk-summary-list__key = "File #{index + 1}"
       dd.govuk-summary-list__value

--- a/app/views/publishers/vacancies/documents/_documents.html.slim
+++ b/app/views/publishers/vacancies/documents/_documents.html.slim
@@ -1,5 +1,5 @@
 dl.govuk-summary-list
-  - vacancy.supporting_documents.each_with_index do |document, index|
+  - vacancy.supporting_documents.order("active_storage_attachments.created_at ASC").each_with_index do |document, index|
     .govuk-summary-list__row
       dt.govuk-summary-list__key = "File #{index + 1}"
       dd.govuk-summary-list__value

--- a/app/views/publishers/vacancies/vacancy_review_sections/_about_the_role.html.slim
+++ b/app/views/publishers/vacancies/vacancy_review_sections/_about_the_role.html.slim
@@ -91,7 +91,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
         = t("jobs.additional_documents")
       - row.with_value
         ul.govuk-list
-          - vacancy.supporting_documents.each do |document|
+          - vacancy.supporting_documents.order("active_storage_attachments.created_at ASC").each do |document|
             li = document_filename(vacancy, document)
       - row.with_action text: t("buttons.change"),
                   href: organisation_job_documents_path(vacancy.id, "back_to_#{action_name}": "true"),

--- a/app/views/publishers/vacancies/vacancy_review_sections/_about_the_role.html.slim
+++ b/app/views/publishers/vacancies/vacancy_review_sections/_about_the_role.html.slim
@@ -91,7 +91,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
         = t("jobs.additional_documents")
       - row.with_value
         ul.govuk-list
-          - vacancy.supporting_documents.order("active_storage_attachments.created_at ASC").each do |document|
+          - vacancy.supporting_documents_in_order.each do |document|
             li = document_filename(vacancy, document)
       - row.with_action text: t("buttons.change"),
                   href: organisation_job_documents_path(vacancy.id, "back_to_#{action_name}": "true"),

--- a/app/views/publishers/vacancies/vacancy_review_sections/_documents.html.slim
+++ b/app/views/publishers/vacancies/vacancy_review_sections/_documents.html.slim
@@ -10,7 +10,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
                     href: organisation_job_build_path(vacancy.id, :documents, "back_to_#{action_name}": "true"),
                     visually_hidden_text: t("jobs.supporting_documents")
   - else
-    - vacancy.supporting_documents.each_with_index do |document, index|
+    - vacancy.supporting_documents.order("active_storage_attachments.created_at ASC").each_with_index do |document, index|
       - summary_list.with_row do |row|
         - row.with_key text: "Document #{index + 1}"
         - row.with_value text: document.filename

--- a/app/views/publishers/vacancies/vacancy_review_sections/_documents.html.slim
+++ b/app/views/publishers/vacancies/vacancy_review_sections/_documents.html.slim
@@ -10,7 +10,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
                     href: organisation_job_build_path(vacancy.id, :documents, "back_to_#{action_name}": "true"),
                     visually_hidden_text: t("jobs.supporting_documents")
   - else
-    - vacancy.supporting_documents.order("active_storage_attachments.created_at ASC").each_with_index do |document, index|
+    - vacancy.supporting_documents_in_order.each_with_index do |document, index|
       - summary_list.with_row do |row|
         - row.with_key text: "Document #{index + 1}"
         - row.with_value text: document.filename

--- a/app/views/vacancies/listing/_job_details.html.slim
+++ b/app/views/vacancies/listing/_job_details.html.slim
@@ -138,4 +138,4 @@ section#job-details class="govuk-!-margin-bottom-5"
       h3.govuk-heading-l.heading--border-bottom = t("jobs.additional_documents")
       p.govuk-body = t("jobs.supporting_documents_accessibility")
       .grey-border-box--thin
-        = render SupportingDocumentComponent.with_collection(vacancy.supporting_documents.order("active_storage_attachments.created_at ASC"))
+        = render SupportingDocumentComponent.with_collection(vacancy.supporting_documents_in_order)

--- a/app/views/vacancies/listing/_job_details.html.slim
+++ b/app/views/vacancies/listing/_job_details.html.slim
@@ -138,4 +138,4 @@ section#job-details class="govuk-!-margin-bottom-5"
       h3.govuk-heading-l.heading--border-bottom = t("jobs.additional_documents")
       p.govuk-body = t("jobs.supporting_documents_accessibility")
       .grey-border-box--thin
-        = render SupportingDocumentComponent.with_collection(vacancy.supporting_documents)
+        = render SupportingDocumentComponent.with_collection(vacancy.supporting_documents.order("active_storage_attachments.created_at ASC"))

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -10,6 +10,35 @@ RSpec.describe Vacancy do
   it { is_expected.to have_many(:job_applications) }
   it { is_expected.to have_one(:equal_opportunities_report) }
 
+  describe "#supporting_documents_in_order" do
+    it "returns supporting documents ordered by upload time" do
+      vacancy = create(:vacancy)
+
+      travel_to(1.minute.ago) do
+        vacancy.supporting_documents.attach(
+          io: File.open(Rails.root.join("spec/fixtures/files/blank_job_spec.pdf")),
+          filename: "blank_job_spec.pdf",
+          content_type: "application/pdf",
+        )
+      end
+
+      vacancy.supporting_documents.attach(
+        io: File.open(Rails.root.join("spec/fixtures/files/blank_baptism_cert.pdf")),
+        filename: "blank_baptism_cert.pdf",
+        content_type: "application/pdf",
+      )
+
+      vacancy.supporting_documents.attach(
+        io: File.open(Rails.root.join("spec/fixtures/files/mime_types/valid_word_document.docx")),
+        filename: "valid_word_document.docx",
+        content_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      )
+
+      expect(vacancy.supporting_documents_in_order.map { |document| document.filename.to_s })
+        .to eq(%w[blank_job_spec.pdf blank_baptism_cert.pdf valid_word_document.docx])
+    end
+  end
+
   describe "publish_on removal callback" do
     it "publish_on is not removed when creating a new draft" do
       draft_vacancy = create(:draft_vacancy, publish_on: Date.current)

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -16,20 +16,20 @@ RSpec.describe Vacancy do
 
       travel_to(1.minute.ago) do
         vacancy.supporting_documents.attach(
-          io: File.open(Rails.root.join("spec/fixtures/files/blank_job_spec.pdf")),
+          io: Rails.root.join("spec/fixtures/files/blank_job_spec.pdf").open,
           filename: "blank_job_spec.pdf",
           content_type: "application/pdf",
         )
       end
 
       vacancy.supporting_documents.attach(
-        io: File.open(Rails.root.join("spec/fixtures/files/blank_baptism_cert.pdf")),
+        io: Rails.root.join("spec/fixtures/files/blank_baptism_cert.pdf").open,
         filename: "blank_baptism_cert.pdf",
         content_type: "application/pdf",
       )
 
       vacancy.supporting_documents.attach(
-        io: File.open(Rails.root.join("spec/fixtures/files/mime_types/valid_word_document.docx")),
+        io: Rails.root.join("spec/fixtures/files/mime_types/valid_word_document.docx").open,
         filename: "valid_word_document.docx",
         content_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
       )

--- a/spec/system/publishers/publishers_can_add_additional_documents_to_a_vacancy_spec.rb
+++ b/spec/system/publishers/publishers_can_add_additional_documents_to_a_vacancy_spec.rb
@@ -66,11 +66,14 @@ RSpec.describe "Publishers can add additional documents to a vacancy" do
     publisher_include_additional_documents_page.include_documents_yes.click
     click_on I18n.t("buttons.save_and_continue")
 
-    upload_and_continue("blank_job_spec.pdf")
-    upload_and_continue("blank_baptism_cert.pdf")
-    upload_and_continue("mime_types/valid_word_document.docx")
+    ["blank_job_spec.pdf", "blank_baptism_cert.pdf", "mime_types/valid_word_document.docx"].each_with_index do |filename, index|
+      page.attach_file("publishers_job_listing_documents_form[supporting_documents][]",
+                       Rails.root.join("spec/fixtures/files/#{filename}"))
+      click_on I18n.t("buttons.save_and_continue")
 
-    publisher_vacancy_documents_page.add_another_document_no_radio.click
+      publisher_vacancy_documents_page.add_another_document_yes_radio.click if index < 2
+      click_on I18n.t("buttons.save_and_continue") if index < 2
+    end
 
     filenames = page.all(".govuk-summary-list__value").map(&:text)
     expect(filenames[0]).to include("blank_job_spec.pdf")
@@ -81,14 +84,6 @@ RSpec.describe "Publishers can add additional documents to a vacancy" do
   def add_document
     page.attach_file("publishers_job_listing_documents_form[supporting_documents][]",
                      Rails.root.join("spec/fixtures/files/blank_job_spec.pdf"))
-    click_on I18n.t("buttons.save_and_continue")
-  end
-
-  def upload_and_continue(filename)
-    page.attach_file("publishers_job_listing_documents_form[supporting_documents][]",
-                     Rails.root.join("spec/fixtures/files/#{filename}"))
-    click_on I18n.t("buttons.save_and_continue")
-    publisher_vacancy_documents_page.add_another_document_yes_radio.click
     click_on I18n.t("buttons.save_and_continue")
   end
 end

--- a/spec/system/publishers/publishers_can_add_additional_documents_to_a_vacancy_spec.rb
+++ b/spec/system/publishers/publishers_can_add_additional_documents_to_a_vacancy_spec.rb
@@ -62,9 +62,33 @@ RSpec.describe "Publishers can add additional documents to a vacancy" do
     expect(current_path).to eq(organisation_job_summary_path(vacancy.id))
   end
 
+  scenario "documents appear in the order they were uploaded" do
+    publisher_include_additional_documents_page.include_documents_yes.click
+    click_on I18n.t("buttons.save_and_continue")
+
+    upload_and_continue("blank_job_spec.pdf")
+    upload_and_continue("blank_baptism_cert.pdf")
+    upload_and_continue("mime_types/valid_word_document.docx")
+
+    publisher_vacancy_documents_page.add_another_document_no_radio.click
+
+    filenames = page.all(".govuk-summary-list__value").map(&:text)
+    expect(filenames[0]).to include("blank_job_spec.pdf")
+    expect(filenames[1]).to include("blank_baptism_cert.pdf")
+    expect(filenames[2]).to include("valid_word_document.docx")
+  end
+
   def add_document
     page.attach_file("publishers_job_listing_documents_form[supporting_documents][]",
                      Rails.root.join("spec/fixtures/files/blank_job_spec.pdf"))
+    click_on I18n.t("buttons.save_and_continue")
+  end
+
+  def upload_and_continue(filename)
+    page.attach_file("publishers_job_listing_documents_form[supporting_documents][]",
+                     Rails.root.join("spec/fixtures/files/#{filename}"))
+    click_on I18n.t("buttons.save_and_continue")
+    publisher_vacancy_documents_page.add_another_document_yes_radio.click
     click_on I18n.t("buttons.save_and_continue")
   end
 end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/BrbwChiw/3090-ux-bug-hiring-staff-ordering-of-supporting-documents-for-vacancies

## Changes in this PR:

Prior to this change, supporting documents were ordered incorrectly . This change displays them in the order in which they are created.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
