### PR TITLE
2855 - Adds review app deletion workflow

### DIFF
--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -4,15 +4,21 @@ on:
   pull_request:
     types: [closed, unlabeled]
     paths-ignore:
-      - 'bigquery/**'
-      - 'documentation/**'
-      - 'terraform/common/**'
-      - '**.md'
+      - "bigquery/**"
+      - "documentation/**"
+      - "terraform/common/**"
+      - "**.md"
   workflow_dispatch:
     inputs:
       pr_number:
-        description: 'Pull Request number to delete (EG: 1234 for review-pr-1234)'
+        description: "Pull Request number to delete (EG: 1234 for review-pr-1234)"
         required: true
+  workflow_call:
+    inputs:
+      pr_number:
+        description: "Pull Request number to delete (EG: 1234 for review-pr-1234)"
+        required: true
+        type: string
 
 # Wait until the Build And Deploy for the same PR is finished before starting this workflow.
 # If triggered by a manual workflow dispatch with a PR number, builds the corresponding 'ref' to match the Build and Deploy
@@ -35,94 +41,100 @@ jobs:
     # Define conditions for triggering the job
     # 1. PR is closed and has the 'deploy' label
     # 2. Workflow is manually triggered
-    # 3. 'deploy' label is removed from the PR
+    # 3. Workflow is called by another workflow
+    # 4. 'deploy' label is removed from the PR
     if: >
       (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'deploy')) ||
       github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'workflow_call' ||
       (github.event.action == 'unlabeled' && github.event.label.name == 'deploy')
     name: Delete review app
     runs-on: ubuntu-latest
     environment: review
 
     steps:
-    - name: Set environment variables
-      run: |
-        PR_NUMBER=${{ github.event.inputs.pr_number || github.event.number }}
-        ENVIRONMENT=review-pr-${PR_NUMBER}
-        echo "PR_NUMBER=${PR_NUMBER}" >> $GITHUB_ENV
-        echo "ENVIRONMENT=${ENVIRONMENT}" >> $GITHUB_ENV
-        echo "LINK_TO_RUN=https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" >> $GITHUB_ENV
-        echo "LINK_TO_PR=https://github.com/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}" >> $GITHUB_ENV
-        echo "LINK_TO_APP=https://teaching-vacancies-${ENVIRONMENT}.test.teacherservices.cloud" >> $GITHUB_ENV
+      - name: Set environment variables
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_call" ]; then
+            PR_NUMBER="${{ inputs.pr_number }}"
+          else
+            PR_NUMBER="${{ github.event.inputs.pr_number || github.event.number }}"
+          fi
+          ENVIRONMENT=review-pr-${PR_NUMBER}
+          echo "PR_NUMBER=${PR_NUMBER}" >> $GITHUB_ENV
+          echo "ENVIRONMENT=${ENVIRONMENT}" >> $GITHUB_ENV
+          echo "LINK_TO_RUN=https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" >> $GITHUB_ENV
+          echo "LINK_TO_PR=https://github.com/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}" >> $GITHUB_ENV
+          echo "LINK_TO_APP=https://teaching-vacancies-${ENVIRONMENT}.test.teacherservices.cloud" >> $GITHUB_ENV
 
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v6.2.3
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: eu-west-2
-        role-to-assume: Deployments
-        role-duration-seconds: 3600
-        role-skip-session-tagging: true
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6.2.3
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+          role-to-assume: Deployments
+          role-duration-seconds: 3600
+          role-skip-session-tagging: true
 
-    - uses: actions/checkout@v7.0.1
-      name: Checkout Code
+      - uses: actions/checkout@v7.0.1
+        name: Checkout Code
 
-    - uses: google-github-actions/auth@v3
-      with:
-        project_id: teacher-vacancy-service
-        workload_identity_provider: projects/689616473831/locations/global/workloadIdentityPools/teaching-vacancies/providers/teaching-vacancies
+      - uses: google-github-actions/auth@v3
+        with:
+          project_id: teacher-vacancy-service
+          workload_identity_provider: projects/689616473831/locations/global/workloadIdentityPools/teaching-vacancies/providers/teaching-vacancies
 
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1.321.0
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1.321.0
 
-    - name: Download fetch_config.rb
-      shell: bash
-      run: |
-        echo "::group:: Download fetch_config.rb script"
-        curl -s https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/master/scripts/fetch_config/fetch_config.rb -o bin/fetch_config.rb
-        chmod +x bin/fetch_config.rb
-        echo "::endgroup::"
+      - name: Download fetch_config.rb
+        shell: bash
+        run: |
+          echo "::group:: Download fetch_config.rb script"
+          curl -s https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/master/scripts/fetch_config/fetch_config.rb -o bin/fetch_config.rb
+          chmod +x bin/fetch_config.rb
+          echo "::endgroup::"
 
