### PR TITLE
Fix create job alert link in footer

### DIFF
--- a/app/views/layouts/_footer.html.slim
+++ b/app/views/layouts/_footer.html.slim
@@ -8,7 +8,7 @@
             ul.govuk-footer__list
               li.govuk-footer__list-item
                 - if jobseeker_signed_in?
-                  = link_to t("nav.create_a_job_alert"), jobseekers_account_path, class: "govuk-footer__link"
+                  = link_to t("nav.create_a_job_alert"), new_subscription_path, class: "govuk-footer__link"
                 - else
                   = link_to t("nav.jobseeker_sign_in"), new_jobseeker_session_path, class: "govuk-footer__link"
               li.govuk-footer__list-item


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/HMmfGbFG/3188-ux-bug-clicking-create-a-job-alert-when-signed-in-as-a-jobseeker-opens-account-settings-and-not-create-job-alert-page

## Changes in this PR:

Fix "Create a job alert" link to link to correct page.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
