### PR TITLE
3178 draft replace httparty with faraday gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,8 +60,6 @@ gem "govuk_design_system_formbuilder", "~> 6.4.0"
 gem "groupdate"
 # guidance pages
 gem "high_voltage"
-# HTTP client for downloading GIAS data
-gem "httparty"
 # needed for processing of message attachments
 gem "image_processing"
 # startard library for creating IPAddresses. Used in production config

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,10 @@ gem "draper"
 # These could be moved into test scope
 gem "factory_bot_rails"
 gem "faker"
+# HTTP client used for external API/feed requests
+gem "faraday"
+# automatic retries on Faraday requests to ephemeral third-party failures
+gem "faraday-retry"
 # more uk-friendly fakes available
 gem "ffaker"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1042,7 +1042,6 @@ DEPENDENCIES
   guard-shell
   guard-slim_lint
   high_voltage
-  httparty
   image_processing
   ipaddr
   jbuilder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,6 +258,8 @@ GEM
       multipart-post (~> 2.0)
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
+    faraday-retry (2.4.0)
+      faraday (~> 2.0)
     fastimage (2.4.1)
     ferrum (0.17.1)
       addressable (~> 2.5)
@@ -1022,6 +1024,8 @@ DEPENDENCIES
   factory_bot_rails
   faker
   fantaskspec
+  faraday
+  faraday-retry
   fastimage
   ffaker
   friendly_id
@@ -1219,6 +1223,7 @@ CHECKSUMS
   faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
   faraday-multipart (1.2.0) sha256=7d89a949693714176f612323ca13746a2ded204031a6ba528adee788694ef757
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
+  faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   fastimage (2.4.1) sha256=c64bebd46b6fd8943ab70c1e6e85ff728f970f2e48f92ecd249b6bc3a540ad20
   ferrum (0.17.1) sha256=51d591120fc593e5a13b5d9d6474389f5145bb92a91e36eab147b5d096c8cbe7
   ffaker (2.25.0) sha256=e485c5adf8195aac55662875b7f515469bca46d77b60d0e7d08db6861bcbec40

--- a/app/controllers/api/location_suggestion_controller.rb
+++ b/app/controllers/api/location_suggestion_controller.rb
@@ -8,7 +8,7 @@ class Api::LocationSuggestionController < Api::ApplicationController
   def show
     begin
       suggestions, matched_terms = LocationSuggestion.new(location).suggest_locations
-    rescue HTTParty::ResponseError, LocationSuggestion::GooglePlacesAutocompleteError => e
+    rescue LocationSuggestion::RequestError, LocationSuggestion::GooglePlacesAutocompleteError => e
       return render(json: { error: e }, status: :bad_request)
     end
 

--- a/app/lib/http_client.rb
+++ b/app/lib/http_client.rb
@@ -1,0 +1,26 @@
+# Shared Faraday connection used for all outbound HTTP requests to third-party
+# APIs/feeds, configured to automatically retry ephemeral failures.
+#
+# Retries are limited to 3 attempts with an exponential backoff (0.5s, 1s, 2s,
+# plus a little jitter) so a flaky endpoint doesn't hold up the job/request for
+# too long, while still smoothing over the kind of transient blips (timeouts,
+# connection resets, 502/503/504) that would otherwise crash the whole import.
+class HttpClient
+  DEFAULT_RETRY_OPTIONS = {
+    max: 3,
+    interval: 0.5,
+    backoff_factor: 2,
+    interval_randomness: 0.5,
+    max_interval: 5,
+    methods: %i[get],
+    retry_statuses: [429, 500, 502, 503, 504],
+    exceptions: Faraday::Retry::Middleware::DEFAULT_EXCEPTIONS + [Faraday::ConnectionFailed],
+  }.freeze
+
+  def self.connection(retry_options: {}, **faraday_options)
+    Faraday.new(**faraday_options) do |conn|
+      conn.request :retry, DEFAULT_RETRY_OPTIONS.merge(retry_options)
+      conn.adapter Faraday.default_adapter
+    end
+  end
+end

