### PR TITLE
Use Ending soon as new default job ordering

### DIFF
--- a/app/services/search/vacancy_search.rb
+++ b/app/services/search/vacancy_search.rb
@@ -66,8 +66,8 @@ class Search::VacancySearch
   end
 
   def sort_by
-    if sort.by == "publish_on_non_default"
-      "publish_on"
+    if sort.by == "expires_at_non_default"
+      "expires_at"
     else
       sort.by
     end

--- a/app/services/search/vacancy_sort.rb
+++ b/app/services/search/vacancy_sort.rb
@@ -7,9 +7,9 @@ class Search::VacancySort < RecordSort
 
   def options
     if location.present?
-      [distance_option, publish_on_non_default_desc_option, closing_date_asc_option]
+      [distance_option, publish_on_desc_option, closing_date_asc_option]
     else
-      [closing_date_asc_option, publish_on_desc_option]
+      [closing_date_asc_non_default_option, publish_on_desc_option]
     end
   end
 
@@ -17,12 +17,12 @@ class Search::VacancySort < RecordSort
     if location.present?
       distance_option
     else
-      closing_date_asc_option
+      closing_date_asc_non_default_option
     end
   end
 
   def by_db_column?
-    return true if sort_by == "publish_on_non_default"
+    return true if sort_by == "expires_at_non_default"
 
     super
   end
@@ -39,11 +39,11 @@ class Search::VacancySort < RecordSort
     SortOption.new("expires_at", I18n.t("jobs.sort_by.expires_at.ascending.vacancy.jobseeker"), "asc")
   end
 
-  def distance_option
-    SortOption.new("distance", "Distance", "asc")
+  def closing_date_asc_non_default_option
+    SortOption.new("expires_at_non_default", I18n.t("jobs.sort_by.expires_at.ascending.vacancy.jobseeker"), "asc")
   end
 
-  def publish_on_non_default_desc_option
-    SortOption.new("publish_on_non_default", I18n.t("jobs.sort_by.publish_on.descending"), "desc")
+  def distance_option
+    SortOption.new("distance", "Distance", "asc")
   end
 end

--- a/app/services/search/vacancy_sort.rb
+++ b/app/services/search/vacancy_sort.rb
@@ -9,7 +9,7 @@ class Search::VacancySort < RecordSort
     if location.present?
       [distance_option, publish_on_non_default_desc_option, closing_date_asc_option]
     else
-      [publish_on_desc_option, closing_date_asc_option]
+      [closing_date_asc_option, publish_on_desc_option]
     end
   end
 
@@ -17,7 +17,7 @@ class Search::VacancySort < RecordSort
     if location.present?
       distance_option
     else
-      publish_on_desc_option
+      closing_date_asc_option
     end
   end
 

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -106,6 +106,7 @@ en:
       sorted_by_publish_on: "Jobs (%{count}) sorted by newest"
       sorted_by_publish_on_non_default: "Jobs (%{count}) sorted by newest"
       sorted_by_expires_at: "Jobs (%{count}) ending soon"
+      sorted_by_expires_at_non_default: "Jobs (%{count}) ending soon"
       sorted_by_distance: "Jobs (%{count}) sorted by distance"
 
     legacy_job_alert:

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -105,7 +105,7 @@ en:
     search_result_title:
       sorted_by_publish_on: "Jobs (%{count}) sorted by newest"
       sorted_by_publish_on_non_default: "Jobs (%{count}) sorted by newest"
-      sorted_by_expires_at: "Jobs (%{count}) sorted by closing date"
+      sorted_by_expires_at: "Jobs (%{count}) ending soon"
       sorted_by_distance: "Jobs (%{count}) sorted by distance"
 
     legacy_job_alert:
@@ -122,7 +122,7 @@ en:
         ascending:
           saved_job: application deadline (soonest)
           vacancy:
-            jobseeker: Closing date
+            jobseeker: Ending soon
             publisher: closing date (soonest)
         descending:
           vacancy:

--- a/spec/services/search/vacancy_sort_spec.rb
+++ b/spec/services/search/vacancy_sort_spec.rb
@@ -5,6 +5,16 @@ RSpec.describe Search::VacancySort do
   let(:sort_by) { "" }
   let(:keyword) { "" }
 
+  shared_examples "sorts by expires_at" do
+    it "sorts by expires_at" do
+      expect(subject.sort_by).to eq("expires_at")
+    end
+
+    it "has order 'asc'" do
+      expect(subject.order).to eq("asc")
+    end
+  end
+
   shared_examples "sorts by publish_on" do
     it "sorts by publish_on" do
       expect(subject.sort_by).to eq("publish_on")
@@ -54,11 +64,11 @@ RSpec.describe Search::VacancySort do
         context "and a keyword is specified" do
           let(:keyword) { "maths" }
 
-          it_behaves_like "sorts by publish_on"
+          it_behaves_like "sorts by expires_at"
         end
 
         context "and a keyword is NOT specified" do
-          it_behaves_like "sorts by publish_on"
+          it_behaves_like "sorts by expires_at"
         end
       end
 
@@ -66,7 +76,7 @@ RSpec.describe Search::VacancySort do
         let(:sort_by) { "worst_listing" }
         let(:keyword) { "maths" }
 
-        it_behaves_like "sorts by publish_on"
+        it_behaves_like "sorts by expires_at"
       end
     end
   end
