### PR TITLE
Strip spaces from submitted vacancy application urls

### DIFF
--- a/app/form_models/publishers/job_listing/application_link_form.rb
+++ b/app/form_models/publishers/job_listing/application_link_form.rb
@@ -1,8 +1,12 @@
 class Publishers::JobListing::ApplicationLinkForm < Publishers::JobListing::JobListingForm
+  include ActiveModel::Attributes::Normalization
+
+  attribute :application_link, :string
+  normalizes :application_link, with: ->(application_link) { application_link.strip }
+
   validates :application_link, presence: true, url: { allow_blank: true }
 
   def self.fields
     %i[application_link]
   end
-  attr_accessor(*fields)
 end

--- a/app/form_models/publishers/organisation/url_override_form.rb
+++ b/app/form_models/publishers/organisation/url_override_form.rb
@@ -1,5 +1,9 @@
 class Publishers::Organisation::UrlOverrideForm < BaseForm
-  attr_accessor :url_override
+  include ActiveModel::Attributes
+  include ActiveModel::Attributes::Normalization
+
+  attribute :url_override, :string
+  normalizes :url_override, with: ->(url_override) { url_override.strip }
 
   validates :url_override, url: { allow_blank: true }
 end

--- a/spec/form_models/publishers/job_listing/application_link_form_spec.rb
+++ b/spec/form_models/publishers/job_listing/application_link_form_spec.rb
@@ -12,6 +12,39 @@ RSpec.describe Publishers::JobListing::ApplicationLinkForm, type: :model do
   it { is_expected.not_to allow_value("").for(:application_link) }
   it { is_expected.not_to allow_value("email@school.com").for(:application_link) }
   it { is_expected.not_to allow_value("A full application pack can be found at www.website.co.uk").for(:application_link) }
+  it { is_expected.to allow_value("https://www.this-is-a-test-url.example.com?utm_source=teaching_vacancies").for(:application_link) }
+  it { is_expected.to allow_value("https://www.this-is-a-test-url.example.com/apply?utm_source=teaching_vacancies&utm_medium=referral&utm_campaign=jobs").for(:application_link) }
+  it { is_expected.to allow_value("https://www.this-is-a-test-url.example.com/apply?utm_content=a%20b#form").for(:application_link) }
+
+  describe "normalising the application link" do
+    it "strips surrounding whitespace so a pasted link is still valid" do
+      form = described_class.new(application_link: "  https://www.this-is-a-test-url.example.com\n")
+
+      expect(form).to be_valid
+      expect(form.application_link).to eq("https://www.this-is-a-test-url.example.com")
+    end
+
+    it "strips surrounding whitespace without disturbing tracking parameters" do
+      form = described_class.new(application_link: " https://www.this-is-a-test-url.example.com/apply?utm_source=teaching_vacancies&utm_medium=referral ")
+
+      expect(form).to be_valid
+      expect(form.application_link).to eq("https://www.this-is-a-test-url.example.com/apply?utm_source=teaching_vacancies&utm_medium=referral")
+    end
+
+    it "treats a whitespace-only link as blank" do
+      form = described_class.new(application_link: "   ")
+
+      expect(form).not_to be_valid
+      expect(form.errors).to be_of_kind(:application_link, :blank)
+    end
+
+    it "leaves a nil link untouched" do
+      form = described_class.new(application_link: nil)
+
+      expect(form).not_to be_valid
+      expect(form.application_link).to be_nil
+    end
+  end
 
   describe "#params_to_save" do
     let(:application_link_form) { described_class.new(application_link: "https://example.com/apply") }

--- a/spec/form_models/publishers/organisation/url_override_form_spec.rb
+++ b/spec/form_models/publishers/organisation/url_override_form_spec.rb
@@ -5,4 +5,37 @@ RSpec.describe Publishers::Organisation::UrlOverrideForm, type: :model do
   it { is_expected.not_to allow_value("www.this-is-a-test-url.example.com").for(:url_override) }
   it { is_expected.to allow_value("").for(:url_override) }
   it { is_expected.not_to allow_value("invalid_url_override").for(:url_override) }
+  it { is_expected.to allow_value("https://www.this-is-a-test-url.example.com?utm_source=teaching_vacancies").for(:url_override) }
+  it { is_expected.to allow_value("https://www.this-is-a-test-url.example.com/jobs?utm_source=teaching_vacancies&utm_medium=referral&utm_campaign=jobs").for(:url_override) }
+  it { is_expected.to allow_value("https://www.this-is-a-test-url.example.com/jobs?utm_content=a%20b#list").for(:url_override) }
+
+  describe "normalising the url override" do
+    it "strips surrounding whitespace so a pasted link is still valid" do
+      form = described_class.new(url_override: "  https://www.this-is-a-test-url.example.com\n")
+
+      expect(form).to be_valid
+      expect(form.url_override).to eq("https://www.this-is-a-test-url.example.com")
+    end
+
+    it "strips surrounding whitespace without disturbing tracking parameters" do
+      form = described_class.new(url_override: " https://www.this-is-a-test-url.example.com/jobs?utm_source=teaching_vacancies&utm_medium=referral ")
+
+      expect(form).to be_valid
+      expect(form.url_override).to eq("https://www.this-is-a-test-url.example.com/jobs?utm_source=teaching_vacancies&utm_medium=referral")
+    end
+
+    it "treats a whitespace-only url as blank" do
+      form = described_class.new(url_override: "   ")
+
+      expect(form).to be_valid
+      expect(form.url_override).to eq("")
+    end
+
+    it "leaves a nil url untouched" do
+      form = described_class.new(url_override: nil)
+
+      expect(form).to be_valid
+      expect(form.url_override).to be_nil
+    end
+  end
 end


### PR DESCRIPTION


## Trello card URL

## Changes in this PR:

When publishers submit an application link form with a URL with leading/trailing spaces, the value will be normalised (by stripping the spaces) and the URL accepted (if valid) rather than showing a validation error.

This has been confusing some users who seem to think the URL format was the issue.

Also extending tests to ensure tracking params will be accepted by the URL validator.

## Screenshots of UI changes:

### Before
<img width="517" height="306" alt="image" src="https://github.com/user-attachments/assets/fc1968bd-4ecb-469c-acd1-5df348685026" />
<img width="666" height="486" alt="image" src="https://github.com/user-attachments/assets/88777863-e258-4bc4-8f6a-cc2797ec2694" />

### After

No error, goes to the next wizard step.
<img width="902" height="395" alt="image" src="https://github.com/user-attachments/assets/b0d71a02-d906-4670-b286-c3f4e160fd1d" />


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
