### PR TITLE
Validate time formatting on interview time form

### DIFF
--- a/config/initializers/active_model_type_time_or_string.rb
+++ b/config/initializers/active_model_type_time_or_string.rb
@@ -10,12 +10,12 @@ module ActiveModel
         end
       end
 
-      private
-
       VALID_TIME_FORMAT = /\A\d{1,2}(:\d{2})?\s*(am|pm)?\z/i
 
+      private
+
       def cast_value(value)
-        return value unless value.match?(VALID_TIME_FORMAT)
+        return value unless value.is_a?(String) && value.match?(VALID_TIME_FORMAT)
 
         ::Time.zone.parse(value).extend(TimeInputField) || value
       rescue ArgumentError, TypeError

--- a/config/initializers/active_model_type_time_or_string.rb
+++ b/config/initializers/active_model_type_time_or_string.rb
@@ -12,7 +12,11 @@ module ActiveModel
 
       private
 
+      VALID_TIME_FORMAT = /\A\d{1,2}(:\d{2})?\s*(am|pm)?\z/i
+
       def cast_value(value)
+        return value unless value.match?(VALID_TIME_FORMAT)
+
         ::Time.zone.parse(value).extend(TimeInputField) || value
       rescue ArgumentError, TypeError
         value

--- a/config/initializers/active_model_type_time_or_string.rb
+++ b/config/initializers/active_model_type_time_or_string.rb
@@ -15,9 +15,12 @@ module ActiveModel
       private
 
       def cast_value(value)
-        return value unless value.is_a?(String) && value.match?(VALID_TIME_FORMAT)
+        return value unless value.is_a?(::String) && value.match?(VALID_TIME_FORMAT)
 
-        ::Time.zone.parse(value).extend(TimeInputField) || value
+        parsed_time = ::Time.zone.parse(value)
+        return value if parsed_time.nil?
+
+        parsed_time.extend(TimeInputField)
       rescue ArgumentError, TypeError
         value
       end

--- a/config/initializers/active_model_type_time_or_string.rb
+++ b/config/initializers/active_model_type_time_or_string.rb
@@ -15,9 +15,12 @@ module ActiveModel
       private
 
       def cast_value(value)
-        return value unless value.is_a?(::String) && value.match?(VALID_TIME_FORMAT)
+        return value unless value.is_a?(::String)
 
-        parsed_time = ::Time.zone.parse(value)
+        stripped_value = value.strip
+        return value unless stripped_value.match?(VALID_TIME_FORMAT)
+
+        parsed_time = ::Time.zone.parse(stripped_value)
         return value if parsed_time.nil?
 
         parsed_time.extend(TimeInputField)

--- a/spec/form_models/publishers/job_application/interview_datetime_form_spec.rb
+++ b/spec/form_models/publishers/job_application/interview_datetime_form_spec.rb
@@ -43,7 +43,7 @@ module Publishers
           it { expect(form.interview_time).to eq(Time.zone.parse("22:30")) }
         end
 
-        context "with 2-digit hour without separator (1030)" do
+        context "with 4-digit time without separator (1030)" do
           let(:interview_time) { "1030" }
 
           it { expect(form.interview_time).to eq("1030") }
@@ -121,6 +121,12 @@ module Publishers
 
           context "with valid time (2:30pm)" do
             let(:interview_time) { "2:30pm" }
+
+            it { expect(form.errors.details).not_to include(:interview_time) }
+          end
+
+          context "with leading and trailing whitespace ( 2:30pm )" do
+            let(:interview_time) { " 2:30pm " }
 
             it { expect(form.errors.details).not_to include(:interview_time) }
           end

--- a/spec/form_models/publishers/job_application/interview_datetime_form_spec.rb
+++ b/spec/form_models/publishers/job_application/interview_datetime_form_spec.rb
@@ -30,6 +30,24 @@ module Publishers
       describe ".interview_time" do
         it { expect(form.interview_time).to eq(Time.zone.parse("10:45")) }
         it { expect(form.interview_time.to_s).to eq("10:45am") }
+
+        context "with 2-digit hour and colon (10:30)" do
+          let(:interview_time) { "10:30" }
+
+          it { expect(form.interview_time).to eq(Time.zone.parse("10:30")) }
+        end
+
+        context "with 2-digit hour and pm (10:30pm)" do
+          let(:interview_time) { "10:30pm" }
+
+          it { expect(form.interview_time).to eq(Time.zone.parse("22:30")) }
+        end
+
+        context "with 2-digit hour without separator (1030)" do
+          let(:interview_time) { "1030" }
+
+          it { expect(form.interview_time).to eq("1030") }
+        end
       end
 
       describe ".interviewing_at" do
