### PR TITLE
DfE Sign-in sync jobs: better handling of errors

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -2,7 +2,12 @@ class ApplicationJob < ActiveJob::Base
   # Order matters: `rescue_from` handlers are matched last-registered-first, and
   # `ActiveJob::DeserializationError` is a `StandardError`. The specific
   # `discard_on` must come after the catch-all `retry_on` so that jobs whose
-  # arguments no longer exist are discarded rather than retried ten times.
-  retry_on StandardError, attempts: 10
+  # arguments no longer exist are discarded rather than retried.
+  #
+  # The backoff is deliberately polynomial rather than the Active Job default of a flat
+  # 3 seconds: attempts spaced 3 seconds apart exhaust the whole retry budget in under half
+  # a minute, which is not long enough to ride out an external API being briefly
+  # unavailable. Polynomially longer spreads the 8 attempts over roughly 75 minutes.
+  retry_on StandardError, wait: :polynomially_longer, attempts: 8
   discard_on ActiveJob::DeserializationError
 end

--- a/app/services/publishers/dfe_sign_in/big_query_export/approvers.rb
+++ b/app/services/publishers/dfe_sign_in/big_query_export/approvers.rb
@@ -3,11 +3,15 @@ module Publishers::DfeSignIn::BigQueryExport
     TABLE_NAME = "dsi_approvers".freeze
 
     def call
+      # See the note in `Users#call`: fetch the first page before deleting the table so a
+      # DSI outage does not leave us with no data at all.
+      pages = dsi_approvers
+
       delete_table(TABLE_NAME)
-      dsi_approvers.each { |page| insert_table_data(page) }
+      pages.each { |page| insert_table_data(page) }
     rescue StandardError => e
       Rails.logger.warn("DSI API /approvers failed to respond with error: #{e.message}")
-      raise "#{e.message}, while writing data from DSI /approvers endpoint. Flag this to Steven + Comms team"
+      raise ExportError, "#{e.message}, while writing data from DSI /approvers endpoint. Flag this to Steven + Comms team"
     end
 
     private

--- a/app/services/publishers/dfe_sign_in/big_query_export/approvers.rb
+++ b/app/services/publishers/dfe_sign_in/big_query_export/approvers.rb
@@ -11,7 +11,7 @@ module Publishers::DfeSignIn::BigQueryExport
       pages.each { |page| insert_table_data(page) }
     rescue StandardError => e
       Rails.logger.warn("DSI API /approvers failed to respond with error: #{e.message}")
-      raise ExportError, "#{e.message}, while writing data from DSI /approvers endpoint. Flag this to Steven + Comms team"
+      raise ExportError, "#{e.message}, while exporting data from DSI /users endpoint into BigQ"
     end
 
     private

--- a/app/services/publishers/dfe_sign_in/big_query_export/base.rb
+++ b/app/services/publishers/dfe_sign_in/big_query_export/base.rb
@@ -3,6 +3,10 @@ require "google/cloud/bigquery"
 
 module Publishers::DfeSignIn::BigQueryExport
   class Base
+    # Raised when an export cannot complete. Always raised from within a `rescue`, so the
+    # underlying error (a DSI or BigQuery failure) is preserved as its `cause`.
+    class ExportError < StandardError; end
+
     include DfeSignIn::API
     include Publishers::DfeSignIn::Parsing
 

--- a/app/services/publishers/dfe_sign_in/big_query_export/users.rb
+++ b/app/services/publishers/dfe_sign_in/big_query_export/users.rb
@@ -3,11 +3,16 @@ module Publishers::DfeSignIn::BigQueryExport
     TABLE_NAME = "dsi_users".freeze
 
     def call
+      # `dsi_users` performs the first page request eagerly, so fetching before deleting
+      # means an unavailable DSI leaves the existing table intact instead of dropping it
+      # and having nothing to replace it with.
+      pages = dsi_users
+
       delete_table(TABLE_NAME)
-      dsi_users.each { |page| insert_table_data(page) }
+      pages.each { |page| insert_table_data(page) }
     rescue StandardError => e
       Rails.logger.warn("DSI API /users failed to respond with error: #{e.message}")
