### PR TITLE
Migrate OnsDataImport::Base (ONS ArcGIS pull) to Faraday

### DIFF
--- a/app/services/ons_data_import/base.rb
+++ b/app/services/ons_data_import/base.rb
@@ -101,14 +101,14 @@ class OnsDataImport::Base
         "resultOffset=#{offset * PER_PAGE}",
       ].join("&")
 
-      response = HTTParty.get("#{ARCGIS_BASE_URL}#{api_name}/FeatureServer/0/query?#{params}")
+      response = HttpClient.connection.get("#{ARCGIS_BASE_URL}#{api_name}/FeatureServer/0/query?#{params}")
       # really hard to auto-test this, as it doesn't normally happen
       # simplecov:disable
-      raise "Unexpected ArcGIS response: #{response.code}" unless response.success?
+      raise "Unexpected ArcGIS response: #{response.status}" unless response.success?
 
       # simplecov:enable
 
-      response_data = JSON.parse(response.to_s)
+      response_data = JSON.parse(response.body)
       raise "ArcGIS error: #{response_data['error']}" if response_data.key?("error")
 
       response_data.fetch("features")

--- a/spec/services/ons_data_import/import_cities_spec.rb
+++ b/spec/services/ons_data_import/import_cities_spec.rb
@@ -1,13 +1,12 @@
 require "rails_helper"
 
 RSpec.describe OnsDataImport::ImportCities do
-  let(:response1) { double(success?: true, to_s: file_fixture("ons_cities_geojson.json").read) }
-  let(:response2) { double(success?: true, to_s: { features: [] }.to_json) }
-
   before do
-    allow(HTTParty).to receive(:get)
-      .with(/Major_Towns_and_Cities_December_2015_Boundaries/)
-      .and_return(response1, response2)
+    stub_request(:get, /Major_Towns_and_Cities_December_2015_Boundaries/)
+      .to_return(
+        { status: 200, body: file_fixture("ons_cities_geojson.json").read },
+        { status: 200, body: { features: [] }.to_json },
+      )
     described_class.call
   end
 

--- a/spec/services/ons_data_import/import_counties_spec.rb
+++ b/spec/services/ons_data_import/import_counties_spec.rb
@@ -1,15 +1,14 @@
 require "rails_helper"
 
 RSpec.describe OnsDataImport::ImportCounties do
-  let(:response1) { double(success?: true, to_s: file_fixture("ons_counties_geojson.json").read) }
-  let(:response2) { double(success?: true, to_s: { features: [] }.to_json) }
-
   # sadly this can't be a VCR test because the resultant download file is 118Mb
   # which is impractical to even cut-down
   before do
-    allow(HTTParty).to receive(:get)
-      .with(/Counties_and_Unitary_Authorities_April_2019_Boundaries_EW_BFC_2022/)
-      .and_return(response1, response2)
+    stub_request(:get, /Counties_and_Unitary_Authorities_April_2019_Boundaries_EW_BFC_2022/)
+      .to_return(
+        { status: 200, body: file_fixture("ons_counties_geojson.json").read },
+        { status: 200, body: { features: [] }.to_json },
+      )
     described_class.call
   end
 

--- a/spec/services/ons_data_import/import_regions_spec.rb
+++ b/spec/services/ons_data_import/import_regions_spec.rb
@@ -1,13 +1,12 @@
 require "rails_helper"
 
 RSpec.describe OnsDataImport::ImportRegions do
-  let(:response1) { double(success?: true, to_s: file_fixture("ons_regions_geojson.json").read) }
-  let(:response2) { double(success?: true, to_s: { features: [] }.to_json) }
-
   before do
-    allow(HTTParty).to receive(:get)
-      .with(/regions/)
-      .and_return(response1, response2)
+    stub_request(:get, /regions/)
+      .to_return(
+        { status: 200, body: file_fixture("ons_regions_geojson.json").read },
+        { status: 200, body: { features: [] }.to_json },
+      )
     described_class.call
   end
 


### PR DESCRIPTION
Moves the ArcGIS feature-page pulls used to build location polygons onto the shared HttpClient.connection, so a flaky ArcGIS response during the paginated pull gets retried instead of aborting the import.

The import_cities/regions/counties specs mocked HTTParty.get directly rather than stubbing at the HTTP layer, so they're rewritten with WebMock stub_request to stay transport-agnostic.

## Trello card URL

https://trello.com/c/OjuPRGNR/3178-replace-httparty-with-faraday-gem

## Changes in this PR:

PR 2/5

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
