### PR TITLE
use current_sign_in_at rather than last_sign_in_at for email warnings

### DIFF
--- a/app/jobs/disable_inactive_profiles_job.rb
+++ b/app/jobs/disable_inactive_profiles_job.rb
@@ -4,7 +4,7 @@ class DisableInactiveProfilesJob < ApplicationJob
   def perform
     Jobseeker.includes(:jobseeker_profile)
              .active
-             .where(last_sign_in_at: ..6.months.ago)
+             .where(current_sign_in_at: ..6.months.ago)
              .find_each
              .filter_map(&:jobseeker_profile)
              .select(&:active?)

--- a/app/jobs/inactive_profile_warnings_job.rb
+++ b/app/jobs/inactive_profile_warnings_job.rb
@@ -12,12 +12,12 @@ class InactiveProfileWarningsJob < ApplicationJob
     next_date = date + 1.day
     Jobseeker.includes(:jobseeker_profile)
              .active
-             .where(last_sign_in_at: date..next_date)
+             .where(current_sign_in_at: date..next_date)
              .find_each
              .filter_map(&:jobseeker_profile)
              .select(&:active?)
              .each do |profile|
-               profile_expiry_date = (profile.jobseeker.last_sign_in_at + 6.months).to_date
+               profile_expiry_date = (profile.jobseeker.current_sign_in_at + 6.months).to_date
                Jobseekers::ProfilesMailer.inactive_profile_warning(profile, profile_expiry_date).deliver_later
     end
   end

--- a/app/models/jobseeker.rb
+++ b/app/models/jobseeker.rb
@@ -19,8 +19,8 @@ class Jobseeker < ApplicationRecord
   scope :active, -> { where(account_closed_on: nil) }
   scope :email_opt_in, -> { active.where(email_opt_out: false) }
 
-  scope :very_inactive_will_be_deleted, -> { where(last_sign_in_at: ..6.years.ago) }
-  scope :send_inactive_warning_message, -> { where("DATE(last_sign_in_at) = ?", (6.years.ago + 2.weeks).to_date) }
+  scope :very_inactive_will_be_deleted, -> { where(current_sign_in_at: ..6.years.ago) }
+  scope :send_inactive_warning_message, -> { where("DATE(current_sign_in_at) = ?", (6.years.ago + 2.weeks).to_date) }
 
   validates :email, presence: true, uniqueness: true
   validates :email, email_address: true, if: -> { email_changed? } # Allows data created prior to validation to still be valid

--- a/spec/factories/jobseekers.rb
+++ b/spec/factories/jobseekers.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     govuk_one_login_id { "urn:fdc:gov.uk:2022:#{SecureRandom.hex}" }
 
     trait :for_seed_data do
-      last_sign_in_at { 5.months.ago + rand(7).days }
+      current_sign_in_at { 5.months.ago + rand(7).days }
     end
 
     trait :with_profile do

--- a/spec/jobs/destroy_inactive_accounts_job_spec.rb
+++ b/spec/jobs/destroy_inactive_accounts_job_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe DestroyInactiveAccountsJob do
   let!(:jobseeker) do
-    create(:jobseeker, last_sign_in_at: last_sign_in_at,
+    create(:jobseeker, current_sign_in_at: last_sign_in_at,
                        job_applications: build_list(:job_application, 1,
                                                     create_details: true, create_self_disclosure: true, create_references: true))
   end

--- a/spec/jobs/disable_inactive_profiles_job_spec.rb
+++ b/spec/jobs/disable_inactive_profiles_job_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe DisableInactiveProfilesJob do
   before do
     create(:jobseeker)
     create(:jobseeker_profile)
-    create(:jobseeker_profile, jobseeker: build(:jobseeker, last_sign_in_at: 7.months.ago))
+    create(:jobseeker_profile, jobseeker: build(:jobseeker, current_sign_in_at: 7.months.ago))
   end
 
   it "makes profiles over 6 months inactive" do

--- a/spec/jobs/inactive_profile_warnings_job_spec.rb
+++ b/spec/jobs/inactive_profile_warnings_job_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe InactiveProfileWarningsJob do
   before do
     create(:jobseeker)
     create(:jobseeker_profile)
-    create(:jobseeker_profile, :with_personal_details, jobseeker: build(:jobseeker, last_sign_in_at: 5.months.ago + 1.hour))
-    create(:jobseeker_profile, jobseeker: build(:jobseeker, last_sign_in_at: 6.months.ago + 2.weeks + 1.hour))
+    create(:jobseeker_profile, :with_personal_details, jobseeker: build(:jobseeker, current_sign_in_at: 5.months.ago + 1.hour))
+    create(:jobseeker_profile, jobseeker: build(:jobseeker, current_sign_in_at: 6.months.ago + 2.weeks + 1.hour))
   end
 
   it "sends a warning email to people at 5 months and 6 months - 2.weeks thresholds" do

--- a/spec/jobs/send_inactive_account_email_job_spec.rb
+++ b/spec/jobs/send_inactive_account_email_job_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe SendInactiveAccountEmailJob do
-  let(:jobseeker) { create(:jobseeker, last_sign_in_at: last_sign_in_at) }
+  let(:jobseeker) { create(:jobseeker, current_sign_in_at: last_sign_in_at) }
   let(:message_delivery) { instance_double(ActionMailer::MessageDelivery) }
 
   context "with inactive jobseeker for 6 years" do


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/vzFGhbTi/3135-bug-profile-deactivation-etc-based-on-second-to-last-login-date

## Changes in this PR:

Use current_sign_in_at date rather than last_sign_in_at for date at which user last signed in