### PR TITLE
waf for staging and production

### DIFF
--- a/terraform/workspace-variables/production.tfvars.json
+++ b/terraform/workspace-variables/production.tfvars.json
@@ -14,7 +14,9 @@
     "tvsprod_aks": {
       "cloudfront_origin_domain_name": "teaching-vacancies-production.teacherservices.cloud",
       "offline_bucket_domain_name": "530003481352-offline-site.s3.amazonaws.com",
-      "offline_bucket_origin_path": "/teaching-vacancies-offline"
+      "offline_bucket_origin_path": "/teaching-vacancies-offline",
+      "enable_cloudfront_waf": true,
+      "waf_ip_rate_limit": 900
     }
   },
   "environment": "production",

--- a/terraform/workspace-variables/staging.tfvars.json
+++ b/terraform/workspace-variables/staging.tfvars.json
@@ -10,7 +10,9 @@
     "tvsstagingaks": {
       "cloudfront_origin_domain_name": "teaching-vacancies-staging.test.teacherservices.cloud",
       "offline_bucket_domain_name": "530003481352-offline-site.s3.amazonaws.com",
-      "offline_bucket_origin_path": "/teaching-vacancies-offline"
+      "offline_bucket_origin_path": "/teaching-vacancies-offline",
+      "enable_cloudfront_waf": true,
+      "waf_ip_rate_limit": 900
     }
   },
   "environment": "staging",


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/l9NZV9MY/2949-add-rate-limiting-for-teaching-vacancies-additional-environments

## Changes in this PR:
WAF with rate limiting and SQL protection was recently implemented in QA for testing purposes, this PR will introduce the same changes into staging and production environments

## To review:
Check the changes in the staging and production tfvars files and confirm they match what is in QA.
Review the tf plan output by running the following commands:
make staging terraform-plan
make production terraform-plan CONFIRM_PRODUCTION=YES
