### PR TITLE
Introduce fe_role_qts_required field (QTS required for FE - phase 1)

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -467,6 +467,7 @@ shared:
     - job_address_town
     - job_address_county
     - job_address_postcode
+    - fe_role_qts_required
   vacancies:
     - id
     - job_title
@@ -540,6 +541,7 @@ shared:
     - job_address_town
     - job_address_county
     - job_address_postcode
+    - fe_role_qts_required
   failed_imported_vacancies:
     - id
     - import_errors

--- a/db/migrate/20260810152440_add_needs_qts_status.rb
+++ b/db/migrate/20260810152440_add_needs_qts_status.rb
@@ -1,0 +1,8 @@
+class AddNeedsQtsStatus < ActiveRecord::Migration[8.0]
+  # rubocop:disable Rails/ThreeStateBooleanColumn
+  def change
+    add_column :vacancies, :fe_role_qts_required, :boolean
+    add_column :vacancy_templates, :fe_role_qts_required, :boolean
+  end
+  # rubocop:enable Rails/ThreeStateBooleanColumn
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_23_204840) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_10_152440) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -974,6 +974,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_23_204840) do
     t.string "external_advert_url"
     t.string "external_reference"
     t.string "external_source"
+    t.boolean "fe_role_qts_required"
     t.string "fixed_term_contract_duration"
     t.string "flexi_working"
     t.boolean "flexi_working_details_provided"
@@ -1073,6 +1074,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_23_204840) do
     t.datetime "created_at", null: false
     t.integer "ect_status"
     t.boolean "enable_job_applications"
+    t.boolean "fe_role_qts_required"
     t.string "fixed_term_contract_duration"
     t.string "flexi_working"
     t.boolean "flexi_working_details_provided"

--- a/lib/tasks/backfill_fe_role_qts_required.rake
+++ b/lib/tasks/backfill_fe_role_qts_required.rake
@@ -1,0 +1,9 @@
+desc "Backfill fe role QTS required"
+task backfill_fe_role_qts_required: :environment do
+  # Backfill live and future vacancies
+  PublishedVacancy.applicable.find_each.select(&:for_an_fe_college?).each do |vacancy|
+    needs_qts_status = vacancy.job_roles.include?("teacher")
+    vacancy.assign_attributes(fe_role_qts_required: needs_qts_status)
+    vacancy.save!(touch: false, validate: false)
+  end
+end

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -84,6 +84,10 @@ FactoryBot.define do
       end
     end
 
+    trait :it_support do
+      job_roles { %w[it_support] }
+    end
+
     trait :secondary do
       phases { %w[secondary] }
       key_stages { %w[ks3] }

--- a/spec/jobs/import_from_vacancy_source_job_spec.rb
+++ b/spec/jobs/import_from_vacancy_source_job_spec.rb
@@ -179,6 +179,7 @@ RSpec.describe ImportFromVacancySourceJob do
           "job_address_town" => nil,
           "job_address_county" => nil,
           "job_address_postcode" => nil,
+          "fe_role_qts_required" => nil,
         )
       end
 

--- a/spec/lib/tasks/backfill_fe_role_qts_required_spec.rb
+++ b/spec/lib/tasks/backfill_fe_role_qts_required_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe "backfill_fe_role_qts_required" do
+  let(:college) { create(:college) }
+  let(:school) { create(:school) }
+  let!(:expired_college_teaching_role) { create(:vacancy, :expired, fe_role_qts_required: nil, organisations: [college]) }
+  let!(:college_teaching_role) { create(:vacancy, fe_role_qts_required: nil, organisations: [college]) }
+  let!(:future_college_teaching_role) { create(:vacancy, :future_publish, fe_role_qts_required: nil, organisations: [college]) }
+  let!(:school_teaching_role) { create(:vacancy, fe_role_qts_required: nil, organisations: [school]) }
+  let!(:support_role) { create(:vacancy, :it_support, fe_role_qts_required: nil) }
+
+  # rubocop:disable RSpec/NamedSubject
+  before do
+    subject.execute
+  end
+  # rubocop:enable RSpec/NamedSubject
+
+  it "backfills the fe_role_qts_required field" do
+    expect([expired_college_teaching_role, college_teaching_role, future_college_teaching_role, school_teaching_role, support_role]
+             .map { |x| x.reload.fe_role_qts_required })
+      .to eq([nil, true, true, nil, nil])
+  end
+end

--- a/spec/system/jobseekers/jobseekers_can_search_for_schools_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_search_for_schools_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe "Searching on the schools page" do
       expect_page_not_to_show_schools([secondary_school, special_school1, primary_school])
     end
 
-    it "passes a11y", :a11y do
+    it "passes a11y", :a11y, :retry do
       expect(page).to be_axe_clean
     end
   end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/rwVcEDGP/3072-hiring-staff-for-fe-additional-step-does-the-applicant-need-qts-before-ect-question

## Changes in this PR:

Introduce needs_qts_status field with back-fill via default value

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [X] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [X] DfE Analytics platform
- [X] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [X] Existing subscription alerts (will legacy subscription search filters break?)
- [X] Legacy vacancy copying (will copied vacancies fail new validations?)
- [X] In-progress drafts for Vacancies or Job Applications
</details>
