### PR TITLE
don't track vacancy view when no referrer

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -26,7 +26,9 @@ class VacanciesController < ApplicationController
     vacancy = PublishedVacancy.kept.listed.friendly.find(params[:id])
     # Only track views which have a referrer - this should reduce bots while in practice not affecting user tracking
     # Referrer is an 'optional, not to be trusted' header, but every browser sends it correctly at the time of writing (Aug 2026)
-    TrackVacancyViewJob.perform_later(vacancy_id: vacancy.id, referrer_url: request.referer, hostname: request.host, params: request.query_parameters) if request.referer.present?
+    if request.referer.present? || params.key?(:utm_campaign)
+      TrackVacancyViewJob.perform_later(vacancy_id: vacancy.id, referrer_url: request.referer, hostname: request.host, params: request.query_parameters)
+    end
 
     @saved_job = vacancy.saved_jobs.find_by(jobseeker: current_jobseeker)
     @job_application = vacancy.job_applications.find_by(jobseeker: current_jobseeker)

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -24,7 +24,10 @@ class VacanciesController < ApplicationController
     end
 
     vacancy = PublishedVacancy.kept.listed.friendly.find(params[:id])
-    TrackVacancyViewJob.perform_later(vacancy_id: vacancy.id, referrer_url: request.referer, hostname: request.host, params: request.query_parameters)
+    # Only track views which have a referrer - this should reduce bots while in practice not affecting user tracking
+    # Referrer is an 'optional, not to be trusted' header, but every browser sends it correctly at the time of writing (Aug 2026)
+    TrackVacancyViewJob.perform_later(vacancy_id: vacancy.id, referrer_url: request.referer, hostname: request.host, params: request.query_parameters) if request.referer.present?
+
     @saved_job = vacancy.saved_jobs.find_by(jobseeker: current_jobseeker)
     @job_application = vacancy.job_applications.find_by(jobseeker: current_jobseeker)
     @invented_job_alert_search_criteria = Search::CriteriaInventor.new(vacancy).criteria

--- a/spec/requests/vacancies_spec.rb
+++ b/spec/requests/vacancies_spec.rb
@@ -37,6 +37,12 @@ RSpec.describe "Vacancies" do
       end
     end
 
+    context "with utm campaign (e.g. job alert links)" do
+      it "tracks the view" do
+        expect { get job_path(vacancy), params: { utm_campaign: "job_alert" } }.to have_enqueued_job(TrackVacancyViewJob)
+      end
+    end
+
     context "without referrer" do
       it "doesnt track the job" do
         expect { get job_path(vacancy) }.not_to have_enqueued_job(TrackVacancyViewJob)

--- a/spec/requests/vacancies_spec.rb
+++ b/spec/requests/vacancies_spec.rb
@@ -17,4 +17,30 @@ RSpec.describe "Vacancies" do
       expect(response).to have_http_status(:ok)
     end
   end
+
+  describe "GET #show" do
+    let(:vacancy) { create(:vacancy) }
+
+    context "with referrer" do
+      let(:referrer_url) {  "https://example.com/some/path?utm=123" }
+
+      it "tracks the view in Redis" do
+        mock_redis = MockRedis.new
+        allow(Redis).to receive(:new).and_return(mock_redis)
+
+        redis_key = "vacancy_referrer_stats:#{vacancy.id}:example"
+
+        perform_enqueued_jobs do
+          get job_path(vacancy), params: {}, headers: { "Referer" => referrer_url }
+        end
+        expect(mock_redis.get(redis_key).to_i).to be > 0
+      end
+    end
+
+    context "without referrer" do
+      it "doesnt track the job" do
+        expect { get job_path(vacancy) }.not_to have_enqueued_job(TrackVacancyViewJob)
+      end
+    end
+  end
 end

--- a/spec/system/jobseekers/jobseekers_can_view_a_vacancy_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_view_a_vacancy_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "Viewing a single published vacancy" do
-  include ActiveJob::TestHelper
-
   let(:school) { create(:school) }
 
   before do
@@ -37,52 +35,12 @@ RSpec.describe "Viewing a single published vacancy" do
       verify_vacancy_show_page_details(vacancy)
     end
 
-    scenario "tracks the view in Redis" do
-      mock_redis = MockRedis.new
-      allow(Redis).to receive(:new).and_return(mock_redis)
-
-      referrer_url = "https://example.com/some/path?utm=123"
-      redis_key = "vacancy_referrer_stats:#{vacancy.id}:example"
-
-      perform_enqueued_jobs do
-        page.driver.header("Referer", referrer_url)
-        visit job_path(vacancy)
-      end
-      expect(mock_redis.get(redis_key).to_i).to be > 0
-    end
-
-    context "when the vacancy has expired" do
-      let(:vacancy) { create(:vacancy, :expired, organisations: [school]) }
-
-      scenario "it shows warnings that the post has expired" do
-        expect(page).to have_content("EXPIRED")
-        expect(page).to have_content("This job expired on #{format_date(vacancy.expires_at, :date_only)}")
-      end
-    end
-
-    context "when the vacancy has not expired" do
-      scenario "it does not show warnings that the post has expired" do
-        expect(page).not_to have_content("EXPIRED")
-        expect(page).not_to have_content("This job expired on #{format_date(vacancy.expires_at, :date_only)}")
-      end
-    end
-
     context "with supporting documents attached" do
       let(:vacancy) { create(:vacancy, :with_supporting_documents, organisations: [school]) }
 
       scenario "can see the supporting documents section" do
         expect(page).to have_content(I18n.t("jobs.additional_documents"))
         expect(page).to have_content(vacancy.supporting_documents.first.filename)