-      raise "#{e.message}, while writing data from DSI /users endpoint. Flag this to Steven + Comms team"
+      raise ExportError, "#{e.message}, while writing data from DSI /users endpoint. Flag this to Steven + Comms team"
     end
 
     private

--- a/app/services/publishers/dfe_sign_in/big_query_export/users.rb
+++ b/app/services/publishers/dfe_sign_in/big_query_export/users.rb
@@ -12,7 +12,7 @@ module Publishers::DfeSignIn::BigQueryExport
       pages.each { |page| insert_table_data(page) }
     rescue StandardError => e
       Rails.logger.warn("DSI API /users failed to respond with error: #{e.message}")
-      raise ExportError, "#{e.message}, while writing data from DSI /users endpoint. Flag this to Steven + Comms team"
+      raise ExportError, "#{e.message}, while exporting data from DSI /users endpoint into BigQ"
     end
 
     private

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -33,6 +33,25 @@ RSpec.describe ApplicationJob do
     end
   end
 
+  describe "retry backoff" do
+    # A flat 3 second wait (the Active Job default) exhausts every attempt in well under a
+    # minute, which is not long enough to ride out a briefly unavailable external API.
+    it "spaces retries polynomially rather than at a flat 3 seconds" do
+      TestApplicationJob.define_method(:perform) { raise "transient failure" }
+
+      job = TestApplicationJob.new
+
+      freeze_time do
+        3.times { job.perform_now }
+
+        delays = enqueued_jobs.map { |enqueued| enqueued[:at] - Time.current.to_f }
+
+        expect(delays.first).to be < 5.seconds
+        expect(delays.last).to be > 60.seconds
+      end
+    end
+  end
+
   describe "retrying other errors" do
     it "re-enqueues instead of failing, then succeeds on retry" do
       attempts = 0

--- a/spec/services/publishers/dfe_sign_in/big_query_export/approvers_spec.rb
+++ b/spec/services/publishers/dfe_sign_in/big_query_export/approvers_spec.rb
@@ -5,7 +5,7 @@ require "dfe_sign_in/api/request"
 RSpec.describe Publishers::DfeSignIn::BigQueryExport::Approvers do
   before do
     expect(bigquery_stub).to receive(:dataset).with("test_dataset").and_return(dataset_stub)
-    expect(dataset_stub).to receive(:table).and_return(table_stub)
+    allow(dataset_stub).to receive(:table).and_return(table_stub)
 
     expect(DfeSignIn::API::Request).to receive(:new).at_least(:once).and_return(api_request)
     expect(api_request).to receive(:perform).at_least(:once).and_return(api_response)
@@ -95,8 +95,15 @@ RSpec.describe Publishers::DfeSignIn::BigQueryExport::Approvers do
     context "when DSI API fails" do
       let(:api_response) { unsuccesful_api_response }
 
-      it "raises a runtime error" do
-        expect { subject.call }.to raise_error(RuntimeError)
+      it "raises an export error that preserves the underlying failure" do
+        expect { subject.call }
+          .to raise_error(described_class::ExportError, /jwt expired, while writing data from DSI \/approvers endpoint/)
+      end
+
+      it "does not touch the existing table, so it is not left empty" do
+        expect { subject.call }.to raise_error(described_class::ExportError)
+
+        expect(dataset_stub).not_to have_received(:table)
       end
     end
   end

--- a/spec/services/publishers/dfe_sign_in/big_query_export/approvers_spec.rb
+++ b/spec/services/publishers/dfe_sign_in/big_query_export/approvers_spec.rb
@@ -91,20 +91,21 @@ RSpec.describe Publishers::DfeSignIn::BigQueryExport::Approvers do
         subject.call
       end
     end
+  end
 
-    context "when DSI API fails" do
-      let(:api_response) { unsuccesful_api_response }
+  context "when DSI API fails" do
+    let(:table_stub) { instance_double(Google::Cloud::Bigquery::Table) }
+    let(:api_response) { unsuccesful_api_response }
 