--- a/app/services/gias/data.rb
+++ b/app/services/gias/data.rb
@@ -13,10 +13,20 @@ class Gias::Data
     Tempfile.create(type) do |file|
       file.binmode
 
-      HTTParty.get(csv_url, stream_body: true, headers: { "User-Agent" => "teaching-vancancies" }) do |fragment|
-        raise "Could not download file #{csv_url} from GIAS: #{fragment.code}" unless fragment.code == 200
+      # If a retry kicks in mid-download, discard whatever was already written so the
+      # retried attempt doesn't get appended after a partial/corrupt download.
+      retry_options = { retry_block: proc {
+        file.truncate(0)
+        file.rewind
+      } }
 
-        file.write(fragment)
+      HttpClient.connection(retry_options: retry_options).get(csv_url) do |req|
+        req.headers["User-Agent"] = "teaching-vancancies"
+        req.options.on_data = proc do |chunk, _bytes_received, env|
+          raise "Could not download file #{csv_url} from GIAS: #{env.status}" unless env.status == 200
+
+          file.write(chunk)
+        end
       end
       file.rewind
 

--- a/app/services/location_suggestion.rb
+++ b/app/services/location_suggestion.rb
@@ -8,6 +8,8 @@ class LocationSuggestion
 
   class GooglePlacesAutocompleteError < StandardError; end
 
+  class RequestError < StandardError; end
+
   attr_accessor :location_input
 
   def initialize(location_input)
@@ -33,8 +35,8 @@ class LocationSuggestion
   end
 
   def get_suggestions_from_google
-    response = HTTParty.get(request_url)
-    raise HTTParty::ResponseError, "Something went wrong" unless response.success?
+    response = HttpClient.connection.get(request_url)
+    raise RequestError, "Something went wrong" unless response.success?
 
     parsed_response = JSON.parse(response.body)
     raise GooglePlacesAutocompleteError, parsed_response["error_message"] if

--- a/app/services/ons_data_import/base.rb
+++ b/app/services/ons_data_import/base.rb
@@ -101,14 +101,14 @@ class OnsDataImport::Base
         "resultOffset=#{offset * PER_PAGE}",
       ].join("&")
 
-      response = HTTParty.get("#{ARCGIS_BASE_URL}#{api_name}/FeatureServer/0/query?#{params}")
+      response = HttpClient.connection.get("#{ARCGIS_BASE_URL}#{api_name}/FeatureServer/0/query?#{params}")
       # really hard to auto-test this, as it doesn't normally happen
       # simplecov:disable
-      raise "Unexpected ArcGIS response: #{response.code}" unless response.success?
+      raise "Unexpected ArcGIS response: #{response.status}" unless response.success?
 
       # simplecov:enable
 
-      response_data = JSON.parse(response.to_s)
+      response_data = JSON.parse(response.body)
       raise "ArcGIS error: #{response_data['error']}" if response_data.key?("error")
 
       response_data.fetch("features")

--- a/app/services/vacancies/import/sources/broadbean.rb
+++ b/app/services/vacancies/import/sources/broadbean.rb
@@ -180,6 +180,6 @@ class Vacancies::Import::Sources::Broadbean
   end
 
   def feed
-    @feed ||= Nokogiri::XML(HTTParty.get(FEED_URL).body)
+    @feed ||= Nokogiri::XML(HttpClient.connection.get(FEED_URL).body)
   end
 end

--- a/app/services/vacancies/import/sources/fusion.rb
+++ b/app/services/vacancies/import/sources/fusion.rb
@@ -173,8 +173,8 @@ class Vacancies::Import::Sources::Fusion
   end
 
   def results
-    response = HTTParty.get(FEED_URL)
-    raise HTTParty::ResponseError, error_message unless response.success?
+    response = HttpClient.connection.get(FEED_URL)
+    raise FusionImportError, error_message unless response.success?
 
     JSON.parse(response.body)
   end

--- a/app/services/vacancies/import/sources/vacancy_poster.rb
+++ b/app/services/vacancies/import/sources/vacancy_poster.rb
@@ -173,6 +173,6 @@ class Vacancies::Import::Sources::VacancyPoster
   end
 
   def feed
