### PR TITLE
Harden dsi jobs against transient 500s

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -2,7 +2,12 @@ class ApplicationJob < ActiveJob::Base
   # Order matters: `rescue_from` handlers are matched last-registered-first, and
   # `ActiveJob::DeserializationError` is a `StandardError`. The specific
   # `discard_on` must come after the catch-all `retry_on` so that jobs whose
-  # arguments no longer exist are discarded rather than retried ten times.
-  retry_on StandardError, attempts: 10
+  # arguments no longer exist are discarded rather than retried.
+  #
+  # The backoff is deliberately polynomial rather than the Active Job default of a flat
+  # 3 seconds: attempts spaced 3 seconds apart exhaust the whole retry budget in under half
+  # a minute, which is not long enough to ride out an external API being briefly
+  # unavailable. Polynomially longer spreads the 8 attempts over roughly 75 minutes.
+  retry_on StandardError, wait: :polynomially_longer, attempts: 8
   discard_on ActiveJob::DeserializationError
 end

--- a/app/services/publishers/dfe_sign_in/big_query_export/approvers.rb
+++ b/app/services/publishers/dfe_sign_in/big_query_export/approvers.rb
@@ -3,11 +3,15 @@ module Publishers::DfeSignIn::BigQueryExport
     TABLE_NAME = "dsi_approvers".freeze
 
     def call
+      # See the note in `Users#call`: fetch the first page before deleting the table so a
+      # DSI outage does not leave us with no data at all.
+      pages = dsi_approvers
+
       delete_table(TABLE_NAME)
-      dsi_approvers.each { |page| insert_table_data(page) }
+      pages.each { |page| insert_table_data(page) }
     rescue StandardError => e
       Rails.logger.warn("DSI API /approvers failed to respond with error: #{e.message}")
-      raise "#{e.message}, while writing data from DSI /approvers endpoint. Flag this to Steven + Comms team"
+      raise ExportError, "#{e.message}, while writing data from DSI /approvers endpoint. Flag this to Steven + Comms team"
     end
 
     private

--- a/app/services/publishers/dfe_sign_in/big_query_export/base.rb
+++ b/app/services/publishers/dfe_sign_in/big_query_export/base.rb
@@ -3,6 +3,10 @@ require "google/cloud/bigquery"
 
 module Publishers::DfeSignIn::BigQueryExport
   class Base
+    # Raised when an export cannot complete. Always raised from within a `rescue`, so the
+    # underlying error (a DSI or BigQuery failure) is preserved as its `cause`.
+    class ExportError < StandardError; end
+
     include DfeSignIn::API
     include Publishers::DfeSignIn::Parsing
 

--- a/app/services/publishers/dfe_sign_in/big_query_export/users.rb
+++ b/app/services/publishers/dfe_sign_in/big_query_export/users.rb
@@ -3,11 +3,16 @@ module Publishers::DfeSignIn::BigQueryExport
     TABLE_NAME = "dsi_users".freeze
 
     def call
+      # `dsi_users` performs the first page request eagerly, so fetching before deleting
+      # means an unavailable DSI leaves the existing table intact instead of dropping it
+      # and having nothing to replace it with.
+      pages = dsi_users
+
       delete_table(TABLE_NAME)
-      dsi_users.each { |page| insert_table_data(page) }
+      pages.each { |page| insert_table_data(page) }
     rescue StandardError => e
       Rails.logger.warn("DSI API /users failed to respond with error: #{e.message}")
-      raise "#{e.message}, while writing data from DSI /users endpoint. Flag this to Steven + Comms team"
+      raise ExportError, "#{e.message}, while writing data from DSI /users endpoint. Flag this to Steven + Comms team"
     end
 
     private

--- a/lib/dfe_sign_in/api.rb
+++ b/lib/dfe_sign_in/api.rb
@@ -17,6 +17,17 @@ module DfeSignIn
     end
 
     class PaginatedUsers
+      # Transient failures are retried per page rather than left to the job-level
+      # `retry_on`, because retrying the job restarts pagination from page one: every page
+      # that had already succeeded gets fetched and processed again.
+      RETRYABLE_ERRORS = [
+        DfeSignIn::API::Request::ExternalServerError,
+        Net::OpenTimeout,
+        Net::ReadTimeout,
+      ].freeze
+      PAGE_ATTEMPTS = 3
+      RETRY_WAIT_SECONDS = 5
+
       attr_reader :endpoint, :page_size
 
       def initialize(endpoint, page_size)
@@ -26,16 +37,30 @@ module DfeSignIn
 
       def results
         # First page request to get the total number of pages
