### PR TITLE
2846 monitoring resources iac

### DIFF
--- a/.github/actions/deploy_2847/action.yml
+++ b/.github/actions/deploy_2847/action.yml
@@ -5,12 +5,6 @@ inputs:
   environment:
     description: Environment
     required: true
-  tag:
-    description: Docker tag
-    required: true
-  pr_id:
-    description: Pull Request
-    required: false
   aws-access-key-id:
     description: AWS-ID
     required: true
@@ -32,7 +26,6 @@ inputs:
   action_group_sms_receivers:
     description: JSON string containing variable values for action group sms receivers
     required: false
-
 
 runs:
   using: composite
@@ -67,18 +60,6 @@ runs:
       with:
         terraform_version: 1.14.5
 
-    - name: Set environment variables for review
-      if: startsWith( inputs.environment, 'review')
-      shell: bash
-      run: |
-        PARAMETER_STORE_ENVIRONMENT=dev
-        TF_VAR_environment=${{ inputs.environment }}
-        echo "DEPLOY_ENV=review" >> $GITHUB_ENV
-        pr_id=${{ inputs.pr_id }}
-        echo "pr_id=${pr_id}" >> $GITHUB_ENV
-        echo "PARAMETER_STORE_ENVIRONMENT=${PARAMETER_STORE_ENVIRONMENT}" >> $GITHUB_ENV
-        echo "TF_VAR_environment=${TF_VAR_environment}" >> $GITHUB_ENV
-
     - name: Set environment variables for non-review environments
       if: startsWith(inputs.environment, 'review') != true
       shell: bash
@@ -89,25 +70,6 @@ runs:
         echo "DEPLOY_ENV=${DEPLOY_ENV}" >> $GITHUB_ENV
         CONFIRM_PRODUCTION=YES
         echo "CONFIRM_PRODUCTION=${CONFIRM_PRODUCTION}" >> $GITHUB_ENV
-
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1.302.0
-
-    - name: Download fetch_config.rb
-      shell: bash
-      run: |
-        echo "::group:: Download fetch_config.rb script"
-        curl -s https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/master/scripts/fetch_config/fetch_config.rb -o bin/fetch_config.rb
-        chmod +x bin/fetch_config.rb
-        echo "::endgroup::"
-
-    # Validate secrets stored in parameter store to prevent terraform from exposing them in case of an issue
-    - name: Validate secrets
-      shell: bash
-      run: |
-        gem install aws-sdk-ssm --no-document
-        bin/fetch_config.rb -s aws-ssm-parameter-path:/teaching-vacancies/${{ env.PARAMETER_STORE_ENVIRONMENT }}/app -d quiet \
-          && echo Data in "/teaching-vacancies/${{ env.PARAMETER_STORE_ENVIRONMENT }}" looks valid
 
     - name: Set variables for action group
       id: action-group-variables
@@ -121,4 +83,4 @@ runs:
       id: deployment-conclusion
       shell: bash
       run: |
-        make ${{ env.DEPLOY_ENV }} ci tag=${{ inputs.tag }} terraform-app-apply
+        make ${{ env.DEPLOY_ENV }} ci tag=${{ inputs.tag }} terraform-app-plan

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -287,6 +287,8 @@ jobs:
         azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
         azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        action_group_email_receivers: ${{ secrets.ACTION_GROUP_EMAIL_RECEIVERS }}
+        action_group_sms_receivers: ${{ secrets.ACTION_GROUP_SMS_RECEIVERS }}
 
     - name: Notify twd_tv_dev channel on ${{ env.ENVIRONMENT }} deployment failure
       if: steps.deploy_app_to_env.conclusion != 'success'

