### PR TITLE
Fix "view your account" bug

### DIFF
--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -11,7 +11,7 @@
     h2.govuk-heading-m = t(".jobseeker_section.title")
     - if jobseeker_signed_in?
       p.govuk-body = t(".jobseeker_section.signed_in.description")
-      .govuk-body class="govuk-!-margin-bottom-3" = govuk_link_to t("buttons.view_account"), jobseekers_account_path, class: "govuk-link--no-visited-state"
+      .govuk-body class="govuk-!-margin-bottom-3" = govuk_link_to t("buttons.view_applications"), jobseekers_job_applications_path, class: "govuk-link--no-visited-state"
     - else
       p.govuk-body = t(".jobseeker_section.signed_out.description_html")
       = govuk_button_link_to(t("buttons.sign_in_jobseeker"), new_jobseeker_session_path, class: "govuk-!-margin-bottom-2 govuk-button--secondary")

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -11,7 +11,7 @@
     h2.govuk-heading-m = t(".jobseeker_section.title")
     - if jobseeker_signed_in?
       p.govuk-body = t(".jobseeker_section.signed_in.description")
-      .govuk-body class="govuk-!-margin-bottom-3" = govuk_link_to t("buttons.view_account"), jobseeker_root_path, class: "govuk-link--no-visited-state"
+      .govuk-body class="govuk-!-margin-bottom-3" = govuk_link_to t("buttons.view_account"), jobseekers_account_path, class: "govuk-link--no-visited-state"
     - else
       p.govuk-body = t(".jobseeker_section.signed_out.description_html")
       = govuk_button_link_to(t("buttons.sign_in_jobseeker"), new_jobseeker_session_path, class: "govuk-!-margin-bottom-2 govuk-button--secondary")

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -128,7 +128,7 @@ en:
     update_job: Update listing
     update_password: Update password
     upload_files: Upload files
-    view_account: View your account
+    view_applications: View your applications
     withdraw_application: Withdraw application
 
   helpers:


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/bSodUIjL/3189-ux-bug-clicking-view-your-account-opens-applications-page-not-account-settings-page

## Changes in this PR:

The "view your account" link on the homepage for logged in jobseekers was not taking the jobseeker to their account page, this change fixes the link.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