-      it "raises an export error that preserves the underlying failure" do
-        expect { subject.call }
-          .to raise_error(described_class::ExportError, /jwt expired, while writing data from DSI \/approvers endpoint/)
-      end
+    it "raises an export error that preserves the underlying failure" do
+      expect { subject.call }
+        .to raise_error(described_class::ExportError, /jwt expired, while exporting data from DSI \/users endpoint into BigQ/)
+    end
 
-      it "does not touch the existing table, so it is not left empty" do
-        expect { subject.call }.to raise_error(described_class::ExportError)
+    it "does not touch the existing table, so it is not left empty" do
+      expect { subject.call }.to raise_error(described_class::ExportError)
 
-        expect(dataset_stub).not_to have_received(:table)
-      end
+      expect(dataset_stub).not_to have_received(:table)
     end
   end
 

--- a/spec/services/publishers/dfe_sign_in/big_query_export/users_spec.rb
+++ b/spec/services/publishers/dfe_sign_in/big_query_export/users_spec.rb
@@ -4,7 +4,7 @@ require "dfe_sign_in/api/request"
 RSpec.describe Publishers::DfeSignIn::BigQueryExport::Users do
   before do
     expect(bigquery_stub).to receive(:dataset).with("test_dataset").and_return(dataset_stub)
-    expect(dataset_stub).to receive(:table).and_return(table_stub)
+    allow(dataset_stub).to receive(:table).and_return(table_stub)
 
     expect(DfeSignIn::API::Request).to receive(:new).at_least(:once).and_return(api_request)
     expect(api_request).to receive(:perform).at_least(:once).and_return(api_response)
@@ -94,8 +94,15 @@ RSpec.describe Publishers::DfeSignIn::BigQueryExport::Users do
     context "when DSI API fails" do
       let(:api_response) { unsuccessful_api_response }
 
-      it "raises a runtime error" do
-        expect { subject.call }.to raise_error(RuntimeError)
+      it "raises an export error that preserves the underlying failure" do
+        expect { subject.call }
+          .to raise_error(described_class::ExportError, /jwt expired, while writing data from DSI \/users endpoint/)
+      end
+
+      it "does not touch the existing table, so it is not left empty" do
+        expect { subject.call }.to raise_error(described_class::ExportError)
+
+        expect(dataset_stub).not_to have_received(:table)
       end
     end
   end

--- a/spec/services/publishers/dfe_sign_in/big_query_export/users_spec.rb
+++ b/spec/services/publishers/dfe_sign_in/big_query_export/users_spec.rb
@@ -90,20 +90,21 @@ RSpec.describe Publishers::DfeSignIn::BigQueryExport::Users do
         subject.call
       end
     end
+  end
 
-    context "when DSI API fails" do
-      let(:api_response) { unsuccessful_api_response }
+  context "when DSI API fails" do
+    let(:table_stub) { instance_double(Google::Cloud::Bigquery::Table) }
+    let(:api_response) { unsuccessful_api_response }
 
-      it "raises an export error that preserves the underlying failure" do
-        expect { subject.call }
-          .to raise_error(described_class::ExportError, /jwt expired, while writing data from DSI \/users endpoint/)
-      end
+    it "raises an export error that preserves the underlying failure" do
+      expect { subject.call }
+        .to raise_error(described_class::ExportError, /jwt expired, while exporting data from DSI \/users endpoint into BigQ/)
+    end
 
-      it "does not touch the existing table, so it is not left empty" do
-        expect { subject.call }.to raise_error(described_class::ExportError)
+    it "does not touch the existing table, so it is not left empty" do
+      expect { subject.call }.to raise_error(described_class::ExportError)
 
-        expect(dataset_stub).not_to have_received(:table)
-      end
+      expect(dataset_stub).not_to have_received(:table)
     end
   end
 


### PR DESCRIPTION
## Trello card URL
- https://trello.com/c/xfS9EdIT/3130-debug-dsi-sync-job-errors

## Changes in this PR:

- Configures ActiveJob to do backoff job retries polynomially. Reproducing a similar approach to Sidekiq retries. Instead of doing all the retries linearly every 3 secs.
- Preserve underlying errors from DfE Sign-in when raising exceptions. Better debugging of errors in Sentry.
- BigQ export: Attempt to fetch users before deleting the table in BigQ. So if the fetching errors, the table deletion doesn't run.


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