@@ -67,6 +85,72 @@ module Publishers
 
           context "with bad time" do
             let(:interview_time) { "badtime" }
+
+            it { expect(form.errors.details).to include(interview_time: [{ error: :invalid }]) }
+          end
+
+          context "with time using a dot separator (2.30pm)" do
+            let(:interview_time) { "2.30pm" }
+
+            it { expect(form.errors.details).to include(interview_time: [{ error: :invalid }]) }
+          end
+
+          context "with time using a comma separator (2,30pm)" do
+            let(:interview_time) { "2,30pm" }
+
+            it { expect(form.errors.details).to include(interview_time: [{ error: :invalid }]) }
+          end
+
+          context "with time missing separator (230pm)" do
+            let(:interview_time) { "230pm" }
+
+            it { expect(form.errors.details).to include(interview_time: [{ error: :invalid }]) }
+          end
+
+          context "with invalid am/pm suffix (230em)" do
+            let(:interview_time) { "230em" }
+
+            it { expect(form.errors.details).to include(interview_time: [{ error: :invalid }]) }
+          end
+
+          context "with time using a space separator (2 30pm)" do
+            let(:interview_time) { "2 30pm" }
+
+            it { expect(form.errors.details).to include(interview_time: [{ error: :invalid }]) }
+          end
+
+          context "with valid time (2:30pm)" do
+            let(:interview_time) { "2:30pm" }
+
+            it { expect(form.errors.details).not_to include(:interview_time) }
+          end
+
+          context "with space between time and am/pm (2:30 pm)" do
+            let(:interview_time) { "2:30 pm" }
+
+            it { expect(form.errors.details).not_to include(:interview_time) }
+          end
+
+          context "with uppercase am/pm (2:30 PM)" do
+            let(:interview_time) { "2:30 PM" }
+
+            it { expect(form.errors.details).not_to include(:interview_time) }
+          end
+
+          context "with 24h time (14:30)" do
+            let(:interview_time) { "14:30" }
+
+            it { expect(form.errors.details).not_to include(:interview_time) }
+          end
+
+          context "with 24h time using space separator (14 30)" do
+            let(:interview_time) { "14 30" }
+
+            it { expect(form.errors.details).to include(interview_time: [{ error: :invalid }]) }
+          end
+
+          context "with 24h time without separator (1430)" do
+            let(:interview_time) { "1430" }
 
             it { expect(form.errors.details).to include(interview_time: [{ error: :invalid }]) }
           end

--- a/spec/page_objects/pages/publisher/ats/interview_datetime_page.rb
+++ b/spec/page_objects/pages/publisher/ats/interview_datetime_page.rb
@@ -21,7 +21,7 @@ module PageObjects
           element :btn_cancel, "#main-content .govuk-button-group .govuk-button--secondary"
 
           section :interview_date, InterviewDateField, ".govuk-date-input"
-          element :interview_time, "#publishers-job-application-interview-datetime-form-interview-time-field"
+          element :interview_time, %(input[name="publishers_job_application_interview_datetime_form[interview_time]"])
 
           def set_interview_datetime(datetime)
             interview_date.day.set(datetime.day)

--- a/spec/system/publishers/publishers_can_set_interview_date_and_time_spec.rb
+++ b/spec/system/publishers/publishers_can_set_interview_date_and_time_spec.rb
@@ -28,6 +28,12 @@ RSpec.describe "Publisher can manully set interview date and time" do
       10,
       45,
     )
+    publisher_ats_interview_datetime_page.set_interview_datetime(interview_datetime)
+    publisher_ats_interview_datetime_page.interview_time.set("2.30pm")
+    publisher_ats_interview_datetime_page.btn_submit.click
+
+    expect(publisher_ats_interview_datetime_page).to have_text("Enter a valid time, for example, 9am or 2:30pm")
+
     publisher_ats_interview_datetime_page.fill_and_submit(interview_datetime)
 
     expect(publisher_ats_applications_page).to be_displayed(vacancy_id: vacancy.id)


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/6MQl5PFl/3192-bug-ats-flow-hs-add-interview-time

## Changes in this PR:

Prior to this change if a user entered an incorrect time format it would not show the user an error and would instead come up with a weird result. For instance Fisal entered 2.30pm and got 6pm as the result. This PR fixes this issue, raising an error if the time is not formatted as suggested in the hint text.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