--- a/.github/workflows/build_and_deploy_2847.yml
+++ b/.github/workflows/build_and_deploy_2847.yml
@@ -1,0 +1,75 @@
+name: Build and deploy - 2847
+
+on:
+  push:
+    branches:
+    - 2846-monitoring-resources-iac
+    paths-ignore:
+    - 'bigquery/**'
+    - 'documentation/**'
+    - 'terraform/common/**'
+    - 'spec/fixtures/files/*.md'
+    - 'app/mailers/previewing_emails.md'
+    - 'README.md'
+    - 'app/assets/stylesheets/README.md'
+    - '.github/pull_request_template.md'
+
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Environment
+        required: true
+        type: choice
+        options:
+        - qa
+        - staging
+        - production
+
+concurrency: workflow-Build-and-deploy-${{ github.ref }}
+permissions:
+  id-token: write
+  packages: write
+  pull-requests: write
+
+jobs:
+  deploy:
+    name: Deploy app
+    environment: ${{ matrix.environment }}
+    strategy:
+      max-parallel: 1
+      matrix: 
+        environment: [qa, production]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v7.0.1
+      name: Checkout Code
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v6.2.3
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: eu-west-2
+        role-to-assume: Deployments
+        role-duration-seconds: 3600
+        role-skip-session-tagging: true
+
+    - name: Set environment variable (Push)
+      if: github.event_name == 'push'
+      run: |
+        ENVIRONMENT=${{ matrix.environment }}
+        echo "ENVIRONMENT=${ENVIRONMENT}" >> $GITHUB_ENV
+
+    - name: Deploy App to ${{ env.ENVIRONMENT }} environment
+      id: deploy_app_to_env
+      uses: ./.github/actions/deploy_2847/
+      with:
+        environment: ${{ env.ENVIRONMENT }}
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        action_group_email_receivers: ${{ secrets.ACTION_GROUP_EMAIL_RECEIVERS }}
+        action_group_sms_receivers: ${{ secrets.ACTION_GROUP_SMS_RECEIVERS }}

--- a/terraform/app/imports.tf
+++ b/terraform/app/imports.tf
@@ -1,0 +1,47 @@
+import {
+  for_each = var.app_environment == "production" ? [1] : null
+  to = module.application_insights[0].azurerm_application_insights.application_insights[0]
+  id = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-tv-pd-rg/providers/Microsoft.Insights/components/s189p01-tv-pd-ai"
+}
+
+import {
+  for_each = var.app_environment == "production" ? [1] : null
+  to = module.application_insights[0].azurerm_application_insights_standard_web_test.availability_test["500 error"]
+  id = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-tv-pd-rg/providers/Microsoft.Insights/webTests/teaching vacancies - 500 error-s189p01-tv-pd-ai"
+}
+
+import {
+  for_each = var.app_environment == "production" ? [1] : null
+  to = module.application_insights[0].azurerm_application_insights_standard_web_test.availability_test["check"]
+  id = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-tv-pd-rg/providers/Microsoft.Insights/webTests/teaching vacancies check-s189p01-tv-pd-ai"
+}
+
+import {
+  for_each = var.app_environment == "production" ? [1] : null
+  to = module.application_insights[0].azurerm_application_insights_standard_web_test.availability_test["homepage string"]
+  id = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-tv-pd-rg/providers/Microsoft.Insights/webTests/teaching vacancies - homepage string-s189p01-tv-pd-ai"
+}
+
+import {
+  for_each = var.app_environment == "production" ? [1] : null
+  to = module.application_insights[0].azurerm_monitor_action_group.action_group[0]
+  id = "/subscriptions/3C033A0C-7A1C-4653-93CB-0F2A9F57A391/resourceGroups/s189p01-tv-pd-rg/providers/Microsoft.Insights/actionGroups/s189p01-tv-pd-act-grp"
+}
+
+import {
+  for_each = var.app_environment == "production" ? [1] : null
+  to = module.application_insights[0].azurerm_monitor_metric_alert.metric_alert["500 error"]
+  id = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-tv-pd-rg/providers/Microsoft.Insights/metricAlerts/teaching vacancies - 500 error-s189p01-tv-pd-ai"
+}
+
+import {
+  for_each = var.app_environment == "production" ? [1] : null
+  to = module.application_insights[0].azurerm_monitor_metric_alert.metric_alert["check"]
+  id = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-tv-pd-rg/providers/Microsoft.Insights/metricAlerts/teaching vacancies check-s189p01-tv-pd-ai"
+}
+
+import {
+  for_each = var.app_environment == "production" ? [1] : null
+  to = module.application_insights[0].azurerm_monitor_metric_alert.metric_alert["homepage string"]
+  id = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-tv-pd-rg/providers/Microsoft.Insights/metricAlerts/teaching vacancies - homepage string-s189p01-tv-pd-ai"
+}