-      end
-    end
-
-    context "when there is an application link set" do
-      let(:vacancy) { create(:vacancy, :apply_via_website, organisations: [school]) }
-
-      scenario "a jobseeker can click on the application link" do
-        click_on I18n.t("jobs.view_advert.school")
-
-        expect(page.current_url).to eq vacancy.application_link
       end
     end
 
@@ -102,17 +60,6 @@ RSpec.describe "Viewing a single published vacancy" do
                                                                      organisation: vacancy.organisation_name,
                                                                      deadline: format_date(vacancy.expires_at, :date_only_shorthand)))
       end
-    end
-
-    scenario "jobseeker sees a tag on jobs that allow to apply through Teaching Vacancies" do
-      expect(page).to have_css("strong.govuk-tag--green", text: I18n.t("vacancies.listing.enable_job_applications_tag"))
-    end
-
-    scenario "jobseeker does not see a tag on jobs that don't allow to apply through Teaching Vacancies" do
-      vacancy_without_apply = create(:vacancy, :apply_via_website, organisations: [school])
-
-      visit job_path(vacancy_without_apply)
-      expect(page).not_to have_css("strong.govuk-tag--green", text: I18n.t("vacancies.listing.enable_job_applications_tag"))
     end
 
     context "with similar jobs listed" do

--- a/spec/system/publishers/publishers_can_edit_a_vacancy_template_spec.rb
+++ b/spec/system/publishers/publishers_can_edit_a_vacancy_template_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe "Editing a vacancy template" do
     context "with visa_sponsorship_available" do
       let(:change) { "visa_sponsorship_available" }
 
-      it "can have its visa_sponsorship_available edited", :a11y do
+      it "can have its visa_sponsorship_available edited", :a11y, :retry do
         expect(page).to have_content "Visa sponsorship"
         expect(page).to be_axe_clean.skipping "aria-allowed-attr"
 

--- a/spec/views/vacancies/show.html.slim_spec.rb
+++ b/spec/views/vacancies/show.html.slim_spec.rb
@@ -9,6 +9,54 @@ RSpec.describe "vacancies/show" do
     render
   end
 
+  let(:school) { build_stubbed(:school) }
+
+  describe "job expiry" do
+    let(:jobseeker) { nil }
+
+    context "when the vacancy has expired" do
+      let(:vacancy) { build_stubbed(:vacancy, :expired, organisations: [school]) }
+
+      it "shows warnings that the post has expired" do
+        expect(rendered).to have_content("EXPIRED")
+        expect(rendered).to have_content("This job expired on #{format_date(vacancy.expires_at, :date_only)}")
+      end
+    end
+
+    context "when the vacancy has not expired" do
+      let(:vacancy) { build_stubbed(:vacancy, organisations: [school]) }
+
+      it "does not show warnings that the post has expired" do
+        expect(rendered).to have_no_content("EXPIRED")
+        expect(rendered).to have_no_content("This job expired on")
+      end
+    end
+  end
+
+  describe "quick apply tags" do
+    let(:jobseeker) { nil }
+
+    context "with a quick apply vacancy" do
+      let(:vacancy) { build_stubbed(:vacancy, organisations: [school]) }
+
+      scenario "jobseeker sees a tag on jobs that allow to apply through Teaching Vacancies" do
+        expect(rendered).to have_css("strong.govuk-tag--green", text: I18n.t("vacancies.listing.enable_job_applications_tag"))
+      end
+    end
+
+    context "with a website vacancy" do
+      let(:vacancy) { build_stubbed(:vacancy, :apply_via_website, organisations: [school]) }
+
+      scenario "jobseeker does not see a tag on jobs that don't allow to apply through Teaching Vacancies" do
+        expect(rendered).to have_no_css("strong.govuk-tag--green", text: I18n.t("vacancies.listing.enable_job_applications_tag"))
+      end
+
+      scenario "a jobseeker can click on the application link" do
+        expect(rendered).to have_link I18n.t("jobs.view_advert.school"), href: vacancy.application_link
+      end
+    end
+  end
+
   describe "job posting metadata" do
     let(:jobseeker) { nil }
     let(:json_ld) { JSON.parse(rendered.html.css("script.jobref").inner_text, symbolize_names: true) }

--- a/spec/views/vacancies/show.html.slim_spec.rb
+++ b/spec/views/vacancies/show.html.slim_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "vacancies/show" do
     context "with a quick apply vacancy" do
       let(:vacancy) { build_stubbed(:vacancy, organisations: [school]) }
 
-      scenario "jobseeker sees a tag on jobs that allow to apply through Teaching Vacancies" do
+      it "has a tag on jobs that allow to apply through Teaching Vacancies" do
         expect(rendered).to have_css("strong.govuk-tag--green", text: I18n.t("vacancies.listing.enable_job_applications_tag"))
       end
     end
@@ -47,11 +47,11 @@ RSpec.describe "vacancies/show" do
     context "with a website vacancy" do
       let(:vacancy) { build_stubbed(:vacancy, :apply_via_website, organisations: [school]) }
 
-      scenario "jobseeker does not see a tag on jobs that don't allow to apply through Teaching Vacancies" do
+      it "does not have a tag on jobs that don't allow to apply through Teaching Vacancies" do
         expect(rendered).to have_no_css("strong.govuk-tag--green", text: I18n.t("vacancies.listing.enable_job_applications_tag"))
       end
 
-      scenario "a jobseeker can click on the application link" do
+      it "has an application link" do
         expect(rendered).to have_link I18n.t("jobs.view_advert.school"), href: vacancy.application_link
       end
     end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/Oyqb7A53/3147-trackvacancyviewjob-could-we-not-trigger-it-for-bots-spiders

## Changes in this PR:

Don't track vacancy views without referrers