### PR TITLE
Fix unsubscribe error

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -68,6 +68,8 @@ class SubscriptionsController < ApplicationController
     subscription = Subscription.kept.find_and_verify_by_token(token)
 
     @subscription = SubscriptionPresenter.new(subscription)
+  rescue ActiveRecord::RecordNotFound
+    redirect_to root_path, success: t(".already_unsubscribed")
   end
 
   def destroy

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -377,6 +377,7 @@ en:
         teaching_roles: Teaching and leadership roles
         support_roles: Support roles
     unsubscribe:
+      already_unsubscribed: You have already unsubscribed from this job alert
       confirmation: Are you sure you want to unsubscribe?
       guidance:
         heading: Want to unsubscribe?

--- a/spec/requests/subscriptions_spec.rb
+++ b/spec/requests/subscriptions_spec.rb
@@ -331,6 +331,27 @@ RSpec.describe "Subscriptions" do
     end
   end
 
+  describe "GET #unsubscribe" do
+    let!(:subscription) { create(:subscription, frequency: :daily) }
+
+    subject { get unsubscribe_subscription_path(subscription.token) }
+
+    it "renders the unsubscribe page" do
+      subject
+      expect(response).to have_http_status(:ok)
+    end
+
+    context "when the subscription has been discarded" do
+      before { subscription.discard }
+
+      it "redirects to root with a success message" do
+        subject
+        expect(response).to redirect_to(root_path)
+        expect(flash[:success]).to be_present
+      end
+    end
+  end
+
   describe "DELETE #destroy" do
     let!(:subscription) { create(:subscription, frequency: :daily) }
 


### PR DESCRIPTION
## Trello card URL

## Changes in this PR:

https://teaching-vacancies.sentry.io/issues/7596427060/?environment=production&project=6212514&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D%20level%3Aerror&referrer=issue-stream

I think the above error is caused by users trying to unsubscribe to a job alert that they have already previously unsubscribed from. This PR should fix this issue.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