-    @feed ||= Nokogiri::XML(HTTParty.get(FEED_URL).body)
+    @feed ||= Nokogiri::XML(HttpClient.connection.get(FEED_URL).body)
   end
 end

--- a/app/services/vacancies/import/sources/ventrus.rb
+++ b/app/services/vacancies/import/sources/ventrus.rb
@@ -172,6 +172,6 @@ class Vacancies::Import::Sources::Ventrus
   end
 
   def feed
-    @feed ||= Nokogiri::XML(HTTParty.get(FEED_URL).body)
+    @feed ||= Nokogiri::XML(HttpClient.connection.get(FEED_URL).body)
   end
 end

--- a/lib/dfe_sign_in/api/request.rb
+++ b/lib/dfe_sign_in/api/request.rb
@@ -13,14 +13,15 @@ module DfeSignIn
 
       def perform
         token = generate_jwt_token
-        response = HTTParty.get(
+        response = HttpClient.connection.get(
           "#{ENV.fetch('DFE_SIGN_IN_URL', nil)}#{@endpoint}?page=#{@page}&pageSize=#{@page_size}",
-          headers: { "Authorization" => "Bearer #{token}" },
-        )
+        ) do |req|
+          req.headers["Authorization"] = "Bearer #{token}"
+        end
 
-        raise ExternalServerError if response.code.eql?(500)
-        raise ForbiddenRequestError if response.code.eql?(403)
-        raise UnknownResponseError unless response.code.eql?(200)
+        raise ExternalServerError if response.status.eql?(500)
+        raise ForbiddenRequestError if response.status.eql?(403)
+        raise UnknownResponseError unless response.status.eql?(200)
 
         JSON.parse(response.body)
       end

--- a/spec/lib/http_client_spec.rb
+++ b/spec/lib/http_client_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe HttpClient do
+  describe ".connection" do
+    it "returns a Faraday connection configured with the retry middleware" do
+      connection = described_class.connection
+
+      expect(connection).to be_a(Faraday::Connection)
+      retry_handler = connection.builder.handlers.find { |handler| handler.klass == Faraday::Retry::Middleware }
+      expect(retry_handler).to be_present
+    end
+
+    it "defaults to 3 retries with an exponential backoff" do
+      connection = described_class.connection
+      retry_handler = connection.builder.handlers.find { |handler| handler.klass == Faraday::Retry::Middleware }
+
+      options = retry_handler.instance_variable_get(:@args).first
+      expect(options[:max]).to eq(3)
+      expect(options[:backoff_factor]).to eq(2)
+    end
+
+    it "allows callers to override the retry options" do
+      connection = described_class.connection(retry_options: { max: 1 })
+      retry_handler = connection.builder.handlers.find { |handler| handler.klass == Faraday::Retry::Middleware }
+
+      options = retry_handler.instance_variable_get(:@args).first
+      expect(options[:max]).to eq(1)
+    end
+
+    it "passes through other Faraday connection options, such as a base url" do
+      connection = described_class.connection(url: "https://example.com")
+
+      expect(connection.url_prefix.to_s).to eq("https://example.com/")
+    end
+  end
+
+  describe "retry behaviour" do
+    let(:url) { "http://example.com/flaky" }
+
+    it "retries on a retryable status and returns the eventual successful response" do
+      stub_request(:get, url)
+        .to_return({ status: 503 }, { status: 503 }, { status: 200, body: "ok" })
+
+      response = described_class.connection(retry_options: { interval: 0 }).get(url)
+
+      expect(response.status).to eq(200)
+      expect(response.body).to eq("ok")
+      expect(WebMock).to have_requested(:get, url).times(3)
+    end
+
+    it "gives up after the max number of retries and returns the last failing response" do
+      stub_request(:get, url).to_return(status: 503)
+
+      response = described_class.connection(retry_options: { max: 2, interval: 0 }).get(url)
+
+      expect(response.status).to eq(503)
+      expect(WebMock).to have_requested(:get, url).times(3)
+    end
+
+    it "retries connection failures" do
+      stub_request(:get, url).to_raise(Faraday::ConnectionFailed).then.to_return(status: 200, body: "ok")
+
+      response = described_class.connection(retry_options: { interval: 0 }).get(url)
+
+      expect(response.status).to eq(200)
+      expect(WebMock).to have_requested(:get, url).times(2)
+    end
+  end
+end