--- a/terraform/app/imports.tf
+++ b/terraform/app/imports.tf
@@ -1,47 +1,47 @@
 import {
   for_each = var.app_environment == "production" ? [1] : null
-  to = module.application_insights[0].azurerm_application_insights.application_insights[0]
-  id = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-tv-pd-rg/providers/Microsoft.Insights/components/s189p01-tv-pd-ai"
+  to       = module.application_insights[0].azurerm_application_insights.application_insights[0]
+  id       = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-tv-pd-rg/providers/Microsoft.Insights/components/s189p01-tv-pd-ai"
 }
 
 import {
   for_each = var.app_environment == "production" ? [1] : null
-  to = module.application_insights[0].azurerm_application_insights_standard_web_test.availability_test["500 error"]
-  id = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-tv-pd-rg/providers/Microsoft.Insights/webTests/teaching vacancies - 500 error-s189p01-tv-pd-ai"
+  to       = module.application_insights[0].azurerm_application_insights_standard_web_test.availability_test["500 error"]
+  id       = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-tv-pd-rg/providers/Microsoft.Insights/webTests/teaching vacancies - 500 error-s189p01-tv-pd-ai"
 }
 
 import {
   for_each = var.app_environment == "production" ? [1] : null
-  to = module.application_insights[0].azurerm_application_insights_standard_web_test.availability_test["check"]
-  id = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-tv-pd-rg/providers/Microsoft.Insights/webTests/teaching vacancies check-s189p01-tv-pd-ai"
+  to       = module.application_insights[0].azurerm_application_insights_standard_web_test.availability_test["check"]
+  id       = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-tv-pd-rg/providers/Microsoft.Insights/webTests/teaching vacancies check-s189p01-tv-pd-ai"
 }
 
 import {
   for_each = var.app_environment == "production" ? [1] : null
-  to = module.application_insights[0].azurerm_application_insights_standard_web_test.availability_test["homepage string"]
-  id = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-tv-pd-rg/providers/Microsoft.Insights/webTests/teaching vacancies - homepage string-s189p01-tv-pd-ai"
+  to       = module.application_insights[0].azurerm_application_insights_standard_web_test.availability_test["homepage string"]
+  id       = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-tv-pd-rg/providers/Microsoft.Insights/webTests/teaching vacancies - homepage string-s189p01-tv-pd-ai"
 }
 
 import {
   for_each = var.app_environment == "production" ? [1] : null
-  to = module.application_insights[0].azurerm_monitor_action_group.action_group[0]
-  id = "/subscriptions/3C033A0C-7A1C-4653-93CB-0F2A9F57A391/resourceGroups/s189p01-tv-pd-rg/providers/Microsoft.Insights/actionGroups/s189p01-tv-pd-act-grp"
+  to       = module.application_insights[0].azurerm_monitor_action_group.action_group[0]
+  id       = "/subscriptions/3C033A0C-7A1C-4653-93CB-0F2A9F57A391/resourceGroups/s189p01-tv-pd-rg/providers/Microsoft.Insights/actionGroups/s189p01-tv-pd-act-grp"
 }
 
 import {
   for_each = var.app_environment == "production" ? [1] : null
-  to = module.application_insights[0].azurerm_monitor_metric_alert.metric_alert["500 error"]
-  id = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-tv-pd-rg/providers/Microsoft.Insights/metricAlerts/teaching vacancies - 500 error-s189p01-tv-pd-ai"
+  to       = module.application_insights[0].azurerm_monitor_metric_alert.metric_alert["500 error"]
+  id       = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-tv-pd-rg/providers/Microsoft.Insights/metricAlerts/teaching vacancies - 500 error-s189p01-tv-pd-ai"
 }
 
 import {
   for_each = var.app_environment == "production" ? [1] : null
-  to = module.application_insights[0].azurerm_monitor_metric_alert.metric_alert["check"]
-  id = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-tv-pd-rg/providers/Microsoft.Insights/metricAlerts/teaching vacancies check-s189p01-tv-pd-ai"
+  to       = module.application_insights[0].azurerm_monitor_metric_alert.metric_alert["check"]
+  id       = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-tv-pd-rg/providers/Microsoft.Insights/metricAlerts/teaching vacancies check-s189p01-tv-pd-ai"
 }
 
 import {
   for_each = var.app_environment == "production" ? [1] : null
-  to = module.application_insights[0].azurerm_monitor_metric_alert.metric_alert["homepage string"]
-  id = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-tv-pd-rg/providers/Microsoft.Insights/metricAlerts/teaching vacancies - homepage string-s189p01-tv-pd-ai"
+  to       = module.application_insights[0].azurerm_monitor_metric_alert.metric_alert["homepage string"]
+  id       = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-tv-pd-rg/providers/Microsoft.Insights/metricAlerts/teaching vacancies - homepage string-s189p01-tv-pd-ai"
 }

