### PR TITLE
3178 faraday client and google places

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,10 @@ gem "draper"
 # These could be moved into test scope
 gem "factory_bot_rails"
 gem "faker"
+# HTTP client used for external API/feed requests
+gem "faraday"
+# automatic retries on Faraday requests to ephemeral third-party failures
+gem "faraday-retry"
 # more uk-friendly fakes available
 gem "ffaker"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,6 +258,8 @@ GEM
       multipart-post (~> 2.0)
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
+    faraday-retry (2.4.0)
+      faraday (~> 2.0)
     fastimage (2.4.1)
     ferrum (0.17.1)
       addressable (~> 2.5)
@@ -1022,6 +1024,8 @@ DEPENDENCIES
   factory_bot_rails
   faker
   fantaskspec
+  faraday
+  faraday-retry
   fastimage
   ffaker
   friendly_id
@@ -1219,6 +1223,7 @@ CHECKSUMS
   faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
   faraday-multipart (1.2.0) sha256=7d89a949693714176f612323ca13746a2ded204031a6ba528adee788694ef757
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
+  faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   fastimage (2.4.1) sha256=c64bebd46b6fd8943ab70c1e6e85ff728f970f2e48f92ecd249b6bc3a540ad20
   ferrum (0.17.1) sha256=51d591120fc593e5a13b5d9d6474389f5145bb92a91e36eab147b5d096c8cbe7
   ffaker (2.25.0) sha256=e485c5adf8195aac55662875b7f515469bca46d77b60d0e7d08db6861bcbec40

--- a/app/controllers/api/location_suggestion_controller.rb
+++ b/app/controllers/api/location_suggestion_controller.rb
@@ -8,7 +8,7 @@ class Api::LocationSuggestionController < Api::ApplicationController
   def show
     begin
       suggestions, matched_terms = LocationSuggestion.new(location).suggest_locations
-    rescue HTTParty::ResponseError, LocationSuggestion::GooglePlacesAutocompleteError => e
+    rescue LocationSuggestion::RequestError, LocationSuggestion::GooglePlacesAutocompleteError => e
       return render(json: { error: e }, status: :bad_request)
     end
 

--- a/app/lib/http_client.rb
+++ b/app/lib/http_client.rb
@@ -1,0 +1,26 @@
+# Shared Faraday connection used for all outbound HTTP requests to third-party
+# APIs/feeds, configured to automatically retry ephemeral failures.
+#
+# Retries are limited to 3 attempts with an exponential backoff (0.5s, 1s, 2s,
+# plus a little jitter) so a flaky endpoint doesn't hold up the job/request for
+# too long, while still smoothing over the kind of transient blips (timeouts,
+# connection resets, 502/503/504) that would otherwise crash the whole import.
+class HttpClient
+  DEFAULT_RETRY_OPTIONS = {
+    max: 3,
+    interval: 0.5,
+    backoff_factor: 2,
+    interval_randomness: 0.5,
+    max_interval: 5,
+    methods: %i[get],
+    retry_statuses: [429, 500, 502, 503, 504],
+    exceptions: Faraday::Retry::Middleware::DEFAULT_EXCEPTIONS + [Faraday::ConnectionFailed],
+  }.freeze
+
+  def self.connection(retry_options: {}, **faraday_options)
+    Faraday.new(**faraday_options) do |conn|
+      conn.request :retry, DEFAULT_RETRY_OPTIONS.merge(retry_options)
+      conn.adapter Faraday.default_adapter
+    end
+  end
+end

--- a/app/services/location_suggestion.rb
+++ b/app/services/location_suggestion.rb
@@ -8,6 +8,8 @@ class LocationSuggestion
 
   class GooglePlacesAutocompleteError < StandardError; end
 
+  class RequestError < StandardError; end
+
   attr_accessor :location_input
 
   def initialize(location_input)
@@ -33,8 +35,8 @@ class LocationSuggestion
   end
 
   def get_suggestions_from_google
-    response = HTTParty.get(request_url)
-    raise HTTParty::ResponseError, "Something went wrong" unless response.success?
+    response = HttpClient.connection.get(request_url)
+    raise RequestError, "Something went wrong" unless response.success?
 
     parsed_response = JSON.parse(response.body)
     raise GooglePlacesAutocompleteError, parsed_response["error_message"] if