-        request = DfeSignIn::API::Request.new(endpoint, 1, page_size)
-        response = DfeSignIn::API::Response.new(request)
+        response = fetch_page(1)
 
         (1..response.number_of_pages).lazy.map do |page|
-          unless page == 1 # We already have the response for page 1
-            request = DfeSignIn::API::Request.new(endpoint, page, page_size)
-            response = DfeSignIn::API::Response.new(request)
-          end
+          response = fetch_page(page) unless page == 1 # We already have the response for page 1
 
           response.users
+        end
+      end
+
+      private
+
+      def fetch_page(page)
+        attempts = 0
+
+        begin
+          attempts += 1
+          DfeSignIn::API::Response.new(DfeSignIn::API::Request.new(endpoint, page, page_size))
+        rescue *RETRYABLE_ERRORS => e
+          raise if attempts >= PAGE_ATTEMPTS
+
+          Rails.logger.warn("DSI API #{endpoint} page #{page} failed with #{e.class}, " \
+                            "retrying (attempt #{attempts} of #{PAGE_ATTEMPTS})")
+          sleep(RETRY_WAIT_SECONDS)
+          retry
         end
       end
     end

--- a/lib/dfe_sign_in/api/request.rb
+++ b/lib/dfe_sign_in/api/request.rb
@@ -5,6 +5,10 @@ module DfeSignIn
       class ForbiddenRequestError < StandardError; end
       class UnknownResponseError < StandardError; end
 
+      # Without this a hanging DSI response pins a Solid Queue worker thread indefinitely,
+      # and there are only a handful of threads per worker process (see `config/queue.yml`).
+      TIMEOUT_SECONDS = 30
+
       def initialize(endpoint, page, page_size)
         @endpoint = endpoint
         @page = page
@@ -16,6 +20,7 @@ module DfeSignIn
         response = HTTParty.get(
           "#{ENV.fetch('DFE_SIGN_IN_URL', nil)}#{@endpoint}?page=#{@page}&pageSize=#{@page_size}",
           headers: { "Authorization" => "Bearer #{token}" },
+          timeout: TIMEOUT_SECONDS,
         )
 
         raise ExternalServerError if response.code.eql?(500)

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -33,6 +33,25 @@ RSpec.describe ApplicationJob do
     end
   end
 
+  describe "retry backoff" do
+    # A flat 3 second wait (the Active Job default) exhausts every attempt in well under a
+    # minute, which is not long enough to ride out a briefly unavailable external API.
+    it "spaces retries polynomially rather than at a flat 3 seconds" do
+      TestApplicationJob.define_method(:perform) { raise "transient failure" }
+
+      job = TestApplicationJob.new
+
+      freeze_time do
+        3.times { job.perform_now }
+
+        delays = enqueued_jobs.map { |enqueued| enqueued[:at] - Time.current.to_f }
+
+        expect(delays.first).to be < 5.seconds
+        expect(delays.last).to be > 60.seconds
+      end
+    end
+  end
+
   describe "retrying other errors" do
     it "re-enqueues instead of failing, then succeeds on retry" do
       attempts = 0

--- a/spec/lib/dfe_sign_in/api/request_spec.rb
+++ b/spec/lib/dfe_sign_in/api/request_spec.rb
@@ -49,6 +49,16 @@ RSpec.shared_examples "a DFE Sign In endpoint" do
       end
     end
 
+    # Without a timeout a hanging DSI response would pin a worker thread indefinitely.
+    it "bounds the request with a timeout" do
+      stub_api_response_for_page(1)
+      expect(HTTParty).to receive(:get)
+        .with(anything, hash_including(timeout: DfeSignIn::API::Request::TIMEOUT_SECONDS))
+        .and_call_original
+
+      subject.perform
+    end
+
     it "sets a token in the header of the request" do
       freeze_time do
         expected_token = generate_jwt_token

--- a/spec/lib/dfe_sign_in/api_spec.rb
+++ b/spec/lib/dfe_sign_in/api_spec.rb
@@ -40,6 +40,45 @@ RSpec.describe DfeSignIn::API do
     end
   end
 
