### PR TITLE
Back off job retries polynomially instead of every 3 seconds

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -2,7 +2,12 @@ class ApplicationJob < ActiveJob::Base
   # Order matters: `rescue_from` handlers are matched last-registered-first, and
   # `ActiveJob::DeserializationError` is a `StandardError`. The specific
   # `discard_on` must come after the catch-all `retry_on` so that jobs whose
-  # arguments no longer exist are discarded rather than retried ten times.
-  retry_on StandardError, attempts: 10
+  # arguments no longer exist are discarded rather than retried.
+  #
+  # The backoff is deliberately polynomial rather than the Active Job default of a flat
+  # 3 seconds: attempts spaced 3 seconds apart exhaust the whole retry budget in under half
+  # a minute, which is not long enough to ride out an external API being briefly
+  # unavailable. Polynomially longer spreads the 8 attempts over roughly 75 minutes.
+  retry_on StandardError, wait: :polynomially_longer, attempts: 8
   discard_on ActiveJob::DeserializationError
 end

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -33,6 +33,25 @@ RSpec.describe ApplicationJob do
     end
   end
 
+  describe "retry backoff" do
+    # A flat 3 second wait (the Active Job default) exhausts every attempt in well under a
+    # minute, which is not long enough to ride out a briefly unavailable external API.
+    it "spaces retries polynomially rather than at a flat 3 seconds" do
+      TestApplicationJob.define_method(:perform) { raise "transient failure" }
+
+      job = TestApplicationJob.new
+
+      freeze_time do
+        3.times { job.perform_now }
+
+        delays = enqueued_jobs.map { |enqueued| enqueued[:at] - Time.current.to_f }
+
+        expect(delays.first).to be < 5.seconds
+        expect(delays.last).to be > 60.seconds
+      end
+    end
+  end
+
   describe "retrying other errors" do
     it "re-enqueues instead of failing, then succeeds on retry" do
       attempts = 0


### PR DESCRIPTION
## Trello card URL

Noticed when going through this ticket: https://trello.com/c/xfS9EdIT/3130-debug-dsi-sync-job-errors

## Changes in this PR:

Changes the frequency of failed jobs retries from the Active Job default (every 3 secs) to a polynomial increase in time for each attempt, reproducing Sidekiq retry behaviour.

Attempts spaced 3 seconds apart exhaust the whole retry budget in under half a minute, which is not long enough to ride out an external API being briefly unavailable. 

Polynomially longer spreads the 8 attempts over roughly 75 minutes:  applies the wait algorithm of `((executions**4) + (Kernel.rand * (executions**4) * jitter)) + 2` (first wait ~3s, then ~18s, then ~83s, etc)


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