-    - name: Validate secrets
-      shell: bash
-      run: |
-        gem install aws-sdk-ssm --no-document
-        bin/fetch_config.rb -s aws-ssm-parameter-path:/teaching-vacancies/dev/app -d quiet \
-          && echo Data in /teaching-vacancies/dev looks valid
+      - name: Validate secrets
+        shell: bash
+        run: |
+          gem install aws-sdk-ssm --no-document
+          bin/fetch_config.rb -s aws-ssm-parameter-path:/teaching-vacancies/dev/app -d quiet \
+            && echo Data in /teaching-vacancies/dev looks valid
 
-    - name: Terraform pin version
-      uses: hashicorp/setup-terraform@v4
-      with:
-        terraform_version: 1.14.5
+      - name: Terraform pin version
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: 1.14.5
 
-    - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
-      with:
-        azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-        azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+      - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
+        with:
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
 
-    - name: Terraform destroy (on PR closed)
-      run: |
-        make review ci terraform-app-destroy pr_id=${{env.PR_NUMBER}}
+      - name: Terraform destroy (on PR closed)
+        run: |
+          make review ci terraform-app-destroy pr_id=${{env.PR_NUMBER}}
 
-    - name: Delete Terraform Statefile
-      run: ./bin/delete-state-file ${{env.PR_NUMBER}}
+      - name: Delete Terraform Statefile
+        run: ./bin/delete-state-file ${{env.PR_NUMBER}}
 
-    - name: Post sticky pull request comment
-      uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # Pinned at v3.0.5
-      with:
-        message: |
-          Review app <${{ env.LINK_TO_APP }}> was successfully deleted
+      - name: Post sticky pull request comment
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # Pinned at v3.0.5
+        with:
+          message: |
+            Review app <${{ env.LINK_TO_APP }}> was successfully deleted
 
-    - name: Send failure message to twd_tv_dev channel
-      if: failure()
-      uses: DFE-Digital/github-actions/send-to-teams-channel@master
-      with:
-        teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
-        title: Delete review app failure
-        service: ${{ vars.TEAMS_MSG_SERVICE_NAME }}
-        message: |
-          Failed deletion of review app PR ${{env.PR_NUMBER}}
-          Pull Requst: ${{ env.LINK_TO_PR }}
-          Review app: ${{ env.LINK_TO_APP }}
+      - name: Send failure message to twd_tv_dev channel
+        if: failure()
+        uses: DFE-Digital/github-actions/send-to-teams-channel@master
+        with:
+          teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
+          title: Delete review app failure
+          service: ${{ vars.TEAMS_MSG_SERVICE_NAME }}
+          message: |
+            Failed deletion of review app PR ${{env.PR_NUMBER}}
+            Pull Requst: ${{ env.LINK_TO_PR }}
+            Review app: ${{ env.LINK_TO_APP }}