--- a/spec/requests/api/location_suggestion_spec.rb
+++ b/spec/requests/api/location_suggestion_spec.rb
@@ -60,9 +60,9 @@ RSpec.describe "Api::LocationSuggestion" do
       end
     end
 
-    context "LocationSuggestion raises HTTParty::Response error" do
+    context "LocationSuggestion raises RequestError" do
       before do
-        allow(location_suggestion).to receive(:suggest_locations).and_raise(HTTParty::ResponseError, "HTTP error")
+        allow(location_suggestion).to receive(:suggest_locations).and_raise(LocationSuggestion::RequestError, "HTTP error")
       end
 
       it "returns status :bad_request" do

--- a/spec/services/gias/data_spec.rb
+++ b/spec/services/gias/data_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe Gias::Data do
+  subject(:data) { described_class.new(type) }
+
+  let(:type) { "allgroupsdata" }
+  let(:csv_url) { "https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public/#{type}#{Time.current.strftime('%Y%m%d')}.csv" }
+  let(:csv_body) { "URN,EstablishmentName\n100000,Test School\n" }
+
+  describe "#each" do
+    it "downloads and yields the parsed CSV rows" do
+      stub_request(:get, csv_url).to_return(status: 200, body: csv_body)
+
+      rows = data.to_a
+
+      expect(rows.size).to eq(1)
+      expect(rows.first["URN"]).to eq("100000")
+    end
+
+    it "sends a User-Agent header" do
+      stub = stub_request(:get, csv_url).with(headers: { "User-Agent" => "teaching-vancancies" }).to_return(status: 200, body: csv_body)
+
+      data.to_a
+
+      expect(stub).to have_been_requested
+    end
+
+    it "raises when the response is not successful" do
+      stub_request(:get, csv_url).to_return(status: 404, body: "not found")
+
+      expect { data.to_a }.to raise_error(/Could not download file #{Regexp.escape(csv_url)} from GIAS: 404/)
+    end
+
+    it "discards any partially-written data when a connection failure is retried" do
+      stub_request(:get, csv_url)
+        .to_raise(Faraday::ConnectionFailed)
+        .then
+        .to_return(status: 200, body: csv_body)
+
+      rows = data.to_a
+
+      expect(rows.size).to eq(1)
+      expect(rows.first["URN"]).to eq("100000")
+    end
+  end
+end

--- a/spec/services/location_suggestion_spec.rb
+++ b/spec/services/location_suggestion_spec.rb
@@ -28,17 +28,16 @@ RSpec.describe LocationSuggestion do
       stub_request(:get, request_url).to_return(body: request_body, status: request_status)
     end
 
-    # false assertion from rubocop
-    # rubocop:disable RSpec/UnspecifiedException
     context "the request is unsuccessful" do
       let(:request_status) { 400 }
 
-      it "raises a HTTParty::ResponseError" do
-        expect { subject.send(:get_suggestions_from_google) }.to raise_error do
-          HTTParty::ResponseError.new("Something went wrong")
-        end
+      it "raises a LocationSuggestion::RequestError" do
+        expect { subject.send(:get_suggestions_from_google) }.to raise_error(described_class::RequestError, "Something went wrong")
       end
     end
+
+    # false assertion from rubocop
+    # rubocop:disable RSpec/UnspecifiedException
 
     context "the response contains an error message" do
       let(:error_message) { "This is an error" }

--- a/spec/services/ons_data_import/import_cities_spec.rb
+++ b/spec/services/ons_data_import/import_cities_spec.rb
@@ -1,13 +1,12 @@
 require "rails_helper"
 
 RSpec.describe OnsDataImport::ImportCities do
-  let(:response1) { double(success?: true, to_s: file_fixture("ons_cities_geojson.json").read) }
-  let(:response2) { double(success?: true, to_s: { features: [] }.to_json) }
-
   before do
-    allow(HTTParty).to receive(:get)
-      .with(/Major_Towns_and_Cities_December_2015_Boundaries/)
-      .and_return(response1, response2)
+    stub_request(:get, /Major_Towns_and_Cities_December_2015_Boundaries/)
+      .to_return(
+        { status: 200, body: file_fixture("ons_cities_geojson.json").read },
+        { status: 200, body: { features: [] }.to_json },
+      )
     described_class.call
   end
 

--- a/spec/services/ons_data_import/import_counties_spec.rb
+++ b/spec/services/ons_data_import/import_counties_spec.rb
@@ -1,15 +1,14 @@
 require "rails_helper"
 
 RSpec.describe OnsDataImport::ImportCounties do
-  let(:response1) { double(success?: true, to_s: file_fixture("ons_counties_geojson.json").read) }
-  let(:response2) { double(success?: true, to_s: { features: [] }.to_json) }
-
   # sadly this can't be a VCR test because the resultant download file is 118Mb
   # which is impractical to even cut-down
   before do
-    allow(HTTParty).to receive(:get)
-      .with(/Counties_and_Unitary_Authorities_April_2019_Boundaries_EW_BFC_2022/)
-      .and_return(response1, response2)
+    stub_request(:get, /Counties_and_Unitary_Authorities_April_2019_Boundaries_EW_BFC_2022/)
+      .to_return(
+        { status: 200, body: file_fixture("ons_counties_geojson.json").read },
+        { status: 200, body: { features: [] }.to_json },
+      )
     described_class.call
   end
 

--- a/spec/services/ons_data_import/import_regions_spec.rb
+++ b/spec/services/ons_data_import/import_regions_spec.rb
@@ -1,13 +1,12 @@
 require "rails_helper"
 
 RSpec.describe OnsDataImport::ImportRegions do
-  let(:response1) { double(success?: true, to_s: file_fixture("ons_regions_geojson.json").read) }
-  let(:response2) { double(success?: true, to_s: { features: [] }.to_json) }
-
   before do
-    allow(HTTParty).to receive(:get)
-      .with(/regions/)
-      .and_return(response1, response2)
+    stub_request(:get, /regions/)
+      .to_return(
+        { status: 200, body: file_fixture("ons_regions_geojson.json").read },
+        { status: 200, body: { features: [] }.to_json },
+      )
     described_class.call
   end
 

--- a/spec/services/vacancies/import/sources/broadbean_spec.rb
+++ b/spec/services/vacancies/import/sources/broadbean_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe Vacancies::Import::Sources::Broadbean do
   let(:response_body) { file_fixture("vacancy_sources/broadbean.xml").read }
-  let(:response) { double("BroadbeanHttpResponse", success?: true, body: response_body) }
 
   let!(:school1) { create(:school, name: "Test School", urn: "111111", phase: :primary, created_at: 1.week.ago) }
   let!(:out_of_scope_school) { create(:school, name: "Out of scope", urn: "999999", detailed_school_type: "Other independent school") }
@@ -30,7 +29,7 @@ RSpec.describe Vacancies::Import::Sources::Broadbean do
     end
 
     before do
-      expect(HTTParty).to receive(:get).with("http://example.com/feed.xml").and_return(response)
+      stub_request(:get, "http://example.com/feed.xml").to_return(body: response_body)
     end
 
     it "has the correct number of vacancies" do

--- a/spec/services/vacancies/import/sources/fusion_spec.rb
+++ b/spec/services/vacancies/import/sources/fusion_spec.rb
@@ -6,12 +6,11 @@ RSpec.describe Vacancies::Import::Sources::Fusion do
   let(:trust_schools) { [school1] }
 
   let(:response_body) { file_fixture("vacancy_sources/fusion.json").read }
-  let(:response) { double("FusionHttpResponse", success?: true, body: response_body) }
-  let(:argument_error_response) { double("FusionHttpResponse", success?: true, body: file_fixture("vacancy_sources/fusion_argument_error.json").read) }
+  let(:argument_error_body) { file_fixture("vacancy_sources/fusion_argument_error.json").read }
 
   describe "enumeration" do
     before do
-      expect(HTTParty).to receive(:get).with("http://example.com/feed.json").and_return(response)
+      stub_request(:get, "http://example.com/feed.json").to_return(body: response_body)
     end
 
     let(:vacancy) { subject.first }
@@ -562,7 +561,7 @@ RSpec.describe Vacancies::Import::Sources::Fusion do
 
   describe "enumeration error" do
     before do
-      expect(HTTParty).to receive(:get).with("http://example.com/feed.json").and_return(argument_error_response)
+      stub_request(:get, "http://example.com/feed.json").to_return(body: argument_error_body)
     end
 
     let(:vacancy) { subject.first }
@@ -571,6 +570,16 @@ RSpec.describe Vacancies::Import::Sources::Fusion do
       it "adds an error to the vacancy object" do
         expect(vacancy.errors.count).to eq(1)
       end
+    end
+  end
+
+  describe "when the feed request is unsuccessful" do
+    before do
+      stub_request(:get, "http://example.com/feed.json").to_return(status: 500)
+    end
+
+    it "raises a FusionImportError" do
+      expect { subject.to_a }.to raise_error(described_class::FusionImportError, "Something went wrong with Fusion Import")
     end
   end
 end

--- a/spec/services/vacancies/import/sources/vacancy_poster_spec.rb
+++ b/spec/services/vacancies/import/sources/vacancy_poster_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe Vacancies::Import::Sources::VacancyPoster do
   let(:response_body) { file_fixture("vacancy_sources/vacancy_poster.xml").read }
-  let(:response) { instance_double(Net::HTTPResponse, body: response_body) }
 
   let!(:school1) { create(:school, name: "Test School", urn: "123456", phase: :primary) }
   let(:schools) { [school1] }
@@ -26,7 +25,7 @@ RSpec.describe Vacancies::Import::Sources::VacancyPoster do
     end
 
     before do
-      expect(HTTParty).to receive(:get).with("http://example.com/feed.xml").and_return(response)
+      stub_request(:get, "http://example.com/feed.xml").to_return(body: response_body)
     end
 
     it "has the correct number of vacancies" do

--- a/spec/services/vacancies/import/sources/ventrus_spec.rb
+++ b/spec/services/vacancies/import/sources/ventrus_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe Vacancies::Import::Sources::Ventrus do
   let(:response_body) { file_fixture("vacancy_sources/ventrus.xml").read }
-  let(:response) { double("VentrusHttpResponse", success?: true, body: response_body) }
 
   let!(:school1) { create(:school, name: "Test School", urn: "111111", phase: :primary) }
   let!(:school_group) { create(:school_group, name: "Ventrus", uid: "4243", schools: schools) }
@@ -28,7 +27,7 @@ RSpec.describe Vacancies::Import::Sources::Ventrus do
     end
 
     before do
-      expect(HTTParty).to receive(:get).with("http://example.com/feed.xml").and_return(response)
+      stub_request(:get, "http://example.com/feed.xml").to_return(body: response_body)
     end
 
     it "has the correct number of vacancies" do

--- a/spec/support/faraday_retry_helpers.rb
+++ b/spec/support/faraday_retry_helpers.rb
@@ -1,0 +1,9 @@
+# Faraday::Retry::Middleware sleeps for real between retries. Skip that in specs so
+# tests that exercise the retry behaviour (deliberately or incidentally, via WebMock
+# stubs returning a retryable status/error) stay fast without changing retry
+# counts/outcomes.
+module SkipFaradayRetrySleep
+  def sleep(*) = nil
+end
+
+Faraday::Retry::Middleware.prepend(SkipFaradayRetrySleep)


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/OjuPRGNR/3178-draft-replace-httparty-with-faraday-gem

## Changes in this PR:

- Is there anything specific you want feedback on?

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