--- a/terraform/app/modules/application_insights/main.tf
+++ b/terraform/app/modules/application_insights/main.tf
@@ -1,0 +1,108 @@
+resource "azurerm_application_insights" "application_insights" {
+  count               = var.enable_application_insights == true ? 1 : 0
+  name                = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-ai"
+  location            = "UK South"
+  resource_group_name = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-rg"
+  application_type    = "web"
+  sampling_percentage = 0
+
+  tags = var.monitoring_tags
+}
+
+resource "azurerm_application_insights_standard_web_test" "availability_test" {
+  for_each                = var.availability_tests
+  name                    = "teaching vacancies ${var.availability_tests[each.key].name}-${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-ai"
+  resource_group_name     = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-rg"
+  location                = "UK South"
+  application_insights_id = azurerm_application_insights.application_insights[0].id
+  geo_locations           = var.availability_tests[each.key].geo_locations
+  timeout                 = var.availability_tests[each.key].timeout
+  enabled                 = true
+  retry_enabled           = true
+
+  request {
+    url                              = var.availability_tests[each.key].url
+    parse_dependent_requests_enabled = false
+    follow_redirects_enabled         = false
+  }
+
+  validation_rules {
+    ssl_check_enabled = var.availability_tests[each.key].ssl_check_enabled == true ? true : false
+    ssl_cert_remaining_lifetime = var.availability_tests[each.key].ssl_cert_remaining_lifetime != null ? var.availability_tests[each.key].ssl_cert_remaining_lifetime : null
+    dynamic "content" {
+      for_each = length(keys(var.availability_tests[each.key].content)) > 0 ? [var.availability_tests[each.key].content] : []
+        content {
+          content_match      = content.value.content_match
+          ignore_case        = content.value.ignore_case
+          pass_if_text_found = content.value.pass_if_text_found
+        }
+      }
+  }
+
+  tags = var.monitoring_tags
+}
+
+resource "azurerm_monitor_action_group" "action_group" {
+  count               = var.enable_application_insights == true ? 1 : 0
+  name                = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-act-grp"
+  resource_group_name = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-rg"
+  short_name          = "${var.service_short}${var.config_short}-act-grp"
+
+  dynamic email_receiver {
+    for_each = var.action_group_email_receivers
+    content {
+      name                    = email_receiver.value.name
+      email_address           = email_receiver.value.emailAddress
+      use_common_alert_schema = true
+    }
+  }
+
+  # action_group_email_receivers variable is stored as environment secret in Github and passed in via workflow. Secret should be stored as a list of JSON objects as below:
+  # [{"name": "FirstName1 LastName1_-EmailAction-","emailAddress":"firstname1.lastname1@education.gov.uk"},{"name": "FirstName2 LastName2_-EmailAction-","emailAddress": "firstname2.lastname2@education.gov.uk"}]
+  # Full existing config can be found by opening the JSON view of the resource in the Azure portal
+
+  dynamic sms_receiver {
+    for_each = var.action_group_sms_receivers
+    content {
+      name         = sms_receiver.value.name
+      phone_number = sms_receiver.value.phoneNumber
+      country_code = "44"
+    }
+  }
+
+  # action_group_sms_receivers variable is stored as environment secret in Github and passed in via workflow. Secret should be stored as a list of JSON objects as below:
+  # [{"name": "FirstName1 LastName1_-SMSAction-","phoneNumber": "1234567890"},{"name": "FirstName2 LastName2_-SMSAction-","phoneNumber": "0987654321"}]
+  # Full existing config can be found by opening the JSON view of the resource in the Azure portal
+
+  tags = var.monitoring_tags
+}
+
+resource "azurerm_monitor_metric_alert" "metric_alert" {
+  for_each            = var.availability_tests
+  name                = "teaching vacancies ${var.availability_tests[each.key].name}-${azurerm_application_insights.application_insights[0].name}"
+  resource_group_name = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-rg"
+  scopes              = [azurerm_application_insights.application_insights[0].id, azurerm_application_insights_standard_web_test.availability_test[each.key].id]
+  description         = "Automatically created alert rule for availability test \"teaching vacancies ${var.availability_tests[each.key].name}-${azurerm_application_insights.application_insights[0].name}\""
+  severity            = 1
+  auto_mitigate       = false
+
+  application_insights_web_test_location_availability_criteria {
+    web_test_id           = azurerm_application_insights_standard_web_test.availability_test[each.key].id
+    component_id          = azurerm_application_insights.application_insights[0].id
+    failed_location_count = 2
+  }
+
+  dynamic action {
+    for_each = var.availability_tests[each.key].action_group ? [1] : []
+    content {
+      action_group_id    = azurerm_monitor_action_group.action_group[0].id
+      webhook_properties = {}
+    }
+  }
+
+  tags = merge(var.monitoring_tags, {
+    "hidden-link:/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourcegroups/s189p01-tv-pd-rg/providers/microsoft.insights/components/${azurerm_application_insights.application_insights[0].name}" = "Resource",
+    "hidden-link:/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourcegroups/s189p01-tv-pd-rg/providers/microsoft.insights/webtests/${azurerm_application_insights_standard_web_test.availability_test[each.key].name}" = "Resource"
+  })
+}
+