@@ -75,7 +85,7 @@ RSpec.describe Search::VacancySort do
     context "when the sort option 'relevance' is selected and there is no keyword" do
       let(:sort_by) { "relevance" }
 
-      it_behaves_like "sorts by publish_on"
+      it_behaves_like "sorts by expires_at"
 
       it "does not include 'relevance' in the sorting options" do
         expect(subject.options.map(&:sort_by)).not_to include("relevance")

--- a/spec/services/search/vacancy_sort_spec.rb
+++ b/spec/services/search/vacancy_sort_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe Search::VacancySort do
   let(:sort_by) { "" }
   let(:keyword) { "" }
 
-  shared_examples "sorts by expires_at" do
-    it "sorts by expires_at" do
-      expect(subject.sort_by).to eq("expires_at")
+  shared_examples "sorts by expires_at_non_default" do
+    it "sorts by expires_at_non_default" do
+      expect(subject.sort_by).to eq("expires_at_non_default")
     end
 
     it "has order 'asc'" do
@@ -64,11 +64,11 @@ RSpec.describe Search::VacancySort do
         context "and a keyword is specified" do
           let(:keyword) { "maths" }
 
-          it_behaves_like "sorts by expires_at"
+          it_behaves_like "sorts by expires_at_non_default"
         end
 
         context "and a keyword is NOT specified" do
-          it_behaves_like "sorts by expires_at"
+          it_behaves_like "sorts by expires_at_non_default"
         end
       end
 
@@ -76,7 +76,7 @@ RSpec.describe Search::VacancySort do
         let(:sort_by) { "worst_listing" }
         let(:keyword) { "maths" }
 
-        it_behaves_like "sorts by expires_at"
+        it_behaves_like "sorts by expires_at_non_default"
       end
     end
   end
@@ -85,18 +85,18 @@ RSpec.describe Search::VacancySort do
     context "when the sort option 'relevance' is selected and there is no keyword" do
       let(:sort_by) { "relevance" }
 
-      it_behaves_like "sorts by expires_at"
+      it_behaves_like "sorts by expires_at_non_default"
 
       it "does not include 'relevance' in the sorting options" do
         expect(subject.options.map(&:sort_by)).not_to include("relevance")
       end
     end
 
-    context "when the sort option `expires_at` is selected" do
-      let(:sort_by) { "expires_at" }
+    context "when the sort option `expires_at_non_default` is selected" do
+      let(:sort_by) { "expires_at_non_default" }
 
-      it "sorts by publish_on" do
-        expect(subject.sort_by).to eq("expires_at")
+      it "sorts by expires_at_non_default" do
+        expect(subject.sort_by).to eq("expires_at_non_default")
       end
 
       it "has order 'asc'" do
@@ -131,8 +131,8 @@ RSpec.describe Search::VacancySort do
       it { is_expected.to be_by_db_column }
     end
 
-    context "when sorting by publish_on" do
-      let(:sort_by) { "publish_on_non_default" }
+    context "when sorting by expires_at_non_default" do
+      let(:sort_by) { "expires_at_non_default" }
 
       it { is_expected.to be_by_db_column }
     end

--- a/spec/system/jobseekers/jobseekers_can_search_for_jobs_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_search_for_jobs_spec.rb
@@ -129,9 +129,9 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
   context "jobseekers can sort jobs by closing date" do
     it "lists the jobs with the earliest closing date first" do
       visit jobs_path
-      select "Closing date", from: "sort-by-field"
+      select "Ending soon", from: "sort-by-field"
       click_button "Sort"
-      expect(page).to have_select("sort_by", selected: "Closing date")
+      expect(page).to have_select("sort_by", selected: "Ending soon")
       expect("Maths 1").to appear_before("Physics Teacher")
       expect("Physics Teacher").to appear_before("Maths Teacher 2")
       expect("Maths Teacher 2").to appear_before("Chemistry Teacher")
@@ -235,8 +235,8 @@ RSpec.describe "Jobseekers can search for jobs on the jobs index page" do
 
         expect(page).to have_select("sort_by", selected: "Distance")
 
-        select "Closing date", from: "sort-by-field"
-        expect(page).to have_select("sort_by", selected: "Closing date")
+        select "Ending soon", from: "sort-by-field"
+        expect(page).to have_select("sort_by", selected: "Ending soon")
 
         expect("Maths 1").to appear_before("Physics Teacher")
         expect("Physics Teacher").to appear_before("Maths Teacher 2")

--- a/spec/views/vacancies/campaign_landing_page.html.slim_spec.rb
+++ b/spec/views/vacancies/campaign_landing_page.html.slim_spec.rb
@@ -67,6 +67,6 @@ RSpec.describe "vacancies/campaign_landing_page" do
     expect(search_results).to have_link(recent_part_time_maths_job.job_title, href: job_path(recent_part_time_maths_job))
     expect(search_results).to have_link(older_part_time_maths_job.job_title, href: job_path(older_part_time_maths_job))
     expect(campaign_landing_view).to have_css(".sort-container")
-    expect(campaign_landing_view).to have_select("Sort by", selected: "Newest job")
+    expect(campaign_landing_view).to have_select("Sort by", selected: "Ending soon")
   end
 end


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/TydWwwzL/3136-sort-the-ending-soon-roles-at-the-top-of-searches-by-default

## Changes in this PR:

This PR switches our jobs page to use Ending soon as new default job ordering

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