+  describe "retrying a failed page" do
+    let(:fixture_filename) { "users" }
+
+    # Retrying at the job level would restart pagination from page one, so a transient
+    # failure has to be absorbed here instead.
+    before { stub_const("DfeSignIn::API::PaginatedUsers::RETRY_WAIT_SECONDS", 0) }
+
+    it "retries the page and carries on when the failure is transient" do
+      stub_responses(DfeSignIn::API::Request::ExternalServerError, stubbed_response, stubbed_response)
+
+      expect(subject.dsi_users.to_a).to eq [JSON.parse(response_file(1))["users"],
+                                            JSON.parse(response_file(2))["users"]]
+    end
+
+    it "gives up once the page has been attempted the maximum number of times" do
+      stub_responses(*Array.new(DfeSignIn::API::PaginatedUsers::PAGE_ATTEMPTS, DfeSignIn::API::Request::ExternalServerError))
+
+      expect { subject.dsi_users }.to raise_error(DfeSignIn::API::Request::ExternalServerError)
+    end
+
+    it "does not retry errors that will not resolve themselves" do
+      stub_responses(DfeSignIn::API::Request::ForbiddenRequestError, stubbed_response)
+
+      expect { subject.dsi_users }.to raise_error(DfeSignIn::API::Request::ForbiddenRequestError)
+      expect(DfeSignIn::API::Response).to have_received(:new).once
+    end
+
+    # Each element is either an exception class to raise or a response to return, consumed
+    # one per call to `DfeSignIn::API::Response.new`.
+    def stub_responses(*outcomes)
+      allow(DfeSignIn::API::Response).to receive(:new) do
+        outcome = outcomes.shift
+        raise outcome if outcome.is_a?(Class)
+
+        outcome
+      end
+    end
+  end
+
   def response_file(page)
     File.read(Rails.root.join(
                 "spec",

--- a/spec/services/publishers/dfe_sign_in/big_query_export/approvers_spec.rb
+++ b/spec/services/publishers/dfe_sign_in/big_query_export/approvers_spec.rb
@@ -5,7 +5,7 @@ require "dfe_sign_in/api/request"
 RSpec.describe Publishers::DfeSignIn::BigQueryExport::Approvers do
   before do
     expect(bigquery_stub).to receive(:dataset).with("test_dataset").and_return(dataset_stub)
-    expect(dataset_stub).to receive(:table).and_return(table_stub)
+    allow(dataset_stub).to receive(:table).and_return(table_stub)
 
     expect(DfeSignIn::API::Request).to receive(:new).at_least(:once).and_return(api_request)
     expect(api_request).to receive(:perform).at_least(:once).and_return(api_response)
@@ -95,8 +95,15 @@ RSpec.describe Publishers::DfeSignIn::BigQueryExport::Approvers do
     context "when DSI API fails" do
       let(:api_response) { unsuccesful_api_response }
 
-      it "raises a runtime error" do
-        expect { subject.call }.to raise_error(RuntimeError)
+      it "raises an export error that preserves the underlying failure" do
+        expect { subject.call }
+          .to raise_error(described_class::ExportError, /jwt expired, while writing data from DSI \/approvers endpoint/)
+      end
+
+      it "does not touch the existing table, so it is not left empty" do
+        expect { subject.call }.to raise_error(described_class::ExportError)
+
+        expect(dataset_stub).not_to have_received(:table)
       end
     end
   end

--- a/spec/services/publishers/dfe_sign_in/big_query_export/users_spec.rb
+++ b/spec/services/publishers/dfe_sign_in/big_query_export/users_spec.rb
@@ -4,7 +4,7 @@ require "dfe_sign_in/api/request"
 RSpec.describe Publishers::DfeSignIn::BigQueryExport::Users do
   before do
     expect(bigquery_stub).to receive(:dataset).with("test_dataset").and_return(dataset_stub)
-    expect(dataset_stub).to receive(:table).and_return(table_stub)
+    allow(dataset_stub).to receive(:table).and_return(table_stub)
 
     expect(DfeSignIn::API::Request).to receive(:new).at_least(:once).and_return(api_request)
     expect(api_request).to receive(:perform).at_least(:once).and_return(api_response)
@@ -94,8 +94,15 @@ RSpec.describe Publishers::DfeSignIn::BigQueryExport::Users do
     context "when DSI API fails" do
       let(:api_response) { unsuccessful_api_response }
 
-      it "raises a runtime error" do
-        expect { subject.call }.to raise_error(RuntimeError)
+      it "raises an export error that preserves the underlying failure" do
+        expect { subject.call }
+          .to raise_error(described_class::ExportError, /jwt expired, while writing data from DSI \/users endpoint/)
+      end
+
+      it "does not touch the existing table, so it is not left empty" do
+        expect { subject.call }.to raise_error(described_class::ExportError)
+
+        expect(dataset_stub).not_to have_received(:table)
       end
     end
   end


### PR DESCRIPTION
## Trello card URL

- https://trello.com/c/xfS9EdIT/3130-debug-dsi-sync-job-errors

## Changes in this PR:

- Is there anything specific you want feedback on?

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