--- a/terraform/app/modules/application_insights/main.tf
+++ b/terraform/app/modules/application_insights/main.tf
@@ -27,16 +27,16 @@ resource "azurerm_application_insights_standard_web_test" "availability_test" {
   }
 
   validation_rules {
-    ssl_check_enabled = var.availability_tests[each.key].ssl_check_enabled == true ? true : false
+    ssl_check_enabled           = var.availability_tests[each.key].ssl_check_enabled == true ? true : false
     ssl_cert_remaining_lifetime = var.availability_tests[each.key].ssl_cert_remaining_lifetime != null ? var.availability_tests[each.key].ssl_cert_remaining_lifetime : null
     dynamic "content" {
       for_each = length(keys(var.availability_tests[each.key].content)) > 0 ? [var.availability_tests[each.key].content] : []
-        content {
-          content_match      = content.value.content_match
-          ignore_case        = content.value.ignore_case
-          pass_if_text_found = content.value.pass_if_text_found
-        }
+      content {
+        content_match      = content.value.content_match
+        ignore_case        = content.value.ignore_case
+        pass_if_text_found = content.value.pass_if_text_found
       }
+    }
   }
 
   tags = var.monitoring_tags
@@ -48,7 +48,7 @@ resource "azurerm_monitor_action_group" "action_group" {
   resource_group_name = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-rg"
   short_name          = "${var.service_short}${var.config_short}-act-grp"
 
-  dynamic email_receiver {
+  dynamic "email_receiver" {
     for_each = var.action_group_email_receivers
     content {
       name                    = email_receiver.value.name
@@ -61,7 +61,7 @@ resource "azurerm_monitor_action_group" "action_group" {
   # [{"name": "FirstName1 LastName1_-EmailAction-","emailAddress":"firstname1.lastname1@education.gov.uk"},{"name": "FirstName2 LastName2_-EmailAction-","emailAddress": "firstname2.lastname2@education.gov.uk"}]
   # Full existing config can be found by opening the JSON view of the resource in the Azure portal
 
-  dynamic sms_receiver {
+  dynamic "sms_receiver" {
     for_each = var.action_group_sms_receivers
     content {
       name         = sms_receiver.value.name
@@ -92,7 +92,7 @@ resource "azurerm_monitor_metric_alert" "metric_alert" {
     failed_location_count = 2
   }
 
-  dynamic action {
+  dynamic "action" {
     for_each = var.availability_tests[each.key].action_group ? [1] : []
     content {
       action_group_id    = azurerm_monitor_action_group.action_group[0].id
@@ -101,7 +101,7 @@ resource "azurerm_monitor_metric_alert" "metric_alert" {
   }
 
   tags = merge(var.monitoring_tags, {
-    "hidden-link:/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourcegroups/s189p01-tv-pd-rg/providers/microsoft.insights/components/${azurerm_application_insights.application_insights[0].name}" = "Resource",
+    "hidden-link:/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourcegroups/s189p01-tv-pd-rg/providers/microsoft.insights/components/${azurerm_application_insights.application_insights[0].name}"                     = "Resource",
     "hidden-link:/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourcegroups/s189p01-tv-pd-rg/providers/microsoft.insights/webtests/${azurerm_application_insights_standard_web_test.availability_test[each.key].name}" = "Resource"
   })
 }

--- a/terraform/app/modules/application_insights/variables.tf
+++ b/terraform/app/modules/application_insights/variables.tf
@@ -9,31 +9,31 @@ variable "service_short" {
 }
 
 variable "enable_application_insights" {
-  type = bool
+  type        = bool
   description = "Boolean to enable application insights resources"
-  default = false
+  default     = false
 }
 
 variable "availability_tests" {
-  type = map
+  type        = map(any)
   description = "Configuration for application insights availability tests"
-  default = {}
+  default     = {}
 }
 
 variable "action_group_email_receivers" {
-  type = list
+  type        = list(any)
   description = "List of email receivers for metric alert action group"
-  default = []
+  default     = []
 }
 
 variable "action_group_sms_receivers" {
-  type = list
+  type        = list(any)
   description = "List of SMS receivers for metric alert action group"
-  default = []
+  default     = []
 }
 
 variable "monitoring_tags" {
-  type = map
+  type        = map(any)
   description = "tags for Azure monitoring resources"
-  default = {}
+  default     = {}
 }

--- a/terraform/app/modules/application_insights/variables.tf
+++ b/terraform/app/modules/application_insights/variables.tf
@@ -1,0 +1,39 @@
+variable "azure_resource_prefix" {
+  description = "Standard resource prefix. Usually s189t01 (test) or s189p01 (production)"
+}
+variable "config_short" {
+  description = "Short name of the environment configuration, e.g. dv, st, pd..."
+}
+variable "service_short" {
+  description = "Short name to identify the service. Up to 6 charcters."
+}
+
+variable "enable_application_insights" {
+  type = bool
+  description = "Boolean to enable application insights resources"
+  default = false
+}
+
+variable "availability_tests" {
+  type = map
+  description = "Configuration for application insights availability tests"
+  default = {}
+}
+
+variable "action_group_email_receivers" {
+  type = list
+  description = "List of email receivers for metric alert action group"
+  default = []
+}
+
+variable "action_group_sms_receivers" {
+  type = list
+  description = "List of SMS receivers for metric alert action group"
+  default = []
+}
+
+variable "monitoring_tags" {
+  type = map
+  description = "tags for Azure monitoring resources"
+  default = {}
+}

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -110,15 +110,15 @@ module "statuscake" {
 }
 
 module "application_insights" {
-  count = var.azure_monitoring ? 1 : 0
+  count  = var.azure_monitoring ? 1 : 0
   source = "./modules/application_insights"
 
-  azure_resource_prefix               = var.azure_resource_prefix
-  config_short                        = var.config_short
-  service_short                       = var.service_short
-  enable_application_insights         = var.enable_application_insights
-  availability_tests                  = var.availability_tests
-  monitoring_tags                     = var.monitoring_tags
-  action_group_email_receivers        = var.action_group_email_receivers
-  action_group_sms_receivers          = var.action_group_sms_receivers
+  azure_resource_prefix        = var.azure_resource_prefix
+  config_short                 = var.config_short
+  service_short                = var.service_short
+  enable_application_insights  = var.enable_application_insights
+  availability_tests           = var.availability_tests
+  monitoring_tags              = var.monitoring_tags
+  action_group_email_receivers = var.action_group_email_receivers
+  action_group_sms_receivers   = var.action_group_sms_receivers
 }

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -108,3 +108,17 @@ module "statuscake" {
   service_name      = local.service_name
   statuscake_alerts = var.statuscake_alerts
 }
+
+module "application_insights" {
+  count = var.azure_monitoring ? 1 : 0
+  source = "./modules/application_insights"
+
+  azure_resource_prefix               = var.azure_resource_prefix
+  config_short                        = var.config_short
+  service_short                       = var.service_short
+  enable_application_insights         = var.enable_application_insights
+  availability_tests                  = var.availability_tests
+  monitoring_tags                     = var.monitoring_tags
+  action_group_email_receivers        = var.action_group_email_receivers
+  action_group_sms_receivers          = var.action_group_sms_receivers
+}

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -63,6 +63,35 @@ variable "statuscake_alerts" {
   default     = {}
 }
 
+# Application Insights
+variable "enable_application_insights" {
+  type = bool
+  description = "Boolean to enable application insights resources"
+  default = false
+}
+variable "availability_tests" {
+  type = map
+  description = "Configuration for application insights availability tests"
+  default = {}
+}
+variable "azure_monitoring" {
+  type = bool
+  description = "Boolean to control whether monitoring resources are used in Azure"
+  default = false
+}
+
+variable "action_group_email_receivers" {
+  type = list
+  description = "List of email receivers for metric alert action group"
+  default = []
+}
+
+variable "action_group_sms_receivers" {
+  type = list
+  description = "List of SMS receivers for metric alert action group"
+  default = []
+}
+
 # AKS
 variable "cluster" {
   description = "AKS cluster where this app is deployed. Either 'test' or 'production'"
@@ -195,6 +224,12 @@ variable "azure_storage_blob_delete_after_days" {
 variable "azure_storage_cors_allowed_origins" {
   default     = []
   description = "Allowed origins (URLs) for Cross Origin Resource Sharing (CORS) rule"
+}
+
+variable "monitoring_tags" {
+  type = map
+  description = "tags for Azure monitoring resources"
+  default = {}
 }
 
 locals {

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -65,31 +65,31 @@ variable "statuscake_alerts" {
 
 # Application Insights
 variable "enable_application_insights" {
-  type = bool
+  type        = bool
   description = "Boolean to enable application insights resources"
-  default = false
+  default     = false
 }
 variable "availability_tests" {
-  type = map
+  type        = map(any)
   description = "Configuration for application insights availability tests"
-  default = {}
+  default     = {}
 }
 variable "azure_monitoring" {
-  type = bool
+  type        = bool
   description = "Boolean to control whether monitoring resources are used in Azure"
-  default = false
+  default     = false
 }
 
 variable "action_group_email_receivers" {
-  type = list
+  type        = list(any)
   description = "List of email receivers for metric alert action group"
-  default = []
+  default     = []
 }
 
 variable "action_group_sms_receivers" {
-  type = list
+  type        = list(any)
   description = "List of SMS receivers for metric alert action group"
-  default = []
+  default     = []
 }
 
 # AKS
@@ -227,9 +227,9 @@ variable "azure_storage_cors_allowed_origins" {
 }
 
 variable "monitoring_tags" {
-  type = map
+  type        = map(any)
   description = "tags for Azure monitoring resources"
-  default = {}
+  default     = {}
 }
 
 locals {

--- a/terraform/workspace-variables/production.tfvars.json
+++ b/terraform/workspace-variables/production.tfvars.json
@@ -79,6 +79,53 @@
       "website_url": "https://teaching-vacancies.service.gov.uk/check"
     }
   },
+  "azure_monitoring": true,
+  "enable_application_insights": true,
+  "availability_tests": {
+    "500 error": {
+      "name": "- 500 error",
+      "geo_locations": ["North Europe", "UK South", "UK West", "West Europe", "West US"],
+      "url": "https://teaching-vacancies.service.gov.uk",
+      "ssl_check_enabled": false,
+      "ssl_cert_remaining_lifetime": null,
+      "timeout": 60,
+      "content": {
+        "content_match": "500 Internal Server Error",
+        "ignore_case": false,
+        "pass_if_text_found": false
+      },
+      "action_group": false
+    },
+    "homepage string": {
+      "name": "- homepage string",
+      "geo_locations": ["North Europe", "UK South", "UK West", "West Europe", "France Central (Formerly France South)"],
+      "url": "https://teaching-vacancies.service.gov.uk",
+      "ssl_check_enabled": true,
+      "ssl_cert_remaining_lifetime": 7,
+      "timeout": 60,
+      "content": {
+        "content_match": "create a jobseeker account",
+        "ignore_case": true,
+        "pass_if_text_found": true
+      },
+      "action_group": true
+    },
+    "check": {
+      "name": "check",
+      "geo_locations": ["North Europe", "UK South", "UK West", "West Europe", "France Central (Formerly France South)"],
+      "url": "https://teaching-vacancies.service.gov.uk/check",
+      "ssl_check_enabled": true,
+      "ssl_cert_remaining_lifetime": 7,
+      "timeout": 120,
+      "content": {},
+      "action_group": true
+    }
+  },
+  "monitoring_tags": {
+    "Environment": "Prod",
+    "Product": "Teaching vacancies",
+    "Service Offering": "Teaching Vacancies"
+  },
   "azure_maintenance_window": {
     "day_of_week": 0,
     "start_hour": 2,


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/2rXHKl6g/2847-tv-availability-monitoring

## Changes in this PR:

This PR is to retrospectively import the monitoring resources deployed in Azure in to IAC. These include:
Application insights
Availability tests
Metric alerts
Action group + members

## To review
Review the code changes, check the test workflow outputs linked below, and and/or run the following command to check the plan output:
make production terraform-plan CONFIRM_PRODUCTION=YES

There will be some in-place updates on the monitoring resources for some scopes and resource IDs, however, this is expected due to some minor formatting changes. The terraform import blocks require a slightly different formatting than what is already in the ARM JSON (e.g. "microsoft.insights" needs to be capitalised to "Microsoft.Insights" for the import to work), so the updates reflect this but ultimately do not change the config or functionality of the resources.

There are also some changes to the geo locations of the availability tests. These are also expected as the Azure API returns the population name rather than the display name, however, these are the same locations. This can be confirmed here - https://learn.microsoft.com/en-gb/azure/azure-monitor/app/availability#location-population-tags:~:text=Australia%E2%80%AFEast,ru%2Dmsa%2Dedge

Running the plan locally will also show the recipients of the action group being removed, this is expected as we should not be storing personal information like names, email addresses and phone numbers in the code. Instead, this information will be stored as secrets in GitHub, and passed in when running Terraform in the workflow, which should result in the action group being imported without any additional changes. This can be confirmed in the following workflow run - https://github.com/DFE-Digital/teaching-vacancies/actions/runs/32049504954

When reviewing the workflow run above, please check the output of both the QA and production environments. The reason for this is that there is logic in the terraform and workflow yaml that will only import the monitoring resources (and include the variables as secrets) for the production environment.

Please also check that the changes to the workflow files (.github/actions/deploy/action.yml and .github/workflows/build_and_deploy.yml) match what is in the temporary test workflows (.github/actions/deploy_2847/action.yml and .github/workflows/build_and_deploy_2847.yml), in terms of additional parameters and secrets being passed in as environment varibles.