### PR TITLE
Migrate DfeSignIn::API::Request (DfE Sign-in user sync) to Faraday

### DIFF
--- a/lib/dfe_sign_in/api/request.rb
+++ b/lib/dfe_sign_in/api/request.rb
@@ -13,14 +13,15 @@ module DfeSignIn
 
       def perform
         token = generate_jwt_token
-        response = HTTParty.get(
+        response = HttpClient.connection.get(
           "#{ENV.fetch('DFE_SIGN_IN_URL', nil)}#{@endpoint}?page=#{@page}&pageSize=#{@page_size}",
-          headers: { "Authorization" => "Bearer #{token}" },
-        )
+        ) do |req|
+          req.headers["Authorization"] = "Bearer #{token}"
+        end
 
-        raise ExternalServerError if response.code.eql?(500)
-        raise ForbiddenRequestError if response.code.eql?(403)
-        raise UnknownResponseError unless response.code.eql?(200)
+        raise ExternalServerError if response.status.eql?(500)
+        raise ForbiddenRequestError if response.status.eql?(403)
+        raise UnknownResponseError unless response.status.eql?(200)
 
         JSON.parse(response.body)
       end

--- a/spec/support/faraday_retry_helpers.rb
+++ b/spec/support/faraday_retry_helpers.rb
@@ -1,0 +1,9 @@
+# Faraday::Retry::Middleware sleeps for real between retries. Skip that in specs so
+# tests that exercise the retry behaviour (deliberately or incidentally, via WebMock
+# stubs returning a retryable status/error) stay fast without changing retry
+# counts/outcomes.
+module SkipFaradayRetrySleep
+  def sleep(*) = nil
+end
+
+Faraday::Retry::Middleware.prepend(SkipFaradayRetrySleep)


### PR DESCRIPTION
Moves the DfE Sign-in users/approvers pagination requests onto the shared HttpClient.connection. A 500 from the DfE Sign-in API is now retried up to 3 times before ExternalServerError is raised, rather than failing the sync on the first blip.

Also adds spec/support/faraday_retry_helpers.rb, which disables the real sleep between Faraday retries during specs. Without it, specs that legitimately exercise retryable failures (like the 500 case here) add several seconds of real sleep each; this keeps them fast without changing retry counts or outcomes.

## Trello card URL

https://trello.com/c/OjuPRGNR/3178-replace-httparty-with-faraday-gem

## Changes in this PR:

PR 4/5

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