--- a/.github/workflows/review-app-reconcile.yml
+++ b/.github/workflows/review-app-reconcile.yml
@@ -1,0 +1,174 @@
+name: Reconcile review apps
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Only display stale review apps; do not delete"
+        required: true
+        default: true
+        type: boolean
+
+  schedule:
+    - cron: "0 08 * * 0"
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+env:
+  TERRAFORM_STATE_BUCKET: 530003481352-terraform-state
+
+jobs:
+  find-stale-review-apps:
+    name: Find stale review apps
+    runs-on: ubuntu-latest
+    environment: review
+
+    outputs:
+      stale_prs: ${{ steps.find-stale.outputs.stale_prs }}
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6.2.1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+          role-to-assume: Deployments
+          role-duration-seconds: 3600
+          role-skip-session-tagging: true
+
+      - name: Azure login
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
+        with:
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Install kubectl
+        uses: DFE-Digital/github-actions/set-kubectl@master
+
+      - name: Get AKS credentials
+        shell: bash
+        run: |
+          az aks get-credentials \
+            --resource-group s189t01-tsc-ts-rg \
+            --name s189t01-tsc-test-aks \
+            --overwrite-existing
+
+          kubelogin convert-kubeconfig -l spn
+
+      - name: Find stale review apps
+        id: find-stale
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "Finding deployed review apps from AKS deployments..."
+          echo ""
+
+          stale_prs=()
+
+          prs=$(
+            kubectl get deployments -n tv-development -o json |
+            jq -r '
+              .items[]
+              | select(.metadata.name | test("^teaching-vacancies-review-pr-[0-9]+-worker$"))
+              | .metadata.name
+            ' |
+            sed -n 's/^teaching-vacancies-review-pr-\([0-9]\+\)-worker$/\1/p' |
+            sort -n
+          )
+
+          if [[ -z "$prs" ]]; then
+            echo "No deployed review apps found."
+            echo "stale_prs=[]" >> "$GITHUB_OUTPUT"
+            echo "stale_count=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          for pr in $prs; do
+
+            pr_json=$(
+              gh pr view "$pr" \
+                --repo "${{ github.repository }}" \
+                --json number,state,mergeable,title,url \
+                2>/dev/null || true
+            )
+
+            if [[ -z "$pr_json" ]]; then
+              echo "PR #$pr | NOT_FOUND | stale review app will be removed"
+              stale_prs+=("$pr")
+              continue
+            fi
+
+            state=$(echo "$pr_json" | jq -r '.state')
+            mergeable=$(echo "$pr_json" | jq -r '.mergeable')
+            title=$(echo "$pr_json" | jq -r '.title')
+            url=$(echo "$pr_json" | jq -r '.url')
+
+            if [[ "$state" != "OPEN" ]]; then
+              echo "PR #$pr | $state | mergeable=$mergeable | $title"
+              echo "$url"
+              echo ""
+
+              stale_prs+=("$pr")
+            fi
+
+          done
+
+          if (( ${#stale_prs[@]} == 0 )); then
+            stale_json="[]"
+          else
+            stale_json=$(printf '%s\n' "${stale_prs[@]}" | jq -R . | jq -s -c .)
+          fi
+
+          stale_count=$(jq 'length' <<< "$stale_json")
+
+          echo ""
+          echo "Stale PRs:"
+          echo "$stale_json"
+
+          echo ""
+          echo "========================================="
+          echo "Stale review apps found: $stale_count"
+          echo "========================================="
+
+          echo "stale_prs=$stale_json" >> "$GITHUB_OUTPUT"
+          echo "stale_count=$stale_count" >> "$GITHUB_OUTPUT"
+
+  delete-review-apps:
+    name: Delete stale review apps
+    needs: find-stale-review-apps
+
+    if: >
+      (
+        github.event_name == 'schedule' ||
+        github.event.inputs.dry_run == 'false'
+      ) &&
+      needs.find-stale-review-apps.outputs.stale_prs != '[]'
+
+    strategy:
+      max-parallel: 1
+      fail-fast: false
+      matrix:
+        pr_number: ${{ fromJson(needs.find-stale-review-apps.outputs.stale_prs) }}
+
+    uses: ./.github/workflows/delete_review_app.yml
+
+    with:
+      pr_number: ${{ matrix.pr_number }}
+
+    secrets: inherit


### PR DESCRIPTION
## Trello card URL

[Trello card](https://trello.com/c/ZWznDc8Y/2855-add-review-app-cleanup-workflow)

## Context

We get quite a few rogue review apps - i.e., the PR has been merged or closed, but the review app wasn’t deleted.

There are various reasons this can occur, but we now require a workflow that will check for rogue review apps and delete them on a scheduled basis. We require it to be run every Sunday.

## Changes proposed in this pull request

A workflow has been added that is set to run every Sunday at 8am. During this period it checks for stale review apps and deletes them. It can also be used to list any existing review apps without deleting by checking the dry run checkbox when run manually.

The code can be found here: [Review app reconcile](https://github.com/DFE-Digital/teaching-vacancies/blob/2855-add-review-app-cleanup-workflow/.github/workflows/review-app-reconcile.yml)

Some minor additions were also applied to the delete_review_app.yml workflow file to accommodate the new functionality.

1. Sets the pr_number input when this workflow is called from another workflow (lines 16-21):

```
  workflow_call:
    inputs:
      pr_number:
        description: "Pull Request number to delete (EG: 1234 for review-pr-1234)"
        required: true
        type: string
```

2. Adds the functionality to call this workflows from another workflow (line 49):

```
    if: >
      (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'deploy')) ||
      github.event_name == 'workflow_dispatch' ||
      github.event_name == 'workflow_call' ||
      (github.event.action == 'unlabeled' && github.event.label.name == 'deploy')
```


## Guidance to review

Branch off of my feature branch and add the following code to the **review-app-reconcile.yml** file of your new branch:

```
schedule:
    - cron: "0 08 * * 0"
push:
    branches:
        - <your-branch-name>
```

Once this is pushed up to remote, the workflow will automatically process a dry run, which should complete successfully. My dry run is here for this service: [Dry run](https://github.com/DFE-Digital/teaching-vacancies/actions/runs/31480949029)

Aside from waiting until it fails on Sunday, we can test the deletion of review apps by running the workflow manually and removing the dry run flag. I did not do this as it is during the day and the review apps may still be needed.

There will be no issue if it fails to delete the review apps on Sunday because it should just list any existing review apps, as it would in a manually launched dry run. This will just need revisiting if the automated deletion process should fail for any reason.

## Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Applied DevOps label
- [x] Tested by running locally