### PR TITLE
Migrate Gias::Data (GIAS bulk CSV download) to Faraday

### DIFF
--- a/app/services/gias/data.rb
+++ b/app/services/gias/data.rb
@@ -20,14 +20,14 @@ class Gias::Data
         file.rewind
       } }
 
-      HttpClient.connection(retry_options: retry_options).get(csv_url) do |req|
-        req.headers["User-Agent"] = "teaching-vancancies"
+      response = HttpClient.connection(retry_options: retry_options).get(csv_url) do |req|
+        req.headers["User-Agent"] = "teaching-vacancies"
         req.options.on_data = proc do |chunk, _bytes_received, env|
-          raise "Could not download file #{csv_url} from GIAS: #{env.status}" unless env.status == 200
-
-          file.write(chunk)
+          file.write(chunk) if env.status == 200
         end
       end
+      raise "Could not download file #{csv_url} from GIAS: #{response.status}" unless response.status == 200
+
       file.rewind
 
       CSV.foreach(file, headers: true, encoding: "windows-1252:utf-8", &)

--- a/app/services/gias/data.rb
+++ b/app/services/gias/data.rb
@@ -13,10 +13,20 @@ class Gias::Data
     Tempfile.create(type) do |file|
       file.binmode
 
-      HTTParty.get(csv_url, stream_body: true, headers: { "User-Agent" => "teaching-vancancies" }) do |fragment|
-        raise "Could not download file #{csv_url} from GIAS: #{fragment.code}" unless fragment.code == 200
+      # If a retry kicks in mid-download, discard whatever was already written so the
+      # retried attempt doesn't get appended after a partial/corrupt download.
+      retry_options = { retry_block: proc {
+        file.truncate(0)
+        file.rewind
+      } }
 
-        file.write(fragment)
+      HttpClient.connection(retry_options: retry_options).get(csv_url) do |req|
+        req.headers["User-Agent"] = "teaching-vancancies"
+        req.options.on_data = proc do |chunk, _bytes_received, env|
+          raise "Could not download file #{csv_url} from GIAS: #{env.status}" unless env.status == 200
+
+          file.write(chunk)
+        end
       end
       file.rewind
 

--- a/spec/services/gias/data_spec.rb
+++ b/spec/services/gias/data_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe Gias::Data do
+  subject(:data) { described_class.new(type) }
+
+  let(:type) { "allgroupsdata" }
+  let(:csv_url) { "https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public/#{type}#{Time.current.strftime('%Y%m%d')}.csv" }
+  let(:csv_body) { "URN,EstablishmentName\n100000,Test School\n" }
+
+  describe "#each" do
+    it "downloads and yields the parsed CSV rows" do
+      stub_request(:get, csv_url).to_return(status: 200, body: csv_body)
+
+      rows = data.to_a
+
+      expect(rows.size).to eq(1)
+      expect(rows.first["URN"]).to eq("100000")
+    end
+
+    it "sends a User-Agent header" do
+      stub = stub_request(:get, csv_url).with(headers: { "User-Agent" => "teaching-vancancies" }).to_return(status: 200, body: csv_body)
+
+      data.to_a
+
+      expect(stub).to have_been_requested
+    end
+
+    it "raises when the response is not successful" do
+      stub_request(:get, csv_url).to_return(status: 404, body: "not found")
+
+      expect { data.to_a }.to raise_error(/Could not download file #{Regexp.escape(csv_url)} from GIAS: 404/)
+    end
+
+    it "discards any partially-written data when a connection failure is retried" do
+      stub_request(:get, csv_url)
+        .to_raise(Faraday::ConnectionFailed)
+        .then
+        .to_return(status: 200, body: csv_body)
+
+      rows = data.to_a
+
+      expect(rows.size).to eq(1)
+      expect(rows.first["URN"]).to eq("100000")
+    end
+  end
+end

--- a/spec/services/gias/data_spec.rb
+++ b/spec/services/gias/data_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Gias::Data do
   let(:csv_url) { "https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public/#{type}#{Time.current.strftime('%Y%m%d')}.csv" }
   let(:csv_body) { "URN,EstablishmentName\n100000,Test School\n" }
 
+  before { freeze_time }
+
   describe "#each" do
     it "downloads and yields the parsed CSV rows" do
       stub_request(:get, csv_url).to_return(status: 200, body: csv_body)
@@ -18,7 +20,7 @@ RSpec.describe Gias::Data do
     end
 
     it "sends a User-Agent header" do
-      stub = stub_request(:get, csv_url).with(headers: { "User-Agent" => "teaching-vancancies" }).to_return(status: 200, body: csv_body)
+      stub = stub_request(:get, csv_url).with(headers: { "User-Agent" => "teaching-vacancies" }).to_return(status: 200, body: csv_body)
 
       data.to_a
 
@@ -31,7 +33,7 @@ RSpec.describe Gias::Data do
       expect { data.to_a }.to raise_error(/Could not download file #{Regexp.escape(csv_url)} from GIAS: 404/)
     end
 
-    it "discards any partially-written data when a connection failure is retried" do
+    it "retries after a connection failure" do
       stub_request(:get, csv_url)
         .to_raise(Faraday::ConnectionFailed)
         .then
@@ -41,6 +43,16 @@ RSpec.describe Gias::Data do
 
       expect(rows.size).to eq(1)
       expect(rows.first["URN"]).to eq("100000")
+    end
+
+    it "retries a retryable status and eventually downloads successfully" do
+      stub_request(:get, csv_url).to_return({ status: 503 }, { status: 200, body: csv_body })
+
+      rows = data.to_a
+
+      expect(rows.size).to eq(1)
+      expect(rows.first["URN"]).to eq("100000")
+      expect(WebMock).to have_requested(:get, csv_url).times(2)
     end
   end
 end


### PR DESCRIPTION
Replaces HTTParty's stream_body option with Faraday's on_data streaming callback, checking the response status via the Env yielded to each chunk. This is the largest/slowest download we make (full GIAS establishment CSVs), so it benefits the most from retrying ephemeral connection failures instead of failing the whole import.

Streaming plus retries needs care: if a retry kicks in mid-download, the previous attempt may have already written a partial file. A retry_block truncates and rewinds the tempfile before each retry so a retried download can't get appended after a corrupt partial one.

Adds spec/services/gias/data_spec.rb, which didn't previously exist as a dedicated spec, covering the happy path, the non-200 error, and the retry/truncation behaviour.

## Trello card URL

https://trello.com/c/OjuPRGNR/3178-replace-httparty-with-faraday-gem

## Changes in this PR:

Pr 3/5

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