--- a/spec/lib/http_client_spec.rb
+++ b/spec/lib/http_client_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe HttpClient do
+  describe ".connection" do
+    it "returns a Faraday connection configured with the retry middleware" do
+      connection = described_class.connection
+
+      expect(connection).to be_a(Faraday::Connection)
+      retry_handler = connection.builder.handlers.find { |handler| handler.klass == Faraday::Retry::Middleware }
+      expect(retry_handler).to be_present
+    end
+
+    it "defaults to 3 retries with an exponential backoff" do
+      connection = described_class.connection
+      retry_handler = connection.builder.handlers.find { |handler| handler.klass == Faraday::Retry::Middleware }
+
+      options = retry_handler.instance_variable_get(:@args).first
+      expect(options[:max]).to eq(3)
+      expect(options[:backoff_factor]).to eq(2)
+    end
+
+    it "allows callers to override the retry options" do
+      connection = described_class.connection(retry_options: { max: 1 })
+      retry_handler = connection.builder.handlers.find { |handler| handler.klass == Faraday::Retry::Middleware }
+
+      options = retry_handler.instance_variable_get(:@args).first
+      expect(options[:max]).to eq(1)
+    end
+
+    it "passes through other Faraday connection options, such as a base url" do
+      connection = described_class.connection(url: "https://example.com")
+
+      expect(connection.url_prefix.to_s).to eq("https://example.com/")
+    end
+  end
+
+  describe "retry behaviour" do
+    let(:url) { "http://example.com/flaky" }
+
+    it "retries on a retryable status and returns the eventual successful response" do
+      stub_request(:get, url)
+        .to_return({ status: 503 }, { status: 503 }, { status: 200, body: "ok" })
+
+      response = described_class.connection(retry_options: { interval: 0 }).get(url)
+
+      expect(response.status).to eq(200)
+      expect(response.body).to eq("ok")
+      expect(WebMock).to have_requested(:get, url).times(3)
+    end
+
+    it "gives up after the max number of retries and returns the last failing response" do
+      stub_request(:get, url).to_return(status: 503)
+
+      response = described_class.connection(retry_options: { max: 2, interval: 0 }).get(url)
+
+      expect(response.status).to eq(503)
+      expect(WebMock).to have_requested(:get, url).times(3)
+    end
+
+    it "retries connection failures" do
+      stub_request(:get, url).to_raise(Faraday::ConnectionFailed).then.to_return(status: 200, body: "ok")
+
+      response = described_class.connection(retry_options: { interval: 0 }).get(url)
+
+      expect(response.status).to eq(200)
+      expect(WebMock).to have_requested(:get, url).times(2)
+    end
+  end
+end

--- a/spec/requests/api/location_suggestion_spec.rb
+++ b/spec/requests/api/location_suggestion_spec.rb
@@ -60,9 +60,9 @@ RSpec.describe "Api::LocationSuggestion" do
       end
     end
 
-    context "LocationSuggestion raises HTTParty::Response error" do
+    context "LocationSuggestion raises RequestError" do
       before do
-        allow(location_suggestion).to receive(:suggest_locations).and_raise(HTTParty::ResponseError, "HTTP error")
+        allow(location_suggestion).to receive(:suggest_locations).and_raise(LocationSuggestion::RequestError, "HTTP error")
       end
 
       it "returns status :bad_request" do

--- a/spec/services/location_suggestion_spec.rb
+++ b/spec/services/location_suggestion_spec.rb
@@ -28,17 +28,16 @@ RSpec.describe LocationSuggestion do
       stub_request(:get, request_url).to_return(body: request_body, status: request_status)
     end
 
-    # false assertion from rubocop
-    # rubocop:disable RSpec/UnspecifiedException
     context "the request is unsuccessful" do
       let(:request_status) { 400 }
 
-      it "raises a HTTParty::ResponseError" do
-        expect { subject.send(:get_suggestions_from_google) }.to raise_error do
-          HTTParty::ResponseError.new("Something went wrong")
-        end
+      it "raises a LocationSuggestion::RequestError" do
+        expect { subject.send(:get_suggestions_from_google) }.to raise_error(described_class::RequestError, "Something went wrong")
       end
     end
+
+    # false assertion from rubocop
+    # rubocop:disable RSpec/UnspecifiedException
 
     context "the response contains an error message" do
       let(:error_message) { "This is an error" }


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/OjuPRGNR/3178-replace-httparty-with-faraday-gem

## Changes in this PR:

Part 1 of 5 from ticket.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
